### PR TITLE
Running code-format for reconstruction

### DIFF
--- a/EventFilter/EcalRawToDigi/interface/DCCDataBlockPrototype.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCDataBlockPrototype.h
@@ -10,8 +10,7 @@
  *
 */
 
-
-#include <iostream>                  
+#include <iostream>
 #include <string>
 #include <vector>
 #include <map>
@@ -27,60 +26,56 @@ class DCCDataUnpacker;
 class DCCEventBlock;
 
 class DCCDataBlockPrototype {
-	
-  public :
-    /**
+public:
+  /**
       Class constructor
     */
-    DCCDataBlockPrototype( DCCDataUnpacker *  unpacker, EcalElectronicsMapper * mapper, DCCEventBlock * event, bool unpack = true);
+  DCCDataBlockPrototype(DCCDataUnpacker* unpacker,
+                        EcalElectronicsMapper* mapper,
+                        DCCEventBlock* event,
+                        bool unpack = true);
 
-    virtual ~DCCDataBlockPrototype() {};
-  
-    virtual int unpack(const uint64_t ** data, unsigned int * dwToEnd){ return BLOCK_UNPACKED;}
+  virtual ~DCCDataBlockPrototype(){};
 
-    virtual void updateCollectors(){};
-	
-    virtual void display(std::ostream & o){} 
+  virtual int unpack(const uint64_t** data, unsigned int* dwToEnd) { return BLOCK_UNPACKED; }
 
-    void enableSyncChecks(){sync_=true;}
-    
-    /**
+  virtual void updateCollectors(){};
+
+  virtual void display(std::ostream& o) {}
+
+  void enableSyncChecks() { sync_ = true; }
+
+  /**
      Updates data pointer and dw to end of event
     */
-    virtual void updateEventPointers(){ 
+  virtual void updateEventPointers() {
+    //cout<<"\n block Length "<<blockLength_;
+    //cout<<"\n dwToEne...   "<<*dwToEnd_;
 
-     //cout<<"\n block Length "<<blockLength_;
-     //cout<<"\n dwToEne...   "<<*dwToEnd_;    
+    *datap_ += blockLength_;
 
-      *datap_   += blockLength_;
+    // preventing pointers from navigating wildly outside of fedBlock
+    if ((*dwToEnd_) >= blockLength_)
+      *dwToEnd_ -= blockLength_;
+    else
+      *dwToEnd_ = 0;
+  }
 
-      // preventing pointers from navigating wildly outside of fedBlock
-      if((*dwToEnd_)>=blockLength_) 
-        *dwToEnd_ -= blockLength_; 
-      else 
-        *dwToEnd_ = 0; 
+  virtual unsigned int getLength() { return blockLength_; }
 
-    }
-    
-    virtual unsigned int getLength(){ return blockLength_; }
+protected:
+  DCCDataUnpacker* unpacker_;
+  bool error_;
+  EcalElectronicsMapper* mapper_;
+  DCCEventBlock* event_;
 
-  
-  protected :
-    DCCDataUnpacker       * unpacker_;
-    bool error_; 
-    EcalElectronicsMapper * mapper_;
-    DCCEventBlock         * event_;
-   
-    
-    const uint64_t             ** datap_;
-    const uint64_t              * data_;
-    unsigned int                  * dwToEnd_;
-   
-   
-    unsigned int blockLength_;
-    bool unpackInternalData_;
-    bool sync_;
+  const uint64_t** datap_;
+  const uint64_t* data_;
+  unsigned int* dwToEnd_;
 
+  unsigned int blockLength_;
+  bool unpackInternalData_;
+  bool sync_;
 };
 
 #endif

--- a/EventFilter/EcalRawToDigi/interface/DCCDataUnpacker.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCDataUnpacker.h
@@ -1,7 +1,6 @@
 #ifndef DCCDATAUNPACKER_HH
 #define DCCDATAUNPACKER_HH
 
-
 /*
  *\ Class DCCDataUnpacker
  *
@@ -16,12 +15,12 @@
  *
 */
 //C++
-#include <fstream>                   
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
 #include <map>
-#include <cstdio>                     
+#include <cstdio>
 #include <cstdint>
 #include <atomic>
 
@@ -47,164 +46,124 @@ class DCCEBEventBlock;
 class DCCEEEventBlock;
 class EcalRawToDigi;
 
-class DCCDataUnpacker{
-
-public : 
-  
-  DCCDataUnpacker(EcalElectronicsMapper *, bool hU,bool srpU, bool tccU, bool feU, bool memU, bool syncCheck, bool feIdCheck, bool forceToKeepFRdata);
+class DCCDataUnpacker {
+public:
+  DCCDataUnpacker(EcalElectronicsMapper*,
+                  bool hU,
+                  bool srpU,
+                  bool tccU,
+                  bool feU,
+                  bool memU,
+                  bool syncCheck,
+                  bool feIdCheck,
+                  bool forceToKeepFRdata);
   ~DCCDataUnpacker();
   /**
      Unpack data from a buffer
   */
   void unpack(const uint64_t* buffer, size_t bufferSize, unsigned int smId, unsigned int fedId);
 
-
   /**
     Set the collection pointers
   */
 
-  void setEBDigisCollection( std::unique_ptr<EBDigiCollection>                         * x )
-  { ebDigis_                = x; } 
- 
-  void setEEDigisCollection( std::unique_ptr<EEDigiCollection>                         * x )
-  { eeDigis_                = x; } 
- 
-  void setDccHeadersCollection( std::unique_ptr<EcalRawDataCollection>                 * x )
-  { dccHeaders_             = x; }
- 
-  void setEBSrFlagsCollection( std::unique_ptr<EBSrFlagCollection>                     * x )
-  { ebSrFlags_              = x; } 
-  
-  void setEESrFlagsCollection( std::unique_ptr<EESrFlagCollection>                     * x )
-  { eeSrFlags_              = x; }
+  void setEBDigisCollection(std::unique_ptr<EBDigiCollection>* x) { ebDigis_ = x; }
 
-  void setEcalTpsCollection( std::unique_ptr<EcalTrigPrimDigiCollection>                  * x )
-  { ecalTps_                  = x; }
+  void setEEDigisCollection(std::unique_ptr<EEDigiCollection>* x) { eeDigis_ = x; }
 
-  void  setEcalPSsCollection( std::unique_ptr<EcalPSInputDigiCollection>                  * x )
-  { ecalPSs_                  = x; }
+  void setDccHeadersCollection(std::unique_ptr<EcalRawDataCollection>* x) { dccHeaders_ = x; }
 
-  void setInvalidGainsCollection( std::unique_ptr<EBDetIdCollection>                    * x )
-  { invalidGains_           = x; }
- 
-  void setInvalidGainsSwitchCollection( std::unique_ptr<EBDetIdCollection>              * x )
-  { invalidGainsSwitch_     = x; }
- 
-  void setInvalidChIdsCollection( std::unique_ptr<EBDetIdCollection>                    * x )
-  { invalidChIds_           = x; }
+  void setEBSrFlagsCollection(std::unique_ptr<EBSrFlagCollection>* x) { ebSrFlags_ = x; }
 
-  // EE 
-  void setInvalidEEGainsCollection( std::unique_ptr<EEDetIdCollection>                    * x )
-  { invalidEEGains_           = x; }
-  
-  void setInvalidEEGainsSwitchCollection( std::unique_ptr<EEDetIdCollection>              * x )
-  { invalidEEGainsSwitch_     = x; }
- 
-  void setInvalidEEChIdsCollection( std::unique_ptr<EEDetIdCollection>                    * x )
-  { invalidEEChIds_           = x; }
-  // EE 
- 
-  void setInvalidTTIdsCollection( std::unique_ptr<EcalElectronicsIdCollection>         * x )
-  { invalidTTIds_           = x; }
+  void setEESrFlagsCollection(std::unique_ptr<EESrFlagCollection>* x) { eeSrFlags_ = x; }
 
-  void setInvalidZSXtalIdsCollection( std::unique_ptr<EcalElectronicsIdCollection>     * x )
-  { invalidZSXtalIds_           = x; }
+  void setEcalTpsCollection(std::unique_ptr<EcalTrigPrimDigiCollection>* x) { ecalTps_ = x; }
 
-  void setInvalidBlockLengthsCollection( std::unique_ptr<EcalElectronicsIdCollection>  * x )
-  { invalidBlockLengths_    = x; }
- 
-  void setPnDiodeDigisCollection( std::unique_ptr<EcalPnDiodeDigiCollection>            * x )
-  { pnDiodeDigis_           = x; }
- 
-  void setInvalidMemTtIdsCollection( std::unique_ptr<EcalElectronicsIdCollection>      * x )
-  { invalidMemTtIds_        = x; }
- 
-  void setInvalidMemBlockSizesCollection( std::unique_ptr<EcalElectronicsIdCollection> * x )
-  { invalidMemBlockSizes_   = x; }
- 
-  void setInvalidMemChIdsCollection( std::unique_ptr<EcalElectronicsIdCollection>      * x )
-  { invalidMemChIds_        = x; }
- 
-  void setInvalidMemGainsCollection( std::unique_ptr<EcalElectronicsIdCollection>      * x )
-  { invalidMemGains_        = x; }
-  
- 
+  void setEcalPSsCollection(std::unique_ptr<EcalPSInputDigiCollection>* x) { ecalPSs_ = x; }
+
+  void setInvalidGainsCollection(std::unique_ptr<EBDetIdCollection>* x) { invalidGains_ = x; }
+
+  void setInvalidGainsSwitchCollection(std::unique_ptr<EBDetIdCollection>* x) { invalidGainsSwitch_ = x; }
+
+  void setInvalidChIdsCollection(std::unique_ptr<EBDetIdCollection>* x) { invalidChIds_ = x; }
+
+  // EE
+  void setInvalidEEGainsCollection(std::unique_ptr<EEDetIdCollection>* x) { invalidEEGains_ = x; }
+
+  void setInvalidEEGainsSwitchCollection(std::unique_ptr<EEDetIdCollection>* x) { invalidEEGainsSwitch_ = x; }
+
+  void setInvalidEEChIdsCollection(std::unique_ptr<EEDetIdCollection>* x) { invalidEEChIds_ = x; }
+  // EE
+
+  void setInvalidTTIdsCollection(std::unique_ptr<EcalElectronicsIdCollection>* x) { invalidTTIds_ = x; }
+
+  void setInvalidZSXtalIdsCollection(std::unique_ptr<EcalElectronicsIdCollection>* x) { invalidZSXtalIds_ = x; }
+
+  void setInvalidBlockLengthsCollection(std::unique_ptr<EcalElectronicsIdCollection>* x) { invalidBlockLengths_ = x; }
+
+  void setPnDiodeDigisCollection(std::unique_ptr<EcalPnDiodeDigiCollection>* x) { pnDiodeDigis_ = x; }
+
+  void setInvalidMemTtIdsCollection(std::unique_ptr<EcalElectronicsIdCollection>* x) { invalidMemTtIds_ = x; }
+
+  void setInvalidMemBlockSizesCollection(std::unique_ptr<EcalElectronicsIdCollection>* x) { invalidMemBlockSizes_ = x; }
+
+  void setInvalidMemChIdsCollection(std::unique_ptr<EcalElectronicsIdCollection>* x) { invalidMemChIds_ = x; }
+
+  void setInvalidMemGainsCollection(std::unique_ptr<EcalElectronicsIdCollection>* x) { invalidMemGains_ = x; }
+
   /**
    Get the collection pointers
   */
-  
-  std::unique_ptr<EBDigiCollection>             * ebDigisCollection()
-  { return ebDigis_;               }
-  
-  std::unique_ptr<EEDigiCollection>             * eeDigisCollection()
-  { return eeDigis_;               }
-  
-  std::unique_ptr<EcalTrigPrimDigiCollection>   * ecalTpsCollection()
-  { return ecalTps_;                 } 
-  
-  std::unique_ptr<EcalPSInputDigiCollection>    * ecalPSsCollection()
-  { return ecalPSs_;                 } 
 
-  std::unique_ptr<EBSrFlagCollection>           * ebSrFlagsCollection()
-  { return ebSrFlags_;             }  
-  
-  std::unique_ptr<EESrFlagCollection>           * eeSrFlagsCollection()
-  { return eeSrFlags_;             } 
-  
-  std::unique_ptr<EcalRawDataCollection>        * dccHeadersCollection()
-  { return dccHeaders_;            }
-  
-  std::unique_ptr<EBDetIdCollection>            * invalidGainsCollection()
-  { return invalidGains_;          }
-  
-  std::unique_ptr<EBDetIdCollection>            * invalidGainsSwitchCollection()
-  { return invalidGainsSwitch_;    }
-  
-  std::unique_ptr<EBDetIdCollection>            * invalidChIdsCollection()
-  { return invalidChIds_;          }
+  std::unique_ptr<EBDigiCollection>* ebDigisCollection() { return ebDigis_; }
+
+  std::unique_ptr<EEDigiCollection>* eeDigisCollection() { return eeDigis_; }
+
+  std::unique_ptr<EcalTrigPrimDigiCollection>* ecalTpsCollection() { return ecalTps_; }
+
+  std::unique_ptr<EcalPSInputDigiCollection>* ecalPSsCollection() { return ecalPSs_; }
+
+  std::unique_ptr<EBSrFlagCollection>* ebSrFlagsCollection() { return ebSrFlags_; }
+
+  std::unique_ptr<EESrFlagCollection>* eeSrFlagsCollection() { return eeSrFlags_; }
+
+  std::unique_ptr<EcalRawDataCollection>* dccHeadersCollection() { return dccHeaders_; }
+
+  std::unique_ptr<EBDetIdCollection>* invalidGainsCollection() { return invalidGains_; }
+
+  std::unique_ptr<EBDetIdCollection>* invalidGainsSwitchCollection() { return invalidGainsSwitch_; }
+
+  std::unique_ptr<EBDetIdCollection>* invalidChIdsCollection() { return invalidChIds_; }
 
   //EE
-  std::unique_ptr<EEDetIdCollection>            * invalidEEGainsCollection()
-  { return invalidEEGains_;          }
-  
-  std::unique_ptr<EEDetIdCollection>            * invalidEEGainsSwitchCollection()
-  { return invalidEEGainsSwitch_;    }
-  
-  std::unique_ptr<EEDetIdCollection>            * invalidEEChIdsCollection()
-  { return invalidEEChIds_;          }
+  std::unique_ptr<EEDetIdCollection>* invalidEEGainsCollection() { return invalidEEGains_; }
+
+  std::unique_ptr<EEDetIdCollection>* invalidEEGainsSwitchCollection() { return invalidEEGainsSwitch_; }
+
+  std::unique_ptr<EEDetIdCollection>* invalidEEChIdsCollection() { return invalidEEChIds_; }
   //EE
 
-  std::unique_ptr<EcalElectronicsIdCollection> * invalidTTIdsCollection()
-  { return invalidTTIds_;          }
+  std::unique_ptr<EcalElectronicsIdCollection>* invalidTTIdsCollection() { return invalidTTIds_; }
 
-  std::unique_ptr<EcalElectronicsIdCollection> * invalidZSXtalIdsCollection()
-  { return invalidZSXtalIds_;          }  
-  
-  std::unique_ptr< EcalElectronicsIdCollection> * invalidBlockLengthsCollection()
-  { return invalidBlockLengths_;   }
-     
-  std::unique_ptr<EcalElectronicsIdCollection>  * invalidMemTtIdsCollection()
-  { return invalidMemTtIds_;       }
- 
-  std::unique_ptr<EcalElectronicsIdCollection>  * invalidMemBlockSizesCollection()
-  { return invalidMemBlockSizes_;  }
-  
-  std::unique_ptr<EcalElectronicsIdCollection>  * invalidMemChIdsCollection()
-  { return invalidMemChIds_;       }
-  
-  std::unique_ptr<EcalElectronicsIdCollection>  * invalidMemGainsCollection()
-  { return invalidMemGains_;       }
+  std::unique_ptr<EcalElectronicsIdCollection>* invalidZSXtalIdsCollection() { return invalidZSXtalIds_; }
 
-  std::unique_ptr<EcalPnDiodeDigiCollection>    * pnDiodeDigisCollection()
-  { return pnDiodeDigis_;          }
-  
+  std::unique_ptr<EcalElectronicsIdCollection>* invalidBlockLengthsCollection() { return invalidBlockLengths_; }
+
+  std::unique_ptr<EcalElectronicsIdCollection>* invalidMemTtIdsCollection() { return invalidMemTtIds_; }
+
+  std::unique_ptr<EcalElectronicsIdCollection>* invalidMemBlockSizesCollection() { return invalidMemBlockSizes_; }
+
+  std::unique_ptr<EcalElectronicsIdCollection>* invalidMemChIdsCollection() { return invalidMemChIds_; }
+
+  std::unique_ptr<EcalElectronicsIdCollection>* invalidMemGainsCollection() { return invalidMemGains_; }
+
+  std::unique_ptr<EcalPnDiodeDigiCollection>* pnDiodeDigisCollection() { return pnDiodeDigis_; }
 
   /**
    Get the ECAL electronics Mapper
   */
-  const EcalElectronicsMapper * electronicsMapper() const { return electronicsMapper_; }
-  
-  
+  const EcalElectronicsMapper* electronicsMapper() const { return electronicsMapper_; }
+
   /**
    Functions to work with Channel Status DB
   */
@@ -217,49 +176,46 @@ public :
   uint16_t getChannelValue(const int fed, const int ccu, const int strip, const int xtal) const;
   // return status of given CCU
   uint16_t getCCUValue(const int fed, const int ccu) const;
-  
-  
+
   /**
   Get the associated event
   */
-  DCCEventBlock * currentEvent(){ return currentEvent_;}
+  DCCEventBlock* currentEvent() { return currentEvent_; }
 
-  static std::atomic<bool> silentMode_; 
- 
-protected :
+  static std::atomic<bool> silentMode_;
 
+protected:
   // Data collections pointers
-  std::unique_ptr<EBDigiCollection>            * ebDigis_;
-  std::unique_ptr<EEDigiCollection>            * eeDigis_;
-  std::unique_ptr<EcalTrigPrimDigiCollection>  * ecalTps_;
-  std::unique_ptr<EcalPSInputDigiCollection>   * ecalPSs_;
-  std::unique_ptr<EcalRawDataCollection>       * dccHeaders_;
-  std::unique_ptr<EBDetIdCollection>           * invalidGains_;
-  std::unique_ptr<EBDetIdCollection>           * invalidGainsSwitch_;
-  std::unique_ptr<EBDetIdCollection>           * invalidChIds_;
+  std::unique_ptr<EBDigiCollection>* ebDigis_;
+  std::unique_ptr<EEDigiCollection>* eeDigis_;
+  std::unique_ptr<EcalTrigPrimDigiCollection>* ecalTps_;
+  std::unique_ptr<EcalPSInputDigiCollection>* ecalPSs_;
+  std::unique_ptr<EcalRawDataCollection>* dccHeaders_;
+  std::unique_ptr<EBDetIdCollection>* invalidGains_;
+  std::unique_ptr<EBDetIdCollection>* invalidGainsSwitch_;
+  std::unique_ptr<EBDetIdCollection>* invalidChIds_;
   //EE
-  std::unique_ptr<EEDetIdCollection>           * invalidEEGains_;
-  std::unique_ptr<EEDetIdCollection>           * invalidEEGainsSwitch_;
-  std::unique_ptr<EEDetIdCollection>           * invalidEEChIds_;
+  std::unique_ptr<EEDetIdCollection>* invalidEEGains_;
+  std::unique_ptr<EEDetIdCollection>* invalidEEGainsSwitch_;
+  std::unique_ptr<EEDetIdCollection>* invalidEEChIds_;
   //EE
-  std::unique_ptr<EBSrFlagCollection>          * ebSrFlags_;
-  std::unique_ptr<EESrFlagCollection>          * eeSrFlags_;
-  std::unique_ptr<EcalElectronicsIdCollection> * invalidTTIds_;
-  std::unique_ptr<EcalElectronicsIdCollection> * invalidZSXtalIds_;
-  std::unique_ptr<EcalElectronicsIdCollection> * invalidBlockLengths_; 
-  
-  std::unique_ptr<EcalElectronicsIdCollection> * invalidMemTtIds_ ;
-  std::unique_ptr<EcalElectronicsIdCollection> * invalidMemBlockSizes_ ;
-  std::unique_ptr<EcalElectronicsIdCollection> * invalidMemChIds_ ;
-  std::unique_ptr<EcalElectronicsIdCollection> * invalidMemGains_ ;
-  std::unique_ptr<EcalPnDiodeDigiCollection>   * pnDiodeDigis_;
+  std::unique_ptr<EBSrFlagCollection>* ebSrFlags_;
+  std::unique_ptr<EESrFlagCollection>* eeSrFlags_;
+  std::unique_ptr<EcalElectronicsIdCollection>* invalidTTIds_;
+  std::unique_ptr<EcalElectronicsIdCollection>* invalidZSXtalIds_;
+  std::unique_ptr<EcalElectronicsIdCollection>* invalidBlockLengths_;
 
-  EcalElectronicsMapper  * electronicsMapper_;
+  std::unique_ptr<EcalElectronicsIdCollection>* invalidMemTtIds_;
+  std::unique_ptr<EcalElectronicsIdCollection>* invalidMemBlockSizes_;
+  std::unique_ptr<EcalElectronicsIdCollection>* invalidMemChIds_;
+  std::unique_ptr<EcalElectronicsIdCollection>* invalidMemGains_;
+  std::unique_ptr<EcalPnDiodeDigiCollection>* pnDiodeDigis_;
+
+  EcalElectronicsMapper* electronicsMapper_;
   const EcalChannelStatusMap* chdb_;
-  DCCEventBlock          * currentEvent_;
-  DCCEBEventBlock        * ebEventBlock_;
-  DCCEEEventBlock        * eeEventBlock_;
-		
+  DCCEventBlock* currentEvent_;
+  DCCEBEventBlock* ebEventBlock_;
+  DCCEEEventBlock* eeEventBlock_;
 };
 
 #endif

--- a/EventFilter/EcalRawToDigi/interface/DCCEBEventBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCEBEventBlock.h
@@ -1,7 +1,6 @@
 #ifndef DCCEBEVENTBLOCK_HH
 #define DCCEBEVENTBLOCK_HH
 
-
 /*
  *\ Class DCCEBEventBlock
  *
@@ -21,19 +20,21 @@
 #include "DCCRawDataDefinitions.h"
 #include "DCCEventBlock.h"
 
+class DCCEBEventBlock : public DCCEventBlock {
+public:
+  DCCEBEventBlock(DCCDataUnpacker *u,
+                  EcalElectronicsMapper *m,
+                  bool hU,
+                  bool srpU,
+                  bool tccU,
+                  bool feU,
+                  bool memU,
+                  bool forceToKeepFRdata);
 
-class DCCEBEventBlock : public DCCEventBlock{
-	
-  public :
+  void unpack(const uint64_t *buffer, size_t bufferSize, unsigned int expFedId) override;
 
-   DCCEBEventBlock( DCCDataUnpacker * u, EcalElectronicsMapper *m ,  bool hU, bool srpU, bool tccU, bool feU, bool memU, bool forceToKeepFRdata);
-   
-   void unpack(const uint64_t * buffer, size_t bufferSize, unsigned int expFedId) override;
-   
-  protected :
-  
-    int unpackTCCBlocks() override;
-   
+protected:
+  int unpackTCCBlocks() override;
 };
 
 #endif

--- a/EventFilter/EcalRawToDigi/interface/DCCEBSRPBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCEBSRPBlock.h
@@ -1,7 +1,6 @@
 #ifndef DCCEBSRPBLOCK_HH
 #define DCCEBSRPBLOCK_HH
 
-
 /*
  *\ Class DCCEBSRPBlock
  *
@@ -13,7 +12,6 @@
  * \author N. Almeida
  *
 */
-
 
 #include <iostream>
 #include <memory>
@@ -29,27 +27,20 @@
 #include <DataFormats/EcalRawData/interface/EcalRawDataCollections.h>
 #include <DataFormats/EcalDetId/interface/EcalDetIdCollections.h>
 
+class DCCEBSRPBlock : public DCCSRPBlock {
+public:
+  DCCEBSRPBlock(DCCDataUnpacker* u, EcalElectronicsMapper* m, DCCEventBlock* e, bool unpack);
 
-class DCCEBSRPBlock : public DCCSRPBlock{
-	
-  public :
+  void updateCollectors() override;
 
-    DCCEBSRPBlock( DCCDataUnpacker * u,EcalElectronicsMapper * m, DCCEventBlock * e, bool unpack);
-    
-    void updateCollectors() override;
-	 
-	 
-  protected :
-  
-    void addSRFlagToCollection() override;
-	 
-    bool checkSrpIdAndNumbSRFlags() override;
-    
-    std::unique_ptr<EBSrFlagCollection>  * ebSrFlagsDigis_;
-    
-    EcalTrigTowerDetId * pTTDetId_;
-		
+protected:
+  void addSRFlagToCollection() override;
+
+  bool checkSrpIdAndNumbSRFlags() override;
+
+  std::unique_ptr<EBSrFlagCollection>* ebSrFlagsDigis_;
+
+  EcalTrigTowerDetId* pTTDetId_;
 };
-
 
 #endif

--- a/EventFilter/EcalRawToDigi/interface/DCCEBTCCBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCEBTCCBlock.h
@@ -14,13 +14,11 @@
  *
 */
 
-#include <iostream>                  
+#include <iostream>
 #include <string>
 #include <vector>
 #include <map>
 #include <utility>
-
-
 
 #include <DataFormats/EcalDigi/interface/EcalTriggerPrimitiveDigi.h>
 #include <DataFormats/EcalDigi/interface/EcalTriggerPrimitiveSample.h>
@@ -32,21 +30,18 @@
 class DCCDataUnpacker;
 
 class DCCEBTCCBlock : public DCCTCCBlock {
-	
-  public :
-    /**
+public:
+  /**
       Class constructor
     */
-    DCCEBTCCBlock( DCCDataUnpacker *  u, EcalElectronicsMapper * m, DCCEventBlock * e, bool unpack);    
-	 
-    void updateCollectors() override;
-   
-    void addTriggerPrimitivesToCollection() override;
-  
-  protected :
+  DCCEBTCCBlock(DCCDataUnpacker* u, EcalElectronicsMapper* m, DCCEventBlock* e, bool unpack);
 
-   bool checkTccIdAndNumbTTs() override;
+  void updateCollectors() override;
 
+  void addTriggerPrimitivesToCollection() override;
+
+protected:
+  bool checkTccIdAndNumbTTs() override;
 };
 
 #endif

--- a/EventFilter/EcalRawToDigi/interface/DCCEEEventBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCEEEventBlock.h
@@ -1,7 +1,6 @@
 #ifndef DCCEEEVENTBLOCK_HH
 #define DCCEEEVENTBLOCK_HH
 
-
 /*
  *\ Class DCCEEventBlock
  *
@@ -20,20 +19,21 @@
 #include "DCCRawDataDefinitions.h"
 #include "DCCEventBlock.h"
 
+class DCCEEEventBlock : public DCCEventBlock {
+public:
+  DCCEEEventBlock(DCCDataUnpacker* u,
+                  EcalElectronicsMapper* m,
+                  bool hU,
+                  bool srpU,
+                  bool tccU,
+                  bool feU,
+                  bool memU,
+                  bool forceToKeepFRdata);
 
-class DCCEEEventBlock : public DCCEventBlock{
-	
-  public :
+  void unpack(const uint64_t* buffer, size_t bufferSize, unsigned int expFedId) override;
 
-   DCCEEEventBlock( DCCDataUnpacker * u, EcalElectronicsMapper * m, bool hU, bool srpU, bool tccU, bool feU, bool memU, bool forceToKeepFRdata );
-   
-   void unpack(const uint64_t * buffer, size_t bufferSize, unsigned int expFedId) override;
-	
-  protected :
-  
-   int unpackTCCBlocks() override;
-   
-   
+protected:
+  int unpackTCCBlocks() override;
 };
 
 #endif

--- a/EventFilter/EcalRawToDigi/interface/DCCEESRPBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCEESRPBlock.h
@@ -1,7 +1,6 @@
 #ifndef DCCEESRPBLOCK_HH
 #define DCCEESRPBLOCK_HH
 
-
 /*
  *\ Class DCCEESRPBlock
  *
@@ -13,7 +12,6 @@
  * \author N. Almeida
  *
 */
-
 
 #include <iostream>
 #include <memory>
@@ -29,28 +27,20 @@
 #include <DataFormats/EcalRawData/interface/EcalRawDataCollections.h>
 #include <DataFormats/EcalDetId/interface/EcalDetIdCollections.h>
 
+class DCCEESRPBlock : public DCCSRPBlock {
+public:
+  DCCEESRPBlock(DCCDataUnpacker* u, EcalElectronicsMapper* m, DCCEventBlock* e, bool unpack);
 
-class DCCEESRPBlock : public DCCSRPBlock{
-	
-  public :
+  void updateCollectors() override;
 
-    DCCEESRPBlock( DCCDataUnpacker * u,EcalElectronicsMapper * m, DCCEventBlock * e, bool unpack);
-    
-    void updateCollectors() override;
-	 
-  protected :
-  
-    void addSRFlagToCollection() override; 
-    
-    bool checkSrpIdAndNumbSRFlags() override;
-	 
-    std::unique_ptr<EESrFlagCollection>  * eeSrFlagsDigis_;
-	 
-    EcalScDetId * pSCDetId_;
-    
-	 
-		
+protected:
+  void addSRFlagToCollection() override;
+
+  bool checkSrpIdAndNumbSRFlags() override;
+
+  std::unique_ptr<EESrFlagCollection>* eeSrFlagsDigis_;
+
+  EcalScDetId* pSCDetId_;
 };
-
 
 #endif

--- a/EventFilter/EcalRawToDigi/interface/DCCEETCCBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCEETCCBlock.h
@@ -13,12 +13,11 @@
  *
 */
 
-#include <iostream>                  
+#include <iostream>
 #include <string>
 #include <vector>
 #include <map>
 #include <utility>
-
 
 #include <DataFormats/EcalDigi/interface/EcalTriggerPrimitiveDigi.h>
 #include <DataFormats/EcalDigi/interface/EcalTriggerPrimitiveSample.h>
@@ -27,25 +26,21 @@
 
 #include "DCCTCCBlock.h"
 
-class DCCEETCCBlock : public DCCTCCBlock{
-	
-  public :
-    /**
+class DCCEETCCBlock : public DCCTCCBlock {
+public:
+  /**
       Class constructor
     */
-    DCCEETCCBlock( DCCDataUnpacker * u, EcalElectronicsMapper * m, DCCEventBlock * e, bool unpacking );    
-  
-    void updateCollectors() override;
-	 
-    void addTriggerPrimitivesToCollection() override;
-	
-	unsigned int getLength() override;
-  
-  protected :
-  
-    bool checkTccIdAndNumbTTs() override;
+  DCCEETCCBlock(DCCDataUnpacker* u, EcalElectronicsMapper* m, DCCEventBlock* e, bool unpacking);
 
+  void updateCollectors() override;
 
+  void addTriggerPrimitivesToCollection() override;
+
+  unsigned int getLength() override;
+
+protected:
+  bool checkTccIdAndNumbTTs() override;
 };
 
 #endif

--- a/EventFilter/EcalRawToDigi/interface/DCCEventBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCEventBlock.h
@@ -1,7 +1,6 @@
 #ifndef DCCEVENTBLOCK_HH
 #define DCCEVENTBLOCK_HH
 
-
 /*
  *\ Class DCCEventBlock
  *
@@ -27,106 +26,116 @@ class DCCDataUnpacker;
 class DCCMemBlock;
 class EcalElectronicsMapper;
 
-
 class DCCEventBlock {
-	
-  public :
+public:
+  DCCEventBlock(DCCDataUnpacker* u,
+                EcalElectronicsMapper* m,
+                bool hU,
+                bool srpU,
+                bool tccU,
+                bool feU,
+                bool memU,
+                bool forceToKeepFRdata);
 
-   DCCEventBlock( DCCDataUnpacker * u, EcalElectronicsMapper * m, bool hU, bool srpU, bool tccU, bool feU, bool memU, bool forceToKeepFRdata);
-	
-   virtual ~DCCEventBlock();  
- 
-   virtual void unpack(const uint64_t * buffer, size_t bufferSize, unsigned int expFedId){};
-   
-   void reset();
-	
-   void enableSyncChecks();
-	
-   void enableFeIdChecks();
+  virtual ~DCCEventBlock();
 
-   void updateCollectors();
-	
-   void display(std::ostream & o);
-		
-   unsigned int smId()                  { return smId_;     }
-   unsigned int fov()                   { return fov_;      }
-   unsigned int mem()                   { return mem_;      }
-   unsigned int l1A()                   { return l1_;       }
-   unsigned int bx()                    { return bx_;       }
-   DCCDataUnpacker  * unpacker(){ return unpacker_; }
-   
-   void setSRPSyncNumbers(short l1, short bx){ srpLv1_=l1; srpBx_=bx; }
-   void setFESyncNumbers(short l1, short bx, short id){ feLv1_[id]= l1; feBx_[id]=bx;}
-   void setTCCSyncNumbers(short l1, short bx, short id){ tccLv1_[id]= l1; tccBx_[id]=bx;}
-   void setHLTChannel( int channel, short value ){ hlt_[channel-1] = value; }   
-   short getHLTChannel(int channel){ return hlt_[channel-1];}
+  virtual void unpack(const uint64_t* buffer, size_t bufferSize, unsigned int expFedId){};
 
-    	
-  protected :
-     
-    void addHeaderToCollection();
-	 
-    int virtual unpackTCCBlocks(){ return BLOCK_UNPACKED;}
- 
-    DCCDataUnpacker  *  unpacker_;
-    const uint64_t       *  data_; 
-    unsigned int eventSize_;
-    unsigned int dwToEnd_;
-    
-    unsigned int next_tower_search(const unsigned int current_tower_id);
-    
-    std::vector<short> feChStatus_;
-    std::vector<short> tccChStatus_;
-    std::vector<short> hlt_;
+  void reset();
 
-    std::vector<short> feLv1_; std::vector<short> feBx_;  
-    std::vector<short> tccLv1_; std::vector<short> tccBx_;    
-    short srpLv1_; short srpBx_; 
+  void enableSyncChecks();
 
-    
-    unsigned int srChStatus_;
+  void enableFeIdChecks();
 
-    unsigned int fov_;
-    unsigned int fedId_;
-    unsigned int bx_;
-    unsigned int l1_;
-    unsigned int triggerType_;
-    unsigned int smId_;
-    unsigned int blockLength_;  
-    unsigned int dccErrors_;
-    unsigned int runNumber_;
-    unsigned int runType_;
-    unsigned int detailedTriggerType_;
-    
-    unsigned int orbitCounter_;
-    unsigned int mem_;
-    unsigned int sr_;
-    unsigned int zs_;
-    unsigned int tzs_;
-    
-    DCCFEBlock             * towerBlock_;
-    DCCTCCBlock            * tccBlock_;
-    DCCMemBlock            * memBlock_;
-    DCCSRPBlock            * srpBlock_;
-    EcalElectronicsMapper  * mapper_;
-	 
-    bool headerUnpacking_;
-    bool srpUnpacking_;
-    bool tccUnpacking_;
-    bool feUnpacking_;
-    bool memUnpacking_;
-    bool forceToKeepFRdata_;
+  void updateCollectors();
 
-    std::unique_ptr<EcalRawDataCollection> *  dccHeaders_;
-	 
+  void display(std::ostream& o);
 
+  unsigned int smId() { return smId_; }
+  unsigned int fov() { return fov_; }
+  unsigned int mem() { return mem_; }
+  unsigned int l1A() { return l1_; }
+  unsigned int bx() { return bx_; }
+  DCCDataUnpacker* unpacker() { return unpacker_; }
+
+  void setSRPSyncNumbers(short l1, short bx) {
+    srpLv1_ = l1;
+    srpBx_ = bx;
+  }
+  void setFESyncNumbers(short l1, short bx, short id) {
+    feLv1_[id] = l1;
+    feBx_[id] = bx;
+  }
+  void setTCCSyncNumbers(short l1, short bx, short id) {
+    tccLv1_[id] = l1;
+    tccBx_[id] = bx;
+  }
+  void setHLTChannel(int channel, short value) { hlt_[channel - 1] = value; }
+  short getHLTChannel(int channel) { return hlt_[channel - 1]; }
+
+protected:
+  void addHeaderToCollection();
+
+  int virtual unpackTCCBlocks() { return BLOCK_UNPACKED; }
+
+  DCCDataUnpacker* unpacker_;
+  const uint64_t* data_;
+  unsigned int eventSize_;
+  unsigned int dwToEnd_;
+
+  unsigned int next_tower_search(const unsigned int current_tower_id);
+
+  std::vector<short> feChStatus_;
+  std::vector<short> tccChStatus_;
+  std::vector<short> hlt_;
+
+  std::vector<short> feLv1_;
+  std::vector<short> feBx_;
+  std::vector<short> tccLv1_;
+  std::vector<short> tccBx_;
+  short srpLv1_;
+  short srpBx_;
+
+  unsigned int srChStatus_;
+
+  unsigned int fov_;
+  unsigned int fedId_;
+  unsigned int bx_;
+  unsigned int l1_;
+  unsigned int triggerType_;
+  unsigned int smId_;
+  unsigned int blockLength_;
+  unsigned int dccErrors_;
+  unsigned int runNumber_;
+  unsigned int runType_;
+  unsigned int detailedTriggerType_;
+
+  unsigned int orbitCounter_;
+  unsigned int mem_;
+  unsigned int sr_;
+  unsigned int zs_;
+  unsigned int tzs_;
+
+  DCCFEBlock* towerBlock_;
+  DCCTCCBlock* tccBlock_;
+  DCCMemBlock* memBlock_;
+  DCCSRPBlock* srpBlock_;
+  EcalElectronicsMapper* mapper_;
+
+  bool headerUnpacking_;
+  bool srpUnpacking_;
+  bool tccUnpacking_;
+  bool feUnpacking_;
+  bool memUnpacking_;
+  bool forceToKeepFRdata_;
+
+  std::unique_ptr<EcalRawDataCollection>* dccHeaders_;
 };
-
 
 // this code intended for sync checking in files:
 //   DCC(FE|Mem|TCC|SRP)Block.cc
 
-enum BlockType {FE_MEM = 1, TCC_SRP = 2};
+enum BlockType { FE_MEM = 1, TCC_SRP = 2 };
 
 bool isSynced(const unsigned int dccBx,
               const unsigned int bx,

--- a/EventFilter/EcalRawToDigi/interface/DCCFEBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCFEBlock.h
@@ -20,55 +20,49 @@ class DCCEventBlock;
 class DCCDataUnpacker;
 
 class DCCFEBlock : public DCCDataBlockPrototype {
-	
-  public :
+public:
+  DCCFEBlock(DCCDataUnpacker* u, EcalElectronicsMapper* m, DCCEventBlock* e, bool unpack, bool forceToKeepFRdata);
 
-    DCCFEBlock(DCCDataUnpacker * u,EcalElectronicsMapper * m, DCCEventBlock * e, bool unpack, bool forceToKeepFRdata);
-    
-    ~DCCFEBlock() override{ delete [] xtalGains_;}
+  ~DCCFEBlock() override { delete[] xtalGains_; }
 
-    void zsFlag(bool zs){ zs_ = zs;}
+  void zsFlag(bool zs) { zs_ = zs; }
 
-    void enableFeIdChecks(){checkFeId_= true;}
-	 
-    void updateCollectors() override;
-    
-    void display(std::ostream & o) override; 
-    using DCCDataBlockPrototype::unpack; 
-    int unpack(const uint64_t** data, unsigned int * dwToEnd, bool zs, unsigned int expectedTowerID);
+  void enableFeIdChecks() { checkFeId_ = true; }
 
-    unsigned int getLength() override{return blockLength_; }
-    			
-  protected :
-	 
-    virtual int unpackXtalData(unsigned int stripID, unsigned int xtalID){      return BLOCK_UNPACKED;};
-    virtual void fillEcalElectronicsError( std::unique_ptr<EcalElectronicsIdCollection> * ){};
-    
-    
-    bool zs_;
-    bool checkFeId_;
-    unsigned int expTowerID_;
-    bool forceToKeepFRdata_;
-    unsigned int expXtalTSamples_;
-    unsigned int unfilteredDataBlockLength_;
-    unsigned int lastStripId_;
-    unsigned int lastXtalId_;
- 
-    unsigned int towerId_;	
-    unsigned int numbDWInXtalBlock_;
-    unsigned int xtalBlockSize_;
-    unsigned int nTSamples_; 
-    
-    unsigned int blockSize_;
-    unsigned int bx_;
-    unsigned int l1_;
-    
-    short * xtalGains_;
-    std::unique_ptr<EcalElectronicsIdCollection> * invalidTTIds_;
-    std::unique_ptr<EcalElectronicsIdCollection> * invalidZSXtalIds_;
-    std::unique_ptr<EcalElectronicsIdCollection> * invalidBlockLengths_;
+  void updateCollectors() override;
 
+  void display(std::ostream& o) override;
+  using DCCDataBlockPrototype::unpack;
+  int unpack(const uint64_t** data, unsigned int* dwToEnd, bool zs, unsigned int expectedTowerID);
+
+  unsigned int getLength() override { return blockLength_; }
+
+protected:
+  virtual int unpackXtalData(unsigned int stripID, unsigned int xtalID) { return BLOCK_UNPACKED; };
+  virtual void fillEcalElectronicsError(std::unique_ptr<EcalElectronicsIdCollection>*){};
+
+  bool zs_;
+  bool checkFeId_;
+  unsigned int expTowerID_;
+  bool forceToKeepFRdata_;
+  unsigned int expXtalTSamples_;
+  unsigned int unfilteredDataBlockLength_;
+  unsigned int lastStripId_;
+  unsigned int lastXtalId_;
+
+  unsigned int towerId_;
+  unsigned int numbDWInXtalBlock_;
+  unsigned int xtalBlockSize_;
+  unsigned int nTSamples_;
+
+  unsigned int blockSize_;
+  unsigned int bx_;
+  unsigned int l1_;
+
+  short* xtalGains_;
+  std::unique_ptr<EcalElectronicsIdCollection>* invalidTTIds_;
+  std::unique_ptr<EcalElectronicsIdCollection>* invalidZSXtalIds_;
+  std::unique_ptr<EcalElectronicsIdCollection>* invalidBlockLengths_;
 };
-
 
 #endif

--- a/EventFilter/EcalRawToDigi/interface/DCCMemBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCMemBlock.h
@@ -32,50 +32,45 @@ class DCCEventBlock;
 class DCCDataUnpacker;
 
 class DCCMemBlock : public DCCDataBlockPrototype {
-	
-  public :
+public:
+  DCCMemBlock(DCCDataUnpacker* u, EcalElectronicsMapper* m, DCCEventBlock* e);
 
-    DCCMemBlock( DCCDataUnpacker * u,EcalElectronicsMapper * m, DCCEventBlock * e);
-	 
-    ~DCCMemBlock() override{}
-	 
-    void updateCollectors() override;
-    
-    void display(std::ostream & o) override; 
-    using DCCDataBlockPrototype::unpack; 
-    int unpack(const uint64_t ** data, unsigned int * dwToEnd, unsigned int expectedTowerID);   
-    			
-  protected :
-	 
-    void unpackMemTowerData();
-    void fillPnDiodeDigisCollection();
+  ~DCCMemBlock() override {}
 
-    std::vector<short> pn_;
+  void updateCollectors() override;
 
-    unsigned int expTowerID_;
-    unsigned int expXtalTSamples_;
-    unsigned int kSamplesPerPn_;
-	 
-    unsigned int lastStripId_;
-    unsigned int lastXtalId_;
-    unsigned int lastTowerBeforeMem_;
+  void display(std::ostream& o) override;
+  using DCCDataBlockPrototype::unpack;
+  int unpack(const uint64_t** data, unsigned int* dwToEnd, unsigned int expectedTowerID);
 
-    unsigned int towerId_;	
-    unsigned int numbDWInXtalBlock_;
-    unsigned int xtalBlockSize_;
-    unsigned int nTSamples_; 
-    unsigned int unfilteredTowerBlockLength_; 
-   
-    unsigned int bx_;
-    unsigned int l1_;
-	 
-    std::unique_ptr<EcalElectronicsIdCollection>   * invalidMemChIds_;  
-    std::unique_ptr<EcalElectronicsIdCollection>   * invalidMemBlockSizes_; 
-    std::unique_ptr<EcalElectronicsIdCollection>   * invalidMemTtIds_; 
-    std::unique_ptr<EcalElectronicsIdCollection>   * invalidMemGains_;
-    std::unique_ptr<EcalPnDiodeDigiCollection>     * pnDiodeDigis_;
-	
+protected:
+  void unpackMemTowerData();
+  void fillPnDiodeDigisCollection();
+
+  std::vector<short> pn_;
+
+  unsigned int expTowerID_;
+  unsigned int expXtalTSamples_;
+  unsigned int kSamplesPerPn_;
+
+  unsigned int lastStripId_;
+  unsigned int lastXtalId_;
+  unsigned int lastTowerBeforeMem_;
+
+  unsigned int towerId_;
+  unsigned int numbDWInXtalBlock_;
+  unsigned int xtalBlockSize_;
+  unsigned int nTSamples_;
+  unsigned int unfilteredTowerBlockLength_;
+
+  unsigned int bx_;
+  unsigned int l1_;
+
+  std::unique_ptr<EcalElectronicsIdCollection>* invalidMemChIds_;
+  std::unique_ptr<EcalElectronicsIdCollection>* invalidMemBlockSizes_;
+  std::unique_ptr<EcalElectronicsIdCollection>* invalidMemTtIds_;
+  std::unique_ptr<EcalElectronicsIdCollection>* invalidMemGains_;
+  std::unique_ptr<EcalPnDiodeDigiCollection>* pnDiodeDigis_;
 };
-
 
 #endif

--- a/EventFilter/EcalRawToDigi/interface/DCCRawDataDefinitions.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCRawDataDefinitions.h
@@ -1,133 +1,123 @@
 #ifndef DCCRAWDATADEFINITIONS_
 #define DCCRAWDATADEFINITIONS_
 
+enum globalFieds {
 
-enum globalFieds{
+  BLOCK_UNPACKED = 0,
+  SKIP_BLOCK_UNPACKING = 1,
+  STOP_EVENT_UNPACKING = 2,
 
-  BLOCK_UNPACKED = 0, 
-  SKIP_BLOCK_UNPACKING=1, 
-  STOP_EVENT_UNPACKING=2, 
+  B_MASK = 1,
+  HEADERLENGTH = 9,
+  HEADERSIZE = 72,
+  EMPTYEVENTSIZE = 32,
 
+  PHYSICTRIGGER = 1,
+  CALIBRATIONTRIGGER = 2,
+  TESTTRIGGER = 3,
+  TECHNICALTRIGGER = 4,
 
-  B_MASK               =  1,
-  HEADERLENGTH         =  9,
-  HEADERSIZE           = 72,
-  EMPTYEVENTSIZE       = 32,
-	
-  PHYSICTRIGGER        = 1,
-  CALIBRATIONTRIGGER   = 2,
-  TESTTRIGGER          = 3,
-  TECHNICALTRIGGER     = 4,
-      
-  CH_ENABLED           = 0,
-  CH_DISABLED          = 1,
-  CH_TIMEOUT           = 2,
-  CH_HEADERERR         = 3,
-  CH_LINKERR           = 5,
-  CH_LENGTHERR         = 6,
-  CH_SUPPRESS          = 7,
-  CH_IFIFOFULL         = 8,
-  CH_L1AIFIFOFULL      = 0xC,
-  CH_FORCEDZS1         = 0xF,
+  CH_ENABLED = 0,
+  CH_DISABLED = 1,
+  CH_TIMEOUT = 2,
+  CH_HEADERERR = 3,
+  CH_LINKERR = 5,
+  CH_LENGTHERR = 6,
+  CH_SUPPRESS = 7,
+  CH_IFIFOFULL = 8,
+  CH_L1AIFIFOFULL = 0xC,
+  CH_FORCEDZS1 = 0xF,
 
+  SRP_NUMBFLAGS = 68,
+  SRP_BLOCKLENGTH = 6,
+  SRP_EB_NUMBFLAGS = 68,
 
-  
-  SRP_NUMBFLAGS        = 68,
-  SRP_BLOCKLENGTH      = 6,
-  SRP_EB_NUMBFLAGS     = 68,
-  
-  BOEVALUE             = 0x5, 
-  ERROR_EMPTYEVENT     = 0x1, 		
-  TOWERH_SIZE          = 8, 
-  TRAILER_SIZE         = 8,
-  TCC_EB_NUMBTTS       = 68,
-  TCCID_SMID_SHIFT_EB  = 27,
-  
-  NUMB_SM             = 54,
-  NUMB_FE             = 68,
-  NUMB_TCC            = 108,
-  NUMB_XTAL           = 5,
-  NUMB_STRIP          = 5,
-  NUMB_PSEUDOSTRIPS   = 30, // input1 and input2 of TCC board has at most 30 PS_input (12 of which are duplicated)
-  NUMB_TTS_TPG2_DUPL  = 12, //
-  NUMB_TTS_TPG1       = 16, // input1 of TCC board has at most 16 TP's
-  NUMB_TTS_TPG2       = 12, // input2 of TCC board has at most 12 TP's
+  BOEVALUE = 0x5,
+  ERROR_EMPTYEVENT = 0x1,
+  TOWERH_SIZE = 8,
+  TRAILER_SIZE = 8,
+  TCC_EB_NUMBTTS = 68,
+  TCCID_SMID_SHIFT_EB = 27,
 
-  NUMB_SM_EE_MIN_MIN  = 1,
-  NUMB_SM_EE_MIN_MAX  = 9,
-  NUMB_SM_EB_MIN_MIN  = 10,
-  NUMB_SM_EB_MIN_MAX  = 27,
-  NUMB_SM_EB_PLU_MIN  = 28,
-  NUMB_SM_EB_PLU_MAX  = 45,
-  NUMB_SM_EE_PLU_MIN  = 46,
-  NUMB_SM_EE_PLU_MAX  = 54,
+  NUMB_SM = 54,
+  NUMB_FE = 68,
+  NUMB_TCC = 108,
+  NUMB_XTAL = 5,
+  NUMB_STRIP = 5,
+  NUMB_PSEUDOSTRIPS = 30,   // input1 and input2 of TCC board has at most 30 PS_input (12 of which are duplicated)
+  NUMB_TTS_TPG2_DUPL = 12,  //
+  NUMB_TTS_TPG1 = 16,       // input1 of TCC board has at most 16 TP's
+  NUMB_TTS_TPG2 = 12,       // input2 of TCC board has at most 12 TP's
+
+  NUMB_SM_EE_MIN_MIN = 1,
+  NUMB_SM_EE_MIN_MAX = 9,
+  NUMB_SM_EB_MIN_MIN = 10,
+  NUMB_SM_EB_MIN_MAX = 27,
+  NUMB_SM_EB_PLU_MIN = 28,
+  NUMB_SM_EB_PLU_MAX = 45,
+  NUMB_SM_EE_PLU_MIN = 46,
+  NUMB_SM_EE_PLU_MAX = 54,
 
   // two DCC have a missing interval in the CCU_id's
   SECTOR_EEM_CCU_JUMP = 8,
   SECTOR_EEP_CCU_JUMP = 53,
-  MIN_CCUID_JUMP      = 18,
-  MAX_CCUID_JUMP      = 24,
-  
-  NUMB_TCC_EE_MIN_EXT_MIN  = 19,     // outer TCC's in EE-
-  NUMB_TCC_EE_MIN_EXT_MAX  = 36,
-  NUMB_TCC_EE_PLU_EXT_MIN  = 73,    // outer TCC's in EE+
-  NUMB_TCC_EE_PLU_EXT_MAX  = 90
+  MIN_CCUID_JUMP = 18,
+  MAX_CCUID_JUMP = 24,
+
+  NUMB_TCC_EE_MIN_EXT_MIN = 19,  // outer TCC's in EE-
+  NUMB_TCC_EE_MIN_EXT_MAX = 36,
+  NUMB_TCC_EE_PLU_EXT_MIN = 73,  // outer TCC's in EE+
+  NUMB_TCC_EE_PLU_EXT_MAX = 90
 
 };
 
+enum headerFields {
 
+  H_FEDID_B = 8,
+  H_FEDID_MASK = 0xFFF,
 
-enum headerFields{ 
-          
-  H_FEDID_B            = 8,
-  H_FEDID_MASK         = 0xFFF,
- 
-  H_BX_B               = 20,
-  H_BX_MASK            = 0xFFF,
-      
-  H_L1_B               = 32,
-  H_L1_MASK            = 0xFFFFFF,
+  H_BX_B = 20,
+  H_BX_MASK = 0xFFF,
 
-  H_TTYPE_B            = 56,
-  H_TTYPE_MASK         = 0xF,    
+  H_L1_B = 32,
+  H_L1_MASK = 0xFFFFFF,
 
-  H_EVLENGTH_MASK      = 0xFFFFFF,
-      
-  H_ERRORS_B           = 24,
-  H_ERRORS_MASK        = 0xFF,
+  H_TTYPE_B = 56,
+  H_TTYPE_MASK = 0xF,
 
-  H_RNUMB_B            = 32,
-  H_RNUMB_MASK         = 0xFFFFFF,
+  H_EVLENGTH_MASK = 0xFFFFFF,
 
-  H_RTYPE_MASK         = 0xFFFFFFFF, // bits 0.. 31 of the 3rd DCC header word
+  H_ERRORS_B = 24,
+  H_ERRORS_MASK = 0xFF,
 
-  H_DET_TTYPE_B        = 32,
-  H_DET_TTYPE_MASK     = 0xFFFF,     // for bits 32.. 47 of the 3rd DCC header word
+  H_RNUMB_B = 32,
+  H_RNUMB_MASK = 0xFFFFFF,
 
-   	
-  H_FOV_B              = 48,
-  H_FOV_MASK           = 0xF,
+  H_RTYPE_MASK = 0xFFFFFFFF,  // bits 0.. 31 of the 3rd DCC header word
 
+  H_DET_TTYPE_B = 32,
+  H_DET_TTYPE_MASK = 0xFFFF,  // for bits 32.. 47 of the 3rd DCC header word
 
-  H_ORBITCOUNTER_B            = 0,
-  H_ORBITCOUNTER_MASK         = 0xFFFFFFFF, // bits 0.. 31 of the 4th DCC header word
+  H_FOV_B = 48,
+  H_FOV_MASK = 0xF,
 
-  H_SR_B               = 32,
-  H_ZS_B               = 33,
-  H_TZS_B              = 34,
-  H_MEM_B              = 35,
-        
-  H_SRCHSTATUS_B       = 36,
-  H_CHSTATUS_MASK      = 0xF,
+  H_ORBITCOUNTER_B = 0,
+  H_ORBITCOUNTER_MASK = 0xFFFFFFFF,  // bits 0.. 31 of the 4th DCC header word
 
-  H_TCC1CHSTATUS_B     = 40, 
-  H_TCC2CHSTATUS_B     = 44,
-  H_TCC3CHSTATUS_B     = 48,
-  H_TCC4CHSTATUS_B     = 52
-     
+  H_SR_B = 32,
+  H_ZS_B = 33,
+  H_TZS_B = 34,
+  H_MEM_B = 35,
 
-};		
+  H_SRCHSTATUS_B = 36,
+  H_CHSTATUS_MASK = 0xF,
 
+  H_TCC1CHSTATUS_B = 40,
+  H_TCC2CHSTATUS_B = 44,
+  H_TCC3CHSTATUS_B = 48,
+  H_TCC4CHSTATUS_B = 52
+
+};
 
 /* 1st TTC Command */
 /*                 Half :       1 bits: 7                 1st Half (0), 2nd Half (1) */
@@ -138,105 +128,98 @@ enum headerFields{
 /* 2nd TCC Command */
 /*                 DCC #:     6 bits: 5-0.              DCC 1 to 54. Zero means all DCC */
 
+enum detailedTriggerTypeFields {
 
-enum detailedTriggerTypeFields{ 
+  H_DCCID_B = 0,
+  H_DCCID_MASK = 0x3F,
 
-   H_DCCID_B            = 0,
-   H_DCCID_MASK         = 0x3F,
+  H_WAVEL_B = 6,
+  H_WAVEL_MASK = 0x3,
 
-   H_WAVEL_B            = 6,
-   H_WAVEL_MASK         = 0x3,
+  H_TR_TYPE_B = 8,
+  H_TR_TYPE_MASK = 0x7,
 
-   H_TR_TYPE_B          = 8,
-   H_TR_TYPE_MASK       = 0x7,
-
-   H_HALF_B             = 11,
-   H_HALF_MASK          = 0x1
-
-};
-
-
-enum towerFields{ 
-       
-  TOWER_ID_MASK        = 0x7F,
-  
-  TOWER_NSAMP_MASK     = 0x7F,
-  TOWER_NSAMP_B        = 8,  
-      
-  TOWER_BX_MASK        = 0xFFF,
-  TOWER_BX_B           = 16,     
- 
-  TOWER_L1_MASK        = 0xFFF,
-  TOWER_L1_B           = 32,
-      
-  TOWER_ADC_MASK       = 0xFFF,
-  TOWER_DIGI_MASK      = 0x3FFF,
-      
-  TOWER_STRIPID_MASK   = 0x7,
-      
-  TOWER_XTALID_MASK    = 0x7,
-  TOWER_XTALID_B       = 4,
-
-
-  TOWER_LENGTH_MASK    = 0x1FF,
-  TOWER_LENGTH_B       = 48
-
-};	
-
-
-enum tccFields{
-  
-   TCC_ID_MASK         = 0xFF,
-   
-   TCC_PS_B            = 11,
- 
-   TCC_BX_MASK         = 0xFFF,
-   TCC_BX_B            = 16,
-
-   TCC_L1_MASK         = 0xFFF, 
-   TCC_L1_B            = 32,  
-
-   TCC_TT_MASK         = 0x7F,
-   TCC_TT_B            = 48,
-
-   TCC_TS_MASK         = 0xF,
-   TCC_TS_B            = 55
+  H_HALF_B = 11,
+  H_HALF_MASK = 0x1
 
 };
 
+enum towerFields {
 
-enum srpFields{
-  
-   SRP_NREAD           = 0,
-   SRP_FULLREADOUT     = 3,
-  
+  TOWER_ID_MASK = 0x7F,
 
-   SRP_ID_MASK         = 0xFF,
- 
-   SRP_BX_MASK         = 0xFFF,
-   SRP_BX_B            = 16,
+  TOWER_NSAMP_MASK = 0x7F,
+  TOWER_NSAMP_B = 8,
 
-   SRP_L1_MASK         = 0xFFF, 
-   SRP_L1_B            = 32,  
+  TOWER_BX_MASK = 0xFFF,
+  TOWER_BX_B = 16,
 
-   SRP_NFLAGS_MASK     = 0x7F,
-   SRP_NFLAGS_B        = 48,
-	
-   SRP_SRFLAG_MASK     = 0x7,
-   SRP_SRVAL_MASK      = 0x3
+  TOWER_L1_MASK = 0xFFF,
+  TOWER_L1_B = 32,
+
+  TOWER_ADC_MASK = 0xFFF,
+  TOWER_DIGI_MASK = 0x3FFF,
+
+  TOWER_STRIPID_MASK = 0x7,
+
+  TOWER_XTALID_MASK = 0x7,
+  TOWER_XTALID_B = 4,
+
+  TOWER_LENGTH_MASK = 0x1FF,
+  TOWER_LENGTH_B = 48
 
 };
 
-enum dccFOVs{
+enum tccFields {
+
+  TCC_ID_MASK = 0xFF,
+
+  TCC_PS_B = 11,
+
+  TCC_BX_MASK = 0xFFF,
+  TCC_BX_B = 16,
+
+  TCC_L1_MASK = 0xFFF,
+  TCC_L1_B = 32,
+
+  TCC_TT_MASK = 0x7F,
+  TCC_TT_B = 48,
+
+  TCC_TS_MASK = 0xF,
+  TCC_TS_B = 55
+
+};
+
+enum srpFields {
+
+  SRP_NREAD = 0,
+  SRP_FULLREADOUT = 3,
+
+  SRP_ID_MASK = 0xFF,
+
+  SRP_BX_MASK = 0xFFF,
+  SRP_BX_B = 16,
+
+  SRP_L1_MASK = 0xFFF,
+  SRP_L1_B = 32,
+
+  SRP_NFLAGS_MASK = 0x7F,
+  SRP_NFLAGS_B = 48,
+
+  SRP_SRFLAG_MASK = 0x7,
+  SRP_SRVAL_MASK = 0x3
+
+};
+
+enum dccFOVs {
   // MC raw data based on CMS NOTE 2005/021
   // (and raw data when FOV was unassigned, earlier than mid 2008)
-  dcc_FOV_0           = 0,
+  dcc_FOV_0 = 0,
 
-  // real data since ever FOV was initialized; only 2 used >= June 09 
-  dcc_FOV_1           = 1,
-  dcc_FOV_2           = 2
- 
+  // real data since ever FOV was initialized; only 2 used >= June 09
+  dcc_FOV_1 = 1,
+  dcc_FOV_2 = 2
+
 };
 
-
-#endif	
+#endif

--- a/EventFilter/EcalRawToDigi/interface/DCCSCBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCSCBlock.h
@@ -20,32 +20,26 @@ class DCCEventBlock;
 class DCCDataUnpacker;
 
 class DCCSCBlock : public DCCFEBlock {
-	
   //to implement
-	
-  public :
 
-    DCCSCBlock(DCCDataUnpacker * u, EcalElectronicsMapper *m, DCCEventBlock * e, bool unpack, bool forceToKeepFRdata);
-	 
-    void updateCollectors() override;
-	 
-	 
-  protected :
+public:
+  DCCSCBlock(DCCDataUnpacker *u, EcalElectronicsMapper *m, DCCEventBlock *e, bool unpack, bool forceToKeepFRdata);
 
-   int unpackXtalData(unsigned int stripID, unsigned int xtalID) override;
-   void fillEcalElectronicsError( std::unique_ptr<EcalElectronicsIdCollection> * ) override;
-	 
-   EEDetId                                * pDetId_;
-   EEDataFrame                            * pDFId_;
-	 
-   std::unique_ptr<EEDigiCollection>        * digis_;
+  void updateCollectors() override;
 
-   // to restructure as common collections to DCCTowerBlock, to inherit from DCCFEBlock
-   std::unique_ptr<EEDetIdCollection>       * invalidGains_;
-   std::unique_ptr<EEDetIdCollection>       * invalidGainsSwitch_ ;
-   std::unique_ptr<EEDetIdCollection>       * invalidChIds_;
-    
+protected:
+  int unpackXtalData(unsigned int stripID, unsigned int xtalID) override;
+  void fillEcalElectronicsError(std::unique_ptr<EcalElectronicsIdCollection> *) override;
+
+  EEDetId *pDetId_;
+  EEDataFrame *pDFId_;
+
+  std::unique_ptr<EEDigiCollection> *digis_;
+
+  // to restructure as common collections to DCCTowerBlock, to inherit from DCCFEBlock
+  std::unique_ptr<EEDetIdCollection> *invalidGains_;
+  std::unique_ptr<EEDetIdCollection> *invalidGainsSwitch_;
+  std::unique_ptr<EEDetIdCollection> *invalidChIds_;
 };
-
 
 #endif

--- a/EventFilter/EcalRawToDigi/interface/DCCSRPBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCSRPBlock.h
@@ -1,7 +1,6 @@
 #ifndef DCCSRPBLOCK_HH
 #define DCCSRPBLOCK_HH
 
-
 /*
  *\ Class DCCSRPBlock
  *
@@ -13,7 +12,6 @@
  * \author N. Almeida
  *
 */
-
 
 #include <iostream>
 #include <memory>
@@ -29,36 +27,28 @@
 #include <DataFormats/EcalRawData/interface/EcalRawDataCollections.h>
 #include <DataFormats/EcalDetId/interface/EcalDetIdCollections.h>
 
-
 class DCCSRPBlock : public DCCDataBlockPrototype {
-	
-  public :
+public:
+  DCCSRPBlock(DCCDataUnpacker* u, EcalElectronicsMapper* m, DCCEventBlock* e, bool unpack);
 
-    DCCSRPBlock( DCCDataUnpacker * u,EcalElectronicsMapper * m, DCCEventBlock * e, bool unpack);
-	 
-    void display(std::ostream & o) override; 
-    using DCCDataBlockPrototype::unpack;
-    int unpack(const uint64_t ** data, unsigned int * dwToEnd, unsigned int numbFlags = SRP_NUMBFLAGS);     	 
+  void display(std::ostream& o) override;
+  using DCCDataBlockPrototype::unpack;
+  int unpack(const uint64_t** data, unsigned int* dwToEnd, unsigned int numbFlags = SRP_NUMBFLAGS);
 
-    unsigned short srFlag(unsigned int feChannel){ return srFlags_[feChannel-1]; }
-    			
-  protected :
-    
-    virtual void addSRFlagToCollection(){};
-	 
-    virtual bool checkSrpIdAndNumbSRFlags(){ return true; };
-	 
-    unsigned int srpId_         ;  
-    unsigned int bx_            ;  
-    unsigned int l1_            ;   
-    unsigned int nSRFlags_      ; 
-    unsigned int expNumbSrFlags_;
-	 
-    unsigned short srFlags_[SRP_NUMBFLAGS]; 
-	 
-	 
-	 
+  unsigned short srFlag(unsigned int feChannel) { return srFlags_[feChannel - 1]; }
+
+protected:
+  virtual void addSRFlagToCollection(){};
+
+  virtual bool checkSrpIdAndNumbSRFlags() { return true; };
+
+  unsigned int srpId_;
+  unsigned int bx_;
+  unsigned int l1_;
+  unsigned int nSRFlags_;
+  unsigned int expNumbSrFlags_;
+
+  unsigned short srFlags_[SRP_NUMBFLAGS];
 };
-
 
 #endif

--- a/EventFilter/EcalRawToDigi/interface/DCCTCCBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCTCCBlock.h
@@ -14,12 +14,11 @@
  *
 */
 
-#include <iostream>                  
+#include <iostream>
 #include <string>
 #include <vector>
 #include <map>
 #include <utility>
-
 
 #include <DataFormats/EcalDigi/interface/EcalDigiCollections.h>
 #include <DataFormats/EcalDigi/interface/EcalTriggerPrimitiveDigi.h>
@@ -32,43 +31,39 @@
 class DCCDataUnpacker;
 
 class DCCTCCBlock : public DCCDataBlockPrototype {
-	
-  public :
-    /**
+public:
+  /**
       Class constructor
     */
-    DCCTCCBlock( DCCDataUnpacker *  u, EcalElectronicsMapper * m, DCCEventBlock * e, bool unpack);    
-   
-    virtual void addTriggerPrimitivesToCollection(){};
+  DCCTCCBlock(DCCDataUnpacker* u, EcalElectronicsMapper* m, DCCEventBlock* e, bool unpack);
 
-    /**
+  virtual void addTriggerPrimitivesToCollection(){};
+
+  /**
       Unpacks TCC data 
      */
-    using DCCDataBlockPrototype::unpack;
-    int unpack(const uint64_t ** data, unsigned int * dwToEnd, short tccChId=0);
-	 
-    void display(std::ostream & o) override; 
-	 
-  
-  protected :
+  using DCCDataBlockPrototype::unpack;
+  int unpack(const uint64_t** data, unsigned int* dwToEnd, short tccChId = 0);
 
-    virtual bool checkTccIdAndNumbTTs(){return true;};
-	  
-    unsigned int tccId_;
-    unsigned int bx_;
-    unsigned int l1_;
-    unsigned int nTTs_;
-    unsigned int nTSamples_;
-    unsigned int expNumbTTs_;
-    unsigned int expTccId_;
-    unsigned int ps_;
-    
-    EcalTrigTowerDetId * pTTDetId_;   
-    EcalTriggerPrimitiveDigi * pTP_;
-    EcalPseudoStripInputDigi * pPS_;
-    std::unique_ptr<EcalTrigPrimDigiCollection> * tps_;  
-    std::unique_ptr<EcalPSInputDigiCollection> * pss_;  
+  void display(std::ostream& o) override;
 
+protected:
+  virtual bool checkTccIdAndNumbTTs() { return true; };
+
+  unsigned int tccId_;
+  unsigned int bx_;
+  unsigned int l1_;
+  unsigned int nTTs_;
+  unsigned int nTSamples_;
+  unsigned int expNumbTTs_;
+  unsigned int expTccId_;
+  unsigned int ps_;
+
+  EcalTrigTowerDetId* pTTDetId_;
+  EcalTriggerPrimitiveDigi* pTP_;
+  EcalPseudoStripInputDigi* pPS_;
+  std::unique_ptr<EcalTrigPrimDigiCollection>* tps_;
+  std::unique_ptr<EcalPSInputDigiCollection>* pss_;
 };
 
 #endif

--- a/EventFilter/EcalRawToDigi/interface/DCCTowerBlock.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCTowerBlock.h
@@ -20,30 +20,25 @@ class DCCEventBlock;
 class DCCDataUnpacker;
 
 class DCCTowerBlock : public DCCFEBlock {
-	
   //to implement
-	
-  public :
 
-    DCCTowerBlock(DCCDataUnpacker * u,EcalElectronicsMapper * m, DCCEventBlock * e, bool unpack, bool forceToKeepFRdata );
-    
-    void updateCollectors() override;
-	 
-  protected:
-	 
-    int unpackXtalData(unsigned int stripID, unsigned int xtalID) override;
-    void fillEcalElectronicsError( std::unique_ptr<EcalElectronicsIdCollection> * ) override;
+public:
+  DCCTowerBlock(DCCDataUnpacker* u, EcalElectronicsMapper* m, DCCEventBlock* e, bool unpack, bool forceToKeepFRdata);
 
-    std::unique_ptr<EBDigiCollection>     * digis_;
-    
-    EBDetId                             * pDetId_;
+  void updateCollectors() override;
 
-    // to restructure as common collections to DCCSCBlock, to inherit from DCCFEBlock
-    std::unique_ptr<EBDetIdCollection>    * invalidGains_;  
-    std::unique_ptr<EBDetIdCollection>    * invalidGainsSwitch_ ;
-    std::unique_ptr<EBDetIdCollection>    * invalidChIds_;
-	 
+protected:
+  int unpackXtalData(unsigned int stripID, unsigned int xtalID) override;
+  void fillEcalElectronicsError(std::unique_ptr<EcalElectronicsIdCollection>*) override;
+
+  std::unique_ptr<EBDigiCollection>* digis_;
+
+  EBDetId* pDetId_;
+
+  // to restructure as common collections to DCCSCBlock, to inherit from DCCFEBlock
+  std::unique_ptr<EBDetIdCollection>* invalidGains_;
+  std::unique_ptr<EBDetIdCollection>* invalidGainsSwitch_;
+  std::unique_ptr<EBDetIdCollection>* invalidChIds_;
 };
-
 
 #endif

--- a/EventFilter/EcalRawToDigi/interface/EcalDCCHeaderRuntypeDecoder.h
+++ b/EventFilter/EcalRawToDigi/interface/EcalDCCHeaderRuntypeDecoder.h
@@ -5,18 +5,19 @@
 #include <DataFormats/EcalRawData/interface/EcalDCCHeaderBlock.h>
 #include "DCCRawDataDefinitions.h"
 
-class EcalDCCHeaderRuntypeDecoder
-{
- public:
+class EcalDCCHeaderRuntypeDecoder {
+public:
   EcalDCCHeaderRuntypeDecoder();
   ~EcalDCCHeaderRuntypeDecoder();
-  bool Decode( unsigned long TrTy, unsigned long detTrTy, unsigned long runType,   EcalDCCHeaderBlock * theHeader);
-  protected:
-  bool WasDecodingOk_ = true;
-  void DecodeSetting ( int settings,  EcalDCCHeaderBlock * theHeader );
-  void DecodeSettingGlobal ( unsigned long TrigType, unsigned long detTrigType,  EcalDCCHeaderBlock * theHeader );
-  void CleanEcalDCCSettingsInfo(  EcalDCCHeaderBlock::EcalDCCEventSettings * theEventSettings);// Re-initialize theEventSettings  before filling with the deocoded event
+  bool Decode(unsigned long TrTy, unsigned long detTrTy, unsigned long runType, EcalDCCHeaderBlock* theHeader);
 
+protected:
+  bool WasDecodingOk_ = true;
+  void DecodeSetting(int settings, EcalDCCHeaderBlock* theHeader);
+  void DecodeSettingGlobal(unsigned long TrigType, unsigned long detTrigType, EcalDCCHeaderBlock* theHeader);
+  void CleanEcalDCCSettingsInfo(
+      EcalDCCHeaderBlock::EcalDCCEventSettings*
+          theEventSettings);  // Re-initialize theEventSettings  before filling with the deocoded event
 };
 
 #endif

--- a/EventFilter/EcalRawToDigi/interface/EcalDumpRaw.h
+++ b/EventFilter/EcalRawToDigi/interface/EcalDumpRaw.h
@@ -31,18 +31,17 @@
  * Author: Ph. Gras CEA/IRFU Saclay
  *
  */
-class EcalDumpRaw : public edm::stream::EDAnalyzer<>{
+class EcalDumpRaw : public edm::stream::EDAnalyzer<> {
   //ctors
 public:
   explicit EcalDumpRaw(const edm::ParameterSet&);
   ~EcalDumpRaw() override;
 
-
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
   void analyzeEB(const edm::Event&, const edm::EventSetup&) const;
   void analyzeEE(const edm::Event&, const edm::EventSetup&) const;
-  void endJob();  
+  void endJob();
   //methods
 public:
 private:
@@ -50,32 +49,36 @@ private:
   void analyzeApd();
   std::string toNth(int n);
   bool decode(const uint32_t* data, int iWord32, std::ostream& out);
-  double max(const std::vector<double>& a, unsigned& pos){
+  double max(const std::vector<double>& a, unsigned& pos) {
     pos = 0;
     double m = a[pos];
-    for(unsigned i = 1; i < a.size(); ++i){
-      if(a[i]>m){ m = a[i]; pos = i;}
+    for (unsigned i = 1; i < a.size(); ++i) {
+      if (a[i] > m) {
+        m = a[i];
+        pos = i;
+      }
     }
     return m;
   }
-  double min(const std::vector<double>& a){
+  double min(const std::vector<double>& a) {
     double m = a[0];
-    for(unsigned i = 1; i < a.size(); ++i){
-      if(a[i]<m) m = a[i];
+    for (unsigned i = 1; i < a.size(); ++i) {
+      if (a[i] < m)
+        m = a[i];
     }
     return m;
   }
   //static int lme(int dccId1, int side);
 
-  template<class T>
-  std::string toString(T val){
+  template <class T>
+  std::string toString(T val) {
     std::stringstream s;
     s << val;
     return s.str();
   }
 
   static int sideOfRu(int ru1);
-  
+
   static int modOfRu(int ru1);
 
   static int lmodOfRu(int ru1);
@@ -85,23 +88,22 @@ private:
   std::string ttfTag(int tccType, unsigned iSeq) const;
 
   std::string tpgTag(int tccType, unsigned iSeq) const;
-  
+
   //fields
 private:
-  int      verbosity_;
-  bool     writeDcc_;
-  int      beg_fed_id_;
-  int      end_fed_id_;
-  int      first_event_;
-  int      last_event_;
-  std::string   filename_;
-  int      iEvent_;
+  int verbosity_;
+  bool writeDcc_;
+  int beg_fed_id_;
+  int end_fed_id_;
+  int first_event_;
+  int last_event_;
+  std::string filename_;
+  int iEvent_;
 
   unsigned iTowerWord64_;
   unsigned iSrWord64_;
   unsigned iTccWord64_;
-  enum {inDaqHeader, inDccHeader, inTccBlock, inSrBlock, inTowerBlock}
-  decodeState_;
+  enum { inDaqHeader, inDccHeader, inTccBlock, inSrBlock, inTowerBlock } decodeState_;
   size_t towerBlockLength_;
 
   std::vector<double> adc_;
@@ -124,21 +126,20 @@ private:
   static const int maxTpgsPerTcc_ = 68;
   static const int maxTccsPerDcc_ = 4;
 
-
   //@{
   /** TCC types
    */
-  static const int ebmTcc_    = 0;
-  static const int ebpTcc_    = 1;
-  static const int eeInnerTcc_   = 2;
-  static const int eeOuterTcc_  = 3;
+  static const int ebmTcc_ = 0;
+  static const int ebpTcc_ = 1;
+  static const int eeInnerTcc_ = 2;
+  static const int eeOuterTcc_ = 3;
   static const int nTccTypes_ = 4;
   //@}
 
   /** TT ID in the order the TPG appears in the data
    */
   static const int ttId_[nTccTypes_][maxTpgsPerTcc_];
-  
+
   unsigned fedId_;
   unsigned dccId_;
   unsigned side_;
@@ -188,4 +189,4 @@ private:
   edm::EDGetTokenT<L1AcceptBunchCrossingCollection> l1AcceptBunchCrossingCollectionToken_;
 };
 
-#endif //ECALDUMPRAW_H not defined
+#endif  //ECALDUMPRAW_H not defined

--- a/EventFilter/EcalRawToDigi/interface/EcalElectronicsMapper.h
+++ b/EventFilter/EcalRawToDigi/interface/EcalElectronicsMapper.h
@@ -1,6 +1,5 @@
 #ifndef _EcalElectronicsMapper_HH_
-#define _EcalElectronicsMapper_HH_ 
-
+#define _EcalElectronicsMapper_HH_
 
 /*
  *\ Class EcalElectronicsMapper
@@ -14,12 +13,10 @@
  *
 */
 
-
-#include <iostream>                    
+#include <iostream>
 #include <fstream>
 #include <string>
 #include <map>
-
 
 #include "DCCRawDataDefinitions.h"
 #include <DataFormats/EcalDetId/interface/EcalTrigTowerDetId.h>
@@ -37,22 +34,18 @@
 class EcalElectronicsMapping;
 
 class EcalElectronicsMapper {
-
 public:
-
   /**
    * Constructor
    */
   EcalElectronicsMapper(unsigned int numbOfXtalTSamples, unsigned int numbOfTriggerTSamples);
-
 
   /**
    * Destructor
    */
   ~EcalElectronicsMapper();
 
-
-  void setEcalElectronicsMapping(const EcalElectronicsMapping *); 
+  void setEcalElectronicsMapping(const EcalElectronicsMapping*);
 
   void deletePointers();
   void resetPointers();
@@ -60,21 +53,18 @@ public:
   /**
   * Set DCC id that is going to be unpacked for the event
   */
-  bool setActiveDCC(unsigned int dccId); 
-
+  bool setActiveDCC(unsigned int dccId);
 
   /**
    * Receives a string with a path and checks if file is accessible
    */
-  bool setDCCMapFilePath(std::string );
-
+  bool setDCCMapFilePath(std::string);
 
   /**
    * Retrieves current path do the map file
    */
   std::string getDCCMapFilePath() const { return pathToMapFile_; }
-  
-  
+
   /**
    * Read map file (returns false if an error ocurred)
    *  deprecated by HLT environment
@@ -87,138 +77,147 @@ public:
    *  use 2 vectors from cfg
    */
   bool makeMapFromVectors(std::vector<int>&, std::vector<int>&);
-  
+
   /**
    * Get methods for DCCId/SMId and map
    */
-  const std::map<unsigned int ,unsigned int>& getDCCMap() const { return myDCCMap_; }
-  
-  DetId  * getDetIdPointer(unsigned int feChannel, unsigned int strip, unsigned int xtal){  return  xtalDetIds_[smId_-1][feChannel-1][strip-1][xtal-1];}
-	 
-  EcalTrigTowerDetId * getTTDetIdPointer(unsigned int tccId, unsigned int tower){ return ttDetIds_[tccId-1][tower-1];}
-	 
-  EcalElectronicsId  * getTTEleIdPointer(unsigned int tccId, unsigned int tower){ return ttEleIds_[tccId-1][tower-1];}
+  const std::map<unsigned int, unsigned int>& getDCCMap() const { return myDCCMap_; }
 
-  EcalTriggerPrimitiveDigi * getTPPointer(unsigned int tccId, unsigned int tower){ return ttTPIds_[tccId-1][tower-1];}
+  DetId* getDetIdPointer(unsigned int feChannel, unsigned int strip, unsigned int xtal) {
+    return xtalDetIds_[smId_ - 1][feChannel - 1][strip - 1][xtal - 1];
+  }
 
-  EcalScDetId  * getSCDetIdPointer(unsigned int smId, unsigned int feChannel){ return  scDetIds_[smId-1][feChannel-1];}
+  EcalTrigTowerDetId* getTTDetIdPointer(unsigned int tccId, unsigned int tower) {
+    return ttDetIds_[tccId - 1][tower - 1];
+  }
 
-  EcalElectronicsId  * getSCElectronicsPointer(unsigned int smId, unsigned int feChannel){ return  scEleIds_[smId-1][feChannel-1];}
+  EcalElectronicsId* getTTEleIdPointer(unsigned int tccId, unsigned int tower) {
+    return ttEleIds_[tccId - 1][tower - 1];
+  }
 
-  EcalPseudoStripInputDigi  * getPSInputDigiPointer(unsigned int tccId, unsigned int towerId, unsigned int psId){ return psInput_[tccId-1][towerId-1][psId-1];}
-    
-  EcalPseudoStripInputDigi  * getPSInputDigiPointer(unsigned int tccId, unsigned int psCounter){
-      return getPSInputDigiPointer(tccId, tTandPs_[tccId-1][psCounter-1][0],tTandPs_[tccId-1][psCounter-1][1]);}
+  EcalTriggerPrimitiveDigi* getTPPointer(unsigned int tccId, unsigned int tower) {
+    return ttTPIds_[tccId - 1][tower - 1];
+  }
 
-    
+  EcalScDetId* getSCDetIdPointer(unsigned int smId, unsigned int feChannel) {
+    return scDetIds_[smId - 1][feChannel - 1];
+  }
+
+  EcalElectronicsId* getSCElectronicsPointer(unsigned int smId, unsigned int feChannel) {
+    return scEleIds_[smId - 1][feChannel - 1];
+  }
+
+  EcalPseudoStripInputDigi* getPSInputDigiPointer(unsigned int tccId, unsigned int towerId, unsigned int psId) {
+    return psInput_[tccId - 1][towerId - 1][psId - 1];
+  }
+
+  EcalPseudoStripInputDigi* getPSInputDigiPointer(unsigned int tccId, unsigned int psCounter) {
+    return getPSInputDigiPointer(tccId, tTandPs_[tccId - 1][psCounter - 1][0], tTandPs_[tccId - 1][psCounter - 1][1]);
+  }
+
   // this getter method needs be clarified.
   // Changed by Ph.G. on July 1, 09: return a vector instead of a single
   // element. One SRF can be associated to two  supercrystals, because of
   // channel grouping.
-  std::vector<EcalSrFlag*> getSrFlagPointer(unsigned int feChannel){ return srFlags_[smId_-1][feChannel-1]; }
-  
-  std::vector<unsigned int> * getTccs(unsigned int smId){ return mapSmIdToTccIds_[smId];}
-	
-  unsigned int getActiveDCC()                 { return dccId_;                      }
- 
-  unsigned int getActiveSM()                  { return smId_;                       }
+  std::vector<EcalSrFlag*> getSrFlagPointer(unsigned int feChannel) { return srFlags_[smId_ - 1][feChannel - 1]; }
 
-  unsigned int numbXtalTSamples()             { return numbXtalTSamples_;           }
+  std::vector<unsigned int>* getTccs(unsigned int smId) { return mapSmIdToTccIds_[smId]; }
 
-  unsigned int numbTriggerTSamples()          { return numbTriggerTSamples_;        }
-  
-  unsigned int getUnfilteredTowerBlockLength(){ return unfilteredFEBlockLength_;    }
+  unsigned int getActiveDCC() { return dccId_; }
 
-  unsigned int getEBTCCBlockLength()          { return ebTccBlockLength_;           }
-  
-  unsigned int getEETCCBlockLength()          { return eeTccBlockLength_;           }
-  
-  unsigned int getSRPBlockLength()            { return srpBlockLength_;             }
-    
+  unsigned int getActiveSM() { return smId_; }
+
+  unsigned int numbXtalTSamples() { return numbXtalTSamples_; }
+
+  unsigned int numbTriggerTSamples() { return numbTriggerTSamples_; }
+
+  unsigned int getUnfilteredTowerBlockLength() { return unfilteredFEBlockLength_; }
+
+  unsigned int getEBTCCBlockLength() { return ebTccBlockLength_; }
+
+  unsigned int getEETCCBlockLength() { return eeTccBlockLength_; }
+
+  unsigned int getSRPBlockLength() { return srpBlockLength_; }
+
   unsigned int getDCCId(unsigned int aSMId) const;
 
   unsigned int getSMId(unsigned int aDCCId) const;
-  
-  unsigned int getNumChannelsInDcc(unsigned int aDCCId){return numChannelsInDcc_[aDCCId-1];}
 
-  const EcalElectronicsMapping * mapping(){return mappingBuilder_;} 
+  unsigned int getNumChannelsInDcc(unsigned int aDCCId) { return numChannelsInDcc_[aDCCId - 1]; }
+
+  const EcalElectronicsMapping* mapping() { return mappingBuilder_; }
 
   bool isTCCExternal(unsigned int TCCId);
-  
+
   /**
    * Print current map
    */
-  friend std::ostream& operator<< (std::ostream &o, const EcalElectronicsMapper& aEcalElectronicsMapper);
-  
+  friend std::ostream& operator<<(std::ostream& o, const EcalElectronicsMapper& aEcalElectronicsMapper);
 
   // Mantain this here as long as everything is moved to a general mapping
   enum SMGeom_t {
-    kModules = 4,           // Number of modules per supermodule
-    kTriggerTowers = 68,    // Number of trigger towers per supermodule
-    kTowersInPhi = 4,       // Number of trigger towers in phi
-    kTowersInEta = 17,      // Number of trigger towers in eta
-    kCrystals = 1700,       // Number of crystals per supermodule
-    kPns = 10,              // Number of PN laser monitoring diodes per supermodule
-    kCrystalsInPhi = 20,    // Number of crystals in phi
-    kCrystalsInEta = 85,    // Number of crystals in eta
-    kCrystalsPerTower = 25, // Number of crystals per trigger tower
-    kCardsPerTower = 5,     // Number of VFE cards per trigger tower
-    kChannelsPerCard = 5,   // Number of channels per VFE card
+    kModules = 4,            // Number of modules per supermodule
+    kTriggerTowers = 68,     // Number of trigger towers per supermodule
+    kTowersInPhi = 4,        // Number of trigger towers in phi
+    kTowersInEta = 17,       // Number of trigger towers in eta
+    kCrystals = 1700,        // Number of crystals per supermodule
+    kPns = 10,               // Number of PN laser monitoring diodes per supermodule
+    kCrystalsInPhi = 20,     // Number of crystals in phi
+    kCrystalsInEta = 85,     // Number of crystals in eta
+    kCrystalsPerTower = 25,  // Number of crystals per trigger tower
+    kCardsPerTower = 5,      // Number of VFE cards per trigger tower
+    kChannelsPerCard = 5,    // Number of channels per VFE card
     TTMAPMASK = 100
   };
 
-
 private:
-
   void fillMaps();
   unsigned int computeUnfilteredFEBlockLength();
   unsigned int computeEBTCCBlockLength();
   unsigned int computeEETCCBlockLength();
 
   std::string pathToMapFile_;
-  
+
   unsigned int numbXtalTSamples_;
-  
+
   unsigned int numbTriggerTSamples_;
 
-  std::map<unsigned int,unsigned int> myDCCMap_;
-  
-  std::map< unsigned int, std::vector<unsigned int> * > mapSmIdToTccIds_;
-  
+  std::map<unsigned int, unsigned int> myDCCMap_;
+
+  std::map<unsigned int, std::vector<unsigned int>*> mapSmIdToTccIds_;
+
   unsigned int dccId_;
-  
+
   unsigned int smId_;
-  
+
   unsigned int unfilteredFEBlockLength_;
-  
+
   unsigned int srpBlockLength_;
-  
+
   unsigned int ebTccBlockLength_, eeTccBlockLength_;
 
   static const unsigned int numChannelsInDcc_[NUMB_SM];
 
-    
-  // ARRAYS OF DetId  
-  DetId                     * xtalDetIds_[NUMB_SM][NUMB_FE][NUMB_STRIP][NUMB_XTAL];
-  EcalScDetId               * scDetIds_[NUMB_SM][NUMB_FE];
-  EcalElectronicsId         * scEleIds_[NUMB_SM][NUMB_FE];
-  EcalTrigTowerDetId        * ttDetIds_[NUMB_TCC][NUMB_FE];
-  EcalElectronicsId         * ttEleIds_[NUMB_TCC][NUMB_FE];
-  EcalTriggerPrimitiveDigi  * ttTPIds_[NUMB_TCC][NUMB_FE];
-  std::vector<EcalSrFlag*>  srFlags_[NUMB_SM][NUMB_FE];
-  EcalPseudoStripInputDigi  * psInput_[NUMB_TCC][TCC_EB_NUMBTTS][NUMB_STRIP];
-    
-  short tTandPs_[NUMB_TCC][5*EcalTrigTowerDetId::kEBTowersPerSM][2];
-    
-  const EcalElectronicsMapping    * mappingBuilder_;
-  
+  // ARRAYS OF DetId
+  DetId* xtalDetIds_[NUMB_SM][NUMB_FE][NUMB_STRIP][NUMB_XTAL];
+  EcalScDetId* scDetIds_[NUMB_SM][NUMB_FE];
+  EcalElectronicsId* scEleIds_[NUMB_SM][NUMB_FE];
+  EcalTrigTowerDetId* ttDetIds_[NUMB_TCC][NUMB_FE];
+  EcalElectronicsId* ttEleIds_[NUMB_TCC][NUMB_FE];
+  EcalTriggerPrimitiveDigi* ttTPIds_[NUMB_TCC][NUMB_FE];
+  std::vector<EcalSrFlag*> srFlags_[NUMB_SM][NUMB_FE];
+  EcalPseudoStripInputDigi* psInput_[NUMB_TCC][TCC_EB_NUMBTTS][NUMB_STRIP];
 
-// functions and fields to work with 'ghost' VFEs:
+  short tTandPs_[NUMB_TCC][5 * EcalTrigTowerDetId::kEBTowersPerSM][2];
+
+  const EcalElectronicsMapping* mappingBuilder_;
+
+  // functions and fields to work with 'ghost' VFEs:
 public:
   // check, does the given [FED (dcc), CCU (tower), VFE (strip)] belongs
   // to the list of VFEs with 'ghost' channels
   bool isGhost(const int FED, const int CCU, const int VFE);
-  
+
 private:
   void setupGhostMap();
   std::map<int, std::map<int, std::map<int, bool> > > ghost_;

--- a/EventFilter/EcalRawToDigi/interface/EcalRegionCabling.h
+++ b/EventFilter/EcalRawToDigi/interface/EcalRegionCabling.h
@@ -11,60 +11,66 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 class EcalRegionCabling {
- public:
-  EcalRegionCabling(edm::ParameterSet & conf, const EcalElectronicsMapping * m)
-  : mapping_(m)
-  {
+public:
+  EcalRegionCabling(edm::ParameterSet& conf, const EcalElectronicsMapping* m) : mapping_(m) {
     const edm::ParameterSet esMap = conf.getParameter<edm::ParameterSet>("esMapping");
     es_mapping_ = new ESElectronicsMapper(esMap);
   }
-  
-  ~EcalRegionCabling(){
+
+  ~EcalRegionCabling() {
     // this pointer is own by this object.
     delete es_mapping_;
   }
-  const EcalElectronicsMapping * mapping() const  { return mapping_;}
-  const ESElectronicsMapper * es_mapping() const { return es_mapping_;}
+  const EcalElectronicsMapping* mapping() const { return mapping_; }
+  const ESElectronicsMapper* es_mapping() const { return es_mapping_; }
 
-  static uint32_t maxElementIndex() {return (FEDNumbering::MAXECALFEDID - FEDNumbering::MINECALFEDID +1);}
-  static uint32_t maxESElementIndex() { return (FEDNumbering::MAXPreShowerFEDID - FEDNumbering::MINPreShowerFEDID +1);}
+  static uint32_t maxElementIndex() { return (FEDNumbering::MAXECALFEDID - FEDNumbering::MINECALFEDID + 1); }
+  static uint32_t maxESElementIndex() {
+    return (FEDNumbering::MAXPreShowerFEDID - FEDNumbering::MINPreShowerFEDID + 1);
+  }
 
   static uint32_t elementIndex(const int FEDindex) {
     //do a test for the time being
     if (FEDindex > FEDNumbering::MAXECALFEDID || FEDindex < FEDNumbering::MINECALFEDID) {
-      edm::LogError("IncorrectMapping")<<"FEDindex: "<< FEDindex
-					<<" is not between: "<<(int) FEDNumbering::MINECALFEDID
-					<<" and "<<(int)FEDNumbering::MAXECALFEDID;
-      return 0;}
+      edm::LogError("IncorrectMapping") << "FEDindex: " << FEDindex
+                                        << " is not between: " << (int)FEDNumbering::MINECALFEDID << " and "
+                                        << (int)FEDNumbering::MAXECALFEDID;
+      return 0;
+    }
     uint32_t eI = FEDindex - FEDNumbering::MINECALFEDID;
-    return eI; }
+    return eI;
+  }
 
   static uint32_t esElementIndex(const int FEDindex) {
     //do a test for the time being
     if (FEDindex > FEDNumbering::MAXPreShowerFEDID || FEDindex < FEDNumbering::MINPreShowerFEDID) {
-      edm::LogError("IncorrectMapping")<<"FEDindex: "<< FEDindex
-					<<" is not between: "<<(int) FEDNumbering::MINPreShowerFEDID
-					<<" and "<<(int)FEDNumbering::MAXPreShowerFEDID;
-      return 0;}
+      edm::LogError("IncorrectMapping") << "FEDindex: " << FEDindex
+                                        << " is not between: " << (int)FEDNumbering::MINPreShowerFEDID << " and "
+                                        << (int)FEDNumbering::MAXPreShowerFEDID;
+      return 0;
+    }
     uint32_t eI = FEDindex - FEDNumbering::MINPreShowerFEDID;
-    return eI; }
+    return eI;
+  }
 
-  static int fedIndex(const uint32_t index){ 
-    int fI = index+FEDNumbering::MINECALFEDID; 
-    return fI;}
-    
-  static int esFedIndex(const uint32_t index){ 
-    int fI = index+FEDNumbering::MINPreShowerFEDID; 
-    return fI;}
+  static int fedIndex(const uint32_t index) {
+    int fI = index + FEDNumbering::MINECALFEDID;
+    return fI;
+  }
 
-    
-  uint32_t elementIndex(const double eta, const double phi) const{
-    int FEDindex = mapping()->GetFED(eta,phi);
-    return elementIndex(FEDindex); }
+  static int esFedIndex(const uint32_t index) {
+    int fI = index + FEDNumbering::MINPreShowerFEDID;
+    return fI;
+  }
 
- private:
-  const EcalElectronicsMapping * mapping_;
-  const ESElectronicsMapper * es_mapping_;
+  uint32_t elementIndex(const double eta, const double phi) const {
+    int FEDindex = mapping()->GetFED(eta, phi);
+    return elementIndex(FEDindex);
+  }
+
+private:
+  const EcalElectronicsMapping* mapping_;
+  const ESElectronicsMapper* es_mapping_;
 };
 
 #endif

--- a/EventFilter/EcalRawToDigi/interface/EcalRegionCablingRecord.h
+++ b/EventFilter/EcalRawToDigi/interface/EcalRegionCablingRecord.h
@@ -6,7 +6,8 @@
 #include "Geometry/EcalMapping/interface/EcalMappingRcd.h"
 #include "boost/mpl/vector.hpp"
 
-class EcalRegionCablingRecord : public edm::eventsetup::DependentRecordImplementation<EcalRegionCablingRecord,
-  boost::mpl::vector<EcalMappingRcd> > {};
+class EcalRegionCablingRecord
+    : public edm::eventsetup::DependentRecordImplementation<EcalRegionCablingRecord,
+                                                            boost::mpl::vector<EcalMappingRcd> > {};
 
 #endif

--- a/EventFilter/EcalRawToDigi/interface/MatacqProducer.h
+++ b/EventFilter/EcalRawToDigi/interface/MatacqProducer.h
@@ -4,16 +4,15 @@
 //#define USE_STORAGE_MANAGER
 
 #ifdef USE_STORAGE_MANAGER
-#  include "Utilities/StorageFactory/interface/Storage.h"
-#  include "Utilities/StorageFactory/interface/StorageFactory.h"
-#else //USE_STORAGE_MANAGER not defined
-#  ifndef _LARGEFILE64_SOURCE
-#    define _LARGEFILE64_SOURCE
-#  endif //_LARGEFILE64_SOURCE not defined
-#  define  _FILE_OFFSET_BITS 64 
-#  include <cstdio>
-#endif //USE_STORAGE_MANAGER defined
-
+#include "Utilities/StorageFactory/interface/Storage.h"
+#include "Utilities/StorageFactory/interface/StorageFactory.h"
+#else  //USE_STORAGE_MANAGER not defined
+#ifndef _LARGEFILE64_SOURCE
+#define _LARGEFILE64_SOURCE
+#endif  //_LARGEFILE64_SOURCE not defined
+#define _FILE_OFFSET_BITS 64
+#include <cstdio>
+#endif  //USE_STORAGE_MANAGER defined
 
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -31,26 +30,18 @@
 
 #include <sys/time.h>
 
-struct NullOut{
-  NullOut&
-  operator<<(std::ostream& (*pf)(std::ostream&)){
-    return *this;
-  }
-  template<typename T>
-  inline NullOut& operator<<(const T& a){
+struct NullOut {
+  NullOut& operator<<(std::ostream& (*pf)(std::ostream&)) { return *this; }
+  template <typename T>
+  inline NullOut& operator<<(const T& a) {
     return *this;
   }
 };
 
-class MatacqProducer : public edm::EDProducer
-{
+class MatacqProducer : public edm::EDProducer {
 public:
-  enum calibTrigType_t{
-    laserType = 4,
-    ledType   = 5,
-    tpType    = 6,
-    pedType   = 7
-  };
+  enum calibTrigType_t { laserType = 4, ledType = 5, tpType = 6, pedType = 7 };
+
 private:
 #ifdef USE_STORAGE_MANAGER
   typedef IOOffset filepos_t;
@@ -59,36 +50,28 @@ private:
   typedef off_t filepos_t;
   typedef FILE* FILE_t;
 #endif
-  struct MatacqEventId{
-    MatacqEventId(): run(0), orbit(0){}
-    MatacqEventId(uint32_t r, uint32_t o): run(r), orbit(o){}
-					  
+  struct MatacqEventId {
+    MatacqEventId() : run(0), orbit(0) {}
+    MatacqEventId(uint32_t r, uint32_t o) : run(r), orbit(o) {}
+
     /** Run number
      */
     uint32_t run;
-    
+
     /** Orbit id
      */
     uint32_t orbit;
-    
-    bool
-    operator<(const MatacqEventId& a){
-      return (this->run < a.run)
-	|| ((this->run == a.run) && (this->orbit < a.orbit));
-    }
-    
-    bool
-    operator>(const MatacqEventId& a){
-      return (this->run > a.run)
-	|| ((this->run == a.run) && (this->orbit > a.orbit));
-    }
-    
-    bool
-    operator==(const MatacqEventId& a){
-      return !((*this) < a || (*this) > a);
-    }
-  };
 
+    bool operator<(const MatacqEventId& a) {
+      return (this->run < a.run) || ((this->run == a.run) && (this->orbit < a.orbit));
+    }
+
+    bool operator>(const MatacqEventId& a) {
+      return (this->run > a.run) || ((this->run == a.run) && (this->orbit > a.orbit));
+    }
+
+    bool operator==(const MatacqEventId& a) { return !((*this) < a || (*this) > a); }
+  };
 
   /** Estimates matacq event position in a file from its orbit id. This
    * estimator requires that every event in the file has the same length. A
@@ -96,19 +79,19 @@ private:
    * is performed. It gives only a rough estimate, relevant only to initiliaze
    * the event search.
    */
-  class PosEstimator{
+  class PosEstimator {
     //Note: a better estimate could be obtained by using segment of linear
     //functions. In such implementation, the estimator must be updated
     //each time a point with wrong estimate has been found.
   public:
-    PosEstimator():eventLength_(0), orbitStepMean_(0), firstOrbit_(0),
-		   invalid_(true), verbosity_(0) { }
+    PosEstimator() : eventLength_(0), orbitStepMean_(0), firstOrbit_(0), invalid_(true), verbosity_(0) {}
     void init(MatacqProducer* mp);
     bool invalid() const { return invalid_; }
     int64_t pos(int orb) const;
     int eventLength() const { return eventLength_; }
     int firstOrbit() const { return firstOrbit_; }
     void verbosity(int verb) { verbosity_ = verb; }
+
   private:
     int eventLength_;
     int orbitStepMean_;
@@ -121,8 +104,7 @@ public:
   /** Constructor
    * @param params seletive readout parameters
    */
-  explicit
-  MatacqProducer(const edm::ParameterSet& params);
+  explicit MatacqProducer(const edm::ParameterSet& params);
 
   /** Destructor
    */
@@ -132,16 +114,14 @@ public:
    * @param CMS event
    * @param eventSetup event conditions
    */
-  void
-  produce(edm::Event& event, const edm::EventSetup& eventSetup) override;
+  void produce(edm::Event& event, const edm::EventSetup& eventSetup) override;
 
 private:
   /** Add matacq digi to the event
    * @param event the event
    * @param digiInstanceName_ name to give to the matacq digi instance
    */
-  void
-  addMatacqData(edm::Event& event);
+  void addMatacqData(edm::Event& event);
 
   /** Retrieve the file containing a given matacq event
    * @param runNumber Number of the run the matacq event is looking from
@@ -150,18 +130,14 @@ private:
    * @return true if file retrieval succeeded, false otherwise.
    * found.
    */
-  bool
-  getMatacqFile(uint32_t runNumber, uint32_t orbitId, bool* fileChange =nullptr);
+  bool getMatacqFile(uint32_t runNumber, uint32_t orbitId, bool* fileChange = nullptr);
 
-  bool
-  getMatacqEvent(uint32_t runNumber, int32_t orbitId,
-		 bool fileChange);
+  bool getMatacqEvent(uint32_t runNumber, int32_t orbitId, bool fileChange);
   /*,bool doWrap = false, std::streamoff maxPos = -1);*/
 
   uint32_t getRunNumber(edm::Event& ev) const;
   uint32_t getOrbitId(edm::Event& ev) const;
 
-  
   bool getOrbitRange(uint32_t& firstOrb, uint32_t& lastOrb);
 
   int getCalibTriggerType(edm::Event& ev) const;
@@ -175,11 +151,11 @@ private:
    * @param n   size of data block
    * @param mess text to insert in the eventual error message.
    * @return true on success, false on failure
-   */  
+   */
   bool mseek(filepos_t offset, int whence = SEEK_SET, const char* mess = nullptr);
 
   bool mtell(filepos_t& pos);
-  
+
   /** Read a data block from input file. On failure file position is restored
    * and if position restoring fails, file is rewind.
    * @param buf buffer to store read data
@@ -199,15 +175,15 @@ private:
   bool misOpened();
 
   bool meof();
-  
+
   bool mrewind();
 
   bool msize(filepos_t& s);
 
   void newRun(int prevRun, int newRun);
-  
+
   static std::string runSubDir(uint32_t runNumber);
-  
+
 private:
   std::vector<std::string> fileNames_;
 
@@ -218,7 +194,7 @@ private:
   /** Instance name to use for the produced Matacq raw data collection
    */
   std::string rawInstanceName_;
-  
+
   /** Parameter to switch module timing.
    */
   bool timing_;
@@ -244,7 +220,6 @@ private:
    */
   edm::InputTag inputRawCollection_;
 
-
   /** EDM token to access the raw data collection the Matacq data must be merge to
    * if merging is enabled.
    */
@@ -258,14 +233,14 @@ private:
   /** When true look for matacq data independently of trigger type.
    */
   bool ignoreTriggerType_;
-  
+
   MatacqRawEvent matacq_;
-  
+
   /** Stream of currently opened matacq file
    */
   FILE_t inFile_;
 
-  static const int bufferSize =  30000; //must greater or equal to maximum
+  static const int bufferSize = 30000;  //must greater or equal to maximum
   //                                      matacq event size.
   std::vector<unsigned char> data_;
   MatacqDataFormatter formatter_;
@@ -273,9 +248,9 @@ private:
   uint32_t openedFileRunNumber_;
   int32_t lastOrb_;
   int fastRetrievalThresh_;
-  
+
   PosEstimator posEstim_;
-  
+
   timeval startTime_;
 
   /** File name of table with orbit offset between
@@ -286,8 +261,8 @@ private:
 
   /** Orbit offset table. @see orbitOffsetFile_
    */
-  std::map<uint32_t,uint32_t> orbitOffset_;
-  
+  std::map<uint32_t, uint32_t> orbitOffset_;
+
   /** Switch for orbit ID correction. @see orbitOffsetFile_
    */
   bool doOrbitOffset_;
@@ -312,7 +287,6 @@ private:
   /** Log file
    */
   std::ofstream logFile_;
-
 
   /** counter for event skipping
    */
@@ -342,4 +316,4 @@ private:
   uint32_t runNumber_;
 };
 
-#endif 
+#endif

--- a/EventFilter/EcalRawToDigi/interface/MatacqRawEvent.h
+++ b/EventFilter/EcalRawToDigi/interface/MatacqRawEvent.h
@@ -7,8 +7,8 @@
 #include <cstddef>
 #include <vector>
 
-#if 0                          //replace 1 by 0 to remove XDAQ dependency. In this case it is assumed the \
-                               //machine is little endian.
+//replace 1 by 0 to remove XDAQ dependency. In this case it is assumed the machine is little endian.
+#if 0
 #include "i2o/utils/endian.h"  //from XDAQ
 #define UINT32_FROM_LE i2odecodel
 #define UINT16_FROM_LE i2odecodes

--- a/EventFilter/EcalRawToDigi/interface/MatacqRawEvent.h
+++ b/EventFilter/EcalRawToDigi/interface/MatacqRawEvent.h
@@ -7,14 +7,14 @@
 #include <cstddef>
 #include <vector>
 
-#if 0 //replace 1 by 0 to remove XDAQ dependency. In this case it is assumed the
-      //machine is little endian.
-#include "i2o/utils/endian.h" //from XDAQ
+#if 0                          //replace 1 by 0 to remove XDAQ dependency. In this case it is assumed the \
+                               //machine is little endian.
+#include "i2o/utils/endian.h"  //from XDAQ
 #define UINT32_FROM_LE i2odecodel
 #define UINT16_FROM_LE i2odecodes
 #define INT16_FROM_LE i2odecodes
 
-#else //assuming little endianness of the machine
+#else  //assuming little endianness of the machine
 
 #define UINT32_FROM_LE
 #define UINT16_FROM_LE
@@ -22,54 +22,48 @@
 
 #endif
 
-#include <sys/time.h> //for timeval definition
+#include <sys/time.h>  //for timeval definition
 
 /** Wrapper for matacq raw event fragments. This class provides the
  * method to interpret the data. 
  */
-class MatacqRawEvent{
+class MatacqRawEvent {
   //typedefs, enums and static constants
 public:
   enum matacqError_t {
     /** Event length is specified both in the data header and the trailer. This
      * flags indicates an inconsitency between the two indications.
      */
-    errorLengthConsistency = 1<<0,
+    errorLengthConsistency = 1 << 0,
     /** Error in data length.
      */
-    errorLength = 1<<1,
+    errorLength = 1 << 1,
     /** Wrong Begin of event flag
      */
-    errorWrongBoe = 1<<2
+    errorWrongBoe = 1 << 2
   };
 
   /* The following types are little-endian encoded types. Use of these types
    * for the I20 data block should offer portability to big-endian platforms.
    */
   //@{
-  struct uint32le_t{
+  struct uint32le_t {
     uint32_t littleEndianInt;
-    operator uint32_t() const{
-      return UINT32_FROM_LE(littleEndianInt);
-    }
+    operator uint32_t() const { return UINT32_FROM_LE(littleEndianInt); }
   };
-  
-  struct uint16le_t{
+
+  struct uint16le_t {
     uint16_t littleEndianInt;
-    operator uint16_t() const{
-      return UINT16_FROM_LE(littleEndianInt);
-    }
+    operator uint16_t() const { return UINT16_FROM_LE(littleEndianInt); }
   };
-  
-  struct int16le_t{
+
+  struct int16le_t {
     int16_t littleEndianInt;
-    operator int16_t() const{
-      return INT16_FROM_LE(littleEndianInt);
-    }
+    operator int16_t() const { return INT16_FROM_LE(littleEndianInt); }
   };
   //@}
-  
-  struct ChannelData{
+
+  struct ChannelData {
     /** Matacq channel number. From 0 to 3.
      */
     int chId;
@@ -81,28 +75,28 @@ public:
     const int16le_t* samples;
   };
 
-private:  
+private:
   /** Matacq header data structure
    */
-//   struct matacqHeader_t{		 
-//     uint16_t version;	 
-//     unsigned char freqGHz;	 
-//     unsigned char channelCount; 
-//     uint32_t orbitId;
-//     unsigned char trigRec;
-//     uint16_t postTrig;
-//     uint16_t vernier[4];
-//     uint32_t timeStamp;
-//   };                                          
+  //   struct matacqHeader_t{
+  //     uint16_t version;
+  //     unsigned char freqGHz;
+  //     unsigned char channelCount;
+  //     uint32_t orbitId;
+  //     unsigned char trigRec;
+  //     uint16_t postTrig;
+  //     uint16_t vernier[4];
+  //     uint32_t timeStamp;
+  //   };
 
   /** Specification of DAQ header field.
    */
-  struct field32spec_t{
+  struct field32spec_t {
     int offset;
     unsigned int mask;
   };
-  
-  //@{  
+
+  //@{
   /** DAQ header field specifications.
    */
   static const field32spec_t fov32;
@@ -116,7 +110,7 @@ private:
   static const field32spec_t runNum32;
   static const field32spec_t h1Marker32;
   //@}
-  
+
   //@{
   /** Matacq header field specifications.
    */
@@ -133,7 +127,7 @@ private:
   static const field32spec_t vernier2_32;
   static const field32spec_t vernier3_32;
   static const field32spec_t timeStampMicroSec32;
-  
+
   static const field32spec_t laserPower32;
   static const field32spec_t attenuation_dB32;
   static const field32spec_t emtcPhase32;
@@ -145,7 +139,7 @@ private:
   static const field32spec_t side32;
 
   //@}
-  
+
   //constructors
 public:
   /** Constuctor.
@@ -157,7 +151,7 @@ public:
    * @throw std::exception if the data cannot be decoded due to data corruption
    * or truncation.
    */
-  MatacqRawEvent(const unsigned char* dataBuffer, size_t bufferSize): vernier(std::vector<int>(4)){
+  MatacqRawEvent(const unsigned char* dataBuffer, size_t bufferSize) : vernier(std::vector<int>(4)) {
     setRawData(dataBuffer, bufferSize);
   }
   //methods
@@ -168,137 +162,135 @@ public:
    * #getMatacqDataFormatVersion()
    * @return FOV
    */
-  int getFov() const { return read32(daqHeader, fov32);}
-  
+  int getFov() const { return read32(daqHeader, fov32); }
+
   /** Gets the FED ID field contents. Should be 655.
    * @return FED ID
    */
-  int getFedId() const { return read32(daqHeader, fedId32);}
+  int getFedId() const { return read32(daqHeader, fedId32); }
 
   /** Gets the bunch crossing id field contents.
    * @return BX id
    */
-  int getBxId() const { return read32(daqHeader, bxId32);}
+  int getBxId() const { return read32(daqHeader, bxId32); }
 
   /** Gets the LV1 field contents.
    * @return LV1 id
    */
-  unsigned getEventId() const { return read32(daqHeader, lv132);}
+  unsigned getEventId() const { return read32(daqHeader, lv132); }
 
   /** Gets the trigger type field contents.
    * @return trigger type
    */
-  int getTriggerType() const { return read32(daqHeader, triggerType32);}
+  int getTriggerType() const { return read32(daqHeader, triggerType32); }
 
   /** Gets the beging of event field contents (BOE). Must be 0x5.
    * @return BOE
    */
-  int getBoe() const { return read32(daqHeader, boeType32);}
+  int getBoe() const { return read32(daqHeader, boeType32); }
 
   /** Gets the event length specifies in the "a la DCC" header.
    * @return event length
    */
-  unsigned getDccLen() const { return read32(daqHeader, dccLen32);}
+  unsigned getDccLen() const { return read32(daqHeader, dccLen32); }
 
-   /** Gets the event length specifies in the DCC-type header of a matacq event.
+  /** Gets the event length specifies in the DCC-type header of a matacq event.
     * @param data buffer. Needs to contains at least the 3 first 32-bit words
     * of the event.
     * @param buffer size
     * @return event length, 0xFFFFFFFF if failed to retrieve dcc length
     */
-   static unsigned getDccLen(unsigned char* data, size_t size){
-     if(size<(unsigned)(dccLen32.offset+1)*4) return (unsigned)-1;
-     return read32((uint32le_t*) data, dccLen32);
-   }
+  static unsigned getDccLen(unsigned char* data, size_t size) {
+    if (size < (unsigned)(dccLen32.offset + 1) * 4)
+      return (unsigned)-1;
+    return read32((uint32le_t*)data, dccLen32);
+  }
 
-   /** Gets the orbit id from the header of a matacq event. Data format
+  /** Gets the orbit id from the header of a matacq event. Data format
     * of the event must be >=3.
     * @param data buffer. Needs to contains at least the 8 first 32-bit words
     * of the event.
     * @param buffer size
     * @return event length, 0xFFFFFFFF if failed to retrieve dcc length
     */
-   static unsigned getOrbitId(unsigned char* data, size_t size){
-     if(size<(unsigned)(orbitId32.offset+1)*8) return (unsigned)-1;
-     return read32((uint32le_t*) data, orbitId32);
-   }
+  static unsigned getOrbitId(unsigned char* data, size_t size) {
+    if (size < (unsigned)(orbitId32.offset + 1) * 8)
+      return (unsigned)-1;
+    return read32((uint32le_t*)data, orbitId32);
+  }
 
-   /** Gets the run number from the  header of a matacq event.
+  /** Gets the run number from the  header of a matacq event.
     * @param data buffer. Needs to contains at least the 4 first 32-bit words
     * of the event.
     * @param buffer size
     * @return event length, 0xFFFFFFFF if failed to retrieve dcc length
     */
-   static unsigned getRunNum(unsigned char* data, size_t size){
-     if(size<(unsigned)(runNum32.offset+1)*8) return (unsigned)-1;
-     return read32((uint32le_t*) data, runNum32);
-   }
+  static unsigned getRunNum(unsigned char* data, size_t size) {
+    if (size < (unsigned)(runNum32.offset + 1) * 8)
+      return (unsigned)-1;
+    return read32((uint32le_t*)data, runNum32);
+  }
 
-  
   /** Gets the event length specifies in the DAQ trailer
    * @return event length
    */
-  unsigned getDaqLen() const { return fragLen;}
-
+  unsigned getDaqLen() const { return fragLen; }
 
   /** Gets the contents of the DCC error field. Currently Not used for Matacq.
    * @return dcc error
    */
-  int getDccErrors() const { return read32(daqHeader, dccErrors32);}
+  int getDccErrors() const { return read32(daqHeader, dccErrors32); }
 
   /** Gets the run number field contents.
    * @return run number
    */
-  unsigned getRunNum() const { return read32(daqHeader, runNum32);}
+  unsigned getRunNum() const { return read32(daqHeader, runNum32); }
 
   /** Gets the header marker field contents. Must be 1
    * @return H1 header marker
    */
-  int getH1Marker() const { return read32(daqHeader, h1Marker32);}
-  
+  int getH1Marker() const { return read32(daqHeader, h1Marker32); }
 
   /** Gets the matcq data format version
    * @return data version
    */
-  int getMatacqDataFormatVersion() const { return matacqDataFormatVersion;}
+  int getMatacqDataFormatVersion() const { return matacqDataFormatVersion; }
 
   /** Gets the raw data status. Bitwise OR of the error flags
    * defined by matcqError_t
    * @return status
    */
-  int32_t getStatus() const { return error;}
+  int32_t getStatus() const { return error; }
 
   /** Gets the matacq sampling frequency field contents.
    * @return sampling frequency in GHz: 1 or 2
    */
-  int getFreqGHz() const { return /*matacqHeader->*/freqGHz;}
+  int getFreqGHz() const { return /*matacqHeader->*/ freqGHz; }
 
   /** Gets the matacq channel count field contents.
    * @return number of channels
    */
-  int getChannelCount() const { return /*matacqHeader->*/channelCount;}
+  int getChannelCount() const { return /*matacqHeader->*/ channelCount; }
 
   /** Gets the matacq channel data. Beware that no copy is done and that
    * the returned data will be invalidated if the data contains in the buffer
    * is modified (see constructor and #setRawData().
    * @return matacq channel data.
    */
-  const std::vector<ChannelData>& getChannelData() const{
-    return channelData;
-  }
+  const std::vector<ChannelData>& getChannelData() const { return channelData; }
 
   /** Gets the data length in number of 64-bit words computed by the data
    * parser.
    * @return event length
    */
-  int getParsedLen() {  return parsedLen; }
-  
+  int getParsedLen() { return parsedLen; }
+
   /** Gets the matacq data timestamp field contents: 
    * @return acquisition date of the data expressed in number of "elapsed"
    * second since the EPOCH as defined in POSIX.1. See time()  standard c
    * function.
    */
-  time_t getTimeStamp() const { return /*matacqHeader->*/timeStamp.tv_sec; }
+  time_t getTimeStamp() const { return /*matacqHeader->*/ timeStamp.tv_sec; }
 
   /** Gets the matacq data timestamp with fine granularity (89.1us) 
    * @return acquisition date of the data expressed in number of "elapsed"
@@ -342,7 +334,7 @@ public:
   /**  WTE-to-Laser delay of EMTC in LHC clock unit.
    */
   int getEmtcDelay() const { return emtcDelay; }
-  
+
   /** EMTC laser phase in 1/8th LHC clock unit.
    */
   int getEmtcPhase() const { return emtcPhase; }
@@ -355,7 +347,7 @@ public:
   /** Laser power in percents (set with the linear attenuator).
    */
   int getLaserPower() const { return laserPower; }
-  
+
 private:
   /** Help function to decode header content.
    * @param data pointer
@@ -365,13 +357,13 @@ private:
    * it is set, then -1 is returned.
    * @return content of data field specified by 'spec'
    */
-  static int read32(const uint32le_t *pData, field32spec_t spec, bool ovfTrans = false);
-  
-//   /** Help function to get the maximum value of a data field
-//    * @param spec32 data field specification
-//    * @return maximum value
-//    */
-//   int max32(field32spec_t spec32) const;
+  static int read32(const uint32le_t* pData, field32spec_t spec, bool ovfTrans = false);
+
+  //   /** Help function to get the maximum value of a data field
+  //    * @param spec32 data field specification
+  //    * @return maximum value
+  //    */
+  //   int max32(field32spec_t spec32) const;
 
   /** Changes the raw data pointer and updates accordingly this object. 
    * @param buffer new pointer to the data buffer. Must be aligned at least
@@ -395,14 +387,14 @@ private:
   /** Number of matacq channels in the data.
    */
   int channelCount;
-  
+
   /** Channel samples
    */
   std::vector<ChannelData> channelData;
 
   /** Pointer to the standard CMS DAQ header
    */
-  const uint32le_t *daqHeader;
+  const uint32le_t* daqHeader;
 
   /** DCC error field content.
    */
@@ -443,7 +435,7 @@ private:
   /**Matacq header:
    */
   //  matacqHeader_t* matacqHeader;
-  
+
   /** MATACQ data format internal version
    */
   int matacqDataFormatVersion;
@@ -467,7 +459,7 @@ private:
   /** MATACQ trigger time position in ps
    */
   int tTrigPs;
-  
+
   /** Trigger type
    */
   int triggerType;
@@ -494,8 +486,8 @@ private:
 
   /**  WTE-to-Laser delay of EMTC in LHC clock unit.
    */
-  int emtcDelay;    
-  
+  int emtcDelay;
+
   /** EMTC laser phase in 1/8th LHC clock unit.
    */
   int emtcPhase;
@@ -510,4 +502,4 @@ private:
   int laserPower;
 };
 
-#endif //MATACQRAWEVENT_H not defined
+#endif  //MATACQRAWEVENT_H not defined

--- a/EventFilter/EcalRawToDigi/plugins/EcalDumpRaw.cc
+++ b/EventFilter/EcalRawToDigi/plugins/EcalDumpRaw.cc
@@ -33,194 +33,156 @@
 const int feBxOffset = 1;
 
 const int EcalDumpRaw::ttId_[nTccTypes_][maxTpgsPerTcc_] = {
-  //EB-
-  { 1,   2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
-    17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
-    33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48,
-    49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64,
-    65, 66, 67, 68
-  },
+    //EB-
+    {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+     24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
+     47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68},
 
-  //EB+
-  { 4,   3,  2,  1,  8,  7,  6,  5, 12, 11, 10,  9, 16, 15, 14, 13,
-    20, 19, 18, 17, 24, 23, 22, 21, 28, 27, 26, 25, 32, 31, 30, 29,
-    36, 35, 34, 33, 40, 39, 38, 37, 44, 43, 42, 41, 48, 47, 46, 45,
-    52, 51, 50, 49, 56, 55, 54, 53, 60, 59, 58, 57, 64, 63, 62, 61,
-    68, 67, 66, 65
-  },
+    //EB+
+    {4,  3,  2,  1,  8,  7,  6,  5,  12, 11, 10, 9,  16, 15, 14, 13, 20, 19, 18, 17, 24, 23, 22,
+     21, 28, 27, 26, 25, 32, 31, 30, 29, 36, 35, 34, 33, 40, 39, 38, 37, 44, 43, 42, 41, 48, 47,
+     46, 45, 52, 51, 50, 49, 56, 55, 54, 53, 60, 59, 58, 57, 64, 63, 62, 61, 68, 67, 66, 65},
 
-  //inner EE
-  { 1,   2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16,
-    17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,  0,  0,  0,  0,
-    0,   0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
-    0,   0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
-    0,   0,  0,  0
-  },
-  
-  //outer EE
-  { 1,   2,  3,  4,  5,  6,  7,  8,  9,
-    0,   0,  0,  0,  0,  0,  0,  0,  0,
-    10, 11, 12, 13, 14, 15, 16,  0,  0,
-    0,   0,  0,  0,  0,  0,  0,  0,  0,
-    0,   0,  0,  0,  0,  0,  0,  0,  0,
-    0,   0,  0,  0,  0,  0,  0,  0,  0,
-    0,   0,  0,  0,  0,  0,  0,  0,  0,
-    0,   0,  0,  0,  0
-  }
-};
+    //inner EE
+    {1,  2,  3,  4,  5,  6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+     24, 25, 26, 27, 28, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
+     0,  0,  0,  0,  0,  0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0},
+
+    //outer EE
+    {1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 11, 12, 13, 14, 15, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,  0,  0,  0,  0, 0, 0, 0, 0, 0, 0, 0, 0}};
 
 using namespace std;
 
-static const char* const trigNames[] = {
-  "Unknown",
-  "Phys",
-  "Calib",
-  "Test",
-  "Ext",
-  "Simu",
-  "Trace",
-  "Err"
-};
+static const char* const trigNames[] = {"Unknown", "Phys", "Calib", "Test", "Ext", "Simu", "Trace", "Err"};
 
 static const char* const detailedTrigNames[] = {
-  "?",   //000
-  "?",   //001
-  "?",   //010
-  "?",   //011
-  "Las", //100
-  "Led", //101
-  "TP",  //110
-  "Ped"  //111
+    "?",    //000
+    "?",    //001
+    "?",    //010
+    "?",    //011
+    "Las",  //100
+    "Led",  //101
+    "TP",   //110
+    "Ped"   //111
 };
 
-static const char* const colorNames[] = {
-  "Blue",
-  "Green",
-  "Red",
-  "IR"
-};
+static const char* const colorNames[] = {"Blue", "Green", "Red", "IR"};
 
 static const char* const ttsNames[] = {
-  "Discon'd", //0000
-  "OvFWarn",  //0001
-  "OoS",      //0010
-  "Forb",     //0011
-  "Busy",     //0100
-  "Forb",     //0101
-  "Forb",     //0110
-  "Forb",     //0111
-  "Ready",    //1000
-  "Forb",     //1001
-  "Idle",     //1010
-  "Forb",     //1011
-  "Err",      //1100
-  "Forb",     //1101
-  "Forb",     //1110
-  "Discon'd"  //1111
+    "Discon'd",  //0000
+    "OvFWarn",   //0001
+    "OoS",       //0010
+    "Forb",      //0011
+    "Busy",      //0100
+    "Forb",      //0101
+    "Forb",      //0110
+    "Forb",      //0111
+    "Ready",     //1000
+    "Forb",      //1001
+    "Idle",      //1010
+    "Forb",      //1011
+    "Err",       //1100
+    "Forb",      //1101
+    "Forb",      //1110
+    "Discon'd"   //1111
 };
 
 //double mgpaGainFactors[] = {12., 1., 12./6., 12.}; //index 0->saturation
 //          gain setting:     sat  12       6    1  //index 0->saturation
 //          gain setting:  1(sat)     12      6        1
 //index 0->saturation
-static const double mgpaGainFactors[] = {10.63, 1., 10.63/5.43, 10.63};
+static const double mgpaGainFactors[] = {10.63, 1., 10.63 / 5.43, 10.63};
 
-EcalDumpRaw::EcalDumpRaw(const edm::ParameterSet& ps):
-  iEvent_(0),
-  adc_(nSamples, 0.),
-  amplCut_(ps.getUntrackedParameter<double>("amplCut", 5.)),
-  dump_(ps.getUntrackedParameter<bool>("dump", true)),
-  dumpAdc_(ps.getUntrackedParameter<bool>("dumpAdc", true)),
-  l1aHistory_(ps.getUntrackedParameter<bool>("l1aHistory", true)),
-  //  doHisto_(ps.getUntrackedParameter<bool>("doHisto", true)),
-  maxEvt_(ps.getUntrackedParameter<int>("maxEvt", 10000)),
-  profileFedId_(ps.getUntrackedParameter<int>("profileFedId", 0)),
-  profileRuId_(ps.getUntrackedParameter<int>("profileRuId", 1)),
-  l1aMinX_(ps.getUntrackedParameter<int>("l1aMinX", 1)),
-  l1aMaxX_(ps.getUntrackedParameter<int>("l1aMaxX", 601)),
-  lastOrbit_(nDccs_, numeric_limits<uint32_t>::max()),
-  eventId_(numeric_limits<unsigned>::max()),
-  eventList_(ps.getUntrackedParameter<vector<unsigned> >("eventList", vector<unsigned>())),
-  minEventId_(999999),
-  maxEventId_(0),
-  orbit0_(0),
-  orbit0Set_(false),
-  bx_(-1),
-  l1a_(-1),
-  simpleTrigType_(-1),
-  detailedTrigType_(-1),
-  //  histo_("hist.root", "RECREATE"),
-  l1as_(36+2),
-  orbits_(36+2),
-  tpg_(maxTccsPerDcc_, std::vector<int>(maxTpgsPerTcc_)),
-  nTpgs_(maxTccsPerDcc_, 0),
-  dccChStatus_(70, 0),
-  srpL1a_(-1),
-  tccL1a_(-1),
-  nTts_(-1),
-  tccBlockLen64_(19),
-  feL1a_(nRu_,-1),
-  srpBx_(-1),
-  tccBx_(-1),
-  tccType_(0),
-  feBx_(nRu_,-1),
-  feRuId_(nRu_,-1),
-  iTow_(0),
-  pulsePerRu_(ps.getUntrackedParameter<bool>("pulsePerRu", true)),
-  pulsePerLmod_(ps.getUntrackedParameter<bool>("pulsePerLmod", true)),
-  pulsePerLme_(ps.getUntrackedParameter<bool>("pulsePerLme", true)),
-  tccId_(0),
-  fedRawDataCollectionTag_(ps.getParameter<edm::InputTag>("fedRawDataCollectionTag")),
-  l1AcceptBunchCrossingCollectionTag_(ps.getParameter<edm::InputTag>("l1AcceptBunchCrossingCollectionTag"))
-{
-  verbosity_= ps.getUntrackedParameter<int>("verbosity",1);
+EcalDumpRaw::EcalDumpRaw(const edm::ParameterSet& ps)
+    : iEvent_(0),
+      adc_(nSamples, 0.),
+      amplCut_(ps.getUntrackedParameter<double>("amplCut", 5.)),
+      dump_(ps.getUntrackedParameter<bool>("dump", true)),
+      dumpAdc_(ps.getUntrackedParameter<bool>("dumpAdc", true)),
+      l1aHistory_(ps.getUntrackedParameter<bool>("l1aHistory", true)),
+      //  doHisto_(ps.getUntrackedParameter<bool>("doHisto", true)),
+      maxEvt_(ps.getUntrackedParameter<int>("maxEvt", 10000)),
+      profileFedId_(ps.getUntrackedParameter<int>("profileFedId", 0)),
+      profileRuId_(ps.getUntrackedParameter<int>("profileRuId", 1)),
+      l1aMinX_(ps.getUntrackedParameter<int>("l1aMinX", 1)),
+      l1aMaxX_(ps.getUntrackedParameter<int>("l1aMaxX", 601)),
+      lastOrbit_(nDccs_, numeric_limits<uint32_t>::max()),
+      eventId_(numeric_limits<unsigned>::max()),
+      eventList_(ps.getUntrackedParameter<vector<unsigned> >("eventList", vector<unsigned>())),
+      minEventId_(999999),
+      maxEventId_(0),
+      orbit0_(0),
+      orbit0Set_(false),
+      bx_(-1),
+      l1a_(-1),
+      simpleTrigType_(-1),
+      detailedTrigType_(-1),
+      //  histo_("hist.root", "RECREATE"),
+      l1as_(36 + 2),
+      orbits_(36 + 2),
+      tpg_(maxTccsPerDcc_, std::vector<int>(maxTpgsPerTcc_)),
+      nTpgs_(maxTccsPerDcc_, 0),
+      dccChStatus_(70, 0),
+      srpL1a_(-1),
+      tccL1a_(-1),
+      nTts_(-1),
+      tccBlockLen64_(19),
+      feL1a_(nRu_, -1),
+      srpBx_(-1),
+      tccBx_(-1),
+      tccType_(0),
+      feBx_(nRu_, -1),
+      feRuId_(nRu_, -1),
+      iTow_(0),
+      pulsePerRu_(ps.getUntrackedParameter<bool>("pulsePerRu", true)),
+      pulsePerLmod_(ps.getUntrackedParameter<bool>("pulsePerLmod", true)),
+      pulsePerLme_(ps.getUntrackedParameter<bool>("pulsePerLme", true)),
+      tccId_(0),
+      fedRawDataCollectionTag_(ps.getParameter<edm::InputTag>("fedRawDataCollectionTag")),
+      l1AcceptBunchCrossingCollectionTag_(ps.getParameter<edm::InputTag>("l1AcceptBunchCrossingCollectionTag")) {
+  verbosity_ = ps.getUntrackedParameter<int>("verbosity", 1);
 
-  beg_fed_id_= ps.getUntrackedParameter<int>("beg_fed_id",601);
-  end_fed_id_= ps.getUntrackedParameter<int>("end_fed_id",654);
+  beg_fed_id_ = ps.getUntrackedParameter<int>("beg_fed_id", 601);
+  end_fed_id_ = ps.getUntrackedParameter<int>("end_fed_id", 654);
 
+  first_event_ = ps.getUntrackedParameter<int>("first_event", 1);
+  last_event_ = ps.getUntrackedParameter<int>("last_event", numeric_limits<int>::max());
 
-  first_event_ = ps.getUntrackedParameter<int>("first_event",1);
-  last_event_  = ps.getUntrackedParameter<int>("last_event",
-                                               numeric_limits<int>::max());
-
-  writeDcc_ = ps.getUntrackedParameter<bool>("writeDCC",false);
-  filename_  = ps.getUntrackedParameter<string>("filename","dump.bin");
+  writeDcc_ = ps.getUntrackedParameter<bool>("writeDCC", false);
+  filename_ = ps.getUntrackedParameter<string>("filename", "dump.bin");
 
   fedRawDataCollectionToken_ = consumes<FEDRawDataCollection>(fedRawDataCollectionTag_);
-  l1AcceptBunchCrossingCollectionToken_ = consumes<L1AcceptBunchCrossingCollection>(l1AcceptBunchCrossingCollectionTag_);
+  l1AcceptBunchCrossingCollectionToken_ =
+      consumes<L1AcceptBunchCrossingCollection>(l1AcceptBunchCrossingCollectionTag_);
 
-  if(writeDcc_){
+  if (writeDcc_) {
     dumpFile_.open(filename_.c_str());
-    if(dumpFile_.bad()){
-      /*edm::LogError("EcalDumpRaw")*/ std::cout << "Failed to open file '"
-                               << filename_.c_str() << "' specified by "
-                               << "parameter filename for writing. DCC data "
-        " dump will be disabled.";
+    if (dumpFile_.bad()) {
+      /*edm::LogError("EcalDumpRaw")*/ std::cout << "Failed to open file '" << filename_.c_str() << "' specified by "
+                                                 << "parameter filename for writing. DCC data "
+                                                    " dump will be disabled.";
       writeDcc_ = false;
     }
   }
 }
 
-void EcalDumpRaw::endJob(){
-}
+void EcalDumpRaw::endJob() {}
 
-EcalDumpRaw::~EcalDumpRaw(){
-}
+EcalDumpRaw::~EcalDumpRaw() {}
 
 // ------------ method called to analyze the data  ------------
-void
-EcalDumpRaw::analyze(const edm::Event& event, const edm::EventSetup& es){
+void EcalDumpRaw::analyze(const edm::Event& event, const edm::EventSetup& es) {
   ++iEvent_;
   eventId_ = event.id().event();
 
-  if(!eventList_.empty() && find(eventList_.begin(), eventList_.end(),
-                                  eventId_) == eventList_.end()){
+  if (!eventList_.empty() && find(eventList_.begin(), eventList_.end(), eventId_) == eventList_.end()) {
     cout << "Skipping event " << eventId_ << ".\n";
     return;
   }
-  
-  if ((first_event_ > 0 && iEvent_ < first_event_) ||
-      (last_event_ > 0 && last_event_ < iEvent_)) return;
+
+  if ((first_event_ > 0 && iEvent_ < first_event_) || (last_event_ > 0 && last_event_ < iEvent_))
+    return;
   timeval start;
   timeval stop;
   gettimeofday(&start, nullptr);
@@ -228,37 +190,35 @@ EcalDumpRaw::analyze(const edm::Event& event, const edm::EventSetup& es){
   edm::Handle<FEDRawDataCollection> rawdata;
   event.getByToken(fedRawDataCollectionToken_, rawdata);
 
-  if(dump_ || l1aHistory_) cout << "\n======================================================================\n"
-                                << toNth(iEvent_)
-                                << " read event. "
-                                << "Event id: "
-                                << " " << eventId_
-                                << "\n----------------------------------------------------------------------\n";
-  
-  if(l1aHistory_){
+  if (dump_ || l1aHistory_)
+    cout << "\n======================================================================\n"
+         << toNth(iEvent_) << " read event. "
+         << "Event id: "
+         << " " << eventId_ << "\n----------------------------------------------------------------------\n";
+
+  if (l1aHistory_) {
     edm::Handle<L1AcceptBunchCrossingCollection> l1aHist;
     event.getByToken(l1AcceptBunchCrossingCollectionToken_, l1aHist);
-    if(!l1aHist.isValid()) {
+    if (!l1aHist.isValid()) {
       cout << "L1A history not found.\n";
     } else if (l1aHist->empty()) {
       cout << "L1A history is empty.\n";
-    } else{
+    } else {
       cout << "L1A history: \n";
-      for(L1AcceptBunchCrossingCollection::const_iterator it = l1aHist->begin();
-          it != l1aHist->end();
-            ++it){
-        cout << "L1A offset: " <<  it->l1AcceptOffset() << "\t"
-             << "BX: " <<  it->bunchCrossing() << "\t"
+      for (L1AcceptBunchCrossingCollection::const_iterator it = l1aHist->begin(); it != l1aHist->end(); ++it) {
+        cout << "L1A offset: " << it->l1AcceptOffset() << "\t"
+             << "BX: " << it->bunchCrossing() << "\t"
              << "Orbit ID: " << it->orbitNumber() << "\t"
-             << "Trigger type: " << it->eventType() << " ("
-             << trigNames[it->eventType()&0xF] << ")\n";
-        }
+             << "Trigger type: " << it->eventType() << " (" << trigNames[it->eventType() & 0xF] << ")\n";
+      }
     }
     cout << "----------------------------------------------------------------------\n";
   }
-  
-  if(eventId_ < minEventId_) minEventId_ = eventId_;
-  if(eventId_ > maxEventId_) maxEventId_ = eventId_;
+
+  if (eventId_ < minEventId_)
+    minEventId_ = eventId_;
+  if (eventId_ > maxEventId_)
+    maxEventId_ = eventId_;
 
 #if 1
 
@@ -269,23 +229,22 @@ EcalDumpRaw::analyze(const edm::Event& event, const edm::EventSetup& es){
   //static int bxCalib = -1;
   //x static int nCalib = 0;
 
-  for (int id = 0; id<=FEDNumbering::lastFEDId(); ++id){
-
-    if (id < beg_fed_id_ || end_fed_id_ < id) continue;
+  for (int id = 0; id <= FEDNumbering::lastFEDId(); ++id) {
+    if (id < beg_fed_id_ || end_fed_id_ < id)
+      continue;
 
     const FEDRawData& data = rawdata->FEDData(id);
 
-    if (data.size()>4){
+    if (data.size() > 4) {
       ++iFed;
-      if ((data.size() % 8) !=0){
+      if ((data.size() % 8) != 0) {
         cout << "***********************************************\n";
         cout << " Fed size in bits not multiple of 64, strange.\n";
         cout << "***********************************************\n";
       }
 
-
-      size_t nWord32 = data.size()/4;
-      const uint32_t * pData = ( reinterpret_cast<uint32_t*>(const_cast<unsigned char*> ( data.data())));
+      size_t nWord32 = data.size() / 4;
+      const uint32_t* pData = (reinterpret_cast<uint32_t*>(const_cast<unsigned char*>(data.data())));
       stringstream s;
       srpL1a_ = -1;
       tccL1a_ = -1;
@@ -297,146 +256,126 @@ EcalDumpRaw::analyze(const edm::Event& event, const edm::EventSetup& es){
       iTcc_ = 0;
       tccType_ = 0;
 
-      for(int i = 0; i < nRu_; ++i){
-        feL1a_[i]  = -1;
-        feBx_[i]   = -1;
+      for (int i = 0; i < nRu_; ++i) {
+        feL1a_[i] = -1;
+        feBx_[i] = -1;
         feRuId_[i] = -1;
       }
 
       fill(nTpgs_.begin(), nTpgs_.end(), 0);
 
       fill(dccChStatus_.begin(), dccChStatus_.end(), 0);
-      
+
       bool rc;
-      for(size_t iWord32=0; iWord32 < nWord32; iWord32+=2){
+      for (size_t iWord32 = 0; iWord32 < nWord32; iWord32 += 2) {
         s.str("");
-        if(id>=601 && id<=654){// ECAL DCC data
-          rc = decode(pData+iWord32, iWord32/2, s);
-        } else{
+        if (id >= 601 && id <= 654) {  // ECAL DCC data
+          rc = decode(pData + iWord32, iWord32 / 2, s);
+        } else {
           rc = true;
         }
-        if(rc && dump_){
-          cout << setfill('0') << hex
-               << "[" << setw(8) << iWord32*4 << "] "
-               <<        setw(4) << (pData[iWord32+1]>>16 & 0xFFFF) << " "
-               <<        setw(4) << (pData[iWord32+1]>>0  & 0xFFFF) << " "
-               <<        setw(4) << (pData[iWord32]>>16 & 0xFFFF) << " "
-               <<        setw(4) << (pData[iWord32]>>0  & 0xFFFF) << " "
-               << setfill(' ') << dec
-               << s.str() << "\n";
+        if (rc && dump_) {
+          cout << setfill('0') << hex << "[" << setw(8) << iWord32 * 4 << "] " << setw(4)
+               << (pData[iWord32 + 1] >> 16 & 0xFFFF) << " " << setw(4) << (pData[iWord32 + 1] >> 0 & 0xFFFF) << " "
+               << setw(4) << (pData[iWord32] >> 16 & 0xFFFF) << " " << setw(4) << (pData[iWord32] >> 0 & 0xFFFF) << " "
+               << setfill(' ') << dec << s.str() << "\n";
         }
       }
 
-      if(iFed==1){
+      if (iFed == 1) {
         refDccId = dccId_;
-      } else{
-        if(dccId_!=refDccId){
+      } else {
+        if (dccId_ != refDccId) {
           dccIdErr = true;
         }
       }
 
-      if(dump_) cout << flush; //flushing cout before writing to cerr
+      if (dump_)
+        cout << flush;  //flushing cout before writing to cerr
 
-      if(srpBx_!=-1 && srpBx_!=bx_){
-        cerr << "Bx discrepancy between SRP and DCC, Bx(SRP) = "
-             << srpBx_ << ", Bx(DCC) = " << bx_
-             << " in " << toNth(iEvent_) << " event, FED "
-             << id << endl;
+      if (srpBx_ != -1 && srpBx_ != bx_) {
+        cerr << "Bx discrepancy between SRP and DCC, Bx(SRP) = " << srpBx_ << ", Bx(DCC) = " << bx_ << " in "
+             << toNth(iEvent_) << " event, FED " << id << endl;
       }
 
-      if(tccBx_!=-1 && tccBx_!=bx_){
-        cerr << "Bx discrepancy between TCC and DCC, Bx(TCC) = "
-             << srpBx_ << ", Bx(DCC) = " << bx_
-             << " in " << toNth(iEvent_) << " event, FED "
-             << id << endl;
+      if (tccBx_ != -1 && tccBx_ != bx_) {
+        cerr << "Bx discrepancy between TCC and DCC, Bx(TCC) = " << srpBx_ << ", Bx(DCC) = " << bx_ << " in "
+             << toNth(iEvent_) << " event, FED " << id << endl;
       }
 
       bool feBxErr = false;
-      for(int i=0; i < nRu_; ++i){
+      for (int i = 0; i < nRu_; ++i) {
         int expectedFeBx;
-        if(feBxOffset==0){
+        if (feBxOffset == 0) {
           expectedFeBx = bx_ - 1;
-        } else{
-          expectedFeBx = (bx_==3564) ? 0 : bx_;
+        } else {
+          expectedFeBx = (bx_ == 3564) ? 0 : bx_;
         }
-        if(feBx_[i]!=-1 && feBx_[i]!=expectedFeBx){
-          cerr << "BX error for " << toNth(i+1) << " RU, RU ID "
-               << feRuId_[i];
-          if((unsigned) feRuId_[i] <= dccChStatus_.size()){
-            bool detected = (dccChStatus_[feRuId_[i]-1] == 10 || dccChStatus_[feRuId_[i]-1] == 11);
-            cerr << (detected?" ":" not ") << "detected by DCC (ch status: "
-                 << dccChStatus_[feRuId_[i]-1] << ")";
+        if (feBx_[i] != -1 && feBx_[i] != expectedFeBx) {
+          cerr << "BX error for " << toNth(i + 1) << " RU, RU ID " << feRuId_[i];
+          if ((unsigned)feRuId_[i] <= dccChStatus_.size()) {
+            bool detected = (dccChStatus_[feRuId_[i] - 1] == 10 || dccChStatus_[feRuId_[i] - 1] == 11);
+            cerr << (detected ? " " : " not ") << "detected by DCC (ch status: " << dccChStatus_[feRuId_[i] - 1] << ")";
           }
-          cerr << " in " << toNth(iEvent_) << " event, FED "
-               << id << "." << endl;
-          
+          cerr << " in " << toNth(iEvent_) << " event, FED " << id << "." << endl;
+
           feBxErr = true;
         }
       }
-      if(feBxErr) cerr << "Bx discrepancy between DCC and at least one FE"
-                       << " in " << toNth(iEvent_) << " event, FED "
-                       << id << "\n";
-
+      if (feBxErr)
+        cerr << "Bx discrepancy between DCC and at least one FE"
+             << " in " << toNth(iEvent_) << " event, FED " << id << "\n";
 
       int localL1a = l1a_ & 0xFFF;
-      if(srpL1a_!=-1 && srpL1a_!=localL1a){
-        cerr << "Discrepancy between SRP and DCC L1a counter, L1a(SRP) = "
-             << srpL1a_ << ", L1a(DCC) & 0xFFF = " << localL1a
-             << " in " << toNth(iEvent_) << " event, FED "
-             << id << endl;
-
+      if (srpL1a_ != -1 && srpL1a_ != localL1a) {
+        cerr << "Discrepancy between SRP and DCC L1a counter, L1a(SRP) = " << srpL1a_
+             << ", L1a(DCC) & 0xFFF = " << localL1a << " in " << toNth(iEvent_) << " event, FED " << id << endl;
       }
 
-      if(tccL1a_!=-1 && tccL1a_!=localL1a){
-        cerr << "Discrepancy between TCC and DCC L1a counter, L1a(TCC) = "
-             << srpL1a_ << ", L1a(DCC) & 0xFFF = " << localL1a
-             << " in " << toNth(iEvent_) << " event, FED "
-             << id << endl;
-
+      if (tccL1a_ != -1 && tccL1a_ != localL1a) {
+        cerr << "Discrepancy between TCC and DCC L1a counter, L1a(TCC) = " << srpL1a_
+             << ", L1a(DCC) & 0xFFF = " << localL1a << " in " << toNth(iEvent_) << " event, FED " << id << endl;
       }
 
       bool feL1aErr = false;
-      for(int i=0; i < nRu_; ++i){
-        if(feL1a_[i] != -1 && feL1a_[i] != ((localL1a-1) & 0xFFF)){
-          cerr << "FE L1A error for " << toNth(i+1) << " RU, RU ID "
-               << feRuId_[i];
-          if((unsigned) feRuId_[i] <= dccChStatus_.size()){
-            bool detected = (dccChStatus_[feRuId_[i]-1] == 9 || dccChStatus_[feRuId_[i]-1] == 11);
-            cerr << (detected?" ":" not ") << "detected by DCC (ch status: "
-                 << dccChStatus_[feRuId_[i]-1] << ")";
+      for (int i = 0; i < nRu_; ++i) {
+        if (feL1a_[i] != -1 && feL1a_[i] != ((localL1a - 1) & 0xFFF)) {
+          cerr << "FE L1A error for " << toNth(i + 1) << " RU, RU ID " << feRuId_[i];
+          if ((unsigned)feRuId_[i] <= dccChStatus_.size()) {
+            bool detected = (dccChStatus_[feRuId_[i] - 1] == 9 || dccChStatus_[feRuId_[i] - 1] == 11);
+            cerr << (detected ? " " : " not ") << "detected by DCC (ch status: " << dccChStatus_[feRuId_[i] - 1] << ")";
           }
-          cerr << " in " << toNth(iEvent_) << " event, FED "
-               << id << "." << endl;
+          cerr << " in " << toNth(iEvent_) << " event, FED " << id << "." << endl;
           feL1aErr = true;
         }
       }
-      if(feL1aErr) cerr << "Discrepancy in L1a counter between DCC "
-                     "and at least one FE (L1A(DCC) & 0xFFF = " << localL1a << ")"
-                        << " in " << toNth(iEvent_) << " event, FED "
-                        << id << "\n";
-      
+      if (feL1aErr)
+        cerr << "Discrepancy in L1a counter between DCC "
+                "and at least one FE (L1A(DCC) & 0xFFF = "
+             << localL1a << ")"
+             << " in " << toNth(iEvent_) << " event, FED " << id << "\n";
 
-      if(iTow_>0 && iTow_< nRu_ && feRuId_[iTow_] < feRuId_[iTow_-1]){
+      if (iTow_ > 0 && iTow_ < nRu_ && feRuId_[iTow_] < feRuId_[iTow_ - 1]) {
         cerr << "Error in RU ID (TT/SC ID)"
-             << " in " << toNth(iEvent_) << " event, FED "
-             << id << endl;
+             << " in " << toNth(iEvent_) << " event, FED " << id << endl;
       }
 
-      if (beg_fed_id_ <= id && id <= end_fed_id_ && writeDcc_){
-        dumpFile_.write( reinterpret_cast <const char *> (pData), nWord32*4);
+      if (beg_fed_id_ <= id && id <= end_fed_id_ && writeDcc_) {
+        dumpFile_.write(reinterpret_cast<const char*>(pData), nWord32 * 4);
       }
-      
-      if(dump_) cout << "\n";
-    } else{
+
+      if (dump_)
+        cout << "\n";
+    } else {
       //      cout << "No data for FED " <<  id << ". Size = "
       //     << data.size() << " byte(s).\n";
     }
-  } //next fed
+  }  //next fed
 
-  if(dump_) cout << "Number of selected FEDs with a data block: "
-                 << iFed << "\n";
+  if (dump_)
+    cout << "Number of selected FEDs with a data block: " << iFed << "\n";
 
-  if(dccIdErr){
+  if (dccIdErr) {
     cout << flush;
     cerr << "DCC ID discrepancy in detailed trigger type "
          << " of " << toNth(iEvent_) << " event." << endl;
@@ -452,399 +391,377 @@ EcalDumpRaw::analyze(const edm::Event& event, const edm::EventSetup& es){
   //             dt);
 }
 
-string EcalDumpRaw::toNth(int n){
+string EcalDumpRaw::toNth(int n) {
   stringstream s;
   s << n;
-  if(n%100<10 || n%100>20){
-    switch(n%10){
-    case 1:
-      s << "st";
-      break;
-    case 2:
-      s << "nd";
-      break;
-    case 3:
-      s << "rd";
-      break;
-    default:
-      s << "th";
+  if (n % 100 < 10 || n % 100 > 20) {
+    switch (n % 10) {
+      case 1:
+        s << "st";
+        break;
+      case 2:
+        s << "nd";
+        break;
+      case 3:
+        s << "rd";
+        break;
+      default:
+        s << "th";
     }
-  } else{
+  } else {
     s << "th";
   }
   return s.str();
 }
 
-
-bool EcalDumpRaw::decode(const uint32_t* data, int iWord64, ostream& out){
+bool EcalDumpRaw::decode(const uint32_t* data, int iWord64, ostream& out) {
   bool rc = true;
-  const bool d  = dump_;
-  if(iWord64==0){//start of event
+  const bool d = dump_;
+  if (iWord64 == 0) {  //start of event
     iSrWord64_ = 0;
     iTccWord64_ = 0;
     iTowerWord64_ = 0;
   }
-  int dataType = (data[1] >>28) & 0xF;
+  int dataType = (data[1] >> 28) & 0xF;
   const int boe = 5;
   const int eoe = 10;
-  if(dataType==boe){//Begin of Event header
+  if (dataType == boe) {  //Begin of Event header
     /**********************************************************************
      *  DAQ header
      *
      **********************************************************************/
-    simpleTrigType_ = (data[1] >>24) & 0xF;
-    l1a_ = (data[1]>>0 )  & 0xFFffFF;
-    bx_ = (data[0] >>20) & 0xFFF;
-    fedId_ = (data[0] >>8 ) & 0xFFF;
-    if(d) out << "Trigger type: " << simpleTrigType_
-              << "(" << trigNames[(data[1]>>24) & 0xF] << ")"
-              << " L1A: "         << l1a_
-              << " BX: "          << bx_
-              << " FED ID: "      << fedId_
-              << " FOV: "         << ((data[0] >>4 ) & 0xF)
-              << " H: "           << ((data[0] >>3 ) & 0x1);
-  } else if((dataType>>2)==0){//DCC header
+    simpleTrigType_ = (data[1] >> 24) & 0xF;
+    l1a_ = (data[1] >> 0) & 0xFFffFF;
+    bx_ = (data[0] >> 20) & 0xFFF;
+    fedId_ = (data[0] >> 8) & 0xFFF;
+    if (d)
+      out << "Trigger type: " << simpleTrigType_ << "(" << trigNames[(data[1] >> 24) & 0xF] << ")"
+          << " L1A: " << l1a_ << " BX: " << bx_ << " FED ID: " << fedId_ << " FOV: " << ((data[0] >> 4) & 0xF)
+          << " H: " << ((data[0] >> 3) & 0x1);
+  } else if ((dataType >> 2) == 0) {  //DCC header
     /**********************************************************************
      * ECAL DCC header
      *
      **********************************************************************/
-    int dccHeaderId = (data[1] >>24) & 0x3F;
-    switch(dccHeaderId){
-    case 1:
-      if(d) out << "Run #: "     << ((data[1] >>0 ) & 0xFFFFFF)
-                << " DCC Err: "  << ((data[0] >>24) & 0xFF)
-                << " Evt Len:  " << ((data[0] >>0 ) & 0xFFFFFF);
-      break;
-    case 2:
-      side_ = (data[1] >>11) & 0x1;
-      detailedTrigType_ = (data[1] >>8 ) & 0x7;
-      dccId_ = (data[1] >>0 ) & 0x3F;
-      if(d) out << "DCC FOV: " << ((data[1] >>16) & 0xF)
-                << " Side: "   << side_
-                << " Trig.: "   << detailedTrigType_
-                << " (" << detailedTrigNames[(data[1]>>8)&0x7] << ")"
-                << " Color: "  << ((data[1] >>6 ) & 0x3)
-                << " (" << colorNames[(data[1]>>6)&0x3] << ")"
-                << " DCC ID: " << dccId_;
-      break;
-    case 3:
-      {
-      if(d) out << "TCC Status ch<4..1>: 0x"
-                << hex << ((data[1]>>8) & 0xFFFF) << dec
-                << " SR status: " << ((data[1] >>4 ) & 0xF)
-                << " TZS: "       << ((data[1] >>2 ) & 0x1)
-                << " ZS: "        << ((data[1] >>1 ) & 0x1)
-                << " SR: "        << ((data[1] >>0 ) & 0x1);
-      orbit_ = data[0];
-      if(d) out << " Orbit: "     << orbit_;
-      if(!orbit0Set_){
-        orbit0_ = orbit_;
-        orbit0Set_ = true;
-      }
-      int iDcc0 = fedId_-fedStart_;
-      if((unsigned)iDcc0<nDccs_){
-        if(lastOrbit_[iDcc0]!=numeric_limits<uint32_t>::max()){
-          if(d) out << " (+" << (int)orbit_-(int)lastOrbit_[iDcc0] <<")";
+    int dccHeaderId = (data[1] >> 24) & 0x3F;
+    switch (dccHeaderId) {
+      case 1:
+        if (d)
+          out << "Run #: " << ((data[1] >> 0) & 0xFFFFFF) << " DCC Err: " << ((data[0] >> 24) & 0xFF)
+              << " Evt Len:  " << ((data[0] >> 0) & 0xFFFFFF);
+        break;
+      case 2:
+        side_ = (data[1] >> 11) & 0x1;
+        detailedTrigType_ = (data[1] >> 8) & 0x7;
+        dccId_ = (data[1] >> 0) & 0x3F;
+        if (d)
+          out << "DCC FOV: " << ((data[1] >> 16) & 0xF) << " Side: " << side_ << " Trig.: " << detailedTrigType_ << " ("
+              << detailedTrigNames[(data[1] >> 8) & 0x7] << ")"
+              << " Color: " << ((data[1] >> 6) & 0x3) << " (" << colorNames[(data[1] >> 6) & 0x3] << ")"
+              << " DCC ID: " << dccId_;
+        break;
+      case 3: {
+        if (d)
+          out << "TCC Status ch<4..1>: 0x" << hex << ((data[1] >> 8) & 0xFFFF) << dec
+              << " SR status: " << ((data[1] >> 4) & 0xF) << " TZS: " << ((data[1] >> 2) & 0x1)
+              << " ZS: " << ((data[1] >> 1) & 0x1) << " SR: " << ((data[1] >> 0) & 0x1);
+        orbit_ = data[0];
+        if (d)
+          out << " Orbit: " << orbit_;
+        if (!orbit0Set_) {
+          orbit0_ = orbit_;
+          orbit0Set_ = true;
         }
-        lastOrbit_[iDcc0] = orbit_;
-      }
-    }
-      break;
-    case 4:
-    case 5:
-    case 6:
-    case 7:
-    case 8:
-      {
-        int chOffset = (dccHeaderId-4)*14;
-        dccChStatus_[13+chOffset] = ((data[1] >>20) & 0xF);
-        dccChStatus_[12+chOffset] = ((data[1] >>16) & 0xF);
-        dccChStatus_[11+chOffset] = ((data[1] >>12) & 0xF);
-        dccChStatus_[10+chOffset] = ((data[1] >>8 ) & 0xF);
-        dccChStatus_[ 9+chOffset] = ((data[1] >>4 ) & 0xF);
-        dccChStatus_[ 8+chOffset] = ((data[1] >>0)  & 0xF);
-        dccChStatus_[ 7+chOffset] = ((data[0] >>28) & 0xF);
-        dccChStatus_[ 6+chOffset] = ((data[0] >>24) & 0xF);
-        dccChStatus_[ 5+chOffset] = ((data[0] >>20) & 0xF);
-        dccChStatus_[ 4+chOffset] = ((data[0] >>16) & 0xF);
-        dccChStatus_[ 3+chOffset] = ((data[0] >>12) & 0xF);
-        dccChStatus_[ 2+chOffset] = ((data[0] >>8 ) & 0xF);
-        dccChStatus_[ 1+chOffset] = ((data[0] >>4 ) & 0xF);
-        dccChStatus_[ 0+chOffset] = ((data[0] >>0 ) & 0xF);
-        
-        if(d){
+        int iDcc0 = fedId_ - fedStart_;
+        if ((unsigned)iDcc0 < nDccs_) {
+          if (lastOrbit_[iDcc0] != numeric_limits<uint32_t>::max()) {
+            if (d)
+              out << " (+" << (int)orbit_ - (int)lastOrbit_[iDcc0] << ")";
+          }
+          lastOrbit_[iDcc0] = orbit_;
+        }
+      } break;
+      case 4:
+      case 5:
+      case 6:
+      case 7:
+      case 8: {
+        int chOffset = (dccHeaderId - 4) * 14;
+        dccChStatus_[13 + chOffset] = ((data[1] >> 20) & 0xF);
+        dccChStatus_[12 + chOffset] = ((data[1] >> 16) & 0xF);
+        dccChStatus_[11 + chOffset] = ((data[1] >> 12) & 0xF);
+        dccChStatus_[10 + chOffset] = ((data[1] >> 8) & 0xF);
+        dccChStatus_[9 + chOffset] = ((data[1] >> 4) & 0xF);
+        dccChStatus_[8 + chOffset] = ((data[1] >> 0) & 0xF);
+        dccChStatus_[7 + chOffset] = ((data[0] >> 28) & 0xF);
+        dccChStatus_[6 + chOffset] = ((data[0] >> 24) & 0xF);
+        dccChStatus_[5 + chOffset] = ((data[0] >> 20) & 0xF);
+        dccChStatus_[4 + chOffset] = ((data[0] >> 16) & 0xF);
+        dccChStatus_[3 + chOffset] = ((data[0] >> 12) & 0xF);
+        dccChStatus_[2 + chOffset] = ((data[0] >> 8) & 0xF);
+        dccChStatus_[1 + chOffset] = ((data[0] >> 4) & 0xF);
+        dccChStatus_[0 + chOffset] = ((data[0] >> 0) & 0xF);
+
+        if (d) {
           out << "FE CH status:";
-          for(int i = chOffset; i < chOffset + 14; ++i){
-            out << " #" << (i+1) << ":" << dccChStatus_[i];
+          for (int i = chOffset; i < chOffset + 14; ++i) {
+            out << " #" << (i + 1) << ":" << dccChStatus_[i];
           }
         }
-      }
-      break;
-    default:
-      if(d) out << " bits<63..62>=0 (DCC header) bits<61..56>=" << dccHeaderId
-                << "(unknown=>ERROR?)";
+      } break;
+      default:
+        if (d)
+          out << " bits<63..62>=0 (DCC header) bits<61..56>=" << dccHeaderId << "(unknown=>ERROR?)";
     }
-  } else if((dataType>>1)==3){//TCC block
+  } else if ((dataType >> 1) == 3) {  //TCC block
     /**********************************************************************
      * TCC block
      *
      **********************************************************************/
-    if(iTccWord64_==0){
+    if (iTccWord64_ == 0) {
       //header
-      tccL1a_ = (data[1] >>0 ) & 0xFFF;
-      tccId_  = ((data[0] >>0 ) & 0xFF);
-      nTts_  =  ((data[1] >>16) & 0x7F);
-      if(iTcc_ < maxTccsPerDcc_) nTpgs_[iTcc_] = nTts_;
+      tccL1a_ = (data[1] >> 0) & 0xFFF;
+      tccId_ = ((data[0] >> 0) & 0xFF);
+      nTts_ = ((data[1] >> 16) & 0x7F);
+      if (iTcc_ < maxTccsPerDcc_)
+        nTpgs_[iTcc_] = nTts_;
       ++iTcc_;
-      if(d) out << "LE1: "         << ((data[1] >>28) & 0x1)
-                << " LE0: "        << ((data[1] >>27) & 0x1)
-                << " N_samples: "  << ((data[1] >>23) & 0x1F)
-                << " N_TTs: "      << nTts_
-                << " E1: "         << ((data[1] >>12) & 0x1)
-                << " L1A: "        << tccL1a_
-                << " '3': "        << ((data[0] >>29) & 0x7)
-                << " E0: "         << ((data[0] >>28) & 0x1)
-                << " Bx: "         << ((data[0] >>16) & 0xFFF)
-                << " TTC ID: "     << tccId_;
-      if(nTts_==68){ //EB TCC (TCC68)
-        if(fedId_ < 628) tccType_ = ebmTcc_;
-        else tccType_ = ebpTcc_;
-      } else if(nTts_ == 16){//Inner EE TCC (TCC48)
+      if (d)
+        out << "LE1: " << ((data[1] >> 28) & 0x1) << " LE0: " << ((data[1] >> 27) & 0x1)
+            << " N_samples: " << ((data[1] >> 23) & 0x1F) << " N_TTs: " << nTts_ << " E1: " << ((data[1] >> 12) & 0x1)
+            << " L1A: " << tccL1a_ << " '3': " << ((data[0] >> 29) & 0x7) << " E0: " << ((data[0] >> 28) & 0x1)
+            << " Bx: " << ((data[0] >> 16) & 0xFFF) << " TTC ID: " << tccId_;
+      if (nTts_ == 68) {  //EB TCC (TCC68)
+        if (fedId_ < 628)
+          tccType_ = ebmTcc_;
+        else
+          tccType_ = ebpTcc_;
+      } else if (nTts_ == 16) {  //Inner EE TCC (TCC48)
         tccType_ = eeOuterTcc_;
-      } else if(nTts_ == 28){//Outer EE TCC (TCC48)
+      } else if (nTts_ == 28) {  //Outer EE TCC (TCC48)
         tccType_ = eeInnerTcc_;
       } else {
         cout << flush;
         cerr << "Error in #TT field of TCC block."
-          "This field is normally used to determine type of TCC "
-          "(TCC48 or TCC68). Type of TCC will be deduced from the TCC ID.\n";
-        if(tccId_ < 19) tccType_ = eeInnerTcc_;
-        else if(tccId_ <  37) tccType_ = eeOuterTcc_;
-        else if(tccId_ <  55) tccType_ = ebmTcc_;
-        else if(tccId_ <  73) tccType_ = ebpTcc_;
-        else if(tccId_ <  91) tccType_ = eeOuterTcc_;
-        else if(tccId_ < 109) tccType_ = eeInnerTcc_;
-        else{
+                "This field is normally used to determine type of TCC "
+                "(TCC48 or TCC68). Type of TCC will be deduced from the TCC ID.\n";
+        if (tccId_ < 19)
+          tccType_ = eeInnerTcc_;
+        else if (tccId_ < 37)
+          tccType_ = eeOuterTcc_;
+        else if (tccId_ < 55)
+          tccType_ = ebmTcc_;
+        else if (tccId_ < 73)
+          tccType_ = ebpTcc_;
+        else if (tccId_ < 91)
+          tccType_ = eeOuterTcc_;
+        else if (tccId_ < 109)
+          tccType_ = eeInnerTcc_;
+        else {
           cerr << "TCC ID is also invalid. EB- TCC type will be assumed.\n";
           tccType_ = ebmTcc_;
         }
         cerr << flush;
       }
-      tccBlockLen64_ = (tccType_==ebmTcc_ || tccType_==ebpTcc_) ? 18 : 9;        
-    } else{// if(iTccWord64_<18){
-      int tpgOffset = (iTccWord64_-1)*4;
-      if(iTcc_ > maxTccsPerDcc_){
+      tccBlockLen64_ = (tccType_ == ebmTcc_ || tccType_ == ebpTcc_) ? 18 : 9;
+    } else {  // if(iTccWord64_<18){
+      int tpgOffset = (iTccWord64_ - 1) * 4;
+      if (iTcc_ > maxTccsPerDcc_) {
         out << "Too many TCC blocks";
-      } else if(tpgOffset > (maxTpgsPerTcc_ - 4)){
+      } else if (tpgOffset > (maxTpgsPerTcc_ - 4)) {
         out << "Too many TPG in one TCC block";
-      } else{
-        tpg_[iTcc_-1][3+tpgOffset] = (data[1] >>16) & 0x1FF;
-        tpg_[iTcc_-1][2+tpgOffset] = (data[1] >>0 ) & 0x1FF;
-        tpg_[iTcc_-1][1+tpgOffset] = (data[0] >>16) & 0x1FF;
-        tpg_[iTcc_-1][0+tpgOffset] = (data[0] >>0 ) & 0x1FF;
+      } else {
+        tpg_[iTcc_ - 1][3 + tpgOffset] = (data[1] >> 16) & 0x1FF;
+        tpg_[iTcc_ - 1][2 + tpgOffset] = (data[1] >> 0) & 0x1FF;
+        tpg_[iTcc_ - 1][1 + tpgOffset] = (data[0] >> 16) & 0x1FF;
+        tpg_[iTcc_ - 1][0 + tpgOffset] = (data[0] >> 0) & 0x1FF;
         //int n[2][4] = {{1,2,3,4},
         //             {4,3,2,1}};
         //int iorder = (628<=fedId_ && fedId_<=645)?1:0;
-        if(d) out << ttfTag(tccType_, 3+tpgOffset) << ":" //"TTF# " << setw(2) << ttId_[3 + tpgOffset] << ":"
-                  << ((data[1] >>25) & 0x7) << " "
-                  << tpgTag(tccType_, 3+tpgOffset) << ":" //" TPG# "<< setw(2) << ttId_[3 + tpgOffset] << ":"
-                  << setw(3) << tpg_[iTcc_-1][3+tpgOffset] << " "
-                  << ttfTag(tccType_, 2+tpgOffset) << ":" //" TTF# "<< setw(2) << ttId_[2 + tpgOffset] << ":"
-                  << ((data[1] >>9 ) & 0x7) << " "
-                  << tpgTag(tccType_, 2+tpgOffset) << ":" //" TPG# "<< setw(2) << ttId_[2 + tpgOffset] << ":"
-                  << setw(3) << tpg_[iTcc_-1][2+tpgOffset] << " "
-                  << " '3': "                     << ((data[0] >>29) & 0x7) << " "
-                  << ttfTag(tccType_, 1+tpgOffset) << ":" //" TTF# "<< setw(2) << ttId_[1 + tpgOffset] << ":"
-                  << ((data[0] >>25) & 0x7) << " "
-                  << setw(3) << tpgTag(tccType_, 1+tpgOffset) << ": "//" TPG# "<< setw(2) << ttId_[1 + tpgOffset] << ":"
-                  << tpg_[iTcc_-1][1+tpgOffset] << " "
-                  << ttfTag(tccType_, 0+tpgOffset) << ":" //" TTF# "<< setw(2) << ttId_[0 + tpgOffset] << ":"
-                  << ((data[0] >>9 ) & 0x7) << " "
-                  << setw(3) << tpgTag(tccType_, 0+tpgOffset) << ":" //" TPG# "<< setw(2) << ttId_[0 + tpgOffset] << ":"
-                  << tpg_[iTcc_-1][0+tpgOffset];
+        if (d)
+          out << ttfTag(tccType_, 3 + tpgOffset) << ":"  //"TTF# " << setw(2) << ttId_[3 + tpgOffset] << ":"
+              << ((data[1] >> 25) & 0x7) << " " << tpgTag(tccType_, 3 + tpgOffset)
+              << ":"  //" TPG# "<< setw(2) << ttId_[3 + tpgOffset] << ":"
+              << setw(3) << tpg_[iTcc_ - 1][3 + tpgOffset] << " " << ttfTag(tccType_, 2 + tpgOffset)
+              << ":"  //" TTF# "<< setw(2) << ttId_[2 + tpgOffset] << ":"
+              << ((data[1] >> 9) & 0x7) << " " << tpgTag(tccType_, 2 + tpgOffset)
+              << ":"  //" TPG# "<< setw(2) << ttId_[2 + tpgOffset] << ":"
+              << setw(3) << tpg_[iTcc_ - 1][2 + tpgOffset] << " "
+              << " '3': " << ((data[0] >> 29) & 0x7) << " " << ttfTag(tccType_, 1 + tpgOffset)
+              << ":"  //" TTF# "<< setw(2) << ttId_[1 + tpgOffset] << ":"
+              << ((data[0] >> 25) & 0x7) << " " << setw(3) << tpgTag(tccType_, 1 + tpgOffset)
+              << ": "  //" TPG# "<< setw(2) << ttId_[1 + tpgOffset] << ":"
+              << tpg_[iTcc_ - 1][1 + tpgOffset] << " " << ttfTag(tccType_, 0 + tpgOffset)
+              << ":"  //" TTF# "<< setw(2) << ttId_[0 + tpgOffset] << ":"
+              << ((data[0] >> 9) & 0x7) << " " << setw(3) << tpgTag(tccType_, 0 + tpgOffset)
+              << ":"  //" TPG# "<< setw(2) << ttId_[0 + tpgOffset] << ":"
+              << tpg_[iTcc_ - 1][0 + tpgOffset];
       }
-    }// else{
-     // if(d) out << "ERROR";
+    }  // else{
+       // if(d) out << "ERROR";
     //}
     ++iTccWord64_;
-    if(iTccWord64_ >= (unsigned)tccBlockLen64_) iTccWord64_ = 0;
-  } else if((dataType>>1)==4){//SRP block
+    if (iTccWord64_ >= (unsigned)tccBlockLen64_)
+      iTccWord64_ = 0;
+  } else if ((dataType >> 1) == 4) {  //SRP block
     /**********************************************************************
      * SRP block
      *
      **********************************************************************/
-    if(iSrWord64_==0){//header
-      srpL1a_ = (data[1] >>0 ) & 0xFFF;
-      srpBx_ = (data[0] >>16) & 0xFFF;
-      if(d) out << "LE1: "     << ((data[1] >>28) & 0x1)
-                << " LE0: "    << ((data[1] >>27) & 0x1)
-                << " N_SRFs: " << ((data[1] >>16) & 0x7F)
-                << " E1: "     << ((data[1] >>12) & 0x1)
-                << " L1A: "    << srpL1a_
-                << " '4': "    << ((data[0] >>29) & 0x7)
-                << " E0: "     << ((data[0] >>28) & 0x1)
-                << " Bx: "     << srpBx_
-                << " SRP ID: " << ((data[0] >>0 ) & 0xFF);
-    } else if(iSrWord64_<6){
-      int ttfOffset = (iSrWord64_-1)*16;
-      if(d){
-        if(iSrWord64_<5){
-          out <<"SRF# " << setw(6) << right << srRange(12+ttfOffset)/*16+ttfOffset << "..#" << 13+ttfOffset*/  << ": "
-              << oct << ((data[1] >>16) & 0xFFF) << dec
-              << " SRF# " << srRange(8+ttfOffset) /*12+ttfOffset << "..#" << 9+ttfOffset*/ << ": "
-              << oct << ((data[1] >>0 ) & 0xFFF) << dec
-              << " '4':" << ((data[0] >>29) & 0x7)
-              << " SRF# " << srRange(4+ttfOffset) /*8+ttfOffset << "..#" << 5+ttfOffset*/ << ": "
-              << oct << ((data[0] >>16) & 0xFFF) << dec;
-        } else{//last 64-bit word has only 4 SRFs.
+    if (iSrWord64_ == 0) {  //header
+      srpL1a_ = (data[1] >> 0) & 0xFFF;
+      srpBx_ = (data[0] >> 16) & 0xFFF;
+      if (d)
+        out << "LE1: " << ((data[1] >> 28) & 0x1) << " LE0: " << ((data[1] >> 27) & 0x1)
+            << " N_SRFs: " << ((data[1] >> 16) & 0x7F) << " E1: " << ((data[1] >> 12) & 0x1) << " L1A: " << srpL1a_
+            << " '4': " << ((data[0] >> 29) & 0x7) << " E0: " << ((data[0] >> 28) & 0x1) << " Bx: " << srpBx_
+            << " SRP ID: " << ((data[0] >> 0) & 0xFF);
+    } else if (iSrWord64_ < 6) {
+      int ttfOffset = (iSrWord64_ - 1) * 16;
+      if (d) {
+        if (iSrWord64_ < 5) {
+          out << "SRF# " << setw(6) << right
+              << srRange(12 + ttfOffset) /*16+ttfOffset << "..#" << 13+ttfOffset*/ << ": " << oct
+              << ((data[1] >> 16) & 0xFFF) << dec << " SRF# "
+              << srRange(8 + ttfOffset) /*12+ttfOffset << "..#" << 9+ttfOffset*/ << ": " << oct
+              << ((data[1] >> 0) & 0xFFF) << dec << " '4':" << ((data[0] >> 29) & 0x7) << " SRF# "
+              << srRange(4 + ttfOffset) /*8+ttfOffset << "..#" << 5+ttfOffset*/ << ": " << oct
+              << ((data[0] >> 16) & 0xFFF) << dec;
+        } else {  //last 64-bit word has only 4 SRFs.
           out << "                                                           ";
         }
-        out << " SRF# " << srRange(ttfOffset) /*4+ttfOffset << "..#" << 1+ttfOffset*/ << ": "
-            << oct << ((data[0] >>0 ) & 0xFFF) << dec;
+        out << " SRF# " << srRange(ttfOffset) /*4+ttfOffset << "..#" << 1+ttfOffset*/ << ": " << oct
+            << ((data[0] >> 0) & 0xFFF) << dec;
       }
-    } else{
-      if(d) out << "ERROR";
+    } else {
+      if (d)
+        out << "ERROR";
     }
     ++iSrWord64_;
-  } else if((dataType>>2)==3){//Tower block
+  } else if ((dataType >> 2) == 3) {  //Tower block
     /**********************************************************************
      * "Tower" block (crystal channel data from a RU (=1 FE cards))
      *
      **********************************************************************/
-    if(iTowerWord64_==0){//header
-      towerBlockLength_ = (data[1]>>16) & 0x1FF;
+    if (iTowerWord64_ == 0) {  //header
+      towerBlockLength_ = (data[1] >> 16) & 0x1FF;
       int l1a;
       int bx;
-      l1a = (data[1] >>0 ) & 0xFFF;
-      bx = (data[0] >>16) & 0xFFF;
-      dccCh_=(data[0] >>0 ) & 0xFF;
-      if(d) out << "Block Len: "  << towerBlockLength_
-                << " E1: "        << ((data[1] >>12) & 0x1)
-                << " L1A: "       << l1a
-                << " '3': "       << ((data[0] >>30) & 0x3)
-                << " E0: "        << ((data[0] >>28) & 0x1)
-                << " Bx: "        << bx
-                << " N_samples: " << ((data[0] >>8 ) & 0x7F)
-                << " RU ID: "     << dccCh_;
-      if(iRu_ < nRu_){
+      l1a = (data[1] >> 0) & 0xFFF;
+      bx = (data[0] >> 16) & 0xFFF;
+      dccCh_ = (data[0] >> 0) & 0xFF;
+      if (d)
+        out << "Block Len: " << towerBlockLength_ << " E1: " << ((data[1] >> 12) & 0x1) << " L1A: " << l1a
+            << " '3': " << ((data[0] >> 30) & 0x3) << " E0: " << ((data[0] >> 28) & 0x1) << " Bx: " << bx
+            << " N_samples: " << ((data[0] >> 8) & 0x7F) << " RU ID: " << dccCh_;
+      if (iRu_ < nRu_) {
         feL1a_[iRu_] = l1a;
         feBx_[iRu_] = bx;
         feRuId_[iRu_] = dccCh_;
         ++iRu_;
       }
-    } else if((unsigned)iTowerWord64_<towerBlockLength_){
-      if(!dumpAdc_){
+    } else if ((unsigned)iTowerWord64_ < towerBlockLength_) {
+      if (!dumpAdc_) {
         //no output.
         rc = false;
       }
       const bool da = dumpAdc_ && dump_;
-      switch((iTowerWord64_-1)%3){
+      switch ((iTowerWord64_ - 1) % 3) {
         int s[4];
         int g[4];
-      case 0:
-        s[0]=(data[0] >>16) & 0xFFF;
-        g[0]=(data[0] >>28) & 0x3;
-        s[1]=(data[1] >>0 ) & 0xFFF;
-        g[1]=(data[1] >>12) & 0x3;
-        s[2]=(data[1] >>16) & 0xFFF;
-        g[2]=(data[1] >>28) & 0x3;
-        fill(adc_.begin(), adc_.end(), 0.);
-        if(da) out << "GMF: "    << ((data[0] >>11) & 0x1)
-                   << " SMF: "   << ((data[0] >>9 ) & 0x1)
-                   << " M: "   << ((data[0] >>8 ) & 0x1)
-                   << " XTAL: "  << ((data[0] >>4 ) & 0x7)
-                   << " STRIP: " << ((data[0] >>0 ) & 0x7)
-                   << " " << setw(4) << s[0]
-                   << "G" << g[0]
-                   << " " << setw(4) << s[1]
-                   << "G" << g[1]
-                   << " " << setw(4) << s[2]
-                   << "G" << g[2];
-        for(int i=0; i<3; ++i) adc_[i] = s[i]*mgpaGainFactors[g[i]];
-        break;
-      case 1:
-        s[0]=(data[0] >>0 ) & 0xFFF;
-        g[0]=(data[0] >>12) & 0x3;
-        s[1]=(data[0] >>16) & 0xFFF;
-        g[1]=(data[0] >>28) & 0x3;
-        s[2]=(data[1] >>0 ) & 0xFFF;
-        g[2]=(data[1] >>12) & 0x3;
-        s[3]=(data[1] >>16) & 0xFFF;
-        g[3]=(data[1] >>28) & 0x3;
-        if(da) out << "                                   "
-                   << " " << setw(4) << s[0]
-                   << "G" << g[0]
-                   << " " << setw(4) << s[1]
-                   << "G" << g[1]
-                   << " " << setw(4) << s[2]
-                   << "G" << g[2]
-                   << " " << setw(4) << s[3]
-                   << "G" << g[3];
-        for(int i=0; i<4; ++i) adc_[i+3] = s[i]*mgpaGainFactors[g[i]];
-        break;
-      case 2:
-        if(da) out << "TZS: " << ((data[1] >>14) & 0x1);
+        case 0:
+          s[0] = (data[0] >> 16) & 0xFFF;
+          g[0] = (data[0] >> 28) & 0x3;
+          s[1] = (data[1] >> 0) & 0xFFF;
+          g[1] = (data[1] >> 12) & 0x3;
+          s[2] = (data[1] >> 16) & 0xFFF;
+          g[2] = (data[1] >> 28) & 0x3;
+          fill(adc_.begin(), adc_.end(), 0.);
+          if (da)
+            out << "GMF: " << ((data[0] >> 11) & 0x1) << " SMF: " << ((data[0] >> 9) & 0x1)
+                << " M: " << ((data[0] >> 8) & 0x1) << " XTAL: " << ((data[0] >> 4) & 0x7)
+                << " STRIP: " << ((data[0] >> 0) & 0x7) << " " << setw(4) << s[0] << "G" << g[0] << " " << setw(4)
+                << s[1] << "G" << g[1] << " " << setw(4) << s[2] << "G" << g[2];
+          for (int i = 0; i < 3; ++i)
+            adc_[i] = s[i] * mgpaGainFactors[g[i]];
+          break;
+        case 1:
+          s[0] = (data[0] >> 0) & 0xFFF;
+          g[0] = (data[0] >> 12) & 0x3;
+          s[1] = (data[0] >> 16) & 0xFFF;
+          g[1] = (data[0] >> 28) & 0x3;
+          s[2] = (data[1] >> 0) & 0xFFF;
+          g[2] = (data[1] >> 12) & 0x3;
+          s[3] = (data[1] >> 16) & 0xFFF;
+          g[3] = (data[1] >> 28) & 0x3;
+          if (da)
+            out << "                                   "
+                << " " << setw(4) << s[0] << "G" << g[0] << " " << setw(4) << s[1] << "G" << g[1] << " " << setw(4)
+                << s[2] << "G" << g[2] << " " << setw(4) << s[3] << "G" << g[3];
+          for (int i = 0; i < 4; ++i)
+            adc_[i + 3] = s[i] * mgpaGainFactors[g[i]];
+          break;
+        case 2:
+          if (da)
+            out << "TZS: " << ((data[1] >> 14) & 0x1);
 
-        s[0]=(data[0] >>0 ) & 0xFFF;
-        g[0]=(data[0] >>12) & 0x3;
-        s[1]=(data[0] >>16) & 0xFFF;
-        g[1]=(data[0] >>28) & 0x3;
-        s[2]=(data[1] >>0 ) & 0xFFF;
-        g[2]=(data[1] >>12) & 0x3  ;
+          s[0] = (data[0] >> 0) & 0xFFF;
+          g[0] = (data[0] >> 12) & 0x3;
+          s[1] = (data[0] >> 16) & 0xFFF;
+          g[1] = (data[0] >> 28) & 0x3;
+          s[2] = (data[1] >> 0) & 0xFFF;
+          g[2] = (data[1] >> 12) & 0x3;
 
-        for(int i=0; i<3; ++i) adc_[i+7] = s[i]*mgpaGainFactors[g[i]];
-        if(dccCh_<=68){
-          unsigned bom0; //Bin of Maximum, starting counting from 0
-          double ampl = max(adc_, bom0)-min(adc_);
-          if(da) out << " Ampl: " << setw(4) << ampl
-                      << (ampl>amplCut_?"*":" ")
-                     << " BoM:" << setw(2) << (bom0+1)
-                     << "          ";
-            if(fedId_ == dccId_ + 600 //block of the read-out SM
-               //if laser, only one side:
-               && (detailedTrigType_!=4 || sideOfRu(dccCh_)==(int)side_)
-               ){
+          for (int i = 0; i < 3; ++i)
+            adc_[i + 7] = s[i] * mgpaGainFactors[g[i]];
+          if (dccCh_ <= 68) {
+            unsigned bom0;  //Bin of Maximum, starting counting from 0
+            double ampl = max(adc_, bom0) - min(adc_);
+            if (da)
+              out << " Ampl: " << setw(4) << ampl << (ampl > amplCut_ ? "*" : " ") << " BoM:" << setw(2) << (bom0 + 1)
+                  << "          ";
+            if (fedId_ == dccId_ + 600  //block of the read-out SM
+                //if laser, only one side:
+                && (detailedTrigType_ != 4 || sideOfRu(dccCh_) == (int)side_)) {
             }
-        } else{
-          if(da) out << setw(29) << "";
-        }
-        if(da) out << " " << setw(4) << s[0]
-                   << "G" << g[0]
-                   << " " << setw(4) << s[1]
-                   << "G" << g[1]
-                   << " " << setw(4) << s[2]
-                  << "G" << g[2];
-        break;
+          } else {
+            if (da)
+              out << setw(29) << "";
+          }
+          if (da)
+            out << " " << setw(4) << s[0] << "G" << g[0] << " " << setw(4) << s[1] << "G" << g[1] << " " << setw(4)
+                << s[2] << "G" << g[2];
+          break;
         default:
           assert(false);
       }
     } else {
-      if(d) out << "ERROR";
+      if (d)
+        out << "ERROR";
     }
     ++iTowerWord64_;
-    if(iTowerWord64_>=towerBlockLength_){
-      iTowerWord64_-=towerBlockLength_;
+    if (iTowerWord64_ >= towerBlockLength_) {
+      iTowerWord64_ -= towerBlockLength_;
       ++dccCh_;
     }
-  } else if(dataType==eoe){//End of event trailer
+  } else if (dataType == eoe) {  //End of event trailer
     /**********************************************************************
      * Event DAQ trailer
      *
      **********************************************************************/
-    int tts = (data[0] >>4)  & 0xF;
-    if(d) out << "Evt Len.: "    << ((data[1] >>0 ) & 0xFFFFFF)
-              << " CRC16: "       << ((data[0] >>16) & 0xFFFF)
-              << " Evt Status: "  << ((data[0] >>8 ) & 0xF)
-              << " TTS: "         << tts
-              << " (" << ttsNames[tts] << ")"
-              << " T:"            << ((data[0] >>3)  & 0x1);
-  } else{
-    if(d) out << " incorrect 64-bit word type marker (see MSBs)";
+    int tts = (data[0] >> 4) & 0xF;
+    if (d)
+      out << "Evt Len.: " << ((data[1] >> 0) & 0xFFFFFF) << " CRC16: " << ((data[0] >> 16) & 0xFFFF)
+          << " Evt Status: " << ((data[0] >> 8) & 0xF) << " TTS: " << tts << " (" << ttsNames[tts] << ")"
+          << " T:" << ((data[0] >> 3) & 0x1);
+  } else {
+    if (d)
+      out << " incorrect 64-bit word type marker (see MSBs)";
   }
   return rc;
 }
 
-// The following method was not removed due to package maintainer 
+// The following method was not removed due to package maintainer
 // (Philippe Gras <philippe.gras@cern.ch>) request.
 
 //int EcalDumpRaw::lme(int dcc1, int side){
@@ -878,48 +795,44 @@ bool EcalDumpRaw::decode(const uint32_t* data, int iWord64, ostream& out){
 //   return lmes.size()==0?-1:lmes[std::min(lmes.size(), (size_t)side)];
 //}
 
-
-int EcalDumpRaw::sideOfRu(int ru1){
-  if(ru1 < 5 || (ru1-5)%4 >= 2){
+int EcalDumpRaw::sideOfRu(int ru1) {
+  if (ru1 < 5 || (ru1 - 5) % 4 >= 2) {
     return 0;
-  } else{
+  } else {
     return 1;
   }
 }
 
-
-int EcalDumpRaw::modOfRu(int ru1){
-  int iEta0 = (ru1-1)/4;
-  if(iEta0<5){
+int EcalDumpRaw::modOfRu(int ru1) {
+  int iEta0 = (ru1 - 1) / 4;
+  if (iEta0 < 5) {
     return 1;
-  } else{
-    return 2 + (iEta0-5)/4;
+  } else {
+    return 2 + (iEta0 - 5) / 4;
   }
 }
 
-int EcalDumpRaw::lmodOfRu(int ru1){
-  int iEta0 = (ru1-1)/4;
-  int iPhi0 = (ru1-1)%4;
+int EcalDumpRaw::lmodOfRu(int ru1) {
+  int iEta0 = (ru1 - 1) / 4;
+  int iPhi0 = (ru1 - 1) % 4;
   int rs;
-  if(iEta0==0){
-    rs =  1;
-  } else{
-    rs = 2 + ((iEta0-1)/4)*2 + (iPhi0%4)/2;
+  if (iEta0 == 0) {
+    rs = 1;
+  } else {
+    rs = 2 + ((iEta0 - 1) / 4) * 2 + (iPhi0 % 4) / 2;
   }
   //  cout << "ru1 = " << ru1 << " -> lmod = " << rs << "\n";
   return rs;
 }
 
-std::string EcalDumpRaw::srRange(int offset) const{
-  int min = offset+1;
-  int max = offset+4;
+std::string EcalDumpRaw::srRange(int offset) const {
+  int min = offset + 1;
+  int max = offset + 4;
   stringstream buf;
-  if(628 <= fedId_ && fedId_ <= 646){//EB+
-    buf << right << min << ".."
-        << left  << max;
-  } else{
-    buf << right << max << ".."
-        << left  << min;
+  if (628 <= fedId_ && fedId_ <= 646) {  //EB+
+    buf << right << min << ".." << left << max;
+  } else {
+    buf << right << max << ".." << left << min;
   }
   string s = buf.str();
   buf.str("");
@@ -927,35 +840,33 @@ std::string EcalDumpRaw::srRange(int offset) const{
   return buf.str();
 }
 
-std::string EcalDumpRaw::ttfTag(int tccType, unsigned iSeq) const{
-  if((unsigned)iSeq > sizeof(ttId_))
-    throw cms::Exception("OutOfRange")
-      << __FILE__ << ":"  << __LINE__ << ": "
-      << "parameter out of range\n";
-                             
+std::string EcalDumpRaw::ttfTag(int tccType, unsigned iSeq) const {
+  if ((unsigned)iSeq > sizeof(ttId_))
+    throw cms::Exception("OutOfRange") << __FILE__ << ":" << __LINE__ << ": "
+                                       << "parameter out of range\n";
+
   const int ttId = ttId_[tccType][iSeq];
   stringstream buf;
   buf.str("");
-  if(ttId==0){
+  if (ttId == 0) {
     buf << "    '0'";
-  } else{
+  } else {
     buf << "TTF# " << setw(2) << ttId;
   }
   return buf.str();
 }
 
-std::string EcalDumpRaw::tpgTag(int tccType, unsigned iSeq) const{
-  if((unsigned)iSeq > sizeof(ttId_))
-    throw cms::Exception("OutOfRange")
-      << __FILE__ << ":"  << __LINE__ << ": "
-      << "parameter out of range\n";
-                             
+std::string EcalDumpRaw::tpgTag(int tccType, unsigned iSeq) const {
+  if ((unsigned)iSeq > sizeof(ttId_))
+    throw cms::Exception("OutOfRange") << __FILE__ << ":" << __LINE__ << ": "
+                                       << "parameter out of range\n";
+
   const int ttId = ttId_[tccType][iSeq];
   stringstream buf;
   buf.str("");
-  if(ttId==0){
+  if (ttId == 0) {
     buf << "    '0'";
-  } else{
+  } else {
     buf << "TPG# " << setw(2) << ttId;
   }
   return buf.str();

--- a/EventFilter/EcalRawToDigi/plugins/EcalRawToDigi.cc
+++ b/EventFilter/EcalRawToDigi/plugins/EcalRawToDigi.cc
@@ -15,117 +15,107 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
-EcalRawToDigi::EcalRawToDigi(edm::ParameterSet const& conf):
-  
-  //define the list of FED to be unpacked
-  fedUnpackList_(conf.getParameter<std::vector<int> >("FEDs")),
+EcalRawToDigi::EcalRawToDigi(edm::ParameterSet const& conf)
+    :
 
-  //define the ordered FED list
-  orderedFedUnpackList_(conf.getParameter<std::vector<int> >("orderedFedList")),
+      //define the list of FED to be unpacked
+      fedUnpackList_(conf.getParameter<std::vector<int> >("FEDs")),
 
-  //define the ordered DCCId list
-  orderedDCCIdList_(conf.getParameter<std::vector<int> >("orderedDCCIdList")),
+      //define the ordered FED list
+      orderedFedUnpackList_(conf.getParameter<std::vector<int> >("orderedFedList")),
 
-  //get number of Xtal Time Samples
-  numbXtalTSamples_(conf.getParameter<int>("numbXtalTSamples")),
+      //define the ordered DCCId list
+      orderedDCCIdList_(conf.getParameter<std::vector<int> >("orderedDCCIdList")),
 
-  //Get number of Trigger Time Samples
-  numbTriggerTSamples_(conf.getParameter<int>("numbTriggerTSamples")),
-  
-  //See if header unpacking is enabled
-  headerUnpacking_(conf.getParameter<bool>("headerUnpacking")),
- 
-  //See if srp unpacking is enabled
-  srpUnpacking_(conf.getParameter<bool>("srpUnpacking")),
-  
-  //See if tcc unpacking is enabled
-  tccUnpacking_(conf.getParameter<bool>("tccUnpacking")),
-  
-  //See if fe unpacking is enabled
-  feUnpacking_(conf.getParameter<bool>("feUnpacking")),
-  
-  //See if fe unpacking is enabled for mem box
-  memUnpacking_(conf.getParameter<bool>("memUnpacking")), 
+      //get number of Xtal Time Samples
+      numbXtalTSamples_(conf.getParameter<int>("numbXtalTSamples")),
 
-  //See if syncCheck is enabled
-  syncCheck_(conf.getParameter<bool>("syncCheck")), 
+      //Get number of Trigger Time Samples
+      numbTriggerTSamples_(conf.getParameter<int>("numbTriggerTSamples")),
 
-  //See if feIdCheck is enabled
-  feIdCheck_(conf.getParameter<bool>("feIdCheck")),
+      //See if header unpacking is enabled
+      headerUnpacking_(conf.getParameter<bool>("headerUnpacking")),
 
-  // See if we want to keep data even if we have a mismatch between SR decision and block length
-  forceToKeepFRdata_(conf.getParameter<bool>("forceToKeepFRData")),
+      //See if srp unpacking is enabled
+      srpUnpacking_(conf.getParameter<bool>("srpUnpacking")),
 
-  
-  put_(conf.getParameter<bool>("eventPut")),
-  
+      //See if tcc unpacking is enabled
+      tccUnpacking_(conf.getParameter<bool>("tccUnpacking")),
 
+      //See if fe unpacking is enabled
+      feUnpacking_(conf.getParameter<bool>("feUnpacking")),
 
-  REGIONAL_(conf.getParameter<bool>("DoRegional")),
+      //See if fe unpacking is enabled for mem box
+      memUnpacking_(conf.getParameter<bool>("memUnpacking")),
 
+      //See if syncCheck is enabled
+      syncCheck_(conf.getParameter<bool>("syncCheck")),
 
+      //See if feIdCheck is enabled
+      feIdCheck_(conf.getParameter<bool>("feIdCheck")),
 
-  myMap_(nullptr),
-  
-  theUnpacker_(nullptr)
+      // See if we want to keep data even if we have a mismatch between SR decision and block length
+      forceToKeepFRdata_(conf.getParameter<bool>("forceToKeepFRData")),
+
+      put_(conf.getParameter<bool>("eventPut")),
+
+      REGIONAL_(conf.getParameter<bool>("DoRegional")),
+
+      myMap_(nullptr),
+
+      theUnpacker_(nullptr)
 
 {
-  
   first_ = true;
-  DCCDataUnpacker::silentMode_ = conf.getUntrackedParameter<bool>("silentMode",false) ;
-  
-  if( numbXtalTSamples_ <6 || numbXtalTSamples_>64 || (numbXtalTSamples_-2)%4 ){
+  DCCDataUnpacker::silentMode_ = conf.getUntrackedParameter<bool>("silentMode", false);
+
+  if (numbXtalTSamples_ < 6 || numbXtalTSamples_ > 64 || (numbXtalTSamples_ - 2) % 4) {
     std::ostringstream output;
-    output      <<"\n Unsuported number of xtal time samples : "<<numbXtalTSamples_
-                <<"\n Valid Number of xtal time samples are : 6,10,14,18,...,62"; 
-    edm::LogError("IncorrectConfiguration")<< output.str();
+    output << "\n Unsuported number of xtal time samples : " << numbXtalTSamples_
+           << "\n Valid Number of xtal time samples are : 6,10,14,18,...,62";
+    edm::LogError("IncorrectConfiguration") << output.str();
     // todo : throw an execption
   }
-  
-  if( numbTriggerTSamples_ !=1 && numbTriggerTSamples_ !=4 && numbTriggerTSamples_ !=8  ){
+
+  if (numbTriggerTSamples_ != 1 && numbTriggerTSamples_ != 4 && numbTriggerTSamples_ != 8) {
     std::ostringstream output;
-    output      <<"\n Unsuported number of trigger time samples : "<<numbTriggerTSamples_
-                <<"\n Valid number of trigger time samples are :  1, 4 or 8"; 
-    edm::LogError("IncorrectConfiguration")<< output.str();
+    output << "\n Unsuported number of trigger time samples : " << numbTriggerTSamples_
+           << "\n Valid number of trigger time samples are :  1, 4 or 8";
+    edm::LogError("IncorrectConfiguration") << output.str();
     // todo : throw an execption
   }
-  
+
   //NA : testing
   //nevts_=0;
   //RUNNING_TIME_=0;
 
   // if there are FEDs specified to unpack fill the vector of the fedUnpackList_
   // else fill with the entire ECAL fed range (600-670)
-  if (fedUnpackList_.empty()) 
-    for (int i=FEDNumbering::MINECALFEDID; i<=FEDNumbering::MAXECALFEDID; i++)
+  if (fedUnpackList_.empty())
+    for (int i = FEDNumbering::MINECALFEDID; i <= FEDNumbering::MAXECALFEDID; i++)
       fedUnpackList_.push_back(i);
 
   //print the FEDs to unpack to the logger
   std::ostringstream loggerOutput_;
-  if(!fedUnpackList_.empty()){
-    for (unsigned int i=0; i<fedUnpackList_.size(); i++) 
+  if (!fedUnpackList_.empty()) {
+    for (unsigned int i = 0; i < fedUnpackList_.size(); i++)
       loggerOutput_ << fedUnpackList_[i] << " ";
     edm::LogInfo("EcalRawToDigi") << "EcalRawToDigi will unpack FEDs ( " << loggerOutput_.str() << ")";
     LogDebug("EcalRawToDigi") << "EcalRawToDigi will unpack FEDs ( " << loggerOutput_.str() << ")";
   }
-  
-  edm::LogInfo("EcalRawToDigi")
-    <<"\n ECAL RawToDigi configuration:"
-    <<"\n Header  unpacking is "<<headerUnpacking_
-    <<"\n SRP Bl. unpacking is "<<srpUnpacking_
-    <<"\n TCC Bl. unpacking is "<<tccUnpacking_  
-    <<"\n FE  Bl. unpacking is "<<feUnpacking_
-    <<"\n MEM Bl. unpacking is "<<memUnpacking_
-    <<"\n sync check is "<<syncCheck_
-    <<"\n feID check is "<<feIdCheck_
-    <<"\n force keep FR data is "<<forceToKeepFRdata_
-    <<"\n";
+
+  edm::LogInfo("EcalRawToDigi") << "\n ECAL RawToDigi configuration:"
+                                << "\n Header  unpacking is " << headerUnpacking_ << "\n SRP Bl. unpacking is "
+                                << srpUnpacking_ << "\n TCC Bl. unpacking is " << tccUnpacking_
+                                << "\n FE  Bl. unpacking is " << feUnpacking_ << "\n MEM Bl. unpacking is "
+                                << memUnpacking_ << "\n sync check is " << syncCheck_ << "\n feID check is "
+                                << feIdCheck_ << "\n force keep FR data is " << forceToKeepFRdata_ << "\n";
 
   edm::InputTag dataLabel = conf.getParameter<edm::InputTag>("InputLabel");
   edm::InputTag fedsLabel = conf.getParameter<edm::InputTag>("FedLabel");
 
   // Producer products :
-  produces<EBDigiCollection>("ebDigis"); 
+  produces<EBDigiCollection>("ebDigis");
   produces<EEDigiCollection>("eeDigis");
   produces<EBSrFlagCollection>();
   produces<EESrFlagCollection>();
@@ -133,7 +123,7 @@ EcalRawToDigi::EcalRawToDigi(edm::ParameterSet const& conf):
   produces<EcalPnDiodeDigiCollection>();
   produces<EcalTrigPrimDigiCollection>("EcalTriggerPrimitives");
   produces<EcalPSInputDigiCollection>("EcalPseudoStripInputs");
-  
+
   // Integrity for xtal data
   produces<EBDetIdCollection>("EcalIntegrityGainErrors");
   produces<EBDetIdCollection>("EcalIntegrityGainSwitchErrors");
@@ -148,48 +138,51 @@ EcalRawToDigi::EcalRawToDigi(edm::ParameterSet const& conf):
   produces<EcalElectronicsIdCollection>("EcalIntegrityTTIdErrors");
   produces<EcalElectronicsIdCollection>("EcalIntegrityZSXtalIdErrors");
   produces<EcalElectronicsIdCollection>("EcalIntegrityBlockSizeErrors");
- 
+
   // Mem channels' integrity
   produces<EcalElectronicsIdCollection>("EcalIntegrityMemTtIdErrors");
   produces<EcalElectronicsIdCollection>("EcalIntegrityMemBlockSizeErrors");
   produces<EcalElectronicsIdCollection>("EcalIntegrityMemChIdErrors");
   produces<EcalElectronicsIdCollection>("EcalIntegrityMemGainErrors");
 
-  dataToken_=consumes<FEDRawDataCollection>(dataLabel);
-  if (REGIONAL_){
-      fedsToken_=consumes<EcalListOfFEDS>(fedsLabel);
+  dataToken_ = consumes<FEDRawDataCollection>(dataLabel);
+  if (REGIONAL_) {
+    fedsToken_ = consumes<EcalListOfFEDS>(fedsLabel);
   }
 
   // Build a new Electronics mapper and parse default map file
-  myMap_ = new EcalElectronicsMapper(numbXtalTSamples_,numbTriggerTSamples_);
+  myMap_ = new EcalElectronicsMapper(numbXtalTSamples_, numbTriggerTSamples_);
 
-  // in case of external  tsext file (deprecated by HLT environment) 
+  // in case of external  tsext file (deprecated by HLT environment)
   //  bool readResult = myMap_->readDCCMapFile(conf.getParameter<std::string>("DCCMapFile",""));
 
-  // use two arrays from cfg to establish DCCId:FedId. If they are empy, than use hard coded correspondence 
+  // use two arrays from cfg to establish DCCId:FedId. If they are empy, than use hard coded correspondence
   bool readResult = myMap_->makeMapFromVectors(orderedFedUnpackList_, orderedDCCIdList_);
   // myMap::makeMapFromVectors() returns "true" always
   // need to be fixed?
 
-  if(!readResult){
-    edm::LogWarning("IncorrectConfiguration")
-      << "Arrays orderedFedList and orderedDCCIdList are emply. "
-         "Hard coded correspondence for DCCId:FedId will be used.";
+  if (!readResult) {
+    edm::LogWarning("IncorrectConfiguration") << "Arrays orderedFedList and orderedDCCIdList are emply. "
+                                                 "Hard coded correspondence for DCCId:FedId will be used.";
     // edm::LogError("EcalRawToDigi")<<"\n unable to read file : "
     //   <<conf.getParameter<std::string>("DCCMapFile");
   }
-  
-  // Build a new ECAL DCC data unpacker
-  theUnpacker_ = new DCCDataUnpacker(myMap_,headerUnpacking_,srpUnpacking_,tccUnpacking_,feUnpacking_,memUnpacking_,syncCheck_,feIdCheck_,forceToKeepFRdata_);
-   
-}
 
+  // Build a new ECAL DCC data unpacker
+  theUnpacker_ = new DCCDataUnpacker(myMap_,
+                                     headerUnpacking_,
+                                     srpUnpacking_,
+                                     tccUnpacking_,
+                                     feUnpacking_,
+                                     memUnpacking_,
+                                     syncCheck_,
+                                     feIdCheck_,
+                                     forceToKeepFRdata_);
+}
 
 // print list of crystals with non-zero statuses
 // this functions is only for debug purposes
-void printStatusRecords(const DCCDataUnpacker* unpacker,
-                        const EcalElectronicsMapping* mapping)
-{
+void printStatusRecords(const DCCDataUnpacker* unpacker, const EcalElectronicsMapping* mapping) {
   // Endcap
   std::cout << "===> ENDCAP" << std::endl;
   for (int i = 0; i < EEDetId::kSizeForDenseIndexing; ++i) {
@@ -197,43 +190,39 @@ void printStatusRecords(const DCCDataUnpacker* unpacker,
     if (!id.null()) {
       // channel status
       const uint16_t code = unpacker->getChannelValue(id);
-      
+
       if (code) {
         const EcalElectronicsId ei = mapping->getElectronicsId(id);
-        
+
         // convert DCC ID (1 - 54) to FED ID (601 - 654)
         const int fed_id = unpacker->electronicsMapper()->getDCCId(ei.dccId());
-        
-        std::cout
-          << " id " << id.rawId()
-          << " -> (" << id.ix() << ", " << id.iy() << ", " << id.zside() << ") "
-          << "(" << ei.dccId() << " : " << fed_id << ", " << ei.towerId() << ", " << ei.stripId() << ", " << ei.xtalId() << ") "
-          << "status = " << code
-          << std::endl;
+
+        std::cout << " id " << id.rawId() << " -> (" << id.ix() << ", " << id.iy() << ", " << id.zside() << ") "
+                  << "(" << ei.dccId() << " : " << fed_id << ", " << ei.towerId() << ", " << ei.stripId() << ", "
+                  << ei.xtalId() << ") "
+                  << "status = " << code << std::endl;
       }
     }
   }
   std::cout << "<=== ENDCAP" << std::endl;
-  
+
   std::cout << "===> BARREL" << std::endl;
   for (int i = 0; i < EBDetId::kSizeForDenseIndexing; ++i) {
     const EBDetId id = EBDetId::unhashIndex(i);
     if (!id.null()) {
       // channel status
       const uint16_t code = unpacker->getChannelValue(id);
-      
+
       if (code) {
         const EcalElectronicsId ei = mapping->getElectronicsId(id);
-        
+
         // convert DCC ID (1 - 54) to FED ID (601 - 654)
         const int fed_id = unpacker->electronicsMapper()->getDCCId(ei.dccId());
-        
-        std::cout
-          << " id " << id.rawId()
-          << " -> (" << id.ieta() << ", " << id.iphi() << ", " << id.zside() << ") "
-          << "(" << ei.dccId() << " : " << fed_id << ", " << ei.towerId() << ", " << ei.stripId() << ", " << ei.xtalId() << ") "
-          << "status = " << code
-          << std::endl;
+
+        std::cout << " id " << id.rawId() << " -> (" << id.ieta() << ", " << id.iphi() << ", " << id.zside() << ") "
+                  << "(" << ei.dccId() << " : " << fed_id << ", " << ei.towerId() << ", " << ei.stripId() << ", "
+                  << ei.xtalId() << ") "
+                  << "status = " << code << std::endl;
       }
     }
   }
@@ -242,53 +231,54 @@ void printStatusRecords(const DCCDataUnpacker* unpacker,
 
 void EcalRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<bool>("tccUnpacking",true);
-  desc.add<edm::InputTag>("FedLabel",edm::InputTag("listfeds"));
-  desc.add<bool>("srpUnpacking",true);
-  desc.add<bool>("syncCheck",true);
-  desc.add<bool>("feIdCheck",true);
-  desc.addUntracked<bool>("silentMode",true);
-  desc.add<edm::InputTag>("InputLabel",edm::InputTag("rawDataCollector"));
+  desc.add<bool>("tccUnpacking", true);
+  desc.add<edm::InputTag>("FedLabel", edm::InputTag("listfeds"));
+  desc.add<bool>("srpUnpacking", true);
+  desc.add<bool>("syncCheck", true);
+  desc.add<bool>("feIdCheck", true);
+  desc.addUntracked<bool>("silentMode", true);
+  desc.add<edm::InputTag>("InputLabel", edm::InputTag("rawDataCollector"));
   {
     std::vector<int> temp1;
     unsigned int nvec = 54;
     temp1.reserve(nvec);
-    for (unsigned int i=0; i<nvec; i++) temp1.push_back(601+i);
-    desc.add<std::vector<int> >("orderedFedList",temp1);
+    for (unsigned int i = 0; i < nvec; i++)
+      temp1.push_back(601 + i);
+    desc.add<std::vector<int> >("orderedFedList", temp1);
   }
-  desc.add<bool>("eventPut",true);
-  desc.add<int>("numbTriggerTSamples",1);
-  desc.add<int>("numbXtalTSamples",10);
+  desc.add<bool>("eventPut", true);
+  desc.add<int>("numbTriggerTSamples", 1);
+  desc.add<int>("numbXtalTSamples", 10);
   {
     std::vector<int> temp1;
     unsigned int nvec = 54;
     temp1.reserve(nvec);
-    for (unsigned int i=0; i<nvec; i++) temp1.push_back(1+i);
-    desc.add<std::vector<int> >("orderedDCCIdList",temp1);
+    for (unsigned int i = 0; i < nvec; i++)
+      temp1.push_back(1 + i);
+    desc.add<std::vector<int> >("orderedDCCIdList", temp1);
   }
   {
     std::vector<int> temp1;
     unsigned int nvec = 54;
     temp1.reserve(nvec);
-    for (unsigned int i=0; i<nvec; i++) temp1.push_back(601+i);
-    desc.add<std::vector<int> >("FEDs",temp1);
+    for (unsigned int i = 0; i < nvec; i++)
+      temp1.push_back(601 + i);
+    desc.add<std::vector<int> >("FEDs", temp1);
   }
-  desc.add<bool>("DoRegional",false);
-  desc.add<bool>("feUnpacking",true);
-  desc.add<bool>("forceToKeepFRData",false);
-  desc.add<bool>("headerUnpacking",true);
-  desc.add<bool>("memUnpacking",true);
-  descriptions.add("ecalRawToDigi",desc);
+  desc.add<bool>("DoRegional", false);
+  desc.add<bool>("feUnpacking", true);
+  desc.add<bool>("forceToKeepFRData", false);
+  desc.add<bool>("headerUnpacking", true);
+  desc.add<bool>("memUnpacking", true);
+  descriptions.add("ecalRawToDigi", desc);
 }
 
-
-void EcalRawToDigi::beginRun(const edm::Run&, const edm::EventSetup& es)
-{
+void EcalRawToDigi::beginRun(const edm::Run&, const edm::EventSetup& es) {
   // channel status database
   edm::ESHandle<EcalChannelStatusMap> pChStatus;
   es.get<EcalChannelStatusRcd>().get(pChStatus);
   theUnpacker_->setChannelStatusDB(pChStatus.product());
-  
+
   // uncomment following line to print list of crystals with bad status
   //edm::ESHandle<EcalElectronicsMapping> pEcalMapping;
   //es.get<EcalMappingRcd>().get(pEcalMapping);
@@ -296,49 +286,40 @@ void EcalRawToDigi::beginRun(const edm::Run&, const edm::EventSetup& es)
   //printStatusRecords(theUnpacker_, mapping);
 }
 
-
-void EcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
-{
-  
+void EcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es) {
   //double TIME_START = clock();
   //nevts_++; //NUNO
 
-
   if (first_) {
-   watcher_.check(es);
-   edm::ESHandle< EcalElectronicsMapping > ecalmapping;
-   es.get< EcalMappingRcd >().get(ecalmapping);
-   myMap_ -> setEcalElectronicsMapping(ecalmapping.product());
-   
-   first_ = false;
+    watcher_.check(es);
+    edm::ESHandle<EcalElectronicsMapping> ecalmapping;
+    es.get<EcalMappingRcd>().get(ecalmapping);
+    myMap_->setEcalElectronicsMapping(ecalmapping.product());
 
-  }else{
+    first_ = false;
 
-    if ( watcher_.check(es) ) {    
-      edm::ESHandle< EcalElectronicsMapping > ecalmapping;
-      es.get< EcalMappingRcd >().get(ecalmapping);
-      myMap_ -> deletePointers();
-      myMap_ -> resetPointers();
-      myMap_ -> setEcalElectronicsMapping(ecalmapping.product());
+  } else {
+    if (watcher_.check(es)) {
+      edm::ESHandle<EcalElectronicsMapping> ecalmapping;
+      es.get<EcalMappingRcd>().get(ecalmapping);
+      myMap_->deletePointers();
+      myMap_->resetPointers();
+      myMap_->setEcalElectronicsMapping(ecalmapping.product());
     }
-
   }
 
   // Get list of FEDS :
   std::vector<int> FEDS_to_unpack;
   if (REGIONAL_) {
-        edm::Handle<EcalListOfFEDS> listoffeds;
-        e.getByToken(fedsToken_, listoffeds);
-        FEDS_to_unpack = listoffeds -> GetList();
+    edm::Handle<EcalListOfFEDS> listoffeds;
+    e.getByToken(fedsToken_, listoffeds);
+    FEDS_to_unpack = listoffeds->GetList();
   }
 
+  // Step A: Get Inputs
 
-
-  // Step A: Get Inputs    
-
-  edm::Handle<FEDRawDataCollection> rawdata;  
-  e.getByToken(dataToken_,rawdata);
-
+  edm::Handle<FEDRawDataCollection> rawdata;
+  e.getByToken(dataToken_, rawdata);
 
   // Step B: encapsulate vectors in actual collections and set unpacker pointers
 
@@ -346,48 +327,48 @@ void EcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   auto productDigisEB = std::make_unique<EBDigiCollection>();
   productDigisEB->reserve(1700);
   theUnpacker_->setEBDigisCollection(&productDigisEB);
-  
+
   // create the collection of Ecal Digis
   auto productDigisEE = std::make_unique<EEDigiCollection>();
   theUnpacker_->setEEDigisCollection(&productDigisEE);
-  
+
   // create the collection for headers
   auto productDccHeaders = std::make_unique<EcalRawDataCollection>();
-  theUnpacker_->setDccHeadersCollection(&productDccHeaders); 
+  theUnpacker_->setDccHeadersCollection(&productDccHeaders);
 
   // create the collection for invalid gains
   auto productInvalidGains = std::make_unique<EBDetIdCollection>();
-  theUnpacker_->setInvalidGainsCollection(&productInvalidGains); 
+  theUnpacker_->setInvalidGainsCollection(&productInvalidGains);
 
   // create the collection for invalid gain Switch
   auto productInvalidGainsSwitch = std::make_unique<EBDetIdCollection>();
   theUnpacker_->setInvalidGainsSwitchCollection(&productInvalidGainsSwitch);
-   
+
   // create the collection for invalid chids
   auto productInvalidChIds = std::make_unique<EBDetIdCollection>();
   theUnpacker_->setInvalidChIdsCollection(&productInvalidChIds);
-  
+
   ///////////////// make EEDetIdCollections for these ones
-    
+
   // create the collection for invalid gains
   auto productInvalidEEGains = std::make_unique<EEDetIdCollection>();
-  theUnpacker_->setInvalidEEGainsCollection(&productInvalidEEGains); 
-    
+  theUnpacker_->setInvalidEEGainsCollection(&productInvalidEEGains);
+
   // create the collection for invalid gain Switch
   auto productInvalidEEGainsSwitch = std::make_unique<EEDetIdCollection>();
   theUnpacker_->setInvalidEEGainsSwitchCollection(&productInvalidEEGainsSwitch);
-    
+
   // create the collection for invalid chids
   auto productInvalidEEChIds = std::make_unique<EEDetIdCollection>();
   theUnpacker_->setInvalidEEChIdsCollection(&productInvalidEEChIds);
 
-  ///////////////// make EEDetIdCollections for these ones    
+  ///////////////// make EEDetIdCollections for these ones
 
-  // create the collection for EB srflags       
+  // create the collection for EB srflags
   auto productEBSrFlags = std::make_unique<EBSrFlagCollection>();
   theUnpacker_->setEBSrFlagsCollection(&productEBSrFlags);
-  
-  // create the collection for EB srflags       
+
+  // create the collection for EB srflags
   auto productEESrFlags = std::make_unique<EESrFlagCollection>();
   theUnpacker_->setEESrFlagsCollection(&productEESrFlags);
 
@@ -404,13 +385,11 @@ void EcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   // create the collection for invalid TTIds
   auto productInvalidTTIds = std::make_unique<EcalElectronicsIdCollection>();
   theUnpacker_->setInvalidTTIdsCollection(&productInvalidTTIds);
- 
-   // create the collection for invalid TTIds
+
+  // create the collection for invalid TTIds
   auto productInvalidZSXtalIds = std::make_unique<EcalElectronicsIdCollection>();
   theUnpacker_->setInvalidZSXtalIdsCollection(&productInvalidZSXtalIds);
 
-
- 
   // create the collection for invalid BlockLengths
   auto productInvalidBlockLengths = std::make_unique<EcalElectronicsIdCollection>();
   theUnpacker_->setInvalidBlockLengthsCollection(&productInvalidBlockLengths);
@@ -420,128 +399,118 @@ void EcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   auto productPnDiodeDigis = std::make_unique<EcalPnDiodeDigiCollection>();
   theUnpacker_->setPnDiodeDigisCollection(&productPnDiodeDigis);
 
-  // create the collection for invalid Mem Tt id 
+  // create the collection for invalid Mem Tt id
   auto productInvalidMemTtIds = std::make_unique<EcalElectronicsIdCollection>();
-  theUnpacker_->setInvalidMemTtIdsCollection(& productInvalidMemTtIds);
-  
-  // create the collection for invalid Mem Block Size 
+  theUnpacker_->setInvalidMemTtIdsCollection(&productInvalidMemTtIds);
+
+  // create the collection for invalid Mem Block Size
   auto productInvalidMemBlockSizes = std::make_unique<EcalElectronicsIdCollection>();
-  theUnpacker_->setInvalidMemBlockSizesCollection(& productInvalidMemBlockSizes);
-  
-  // create the collection for invalid Mem Block Size 
+  theUnpacker_->setInvalidMemBlockSizesCollection(&productInvalidMemBlockSizes);
+
+  // create the collection for invalid Mem Block Size
   auto productInvalidMemChIds = std::make_unique<EcalElectronicsIdCollection>();
-  theUnpacker_->setInvalidMemChIdsCollection(& productInvalidMemChIds);
- 
-  // create the collection for invalid Mem Gain Errors 
+  theUnpacker_->setInvalidMemChIdsCollection(&productInvalidMemChIds);
+
+  // create the collection for invalid Mem Gain Errors
   auto productInvalidMemGains = std::make_unique<EcalElectronicsIdCollection>();
-  theUnpacker_->setInvalidMemGainsCollection(& productInvalidMemGains); 
-  //  double TIME_START = clock(); 
-  
+  theUnpacker_->setInvalidMemGainsCollection(&productInvalidMemGains);
+  //  double TIME_START = clock();
 
-  // Step C: unpack all requested FEDs    
-  for (std::vector<int>::const_iterator i=fedUnpackList_.begin(); i!=fedUnpackList_.end(); i++) {
-
+  // Step C: unpack all requested FEDs
+  for (std::vector<int>::const_iterator i = fedUnpackList_.begin(); i != fedUnpackList_.end(); i++) {
     if (REGIONAL_) {
       std::vector<int>::const_iterator fed_it = find(FEDS_to_unpack.begin(), FEDS_to_unpack.end(), *i);
-      if (fed_it == FEDS_to_unpack.end()) continue;
+      if (fed_it == FEDS_to_unpack.end())
+        continue;
     }
 
-  
     // get fed raw data and SM id
     const FEDRawData& fedData = rawdata->FEDData(*i);
     const size_t length = fedData.size();
 
-    LogDebug("EcalRawToDigi") << "raw data length: " << length ;
+    LogDebug("EcalRawToDigi") << "raw data length: " << length;
     //if data size is not null interpret data
-    if ( length >= EMPTYEVENTSIZE ){
-      
-      if(myMap_->setActiveDCC(*i)){
-
+    if (length >= EMPTYEVENTSIZE) {
+      if (myMap_->setActiveDCC(*i)) {
         const int smId = myMap_->getActiveSM();
-        LogDebug("EcalRawToDigi") << "Getting FED = " << *i <<"(SM = "<<smId<<")"<<" data size is: " << length;
+        LogDebug("EcalRawToDigi") << "Getting FED = " << *i << "(SM = " << smId << ")"
+                                  << " data size is: " << length;
 
-        const uint64_t* data = (uint64_t*) fedData.data();
+        const uint64_t* data = (uint64_t*)fedData.data();
         theUnpacker_->unpack(data, length, smId, *i);
 
-        LogDebug("EcalRawToDigi") <<" in EE :"<<productDigisEE->size()
-                                  <<" in EB :"<<productDigisEB->size();
+        LogDebug("EcalRawToDigi") << " in EE :" << productDigisEE->size() << " in EB :" << productDigisEB->size();
       }
     }
-    
-  }// loop on FEDs
-  
+
+  }  // loop on FEDs
+
   //if(nevts_>1){   //NUNO
   //  double TIME_END = clock(); //NUNO
   //  RUNNING_TIME_ += TIME_END-TIME_START; //NUNO
   // }
-  
-  
-  // Add collections to the event 
-  
-  if(put_){
-    
-    if( headerUnpacking_){ 
+
+  // Add collections to the event
+
+  if (put_) {
+    if (headerUnpacking_) {
       e.put(std::move(productDccHeaders));
     }
-    
-    if(feUnpacking_){
+
+    if (feUnpacking_) {
       productDigisEB->sort();
-      e.put(std::move(productDigisEB),"ebDigis");
+      e.put(std::move(productDigisEB), "ebDigis");
       productDigisEE->sort();
-      e.put(std::move(productDigisEE),"eeDigis");
-      e.put(std::move(productInvalidGains),"EcalIntegrityGainErrors");
+      e.put(std::move(productDigisEE), "eeDigis");
+      e.put(std::move(productInvalidGains), "EcalIntegrityGainErrors");
       e.put(std::move(productInvalidGainsSwitch), "EcalIntegrityGainSwitchErrors");
       e.put(std::move(productInvalidChIds), "EcalIntegrityChIdErrors");
       // EE (leaving for now the same names as in EB)
-      e.put(std::move(productInvalidEEGains),"EcalIntegrityGainErrors");
+      e.put(std::move(productInvalidEEGains), "EcalIntegrityGainErrors");
       e.put(std::move(productInvalidEEGainsSwitch), "EcalIntegrityGainSwitchErrors");
       e.put(std::move(productInvalidEEChIds), "EcalIntegrityChIdErrors");
       // EE
-      e.put(std::move(productInvalidTTIds),"EcalIntegrityTTIdErrors");
-      e.put(std::move(productInvalidZSXtalIds),"EcalIntegrityZSXtalIdErrors");
-      e.put(std::move(productInvalidBlockLengths),"EcalIntegrityBlockSizeErrors");
+      e.put(std::move(productInvalidTTIds), "EcalIntegrityTTIdErrors");
+      e.put(std::move(productInvalidZSXtalIds), "EcalIntegrityZSXtalIdErrors");
+      e.put(std::move(productInvalidBlockLengths), "EcalIntegrityBlockSizeErrors");
       e.put(std::move(productPnDiodeDigis));
     }
-    if(memUnpacking_){
-      e.put(std::move(productInvalidMemTtIds),"EcalIntegrityMemTtIdErrors");
-      e.put(std::move(productInvalidMemBlockSizes),"EcalIntegrityMemBlockSizeErrors");
-      e.put(std::move(productInvalidMemChIds),"EcalIntegrityMemChIdErrors");
-      e.put(std::move(productInvalidMemGains),"EcalIntegrityMemGainErrors");
+    if (memUnpacking_) {
+      e.put(std::move(productInvalidMemTtIds), "EcalIntegrityMemTtIdErrors");
+      e.put(std::move(productInvalidMemBlockSizes), "EcalIntegrityMemBlockSizeErrors");
+      e.put(std::move(productInvalidMemChIds), "EcalIntegrityMemChIdErrors");
+      e.put(std::move(productInvalidMemGains), "EcalIntegrityMemGainErrors");
     }
-    if(srpUnpacking_){
+    if (srpUnpacking_) {
       e.put(std::move(productEBSrFlags));
       e.put(std::move(productEESrFlags));
     }
-    if(tccUnpacking_){
-      e.put(std::move(productEcalTps),"EcalTriggerPrimitives");
-      e.put(std::move(productEcalPSs),"EcalPseudoStripInputs");
+    if (tccUnpacking_) {
+      e.put(std::move(productEcalTps), "EcalTriggerPrimitives");
+      e.put(std::move(productEcalPSs), "EcalPseudoStripInputs");
     }
   }
-  
-//if(nevts_>1){   //NUNO
-//  double TIME_END = clock(); //NUNO 
-//  RUNNING_TIME_ += TIME_END-TIME_START; //NUNO
-//}
-  
+
+  //if(nevts_>1){   //NUNO
+  //  double TIME_END = clock(); //NUNO
+  //  RUNNING_TIME_ += TIME_END-TIME_START; //NUNO
+  //}
 }
 
-EcalRawToDigi::~EcalRawToDigi()
-{
-  
+EcalRawToDigi::~EcalRawToDigi() {
   //cout << "EcalDCCUnpackingModule  " << "N events        " << (nevts_-1)<<endl;
   //cout << "EcalDCCUnpackingModule  " << " --- SETUP time " << endl;
   //cout << "EcalDCCUnpackingModule  " << "Time (sys)      " << SETUP_TIME_ << endl;
   //cout << "EcalDCCUnpackingModule  " << "Time in sec.    " << SETUP_TIME_/ CLOCKS_PER_SEC  << endl;
   //cout << "EcalDCCUnpackingModule  " << " --- Per event  " << endl;
-  
+
   //RUNNING_TIME_ = RUNNING_TIME_ / (nevts_-1);
-  
+
   //cout << "EcalDCCUnpackingModule  "<< "Time (sys)      " << RUNNING_TIME_  << endl;
   //cout << "EcalDCCUnpackingModule  "<< "Time in sec.    " << RUNNING_TIME_ / CLOCKS_PER_SEC  << endl;
-  
-  
-  
-  if(myMap_      ) delete myMap_;
-  if(theUnpacker_) delete theUnpacker_;
-  
+
+  if (myMap_)
+    delete myMap_;
+  if (theUnpacker_)
+    delete theUnpacker_;
 }

--- a/EventFilter/EcalRawToDigi/plugins/EcalRawToDigi.h
+++ b/EventFilter/EcalRawToDigi/plugins/EcalRawToDigi.h
@@ -1,5 +1,5 @@
-#ifndef _ECALRAWTODIGIDEV_H_ 
-#define _ECALRAWTODIGIDEV_H_ 
+#ifndef _ECALRAWTODIGIDEV_H_
+#define _ECALRAWTODIGIDEV_H_
 
 /*
  *\ Class EcalRawToDigi
@@ -14,7 +14,7 @@
  *
 */
 
-#include <iostream>                                 
+#include <iostream>
 
 #include "EventFilter/EcalRawToDigi/interface/DCCRawDataDefinitions.h"
 
@@ -38,9 +38,8 @@ class EcalElectronicsMapper;
 class EcalElectronicsMapping;
 class DCCDataUnpacker;
 
-class EcalRawToDigi : public edm::stream::EDProducer<>{
-
- public:
+class EcalRawToDigi : public edm::stream::EDProducer<> {
+public:
   /**
    * Class constructor
    */
@@ -54,27 +53,24 @@ class EcalRawToDigi : public edm::stream::EDProducer<>{
 
   // function called at start of each run
   void beginRun(const edm::Run& run, const edm::EventSetup& es) override;
-  
+
   /**
    * Class destructor
    */
   ~EcalRawToDigi() override;
 
- 
   edm::ESWatcher<EcalMappingRcd> watcher_;
 
-  
- private:
-
+private:
   //list of FEDs to unpack
   std::vector<int> fedUnpackList_;
 
   std::vector<int> orderedFedUnpackList_;
   std::vector<int> orderedDCCIdList_;
-  
+
   unsigned int numbXtalTSamples_;
   unsigned int numbTriggerTSamples_;
-  
+
   bool headerUnpacking_;
   bool srpUnpacking_;
   bool tccUnpacking_;
@@ -86,22 +82,20 @@ class EcalRawToDigi : public edm::stream::EDProducer<>{
   bool first_;
   bool put_;
 
-  
   edm::EDGetTokenT<FEDRawDataCollection> dataToken_;
-  edm::EDGetTokenT<EcalListOfFEDS> fedsToken_;  
+  edm::EDGetTokenT<EcalListOfFEDS> fedsToken_;
 
   // -- For regional unacking :
-  bool REGIONAL_ ;
-    
+  bool REGIONAL_;
 
-  //an electronics mapper class 
-  EcalElectronicsMapper * myMap_;
-  
+  //an electronics mapper class
+  EcalElectronicsMapper* myMap_;
+
   //Ecal unpacker
-  DCCDataUnpacker * theUnpacker_;
-  
-  unsigned int nevts_; // NA: for testing
-  double  RUNNING_TIME_, SETUP_TIME_;
+  DCCDataUnpacker* theUnpacker_;
+
+  unsigned int nevts_;  // NA: for testing
+  double RUNNING_TIME_, SETUP_TIME_;
 };
 
 #endif

--- a/EventFilter/EcalRawToDigi/plugins/EcalRegionCablingESProducer.cc
+++ b/EventFilter/EcalRawToDigi/plugins/EcalRegionCablingESProducer.cc
@@ -1,22 +1,16 @@
 #include "EventFilter/EcalRawToDigi/plugins/EcalRegionCablingESProducer.h"
 
-EcalRegionCablingESProducer::EcalRegionCablingESProducer(const edm::ParameterSet& iConfig)
-{
-  conf_=iConfig;
+EcalRegionCablingESProducer::EcalRegionCablingESProducer(const edm::ParameterSet& iConfig) {
+  conf_ = iConfig;
   setWhatProduced(this);
 }
 
+EcalRegionCablingESProducer::~EcalRegionCablingESProducer() {}
 
-EcalRegionCablingESProducer::~EcalRegionCablingESProducer(){}
+EcalRegionCablingESProducer::ReturnType EcalRegionCablingESProducer::produce(const EcalRegionCablingRecord& iRecord) {
+  using namespace edm::es;
+  edm::ESHandle<EcalElectronicsMapping> mapping;
+  iRecord.getRecord<EcalMappingRcd>().get(mapping);
 
-EcalRegionCablingESProducer::ReturnType
-EcalRegionCablingESProducer::produce(const EcalRegionCablingRecord & iRecord)
-{
-   using namespace edm::es;
-   edm::ESHandle<EcalElectronicsMapping> mapping;
-   iRecord.getRecord<EcalMappingRcd>().get(mapping);
-
-   return std::make_unique<EcalRegionCabling>(conf_,
-					 mapping.product());
-
+  return std::make_unique<EcalRegionCabling>(conf_, mapping.product());
 }

--- a/EventFilter/EcalRawToDigi/plugins/EcalRegionCablingESProducer.h
+++ b/EventFilter/EcalRawToDigi/plugins/EcalRegionCablingESProducer.h
@@ -4,7 +4,7 @@
 //
 // Package:    EcalRegionCablingESProducer
 // Class:      EcalRegionCablingESProducer
-// 
+//
 /**\class EcalRegionCablingESProducer EcalRegionCablingESProducer.h EventFilter/EcalRegionCablingESProducer/src/EcalRegionCablingESProducer.cc
 
  Description: <one line class summary>
@@ -18,7 +18,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 
@@ -31,12 +30,13 @@
 
 class EcalRegionCablingESProducer : public edm::ESProducer {
 public:
-      EcalRegionCablingESProducer(const edm::ParameterSet&);
+  EcalRegionCablingESProducer(const edm::ParameterSet&);
   ~EcalRegionCablingESProducer() override;
 
   typedef std::unique_ptr<EcalRegionCabling> ReturnType;
 
   ReturnType produce(const EcalRegionCablingRecord&);
+
 private:
   edm::ParameterSet conf_;
 };

--- a/EventFilter/EcalRawToDigi/plugins/MatacqProducer.cc
+++ b/EventFilter/EcalRawToDigi/plugins/MatacqProducer.cc
@@ -39,256 +39,242 @@ using namespace edm;
 // #undef LogDebug
 // #define LogDebug(a) cout << "DBG " << a << ": "
 
-
 //verbose mode for matacq event retrieval debugging:
 //static const bool searchDbg = false;
 
 //laser freq is 1 every 112 orbit => >80 orbit
-const int MatacqProducer::orbitTolerance_ = 80; 
+const int MatacqProducer::orbitTolerance_ = 80;
 
-const MatacqProducer::stats_t MatacqProducer::stats_init = {0,0,0};
+const MatacqProducer::stats_t MatacqProducer::stats_init = {0, 0, 0};
 
-static std::string now(){
+static std::string now() {
   struct timeval t;
   gettimeofday(&t, nullptr);
- 
+
   char buf[256];
   strftime(buf, sizeof(buf), "%F %R %S s", localtime(&t.tv_sec));
-  buf[sizeof(buf)-1] = 0;
+  buf[sizeof(buf) - 1] = 0;
 
   stringstream buf2;
-  buf2 << buf << " " << ((t.tv_usec+500)/1000)  << " ms";
+  buf2 << buf << " " << ((t.tv_usec + 500) / 1000) << " ms";
 
   return buf2.str();
 }
 
+MatacqProducer::MatacqProducer(const edm::ParameterSet& params)
+    : fileNames_(params.getParameter<std::vector<std::string> >("fileNames")),
+      digiInstanceName_(params.getParameter<string>("digiInstanceName")),
+      rawInstanceName_(params.getParameter<string>("rawInstanceName")),
+      timing_(params.getUntrackedParameter<bool>("timing", false)),
+      disabled_(params.getParameter<bool>("disabled")),
+      verbosity_(params.getUntrackedParameter<int>("verbosity", 0)),
+      produceDigis_(params.getParameter<bool>("produceDigis")),
+      produceRaw_(params.getParameter<bool>("produceRaw")),
+      inputRawCollection_(params.getParameter<edm::InputTag>("inputRawCollection")),
+      mergeRaw_(params.getParameter<bool>("mergeRaw")),
+      ignoreTriggerType_(params.getParameter<bool>("ignoreTriggerType")),
+      matacq_(nullptr, 0),
+      inFile_(nullptr),
+      data_(bufferSize),
+      openedFileRunNumber_(0),
+      lastOrb_(0),
+      fastRetrievalThresh_(0),
+      orbitOffsetFile_(params.getUntrackedParameter<std::string>("orbitOffsetFile", "")),
+      inFileName_(""),
+      stats_(stats_init),
+      logFileName_(params.getUntrackedParameter<std::string>("logFileName", "matacqProducer.log")),
+      eventSkipCounter_(0),
+      onErrorDisablingEvtCnt_(params.getParameter<int>("onErrorDisablingEvtCnt")),
+      timeLogFile_(params.getUntrackedParameter<std::string>("timeLogFile", "")),
+      runNumber_(0) {
+  if (verbosity_ >= 4)
+    cout << "[Matacq " << now() << "] in MatacqProducer ctor" << endl;
 
-MatacqProducer::MatacqProducer(const edm::ParameterSet& params):
-  fileNames_(params.getParameter<std::vector<std::string> >("fileNames")),
-  digiInstanceName_(params.getParameter<string>("digiInstanceName")),
-  rawInstanceName_(params.getParameter<string>("rawInstanceName")),
-  timing_(params.getUntrackedParameter<bool>("timing", false)),
-  disabled_(params.getParameter<bool>("disabled")),
-  verbosity_(params.getUntrackedParameter<int>("verbosity", 0)),
-  produceDigis_(params.getParameter<bool>("produceDigis")),
-  produceRaw_(params.getParameter<bool>("produceRaw")),
-  inputRawCollection_(params.getParameter<edm::InputTag>("inputRawCollection")),
-  mergeRaw_(params.getParameter<bool>("mergeRaw")),
-  ignoreTriggerType_(params.getParameter<bool>("ignoreTriggerType")),
-  matacq_(nullptr, 0),
-  inFile_(nullptr),
-  data_(bufferSize),
-  openedFileRunNumber_(0),
-  lastOrb_(0),
-  fastRetrievalThresh_(0),
-  orbitOffsetFile_(params.getUntrackedParameter<std::string>("orbitOffsetFile",
-							     "")),
-  inFileName_(""),
-  stats_(stats_init),
-  logFileName_(params.getUntrackedParameter<std::string>("logFileName",
-							 "matacqProducer.log")),
-  eventSkipCounter_(0),
-  onErrorDisablingEvtCnt_(params.getParameter<int>("onErrorDisablingEvtCnt")),
-  timeLogFile_(params.getUntrackedParameter<std::string>("timeLogFile", "")),
-  runNumber_(0)
-{
-  if(verbosity_>=4) cout << "[Matacq " << now() << "] in MatacqProducer ctor"  << endl;
-  
   gettimeofday(&timer_, nullptr);
 
-  if(!timeLogFile_.empty()){
+  if (!timeLogFile_.empty()) {
     timeLog_.open(timeLogFile_.c_str());
-    if(timeLog_.fail()){
+    if (timeLog_.fail()) {
       cout << "[LaserSorter " << now() << "] "
            << "Failed to open file " << timeLogFile_ << " to log timing.\n";
       logTiming_ = false;
-    } else{
+    } else {
       logTiming_ = true;
     }
   }
-  
+
   posEstim_.verbosity(verbosity_);
 
   logFile_.open(logFileName_.c_str(), ios::app | ios::out);
-  
-  if(logFile_.bad()){
-    throw cms::Exception("FileOpen") << "Failed to open file "
-				     << logFileName_ << " for logging.\n";
+
+  if (logFile_.bad()) {
+    throw cms::Exception("FileOpen") << "Failed to open file " << logFileName_ << " for logging.\n";
   }
 
   inputRawCollectionToken_ = consumes<FEDRawDataCollection>(params.getParameter<InputTag>("inputRawCollection"));
 
-
-  if(produceDigis_){
-    if(verbosity_>0) cout << "[Matacq " << now() << "] registering new "
-                       "EcalMatacqDigiCollection product with instance name '"
-                          << digiInstanceName_ << "'\n";
+  if (produceDigis_) {
+    if (verbosity_ > 0)
+      cout << "[Matacq " << now()
+           << "] registering new "
+              "EcalMatacqDigiCollection product with instance name '"
+           << digiInstanceName_ << "'\n";
     produces<EcalMatacqDigiCollection>(digiInstanceName_);
   }
-  
-  if(produceRaw_){
-    if(verbosity_>0) cout << "[Matacq " << now() << "] registering new FEDRawDataCollection "
-                       "product with instance name '"
-                          << rawInstanceName_ << "'\n";
+
+  if (produceRaw_) {
+    if (verbosity_ > 0)
+      cout << "[Matacq " << now()
+           << "] registering new FEDRawDataCollection "
+              "product with instance name '"
+           << rawInstanceName_ << "'\n";
     produces<FEDRawDataCollection>(rawInstanceName_);
   }
-  
+
   startTime_.tv_sec = startTime_.tv_usec = 0;
-  if(!orbitOffsetFile_.empty()){
+  if (!orbitOffsetFile_.empty()) {
     doOrbitOffset_ = true;
     loadOrbitOffset();
-  } else{
+  } else {
     doOrbitOffset_ = false;
   }
-  if(verbosity_>=4) cout << "[Matacq " << now() << "] exiting MatacqProducer ctor"  << endl;
+  if (verbosity_ >= 4)
+    cout << "[Matacq " << now() << "] exiting MatacqProducer ctor" << endl;
 }
 
-
-void
-MatacqProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup){
-  if(verbosity_>=4) cout << "[Matacq " << now() << "] in MatacqProducer::produce"  << endl;
-  if(logTiming_){
+void MatacqProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup) {
+  if (verbosity_ >= 4)
+    cout << "[Matacq " << now() << "] in MatacqProducer::produce" << endl;
+  if (logTiming_) {
     timeval t;
     gettimeofday(&t, nullptr);
 
-    timeLog_ << t.tv_sec << "."
-             << setfill('0') << setw(3) << (t.tv_usec+500)/1000 << setfill(' ')<< "\t"
-             << (t.tv_usec - timer_.tv_usec)*1. 
-      + (t.tv_sec - timer_.tv_sec)*1.e6 << "\t";
+    timeLog_ << t.tv_sec << "." << setfill('0') << setw(3) << (t.tv_usec + 500) / 1000 << setfill(' ') << "\t"
+             << (t.tv_usec - timer_.tv_usec) * 1. + (t.tv_sec - timer_.tv_sec) * 1.e6 << "\t";
     timer_ = t;
-  } 
- 
-  if(startTime_.tv_sec==0) gettimeofday(&startTime_, nullptr);
-  ++stats_.nEvents;  
-  if(disabled_) return;
+  }
+
+  if (startTime_.tv_sec == 0)
+    gettimeofday(&startTime_, nullptr);
+  ++stats_.nEvents;
+  if (disabled_)
+    return;
   const uint32_t runNumber = getRunNumber(event);
-  if(runNumber!=runNumber_){
+  if (runNumber != runNumber_) {
     newRun(runNumber_, runNumber);
   }
   addMatacqData(event);
 
-  if(logTiming_){
+  if (logTiming_) {
     timeval t;
-      gettimeofday(&t, nullptr);
-      timeLog_ << (t.tv_usec - timer_.tv_usec)*1. 
-        + (t.tv_sec - timer_.tv_sec)*1.e6 << "\n";
-      timer_ = t;
+    gettimeofday(&t, nullptr);
+    timeLog_ << (t.tv_usec - timer_.tv_usec) * 1. + (t.tv_sec - timer_.tv_sec) * 1.e6 << "\n";
+    timer_ = t;
   }
 }
 
-void
-MatacqProducer::addMatacqData(edm::Event& event){
-
+void MatacqProducer::addMatacqData(edm::Event& event) {
   edm::Handle<FEDRawDataCollection> sourceColl;
   event.getByToken(inputRawCollectionToken_, sourceColl);
 
   std::unique_ptr<FEDRawDataCollection> rawColl;
-  if(produceRaw_){
-    if(mergeRaw_){
+  if (produceRaw_) {
+    if (mergeRaw_) {
       rawColl = std::make_unique<FEDRawDataCollection>(*sourceColl);
-    } else{
+    } else {
       rawColl = std::make_unique<FEDRawDataCollection>();
     }
   }
-  
+
   auto digiColl = std::make_unique<EcalMatacqDigiCollection>();
-  
-  if(eventSkipCounter_==0){
-    if(sourceColl->FEDData(matacqFedId_).size()>4 && !produceRaw_){
+
+  if (eventSkipCounter_ == 0) {
+    if (sourceColl->FEDData(matacqFedId_).size() > 4 && !produceRaw_) {
       //input raw data collection already contains matacqData
-      formatter_.interpretRawData(sourceColl->FEDData(matacqFedId_),
-				  *digiColl);             
-    } else{
+      formatter_.interpretRawData(sourceColl->FEDData(matacqFedId_), *digiColl);
+    } else {
       bool isLaserEvent = (getCalibTriggerType(event) == laserType);
 
-
       //      cout << "---> " << (ignoreTriggerType_?"yes":"no") << " " << getCalibTriggerType(event) << endl;
-      
-      if(isLaserEvent || ignoreTriggerType_){
-	
-	const uint32_t runNumber = getRunNumber(event);
-	const uint32_t orbitId   = getOrbitId(event);
-      
-	LogInfo("Matacq") << "Run " << runNumber << "\t Orbit " << orbitId << "\n";
-	
-	bool fileChange;
-	if(doOrbitOffset_){
-	  map<uint32_t,uint32_t>::iterator it = orbitOffset_.find(runNumber);
-	  if(it == orbitOffset_.end()){
-	    LogWarning("Matacq") << "Orbit offset not found for run "
-				 << runNumber
-				 << ". No orbit correction will be applied.";
-	  }
-	}  
-      
-	if(getMatacqFile(runNumber, orbitId, &fileChange)){
-	  //matacq file retrieval succeeded
-	  LogInfo("Matacq") << "Matacq data file found for "
-			    << "run " << runNumber << " orbit " << orbitId;
-	  if(getMatacqEvent(runNumber, orbitId, fileChange)){
-	    if(produceDigis_){
-	      formatter_.interpretRawData(matacq_, *digiColl);
-	    }
-	    if(produceRaw_){
-	      uint32_t dataLen64 = matacq_.getParsedLen();
-	      if(dataLen64 > bufferSize*8 || matacq_.getDccLen()!= dataLen64){
-		LogWarning("Matacq") << " Error in Matacq event fragment length! "
-				     << "DCC len: " << matacq_.getDccLen()
-				     << "*8 Bytes, Parsed len: "
-				     << matacq_.getParsedLen() << "*8 Bytes.  "
-				     << "Matacq data will not be included for this event.\n";
-	      } else{
-		rawColl->FEDData(matacqFedId_).resize(dataLen64*8);
-		copy(data_.begin(), data_.begin() + dataLen64*8,
-		     rawColl->FEDData(matacqFedId_).data());
-	      }
-	    }
-	    LogInfo("Matacq") << "Associating matacq data with orbit id "
-			      << matacq_.getOrbitId()
-			      << " to dcc event with orbit id "
-			      << orbitId << std::endl;
-	    if(isLaserEvent){
-	      ++stats_.nLaserEventsWithMatacq;
-	    } else{
-	      ++stats_.nNonLaserEventsWithMatacq;
-	    }
-	  } else{
-	    if(isLaserEvent){
-	      LogWarning("Matacq") << "No matacq data found for laser event "
-				   << "of run " << runNumber << " orbit "
-				   << orbitId;
-	    }
-	  }
-	} else{
-	  LogWarning("Matacq") << "No matacq file found for event "
-			       << event.id();
-	}
+
+      if (isLaserEvent || ignoreTriggerType_) {
+        const uint32_t runNumber = getRunNumber(event);
+        const uint32_t orbitId = getOrbitId(event);
+
+        LogInfo("Matacq") << "Run " << runNumber << "\t Orbit " << orbitId << "\n";
+
+        bool fileChange;
+        if (doOrbitOffset_) {
+          map<uint32_t, uint32_t>::iterator it = orbitOffset_.find(runNumber);
+          if (it == orbitOffset_.end()) {
+            LogWarning("Matacq") << "Orbit offset not found for run " << runNumber
+                                 << ". No orbit correction will be applied.";
+          }
+        }
+
+        if (getMatacqFile(runNumber, orbitId, &fileChange)) {
+          //matacq file retrieval succeeded
+          LogInfo("Matacq") << "Matacq data file found for "
+                            << "run " << runNumber << " orbit " << orbitId;
+          if (getMatacqEvent(runNumber, orbitId, fileChange)) {
+            if (produceDigis_) {
+              formatter_.interpretRawData(matacq_, *digiColl);
+            }
+            if (produceRaw_) {
+              uint32_t dataLen64 = matacq_.getParsedLen();
+              if (dataLen64 > bufferSize * 8 || matacq_.getDccLen() != dataLen64) {
+                LogWarning("Matacq") << " Error in Matacq event fragment length! "
+                                     << "DCC len: " << matacq_.getDccLen()
+                                     << "*8 Bytes, Parsed len: " << matacq_.getParsedLen() << "*8 Bytes.  "
+                                     << "Matacq data will not be included for this event.\n";
+              } else {
+                rawColl->FEDData(matacqFedId_).resize(dataLen64 * 8);
+                copy(data_.begin(), data_.begin() + dataLen64 * 8, rawColl->FEDData(matacqFedId_).data());
+              }
+            }
+            LogInfo("Matacq") << "Associating matacq data with orbit id " << matacq_.getOrbitId()
+                              << " to dcc event with orbit id " << orbitId << std::endl;
+            if (isLaserEvent) {
+              ++stats_.nLaserEventsWithMatacq;
+            } else {
+              ++stats_.nNonLaserEventsWithMatacq;
+            }
+          } else {
+            if (isLaserEvent) {
+              LogWarning("Matacq") << "No matacq data found for laser event "
+                                   << "of run " << runNumber << " orbit " << orbitId;
+            }
+          }
+        } else {
+          LogWarning("Matacq") << "No matacq file found for event " << event.id();
+        }
       }
     }
-    if(eventSkipCounter_>0){ //error occured for this events
+    if (eventSkipCounter_ > 0) {  //error occured for this events
       //                       and some events will be skipped following
       //                       to this error.
-      LogInfo("Matacq") << " [" << now() << "] "
-			<< eventSkipCounter_
-			<< " next events will be skipped, following to an "
-			<< "error on the last processed event, "
-			<< "which is expected to be persistant.";
+      LogInfo("Matacq") << " [" << now() << "] " << eventSkipCounter_
+                        << " next events will be skipped, following to an "
+                        << "error on the last processed event, "
+                        << "which is expected to be persistant.";
     }
-  } else{
+  } else {
     --eventSkipCounter_;
   }
-  
-  if(produceRaw_){
-    if(verbosity_>1) cout << "[Matacq " << now() << "] "
-                          << "Adding FEDRawDataCollection collection "
-                          << " to event.\n";
+
+  if (produceRaw_) {
+    if (verbosity_ > 1)
+      cout << "[Matacq " << now() << "] "
+           << "Adding FEDRawDataCollection collection "
+           << " to event.\n";
     event.put(std::move(rawColl), rawInstanceName_);
   }
 
-  if(produceDigis_){
-    if(verbosity_>1) cout << "[Matacq " << now() << "] "
-                          << "Adding EcalMatacqDigiCollection collection "
-                          << " to event.\n";
+  if (produceDigis_) {
+    if (verbosity_ > 1)
+      cout << "[Matacq " << now() << "] "
+           << "Adding EcalMatacqDigiCollection collection "
+           << " to event.\n";
     event.put(std::move(digiColl), digiInstanceName_);
   }
 }
@@ -329,8 +315,8 @@ MatacqProducer::addMatacqData(edm::Event& event){
 //       f.seekg(len*8 - headerSize, ios::cur);
 //     }
 //   }
-  
-//   f.clear(); //clears eof error to allow seekg  
+
+//   f.clear(); //clears eof error to allow seekg
 //   if(doWrap && !found){
 //     f.seekg(0, ios::beg);
 //     found =  getMatacqEvent(f, runNumber, orbitId, false, startPos);
@@ -339,221 +325,219 @@ MatacqProducer::addMatacqData(edm::Event& event){
 // }
 //#endif
 
-bool
-MatacqProducer::getMatacqEvent(uint32_t runNumber,
-			       int32_t orbitId,
-			       bool fileChange){
+bool MatacqProducer::getMatacqEvent(uint32_t runNumber, int32_t orbitId, bool fileChange) {
   filepos_t startPos;
-  if(!mtell(startPos)) return false;
-  
+  if (!mtell(startPos))
+    return false;
+
   int32_t startOrb = -1;
-  const size_t headerSize = 8*8;
-  if(mread((char*)&data_[0], headerSize, "Reading matacq header", true)){
+  const size_t headerSize = 8 * 8;
+  if (mread((char*)&data_[0], headerSize, "Reading matacq header", true)) {
     startOrb = MatacqRawEvent::getOrbitId(&data_[0], headerSize);
-    if(startOrb<0) startOrb = 0;
-  } else{
-    if(verbosity_>2){
-      cout << "[Matacq " << now() << "] Failed to read matacq header. Moved to start of "
-	" the file.\n";
+    if (startOrb < 0)
+      startOrb = 0;
+  } else {
+    if (verbosity_ > 2) {
+      cout << "[Matacq " << now()
+           << "] Failed to read matacq header. Moved to start of "
+              " the file.\n";
     }
     mrewind();
-    if(mread((char*)&data_[0], headerSize, "Reading matacq header", true)){
+    if (mread((char*)&data_[0], headerSize, "Reading matacq header", true)) {
       startPos = 0;
       startOrb = MatacqRawEvent::getOrbitId(&data_[0], headerSize);
-    } else{
-      if(verbosity_>2) cout << "[Matacq " << now() << "] Looks like matacq file is empty"
-                            << "\n";
+    } else {
+      if (verbosity_ > 2)
+        cout << "[Matacq " << now() << "] Looks like matacq file is empty"
+             << "\n";
       return false;
     }
   }
-  
-  if(verbosity_>2) cout << "[Matacq " << now() << "] Last read orbit: " << lastOrb_
-                        << " looking for orbit " << orbitId
-                        << ". Current file position: " << startPos
-                        << " Orbit at current position: " << startOrb << "\n";
-  
+
+  if (verbosity_ > 2)
+    cout << "[Matacq " << now() << "] Last read orbit: " << lastOrb_ << " looking for orbit " << orbitId
+         << ". Current file position: " << startPos << " Orbit at current position: " << startOrb << "\n";
+
   //  f.clear();
   bool didCoarseMove = false;
 
   //FIXME: case where posEtim_.invalid() is false
-  if(!posEstim_.invalid()
-     && (abs(lastOrb_-orbitId) > fastRetrievalThresh_)){
+  if (!posEstim_.invalid() && (abs(lastOrb_ - orbitId) > fastRetrievalThresh_)) {
     filepos_t pos = posEstim_.pos(orbitId);
 
     //    struct stat st;
     filepos_t fsize;
     //    if(0==stat(inFileName_.c_str(), &st)){
-    if(msize(fsize)){
+    if (msize(fsize)) {
       //      const int64_t fsize = st.st_size;
-      if(0!=posEstim_.eventLength() && pos > fsize){
-	//estimated position is beyong end of file
-	//-> move to beginning of last event:
-	int64_t evtSize = posEstim_.eventLength()*sizeof(uint64_t);
-	pos = ((int64_t)fsize/evtSize-1)*evtSize;
-	if(verbosity_>2){
-	  cout << "[Matacq " << now() << "] Estimated position was beyond end of file. "
-	    "Changed to " << pos << "\n";
-	}
+      if (0 != posEstim_.eventLength() && pos > fsize) {
+        //estimated position is beyong end of file
+        //-> move to beginning of last event:
+        int64_t evtSize = posEstim_.eventLength() * sizeof(uint64_t);
+        pos = ((int64_t)fsize / evtSize - 1) * evtSize;
+        if (verbosity_ > 2) {
+          cout << "[Matacq " << now()
+               << "] Estimated position was beyond end of file. "
+                  "Changed to "
+               << pos << "\n";
+        }
       }
-    } else{
+    } else {
       LogWarning("Matacq") << "Failed to access file " << inFileName_ << ".";
     }
-    if(pos>=0){
-      if(verbosity_>2) cout << "[Matacq " << now() << "] jumping to estimated position "
-			    << pos << "\n";
+    if (pos >= 0) {
+      if (verbosity_ > 2)
+        cout << "[Matacq " << now() << "] jumping to estimated position " << pos << "\n";
       mseek(pos, SEEK_SET, "Jumping to estimated event position");
-      if(mread((char*)&data_[0], headerSize, "Reading matacq header", true)){
-	didCoarseMove = true;
-      } else{
-	//estimated position might have been beyond the end of the file,
-	//try, with original position:
-	didCoarseMove = false;
-	if(!mread((char*)&data_[0], headerSize, "Reading event header", true)){
-	  return false;
-	}
+      if (mread((char*)&data_[0], headerSize, "Reading matacq header", true)) {
+        didCoarseMove = true;
+      } else {
+        //estimated position might have been beyond the end of the file,
+        //try, with original position:
+        didCoarseMove = false;
+        if (!mread((char*)&data_[0], headerSize, "Reading event header", true)) {
+          return false;
+        }
       }
-    } else{
-      if(verbosity_) cout << "[Matacq " << now() << "] Event orbit outside of orbit range "
-		       "of matacq data file events\n";
+    } else {
+      if (verbosity_)
+        cout << "[Matacq " << now()
+             << "] Event orbit outside of orbit range "
+                "of matacq data file events\n";
       return false;
     }
   }
-  
+
   int32_t orb = MatacqRawEvent::getOrbitId(&data_[0], headerSize);
 
-  if(didCoarseMove){
+  if (didCoarseMove) {
     //autoadjustement of threshold for coarse move:
-    if(abs(orb-orbitId) > fastRetrievalThresh_){
-      if(verbosity_>2) cout << "[Matacq " << now() << "] Fast retrieval threshold increased from "
-                            << fastRetrievalThresh_;
-      fastRetrievalThresh_ = 2*abs(orb-orbitId);
-      if(verbosity_>2) cout << " to " << fastRetrievalThresh_ << "\n";
+    if (abs(orb - orbitId) > fastRetrievalThresh_) {
+      if (verbosity_ > 2)
+        cout << "[Matacq " << now() << "] Fast retrieval threshold increased from " << fastRetrievalThresh_;
+      fastRetrievalThresh_ = 2 * abs(orb - orbitId);
+      if (verbosity_ > 2)
+        cout << " to " << fastRetrievalThresh_ << "\n";
     }
 
     //if coarse move did not improve situation, rolls back:
-    if(startOrb > 0
-       && (abs(orb-orbitId) > abs(startOrb-orbitId))){
-      if(verbosity_>2) cout << "[Matacq " << now() << "] Estimation (-> orbit " << orb << ") "
-                         "was worst than original position (-> orbit "
-                            << startOrb
-                            << "). Restoring position (" << startPos << ").\n";
+    if (startOrb > 0 && (abs(orb - orbitId) > abs(startOrb - orbitId))) {
+      if (verbosity_ > 2)
+        cout << "[Matacq " << now() << "] Estimation (-> orbit " << orb
+             << ") "
+                "was worst than original position (-> orbit "
+             << startOrb << "). Restoring position (" << startPos << ").\n";
       mseek(startPos, SEEK_SET);
       mread((char*)&data_[0], headerSize, "Reading event header", true);
       orb = MatacqRawEvent::getOrbitId(&data_[0], headerSize);
     }
   }
-  
-  bool searchBackward = (orb>orbitId)?true:false;
+
+  bool searchBackward = (orb > orbitId) ? true : false;
   //BEWARE: len must be signed, because we are using latter in the code (-len)
   //expression
   int len = (int)MatacqRawEvent::getDccLen(&data_[0], headerSize);
 
-  if(len==0){
+  if (len == 0) {
     cout << "[Matacq " << now() << "] read DCC length is null! Cancels matacq event search "
-	 << " and move matacq file pointer to beginning of the file. "
-	 << "(" << __FILE__ << ":" << __LINE__ << ")."
-	 << "\n";
+         << " and move matacq file pointer to beginning of the file. "
+         << "(" << __FILE__ << ":" << __LINE__ << ")."
+         << "\n";
     //rewind(f);
     mrewind();
     return false;
   }
-  
+
   enum state_t { searching, found, failed } state = searching;
-  
-  while(state == searching){
+
+  while (state == searching) {
     orb = MatacqRawEvent::getOrbitId(&data_[0], headerSize);
     len = (int)MatacqRawEvent::getDccLen(&data_[0], headerSize);
     uint32_t run = MatacqRawEvent::getRunNum(&data_[0], headerSize);
-    if(verbosity_>3){
+    if (verbosity_ > 3) {
       filepos_t pos = -1;
       mtell(pos);
-      cout << "[Matacq " << now() << "] Header read at file position "
-	   << pos
-	   << ":  orbit = " << orb
-	   << " len = " << len << "x8 Byte"
-	   << " run = " << run << "\n";
+      cout << "[Matacq " << now() << "] Header read at file position " << pos << ":  orbit = " << orb
+           << " len = " << len << "x8 Byte"
+           << " run = " << run << "\n";
     }
-    if((abs(orb-orbitId) < orbitTolerance_)
-       && (runNumber==0 || runNumber==run)){
+    if ((abs(orb - orbitId) < orbitTolerance_) && (runNumber == 0 || runNumber == run)) {
       state = found;
       lastOrb_ = orb;
       //reads the rest of the event:
-      if((int)data_.size() < len*8){
-	throw cms::Exception("Matacq") << "Buffer overflow";
+      if ((int)data_.size() < len * 8) {
+        throw cms::Exception("Matacq") << "Buffer overflow";
       }
-      if(verbosity_>2) cout << "[Matacq " << now() << "] Event found. Reading "
-                         " matacq event." << "\n";
-      if(!mread((char*)&data_[0], len*8, "Reading matacq event")){
-	if(verbosity_>2) cout << "[Matacq " << now() << "] Failed to read matacq event."
-                              << "\n";
-	state = failed;
+      if (verbosity_ > 2)
+        cout << "[Matacq " << now()
+             << "] Event found. Reading "
+                " matacq event."
+             << "\n";
+      if (!mread((char*)&data_[0], len * 8, "Reading matacq event")) {
+        if (verbosity_ > 2)
+          cout << "[Matacq " << now() << "] Failed to read matacq event."
+               << "\n";
+        state = failed;
       }
-      matacq_ = MatacqRawEvent((unsigned char*)&data_[0], len*8);
+      matacq_ = MatacqRawEvent((unsigned char*)&data_[0], len * 8);
     } else {
-      if((searchBackward && (orb < orbitId))
-	 || (!searchBackward && (orb > orbitId))){ //search ended
-	lastOrb_ = orb;      
-	state = failed;
-	if(verbosity_>2) cout << "[Matacq " << now()
-			    << "] No matacq data found for run " << run
-			    << ", orbit ID " << orbitId << "." << "\n";
-      } else{
-	off_t offset = (searchBackward?-len:len)*8;
-	lastOrb_ = orb;	
-	if(verbosity_>3){
-	  cout << "[Matacq " << now() << "] In matacq file, moving "
-	       << abs(offset) << " byte " << (offset>0?"forward":"backward")
-	       << ".\n";
-	}	
+      if ((searchBackward && (orb < orbitId)) || (!searchBackward && (orb > orbitId))) {  //search ended
+        lastOrb_ = orb;
+        state = failed;
+        if (verbosity_ > 2)
+          cout << "[Matacq " << now() << "] No matacq data found for run " << run << ", orbit ID " << orbitId << "."
+               << "\n";
+      } else {
+        off_t offset = (searchBackward ? -len : len) * 8;
+        lastOrb_ = orb;
+        if (verbosity_ > 3) {
+          cout << "[Matacq " << now() << "] In matacq file, moving " << abs(offset) << " byte "
+               << (offset > 0 ? "forward" : "backward") << ".\n";
+        }
 
-	if(mseek(offset, SEEK_CUR,
-		 (searchBackward?"Moving to previous event":
-		  "Moving to next event"))
-	   && mread((char*)&data_[0], headerSize, "Reading event header",
-		    true)){
-	} else{
-	  if(!searchBackward) mseek(-len*8, SEEK_CUR,
-				    "Moving to start of last complete event");
-	  state = failed;
-	}
+        if (mseek(offset, SEEK_CUR, (searchBackward ? "Moving to previous event" : "Moving to next event")) &&
+            mread((char*)&data_[0], headerSize, "Reading event header", true)) {
+        } else {
+          if (!searchBackward)
+            mseek(-len * 8, SEEK_CUR, "Moving to start of last complete event");
+          state = failed;
+        }
       }
     }
   }
-  
-  if(state==found){
+
+  if (state == found) {
     filepos_t pos = -1;
     filepos_t fsize = -1;
     mtell(pos);
     msize(fsize);
-    if(pos==fsize-1){ //last byte.
-      if(verbosity_>2){
-	cout << "[Matacq " << now() << "] Event found was at the end of the file. Moving "
-	  "stream position to beginning of this event."
-	     << "\n";
+    if (pos == fsize - 1) {  //last byte.
+      if (verbosity_ > 2) {
+        cout << "[Matacq " << now()
+             << "] Event found was at the end of the file. Moving "
+                "stream position to beginning of this event."
+             << "\n";
       }
-      mseek(-(int)len*8-1, SEEK_CUR,
-	    "Moving to beginning of last matacq event");
+      mseek(-(int)len * 8 - 1, SEEK_CUR, "Moving to beginning of last matacq event");
     }
   }
-  return (state==found);
+  return (state == found);
 }
 
-
-bool
-MatacqProducer::getMatacqFile(uint32_t runNumber, uint32_t orbitId,
-			      bool* fileChange){
-  if(openedFileRunNumber_ != 0
-     && openedFileRunNumber_ == runNumber){
+bool MatacqProducer::getMatacqFile(uint32_t runNumber, uint32_t orbitId, bool* fileChange) {
+  if (openedFileRunNumber_ != 0 && openedFileRunNumber_ == runNumber) {
     uint32_t firstOrb, lastOrb;
     bool goodRange = getOrbitRange(firstOrb, lastOrb);
     //    if(orbitId < firstOrb || orbitId > lastOrb) continue;
-    if(goodRange && firstOrb <= orbitId && orbitId <= lastOrb){
-      if(fileChange!=nullptr) *fileChange = false;
+    if (goodRange && firstOrb <= orbitId && orbitId <= lastOrb) {
+      if (fileChange != nullptr)
+        *fileChange = false;
       return misOpened();
     }
   }
 
-  if(fileNames_.empty()) return false;
+  if (fileNames_.empty())
+    return false;
 
   const string runNumberFormat = "%08d{,_*}";
   string sRunNumber = str(boost::format(runNumberFormat) % runNumber);
@@ -564,198 +548,204 @@ MatacqProducer::getMatacqFile(uint32_t runNumber, uint32_t orbitId,
   //we make two iterations to handle the case where the event is procesed
   //before the matacq data are available. In such case we would have
   //orbitId > maxOrb (maxOrb: orbit of last written matacq event)
-  for(int itry = 0; itry < 2 && (orbitId > maxOrb); ++itry){
-    if(itry > 0){
+  for (int itry = 0; itry < 2 && (orbitId > maxOrb); ++itry) {
+    if (itry > 0) {
       int n_sec = 1;
-      std::cout << "[Matacq " << now() << "] Event orbit id (" << orbitId << ") goes "
-	"beyound the range of available one. Waiting for " << n_sec << " seconds in case "
-	"it was not written yet to disk.";
+      std::cout << "[Matacq " << now() << "] Event orbit id (" << orbitId
+                << ") goes "
+                   "beyound the range of available one. Waiting for "
+                << n_sec
+                << " seconds in case "
+                   "it was not written yet to disk.";
       sleep(n_sec);
     }
-    
-    for(unsigned i=0; i < fileNames_.size() && !found; ++i){
+
+    for (unsigned i = 0; i < fileNames_.size() && !found; ++i) {
       fname = fileNames_[i];
-      boost::algorithm::replace_all(fname, "%run_subdir%",
-				    runSubDir(runNumber));
+      boost::algorithm::replace_all(fname, "%run_subdir%", runSubDir(runNumber));
       boost::algorithm::replace_all(fname, "%run_number%", sRunNumber);
 
       glob_t g;
-      int rc  = glob(fname.c_str(), GLOB_BRACE, nullptr, &g);
-      if(rc){
-	if(verbosity_ > 1){
-	  switch(rc){
-	  case GLOB_NOSPACE:
-	    std::cout << "[Matacq " << now() << "] Running out of memory while calling glob function to look for matacq file paths\n";
-	    break;
-	  case GLOB_ABORTED:
-	    std::cout << "[Matacq " << now() << "] Read error while calling glob function to look for matacq file paths\n";
-	    break;
-	  case GLOB_NOMATCH:
-	    //ok. No message to report.
-	    break;
-	  }
-	  continue;
-	}
-      } //rc
-      for(unsigned iglob = 0; iglob < g.gl_pathc; ++iglob){
-	char* thePath = g.gl_pathv[iglob];
-	//FIXME: add sanity check on the path
-	static std::atomic<int> nOpenErrors {0};
-	const int maxOpenErrors = 50;
-	if(!mopen(thePath) && nOpenErrors < maxOpenErrors){
-	  std::cout << "[Matacq " << now() << "] Failed to open file " << thePath;
-	  ++nOpenErrors;
-	  if(nOpenErrors == maxOpenErrors){
-	    std::cout << nOpenErrors << "This is the " << maxOpenErrors
-		      << "th occurence of this error. Report of this error is now disabled.\n";
-	  } else{
-	    std::cout << "\n";
-	  }
-	}
-	uint32_t firstOrb;
-	uint32_t lastOrb;
-	bool goodRange = getOrbitRange(firstOrb, lastOrb);
-	if(goodRange && lastOrb > maxOrb) maxOrb = lastOrb;
-	if(goodRange && firstOrb <= orbitId && orbitId <= lastOrb){
-	  found = true;
-	  //continue;
-	  fname = thePath;
-	  if(verbosity_ > 1) std::cout << "[Matacq " << now() << "] Switching to file " << fname << "\n";
-	  break;
-	}
-      } //next iglob
+      int rc = glob(fname.c_str(), GLOB_BRACE, nullptr, &g);
+      if (rc) {
+        if (verbosity_ > 1) {
+          switch (rc) {
+            case GLOB_NOSPACE:
+              std::cout << "[Matacq " << now()
+                        << "] Running out of memory while calling glob function to look for matacq file paths\n";
+              break;
+            case GLOB_ABORTED:
+              std::cout << "[Matacq " << now()
+                        << "] Read error while calling glob function to look for matacq file paths\n";
+              break;
+            case GLOB_NOMATCH:
+              //ok. No message to report.
+              break;
+          }
+          continue;
+        }
+      }  //rc
+      for (unsigned iglob = 0; iglob < g.gl_pathc; ++iglob) {
+        char* thePath = g.gl_pathv[iglob];
+        //FIXME: add sanity check on the path
+        static std::atomic<int> nOpenErrors{0};
+        const int maxOpenErrors = 50;
+        if (!mopen(thePath) && nOpenErrors < maxOpenErrors) {
+          std::cout << "[Matacq " << now() << "] Failed to open file " << thePath;
+          ++nOpenErrors;
+          if (nOpenErrors == maxOpenErrors) {
+            std::cout << nOpenErrors << "This is the " << maxOpenErrors
+                      << "th occurence of this error. Report of this error is now disabled.\n";
+          } else {
+            std::cout << "\n";
+          }
+        }
+        uint32_t firstOrb;
+        uint32_t lastOrb;
+        bool goodRange = getOrbitRange(firstOrb, lastOrb);
+        if (goodRange && lastOrb > maxOrb)
+          maxOrb = lastOrb;
+        if (goodRange && firstOrb <= orbitId && orbitId <= lastOrb) {
+          found = true;
+          //continue;
+          fname = thePath;
+          if (verbosity_ > 1)
+            std::cout << "[Matacq " << now() << "] Switching to file " << fname << "\n";
+          break;
+        }
+      }  //next iglob
       globfree(&g);
-    }//next filenames
-  } //next itry
-  
-  if(found){
+    }  //next filenames
+  }    //next itry
+
+  if (found) {
     LogInfo("Matacq") << "Uses matacq data file: '" << fname << "'\n";
-  } else{
-    if(verbosity_>=0) cout << "[Matacq " << now() << "] no matacq file found "
-			"for run " << runNumber << "\n";
+  } else {
+    if (verbosity_ >= 0)
+      cout << "[Matacq " << now()
+           << "] no matacq file found "
+              "for run "
+           << runNumber << "\n";
     eventSkipCounter_ = onErrorDisablingEvtCnt_;
     openedFileRunNumber_ = 0;
-    if(fileChange!=nullptr) *fileChange = false;
+    if (fileChange != nullptr)
+      *fileChange = false;
     return false;
   }
 
-   if(found){
+  if (found) {
     openedFileRunNumber_ = runNumber;
     lastOrb_ = 0;
     posEstim_.init(this);
-    if(fileChange!=nullptr) *fileChange = true;
+    if (fileChange != nullptr)
+      *fileChange = true;
     return true;
-  } else{
+  } else {
     return false;
   }
 }
 
+uint32_t MatacqProducer::getRunNumber(edm::Event& ev) const { return ev.run(); }
 
-uint32_t MatacqProducer::getRunNumber(edm::Event& ev) const{
-  return ev.run();
-}
-
-uint32_t MatacqProducer::getOrbitId(edm::Event& ev) const{
+uint32_t MatacqProducer::getOrbitId(edm::Event& ev) const {
   //on CVS HEAD (June 4, 08), class Event has a method orbitNumber()
   //we could use here. The code would be shorten to:
   //return ev.orbitNumber();
   //we have to deal with what we have in current CMSSW releases:
   edm::Handle<FEDRawDataCollection> rawdata;
   ev.getByToken(inputRawCollectionToken_, rawdata);
-  if(!(rawdata.isValid())){
-    throw cms::Exception("NotFound")
-      << "No FED raw data collection found. ECAL raw data are "
-      "required to retrieve the orbit ID";
+  if (!(rawdata.isValid())) {
+    throw cms::Exception("NotFound") << "No FED raw data collection found. ECAL raw data are "
+                                        "required to retrieve the orbit ID";
   }
-  
+
   int orbit = 0;
-  for(int id=601; id<=654; ++id){
-    if(!FEDNumbering::inRange(id)) continue;
+  for (int id = 601; id <= 654; ++id) {
+    if (!FEDNumbering::inRange(id))
+      continue;
     const FEDRawData& data = rawdata->FEDData(id);
     const int orbitIdOffset64 = 3;
-    if(data.size()>=8*(orbitIdOffset64+1)){//orbit id is in 4th 64-bit word
-      const unsigned char* pOrbit = data.data() + orbitIdOffset64*8;
-      int thisOrbit = pOrbit[0]
-	| (pOrbit[1] <<8)
-	| (pOrbit[2] <<16)
-	| (pOrbit[3] <<24);
-      if(orbit!=0 && thisOrbit!=0 && abs(orbit-thisOrbit)>orbitTolerance_){
-	//throw cms::Exception("EventCorruption")
-	//  << "Orbit ID inconsitency in DCC headers";
-	LogWarning("EventCorruption")
-	  << "Orbit ID inconsitency in DCC headers";
-	orbit = 0;
-	break;
+    if (data.size() >= 8 * (orbitIdOffset64 + 1)) {  //orbit id is in 4th 64-bit word
+      const unsigned char* pOrbit = data.data() + orbitIdOffset64 * 8;
+      int thisOrbit = pOrbit[0] | (pOrbit[1] << 8) | (pOrbit[2] << 16) | (pOrbit[3] << 24);
+      if (orbit != 0 && thisOrbit != 0 && abs(orbit - thisOrbit) > orbitTolerance_) {
+        //throw cms::Exception("EventCorruption")
+        //  << "Orbit ID inconsitency in DCC headers";
+        LogWarning("EventCorruption") << "Orbit ID inconsitency in DCC headers";
+        orbit = 0;
+        break;
       }
-      if(thisOrbit!=0) orbit = thisOrbit;
+      if (thisOrbit != 0)
+        orbit = thisOrbit;
     }
   }
-  
-  if(orbit==0){
+
+  if (orbit == 0) {
     //    throw cms::Exception("NotFound")
     //  << "Failed to retrieve orbit ID of event "<< ev.id();
-    LogWarning("NotFound") << "Failed to retrieve orbit ID of event "
-			   << ev.id();
+    LogWarning("NotFound") << "Failed to retrieve orbit ID of event " << ev.id();
   }
   return orbit;
 }
 
-int MatacqProducer::getCalibTriggerType(edm::Event& ev) const{  
+int MatacqProducer::getCalibTriggerType(edm::Event& ev) const {
   edm::Handle<FEDRawDataCollection> rawdata;
   ev.getByToken(inputRawCollectionToken_, rawdata);
-  if(!(rawdata.isValid())){
-    throw cms::Exception("NotFound")
-      << "No FED raw data collection found. ECAL raw data are "
-      "required to retrieve the trigger type";
+  if (!(rawdata.isValid())) {
+    throw cms::Exception("NotFound") << "No FED raw data collection found. ECAL raw data are "
+                                        "required to retrieve the trigger type";
   }
-  
+
   Majority<int> stat;
-  for(int id=601; id<=654; ++id){
-    if(!FEDNumbering::inRange(id)) continue;
+  for (int id = 601; id <= 654; ++id) {
+    if (!FEDNumbering::inRange(id))
+      continue;
     const FEDRawData& data = rawdata->FEDData(id);
     const int detailedTrigger32 = 5;
-    if(data.size()>=4*(detailedTrigger32+1)){
-      const unsigned char* pTType = data.data() + detailedTrigger32*4;
+    if (data.size() >= 4 * (detailedTrigger32 + 1)) {
+      const unsigned char* pTType = data.data() + detailedTrigger32 * 4;
       int tType = pTType[1] & 0x7;
       stat.add(tType);
     }
   }
   double p;
   int tType = stat.result(&p);
-  if(p<0){
+  if (p < 0) {
     //throw cms::Exception("NotFound") << "No ECAL DCC data found\n";
-    LogWarning("NotFound")  << "No ECAL DCC data found\n";
+    LogWarning("NotFound") << "No ECAL DCC data found\n";
     tType = -1;
   }
-  if(p<.8){
+  if (p < .8) {
     //throw cms::Exception("EventCorruption") << "Inconsitency in detailed trigger type indicated in ECAL DCC data headers\n";
     LogWarning("EventCorruption") << "Inconsitency in detailed trigger type indicated in ECAL DCC data headers\n";
     tType = -1;
   }
   return tType;
 }
-  
-void MatacqProducer::PosEstimator::init(MatacqProducer* mp){
+
+void MatacqProducer::PosEstimator::init(MatacqProducer* mp) {
   mp->mrewind();
 
-  const size_t headerSize = 8*8;
+  const size_t headerSize = 8 * 8;
   unsigned char data[headerSize];
-  if(!mp->mread((char*)data, headerSize)){
-    if(verbosity_) cout << "[Matacq " << now() << "] reached end of file!\n"; 
+  if (!mp->mread((char*)data, headerSize)) {
+    if (verbosity_)
+      cout << "[Matacq " << now() << "] reached end of file!\n";
     firstOrbit_ = eventLength_ = orbitStepMean_ = 0;
     return;
-  } else{
+  } else {
     firstOrbit_ = MatacqRawEvent::getOrbitId(data, headerSize);
     eventLength_ = MatacqRawEvent::getDccLen(data, headerSize);
-    if(verbosity_>1) cout << "[Matacq " << now() << "] First event orbit: " << firstOrbit_
-                          << " event length: " << eventLength_
-                          << "*8 byte\n";
+    if (verbosity_ > 1)
+      cout << "[Matacq " << now() << "] First event orbit: " << firstOrbit_ << " event length: " << eventLength_
+           << "*8 byte\n";
   }
 
   mp->mrewind();
-  
-  if(eventLength_==0){    
-    if(verbosity_) cout << "[Matacq " << now() << "] event length is null!" << endl; 
+
+  if (eventLength_ == 0) {
+    if (verbosity_)
+      cout << "[Matacq " << now() << "] event length is null!" << endl;
     return;
   }
 
@@ -763,82 +753,82 @@ void MatacqProducer::PosEstimator::init(MatacqProducer* mp){
   mp->msize(s);
 
   //number of complete events:
-  const unsigned nEvents = s/eventLength_/8;
+  const unsigned nEvents = s / eventLength_ / 8;
 
-  if(nEvents==0){
-    if(verbosity_) cout << "[Matacq " << now() << "] File is empty!" << endl;
+  if (nEvents == 0) {
+    if (verbosity_)
+      cout << "[Matacq " << now() << "] File is empty!" << endl;
     orbitStepMean_ = 0;
     return;
   }
 
-  if(verbosity_>1) cout << "[Matacq " << now() << "] File size: " << s
-                        << " Number of events: " << nEvents << endl;
-  
+  if (verbosity_ > 1)
+    cout << "[Matacq " << now() << "] File size: " << s << " Number of events: " << nEvents << endl;
+
   //position of last complete events:
-  off_t last = (nEvents-1)*(off_t)eventLength_*8;
-  mp->mseek(last, SEEK_SET, "Moving to beginning of last complete "
-	    "matacq event");
-  if(!mp->mread((char*) data, headerSize, "Reading matacq header", true)){
+  off_t last = (nEvents - 1) * (off_t)eventLength_ * 8;
+  mp->mseek(last,
+            SEEK_SET,
+            "Moving to beginning of last complete "
+            "matacq event");
+  if (!mp->mread((char*)data, headerSize, "Reading matacq header", true)) {
     LogWarning("Matacq") << "Fast matacq event retrieval failure. "
-      "Falling back to safe retrieval mode.";
+                            "Falling back to safe retrieval mode.";
     orbitStepMean_ = 0;
   }
-  
+
   int32_t lastOrb = MatacqRawEvent::getOrbitId(data, headerSize);
   int32_t lastLen = MatacqRawEvent::getDccLen(data, headerSize);
 
-  if(verbosity_>1) cout << "[Matacq " << now() << "] Last event orbit: " << lastOrb
-                        << " last event length: " << lastLen << endl;
-  
+  if (verbosity_ > 1)
+    cout << "[Matacq " << now() << "] Last event orbit: " << lastOrb << " last event length: " << lastLen << endl;
+
   //some consistency check
-  if(lastLen!=eventLength_){
+  if (lastLen != eventLength_) {
     LogWarning("Matacq")
-      //throw cms::Exception("Matacq")
-      << "Fast matacq event retrieval failure: it looks like "
-      "the matacq file contains events of different sizes.";
-      //      " Falling back to safe retrieval mode.";
-    invalid_ = false; //true;
-    orbitStepMean_ = 112; //0;
+        //throw cms::Exception("Matacq")
+        << "Fast matacq event retrieval failure: it looks like "
+           "the matacq file contains events of different sizes.";
+    //      " Falling back to safe retrieval mode.";
+    invalid_ = false;      //true;
+    orbitStepMean_ = 112;  //0;
     return;
   }
 
-  orbitStepMean_ = (lastOrb - firstOrbit_)/nEvents;
-  
-  if(verbosity_>1) cout << "[Matacq " << now() << "] Orbit step mean: " << orbitStepMean_
-                        << "\n";
+  orbitStepMean_ = (lastOrb - firstOrbit_) / nEvents;
+
+  if (verbosity_ > 1)
+    cout << "[Matacq " << now() << "] Orbit step mean: " << orbitStepMean_ << "\n";
 
   invalid_ = false;
 }
 
-int64_t MatacqProducer::PosEstimator::pos(int orb) const{
-  if(orb<firstOrbit_) return -1;
-  uint64_t r = orbitStepMean_!=0?
-    (((uint64_t)(orb-firstOrbit_))/orbitStepMean_)*eventLength_*8
-    :0;
-  if(verbosity_>2) cout << "[Matacq " << now() << "] Estimated Position for orbit  " << orb
-                        << ": " << r << endl;
+int64_t MatacqProducer::PosEstimator::pos(int orb) const {
+  if (orb < firstOrbit_)
+    return -1;
+  uint64_t r = orbitStepMean_ != 0 ? (((uint64_t)(orb - firstOrbit_)) / orbitStepMean_) * eventLength_ * 8 : 0;
+  if (verbosity_ > 2)
+    cout << "[Matacq " << now() << "] Estimated Position for orbit  " << orb << ": " << r << endl;
   return r;
 }
 
-MatacqProducer::~MatacqProducer(){
+MatacqProducer::~MatacqProducer() {
   mclose();
   timeval t;
   gettimeofday(&t, nullptr);
-  if(logTiming_ && startTime_.tv_sec!=0){
+  if (logTiming_ && startTime_.tv_sec != 0) {
     //not using logger, to allow timing with different logging options
-    cout << "[Matacq " << now() << "] Time elapsed between first event and "
-      "destruction of MatacqProducer: "
-	 << ((t.tv_sec-startTime_.tv_sec)*1.
-	     + (t.tv_usec-startTime_.tv_usec)*1.e-6) << "s\n";
+    cout << "[Matacq " << now()
+         << "] Time elapsed between first event and "
+            "destruction of MatacqProducer: "
+         << ((t.tv_sec - startTime_.tv_sec) * 1. + (t.tv_usec - startTime_.tv_usec) * 1.e-6) << "s\n";
   }
 }
 
-void MatacqProducer::loadOrbitOffset(){
+void MatacqProducer::loadOrbitOffset() {
   std::ifstream f(orbitOffsetFile_.c_str());
-  if(f.bad()){
-    throw cms::Exception("Matacq")
-      << "Failed to open orbit ID correction file '"
-      << orbitOffsetFile_ << "'\n";
+  if (f.bad()) {
+    throw cms::Exception("Matacq") << "Failed to open orbit ID correction file '" << orbitOffsetFile_ << "'\n";
   }
 
   cout << "[Matacq " << now() << "] "
@@ -848,10 +838,10 @@ void MatacqProducer::loadOrbitOffset(){
   int iline = 0;
   string s;
   stringstream buf;
-  while(f.eof()){
+  while (f.eof()) {
     getline(f, s);
     ++iline;
-    if(s[0]=='#'){//comment
+    if (s[0] == '#') {  //comment
       //skip line:
       f.ignore(numeric_limits<streamsize>::max(), '\n');
       continue;
@@ -862,10 +852,8 @@ void MatacqProducer::loadOrbitOffset(){
     int orbit;
     buf >> run;
     buf >> orbit;
-    if(buf.bad()){
-      throw cms::Exception("Matacq")
-	<< "Syntax error in Orbit offset file '"
-	<< orbitOffsetFile_ << "'";
+    if (buf.bad()) {
+      throw cms::Exception("Matacq") << "Syntax error in Orbit offset file '" << orbitOffsetFile_ << "'";
     }
     cout << run << "\t" << orbit << "\n";
     orbitOffset_.insert(pair<int, int>(run, orbit));
@@ -873,26 +861,34 @@ void MatacqProducer::loadOrbitOffset(){
 }
 
 #ifdef USE_STORAGE_MANAGER
-bool MatacqProducer::mseek(filepos_t offset, int whence, const char* mess){
-  if(0==inFile_.get()) return false;
-  try{
+bool MatacqProducer::mseek(filepos_t offset, int whence, const char* mess) {
+  if (0 == inFile_.get())
+    return false;
+  try {
     Storage::Relative wh;
-    if(whence==SEEK_SET) wh = Storage::SET;
-    else if(whence==SEEK_CUR) wh = Storage::CURRENT;
-    else if(whence==SEEK_END) wh = Storage::END;
-    else throw cms::Exception("Bug") << "Bug found in "
-                                     << __FILE__ << ": "<< __LINE__ << "\n";
-                   
+    if (whence == SEEK_SET)
+      wh = Storage::SET;
+    else if (whence == SEEK_CUR)
+      wh = Storage::CURRENT;
+    else if (whence == SEEK_END)
+      wh = Storage::END;
+    else
+      throw cms::Exception("Bug") << "Bug found in " << __FILE__ << ": " << __LINE__ << "\n";
+
     inFile_->position(offset, wh);
-  } catch(cms::Exception& e){
-    if(verbosity_){
+  } catch (cms::Exception& e) {
+    if (verbosity_) {
       cout << "[Matacq " << now() << "] ";
-      if(mess) cout << mess << ". ";
+      if (mess)
+        cout << mess << ". ";
       cout << "Random access error on input matacq file. ";
-      if(whence==SEEK_SET) cout << "Failed to seek absolute position " << offset;
-      else if(whence==SEEK_CUR) cout << "Failed to move " << offset << " bytes forward";
-      else if(whence==SEEK_END) cout << "Failed to seek position at " << offset << " bytes before end of file";
-	cout << ". Reopening file. " << e.what() << "\n";
+      if (whence == SEEK_SET)
+        cout << "Failed to seek absolute position " << offset;
+      else if (whence == SEEK_CUR)
+        cout << "Failed to move " << offset << " bytes forward";
+      else if (whence == SEEK_END)
+        cout << "Failed to seek position at " << offset << " bytes before end of file";
+      cout << ". Reopening file. " << e.what() << "\n";
       mopen(inFileName_);
       return false;
     }
@@ -900,73 +896,74 @@ bool MatacqProducer::mseek(filepos_t offset, int whence, const char* mess){
   return true;
 }
 
-bool MatacqProducer::mtell(filepos_t& pos){
-  if(0==inFile_.get()) return false;
+bool MatacqProducer::mtell(filepos_t& pos) {
+  if (0 == inFile_.get())
+    return false;
   pos = inFile_->position();
   return true;
 }
 
-bool MatacqProducer::mread(char* buf, size_t n, const char* mess, bool peek){
-  if(0==inFile_.get()) return false;
-  
+bool MatacqProducer::mread(char* buf, size_t n, const char* mess, bool peek) {
+  if (0 == inFile_.get())
+    return false;
+
   filepos_t pos = -1;
-  if(!mtell(pos)) return false;
+  if (!mtell(pos))
+    return false;
 
   bool rc = false;
-  try{
-    rc =  (n==inFile_->xread(buf, n));
-  } catch(cms::Exception& e){
-    if(verbosity_){
+  try {
+    rc = (n == inFile_->xread(buf, n));
+  } catch (cms::Exception& e) {
+    if (verbosity_) {
       cout << "[Matacq " << now() << "] ";
-      if(mess) cout << mess << ". ";
-      cout << "Read failure from input matacq file: "
-           << e.what() << "\n";
+      if (mess)
+        cout << mess << ". ";
+      cout << "Read failure from input matacq file: " << e.what() << "\n";
     }
     //recovering from error:
     mopen(inFileName_);
     mseek(pos);
     return false;
   }
-  if(peek){//asked to restore original file position
+  if (peek) {  //asked to restore original file position
     mseek(pos);
   }
   return rc;
 }
 
-bool MatacqProducer::msize(filepos_t& s){
-  if(inFile_.get()==0) return false;
+bool MatacqProducer::msize(filepos_t& s) {
+  if (inFile_.get() == 0)
+    return false;
   s = inFile_.get()->size();
   return true;
 }
 
-bool MatacqProducer::mrewind(){
+bool MatacqProducer::mrewind() {
   Storage* file = inFile_.get();
-  if(file==0) return false;
-  try{
+  if (file == 0)
+    return false;
+  try {
     file->rewind();
-  } catch(cms::Exception e){
-    if(verbosity_) cout << "Exception cautgh while rewinding file "
-                        << inFileName_ << ": " << e.what() << ". "
-                        << "File will be reopened.";
+  } catch (cms::Exception e) {
+    if (verbosity_)
+      cout << "Exception cautgh while rewinding file " << inFileName_ << ": " << e.what() << ". "
+           << "File will be reopened.";
     return mopen(inFileName_);
   }
   return true;
 }
 
-bool MatacqProducer::mcheck(const std::string& name){
-  return StorageFactory::get()->check(name);
-}
+bool MatacqProducer::mcheck(const std::string& name) { return StorageFactory::get()->check(name); }
 
-bool MatacqProducer::mopen(const std::string& name){
+bool MatacqProducer::mopen(const std::string& name) {
   //close already opened file if any:
   mclose();
-  
-  try{
-    inFile_
-      = unique_ptr<Storage>(StorageFactory::get()->open(name,
-                                                      IOFlags::OpenRead));
+
+  try {
+    inFile_ = unique_ptr<Storage>(StorageFactory::get()->open(name, IOFlags::OpenRead));
     inFileName_ = name;
-  } catch(cms::Exception& e){
+  } catch (cms::Exception& e) {
     LogWarning("Matacq") << e.what();
     inFile_.reset();
     inFileName_ = "";
@@ -975,62 +972,66 @@ bool MatacqProducer::mopen(const std::string& name){
   return true;
 }
 
-void MatacqProducer::mclose(){
-  if(inFile_.get()!=0){
+void MatacqProducer::mclose() {
+  if (inFile_.get() != 0) {
     inFile_->close();
     inFile_.reset();
   }
 }
 
-bool MatacqProducer::misOpened(){
-  return inFile_.get()!=0;
-}
+bool MatacqProducer::misOpened() { return inFile_.get() != 0; }
 
-bool MatacqProducer::meof(){
-  if(inFile_.get()==0) return true;
+bool MatacqProducer::meof() {
+  if (inFile_.get() == 0)
+    return true;
   return inFile_->eof();
 }
 
-#else //USE_STORAGE_MANAGER not defined
-bool MatacqProducer::mseek(off_t offset, int whence, const char* mess){
-  if(nullptr==inFile_) return false;
+#else  //USE_STORAGE_MANAGER not defined
+bool MatacqProducer::mseek(off_t offset, int whence, const char* mess) {
+  if (nullptr == inFile_)
+    return false;
   const int rc = fseeko(inFile_, offset, whence);
-  if(rc!=0 && verbosity_){
+  if (rc != 0 && verbosity_) {
     cout << "[Matacq " << now() << "] ";
-    if(mess) cout << mess << ". ";
+    if (mess)
+      cout << mess << ". ";
     cout << "Random access error on input matacq file. "
-      "Rewind file.\n";
+            "Rewind file.\n";
     mrewind();
   }
-  return rc==0;
+  return rc == 0;
 }
 
-bool MatacqProducer::mtell(filepos_t& pos){
-  if(nullptr==inFile_) return false;
+bool MatacqProducer::mtell(filepos_t& pos) {
+  if (nullptr == inFile_)
+    return false;
   pos = ftello(inFile_);
   return pos != -1;
-    
 }
 
-bool MatacqProducer::mread(char* buf, size_t n, const char* mess, bool peek){
-  if(nullptr==inFile_) return false;
+bool MatacqProducer::mread(char* buf, size_t n, const char* mess, bool peek) {
+  if (nullptr == inFile_)
+    return false;
   off_t pos = ftello(inFile_);
-  bool rc = (pos!=-1) && (1==fread(buf, n, 1, inFile_));
-  if(!rc){
-    if(verbosity_){
+  bool rc = (pos != -1) && (1 == fread(buf, n, 1, inFile_));
+  if (!rc) {
+    if (verbosity_) {
       cout << "[Matacq " << now() << "] ";
-      if(mess) cout << mess << ". ";
+      if (mess)
+        cout << mess << ". ";
       cout << "Read failure from input matacq file.\n";
     }
     clearerr(inFile_);
   }
-  if(peek || !rc){//need to restore file position
-    if(0!=fseeko(inFile_, pos, SEEK_SET)){
-      if(verbosity_){
-	cout << "[Matacq " << now() << "] ";
-	if(mess) cout << mess << ". ";
-	cout << "Failed to restore file position of "
-	  "before read error. Rewind file.\n";
+  if (peek || !rc) {  //need to restore file position
+    if (0 != fseeko(inFile_, pos, SEEK_SET)) {
+      if (verbosity_) {
+        cout << "[Matacq " << now() << "] ";
+        if (mess)
+          cout << mess << ". ";
+        cout << "Failed to restore file position of "
+                "before read error. Rewind file.\n";
       }
       //rewind(inFile_.get());
       mrewind();
@@ -1040,111 +1041,111 @@ bool MatacqProducer::mread(char* buf, size_t n, const char* mess, bool peek){
   return rc;
 }
 
-bool MatacqProducer::msize(filepos_t& s){
-  if(nullptr==inFile_) return false;
+bool MatacqProducer::msize(filepos_t& s) {
+  if (nullptr == inFile_)
+    return false;
   struct stat buf;
-  if(0!=fstat(fileno(inFile_), &buf)){
+  if (0 != fstat(fileno(inFile_), &buf)) {
     s = 0;
     return false;
-  } else{
+  } else {
     s = buf.st_size;
     return true;
   }
 }
 
-bool MatacqProducer::mrewind(){
-  if(nullptr==inFile_) return false;
+bool MatacqProducer::mrewind() {
+  if (nullptr == inFile_)
+    return false;
   clearerr(inFile_);
-  return fseeko(inFile_, 0, SEEK_SET)!=0; 
+  return fseeko(inFile_, 0, SEEK_SET) != 0;
 }
 
-bool MatacqProducer::mcheck(const std::string& name){
+bool MatacqProducer::mcheck(const std::string& name) {
   struct stat dummy;
-  return 0==stat(name.c_str(), &dummy);
-//   if(stat(name.c_str(), &dummy)==0){
-//     return true;
-//   } else{
-//     cout << "[Matacq " << now() << "] Failed to stat file '"
-// 	 << name.c_str() << "'. " 
-// 	 << "Error " << errno << ": " << strerror(errno) << "\n";
-//     return false;
-//   }
+  return 0 == stat(name.c_str(), &dummy);
+  //   if(stat(name.c_str(), &dummy)==0){
+  //     return true;
+  //   } else{
+  //     cout << "[Matacq " << now() << "] Failed to stat file '"
+  // 	 << name.c_str() << "'. "
+  // 	 << "Error " << errno << ": " << strerror(errno) << "\n";
+  //     return false;
+  //   }
 }
 
-bool MatacqProducer::mopen(const std::string& name){
-  if(inFile_!=nullptr) mclose();
+bool MatacqProducer::mopen(const std::string& name) {
+  if (inFile_ != nullptr)
+    mclose();
   inFile_ = fopen(name.c_str(), "r");
-  if(inFile_!=nullptr){
+  if (inFile_ != nullptr) {
     inFileName_ = name;
     return true;
-  } else{
+  } else {
     inFileName_ = "";
     return false;
   }
 }
 
-void MatacqProducer::mclose(){
-  if(inFile_!=nullptr) fclose(inFile_);
+void MatacqProducer::mclose() {
+  if (inFile_ != nullptr)
+    fclose(inFile_);
   inFile_ = nullptr;
 }
 
-bool MatacqProducer::misOpened(){
-  return inFile_!=nullptr;
+bool MatacqProducer::misOpened() { return inFile_ != nullptr; }
+
+bool MatacqProducer::meof() {
+  if (nullptr == inFile_)
+    return true;
+  return feof(inFile_) == 0;
 }
 
-bool MatacqProducer::meof(){
-  if(nullptr==inFile_) return true;
-  return feof(inFile_)==0;
-}
+#endif  //USE_STORAGE_MANAGER defined
 
-#endif //USE_STORAGE_MANAGER defined
-
-std::string MatacqProducer::runSubDir(uint32_t runNumber){
-  int millions = runNumber / (1000*1000);
-  int thousands = (runNumber-millions*1000*1000) / 1000;
-  int units = runNumber-millions*1000*1000 - thousands*1000;
+std::string MatacqProducer::runSubDir(uint32_t runNumber) {
+  int millions = runNumber / (1000 * 1000);
+  int thousands = (runNumber - millions * 1000 * 1000) / 1000;
+  int units = runNumber - millions * 1000 * 1000 - thousands * 1000;
   return str(boost::format("%03d/%03d/%03d") % millions % thousands % units);
 }
 
-void MatacqProducer::newRun(int prevRun, int newRun){
-    runNumber_ = newRun;
-    eventSkipCounter_ = 0;
-    logFile_ << "[" << now() << "] Event count for run "
-	     << runNumber_ << ": "
-	     << "total: " << stats_.nEvents << ", "
-	     << "Laser event with Matacq data: "
-	     << stats_.nLaserEventsWithMatacq << ", "
-	     << "Non laser event (according to DCC header) with Matacq data: "
-	     << stats_.nNonLaserEventsWithMatacq << "\n" << flush;
+void MatacqProducer::newRun(int prevRun, int newRun) {
+  runNumber_ = newRun;
+  eventSkipCounter_ = 0;
+  logFile_ << "[" << now() << "] Event count for run " << runNumber_ << ": "
+           << "total: " << stats_.nEvents << ", "
+           << "Laser event with Matacq data: " << stats_.nLaserEventsWithMatacq << ", "
+           << "Non laser event (according to DCC header) with Matacq data: " << stats_.nNonLaserEventsWithMatacq << "\n"
+           << flush;
 
-    stats_.nEvents = 0;
-    stats_.nLaserEventsWithMatacq = 0;
-    stats_.nNonLaserEventsWithMatacq = 0;
-
-    
+  stats_.nEvents = 0;
+  stats_.nLaserEventsWithMatacq = 0;
+  stats_.nNonLaserEventsWithMatacq = 0;
 }
 
-bool MatacqProducer::getOrbitRange(uint32_t& firstOrb, uint32_t& lastOrb){
+bool MatacqProducer::getOrbitRange(uint32_t& firstOrb, uint32_t& lastOrb) {
   filepos_t pos = -1;
   filepos_t fsize = -1;
   mtell(pos);
   msize(fsize);
-  const unsigned headerSize = 8*8;
+  const unsigned headerSize = 8 * 8;
   unsigned char header[headerSize];
   //FIXME: Don't we need here to rewind?
   mseek(0);
-  if(!mread((char*)header, headerSize, nullptr, false)) return false;
+  if (!mread((char*)header, headerSize, nullptr, false))
+    return false;
   firstOrb = MatacqRawEvent::getOrbitId(header, headerSize);
   int len = (int)MatacqRawEvent::getDccLen(header, headerSize);
   //number of complete events. If last event is partially written,
   //it won't be included in the count.
-  unsigned nEvts = fsize / (len*64);
+  unsigned nEvts = fsize / (len * 64);
   //Position of last complete event:
   filepos_t lastEvtPos = (nEvts - 1) * len * 64;
   mseek(lastEvtPos);
   mread((char*)header, headerSize, nullptr, false);
   lastOrb = MatacqRawEvent::getOrbitId(header, headerSize);
-  
+
   //restore file position:
   mseek(pos);
 

--- a/EventFilter/EcalRawToDigi/plugins/SealModules.cc
+++ b/EventFilter/EcalRawToDigi/plugins/SealModules.cc
@@ -12,4 +12,3 @@ DEFINE_FWK_MODULE(MatacqProducer);
 
 #include "EventFilter/EcalRawToDigi/interface/EcalDumpRaw.h"
 DEFINE_FWK_MODULE(EcalDumpRaw);
-

--- a/EventFilter/EcalRawToDigi/src/DCCDataBlockPrototype.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCDataBlockPrototype.cc
@@ -1,6 +1,12 @@
 #include "EventFilter/EcalRawToDigi/interface/DCCDataBlockPrototype.h"
 
-
-DCCDataBlockPrototype::DCCDataBlockPrototype ( DCCDataUnpacker  * unp, EcalElectronicsMapper * mapper, DCCEventBlock * event, bool unpackInternalData) 
-: unpacker_(unp), error_(false), mapper_(mapper), event_(event), unpackInternalData_(unpackInternalData), sync_(false)
-{}
+DCCDataBlockPrototype::DCCDataBlockPrototype(DCCDataUnpacker* unp,
+                                             EcalElectronicsMapper* mapper,
+                                             DCCEventBlock* event,
+                                             bool unpackInternalData)
+    : unpacker_(unp),
+      error_(false),
+      mapper_(mapper),
+      event_(event),
+      unpackInternalData_(unpackInternalData),
+      sync_(false) {}

--- a/EventFilter/EcalRawToDigi/src/DCCDataUnpacker.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCDataUnpacker.cc
@@ -8,113 +8,103 @@
 
 std::atomic<bool> DCCDataUnpacker::silentMode_(false);
 
-DCCDataUnpacker::DCCDataUnpacker( 
-  EcalElectronicsMapper * mapper, bool hU, bool srpU, bool tccU, bool feU , bool memU, bool syncCheck, bool feIdCheck, bool forceToKeepFRdata
-){ 
+DCCDataUnpacker::DCCDataUnpacker(EcalElectronicsMapper* mapper,
+                                 bool hU,
+                                 bool srpU,
+                                 bool tccU,
+                                 bool feU,
+                                 bool memU,
+                                 bool syncCheck,
+                                 bool feIdCheck,
+                                 bool forceToKeepFRdata) {
   electronicsMapper_ = mapper;
-  ebEventBlock_   = new DCCEBEventBlock(this,mapper,hU,srpU,tccU,feU,memU,forceToKeepFRdata);
-  eeEventBlock_   = new DCCEEEventBlock(this,mapper,hU,srpU,tccU,feU,memU,forceToKeepFRdata);
-  if(syncCheck){
-    ebEventBlock_->enableSyncChecks();  
+  ebEventBlock_ = new DCCEBEventBlock(this, mapper, hU, srpU, tccU, feU, memU, forceToKeepFRdata);
+  eeEventBlock_ = new DCCEEEventBlock(this, mapper, hU, srpU, tccU, feU, memU, forceToKeepFRdata);
+  if (syncCheck) {
+    ebEventBlock_->enableSyncChecks();
     eeEventBlock_->enableSyncChecks();
   }
-  if(feIdCheck){
-    ebEventBlock_->enableFeIdChecks();  
+  if (feIdCheck) {
+    ebEventBlock_->enableFeIdChecks();
     eeEventBlock_->enableFeIdChecks();
   }
 }
 
-
-void DCCDataUnpacker::unpack(const uint64_t* buffer, size_t bufferSize, unsigned int smId, unsigned int fedId){
+void DCCDataUnpacker::unpack(const uint64_t* buffer, size_t bufferSize, unsigned int smId, unsigned int fedId) {
   //buffer is pointer to binary data
   //See if this fed is on EB or in EE
 
-  if(smId>9&&smId<46){ 
-    
-    currentEvent_      = ebEventBlock_;
-    ebEventBlock_    ->updateCollectors();
-    ebEventBlock_    ->unpack(buffer,bufferSize,fedId); 
-	 
-  }
-  else{               
-   
-    currentEvent_     = eeEventBlock_;
-    eeEventBlock_    ->updateCollectors();
-    eeEventBlock_    ->unpack(buffer,bufferSize,fedId); 
+  if (smId > 9 && smId < 46) {
+    currentEvent_ = ebEventBlock_;
+    ebEventBlock_->updateCollectors();
+    ebEventBlock_->unpack(buffer, bufferSize, fedId);
 
+  } else {
+    currentEvent_ = eeEventBlock_;
+    eeEventBlock_->updateCollectors();
+    eeEventBlock_->unpack(buffer, bufferSize, fedId);
   }
-    
 }
 
-DCCDataUnpacker::~DCCDataUnpacker(){
+DCCDataUnpacker::~DCCDataUnpacker() {
   delete ebEventBlock_;
   delete eeEventBlock_;
 }
 
-uint16_t DCCDataUnpacker::getChannelStatus(const DetId& id) const
-{
+uint16_t DCCDataUnpacker::getChannelStatus(const DetId& id) const {
   // return code for situation of missing channel record
   // equal to "non responding isolated channel (dead of type other)":
   //   https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideEcalRecoLocalReco#Treatment_of_problematic_channel
   // TODO: think on a better way how to cover this case
   const uint16_t NO_DATA = 11;
-  
+
   if (chdb_ == nullptr) {
-    edm::LogError("IncorrectMapping")
-      << "ECAL channel status database do not initialized";
+    edm::LogError("IncorrectMapping") << "ECAL channel status database do not initialized";
     return NO_DATA;
   }
-  
+
   EcalChannelStatus::const_iterator pCh = chdb_->find(id);
-  
+
   if (pCh != chdb_->end()) {
     return pCh->getStatusCode();
-  }
-  else {
-    edm::LogError("IncorrectMapping")
-      << "No channel status record found for detit = " << id.rawId();
+  } else {
+    edm::LogError("IncorrectMapping") << "No channel status record found for detit = " << id.rawId();
     return NO_DATA;
   }
 }
 
-uint16_t DCCDataUnpacker::getChannelValue(const DetId& id) const
-{
-  return getChannelStatus(id) & 0x1F;
-}
+uint16_t DCCDataUnpacker::getChannelValue(const DetId& id) const { return getChannelStatus(id) & 0x1F; }
 
-uint16_t DCCDataUnpacker::getChannelValue(const int fed, const int ccu, const int strip, const int xtal) const
-{
+uint16_t DCCDataUnpacker::getChannelValue(const int fed, const int ccu, const int strip, const int xtal) const {
   // conversion FED ID [601 - 654] -> DCC ID [1 - 54]
   const int dcc = electronicsMapper_->getSMId(fed);
-  
+
   // convert (dcc, ccu, strip, xtal) -> DetId
   const EcalElectronicsId eid(dcc, ccu, strip, xtal);
   const DetId id = electronicsMapper_->mapping()->getDetId(eid);
-  
+
   return getChannelStatus(id) & 0x1F;
 }
 
-uint16_t DCCDataUnpacker::getCCUValue(const int fed, const int ccu) const
-{
+uint16_t DCCDataUnpacker::getCCUValue(const int fed, const int ccu) const {
   // get list of crystals (DetId) which correspond to given CCU
   // (return empty list for MEM channels [CCU > 68])
   const int dcc = electronicsMapper_->getSMId(fed);
   const std::vector<DetId> xtals =
-    (ccu <= 68) ?
-      electronicsMapper_->mapping()->dccTowerConstituents(dcc, ccu) :
-      std::vector<DetId>();
-  
+      (ccu <= 68) ? electronicsMapper_->mapping()->dccTowerConstituents(dcc, ccu) : std::vector<DetId>();
+
   // collect set of status codes of given CCU
   std::set<uint16_t> set;
   for (size_t i = 0; i < xtals.size(); ++i) {
     const uint16_t val = getChannelValue(xtals[i]);
     set.insert(val);
   }
-  
+
   // if all crystals in CCU have the same status
   // then this status is treated as CCU status
-  if (set.size() == 1) return *set.begin();
-  
+  if (set.size() == 1)
+    return *set.begin();
+
   // if there are several or no statuses:
   return 0;
 }

--- a/EventFilter/EcalRawToDigi/src/DCCEBEventBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCEBEventBlock.cc
@@ -4,7 +4,6 @@
 #include "EventFilter/EcalRawToDigi/interface/EcalElectronicsMapper.h"
 #include "EventFilter/EcalRawToDigi/interface/DCCMemBlock.h"
 
-
 #include "EventFilter/EcalRawToDigi/interface/DCCEBEventBlock.h"
 #include "EventFilter/EcalRawToDigi/interface/DCCTowerBlock.h"
 #include "EventFilter/EcalRawToDigi/interface/DCCEBTCCBlock.h"
@@ -14,312 +13,282 @@
 #include <iomanip>
 #include <sstream>
 
-
-DCCEBEventBlock::DCCEBEventBlock( DCCDataUnpacker * u, EcalElectronicsMapper * m , bool hU, bool srpU, bool tccU, bool feU , bool memU, bool forceToKeepFRdata) : 
-  DCCEventBlock(u,m,hU,srpU,tccU,feU,memU,forceToKeepFRdata)
-{
-
+DCCEBEventBlock::DCCEBEventBlock(DCCDataUnpacker* u,
+                                 EcalElectronicsMapper* m,
+                                 bool hU,
+                                 bool srpU,
+                                 bool tccU,
+                                 bool feU,
+                                 bool memU,
+                                 bool forceToKeepFRdata)
+    : DCCEventBlock(u, m, hU, srpU, tccU, feU, memU, forceToKeepFRdata) {
   //Builds a tower unpacker block
-  towerBlock_ = new DCCTowerBlock(u,m,this,feUnpacking_, forceToKeepFRdata_); 
-  
+  towerBlock_ = new DCCTowerBlock(u, m, this, feUnpacking_, forceToKeepFRdata_);
+
   //Builds a srp unpacker block
-  srpBlock_   = new DCCEBSRPBlock(u,m,this,srpUnpacking_);
-  
+  srpBlock_ = new DCCEBSRPBlock(u, m, this, srpUnpacking_);
+
   //Builds a tcc unpacker block
-  tccBlock_   = new DCCEBTCCBlock(u,m,this,tccUnpacking_);
+  tccBlock_ = new DCCEBTCCBlock(u, m, this, tccUnpacking_);
 
   // This field is not used in EB
-  mem_ = 0;    
-  
- 
+  mem_ = 0;
 }
 
-
-
-void DCCEBEventBlock::unpack(const uint64_t * buffer, size_t numbBytes, unsigned int expFedId){
-  
+void DCCEBEventBlock::unpack(const uint64_t* buffer, size_t numbBytes, unsigned int expFedId) {
   reset();
- 
-  eventSize_ = numbBytes;        
-  data_      = buffer;
-  
-  // First Header Word of fed block
-  fedId_             = ((*data_)>>H_FEDID_B)   & H_FEDID_MASK;
-  bx_                = ((*data_)>>H_BX_B   )   & H_BX_MASK;
-  l1_                = ((*data_)>>H_L1_B   )   & H_L1_MASK;
-  triggerType_       = ((*data_)>>H_TTYPE_B)   & H_TTYPE_MASK;
-  
-  // Check if fed id is the same as expected...
-  if( fedId_ != expFedId  ){ 
 
-  if( ! DCCDataUnpacker::silentMode_ ){  
-    edm::LogWarning("IncorrectEvent")
-      <<"\n For event L1A: "<<l1_
-      <<"\n Expected FED id is: "<<expFedId<<" while current FED id is: "<<fedId_
-      <<"\n => Skipping to next fed block...";
+  eventSize_ = numbBytes;
+  data_ = buffer;
+
+  // First Header Word of fed block
+  fedId_ = ((*data_) >> H_FEDID_B) & H_FEDID_MASK;
+  bx_ = ((*data_) >> H_BX_B) & H_BX_MASK;
+  l1_ = ((*data_) >> H_L1_B) & H_L1_MASK;
+  triggerType_ = ((*data_) >> H_TTYPE_B) & H_TTYPE_MASK;
+
+  // Check if fed id is the same as expected...
+  if (fedId_ != expFedId) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectEvent") << "\n For event L1A: " << l1_ << "\n Expected FED id is: " << expFedId
+                                        << " while current FED id is: " << fedId_
+                                        << "\n => Skipping to next fed block...";
     }
-  
-  //TODO : add this to an error event collection
-  
-  return;
-  } 
-  
-  // Check if this event is an empty event 
-  if( eventSize_ == EMPTYEVENTSIZE ){ 
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogWarning("IncorrectEvent")
-        <<"\n Event L1A: "<<l1_<<" is empty for fed: "<<fedId_
-        <<"\n => Skipping to next fed block...";
-    }
+
+    //TODO : add this to an error event collection
+
     return;
-    
-  } 
-  
-  //Check if event size allows at least building the header
-  else if( eventSize_ < HEADERSIZE ){    
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogError("IncorrectEvent")
-        <<"\n Event L1A: "<<l1_<<" in fed: "<< fedId_
-        <<"\n Event size is "<<eventSize_<<" bytes while the minimum is "<<HEADERSIZE<<" bytes"
-        <<"\n => Skipping to next fed block..."; 
-     }
-    
-    //TODO : add this to a dcc size error collection  
-    
-    return;
-    
   }
-  
+
+  // Check if this event is an empty event
+  if (eventSize_ == EMPTYEVENTSIZE) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectEvent") << "\n Event L1A: " << l1_ << " is empty for fed: " << fedId_
+                                        << "\n => Skipping to next fed block...";
+    }
+    return;
+
+  }
+
+  //Check if event size allows at least building the header
+  else if (eventSize_ < HEADERSIZE) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogError("IncorrectEvent") << "\n Event L1A: " << l1_ << " in fed: " << fedId_ << "\n Event size is "
+                                      << eventSize_ << " bytes while the minimum is " << HEADERSIZE << " bytes"
+                                      << "\n => Skipping to next fed block...";
+    }
+
+    //TODO : add this to a dcc size error collection
+
+    return;
+  }
+
   //Second Header Word of fed block
   data_++;
-  
-  blockLength_   =   (*data_ )                 & H_EVLENGTH_MASK;
-  dccErrors_     =   ((*data_)>>H_ERRORS_B)    & H_ERRORS_MASK;
-  runNumber_     =   ((*data_)>>H_RNUMB_B )    & H_RNUMB_MASK;
-  
-  
-  if( eventSize_ != blockLength_*8 ){
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogError("IncorrectEvent")
-        <<"\n Event L1A: "<<l1_<<" in fed: "<< fedId_
-        <<"\n size is "<<eventSize_<<" bytes while "<<(blockLength_*8)<<" are set in the event header "
-        <<"\n => Skipping to next fed block..."; 
-      //TODO : add this to a dcc size error collection 
-     }
+
+  blockLength_ = (*data_) & H_EVLENGTH_MASK;
+  dccErrors_ = ((*data_) >> H_ERRORS_B) & H_ERRORS_MASK;
+  runNumber_ = ((*data_) >> H_RNUMB_B) & H_RNUMB_MASK;
+
+  if (eventSize_ != blockLength_ * 8) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogError("IncorrectEvent") << "\n Event L1A: " << l1_ << " in fed: " << fedId_ << "\n size is " << eventSize_
+                                      << " bytes while " << (blockLength_ * 8) << " are set in the event header "
+                                      << "\n => Skipping to next fed block...";
+      //TODO : add this to a dcc size error collection
+    }
     return;
-    
-  }  
-  
+  }
+
   //Third Header Word  of fed block
   data_++;
 
-
   // bits 0.. 31 of the 3rd DCC header word
-  runType_              = (*data_) & H_RTYPE_MASK;
-  
-  fov_                  = ((*data_)>>H_FOV_B) & H_FOV_MASK;
+  runType_ = (*data_) & H_RTYPE_MASK;
+
+  fov_ = ((*data_) >> H_FOV_B) & H_FOV_MASK;
 
   // bits 32.. 47 of the 3rd DCC header word
   detailedTriggerType_ = ((*data_) >> H_DET_TTYPE_B) & H_DET_TTYPE_MASK;
 
   //Forth Header Word
   data_++;
-  orbitCounter_        = ((*data_)>>H_ORBITCOUNTER_B)  & H_ORBITCOUNTER_MASK;
-  sr_                  = ((*data_)>>H_SR_B)            & B_MASK;
-  zs_                  = ((*data_)>>H_ZS_B)            & B_MASK;
-  tzs_                 = ((*data_)>>H_TZS_B)           & B_MASK;
-  srChStatus_          = ((*data_)>>H_SRCHSTATUS_B)    & H_CHSTATUS_MASK;
-  
+  orbitCounter_ = ((*data_) >> H_ORBITCOUNTER_B) & H_ORBITCOUNTER_MASK;
+  sr_ = ((*data_) >> H_SR_B) & B_MASK;
+  zs_ = ((*data_) >> H_ZS_B) & B_MASK;
+  tzs_ = ((*data_) >> H_TZS_B) & B_MASK;
+  srChStatus_ = ((*data_) >> H_SRCHSTATUS_B) & H_CHSTATUS_MASK;
 
   bool ignoreSR(true);
 
   // getting TCC channel status bits
-  tccChStatus_[0] = ((*data_)>>H_TCC1CHSTATUS_B)   & H_CHSTATUS_MASK; 
-  tccChStatus_[1] = ((*data_)>>H_TCC2CHSTATUS_B)   & H_CHSTATUS_MASK;
-  tccChStatus_[2] = ((*data_)>>H_TCC3CHSTATUS_B)   & H_CHSTATUS_MASK;
-  tccChStatus_[3] = ((*data_)>>H_TCC4CHSTATUS_B)   & H_CHSTATUS_MASK;
-    
+  tccChStatus_[0] = ((*data_) >> H_TCC1CHSTATUS_B) & H_CHSTATUS_MASK;
+  tccChStatus_[1] = ((*data_) >> H_TCC2CHSTATUS_B) & H_CHSTATUS_MASK;
+  tccChStatus_[2] = ((*data_) >> H_TCC3CHSTATUS_B) & H_CHSTATUS_MASK;
+  tccChStatus_[3] = ((*data_) >> H_TCC4CHSTATUS_B) & H_CHSTATUS_MASK;
+
   // FE  channel Status data
   int channel(0);
-  for( int dw = 0; dw<5; dw++ ){
+  for (int dw = 0; dw < 5; dw++) {
     data_++;
-    for( int i = 0; i<14; i++, channel++){
-      unsigned int shift = i*4; //each channel has 4 bits
-      feChStatus_[channel] = ( (*data_)>>shift ) &  H_CHSTATUS_MASK ;
+    for (int i = 0; i < 14; i++, channel++) {
+      unsigned int shift = i * 4;  //each channel has 4 bits
+      feChStatus_[channel] = ((*data_) >> shift) & H_CHSTATUS_MASK;
     }
   }
-   
+
   // debugging
   //display(cout);
-  
+
   // Update number of available dwords
-  dwToEnd_ = blockLength_ - HEADERLENGTH ;
-   
+  dwToEnd_ = blockLength_ - HEADERLENGTH;
+
   int STATUS = unpackTCCBlocks();
 
-  if(  STATUS != STOP_EVENT_UNPACKING && (feUnpacking_ || srpUnpacking_) ){
-    
-    //NMGA note : SR comes before TCC blocks 
+  if (STATUS != STOP_EVENT_UNPACKING && (feUnpacking_ || srpUnpacking_)) {
+    //NMGA note : SR comes before TCC blocks
     // Emmanuelle please change this in the digi to raw
-  
+
     // Unpack SRP block
-    if(srChStatus_ != CH_TIMEOUT &&  srChStatus_ != CH_DISABLED){
-      STATUS = srpBlock_->unpack(&data_,&dwToEnd_,SRP_NUMBFLAGS);
-      if ( STATUS == BLOCK_UNPACKED ){ ignoreSR = false; }
+    if (srChStatus_ != CH_TIMEOUT && srChStatus_ != CH_DISABLED) {
+      STATUS = srpBlock_->unpack(&data_, &dwToEnd_, SRP_NUMBFLAGS);
+      if (STATUS == BLOCK_UNPACKED) {
+        ignoreSR = false;
+      }
     }
-    
   }
 
-
-
-
-
   // See number of FE channels that we need according to the trigger type //
-  // TODO : WHEN IN LOCAL MODE WE SHOULD CHECK RUN TYPE                        
+  // TODO : WHEN IN LOCAL MODE WE SHOULD CHECK RUN TYPE
   unsigned int numbChannels(0);
-  
-  if(       triggerType_ == PHYSICTRIGGER      ){ numbChannels = 68; }
-  else if ( triggerType_ == CALIBRATIONTRIGGER ){ numbChannels = 70; }
-  else {
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogError("IncorrectEvent")
-        <<"\n Event L1A: "<<l1_<<" in fed: "<< fedId_
-        <<"\n Event has an unsupported trigger type "<<triggerType_
-        <<"\n => Skipping to next fed block..."; 
-      //TODO : add this to a dcc trigger type error collection 
+
+  if (triggerType_ == PHYSICTRIGGER) {
+    numbChannels = 68;
+  } else if (triggerType_ == CALIBRATIONTRIGGER) {
+    numbChannels = 70;
+  } else {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogError("IncorrectEvent") << "\n Event L1A: " << l1_ << " in fed: " << fedId_
+                                      << "\n Event has an unsupported trigger type " << triggerType_
+                                      << "\n => Skipping to next fed block...";
+      //TODO : add this to a dcc trigger type error collection
     }
     return;
   }
-  
+
   // note: there is no a-priori check that number_active_channels_from_header
   //          equals number_channels_found_in_data.
   //          The checks are doing f.e. by f.e. only.
-  
-  if( feUnpacking_ || memUnpacking_ ){
+
+  if (feUnpacking_ || memUnpacking_) {
     // pointer for the
     std::vector<short>::iterator it = feChStatus_.begin();
-    
+
     // fields for tower recovery code
     unsigned int next_tower_id = 1000;
     const uint64_t* next_data = data_;
     unsigned int next_dwToEnd = dwToEnd_;
-    
+
     // looping over FE channels, i.e. tower blocks
-    for (unsigned int chNumber=1; chNumber<= numbChannels && STATUS!=STOP_EVENT_UNPACKING; chNumber++, it++ ){
-      //for( unsigned int i=1; chNumber<= numbChannels; chNumber++, it++ ){                        
+    for (unsigned int chNumber = 1; chNumber <= numbChannels && STATUS != STOP_EVENT_UNPACKING; chNumber++, it++) {
+      //for( unsigned int i=1; chNumber<= numbChannels; chNumber++, it++ ){
 
       const short chStatus(*it);
-      
+
       // regular cases
-      const bool regular = (chStatus == CH_DISABLED ||
-                            chStatus == CH_SUPPRESS);
-      
+      const bool regular = (chStatus == CH_DISABLED || chStatus == CH_SUPPRESS);
+
       // problematic cases
-      const bool problematic = (chStatus == CH_TIMEOUT ||
-                                chStatus == CH_HEADERERR ||
-                                chStatus == CH_LINKERR ||
-                                chStatus == CH_LENGTHERR ||
-                                chStatus == CH_IFIFOFULL ||
-                                chStatus == CH_L1AIFIFOFULL);
-      
+      const bool problematic = (chStatus == CH_TIMEOUT || chStatus == CH_HEADERERR || chStatus == CH_LINKERR ||
+                                chStatus == CH_LENGTHERR || chStatus == CH_IFIFOFULL || chStatus == CH_L1AIFIFOFULL);
+
       // issuiung messages for problematic cases, even though handled by the DCC
       if (problematic) {
-        if (! DCCDataUnpacker::silentMode_ ) {
+        if (!DCCDataUnpacker::silentMode_) {
           const int val = unpacker_->getCCUValue(fedId_, chNumber);
           const bool ttProblem = (val == 13) || (val == 14);
-          if (! ttProblem) {
-            edm::LogWarning("IncorrectBlock")
-              << "Bad DCC channel status: " << chStatus
-              << " (LV1 " << l1_ << " fed " << fedId_ << " tower " << chNumber << ")\n"
-              << "  => DCC channel is not being unpacked";
+          if (!ttProblem) {
+            edm::LogWarning("IncorrectBlock") << "Bad DCC channel status: " << chStatus << " (LV1 " << l1_ << " fed "
+                                              << fedId_ << " tower " << chNumber << ")\n"
+                                              << "  => DCC channel is not being unpacked";
           }
         }
       }
-      
+
       // skip unpack in case of bad status
       if (regular || problematic) {
         continue;
       }
-      
+
       // preserve data pointer
       const uint64_t* const prev_data = data_;
       const unsigned int prev_dwToEnd = dwToEnd_;
-      
+
       // skip corrupted/problematic data block
       if (chNumber >= next_tower_id) {
         data_ = next_data;
         dwToEnd_ = next_dwToEnd;
         next_tower_id = 1000;
       }
-      
-      
+
       // Unpack Tower (Xtal Block)
       if (feUnpacking_ && chNumber <= 68) {
-        
         //  in case of SR (data are 0 suppressed)
         if (sr_) {
-          const bool applyZS =
-            (fov_ == 0) ||      // backward compatibility with FOV = 0;
-            ignoreSR ||
-            (chStatus == CH_FORCEDZS1) ||
-            ((srpBlock_->srFlag(chNumber) & SRP_SRVAL_MASK) != SRP_FULLREADOUT);
-          
+          const bool applyZS = (fov_ == 0) ||  // backward compatibility with FOV = 0;
+                               ignoreSR || (chStatus == CH_FORCEDZS1) ||
+                               ((srpBlock_->srFlag(chNumber) & SRP_SRVAL_MASK) != SRP_FULLREADOUT);
+
           STATUS = towerBlock_->unpack(&data_, &dwToEnd_, applyZS, chNumber);
-          
-              // If there is an action to suppress SR channel the associated channel status should be updated 
-              // so we can remove this piece of code
-              // if ( ( srpBlock_->srFlag(chNumber) & SRP_SRVAL_MASK) != SRP_NREAD ){
-              //
-              //  STATUS = towerBlock_->unpack(&data_,&dwToEnd_,applyZS,chNumber);
-              //}
+
+          // If there is an action to suppress SR channel the associated channel status should be updated
+          // so we can remove this piece of code
+          // if ( ( srpBlock_->srFlag(chNumber) & SRP_SRVAL_MASK) != SRP_NREAD ){
+          //
+          //  STATUS = towerBlock_->unpack(&data_,&dwToEnd_,applyZS,chNumber);
+          //}
         }
         // no SR (possibly 0 suppression flags)
         else {
           // if tzs_ data are not really suppressed, even though zs flags are calculated
-          if(tzs_){ zs_ = false;}
-          STATUS = towerBlock_->unpack(&data_,&dwToEnd_,zs_,chNumber);
+          if (tzs_) {
+            zs_ = false;
+          }
+          STATUS = towerBlock_->unpack(&data_, &dwToEnd_, zs_, chNumber);
         }
       }
-      
-      
+
       // Unpack Mem blocks
       if (memUnpacking_ && chNumber > 68) {
-          STATUS = memBlock_->unpack(&data_,&dwToEnd_,chNumber);
+        STATUS = memBlock_->unpack(&data_, &dwToEnd_, chNumber);
       }
-      
-      
+
       // corruption recovery
       if (STATUS == SKIP_BLOCK_UNPACKING) {
         data_ = prev_data;
         dwToEnd_ = prev_dwToEnd;
-        
+
         next_tower_id = next_tower_search(chNumber);
-        
+
         next_data = data_;
         next_dwToEnd = dwToEnd_;
-        
+
         data_ = prev_data;
         dwToEnd_ = prev_dwToEnd;
       }
-      
     }
     // closing loop over FE/TTblock channels
-    
-  }// check if we need to perform unpacking of FE or mem data
-  
-  
-  if(headerUnpacking_) addHeaderToCollection();
-  
-  
+
+  }  // check if we need to perform unpacking of FE or mem data
+
+  if (headerUnpacking_)
+    addHeaderToCollection();
 }
 
-
-
- // Unpack TCC blocks
-int DCCEBEventBlock::unpackTCCBlocks(){
-
-    if(tccChStatus_[0] != CH_TIMEOUT && tccChStatus_[0] != CH_DISABLED)
-      return tccBlock_->unpack(&data_,&dwToEnd_,0);
-    else return BLOCK_UNPACKED;
-
+// Unpack TCC blocks
+int DCCEBEventBlock::unpackTCCBlocks() {
+  if (tccChStatus_[0] != CH_TIMEOUT && tccChStatus_[0] != CH_DISABLED)
+    return tccBlock_->unpack(&data_, &dwToEnd_, 0);
+  else
+    return BLOCK_UNPACKED;
 }

--- a/EventFilter/EcalRawToDigi/src/DCCEBSRPBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCEBSRPBlock.cc
@@ -4,82 +4,64 @@
 #include "EventFilter/EcalRawToDigi/interface/DCCDataUnpacker.h"
 #include "EventFilter/EcalRawToDigi/interface/EcalElectronicsMapper.h"
 
-
-
-DCCEBSRPBlock::DCCEBSRPBlock(
-  DCCDataUnpacker * u,EcalElectronicsMapper * m, DCCEventBlock * e, bool unpack
-) : DCCSRPBlock(u,m,e,unpack)
-{
-  
+DCCEBSRPBlock::DCCEBSRPBlock(DCCDataUnpacker *u, EcalElectronicsMapper *m, DCCEventBlock *e, bool unpack)
+    : DCCSRPBlock(u, m, e, unpack) {
   expNumbSrFlags_ = SRP_EB_NUMBFLAGS;
-  
 }
 
-
-void DCCEBSRPBlock::updateCollectors(){
- // Set SR flag digis
-  ebSrFlagsDigis_ = unpacker_->ebSrFlagsCollection(); 
+void DCCEBSRPBlock::updateCollectors() {
+  // Set SR flag digis
+  ebSrFlagsDigis_ = unpacker_->ebSrFlagsCollection();
 }
 
-
-void DCCEBSRPBlock::addSRFlagToCollection(){
-  
-  // Point to SR flags 
+void DCCEBSRPBlock::addSRFlagToCollection() {
+  // Point to SR flags
   data_++;
-  const uint16_t * my16Bitp_ = reinterpret_cast<const uint16_t *> (data_);
-  
+  const uint16_t *my16Bitp_ = reinterpret_cast<const uint16_t *>(data_);
+
   unsigned int towersInPhi = EcalElectronicsMapper::kTowersInPhi;
 
   unsigned int fov = event_->fov();
 
+  for (unsigned int n = 0; n < expNumbSrFlags_; n++) {
+    if (n > 0 && n % 4 == 0)
+      my16Bitp_++;
 
-  for( unsigned int n=0; n<expNumbSrFlags_ ; n++ ){
-    
-    if(n>0&&n%4==0) my16Bitp_++;
-   
-    unsigned short  srFlag =  ( *my16Bitp_ >> ( (n-(n/4)*4) * 3 ) )  &  SRP_SRFLAG_MASK ;
+    unsigned short srFlag = (*my16Bitp_ >> ((n - (n / 4) * 4) * 3)) & SRP_SRFLAG_MASK;
 
-    unsigned int theSRPi = n ;
+    unsigned int theSRPi = n;
 
-
-    if(NUMB_SM_EB_PLU_MIN<= mapper_->getActiveSM() && mapper_->getActiveSM()<=NUMB_SM_EB_PLU_MAX && fov>=1 ){
-      unsigned int u   = n%towersInPhi;
-      u        = towersInPhi-u;
-      theSRPi  = ( n/towersInPhi )*towersInPhi + u - 1;
+    if (NUMB_SM_EB_PLU_MIN <= mapper_->getActiveSM() && mapper_->getActiveSM() <= NUMB_SM_EB_PLU_MAX && fov >= 1) {
+      unsigned int u = n % towersInPhi;
+      u = towersInPhi - u;
+      theSRPi = (n / towersInPhi) * towersInPhi + u - 1;
     }
 
-    
     srFlags_[theSRPi] = srFlag;
 
-    if(unpackInternalData_){  
-    
-      std::vector<EcalSrFlag*> srs = mapper_->getSrFlagPointer(theSRPi+1);
+    if (unpackInternalData_) {
+      std::vector<EcalSrFlag *> srs = mapper_->getSrFlagPointer(theSRPi + 1);
 
-      for(size_t i = 0; i < srs.size(); ++i){
-	srs[i]->setValue(srFlag); 
-	(*ebSrFlagsDigis_)->push_back(*((EBSrFlag*)srs[i]));
-      } 
+      for (size_t i = 0; i < srs.size(); ++i) {
+        srs[i]->setValue(srFlag);
+        (*ebSrFlagsDigis_)->push_back(*((EBSrFlag *)srs[i]));
+      }
     }
-  } 
+  }
 }
 
-
-
-bool DCCEBSRPBlock::checkSrpIdAndNumbSRFlags(){
-
-   //todo : check srp id based on sm...
+bool DCCEBSRPBlock::checkSrpIdAndNumbSRFlags() {
+  //todo : check srp id based on sm...
 
   // Check number of SR flags
   if (nSRFlags_ != expNumbSrFlags_) {
-    if (! DCCDataUnpacker::silentMode_) {
-      edm::LogWarning("IncorrectBlock")
-        <<"Unable to unpack SRP block for event " << event_->l1A()<<" in fed <<"<<mapper_->getActiveDCC()
-        <<"\nNumber of flags "<<nSRFlags_<<" is different from expected "<<expNumbSrFlags_;
-     }
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectBlock") << "Unable to unpack SRP block for event " << event_->l1A() << " in fed <<"
+                                        << mapper_->getActiveDCC() << "\nNumber of flags " << nSRFlags_
+                                        << " is different from expected " << expNumbSrFlags_;
+    }
     //Note : add to error collection ?
     return false;
   }
   return true;
-
-} 
-
+}

--- a/EventFilter/EcalRawToDigi/src/DCCEBTCCBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCEBTCCBlock.cc
@@ -3,79 +3,61 @@
 #include "EventFilter/EcalRawToDigi/interface/EcalElectronicsMapper.h"
 #include "EventFilter/EcalRawToDigi/interface/DCCDataUnpacker.h"
 
-DCCEBTCCBlock::DCCEBTCCBlock ( DCCDataUnpacker  * u,  EcalElectronicsMapper * m, DCCEventBlock * e, bool unpack) 
-: DCCTCCBlock(u,m,e,unpack)
-{
+DCCEBTCCBlock::DCCEBTCCBlock(DCCDataUnpacker* u, EcalElectronicsMapper* m, DCCEventBlock* e, bool unpack)
+    : DCCTCCBlock(u, m, e, unpack) {
   blockLength_ = mapper_->getEBTCCBlockLength();
-  expNumbTTs_  = TCC_EB_NUMBTTS;
+  expNumbTTs_ = TCC_EB_NUMBTTS;
 }
 
-void DCCEBTCCBlock::updateCollectors(){
-  tps_ = unpacker_->ecalTpsCollection();
-}
+void DCCEBTCCBlock::updateCollectors() { tps_ = unpacker_->ecalTpsCollection(); }
 
-bool DCCEBTCCBlock::checkTccIdAndNumbTTs(){
+bool DCCEBTCCBlock::checkTccIdAndNumbTTs() {
+  expTccId_ = mapper_->getActiveSM() + TCCID_SMID_SHIFT_EB;
 
-  expTccId_ = mapper_->getActiveSM()+TCCID_SMID_SHIFT_EB;
-
-  if( tccId_ != expTccId_ ){
-
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogWarning("IncorrectBlock")
-        <<"Error on event "<<event_->l1A()<<" with bx "<<event_->bx()<<" in fed "<<mapper_->getActiveDCC()
-        <<"\n TCC id is "<<tccId_<<" while expected is "<<expTccId_
-        <<"\n TCC Block Skipped ...";  
-         //todo : add this to error colection
-     }
-     return false;
+  if (tccId_ != expTccId_) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectBlock") << "Error on event " << event_->l1A() << " with bx " << event_->bx()
+                                        << " in fed " << mapper_->getActiveDCC() << "\n TCC id is " << tccId_
+                                        << " while expected is " << expTccId_ << "\n TCC Block Skipped ...";
+      //todo : add this to error colection
+    }
+    return false;
   }
-  
+
   //Check number of TT Flags
-  if( nTTs_ != expNumbTTs_ ){
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogWarning("IncorrectBlock")
-       <<"Unable to unpack TCC block for event "<<event_->l1A()<<" in fed "<<mapper_->getActiveDCC()
-       <<"\n Number of TTs "<<nTTs_<<" is different from expected "<<expNumbTTs_
-       <<"\n TCC Block Skipped ..."; 
-         //todo : add this to error colection
-     }
-     return false;
-  }  
+  if (nTTs_ != expNumbTTs_) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectBlock") << "Unable to unpack TCC block for event " << event_->l1A() << " in fed "
+                                        << mapper_->getActiveDCC() << "\n Number of TTs " << nTTs_
+                                        << " is different from expected " << expNumbTTs_ << "\n TCC Block Skipped ...";
+      //todo : add this to error colection
+    }
+    return false;
+  }
   return true;
 }
 
-
-void DCCEBTCCBlock::addTriggerPrimitivesToCollection(){
-
+void DCCEBTCCBlock::addTriggerPrimitivesToCollection() {
   //point to trigger data
   data_++;
 
   unsigned int towersInPhi = EcalElectronicsMapper::kTowersInPhi;
-  
-  const uint16_t * tccP_= reinterpret_cast<const uint16_t * >(data_);
- 
 
-  for( unsigned int i = 1; i <= expNumbTTs_; i++){
+  const uint16_t* tccP_ = reinterpret_cast<const uint16_t*>(data_);
 
+  for (unsigned int i = 1; i <= expNumbTTs_; i++) {
     unsigned int theTT = i;
 
-    if(NUMB_SM_EB_PLU_MIN<= mapper_->getActiveSM() && mapper_->getActiveSM()<=NUMB_SM_EB_PLU_MAX)
-    {
-        unsigned int u = (i-1)%towersInPhi;
-        u      = towersInPhi-u;
-        theTT  = ( (i-1)/towersInPhi )*towersInPhi + u;
+    if (NUMB_SM_EB_PLU_MIN <= mapper_->getActiveSM() && mapper_->getActiveSM() <= NUMB_SM_EB_PLU_MAX) {
+      unsigned int u = (i - 1) % towersInPhi;
+      u = towersInPhi - u;
+      theTT = ((i - 1) / towersInPhi) * towersInPhi + u;
     }
-   
-    pTP_ =  mapper_->getTPPointer(tccId_,theTT);
-    for(unsigned int ns = 0; ns<nTSamples_;ns++,tccP_++){
-      
+
+    pTP_ = mapper_->getTPPointer(tccId_, theTT);
+    for (unsigned int ns = 0; ns < nTSamples_; ns++, tccP_++) {
       pTP_->setSampleValue(ns, (*tccP_));
       (*tps_)->push_back(*pTP_);
-                  
     }
   }
-
-
 }
-
-

--- a/EventFilter/EcalRawToDigi/src/DCCEEEventBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCEEEventBlock.cc
@@ -3,7 +3,6 @@
 #include "EventFilter/EcalRawToDigi/interface/EcalElectronicsMapper.h"
 #include "EventFilter/EcalRawToDigi/interface/DCCMemBlock.h"
 
-
 #include "EventFilter/EcalRawToDigi/interface/DCCEEEventBlock.h"
 #include "EventFilter/EcalRawToDigi/interface/DCCFEBlock.h"
 #include "EventFilter/EcalRawToDigi/interface/DCCSCBlock.h"
@@ -14,315 +13,294 @@
 #include <iomanip>
 #include <sstream>
 
-
-DCCEEEventBlock::DCCEEEventBlock( DCCDataUnpacker * u,EcalElectronicsMapper * m, bool hU, bool srpU, bool tccU, bool feU, bool memU, bool forceToKeepFRdata) : 
-  DCCEventBlock(u,m,hU,srpU,tccU,feU,memU,forceToKeepFRdata) 
-{
-  
+DCCEEEventBlock::DCCEEEventBlock(DCCDataUnpacker* u,
+                                 EcalElectronicsMapper* m,
+                                 bool hU,
+                                 bool srpU,
+                                 bool tccU,
+                                 bool feU,
+                                 bool memU,
+                                 bool forceToKeepFRdata)
+    : DCCEventBlock(u, m, hU, srpU, tccU, feU, memU, forceToKeepFRdata) {
   //Builds a tower unpacker block
-  towerBlock_ = new DCCSCBlock(u,m,this,feUnpacking_,forceToKeepFRdata_); 
-  
+  towerBlock_ = new DCCSCBlock(u, m, this, feUnpacking_, forceToKeepFRdata_);
+
   //Builds a srp unpacker block
-  srpBlock_   = new DCCEESRPBlock(u,m,this,srpUnpacking_);
-  
+  srpBlock_ = new DCCEESRPBlock(u, m, this, srpUnpacking_);
+
   //Builds a tcc unpacker block
-  tccBlock_   = new DCCEETCCBlock(u,m,this,tccUnpacking_);
-  
- 
+  tccBlock_ = new DCCEETCCBlock(u, m, this, tccUnpacking_);
 }
 
-
-
-void DCCEEEventBlock::unpack(const uint64_t * buffer, size_t numbBytes, unsigned int expFedId){
-  
+void DCCEEEventBlock::unpack(const uint64_t* buffer, size_t numbBytes, unsigned int expFedId) {
   reset();
-  
-  eventSize_ = numbBytes;        
-  data_      = buffer;
-  
-  // First Header Word of fed block
-  fedId_             = ((*data_)>>H_FEDID_B)   & H_FEDID_MASK;
-  bx_                = ((*data_)>>H_BX_B   )   & H_BX_MASK;
-  l1_                = ((*data_)>>H_L1_B   )   & H_L1_MASK;
-  triggerType_       = ((*data_)>>H_TTYPE_B)   & H_TTYPE_MASK;
-  
-  // Check if fed id is the same as expected...
-  if( fedId_ != expFedId  ){ 
 
-  if( ! DCCDataUnpacker::silentMode_ ){  
-    edm::LogWarning("IncorrectEvent")
-      <<"\n For event L1A: "<<l1_
-      <<"\n Expected FED id is: "<<expFedId<<" while current FED id is: "<<fedId_
-      <<"\n => Skipping to next fed block...";
+  eventSize_ = numbBytes;
+  data_ = buffer;
+
+  // First Header Word of fed block
+  fedId_ = ((*data_) >> H_FEDID_B) & H_FEDID_MASK;
+  bx_ = ((*data_) >> H_BX_B) & H_BX_MASK;
+  l1_ = ((*data_) >> H_L1_B) & H_L1_MASK;
+  triggerType_ = ((*data_) >> H_TTYPE_B) & H_TTYPE_MASK;
+
+  // Check if fed id is the same as expected...
+  if (fedId_ != expFedId) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectEvent") << "\n For event L1A: " << l1_ << "\n Expected FED id is: " << expFedId
+                                        << " while current FED id is: " << fedId_
+                                        << "\n => Skipping to next fed block...";
     }
-  
-  //TODO : add this to an error event collection
-  
-  return;
-  } 
-  
-  // Check if this event is an empty event 
-  if( eventSize_ == EMPTYEVENTSIZE ){ 
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogWarning("IncorrectEvent")
-        <<"\n Event L1A: "<<l1_<<" is empty for fed: "<<fedId_
-        <<"\n => Skipping to next fed block...";
-    }
+
+    //TODO : add this to an error event collection
+
     return;
-    
-  } 
-  
-  //Check if event size allows at least building the header
-  else if( eventSize_ < HEADERSIZE ){    
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogError("IncorrectEvent")
-        <<"\n Event L1A: "<<l1_<<" in fed: "<< fedId_
-        <<"\n Event size is "<<eventSize_<<" bytes while the minimum is "<<HEADERSIZE<<" bytes"
-        <<"\n => Skipping to next fed block..."; 
-     }
-    
-    //TODO : add this to a dcc size error collection  
-    
-    return;
-    
   }
-  
+
+  // Check if this event is an empty event
+  if (eventSize_ == EMPTYEVENTSIZE) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectEvent") << "\n Event L1A: " << l1_ << " is empty for fed: " << fedId_
+                                        << "\n => Skipping to next fed block...";
+    }
+    return;
+
+  }
+
+  //Check if event size allows at least building the header
+  else if (eventSize_ < HEADERSIZE) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogError("IncorrectEvent") << "\n Event L1A: " << l1_ << " in fed: " << fedId_ << "\n Event size is "
+                                      << eventSize_ << " bytes while the minimum is " << HEADERSIZE << " bytes"
+                                      << "\n => Skipping to next fed block...";
+    }
+
+    //TODO : add this to a dcc size error collection
+
+    return;
+  }
+
   //Second Header Word of fed block
   data_++;
-  
-  blockLength_   =   (*data_ )                 & H_EVLENGTH_MASK;
-  dccErrors_     =   ((*data_)>>H_ERRORS_B)    & H_ERRORS_MASK;
-  runNumber_     =   ((*data_)>>H_RNUMB_B )    & H_RNUMB_MASK;
-  
-  
-  if( eventSize_ != blockLength_*8 ){
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogError("IncorrectEvent")
-        <<"\n Event L1A: "<<l1_<<" in fed: "<< fedId_
-        <<"\n size is "<<eventSize_<<" bytes while "<<(blockLength_*8)<<" are set in the event header "
-        <<"\n => Skipping to next fed block..."; 
-      //TODO : add this to a dcc size error collection 
-     }
+
+  blockLength_ = (*data_) & H_EVLENGTH_MASK;
+  dccErrors_ = ((*data_) >> H_ERRORS_B) & H_ERRORS_MASK;
+  runNumber_ = ((*data_) >> H_RNUMB_B) & H_RNUMB_MASK;
+
+  if (eventSize_ != blockLength_ * 8) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogError("IncorrectEvent") << "\n Event L1A: " << l1_ << " in fed: " << fedId_ << "\n size is " << eventSize_
+                                      << " bytes while " << (blockLength_ * 8) << " are set in the event header "
+                                      << "\n => Skipping to next fed block...";
+      //TODO : add this to a dcc size error collection
+    }
     return;
-    
-  }  
-  
+  }
+
   //Third Header Word  of fed block
   data_++;
 
   // bits 0.. 31 of the 3rd DCC header word
-  runType_              = (*data_) & H_RTYPE_MASK;
-  
-  fov_                  = ((*data_)>>H_FOV_B) & H_FOV_MASK;
+  runType_ = (*data_) & H_RTYPE_MASK;
+
+  fov_ = ((*data_) >> H_FOV_B) & H_FOV_MASK;
 
   // bits 32.. 47 of the 3rd DCC header word
   detailedTriggerType_ = ((*data_) >> H_DET_TTYPE_B) & H_DET_TTYPE_MASK;
 
   //Forth Header Word
   data_++;
-  orbitCounter_        = ((*data_)>>H_ORBITCOUNTER_B)  & H_ORBITCOUNTER_MASK;
-  sr_                  = ((*data_)>>H_SR_B)            & B_MASK;
-  zs_                  = ((*data_)>>H_ZS_B)            & B_MASK;
-  tzs_                 = ((*data_)>>H_TZS_B)           & B_MASK;
+  orbitCounter_ = ((*data_) >> H_ORBITCOUNTER_B) & H_ORBITCOUNTER_MASK;
+  sr_ = ((*data_) >> H_SR_B) & B_MASK;
+  zs_ = ((*data_) >> H_ZS_B) & B_MASK;
+  tzs_ = ((*data_) >> H_TZS_B) & B_MASK;
 
-  // MEM (forces readout of MEM channels if enabled)is only used in the EE DCCs and for FOV >1 
-  mem_  = ((*data_)>>H_MEM_B) & B_MASK;
-  if( fov_ < 2) { mem_ = 0;}
-  
+  // MEM (forces readout of MEM channels if enabled)is only used in the EE DCCs and for FOV >1
+  mem_ = ((*data_) >> H_MEM_B) & B_MASK;
+  if (fov_ < 2) {
+    mem_ = 0;
+  }
 
   bool ignoreSR(true);
-  
-  srChStatus_          = ((*data_)>>H_SRCHSTATUS_B)    & H_CHSTATUS_MASK;
-  
+
+  srChStatus_ = ((*data_) >> H_SRCHSTATUS_B) & H_CHSTATUS_MASK;
+
   // getting TCC channel status bits
-  tccChStatus_[0] = ((*data_)>>H_TCC1CHSTATUS_B)   & H_CHSTATUS_MASK; 
-  tccChStatus_[1] = ((*data_)>>H_TCC2CHSTATUS_B)   & H_CHSTATUS_MASK;
-  tccChStatus_[2] = ((*data_)>>H_TCC3CHSTATUS_B)   & H_CHSTATUS_MASK;
-  tccChStatus_[3] = ((*data_)>>H_TCC4CHSTATUS_B)   & H_CHSTATUS_MASK;
-    
+  tccChStatus_[0] = ((*data_) >> H_TCC1CHSTATUS_B) & H_CHSTATUS_MASK;
+  tccChStatus_[1] = ((*data_) >> H_TCC2CHSTATUS_B) & H_CHSTATUS_MASK;
+  tccChStatus_[2] = ((*data_) >> H_TCC3CHSTATUS_B) & H_CHSTATUS_MASK;
+  tccChStatus_[3] = ((*data_) >> H_TCC4CHSTATUS_B) & H_CHSTATUS_MASK;
+
   // FE  channel Status data
   int channel(0);
-  for( int dw = 0; dw<5; dw++ ){
+  for (int dw = 0; dw < 5; dw++) {
     data_++;
-    for( int i = 0; i<14; i++, channel++){
-      unsigned int shift = i*4; //each channel has 4 bits
-      feChStatus_[channel] = ( (*data_)>>shift ) &  H_CHSTATUS_MASK ;
+    for (int i = 0; i < 14; i++, channel++) {
+      unsigned int shift = i * 4;  //each channel has 4 bits
+      feChStatus_[channel] = ((*data_) >> shift) & H_CHSTATUS_MASK;
     }
   }
-   
+
   // debugging
   //display(cout);
-  
-  
-  // pointer for the 
+
+  // pointer for the
   std::vector<short>::iterator it;
-  
+
   // Update number of available dwords
-  dwToEnd_ = blockLength_ - HEADERLENGTH ;
-   
+  dwToEnd_ = blockLength_ - HEADERLENGTH;
+
   int STATUS = unpackTCCBlocks();
 
-  if(  STATUS != STOP_EVENT_UNPACKING && (feUnpacking_ || srpUnpacking_) ){
-    
-    //NMGA note : SR comes before TCC blocks 
+  if (STATUS != STOP_EVENT_UNPACKING && (feUnpacking_ || srpUnpacking_)) {
+    //NMGA note : SR comes before TCC blocks
     // Emmanuelle please change this in the digi to raw
-  
+
     // Unpack SRP block
-    if(srChStatus_ != CH_TIMEOUT &&  srChStatus_ != CH_DISABLED){
-      STATUS = srpBlock_->unpack(&data_,&dwToEnd_,SRP_NUMBFLAGS);
-      if ( STATUS == BLOCK_UNPACKED ){ ignoreSR = false; }
+    if (srChStatus_ != CH_TIMEOUT && srChStatus_ != CH_DISABLED) {
+      STATUS = srpBlock_->unpack(&data_, &dwToEnd_, SRP_NUMBFLAGS);
+      if (STATUS == BLOCK_UNPACKED) {
+        ignoreSR = false;
+      }
     }
   }
 
   // See number of FE channels that we need according to the trigger type //
-  // TODO : WHEN IN LOCAL MODE WE SHOULD CHECK RUN TYPE                        
+  // TODO : WHEN IN LOCAL MODE WE SHOULD CHECK RUN TYPE
   unsigned int numbChannels(0);
-  
-  if(       triggerType_ == PHYSICTRIGGER      ){ numbChannels = 68; }
-  else if ( triggerType_ == CALIBRATIONTRIGGER ){ numbChannels = 70; }
-  else {
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogError("IncorrectEvent")
-        <<"\n Event L1A: "<<l1_<<" in fed: "<< fedId_
-        <<"\n Event has an unsupported trigger type "<<triggerType_
-        <<"\n => Skipping to next fed block..."; 
-      //TODO : add this to a dcc trigger type error collection 
+
+  if (triggerType_ == PHYSICTRIGGER) {
+    numbChannels = 68;
+  } else if (triggerType_ == CALIBRATIONTRIGGER) {
+    numbChannels = 70;
+  } else {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogError("IncorrectEvent") << "\n Event L1A: " << l1_ << " in fed: " << fedId_
+                                      << "\n Event has an unsupported trigger type " << triggerType_
+                                      << "\n => Skipping to next fed block...";
+      //TODO : add this to a dcc trigger type error collection
     }
     return;
   }
-  
+
   // note: there is no a-priori check that number_active_channels_from_header
   //          equals number_channels_found_in_data.
   //          The checks are doing f.e. by f.e. only.
-  
-  if( feUnpacking_ || memUnpacking_ ){                                                      
+
+  if (feUnpacking_ || memUnpacking_) {
     it = feChStatus_.begin();
-    
+
     // fields for tower recovery code
     unsigned int next_tower_id = 1000;
     const uint64_t* next_data = data_;
     unsigned int next_dwToEnd = dwToEnd_;
-    
+
     // looping over FE channels, i.e. tower blocks
-    for( unsigned int chNumber=1; chNumber<= numbChannels && STATUS!=STOP_EVENT_UNPACKING; chNumber++, it++ ){                        
-      //for( unsigned int i=1; chNumber<= numbChannels; chNumber++, it++ ){                        
-      
+    for (unsigned int chNumber = 1; chNumber <= numbChannels && STATUS != STOP_EVENT_UNPACKING; chNumber++, it++) {
+      //for( unsigned int i=1; chNumber<= numbChannels; chNumber++, it++ ){
+
       const short chStatus(*it);
-      
+
       // skip unpacking if channel disabled
       if (chStatus == CH_DISABLED) {
         continue;
       }
-      
+
       // force MEM readout if mem_ is enabled in EEs regardless on ch suppress status flag
-      if (chStatus == CH_SUPPRESS && !mem_ ) {
+      if (chStatus == CH_SUPPRESS && !mem_) {
         continue;
       }
-      
+
       // issuiung messages for problematic cases, even though handled by the DCC
       // and skip channel
-      if (chStatus == CH_TIMEOUT || chStatus == CH_HEADERERR ||
-          chStatus == CH_LINKERR || chStatus == CH_LENGTHERR ||
-          chStatus == CH_IFIFOFULL || chStatus == CH_L1AIFIFOFULL)
-      {
-        if (! DCCDataUnpacker::silentMode_) {
+      if (chStatus == CH_TIMEOUT || chStatus == CH_HEADERERR || chStatus == CH_LINKERR || chStatus == CH_LENGTHERR ||
+          chStatus == CH_IFIFOFULL || chStatus == CH_L1AIFIFOFULL) {
+        if (!DCCDataUnpacker::silentMode_) {
           const int val = unpacker_->getCCUValue(fedId_, chNumber);
           const bool ttProblem = (val == 13) || (val == 14);
-          if (! ttProblem) {
+          if (!ttProblem) {
             edm::LogWarning("IncorrectBlock")
-              << "Bad channel status: " << chStatus
-              << " in the DCC channel: " << chNumber
-              << " (LV1 " << l1_ << " fed " << fedId_ << ")\n"
-              << "  => DCC channel is not being unpacked";
+                << "Bad channel status: " << chStatus << " in the DCC channel: " << chNumber << " (LV1 " << l1_
+                << " fed " << fedId_ << ")\n"
+                << "  => DCC channel is not being unpacked";
           }
         }
         continue;
       }
-      
+
       // preserve data pointer
       const uint64_t* const prev_data = data_;
       const unsigned int prev_dwToEnd = dwToEnd_;
-      
+
       // skip corrupted/problematic data block
       if (chNumber >= next_tower_id) {
         data_ = next_data;
         dwToEnd_ = next_dwToEnd;
         next_tower_id = 1000;
       }
-      
-      
+
       // Unpack Tower (Xtal Block)
       if (feUnpacking_ && chNumber <= 68) {
-        
         //  in case of SR (data are 0 suppressed)
         if (sr_) {
-          const bool applyZS =
-            (fov_ == 0) ||      // backward compatibility with FOV = 0;
-            ignoreSR ||
-            (chStatus == CH_FORCEDZS1) ||
-            ((srpBlock_->srFlag(chNumber) & SRP_SRVAL_MASK) != SRP_FULLREADOUT);
-            
-          STATUS = towerBlock_->unpack(&data_,&dwToEnd_,applyZS,chNumber);
+          const bool applyZS = (fov_ == 0) ||  // backward compatibility with FOV = 0;
+                               ignoreSR || (chStatus == CH_FORCEDZS1) ||
+                               ((srpBlock_->srFlag(chNumber) & SRP_SRVAL_MASK) != SRP_FULLREADOUT);
 
-            // If there is a decision to fully suppress data this is updated in channel status by the dcc
-            //if ( ( srpBlock_->srFlag(chNumber) & SRP_SRVAL_MASK) != SRP_NREAD ){
-            //    STATUS = towerBlock_->unpack(&data_,&dwToEnd_,applyZS,chNumber);
-            //}
+          STATUS = towerBlock_->unpack(&data_, &dwToEnd_, applyZS, chNumber);
+
+          // If there is a decision to fully suppress data this is updated in channel status by the dcc
+          //if ( ( srpBlock_->srFlag(chNumber) & SRP_SRVAL_MASK) != SRP_NREAD ){
+          //    STATUS = towerBlock_->unpack(&data_,&dwToEnd_,applyZS,chNumber);
+          //}
         }
         // no SR (possibly 0 suppression flags)
         else {
           // if tzs_ data are not really suppressed, even though zs flags are calculated
-          if(tzs_){ zs_ = false;}
-          STATUS = towerBlock_->unpack(&data_,&dwToEnd_,zs_,chNumber);
+          if (tzs_) {
+            zs_ = false;
+          }
+          STATUS = towerBlock_->unpack(&data_, &dwToEnd_, zs_, chNumber);
         }
       }
-      
+
       // Unpack Mem blocks
-      if(memUnpacking_        && chNumber>68 )
-        {
-          STATUS = memBlock_->unpack(&data_,&dwToEnd_,chNumber);
-        }
-      
-      
+      if (memUnpacking_ && chNumber > 68) {
+        STATUS = memBlock_->unpack(&data_, &dwToEnd_, chNumber);
+      }
+
       // corruption recovery
       if (STATUS == SKIP_BLOCK_UNPACKING) {
         data_ = prev_data;
         dwToEnd_ = prev_dwToEnd;
-        
+
         next_tower_id = next_tower_search(chNumber);
-        
+
         next_data = data_;
         next_dwToEnd = dwToEnd_;
-        
+
         data_ = prev_data;
         dwToEnd_ = prev_dwToEnd;
       }
-      
     }
     // closing loop over FE/TTblock channels
-    
-  }// check if we need to perform unpacking of FE or mem data
-  
-  
-  if(headerUnpacking_) addHeaderToCollection();
-  
+
+  }  // check if we need to perform unpacking of FE or mem data
+
+  if (headerUnpacking_)
+    addHeaderToCollection();
 }
 
-
-
-
-int DCCEEEventBlock::unpackTCCBlocks(){
-
+int DCCEEEventBlock::unpackTCCBlocks() {
   int STATUS(BLOCK_UNPACKED);
   std::vector<short>::iterator it;
   unsigned int tccChId(0);
-  for(it=tccChStatus_.begin();it!=tccChStatus_.end();it++, tccChId++){
-    if( (*it) != CH_TIMEOUT &&  (*it) != CH_DISABLED){
-      STATUS = tccBlock_->unpack(&data_,&dwToEnd_,tccChId);
-          if(STATUS == STOP_EVENT_UNPACKING) break;
+  for (it = tccChStatus_.begin(); it != tccChStatus_.end(); it++, tccChId++) {
+    if ((*it) != CH_TIMEOUT && (*it) != CH_DISABLED) {
+      STATUS = tccBlock_->unpack(&data_, &dwToEnd_, tccChId);
+      if (STATUS == STOP_EVENT_UNPACKING)
+        break;
     }
   }
   return STATUS;
-  
 }
-

--- a/EventFilter/EcalRawToDigi/src/DCCEESRPBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCEESRPBlock.cc
@@ -3,51 +3,42 @@
 #include "EventFilter/EcalRawToDigi/interface/DCCDataUnpacker.h"
 #include "EventFilter/EcalRawToDigi/interface/EcalElectronicsMapper.h"
 
+DCCEESRPBlock::DCCEESRPBlock(DCCDataUnpacker *u, EcalElectronicsMapper *m, DCCEventBlock *e, bool unpack)
+    : DCCSRPBlock(u, m, e, unpack) {}
 
-
-DCCEESRPBlock::DCCEESRPBlock( DCCDataUnpacker * u,EcalElectronicsMapper * m, DCCEventBlock * e, bool unpack ) : 
-DCCSRPBlock(u,m,e,unpack)
-{}
-
-
-void DCCEESRPBlock::updateCollectors(){
+void DCCEESRPBlock::updateCollectors() {
   // Set SR flag digis
-  eeSrFlagsDigis_ = unpacker_->eeSrFlagsCollection(); 
+  eeSrFlagsDigis_ = unpacker_->eeSrFlagsCollection();
 }
 
-
-void DCCEESRPBlock::addSRFlagToCollection(){
-  
-  // Point to SR flags 
+void DCCEESRPBlock::addSRFlagToCollection() {
+  // Point to SR flags
   data_++;
-  const uint16_t * my16Bitp_ = reinterpret_cast<const uint16_t *> (data_);
+  const uint16_t *my16Bitp_ = reinterpret_cast<const uint16_t *>(data_);
 
-  
-  for( unsigned int n=0; n<expNumbSrFlags_ ;n++,pSCDetId_++ ){
-   
-    if( n!=0 && n%4==0 ) my16Bitp_++;
- 
-     unsigned short srFlag =  ( *my16Bitp_ >> ( (n-(n/4)*4) * 3 ) )  &  SRP_SRFLAG_MASK ;
-     srFlags_[n] = srFlag;
-     if(unpackInternalData_){
-       std::vector<EcalSrFlag*> srs = mapper_->getSrFlagPointer(n+1);
-       for(size_t i = 0; i < srs.size(); ++i){
-         srs[i]->setValue(srFlag); 
-         (*eeSrFlagsDigis_)->push_back(*((EESrFlag*)srs[i]));
-       } 
-     }  
+  for (unsigned int n = 0; n < expNumbSrFlags_; n++, pSCDetId_++) {
+    if (n != 0 && n % 4 == 0)
+      my16Bitp_++;
+
+    unsigned short srFlag = (*my16Bitp_ >> ((n - (n / 4) * 4) * 3)) & SRP_SRFLAG_MASK;
+    srFlags_[n] = srFlag;
+    if (unpackInternalData_) {
+      std::vector<EcalSrFlag *> srs = mapper_->getSrFlagPointer(n + 1);
+      for (size_t i = 0; i < srs.size(); ++i) {
+        srs[i]->setValue(srFlag);
+        (*eeSrFlagsDigis_)->push_back(*((EESrFlag *)srs[i]));
+      }
+    }
   }
 }
 
-bool DCCEESRPBlock::checkSrpIdAndNumbSRFlags(){
-
-  expNumbSrFlags_=36;//to be corrected
+bool DCCEESRPBlock::checkSrpIdAndNumbSRFlags() {
+  expNumbSrFlags_ = 36;  //to be corrected
 
   int dccId = mapper_->getActiveDCC() - 600;
-  if (dccId == SECTOR_EEM_CCU_JUMP || dccId == SECTOR_EEP_CCU_JUMP) expNumbSrFlags_ = 41;
+  if (dccId == SECTOR_EEM_CCU_JUMP || dccId == SECTOR_EEP_CCU_JUMP)
+    expNumbSrFlags_ = 41;
 
   //todo :  checks to be implemented...
   return true;
-
-} 
-
+}

--- a/EventFilter/EcalRawToDigi/src/DCCEETCCBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCEETCCBlock.cc
@@ -3,197 +3,199 @@
 #include "EventFilter/EcalRawToDigi/interface/EcalElectronicsMapper.h"
 #include "EventFilter/EcalRawToDigi/interface/DCCDataUnpacker.h"
 
-
-DCCEETCCBlock::DCCEETCCBlock ( DCCDataUnpacker  * u,EcalElectronicsMapper * m, DCCEventBlock * e, bool unpack) : 
-DCCTCCBlock(u,m,e,unpack)
-{
-   blockLength_ = 0;
-  
+DCCEETCCBlock::DCCEETCCBlock(DCCDataUnpacker* u, EcalElectronicsMapper* m, DCCEventBlock* e, bool unpack)
+    : DCCTCCBlock(u, m, e, unpack) {
+  blockLength_ = 0;
 }
 
-void DCCEETCCBlock::updateCollectors(){
+void DCCEETCCBlock::updateCollectors() {
   tps_ = unpacker_->ecalTpsCollection();
   pss_ = unpacker_->ecalPSsCollection();
 }
 
-void DCCEETCCBlock::addTriggerPrimitivesToCollection(){
-  
+void DCCEETCCBlock::addTriggerPrimitivesToCollection() {
   //point to trigger data
   data_++;
 
-  bool processTPG2(true) ;
+  bool processTPG2(true);
   unsigned int psInputCounter(0);
-  
-  const uint16_t * tccP_= reinterpret_cast<const uint16_t * >(data_);
-  
-  
-  int dccFOV =  event_->fov();
-  if (! (dccFOV==dcc_FOV_0 || dccFOV==dcc_FOV_1 || dccFOV==dcc_FOV_2) ){
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogWarning("IncorrectEvent") 
-        <<"\n FOV value in data is: " << dccFOV <<
-        "At event: "  <<event_->l1A()<<" with bx "<<event_->bx()<<" in fed <<"<<mapper_->getActiveDCC()
-        <<"\n TCC id "<<tccId_<<" FOV "<< dccFOV << " which is not a foreseen value. Setting it to: " << dcc_FOV_2;
-    }
-    dccFOV=dcc_FOV_2;
-  }
-  
-  
-  /////////////////////////
-  // MC raw data based on CMS NOTE 2005/021 
-  // (and raw data when FOV was unassigned, earlier than mid 2008)   
-    if (dccFOV == dcc_FOV_0)
-      {
 
-        // Unpack TPG1 pseudostrip input block
-        if(ps_){ 
-          for(unsigned int i = 1; i<= NUMB_PSEUDOSTRIPS; i++, tccP_++, psInputCounter++){
-            pPS_= mapper_->getPSInputDigiPointer(tccId_,psInputCounter);
-            if(!pPS_) continue;
-            pPS_->setSampleValue(0, *tccP_ );
-            (*pss_)->push_back(*pPS_);
-          }
+  const uint16_t* tccP_ = reinterpret_cast<const uint16_t*>(data_);
+
+  int dccFOV = event_->fov();
+  if (!(dccFOV == dcc_FOV_0 || dccFOV == dcc_FOV_1 || dccFOV == dcc_FOV_2)) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectEvent") << "\n FOV value in data is: " << dccFOV << "At event: " << event_->l1A()
+                                        << " with bx " << event_->bx() << " in fed <<" << mapper_->getActiveDCC()
+                                        << "\n TCC id " << tccId_ << " FOV " << dccFOV
+                                        << " which is not a foreseen value. Setting it to: " << dcc_FOV_2;
+    }
+    dccFOV = dcc_FOV_2;
+  }
+
+  /////////////////////////
+  // MC raw data based on CMS NOTE 2005/021
+  // (and raw data when FOV was unassigned, earlier than mid 2008)
+  if (dccFOV == dcc_FOV_0) {
+    // Unpack TPG1 pseudostrip input block
+    if (ps_) {
+      for (unsigned int i = 1; i <= NUMB_PSEUDOSTRIPS; i++, tccP_++, psInputCounter++) {
+        pPS_ = mapper_->getPSInputDigiPointer(tccId_, psInputCounter);
+        if (!pPS_)
+          continue;
+        pPS_->setSampleValue(0, *tccP_);
+        (*pss_)->push_back(*pPS_);
+      }
+    }
+
+    // Unpack TPG1 trigger primitive block
+    // loop over tp_counter=i and navigate forward in raw (tccP_)
+    for (unsigned int i = 1; i <= NUMB_TTS_TPG1; i++, tccP_++) {  //16
+
+      if (i <= nTTs_) {
+        pTP_ = mapper_->getTPPointer(tccId_, i);  // pointer to tp digi container
+        if (pTP_)
+          pTP_->setSample(0, *tccP_);  // fill it
+      } else {
+        processTPG2 = false;
+        break;
+      }
+      // adding trigger primitive digi to the collection
+      if (pTP_)
+        (*tps_)->push_back(*pTP_);
+      else
+        edm::LogError("IncorrectBlock") << "trigger primitive digi was not aquired";
+    }
+
+    if (processTPG2) {
+      // Unpack TPG2 pseudostrip input block
+      if (ps_) {
+        for (unsigned int i = 1; i <= NUMB_PSEUDOSTRIPS; i++, tccP_++, psInputCounter++) {
+          if (i <= NUMB_TTS_TPG2_DUPL)
+            continue;
+          //fill pseudostrip container
+          pPS_ = mapper_->getPSInputDigiPointer(tccId_, psInputCounter);
+          if (!pPS_)
+            continue;
+          pPS_->setSampleValue(0, *tccP_);
+          (*pss_)->push_back(*pPS_);
         }
-  
-        // Unpack TPG1 trigger primitive block
-        // loop over tp_counter=i and navigate forward in raw (tccP_)
-        for(unsigned int i = 1; i<= NUMB_TTS_TPG1; i++, tccP_++){//16
-          
-          if( i<= nTTs_){
-            pTP_ = mapper_->getTPPointer(tccId_,i);  // pointer to tp digi container
-            if(pTP_) pTP_->setSample(0, *tccP_ );    // fill it
-          }else {
-            processTPG2 = false;
-            break;
-          }
-          // adding trigger primitive digi to the collection
-          if (pTP_) (*tps_)->push_back(*pTP_);
-          else edm::LogError("IncorrectBlock")<<"trigger primitive digi was not aquired";
+      }
+
+      // Unpack TPG2 trigger primitive block
+      for (unsigned int i = 1; i <= NUMB_TTS_TPG2; i++, tccP_++) {  //12
+        unsigned int tt = i + NUMB_TTS_TPG1;
+
+        if (tt <= nTTs_) {
+          pTP_ = mapper_->getTPPointer(tccId_, tt);
+          if (pTP_)
+            pTP_->setSample(0, *tccP_);
+        } else
+          break;
+        // adding trigger primitive digi to the collection
+        (*tps_)->push_back(*pTP_);
+      }
+
+    }  // end if(processTPG2)
+
+  }  // end FOV==0
+
+  ///////////////////////////
+  // real data since ever FOV was initialized; only 2 used >= June 09
+  else if (dccFOV == dcc_FOV_1 || dccFOV == dcc_FOV_2) {
+    // Unpack TPG1 pseudostrip input block
+    if (ps_) {
+      for (unsigned int i = 1; i <= NUMB_PSEUDOSTRIPS; i++, tccP_++, psInputCounter++) {
+        pPS_ = mapper_->getPSInputDigiPointer(tccId_, psInputCounter);
+        if (!pPS_)
+          continue;
+        pPS_->setSampleValue(0, *tccP_);
+        (*pss_)->push_back(*pPS_);
+      }
+    }
+
+    int offset(0);
+    // Unpack TPG1 trigger primitive block
+    // loop over tp_counter=i and navigate forward in raw (tccP_)
+    for (unsigned int i = 1; i <= NUMB_TTS_TPG1; i++, tccP_++) {  //16
+
+      if (i <= nTTs_) {
+        if (mapper_->isTCCExternal(tccId_)) {
+          if (i > 8 && i <= 16)
+            continue;  // skip blank tp's [9,16]
+          if (i > 8)
+            offset = 8;  //
+          if (i > 24)
+            continue;  // skip blank tp's [25, 28]
         }
-        
-        
-        if(processTPG2){
-          
-          // Unpack TPG2 pseudostrip input block
-          if(ps_){ 
-            for(unsigned int i = 1; i<= NUMB_PSEUDOSTRIPS; i++, tccP_++, psInputCounter++){
-              if (i<=NUMB_TTS_TPG2_DUPL) continue;
-              //fill pseudostrip container
-              pPS_= mapper_->getPSInputDigiPointer(tccId_,psInputCounter);
-              if(!pPS_) continue;
-              pPS_->setSampleValue(0, *tccP_ );
-              (*pss_)->push_back(*pPS_);
-            }
-          }
-          
-          
-          // Unpack TPG2 trigger primitive block
-          for(unsigned int i = 1; i<= NUMB_TTS_TPG2; i++, tccP_++){//12
-            unsigned int tt = i+NUMB_TTS_TPG1;
-            
-            if( tt <= nTTs_){
-              pTP_ = mapper_->getTPPointer(tccId_,tt);
-              if(pTP_) pTP_->setSample(0, *tccP_ ); 
-            }
-            else break;
-            // adding trigger primitive digi to the collection
-            (*tps_)->push_back(*pTP_);
-          }
-          
-        }// end if(processTPG2)
-        
-      }// end FOV==0
-    
-    ///////////////////////////
-      // real data since ever FOV was initialized; only 2 used >= June 09  
-    else if (dccFOV == dcc_FOV_1  || dccFOV == dcc_FOV_2) 
-      {
-        
-        // Unpack TPG1 pseudostrip input block
-        if(ps_){ 
-          for(unsigned int i = 1; i<= NUMB_PSEUDOSTRIPS; i++, tccP_++, psInputCounter++){
-            pPS_= mapper_->getPSInputDigiPointer(tccId_,psInputCounter);
-            if(!pPS_) continue;
-            pPS_->setSampleValue(0, *tccP_ );
-            (*pss_)->push_back(*pPS_);
-          }
+
+        pTP_ = mapper_->getTPPointer(tccId_, i - offset);  // pointer to tp digi container
+        if (pTP_)
+          pTP_->setSample(0, *tccP_);  // fill it
+
+      } else {
+        processTPG2 = false;
+        break;
+      }
+      // adding trigger primitive digi to the collection
+      if (pTP_)
+        (*tps_)->push_back(*pTP_);
+      else
+        edm::LogError("IncorrectBlock") << "trigger primitive digi was not aquired";
+    }
+
+    if (processTPG2) {
+      // Unpack TPG2 pseudostrip input block
+      if (ps_) {
+        for (unsigned int i = 1; i <= NUMB_PSEUDOSTRIPS; i++, tccP_++, psInputCounter++) {
+          if (i <= NUMB_TTS_TPG2_DUPL)
+            continue;
+          //fill pseudostrip container
+          pPS_ = mapper_->getPSInputDigiPointer(tccId_, psInputCounter);
+          if (!pPS_)
+            continue;
+          pPS_->setSampleValue(0, *tccP_);
+          (*pss_)->push_back(*pPS_);
         }
-        
-        int offset(0);
-        // Unpack TPG1 trigger primitive block
-        // loop over tp_counter=i and navigate forward in raw (tccP_)
-        for(unsigned int i = 1; i<= NUMB_TTS_TPG1; i++, tccP_++){//16
-          
-          if( i<= nTTs_){
-            if(mapper_->isTCCExternal(tccId_)){
-              if(i>8 && i<=16 ) continue;   // skip blank tp's [9,16]
-              if(i>8  )         offset=8;   // 
-              if(i>24 )         continue;   // skip blank tp's [25, 28]
-            }
-            
-            pTP_ = mapper_->getTPPointer(tccId_,i-offset);  // pointer to tp digi container
-            if(pTP_) pTP_->setSample(0, *tccP_ );    // fill it
-            
-          }else {
-            processTPG2 = false;
-            break;
+      }
+
+      // Unpack TPG2 trigger primitive block
+      for (unsigned int i = 1; i <= NUMB_TTS_TPG2; i++, tccP_++) {  //12
+        unsigned int tt = i + NUMB_TTS_TPG1;
+
+        if (i <= nTTs_) {
+          if (mapper_->isTCCExternal(tccId_)) {
+            if (tt > 8 && tt <= 16)
+              continue;  // skip blank tp's [9,16]
+            if (tt > 8)
+              offset = 8;  //
+            if (tt > 24)
+              continue;  // skip blank tp's [25, 28]
           }
-          // adding trigger primitive digi to the collection
-          if (pTP_) (*tps_)->push_back(*pTP_);
-          else edm::LogError("IncorrectBlock")<<"trigger primitive digi was not aquired";
-        }
-        
-        if(processTPG2){
-          
-          // Unpack TPG2 pseudostrip input block
-          if(ps_){ 
-            for(unsigned int i = 1; i<= NUMB_PSEUDOSTRIPS; i++, tccP_++, psInputCounter++){
-              if (i<=NUMB_TTS_TPG2_DUPL) continue;
-              //fill pseudostrip container
-              pPS_= mapper_->getPSInputDigiPointer(tccId_,psInputCounter);
-              if(!pPS_) continue;
-              pPS_->setSampleValue(0, *tccP_ );
-              (*pss_)->push_back(*pPS_);
-            }
-          }
-          
-          
-          // Unpack TPG2 trigger primitive block
-          for(unsigned int i = 1; i<= NUMB_TTS_TPG2; i++, tccP_++){//12
-            unsigned int tt = i+NUMB_TTS_TPG1;
-            
-            if( i<= nTTs_){
-              if(mapper_->isTCCExternal(tccId_)){
-                if(tt>8 && tt<=16 ) continue;   // skip blank tp's [9,16]
-                if(tt>8  )          offset=8;    // 
-                if(tt>24 )          continue;    // skip blank tp's [25, 28]
-              }
-              
-              pTP_ = mapper_->getTPPointer(tccId_,tt-offset);
-              if(pTP_) pTP_->setSample(0, *tccP_ ); 
-            }
-            else break;
-            // adding trigger primitive digi to the collection
-            (*tps_)->push_back(*pTP_);
-          }
-        }// end if(processTPG2)
-      }// end FOV==1 or 2
+
+          pTP_ = mapper_->getTPPointer(tccId_, tt - offset);
+          if (pTP_)
+            pTP_->setSample(0, *tccP_);
+        } else
+          break;
+        // adding trigger primitive digi to the collection
+        (*tps_)->push_back(*pTP_);
+      }
+    }  // end if(processTPG2)
+  }    // end FOV==1 or 2
 }
 
-
-bool DCCEETCCBlock::checkTccIdAndNumbTTs(){
-  
-        
+bool DCCEETCCBlock::checkTccIdAndNumbTTs() {
   bool tccFound(false);
   bool errorOnNumbOfTTs(false);
-  const int  activeDCC =  mapper_->getActiveSM();
-  std::vector<unsigned int> * m = mapper_->getTccs(activeDCC);
+  const int activeDCC = mapper_->getActiveSM();
+  std::vector<unsigned int>* m = mapper_->getTccs(activeDCC);
   std::vector<unsigned int>::iterator it;
-  for(it= m->begin();it!=m->end();it++){
-    if((*it) == tccId_){
-      tccFound=true;
-     
-          /*
+  for (it = m->begin(); it != m->end(); it++) {
+    if ((*it) == tccId_) {
+      tccFound = true;
+
+      /*
             expNumbTTs_= 28; //separate from inner and outer tcc 
             For inner TCCs you expect 28 TTs (4 in phi, 7 in eta).
             For outer TCCs you expect 16 TTs (4 in phi, 4 in eta).
@@ -206,52 +208,47 @@ bool DCCEETCCBlock::checkTccIdAndNumbTTs(){
             - [25, 28] are empty ie should be skipped by unpacker 
           */
 
-          if( nTTs_ != 28 && nTTs_ !=16 ){
-            if( ! DCCDataUnpacker::silentMode_ ){
-          edm::LogWarning("IncorrectBlock") 
-            <<"Error on event "<<event_->l1A()<<" with bx "<<event_->bx()<<" in fed <<"<<mapper_->getActiveDCC()
-           <<"\n TCC id "<<tccId_<<" has "<<nTTs_<<" Trigger Towers (only 28 or 16 are the expected values in EE)"
-           <<"\n => Skipping to next fed block...";
-          errorOnNumbOfTTs = true; 
-          //todo : add to error collection   
-            }
-          }
+      if (nTTs_ != 28 && nTTs_ != 16) {
+        if (!DCCDataUnpacker::silentMode_) {
+          edm::LogWarning("IncorrectBlock")
+              << "Error on event " << event_->l1A() << " with bx " << event_->bx() << " in fed <<"
+              << mapper_->getActiveDCC() << "\n TCC id " << tccId_ << " has " << nTTs_
+              << " Trigger Towers (only 28 or 16 are the expected values in EE)"
+              << "\n => Skipping to next fed block...";
+          errorOnNumbOfTTs = true;
+          //todo : add to error collection
+        }
+      }
     }
   }
-        
-  if(!tccFound){
 
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogWarning("IncorrectBlock") 
-        <<"Error on event "<<event_->l1A()<<" with bx "<<event_->bx()<<" in fed <<"<<mapper_->getActiveDCC()
-        <<"\n TCC id "<<tccId_<<" is not valid for this dcc "
-        <<"\n => Skipping to next fed block...";
-       //todo : add to error collection   
-     }
+  if (!tccFound) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectBlock") << "Error on event " << event_->l1A() << " with bx " << event_->bx()
+                                        << " in fed <<" << mapper_->getActiveDCC() << "\n TCC id " << tccId_
+                                        << " is not valid for this dcc "
+                                        << "\n => Skipping to next fed block...";
+      //todo : add to error collection
+    }
   }
-  
 
- return (tccFound || errorOnNumbOfTTs);
-
+  return (tccFound || errorOnNumbOfTTs);
 }
 
-
-unsigned int DCCEETCCBlock::getLength(){
-
-  const uint64_t * temp = data_;
+unsigned int DCCEETCCBlock::getLength() {
+  const uint64_t* temp = data_;
   temp++;
 
-  ps_       = ( *temp>>TCC_PS_B ) & B_MASK;   
-   
+  ps_ = (*temp >> TCC_PS_B) & B_MASK;
+
   unsigned int numbTps = (NUMB_TTS_TPG1 + NUMB_TTS_TPG2);
-  if(ps_){ numbTps += 2*NUMB_PSEUDOSTRIPS;}
-  
-  unsigned int length = numbTps/4 + 2; //header and trailer
-  if(numbTps%4) length++ ;
-  
-  
+  if (ps_) {
+    numbTps += 2 * NUMB_PSEUDOSTRIPS;
+  }
+
+  unsigned int length = numbTps / 4 + 2;  //header and trailer
+  if (numbTps % 4)
+    length++;
+
   return length;
-
 }
-
-

--- a/EventFilter/EcalRawToDigi/src/DCCEventBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCEventBlock.cc
@@ -11,98 +11,116 @@
 #include <iomanip>
 #include <sstream>
 
-DCCEventBlock::DCCEventBlock( DCCDataUnpacker * u , EcalElectronicsMapper * m ,  bool hU, bool srpU, bool tccU, bool feU, bool memU, bool forceToKeepFRdata) : 
-  unpacker_(u), mapper_(m), headerUnpacking_(hU), srpUnpacking_(srpU), tccUnpacking_(tccU), feUnpacking_(feU),memUnpacking_(memU), forceToKeepFRdata_(forceToKeepFRdata)
-{
-  
+DCCEventBlock::DCCEventBlock(DCCDataUnpacker* u,
+                             EcalElectronicsMapper* m,
+                             bool hU,
+                             bool srpU,
+                             bool tccU,
+                             bool feU,
+                             bool memU,
+                             bool forceToKeepFRdata)
+    : unpacker_(u),
+      mapper_(m),
+      headerUnpacking_(hU),
+      srpUnpacking_(srpU),
+      tccUnpacking_(tccU),
+      feUnpacking_(feU),
+      memUnpacking_(memU),
+      forceToKeepFRdata_(forceToKeepFRdata) {
   // Build a Mem Unpacker Block
-  memBlock_   = new DCCMemBlock(u,m,this);
- 
+  memBlock_ = new DCCMemBlock(u, m, this);
+
   // setup and initialize ch status vectors
-  for( int feChannel=1;  feChannel <= 70;  feChannel++) { feChStatus_.push_back(0); hlt_.push_back(1);}
-  for( int tccChannel=1; tccChannel <= 4 ; tccChannel++){ tccChStatus_.push_back(0);}
-  
+  for (int feChannel = 1; feChannel <= 70; feChannel++) {
+    feChStatus_.push_back(0);
+    hlt_.push_back(1);
+  }
+  for (int tccChannel = 1; tccChannel <= 4; tccChannel++) {
+    tccChStatus_.push_back(0);
+  }
+
   // setup and initialize sync vectors
-  for( int feChannel=1;  feChannel <= 70;  feChannel++) { feBx_.push_back(-1);  feLv1_.push_back(-1); }
-  for( int tccChannel=1; tccChannel <= 4 ; tccChannel++){ tccBx_.push_back(-1); tccLv1_.push_back(-1);}
-  srpBx_=-1;
-  srpLv1_=-1;
-  
+  for (int feChannel = 1; feChannel <= 70; feChannel++) {
+    feBx_.push_back(-1);
+    feLv1_.push_back(-1);
+  }
+  for (int tccChannel = 1; tccChannel <= 4; tccChannel++) {
+    tccBx_.push_back(-1);
+    tccLv1_.push_back(-1);
+  }
+  srpBx_ = -1;
+  srpLv1_ = -1;
 }
 
-
-void DCCEventBlock::reset(){
-
+void DCCEventBlock::reset() {
   // reset sync vectors
-  for( int feChannel=1;  feChannel <= 70;  feChannel++) {   feBx_[feChannel-1]=-1;   feLv1_[feChannel-1]=-1; }
-  for( int tccChannel=1; tccChannel <= 4 ; tccChannel++){ tccBx_[tccChannel-1]=-1; tccLv1_[tccChannel-1]=-1;}
-  srpBx_=-1;
-  srpLv1_=-1;
-
-
+  for (int feChannel = 1; feChannel <= 70; feChannel++) {
+    feBx_[feChannel - 1] = -1;
+    feLv1_[feChannel - 1] = -1;
+  }
+  for (int tccChannel = 1; tccChannel <= 4; tccChannel++) {
+    tccBx_[tccChannel - 1] = -1;
+    tccLv1_[tccChannel - 1] = -1;
+  }
+  srpBx_ = -1;
+  srpLv1_ = -1;
 }
 
-void DCCEventBlock::enableSyncChecks(){
-   towerBlock_   ->enableSyncChecks();
-   tccBlock_     ->enableSyncChecks();
-   memBlock_     ->enableSyncChecks();
-   srpBlock_     ->enableSyncChecks();
+void DCCEventBlock::enableSyncChecks() {
+  towerBlock_->enableSyncChecks();
+  tccBlock_->enableSyncChecks();
+  memBlock_->enableSyncChecks();
+  srpBlock_->enableSyncChecks();
 }
 
+void DCCEventBlock::enableFeIdChecks() { towerBlock_->enableFeIdChecks(); }
 
-
-void DCCEventBlock::enableFeIdChecks(){
-   towerBlock_   ->enableFeIdChecks();
-}
-
-
-
-unsigned int DCCEventBlock::next_tower_search(const unsigned int current_tower_id)
-{
+unsigned int DCCEventBlock::next_tower_search(const unsigned int current_tower_id) {
   const uint64_t* const prev_data = data_;
   const unsigned int prev_dwToEnd = dwToEnd_;
-  
+
   // expected LV1, BX, #TS
   const uint32_t lv1 = ((l1_ - 1) & 0xFFF);
   const uint32_t bx = (bx_ != 3564) ? bx_ : 0;
   const uint32_t ts = mapper_->numbXtalTSamples();
-  
+
   // construct tower header and mask
   const uint64_t s_hi = 0xC0000000 + lv1;
   const uint64_t s_lo = 0xC0000000 + (bx << 16) + (ts << 8);
-  
+
   const uint64_t sign = (s_hi << 32) + s_lo;
   const uint64_t mask = 0xC0001FFFDFFF7F00;
-  
+
   // step forward to skip header word of problematic tower
   data_++;
   dwToEnd_--;
-  
+
   //std::cerr << "header of bad tower = " << current_tower_id << " #" << dwToEnd_ << " 0x" << std::hex << *data_ << std::dec << std::endl;
   //std::cerr << "mask and sign = 0x" << std::hex << mask << " 0x" << sign << std::dec << std::endl;
-  
+
   // navigate through tower data blocks to find tower block header
   while (dwToEnd_ > 0) {
     data_++;
     dwToEnd_--;
-    
+
     //std::cerr << current_tower_id << " #" << dwToEnd_ << " 0x" << std::hex << *data_ << " 0x" << (*data_ & mask) << std::dec << std::endl;
-    
+
     if ((*data_ & mask) == sign) {
       const unsigned int next_tower_id = (*data_) & 0xFF;
-      
-      if (next_tower_id <= current_tower_id) continue;
-      
+
+      if (next_tower_id <= current_tower_id)
+        continue;
+
       //std::cerr << "next tower = " << next_tower_id << std::endl;
-      
+
       // step back one word of the next tower header
       data_--;
       dwToEnd_++;
-      
+
       return next_tower_id;
     }
   }
-  
+
   // can't find next tower header
   // restore data pointer
   data_ = prev_data;
@@ -110,29 +128,21 @@ unsigned int DCCEventBlock::next_tower_search(const unsigned int current_tower_i
   return 1000;
 }
 
-void DCCEventBlock::updateCollectors(){
+void DCCEventBlock::updateCollectors() {
+  dccHeaders_ = unpacker_->dccHeadersCollection();
 
-  dccHeaders_  = unpacker_->dccHeadersCollection();
-
-  memBlock_    ->updateCollectors(); 
-  tccBlock_    ->updateCollectors();
-  srpBlock_    ->updateCollectors();
-  towerBlock_  ->updateCollectors();
-  
+  memBlock_->updateCollectors();
+  tccBlock_->updateCollectors();
+  srpBlock_->updateCollectors();
+  towerBlock_->updateCollectors();
 }
 
-
-
-
-void DCCEventBlock::addHeaderToCollection(){
-  
-  
+void DCCEventBlock::addHeaderToCollection() {
   EcalDCCHeaderBlock theDCCheader;
 
-  // container for fed_id (601-654 for ECAL) 
+  // container for fed_id (601-654 for ECAL)
   theDCCheader.setFedId(fedId_);
-  
-  
+
   // this needs to be migrated to the ECAL mapping package
 
   // dccId is number internal to ECAL running 1.. 54.
@@ -140,9 +150,8 @@ void DCCEventBlock::addHeaderToCollection(){
   int dccId = mapper_->getActiveSM();
   // DCCHeaders follow  the same convenction
   theDCCheader.setId(dccId);
-  
 
-  theDCCheader.setRunNumber(runNumber_);  
+  theDCCheader.setRunNumber(runNumber_);
   theDCCheader.setBasicTriggerType(triggerType_);
   theDCCheader.setLV1(l1_);
   theDCCheader.setBX(bx_);
@@ -154,66 +163,64 @@ void DCCEventBlock::addHeaderToCollection(){
   theDCCheader.setSrpStatus(srChStatus_);
   theDCCheader.setTccStatus(tccChStatus_);
   theDCCheader.setFEStatus(feChStatus_);
-  
-  
+
   theDCCheader.setSRPLv1(srpLv1_);
   theDCCheader.setSRPBx(srpBx_);
   theDCCheader.setFELv1(feLv1_);
   theDCCheader.setFEBx(feBx_);
   theDCCheader.setTCCLv1(tccLv1_);
   theDCCheader.setTCCBx(tccBx_);
-  
 
   EcalDCCHeaderRuntypeDecoder theRuntypeDecoder;
-  unsigned int DCCruntype              = runType_;
+  unsigned int DCCruntype = runType_;
   unsigned int DCCdetTriggerType = detailedTriggerType_;
-  theRuntypeDecoder.Decode(triggerType_, DCCdetTriggerType , DCCruntype, &theDCCheader);
+  theRuntypeDecoder.Decode(triggerType_, DCCdetTriggerType, DCCruntype, &theDCCheader);
 
-  // Add Header to collection 
+  // Add Header to collection
   (*dccHeaders_)->push_back(theDCCheader);
-   
 }
 
-void DCCEventBlock::display(std::ostream& o){
-  o<<"\n Unpacked Info for DCC Event Class"
-   <<"\n DW1 ============================="
-   <<"\n Fed Id "<<fedId_
-   <<"\n Bx "<<bx_
-   <<"\n L1 "<<l1_
-   <<"\n Trigger Type "<<triggerType_
-   <<"\n DW2 ============================="	
-   <<"\n Length "<<blockLength_
-   <<"\n Dcc errors "<<dccErrors_
-   <<"\n Run number "<<runNumber_
-   <<"\n DW3 ============================="
-   <<"\n SR "<<sr_
-   <<"\n ZS "<<zs_
-   <<"\n TZS "<<tzs_
-   <<"\n SRStatus "<<srChStatus_;
-	
+void DCCEventBlock::display(std::ostream& o) {
+  o << "\n Unpacked Info for DCC Event Class"
+    << "\n DW1 ============================="
+    << "\n Fed Id " << fedId_ << "\n Bx " << bx_ << "\n L1 " << l1_ << "\n Trigger Type " << triggerType_
+    << "\n DW2 ============================="
+    << "\n Length " << blockLength_ << "\n Dcc errors " << dccErrors_ << "\n Run number " << runNumber_
+    << "\n DW3 ============================="
+    << "\n SR " << sr_ << "\n ZS " << zs_ << "\n TZS " << tzs_ << "\n SRStatus " << srChStatus_;
+
   std::vector<short>::iterator it;
-  int i(0),k(0);
-  for(it = tccChStatus_.begin(); it!=tccChStatus_.end();it++,i++){
-    o<<"\n TCCStatus#"<<i<<" "<<(*it);
-  } 
-  
-  i=0;
-  for(it = feChStatus_.begin();it!=feChStatus_.end();it++ ,i++){
-    if(!(i%14)){ o<<"\n DW"<<(k+3)<<" ============================="; k++; }
-    o<<"\n FEStatus#"<<i<<" "<<(*it);   	
+  int i(0), k(0);
+  for (it = tccChStatus_.begin(); it != tccChStatus_.end(); it++, i++) {
+    o << "\n TCCStatus#" << i << " " << (*it);
   }
 
-  o<<"\n";  
-} 
-    
+  i = 0;
+  for (it = feChStatus_.begin(); it != feChStatus_.end(); it++, i++) {
+    if (!(i % 14)) {
+      o << "\n DW" << (k + 3) << " =============================";
+      k++;
+    }
+    o << "\n FEStatus#" << i << " " << (*it);
+  }
 
-DCCEventBlock::~DCCEventBlock(){
-  if(towerBlock_){ delete towerBlock_; } 
-  if(tccBlock_)  { delete tccBlock_;   }
-  if(memBlock_)  { delete memBlock_;   }
-  if(srpBlock_)  { delete srpBlock_;   }
+  o << "\n";
 }
 
+DCCEventBlock::~DCCEventBlock() {
+  if (towerBlock_) {
+    delete towerBlock_;
+  }
+  if (tccBlock_) {
+    delete tccBlock_;
+  }
+  if (memBlock_) {
+    delete memBlock_;
+  }
+  if (srpBlock_) {
+    delete srpBlock_;
+  }
+}
 
 // -----------------------------------------------------------------------
 // sync checking
@@ -223,32 +230,29 @@ bool isSynced(const unsigned int dccBx,
               const unsigned int dccL1,
               const unsigned int l1,
               const BlockType type,
-              const unsigned int fov)
-{
+              const unsigned int fov) {
   // avoid checking for MC until EcalDigiToRaw bugfixed
   // and to guarantee backward compatibility on RAW data
-  if ( fov < 1 ) return true;
+  if (fov < 1)
+    return true;
   // check the BX sync according the following rule:
   //
   //   FE Block     MEM Block     TCC Block  SRP Block  DCC
   // ------------------------------------------------------------------
   //   fe_bx     == mem_bx == 0   tcc_bx ==  srp_bx ==  DCC_bx == 3564
   //   fe_bx     == mem_bx     == tcc_bx ==  srp_bx ==  DCC_bx != 3564
-  
-  const bool bxSynced =
-    ((type ==  FE_MEM) && (bx ==     0) && (dccBx == 3564)) ||
-    ((type ==  FE_MEM) && (bx == dccBx) && (dccBx != 3564)) ||
-    ((type == TCC_SRP) && (bx == dccBx));
-  
+
+  const bool bxSynced = ((type == FE_MEM) && (bx == 0) && (dccBx == 3564)) ||
+                        ((type == FE_MEM) && (bx == dccBx) && (dccBx != 3564)) || ((type == TCC_SRP) && (bx == dccBx));
+
   // check the L1A sync:
   //
   // L1A counter relation is valid modulo 0xFFF:
   // fe_l1  == mem_l1 == (DCC_l1-1) & 0xFFF
   // tcc_l1 == srp_l1 ==  DCC_l1    & 0xFFF
-  
+
   const bool l1Synced =
-    ((type ==  FE_MEM) && (l1 == ((dccL1 - 1) & 0xFFF))) ||
-    ((type == TCC_SRP) && (l1 == ( dccL1      & 0xFFF)));
-  
+      ((type == FE_MEM) && (l1 == ((dccL1 - 1) & 0xFFF))) || ((type == TCC_SRP) && (l1 == (dccL1 & 0xFFF)));
+
   return (bxSynced && l1Synced);
 }

--- a/EventFilter/EcalRawToDigi/src/DCCFEBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCFEBlock.cc
@@ -4,262 +4,227 @@
 #include <cstdio>
 #include "EventFilter/EcalRawToDigi/interface/EcalElectronicsMapper.h"
 
-
-
-DCCFEBlock::DCCFEBlock( DCCDataUnpacker * u, EcalElectronicsMapper * m, DCCEventBlock * e,bool unpack, bool forceToKeepFRdata)
-  : DCCDataBlockPrototype(u,m,e,unpack), checkFeId_(false), forceToKeepFRdata_(forceToKeepFRdata) {
-   
-  expXtalTSamples_           = mapper_->numbXtalTSamples();
-  numbDWInXtalBlock_         = (expXtalTSamples_-2)/4+1;
+DCCFEBlock::DCCFEBlock(
+    DCCDataUnpacker* u, EcalElectronicsMapper* m, DCCEventBlock* e, bool unpack, bool forceToKeepFRdata)
+    : DCCDataBlockPrototype(u, m, e, unpack), checkFeId_(false), forceToKeepFRdata_(forceToKeepFRdata) {
+  expXtalTSamples_ = mapper_->numbXtalTSamples();
+  numbDWInXtalBlock_ = (expXtalTSamples_ - 2) / 4 + 1;
   unfilteredDataBlockLength_ = mapper_->getUnfilteredTowerBlockLength();
-  xtalGains_                 = new short[expXtalTSamples_]; 
-  
+  xtalGains_ = new short[expXtalTSamples_];
 }
 
-
-void DCCFEBlock::updateCollectors(){
-
-  invalidBlockLengths_    = unpacker_->invalidBlockLengthsCollection();
-  invalidTTIds_           = unpacker_->invalidTTIdsCollection();
-  invalidZSXtalIds_       = unpacker_->invalidZSXtalIdsCollection();
+void DCCFEBlock::updateCollectors() {
+  invalidBlockLengths_ = unpacker_->invalidBlockLengthsCollection();
+  invalidTTIds_ = unpacker_->invalidTTIdsCollection();
+  invalidZSXtalIds_ = unpacker_->invalidZSXtalIdsCollection();
 }
 
-
-
-int DCCFEBlock::unpack(const uint64_t ** data, unsigned int * dwToEnd, bool zs, unsigned int expectedTowerID){
-  
-  zs_      = zs;  
-  datap_   = data;
-  data_    = *data;
+int DCCFEBlock::unpack(const uint64_t** data, unsigned int* dwToEnd, bool zs, unsigned int expectedTowerID) {
+  zs_ = zs;
+  datap_ = data;
+  data_ = *data;
   dwToEnd_ = dwToEnd;
-  
+
   const unsigned int activeDCC = mapper_->getActiveSM();
 
-  if( (*dwToEnd_)<1){
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogWarning("IncorrectEvent")
-        <<"\n Unable to unpack Tower block for event "<<event_->l1A()<<" in fed "<<activeDCC
-        <<"\n The end of event was reached "
-        <<"\n(or, previously, pointers intended to navigate outside of FedBlock (based on block sizes), and were stopped by setting dwToEnd_ to zero)"    ;
+  if ((*dwToEnd_) < 1) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectEvent") << "\n Unable to unpack Tower block for event " << event_->l1A() << " in fed "
+                                        << activeDCC << "\n The end of event was reached "
+                                        << "\n(or, previously, pointers intended to navigate outside of FedBlock "
+                                           "(based on block sizes), and were stopped by setting dwToEnd_ to zero)";
       //TODO : add this to a dcc event size collection error?
     }
     return STOP_EVENT_UNPACKING;
   }
-  
-  lastStripId_     = 0;
-  lastXtalId_      = 0;
-  expTowerID_      = expectedTowerID;
-  
-  
+
+  lastStripId_ = 0;
+  lastXtalId_ = 0;
+  expTowerID_ = expectedTowerID;
+
   //Point to begin of block
   data_++;
-  
-  towerId_           = ( *data_ )                   & TOWER_ID_MASK;
-  nTSamples_         = ( *data_>>TOWER_NSAMP_B  )   & TOWER_NSAMP_MASK; 
-  bx_                = ( *data_>>TOWER_BX_B     )   & TOWER_BX_MASK;
-  l1_                = ( *data_>>TOWER_L1_B     )   & TOWER_L1_MASK;
-  blockLength_       = ( *data_>>TOWER_LENGTH_B )   & TOWER_LENGTH_MASK;
-  
-  event_->setFESyncNumbers(l1_,bx_, (short)(expTowerID_-1));
+
+  towerId_ = (*data_) & TOWER_ID_MASK;
+  nTSamples_ = (*data_ >> TOWER_NSAMP_B) & TOWER_NSAMP_MASK;
+  bx_ = (*data_ >> TOWER_BX_B) & TOWER_BX_MASK;
+  l1_ = (*data_ >> TOWER_L1_B) & TOWER_L1_MASK;
+  blockLength_ = (*data_ >> TOWER_LENGTH_B) & TOWER_LENGTH_MASK;
+
+  event_->setFESyncNumbers(l1_, bx_, (short)(expTowerID_ - 1));
 
   //debugging
   //display(cout);
 
-
-  
   ////////////////////////////////////////////////////
   // check that expected fe_id==fe_expected is on
-  if (checkFeId_              &&
-      expTowerID_ != towerId_ &&
-      expTowerID_ <= mapper_->getNumChannelsInDcc(activeDCC) ){ // fe_id must be within range foreseen in the FED 
-    if (! DCCDataUnpacker::silentMode_) {
-      edm::LogWarning("IncorrectBlock")
-        << "Expected tower ID is " << expTowerID_ << " while " << towerId_ << " was found"
-        << " (L1A " << event_->l1A() << " fed " << mapper_->getActiveDCC() << ")\n"
-        << "  => Skipping to next FE block...";
+  if (checkFeId_ && expTowerID_ != towerId_ &&
+      expTowerID_ <= mapper_->getNumChannelsInDcc(activeDCC)) {  // fe_id must be within range foreseen in the FED
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectBlock") << "Expected tower ID is " << expTowerID_ << " while " << towerId_
+                                        << " was found"
+                                        << " (L1A " << event_->l1A() << " fed " << mapper_->getActiveDCC() << ")\n"
+                                        << "  => Skipping to next FE block...";
     }
-    
-    fillEcalElectronicsError(invalidTTIds_); 
-    
+
+    fillEcalElectronicsError(invalidTTIds_);
+
     updateEventPointers();
     return SKIP_BLOCK_UNPACKING;
   }
 
   //////////////////////////////////////////////////////////
   // check that expected fe_id==fe_expected is off
-  else if( (!checkFeId_) && 
-           towerId_ > mapper_->getNumChannelsInDcc(activeDCC) ){ // fe_id must still be within range foreseen in the FED 
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogWarning("IncorrectBlock")
-        <<"For event "<<event_->l1A()<<" and fed "<<mapper_->getActiveDCC()<<" (there's no check fe_id==dcc_channel)"
-        <<"\n the FE_id found: "<<towerId_<<" exceeds max number of FE foreseen in fed"
-        <<"\n => Skipping to next FE block...";
+  else if ((!checkFeId_) && towerId_ > mapper_->getNumChannelsInDcc(
+                                           activeDCC)) {  // fe_id must still be within range foreseen in the FED
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectBlock") << "For event " << event_->l1A() << " and fed " << mapper_->getActiveDCC()
+                                        << " (there's no check fe_id==dcc_channel)"
+                                        << "\n the FE_id found: " << towerId_
+                                        << " exceeds max number of FE foreseen in fed"
+                                        << "\n => Skipping to next FE block...";
     }
-    
+
     updateEventPointers();
     return SKIP_BLOCK_UNPACKING;
   }
-  
+
   // Check synchronization
   if (sync_) {
-    const unsigned int dccBx = (event_->bx())  & TCC_BX_MASK;
+    const unsigned int dccBx = (event_->bx()) & TCC_BX_MASK;
     const unsigned int dccL1 = (event_->l1A()) & TCC_L1_MASK;
-    const unsigned int fov   = (event_->fov()) & H_FOV_MASK;
-    
-    if (! isSynced(dccBx, bx_, dccL1, l1_, FE_MEM, fov)) {
-      if (! DCCDataUnpacker::silentMode_) {
+    const unsigned int fov = (event_->fov()) & H_FOV_MASK;
+
+    if (!isSynced(dccBx, bx_, dccL1, l1_, FE_MEM, fov)) {
+      if (!DCCDataUnpacker::silentMode_) {
         // TODO: add check for status from Channel Status DB
-        
+
         edm::LogWarning("IncorrectBlock")
-          << "Synchronization error for Tower Block"
-          << " (L1A " << event_->l1A() << " bx " << event_->bx() << " fed " << mapper_->getActiveDCC() << " tower " << towerId_ << ")\n"
-          << "  dccBx = " << dccBx << " bx_ = " << bx_ << " dccL1 = " << dccL1 << " l1_ = " << l1_ << "\n"
-          << "  => Skipping to next tower block";
+            << "Synchronization error for Tower Block"
+            << " (L1A " << event_->l1A() << " bx " << event_->bx() << " fed " << mapper_->getActiveDCC() << " tower "
+            << towerId_ << ")\n"
+            << "  dccBx = " << dccBx << " bx_ = " << bx_ << " dccL1 = " << dccL1 << " l1_ = " << l1_ << "\n"
+            << "  => Skipping to next tower block";
       }
-      
+
       //Note : add to error collection ?
       updateEventPointers();
       return SKIP_BLOCK_UNPACKING;
     }
   }
-  
+
   // check number of samples
-  if( nTSamples_ != expXtalTSamples_ ){
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogWarning("IncorrectBlock")
-        <<"Unable to unpack Tower Block "<<towerId_<<" for event L1A "<<event_->l1A()<<" in fed "<<mapper_->getActiveDCC()
-        <<"\n Number of time samples "<<nTSamples_<<" is not the same as expected ("<<expXtalTSamples_<<")"
-        <<"\n => Skipping to next tower block...";
-     } 
-    //Note : add to error collection ?                 
+  if (nTSamples_ != expXtalTSamples_) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectBlock") << "Unable to unpack Tower Block " << towerId_ << " for event L1A "
+                                        << event_->l1A() << " in fed " << mapper_->getActiveDCC()
+                                        << "\n Number of time samples " << nTSamples_
+                                        << " is not the same as expected (" << expXtalTSamples_ << ")"
+                                        << "\n => Skipping to next tower block...";
+    }
+    //Note : add to error collection ?
     updateEventPointers();
     return SKIP_BLOCK_UNPACKING;
   }
 
-  
-  xtalBlockSize_     = numbDWInXtalBlock_*8;
-  blockSize_           = blockLength_*8;  
-  
-  if((*dwToEnd_)<blockLength_){
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogWarning("IncorrectEvent")
-        <<"\n Unable to unpack Tower Block "<<towerId_<<" for event L1A "<<event_->l1A()<<" in fed "<<mapper_->getActiveDCC()
-        <<"\n Only "<<((*dwToEnd_)*8)<<" bytes are available while "<<blockSize_<<" are needed!"
-        <<"\n => Skipping to next fed block...";
+  xtalBlockSize_ = numbDWInXtalBlock_ * 8;
+  blockSize_ = blockLength_ * 8;
+
+  if ((*dwToEnd_) < blockLength_) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectEvent") << "\n Unable to unpack Tower Block " << towerId_ << " for event L1A "
+                                        << event_->l1A() << " in fed " << mapper_->getActiveDCC() << "\n Only "
+                                        << ((*dwToEnd_) * 8) << " bytes are available while " << blockSize_
+                                        << " are needed!"
+                                        << "\n => Skipping to next fed block...";
     }
     //TODO : add to error collections
     return STOP_EVENT_UNPACKING;
   }
 
-
-  if(!zs_ && !forceToKeepFRdata_){
-         
-    if ( unfilteredDataBlockLength_ != blockLength_ ){
-      if( ! DCCDataUnpacker::silentMode_ ){ 
+  if (!zs_ && !forceToKeepFRdata_) {
+    if (unfilteredDataBlockLength_ != blockLength_) {
+      if (!DCCDataUnpacker::silentMode_) {
         edm::LogWarning("IncorrectEvent")
-          <<"\n For event L1A "<<event_->l1A()<<", fed "<<mapper_->getActiveDCC()<<" and tower "<<towerId_
-          <<"\n Expected block size is "<<(unfilteredDataBlockLength_*8)<<" bytes while "<<(blockLength_*8)<<" was found"
-          <<"\n => Skipping to next fed block...";
-       }
+            << "\n For event L1A " << event_->l1A() << ", fed " << mapper_->getActiveDCC() << " and tower " << towerId_
+            << "\n Expected block size is " << (unfilteredDataBlockLength_ * 8) << " bytes while " << (blockLength_ * 8)
+            << " was found"
+            << "\n => Skipping to next fed block...";
+      }
 
-      fillEcalElectronicsError(invalidBlockLengths_) ;
+      fillEcalElectronicsError(invalidBlockLengths_);
 
       //Safer approach...  - why pointers do not navigate in this case?
-      return STOP_EVENT_UNPACKING;          
-
-      
+      return STOP_EVENT_UNPACKING;
     }
 
-    
-  }
-  else if (!zs && forceToKeepFRdata_){
-
-     if ( unfilteredDataBlockLength_ != blockLength_ ){
-      if( ! DCCDataUnpacker::silentMode_ ){ 
+  } else if (!zs && forceToKeepFRdata_) {
+    if (unfilteredDataBlockLength_ != blockLength_) {
+      if (!DCCDataUnpacker::silentMode_) {
         edm::LogWarning("IncorrectBlock")
-          <<"For event L1A "<<event_->l1A()<<", fed "<<mapper_->getActiveDCC()<<" and tower "<<towerId_
-          <<"\n Expected block size is "<<(unfilteredDataBlockLength_*8)<<" bytes while "<<(blockLength_*8)<<" was found"
-          <<"\n => Keeps unpacking as the unpacker was forced to keep FR data (by configuration) ...";
-       }
+            << "For event L1A " << event_->l1A() << ", fed " << mapper_->getActiveDCC() << " and tower " << towerId_
+            << "\n Expected block size is " << (unfilteredDataBlockLength_ * 8) << " bytes while " << (blockLength_ * 8)
+            << " was found"
+            << "\n => Keeps unpacking as the unpacker was forced to keep FR data (by configuration) ...";
+      }
 
-      fillEcalElectronicsError(invalidBlockLengths_) ;
-     }
+      fillEcalElectronicsError(invalidBlockLengths_);
+    }
 
-  }
-  else if( blockLength_ > unfilteredDataBlockLength_ || (blockLength_-1) < numbDWInXtalBlock_ ){
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogWarning("IncorrectEvent")
-        <<"\n For event L1A "<<event_->l1A()<<" and fed "<<mapper_->getActiveDCC()
-        <<"\n The tower "<<towerId_<<" has a wrong number of bytes : "<<(blockLength_*8)           
-        <<"\n => Skipping to next fed block...";
-     }
+  } else if (blockLength_ > unfilteredDataBlockLength_ || (blockLength_ - 1) < numbDWInXtalBlock_) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectEvent") << "\n For event L1A " << event_->l1A() << " and fed "
+                                        << mapper_->getActiveDCC() << "\n The tower " << towerId_
+                                        << " has a wrong number of bytes : " << (blockLength_ * 8)
+                                        << "\n => Skipping to next fed block...";
+    }
 
-     fillEcalElectronicsError(invalidBlockLengths_) ;
-
+    fillEcalElectronicsError(invalidBlockLengths_);
 
     //Safer approach... - why pointers do not navigate in this case?
     return STOP_EVENT_UNPACKING;
   }
-  
-
 
   // If the HLT says to skip this tower we skip it...
-  if( ! event_->getHLTChannel(towerId_) ){
+  if (!event_->getHLTChannel(towerId_)) {
     updateEventPointers();
     return SKIP_BLOCK_UNPACKING;
   }
   /////////////////////////////////////////////////
 
-
-
-
-
-  unsigned int numbOfXtalBlocks = (blockLength_-1)/numbDWInXtalBlock_; 
+  unsigned int numbOfXtalBlocks = (blockLength_ - 1) / numbDWInXtalBlock_;
 
   // get XTAL Data
   unsigned int expStripID(0), expXtalID(0);
   //point to xtal data
   data_++;
-  
-  int statusUnpackXtal =0;
 
-  for(unsigned int numbXtal=1; numbXtal <= numbOfXtalBlocks && statusUnpackXtal!= SKIP_BLOCK_UNPACKING; numbXtal++){
+  int statusUnpackXtal = 0;
 
-    
-    if(!zs_ && ! forceToKeepFRdata_){
-      expStripID  = ( numbXtal-1)/5 + 1;        
-      expXtalID   =  numbXtal - (expStripID-1)*5;
+  for (unsigned int numbXtal = 1; numbXtal <= numbOfXtalBlocks && statusUnpackXtal != SKIP_BLOCK_UNPACKING;
+       numbXtal++) {
+    if (!zs_ && !forceToKeepFRdata_) {
+      expStripID = (numbXtal - 1) / 5 + 1;
+      expXtalID = numbXtal - (expStripID - 1) * 5;
     }
-    
-    statusUnpackXtal = unpackXtalData(expStripID,expXtalID);
-    if (statusUnpackXtal== SKIP_BLOCK_UNPACKING)
-      {
-        if( ! DCCDataUnpacker::silentMode_ ){
-            edm::LogWarning("IncorrectBlock")
-            <<"For event L1A "<<event_->l1A()<<" and fed "<<mapper_->getActiveDCC()
-            <<"\n The tower "<<towerId_<<" won't be unpacked further";
-        }
-      }
 
-  }// end loop over xtals of given FE 
+    statusUnpackXtal = unpackXtalData(expStripID, expXtalID);
+    if (statusUnpackXtal == SKIP_BLOCK_UNPACKING) {
+      if (!DCCDataUnpacker::silentMode_) {
+        edm::LogWarning("IncorrectBlock") << "For event L1A " << event_->l1A() << " and fed " << mapper_->getActiveDCC()
+                                          << "\n The tower " << towerId_ << " won't be unpacked further";
+      }
+    }
+
+  }  // end loop over xtals of given FE
 
   updateEventPointers();
-  return BLOCK_UNPACKED;                
-  
+  return BLOCK_UNPACKED;
 }
 
-
-
-
-void DCCFEBlock::display(std::ostream& o){
-
-  o<<"\n Unpacked Info for DCC Tower Block"
-  <<"\n DW1 ============================="
-  <<"\n Tower Id "<<towerId_
-  <<"\n Numb Samp "<<nTSamples_
-  <<"\n Bx "<<bx_
-  <<"\n L1 "<<l1_
-  <<"\n blockLength "<<blockLength_;  
-} 
-
-
+void DCCFEBlock::display(std::ostream& o) {
+  o << "\n Unpacked Info for DCC Tower Block"
+    << "\n DW1 ============================="
+    << "\n Tower Id " << towerId_ << "\n Numb Samp " << nTSamples_ << "\n Bx " << bx_ << "\n L1 " << l1_
+    << "\n blockLength " << blockLength_;
+}

--- a/EventFilter/EcalRawToDigi/src/DCCMemBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCMemBlock.cc
@@ -4,296 +4,271 @@
 #include <cstdio>
 #include "EventFilter/EcalRawToDigi/interface/EcalElectronicsMapper.h"
 
+DCCMemBlock::DCCMemBlock(DCCDataUnpacker* u, EcalElectronicsMapper* m, DCCEventBlock* e)
+    : DCCDataBlockPrototype(u, m, e) {
+  unfilteredTowerBlockLength_ = mapper_->getUnfilteredTowerBlockLength();
+  expXtalTSamples_ = mapper_->numbXtalTSamples();
 
+  numbDWInXtalBlock_ = (expXtalTSamples_ - 2) / 4 + 1;
+  xtalBlockSize_ = numbDWInXtalBlock_ * 8;
+  kSamplesPerPn_ = expXtalTSamples_ * 5;
 
-DCCMemBlock::DCCMemBlock( DCCDataUnpacker * u,EcalElectronicsMapper * m, DCCEventBlock * e) 
-:DCCDataBlockPrototype(u,m,e)
-{
-
-  unfilteredTowerBlockLength_  = mapper_->getUnfilteredTowerBlockLength();
-  expXtalTSamples_             = mapper_->numbXtalTSamples();
-
-  numbDWInXtalBlock_           = (expXtalTSamples_-2)/4+1;
-  xtalBlockSize_               = numbDWInXtalBlock_*8;
-  kSamplesPerPn_               = expXtalTSamples_*5;  
-  
-  unsigned int numbOfXtalBlocks        = (unfilteredTowerBlockLength_-1)/numbDWInXtalBlock_; 
-  unsigned int numbOfPnBlocks          = numbOfXtalBlocks/5; //change 5 by a variable
-  unsigned int vectorSize              = numbOfPnBlocks*10*expXtalTSamples_;
+  unsigned int numbOfXtalBlocks = (unfilteredTowerBlockLength_ - 1) / numbDWInXtalBlock_;
+  unsigned int numbOfPnBlocks = numbOfXtalBlocks / 5;  //change 5 by a variable
+  unsigned int vectorSize = numbOfPnBlocks * 10 * expXtalTSamples_;
 
   //Build pnDiodevector
-  for(unsigned int i =0; i< vectorSize; i++){ pn_.push_back(-1);}
-
+  for (unsigned int i = 0; i < vectorSize; i++) {
+    pn_.push_back(-1);
+  }
 }
 
-void DCCMemBlock::updateCollectors(){
-
-  invalidMemChIds_             = unpacker_->invalidMemChIdsCollection();
-  invalidMemBlockSizes_        = unpacker_->invalidMemBlockSizesCollection();
-  invalidMemTtIds_             = unpacker_->invalidMemTtIdsCollection();
-  invalidMemGains_             = unpacker_->invalidMemGainsCollection();
-  pnDiodeDigis_                = unpacker_->pnDiodeDigisCollection();
-
+void DCCMemBlock::updateCollectors() {
+  invalidMemChIds_ = unpacker_->invalidMemChIdsCollection();
+  invalidMemBlockSizes_ = unpacker_->invalidMemBlockSizesCollection();
+  invalidMemTtIds_ = unpacker_->invalidMemTtIdsCollection();
+  invalidMemGains_ = unpacker_->invalidMemGainsCollection();
+  pnDiodeDigis_ = unpacker_->pnDiodeDigisCollection();
 }
 
-
-
-int DCCMemBlock::unpack(const uint64_t ** data, unsigned int * dwToEnd, unsigned int expectedTowerID){
-  
-  error_   = false;  
-  datap_   = data;
-  data_    = *data;
+int DCCMemBlock::unpack(const uint64_t** data, unsigned int* dwToEnd, unsigned int expectedTowerID) {
+  error_ = false;
+  datap_ = data;
+  data_ = *data;
   dwToEnd_ = dwToEnd;
 
- 
-  if( (*dwToEnd_)<1){
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogWarning("IncorrectEvent")
-        <<"\nUnable to unpack MEM block for event "<<event_->l1A()<<" in fed "<<mapper_->getActiveDCC()
-        <<"\nThe end of event was reached !";
+  if ((*dwToEnd_) < 1) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectEvent") << "\nUnable to unpack MEM block for event " << event_->l1A() << " in fed "
+                                        << mapper_->getActiveDCC() << "\nThe end of event was reached !";
     }
     return STOP_EVENT_UNPACKING;
   }
-  
-  lastStripId_     = 0;
-  lastXtalId_      = 0;
-  expTowerID_      = expectedTowerID;
-  
-  
+
+  lastStripId_ = 0;
+  lastXtalId_ = 0;
+  expTowerID_ = expectedTowerID;
+
   //Point to begin of block
   data_++;
-  
-  towerId_           = ( *data_ ) & TOWER_ID_MASK;
-  nTSamples_         = ( *data_>>TOWER_NSAMP_B  ) & TOWER_NSAMP_MASK; 
-  bx_                = ( *data_>>TOWER_BX_B     ) & TOWER_BX_MASK;
-  l1_                = ( *data_>>TOWER_L1_B     ) & TOWER_L1_MASK;
-  blockLength_       = ( *data_>>TOWER_LENGTH_B ) & TOWER_LENGTH_MASK;
- 
-  event_->setFESyncNumbers(l1_,bx_,short(expectedTowerID-1));
 
- 
+  towerId_ = (*data_) & TOWER_ID_MASK;
+  nTSamples_ = (*data_ >> TOWER_NSAMP_B) & TOWER_NSAMP_MASK;
+  bx_ = (*data_ >> TOWER_BX_B) & TOWER_BX_MASK;
+  l1_ = (*data_ >> TOWER_L1_B) & TOWER_L1_MASK;
+  blockLength_ = (*data_ >> TOWER_LENGTH_B) & TOWER_LENGTH_MASK;
+
+  event_->setFESyncNumbers(l1_, bx_, short(expectedTowerID - 1));
+
   //debugging
   //display(cout);
 
   // Block Length Check (1)
-  if ( unfilteredTowerBlockLength_ != blockLength_ ){    
-   
+  if (unfilteredTowerBlockLength_ != blockLength_) {
     // chosing channel 1 as representative of a dummy...
-    EcalElectronicsId id( mapper_->getActiveSM() , expTowerID_,1, 1);
+    EcalElectronicsId id(mapper_->getActiveSM(), expTowerID_, 1, 1);
     (*invalidMemBlockSizes_)->push_back(id);
-    if( ! DCCDataUnpacker::silentMode_ ){ 
-      edm::LogWarning("IncorrectEvent")
-        <<"\nFor event "<<event_->l1A()<<", fed "<<mapper_->getActiveDCC()<<" and tower block "<<towerId_
-        <<"\nExpected mem block size is "<<(unfilteredTowerBlockLength_*8)<<" bytes while "<<(blockLength_*8)<<" was found";
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectEvent") << "\nFor event " << event_->l1A() << ", fed " << mapper_->getActiveDCC()
+                                        << " and tower block " << towerId_ << "\nExpected mem block size is "
+                                        << (unfilteredTowerBlockLength_ * 8) << " bytes while " << (blockLength_ * 8)
+                                        << " was found";
     }
     return STOP_EVENT_UNPACKING;
-    
   }
-  
+
   // Block Length Check (2)
-  if((*dwToEnd_)<blockLength_){
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogWarning("IncorrectEvent")
-        <<"\nUnable to unpack MEM block for event "<<event_->l1A()<<" in fed "<<mapper_->getActiveDCC()
-        <<"\n Only "<<((*dwToEnd_)*8)<<" bytes are available while "<<(blockLength_*8)<<" are needed!";
+  if ((*dwToEnd_) < blockLength_) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectEvent") << "\nUnable to unpack MEM block for event " << event_->l1A() << " in fed "
+                                        << mapper_->getActiveDCC() << "\n Only " << ((*dwToEnd_) * 8)
+                                        << " bytes are available while " << (blockLength_ * 8) << " are needed!";
       // chosing channel 1 as representative of a dummy...
-    } 
-    EcalElectronicsId id( mapper_->getActiveSM() , expTowerID_,1, 1);
+    }
+    EcalElectronicsId id(mapper_->getActiveSM(), expTowerID_, 1, 1);
     (*invalidMemBlockSizes_)->push_back(id);
     return STOP_EVENT_UNPACKING;
   }
-  
-  // Synchronization Check 
-  if(sync_){
-    const unsigned int dccBx = ( event_->bx()) & TOWER_BX_MASK;
-    const unsigned int dccL1 = ( event_->l1A() ) & TOWER_L1_MASK;
-    const unsigned int fov   = ( event_->fov() ) & H_FOV_MASK;
-    
-    if (! isSynced(dccBx, bx_, dccL1, l1_, FE_MEM, fov)) {
-      if( ! DCCDataUnpacker::silentMode_ ){
+
+  // Synchronization Check
+  if (sync_) {
+    const unsigned int dccBx = (event_->bx()) & TOWER_BX_MASK;
+    const unsigned int dccL1 = (event_->l1A()) & TOWER_L1_MASK;
+    const unsigned int fov = (event_->fov()) & H_FOV_MASK;
+
+    if (!isSynced(dccBx, bx_, dccL1, l1_, FE_MEM, fov)) {
+      if (!DCCDataUnpacker::silentMode_) {
         edm::LogWarning("IncorrectEvent")
-          << "Synchronization error for Mem block"
-          << " (L1A " << event_->l1A() << " bx " << event_->bx() << " fed " << mapper_->getActiveDCC() << ")\n"
-          << "  dccBx = " << dccBx << " bx_ = " << bx_ << " dccL1 = " << dccL1 << " l1_ = " << l1_ << "\n"
-          << "  => Stop event unpacking";
+            << "Synchronization error for Mem block"
+            << " (L1A " << event_->l1A() << " bx " << event_->bx() << " fed " << mapper_->getActiveDCC() << ")\n"
+            << "  dccBx = " << dccBx << " bx_ = " << bx_ << " dccL1 = " << dccL1 << " l1_ = " << l1_ << "\n"
+            << "  => Stop event unpacking";
       }
       //Note : add to error collection ?
       // need of a new collection
       return STOP_EVENT_UNPACKING;
     }
-  }  
-  
+  }
+
   // Number Of Samples Check
-  if( nTSamples_ != expXtalTSamples_ ){
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogWarning("IncorrectEvent")
-        <<"\nUnable to unpack MEM block for event "<<event_->l1A()<<" in fed "<<mapper_->getActiveDCC()
-        <<"\nNumber of time samples "<<nTSamples_<<" is not the same as expected ("<<expXtalTSamples_<<")";
-     }
-    //Note : add to error collection ?		 
+  if (nTSamples_ != expXtalTSamples_) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectEvent") << "\nUnable to unpack MEM block for event " << event_->l1A() << " in fed "
+                                        << mapper_->getActiveDCC() << "\nNumber of time samples " << nTSamples_
+                                        << " is not the same as expected (" << expXtalTSamples_ << ")";
+    }
+    //Note : add to error collection ?
     return STOP_EVENT_UNPACKING;
   }
-  
-  
+
   //Channel Id Check
-  if( expTowerID_ != towerId_){
-    
+  if (expTowerID_ != towerId_) {
     // chosing channel 1 as representative as a dummy...
-    EcalElectronicsId id( mapper_->getActiveSM() , expTowerID_, 1,1);
+    EcalElectronicsId id(mapper_->getActiveSM(), expTowerID_, 1, 1);
     (*invalidMemTtIds_)->push_back(id);
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogWarning("IncorrectBlock")
-        <<"For event "<<event_->l1A()<<" and fed "<<mapper_->getActiveDCC() << " and sm: "  << mapper_->getActiveSM()
-        <<"\nExpected mem tower block is "<<expTowerID_<<" while "<<towerId_<<" was found ";
-     }
-    
-    towerId_=expTowerID_;
-    
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectBlock") << "For event " << event_->l1A() << " and fed " << mapper_->getActiveDCC()
+                                        << " and sm: " << mapper_->getActiveSM() << "\nExpected mem tower block is "
+                                        << expTowerID_ << " while " << towerId_ << " was found ";
+    }
+
+    towerId_ = expTowerID_;
+
     // todo : go to the next mem
-    error_= true;
-	
-	updateEventPointers();
-	return SKIP_BLOCK_UNPACKING;
+    error_ = true;
+
+    updateEventPointers();
+    return SKIP_BLOCK_UNPACKING;
   }
-   
- 
+
   //point to xtal data
   data_++;
-		               
-  
+
   unpackMemTowerData();
-  
-  if(!error_){ fillPnDiodeDigisCollection();}
+
+  if (!error_) {
+    fillPnDiodeDigisCollection();
+  }
 
   updateEventPointers();
-  
+
   return BLOCK_UNPACKED;
-     
 }
 
-
-
-void DCCMemBlock::unpackMemTowerData(){
-  
-    
+void DCCMemBlock::unpackMemTowerData() {
   //todo: move EcalPnDiodeDetId to electronics mapper
-
 
   lastTowerBeforeMem_ = 0;
   // differentiating the barrel and the endcap case
-  if (9 < mapper_->getActiveSM() || mapper_->getActiveSM() < 46){
-    lastTowerBeforeMem_ = 69; }
-  else {
-    lastTowerBeforeMem_ = 69; } 
-  
+  if (9 < mapper_->getActiveSM() || mapper_->getActiveSM() < 46) {
+    lastTowerBeforeMem_ = 69;
+  } else {
+    lastTowerBeforeMem_ = 69;
+  }
 
-  for(unsigned int expStripId = 1; expStripId<= 5; expStripId++){
+  for (unsigned int expStripId = 1; expStripId <= 5; expStripId++) {
+    for (unsigned int expXtalId = 1; expXtalId <= 5; expXtalId++) {
+      const uint16_t* xData_ = reinterpret_cast<const uint16_t*>(data_);
 
-    for(unsigned int expXtalId = 1; expXtalId <= 5; expXtalId++){
-	 
-      const uint16_t * xData_= reinterpret_cast<const uint16_t *>(data_);
- 
       // Get xtal data ids
       unsigned int stripId = (*xData_) & TOWER_STRIPID_MASK;
-      unsigned int xtalId  =((*xData_)>>TOWER_XTALID_B ) & TOWER_XTALID_MASK;
-   
-      bool errorOnDecoding(false);
-	  
-      if(expStripId != stripId || expXtalId != xtalId){
+      unsigned int xtalId = ((*xData_) >> TOWER_XTALID_B) & TOWER_XTALID_MASK;
 
+      bool errorOnDecoding(false);
+
+      if (expStripId != stripId || expXtalId != xtalId) {
         // chosing channel and strip as EcalElectronicsId
-        EcalElectronicsId id( mapper_->getActiveSM() , towerId_, expStripId, expXtalId);
-       (*invalidMemChIds_)->push_back(id);
-      
-        if( ! DCCDataUnpacker::silentMode_ ){
+        EcalElectronicsId id(mapper_->getActiveSM(), towerId_, expStripId, expXtalId);
+        (*invalidMemChIds_)->push_back(id);
+
+        if (!DCCDataUnpacker::silentMode_) {
           edm::LogWarning("IncorrectBlock")
-            <<"For event "<<event_->l1A()<<", fed "<<mapper_->getActiveDCC()<<" and tower mem block "<<towerId_
-            <<"\nThe expected strip is "<<expStripId<<" and "<<stripId<<" was found"
-            <<"\nThe expected xtal  is "<<expXtalId <<" and "<<xtalId<<" was found";
+              << "For event " << event_->l1A() << ", fed " << mapper_->getActiveDCC() << " and tower mem block "
+              << towerId_ << "\nThe expected strip is " << expStripId << " and " << stripId << " was found"
+              << "\nThe expected xtal  is " << expXtalId << " and " << xtalId << " was found";
         }
 
         stripId = expStripId;
-        xtalId  = expXtalId;
-		 
+        xtalId = expXtalId;
 
+        errorOnDecoding = true;
 
-         errorOnDecoding = true; 
-	
-       //Note : move to the next ...   
-		 
-     }
-	 
-     unsigned int ipn, index;
-		
-     if((stripId-1)%2==0){ ipn = (towerId_-lastTowerBeforeMem_)*5 + xtalId - 1; }
-     else                { ipn = (towerId_-lastTowerBeforeMem_)*5 + 5 - xtalId; }
-	 
-	  	
+        //Note : move to the next ...
+      }
+
+      unsigned int ipn, index;
+
+      if ((stripId - 1) % 2 == 0) {
+        ipn = (towerId_ - lastTowerBeforeMem_) * 5 + xtalId - 1;
+      } else {
+        ipn = (towerId_ - lastTowerBeforeMem_) * 5 + 5 - xtalId;
+      }
+
       //Cooking samples
-      for(unsigned int i =0; i< nTSamples_ ;i++){ 
-      
+      for (unsigned int i = 0; i < nTSamples_; i++) {
         xData_++;
-		  
-        index = ipn*50 + (stripId-1)*nTSamples_+i;
-		 
-	    //edm::LogDebug("EcalRawToDigiMemChId")<<"\n Strip id "<<std::dec<<stripId<<" Xtal id "<<xtalId
-	    //  <<" tsamp = "<<i<<" 16b = 0x "<<std::hex<<(*xData_)<<dec;
-	   
-        unsigned int temp = (*xData_)&TOWER_DIGI_MASK;
-		
-  	     short sample(0);
-		
-		
-        if( (stripId-1)%2 ) {
-	     
+
+        index = ipn * 50 + (stripId - 1) * nTSamples_ + i;
+
+        //edm::LogDebug("EcalRawToDigiMemChId")<<"\n Strip id "<<std::dec<<stripId<<" Xtal id "<<xtalId
+        //  <<" tsamp = "<<i<<" 16b = 0x "<<std::hex<<(*xData_)<<dec;
+
+        unsigned int temp = (*xData_) & TOWER_DIGI_MASK;
+
+        short sample(0);
+
+        if ((stripId - 1) % 2) {
           // If strip number is even, 14 bits are reversed in order
-	       for(int ib=0;ib<14;ib++){ 
-	         sample <<= 1;
-	         sample |= (temp&1);
-	         temp  >>= 1;
-	       }
-			
-        } else { sample=temp;}
-	
-	     sample   ^=  0x800;
-        unsigned int gain =  sample>>12;
-			
-        if( gain >= 2 ){
+          for (int ib = 0; ib < 14; ib++) {
+            sample <<= 1;
+            sample |= (temp & 1);
+            temp >>= 1;
+          }
 
-          EcalElectronicsId id(mapper_->getActiveSM() , towerId_, stripId,xtalId);
-          (*invalidMemGains_)->push_back(id);
-          
-           if( ! DCCDataUnpacker::silentMode_ ){
-	      edm::LogWarning("IncorrectGain")
-	       <<"For event "<<event_->l1A()<<", fed "<<mapper_->getActiveDCC()<<" , mem tower block "<<towerId_
-	       <<"\nIn strip "<<stripId<<" xtal "<<xtalId<<" the gain is "<<gain<<" in sample "<<(i+1);
-           }
-
-          errorOnDecoding=true;
+        } else {
+          sample = temp;
         }
-		
-        if( !errorOnDecoding && !error_){pn_[index]=sample;} //Note : move to the next versus flag...
-		 
-      }// loop over samples ended
-	
-      data_ += numbDWInXtalBlock_;
-    }//loop over xtals
-  }// loop over strips
-	 
 
+        sample ^= 0x800;
+        unsigned int gain = sample >> 12;
+
+        if (gain >= 2) {
+          EcalElectronicsId id(mapper_->getActiveSM(), towerId_, stripId, xtalId);
+          (*invalidMemGains_)->push_back(id);
+
+          if (!DCCDataUnpacker::silentMode_) {
+            edm::LogWarning("IncorrectGain")
+                << "For event " << event_->l1A() << ", fed " << mapper_->getActiveDCC() << " , mem tower block "
+                << towerId_ << "\nIn strip " << stripId << " xtal " << xtalId << " the gain is " << gain
+                << " in sample " << (i + 1);
+          }
+
+          errorOnDecoding = true;
+        }
+
+        if (!errorOnDecoding && !error_) {
+          pn_[index] = sample;
+        }  //Note : move to the next versus flag...
+
+      }  // loop over samples ended
+
+      data_ += numbDWInXtalBlock_;
+    }  //loop over xtals
+  }    // loop over strips
 }
 
-void DCCMemBlock::fillPnDiodeDigisCollection(){
- 
+void DCCMemBlock::fillPnDiodeDigisCollection() {
   //todo change pnId max
-  for (int pnId=1; pnId<=5; pnId++){
+  for (int pnId = 1; pnId <= 5; pnId++) {
     bool errorOnPn(false);
     unsigned int realPnId = pnId;
-    
-    if(towerId_==70){ realPnId += 5;}
-	 
-    // Note : we are assuming always 5 VFE channels enabled 
-    // This means we all have 5 pns per tower 
+
+    if (towerId_ == 70) {
+      realPnId += 5;
+    }
+
+    // Note : we are assuming always 5 VFE channels enabled
+    // This means we all have 5 pns per tower
 
     // solution before sending creation of PnDigi's in mapper as done with crystals
     //     mapper_->getActiveSM()  : this is the 'dccid'
@@ -306,56 +281,40 @@ void DCCMemBlock::fillPnDiodeDigisCollection(){
     int subdet(0);
     if (NUMB_SM_EB_MIN_MIN <= activeSM && activeSM <= NUMB_SM_EB_PLU_MAX) {
       subdet = EcalBarrel;
-    }
-    else if( (NUMB_SM_EE_MIN_MIN <= activeSM && activeSM <= NUMB_SM_EE_MIN_MAX) ||
-            (NUMB_SM_EE_PLU_MIN <= activeSM && activeSM <= NUMB_SM_EE_PLU_MAX) ) {
+    } else if ((NUMB_SM_EE_MIN_MIN <= activeSM && activeSM <= NUMB_SM_EE_MIN_MAX) ||
+               (NUMB_SM_EE_PLU_MIN <= activeSM && activeSM <= NUMB_SM_EE_PLU_MAX)) {
       subdet = EcalEndcap;
-    }
-    else {
-      if( ! DCCDataUnpacker::silentMode_ ){
-        edm::LogWarning("IncorrectMapping")
-          <<"\n mapper points to non existing dccid: " << activeSM;
+    } else {
+      if (!DCCDataUnpacker::silentMode_) {
+        edm::LogWarning("IncorrectMapping") << "\n mapper points to non existing dccid: " << activeSM;
       }
     }
 
+    EcalPnDiodeDetId PnId(subdet, activeSM, realPnId);
 
-    EcalPnDiodeDetId PnId(subdet, activeSM, realPnId );
-    
-    EcalPnDiodeDigi thePnDigi(PnId );
+    EcalPnDiodeDigi thePnDigi(PnId);
     thePnDigi.setSize(kSamplesPerPn_);
-    
-    
-    for (unsigned int ts =0; ts <kSamplesPerPn_; ts++){
-      
-      short pnDiodeData = pn_[(towerId_-lastTowerBeforeMem_)*250 + (pnId-1)*kSamplesPerPn_ + ts];
-      if( pnDiodeData == -1){
-        errorOnPn=true;
-	     break;
+
+    for (unsigned int ts = 0; ts < kSamplesPerPn_; ts++) {
+      short pnDiodeData = pn_[(towerId_ - lastTowerBeforeMem_) * 250 + (pnId - 1) * kSamplesPerPn_ + ts];
+      if (pnDiodeData == -1) {
+        errorOnPn = true;
+        break;
       }
-	 
-      EcalFEMSample thePnSample(pnDiodeData );
-      thePnDigi.setSample(ts, thePnSample );  
+
+      EcalFEMSample thePnSample(pnDiodeData);
+      thePnDigi.setSample(ts, thePnSample);
     }
-    
-    if(!errorOnPn){ (*pnDiodeDigis_)->push_back(thePnDigi);}
-  
+
+    if (!errorOnPn) {
+      (*pnDiodeDigis_)->push_back(thePnDigi);
+    }
   }
-  
-} 
+}
 
-
-
-void DCCMemBlock::display(std::ostream& o){
-
-  o<<"\n Unpacked Info for DCC MEM Block"
-  <<"\n DW1 ============================="
-  <<"\n Mem Tower Block Id "<<towerId_
-  <<"\n Numb Samp "<<nTSamples_
-  <<"\n Bx "<<bx_
-  <<"\n L1 "<<l1_
-  <<"\n blockLength "<<blockLength_;  
-} 
-
-
-
-
+void DCCMemBlock::display(std::ostream& o) {
+  o << "\n Unpacked Info for DCC MEM Block"
+    << "\n DW1 ============================="
+    << "\n Mem Tower Block Id " << towerId_ << "\n Numb Samp " << nTSamples_ << "\n Bx " << bx_ << "\n L1 " << l1_
+    << "\n blockLength " << blockLength_;
+}

--- a/EventFilter/EcalRawToDigi/src/DCCSCBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCSCBlock.cc
@@ -4,284 +4,280 @@
 #include <cstdio>
 #include "EventFilter/EcalRawToDigi/interface/EcalElectronicsMapper.h"
 
+DCCSCBlock::DCCSCBlock(
+    DCCDataUnpacker *u, EcalElectronicsMapper *m, DCCEventBlock *e, bool unpack, bool forceToKeepFRdata)
+    : DCCFEBlock(u, m, e, unpack, forceToKeepFRdata) {}
 
-
-DCCSCBlock::DCCSCBlock( DCCDataUnpacker * u,EcalElectronicsMapper * m , DCCEventBlock * e, bool unpack, bool forceToKeepFRdata)
-: DCCFEBlock(u,m,e,unpack,forceToKeepFRdata){}
-
-
-void DCCSCBlock::updateCollectors(){
-
+void DCCSCBlock::updateCollectors() {
   DCCFEBlock::updateCollectors();
-  
+
   // needs to be update for eb/ee
-  digis_               = unpacker_->eeDigisCollection();
+  digis_ = unpacker_->eeDigisCollection();
 
-  invalidGains_        = unpacker_->invalidEEGainsCollection();
-  invalidGainsSwitch_  = unpacker_->invalidEEGainsSwitchCollection();
-  invalidChIds_        = unpacker_->invalidEEChIdsCollection();
-
+  invalidGains_ = unpacker_->invalidEEGainsCollection();
+  invalidGainsSwitch_ = unpacker_->invalidEEGainsSwitchCollection();
+  invalidChIds_ = unpacker_->invalidEEChIdsCollection();
 }
 
-
-
-
-int DCCSCBlock::unpackXtalData(unsigned int expStripID, unsigned int expXtalID){
-  
+int DCCSCBlock::unpackXtalData(unsigned int expStripID, unsigned int expXtalID) {
   bool errorOnXtal(false);
- 
-  const uint16_t * xData_= reinterpret_cast<const uint16_t *>(data_);
 
- 
+  const uint16_t *xData_ = reinterpret_cast<const uint16_t *>(data_);
+
   // Get xtal data ids
   unsigned int stripId = (*xData_) & TOWER_STRIPID_MASK;
-  unsigned int xtalId  =((*xData_)>>TOWER_XTALID_B ) & TOWER_XTALID_MASK;
-  
+  unsigned int xtalId = ((*xData_) >> TOWER_XTALID_B) & TOWER_XTALID_MASK;
+
   // std::cout<<"\n DEBUG : unpacked xtal data for strip id "<<stripId<<" and xtal id "<<xtalId<<std::endl;
   // std::cout<<"\n DEBUG : expected strip id "<<expStripID<<" expected xtal id "<<expXtalID<<std::endl;
-  
 
-  if( !zs_ && (expStripID != stripId || expXtalID != xtalId)){ 
+  if (!zs_ && (expStripID != stripId || expXtalID != xtalId)) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectBlock") << "For event LV1: " << event_->l1A() << ", fed " << mapper_->getActiveDCC()
+                                        << " and tower " << towerId_ << "\n The expected strip is " << expStripID
+                                        << " and " << stripId << " was found"
+                                        << "\n The expected xtal  is " << expXtalID << " and " << xtalId
+                                        << " was found";
+    }
 
-    if( ! DCCDataUnpacker::silentMode_ ){         
-      edm::LogWarning("IncorrectBlock")
-        <<"For event LV1: "<<event_->l1A()<<", fed "<<mapper_->getActiveDCC()<<" and tower "<<towerId_
-        <<"\n The expected strip is "<<expStripID<<" and "<<stripId<<" was found"
-        <<"\n The expected xtal  is "<<expXtalID <<" and "<<xtalId<<" was found";        
-     }
-    
-    
     // using expected cry_di to raise warning about xtal_id problem
-    pDetId_ = (EEDetId*) mapper_->getDetIdPointer(towerId_,expStripID,expXtalID);
-    if(pDetId_) {  (*invalidChIds_)->push_back(*pDetId_); }
-    
-    
+    pDetId_ = (EEDetId *)mapper_->getDetIdPointer(towerId_, expStripID, expXtalID);
+    if (pDetId_) {
+      (*invalidChIds_)->push_back(*pDetId_);
+    }
+
     // return here, so to skip all following checks
     data_ += numbDWInXtalBlock_;
     return BLOCK_UNPACKED;
   }
 
-
   // check id in case of 0suppressed data
 
-  else if(zs_) {
-
+  else if (zs_) {
     // Check for valid Ids 1) values out of range
 
     if (stripId == 0 || stripId > 5 || xtalId == 0 || xtalId > 5) {
-      
-      if (! DCCDataUnpacker::silentMode_ ) {
+      if (!DCCDataUnpacker::silentMode_) {
         edm::LogWarning("IncorrectBlock")
-          <<"For event LV1: "<<event_->l1A()<<", fed "<<mapper_->getActiveDCC()<<" and tower "<<towerId_
-          <<"\n Invalid strip : "<<stripId<<" or xtal : "<<xtalId
-          <<" ids ( last strip was: " << lastStripId_ << " last ch was: " << lastXtalId_ << ")";
-       }
-      
+            << "For event LV1: " << event_->l1A() << ", fed " << mapper_->getActiveDCC() << " and tower " << towerId_
+            << "\n Invalid strip : " << stripId << " or xtal : " << xtalId << " ids ( last strip was: " << lastStripId_
+            << " last ch was: " << lastXtalId_ << ")";
+      }
+
       int st = lastStripId_;
       int ch = lastXtalId_;
       ch++;
-      if (ch > NUMB_XTAL)         {ch=1; st++;}
-      if (st > NUMB_STRIP)        {ch=1; st=1;}
+      if (ch > NUMB_XTAL) {
+        ch = 1;
+        st++;
+      }
+      if (st > NUMB_STRIP) {
+        ch = 1;
+        st = 1;
+      }
 
       // adding channel following the last valid
       //pDetId_ = (EEDetId*) mapper_->getDetIdPointer(towerId_,st,ch);
       //(*invalidChIds_)->push_back(*pDetId_);
-      fillEcalElectronicsError(invalidZSXtalIds_); 
+      fillEcalElectronicsError(invalidZSXtalIds_);
 
       lastStripId_ = st;
-      lastXtalId_  = ch;
+      lastXtalId_ = ch;
 
       // return here, so to skip all following checks
       return SKIP_BLOCK_UNPACKING;
-    }
-    else {
+    } else {
       // Check for zs valid Ids 2) if channel-in-strip has increased wrt previous xtal
       //                        3) if strip has increased wrt previous xtal
-      if ((stripId == lastStripId_ && xtalId <= lastXtalId_ ) ||
-          (stripId < lastStripId_))
-        {
-          if (! DCCDataUnpacker::silentMode_) {
-            edm::LogWarning("IncorrectBlock")
-              << "Xtal id was expected to increase but it didn't - last xtal id was " << lastXtalId_ << " while current xtal is " << xtalId
-              << " (LV1 " << event_->l1A() << " fed " << mapper_->getActiveDCC() << " tower " << towerId_ << ")";
-          }
-          
-          int st = lastStripId_;
-          int ch = lastXtalId_;
-          ch++;
-          if (ch > NUMB_XTAL)        {ch=1; st++;}
-          if (st > NUMB_STRIP)        {ch=1; st=1;}
-          
-          // adding channel following the last valid
-          //pDetId_ = (EEDetId*) mapper_->getDetIdPointer(towerId_,stripId,xtalId);
-          //(*invalidChIds_)->push_back(*pDetId_);
-          fillEcalElectronicsError(invalidZSXtalIds_); 
-           
-           lastStripId_ = st;
-           lastXtalId_  = ch;
-           
-           // return here, so to skip all following checks
-           return SKIP_BLOCK_UNPACKING;
-
+      if ((stripId == lastStripId_ && xtalId <= lastXtalId_) || (stripId < lastStripId_)) {
+        if (!DCCDataUnpacker::silentMode_) {
+          edm::LogWarning("IncorrectBlock")
+              << "Xtal id was expected to increase but it didn't - last xtal id was " << lastXtalId_
+              << " while current xtal is " << xtalId << " (LV1 " << event_->l1A() << " fed " << mapper_->getActiveDCC()
+              << " tower " << towerId_ << ")";
         }
-        
-      lastStripId_  = stripId;
-      lastXtalId_   = xtalId;
-    }// end else
-  }// end if(zs_)
- 
-  bool addedFrame=false;
-  
-  // if there is an error on xtal id ignore next error checks  
+
+        int st = lastStripId_;
+        int ch = lastXtalId_;
+        ch++;
+        if (ch > NUMB_XTAL) {
+          ch = 1;
+          st++;
+        }
+        if (st > NUMB_STRIP) {
+          ch = 1;
+          st = 1;
+        }
+
+        // adding channel following the last valid
+        //pDetId_ = (EEDetId*) mapper_->getDetIdPointer(towerId_,stripId,xtalId);
+        //(*invalidChIds_)->push_back(*pDetId_);
+        fillEcalElectronicsError(invalidZSXtalIds_);
+
+        lastStripId_ = st;
+        lastXtalId_ = ch;
+
+        // return here, so to skip all following checks
+        return SKIP_BLOCK_UNPACKING;
+      }
+
+      lastStripId_ = stripId;
+      lastXtalId_ = xtalId;
+    }  // end else
+  }    // end if(zs_)
+
+  bool addedFrame = false;
+
+  // if there is an error on xtal id ignore next error checks
   // otherwise, assume channel_id is valid and proceed with making and checking the data frame
-  if(errorOnXtal) return SKIP_BLOCK_UNPACKING;
-  
-  pDetId_ = (EEDetId*) mapper_->getDetIdPointer(towerId_, stripId, xtalId);
-  
-  if(pDetId_){// checking that requested EEDetId exists
-    
+  if (errorOnXtal)
+    return SKIP_BLOCK_UNPACKING;
+
+  pDetId_ = (EEDetId *)mapper_->getDetIdPointer(towerId_, stripId, xtalId);
+
+  if (pDetId_) {  // checking that requested EEDetId exists
+
     (*digis_)->push_back(*pDetId_);
-    EEDataFrame df( (*digis_)->back() );
-    addedFrame=true;
+    EEDataFrame df((*digis_)->back());
+    addedFrame = true;
     bool wrongGain(false);
-    
+
     //set samples in the frame
-    for(unsigned int i =0; i< nTSamples_ ;i++){ 
+    for (unsigned int i = 0; i < nTSamples_; i++) {
       xData_++;
-      unsigned int data =  (*xData_) & TOWER_DIGI_MASK;
-      unsigned int gain =  data>>12;
-      xtalGains_[i]=gain;
-      if(gain == 0){          wrongGain = true; }      // although gain==0 found, produce the dataFrame in order to have it, for saturation case
-      df.setSample(i,data);
+      unsigned int data = (*xData_) & TOWER_DIGI_MASK;
+      unsigned int gain = data >> 12;
+      xtalGains_[i] = gain;
+      if (gain == 0) {
+        wrongGain = true;
+      }  // although gain==0 found, produce the dataFrame in order to have it, for saturation case
+      df.setSample(i, data);
     }
-    
+
     bool isSaturation(true);
-    if(wrongGain){
-      
-      // check whether the gain==0 has features of saturation or not 
-      // gain==0 occurs either in case of data corruption or of ADC saturation 
-      //                                  \->reject digi            \-> keep digi 
-      
+    if (wrongGain) {
+      // check whether the gain==0 has features of saturation or not
+      // gain==0 occurs either in case of data corruption or of ADC saturation
+      //                                  \->reject digi            \-> keep digi
+
       // determine where gainId==0 starts
-      short firstGainZeroSampID(-1);    short firstGainZeroSampADC(-1);
-      for (unsigned int s=0; s<nTSamples_; s++ ) {
-        if(df.sample(s).gainId()==0 && firstGainZeroSampID==-1)
-          {
-          firstGainZeroSampID  = s;
+      short firstGainZeroSampID(-1);
+      short firstGainZeroSampADC(-1);
+      for (unsigned int s = 0; s < nTSamples_; s++) {
+        if (df.sample(s).gainId() == 0 && firstGainZeroSampID == -1) {
+          firstGainZeroSampID = s;
           firstGainZeroSampADC = df.sample(s).adc();
           break;
-          }
+        }
       }
-      
-    // check whether gain==0 and adc() stays constant for (at least) 5 consecutive samples
-    unsigned int plateauEnd = std::min(nTSamples_,(unsigned int)(firstGainZeroSampID+5));
-    for (unsigned int s=firstGainZeroSampID; s<plateauEnd; s++) 
-      {
-        if( df.sample(s).gainId()==0 && df.sample(s).adc()==firstGainZeroSampADC ) {;}
-        else
-          { isSaturation=false;   break;}  //it's not saturation
-      }
-    // get rid of channels which are stuck in gain0
-    if(firstGainZeroSampID<3) {isSaturation=false; }
 
-    if (! DCCDataUnpacker::silentMode_) {
-      if (unpacker_->getChannelValue(mapper_->getActiveDCC(), towerId_, stripId, xtalId) != 10) {
-        edm::LogWarning("IncorrectGain")
-          << "Gain zero" << (isSaturation ? " with features of saturation" : "" ) << " was found in SC Block"
-          << " (L1A " << event_->l1A() << " bx " << event_->bx() << " fed " << mapper_->getActiveDCC()
-          << " tower " << towerId_ << " strip " << stripId << " xtal " << xtalId << ")";
+      // check whether gain==0 and adc() stays constant for (at least) 5 consecutive samples
+      unsigned int plateauEnd = std::min(nTSamples_, (unsigned int)(firstGainZeroSampID + 5));
+      for (unsigned int s = firstGainZeroSampID; s < plateauEnd; s++) {
+        if (df.sample(s).gainId() == 0 && df.sample(s).adc() == firstGainZeroSampADC) {
+          ;
+        } else {
+          isSaturation = false;
+          break;
+        }  //it's not saturation
       }
-    }
-    
-    if (! isSaturation)
-      {     
-        (*invalidGains_)->push_back(*pDetId_); 
+      // get rid of channels which are stuck in gain0
+      if (firstGainZeroSampID < 3) {
+        isSaturation = false;
+      }
+
+      if (!DCCDataUnpacker::silentMode_) {
+        if (unpacker_->getChannelValue(mapper_->getActiveDCC(), towerId_, stripId, xtalId) != 10) {
+          edm::LogWarning("IncorrectGain")
+              << "Gain zero" << (isSaturation ? " with features of saturation" : "") << " was found in SC Block"
+              << " (L1A " << event_->l1A() << " bx " << event_->bx() << " fed " << mapper_->getActiveDCC() << " tower "
+              << towerId_ << " strip " << stripId << " xtal " << xtalId << ")";
+        }
+      }
+
+      if (!isSaturation) {
+        (*invalidGains_)->push_back(*pDetId_);
         (*digis_)->pop_back();
-        
+
         //return here, so to skip all the rest
         //make special collection for gain0 data frames (saturation)
         //Point to begin of next xtal Block
         data_ += numbDWInXtalBlock_;
-        
+
         return BLOCK_UNPACKED;
-        
-      }//end isSaturation 
-    else {
-            data_ += numbDWInXtalBlock_;
-            return BLOCK_UNPACKED;
-    }
-    }//end WrongGain
-    
-    short firstGainWrong=-1;
-    short numGainWrong=0;
-    
-    for (unsigned int i=1; i<nTSamples_; i++ ) {
-      if (xtalGains_[i-1]>xtalGains_[i]) {
+
+      }  //end isSaturation
+      else {
+        data_ += numbDWInXtalBlock_;
+        return BLOCK_UNPACKED;
+      }
+    }  //end WrongGain
+
+    short firstGainWrong = -1;
+    short numGainWrong = 0;
+
+    for (unsigned int i = 1; i < nTSamples_; i++) {
+      if (xtalGains_[i - 1] > xtalGains_[i]) {
         numGainWrong++;
-        
-        if (firstGainWrong == -1) { firstGainWrong=i;}
+
+        if (firstGainWrong == -1) {
+          firstGainWrong = i;
+        }
       }
     }
-    
+
     if (numGainWrong > 0) {
-      if (! DCCDataUnpacker::silentMode_) {
-        edm::LogWarning("IncorrectGain")
-          << "A wrong gain transition switch was found for SC Block in strip " << stripId << " and xtal " << xtalId
-          << " (L1A " << event_->l1A() << " bx " << event_->bx() << " fed " << mapper_->getActiveDCC() << " tower " << towerId_ << ")";
+      if (!DCCDataUnpacker::silentMode_) {
+        edm::LogWarning("IncorrectGain") << "A wrong gain transition switch was found for SC Block in strip " << stripId
+                                         << " and xtal " << xtalId << " (L1A " << event_->l1A() << " bx "
+                                         << event_->bx() << " fed " << mapper_->getActiveDCC() << " tower " << towerId_
+                                         << ")";
       }
-      
+
       (*invalidGainsSwitch_)->push_back(*pDetId_);
-      
+
       errorOnXtal = true;
     }
-    
+
     //Add frame to collection only if all data format and gain rules are respected
     if (errorOnXtal && addedFrame) {
       (*digis_)->pop_back();
     }
-    
-  }// End 'if EE id exist'
-  
+
+  }  // End 'if EE id exist'
+
   else {
     // in case EEDetId do not exist
     // In EE we may have crystals with no valid EEDetId
-    if (! mapper_->isGhost(mapper_->getActiveDCC(), towerId_, stripId)) { // check the VFE is not a 'ghost'
-      
+    if (!mapper_->isGhost(mapper_->getActiveDCC(), towerId_, stripId)) {  // check the VFE is not a 'ghost'
+
       // this is real EE VFE - print warning
-      if (! DCCDataUnpacker::silentMode_) {
-        edm::LogWarning("IncorrectBlock")
-          << "An EEDetId was requested that does not exist "
-          << "(LV1 " << event_->l1A()
-          << " fed " << mapper_->getActiveDCC()
-          << " tower " << towerId_
-          << " strip " << stripId
-          << " xtal " << xtalId << ")";
+      if (!DCCDataUnpacker::silentMode_) {
+        edm::LogWarning("IncorrectBlock") << "An EEDetId was requested that does not exist "
+                                          << "(LV1 " << event_->l1A() << " fed " << mapper_->getActiveDCC() << " tower "
+                                          << towerId_ << " strip " << stripId << " xtal " << xtalId << ")";
       }
     }
   }
-  
+
   //Point to begin of next xtal Block
   data_ += numbDWInXtalBlock_;
-  
+
   return BLOCK_UNPACKED;
 }
 
-
-void DCCSCBlock::fillEcalElectronicsError( std::unique_ptr<EcalElectronicsIdCollection> * errorColection){
-
+void DCCSCBlock::fillEcalElectronicsError(std::unique_ptr<EcalElectronicsIdCollection> *errorColection) {
   const int activeDCC = mapper_->getActiveSM();
 
-  if ( (NUMB_SM_EE_MIN_MIN <=activeDCC && activeDCC<=NUMB_SM_EE_MIN_MAX) ||
-         (NUMB_SM_EE_PLU_MIN <=activeDCC && activeDCC<=NUMB_SM_EE_PLU_MAX) ){
-     EcalElectronicsId  *  eleTp = mapper_->getSCElectronicsPointer(activeDCC,expTowerID_);
-     (*errorColection)->push_back(*eleTp);
-  }else{
-     if( ! DCCDataUnpacker::silentMode_ ){
-       edm::LogWarning("IncorrectBlock")
-         <<"For event "<<event_->l1A()<<" there's fed: "<< activeDCC
-         <<" activeDcc: "<<mapper_->getActiveSM()
-         <<" but that activeDcc is not valid in EE.";
-     }
+  if ((NUMB_SM_EE_MIN_MIN <= activeDCC && activeDCC <= NUMB_SM_EE_MIN_MAX) ||
+      (NUMB_SM_EE_PLU_MIN <= activeDCC && activeDCC <= NUMB_SM_EE_PLU_MAX)) {
+    EcalElectronicsId *eleTp = mapper_->getSCElectronicsPointer(activeDCC, expTowerID_);
+    (*errorColection)->push_back(*eleTp);
+  } else {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectBlock") << "For event " << event_->l1A() << " there's fed: " << activeDCC
+                                        << " activeDcc: " << mapper_->getActiveSM()
+                                        << " but that activeDcc is not valid in EE.";
+    }
   }
-
 }

--- a/EventFilter/EcalRawToDigi/src/DCCSRPBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCSRPBlock.cc
@@ -3,115 +3,99 @@
 #include "EventFilter/EcalRawToDigi/interface/EcalElectronicsMapper.h"
 #include "EventFilter/EcalRawToDigi/interface/DCCDataUnpacker.h"
 
-DCCSRPBlock::DCCSRPBlock(
-  DCCDataUnpacker * u,EcalElectronicsMapper * m, DCCEventBlock * e, bool unpack
-) : DCCDataBlockPrototype(u,m,e,unpack)
-{
- 
+DCCSRPBlock::DCCSRPBlock(DCCDataUnpacker* u, EcalElectronicsMapper* m, DCCEventBlock* e, bool unpack)
+    : DCCDataBlockPrototype(u, m, e, unpack) {
   // Todo : include data integrity collections
-  blockLength_    = SRP_BLOCKLENGTH;
+  blockLength_ = SRP_BLOCKLENGTH;
   // Set SR flags to zero
-  for(unsigned int i=0; i<SRP_NUMBFLAGS; i++){ srFlags_[i]=0; }
-
+  for (unsigned int i = 0; i < SRP_NUMBFLAGS; i++) {
+    srFlags_[i] = 0;
+  }
 }
 
-
-int DCCSRPBlock::unpack(const uint64_t ** data, unsigned int * dwToEnd, unsigned int numbFlags ){    
-
+int DCCSRPBlock::unpack(const uint64_t** data, unsigned int* dwToEnd, unsigned int numbFlags) {
   // Set SR flags to zero
-  for(unsigned int i=0; i<SRP_NUMBFLAGS; i++){ srFlags_[i]=0; }
-  
+  for (unsigned int i = 0; i < SRP_NUMBFLAGS; i++) {
+    srFlags_[i] = 0;
+  }
 
   expNumbSrFlags_ = numbFlags;
-  error_          = false;  
-  datap_          = data;
-  data_           = *data;
-  dwToEnd_        = dwToEnd;
-  
+  error_ = false;
+  datap_ = data;
+  data_ = *data;
+  dwToEnd_ = dwToEnd;
+
   // Check SRP Length
-  if( (*dwToEnd_) < blockLength_ ){
-    if( ! DCCDataUnpacker::silentMode_ ){ 
-      edm::LogWarning("IncorrectEvent")
-        <<"\n Event "<<l1_
-        <<"\n Unable to unpack SRP block for event "<<event_->l1A()<<" in fed <<"<<mapper_->getActiveDCC()
-        <<"\n Only "<<((*dwToEnd_)*8)<<" bytes are available while "<<(blockLength_*8)<<" are needed!";
-     }
-    
-    //Note : add to error collection 
-    
+  if ((*dwToEnd_) < blockLength_) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectEvent") << "\n Event " << l1_ << "\n Unable to unpack SRP block for event "
+                                        << event_->l1A() << " in fed <<" << mapper_->getActiveDCC() << "\n Only "
+                                        << ((*dwToEnd_) * 8) << " bytes are available while " << (blockLength_ * 8)
+                                        << " are needed!";
+    }
+
+    //Note : add to error collection
+
     return STOP_EVENT_UNPACKING;
-    
   }
-  
-  
-  
+
   // Point to begin of block
   data_++;
-  
-  srpId_          = ( *data_ ) & SRP_ID_MASK; 
-  bx_             = ( *data_>>SRP_BX_B     ) & SRP_BX_MASK;
-  l1_             = ( *data_>>SRP_L1_B     ) & SRP_L1_MASK;
-  nSRFlags_       = ( *data_>>SRP_NFLAGS_B ) & SRP_NFLAGS_MASK;
-  
-  event_->setSRPSyncNumbers(l1_,bx_);
- 
-  if( ! checkSrpIdAndNumbSRFlags() ){ 
-    //// SRP flags are required to check FE data 
+
+  srpId_ = (*data_) & SRP_ID_MASK;
+  bx_ = (*data_ >> SRP_BX_B) & SRP_BX_MASK;
+  l1_ = (*data_ >> SRP_L1_B) & SRP_L1_MASK;
+  nSRFlags_ = (*data_ >> SRP_NFLAGS_B) & SRP_NFLAGS_MASK;
+
+  event_->setSRPSyncNumbers(l1_, bx_);
+
+  if (!checkSrpIdAndNumbSRFlags()) {
+    //// SRP flags are required to check FE data
     //return  STOP_EVENT_UNPACKING;
     updateEventPointers();
     return SKIP_BLOCK_UNPACKING;
   }
-	 
+
   // Check synchronization
-  if(sync_){
-    const unsigned int dccL1 = ( event_->l1A() ) & SRP_L1_MASK;
-    const unsigned int dccBx = ( event_->bx()  ) & SRP_BX_MASK;
-    const unsigned int fov   = ( event_->fov() ) & H_FOV_MASK;
-    
-    if (! isSynced(dccBx, bx_, dccL1, l1_, TCC_SRP, fov)) {
-      if( ! DCCDataUnpacker::silentMode_ ){
+  if (sync_) {
+    const unsigned int dccL1 = (event_->l1A()) & SRP_L1_MASK;
+    const unsigned int dccBx = (event_->bx()) & SRP_BX_MASK;
+    const unsigned int fov = (event_->fov()) & H_FOV_MASK;
+
+    if (!isSynced(dccBx, bx_, dccL1, l1_, TCC_SRP, fov)) {
+      if (!DCCDataUnpacker::silentMode_) {
         edm::LogWarning("IncorrectEvent")
-          << "Synchronization error for SRP block"
-          << " (L1A " << event_->l1A() << " bx " << event_->bx() << " fed " << mapper_->getActiveDCC() << ")\n"
-          << "  dccBx = " << dccBx << " bx_ = " << bx_ << " dccL1 = " << dccL1 << " l1_ = " << l1_ << "\n"
-          << "  => Stop event unpacking";
+            << "Synchronization error for SRP block"
+            << " (L1A " << event_->l1A() << " bx " << event_->bx() << " fed " << mapper_->getActiveDCC() << ")\n"
+            << "  dccBx = " << dccBx << " bx_ = " << bx_ << " dccL1 = " << dccL1 << " l1_ = " << l1_ << "\n"
+            << "  => Stop event unpacking";
       }
-       //Note : add to error collection ?		 
-       //// SRP flags are required to check FE , better using synchronized data...
+      //Note : add to error collection ?
+      //// SRP flags are required to check FE , better using synchronized data...
       //	   return STOP_EVENT_UNPACKING;
       updateEventPointers();
       return SKIP_BLOCK_UNPACKING;
     }
-  } 
+  }
 
   // initialize array, protecting in case of inconsistently formatted data
-  for(int dccCh=0; dccCh<SRP_NUMBFLAGS; dccCh++) srFlags_[dccCh] =0;
-  
-  //display(cout); 
+  for (int dccCh = 0; dccCh < SRP_NUMBFLAGS; dccCh++)
+    srFlags_[dccCh] = 0;
+
+  //display(cout);
   addSRFlagToCollection();
-  
+
   updateEventPointers();
-  
+
   return true;
-        
 }
 
+void DCCSRPBlock::display(std::ostream& o) {
+  o << "\n Unpacked Info for SRP Block"
+    << "\n DW1 ============================="
+    << "\n SRP Id " << srpId_ << "\n Numb Flags " << nSRFlags_ << "\n Bx " << bx_ << "\n L1 " << l1_;
 
-
-void DCCSRPBlock::display(std::ostream& o){
-
-  o<<"\n Unpacked Info for SRP Block"
-  <<"\n DW1 ============================="
-  <<"\n SRP Id "<<srpId_
-  <<"\n Numb Flags "<<nSRFlags_ 
-  <<"\n Bx "<<bx_
-  <<"\n L1 "<<l1_;
- 
-  for(unsigned int i=0; i<SRP_NUMBFLAGS; i++){ 
-    o<<"\n SR flag "<<(i+1)<<" = "<<(srFlags_[i]); 
-  } 
-} 
-
-
-
-
+  for (unsigned int i = 0; i < SRP_NUMBFLAGS; i++) {
+    o << "\n SR flag " << (i + 1) << " = " << (srFlags_[i]);
+  }
+}

--- a/EventFilter/EcalRawToDigi/src/DCCTCCBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCTCCBlock.cc
@@ -4,93 +4,87 @@
 #include "EventFilter/EcalRawToDigi/interface/DCCDataUnpacker.h"
 #include "EventFilter/EcalRawToDigi/interface/DCCEventBlock.h"
 
-DCCTCCBlock::DCCTCCBlock ( DCCDataUnpacker  * u, EcalElectronicsMapper * m, DCCEventBlock * e, bool unpack) : 
-DCCDataBlockPrototype(u,m,e,unpack){}
+DCCTCCBlock::DCCTCCBlock(DCCDataUnpacker* u, EcalElectronicsMapper* m, DCCEventBlock* e, bool unpack)
+    : DCCDataBlockPrototype(u, m, e, unpack) {}
 
- 
-int DCCTCCBlock::unpack(const uint64_t ** data, unsigned int * dwToEnd, short tccChId){ 
- 
-  dwToEnd_    = dwToEnd;  
-  datap_      = data;
-  data_       = *data;
-  
+int DCCTCCBlock::unpack(const uint64_t** data, unsigned int* dwToEnd, short tccChId) {
+  dwToEnd_ = dwToEnd;
+  datap_ = data;
+  data_ = *data;
+
   // Need at least 1 dw to findout if pseudo-strips readout is enabled
-  if(*dwToEnd == 1){
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogWarning("IncorrectEvent")
-        <<"EcalRawToDigi@SUB=DCCTCCBlock:unpack"
-        <<"\n Unable to unpack TCC block for event "<<event_->l1A()<<" in fed "<<mapper_->getActiveDCC()
-        <<"\n Only 8 bytes are available until the end of event ..."
-        <<"\n => Skipping to next fed block...";
-     }
-    
+  if (*dwToEnd == 1) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectEvent") << "EcalRawToDigi@SUB=DCCTCCBlock:unpack"
+                                        << "\n Unable to unpack TCC block for event " << event_->l1A() << " in fed "
+                                        << mapper_->getActiveDCC()
+                                        << "\n Only 8 bytes are available until the end of event ..."
+                                        << "\n => Skipping to next fed block...";
+    }
+
     //todo : add this to error colection
-    
+
     return STOP_EVENT_UNPACKING;
   }
 
   blockLength_ = getLength();
-  
-  
-  if( (*dwToEnd_)<blockLength_ ){
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogWarning("IncorrectEvent")
-        <<"EcalRawToDigi@SUB=DCCTCCBlock:unpack"
-        <<"\n Unable to unpack TCC block for event "<<event_->l1A()<<" in fed "<<mapper_->getActiveDCC()
-        <<"\n Only "<<((*dwToEnd_)*8)<<" bytes are available until the end of event while "<<(blockLength_*8)<<" are needed!"
-        <<"\n => Skipping to next fed block...";
-     }
-    
+
+  if ((*dwToEnd_) < blockLength_) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectEvent") << "EcalRawToDigi@SUB=DCCTCCBlock:unpack"
+                                        << "\n Unable to unpack TCC block for event " << event_->l1A() << " in fed "
+                                        << mapper_->getActiveDCC() << "\n Only " << ((*dwToEnd_) * 8)
+                                        << " bytes are available until the end of event while " << (blockLength_ * 8)
+                                        << " are needed!"
+                                        << "\n => Skipping to next fed block...";
+    }
+
     //todo : add this to error colection
-    
+
     return STOP_EVENT_UNPACKING;
   }
-  
-  
-  
-  if(unpackInternalData_){ 
-  
+
+  if (unpackInternalData_) {
     //  Go to the begining of the tcc block
     data_++;
-  
-    tccId_    = ( *data_ )           & TCC_ID_MASK;
-    ps_       = ( *data_>>TCC_PS_B ) & B_MASK;      
-    bx_       = ( *data_>>TCC_BX_B ) & TCC_BX_MASK;
-    l1_       = ( *data_>>TCC_L1_B ) & TCC_L1_MASK;
-    nTTs_     = ( *data_>>TCC_TT_B ) & TCC_TT_MASK;
-    nTSamples_= ( *data_>>TCC_TS_B ) & TCC_TS_MASK;
-        
-    event_->setTCCSyncNumbers(l1_,bx_,tccChId);
 
-    if ( ! checkTccIdAndNumbTTs() ){
-          updateEventPointers();
-          return SKIP_BLOCK_UNPACKING;
-        }  
-  
+    tccId_ = (*data_) & TCC_ID_MASK;
+    ps_ = (*data_ >> TCC_PS_B) & B_MASK;
+    bx_ = (*data_ >> TCC_BX_B) & TCC_BX_MASK;
+    l1_ = (*data_ >> TCC_L1_B) & TCC_L1_MASK;
+    nTTs_ = (*data_ >> TCC_TT_B) & TCC_TT_MASK;
+    nTSamples_ = (*data_ >> TCC_TS_B) & TCC_TS_MASK;
+
+    event_->setTCCSyncNumbers(l1_, bx_, tccChId);
+
+    if (!checkTccIdAndNumbTTs()) {
+      updateEventPointers();
+      return SKIP_BLOCK_UNPACKING;
+    }
+
     // Check synchronization
-    if(sync_){
-      const unsigned int dccBx = (event_->bx())  & TCC_BX_MASK;
+    if (sync_) {
+      const unsigned int dccBx = (event_->bx()) & TCC_BX_MASK;
       const unsigned int dccL1 = (event_->l1A()) & TCC_L1_MASK;
-      const unsigned int fov   = ( event_->fov() ) & H_FOV_MASK;
-      
-      if (! isSynced(dccBx, bx_, dccL1, l1_, TCC_SRP, fov)) {
-        if( ! DCCDataUnpacker::silentMode_ ){
+      const unsigned int fov = (event_->fov()) & H_FOV_MASK;
+
+      if (!isSynced(dccBx, bx_, dccL1, l1_, TCC_SRP, fov)) {
+        if (!DCCDataUnpacker::silentMode_) {
           edm::LogWarning("IncorrectBlock")
-            << "Synchronization error for TCC block"
-            << " (L1A " << event_->l1A() << " bx " << event_->bx() << " fed " << mapper_->getActiveDCC() << ")\n"
-            << "  dccBx = " << dccBx << " bx_ = " << bx_ << " dccL1 = " << dccL1 << " l1_ = " << l1_ << "\n"
-            << "  => TCC block skipped";
+              << "Synchronization error for TCC block"
+              << " (L1A " << event_->l1A() << " bx " << event_->bx() << " fed " << mapper_->getActiveDCC() << ")\n"
+              << "  dccBx = " << dccBx << " bx_ = " << bx_ << " dccL1 = " << dccL1 << " l1_ = " << l1_ << "\n"
+              << "  => TCC block skipped";
         }
-        
-        //Note : add to error collection ?        
+
+        //Note : add to error collection ?
         updateEventPointers();
         return SKIP_BLOCK_UNPACKING;
-        
       }
     }
-    
+
     //check numb of samples
-   /*  
+    /*  
     unsigned int expTriggerTSamples(mapper_->numbTriggerTSamples());
     
     if( nTSamples_ != expTriggerTSamples ){
@@ -103,30 +97,21 @@ int DCCTCCBlock::unpack(const uint64_t ** data, unsigned int * dwToEnd, short tc
            updateEventPointers();                 
       return SKIP_BLOCK_UNPACKING;
     }
-    */         
-  
+    */
+
     // debugging
     // display(cout);
 
     addTriggerPrimitivesToCollection();
-
-  } 
+  }
 
   updateEventPointers();
-  return BLOCK_UNPACKED;        
-  
+  return BLOCK_UNPACKED;
 }
 
-
-
-void DCCTCCBlock::display(std::ostream& o){
-
-  o<<"\n Unpacked Info for DCC TCC Block"
-   <<"\n DW1 ============================="
-   <<"\n TCC Id "<<tccId_
-   <<"\n Bx "<<bx_
-   <<"\n L1 "<<l1_
-   <<"\n Numb TT "<<nTTs_
-   <<"\n Numb Samp "<<nTSamples_;  
-} 
-    
+void DCCTCCBlock::display(std::ostream& o) {
+  o << "\n Unpacked Info for DCC TCC Block"
+    << "\n DW1 ============================="
+    << "\n TCC Id " << tccId_ << "\n Bx " << bx_ << "\n L1 " << l1_ << "\n Numb TT " << nTTs_ << "\n Numb Samp "
+    << nTSamples_;
+}

--- a/EventFilter/EcalRawToDigi/src/DCCTowerBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCTowerBlock.cc
@@ -5,270 +5,272 @@
 #include "EventFilter/EcalRawToDigi/interface/DCCDataUnpacker.h"
 #include "EventFilter/EcalRawToDigi/interface/EcalElectronicsMapper.h"
 
+DCCTowerBlock::DCCTowerBlock(
+    DCCDataUnpacker *u, EcalElectronicsMapper *m, DCCEventBlock *e, bool unpack, bool forceToKeepFRdata)
+    : DCCFEBlock(u, m, e, unpack, forceToKeepFRdata) {}
 
-
-DCCTowerBlock::DCCTowerBlock( DCCDataUnpacker * u, EcalElectronicsMapper * m, DCCEventBlock * e, bool unpack , bool forceToKeepFRdata)
-: DCCFEBlock(u,m,e,unpack,forceToKeepFRdata){}
-
-
-void DCCTowerBlock::updateCollectors(){
-
+void DCCTowerBlock::updateCollectors() {
   DCCFEBlock::updateCollectors();
-  
-  // needs to be update for eb/ee
-  digis_                 = unpacker_->ebDigisCollection();
-   
-  invalidGains_          = unpacker_->invalidGainsCollection();
-  invalidGainsSwitch_    = unpacker_->invalidGainsSwitchCollection();
-  invalidChIds_          = unpacker_->invalidChIdsCollection();
 
+  // needs to be update for eb/ee
+  digis_ = unpacker_->ebDigisCollection();
+
+  invalidGains_ = unpacker_->invalidGainsCollection();
+  invalidGainsSwitch_ = unpacker_->invalidGainsSwitchCollection();
+  invalidChIds_ = unpacker_->invalidChIdsCollection();
 }
 
-
-
-int DCCTowerBlock::unpackXtalData(unsigned int expStripID, unsigned int expXtalID){
-  
+int DCCTowerBlock::unpackXtalData(unsigned int expStripID, unsigned int expXtalID) {
   bool errorOnXtal(false);
- 
-  const uint16_t * xData_= reinterpret_cast<const uint16_t *>(data_);
+
+  const uint16_t *xData_ = reinterpret_cast<const uint16_t *>(data_);
 
   // Get xtal data ids
-  unsigned int stripId  = (*xData_)                     & TOWER_STRIPID_MASK;
-  unsigned int xtalId   = ((*xData_)>>TOWER_XTALID_B )  & TOWER_XTALID_MASK;
+  unsigned int stripId = (*xData_) & TOWER_STRIPID_MASK;
+  unsigned int xtalId = ((*xData_) >> TOWER_XTALID_B) & TOWER_XTALID_MASK;
 
   // check id in case data are not 0suppressed
-  if( !zs_ && (expStripID != stripId || expXtalID != xtalId)){ 
-    if(! DCCDataUnpacker::silentMode_){ 
-      edm::LogWarning("IncorrectBlock")
-        <<"For event L1A: "<<event_->l1A()<<", fed "<<mapper_->getActiveDCC()<<" and tower "<<towerId_
-        <<"\n The expected strip is "<<expStripID<<" and "<<stripId<<" was found"
-        <<"\n The expected xtal  is "<<expXtalID <<" and "<<xtalId<<" was found";        
-    } 
+  if (!zs_ && (expStripID != stripId || expXtalID != xtalId)) {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectBlock") << "For event L1A: " << event_->l1A() << ", fed " << mapper_->getActiveDCC()
+                                        << " and tower " << towerId_ << "\n The expected strip is " << expStripID
+                                        << " and " << stripId << " was found"
+                                        << "\n The expected xtal  is " << expXtalID << " and " << xtalId
+                                        << " was found";
+    }
     // using expected cry_di to raise warning about xtal_id problem
-    pDetId_ = (EBDetId*) mapper_->getDetIdPointer(towerId_,expStripID,expXtalID);
+    pDetId_ = (EBDetId *)mapper_->getDetIdPointer(towerId_, expStripID, expXtalID);
     (*invalidChIds_)->push_back(*pDetId_);
-    
+
     // return here, so to skip all following checks
     lastXtalId_++;
-    if (lastXtalId_ > NUMB_XTAL)         {lastXtalId_=1; lastStripId_++;}
+    if (lastXtalId_ > NUMB_XTAL) {
+      lastXtalId_ = 1;
+      lastStripId_++;
+    }
     data_ += numbDWInXtalBlock_;
     return BLOCK_UNPACKED;
 
     //keep these here in case the return is to be dropped
-    stripId    = expStripID;
-    xtalId     = expXtalID;
-    errorOnXtal= true;    
+    stripId = expStripID;
+    xtalId = expXtalID;
+    errorOnXtal = true;
   }
-
 
   // check id in case of 0suppressed data
 
-  else if(zs_){
-
+  else if (zs_) {
     // Check for valid Ids 1) values out of range
 
-    if(stripId == 0 || stripId > 5 || xtalId == 0 || xtalId > 5){
-      if( ! DCCDataUnpacker::silentMode_ ){
+    if (stripId == 0 || stripId > 5 || xtalId == 0 || xtalId > 5) {
+      if (!DCCDataUnpacker::silentMode_) {
         edm::LogWarning("IncorrectBlock")
-          <<"For event L1A: "<<event_->l1A()<<", fed "<<mapper_->getActiveDCC()<<" and tower "<<towerId_
-          <<"\n Invalid strip : "<<stripId<<" or xtal : "<<xtalId
-          <<" ids ( last strip was: " << lastStripId_ << " last ch was: " << lastXtalId_ << ")";
+            << "For event L1A: " << event_->l1A() << ", fed " << mapper_->getActiveDCC() << " and tower " << towerId_
+            << "\n Invalid strip : " << stripId << " or xtal : " << xtalId << " ids ( last strip was: " << lastStripId_
+            << " last ch was: " << lastXtalId_ << ")";
       }
-      
+
       int st = lastStripId_;
       int ch = lastXtalId_;
       ch++;
-      if (ch > NUMB_XTAL)         {ch=1; st++;}
-      if (st > NUMB_STRIP)        {ch=1; st=1;}
-      
+      if (ch > NUMB_XTAL) {
+        ch = 1;
+        st++;
+      }
+      if (st > NUMB_STRIP) {
+        ch = 1;
+        st = 1;
+      }
+
       // adding channel following the last valid
       //pDetId_ = (EBDetId*) mapper_->getDetIdPointer(towerId_,st,ch);
       //(*invalidChIds_)->push_back(*pDetId_);
-      fillEcalElectronicsError(invalidZSXtalIds_); 
-
+      fillEcalElectronicsError(invalidZSXtalIds_);
 
       lastStripId_ = st;
-      lastXtalId_  = ch;
-      
+      lastXtalId_ = ch;
+
       // return here, so to skip all following checks
       return SKIP_BLOCK_UNPACKING;
-      errorOnXtal = true; //keep it here in case the return is to be dropped      
-    }else{
-
+      errorOnXtal = true;  //keep it here in case the return is to be dropped
+    } else {
       // Check for zs valid Ids 2) if channel-in-strip has increased wrt previous xtal
-      
-      
+
       // Check for zs valid Ids 2) if channel-in-strip has increased wrt previous xtal
       //                        3) if strip has increased wrt previous xtal
-      if( ( stripId == lastStripId_ && xtalId <= lastXtalId_ ) ||
-          (stripId < lastStripId_))
-        {
-          if (! DCCDataUnpacker::silentMode_) {
-            edm::LogWarning("IncorrectBlock")
-              << "Xtal id was expected to increase but it didn't - last valid xtal id was " << lastXtalId_ << " while current xtal is " << xtalId
-              << " (LV1 " << event_->l1A() << " fed " << mapper_->getActiveDCC() << " tower " << towerId_ << ")";
-          }
-          
-          int st = lastStripId_;
-          int ch = lastXtalId_;
-          ch++;
-          if (ch > NUMB_XTAL)        {ch=1; st++;}
-          if (st >  NUMB_STRIP)        {ch=1; st=1;}
-          
-          // adding channel following the last valid
-          //pDetId_ = (EBDetId*) mapper_->getDetIdPointer(towerId_,st,ch);
-          //(*invalidChIds_)->push_back(*pDetId_);
-          fillEcalElectronicsError(invalidZSXtalIds_); 
-          
-          lastStripId_ = st;
-          lastXtalId_  = ch;
-
-          // return here, so to skip all following checks
-          return SKIP_BLOCK_UNPACKING;
-          errorOnXtal = true; //keep it here in case the return is to be dropped
+      if ((stripId == lastStripId_ && xtalId <= lastXtalId_) || (stripId < lastStripId_)) {
+        if (!DCCDataUnpacker::silentMode_) {
+          edm::LogWarning("IncorrectBlock")
+              << "Xtal id was expected to increase but it didn't - last valid xtal id was " << lastXtalId_
+              << " while current xtal is " << xtalId << " (LV1 " << event_->l1A() << " fed " << mapper_->getActiveDCC()
+              << " tower " << towerId_ << ")";
         }
-      
+
+        int st = lastStripId_;
+        int ch = lastXtalId_;
+        ch++;
+        if (ch > NUMB_XTAL) {
+          ch = 1;
+          st++;
+        }
+        if (st > NUMB_STRIP) {
+          ch = 1;
+          st = 1;
+        }
+
+        // adding channel following the last valid
+        //pDetId_ = (EBDetId*) mapper_->getDetIdPointer(towerId_,st,ch);
+        //(*invalidChIds_)->push_back(*pDetId_);
+        fillEcalElectronicsError(invalidZSXtalIds_);
+
+        lastStripId_ = st;
+        lastXtalId_ = ch;
+
+        // return here, so to skip all following checks
+        return SKIP_BLOCK_UNPACKING;
+        errorOnXtal = true;  //keep it here in case the return is to be dropped
+      }
+
       // if channel id not proven wrong, update lastStripId_ and lastXtalId_
-      lastStripId_  = stripId;
-      lastXtalId_   = xtalId;
-    }//end else
-  }// end if (zs_)
+      lastStripId_ = stripId;
+      lastXtalId_ = xtalId;
+    }  //end else
+  }    // end if (zs_)
 
+  bool addedFrame = false;
 
-  bool addedFrame=false;
-
-  // if there is an error on xtal id ignore next error checks  
+  // if there is an error on xtal id ignore next error checks
   // otherwise, assume channel_id is valid and proceed with making and checking the data frame
-  if(errorOnXtal) return SKIP_BLOCK_UNPACKING;
+  if (errorOnXtal)
+    return SKIP_BLOCK_UNPACKING;
 
-  pDetId_ = (EBDetId*) mapper_->getDetIdPointer(towerId_,stripId,xtalId);
+  pDetId_ = (EBDetId *)mapper_->getDetIdPointer(towerId_, stripId, xtalId);
   (*digis_)->push_back(*pDetId_);
-  EBDataFrame df( (*digis_)->back() );
-  addedFrame=true;
+  EBDataFrame df((*digis_)->back());
+  addedFrame = true;
   bool wrongGain(false);
 
   //set samples in the data frame
-  for(unsigned int i =0; i< nTSamples_ ;i++){ // loop on samples 
+  for (unsigned int i = 0; i < nTSamples_; i++) {  // loop on samples
     xData_++;
-    unsigned int data =  (*xData_) & TOWER_DIGI_MASK;
-    unsigned int gain =  data>>12;
-    xtalGains_[i]=gain;
-    if(gain == 0){ 
-      wrongGain = true; 
+    unsigned int data = (*xData_) & TOWER_DIGI_MASK;
+    unsigned int gain = data >> 12;
+    xtalGains_[i] = gain;
+    if (gain == 0) {
+      wrongGain = true;
       // although gain==0 found, produce the dataFrame in order to have it, for saturation case
-    } 
-    df.setSample(i,data);
-  }// loop on samples        
+    }
+    df.setSample(i, data);
+  }  // loop on samples
 
   bool isSaturation(true);
-  if(wrongGain){
-    
+  if (wrongGain) {
     // check whether the gain==0 has features of saturation or not
     // gain==0 occurs either in case of data corruption or of ADC saturation
     //                                  \->reject digi            \-> keep digi
-    
+
     // determine where gainId==0 starts
-    short firstGainZeroSampID(-1);    short firstGainZeroSampADC(-1);
-    for (unsigned int s=0; s<nTSamples_; s++ ) {
-      if(df.sample(s).gainId()==0 && firstGainZeroSampID==-1)
-        {
-          firstGainZeroSampID  = s;
-          firstGainZeroSampADC = df.sample(s).adc();
-          break;
-        }
-    }
-    
-    // check whether gain==0 and adc() stays constant for (at least) 5 consecutive samples
-    unsigned int plateauEnd = std::min(nTSamples_,(unsigned int)(firstGainZeroSampID+5));
-    for (unsigned int s=firstGainZeroSampID; s<plateauEnd; s++) 
-      {
-        if( df.sample(s).gainId()==0 && df.sample(s).adc()==firstGainZeroSampADC ) {;}
-        else
-          { isSaturation=false;  break;}  //it's not saturation
+    short firstGainZeroSampID(-1);
+    short firstGainZeroSampADC(-1);
+    for (unsigned int s = 0; s < nTSamples_; s++) {
+      if (df.sample(s).gainId() == 0 && firstGainZeroSampID == -1) {
+        firstGainZeroSampID = s;
+        firstGainZeroSampADC = df.sample(s).adc();
+        break;
       }
-    // get rid of channels which are stuck in gain0
-    if(firstGainZeroSampID<3) {isSaturation=false; }
-    
-    if (! DCCDataUnpacker::silentMode_) {
-      if (unpacker_->getChannelValue(mapper_->getActiveDCC(), towerId_, stripId, xtalId) != 10) {
-        edm::LogWarning("IncorrectGain")
-          << "Gain zero" << (isSaturation ? " with features of saturation" : "" ) << " was found in Tower Block"
-          << " (L1A " << event_->l1A() << " bx " << event_->bx() << " fed " << mapper_->getActiveDCC()
-          << " tower " << towerId_ << " strip " << stripId << " xtal " << xtalId << ")";
-      }
-    }
-    
-    if (! isSaturation)
-      {
-        (*invalidGains_)->push_back(*pDetId_);
-        (*digis_)->pop_back(); 
-        
-        //Point to begin of next xtal Block
-        data_ += numbDWInXtalBlock_;
-        //return here, so to skip all the rest
-        //make special collection for gain0 data frames when due to saturation
-        return BLOCK_UNPACKED;
-        errorOnXtal = true; //keep it here in case the return is to be dropped
-      }//end isSaturation 
-    else {
-        data_ += numbDWInXtalBlock_;
-        return BLOCK_UNPACKED;
     }
 
-    }//end WrongGain
-  
-  
+    // check whether gain==0 and adc() stays constant for (at least) 5 consecutive samples
+    unsigned int plateauEnd = std::min(nTSamples_, (unsigned int)(firstGainZeroSampID + 5));
+    for (unsigned int s = firstGainZeroSampID; s < plateauEnd; s++) {
+      if (df.sample(s).gainId() == 0 && df.sample(s).adc() == firstGainZeroSampADC) {
+        ;
+      } else {
+        isSaturation = false;
+        break;
+      }  //it's not saturation
+    }
+    // get rid of channels which are stuck in gain0
+    if (firstGainZeroSampID < 3) {
+      isSaturation = false;
+    }
+
+    if (!DCCDataUnpacker::silentMode_) {
+      if (unpacker_->getChannelValue(mapper_->getActiveDCC(), towerId_, stripId, xtalId) != 10) {
+        edm::LogWarning("IncorrectGain") << "Gain zero" << (isSaturation ? " with features of saturation" : "")
+                                         << " was found in Tower Block"
+                                         << " (L1A " << event_->l1A() << " bx " << event_->bx() << " fed "
+                                         << mapper_->getActiveDCC() << " tower " << towerId_ << " strip " << stripId
+                                         << " xtal " << xtalId << ")";
+      }
+    }
+
+    if (!isSaturation) {
+      (*invalidGains_)->push_back(*pDetId_);
+      (*digis_)->pop_back();
+
+      //Point to begin of next xtal Block
+      data_ += numbDWInXtalBlock_;
+      //return here, so to skip all the rest
+      //make special collection for gain0 data frames when due to saturation
+      return BLOCK_UNPACKED;
+      errorOnXtal = true;  //keep it here in case the return is to be dropped
+    }                      //end isSaturation
+    else {
+      data_ += numbDWInXtalBlock_;
+      return BLOCK_UNPACKED;
+    }
+
+  }  //end WrongGain
+
   // from here on, care about gain switches
-  
-  short numGain=1;
+
+  short numGain = 1;
   bool gainSwitchError = false;
 
-  for (unsigned int i=1; i<nTSamples_; i++ ) {
-    if (xtalGains_[i-1] >  xtalGains_[i] && numGain<5) gainSwitchError = true;
-    if (xtalGains_[i-1] == xtalGains_[i]) numGain++;
-    else numGain=1;
+  for (unsigned int i = 1; i < nTSamples_; i++) {
+    if (xtalGains_[i - 1] > xtalGains_[i] && numGain < 5)
+      gainSwitchError = true;
+    if (xtalGains_[i - 1] == xtalGains_[i])
+      numGain++;
+    else
+      numGain = 1;
   }
 
   if (gainSwitchError) {
-    if (! DCCDataUnpacker::silentMode_) {
-      edm::LogWarning("IncorrectGain")
-        << "A wrong gain transition switch was found for Tower Block in strip " << stripId << " and xtal " << xtalId
-        << " (L1A " << event_->l1A() << " bx " << event_->bx() << " fed " << mapper_->getActiveDCC() << " tower " << towerId_ << ")";
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectGain") << "A wrong gain transition switch was found for Tower Block in strip "
+                                       << stripId << " and xtal " << xtalId << " (L1A " << event_->l1A() << " bx "
+                                       << event_->bx() << " fed " << mapper_->getActiveDCC() << " tower " << towerId_
+                                       << ")";
     }
-    
+
     (*invalidGainsSwitch_)->push_back(*pDetId_);
     errorOnXtal = true;
   }
-  
+
   //Add frame to collection only if all data format and gain rules are respected
   if (errorOnXtal && addedFrame) {
     (*digis_)->pop_back();
   }
-  
+
   //Point to begin of next xtal Block
   data_ += numbDWInXtalBlock_;
-  
+
   return BLOCK_UNPACKED;
 }
 
+void DCCTowerBlock::fillEcalElectronicsError(std::unique_ptr<EcalElectronicsIdCollection> *errorColection) {
+  const int activeDCC = mapper_->getActiveSM();
 
-
-void DCCTowerBlock::fillEcalElectronicsError( std::unique_ptr<EcalElectronicsIdCollection> * errorColection ){
-
-   const int activeDCC = mapper_->getActiveSM();
-
-   if(NUMB_SM_EB_MIN_MIN<=activeDCC && activeDCC<=NUMB_SM_EB_PLU_MAX){
-     EcalElectronicsId  *  eleTp = mapper_->getTTEleIdPointer(activeDCC+TCCID_SMID_SHIFT_EB,expTowerID_);
-     (*errorColection)->push_back(*eleTp);
-   }else{
-      if( ! DCCDataUnpacker::silentMode_ ){
-          edm::LogWarning("IncorrectBlock")
-            <<"For event "<<event_->l1A()<<" there's fed: "<< activeDCC
-            <<" activeDcc: "<<mapper_->getActiveSM()
-            <<" but that activeDcc is not valid in EB.";
-        }
-
-   }
-
+  if (NUMB_SM_EB_MIN_MIN <= activeDCC && activeDCC <= NUMB_SM_EB_PLU_MAX) {
+    EcalElectronicsId *eleTp = mapper_->getTTEleIdPointer(activeDCC + TCCID_SMID_SHIFT_EB, expTowerID_);
+    (*errorColection)->push_back(*eleTp);
+  } else {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogWarning("IncorrectBlock") << "For event " << event_->l1A() << " there's fed: " << activeDCC
+                                        << " activeDcc: " << mapper_->getActiveSM()
+                                        << " but that activeDcc is not valid in EB.";
+    }
+  }
 }
-

--- a/EventFilter/EcalRawToDigi/src/EcalDCCHeaderRuntypeDecoder.cc
+++ b/EventFilter/EcalRawToDigi/src/EcalDCCHeaderRuntypeDecoder.cc
@@ -5,230 +5,253 @@
 #include <string>
 #include <iostream>
 
-EcalDCCHeaderRuntypeDecoder::EcalDCCHeaderRuntypeDecoder(){;}
-EcalDCCHeaderRuntypeDecoder::~EcalDCCHeaderRuntypeDecoder(){;}
+EcalDCCHeaderRuntypeDecoder::EcalDCCHeaderRuntypeDecoder() { ; }
+EcalDCCHeaderRuntypeDecoder::~EcalDCCHeaderRuntypeDecoder() { ; }
 
-bool EcalDCCHeaderRuntypeDecoder::Decode( unsigned long TrigType,            // global header,     bits 56-59
-					  unsigned long detTrigType,         // dcc header word 2, bits 32-47
-					  unsigned long runType,             // dcc header word 2, bits  0-31
-					  EcalDCCHeaderBlock* EcalDCCHeaderInfos)
-{
-  
+bool EcalDCCHeaderRuntypeDecoder::Decode(unsigned long TrigType,     // global header,     bits 56-59
+                                         unsigned long detTrigType,  // dcc header word 2, bits 32-47
+                                         unsigned long runType,      // dcc header word 2, bits  0-31
+                                         EcalDCCHeaderBlock* EcalDCCHeaderInfos) {
   //  unsigned int DCCNumberMask   = 63;//2^6-1
 
-  unsigned int WhichHalfOffSet= 64;//2^6 
-  unsigned int TypeOffSet     = 256;//2^8
-  unsigned int SubTypeOffSet  = 2048;//2^11
-  unsigned int SettingOffSet  = 131072;//2^17;
-  unsigned int GainModeOffSet = 16384;//2^14
-  
-  unsigned int TwoBitsMask    = 3;
-  unsigned int ThreeBitsMask  = 7;
-  unsigned int ThirdBitMask   = 4;
-  
-  EcalDCCHeaderInfos-> setRtHalf( int ((runType / WhichHalfOffSet) & TwoBitsMask) );
-  int type      = int ((runType / TypeOffSet)      & ThreeBitsMask);
-  int sequence  = int ((runType / SubTypeOffSet)   & ThreeBitsMask);
-  EcalDCCHeaderInfos->setMgpaGain(int ((runType / GainModeOffSet)  & TwoBitsMask) );
-  EcalDCCHeaderInfos->setMemGain( int ((runType / GainModeOffSet)  & ThirdBitMask)/ThirdBitMask );
+  unsigned int WhichHalfOffSet = 64;    //2^6
+  unsigned int TypeOffSet = 256;        //2^8
+  unsigned int SubTypeOffSet = 2048;    //2^11
+  unsigned int SettingOffSet = 131072;  //2^17;
+  unsigned int GainModeOffSet = 16384;  //2^14
+
+  unsigned int TwoBitsMask = 3;
+  unsigned int ThreeBitsMask = 7;
+  unsigned int ThirdBitMask = 4;
+
+  EcalDCCHeaderInfos->setRtHalf(int((runType / WhichHalfOffSet) & TwoBitsMask));
+  int type = int((runType / TypeOffSet) & ThreeBitsMask);
+  int sequence = int((runType / SubTypeOffSet) & ThreeBitsMask);
+  EcalDCCHeaderInfos->setMgpaGain(int((runType / GainModeOffSet) & TwoBitsMask));
+  EcalDCCHeaderInfos->setMemGain(int((runType / GainModeOffSet) & ThirdBitMask) / ThirdBitMask);
   //  EcalDCCHeaderInfos.Setting       = int ( runType / SettingOffSet);
 
-  if (type ==0 && sequence == 0){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::COSMIC);}
+  if (type == 0 && sequence == 0) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::COSMIC);
+  }
   // begin: added for XDAQ 3
-  else if (type ==0 && sequence == 1){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::COSMIC);}
-  else if (type ==0 && sequence == 2){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::BEAMH4);}
-  else if (type ==0 && sequence == 3){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::BEAMH2);}
-  else if (type ==0 && sequence == 4){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::MTCC);}
+  else if (type == 0 && sequence == 1) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::COSMIC);
+  } else if (type == 0 && sequence == 2) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::BEAMH4);
+  } else if (type == 0 && sequence == 3) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::BEAMH2);
+  } else if (type == 0 && sequence == 4) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::MTCC);
+  }
   // end: added for XDAQ 3
-  else if (type ==1 && sequence == 0){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::LASER_STD);}
-  else if (type ==1 && sequence == 1){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::LASER_POWER_SCAN);}
-  else if (type ==1 && sequence == 2){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::LASER_DELAY_SCAN);}
-  else if (type ==2 && sequence == 0){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::TESTPULSE_SCAN_MEM);}
-  else if (type ==2 && sequence == 1){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::TESTPULSE_MGPA);}
-  else if (type ==3 && sequence == 0){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::PEDESTAL_STD);}
-  else if (type ==3 && sequence == 1){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::PEDESTAL_OFFSET_SCAN);}
-  else if (type ==3 && sequence == 2){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::PEDESTAL_25NS_SCAN);}
-  else if (type ==4 && sequence == 0){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::LED_STD);}
+  else if (type == 1 && sequence == 0) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::LASER_STD);
+  } else if (type == 1 && sequence == 1) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::LASER_POWER_SCAN);
+  } else if (type == 1 && sequence == 2) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::LASER_DELAY_SCAN);
+  } else if (type == 2 && sequence == 0) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::TESTPULSE_SCAN_MEM);
+  } else if (type == 2 && sequence == 1) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::TESTPULSE_MGPA);
+  } else if (type == 3 && sequence == 0) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::PEDESTAL_STD);
+  } else if (type == 3 && sequence == 1) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::PEDESTAL_OFFSET_SCAN);
+  } else if (type == 3 && sequence == 2) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::PEDESTAL_25NS_SCAN);
+  } else if (type == 4 && sequence == 0) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::LED_STD);
+  }
 
-  else if (type ==5 && sequence == 0){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::PHYSICS_GLOBAL);}
-  else if (type ==5 && sequence == 1){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::COSMICS_GLOBAL);}
-  else if (type ==5 && sequence == 2){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::HALO_GLOBAL);}
-  // 
+  else if (type == 5 && sequence == 0) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::PHYSICS_GLOBAL);
+  } else if (type == 5 && sequence == 1) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::COSMICS_GLOBAL);
+  } else if (type == 5 && sequence == 2) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::HALO_GLOBAL);
+  }
+  //
   // else if (type ==5 && sequence == 3){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::CALIB_GLOBAL);}
 
-  else if (type ==6 && sequence == 0){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::PHYSICS_LOCAL);}
-  else if (type ==6 && sequence == 1){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::COSMICS_LOCAL);}
-  else if (type ==6 && sequence == 2){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::HALO_LOCAL);}
-  else if (type ==6 && sequence == 3){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::CALIB_LOCAL);}
+  else if (type == 6 && sequence == 0) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::PHYSICS_LOCAL);
+  } else if (type == 6 && sequence == 1) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::COSMICS_LOCAL);
+  } else if (type == 6 && sequence == 2) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::HALO_LOCAL);
+  } else if (type == 6 && sequence == 3) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::CALIB_LOCAL);
+  }
 
   else {
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogError("IncorrectHeader") <<"Unrecognized runtype and sequence: "<<type<<" "<<sequence;
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogError("IncorrectHeader") << "Unrecognized runtype and sequence: " << type << " " << sequence;
     }
     EcalDCCHeaderInfos->setRunType(-1);
     WasDecodingOk_ = false;
     return WasDecodingOk_;
   }
-  
+
   // decoding of settings depends on whether run is global or local
-  if (type == 5 || type == 6){    DecodeSettingGlobal ( TrigType, detTrigType, EcalDCCHeaderInfos );         }
-  else {                 DecodeSetting            (int ( runType / SettingOffSet),EcalDCCHeaderInfos);  }
-  
-  
+  if (type == 5 || type == 6) {
+    DecodeSettingGlobal(TrigType, detTrigType, EcalDCCHeaderInfos);
+  } else {
+    DecodeSetting(int(runType / SettingOffSet), EcalDCCHeaderInfos);
+  }
+
   return WasDecodingOk_;
 }
 
-
-
-
-
-void EcalDCCHeaderRuntypeDecoder::DecodeSettingGlobal ( unsigned long TrigType, unsigned long detTrigType,  EcalDCCHeaderBlock * theHeader ){
-
+void EcalDCCHeaderRuntypeDecoder::DecodeSettingGlobal(unsigned long TrigType,
+                                                      unsigned long detTrigType,
+                                                      EcalDCCHeaderBlock* theHeader) {
   // TCC commands are decoded both in global (type ==5) and in local (type ==6)
   // keep an eye on the possible: EcalDCCHeaderBlock::CALIB_GLOBAL
   bool isLocal = false;
-  if (theHeader->getRunType() == EcalDCCHeaderBlock::CALIB_LOCAL)     isLocal = true;
-  
+  if (theHeader->getRunType() == EcalDCCHeaderBlock::CALIB_LOCAL)
+    isLocal = true;
+
   // if Trigger_Type is physics, only dccIdInTTCCommand is meaningful
-  if         (TrigType == 1){
-      int dccIdInTTCCommand  = (detTrigType >> H_DCCID_B)    &  H_DCCID_MASK;
-      theHeader-> setDccInTTCCommand( dccIdInTTCCommand );
-      return;
+  if (TrigType == 1) {
+    int dccIdInTTCCommand = (detTrigType >> H_DCCID_B) & H_DCCID_MASK;
+    theHeader->setDccInTTCCommand(dccIdInTTCCommand);
+    return;
   }
-  
+
   // if calibration trigger (gap)
   else if (TrigType == 2) {
-
-
     EcalDCCHeaderBlock::EcalDCCEventSettings theSettings;
     CleanEcalDCCSettingsInfo(&theSettings);
 
-    int dccIdInTTCCommand                    = (detTrigType >> H_DCCID_B)    &  H_DCCID_MASK;
-    int halfInTTCCommand                     = (detTrigType >> H_HALF_B)     &  H_HALF_MASK;
-    int detailedTriggerTypeInTTCCommand      = (detTrigType >> H_TR_TYPE_B)  &  H_TR_TYPE_MASK;
-    int wavelengthInTTCCommand               = (detTrigType >> H_WAVEL_B)    &  H_WAVEL_MASK;
+    int dccIdInTTCCommand = (detTrigType >> H_DCCID_B) & H_DCCID_MASK;
+    int halfInTTCCommand = (detTrigType >> H_HALF_B) & H_HALF_MASK;
+    int detailedTriggerTypeInTTCCommand = (detTrigType >> H_TR_TYPE_B) & H_TR_TYPE_MASK;
+    int wavelengthInTTCCommand = (detTrigType >> H_WAVEL_B) & H_WAVEL_MASK;
 
-
-    theHeader-> setRtHalf( halfInTTCCommand );
-    theHeader-> setDccInTTCCommand( dccIdInTTCCommand );
-    if (detailedTriggerTypeInTTCCommand == EcalDCCHeaderBlock::TTC_LASER){
-      if(isLocal) theHeader->        setRunType(EcalDCCHeaderBlock::LASER_STD);
-      else        theHeader->        setRunType(EcalDCCHeaderBlock::LASER_GAP);
-      theSettings.wavelength = wavelengthInTTCCommand;    }
-    
-    
-    else if (detailedTriggerTypeInTTCCommand == EcalDCCHeaderBlock::TTC_LED){
-      if(isLocal)  theHeader->      setRunType(EcalDCCHeaderBlock::LED_STD);
-      else         theHeader->      setRunType(EcalDCCHeaderBlock::LED_GAP);
-      theSettings.wavelength = wavelengthInTTCCommand;    }
-    
-    else if (detailedTriggerTypeInTTCCommand == EcalDCCHeaderBlock::TTC_TESTPULSE){
-      if(isLocal) theHeader->       setRunType(EcalDCCHeaderBlock::TESTPULSE_MGPA);
-      else        theHeader->       setRunType(EcalDCCHeaderBlock::TESTPULSE_GAP);
+    theHeader->setRtHalf(halfInTTCCommand);
+    theHeader->setDccInTTCCommand(dccIdInTTCCommand);
+    if (detailedTriggerTypeInTTCCommand == EcalDCCHeaderBlock::TTC_LASER) {
+      if (isLocal)
+        theHeader->setRunType(EcalDCCHeaderBlock::LASER_STD);
+      else
+        theHeader->setRunType(EcalDCCHeaderBlock::LASER_GAP);
+      theSettings.wavelength = wavelengthInTTCCommand;
     }
-    
-    else if (detailedTriggerTypeInTTCCommand == EcalDCCHeaderBlock::TTC_PEDESTAL){
-      if(isLocal) theHeader->       setRunType(EcalDCCHeaderBlock::PEDESTAL_STD);
-      else        theHeader->       setRunType(EcalDCCHeaderBlock::PEDESTAL_GAP);
+
+    else if (detailedTriggerTypeInTTCCommand == EcalDCCHeaderBlock::TTC_LED) {
+      if (isLocal)
+        theHeader->setRunType(EcalDCCHeaderBlock::LED_STD);
+      else
+        theHeader->setRunType(EcalDCCHeaderBlock::LED_GAP);
+      theSettings.wavelength = wavelengthInTTCCommand;
+    }
+
+    else if (detailedTriggerTypeInTTCCommand == EcalDCCHeaderBlock::TTC_TESTPULSE) {
+      if (isLocal)
+        theHeader->setRunType(EcalDCCHeaderBlock::TESTPULSE_MGPA);
+      else
+        theHeader->setRunType(EcalDCCHeaderBlock::TESTPULSE_GAP);
+    }
+
+    else if (detailedTriggerTypeInTTCCommand == EcalDCCHeaderBlock::TTC_PEDESTAL) {
+      if (isLocal)
+        theHeader->setRunType(EcalDCCHeaderBlock::PEDESTAL_STD);
+      else
+        theHeader->setRunType(EcalDCCHeaderBlock::PEDESTAL_GAP);
     }
 
     else {
-      if( ! DCCDataUnpacker::silentMode_ ){
-        edm::LogError("IncorrectHeader") <<"Unrecognized detailedTriggerTypeInTTCCommand: " << detailedTriggerTypeInTTCCommand;
+      if (!DCCDataUnpacker::silentMode_) {
+        edm::LogError("IncorrectHeader") << "Unrecognized detailedTriggerTypeInTTCCommand: "
+                                         << detailedTriggerTypeInTTCCommand;
       }
       theHeader->setRunType(-1);
       WasDecodingOk_ = false;
     }
-    
+
     theHeader->setEventSettings(theSettings);
-    
+
   }
-  
+
   else {
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogError("IncorrectHeader") <<"Unrecognized detailed trigger type";
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogError("IncorrectHeader") << "Unrecognized detailed trigger type";
     }
     theHeader->setRunType(-1);
     WasDecodingOk_ = false;
   }
-
 }
 
-
-
-void  EcalDCCHeaderRuntypeDecoder::DecodeSetting ( int Setting,  EcalDCCHeaderBlock* theHeader )
-{
+void EcalDCCHeaderRuntypeDecoder::DecodeSetting(int Setting, EcalDCCHeaderBlock* theHeader) {
   EcalDCCHeaderBlock::EcalDCCEventSettings theSettings;
   CleanEcalDCCSettingsInfo(&theSettings);
 
-  if( theHeader->getRunType() == EcalDCCHeaderBlock::COSMIC || 
-      theHeader->getRunType() == EcalDCCHeaderBlock::BEAMH2 || 
-      theHeader->getRunType() == EcalDCCHeaderBlock::BEAMH4 || 
-      theHeader->getRunType() == EcalDCCHeaderBlock::MTCC ||
+  if (theHeader->getRunType() == EcalDCCHeaderBlock::COSMIC || theHeader->getRunType() == EcalDCCHeaderBlock::BEAMH2 ||
+      theHeader->getRunType() == EcalDCCHeaderBlock::BEAMH4 || theHeader->getRunType() == EcalDCCHeaderBlock::MTCC ||
       theHeader->getRunType() == EcalDCCHeaderBlock::PHYSICS_LOCAL ||
       theHeader->getRunType() == EcalDCCHeaderBlock::COSMICS_LOCAL ||
-      theHeader->getRunType() == EcalDCCHeaderBlock::HALO_LOCAL )
-    {;}
+      theHeader->getRunType() == EcalDCCHeaderBlock::HALO_LOCAL) {
+    ;
+  }
   //no settings foreseen
 
-  else if(theHeader->getRunType() == EcalDCCHeaderBlock::LASER_STD)
-    {
-      theSettings.LaserPower = (Setting & 8128)/64;
-      theSettings.LaserFilter = (Setting & 56)/8;
-      theSettings.wavelength = Setting & 7;
-    }
-
-  else if(theHeader->getRunType() == EcalDCCHeaderBlock::LASER_POWER_SCAN){
-    theSettings.LaserPower = (Setting & 8128)/64;
-    theSettings.LaserFilter = (Setting & 56)/8;
+  else if (theHeader->getRunType() == EcalDCCHeaderBlock::LASER_STD) {
+    theSettings.LaserPower = (Setting & 8128) / 64;
+    theSettings.LaserFilter = (Setting & 56) / 8;
     theSettings.wavelength = Setting & 7;
   }
 
-  else if(theHeader->getRunType() == EcalDCCHeaderBlock::LASER_DELAY_SCAN){
-    theSettings.wavelength = Setting & 7;  
-    theSettings.delay = (Setting & 2040)/8;
+  else if (theHeader->getRunType() == EcalDCCHeaderBlock::LASER_POWER_SCAN) {
+    theSettings.LaserPower = (Setting & 8128) / 64;
+    theSettings.LaserFilter = (Setting & 56) / 8;
+    theSettings.wavelength = Setting & 7;
   }
 
-  else if(theHeader->getRunType() == EcalDCCHeaderBlock::TESTPULSE_SCAN_MEM){
+  else if (theHeader->getRunType() == EcalDCCHeaderBlock::LASER_DELAY_SCAN) {
+    theSettings.wavelength = Setting & 7;
+    theSettings.delay = (Setting & 2040) / 8;
+  }
+
+  else if (theHeader->getRunType() == EcalDCCHeaderBlock::TESTPULSE_SCAN_MEM) {
     theSettings.MEMVinj = Setting & 511;
   }
 
-  else if(theHeader->getRunType() == EcalDCCHeaderBlock::TESTPULSE_MGPA){
-    theSettings.mgpa_content =  Setting & 255;
+  else if (theHeader->getRunType() == EcalDCCHeaderBlock::TESTPULSE_MGPA) {
+    theSettings.mgpa_content = Setting & 255;
   }
 
-  else if(theHeader->getRunType() == EcalDCCHeaderBlock::PEDESTAL_STD){;}//no settings foreseen
+  else if (theHeader->getRunType() == EcalDCCHeaderBlock::PEDESTAL_STD) {
+    ;
+  }  //no settings foreseen
 
-  else if(theHeader->getRunType() == EcalDCCHeaderBlock::PEDESTAL_OFFSET_SCAN){
-    theSettings.ped_offset  =  Setting;
+  else if (theHeader->getRunType() == EcalDCCHeaderBlock::PEDESTAL_OFFSET_SCAN) {
+    theSettings.ped_offset = Setting;
   }
 
-  else if(theHeader->getRunType() == EcalDCCHeaderBlock::PEDESTAL_25NS_SCAN ){
-    theSettings.delay = (Setting & 255);  
+  else if (theHeader->getRunType() == EcalDCCHeaderBlock::PEDESTAL_25NS_SCAN) {
+    theSettings.delay = (Setting & 255);
   }
 
-  else if(theHeader->getRunType() == EcalDCCHeaderBlock::LED_STD){
+  else if (theHeader->getRunType() == EcalDCCHeaderBlock::LED_STD) {
     theSettings.wavelength = Setting & 7;
-  }
-  else {
-    if( ! DCCDataUnpacker::silentMode_ ){
-      edm::LogError("IncorrectHeader") <<"Unrecognized run type: "<<theHeader->getRunType();
+  } else {
+    if (!DCCDataUnpacker::silentMode_) {
+      edm::LogError("IncorrectHeader") << "Unrecognized run type: " << theHeader->getRunType();
     }
     WasDecodingOk_ = false;
   }
 
   theHeader->setEventSettings(theSettings);
-  
 }
 
-
-
-void EcalDCCHeaderRuntypeDecoder::CleanEcalDCCSettingsInfo( EcalDCCHeaderBlock::EcalDCCEventSettings * dummySettings){
-  dummySettings->LaserPower =-1;
-  dummySettings->LaserFilter =-1;
-  dummySettings->wavelength =-1;
-  dummySettings->delay =-1;
-  dummySettings->MEMVinj =-1;
-  dummySettings->mgpa_content =-1;
-  dummySettings->ped_offset =-1;
+void EcalDCCHeaderRuntypeDecoder::CleanEcalDCCSettingsInfo(EcalDCCHeaderBlock::EcalDCCEventSettings* dummySettings) {
+  dummySettings->LaserPower = -1;
+  dummySettings->LaserFilter = -1;
+  dummySettings->wavelength = -1;
+  dummySettings->delay = -1;
+  dummySettings->MEMVinj = -1;
+  dummySettings->mgpa_content = -1;
+  dummySettings->ped_offset = -1;
 }

--- a/EventFilter/EcalRawToDigi/src/EcalElectronicsMapper.cc
+++ b/EventFilter/EcalRawToDigi/src/EcalElectronicsMapper.cc
@@ -5,186 +5,228 @@
 #include <DataFormats/EcalDigi/interface/EESrFlag.h>
 #include <EventFilter/EcalRawToDigi/interface/DCCDataUnpacker.h>
 
-EcalElectronicsMapper::EcalElectronicsMapper( unsigned int numbXtalTSamples, unsigned int numbTriggerTSamples)
-: pathToMapFile_(""),
-numbXtalTSamples_(numbXtalTSamples),
-numbTriggerTSamples_(numbTriggerTSamples),
-mappingBuilder_(nullptr)
-{
+EcalElectronicsMapper::EcalElectronicsMapper(unsigned int numbXtalTSamples, unsigned int numbTriggerTSamples)
+    : pathToMapFile_(""),
+      numbXtalTSamples_(numbXtalTSamples),
+      numbTriggerTSamples_(numbTriggerTSamples),
+      mappingBuilder_(nullptr) {
   resetPointers();
   setupGhostMap();
 }
 
-void EcalElectronicsMapper::resetPointers(){
-  
+void EcalElectronicsMapper::resetPointers() {
   // Reset Arrays
-  for(unsigned int sm=0; sm < NUMB_SM; sm++){
-    for(unsigned int fe=0; fe< NUMB_FE; fe++){
-          
-      for(unsigned int strip=0; strip<NUMB_STRIP;strip++){
-        for(unsigned int xtal=0; xtal<NUMB_XTAL;xtal++){
-                    
-             //Reset DFrames and xtalDetIds
-          xtalDetIds_[sm][fe][strip][xtal]=nullptr;
+  for (unsigned int sm = 0; sm < NUMB_SM; sm++) {
+    for (unsigned int fe = 0; fe < NUMB_FE; fe++) {
+      for (unsigned int strip = 0; strip < NUMB_STRIP; strip++) {
+        for (unsigned int xtal = 0; xtal < NUMB_XTAL; xtal++) {
+          //Reset DFrames and xtalDetIds
+          xtalDetIds_[sm][fe][strip][xtal] = nullptr;
         }
       }
 
       //Reset SC Det Ids
       //scDetIds_[sm][fe]=0;
-      scEleIds_[sm][fe]=nullptr;
+      scEleIds_[sm][fe] = nullptr;
       //srFlags_[sm][fe]=0;
     }
   }
-  
-  
+
   //Reset TT det Ids
-  for( unsigned int tccid=0; tccid < NUMB_TCC; tccid++){
-    for(unsigned int tpg =0; tpg<NUMB_FE;tpg++){
-      ttDetIds_[tccid][tpg]=nullptr;
-      ttTPIds_[tccid][tpg]=nullptr;
-      ttEleIds_[tccid][tpg]=nullptr;
+  for (unsigned int tccid = 0; tccid < NUMB_TCC; tccid++) {
+    for (unsigned int tpg = 0; tpg < NUMB_FE; tpg++) {
+      ttDetIds_[tccid][tpg] = nullptr;
+      ttTPIds_[tccid][tpg] = nullptr;
+      ttEleIds_[tccid][tpg] = nullptr;
     }
   }
 
   // reset trigger electronics Id
-  for (int tccid=0; tccid<NUMB_TCC; tccid++){
-      for (int ttid=0; ttid<TCC_EB_NUMBTTS; ttid++){
-          for (int ps=0; ps<NUMB_STRIP; ps++){
-              psInput_[tccid][ttid][ps]=nullptr;
-          }}}
-  
+  for (int tccid = 0; tccid < NUMB_TCC; tccid++) {
+    for (int ttid = 0; ttid < TCC_EB_NUMBTTS; ttid++) {
+      for (int ps = 0; ps < NUMB_STRIP; ps++) {
+        psInput_[tccid][ttid][ps] = nullptr;
+      }
+    }
+  }
+
   // initialize TCC maps
-  for (int tccId=0; tccId<EcalTriggerElectronicsId::MAX_TCCID; tccId++) {
-      for (int psCounter=0; psCounter<EcalTrigTowerDetId::kEBTowersPerSM*5; psCounter++) {
-          for (int u=0; u<2; u++){
-              tTandPs_[tccId][psCounter][u]=-1;
-          } } }
-  
-  
+  for (int tccId = 0; tccId < EcalTriggerElectronicsId::MAX_TCCID; tccId++) {
+    for (int psCounter = 0; psCounter < EcalTrigTowerDetId::kEBTowersPerSM * 5; psCounter++) {
+      for (int u = 0; u < 2; u++) {
+        tTandPs_[tccId][psCounter][u] = -1;
+      }
+    }
+  }
 
   //Fill map sm id to tcc ids
-  std::vector<unsigned int> * ids;
+  std::vector<unsigned int>* ids;
   ids = new std::vector<unsigned int>;
-  ids->push_back(1); ids->push_back(18);ids->push_back(19);ids->push_back(36);
-  mapSmIdToTccIds_[1]= ids;
-                
+  ids->push_back(1);
+  ids->push_back(18);
+  ids->push_back(19);
+  ids->push_back(36);
+  mapSmIdToTccIds_[1] = ids;
+
   ids = new std::vector<unsigned int>;
-  ids->push_back(2); ids->push_back(3);ids->push_back(20);ids->push_back(21);
-  mapSmIdToTccIds_[2]= ids;
-                
+  ids->push_back(2);
+  ids->push_back(3);
+  ids->push_back(20);
+  ids->push_back(21);
+  mapSmIdToTccIds_[2] = ids;
+
   ids = new std::vector<unsigned int>;
-  ids->push_back(4); ids->push_back(5);ids->push_back(22);ids->push_back(23);
-  mapSmIdToTccIds_[3]= ids;
-                
+  ids->push_back(4);
+  ids->push_back(5);
+  ids->push_back(22);
+  ids->push_back(23);
+  mapSmIdToTccIds_[3] = ids;
+
   ids = new std::vector<unsigned int>;
-  ids->push_back(6); ids->push_back(7);ids->push_back(24);ids->push_back(25);
-  mapSmIdToTccIds_[4]= ids;
-                
+  ids->push_back(6);
+  ids->push_back(7);
+  ids->push_back(24);
+  ids->push_back(25);
+  mapSmIdToTccIds_[4] = ids;
+
   ids = new std::vector<unsigned int>;
-  ids->push_back(8); ids->push_back(9);ids->push_back(26);ids->push_back(27);
-  mapSmIdToTccIds_[5]= ids;
-                
+  ids->push_back(8);
+  ids->push_back(9);
+  ids->push_back(26);
+  ids->push_back(27);
+  mapSmIdToTccIds_[5] = ids;
+
   ids = new std::vector<unsigned int>;
-  ids->push_back(10); ids->push_back(11);ids->push_back(28);ids->push_back(29);
-  mapSmIdToTccIds_[6]= ids;
-                
+  ids->push_back(10);
+  ids->push_back(11);
+  ids->push_back(28);
+  ids->push_back(29);
+  mapSmIdToTccIds_[6] = ids;
+
   ids = new std::vector<unsigned int>;
-  ids->push_back(12); ids->push_back(13);ids->push_back(30);ids->push_back(31);
-  mapSmIdToTccIds_[7]= ids;
-                
+  ids->push_back(12);
+  ids->push_back(13);
+  ids->push_back(30);
+  ids->push_back(31);
+  mapSmIdToTccIds_[7] = ids;
+
   ids = new std::vector<unsigned int>;
-  ids->push_back(14); ids->push_back(15);ids->push_back(32);ids->push_back(33);
-  mapSmIdToTccIds_[8]= ids;
-                
+  ids->push_back(14);
+  ids->push_back(15);
+  ids->push_back(32);
+  ids->push_back(33);
+  mapSmIdToTccIds_[8] = ids;
+
   ids = new std::vector<unsigned int>;
-  ids->push_back(16); ids->push_back(17);ids->push_back(34);ids->push_back(35);
-  mapSmIdToTccIds_[9]= ids;
-                
+  ids->push_back(16);
+  ids->push_back(17);
+  ids->push_back(34);
+  ids->push_back(35);
+  mapSmIdToTccIds_[9] = ids;
+
   ids = new std::vector<unsigned int>;
-  ids->push_back(73); ids->push_back(90);ids->push_back(91);ids->push_back(108);
-  mapSmIdToTccIds_[46]= ids;
-                
+  ids->push_back(73);
+  ids->push_back(90);
+  ids->push_back(91);
+  ids->push_back(108);
+  mapSmIdToTccIds_[46] = ids;
+
   ids = new std::vector<unsigned int>;
-  ids->push_back(74); ids->push_back(75);ids->push_back(92);ids->push_back(93);
-  mapSmIdToTccIds_[47]= ids;
-                
+  ids->push_back(74);
+  ids->push_back(75);
+  ids->push_back(92);
+  ids->push_back(93);
+  mapSmIdToTccIds_[47] = ids;
+
   ids = new std::vector<unsigned int>;
-  ids->push_back(76); ids->push_back(77);ids->push_back(94);ids->push_back(95);
-  mapSmIdToTccIds_[48]= ids;
-                
+  ids->push_back(76);
+  ids->push_back(77);
+  ids->push_back(94);
+  ids->push_back(95);
+  mapSmIdToTccIds_[48] = ids;
+
   ids = new std::vector<unsigned int>;
-  ids->push_back(78); ids->push_back(79);ids->push_back(96);ids->push_back(97);
-  mapSmIdToTccIds_[49]= ids;
-                
+  ids->push_back(78);
+  ids->push_back(79);
+  ids->push_back(96);
+  ids->push_back(97);
+  mapSmIdToTccIds_[49] = ids;
+
   ids = new std::vector<unsigned int>;
-  ids->push_back(80); ids->push_back(81);ids->push_back(98);ids->push_back(99);  
-  mapSmIdToTccIds_[50]= ids;
-                 
+  ids->push_back(80);
+  ids->push_back(81);
+  ids->push_back(98);
+  ids->push_back(99);
+  mapSmIdToTccIds_[50] = ids;
+
   ids = new std::vector<unsigned int>;
-  ids->push_back(82); ids->push_back(83);ids->push_back(100);ids->push_back(101);
-  mapSmIdToTccIds_[51]= ids;
-                
+  ids->push_back(82);
+  ids->push_back(83);
+  ids->push_back(100);
+  ids->push_back(101);
+  mapSmIdToTccIds_[51] = ids;
+
   ids = new std::vector<unsigned int>;
-  ids->push_back(84); ids->push_back(85);ids->push_back(102);ids->push_back(103);
-  mapSmIdToTccIds_[52]= ids;
-                
+  ids->push_back(84);
+  ids->push_back(85);
+  ids->push_back(102);
+  ids->push_back(103);
+  mapSmIdToTccIds_[52] = ids;
+
   ids = new std::vector<unsigned int>;
-  ids->push_back(86); ids->push_back(87);ids->push_back(104);ids->push_back(105);
-  mapSmIdToTccIds_[53]= ids;
-                
+  ids->push_back(86);
+  ids->push_back(87);
+  ids->push_back(104);
+  ids->push_back(105);
+  mapSmIdToTccIds_[53] = ids;
+
   ids = new std::vector<unsigned int>;
-  ids->push_back(88); ids->push_back(89);ids->push_back(106);ids->push_back(107);
-  mapSmIdToTccIds_[54]= ids;
-        
-  
+  ids->push_back(88);
+  ids->push_back(89);
+  ids->push_back(106);
+  ids->push_back(107);
+  mapSmIdToTccIds_[54] = ids;
+
   //Compute data block sizes
-  unfilteredFEBlockLength_= computeUnfilteredFEBlockLength();  
-  ebTccBlockLength_       = computeEBTCCBlockLength();
-  eeTccBlockLength_       = computeEETCCBlockLength();
-    
-
+  unfilteredFEBlockLength_ = computeUnfilteredFEBlockLength();
+  ebTccBlockLength_ = computeEBTCCBlockLength();
+  eeTccBlockLength_ = computeEETCCBlockLength();
 }
 
+EcalElectronicsMapper::~EcalElectronicsMapper() { deletePointers(); }
 
-EcalElectronicsMapper::~EcalElectronicsMapper(){
-  deletePointers();
-}
-
-void EcalElectronicsMapper::deletePointers(){
-
+void EcalElectronicsMapper::deletePointers() {
   //DETETE ARRAYS
-  for(unsigned int sm=0; sm < NUMB_SM; sm++){
-    for(unsigned int fe=0; fe< NUMB_FE; fe++){
-      for(unsigned int strip=0; strip<NUMB_STRIP;strip++){
-        for(unsigned int xtal=0; xtal<NUMB_XTAL;xtal++) delete xtalDetIds_[sm][fe][strip][xtal];         
+  for (unsigned int sm = 0; sm < NUMB_SM; sm++) {
+    for (unsigned int fe = 0; fe < NUMB_FE; fe++) {
+      for (unsigned int strip = 0; strip < NUMB_STRIP; strip++) {
+        for (unsigned int xtal = 0; xtal < NUMB_XTAL; xtal++)
+          delete xtalDetIds_[sm][fe][strip][xtal];
       }
 
-      // if(scDetIds_[sm][fe]){ 
+      // if(scDetIds_[sm][fe]){
       //  delete scDetIds_[sm][fe];
       //  delete scEleIds_[sm][fe];
-      for(size_t i = 0; i< srFlags_[sm][fe].size(); ++i) delete srFlags_[sm][fe][i];
+      for (size_t i = 0; i < srFlags_[sm][fe].size(); ++i)
+        delete srFlags_[sm][fe][i];
       srFlags_[sm][fe].clear();
- 
+
       delete scEleIds_[sm][fe];
-           
     }
- 
   }
 
   // delete trigger electronics Id
-  for (int tccid=0; tccid<NUMB_TCC; tccid++){
-    for (int ttid=0; ttid<TCC_EB_NUMBTTS; ttid++){
-      for (int ps=0; ps<NUMB_STRIP; ps++){
+  for (int tccid = 0; tccid < NUMB_TCC; tccid++) {
+    for (int ttid = 0; ttid < TCC_EB_NUMBTTS; ttid++) {
+      for (int ps = 0; ps < NUMB_STRIP; ps++) {
         delete psInput_[tccid][ttid][ps];
       }
     }
   }
 
-
-  
-  for( unsigned int tccid=0; tccid < NUMB_TCC; tccid++){
-    for(unsigned int tpg =0; tpg<NUMB_FE;tpg++){
-      if(ttDetIds_[tccid][tpg]){ 
+  for (unsigned int tccid = 0; tccid < NUMB_TCC; tccid++) {
+    for (unsigned int tpg = 0; tpg < NUMB_FE; tpg++) {
+      if (ttDetIds_[tccid][tpg]) {
         delete ttDetIds_[tccid][tpg];
         delete ttTPIds_[tccid][tpg];
         delete ttEleIds_[tccid][tpg];
@@ -192,46 +234,42 @@ void EcalElectronicsMapper::deletePointers(){
     }
   }
 
-
   pathToMapFile_.clear();
-  
-  
-  std::map<unsigned int, std::vector<unsigned int> *>::iterator it;
-  for(it = mapSmIdToTccIds_.begin(); it != mapSmIdToTccIds_.end(); it++ ){ delete (*it).second; }
-  
+
+  std::map<unsigned int, std::vector<unsigned int>*>::iterator it;
+  for (it = mapSmIdToTccIds_.begin(); it != mapSmIdToTccIds_.end(); it++) {
+    delete (*it).second;
+  }
+
   mapSmIdToTccIds_.clear();
- 
 }
 
-void EcalElectronicsMapper::setEcalElectronicsMapping(const EcalElectronicsMapping * m){
-  mappingBuilder_= m;
+void EcalElectronicsMapper::setEcalElectronicsMapping(const EcalElectronicsMapping* m) {
+  mappingBuilder_ = m;
   fillMaps();
 }
 
-bool EcalElectronicsMapper::setActiveDCC(unsigned int dccId){
-   
+bool EcalElectronicsMapper::setActiveDCC(unsigned int dccId) {
   bool ret(true);
-        
+
   //Update active dcc and associated smId
   dccId_ = dccId;
-   
-  smId_  = getSMId(dccId_);
-        
-  if(!smId_) ret = false;
-        
-  return ret;
-        
- } 
- 
- 
-bool EcalElectronicsMapper::setDCCMapFilePath(std::string aPath_){
 
-  
+  smId_ = getSMId(dccId_);
+
+  if (!smId_)
+    ret = false;
+
+  return ret;
+}
+
+bool EcalElectronicsMapper::setDCCMapFilePath(std::string aPath_) {
   //try to open a dccMapFile in the given path
   std::ifstream dccMapFile_(aPath_.c_str());
 
   //if not successful return false
-  if(!dccMapFile_.is_open()) return false;
+  if (!dccMapFile_.is_open())
+    return false;
 
   //else close file and accept given path
   dccMapFile_.close();
@@ -240,15 +278,14 @@ bool EcalElectronicsMapper::setDCCMapFilePath(std::string aPath_){
   return true;
 }
 
-
 // bool EcalElectronicsMapper::readDCCMapFile(){
 
 //   //try to open a dccMapFile in the given path
 //   std::ifstream dccMapFile_(pathToMapFile_.c_str());
-  
+
 //   //if not successful return false
 //   if(!dccMapFile_.is_open()) return false;
-  
+
 //   char lineBuf_[100];
 //   unsigned int SMId_,DCCId_;
 //   // loop while extraction from file is possible
@@ -258,16 +295,15 @@ bool EcalElectronicsMapper::setDCCMapFilePath(std::string aPath_){
 //     myDCCMap_[SMId_] = DCCId_;
 //     dccMapFile_.getline(lineBuf_,10);       //read line from file
 //   }
-  
-  
+
 //   return true;
-  
+
 // }
 
 // bool EcalElectronicsMapper::readDCCMapFile(std::string aPath_){
 //   //test if path is good
 //   edm::FileInPath eff(aPath_);
-  
+
 //   if(!setDCCMapFilePath(eff.fullPath())) return false;
 
 //   //read DCC map file
@@ -275,62 +311,55 @@ bool EcalElectronicsMapper::setDCCMapFilePath(std::string aPath_){
 //   return true;
 // }
 
-
-bool EcalElectronicsMapper::makeMapFromVectors( std::vector<int>& orderedFedUnpackList,
-                                               std::vector<int>& orderedDCCIdList )
-{
-
+bool EcalElectronicsMapper::makeMapFromVectors(std::vector<int>& orderedFedUnpackList,
+                                               std::vector<int>& orderedDCCIdList) {
   // in case as non standard set of DCCId:FedId pairs was provided
-  if ( orderedFedUnpackList.size() == orderedDCCIdList.size() &&
-       !orderedFedUnpackList.empty())
-    {
-      edm::LogInfo("EcalElectronicsMapper") << "DCCIdList/FedUnpackList lists given. Being loaded.";
-      
-      std::string correspondence("list of pairs DCCId:FedId :  ");
-      char           onePair[50];
-      for (int v=0;  v< ((int)orderedFedUnpackList.size());  v++)        {
-        myDCCMap_[ orderedDCCIdList[v]  ] = orderedFedUnpackList[v] ;
-        
-        sprintf( onePair, "  %d:%d",  orderedDCCIdList[v], orderedFedUnpackList[v]);
-        std::string                 tmp(onePair);
-        correspondence += tmp;
-      }
-      edm::LogInfo("EcalElectronicsMapper") << correspondence;
-      
-    }
-  else    
-    {  // default set of DCCId:FedId for ECAL
+  if (orderedFedUnpackList.size() == orderedDCCIdList.size() && !orderedFedUnpackList.empty()) {
+    edm::LogInfo("EcalElectronicsMapper") << "DCCIdList/FedUnpackList lists given. Being loaded.";
 
-      edm::LogInfo("EcalElectronicsMapper") << "No input DCCIdList/FedUnpackList lists given for ECAL unpacker"
-                                            << "(or given with different number of elements). "
-                                            << " Loading default association DCCIdList:FedUnpackList,"
-                                            << "i.e.  1:601 ... 53:653,  54:654.";
-      
-      for (unsigned int v=1; v<=54; v++)        {
-        myDCCMap_[ v ] = (v+600) ;   }
+    std::string correspondence("list of pairs DCCId:FedId :  ");
+    char onePair[50];
+    for (int v = 0; v < ((int)orderedFedUnpackList.size()); v++) {
+      myDCCMap_[orderedDCCIdList[v]] = orderedFedUnpackList[v];
+
+      sprintf(onePair, "  %d:%d", orderedDCCIdList[v], orderedFedUnpackList[v]);
+      std::string tmp(onePair);
+      correspondence += tmp;
     }
+    edm::LogInfo("EcalElectronicsMapper") << correspondence;
+
+  } else {  // default set of DCCId:FedId for ECAL
+
+    edm::LogInfo("EcalElectronicsMapper") << "No input DCCIdList/FedUnpackList lists given for ECAL unpacker"
+                                          << "(or given with different number of elements). "
+                                          << " Loading default association DCCIdList:FedUnpackList,"
+                                          << "i.e.  1:601 ... 53:653,  54:654.";
+
+    for (unsigned int v = 1; v <= 54; v++) {
+      myDCCMap_[v] = (v + 600);
+    }
+  }
 
   return true;
 }
 
-
-std::ostream &operator<< (std::ostream& o, const EcalElectronicsMapper &aMapper_) {
+std::ostream& operator<<(std::ostream& o, const EcalElectronicsMapper& aMapper_) {
   //print class information
   o << "---------------------------------------------------------";
 
-  if(aMapper_.pathToMapFile_.empty()){
+  if (aMapper_.pathToMapFile_.empty()) {
     o << "No correct input for DCC map has been given yet...";
-  }
-  else{
-    o << "DCC Map (Map file: " << aMapper_.pathToMapFile_ << " )" << "SM id\t\tDCCid ";
+  } else {
+    o << "DCC Map (Map file: " << aMapper_.pathToMapFile_ << " )"
+      << "SM id\t\tDCCid ";
 
     //get DCC map and iterator
-    std::map<unsigned int ,unsigned int > aMap;
-    aMap=aMapper_.myDCCMap_;
-    std::map<unsigned int ,unsigned int >::iterator iter;
+    std::map<unsigned int, unsigned int> aMap;
+    aMap = aMapper_.myDCCMap_;
+    std::map<unsigned int, unsigned int>::iterator iter;
 
     //print info contained in map
-    for(iter = aMap.begin(); iter != aMap.end(); iter++)
+    for (iter = aMap.begin(); iter != aMap.end(); iter++)
       o << iter->first << "\t\t" << iter->second;
   }
 
@@ -338,413 +367,340 @@ std::ostream &operator<< (std::ostream& o, const EcalElectronicsMapper &aMapper_
   return o;
 }
 
-  
-
-unsigned int EcalElectronicsMapper::computeUnfilteredFEBlockLength(){
-
-  return ((numbXtalTSamples_-2)/4+1)*25+1; 
-
+unsigned int EcalElectronicsMapper::computeUnfilteredFEBlockLength() {
+  return ((numbXtalTSamples_ - 2) / 4 + 1) * 25 + 1;
 }
 
-
-unsigned int EcalElectronicsMapper::computeEBTCCBlockLength(){
-
-  unsigned int nTT=68;
+unsigned int EcalElectronicsMapper::computeEBTCCBlockLength() {
+  unsigned int nTT = 68;
   unsigned int tf;
-          
+
   //TCC block size: header (8 bytes) + 17 words with 4 trigger primitives (17*8bytes)
-  if( (nTT*numbTriggerTSamples_)<4 || (nTT*numbTriggerTSamples_)%4 ) tf=1;  
-  else tf=0;
-    
-  return 1 + ((nTT*numbTriggerTSamples_)/4) + tf ;
+  if ((nTT * numbTriggerTSamples_) < 4 || (nTT * numbTriggerTSamples_) % 4)
+    tf = 1;
+  else
+    tf = 0;
 
+  return 1 + ((nTT * numbTriggerTSamples_) / 4) + tf;
 }
 
-unsigned int EcalElectronicsMapper::computeEETCCBlockLength(){
+unsigned int EcalElectronicsMapper::computeEETCCBlockLength() {
   //Todo : implement multiple tt samples for the endcap
-  return 9;  
-
+  return 9;
 }
 
-bool EcalElectronicsMapper::isTCCExternal(unsigned int TCCId){
-  if(
-     (NUMB_TCC_EE_MIN_EXT_MIN <= TCCId && TCCId<=NUMB_TCC_EE_MIN_EXT_MAX) ||
-     (NUMB_TCC_EE_PLU_EXT_MIN <= TCCId && TCCId<=NUMB_TCC_EE_PLU_EXT_MAX)
-     ) return true;
-  else return false;
+bool EcalElectronicsMapper::isTCCExternal(unsigned int TCCId) {
+  if ((NUMB_TCC_EE_MIN_EXT_MIN <= TCCId && TCCId <= NUMB_TCC_EE_MIN_EXT_MAX) ||
+      (NUMB_TCC_EE_PLU_EXT_MIN <= TCCId && TCCId <= NUMB_TCC_EE_PLU_EXT_MAX))
+    return true;
+  else
+    return false;
 }
 
-unsigned int EcalElectronicsMapper::getDCCId(unsigned int aSMId_) const{
+unsigned int EcalElectronicsMapper::getDCCId(unsigned int aSMId_) const {
   //get iterator for SM id
-  std::map<unsigned int ,unsigned int>::const_iterator it = myDCCMap_.find(aSMId_);
+  std::map<unsigned int, unsigned int>::const_iterator it = myDCCMap_.find(aSMId_);
 
   //check if SMid exists and return DCC id
-  if(it!= myDCCMap_.end()) return it->second;
- 
+  if (it != myDCCMap_.end())
+    return it->second;
+
   //error return
-  if( ! DCCDataUnpacker::silentMode_ ){
+  if (!DCCDataUnpacker::silentMode_) {
     edm::LogError("IncorrectMapping") << "DCC requested for SM id: " << aSMId_ << " not found";
   }
   return 0;
 }
 
-
 unsigned int EcalElectronicsMapper::getSMId(unsigned int aDCCId_) const {
   //get iterator map
-  std::map<unsigned int ,unsigned int>::const_iterator it;
+  std::map<unsigned int, unsigned int>::const_iterator it;
 
   //try to find SM id for given DCC id
-  for(it = myDCCMap_.begin(); it != myDCCMap_.end(); it++)
-    if(it->second == aDCCId_) 
+  for (it = myDCCMap_.begin(); it != myDCCMap_.end(); it++)
+    if (it->second == aDCCId_)
       return it->first;
 
   //error return
-  if( ! DCCDataUnpacker::silentMode_ ){
+  if (!DCCDataUnpacker::silentMode_) {
     edm::LogError("IncorrectMapping") << "SM requested DCC id: " << aDCCId_ << " not found";
   }
   return 0;
 }
 
-
-
-
-void EcalElectronicsMapper::fillMaps(){
- 
-  for( int smId=1 ; smId<= 54; smId++){
-
-    
-    // Fill EB arrays  
-    if( smId > 9 && smId < 46 ){
-         
-      for(int feChannel =1; feChannel<=68; feChannel++){
-                   
+void EcalElectronicsMapper::fillMaps() {
+  for (int smId = 1; smId <= 54; smId++) {
+    // Fill EB arrays
+    if (smId > 9 && smId < 46) {
+      for (int feChannel = 1; feChannel <= 68; feChannel++) {
         unsigned int tccId = smId + TCCID_SMID_SHIFT_EB;
-                  
-        // Builds Ecal Trigger Tower Det Id 
+
+        // Builds Ecal Trigger Tower Det Id
 
         unsigned int rawid = (mappingBuilder_->getTrigTowerDetId(tccId, feChannel)).rawId();
-        EcalTrigTowerDetId * ttDetId = new EcalTrigTowerDetId(rawid);
-        ttDetIds_[tccId-1][feChannel-1] = ttDetId;
-        EcalElectronicsId * ttEleId = new EcalElectronicsId(smId, feChannel, 1, 1);
-        ttEleIds_[tccId-1][feChannel-1] = ttEleId;
-        EcalTriggerPrimitiveDigi * tp     = new EcalTriggerPrimitiveDigi(*ttDetId);
+        EcalTrigTowerDetId* ttDetId = new EcalTrigTowerDetId(rawid);
+        ttDetIds_[tccId - 1][feChannel - 1] = ttDetId;
+        EcalElectronicsId* ttEleId = new EcalElectronicsId(smId, feChannel, 1, 1);
+        ttEleIds_[tccId - 1][feChannel - 1] = ttEleId;
+        EcalTriggerPrimitiveDigi* tp = new EcalTriggerPrimitiveDigi(*ttDetId);
         tp->setSize(numbTriggerTSamples_);
-        for(unsigned int i=0;i<numbTriggerTSamples_;i++){
-          tp->setSample( i, EcalTriggerPrimitiveSample(0) );
+        for (unsigned int i = 0; i < numbTriggerTSamples_; i++) {
+          tp->setSample(i, EcalTriggerPrimitiveSample(0));
         }
-        ttTPIds_[tccId-1][feChannel-1]  = tp;
+        ttTPIds_[tccId - 1][feChannel - 1] = tp;
 
         // build pseudostrip input data digi
-        for(int ps=1; ps<=5; ps++){
-            psInput_[tccId-1][feChannel-1][ps-1]= new EcalPseudoStripInputDigi( EcalTriggerElectronicsId(tccId, feChannel, ps, 1) );
-            psInput_[tccId-1][feChannel-1][ps-1]->setSize(1);
-            psInput_[tccId-1][feChannel-1][ps-1]->setSample( 0, EcalPseudoStripInputSample(0) );
+        for (int ps = 1; ps <= 5; ps++) {
+          psInput_[tccId - 1][feChannel - 1][ps - 1] =
+              new EcalPseudoStripInputDigi(EcalTriggerElectronicsId(tccId, feChannel, ps, 1));
+          psInput_[tccId - 1][feChannel - 1][ps - 1]->setSize(1);
+          psInput_[tccId - 1][feChannel - 1][ps - 1]->setSample(0, EcalPseudoStripInputSample(0));
         }
 
         // Buil SRP Flag
-        srFlags_[smId-1][feChannel-1].push_back(new EBSrFlag(*ttDetId,0));
+        srFlags_[smId - 1][feChannel - 1].push_back(new EBSrFlag(*ttDetId, 0));
 
         //only one element for barrel: 1-to-1 correspondance between
         //DCC channels and EB trigger tower:
-        assert(srFlags_[smId-1][feChannel-1].size()==1);
- 
-        for(unsigned int stripId =1; stripId<=5; stripId++){
-                    
-          for(unsigned int xtalId =1;xtalId<=5;xtalId++){
-                   
-              EcalElectronicsId eid(smId,feChannel,stripId,xtalId);
-              EBDetId * detId = new EBDetId( (mappingBuilder_->getDetId(eid)).rawId());
-              xtalDetIds_[smId-1][feChannel-1][stripId-1][xtalId-1] = detId;
-                         
-           } // close loop over xtals
-        }// close loop over strips
-                                  
-      }// close loop over fechannels
-                
-    }//close loop over sm ids in the EB
+        assert(srFlags_[smId - 1][feChannel - 1].size() == 1);
+
+        for (unsigned int stripId = 1; stripId <= 5; stripId++) {
+          for (unsigned int xtalId = 1; xtalId <= 5; xtalId++) {
+            EcalElectronicsId eid(smId, feChannel, stripId, xtalId);
+            EBDetId* detId = new EBDetId((mappingBuilder_->getDetId(eid)).rawId());
+            xtalDetIds_[smId - 1][feChannel - 1][stripId - 1][xtalId - 1] = detId;
+
+          }  // close loop over xtals
+        }    // close loop over strips
+
+      }  // close loop over fechannels
+
+    }  //close loop over sm ids in the EB
     // Fill EE arrays (Todo : waiting SC correction)
-    
-    else{
-         
-        std::vector<unsigned int> * pTCCIds = mapSmIdToTccIds_[smId];
-        std::vector<unsigned int>::iterator it;
-                
-        for(it= pTCCIds->begin(); it!= pTCCIds->end(); it++){
-                        
-          unsigned int tccId = *it;
-          
-          // creating arrays of pointers for trigger objects
-          for(unsigned int towerInTCC =1; towerInTCC <= numChannelsInDcc_[smId-1]; towerInTCC++){
-              
-              // Builds Ecal Trigger Tower Det Id 
-              EcalTrigTowerDetId ttDetId = mappingBuilder_->getTrigTowerDetId(tccId, towerInTCC);
-              
-              ttDetIds_[tccId-1][towerInTCC-1] = new EcalTrigTowerDetId(ttDetId.rawId());
-              EcalTriggerPrimitiveDigi * tp   = new EcalTriggerPrimitiveDigi(ttDetId);
-              tp->setSize(numbTriggerTSamples_);
-              for(unsigned int i=0;i<numbTriggerTSamples_;i++){
-                  tp->setSample( i, EcalTriggerPrimitiveSample(0) );
-              }
-              
-              ttTPIds_[tccId-1][towerInTCC-1]  = tp;
-              
-              // build pseudostrip input data digi
-               for(int ps=1; ps<=5; ps++){
-                   psInput_[tccId-1][towerInTCC-1][ps-1]= new EcalPseudoStripInputDigi( EcalTriggerElectronicsId(tccId, towerInTCC, ps, 1) );
-                   psInput_[tccId-1][towerInTCC-1][ps-1]->setSize(1);
-                   psInput_[tccId-1][towerInTCC-1][ps-1]->setSample( 0, EcalPseudoStripInputSample(0) );
-               }
-              
+
+    else {
+      std::vector<unsigned int>* pTCCIds = mapSmIdToTccIds_[smId];
+      std::vector<unsigned int>::iterator it;
+
+      for (it = pTCCIds->begin(); it != pTCCIds->end(); it++) {
+        unsigned int tccId = *it;
+
+        // creating arrays of pointers for trigger objects
+        for (unsigned int towerInTCC = 1; towerInTCC <= numChannelsInDcc_[smId - 1]; towerInTCC++) {
+          // Builds Ecal Trigger Tower Det Id
+          EcalTrigTowerDetId ttDetId = mappingBuilder_->getTrigTowerDetId(tccId, towerInTCC);
+
+          ttDetIds_[tccId - 1][towerInTCC - 1] = new EcalTrigTowerDetId(ttDetId.rawId());
+          EcalTriggerPrimitiveDigi* tp = new EcalTriggerPrimitiveDigi(ttDetId);
+          tp->setSize(numbTriggerTSamples_);
+          for (unsigned int i = 0; i < numbTriggerTSamples_; i++) {
+            tp->setSample(i, EcalTriggerPrimitiveSample(0));
+          }
+
+          ttTPIds_[tccId - 1][towerInTCC - 1] = tp;
+
+          // build pseudostrip input data digi
+          for (int ps = 1; ps <= 5; ps++) {
+            psInput_[tccId - 1][towerInTCC - 1][ps - 1] =
+                new EcalPseudoStripInputDigi(EcalTriggerElectronicsId(tccId, towerInTCC, ps, 1));
+            psInput_[tccId - 1][towerInTCC - 1][ps - 1]->setSize(1);
+            psInput_[tccId - 1][towerInTCC - 1][ps - 1]->setSample(0, EcalPseudoStripInputSample(0));
           }
         }
-        
-        // creating arrays of pointers for digi objects
-        for(unsigned int feChannel = 1; feChannel <= numChannelsInDcc_[smId-1]; feChannel++){
-          
-          // to avoid gap in CCU_id's
-          if((smId==SECTOR_EEM_CCU_JUMP   || smId== SECTOR_EEP_CCU_JUMP) &&
-             (MIN_CCUID_JUMP <= feChannel && feChannel <=MAX_CCUID_JUMP )
-             ) continue;
-          
-          std::vector<EcalScDetId> scDetIds = mappingBuilder_->getEcalScDetId(smId,feChannel);
-          // scDetIds_[smId-1][feChannel-1] = new EcalScDetId(scDetId.rawId());
-          scEleIds_[smId-1][feChannel-1] = new EcalElectronicsId(smId,feChannel,1,1);
+      }
 
-          for(size_t i = 0; i < scDetIds.size(); ++i){
-            // std::cout << __FILE__ << ":" << __LINE__ << ": "
-            //            << "(DCC,RU) = (" <<  smId << "," << feChannel
-            //            << ") -> " << scDetIds[i] << "\n";
-            
-            srFlags_[smId-1][feChannel-1].push_back(new EESrFlag( EcalScDetId( scDetIds[i].rawId() ) , 0 ));
-          }
-          //usually only one element 1 DCC channel <-> 1 SC
-          //in few case two or three elements: partial SCs grouped. 
-          assert(srFlags_[smId-1][feChannel-1].size()<=3);
-          
-          std::vector<DetId> ecalDetIds = mappingBuilder_->dccTowerConstituents(smId,feChannel);
-          std::vector<DetId>::iterator it;
-                                  
-          //EEDetIds        
-          for(it = ecalDetIds.begin(); it!= ecalDetIds.end(); it++){
-            
-            EcalElectronicsId ids = mappingBuilder_->getElectronicsId((*it));
-            
-            int stripId    = ids.stripId();
-            int xtalId     = ids.xtalId();
-            
-            EEDetId * detId = new EEDetId((*it).rawId());
-            xtalDetIds_[smId-1][feChannel-1][stripId-1][xtalId-1] = detId;
-          }// close loop over tower constituents
-          
-        }// close loop over  FE Channels                
-        
-    }// closing loop over sm ids in EE
-        
+      // creating arrays of pointers for digi objects
+      for (unsigned int feChannel = 1; feChannel <= numChannelsInDcc_[smId - 1]; feChannel++) {
+        // to avoid gap in CCU_id's
+        if ((smId == SECTOR_EEM_CCU_JUMP || smId == SECTOR_EEP_CCU_JUMP) &&
+            (MIN_CCUID_JUMP <= feChannel && feChannel <= MAX_CCUID_JUMP))
+          continue;
+
+        std::vector<EcalScDetId> scDetIds = mappingBuilder_->getEcalScDetId(smId, feChannel);
+        // scDetIds_[smId-1][feChannel-1] = new EcalScDetId(scDetId.rawId());
+        scEleIds_[smId - 1][feChannel - 1] = new EcalElectronicsId(smId, feChannel, 1, 1);
+
+        for (size_t i = 0; i < scDetIds.size(); ++i) {
+          // std::cout << __FILE__ << ":" << __LINE__ << ": "
+          //            << "(DCC,RU) = (" <<  smId << "," << feChannel
+          //            << ") -> " << scDetIds[i] << "\n";
+
+          srFlags_[smId - 1][feChannel - 1].push_back(new EESrFlag(EcalScDetId(scDetIds[i].rawId()), 0));
+        }
+        //usually only one element 1 DCC channel <-> 1 SC
+        //in few case two or three elements: partial SCs grouped.
+        assert(srFlags_[smId - 1][feChannel - 1].size() <= 3);
+
+        std::vector<DetId> ecalDetIds = mappingBuilder_->dccTowerConstituents(smId, feChannel);
+        std::vector<DetId>::iterator it;
+
+        //EEDetIds
+        for (it = ecalDetIds.begin(); it != ecalDetIds.end(); it++) {
+          EcalElectronicsId ids = mappingBuilder_->getElectronicsId((*it));
+
+          int stripId = ids.stripId();
+          int xtalId = ids.xtalId();
+
+          EEDetId* detId = new EEDetId((*it).rawId());
+          xtalDetIds_[smId - 1][feChannel - 1][stripId - 1][xtalId - 1] = detId;
+        }  // close loop over tower constituents
+
+      }  // close loop over  FE Channels
+
+    }  // closing loop over sm ids in EE
   }
-
 
   // developing mapping for pseudostrip input data: (tccId,psNumber)->(tccId,towerId,psId)
   // initializing array for pseudostrip data
   short numStripInTT[EcalTriggerElectronicsId::MAX_TCCID][EcalTrigTowerDetId::kEBTowersPerSM];
-  for (int tccId=0; tccId<EcalTriggerElectronicsId::MAX_TCCID; tccId++){
-      for (int tt=0; tt<EcalTrigTowerDetId::kEBTowersPerSM; tt++){
-          numStripInTT[tccId][tt]=-2;} }
+  for (int tccId = 0; tccId < EcalTriggerElectronicsId::MAX_TCCID; tccId++) {
+    for (int tt = 0; tt < EcalTrigTowerDetId::kEBTowersPerSM; tt++) {
+      numStripInTT[tccId][tt] = -2;
+    }
+  }
 
-  
   // assumption: if ps_max is the largest pseudostripId within a trigger tower
   // all the pseudostrip 1 ...  ps_max are actually present
   std::vector<DetId>::iterator theTCCConstituent;
-  for(int tccId = 0; tccId< EcalTriggerElectronicsId::MAX_TCCID ; tccId++)
-  {
-      
-      // loop over all constituents of a TCC and collect
-      // the largest pseudostripId within each trigger tower
-      std::vector<DetId> tccConstituents = mappingBuilder_->tccConstituents(tccId+1);
-      
-      for (theTCCConstituent  = tccConstituents.begin();
-           theTCCConstituent != tccConstituents.end();
-           theTCCConstituent++)
-      {
+  for (int tccId = 0; tccId < EcalTriggerElectronicsId::MAX_TCCID; tccId++) {
+    // loop over all constituents of a TCC and collect
+    // the largest pseudostripId within each trigger tower
+    std::vector<DetId> tccConstituents = mappingBuilder_->tccConstituents(tccId + 1);
 
-          int towerId = ( mappingBuilder_->getTriggerElectronicsId(*theTCCConstituent) ) .ttId();
-          int ps    = ( mappingBuilder_->getTriggerElectronicsId(*theTCCConstituent) ) .pseudoStripId();
-          if( ps > numStripInTT[tccId][towerId-1]) numStripInTT[tccId][towerId-1] = ps;
+    for (theTCCConstituent = tccConstituents.begin(); theTCCConstituent != tccConstituents.end(); theTCCConstituent++) {
+      int towerId = (mappingBuilder_->getTriggerElectronicsId(*theTCCConstituent)).ttId();
+      int ps = (mappingBuilder_->getTriggerElectronicsId(*theTCCConstituent)).pseudoStripId();
+      if (ps > numStripInTT[tccId][towerId - 1])
+        numStripInTT[tccId][towerId - 1] = ps;
 
-          //std::cout << "tccId: " << (tccId+1) << "    towerId: " << towerId
-          // << "    ps: " << ps << "    numStripInTT: " << numStripInTT[tccId][towerId-1] << std::endl;
-          
-      }// loop on TCC constituents
+      //std::cout << "tccId: " << (tccId+1) << "    towerId: " << towerId
+      // << "    ps: " << ps << "    numStripInTT: " << numStripInTT[tccId][towerId-1] << std::endl;
 
-  }// loop on TCC's
+    }  // loop on TCC constituents
 
-  
-  int   psCounter;
-  for (int tccId=0; tccId<EcalTriggerElectronicsId::MAX_TCCID; tccId++)
-  {
-      // resetting pseudostrip counter at each new TCC
-      psCounter=0;
-      for (int towerId=0; towerId < EcalTrigTowerDetId::kEBTowersPerSM; towerId++)
-      {
-          // if there's not a given towerId, numStripInTT==-1
-          for (int ps=0; ps<numStripInTT[tccId][towerId]; ps++)
-          {
-              tTandPs_[tccId][psCounter][0]=towerId+1;
-              tTandPs_[tccId][psCounter][1]=ps+1;
-              psCounter++;
-          } // loop on TCC's
-      } // loop on towers in TCC
-  } // loop in ps in tower
-  
-  
-//   for (int tccId=0; tccId<EcalTriggerElectronicsId::MAX_TCCID; tccId++) {
-//       for (int psCounter=0; psCounter<EcalTrigTowerDetId::kEBTowersPerSM*5; psCounter++) {
-//           std::cout << "tccId: " << (tccId+1) << "    counter: " << (psCounter+1)
-//                     << " tt: " << tTandPs_[tccId][psCounter][0]
-//                     << " ps: " << tTandPs_[tccId][psCounter][1]
-//                     << std::endl;
-//       } } 
-  
-  
-  
+  }  // loop on TCC's
+
+  int psCounter;
+  for (int tccId = 0; tccId < EcalTriggerElectronicsId::MAX_TCCID; tccId++) {
+    // resetting pseudostrip counter at each new TCC
+    psCounter = 0;
+    for (int towerId = 0; towerId < EcalTrigTowerDetId::kEBTowersPerSM; towerId++) {
+      // if there's not a given towerId, numStripInTT==-1
+      for (int ps = 0; ps < numStripInTT[tccId][towerId]; ps++) {
+        tTandPs_[tccId][psCounter][0] = towerId + 1;
+        tTandPs_[tccId][psCounter][1] = ps + 1;
+        psCounter++;
+      }  // loop on TCC's
+    }    // loop on towers in TCC
+  }      // loop in ps in tower
+
+  //   for (int tccId=0; tccId<EcalTriggerElectronicsId::MAX_TCCID; tccId++) {
+  //       for (int psCounter=0; psCounter<EcalTrigTowerDetId::kEBTowersPerSM*5; psCounter++) {
+  //           std::cout << "tccId: " << (tccId+1) << "    counter: " << (psCounter+1)
+  //                     << " tt: " << tTandPs_[tccId][psCounter][0]
+  //                     << " ps: " << tTandPs_[tccId][psCounter][1]
+  //                     << std::endl;
+  //       } }
+
   // Note:
   // for TCC 48 in EE, pseudostrip data in the interval:
   // + 1-30 is good pseudostrip data
   // + 31-42 is a duplication of the last 12 ps of the previous block, and needs be ignored
   // + 43-60 is further good pseudostrip data
-  
-  for (int tcc=EcalTriggerElectronicsId::MIN_TCCID_EEM; tcc<=EcalTriggerElectronicsId::MAX_TCCID_EEM; tcc++)
-  {
-      int tccId=tcc-1;
-      short tTandPs_tmp[18][2];
 
-      // store entries _after_ the pseudostrip data which gets duplicated
-      for (int psCounter=30; psCounter<48; psCounter++) {
-          tTandPs_tmp[psCounter-30][0] = tTandPs_[tccId][psCounter][0];
-          tTandPs_tmp[psCounter-30][1] = tTandPs_[tccId][psCounter][1]; }
-      
-      // duplication
-      for (int psCounter=18; psCounter<30; psCounter++) {
-          tTandPs_[tccId][psCounter+12][0] = tTandPs_[tccId][psCounter][0];
-          tTandPs_[tccId][psCounter+12][1] = tTandPs_[tccId][psCounter][1]; }
-      
-      // append stoed
-      for (int psCounter=42; psCounter<60; psCounter++) {
-          tTandPs_[tccId][psCounter][0] = tTandPs_tmp[psCounter-42][0];
-          tTandPs_[tccId][psCounter][1] = tTandPs_tmp[psCounter-42][1]; }
-      
-  }// loop on EEM TCC's
+  for (int tcc = EcalTriggerElectronicsId::MIN_TCCID_EEM; tcc <= EcalTriggerElectronicsId::MAX_TCCID_EEM; tcc++) {
+    int tccId = tcc - 1;
+    short tTandPs_tmp[18][2];
 
-  
-  for (int tcc=EcalTriggerElectronicsId::MIN_TCCID_EEP; tcc<=EcalTriggerElectronicsId::MAX_TCCID_EEP; tcc++)
-  {
-      int tccId=tcc-1;
-      short tTandPs_tmp[18][2];
-      
-      // store entries _after_ the pseudostrip data which gets duplicated
-      for (int psCounter=30; psCounter<48; psCounter++) {
-          tTandPs_tmp[psCounter-30][0] = tTandPs_[tccId][psCounter][0];
-          tTandPs_tmp[psCounter-30][1] = tTandPs_[tccId][psCounter][1]; }
-      
-      // duplication
-      for (int psCounter=18; psCounter<30; psCounter++) {
-          tTandPs_[tccId][psCounter+12][0] = tTandPs_[tccId][psCounter][0];
-          tTandPs_[tccId][psCounter+12][1] = tTandPs_[tccId][psCounter][1]; }
-      
-      // append stoed
-      for (int psCounter=42; psCounter<60; psCounter++) {
-          tTandPs_[tccId][psCounter][0] = tTandPs_tmp[psCounter-42][0];
-          tTandPs_[tccId][psCounter][1] = tTandPs_tmp[psCounter-42][1]; }
-      
-  }// loop on EEP TCC's
+    // store entries _after_ the pseudostrip data which gets duplicated
+    for (int psCounter = 30; psCounter < 48; psCounter++) {
+      tTandPs_tmp[psCounter - 30][0] = tTandPs_[tccId][psCounter][0];
+      tTandPs_tmp[psCounter - 30][1] = tTandPs_[tccId][psCounter][1];
+    }
 
-  
+    // duplication
+    for (int psCounter = 18; psCounter < 30; psCounter++) {
+      tTandPs_[tccId][psCounter + 12][0] = tTandPs_[tccId][psCounter][0];
+      tTandPs_[tccId][psCounter + 12][1] = tTandPs_[tccId][psCounter][1];
+    }
+
+    // append stoed
+    for (int psCounter = 42; psCounter < 60; psCounter++) {
+      tTandPs_[tccId][psCounter][0] = tTandPs_tmp[psCounter - 42][0];
+      tTandPs_[tccId][psCounter][1] = tTandPs_tmp[psCounter - 42][1];
+    }
+
+  }  // loop on EEM TCC's
+
+  for (int tcc = EcalTriggerElectronicsId::MIN_TCCID_EEP; tcc <= EcalTriggerElectronicsId::MAX_TCCID_EEP; tcc++) {
+    int tccId = tcc - 1;
+    short tTandPs_tmp[18][2];
+
+    // store entries _after_ the pseudostrip data which gets duplicated
+    for (int psCounter = 30; psCounter < 48; psCounter++) {
+      tTandPs_tmp[psCounter - 30][0] = tTandPs_[tccId][psCounter][0];
+      tTandPs_tmp[psCounter - 30][1] = tTandPs_[tccId][psCounter][1];
+    }
+
+    // duplication
+    for (int psCounter = 18; psCounter < 30; psCounter++) {
+      tTandPs_[tccId][psCounter + 12][0] = tTandPs_[tccId][psCounter][0];
+      tTandPs_[tccId][psCounter + 12][1] = tTandPs_[tccId][psCounter][1];
+    }
+
+    // append stoed
+    for (int psCounter = 42; psCounter < 60; psCounter++) {
+      tTandPs_[tccId][psCounter][0] = tTandPs_tmp[psCounter - 42][0];
+      tTandPs_[tccId][psCounter][1] = tTandPs_tmp[psCounter - 42][1];
+    }
+
+  }  // loop on EEP TCC's
+
   //for (int tccId=0; tccId<EcalTriggerElectronicsId::MAX_TCCID; tccId++) {
   //for (int psCounter=0; psCounter<EcalTrigTowerDetId::kEBTowersPerSM*5; psCounter++) {
   //std::cout << "AF tccId: " << (tccId+1) << "    counter: " << (psCounter+1)
   //<< " tt: " << tTandPs_[tccId][psCounter][0]
   //<< " ps: " << tTandPs_[tccId][psCounter][1]
   //<< std::endl;
-// } }
-
+  // } }
 }
 
-
-void EcalElectronicsMapper::setupGhostMap()
-{
+void EcalElectronicsMapper::setupGhostMap() {
   // number of 'ghost' VFEs
   const int n = 44;
-  
+
   // here is a list of all 'ghost' VFEs
   // in format {FED, CCU, VFE}
-  const struct {int FED, CCU, VFE;} v[n] = {
-    {601, 10, 5},
-    {601, 34, 3},
-    {601, 34, 4},
-    {601, 34, 5},
-    {602, 32, 5},
-    {603, 12, 5},
-    {603, 30, 5},
-    {604, 12, 5},
-    {604, 30, 5},
-    {605, 32, 5},
-    {606, 10, 5},
-    {606, 34, 3},
-    {606, 34, 4},
-    {606, 34, 5},
-    {608, 27, 3},
-    {608, 27, 4},
-    {608, 27, 5},
-    {608,  3, 3},
-    {608,  3, 4},
-    {608,  3, 5},
-    {608, 30, 5},
-    {608,  6, 5},
-    {646, 10, 5},
-    {646, 34, 3},
-    {646, 34, 4},
-    {646, 34, 5},
-    {647, 32, 5},
-    {648, 12, 5},
-    {648, 30, 5},
-    {649, 12, 5},
-    {649, 30, 5},
-    {650, 32, 5},
-    {651, 10, 5},
-    {651, 34, 3},
-    {651, 34, 4},
-    {651, 34, 5},
-    {653, 27, 3},
-    {653, 27, 4},
-    {653, 27, 5},
-    {653,  3, 3},
-    {653,  3, 4},
-    {653,  3, 5},
-    {653, 30, 5},
-    {653,  6, 5}
-  };
-  
+  const struct {
+    int FED, CCU, VFE;
+  } v[n] = {{601, 10, 5}, {601, 34, 3}, {601, 34, 4}, {601, 34, 5}, {602, 32, 5}, {603, 12, 5}, {603, 30, 5},
+            {604, 12, 5}, {604, 30, 5}, {605, 32, 5}, {606, 10, 5}, {606, 34, 3}, {606, 34, 4}, {606, 34, 5},
+            {608, 27, 3}, {608, 27, 4}, {608, 27, 5}, {608, 3, 3},  {608, 3, 4},  {608, 3, 5},  {608, 30, 5},
+            {608, 6, 5},  {646, 10, 5}, {646, 34, 3}, {646, 34, 4}, {646, 34, 5}, {647, 32, 5}, {648, 12, 5},
+            {648, 30, 5}, {649, 12, 5}, {649, 30, 5}, {650, 32, 5}, {651, 10, 5}, {651, 34, 3}, {651, 34, 4},
+            {651, 34, 5}, {653, 27, 3}, {653, 27, 4}, {653, 27, 5}, {653, 3, 3},  {653, 3, 4},  {653, 3, 5},
+            {653, 30, 5}, {653, 6, 5}};
+
   for (int i = 0; i < n; ++i)
     ghost_[v[i].FED][v[i].CCU][v[i].VFE] = true;
 }
 
-bool EcalElectronicsMapper::isGhost(const int FED, const int CCU, const int VFE)
-{
+bool EcalElectronicsMapper::isGhost(const int FED, const int CCU, const int VFE) {
   if (ghost_.find(FED) == ghost_.end())
     return false;
-  
+
   if (ghost_[FED].find(CCU) == ghost_[FED].end())
     return false;
-  
+
   if (ghost_[FED][CCU].find(VFE) == ghost_[FED][CCU].end())
     return false;
-  
+
   return true;
 }
 
 // number of readout channels (TT in EB, SC in EE) in a DCC
-const unsigned int  EcalElectronicsMapper::numChannelsInDcc_[NUMB_SM] = {34,32,33,33,32,34,33,41,33,    // EE -
-                                                                          68,68,68,68,68,68,68,68,68,68, // EB-
-                                                                          68,68,68,68,68,68,68,68,
-                                                                          68,68,68,68,68,68,68,68,68,68, // EB+
-                                                                          68,68,68,68,68,68,68,68,
-                                                                          34,32,33,33,32,34,33,41,33};   // EE+
+const unsigned int EcalElectronicsMapper::numChannelsInDcc_[NUMB_SM] = {
+    34, 32, 33, 33, 32, 34, 33, 41, 33,                                      // EE -
+    68, 68, 68, 68, 68, 68, 68, 68, 68, 68,                                  // EB-
+    68, 68, 68, 68, 68, 68, 68, 68, 68, 68, 68, 68, 68, 68, 68, 68, 68, 68,  // EB+
+    68, 68, 68, 68, 68, 68, 68, 68, 34, 32, 33, 33, 32, 34, 33, 41, 33};     // EE+

--- a/EventFilter/EcalRawToDigi/src/EcalRegionCabling.cc
+++ b/EventFilter/EcalRawToDigi/src/EcalRegionCabling.cc
@@ -1,5 +1,4 @@
 #include "EventFilter/EcalRawToDigi/interface/EcalRegionCabling.h"
 
-
 #include "FWCore/Utilities/interface/typelookup.h"
 TYPELOOKUP_DATA_REG(EcalRegionCabling);

--- a/EventFilter/EcalRawToDigi/src/EcalRegionCablingRecord.cc
+++ b/EventFilter/EcalRawToDigi/src/EcalRegionCablingRecord.cc
@@ -1,4 +1,4 @@
 #include "EventFilter/EcalRawToDigi/interface/EcalRegionCablingRecord.h"
 #include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
- 
+
 EVENTSETUP_RECORD_REG(EcalRegionCablingRecord);

--- a/EventFilter/EcalRawToDigi/src/Majority.h
+++ b/EventFilter/EcalRawToDigi/src/Majority.h
@@ -5,27 +5,26 @@
 #define MAJORITY_H
 
 #include <map>
-  
+
 /** Utility class to take a decision on majority based.
  * Used by MatacqProducer.
  */
-template<class T>
+template <class T>
 class Majority {
   //constructor(s) and destructor(s)
 public:
   /** Constructs a Majority
    */
-  Majority(): n_(0){}
+  Majority() : n_(0) {}
 
   /**Destructor
    */
-  virtual ~Majority(){}
+  virtual ~Majority() {}
 
   /** Collects event
    * @param value event
    */
-  void
-  add(const T& value){
+  void add(const T& value) {
     votes_[value] += 1.;
     n_ += 1.;
   }
@@ -35,23 +34,21 @@ public:
    * value.
    * @return selected value, that is the most frequent one.
    */
-  T result(double* proba) const{
+  T result(double* proba) const {
     std::pair<T, double> m(T(), -1.);
-    for(typename std::map<T, double>::const_iterator it = votes_.begin();
-	it != votes_.end();
-	++it){
-      if(it->second > m.second){
-	m = *it;
+    for (typename std::map<T, double>::const_iterator it = votes_.begin(); it != votes_.end(); ++it) {
+      if (it->second > m.second) {
+        m = *it;
       }
     }
-    if(proba) *proba = n_>0?m.second/n_:-1;
+    if (proba)
+      *proba = n_ > 0 ? m.second / n_ : -1;
     return m.first;
   }
 
   //method(s)
 public:
 private:
-
   //attribute(s)
 protected:
 private:
@@ -59,4 +56,4 @@ private:
   double n_;
 };
 
-#endif //MAJORITY_H not defined
+#endif  //MAJORITY_H not defined

--- a/EventFilter/EcalRawToDigi/src/MatacqDataFormatter.cc
+++ b/EventFilter/EcalRawToDigi/src/MatacqDataFormatter.cc
@@ -16,48 +16,43 @@ using namespace std;
 
 //#define MATACQ_DEBUG
 
-void
-MatacqDataFormatter::interpretRawData(const FEDRawData & data, EcalMatacqDigiCollection& matacqDigiCollection) {
+void MatacqDataFormatter::interpretRawData(const FEDRawData& data, EcalMatacqDigiCollection& matacqDigiCollection) {
 #if MATACQ_DEBUG
   cout << "****************************************************************\n";
   cout << "********************** MATACQ decoder **************************\n";
   cout << "****************************************************************\n";
   cout << "FEDRawData: \n";
   char oldPad = cout.fill('0');
-  for(int i=0; i < max(100, (int)data.size()); ++i){
-    cout << hex << setw(2) << (int)(data.data()[i])
-	 << ((i+1)%8?" ":"\n") ;
+  for (int i = 0; i < max(100, (int)data.size()); ++i) {
+    cout << hex << setw(2) << (int)(data.data()[i]) << ((i + 1) % 8 ? " " : "\n");
   }
   cout.fill(oldPad);
   cout << "======================================================================\n";
-#endif //MATACQ_DEBUG defined
-  interpretRawData(MatacqRawEvent(data.data(), data.size()),
-		   matacqDigiCollection);  
+#endif  //MATACQ_DEBUG defined
+  interpretRawData(MatacqRawEvent(data.data(), data.size()), matacqDigiCollection);
 }
 
-void
-MatacqDataFormatter::interpretRawData(const MatacqRawEvent& matacq, EcalMatacqDigiCollection& matacqDigiCollection) {
+void MatacqDataFormatter::interpretRawData(const MatacqRawEvent& matacq,
+                                           EcalMatacqDigiCollection& matacqDigiCollection) {
 #if MATACQ_DEBUG
   printData(cout, matacq);
-#endif //MATACQ_DEBUG defined
+#endif  //MATACQ_DEBUG defined
 
-  const double ns = 1.e-9; //ns->s
-  const double ps = 1.e-12;//ps->s
-  double ts = ns/matacq.getFreqGHz();
-  double tTrig = matacq.getTTrigPs()<.5*numeric_limits<int>::max()?
-    ps*matacq.getTTrigPs():999.;
+  const double ns = 1.e-9;   //ns->s
+  const double ps = 1.e-12;  //ps->s
+  double ts = ns / matacq.getFreqGHz();
+  double tTrig = matacq.getTTrigPs() < .5 * numeric_limits<int>::max() ? ps * matacq.getTTrigPs() : 999.;
   int version = matacq.getMatacqDataFormatVersion();
-  
+
   vector<int16_t> samples;
   //FIXME: the interpretRawData method should fill an EcalMatacqDigiCollection
   //instead of an EcalMatacqDigi because Matacq channels are several.
   //In the meamtime copy only the first channel appearing in data:
   const vector<MatacqRawEvent::ChannelData>& chData = matacq.getChannelData();
-  for(unsigned iCh=0; iCh < chData.size(); ++iCh){
+  for (unsigned iCh = 0; iCh < chData.size(); ++iCh) {
     //copy time samples into a vector:
     samples.resize(chData[iCh].nSamples);
-    copy(chData[iCh].samples, chData[iCh].samples+chData[iCh].nSamples,
-	 samples.begin());
+    copy(chData[iCh].samples, chData[iCh].samples + chData[iCh].nSamples, samples.begin());
     int chId = chData[iCh].chId;
     vector<int16_t> empty;
     EcalMatacqDigi matacqDigi(empty, chId, ts, version, tTrig);
@@ -76,52 +71,43 @@ MatacqDataFormatter::interpretRawData(const MatacqRawEvent& matacq, EcalMatacqDi
     matacqDigi.laserPower(matacq.getLaserPower());
     timeval t;
     matacq.getTimeStamp(t);
-    matacqDigi.timeStamp(t);    
-#endif //matacq digi version >=2
+    matacqDigi.timeStamp(t);
+#endif  //matacq digi version >=2
     matacqDigiCollection.push_back(matacqDigi);
-    matacqDigiCollection.back().swap(samples); //swap is more efficient than a copy
+    matacqDigiCollection.back().swap(samples);  //swap is more efficient than a copy
   }
 }
 
-void MatacqDataFormatter::printData(ostream& out, const MatacqRawEvent& matacq) const{
+void MatacqDataFormatter::printData(ostream& out, const MatacqRawEvent& matacq) const {
   cout << "FED id: " << hex << "0x" << matacq.getFedId() << dec << "\n";
-  cout << "Event id (lv1): " 
-       << hex << "0x" << matacq.getEventId() << dec << "\n";
+  cout << "Event id (lv1): " << hex << "0x" << matacq.getEventId() << dec << "\n";
   cout << "FOV: " << hex << "0x" << matacq.getFov() << dec << "\n";
   cout << "BX id: " << hex << "0x" << matacq.getBxId() << dec << "\n";
-  cout << "Trigger type: " 
-       << hex << "0x" << matacq.getTriggerType() << dec << "\n";
+  cout << "Trigger type: " << hex << "0x" << matacq.getTriggerType() << dec << "\n";
   cout << "DCC Length: " << matacq.getDccLen() << "\n";
   cout << "Run number: " << matacq.getRunNum() << "\n";
-  cout << "Field 'DCC errors': " 
-       << hex << "0x" << matacq.getDccErrors() << dec << "\n";
-  
-  if(matacq.getStatus()){
-    cout << "Error in matacq data. Errot code: "
-	 << hex << "0x" << matacq.getStatus() << dec << "\n";
+  cout << "Field 'DCC errors': " << hex << "0x" << matacq.getDccErrors() << dec << "\n";
+
+  if (matacq.getStatus()) {
+    cout << "Error in matacq data. Errot code: " << hex << "0x" << matacq.getStatus() << dec << "\n";
   }
-  
-  cout << "MATACQ data format version: " << matacq.getMatacqDataFormatVersion()
-       << "\n";
+
+  cout << "MATACQ data format version: " << matacq.getMatacqDataFormatVersion() << "\n";
   cout << "Sampling frequency: " << matacq.getFreqGHz() << " GHz\n";
   cout << "MATACQ channel count: " << matacq.getChannelCount() << "\n";
   time_t timeStamp = matacq.getTimeStamp();
   cout << "Data acquired on : " << ctime(&timeStamp);
 
   const vector<MatacqRawEvent::ChannelData>& channels = matacq.getChannelData();
-  for(unsigned i=0; i< channels.size(); ++i){
-    cout << "-------------------------------------- Channel "
-	 << channels[i].chId
-	 << ": " << setw(4) << channels[i].nSamples
-	 << " samples --------------------------------------\n";
-    
-    for(int iSample = 0; iSample<channels[i].nSamples; ++iSample){
+  for (unsigned i = 0; i < channels.size(); ++i) {
+    cout << "-------------------------------------- Channel " << channels[i].chId << ": " << setw(4)
+         << channels[i].nSamples << " samples --------------------------------------\n";
+
+    for (int iSample = 0; iSample < channels[i].nSamples; ++iSample) {
       MatacqRawEvent::int16le_t adc = (channels[i].samples)[iSample];
-      cout << setw(4) << adc
-	   << ((iSample%20==19)?"\n":" ");
+      cout << setw(4) << adc << ((iSample % 20 == 19) ? "\n" : " ");
     }
   }
   cout << "=================================================="
-    "==================================================\n\n";   
+          "==================================================\n\n";
 }
-

--- a/EventFilter/EcalRawToDigi/src/MatacqDataFormatter.h
+++ b/EventFilter/EcalRawToDigi/src/MatacqDataFormatter.h
@@ -13,28 +13,25 @@ class FEDRawData;
  * This class is used by the MatacqProducer module.
  *  @author: Ph. Gras (CEA/Saclay)
  */
-class MatacqDataFormatter{
+class MatacqDataFormatter {
 public:
-  MatacqDataFormatter() {};
-  
+  MatacqDataFormatter(){};
+
   /** Callback method for decoding raw data
    * @param data raw data
    * @param matacqDigiCollection [out] digi collection object to fill with
    * the decoded data
    */
-  void interpretRawData(const FEDRawData & data,
-			EcalMatacqDigiCollection& matacqDigiCollection);
-  
+  void interpretRawData(const FEDRawData& data, EcalMatacqDigiCollection& matacqDigiCollection);
+
   /** Callback method for decoding raw data
    * @param data raw data
    * @param matacqDigiCollection [out] digi collection object to fill with
    * the decoded data
    */
-  void interpretRawData(const MatacqRawEvent& data,
-			EcalMatacqDigiCollection& matacqDigiCollection);
-  
+  void interpretRawData(const MatacqRawEvent& data, EcalMatacqDigiCollection& matacqDigiCollection);
+
 private:
   void printData(std::ostream& out, const MatacqRawEvent& event) const;
 };
 #endif
-

--- a/EventFilter/EcalRawToDigi/src/MatacqRawEvent.cc
+++ b/EventFilter/EcalRawToDigi/src/MatacqRawEvent.cc
@@ -19,103 +19,99 @@
 
 #define CMSSW
 
-#ifdef CMSSW //compilation within CMSSW framework
+#ifdef CMSSW  //compilation within CMSSW framework
 
 #include "EventFilter/EcalRawToDigi/interface/MatacqRawEvent.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-static inline void throwExcept(const std::string& s){
-  throw cms::Exception("Matacq") << s;
-}
+static inline void throwExcept(const std::string &s) { throw cms::Exception("Matacq") << s; }
 
-#else //compilation outside CMSSW framework (e.g. online)
+#else  //compilation outside CMSSW framework (e.g. online)
 
 #include "MatacqRawEvent.h"
 #include <stdexcept>
-static inline void throwExcept(const std::string& s){
-  throw std::runtime_error(s.c_str());
-}
+static inline void throwExcept(const std::string &s) { throw std::runtime_error(s.c_str()); }
 
-#endif //CMSSW not defined
+#endif  //CMSSW not defined
 
 using namespace std;
 
 //DAQ header fields:
-const MatacqRawEvent::field32spec_t MatacqRawEvent::fov32             	= {0, 0x000000F0};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::fedId32           	= {0, 0x000FFF00};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::bxId32            	= {0, 0xFFF00000};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::lv132             	= {1, 0x00FFFFFF};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::triggerType32     	= {1, 0x0F000000};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::boeType32         	= {1, 0xF0000000};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::dccLen32          	= {2, 0x00FFFFFF};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::dccErrors32       	= {2, 0xFF000000};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::runNum32          	= {3, 0x00FFFFFF};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::h1Marker32        	= {3, 0x3F000000};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::fov32 = {0, 0x000000F0};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::fedId32 = {0, 0x000FFF00};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::bxId32 = {0, 0xFFF00000};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::lv132 = {1, 0x00FFFFFF};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::triggerType32 = {1, 0x0F000000};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::boeType32 = {1, 0xF0000000};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::dccLen32 = {2, 0x00FFFFFF};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::dccErrors32 = {2, 0xFF000000};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::runNum32 = {3, 0x00FFFFFF};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::h1Marker32 = {3, 0x3F000000};
 
 //Matacq header fields:
-const MatacqRawEvent::field32spec_t MatacqRawEvent::formatVersion32   	= {4, 0x0000FFFF};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::freqGHz32         	= {4, 0x00FF0000};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::channelCount32    	= {4, 0xFF000000};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::timeStamp32       	= {5, 0xFFFFFFFF};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::formatVersion32 = {4, 0x0000FFFF};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::freqGHz32 = {4, 0x00FF0000};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::channelCount32 = {4, 0xFF000000};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::timeStamp32 = {5, 0xFFFFFFFF};
 //  for data format version >=2:
-const MatacqRawEvent::field32spec_t MatacqRawEvent::tTrigPs32         	= {6, 0xFFFFFFFF};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::tTrigPs32 = {6, 0xFFFFFFFF};
 //  for data format version >=3:
-const MatacqRawEvent::field32spec_t MatacqRawEvent::orbitId32         	= {7, 0xFFFFFFFF};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::vernier0_32       	= {8, 0x0000FFFF};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::vernier1_32       	= {8, 0xFFFF0000};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::vernier2_32       	= {9, 0x0000FFFF};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::vernier3_32       	= {9, 0xFFFF0000};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::timeStampMicroSec32 = {10,0xFFFFFFFF};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::trigRec32         	= {11,0xFF000000};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::postTrig32        	= {11,0x0000FFFF};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::laserPower32        = {12,0x000000FF};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::attenuation_dB32    = {12,0x00000F00};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::emtcPhase32         = {12,0x0000F000};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::emtcDelay32         = {12,0xFFFF0000};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::delayA32            = {13,0x0000FFFF};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::dccId32             = {13,0x003F0000}; 
-const MatacqRawEvent::field32spec_t MatacqRawEvent::color32             = {13,0x00600000};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::trigType32          = {13,0x07000000};
-const MatacqRawEvent::field32spec_t MatacqRawEvent::side32              = {13,0x08000000};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::orbitId32 = {7, 0xFFFFFFFF};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::vernier0_32 = {8, 0x0000FFFF};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::vernier1_32 = {8, 0xFFFF0000};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::vernier2_32 = {9, 0x0000FFFF};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::vernier3_32 = {9, 0xFFFF0000};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::timeStampMicroSec32 = {10, 0xFFFFFFFF};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::trigRec32 = {11, 0xFF000000};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::postTrig32 = {11, 0x0000FFFF};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::laserPower32 = {12, 0x000000FF};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::attenuation_dB32 = {12, 0x00000F00};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::emtcPhase32 = {12, 0x0000F000};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::emtcDelay32 = {12, 0xFFFF0000};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::delayA32 = {13, 0x0000FFFF};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::dccId32 = {13, 0x003F0000};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::color32 = {13, 0x00600000};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::trigType32 = {13, 0x07000000};
+const MatacqRawEvent::field32spec_t MatacqRawEvent::side32 = {13, 0x08000000};
 
-void MatacqRawEvent::setRawData(const unsigned char* pData, size_t maxSize){
+void MatacqRawEvent::setRawData(const unsigned char *pData, size_t maxSize) {
   error = 0;
-  const int16le_t *begin16 = (const int16le_t *) pData;
-  const uint32le_t *begin32 = (const uint32le_t *) pData;
-  if(maxSize < 6*4){
+  const int16le_t *begin16 = (const int16le_t *)pData;
+  const uint32le_t *begin32 = (const uint32le_t *)pData;
+  if (maxSize < 6 * 4) {
     error = errorLength;
     return;
   }
-  
+
   daqHeader = begin32;
   matacqDataFormatVersion = read32(begin32, formatVersion32);
-  freqGHz       	  = read32(begin32, freqGHz32);
-  channelCount  	  = read32(begin32, channelCount32);
-  timeStamp.tv_sec     	  = read32(begin32, timeStamp32);
-  int headerLen = 24; //in bytes
-  if(matacqDataFormatVersion>=2){
-    tTrigPs       = read32(begin32, tTrigPs32);
+  freqGHz = read32(begin32, freqGHz32);
+  channelCount = read32(begin32, channelCount32);
+  timeStamp.tv_sec = read32(begin32, timeStamp32);
+  int headerLen = 24;  //in bytes
+  if (matacqDataFormatVersion >= 2) {
+    tTrigPs = read32(begin32, tTrigPs32);
     headerLen += 4;
-  } else{
+  } else {
     tTrigPs = numeric_limits<int>::max();
   }
 
-  if(matacqDataFormatVersion>=3){
-    orbitId           = read32(begin32, orbitId32);
-    vernier[0]        = read32(begin32, vernier0_32);
-    vernier[1]        = read32(begin32, vernier1_32);
-    vernier[2]        = read32(begin32, vernier2_32);
-    vernier[3]        = read32(begin32, vernier3_32);
+  if (matacqDataFormatVersion >= 3) {
+    orbitId = read32(begin32, orbitId32);
+    vernier[0] = read32(begin32, vernier0_32);
+    vernier[1] = read32(begin32, vernier1_32);
+    vernier[2] = read32(begin32, vernier2_32);
+    vernier[3] = read32(begin32, vernier3_32);
     timeStamp.tv_usec = read32(begin32, timeStampMicroSec32);
-    trigRec           = read32(begin32, trigRec32, true);
-    postTrig          = read32(begin32, postTrig32);
-    delayA            = read32(begin32, delayA32, true);
-    emtcDelay         = read32(begin32, emtcDelay32, true);
-    emtcPhase         = read32(begin32, emtcPhase32, true);
-    attenuation_dB    = read32(begin32, attenuation_dB32, true);
-    laserPower        = read32(begin32, laserPower32, true);
+    trigRec = read32(begin32, trigRec32, true);
+    postTrig = read32(begin32, postTrig32);
+    delayA = read32(begin32, delayA32, true);
+    emtcDelay = read32(begin32, emtcDelay32, true);
+    emtcPhase = read32(begin32, emtcPhase32, true);
+    attenuation_dB = read32(begin32, attenuation_dB32, true);
+    laserPower = read32(begin32, laserPower32, true);
     headerLen = 64;
-  } else{
+  } else {
     orbitId = 0;
     vernier[0] = -1;
     vernier[1] = -1;
@@ -129,14 +125,14 @@ void MatacqRawEvent::setRawData(const unsigned char* pData, size_t maxSize){
     attenuation_dB = -1;
     laserPower = -1;
   }
-    
+
   const int nCh = getChannelCount();
   channelData.resize(nCh);
 
-  const int16le_t *pData16 = (const int16le_t *) (pData+headerLen); 
+  const int16le_t *pData16 = (const int16le_t *)(pData + headerLen);
 
-  for(int iCh=0; iCh<nCh; ++iCh){
-    if((size_t)(pData16-begin16)>maxSize){
+  for (int iCh = 0; iCh < nCh; ++iCh) {
+    if ((size_t)(pData16 - begin16) > maxSize) {
       throwExcept(string("Corrupted or truncated data"));
     }
     //channel id:
@@ -146,68 +142,68 @@ void MatacqRawEvent::setRawData(const unsigned char* pData, size_t maxSize){
     //pointer to time sample data of this channel:
     channelData[iCh].samples = pData16;
     //moves to next channel data block:
-    if(channelData[iCh].nSamples<0){
+    if (channelData[iCh].nSamples < 0) {
       throwExcept(string("Corrupted or truncated data"));
     }
     pData16 += channelData[iCh].nSamples;
   }
-  
+
   //data trailer chekes:
   //FED header is aligned on 64-bit=>padding to skip
-  int padding = (4-(pData16-begin16))%4;
-  if(padding<0) padding+=4;
+  int padding = (4 - (pData16 - begin16)) % 4;
+  if (padding < 0)
+    padding += 4;
   pData16 += padding;
-  if((size_t)(pData16-begin16)>maxSize){
+  if ((size_t)(pData16 - begin16) > maxSize) {
     throwExcept(string("Corrupted or truncated data"));
   }
-  const uint32le_t* trailer32 = (const uint32le_t*)(pData16);
-  fragLen = trailer32[1]&0xFFFFFF;
-  
+  const uint32le_t *trailer32 = (const uint32le_t *)(pData16);
+  fragLen = trailer32[1] & 0xFFFFFF;
+
   //cout << "Event fragment length including headers: " << fragLen
   //	 << " 64-bit words\n";
-  
+
   //FIXME: I am expecting the event length specifies in the header to
   //include the header, while it is not the case in current TB 2006 data
   const int nHeaders = 3;
-  if(fragLen!=read32(begin32,dccLen32)+nHeaders
-     && fragLen != read32(begin32,dccLen32)){
+  if (fragLen != read32(begin32, dccLen32) + nHeaders && fragLen != read32(begin32, dccLen32)) {
     //cout << "Error: fragment length is not consistent with DCC "
     //	"length\n";
     error |= errorLengthConsistency;
   }
-  
+
   //skip trailers
   const int trailerLen = 4;
   pData16 += trailerLen;
-  
-  parsedLen = (pData16-begin16) / 4;
 
-  if((pData16-begin16)!=(4*fragLen)){
+  parsedLen = (pData16 - begin16) / 4;
+
+  if ((pData16 - begin16) != (4 * fragLen)) {
     error |= errorLength;
   }
 
-  if((size_t)(pData16-begin16)>maxSize){
+  if ((size_t)(pData16 - begin16) > maxSize) {
     throwExcept(string("Corrupted or truncated data"));
   }
 
   //some checks
-  if(getBoe()!=0x5){
+  if (getBoe() != 0x5) {
     error |= errorWrongBoe;
   }
 }
 
-int MatacqRawEvent::read32(const uint32le_t* pData, field32spec_t spec32,
-			   bool ovfTrans){
-  uint32_t result =  pData[spec32.offset] & spec32.mask;
+int MatacqRawEvent::read32(const uint32le_t *pData, field32spec_t spec32, bool ovfTrans) {
+  uint32_t result = pData[spec32.offset] & spec32.mask;
   uint32_t mask = spec32.mask;
-  while((mask&0x1) == 0){
-      mask >>= 1;
-      result >>= 1;
+  while ((mask & 0x1) == 0) {
+    mask >>= 1;
+    result >>= 1;
   }
-  if(ovfTrans){
+  if (ovfTrans) {
     //overflow bit (MSB) mask:
-    mask = ((mask >>1) + 1);
-    if(result & mask)  result = (uint32_t)-1;
+    mask = ((mask >> 1) + 1);
+    if (result & mask)
+      result = (uint32_t)-1;
   }
   return result;
 }

--- a/EventFilter/EcalTBRawToDigi/interface/EcalDCC07UnpackingModule.h
+++ b/EventFilter/EcalTBRawToDigi/interface/EcalDCC07UnpackingModule.h
@@ -16,41 +16,39 @@
 #include <iostream>
 #include <string>
 
-
 class EcalTB07DaqFormatter;
 class EcalSupervisorTBDataFormatter;
 class CamacTBDataFormatter;
 class TableDataFormatter;
 class MatacqTBDataFormatter;
 
-  class EcalDCCTB07UnpackingModule: public edm::EDProducer {
-  public:
-    /// Constructor
-    EcalDCCTB07UnpackingModule(const edm::ParameterSet& pset);
+class EcalDCCTB07UnpackingModule : public edm::EDProducer {
+public:
+  /// Constructor
+  EcalDCCTB07UnpackingModule(const edm::ParameterSet& pset);
 
-    /// Destructor
-    ~EcalDCCTB07UnpackingModule() override;
-    
-    /// Produce digis out of raw data
-    void produce(edm::Event & e, const edm::EventSetup& c) override;
+  /// Destructor
+  ~EcalDCCTB07UnpackingModule() override;
 
-    // BeginJob
-    void beginJob() override;
+  /// Produce digis out of raw data
+  void produce(edm::Event& e, const edm::EventSetup& c) override;
 
-    // EndJob
-    void endJob(void) override;
+  // BeginJob
+  void beginJob() override;
 
-  private:
+  // EndJob
+  void endJob(void) override;
 
-    EcalTB07DaqFormatter* formatter_;
-    EcalSupervisorTBDataFormatter* ecalSupervisorFormatter_;
-    CamacTBDataFormatter* camacTBformatter_;
-    TableDataFormatter* tableFormatter_;
-    MatacqTBDataFormatter* matacqFormatter_;
+private:
+  EcalTB07DaqFormatter* formatter_;
+  EcalSupervisorTBDataFormatter* ecalSupervisorFormatter_;
+  CamacTBDataFormatter* camacTBformatter_;
+  TableDataFormatter* tableFormatter_;
+  MatacqTBDataFormatter* matacqFormatter_;
 
-    bool ProduceEEDigis_;
-    bool ProduceEBDigis_;
-    edm::InputTag fedRawDataCollectionTag_;
-  };
+  bool ProduceEEDigis_;
+  bool ProduceEBDigis_;
+  edm::InputTag fedRawDataCollectionTag_;
+};
 
 #endif

--- a/EventFilter/EcalTBRawToDigi/interface/EcalDCCHeaderRuntypeDecoder.h
+++ b/EventFilter/EcalTBRawToDigi/interface/EcalDCCHeaderRuntypeDecoder.h
@@ -3,15 +3,17 @@
 #ifndef ECALDCCTBHEADERRUNTYPE_DECODER_H
 #define ECALDCCTBHEADERRUNTYPE_DECODER_H
 #include <DataFormats/EcalRawData/interface/EcalDCCHeaderBlock.h>
-class EcalDCCTBHeaderRuntypeDecoder
-{
- public:
+class EcalDCCTBHeaderRuntypeDecoder {
+public:
   EcalDCCTBHeaderRuntypeDecoder();
   ~EcalDCCTBHeaderRuntypeDecoder();
-  bool Decode( unsigned long headerWord,   EcalDCCHeaderBlock * theHeader);
-  protected:
+  bool Decode(unsigned long headerWord, EcalDCCHeaderBlock* theHeader);
+
+protected:
   bool WasDecodingOk_;
-  void DecodeSetting ( int settings,  EcalDCCHeaderBlock * theHeader );
-  void CleanEcalDCCSettingsInfo(  EcalDCCHeaderBlock::EcalDCCEventSettings * theEventSettings);// Re-initialize theEventSettings  before filling with the deocoded event
+  void DecodeSetting(int settings, EcalDCCHeaderBlock* theHeader);
+  void CleanEcalDCCSettingsInfo(
+      EcalDCCHeaderBlock::EcalDCCEventSettings*
+          theEventSettings);  // Re-initialize theEventSettings  before filling with the deocoded event
 };
 #endif

--- a/EventFilter/EcalTBRawToDigi/interface/EcalDCCUnpackingModule.h
+++ b/EventFilter/EcalTBRawToDigi/interface/EcalDCCUnpackingModule.h
@@ -15,38 +15,36 @@
 #include <iostream>
 #include <string>
 
-
 class EcalTBDaqFormatter;
 class EcalSupervisorTBDataFormatter;
 class CamacTBDataFormatter;
 class TableDataFormatter;
 class MatacqTBDataFormatter;
 
-  class EcalDCCTBUnpackingModule: public edm::EDProducer {
-  public:
-    /// Constructor
-    EcalDCCTBUnpackingModule(const edm::ParameterSet& pset);
+class EcalDCCTBUnpackingModule : public edm::EDProducer {
+public:
+  /// Constructor
+  EcalDCCTBUnpackingModule(const edm::ParameterSet& pset);
 
-    /// Destructor
-    ~EcalDCCTBUnpackingModule() override;
-    
-    /// Produce digis out of raw data
-    void produce(edm::Event & e, const edm::EventSetup& c) override;
+  /// Destructor
+  ~EcalDCCTBUnpackingModule() override;
 
-    // BeginJob
-    void beginJob() override;
+  /// Produce digis out of raw data
+  void produce(edm::Event& e, const edm::EventSetup& c) override;
 
-    // EndJob
-    void endJob(void) override;
+  // BeginJob
+  void beginJob() override;
 
-  private:
+  // EndJob
+  void endJob(void) override;
 
-    EcalTBDaqFormatter* formatter_;
-    EcalSupervisorTBDataFormatter* ecalSupervisorFormatter_;
-    CamacTBDataFormatter* camacTBformatter_;
-    TableDataFormatter* tableFormatter_;
-    MatacqTBDataFormatter* matacqFormatter_;
-    edm::InputTag fedRawDataCollectionTag_;
-  };
+private:
+  EcalTBDaqFormatter* formatter_;
+  EcalSupervisorTBDataFormatter* ecalSupervisorFormatter_;
+  CamacTBDataFormatter* camacTBformatter_;
+  TableDataFormatter* tableFormatter_;
+  MatacqTBDataFormatter* matacqFormatter_;
+  edm::InputTag fedRawDataCollectionTag_;
+};
 
 #endif

--- a/EventFilter/EcalTBRawToDigi/src/CamacTBDataFormatter.cc
+++ b/EventFilter/EcalTBRawToDigi/src/CamacTBDataFormatter.cc
@@ -6,252 +6,321 @@
 
 #include "CamacTBDataFormatter.h"
 
-
-
 // pro-memo:
 // "ff" = 1 Byte
 // 64 bits = 8 Bytes = 16 hex carachters
 // for now: event is  ( 114 words x 32 bits ) = 448 Bytes
-// size of unsigned long = 4 Bytes. Thus, 1 (32 bit) word = 1 (unsigned long) 
+// size of unsigned long = 4 Bytes. Thus, 1 (32 bit) word = 1 (unsigned long)
 
-struct hodo_fibre_index 
-{
+struct hodo_fibre_index {
   int nfiber;
   int ndet;
 };
 
-// nHodoscopes = 2; nFibres = 64 
-const static struct hodo_fibre_index hodoFiberMap[2][64] = {
-  { // Hodo 0
-    // unit 1A
-    {23,44}, {29,47}, {31,48}, {21,43},
-    { 5,35}, {15,40}, { 7,36}, {13,39},
-    { 1,33}, {11,38}, { 3,34}, { 9,37},
-    { 6, 3}, {16, 8}, { 8, 4}, {14, 7},
-    // unit 1C
-    {17,41}, {19,42}, {27,46}, {25,45},
-    {32,16}, {22,11}, {24,12}, {30,15},
-    {12, 6}, { 2, 1}, { 4, 2}, {10, 5},
-    {28,14}, {18, 9}, {20,10}, {26,13},
-    // unit 2A
-    {54,27}, {56,28}, {64,32}, {62,31},
-    {49,57}, {59,62}, {51,58}, {57,61},
-    {53,59}, {63,64}, {55,60}, {61,63},
-    {45,55}, {39,52}, {37,51}, {47,56},
-    // unit 2C
-    {34,17}, {42,21}, {44,22}, {36,18},
-    {50,25}, {60,30}, {58,29}, {52,26},
-    {38,19}, {40,20}, {48,24}, {46,23},
-    {41,53}, {35,50}, {33,49}, {43,54}
-  },
-  { // Hodo 1
-    // unit 1A
-    {31,48}, {29,47}, {23,44}, {21,43},
-    { 5,35}, { 7,36}, {15,40}, {13,39},
-    { 1,33}, { 3,34}, {11,38}, { 9,37},
-    { 6, 3}, { 8, 4}, {16, 8}, {14, 7},
-    // unit 1C
-    {17,41}, {27,46}, {19,42}, {25,45},
-    {24,12}, {22,11}, {32,16}, {30,15},
-    { 4, 2}, { 2, 1}, {12, 6}, {10, 5},
-    {20,10}, {18, 9}, {28,14}, {26,13},
-    // unit 2A
-    {54,27}, {64,32}, {56,28}, {62,31},
-    {49,57}, {51,58}, {59,62}, {57,61},
-    {53,59}, {55,60}, {63,64}, {61,63},
-    {45,55}, {47,56}, {37,51}, {39,52},
-    // unit 2C
-    {34,17}, {42,21}, {36,18}, {44,22},
-    {50,25}, {52,26}, {58,29}, {60,30},
-    {38,19}, {48,24}, {40,20}, {46,23},
-    {41,53}, {43,54}, {33,49}, {35,50}
-  }
-};
+// nHodoscopes = 2; nFibres = 64
+const static struct hodo_fibre_index hodoFiberMap[2][64] = {{// Hodo 0
+                                                             // unit 1A
+                                                             {23, 44},
+                                                             {29, 47},
+                                                             {31, 48},
+                                                             {21, 43},
+                                                             {5, 35},
+                                                             {15, 40},
+                                                             {7, 36},
+                                                             {13, 39},
+                                                             {1, 33},
+                                                             {11, 38},
+                                                             {3, 34},
+                                                             {9, 37},
+                                                             {6, 3},
+                                                             {16, 8},
+                                                             {8, 4},
+                                                             {14, 7},
+                                                             // unit 1C
+                                                             {17, 41},
+                                                             {19, 42},
+                                                             {27, 46},
+                                                             {25, 45},
+                                                             {32, 16},
+                                                             {22, 11},
+                                                             {24, 12},
+                                                             {30, 15},
+                                                             {12, 6},
+                                                             {2, 1},
+                                                             {4, 2},
+                                                             {10, 5},
+                                                             {28, 14},
+                                                             {18, 9},
+                                                             {20, 10},
+                                                             {26, 13},
+                                                             // unit 2A
+                                                             {54, 27},
+                                                             {56, 28},
+                                                             {64, 32},
+                                                             {62, 31},
+                                                             {49, 57},
+                                                             {59, 62},
+                                                             {51, 58},
+                                                             {57, 61},
+                                                             {53, 59},
+                                                             {63, 64},
+                                                             {55, 60},
+                                                             {61, 63},
+                                                             {45, 55},
+                                                             {39, 52},
+                                                             {37, 51},
+                                                             {47, 56},
+                                                             // unit 2C
+                                                             {34, 17},
+                                                             {42, 21},
+                                                             {44, 22},
+                                                             {36, 18},
+                                                             {50, 25},
+                                                             {60, 30},
+                                                             {58, 29},
+                                                             {52, 26},
+                                                             {38, 19},
+                                                             {40, 20},
+                                                             {48, 24},
+                                                             {46, 23},
+                                                             {41, 53},
+                                                             {35, 50},
+                                                             {33, 49},
+                                                             {43, 54}},
+                                                            {// Hodo 1
+                                                             // unit 1A
+                                                             {31, 48},
+                                                             {29, 47},
+                                                             {23, 44},
+                                                             {21, 43},
+                                                             {5, 35},
+                                                             {7, 36},
+                                                             {15, 40},
+                                                             {13, 39},
+                                                             {1, 33},
+                                                             {3, 34},
+                                                             {11, 38},
+                                                             {9, 37},
+                                                             {6, 3},
+                                                             {8, 4},
+                                                             {16, 8},
+                                                             {14, 7},
+                                                             // unit 1C
+                                                             {17, 41},
+                                                             {27, 46},
+                                                             {19, 42},
+                                                             {25, 45},
+                                                             {24, 12},
+                                                             {22, 11},
+                                                             {32, 16},
+                                                             {30, 15},
+                                                             {4, 2},
+                                                             {2, 1},
+                                                             {12, 6},
+                                                             {10, 5},
+                                                             {20, 10},
+                                                             {18, 9},
+                                                             {28, 14},
+                                                             {26, 13},
+                                                             // unit 2A
+                                                             {54, 27},
+                                                             {64, 32},
+                                                             {56, 28},
+                                                             {62, 31},
+                                                             {49, 57},
+                                                             {51, 58},
+                                                             {59, 62},
+                                                             {57, 61},
+                                                             {53, 59},
+                                                             {55, 60},
+                                                             {63, 64},
+                                                             {61, 63},
+                                                             {45, 55},
+                                                             {47, 56},
+                                                             {37, 51},
+                                                             {39, 52},
+                                                             // unit 2C
+                                                             {34, 17},
+                                                             {42, 21},
+                                                             {36, 18},
+                                                             {44, 22},
+                                                             {50, 25},
+                                                             {52, 26},
+                                                             {58, 29},
+                                                             {60, 30},
+                                                             {38, 19},
+                                                             {48, 24},
+                                                             {40, 20},
+                                                             {46, 23},
+                                                             {41, 53},
+                                                             {43, 54},
+                                                             {33, 49},
+                                                             {35, 50}}};
 
+CamacTBDataFormatter::CamacTBDataFormatter() { nWordsPerEvent = 148; }
 
+void CamacTBDataFormatter::interpretRawData(const FEDRawData& fedData,
+                                            EcalTBEventHeader& tbEventHeader,
+                                            EcalTBHodoscopeRawInfo& hodoRaw,
+                                            EcalTBTDCRawInfo& tdcRawInfo) {
+  const unsigned long* buffer = (reinterpret_cast<const unsigned long*>(fedData.data()));
+  int fedLenght = fedData.size();  // in Bytes
 
-CamacTBDataFormatter::CamacTBDataFormatter () {
-  nWordsPerEvent = 148;
-}
-
-
-
-void CamacTBDataFormatter::interpretRawData( const FEDRawData & fedData, 
-					     EcalTBEventHeader& tbEventHeader,
-					     EcalTBHodoscopeRawInfo& hodoRaw,
-					     EcalTBTDCRawInfo& tdcRawInfo )
-{
-  
-
-  const unsigned long * buffer = ( reinterpret_cast<const unsigned long*>( fedData.data()));
-  int fedLenght                        = fedData.size(); // in Bytes
-  
   // check ultimate fed size and strip off fed-header and -trailer
-  if (fedLenght != (nWordsPerEvent *4) )
-    {
-      edm::LogError("CamacTBDataFormatter") << "CamacTBData has size "  <<  fedLenght
-				       <<" Bytes as opposed to expected " 
-				       << (nWordsPerEvent *4)
-				       << ". Returning.";
-      return;
-    }
+  if (fedLenght != (nWordsPerEvent * 4)) {
+    edm::LogError("CamacTBDataFormatter") << "CamacTBData has size " << fedLenght << " Bytes as opposed to expected "
+                                          << (nWordsPerEvent * 4) << ". Returning.";
+    return;
+  }
 
-  
-  
-  unsigned long a=1; // used to extract an 8 Bytes word from fed 
-  unsigned long b=1; // used to manipulate the 8 Bytes word and get what needed
+  unsigned long a = 1;  // used to extract an 8 Bytes word from fed
+  unsigned long b = 1;  // used to manipulate the 8 Bytes word and get what needed
 
   // initializing array of statuses
-  for (int wordNumber=0; wordNumber<nWordsPerEvent; wordNumber++)
-    { statusWords[wordNumber ] = true;}
+  for (int wordNumber = 0; wordNumber < nWordsPerEvent; wordNumber++) {
+    statusWords[wordNumber] = true;
+  }
 
   //  for (int wordNumber=0; wordNumber<nWordsPerEvent; wordNumber++)
   //    { checkStatus( buffer[wordNumber],  wordNumber);}
-  
+
   //   for (int wordNumber=0; wordNumber<nWordsPerEvent; wordNumber++)
   //     {
   //       if (! statusWords[wordNumber])
   // 	{
-  // 	  edm::LogError("CamacTBDataFormatter") << "bad status in some of the event words; returning;";	  
+  // 	  edm::LogError("CamacTBDataFormatter") << "bad status in some of the event words; returning;";
   // 	}
   //     }
-  
-  
 
-  int wordCounter =0;
-  wordCounter +=4;
-
+  int wordCounter = 0;
+  wordCounter += 4;
 
   // read first word
-  a = buffer[wordCounter];wordCounter++;
+  a = buffer[wordCounter];
+  wordCounter++;
   LogDebug("CamacTBDataFormatter") << "\n\nword:\t" << a;
-  
-  b = (a& 0xff000000);
+
+  b = (a & 0xff000000);
   b = b >> 24;
   LogDebug("CamacTBDataFormatter") << "format  ver:\t" << b;
 
-  b = (a& 0xff0000);
+  b = (a & 0xff0000);
   b = b >> 16;
   LogDebug("CamacTBDataFormatter") << "major:\t" << b;
 
-  b = (a& 0xff00);
+  b = (a & 0xff00);
   b = b >> 8;
   LogDebug("CamacTBDataFormatter") << "minor:\t" << b;
 
   LogDebug("CamacTBDataFormatter") << "\n\n word:\t" << a;
-  LogDebug("CamacTBDataFormatter") << "time stamp secs: "<<a;
+  LogDebug("CamacTBDataFormatter") << "time stamp secs: " << a;
 
   LogDebug("CamacTBDataFormatter") << "\n\n word:\t" << a;
-  LogDebug("CamacTBDataFormatter") << "time stamp musecs: " <<a;
+  LogDebug("CamacTBDataFormatter") << "time stamp musecs: " << a;
 
-
-  a = buffer[wordCounter];wordCounter++;
+  a = buffer[wordCounter];
+  wordCounter++;
   LogDebug("CamacTBDataFormatter") << "\n\n word:\t" << a;
-  b = (a& 0xffffff);
-  LogDebug("CamacTBDataFormatter") << "LV1A: "<< b;
+  b = (a & 0xffffff);
+  LogDebug("CamacTBDataFormatter") << "LV1A: " << b;
   int lv1 = b;
 
-  a = buffer[wordCounter];wordCounter++;
+  a = buffer[wordCounter];
+  wordCounter++;
   LogDebug("CamacTBDataFormatter") << "\n\n word:\t" << a;
-  b = (a& 0xffff0000);
+  b = (a & 0xffff0000);
   b = b >> 16;
-  LogDebug("CamacTBDataFormatter") << "run number: "<< b;
+  LogDebug("CamacTBDataFormatter") << "run number: " << b;
   int run = b;
-  b = (a& 0xffff);
-  LogDebug("CamacTBDataFormatter") << "spill number: "<< b;
+  b = (a & 0xffff);
+  LogDebug("CamacTBDataFormatter") << "spill number: " << b;
   int spill = b;
 
-  a = buffer[wordCounter];wordCounter++;
-  b = (a& 0xffff);
-  LogDebug("CamacTBDataFormatter") << "event number in spill: "<< b;
+  a = buffer[wordCounter];
+  wordCounter++;
+  b = (a & 0xffff);
+  LogDebug("CamacTBDataFormatter") << "event number in spill: " << b;
 
-  a = buffer[wordCounter];wordCounter++;
-  b = (a& 0xffffff);
-  LogDebug("CamacTBDataFormatter") << "internal event number: "<< b;
+  a = buffer[wordCounter];
+  wordCounter++;
+  b = (a & 0xffffff);
+  LogDebug("CamacTBDataFormatter") << "internal event number: " << b;
 
-  a = buffer[wordCounter];wordCounter++;
+  a = buffer[wordCounter];
+  wordCounter++;
   LogDebug("CamacTBDataFormatter") << "\n\n word:\t" << a;
-  b = (a& 0xffff0000);
+  b = (a & 0xffff0000);
   b = b >> 16;
-  LogDebug("CamacTBDataFormatter") << "vme errors: "<< b;
-  b = (a& 0xffff);
-  LogDebug("CamacTBDataFormatter") << "camac errors: "<< b;
+  LogDebug("CamacTBDataFormatter") << "vme errors: " << b;
+  b = (a & 0xffff);
+  LogDebug("CamacTBDataFormatter") << "camac errors: " << b;
 
-  a = buffer[wordCounter];wordCounter++;
+  a = buffer[wordCounter];
+  wordCounter++;
   LogDebug("CamacTBDataFormatter") << "\n\n word:\t" << a;
   b = a;
-  LogDebug("CamacTBDataFormatter") << "extended (32 bits) run number: "<< b;
+  LogDebug("CamacTBDataFormatter") << "extended (32 bits) run number: " << b;
 
   // skip 1 reserved words
-  wordCounter +=1;
+  wordCounter += 1;
 
   /**********************************
   // acessing the hodoscope block
   **********************************/
 
   // getting 16 words buffer and checking words statuses
-  unsigned long bufferHodo[16]; 
+  unsigned long bufferHodo[16];
   bool hodoAreGood = true;
-  for (int hodo=0; hodo<16; hodo++)
-    {
-      hodoAreGood = hodoAreGood && checkStatus(buffer[wordCounter], wordCounter);
+  for (int hodo = 0; hodo < 16; hodo++) {
+    hodoAreGood = hodoAreGood && checkStatus(buffer[wordCounter], wordCounter);
 
-      a                 = buffer[wordCounter];
-      bufferHodo[hodo]  = buffer[wordCounter];
-      wordCounter++;
-      b = (a& 0xffffff);      
-      LogDebug("CamacTBDataFormatter") << "hodo: " << hodo << "\t: " << b;
-    }
+    a = buffer[wordCounter];
+    bufferHodo[hodo] = buffer[wordCounter];
+    wordCounter++;
+    b = (a & 0xffffff);
+    LogDebug("CamacTBDataFormatter") << "hodo: " << hodo << "\t: " << b;
+  }
 
   hodoRaw.setPlanes(0);
   // unpacking the hodo data
-  if (hodoAreGood){
-  for (int iplane=0; iplane<nHodoPlanes; iplane++) 
-    {         
-      int detType = 1;       // new mapping for electronics channels  
-               
-      for (int fiber=0; fiber<nHodoFibers; fiber++) { hodoHits[iplane][fiber] = 0; }            
-               
-      int ch=0;
-      
-      // loop on [4-24bits words] = 1 plane 
-      for(int j=0; j<hodoRawLen; j++) 
-	{
-	  int word=  bufferHodo[  j+iplane*hodoRawLen  ]  &0xffff;
-	  for(int i=1; i<0x10000; i<<=1) 
-	    {
-	      if ( word & i ) 
-		{
-		  // map electronics channel to No of fibre
-		  hodoHits[iplane][ hodoFiberMap[detType][ch].nfiber - 1]++;
-		}
-	      ch ++;
-	    }
-	} 
+  if (hodoAreGood) {
+    for (int iplane = 0; iplane < nHodoPlanes; iplane++) {
+      int detType = 1;  // new mapping for electronics channels
+
+      for (int fiber = 0; fiber < nHodoFibers; fiber++) {
+        hodoHits[iplane][fiber] = 0;
+      }
+
+      int ch = 0;
+
+      // loop on [4-24bits words] = 1 plane
+      for (int j = 0; j < hodoRawLen; j++) {
+        int word = bufferHodo[j + iplane * hodoRawLen] & 0xffff;
+        for (int i = 1; i < 0x10000; i <<= 1) {
+          if (word & i) {
+            // map electronics channel to No of fibre
+            hodoHits[iplane][hodoFiberMap[detType][ch].nfiber - 1]++;
+          }
+          ch++;
+        }
+      }
     }
 
-  
-  // building the hodo infos (returning decoded hodoscope hits information)
-  hodoRaw.setPlanes((unsigned int)nHodoPlanes);
-  for (int ipl = 0; ipl < nHodoPlanes; ipl++) 
-    {             
+    // building the hodo infos (returning decoded hodoscope hits information)
+    hodoRaw.setPlanes((unsigned int)nHodoPlanes);
+    for (int ipl = 0; ipl < nHodoPlanes; ipl++) {
       EcalTBHodoscopePlaneRawHits theHodoPlane;
       theHodoPlane.setChannels((unsigned int)nHodoFibers);
-      for (int fib = 0; fib < nHodoFibers; fib++){ theHodoPlane.setHit((unsigned int)fib, (bool)hodoHits[ipl][fib]); }
+      for (int fib = 0; fib < nHodoFibers; fib++) {
+        theHodoPlane.setHit((unsigned int)fib, (bool)hodoHits[ipl][fib]);
+      }
       hodoRaw.setPlane((unsigned int)ipl, theHodoPlane);
     }
+  } else {
+    edm::LogWarning("CamacTBDataFormatter")
+        << "hodoscope block has hardware problems or is partly unused at LV1: " << lv1 << " spill: " << spill
+        << "run: " << run << ". Skipping digi.";
   }
-  else
-    {
-      edm::LogWarning("CamacTBDataFormatter") << "hodoscope block has hardware problems or is partly unused at LV1: "
-					 << lv1 << " spill: " << spill 
-					 << "run: " << run 
-					 << ". Skipping digi.";
-    }
-  
-  
-
-
 
   /**********************************
   // acessing the scalers block
@@ -261,229 +330,203 @@ void CamacTBDataFormatter::interpretRawData( const FEDRawData & fedData,
 
   scalers_.clear();
   scalers_.reserve(36);
-  
+
   bool scalersAreGood = true;
-  for (int scaler=0; scaler<72; scaler++)
-    {
-      scalersAreGood = scalersAreGood && checkStatus(buffer[wordCounter], wordCounter);
+  for (int scaler = 0; scaler < 72; scaler++) {
+    scalersAreGood = scalersAreGood && checkStatus(buffer[wordCounter], wordCounter);
 
-      a = buffer[wordCounter];      wordCounter++;
-      b = (a& 0xffffff);
-      LogDebug("CamacTBDataFormatter") << "scaler: " << scaler << "\t: " << b;
+    a = buffer[wordCounter];
+    wordCounter++;
+    b = (a & 0xffffff);
+    LogDebug("CamacTBDataFormatter") << "scaler: " << scaler << "\t: " << b;
 
-      // filling vector container with scalers words
-      if ( (scaler%2)==0 ) scalers_.push_back(b);
-    }
-  if (scalersAreGood){
-    tbEventHeader.setScalers (scalers_);  
+    // filling vector container with scalers words
+    if ((scaler % 2) == 0)
+      scalers_.push_back(b);
   }
-  else
-    {
-      edm::LogWarning("CamacTBDataFormatter") << "scalers block has hardware problems  or is partly unused at LV1: "
-					 << lv1 << " spill: " << spill 
-					 << "run: " << run;
-    }
-  
-
-
-
+  if (scalersAreGood) {
+    tbEventHeader.setScalers(scalers_);
+  } else {
+    edm::LogWarning("CamacTBDataFormatter")
+        << "scalers block has hardware problems  or is partly unused at LV1: " << lv1 << " spill: " << spill
+        << "run: " << run;
+  }
 
   /**********************************
   // acessing the fingers block
   **********************************/
 
-  LogDebug("CamacTBDataFormatter") <<"\n";
+  LogDebug("CamacTBDataFormatter") << "\n";
   bool fingersAreGood = true;
-  for (int finger=0; finger<2; finger++)
-    {
-      fingersAreGood = fingersAreGood && checkStatus(buffer[wordCounter], wordCounter);
+  for (int finger = 0; finger < 2; finger++) {
+    fingersAreGood = fingersAreGood && checkStatus(buffer[wordCounter], wordCounter);
 
-      a = buffer[wordCounter];      wordCounter++;
-      b = (a& 0xffffff);
-      LogDebug("CamacTBDataFormatter") << "finger: " << finger << "\t: " << b;
-    }
-  if (fingersAreGood){
-    ;  }
-  else
-    {
-      edm::LogWarning("CamacTBDataFormatter") << "fingers block has hardware problems  or is partly unused at LV1: "
-					 << lv1 << " spill: " << spill 
-					 << "run: " << run;
-    }
-  
-
-
+    a = buffer[wordCounter];
+    wordCounter++;
+    b = (a & 0xffffff);
+    LogDebug("CamacTBDataFormatter") << "finger: " << finger << "\t: " << b;
+  }
+  if (fingersAreGood) {
+    ;
+  } else {
+    edm::LogWarning("CamacTBDataFormatter")
+        << "fingers block has hardware problems  or is partly unused at LV1: " << lv1 << " spill: " << spill
+        << "run: " << run;
+  }
 
   /**********************************
   // acessing the multi stop TDC block
   **********************************/
 
-  a = buffer[wordCounter];      wordCounter++;
+  a = buffer[wordCounter];
+  wordCounter++;
   LogDebug("CamacTBDataFormatter") << "\n\n word:\t" << a;
-  b = (a& 0x000000ff);
-  LogDebug("CamacTBDataFormatter") << "number of words used in multi stop TDC words: "<< b;
-  
+  b = (a & 0x000000ff);
+  LogDebug("CamacTBDataFormatter") << "number of words used in multi stop TDC words: " << b;
+
   int numberTDCwords = 16;
   bool multiStopTDCIsGood = true;
-  for (int tdc=0; tdc< numberTDCwords ; tdc++)
-    {
-      multiStopTDCIsGood =  multiStopTDCIsGood && checkStatus(buffer[wordCounter], wordCounter);
+  for (int tdc = 0; tdc < numberTDCwords; tdc++) {
+    multiStopTDCIsGood = multiStopTDCIsGood && checkStatus(buffer[wordCounter], wordCounter);
 
-      a = buffer[wordCounter];      wordCounter++;
-      b =a;
-      LogDebug("CamacTBDataFormatter") << "tdc: " << tdc << "\t: " << b;
-    }
-  if ( multiStopTDCIsGood ){
-    ;  }
-  else
-    {
-      edm::LogWarning("CamacTBDataFormatter") << "multi stop TDC block has hardware problems or is partly unused at LV1: "
-					 << lv1 << " spill: " << spill 
-					 << "run: " << run;
-    }
-  
+    a = buffer[wordCounter];
+    wordCounter++;
+    b = a;
+    LogDebug("CamacTBDataFormatter") << "tdc: " << tdc << "\t: " << b;
+  }
+  if (multiStopTDCIsGood) {
+    ;
+  } else {
+    edm::LogWarning("CamacTBDataFormatter")
+        << "multi stop TDC block has hardware problems or is partly unused at LV1: " << lv1 << " spill: " << spill
+        << "run: " << run;
+  }
+
   // skip the unused words in multi stop TDC block
   wordCounter += (16 - numberTDCwords);
 
-  
-
-  
   /**********************************
   // acessing table in position bit
   **********************************/
-  a = buffer[wordCounter];      wordCounter++;
+  a = buffer[wordCounter];
+  wordCounter++;
   b = (a & 0x00000001);  //1= table is in position; 0=table is moving
   bool tableIsMoving;
-  if ( b ){
+  if (b) {
     LogDebug("CamacTBDataFormatter") << " table is in position.";
     tableIsMoving = false;
-  }
-  else
-    {
+  } else {
     LogDebug("CamacTBDataFormatter") << " table is moving.";
     tableIsMoving = true;
-    }
-  tbEventHeader.setTableIsMoving( tableIsMoving );
-
+  }
+  tbEventHeader.setTableIsMoving(tableIsMoving);
 
   wordCounter += 3;
 
-  
-  
   /**********************************
    // acessing ADC block
    **********************************/
   // skip 10 reserved words
   wordCounter += 10;
   bool ADCIsGood = true;
-  a = buffer[wordCounter];      wordCounter++;  // NOT read out
-  b = (a&0x00ffffff);
-  LogDebug("CamacTBDataFormatter") << "ADC word1: " << a << "\t ADC2: " << b << " word is: " << (wordCounter-1);
-//  ADCIsGood = true;
-//  ADCIsGood = ADCIsGood && checkStatus(buffer[wordCounter], wordCounter);
+  a = buffer[wordCounter];
+  wordCounter++;  // NOT read out
+  b = (a & 0x00ffffff);
+  LogDebug("CamacTBDataFormatter") << "ADC word1: " << a << "\t ADC2: " << b << " word is: " << (wordCounter - 1);
+  //  ADCIsGood = true;
+  //  ADCIsGood = ADCIsGood && checkStatus(buffer[wordCounter], wordCounter);
   ADCIsGood = checkStatus(buffer[wordCounter], wordCounter);
-  a = buffer[wordCounter];      wordCounter++;  // read out
-  b = (a&0xffffff);
+  a = buffer[wordCounter];
+  wordCounter++;  // read out
+  b = (a & 0xffffff);
   LogDebug("CamacTBDataFormatter") << "ADC word2, adc channel 11, ampli S6: " << a << "\t ADC2: " << b;
-  if (ADCIsGood) tbEventHeader.setS6ADC ( b ) ;
-  else tbEventHeader.setS6ADC ( -1 ) ;
+  if (ADCIsGood)
+    tbEventHeader.setS6ADC(b);
+  else
+    tbEventHeader.setS6ADC(-1);
 
-  
   /**********************************
    // acessing TDC block
    **********************************/
   // skip 6 reserved words
   wordCounter += 6;
-  ADCIsGood && checkStatus(buffer[wordCounter], wordCounter);
-  a = buffer[wordCounter];      wordCounter++;
+  ADCIsGood&& checkStatus(buffer[wordCounter], wordCounter);
+  a = buffer[wordCounter];
+  wordCounter++;
   b = (a & 0xfffff);
   LogDebug("CamacTBDataFormatter") << "TDC word1: " << a << "\t TDC2: " << b;
-  ADCIsGood && checkStatus(buffer[wordCounter], wordCounter);
-  a = buffer[wordCounter];      wordCounter++;
+  ADCIsGood&& checkStatus(buffer[wordCounter], wordCounter);
+  a = buffer[wordCounter];
+  wordCounter++;
   b = (a & 0xfffff);
-  LogDebug("CamacTBDataFormatter") << "TDC word2: (ext_val_trig - LHC_clock) " 
-				   << a << "\t (ext_val_trig - LHC_clock): "
-				   << b;
-  
+  LogDebug("CamacTBDataFormatter") << "TDC word2: (ext_val_trig - LHC_clock) " << a
+                                   << "\t (ext_val_trig - LHC_clock): " << b;
+
   tdcRawInfo.setSize(1);
-  int sampleNumber =1;
+  int sampleNumber = 1;
   EcalTBTDCSample theTdc(sampleNumber, b);
   tdcRawInfo.setSample(0, theTdc);
 
-
-  a = buffer[wordCounter];      wordCounter++;
+  a = buffer[wordCounter];
+  wordCounter++;
   LogDebug("CamacTBDataFormatter") << "\n\n word:\t" << a;
   b = a;
-  LogDebug("CamacTBDataFormatter") << "last word of event: "<< b;
-
-
+  LogDebug("CamacTBDataFormatter") << "last word of event: " << b;
 }
-
-
-
-
-
-
-
 
 // given a data word with 8 msb as status, checks status
 
-bool CamacTBDataFormatter::checkStatus(unsigned long word, int wordNumber){
-  
-
-  if ( wordNumber < 1 || wordNumber > nWordsPerEvent)
-    { 
-      edm::LogWarning("CamacTBDataFormatter::checkStatus") << "checking word number: "
-						    <<  wordNumber << " which is out of allowed range (" 
-						    << nWordsPerEvent << ")";
-      return false;
-    }
+bool CamacTBDataFormatter::checkStatus(unsigned long word, int wordNumber) {
+  if (wordNumber < 1 || wordNumber > nWordsPerEvent) {
+    edm::LogWarning("CamacTBDataFormatter::checkStatus")
+        << "checking word number: " << wordNumber << " which is out of allowed range (" << nWordsPerEvent << ")";
+    return false;
+  }
 
   bool isOk = true;
 
-  if  (word & 0x80000000) // daq item not used
-    { 
-      edm::LogWarning("CamacTBDataFormatter::checkStatus") << "daq item not used at word: "<<  wordNumber;
-      statusWords[wordNumber -1] = false;      
-      isOk = false;
-    }
-  
-  if (word & 0x40000000) // vme error on data
-    { 
-      edm::LogWarning("CamacTBDataFormatter::checkStatus") << "vme error on word: "<<  wordNumber;
-      statusWords[wordNumber -1] = false;      
-      isOk = false;
-    }
-    
-  if (word & 0x20000000) // vme error on status
-    { 
-      edm::LogWarning("CamacTBDataFormatter::checkStatus") << "vme status error at word: "<<  wordNumber;
-      statusWords[wordNumber -1] = false;      
-      isOk = false;
-    }
-    
-  if (word & 0x10000000) // camac error (no X)
-    { 
-      edm::LogWarning("CamacTBDataFormatter::checkStatus") << "camac error (no X) at word: "<<  wordNumber;
-      statusWords[wordNumber -1] = false;      
-      isOk = false;
-    }
-    
-  if (word & 0x08000000) // camac error (no Q)
-    { 
-      edm::LogWarning("CamacTBDataFormatter::checkStatus") << "camac error (no Q) at word: "<<  wordNumber;
-      statusWords[wordNumber -1] = false;      
-      isOk = false;
-    }
-  
+  if (word & 0x80000000)  // daq item not used
+  {
+    edm::LogWarning("CamacTBDataFormatter::checkStatus") << "daq item not used at word: " << wordNumber;
+    statusWords[wordNumber - 1] = false;
+    isOk = false;
+  }
+
+  if (word & 0x40000000)  // vme error on data
+  {
+    edm::LogWarning("CamacTBDataFormatter::checkStatus") << "vme error on word: " << wordNumber;
+    statusWords[wordNumber - 1] = false;
+    isOk = false;
+  }
+
+  if (word & 0x20000000)  // vme error on status
+  {
+    edm::LogWarning("CamacTBDataFormatter::checkStatus") << "vme status error at word: " << wordNumber;
+    statusWords[wordNumber - 1] = false;
+    isOk = false;
+  }
+
+  if (word & 0x10000000)  // camac error (no X)
+  {
+    edm::LogWarning("CamacTBDataFormatter::checkStatus") << "camac error (no X) at word: " << wordNumber;
+    statusWords[wordNumber - 1] = false;
+    isOk = false;
+  }
+
+  if (word & 0x08000000)  // camac error (no Q)
+  {
+    edm::LogWarning("CamacTBDataFormatter::checkStatus") << "camac error (no Q) at word: " << wordNumber;
+    statusWords[wordNumber - 1] = false;
+    isOk = false;
+  }
+
   // camac error check not done on purpose from Aug 8, to speed up Camac communication. This bit status is now ignored.
   //  if (word & 0x04000000) // no camac check error
-  //    { 
+  //    {
   //edm::LogWarning("CamacTBDataFormatter::checkStatus") << "no camac check error at word: "<<  wordNumber;
-  //statusWords[wordNumber -1] = false;      
+  //statusWords[wordNumber -1] = false;
   //isOk = false;
   //    }
-  
-  return isOk;
 
+  return isOk;
 }

--- a/EventFilter/EcalTBRawToDigi/src/CamacTBDataFormatter.h
+++ b/EventFilter/EcalTBRawToDigi/src/CamacTBDataFormatter.h
@@ -6,8 +6,7 @@
  *  \author G. Franzoni
  */
 
-
-#include <vector> 
+#include <vector>
 #include <iostream>
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
@@ -21,43 +20,39 @@
 
 #include "TBDataFormats/EcalTBObjects/interface/EcalTBTDCSample.h"
 
-
-
-
-class CamacTBDataFormatter   {
-
- public:
-
+class CamacTBDataFormatter {
+public:
   CamacTBDataFormatter();
-  virtual ~CamacTBDataFormatter(){LogDebug("EcalTBRawToDigi") << "@SUB=CamacTBDataFormatter" << "\n"; };
+  virtual ~CamacTBDataFormatter() {
+    LogDebug("EcalTBRawToDigi") << "@SUB=CamacTBDataFormatter"
+                                << "\n";
+  };
 
-  
-  void  interpretRawData( const FEDRawData & data, EcalTBEventHeader& tbEventHeader, 
-			  EcalTBHodoscopeRawInfo& hodoRaw, EcalTBTDCRawInfo& tdcRawInfo );
-  
+  void interpretRawData(const FEDRawData& data,
+                        EcalTBEventHeader& tbEventHeader,
+                        EcalTBHodoscopeRawInfo& hodoRaw,
+                        EcalTBTDCRawInfo& tdcRawInfo);
+
   // for tests based on standalone file
   /*   void  interpretRawData(unsigned long * buffer, unsigned long bufferSize, */
   /* 			 EcalTBEventHeader& tbEventHeader,  */
   /* 			 EcalTBHodoscopeRawInfo & hodo, */
   /* 			 EcalTBTDCRawInfo & tdc); */
-  
 
-
- private:
-
+private:
   bool checkStatus(unsigned long word, int wordNumber);
 
-  int nWordsPerEvent;    // Number of fibers per hodoscope plane   
-  
-  static const int nHodoFibers        = 64;    // Number of fibers per hodoscope plane   
-  static const int nHodoscopes      = 2;      // Number of different mappings between fiber and electronics     
-  static const int nHodoPlanes       = 4;      // Number of hodoscopes along the beam
-  static const int hodoRawLen       = 4;      // The raw data is stored as 4 integers for each hodo plane
+  int nWordsPerEvent;  // Number of fibers per hodoscope plane
+
+  static const int nHodoFibers = 64;  // Number of fibers per hodoscope plane
+  static const int nHodoscopes = 2;   // Number of different mappings between fiber and electronics
+  static const int nHodoPlanes = 4;   // Number of hodoscopes along the beam
+  static const int hodoRawLen = 4;    // The raw data is stored as 4 integers for each hodo plane
 
   int nHodoHits[nHodoPlanes];
   int hodoHits[nHodoPlanes][nHodoFibers];
-  int hodoAll[nHodoPlanes*nHodoFibers];
-  bool statusWords[148+4];
+  int hodoAll[nHodoPlanes * nHodoFibers];
+  bool statusWords[148 + 4];
 
   std::vector<int> scalers_;
 };

--- a/EventFilter/EcalTBRawToDigi/src/DCCBlockPrototype.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCBlockPrototype.cc
@@ -6,21 +6,24 @@
 #include <cstdio>
 #include <sstream>
 
+DCCTBBlockPrototype::DCCTBBlockPrototype(DCCTBDataParser *parser,
+                                         std::string name,
+                                         const uint32_t *buffer,
+                                         uint32_t numbBytes,
+                                         uint32_t wordsToEndOfEvent,
+                                         uint32_t wordEventOffset) {
+  blockError_ = false;
+  parser_ = parser;
+  name_ = name;
+  dataP_ = buffer;
+  beginOfBuffer_ = buffer;
+  blockSize_ = numbBytes;
+  wordEventOffset_ = wordEventOffset;
+  wordsToEndOfEvent_ = wordsToEndOfEvent;
 
-DCCTBBlockPrototype::DCCTBBlockPrototype(DCCTBDataParser * parser, std::string name, const uint32_t * buffer, uint32_t numbBytes, uint32_t wordsToEndOfEvent,  uint32_t wordEventOffset ){
-			
-	blockError_        = false;
-	parser_            = parser;
-	name_              = name;
-	dataP_             = buffer ;
-	beginOfBuffer_     = buffer ;
-	blockSize_         = numbBytes ;
-	wordEventOffset_   = wordEventOffset;
-	wordsToEndOfEvent_ = wordsToEndOfEvent;
-	
-	wordCounter_ = 0;
-	
-	/*
+  wordCounter_ = 0;
+
+  /*
 	std::cout<<std::endl;
 	std::cout<<" DEBUG::DCCTBBlockPrototype:: Block Name                  :   "<<name_<<std::endl;
 	std::cout<<" DEBUG::DCCTBBlockPrototype:: Block size  [bytes]         :   "<<std::dec<<blockSize_<<std::endl;
@@ -32,19 +35,17 @@ DCCTBBlockPrototype::DCCTBBlockPrototype(DCCTBDataParser * parser, std::string n
 	*/
 }
 
+void DCCTBBlockPrototype::parseData() {
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator>::iterator it;  //iterator for data fields
 
-void DCCTBBlockPrototype::parseData(){
-  std::set<DCCTBDataField *,DCCTBDataFieldComparator>::iterator it;          //iterator for data fields
-	
   //for debug purposes
   //std::cout << "Starting to parse data in block named : " << std::endl;
-  //std::cout << " Fields: " << std::dec << (mapperFields_->size()) << std::endl;	
+  //std::cout << " Fields: " << std::dec << (mapperFields_->size()) << std::endl;
   //std::cout << "\n begin of buffer : "<<hex<<(*beginOfBuffer_)<<std::endl;
-  
+
   //cycle through mapper fields
-  for(it = mapperFields_->begin(); it!= mapperFields_->end(); it++){
-	
-	/*	
+  for (it = mapperFields_->begin(); it != mapperFields_->end(); it++) {
+    /*	
     //for debug purposes
     std::cout << "\n Field name        : " << (*it)->name();
     std::cout << "\n Word position     : " <<std::dec<< (*it)->wordPosition();
@@ -52,293 +53,263 @@ void DCCTBBlockPrototype::parseData(){
     std::cout << "\n Size              : " << hex << (*it)->mask() << std::endl;
     std::cout << "\n data pointer      : " <<hex<<(*dataP_)<<std::endl;
     std::cout << "\n wordsToEndOfEvent : " <<std::dec<<wordsToEndOfEvent_<<std::endl;
-	*/	
-		
-    try{
-      uint32_t data = getDataWord( (*it)->wordPosition() , (*it)->bitPosition(),(*it)->mask());
-      dataFields_[(*it)->name()]= data;
-      	
-    }catch( ECALTBParserBlockException & e){
-			
+	*/
+
+    try {
+      uint32_t data = getDataWord((*it)->wordPosition(), (*it)->bitPosition(), (*it)->mask());
+      dataFields_[(*it)->name()] = data;
+
+    } catch (ECALTBParserBlockException &e) {
       std::string localString;
-      
-      localString +="\n ======================================================================\n"; 		
-      localString += std::string(" ") + name_ + std::string(" :: out of scope Error :: Unable to get data field : ") + (*it)->name();
-      localString += "\n Word position inside block   : " + parser_->getDecString( (*it)->wordPosition() );
-      localString += "\n Word position inside event   : " + parser_->getDecString( (*it)->wordPosition() + wordEventOffset_);
+
+      localString += "\n ======================================================================\n";
+      localString += std::string(" ") + name_ + std::string(" :: out of scope Error :: Unable to get data field : ") +
+                     (*it)->name();
+      localString += "\n Word position inside block   : " + parser_->getDecString((*it)->wordPosition());
+      localString +=
+          "\n Word position inside event   : " + parser_->getDecString((*it)->wordPosition() + wordEventOffset_);
       localString += "\n Block Size [bytes]           : " + parser_->getDecString(blockSize_);
       localString += "\n Action -> Stop parsing this block !";
       localString += "\n ======================================================================";
-			
+
       std::string error("\n Last decoded fields until error : ");
-			
+
       std::ostringstream a;
-      
-      try{ displayData(a);}
-      catch(ECALTBParserBlockException &e){}
-     
+
+      try {
+        displayData(a);
+      } catch (ECALTBParserBlockException &e) {
+      }
+
       std::string outputErrorString(a.str());
       error += outputErrorString;
-			
-      errorString_ +=  localString + error;
-       
+
+      errorString_ += localString + error;
+
       blockError_ = true;
-      
-      throw( ECALTBParserBlockException(errorString_) );
-      
-    }		
+
+      throw(ECALTBParserBlockException(errorString_));
+    }
   }
-  
+
   //debugg
   //displayData(std::cout);
 }
 
-
-
-uint32_t DCCTBBlockPrototype::getDataWord(uint32_t wordPosition, uint32_t bitPosition, uint32_t mask){
-	
-	/*
+uint32_t DCCTBBlockPrototype::getDataWord(uint32_t wordPosition, uint32_t bitPosition, uint32_t mask) {
+  /*
 	std::cout<<"\n DEBUG::DCCTBBlockPrototype getDataWord method "
 	    <<"\n DEBUG::DCCTBBlockPrototype wordPosition       = "<<wordPosition
 	    <<"\n DEBUG::DCCTBBlockPrototype wordCounter        = "<<wordCounter_
 	    <<"\n DEBUG::DCCTBBlockPrototype going to increment = "<<(wordPosition-wordCounter_)<<std::endl;
 	*/
-	if( wordPosition > wordCounter_ ){ increment(wordPosition - wordCounter_);	}
+  if (wordPosition > wordCounter_) {
+    increment(wordPosition - wordCounter_);
+  }
 
-	return ((*dataP_)>>bitPosition)&mask;
-	
+  return ((*dataP_) >> bitPosition) & mask;
 }
 
-
-
-void DCCTBBlockPrototype::increment(uint32_t numb,std::string msg){
-	
-	seeIfIsPossibleToIncrement(numb,msg);
-	dataP_ += numb; wordCounter_ += numb;
+void DCCTBBlockPrototype::increment(uint32_t numb, std::string msg) {
+  seeIfIsPossibleToIncrement(numb, msg);
+  dataP_ += numb;
+  wordCounter_ += numb;
 }
 
-
-
-void DCCTBBlockPrototype::seeIfIsPossibleToIncrement(uint32_t numb, std::string msg){
-	
-	/*
+void DCCTBBlockPrototype::seeIfIsPossibleToIncrement(uint32_t numb, std::string msg) {
+  /*
 	std::cout<<"\n See if is possible to increment numb ="<<std::dec<<numb<<" msg "<<msg<<std::endl;
 	std::cout<<" wordCounter_       "<<wordCounter_<<std::endl;
 	std::cout<<" blockSize          "<<blockSize_<<std::endl;
 	std::cout<<" wordsToEndOfEvent_ "<<wordsToEndOfEvent_<<std::endl;
 	*/
-	
-	if (( ((wordCounter_+numb +1) > blockSize_/4)) ||( wordCounter_ + numb > wordsToEndOfEvent_ )){ 
-			
-		std::string error=std::string("\n Unable to get next block position (parser stoped!)") +msg;
-		error += "\n Decoded fields untill error : ";
-		//ostream dataUntilError ;
-		std::ostringstream a;
-		std::string outputErrorString;
-		
-		
-		try{ displayData(a);}
-		catch(ECALTBParserBlockException &e){}
-		outputErrorString = a.str();
-		error += outputErrorString;
-		
-		throw ECALTBParserBlockException(error); 
-		blockError_=true;
-	}
-	
+
+  if ((((wordCounter_ + numb + 1) > blockSize_ / 4)) || (wordCounter_ + numb > wordsToEndOfEvent_)) {
+    std::string error = std::string("\n Unable to get next block position (parser stoped!)") + msg;
+    error += "\n Decoded fields untill error : ";
+    //ostream dataUntilError ;
+    std::ostringstream a;
+    std::string outputErrorString;
+
+    try {
+      displayData(a);
+    } catch (ECALTBParserBlockException &e) {
+    }
+    outputErrorString = a.str();
+    error += outputErrorString;
+
+    throw ECALTBParserBlockException(error);
+    blockError_ = true;
+  }
 }
 
+void DCCTBBlockPrototype::displayData(std::ostream &os) {
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator>::iterator it;
 
+  bool process(true);
+  os << "\n ======================================================================\n";
+  os << " Block name : " << name_ << ", size : " << std::dec << blockSize_
+     << " bytes, event WOffset : " << wordEventOffset_;
+  long currentPosition(0), position(-1);
 
-void DCCTBBlockPrototype::displayData(  std::ostream & os  ){
-
-  
-  std::set<DCCTBDataField *,DCCTBDataFieldComparator>::iterator it;
-
-	bool process(true);
-	os << "\n ======================================================================\n"; 
-	os << " Block name : "<<name_<<", size : "<<std::dec<<blockSize_<<" bytes, event WOffset : "<<wordEventOffset_;
-	long currentPosition(0), position(-1);
-	
-	std::string dataFieldName;
-	for(it = mapperFields_->begin(); it!= mapperFields_->end() && process; it++){
-		try{
-			dataFieldName =  (*it)->name();
-			currentPosition      =  (*it)->wordPosition();
-			if( currentPosition != position ){
-			  os << "\n W["<<std::setw(5)<<std::setfill('0')<<currentPosition<<"]" ;
-				position = currentPosition; 
-			}
-			os<<" "<<formatString(dataFieldName,14)<<" = "<<std::dec<<std::setw(5)<<getDataField(dataFieldName); 			
-		} catch (ECALTBParserBlockException & e){ process = false; os<<" not able to get data field..."<<dataFieldName<<std::endl;}
-	}
-	os<<"\n ======================================================================\n"; 
-
+  std::string dataFieldName;
+  for (it = mapperFields_->begin(); it != mapperFields_->end() && process; it++) {
+    try {
+      dataFieldName = (*it)->name();
+      currentPosition = (*it)->wordPosition();
+      if (currentPosition != position) {
+        os << "\n W[" << std::setw(5) << std::setfill('0') << currentPosition << "]";
+        position = currentPosition;
+      }
+      os << " " << formatString(dataFieldName, 14) << " = " << std::dec << std::setw(5) << getDataField(dataFieldName);
+    } catch (ECALTBParserBlockException &e) {
+      process = false;
+      os << " not able to get data field..." << dataFieldName << std::endl;
+    }
+  }
+  os << "\n ======================================================================\n";
 }
 
+std::pair<bool, std::string> DCCTBBlockPrototype::checkDataField(std::string name, uint32_t data) {
+  std::string output("");
+  std::pair<bool, std::string> res;
+  bool errorFound(false);
+  uint32_t parsedData = getDataField(name);
+  if (parsedData != data) {
+    output += std::string("\n Field : ") + name + (" has value ") + parser_->getDecString(parsedData) +
+              std::string(", while ") + parser_->getDecString(data) + std::string(" is expected");
 
+    //debug//////////
+    //std::cout<<output<<std::endl;
+    //////////////////
 
-
-
-std::pair<bool,std::string> DCCTBBlockPrototype::checkDataField(std::string name, uint32_t data){
-
-	std::string output("");
-	std::pair<bool,std::string> res;
-	bool errorFound(false);
-	uint32_t parsedData =  getDataField(name);
-	if( parsedData != data){
-		output += std::string("\n Field : ")+name+(" has value ")+parser_->getDecString( parsedData )+ std::string(", while ")+parser_->getDecString(data)+std::string(" is expected"); 	
-		
-		//debug//////////
-		//std::cout<<output<<std::endl;
-		//////////////////
-		
-		blockError_ = true;
-		errorFound  = true;
-	}
-	res.first  = !errorFound;
-	res.second = output; 
-	return res;
+    blockError_ = true;
+    errorFound = true;
+  }
+  res.first = !errorFound;
+  res.second = output;
+  return res;
 }
 
+uint32_t DCCTBBlockPrototype::getDataField(std::string name) {
+  std::map<std::string, uint32_t>::iterator it = dataFields_.find(name);
+  if (it == dataFields_.end()) {
+    throw ECALTBParserBlockException(std::string("\n field named : ") + name + std::string(" was not found in block ") +
+                                     name_);
+    blockError_ = true;
+  }
 
-
-uint32_t DCCTBBlockPrototype::getDataField(std::string name){
-	
-	std::map<std::string,uint32_t>::iterator it = dataFields_.find(name);
-	if(it == dataFields_.end()){		
-		throw ECALTBParserBlockException( std::string("\n field named : ")+name+std::string(" was not found in block ")+name_ );
-		blockError_=true;
-	}
-
-	return (*it).second;
-
+  return (*it).second;
 }
 
-
-
-std::string DCCTBBlockPrototype::formatString(std::string myString,uint32_t minPositions){
-	std::string ret(myString);
-	uint32_t stringSize = ret.size();
-	if( minPositions > stringSize ){
-		for(uint32_t i=0;i< minPositions-stringSize;i++){ ret+=" ";}
-	}
-	return  ret;
-
+std::string DCCTBBlockPrototype::formatString(std::string myString, uint32_t minPositions) {
+  std::string ret(myString);
+  uint32_t stringSize = ret.size();
+  if (minPositions > stringSize) {
+    for (uint32_t i = 0; i < minPositions - stringSize; i++) {
+      ret += " ";
+    }
+  }
+  return ret;
 }
 
-
-
-
-
-
-void DCCTBBlockPrototype::setDataField(std::string name, uint32_t data){
-  std::set<DCCTBDataField *,DCCTBDataFieldComparator>::iterator it;          //iterator for data fields
+void DCCTBBlockPrototype::setDataField(std::string name, uint32_t data) {
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator>::iterator it;  //iterator for data fields
   bool fieldFound(false);
-  for(it = mapperFields_->begin(); it!= mapperFields_->end(); it++){
-  	if( ! ((*it)->name()).compare(name) ){ fieldFound = true; }
+  for (it = mapperFields_->begin(); it != mapperFields_->end(); it++) {
+    if (!((*it)->name()).compare(name)) {
+      fieldFound = true;
+    }
   }
-  
-  if(fieldFound){ dataFields_[name]= data;}
-  else{ 
-  	throw  ECALTBParserBlockException( std::string("\n field named : ")+name+std::string(" was not found in block ")+name_ );
+
+  if (fieldFound) {
+    dataFields_[name] = data;
+  } else {
+    throw ECALTBParserBlockException(std::string("\n field named : ") + name + std::string(" was not found in block ") +
+                                     name_);
   }
-  
 }
 
+std::pair<bool, std::string> DCCTBBlockPrototype::compare(DCCTBBlockPrototype *block) {
+  std::pair<bool, std::string> ret(true, "");
 
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator>::iterator it;
+  std::stringstream out;
 
+  out << "\n ======================================================================";
+  out << "\n ORIGINAL BLOCK    : ";
+  out << "\n Block name : " << name_ << ", size : " << std::dec << blockSize_
+      << " bytes, event WOffset : " << wordEventOffset_;
+  out << "\n COMPARISION BLOCK : ";
+  out << "\n Block name : " << (block->name()) << ", size : " << std::dec << (block->size())
+      << " bytes, event WOffset : " << (block->wOffset());
+  out << "\n =====================================================================";
 
+  if (block->name() != name_) {
+    ret.first = false;
+    out << "\n ERROR >> It is not possible to compare blocks with different names ! ";
+    ret.second += out.str();
+    return ret;
+  }
 
+  if (block->size() != blockSize_) {
+    ret.first = false;
+    out << "\n WARNING >> Blocks have different sizes "
+        << "\n WARNING >> Comparision will be carried on untill possible";
+  }
 
-std::pair<bool,std::string> DCCTBBlockPrototype::compare(DCCTBBlockPrototype * block){
-	
-	
-	std::pair<bool,std::string> ret(true,"");
-	
-	
-	std::set<DCCTBDataField *,DCCTBDataFieldComparator>::iterator it;
-	std::stringstream out;
-	
+  if (block->wOffset() != wordEventOffset_) {
+    ret.first = false;
+    out << "\n WARNING >> Blocks have different word offset within the event ";
+  }
 
-	
-	out<<"\n ======================================================================"; 
-    out<<"\n ORIGINAL BLOCK    : ";
-    out<<"\n Block name : "<<name_<<", size : "<<std::dec<<blockSize_<<" bytes, event WOffset : "<<wordEventOffset_;
-	out<<"\n COMPARISION BLOCK : ";
-	out<<"\n Block name : "<<(block->name())<<", size : "<<std::dec<<(block->size())<<" bytes, event WOffset : "<<(block->wOffset());
-	out<<"\n =====================================================================";
-	
-	
-	if( block->name() != name_ ){
-		ret.first  = false;
-		out<<"\n ERROR >> It is not possible to compare blocks with different names ! ";
-		ret.second += out.str();
-		return ret;
-	}
-	
-	if( block->size() != blockSize_ ){
-		ret.first  = false;
-		out<<"\n WARNING >> Blocks have different sizes "
-		   <<"\n WARNING >> Comparision will be carried on untill possible";	
-	}
-	
+  std::string dataFieldName;
 
-	if( block->wOffset()!= wordEventOffset_){
-		ret.first  = false;
-		out<<"\n WARNING >> Blocks have different word offset within the event ";	
-	}
+  for (it = mapperFields_->begin(); it != mapperFields_->end(); it++) {
+    dataFieldName = (*it)->name();
 
-		
-	std::string dataFieldName;
-	
-	for(it = mapperFields_->begin(); it!= mapperFields_->end(); it++){
-		
-		dataFieldName    =  (*it)->name();
-		
-		uint32_t aValue, bValue;
-			
-		//Access original block data fields /////////////////////////////////////////////////////
-		try{ aValue = getDataField(dataFieldName); }
-		
-		catch(ECALTBParserBlockException &e ){
-			ret.first   = false;
-			out<<"\n ERROR ON ORIGINAL BLOCK unable to get data field :"<<dataFieldName;
-			out<<"\n Comparision was stoped ! ";
-			ret.second += out.str();
-			return ret;
-		}
-		/////////////////////////////////////////////////////////////////////////////////////////
-			
-		//Access comparision block data fields ///////////////////////////////////////////////////////
-		try{ bValue = block->getDataField(dataFieldName); }
-		catch(ECALTBParserBlockException &e ){
-			ret.first  = false;
-			out<<"\n ERROR ON COMPARISION BLOCK unable to get data field :"<<dataFieldName
-			   <<"\n Comparision was stoped ! ";
-			ret.second += out.str();
-			return ret;
-		}
-		////////////////////////////////////////////////////////////////////////////////////////////////
-		
-		
-		//std::cout<<"\n data Field name "<<dataFieldName<<std::endl;
-		//std::cout<<"\n aValue "<<std::dec<<aValue<<std::endl;
-		//std::cout<<"\n bValue "<<std::dec<<bValue<<std::endl;
-		
-		
-			
-		// Compare values 
-		if( aValue != bValue ){
-			ret.first = false;
-			out<<"\n Data Field : "<<dataFieldName
-			   <<"\n ORIGINAL BLOCK value : "<<std::dec<<std::setw(5)<<aValue<<" , COMPARISION BLOCK value : "<<std::dec<<std::setw(5)<<bValue;
-		    //std::cout<<"\n  debug... "<<out<<std::endl; 
-		}
-	}
-	out<<"\n ======================================================================\n"; 
-	ret.second = out.str();
-	
-	return ret;
-	
+    uint32_t aValue, bValue;
+
+    //Access original block data fields /////////////////////////////////////////////////////
+    try {
+      aValue = getDataField(dataFieldName);
+    }
+
+    catch (ECALTBParserBlockException &e) {
+      ret.first = false;
+      out << "\n ERROR ON ORIGINAL BLOCK unable to get data field :" << dataFieldName;
+      out << "\n Comparision was stoped ! ";
+      ret.second += out.str();
+      return ret;
+    }
+    /////////////////////////////////////////////////////////////////////////////////////////
+
+    //Access comparision block data fields ///////////////////////////////////////////////////////
+    try {
+      bValue = block->getDataField(dataFieldName);
+    } catch (ECALTBParserBlockException &e) {
+      ret.first = false;
+      out << "\n ERROR ON COMPARISION BLOCK unable to get data field :" << dataFieldName
+          << "\n Comparision was stoped ! ";
+      ret.second += out.str();
+      return ret;
+    }
+    ////////////////////////////////////////////////////////////////////////////////////////////////
+
+    //std::cout<<"\n data Field name "<<dataFieldName<<std::endl;
+    //std::cout<<"\n aValue "<<std::dec<<aValue<<std::endl;
+    //std::cout<<"\n bValue "<<std::dec<<bValue<<std::endl;
+
+    // Compare values
+    if (aValue != bValue) {
+      ret.first = false;
+      out << "\n Data Field : " << dataFieldName << "\n ORIGINAL BLOCK value : " << std::dec << std::setw(5) << aValue
+          << " , COMPARISION BLOCK value : " << std::dec << std::setw(5) << bValue;
+      //std::cout<<"\n  debug... "<<out<<std::endl;
+    }
+  }
+  out << "\n ======================================================================\n";
+  ret.second = out.str();
+
+  return ret;
 }

--- a/EventFilter/EcalTBRawToDigi/src/DCCBlockPrototype.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCBlockPrototype.h
@@ -4,7 +4,6 @@
 #ifndef DCCTBBLOCKPROTOTYPE_HH
 #define DCCTBBLOCKPROTOTYPE_HH
 
-
 #include <iostream>
 #include <string>
 #include <vector>
@@ -19,85 +18,72 @@ class DCCTBDataParser;
 class DCCTBDataField;
 class DCCTBDataFieldComparator;
 
+class DCCTBBlockPrototype {
+public:
+  DCCTBBlockPrototype(DCCTBDataParser *parser,
+                      std::string name,
+                      const uint32_t *buffer,
+                      uint32_t numbBytes,
+                      uint32_t wordsToEndOfEvent,
+                      uint32_t wordEventOffset = 0);
 
-class DCCTBBlockPrototype{
-	
-	public :
-		
-		DCCTBBlockPrototype(
-			DCCTBDataParser * parser, 
-			std::string name, 
-			const uint32_t* buffer,
-			uint32_t numbBytes, 
-			uint32_t wordsToEndOfEvent, 
-			uint32_t wordEventOffset = 0 
-		);
+  virtual ~DCCTBBlockPrototype() {}
 
-		virtual ~ DCCTBBlockPrototype(){}
+  virtual void parseData();
+  virtual void increment(uint32_t numb, std::string msg = "");
+  virtual void seeIfIsPossibleToIncrement(uint32_t numb, std::string msg = "");
+  virtual uint32_t getDataWord(uint32_t wordPosition, uint32_t bitPosition, uint32_t mask);
+  virtual uint32_t getDataField(std::string name);
+  virtual void setDataField(std::string name, uint32_t data);
 
-		virtual void   parseData();		
-		virtual void   increment(uint32_t numb, std::string msg="");
-		virtual void   seeIfIsPossibleToIncrement(uint32_t numb, std::string msg="");		
-		virtual uint32_t  getDataWord(uint32_t wordPosition, uint32_t bitPosition, uint32_t mask);
-		virtual uint32_t  getDataField(std::string name);
-		virtual void   setDataField(std::string name, uint32_t data);
-		
-		virtual std::pair<bool,std::string> checkDataField(std::string name, uint32_t data);
-		virtual void displayData(std::ostream & os=std::cout);
-		virtual std::pair<bool,std::string> compare(DCCTBBlockPrototype * block);
-	
-		std::map<std::string,uint32_t> & errorCounters(){ return errors_; }
-		
-		// Block Name
-		std::string name(){ return name_;}
+  virtual std::pair<bool, std::string> checkDataField(std::string name, uint32_t data);
+  virtual void displayData(std::ostream &os = std::cout);
+  virtual std::pair<bool, std::string> compare(DCCTBBlockPrototype *block);
 
-		// Block Size in Bytes
-		uint32_t size(){ return blockSize_;  }
-		
-		std::string & errorString(){ return errorString_;}	
-		
-		//Word Block Offest inside event
-		uint32_t wOffset(){ return wordEventOffset_;}
-	
-		bool blockError(){return blockError_;}
+  std::map<std::string, uint32_t> &errorCounters() { return errors_; }
 
-                /**
+  // Block Name
+  std::string name() { return name_; }
+
+  // Block Size in Bytes
+  uint32_t size() { return blockSize_; }
+
+  std::string &errorString() { return errorString_; }
+
+  //Word Block Offest inside event
+  uint32_t wOffset() { return wordEventOffset_; }
+
+  bool blockError() { return blockError_; }
+
+  /**
                  * Returns data parser
                  */
-                DCCTBDataParser *getParser() { return parser_; }
-		
-	protected :
-		
-		std::string formatString(std::string myString,uint32_t minPositions);
-		
-		const uint32_t * dataP_;
-		const uint32_t * beginOfBuffer_;
-		
-		uint32_t blockSize_;
-		uint32_t wordCounter_;
-		uint32_t wordEventOffset_;
-		uint32_t wordsToEndOfEvent_;
-	
-		bool blockError_;
-		
-		std::string name_;
-		std::string errorString_;
-		std::string blockString_;
-		std::string processingString_;
-		
-		DCCTBDataParser * parser_;
-		
-		std::map<std::string,uint32_t> dataFields_;
-		std::map<std::string,uint32_t> errors_;
-		
-		std::set<DCCTBDataField *,DCCTBDataFieldComparator> * mapperFields_;
-		
-	
+  DCCTBDataParser *getParser() { return parser_; }
+
+protected:
+  std::string formatString(std::string myString, uint32_t minPositions);
+
+  const uint32_t *dataP_;
+  const uint32_t *beginOfBuffer_;
+
+  uint32_t blockSize_;
+  uint32_t wordCounter_;
+  uint32_t wordEventOffset_;
+  uint32_t wordsToEndOfEvent_;
+
+  bool blockError_;
+
+  std::string name_;
+  std::string errorString_;
+  std::string blockString_;
+  std::string processingString_;
+
+  DCCTBDataParser *parser_;
+
+  std::map<std::string, uint32_t> dataFields_;
+  std::map<std::string, uint32_t> errors_;
+
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *mapperFields_;
 };
 
-
-
 #endif
-
-
-

--- a/EventFilter/EcalTBRawToDigi/src/DCCDataMapper.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCDataMapper.cc
@@ -1,328 +1,373 @@
 #include "DCCDataMapper.h"
- 
+
 /*--------------------------------------------*/
 /* DCCTBDataMapper::DCCTBDataMapper               */
 /* class constructor                          */
 /*--------------------------------------------*/
-DCCTBDataMapper::DCCTBDataMapper( DCCTBDataParser * myParser)
-: parser_(myParser){
-  
-  dccFields_        = new std::set<DCCTBDataField  * , DCCTBDataFieldComparator>;
-  emptyEventFields_ = new std::set<DCCTBDataField  * , DCCTBDataFieldComparator>;
-  
-  tcc68Fields_    = new std::set<DCCTBDataField  * , DCCTBDataFieldComparator>; 
-  tcc32Fields_    = new std::set<DCCTBDataField  * , DCCTBDataFieldComparator>;
-  tcc16Fields_    = new std::set<DCCTBDataField  * , DCCTBDataFieldComparator>;
+DCCTBDataMapper::DCCTBDataMapper(DCCTBDataParser *myParser) : parser_(myParser) {
+  dccFields_ = new std::set<DCCTBDataField *, DCCTBDataFieldComparator>;
+  emptyEventFields_ = new std::set<DCCTBDataField *, DCCTBDataFieldComparator>;
 
-  srp68Fields_    = new std::set<DCCTBDataField  * , DCCTBDataFieldComparator>;
-  srp32Fields_    = new std::set<DCCTBDataField  * , DCCTBDataFieldComparator>;
-  srp16Fields_    = new std::set<DCCTBDataField  * , DCCTBDataFieldComparator>;
-  
-  towerFields_  = new std::set<DCCTBDataField  * , DCCTBDataFieldComparator>;   
-  xtalFields_   = new std::set<DCCTBDataField  * , DCCTBDataFieldComparator>;
-  trailerFields_= new std::set<DCCTBDataField  * , DCCTBDataFieldComparator>;
-	
+  tcc68Fields_ = new std::set<DCCTBDataField *, DCCTBDataFieldComparator>;
+  tcc32Fields_ = new std::set<DCCTBDataField *, DCCTBDataFieldComparator>;
+  tcc16Fields_ = new std::set<DCCTBDataField *, DCCTBDataFieldComparator>;
+
+  srp68Fields_ = new std::set<DCCTBDataField *, DCCTBDataFieldComparator>;
+  srp32Fields_ = new std::set<DCCTBDataField *, DCCTBDataFieldComparator>;
+  srp16Fields_ = new std::set<DCCTBDataField *, DCCTBDataFieldComparator>;
+
+  towerFields_ = new std::set<DCCTBDataField *, DCCTBDataFieldComparator>;
+  xtalFields_ = new std::set<DCCTBDataField *, DCCTBDataFieldComparator>;
+  trailerFields_ = new std::set<DCCTBDataField *, DCCTBDataFieldComparator>;
+
   buildDCCFields();
-  buildTCCFields(); 
-  buildSRPFields(); 
+  buildTCCFields();
+  buildSRPFields();
   buildTowerFields();
   buildXtalFields();
-  buildTrailerFields();	
+  buildTrailerFields();
 }
 
 /*---------------------------------------------*/
 /* DCCTBDataMapper::~DCCTBDataMapper               */
 /* class destructor (free memory)              */
 /*---------------------------------------------*/
-DCCTBDataMapper::~DCCTBDataMapper(){
-  
-  std::set<DCCTBDataField *,DCCTBDataFieldComparator>::iterator it;
-  
-  for(it = dccFields_->begin()    ;it != dccFields_->end();     it++){ delete (*it);}
-  for(it = emptyEventFields_->begin()    ;it != emptyEventFields_->end();     it++){ delete (*it);}
-  
-  for(it = tcc68Fields_->begin()  ;it != tcc68Fields_->end();     it++){ delete (*it);}		
-  for(it = tcc32Fields_->begin()  ;it != tcc32Fields_->end();     it++){ delete (*it);}
-  for(it = tcc16Fields_->begin()  ;it != tcc16Fields_->end();     it++){ delete (*it);}
-  
-  for(it = srp68Fields_->begin()  ;it != srp68Fields_->end();     it++){ delete (*it);}
-  for(it = srp32Fields_->begin()  ;it != srp32Fields_->end();     it++){ delete (*it);}
-  for(it = srp16Fields_->begin()  ;it != srp16Fields_->end();     it++){ delete (*it);}
-	
-  for(it = towerFields_->begin()  ;it != towerFields_->end();   it++){ delete (*it);}
-  for(it = xtalFields_->begin()   ;it != xtalFields_->end();    it++){ delete (*it);}
-  for(it = trailerFields_->begin();it != trailerFields_->end(); it++){ delete (*it);}
-	
+DCCTBDataMapper::~DCCTBDataMapper() {
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator>::iterator it;
+
+  for (it = dccFields_->begin(); it != dccFields_->end(); it++) {
+    delete (*it);
+  }
+  for (it = emptyEventFields_->begin(); it != emptyEventFields_->end(); it++) {
+    delete (*it);
+  }
+
+  for (it = tcc68Fields_->begin(); it != tcc68Fields_->end(); it++) {
+    delete (*it);
+  }
+  for (it = tcc32Fields_->begin(); it != tcc32Fields_->end(); it++) {
+    delete (*it);
+  }
+  for (it = tcc16Fields_->begin(); it != tcc16Fields_->end(); it++) {
+    delete (*it);
+  }
+
+  for (it = srp68Fields_->begin(); it != srp68Fields_->end(); it++) {
+    delete (*it);
+  }
+  for (it = srp32Fields_->begin(); it != srp32Fields_->end(); it++) {
+    delete (*it);
+  }
+  for (it = srp16Fields_->begin(); it != srp16Fields_->end(); it++) {
+    delete (*it);
+  }
+
+  for (it = towerFields_->begin(); it != towerFields_->end(); it++) {
+    delete (*it);
+  }
+  for (it = xtalFields_->begin(); it != xtalFields_->end(); it++) {
+    delete (*it);
+  }
+  for (it = trailerFields_->begin(); it != trailerFields_->end(); it++) {
+    delete (*it);
+  }
+
   delete dccFields_;
   delete emptyEventFields_;
 
   delete tcc68Fields_;
   delete tcc32Fields_;
   delete tcc16Fields_;
-  
+
   delete srp68Fields_;
   delete srp32Fields_;
   delete srp16Fields_;
-  
+
   delete towerFields_;
   delete xtalFields_;
   delete trailerFields_;
 }
 
-
 /*-------------------------------------------------*/
 /* DCCTBDataMapper::buildDccFields                   */
 /* builds raw data header fields                   */
 /*-------------------------------------------------*/
-void DCCTBDataMapper::buildDCCFields(){
-
+void DCCTBDataMapper::buildDCCFields() {
   //32 Bit word numb 0
-  dccFields_->insert( new DCCTBDataField("H",H_WPOSITION,H_BPOSITION,H_MASK));
-  emptyEventFields_->insert( new DCCTBDataField("H",H_WPOSITION,H_BPOSITION,H_MASK));
-  
-  dccFields_->insert( new DCCTBDataField("FOV",FOV_WPOSITION,FOV_BPOSITION,FOV_MASK));
-  emptyEventFields_->insert( new DCCTBDataField("FOV",FOV_WPOSITION,FOV_BPOSITION,FOV_MASK));
-  
-  dccFields_->insert( new DCCTBDataField("FED/DCC ID",DCCID_WPOSITION,DCCID_BPOSITION,DCCID_MASK));
-  emptyEventFields_->insert( new DCCTBDataField("FED/DCC ID",DCCID_WPOSITION,DCCID_BPOSITION,DCCID_MASK));
-	
-  dccFields_->insert( new DCCTBDataField("BX",DCCBX_WPOSITION,DCCBX_BPOSITION,DCCBX_MASK));
-  emptyEventFields_->insert( new DCCTBDataField("BX",DCCBX_WPOSITION,DCCBX_BPOSITION,DCCBX_MASK));
+  dccFields_->insert(new DCCTBDataField("H", H_WPOSITION, H_BPOSITION, H_MASK));
+  emptyEventFields_->insert(new DCCTBDataField("H", H_WPOSITION, H_BPOSITION, H_MASK));
+
+  dccFields_->insert(new DCCTBDataField("FOV", FOV_WPOSITION, FOV_BPOSITION, FOV_MASK));
+  emptyEventFields_->insert(new DCCTBDataField("FOV", FOV_WPOSITION, FOV_BPOSITION, FOV_MASK));
+
+  dccFields_->insert(new DCCTBDataField("FED/DCC ID", DCCID_WPOSITION, DCCID_BPOSITION, DCCID_MASK));
+  emptyEventFields_->insert(new DCCTBDataField("FED/DCC ID", DCCID_WPOSITION, DCCID_BPOSITION, DCCID_MASK));
+
+  dccFields_->insert(new DCCTBDataField("BX", DCCBX_WPOSITION, DCCBX_BPOSITION, DCCBX_MASK));
+  emptyEventFields_->insert(new DCCTBDataField("BX", DCCBX_WPOSITION, DCCBX_BPOSITION, DCCBX_MASK));
 
   //32Bit word numb 1
-  dccFields_->insert( new DCCTBDataField("LV1",DCCL1_WPOSITION ,DCCL1_BPOSITION,DCCL1_MASK));
-  emptyEventFields_->insert( new DCCTBDataField("LV1",DCCL1_WPOSITION ,DCCL1_BPOSITION,DCCL1_MASK));
-	
-  dccFields_->insert( new DCCTBDataField("TRIGGER TYPE",TRIGGERTYPE_WPOSITION,TRIGGERTYPE_BPOSITION,TRIGGERTYPE_MASK));
-  emptyEventFields_->insert( new DCCTBDataField("TRIGGER TYPE",TRIGGERTYPE_WPOSITION,TRIGGERTYPE_BPOSITION,TRIGGERTYPE_MASK));
-	
-  dccFields_->insert( new DCCTBDataField("BOE",BOE_WPOSITION,BOE_BPOSITION,BOE_MASK));
-  emptyEventFields_->insert( new DCCTBDataField("BOE",BOE_WPOSITION,BOE_BPOSITION,BOE_MASK));
+  dccFields_->insert(new DCCTBDataField("LV1", DCCL1_WPOSITION, DCCL1_BPOSITION, DCCL1_MASK));
+  emptyEventFields_->insert(new DCCTBDataField("LV1", DCCL1_WPOSITION, DCCL1_BPOSITION, DCCL1_MASK));
+
+  dccFields_->insert(
+      new DCCTBDataField("TRIGGER TYPE", TRIGGERTYPE_WPOSITION, TRIGGERTYPE_BPOSITION, TRIGGERTYPE_MASK));
+  emptyEventFields_->insert(
+      new DCCTBDataField("TRIGGER TYPE", TRIGGERTYPE_WPOSITION, TRIGGERTYPE_BPOSITION, TRIGGERTYPE_MASK));
+
+  dccFields_->insert(new DCCTBDataField("BOE", BOE_WPOSITION, BOE_BPOSITION, BOE_MASK));
+  emptyEventFields_->insert(new DCCTBDataField("BOE", BOE_WPOSITION, BOE_BPOSITION, BOE_MASK));
 
   //32Bit word numb 2
-  dccFields_->insert( new DCCTBDataField("EVENT LENGTH",EVENTLENGTH_WPOSITION,EVENTLENGTH_BPOSITION,EVENTLENGTH_MASK));
-  emptyEventFields_->insert( new DCCTBDataField("EVENT LENGTH",EVENTLENGTH_WPOSITION,EVENTLENGTH_BPOSITION,EVENTLENGTH_MASK));
-  
-  dccFields_->insert( new DCCTBDataField("DCC ERRORS",DCCERRORS_WPOSITION  ,DCCERRORS_BPOSITION,DCCERRORS_MASK));
-  emptyEventFields_->insert( new DCCTBDataField("DCC ERRORS",DCCERRORS_WPOSITION  ,DCCERRORS_BPOSITION,DCCERRORS_MASK));
-  
-  //32Bit word numb 3 
-  dccFields_->insert( new DCCTBDataField("RUN NUMBER",RNUMB_WPOSITION,RNUMB_BPOSITION,RNUMB_MASK));
-  emptyEventFields_->insert( new DCCTBDataField("RUN NUMBER",RNUMB_WPOSITION,RNUMB_BPOSITION,RNUMB_MASK));
-	
+  dccFields_->insert(
+      new DCCTBDataField("EVENT LENGTH", EVENTLENGTH_WPOSITION, EVENTLENGTH_BPOSITION, EVENTLENGTH_MASK));
+  emptyEventFields_->insert(
+      new DCCTBDataField("EVENT LENGTH", EVENTLENGTH_WPOSITION, EVENTLENGTH_BPOSITION, EVENTLENGTH_MASK));
+
+  dccFields_->insert(new DCCTBDataField("DCC ERRORS", DCCERRORS_WPOSITION, DCCERRORS_BPOSITION, DCCERRORS_MASK));
+  emptyEventFields_->insert(new DCCTBDataField("DCC ERRORS", DCCERRORS_WPOSITION, DCCERRORS_BPOSITION, DCCERRORS_MASK));
+
+  //32Bit word numb 3
+  dccFields_->insert(new DCCTBDataField("RUN NUMBER", RNUMB_WPOSITION, RNUMB_BPOSITION, RNUMB_MASK));
+  emptyEventFields_->insert(new DCCTBDataField("RUN NUMBER", RNUMB_WPOSITION, RNUMB_BPOSITION, RNUMB_MASK));
+
   //32 Bit word numb 4
-  dccFields_->insert( new DCCTBDataField("RUN TYPE",RUNTYPE_WPOSITION,RUNTYPE_BPOSITION,RUNTYPE_MASK));	
-  emptyEventFields_->insert( new DCCTBDataField("RUN TYPE",RUNTYPE_WPOSITION,RUNTYPE_BPOSITION,RUNTYPE_MASK));	
-  
-  //32Bit word numb 5 
-  dccFields_->insert( new DCCTBDataField("DETAILED TRIGGER TYPE",DETAILEDTT_WPOSITION,DETAILEDTT_BPOSITION,DETAILEDTT_MASK));
-  emptyEventFields_->insert( new DCCTBDataField("DETAILED TRIGGER TYPE",DETAILEDTT_WPOSITION,DETAILEDTT_BPOSITION,DETAILEDTT_MASK));
+  dccFields_->insert(new DCCTBDataField("RUN TYPE", RUNTYPE_WPOSITION, RUNTYPE_BPOSITION, RUNTYPE_MASK));
+  emptyEventFields_->insert(new DCCTBDataField("RUN TYPE", RUNTYPE_WPOSITION, RUNTYPE_BPOSITION, RUNTYPE_MASK));
+
+  //32Bit word numb 5
+  dccFields_->insert(
+      new DCCTBDataField("DETAILED TRIGGER TYPE", DETAILEDTT_WPOSITION, DETAILEDTT_BPOSITION, DETAILEDTT_MASK));
+  emptyEventFields_->insert(
+      new DCCTBDataField("DETAILED TRIGGER TYPE", DETAILEDTT_WPOSITION, DETAILEDTT_BPOSITION, DETAILEDTT_MASK));
 
   //32 Bit word numb 6
-  dccFields_->insert( new DCCTBDataField("ORBIT COUNTER",ORBITCOUNTER_WPOSITION,ORBITCOUNTER_BPOSITION,ORBITCOUNTER_MASK));
+  dccFields_->insert(
+      new DCCTBDataField("ORBIT COUNTER", ORBITCOUNTER_WPOSITION, ORBITCOUNTER_BPOSITION, ORBITCOUNTER_MASK));
 
   //32 Bit word numb 7
-  dccFields_->insert( new DCCTBDataField("SR",SR_WPOSITION,SR_BPOSITION,SR_MASK));
-  dccFields_->insert( new DCCTBDataField("ZS",ZS_WPOSITION,ZS_BPOSITION,ZS_MASK));
-  dccFields_->insert( new DCCTBDataField("TZS",TZS_WPOSITION,TZS_BPOSITION,TZS_MASK));
-	
-  dccFields_->insert( new DCCTBDataField("SR_CHSTATUS",SR_CHSTATUS_WPOSITION,SR_CHSTATUS_BPOSITION,SR_CHSTATUS_MASK));	
-  dccFields_->insert( new DCCTBDataField("TCC_CHSTATUS#1",TCC_CHSTATUS_WPOSITION,TCC_CHSTATUS_BPOSITION,TCC_CHSTATUS_MASK));	
-  dccFields_->insert( new DCCTBDataField("TCC_CHSTATUS#2",TCC_CHSTATUS_WPOSITION,TCC_CHSTATUS_BPOSITION+4,TCC_CHSTATUS_MASK));
-  dccFields_->insert( new DCCTBDataField("TCC_CHSTATUS#3",TCC_CHSTATUS_WPOSITION,TCC_CHSTATUS_BPOSITION+8,TCC_CHSTATUS_MASK));	
-  dccFields_->insert( new DCCTBDataField("TCC_CHSTATUS#4",TCC_CHSTATUS_WPOSITION,TCC_CHSTATUS_BPOSITION+12,TCC_CHSTATUS_MASK));
-  
+  dccFields_->insert(new DCCTBDataField("SR", SR_WPOSITION, SR_BPOSITION, SR_MASK));
+  dccFields_->insert(new DCCTBDataField("ZS", ZS_WPOSITION, ZS_BPOSITION, ZS_MASK));
+  dccFields_->insert(new DCCTBDataField("TZS", TZS_WPOSITION, TZS_BPOSITION, TZS_MASK));
+
+  dccFields_->insert(new DCCTBDataField("SR_CHSTATUS", SR_CHSTATUS_WPOSITION, SR_CHSTATUS_BPOSITION, SR_CHSTATUS_MASK));
+  dccFields_->insert(
+      new DCCTBDataField("TCC_CHSTATUS#1", TCC_CHSTATUS_WPOSITION, TCC_CHSTATUS_BPOSITION, TCC_CHSTATUS_MASK));
+  dccFields_->insert(
+      new DCCTBDataField("TCC_CHSTATUS#2", TCC_CHSTATUS_WPOSITION, TCC_CHSTATUS_BPOSITION + 4, TCC_CHSTATUS_MASK));
+  dccFields_->insert(
+      new DCCTBDataField("TCC_CHSTATUS#3", TCC_CHSTATUS_WPOSITION, TCC_CHSTATUS_BPOSITION + 8, TCC_CHSTATUS_MASK));
+  dccFields_->insert(
+      new DCCTBDataField("TCC_CHSTATUS#4", TCC_CHSTATUS_WPOSITION, TCC_CHSTATUS_BPOSITION + 12, TCC_CHSTATUS_MASK));
 
   //add Headers Qualifiers: 8 words with 6 bits each written on the 2nd 32bit words
-  for(uint32_t i=1;i<=8;i++){
+  for (uint32_t i = 1; i <= 8; i++) {
     std::string header = std::string("H") + parser_->getDecString(i);
-    dccFields_->insert( new DCCTBDataField(header,HD_WPOSITION + (i-1)*2 ,HD_BPOSITION,HD_MASK));		
+    dccFields_->insert(new DCCTBDataField(header, HD_WPOSITION + (i - 1) * 2, HD_BPOSITION, HD_MASK));
 
     //fill only for empty events
-    if(i<3){ emptyEventFields_->insert( new DCCTBDataField(header,HD_WPOSITION + (i-1)*2 ,HD_BPOSITION,HD_MASK));	}	
+    if (i < 3) {
+      emptyEventFields_->insert(new DCCTBDataField(header, HD_WPOSITION + (i - 1) * 2, HD_BPOSITION, HD_MASK));
+    }
   }
 
-
   //add FE_CHSTATUS: 5 words each having 14 FE_CHSTATUS
-  for(uint32_t wcount = 1; wcount<=5; wcount++){
-
+  for (uint32_t wcount = 1; wcount <= 5; wcount++) {
     //1st word 32 bit
-    for(uint32_t i=1;i<=8;i++){
-      std::string chStatus = std::string("FE_CHSTATUS#") + parser_->getDecString( (wcount-1)*14 + i );
-      dccFields_->insert( new DCCTBDataField(chStatus, FE_CHSTATUS_WPOSITION +(wcount-1)*2, 4*(i-1),FE_CHSTATUS_MASK));	
+    for (uint32_t i = 1; i <= 8; i++) {
+      std::string chStatus = std::string("FE_CHSTATUS#") + parser_->getDecString((wcount - 1) * 14 + i);
+      dccFields_->insert(
+          new DCCTBDataField(chStatus, FE_CHSTATUS_WPOSITION + (wcount - 1) * 2, 4 * (i - 1), FE_CHSTATUS_MASK));
     }
 
     //2nd word 32 bit
-    for(uint32_t i=9;i<=14;i++){
-      std::string chStatus = std::string("FE_CHSTATUS#") + parser_->getDecString((wcount-1)*14 + i);
-      dccFields_->insert( new DCCTBDataField(chStatus, FE_CHSTATUS_WPOSITION + (wcount-1)*2 + 1,4*(i-9),FE_CHSTATUS_MASK));	
+    for (uint32_t i = 9; i <= 14; i++) {
+      std::string chStatus = std::string("FE_CHSTATUS#") + parser_->getDecString((wcount - 1) * 14 + i);
+      dccFields_->insert(
+          new DCCTBDataField(chStatus, FE_CHSTATUS_WPOSITION + (wcount - 1) * 2 + 1, 4 * (i - 9), FE_CHSTATUS_MASK));
     }
-    
   }
-
 }
 
 /*-------------------------------------------------*/
 /* DCCTBDataMapper::buildTCCFields                   */
 /* builds raw data TCC block fields                */
 /*-------------------------------------------------*/
-void DCCTBDataMapper::buildTCCFields(){
-	
+void DCCTBDataMapper::buildTCCFields() {
   std::vector<std::set<DCCTBDataField *, DCCTBDataFieldComparator> *> pVector;
   pVector.push_back(tcc16Fields_);
   pVector.push_back(tcc32Fields_);
   pVector.push_back(tcc68Fields_);
-	
-  for(int i=0; i< ((int)(pVector.size())) ;i++){
-    (pVector[i])->insert( new DCCTBDataField("TCC ID",TCCID_WPOSITION ,TCCID_BPOSITION,TCCID_MASK));
-    (pVector[i])->insert( new DCCTBDataField("BX",TCCBX_WPOSITION ,TCCBX_BPOSITION,TCCBX_MASK));	
-    (pVector[i])->insert( new DCCTBDataField("E0",TCCE0_WPOSITION ,TCCE0_BPOSITION,TCCE0_MASK));
-    (pVector[i])->insert( new DCCTBDataField("LV1",TCCL1_WPOSITION ,TCCL1_BPOSITION,TCCL1_MASK));
-    (pVector[i])->insert( new DCCTBDataField("E1", TCCE1_WPOSITION, TCCE1_BPOSITION, TCCE1_MASK));	
-    (pVector[i])->insert( new DCCTBDataField("#TT", NTT_WPOSITION, NTT_BPOSITION, NTT_MASK));
-    (pVector[i])->insert( new DCCTBDataField("#TIME SAMPLES",TCCTSAMP_WPOSITION, TCCTSAMP_BPOSITION,TCCTSAMP_MASK));	
-    (pVector[i])->insert( new DCCTBDataField("LE0",TCCLE0_WPOSITION, TCCLE0_BPOSITION, TCCLE0_MASK));	
-    (pVector[i])->insert( new DCCTBDataField("LE1",TCCLE1_WPOSITION, TCCLE1_BPOSITION, TCCLE1_MASK));	
+
+  for (int i = 0; i < ((int)(pVector.size())); i++) {
+    (pVector[i])->insert(new DCCTBDataField("TCC ID", TCCID_WPOSITION, TCCID_BPOSITION, TCCID_MASK));
+    (pVector[i])->insert(new DCCTBDataField("BX", TCCBX_WPOSITION, TCCBX_BPOSITION, TCCBX_MASK));
+    (pVector[i])->insert(new DCCTBDataField("E0", TCCE0_WPOSITION, TCCE0_BPOSITION, TCCE0_MASK));
+    (pVector[i])->insert(new DCCTBDataField("LV1", TCCL1_WPOSITION, TCCL1_BPOSITION, TCCL1_MASK));
+    (pVector[i])->insert(new DCCTBDataField("E1", TCCE1_WPOSITION, TCCE1_BPOSITION, TCCE1_MASK));
+    (pVector[i])->insert(new DCCTBDataField("#TT", NTT_WPOSITION, NTT_BPOSITION, NTT_MASK));
+    (pVector[i])->insert(new DCCTBDataField("#TIME SAMPLES", TCCTSAMP_WPOSITION, TCCTSAMP_BPOSITION, TCCTSAMP_MASK));
+    (pVector[i])->insert(new DCCTBDataField("LE0", TCCLE0_WPOSITION, TCCLE0_BPOSITION, TCCLE0_MASK));
+    (pVector[i])->insert(new DCCTBDataField("LE1", TCCLE1_WPOSITION, TCCLE1_BPOSITION, TCCLE1_MASK));
   }
-  
+
   uint32_t nTSamples = parser_->numbTriggerSamples();
-	
-  uint32_t totalTT   = 68*nTSamples; 
-  
-  uint32_t filter1 = 16*nTSamples;
-  uint32_t filter2 = 32*nTSamples;
-	
-  uint32_t count(2) ;
-	
-  // Fill block with TT definition 
-  for(uint32_t tt=1; tt<=totalTT; tt++){
-    std::string tpg    = std::string("TPG#") + parser_->getDecString(tt);
+
+  uint32_t totalTT = 68 * nTSamples;
+
+  uint32_t filter1 = 16 * nTSamples;
+  uint32_t filter2 = 32 * nTSamples;
+
+  uint32_t count(2);
+
+  // Fill block with TT definition
+  for (uint32_t tt = 1; tt <= totalTT; tt++) {
+    std::string tpg = std::string("TPG#") + parser_->getDecString(tt);
     std::string ttFlag = std::string("TTF#") + parser_->getDecString(tt);
 
-    if(tt<=filter1){ 
-      tcc16Fields_->insert( new DCCTBDataField(tpg, TPG_WPOSITION -1 + count/2, TPG_BPOSITION + 16*( (count+2)%2 ),TPG_MASK));
-      tcc16Fields_->insert( new DCCTBDataField(ttFlag, TTF_WPOSITION -1 + count/2, TTF_BPOSITION + 16*( (count+2)%2 ),TTF_MASK));
+    if (tt <= filter1) {
+      tcc16Fields_->insert(
+          new DCCTBDataField(tpg, TPG_WPOSITION - 1 + count / 2, TPG_BPOSITION + 16 * ((count + 2) % 2), TPG_MASK));
+      tcc16Fields_->insert(
+          new DCCTBDataField(ttFlag, TTF_WPOSITION - 1 + count / 2, TTF_BPOSITION + 16 * ((count + 2) % 2), TTF_MASK));
     }
-    if(tt<=filter2){
-      tcc32Fields_->insert( new DCCTBDataField(tpg, TPG_WPOSITION -1 + count/2, TPG_BPOSITION + 16*( (count+2)%2 ),TPG_MASK));
-      tcc32Fields_->insert( new DCCTBDataField(ttFlag, TTF_WPOSITION -1 + count/2, TTF_BPOSITION + 16*( (count+2)%2 ),TTF_MASK));
+    if (tt <= filter2) {
+      tcc32Fields_->insert(
+          new DCCTBDataField(tpg, TPG_WPOSITION - 1 + count / 2, TPG_BPOSITION + 16 * ((count + 2) % 2), TPG_MASK));
+      tcc32Fields_->insert(
+          new DCCTBDataField(ttFlag, TTF_WPOSITION - 1 + count / 2, TTF_BPOSITION + 16 * ((count + 2) % 2), TTF_MASK));
     }
-    
-    tcc68Fields_->insert( new DCCTBDataField(tpg, TPG_WPOSITION -1 + count/2, TPG_BPOSITION + 16*( (count+2)%2 ),TPG_MASK));
-    tcc68Fields_->insert( new DCCTBDataField(ttFlag, TTF_WPOSITION -1 + count/2, TTF_BPOSITION + 16*( (count+2)%2 ),TTF_MASK));
+
+    tcc68Fields_->insert(
+        new DCCTBDataField(tpg, TPG_WPOSITION - 1 + count / 2, TPG_BPOSITION + 16 * ((count + 2) % 2), TPG_MASK));
+    tcc68Fields_->insert(
+        new DCCTBDataField(ttFlag, TTF_WPOSITION - 1 + count / 2, TTF_BPOSITION + 16 * ((count + 2) % 2), TTF_MASK));
     count++;
   }
-		
 }
 
 // ---> update with the correct number of SRP fields
-void DCCTBDataMapper::buildSRPFields(){
-  std::vector<std::set<DCCTBDataField *, DCCTBDataFieldComparator> * > pVector;
+void DCCTBDataMapper::buildSRPFields() {
+  std::vector<std::set<DCCTBDataField *, DCCTBDataFieldComparator> *> pVector;
   pVector.push_back(srp68Fields_);
   pVector.push_back(srp32Fields_);
   pVector.push_back(srp16Fields_);
-  
-  for(int i=0; i< ((int)(pVector.size())) ;i++){
+
+  for (int i = 0; i < ((int)(pVector.size())); i++) {
     // This method must be modified to take into account the different SRP blocks : 68 SRF in the barrel, 34 ,35 or 36 in the EE
-    (pVector[i])->insert( new DCCTBDataField("SRP ID",SRPID_WPOSITION ,SRPID_BPOSITION,SRPID_MASK));
-    (pVector[i])->insert( new DCCTBDataField("BX",SRPBX_WPOSITION ,SRPBX_BPOSITION,SRPBX_MASK));	
-    (pVector[i])->insert( new DCCTBDataField("E0",SRPE0_WPOSITION ,SRPE0_BPOSITION,SRPE0_MASK));
-    
-    (pVector[i])->insert( new DCCTBDataField("LV1",SRPL1_WPOSITION ,SRPL1_BPOSITION,SRPL1_MASK));
-    (pVector[i])->insert( new DCCTBDataField("E1", SRPE1_WPOSITION, SRPE1_BPOSITION, SRPE1_MASK));	
-    (pVector[i])->insert( new DCCTBDataField("#SR FLAGS",NSRF_WPOSITION, NSRF_BPOSITION,NSRF_MASK));
-    (pVector[i])->insert( new DCCTBDataField("LE0",SRPLE0_WPOSITION, SRPLE0_BPOSITION, SRPLE0_MASK));	
-    (pVector[i])->insert( new DCCTBDataField("LE1",SRPLE1_WPOSITION, SRPLE1_BPOSITION, SRPLE1_MASK));	
+    (pVector[i])->insert(new DCCTBDataField("SRP ID", SRPID_WPOSITION, SRPID_BPOSITION, SRPID_MASK));
+    (pVector[i])->insert(new DCCTBDataField("BX", SRPBX_WPOSITION, SRPBX_BPOSITION, SRPBX_MASK));
+    (pVector[i])->insert(new DCCTBDataField("E0", SRPE0_WPOSITION, SRPE0_BPOSITION, SRPE0_MASK));
+
+    (pVector[i])->insert(new DCCTBDataField("LV1", SRPL1_WPOSITION, SRPL1_BPOSITION, SRPL1_MASK));
+    (pVector[i])->insert(new DCCTBDataField("E1", SRPE1_WPOSITION, SRPE1_BPOSITION, SRPE1_MASK));
+    (pVector[i])->insert(new DCCTBDataField("#SR FLAGS", NSRF_WPOSITION, NSRF_BPOSITION, NSRF_MASK));
+    (pVector[i])->insert(new DCCTBDataField("LE0", SRPLE0_WPOSITION, SRPLE0_BPOSITION, SRPLE0_MASK));
+    (pVector[i])->insert(new DCCTBDataField("LE1", SRPLE1_WPOSITION, SRPLE1_BPOSITION, SRPLE1_MASK));
   }
-  
-  uint32_t srpFlags(68); 
-  
+
+  uint32_t srpFlags(68);
+
   uint32_t count1(1), count2(1), srSize(3), factor(0), wcount(0);
-  for(uint32_t nsr =1; nsr<=srpFlags; nsr++){
-    
+  for (uint32_t nsr = 1; nsr <= srpFlags; nsr++) {
     std::string sr = std::string("SR#") + parser_->getDecString(nsr);
-    
-    srp68Fields_->insert( new DCCTBDataField(sr,SRF_WPOSITION + wcount, SRF_BPOSITION + SRPBOFFSET*factor + (count2-1)*srSize,SRF_MASK));
-    if( nsr<=32 ){ srp32Fields_->insert( new DCCTBDataField(sr,SRF_WPOSITION + wcount, SRF_BPOSITION + SRPBOFFSET*factor + (count2-1)*srSize,SRF_MASK));}
-    if( nsr<=16 ){ srp16Fields_->insert( new DCCTBDataField(sr,SRF_WPOSITION + wcount, SRF_BPOSITION + SRPBOFFSET*factor + (count2-1)*srSize,SRF_MASK));}
-    
-    count1++; count2++; 
-    
+
+    srp68Fields_->insert(new DCCTBDataField(
+        sr, SRF_WPOSITION + wcount, SRF_BPOSITION + SRPBOFFSET * factor + (count2 - 1) * srSize, SRF_MASK));
+    if (nsr <= 32) {
+      srp32Fields_->insert(new DCCTBDataField(
+          sr, SRF_WPOSITION + wcount, SRF_BPOSITION + SRPBOFFSET * factor + (count2 - 1) * srSize, SRF_MASK));
+    }
+    if (nsr <= 16) {
+      srp16Fields_->insert(new DCCTBDataField(
+          sr, SRF_WPOSITION + wcount, SRF_BPOSITION + SRPBOFFSET * factor + (count2 - 1) * srSize, SRF_MASK));
+    }
+
+    count1++;
+    count2++;
+
     //update word count
-    if( count1 > 8){ wcount++; count1=1;}	
-    
+    if (count1 > 8) {
+      wcount++;
+      count1 = 1;
+    }
+
     //update bit offset
-    if(count1 > 4){ factor = 1;}
-    else{factor = 0;}
-    
+    if (count1 > 4) {
+      factor = 1;
+    } else {
+      factor = 0;
+    }
+
     //update bit shift
-    if( count2 > 4){ count2 = 1;}
-    
+    if (count2 > 4) {
+      count2 = 1;
+    }
   }
 }
-
 
 /*-------------------------------------------------*/
 /* DCCTBDataMapper::buildTowerFields                 */
 /* builds raw data Tower Data fields               */
 /*-------------------------------------------------*/
-void DCCTBDataMapper::buildTowerFields(){
+void DCCTBDataMapper::buildTowerFields() {
   //32bit word numb 1
-  towerFields_->insert( new DCCTBDataField("TT/SC ID",TOWERID_WPOSITION ,TOWERID_BPOSITION,TOWERID_MASK));
-  towerFields_->insert( new DCCTBDataField("#TIME SAMPLES",XSAMP_WPOSITION ,XSAMP_BPOSITION,XSAMP_MASK));
-  towerFields_->insert( new DCCTBDataField("BX", TOWERBX_WPOSITION ,TOWERBX_BPOSITION,TOWERBX_MASK));	
-  towerFields_->insert( new DCCTBDataField("E0",TOWERE0_WPOSITION ,TOWERE0_BPOSITION,TOWERE0_MASK));
-  
-  //32 bit word numb 2
-  towerFields_->insert( new DCCTBDataField("LV1",TOWERL1_WPOSITION ,TOWERL1_BPOSITION, TOWERL1_MASK));
-  towerFields_->insert( new DCCTBDataField("E1", TOWERE1_WPOSITION, TOWERE1_BPOSITION, TOWERE1_MASK));	
-  towerFields_->insert( new DCCTBDataField("BLOCK LENGTH",TOWERLENGTH_WPOSITION, TOWERLENGTH_BPOSITION,TOWERLENGTH_MASK));
-}
+  towerFields_->insert(new DCCTBDataField("TT/SC ID", TOWERID_WPOSITION, TOWERID_BPOSITION, TOWERID_MASK));
+  towerFields_->insert(new DCCTBDataField("#TIME SAMPLES", XSAMP_WPOSITION, XSAMP_BPOSITION, XSAMP_MASK));
+  towerFields_->insert(new DCCTBDataField("BX", TOWERBX_WPOSITION, TOWERBX_BPOSITION, TOWERBX_MASK));
+  towerFields_->insert(new DCCTBDataField("E0", TOWERE0_WPOSITION, TOWERE0_BPOSITION, TOWERE0_MASK));
 
+  //32 bit word numb 2
+  towerFields_->insert(new DCCTBDataField("LV1", TOWERL1_WPOSITION, TOWERL1_BPOSITION, TOWERL1_MASK));
+  towerFields_->insert(new DCCTBDataField("E1", TOWERE1_WPOSITION, TOWERE1_BPOSITION, TOWERE1_MASK));
+  towerFields_->insert(
+      new DCCTBDataField("BLOCK LENGTH", TOWERLENGTH_WPOSITION, TOWERLENGTH_BPOSITION, TOWERLENGTH_MASK));
+}
 
 /*-------------------------------------------------*/
 /* DCCTBDataMapper::buildXtalFields                  */
 /* builds raw data Crystal Data fields             */
 /*-------------------------------------------------*/
-void DCCTBDataMapper::buildXtalFields(){
-	
-  //32bit word numb 1	
-  xtalFields_->insert(new DCCTBDataField("STRIP ID",STRIPID_WPOSITION,STRIPID_BPOSITION,STRIPID_MASK));
-  xtalFields_->insert(new DCCTBDataField("XTAL ID",XTALID_WPOSITION,XTALID_BPOSITION,XTALID_MASK));
-  xtalFields_->insert(new DCCTBDataField("M",M_WPOSITION,M_BPOSITION,M_MASK));
-  xtalFields_->insert(new DCCTBDataField("SMF",SMF_WPOSITION,SMF_BPOSITION,SMF_MASK));
-  xtalFields_->insert(new DCCTBDataField("GMF",GMF_WPOSITION,GMF_BPOSITION,GMF_MASK));
+void DCCTBDataMapper::buildXtalFields() {
+  //32bit word numb 1
+  xtalFields_->insert(new DCCTBDataField("STRIP ID", STRIPID_WPOSITION, STRIPID_BPOSITION, STRIPID_MASK));
+  xtalFields_->insert(new DCCTBDataField("XTAL ID", XTALID_WPOSITION, XTALID_BPOSITION, XTALID_MASK));
+  xtalFields_->insert(new DCCTBDataField("M", M_WPOSITION, M_BPOSITION, M_MASK));
+  xtalFields_->insert(new DCCTBDataField("SMF", SMF_WPOSITION, SMF_BPOSITION, SMF_MASK));
+  xtalFields_->insert(new DCCTBDataField("GMF", GMF_WPOSITION, GMF_BPOSITION, GMF_MASK));
 
   //first ADC is still on 1st word
-  xtalFields_->insert(new DCCTBDataField("ADC#1",ADC_WPOSITION,ADCBOFFSET,ADC_MASK));
-	
-  //add the rest of the ADCs 
-  for(uint32_t i=2; i <= parser_->numbXtalSamples();i++){
+  xtalFields_->insert(new DCCTBDataField("ADC#1", ADC_WPOSITION, ADCBOFFSET, ADC_MASK));
+
+  //add the rest of the ADCs
+  for (uint32_t i = 2; i <= parser_->numbXtalSamples(); i++) {
     std::string adc = std::string("ADC#") + parser_->getDecString(i);
-    if(i%2){ xtalFields_->insert(new DCCTBDataField(adc,ADC_WPOSITION + i/2, ADCBOFFSET,ADC_MASK)); }
-    else   { xtalFields_->insert(new DCCTBDataField(adc,ADC_WPOSITION + i/2, 0,ADC_MASK)); }
+    if (i % 2) {
+      xtalFields_->insert(new DCCTBDataField(adc, ADC_WPOSITION + i / 2, ADCBOFFSET, ADC_MASK));
+    } else {
+      xtalFields_->insert(new DCCTBDataField(adc, ADC_WPOSITION + i / 2, 0, ADC_MASK));
+    }
   }
 
   //the last word has written the test zero suppression flag and the gain decision bit
-  uint32_t tzsOffset_ = parser_->numbXtalSamples()/2;
-  xtalFields_->insert(new DCCTBDataField("TZS",XTAL_TZS_WPOSITION+tzsOffset_,XTAL_TZS_BPOSITION,XTAL_TZS_MASK));
-  xtalFields_->insert(new DCCTBDataField("GDECISION",XTAL_GDECISION_WPOSITION+tzsOffset_,XTAL_GDECISION_BPOSITION,XTAL_GDECISION_MASK));
+  uint32_t tzsOffset_ = parser_->numbXtalSamples() / 2;
+  xtalFields_->insert(new DCCTBDataField("TZS", XTAL_TZS_WPOSITION + tzsOffset_, XTAL_TZS_BPOSITION, XTAL_TZS_MASK));
+  xtalFields_->insert(new DCCTBDataField(
+      "GDECISION", XTAL_GDECISION_WPOSITION + tzsOffset_, XTAL_GDECISION_BPOSITION, XTAL_GDECISION_MASK));
 }
-
 
 /*-------------------------------------------------*/
 /* DCCTBDataMapper::buildTrailerFields               */
 /* builds raw data Trailer words                   */
 /*-------------------------------------------------*/
-void DCCTBDataMapper::buildTrailerFields(){
+void DCCTBDataMapper::buildTrailerFields() {
   //32bit word numb 1
-  trailerFields_->insert(new DCCTBDataField("T",T_WPOSITION,T_BPOSITION,T_MASK));
-  trailerFields_->insert(new DCCTBDataField("TTS",TTS_WPOSITION,TTS_BPOSITION,TTS_MASK));
-  trailerFields_->insert(new DCCTBDataField("EVENT STATUS",ESTAT_WPOSITION,ESTAT_BPOSITION,ESTAT_MASK));
-  trailerFields_->insert(new DCCTBDataField("CRC",CRC_WPOSITION,CRC_BPOSITION,CRC_MASK));
+  trailerFields_->insert(new DCCTBDataField("T", T_WPOSITION, T_BPOSITION, T_MASK));
+  trailerFields_->insert(new DCCTBDataField("TTS", TTS_WPOSITION, TTS_BPOSITION, TTS_MASK));
+  trailerFields_->insert(new DCCTBDataField("EVENT STATUS", ESTAT_WPOSITION, ESTAT_BPOSITION, ESTAT_MASK));
+  trailerFields_->insert(new DCCTBDataField("CRC", CRC_WPOSITION, CRC_BPOSITION, CRC_MASK));
 
   //32bit word numb 2
-  trailerFields_->insert(new DCCTBDataField("EVENT LENGTH",TLENGTH_WPOSITION,TLENGTH_BPOSITION,TLENGTH_MASK));
-  trailerFields_->insert(new DCCTBDataField("EOE",EOE_WPOSITION,EOE_BPOSITION,EOE_MASK));
-	
+  trailerFields_->insert(new DCCTBDataField("EVENT LENGTH", TLENGTH_WPOSITION, TLENGTH_BPOSITION, TLENGTH_MASK));
+  trailerFields_->insert(new DCCTBDataField("EOE", EOE_WPOSITION, EOE_BPOSITION, EOE_MASK));
 }

--- a/EventFilter/EcalTBRawToDigi/src/DCCDataMapper.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCDataMapper.h
@@ -4,12 +4,10 @@
 #ifndef DCCTBDATAMAPPER_HH
 #define DCCTBDATAMAPPER_HH
 
-
-#include <string>                //STL
+#include <string>  //STL
 #include <set>
 
 #include "DCCDataParser.h"
-
 
 /*----------------------------------------------------------*/
 /* DCC DATA FIELD                                           */
@@ -18,78 +16,76 @@
 /* and a mask (number of bits)                              */
 /* Note: this class is defined inline                       */
 /*----------------------------------------------------------*/
-class DCCTBDataField{
-public : 
+class DCCTBDataField {
+public:
   /**
      Class constructor (sets data field's characteristics)
   */
-  DCCTBDataField(std::string name, uint32_t wordPosition, uint32_t bitPosition, uint32_t mask){
-    name_=name; wordPosition_ = wordPosition; bitPosition_= bitPosition; mask_= mask;
+  DCCTBDataField(std::string name, uint32_t wordPosition, uint32_t bitPosition, uint32_t mask) {
+    name_ = name;
+    wordPosition_ = wordPosition;
+    bitPosition_ = bitPosition;
+    mask_ = mask;
   }
-		
+
   /**
      Return and set methods for field's data
   */
-  void setName(std::string namestr)        { name_.clear(); name_ = namestr; }
-  std::string name()                       { return name_;                   }
-  void setWordPosition(uint32_t wordpos) { wordPosition_ = wordpos;        }
-  uint32_t wordPosition()                { return wordPosition_;           }
-  void setBitPosition(uint32_t bitpos)   { bitPosition_ = bitpos;          }
-  uint32_t bitPosition()                 { return bitPosition_;            }
-  void setMask(uint32_t maskvalue)       { mask_=maskvalue;                }
-  uint32_t mask()                        { return mask_;                   }
+  void setName(std::string namestr) {
+    name_.clear();
+    name_ = namestr;
+  }
+  std::string name() { return name_; }
+  void setWordPosition(uint32_t wordpos) { wordPosition_ = wordpos; }
+  uint32_t wordPosition() { return wordPosition_; }
+  void setBitPosition(uint32_t bitpos) { bitPosition_ = bitpos; }
+  uint32_t bitPosition() { return bitPosition_; }
+  void setMask(uint32_t maskvalue) { mask_ = maskvalue; }
+  uint32_t mask() { return mask_; }
 
   /**
      Class destructor
   */
-  ~DCCTBDataField() { };
-		
-protected :
+  ~DCCTBDataField(){};
+
+protected:
   std::string name_;
   uint32_t wordPosition_;
   uint32_t bitPosition_;
   uint32_t mask_;
 };
 
-
-
 /*----------------------------------------------------------*/
 /* DCC DATA FIELD COMPARATOR                                */
 /* compares data fields positions                           */
 /*----------------------------------------------------------*/
-class DCCTBDataFieldComparator{ 
- 
-public : 
-
+class DCCTBDataFieldComparator {
+public:
   /** 
       Overloads operator() returning true if DCCDataField 1 comes first then DCCDataField 2 in the DCC data block
-  */ 
-  bool operator()(DCCTBDataField *d1, DCCTBDataField * d2) const{
+  */
+  bool operator()(DCCTBDataField *d1, DCCTBDataField *d2) const {
     bool value(false);
-    
-    if (d1->wordPosition() < d2->wordPosition()){ 
-      value=true;
-    }
-    else if(d1->wordPosition() == d2->wordPosition()){ 
-      if(d1->bitPosition() > d2->bitPosition()) {
-	value=true;
-      } 
-    }
-    
-    return value;  
-  } 
-}; 
 
+    if (d1->wordPosition() < d2->wordPosition()) {
+      value = true;
+    } else if (d1->wordPosition() == d2->wordPosition()) {
+      if (d1->bitPosition() > d2->bitPosition()) {
+        value = true;
+      }
+    }
 
+    return value;
+  }
+};
 
 /*----------------------------------------------------------*/
 /* DCC DATA MAPPER                                          */
 /* maps the data according to ECAL raw data format specs.   */
 /*----------------------------------------------------------*/
-class DCCTBDataMapper{
-public: 
-  
-  DCCTBDataMapper(DCCTBDataParser * myParser );
+class DCCTBDataMapper {
+public:
+  DCCTBDataMapper(DCCTBDataParser *myParser);
   ~DCCTBDataMapper();
 
   /**
@@ -101,143 +97,262 @@ public:
   void buildTowerFields();
   void buildXtalFields();
   void buildTrailerFields();
-  
+
   /**
      Return methods for raw data fields
   */
-  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *dccFields()        { return dccFields_;        }
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *dccFields() { return dccFields_; }
   std::set<DCCTBDataField *, DCCTBDataFieldComparator> *emptyEventFields() { return emptyEventFields_; }
-  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *tcc68Fields()      { return tcc68Fields_;      }
-  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *tcc32Fields()      { return tcc32Fields_;      }
-  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *tcc16Fields()      { return tcc16Fields_;      }
-  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *srp68Fields()      { return srp68Fields_;      }
-  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *srp32Fields()      { return srp32Fields_;      }
-  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *srp16Fields()      { return srp16Fields_;      }
-  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *towerFields()      { return towerFields_;      }
-  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *xtalFields()       { return xtalFields_;       }
-  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *trailerFields()    { return trailerFields_;    }
-  
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *tcc68Fields() { return tcc68Fields_; }
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *tcc32Fields() { return tcc32Fields_; }
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *tcc16Fields() { return tcc16Fields_; }
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *srp68Fields() { return srp68Fields_; }
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *srp32Fields() { return srp32Fields_; }
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *srp16Fields() { return srp16Fields_; }
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *towerFields() { return towerFields_; }
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *xtalFields() { return xtalFields_; }
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *trailerFields() { return trailerFields_; }
+
 protected:
-  DCCTBDataParser * parser_;
-  std::set<DCCTBDataField *, DCCTBDataFieldComparator> * dccFields_;
-  std::set<DCCTBDataField *, DCCTBDataFieldComparator> * emptyEventFields_;
-  std::set<DCCTBDataField *, DCCTBDataFieldComparator> * tcc68Fields_;
-  std::set<DCCTBDataField *, DCCTBDataFieldComparator> * tcc32Fields_;
-  std::set<DCCTBDataField *, DCCTBDataFieldComparator> * tcc16Fields_;
-  
-  std::set<DCCTBDataField *, DCCTBDataFieldComparator> * srp68Fields_;
-  std::set<DCCTBDataField *, DCCTBDataFieldComparator> * srp32Fields_;
-  std::set<DCCTBDataField *, DCCTBDataFieldComparator> * srp16Fields_;
-  
-  std::set<DCCTBDataField *, DCCTBDataFieldComparator> * towerFields_;
-  std::set<DCCTBDataField *, DCCTBDataFieldComparator> * xtalFields_;
-  std::set<DCCTBDataField *, DCCTBDataFieldComparator> * trailerFields_;
-  
-public: 
+  DCCTBDataParser *parser_;
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *dccFields_;
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *emptyEventFields_;
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *tcc68Fields_;
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *tcc32Fields_;
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *tcc16Fields_;
 
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *srp68Fields_;
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *srp32Fields_;
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *srp16Fields_;
+
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *towerFields_;
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *xtalFields_;
+  std::set<DCCTBDataField *, DCCTBDataFieldComparator> *trailerFields_;
+
+public:
   //HEADER data fields (each 32 bits is separated by a space in the enum)
-  enum DCCFIELDS{
-    H_WPOSITION                = 0, H_BPOSITION              =  3,    H_MASK              = 0x1,
-    FOV_WPOSITION              = 0, FOV_BPOSITION            =  4,    FOV_MASK            = 0xF,
-    DCCID_WPOSITION            = 0, DCCID_BPOSITION          =  8,    DCCID_MASK          = 0xFFF,
-    DCCBX_WPOSITION            = 0, DCCBX_BPOSITION          = 20,    DCCBX_MASK          = 0xFFF,
+  enum DCCFIELDS {
+    H_WPOSITION = 0,
+    H_BPOSITION = 3,
+    H_MASK = 0x1,
+    FOV_WPOSITION = 0,
+    FOV_BPOSITION = 4,
+    FOV_MASK = 0xF,
+    DCCID_WPOSITION = 0,
+    DCCID_BPOSITION = 8,
+    DCCID_MASK = 0xFFF,
+    DCCBX_WPOSITION = 0,
+    DCCBX_BPOSITION = 20,
+    DCCBX_MASK = 0xFFF,
 
-    DCCL1_WPOSITION            = 1, DCCL1_BPOSITION          =  0,    DCCL1_MASK          = 0xFFFFFF,
-    TRIGGERTYPE_WPOSITION      = 1, TRIGGERTYPE_BPOSITION    = 24,    TRIGGERTYPE_MASK    = 0xF,
-    BOE_WPOSITION              = 1, BOE_BPOSITION            = 28,    BOE_MASK            = 0xF,
-    
-    EVENTLENGTH_WPOSITION      = 2, EVENTLENGTH_BPOSITION     =  0,    EVENTLENGTH_MASK    = 0xFFFFFF,
-    DCCERRORS_WPOSITION        = 2, DCCERRORS_BPOSITION       = 24,    DCCERRORS_MASK      = 0xFF,
-    
-    RNUMB_WPOSITION            = 3, RNUMB_BPOSITION           =  0,    RNUMB_MASK          = 0xFFFFFF,
-    HD_WPOSITION               = 3, HD_BPOSITION              = 24,    HD_MASK             = 0xFF,
-    
-    RUNTYPE_WPOSITION          = 4, RUNTYPE_BPOSITION         =  0,    RUNTYPE_MASK        = 0xFFFFFFFF,
-    
-    DETAILEDTT_WPOSITION       = 5, DETAILEDTT_BPOSITION      =  0,    DETAILEDTT_MASK     = 0xFFFF,
-    
-    ORBITCOUNTER_WPOSITION     = 6, ORBITCOUNTER_BPOSITION   =  0,    ORBITCOUNTER_MASK    = 0xFFFFFFFF,
-			
-    SR_WPOSITION               = 7, SR_BPOSITION             =  0,    SR_MASK             = 0x1,
-    ZS_WPOSITION               = 7, ZS_BPOSITION             =  1,    ZS_MASK             = 0x1,
-    TZS_WPOSITION              = 7, TZS_BPOSITION            =  2,    TZS_MASK            = 0x1,
-    SR_CHSTATUS_WPOSITION      = 7, SR_CHSTATUS_BPOSITION    =  4,    SR_CHSTATUS_MASK    = 0xF, 
-    TCC_CHSTATUS_WPOSITION     = 7, TCC_CHSTATUS_BPOSITION   =  8,    TCC_CHSTATUS_MASK   = 0xF, 
-    
-    FE_CHSTATUS_WPOSITION      = 8, CHSTATUS_BPOSITION       =  0,    FE_CHSTATUS_MASK    = 0xF 
+    DCCL1_WPOSITION = 1,
+    DCCL1_BPOSITION = 0,
+    DCCL1_MASK = 0xFFFFFF,
+    TRIGGERTYPE_WPOSITION = 1,
+    TRIGGERTYPE_BPOSITION = 24,
+    TRIGGERTYPE_MASK = 0xF,
+    BOE_WPOSITION = 1,
+    BOE_BPOSITION = 28,
+    BOE_MASK = 0xF,
+
+    EVENTLENGTH_WPOSITION = 2,
+    EVENTLENGTH_BPOSITION = 0,
+    EVENTLENGTH_MASK = 0xFFFFFF,
+    DCCERRORS_WPOSITION = 2,
+    DCCERRORS_BPOSITION = 24,
+    DCCERRORS_MASK = 0xFF,
+
+    RNUMB_WPOSITION = 3,
+    RNUMB_BPOSITION = 0,
+    RNUMB_MASK = 0xFFFFFF,
+    HD_WPOSITION = 3,
+    HD_BPOSITION = 24,
+    HD_MASK = 0xFF,
+
+    RUNTYPE_WPOSITION = 4,
+    RUNTYPE_BPOSITION = 0,
+    RUNTYPE_MASK = 0xFFFFFFFF,
+
+    DETAILEDTT_WPOSITION = 5,
+    DETAILEDTT_BPOSITION = 0,
+    DETAILEDTT_MASK = 0xFFFF,
+
+    ORBITCOUNTER_WPOSITION = 6,
+    ORBITCOUNTER_BPOSITION = 0,
+    ORBITCOUNTER_MASK = 0xFFFFFFFF,
+
+    SR_WPOSITION = 7,
+    SR_BPOSITION = 0,
+    SR_MASK = 0x1,
+    ZS_WPOSITION = 7,
+    ZS_BPOSITION = 1,
+    ZS_MASK = 0x1,
+    TZS_WPOSITION = 7,
+    TZS_BPOSITION = 2,
+    TZS_MASK = 0x1,
+    SR_CHSTATUS_WPOSITION = 7,
+    SR_CHSTATUS_BPOSITION = 4,
+    SR_CHSTATUS_MASK = 0xF,
+    TCC_CHSTATUS_WPOSITION = 7,
+    TCC_CHSTATUS_BPOSITION = 8,
+    TCC_CHSTATUS_MASK = 0xF,
+
+    FE_CHSTATUS_WPOSITION = 8,
+    CHSTATUS_BPOSITION = 0,
+    FE_CHSTATUS_MASK = 0xF
   };
-
 
   //TCC block data fields
-  enum TCCFIELDS{
-    TCCID_WPOSITION           =  0, TCCID_BPOSITION          =  0,    TCCID_MASK          = 0xFF,
-    TCCBX_WPOSITION           =  0, TCCBX_BPOSITION          = 16,    TCCBX_MASK          = 0xFFF,
-    TCCE0_WPOSITION           =  0, TCCE0_BPOSITION          = 28,    TCCE0_MASK          = 0x1,
-    
-    TCCL1_WPOSITION           =  1, TCCL1_BPOSITION          =  0,    TCCL1_MASK          = 0xFFF,
-    TCCE1_WPOSITION           =  1, TCCE1_BPOSITION          = 12,    TCCE1_MASK          = 0x1,
-    NTT_WPOSITION             =  1, NTT_BPOSITION            = 16,    NTT_MASK            = 0x7F,
-    TCCTSAMP_WPOSITION        =  1, TCCTSAMP_BPOSITION       = 23,    TCCTSAMP_MASK       = 0xF,
-    TCCLE0_WPOSITION          =  1, TCCLE0_BPOSITION         = 27,    TCCLE0_MASK         = 0x1,
-    TCCLE1_WPOSITION          =  1, TCCLE1_BPOSITION         = 28,    TCCLE1_MASK         = 0x1,
-			
-    TPG_WPOSITION             =  2,  TPG_BPOSITION           =  0,    TPG_MASK            = 0x1FF,
-    TTF_WPOSITION             =  2,  TTF_BPOSITION           =  9,    TTF_MASK            = 0x7
-  };
-		
-  //SR block data fields
-  enum SRPFIELDS{
-    SRPID_WPOSITION           =  0, SRPID_BPOSITION          =  0,    SRPID_MASK          = 0xFF,
-    SRPBX_WPOSITION           =  0, SRPBX_BPOSITION          = 16,    SRPBX_MASK          = 0xFFF,
-    SRPE0_WPOSITION           =  0, SRPE0_BPOSITION          = 28,    SRPE0_MASK          = 0x1,
-				
-    SRPL1_WPOSITION           =  1, SRPL1_BPOSITION          =  0,    SRPL1_MASK          = 0xFFF,
-    SRPE1_WPOSITION           =  1, SRPE1_BPOSITION          = 12,    SRPE1_MASK          = 0x1,
-    NSRF_WPOSITION            =  1, NSRF_BPOSITION           = 16,    NSRF_MASK           = 0x7F,
-    SRPLE0_WPOSITION          =  1, SRPLE0_BPOSITION         = 27,    SRPLE0_MASK         = 0x1,
-    SRPLE1_WPOSITION          =  1, SRPLE1_BPOSITION         = 28,    SRPLE1_MASK         = 0x1,
+  enum TCCFIELDS {
+    TCCID_WPOSITION = 0,
+    TCCID_BPOSITION = 0,
+    TCCID_MASK = 0xFF,
+    TCCBX_WPOSITION = 0,
+    TCCBX_BPOSITION = 16,
+    TCCBX_MASK = 0xFFF,
+    TCCE0_WPOSITION = 0,
+    TCCE0_BPOSITION = 28,
+    TCCE0_MASK = 0x1,
 
-    SRF_WPOSITION             =  2, SRF_BPOSITION            =  0,    SRF_MASK            = 0x3, 
-    SRPBOFFSET                = 16 
+    TCCL1_WPOSITION = 1,
+    TCCL1_BPOSITION = 0,
+    TCCL1_MASK = 0xFFF,
+    TCCE1_WPOSITION = 1,
+    TCCE1_BPOSITION = 12,
+    TCCE1_MASK = 0x1,
+    NTT_WPOSITION = 1,
+    NTT_BPOSITION = 16,
+    NTT_MASK = 0x7F,
+    TCCTSAMP_WPOSITION = 1,
+    TCCTSAMP_BPOSITION = 23,
+    TCCTSAMP_MASK = 0xF,
+    TCCLE0_WPOSITION = 1,
+    TCCLE0_BPOSITION = 27,
+    TCCLE0_MASK = 0x1,
+    TCCLE1_WPOSITION = 1,
+    TCCLE1_BPOSITION = 28,
+    TCCLE1_MASK = 0x1,
+
+    TPG_WPOSITION = 2,
+    TPG_BPOSITION = 0,
+    TPG_MASK = 0x1FF,
+    TTF_WPOSITION = 2,
+    TTF_BPOSITION = 9,
+    TTF_MASK = 0x7
   };
-	
+
+  //SR block data fields
+  enum SRPFIELDS {
+    SRPID_WPOSITION = 0,
+    SRPID_BPOSITION = 0,
+    SRPID_MASK = 0xFF,
+    SRPBX_WPOSITION = 0,
+    SRPBX_BPOSITION = 16,
+    SRPBX_MASK = 0xFFF,
+    SRPE0_WPOSITION = 0,
+    SRPE0_BPOSITION = 28,
+    SRPE0_MASK = 0x1,
+
+    SRPL1_WPOSITION = 1,
+    SRPL1_BPOSITION = 0,
+    SRPL1_MASK = 0xFFF,
+    SRPE1_WPOSITION = 1,
+    SRPE1_BPOSITION = 12,
+    SRPE1_MASK = 0x1,
+    NSRF_WPOSITION = 1,
+    NSRF_BPOSITION = 16,
+    NSRF_MASK = 0x7F,
+    SRPLE0_WPOSITION = 1,
+    SRPLE0_BPOSITION = 27,
+    SRPLE0_MASK = 0x1,
+    SRPLE1_WPOSITION = 1,
+    SRPLE1_BPOSITION = 28,
+    SRPLE1_MASK = 0x1,
+
+    SRF_WPOSITION = 2,
+    SRF_BPOSITION = 0,
+    SRF_MASK = 0x3,
+    SRPBOFFSET = 16
+  };
+
   //TOWER block data fields
-  enum TOWERFIELDS{
-    TOWERID_WPOSITION          = 0, TOWERID_BPOSITION          =   0,   TOWERID_MASK          = 0x7F, //FEID remask?? --> the 8th bit is in use 
-    XSAMP_WPOSITION            = 0, XSAMP_BPOSITION            =   8,   XSAMP_MASK            = 0x7F,
-    TOWERBX_WPOSITION          = 0, TOWERBX_BPOSITION          =  16,   TOWERBX_MASK          = 0xFFF,
-    TOWERE0_WPOSITION          = 0, TOWERE0_BPOSITION          =  28,   TOWERE0_MASK          = 0x1,
-    
-    TOWERL1_WPOSITION          = 1, TOWERL1_BPOSITION          =  0,    TOWERL1_MASK         = 0xFFF,
-    TOWERE1_WPOSITION          = 1, TOWERE1_BPOSITION          = 12,    TOWERE1_MASK         = 0x1,
-    TOWERLENGTH_WPOSITION      = 1, TOWERLENGTH_BPOSITION      = 16,   TOWERLENGTH_MASK      = 0x1FF			
+  enum TOWERFIELDS {
+    TOWERID_WPOSITION = 0,
+    TOWERID_BPOSITION = 0,
+    TOWERID_MASK = 0x7F,  //FEID remask?? --> the 8th bit is in use
+    XSAMP_WPOSITION = 0,
+    XSAMP_BPOSITION = 8,
+    XSAMP_MASK = 0x7F,
+    TOWERBX_WPOSITION = 0,
+    TOWERBX_BPOSITION = 16,
+    TOWERBX_MASK = 0xFFF,
+    TOWERE0_WPOSITION = 0,
+    TOWERE0_BPOSITION = 28,
+    TOWERE0_MASK = 0x1,
+
+    TOWERL1_WPOSITION = 1,
+    TOWERL1_BPOSITION = 0,
+    TOWERL1_MASK = 0xFFF,
+    TOWERE1_WPOSITION = 1,
+    TOWERE1_BPOSITION = 12,
+    TOWERE1_MASK = 0x1,
+    TOWERLENGTH_WPOSITION = 1,
+    TOWERLENGTH_BPOSITION = 16,
+    TOWERLENGTH_MASK = 0x1FF
   };
-		
+
   //CRYSTAL data fields
-  enum XTALFIELDS{
-    STRIPID_WPOSITION        = 0, STRIPID_BPOSITION        =  0, STRIPID_MASK         = 0x7,
-    XTALID_WPOSITION         = 0, XTALID_BPOSITION         =  4, XTALID_MASK          = 0x7,
-    M_WPOSITION              = 0, M_BPOSITION              =  8, M_MASK               = 0x1,
-    SMF_WPOSITION            = 0, SMF_BPOSITION            =  9, SMF_MASK             = 0x1,
-    GMF_WPOSITION            = 0, GMF_BPOSITION            = 10, GMF_MASK             = 0x1,  
-    XTAL_TZS_WPOSITION       = 0, XTAL_TZS_BPOSITION       = 16, XTAL_TZS_MASK        = 0x1,  
-    XTAL_GDECISION_WPOSITION = 0, XTAL_GDECISION_BPOSITION = 17, XTAL_GDECISION_MASK  = 0x1,	
-    ADC_WPOSITION            = 0, ADC_BPOSITION            =  0, ADC_MASK             = 0x3FFF,
-    ADCBOFFSET               = 16 
+  enum XTALFIELDS {
+    STRIPID_WPOSITION = 0,
+    STRIPID_BPOSITION = 0,
+    STRIPID_MASK = 0x7,
+    XTALID_WPOSITION = 0,
+    XTALID_BPOSITION = 4,
+    XTALID_MASK = 0x7,
+    M_WPOSITION = 0,
+    M_BPOSITION = 8,
+    M_MASK = 0x1,
+    SMF_WPOSITION = 0,
+    SMF_BPOSITION = 9,
+    SMF_MASK = 0x1,
+    GMF_WPOSITION = 0,
+    GMF_BPOSITION = 10,
+    GMF_MASK = 0x1,
+    XTAL_TZS_WPOSITION = 0,
+    XTAL_TZS_BPOSITION = 16,
+    XTAL_TZS_MASK = 0x1,
+    XTAL_GDECISION_WPOSITION = 0,
+    XTAL_GDECISION_BPOSITION = 17,
+    XTAL_GDECISION_MASK = 0x1,
+    ADC_WPOSITION = 0,
+    ADC_BPOSITION = 0,
+    ADC_MASK = 0x3FFF,
+    ADCBOFFSET = 16
   };
-	
+
   //TRAILER data fields
-  enum TRAILERFIELDS{
-    T_WPOSITION                = 0, T_BPOSITION                =   3,    T_MASK               = 0x1,
-    ESTAT_WPOSITION            = 0, ESTAT_BPOSITION            =   8,    ESTAT_MASK           = 0xF,
-			
-    TTS_WPOSITION              = 0, TTS_BPOSITION              =   4,     TTS_MASK             = 0xF,
-    
-    CRC_WPOSITION              = 0, CRC_BPOSITION              =  16,    CRC_MASK             = 0xFFFF,
-    TLENGTH_WPOSITION          = 1, TLENGTH_BPOSITION          =   0,    TLENGTH_MASK         = 0xFFFFFF,
-    EOE_WPOSITION              = 1, EOE_BPOSITION              =  28,    EOE_MASK             = 0xF
+  enum TRAILERFIELDS {
+    T_WPOSITION = 0,
+    T_BPOSITION = 3,
+    T_MASK = 0x1,
+    ESTAT_WPOSITION = 0,
+    ESTAT_BPOSITION = 8,
+    ESTAT_MASK = 0xF,
+
+    TTS_WPOSITION = 0,
+    TTS_BPOSITION = 4,
+    TTS_MASK = 0xF,
+
+    CRC_WPOSITION = 0,
+    CRC_BPOSITION = 16,
+    CRC_MASK = 0xFFFF,
+    TLENGTH_WPOSITION = 1,
+    TLENGTH_BPOSITION = 0,
+    TLENGTH_MASK = 0xFFFFFF,
+    EOE_WPOSITION = 1,
+    EOE_BPOSITION = 28,
+    EOE_MASK = 0xF
   };
-				
 };
 
 #endif

--- a/EventFilter/EcalTBRawToDigi/src/DCCDataParser.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCDataParser.cc
@@ -1,208 +1,197 @@
 #include "DCCDataParser.h"
 
-
-
 /*----------------------------------------------*/
 /* DCCTBDataParser::DCCTBDataParser                 */
 /* class constructor                            */
 /*----------------------------------------------*/
-DCCTBDataParser::DCCTBDataParser(const std::vector<uint32_t>& parserParameters, bool parseInternalData,bool debug):
-  buffer_(nullptr),parseInternalData_(parseInternalData),debug_(debug), parameters(parserParameters){
-	
-  mapper_ = new DCCTBDataMapper(this);       //build a new data mapper
-  resetErrorCounters();                    //restart error counters
-  computeBlockSizes();                     //calculate block sizes
-  
+DCCTBDataParser::DCCTBDataParser(const std::vector<uint32_t> &parserParameters, bool parseInternalData, bool debug)
+    : buffer_(nullptr), parseInternalData_(parseInternalData), debug_(debug), parameters(parserParameters) {
+  mapper_ = new DCCTBDataMapper(this);  //build a new data mapper
+  resetErrorCounters();                 //restart error counters
+  computeBlockSizes();                  //calculate block sizes
 }
-
 
 /*----------------------------------------------*/
 /* DCCTBDataParser::resetErrorCounters            */
 /* resets error counters                        */
 /*----------------------------------------------*/
-void DCCTBDataParser::resetErrorCounters(){
+void DCCTBDataParser::resetErrorCounters() {
   //set error counters to 0
-  errors_["DCC::BOE"] = 0;               //begin of event (header B[60-63])
-  errors_["DCC::EOE"] = 0;               //end of event (trailer B[60-63])
-  errors_["DCC::EVENT LENGTH"] = 0;	 //event length (trailer B[32-55])
+  errors_["DCC::BOE"] = 0;           //begin of event (header B[60-63])
+  errors_["DCC::EOE"] = 0;           //end of event (trailer B[60-63])
+  errors_["DCC::EVENT LENGTH"] = 0;  //event length (trailer B[32-55])
 }
-
 
 /*----------------------------------------------*/
 /* DCCTBDataParser::computeBlockSizes             */
 /* calculate the size of TCC and SR blocks      */
 /*----------------------------------------------*/
-void DCCTBDataParser::computeBlockSizes(){
-  uint32_t nTT = numbTTs();                                      //gets the number of the trigger towers (default:68)  
-  uint32_t tSamples = numbTriggerSamples();                      //gets the number of trigger time samples (default: 1)
-  uint32_t nSr = numbSRF();                                      //gests the number of SR flags (default:68)
+void DCCTBDataParser::computeBlockSizes() {
+  uint32_t nTT = numbTTs();                  //gets the number of the trigger towers (default:68)
+  uint32_t tSamples = numbTriggerSamples();  //gets the number of trigger time samples (default: 1)
+  uint32_t nSr = numbSRF();                  //gests the number of SR flags (default:68)
 
   uint32_t tf(0), srf(0);
-	
-  if( (nTT*tSamples)<4 || (nTT*tSamples)%4 ) tf=1;            //test is there is no TTC primitives or if it's a multiple of 4?
-  else tf=0;
-  
 
-  if( srf<16 || srf%16 ) srf=1;                               //??? by default srf=0 why do we make this test ?????
-  else srf=0;
-  
+  if ((nTT * tSamples) < 4 || (nTT * tSamples) % 4)
+    tf = 1;  //test is there is no TTC primitives or if it's a multiple of 4?
+  else
+    tf = 0;
+
+  if (srf < 16 || srf % 16)
+    srf = 1;  //??? by default srf=0 why do we make this test ?????
+  else
+    srf = 0;
+
   //TTC block size: header (8 bytes) + 17 words with 4 trigger primitives (17*8bytes)
-  tccBlockSize_ = 8 + ((nTT*tSamples)/4)*8 + tf*8 ;          
+  tccBlockSize_ = 8 + ((nTT * tSamples) / 4) * 8 + tf * 8;
 
   //SR block size: header (8 bytes) + 4 words with 16 SR flags + 1 word with 4 SR flags (5*8bytes)
-  srpBlockSize_ = 8 + (nSr/16)*8 + srf*8;
+  srpBlockSize_ = 8 + (nSr / 16) * 8 + srf * 8;
 }
-
 
 /*------------------------------------------------*/
 /* DCCTBDataParser::parseFile                       */
 /* reada data from file and parse it              */
 /*------------------------------------------------*/
-void DCCTBDataParser::parseFile(std::string fileName, bool singleEvent){
-	
-  std::ifstream inputFile;                            //open file as input
+void DCCTBDataParser::parseFile(std::string fileName, bool singleEvent) {
+  std::ifstream inputFile;  //open file as input
   inputFile.open(fileName.c_str());
-	
-  resetErrorCounters();                          //reset error counters
+
+  resetErrorCounters();  //reset error counters
 
   //for debug purposes
   //std::cout << "Now in DCCTBDataParser::parseFile " << std::endl;
 
-	
   //if file opened correctly read data to a buffer and parse it
   //else throw an exception
-  if( !inputFile.fail() ){ 
-	
-    std::string myWord;                               //word read from line
-    std::vector<std::string> dataVector;                   //data vector
-    
-    //until the end of file read each line as a string and add it to the data vector
-    while( inputFile >> myWord ){ 
-      dataVector.push_back( myWord ); 
-    }
-    
-    bufferSize_ = (dataVector.size() ) * 4 ;      //buffer size in bytes (note:each char is an hex number)
+  if (!inputFile.fail()) {
+    std::string myWord;                   //word read from line
+    std::vector<std::string> dataVector;  //data vector
 
-    uint32_t *myData = new uint32_t[dataVector.size()];       //allocate memory for a new data buffer
-    uint32_t * const myDataBeginning = myData;                //pointer that stays at the beginning of the allocated memory
-    
+    //until the end of file read each line as a string and add it to the data vector
+    while (inputFile >> myWord) {
+      dataVector.push_back(myWord);
+    }
+
+    bufferSize_ = (dataVector.size()) * 4;  //buffer size in bytes (note:each char is an hex number)
+
+    uint32_t *myData = new uint32_t[dataVector.size()];  //allocate memory for a new data buffer
+    uint32_t *const myDataBeginning = myData;            //pointer that stays at the beginning of the allocated memory
+
     //fill buffer data with data from file lines
-    for(uint32_t i = 1; i <= dataVector.size() ; i++, myData++ ){
-      sscanf((dataVector[i-1]).c_str(),"%x",myData);
-      
+    for (uint32_t i = 1; i <= dataVector.size(); i++, myData++) {
+      sscanf((dataVector[i - 1]).c_str(), "%x", myData);
+
       //for debug purposes
       //std::cout << std::endl << "Data position: " << dec << i << " val = " << getHexString(*myData);
     }
-    
-    inputFile.close();                              //close file
-    
-    parseBuffer( myData,bufferSize_,singleEvent);  //parse data from the newly filled myData
-    delete [] myDataBeginning;
-  }
-  else{ 
+
+    inputFile.close();  //close file
+
+    parseBuffer(myData, bufferSize_, singleEvent);  //parse data from the newly filled myData
+    delete[] myDataBeginning;
+  } else {
     std::string errorMessage = std::string(" Error::Unable to open file :") + fileName;
     throw ECALTBParserException(errorMessage);
   }
 }
 
-
 /*----------------------------------------------------------*/
 /* DCCTBDataParser::parseBuffer                               */
 /* parse data from a buffer                                 */
 /*----------------------------------------------------------*/
-void DCCTBDataParser::parseBuffer(const uint32_t * buffer, uint32_t bufferSize, bool singleEvent){
-	
-  resetErrorCounters();                           //reset error counters
-	
-  buffer_ = buffer;                               //set class buffer
-  
+void DCCTBDataParser::parseBuffer(const uint32_t *buffer, uint32_t bufferSize, bool singleEvent) {
+  resetErrorCounters();  //reset error counters
+
+  buffer_ = buffer;  //set class buffer
+
   //clear stored data
   processedEvent_ = 0;
   events_.clear();
   std::vector<DCCTBEventBlock *>::iterator it;
-  for( it = dccEvents_.begin(); it!=dccEvents_.end(); it++ ) { delete *it; }
+  for (it = dccEvents_.begin(); it != dccEvents_.end(); it++) {
+    delete *it;
+  }
   dccEvents_.clear();
   eventErrors_ = "";
-	
+
   //for debug purposes
   //std::cout << std::endl << "Now in DCCTBDataParser::parseBuffer" << std::endl;
   //std::cout << std::endl << "Buffer Size:" << dec << bufferSize << std::endl;
-	
+
   //check if we have a coherent buffer size
-  if( bufferSize%8  ){
-    std::string fatalError ;
-    fatalError += "\n ======================================================================"; 		
-    fatalError += "\n Fatal error at event = " + getDecString(events_.size()+1);
-    fatalError += "\n Buffer Size of = "+ getDecString(bufferSize) + "[bytes] is not divisible by 8 ... ";
+  if (bufferSize % 8) {
+    std::string fatalError;
+    fatalError += "\n ======================================================================";
+    fatalError += "\n Fatal error at event = " + getDecString(events_.size() + 1);
+    fatalError += "\n Buffer Size of = " + getDecString(bufferSize) + "[bytes] is not divisible by 8 ... ";
     fatalError += "\n ======================================================================";
     throw ECALTBParserException(fatalError);
   }
-  if ( bufferSize < EMPTYEVENTSIZE ){
-    std::string fatalError ;
-    fatalError += "\n ======================================================================"; 		
-    fatalError += "\n Fatal error at event = " + getDecString(events_.size()+1);
-    fatalError += "\n Buffer Size of = "+ getDecString(bufferSize) + "[bytes] is less than an empty event ... ";
+  if (bufferSize < EMPTYEVENTSIZE) {
+    std::string fatalError;
+    fatalError += "\n ======================================================================";
+    fatalError += "\n Fatal error at event = " + getDecString(events_.size() + 1);
+    fatalError += "\n Buffer Size of = " + getDecString(bufferSize) + "[bytes] is less than an empty event ... ";
     fatalError += "\n ======================================================================";
     throw ECALTBParserException(fatalError);
   }
 
-  const uint32_t *myPointer =  buffer_;                        
-  
+  const uint32_t *myPointer = buffer_;
+
   //  uint32_t processedBytes(0), wordIndex(0), lastEvIndex(0),eventSize(0), eventLength(0), errorMask(0);
   uint32_t processedBytes(0), wordIndex(0), eventLength(0), errorMask(0);
-  
-  //parse until there are no more events
-  while( processedBytes + EMPTYEVENTSIZE <= bufferSize ){
 
+  //parse until there are no more events
+  while (processedBytes + EMPTYEVENTSIZE <= bufferSize) {
     //for debug purposes
     //std::cout << "-> processedBytes.  =   " << dec << processedBytes << std::endl;
     //std::cout << " -> Processed Event index =   " << dec << processedEvent_ << std::endl;
     //std::cout << "-> First ev.word    = 0x" << hex << (*myPointer) << std::endl;
     //std::cout << "-> word index       =   " << dec << wordIndex << std::endl;
-    
+
     //check if Event Length is coherent /////////////////////////////////////////
-    uint32_t bytesToEnd         = bufferSize - processedBytes;
-    std::pair<uint32_t,uint32_t> eventD = checkEventLength(myPointer,bytesToEnd,singleEvent);
-    eventLength              = eventD.second; 
-    errorMask                = eventD.first;
+    uint32_t bytesToEnd = bufferSize - processedBytes;
+    std::pair<uint32_t, uint32_t> eventD = checkEventLength(myPointer, bytesToEnd, singleEvent);
+    eventLength = eventD.second;
+    errorMask = eventD.first;
     //////////////////////////////////////////////////////////////////////////////
-     
+
     //for debug purposes
     //std::cout <<" -> EventSizeBytes        =   " << dec << eventLength*8 << std::endl;
-   
-	  
-	     
-    //for debug purposes debug 
+
+    //for debug purposes debug
     //std::cout<<std::endl;
     //std::cout<<" out... Bytes To End.... =   "<<dec<<bytesToEnd<<std::endl;
-    //std::cout<<" out... Processed Event  =   "<<dec<<processedEvent_<<std::endl;	
+    //std::cout<<" out... Processed Event  =   "<<dec<<processedEvent_<<std::endl;
     //std::cout<<" out... Event Length     =   "<<dec<<eventLength<<std::endl;
     //std::cout<<" out... LastWord         = 0x"<<hex<<*(myPointer+eventLength*2-1)<<std::endl;
-    
-    if (parseInternalData_){ 
+
+    if (parseInternalData_) {
       //build a new event block from buffer
-      DCCTBEventBlock *myBlock = new DCCTBEventBlock(this,myPointer,eventLength*8, eventLength*2 -1 ,wordIndex,0);
-      
+      DCCTBEventBlock *myBlock =
+          new DCCTBEventBlock(this, myPointer, eventLength * 8, eventLength * 2 - 1, wordIndex, 0);
+
       //add event to dccEvents vector
       dccEvents_.push_back(myBlock);
     }
-    
-    //build the event pointer with error mask and add it to the events vector
-    std::pair<const uint32_t *, uint32_t> eventPointer(myPointer,eventLength);
-    std::pair<uint32_t, std::pair<const uint32_t*, uint32_t> > eventPointerWithErrorMask(errorMask,eventPointer);
-    events_.push_back(eventPointerWithErrorMask);
-    		
-    //update processed buffer size 
-    processedEvent_++;
-    processedBytes += eventLength*8;
-    //std::cout << std::endl << "Processed Bytes = " << dec << processedBytes << std::endl;
-    
-    //go to next event
-    myPointer     += eventLength*2;
-    wordIndex     += eventLength*2;
-  } 
-}
 
+    //build the event pointer with error mask and add it to the events vector
+    std::pair<const uint32_t *, uint32_t> eventPointer(myPointer, eventLength);
+    std::pair<uint32_t, std::pair<const uint32_t *, uint32_t> > eventPointerWithErrorMask(errorMask, eventPointer);
+    events_.push_back(eventPointerWithErrorMask);
+
+    //update processed buffer size
+    processedEvent_++;
+    processedBytes += eventLength * 8;
+    //std::cout << std::endl << "Processed Bytes = " << dec << processedBytes << std::endl;
+
+    //go to next event
+    myPointer += eventLength * 2;
+    wordIndex += eventLength * 2;
+  }
+}
 
 /*---------------------------------------------*/
 /* DCCTBDataParser::checkEventLength             */
@@ -214,119 +203,116 @@ void DCCTBDataParser::parseBuffer(const uint32_t * buffer, uint32_t bufferSize, 
 /*   bit 3 - EOE Error                         */
 /* and the event length                        */
 /*---------------------------------------------*/
-std::pair<uint32_t,uint32_t> DCCTBDataParser::checkEventLength(const uint32_t *pointerToEvent, uint32_t bytesToEnd, bool singleEvent){
-	
-  std::pair<uint32_t,uint32_t> result;    //returns error mask and event length 
-  uint32_t errorMask(0);          //error mask to return
+std::pair<uint32_t, uint32_t> DCCTBDataParser::checkEventLength(const uint32_t *pointerToEvent,
+                                                                uint32_t bytesToEnd,
+                                                                bool singleEvent) {
+  std::pair<uint32_t, uint32_t> result;  //returns error mask and event length
+  uint32_t errorMask(0);                 //error mask to return
 
-  //check begin of event (BOE bits field) 
+  //check begin of event (BOE bits field)
   //(Note: we have to add one to read the 2nd 32 bit word where BOE is written)
   const uint32_t *boePointer = pointerToEvent + 1;
-  if( (  ((*boePointer)>>BOEBEGIN)& BOEMASK  )  != BOE ) { 
-    (errors_["DCC::BOE"])++; errorMask = 1; 
+  if ((((*boePointer) >> BOEBEGIN) & BOEMASK) != BOE) {
+    (errors_["DCC::BOE"])++;
+    errorMask = 1;
   }
-	
-	
+
   //get Event Length from buffer (Note: we have to add two to read the 3rd 32 bit word where EVENT LENGTH is written)
-  const uint32_t * myPointer = pointerToEvent + 2; 
-  uint32_t eventLength = (*myPointer)&EVENTLENGTHMASK;
+  const uint32_t *myPointer = pointerToEvent + 2;
+  uint32_t eventLength = (*myPointer) & EVENTLENGTHMASK;
 
   // std::cout << " Event Length(from decoding) = " << dec << eventLength << "... bytes to end... " << bytesToEnd << ", event numb : " << processedEvent_ << std::endl;
-  
+
   bool eoeError = false;
 
   //check if event is empty but but EVENT LENGTH is not corresponding to it
-  if( singleEvent && eventLength != bytesToEnd/8 ){
-    eventLength = bytesToEnd/8;
-    (errors_["DCC::EVENT LENGTH"])++; 
-    errorMask = errorMask | (1<<1);
+  if (singleEvent && eventLength != bytesToEnd / 8) {
+    eventLength = bytesToEnd / 8;
+    (errors_["DCC::EVENT LENGTH"])++;
+    errorMask = errorMask | (1 << 1);
   }
   //check if event length mismatches the number of words written as data
-  else if( eventLength == 0 || eventLength > (bytesToEnd / 8) || eventLength < (EMPTYEVENTSIZE/8) ){  
+  else if (eventLength == 0 || eventLength > (bytesToEnd / 8) || eventLength < (EMPTYEVENTSIZE / 8)) {
     // How to handle bad event length in multiple event buffers
-    // First approach : Send an exception	
+    // First approach : Send an exception
     // Second aproach : Try to find the EOE (To be done? If yes check dataDecoder tBeam implementation)
     std::string fatalError;
-		
-    fatalError +="\n ======================================================================"; 		
-    fatalError +="\n Fatal error at event = " + getDecString(events_.size()+1);
-    fatalError +="\n Decoded event length = " + getDecString(eventLength);
-    fatalError +="\n bytes to buffer end  = " + getDecString(bytesToEnd);
-    fatalError +="\n Unable to procead the data decoding ...";
 
-    if(eventLength > (bytesToEnd / 8)){ fatalError +=" (eventLength > (bytesToEnd / 8)";}
-    else{ fatalError += "\n event length not big enough heaven to build an empty event ( 4x8 bytes)";}
+    fatalError += "\n ======================================================================";
+    fatalError += "\n Fatal error at event = " + getDecString(events_.size() + 1);
+    fatalError += "\n Decoded event length = " + getDecString(eventLength);
+    fatalError += "\n bytes to buffer end  = " + getDecString(bytesToEnd);
+    fatalError += "\n Unable to procead the data decoding ...";
 
-    fatalError +="\n ======================================================================";
+    if (eventLength > (bytesToEnd / 8)) {
+      fatalError += " (eventLength > (bytesToEnd / 8)";
+    } else {
+      fatalError += "\n event length not big enough heaven to build an empty event ( 4x8 bytes)";
+    }
+
+    fatalError += "\n ======================================================================";
 
     throw ECALTBParserException(fatalError);
   }
 
-  //check end of event (EOE bits field) 
+  //check end of event (EOE bits field)
   //(Note: event length is multiplied by 2 because its written as 32 bit words and not 64 bit words)
-  const uint32_t *endOfEventPointer = pointerToEvent + eventLength*2 -1;
-  if ( (  ((*endOfEventPointer) >> EOEBEGIN & EOEMASK )  != EOEMASK) && !eoeError ){ 
-    (errors_["DCC::EOE"])++; 
-    errorMask = errorMask | (1<<2); 
+  const uint32_t *endOfEventPointer = pointerToEvent + eventLength * 2 - 1;
+  if ((((*endOfEventPointer) >> EOEBEGIN & EOEMASK) != EOEMASK) && !eoeError) {
+    (errors_["DCC::EOE"])++;
+    errorMask = errorMask | (1 << 2);
   }
-  
+
   //build result to return
-  result.first  = errorMask;
+  result.first = errorMask;
   result.second = eventLength;
-  
+
   return result;
 }
-
-
 
 /*----------------------------------------------*/
 /* DCCTBDataParser::index                         */
 /* build an index string                        */
 /*----------------------------------------------*/
-std::string DCCTBDataParser::index(uint32_t position){
-
+std::string DCCTBDataParser::index(uint32_t position) {
   char indexBuffer[20];
   long unsigned int pos = position;
-  snprintf(indexBuffer, sizeof(indexBuffer), "W[%08lu]",pos);        //build an index string for display purposes, p.e.  W[15] 
+  snprintf(
+      indexBuffer, sizeof(indexBuffer), "W[%08lu]", pos);  //build an index string for display purposes, p.e.  W[15]
 
-  return std::string(indexBuffer);	
+  return std::string(indexBuffer);
 }
-
 
 /*-----------------------------------------------*/
 /* DCCTBDataParser::getDecString                   */
 /* print decimal data to a string                */
 /*-----------------------------------------------*/
-std::string DCCTBDataParser::getDecString(uint32_t dat){
-	
+std::string DCCTBDataParser::getDecString(uint32_t dat) {
   char buffer[15];
   long unsigned int data = dat;
-  snprintf(buffer, sizeof(buffer), "%lu",data);
+  snprintf(buffer, sizeof(buffer), "%lu", data);
 
-  return std::string(buffer);	
+  return std::string(buffer);
 }
-
 
 /*-------------------------------------------------*/
 /* DCCTBDataParser::getHexString                     */
 /* print data in hexadecimal base to a string      */
 /*-------------------------------------------------*/
-std::string DCCTBDataParser::getHexString(uint32_t data){
-	
+std::string DCCTBDataParser::getHexString(uint32_t data) {
   char buffer[15];
-  snprintf(buffer, sizeof(buffer), "0x%08x",(uint16_t)(data));
+  snprintf(buffer, sizeof(buffer), "0x%08x", (uint16_t)(data));
 
-  return std::string(buffer);	
+  return std::string(buffer);
 }
-
 
 /*------------------------------------------------*/
 /* DCCTBDataParser::getIndexedData                  */
 /* build a string with index and data             */
 /*------------------------------------------------*/
-std::string DCCTBDataParser::getIndexedData(uint32_t position, uint32_t *pointer){
+std::string DCCTBDataParser::getIndexedData(uint32_t position, uint32_t *pointer) {
   std::string ret;
-  
+
   //char indexBuffer[20];
   //char dataBuffer[20];
   //sprintf(indexBuffer,"W[%08u] = ",position);
@@ -334,21 +320,21 @@ std::string DCCTBDataParser::getIndexedData(uint32_t position, uint32_t *pointer
   //ret = std::string(indexBuffer)+std::string(dataBuffer);
 
   ret = index(position) + getHexString(*pointer);
-  
-  return ret;	
-}
 
+  return ret;
+}
 
 /*-------------------------------------------------*/
 /* DCCTBDataParser::~DCCTBDataParser                   */
 /* destructor                                      */
 /*-------------------------------------------------*/
-DCCTBDataParser::~DCCTBDataParser(){
-  
+DCCTBDataParser::~DCCTBDataParser() {
   // delete DCCTBEvents if any...
   std::vector<DCCTBEventBlock *>::iterator it;
-  for(it=dccEvents_.begin();it!=dccEvents_.end();it++){delete *it;}
+  for (it = dccEvents_.begin(); it != dccEvents_.end(); it++) {
+    delete *it;
+  }
   dccEvents_.clear();
-    
+
   delete mapper_;
 }

--- a/EventFilter/EcalTBRawToDigi/src/DCCDataParser.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCDataParser.h
@@ -7,27 +7,23 @@
 #ifndef DCCTBDATAPARSER_HH
 #define DCCTBDATAPARSER_HH
 
-#include <fstream>                   //STL
+#include <fstream>  //STL
 #include <iostream>
 #include <string>
 #include <vector>
 #include <map>
 
-#include <cstdio>                     //C
+#include <cstdio>  //C
 
-#include "ECALParserException.h"      //DATA DECODER
+#include "ECALParserException.h"  //DATA DECODER
 #include "DCCEventBlock.h"
 #include "DCCDataMapper.h"
-
 
 class DCCTBDataMapper;
 class DCCTBEventBlock;
 
-
-class DCCTBDataParser{
-
-public : 
-  
+class DCCTBDataParser {
+public:
   /**
      Class constructor: takes a vector of 10 parameters and flags for parseInternalData and debug
      Parameters are: 
@@ -39,33 +35,35 @@ public :
      5 - SR id
      [6-9] - TCC[6-9] id
   */
-  DCCTBDataParser( const std::vector<uint32_t>& parserParameters , bool parseInternalData = true, bool debug = true);
-  
+  DCCTBDataParser(const std::vector<uint32_t> &parserParameters, bool parseInternalData = true, bool debug = true);
+
   /**
     Parse data from file 
   */
-  void parseFile( std::string fileName, bool singleEvent = false);
-	
+  void parseFile(std::string fileName, bool singleEvent = false);
+
   /**
      Parse data from a buffer
   */
-  void parseBuffer( const uint32_t * buffer, uint32_t bufferSize, bool singleEvent = false);
+  void parseBuffer(const uint32_t *buffer, uint32_t bufferSize, bool singleEvent = false);
 
   /**
      Get method for DCCTBDataMapper
   */
   DCCTBDataMapper *mapper();
-		
+
   /**
      Check if EVENT LENGTH is coeherent and if BOE/EOE are correctly written
      returns 3 bits code with the error found + event length
   */
-  std::pair<uint32_t,uint32_t> checkEventLength(const uint32_t * pointerToEvent, uint32_t bytesToEnd, bool singleEvent = false);
-  
+  std::pair<uint32_t, uint32_t> checkEventLength(const uint32_t *pointerToEvent,
+                                                 uint32_t bytesToEnd,
+                                                 bool singleEvent = false);
+
   /**
      Get methods for parser parameters;
   */
-  std::vector<uint32_t> parserParameters(); 
+  std::vector<uint32_t> parserParameters();
   uint32_t numbXtalSamples();
   uint32_t numbTriggerSamples();
   uint32_t numbTTs();
@@ -76,13 +74,11 @@ public :
   uint32_t tcc2Id();
   uint32_t tcc3Id();
   uint32_t tcc4Id();
-  
 
   /**
      Set method for parser parameters
   */
-  void  setParameters( const std::vector<uint32_t>& newParameters );
-
+  void setParameters(const std::vector<uint32_t> &newParameters);
 
   /**
      Get methods for block sizes
@@ -93,113 +89,113 @@ public :
   /**
      Get methods for debug flag
   */
-  bool  debug();
+  bool debug();
 
   /**
      Get method for DCCEventBlocks vector
    */
-  std::vector<DCCTBEventBlock *> & dccEvents();
+  std::vector<DCCTBEventBlock *> &dccEvents();
 
   /**
      Get method for error counters map
   */
-  std::map<std::string,uint32_t> & errorCounters();
+  std::map<std::string, uint32_t> &errorCounters();
 
   /**
    * Get method for events
    */
-  std::vector< std::pair< uint32_t, std::pair<const uint32_t *, uint32_t> > > events();
-
+  std::vector<std::pair<uint32_t, std::pair<const uint32_t *, uint32_t> > > events();
 
   /**
      Reset Error Counters
   */
   void resetErrorCounters();
-		
 
   /**
      Methods to get data strings formatted as decimal/hexadecimal, indexes and indexed data
   */
-  std::string getDecString(uint32_t data);		
+  std::string getDecString(uint32_t data);
   std::string getHexString(uint32_t data);
   std::string index(uint32_t position);
-  std::string getIndexedData( uint32_t indexed, uint32_t * pointer);
+  std::string getIndexedData(uint32_t indexed, uint32_t *pointer);
 
   /**
    * Retrieves a pointer to the data buffer
    */
-  const uint32_t *getBuffer() { return buffer_;}
-  
+  const uint32_t *getBuffer() { return buffer_; }
+
   /**
      Class destructor
   */
   ~DCCTBDataParser();
 
-  enum DCCDataParserGlobalFields{
-    EMPTYEVENTSIZE = 32                   //bytes
+  enum DCCDataParserGlobalFields {
+    EMPTYEVENTSIZE = 32  //bytes
   };
- 
-protected :
+
+protected:
   void computeBlockSizes();
 
-  const uint32_t *buffer_;                //data buffer
-  uint32_t bufferSize_;             //buffer size
+  const uint32_t *buffer_;  //data buffer
+  uint32_t bufferSize_;     //buffer size
 
-  uint32_t srpBlockSize_;           //SR block size
-  uint32_t tccBlockSize_;           //TCC block size
+  uint32_t srpBlockSize_;  //SR block size
+  uint32_t tccBlockSize_;  //TCC block size
 
   uint32_t processedEvent_;
   std::string eventErrors_;
   DCCTBDataMapper *mapper_;
-  
+
   std::vector<DCCTBEventBlock *> dccEvents_;
-  
+
   // std::pair< errorMask, std::pair< pointer to event, event size (number of DW)> >
-  std::vector< std::pair< uint32_t, std::pair<const uint32_t *, uint32_t> > > events_;
-  
-  bool parseInternalData_;          //parse internal data flag
-  bool debug_;                      //debug flag
-  std::map<std::string,uint32_t> errors_;        //errors map
+  std::vector<std::pair<uint32_t, std::pair<const uint32_t *, uint32_t> > > events_;
+
+  bool parseInternalData_;                  //parse internal data flag
+  bool debug_;                              //debug flag
+  std::map<std::string, uint32_t> errors_;  //errors map
   std::vector<uint32_t> parameters;         //parameters vector
 
-  enum DCCTBDataParserFields{
+  enum DCCTBDataParserFields {
     EVENTLENGTHMASK = 0xFFFFFF,
-    
-    BOEBEGIN = 28,                  //begin of event (on 32 bit string starts at bit 28)
-    BOEMASK = 0xF,                  //mask is 4 bits (F)
-    BOE =0x5,                       //B'0101'
 
-    EOEBEGIN = 28,                  //end of event
-    EOEMASK = 0xF,                  //4 bits
-    EOE =0xA                        //B'1010'
+    BOEBEGIN = 28,  //begin of event (on 32 bit string starts at bit 28)
+    BOEMASK = 0xF,  //mask is 4 bits (F)
+    BOE = 0x5,      //B'0101'
+
+    EOEBEGIN = 28,  //end of event
+    EOEMASK = 0xF,  //4 bits
+    EOE = 0xA       //B'1010'
   };
-		
 };
 
-inline DCCTBDataMapper *DCCTBDataParser::mapper() { return mapper_;}
+inline DCCTBDataMapper *DCCTBDataParser::mapper() { return mapper_; }
 
 inline std::vector<uint32_t> DCCTBDataParser::parserParameters() { return parameters; }
-inline uint32_t DCCTBDataParser::numbXtalSamples()     { return parameters[0]; }
-inline uint32_t DCCTBDataParser::numbTriggerSamples()  { return parameters[1]; }
-inline uint32_t DCCTBDataParser::numbTTs()             { return parameters[2]; }
-inline uint32_t DCCTBDataParser::numbSRF()             { return parameters[3]; }
-inline uint32_t DCCTBDataParser::dccId()               { return parameters[4]; }
-inline uint32_t DCCTBDataParser::srpId()               { return parameters[5]; }
-inline uint32_t DCCTBDataParser::tcc1Id()              { return parameters[6]; } 
-inline uint32_t DCCTBDataParser::tcc2Id()              { return parameters[7]; } 
-inline uint32_t DCCTBDataParser::tcc3Id()              { return parameters[8]; } 
-inline uint32_t DCCTBDataParser::tcc4Id()              { return parameters[9]; }
+inline uint32_t DCCTBDataParser::numbXtalSamples() { return parameters[0]; }
+inline uint32_t DCCTBDataParser::numbTriggerSamples() { return parameters[1]; }
+inline uint32_t DCCTBDataParser::numbTTs() { return parameters[2]; }
+inline uint32_t DCCTBDataParser::numbSRF() { return parameters[3]; }
+inline uint32_t DCCTBDataParser::dccId() { return parameters[4]; }
+inline uint32_t DCCTBDataParser::srpId() { return parameters[5]; }
+inline uint32_t DCCTBDataParser::tcc1Id() { return parameters[6]; }
+inline uint32_t DCCTBDataParser::tcc2Id() { return parameters[7]; }
+inline uint32_t DCCTBDataParser::tcc3Id() { return parameters[8]; }
+inline uint32_t DCCTBDataParser::tcc4Id() { return parameters[9]; }
 
-inline void  DCCTBDataParser::setParameters( const std::vector<uint32_t>& newParameters ){ parameters = newParameters; computeBlockSizes();}
+inline void DCCTBDataParser::setParameters(const std::vector<uint32_t> &newParameters) {
+  parameters = newParameters;
+  computeBlockSizes();
+}
 
-inline uint32_t DCCTBDataParser::srpBlockSize()        { return srpBlockSize_; } 
-inline uint32_t DCCTBDataParser::tccBlockSize()        { return tccBlockSize_; } 
+inline uint32_t DCCTBDataParser::srpBlockSize() { return srpBlockSize_; }
+inline uint32_t DCCTBDataParser::tccBlockSize() { return tccBlockSize_; }
 
-inline bool DCCTBDataParser::debug()                          { return debug_;     }
-inline std::vector<DCCTBEventBlock *> &DCCTBDataParser::dccEvents()  { return dccEvents_;    }
-inline std::map<std::string,uint32_t> &DCCTBDataParser::errorCounters()    { return errors_;       }
-inline std::vector< std::pair< uint32_t, std::pair<const uint32_t *, uint32_t> > > DCCTBDataParser::events() { return events_;   }
-
+inline bool DCCTBDataParser::debug() { return debug_; }
+inline std::vector<DCCTBEventBlock *> &DCCTBDataParser::dccEvents() { return dccEvents_; }
+inline std::map<std::string, uint32_t> &DCCTBDataParser::errorCounters() { return errors_; }
+inline std::vector<std::pair<uint32_t, std::pair<const uint32_t *, uint32_t> > > DCCTBDataParser::events() {
+  return events_;
+}
 
 #endif
-

--- a/EventFilter/EcalTBRawToDigi/src/DCCEventBlock.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCEventBlock.cc
@@ -251,7 +251,7 @@ void DCCTBEventBlock::dataCheck(){
 	/////////////////////////////////////////////////////////////////////////////
 		
 	
-	if(checkErrors!=""){
+	if(!checkErrors.empty()){
 		errorString_ +="\n ======================================================================\n"; 		
 		errorString_ += std::string(" ") + name_ + std::string(" data fields checks errors : ") ;
 		errorString_ += checkErrors ;
@@ -520,7 +520,7 @@ std::string DCCTBEventBlock::eventErrorString(){
 			std::string temp;
 			for(it3 = xtalBlocks.begin();it3!=xtalBlocks.end();it3++){ temp += (*it3)->errorString();}
 		
-			if(temp!=""){
+			if(!temp.empty()){
 				ret += "\n Fine grain data Errors found ...";
 				ret += "\n(  Tower ID = " + parser_->getDecString( (*it2)->getDataField("TT/SC ID"));
 				ret += ", LV1 = " + parser_->getDecString( (*it2)->getDataField("LV1"));

--- a/EventFilter/EcalTBRawToDigi/src/DCCEventBlock.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCEventBlock.cc
@@ -12,551 +12,526 @@
 #include <iomanip>
 #include <sstream>
 
-DCCTBEventBlock::DCCTBEventBlock(
-	DCCTBDataParser * parser, 
-	const uint32_t * buffer, 
-	uint32_t numbBytes, 
-	uint32_t wordsToEnd, 
-	uint32_t wordBufferOffset , 
-	uint32_t wordEventOffset 
-) : 
-DCCTBBlockPrototype(parser,"DCCHEADER", buffer, numbBytes,wordsToEnd)
-,dccTrailerBlock_(nullptr),srpBlock_(nullptr),wordBufferOffset_(wordBufferOffset) {
-	
-	
-	//Reset error counters ////
-	errors_["DCC::HEADER"] = 0;
-	errors_["DCC::EVENT LENGTH"] = 0;
-	///////////////////////////
-	
-	uint32_t wToEnd(0);
-	
-	try{ 
-	
-		// Get data fields from the mapper and retrieve data ///	
-		if(numbBytes == DCCTBDataParser::EMPTYEVENTSIZE ){
-			mapperFields_ = parser_->mapper()->emptyEventFields();
-			emptyEvent = true;
-		}else{
-			mapperFields_ = parser_->mapper()->dccFields();	
-			emptyEvent = false;
-		}
-		
-		try{ parseData(); }
-		catch (ECALTBParserBlockException &e){/*ignore*/}
-		///////////////////////////////////////////////////////
-		
+DCCTBEventBlock::DCCTBEventBlock(DCCTBDataParser *parser,
+                                 const uint32_t *buffer,
+                                 uint32_t numbBytes,
+                                 uint32_t wordsToEnd,
+                                 uint32_t wordBufferOffset,
+                                 uint32_t wordEventOffset)
+    : DCCTBBlockPrototype(parser, "DCCHEADER", buffer, numbBytes, wordsToEnd),
+      dccTrailerBlock_(nullptr),
+      srpBlock_(nullptr),
+      wordBufferOffset_(wordBufferOffset) {
+  //Reset error counters ////
+  errors_["DCC::HEADER"] = 0;
+  errors_["DCC::EVENT LENGTH"] = 0;
+  ///////////////////////////
 
-	
-		// Check internal data //////////////
-		if(parser_->debug()){ dataCheck(); }
-		/////////////////////////////////////
-	
-	
-		// Check if empty event was produced /////////////////////////////////////////////////////////////////
+  uint32_t wToEnd(0);
 
-		if( !emptyEvent && getDataField("DCC ERRORS")!= DCCERROR_EMPTYEVENT ){
-			 		
-			// Build the SRP block ////////////////////////////////////////////////////////////////////////////////////
-		
-			bool srp(false);
-			uint32_t sr_ch = getDataField("SR_CHSTATUS");
-			if( sr_ch!=CH_TIMEOUT  && sr_ch != CH_DISABLED ){ 			
-				
-				//Go to the begining of the block
-				increment(1," (while trying to create a SR Block !)");
-				wToEnd = numbBytes/4-wordCounter_-1;	
-				
-				// Build SRP Block //////////////////////////////////////////////////////////////////////
-				srpBlock_ = new DCCTBSRPBlock( this, parser_, dataP_, parser_->srpBlockSize(), wToEnd,wordCounter_);
-				//////////////////////////////////////////////////////////////////////////////////////////
-		
-				increment((parser_->srpBlockSize())/4-1);
-				if(getDataField("SR")){ srp=true; }
-			}	
-			
-			////////////////////////////////////////////////////////////////////////////////////////////////////////////		
+  try {
+    // Get data fields from the mapper and retrieve data ///
+    if (numbBytes == DCCTBDataParser::EMPTYEVENTSIZE) {
+      mapperFields_ = parser_->mapper()->emptyEventFields();
+      emptyEvent = true;
+    } else {
+      mapperFields_ = parser_->mapper()->dccFields();
+      emptyEvent = false;
+    }
 
+    try {
+      parseData();
+    } catch (ECALTBParserBlockException &e) { /*ignore*/
+    }
+    ///////////////////////////////////////////////////////
 
-			// Build TCC blocks ////////////////////////////////////////////////////////////////////////////////////////
-			for(uint32_t i=1; i<=4;i++){
-			  uint32_t tcc_ch=0;  uint32_t  tccId=0;
-				if( i == 1){ tccId = parser_->tcc1Id();}
-				if( i == 2){ tccId = parser_->tcc2Id();}
-				if( i == 3){ tccId = parser_->tcc3Id();}	
-				if( i == 4){ tccId = parser_->tcc4Id();}
-				
-				std::string tcc = std::string("TCC_CHSTATUS#") + parser_->getDecString(i);	
-				tcc_ch = getDataField(tcc);
-				
-				if( tcc_ch != CH_TIMEOUT && tcc_ch != CH_DISABLED){	 
-					
-					//std::cout<<"\n debug:Building TCC Block, channel enabled without errors"<<std::endl;
-					
-					// Go to the begining of the block
-					increment(1," (while trying to create a"+tcc+" Block !)");
-					
-					wToEnd = numbBytes/4-wordCounter_-1;	
-					//wToEnd or wordsToEnd ????????????????????????????????????????
-					
-				
-					
-					// Build TCC Block /////////////////////////////////////////////////////////////////////////////////
-					tccBlocks_.push_back(  new DCCTBTCCBlock( this, parser_, dataP_,parser_->tccBlockSize(), wToEnd,wordCounter_, tccId));
-					//////////////////////////////////////////////////////////////////////////////////////////////////////	
-					
-					increment((parser_->tccBlockSize())/4-1);
-				}
-			}
-			////////////////////////////////////////////////////////////////////////////////////////////////////////////
-			
-			
-			
-			// Build channel data //////////////////////////////////////////////////////////////////////////////////////////////////////	
-			// See number of channels that we need according to the trigger type //
-			// TODO : WHEN IN LOCAL MODE WE SHOULD CHECK RUN TYPE
-			uint32_t triggerType = getDataField("TRIGGER TYPE");			
-			uint32_t numbChannels;
-			if( triggerType == PHYSICTRIGGER )          { numbChannels = 68; }
-			else if (triggerType == CALIBRATIONTRIGGER ){ numbChannels = 70; }
-			// TODO :: implement other triggers
-			else{
-			  std::string error = std::string("\n DCC::HEADER TRIGGER TYPE = ")+parser_->getDecString(triggerType)+std::string(" is not a valid type !");
-				ECALTBParserBlockException a(error);
-				throw a;
-			}
-			////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-			
-			
-			
-//			uint32_t chStatus;
-			uint32_t srFlag;
-			bool suppress(false);
-			
-			for( uint32_t i=1; i<=numbChannels; i++){
-				
-			  std::string chStatusId = std::string("FE_CHSTATUS#") + parser_->getDecString(i);
-				uint32_t chStatus = getDataField(chStatusId);
-				
-				// If srp is on, we need to check if channel was suppressed ////////////////////
-				if(srp){ 
-					srFlag   = srpBlock_->getDataField( std::string("SR#") + parser_->getDecString(i));
-					if(srFlag == SR_NREAD){ suppress = true; }
-					else{ suppress = false; }
-				}
-				////////////////////////////////////////////////////////////////////////////////
-					
-				 
-				if( chStatus != CH_TIMEOUT && chStatus != CH_DISABLED && !suppress && chStatus !=CH_SUPPRESS){
+    // Check internal data //////////////
+    if (parser_->debug()) {
+      dataCheck();
+    }
+    /////////////////////////////////////
 
-					
-					//Go to the begining of the block ///////////////////////////////////////////////////////////////////////
-					increment(1," (while trying to create a TOWERHEADER Block for channel "+parser_->getDecString(i)+" !)" );
-					/////////////////////////////////////////////////////////////////////////////////////////////////////////
-					
-					
-					// Instantiate a new tower block//////////////////////////////////////////////////////////////////////////
-					wToEnd = numbBytes/4-wordCounter_-1;
-					DCCTBTowerBlock * towerBlock = new DCCTBTowerBlock(this,parser_,dataP_,TOWERHEADER_SIZE,wToEnd,wordCounter_,i); 
-					towerBlocks_.push_back (towerBlock);
-					towerBlock->parseXtalData();
-					//////////////////////////////////////////////////////////////////////////////////////////////////////////
-					
-					
-					//go to the end of the block ///////////////////////////////
-					increment((towerBlock->getDataField("BLOCK LENGTH"))*2 - 1);
-					////////////////////////////////////////////////////////////
-						
-				}
-			}
-			////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-			
+    // Check if empty event was produced /////////////////////////////////////////////////////////////////
 
-			// go to the begining of the block ////////////////////////////////////////////////////////////////////			
-			increment(1," (while trying to create a DCC TRAILER Block !)");
-			wToEnd = numbBytes/4-wordCounter_-1;
-			dccTrailerBlock_ = new DCCTBTrailerBlock(parser_,dataP_,TRAILER_SIZE,wToEnd,wordCounter_,blockSize_/8,0);
-			//////////////////////////////////////////////////////////////////////////////////////////////////////
-			
-		}
-	
-	}catch( ECALTBParserException & e){}
-	catch( ECALTBParserBlockException & e){
-	  // uint32_t nEv = (parser_->dccEvents()).size() +1;
-	  errorString_ += std::string(e.what());
-	  blockError_=true;
-	  //std::cout<<"cout"<<e.what();
-	}
-	
-	
+    if (!emptyEvent && getDataField("DCC ERRORS") != DCCERROR_EMPTYEVENT) {
+      // Build the SRP block ////////////////////////////////////////////////////////////////////////////////////
 
-} 
+      bool srp(false);
+      uint32_t sr_ch = getDataField("SR_CHSTATUS");
+      if (sr_ch != CH_TIMEOUT && sr_ch != CH_DISABLED) {
+        //Go to the begining of the block
+        increment(1, " (while trying to create a SR Block !)");
+        wToEnd = numbBytes / 4 - wordCounter_ - 1;
 
+        // Build SRP Block //////////////////////////////////////////////////////////////////////
+        srpBlock_ = new DCCTBSRPBlock(this, parser_, dataP_, parser_->srpBlockSize(), wToEnd, wordCounter_);
+        //////////////////////////////////////////////////////////////////////////////////////////
 
+        increment((parser_->srpBlockSize()) / 4 - 1);
+        if (getDataField("SR")) {
+          srp = true;
+        }
+      }
 
-DCCTBEventBlock::~DCCTBEventBlock(){
-	
-	std::vector<DCCTBTCCBlock *>::iterator it1;
-	for(it1=tccBlocks_.begin();it1!=tccBlocks_.end();it1++){ delete (*it1);}
-	tccBlocks_.clear();
-	
-	std::vector<DCCTBTowerBlock *>::iterator it2;
-	for(it2=towerBlocks_.begin();it2!=towerBlocks_.end();it2++){ delete (*it2);}
-	towerBlocks_.clear();
-	
-	if(srpBlock_ !=        nullptr ) { delete srpBlock_;       }
-	if(dccTrailerBlock_ != nullptr ) { delete dccTrailerBlock_;}
-	
+      ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+      // Build TCC blocks ////////////////////////////////////////////////////////////////////////////////////////
+      for (uint32_t i = 1; i <= 4; i++) {
+        uint32_t tcc_ch = 0;
+        uint32_t tccId = 0;
+        if (i == 1) {
+          tccId = parser_->tcc1Id();
+        }
+        if (i == 2) {
+          tccId = parser_->tcc2Id();
+        }
+        if (i == 3) {
+          tccId = parser_->tcc3Id();
+        }
+        if (i == 4) {
+          tccId = parser_->tcc4Id();
+        }
+
+        std::string tcc = std::string("TCC_CHSTATUS#") + parser_->getDecString(i);
+        tcc_ch = getDataField(tcc);
+
+        if (tcc_ch != CH_TIMEOUT && tcc_ch != CH_DISABLED) {
+          //std::cout<<"\n debug:Building TCC Block, channel enabled without errors"<<std::endl;
+
+          // Go to the begining of the block
+          increment(1, " (while trying to create a" + tcc + " Block !)");
+
+          wToEnd = numbBytes / 4 - wordCounter_ - 1;
+          //wToEnd or wordsToEnd ????????????????????????????????????????
+
+          // Build TCC Block /////////////////////////////////////////////////////////////////////////////////
+          tccBlocks_.push_back(
+              new DCCTBTCCBlock(this, parser_, dataP_, parser_->tccBlockSize(), wToEnd, wordCounter_, tccId));
+          //////////////////////////////////////////////////////////////////////////////////////////////////////
+
+          increment((parser_->tccBlockSize()) / 4 - 1);
+        }
+      }
+      ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+      // Build channel data //////////////////////////////////////////////////////////////////////////////////////////////////////
+      // See number of channels that we need according to the trigger type //
+      // TODO : WHEN IN LOCAL MODE WE SHOULD CHECK RUN TYPE
+      uint32_t triggerType = getDataField("TRIGGER TYPE");
+      uint32_t numbChannels;
+      if (triggerType == PHYSICTRIGGER) {
+        numbChannels = 68;
+      } else if (triggerType == CALIBRATIONTRIGGER) {
+        numbChannels = 70;
+      }
+      // TODO :: implement other triggers
+      else {
+        std::string error = std::string("\n DCC::HEADER TRIGGER TYPE = ") + parser_->getDecString(triggerType) +
+                            std::string(" is not a valid type !");
+        ECALTBParserBlockException a(error);
+        throw a;
+      }
+      ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+      //			uint32_t chStatus;
+      uint32_t srFlag;
+      bool suppress(false);
+
+      for (uint32_t i = 1; i <= numbChannels; i++) {
+        std::string chStatusId = std::string("FE_CHSTATUS#") + parser_->getDecString(i);
+        uint32_t chStatus = getDataField(chStatusId);
+
+        // If srp is on, we need to check if channel was suppressed ////////////////////
+        if (srp) {
+          srFlag = srpBlock_->getDataField(std::string("SR#") + parser_->getDecString(i));
+          if (srFlag == SR_NREAD) {
+            suppress = true;
+          } else {
+            suppress = false;
+          }
+        }
+        ////////////////////////////////////////////////////////////////////////////////
+
+        if (chStatus != CH_TIMEOUT && chStatus != CH_DISABLED && !suppress && chStatus != CH_SUPPRESS) {
+          //Go to the begining of the block ///////////////////////////////////////////////////////////////////////
+          increment(1, " (while trying to create a TOWERHEADER Block for channel " + parser_->getDecString(i) + " !)");
+          /////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+          // Instantiate a new tower block//////////////////////////////////////////////////////////////////////////
+          wToEnd = numbBytes / 4 - wordCounter_ - 1;
+          DCCTBTowerBlock *towerBlock =
+              new DCCTBTowerBlock(this, parser_, dataP_, TOWERHEADER_SIZE, wToEnd, wordCounter_, i);
+          towerBlocks_.push_back(towerBlock);
+          towerBlock->parseXtalData();
+          //////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+          //go to the end of the block ///////////////////////////////
+          increment((towerBlock->getDataField("BLOCK LENGTH")) * 2 - 1);
+          ////////////////////////////////////////////////////////////
+        }
+      }
+      ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+      // go to the begining of the block ////////////////////////////////////////////////////////////////////
+      increment(1, " (while trying to create a DCC TRAILER Block !)");
+      wToEnd = numbBytes / 4 - wordCounter_ - 1;
+      dccTrailerBlock_ = new DCCTBTrailerBlock(parser_, dataP_, TRAILER_SIZE, wToEnd, wordCounter_, blockSize_ / 8, 0);
+      //////////////////////////////////////////////////////////////////////////////////////////////////////
+    }
+
+  } catch (ECALTBParserException &e) {
+  } catch (ECALTBParserBlockException &e) {
+    // uint32_t nEv = (parser_->dccEvents()).size() +1;
+    errorString_ += std::string(e.what());
+    blockError_ = true;
+    //std::cout<<"cout"<<e.what();
+  }
 }
 
+DCCTBEventBlock::~DCCTBEventBlock() {
+  std::vector<DCCTBTCCBlock *>::iterator it1;
+  for (it1 = tccBlocks_.begin(); it1 != tccBlocks_.end(); it1++) {
+    delete (*it1);
+  }
+  tccBlocks_.clear();
 
+  std::vector<DCCTBTowerBlock *>::iterator it2;
+  for (it2 = towerBlocks_.begin(); it2 != towerBlocks_.end(); it2++) {
+    delete (*it2);
+  }
+  towerBlocks_.clear();
 
-void DCCTBEventBlock::dataCheck(){
-	
-	
-	std::string checkErrors("");
-	
-	
-	// Check BOE field/////////////////////////////////////////////////////
-	std::pair<bool,std::string> res =  checkDataField("BOE",BOE);
-	if(!res.first){ checkErrors += res.second; (errors_["DCC::HEADER"])++; }
-	///////////////////////////////////////////////////////////////////////
-	
-	
-	// Check H Field //////////////////////////////////////////////////////
-	std::string hField= std::string("H");
-	res = checkDataField(hField,1);
-	if(!res.first){ checkErrors += res.second; (errors_["DCC::HEADER"])++; }
-	////////////////////////////////////////////////////////////////////////
-	
-	
-	// Check Headers //////////////////////////////////////////////////////////
-	uint32_t dccHeaderWords = 0;
-	
-	if(emptyEvent){ dccHeaderWords = 2;}
-	else if(!emptyEvent){ dccHeaderWords = 7;}
-
-	for(uint32_t i = 1; i<=dccHeaderWords ; i++){
-
-		std::string header= std::string("H") + parser_->getDecString(i);
-		res = checkDataField(header,i);
-		if(!res.first){ checkErrors += res.second; (errors_["DCC::HEADER"])++; }
-	}
-	////////////////////////////////////////////////////////////////////////////
-	
-	
-	// Check event length ///////////////////////////////////////////////////////
-	res = checkDataField("EVENT LENGTH",blockSize_/8);
-	if(!res.first){ checkErrors += res.second; (errors_["DCC::EVENT LENGTH"])++; }
-	/////////////////////////////////////////////////////////////////////////////
-		
-	
-	if(!checkErrors.empty()){
-		errorString_ +="\n ======================================================================\n"; 		
-		errorString_ += std::string(" ") + name_ + std::string(" data fields checks errors : ") ;
-		errorString_ += checkErrors ;
-		errorString_ += "\n ======================================================================";
-		blockError_ = true;	
-	}
-	
-	
+  if (srpBlock_ != nullptr) {
+    delete srpBlock_;
+  }
+  if (dccTrailerBlock_ != nullptr) {
+    delete dccTrailerBlock_;
+  }
 }
 
+void DCCTBEventBlock::dataCheck() {
+  std::string checkErrors("");
 
+  // Check BOE field/////////////////////////////////////////////////////
+  std::pair<bool, std::string> res = checkDataField("BOE", BOE);
+  if (!res.first) {
+    checkErrors += res.second;
+    (errors_["DCC::HEADER"])++;
+  }
+  ///////////////////////////////////////////////////////////////////////
 
-void  DCCTBEventBlock::displayEvent(std::ostream & os){
+  // Check H Field //////////////////////////////////////////////////////
+  std::string hField = std::string("H");
+  res = checkDataField(hField, 1);
+  if (!res.first) {
+    checkErrors += res.second;
+    (errors_["DCC::HEADER"])++;
+  }
+  ////////////////////////////////////////////////////////////////////////
 
-  os << "\n\n\n\n\n >>>>>>>>>>>>>>>>>>>> Event started at word position " << std::dec << wordBufferOffset_ <<" <<<<<<<<<<<<<<<<<<<<"<<std::endl;
-  	
-	// Display DCC Header ///
-	displayData(os);
-	/////////////////////////
-		
-		
-	// Display SRP Block Contents //////////////
-	if(srpBlock_){ srpBlock_->displayData(os);}
-	////////////////////////////////////////////
-		
-		
-	// Display TCC Block Contents ///////////////////////////////
-	std::vector<DCCTBTCCBlock *>::iterator it1;
-	for( it1 = tccBlocks_.begin(); it1!= tccBlocks_.end(); it1++){
-		(*it1)->displayData(os);
-	}
-	
-	// Display Towers Blocks /////////////////////////////////////
-	std::vector<DCCTBTowerBlock *>::iterator it2;
-	for(it2 = towerBlocks_.begin();it2!=towerBlocks_.end();it2++){
-			
-		(*it2)->displayData(os);
-			
-		// Display Xtal Data /////////////////////////////////////
-		std::vector<DCCTBXtalBlock * > &xtalBlocks = (*it2)->xtalBlocks();
-		std::vector<DCCTBXtalBlock * >::iterator it3;
-		for(it3 = xtalBlocks.begin();it3!=xtalBlocks.end();it3++){
-			(*it3)->displayData(os);
-		}	
-	}
-		
-	// Display Trailer Block Contents /////////////////////////
-	if(dccTrailerBlock_){ dccTrailerBlock_->displayData(os);}
-		
+  // Check Headers //////////////////////////////////////////////////////////
+  uint32_t dccHeaderWords = 0;
+
+  if (emptyEvent) {
+    dccHeaderWords = 2;
+  } else if (!emptyEvent) {
+    dccHeaderWords = 7;
+  }
+
+  for (uint32_t i = 1; i <= dccHeaderWords; i++) {
+    std::string header = std::string("H") + parser_->getDecString(i);
+    res = checkDataField(header, i);
+    if (!res.first) {
+      checkErrors += res.second;
+      (errors_["DCC::HEADER"])++;
+    }
+  }
+  ////////////////////////////////////////////////////////////////////////////
+
+  // Check event length ///////////////////////////////////////////////////////
+  res = checkDataField("EVENT LENGTH", blockSize_ / 8);
+  if (!res.first) {
+    checkErrors += res.second;
+    (errors_["DCC::EVENT LENGTH"])++;
+  }
+  /////////////////////////////////////////////////////////////////////////////
+
+  if (!checkErrors.empty()) {
+    errorString_ += "\n ======================================================================\n";
+    errorString_ += std::string(" ") + name_ + std::string(" data fields checks errors : ");
+    errorString_ += checkErrors;
+    errorString_ += "\n ======================================================================";
+    blockError_ = true;
+  }
 }
 
+void DCCTBEventBlock::displayEvent(std::ostream &os) {
+  os << "\n\n\n\n\n >>>>>>>>>>>>>>>>>>>> Event started at word position " << std::dec << wordBufferOffset_
+     << " <<<<<<<<<<<<<<<<<<<<" << std::endl;
 
-std::pair<bool,std::string> DCCTBEventBlock::compare(DCCTBEventBlock * block){
-	
-	// DCC Header comparision /////////////////////////////// 
-	std::pair<bool,std::string> ret(DCCTBBlockPrototype::compare(block));
-	/////////////////////////////////////////////////////////
-	
-	  std::stringstream out;
-	
-	// Selective readout processor block comparision ////////////////////////////////////////////
-	if( srpBlock_ && block->srpBlock() ){ 
-		std::pair<bool,std::string> temp( srpBlock_->compare(block->srpBlock()));
-		ret.first   = ret.first & temp.first;
-		out<<temp.second; 
-	}else if( !srpBlock_ && block->srpBlock() ){
-		ret.first   = false;	
-		out<<"\n ====================================================================="
-		   <<"\n ERROR SR block identified in the ORIGINAL BLOCK ... "
-		   <<"\n ... but the block is not present in the COMPARISION BLOCK !" 
-		   <<"\n =====================================================================";
-	}else if( srpBlock_ && !(block->srpBlock()) ){
-		ret.first   = false;	
-		out<<"\n ====================================================================="
-		   <<"\n ERROR SR block identified in the COMPARISION BLOCK ... "
-		   <<"\n ... but the block is not present in the ORIGINAL BLOCK !" 
-		   <<"\n =====================================================================";
-	}
-	////////////////////////////////////////////////////////////////////////////////////////////
-	
-	
-	
-	// TCC Blocks comparision ////////////////////////////////////////////////////////
-	// check number of TCC blocks 
-	int numbTccBlocks_a = tccBlocks_.size();
-	int numbTccBlocks_b = block->tccBlocks().size();
-	
-	if( numbTccBlocks_a != numbTccBlocks_b ){
-		ret.first = false;
-		out<<"\n ====================================================================="
-		   <<"\n ERROR number of TCC blocks in the ORIGINAL BLOCK( ="<<numbTccBlocks_a<<" )"
-		   <<"\n and in the COMPARISION BLOCK( = "<<numbTccBlocks_b<<" is different !"
-		   <<"\n =====================================================================";
-	}
-	
-	std::vector<DCCTBTCCBlock *>::iterator it1Tcc    = tccBlocks_.begin();
-	std::vector<DCCTBTCCBlock *>::iterator it1TccEnd = tccBlocks_.end();
-	std::vector<DCCTBTCCBlock *>::iterator it2Tcc    = block->tccBlocks().begin();
-	std::vector<DCCTBTCCBlock *>::iterator it2TccEnd = block->tccBlocks().end();
-	
-	for( ; it1Tcc!=it1TccEnd && it2Tcc!=it2TccEnd; it1Tcc++, it2Tcc++){
-		std::pair<bool,std::string> temp( (*it1Tcc)->compare( *it2Tcc ) );
-		ret.first   = ret.first & temp.first;
-		out<<temp.second; 
-	}
-	//////////////////////////////////////////////////////////////////////////////////
-	
-	
-	// FE Blocks comparision ////////////////////////////////////////////////////////
-	// check number of FE blocks 
-	int numbTowerBlocks_a = towerBlocks_.size();
-	int numbTowerBlocks_b = block->towerBlocks().size();
-	
-	if( numbTowerBlocks_a != numbTowerBlocks_b ){
-		ret.first = false;
-		out<<"\n ====================================================================="
-		   <<"\n ERROR number of Tower blocks in the ORIGINAL BLOCK( ="<<numbTowerBlocks_a<<" )"
-		   <<"\n and in the COMPARISION BLOCK( = "<<numbTowerBlocks_b<<" is different !"
-		   <<"\n =====================================================================";
-	}
-	
-	std::vector<DCCTBTowerBlock *>::iterator it1Tower    = towerBlocks_.begin();
-	std::vector<DCCTBTowerBlock *>::iterator it1TowerEnd  = towerBlocks_.end();
-	std::vector<DCCTBTowerBlock *>::iterator it2Tower    = (block->towerBlocks()).begin();
-	std::vector<DCCTBTowerBlock *>::iterator it2TowerEnd = (block->towerBlocks()).end();
-	
-	for( ; it1Tower!=it1TowerEnd && it2Tower!=it2TowerEnd; it1Tower++, it2Tower++){
-		
-		std::pair<bool,std::string> temp( (*it1Tower)->compare( *it2Tower ) );
-		ret.first   = ret.first & temp.first;
-		out<<temp.second;
+  // Display DCC Header ///
+  displayData(os);
+  /////////////////////////
 
-		// Xtal Block comparision ////////////////////////////
-		std::vector<DCCTBXtalBlock *> xtalBlocks1( (*it1Tower)->xtalBlocks());
-		std::vector<DCCTBXtalBlock *> xtalBlocks2( (*it2Tower)->xtalBlocks());
-		// check number of xtal blocks 
-    	int numbXtalBlocks_a = xtalBlocks1.size();
-		int numbXtalBlocks_b = xtalBlocks2.size();
-	
-		if( numbXtalBlocks_a != numbXtalBlocks_b ){
-			ret.first = false;
-			out<<"\n ====================================================================="
-			   <<"\n ERROR number of Xtal blocks in this TOWER ORIGINAL BLOCK( ="<<numbXtalBlocks_a<<" )"
-		  	   <<"\n and in the TOWER COMPARISION BLOCK( = "<<numbXtalBlocks_b<<" is different !"
-		  	   <<"\n =====================================================================";
-		}
-		
-		std::vector<DCCTBXtalBlock *>::iterator it1Xtal    = xtalBlocks1.begin();
-		std::vector<DCCTBXtalBlock *>::iterator it1XtalEnd = xtalBlocks1.end();
-		std::vector<DCCTBXtalBlock *>::iterator it2Xtal    = xtalBlocks1.begin();
-		std::vector<DCCTBXtalBlock *>::iterator it2XtalEnd = xtalBlocks2.end();
-		
-		for( ; it1Xtal!=it1XtalEnd && it2Xtal!=it2XtalEnd; it1Xtal++, it2Xtal++){
-			std::pair<bool,std::string> temp( (*it1Xtal)->compare( *it2Xtal ) );
-			ret.first   = ret.first & temp.first;
-			out<<temp.second; 
-		}
-		
-	}
-	
-	
-	// Trailer block comparision ////////////////////////////////////////////
-	if(  block->trailerBlock() && trailerBlock() ){ 
-		std::pair<bool,std::string> temp( trailerBlock()->compare(block->trailerBlock()));
-		ret.first   = ret.first & temp.first;
-		out<<temp.second; 
-	}
-	
-	ret.second += out.str(); 
+  // Display SRP Block Contents //////////////
+  if (srpBlock_) {
+    srpBlock_->displayData(os);
+  }
+  ////////////////////////////////////////////
 
-	return ret;
-}
-			
-		
-		
-		
-		
-		
-		
-		
+  // Display TCC Block Contents ///////////////////////////////
+  std::vector<DCCTBTCCBlock *>::iterator it1;
+  for (it1 = tccBlocks_.begin(); it1 != tccBlocks_.end(); it1++) {
+    (*it1)->displayData(os);
+  }
 
-bool DCCTBEventBlock::eventHasErrors(){
-	
-	bool ret(false);
-	ret = blockError() ;
-	
+  // Display Towers Blocks /////////////////////////////////////
+  std::vector<DCCTBTowerBlock *>::iterator it2;
+  for (it2 = towerBlocks_.begin(); it2 != towerBlocks_.end(); it2++) {
+    (*it2)->displayData(os);
 
-	// See if we have errors in the  TCC Block Contents ///////////////////////////////
-	std::vector<DCCTBTCCBlock *>::iterator it1;
-	for( it1 = tccBlocks_.begin(); it1!= tccBlocks_.end(); it1++){
-		ret |= (*it1)->blockError();
-	}
-	/////////////////////////////////////////////////////////////		
+    // Display Xtal Data /////////////////////////////////////
+    std::vector<DCCTBXtalBlock *> &xtalBlocks = (*it2)->xtalBlocks();
+    std::vector<DCCTBXtalBlock *>::iterator it3;
+    for (it3 = xtalBlocks.begin(); it3 != xtalBlocks.end(); it3++) {
+      (*it3)->displayData(os);
+    }
+  }
 
-	// See if we have errors in the SRP Block /////////
-	if(srpBlock_){  ret |= srpBlock_->blockError(); }
-	////////////////////////////////////////////////////
-
-	
-	// See if we have errors in the Trigger Blocks ///////////////
-	std::vector<DCCTBTowerBlock *>::iterator it2;
-	for(it2 = towerBlocks_.begin();it2!=towerBlocks_.end();it2++){
-			
-		ret |= (*it2)->blockError();
-			
-		// See if we have errors in the Xtal Data /////////////////
-		std::vector<DCCTBXtalBlock * > & xtalBlocks = (*it2)->xtalBlocks();
-		std::vector<DCCTBXtalBlock * >::iterator it3;
-		for(it3 = xtalBlocks.begin();it3!=xtalBlocks.end();it3++){
-			ret |= (*it3)->blockError();
-		}
-		////////////////////////////////////////////////////////////
-	}
-	///////////////////////////////////////////////////////////////
-	
-		
-	// See if we have errors in the  trailler ///////////////////
-	if(dccTrailerBlock_){ ret |= dccTrailerBlock_->blockError();}
-	/////////////////////////////////////////////////////////////
-	
-	
-	return ret;
-	
+  // Display Trailer Block Contents /////////////////////////
+  if (dccTrailerBlock_) {
+    dccTrailerBlock_->displayData(os);
+  }
 }
 
+std::pair<bool, std::string> DCCTBEventBlock::compare(DCCTBEventBlock *block) {
+  // DCC Header comparision ///////////////////////////////
+  std::pair<bool, std::string> ret(DCCTBBlockPrototype::compare(block));
+  /////////////////////////////////////////////////////////
 
-std::string DCCTBEventBlock::eventErrorString(){
-	
-	std::string ret("");
-	
-	if( eventHasErrors() ){
-		
-		
-		ret +="\n ======================================================================\n"; 		
-		ret += std::string(" Event Erros occurred for L1A ( decoded value ) = ") ; 
-		ret += parser_->getDecString(getDataField("LV1"));
-		ret += "\n ======================================================================";
-		
-	
-		ret += errorString();
-	
-		// TODO ::
-		// See if we have errors in the  TCC Block Contents /////////////
-		std::vector<DCCTBTCCBlock *>::iterator it1;
-		for( it1 = tccBlocks_.begin(); it1!= tccBlocks_.end(); it1++){
-			ret += (*it1)->errorString();
-		}
-		/////////////////////////////////////////////////////////////////
-		// See if we have errors in the SRP Block ////
-		 if(srpBlock_){  ret += srpBlock_->errorString(); }
-		/////////////////////////////////////////////////////////////////
-	
-	
-		// See if we have errors in the Tower Blocks ///////////////////////////////////////////////////
-		std::vector<DCCTBTowerBlock *>::iterator it2;
-		
-		for(it2 = towerBlocks_.begin();it2!=towerBlocks_.end();it2++){
-			
-			ret += (*it2)->errorString();
-			
-			// See if we have errors in the Xtal Data /////////////////
-			std::vector<DCCTBXtalBlock * > & xtalBlocks = (*it2)->xtalBlocks();
-			std::vector<DCCTBXtalBlock * >::iterator it3;
-		
-		
-			std::string temp;
-			for(it3 = xtalBlocks.begin();it3!=xtalBlocks.end();it3++){ temp += (*it3)->errorString();}
-		
-			if(!temp.empty()){
-				ret += "\n Fine grain data Errors found ...";
-				ret += "\n(  Tower ID = " + parser_->getDecString( (*it2)->getDataField("TT/SC ID"));
-				ret += ", LV1 = " + parser_->getDecString( (*it2)->getDataField("LV1"));
-				ret += ", BX = " + parser_->getDecString( (*it2)->getDataField("BX")) + " )";
-				ret += temp;
-			}
-			////////////////////////////////////////////////////////////
-			
-		}
-	
-		
-		// See if we have errors in the  trailler ////////////////////
-		if(dccTrailerBlock_){ ret += dccTrailerBlock_->errorString();}
-		//////////////////////////////////////////////////////////////
-	
-	}
-	
-	return ret;
-	
+  std::stringstream out;
+
+  // Selective readout processor block comparision ////////////////////////////////////////////
+  if (srpBlock_ && block->srpBlock()) {
+    std::pair<bool, std::string> temp(srpBlock_->compare(block->srpBlock()));
+    ret.first = ret.first & temp.first;
+    out << temp.second;
+  } else if (!srpBlock_ && block->srpBlock()) {
+    ret.first = false;
+    out << "\n ====================================================================="
+        << "\n ERROR SR block identified in the ORIGINAL BLOCK ... "
+        << "\n ... but the block is not present in the COMPARISION BLOCK !"
+        << "\n =====================================================================";
+  } else if (srpBlock_ && !(block->srpBlock())) {
+    ret.first = false;
+    out << "\n ====================================================================="
+        << "\n ERROR SR block identified in the COMPARISION BLOCK ... "
+        << "\n ... but the block is not present in the ORIGINAL BLOCK !"
+        << "\n =====================================================================";
+  }
+  ////////////////////////////////////////////////////////////////////////////////////////////
+
+  // TCC Blocks comparision ////////////////////////////////////////////////////////
+  // check number of TCC blocks
+  int numbTccBlocks_a = tccBlocks_.size();
+  int numbTccBlocks_b = block->tccBlocks().size();
+
+  if (numbTccBlocks_a != numbTccBlocks_b) {
+    ret.first = false;
+    out << "\n ====================================================================="
+        << "\n ERROR number of TCC blocks in the ORIGINAL BLOCK( =" << numbTccBlocks_a << " )"
+        << "\n and in the COMPARISION BLOCK( = " << numbTccBlocks_b << " is different !"
+        << "\n =====================================================================";
+  }
+
+  std::vector<DCCTBTCCBlock *>::iterator it1Tcc = tccBlocks_.begin();
+  std::vector<DCCTBTCCBlock *>::iterator it1TccEnd = tccBlocks_.end();
+  std::vector<DCCTBTCCBlock *>::iterator it2Tcc = block->tccBlocks().begin();
+  std::vector<DCCTBTCCBlock *>::iterator it2TccEnd = block->tccBlocks().end();
+
+  for (; it1Tcc != it1TccEnd && it2Tcc != it2TccEnd; it1Tcc++, it2Tcc++) {
+    std::pair<bool, std::string> temp((*it1Tcc)->compare(*it2Tcc));
+    ret.first = ret.first & temp.first;
+    out << temp.second;
+  }
+  //////////////////////////////////////////////////////////////////////////////////
+
+  // FE Blocks comparision ////////////////////////////////////////////////////////
+  // check number of FE blocks
+  int numbTowerBlocks_a = towerBlocks_.size();
+  int numbTowerBlocks_b = block->towerBlocks().size();
+
+  if (numbTowerBlocks_a != numbTowerBlocks_b) {
+    ret.first = false;
+    out << "\n ====================================================================="
+        << "\n ERROR number of Tower blocks in the ORIGINAL BLOCK( =" << numbTowerBlocks_a << " )"
+        << "\n and in the COMPARISION BLOCK( = " << numbTowerBlocks_b << " is different !"
+        << "\n =====================================================================";
+  }
+
+  std::vector<DCCTBTowerBlock *>::iterator it1Tower = towerBlocks_.begin();
+  std::vector<DCCTBTowerBlock *>::iterator it1TowerEnd = towerBlocks_.end();
+  std::vector<DCCTBTowerBlock *>::iterator it2Tower = (block->towerBlocks()).begin();
+  std::vector<DCCTBTowerBlock *>::iterator it2TowerEnd = (block->towerBlocks()).end();
+
+  for (; it1Tower != it1TowerEnd && it2Tower != it2TowerEnd; it1Tower++, it2Tower++) {
+    std::pair<bool, std::string> temp((*it1Tower)->compare(*it2Tower));
+    ret.first = ret.first & temp.first;
+    out << temp.second;
+
+    // Xtal Block comparision ////////////////////////////
+    std::vector<DCCTBXtalBlock *> xtalBlocks1((*it1Tower)->xtalBlocks());
+    std::vector<DCCTBXtalBlock *> xtalBlocks2((*it2Tower)->xtalBlocks());
+    // check number of xtal blocks
+    int numbXtalBlocks_a = xtalBlocks1.size();
+    int numbXtalBlocks_b = xtalBlocks2.size();
+
+    if (numbXtalBlocks_a != numbXtalBlocks_b) {
+      ret.first = false;
+      out << "\n ====================================================================="
+          << "\n ERROR number of Xtal blocks in this TOWER ORIGINAL BLOCK( =" << numbXtalBlocks_a << " )"
+          << "\n and in the TOWER COMPARISION BLOCK( = " << numbXtalBlocks_b << " is different !"
+          << "\n =====================================================================";
+    }
+
+    std::vector<DCCTBXtalBlock *>::iterator it1Xtal = xtalBlocks1.begin();
+    std::vector<DCCTBXtalBlock *>::iterator it1XtalEnd = xtalBlocks1.end();
+    std::vector<DCCTBXtalBlock *>::iterator it2Xtal = xtalBlocks1.begin();
+    std::vector<DCCTBXtalBlock *>::iterator it2XtalEnd = xtalBlocks2.end();
+
+    for (; it1Xtal != it1XtalEnd && it2Xtal != it2XtalEnd; it1Xtal++, it2Xtal++) {
+      std::pair<bool, std::string> temp((*it1Xtal)->compare(*it2Xtal));
+      ret.first = ret.first & temp.first;
+      out << temp.second;
+    }
+  }
+
+  // Trailer block comparision ////////////////////////////////////////////
+  if (block->trailerBlock() && trailerBlock()) {
+    std::pair<bool, std::string> temp(trailerBlock()->compare(block->trailerBlock()));
+    ret.first = ret.first & temp.first;
+    out << temp.second;
+  }
+
+  ret.second += out.str();
+
+  return ret;
 }
 
+bool DCCTBEventBlock::eventHasErrors() {
+  bool ret(false);
+  ret = blockError();
 
+  // See if we have errors in the  TCC Block Contents ///////////////////////////////
+  std::vector<DCCTBTCCBlock *>::iterator it1;
+  for (it1 = tccBlocks_.begin(); it1 != tccBlocks_.end(); it1++) {
+    ret |= (*it1)->blockError();
+  }
+  /////////////////////////////////////////////////////////////
 
+  // See if we have errors in the SRP Block /////////
+  if (srpBlock_) {
+    ret |= srpBlock_->blockError();
+  }
+  ////////////////////////////////////////////////////
 
-std::vector< DCCTBTowerBlock * > DCCTBEventBlock::towerBlocksById(uint32_t towerId){
-	std::vector<DCCTBTowerBlock *> myVector;	
-	std::vector<DCCTBTowerBlock *>::iterator it;
-	
-	for( it = towerBlocks_.begin(); it!= towerBlocks_.end(); it++ ){
-		try{
-			
-			std::pair<bool,std::string> idCheck   = (*it)->checkDataField("TT/SC ID",towerId);
-			
-			if(idCheck.first ){ myVector.push_back( (*it) ); }
-		}catch (ECALTBParserBlockException &e){/*ignore*/}
-	}
-	
-	return myVector;
+  // See if we have errors in the Trigger Blocks ///////////////
+  std::vector<DCCTBTowerBlock *>::iterator it2;
+  for (it2 = towerBlocks_.begin(); it2 != towerBlocks_.end(); it2++) {
+    ret |= (*it2)->blockError();
+
+    // See if we have errors in the Xtal Data /////////////////
+    std::vector<DCCTBXtalBlock *> &xtalBlocks = (*it2)->xtalBlocks();
+    std::vector<DCCTBXtalBlock *>::iterator it3;
+    for (it3 = xtalBlocks.begin(); it3 != xtalBlocks.end(); it3++) {
+      ret |= (*it3)->blockError();
+    }
+    ////////////////////////////////////////////////////////////
+  }
+  ///////////////////////////////////////////////////////////////
+
+  // See if we have errors in the  trailler ///////////////////
+  if (dccTrailerBlock_) {
+    ret |= dccTrailerBlock_->blockError();
+  }
+  /////////////////////////////////////////////////////////////
+
+  return ret;
+}
+
+std::string DCCTBEventBlock::eventErrorString() {
+  std::string ret("");
+
+  if (eventHasErrors()) {
+    ret += "\n ======================================================================\n";
+    ret += std::string(" Event Erros occurred for L1A ( decoded value ) = ");
+    ret += parser_->getDecString(getDataField("LV1"));
+    ret += "\n ======================================================================";
+
+    ret += errorString();
+
+    // TODO ::
+    // See if we have errors in the  TCC Block Contents /////////////
+    std::vector<DCCTBTCCBlock *>::iterator it1;
+    for (it1 = tccBlocks_.begin(); it1 != tccBlocks_.end(); it1++) {
+      ret += (*it1)->errorString();
+    }
+    /////////////////////////////////////////////////////////////////
+    // See if we have errors in the SRP Block ////
+    if (srpBlock_) {
+      ret += srpBlock_->errorString();
+    }
+    /////////////////////////////////////////////////////////////////
+
+    // See if we have errors in the Tower Blocks ///////////////////////////////////////////////////
+    std::vector<DCCTBTowerBlock *>::iterator it2;
+
+    for (it2 = towerBlocks_.begin(); it2 != towerBlocks_.end(); it2++) {
+      ret += (*it2)->errorString();
+
+      // See if we have errors in the Xtal Data /////////////////
+      std::vector<DCCTBXtalBlock *> &xtalBlocks = (*it2)->xtalBlocks();
+      std::vector<DCCTBXtalBlock *>::iterator it3;
+
+      std::string temp;
+      for (it3 = xtalBlocks.begin(); it3 != xtalBlocks.end(); it3++) {
+        temp += (*it3)->errorString();
+      }
+
+      if (!temp.empty()) {
+        ret += "\n Fine grain data Errors found ...";
+        ret += "\n(  Tower ID = " + parser_->getDecString((*it2)->getDataField("TT/SC ID"));
+        ret += ", LV1 = " + parser_->getDecString((*it2)->getDataField("LV1"));
+        ret += ", BX = " + parser_->getDecString((*it2)->getDataField("BX")) + " )";
+        ret += temp;
+      }
+      ////////////////////////////////////////////////////////////
+    }
+
+    // See if we have errors in the  trailler ////////////////////
+    if (dccTrailerBlock_) {
+      ret += dccTrailerBlock_->errorString();
+    }
+    //////////////////////////////////////////////////////////////
+  }
+
+  return ret;
+}
+
+std::vector<DCCTBTowerBlock *> DCCTBEventBlock::towerBlocksById(uint32_t towerId) {
+  std::vector<DCCTBTowerBlock *> myVector;
+  std::vector<DCCTBTowerBlock *>::iterator it;
+
+  for (it = towerBlocks_.begin(); it != towerBlocks_.end(); it++) {
+    try {
+      std::pair<bool, std::string> idCheck = (*it)->checkDataField("TT/SC ID", towerId);
+
+      if (idCheck.first) {
+        myVector.push_back((*it));
+      }
+    } catch (ECALTBParserBlockException &e) { /*ignore*/
+    }
+  }
+
+  return myVector;
 }

--- a/EventFilter/EcalTBRawToDigi/src/DCCEventBlock.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCEventBlock.h
@@ -5,7 +5,6 @@
 #ifndef DCCTBEVENTBLOCK_HH
 #define DCCTBEVENTBLOCK_HH
 
-
 #include "DCCBlockPrototype.h"
 
 class DCCTBTowerBlock;
@@ -15,73 +14,65 @@ class DCCTBTCCBlock;
 class DCCTBSRPBlock;
 
 class DCCTBEventBlock : public DCCTBBlockPrototype {
-	
-	public :
-		
-		DCCTBEventBlock(
-			DCCTBDataParser * parser, 
-			const uint32_t * buffer, 
-			uint32_t numbBytes, 
-			uint32_t wordsToEnd, 
-			uint32_t wordBufferOffset = 0 , 
-			uint32_t wordEventOffset = 0 
-		);
-		
-		~DCCTBEventBlock() override;
-		
-		void dataCheck(); 
-		
-		std::vector< DCCTBTowerBlock * > & towerBlocks();
-		std::vector< DCCTBTCCBlock *   > & tccBlocks();
-		DCCTBSRPBlock               * srpBlock();
-		DCCTBTrailerBlock           * trailerBlock();
-		std::vector< DCCTBTowerBlock * >   towerBlocksById(uint32_t towerId);
-		using DCCTBBlockPrototype::compare;
-		std::pair<bool,std::string> compare(DCCTBEventBlock * );
+public:
+  DCCTBEventBlock(DCCTBDataParser* parser,
+                  const uint32_t* buffer,
+                  uint32_t numbBytes,
+                  uint32_t wordsToEnd,
+                  uint32_t wordBufferOffset = 0,
+                  uint32_t wordEventOffset = 0);
 
-		bool eventHasErrors();
-		std::string eventErrorString();
-		void displayEvent(std::ostream & os=std::cout);
-	
-		
-	protected :
-		enum dccFields{ 
-			
-			PHYSICTRIGGER        = 1,
-			CALIBRATIONTRIGGER   = 2,
-			TESTTRIGGER          = 3,
-			TECHNICALTRIGGER     = 4,
-			
-			CH_ENABLED           = 0,
-			CH_DISABLED          = 1,
-			CH_TIMEOUT           = 2,
-			CH_SUPPRESS          = 7,
-			
-			SR_NREAD              = 0,
-			
-		
-			BOE                  = 0x5, 
-			
-			DCCERROR_EMPTYEVENT  = 0x1, 
-			
-			TOWERHEADER_SIZE     = 8, 
-			TRAILER_SIZE         = 8
-	
-		
-		};		
+  ~DCCTBEventBlock() override;
 
-		std::vector< DCCTBTowerBlock * > towerBlocks_      ;
-		std::vector< DCCTBTCCBlock   * > tccBlocks_        ;
-		DCCTBTrailerBlock       *   dccTrailerBlock_  ;
-		DCCTBSRPBlock           *   srpBlock_;
-		uint32_t wordBufferOffset_;
-		bool emptyEvent;
+  void dataCheck();
+
+  std::vector<DCCTBTowerBlock*>& towerBlocks();
+  std::vector<DCCTBTCCBlock*>& tccBlocks();
+  DCCTBSRPBlock* srpBlock();
+  DCCTBTrailerBlock* trailerBlock();
+  std::vector<DCCTBTowerBlock*> towerBlocksById(uint32_t towerId);
+  using DCCTBBlockPrototype::compare;
+  std::pair<bool, std::string> compare(DCCTBEventBlock*);
+
+  bool eventHasErrors();
+  std::string eventErrorString();
+  void displayEvent(std::ostream& os = std::cout);
+
+protected:
+  enum dccFields {
+
+    PHYSICTRIGGER = 1,
+    CALIBRATIONTRIGGER = 2,
+    TESTTRIGGER = 3,
+    TECHNICALTRIGGER = 4,
+
+    CH_ENABLED = 0,
+    CH_DISABLED = 1,
+    CH_TIMEOUT = 2,
+    CH_SUPPRESS = 7,
+
+    SR_NREAD = 0,
+
+    BOE = 0x5,
+
+    DCCERROR_EMPTYEVENT = 0x1,
+
+    TOWERHEADER_SIZE = 8,
+    TRAILER_SIZE = 8
+
+  };
+
+  std::vector<DCCTBTowerBlock*> towerBlocks_;
+  std::vector<DCCTBTCCBlock*> tccBlocks_;
+  DCCTBTrailerBlock* dccTrailerBlock_;
+  DCCTBSRPBlock* srpBlock_;
+  uint32_t wordBufferOffset_;
+  bool emptyEvent;
 };
 
-
-inline std::vector< DCCTBTowerBlock * > & DCCTBEventBlock::towerBlocks()  { return towerBlocks_;     }
-inline std::vector< DCCTBTCCBlock * >   & DCCTBEventBlock::tccBlocks()    { return tccBlocks_;       }
-inline DCCTBSRPBlock               * DCCTBEventBlock::srpBlock()     { return srpBlock_;        }
-inline DCCTBTrailerBlock           * DCCTBEventBlock::trailerBlock() { return dccTrailerBlock_; }
+inline std::vector<DCCTBTowerBlock*>& DCCTBEventBlock::towerBlocks() { return towerBlocks_; }
+inline std::vector<DCCTBTCCBlock*>& DCCTBEventBlock::tccBlocks() { return tccBlocks_; }
+inline DCCTBSRPBlock* DCCTBEventBlock::srpBlock() { return srpBlock_; }
+inline DCCTBTrailerBlock* DCCTBEventBlock::trailerBlock() { return dccTrailerBlock_; }
 
 #endif

--- a/EventFilter/EcalTBRawToDigi/src/DCCSRPBlock.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCSRPBlock.cc
@@ -3,77 +3,78 @@
 #include "DCCDataMapper.h"
 #include "DCCEventBlock.h"
 
-DCCTBSRPBlock::DCCTBSRPBlock(
-	DCCTBEventBlock * dccBlock,
-	DCCTBDataParser * parser, 
-	const uint32_t * buffer, 
-	uint32_t numbBytes,
-	uint32_t wordsToEnd,
-	uint32_t wordEventOffset
-) : DCCTBBlockPrototype(parser,"SRP", buffer, numbBytes,wordsToEnd,wordEventOffset), dccBlock_(dccBlock){
-	
-	//Reset error counters ///////
-	errors_["SRP::HEADER"]  = 0;
-	errors_["SRP::BLOCKID"] = 0;
-	//////////////////////////////
-	
-	// Get data fields from the mapper and retrieve data /////////////////////////////////////
-	     if( parser_->numbSRF() == 68){ mapperFields_ = parser_->mapper()->srp68Fields();}
-	else if( parser_->numbSRF() == 32){ mapperFields_ = parser_->mapper()->srp32Fields();}	
-	else if( parser_->numbSRF() == 16){ mapperFields_ = parser_->mapper()->srp16Fields();}
-	parseData();
-	//////////////////////////////////////////////////////////////////////////////////////////
-	
-	// check internal data ////////////
-	if(parser_->debug()){ dataCheck();}
-	///////////////////////////////////
+DCCTBSRPBlock::DCCTBSRPBlock(DCCTBEventBlock* dccBlock,
+                             DCCTBDataParser* parser,
+                             const uint32_t* buffer,
+                             uint32_t numbBytes,
+                             uint32_t wordsToEnd,
+                             uint32_t wordEventOffset)
+    : DCCTBBlockPrototype(parser, "SRP", buffer, numbBytes, wordsToEnd, wordEventOffset), dccBlock_(dccBlock) {
+  //Reset error counters ///////
+  errors_["SRP::HEADER"] = 0;
+  errors_["SRP::BLOCKID"] = 0;
+  //////////////////////////////
 
+  // Get data fields from the mapper and retrieve data /////////////////////////////////////
+  if (parser_->numbSRF() == 68) {
+    mapperFields_ = parser_->mapper()->srp68Fields();
+  } else if (parser_->numbSRF() == 32) {
+    mapperFields_ = parser_->mapper()->srp32Fields();
+  } else if (parser_->numbSRF() == 16) {
+    mapperFields_ = parser_->mapper()->srp16Fields();
+  }
+  parseData();
+  //////////////////////////////////////////////////////////////////////////////////////////
+
+  // check internal data ////////////
+  if (parser_->debug()) {
+    dataCheck();
+  }
+  ///////////////////////////////////
 }
 
+void DCCTBSRPBlock::dataCheck() {
+  std::string checkErrors("");
 
+  std::pair<bool, std::string> res;
 
-void DCCTBSRPBlock::dataCheck(){ 
-	
-	std::string checkErrors("");
+  res = checkDataField("BX", BXMASK & (dccBlock_->getDataField("BX")));
+  if (!res.first) {
+    checkErrors += res.second;
+    (errors_["SRP::HEADER"])++;
+  }
+  res = checkDataField("LV1", L1MASK & (dccBlock_->getDataField("LV1")));
+  if (!res.first) {
+    checkErrors += res.second;
+    (errors_["SRP::HEADER"])++;
+  }
 
-	std::pair <bool,std::string> res;
-	
-	res = checkDataField("BX", BXMASK & (dccBlock_->getDataField("BX")));
-	if(!res.first){ checkErrors += res.second; (errors_["SRP::HEADER"])++; }
-	res = checkDataField("LV1", L1MASK & (dccBlock_->getDataField("LV1"))); 
-	if(!res.first){ checkErrors += res.second; (errors_["SRP::HEADER"])++; }
-	
-	 
-	res = checkDataField("SRP ID",parser_->srpId()); 
-	if(!res.first){ checkErrors += res.second; (errors_["SRP::HEADER"])++; } 
-	
-	
-	if(!checkErrors.empty()){
-		errorString_ +="\n ======================================================================\n"; 		
-		errorString_ += std::string(" ") + name_ + std::string(" data fields checks errors : ") ;
-		errorString_ += checkErrors ;
-		errorString_ += "\n ======================================================================";
-		blockError_ = true;	
-	}
-	
-	
+  res = checkDataField("SRP ID", parser_->srpId());
+  if (!res.first) {
+    checkErrors += res.second;
+    (errors_["SRP::HEADER"])++;
+  }
+
+  if (!checkErrors.empty()) {
+    errorString_ += "\n ======================================================================\n";
+    errorString_ += std::string(" ") + name_ + std::string(" data fields checks errors : ");
+    errorString_ += checkErrors;
+    errorString_ += "\n ======================================================================";
+    blockError_ = true;
+  }
 }
 
-
-void  DCCTBSRPBlock::increment(uint32_t numb){
-	if(!parser_->debug()){ DCCTBBlockPrototype::increment(numb); }
-	else {
-		for(uint32_t counter=0; counter<numb; counter++, dataP_++,wordCounter_++){
-			uint32_t blockID = (*dataP_)>>BPOSITION_BLOCKID;
-			if( blockID != BLOCKID ){
-				(errors_["SRP::BLOCKID"])++;
-				//errorString_ += std::string("\n") + parser_->index(nunb)+(" blockId has value ") + parser_->getDecString(blockID);
-				//errorString  += std::string(", while ")+parser_->getDecString(BLOCKID)+std::string(" is expected");
-			}
-		}
-	}
-	
-	
+void DCCTBSRPBlock::increment(uint32_t numb) {
+  if (!parser_->debug()) {
+    DCCTBBlockPrototype::increment(numb);
+  } else {
+    for (uint32_t counter = 0; counter < numb; counter++, dataP_++, wordCounter_++) {
+      uint32_t blockID = (*dataP_) >> BPOSITION_BLOCKID;
+      if (blockID != BLOCKID) {
+        (errors_["SRP::BLOCKID"])++;
+        //errorString_ += std::string("\n") + parser_->index(nunb)+(" blockId has value ") + parser_->getDecString(blockID);
+        //errorString  += std::string(", while ")+parser_->getDecString(BLOCKID)+std::string(" is expected");
+      }
+    }
+  }
 }
-
-

--- a/EventFilter/EcalTBRawToDigi/src/DCCSRPBlock.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCSRPBlock.cc
@@ -48,7 +48,7 @@ void DCCTBSRPBlock::dataCheck(){
 	if(!res.first){ checkErrors += res.second; (errors_["SRP::HEADER"])++; } 
 	
 	
-	if(checkErrors!=""){
+	if(!checkErrors.empty()){
 		errorString_ +="\n ======================================================================\n"; 		
 		errorString_ += std::string(" ") + name_ + std::string(" data fields checks errors : ") ;
 		errorString_ += checkErrors ;

--- a/EventFilter/EcalTBRawToDigi/src/DCCSRPBlock.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCSRPBlock.h
@@ -1,7 +1,6 @@
 // Date   : 30/05/2005
 // Author : N.Almeida (LIP)
 
-
 #ifndef DCCTBSRPBLOCK_HH
 #define DCCTBSRPBLOCK_HH
 
@@ -11,7 +10,6 @@
 #include <map>
 #include <utility>
 
-
 #include "DCCBlockPrototype.h"
 
 class DCCTBEventBlock;
@@ -19,37 +17,22 @@ class DCCTBXtalBlock;
 class DCCTBDataParser;
 
 class DCCTBSRPBlock : public DCCTBBlockPrototype {
-	
-	public :
-		
-		DCCTBSRPBlock(
-			DCCTBEventBlock * dccBlock,
-			DCCTBDataParser * parser, 
-			const uint32_t * buffer, 
-			uint32_t numbBytes,
-			uint32_t wordsToEnd, 
-			uint32_t wordEventOffset
-		);
-	
-		
-		
-	protected :
-		
-		void dataCheck();
-		using DCCTBBlockPrototype::increment;
-		void  increment(uint32_t numb);
-		
-		enum srpFields{ 
-			BXMASK = 0xFFF,
-			L1MASK = 0xFFF, 
-			BPOSITION_BLOCKID = 29,
-			BLOCKID = 4
-		};
-	
-		DCCTBEventBlock * dccBlock_;
-		
-		
-		
+public:
+  DCCTBSRPBlock(DCCTBEventBlock* dccBlock,
+                DCCTBDataParser* parser,
+                const uint32_t* buffer,
+                uint32_t numbBytes,
+                uint32_t wordsToEnd,
+                uint32_t wordEventOffset);
+
+protected:
+  void dataCheck();
+  using DCCTBBlockPrototype::increment;
+  void increment(uint32_t numb);
+
+  enum srpFields { BXMASK = 0xFFF, L1MASK = 0xFFF, BPOSITION_BLOCKID = 29, BLOCKID = 4 };
+
+  DCCTBEventBlock* dccBlock_;
 };
 
 #endif

--- a/EventFilter/EcalTBRawToDigi/src/DCCTCCBlock.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCTCCBlock.cc
@@ -10,130 +10,118 @@
 /* DCCTBTCCBlock::DCCTBTCCBlock                        */
 /* class constructor                               */
 /*-------------------------------------------------*/
-DCCTBTCCBlock::DCCTBTCCBlock(
-	DCCTBEventBlock * dccBlock,
-	DCCTBDataParser * parser, 
-	const uint32_t * buffer, 
-	uint32_t numbBytes,  
-	uint32_t wordsToEnd,
-	uint32_t wordEventOffset,
-	uint32_t expectedId) : 
-  DCCTBBlockPrototype(parser,"TCC", buffer, numbBytes, wordsToEnd, wordEventOffset),dccBlock_(dccBlock), expectedId_(expectedId){
-
+DCCTBTCCBlock::DCCTBTCCBlock(DCCTBEventBlock* dccBlock,
+                             DCCTBDataParser* parser,
+                             const uint32_t* buffer,
+                             uint32_t numbBytes,
+                             uint32_t wordsToEnd,
+                             uint32_t wordEventOffset,
+                             uint32_t expectedId)
+    : DCCTBBlockPrototype(parser, "TCC", buffer, numbBytes, wordsToEnd, wordEventOffset),
+      dccBlock_(dccBlock),
+      expectedId_(expectedId) {
   //Reset error counters
-  errors_["TCC::HEADER"]  = 0;
+  errors_["TCC::HEADER"] = 0;
   errors_["TCC::BLOCKID"] = 0;
-	
-  //Get data fields from the mapper and retrieve data 
-  if(      parser_->numbTTs() == 68){ mapperFields_ = parser_->mapper()->tcc68Fields();}
-  else if( parser_->numbTTs() == 32){ mapperFields_ = parser_->mapper()->tcc32Fields();}	
-  else if( parser_->numbTTs() == 16){ mapperFields_ = parser_->mapper()->tcc16Fields();}
-  
+
+  //Get data fields from the mapper and retrieve data
+  if (parser_->numbTTs() == 68) {
+    mapperFields_ = parser_->mapper()->tcc68Fields();
+  } else if (parser_->numbTTs() == 32) {
+    mapperFields_ = parser_->mapper()->tcc32Fields();
+  } else if (parser_->numbTTs() == 16) {
+    mapperFields_ = parser_->mapper()->tcc16Fields();
+  }
+
   parseData();
-  
-  // check internal data 
-  if(parser_->debug())
+
+  // check internal data
+  if (parser_->debug())
     dataCheck();
 }
- 
+
 /*---------------------------------------------------*/
 /* DCCTBTCCBlock::dataCheck                            */
 /* check data with data fields                       */
 /*---------------------------------------------------*/
-void DCCTBTCCBlock::dataCheck(){
-  std::pair <bool,std::string> res;            //check result
-  std::string checkErrors("");            //error string
+void DCCTBTCCBlock::dataCheck() {
+  std::pair<bool, std::string> res;  //check result
+  std::string checkErrors("");       //error string
 
   //check BX(LOCAL) field (1st word bit 16)
   res = checkDataField("BX", BXMASK & (dccBlock_->getDataField("BX")));
-  if(!res.first){ 
-    checkErrors += res.second; 
-    (errors_["TCC::HEADER"])++; 
+  if (!res.first) {
+    checkErrors += res.second;
+    (errors_["TCC::HEADER"])++;
   }
-  
-  //check LV1(LOCAL) field (1st word bit 32)
-  res = checkDataField("LV1", L1MASK & (dccBlock_->getDataField("LV1"))); 
-  if(!res.first){ 
-    checkErrors += res.second; 
-    (errors_["TCC::HEADER"])++; 
-  }
-  
-  //check TCC ID field (1st word bit 0)
-  res = checkDataField("TCC ID",expectedId_); 
-  if(!res.first){ 
-    checkErrors += res.second; 
-    (errors_["TCC::HEADER"])++; 
-  } 
-  
-  
-  if(!checkErrors.empty()){
-  	 blockError_=true;
-    errorString_ +="\n ======================================================================\n"; 
-	 errorString_ += std::string(" ") + name_ + std::string("( ID = ")+parser_->getDecString((uint32_t)(expectedId_))+std::string(" ) errors : ") ;
-	 errorString_ += checkErrors ;
-	 errorString_ += "\n ======================================================================";
-  }
-  
-  
-}
 
+  //check LV1(LOCAL) field (1st word bit 32)
+  res = checkDataField("LV1", L1MASK & (dccBlock_->getDataField("LV1")));
+  if (!res.first) {
+    checkErrors += res.second;
+    (errors_["TCC::HEADER"])++;
+  }
+
+  //check TCC ID field (1st word bit 0)
+  res = checkDataField("TCC ID", expectedId_);
+  if (!res.first) {
+    checkErrors += res.second;
+    (errors_["TCC::HEADER"])++;
+  }
+
+  if (!checkErrors.empty()) {
+    blockError_ = true;
+    errorString_ += "\n ======================================================================\n";
+    errorString_ += std::string(" ") + name_ + std::string("( ID = ") + parser_->getDecString((uint32_t)(expectedId_)) +
+                    std::string(" ) errors : ");
+    errorString_ += checkErrors;
+    errorString_ += "\n ======================================================================";
+  }
+}
 
 /*--------------------------------------------------*/
 /* DCCTBTCCBlock::increment                           */
 /* increment a TCC block                            */
 /*--------------------------------------------------*/
 
-void  DCCTBTCCBlock::increment(uint32_t numb){
+void DCCTBTCCBlock::increment(uint32_t numb) {
   //if no debug is required increments the number of blocks
   //otherwise checks if block id is really B'011'=3
-  if(!parser_->debug()){ 
-    DCCTBBlockPrototype::increment(numb); 
-  }
-  else {
-    for(uint32_t counter=0; counter<numb; counter++, dataP_++, wordCounter_++){
+  if (!parser_->debug()) {
+    DCCTBBlockPrototype::increment(numb);
+  } else {
+    for (uint32_t counter = 0; counter < numb; counter++, dataP_++, wordCounter_++) {
       uint32_t blockID = (*dataP_) >> BPOSITION_BLOCKID;
-      if( blockID != BLOCKID ){
-	(errors_["TCC::BLOCKID"])++;
-	//errorString_ += std::string("\n") + parser_->index(nunb)+(" blockId has value ") + parser_->getDecString(blockID);
-	//errorString  += std::string(", while ")+parser_->getDecString(BLOCKID)+std::string(" is expected");
+      if (blockID != BLOCKID) {
+        (errors_["TCC::BLOCKID"])++;
+        //errorString_ += std::string("\n") + parser_->index(nunb)+(" blockId has value ") + parser_->getDecString(blockID);
+        //errorString  += std::string(", while ")+parser_->getDecString(BLOCKID)+std::string(" is expected");
       }
     }
   }
-  
 }
 
+std::vector<std::pair<int, bool> > DCCTBTCCBlock::triggerSamples() {
+  std::vector<std::pair<int, bool> > data;
 
-
-std::vector< std::pair<int,bool> > DCCTBTCCBlock::triggerSamples() {
-  std::vector< std::pair<int,bool> > data;
-
-  for(unsigned int i=1;i <= parser_->numbTTs();i++){
+  for (unsigned int i = 1; i <= parser_->numbTTs(); i++) {
     std::string name = std::string("TPG#") + parser_->getDecString(i);
-    int tpgValue = getDataField( name ) ;
-                 std::pair<int,bool> tpg( tpgValue&ETMASK, bool(tpgValue>>BPOSITION_FGVB));
-    data.push_back (tpg);
-     
+    int tpgValue = getDataField(name);
+    std::pair<int, bool> tpg(tpgValue & ETMASK, bool(tpgValue >> BPOSITION_FGVB));
+    data.push_back(tpg);
   }
 
   return data;
 }
-
-
-
 
 std::vector<int> DCCTBTCCBlock::triggerFlags() {
   std::vector<int> data;
 
-  for(unsigned int i=1; i<= parser_->numbTTs();i++){
+  for (unsigned int i = 1; i <= parser_->numbTTs(); i++) {
     std::string name = std::string("TTF#") + parser_->getDecString(i);
-    
-    data.push_back ( getDataField( name )  );
-     
+
+    data.push_back(getDataField(name));
   }
 
   return data;
 }
-
-
-
-

--- a/EventFilter/EcalTBRawToDigi/src/DCCTCCBlock.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCTCCBlock.cc
@@ -66,7 +66,7 @@ void DCCTBTCCBlock::dataCheck(){
   } 
   
   
-  if(checkErrors!=""){
+  if(!checkErrors.empty()){
   	 blockError_=true;
     errorString_ +="\n ======================================================================\n"; 
 	 errorString_ += std::string(" ") + name_ + std::string("( ID = ")+parser_->getDecString((uint32_t)(expectedId_))+std::string(" ) errors : ") ;

--- a/EventFilter/EcalTBRawToDigi/src/DCCTCCBlock.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCTCCBlock.h
@@ -6,13 +6,13 @@
 #ifndef DCCTBTCCBLOCK_HH
 #define DCCTBTCCBLOCK_HH
 
-#include <iostream>                  //STL
+#include <iostream>  //STL
 #include <string>
 #include <vector>
 #include <map>
 #include <utility>
 
-#include "DCCBlockPrototype.h"      //DATA DECODER
+#include "DCCBlockPrototype.h"  //DATA DECODER
 #include "DCCDataParser.h"
 #include "DCCDataMapper.h"
 #include "DCCEventBlock.h"
@@ -20,39 +20,35 @@
 class DCCTBEventBlock;
 class DCCTBDataParser;
 
-
 class DCCTBTCCBlock : public DCCTBBlockPrototype {
-	
-public :
+public:
   /**
      Class constructor
   */
-  DCCTBTCCBlock(DCCTBEventBlock * dccBlock,
-	      DCCTBDataParser * parser, 
-              const uint32_t * buffer, 
-	      uint32_t numbBytes, 
-	      uint32_t wordsToEnd,
-	      uint32_t wordEventOffset,
-	      uint32_t expectedId );     
-  
-  
+  DCCTBTCCBlock(DCCTBEventBlock* dccBlock,
+                DCCTBDataParser* parser,
+                const uint32_t* buffer,
+                uint32_t numbBytes,
+                uint32_t wordsToEnd,
+                uint32_t wordEventOffset,
+                uint32_t expectedId);
 
-  std::vector< std::pair<int, bool> > triggerSamples();
-  
+  std::vector<std::pair<int, bool> > triggerSamples();
+
   std::vector<int> triggerFlags();
-  
-protected :
+
+protected:
   /**
      Checks header's data
   */
   void dataCheck();
-  
+
   /**
      Adds a new TCC block
   */
   using DCCTBBlockPrototype::increment;
-  void  increment(uint32_t numb);
-  
+  void increment(uint32_t numb);
+
   /**
      Define TCC block fields
      BXMASK (mask for BX, 12bit)
@@ -60,16 +56,16 @@ protected :
      BPOSITION_BLOCKID (bit position for TCC block id, bit=61/29 for 64/32bit words
      BLOCKID (TCC block id B'011' = 3)
   */
-  enum tccFields{ 
+  enum tccFields {
     BXMASK = 0xFFF,
-    L1MASK = 0xFFF, 
+    L1MASK = 0xFFF,
     BPOSITION_BLOCKID = 29,
     BLOCKID = 3,
     BPOSITION_FGVB = 8,
-    ETMASK = 0xFF                  
+    ETMASK = 0xFF
   };
-  
-  DCCTBEventBlock * dccBlock_;
+
+  DCCTBEventBlock* dccBlock_;
   uint32_t expectedId_;
 };
 

--- a/EventFilter/EcalTBRawToDigi/src/DCCTowerBlock.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCTowerBlock.cc
@@ -6,184 +6,180 @@
 #include "ECALParserBlockException.h"
 #include <cstdio>
 
+DCCTBTowerBlock::DCCTBTowerBlock(DCCTBEventBlock *dccBlock,
+                                 DCCTBDataParser *parser,
+                                 const uint32_t *buffer,
+                                 uint32_t numbBytes,
+                                 uint32_t wordsToEnd,
+                                 uint32_t wordEventOffset,
+                                 uint32_t expectedTowerID)
+    : DCCTBBlockPrototype(parser, "TOWERHEADER", buffer, numbBytes, wordsToEnd, wordEventOffset),
+      dccBlock_(dccBlock),
+      expectedTowerID_(expectedTowerID) {
+  //Reset error counters ///////////
+  errors_["FE::HEADER"] = 0;
+  errors_["FE::TT/SC ID"] = 0;
+  errors_["FE::BLOCK LENGTH"] = 0;
+  //////////////////////////////////
 
-
-DCCTBTowerBlock::DCCTBTowerBlock(
- 	DCCTBEventBlock * dccBlock, 
-	DCCTBDataParser * parser, 
-	const uint32_t * buffer, 
-	uint32_t numbBytes,
-	uint32_t wordsToEnd,
-	uint32_t wordEventOffset,
-	uint32_t expectedTowerID
-)
-: DCCTBBlockPrototype(parser,"TOWERHEADER", buffer, numbBytes,wordsToEnd, wordEventOffset ) 
- , dccBlock_(dccBlock), expectedTowerID_(expectedTowerID)
-{
-	
-	//Reset error counters ///////////
-	errors_["FE::HEADER"]        = 0;
-	errors_["FE::TT/SC ID"]      = 0; 
-	errors_["FE::BLOCK LENGTH"]  = 0;
-	//////////////////////////////////
-
-	
-	
-	// Get data fields from the mapper and retrieve data /////////////////////////////////////
-	mapperFields_ = parser_->mapper()->towerFields();	
-	parseData();
-	//////////////////////////////////////////////////////////////////////////////////////////
- }
- 
- 
- void DCCTBTowerBlock::parseXtalData(){
-	
-	uint32_t numbBytes = blockSize_;
-	uint32_t wordsToEnd =wordsToEndOfEvent_;
-	
-	// See if we can construct the correct number of XTAL Blocks////////////////////////////////////////////////////////////////////////////////
-	uint32_t numbDWInXtalBlock = ( parser_->numbXtalSamples() )/4 + 1;
-	uint32_t length            = getDataField("BLOCK LENGTH");
-	uint32_t numbOfXtalBlocks  = 0 ;
-	
-	if( length > 0 ){ numbOfXtalBlocks = (length-1)/numbDWInXtalBlock; }
-	uint32_t xtalBlockSize     =  numbDWInXtalBlock*8;
-	//uint32_t pIncrease         =  numbDWInXtalBlock*2;
-	
-	//std::cout<<"\n DEBUG::numbDWInXtal Block "<<dec<<numbDWInXtalBlock<<std::endl;
-	//std::cout<<"\n DEBUG::length             "<<length<<std::endl;
-	//std::cout<<"\n DEBUG::xtalBlockSize      "<<xtalBlockSize<<std::endl;
-	//std::cout<<"\n DEBUG::pIncreade          "<<pIncrease<<std::endl;
-
-	
-	
-	bool zs = dccBlock_->getDataField("ZS");
-	if( !zs && numbOfXtalBlocks != 25 ){
-	
-	   
-		(errors_["FE::BLOCK LENGTH"])++;
-		errorString_ += "\n ======================================================================\n"; 		
-		errorString_ += std::string(" ") + name_ + std::string(" ZS is not active, error in the Tower Length !") ;
-		errorString_ += "\n Tower Length is : " + (parser_->getDecString(numbBytes/8))+std::string(" , while it should be : ");
-		std::string myString = parser_->getDecString((uint32_t)(25*numbDWInXtalBlock+1));
-		errorString_ += "\n It was only possible to build : " + parser_->getDecString( numbOfXtalBlocks)+ std::string(" XTAL blocks");
-		errorString_ += "\n ======================================================================";
-		blockError_ = true;
-	};
-	if( numbOfXtalBlocks > 25 ){
-		if (errors_["FE::BLOCK LENGTH"]==0)(errors_["FE::BLOCK LENGTH"])++;
-		errorString_ += "\n ======================================================================\n"; 		
-		errorString_ += std::string(" ") + name_ + std::string(" Tower Length is larger then expected...!") ;
-		errorString_ += "\n Tower Length is : " + parser_->getDecString(numbBytes/8)+std::string(" , while it should be at maximum : ");
-		std::string myString = parser_->getDecString((uint32_t)(25*numbDWInXtalBlock+1));
-		errorString_ += "\n Action -> data after the xtal 25 is ignored... "; 
-		errorString_ += "\n ======================================================================";
-		blockError_ = true;
-		
-	}
-	///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-	
-	blockSize_     += length*8;  //??????????????????????
-	
-	// Get XTAL Data //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-	uint32_t stripID, xtalID;
-	
-	
-	for(uint32_t numbXtal=1; numbXtal <= numbOfXtalBlocks && numbXtal <=25 ; numbXtal++){
-	
-		increment(1);
-		
-		stripID =( numbXtal-1)/5 + 1;	
-		xtalID  = numbXtal - (stripID-1)*5;
-		
-		
-		if(!zs){ 	
-			xtalBlocks_.push_back(  new DCCTBXtalBlock( parser_, dataP_, xtalBlockSize, wordsToEnd-wordCounter_,wordCounter_+wordEventOffset_,xtalID, stripID) );
-		}else{
-			xtalBlocks_.push_back(  new DCCTBXtalBlock( parser_, dataP_, xtalBlockSize, wordsToEnd-wordCounter_,wordCounter_+wordEventOffset_,0,0));
-		}
-		
-		increment(xtalBlockSize/4-1);
-	}
-	////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-		
-	// Check internal data ////////////
-	if(parser_->debug()){ dataCheck();};
-	///////////////////////////////////
+  // Get data fields from the mapper and retrieve data /////////////////////////////////////
+  mapperFields_ = parser_->mapper()->towerFields();
+  parseData();
+  //////////////////////////////////////////////////////////////////////////////////////////
 }
 
+void DCCTBTowerBlock::parseXtalData() {
+  uint32_t numbBytes = blockSize_;
+  uint32_t wordsToEnd = wordsToEndOfEvent_;
 
+  // See if we can construct the correct number of XTAL Blocks////////////////////////////////////////////////////////////////////////////////
+  uint32_t numbDWInXtalBlock = (parser_->numbXtalSamples()) / 4 + 1;
+  uint32_t length = getDataField("BLOCK LENGTH");
+  uint32_t numbOfXtalBlocks = 0;
 
-DCCTBTowerBlock::~DCCTBTowerBlock(){
-	std::vector<DCCTBXtalBlock *>::iterator it;
-	for(it=xtalBlocks_.begin();it!=xtalBlocks_.end();it++){ delete (*it);}
-	xtalBlocks_.clear();
+  if (length > 0) {
+    numbOfXtalBlocks = (length - 1) / numbDWInXtalBlock;
+  }
+  uint32_t xtalBlockSize = numbDWInXtalBlock * 8;
+  //uint32_t pIncrease         =  numbDWInXtalBlock*2;
+
+  //std::cout<<"\n DEBUG::numbDWInXtal Block "<<dec<<numbDWInXtalBlock<<std::endl;
+  //std::cout<<"\n DEBUG::length             "<<length<<std::endl;
+  //std::cout<<"\n DEBUG::xtalBlockSize      "<<xtalBlockSize<<std::endl;
+  //std::cout<<"\n DEBUG::pIncreade          "<<pIncrease<<std::endl;
+
+  bool zs = dccBlock_->getDataField("ZS");
+  if (!zs && numbOfXtalBlocks != 25) {
+    (errors_["FE::BLOCK LENGTH"])++;
+    errorString_ += "\n ======================================================================\n";
+    errorString_ += std::string(" ") + name_ + std::string(" ZS is not active, error in the Tower Length !");
+    errorString_ +=
+        "\n Tower Length is : " + (parser_->getDecString(numbBytes / 8)) + std::string(" , while it should be : ");
+    std::string myString = parser_->getDecString((uint32_t)(25 * numbDWInXtalBlock + 1));
+    errorString_ +=
+        "\n It was only possible to build : " + parser_->getDecString(numbOfXtalBlocks) + std::string(" XTAL blocks");
+    errorString_ += "\n ======================================================================";
+    blockError_ = true;
+  };
+  if (numbOfXtalBlocks > 25) {
+    if (errors_["FE::BLOCK LENGTH"] == 0)
+      (errors_["FE::BLOCK LENGTH"])++;
+    errorString_ += "\n ======================================================================\n";
+    errorString_ += std::string(" ") + name_ + std::string(" Tower Length is larger then expected...!");
+    errorString_ += "\n Tower Length is : " + parser_->getDecString(numbBytes / 8) +
+                    std::string(" , while it should be at maximum : ");
+    std::string myString = parser_->getDecString((uint32_t)(25 * numbDWInXtalBlock + 1));
+    errorString_ += "\n Action -> data after the xtal 25 is ignored... ";
+    errorString_ += "\n ======================================================================";
+    blockError_ = true;
+  }
+  ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  blockSize_ += length * 8;  //??????????????????????
+
+  // Get XTAL Data //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+  uint32_t stripID, xtalID;
+
+  for (uint32_t numbXtal = 1; numbXtal <= numbOfXtalBlocks && numbXtal <= 25; numbXtal++) {
+    increment(1);
+
+    stripID = (numbXtal - 1) / 5 + 1;
+    xtalID = numbXtal - (stripID - 1) * 5;
+
+    if (!zs) {
+      xtalBlocks_.push_back(new DCCTBXtalBlock(
+          parser_, dataP_, xtalBlockSize, wordsToEnd - wordCounter_, wordCounter_ + wordEventOffset_, xtalID, stripID));
+    } else {
+      xtalBlocks_.push_back(new DCCTBXtalBlock(
+          parser_, dataP_, xtalBlockSize, wordsToEnd - wordCounter_, wordCounter_ + wordEventOffset_, 0, 0));
+    }
+
+    increment(xtalBlockSize / 4 - 1);
+  }
+  ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+  // Check internal data ////////////
+  if (parser_->debug()) {
+    dataCheck();
+  };
+  ///////////////////////////////////
 }
 
+DCCTBTowerBlock::~DCCTBTowerBlock() {
+  std::vector<DCCTBXtalBlock *>::iterator it;
+  for (it = xtalBlocks_.begin(); it != xtalBlocks_.end(); it++) {
+    delete (*it);
+  }
+  xtalBlocks_.clear();
+}
 
+void DCCTBTowerBlock::dataCheck() {
+  std::string checkErrors("");
 
-void DCCTBTowerBlock::dataCheck(){
-	std::string checkErrors("");	
-	
-	
-	std::pair <bool,std::string> res;
-	
-	///////////////////////////////////////////////////////////////////////////
-	// For TB we don-t check Bx 
-	//res = checkDataField("BX", BXMASK & (dccBlock_->getDataField("BX")));
-	//if(!res.first){ checkErrors += res.second; (errors_["FE::HEADER"])++; }
-	////////////////////////////////////////////////////////////////////////////
-	
-        // mod to account for ECAL counters starting from 0 in the front end N. Almeida
-	res = checkDataField("LV1", L1MASK &  (dccBlock_->getDataField("LV1")  -1)   ); 
-	if(!res.first){ checkErrors += res.second; (errors_["FE::HEADER"])++; }
-	
-	
-	if(expectedTowerID_ != 0){ 
-		res = checkDataField("TT/SC ID",expectedTowerID_); 
-		if(!res.first){ checkErrors += res.second; (errors_["FE::HEADER"])++; } 
-	}
-	
-	if( !checkErrors.empty() ){
-		std::string myTowerId;
-		
-		errorString_ +="\n ======================================================================\n"; 
-		errorString_ += std::string(" ") + name_ + std::string("( ID = ")+parser_->getDecString((uint32_t)(expectedTowerID_))+std::string(" ) errors : ") ;
-		errorString_ += checkErrors ;
-		errorString_ += "\n ======================================================================";
-		blockError_ = true;	
-	}
-} 
+  std::pair<bool, std::string> res;
 
+  ///////////////////////////////////////////////////////////////////////////
+  // For TB we don-t check Bx
+  //res = checkDataField("BX", BXMASK & (dccBlock_->getDataField("BX")));
+  //if(!res.first){ checkErrors += res.second; (errors_["FE::HEADER"])++; }
+  ////////////////////////////////////////////////////////////////////////////
 
-std::vector< DCCTBXtalBlock * > DCCTBTowerBlock::xtalBlocksById(uint32_t stripId, uint32_t xtalId){
-	std::vector<DCCTBXtalBlock *> myVector;	
-	std::vector<DCCTBXtalBlock *>::iterator it;
-	
-	for( it = xtalBlocks_.begin(); it!= xtalBlocks_.end(); it++ ){
-		try{
-			
-		  std::pair<bool,std::string> stripIdCheck   = (*it)->checkDataField("STRIP ID",stripId);
-		  std::pair<bool,std::string> xtalIdCheck    = (*it)->checkDataField("XTAL ID",xtalId);
-			
-			if(xtalIdCheck.first && stripIdCheck.first ){ myVector.push_back( (*it) ); }
-			
-		}catch (ECALTBParserBlockException &e){/*ignore*/ }
-	}
-	
-	return myVector;
+  // mod to account for ECAL counters starting from 0 in the front end N. Almeida
+  res = checkDataField("LV1", L1MASK & (dccBlock_->getDataField("LV1") - 1));
+  if (!res.first) {
+    checkErrors += res.second;
+    (errors_["FE::HEADER"])++;
+  }
+
+  if (expectedTowerID_ != 0) {
+    res = checkDataField("TT/SC ID", expectedTowerID_);
+    if (!res.first) {
+      checkErrors += res.second;
+      (errors_["FE::HEADER"])++;
+    }
+  }
+
+  if (!checkErrors.empty()) {
+    std::string myTowerId;
+
+    errorString_ += "\n ======================================================================\n";
+    errorString_ += std::string(" ") + name_ + std::string("( ID = ") +
+                    parser_->getDecString((uint32_t)(expectedTowerID_)) + std::string(" ) errors : ");
+    errorString_ += checkErrors;
+    errorString_ += "\n ======================================================================";
+    blockError_ = true;
+  }
+}
+
+std::vector<DCCTBXtalBlock *> DCCTBTowerBlock::xtalBlocksById(uint32_t stripId, uint32_t xtalId) {
+  std::vector<DCCTBXtalBlock *> myVector;
+  std::vector<DCCTBXtalBlock *>::iterator it;
+
+  for (it = xtalBlocks_.begin(); it != xtalBlocks_.end(); it++) {
+    try {
+      std::pair<bool, std::string> stripIdCheck = (*it)->checkDataField("STRIP ID", stripId);
+      std::pair<bool, std::string> xtalIdCheck = (*it)->checkDataField("XTAL ID", xtalId);
+
+      if (xtalIdCheck.first && stripIdCheck.first) {
+        myVector.push_back((*it));
+      }
+
+    } catch (ECALTBParserBlockException &e) { /*ignore*/
+    }
+  }
+
+  return myVector;
 }
 
 int DCCTBTowerBlock::towerID() {
-  int result=-1;
+  int result = -1;
 
-  for(std::set<DCCTBDataField *,DCCTBDataFieldComparator>::iterator it = mapperFields_->begin(); it!= mapperFields_->end(); it++){
-    if ( (*it)->name() == "TT/SC ID" ) 
-      result=getDataField( (*it)->name() )  ;
-    
+  for (std::set<DCCTBDataField *, DCCTBDataFieldComparator>::iterator it = mapperFields_->begin();
+       it != mapperFields_->end();
+       it++) {
+    if ((*it)->name() == "TT/SC ID")
+      result = getDataField((*it)->name());
   }
-  
-  return result;
 
+  return result;
 }

--- a/EventFilter/EcalTBRawToDigi/src/DCCTowerBlock.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCTowerBlock.cc
@@ -145,7 +145,7 @@ void DCCTBTowerBlock::dataCheck(){
 		if(!res.first){ checkErrors += res.second; (errors_["FE::HEADER"])++; } 
 	}
 	
-	if( checkErrors !="" ){
+	if( !checkErrors.empty() ){
 		std::string myTowerId;
 		
 		errorString_ +="\n ======================================================================\n"; 

--- a/EventFilter/EcalTBRawToDigi/src/DCCTowerBlock.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCTowerBlock.h
@@ -1,7 +1,6 @@
 // Date   : 02/03/2004
 // Author : N.Almeida (LIP)
 
-
 #ifndef DCCTBTOWERBLOCK_HH
 #define DCCTBTOWERBLOCK_HH
 
@@ -11,7 +10,6 @@
 #include <map>
 #include <utility>
 
-
 #include "DCCBlockPrototype.h"
 
 class DCCTBEventBlock;
@@ -19,41 +17,34 @@ class DCCTBXtalBlock;
 class DCCTBDataParser;
 
 class DCCTBTowerBlock : public DCCTBBlockPrototype {
-	
-	public :
-		
-		DCCTBTowerBlock(
-			DCCTBEventBlock * dccBlock,
-			DCCTBDataParser * parser, 
-			const uint32_t * buffer, 
-			uint32_t numbBytes, 
-			uint32_t wordsToEnd,
-			uint32_t wordEventOffset,
-			uint32_t expectedTowerID
-		);
-		
-		~DCCTBTowerBlock() override;
-		
-		void parseXtalData();
-		int towerID();
+public:
+  DCCTBTowerBlock(DCCTBEventBlock *dccBlock,
+                  DCCTBDataParser *parser,
+                  const uint32_t *buffer,
+                  uint32_t numbBytes,
+                  uint32_t wordsToEnd,
+                  uint32_t wordEventOffset,
+                  uint32_t expectedTowerID);
 
-		std::vector< DCCTBXtalBlock * > & xtalBlocks();
-		
-		std::vector< DCCTBXtalBlock * > xtalBlocksById(uint32_t stripId, uint32_t xtalId);
-		
-	protected :
-		
-		void dataCheck();
-		
-		enum towerFields{ BXMASK = 0xFFF,L1MASK = 0xFFF };
-		
-		std::vector<DCCTBXtalBlock * > xtalBlocks_;
-		DCCTBEventBlock * dccBlock_;
-		uint32_t expectedTowerID_;
-		
-		
+  ~DCCTBTowerBlock() override;
+
+  void parseXtalData();
+  int towerID();
+
+  std::vector<DCCTBXtalBlock *> &xtalBlocks();
+
+  std::vector<DCCTBXtalBlock *> xtalBlocksById(uint32_t stripId, uint32_t xtalId);
+
+protected:
+  void dataCheck();
+
+  enum towerFields { BXMASK = 0xFFF, L1MASK = 0xFFF };
+
+  std::vector<DCCTBXtalBlock *> xtalBlocks_;
+  DCCTBEventBlock *dccBlock_;
+  uint32_t expectedTowerID_;
 };
 
-inline std::vector<DCCTBXtalBlock *> & DCCTBTowerBlock::xtalBlocks(){ return xtalBlocks_; }
+inline std::vector<DCCTBXtalBlock *> &DCCTBTowerBlock::xtalBlocks() { return xtalBlocks_; }
 
 #endif

--- a/EventFilter/EcalTBRawToDigi/src/DCCTrailerBlock.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCTrailerBlock.cc
@@ -1,57 +1,60 @@
 #include "DCCTrailerBlock.h"
 #include "DCCDataParser.h"
 #include "DCCDataMapper.h"
-DCCTBTrailerBlock::DCCTBTrailerBlock(
-	DCCTBDataParser * parser, 
-	const uint32_t * buffer, 
-	uint32_t numbBytes,  
-	uint32_t wToEnd,
-	uint32_t wordEventOffset,
-	uint32_t expectedLength,
-	uint32_t expectedCRC
-) : DCCTBBlockPrototype(parser,"DCCTRAILER", buffer, numbBytes,wToEnd, wordEventOffset),
-expectedLength_(expectedLength){
-	
-	errors_["TRAILER::EVENT LENGTH"] = 0 ;
-	errors_["TRAILER::EOE"]    = 0 ; 
-	errors_["TRAILER::CRC"]    = 0 ;
-	errors_["TRAILER::T"]      = 0 ;
-	
-	// Get data fields from the mapper and retrieve data ///////////////////////////////////////////
-	mapperFields_ = parser_->mapper()->trailerFields();
-	parseData();
-	////////////////////////////////////////////////////////////////////////////////////////////////
+DCCTBTrailerBlock::DCCTBTrailerBlock(DCCTBDataParser* parser,
+                                     const uint32_t* buffer,
+                                     uint32_t numbBytes,
+                                     uint32_t wToEnd,
+                                     uint32_t wordEventOffset,
+                                     uint32_t expectedLength,
+                                     uint32_t expectedCRC)
+    : DCCTBBlockPrototype(parser, "DCCTRAILER", buffer, numbBytes, wToEnd, wordEventOffset),
+      expectedLength_(expectedLength) {
+  errors_["TRAILER::EVENT LENGTH"] = 0;
+  errors_["TRAILER::EOE"] = 0;
+  errors_["TRAILER::CRC"] = 0;
+  errors_["TRAILER::T"] = 0;
 
-	// check internal data ////
-	dataCheck();
-	///////////////////////////
+  // Get data fields from the mapper and retrieve data ///////////////////////////////////////////
+  mapperFields_ = parser_->mapper()->trailerFields();
+  parseData();
+  ////////////////////////////////////////////////////////////////////////////////////////////////
 
+  // check internal data ////
+  dataCheck();
+  ///////////////////////////
 }
 
+void DCCTBTrailerBlock::dataCheck() {
+  std::string checkErrors("");
 
-void DCCTBTrailerBlock::dataCheck(){
-	
-	std::string checkErrors("");
-	
-	std::pair<bool,std::string> res;
-	
-	res = checkDataField("EVENT LENGTH",expectedLength_);
-	if(!res.first){ checkErrors += res.second; (errors_["TRAILER::EVENT LENGTH"])++; }
-	
-	res = checkDataField("EOE",EOE);
-	if(!res.first){ checkErrors += res.second; (errors_["TRAILER::EOE"])++; }
-	
-	res = checkDataField("T",0);
-	if(!res.first){ checkErrors += res.second; (errors_["TRAILER::T"])++; }
-	
-	//checkErrors += checkDataField("CRC",expectedCRC_);
-	
-	if(!checkErrors.empty()){
-		errorString_ +="\n ======================================================================\n"; 		
-		errorString_ += std::string(" ") + name_ + std::string(" data fields checks errors : ") ;
-		errorString_ += checkErrors ;
-		errorString_ += "\n ======================================================================";
-		blockError_ = true;	
-	}
+  std::pair<bool, std::string> res;
+
+  res = checkDataField("EVENT LENGTH", expectedLength_);
+  if (!res.first) {
+    checkErrors += res.second;
+    (errors_["TRAILER::EVENT LENGTH"])++;
+  }
+
+  res = checkDataField("EOE", EOE);
+  if (!res.first) {
+    checkErrors += res.second;
+    (errors_["TRAILER::EOE"])++;
+  }
+
+  res = checkDataField("T", 0);
+  if (!res.first) {
+    checkErrors += res.second;
+    (errors_["TRAILER::T"])++;
+  }
+
+  //checkErrors += checkDataField("CRC",expectedCRC_);
+
+  if (!checkErrors.empty()) {
+    errorString_ += "\n ======================================================================\n";
+    errorString_ += std::string(" ") + name_ + std::string(" data fields checks errors : ");
+    errorString_ += checkErrors;
+    errorString_ += "\n ======================================================================";
+    blockError_ = true;
+  }
 }
-

--- a/EventFilter/EcalTBRawToDigi/src/DCCTrailerBlock.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCTrailerBlock.cc
@@ -46,7 +46,7 @@ void DCCTBTrailerBlock::dataCheck(){
 	
 	//checkErrors += checkDataField("CRC",expectedCRC_);
 	
-	if(checkErrors!=""){
+	if(!checkErrors.empty()){
 		errorString_ +="\n ======================================================================\n"; 		
 		errorString_ += std::string(" ") + name_ + std::string(" data fields checks errors : ") ;
 		errorString_ += checkErrors ;

--- a/EventFilter/EcalTBRawToDigi/src/DCCTrailerBlock.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCTrailerBlock.h
@@ -4,35 +4,25 @@
 #ifndef DCCTBTRAILERBLOCK_HH
 #define DCCTBTRAILERBLOCK_HH
 
-
 #include "DCCBlockPrototype.h"
 class DCCDataParser;
 
 class DCCTBTrailerBlock : public DCCTBBlockPrototype {
+public:
+  DCCTBTrailerBlock(DCCTBDataParser* parser,
+                    const uint32_t* buffer,
+                    uint32_t numbBytes,
+                    uint32_t wToEnd,
+                    uint32_t wordEventOffset,
+                    uint32_t expectedLength,
+                    uint32_t expectedCRC);
 
-	public :
-		
-		DCCTBTrailerBlock(
-			DCCTBDataParser * parser, 
-			const uint32_t * buffer, 
-			uint32_t numbBytes,
-			uint32_t wToEnd, 
-			uint32_t wordEventOffset,
-			uint32_t expectedLength,
-			uint32_t expectedCRC
-		);
-		
-		void dataCheck(); 
-		
-		
-	protected :
-		
-		enum traillerFields{ EOE = 0xA};
-		uint32_t expectedLength_;
-		uint32_t expectedCRC_;
+  void dataCheck();
 
-
+protected:
+  enum traillerFields { EOE = 0xA };
+  uint32_t expectedLength_;
+  uint32_t expectedCRC_;
 };
 
 #endif
-

--- a/EventFilter/EcalTBRawToDigi/src/DCCXtalBlock.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCXtalBlock.cc
@@ -48,7 +48,7 @@ void DCCTBXtalBlock::dataCheck(){
 		res = checkDataField("STRIP ID",expectedStripID_);
 		if(!res.first){ checkErrors += res.second; (errors_["XTAL::HEADER"])++; } 
 	}
-	if(checkErrors!=""){
+	if(!checkErrors.empty()){
 		errorString_ +="\n ======================================================================\n"; 		
 		errorString_ += std::string(" ") + name_ + std::string(" data fields checks errors : ") ;
 		errorString_ += checkErrors ;

--- a/EventFilter/EcalTBRawToDigi/src/DCCXtalBlock.cc
+++ b/EventFilter/EcalTBRawToDigi/src/DCCXtalBlock.cc
@@ -2,119 +2,109 @@
 #include "DCCDataParser.h"
 #include "DCCDataMapper.h"
 
+DCCTBXtalBlock::DCCTBXtalBlock(DCCTBDataParser *parser,
+                               const uint32_t *buffer,
+                               uint32_t numbBytes,
+                               uint32_t wordsToEnd,
+                               uint32_t wordEventOffset,
+                               uint32_t expectedXtalID,
+                               uint32_t expectedStripID)
+    : DCCTBBlockPrototype(parser, "XTAL", buffer, numbBytes, wordsToEnd, wordEventOffset),
+      expectedXtalID_(expectedXtalID),
+      expectedStripID_(expectedStripID) {
+  //Reset error counters ////
+  errors_["XTAL::HEADER"] = 0;
+  errors_["XTAL::BLOCKID"] = 0;
+  ///////////////////////////
 
-DCCTBXtalBlock::DCCTBXtalBlock(
-	DCCTBDataParser * parser, 
-	const uint32_t * buffer, 
-	uint32_t numbBytes,  
-	uint32_t wordsToEnd,
-	uint32_t wordEventOffset,
-	uint32_t expectedXtalID,
-	uint32_t expectedStripID
-) : DCCTBBlockPrototype(parser,"XTAL", buffer, numbBytes, wordsToEnd, wordEventOffset),
-expectedXtalID_(expectedXtalID), expectedStripID_(expectedStripID){
-	
-	
-	//Reset error counters ////
-	errors_["XTAL::HEADER"]  = 0;
-	errors_["XTAL::BLOCKID"] = 0; 
-	///////////////////////////
-	
-	// Get data fields from the mapper and retrieve data /////////////////////////////////////
-	mapperFields_ = parser_->mapper()->xtalFields();	
-	parseData();
-	//////////////////////////////////////////////////////////////////////////////////////////
-	
-	// check internal data ////////////
-	if(parser_->debug()){ dataCheck();}
-	///////////////////////////////////
+  // Get data fields from the mapper and retrieve data /////////////////////////////////////
+  mapperFields_ = parser_->mapper()->xtalFields();
+  parseData();
+  //////////////////////////////////////////////////////////////////////////////////////////
 
+  // check internal data ////////////
+  if (parser_->debug()) {
+    dataCheck();
+  }
+  ///////////////////////////////////
 }
 
+void DCCTBXtalBlock::dataCheck() {
+  std::string checkErrors("");
 
+  std::pair<bool, std::string> res;
 
-void DCCTBXtalBlock::dataCheck(){
-	
-	std::string checkErrors("");
-		
-	std::pair <bool,std::string> res;
-	
-	
-	if(expectedXtalID_ !=0){ 
-		res = checkDataField("XTAL ID",expectedXtalID_); 
-		if(!res.first){ checkErrors += res.second; (errors_["XTAL::HEADER"])++; } 
-	}
-	if(expectedStripID_!=0){ 
-		res = checkDataField("STRIP ID",expectedStripID_);
-		if(!res.first){ checkErrors += res.second; (errors_["XTAL::HEADER"])++; } 
-	}
-	if(!checkErrors.empty()){
-		errorString_ +="\n ======================================================================\n"; 		
-		errorString_ += std::string(" ") + name_ + std::string(" data fields checks errors : ") ;
-		errorString_ += checkErrors ;
-		errorString_ += "\n ======================================================================";
-		blockError_ = true;	
-	}
-	
+  if (expectedXtalID_ != 0) {
+    res = checkDataField("XTAL ID", expectedXtalID_);
+    if (!res.first) {
+      checkErrors += res.second;
+      (errors_["XTAL::HEADER"])++;
+    }
+  }
+  if (expectedStripID_ != 0) {
+    res = checkDataField("STRIP ID", expectedStripID_);
+    if (!res.first) {
+      checkErrors += res.second;
+      (errors_["XTAL::HEADER"])++;
+    }
+  }
+  if (!checkErrors.empty()) {
+    errorString_ += "\n ======================================================================\n";
+    errorString_ += std::string(" ") + name_ + std::string(" data fields checks errors : ");
+    errorString_ += checkErrors;
+    errorString_ += "\n ======================================================================";
+    blockError_ = true;
+  }
 }
 
-
-void  DCCTBXtalBlock::increment(uint32_t numb){
-	if(!parser_->debug()){ DCCTBBlockPrototype::increment(numb); }
-	else {
-		for(uint32_t counter=0; counter<numb; counter++, dataP_++,wordCounter_++){
-			uint32_t blockID = (*dataP_)>>BPOSITION_BLOCKID;
-			if( blockID != BLOCKID ){
-				(errors_["XTAL::BLOCKID"])++;
-				//errorString_ += std::string("\n") + parser_->index(nunb)+(" blockId has value ") + parser_->getDecString(blockID);
-				//errorString  += std::string(", while ")+parser_->getDecString(BLOCKID)+std::string(" is expected");
-			}
-		}
-	}
+void DCCTBXtalBlock::increment(uint32_t numb) {
+  if (!parser_->debug()) {
+    DCCTBBlockPrototype::increment(numb);
+  } else {
+    for (uint32_t counter = 0; counter < numb; counter++, dataP_++, wordCounter_++) {
+      uint32_t blockID = (*dataP_) >> BPOSITION_BLOCKID;
+      if (blockID != BLOCKID) {
+        (errors_["XTAL::BLOCKID"])++;
+        //errorString_ += std::string("\n") + parser_->index(nunb)+(" blockId has value ") + parser_->getDecString(blockID);
+        //errorString  += std::string(", while ")+parser_->getDecString(BLOCKID)+std::string(" is expected");
+      }
+    }
+  }
 }
 
 int DCCTBXtalBlock::xtalID() {
+  int result = -1;
 
-  int result=-1;
-
-  for(  std::set<DCCTBDataField *,DCCTBDataFieldComparator>::iterator 
-           it = mapperFields_->begin(); it!= mapperFields_->end(); it++){
-  
-    if ( (*it)->name() == "XTAL ID" ) 
-      result=getDataField( (*it)->name() )  ;
-    
+  for (std::set<DCCTBDataField *, DCCTBDataFieldComparator>::iterator it = mapperFields_->begin();
+       it != mapperFields_->end();
+       it++) {
+    if ((*it)->name() == "XTAL ID")
+      result = getDataField((*it)->name());
   }
 
-
- 
-  return result; 
-
+  return result;
 }
 
 int DCCTBXtalBlock::stripID() {
-  int result=-1;
+  int result = -1;
 
-  for(std::set<DCCTBDataField *,DCCTBDataFieldComparator>::iterator it = mapperFields_->begin(); it!= mapperFields_->end(); it++){
-    if ( (*it)->name() == "STRIP ID" ) 
-      result=getDataField( (*it)->name() )  ;
-    
+  for (std::set<DCCTBDataField *, DCCTBDataFieldComparator>::iterator it = mapperFields_->begin();
+       it != mapperFields_->end();
+       it++) {
+    if ((*it)->name() == "STRIP ID")
+      result = getDataField((*it)->name());
   }
-  
+
   return result;
-
 }
-
-
 
 std::vector<int> DCCTBXtalBlock::xtalDataSamples() {
   std::vector<int> data;
 
-
-  for(unsigned int i=1;i <= parser_->numbXtalSamples();i++){
+  for (unsigned int i = 1; i <= parser_->numbXtalSamples(); i++) {
     std::string name = std::string("ADC#") + parser_->getDecString(i);
-    
-    data.push_back ( getDataField( name )  );
-     
+
+    data.push_back(getDataField(name));
   }
 
   return data;

--- a/EventFilter/EcalTBRawToDigi/src/DCCXtalBlock.h
+++ b/EventFilter/EcalTBRawToDigi/src/DCCXtalBlock.h
@@ -8,33 +8,27 @@
 class DCCTBDataParser;
 
 class DCCTBXtalBlock : public DCCTBBlockPrototype {
+public:
+  DCCTBXtalBlock(DCCTBDataParser* parser,
+                 const uint32_t* buffer,
+                 uint32_t numbBytes,
+                 uint32_t wordsToEnd,
+                 uint32_t wordEventOffset,
+                 uint32_t expectedXtalID,
+                 uint32_t expectedStripID);
 
-	public :
-		
-		DCCTBXtalBlock(
-			DCCTBDataParser * parser, 
-			const uint32_t * buffer,
-			uint32_t numbBytes,
-			uint32_t wordsToEnd,  
-			uint32_t wordEventOffset,
-			uint32_t expectedXtalID ,
-			uint32_t expectedStripID 
-		);
-		
-		void dataCheck(); 
-		int xtalID();
-                                int stripID();
-		std::vector<int> xtalDataSamples();
+  void dataCheck();
+  int xtalID();
+  int stripID();
+  std::vector<int> xtalDataSamples();
 
-	protected :
-		using DCCTBBlockPrototype::increment;
-		void increment(uint32_t numb);
-		
-		enum xtalBlockFields{ BPOSITION_BLOCKID = 30, BLOCKID = 3};
-		
-		uint32_t expectedXtalID_;
-		uint32_t expectedStripID_;
+protected:
+  using DCCTBBlockPrototype::increment;
+  void increment(uint32_t numb);
 
+  enum xtalBlockFields { BPOSITION_BLOCKID = 30, BLOCKID = 3 };
 
+  uint32_t expectedXtalID_;
+  uint32_t expectedStripID_;
 };
 #endif

--- a/EventFilter/EcalTBRawToDigi/src/ECALParserBlockException.h
+++ b/EventFilter/EcalTBRawToDigi/src/ECALParserBlockException.h
@@ -7,26 +7,20 @@
 #include <iostream>
 #include <string>
 
-
-
-class ECALTBParserBlockException{ 
-		public :
-		
-			/**
+class ECALTBParserBlockException {
+public:
+  /**
 			 * Constructor
 			 */
-  ECALTBParserBlockException(std::string exceptionInfo_){info_ = exceptionInfo_; }
-		
-		
-			/**
+  ECALTBParserBlockException(std::string exceptionInfo_) { info_ = exceptionInfo_; }
+
+  /**
 			 * Exception's discription
 			 */
-			const char * what() const throw() {	return info_.c_str();}
-			
-		protected :
-	
-			std::string info_;
+  const char* what() const throw() { return info_.c_str(); }
 
+protected:
+  std::string info_;
 };
 
 #endif

--- a/EventFilter/EcalTBRawToDigi/src/ECALParserException.h
+++ b/EventFilter/EcalTBRawToDigi/src/ECALParserException.h
@@ -7,26 +7,20 @@
 #include <iostream>
 #include <string>
 
-
-
-class ECALTBParserException { 
-		public :
-		
-			/**
+class ECALTBParserException {
+public:
+  /**
 			 * Constructor
 			 */
-  ECALTBParserException( std::string  exceptionInfo_ ){ info_ = exceptionInfo_; }
-		
-		
-			/**
+  ECALTBParserException(std::string exceptionInfo_) { info_ = exceptionInfo_; }
+
+  /**
 			 * Exception's discription
 			 */
-			const char * what() const throw() {	return info_.c_str();}
-			
-		protected :
-	
-			std::string info_;
+  const char* what() const throw() { return info_.c_str(); }
 
+protected:
+  std::string info_;
 };
 
 #endif

--- a/EventFilter/EcalTBRawToDigi/src/EcalDCC07UnpackingModule.cc
+++ b/EventFilter/EcalTBRawToDigi/src/EcalDCC07UnpackingModule.cc
@@ -23,97 +23,93 @@
 #include <FWCore/Framework/interface/Event.h>
 #include <FWCore/ParameterSet/interface/FileInPath.h>
 
-
 #include <iostream>
 #include <iomanip>
 
-// in full CMS this range cannot be used (allocated to pixel, see DataFormats/ FEDRawData/ src/ FEDNumbering.cc) 
+// in full CMS this range cannot be used (allocated to pixel, see DataFormats/ FEDRawData/ src/ FEDNumbering.cc)
 #define BEG_DCC_FED_ID 0
 #define END_DCC_FED_ID 0
 #define BEG_DCC_FED_ID_GLOBAL 0
 #define END_DCC_FED_ID_GLOBAL 0
 
-#define ECAL_SUPERVISOR_FED_ID 40 
+#define ECAL_SUPERVISOR_FED_ID 40
 #define TBCAMAC_FED_ID 41
 #define TABLE_FED_ID 42
 #define MATACQ_FED_ID 43
 
-EcalDCCTB07UnpackingModule::EcalDCCTB07UnpackingModule(const edm::ParameterSet& pset) :
-  fedRawDataCollectionTag_(pset.getParameter<edm::InputTag>("fedRawDataCollectionTag")) {
+EcalDCCTB07UnpackingModule::EcalDCCTB07UnpackingModule(const edm::ParameterSet& pset)
+    : fedRawDataCollectionTag_(pset.getParameter<edm::InputTag>("fedRawDataCollectionTag")) {
+  std::string tbName = pset.getUntrackedParameter<std::string>("tbName", std::string("h2"));
 
-  std::string tbName = pset.getUntrackedParameter<std::string >("tbName", std::string("h2") );
-
-  ProduceEEDigis_ = pset.getUntrackedParameter<bool >("produceEEdigi", true );
-  ProduceEBDigis_ = pset.getUntrackedParameter<bool >("produceEBdigi", false );
+  ProduceEEDigis_ = pset.getUntrackedParameter<bool>("produceEEdigi", true);
+  ProduceEBDigis_ = pset.getUntrackedParameter<bool>("produceEBdigi", false);
 
   // index of crystal <-> tower ID (DQM plots) position <-> stripIDs <-> channelIDs for the test beam (2007)
-  std::vector<int> ics        = pset.getUntrackedParameter<std::vector<int> >("ics",          std::vector<int>());
-  std::vector<int> towerIDs   = pset.getUntrackedParameter<std::vector<int> >("towerIDs",     std::vector<int>());
-  std::vector<int> stripIDs   = pset.getUntrackedParameter<std::vector<int> >("stripIDs",     std::vector<int>());
-  std::vector<int> channelIDs = pset.getUntrackedParameter<std::vector<int> >("channelIDs",   std::vector<int>());
+  std::vector<int> ics = pset.getUntrackedParameter<std::vector<int> >("ics", std::vector<int>());
+  std::vector<int> towerIDs = pset.getUntrackedParameter<std::vector<int> >("towerIDs", std::vector<int>());
+  std::vector<int> stripIDs = pset.getUntrackedParameter<std::vector<int> >("stripIDs", std::vector<int>());
+  std::vector<int> channelIDs = pset.getUntrackedParameter<std::vector<int> >("channelIDs", std::vector<int>());
 
   // status id <-> tower CCU ID <-> DQM plots position mapping for the test beam (2007)
-  std::vector<int> statusIDs   = pset.getUntrackedParameter<std::vector<int> >("statusIDs",   std::vector<int>());
-  std::vector<int> ccuIDs      = pset.getUntrackedParameter<std::vector<int> >("ccuIDs",      std::vector<int>());
+  std::vector<int> statusIDs = pset.getUntrackedParameter<std::vector<int> >("statusIDs", std::vector<int>());
+  std::vector<int> ccuIDs = pset.getUntrackedParameter<std::vector<int> >("ccuIDs", std::vector<int>());
   std::vector<int> positionIDs = pset.getUntrackedParameter<std::vector<int> >("positionIDs", std::vector<int>());
 
   // check if vectors are filled
-  if ( ics.empty() || towerIDs.empty() || stripIDs.empty() || channelIDs.empty() ){
-    edm::LogError("EcalDCCTB07UnpackingModule") << "Some of the mapping info is missing! Check config files! " <<
-      " Size of IC vector is " << ics.size() <<
-      " Size of Tower ID vector is " << towerIDs.size() <<
-      " Size of Strip ID vector is " << stripIDs.size() <<
-      " Size of Channel ID vector is " << channelIDs.size();
+  if (ics.empty() || towerIDs.empty() || stripIDs.empty() || channelIDs.empty()) {
+    edm::LogError("EcalDCCTB07UnpackingModule")
+        << "Some of the mapping info is missing! Check config files! "
+        << " Size of IC vector is " << ics.size() << " Size of Tower ID vector is " << towerIDs.size()
+        << " Size of Strip ID vector is " << stripIDs.size() << " Size of Channel ID vector is " << channelIDs.size();
   }
-  if ( statusIDs.empty() || ccuIDs.empty() || positionIDs.empty() ) {
-    edm::LogError("EcalDCCTB07UnpackingModule") << "Some of the mapping info is missing! Check config files! " <<
-      " Size of status ID vector is " << statusIDs.size() <<
-      " Size of ccu ID vector is " << ccuIDs.size() <<
-      " positionIDs size is " << positionIDs.size();
+  if (statusIDs.empty() || ccuIDs.empty() || positionIDs.empty()) {
+    edm::LogError("EcalDCCTB07UnpackingModule")
+        << "Some of the mapping info is missing! Check config files! "
+        << " Size of status ID vector is " << statusIDs.size() << " Size of ccu ID vector is " << ccuIDs.size()
+        << " positionIDs size is " << positionIDs.size();
   }
-  
+
   // check if vectors have the same size
-  if ( ics.size() != towerIDs.size() || ics.size() != stripIDs.size() || ics.size() != channelIDs.size() ||
-       towerIDs.size() != stripIDs.size() || towerIDs.size() != channelIDs.size() ||
-       stripIDs.size() != channelIDs.size() )
-    edm::LogError("EcalDCCTB07UnpackingModule") << "Mapping information is corrupted. " <<
-      "Tower/DQM position/strip/channel vectors are of different size! Check cfi files! \n" <<
-      " Size of IC vector is " << ics.size() <<
-      " Size of Tower ID vector is " << towerIDs.size() <<
-      " Size of Strip ID vector is " << stripIDs.size() <<
-      " Size of Channel ID vector is " << channelIDs.size();
-  
-  if ( statusIDs.size() != ccuIDs.size() || statusIDs.size() != positionIDs.size() ||
-       ccuIDs.size() != positionIDs.size() ) 
-    edm::LogError("EcalDCCTB07UnpackingModule") << "Mapping information is corrupted. " <<
-      "Status/CCU ID/DQM position vectors are of different size! Check cfi files! \n" <<
-      " Size of status ID vector is " << statusIDs.size() <<
-      " Size of ccu ID vector is " << ccuIDs.size() <<
-      " positionIDs size is " << positionIDs.size();
-  
+  if (ics.size() != towerIDs.size() || ics.size() != stripIDs.size() || ics.size() != channelIDs.size() ||
+      towerIDs.size() != stripIDs.size() || towerIDs.size() != channelIDs.size() ||
+      stripIDs.size() != channelIDs.size())
+    edm::LogError("EcalDCCTB07UnpackingModule")
+        << "Mapping information is corrupted. "
+        << "Tower/DQM position/strip/channel vectors are of different size! Check cfi files! \n"
+        << " Size of IC vector is " << ics.size() << " Size of Tower ID vector is " << towerIDs.size()
+        << " Size of Strip ID vector is " << stripIDs.size() << " Size of Channel ID vector is " << channelIDs.size();
+
+  if (statusIDs.size() != ccuIDs.size() || statusIDs.size() != positionIDs.size() ||
+      ccuIDs.size() != positionIDs.size())
+    edm::LogError("EcalDCCTB07UnpackingModule")
+        << "Mapping information is corrupted. "
+        << "Status/CCU ID/DQM position vectors are of different size! Check cfi files! \n"
+        << " Size of status ID vector is " << statusIDs.size() << " Size of ccu ID vector is " << ccuIDs.size()
+        << " positionIDs size is " << positionIDs.size();
+
   int cryIcMap[68][5][5];
   int tbStatusToLocation[71];
   int tbTowerIDToLocation[201];
-  for (unsigned it=1; it <= 68; ++it )
-    for (unsigned is=1; is <=5; ++is )
-      for (unsigned ic=1; ic <=5; ++ic)
-	cryIcMap[it-1][is-1][ic-1] = 1700;
+  for (unsigned it = 1; it <= 68; ++it)
+    for (unsigned is = 1; is <= 5; ++is)
+      for (unsigned ic = 1; ic <= 5; ++ic)
+        cryIcMap[it - 1][is - 1][ic - 1] = 1700;
 
-  for (unsigned it=1; it <=71; ++it)
-    tbStatusToLocation[it-1] = it - 1;
+  for (unsigned it = 1; it <= 71; ++it)
+    tbStatusToLocation[it - 1] = it - 1;
 
-  for (unsigned it=1; it <= 201; ++it)
-    tbTowerIDToLocation[it-1] = it - 1;
+  for (unsigned it = 1; it <= 201; ++it)
+    tbTowerIDToLocation[it - 1] = it - 1;
 
   // Fill the cry IC map
-  for(unsigned int i=0; i < ics.size(); ++i) {
+  for (unsigned int i = 0; i < ics.size(); ++i) {
     int tower = towerIDs[i];
     int strip = stripIDs[i];
     int channel = channelIDs[i];
     int ic = ics[i];
-    cryIcMap[tower-1][strip-1][channel-1] = ic;
+    cryIcMap[tower - 1][strip - 1][channel - 1] = ic;
   }
-  for(unsigned int i = 0; i < statusIDs.size(); ++i) {
+  for (unsigned int i = 0; i < statusIDs.size(); ++i) {
     int is = statusIDs[i];
     int it = ccuIDs[i];
     int itEB = positionIDs[i];
@@ -127,7 +123,6 @@ EcalDCCTB07UnpackingModule::EcalDCCTB07UnpackingModule(const edm::ParameterSet& 
   camacTBformatter_ = new CamacTBDataFormatter();
   tableFormatter_ = new TableDataFormatter();
   matacqFormatter_ = new MatacqTBDataFormatter();
-
 
   // digis
   produces<EBDigiCollection>("ebDigis");
@@ -157,26 +152,15 @@ EcalDCCTB07UnpackingModule::EcalDCCTB07UnpackingModule(const edm::ParameterSet& 
   produces<EcalElectronicsIdCollection>("EcalIntegrityMemGainErrors");
 }
 
+EcalDCCTB07UnpackingModule::~EcalDCCTB07UnpackingModule() { delete formatter_; }
 
-EcalDCCTB07UnpackingModule::~EcalDCCTB07UnpackingModule(){
+void EcalDCCTB07UnpackingModule::beginJob() {}
 
-  delete formatter_;
+void EcalDCCTB07UnpackingModule::endJob() {}
 
-}
-
-void EcalDCCTB07UnpackingModule::beginJob(){
-
-}
-
-void EcalDCCTB07UnpackingModule::endJob(){
-
-}
-
-void EcalDCCTB07UnpackingModule::produce(edm::Event & e, const edm::EventSetup& c){
-
+void EcalDCCTB07UnpackingModule::produce(edm::Event& e, const edm::EventSetup& c) {
   edm::Handle<FEDRawDataCollection> rawdata;
   e.getByLabel(fedRawDataCollectionTag_, rawdata);
-  
 
   // create the collection of Ecal Digis
   auto productEb = std::make_unique<EBDigiCollection>();
@@ -189,7 +173,7 @@ void EcalDCCTB07UnpackingModule::produce(edm::Event & e, const edm::EventSetup& 
 
   // create the collection of Ecal PN's
   auto productPN = std::make_unique<EcalPnDiodeDigiCollection>();
-  
+
   //create the collection of Ecal DCC Header
   auto productDCCHeader = std::make_unique<EcalRawDataCollection>();
 
@@ -216,112 +200,125 @@ void EcalDCCTB07UnpackingModule::produce(edm::Event & e, const edm::EventSetup& 
 
   // create the collection of Ecal Integrity Mem towerBlock_id errors
   auto productMemTtId = std::make_unique<EcalElectronicsIdCollection>();
-  
-  // create the collection of Ecal Integrity Mem gain errors
-  auto productMemBlockSize = std::make_unique< EcalElectronicsIdCollection>();
 
   // create the collection of Ecal Integrity Mem gain errors
-  auto productMemGain = std::make_unique< EcalElectronicsIdCollection>();
-  
+  auto productMemBlockSize = std::make_unique<EcalElectronicsIdCollection>();
+
+  // create the collection of Ecal Integrity Mem gain errors
+  auto productMemGain = std::make_unique<EcalElectronicsIdCollection>();
+
   // create the collection of Ecal Integrity Mem ch_id errors
   auto productMemChIdErrors = std::make_unique<EcalElectronicsIdCollection>();
-  
-  // create the collection of TB specifics data
-  auto productHodo = std::make_unique<EcalTBHodoscopeRawInfo>();         
-  auto productTdc = std::make_unique<EcalTBTDCRawInfo>();                      
-  auto productHeader = std::make_unique<EcalTBEventHeader>();                      
 
+  // create the collection of TB specifics data
+  auto productHodo = std::make_unique<EcalTBHodoscopeRawInfo>();
+  auto productTdc = std::make_unique<EcalTBTDCRawInfo>();
+  auto productHeader = std::make_unique<EcalTBEventHeader>();
 
   try {
+    for (int id = 0; id <= FEDNumbering::MAXFEDID; ++id) {
+      //    edm::LogInfo("EcalDCCTB07UnpackingModule") << "EcalDCCTB07UnpackingModule::Got FED ID "<< id <<" ";
+      const FEDRawData& data = rawdata->FEDData(id);
+      //    edm::LogInfo("EcalDCCTB07UnpackingModule") << " Fed data size " << data.size() ;
 
-  for (int id= 0; id<=FEDNumbering::MAXFEDID; ++id){ 
+      //std::cout <<"1 Fed id: "<<dec<<id<< " Fed data size: " <<data.size() << std::endl;
+      //    const unsigned char * pData = data.data();
+      //    int length = data.size();
+      //    if(length >0 ){
+      //      if(length >= 40){length = 40;}
+      //    std::cout<<"##############################################################"<<std::endl;
+      //    for( int i=0; i<length; i++ ) {
+      //      std::cout << std::hex << std::setw(8) << int(pData[i]) << " ";
+      //      if( (i+1)%8 == 0 ) std::cout << std::endl;
+      //     }
+      //    std::cout<<"##############################################################"<<std::endl;
+      //    }
+      if (data.size() > 16) {
+        if ((id >= BEG_DCC_FED_ID && id <= END_DCC_FED_ID) ||
+            (BEG_DCC_FED_ID_GLOBAL <= id &&
+             id <= END_DCC_FED_ID_GLOBAL)) {  // do the DCC data unpacking and fill the collections
 
-    //    edm::LogInfo("EcalDCCTB07UnpackingModule") << "EcalDCCTB07UnpackingModule::Got FED ID "<< id <<" ";
-    const FEDRawData& data = rawdata->FEDData(id);
-    //    edm::LogInfo("EcalDCCTB07UnpackingModule") << " Fed data size " << data.size() ;
-   
-    //std::cout <<"1 Fed id: "<<dec<<id<< " Fed data size: " <<data.size() << std::endl;
-//    const unsigned char * pData = data.data();
-//    int length = data.size();
-//    if(length >0 ){
-//      if(length >= 40){length = 40;}
-//    std::cout<<"##############################################################"<<std::endl;
-//    for( int i=0; i<length; i++ ) {
-//      std::cout << std::hex << std::setw(8) << int(pData[i]) << " ";
-//      if( (i+1)%8 == 0 ) std::cout << std::endl;
-//     }
-//    std::cout<<"##############################################################"<<std::endl;
-//    } 
-    if (data.size()>16){
+          (*productHeader).setSmInBeam(id);
+          // YM add productEe to the list of arguments of the formatter
+          formatter_->interpretRawData(data,
+                                       *productEb,
+                                       *productEe,
+                                       *productPN,
+                                       *productDCCHeader,
+                                       *productDCCSize,
+                                       *productTTId,
+                                       *productBlockSize,
+                                       *productChId,
+                                       *productGain,
+                                       *productGainSwitch,
+                                       *productMemTtId,
+                                       *productMemBlockSize,
+                                       *productMemGain,
+                                       *productMemChIdErrors,
+                                       *productTriggerPrimitives);
+          int runType = (*productDCCHeader)[0].getRunType();
+          if (runType == EcalDCCHeaderBlock::COSMIC || runType == EcalDCCHeaderBlock::BEAMH4)
+            (*productHeader).setTriggerMask(0x1);
+          else if (runType == 4 || runType == 5 || runType == 6)  //laser runs
+            (*productHeader).setTriggerMask(0x2000);
+          else if (runType == 9 || runType == 10 || runType == 11)  //pedestal runs
+            (*productHeader).setTriggerMask(0x800);
+          LogDebug("EcalDCCTB07UnpackingModule")
+              << "Event type is " << (*productHeader).eventType() << " dbEventType " << (*productHeader).dbEventType();
+        } else if (id == ECAL_SUPERVISOR_FED_ID)
+          ecalSupervisorFormatter_->interpretRawData(data, *productHeader);
+        else if (id == TBCAMAC_FED_ID)
+          camacTBformatter_->interpretRawData(data, *productHeader, *productHodo, *productTdc);
+        else if (id == TABLE_FED_ID)
+          tableFormatter_->interpretRawData(data, *productHeader);
+        else if (id == MATACQ_FED_ID)
+          matacqFormatter_->interpretRawData(data, *productMatacq);
+      }  // endif
+    }    //endfor
 
-      if (	  (id >= BEG_DCC_FED_ID && id <= END_DCC_FED_ID) ||
-	  ( BEG_DCC_FED_ID_GLOBAL <= id &&  id <= END_DCC_FED_ID_GLOBAL )
-	  )
-	{	// do the DCC data unpacking and fill the collections
-	  
-	  (*productHeader).setSmInBeam(id);
-	  // YM add productEe to the list of arguments of the formatter
-	  formatter_->interpretRawData(data,  *productEb, *productEe, *productPN, 
-				       *productDCCHeader, 
-				       *productDCCSize, 
-				       *productTTId, *productBlockSize, 
-				       *productChId, *productGain, *productGainSwitch, 
-				       *productMemTtId,  *productMemBlockSize,
-				       *productMemGain,  *productMemChIdErrors,
-				       *productTriggerPrimitives);
-	  int runType = (*productDCCHeader)[0].getRunType();
-	  if ( runType == EcalDCCHeaderBlock::COSMIC || runType == EcalDCCHeaderBlock::BEAMH4 ) 
-	    (*productHeader).setTriggerMask(0x1);
-	  else if ( runType == 4 || runType == 5 || runType == 6 ) //laser runs
-	    (*productHeader).setTriggerMask(0x2000);
-	  else if ( runType == 9 || runType == 10 || runType == 11 ) //pedestal runs
-	    (*productHeader).setTriggerMask(0x800);
-	  LogDebug("EcalDCCTB07UnpackingModule") << "Event type is " << (*productHeader).eventType() << " dbEventType " << (*productHeader).dbEventType();
-	} 
-      else if ( id == ECAL_SUPERVISOR_FED_ID )
-	ecalSupervisorFormatter_->interpretRawData(data, *productHeader);
-      else if ( id == TBCAMAC_FED_ID )
-	camacTBformatter_->interpretRawData(data, *productHeader,*productHodo, *productTdc );
-      else if ( id == TABLE_FED_ID )
-	tableFormatter_->interpretRawData(data, *productHeader);
-      else if ( id == MATACQ_FED_ID )	  
-	matacqFormatter_->interpretRawData(data, *productMatacq);
-    }// endif 
-  }//endfor
-  
+    // commit to the event
+    e.put(std::move(productPN));
+    if (ProduceEBDigis_)
+      e.put(std::move(productEb), "ebDigis");
+    if (ProduceEEDigis_)
+      e.put(std::move(productEe), "eeDigis");
+    e.put(std::move(productMatacq));
+    e.put(std::move(productDCCHeader));
+    e.put(std::move(productTriggerPrimitives), "EBTT");
 
-  // commit to the event  
-  e.put(std::move(productPN));
-  if (ProduceEBDigis_)  e.put(std::move(productEb),"ebDigis");
-  if (ProduceEEDigis_)  e.put(std::move(productEe),"eeDigis");
-  e.put(std::move(productMatacq));
-  e.put(std::move(productDCCHeader));
-  e.put(std::move(productTriggerPrimitives), "EBTT");
-  
-  if (ProduceEBDigis_)  e.put(std::move(productDCCSize),"EcalIntegrityDCCSizeErrors");
-  if (ProduceEBDigis_)  e.put(std::move(productTTId),"EcalIntegrityTTIdErrors");
-  if (ProduceEBDigis_)  e.put(std::move(productBlockSize),"EcalIntegrityBlockSizeErrors");
-  if (ProduceEBDigis_)  e.put(std::move(productChId),"EcalIntegrityChIdErrors");
-  if (ProduceEBDigis_)  e.put(std::move(productGain),"EcalIntegrityGainErrors");
-  if (ProduceEBDigis_)  e.put(std::move(productGainSwitch),"EcalIntegrityGainSwitchErrors");
-  
-  if (ProduceEBDigis_)  e.put(std::move(productMemTtId),"EcalIntegrityMemTtIdErrors");
-  if (ProduceEBDigis_)  e.put(std::move(productMemBlockSize),"EcalIntegrityMemBlockSize");
-  if (ProduceEBDigis_)  e.put(std::move(productMemChIdErrors),"EcalIntegrityMemChIdErrors");
-  if (ProduceEBDigis_)  e.put(std::move(productMemGain),"EcalIntegrityMemGainErrors");
+    if (ProduceEBDigis_)
+      e.put(std::move(productDCCSize), "EcalIntegrityDCCSizeErrors");
+    if (ProduceEBDigis_)
+      e.put(std::move(productTTId), "EcalIntegrityTTIdErrors");
+    if (ProduceEBDigis_)
+      e.put(std::move(productBlockSize), "EcalIntegrityBlockSizeErrors");
+    if (ProduceEBDigis_)
+      e.put(std::move(productChId), "EcalIntegrityChIdErrors");
+    if (ProduceEBDigis_)
+      e.put(std::move(productGain), "EcalIntegrityGainErrors");
+    if (ProduceEBDigis_)
+      e.put(std::move(productGainSwitch), "EcalIntegrityGainSwitchErrors");
 
-  e.put(std::move(productHodo));
-  e.put(std::move(productTdc));
-  e.put(std::move(productHeader));
+    if (ProduceEBDigis_)
+      e.put(std::move(productMemTtId), "EcalIntegrityMemTtIdErrors");
+    if (ProduceEBDigis_)
+      e.put(std::move(productMemBlockSize), "EcalIntegrityMemBlockSize");
+    if (ProduceEBDigis_)
+      e.put(std::move(productMemChIdErrors), "EcalIntegrityMemChIdErrors");
+    if (ProduceEBDigis_)
+      e.put(std::move(productMemGain), "EcalIntegrityMemGainErrors");
 
-  } catch (ECALTBParserException &e) {
+    e.put(std::move(productHodo));
+    e.put(std::move(productTdc));
+    e.put(std::move(productHeader));
+
+  } catch (ECALTBParserException& e) {
     std::cout << "[EcalDCCTB07UnpackingModule] " << e.what() << std::endl;
-  } catch (ECALTBParserBlockException &e) {
+  } catch (ECALTBParserBlockException& e) {
     std::cout << "[EcalDCCTB07UnpackingModule] " << e.what() << std::endl;
-  } catch (cms::Exception &e) {
+  } catch (cms::Exception& e) {
     std::cout << "[EcalDCCTB07UnpackingModule] " << e.what() << std::endl;
   } catch (...) {
     std::cout << "[EcalDCCTB07UnpackingModule] Unknown exception ..." << std::endl;
   }
-
 }

--- a/EventFilter/EcalTBRawToDigi/src/EcalDCCHeaderRuntypeDecoder.cc
+++ b/EventFilter/EcalTBRawToDigi/src/EcalDCCHeaderRuntypeDecoder.cc
@@ -5,118 +5,120 @@
 #include <string>
 #include <iostream>
 
-EcalDCCTBHeaderRuntypeDecoder::EcalDCCTBHeaderRuntypeDecoder(){;}
-EcalDCCTBHeaderRuntypeDecoder::~EcalDCCTBHeaderRuntypeDecoder(){;}
+EcalDCCTBHeaderRuntypeDecoder::EcalDCCTBHeaderRuntypeDecoder() { ; }
+EcalDCCTBHeaderRuntypeDecoder::~EcalDCCTBHeaderRuntypeDecoder() { ; }
 
-bool EcalDCCTBHeaderRuntypeDecoder::Decode(unsigned long headerWord, EcalDCCHeaderBlock* EcalDCCHeaderInfos){
-  
+bool EcalDCCTBHeaderRuntypeDecoder::Decode(unsigned long headerWord, EcalDCCHeaderBlock* EcalDCCHeaderInfos) {
   //  unsigned long DCCNumberMask      = 63;//2^6-1
 
-  unsigned long WhichHalfOffSet   = 64;//2^6 
-  unsigned long TypeOffSet        = 256;//2^8
-  unsigned long SubTypeOffSet     = 2048;//2^11
-  unsigned long SettingOffSet     = 131072;//2^17;
-  unsigned long GainModeOffSet    = 16384;//2^14
-  
+  unsigned long WhichHalfOffSet = 64;    //2^6
+  unsigned long TypeOffSet = 256;        //2^8
+  unsigned long SubTypeOffSet = 2048;    //2^11
+  unsigned long SettingOffSet = 131072;  //2^17;
+  unsigned long GainModeOffSet = 16384;  //2^14
+
   unsigned long TwoBitsMask = 3;
   unsigned long ThreeBitsMask = 7;
   unsigned long ThirdBitMask = 4;
-  
+
   //  EcalDCCTBHeaderInfos->setId( int ( headerWord & DCCNumberMask) );
-  EcalDCCHeaderInfos-> setRtHalf( int ((headerWord / WhichHalfOffSet) & TwoBitsMask) );
-  int type = int ((headerWord / TypeOffSet)      & ThreeBitsMask);
-  int sequence  = int ((headerWord / SubTypeOffSet)   & ThreeBitsMask);
-  EcalDCCHeaderInfos->setMgpaGain(int ((headerWord / GainModeOffSet)  & TwoBitsMask) );
-  EcalDCCHeaderInfos->setMemGain( int ((headerWord / GainModeOffSet)  & ThirdBitMask)/ThirdBitMask );
+  EcalDCCHeaderInfos->setRtHalf(int((headerWord / WhichHalfOffSet) & TwoBitsMask));
+  int type = int((headerWord / TypeOffSet) & ThreeBitsMask);
+  int sequence = int((headerWord / SubTypeOffSet) & ThreeBitsMask);
+  EcalDCCHeaderInfos->setMgpaGain(int((headerWord / GainModeOffSet) & TwoBitsMask));
+  EcalDCCHeaderInfos->setMemGain(int((headerWord / GainModeOffSet) & ThirdBitMask) / ThirdBitMask);
   //  EcalDCCHeaderInfos.Setting       = int ( headerWord / SettingOffSet);
 
-
-  if (type ==0 && sequence == 0){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::COSMIC);}
-// begin: added for XDAQ 3
-  else if (type ==0 && sequence == 1){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::COSMIC);}
-  else if (type ==0 && sequence == 2){
-    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::BEAMH4);}
-  else if (type ==0 && sequence == 3){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::BEAMH2);}
-  else if (type ==0 && sequence == 4){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::MTCC);}
-// end: added for XDAQ 3
-  else if (type ==1 && sequence == 0){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::LASER_STD);}
-  else if (type ==1 && sequence == 1){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::LASER_POWER_SCAN);}
-  else if (type ==1 && sequence == 2){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::LASER_DELAY_SCAN);}
-  else if (type ==2 && sequence == 0){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::TESTPULSE_SCAN_MEM);}
-  else if (type ==2 && sequence == 1){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::TESTPULSE_MGPA);}
-  else if (type ==3 && sequence == 0){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::PEDESTAL_STD);}
-  else if (type ==3 && sequence == 1){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::PEDESTAL_OFFSET_SCAN);}
-  else if (type ==3 && sequence == 2){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::PEDESTAL_25NS_SCAN);}
-  else if (type ==4 && sequence == 0){EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::LED_STD);}
-  else {
-    edm::LogWarning("EcalTBRawToDigi") <<"@SUB=EcalDCCHeaderRuntypeDecoder::Decode unrecognized runtype and sequence: "<<type<<" "<<sequence;
+  if (type == 0 && sequence == 0) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::COSMIC);
+  }
+  // begin: added for XDAQ 3
+  else if (type == 0 && sequence == 1) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::COSMIC);
+  } else if (type == 0 && sequence == 2) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::BEAMH4);
+  } else if (type == 0 && sequence == 3) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::BEAMH2);
+  } else if (type == 0 && sequence == 4) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::MTCC);
+  }
+  // end: added for XDAQ 3
+  else if (type == 1 && sequence == 0) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::LASER_STD);
+  } else if (type == 1 && sequence == 1) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::LASER_POWER_SCAN);
+  } else if (type == 1 && sequence == 2) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::LASER_DELAY_SCAN);
+  } else if (type == 2 && sequence == 0) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::TESTPULSE_SCAN_MEM);
+  } else if (type == 2 && sequence == 1) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::TESTPULSE_MGPA);
+  } else if (type == 3 && sequence == 0) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::PEDESTAL_STD);
+  } else if (type == 3 && sequence == 1) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::PEDESTAL_OFFSET_SCAN);
+  } else if (type == 3 && sequence == 2) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::PEDESTAL_25NS_SCAN);
+  } else if (type == 4 && sequence == 0) {
+    EcalDCCHeaderInfos->setRunType(EcalDCCHeaderBlock::LED_STD);
+  } else {
+    edm::LogWarning("EcalTBRawToDigi") << "@SUB=EcalDCCHeaderRuntypeDecoder::Decode unrecognized runtype and sequence: "
+                                       << type << " " << sequence;
     EcalDCCHeaderInfos->setRunType(-1);
     WasDecodingOk_ = false;
   }
 
-
-  DecodeSetting (int ( headerWord / SettingOffSet),EcalDCCHeaderInfos);
-
+  DecodeSetting(int(headerWord / SettingOffSet), EcalDCCHeaderInfos);
 
   return WasDecodingOk_;
 }
 
-void  EcalDCCTBHeaderRuntypeDecoder::DecodeSetting ( int Setting,  EcalDCCHeaderBlock* theHeader )
-{
-  EcalDCCHeaderBlock::EcalDCCEventSettings theSettings;// = new EcalDCCEventSettings;
+void EcalDCCTBHeaderRuntypeDecoder::DecodeSetting(int Setting, EcalDCCHeaderBlock* theHeader) {
+  EcalDCCHeaderBlock::EcalDCCEventSettings theSettings;  // = new EcalDCCEventSettings;
   CleanEcalDCCSettingsInfo(&theSettings);
 
-  if( theHeader->getRunType() == EcalDCCHeaderBlock::COSMIC || 
-      theHeader->getRunType() == EcalDCCHeaderBlock::BEAMH2 || 
-      theHeader->getRunType() == EcalDCCHeaderBlock::BEAMH4 || 
-      theHeader->getRunType() == EcalDCCHeaderBlock::MTCC 
-      )
-    {;}//no settings foreseen
-  else if(theHeader->getRunType() == EcalDCCHeaderBlock::LASER_STD)
-    {
-      theSettings.LaserPower = (Setting & 8128)/64;
-      theSettings.LaserFilter = (Setting & 56)/8;
-      theSettings.wavelength = Setting & 7;
-    }
-  else if(theHeader->getRunType() == EcalDCCHeaderBlock::LASER_POWER_SCAN){
-    theSettings.LaserPower = (Setting & 8128)/64;
-    theSettings.LaserFilter = (Setting & 56)/8;
+  if (theHeader->getRunType() == EcalDCCHeaderBlock::COSMIC || theHeader->getRunType() == EcalDCCHeaderBlock::BEAMH2 ||
+      theHeader->getRunType() == EcalDCCHeaderBlock::BEAMH4 || theHeader->getRunType() == EcalDCCHeaderBlock::MTCC) {
+    ;
+  }  //no settings foreseen
+  else if (theHeader->getRunType() == EcalDCCHeaderBlock::LASER_STD) {
+    theSettings.LaserPower = (Setting & 8128) / 64;
+    theSettings.LaserFilter = (Setting & 56) / 8;
     theSettings.wavelength = Setting & 7;
-  }
-  else if(theHeader->getRunType() == EcalDCCHeaderBlock::LASER_DELAY_SCAN){
-    theSettings.wavelength = Setting & 7;  
-    theSettings.delay = (Setting & 2040)/8;
-  }
-  else if(theHeader->getRunType() == EcalDCCHeaderBlock::TESTPULSE_SCAN_MEM){
+  } else if (theHeader->getRunType() == EcalDCCHeaderBlock::LASER_POWER_SCAN) {
+    theSettings.LaserPower = (Setting & 8128) / 64;
+    theSettings.LaserFilter = (Setting & 56) / 8;
+    theSettings.wavelength = Setting & 7;
+  } else if (theHeader->getRunType() == EcalDCCHeaderBlock::LASER_DELAY_SCAN) {
+    theSettings.wavelength = Setting & 7;
+    theSettings.delay = (Setting & 2040) / 8;
+  } else if (theHeader->getRunType() == EcalDCCHeaderBlock::TESTPULSE_SCAN_MEM) {
     theSettings.MEMVinj = Setting & 511;
-  }
-  else if(theHeader->getRunType() == EcalDCCHeaderBlock::TESTPULSE_MGPA){
-      theSettings.mgpa_content =  Setting & 255;
-  }
-  else if(theHeader->getRunType() == EcalDCCHeaderBlock::PEDESTAL_STD){;}//no settings foreseen
-  else if(theHeader->getRunType() == EcalDCCHeaderBlock::PEDESTAL_OFFSET_SCAN){
-    theSettings.ped_offset  =  Setting;
-  }
-  else if(theHeader->getRunType() == EcalDCCHeaderBlock::PEDESTAL_25NS_SCAN ){
-    theSettings.delay = (Setting & 255);  
-  }
-  else if(theHeader->getRunType() == EcalDCCHeaderBlock::LED_STD){
+  } else if (theHeader->getRunType() == EcalDCCHeaderBlock::TESTPULSE_MGPA) {
+    theSettings.mgpa_content = Setting & 255;
+  } else if (theHeader->getRunType() == EcalDCCHeaderBlock::PEDESTAL_STD) {
+    ;
+  }  //no settings foreseen
+  else if (theHeader->getRunType() == EcalDCCHeaderBlock::PEDESTAL_OFFSET_SCAN) {
+    theSettings.ped_offset = Setting;
+  } else if (theHeader->getRunType() == EcalDCCHeaderBlock::PEDESTAL_25NS_SCAN) {
+    theSettings.delay = (Setting & 255);
+  } else if (theHeader->getRunType() == EcalDCCHeaderBlock::LED_STD) {
     theSettings.wavelength = Setting & 7;
-  }
-  else {
-    edm::LogWarning("EcalTBRawToDigi") <<"@SUB=EcalDCCTBHeaderRuntypeDecoder::DecodeSettings unrecognized run type: "<<theHeader->getRunType();
+  } else {
+    edm::LogWarning("EcalTBRawToDigi") << "@SUB=EcalDCCTBHeaderRuntypeDecoder::DecodeSettings unrecognized run type: "
+                                       << theHeader->getRunType();
     WasDecodingOk_ = false;
   }
   theHeader->setEventSettings(theSettings);
-  
 }
 
-void EcalDCCTBHeaderRuntypeDecoder::CleanEcalDCCSettingsInfo( EcalDCCHeaderBlock::EcalDCCEventSettings * dummySettings){
-  dummySettings->LaserPower =-1;
-  dummySettings->LaserFilter =-1;
-  dummySettings->wavelength =-1;
-  dummySettings->delay =-1;
-  dummySettings->MEMVinj =-1;
-  dummySettings->mgpa_content =-1;
-  dummySettings->ped_offset =-1;
+void EcalDCCTBHeaderRuntypeDecoder::CleanEcalDCCSettingsInfo(EcalDCCHeaderBlock::EcalDCCEventSettings* dummySettings) {
+  dummySettings->LaserPower = -1;
+  dummySettings->LaserFilter = -1;
+  dummySettings->wavelength = -1;
+  dummySettings->delay = -1;
+  dummySettings->MEMVinj = -1;
+  dummySettings->mgpa_content = -1;
+  dummySettings->ped_offset = -1;
 }

--- a/EventFilter/EcalTBRawToDigi/src/EcalSupervisorDataFormatter.cc
+++ b/EventFilter/EcalTBRawToDigi/src/EcalSupervisorDataFormatter.cc
@@ -1,133 +1,143 @@
 #include "EcalSupervisorDataFormatter.h"
 
-
 #include <iostream>
 
-EcalSupervisorTBDataFormatter::EcalSupervisorTBDataFormatter () {
-}
+EcalSupervisorTBDataFormatter::EcalSupervisorTBDataFormatter() {}
 
-void EcalSupervisorTBDataFormatter::interpretRawData( const FEDRawData & fedData, 
-					   EcalTBEventHeader& tbEventHeader)
-{
-  const unsigned long * buffer = reinterpret_cast<const unsigned long*>(fedData.data());
-  int fedLenght                        = fedData.size(); // in Bytes
-  
+void EcalSupervisorTBDataFormatter::interpretRawData(const FEDRawData& fedData, EcalTBEventHeader& tbEventHeader) {
+  const unsigned long* buffer = reinterpret_cast<const unsigned long*>(fedData.data());
+  int fedLenght = fedData.size();  // in Bytes
+
   // check ultimate fed size and strip off fed-header and -trailer
-   if (fedLenght < (nWordsPerEvent *4) )
-     {
-       edm::LogError("EcalSupervisorTBDataFormatter") << "EcalSupervisorTBData has size "  <<  fedLenght
- 				       <<" Bytes as opposed to expected " 
- 				       << (nWordsPerEvent *4)
- 				       << ". Returning.";
-       return;
-     }
+  if (fedLenght < (nWordsPerEvent * 4)) {
+    edm::LogError("EcalSupervisorTBDataFormatter")
+        << "EcalSupervisorTBData has size " << fedLenght << " Bytes as opposed to expected " << (nWordsPerEvent * 4)
+        << ". Returning.";
+    return;
+  }
 
-  unsigned long a=1; // used to extract an 8 Bytes word from fed 
-  unsigned long b=1; // used to manipulate the 8 Bytes word and get what needed
+  unsigned long a = 1;  // used to extract an 8 Bytes word from fed
+  unsigned long b = 1;  // used to manipulate the 8 Bytes word and get what needed
 
-  int wordCounter =0;
-  a = buffer[wordCounter];wordCounter++;
+  int wordCounter = 0;
+  a = buffer[wordCounter];
+  wordCounter++;
   b = (a & 0xfff00000);
   b = b >> 20;
   tbEventHeader.setBurstNumber(b);
   LogDebug("EcalSupervisorTBDataFormatter") << "Burst number:\t" << b;
   //Skipping the second word
-  wordCounter +=1;
-  a = buffer[wordCounter];wordCounter++;
-  b = (a& 0x80000000);
+  wordCounter += 1;
+  a = buffer[wordCounter];
+  wordCounter++;
+  b = (a & 0x80000000);
   b = b >> 31;
   tbEventHeader.setSyncError(b & 0x1);
   LogDebug("EcalSupervisorTBDataFormatter") << "Sync Error:\t" << b;
-  a = buffer[wordCounter];wordCounter++;
-  b = (a& 0xffffff);
+  a = buffer[wordCounter];
+  wordCounter++;
+  b = (a & 0xffffff);
   tbEventHeader.setRunNumber(b);
   LogDebug("EcalSupervisorTBDataFormatter") << "Run Number:\t" << b;
-  a = buffer[wordCounter];wordCounter++;
-  b = (a& 0xff);
+  a = buffer[wordCounter];
+  wordCounter++;
+  b = (a & 0xff);
   int version = b;
   LogDebug("EcalSupervisorTBDataFormatter") << "Version Number:\t" << b;
 
   int numberOfMagnetMeasurements = -1;
-  if (version >= 11)
-    {
-      b = (a& 0xff00);
-      b = b >> 8;
-      numberOfMagnetMeasurements= b;
-      tbEventHeader.setNumberOfMagnetMeasurements(b);
-      LogDebug("EcalSupervisorTBDataFormatter") << "Number Of Magnet Measurements:\t" << b;
-    }
+  if (version >= 11) {
+    b = (a & 0xff00);
+    b = b >> 8;
+    numberOfMagnetMeasurements = b;
+    tbEventHeader.setNumberOfMagnetMeasurements(b);
+    LogDebug("EcalSupervisorTBDataFormatter") << "Number Of Magnet Measurements:\t" << b;
+  }
 
-  a = buffer[wordCounter];wordCounter++;
-  b = (a& 0xffffffff);
+  a = buffer[wordCounter];
+  wordCounter++;
+  b = (a & 0xffffffff);
   tbEventHeader.setEventNumber(b);
   LogDebug("EcalSupervisorTBDataFormatter") << "Event Number:\t" << b;
-  a = buffer[wordCounter];wordCounter++;
-  b = (a& 0xffffffff);
+  a = buffer[wordCounter];
+  wordCounter++;
+  b = (a & 0xffffffff);
   tbEventHeader.setBegBurstTimeSec(b);
   LogDebug("EcalSupervisorTBDataFormatter") << "BegBurstTimeSec:\t" << b;
-  a = buffer[wordCounter];wordCounter++;
-  b = (a& 0xffffffff);
+  a = buffer[wordCounter];
+  wordCounter++;
+  b = (a & 0xffffffff);
   tbEventHeader.setBegBurstTimeMsec(b);
   LogDebug("EcalSupervisorTBDataFormatter") << "BegBurstTimeMsec:\t" << b;
-  a = buffer[wordCounter];wordCounter++;
-  b = (a& 0xffffffff);
+  a = buffer[wordCounter];
+  wordCounter++;
+  b = (a & 0xffffffff);
   tbEventHeader.setEndBurstTimeSec(b);
   LogDebug("EcalSupervisorTBDataFormatter") << "EndBurstTimeSec:\t" << b;
-  a = buffer[wordCounter];wordCounter++;
-  b = (a& 0xffffffff);
+  a = buffer[wordCounter];
+  wordCounter++;
+  b = (a & 0xffffffff);
   tbEventHeader.setEndBurstTimeMsec(b);
   LogDebug("EcalSupervisorTBDataFormatter") << "EndBurstTimeMsec:\t" << b;
-  a = buffer[wordCounter];wordCounter++;
-  b = (a& 0xffffffff);
+  a = buffer[wordCounter];
+  wordCounter++;
+  b = (a & 0xffffffff);
   tbEventHeader.setBegBurstLV1A(b);
   LogDebug("EcalSupervisorTBDataFormatter") << "BegBurstLV1A:\t" << b;
-  a = buffer[wordCounter];wordCounter++;
-  b = (a& 0xffffffff);
+  a = buffer[wordCounter];
+  wordCounter++;
+  b = (a & 0xffffffff);
   tbEventHeader.setEndBurstLV1A(b);
   LogDebug("EcalSupervisorTBDataFormatter") << "EndBurstLV1A:\t" << b;
 
-  if (version >= 11)
-    {
-      std::vector<EcalTBEventHeader::magnetsMeasurement_t> magnetMeasurements;
-      for (int iMagMeas = 0; iMagMeas < numberOfMagnetMeasurements; iMagMeas ++)
-	{ 
-	  LogDebug("EcalSupervisorTBDataFormatter") << "++++++ New Magnet Measurement++++++\t" << (iMagMeas + 1);
-	  EcalTBEventHeader::magnetsMeasurement_t aMeasurement;
-	  wordCounter+=4;
-	  a = buffer[wordCounter];wordCounter++;
-	  b = (a& 0xffffffff);
-	  aMeasurement.magnet6IRead_ampere = b;
-	  LogDebug("EcalSupervisorTBDataFormatter") << "NominalMagnet6ReadAmpere:\t" << b;
-	  a = buffer[wordCounter];wordCounter++;
-	  b = (a& 0xffffffff);
-	  aMeasurement.magnet6ISet_ampere = b;
-	  LogDebug("EcalSupervisorTBDataFormatter") << "NominalMagnet6SetAmpere:\t" << b;
-	  a = buffer[wordCounter];wordCounter++;
-	  b = (a& 0xffffffff);
-	  aMeasurement.magnet7IRead_ampere = b;
-	  LogDebug("EcalSupervisorTBDataFormatter") << "NominalMagnet7ReadAmpere:\t" << b;
-	  a = buffer[wordCounter];wordCounter++;
-	  b = (a& 0xffffffff);
-	  aMeasurement.magnet7ISet_ampere = b;
-	  LogDebug("EcalSupervisorTBDataFormatter") << "NominalMagnet7SetAmpere:\t" << b;
-	  a = buffer[wordCounter];wordCounter++;
-	  b = (a& 0xffffffff);
-	  aMeasurement.magnet7VMeas_uvolt = b;
-	  LogDebug("EcalSupervisorTBDataFormatter") << "MeasuredMagnet7MicroVolt:\t" << b;
-	  a = buffer[wordCounter];wordCounter++;
-	  b = (a& 0xffffffff);
-	  aMeasurement.magnet7IMeas_uampere = b;
-	  LogDebug("EcalSupervisorTBDataFormatter") << "MeasuredMagnet7Ampere:\t" << b;
-	  a = buffer[wordCounter];wordCounter++;
-	  b = (a& 0xffffffff);
-	  aMeasurement.magnet6VMeas_uvolt = b;
-	  LogDebug("EcalSupervisorTBDataFormatter") << "MeasuredMagnet6MicroVolt:\t" << b;
-	  a = buffer[wordCounter];wordCounter++;
-	  b = (a& 0xffffffff);
-	  aMeasurement.magnet6IMeas_uampere = b;
-	  LogDebug("EcalSupervisorTBDataFormatter") << "MeasuredMagnet6Ampere:\t" << b;
-	  magnetMeasurements.push_back(aMeasurement);
-	}
-      tbEventHeader.setMagnetMeasurements(magnetMeasurements);
+  if (version >= 11) {
+    std::vector<EcalTBEventHeader::magnetsMeasurement_t> magnetMeasurements;
+    for (int iMagMeas = 0; iMagMeas < numberOfMagnetMeasurements; iMagMeas++) {
+      LogDebug("EcalSupervisorTBDataFormatter") << "++++++ New Magnet Measurement++++++\t" << (iMagMeas + 1);
+      EcalTBEventHeader::magnetsMeasurement_t aMeasurement;
+      wordCounter += 4;
+      a = buffer[wordCounter];
+      wordCounter++;
+      b = (a & 0xffffffff);
+      aMeasurement.magnet6IRead_ampere = b;
+      LogDebug("EcalSupervisorTBDataFormatter") << "NominalMagnet6ReadAmpere:\t" << b;
+      a = buffer[wordCounter];
+      wordCounter++;
+      b = (a & 0xffffffff);
+      aMeasurement.magnet6ISet_ampere = b;
+      LogDebug("EcalSupervisorTBDataFormatter") << "NominalMagnet6SetAmpere:\t" << b;
+      a = buffer[wordCounter];
+      wordCounter++;
+      b = (a & 0xffffffff);
+      aMeasurement.magnet7IRead_ampere = b;
+      LogDebug("EcalSupervisorTBDataFormatter") << "NominalMagnet7ReadAmpere:\t" << b;
+      a = buffer[wordCounter];
+      wordCounter++;
+      b = (a & 0xffffffff);
+      aMeasurement.magnet7ISet_ampere = b;
+      LogDebug("EcalSupervisorTBDataFormatter") << "NominalMagnet7SetAmpere:\t" << b;
+      a = buffer[wordCounter];
+      wordCounter++;
+      b = (a & 0xffffffff);
+      aMeasurement.magnet7VMeas_uvolt = b;
+      LogDebug("EcalSupervisorTBDataFormatter") << "MeasuredMagnet7MicroVolt:\t" << b;
+      a = buffer[wordCounter];
+      wordCounter++;
+      b = (a & 0xffffffff);
+      aMeasurement.magnet7IMeas_uampere = b;
+      LogDebug("EcalSupervisorTBDataFormatter") << "MeasuredMagnet7Ampere:\t" << b;
+      a = buffer[wordCounter];
+      wordCounter++;
+      b = (a & 0xffffffff);
+      aMeasurement.magnet6VMeas_uvolt = b;
+      LogDebug("EcalSupervisorTBDataFormatter") << "MeasuredMagnet6MicroVolt:\t" << b;
+      a = buffer[wordCounter];
+      wordCounter++;
+      b = (a & 0xffffffff);
+      aMeasurement.magnet6IMeas_uampere = b;
+      LogDebug("EcalSupervisorTBDataFormatter") << "MeasuredMagnet6Ampere:\t" << b;
+      magnetMeasurements.push_back(aMeasurement);
     }
+    tbEventHeader.setMagnetMeasurements(magnetMeasurements);
+  }
 }

--- a/EventFilter/EcalTBRawToDigi/src/EcalSupervisorDataFormatter.h
+++ b/EventFilter/EcalTBRawToDigi/src/EcalSupervisorDataFormatter.h
@@ -10,21 +10,19 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
 class FEDRawData;
-class EcalSupervisorTBDataFormatter   {
-
- public:
-
-  EcalSupervisorTBDataFormatter() ;
-  virtual ~EcalSupervisorTBDataFormatter(){LogDebug("EcalTBRawToDigi") << "@SUB=EcalSupervisorTBDataFormatter" << "\n"; };
+class EcalSupervisorTBDataFormatter {
+public:
+  EcalSupervisorTBDataFormatter();
+  virtual ~EcalSupervisorTBDataFormatter() {
+    LogDebug("EcalTBRawToDigi") << "@SUB=EcalSupervisorTBDataFormatter"
+                                << "\n";
+  };
 
   //Method to be implemented
-  void  interpretRawData( const FEDRawData & data, EcalTBEventHeader& tbEventHeader ) ;
+  void interpretRawData(const FEDRawData& data, EcalTBEventHeader& tbEventHeader);
 
- private:
-
-  static const int nWordsPerEvent = 14;    
-
+private:
+  static const int nWordsPerEvent = 14;
 };
 #endif

--- a/EventFilter/EcalTBRawToDigi/src/EcalTB07DaqFormatter.cc
+++ b/EventFilter/EcalTBRawToDigi/src/EcalTB07DaqFormatter.cc
@@ -28,210 +28,193 @@
 #include "DCCXtalBlock.h"
 #include "DCCDataMapper.h"
 
-
 #include <iostream>
 #include <string>
 
-EcalTB07DaqFormatter::EcalTB07DaqFormatter (std::string tbName,
-					    int cryIcMap[68][5][5], 
-					    int tbStatusToLocation[71], 
-					    int tbTowerIDToLocation[201]) {
-
+EcalTB07DaqFormatter::EcalTB07DaqFormatter(std::string tbName,
+                                           int cryIcMap[68][5][5],
+                                           int tbStatusToLocation[71],
+                                           int tbTowerIDToLocation[201]) {
   LogDebug("EcalTB07RawToDigi") << "@SUB=EcalTB07DaqFormatter";
   std::vector<uint32_t> parameters;
-  parameters.push_back(10); // parameters[0] is the xtal samples 
-  parameters.push_back(1);  // parameters[1] is the number of trigger time samples for TPG's
-  parameters.push_back(68); // parameters[2] is the number of TT
-  parameters.push_back(68); // parameters[3] is the number of SR Flags
-  parameters.push_back(1);  // parameters[4] is the dcc id
-  parameters.push_back(1);  // parameters[5] is the sr id
-  parameters.push_back(1);  // parameters[6] is the tcc1 id
-  parameters.push_back(2);  // parameters[7] is the tcc2 id
-  parameters.push_back(3);  // parameters[8] is the tcc3 id
-  parameters.push_back(4);  // parameters[9] is the tcc4 id
+  parameters.push_back(10);  // parameters[0] is the xtal samples
+  parameters.push_back(1);   // parameters[1] is the number of trigger time samples for TPG's
+  parameters.push_back(68);  // parameters[2] is the number of TT
+  parameters.push_back(68);  // parameters[3] is the number of SR Flags
+  parameters.push_back(1);   // parameters[4] is the dcc id
+  parameters.push_back(1);   // parameters[5] is the sr id
+  parameters.push_back(1);   // parameters[6] is the tcc1 id
+  parameters.push_back(2);   // parameters[7] is the tcc2 id
+  parameters.push_back(3);   // parameters[8] is the tcc3 id
+  parameters.push_back(4);   // parameters[9] is the tcc4 id
 
   theParser_ = new DCCTBDataParser(parameters);
 
   tbName_ = tbName;
 
-  for(int i=0; i<68; ++i) 
-    for (int j=0; j<5; ++j)
-      for (int k=0; k<5; ++k)
-	cryIcMap_[i][j][k] = cryIcMap[i][j][k];
-  
-  for(int i=0; i<71; ++i)
+  for (int i = 0; i < 68; ++i)
+    for (int j = 0; j < 5; ++j)
+      for (int k = 0; k < 5; ++k)
+        cryIcMap_[i][j][k] = cryIcMap[i][j][k];
+
+  for (int i = 0; i < 71; ++i)
     tbStatusToLocation_[i] = tbStatusToLocation[i];
-  
-  for(int i=0; i<201; ++i)
+
+  for (int i = 0; i < 201; ++i)
     tbTowerIDToLocation_[i] = tbTowerIDToLocation[i];
-
-
 }
- 
-void EcalTB07DaqFormatter::interpretRawData(const FEDRawData & fedData , 
-					    EBDigiCollection& digicollection,
-					    EEDigiCollection& eeDigiCollection,
-					    EcalPnDiodeDigiCollection & pndigicollection, 
-					    EcalRawDataCollection& DCCheaderCollection, 
-					    EBDetIdCollection & dccsizecollection, 
-					    EcalElectronicsIdCollection & ttidcollection, 
-					    EcalElectronicsIdCollection & blocksizecollection,
-					    EBDetIdCollection & chidcollection , EBDetIdCollection & gaincollection, 
-					    EBDetIdCollection & gainswitchcollection, 
-					    EcalElectronicsIdCollection & memttidcollection,  
-					    EcalElectronicsIdCollection & memblocksizecollection,
-					    EcalElectronicsIdCollection & memgaincollection,  
-					    EcalElectronicsIdCollection & memchidcollection,
-					    EcalTrigPrimDigiCollection &tpcollection)
-  {
 
-
-  const unsigned char * pData = fedData.data();
+void EcalTB07DaqFormatter::interpretRawData(const FEDRawData& fedData,
+                                            EBDigiCollection& digicollection,
+                                            EEDigiCollection& eeDigiCollection,
+                                            EcalPnDiodeDigiCollection& pndigicollection,
+                                            EcalRawDataCollection& DCCheaderCollection,
+                                            EBDetIdCollection& dccsizecollection,
+                                            EcalElectronicsIdCollection& ttidcollection,
+                                            EcalElectronicsIdCollection& blocksizecollection,
+                                            EBDetIdCollection& chidcollection,
+                                            EBDetIdCollection& gaincollection,
+                                            EBDetIdCollection& gainswitchcollection,
+                                            EcalElectronicsIdCollection& memttidcollection,
+                                            EcalElectronicsIdCollection& memblocksizecollection,
+                                            EcalElectronicsIdCollection& memgaincollection,
+                                            EcalElectronicsIdCollection& memchidcollection,
+                                            EcalTrigPrimDigiCollection& tpcollection) {
+  const unsigned char* pData = fedData.data();
   int length = fedData.size();
-  bool shit=true;
-  unsigned int tower=0;
-  int ch=0;
-  int strip=0;
+  bool shit = true;
+  unsigned int tower = 0;
+  int ch = 0;
+  int strip = 0;
 
   LogDebug("EcalTB07RawToDigi") << "@SUB=EcalTB07DaqFormatter::interpretRawData"
-			      << "size " << length;
- 
+                                << "size " << length;
 
   // mean + 3sigma estimation needed when switching to 0suppressed data
   digicollection.reserve(kCrystals);
   eeDigiCollection.reserve(kCrystals);
   pnAllocated = false;
-  
 
-  theParser_->parseBuffer( reinterpret_cast<const uint32_t*>(pData), static_cast<uint32_t>(length), shit );
-  
-  std::vector< DCCTBEventBlock * > &   dccEventBlocks = theParser_->dccEvents();
+  theParser_->parseBuffer(reinterpret_cast<const uint32_t*>(pData), static_cast<uint32_t>(length), shit);
+
+  std::vector<DCCTBEventBlock*>& dccEventBlocks = theParser_->dccEvents();
 
   // Access each DCCTB block
-  for( std::vector< DCCTBEventBlock * >::iterator itEventBlock = dccEventBlocks.begin(); 
-       itEventBlock != dccEventBlocks.end(); 
-       itEventBlock++){
-    
+  for (std::vector<DCCTBEventBlock*>::iterator itEventBlock = dccEventBlocks.begin();
+       itEventBlock != dccEventBlocks.end();
+       itEventBlock++) {
     bool _displayParserMessages = false;
-    if( (*itEventBlock)->eventHasErrors() && _displayParserMessages)
-      {
-	edm::LogWarning("EcalTB07RawToDigi") << "@SUB=EcalTB07DaqFormatter::interpretRawData"
-				      << "errors found from parser... ";
-        edm::LogWarning("EcalTB07RawToDigi") << (*itEventBlock)->eventErrorString();
-        edm::LogWarning("EcalTB07RawToDigi") << "@SUB=EcalTB07DaqFormatter::interpretRawData"
-				      << "... errors from parser notified";
-      }
+    if ((*itEventBlock)->eventHasErrors() && _displayParserMessages) {
+      edm::LogWarning("EcalTB07RawToDigi") << "@SUB=EcalTB07DaqFormatter::interpretRawData"
+                                           << "errors found from parser... ";
+      edm::LogWarning("EcalTB07RawToDigi") << (*itEventBlock)->eventErrorString();
+      edm::LogWarning("EcalTB07RawToDigi") << "@SUB=EcalTB07DaqFormatter::interpretRawData"
+                                           << "... errors from parser notified";
+    }
 
     // getting the fields of the DCC header
     EcalDCCHeaderBlock theDCCheader;
 
-    theDCCheader.setId(46);                                                      // tb EE unpacker: forced to 46 to match EE region used at h2
+    theDCCheader.setId(46);  // tb EE unpacker: forced to 46 to match EE region used at h2
     int fedId = (*itEventBlock)->getDataField("FED/DCC ID");
-    theDCCheader.setFedId( fedId );                                             // fed id as found in raw data (0... 35 at tb )
+    theDCCheader.setFedId(fedId);  // fed id as found in raw data (0... 35 at tb )
 
     theDCCheader.setRunNumber((*itEventBlock)->getDataField("RUN NUMBER"));
     short trigger_type = (*itEventBlock)->getDataField("TRIGGER TYPE");
-    short zs  = (*itEventBlock)->getDataField("ZS");
+    short zs = (*itEventBlock)->getDataField("ZS");
     short tzs = (*itEventBlock)->getDataField("TZS");
-    short sr  = (*itEventBlock)->getDataField("SR");
-    bool  dataIsSuppressed;
+    short sr = (*itEventBlock)->getDataField("SR");
+    bool dataIsSuppressed;
 
     // if zs&&tzs the suppression algo is used in DCC, the data are not suppressed and zs-bits are set
-    if ( zs && !(tzs) ) dataIsSuppressed = true;
-    else  dataIsSuppressed = false;
+    if (zs && !(tzs))
+      dataIsSuppressed = true;
+    else
+      dataIsSuppressed = false;
 
-    if(trigger_type >0 && trigger_type <5){theDCCheader.setBasicTriggerType(trigger_type);}
-    else{ edm::LogWarning("EcalTB07RawToDigiTriggerType") << "@SUB=EcalTB07DaqFormatter::interpretRawData"
-							<< "unrecognized TRIGGER TYPE: "<<trigger_type;}
+    if (trigger_type > 0 && trigger_type < 5) {
+      theDCCheader.setBasicTriggerType(trigger_type);
+    } else {
+      edm::LogWarning("EcalTB07RawToDigiTriggerType") << "@SUB=EcalTB07DaqFormatter::interpretRawData"
+                                                      << "unrecognized TRIGGER TYPE: " << trigger_type;
+    }
     theDCCheader.setLV1((*itEventBlock)->getDataField("LV1"));
     theDCCheader.setOrbit((*itEventBlock)->getDataField("ORBIT COUNTER"));
     theDCCheader.setBX((*itEventBlock)->getDataField("BX"));
     theDCCheader.setErrors((*itEventBlock)->getDataField("DCC ERRORS"));
-    theDCCheader.setSelectiveReadout( sr );
-    theDCCheader.setZeroSuppression( zs );
-    theDCCheader.setTestZeroSuppression( tzs );
+    theDCCheader.setSelectiveReadout(sr);
+    theDCCheader.setZeroSuppression(zs);
+    theDCCheader.setTestZeroSuppression(tzs);
     theDCCheader.setSrpStatus((*itEventBlock)->getDataField("SR_CHSTATUS"));
 
-
-
-
     std::vector<short> theTCCs;
-    for(int i=0; i<MAX_TCC_SIZE; i++){
-      
-      char TCCnum[20]; sprintf(TCCnum,"TCC_CHSTATUS#%d",i+1); std::string TCCnumS(TCCnum);
-      theTCCs.push_back ((*itEventBlock)->getDataField(TCCnumS) );
+    for (int i = 0; i < MAX_TCC_SIZE; i++) {
+      char TCCnum[20];
+      sprintf(TCCnum, "TCC_CHSTATUS#%d", i + 1);
+      std::string TCCnumS(TCCnum);
+      theTCCs.push_back((*itEventBlock)->getDataField(TCCnumS));
     }
     theDCCheader.setTccStatus(theTCCs);
 
+    std::vector<DCCTBTCCBlock*> tccBlocks = (*itEventBlock)->tccBlocks();
 
-    std::vector< DCCTBTCCBlock * > tccBlocks = (*itEventBlock)->tccBlocks();
-    
-    for(    std::vector< DCCTBTCCBlock * >::iterator itTCCBlock = tccBlocks.begin(); 
-	    itTCCBlock != tccBlocks.end(); 
-	    itTCCBlock ++)
-      {
+    for (std::vector<DCCTBTCCBlock*>::iterator itTCCBlock = tccBlocks.begin(); itTCCBlock != tccBlocks.end();
+         itTCCBlock++) {
+      std::vector<std::pair<int, bool> > TpSamples = (*itTCCBlock)->triggerSamples();
+      // std::vector of 3 bits
+      std::vector<int> TpFlags = (*itTCCBlock)->triggerFlags();
 
-	std::vector< std::pair<int,bool> > TpSamples = (* itTCCBlock) -> triggerSamples() ;
-	// std::vector of 3 bits
-	std::vector<int> TpFlags      = (* itTCCBlock) -> triggerFlags() ;
-	
-	// there have always to be 68 primitives and flags, per FED
-	if (TpSamples.size()==68   && TpFlags.size()==68)
-	  {
-	    for(int i=0; i<((int)TpSamples.size()); i++)	
-	      {
-		
-		int etaTT = (i)  / kTowersInPhi +1;
-		int phiTT = (i) % kTowersInPhi +1;
+      // there have always to be 68 primitives and flags, per FED
+      if (TpSamples.size() == 68 && TpFlags.size() == 68) {
+        for (int i = 0; i < ((int)TpSamples.size()); i++) {
+          int etaTT = (i) / kTowersInPhi + 1;
+          int phiTT = (i) % kTowersInPhi + 1;
 
-		// follow HB convention in iphi
-		phiTT=3-phiTT;
-		if(phiTT<=0)phiTT=phiTT+72;
+          // follow HB convention in iphi
+          phiTT = 3 - phiTT;
+          if (phiTT <= 0)
+            phiTT = phiTT + 72;
 
-		EcalTriggerPrimitiveSample theSample(TpSamples[i].first, TpSamples[i].second, TpFlags[i]);
+          EcalTriggerPrimitiveSample theSample(TpSamples[i].first, TpSamples[i].second, TpFlags[i]);
 
-		EcalTrigTowerDetId idtt(2, EcalBarrel, etaTT, phiTT, 0);
-		EcalTriggerPrimitiveDigi thePrimitive(idtt);
-		thePrimitive.setSize(1);                          // hard coded
-		thePrimitive.setSample(0, theSample);
-		
-		tpcollection.push_back(thePrimitive);
-		
-		LogDebug("EcalTB07RawToDigiTpg") << "@SUBS=EcalTB07DaqFormatter::interpretRawData"
-					       << "tower: " << (i+1) 
-					       << " primitive: " << TpSamples[i].first
-					       << " flag: " << TpSamples[i].second;
+          EcalTrigTowerDetId idtt(2, EcalBarrel, etaTT, phiTT, 0);
+          EcalTriggerPrimitiveDigi thePrimitive(idtt);
+          thePrimitive.setSize(1);  // hard coded
+          thePrimitive.setSample(0, theSample);
 
-		LogDebug("EcalTB07RawToDigiTpg") << "@SUBS=EcalTB07DaqFormatter::interpretRawData"<<
-		  "tower: " << (i+1) << " flag: " << TpFlags[i];
-	      }// end loop on tower primitives
-	    
-	  }// end if
-	else
-	  {
-	    edm::LogWarning("EcalTB07RawToDigiTpg") << "68 elements not found for TpFlags or TpSamples, collection will be empty";
-	  }
-      }  
-    
-    
-    
-    
-    short TowerStatus[MAX_TT_SIZE+1];
+          tpcollection.push_back(thePrimitive);
+
+          LogDebug("EcalTB07RawToDigiTpg")
+              << "@SUBS=EcalTB07DaqFormatter::interpretRawData"
+              << "tower: " << (i + 1) << " primitive: " << TpSamples[i].first << " flag: " << TpSamples[i].second;
+
+          LogDebug("EcalTB07RawToDigiTpg") << "@SUBS=EcalTB07DaqFormatter::interpretRawData"
+                                           << "tower: " << (i + 1) << " flag: " << TpFlags[i];
+        }  // end loop on tower primitives
+
+      }  // end if
+      else {
+        edm::LogWarning("EcalTB07RawToDigiTpg")
+            << "68 elements not found for TpFlags or TpSamples, collection will be empty";
+      }
+    }
+
+    short TowerStatus[MAX_TT_SIZE + 1];
     char buffer[25];
     std::vector<short> theTTstatus;
-    for(int i=1;i<MAX_TT_SIZE+1;i++)
-      { 
- 	sprintf(buffer, "FE_CHSTATUS#%d", i);
- 	std::string Tower(buffer);
- 	TowerStatus[i]= (*itEventBlock)->getDataField(Tower);
-	theTTstatus.push_back(TowerStatus[i]);
-	//std::cout << "tower " << i << " has status " <<  TowerStatus[i] << std::endl;  
-      }
+    for (int i = 1; i < MAX_TT_SIZE + 1; i++) {
+      sprintf(buffer, "FE_CHSTATUS#%d", i);
+      std::string Tower(buffer);
+      TowerStatus[i] = (*itEventBlock)->getDataField(Tower);
+      theTTstatus.push_back(TowerStatus[i]);
+      //std::cout << "tower " << i << " has status " <<  TowerStatus[i] << std::endl;
+    }
     bool checkTowerStatus = TowerStatus[1] == 0 && TowerStatus[2] == 0 && TowerStatus[3] == 0 && TowerStatus[4] == 0;
-    for (int i=5; i < MAX_TT_SIZE+1; ++i) checkTowerStatus = checkTowerStatus && TowerStatus[i] == 1;
+    for (int i = 5; i < MAX_TT_SIZE + 1; ++i)
+      checkTowerStatus = checkTowerStatus && TowerStatus[i] == 1;
     if (!checkTowerStatus) {
-      for(int i=1; i<MAX_TT_SIZE+1; ++i) {
-	std::cout << "tower " << i << " has status " << TowerStatus[i] << std::endl;
+      for (int i = 1; i < MAX_TT_SIZE + 1; ++i) {
+        std::cout << "tower " << i << " has status " << TowerStatus[i] << std::endl;
       }
     }
 
@@ -242,7 +225,7 @@ void EcalTB07DaqFormatter::interpretRawData(const FEDRawData & fedData ,
     theRuntypeDecoder.Decode(DCCruntype, &theDCCheader);
     //DCCHeader filled!
     DCCheaderCollection.push_back(theDCCheader);
-    
+
     // add three more DCC headers (EE region used at h4)
     EcalDCCHeaderBlock hdr = theDCCheader;
     hdr.setId(04);
@@ -252,15 +235,14 @@ void EcalTB07DaqFormatter::interpretRawData(const FEDRawData & fedData ,
     hdr.setId(06);
     DCCheaderCollection.push_back(hdr);
 
-    std::vector< DCCTBTowerBlock * > dccTowerBlocks = (*itEventBlock)->towerBlocks();
+    std::vector<DCCTBTowerBlock*> dccTowerBlocks = (*itEventBlock)->towerBlocks();
     LogDebug("EcalTB07RawToDigi") << "@SUBS=EcalTB07DaqFormatter::interpretRawData"
-				<< "dccTowerBlocks size " << dccTowerBlocks.size();
+                                  << "dccTowerBlocks size " << dccTowerBlocks.size();
 
-
-
-    _expTowersIndex=0;_numExpectedTowers=0;
-    for (int v=0; v<71; v++){
-      _ExpectedTowers[v]=99999;
+    _expTowersIndex = 0;
+    _numExpectedTowers = 0;
+    for (int v = 0; v < 71; v++) {
+      _ExpectedTowers[v] = 99999;
     }
 
     // note: these are the tower statuses handled at the moment - to be completed
@@ -268,52 +250,43 @@ void EcalTB07DaqFormatter::interpretRawData(const FEDRawData & fedData ,
     // staus==9:   Synk error LV1, tower expected;
     // staus==10:  Synk error BX, tower expected;
     // status==1, 2, 3, 4, 5:  tower not expected
-    for (int u=1; u< (kTriggerTowersAndMem+1); u++)
-      {
-	// map status array to expected tower array
-	//int towerMap[kTriggerTowersAndMem+1];
-	//for (int i=0; i<kTriggerTowersAndMem; ++i ) towerMap[i] = i;
-	//towerMap[1] = 6;
-	//towerMap[2] = 2;
-	//towerMap[3] = 1;
-	//towerMap[4] = 5;
+    for (int u = 1; u < (kTriggerTowersAndMem + 1); u++) {
+      // map status array to expected tower array
+      //int towerMap[kTriggerTowersAndMem+1];
+      //for (int i=0; i<kTriggerTowersAndMem; ++i ) towerMap[i] = i;
+      //towerMap[1] = 6;
+      //towerMap[2] = 2;
+      //towerMap[3] = 1;
+      //towerMap[4] = 5;
 
-	if(   TowerStatus[u] ==0 || TowerStatus[u] ==9 || TowerStatus[u] ==10  ) 
-	  {_ExpectedTowers[_expTowersIndex]= tbStatusToLocation_[u];
-	    _expTowersIndex++;
-	    _numExpectedTowers++;
-	  }
+      if (TowerStatus[u] == 0 || TowerStatus[u] == 9 || TowerStatus[u] == 10) {
+        _ExpectedTowers[_expTowersIndex] = tbStatusToLocation_[u];
+        _expTowersIndex++;
+        _numExpectedTowers++;
       }
+    }
     // resetting counter of expected towers
-    _expTowersIndex=0;
-      
-      
+    _expTowersIndex = 0;
+
     // if number of dccEventBlocks NOT same as expected stop
-    if (!      (dccTowerBlocks.size() == _numExpectedTowers)      )
-      {
-        // we probably always want to know if this happens
-        edm::LogWarning("EcalTB07RawToDigiNumTowerBlocks") << "@SUB=EcalTB07DaqFormatter::interpretRawData"
-				      << "number of TowerBlocks found (" << dccTowerBlocks.size()
-				      << ") differs from expected (" << _numExpectedTowers 
-				      << ") skipping event"; 
+    if (!(dccTowerBlocks.size() == _numExpectedTowers)) {
+      // we probably always want to know if this happens
+      edm::LogWarning("EcalTB07RawToDigiNumTowerBlocks")
+          << "@SUB=EcalTB07DaqFormatter::interpretRawData"
+          << "number of TowerBlocks found (" << dccTowerBlocks.size() << ") differs from expected ("
+          << _numExpectedTowers << ") skipping event";
 
-        EBDetId idsm(1, 1);
-        dccsizecollection.push_back(idsm);
-	
-	return;
-	
-      }
-      
+      EBDetId idsm(1, 1);
+      dccsizecollection.push_back(idsm);
 
+      return;
+    }
 
-
-
-    // Access the Tower block    
-    for( std::vector< DCCTBTowerBlock * >::iterator itTowerBlock = dccTowerBlocks.begin(); 
-         itTowerBlock!= dccTowerBlocks.end(); 
-         itTowerBlock++){
-
-      tower=(*itTowerBlock)->towerID();
+    // Access the Tower block
+    for (std::vector<DCCTBTowerBlock*>::iterator itTowerBlock = dccTowerBlocks.begin();
+         itTowerBlock != dccTowerBlocks.end();
+         itTowerBlock++) {
+      tower = (*itTowerBlock)->towerID();
       // here is "correct" h2 map
       //if ( tower == 1  ) tower = 6;
       //if ( tower == 71 ) tower = 2;
@@ -321,432 +294,376 @@ void EcalTB07DaqFormatter::interpretRawData(const FEDRawData & fedData ,
       //if ( tower == 45 ) tower = 5;
       tower = tbTowerIDToLocation_[tower];
 
-      // checking if tt in data is the same as tt expected 
+      // checking if tt in data is the same as tt expected
       // else skip tower and increment problem counter
-	    
+
       // dccId set to 46 in order to match 'real' CMS positio at H2
 
       EcalElectronicsId idtt(46, _ExpectedTowers[_expTowersIndex], 1, 1);
-    
 
-      if (  !(tower == _ExpectedTowers[_expTowersIndex])	  )
-        {	
-	  
-	  if (_ExpectedTowers[_expTowersIndex] <= 68){
-	    edm::LogWarning("EcalTB07RawToDigiTowerId") << "@SUBS=EcalTB07DaqFormatter::interpretRawData"
-							<< "TTower id found (=" << tower 
-							<< ") different from expected (=" <<  _ExpectedTowers[_expTowersIndex] 
-							<< ") " << (_expTowersIndex+1) << "-th tower checked"
-							<< "\n Real hardware id is " << (*itTowerBlock)->towerID();
+      if (!(tower == _ExpectedTowers[_expTowersIndex])) {
+        if (_ExpectedTowers[_expTowersIndex] <= 68) {
+          edm::LogWarning("EcalTB07RawToDigiTowerId")
+              << "@SUBS=EcalTB07DaqFormatter::interpretRawData"
+              << "TTower id found (=" << tower << ") different from expected (=" << _ExpectedTowers[_expTowersIndex]
+              << ") " << (_expTowersIndex + 1) << "-th tower checked"
+              << "\n Real hardware id is " << (*itTowerBlock)->towerID();
 
-	    //  report on failed tt_id for regular tower block
-	    ttidcollection.push_back(idtt);
-	  }
-	  else
-	    {
-	      edm::LogWarning("EcalTB07RawToDigiTowerId") << "@SUB=EcalTB07DaqFormatter:interpretRawData"
-							<< "DecodeMEM: tower " << tower  
-							<< " is not the same as expected " << ((int)_ExpectedTowers[_expTowersIndex])
-							<< " (according to DCC header channel status)";
-	      
-	      // report on failed tt_id for mem tower block
-	      // chosing channel 1 as representative
-	      EcalElectronicsId id(1, (int)_ExpectedTowers[_expTowersIndex], 1, 1);
-	      memttidcollection.push_back(id);
-	    }
+          //  report on failed tt_id for regular tower block
+          ttidcollection.push_back(idtt);
+        } else {
+          edm::LogWarning("EcalTB07RawToDigiTowerId")
+              << "@SUB=EcalTB07DaqFormatter:interpretRawData"
+              << "DecodeMEM: tower " << tower << " is not the same as expected "
+              << ((int)_ExpectedTowers[_expTowersIndex]) << " (according to DCC header channel status)";
 
-          ++ _expTowersIndex;
-          continue;	
-        }// if TT id found  different than expected 
-	
+          // report on failed tt_id for mem tower block
+          // chosing channel 1 as representative
+          EcalElectronicsId id(1, (int)_ExpectedTowers[_expTowersIndex], 1, 1);
+          memttidcollection.push_back(id);
+        }
 
+        ++_expTowersIndex;
+        continue;
+      }  // if TT id found  different than expected
 
       /*********************************
        //    tt: 1 ... 68: crystal data
        *********************************/
-      if (  0<  (*itTowerBlock)->towerID() &&
-	    ((*itTowerBlock)->towerID() < (kTriggerTowers+1)  || 
-	     (*itTowerBlock)->towerID() == 71 || 
-	     (*itTowerBlock)->towerID() == 80)
-	    )
-	{
-	  
-	  std::vector<DCCTBXtalBlock * > & xtalDataBlocks = (*itTowerBlock)->xtalBlocks();	
-	  
-	  // if there is no zero suppression, tower block must have have 25 channels in it
-	  if (  (!dataIsSuppressed)   &&   (xtalDataBlocks.size() != kChannelsPerTower)   )
-	    {     
-	      edm::LogWarning("EcalTB07RawToDigiTowerSize") << "EcalTB07DaqFormatter::interpretRawData, no zero suppression "
-					    << "wrong tower block size is: "  << xtalDataBlocks.size() 
-					    << " at LV1 " << (*itEventBlock)->getDataField("LV1")
-					    << " for TT " << _ExpectedTowers[_expTowersIndex];
-	      // report on wrong tt block size
-	      blocksizecollection.push_back(idtt);
+      if (0 < (*itTowerBlock)->towerID() && ((*itTowerBlock)->towerID() < (kTriggerTowers + 1) ||
+                                             (*itTowerBlock)->towerID() == 71 || (*itTowerBlock)->towerID() == 80)) {
+        std::vector<DCCTBXtalBlock*>& xtalDataBlocks = (*itTowerBlock)->xtalBlocks();
 
-	      ++ _expTowersIndex; 	      continue;	
+        // if there is no zero suppression, tower block must have have 25 channels in it
+        if ((!dataIsSuppressed) && (xtalDataBlocks.size() != kChannelsPerTower)) {
+          edm::LogWarning("EcalTB07RawToDigiTowerSize")
+              << "EcalTB07DaqFormatter::interpretRawData, no zero suppression "
+              << "wrong tower block size is: " << xtalDataBlocks.size() << " at LV1 "
+              << (*itEventBlock)->getDataField("LV1") << " for TT " << _ExpectedTowers[_expTowersIndex];
+          // report on wrong tt block size
+          blocksizecollection.push_back(idtt);
 
-	    }
-	  
+          ++_expTowersIndex;
+          continue;
+        }
 
-	  short cryInTower =0;
+        short cryInTower = 0;
 
-	  short expStripInTower;
-	  short expCryInStrip;
-	  short expCryInTower =0;
+        short expStripInTower;
+        short expCryInStrip;
+        short expCryInTower = 0;
 
-	  // Access the Xstal data
-	  for( std::vector< DCCTBXtalBlock * >::iterator itXtalBlock = xtalDataBlocks.begin(); 
-	       itXtalBlock!= xtalDataBlocks.end(); 
-	       itXtalBlock++){ //loop on crys of a  tower
+        // Access the Xstal data
+        for (std::vector<DCCTBXtalBlock*>::iterator itXtalBlock = xtalDataBlocks.begin();
+             itXtalBlock != xtalDataBlocks.end();
+             itXtalBlock++) {  //loop on crys of a  tower
 
-	    strip              =(*itXtalBlock)->stripID();
-	    ch                 =(*itXtalBlock)->xtalID();
-	    cryInTower  =(strip-1)* kChannelsPerCard + (ch -1);
+          strip = (*itXtalBlock)->stripID();
+          ch = (*itXtalBlock)->xtalID();
+          cryInTower = (strip - 1) * kChannelsPerCard + (ch - 1);
 
-	    expStripInTower   =  expCryInTower/5 +1;
-	    expCryInStrip     =  expCryInTower%5 +1;
-	    
-	    
-	    // FIXME: waiting for geometry to do (TT, strip,chNum) <--> (SMChId)
-	    // short abscissa = (_ExpectedTowers[_expTowersIndex]-1)  /4;
-	    // short ordinate = (_ExpectedTowers[_expTowersIndex]-1)  %4;
-	    // temporarily choosing central crystal in trigger tower
-	    // int cryIdInSM  = 45 + ordinate*5 + abscissa * 100;
-	    
-	    
-	    // in case of 0 zuppressed data, check that cryInTower constantly grows
-	    if (dataIsSuppressed)
-	      {
-		
-		if ( strip < 1 || 5<strip || ch <1 || 5 < ch)
-		  {
-		    int  sm = 1; // hardcoded because of test  beam
-		    for (int StripInTower_ =1;  StripInTower_ < 6; StripInTower_++){
-		      for (int  CryInStrip_ =1;  CryInStrip_ < 6; CryInStrip_++){
-			int  ic        = cryIc(tower, StripInTower_,  CryInStrip_) ;
-			EBDetId               idExp(sm, ic,1);
-			chidcollection.push_back(idExp);
-		      }
-		    }
-		    
-		    edm::LogWarning("EcalTB07RawToDigiChId") << "EcalTB07DaqFormatter::interpretRawData with zero suppression, "
-							   << " wrong channel id, since out of range: "
-							   << "\t strip: "  << strip  << "\t channel: " << ch
-							   << "\t in TT: " << _ExpectedTowers[_expTowersIndex]
-							   << "\t at LV1 : " << (*itEventBlock)->getDataField("LV1");
-		    
-		    expCryInTower++;
-		    continue;
-		  }
+          expStripInTower = expCryInTower / 5 + 1;
+          expCryInStrip = expCryInTower % 5 + 1;
 
+          // FIXME: waiting for geometry to do (TT, strip,chNum) <--> (SMChId)
+          // short abscissa = (_ExpectedTowers[_expTowersIndex]-1)  /4;
+          // short ordinate = (_ExpectedTowers[_expTowersIndex]-1)  %4;
+          // temporarily choosing central crystal in trigger tower
+          // int cryIdInSM  = 45 + ordinate*5 + abscissa * 100;
 
-		// correct ordering
-		if(  cryInTower >= expCryInTower ){
-		  expCryInTower = cryInTower +1;
-		}
-		
-		
-		// cry_id wrong because of incorrect ordering within trigger tower
-		else
-		  {
-		    edm::LogWarning("EcalTB07RawToDigiChId") << "EcalTB07DaqFormatter::interpretRawData with zero suppression, "
-						  << " based on ch ordering within tt, wrong channel id: "
-						  << "\t strip: "  << strip  << "\t channel: " << ch
-						  << "\t cryInTower "  << cryInTower
-						  << "\t expCryInTower: " << expCryInTower
-						  << "\t in TT: " << _ExpectedTowers[_expTowersIndex]
-						  << "\t at LV1: " << (*itEventBlock)->getDataField("LV1");
-		    
-		    int  sm = 1; // hardcoded because of test  beam
-		    for (int StripInTower_ =1;  StripInTower_ < 6; StripInTower_++){
-		      for (int  CryInStrip_ =1;  CryInStrip_ < 6; CryInStrip_++){
-			int  ic        = cryIc(tower, StripInTower_,  CryInStrip_) ;
-			EBDetId               idExp(sm, ic,1);
-			chidcollection.push_back(idExp);
-		      }
-		    }
-		    
-		    // chennel with id which does not follow correct odering
-		    expCryInTower++;		    continue;
-		    
-		  }// end 'ch_id does not respect growing order'
-		
-	      }// end   if zero supression
-	    
-	    
+          // in case of 0 zuppressed data, check that cryInTower constantly grows
+          if (dataIsSuppressed) {
+            if (strip < 1 || 5 < strip || ch < 1 || 5 < ch) {
+              int sm = 1;  // hardcoded because of test  beam
+              for (int StripInTower_ = 1; StripInTower_ < 6; StripInTower_++) {
+                for (int CryInStrip_ = 1; CryInStrip_ < 6; CryInStrip_++) {
+                  int ic = cryIc(tower, StripInTower_, CryInStrip_);
+                  EBDetId idExp(sm, ic, 1);
+                  chidcollection.push_back(idExp);
+                }
+              }
 
-	    else {
-	      
-	      // checking that ch and strip are within range and cryInTower is as expected
-	      if(   cryInTower != expCryInTower   ||  
-		    strip < 1 ||   kStripsPerTower <strip  ||
-		    ch <1  ||   kChannelsPerStrip < ch    ) 
-		{
-		  
-		  int ic        = cryIc(tower, expStripInTower,  expCryInStrip) ;
-		  int  sm = 1; // hardcoded because of test  beam
-		  EBDetId  idExp(sm, ic,1);
-		  
-		  edm::LogWarning("EcalTB07RawToDigiChId") << "EcalTB07DaqFormatter::interpretRawData no zero suppression "
-						    << " wrong channel id for channel: "  << expCryInStrip
-						    << "\t strip: " << expStripInTower
-						    << "\t in TT: " << _ExpectedTowers[_expTowersIndex]
-						    << "\t at LV1: " << (*itEventBlock)->getDataField("LV1")
-						    << "\t   (in the data, found channel:  " << ch
-						    << "\t strip:  " << strip << " ).";
+              edm::LogWarning("EcalTB07RawToDigiChId")
+                  << "EcalTB07DaqFormatter::interpretRawData with zero suppression, "
+                  << " wrong channel id, since out of range: "
+                  << "\t strip: " << strip << "\t channel: " << ch << "\t in TT: " << _ExpectedTowers[_expTowersIndex]
+                  << "\t at LV1 : " << (*itEventBlock)->getDataField("LV1");
 
-		  
-		  // report on wrong channel id
-		  chidcollection.push_back(idExp);
+              expCryInTower++;
+              continue;
+            }
 
-		  // there has been unexpected crystal id, dataframe not to go to the Event
-		  expCryInTower++; 		  continue;
-		  
-		} // if channel in data does not equal expected channel
+            // correct ordering
+            if (cryInTower >= expCryInTower) {
+              expCryInTower = cryInTower + 1;
+            }
 
-	      expCryInTower++;
+            // cry_id wrong because of incorrect ordering within trigger tower
+            else {
+              edm::LogWarning("EcalTB07RawToDigiChId")
+                  << "EcalTB07DaqFormatter::interpretRawData with zero suppression, "
+                  << " based on ch ordering within tt, wrong channel id: "
+                  << "\t strip: " << strip << "\t channel: " << ch << "\t cryInTower " << cryInTower
+                  << "\t expCryInTower: " << expCryInTower << "\t in TT: " << _ExpectedTowers[_expTowersIndex]
+                  << "\t at LV1: " << (*itEventBlock)->getDataField("LV1");
 
-	    } // end 'not zero suppression'
-	    
-	    
-	    
-	    // data  to be stored in EBDataFrame, identified by EBDetId
-	    int  ic = cryIc(tower, strip, ch) ;
-	    int  sm = 1;
-	    EBDetId  id(sm, ic,1);      
-	    // EE data to be stored in EEDataFrame, identified by EEDetId
-	    // eeId(int i, int j, int iz (+1/-1), int mode = XYMODE)
-	    int ix = getEE_ix(tower, strip, ch);
-	    int iy = getEE_iy(tower, strip, ch);
+              int sm = 1;  // hardcoded because of test  beam
+              for (int StripInTower_ = 1; StripInTower_ < 6; StripInTower_++) {
+                for (int CryInStrip_ = 1; CryInStrip_ < 6; CryInStrip_++) {
+                  int ic = cryIc(tower, StripInTower_, CryInStrip_);
+                  EBDetId idExp(sm, ic, 1);
+                  chidcollection.push_back(idExp);
+                }
+              }
 
-	    int iz = 1;
-	    if ( tbName_ == "h4" ) iz = -1;
-	    EEDetId  eeId(ix, iy, iz);
-	        
-            // here data frame go into the Event
-            // removed later on (with a pop_back()) if gain==0 or if forbidden-gain-switch
-            digicollection.push_back( id );
-            eeDigiCollection.push_back( eeId );
-            EBDataFrame theFrame ( digicollection.back() );
-            EEDataFrame eeFrame ( eeDigiCollection.back() );
+              // chennel with id which does not follow correct odering
+              expCryInTower++;
+              continue;
 
-	    std::vector<int> xtalDataSamples = (*itXtalBlock)->xtalDataSamples();   
-	    //theFrame.setSize(xtalDataSamples.size()); // if needed, to be changed when constructing digicollection
-	    //eeFrame. setSize(xtalDataSamples.size()); // if needed, to be changed when constructing eeDigicollection
-      
+            }  // end 'ch_id does not respect growing order'
 
-	    // gain cannot be 0, checking for that
-	    bool        gainIsOk =true;
-	    unsigned gain_mask      = 12288;    //12th and 13th bit
-	    std::vector <int> xtalGain;
+          }  // end   if zero supression
 
-	    for (unsigned short i=0; i<xtalDataSamples.size(); ++i ) {
-	      
-	      theFrame.setSample (i, xtalDataSamples[i] );
-	      eeFrame .setSample (i, xtalDataSamples[i] );
-	      
-	      if((xtalDataSamples[i] & gain_mask) == 0){gainIsOk =false;}
-	      
-	      xtalGain.push_back(0);
-	      xtalGain[i] |= (xtalDataSamples[i] >> 12);
-	    }
-	    
-	    if (! gainIsOk) {
-	      
-	      edm::LogWarning("EcalTB07RawToDigiGainZero") << "@SUB=EcalTB07DaqFormatter::interpretRawData"
-					    << " gain==0 for strip: "  << expStripInTower
-					    << "\t channel: " << expCryInStrip
-					    << "\t in TT: " << _ExpectedTowers[_expTowersIndex]
-					    << "\t ic: " << ic
-					    << "\t at LV1: " << (*itEventBlock)->getDataField("LV1");
-	      // report on gain==0
-	      gaincollection.push_back(id);
-	      
-	      // there has been a gain==0, dataframe not to go to the Event
-              digicollection.pop_back();
-              eeDigiCollection.pop_back();
-	      continue; //	      expCryInTower already incremented
-	    }
+          else {
+            // checking that ch and strip are within range and cryInTower is as expected
+            if (cryInTower != expCryInTower || strip < 1 || kStripsPerTower < strip || ch < 1 ||
+                kChannelsPerStrip < ch) {
+              int ic = cryIc(tower, expStripInTower, expCryInStrip);
+              int sm = 1;  // hardcoded because of test  beam
+              EBDetId idExp(sm, ic, 1);
 
+              edm::LogWarning("EcalTB07RawToDigiChId")
+                  << "EcalTB07DaqFormatter::interpretRawData no zero suppression "
+                  << " wrong channel id for channel: " << expCryInStrip << "\t strip: " << expStripInTower
+                  << "\t in TT: " << _ExpectedTowers[_expTowersIndex]
+                  << "\t at LV1: " << (*itEventBlock)->getDataField("LV1")
+                  << "\t   (in the data, found channel:  " << ch << "\t strip:  " << strip << " ).";
 
-	    
-	    
-	    // looking for forbidden gain transitions
-	    
-	    short firstGainWrong=-1;
-	    short numGainWrong=0;
-	    
-	    for (unsigned short i=0; i<xtalGain.size(); i++ ) {
-	      
-	      if (i>0 && xtalGain[i-1]>xtalGain[i]) {
-		
-		numGainWrong++;// counting forbidden gain transitions
-		
-		if (firstGainWrong == -1) {
-		  firstGainWrong=i;
-		  edm::LogWarning("EcalTB07RawToDigiGainSwitch") << "@SUB=EcalTB07DaqFormatter::interpretRawData"
-							  << "channelHasGainSwitchProblem: crystal eta = " 
-							  << id.ieta() << " phi = " << id.iphi();
-		}
-		edm::LogWarning("EcalTB07RawToDigiGainSwitch") << "@SUB=EcalTB07DaqFormatter::interpretRawData"
-							<< "channelHasGainSwitchProblem: sample = " << (i-1) 
-							<< " gain: " << xtalGain[i-1] << " sample: " 
-							<< i << " gain: " << xtalGain[i];
-	      }
-	    }
+              // report on wrong channel id
+              chidcollection.push_back(idExp);
 
-	    if (numGainWrong>0) {
-	      gainswitchcollection.push_back(id);
+              // there has been unexpected crystal id, dataframe not to go to the Event
+              expCryInTower++;
+              continue;
 
-	      edm::LogWarning("EcalTB07RawToDigiGainSwitch") << "@SUB=EcalTB07DaqFormatter:interpretRawData"
-							<< "channelHasGainSwitchProblem: more than 1 wrong transition";
-		
-	      for (unsigned short i1=0; i1<xtalDataSamples.size(); ++i1 ) {
-		int countADC = 0x00000FFF;
-		countADC &= xtalDataSamples[i1];
-		LogDebug("EcalTB07RawToDigi") << "Sample " << i1 << " ADC " << countADC << " Gain " << xtalGain[i1];
-	      }
+            }  // if channel in data does not equal expected channel
 
-	      // there has been a forbidden gain transition,  dataframe not to go to the Event
-              digicollection.pop_back();
-              eeDigiCollection.pop_back();
-	      continue; //	      expCryInTower already incremented
+            expCryInTower++;
 
-	    }// END of:   'if there is a forbidden gain transition'
+          }  // end 'not zero suppression'
 
-	  }// end loop on crystals within a tower block
-	  
-	  _expTowersIndex++;
-	}// end: tt1 ... tt68, crystal data
-      
+          // data  to be stored in EBDataFrame, identified by EBDetId
+          int ic = cryIc(tower, strip, ch);
+          int sm = 1;
+          EBDetId id(sm, ic, 1);
+          // EE data to be stored in EEDataFrame, identified by EEDetId
+          // eeId(int i, int j, int iz (+1/-1), int mode = XYMODE)
+          int ix = getEE_ix(tower, strip, ch);
+          int iy = getEE_iy(tower, strip, ch);
 
+          int iz = 1;
+          if (tbName_ == "h4")
+            iz = -1;
+          EEDetId eeId(ix, iy, iz);
 
-      
-      
+          // here data frame go into the Event
+          // removed later on (with a pop_back()) if gain==0 or if forbidden-gain-switch
+          digicollection.push_back(id);
+          eeDigiCollection.push_back(eeId);
+          EBDataFrame theFrame(digicollection.back());
+          EEDataFrame eeFrame(eeDigiCollection.back());
+
+          std::vector<int> xtalDataSamples = (*itXtalBlock)->xtalDataSamples();
+          //theFrame.setSize(xtalDataSamples.size()); // if needed, to be changed when constructing digicollection
+          //eeFrame. setSize(xtalDataSamples.size()); // if needed, to be changed when constructing eeDigicollection
+
+          // gain cannot be 0, checking for that
+          bool gainIsOk = true;
+          unsigned gain_mask = 12288;  //12th and 13th bit
+          std::vector<int> xtalGain;
+
+          for (unsigned short i = 0; i < xtalDataSamples.size(); ++i) {
+            theFrame.setSample(i, xtalDataSamples[i]);
+            eeFrame.setSample(i, xtalDataSamples[i]);
+
+            if ((xtalDataSamples[i] & gain_mask) == 0) {
+              gainIsOk = false;
+            }
+
+            xtalGain.push_back(0);
+            xtalGain[i] |= (xtalDataSamples[i] >> 12);
+          }
+
+          if (!gainIsOk) {
+            edm::LogWarning("EcalTB07RawToDigiGainZero")
+                << "@SUB=EcalTB07DaqFormatter::interpretRawData"
+                << " gain==0 for strip: " << expStripInTower << "\t channel: " << expCryInStrip
+                << "\t in TT: " << _ExpectedTowers[_expTowersIndex] << "\t ic: " << ic
+                << "\t at LV1: " << (*itEventBlock)->getDataField("LV1");
+            // report on gain==0
+            gaincollection.push_back(id);
+
+            // there has been a gain==0, dataframe not to go to the Event
+            digicollection.pop_back();
+            eeDigiCollection.pop_back();
+            continue;  //	      expCryInTower already incremented
+          }
+
+          // looking for forbidden gain transitions
+
+          short firstGainWrong = -1;
+          short numGainWrong = 0;
+
+          for (unsigned short i = 0; i < xtalGain.size(); i++) {
+            if (i > 0 && xtalGain[i - 1] > xtalGain[i]) {
+              numGainWrong++;  // counting forbidden gain transitions
+
+              if (firstGainWrong == -1) {
+                firstGainWrong = i;
+                edm::LogWarning("EcalTB07RawToDigiGainSwitch")
+                    << "@SUB=EcalTB07DaqFormatter::interpretRawData"
+                    << "channelHasGainSwitchProblem: crystal eta = " << id.ieta() << " phi = " << id.iphi();
+              }
+              edm::LogWarning("EcalTB07RawToDigiGainSwitch")
+                  << "@SUB=EcalTB07DaqFormatter::interpretRawData"
+                  << "channelHasGainSwitchProblem: sample = " << (i - 1) << " gain: " << xtalGain[i - 1]
+                  << " sample: " << i << " gain: " << xtalGain[i];
+            }
+          }
+
+          if (numGainWrong > 0) {
+            gainswitchcollection.push_back(id);
+
+            edm::LogWarning("EcalTB07RawToDigiGainSwitch")
+                << "@SUB=EcalTB07DaqFormatter:interpretRawData"
+                << "channelHasGainSwitchProblem: more than 1 wrong transition";
+
+            for (unsigned short i1 = 0; i1 < xtalDataSamples.size(); ++i1) {
+              int countADC = 0x00000FFF;
+              countADC &= xtalDataSamples[i1];
+              LogDebug("EcalTB07RawToDigi") << "Sample " << i1 << " ADC " << countADC << " Gain " << xtalGain[i1];
+            }
+
+            // there has been a forbidden gain transition,  dataframe not to go to the Event
+            digicollection.pop_back();
+            eeDigiCollection.pop_back();
+            continue;  //	      expCryInTower already incremented
+
+          }  // END of:   'if there is a forbidden gain transition'
+
+        }  // end loop on crystals within a tower block
+
+        _expTowersIndex++;
+      }  // end: tt1 ... tt68, crystal data
+
       /******************************************************************
        //    tt 69 and 70:  two mem boxes, holding PN0 ... PN9
-       ******************************************************************/	
-      else if (       (*itTowerBlock)->towerID() == 69 
-                      ||	   (*itTowerBlock)->towerID() == 70       )	
-	{
-	  
-	  LogDebug("EcalTB07RawToDigi") << "@SUB=EcalTB07DaqFormatter::interpretRawData"
-				      << "processing mem box num: " << (*itTowerBlock)->towerID();
+       ******************************************************************/
+      else if ((*itTowerBlock)->towerID() == 69 || (*itTowerBlock)->towerID() == 70) {
+        LogDebug("EcalTB07RawToDigi") << "@SUB=EcalTB07DaqFormatter::interpretRawData"
+                                      << "processing mem box num: " << (*itTowerBlock)->towerID();
 
-	  // if tt 69 or 70 found, allocate Pn digi collection
-	  if(! pnAllocated) 
-	    {
-	      pndigicollection.reserve(kPns);
-	      pnAllocated = true;
-	    }
+        // if tt 69 or 70 found, allocate Pn digi collection
+        if (!pnAllocated) {
+          pndigicollection.reserve(kPns);
+          pnAllocated = true;
+        }
 
-	  DecodeMEM( (*itTowerBlock),  pndigicollection , 
-		     memttidcollection,  memblocksizecollection,
-		     memgaincollection,  memchidcollection);
-	  
-	}// end of < if it is a mem box>
-      
-      
-    
+        DecodeMEM((*itTowerBlock),
+                  pndigicollection,
+                  memttidcollection,
+                  memblocksizecollection,
+                  memgaincollection,
+                  memchidcollection);
 
+      }  // end of < if it is a mem box>
 
       // wrong tt id
-      else  {
-        edm::LogWarning("EcalTB07RawToDigiTowerId") <<"@SUB=EcalTB07DaqFormatter::interpretRawData"
-				      << " processing tt with ID not existing ( "
-				      <<  (*itTowerBlock)->towerID() << ")";
-        ++ _expTowersIndex;
-	continue; 
-      }// end: tt id error
+      else {
+        edm::LogWarning("EcalTB07RawToDigiTowerId")
+            << "@SUB=EcalTB07DaqFormatter::interpretRawData"
+            << " processing tt with ID not existing ( " << (*itTowerBlock)->towerID() << ")";
+        ++_expTowersIndex;
+        continue;
+      }  // end: tt id error
 
-    }// end loop on trigger towers
-      
-  }// end loop on events
+    }  // end loop on trigger towers
+
+  }  // end loop on events
 }
 
-
-
-
-
-
-
-
-void EcalTB07DaqFormatter::DecodeMEM( DCCTBTowerBlock *  towerblock,  EcalPnDiodeDigiCollection & pndigicollection ,
-				    EcalElectronicsIdCollection & memttidcollection,  EcalElectronicsIdCollection &  memblocksizecollection,
-				    EcalElectronicsIdCollection & memgaincollection,  EcalElectronicsIdCollection & memchidcollection)
-{
-  
+void EcalTB07DaqFormatter::DecodeMEM(DCCTBTowerBlock* towerblock,
+                                     EcalPnDiodeDigiCollection& pndigicollection,
+                                     EcalElectronicsIdCollection& memttidcollection,
+                                     EcalElectronicsIdCollection& memblocksizecollection,
+                                     EcalElectronicsIdCollection& memgaincollection,
+                                     EcalElectronicsIdCollection& memchidcollection) {
   LogDebug("EcalTB07RawToDigi") << "@SUB=EcalTB07DaqFormatter::DecodeMEM"
- 			      << "in mem " << towerblock->towerID();  
-  
-  int  tower_id = towerblock ->towerID() ;
-  int  mem_id   = tower_id-69;
+                                << "in mem " << towerblock->towerID();
+
+  int tower_id = towerblock->towerID();
+  int mem_id = tower_id - 69;
 
   // initializing container
-  for (int st_id=0; st_id< kStripsPerTower; st_id++){
-    for (int ch_id=0; ch_id<kChannelsPerStrip; ch_id++){
-      for (int sa=0; sa<11; sa++){      
-	memRawSample_[st_id][ch_id][sa] = -1;}    } }
-
-  
-  // check that tower block id corresponds to mem boxes
-  if(tower_id != 69 && tower_id != 70) 
-    {
-      edm::LogWarning("EcalTB07RawToDigiTowerId") << "@SUB=EcalTB07DaqFormatter:decodeMem"
-				    << "DecodeMEM: this is not a mem box tower (" << tower_id << ")";
-      ++ _expTowersIndex;
-      return;
+  for (int st_id = 0; st_id < kStripsPerTower; st_id++) {
+    for (int ch_id = 0; ch_id < kChannelsPerStrip; ch_id++) {
+      for (int sa = 0; sa < 11; sa++) {
+        memRawSample_[st_id][ch_id][sa] = -1;
+      }
     }
+  }
 
-     
+  // check that tower block id corresponds to mem boxes
+  if (tower_id != 69 && tower_id != 70) {
+    edm::LogWarning("EcalTB07RawToDigiTowerId") << "@SUB=EcalTB07DaqFormatter:decodeMem"
+                                                << "DecodeMEM: this is not a mem box tower (" << tower_id << ")";
+    ++_expTowersIndex;
+    return;
+  }
+
   /******************************************************************************
    // getting the raw hits from towerBlock while checking tt and ch data structure 
    ******************************************************************************/
-  std::vector<DCCTBXtalBlock *> & dccXtalBlocks = towerblock->xtalBlocks();
+  std::vector<DCCTBXtalBlock*>& dccXtalBlocks = towerblock->xtalBlocks();
   std::vector<DCCTBXtalBlock*>::iterator itXtal;
 
   // checking mem tower block fo size
-  if (dccXtalBlocks.size() != kChannelsPerTower)
-    {     
-      LogDebug("EcalTB07RawToDigiDccBlockSize") << "@SUB=EcalTB07DaqFormatter:decodeMem"
-				  << " wrong dccBlock size, namely: "  << dccXtalBlocks.size() 
-				  << ", for mem " << _ExpectedTowers[_expTowersIndex];
+  if (dccXtalBlocks.size() != kChannelsPerTower) {
+    LogDebug("EcalTB07RawToDigiDccBlockSize")
+        << "@SUB=EcalTB07DaqFormatter:decodeMem"
+        << " wrong dccBlock size, namely: " << dccXtalBlocks.size() << ", for mem " << _ExpectedTowers[_expTowersIndex];
 
-      // reporting mem-tt block size problem
-      // chosing channel 1 as representative as a dummy...
-      EcalElectronicsId id(1, (int)_ExpectedTowers[_expTowersIndex], 1, 1);
-      memblocksizecollection.push_back(id);
+    // reporting mem-tt block size problem
+    // chosing channel 1 as representative as a dummy...
+    EcalElectronicsId id(1, (int)_ExpectedTowers[_expTowersIndex], 1, 1);
+    memblocksizecollection.push_back(id);
 
-      ++ _expTowersIndex;
-      return;  // if mem tt block size not ok - do not build any Pn digis
-    }
-  
+    ++_expTowersIndex;
+    return;  // if mem tt block size not ok - do not build any Pn digis
+  }
 
   // loop on channels of the mem block
-  int  cryCounter = 0;   int  strip_id  = 0;   int  xtal_id   = 0;  
+  int cryCounter = 0;
+  int strip_id = 0;
+  int xtal_id = 0;
 
-  for ( itXtal = dccXtalBlocks.begin(); itXtal < dccXtalBlocks.end(); itXtal++ ) {
-    strip_id                     = (*itXtal) ->getDataField("STRIP ID");
-    xtal_id                      = (*itXtal) ->getDataField("XTAL ID");
-    int wished_strip_id  = cryCounter/ kStripsPerTower;
-    int wished_ch_id     = cryCounter% kStripsPerTower;
-    
-    if( (wished_strip_id+1) != ((int)strip_id) ||
-	(wished_ch_id+1) != ((int)xtal_id) )
-      {
-	
-	LogDebug("EcalTB07RawToDigiChId") << "@SUB=EcalTB07DaqFormatter:decodeMem"
-				    << " in mem " <<  towerblock->towerID()
-				    << ", expected:\t strip"
-				    << (wished_strip_id+1)  << " cry " << (wished_ch_id+1) << "\tfound: "
-				    << "  strip " <<  strip_id << "  cry " << xtal_id;
-	
-	// report on crystal with unexpected indices
-	EcalElectronicsId id(1, (int)_ExpectedTowers[_expTowersIndex], wished_strip_id,  wished_ch_id);
-	memchidcollection.push_back(id);
-      }
-    
-    
+  for (itXtal = dccXtalBlocks.begin(); itXtal < dccXtalBlocks.end(); itXtal++) {
+    strip_id = (*itXtal)->getDataField("STRIP ID");
+    xtal_id = (*itXtal)->getDataField("XTAL ID");
+    int wished_strip_id = cryCounter / kStripsPerTower;
+    int wished_ch_id = cryCounter % kStripsPerTower;
+
+    if ((wished_strip_id + 1) != ((int)strip_id) || (wished_ch_id + 1) != ((int)xtal_id)) {
+      LogDebug("EcalTB07RawToDigiChId") << "@SUB=EcalTB07DaqFormatter:decodeMem"
+                                        << " in mem " << towerblock->towerID() << ", expected:\t strip"
+                                        << (wished_strip_id + 1) << " cry " << (wished_ch_id + 1) << "\tfound: "
+                                        << "  strip " << strip_id << "  cry " << xtal_id;
+
+      // report on crystal with unexpected indices
+      EcalElectronicsId id(1, (int)_ExpectedTowers[_expTowersIndex], wished_strip_id, wished_ch_id);
+      memchidcollection.push_back(id);
+    }
+
     // Accessing the 10 time samples per Xtal:
     memRawSample_[wished_strip_id][wished_ch_id][1] = (*itXtal)->getDataField("ADC#1");
     memRawSample_[wished_strip_id][wished_ch_id][2] = (*itXtal)->getDataField("ADC#2");
@@ -758,225 +675,193 @@ void EcalTB07DaqFormatter::DecodeMEM( DCCTBTowerBlock *  towerblock,  EcalPnDiod
     memRawSample_[wished_strip_id][wished_ch_id][8] = (*itXtal)->getDataField("ADC#8");
     memRawSample_[wished_strip_id][wished_ch_id][9] = (*itXtal)->getDataField("ADC#9");
     memRawSample_[wished_strip_id][wished_ch_id][10] = (*itXtal)->getDataField("ADC#10");
-      
+
     cryCounter++;
-  }// end loop on crystals of mem dccXtalBlock
-  
+  }  // end loop on crystals of mem dccXtalBlock
+
   // tower accepted and digi read from all 25 channels.
   // Increase counter of expected towers before unpacking in the 5 PNs
-  ++ _expTowersIndex;
-
-
+  ++_expTowersIndex;
 
   /************************************************************
    // unpacking and 'cooking' the raw numbers to get PN sample
    ************************************************************/
-  int tempSample=0;
-  int memStoreIndex=0;
-  int ipn=0;
-  for (memStoreIndex=0; memStoreIndex<500; memStoreIndex++)    {
-    data_MEM[memStoreIndex]= -1;   }
-  
-  
-  for(int strip=0; strip<kStripsPerTower; strip++) {// loop on strips
-    for(int channel=0; channel<kChannelsPerStrip; channel++) {// loop on channels
+  int tempSample = 0;
+  int memStoreIndex = 0;
+  int ipn = 0;
+  for (memStoreIndex = 0; memStoreIndex < 500; memStoreIndex++) {
+    data_MEM[memStoreIndex] = -1;
+  }
 
-      if(strip%2 == 0) 
-	{ipn= mem_id*5+channel;}
-      else 
-	{ipn=mem_id*5+4-channel;}
+  for (int strip = 0; strip < kStripsPerTower; strip++) {            // loop on strips
+    for (int channel = 0; channel < kChannelsPerStrip; channel++) {  // loop on channels
 
-      for(int sample=0;sample< kSamplesPerChannel ;sample++) {
-	tempSample= memRawSample_[strip][channel][sample+1];
+      if (strip % 2 == 0) {
+        ipn = mem_id * 5 + channel;
+      } else {
+        ipn = mem_id * 5 + 4 - channel;
+      }
 
-	int new_data=0;
-	if(strip%2 == 1) {
-	  // 1) if strip number is even, 14 bits are reversed in order
-	  for(int ib=0;ib<14;ib++)
-	    { 
-	      new_data <<= 1;
-	      new_data=new_data | (tempSample&1);
-	      tempSample >>= 1;
-	    }
-	} else {
-	  new_data=tempSample;
-	}
+      for (int sample = 0; sample < kSamplesPerChannel; sample++) {
+        tempSample = memRawSample_[strip][channel][sample + 1];
 
-	// 2) flip 11th bit for AD9052 still there on MEM !
-	// 3) mask with 1 1111 1111 1111
-	new_data = (new_data ^ 0x800) & 0x3fff;    // (new_data  XOR 1000 0000 0000) & 11 1111 1111 1111
-	// new_data = (new_data ^ 0x800) & 0x1fff;    // (new_data  XOR 1000 0000 0000) & 1 1111 1111 1111
+        int new_data = 0;
+        if (strip % 2 == 1) {
+          // 1) if strip number is even, 14 bits are reversed in order
+          for (int ib = 0; ib < 14; ib++) {
+            new_data <<= 1;
+            new_data = new_data | (tempSample & 1);
+            tempSample >>= 1;
+          }
+        } else {
+          new_data = tempSample;
+        }
 
-	//(Bit 12) == 1 -> Gain 16;    (Bit 12) == 0 -> Gain 1	
-	// gain in mem can be 1 or 16 encoded resp. with 0 ir 1 in the 13th bit.
-	// checking and reporting if there is any sample with gain==2,3
-	short sampleGain = (new_data &0x3000)/4096;
-	if (  sampleGain==2 || sampleGain==3) 
-	  {
-	    EcalElectronicsId id(1, (int)_ExpectedTowers[_expTowersIndex], strip, channel);
-	    memgaincollection.push_back(id);
-	    
-	    edm::LogWarning("EcalTB07RawToDigiGainZero")  << "@SUB=EcalTB07DaqFormatter:decodeMem"
-					   << "in mem " <<  towerblock->towerID()
-					   << " :\t strip: "
-					   << (strip +1)  << " cry: " << (channel+1) 
-					   << " has 14th bit non zero! Gain results: "
-					   << sampleGain << ".";
-	    
-	    continue;
-	  }// end 'if gain is zero'
+        // 2) flip 11th bit for AD9052 still there on MEM !
+        // 3) mask with 1 1111 1111 1111
+        new_data = (new_data ^ 0x800) & 0x3fff;  // (new_data  XOR 1000 0000 0000) & 11 1111 1111 1111
+        // new_data = (new_data ^ 0x800) & 0x1fff;    // (new_data  XOR 1000 0000 0000) & 1 1111 1111 1111
 
-	memStoreIndex= ipn*50+strip*kSamplesPerChannel+sample;
-	// storing in data_MEM also the gain bits
-	data_MEM[memStoreIndex]= new_data & 0x3fff;
+        //(Bit 12) == 1 -> Gain 16;    (Bit 12) == 0 -> Gain 1
+        // gain in mem can be 1 or 16 encoded resp. with 0 ir 1 in the 13th bit.
+        // checking and reporting if there is any sample with gain==2,3
+        short sampleGain = (new_data & 0x3000) / 4096;
+        if (sampleGain == 2 || sampleGain == 3) {
+          EcalElectronicsId id(1, (int)_ExpectedTowers[_expTowersIndex], strip, channel);
+          memgaincollection.push_back(id);
 
-      }// loop on samples
-    }// loop on strips
-  }// loop on channels
-  
+          edm::LogWarning("EcalTB07RawToDigiGainZero")
+              << "@SUB=EcalTB07DaqFormatter:decodeMem"
+              << "in mem " << towerblock->towerID() << " :\t strip: " << (strip + 1) << " cry: " << (channel + 1)
+              << " has 14th bit non zero! Gain results: " << sampleGain << ".";
 
+          continue;
+        }  // end 'if gain is zero'
 
+        memStoreIndex = ipn * 50 + strip * kSamplesPerChannel + sample;
+        // storing in data_MEM also the gain bits
+        data_MEM[memStoreIndex] = new_data & 0x3fff;
 
-  for (int pnId=0; pnId<kPnPerTowerBlock; pnId++) pnIsOkInBlock[pnId]=true;
+      }  // loop on samples
+    }    // loop on strips
+  }      // loop on channels
+
+  for (int pnId = 0; pnId < kPnPerTowerBlock; pnId++)
+    pnIsOkInBlock[pnId] = true;
   // if anything was wrong with mem_tt_id or mem_tt_size: you would have already exited
   // otherwise, if any problem with ch_gain or ch_id: must not produce digis for the pertaining Pn
 
-  if (!      (memgaincollection.empty() && memchidcollection.empty())          )
-    {
-      for ( EcalElectronicsIdCollection::const_iterator idItr = memgaincollection.begin();
-	    idItr != memgaincollection.end();
-	    ++ idItr ) {
-	int ch = (*idItr).channelId();
-	ch = (ch-1)/5;
-	pnIsOkInBlock [ch] = false;
-      }
+  if (!(memgaincollection.empty() && memchidcollection.empty())) {
+    for (EcalElectronicsIdCollection::const_iterator idItr = memgaincollection.begin();
+         idItr != memgaincollection.end();
+         ++idItr) {
+      int ch = (*idItr).channelId();
+      ch = (ch - 1) / 5;
+      pnIsOkInBlock[ch] = false;
+    }
 
-      for ( EcalElectronicsIdCollection::const_iterator idItr = memchidcollection.begin();
-	    idItr != memchidcollection.end();
-	    ++ idItr ) {
-	int ch = (*idItr).channelId();
-	ch = (ch-1)/5;
-	pnIsOkInBlock [ch] = false;
-      }
+    for (EcalElectronicsIdCollection::const_iterator idItr = memchidcollection.begin();
+         idItr != memchidcollection.end();
+         ++idItr) {
+      int ch = (*idItr).channelId();
+      ch = (ch - 1) / 5;
+      pnIsOkInBlock[ch] = false;
+    }
 
-    }// end: if any ch_gain or ch_id problems exclude the Pn's from digi production
-
-
-
+  }  // end: if any ch_gain or ch_id problems exclude the Pn's from digi production
 
   // looping on PN's of current mem box
-  for (int pnId = 1;  pnId <  (kPnPerTowerBlock+1); pnId++){
-
+  for (int pnId = 1; pnId < (kPnPerTowerBlock + 1); pnId++) {
     // if present Pn has any of its 5 channels with problems, do not produce digi for it
-    if (! pnIsOkInBlock [pnId-1] ) continue;
+    if (!pnIsOkInBlock[pnId - 1])
+      continue;
 
     // second argument is DccId which is set to 46 to match h2 data in global CMS geometry
-    EcalPnDiodeDetId PnId(2, 46, pnId +  kPnPerTowerBlock*mem_id);
-    EcalPnDiodeDigi thePnDigi(PnId );
+    EcalPnDiodeDetId PnId(2, 46, pnId + kPnPerTowerBlock * mem_id);
+    EcalPnDiodeDigi thePnDigi(PnId);
 
     thePnDigi.setSize(kSamplesPerPn);
 
-    for (int sample =0; sample<kSamplesPerPn; sample++)
-      {
-	EcalFEMSample thePnSample( data_MEM[(mem_id)*250 + (pnId-1)*kSamplesPerPn + sample ] );
-	thePnDigi.setSample(sample,  thePnSample );  
-      }
+    for (int sample = 0; sample < kSamplesPerPn; sample++) {
+      EcalFEMSample thePnSample(data_MEM[(mem_id)*250 + (pnId - 1) * kSamplesPerPn + sample]);
+      thePnDigi.setSample(sample, thePnSample);
+    }
     pndigicollection.push_back(thePnDigi);
   }
-  
-  
 }
 
-
-std::pair<int,int>  EcalTB07DaqFormatter::cellIndex(int tower_id, int strip, int ch) {
-  
-  int xtal= (strip-1)*5+ch-1;
+std::pair<int, int> EcalTB07DaqFormatter::cellIndex(int tower_id, int strip, int ch) {
+  int xtal = (strip - 1) * 5 + ch - 1;
   //  std::cout << " cellIndex input xtal " << xtal << std::endl;
-  std::pair<int,int> ind;
-  
-  int eta = (tower_id - 1)/kTowersInPhi*kCardsPerTower;
-  int phi = (tower_id - 1)%kTowersInPhi*kChannelsPerCard;
+  std::pair<int, int> ind;
+
+  int eta = (tower_id - 1) / kTowersInPhi * kCardsPerTower;
+  int phi = (tower_id - 1) % kTowersInPhi * kChannelsPerCard;
 
   if (rightTower(tower_id))
-    eta += xtal/kCardsPerTower;
+    eta += xtal / kCardsPerTower;
   else
-    eta += (kCrystalsPerTower - 1 - xtal)/kCardsPerTower;
+    eta += (kCrystalsPerTower - 1 - xtal) / kCardsPerTower;
 
-  if ((rightTower(tower_id) && (xtal/kCardsPerTower)%2 == 1) ||
-      (!rightTower(tower_id) && (xtal/kCardsPerTower)%2 == 0))
+  if ((rightTower(tower_id) && (xtal / kCardsPerTower) % 2 == 1) ||
+      (!rightTower(tower_id) && (xtal / kCardsPerTower) % 2 == 0))
 
-    phi += (kChannelsPerCard - 1 - xtal%kChannelsPerCard);
+    phi += (kChannelsPerCard - 1 - xtal % kChannelsPerCard);
   else
-    phi += xtal%kChannelsPerCard;
+    phi += xtal % kChannelsPerCard;
 
-
-  ind.first =eta+1;  
-  ind.second=phi+1; 
+  ind.first = eta + 1;
+  ind.second = phi + 1;
 
   //  std::cout << "  EcalTB07DaqFormatter::cell_index eta " << ind.first << " phi " << ind.second << " " << std::endl;
 
   return ind;
-
 }
 
-int EcalTB07DaqFormatter::getEE_ix(int tower, int strip, int ch){
+int EcalTB07DaqFormatter::getEE_ix(int tower, int strip, int ch) {
   // H2 -- ix is in [-90, -80], and iy is in [-5; 5]
   int ic = cryIc(tower, strip, ch);
   int ix = 0;
-  if ( tbName_ == "h2" ) 
-    ix = 95 - (ic-1)/20;
+  if (tbName_ == "h2")
+    ix = 95 - (ic - 1) / 20;
 
-  if ( tbName_ == "h4" )
-    ix = 35 - (ic-1)%20;
+  if (tbName_ == "h4")
+    ix = 35 - (ic - 1) % 20;
 
   return ix;
-
 }
-int EcalTB07DaqFormatter::getEE_iy(int tower, int strip, int ch){
+int EcalTB07DaqFormatter::getEE_iy(int tower, int strip, int ch) {
   int ic = cryIc(tower, strip, ch);
   int iy = 0;
-  if ( tbName_ == "h2" ) 
-    iy = 46 + (ic-1)%20;
+  if (tbName_ == "h2")
+    iy = 46 + (ic - 1) % 20;
 
-  if ( tbName_ == "h4" )
-    iy = 51 + (int)((ic-1)/20);
+  if (tbName_ == "h4")
+    iy = 51 + (int)((ic - 1) / 20);
 
   return iy;
 }
 
-int  EcalTB07DaqFormatter::cryIc(int tower, int strip, int ch) {
+int EcalTB07DaqFormatter::cryIc(int tower, int strip, int ch) {
+  if (strip < 1 || 5 < strip || ch < 1 || 5 < ch || 68 < tower) {
+    edm::LogWarning("EcalTB07RawToDigiChId") << "EcalTB07DaqFormatter::interpretRawData (cryIc) "
+                                             << " wrong channel id, since out of range: "
+                                             << "\t strip: " << strip << "\t channel: " << ch << "\t in TT: " << tower;
+    return -1;
+  }
 
-  if ( strip < 1 || 5<strip || ch <1 || 5 < ch || 68<tower)
-    {
-      edm::LogWarning("EcalTB07RawToDigiChId") << "EcalTB07DaqFormatter::interpretRawData (cryIc) "
-					     << " wrong channel id, since out of range: "
-					     << "\t strip: "  << strip  << "\t channel: " << ch
-					     << "\t in TT: " << tower;
-      return -1;
-    }
-  
   // YM
-  return cryIcMap_[tower-1][strip-1][ch-1];
-  //std::pair<int,int> cellInd= EcalTB07DaqFormatter::cellIndex(tower, strip, ch); 
+  return cryIcMap_[tower - 1][strip - 1][ch - 1];
+  //std::pair<int,int> cellInd= EcalTB07DaqFormatter::cellIndex(tower, strip, ch);
   //return cellInd.second + (cellInd.first-1)*kCrystalsInPhi;
 }
 
-
-
 bool EcalTB07DaqFormatter::rightTower(int tower) const {
-  
-  if ((tower>12 && tower<21) || (tower>28 && tower<37) ||
-      (tower>44 && tower<53) || (tower>60 && tower<69))
+  if ((tower > 12 && tower < 21) || (tower > 28 && tower < 37) || (tower > 44 && tower < 53) ||
+      (tower > 60 && tower < 69))
     return true;
   else
     return false;
 }
 
-
-
-bool EcalTB07DaqFormatter::leftTower(int tower) const
-{
-  return !rightTower(tower);
-}
-
-
+bool EcalTB07DaqFormatter::leftTower(int tower) const { return !rightTower(tower); }

--- a/EventFilter/EcalTBRawToDigi/src/EcalTB07DaqFormatter.h
+++ b/EventFilter/EcalTBRawToDigi/src/EcalTB07DaqFormatter.h
@@ -13,7 +13,7 @@
 #include <DataFormats/EcalDetId/interface/EcalDetIdCollections.h>
 #include "DCCTowerBlock.h"
 
-#include <vector> 
+#include <vector>
 #include <map>
 #include <iostream>
 
@@ -24,37 +24,45 @@
 
 class FEDRawData;
 class DCCDataParser;
-class EcalTB07DaqFormatter   {
-
- public:
-
+class EcalTB07DaqFormatter {
+public:
   EcalTB07DaqFormatter(std::string tbName, int a[68][5][5], int b[71], int c[201]);
-  virtual ~EcalTB07DaqFormatter(){LogDebug("EcalTB07RawToDigi") << "@SUB=EcalTB07DaqFormatter" << "\n"; };
+  virtual ~EcalTB07DaqFormatter() {
+    LogDebug("EcalTB07RawToDigi") << "@SUB=EcalTB07DaqFormatter"
+                                  << "\n";
+  };
 
-  void  interpretRawData( const FEDRawData & data , EBDigiCollection& digicollection , EEDigiCollection& eeDigiCollection, 
-			  EcalPnDiodeDigiCollection & pndigicollection,
-			  EcalRawDataCollection& DCCheaderCollection,
-			  EBDetIdCollection & dccsizecollection,
-			  EcalElectronicsIdCollection & ttidcollection , EcalElectronicsIdCollection & blocksizecollection,
-			  EBDetIdCollection & chidcollection , EBDetIdCollection & gaincollection,
-			  EBDetIdCollection & gainswitchcollection ,
-			  EcalElectronicsIdCollection & memttidcollection,  EcalElectronicsIdCollection &  memblocksizecollection,
-			  EcalElectronicsIdCollection & memgaincollection,  EcalElectronicsIdCollection & memchidcollection,
-			  EcalTrigPrimDigiCollection &tpcollection);
- 
+  void interpretRawData(const FEDRawData& data,
+                        EBDigiCollection& digicollection,
+                        EEDigiCollection& eeDigiCollection,
+                        EcalPnDiodeDigiCollection& pndigicollection,
+                        EcalRawDataCollection& DCCheaderCollection,
+                        EBDetIdCollection& dccsizecollection,
+                        EcalElectronicsIdCollection& ttidcollection,
+                        EcalElectronicsIdCollection& blocksizecollection,
+                        EBDetIdCollection& chidcollection,
+                        EBDetIdCollection& gaincollection,
+                        EBDetIdCollection& gainswitchcollection,
+                        EcalElectronicsIdCollection& memttidcollection,
+                        EcalElectronicsIdCollection& memblocksizecollection,
+                        EcalElectronicsIdCollection& memgaincollection,
+                        EcalElectronicsIdCollection& memchidcollection,
+                        EcalTrigPrimDigiCollection& tpcollection);
 
- private:
-  
-  void  DecodeMEM( DCCTBTowerBlock *  towerblock, EcalPnDiodeDigiCollection & pndigicollection ,
-		   EcalElectronicsIdCollection & memttidcollection,  EcalElectronicsIdCollection &  memblocksizecollection,
-		   EcalElectronicsIdCollection & memgaincollection,  EcalElectronicsIdCollection & memchidcollection);
-  
-  std::pair<int,int>  cellIndex(int tower_id, int strip, int xtal); 
-  int            cryIc(int tower_id, int strip, int xtal); 
-  bool leftTower(int tower) const ;
-  bool rightTower(int tower) const ;
+private:
+  void DecodeMEM(DCCTBTowerBlock* towerblock,
+                 EcalPnDiodeDigiCollection& pndigicollection,
+                 EcalElectronicsIdCollection& memttidcollection,
+                 EcalElectronicsIdCollection& memblocksizecollection,
+                 EcalElectronicsIdCollection& memgaincollection,
+                 EcalElectronicsIdCollection& memchidcollection);
 
- private:
+  std::pair<int, int> cellIndex(int tower_id, int strip, int xtal);
+  int cryIc(int tower_id, int strip, int xtal);
+  bool leftTower(int tower) const;
+  bool rightTower(int tower) const;
+
+private:
   DCCTBDataParser* theParser_;
   int cryIcMap_[68][5][5];
   int tbStatusToLocation_[71];
@@ -65,27 +73,27 @@ class EcalTB07DaqFormatter   {
   int getEE_iy(int tower, int strip, int ch);
 
   enum SMGeom_t {
-     kModules = 4,           // Number of modules per supermodule
-     kTriggerTowers = 68,    // Number of trigger towers per supermodule
-     kTowersInPhi = 4,       // Number of trigger towers in phi
-     kTowersInEta = 17,      // Number of trigger towers in eta
-     kCrystals = 1700,       // Number of crystals per supermodule
-     kPns = 10,                  // Number of PN laser monitoring diodes per supermodule
-     kCrystalsInPhi = 20,    // Number of crystals in phi
-     kCrystalsInEta = 85,    // Number of crystals in eta
-     kCrystalsPerTower = 25, // Number of crystals per trigger tower
-     kCardsPerTower = 5,     // Number of VFE cards per trigger tower
-     kChannelsPerCard = 5    // Number of channels per VFE card
-   };
+    kModules = 4,            // Number of modules per supermodule
+    kTriggerTowers = 68,     // Number of trigger towers per supermodule
+    kTowersInPhi = 4,        // Number of trigger towers in phi
+    kTowersInEta = 17,       // Number of trigger towers in eta
+    kCrystals = 1700,        // Number of crystals per supermodule
+    kPns = 10,               // Number of PN laser monitoring diodes per supermodule
+    kCrystalsInPhi = 20,     // Number of crystals in phi
+    kCrystalsInEta = 85,     // Number of crystals in eta
+    kCrystalsPerTower = 25,  // Number of crystals per trigger tower
+    kCardsPerTower = 5,      // Number of VFE cards per trigger tower
+    kChannelsPerCard = 5     // Number of channels per VFE card
+  };
 
   enum SMElectronics_t {
-    kSamplesPerChannel = 10,  // Number of sample per channel, per event
-    kSamplesPerPn          = 50,  // Number of sample per PN, per event
-    kChannelsPerTower   = 25,  // Number of channels per trigger tower
-    kStripsPerTower        = 5,   // Number of VFE cards per trigger tower
-    kChannelsPerStrip     = 5,   // Number channels per VFE card
-    kPnPerTowerBlock    = 5,    // Number Pn diodes pertaining to 1 tower block = 1/2 mem box
-    kTriggerTowersAndMem  = 70    // Number of trigger towers block including mems
+    kSamplesPerChannel = 10,   // Number of sample per channel, per event
+    kSamplesPerPn = 50,        // Number of sample per PN, per event
+    kChannelsPerTower = 25,    // Number of channels per trigger tower
+    kStripsPerTower = 5,       // Number of VFE cards per trigger tower
+    kChannelsPerStrip = 5,     // Number channels per VFE card
+    kPnPerTowerBlock = 5,      // Number Pn diodes pertaining to 1 tower block = 1/2 mem box
+    kTriggerTowersAndMem = 70  // Number of trigger towers block including mems
   };
 
   // index and container for expected towers (according to DCC status)
@@ -94,10 +102,9 @@ class EcalTB07DaqFormatter   {
   unsigned _expTowersIndex;
 
   // used for mem boxes unpacking
-  int    memRawSample_[kStripsPerTower][kChannelsPerStrip][ kSamplesPerChannel+1];       // store raw data for one mem
-  int    data_MEM[500];                                                                                                                  // collects unpacked data for both mems 
+  int memRawSample_[kStripsPerTower][kChannelsPerStrip][kSamplesPerChannel + 1];  // store raw data for one mem
+  int data_MEM[500];  // collects unpacked data for both mems
   bool pnAllocated;
   bool pnIsOkInBlock[kPnPerTowerBlock];
-
 };
 #endif

--- a/EventFilter/EcalTBRawToDigi/src/EcalTBDaqFormatter.cc
+++ b/EventFilter/EcalTBRawToDigi/src/EcalTBDaqFormatter.cc
@@ -25,200 +25,186 @@
 #include "DCCXtalBlock.h"
 #include "DCCDataMapper.h"
 
-
 #include <iostream>
 
-EcalTBDaqFormatter::EcalTBDaqFormatter () {
-
+EcalTBDaqFormatter::EcalTBDaqFormatter() {
   LogDebug("EcalTBRawToDigi") << "@SUB=EcalTBDaqFormatter";
   std::vector<uint32_t> parameters;
-  parameters.push_back(10); // parameters[0] is the xtal samples 
-  parameters.push_back(1);  // parameters[1] is the number of trigger time samples for TPG's
-  parameters.push_back(68); // parameters[2] is the number of TT
-  parameters.push_back(68); // parameters[3] is the number of SR Flags
-  parameters.push_back(1);  // parameters[4] is the dcc id
-  parameters.push_back(1);  // parameters[5] is the sr id
-  parameters.push_back(1);  // parameters[6] is the tcc1 id
-  parameters.push_back(2);  // parameters[7] is the tcc2 id
-  parameters.push_back(3);  // parameters[8] is the tcc3 id
-  parameters.push_back(4);  // parameters[9] is the tcc4 id
+  parameters.push_back(10);  // parameters[0] is the xtal samples
+  parameters.push_back(1);   // parameters[1] is the number of trigger time samples for TPG's
+  parameters.push_back(68);  // parameters[2] is the number of TT
+  parameters.push_back(68);  // parameters[3] is the number of SR Flags
+  parameters.push_back(1);   // parameters[4] is the dcc id
+  parameters.push_back(1);   // parameters[5] is the sr id
+  parameters.push_back(1);   // parameters[6] is the tcc1 id
+  parameters.push_back(2);   // parameters[7] is the tcc2 id
+  parameters.push_back(3);   // parameters[8] is the tcc3 id
+  parameters.push_back(4);   // parameters[9] is the tcc4 id
 
   theParser_ = new DCCTBDataParser(parameters);
-
 }
 
-void EcalTBDaqFormatter::interpretRawData(const FEDRawData & fedData , 
-					  EBDigiCollection& digicollection, EcalPnDiodeDigiCollection & pndigicollection , 
-					  EcalRawDataCollection& DCCheaderCollection, 
-					  EBDetIdCollection & dccsizecollection,
-					  EcalElectronicsIdCollection & ttidcollection ,  EcalElectronicsIdCollection & blocksizecollection,
-					  EBDetIdCollection & chidcollection , EBDetIdCollection & gaincollection, 
-					  EBDetIdCollection & gainswitchcollection, 
-					  EcalElectronicsIdCollection & memttidcollection,  EcalElectronicsIdCollection &  memblocksizecollection,
-					  EcalElectronicsIdCollection & memgaincollection,  EcalElectronicsIdCollection & memchidcollection,
-					  EcalTrigPrimDigiCollection &tpcollection)
-{
-
-
-  const unsigned char * pData = fedData.data();
+void EcalTBDaqFormatter::interpretRawData(const FEDRawData& fedData,
+                                          EBDigiCollection& digicollection,
+                                          EcalPnDiodeDigiCollection& pndigicollection,
+                                          EcalRawDataCollection& DCCheaderCollection,
+                                          EBDetIdCollection& dccsizecollection,
+                                          EcalElectronicsIdCollection& ttidcollection,
+                                          EcalElectronicsIdCollection& blocksizecollection,
+                                          EBDetIdCollection& chidcollection,
+                                          EBDetIdCollection& gaincollection,
+                                          EBDetIdCollection& gainswitchcollection,
+                                          EcalElectronicsIdCollection& memttidcollection,
+                                          EcalElectronicsIdCollection& memblocksizecollection,
+                                          EcalElectronicsIdCollection& memgaincollection,
+                                          EcalElectronicsIdCollection& memchidcollection,
+                                          EcalTrigPrimDigiCollection& tpcollection) {
+  const unsigned char* pData = fedData.data();
   int length = fedData.size();
-  bool shit=true;
-  unsigned int tower=0;
-  int ch=0;
-  int strip=0;
+  bool shit = true;
+  unsigned int tower = 0;
+  int ch = 0;
+  int strip = 0;
 
   LogDebug("EcalTBRawToDigi") << "@SUB=EcalTBDaqFormatter::interpretRawData"
-			      << "size " << length;
- 
+                              << "size " << length;
 
   // mean + 3sigma estimation needed when switching to 0suppressed data
   digicollection.reserve(kCrystals);
   pnAllocated = false;
-  
 
-  theParser_->parseBuffer( reinterpret_cast<const uint32_t*>(pData), static_cast<uint32_t>(length), shit );
-  
-  std::vector< DCCTBEventBlock * > &   dccEventBlocks = theParser_->dccEvents();
+  theParser_->parseBuffer(reinterpret_cast<const uint32_t*>(pData), static_cast<uint32_t>(length), shit);
+
+  std::vector<DCCTBEventBlock*>& dccEventBlocks = theParser_->dccEvents();
 
   // Access each DCCTB block
-  for( std::vector< DCCTBEventBlock * >::iterator itEventBlock = dccEventBlocks.begin(); 
-       itEventBlock != dccEventBlocks.end(); 
-       itEventBlock++){
-    
+  for (std::vector<DCCTBEventBlock*>::iterator itEventBlock = dccEventBlocks.begin();
+       itEventBlock != dccEventBlocks.end();
+       itEventBlock++) {
     bool _displayParserMessages = false;
-    if( (*itEventBlock)->eventHasErrors() && _displayParserMessages)
-      {
-	edm::LogWarning("EcalTBRawToDigi") << "@SUB=EcalTBDaqFormatter::interpretRawData"
-				      << "errors found from parser... ";
-        edm::LogWarning("EcalTBRawToDigi") << (*itEventBlock)->eventErrorString();
-        edm::LogWarning("EcalTBRawToDigi") << "@SUB=EcalTBDaqFormatter::interpretRawData"
-				      << "... errors from parser notified";
-      }
+    if ((*itEventBlock)->eventHasErrors() && _displayParserMessages) {
+      edm::LogWarning("EcalTBRawToDigi") << "@SUB=EcalTBDaqFormatter::interpretRawData"
+                                         << "errors found from parser... ";
+      edm::LogWarning("EcalTBRawToDigi") << (*itEventBlock)->eventErrorString();
+      edm::LogWarning("EcalTBRawToDigi") << "@SUB=EcalTBDaqFormatter::interpretRawData"
+                                         << "... errors from parser notified";
+    }
 
     // getting the fields of the DCC header
     EcalDCCHeaderBlock theDCCheader;
 
-    theDCCheader.setId(28);                                                     // tb unpacker: forced to 28 to get first geom slot in EB
+    theDCCheader.setId(28);  // tb unpacker: forced to 28 to get first geom slot in EB
     int fedId = (*itEventBlock)->getDataField("FED/DCC ID");
-    theDCCheader.setFedId( fedId );                                             // fed id as found in raw data (0... 35 at tb )
+    theDCCheader.setFedId(fedId);  // fed id as found in raw data (0... 35 at tb )
 
     theDCCheader.setRunNumber((*itEventBlock)->getDataField("RUN NUMBER"));
     short trigger_type = (*itEventBlock)->getDataField("TRIGGER TYPE");
-    short zs  = (*itEventBlock)->getDataField("ZS");
+    short zs = (*itEventBlock)->getDataField("ZS");
     short tzs = (*itEventBlock)->getDataField("TZS");
-    short sr  = (*itEventBlock)->getDataField("SR");
-    bool  dataIsSuppressed;
+    short sr = (*itEventBlock)->getDataField("SR");
+    bool dataIsSuppressed;
 
     // if zs&&tzs the suppression algo is used in DCC, the data are not suppressed and zs-bits are set
-    if ( zs && !(tzs) ) dataIsSuppressed = true;
-    else  dataIsSuppressed = false;
+    if (zs && !(tzs))
+      dataIsSuppressed = true;
+    else
+      dataIsSuppressed = false;
 
-    if(trigger_type >0 && trigger_type <5){theDCCheader.setBasicTriggerType(trigger_type);}
-    else{ edm::LogWarning("EcalTBRawToDigiTriggerType") << "@SUB=EcalTBDaqFormatter::interpretRawData"
-							<< "unrecognized TRIGGER TYPE: "<<trigger_type;}
+    if (trigger_type > 0 && trigger_type < 5) {
+      theDCCheader.setBasicTriggerType(trigger_type);
+    } else {
+      edm::LogWarning("EcalTBRawToDigiTriggerType") << "@SUB=EcalTBDaqFormatter::interpretRawData"
+                                                    << "unrecognized TRIGGER TYPE: " << trigger_type;
+    }
     theDCCheader.setLV1((*itEventBlock)->getDataField("LV1"));
     theDCCheader.setOrbit((*itEventBlock)->getDataField("ORBIT COUNTER"));
     theDCCheader.setBX((*itEventBlock)->getDataField("BX"));
     theDCCheader.setErrors((*itEventBlock)->getDataField("DCC ERRORS"));
-    theDCCheader.setSelectiveReadout( sr );
-    theDCCheader.setZeroSuppression( zs );
-    theDCCheader.setTestZeroSuppression( tzs );
+    theDCCheader.setSelectiveReadout(sr);
+    theDCCheader.setZeroSuppression(zs);
+    theDCCheader.setTestZeroSuppression(tzs);
     theDCCheader.setSrpStatus((*itEventBlock)->getDataField("SR_CHSTATUS"));
 
-
-
-
     std::vector<short> theTCCs;
-    for(int i=0; i<MAX_TCC_SIZE; i++){
-      
-      char TCCnum[20]; sprintf(TCCnum,"TCC_CHSTATUS#%d",i+1); std::string TCCnumS(TCCnum);
-      theTCCs.push_back ((*itEventBlock)->getDataField(TCCnumS) );
+    for (int i = 0; i < MAX_TCC_SIZE; i++) {
+      char TCCnum[20];
+      sprintf(TCCnum, "TCC_CHSTATUS#%d", i + 1);
+      std::string TCCnumS(TCCnum);
+      theTCCs.push_back((*itEventBlock)->getDataField(TCCnumS));
     }
     theDCCheader.setTccStatus(theTCCs);
 
+    std::vector<DCCTBTCCBlock*> tccBlocks = (*itEventBlock)->tccBlocks();
 
-    std::vector< DCCTBTCCBlock * > tccBlocks = (*itEventBlock)->tccBlocks();
-    
-    for(    std::vector< DCCTBTCCBlock * >::iterator itTCCBlock = tccBlocks.begin(); 
-	    itTCCBlock != tccBlocks.end(); 
-	    itTCCBlock ++)
-      {
+    for (std::vector<DCCTBTCCBlock*>::iterator itTCCBlock = tccBlocks.begin(); itTCCBlock != tccBlocks.end();
+         itTCCBlock++) {
+      std::vector<std::pair<int, bool> > TpSamples = (*itTCCBlock)->triggerSamples();
+      // std::vector of 3 bits
+      std::vector<int> TpFlags = (*itTCCBlock)->triggerFlags();
 
-	std::vector< std::pair<int,bool> > TpSamples = (* itTCCBlock) -> triggerSamples() ;
-	// std::vector of 3 bits
-	std::vector<int> TpFlags      = (* itTCCBlock) -> triggerFlags() ;
-	
-	// there have always to be 68 primitives and flags, per FED
-	if (TpSamples.size()==68   && TpFlags.size()==68)
-	  {
-	    for(int i=0; i<((int)TpSamples.size()); i++)	
-	      {
-		
-		int etaTT = (i)  / kTowersInPhi +1;
-		int phiTT = (i) % kTowersInPhi +1;
+      // there have always to be 68 primitives and flags, per FED
+      if (TpSamples.size() == 68 && TpFlags.size() == 68) {
+        for (int i = 0; i < ((int)TpSamples.size()); i++) {
+          int etaTT = (i) / kTowersInPhi + 1;
+          int phiTT = (i) % kTowersInPhi + 1;
 
-		// follow HB convention in iphi
-		phiTT=3-phiTT;
-		if(phiTT<=0)phiTT=phiTT+72;
+          // follow HB convention in iphi
+          phiTT = 3 - phiTT;
+          if (phiTT <= 0)
+            phiTT = phiTT + 72;
 
-		EcalTriggerPrimitiveSample theSample(TpSamples[i].first, TpSamples[i].second, TpFlags[i]);
-		
-		EcalTrigTowerDetId idtt(1, EcalBarrel, etaTT, phiTT, 0);
+          EcalTriggerPrimitiveSample theSample(TpSamples[i].first, TpSamples[i].second, TpFlags[i]);
 
-		EcalTriggerPrimitiveDigi thePrimitive(idtt);
-		thePrimitive.setSize(1);                          // hard coded
-		thePrimitive.setSample(0, theSample);
-		
-		tpcollection.push_back(thePrimitive);
-		
-		LogDebug("EcalTBRawToDigiTpg") << "@SUBS=EcalTBDaqFormatter::interpretRawData"
-					       << "tower: " << (i+1) 
-					       << " primitive: " << TpSamples[i].first
-					       << " flag: " << TpSamples[i].second;
+          EcalTrigTowerDetId idtt(1, EcalBarrel, etaTT, phiTT, 0);
 
-		LogDebug("EcalTBRawToDigiTpg") << "@SUBS=EcalTBDaqFormatter::interpretRawData"<<
-		  "tower: " << (i+1) << " flag: " << TpFlags[i];
-	      }// end loop on tower primitives
-	    
-	  }// end if
-	else
-	  {
-	    edm::LogWarning("EcalTBRawToDigiTpg") << "68 elements not found for TpFlags or TpSamples, collection will be empty";
-	  }
-      }  
-    
-    
-    
-    
-    short TowerStatus[MAX_TT_SIZE+1];
+          EcalTriggerPrimitiveDigi thePrimitive(idtt);
+          thePrimitive.setSize(1);  // hard coded
+          thePrimitive.setSample(0, theSample);
+
+          tpcollection.push_back(thePrimitive);
+
+          LogDebug("EcalTBRawToDigiTpg") << "@SUBS=EcalTBDaqFormatter::interpretRawData"
+                                         << "tower: " << (i + 1) << " primitive: " << TpSamples[i].first
+                                         << " flag: " << TpSamples[i].second;
+
+          LogDebug("EcalTBRawToDigiTpg") << "@SUBS=EcalTBDaqFormatter::interpretRawData"
+                                         << "tower: " << (i + 1) << " flag: " << TpFlags[i];
+        }  // end loop on tower primitives
+
+      }  // end if
+      else {
+        edm::LogWarning("EcalTBRawToDigiTpg")
+            << "68 elements not found for TpFlags or TpSamples, collection will be empty";
+      }
+    }
+
+    short TowerStatus[MAX_TT_SIZE + 1];
     char buffer[25];
     std::vector<short> theTTstatus;
-    for(int i=1;i<MAX_TT_SIZE+1;i++)
-      { 
- 	sprintf(buffer, "FE_CHSTATUS#%d", i);
- 	std::string Tower(buffer);
- 	TowerStatus[i]= (*itEventBlock)->getDataField(Tower);
-	theTTstatus.push_back(TowerStatus[i]);
-	//std::cout << "tower " << i << " has status " <<  TowerStatus[i] << std::endl;  
-      }
+    for (int i = 1; i < MAX_TT_SIZE + 1; i++) {
+      sprintf(buffer, "FE_CHSTATUS#%d", i);
+      std::string Tower(buffer);
+      TowerStatus[i] = (*itEventBlock)->getDataField(Tower);
+      theTTstatus.push_back(TowerStatus[i]);
+      //std::cout << "tower " << i << " has status " <<  TowerStatus[i] << std::endl;
+    }
 
     theDCCheader.setFEStatus(theTTstatus);
-    
+
     EcalDCCTBHeaderRuntypeDecoder theRuntypeDecoder;
     uint32_t DCCruntype = (*itEventBlock)->getDataField("RUN TYPE");
     theRuntypeDecoder.Decode(DCCruntype, &theDCCheader);
     //DCCHeader filled!
     DCCheaderCollection.push_back(theDCCheader);
-    
-    std::vector< DCCTBTowerBlock * > dccTowerBlocks = (*itEventBlock)->towerBlocks();
+
+    std::vector<DCCTBTowerBlock*> dccTowerBlocks = (*itEventBlock)->towerBlocks();
     LogDebug("EcalTBRawToDigi") << "@SUBS=EcalTBDaqFormatter::interpretRawData"
-				<< "dccTowerBlocks size " << dccTowerBlocks.size();
+                                << "dccTowerBlocks size " << dccTowerBlocks.size();
 
-
-
-    _expTowersIndex=0;_numExpectedTowers=0;
-    for (int v=0; v<71; v++){
-      _ExpectedTowers[v]=99999;
+    _expTowersIndex = 0;
+    _numExpectedTowers = 0;
+    for (int v = 0; v < 71; v++) {
+      _ExpectedTowers[v] = 99999;
     }
 
     // note: these are the tower statuses handled at the moment - to be completed
@@ -226,454 +212,388 @@ void EcalTBDaqFormatter::interpretRawData(const FEDRawData & fedData ,
     // staus==9:   Synk error LV1, tower expected;
     // staus==10:  Synk error BX, tower expected;
     // status==1, 2, 3, 4, 5:  tower not expected
-    for (int u=1; u< (kTriggerTowersAndMem+1); u++)
-      {
-	if(   TowerStatus[u] ==0 || TowerStatus[u] ==9 || TowerStatus[u] ==10  ) 
-	  {_ExpectedTowers[_expTowersIndex]=u;
-	    _expTowersIndex++;
-	    _numExpectedTowers++;
-	  }
+    for (int u = 1; u < (kTriggerTowersAndMem + 1); u++) {
+      if (TowerStatus[u] == 0 || TowerStatus[u] == 9 || TowerStatus[u] == 10) {
+        _ExpectedTowers[_expTowersIndex] = u;
+        _expTowersIndex++;
+        _numExpectedTowers++;
       }
+    }
     // resetting counter of expected towers
-    _expTowersIndex=0;
-      
-      
+    _expTowersIndex = 0;
+
     // if number of dccEventBlocks NOT same as expected stop
-    if (!      (dccTowerBlocks.size() == _numExpectedTowers)      )
-      {
-        // we probably always want to know if this happens
-        edm::LogWarning("EcalTBRawToDigiNumTowerBlocks") << "@SUB=EcalTBDaqFormatter::interpretRawData"
-				      << "number of TowerBlocks found (" << dccTowerBlocks.size()
-				      << ") differs from expected (" << _numExpectedTowers 
-				      << ") skipping event"; 
-	
-        EBDetId idsm(1, 1);
-        dccsizecollection.push_back(idsm);
+    if (!(dccTowerBlocks.size() == _numExpectedTowers)) {
+      // we probably always want to know if this happens
+      edm::LogWarning("EcalTBRawToDigiNumTowerBlocks")
+          << "@SUB=EcalTBDaqFormatter::interpretRawData"
+          << "number of TowerBlocks found (" << dccTowerBlocks.size() << ") differs from expected ("
+          << _numExpectedTowers << ") skipping event";
 
-	return;
-	
-      }
-      
+      EBDetId idsm(1, 1);
+      dccsizecollection.push_back(idsm);
 
+      return;
+    }
 
+    // Access the Tower block
+    for (std::vector<DCCTBTowerBlock*>::iterator itTowerBlock = dccTowerBlocks.begin();
+         itTowerBlock != dccTowerBlocks.end();
+         itTowerBlock++) {
+      tower = (*itTowerBlock)->towerID();
 
-
-    // Access the Tower block    
-    for( std::vector< DCCTBTowerBlock * >::iterator itTowerBlock = dccTowerBlocks.begin(); 
-         itTowerBlock!= dccTowerBlocks.end(); 
-         itTowerBlock++){
-
-      tower=(*itTowerBlock)->towerID();
-      
-      // checking if tt in data is the same as tt expected 
+      // checking if tt in data is the same as tt expected
       // else skip tower and increment problem counter
-	    
+
       // compute eta/phi in order to have iTT = _ExpectedTowers[_expTowersIndex]
       // for the time being consider only zside>0
 
       EcalElectronicsId idtt(28, _ExpectedTowers[_expTowersIndex], 1, 1);
 
-      if (  !(tower == _ExpectedTowers[_expTowersIndex])	  )
-        {	
-	  
-	  if (_ExpectedTowers[_expTowersIndex] <= 68){
-	    edm::LogWarning("EcalTBRawToDigiTowerId") << "@SUBS=EcalTBDaqFormatter::interpretRawData"
-						      << "TTower id found (=" << tower 
-						      << ") different from expected (=" <<  _ExpectedTowers[_expTowersIndex] 
-						      << ") " << (_expTowersIndex+1) << "-th tower checked"; 
-	    
-	    //  report on failed tt_id for regular tower block
-	    ttidcollection.push_back(idtt);
-	  }
-	  else
-	    {
-	      edm::LogWarning("EcalTBRawToDigiTowerId") << "@SUB=EcalTBDaqFormatter:interpretRawData"
-							<< "DecodeMEM: tower " << tower  
-							<< " is not the same as expected " << ((int)_ExpectedTowers[_expTowersIndex])
-							<< " (according to DCC header channel status)";
-	      
-	      // report on failed tt_id for mem tower block
-	      // chosing channel 1 as representative
-	      EcalElectronicsId id(1, (int)_ExpectedTowers[_expTowersIndex], 1, 1);
-	      memttidcollection.push_back(id);
-	    }
+      if (!(tower == _ExpectedTowers[_expTowersIndex])) {
+        if (_ExpectedTowers[_expTowersIndex] <= 68) {
+          edm::LogWarning("EcalTBRawToDigiTowerId")
+              << "@SUBS=EcalTBDaqFormatter::interpretRawData"
+              << "TTower id found (=" << tower << ") different from expected (=" << _ExpectedTowers[_expTowersIndex]
+              << ") " << (_expTowersIndex + 1) << "-th tower checked";
 
-          ++ _expTowersIndex;
-          continue;	
-        }// if TT id found  different than expected 
-	
+          //  report on failed tt_id for regular tower block
+          ttidcollection.push_back(idtt);
+        } else {
+          edm::LogWarning("EcalTBRawToDigiTowerId")
+              << "@SUB=EcalTBDaqFormatter:interpretRawData"
+              << "DecodeMEM: tower " << tower << " is not the same as expected "
+              << ((int)_ExpectedTowers[_expTowersIndex]) << " (according to DCC header channel status)";
 
+          // report on failed tt_id for mem tower block
+          // chosing channel 1 as representative
+          EcalElectronicsId id(1, (int)_ExpectedTowers[_expTowersIndex], 1, 1);
+          memttidcollection.push_back(id);
+        }
 
+        ++_expTowersIndex;
+        continue;
+      }  // if TT id found  different than expected
 
       /*********************************
        //    tt: 1 ... 68: crystal data
        *********************************/
-      if (  0<  (*itTowerBlock)->towerID() &&
-	    (*itTowerBlock)->towerID() < (kTriggerTowers+1) 	    )
- 	{
-	  
-	  std::vector<DCCTBXtalBlock * > & xtalDataBlocks = (*itTowerBlock)->xtalBlocks();	
-	  
-	  // if there is no zero suppression, tower block must have have 25 channels in it
-	  if (  (!dataIsSuppressed)   &&   (xtalDataBlocks.size() != kChannelsPerTower)   )
-	    {     
-	      edm::LogWarning("EcalTBRawToDigiTowerSize") << "EcalTBDaqFormatter::interpretRawData, no zero suppression "
-					    << "wrong tower block size is: "  << xtalDataBlocks.size() 
-					    << " at LV1 " << (*itEventBlock)->getDataField("LV1")
-					    << " for TT " << _ExpectedTowers[_expTowersIndex];
-	      // report on wrong tt block size
-	      blocksizecollection.push_back(idtt);
+      if (0 < (*itTowerBlock)->towerID() && (*itTowerBlock)->towerID() < (kTriggerTowers + 1)) {
+        std::vector<DCCTBXtalBlock*>& xtalDataBlocks = (*itTowerBlock)->xtalBlocks();
 
-	      ++ _expTowersIndex; 	      continue;	
+        // if there is no zero suppression, tower block must have have 25 channels in it
+        if ((!dataIsSuppressed) && (xtalDataBlocks.size() != kChannelsPerTower)) {
+          edm::LogWarning("EcalTBRawToDigiTowerSize")
+              << "EcalTBDaqFormatter::interpretRawData, no zero suppression "
+              << "wrong tower block size is: " << xtalDataBlocks.size() << " at LV1 "
+              << (*itEventBlock)->getDataField("LV1") << " for TT " << _ExpectedTowers[_expTowersIndex];
+          // report on wrong tt block size
+          blocksizecollection.push_back(idtt);
 
-	    }
-	  
+          ++_expTowersIndex;
+          continue;
+        }
 
-	  short cryInTower =0;
+        short cryInTower = 0;
 
-	  short expStripInTower;
-	  short expCryInStrip;
-	  short expCryInTower =0;
+        short expStripInTower;
+        short expCryInStrip;
+        short expCryInTower = 0;
 
-	  // Access the Xstal data
-	  for( std::vector< DCCTBXtalBlock * >::iterator itXtalBlock = xtalDataBlocks.begin(); 
-	       itXtalBlock!= xtalDataBlocks.end(); 
-	       itXtalBlock++){ //loop on crys of a  tower
+        // Access the Xstal data
+        for (std::vector<DCCTBXtalBlock*>::iterator itXtalBlock = xtalDataBlocks.begin();
+             itXtalBlock != xtalDataBlocks.end();
+             itXtalBlock++) {  //loop on crys of a  tower
 
-	    strip              =(*itXtalBlock)->stripID();
-	    ch                 =(*itXtalBlock)->xtalID();
-	    cryInTower  =(strip-1)* kChannelsPerCard + (ch -1);
+          strip = (*itXtalBlock)->stripID();
+          ch = (*itXtalBlock)->xtalID();
+          cryInTower = (strip - 1) * kChannelsPerCard + (ch - 1);
 
-	    expStripInTower   =  expCryInTower/5 +1;
-	    expCryInStrip     =  expCryInTower%5 +1;
-	    
-	    
-	    // FIXME: waiting for geometry to do (TT, strip,chNum) <--> (SMChId)
-	    // short abscissa = (_ExpectedTowers[_expTowersIndex]-1)  /4;
-	    // short ordinate = (_ExpectedTowers[_expTowersIndex]-1)  %4;
-	    // temporarily choosing central crystal in trigger tower
-	    // int cryIdInSM  = 45 + ordinate*5 + abscissa * 100;
-	    
-	    
-	    // in case of 0 zuppressed data, check that cryInTower constantly grows
-	    if (dataIsSuppressed)
-	      {
-		
-		if ( strip < 1 || 5<strip || ch <1 || 5 < ch)
-		  {
-		    int  sm = 1; // hardcoded because of test  beam
-		    for (int StripInTower_ =1;  StripInTower_ < 6; StripInTower_++){
-		      for (int  CryInStrip_ =1;  CryInStrip_ < 6; CryInStrip_++){
-			int  ic        = cryIc(tower, StripInTower_,  CryInStrip_) ;
-			EBDetId               idExp(sm, ic,1);
-			chidcollection.push_back(idExp);
-		      }
-		    }
-		    
-		    edm::LogWarning("EcalTBRawToDigiChId") << "EcalTBDaqFormatter::interpretRawData with zero suppression, "
-							   << " wrong channel id, since out of range: "
-							   << "\t strip: "  << strip  << "\t channel: " << ch
-							   << "\t in TT: " << _ExpectedTowers[_expTowersIndex]
-							   << "\t at LV1 : " << (*itEventBlock)->getDataField("LV1");
-		    
-		    expCryInTower++;
-		    continue;
-		  }
+          expStripInTower = expCryInTower / 5 + 1;
+          expCryInStrip = expCryInTower % 5 + 1;
 
+          // FIXME: waiting for geometry to do (TT, strip,chNum) <--> (SMChId)
+          // short abscissa = (_ExpectedTowers[_expTowersIndex]-1)  /4;
+          // short ordinate = (_ExpectedTowers[_expTowersIndex]-1)  %4;
+          // temporarily choosing central crystal in trigger tower
+          // int cryIdInSM  = 45 + ordinate*5 + abscissa * 100;
 
-		// correct ordering
-		if(  cryInTower >= expCryInTower ){
-		  expCryInTower = cryInTower +1;
-		}
-		
-		
-		// cry_id wrong because of incorrect ordering within trigger tower
-		else
-		  {
-		    edm::LogWarning("EcalTBRawToDigiChId") << "EcalTBDaqFormatter::interpretRawData with zero suppression, "
-						  << " based on ch ordering within tt, wrong channel id: "
-						  << "\t strip: "  << strip  << "\t channel: " << ch
-						  << "\t cryInTower "  << cryInTower
-						  << "\t expCryInTower: " << expCryInTower
-						  << "\t in TT: " << _ExpectedTowers[_expTowersIndex]
-						  << "\t at LV1: " << (*itEventBlock)->getDataField("LV1");
-		    
-		    int  sm = 1; // hardcoded because of test  beam
-		    for (int StripInTower_ =1;  StripInTower_ < 6; StripInTower_++){
-		      for (int  CryInStrip_ =1;  CryInStrip_ < 6; CryInStrip_++){
-			int  ic        = cryIc(tower, StripInTower_,  CryInStrip_) ;
-			EBDetId               idExp(sm, ic,1);
-			chidcollection.push_back(idExp);
-		      }
-		    }
-		    
-		    // chennel with id which does not follow correct odering
-		    expCryInTower++;		    continue;
-		    
-		  }// end 'ch_id does not respect growing order'
-		
-	      }// end   if zero supression
-	    
-	    
+          // in case of 0 zuppressed data, check that cryInTower constantly grows
+          if (dataIsSuppressed) {
+            if (strip < 1 || 5 < strip || ch < 1 || 5 < ch) {
+              int sm = 1;  // hardcoded because of test  beam
+              for (int StripInTower_ = 1; StripInTower_ < 6; StripInTower_++) {
+                for (int CryInStrip_ = 1; CryInStrip_ < 6; CryInStrip_++) {
+                  int ic = cryIc(tower, StripInTower_, CryInStrip_);
+                  EBDetId idExp(sm, ic, 1);
+                  chidcollection.push_back(idExp);
+                }
+              }
 
-	    else {
-	      
-	      // checking that ch and strip are within range and cryInTower is as expected
-	      if(   cryInTower != expCryInTower   ||  
-		    strip < 1 ||   kStripsPerTower <strip  ||
-		    ch <1  ||   kChannelsPerStrip < ch    ) 
-		{
-		  
-		  int ic        = cryIc(tower, expStripInTower,  expCryInStrip) ;
-		  int  sm = 1; // hardcoded because of test  beam
-		  EBDetId  idExp(sm, ic,1);
-		  
-		  edm::LogWarning("EcalTBRawToDigiChId") << "EcalTBDaqFormatter::interpretRawData no zero suppression "
-						    << " wrong channel id for channel: "  << expCryInStrip
-						    << "\t strip: " << expStripInTower
-						    << "\t in TT: " << _ExpectedTowers[_expTowersIndex]
-						    << "\t at LV1: " << (*itEventBlock)->getDataField("LV1")
-						    << "\t   (in the data, found channel:  " << ch
-						    << "\t strip:  " << strip << " ).";
+              edm::LogWarning("EcalTBRawToDigiChId")
+                  << "EcalTBDaqFormatter::interpretRawData with zero suppression, "
+                  << " wrong channel id, since out of range: "
+                  << "\t strip: " << strip << "\t channel: " << ch << "\t in TT: " << _ExpectedTowers[_expTowersIndex]
+                  << "\t at LV1 : " << (*itEventBlock)->getDataField("LV1");
 
-		  
-		  // report on wrong channel id
-		  chidcollection.push_back(idExp);
+              expCryInTower++;
+              continue;
+            }
 
-		  // there has been unexpected crystal id, dataframe not to go to the Event
-		  expCryInTower++; 		  continue;
-		  
-		} // if channel in data does not equal expected channel
+            // correct ordering
+            if (cryInTower >= expCryInTower) {
+              expCryInTower = cryInTower + 1;
+            }
 
-	      expCryInTower++;
+            // cry_id wrong because of incorrect ordering within trigger tower
+            else {
+              edm::LogWarning("EcalTBRawToDigiChId")
+                  << "EcalTBDaqFormatter::interpretRawData with zero suppression, "
+                  << " based on ch ordering within tt, wrong channel id: "
+                  << "\t strip: " << strip << "\t channel: " << ch << "\t cryInTower " << cryInTower
+                  << "\t expCryInTower: " << expCryInTower << "\t in TT: " << _ExpectedTowers[_expTowersIndex]
+                  << "\t at LV1: " << (*itEventBlock)->getDataField("LV1");
 
-	    } // end 'not zero suppression'
-	    
-	    
-	    
-	    // data  to be stored in EBDataFrame, identified by EBDetId
-	    int  ic = cryIc(tower, strip, ch) ;
-	    int  sm = 1;
-	    EBDetId  id(sm, ic,1);                 
-	    
-            // here data frame go into the Event
-            // removed later on (with a pop_back()) if gain==0 or if forbidden-gain-switch
-            digicollection.push_back( id );
-	    EBDataFrame theFrame ( digicollection.back() );
-	    std::vector<int> xtalDataSamples = (*itXtalBlock)->xtalDataSamples();   
-	    //theFrame.setSize(xtalDataSamples.size()); // if needed, to be changed when constructing digicollection
-      
-      
+              int sm = 1;  // hardcoded because of test  beam
+              for (int StripInTower_ = 1; StripInTower_ < 6; StripInTower_++) {
+                for (int CryInStrip_ = 1; CryInStrip_ < 6; CryInStrip_++) {
+                  int ic = cryIc(tower, StripInTower_, CryInStrip_);
+                  EBDetId idExp(sm, ic, 1);
+                  chidcollection.push_back(idExp);
+                }
+              }
 
-	    // gain cannot be 0, checking for that
-	    bool        gainIsOk =true;
-	    unsigned gain_mask      = 12288;    //12th and 13th bit
-	    std::vector <int> xtalGain;
+              // chennel with id which does not follow correct odering
+              expCryInTower++;
+              continue;
 
-	    for (unsigned short i=0; i<xtalDataSamples.size(); ++i ) {
-	      
-	      theFrame.setSample (i, xtalDataSamples[i] );
-	      
-	      if((xtalDataSamples[i] & gain_mask) == 0){gainIsOk =false;}
-	      
-	      xtalGain.push_back(0);
-	      xtalGain[i] |= (xtalDataSamples[i] >> 12);
-	    }
-	    
-	    if (! gainIsOk) {
-	      
-	      edm::LogWarning("EcalTBRawToDigiGainZero") << "@SUB=EcalTBDaqFormatter::interpretRawData"
-					    << " gain==0 for strip: "  << expStripInTower
-					    << "\t channel: " << expCryInStrip
-					    << "\t in TT: " << _ExpectedTowers[_expTowersIndex]
-					    << "\t ic: " << ic
-					    << "\t at LV1: " << (*itEventBlock)->getDataField("LV1");
-	      // report on gain==0
-	      gaincollection.push_back(id);
-	      
-	      // there has been a gain==0, dataframe not to go to the Event
-              digicollection.pop_back();
-	      continue; //	      expCryInTower already incremented
-	    }
+            }  // end 'ch_id does not respect growing order'
 
+          }  // end   if zero supression
 
-	    
-	    
-	    // looking for forbidden gain transitions
-	    
-	    short firstGainWrong=-1;
-	    short numGainWrong=0;
-	    
-	    for (unsigned short i=0; i<xtalGain.size(); i++ ) {
-	      
-	      if (i>0 && xtalGain[i-1]>xtalGain[i]) {
-		
-		numGainWrong++;// counting forbidden gain transitions
-		
-		if (firstGainWrong == -1) {
-		  firstGainWrong=i;
-		  edm::LogWarning("EcalTBRawToDigiGainSwitch") << "@SUB=EcalTBDaqFormatter::interpretRawData"
-							  << "channelHasGainSwitchProblem: crystal eta = " 
-							  << id.ieta() << " phi = " << id.iphi();
-		}
-		edm::LogWarning("EcalTBRawToDigiGainSwitch") << "@SUB=EcalTBDaqFormatter::interpretRawData"
-							<< "channelHasGainSwitchProblem: sample = " << (i-1) 
-							<< " gain: " << xtalGain[i-1] << " sample: " 
-							<< i << " gain: " << xtalGain[i];
-	      }
-	    }
+          else {
+            // checking that ch and strip are within range and cryInTower is as expected
+            if (cryInTower != expCryInTower || strip < 1 || kStripsPerTower < strip || ch < 1 ||
+                kChannelsPerStrip < ch) {
+              int ic = cryIc(tower, expStripInTower, expCryInStrip);
+              int sm = 1;  // hardcoded because of test  beam
+              EBDetId idExp(sm, ic, 1);
 
-	    if (numGainWrong>0) {
-	      gainswitchcollection.push_back(id);
+              edm::LogWarning("EcalTBRawToDigiChId")
+                  << "EcalTBDaqFormatter::interpretRawData no zero suppression "
+                  << " wrong channel id for channel: " << expCryInStrip << "\t strip: " << expStripInTower
+                  << "\t in TT: " << _ExpectedTowers[_expTowersIndex]
+                  << "\t at LV1: " << (*itEventBlock)->getDataField("LV1")
+                  << "\t   (in the data, found channel:  " << ch << "\t strip:  " << strip << " ).";
 
-	      edm::LogWarning("EcalTBRawToDigiGainSwitch") << "@SUB=EcalTBDaqFormatter:interpretRawData"
-							<< "channelHasGainSwitchProblem: more than 1 wrong transition";
-	
-	      for (unsigned short i1=0; i1<xtalDataSamples.size(); ++i1 ) {
-		int countADC = 0x00000FFF;
-		countADC &= xtalDataSamples[i1];
-		LogDebug("EcalTBRawToDigi") << "Sample " << i1 << " ADC " << countADC << " Gain " << xtalGain[i1];
+              // report on wrong channel id
+              chidcollection.push_back(idExp);
 
-	      }
+              // there has been unexpected crystal id, dataframe not to go to the Event
+              expCryInTower++;
+              continue;
 
-	      // there has been a forbidden gain transition,  dataframe not to go to the Event
-              digicollection.pop_back();
-	      continue; //	      expCryInTower already incremented
+            }  // if channel in data does not equal expected channel
 
-	    }// END of:   'if there is a forbidden gain transition'
-	    
-	  }// end loop on crystals within a tower block
-	  
-	  _expTowersIndex++;
-	}// end: tt1 ... tt68, crystal data
-      
+            expCryInTower++;
 
+          }  // end 'not zero suppression'
 
-      
-      
+          // data  to be stored in EBDataFrame, identified by EBDetId
+          int ic = cryIc(tower, strip, ch);
+          int sm = 1;
+          EBDetId id(sm, ic, 1);
+
+          // here data frame go into the Event
+          // removed later on (with a pop_back()) if gain==0 or if forbidden-gain-switch
+          digicollection.push_back(id);
+          EBDataFrame theFrame(digicollection.back());
+          std::vector<int> xtalDataSamples = (*itXtalBlock)->xtalDataSamples();
+          //theFrame.setSize(xtalDataSamples.size()); // if needed, to be changed when constructing digicollection
+
+          // gain cannot be 0, checking for that
+          bool gainIsOk = true;
+          unsigned gain_mask = 12288;  //12th and 13th bit
+          std::vector<int> xtalGain;
+
+          for (unsigned short i = 0; i < xtalDataSamples.size(); ++i) {
+            theFrame.setSample(i, xtalDataSamples[i]);
+
+            if ((xtalDataSamples[i] & gain_mask) == 0) {
+              gainIsOk = false;
+            }
+
+            xtalGain.push_back(0);
+            xtalGain[i] |= (xtalDataSamples[i] >> 12);
+          }
+
+          if (!gainIsOk) {
+            edm::LogWarning("EcalTBRawToDigiGainZero")
+                << "@SUB=EcalTBDaqFormatter::interpretRawData"
+                << " gain==0 for strip: " << expStripInTower << "\t channel: " << expCryInStrip
+                << "\t in TT: " << _ExpectedTowers[_expTowersIndex] << "\t ic: " << ic
+                << "\t at LV1: " << (*itEventBlock)->getDataField("LV1");
+            // report on gain==0
+            gaincollection.push_back(id);
+
+            // there has been a gain==0, dataframe not to go to the Event
+            digicollection.pop_back();
+            continue;  //	      expCryInTower already incremented
+          }
+
+          // looking for forbidden gain transitions
+
+          short firstGainWrong = -1;
+          short numGainWrong = 0;
+
+          for (unsigned short i = 0; i < xtalGain.size(); i++) {
+            if (i > 0 && xtalGain[i - 1] > xtalGain[i]) {
+              numGainWrong++;  // counting forbidden gain transitions
+
+              if (firstGainWrong == -1) {
+                firstGainWrong = i;
+                edm::LogWarning("EcalTBRawToDigiGainSwitch")
+                    << "@SUB=EcalTBDaqFormatter::interpretRawData"
+                    << "channelHasGainSwitchProblem: crystal eta = " << id.ieta() << " phi = " << id.iphi();
+              }
+              edm::LogWarning("EcalTBRawToDigiGainSwitch")
+                  << "@SUB=EcalTBDaqFormatter::interpretRawData"
+                  << "channelHasGainSwitchProblem: sample = " << (i - 1) << " gain: " << xtalGain[i - 1]
+                  << " sample: " << i << " gain: " << xtalGain[i];
+            }
+          }
+
+          if (numGainWrong > 0) {
+            gainswitchcollection.push_back(id);
+
+            edm::LogWarning("EcalTBRawToDigiGainSwitch") << "@SUB=EcalTBDaqFormatter:interpretRawData"
+                                                         << "channelHasGainSwitchProblem: more than 1 wrong transition";
+
+            for (unsigned short i1 = 0; i1 < xtalDataSamples.size(); ++i1) {
+              int countADC = 0x00000FFF;
+              countADC &= xtalDataSamples[i1];
+              LogDebug("EcalTBRawToDigi") << "Sample " << i1 << " ADC " << countADC << " Gain " << xtalGain[i1];
+            }
+
+            // there has been a forbidden gain transition,  dataframe not to go to the Event
+            digicollection.pop_back();
+            continue;  //	      expCryInTower already incremented
+
+          }  // END of:   'if there is a forbidden gain transition'
+
+        }  // end loop on crystals within a tower block
+
+        _expTowersIndex++;
+      }  // end: tt1 ... tt68, crystal data
+
       /******************************************************************
        //    tt 69 and 70:  two mem boxes, holding PN0 ... PN9
-       ******************************************************************/	
-      else if (       (*itTowerBlock)->towerID() == 69 
-                      ||	   (*itTowerBlock)->towerID() == 70       )	
-	{
-	  
-	  LogDebug("EcalTBRawToDigi") << "@SUB=EcalTBDaqFormatter::interpretRawData"
-				      << "processing mem box num: " << (*itTowerBlock)->towerID();
+       ******************************************************************/
+      else if ((*itTowerBlock)->towerID() == 69 || (*itTowerBlock)->towerID() == 70) {
+        LogDebug("EcalTBRawToDigi") << "@SUB=EcalTBDaqFormatter::interpretRawData"
+                                    << "processing mem box num: " << (*itTowerBlock)->towerID();
 
-	  // if tt 69 or 70 found, allocate Pn digi collection
-	  if(! pnAllocated) 
-	    {
-	      pndigicollection.reserve(kPns);
-	      pnAllocated = true;
-	    }
+        // if tt 69 or 70 found, allocate Pn digi collection
+        if (!pnAllocated) {
+          pndigicollection.reserve(kPns);
+          pnAllocated = true;
+        }
 
-	  DecodeMEM( (*itTowerBlock),  pndigicollection , 
-		     memttidcollection,  memblocksizecollection,
-		     memgaincollection,  memchidcollection);
-	  
-	}// end of < if it is a mem box>
-      
-      
-    
+        DecodeMEM((*itTowerBlock),
+                  pndigicollection,
+                  memttidcollection,
+                  memblocksizecollection,
+                  memgaincollection,
+                  memchidcollection);
 
+      }  // end of < if it is a mem box>
 
       // wrong tt id
-      else  {
-        edm::LogWarning("EcalTBRawToDigiTowerId") <<"@SUB=EcalTBDaqFormatter::interpretRawData"
-				      << " processing tt with ID not existing ( "
-				      <<  (*itTowerBlock)->towerID() << ")";
-        ++ _expTowersIndex;continue; 
-      }// end: tt id error
+      else {
+        edm::LogWarning("EcalTBRawToDigiTowerId")
+            << "@SUB=EcalTBDaqFormatter::interpretRawData"
+            << " processing tt with ID not existing ( " << (*itTowerBlock)->towerID() << ")";
+        ++_expTowersIndex;
+        continue;
+      }  // end: tt id error
 
-    }// end loop on trigger towers
-      
-  }// end loop on events
+    }  // end loop on trigger towers
+
+  }  // end loop on events
 }
 
-
-
-
-
-
-
-
-void EcalTBDaqFormatter::DecodeMEM( DCCTBTowerBlock *  towerblock,  EcalPnDiodeDigiCollection & pndigicollection ,
-				    EcalElectronicsIdCollection & memttidcollection,  EcalElectronicsIdCollection &  memblocksizecollection,
-				    EcalElectronicsIdCollection & memgaincollection,  EcalElectronicsIdCollection & memchidcollection)
-{
-  
+void EcalTBDaqFormatter::DecodeMEM(DCCTBTowerBlock* towerblock,
+                                   EcalPnDiodeDigiCollection& pndigicollection,
+                                   EcalElectronicsIdCollection& memttidcollection,
+                                   EcalElectronicsIdCollection& memblocksizecollection,
+                                   EcalElectronicsIdCollection& memgaincollection,
+                                   EcalElectronicsIdCollection& memchidcollection) {
   LogDebug("EcalTBRawToDigi") << "@SUB=EcalTBDaqFormatter::DecodeMEM"
- 			      << "in mem " << towerblock->towerID();  
-  
-  int  tower_id = towerblock ->towerID() ;
-  int  mem_id   = tower_id-69;
+                              << "in mem " << towerblock->towerID();
+
+  int tower_id = towerblock->towerID();
+  int mem_id = tower_id - 69;
 
   // initializing container
-  for (int st_id=0; st_id< kStripsPerTower; st_id++){
-    for (int ch_id=0; ch_id<kChannelsPerStrip; ch_id++){
-      for (int sa=0; sa<11; sa++){      
-	memRawSample_[st_id][ch_id][sa] = -1;}    } }
-
-  
-  // check that tower block id corresponds to mem boxes
-  if(tower_id != 69 && tower_id != 70) 
-    {
-      edm::LogWarning("EcalTBRawToDigiTowerId") << "@SUB=EcalTBDaqFormatter:decodeMem"
-				    << "DecodeMEM: this is not a mem box tower (" << tower_id << ")";
-      ++ _expTowersIndex;
-      return;
+  for (int st_id = 0; st_id < kStripsPerTower; st_id++) {
+    for (int ch_id = 0; ch_id < kChannelsPerStrip; ch_id++) {
+      for (int sa = 0; sa < 11; sa++) {
+        memRawSample_[st_id][ch_id][sa] = -1;
+      }
     }
+  }
 
-     
+  // check that tower block id corresponds to mem boxes
+  if (tower_id != 69 && tower_id != 70) {
+    edm::LogWarning("EcalTBRawToDigiTowerId") << "@SUB=EcalTBDaqFormatter:decodeMem"
+                                              << "DecodeMEM: this is not a mem box tower (" << tower_id << ")";
+    ++_expTowersIndex;
+    return;
+  }
+
   /******************************************************************************
    // getting the raw hits from towerBlock while checking tt and ch data structure 
    ******************************************************************************/
-  std::vector<DCCTBXtalBlock *> & dccXtalBlocks = towerblock->xtalBlocks();
+  std::vector<DCCTBXtalBlock*>& dccXtalBlocks = towerblock->xtalBlocks();
   std::vector<DCCTBXtalBlock*>::iterator itXtal;
 
   // checking mem tower block fo size
-  if (dccXtalBlocks.size() != kChannelsPerTower)
-    {     
-      LogDebug("EcalTBRawToDigiDccBlockSize") << "@SUB=EcalTBDaqFormatter:decodeMem"
-				  << " wrong dccBlock size, namely: "  << dccXtalBlocks.size() 
-				  << ", for mem " << _ExpectedTowers[_expTowersIndex];
+  if (dccXtalBlocks.size() != kChannelsPerTower) {
+    LogDebug("EcalTBRawToDigiDccBlockSize")
+        << "@SUB=EcalTBDaqFormatter:decodeMem"
+        << " wrong dccBlock size, namely: " << dccXtalBlocks.size() << ", for mem " << _ExpectedTowers[_expTowersIndex];
 
-      // reporting mem-tt block size problem
-      // chosing channel 1 as representative as a dummy...
-      EcalElectronicsId id(1, (int)_ExpectedTowers[_expTowersIndex], 1, 1);
-      memblocksizecollection.push_back(id);
+    // reporting mem-tt block size problem
+    // chosing channel 1 as representative as a dummy...
+    EcalElectronicsId id(1, (int)_ExpectedTowers[_expTowersIndex], 1, 1);
+    memblocksizecollection.push_back(id);
 
-      ++ _expTowersIndex;
-      return;  // if mem tt block size not ok - do not build any Pn digis
-    }
-  
+    ++_expTowersIndex;
+    return;  // if mem tt block size not ok - do not build any Pn digis
+  }
 
   // loop on channels of the mem block
-  int  cryCounter = 0;   int  strip_id  = 0;   int  xtal_id   = 0;  
+  int cryCounter = 0;
+  int strip_id = 0;
+  int xtal_id = 0;
 
-  for ( itXtal = dccXtalBlocks.begin(); itXtal < dccXtalBlocks.end(); itXtal++ ) {
-    strip_id                     = (*itXtal) ->getDataField("STRIP ID");
-    xtal_id                      = (*itXtal) ->getDataField("XTAL ID");
-    int wished_strip_id  = cryCounter/ kStripsPerTower;
-    int wished_ch_id     = cryCounter% kStripsPerTower;
-    
-    if( (wished_strip_id+1) != ((int)strip_id) ||
-	(wished_ch_id+1) != ((int)xtal_id) )
-      {
-	
-	LogDebug("EcalTBRawToDigiChId") << "@SUB=EcalTBDaqFormatter:decodeMem"
-				    << " in mem " <<  towerblock->towerID()
-				    << ", expected:\t strip"
-				    << (wished_strip_id+1)  << " cry " << (wished_ch_id+1) << "\tfound: "
-				    << "  strip " <<  strip_id << "  cry " << xtal_id;
-	
-	// report on crystal with unexpected indices
-	EcalElectronicsId id(1, (int)_ExpectedTowers[_expTowersIndex], wished_strip_id,  wished_ch_id);
-	memchidcollection.push_back(id);
-      }
-    
-    
+  for (itXtal = dccXtalBlocks.begin(); itXtal < dccXtalBlocks.end(); itXtal++) {
+    strip_id = (*itXtal)->getDataField("STRIP ID");
+    xtal_id = (*itXtal)->getDataField("XTAL ID");
+    int wished_strip_id = cryCounter / kStripsPerTower;
+    int wished_ch_id = cryCounter % kStripsPerTower;
+
+    if ((wished_strip_id + 1) != ((int)strip_id) || (wished_ch_id + 1) != ((int)xtal_id)) {
+      LogDebug("EcalTBRawToDigiChId") << "@SUB=EcalTBDaqFormatter:decodeMem"
+                                      << " in mem " << towerblock->towerID() << ", expected:\t strip"
+                                      << (wished_strip_id + 1) << " cry " << (wished_ch_id + 1) << "\tfound: "
+                                      << "  strip " << strip_id << "  cry " << xtal_id;
+
+      // report on crystal with unexpected indices
+      EcalElectronicsId id(1, (int)_ExpectedTowers[_expTowersIndex], wished_strip_id, wished_ch_id);
+      memchidcollection.push_back(id);
+    }
+
     // Accessing the 10 time samples per Xtal:
     memRawSample_[wished_strip_id][wished_ch_id][1] = (*itXtal)->getDataField("ADC#1");
     memRawSample_[wished_strip_id][wished_ch_id][2] = (*itXtal)->getDataField("ADC#2");
@@ -685,212 +605,167 @@ void EcalTBDaqFormatter::DecodeMEM( DCCTBTowerBlock *  towerblock,  EcalPnDiodeD
     memRawSample_[wished_strip_id][wished_ch_id][8] = (*itXtal)->getDataField("ADC#8");
     memRawSample_[wished_strip_id][wished_ch_id][9] = (*itXtal)->getDataField("ADC#9");
     memRawSample_[wished_strip_id][wished_ch_id][10] = (*itXtal)->getDataField("ADC#10");
-      
+
     cryCounter++;
-  }// end loop on crystals of mem dccXtalBlock
-  
+  }  // end loop on crystals of mem dccXtalBlock
+
   // tower accepted and digi read from all 25 channels.
   // Increase counter of expected towers before unpacking in the 5 PNs
-  ++ _expTowersIndex;
-
-
+  ++_expTowersIndex;
 
   /************************************************************
    // unpacking and 'cooking' the raw numbers to get PN sample
    ************************************************************/
-  int tempSample=0;
-  int memStoreIndex=0;
-  int ipn=0;
-  for (memStoreIndex=0; memStoreIndex<500; memStoreIndex++)    {
-    data_MEM[memStoreIndex]= -1;   }
-  
-  
-  for(int strip=0; strip<kStripsPerTower; strip++) {// loop on strips
-    for(int channel=0; channel<kChannelsPerStrip; channel++) {// loop on channels
+  int tempSample = 0;
+  int memStoreIndex = 0;
+  int ipn = 0;
+  for (memStoreIndex = 0; memStoreIndex < 500; memStoreIndex++) {
+    data_MEM[memStoreIndex] = -1;
+  }
 
-      if(strip%2 == 0) 
-	{ipn= mem_id*5+channel;}
-      else 
-	{ipn=mem_id*5+4-channel;}
+  for (int strip = 0; strip < kStripsPerTower; strip++) {            // loop on strips
+    for (int channel = 0; channel < kChannelsPerStrip; channel++) {  // loop on channels
 
-      for(int sample=0;sample< kSamplesPerChannel ;sample++) {
-	tempSample= memRawSample_[strip][channel][sample+1];
+      if (strip % 2 == 0) {
+        ipn = mem_id * 5 + channel;
+      } else {
+        ipn = mem_id * 5 + 4 - channel;
+      }
 
-	int new_data=0;
-	if(strip%2 == 1) {
-	  // 1) if strip number is even, 14 bits are reversed in order
-	  for(int ib=0;ib<14;ib++)
-	    { 
-	      new_data <<= 1;
-	      new_data=new_data | (tempSample&1);
-	      tempSample >>= 1;
-	    }
-	} else {
-	  new_data=tempSample;
-	}
+      for (int sample = 0; sample < kSamplesPerChannel; sample++) {
+        tempSample = memRawSample_[strip][channel][sample + 1];
 
-	// 2) flip 11th bit for AD9052 still there on MEM !
-	// 3) mask with 1 1111 1111 1111
-	new_data = (new_data ^ 0x800) & 0x3fff;    // (new_data  XOR 1000 0000 0000) & 11 1111 1111 1111
-	// new_data = (new_data ^ 0x800) & 0x1fff;    // (new_data  XOR 1000 0000 0000) & 1 1111 1111 1111
+        int new_data = 0;
+        if (strip % 2 == 1) {
+          // 1) if strip number is even, 14 bits are reversed in order
+          for (int ib = 0; ib < 14; ib++) {
+            new_data <<= 1;
+            new_data = new_data | (tempSample & 1);
+            tempSample >>= 1;
+          }
+        } else {
+          new_data = tempSample;
+        }
 
-	//(Bit 12) == 1 -> Gain 16;    (Bit 12) == 0 -> Gain 1	
-	// gain in mem can be 1 or 16 encoded resp. with 0 ir 1 in the 13th bit.
-	// checking and reporting if there is any sample with gain==2,3
-	short sampleGain = (new_data &0x3000)/4096;
-	if (  sampleGain==2 || sampleGain==3) 
-	  {
-	    EcalElectronicsId id(1, (int)_ExpectedTowers[_expTowersIndex], strip, channel);
-	    memgaincollection.push_back(id);
-	    
-	    edm::LogWarning("EcalTBRawToDigiGainZero")  << "@SUB=EcalTBDaqFormatter:decodeMem"
-					   << "in mem " <<  towerblock->towerID()
-					   << " :\t strip: "
-					   << (strip +1)  << " cry: " << (channel+1) 
-					   << " has 14th bit non zero! Gain results: "
-					   << sampleGain << ".";
-	    
-	    continue;
-	  }// end 'if gain is zero'
+        // 2) flip 11th bit for AD9052 still there on MEM !
+        // 3) mask with 1 1111 1111 1111
+        new_data = (new_data ^ 0x800) & 0x3fff;  // (new_data  XOR 1000 0000 0000) & 11 1111 1111 1111
+        // new_data = (new_data ^ 0x800) & 0x1fff;    // (new_data  XOR 1000 0000 0000) & 1 1111 1111 1111
 
-	memStoreIndex= ipn*50+strip*kSamplesPerChannel+sample;
-	// storing in data_MEM also the gain bits
-	data_MEM[memStoreIndex]= new_data & 0x3fff;
+        //(Bit 12) == 1 -> Gain 16;    (Bit 12) == 0 -> Gain 1
+        // gain in mem can be 1 or 16 encoded resp. with 0 ir 1 in the 13th bit.
+        // checking and reporting if there is any sample with gain==2,3
+        short sampleGain = (new_data & 0x3000) / 4096;
+        if (sampleGain == 2 || sampleGain == 3) {
+          EcalElectronicsId id(1, (int)_ExpectedTowers[_expTowersIndex], strip, channel);
+          memgaincollection.push_back(id);
 
-      }// loop on samples
-    }// loop on strips
-  }// loop on channels
-  
+          edm::LogWarning("EcalTBRawToDigiGainZero")
+              << "@SUB=EcalTBDaqFormatter:decodeMem"
+              << "in mem " << towerblock->towerID() << " :\t strip: " << (strip + 1) << " cry: " << (channel + 1)
+              << " has 14th bit non zero! Gain results: " << sampleGain << ".";
 
+          continue;
+        }  // end 'if gain is zero'
 
+        memStoreIndex = ipn * 50 + strip * kSamplesPerChannel + sample;
+        // storing in data_MEM also the gain bits
+        data_MEM[memStoreIndex] = new_data & 0x3fff;
 
-  for (int pnId=0; pnId<kPnPerTowerBlock; pnId++) pnIsOkInBlock[pnId]=true;
+      }  // loop on samples
+    }    // loop on strips
+  }      // loop on channels
+
+  for (int pnId = 0; pnId < kPnPerTowerBlock; pnId++)
+    pnIsOkInBlock[pnId] = true;
   // if anything was wrong with mem_tt_id or mem_tt_size: you would have already exited
   // otherwise, if any problem with ch_gain or ch_id: must not produce digis for the pertaining Pn
 
-  if (!      (memgaincollection.empty() && memchidcollection.empty())          )
-    {
-      for ( EcalElectronicsIdCollection::const_iterator idItr = memgaincollection.begin();
-	    idItr != memgaincollection.end();
-	    ++ idItr ) {
-	int ch = (*idItr).channelId();
-	ch = (ch-1)/5;
-	pnIsOkInBlock [ch] = false;
-      }
+  if (!(memgaincollection.empty() && memchidcollection.empty())) {
+    for (EcalElectronicsIdCollection::const_iterator idItr = memgaincollection.begin();
+         idItr != memgaincollection.end();
+         ++idItr) {
+      int ch = (*idItr).channelId();
+      ch = (ch - 1) / 5;
+      pnIsOkInBlock[ch] = false;
+    }
 
-      for ( EcalElectronicsIdCollection::const_iterator idItr = memchidcollection.begin();
-	    idItr != memchidcollection.end();
-	    ++ idItr ) {
-	int ch = (*idItr).channelId();
-	ch = (ch-1)/5;
-	pnIsOkInBlock [ch] = false;
-      }
+    for (EcalElectronicsIdCollection::const_iterator idItr = memchidcollection.begin();
+         idItr != memchidcollection.end();
+         ++idItr) {
+      int ch = (*idItr).channelId();
+      ch = (ch - 1) / 5;
+      pnIsOkInBlock[ch] = false;
+    }
 
-    }// end: if any ch_gain or ch_id problems exclude the Pn's from digi production
-
-
-
+  }  // end: if any ch_gain or ch_id problems exclude the Pn's from digi production
 
   // looping on PN's of current mem box
-  for (int pnId = 1;  pnId <  (kPnPerTowerBlock+1); pnId++){
-
+  for (int pnId = 1; pnId < (kPnPerTowerBlock + 1); pnId++) {
     // if present Pn has any of its 5 channels with problems, do not produce digi for it
-    if (! pnIsOkInBlock [pnId-1] ) continue;
+    if (!pnIsOkInBlock[pnId - 1])
+      continue;
 
     // DccId set to 28 to be consistent with ism==1
-    EcalPnDiodeDetId PnId(1, 28, pnId +  kPnPerTowerBlock*mem_id);
-    EcalPnDiodeDigi thePnDigi(PnId );
+    EcalPnDiodeDetId PnId(1, 28, pnId + kPnPerTowerBlock * mem_id);
+    EcalPnDiodeDigi thePnDigi(PnId);
 
     thePnDigi.setSize(kSamplesPerPn);
 
-    for (int sample =0; sample<kSamplesPerPn; sample++)
-      {
-	EcalFEMSample thePnSample( data_MEM[(mem_id)*250 + (pnId-1)*kSamplesPerPn + sample ] );
-	thePnDigi.setSample(sample,  thePnSample );  
-      }
+    for (int sample = 0; sample < kSamplesPerPn; sample++) {
+      EcalFEMSample thePnSample(data_MEM[(mem_id)*250 + (pnId - 1) * kSamplesPerPn + sample]);
+      thePnDigi.setSample(sample, thePnSample);
+    }
     pndigicollection.push_back(thePnDigi);
   }
-  
-  
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-std::pair<int,int>  EcalTBDaqFormatter::cellIndex(int tower_id, int strip, int ch) {
-  
-  int xtal= (strip-1)*5+ch-1;
+std::pair<int, int> EcalTBDaqFormatter::cellIndex(int tower_id, int strip, int ch) {
+  int xtal = (strip - 1) * 5 + ch - 1;
   //  std::cout << " cellIndex input xtal " << xtal << std::endl;
-  std::pair<int,int> ind;
-  
-  int eta = (tower_id - 1)/kTowersInPhi*kCardsPerTower;
-  int phi = (tower_id - 1)%kTowersInPhi*kChannelsPerCard;
+  std::pair<int, int> ind;
+
+  int eta = (tower_id - 1) / kTowersInPhi * kCardsPerTower;
+  int phi = (tower_id - 1) % kTowersInPhi * kChannelsPerCard;
 
   if (rightTower(tower_id))
-    eta += xtal/kCardsPerTower;
+    eta += xtal / kCardsPerTower;
   else
-    eta += (kCrystalsPerTower - 1 - xtal)/kCardsPerTower;
+    eta += (kCrystalsPerTower - 1 - xtal) / kCardsPerTower;
 
-  if ((rightTower(tower_id) && (xtal/kCardsPerTower)%2 == 1) ||
-      (!rightTower(tower_id) && (xtal/kCardsPerTower)%2 == 0))
+  if ((rightTower(tower_id) && (xtal / kCardsPerTower) % 2 == 1) ||
+      (!rightTower(tower_id) && (xtal / kCardsPerTower) % 2 == 0))
 
-    phi += (kChannelsPerCard - 1 - xtal%kChannelsPerCard);
+    phi += (kChannelsPerCard - 1 - xtal % kChannelsPerCard);
   else
-    phi += xtal%kChannelsPerCard;
+    phi += xtal % kChannelsPerCard;
 
-
-  ind.first =eta+1;  
-  ind.second=phi+1; 
+  ind.first = eta + 1;
+  ind.second = phi + 1;
 
   //  std::cout << "  EcalTBDaqFormatter::cell_index eta " << ind.first << " phi " << ind.second << " " << std::endl;
 
   return ind;
-
 }
 
+int EcalTBDaqFormatter::cryIc(int tower, int strip, int ch) {
+  if (strip < 1 || 5 < strip || ch < 1 || 5 < ch || 68 < tower) {
+    edm::LogWarning("EcalTBRawToDigiChId") << "EcalTBDaqFormatter::interpretRawData (cryIc) "
+                                           << " wrong channel id, since out of range: "
+                                           << "\t strip: " << strip << "\t channel: " << ch << "\t in TT: " << tower;
+    return -1;
+  }
 
-
-int  EcalTBDaqFormatter::cryIc(int tower, int strip, int ch) {
-
-  if ( strip < 1 || 5<strip || ch <1 || 5 < ch || 68<tower)
-    {
-      edm::LogWarning("EcalTBRawToDigiChId") << "EcalTBDaqFormatter::interpretRawData (cryIc) "
-					     << " wrong channel id, since out of range: "
-					     << "\t strip: "  << strip  << "\t channel: " << ch
-					     << "\t in TT: " << tower;
-      return -1;
-    }
-  
-  std::pair<int,int> cellInd= EcalTBDaqFormatter::cellIndex(tower, strip, ch); 
-  return cellInd.second + (cellInd.first-1)*kCrystalsInPhi;
+  std::pair<int, int> cellInd = EcalTBDaqFormatter::cellIndex(tower, strip, ch);
+  return cellInd.second + (cellInd.first - 1) * kCrystalsInPhi;
 }
-
-
 
 bool EcalTBDaqFormatter::rightTower(int tower) const {
-  
-  if ((tower>12 && tower<21) || (tower>28 && tower<37) ||
-      (tower>44 && tower<53) || (tower>60 && tower<69))
+  if ((tower > 12 && tower < 21) || (tower > 28 && tower < 37) || (tower > 44 && tower < 53) ||
+      (tower > 60 && tower < 69))
     return true;
   else
     return false;
 }
 
-
-
-bool EcalTBDaqFormatter::leftTower(int tower) const
-{
-  return !rightTower(tower);
-}
-
-
+bool EcalTBDaqFormatter::leftTower(int tower) const { return !rightTower(tower); }

--- a/EventFilter/EcalTBRawToDigi/src/EcalTBDaqFormatter.h
+++ b/EventFilter/EcalTBRawToDigi/src/EcalTBDaqFormatter.h
@@ -13,7 +13,7 @@
 #include <DataFormats/EcalDetId/interface/EcalDetIdCollections.h>
 #include "DCCTowerBlock.h"
 
-#include <vector> 
+#include <vector>
 #include <map>
 #include <iostream>
 
@@ -21,63 +21,70 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
 class FEDRawData;
 class DCCTBDataParser;
-class EcalTBDaqFormatter   {
-
- public:
-
+class EcalTBDaqFormatter {
+public:
   EcalTBDaqFormatter();
-  virtual ~EcalTBDaqFormatter(){LogDebug("EcalTBRawToDigi") << "@SUB=EcalTBDaqFormatter" << "\n"; };
+  virtual ~EcalTBDaqFormatter() {
+    LogDebug("EcalTBRawToDigi") << "@SUB=EcalTBDaqFormatter"
+                                << "\n";
+  };
 
-  void  interpretRawData( const FEDRawData & data , EBDigiCollection& digicollection , EcalPnDiodeDigiCollection & pndigicollection ,
-			  EcalRawDataCollection& DCCheaderCollection,
-			  EBDetIdCollection & dccsizecollection,
-			  EcalElectronicsIdCollection & ttidcollection , EcalElectronicsIdCollection & blocksizecollection,
-			  EBDetIdCollection & chidcollection , EBDetIdCollection & gaincollection ,
-			  EBDetIdCollection & gainswitchcollection , 
-			  EcalElectronicsIdCollection & memttidcollection,  EcalElectronicsIdCollection &  memblocksizecollection,
-			  EcalElectronicsIdCollection & memgaincollection,  EcalElectronicsIdCollection & memchidcollection,
-			  EcalTrigPrimDigiCollection &tpcollection);
- 
+  void interpretRawData(const FEDRawData& data,
+                        EBDigiCollection& digicollection,
+                        EcalPnDiodeDigiCollection& pndigicollection,
+                        EcalRawDataCollection& DCCheaderCollection,
+                        EBDetIdCollection& dccsizecollection,
+                        EcalElectronicsIdCollection& ttidcollection,
+                        EcalElectronicsIdCollection& blocksizecollection,
+                        EBDetIdCollection& chidcollection,
+                        EBDetIdCollection& gaincollection,
+                        EBDetIdCollection& gainswitchcollection,
+                        EcalElectronicsIdCollection& memttidcollection,
+                        EcalElectronicsIdCollection& memblocksizecollection,
+                        EcalElectronicsIdCollection& memgaincollection,
+                        EcalElectronicsIdCollection& memchidcollection,
+                        EcalTrigPrimDigiCollection& tpcollection);
 
- private:
-  
-  void  DecodeMEM( DCCTBTowerBlock *  towerblock, EcalPnDiodeDigiCollection & pndigicollection ,
-		   EcalElectronicsIdCollection & memttidcollection,  EcalElectronicsIdCollection &  memblocksizecollection,
-		   EcalElectronicsIdCollection & memgaincollection,  EcalElectronicsIdCollection & memchidcollection);
-  
-  std::pair<int,int>  cellIndex(int tower_id, int strip, int xtal); 
-  int            cryIc(int tower_id, int strip, int xtal); 
-  bool leftTower(int tower) const ;
-  bool rightTower(int tower) const ;
+private:
+  void DecodeMEM(DCCTBTowerBlock* towerblock,
+                 EcalPnDiodeDigiCollection& pndigicollection,
+                 EcalElectronicsIdCollection& memttidcollection,
+                 EcalElectronicsIdCollection& memblocksizecollection,
+                 EcalElectronicsIdCollection& memgaincollection,
+                 EcalElectronicsIdCollection& memchidcollection);
 
- private:
+  std::pair<int, int> cellIndex(int tower_id, int strip, int xtal);
+  int cryIc(int tower_id, int strip, int xtal);
+  bool leftTower(int tower) const;
+  bool rightTower(int tower) const;
+
+private:
   DCCTBDataParser* theParser_;
 
   enum SMGeom_t {
-     kModules = 4,           // Number of modules per supermodule
-     kTriggerTowers = 68,    // Number of trigger towers per supermodule
-     kTowersInPhi = 4,       // Number of trigger towers in phi
-     kTowersInEta = 17,      // Number of trigger towers in eta
-     kCrystals = 1700,       // Number of crystals per supermodule
-     kPns = 10,                  // Number of PN laser monitoring diodes per supermodule
-     kCrystalsInPhi = 20,    // Number of crystals in phi
-     kCrystalsInEta = 85,    // Number of crystals in eta
-     kCrystalsPerTower = 25, // Number of crystals per trigger tower
-     kCardsPerTower = 5,     // Number of VFE cards per trigger tower
-     kChannelsPerCard = 5    // Number of channels per VFE card
-   };
+    kModules = 4,            // Number of modules per supermodule
+    kTriggerTowers = 68,     // Number of trigger towers per supermodule
+    kTowersInPhi = 4,        // Number of trigger towers in phi
+    kTowersInEta = 17,       // Number of trigger towers in eta
+    kCrystals = 1700,        // Number of crystals per supermodule
+    kPns = 10,               // Number of PN laser monitoring diodes per supermodule
+    kCrystalsInPhi = 20,     // Number of crystals in phi
+    kCrystalsInEta = 85,     // Number of crystals in eta
+    kCrystalsPerTower = 25,  // Number of crystals per trigger tower
+    kCardsPerTower = 5,      // Number of VFE cards per trigger tower
+    kChannelsPerCard = 5     // Number of channels per VFE card
+  };
 
   enum SMElectronics_t {
-    kSamplesPerChannel = 10,  // Number of sample per channel, per event
-    kSamplesPerPn          = 50,  // Number of sample per PN, per event
-    kChannelsPerTower   = 25,  // Number of channels per trigger tower
-    kStripsPerTower        = 5,   // Number of VFE cards per trigger tower
-    kChannelsPerStrip     = 5,   // Number channels per VFE card
-    kPnPerTowerBlock    = 5,    // Number Pn diodes pertaining to 1 tower block = 1/2 mem box
-    kTriggerTowersAndMem  = 70    // Number of trigger towers block including mems
+    kSamplesPerChannel = 10,   // Number of sample per channel, per event
+    kSamplesPerPn = 50,        // Number of sample per PN, per event
+    kChannelsPerTower = 25,    // Number of channels per trigger tower
+    kStripsPerTower = 5,       // Number of VFE cards per trigger tower
+    kChannelsPerStrip = 5,     // Number channels per VFE card
+    kPnPerTowerBlock = 5,      // Number Pn diodes pertaining to 1 tower block = 1/2 mem box
+    kTriggerTowersAndMem = 70  // Number of trigger towers block including mems
   };
 
   // index and container for expected towers (according to DCC status)
@@ -86,10 +93,9 @@ class EcalTBDaqFormatter   {
   unsigned _expTowersIndex;
 
   // used for mem boxes unpacking
-  int    memRawSample_[kStripsPerTower][kChannelsPerStrip][ kSamplesPerChannel+1];       // store raw data for one mem
-  int    data_MEM[500];                                                                                                                  // collects unpacked data for both mems 
+  int memRawSample_[kStripsPerTower][kChannelsPerStrip][kSamplesPerChannel + 1];  // store raw data for one mem
+  int data_MEM[500];  // collects unpacked data for both mems
   bool pnAllocated;
   bool pnIsOkInBlock[kPnPerTowerBlock];
-
 };
 #endif

--- a/EventFilter/EcalTBRawToDigi/src/MatacqDataFormatter.cc
+++ b/EventFilter/EcalTBRawToDigi/src/MatacqDataFormatter.cc
@@ -11,94 +11,81 @@
 #include <algorithm>
 #include <vector>
 
-
-
 //#define MATACQ_DEBUG
 
-void  MatacqTBDataFormatter::interpretRawData(const FEDRawData & data, EcalMatacqDigiCollection& matacqDigiCollection) {
+void MatacqTBDataFormatter::interpretRawData(const FEDRawData& data, EcalMatacqDigiCollection& matacqDigiCollection) {
 #if MATACQ_DEBUG
   std::cout << "****************************************************************\n";
   std::cout << "********************** MATACQ decoder **************************\n";
   std::cout << "****************************************************************\n";
   std::cout << "FEDRawData: \n";
   char oldPad = std::cout.fill('0');
-  for(int i=0; i < max(100, (int)data.size()); ++i){
-    std::cout << std::hex << std::setw(2) << (int)(data.data()[i])
-	 << ((i+1)%8?" ":"\n") ;
+  for (int i = 0; i < max(100, (int)data.size()); ++i) {
+    std::cout << std::hex << std::setw(2) << (int)(data.data()[i]) << ((i + 1) % 8 ? " " : "\n");
   }
   std::cout.fill(oldPad);
   std::cout << "======================================================================\n";
-#endif //MATACQ_DEBUG defined
-  
+#endif  //MATACQ_DEBUG defined
+
   MatacqTBRawEvent matacq(data.data(), data.size());
 
 #if MATACQ_DEBUG
   printData(std::cout, matacq);
-#endif //MATACQ_DEBUG defined
+#endif  //MATACQ_DEBUG defined
 
-  const double ns = 1.e-9; //ns->s
-  const double ps = 1.e-12;//ps->s
-  double ts = ns/matacq.getFreqGHz();
-  double tTrig = matacq.getTTrigPs()<.5*std::numeric_limits<int>::max()?
-    ps*matacq.getTTrigPs():999.;
+  const double ns = 1.e-9;   //ns->s
+  const double ps = 1.e-12;  //ps->s
+  double ts = ns / matacq.getFreqGHz();
+  double tTrig = matacq.getTTrigPs() < .5 * std::numeric_limits<int>::max() ? ps * matacq.getTTrigPs() : 999.;
   int version = matacq.getMatacqDataFormatVersion();
-  
+
   std::vector<int16_t> samples;
   //FIXME: the interpretRawData method should fill an EcalMatacqDigiCollection
   //instead of an EcalMatacqDigi because Matacq channels are several.
   //In the meamtime copy only the first channel appearing in data:
   const std::vector<MatacqTBRawEvent::ChannelData>& chData = matacq.getChannelData();
-  for(unsigned iCh=0; iCh < chData.size(); ++iCh){
+  for (unsigned iCh = 0; iCh < chData.size(); ++iCh) {
     //copy time samples into a vector:
     samples.resize(chData[iCh].nSamples);
-    copy(chData[iCh].samples, chData[iCh].samples+chData[iCh].nSamples,
-	 samples.begin());
+    copy(chData[iCh].samples, chData[iCh].samples + chData[iCh].nSamples, samples.begin());
     int chId = chData[iCh].chId;
     std::vector<int16_t> empty;
     EcalMatacqDigi matacqDigi(empty, chId, ts, version, tTrig);
     matacqDigiCollection.push_back(matacqDigi);
-    matacqDigiCollection.back().swap(samples); //swap is more efficient than a copy
+    matacqDigiCollection.back().swap(samples);  //swap is more efficient than a copy
   }
 }
 
-void MatacqTBDataFormatter::printData(std::ostream& out, const MatacqTBRawEvent& matacq) const{
+void MatacqTBDataFormatter::printData(std::ostream& out, const MatacqTBRawEvent& matacq) const {
   std::cout << "FED id: " << std::hex << "0x" << matacq.getFedId() << std::dec << "\n";
-  std::cout << "Event id (lv1): " 
-       << std::hex << "0x" << matacq.getEventId() << std::dec << "\n";
+  std::cout << "Event id (lv1): " << std::hex << "0x" << matacq.getEventId() << std::dec << "\n";
   std::cout << "FOV: " << std::hex << "0x" << matacq.getFov() << std::dec << "\n";
   std::cout << "BX id: " << std::hex << "0x" << matacq.getBxId() << std::dec << "\n";
-  std::cout << "Trigger type: " 
-       << std::hex << "0x" << matacq.getTriggerType() << std::dec << "\n";
+  std::cout << "Trigger type: " << std::hex << "0x" << matacq.getTriggerType() << std::dec << "\n";
   std::cout << "DCC Length: " << matacq.getDccLen() << "\n";
   std::cout << "Run number: " << matacq.getRunNum() << "\n";
-  std::cout << "Field 'DCC errors': " 
-       << std::hex << "0x" << matacq.getDccErrors() << std::dec << "\n";
-  
-  if(matacq.getStatus()){
-    std::cout << "Error in matacq data. Errot code: "
-	 << std::hex << "0x" << matacq.getStatus() << std::dec << "\n";
+  std::cout << "Field 'DCC errors': " << std::hex << "0x" << matacq.getDccErrors() << std::dec << "\n";
+
+  if (matacq.getStatus()) {
+    std::cout << "Error in matacq data. Errot code: " << std::hex << "0x" << matacq.getStatus() << std::dec << "\n";
   }
-  
-  std::cout << "MATACQ data format version: " << matacq.getMatacqDataFormatVersion()
-       << "\n";
+
+  std::cout << "MATACQ data format version: " << matacq.getMatacqDataFormatVersion() << "\n";
   std::cout << "Sampling frequency: " << matacq.getFreqGHz() << " GHz\n";
   std::cout << "MATACQ channel count: " << matacq.getChannelCount() << "\n";
   time_t timeStamp = matacq.getTimeStamp();
   std::cout << "Data acquired on : " << ctime(&timeStamp);
 
   const std::vector<MatacqTBRawEvent::ChannelData>& channels = matacq.getChannelData();
-  for(unsigned i=0; i< channels.size(); ++i){
-    std::cout << "-------------------------------------- Channel "
-	 << channels[i].chId
-	 << ": " << std::setw(4) << channels[i].nSamples
-	 << " samples --------------------------------------\n";
-    
-    for(int iSample = 0; iSample<channels[i].nSamples; ++iSample){
+  for (unsigned i = 0; i < channels.size(); ++i) {
+    std::cout << "-------------------------------------- Channel " << channels[i].chId << ": " << std::setw(4)
+              << channels[i].nSamples << " samples --------------------------------------\n";
+
+    for (int iSample = 0; iSample < channels[i].nSamples; ++iSample) {
       MatacqTBRawEvent::int16le_t adc = (channels[i].samples)[iSample];
-      std::cout << std::setw(4) << adc
-	   << ((iSample%20==19)?"\n":" ");
+      std::cout << std::setw(4) << adc << ((iSample % 20 == 19) ? "\n" : " ");
     }
   }
   std::cout << "=================================================="
-    "==================================================\n\n";   
+               "==================================================\n\n";
 }

--- a/EventFilter/EcalTBRawToDigi/src/MatacqDataFormatter.h
+++ b/EventFilter/EcalTBRawToDigi/src/MatacqDataFormatter.h
@@ -6,26 +6,27 @@
 
 #include <ostream>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include  "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
+#include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 
 class MatacqTBRawEvent;
 class FEDRawData;
 
-class MatacqTBDataFormatter{
+class MatacqTBDataFormatter {
 public:
-  MatacqTBDataFormatter() {};
-  virtual ~MatacqTBDataFormatter(){LogDebug("EcalTBRawToDigi") << "@SUB=MatacqTBDataFormatter" << "\n"; };
-  
+  MatacqTBDataFormatter(){};
+  virtual ~MatacqTBDataFormatter() {
+    LogDebug("EcalTBRawToDigi") << "@SUB=MatacqTBDataFormatter"
+                                << "\n";
+  };
+
   /** Callback method for decoding raw data
    * @param data raw data
    * @param matacqDigiCollection [out] digi collection object to fill with
    * the decoded data
    */
-  void  interpretRawData(const FEDRawData & data,
-			 EcalMatacqDigiCollection& matacqDigiCollection);
-  
+  void interpretRawData(const FEDRawData& data, EcalMatacqDigiCollection& matacqDigiCollection);
+
 private:
   void printData(std::ostream& out, const MatacqTBRawEvent& event) const;
 };
 #endif
-

--- a/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.cc
+++ b/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.cc
@@ -19,36 +19,35 @@
 #include <stdexcept>
 #include "EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.h"
 
+const MatacqTBRawEvent::field32spec_t MatacqTBRawEvent::fov32 = {0, 0x000000F0};
+const MatacqTBRawEvent::field32spec_t MatacqTBRawEvent::fedId32 = {0, 0x000FFF00};
+const MatacqTBRawEvent::field32spec_t MatacqTBRawEvent::bxId32 = {0, 0xFFF00000};
+const MatacqTBRawEvent::field32spec_t MatacqTBRawEvent::lv132 = {1, 0x00FFFFFF};
+const MatacqTBRawEvent::field32spec_t MatacqTBRawEvent::triggerType32 = {1, 0x0F000000};
+const MatacqTBRawEvent::field32spec_t MatacqTBRawEvent::boeType32 = {1, 0xF0000000};
+const MatacqTBRawEvent::field32spec_t MatacqTBRawEvent::dccLen32 = {2, 0x00FFFFFF};
+const MatacqTBRawEvent::field32spec_t MatacqTBRawEvent::dccErrors32 = {2, 0xFF000000};
+const MatacqTBRawEvent::field32spec_t MatacqTBRawEvent::runNum32 = {3, 0x00FFFFFF};
+const MatacqTBRawEvent::field32spec_t MatacqTBRawEvent::h1Marker32 = {3, 0xF0000000};
 
-const MatacqTBRawEvent::field32spec_t MatacqTBRawEvent::fov32             = {0, 0x000000F0};
-const MatacqTBRawEvent::field32spec_t MatacqTBRawEvent::fedId32           = {0, 0x000FFF00};
-const MatacqTBRawEvent::field32spec_t MatacqTBRawEvent::bxId32            = {0, 0xFFF00000};
-const MatacqTBRawEvent::field32spec_t MatacqTBRawEvent::lv132             = {1, 0x00FFFFFF};
-const MatacqTBRawEvent::field32spec_t MatacqTBRawEvent::triggerType32     = {1, 0x0F000000};
-const MatacqTBRawEvent::field32spec_t MatacqTBRawEvent::boeType32         = {1, 0xF0000000};
-const MatacqTBRawEvent::field32spec_t MatacqTBRawEvent::dccLen32          = {2, 0x00FFFFFF};
-const MatacqTBRawEvent::field32spec_t MatacqTBRawEvent::dccErrors32       = {2, 0xFF000000};
-const MatacqTBRawEvent::field32spec_t MatacqTBRawEvent::runNum32          = {3, 0x00FFFFFF};
-const MatacqTBRawEvent::field32spec_t MatacqTBRawEvent::h1Marker32        = {3, 0xF0000000};
-
-void MatacqTBRawEvent::setRawData(const unsigned char* pData, size_t maxSize){
+void MatacqTBRawEvent::setRawData(const unsigned char* pData, size_t maxSize) {
   error = 0;
-  const int16le_t* begin16 = (const int16le_t*) pData;
+  const int16le_t* begin16 = (const int16le_t*)pData;
   const int16le_t* pData16 = begin16;
-  daqHeader = (const uint32le_t*) pData16;
-  const int daqHeaderLen = 16; //in bytes 
-  pData16 += daqHeaderLen/sizeof(pData16[0]);
-  matacqHeader = (const matacqHeader_t*) pData16;
-  pData16 += sizeof(matacqHeader_t)/sizeof(pData16[0]);
-  if(getMatacqDataFormatVersion()>=2){//trigger position present
+  daqHeader = (const uint32le_t*)pData16;
+  const int daqHeaderLen = 16;  //in bytes
+  pData16 += daqHeaderLen / sizeof(pData16[0]);
+  matacqHeader = (const matacqHeader_t*)pData16;
+  pData16 += sizeof(matacqHeader_t) / sizeof(pData16[0]);
+  if (getMatacqDataFormatVersion() >= 2) {  //trigger position present
     tTrigPs = *((const int32_t*)pData16);
     pData16 += 2;
-  } else{
-    tTrigPs = std::numeric_limits<int>::max();    
+  } else {
+    tTrigPs = std::numeric_limits<int>::max();
   }
   const int nCh = getChannelCount();
   channelData.resize(nCh);
-  for(int iCh=0; iCh<nCh; ++iCh){
+  for (int iCh = 0; iCh < nCh; ++iCh) {
     //channel id:
     channelData[iCh].chId = *(pData16++);
     //number of time samples for this channel:
@@ -58,54 +57,54 @@ void MatacqTBRawEvent::setRawData(const unsigned char* pData, size_t maxSize){
     //moves to next channel data block:
     pData16 += channelData[iCh].nSamples;
   }
-  
+
   //data trailer chekes:
   //FED header is aligned on 64-bit=>padding to skip
-  int padding = (4-(pData16-begin16))%4;
-  if(padding<0) padding+=4;
+  int padding = (4 - (pData16 - begin16)) % 4;
+  if (padding < 0)
+    padding += 4;
   pData16 += padding;
   const uint32le_t* trailer32 = (const uint32le_t*)(pData16);
-  fragLen = trailer32[1]&0xFFFFFF;
-  
+  fragLen = trailer32[1] & 0xFFFFFF;
+
   //std::cout << "Event fragment length including headers: " << fragLen
   //	 << " 64-bit words\n";
-  
+
   //FIXME: I am expecting the event length specifies in the header to
   //include the header, while it is not the case in current TB 2006 data
   const int nHeaders = 3;
-  if(fragLen!=read32(daqHeader,dccLen32)+nHeaders
-     && fragLen != read32(daqHeader,dccLen32)){
+  if (fragLen != read32(daqHeader, dccLen32) + nHeaders && fragLen != read32(daqHeader, dccLen32)) {
     //std::cout << "Error: fragment length is not consistent with DCC "
     //	"length\n";
     error |= errorLengthConsistency;
   }
-  
+
   //skip trailers
   const int trailerLen = 4;
   pData16 += trailerLen;
-  
-  parsedLen = (pData16-begin16) / 4;
 
-  if((pData16-begin16)!=(4*fragLen)){
+  parsedLen = (pData16 - begin16) / 4;
+
+  if ((pData16 - begin16) != (4 * fragLen)) {
     error |= errorLength;
   }
 
-  if((size_t)(pData16-begin16)>maxSize){
+  if ((size_t)(pData16 - begin16) > maxSize) {
     throw std::runtime_error(std::string("Corrupted or truncated data"));
   }
 
   //some checks
-  if(getBoe()!=0x5){
+  if (getBoe() != 0x5) {
     error |= errorWrongBoe;
   }
 }
 
-int MatacqTBRawEvent::read32(const uint32le_t* pData, field32spec_t spec32) const{
-  int result =  pData[spec32.offset] & spec32.mask;
+int MatacqTBRawEvent::read32(const uint32le_t* pData, field32spec_t spec32) const {
+  int result = pData[spec32.offset] & spec32.mask;
   int mask = spec32.mask;
-  while((mask&0x1) == 0){
-      mask >>= 1;
-      result >>= 1;
-    }
+  while ((mask & 0x1) == 0) {
+    mask >>= 1;
+    result >>= 1;
+  }
   return result;
 }

--- a/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.h
+++ b/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.h
@@ -4,7 +4,7 @@
 #define MATACQTBRAWEVENT_H
 
 #include <cinttypes>
-#include <time.h>
+#include <ctime>
 #include <vector>
 #if 0 //replace 1 by 0 to remove XDAQ dependency. In this case it is assumed
       //the machine is little endian.

--- a/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.h
+++ b/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.h
@@ -6,14 +6,14 @@
 #include <cinttypes>
 #include <ctime>
 #include <vector>
-#if 0 //replace 1 by 0 to remove XDAQ dependency. In this case it is assumed
-      //the machine is little endian.
-#include "i2o/utils/endian.h" //from XDAQ
+#if 0                          //replace 1 by 0 to remove XDAQ dependency. In this case it is assumed \
+                               //the machine is little endian.
+#include "i2o/utils/endian.h"  //from XDAQ
 #define UINT32_FROM_LE i2odecodel
 #define UINT16_FROM_LE i2odecodes
 #define INT16_FROM_LE i2odecodes
 
-#else //assuming little endianness of the machine
+#else  //assuming little endianness of the machine
 
 #define UINT32_FROM_LE
 #define UINT16_FROM_LE
@@ -24,49 +24,43 @@
 /** Wrapper for matacq raw event fragments. This class provides the
  * method to interpret the data. 
  */
-class MatacqTBRawEvent{
+class MatacqTBRawEvent {
   //typedefs, enums and static constants
 public:
   enum matacqError_t {
     /** Event length is specified both in the data header and the trailer. This
      * flags indicates an inconsitency between the two indications.
      */
-    errorLengthConsistency = 1<<0,
+    errorLengthConsistency = 1 << 0,
     /** Error in data length.
      */
-    errorLength = 1<<1,
+    errorLength = 1 << 1,
     /** Wrong Begin of eevent flag
      */
-    errorWrongBoe = 1<<2
+    errorWrongBoe = 1 << 2
   };
 
   /* The following types are little-endian encoded types. Use of these types
    * for the I20 data block should offer portability to big-endian platforms.
    */
   //@{
-  struct uint32le_t{
+  struct uint32le_t {
     uint32_t littleEndianInt;
-    operator uint32_t() const{
-      return UINT32_FROM_LE(littleEndianInt);
-    }
+    operator uint32_t() const { return UINT32_FROM_LE(littleEndianInt); }
   };
-  
-  struct uint16le_t{
+
+  struct uint16le_t {
     uint16_t littleEndianInt;
-    operator uint16_t() const{
-      return UINT16_FROM_LE(littleEndianInt);
-    }
+    operator uint16_t() const { return UINT16_FROM_LE(littleEndianInt); }
   };
-  
-  struct int16le_t{
+
+  struct int16le_t {
     int16_t littleEndianInt;
-    operator int16_t() const{
-      return INT16_FROM_LE(littleEndianInt);
-    }
+    operator int16_t() const { return INT16_FROM_LE(littleEndianInt); }
   };
   //@}
-  
-  struct ChannelData{
+
+  struct ChannelData {
     /** Matacq channel number. From 0 to 3.
      */
     int chId;
@@ -78,23 +72,23 @@ public:
     const int16le_t* samples;
   };
 
-private:  
+private:
   /** Matacq header data structure
    */
-  struct matacqHeader_t{		 
-    uint16le_t version;	 
-    unsigned char freqGHz;	 
-    unsigned char channelCount; 
-    uint32_t timeStamp;	 
-  };                                          
+  struct matacqHeader_t {
+    uint16le_t version;
+    unsigned char freqGHz;
+    unsigned char channelCount;
+    uint32_t timeStamp;
+  };
 
   /** Specification of DAQ header field.
    */
-  struct field32spec_t{
+  struct field32spec_t {
     int offset;
     unsigned int mask;
   };
-  
+
   /** DAQ header field specifications.
    */
   static const field32spec_t fov32;
@@ -108,7 +102,6 @@ private:
   static const field32spec_t runNum32;
   static const field32spec_t h1Marker32;
 
-  
   //constructors
 public:
   /** Constuctor.
@@ -120,9 +113,7 @@ public:
    * @throw std::exception if the data cannot be decoded due to data corruption
    * or truncation.
    */
-  MatacqTBRawEvent(const unsigned char* dataBuffer, std::size_t bufferSize){
-    setRawData(dataBuffer, bufferSize);
-  }
+  MatacqTBRawEvent(const unsigned char* dataBuffer, std::size_t bufferSize) { setRawData(dataBuffer, bufferSize); }
   //methods
 public:
   /** Gets the Fed event fragment data format (FOV) field content.
@@ -131,109 +122,104 @@ public:
    * #getMatacqDataFormatVersion()
    * @return FOV
    */
-  int getFov() const { return read32(daqHeader, fov32);}
-  
+  int getFov() const { return read32(daqHeader, fov32); }
+
   /** Gets the FED ID field contents. Should be 43.
    * @return FED ID
    */
-  int getFedId() const { return read32(daqHeader, fedId32);}
+  int getFedId() const { return read32(daqHeader, fedId32); }
 
   /** Gets the bunch crossing id field contents.
    * @return BX id
    */
-  int getBxId() const { return read32(daqHeader, bxId32);}
+  int getBxId() const { return read32(daqHeader, bxId32); }
 
   /** Gets the LV1 field contents.
    * @return LV1 id
    */
-  unsigned getEventId() const { return read32(daqHeader, lv132);}
+  unsigned getEventId() const { return read32(daqHeader, lv132); }
 
   /** Gets the trigger type field contents.
    * @return trigger type
    */
-  int getTriggerType() const { return read32(daqHeader, triggerType32);}
+  int getTriggerType() const { return read32(daqHeader, triggerType32); }
 
   /** Gets the beging of event field contents (BOE). Must be 0x5.
    * @return BOE
    */
-  int getBoe() const { return read32(daqHeader, boeType32);}
+  int getBoe() const { return read32(daqHeader, boeType32); }
 
   /** Gets the event length specifies in the "a la DCC" header.
    * @return event length
    */
-  unsigned getDccLen() const { return read32(daqHeader, dccLen32);}
+  unsigned getDccLen() const { return read32(daqHeader, dccLen32); }
 
   /** Gets the event length specifies in the DAQ trailer
    * @return event length
    */
-  unsigned getDaqLen() const { return fragLen;}
-
+  unsigned getDaqLen() const { return fragLen; }
 
   /** Gets the contents of the DCC error field. Currently Not used for Matacq.
    * @return dcc error
    */
-  int getDccErrors() const { return read32(daqHeader, dccErrors32);}
+  int getDccErrors() const { return read32(daqHeader, dccErrors32); }
 
   /** Gets the run number field contents.
    * @return run number
    */
-  unsigned getRunNum() const { return read32(daqHeader, runNum32);}
+  unsigned getRunNum() const { return read32(daqHeader, runNum32); }
 
   /** Gets the header marker field contents. Must be 1
    * @return H1 header marker
    */
-  int getH1Marker() const { return read32(daqHeader, h1Marker32);}
-  
+  int getH1Marker() const { return read32(daqHeader, h1Marker32); }
 
   /** Gets the matcq data format version
    * @return data version
    */
-  int getMatacqDataFormatVersion() const { return matacqHeader->version;}
+  int getMatacqDataFormatVersion() const { return matacqHeader->version; }
 
   /** Gets the raw data status. Bitwise OR of the error flags
    * defined by matcqError_t
    * @return status
    */
-  int32_t getStatus() const { return error;}
+  int32_t getStatus() const { return error; }
 
   /** Gets the matacq sampling frequency field contents.
    * @return sampling frequency in GHz: 1 or 2
    */
-  int getFreqGHz() const { return matacqHeader->freqGHz;}
+  int getFreqGHz() const { return matacqHeader->freqGHz; }
 
   /** Gets the matacq channel count field contents.
    * @return number of channels
    */
-  int getChannelCount() const { return matacqHeader->channelCount;}
+  int getChannelCount() const { return matacqHeader->channelCount; }
 
   /** Gets the matacq channel data. Beware that no copy is done and that
    * the returned data will be invalidated if the data contains in the buffer
    * is modified (see constructor and #setRawData().
    * @return matacq channel data.
    */
-  const std::vector<ChannelData>& getChannelData() const{
-    return channelData;
-  }
+  const std::vector<ChannelData>& getChannelData() const { return channelData; }
 
   /** Gets the data length in number of 64-bit words computed by the data
    * parser.
    * @return event length
    */
-  int getParsedLen() {  return parsedLen; }
-  
+  int getParsedLen() { return parsedLen; }
+
   /** Gets the matacq data timestamp field contents: 
    * @return acquisition date of the data expressed in number of "elapsed"
    * second since the EPOCH as defined in POSIX.1. See time()  standard c
    * function.
    */
-  time_t getTimeStamp() const { return matacqHeader->timeStamp;}
-
+  time_t getTimeStamp() const { return matacqHeader->timeStamp; }
 
   /** Gets the Matacq trigger time.
    * @return (t_trig-t_0) in ps, with t_0 the time of the first sample and
    * t_trig the trigger time.
    */
-  int getTTrigPs() const { return tTrigPs;}
+  int getTTrigPs() const { return tTrigPs; }
 
 private:
   /** Help function to decode header content.
@@ -242,7 +228,7 @@ private:
    * @return content of data field specified by 'spec'
    */
   int read32(const uint32le_t* pData, field32spec_t spec) const;
-  
+
   /** Changes the raw data pointer and updates accordingly this object. 
    * @param buffer new pointer to the data buffer. Must be aligned at least
    * on 32-bit words.
@@ -265,7 +251,7 @@ private:
   /** Number of matacq channels in the data.
    */
   int channelCount;
-  
+
   /** Channel samples
    */
   std::vector<ChannelData> channelData;
@@ -313,7 +299,7 @@ private:
   /**Matacq header:
    */
   const matacqHeader_t* matacqHeader;
-  
+
   /** MATACQ data format internal version
    */
   int matacqDataFormatVersion;
@@ -337,10 +323,10 @@ private:
   /** MATACQ trigger time position in ps
    */
   int tTrigPs;
-  
+
   /** Trigger type
    */
   int triggerType;
 };
 
-#endif //MATACQRAWEVENT_H not defined
+#endif  //MATACQRAWEVENT_H not defined

--- a/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.h
+++ b/EventFilter/EcalTBRawToDigi/src/MatacqRawEvent.h
@@ -6,8 +6,8 @@
 #include <cinttypes>
 #include <ctime>
 #include <vector>
-#if 0                          //replace 1 by 0 to remove XDAQ dependency. In this case it is assumed \
-                               //the machine is little endian.
+//replace 1 by 0 to remove XDAQ dependency. In this case it is assumed the machine is little endian.
+#if 0
 #include "i2o/utils/endian.h"  //from XDAQ
 #define UINT32_FROM_LE i2odecodel
 #define UINT16_FROM_LE i2odecodes

--- a/EventFilter/EcalTBRawToDigi/src/SealModule.cc
+++ b/EventFilter/EcalTBRawToDigi/src/SealModule.cc
@@ -1,11 +1,8 @@
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
-
 #include <EventFilter/EcalTBRawToDigi/interface/EcalDCCUnpackingModule.h>
 DEFINE_FWK_MODULE(EcalDCCTBUnpackingModule);
 
 #include <EventFilter/EcalTBRawToDigi/interface/EcalDCC07UnpackingModule.h>
 DEFINE_FWK_MODULE(EcalDCCTB07UnpackingModule);
-

--- a/EventFilter/EcalTBRawToDigi/src/TableDataFormatter.cc
+++ b/EventFilter/EcalTBRawToDigi/src/TableDataFormatter.cc
@@ -1,54 +1,51 @@
 #include "TableDataFormatter.h"
 
-
 #include <iostream>
 
-TableDataFormatter::TableDataFormatter () {
-}
+TableDataFormatter::TableDataFormatter() {}
 
-void TableDataFormatter::interpretRawData( const FEDRawData & fedData, 
-					   EcalTBEventHeader& tbEventHeader)
-{
-  const unsigned long * buffer = reinterpret_cast<const unsigned long*>(fedData.data());
-  int fedLenght                        = fedData.size(); // in Bytes
-  
+void TableDataFormatter::interpretRawData(const FEDRawData& fedData, EcalTBEventHeader& tbEventHeader) {
+  const unsigned long* buffer = reinterpret_cast<const unsigned long*>(fedData.data());
+  int fedLenght = fedData.size();  // in Bytes
+
   // check ultimate fed size and strip off fed-header and -trailer
-  if (fedLenght != (nWordsPerEvent *4) )
-    {
-      edm::LogError("TableDataFormatter") << "TableData has size "  <<  fedLenght
-				       <<" Bytes as opposed to expected " 
-				       << (nWordsPerEvent *4)
-				     << ". Returning.";
-      return;
-    }
+  if (fedLenght != (nWordsPerEvent * 4)) {
+    edm::LogError("TableDataFormatter") << "TableData has size " << fedLenght << " Bytes as opposed to expected "
+                                        << (nWordsPerEvent * 4) << ". Returning.";
+    return;
+  }
 
-  unsigned long a=1; // used to extract an 8 Bytes word from fed 
-  unsigned long b=1; // used to manipulate the 8 Bytes word and get what needed
+  unsigned long a = 1;  // used to extract an 8 Bytes word from fed
+  unsigned long b = 1;  // used to manipulate the 8 Bytes word and get what needed
 
-  int wordCounter =0;
-  wordCounter +=4;
+  int wordCounter = 0;
+  wordCounter += 4;
 
-  a = buffer[wordCounter];wordCounter++;
-  b = (a& 0xffffffff);
+  a = buffer[wordCounter];
+  wordCounter++;
+  b = (a & 0xffffffff);
   tbEventHeader.setThetaTableIndex(b);
   LogDebug("TableDataFormatter") << "Table theta position:\t" << b;
-  a = buffer[wordCounter];wordCounter++;
-  b = (a& 0xffffffff);
+  a = buffer[wordCounter];
+  wordCounter++;
+  b = (a & 0xffffffff);
   tbEventHeader.setPhiTableIndex(b);
   LogDebug("TableDataFormatter") << "Table phi position:\t" << b;
-  a = buffer[wordCounter];wordCounter++;
-  b = (a& 0xffff);
-  tbEventHeader.setCrystalInBeam(EBDetId(1,b,EBDetId::SMCRYSTALMODE));
+  a = buffer[wordCounter];
+  wordCounter++;
+  b = (a & 0xffff);
+  tbEventHeader.setCrystalInBeam(EBDetId(1, b, EBDetId::SMCRYSTALMODE));
   LogDebug("TableDataFormatter") << "Actual Current crystal in beam:\t" << b;
-  b = (a& 0xffff0000);
+  b = (a & 0xffff0000);
   b = b >> 16;
-  tbEventHeader.setNominalCrystalInBeam(EBDetId(1,b,EBDetId::SMCRYSTALMODE));
+  tbEventHeader.setNominalCrystalInBeam(EBDetId(1, b, EBDetId::SMCRYSTALMODE));
   LogDebug("TableDataFormatter") << "Nominal Current crystal in beam:\t" << b;
-  a = buffer[wordCounter];wordCounter++;
-  b = (a& 0xffff);
-  tbEventHeader.setNextCrystalInBeam(EBDetId(1,b,EBDetId::SMCRYSTALMODE));
+  a = buffer[wordCounter];
+  wordCounter++;
+  b = (a & 0xffff);
+  tbEventHeader.setNextCrystalInBeam(EBDetId(1, b, EBDetId::SMCRYSTALMODE));
   LogDebug("TableDataFormatter") << "Next crystal in beam:\t" << b;
-  b = (a& 0x00010000); //Table is moving at the begin of the spill
+  b = (a & 0x00010000);  //Table is moving at the begin of the spill
   b = b >> 16;
   tbEventHeader.setTableIsMovingAtBegSpill(b & 0x1);
   LogDebug("TableDataFormatter") << "Table is moving at begin of the spill:\t" << b;

--- a/EventFilter/EcalTBRawToDigi/src/TableDataFormatter.h
+++ b/EventFilter/EcalTBRawToDigi/src/TableDataFormatter.h
@@ -9,20 +9,19 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
-
 class FEDRawData;
-class TableDataFormatter   {
-
- public:
-
-  TableDataFormatter() ;
-  virtual ~TableDataFormatter(){LogDebug("EcalTBRawToDigi") << "@SUB=TableDataFormatter" << "\n"; };
+class TableDataFormatter {
+public:
+  TableDataFormatter();
+  virtual ~TableDataFormatter() {
+    LogDebug("EcalTBRawToDigi") << "@SUB=TableDataFormatter"
+                                << "\n";
+  };
 
   //Method to be implemented
-  void  interpretRawData( const FEDRawData & data, EcalTBEventHeader& tbEventHeader);
- private:
+  void interpretRawData(const FEDRawData& data, EcalTBEventHeader& tbEventHeader);
 
- static const int nWordsPerEvent =10;    // Number of fibers per hodoscope plane   
+private:
+  static const int nWordsPerEvent = 10;  // Number of fibers per hodoscope plane
 };
 #endif

--- a/EventFilter/EcalTBRawToDigi/test/stubs/EcalDCCHeaderDumperModule.cc
+++ b/EventFilter/EcalTBRawToDigi/test/stubs/EcalDCCHeaderDumperModule.cc
@@ -15,103 +15,97 @@
 #include <iostream>
 #include <vector>
 
+class EcalDCCHeaderDumperModule : public edm::EDAnalyzer {
+public:
+  EcalDCCHeaderDumperModule(const edm::ParameterSet& ps) {}
 
-
-class EcalDCCHeaderDumperModule: public edm::EDAnalyzer{
-  
- public:
-  EcalDCCHeaderDumperModule(const edm::ParameterSet& ps){   }
-  
- protected:
-  
-  void analyze( const edm::Event & e, const  edm::EventSetup& c){
-    
+protected:
+  void analyze(const edm::Event& e, const edm::EventSetup& c) {
     edm::Handle<EcalRawDataCollection> DCCHeaders;
     e.getByLabel("ecalEBunpacker", DCCHeaders);
-    
 
-    std::cout << "\n\n ^^^^^^^^^^^^^^^^^^ [EcalDCCHeaderDumperModule]  DCCHeaders collection size " << DCCHeaders->size() << std::endl;
-    std::cout << "          [EcalDCCHeaderDumperModule]  the Header(s)\n"  << std::endl;
-    //short dumpConter =0;      
+    std::cout << "\n\n ^^^^^^^^^^^^^^^^^^ [EcalDCCHeaderDumperModule]  DCCHeaders collection size "
+              << DCCHeaders->size() << std::endl;
+    std::cout << "          [EcalDCCHeaderDumperModule]  the Header(s)\n" << std::endl;
+    //short dumpConter =0;
 
-    for ( EcalRawDataCollection::const_iterator headerItr= DCCHeaders->begin();headerItr != DCCHeaders->end(); 
-	  ++headerItr ) {
-      //      int nevt =headerItr->getLV1(); 
+    for (EcalRawDataCollection::const_iterator headerItr = DCCHeaders->begin(); headerItr != DCCHeaders->end();
+         ++headerItr) {
+      //      int nevt =headerItr->getLV1();
       bool skip = false;
       //LASER
-//       bool skip = nevt > 3 && nevt < 620;
-//       skip = skip || (nevt > 623 && nevt <1230);
-//       skip = skip || (nevt > 1233 && nevt <1810);
-//       skip = skip || (nevt > 1813);
+      //       bool skip = nevt > 3 && nevt < 620;
+      //       skip = skip || (nevt > 623 && nevt <1230);
+      //       skip = skip || (nevt > 1233 && nevt <1810);
+      //       skip = skip || (nevt > 1813);
 
- //    MGPA test pulse
- //      bool skip = nevt > 3 && nevt <53;
-//       skip = skip || (nevt > 56 && nevt <102);
-//       skip = skip || (nevt > 105);
+      //    MGPA test pulse
+      //      bool skip = nevt > 3 && nevt <53;
+      //       skip = skip || (nevt > 56 && nevt <102);
+      //       skip = skip || (nevt > 105);
 
- //    PEDESTAL
- //    bool skip = nevt > 3 && nevt <153;
-//     skip = skip || (nevt > 156 && nevt <302);
-//     skip = skip || (nevt > 305);
+      //    PEDESTAL
+      //    bool skip = nevt > 3 && nevt <153;
+      //     skip = skip || (nevt > 156 && nevt <302);
+      //     skip = skip || (nevt > 305);
 
-
-    if(skip){continue;}
+      if (skip) {
+        continue;
+      }
       // if(nevt > 60 ){break;}
-      std::cout<<"###################################################################### \n";
-      std::cout << "DCCid: "<< headerItr->id()<<"\n";
-      
-      std::cout << "DCCErrors: "<<headerItr->getDCCErrors()<<"\n";
-      std::cout<<"Run Number: "<<headerItr->getRunNumber()<<"\n";
-      std::cout<<"Event number (LV1): "<<headerItr->getLV1()<<"\n";
+      std::cout << "###################################################################### \n";
+      std::cout << "DCCid: " << headerItr->id() << "\n";
+
+      std::cout << "DCCErrors: " << headerItr->getDCCErrors() << "\n";
+      std::cout << "Run Number: " << headerItr->getRunNumber() << "\n";
+      std::cout << "Event number (LV1): " << headerItr->getLV1() << "\n";
       // this requires DataFormats/EcalRawData V01-01-12
       //std::cout << "Orbit: " << headerItr->getOrbit () << "\n";
-      std::cout<<"BX: "<<headerItr->getBX()<<"\n";
-      std::cout<<"TRIGGER TYPE: "<< headerItr->getBasicTriggerType()<<"\n";
-      
-      std::cout<<"RUNTYPE: "<< headerItr->getRunType()<<"\n";
-      std::cout<<"Half: "<<headerItr->getRtHalf()<<"\n";
-      std::cout<<"MGPA gain: "<<headerItr->getMgpaGain()<<"\n";
-      std::cout<<"MEM gain: "<<headerItr->getMemGain()<<"\n";
-      EcalDCCHeaderBlock::EcalDCCEventSettings settings = headerItr->getEventSettings();
-      std::cout<<"LaserPower: "<<  settings.LaserPower<<"\n";
-      std::cout <<"LAserFilter: "<<settings.LaserFilter<<"\n";
-      std::cout<<"Wavelenght: "<<settings.wavelength<<"\n";
-      std::cout<<"delay: "<<settings.delay<<"\n";
-      std::cout<<"MEM Vinj: "<< settings.MEMVinj<<"\n";
-      std::cout<<"MGPA content: "<<settings.mgpa_content<<"\n";
-      std::cout<<"Ped offset dac: "<<settings.ped_offset<<"\n";
+      std::cout << "BX: " << headerItr->getBX() << "\n";
+      std::cout << "TRIGGER TYPE: " << headerItr->getBasicTriggerType() << "\n";
 
-      std::cout<<"Selective Readout: "<<headerItr->getSelectiveReadout()<<"\n";
-      std::cout<<"ZS: "<<headerItr->getZeroSuppression()<<"\n";
-      std::cout <<"TZS: "<<headerItr->getTestZeroSuppression()<<"\n";
-      std::cout<<"SRStatus: "<<headerItr->getSrpStatus()<<"\n";
+      std::cout << "RUNTYPE: " << headerItr->getRunType() << "\n";
+      std::cout << "Half: " << headerItr->getRtHalf() << "\n";
+      std::cout << "MGPA gain: " << headerItr->getMgpaGain() << "\n";
+      std::cout << "MEM gain: " << headerItr->getMemGain() << "\n";
+      EcalDCCHeaderBlock::EcalDCCEventSettings settings = headerItr->getEventSettings();
+      std::cout << "LaserPower: " << settings.LaserPower << "\n";
+      std::cout << "LAserFilter: " << settings.LaserFilter << "\n";
+      std::cout << "Wavelenght: " << settings.wavelength << "\n";
+      std::cout << "delay: " << settings.delay << "\n";
+      std::cout << "MEM Vinj: " << settings.MEMVinj << "\n";
+      std::cout << "MGPA content: " << settings.mgpa_content << "\n";
+      std::cout << "Ped offset dac: " << settings.ped_offset << "\n";
+
+      std::cout << "Selective Readout: " << headerItr->getSelectiveReadout() << "\n";
+      std::cout << "ZS: " << headerItr->getZeroSuppression() << "\n";
+      std::cout << "TZS: " << headerItr->getTestZeroSuppression() << "\n";
+      std::cout << "SRStatus: " << headerItr->getSrpStatus() << "\n";
 
       std::vector<short> TCCStatus = headerItr->getTccStatus();
-      std::cout<<"TCC Status size: "<<TCCStatus.size()<<std::endl;
-      std::cout<<"TCC Status: ";
-      for(unsigned u =0;u<TCCStatus.size();u++){
-	std::cout<<TCCStatus[u]<<" ";
+      std::cout << "TCC Status size: " << TCCStatus.size() << std::endl;
+      std::cout << "TCC Status: ";
+      for (unsigned u = 0; u < TCCStatus.size(); u++) {
+        std::cout << TCCStatus[u] << " ";
       }
-      std::cout<<std::endl;
-      
+      std::cout << std::endl;
+
       // this requires DataFormats/EcalRawData V01-01-12
       //std::vector<short> TTStatus = headerItr->getFEStatus();
       std::vector<short> TTStatus = headerItr->getFEStatus();
-      std::cout<<"TT Status size: "<<TTStatus.size()<<std::endl;
-      std::cout<<"TT Status: ";
-      for(unsigned u =0;u<TTStatus.size();u++){
-	std::cout<<TTStatus[u]<<" ";
+      std::cout << "TT Status size: " << TTStatus.size() << std::endl;
+      std::cout << "TT Status: ";
+      for (unsigned u = 0; u < TTStatus.size(); u++) {
+        std::cout << TTStatus[u] << " ";
       }
-      std::cout<<std::endl;
-      std::cout<<"######################################################################"<<std::endl;;
+      std::cout << std::endl;
+      std::cout << "######################################################################" << std::endl;
+      ;
       //if( (dumpConter++) > 10) break;
+    }
 
-    }	
-    
-    
-    
-  } // produce
+  }  // produce
 
-};// class EcalDigiDumperModule
+};  // class EcalDigiDumperModule
 
 DEFINE_FWK_MODULE(EcalDCCHeaderDumperModule);

--- a/EventFilter/EcalTBRawToDigi/test/stubs/EcalDigiDumperModule.cc
+++ b/EventFilter/EcalTBRawToDigi/test/stubs/EcalDigiDumperModule.cc
@@ -14,84 +14,71 @@
 #include <DataFormats/EcalDigi/interface/EcalDigiCollections.h>
 #include <DataFormats/EcalDetId/interface/EcalDetIdCollections.h>
 
-
 #include <iostream>
 #include <vector>
 
+class EcalDigiDumperModule : public edm::EDAnalyzer {
+public:
+  EcalDigiDumperModule(const edm::ParameterSet& ps) {
+    verbosity = ps.getUntrackedParameter<int>("verbosity", 1);
 
-class EcalDigiDumperModule: public edm::EDAnalyzer{
-  
- public:
-  EcalDigiDumperModule(const edm::ParameterSet& ps){  
-    verbosity      = ps.getUntrackedParameter<int>("verbosity",1);
+    ieb_id = ps.getUntrackedParameter<int>("ieb_id", -1);
 
-    ieb_id         = ps.getUntrackedParameter<int>("ieb_id",-1);
+    memErrors = ps.getUntrackedParameter<bool>("memErrors", true);
+    cryDigi = ps.getUntrackedParameter<bool>("cryDigi", true);
+    pnDigi = ps.getUntrackedParameter<bool>("pnDigi", true);
+    tpDigi = ps.getUntrackedParameter<bool>("tpDigi", true);
 
-    memErrors      = ps.getUntrackedParameter<bool>("memErrors",true);
-    cryDigi        = ps.getUntrackedParameter<bool>("cryDigi",true);
-    pnDigi         = ps.getUntrackedParameter<bool>("pnDigi",true);
-    tpDigi         = ps.getUntrackedParameter<bool>("tpDigi",true);
+    mode = ps.getUntrackedParameter<int>("mode", 2);
 
+    numChannel = ps.getUntrackedParameter<int>("numChannel", 10);
+    numPN = ps.getUntrackedParameter<int>("numPN", 2);
 
-    mode           = ps.getUntrackedParameter<int>("mode",2);
+    listChannels = ps.getUntrackedParameter<std::vector<int> >("listChannels", std::vector<int>());
+    listTowers = ps.getUntrackedParameter<std::vector<int> >("listTowers", std::vector<int>());
+    listPns = ps.getUntrackedParameter<std::vector<int> >("listPns", std::vector<int>());
 
-    numChannel     = ps.getUntrackedParameter<int>("numChannel",10);
-    numPN          = ps.getUntrackedParameter<int>("numPN",2);
-    
-    listChannels   = ps.getUntrackedParameter<std::vector<int> >("listChannels", std::vector<int>());
-    listTowers     = ps.getUntrackedParameter<std::vector<int> >("listTowers", std::vector<int>());
-    listPns        = ps.getUntrackedParameter<std::vector<int> >("listPns", std::vector<int>());
-   
-    
     inputIsOk = true;
     // consistency checks checks
-    
-    if ( (!(mode==1))  &&  (!(mode==2)) )
-      {  
-	std::cout << "[EcalDigiDumperModule] parameter mode set to: " << mode 
-	     << ". Only mode 1 and 2 are allowed, returning." << std::endl;
-	inputIsOk = false;
-	return;
-      }
-    
-    
+
+    if ((!(mode == 1)) && (!(mode == 2))) {
+      std::cout << "[EcalDigiDumperModule] parameter mode set to: " << mode
+                << ". Only mode 1 and 2 are allowed, returning." << std::endl;
+      inputIsOk = false;
+      return;
+    }
+
     std::vector<int>::iterator intIter;
-    
-    for (intIter = listChannels.begin(); intIter != listChannels.end(); intIter++)
-      {  
-	if ( ((*intIter) < 1) ||  (1700 < (*intIter)) )       {  
-	  std::cout << "[EcalDigiDumperModule] ic value: " << (*intIter) << " found in listChannels. "
-	       << " Valid range is 1-1700. Returning." << std::endl;
-	  inputIsOk = false;
-	  return;
-	}
+
+    for (intIter = listChannels.begin(); intIter != listChannels.end(); intIter++) {
+      if (((*intIter) < 1) || (1700 < (*intIter))) {
+        std::cout << "[EcalDigiDumperModule] ic value: " << (*intIter) << " found in listChannels. "
+                  << " Valid range is 1-1700. Returning." << std::endl;
+        inputIsOk = false;
+        return;
       }
-    
-    
-    for (intIter = listTowers.begin(); intIter != listTowers.end(); intIter++)
-      {  
-	if ( ((*intIter) < 1) ||  (70 < (*intIter)) )       {  
-	  std::cout << "[EcalDigiDumperModule] ic value: " << (*intIter) << " found in listTowers. "
-	       << " Valid range is 1-70. Returning." << std::endl;
-	  inputIsOk = false;
-	  return;
-	}
+    }
+
+    for (intIter = listTowers.begin(); intIter != listTowers.end(); intIter++) {
+      if (((*intIter) < 1) || (70 < (*intIter))) {
+        std::cout << "[EcalDigiDumperModule] ic value: " << (*intIter) << " found in listTowers. "
+                  << " Valid range is 1-70. Returning." << std::endl;
+        inputIsOk = false;
+        return;
       }
-    
-    for (intIter = listPns.begin(); intIter != listPns.end(); intIter++)
-      {  
-	if ( ((*intIter) < 1) ||  (10 < (*intIter)) )       {  
-	  std::cout << "[EcalDigiDumperModule] pn number : " << (*intIter) << " found in listPns. "
-	       << " Valid range is 1-10. Returning." << std::endl;
-	  inputIsOk = false;
-	  return;
-	}
+    }
+
+    for (intIter = listPns.begin(); intIter != listPns.end(); intIter++) {
+      if (((*intIter) < 1) || (10 < (*intIter))) {
+        std::cout << "[EcalDigiDumperModule] pn number : " << (*intIter) << " found in listPns. "
+                  << " Valid range is 1-10. Returning." << std::endl;
+        inputIsOk = false;
+        return;
       }
-    
+    }
   }
-  
-  
- protected:
+
+protected:
   int verbosity;
   bool memErrors;
   bool cryDigi;
@@ -111,206 +98,183 @@ class EcalDigiDumperModule: public edm::EDAnalyzer{
   std::vector<int> listTowers;
   std::vector<int> listPns;
 
+  void analyze(const edm::Event& e, const edm::EventSetup& c) {
+    if (!inputIsOk)
+      return;
 
-
-
-  void analyze( const edm::Event & e, const  edm::EventSetup& c){
-
-    if (!inputIsOk) return;
-    
-    
     // retrieving crystal data from Event
-    edm::Handle<EBDigiCollection>  digis;
+    edm::Handle<EBDigiCollection> digis;
     e.getByLabel("ecalEBunpacker", "ebDigis", digis);
 
     // retrieving crystal PN diodes from Event
-    edm::Handle<EcalPnDiodeDigiCollection>  PNs;
+    edm::Handle<EcalPnDiodeDigiCollection> PNs;
     e.getByLabel("ecalEBunpacker", PNs);
 
     // retrieve collection of errors in the mem gain data
     edm::Handle<EcalElectronicsIdCollection> gainMem;
     e.getByLabel("ecalEBunpacker", "EcalIntegrityMemChIdErrors", gainMem);
-    
+
     // retrieve collection of errors in the mem gain data
     edm::Handle<EcalElectronicsIdCollection> MemId;
     e.getByLabel("ecalEBunpacker", "EcalIntegrityMemTtIdErrors", MemId);
 
-    
     std::cout << "\n\n";
 
-    if(gainMem->size() && memErrors) {  
-      std::cout << "\n\n^^^^^^^^^^^^^^^^^^ [EcalDigiDumperModule]  Size of collection of mem gain errors is: " << gainMem->size() << std::endl;
-      std::cout << "                                  [EcalDigiDumperModule]  dumping the bit gain errors\n"  << std::endl;
-      for (EcalElectronicsIdCollection::const_iterator errItr= gainMem->begin();
-	   errItr  != gainMem->end(); 
-	   ++errItr ) {
-	EcalElectronicsId  id = (*errItr);
-	    std::cout << "channel: dccNum= " << id.dccId() 
-		 << "\t tower= " << id.towerId() 
-		 << "\t channelNum= " << id.channelId()
-		 << " has problems in the gain bits" << std::endl;
-      }// end of loop on gain errors in the mem
-      }// end if
-      
+    if (gainMem->size() && memErrors) {
+      std::cout << "\n\n^^^^^^^^^^^^^^^^^^ [EcalDigiDumperModule]  Size of collection of mem gain errors is: "
+                << gainMem->size() << std::endl;
+      std::cout << "                                  [EcalDigiDumperModule]  dumping the bit gain errors\n"
+                << std::endl;
+      for (EcalElectronicsIdCollection::const_iterator errItr = gainMem->begin(); errItr != gainMem->end(); ++errItr) {
+        EcalElectronicsId id = (*errItr);
+        std::cout << "channel: dccNum= " << id.dccId() << "\t tower= " << id.towerId()
+                  << "\t channelNum= " << id.channelId() << " has problems in the gain bits" << std::endl;
+      }  // end of loop on gain errors in the mem
+    }    // end if
 
-        
-    if(MemId->size() && memErrors) {  
-      std::cout << "\n\n^^^^^^^^^^^^^^^^^^ [EcalDigiDumperModule]  Size of collection of mem tt_block_id errors is: " << MemId->size() << std::endl;
-      std::cout << "                                  [EcalDigiDumperModule]  dumping the mem tt_block_idb errors\n"  << std::endl;
-      for (EcalElectronicsIdCollection::const_iterator errItr= MemId->begin();
-	   errItr  != MemId->end(); 
-	   ++errItr ) {
-	EcalElectronicsId  id = (*errItr);
-	    std::cout << "tower_block: dccNum= " << id.dccId() 
-		 << "\t tower= " << id.towerId() 
-		 << " has ID problems " << std::endl;
-      }// end of loop tower_block_id errors in the mem
-    }// end if
-    
+    if (MemId->size() && memErrors) {
+      std::cout << "\n\n^^^^^^^^^^^^^^^^^^ [EcalDigiDumperModule]  Size of collection of mem tt_block_id errors is: "
+                << MemId->size() << std::endl;
+      std::cout << "                                  [EcalDigiDumperModule]  dumping the mem tt_block_idb errors\n"
+                << std::endl;
+      for (EcalElectronicsIdCollection::const_iterator errItr = MemId->begin(); errItr != MemId->end(); ++errItr) {
+        EcalElectronicsId id = (*errItr);
+        std::cout << "tower_block: dccNum= " << id.dccId() << "\t tower= " << id.towerId() << " has ID problems "
+                  << std::endl;
+      }  // end of loop tower_block_id errors in the mem
+    }    // end if
 
-    short dumpCounter =0;      
+    short dumpCounter = 0;
 
-    if (verbosity>0 && cryDigi && (mode==1) )
-      {
-	std::cout << "\n\n^^^^^^^^^^^^^^^^^^ [EcalDigiDumperModule]  digi cry collection size " << digis->size() << std::endl;
-	std::cout << "                                  [EcalDigiDumperModule]  dumping first " << numChannel << " crystals\n";
-	dumpCounter =0;      
-	for ( EBDigiCollection::const_iterator digiItr= digis->begin();digiItr != digis->end(); 
-	      ++digiItr ) {
-	  
-	  {
-	    if( (dumpCounter++) >= numChannel) break;
-	    if (! ((EBDetId((*digiItr).id()).ism()==ieb_id) || (ieb_id==-1))  ) continue;
-	    
-		std::cout << "ic-cry: " 
-		     << EBDetId((*digiItr).id()).ic() << " i-phi: " 
-		     << EBDetId((*digiItr).id()).iphi() << " j-eta: " 
-		     << EBDetId((*digiItr).id()).ieta();
-		
-		for ( unsigned int i=0; i< (*digiItr).size() ; ++i ) {
-                  EBDataFrame df( *digiItr );
-		  if (!(i%3)  )  std::cout << "\n\t";
-		  std::cout << "sId: " << (i+1) << " "
-		       <<  df.sample(i) << "\t";
-		}       
-		std::cout << " " << std::endl;
+    if (verbosity > 0 && cryDigi && (mode == 1)) {
+      std::cout << "\n\n^^^^^^^^^^^^^^^^^^ [EcalDigiDumperModule]  digi cry collection size " << digis->size()
+                << std::endl;
+      std::cout << "                                  [EcalDigiDumperModule]  dumping first " << numChannel
+                << " crystals\n";
+      dumpCounter = 0;
+      for (EBDigiCollection::const_iterator digiItr = digis->begin(); digiItr != digis->end(); ++digiItr) {
+        {
+          if ((dumpCounter++) >= numChannel)
+            break;
+          if (!((EBDetId((*digiItr).id()).ism() == ieb_id) || (ieb_id == -1)))
+            continue;
 
-	  } 
-	}
+          std::cout << "ic-cry: " << EBDetId((*digiItr).id()).ic() << " i-phi: " << EBDetId((*digiItr).id()).iphi()
+                    << " j-eta: " << EBDetId((*digiItr).id()).ieta();
+
+          for (unsigned int i = 0; i < (*digiItr).size(); ++i) {
+            EBDataFrame df(*digiItr);
+            if (!(i % 3))
+              std::cout << "\n\t";
+            std::cout << "sId: " << (i + 1) << " " << df.sample(i) << "\t";
+          }
+          std::cout << " " << std::endl;
+        }
       }
-    
-    
-    if (verbosity>0 && cryDigi && (mode==2) )
-      {
-	std::cout << "\n\n^^^^^^^^^^^^^^^^^^ [EcalDigiDumperModule]  digi cry collection size " << digis->size() << std::endl;
-	for ( EBDigiCollection::const_iterator digiItr= digis->begin();digiItr != digis->end(); 
-	      ++digiItr ) {
-	  {
-	    int ic = EBDetId((*digiItr).id()).ic();
-	    int tt = EBDetId((*digiItr).id()).tower().iTT();
-	    
-	    if (!  ((EBDetId((*digiItr).id()).ism()==ieb_id) || (ieb_id==-1))  ) continue;
+    }
 
-	    std::vector<int>::iterator icIterCh;
-	    std::vector<int>::iterator icIterTt;
-	    icIterCh = find(listChannels.begin(), listChannels.end(), ic);
-	    icIterTt = find(listTowers.begin(), listTowers.end(), tt);
-	    if (icIterCh == listChannels.end()  
-		&& icIterTt == listTowers.end() ) { continue; }
+    if (verbosity > 0 && cryDigi && (mode == 2)) {
+      std::cout << "\n\n^^^^^^^^^^^^^^^^^^ [EcalDigiDumperModule]  digi cry collection size " << digis->size()
+                << std::endl;
+      for (EBDigiCollection::const_iterator digiItr = digis->begin(); digiItr != digis->end(); ++digiItr) {
+        {
+          int ic = EBDetId((*digiItr).id()).ic();
+          int tt = EBDetId((*digiItr).id()).tower().iTT();
 
-	    std::cout << "ic-cry: " 
-		      << ic << " i-phi: " 
-		      << EBDetId((*digiItr).id()).iphi() << " j-eta: " 
-		      << EBDetId((*digiItr).id()).ieta() << " tower: "
-		      << tt ;
+          if (!((EBDetId((*digiItr).id()).ism() == ieb_id) || (ieb_id == -1)))
+            continue;
 
-	    for ( unsigned int i=0; i< (*digiItr).size() ; ++i ) {
-              EBDataFrame df( *digiItr );
-	      if (!(i%3)  )  std::cout << "\n\t";
-	      std::cout << "sId: " << (i+1) << " " <<  df.sample(i) << "\t";
-	    }       
-	    std::cout << " " << std::endl;
-	  } 
-	}
+          std::vector<int>::iterator icIterCh;
+          std::vector<int>::iterator icIterTt;
+          icIterCh = find(listChannels.begin(), listChannels.end(), ic);
+          icIterTt = find(listTowers.begin(), listTowers.end(), tt);
+          if (icIterCh == listChannels.end() && icIterTt == listTowers.end()) {
+            continue;
+          }
+
+          std::cout << "ic-cry: " << ic << " i-phi: " << EBDetId((*digiItr).id()).iphi()
+                    << " j-eta: " << EBDetId((*digiItr).id()).ieta() << " tower: " << tt;
+
+          for (unsigned int i = 0; i < (*digiItr).size(); ++i) {
+            EBDataFrame df(*digiItr);
+            if (!(i % 3))
+              std::cout << "\n\t";
+            std::cout << "sId: " << (i + 1) << " " << df.sample(i) << "\t";
+          }
+          std::cout << " " << std::endl;
+        }
       }
-    
-    
+    }
 
+    if (verbosity > 0 && pnDigi && (mode == 1)) {
+      std::cout << "\n\n^^^^^^^^^^^^^^^^^^ EcalDigiDumperModule  digi PN collection.  Size: " << PNs->size()
+                << std::endl;
+      std::cout << "                                  [EcalDigiDumperModule]  dumping first " << numPN << " PNs ";
+      dumpCounter = 0;
+      for (EcalPnDiodeDigiCollection::const_iterator pnItr = PNs->begin(); pnItr != PNs->end(); ++pnItr) {
+        if ((dumpCounter++) >= numPN)
+          break;
+        if (!((EcalPnDiodeDetId((*pnItr).id()).iDCCId() == ieb_id) || (ieb_id == -1)))
+          continue;
 
-    if (verbosity>0 && pnDigi && (mode==1) )
-      {
-	std::cout << "\n\n^^^^^^^^^^^^^^^^^^ EcalDigiDumperModule  digi PN collection.  Size: " << PNs->size() << std::endl;
-	std::cout << "                                  [EcalDigiDumperModule]  dumping first " << numPN << " PNs ";
-	dumpCounter=0;
-	for ( EcalPnDiodeDigiCollection::const_iterator pnItr = PNs->begin(); pnItr != PNs->end(); ++pnItr ) {
-	  
-	  if( (dumpCounter++) >= numPN) break;
-	  if (! ((EcalPnDiodeDetId((*pnItr).id()).iDCCId()==ieb_id) || (ieb_id==-1))  ) continue;
-	  
-	  std::cout << "\nPN num: " << (*pnItr).id().iPnId();
-	  
-	  for ( int samId=0; samId < (*pnItr).size() ; samId++ ) {
-	    if (!(samId%3)  )  std::cout << "\n\t";
-	    std::cout <<  "sId: " << (samId+1) << " "
-		 << (*pnItr).sample(samId) 
-		 << "\t";
-	  }//  PN samples
-	  
-	}// PNs
-      }
-    
-    
+        std::cout << "\nPN num: " << (*pnItr).id().iPnId();
 
-    if (verbosity>0 && pnDigi && (mode==2) )
-      {
-	std::cout << "\n\n^^^^^^^^^^^^^^^^^^ EcalDigiDumperModule  digi PN collection.  Size: " << PNs->size() << std::endl;
+        for (int samId = 0; samId < (*pnItr).size(); samId++) {
+          if (!(samId % 3))
+            std::cout << "\n\t";
+          std::cout << "sId: " << (samId + 1) << " " << (*pnItr).sample(samId) << "\t";
+        }  //  PN samples
 
-	for ( EcalPnDiodeDigiCollection::const_iterator pnItr = PNs->begin(); pnItr != PNs->end(); ++pnItr ) {
-	  
-	  int pnNum = (*pnItr).id().iPnId();
+      }  // PNs
+    }
 
-	  if (! ((EcalPnDiodeDetId((*pnItr).id()).iDCCId()==ieb_id) || (ieb_id==-1))  ) continue;
+    if (verbosity > 0 && pnDigi && (mode == 2)) {
+      std::cout << "\n\n^^^^^^^^^^^^^^^^^^ EcalDigiDumperModule  digi PN collection.  Size: " << PNs->size()
+                << std::endl;
 
-	  std::vector<int>::iterator pnIter;
-	  pnIter = find(listPns.begin(), listPns.end(), pnNum);
-	  if (pnIter == listPns.end()) { continue; }
-	  
-	  std::cout << "\nPN num: " << (*pnItr).id().iPnId();
-	  for ( int samId=0; samId < (*pnItr).size() ; samId++ ) {
-	    if (!(samId%3)  )  std::cout << "\n\t";
-	    std::cout <<  "sId: " << (samId+1) << " "
-		 << (*pnItr).sample(samId) 
-		 << "\t";
-	  }//  PN samples
-	  
-	}// PNs
-      }
-    
-    
+      for (EcalPnDiodeDigiCollection::const_iterator pnItr = PNs->begin(); pnItr != PNs->end(); ++pnItr) {
+        int pnNum = (*pnItr).id().iPnId();
 
-//     // retrieving crystal TP from the Event
-//     edm::Handle<EcalTrigPrimDigiCollection>  primitives;
-//     e.getByLabel("ecalEBunpacker", primitives);
-    
-//     if (verbosity>0 && tpDigi)
-//       {
-// 	std::cout << "\n\n^^^^^^^^^^^^^^^^^^ EcalDigiDumperModule  digi TP collection.  Size: " << primitives->size() << std::endl;
-// 	std::cout << "                                  [EcalDigiDumperModule]  dumping primitives "  << std::endl;
-// 	for ( EcalTrigPrimDigiCollection::const_iterator TPtr = primitives->begin();
-// 	      ( TPtr != primitives->end()  && (TPtr-primitives->begin())<4 ); 
-// 		++TPtr ) {
+        if (!((EcalPnDiodeDetId((*pnItr).id()).iDCCId() == ieb_id) || (ieb_id == -1)))
+          continue;
 
-// 	  if (!  ((EcalTrigTowerDetId((*TPtr).id()).iDCC()==ieb_id) || (ieb_id==-1))   ) continue;
+        std::vector<int>::iterator pnIter;
+        pnIter = find(listPns.begin(), listPns.end(), pnNum);
+        if (pnIter == listPns.end()) {
+          continue;
+        }
 
-// 	  std::cout << "[EcalDigiDumperModule] tower: " << ( (TPtr-primitives->begin()) +1) 
-// 	       << "\n" << (*TPtr) << std::endl;
-// 	}
-//       }
+        std::cout << "\nPN num: " << (*pnItr).id().iPnId();
+        for (int samId = 0; samId < (*pnItr).size(); samId++) {
+          if (!(samId % 3))
+            std::cout << "\n\t";
+          std::cout << "sId: " << (samId + 1) << " " << (*pnItr).sample(samId) << "\t";
+        }  //  PN samples
 
+      }  // PNs
+    }
 
- 
-  } // produce
+    //     // retrieving crystal TP from the Event
+    //     edm::Handle<EcalTrigPrimDigiCollection>  primitives;
+    //     e.getByLabel("ecalEBunpacker", primitives);
 
-};// class EcalDigiDumperModule
+    //     if (verbosity>0 && tpDigi)
+    //       {
+    // 	std::cout << "\n\n^^^^^^^^^^^^^^^^^^ EcalDigiDumperModule  digi TP collection.  Size: " << primitives->size() << std::endl;
+    // 	std::cout << "                                  [EcalDigiDumperModule]  dumping primitives "  << std::endl;
+    // 	for ( EcalTrigPrimDigiCollection::const_iterator TPtr = primitives->begin();
+    // 	      ( TPtr != primitives->end()  && (TPtr-primitives->begin())<4 );
+    // 		++TPtr ) {
+
+    // 	  if (!  ((EcalTrigTowerDetId((*TPtr).id()).iDCC()==ieb_id) || (ieb_id==-1))   ) continue;
+
+    // 	  std::cout << "[EcalDigiDumperModule] tower: " << ( (TPtr-primitives->begin()) +1)
+    // 	       << "\n" << (*TPtr) << std::endl;
+    // 	}
+    //       }
+
+  }  // produce
+
+};  // class EcalDigiDumperModule
 
 DEFINE_FWK_MODULE(EcalDigiDumperModule);

--- a/EventFilter/EcalTBRawToDigi/test/stubs/EcalGraphDumperModule.cc
+++ b/EventFilter/EcalTBRawToDigi/test/stubs/EcalGraphDumperModule.cc
@@ -21,27 +21,21 @@
 #include "TFile.h"
 #include "TGraph.h"
 
-
-
-class EcalGraphDumperModule: public edm::EDAnalyzer{
-  
+class EcalGraphDumperModule : public edm::EDAnalyzer {
 public:
-
-  EcalGraphDumperModule(const edm::ParameterSet& ps);   
+  EcalGraphDumperModule(const edm::ParameterSet& ps);
   ~EcalGraphDumperModule();
-    
+
   std::string intToString(int num);
-  
-  void analyze( const edm::Event & e, const  edm::EventSetup& c);
-  
-  
+
+  void analyze(const edm::Event& e, const edm::EventSetup& c);
+
 protected:
   int verbosity;
   int eventCounter;
-   
+
   int ieb_id;
   int first_ic;
-  
 
   bool inputIsOk;
 
@@ -55,158 +49,136 @@ protected:
 
   int abscissa[10];
   int ordinate[10];
-  
+
   std::vector<TGraph> graphs;
-  
-  TFile * root_file;
-  
+
+  TFile* root_file;
 };
 
+EcalGraphDumperModule::EcalGraphDumperModule(const edm::ParameterSet& ps) {
+  fileName = ps.getUntrackedParameter<std::string>("fileName", std::string("toto"));
 
+  ieb_id = ps.getUntrackedParameter<int>("ieb_id", 1);
+  first_ic = 0;
 
+  listChannels = ps.getUntrackedParameter<std::vector<int> >("listChannels", std::vector<int>());
 
-
-
-EcalGraphDumperModule::EcalGraphDumperModule(const edm::ParameterSet& ps){  
-
-  fileName         = ps.getUntrackedParameter<std::string >("fileName", std::string("toto") );
-
-  ieb_id             = ps.getUntrackedParameter< int >("ieb_id", 1);
-  first_ic            = 0;
-
-  listChannels   = ps.getUntrackedParameter<std::vector<int> >("listChannels", std::vector<int>());
-
-  side                = ps.getUntrackedParameter< int >("side", 3);
+  side = ps.getUntrackedParameter<int>("side", 3);
 
   // consistency checks checks
-  inputIsOk       = true;
-    
-  std::vector<int>::iterator intIter;
-    
-  for (intIter = listChannels.begin(); intIter != listChannels.end(); intIter++)
-    {  
-      if ( ((*intIter) < 1) ||  (1700 < (*intIter)) )       {  
-	std::cout << "[EcalGraphDumperModule] ic value: " << (*intIter) << " found in listChannels. "
-		  << " Valid range is 1-1700. Returning." << std::endl;
-	inputIsOk = false;
-	return;
-      }
-      // initializing with the first channel of the list
-      if (!   first_ic )   first_ic = (*intIter);
-    }
+  inputIsOk = true;
 
-  
+  std::vector<int>::iterator intIter;
+
+  for (intIter = listChannels.begin(); intIter != listChannels.end(); intIter++) {
+    if (((*intIter) < 1) || (1700 < (*intIter))) {
+      std::cout << "[EcalGraphDumperModule] ic value: " << (*intIter) << " found in listChannels. "
+                << " Valid range is 1-1700. Returning." << std::endl;
+      inputIsOk = false;
+      return;
+    }
+    // initializing with the first channel of the list
+    if (!first_ic)
+      first_ic = (*intIter);
+  }
+
   // setting the abcissa array once for all
-  for (int i=0; i<10; i++)        abscissa[i] = i;
-  
+  for (int i = 0; i < 10; i++)
+    abscissa[i] = i;
+
   // local event counter (in general different from LV1)
-  eventCounter =0;
+  eventCounter = 0;
 }
 
-
-
-EcalGraphDumperModule::~EcalGraphDumperModule(){  
-
-  
-  fileName += ( std::string("_iEB")  + intToString(ieb_id) ) ;
-  fileName +=  ( std::string("_ic")    + intToString(first_ic) ); 
+EcalGraphDumperModule::~EcalGraphDumperModule() {
+  fileName += (std::string("_iEB") + intToString(ieb_id));
+  fileName += (std::string("_ic") + intToString(first_ic));
   fileName += ".graph.root";
 
-  root_file = new TFile( fileName.c_str() , "RECREATE" );
+  root_file = new TFile(fileName.c_str(), "RECREATE");
   std::vector<TGraph>::iterator gr_it;
-  for ( gr_it = graphs.begin(); gr_it !=  graphs.end(); gr_it++ )      (*gr_it).Write();
+  for (gr_it = graphs.begin(); gr_it != graphs.end(); gr_it++)
+    (*gr_it).Write();
   root_file->Close();
-  
 }
 
-
-std::string EcalGraphDumperModule::intToString(int num)
-{
+std::string EcalGraphDumperModule::intToString(int num) {
   //
   // outputs the number into the string stream and then flushes
   // the buffer (makes sure the output is put into the stream)
   //
-  std::ostringstream myStream; //creates an ostringstream object
+  std::ostringstream myStream;  //creates an ostringstream object
   myStream << num << std::flush;
 
-  return(myStream.str()); //returns the string form of the stringstream object
+  return (myStream.str());  //returns the string form of the stringstream object
 }
 
-
-
-
-void EcalGraphDumperModule::analyze( const edm::Event & e, const  edm::EventSetup& c){
-
+void EcalGraphDumperModule::analyze(const edm::Event& e, const edm::EventSetup& c) {
   eventCounter++;
-  if (!inputIsOk) return;
+  if (!inputIsOk)
+    return;
 
   // retrieving crystal data from Event
-  edm::Handle<EBDigiCollection>  digis;
+  edm::Handle<EBDigiCollection> digis;
   e.getByLabel("ecalEBunpacker", "ebDigis", digis);
 
   // retrieving crystal PN diodes from Event
-  edm::Handle<EcalPnDiodeDigiCollection>  PNs;
+  edm::Handle<EcalPnDiodeDigiCollection> PNs;
   e.getByLabel("ecalEBunpacker", PNs);
-
 
   // getting the list of all the channels which will be dumped on TGraph
   std::vector<int>::iterator ch_it;
-  for ( ch_it = listChannels.begin();  ch_it != listChannels.end() ; ch_it++  )
-    {
-      int ic    = (*ch_it);
-      int ieta = (ic-1)/20   +1;
-      int iphi = (ic-1)%20 +1;
-      
-      int hside = (side/2);
-      
-      for (int u = (-hside) ; u<=hside; u++){
-	for (int v = (-hside) ; v<=hside; v++){
-	  
-	  int ieta_c = ieta + u;
-	  int iphi_c = iphi + v;
-	  
-	  if (ieta_c < 1 || 85 < ieta_c) continue;
-	  if (iphi_c < 1 || 20 < iphi_c)  continue;
-	  
-	  int ic_c = (ieta_c-1) *20 + iphi_c;
-	  listAllChannels.push_back ( ic_c ) ;
-	  
-	}
+  for (ch_it = listChannels.begin(); ch_it != listChannels.end(); ch_it++) {
+    int ic = (*ch_it);
+    int ieta = (ic - 1) / 20 + 1;
+    int iphi = (ic - 1) % 20 + 1;
+
+    int hside = (side / 2);
+
+    for (int u = (-hside); u <= hside; u++) {
+      for (int v = (-hside); v <= hside; v++) {
+        int ieta_c = ieta + u;
+        int iphi_c = iphi + v;
+
+        if (ieta_c < 1 || 85 < ieta_c)
+          continue;
+        if (iphi_c < 1 || 20 < iphi_c)
+          continue;
+
+        int ic_c = (ieta_c - 1) * 20 + iphi_c;
+        listAllChannels.push_back(ic_c);
       }
     }
-  
+  }
 
-  for ( EBDigiCollection::const_iterator digiItr= digis->begin();digiItr != digis->end(); 
-	++digiItr ) {
+  for (EBDigiCollection::const_iterator digiItr = digis->begin(); digiItr != digis->end(); ++digiItr) {
     {
-	    
-      int ic     = EBDetId((*digiItr).id()).ic();
-      int ieb    = EBDetId((*digiItr).id()).ism();
-      if (ieb != ieb_id) return;
-      
+      int ic = EBDetId((*digiItr).id()).ic();
+      int ieb = EBDetId((*digiItr).id()).ism();
+      if (ieb != ieb_id)
+        return;
+
       // selecting desired channels only
       std::vector<int>::iterator icIter;
-      icIter     = find( listAllChannels.begin() , listAllChannels.end() , ic);
-      if (icIter == listAllChannels.end()) { continue; }
-	    
-
-      for (int i=0; i< ((int)(*digiItr).size()) ; ++i ) {
-        EBDataFrame df( *digiItr );
-	ordinate[i] = df.sample(i).adc();
+      icIter = find(listAllChannels.begin(), listAllChannels.end(), ic);
+      if (icIter == listAllChannels.end()) {
+        continue;
       }
-	    
-      TGraph oneGraph(10, abscissa,ordinate);
+
+      for (int i = 0; i < ((int)(*digiItr).size()); ++i) {
+        EBDataFrame df(*digiItr);
+        ordinate[i] = df.sample(i).adc();
+      }
+
+      TGraph oneGraph(10, abscissa, ordinate);
       std::string title;
-      title = "Graph_ev" + intToString( eventCounter ) + "_ic" + intToString( ic );
+      title = "Graph_ev" + intToString(eventCounter) + "_ic" + intToString(ic);
       oneGraph.SetTitle(title.c_str());
       oneGraph.SetName(title.c_str());
       graphs.push_back(oneGraph);
 
-    }// loop in crystals
+    }  // loop in crystals
   }
-
-    
 }
-
 
 DEFINE_FWK_MODULE(EcalGraphDumperModule);

--- a/EventFilter/EcalTBRawToDigi/test/stubs/EcalHexDumperModule.cc
+++ b/EventFilter/EcalTBRawToDigi/test/stubs/EcalHexDumperModule.cc
@@ -4,7 +4,6 @@
  *
  */
 
-
 #include <FWCore/Framework/interface/EDAnalyzer.h>
 #include <DataFormats/Common/interface/Handle.h>
 #include <FWCore/Framework/interface/Event.h>
@@ -22,103 +21,86 @@
 #include <stdio.h>
 #include <fstream>
 
-#include <iomanip> 
+#include <iomanip>
 
+class EcalHexDumperModule : public edm::EDAnalyzer {
+public:
+  EcalHexDumperModule(const edm::ParameterSet& ps)
+      : fedRawDataCollectionTag_(ps.getParameter<edm::InputTag>("fedRawDataCollectionTag")) {
+    verbosity_ = ps.getUntrackedParameter<int>("verbosity", 1);
 
-class EcalHexDumperModule: public edm::EDAnalyzer{
-  
- public:
+    beg_fed_id_ = ps.getUntrackedParameter<int>("beg_fed_id", 0);
+    end_fed_id_ = ps.getUntrackedParameter<int>("end_fed_id", 654);
 
-  EcalHexDumperModule(const edm::ParameterSet& ps) :
-    fedRawDataCollectionTag_(ps.getParameter<edm::InputTag>("fedRawDataCollectionTag")) {  
-    verbosity_= ps.getUntrackedParameter<int>("verbosity",1);
-    
-    beg_fed_id_= ps.getUntrackedParameter<int>("beg_fed_id",0);
-    end_fed_id_= ps.getUntrackedParameter<int>("end_fed_id",654);
+    first_event_ = ps.getUntrackedParameter<int>("first_event", 1);
+    last_event_ = ps.getUntrackedParameter<int>("last_event", 9999999);
+    event_ = 0;
 
-
-    first_event_ = ps.getUntrackedParameter<int>("first_event",1);
-    last_event_  = ps.getUntrackedParameter<int>("last_event",9999999);
-    event_ =0;
-
-    writeDcc_ =ps.getUntrackedParameter<bool>("writeDCC",false);
-    filename_  =ps.getUntrackedParameter<std::string>("filename","dump.bin");
-
+    writeDcc_ = ps.getUntrackedParameter<bool>("writeDCC", false);
+    filename_ = ps.getUntrackedParameter<std::string>("filename", "dump.bin");
   }
 
-  
- protected:
-  int      verbosity_;
-  bool     writeDcc_;
-  int      beg_fed_id_;
-  int      end_fed_id_;
-  int      first_event_;
-  int      last_event_;
-  std::string   filename_;
-  int      event_;
+protected:
+  int verbosity_;
+  bool writeDcc_;
+  int beg_fed_id_;
+  int end_fed_id_;
+  int first_event_;
+  int last_event_;
+  std::string filename_;
+  int event_;
 
-  void analyze( const edm::Event & e, const  edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c);
 
- private:
+private:
   edm::InputTag fedRawDataCollectionTag_;
 };
 
-
-
-void EcalHexDumperModule::analyze( const edm::Event & e, const  edm::EventSetup& c){
-  
+void EcalHexDumperModule::analyze(const edm::Event& e, const edm::EventSetup& c) {
   event_++;
-  if (event_ < first_event_ || last_event_ < event_) return;
-  
+  if (event_ < first_event_ || last_event_ < event_)
+    return;
 
   edm::Handle<FEDRawDataCollection> rawdata;
-  e.getByLabel(fedRawDataCollectionTag_, rawdata);  
+  e.getByLabel(fedRawDataCollectionTag_, rawdata);
 
-  std::ofstream dumpFile (filename_.c_str(),std::ios::app );
-  
-  for (int id= 0; id<=FEDNumbering::MAXFEDID; ++id){ 
-    
-    if (id < beg_fed_id_ || end_fed_id_ < id) continue;
+  std::ofstream dumpFile(filename_.c_str(), std::ios::app);
+
+  for (int id = 0; id <= FEDNumbering::MAXFEDID; ++id) {
+    if (id < beg_fed_id_ || end_fed_id_ < id)
+      continue;
 
     const FEDRawData& data = rawdata->FEDData(id);
-    
-    if (data.size()>4){      
-      
-      std::cout << "\n\n\n[EcalHexDumperModule] Event: " 
-		<< std::dec << event_ 
-		<< " fed_id: " << id 
-		<< " size_fed: " << data.size() << "\n"<< std::endl;
-      
-      if ( ( data.size() %16 ) !=0)
-	{
-	  std::cout << "***********************************************" << std::endl;
-	  std::cout<< "Fed size in bits not multiple of 64, strange." << std::endl;
-	  std::cout << "***********************************************" << std::endl;
-	}
-      
-      
+
+    if (data.size() > 4) {
+      std::cout << "\n\n\n[EcalHexDumperModule] Event: " << std::dec << event_ << " fed_id: " << id
+                << " size_fed: " << data.size() << "\n"
+                << std::endl;
+
+      if ((data.size() % 16) != 0) {
+        std::cout << "***********************************************" << std::endl;
+        std::cout << "Fed size in bits not multiple of 64, strange." << std::endl;
+        std::cout << "***********************************************" << std::endl;
+      }
+
       int length = data.size();
-      const unsigned long               * pData     = ( reinterpret_cast<unsigned long*>(const_cast<unsigned char*> ( data.data())));
+      const unsigned long* pData = (reinterpret_cast<unsigned long*>(const_cast<unsigned char*>(data.data())));
       std::cout << std::setfill('0');
-      for (int words=0; words < length/4; (words+=2)  )
-	{
-	  std::cout << std::setw(8)   << std::hex << pData[words+1] << " ";
-	  std::cout << std::setw(8)   << std::hex << pData[words] << std::endl;
-	}
+      for (int words = 0; words < length / 4; (words += 2)) {
+        std::cout << std::setw(8) << std::hex << pData[words + 1] << " ";
+        std::cout << std::setw(8) << std::hex << pData[words] << std::endl;
+      }
 
       std::cout << "\n";
 
-
-      if (beg_fed_id_ <= id && id <= end_fed_id_ && writeDcc_)
-	{
-	  dumpFile.write( reinterpret_cast <const char *> (pData), length);
-	}
+      if (beg_fed_id_ <= id && id <= end_fed_id_ && writeDcc_) {
+        dumpFile.write(reinterpret_cast<const char*>(pData), length);
+      }
     }
-    
   }
-  dumpFile.close();    
-  if (! writeDcc_) remove(filename_.c_str()); 
+  dumpFile.close();
+  if (!writeDcc_)
+    remove(filename_.c_str());
 }
-
 
 DEFINE_FWK_MODULE(EcalHexDumperModule);

--- a/EventFilter/EcalTBRawToDigi/test/stubs/EcalMatacqHist.cc
+++ b/EventFilter/EcalTBRawToDigi/test/stubs/EcalMatacqHist.cc
@@ -7,115 +7,96 @@
 #include <DataFormats/EcalDigi/interface/EcalDigiCollections.h>
 #include <FWCore/Utilities/interface/Exception.h>
 
-
-EcalMatacqHist::EcalMatacqHist(const edm::ParameterSet& ps):
-  iEvent(0){
-  outFileName= ps.getUntrackedParameter<std::string>("outputRootFile", "matacqHist.root");
+EcalMatacqHist::EcalMatacqHist(const edm::ParameterSet& ps) : iEvent(0) {
+  outFileName = ps.getUntrackedParameter<std::string>("outputRootFile", "matacqHist.root");
   nTimePlots = ps.getUntrackedParameter<int>("nTimePlots", 10);
-  firstTimePlotEvent = ps.getUntrackedParameter<int>("firstTimePlotEvent",
-						     1);
+  firstTimePlotEvent = ps.getUntrackedParameter<int>("firstTimePlotEvent", 1);
   hTTrigMin = ps.getUntrackedParameter<double>("hTTrigMin", 0.);
   hTTrigMax = ps.getUntrackedParameter<double>("hTTrigMax", 2000.);
   TDirectory* dsave = gDirectory;
-  outFile = std::unique_ptr<TFile> (new TFile(outFileName.c_str(), "RECREATE"));
-  if(outFile->IsZombie()){
-    std::cout << "EcalMatacqHist: Failed to create file " << outFileName
-	 << " No histogram will be created.\n";
+  outFile = std::unique_ptr<TFile>(new TFile(outFileName.c_str(), "RECREATE"));
+  if (outFile->IsZombie()) {
+    std::cout << "EcalMatacqHist: Failed to create file " << outFileName << " No histogram will be created.\n";
   }
 
-  hTTrig =  new TH1D("tTrig", "Trigger time in ns",
-		      100,
-		      hTTrigMin,
-		      hTTrigMax);
+  hTTrig = new TH1D("tTrig", "Trigger time in ns", 100, hTTrigMin, hTTrigMax);
   dsave->cd();
 }
 
-EcalMatacqHist::~EcalMatacqHist(){
-  if(!outFile->IsZombie()){
+EcalMatacqHist::~EcalMatacqHist() {
+  if (!outFile->IsZombie()) {
     TDirectory* dsave = gDirectory;
     outFile->cd();
-    for(std::vector<TProfile>::iterator it = profiles.begin();
-       it != profiles.end();
-       ++it){
+    for (std::vector<TProfile>::iterator it = profiles.begin(); it != profiles.end(); ++it) {
       it->Write();
     }
-    if(hTTrig!=0) hTTrig->Write();
+    if (hTTrig != 0)
+      hTTrig->Write();
     dsave->cd();
   }
 }
 
-void
-EcalMatacqHist:: analyze( const edm::Event & e, const  edm::EventSetup& c){
+void EcalMatacqHist::analyze(const edm::Event& e, const edm::EventSetup& c) {
   ++iEvent;
-  if(outFile->IsZombie()) return;
+  if (outFile->IsZombie())
+    return;
   TDirectory* dsave = gDirectory;
   outFile->cd();
   // retrieving MATACQ digis:
   edm::Handle<EcalMatacqDigiCollection> digiColl;
   e.getByLabel("ecalEBunpacker", digiColl);
 
-  unsigned iCh=0;
-  for(EcalMatacqDigiCollection::const_iterator it = digiColl->begin();
-      it!=digiColl->end(); ++it, ++iCh){
-   
+  unsigned iCh = 0;
+  for (EcalMatacqDigiCollection::const_iterator it = digiColl->begin(); it != digiColl->end(); ++it, ++iCh) {
     const EcalMatacqDigi& digis = *it;
 
-    if(digis.size()==0) continue;
-    
-    if(iEvent >= firstTimePlotEvent
-       && iEvent < firstTimePlotEvent + nTimePlots){
+    if (digis.size() == 0)
+      continue;
+
+    if (iEvent >= firstTimePlotEvent && iEvent < firstTimePlotEvent + nTimePlots) {
       int nSamples = digis.size();
       std::stringstream title;
       std::stringstream name;
-      name << "matacq" << digis.chId() << "_"
-	   << std::setfill('0') << std::setw(4) << iEvent;
-      title << "Matacq channel " <<  digis.chId() << ", event " << iEvent
-	    << ", Ts = " << digis.ts()*1.e9 << "ns";
+      name << "matacq" << digis.chId() << "_" << std::setfill('0') << std::setw(4) << iEvent;
+      title << "Matacq channel " << digis.chId() << ", event " << iEvent << ", Ts = " << digis.ts() * 1.e9 << "ns";
       float tTrig_s = digis.tTrig();
-      if(tTrig_s<999.){
-	title << ", t_trig = " << tTrig_s * 1.e9 << "ns";
+      if (tTrig_s < 999.) {
+        title << ", t_trig = " << tTrig_s * 1.e9 << "ns";
       }
-      TH1D h1(name.str().c_str(), title.str().c_str(),
-	      nSamples, -.5, -.5+nSamples);
-      for(int i=0; i<digis.size(); ++i){
-	h1.Fill(i, digis.adcCount(i));
+      TH1D h1(name.str().c_str(), title.str().c_str(), nSamples, -.5, -.5 + nSamples);
+      for (int i = 0; i < digis.size(); ++i) {
+        h1.Fill(i, digis.adcCount(i));
       }
       h1.Write();
     }
-    
+
     //profile
     //init:
-    if(iCh>=profiles.size()){ //profile not yet allocated for this matacq ch.
+    if (iCh >= profiles.size()) {  //profile not yet allocated for this matacq ch.
       std::stringstream profTitle;
-      profTitle << "Matacq channel " <<  digis.chId()
-		<< " profile";
+      profTitle << "Matacq channel " << digis.chId() << " profile";
       std::stringstream profileName;
       profileName << "matacq" << digis.chId();
-      profiles.push_back(TProfile(profileName.str().c_str(),
-				  profTitle.str().c_str(),
-				  digis.size(),
-				  -.5,
-				  -.5+digis.size(),
-				  "I"));
-      profiles.back().SetDirectory(0);//mem. management done by std::vector
+      profiles.push_back(
+          TProfile(profileName.str().c_str(), profTitle.str().c_str(), digis.size(), -.5, -.5 + digis.size(), "I"));
+      profiles.back().SetDirectory(0);  //mem. management done by std::vector
       profChId.push_back(digis.chId());
     }
-    
-    for(int i=0; i<digis.size(); ++i){
-      if(profChId[iCh]==digis.chId()){
-	profiles[iCh].Fill(i, digis.adcCount(i));
-      } else{
-	throw cms::Exception("EcalMatacqHist",
-			     "Order or number of matacq channels is not the "
-			     "same in the different event. Such a "
-			     "configuration is not supported by "
-			     "EcalMatacqHist");
+
+    for (int i = 0; i < digis.size(); ++i) {
+      if (profChId[iCh] == digis.chId()) {
+        profiles[iCh].Fill(i, digis.adcCount(i));
+      } else {
+        throw cms::Exception("EcalMatacqHist",
+                             "Order or number of matacq channels is not the "
+                             "same in the different event. Such a "
+                             "configuration is not supported by "
+                             "EcalMatacqHist");
       }
-      hTTrig->Fill(digis.tTrig()*1.e9);
+      hTTrig->Fill(digis.tTrig() * 1.e9);
     }
   }
   dsave->cd();
-} // analyze
-
+}  // analyze
 
 DEFINE_FWK_MODULE(EcalMatacqHist);

--- a/EventFilter/EcalTBRawToDigi/test/stubs/EcalMatacqHist.h
+++ b/EventFilter/EcalTBRawToDigi/test/stubs/EcalMatacqHist.h
@@ -24,16 +24,14 @@
 class TProfile;
 class TH1D;
 
-class EcalMatacqHist: public edm::EDAnalyzer{  
- public:
-  EcalMatacqHist(const edm::ParameterSet& ps);  
+class EcalMatacqHist : public edm::EDAnalyzer {
+public:
+  EcalMatacqHist(const edm::ParameterSet& ps);
 
   virtual ~EcalMatacqHist();
-  
- protected:
-  void
-  analyze( const edm::Event & e, const  edm::EventSetup& c);
 
+protected:
+  void analyze(const edm::Event& e, const edm::EventSetup& c);
 
 private:
   std::string outFileName;
@@ -48,5 +46,3 @@ private:
   std::vector<int> profChId;
   TH1D* hTTrig;
 };
-
-

--- a/EventFilter/EcalTBRawToDigi/test/stubs/EcalPnGraphDumperModule.cc
+++ b/EventFilter/EcalTBRawToDigi/test/stubs/EcalPnGraphDumperModule.cc
@@ -24,27 +24,21 @@
 #include "TFile.h"
 #include "TGraph.h"
 
-
-
-class EcalPnGraphDumperModule: public edm::EDAnalyzer{
-  
+class EcalPnGraphDumperModule : public edm::EDAnalyzer {
 public:
-
-  EcalPnGraphDumperModule(const edm::ParameterSet& ps);   
+  EcalPnGraphDumperModule(const edm::ParameterSet& ps);
   ~EcalPnGraphDumperModule();
-    
+
   std::string intToString(int num);
-  
-  void analyze( const edm::Event & e, const  edm::EventSetup& c);
-  
-  
+
+  void analyze(const edm::Event& e, const edm::EventSetup& c);
+
 protected:
   int verbosity;
   int eventCounter;
-   
+
   int ieb_id;
   int first_Pn;
-  
 
   bool inputIsOk;
 
@@ -59,143 +53,124 @@ protected:
 
   int abscissa[50];
   int ordinate[50];
-  
+
   std::vector<TGraph> graphs;
-  
-  TFile * root_file;
-  
+
+  TFile* root_file;
 };
 
+EcalPnGraphDumperModule::EcalPnGraphDumperModule(const edm::ParameterSet& ps) {
+  fileName = ps.getUntrackedParameter<std::string>("fileName", std::string("toto"));
 
+  ieb_id = ps.getUntrackedParameter<int>("ieb_id", 1);
+  first_Pn = 0;
 
+  listPns = ps.getUntrackedParameter<std::vector<int> >("listPns", std::vector<int>());
 
-
-
-EcalPnGraphDumperModule::EcalPnGraphDumperModule(const edm::ParameterSet& ps){  
-
-  fileName         = ps.getUntrackedParameter<std::string >("fileName", std::string("toto") );
-
-  ieb_id             = ps.getUntrackedParameter< int >("ieb_id", 1);
-  first_Pn            = 0;
-
-  listPns          = ps.getUntrackedParameter<std::vector<int> >("listPns", std::vector<int>());
-
-  numPn                = ps.getUntrackedParameter< int >("numPn", 9);
+  numPn = ps.getUntrackedParameter<int>("numPn", 9);
 
   // consistency checks checks
-  inputIsOk       = true;
-    
+  inputIsOk = true;
+
   std::vector<int>::iterator intIter;
 
-  for (intIter = listPns.begin(); intIter != listPns.end(); intIter++)
-      {  
-	if ( ((*intIter) < 1) ||  (10 < (*intIter)) )       {  
-	  std::cout << "[EcalPnGraphDumperModule] pn number : " << (*intIter) << " found in listPns. "
-	       << " Valid range is 1-10. Returning." << std::endl;
-	  inputIsOk = false;
-	  return;
-	}
-      if (!   first_Pn )   first_Pn = (*intIter);	
-      }
-  
+  for (intIter = listPns.begin(); intIter != listPns.end(); intIter++) {
+    if (((*intIter) < 1) || (10 < (*intIter))) {
+      std::cout << "[EcalPnGraphDumperModule] pn number : " << (*intIter) << " found in listPns. "
+                << " Valid range is 1-10. Returning." << std::endl;
+      inputIsOk = false;
+      return;
+    }
+    if (!first_Pn)
+      first_Pn = (*intIter);
+  }
+
   // setting the abcissa array once for all
-  for (int i=0; i<50; i++)        abscissa[i] = i;
-  
+  for (int i = 0; i < 50; i++)
+    abscissa[i] = i;
+
   // local event counter (in general different from LV1)
-  eventCounter =0;
+  eventCounter = 0;
 }
 
-
-
-EcalPnGraphDumperModule::~EcalPnGraphDumperModule(){  
-
-  
-  fileName += ( std::string("_iEB")  + intToString(ieb_id) ) ;
-  fileName +=  ( std::string("_Pn")    + intToString(first_Pn) ); 
+EcalPnGraphDumperModule::~EcalPnGraphDumperModule() {
+  fileName += (std::string("_iEB") + intToString(ieb_id));
+  fileName += (std::string("_Pn") + intToString(first_Pn));
   fileName += ".graph.root";
 
-  root_file = new TFile( fileName.c_str() , "RECREATE" );
+  root_file = new TFile(fileName.c_str(), "RECREATE");
   std::vector<TGraph>::iterator gr_it;
-  for ( gr_it = graphs.begin(); gr_it !=  graphs.end(); gr_it++ )      (*gr_it).Write();
+  for (gr_it = graphs.begin(); gr_it != graphs.end(); gr_it++)
+    (*gr_it).Write();
   root_file->Close();
-  
 }
 
-
-std::string EcalPnGraphDumperModule::intToString(int num)
-{
+std::string EcalPnGraphDumperModule::intToString(int num) {
   //
   // outputs the number into the string stream and then flushes
   // the buffer (makes sure the output is put into the stream)
   //
-  std::ostringstream myStream; //creates an ostringstream object
+  std::ostringstream myStream;  //creates an ostringstream object
   myStream << num << std::flush;
 
-  return(myStream.str()); //returns the string form of the stringstream object
+  return (myStream.str());  //returns the string form of the stringstream object
 }
 
-
-
-
-void EcalPnGraphDumperModule::analyze( const edm::Event & e, const  edm::EventSetup& c){
-
+void EcalPnGraphDumperModule::analyze(const edm::Event& e, const edm::EventSetup& c) {
   eventCounter++;
-  if (!inputIsOk) return;
+  if (!inputIsOk)
+    return;
 
   // retrieving crystal PN diodes from Event
-  edm::Handle<EcalPnDiodeDigiCollection>  PNs;
+  edm::Handle<EcalPnDiodeDigiCollection> PNs;
   e.getByLabel("ecalEBunpacker", PNs);
-
 
   // getting the list of all the Pns which will be dumped on TGraph
   // - listPns is the list as given by the user
   // - numPn is number of Pn's for which graphs are required
   std::vector<int>::iterator pn_it;
-  for ( pn_it = listPns.begin();  pn_it != listPns.end() ; pn_it++  )
-    {
-      int ipn    = (*pn_it);
-      int hpn = (numPn/2);
-      
-      for (int u = (-hpn) ; u<=hpn; u++){	  
-	  int ipn_c = ipn + u;
-	  if (ipn_c < 1 || ipn_c > 10) continue;
-	  listAllPns.push_back ( ipn_c ) ;
-      }
+  for (pn_it = listPns.begin(); pn_it != listPns.end(); pn_it++) {
+    int ipn = (*pn_it);
+    int hpn = (numPn / 2);
+
+    for (int u = (-hpn); u <= hpn; u++) {
+      int ipn_c = ipn + u;
+      if (ipn_c < 1 || ipn_c > 10)
+        continue;
+      listAllPns.push_back(ipn_c);
     }
-  
+  }
+
   // loop over all the available PN digis and make graphs for those which have been chosen by the user
-  for ( EcalPnDiodeDigiCollection::const_iterator pnItr = PNs->begin(); pnItr != PNs->end();
-        ++pnItr )  {
+  for (EcalPnDiodeDigiCollection::const_iterator pnItr = PNs->begin(); pnItr != PNs->end(); ++pnItr) {
     {
-      int ipn = (*pnItr).id().iPnId();    
-      int ieb    = EcalPnDiodeDetId((*pnItr).id()).iDCCId();
+      int ipn = (*pnItr).id().iPnId();
+      int ieb = EcalPnDiodeDetId((*pnItr).id()).iDCCId();
 
       // selecting based on DCCId
-      if (ieb != ieb_id) return;
-      
+      if (ieb != ieb_id)
+        return;
+
       // selecting desired Pns only
       std::vector<int>::iterator iPnIter;
-      iPnIter     = find( listAllPns.begin() , listAllPns.end() , ipn);
-      if (iPnIter == listAllPns.end()) { continue; }
-	    
-
-      for ( int i=0; i< (*pnItr).size() && i<50 ; ++i ) {
-	ordinate[i] = (*pnItr).sample(i).adc();
+      iPnIter = find(listAllPns.begin(), listAllPns.end(), ipn);
+      if (iPnIter == listAllPns.end()) {
+        continue;
       }
-	    
-      TGraph oneGraph(50, abscissa,ordinate);
+
+      for (int i = 0; i < (*pnItr).size() && i < 50; ++i) {
+        ordinate[i] = (*pnItr).sample(i).adc();
+      }
+
+      TGraph oneGraph(50, abscissa, ordinate);
       std::string title;
-      title = "Graph_ev" + intToString( eventCounter ) + "_ipn" + intToString( ipn );
+      title = "Graph_ev" + intToString(eventCounter) + "_ipn" + intToString(ipn);
       oneGraph.SetTitle(title.c_str());
       oneGraph.SetName(title.c_str());
       graphs.push_back(oneGraph);
 
-    }// loop in crystals
-  } 
-
-
-    
+    }  // loop in crystals
+  }
 }
-
 
 DEFINE_FWK_MODULE(EcalPnGraphDumperModule);

--- a/RecoBTag/SecondaryVertex/interface/CandidateBoostedDoubleSecondaryVertexComputer.h
+++ b/RecoBTag/SecondaryVertex/interface/CandidateBoostedDoubleSecondaryVertexComputer.h
@@ -5,23 +5,21 @@
 #include "CommonTools/MVAUtils/interface/TMVAEvaluator.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
 
-
 class CandidateBoostedDoubleSecondaryVertexComputer : public JetTagComputer {
+public:
+  CandidateBoostedDoubleSecondaryVertexComputer(const edm::ParameterSet &parameters);
 
-  public:
-    CandidateBoostedDoubleSecondaryVertexComputer(const edm::ParameterSet & parameters);
+  void initialize(const JetTagComputerRecord &) override;
+  float discriminator(const TagInfoHelper &tagInfos) const override;
 
-    void  initialize(const JetTagComputerRecord &) override;
-    float discriminator(const TagInfoHelper & tagInfos) const override;
+private:
+  const bool useCondDB_;
+  const std::string gbrForestLabel_;
+  const edm::FileInPath weightFile_;
+  const bool useGBRForest_;
+  const bool useAdaBoost_;
 
-  private:
-    const bool useCondDB_;
-    const std::string gbrForestLabel_;
-    const edm::FileInPath weightFile_;
-    const bool useGBRForest_;
-    const bool useAdaBoost_;
-
-    std::unique_ptr<TMVAEvaluator> mvaID;
+  std::unique_ptr<TMVAEvaluator> mvaID;
 };
 
-#endif // RecoBTag_SecondaryVertex_CandidateBoostedDoubleSecondaryVertexComputer_h
+#endif  // RecoBTag_SecondaryVertex_CandidateBoostedDoubleSecondaryVertexComputer_h

--- a/RecoBTag/SecondaryVertex/interface/CandidateSimpleSecondaryVertexComputer.h
+++ b/RecoBTag/SecondaryVertex/interface/CandidateSimpleSecondaryVertexComputer.h
@@ -5,7 +5,7 @@
 #include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
 #include "RecoBTag/SecondaryVertex/interface/TemplatedSimpleSecondaryVertexComputer.h"
 
+typedef TemplatedSimpleSecondaryVertexComputer<reco::CandIPTagInfo, reco::VertexCompositePtrCandidate>
+    CandidateSimpleSecondaryVertexComputer;
 
-typedef TemplatedSimpleSecondaryVertexComputer<reco::CandIPTagInfo,reco::VertexCompositePtrCandidate> CandidateSimpleSecondaryVertexComputer;
-
-#endif // RecoBTag_SecondaryVertex_CandidateSimpleSecondaryVertexComputer_h
+#endif  // RecoBTag_SecondaryVertex_CandidateSimpleSecondaryVertexComputer_h

--- a/RecoBTag/SecondaryVertex/interface/CombinedSVComputer.h
+++ b/RecoBTag/SecondaryVertex/interface/CombinedSVComputer.h
@@ -34,314 +34,322 @@
 #include "RecoBTag/SecondaryVertex/interface/TrackSorting.h"
 #include "RecoBTag/SecondaryVertex/interface/TrackKinematics.h"
 
-
-#define range_for(i, x) \
-        for(int i = (x).begin; i != (x).end; i += (x).increment)
-
+#define range_for(i, x) for (int i = (x).begin; i != (x).end; i += (x).increment)
 
 class CombinedSVComputer {
-    public:
-	explicit CombinedSVComputer(const edm::ParameterSet &params);
-        virtual ~CombinedSVComputer() = default;
-	virtual reco::TaggingVariableList
-	operator () (const reco::TrackIPTagInfo &ipInfo,
-	             const reco::SecondaryVertexTagInfo &svInfo) const;
-	virtual reco::TaggingVariableList
-	operator () (const reco::CandIPTagInfo &ipInfo,
-	             const reco::CandSecondaryVertexTagInfo &svInfo) const;
-	
-	struct IterationRange {
-	        int begin, end, increment;
-	};
-	double flipValue(double value, bool vertex) const;
-	IterationRange flipIterate(int size, bool vertex) const;
-	
-	edm::ParameterSet dropDeltaR(const edm::ParameterSet &pset) const;
-	
-	const reco::btag::TrackIPData &
-	threshTrack(const reco::CandIPTagInfo &trackIPTagInfo,
-	            const reco::btag::SortCriteria sort,
-	            const reco::Jet &jet,
-	            const GlobalPoint &pv) const;
-	const reco::btag::TrackIPData &
-	threshTrack(const reco::TrackIPTagInfo &trackIPTagInfo,
-	            const reco::btag::SortCriteria sort,
-	            const reco::Jet &jet,
-	            const GlobalPoint &pv) const;
-	template <class SVTI,class IPTI>
-	void fillCommonVariables(reco::TaggingVariableList & vars, reco::TrackKinematics & vertexKinematics,
-				 const IPTI & ipInfo,const SVTI & svInfo,
-				 double & vtx_track_ptSum, double & vtx_track_ESum) const;
+public:
+  explicit CombinedSVComputer(const edm::ParameterSet &params);
+  virtual ~CombinedSVComputer() = default;
+  virtual reco::TaggingVariableList operator()(const reco::TrackIPTagInfo &ipInfo,
+                                               const reco::SecondaryVertexTagInfo &svInfo) const;
+  virtual reco::TaggingVariableList operator()(const reco::CandIPTagInfo &ipInfo,
+                                               const reco::CandSecondaryVertexTagInfo &svInfo) const;
 
-    private:
-	bool					trackFlip;
-	bool					vertexFlip;
-	double					charmCut;
-	reco::btag::SortCriteria		sortCriterium;
-	reco::TrackSelector			trackSelector;
-	reco::TrackSelector			trackNoDeltaRSelector;
-	reco::TrackSelector			trackPseudoSelector;
-	unsigned int				pseudoMultiplicityMin;
-	unsigned int				trackMultiplicityMin;
-	double					minTrackWeight;
-	bool					useTrackWeights;
-	bool					vertexMassCorrection;
-	reco::V0Filter				pseudoVertexV0Filter;
-	reco::V0Filter				trackPairV0Filter;
-	std::vector<reco::btau::TaggingVariableName>	taggingVariables;
+  struct IterationRange {
+    int begin, end, increment;
+  };
+  double flipValue(double value, bool vertex) const;
+  IterationRange flipIterate(int size, bool vertex) const;
+
+  edm::ParameterSet dropDeltaR(const edm::ParameterSet &pset) const;
+
+  const reco::btag::TrackIPData &threshTrack(const reco::CandIPTagInfo &trackIPTagInfo,
+                                             const reco::btag::SortCriteria sort,
+                                             const reco::Jet &jet,
+                                             const GlobalPoint &pv) const;
+  const reco::btag::TrackIPData &threshTrack(const reco::TrackIPTagInfo &trackIPTagInfo,
+                                             const reco::btag::SortCriteria sort,
+                                             const reco::Jet &jet,
+                                             const GlobalPoint &pv) const;
+  template <class SVTI, class IPTI>
+  void fillCommonVariables(reco::TaggingVariableList &vars,
+                           reco::TrackKinematics &vertexKinematics,
+                           const IPTI &ipInfo,
+                           const SVTI &svInfo,
+                           double &vtx_track_ptSum,
+                           double &vtx_track_ESum) const;
+
+private:
+  bool trackFlip;
+  bool vertexFlip;
+  double charmCut;
+  reco::btag::SortCriteria sortCriterium;
+  reco::TrackSelector trackSelector;
+  reco::TrackSelector trackNoDeltaRSelector;
+  reco::TrackSelector trackPseudoSelector;
+  unsigned int pseudoMultiplicityMin;
+  unsigned int trackMultiplicityMin;
+  double minTrackWeight;
+  bool useTrackWeights;
+  bool vertexMassCorrection;
+  reco::V0Filter pseudoVertexV0Filter;
+  reco::V0Filter trackPairV0Filter;
+  std::vector<reco::btau::TaggingVariableName> taggingVariables;
 };
 
-template <class SVTI,class IPTI>
-void CombinedSVComputer::fillCommonVariables(reco::TaggingVariableList & vars, reco::TrackKinematics & vertexKinematics,
-					     const IPTI & ipInfo, const SVTI & svInfo,
-					     double & vtx_track_ptSum, double & vtx_track_ESum) const
-{
-        using namespace ROOT::Math;
-        using namespace reco;
+template <class SVTI, class IPTI>
+void CombinedSVComputer::fillCommonVariables(reco::TaggingVariableList &vars,
+                                             reco::TrackKinematics &vertexKinematics,
+                                             const IPTI &ipInfo,
+                                             const SVTI &svInfo,
+                                             double &vtx_track_ptSum,
+                                             double &vtx_track_ESum) const {
+  using namespace ROOT::Math;
+  using namespace reco;
 
-        typedef typename IPTI::input_container Container;
-        typedef typename Container::value_type TrackRef;
+  typedef typename IPTI::input_container Container;
+  typedef typename Container::value_type TrackRef;
 
-        edm::RefToBase<Jet> jet = ipInfo.jet();
-        math::XYZVector jetDir = jet->momentum().Unit();
-        bool havePv = ipInfo.primaryVertex().isNonnull();
-        GlobalPoint pv;
-        if (havePv)
-                pv = GlobalPoint(ipInfo.primaryVertex()->x(),
-                                 ipInfo.primaryVertex()->y(),
-                                 ipInfo.primaryVertex()->z());
+  edm::RefToBase<Jet> jet = ipInfo.jet();
+  math::XYZVector jetDir = jet->momentum().Unit();
+  bool havePv = ipInfo.primaryVertex().isNonnull();
+  GlobalPoint pv;
+  if (havePv)
+    pv = GlobalPoint(ipInfo.primaryVertex()->x(), ipInfo.primaryVertex()->y(), ipInfo.primaryVertex()->z());
 
-        btag::Vertices::VertexType vtxType = btag::Vertices::NoVertex;
+  btag::Vertices::VertexType vtxType = btag::Vertices::NoVertex;
 
+  vars.insert(btau::jetPt, jet->pt(), true);
+  vars.insert(btau::jetEta, jet->eta(), true);
+  vars.insert(btau::jetAbsEta, fabs(jet->eta()), true);
 
-        vars.insert(btau::jetPt, jet->pt(), true);
-        vars.insert(btau::jetEta, jet->eta(), true);
-        vars.insert(btau::jetAbsEta, fabs(jet->eta()), true);
+  if (ipInfo.selectedTracks().size() < trackMultiplicityMin)
+    return;
 
-        if (ipInfo.selectedTracks().size() < trackMultiplicityMin)
-                return;
+  vars.insert(btau::jetNTracks, ipInfo.selectedTracks().size(), true);
 
-	vars.insert(btau::jetNTracks, ipInfo.selectedTracks().size(), true);
-	
-        TrackKinematics allKinematics;
-	TrackKinematics trackJetKinematics;
-	
-	double jet_track_ESum= 0.; 
-	
-	int vtx = -1;
-	
-	IterationRange range = flipIterate(svInfo.nVertices(), true);
-	range_for(i , range) {
-		if (vtx < 0) vtx = i;
-	}
+  TrackKinematics allKinematics;
+  TrackKinematics trackJetKinematics;
 
-	if (vtx >= 0) {
-		vtxType = btag::Vertices::RecoVertex;
-		vars.insert(btau::flightDistance1dVal,flipValue(svInfo.flightDistance(vtx, 1).value(),true),true);
-                vars.insert(btau::flightDistance1dSig,flipValue(svInfo.flightDistance(vtx, 1).significance(),true),true);
-		vars.insert(btau::flightDistance2dVal,flipValue(svInfo.flightDistance(vtx, 2).value(),true),true);
-		vars.insert(btau::flightDistance2dSig,flipValue(svInfo.flightDistance(vtx, 2).significance(),true),true);
-		vars.insert(btau::flightDistance3dVal,flipValue(svInfo.flightDistance(vtx, 3).value(),true),true);
-		vars.insert(btau::flightDistance3dSig,flipValue(svInfo.flightDistance(vtx, 3).significance(),true),true);
-		vars.insert(btau::vertexJetDeltaR,Geom::deltaR(svInfo.flightDirection(vtx), vertexFlip ? -jetDir : jetDir),true);
-		vars.insert(btau::jetNSecondaryVertices, svInfo.nVertices(), true);
-	}
+  double jet_track_ESum = 0.;
 
-	std::vector<std::size_t> indices = ipInfo.sortedIndexes(sortCriterium);
-	const std::vector<reco::btag::TrackIPData> &ipData = ipInfo.impactParameterData();
+  int vtx = -1;
 
-	const Container &tracks = ipInfo.selectedTracks();
-	std::vector<TrackRef> pseudoVertexTracks;
+  IterationRange range = flipIterate(svInfo.nVertices(), true);
+  range_for(i, range) {
+    if (vtx < 0)
+      vtx = i;
+  }
 
-        std::vector<TrackRef> trackPairV0Test(2);
-        range = flipIterate(indices.size(), false);
-        range_for(i, range) {
-                std::size_t idx = indices[i];
-                const reco::btag::TrackIPData &data = ipData[idx];
-                const TrackRef &track = tracks[idx];
+  if (vtx >= 0) {
+    vtxType = btag::Vertices::RecoVertex;
+    vars.insert(btau::flightDistance1dVal, flipValue(svInfo.flightDistance(vtx, 1).value(), true), true);
+    vars.insert(btau::flightDistance1dSig, flipValue(svInfo.flightDistance(vtx, 1).significance(), true), true);
+    vars.insert(btau::flightDistance2dVal, flipValue(svInfo.flightDistance(vtx, 2).value(), true), true);
+    vars.insert(btau::flightDistance2dSig, flipValue(svInfo.flightDistance(vtx, 2).significance(), true), true);
+    vars.insert(btau::flightDistance3dVal, flipValue(svInfo.flightDistance(vtx, 3).value(), true), true);
+    vars.insert(btau::flightDistance3dSig, flipValue(svInfo.flightDistance(vtx, 3).significance(), true), true);
+    vars.insert(btau::vertexJetDeltaR, Geom::deltaR(svInfo.flightDirection(vtx), vertexFlip ? -jetDir : jetDir), true);
+    vars.insert(btau::jetNSecondaryVertices, svInfo.nVertices(), true);
+  }
 
-                jet_track_ESum += std::sqrt(track->momentum().Mag2() + ROOT::Math::Square(ParticleMasses::piPlus));
+  std::vector<std::size_t> indices = ipInfo.sortedIndexes(sortCriterium);
+  const std::vector<reco::btag::TrackIPData> &ipData = ipInfo.impactParameterData();
 
-                // add track to kinematics for all tracks in jet
-                //allKinematics.add(track); // would make more sense for some variables, e.g. vertexEnergyRatio nicely between 0 and 1, but not necessarily the best option for the discriminating power...
+  const Container &tracks = ipInfo.selectedTracks();
+  std::vector<TrackRef> pseudoVertexTracks;
 
-                // filter track -> this track selection can be tighter than the vertex track selection (used to fill the track related variables...)
-                if (!trackSelector(track, data, *jet, pv))
-                        continue;
+  std::vector<TrackRef> trackPairV0Test(2);
+  range = flipIterate(indices.size(), false);
+  range_for(i, range) {
+    std::size_t idx = indices[i];
+    const reco::btag::TrackIPData &data = ipData[idx];
+    const TrackRef &track = tracks[idx];
 
-                // add track to kinematics for all tracks in jet
-                allKinematics.add(track);
+    jet_track_ESum += std::sqrt(track->momentum().Mag2() + ROOT::Math::Square(ParticleMasses::piPlus));
 
-                // if no vertex was reconstructed, attempt pseudo vertex
-                if (vtxType == btag::Vertices::NoVertex && trackPseudoSelector(track, data, *jet, pv)) {
-                        pseudoVertexTracks.push_back(track);
-                        vertexKinematics.add(track);
-                }
+    // add track to kinematics for all tracks in jet
+    //allKinematics.add(track); // would make more sense for some variables, e.g. vertexEnergyRatio nicely between 0 and 1, but not necessarily the best option for the discriminating power...
 
-                // check against all other tracks for V0 track pairs
-                trackPairV0Test[0] = track;
-                bool ok = true;
-                range_for(j, range) {
-                        if (i == j)
-                                continue;
+    // filter track -> this track selection can be tighter than the vertex track selection (used to fill the track related variables...)
+    if (!trackSelector(track, data, *jet, pv))
+      continue;
 
-                        std::size_t pairIdx = indices[j];
-                        const reco::btag::TrackIPData &pairTrackData = ipData[pairIdx];
-                        const TrackRef &pairTrack = tracks[pairIdx];
+    // add track to kinematics for all tracks in jet
+    allKinematics.add(track);
 
-                        if (!trackSelector(pairTrack, pairTrackData, *jet, pv))
-                                continue;
+    // if no vertex was reconstructed, attempt pseudo vertex
+    if (vtxType == btag::Vertices::NoVertex && trackPseudoSelector(track, data, *jet, pv)) {
+      pseudoVertexTracks.push_back(track);
+      vertexKinematics.add(track);
+    }
 
-                        trackPairV0Test[1] = pairTrack;
-                        if (!trackPairV0Filter(trackPairV0Test)) {
-                                ok = false;
-                                break;
-                        }
-                }
-                if (!ok)
-                        continue;
+    // check against all other tracks for V0 track pairs
+    trackPairV0Test[0] = track;
+    bool ok = true;
+    range_for(j, range) {
+      if (i == j)
+        continue;
 
-                trackJetKinematics.add(track);
+      std::size_t pairIdx = indices[j];
+      const reco::btag::TrackIPData &pairTrackData = ipData[pairIdx];
+      const TrackRef &pairTrack = tracks[pairIdx];
 
-                // add track variables
-                math::XYZVector trackMom = track->momentum();
-                double trackMag = std::sqrt(trackMom.Mag2());
+      if (!trackSelector(pairTrack, pairTrackData, *jet, pv))
+        continue;
 
-                vars.insert(btau::trackSip3dVal, flipValue(data.ip3d.value(), false), true);
-                vars.insert(btau::trackSip3dSig, flipValue(data.ip3d.significance(), false), true);
-                vars.insert(btau::trackSip2dVal, flipValue(data.ip2d.value(), false), true);
-                vars.insert(btau::trackSip2dSig, flipValue(data.ip2d.significance(), false), true);
-                vars.insert(btau::trackJetDistVal, data.distanceToJetAxis.value(), true);
-//              vars.insert(btau::trackJetDistSig, data.distanceToJetAxis.significance(), true);
-//              vars.insert(btau::trackFirstTrackDist, data.distanceToFirstTrack, true);
-//              vars.insert(btau::trackGhostTrackVal, data.distanceToGhostTrack.value(), true);
-//              vars.insert(btau::trackGhostTrackSig, data.distanceToGhostTrack.significance(), true);
-                vars.insert(btau::trackDecayLenVal, havePv ? (data.closestToJetAxis - pv).mag() : -1.0, true);
+      trackPairV0Test[1] = pairTrack;
+      if (!trackPairV0Filter(trackPairV0Test)) {
+        ok = false;
+        break;
+      }
+    }
+    if (!ok)
+      continue;
 
-                vars.insert(btau::trackMomentum, trackMag, true);
-                vars.insert(btau::trackEta, trackMom.Eta(), true);
+    trackJetKinematics.add(track);
 
-                // check for erroneous Perp^2 values before evaluating Perp (fix for DeepCSV NaN outputs)
-                double perp_trackMom_jetDir = VectorUtil::Perp2(trackMom, jetDir);
-                perp_trackMom_jetDir = (perp_trackMom_jetDir > 0. ? std::sqrt(perp_trackMom_jetDir ) : 0. );
+    // add track variables
+    math::XYZVector trackMom = track->momentum();
+    double trackMag = std::sqrt(trackMom.Mag2());
 
-                vars.insert(btau::trackPtRel, perp_trackMom_jetDir, true);
-                vars.insert(btau::trackPPar, jetDir.Dot(trackMom), true);
-                vars.insert(btau::trackDeltaR, VectorUtil::DeltaR(trackMom, jetDir), true);
-                vars.insert(btau::trackPtRatio, perp_trackMom_jetDir / trackMag, true);
-                vars.insert(btau::trackPParRatio, jetDir.Dot(trackMom) / trackMag, true);
-        }
+    vars.insert(btau::trackSip3dVal, flipValue(data.ip3d.value(), false), true);
+    vars.insert(btau::trackSip3dSig, flipValue(data.ip3d.significance(), false), true);
+    vars.insert(btau::trackSip2dVal, flipValue(data.ip2d.value(), false), true);
+    vars.insert(btau::trackSip2dSig, flipValue(data.ip2d.significance(), false), true);
+    vars.insert(btau::trackJetDistVal, data.distanceToJetAxis.value(), true);
+    //              vars.insert(btau::trackJetDistSig, data.distanceToJetAxis.significance(), true);
+    //              vars.insert(btau::trackFirstTrackDist, data.distanceToFirstTrack, true);
+    //              vars.insert(btau::trackGhostTrackVal, data.distanceToGhostTrack.value(), true);
+    //              vars.insert(btau::trackGhostTrackSig, data.distanceToGhostTrack.significance(), true);
+    vars.insert(btau::trackDecayLenVal, havePv ? (data.closestToJetAxis - pv).mag() : -1.0, true);
 
-        if (vtxType == btag::Vertices::NoVertex && vertexKinematics.numberOfTracks() >= pseudoMultiplicityMin && pseudoVertexV0Filter(pseudoVertexTracks))
-        {
-                vtxType = btag::Vertices::PseudoVertex;
-                for(typename std::vector<TrackRef>::const_iterator trkIt = pseudoVertexTracks.begin(); trkIt != pseudoVertexTracks.end(); ++trkIt)
-                {
-                        vars.insert(btau::trackEtaRel, reco::btau::etaRel(jetDir,(*trkIt)->momentum()), true);
-                        vtx_track_ptSum += std::sqrt((*trkIt)->momentum().Perp2());
-                        vtx_track_ESum  += std::sqrt((*trkIt)->momentum().Mag2() + ROOT::Math::Square(ParticleMasses::piPlus));
-                }
-        }
+    vars.insert(btau::trackMomentum, trackMag, true);
+    vars.insert(btau::trackEta, trackMom.Eta(), true);
 
-	vars.insert(btau::vertexCategory, vtxType, true);
-        	
-	vars.insert(btau::trackJetPt, trackJetKinematics.vectorSum().Pt(), true);
-	vars.insert(btau::trackSumJetDeltaR,VectorUtil::DeltaR(allKinematics.vectorSum(), jetDir), true);
-	vars.insert(btau::trackSumJetEtRatio,allKinematics.vectorSum().Et() / ipInfo.jet()->et(), true);
+    // check for erroneous Perp^2 values before evaluating Perp (fix for DeepCSV NaN outputs)
+    double perp_trackMom_jetDir = VectorUtil::Perp2(trackMom, jetDir);
+    perp_trackMom_jetDir = (perp_trackMom_jetDir > 0. ? std::sqrt(perp_trackMom_jetDir) : 0.);
 
-	vars.insert(btau::trackSip3dSigAboveCharm, flipValue(threshTrack(ipInfo, reco::btag::IP3DSig, *jet, pv).ip3d.significance(),false),true);
-	vars.insert(btau::trackSip3dValAboveCharm, flipValue(threshTrack(ipInfo, reco::btag::IP3DSig, *jet, pv).ip3d.value(),false),true);
-	vars.insert(btau::trackSip2dSigAboveCharm, flipValue(threshTrack(ipInfo, reco::btag::IP2DSig, *jet, pv).ip2d.significance(),false),true);
-	vars.insert(btau::trackSip2dValAboveCharm, flipValue(threshTrack(ipInfo, reco::btag::IP2DSig, *jet, pv).ip2d.value(),false),true);
+    vars.insert(btau::trackPtRel, perp_trackMom_jetDir, true);
+    vars.insert(btau::trackPPar, jetDir.Dot(trackMom), true);
+    vars.insert(btau::trackDeltaR, VectorUtil::DeltaR(trackMom, jetDir), true);
+    vars.insert(btau::trackPtRatio, perp_trackMom_jetDir / trackMag, true);
+    vars.insert(btau::trackPParRatio, jetDir.Dot(trackMom) / trackMag, true);
+  }
 
-        if (vtxType != btag::Vertices::NoVertex) {
-                math::XYZTLorentzVector allSum = useTrackWeights
-                        ? allKinematics.weightedVectorSum()
-                        : allKinematics.vectorSum();
-                math::XYZTLorentzVector vertexSum = useTrackWeights
-                        ? vertexKinematics.weightedVectorSum()
-                        : vertexKinematics.vectorSum();
+  if (vtxType == btag::Vertices::NoVertex && vertexKinematics.numberOfTracks() >= pseudoMultiplicityMin &&
+      pseudoVertexV0Filter(pseudoVertexTracks)) {
+    vtxType = btag::Vertices::PseudoVertex;
+    for (typename std::vector<TrackRef>::const_iterator trkIt = pseudoVertexTracks.begin();
+         trkIt != pseudoVertexTracks.end();
+         ++trkIt) {
+      vars.insert(btau::trackEtaRel, reco::btau::etaRel(jetDir, (*trkIt)->momentum()), true);
+      vtx_track_ptSum += std::sqrt((*trkIt)->momentum().Perp2());
+      vtx_track_ESum += std::sqrt((*trkIt)->momentum().Mag2() + ROOT::Math::Square(ParticleMasses::piPlus));
+    }
+  }
 
-                if (vtxType != btag::Vertices::RecoVertex) {
-                        vars.insert(btau::vertexNTracks,vertexKinematics.numberOfTracks(), true);
-                        vars.insert(btau::vertexJetDeltaR,VectorUtil::DeltaR(vertexSum, jetDir), true);
-                }
+  vars.insert(btau::vertexCategory, vtxType, true);
 
-                double vertexMass = vertexSum.M();
-                if (vtxType == btag::Vertices::RecoVertex &&
-                    vertexMassCorrection) {
-                        const GlobalVector& dir = svInfo.flightDirection(vtx);
-                        double vertexPt2 = math::XYZVector(dir.x(), dir.y(), dir.z()).Cross(vertexSum).Mag2() / dir.mag2();
-                        vertexMass = std::sqrt(vertexMass * vertexMass + vertexPt2) + std::sqrt(vertexPt2);
-                }
-                vars.insert(btau::vertexMass, vertexMass, true);
+  vars.insert(btau::trackJetPt, trackJetKinematics.vectorSum().Pt(), true);
+  vars.insert(btau::trackSumJetDeltaR, VectorUtil::DeltaR(allKinematics.vectorSum(), jetDir), true);
+  vars.insert(btau::trackSumJetEtRatio, allKinematics.vectorSum().Et() / ipInfo.jet()->et(), true);
 
-                double varPi = (vertexMass/5.2794) * (vtx_track_ESum /jet_track_ESum); // 5.2794 should be the average B meson mass of PDG! CHECK!!!
-                vars.insert(btau::massVertexEnergyFraction, varPi / (varPi + 0.04), true);
-                double varB  = (std::sqrt(5.2794) * vtx_track_ptSum) / ( vertexMass * std::sqrt(jet->pt()));
-                vars.insert(btau::vertexBoostOverSqrtJetPt,varB*varB/(varB*varB + 10.), true);
+  vars.insert(btau::trackSip3dSigAboveCharm,
+              flipValue(threshTrack(ipInfo, reco::btag::IP3DSig, *jet, pv).ip3d.significance(), false),
+              true);
+  vars.insert(btau::trackSip3dValAboveCharm,
+              flipValue(threshTrack(ipInfo, reco::btag::IP3DSig, *jet, pv).ip3d.value(), false),
+              true);
+  vars.insert(btau::trackSip2dSigAboveCharm,
+              flipValue(threshTrack(ipInfo, reco::btag::IP2DSig, *jet, pv).ip2d.significance(), false),
+              true);
+  vars.insert(btau::trackSip2dValAboveCharm,
+              flipValue(threshTrack(ipInfo, reco::btag::IP2DSig, *jet, pv).ip2d.value(), false),
+              true);
 
-                if (allKinematics.numberOfTracks()) {
-                        vars.insert(btau::vertexEnergyRatio, vertexSum.E() / allSum.E(), true);
-                }
-                else {
-                        vars.insert(btau::vertexEnergyRatio, 1, true);
-                }
-        }
+  if (vtxType != btag::Vertices::NoVertex) {
+    math::XYZTLorentzVector allSum = useTrackWeights ? allKinematics.weightedVectorSum() : allKinematics.vectorSum();
+    math::XYZTLorentzVector vertexSum =
+        useTrackWeights ? vertexKinematics.weightedVectorSum() : vertexKinematics.vectorSum();
 
-	reco::PFJet const * pfJet = dynamic_cast<reco::PFJet const *>( &* jet ) ;
-	pat::Jet const * patJet = dynamic_cast<pat::Jet const *>( &* jet ) ;
-	if ( pfJet != nullptr ) 
-	{
-		vars.insert(btau::chargedHadronEnergyFraction,pfJet->chargedHadronEnergyFraction(), true);
-		vars.insert(btau::neutralHadronEnergyFraction,pfJet->neutralHadronEnergyFraction(), true);
-		vars.insert(btau::photonEnergyFraction,pfJet->photonEnergyFraction(), true);
-		vars.insert(btau::electronEnergyFraction,pfJet->electronEnergyFraction(), true);
-		vars.insert(btau::muonEnergyFraction,pfJet->muonEnergyFraction(), true);
-		vars.insert(btau::chargedHadronMultiplicity,pfJet->chargedHadronMultiplicity(), true);
-		vars.insert(btau::neutralHadronMultiplicity,pfJet->neutralHadronMultiplicity(), true);
-		vars.insert(btau::photonMultiplicity,pfJet->photonMultiplicity(), true);
-		vars.insert(btau::electronMultiplicity,pfJet->electronMultiplicity(), true);
-		vars.insert(btau::muonMultiplicity,pfJet->muonMultiplicity(), true);
-		vars.insert(btau::hadronMultiplicity,pfJet->chargedHadronMultiplicity()+pfJet->neutralHadronMultiplicity(), true);
-		vars.insert(btau::hadronPhotonMultiplicity,pfJet->chargedHadronMultiplicity()+pfJet->neutralHadronMultiplicity()+pfJet->photonMultiplicity(), true);
-		vars.insert(btau::totalMultiplicity,pfJet->chargedHadronMultiplicity()+pfJet->neutralHadronMultiplicity()+pfJet->photonMultiplicity()+pfJet->electronMultiplicity()+pfJet->muonMultiplicity(), true);
+    if (vtxType != btag::Vertices::RecoVertex) {
+      vars.insert(btau::vertexNTracks, vertexKinematics.numberOfTracks(), true);
+      vars.insert(btau::vertexJetDeltaR, VectorUtil::DeltaR(vertexSum, jetDir), true);
+    }
 
-	}
-	else if( patJet != nullptr && patJet->isPFJet() )
-	{
-		vars.insert(btau::chargedHadronEnergyFraction,patJet->chargedHadronEnergyFraction(), true);
-		vars.insert(btau::neutralHadronEnergyFraction,patJet->neutralHadronEnergyFraction(), true);
-		vars.insert(btau::photonEnergyFraction,patJet->photonEnergyFraction(), true);
-		vars.insert(btau::electronEnergyFraction,patJet->electronEnergyFraction(), true);
-		vars.insert(btau::muonEnergyFraction,patJet->muonEnergyFraction(), true);
-		vars.insert(btau::chargedHadronMultiplicity,patJet->chargedHadronMultiplicity(), true);
-		vars.insert(btau::neutralHadronMultiplicity,patJet->neutralHadronMultiplicity(), true);
-		vars.insert(btau::photonMultiplicity,patJet->photonMultiplicity(), true);
-		vars.insert(btau::electronMultiplicity,patJet->electronMultiplicity(), true);
-		vars.insert(btau::muonMultiplicity,patJet->muonMultiplicity(), true);
-		vars.insert(btau::hadronMultiplicity,patJet->chargedHadronMultiplicity()+patJet->neutralHadronMultiplicity(), true);
-		vars.insert(btau::hadronPhotonMultiplicity,patJet->chargedHadronMultiplicity()+patJet->neutralHadronMultiplicity()+patJet->photonMultiplicity(), true);
-		vars.insert(btau::totalMultiplicity,patJet->chargedHadronMultiplicity()+patJet->neutralHadronMultiplicity()+patJet->photonMultiplicity()+patJet->electronMultiplicity()+patJet->muonMultiplicity(), true);
-	
-	}
-	else
-	{
-		vars.insert(btau::chargedHadronEnergyFraction,0., true);
-		vars.insert(btau::neutralHadronEnergyFraction,0., true);
-		vars.insert(btau::photonEnergyFraction,0., true);
-		vars.insert(btau::electronEnergyFraction,0., true);
-		vars.insert(btau::muonEnergyFraction,0., true);
-		vars.insert(btau::chargedHadronMultiplicity,0, true);
-		vars.insert(btau::neutralHadronMultiplicity,0, true);
-		vars.insert(btau::photonMultiplicity,0, true);
-		vars.insert(btau::electronMultiplicity,0, true);
-		vars.insert(btau::muonMultiplicity,0, true);
-		vars.insert(btau::hadronMultiplicity,0, true);
-		vars.insert(btau::hadronPhotonMultiplicity,0, true);
-		vars.insert(btau::totalMultiplicity,0, true);
-	}
+    double vertexMass = vertexSum.M();
+    if (vtxType == btag::Vertices::RecoVertex && vertexMassCorrection) {
+      const GlobalVector &dir = svInfo.flightDirection(vtx);
+      double vertexPt2 = math::XYZVector(dir.x(), dir.y(), dir.z()).Cross(vertexSum).Mag2() / dir.mag2();
+      vertexMass = std::sqrt(vertexMass * vertexMass + vertexPt2) + std::sqrt(vertexPt2);
+    }
+    vars.insert(btau::vertexMass, vertexMass, true);
+
+    double varPi = (vertexMass / 5.2794) *
+                   (vtx_track_ESum / jet_track_ESum);  // 5.2794 should be the average B meson mass of PDG! CHECK!!!
+    vars.insert(btau::massVertexEnergyFraction, varPi / (varPi + 0.04), true);
+    double varB = (std::sqrt(5.2794) * vtx_track_ptSum) / (vertexMass * std::sqrt(jet->pt()));
+    vars.insert(btau::vertexBoostOverSqrtJetPt, varB * varB / (varB * varB + 10.), true);
+
+    if (allKinematics.numberOfTracks()) {
+      vars.insert(btau::vertexEnergyRatio, vertexSum.E() / allSum.E(), true);
+    } else {
+      vars.insert(btau::vertexEnergyRatio, 1, true);
+    }
+  }
+
+  reco::PFJet const *pfJet = dynamic_cast<reco::PFJet const *>(&*jet);
+  pat::Jet const *patJet = dynamic_cast<pat::Jet const *>(&*jet);
+  if (pfJet != nullptr) {
+    vars.insert(btau::chargedHadronEnergyFraction, pfJet->chargedHadronEnergyFraction(), true);
+    vars.insert(btau::neutralHadronEnergyFraction, pfJet->neutralHadronEnergyFraction(), true);
+    vars.insert(btau::photonEnergyFraction, pfJet->photonEnergyFraction(), true);
+    vars.insert(btau::electronEnergyFraction, pfJet->electronEnergyFraction(), true);
+    vars.insert(btau::muonEnergyFraction, pfJet->muonEnergyFraction(), true);
+    vars.insert(btau::chargedHadronMultiplicity, pfJet->chargedHadronMultiplicity(), true);
+    vars.insert(btau::neutralHadronMultiplicity, pfJet->neutralHadronMultiplicity(), true);
+    vars.insert(btau::photonMultiplicity, pfJet->photonMultiplicity(), true);
+    vars.insert(btau::electronMultiplicity, pfJet->electronMultiplicity(), true);
+    vars.insert(btau::muonMultiplicity, pfJet->muonMultiplicity(), true);
+    vars.insert(
+        btau::hadronMultiplicity, pfJet->chargedHadronMultiplicity() + pfJet->neutralHadronMultiplicity(), true);
+    vars.insert(btau::hadronPhotonMultiplicity,
+                pfJet->chargedHadronMultiplicity() + pfJet->neutralHadronMultiplicity() + pfJet->photonMultiplicity(),
+                true);
+    vars.insert(btau::totalMultiplicity,
+                pfJet->chargedHadronMultiplicity() + pfJet->neutralHadronMultiplicity() + pfJet->photonMultiplicity() +
+                    pfJet->electronMultiplicity() + pfJet->muonMultiplicity(),
+                true);
+
+  } else if (patJet != nullptr && patJet->isPFJet()) {
+    vars.insert(btau::chargedHadronEnergyFraction, patJet->chargedHadronEnergyFraction(), true);
+    vars.insert(btau::neutralHadronEnergyFraction, patJet->neutralHadronEnergyFraction(), true);
+    vars.insert(btau::photonEnergyFraction, patJet->photonEnergyFraction(), true);
+    vars.insert(btau::electronEnergyFraction, patJet->electronEnergyFraction(), true);
+    vars.insert(btau::muonEnergyFraction, patJet->muonEnergyFraction(), true);
+    vars.insert(btau::chargedHadronMultiplicity, patJet->chargedHadronMultiplicity(), true);
+    vars.insert(btau::neutralHadronMultiplicity, patJet->neutralHadronMultiplicity(), true);
+    vars.insert(btau::photonMultiplicity, patJet->photonMultiplicity(), true);
+    vars.insert(btau::electronMultiplicity, patJet->electronMultiplicity(), true);
+    vars.insert(btau::muonMultiplicity, patJet->muonMultiplicity(), true);
+    vars.insert(
+        btau::hadronMultiplicity, patJet->chargedHadronMultiplicity() + patJet->neutralHadronMultiplicity(), true);
+    vars.insert(
+        btau::hadronPhotonMultiplicity,
+        patJet->chargedHadronMultiplicity() + patJet->neutralHadronMultiplicity() + patJet->photonMultiplicity(),
+        true);
+    vars.insert(btau::totalMultiplicity,
+                patJet->chargedHadronMultiplicity() + patJet->neutralHadronMultiplicity() +
+                    patJet->photonMultiplicity() + patJet->electronMultiplicity() + patJet->muonMultiplicity(),
+                true);
+
+  } else {
+    vars.insert(btau::chargedHadronEnergyFraction, 0., true);
+    vars.insert(btau::neutralHadronEnergyFraction, 0., true);
+    vars.insert(btau::photonEnergyFraction, 0., true);
+    vars.insert(btau::electronEnergyFraction, 0., true);
+    vars.insert(btau::muonEnergyFraction, 0., true);
+    vars.insert(btau::chargedHadronMultiplicity, 0, true);
+    vars.insert(btau::neutralHadronMultiplicity, 0, true);
+    vars.insert(btau::photonMultiplicity, 0, true);
+    vars.insert(btau::electronMultiplicity, 0, true);
+    vars.insert(btau::muonMultiplicity, 0, true);
+    vars.insert(btau::hadronMultiplicity, 0, true);
+    vars.insert(btau::hadronPhotonMultiplicity, 0, true);
+    vars.insert(btau::totalMultiplicity, 0, true);
+  }
 }
 
-
-#endif // RecoBTag_SecondaryVertex_CombinedSVComputer_h
+#endif  // RecoBTag_SecondaryVertex_CombinedSVComputer_h

--- a/RecoBTag/SecondaryVertex/interface/CombinedSVSoftLeptonComputer.h
+++ b/RecoBTag/SecondaryVertex/interface/CombinedSVSoftLeptonComputer.h
@@ -10,110 +10,104 @@
 #include "DataFormats/BTauReco/src/classes.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
-
 class CombinedSVSoftLeptonComputer : public CombinedSVComputer {
-    public:
-	explicit CombinedSVSoftLeptonComputer(const edm::ParameterSet &params);
-        ~CombinedSVSoftLeptonComputer() override = default;	
-	double flipSoftLeptonValue(double value) const;
-	
-	template <class IPTI,class SVTI>
-	reco::TaggingVariableList
-	operator () (const IPTI &ipInfo, const SVTI &svInfo,
-		     const reco::CandSoftLeptonTagInfo &muonInfo,
-		     const reco::CandSoftLeptonTagInfo &elecInfo ) const;
-	
-	private:
-	bool					SoftLeptonFlip;
+public:
+  explicit CombinedSVSoftLeptonComputer(const edm::ParameterSet &params);
+  ~CombinedSVSoftLeptonComputer() override = default;
+  double flipSoftLeptonValue(double value) const;
+
+  template <class IPTI, class SVTI>
+  reco::TaggingVariableList operator()(const IPTI &ipInfo,
+                                       const SVTI &svInfo,
+                                       const reco::CandSoftLeptonTagInfo &muonInfo,
+                                       const reco::CandSoftLeptonTagInfo &elecInfo) const;
+
+private:
+  bool SoftLeptonFlip;
 };
 
-double CombinedSVSoftLeptonComputer::flipSoftLeptonValue(double value) const
-{
-	return SoftLeptonFlip ? -value : value;
+double CombinedSVSoftLeptonComputer::flipSoftLeptonValue(double value) const { return SoftLeptonFlip ? -value : value; }
+
+template <class IPTI, class SVTI>
+reco::TaggingVariableList CombinedSVSoftLeptonComputer::operator()(const IPTI &ipInfo,
+                                                                   const SVTI &svInfo,
+                                                                   const reco::CandSoftLeptonTagInfo &muonInfo,
+                                                                   const reco::CandSoftLeptonTagInfo &elecInfo) const {
+  using namespace reco;
+
+  // call the inherited operator()
+  TaggingVariableList vars = CombinedSVComputer::operator()(ipInfo, svInfo);
+
+  //Jets with vtxCategory 99 cause problems
+  unsigned int vtxType =
+      (vars.checkTag(reco::btau::vertexCategory) ? (unsigned int)(vars.get(reco::btau::vertexCategory)) : 99);
+  if (vtxType == 99)
+    return vars;
+
+  // the following is specific to soft leptons
+  int leptonCategory = 0;  // 0 = no lepton, 1 = muon, 2 = electron
+
+  for (unsigned int i = 0; i < muonInfo.leptons();
+       ++i)  // loop over all muons, not optimal -> find the best or use ranking from best to worst
+  {
+    leptonCategory = 1;  // muon category
+    const SoftLeptonProperties &propertiesMuon = muonInfo.properties(i);
+    vars.insert(btau::leptonPtRel, propertiesMuon.ptRel, true);
+    vars.insert(btau::leptonSip3d, flipSoftLeptonValue(propertiesMuon.sip3d), true);
+    vars.insert(btau::leptonDeltaR, propertiesMuon.deltaR, true);
+    vars.insert(btau::leptonRatioRel, propertiesMuon.ratioRel, true);
+    vars.insert(btau::leptonEtaRel, propertiesMuon.etaRel, true);
+    vars.insert(btau::leptonRatio, propertiesMuon.ratio, true);
+  }
+
+  if (leptonCategory != 1)  // no soft muon found, try soft electron
+  {
+    for (unsigned int i = 0; i < elecInfo.leptons();
+         ++i)  // loop over all electrons, not optimal -> find the best or use ranking from best to worst
+    {
+      leptonCategory = 2;  // electron category
+      const SoftLeptonProperties &propertiesElec = elecInfo.properties(i);
+      vars.insert(btau::leptonPtRel, propertiesElec.ptRel, true);
+      vars.insert(btau::leptonSip3d, flipSoftLeptonValue(propertiesElec.sip3d), true);
+      vars.insert(btau::leptonDeltaR, propertiesElec.deltaR, true);
+      vars.insert(btau::leptonRatioRel, propertiesElec.ratioRel, true);
+      vars.insert(btau::leptonEtaRel, propertiesElec.etaRel, true);
+      vars.insert(btau::leptonRatio, propertiesElec.ratio, true);
+    }
+  }
+
+  // set the default value for vertexLeptonCategory to 2 (= NoVertexNoSoftLepton)
+  int vertexLepCat = 2;
+
+  if (leptonCategory == 0)  // no soft lepton
+  {
+    if (vtxType == (unsigned int)(btag::Vertices::RecoVertex))
+      vertexLepCat = 0;
+    else if (vtxType == (unsigned int)(btag::Vertices::PseudoVertex))
+      vertexLepCat = 1;
+    else
+      vertexLepCat = 2;
+  } else if (leptonCategory == 1)  // soft muon
+  {
+    if (vtxType == (unsigned int)(btag::Vertices::RecoVertex))
+      vertexLepCat = 3;
+    else if (vtxType == (unsigned int)(btag::Vertices::PseudoVertex))
+      vertexLepCat = 4;
+    else
+      vertexLepCat = 5;
+  } else if (leptonCategory == 2)  // soft electron
+  {
+    if (vtxType == (unsigned int)(btag::Vertices::RecoVertex))
+      vertexLepCat = 6;
+    else if (vtxType == (unsigned int)(btag::Vertices::PseudoVertex))
+      vertexLepCat = 7;
+    else
+      vertexLepCat = 8;
+  }
+  vars.insert(btau::vertexLeptonCategory, vertexLepCat, true);
+
+  vars.finalize();
+  return vars;
 }
 
-template <class IPTI,class SVTI>
-reco::TaggingVariableList CombinedSVSoftLeptonComputer::operator () (const IPTI &ipInfo, const SVTI &svInfo,
-								     const reco::CandSoftLeptonTagInfo &muonInfo,
-								     const reco::CandSoftLeptonTagInfo &elecInfo) const
-{
-	using namespace reco;
-	
-	// call the inherited operator()
-	TaggingVariableList vars = CombinedSVComputer::operator()(ipInfo,svInfo);
-
-	//Jets with vtxCategory 99 cause problems
-	unsigned int vtxType = ( vars.checkTag(reco::btau::vertexCategory) ? (unsigned int)(vars.get(reco::btau::vertexCategory)) : 99 );
-	if (vtxType == 99)
-     		return vars;
-
-	
-	// the following is specific to soft leptons
-	int leptonCategory = 0; // 0 = no lepton, 1 = muon, 2 = electron
-	
-	for (unsigned int i = 0; i < muonInfo.leptons(); ++i) // loop over all muons, not optimal -> find the best or use ranking from best to worst
-	{
-		leptonCategory = 1; // muon category
-		const SoftLeptonProperties & propertiesMuon = muonInfo.properties(i);
-		vars.insert(btau::leptonPtRel,propertiesMuon.ptRel , true);
-		vars.insert(btau::leptonSip3d,flipSoftLeptonValue(propertiesMuon.sip3d) , true);
-		vars.insert(btau::leptonDeltaR,propertiesMuon.deltaR , true);
-		vars.insert(btau::leptonRatioRel,propertiesMuon.ratioRel , true);
-		vars.insert(btau::leptonEtaRel,propertiesMuon.etaRel , true);
-		vars.insert(btau::leptonRatio,propertiesMuon.ratio , true);
-	}
-	
-	if(leptonCategory != 1) // no soft muon found, try soft electron
-	{ 
-		for (unsigned int i = 0; i < elecInfo.leptons(); ++i) // loop over all electrons, not optimal -> find the best or use ranking from best to worst
-		{
-			leptonCategory = 2; // electron category
-			const SoftLeptonProperties & propertiesElec = elecInfo.properties(i);
-			vars.insert(btau::leptonPtRel,propertiesElec.ptRel , true);
-			vars.insert(btau::leptonSip3d,flipSoftLeptonValue(propertiesElec.sip3d) , true);
-			vars.insert(btau::leptonDeltaR,propertiesElec.deltaR , true);
-			vars.insert(btau::leptonRatioRel,propertiesElec.ratioRel , true);
-			vars.insert(btau::leptonEtaRel,propertiesElec.etaRel , true);
-			vars.insert(btau::leptonRatio,propertiesElec.ratio , true);
-		}
-	}
-	
-
-	// set the default value for vertexLeptonCategory to 2 (= NoVertexNoSoftLepton)
-	int vertexLepCat = 2; 
-
-	
-	if(leptonCategory == 0) // no soft lepton
-	{
-		if (vtxType == (unsigned int)(btag::Vertices::RecoVertex))
-			vertexLepCat = 0;
-		else if (vtxType == (unsigned int)(btag::Vertices::PseudoVertex))
-			vertexLepCat = 1;
-		else
-			vertexLepCat = 2;
-	} 
-	else if(leptonCategory == 1) // soft muon
-	{
-		if (vtxType == (unsigned int)(btag::Vertices::RecoVertex))
-			vertexLepCat = 3;
-		else if(vtxType == (unsigned int)(btag::Vertices::PseudoVertex))
-			vertexLepCat = 4;
-		else 
-			vertexLepCat = 5;
-	} 
-	else if(leptonCategory == 2) // soft electron
-	{
-		if (vtxType == (unsigned int)(btag::Vertices::RecoVertex))
-			vertexLepCat = 6;
-		else if (vtxType == (unsigned int)(btag::Vertices::PseudoVertex))
-			vertexLepCat = 7;
-		else 
-			vertexLepCat = 8;
-	}
-	vars.insert(btau::vertexLeptonCategory, vertexLepCat , true);	
-	
-	vars.finalize();
-	return vars;
-}
-
-#endif // RecoBTag_SecondaryVertex_CombinedSVSoftLeptonComputer_h
+#endif  // RecoBTag_SecondaryVertex_CombinedSVSoftLeptonComputer_h

--- a/RecoBTag/SecondaryVertex/interface/GhostTrackComputer.h
+++ b/RecoBTag/SecondaryVertex/interface/GhostTrackComputer.h
@@ -6,7 +6,7 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/BTauReco/interface/TrackIPTagInfo.h"
 #include "DataFormats/BTauReco/interface/CandIPTagInfo.h"
-#include "DataFormats/BTauReco/interface/SecondaryVertexTagInfo.h"  
+#include "DataFormats/BTauReco/interface/SecondaryVertexTagInfo.h"
 #include "DataFormats/BTauReco/interface/CandSecondaryVertexTagInfo.h"
 #include "DataFormats/BTauReco/interface/TaggingVariable.h"
 
@@ -14,35 +14,31 @@
 #include "RecoBTag/SecondaryVertex/interface/V0Filter.h"
 
 class GhostTrackComputer {
-    public:
-	GhostTrackComputer(const edm::ParameterSet &params);
-        virtual ~GhostTrackComputer() = default;
-	virtual reco::TaggingVariableList
-	operator () (const reco::TrackIPTagInfo &ipInfo,
-	             const reco::SecondaryVertexTagInfo &svInfo) const;
-	virtual reco::TaggingVariableList
-	operator () (const reco::CandIPTagInfo &ipInfo,
-	             const reco::CandSecondaryVertexTagInfo &svInfo) const;
+public:
+  GhostTrackComputer(const edm::ParameterSet &params);
+  virtual ~GhostTrackComputer() = default;
+  virtual reco::TaggingVariableList operator()(const reco::TrackIPTagInfo &ipInfo,
+                                               const reco::SecondaryVertexTagInfo &svInfo) const;
+  virtual reco::TaggingVariableList operator()(const reco::CandIPTagInfo &ipInfo,
+                                               const reco::CandSecondaryVertexTagInfo &svInfo) const;
 
-    private:
-	const reco::btag::TrackIPData &
-	threshTrack(const reco::TrackIPTagInfo &trackIPTagInfo,
-	            const reco::btag::SortCriteria sort,
-	            const reco::Jet &jet,
-	            const GlobalPoint &pv) const;
-	const reco::btag::TrackIPData &
-	threshTrack(const reco::CandIPTagInfo &trackIPTagInfo,
-	            const reco::btag::SortCriteria sort,
-	            const reco::Jet &jet,
-	            const GlobalPoint &pv) const;
+private:
+  const reco::btag::TrackIPData &threshTrack(const reco::TrackIPTagInfo &trackIPTagInfo,
+                                             const reco::btag::SortCriteria sort,
+                                             const reco::Jet &jet,
+                                             const GlobalPoint &pv) const;
+  const reco::btag::TrackIPData &threshTrack(const reco::CandIPTagInfo &trackIPTagInfo,
+                                             const reco::btag::SortCriteria sort,
+                                             const reco::Jet &jet,
+                                             const GlobalPoint &pv) const;
 
-	double					charmCut;
-	reco::btag::SortCriteria		sortCriterium;
-	reco::TrackSelector			trackSelector;
-	reco::TrackSelector			trackNoDeltaRSelector;
-	double					minTrackWeight;
-	bool					vertexMassCorrection;
-	reco::V0Filter				trackPairV0Filter;
+  double charmCut;
+  reco::btag::SortCriteria sortCriterium;
+  reco::TrackSelector trackSelector;
+  reco::TrackSelector trackNoDeltaRSelector;
+  double minTrackWeight;
+  bool vertexMassCorrection;
+  reco::V0Filter trackPairV0Filter;
 };
 
-#endif // RecoBTag_SecondaryVertex_GhostTrackComputer_h
+#endif  // RecoBTag_SecondaryVertex_GhostTrackComputer_h

--- a/RecoBTag/SecondaryVertex/interface/SecondaryVertex.h
+++ b/RecoBTag/SecondaryVertex/interface/SecondaryVertex.h
@@ -8,8 +8,8 @@
 
 namespace reco {
 
-typedef TemplatedSecondaryVertex<reco::Vertex> SecondaryVertex; 
+  typedef TemplatedSecondaryVertex<reco::Vertex> SecondaryVertex;
 
-} // namespace reco
+}  // namespace reco
 
-#endif // RecoBTag_SecondaryVertex_SecondaryVertex_h
+#endif  // RecoBTag_SecondaryVertex_SecondaryVertex_h

--- a/RecoBTag/SecondaryVertex/interface/SimpleSecondaryVertexComputer.h
+++ b/RecoBTag/SecondaryVertex/interface/SimpleSecondaryVertexComputer.h
@@ -5,7 +5,6 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "RecoBTag/SecondaryVertex/interface/TemplatedSimpleSecondaryVertexComputer.h"
 
+typedef TemplatedSimpleSecondaryVertexComputer<reco::TrackIPTagInfo, reco::Vertex> SimpleSecondaryVertexComputer;
 
-typedef TemplatedSimpleSecondaryVertexComputer<reco::TrackIPTagInfo,reco::Vertex> SimpleSecondaryVertexComputer;
-
-#endif // RecoBTag_SecondaryVertex_SimpleSecondaryVertexComputer_h
+#endif  // RecoBTag_SecondaryVertex_SimpleSecondaryVertexComputer_h

--- a/RecoBTag/SecondaryVertex/interface/TemplatedSecondaryVertex.h
+++ b/RecoBTag/SecondaryVertex/interface/TemplatedSecondaryVertex.h
@@ -7,41 +7,47 @@
 
 namespace reco {
 
-template <class SV>
-class TemplatedSecondaryVertex : public SV {
-    public:
-	TemplatedSecondaryVertex() {}
-	TemplatedSecondaryVertex(const reco::Vertex &pv,
-	                const SV &sv,
-	                const GlobalVector &direction,
-	                bool withPVError = false) :
-		SV(sv),dist1d_(computeDist1d(pv, sv, direction, withPVError)),dist2d_(computeDist2d(pv, sv, direction, withPVError)),dist3d_(computeDist3d(pv, sv, direction, withPVError)) {}
+  template <class SV>
+  class TemplatedSecondaryVertex : public SV {
+  public:
+    TemplatedSecondaryVertex() {}
+    TemplatedSecondaryVertex(const reco::Vertex &pv,
+                             const SV &sv,
+                             const GlobalVector &direction,
+                             bool withPVError = false)
+        : SV(sv),
+          dist1d_(computeDist1d(pv, sv, direction, withPVError)),
+          dist2d_(computeDist2d(pv, sv, direction, withPVError)),
+          dist3d_(computeDist3d(pv, sv, direction, withPVError)) {}
 
-		~TemplatedSecondaryVertex()  {} //NOLINT
-        inline Measurement1D dist1d() const { return dist1d_; }
-        inline Measurement1D dist2d() const { return dist2d_; }
-        inline Measurement1D dist3d() const { return dist3d_; }
-        static Measurement1D computeDist1d(
-                const reco::Vertex &pv, const SV &sv,
-                const GlobalVector &direction, bool withPVError);
-	static Measurement1D computeDist2d(
-//		const reco::Vertex &pv, const reco::Vertex &sv,
-		const reco::Vertex &pv, const SV &sv,
-		const GlobalVector &direction, bool withPVError);
-	static Measurement1D computeDist3d(
-//		const reco::Vertex &pv, const reco::Vertex &sv,
-		const reco::Vertex &pv, const SV &sv,
-		const GlobalVector &direction, bool withPVError);
-	operator reco::Vertex();
+    ~TemplatedSecondaryVertex() {}  //NOLINT
+    inline Measurement1D dist1d() const { return dist1d_; }
+    inline Measurement1D dist2d() const { return dist2d_; }
+    inline Measurement1D dist3d() const { return dist3d_; }
+    static Measurement1D computeDist1d(const reco::Vertex &pv,
+                                       const SV &sv,
+                                       const GlobalVector &direction,
+                                       bool withPVError);
+    static Measurement1D computeDist2d(
+        //		const reco::Vertex &pv, const reco::Vertex &sv,
+        const reco::Vertex &pv,
+        const SV &sv,
+        const GlobalVector &direction,
+        bool withPVError);
+    static Measurement1D computeDist3d(
+        //		const reco::Vertex &pv, const reco::Vertex &sv,
+        const reco::Vertex &pv,
+        const SV &sv,
+        const GlobalVector &direction,
+        bool withPVError);
+    operator reco::Vertex();
 
-	private:
-                Measurement1D dist1d_;
-                Measurement1D dist2d_;
-        	Measurement1D dist3d_;
-	
+  private:
+    Measurement1D dist1d_;
+    Measurement1D dist2d_;
+    Measurement1D dist3d_;
+  };
 
-};
+}  // namespace reco
 
-} // namespace reco
-
-#endif // RecoBTag_SecondaryVertex_TemplatedSecondaryVertex_h
+#endif  // RecoBTag_SecondaryVertex_TemplatedSecondaryVertex_h

--- a/RecoBTag/SecondaryVertex/interface/TrackKinematics.h
+++ b/RecoBTag/SecondaryVertex/interface/TrackKinematics.h
@@ -13,46 +13,47 @@
 
 namespace reco {
 
-class TrackKinematics {
-    public:
-	TrackKinematics();
-	TrackKinematics(const std::vector<reco::Track> &tracks);
-	TrackKinematics(const reco::TrackRefVector &tracks);
-	TrackKinematics(const std::vector<reco::CandidatePtr> &tracks);
-	TrackKinematics(const reco::CandidatePtrVector &tracks);
-	TrackKinematics(const reco::Vertex &vertex);
-	TrackKinematics(const reco::VertexCompositePtrCandidate &vertex):
- 	       n(vertex.numberOfSourceCandidatePtrs()), sumWeights(vertex.numberOfSourceCandidatePtrs()),
-	       sum(vertex.p4()),weightedSum(vertex.p4()){}
+  class TrackKinematics {
+  public:
+    TrackKinematics();
+    TrackKinematics(const std::vector<reco::Track> &tracks);
+    TrackKinematics(const reco::TrackRefVector &tracks);
+    TrackKinematics(const std::vector<reco::CandidatePtr> &tracks);
+    TrackKinematics(const reco::CandidatePtrVector &tracks);
+    TrackKinematics(const reco::Vertex &vertex);
+    TrackKinematics(const reco::VertexCompositePtrCandidate &vertex)
+        : n(vertex.numberOfSourceCandidatePtrs()),
+          sumWeights(vertex.numberOfSourceCandidatePtrs()),
+          sum(vertex.p4()),
+          weightedSum(vertex.p4()) {}
 
-	~TrackKinematics() {}
+    ~TrackKinematics() {}
 
-	void add(const reco::Track &track, double weight = 1.0);
-	void add(const reco::CandidatePtr &track);
+    void add(const reco::Track &track, double weight = 1.0);
+    void add(const reco::CandidatePtr &track);
 
-	inline
-	void add(const reco::TrackRef &track, double weight = 1.0)
-	{return add(*track, weight); }
+    inline void add(const reco::TrackRef &track, double weight = 1.0) { return add(*track, weight); }
 
-	TrackKinematics &operator += (const TrackKinematics &other);
-	inline TrackKinematics operator + (const TrackKinematics &other)
-	{ TrackKinematics copy = *this; copy += other; return copy; }
+    TrackKinematics &operator+=(const TrackKinematics &other);
+    inline TrackKinematics operator+(const TrackKinematics &other) {
+      TrackKinematics copy = *this;
+      copy += other;
+      return copy;
+    }
 
-	inline unsigned int numberOfTracks() const { return n; }
-	inline double sumOfWeights() const { return sumWeights; }
+    inline unsigned int numberOfTracks() const { return n; }
+    inline double sumOfWeights() const { return sumWeights; }
 
-	inline const math::XYZTLorentzVector &vectorSum() const
-	{ return sum; }
-	inline const math::XYZTLorentzVector &weightedVectorSum() const
-	{ return weightedSum; }
+    inline const math::XYZTLorentzVector &vectorSum() const { return sum; }
+    inline const math::XYZTLorentzVector &weightedVectorSum() const { return weightedSum; }
 
-    private:
-	unsigned int		n;
-	double			sumWeights;
-	math::XYZTLorentzVector	sum;
-	math::XYZTLorentzVector	weightedSum;
-};
+  private:
+    unsigned int n;
+    double sumWeights;
+    math::XYZTLorentzVector sum;
+    math::XYZTLorentzVector weightedSum;
+  };
 
-} // namespace reco
+}  // namespace reco
 
-#endif // RecoBTag_SecondaryVertex_TrackKinematics_h
+#endif  // RecoBTag_SecondaryVertex_TrackKinematics_h

--- a/RecoBTag/SecondaryVertex/interface/TrackSelector.h
+++ b/RecoBTag/SecondaryVertex/interface/TrackSelector.h
@@ -11,55 +11,55 @@
 
 namespace reco {
 
-class TrackSelector {
-    public:
-	TrackSelector(const edm::ParameterSet &params);
-	~TrackSelector() {}
+  class TrackSelector {
+  public:
+    TrackSelector(const edm::ParameterSet &params);
+    ~TrackSelector() {}
 
-	bool operator() (const reco::Track &track,
-	                 const reco::btag::TrackIPData &ipData,
-	                 const reco::Jet &jet,
-	                 const GlobalPoint &pv) const;
+    bool operator()(const reco::Track &track,
+                    const reco::btag::TrackIPData &ipData,
+                    const reco::Jet &jet,
+                    const GlobalPoint &pv) const;
 
-	bool operator() (const reco::CandidatePtr &track,
-	                 const reco::btag::TrackIPData &ipData,
-	                 const reco::Jet &jet,
-	                 const GlobalPoint &pv) const;
+    bool operator()(const reco::CandidatePtr &track,
+                    const reco::btag::TrackIPData &ipData,
+                    const reco::Jet &jet,
+                    const GlobalPoint &pv) const;
 
-	inline
-	bool operator() (const reco::TrackRef &track,
-	                 const reco::btag::TrackIPData &ipData,
-	                 const reco::Jet &jet,
-	                 const GlobalPoint &pv) const
-	{ return (*this)(*track, ipData, jet, pv); }
+    inline bool operator()(const reco::TrackRef &track,
+                           const reco::btag::TrackIPData &ipData,
+                           const reco::Jet &jet,
+                           const GlobalPoint &pv) const {
+      return (*this)(*track, ipData, jet, pv);
+    }
 
-    private:
-	bool trackSelection(const reco::Track &track,
-	                    const reco::btag::TrackIPData &ipData,
-	                    const reco::Jet &jet,
-	                    const GlobalPoint &pv) const;
+  private:
+    bool trackSelection(const reco::Track &track,
+                        const reco::btag::TrackIPData &ipData,
+                        const reco::Jet &jet,
+                        const GlobalPoint &pv) const;
 
-	bool				selectQuality;
-	reco::TrackBase::TrackQuality	quality;
-	unsigned int			minPixelHits;
-	unsigned int			minTotalHits;
-	double				minPt;
-	double				maxNormChi2;
-	double				maxJetDeltaR;
-	double				maxDistToAxis;
-	double				maxDecayLen;
-	double				sip2dValMin;
-	double				sip2dValMax;
-	double				sip2dSigMin;
-	double				sip2dSigMax;
-	double				sip3dValMin;
-	double				sip3dValMax;
-	double				sip3dSigMin;
-	double				sip3dSigMax;
-	bool                            useVariableJTA_;
-	reco::btag::variableJTAParameters varJTApars;
-};
+    bool selectQuality;
+    reco::TrackBase::TrackQuality quality;
+    unsigned int minPixelHits;
+    unsigned int minTotalHits;
+    double minPt;
+    double maxNormChi2;
+    double maxJetDeltaR;
+    double maxDistToAxis;
+    double maxDecayLen;
+    double sip2dValMin;
+    double sip2dValMax;
+    double sip2dSigMin;
+    double sip2dSigMax;
+    double sip3dValMin;
+    double sip3dValMax;
+    double sip3dSigMin;
+    double sip3dSigMax;
+    bool useVariableJTA_;
+    reco::btag::variableJTAParameters varJTApars;
+  };
 
-} // namespace reco
+}  // namespace reco
 
-#endif // RecoBTag_SecondaryVertex_TrackSelector_h
+#endif  // RecoBTag_SecondaryVertex_TrackSelector_h

--- a/RecoBTag/SecondaryVertex/interface/TrackSorting.h
+++ b/RecoBTag/SecondaryVertex/interface/TrackSorting.h
@@ -6,8 +6,7 @@
 #include "DataFormats/BTauReco/interface/IPTagInfo.h"
 
 namespace TrackSorting {
-	extern reco::btag::SortCriteria
-	getCriterium(const std::string &name);
+  extern reco::btag::SortCriteria getCriterium(const std::string &name);
 }
 
-#endif // RecoBTag_SecondaryVertex_TrackSorting_h
+#endif  // RecoBTag_SecondaryVertex_TrackSorting_h

--- a/RecoBTag/SecondaryVertex/interface/V0Filter.h
+++ b/RecoBTag/SecondaryVertex/interface/V0Filter.h
@@ -11,32 +11,28 @@
 
 namespace reco {
 
-class V0Filter {
-    public:
-	V0Filter(const edm::ParameterSet &params);
-	~V0Filter() {}
+  class V0Filter {
+  public:
+    V0Filter(const edm::ParameterSet &params);
+    ~V0Filter() {}
 
-	bool operator () (const reco::TrackRef *tracks, unsigned int n) const;
-	bool operator () (const reco::Track *tracks, unsigned int n) const;
-	bool operator () (const std::vector<reco::CandidatePtr> &tracks) const;
-	bool operator () (const std::vector<const Track *> &tracks) const;
+    bool operator()(const reco::TrackRef *tracks, unsigned int n) const;
+    bool operator()(const reco::Track *tracks, unsigned int n) const;
+    bool operator()(const std::vector<reco::CandidatePtr> &tracks) const;
+    bool operator()(const std::vector<const Track *> &tracks) const;
 
-       
-	inline bool
-	operator () (const std::vector<reco::TrackRef> &tracks) const
-	{ return (*this)(&tracks[0], tracks.size()); }
+    inline bool operator()(const std::vector<reco::TrackRef> &tracks) const {
+      return (*this)(&tracks[0], tracks.size());
+    }
 
-	inline bool
-	operator () (const std::vector<reco::Track> &tracks) const
-	{ return (*this)(&tracks[0], tracks.size()); }
+    inline bool operator()(const std::vector<reco::Track> &tracks) const { return (*this)(&tracks[0], tracks.size()); }
 
-	bool
-	operator () (const reco::Track * const *tracks, unsigned int n) const;
-    private:
+    bool operator()(const reco::Track *const *tracks, unsigned int n) const;
 
-	double	k0sMassWindow;
-};
+  private:
+    double k0sMassWindow;
+  };
 
-} // namespace reco
+}  // namespace reco
 
-#endif // RecoBTag_SecondaryVertex_V0Filter_h
+#endif  // RecoBTag_SecondaryVertex_V0Filter_h

--- a/RecoBTag/SecondaryVertex/interface/VertexFilter.h
+++ b/RecoBTag/SecondaryVertex/interface/VertexFilter.h
@@ -22,37 +22,39 @@
 
 namespace reco {
 
-class VertexFilter {
-    public:
-	VertexFilter(const edm::ParameterSet &params);
-	~VertexFilter() {}
+  class VertexFilter {
+  public:
+    VertexFilter(const edm::ParameterSet &params);
+    ~VertexFilter() {}
 
-	bool operator () (const reco::Vertex &pv, const TemplatedSecondaryVertex<reco::Vertex> &sv,
-	                  const GlobalVector &direction) const;
-	bool operator () (const reco::Vertex &pv, const TemplatedSecondaryVertex<reco::VertexCompositePtrCandidate> &sv,
-	                  const GlobalVector &direction) const;
+    bool operator()(const reco::Vertex &pv,
+                    const TemplatedSecondaryVertex<reco::Vertex> &sv,
+                    const GlobalVector &direction) const;
+    bool operator()(const reco::Vertex &pv,
+                    const TemplatedSecondaryVertex<reco::VertexCompositePtrCandidate> &sv,
+                    const GlobalVector &direction) const;
 
-    private:
-	bool		useTrackWeights;
-	double		minTrackWeight;
-	double		massMax;
-	double		fracPV;
-	unsigned int	multiplicityMin;
+  private:
+    bool useTrackWeights;
+    double minTrackWeight;
+    double massMax;
+    double fracPV;
+    unsigned int multiplicityMin;
 
-	double		distVal2dMin;
-	double		distVal2dMax;
-	double		distVal3dMin;
-	double		distVal3dMax;
+    double distVal2dMin;
+    double distVal2dMax;
+    double distVal3dMin;
+    double distVal3dMax;
 
-	double		distSig2dMin;
-	double		distSig2dMax;
-	double		distSig3dMin;
-	double		distSig3dMax;
+    double distSig2dMin;
+    double distSig2dMax;
+    double distSig3dMin;
+    double distSig3dMax;
 
-	double		maxDeltaRToJetAxis;
-	V0Filter	v0Filter;
-};
+    double maxDeltaRToJetAxis;
+    V0Filter v0Filter;
+  };
 
-} // namespace reco
+}  // namespace reco
 
-#endif // RecoBTag_SecondaryVertex_VertexFilter_h
+#endif  // RecoBTag_SecondaryVertex_VertexFilter_h

--- a/RecoBTag/SecondaryVertex/interface/VertexSorting.h
+++ b/RecoBTag/SecondaryVertex/interface/VertexSorting.h
@@ -12,109 +12,93 @@
 #include "RecoBTag/SecondaryVertex/interface/SecondaryVertex.h"
 #include "RecoBTag/SecondaryVertex/interface/VertexSorting.h"
 
-
-
 namespace reco {
 
-template <class SecondaryVertex>
-class VertexSorting {
-    public:
-	VertexSorting(const edm::ParameterSet &params):
-		sortCriterium(getSortCriterium(params.getParameter<std::string>("sortCriterium"))){}
-	~VertexSorting() {}
+  template <class SecondaryVertex>
+  class VertexSorting {
+  public:
+    VertexSorting(const edm::ParameterSet &params)
+        : sortCriterium(getSortCriterium(params.getParameter<std::string>("sortCriterium"))) {}
+    ~VertexSorting() {}
 
-	std::vector<unsigned int>
-	operator () (const std::vector<SecondaryVertex>&svCandidates) const;
+    std::vector<unsigned int> operator()(const std::vector<SecondaryVertex> &svCandidates) const;
 
-    private:
-	enum SortCriterium {
-		sortDist3dVal = 0,
-		sortDist3dErr,
-		sortDist3dSig,
-		sortDist2dErr,
-		sortDist2dSig,
-		sortDist2dVal
-	};
+  private:
+    enum SortCriterium { sortDist3dVal = 0, sortDist3dErr, sortDist3dSig, sortDist2dErr, sortDist2dSig, sortDist2dVal };
 
-	static SortCriterium getSortCriterium(const std::string &criterium);
+    static SortCriterium getSortCriterium(const std::string &criterium);
 
-	SortCriterium	sortCriterium;
-};
+    SortCriterium sortCriterium;
+  };
 
-template <class SecondaryVertex>
-typename VertexSorting<SecondaryVertex>::SortCriterium
-VertexSorting<SecondaryVertex>::getSortCriterium(const std::string &criterium)
-{
-	if (criterium == "dist3dError")
-		return sortDist3dErr;
-	if (criterium == "dist3dValue")
-		return sortDist3dVal;
-	if (criterium == "dist3dSignificance")
-		return sortDist3dSig;
-	if (criterium == "dist2dError")
-		return sortDist2dErr;
-	if (criterium == "dist2dValue")
-		return sortDist2dVal;
-	if (criterium == "dist2dSignificance")
-		return sortDist2dSig;
+  template <class SecondaryVertex>
+  typename VertexSorting<SecondaryVertex>::SortCriterium VertexSorting<SecondaryVertex>::getSortCriterium(
+      const std::string &criterium) {
+    if (criterium == "dist3dError")
+      return sortDist3dErr;
+    if (criterium == "dist3dValue")
+      return sortDist3dVal;
+    if (criterium == "dist3dSignificance")
+      return sortDist3dSig;
+    if (criterium == "dist2dError")
+      return sortDist2dErr;
+    if (criterium == "dist2dValue")
+      return sortDist2dVal;
+    if (criterium == "dist2dSignificance")
+      return sortDist2dSig;
 
-	throw cms::Exception("InvalidArgument")
-		<< "Vertex sort criterium \"" << criterium << "\" is invalid."
-		<< std::endl;
-}
+    throw cms::Exception("InvalidArgument") << "Vertex sort criterium \"" << criterium << "\" is invalid." << std::endl;
+  }
 
-// identify most probable SV (closest to interaction point, significance-wise)
-// FIXME: identify if this is the best strategy!
-template <class SecondaryVertex>
-std::vector<unsigned int> VertexSorting<SecondaryVertex>::operator () (
-		const std::vector<SecondaryVertex> &svCandidates) const
-{
-	Measurement1D (SecondaryVertex::*measurementFn)() const = nullptr;
-	switch(sortCriterium) {
-	    case sortDist3dErr:
-	    case sortDist3dVal:
-	    case sortDist3dSig:
-		measurementFn = &SecondaryVertex::dist3d;
-		break;
-	    case sortDist2dErr:
-	    case sortDist2dVal:
-	    case sortDist2dSig:
-		measurementFn = &SecondaryVertex::dist2d;
-		break;
-	}
+  // identify most probable SV (closest to interaction point, significance-wise)
+  // FIXME: identify if this is the best strategy!
+  template <class SecondaryVertex>
+  std::vector<unsigned int> VertexSorting<SecondaryVertex>::operator()(
+      const std::vector<SecondaryVertex> &svCandidates) const {
+    Measurement1D (SecondaryVertex::*measurementFn)() const = nullptr;
+    switch (sortCriterium) {
+      case sortDist3dErr:
+      case sortDist3dVal:
+      case sortDist3dSig:
+        measurementFn = &SecondaryVertex::dist3d;
+        break;
+      case sortDist2dErr:
+      case sortDist2dVal:
+      case sortDist2dSig:
+        measurementFn = &SecondaryVertex::dist2d;
+        break;
+    }
 
-	double (Measurement1D::*valueFn)() const = nullptr;
-	switch(sortCriterium) {
-	    case sortDist3dErr:
-	    case sortDist2dErr:
-		valueFn = &Measurement1D::error;
-		break;
-	    case sortDist3dVal:
-	    case sortDist2dVal:
-		valueFn = &Measurement1D::value;
-		break;
-	    case sortDist3dSig:
-	    case sortDist2dSig:
-		valueFn = &Measurement1D::significance;
-		break;
-	}
+    double (Measurement1D::*valueFn)() const = nullptr;
+    switch (sortCriterium) {
+      case sortDist3dErr:
+      case sortDist2dErr:
+        valueFn = &Measurement1D::error;
+        break;
+      case sortDist3dVal:
+      case sortDist2dVal:
+        valueFn = &Measurement1D::value;
+        break;
+      case sortDist3dSig:
+      case sortDist2dSig:
+        valueFn = &Measurement1D::significance;
+        break;
+    }
 
-	std::multimap<double, unsigned int> sortedMap;
-	unsigned int i = 0;
-	for(typename std::vector<SecondaryVertex>::const_iterator iter =
-		svCandidates.begin(); iter != svCandidates.end(); iter++) {
+    std::multimap<double, unsigned int> sortedMap;
+    unsigned int i = 0;
+    for (typename std::vector<SecondaryVertex>::const_iterator iter = svCandidates.begin(); iter != svCandidates.end();
+         iter++) {
+      double value = std::abs((((*iter).*measurementFn)().*valueFn)());
+      sortedMap.insert(std::make_pair(value, i++));
+    }
 
-		double value = std::abs((((*iter).*measurementFn)().*valueFn)());
-		sortedMap.insert(std::make_pair(value, i++));
-	}
+    std::vector<unsigned int> result;
+    for (std::multimap<double, unsigned int>::const_iterator iter = sortedMap.begin(); iter != sortedMap.end(); iter++)
+      result.push_back(iter->second);
 
-	std::vector<unsigned int> result;
-	for(std::multimap<double, unsigned int>::const_iterator iter =
-		sortedMap.begin(); iter != sortedMap.end(); iter++)
-		result.push_back(iter->second);
+    return result;
+  }
+}  // namespace reco
 
-	return result;
-}
-} // namespace reco
-
-#endif // RecoBTag_SecondaryVertex_VertexSorting_h
+#endif  // RecoBTag_SecondaryVertex_VertexSorting_h

--- a/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/BoostedDoubleSVProducer.cc
@@ -17,7 +17,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 
@@ -59,52 +58,56 @@
 //
 
 class BoostedDoubleSVProducer : public edm::stream::EDProducer<> {
-   public:
-      explicit BoostedDoubleSVProducer(const edm::ParameterSet&);
-      ~BoostedDoubleSVProducer() override;
+public:
+  explicit BoostedDoubleSVProducer(const edm::ParameterSet&);
+  ~BoostedDoubleSVProducer() override;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-   private:
-      void beginStream(edm::StreamID) override;
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      void endStream() override;
+private:
+  void beginStream(edm::StreamID) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override;
 
-      void calcNsubjettiness(const reco::JetBaseRef & jet, float & tau1, float & tau2, std::vector<fastjet::PseudoJet> & currentAxes) const;
-      void setTracksPVBase(const reco::TrackRef & trackRef, const reco::VertexRef & vertexRef, float & PVweight) const;
-      void setTracksPV(const reco::CandidatePtr & trackRef, const reco::VertexRef & vertexRef, float & PVweight) const;
-      void etaRelToTauAxis(const reco::VertexCompositePtrCandidate & vertex, const fastjet::PseudoJet & tauAxis, std::vector<float> & tau_trackEtaRel) const;
+  void calcNsubjettiness(const reco::JetBaseRef& jet,
+                         float& tau1,
+                         float& tau2,
+                         std::vector<fastjet::PseudoJet>& currentAxes) const;
+  void setTracksPVBase(const reco::TrackRef& trackRef, const reco::VertexRef& vertexRef, float& PVweight) const;
+  void setTracksPV(const reco::CandidatePtr& trackRef, const reco::VertexRef& vertexRef, float& PVweight) const;
+  void etaRelToTauAxis(const reco::VertexCompositePtrCandidate& vertex,
+                       const fastjet::PseudoJet& tauAxis,
+                       std::vector<float>& tau_trackEtaRel) const;
 
-      // ----------member data ---------------------------
-      const edm::EDGetTokenT<std::vector<reco::CandSecondaryVertexTagInfo> > svTagInfos_;
+  // ----------member data ---------------------------
+  const edm::EDGetTokenT<std::vector<reco::CandSecondaryVertexTagInfo> > svTagInfos_;
 
-      const double beta_;
-      const double R0_;
+  const double beta_;
+  const double R0_;
 
-      const double maxSVDeltaRToJet_;
-      const double maxDistToAxis_;
-      const double maxDecayLen_;
-      reco::V0Filter trackPairV0Filter;
-      reco::TrackSelector trackSelector;
+  const double maxSVDeltaRToJet_;
+  const double maxDistToAxis_;
+  const double maxDecayLen_;
+  reco::V0Filter trackPairV0Filter;
+  reco::TrackSelector trackSelector;
 
-      // static variables
-      static constexpr float dummyZ_ratio             = -3.0f;
-      static constexpr float dummyTrackSip3dSig       = -50.0f;
-      static constexpr float dummyTrackSip2dSigAbove  = -19.0f;
-      static constexpr float dummyTrackEtaRel         = -1.0f;
-      static constexpr float dummyVertexMass          = -1.0f;
-      static constexpr float dummyVertexEnergyRatio   = -1.0f;
-      static constexpr float dummyVertexDeltaR        = -1.0f;
-      static constexpr float dummyFlightDistance2dSig = -1.0f;
+  // static variables
+  static constexpr float dummyZ_ratio = -3.0f;
+  static constexpr float dummyTrackSip3dSig = -50.0f;
+  static constexpr float dummyTrackSip2dSigAbove = -19.0f;
+  static constexpr float dummyTrackEtaRel = -1.0f;
+  static constexpr float dummyVertexMass = -1.0f;
+  static constexpr float dummyVertexEnergyRatio = -1.0f;
+  static constexpr float dummyVertexDeltaR = -1.0f;
+  static constexpr float dummyFlightDistance2dSig = -1.0f;
 
-      static constexpr float charmThreshold  = 1.5f;
-      static constexpr float bottomThreshold = 5.2f;
+  static constexpr float charmThreshold = 1.5f;
+  static constexpr float bottomThreshold = 5.2f;
 };
 
 //
 // constants, enums and typedefs
 //
-
 
 //
 // static data member definitions
@@ -113,576 +116,554 @@ class BoostedDoubleSVProducer : public edm::stream::EDProducer<> {
 //
 // constructors and destructor
 //
-BoostedDoubleSVProducer::BoostedDoubleSVProducer(const edm::ParameterSet& iConfig) :
-  svTagInfos_( consumes<std::vector<reco::CandSecondaryVertexTagInfo> >(iConfig.getParameter<edm::InputTag>("svTagInfos")) ),
-  beta_(iConfig.getParameter<double>("beta")),
-  R0_(iConfig.getParameter<double>("R0")),
-  maxSVDeltaRToJet_(iConfig.getParameter<double>("maxSVDeltaRToJet")),
-  maxDistToAxis_(iConfig.getParameter<edm::ParameterSet>("trackSelection").getParameter<double>("maxDistToAxis")),
-  maxDecayLen_(iConfig.getParameter<edm::ParameterSet>("trackSelection").getParameter<double>("maxDecayLen")),
-  trackPairV0Filter(iConfig.getParameter<edm::ParameterSet>("trackPairV0Filter")),
-  trackSelector(iConfig.getParameter<edm::ParameterSet>("trackSelection"))
-{
-    produces<std::vector<reco::BoostedDoubleSVTagInfo> >();
+BoostedDoubleSVProducer::BoostedDoubleSVProducer(const edm::ParameterSet& iConfig)
+    : svTagInfos_(
+          consumes<std::vector<reco::CandSecondaryVertexTagInfo> >(iConfig.getParameter<edm::InputTag>("svTagInfos"))),
+      beta_(iConfig.getParameter<double>("beta")),
+      R0_(iConfig.getParameter<double>("R0")),
+      maxSVDeltaRToJet_(iConfig.getParameter<double>("maxSVDeltaRToJet")),
+      maxDistToAxis_(iConfig.getParameter<edm::ParameterSet>("trackSelection").getParameter<double>("maxDistToAxis")),
+      maxDecayLen_(iConfig.getParameter<edm::ParameterSet>("trackSelection").getParameter<double>("maxDecayLen")),
+      trackPairV0Filter(iConfig.getParameter<edm::ParameterSet>("trackPairV0Filter")),
+      trackSelector(iConfig.getParameter<edm::ParameterSet>("trackSelection")) {
+  produces<std::vector<reco::BoostedDoubleSVTagInfo> >();
 }
 
-
-BoostedDoubleSVProducer::~BoostedDoubleSVProducer()
-{
-
-   // do anything here that needs to be done at destruction time
-   // (e.g. close files, deallocate resources etc.)
-
+BoostedDoubleSVProducer::~BoostedDoubleSVProducer() {
+  // do anything here that needs to be done at destruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-BoostedDoubleSVProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   // get the track builder
-   edm::ESHandle<TransientTrackBuilder> trackBuilder;
-   iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",trackBuilder);
-
-   // get input secondary vertex TagInfos
-   edm::Handle<std::vector<reco::CandSecondaryVertexTagInfo> > svTagInfos;
-   iEvent.getByToken(svTagInfos_, svTagInfos);
-
-   // create the output collection
-   auto tagInfos = std::make_unique<std::vector<reco::BoostedDoubleSVTagInfo> >();
-
-   // loop over TagInfos
-   for(std::vector<reco::CandSecondaryVertexTagInfo>::const_iterator iterTI = svTagInfos->begin(); iterTI != svTagInfos->end(); ++iterTI)
-   {
-     // get TagInfos
-     const reco::CandIPTagInfo              & ipTagInfo = *(iterTI->trackIPTagInfoRef().get());
-     const reco::CandSecondaryVertexTagInfo & svTagInfo = *(iterTI);
-
-     // default variable values
-     float z_ratio = dummyZ_ratio;
-     float trackSip3dSig_3 = dummyTrackSip3dSig, trackSip3dSig_2 = dummyTrackSip3dSig, trackSip3dSig_1 = dummyTrackSip3dSig, trackSip3dSig_0 = dummyTrackSip3dSig;
-     float tau2_trackSip3dSig_0 = dummyTrackSip3dSig, tau1_trackSip3dSig_0 = dummyTrackSip3dSig, tau2_trackSip3dSig_1 = dummyTrackSip3dSig, tau1_trackSip3dSig_1 = dummyTrackSip3dSig;
-     float trackSip2dSigAboveCharm_0 = dummyTrackSip2dSigAbove, trackSip2dSigAboveBottom_0 = dummyTrackSip2dSigAbove, trackSip2dSigAboveBottom_1 = dummyTrackSip2dSigAbove;
-     float tau1_trackEtaRel_0 = dummyTrackEtaRel, tau1_trackEtaRel_1 = dummyTrackEtaRel, tau1_trackEtaRel_2 = dummyTrackEtaRel;
-     float tau2_trackEtaRel_0 = dummyTrackEtaRel, tau2_trackEtaRel_1 = dummyTrackEtaRel, tau2_trackEtaRel_2 = dummyTrackEtaRel;
-     float tau1_vertexMass = dummyVertexMass, tau1_vertexEnergyRatio = dummyVertexEnergyRatio, tau1_vertexDeltaR = dummyVertexDeltaR, tau1_flightDistance2dSig = dummyFlightDistance2dSig;
-     float tau2_vertexMass = dummyVertexMass, tau2_vertexEnergyRatio = dummyVertexEnergyRatio, tau2_vertexDeltaR = dummyVertexDeltaR, tau2_flightDistance2dSig = dummyFlightDistance2dSig;
-     float jetNTracks = 0, nSV = 0, tau1_nSecondaryVertices = 0, tau2_nSecondaryVertices = 0;
-
-     // get the jet reference
-     const reco::JetBaseRef jet = svTagInfo.jet();
-
-     std::vector<fastjet::PseudoJet> currentAxes;
-     float tau2, tau1;
-     // calculate N-subjettiness
-     calcNsubjettiness(jet, tau1, tau2, currentAxes);
-
-     const reco::VertexRef & vertexRef = ipTagInfo.primaryVertex();
-     GlobalPoint pv(0.,0.,0.);
-     if ( ipTagInfo.primaryVertex().isNonnull() )
-       pv = GlobalPoint(vertexRef->x(),vertexRef->y(),vertexRef->z());
-
-     const std::vector<reco::CandidatePtr> & selectedTracks = ipTagInfo.selectedTracks();
-     const std::vector<reco::btag::TrackIPData> & ipData = ipTagInfo.impactParameterData();
-     size_t trackSize = selectedTracks.size();
-
-
-     reco::TrackKinematics allKinematics;
-     std::vector<float> IP3Ds, IP3Ds_1, IP3Ds_2;
-     int contTrk=0;
-
-     // loop over tracks associated to the jet
-     for (size_t itt=0; itt < trackSize; ++itt)
-     {
-       const reco::CandidatePtr trackRef = selectedTracks[itt];
-
-       float track_PVweight = 0.;
-       setTracksPV(trackRef, vertexRef, track_PVweight);
-       if (track_PVweight>0.5) allKinematics.add(trackRef);
-
-       const reco::btag::TrackIPData &data = ipData[itt];
-       bool isSelected = false;
-       if (trackSelector(trackRef, data, *jet, pv)) isSelected = true;
-
-       // check if the track is from V0
-       bool isfromV0 = false, isfromV0Tight = false;
-       std::vector<reco::CandidatePtr> trackPairV0Test(2);
-
-       trackPairV0Test[0] = trackRef;
-
-       for (size_t jtt=0; jtt < trackSize; ++jtt)
-       {
-         if (itt == jtt) continue;
-
-         const reco::btag::TrackIPData & pairTrackData = ipData[jtt];
-         const reco::CandidatePtr pairTrackRef = selectedTracks[jtt];
-
-         trackPairV0Test[1] = pairTrackRef;
-
-         if (!trackPairV0Filter(trackPairV0Test))
-         {
-           isfromV0 = true;
-
-           if ( trackSelector(pairTrackRef, pairTrackData, *jet, pv) )
-             isfromV0Tight = true;
-         }
-
-         if (isfromV0 && isfromV0Tight)
-           break;
-       }
-
-       if( isSelected && !isfromV0Tight ) jetNTracks += 1.;
-
-       reco::TransientTrack transientTrack = trackBuilder->build(trackRef);
-       GlobalVector direction(jet->px(), jet->py(), jet->pz());
-
-       int index = 0;
-       if (currentAxes.size() > 1 && reco::deltaR2(trackRef->momentum(),currentAxes[1]) < reco::deltaR2(trackRef->momentum(),currentAxes[0]))
-           index = 1;
-       direction = GlobalVector(currentAxes[index].px(), currentAxes[index].py(), currentAxes[index].pz());
-
-       // decay distance and track distance wrt to the closest tau axis
-       float decayLengthTau=-1;
-       float distTauAxis=-1;
+void BoostedDoubleSVProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // get the track builder
+  edm::ESHandle<TransientTrackBuilder> trackBuilder;
+  iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", trackBuilder);
+
+  // get input secondary vertex TagInfos
+  edm::Handle<std::vector<reco::CandSecondaryVertexTagInfo> > svTagInfos;
+  iEvent.getByToken(svTagInfos_, svTagInfos);
+
+  // create the output collection
+  auto tagInfos = std::make_unique<std::vector<reco::BoostedDoubleSVTagInfo> >();
+
+  // loop over TagInfos
+  for (std::vector<reco::CandSecondaryVertexTagInfo>::const_iterator iterTI = svTagInfos->begin();
+       iterTI != svTagInfos->end();
+       ++iterTI) {
+    // get TagInfos
+    const reco::CandIPTagInfo& ipTagInfo = *(iterTI->trackIPTagInfoRef().get());
+    const reco::CandSecondaryVertexTagInfo& svTagInfo = *(iterTI);
+
+    // default variable values
+    float z_ratio = dummyZ_ratio;
+    float trackSip3dSig_3 = dummyTrackSip3dSig, trackSip3dSig_2 = dummyTrackSip3dSig,
+          trackSip3dSig_1 = dummyTrackSip3dSig, trackSip3dSig_0 = dummyTrackSip3dSig;
+    float tau2_trackSip3dSig_0 = dummyTrackSip3dSig, tau1_trackSip3dSig_0 = dummyTrackSip3dSig,
+          tau2_trackSip3dSig_1 = dummyTrackSip3dSig, tau1_trackSip3dSig_1 = dummyTrackSip3dSig;
+    float trackSip2dSigAboveCharm_0 = dummyTrackSip2dSigAbove, trackSip2dSigAboveBottom_0 = dummyTrackSip2dSigAbove,
+          trackSip2dSigAboveBottom_1 = dummyTrackSip2dSigAbove;
+    float tau1_trackEtaRel_0 = dummyTrackEtaRel, tau1_trackEtaRel_1 = dummyTrackEtaRel,
+          tau1_trackEtaRel_2 = dummyTrackEtaRel;
+    float tau2_trackEtaRel_0 = dummyTrackEtaRel, tau2_trackEtaRel_1 = dummyTrackEtaRel,
+          tau2_trackEtaRel_2 = dummyTrackEtaRel;
+    float tau1_vertexMass = dummyVertexMass, tau1_vertexEnergyRatio = dummyVertexEnergyRatio,
+          tau1_vertexDeltaR = dummyVertexDeltaR, tau1_flightDistance2dSig = dummyFlightDistance2dSig;
+    float tau2_vertexMass = dummyVertexMass, tau2_vertexEnergyRatio = dummyVertexEnergyRatio,
+          tau2_vertexDeltaR = dummyVertexDeltaR, tau2_flightDistance2dSig = dummyFlightDistance2dSig;
+    float jetNTracks = 0, nSV = 0, tau1_nSecondaryVertices = 0, tau2_nSecondaryVertices = 0;
+
+    // get the jet reference
+    const reco::JetBaseRef jet = svTagInfo.jet();
+
+    std::vector<fastjet::PseudoJet> currentAxes;
+    float tau2, tau1;
+    // calculate N-subjettiness
+    calcNsubjettiness(jet, tau1, tau2, currentAxes);
+
+    const reco::VertexRef& vertexRef = ipTagInfo.primaryVertex();
+    GlobalPoint pv(0., 0., 0.);
+    if (ipTagInfo.primaryVertex().isNonnull())
+      pv = GlobalPoint(vertexRef->x(), vertexRef->y(), vertexRef->z());
+
+    const std::vector<reco::CandidatePtr>& selectedTracks = ipTagInfo.selectedTracks();
+    const std::vector<reco::btag::TrackIPData>& ipData = ipTagInfo.impactParameterData();
+    size_t trackSize = selectedTracks.size();
+
+    reco::TrackKinematics allKinematics;
+    std::vector<float> IP3Ds, IP3Ds_1, IP3Ds_2;
+    int contTrk = 0;
+
+    // loop over tracks associated to the jet
+    for (size_t itt = 0; itt < trackSize; ++itt) {
+      const reco::CandidatePtr trackRef = selectedTracks[itt];
+
+      float track_PVweight = 0.;
+      setTracksPV(trackRef, vertexRef, track_PVweight);
+      if (track_PVweight > 0.5)
+        allKinematics.add(trackRef);
+
+      const reco::btag::TrackIPData& data = ipData[itt];
+      bool isSelected = false;
+      if (trackSelector(trackRef, data, *jet, pv))
+        isSelected = true;
+
+      // check if the track is from V0
+      bool isfromV0 = false, isfromV0Tight = false;
+      std::vector<reco::CandidatePtr> trackPairV0Test(2);
+
+      trackPairV0Test[0] = trackRef;
+
+      for (size_t jtt = 0; jtt < trackSize; ++jtt) {
+        if (itt == jtt)
+          continue;
+
+        const reco::btag::TrackIPData& pairTrackData = ipData[jtt];
+        const reco::CandidatePtr pairTrackRef = selectedTracks[jtt];
+
+        trackPairV0Test[1] = pairTrackRef;
+
+        if (!trackPairV0Filter(trackPairV0Test)) {
+          isfromV0 = true;
+
+          if (trackSelector(pairTrackRef, pairTrackData, *jet, pv))
+            isfromV0Tight = true;
+        }
+
+        if (isfromV0 && isfromV0Tight)
+          break;
+      }
+
+      if (isSelected && !isfromV0Tight)
+        jetNTracks += 1.;
 
-       TrajectoryStateOnSurface closest = IPTools::closestApproachToJet(transientTrack.impactPointState(), *vertexRef , direction, transientTrack.field());
-       if (closest.isValid())
-         decayLengthTau =  (closest.globalPosition() - RecoVertex::convertPos(vertexRef->position())).mag();
+      reco::TransientTrack transientTrack = trackBuilder->build(trackRef);
+      GlobalVector direction(jet->px(), jet->py(), jet->pz());
 
-       distTauAxis = std::abs(IPTools::jetTrackDistance(transientTrack, direction, *vertexRef ).second.value());
+      int index = 0;
+      if (currentAxes.size() > 1 &&
+          reco::deltaR2(trackRef->momentum(), currentAxes[1]) < reco::deltaR2(trackRef->momentum(), currentAxes[0]))
+        index = 1;
+      direction = GlobalVector(currentAxes[index].px(), currentAxes[index].py(), currentAxes[index].pz());
 
-       float IP3Dsig = ipTagInfo.impactParameterData()[itt].ip3d.significance();
+      // decay distance and track distance wrt to the closest tau axis
+      float decayLengthTau = -1;
+      float distTauAxis = -1;
 
-       if( !isfromV0 && decayLengthTau<maxDecayLen_ && distTauAxis<maxDistToAxis_ )
-       {
-         IP3Ds.push_back( IP3Dsig<-50. ? -50. : IP3Dsig );
-         ++contTrk;
-         if (currentAxes.size() > 1)
-         {
-           if (reco::deltaR2(trackRef->momentum(),currentAxes[0]) < reco::deltaR2(trackRef->momentum(),currentAxes[1]))
-             IP3Ds_1.push_back( IP3Dsig<-50. ? -50. : IP3Dsig );
-           else
-             IP3Ds_2.push_back( IP3Dsig<-50. ? -50. : IP3Dsig );
-         }
-         else
-           IP3Ds_1.push_back( IP3Dsig<-50. ? -50. : IP3Dsig );
-       }
-     }
+      TrajectoryStateOnSurface closest = IPTools::closestApproachToJet(
+          transientTrack.impactPointState(), *vertexRef, direction, transientTrack.field());
+      if (closest.isValid())
+        decayLengthTau = (closest.globalPosition() - RecoVertex::convertPos(vertexRef->position())).mag();
 
-     std::vector<size_t> indices = ipTagInfo.sortedIndexes(reco::btag::IP2DSig);
-     bool charmThreshSet = false;
+      distTauAxis = std::abs(IPTools::jetTrackDistance(transientTrack, direction, *vertexRef).second.value());
 
-     reco::TrackKinematics kin;
-     for (size_t i=0; i<indices.size(); ++i)
-     {
-       size_t idx = indices[i];
-       const reco::btag::TrackIPData & data = ipData[idx];
-       const reco::CandidatePtr trackRef = selectedTracks[idx];
+      float IP3Dsig = ipTagInfo.impactParameterData()[itt].ip3d.significance();
 
-       kin.add(trackRef);
+      if (!isfromV0 && decayLengthTau < maxDecayLen_ && distTauAxis < maxDistToAxis_) {
+        IP3Ds.push_back(IP3Dsig < -50. ? -50. : IP3Dsig);
+        ++contTrk;
+        if (currentAxes.size() > 1) {
+          if (reco::deltaR2(trackRef->momentum(), currentAxes[0]) < reco::deltaR2(trackRef->momentum(), currentAxes[1]))
+            IP3Ds_1.push_back(IP3Dsig < -50. ? -50. : IP3Dsig);
+          else
+            IP3Ds_2.push_back(IP3Dsig < -50. ? -50. : IP3Dsig);
+        } else
+          IP3Ds_1.push_back(IP3Dsig < -50. ? -50. : IP3Dsig);
+      }
+    }
 
-       if ( kin.vectorSum().M() > charmThreshold // charm cut
-            && !charmThreshSet )
-       {
-         trackSip2dSigAboveCharm_0 = data.ip2d.significance();
+    std::vector<size_t> indices = ipTagInfo.sortedIndexes(reco::btag::IP2DSig);
+    bool charmThreshSet = false;
 
-         charmThreshSet = true;
-       }
+    reco::TrackKinematics kin;
+    for (size_t i = 0; i < indices.size(); ++i) {
+      size_t idx = indices[i];
+      const reco::btag::TrackIPData& data = ipData[idx];
+      const reco::CandidatePtr trackRef = selectedTracks[idx];
 
-       if ( kin.vectorSum().M() > bottomThreshold ) // bottom cut
-       {
-         trackSip2dSigAboveBottom_0 = data.ip2d.significance();
-         if ( (i+1)<indices.size() ) trackSip2dSigAboveBottom_1 = (ipData[indices[i+1]]).ip2d.significance();
+      kin.add(trackRef);
 
-         break;
-       }
-     }
+      if (kin.vectorSum().M() > charmThreshold  // charm cut
+          && !charmThreshSet) {
+        trackSip2dSigAboveCharm_0 = data.ip2d.significance();
 
-     float dummyTrack = -50.;
+        charmThreshSet = true;
+      }
 
-     std::sort( IP3Ds.begin(),IP3Ds.end(),std::greater<float>() );
-     std::sort( IP3Ds_1.begin(),IP3Ds_1.end(),std::greater<float>() );
-     std::sort( IP3Ds_2.begin(),IP3Ds_2.end(),std::greater<float>() );
-     int num_1 = IP3Ds_1.size();
-     int num_2 = IP3Ds_2.size();
+      if (kin.vectorSum().M() > bottomThreshold)  // bottom cut
+      {
+        trackSip2dSigAboveBottom_0 = data.ip2d.significance();
+        if ((i + 1) < indices.size())
+          trackSip2dSigAboveBottom_1 = (ipData[indices[i + 1]]).ip2d.significance();
 
-     switch(contTrk){
-             case 0:
+        break;
+      }
+    }
 
-                     trackSip3dSig_0 = dummyTrack;
-                     trackSip3dSig_1 = dummyTrack;
-                     trackSip3dSig_2 = dummyTrack;
-                     trackSip3dSig_3 = dummyTrack;
+    float dummyTrack = -50.;
 
-                     break;
+    std::sort(IP3Ds.begin(), IP3Ds.end(), std::greater<float>());
+    std::sort(IP3Ds_1.begin(), IP3Ds_1.end(), std::greater<float>());
+    std::sort(IP3Ds_2.begin(), IP3Ds_2.end(), std::greater<float>());
+    int num_1 = IP3Ds_1.size();
+    int num_2 = IP3Ds_2.size();
 
-             case 1:
+    switch (contTrk) {
+      case 0:
 
-                     trackSip3dSig_0 = IP3Ds.at(0);
-                     trackSip3dSig_1 = dummyTrack;
-                     trackSip3dSig_2 = dummyTrack;
-                     trackSip3dSig_3 = dummyTrack;
+        trackSip3dSig_0 = dummyTrack;
+        trackSip3dSig_1 = dummyTrack;
+        trackSip3dSig_2 = dummyTrack;
+        trackSip3dSig_3 = dummyTrack;
 
-                     break;
+        break;
 
-             case 2:
+      case 1:
 
-                     trackSip3dSig_0 = IP3Ds.at(0);
-                     trackSip3dSig_1 = IP3Ds.at(1);
-                     trackSip3dSig_2 = dummyTrack;
-                     trackSip3dSig_3 = dummyTrack;
+        trackSip3dSig_0 = IP3Ds.at(0);
+        trackSip3dSig_1 = dummyTrack;
+        trackSip3dSig_2 = dummyTrack;
+        trackSip3dSig_3 = dummyTrack;
 
-                     break;
+        break;
 
-             case 3:
+      case 2:
 
-                     trackSip3dSig_0 = IP3Ds.at(0);
-                     trackSip3dSig_1 = IP3Ds.at(1);
-                     trackSip3dSig_2 = IP3Ds.at(2);
-                     trackSip3dSig_3 = dummyTrack;
-
-                     break;
-
-             default:
-
-                     trackSip3dSig_0 = IP3Ds.at(0);
-                     trackSip3dSig_1 = IP3Ds.at(1);
-                     trackSip3dSig_2 = IP3Ds.at(2);
-                     trackSip3dSig_3 = IP3Ds.at(3);
-
-     }
-
-     switch(num_1){
-             case 0:
-
-                     tau1_trackSip3dSig_0 = dummyTrack;
-                     tau1_trackSip3dSig_1 = dummyTrack;
-
-                     break;
-
-             case 1:
-
-                     tau1_trackSip3dSig_0 = IP3Ds_1.at(0);
-                     tau1_trackSip3dSig_1 = dummyTrack;
-
-                     break;
-
-             default:
-
-                     tau1_trackSip3dSig_0 = IP3Ds_1.at(0);
-                     tau1_trackSip3dSig_1 = IP3Ds_1.at(1);
-
-     }
-
-     switch(num_2){
-             case 0:
-
-                      tau2_trackSip3dSig_0 = dummyTrack;
-                      tau2_trackSip3dSig_1 = dummyTrack;
-
-                      break;
+        trackSip3dSig_0 = IP3Ds.at(0);
+        trackSip3dSig_1 = IP3Ds.at(1);
+        trackSip3dSig_2 = dummyTrack;
+        trackSip3dSig_3 = dummyTrack;
+
+        break;
 
-             case 1:
-                      tau2_trackSip3dSig_0 = IP3Ds_2.at(0);
-                      tau2_trackSip3dSig_1 = dummyTrack;
+      case 3:
+
+        trackSip3dSig_0 = IP3Ds.at(0);
+        trackSip3dSig_1 = IP3Ds.at(1);
+        trackSip3dSig_2 = IP3Ds.at(2);
+        trackSip3dSig_3 = dummyTrack;
+
+        break;
+
+      default:
+
+        trackSip3dSig_0 = IP3Ds.at(0);
+        trackSip3dSig_1 = IP3Ds.at(1);
+        trackSip3dSig_2 = IP3Ds.at(2);
+        trackSip3dSig_3 = IP3Ds.at(3);
+    }
+
+    switch (num_1) {
+      case 0:
+
+        tau1_trackSip3dSig_0 = dummyTrack;
+        tau1_trackSip3dSig_1 = dummyTrack;
+
+        break;
+
+      case 1:
+
+        tau1_trackSip3dSig_0 = IP3Ds_1.at(0);
+        tau1_trackSip3dSig_1 = dummyTrack;
+
+        break;
+
+      default:
+
+        tau1_trackSip3dSig_0 = IP3Ds_1.at(0);
+        tau1_trackSip3dSig_1 = IP3Ds_1.at(1);
+    }
+
+    switch (num_2) {
+      case 0:
+
+        tau2_trackSip3dSig_0 = dummyTrack;
+        tau2_trackSip3dSig_1 = dummyTrack;
 
-                      break;
+        break;
+
+      case 1:
+        tau2_trackSip3dSig_0 = IP3Ds_2.at(0);
+        tau2_trackSip3dSig_1 = dummyTrack;
 
-             default:
+        break;
 
-                      tau2_trackSip3dSig_0 = IP3Ds_2.at(0);
-                      tau2_trackSip3dSig_1 = IP3Ds_2.at(1);
+      default:
 
-     }
+        tau2_trackSip3dSig_0 = IP3Ds_2.at(0);
+        tau2_trackSip3dSig_1 = IP3Ds_2.at(1);
+    }
 
-     math::XYZVector jetDir = jet->momentum().Unit();
-     reco::TrackKinematics tau1Kinematics;
-     reco::TrackKinematics tau2Kinematics;
-     std::vector<float> tau1_trackEtaRels, tau2_trackEtaRels;
+    math::XYZVector jetDir = jet->momentum().Unit();
+    reco::TrackKinematics tau1Kinematics;
+    reco::TrackKinematics tau2Kinematics;
+    std::vector<float> tau1_trackEtaRels, tau2_trackEtaRels;
 
-     std::map<double, size_t> VTXmap;
-     for (size_t vtx = 0; vtx < svTagInfo.nVertices(); ++vtx)
-     {
-       const reco::VertexCompositePtrCandidate& vertex = svTagInfo.secondaryVertex(vtx);
-       // get the vertex kinematics
-       reco::TrackKinematics vertexKinematic(vertex);
+    std::map<double, size_t> VTXmap;
+    for (size_t vtx = 0; vtx < svTagInfo.nVertices(); ++vtx) {
+      const reco::VertexCompositePtrCandidate& vertex = svTagInfo.secondaryVertex(vtx);
+      // get the vertex kinematics
+      reco::TrackKinematics vertexKinematic(vertex);
 
-       if (currentAxes.size() > 1)
-       {
-               if (reco::deltaR2(svTagInfo.flightDirection(vtx),currentAxes[1]) < reco::deltaR2(svTagInfo.flightDirection(vtx),currentAxes[0]))
-               {
-                       tau2Kinematics = tau2Kinematics + vertexKinematic;
-                       if( tau2_flightDistance2dSig < 0 )
-                       {
-                         tau2_flightDistance2dSig = svTagInfo.flightDistance(vtx,true).significance();
-                         tau2_vertexDeltaR = reco::deltaR(svTagInfo.flightDirection(vtx),currentAxes[1]);
-                       }
-                       etaRelToTauAxis(vertex, currentAxes[1], tau2_trackEtaRels);
-                       tau2_nSecondaryVertices += 1.;
-               }
-               else
-               {
-                       tau1Kinematics = tau1Kinematics + vertexKinematic;
-                       if( tau1_flightDistance2dSig < 0 )
-                       {
-                         tau1_flightDistance2dSig =svTagInfo.flightDistance(vtx,true).significance();
-                         tau1_vertexDeltaR = reco::deltaR(svTagInfo.flightDirection(vtx),currentAxes[0]);
-                       }
-                       etaRelToTauAxis(vertex, currentAxes[0], tau1_trackEtaRels);
-                       tau1_nSecondaryVertices += 1.;
-               }
+      if (currentAxes.size() > 1) {
+        if (reco::deltaR2(svTagInfo.flightDirection(vtx), currentAxes[1]) <
+            reco::deltaR2(svTagInfo.flightDirection(vtx), currentAxes[0])) {
+          tau2Kinematics = tau2Kinematics + vertexKinematic;
+          if (tau2_flightDistance2dSig < 0) {
+            tau2_flightDistance2dSig = svTagInfo.flightDistance(vtx, true).significance();
+            tau2_vertexDeltaR = reco::deltaR(svTagInfo.flightDirection(vtx), currentAxes[1]);
+          }
+          etaRelToTauAxis(vertex, currentAxes[1], tau2_trackEtaRels);
+          tau2_nSecondaryVertices += 1.;
+        } else {
+          tau1Kinematics = tau1Kinematics + vertexKinematic;
+          if (tau1_flightDistance2dSig < 0) {
+            tau1_flightDistance2dSig = svTagInfo.flightDistance(vtx, true).significance();
+            tau1_vertexDeltaR = reco::deltaR(svTagInfo.flightDirection(vtx), currentAxes[0]);
+          }
+          etaRelToTauAxis(vertex, currentAxes[0], tau1_trackEtaRels);
+          tau1_nSecondaryVertices += 1.;
+        }
 
-       }
-       else if (!currentAxes.empty())
-       {
-               tau1Kinematics = tau1Kinematics + vertexKinematic;
-               if( tau1_flightDistance2dSig < 0 )
-               {
-                 tau1_flightDistance2dSig =svTagInfo.flightDistance(vtx,true).significance();
-                 tau1_vertexDeltaR = reco::deltaR(svTagInfo.flightDirection(vtx),currentAxes[0]);
-               }
-               etaRelToTauAxis(vertex, currentAxes[0], tau1_trackEtaRels);
-               tau1_nSecondaryVertices += 1.;
-       }
+      } else if (!currentAxes.empty()) {
+        tau1Kinematics = tau1Kinematics + vertexKinematic;
+        if (tau1_flightDistance2dSig < 0) {
+          tau1_flightDistance2dSig = svTagInfo.flightDistance(vtx, true).significance();
+          tau1_vertexDeltaR = reco::deltaR(svTagInfo.flightDirection(vtx), currentAxes[0]);
+        }
+        etaRelToTauAxis(vertex, currentAxes[0], tau1_trackEtaRels);
+        tau1_nSecondaryVertices += 1.;
+      }
 
-       const GlobalVector& flightDir = svTagInfo.flightDirection(vtx);
-       if (reco::deltaR2(flightDir, jetDir)<(maxSVDeltaRToJet_*maxSVDeltaRToJet_))
-         VTXmap[svTagInfo.flightDistance(vtx).error()]=vtx;
-     }
-     nSV = VTXmap.size();
+      const GlobalVector& flightDir = svTagInfo.flightDirection(vtx);
+      if (reco::deltaR2(flightDir, jetDir) < (maxSVDeltaRToJet_ * maxSVDeltaRToJet_))
+        VTXmap[svTagInfo.flightDistance(vtx).error()] = vtx;
+    }
+    nSV = VTXmap.size();
 
+    math::XYZTLorentzVector allSum = allKinematics.weightedVectorSum();
+    if (tau1_nSecondaryVertices > 0.) {
+      const math::XYZTLorentzVector& tau1_vertexSum = tau1Kinematics.weightedVectorSum();
+      if (allSum.E() > 0.)
+        tau1_vertexEnergyRatio = tau1_vertexSum.E() / allSum.E();
+      if (tau1_vertexEnergyRatio > 50.)
+        tau1_vertexEnergyRatio = 50.;
 
-     math::XYZTLorentzVector allSum = allKinematics.weightedVectorSum() ;
-     if ( tau1_nSecondaryVertices > 0. )
-     {
-       const math::XYZTLorentzVector& tau1_vertexSum = tau1Kinematics.weightedVectorSum();
-       if ( allSum.E() > 0. ) tau1_vertexEnergyRatio = tau1_vertexSum.E() / allSum.E();
-       if ( tau1_vertexEnergyRatio > 50. ) tau1_vertexEnergyRatio = 50.;
+      tau1_vertexMass = tau1_vertexSum.M();
+    }
 
-       tau1_vertexMass = tau1_vertexSum.M();
-     }
+    if (tau2_nSecondaryVertices > 0.) {
+      const math::XYZTLorentzVector& tau2_vertexSum = tau2Kinematics.weightedVectorSum();
+      if (allSum.E() > 0.)
+        tau2_vertexEnergyRatio = tau2_vertexSum.E() / allSum.E();
+      if (tau2_vertexEnergyRatio > 50.)
+        tau2_vertexEnergyRatio = 50.;
 
-     if ( tau2_nSecondaryVertices > 0. )
-     {
-       const math::XYZTLorentzVector& tau2_vertexSum = tau2Kinematics.weightedVectorSum();
-       if ( allSum.E() > 0. ) tau2_vertexEnergyRatio = tau2_vertexSum.E() / allSum.E();
-       if ( tau2_vertexEnergyRatio > 50. ) tau2_vertexEnergyRatio = 50.;
+      tau2_vertexMass = tau2_vertexSum.M();
+    }
 
-       tau2_vertexMass= tau2_vertexSum.M();
-     }
+    float dummyEtaRel = -1.;
 
+    std::sort(tau1_trackEtaRels.begin(), tau1_trackEtaRels.end());
+    std::sort(tau2_trackEtaRels.begin(), tau2_trackEtaRels.end());
 
-     float dummyEtaRel = -1.;
+    switch (tau2_trackEtaRels.size()) {
+      case 0:
 
-     std::sort( tau1_trackEtaRels.begin(),tau1_trackEtaRels.end() );
-     std::sort( tau2_trackEtaRels.begin(),tau2_trackEtaRels.end() );
+        tau2_trackEtaRel_0 = dummyEtaRel;
+        tau2_trackEtaRel_1 = dummyEtaRel;
+        tau2_trackEtaRel_2 = dummyEtaRel;
 
-     switch(tau2_trackEtaRels.size()){
-             case 0:
+        break;
 
-                     tau2_trackEtaRel_0 = dummyEtaRel;
-                     tau2_trackEtaRel_1 = dummyEtaRel;
-                     tau2_trackEtaRel_2 = dummyEtaRel;
+      case 1:
 
-                     break;
+        tau2_trackEtaRel_0 = tau2_trackEtaRels.at(0);
+        tau2_trackEtaRel_1 = dummyEtaRel;
+        tau2_trackEtaRel_2 = dummyEtaRel;
 
-             case 1:
+        break;
 
-                     tau2_trackEtaRel_0 = tau2_trackEtaRels.at(0);
-                     tau2_trackEtaRel_1 = dummyEtaRel;
-                     tau2_trackEtaRel_2 = dummyEtaRel;
+      case 2:
 
-                     break;
+        tau2_trackEtaRel_0 = tau2_trackEtaRels.at(0);
+        tau2_trackEtaRel_1 = tau2_trackEtaRels.at(1);
+        tau2_trackEtaRel_2 = dummyEtaRel;
 
-             case 2:
+        break;
 
-                     tau2_trackEtaRel_0 = tau2_trackEtaRels.at(0);
-                     tau2_trackEtaRel_1 = tau2_trackEtaRels.at(1);
-                     tau2_trackEtaRel_2 = dummyEtaRel;
+      default:
 
-                     break;
+        tau2_trackEtaRel_0 = tau2_trackEtaRels.at(0);
+        tau2_trackEtaRel_1 = tau2_trackEtaRels.at(1);
+        tau2_trackEtaRel_2 = tau2_trackEtaRels.at(2);
+    }
 
-             default:
+    switch (tau1_trackEtaRels.size()) {
+      case 0:
 
-                     tau2_trackEtaRel_0 = tau2_trackEtaRels.at(0);
-                     tau2_trackEtaRel_1 = tau2_trackEtaRels.at(1);
-                     tau2_trackEtaRel_2 = tau2_trackEtaRels.at(2);
-
-     }
-
-     switch(tau1_trackEtaRels.size()){
-             case 0:
-
-                     tau1_trackEtaRel_0 = dummyEtaRel;
-                     tau1_trackEtaRel_1 = dummyEtaRel;
-                     tau1_trackEtaRel_2 = dummyEtaRel;
-
-                     break;
-
-             case 1:
-
-                     tau1_trackEtaRel_0 = tau1_trackEtaRels.at(0);
-                     tau1_trackEtaRel_1 = dummyEtaRel;
-                     tau1_trackEtaRel_2 = dummyEtaRel;
-
-                     break;
-
-             case 2:
-
-                     tau1_trackEtaRel_0 = tau1_trackEtaRels.at(0);
-                     tau1_trackEtaRel_1 = tau1_trackEtaRels.at(1);
-                     tau1_trackEtaRel_2 = dummyEtaRel;
-
-                     break;
-
-             default:
-
-                     tau1_trackEtaRel_0 = tau1_trackEtaRels.at(0);
-                     tau1_trackEtaRel_1 = tau1_trackEtaRels.at(1);
-                     tau1_trackEtaRel_2 = tau1_trackEtaRels.at(2);
-
-     }
-
-     int cont=0;
-     GlobalVector flightDir_0, flightDir_1;
-     reco::Candidate::LorentzVector SV_p4_0 , SV_p4_1;
-     double vtxMass = 0.;
-
-     for ( std::map<double, size_t>::iterator iVtx=VTXmap.begin(); iVtx!=VTXmap.end(); ++iVtx)
-     {
-       ++cont;
-       const reco::VertexCompositePtrCandidate &vertex = svTagInfo.secondaryVertex(iVtx->second);
-       if (cont==1)
-       {
-         flightDir_0 = svTagInfo.flightDirection(iVtx->second);
-         SV_p4_0 = vertex.p4();
-         vtxMass = SV_p4_0.mass();
-
-         if(vtxMass > 0.)
-           z_ratio = reco::deltaR(currentAxes[1],currentAxes[0])*SV_p4_0.pt()/vtxMass;
-       }
-       if (cont==2)
-       {
-         flightDir_1 = svTagInfo.flightDirection(iVtx->second);
-         SV_p4_1 = vertex.p4();
-         vtxMass = (SV_p4_1+SV_p4_0).mass();
-
-         if(vtxMass > 0.)
-           z_ratio = reco::deltaR(flightDir_0,flightDir_1)*SV_p4_1.pt()/vtxMass;
-
-         break;
-       }
-     }
-
-     // when only one tau axis has SVs assigned, they are all assigned to the 1st tau axis
-     // in the special case below need to swap values
-     if( (tau1_vertexMass<0 && tau2_vertexMass>0) )
-     {
-       float temp = tau1_trackEtaRel_0;
-       tau1_trackEtaRel_0= tau2_trackEtaRel_0;
-       tau2_trackEtaRel_0= temp;
-
-       temp = tau1_trackEtaRel_1;
-       tau1_trackEtaRel_1= tau2_trackEtaRel_1;
-       tau2_trackEtaRel_1= temp;
-
-       temp = tau1_trackEtaRel_2;
-       tau1_trackEtaRel_2= tau2_trackEtaRel_2;
-       tau2_trackEtaRel_2= temp;
-
-       temp = tau1_flightDistance2dSig;
-       tau1_flightDistance2dSig= tau2_flightDistance2dSig;
-       tau2_flightDistance2dSig= temp;
-
-       tau1_vertexDeltaR= tau2_vertexDeltaR;
-
-       temp = tau1_vertexEnergyRatio;
-       tau1_vertexEnergyRatio= tau2_vertexEnergyRatio;
-       tau2_vertexEnergyRatio= temp;
-
-       temp = tau1_vertexMass;
-       tau1_vertexMass= tau2_vertexMass;
-       tau2_vertexMass= temp;
-     }
-
-     reco::TaggingVariableList vars;
-
-     vars.insert(reco::btau::jetNTracks, jetNTracks, true);
-     vars.insert(reco::btau::jetNSecondaryVertices, nSV, true);
-     vars.insert(reco::btau::trackSip3dSig_0, trackSip3dSig_0, true);
-     vars.insert(reco::btau::trackSip3dSig_1, trackSip3dSig_1, true);
-     vars.insert(reco::btau::trackSip3dSig_2, trackSip3dSig_2, true);
-     vars.insert(reco::btau::trackSip3dSig_3, trackSip3dSig_3, true);
-     vars.insert(reco::btau::tau1_trackSip3dSig_0, tau1_trackSip3dSig_0, true);
-     vars.insert(reco::btau::tau1_trackSip3dSig_1, tau1_trackSip3dSig_1, true);
-     vars.insert(reco::btau::tau2_trackSip3dSig_0, tau2_trackSip3dSig_0, true);
-     vars.insert(reco::btau::tau2_trackSip3dSig_1, tau2_trackSip3dSig_1, true);
-     vars.insert(reco::btau::trackSip2dSigAboveCharm, trackSip2dSigAboveCharm_0, true);
-     vars.insert(reco::btau::trackSip2dSigAboveBottom_0, trackSip2dSigAboveBottom_0, true);
-     vars.insert(reco::btau::trackSip2dSigAboveBottom_1, trackSip2dSigAboveBottom_1, true);
-     vars.insert(reco::btau::tau1_trackEtaRel_0, tau1_trackEtaRel_0, true);
-     vars.insert(reco::btau::tau1_trackEtaRel_1, tau1_trackEtaRel_1, true);
-     vars.insert(reco::btau::tau1_trackEtaRel_2, tau1_trackEtaRel_2, true);
-     vars.insert(reco::btau::tau2_trackEtaRel_0, tau2_trackEtaRel_0, true);
-     vars.insert(reco::btau::tau2_trackEtaRel_1, tau2_trackEtaRel_1, true);
-     vars.insert(reco::btau::tau2_trackEtaRel_2, tau2_trackEtaRel_2, true);
-     vars.insert(reco::btau::tau1_vertexMass, tau1_vertexMass, true);
-     vars.insert(reco::btau::tau1_vertexEnergyRatio, tau1_vertexEnergyRatio, true);
-     vars.insert(reco::btau::tau1_flightDistance2dSig, tau1_flightDistance2dSig, true);
-     vars.insert(reco::btau::tau1_vertexDeltaR, tau1_vertexDeltaR, true);
-     vars.insert(reco::btau::tau2_vertexMass, tau2_vertexMass, true);
-     vars.insert(reco::btau::tau2_vertexEnergyRatio, tau2_vertexEnergyRatio, true);
-     vars.insert(reco::btau::tau2_flightDistance2dSig, tau2_flightDistance2dSig, true);
-     vars.insert(reco::btau::z_ratio, z_ratio, true);
-
-     vars.finalize();
-
-     tagInfos->push_back( reco::BoostedDoubleSVTagInfo(vars, edm::Ref<std::vector<reco::CandSecondaryVertexTagInfo> >(svTagInfos, iterTI - svTagInfos->begin())) );
-   }
-
-   // put the output in the event
-   iEvent.put( std::move(tagInfos) );
+        tau1_trackEtaRel_0 = dummyEtaRel;
+        tau1_trackEtaRel_1 = dummyEtaRel;
+        tau1_trackEtaRel_2 = dummyEtaRel;
+
+        break;
+
+      case 1:
+
+        tau1_trackEtaRel_0 = tau1_trackEtaRels.at(0);
+        tau1_trackEtaRel_1 = dummyEtaRel;
+        tau1_trackEtaRel_2 = dummyEtaRel;
+
+        break;
+
+      case 2:
+
+        tau1_trackEtaRel_0 = tau1_trackEtaRels.at(0);
+        tau1_trackEtaRel_1 = tau1_trackEtaRels.at(1);
+        tau1_trackEtaRel_2 = dummyEtaRel;
+
+        break;
+
+      default:
+
+        tau1_trackEtaRel_0 = tau1_trackEtaRels.at(0);
+        tau1_trackEtaRel_1 = tau1_trackEtaRels.at(1);
+        tau1_trackEtaRel_2 = tau1_trackEtaRels.at(2);
+    }
+
+    int cont = 0;
+    GlobalVector flightDir_0, flightDir_1;
+    reco::Candidate::LorentzVector SV_p4_0, SV_p4_1;
+    double vtxMass = 0.;
+
+    for (std::map<double, size_t>::iterator iVtx = VTXmap.begin(); iVtx != VTXmap.end(); ++iVtx) {
+      ++cont;
+      const reco::VertexCompositePtrCandidate& vertex = svTagInfo.secondaryVertex(iVtx->second);
+      if (cont == 1) {
+        flightDir_0 = svTagInfo.flightDirection(iVtx->second);
+        SV_p4_0 = vertex.p4();
+        vtxMass = SV_p4_0.mass();
+
+        if (vtxMass > 0.)
+          z_ratio = reco::deltaR(currentAxes[1], currentAxes[0]) * SV_p4_0.pt() / vtxMass;
+      }
+      if (cont == 2) {
+        flightDir_1 = svTagInfo.flightDirection(iVtx->second);
+        SV_p4_1 = vertex.p4();
+        vtxMass = (SV_p4_1 + SV_p4_0).mass();
+
+        if (vtxMass > 0.)
+          z_ratio = reco::deltaR(flightDir_0, flightDir_1) * SV_p4_1.pt() / vtxMass;
+
+        break;
+      }
+    }
+
+    // when only one tau axis has SVs assigned, they are all assigned to the 1st tau axis
+    // in the special case below need to swap values
+    if ((tau1_vertexMass < 0 && tau2_vertexMass > 0)) {
+      float temp = tau1_trackEtaRel_0;
+      tau1_trackEtaRel_0 = tau2_trackEtaRel_0;
+      tau2_trackEtaRel_0 = temp;
+
+      temp = tau1_trackEtaRel_1;
+      tau1_trackEtaRel_1 = tau2_trackEtaRel_1;
+      tau2_trackEtaRel_1 = temp;
+
+      temp = tau1_trackEtaRel_2;
+      tau1_trackEtaRel_2 = tau2_trackEtaRel_2;
+      tau2_trackEtaRel_2 = temp;
+
+      temp = tau1_flightDistance2dSig;
+      tau1_flightDistance2dSig = tau2_flightDistance2dSig;
+      tau2_flightDistance2dSig = temp;
+
+      tau1_vertexDeltaR = tau2_vertexDeltaR;
+
+      temp = tau1_vertexEnergyRatio;
+      tau1_vertexEnergyRatio = tau2_vertexEnergyRatio;
+      tau2_vertexEnergyRatio = temp;
+
+      temp = tau1_vertexMass;
+      tau1_vertexMass = tau2_vertexMass;
+      tau2_vertexMass = temp;
+    }
+
+    reco::TaggingVariableList vars;
+
+    vars.insert(reco::btau::jetNTracks, jetNTracks, true);
+    vars.insert(reco::btau::jetNSecondaryVertices, nSV, true);
+    vars.insert(reco::btau::trackSip3dSig_0, trackSip3dSig_0, true);
+    vars.insert(reco::btau::trackSip3dSig_1, trackSip3dSig_1, true);
+    vars.insert(reco::btau::trackSip3dSig_2, trackSip3dSig_2, true);
+    vars.insert(reco::btau::trackSip3dSig_3, trackSip3dSig_3, true);
+    vars.insert(reco::btau::tau1_trackSip3dSig_0, tau1_trackSip3dSig_0, true);
+    vars.insert(reco::btau::tau1_trackSip3dSig_1, tau1_trackSip3dSig_1, true);
+    vars.insert(reco::btau::tau2_trackSip3dSig_0, tau2_trackSip3dSig_0, true);
+    vars.insert(reco::btau::tau2_trackSip3dSig_1, tau2_trackSip3dSig_1, true);
+    vars.insert(reco::btau::trackSip2dSigAboveCharm, trackSip2dSigAboveCharm_0, true);
+    vars.insert(reco::btau::trackSip2dSigAboveBottom_0, trackSip2dSigAboveBottom_0, true);
+    vars.insert(reco::btau::trackSip2dSigAboveBottom_1, trackSip2dSigAboveBottom_1, true);
+    vars.insert(reco::btau::tau1_trackEtaRel_0, tau1_trackEtaRel_0, true);
+    vars.insert(reco::btau::tau1_trackEtaRel_1, tau1_trackEtaRel_1, true);
+    vars.insert(reco::btau::tau1_trackEtaRel_2, tau1_trackEtaRel_2, true);
+    vars.insert(reco::btau::tau2_trackEtaRel_0, tau2_trackEtaRel_0, true);
+    vars.insert(reco::btau::tau2_trackEtaRel_1, tau2_trackEtaRel_1, true);
+    vars.insert(reco::btau::tau2_trackEtaRel_2, tau2_trackEtaRel_2, true);
+    vars.insert(reco::btau::tau1_vertexMass, tau1_vertexMass, true);
+    vars.insert(reco::btau::tau1_vertexEnergyRatio, tau1_vertexEnergyRatio, true);
+    vars.insert(reco::btau::tau1_flightDistance2dSig, tau1_flightDistance2dSig, true);
+    vars.insert(reco::btau::tau1_vertexDeltaR, tau1_vertexDeltaR, true);
+    vars.insert(reco::btau::tau2_vertexMass, tau2_vertexMass, true);
+    vars.insert(reco::btau::tau2_vertexEnergyRatio, tau2_vertexEnergyRatio, true);
+    vars.insert(reco::btau::tau2_flightDistance2dSig, tau2_flightDistance2dSig, true);
+    vars.insert(reco::btau::z_ratio, z_ratio, true);
+
+    vars.finalize();
+
+    tagInfos->push_back(reco::BoostedDoubleSVTagInfo(
+        vars, edm::Ref<std::vector<reco::CandSecondaryVertexTagInfo> >(svTagInfos, iterTI - svTagInfos->begin())));
+  }
+
+  // put the output in the event
+  iEvent.put(std::move(tagInfos));
 }
 
-
-void
-BoostedDoubleSVProducer::calcNsubjettiness(const reco::JetBaseRef & jet, float & tau1, float & tau2, std::vector<fastjet::PseudoJet> & currentAxes) const
-{
+void BoostedDoubleSVProducer::calcNsubjettiness(const reco::JetBaseRef& jet,
+                                                float& tau1,
+                                                float& tau2,
+                                                std::vector<fastjet::PseudoJet>& currentAxes) const {
   std::vector<fastjet::PseudoJet> fjParticles;
 
   // loop over jet constituents and push them in the vector of FastJet constituents
-  for(const reco::CandidatePtr & daughter : jet->daughterPtrVector())
-  {
-    if ( daughter.isNonnull() && daughter.isAvailable() )
-    {
-      const reco::Jet * subjet = dynamic_cast<const reco::Jet *>(daughter.get());
+  for (const reco::CandidatePtr& daughter : jet->daughterPtrVector()) {
+    if (daughter.isNonnull() && daughter.isAvailable()) {
+      const reco::Jet* subjet = dynamic_cast<const reco::Jet*>(daughter.get());
       // if the daughter is actually a subjet
-      if( subjet && daughter->numberOfDaughters() > 1 )
-      {
+      if (subjet && daughter->numberOfDaughters() > 1) {
         // loop over subjet constituents and push them in the vector of FastJet constituents
-        for(size_t i=0; i<daughter->numberOfDaughters(); ++i)
-        {
-          const reco::Candidate * constit = daughter->daughter(i);
+        for (size_t i = 0; i < daughter->numberOfDaughters(); ++i) {
+          const reco::Candidate* constit = daughter->daughter(i);
 
-          if ( constit )
-            fjParticles.push_back( fastjet::PseudoJet( constit->px(), constit->py(), constit->pz(), constit->energy() ) );
+          if (constit)
+            fjParticles.push_back(fastjet::PseudoJet(constit->px(), constit->py(), constit->pz(), constit->energy()));
           else
-            edm::LogWarning("MissingJetConstituent") << "Jet constituent required for N-subjettiness computation is missing!";
+            edm::LogWarning("MissingJetConstituent")
+                << "Jet constituent required for N-subjettiness computation is missing!";
         }
-      }
-      else
-        fjParticles.push_back( fastjet::PseudoJet( daughter->px(), daughter->py(), daughter->pz(), daughter->energy() ) );
-    }
-    else
+      } else
+        fjParticles.push_back(fastjet::PseudoJet(daughter->px(), daughter->py(), daughter->pz(), daughter->energy()));
+    } else
       edm::LogWarning("MissingJetConstituent") << "Jet constituent required for N-subjettiness computation is missing!";
   }
 
   // N-subjettiness calculator
-  fastjet::contrib::Njettiness njettiness(fastjet::contrib::OnePass_KT_Axes(), fastjet::contrib::NormalizedMeasure(beta_,R0_));
+  fastjet::contrib::Njettiness njettiness(fastjet::contrib::OnePass_KT_Axes(),
+                                          fastjet::contrib::NormalizedMeasure(beta_, R0_));
 
   // calculate N-subjettiness
   tau1 = njettiness.getTau(1, fjParticles);
@@ -690,78 +671,64 @@ BoostedDoubleSVProducer::calcNsubjettiness(const reco::JetBaseRef & jet, float &
   currentAxes = njettiness.currentAxes();
 }
 
-
-void
-BoostedDoubleSVProducer::setTracksPVBase(const reco::TrackRef & trackRef, const reco::VertexRef & vertexRef, float & PVweight) const
-{
+void BoostedDoubleSVProducer::setTracksPVBase(const reco::TrackRef& trackRef,
+                                              const reco::VertexRef& vertexRef,
+                                              float& PVweight) const {
   PVweight = 0.;
 
-  const reco::TrackBaseRef trackBaseRef( trackRef );
+  const reco::TrackBaseRef trackBaseRef(trackRef);
 
   typedef reco::Vertex::trackRef_iterator IT;
 
-  const reco::Vertex & vtx = *(vertexRef);
+  const reco::Vertex& vtx = *(vertexRef);
   // loop over tracks in vertices
-  for(IT it=vtx.tracks_begin(); it!=vtx.tracks_end(); ++it)
-  {
-    const reco::TrackBaseRef & baseRef = *it;
+  for (IT it = vtx.tracks_begin(); it != vtx.tracks_end(); ++it) {
+    const reco::TrackBaseRef& baseRef = *it;
     // one of the tracks in the vertex is the same as the track considered in the function
-    if( baseRef == trackBaseRef )
-    {
+    if (baseRef == trackBaseRef) {
       PVweight = vtx.trackWeight(baseRef);
       break;
     }
   }
 }
 
-
-void
-BoostedDoubleSVProducer::setTracksPV(const reco::CandidatePtr & trackRef, const reco::VertexRef & vertexRef, float & PVweight) const
-{
+void BoostedDoubleSVProducer::setTracksPV(const reco::CandidatePtr& trackRef,
+                                          const reco::VertexRef& vertexRef,
+                                          float& PVweight) const {
   PVweight = 0.;
 
-  const pat::PackedCandidate * pcand = dynamic_cast<const pat::PackedCandidate *>(trackRef.get());
+  const pat::PackedCandidate* pcand = dynamic_cast<const pat::PackedCandidate*>(trackRef.get());
 
-  if(pcand) // MiniAOD case
+  if (pcand)  // MiniAOD case
   {
-    if( pcand->fromPV() == pat::PackedCandidate::PVUsedInFit )
-    {
+    if (pcand->fromPV() == pat::PackedCandidate::PVUsedInFit) {
       PVweight = 1.;
     }
-  }
-  else
-  {
-    const reco::PFCandidate * pfcand = dynamic_cast<const reco::PFCandidate *>(trackRef.get());
+  } else {
+    const reco::PFCandidate* pfcand = dynamic_cast<const reco::PFCandidate*>(trackRef.get());
 
     setTracksPVBase(pfcand->trackRef(), vertexRef, PVweight);
   }
 }
 
-
-void
-BoostedDoubleSVProducer::etaRelToTauAxis(const reco::VertexCompositePtrCandidate & vertex, const fastjet::PseudoJet & tauAxis, std::vector<float> & tau_trackEtaRel) const
-{
+void BoostedDoubleSVProducer::etaRelToTauAxis(const reco::VertexCompositePtrCandidate& vertex,
+                                              const fastjet::PseudoJet& tauAxis,
+                                              std::vector<float>& tau_trackEtaRel) const {
   math::XYZVector direction(tauAxis.px(), tauAxis.py(), tauAxis.pz());
-  const std::vector<reco::CandidatePtr> & tracks = vertex.daughterPtrVector();
+  const std::vector<reco::CandidatePtr>& tracks = vertex.daughterPtrVector();
 
-  for(std::vector<reco::CandidatePtr>::const_iterator track = tracks.begin(); track != tracks.end(); ++track)
+  for (std::vector<reco::CandidatePtr>::const_iterator track = tracks.begin(); track != tracks.end(); ++track)
     tau_trackEtaRel.push_back(std::abs(reco::btau::etaRel(direction.Unit(), (*track)->momentum())));
 }
 
 // ------------ method called once each stream before processing any runs, lumis or events  ------------
-void
-BoostedDoubleSVProducer::beginStream(edm::StreamID)
-{
-}
+void BoostedDoubleSVProducer::beginStream(edm::StreamID) {}
 
 // ------------ method called once each stream after processing all runs, lumis and events  ------------
-void
-BoostedDoubleSVProducer::endStream() {
-}
+void BoostedDoubleSVProducer::endStream() {}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
-void
-BoostedDoubleSVProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void BoostedDoubleSVProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;

--- a/RecoBTag/SecondaryVertex/plugins/BtoCharmDecayVertexMerger.cc
+++ b/RecoBTag/SecondaryVertex/plugins/BtoCharmDecayVertexMerger.cc
@@ -22,12 +22,12 @@
 
 #include <algorithm>
 
-reco::Candidate::LorentzVector vtxP4(const reco::VertexCompositePtrCandidate & vtx) {
+reco::Candidate::LorentzVector vtxP4(const reco::VertexCompositePtrCandidate &vtx) {
   reco::Candidate::LorentzVector sum;
-  const std::vector<reco::CandidatePtr> & tracks = vtx.daughterPtrVector();
+  const std::vector<reco::CandidatePtr> &tracks = vtx.daughterPtrVector();
 
-  for(std::vector<reco::CandidatePtr>::const_iterator track = tracks.begin(); track != tracks.end(); ++track) {
-    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> > vec;
+  for (std::vector<reco::CandidatePtr>::const_iterator track = tracks.begin(); track != tracks.end(); ++track) {
+    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double>> vec;
     vec.SetPx((*track)->px());
     vec.SetPy((*track)->py());
     vec.SetPz((*track)->pz());
@@ -37,261 +37,256 @@ reco::Candidate::LorentzVector vtxP4(const reco::VertexCompositePtrCandidate & v
   return sum;
 }
 
-template<typename VTX>
+template <typename VTX>
 class BtoCharmDecayVertexMergerT : public edm::stream::EDProducer<> {
-    public:
-       BtoCharmDecayVertexMergerT(const edm::ParameterSet &params);
+public:
+  BtoCharmDecayVertexMergerT(const edm::ParameterSet &params);
 
-       void produce(edm::Event &event, const edm::EventSetup &es) override;
+  void produce(edm::Event &event, const edm::EventSetup &es) override;
 
-       typedef reco::TemplatedSecondaryVertex<VTX> SecondaryVertex;
+  typedef reco::TemplatedSecondaryVertex<VTX> SecondaryVertex;
 
-    private:
-       edm::EDGetTokenT<reco::VertexCollection>  token_primaryVertex;
-       edm::EDGetTokenT<edm::View<VTX> >         token_secondaryVertex;
-       reco::Vertex                              pv;
-       // double                                    maxFraction;
-       // double                                    minSignificance;
+private:
+  edm::EDGetTokenT<reco::VertexCollection> token_primaryVertex;
+  edm::EDGetTokenT<edm::View<VTX>> token_secondaryVertex;
+  reco::Vertex pv;
+  // double                                    maxFraction;
+  // double                                    minSignificance;
 
-       double maxDRForUnique, maxvecSumIMCUTForUnique, minCosPAtomerge, maxPtreltomerge;
+  double maxDRForUnique, maxvecSumIMCUTForUnique, minCosPAtomerge, maxPtreltomerge;
 
-       // a vertex proxy for sorting using stl
-       struct VertexProxy{
-         VTX vert;
-         double invm;
-         size_t ntracks;
-       };
+  // a vertex proxy for sorting using stl
+  struct VertexProxy {
+    VTX vert;
+    double invm;
+    size_t ntracks;
+  };
 
-       // comparison operator for VertexProxy, used in sorting
-       friend bool operator<(VertexProxy v1, VertexProxy v2){
-         if(v1.ntracks>2 && v2.ntracks<3) return true;
-         if(v1.ntracks<3 && v2.ntracks>2) return false;
-         return (v1.invm>v2.invm);
-       }
+  // comparison operator for VertexProxy, used in sorting
+  friend bool operator<(VertexProxy v1, VertexProxy v2) {
+    if (v1.ntracks > 2 && v2.ntracks < 3)
+      return true;
+    if (v1.ntracks < 3 && v2.ntracks > 2)
+      return false;
+    return (v1.invm > v2.invm);
+  }
 
-       VertexProxy buildVertexProxy(const VTX & vtx);
+  VertexProxy buildVertexProxy(const VTX &vtx);
 
-       void resolveBtoDchain(std::vector<VertexProxy>& coll, unsigned int i, unsigned int k);
-       GlobalVector flightDirection(const reco::Vertex &v1, const reco::Vertex &v2);
-       GlobalVector flightDirection(const reco::Vertex &v1, const reco::VertexCompositePtrCandidate &v2);
-       GlobalVector flightDirection(const reco::VertexCompositePtrCandidate &v1, const reco::VertexCompositePtrCandidate &v2);
+  void resolveBtoDchain(std::vector<VertexProxy> &coll, unsigned int i, unsigned int k);
+  GlobalVector flightDirection(const reco::Vertex &v1, const reco::Vertex &v2);
+  GlobalVector flightDirection(const reco::Vertex &v1, const reco::VertexCompositePtrCandidate &v2);
+  GlobalVector flightDirection(const reco::VertexCompositePtrCandidate &v1,
+                               const reco::VertexCompositePtrCandidate &v2);
 };
 
-
-template<typename VTX>
-BtoCharmDecayVertexMergerT<VTX>::BtoCharmDecayVertexMergerT(const edm::ParameterSet &params) :
-       token_primaryVertex(consumes<reco::VertexCollection>(params.getParameter<edm::InputTag>("primaryVertices"))),
-       token_secondaryVertex(consumes<edm::View<VTX> >(params.getParameter<edm::InputTag>("secondaryVertices"))),
-       maxDRForUnique(params.getParameter<double>("maxDRUnique")),
-       maxvecSumIMCUTForUnique(params.getParameter<double>("maxvecSumIMifsmallDRUnique")),
-       minCosPAtomerge(params.getParameter<double>("minCosPAtomerge")),
-       maxPtreltomerge(params.getParameter<double>("maxPtreltomerge"))
-       // maxFraction(params.getParameter<double>("maxFraction")),
-       // minSignificance(params.getParameter<double>("minSignificance"))
+template <typename VTX>
+BtoCharmDecayVertexMergerT<VTX>::BtoCharmDecayVertexMergerT(const edm::ParameterSet &params)
+    : token_primaryVertex(consumes<reco::VertexCollection>(params.getParameter<edm::InputTag>("primaryVertices"))),
+      token_secondaryVertex(consumes<edm::View<VTX>>(params.getParameter<edm::InputTag>("secondaryVertices"))),
+      maxDRForUnique(params.getParameter<double>("maxDRUnique")),
+      maxvecSumIMCUTForUnique(params.getParameter<double>("maxvecSumIMifsmallDRUnique")),
+      minCosPAtomerge(params.getParameter<double>("minCosPAtomerge")),
+      maxPtreltomerge(params.getParameter<double>("maxPtreltomerge"))
+// maxFraction(params.getParameter<double>("maxFraction")),
+// minSignificance(params.getParameter<double>("minSignificance"))
 {
-       produces<std::vector<VTX> >();
+  produces<std::vector<VTX>>();
 }
 //------------------------------------
-template<typename VTX>
-void BtoCharmDecayVertexMergerT<VTX>::produce(edm::Event &iEvent, const edm::EventSetup &iSetup){
-
+template <typename VTX>
+void BtoCharmDecayVertexMergerT<VTX>::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   using namespace reco;
   // PV
   edm::Handle<reco::VertexCollection> PVcoll;
   iEvent.getByToken(token_primaryVertex, PVcoll);
 
-  if(!PVcoll->empty()) {
+  if (!PVcoll->empty()) {
+    const reco::VertexCollection pvc = *(PVcoll.product());
+    pv = pvc[0];
 
-  const reco::VertexCollection pvc = *( PVcoll.product());
-  pv = pvc[0];
+    // get the IVF collection
+    edm::Handle<edm::View<VTX>> secondaryVertices;
+    iEvent.getByToken(token_secondaryVertex, secondaryVertices);
 
-  // get the IVF collection
-  edm::Handle<edm::View<VTX> > secondaryVertices;
-  iEvent.getByToken(token_secondaryVertex, secondaryVertices);
-
-
-
-  //loop over vertices,  fill into own collection for sorting
-  std::vector<VertexProxy> vertexProxyColl;
-  for(typename edm::View<VTX>::const_iterator sv = secondaryVertices->begin();
-      sv != secondaryVertices->end(); ++sv) {
-    vertexProxyColl.push_back( buildVertexProxy(*sv) );
-  }
-
-  // sort the vertices by mass and track multiplicity
-  sort( vertexProxyColl.begin(), vertexProxyColl.end());
-
-
-  // loop forward over all vertices
-  for(unsigned int iVtx=0; iVtx < vertexProxyColl.size(); ++iVtx){
-
-    // nested loop backwards (in order to start from light masses)
-    // check all vertices against each other for B->D chain
-    for(unsigned int kVtx=vertexProxyColl.size()-1; kVtx>iVtx; --kVtx){
-      // remove D vertices from the collection and add the tracks to the original one
-      resolveBtoDchain(vertexProxyColl, iVtx, kVtx);
+    //loop over vertices,  fill into own collection for sorting
+    std::vector<VertexProxy> vertexProxyColl;
+    for (typename edm::View<VTX>::const_iterator sv = secondaryVertices->begin(); sv != secondaryVertices->end();
+         ++sv) {
+      vertexProxyColl.push_back(buildVertexProxy(*sv));
     }
-  }
 
-  // now create new vertex collection and add to event
-  auto bvertColl = std::make_unique<std::vector<VTX>>();
-  for(typename std::vector<VertexProxy>::const_iterator it=vertexProxyColl.begin(); it!=vertexProxyColl.end(); ++it) bvertColl->push_back((*it).vert);
-  iEvent.put(std::move(bvertColl));
-  }
-  else{
+    // sort the vertices by mass and track multiplicity
+    sort(vertexProxyColl.begin(), vertexProxyColl.end());
+
+    // loop forward over all vertices
+    for (unsigned int iVtx = 0; iVtx < vertexProxyColl.size(); ++iVtx) {
+      // nested loop backwards (in order to start from light masses)
+      // check all vertices against each other for B->D chain
+      for (unsigned int kVtx = vertexProxyColl.size() - 1; kVtx > iVtx; --kVtx) {
+        // remove D vertices from the collection and add the tracks to the original one
+        resolveBtoDchain(vertexProxyColl, iVtx, kVtx);
+      }
+    }
+
+    // now create new vertex collection and add to event
+    auto bvertColl = std::make_unique<std::vector<VTX>>();
+    for (typename std::vector<VertexProxy>::const_iterator it = vertexProxyColl.begin(); it != vertexProxyColl.end();
+         ++it)
+      bvertColl->push_back((*it).vert);
+    iEvent.put(std::move(bvertColl));
+  } else {
     iEvent.put(std::make_unique<std::vector<VTX>>());
   }
 }
 //------------------------------------
-template<typename VTX>
-GlobalVector
-BtoCharmDecayVertexMergerT<VTX>::flightDirection(const reco::Vertex & v1, const reco::Vertex & v2) {
-  return  GlobalVector(v2.x() - v1.x(),
-                       v2.y() - v1.y(),
-                       v2.z() - v1.z());
+template <typename VTX>
+GlobalVector BtoCharmDecayVertexMergerT<VTX>::flightDirection(const reco::Vertex &v1, const reco::Vertex &v2) {
+  return GlobalVector(v2.x() - v1.x(), v2.y() - v1.y(), v2.z() - v1.z());
 }
 
-template<typename VTX>
-GlobalVector
-BtoCharmDecayVertexMergerT<VTX>::flightDirection(const reco::Vertex & v1, const reco::VertexCompositePtrCandidate & v2) {
-  return  GlobalVector(v2.vertex().x() - v1.x(),
-                       v2.vertex().y() - v1.y(),
-                       v2.vertex().z() - v1.z());
+template <typename VTX>
+GlobalVector BtoCharmDecayVertexMergerT<VTX>::flightDirection(const reco::Vertex &v1,
+                                                              const reco::VertexCompositePtrCandidate &v2) {
+  return GlobalVector(v2.vertex().x() - v1.x(), v2.vertex().y() - v1.y(), v2.vertex().z() - v1.z());
 }
 
-template<typename VTX>
-GlobalVector
-BtoCharmDecayVertexMergerT<VTX>::flightDirection(const reco::VertexCompositePtrCandidate & v1, const reco::VertexCompositePtrCandidate & v2) {
-  return  GlobalVector(v2.vertex().x() - v1.vertex().x(),
-                       v2.vertex().y() - v1.vertex().y(),
-                       v2.vertex().z() - v1.vertex().z());
+template <typename VTX>
+GlobalVector BtoCharmDecayVertexMergerT<VTX>::flightDirection(const reco::VertexCompositePtrCandidate &v1,
+                                                              const reco::VertexCompositePtrCandidate &v2) {
+  return GlobalVector(
+      v2.vertex().x() - v1.vertex().x(), v2.vertex().y() - v1.vertex().y(), v2.vertex().z() - v1.vertex().z());
 }
 //-------------- template specializations --------------------
 
 // -------------- buildVertexProxy ----------------
-template<>
-BtoCharmDecayVertexMergerT<reco::Vertex>::VertexProxy
-BtoCharmDecayVertexMergerT<reco::Vertex>::buildVertexProxy(const reco::Vertex & vtx) {
-  VertexProxy vtxProxy = {vtx,vtx.p4().M(),vtx.tracksSize()};
+template <>
+BtoCharmDecayVertexMergerT<reco::Vertex>::VertexProxy BtoCharmDecayVertexMergerT<reco::Vertex>::buildVertexProxy(
+    const reco::Vertex &vtx) {
+  VertexProxy vtxProxy = {vtx, vtx.p4().M(), vtx.tracksSize()};
   return vtxProxy;
 }
 
-template<>
+template <>
 BtoCharmDecayVertexMergerT<reco::VertexCompositePtrCandidate>::VertexProxy
-BtoCharmDecayVertexMergerT<reco::VertexCompositePtrCandidate>::buildVertexProxy(const reco::VertexCompositePtrCandidate & vtx) {
-  VertexProxy vtxProxy = {vtx,vtxP4(vtx).M(),vtx.numberOfSourceCandidatePtrs()};
+BtoCharmDecayVertexMergerT<reco::VertexCompositePtrCandidate>::buildVertexProxy(
+    const reco::VertexCompositePtrCandidate &vtx) {
+  VertexProxy vtxProxy = {vtx, vtxP4(vtx).M(), vtx.numberOfSourceCandidatePtrs()};
   return vtxProxy;
 }
 
 // -------------- resolveBtoDchain ----------------
-template<>
-void BtoCharmDecayVertexMergerT<reco::Vertex>::resolveBtoDchain(std::vector<VertexProxy>& coll, unsigned int i, unsigned int k){
+template <>
+void BtoCharmDecayVertexMergerT<reco::Vertex>::resolveBtoDchain(std::vector<VertexProxy> &coll,
+                                                                unsigned int i,
+                                                                unsigned int k) {
   using namespace reco;
 
   GlobalVector momentum1 = GlobalVector(coll[i].vert.p4().X(), coll[i].vert.p4().Y(), coll[i].vert.p4().Z());
   GlobalVector momentum2 = GlobalVector(coll[k].vert.p4().X(), coll[k].vert.p4().Y(), coll[k].vert.p4().Z());
 
-  SecondaryVertex sv1(pv, coll[i].vert, momentum1 , true);
-  SecondaryVertex sv2(pv, coll[k].vert, momentum2 , true);
-
+  SecondaryVertex sv1(pv, coll[i].vert, momentum1, true);
+  SecondaryVertex sv2(pv, coll[k].vert, momentum2, true);
 
   // find out which one is near and far
   SecondaryVertex svNear = sv1;
-  SecondaryVertex svFar  = sv2;
-  GlobalVector momentumNear  = momentum1;
-  GlobalVector momentumFar   = momentum2;
+  SecondaryVertex svFar = sv2;
+  GlobalVector momentumNear = momentum1;
+  GlobalVector momentumFar = momentum2;
 
   // swap if it is the other way around
-  if(sv1.dist3d().value() >= sv2.dist3d().value()){
+  if (sv1.dist3d().value() >= sv2.dist3d().value()) {
     svNear = sv2;
     svFar = sv1;
     momentumNear = momentum2;
     momentumFar = momentum1;
   }
-  GlobalVector nearToFar = flightDirection( svNear, svFar);
-  GlobalVector pvToNear  = flightDirection( pv, svNear);
-  GlobalVector pvToFar   = flightDirection( pv, svFar);
+  GlobalVector nearToFar = flightDirection(svNear, svFar);
+  GlobalVector pvToNear = flightDirection(pv, svNear);
+  GlobalVector pvToFar = flightDirection(pv, svFar);
 
-  double cosPA =  nearToFar.dot(momentumFar) / momentumFar.mag()/ nearToFar.mag();
-  double cosa  =  pvToNear. dot(momentumFar) / pvToNear.mag()   / momentumFar.mag();
-  double ptrel = sqrt(1.0 - cosa*cosa)* momentumFar.mag();
+  double cosPA = nearToFar.dot(momentumFar) / momentumFar.mag() / nearToFar.mag();
+  double cosa = pvToNear.dot(momentumFar) / pvToNear.mag() / momentumFar.mag();
+  double ptrel = sqrt(1.0 - cosa * cosa) * momentumFar.mag();
 
   double vertexDeltaR = Geom::deltaR(pvToNear, pvToFar);
 
   // create a set of all tracks from both vertices, avoid double counting by using a std::set<>
   std::set<reco::TrackRef> trackrefs;
   // first vertex
-  for(reco::Vertex::trackRef_iterator ti = sv1.tracks_begin(); ti!=sv1.tracks_end(); ++ti){
-    if(sv1.trackWeight(*ti)>0.5){
+  for (reco::Vertex::trackRef_iterator ti = sv1.tracks_begin(); ti != sv1.tracks_end(); ++ti) {
+    if (sv1.trackWeight(*ti) > 0.5) {
       reco::TrackRef t = ti->castTo<reco::TrackRef>();
       trackrefs.insert(t);
     }
   }
   // second vertex
-  for(reco::Vertex::trackRef_iterator ti = sv2.tracks_begin(); ti!=sv2.tracks_end(); ++ti){
-    if(sv2.trackWeight(*ti)>0.5){
+  for (reco::Vertex::trackRef_iterator ti = sv2.tracks_begin(); ti != sv2.tracks_end(); ++ti) {
+    if (sv2.trackWeight(*ti) > 0.5) {
       reco::TrackRef t = ti->castTo<reco::TrackRef>();
       trackrefs.insert(t);
     }
   }
 
   // now calculate one LorentzVector from the track momenta
-  ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> > mother;
-  for(std::set<reco::TrackRef>::const_iterator it = trackrefs.begin(); it!= trackrefs.end(); ++it){
-    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> >  temp ( (*it)->px(),(*it)->py(),(*it)->pz(), ParticleMasses::piPlus );
+  ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double>> mother;
+  for (std::set<reco::TrackRef>::const_iterator it = trackrefs.begin(); it != trackrefs.end(); ++it) {
+    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double>> temp(
+        (*it)->px(), (*it)->py(), (*it)->pz(), ParticleMasses::piPlus);
     mother += temp;
   }
 
-
   //   check if criteria for merging are fulfilled
-  if(vertexDeltaR<maxDRForUnique && mother.M()<maxvecSumIMCUTForUnique && cosPA>minCosPAtomerge && std::abs(ptrel)<maxPtreltomerge ) {
-
-
+  if (vertexDeltaR < maxDRForUnique && mother.M() < maxvecSumIMCUTForUnique && cosPA > minCosPAtomerge &&
+      std::abs(ptrel) < maxPtreltomerge) {
     // add tracks of second vertex which are missing to first vertex
     // loop over the second
-    bool bFoundDuplicate=false;
-    for(reco::Vertex::trackRef_iterator ti = sv2.tracks_begin(); ti!=sv2.tracks_end(); ++ti){
+    bool bFoundDuplicate = false;
+    for (reco::Vertex::trackRef_iterator ti = sv2.tracks_begin(); ti != sv2.tracks_end(); ++ti) {
       reco::Vertex::trackRef_iterator it = find(sv1.tracks_begin(), sv1.tracks_end(), *ti);
-      if (it==sv1.tracks_end()) coll[i].vert.add( *ti, sv2.refittedTrack(*ti), sv2.trackWeight(*ti) );
-      else bFoundDuplicate=true;
+      if (it == sv1.tracks_end())
+        coll[i].vert.add(*ti, sv2.refittedTrack(*ti), sv2.trackWeight(*ti));
+      else
+        bFoundDuplicate = true;
     }
     // in case a duplicate track is found, need to create the full track list in the vertex from scratch because we need to modify the weight.
     // the weight must be the larger one, otherwise we may have outliers which are not real outliers
 
-    if(bFoundDuplicate){
+    if (bFoundDuplicate) {
       // create backup track containers from main vertex
-      std::vector<TrackBaseRef > tracks_;
+      std::vector<TrackBaseRef> tracks_;
       std::vector<Track> refittedTracks_;
       std::vector<float> weights_;
-      for(reco::Vertex::trackRef_iterator it = coll[i].vert.tracks_begin(); it!=coll[i].vert.tracks_end(); ++it) {
-       tracks_.push_back( *it);
-       refittedTracks_.push_back( coll[i].vert.refittedTrack(*it));
-       weights_.push_back( coll[i].vert.trackWeight(*it) );
+      for (reco::Vertex::trackRef_iterator it = coll[i].vert.tracks_begin(); it != coll[i].vert.tracks_end(); ++it) {
+        tracks_.push_back(*it);
+        refittedTracks_.push_back(coll[i].vert.refittedTrack(*it));
+        weights_.push_back(coll[i].vert.trackWeight(*it));
       }
       // delete tracks and add all tracks back, and check in which vertex the weight is larger
       coll[i].vert.removeTracks();
       std::vector<Track>::iterator it2 = refittedTracks_.begin();
       std::vector<float>::iterator it3 = weights_.begin();
-      for(reco::Vertex::trackRef_iterator it = tracks_.begin(); it!=tracks_.end(); ++it, ++it2, ++it3){
-       float weight = *it3;
-       float weight2= sv2.trackWeight(*it);
-       Track refittedTrackWithLargerWeight = *it2;
-       if( weight2 >weight) {
-         weight = weight2;
-         refittedTrackWithLargerWeight = sv2.refittedTrack(*it);
-       }
-       coll[i].vert.add(*it , refittedTrackWithLargerWeight  , weight);
+      for (reco::Vertex::trackRef_iterator it = tracks_.begin(); it != tracks_.end(); ++it, ++it2, ++it3) {
+        float weight = *it3;
+        float weight2 = sv2.trackWeight(*it);
+        Track refittedTrackWithLargerWeight = *it2;
+        if (weight2 > weight) {
+          weight = weight2;
+          refittedTrackWithLargerWeight = sv2.refittedTrack(*it);
+        }
+        coll[i].vert.add(*it, refittedTrackWithLargerWeight, weight);
       }
     }
 
     // remove the second vertex from the collection
-    coll.erase( coll.begin() + k  );
+    coll.erase(coll.begin() + k);
   }
-
 }
 
-template<>
-void BtoCharmDecayVertexMergerT<reco::VertexCompositePtrCandidate>::resolveBtoDchain(std::vector<VertexProxy>& coll, unsigned int i, unsigned int k){
+template <>
+void BtoCharmDecayVertexMergerT<reco::VertexCompositePtrCandidate>::resolveBtoDchain(std::vector<VertexProxy> &coll,
+                                                                                     unsigned int i,
+                                                                                     unsigned int k) {
   using namespace reco;
 
   Candidate::LorentzVector vtx1P4 = vtxP4(coll[i].vert);
@@ -299,72 +294,70 @@ void BtoCharmDecayVertexMergerT<reco::VertexCompositePtrCandidate>::resolveBtoDc
   GlobalVector momentum1 = GlobalVector(vtx1P4.X(), vtx1P4.Y(), vtx1P4.Z());
   GlobalVector momentum2 = GlobalVector(vtx2P4.X(), vtx2P4.Y(), vtx2P4.Z());
 
-  SecondaryVertex sv1(pv, coll[i].vert, momentum1 , true);
-  SecondaryVertex sv2(pv, coll[k].vert, momentum2 , true);
-
+  SecondaryVertex sv1(pv, coll[i].vert, momentum1, true);
+  SecondaryVertex sv2(pv, coll[k].vert, momentum2, true);
 
   // find out which one is near and far
   SecondaryVertex svNear = sv1;
-  SecondaryVertex svFar  = sv2;
-  GlobalVector momentumNear  = momentum1;
-  GlobalVector momentumFar   = momentum2;
+  SecondaryVertex svFar = sv2;
+  GlobalVector momentumNear = momentum1;
+  GlobalVector momentumFar = momentum2;
 
   // swap if it is the other way around
-  if(sv1.dist3d().value() >= sv2.dist3d().value()){
+  if (sv1.dist3d().value() >= sv2.dist3d().value()) {
     svNear = sv2;
     svFar = sv1;
     momentumNear = momentum2;
     momentumFar = momentum1;
   }
-  GlobalVector nearToFar = flightDirection( svNear, svFar);
-  GlobalVector pvToNear  = flightDirection( pv, svNear);
-  GlobalVector pvToFar   = flightDirection( pv, svFar);
+  GlobalVector nearToFar = flightDirection(svNear, svFar);
+  GlobalVector pvToNear = flightDirection(pv, svNear);
+  GlobalVector pvToFar = flightDirection(pv, svFar);
 
-  double cosPA =  nearToFar.dot(momentumFar) / momentumFar.mag()/ nearToFar.mag();
-  double cosa  =  pvToNear. dot(momentumFar) / pvToNear.mag()   / momentumFar.mag();
-  double ptrel = sqrt(1.0 - cosa*cosa)* momentumFar.mag();
+  double cosPA = nearToFar.dot(momentumFar) / momentumFar.mag() / nearToFar.mag();
+  double cosa = pvToNear.dot(momentumFar) / pvToNear.mag() / momentumFar.mag();
+  double ptrel = sqrt(1.0 - cosa * cosa) * momentumFar.mag();
 
   double vertexDeltaR = Geom::deltaR(pvToNear, pvToFar);
 
   // create a set of all tracks from both vertices, avoid double counting by using a std::set<>
   std::set<reco::CandidatePtr> trackrefs;
   // first vertex
-  for(size_t i=0; i < sv1.numberOfSourceCandidatePtrs(); ++i)
-      trackrefs.insert(sv1.daughterPtr(i));
+  for (size_t i = 0; i < sv1.numberOfSourceCandidatePtrs(); ++i)
+    trackrefs.insert(sv1.daughterPtr(i));
   // second vertex
-  for(size_t i=0; i < sv2.numberOfSourceCandidatePtrs(); ++i)
-      trackrefs.insert(sv2.daughterPtr(i));
+  for (size_t i = 0; i < sv2.numberOfSourceCandidatePtrs(); ++i)
+    trackrefs.insert(sv2.daughterPtr(i));
 
   // now calculate one LorentzVector from the track momenta
   Candidate::LorentzVector mother;
-  for(std::set<reco::CandidatePtr>::const_iterator it = trackrefs.begin(); it!= trackrefs.end(); ++it){
-    Candidate::LorentzVector temp ( (*it)->px(),(*it)->py(),(*it)->pz(), ParticleMasses::piPlus );
+  for (std::set<reco::CandidatePtr>::const_iterator it = trackrefs.begin(); it != trackrefs.end(); ++it) {
+    Candidate::LorentzVector temp((*it)->px(), (*it)->py(), (*it)->pz(), ParticleMasses::piPlus);
     mother += temp;
   }
 
   //   check if criteria for merging are fulfilled
-  if(vertexDeltaR<maxDRForUnique && mother.M()<maxvecSumIMCUTForUnique && cosPA>minCosPAtomerge && std::abs(ptrel)<maxPtreltomerge ) {
-
+  if (vertexDeltaR < maxDRForUnique && mother.M() < maxvecSumIMCUTForUnique && cosPA > minCosPAtomerge &&
+      std::abs(ptrel) < maxPtreltomerge) {
     // add tracks of second vertex which are missing to first vertex
     // loop over the second
-    const std::vector<reco::CandidatePtr> & tracks1 = sv1.daughterPtrVector();
-    const std::vector<reco::CandidatePtr> & tracks2 = sv2.daughterPtrVector();
-    for(std::vector<reco::CandidatePtr>::const_iterator ti = tracks2.begin(); ti!=tracks2.end(); ++ti){
+    const std::vector<reco::CandidatePtr> &tracks1 = sv1.daughterPtrVector();
+    const std::vector<reco::CandidatePtr> &tracks2 = sv2.daughterPtrVector();
+    for (std::vector<reco::CandidatePtr>::const_iterator ti = tracks2.begin(); ti != tracks2.end(); ++ti) {
       std::vector<reco::CandidatePtr>::const_iterator it = find(tracks1.begin(), tracks1.end(), *ti);
-      if (it==tracks1.end()) {
-        coll[i].vert.addDaughter( *ti );
-        coll[i].vert.setP4( (*ti)->p4() + coll[i].vert.p4() );
+      if (it == tracks1.end()) {
+        coll[i].vert.addDaughter(*ti);
+        coll[i].vert.setP4((*ti)->p4() + coll[i].vert.p4());
       }
     }
 
     // remove the second vertex from the collection
-    coll.erase( coll.begin() + k  );
+    coll.erase(coll.begin() + k);
   }
 }
 
-
 // define specific instances of the templated BtoCharmDecayVertexMergerT class
-typedef BtoCharmDecayVertexMergerT<reco::Vertex>                      BtoCharmDecayVertexMerger;
+typedef BtoCharmDecayVertexMergerT<reco::Vertex> BtoCharmDecayVertexMerger;
 typedef BtoCharmDecayVertexMergerT<reco::VertexCompositePtrCandidate> CandidateBtoCharmDecayVertexMerger;
 
 // define plugins

--- a/RecoBTag/SecondaryVertex/plugins/JetTagESProducers.cc
+++ b/RecoBTag/SecondaryVertex/plugins/JetTagESProducers.cc
@@ -15,47 +15,74 @@
 #include "RecoBTag/SecondaryVertex/interface/CandidateSimpleSecondaryVertexComputer.h"
 #include "RecoBTag/SecondaryVertex/interface/SimpleSecondaryVertexComputer.h"
 
-namespace { // C++ template pointer want "external" linkage, so here we go
-	extern const char ipTagInfos[] = "ipTagInfos";
-	extern const char svTagInfos[] = "svTagInfos";
-	extern const char muonTagInfos[] = "muonTagInfos";
-	extern const char elecTagInfos[] = "elecTagInfos";
-}
+namespace {  // C++ template pointer want "external" linkage, so here we go
+  extern const char ipTagInfos[] = "ipTagInfos";
+  extern const char svTagInfos[] = "svTagInfos";
+  extern const char muonTagInfos[] = "muonTagInfos";
+  extern const char elecTagInfos[] = "elecTagInfos";
+}  // namespace
 
 typedef GenericMVAJetTagComputerWrapper<CombinedSVComputer,
-	reco::TrackIPTagInfo,         ipTagInfos,
-	reco::SecondaryVertexTagInfo, svTagInfos> CombinedSVJetTagComputer;
+                                        reco::TrackIPTagInfo,
+                                        ipTagInfos,
+                                        reco::SecondaryVertexTagInfo,
+                                        svTagInfos>
+    CombinedSVJetTagComputer;
 
 typedef GenericMVAJetTagComputerWrapper<CombinedSVComputer,
-	reco::CandIPTagInfo,         ipTagInfos,
-	reco::CandSecondaryVertexTagInfo, svTagInfos> CandidateCombinedSVJetTagComputer;
-		
+                                        reco::CandIPTagInfo,
+                                        ipTagInfos,
+                                        reco::CandSecondaryVertexTagInfo,
+                                        svTagInfos>
+    CandidateCombinedSVJetTagComputer;
+
 //this one is actually not fully non-candidate based anymore (no backward compatibility with old SL taginfos for the moment)
 typedef GenericMVAJetTagComputerWrapper<CombinedSVSoftLeptonComputer,
-	reco::TrackIPTagInfo,         ipTagInfos,
-	reco::SecondaryVertexTagInfo, svTagInfos,
-	reco::CandSoftLeptonTagInfo, muonTagInfos,
-	reco::CandSoftLeptonTagInfo, elecTagInfos> CombinedSVSoftLeptonJetTagComputer;
-		
-typedef GenericMVAJetTagComputerWrapper<CombinedSVSoftLeptonComputer,
-	reco::CandIPTagInfo,         ipTagInfos,
-	reco::CandSecondaryVertexTagInfo, svTagInfos,
-	reco::CandSoftLeptonTagInfo, muonTagInfos,
-	reco::CandSoftLeptonTagInfo, elecTagInfos> CandidateCombinedSVSoftLeptonJetTagComputer;
-
-typedef GenericMVAJetTagComputerWrapper<GhostTrackComputer,
-	reco::TrackIPTagInfo,         ipTagInfos,
-	reco::SecondaryVertexTagInfo, svTagInfos> GhostTrackJetTagComputer;
-
-typedef GenericMVAJetTagComputerWrapper<GhostTrackComputer,
-	reco::CandIPTagInfo,         ipTagInfos,
-	reco::CandSecondaryVertexTagInfo, svTagInfos> CandidateGhostTrackJetTagComputer;
+                                        reco::TrackIPTagInfo,
+                                        ipTagInfos,
+                                        reco::SecondaryVertexTagInfo,
+                                        svTagInfos,
+                                        reco::CandSoftLeptonTagInfo,
+                                        muonTagInfos,
+                                        reco::CandSoftLeptonTagInfo,
+                                        elecTagInfos>
+    CombinedSVSoftLeptonJetTagComputer;
 
 typedef GenericMVAJetTagComputerWrapper<CombinedSVSoftLeptonComputer,
-	reco::CandIPTagInfo,         ipTagInfos,
-	reco::CandSecondaryVertexTagInfo, svTagInfos,
-	reco::CandSoftLeptonTagInfo, muonTagInfos,
-	reco::CandSoftLeptonTagInfo, elecTagInfos> CandidateCombinedSVSoftLeptonJetTagComputer;
+                                        reco::CandIPTagInfo,
+                                        ipTagInfos,
+                                        reco::CandSecondaryVertexTagInfo,
+                                        svTagInfos,
+                                        reco::CandSoftLeptonTagInfo,
+                                        muonTagInfos,
+                                        reco::CandSoftLeptonTagInfo,
+                                        elecTagInfos>
+    CandidateCombinedSVSoftLeptonJetTagComputer;
+
+typedef GenericMVAJetTagComputerWrapper<GhostTrackComputer,
+                                        reco::TrackIPTagInfo,
+                                        ipTagInfos,
+                                        reco::SecondaryVertexTagInfo,
+                                        svTagInfos>
+    GhostTrackJetTagComputer;
+
+typedef GenericMVAJetTagComputerWrapper<GhostTrackComputer,
+                                        reco::CandIPTagInfo,
+                                        ipTagInfos,
+                                        reco::CandSecondaryVertexTagInfo,
+                                        svTagInfos>
+    CandidateGhostTrackJetTagComputer;
+
+typedef GenericMVAJetTagComputerWrapper<CombinedSVSoftLeptonComputer,
+                                        reco::CandIPTagInfo,
+                                        ipTagInfos,
+                                        reco::CandSecondaryVertexTagInfo,
+                                        svTagInfos,
+                                        reco::CandSoftLeptonTagInfo,
+                                        muonTagInfos,
+                                        reco::CandSoftLeptonTagInfo,
+                                        elecTagInfos>
+    CandidateCombinedSVSoftLeptonJetTagComputer;
 
 typedef JetTagComputerESProducer<CandidateCombinedSVJetTagComputer> CandidateCombinedSecondaryVertexESProducer;
 DEFINE_FWK_EVENTSETUP_MODULE(CandidateCombinedSecondaryVertexESProducer);
@@ -63,7 +90,8 @@ DEFINE_FWK_EVENTSETUP_MODULE(CandidateCombinedSecondaryVertexESProducer);
 typedef JetTagComputerESProducer<CombinedSVJetTagComputer> CombinedSecondaryVertexESProducer;
 DEFINE_FWK_EVENTSETUP_MODULE(CombinedSecondaryVertexESProducer);
 
-typedef JetTagComputerESProducer<CandidateCombinedSVSoftLeptonJetTagComputer> CandidateCombinedSecondaryVertexSoftLeptonESProducer;
+typedef JetTagComputerESProducer<CandidateCombinedSVSoftLeptonJetTagComputer>
+    CandidateCombinedSecondaryVertexSoftLeptonESProducer;
 DEFINE_FWK_EVENTSETUP_MODULE(CandidateCombinedSecondaryVertexSoftLeptonESProducer);
 
 typedef JetTagComputerESProducer<CombinedSVSoftLeptonJetTagComputer> CombinedSecondaryVertexSoftLeptonESProducer;
@@ -81,8 +109,10 @@ DEFINE_FWK_EVENTSETUP_MODULE(CandidateSimpleSecondaryVertexESProducer);
 typedef JetTagComputerESProducer<SimpleSecondaryVertexComputer> SimpleSecondaryVertexESProducer;
 DEFINE_FWK_EVENTSETUP_MODULE(SimpleSecondaryVertexESProducer);
 
-typedef JetTagComputerESProducer<CandidateCombinedSVSoftLeptonJetTagComputer> CandidateCombinedSecondaryVertexSoftLeptonCvsLESProducer;
+typedef JetTagComputerESProducer<CandidateCombinedSVSoftLeptonJetTagComputer>
+    CandidateCombinedSecondaryVertexSoftLeptonCvsLESProducer;
 DEFINE_FWK_EVENTSETUP_MODULE(CandidateCombinedSecondaryVertexSoftLeptonCvsLESProducer);
 
-typedef JetTagComputerESProducer<CandidateBoostedDoubleSecondaryVertexComputer> CandidateBoostedDoubleSecondaryVertexESProducer;
+typedef JetTagComputerESProducer<CandidateBoostedDoubleSecondaryVertexComputer>
+    CandidateBoostedDoubleSecondaryVertexESProducer;
 DEFINE_FWK_EVENTSETUP_MODULE(CandidateBoostedDoubleSecondaryVertexESProducer);

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -59,1260 +59,1224 @@
 //
 // constants, enums and typedefs
 //
-typedef boost::shared_ptr<fastjet::ClusterSequence>  ClusterSequencePtr;
-typedef boost::shared_ptr<fastjet::JetDefinition>    JetDefPtr;
-
+typedef boost::shared_ptr<fastjet::ClusterSequence> ClusterSequencePtr;
+typedef boost::shared_ptr<fastjet::JetDefinition> JetDefPtr;
 
 using namespace reco;
 
 namespace {
-	class VertexInfo : public fastjet::PseudoJet::UserInfoBase{
-	  public:
-	    VertexInfo(const int vertexIndex) :
-	      m_vertexIndex(vertexIndex) { }
+  class VertexInfo : public fastjet::PseudoJet::UserInfoBase {
+  public:
+    VertexInfo(const int vertexIndex) : m_vertexIndex(vertexIndex) {}
 
-	    inline const int vertexIndex() const { return m_vertexIndex; }
+    inline const int vertexIndex() const { return m_vertexIndex; }
 
-	  protected:
-	    int m_vertexIndex;
-	};
-	
-	template<typename T>
-	struct RefToBaseLess {
-		inline bool operator()(const edm::RefToBase<T> &r1,
-				       const edm::RefToBase<T> &r2) const
-		{
-			return r1.id() < r2.id() ||
-			       (r1.id() == r2.id() && r1.key() < r2.key());
-		}
-	};
+  protected:
+    int m_vertexIndex;
+  };
+
+  template <typename T>
+  struct RefToBaseLess {
+    inline bool operator()(const edm::RefToBase<T> &r1, const edm::RefToBase<T> &r2) const {
+      return r1.id() < r2.id() || (r1.id() == r2.id() && r1.key() < r2.key());
+    }
+  };
+}  // namespace
+
+GlobalVector flightDirection(const reco::Vertex &pv, const reco::Vertex &sv) {
+  return GlobalVector(sv.x() - pv.x(), sv.y() - pv.y(), sv.z() - pv.z());
 }
-
-GlobalVector flightDirection(const reco::Vertex & pv, const reco::Vertex & sv) {
-return  GlobalVector(sv.x() - pv.x(), sv.y() - pv.y(),sv.z() - pv.z());
+GlobalVector flightDirection(const reco::Vertex &pv, const reco::VertexCompositePtrCandidate &sv) {
+  return GlobalVector(sv.vertex().x() - pv.x(), sv.vertex().y() - pv.y(), sv.vertex().z() - pv.z());
 }
-GlobalVector flightDirection(const reco::Vertex & pv, const reco::VertexCompositePtrCandidate & sv) {
-return  GlobalVector(sv.vertex().x() - pv.x(), sv.vertex().y() - pv.y(),sv.vertex().z() - pv.z());
-}
-const math::XYZPoint & position(const reco::Vertex & sv)
-{return sv.position();}
-const math::XYZPoint & position(const reco::VertexCompositePtrCandidate & sv)
-{return sv.vertex();}
+const math::XYZPoint &position(const reco::Vertex &sv) { return sv.position(); }
+const math::XYZPoint &position(const reco::VertexCompositePtrCandidate &sv) { return sv.vertex(); }
 
-
-template <class IPTI,class VTX>
+template <class IPTI, class VTX>
 class TemplatedSecondaryVertexProducer : public edm::stream::EDProducer<> {
-    public:
-	explicit TemplatedSecondaryVertexProducer(const edm::ParameterSet &params);
-	~TemplatedSecondaryVertexProducer() override;
-	static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-	typedef std::vector<TemplatedSecondaryVertexTagInfo<IPTI,VTX> > Product;
-	typedef TemplatedSecondaryVertex<VTX> SecondaryVertex;
-	typedef typename IPTI::input_container input_container;
-	typedef typename IPTI::input_container::value_type input_item;
-	typedef typename std::vector<reco::btag::IndexedTrackData> TrackDataVector;
-	void produce(edm::Event &event, const edm::EventSetup &es) override;
+public:
+  explicit TemplatedSecondaryVertexProducer(const edm::ParameterSet &params);
+  ~TemplatedSecondaryVertexProducer() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+  typedef std::vector<TemplatedSecondaryVertexTagInfo<IPTI, VTX> > Product;
+  typedef TemplatedSecondaryVertex<VTX> SecondaryVertex;
+  typedef typename IPTI::input_container input_container;
+  typedef typename IPTI::input_container::value_type input_item;
+  typedef typename std::vector<reco::btag::IndexedTrackData> TrackDataVector;
+  void produce(edm::Event &event, const edm::EventSetup &es) override;
 
-    private:
-        template<class CONTAINER>
-	void matchReclusteredJets(const edm::Handle<CONTAINER>& jets,
-				  const std::vector<fastjet::PseudoJet>& matchedJets,
-				  std::vector<int>& matchedIndices,
-				  const std::string& jetType="");
-	void matchGroomedJets(const edm::Handle<edm::View<reco::Jet> >& jets,
-			      const edm::Handle<edm::View<reco::Jet> >& matchedJets,
-			      std::vector<int>& matchedIndices);
-	void matchSubjets(const std::vector<int>& groomedIndices,
-			  const edm::Handle<edm::View<reco::Jet> >& groomedJets,
-			  const edm::Handle<std::vector<IPTI> >& subjets,
-			  std::vector<std::vector<int> >& matchedIndices);
-	void matchSubjets(const edm::Handle<edm::View<reco::Jet> >& fatJets,
-			  const edm::Handle<std::vector<IPTI> >& subjets,
-			  std::vector<std::vector<int> >& matchedIndices);
-	
-	const reco::Jet * toJet(const reco::Jet & j) { return &j; }
-	const reco::Jet * toJet(const IPTI & j) { return &(*(j.jet())); }
+private:
+  template <class CONTAINER>
+  void matchReclusteredJets(const edm::Handle<CONTAINER> &jets,
+                            const std::vector<fastjet::PseudoJet> &matchedJets,
+                            std::vector<int> &matchedIndices,
+                            const std::string &jetType = "");
+  void matchGroomedJets(const edm::Handle<edm::View<reco::Jet> > &jets,
+                        const edm::Handle<edm::View<reco::Jet> > &matchedJets,
+                        std::vector<int> &matchedIndices);
+  void matchSubjets(const std::vector<int> &groomedIndices,
+                    const edm::Handle<edm::View<reco::Jet> > &groomedJets,
+                    const edm::Handle<std::vector<IPTI> > &subjets,
+                    std::vector<std::vector<int> > &matchedIndices);
+  void matchSubjets(const edm::Handle<edm::View<reco::Jet> > &fatJets,
+                    const edm::Handle<std::vector<IPTI> > &subjets,
+                    std::vector<std::vector<int> > &matchedIndices);
 
-	enum ConstraintType {
-		CONSTRAINT_NONE	= 0,
-		CONSTRAINT_BEAMSPOT,
-		CONSTRAINT_PV_BEAMSPOT_SIZE,
-		CONSTRAINT_PV_BS_Z_ERRORS_SCALED,
-		CONSTRAINT_PV_ERROR_SCALED,
-		CONSTRAINT_PV_PRIMARIES_IN_FIT
-	};
-	static ConstraintType getConstraintType(const std::string &name);
+  const reco::Jet *toJet(const reco::Jet &j) { return &j; }
+  const reco::Jet *toJet(const IPTI &j) { return &(*(j.jet())); }
 
-        edm::EDGetTokenT<reco::BeamSpot> token_BeamSpot;
-        edm::EDGetTokenT<std::vector<IPTI> > token_trackIPTagInfo;
-	reco::btag::SortCriteria	sortCriterium;
-	TrackSelector			trackSelector;
-	ConstraintType			constraint;
-	double				constraintScaling;
-	edm::ParameterSet		vtxRecoPSet;
-	bool				useGhostTrack;
-	bool				withPVError;
-	double				minTrackWeight;
-	VertexFilter			vertexFilter;
-	VertexSorting<SecondaryVertex>	vertexSorting;
-        bool                            useExternalSV;  
-        double                          extSVDeltaRToJet;      
-        edm::EDGetTokenT<edm::View<VTX> > token_extSVCollection;
-	bool				useSVClustering;
-	bool				useSVMomentum;
-	std::string			jetAlgorithm;
-	double				rParam;
-	double				jetPtMin;
-	double				ghostRescaling;
-	double				relPtTolerance;
-	bool				useFatJets;
-	bool				useGroomedFatJets;
-	edm::EDGetTokenT<edm::View<reco::Jet> > token_fatJets;
-	edm::EDGetTokenT<edm::View<reco::Jet> > token_groomedFatJets;
-	
-	ClusterSequencePtr		fjClusterSeq;
-	JetDefPtr			fjJetDefinition;
+  enum ConstraintType {
+    CONSTRAINT_NONE = 0,
+    CONSTRAINT_BEAMSPOT,
+    CONSTRAINT_PV_BEAMSPOT_SIZE,
+    CONSTRAINT_PV_BS_Z_ERRORS_SCALED,
+    CONSTRAINT_PV_ERROR_SCALED,
+    CONSTRAINT_PV_PRIMARIES_IN_FIT
+  };
+  static ConstraintType getConstraintType(const std::string &name);
 
-	void markUsedTracks(TrackDataVector & trackData, const input_container & trackRefs, const SecondaryVertex & sv,size_t idx);
+  edm::EDGetTokenT<reco::BeamSpot> token_BeamSpot;
+  edm::EDGetTokenT<std::vector<IPTI> > token_trackIPTagInfo;
+  reco::btag::SortCriteria sortCriterium;
+  TrackSelector trackSelector;
+  ConstraintType constraint;
+  double constraintScaling;
+  edm::ParameterSet vtxRecoPSet;
+  bool useGhostTrack;
+  bool withPVError;
+  double minTrackWeight;
+  VertexFilter vertexFilter;
+  VertexSorting<SecondaryVertex> vertexSorting;
+  bool useExternalSV;
+  double extSVDeltaRToJet;
+  edm::EDGetTokenT<edm::View<VTX> > token_extSVCollection;
+  bool useSVClustering;
+  bool useSVMomentum;
+  std::string jetAlgorithm;
+  double rParam;
+  double jetPtMin;
+  double ghostRescaling;
+  double relPtTolerance;
+  bool useFatJets;
+  bool useGroomedFatJets;
+  edm::EDGetTokenT<edm::View<reco::Jet> > token_fatJets;
+  edm::EDGetTokenT<edm::View<reco::Jet> > token_groomedFatJets;
 
-	struct SVBuilder {
+  ClusterSequencePtr fjClusterSeq;
+  JetDefPtr fjJetDefinition;
 
-		SVBuilder(const reco::Vertex &pv,
-		          const GlobalVector &direction,
-		          bool withPVError,
-			  double minTrackWeight) :
-			pv(pv), direction(direction),
-			withPVError(withPVError),
-			minTrackWeight(minTrackWeight) {}
-		SecondaryVertex operator () (const TransientVertex &sv) const;
+  void markUsedTracks(TrackDataVector &trackData,
+                      const input_container &trackRefs,
+                      const SecondaryVertex &sv,
+                      size_t idx);
 
-		SecondaryVertex operator () (const VTX &sv) const
-		{ return SecondaryVertex(pv, sv, direction, withPVError); }
+  struct SVBuilder {
+    SVBuilder(const reco::Vertex &pv, const GlobalVector &direction, bool withPVError, double minTrackWeight)
+        : pv(pv), direction(direction), withPVError(withPVError), minTrackWeight(minTrackWeight) {}
+    SecondaryVertex operator()(const TransientVertex &sv) const;
 
+    SecondaryVertex operator()(const VTX &sv) const { return SecondaryVertex(pv, sv, direction, withPVError); }
 
-		const Vertex		&pv;
-		const GlobalVector	&direction;
-		bool			withPVError;
-		double 			minTrackWeight;
-	};
+    const Vertex &pv;
+    const GlobalVector &direction;
+    bool withPVError;
+    double minTrackWeight;
+  };
 
-	struct SVFilter {
+  struct SVFilter {
+    SVFilter(const VertexFilter &filter, const Vertex &pv, const GlobalVector &direction)
+        : filter(filter), pv(pv), direction(direction) {}
 
-		SVFilter(const VertexFilter &filter, const Vertex &pv,
-		         const GlobalVector &direction) :
-			filter(filter), pv(pv), direction(direction) {}
+    inline bool operator()(const SecondaryVertex &sv) const { return !filter(pv, sv, direction); }
 
-		inline bool operator () (const SecondaryVertex &sv) const
-		{ return !filter(pv, sv, direction); }
-
-		const VertexFilter	&filter;
-		const Vertex		&pv;
-		const GlobalVector	&direction;
-	};
+    const VertexFilter &filter;
+    const Vertex &pv;
+    const GlobalVector &direction;
+  };
 };
-template <class IPTI,class VTX>
-typename TemplatedSecondaryVertexProducer<IPTI,VTX>::ConstraintType
-TemplatedSecondaryVertexProducer<IPTI,VTX>::getConstraintType(const std::string &name)
-{
-	if (name == "None")
-		return CONSTRAINT_NONE;
-	else if (name == "BeamSpot")
-		return CONSTRAINT_BEAMSPOT;
-	else if (name == "BeamSpot+PVPosition")
-		return CONSTRAINT_PV_BEAMSPOT_SIZE;
-	else if (name == "BeamSpotZ+PVErrorScaledXY")
-		return CONSTRAINT_PV_BS_Z_ERRORS_SCALED;
-	else if (name == "PVErrorScaled")
-		return CONSTRAINT_PV_ERROR_SCALED;
-	else if (name == "BeamSpot+PVTracksInFit")
-		return CONSTRAINT_PV_PRIMARIES_IN_FIT;
-	else
-		throw cms::Exception("InvalidArgument")
-			<< "TemplatedSecondaryVertexProducer: ``constraint'' parameter "
-			   "value \"" << name << "\" not understood."
-			<< std::endl;
+template <class IPTI, class VTX>
+typename TemplatedSecondaryVertexProducer<IPTI, VTX>::ConstraintType
+TemplatedSecondaryVertexProducer<IPTI, VTX>::getConstraintType(const std::string &name) {
+  if (name == "None")
+    return CONSTRAINT_NONE;
+  else if (name == "BeamSpot")
+    return CONSTRAINT_BEAMSPOT;
+  else if (name == "BeamSpot+PVPosition")
+    return CONSTRAINT_PV_BEAMSPOT_SIZE;
+  else if (name == "BeamSpotZ+PVErrorScaledXY")
+    return CONSTRAINT_PV_BS_Z_ERRORS_SCALED;
+  else if (name == "PVErrorScaled")
+    return CONSTRAINT_PV_ERROR_SCALED;
+  else if (name == "BeamSpot+PVTracksInFit")
+    return CONSTRAINT_PV_PRIMARIES_IN_FIT;
+  else
+    throw cms::Exception("InvalidArgument") << "TemplatedSecondaryVertexProducer: ``constraint'' parameter "
+                                               "value \""
+                                            << name << "\" not understood." << std::endl;
 }
 
-static GhostTrackVertexFinder::FitType
-getGhostTrackFitType(const std::string &name)
-{
-	if (name == "AlwaysWithGhostTrack")
-		return GhostTrackVertexFinder::kAlwaysWithGhostTrack;
-	else if (name == "SingleTracksWithGhostTrack")
-		return GhostTrackVertexFinder::kSingleTracksWithGhostTrack;
-	else if (name == "RefitGhostTrackWithVertices")
-		return GhostTrackVertexFinder::kRefitGhostTrackWithVertices;
-	else
-		throw cms::Exception("InvalidArgument")
-			<< "TemplatedSecondaryVertexProducer: ``fitType'' "
-			   "parameter value \"" << name << "\" for "
-			   "GhostTrackVertexFinder settings not "
-			   "understood." << std::endl;
+static GhostTrackVertexFinder::FitType getGhostTrackFitType(const std::string &name) {
+  if (name == "AlwaysWithGhostTrack")
+    return GhostTrackVertexFinder::kAlwaysWithGhostTrack;
+  else if (name == "SingleTracksWithGhostTrack")
+    return GhostTrackVertexFinder::kSingleTracksWithGhostTrack;
+  else if (name == "RefitGhostTrackWithVertices")
+    return GhostTrackVertexFinder::kRefitGhostTrackWithVertices;
+  else
+    throw cms::Exception("InvalidArgument") << "TemplatedSecondaryVertexProducer: ``fitType'' "
+                                               "parameter value \""
+                                            << name
+                                            << "\" for "
+                                               "GhostTrackVertexFinder settings not "
+                                               "understood."
+                                            << std::endl;
 }
 
-template <class IPTI,class VTX>
-TemplatedSecondaryVertexProducer<IPTI,VTX>::TemplatedSecondaryVertexProducer(
-					const edm::ParameterSet &params) :
-	sortCriterium(TrackSorting::getCriterium(params.getParameter<std::string>("trackSort"))),
-	trackSelector(params.getParameter<edm::ParameterSet>("trackSelection")),
-	constraint(getConstraintType(params.getParameter<std::string>("constraint"))),
-	constraintScaling(1.0),
-	vtxRecoPSet(params.getParameter<edm::ParameterSet>("vertexReco")),
-	useGhostTrack(vtxRecoPSet.getParameter<std::string>("finder") == "gtvr"),
-	withPVError(params.getParameter<bool>("usePVError")),
-	minTrackWeight(params.getParameter<double>("minimumTrackWeight")),
-	vertexFilter(params.getParameter<edm::ParameterSet>("vertexCuts")),
-	vertexSorting(params.getParameter<edm::ParameterSet>("vertexSelection"))
-{
-	token_trackIPTagInfo =  consumes<std::vector<IPTI> >(params.getParameter<edm::InputTag>("trackIPTagInfos"));
-	if (constraint == CONSTRAINT_PV_ERROR_SCALED ||
-	    constraint == CONSTRAINT_PV_BS_Z_ERRORS_SCALED)
-		constraintScaling = params.getParameter<double>("pvErrorScaling");
+template <class IPTI, class VTX>
+TemplatedSecondaryVertexProducer<IPTI, VTX>::TemplatedSecondaryVertexProducer(const edm::ParameterSet &params)
+    : sortCriterium(TrackSorting::getCriterium(params.getParameter<std::string>("trackSort"))),
+      trackSelector(params.getParameter<edm::ParameterSet>("trackSelection")),
+      constraint(getConstraintType(params.getParameter<std::string>("constraint"))),
+      constraintScaling(1.0),
+      vtxRecoPSet(params.getParameter<edm::ParameterSet>("vertexReco")),
+      useGhostTrack(vtxRecoPSet.getParameter<std::string>("finder") == "gtvr"),
+      withPVError(params.getParameter<bool>("usePVError")),
+      minTrackWeight(params.getParameter<double>("minimumTrackWeight")),
+      vertexFilter(params.getParameter<edm::ParameterSet>("vertexCuts")),
+      vertexSorting(params.getParameter<edm::ParameterSet>("vertexSelection")) {
+  token_trackIPTagInfo = consumes<std::vector<IPTI> >(params.getParameter<edm::InputTag>("trackIPTagInfos"));
+  if (constraint == CONSTRAINT_PV_ERROR_SCALED || constraint == CONSTRAINT_PV_BS_Z_ERRORS_SCALED)
+    constraintScaling = params.getParameter<double>("pvErrorScaling");
 
-	if (constraint == CONSTRAINT_PV_BEAMSPOT_SIZE ||
-	    constraint == CONSTRAINT_PV_BS_Z_ERRORS_SCALED ||
-	    constraint == CONSTRAINT_BEAMSPOT ||
-	    constraint == CONSTRAINT_PV_PRIMARIES_IN_FIT )
-	    token_BeamSpot = consumes<reco::BeamSpot>(params.getParameter<edm::InputTag>("beamSpotTag"));
-	useExternalSV = false;
-	if(params.existsAs<bool>("useExternalSV")) useExternalSV = params.getParameter<bool> ("useExternalSV");
-	if(useExternalSV) {
-	   token_extSVCollection =  consumes<edm::View<VTX> >(params.getParameter<edm::InputTag>("extSVCollection"));
-	   extSVDeltaRToJet = params.getParameter<double>("extSVDeltaRToJet");
-	}
-	useSVClustering = ( params.existsAs<bool>("useSVClustering") ? params.getParameter<bool>("useSVClustering") : false );
-	useSVMomentum = ( params.existsAs<bool>("useSVMomentum") ? params.getParameter<bool>("useSVMomentum") : false );
-	useFatJets = ( useExternalSV && params.exists("fatJets") );
-	useGroomedFatJets = ( useExternalSV && params.exists("groomedFatJets") );
-	if( useSVClustering )
-	{
-	  jetAlgorithm = params.getParameter<std::string>("jetAlgorithm");
-	  rParam = params.getParameter<double>("rParam");
-	  jetPtMin = 0.; // hardcoded to 0. since we simply want to recluster all input jets which already had some PtMin applied
-	  ghostRescaling = ( params.existsAs<double>("ghostRescaling") ? params.getParameter<double>("ghostRescaling") : 1e-18 );
-	  relPtTolerance = ( params.existsAs<double>("relPtTolerance") ? params.getParameter<double>("relPtTolerance") : 1e-03); // 0.1% relative difference in Pt should be sufficient to detect possible misconfigurations
+  if (constraint == CONSTRAINT_PV_BEAMSPOT_SIZE || constraint == CONSTRAINT_PV_BS_Z_ERRORS_SCALED ||
+      constraint == CONSTRAINT_BEAMSPOT || constraint == CONSTRAINT_PV_PRIMARIES_IN_FIT)
+    token_BeamSpot = consumes<reco::BeamSpot>(params.getParameter<edm::InputTag>("beamSpotTag"));
+  useExternalSV = false;
+  if (params.existsAs<bool>("useExternalSV"))
+    useExternalSV = params.getParameter<bool>("useExternalSV");
+  if (useExternalSV) {
+    token_extSVCollection = consumes<edm::View<VTX> >(params.getParameter<edm::InputTag>("extSVCollection"));
+    extSVDeltaRToJet = params.getParameter<double>("extSVDeltaRToJet");
+  }
+  useSVClustering = (params.existsAs<bool>("useSVClustering") ? params.getParameter<bool>("useSVClustering") : false);
+  useSVMomentum = (params.existsAs<bool>("useSVMomentum") ? params.getParameter<bool>("useSVMomentum") : false);
+  useFatJets = (useExternalSV && params.exists("fatJets"));
+  useGroomedFatJets = (useExternalSV && params.exists("groomedFatJets"));
+  if (useSVClustering) {
+    jetAlgorithm = params.getParameter<std::string>("jetAlgorithm");
+    rParam = params.getParameter<double>("rParam");
+    jetPtMin =
+        0.;  // hardcoded to 0. since we simply want to recluster all input jets which already had some PtMin applied
+    ghostRescaling =
+        (params.existsAs<double>("ghostRescaling") ? params.getParameter<double>("ghostRescaling") : 1e-18);
+    relPtTolerance =
+        (params.existsAs<double>("relPtTolerance")
+             ? params.getParameter<double>("relPtTolerance")
+             : 1e-03);  // 0.1% relative difference in Pt should be sufficient to detect possible misconfigurations
 
-	  // set jet algorithm
-	  if (jetAlgorithm=="Kt")
-	    fjJetDefinition = JetDefPtr( new fastjet::JetDefinition(fastjet::kt_algorithm, rParam) );
-	  else if (jetAlgorithm=="CambridgeAachen")
-	    fjJetDefinition = JetDefPtr( new fastjet::JetDefinition(fastjet::cambridge_algorithm, rParam) );
-	  else if (jetAlgorithm=="AntiKt")
-	    fjJetDefinition = JetDefPtr( new fastjet::JetDefinition(fastjet::antikt_algorithm, rParam) );
-	  else
-	    throw cms::Exception("InvalidJetAlgorithm") << "Jet clustering algorithm is invalid: " << jetAlgorithm << ", use CambridgeAachen | Kt | AntiKt" << std::endl;
-	}
-	if( useFatJets )
-	  token_fatJets = consumes<edm::View<reco::Jet> >(params.getParameter<edm::InputTag>("fatJets"));
-	if( useGroomedFatJets )
-	  token_groomedFatJets = consumes<edm::View<reco::Jet> >(params.getParameter<edm::InputTag>("groomedFatJets"));
-	if( useFatJets && !useSVClustering )
-	  rParam = params.getParameter<double>("rParam"); // will be used later as a dR cut
-	
-	produces<Product>();
+    // set jet algorithm
+    if (jetAlgorithm == "Kt")
+      fjJetDefinition = JetDefPtr(new fastjet::JetDefinition(fastjet::kt_algorithm, rParam));
+    else if (jetAlgorithm == "CambridgeAachen")
+      fjJetDefinition = JetDefPtr(new fastjet::JetDefinition(fastjet::cambridge_algorithm, rParam));
+    else if (jetAlgorithm == "AntiKt")
+      fjJetDefinition = JetDefPtr(new fastjet::JetDefinition(fastjet::antikt_algorithm, rParam));
+    else
+      throw cms::Exception("InvalidJetAlgorithm") << "Jet clustering algorithm is invalid: " << jetAlgorithm
+                                                  << ", use CambridgeAachen | Kt | AntiKt" << std::endl;
+  }
+  if (useFatJets)
+    token_fatJets = consumes<edm::View<reco::Jet> >(params.getParameter<edm::InputTag>("fatJets"));
+  if (useGroomedFatJets)
+    token_groomedFatJets = consumes<edm::View<reco::Jet> >(params.getParameter<edm::InputTag>("groomedFatJets"));
+  if (useFatJets && !useSVClustering)
+    rParam = params.getParameter<double>("rParam");  // will be used later as a dR cut
+
+  produces<Product>();
 }
-template <class IPTI,class VTX>
-TemplatedSecondaryVertexProducer<IPTI,VTX>::~TemplatedSecondaryVertexProducer()
-{
-}
-
-template <class IPTI,class VTX>
-void TemplatedSecondaryVertexProducer<IPTI,VTX>::produce(edm::Event &event,
-                                      const edm::EventSetup &es)
-{
-//	typedef std::map<TrackBaseRef, TransientTrack,
-//	                 RefToBaseLess<Track> > TransientTrackMap;
-	//How about good old pointers?
-	typedef std::map<const Track *, TransientTrack> TransientTrackMap;
-	
-
-	edm::ESHandle<TransientTrackBuilder> trackBuilder;
-	es.get<TransientTrackRecord>().get("TransientTrackBuilder",
-	                                   trackBuilder);
-
-	edm::Handle<std::vector<IPTI> > trackIPTagInfos;
-	event.getByToken(token_trackIPTagInfo, trackIPTagInfos);
-
-        // External Sec Vertex collection (e.g. for IVF usage)
-        edm::Handle<edm::View<VTX> > extSecVertex;          
-        if(useExternalSV) event.getByToken(token_extSVCollection,extSecVertex);
-
-	edm::Handle<edm::View<reco::Jet> > fatJetsHandle;
-	edm::Handle<edm::View<reco::Jet> > groomedFatJetsHandle;
-	if( useFatJets )
-	{
-	  event.getByToken(token_fatJets, fatJetsHandle);
-	
-	  if( useGroomedFatJets )
-	  {
-	    event.getByToken(token_groomedFatJets, groomedFatJetsHandle);
-	
-	    if( groomedFatJetsHandle->size() > fatJetsHandle->size() )
-	      edm::LogError("TooManyGroomedJets") << "There are more groomed (" << groomedFatJetsHandle->size() << ") than original fat jets (" << fatJetsHandle->size() << "). Please check that the two jet collections belong to each other.";
-	  }
-	}
-
-	edm::Handle<BeamSpot> beamSpot;
-	unsigned int bsCovSrc[7] = { 0, };
-	double sigmaZ = 0.0, beamWidth = 0.0;
-	switch(constraint) {
-	    case CONSTRAINT_PV_BEAMSPOT_SIZE:
-		event.getByToken(token_BeamSpot,beamSpot);
-		bsCovSrc[3] = bsCovSrc[4] = bsCovSrc[5] = bsCovSrc[6] = 1;
-		sigmaZ = beamSpot->sigmaZ();
-		beamWidth = beamSpot->BeamWidthX();
-		break;
-
-	    case CONSTRAINT_PV_BS_Z_ERRORS_SCALED:
-		event.getByToken(token_BeamSpot,beamSpot);
-		bsCovSrc[0] = bsCovSrc[1] = 2;
-		bsCovSrc[3] = bsCovSrc[4] = bsCovSrc[5] = 1;
-		sigmaZ = beamSpot->sigmaZ();
-		break;
-
-	    case CONSTRAINT_PV_ERROR_SCALED:
-		bsCovSrc[0] = bsCovSrc[1] = bsCovSrc[2] = 2;
-		break;
-
-	    case CONSTRAINT_BEAMSPOT:
-	    case CONSTRAINT_PV_PRIMARIES_IN_FIT:
-		event.getByToken(token_BeamSpot,beamSpot);
-		break;
-
-	    default:
-		/* nothing */;
-	}
-
-	// ------------------------------------ SV clustering START --------------------------------------------
-	std::vector<std::vector<int> > clusteredSVs(trackIPTagInfos->size(),std::vector<int>());
-	if( useExternalSV && useSVClustering && !trackIPTagInfos->empty() )
-	{
-	  // vector of constituents for reclustering jets and "ghost" SVs
-	  std::vector<fastjet::PseudoJet> fjInputs;
-	  // loop over all input jets and collect all their constituents
-	  if( useFatJets )
-	  {
-	    for(edm::View<reco::Jet>::const_iterator it = fatJetsHandle->begin(); it != fatJetsHandle->end(); ++it)
-	    {
-	      std::vector<edm::Ptr<reco::Candidate> > constituents = it->getJetConstituents();
-	      std::vector<edm::Ptr<reco::Candidate> >::const_iterator m;
-	      for( m = constituents.begin(); m != constituents.end(); ++m )
-	      {
-		 reco::CandidatePtr constit = *m;
-		 if(constit->pt() == 0)
-		 {
-		   edm::LogWarning("NullTransverseMomentum") << "dropping input candidate with pt=0";
-		   continue;
-		 }
-		 fjInputs.push_back(fastjet::PseudoJet(constit->px(),constit->py(),constit->pz(),constit->energy()));
-	      }
-	    }
-	  }
-	  else
-	  {
-	    for(typename std::vector<IPTI>::const_iterator it = trackIPTagInfos->begin(); it != trackIPTagInfos->end(); ++it)
-	    {
-	      std::vector<edm::Ptr<reco::Candidate> > constituents = it->jet()->getJetConstituents();
-	      std::vector<edm::Ptr<reco::Candidate> >::const_iterator m;
-	      for( m = constituents.begin(); m != constituents.end(); ++m )
-	      {
-		 reco::CandidatePtr constit = *m;
-		 if(constit->pt() == 0)
-		 {
-		   edm::LogWarning("NullTransverseMomentum") << "dropping input candidate with pt=0";
-		   continue;
-		 }
-		 fjInputs.push_back(fastjet::PseudoJet(constit->px(),constit->py(),constit->pz(),constit->energy()));
-	      }
-	    }
-	  }
-	  // insert "ghost" SVs in the vector of constituents
-	  for(typename edm::View<VTX>::const_iterator it = extSecVertex->begin(); it != extSecVertex->end(); ++it)
-	  {
-	    const reco::Vertex &pv = *(trackIPTagInfos->front().primaryVertex());
-	    GlobalVector dir = flightDirection(pv, *it);
-	    dir = dir.unit();
-	    fastjet::PseudoJet p(dir.x(),dir.y(),dir.z(),dir.mag()); // using SV flight direction so treating SV as massless
-	    if( useSVMomentum )
-	      p = fastjet::PseudoJet(it->p4().px(),it->p4().py(),it->p4().pz(),it->p4().energy());
-	    p*=ghostRescaling; // rescale SV direction/momentum
-	    p.set_user_info(new VertexInfo( it - extSecVertex->begin() ));
-	    fjInputs.push_back(p);
-	  }
-	  
-	  // define jet clustering sequence
-	  fjClusterSeq = ClusterSequencePtr( new fastjet::ClusterSequence( fjInputs, *fjJetDefinition ) );
-	  // recluster jet constituents and inserted "ghosts"
-	  std::vector<fastjet::PseudoJet> inclusiveJets = fastjet::sorted_by_pt( fjClusterSeq->inclusive_jets(jetPtMin) );
-	  
-	  if( useFatJets )
-	  {
-	    if( inclusiveJets.size() < fatJetsHandle->size() )
-	      edm::LogError("TooFewReclusteredJets") << "There are fewer reclustered (" << inclusiveJets.size() << ") than original fat jets (" << fatJetsHandle->size() << "). Please check that the jet algorithm and jet size match those used for the original jet collection.";
-
-	    // match reclustered and original fat jets
-	    std::vector<int> reclusteredIndices;
-	    matchReclusteredJets<edm::View<reco::Jet> >(fatJetsHandle,inclusiveJets,reclusteredIndices,"fat");
-
-	    // match groomed and original fat jets
-	    std::vector<int> groomedIndices;
-	    if( useGroomedFatJets )
-	      matchGroomedJets(fatJetsHandle,groomedFatJetsHandle,groomedIndices);
-
-	    // match subjets and original fat jets
-	    std::vector<std::vector<int> > subjetIndices;
-	    if( useGroomedFatJets )
-	      matchSubjets(groomedIndices,groomedFatJetsHandle,trackIPTagInfos,subjetIndices);
-	    else
-	      matchSubjets(fatJetsHandle,trackIPTagInfos,subjetIndices);
-	
-	    // collect clustered SVs
-	    for(size_t i=0; i<fatJetsHandle->size(); ++i)
-	    {
-	      if( reclusteredIndices.at(i) < 0 ) continue; // continue if matching reclustered to original jets failed
-	
-	      if( fatJetsHandle->at(i).pt() == 0 ) // continue if the original jet has Pt=0
-	      {
-	        edm::LogWarning("NullTransverseMomentum") << "The original fat jet " << i << " has Pt=0. This is not expected so the jet will be skipped.";
-	        continue;
-	      }
-	
-	      if( subjetIndices.at(i).empty() ) continue; // continue if the original jet does not have subjets assigned
-		
-	      // since the "ghosts" are extremely soft, the configuration and ordering of the reclustered and original fat jets should in principle stay the same
-	      if( ( std::abs( inclusiveJets.at(reclusteredIndices.at(i)).pt() - fatJetsHandle->at(i).pt() ) / fatJetsHandle->at(i).pt() ) > relPtTolerance )
-	      {
-		 if( fatJetsHandle->at(i).pt() < 10. )  // special handling for low-Pt jets (Pt<10 GeV)
-		   edm::LogWarning("JetPtMismatchAtLowPt") << "The reclustered and original fat jet " << i << " have different Pt's (" << inclusiveJets.at(reclusteredIndices.at(i)).pt() << " vs " << fatJetsHandle->at(i).pt() << " GeV, respectively).\n"
-							   << "Please check that the jet algorithm and jet size match those used for the original fat jet collection and also make sure the original fat jets are uncorrected. In addition, make sure you are not using CaloJets which are presently not supported.\n"
-							   << "Since the mismatch is at low Pt, it is ignored and only a warning is issued.\n"
-							   << "\nIn extremely rare instances the mismatch could be caused by a difference in the machine precision in which case make sure the original jet collection is produced and reclustering is performed in the same job.";
-		 else
-		   edm::LogError("JetPtMismatch") << "The reclustered and original fat jet " << i << " have different Pt's (" << inclusiveJets.at(reclusteredIndices.at(i)).pt() << " vs " << fatJetsHandle->at(i).pt() << " GeV, respectively).\n"
-						  << "Please check that the jet algorithm and jet size match those used for the original fat jet collection and also make sure the original fat jets are uncorrected. In addition, make sure you are not using CaloJets which are presently not supported.\n"
-						  << "\nIn extremely rare instances the mismatch could be caused by a difference in the machine precision in which case make sure the original jet collection is produced and reclustering is performed in the same job.";
-	      }
-	
-	      // get jet constituents
-	      std::vector<fastjet::PseudoJet> constituents = inclusiveJets.at(reclusteredIndices.at(i)).constituents();
-
-	      std::vector<int> svIndices;
-	      // loop over jet constituents and try to find "ghosts"
-	      for(std::vector<fastjet::PseudoJet>::const_iterator it = constituents.begin(); it != constituents.end(); ++it)
-	      {
-		 if( !it->has_user_info() ) continue; // skip if not a "ghost"
-		 
-		 svIndices.push_back( it->user_info<VertexInfo>().vertexIndex() );
-	      }
-	
-	      // loop over clustered SVs and assign them to different subjets based on smallest dR
-	      for(size_t sv=0; sv<svIndices.size(); ++sv)
-	      {
-		const reco::Vertex &pv = *(trackIPTagInfos->front().primaryVertex());
-		const VTX &extSV = (*extSecVertex)[ svIndices.at(sv) ];
-		GlobalVector dir = flightDirection(pv, extSV);
-		dir = dir.unit();
-		fastjet::PseudoJet p(dir.x(),dir.y(),dir.z(),dir.mag()); // using SV flight direction so treating SV as massless
-		if( useSVMomentum )
-		  p = fastjet::PseudoJet(extSV.p4().px(),extSV.p4().py(),extSV.p4().pz(),extSV.p4().energy());
-		
-		std::vector<double> dR2toSubjets;
-		
-		for(size_t sj=0; sj<subjetIndices.at(i).size(); ++sj)
-		  dR2toSubjets.push_back( Geom::deltaR2( p.rapidity(), p.phi_std(), trackIPTagInfos->at(subjetIndices.at(i).at(sj)).jet()->rapidity(), trackIPTagInfos->at(subjetIndices.at(i).at(sj)).jet()->phi() ) );
-
-		// find the closest subjet
-		int closestSubjetIdx = std::distance( dR2toSubjets.begin(), std::min_element(dR2toSubjets.begin(), dR2toSubjets.end()) );
-
-		clusteredSVs.at(subjetIndices.at(i).at(closestSubjetIdx)).push_back( svIndices.at(sv) );
-	      }
-	    }
-	  }
-	  else
-	  {
-	    if( inclusiveJets.size() < trackIPTagInfos->size() )
-	      edm::LogError("TooFewReclusteredJets") << "There are fewer reclustered (" << inclusiveJets.size() << ") than original jets (" << trackIPTagInfos->size() << "). Please check that the jet algorithm and jet size match those used for the original jet collection.";
-	
-	    // match reclustered and original jets
-	    std::vector<int> reclusteredIndices;
-	    matchReclusteredJets<std::vector<IPTI> >(trackIPTagInfos,inclusiveJets,reclusteredIndices);
-	
-	    // collect clustered SVs
-	    for(size_t i=0; i<trackIPTagInfos->size(); ++i)
-	    {
-	      if( reclusteredIndices.at(i) < 0 ) continue; // continue if matching reclustered to original jets failed
-	
-	      if( trackIPTagInfos->at(i).jet()->pt() == 0 ) // continue if the original jet has Pt=0
-	      {
-	        edm::LogWarning("NullTransverseMomentum") << "The original jet " << i << " has Pt=0. This is not expected so the jet will be skipped.";
-	        continue;
-	      }
-	
-	      // since the "ghosts" are extremely soft, the configuration and ordering of the reclustered and original jets should in principle stay the same
-	      if( ( std::abs( inclusiveJets.at(reclusteredIndices.at(i)).pt() - trackIPTagInfos->at(i).jet()->pt() ) / trackIPTagInfos->at(i).jet()->pt() ) > relPtTolerance )
-	      {
-		 if( trackIPTagInfos->at(i).jet()->pt() < 10. )  // special handling for low-Pt jets (Pt<10 GeV)
-		   edm::LogWarning("JetPtMismatchAtLowPt") << "The reclustered and original jet " << i << " have different Pt's (" << inclusiveJets.at(reclusteredIndices.at(i)).pt() << " vs " << trackIPTagInfos->at(i).jet()->pt() << " GeV, respectively).\n"
-							   << "Please check that the jet algorithm and jet size match those used for the original jet collection and also make sure the original jets are uncorrected. In addition, make sure you are not using CaloJets which are presently not supported.\n"
-							   << "Since the mismatch is at low Pt, it is ignored and only a warning is issued.\n"
-							   << "\nIn extremely rare instances the mismatch could be caused by a difference in the machine precision in which case make sure the original jet collection is produced and reclustering is performed in the same job.";
-		 else
-		   edm::LogError("JetPtMismatch") << "The reclustered and original jet " << i << " have different Pt's (" << inclusiveJets.at(reclusteredIndices.at(i)).pt() << " vs " << trackIPTagInfos->at(i).jet()->pt() << " GeV, respectively).\n"
-						  << "Please check that the jet algorithm and jet size match those used for the original jet collection and also make sure the original jets are uncorrected. In addition, make sure you are not using CaloJets which are presently not supported.\n"
-						  << "\nIn extremely rare instances the mismatch could be caused by a difference in the machine precision in which case make sure the original jet collection is produced and reclustering is performed in the same job.";
-	      }
-	
-	      // get jet constituents
-	      std::vector<fastjet::PseudoJet> constituents = inclusiveJets.at(reclusteredIndices.at(i)).constituents();
-
-	      // loop over jet constituents and try to find "ghosts"
-	      for(std::vector<fastjet::PseudoJet>::const_iterator it = constituents.begin(); it != constituents.end(); ++it)
-	      {
-		 if( !it->has_user_info() ) continue; // skip if not a "ghost"
-		 // push back clustered SV indices
-		 clusteredSVs.at(i).push_back( it->user_info<VertexInfo>().vertexIndex() );
-	      }
-	    }
-	  }
-	}
-	// case where fat jets are used to associate SVs to subjets but no SV clustering is performed
-	else if( useExternalSV && !useSVClustering && !trackIPTagInfos->empty() && useFatJets )
-	{
-	  // match groomed and original fat jets
-	  std::vector<int> groomedIndices;
-	  if( useGroomedFatJets )
-	    matchGroomedJets(fatJetsHandle,groomedFatJetsHandle,groomedIndices);
-
-	  // match subjets and original fat jets
-	  std::vector<std::vector<int> > subjetIndices;
-	  if( useGroomedFatJets )
-	    matchSubjets(groomedIndices,groomedFatJetsHandle,trackIPTagInfos,subjetIndices);
-	  else
-	    matchSubjets(fatJetsHandle,trackIPTagInfos,subjetIndices);
-
-	  // loop over fat jets
-	  for(size_t i=0; i<fatJetsHandle->size(); ++i)
-	  {
-	    if( fatJetsHandle->at(i).pt() == 0 ) // continue if the original jet has Pt=0
-	    {
-	      edm::LogWarning("NullTransverseMomentum") << "The original fat jet " << i << " has Pt=0. This is not expected so the jet will be skipped.";
-	      continue;
-	    }
-
-	    if( subjetIndices.at(i).empty() ) continue; // continue if the original jet does not have subjets assigned
-
-	    // loop over SVs, associate them to fat jets based on dR cone and
-	    // then assign them to the closets subjet in dR
-	    for(typename edm::View<VTX>::const_iterator it = extSecVertex->begin(); it != extSecVertex->end(); ++it)
-	    {
-	      size_t sv = ( it - extSecVertex->begin() );
-	
-	      const reco::Vertex &pv = *(trackIPTagInfos->front().primaryVertex());
-	      const VTX &extSV = (*extSecVertex)[sv];
-	      GlobalVector dir = flightDirection(pv, extSV);
-	      GlobalVector jetDir(fatJetsHandle->at(i).px(),
-				  fatJetsHandle->at(i).py(),
-				  fatJetsHandle->at(i).pz());
-	      // skip SVs outside the dR cone
-              if( Geom::deltaR2( dir, jetDir ) > rParam*rParam ) // here using the jet clustering rParam as a dR cut
-	        continue;
-
-	      dir = dir.unit();
-	      fastjet::PseudoJet p(dir.x(),dir.y(),dir.z(),dir.mag()); // using SV flight direction so treating SV as massless
-	      if( useSVMomentum )
-		p = fastjet::PseudoJet(extSV.p4().px(),extSV.p4().py(),extSV.p4().pz(),extSV.p4().energy());
-	
-	      std::vector<double> dR2toSubjets;
-	
-	      for(size_t sj=0; sj<subjetIndices.at(i).size(); ++sj)
-		dR2toSubjets.push_back( Geom::deltaR2( p.rapidity(), p.phi_std(), trackIPTagInfos->at(subjetIndices.at(i).at(sj)).jet()->rapidity(), trackIPTagInfos->at(subjetIndices.at(i).at(sj)).jet()->phi() ) );
-
-	      // find the closest subjet
-	      int closestSubjetIdx = std::distance( dR2toSubjets.begin(), std::min_element(dR2toSubjets.begin(), dR2toSubjets.end()) );
-
-	      clusteredSVs.at(subjetIndices.at(i).at(closestSubjetIdx)).push_back(sv);
-	    }
-	  }
-	}
-	// ------------------------------------ SV clustering END ----------------------------------------------
-
-	std::unique_ptr<ConfigurableVertexReconstructor> vertexReco;
-	std::unique_ptr<GhostTrackVertexFinder> vertexRecoGT;
-	if (useGhostTrack)
-		vertexRecoGT.reset(new GhostTrackVertexFinder(
-			vtxRecoPSet.getParameter<double>("maxFitChi2"),
-			vtxRecoPSet.getParameter<double>("mergeThreshold"),
-			vtxRecoPSet.getParameter<double>("primcut"),
-			vtxRecoPSet.getParameter<double>("seccut"),
-			getGhostTrackFitType(vtxRecoPSet.getParameter<std::string>("fitType"))));
-	else
-		vertexReco.reset(
-			new ConfigurableVertexReconstructor(vtxRecoPSet));
-
-	TransientTrackMap primariesMap;
-
-	// result secondary vertices
-
-	auto tagInfos = std::make_unique<Product>();
-
-	for(typename std::vector<IPTI>::const_iterator iterJets =
-		trackIPTagInfos->begin(); iterJets != trackIPTagInfos->end();
-		++iterJets) {
-		TrackDataVector trackData;
-//		      std::cout << "Jet " << iterJets-trackIPTagInfos->begin() << std::endl; 
-
-		const Vertex &pv = *iterJets->primaryVertex();
-
-		std::set<TransientTrack> primaries;
-		if (constraint == CONSTRAINT_PV_PRIMARIES_IN_FIT) {
-			for(Vertex::trackRef_iterator iter = pv.tracks_begin();
-			    iter != pv.tracks_end(); ++iter) {
-				TransientTrackMap::iterator pos =
-					primariesMap.lower_bound(iter->get());
-
-				if (pos != primariesMap.end() &&
-				    pos->first == iter->get())
-					primaries.insert(pos->second);
-				else {
-					TransientTrack track =
-						trackBuilder->build(
-							iter->castTo<TrackRef>());
-					primariesMap.insert(pos,
-						std::make_pair(iter->get(), track));
-					primaries.insert(track);
-				}
-			}
-		}
-
-		edm::RefToBase<Jet> jetRef = iterJets->jet();
-
-		GlobalVector jetDir(jetRef->momentum().x(),
-		                    jetRef->momentum().y(),
-		                    jetRef->momentum().z());
-
-		std::vector<std::size_t> indices =
-				iterJets->sortedIndexes(sortCriterium);
-
-		input_container trackRefs = iterJets->sortedTracks(indices);
-
-		const std::vector<reco::btag::TrackIPData> &ipData =
-					iterJets->impactParameterData();
-
-		// build transient tracks used for vertex reconstruction
-
-		std::vector<TransientTrack> fitTracks;
-		std::vector<GhostTrackState> gtStates;
-		std::unique_ptr<GhostTrackPrediction> gtPred;
-		if (useGhostTrack)
-			gtPred.reset(new GhostTrackPrediction(
-						*iterJets->ghostTrack()));
-
-		for(unsigned int i = 0; i < indices.size(); i++) {
-			typedef typename TemplatedSecondaryVertexTagInfo<IPTI,VTX>::IndexedTrackData IndexedTrackData;
-
-			const input_item &trackRef = trackRefs[i];
-
-			trackData.push_back(IndexedTrackData());
-			trackData.back().first = indices[i];
-
-			// select tracks for SV finder
-
-			if (!trackSelector(*reco::btag::toTrack(trackRef), ipData[indices[i]], *jetRef,
-			                   RecoVertex::convertPos(
-			                   		pv.position()))) {
-				trackData.back().second.svStatus =
-					  TemplatedSecondaryVertexTagInfo<IPTI,VTX>::TrackData::trackSelected;
-				continue;
-			}
-
-			TransientTrackMap::const_iterator pos =
-					primariesMap.find(reco::btag::toTrack((trackRef)));
-			TransientTrack fitTrack;
-			if (pos != primariesMap.end()) {
-				primaries.erase(pos->second);
-				fitTrack = pos->second;
-			} else
-				fitTrack = trackBuilder->build(trackRef);
-			fitTracks.push_back(fitTrack);
-
-			trackData.back().second.svStatus =
-				  TemplatedSecondaryVertexTagInfo<IPTI,VTX>::TrackData::trackUsedForVertexFit;
-
-			if (useGhostTrack) {
-				GhostTrackState gtState(fitTrack);
-				GlobalPoint pos =
-					ipData[indices[i]].closestToGhostTrack;
-				gtState.linearize(*gtPred, true,
-				                  gtPred->lambda(pos));
-				gtState.setWeight(ipData[indices[i]].ghostTrackWeight);
-				gtStates.push_back(gtState);
-			}
-		}
-
-		std::unique_ptr<GhostTrack> ghostTrack;
-		if (useGhostTrack)
-			ghostTrack.reset(new GhostTrack(
-				GhostTrackPrediction(
-					RecoVertex::convertPos(pv.position()),
-					RecoVertex::convertError(pv.error()),
-					GlobalVector(
-						iterJets->ghostTrack()->px(),
-						iterJets->ghostTrack()->py(),
-						iterJets->ghostTrack()->pz()),
-					0.05),
-				*gtPred, gtStates,
-				iterJets->ghostTrack()->chi2(),
-				iterJets->ghostTrack()->ndof()));
-
-		// perform actual vertex finding
-
-
-	 	std::vector<VTX>       extAssoCollection;    
-		std::vector<TransientVertex> fittedSVs;
-		std::vector<SecondaryVertex> SVs;
-		if(!useExternalSV){ 
-    		  switch(constraint)   {
-		    case CONSTRAINT_NONE:
-			if (useGhostTrack)
-				fittedSVs = vertexRecoGT->vertices(
-						pv, *ghostTrack);
-			else
-				fittedSVs = vertexReco->vertices(fitTracks);
-			break;
-
-		    case CONSTRAINT_BEAMSPOT:
-			if (useGhostTrack)
-				fittedSVs = vertexRecoGT->vertices(
-						pv, *beamSpot, *ghostTrack);
-			else
-				fittedSVs = vertexReco->vertices(fitTracks,
-				                                 *beamSpot);
-			break;
-
-		    case CONSTRAINT_PV_BEAMSPOT_SIZE:
-		    case CONSTRAINT_PV_BS_Z_ERRORS_SCALED:
-		    case CONSTRAINT_PV_ERROR_SCALED: {
-			BeamSpot::CovarianceMatrix cov;
-			for(unsigned int i = 0; i < 7; i++) {
-				unsigned int covSrc = bsCovSrc[i];
-				for(unsigned int j = 0; j < 7; j++) {
-					double v=0.0;
-					if (!covSrc || bsCovSrc[j] != covSrc)
-						v = 0.0;
-					else if (covSrc == 1)
-						v = beamSpot->covariance(i, j);
-					else if (j<3 && i<3)
-						v = pv.covariance(i, j) *
-						    constraintScaling;
-					cov(i, j) = v;
-				}
-			}
-
-			BeamSpot bs(pv.position(), sigmaZ,
-			            beamSpot.isValid() ? beamSpot->dxdz() : 0.,
-			            beamSpot.isValid() ? beamSpot->dydz() : 0.,
-			            beamWidth, cov, BeamSpot::Unknown);
-
-			if (useGhostTrack)
-				fittedSVs = vertexRecoGT->vertices(
-						pv, bs, *ghostTrack);
-			else
-				fittedSVs = vertexReco->vertices(fitTracks, bs);
-		    }	break;
-
-		    case CONSTRAINT_PV_PRIMARIES_IN_FIT: {
-			std::vector<TransientTrack> primaries_(
-					primaries.begin(), primaries.end());
-			if (useGhostTrack)
-				fittedSVs = vertexRecoGT->vertices(
-						pv, *beamSpot, primaries_,
-						*ghostTrack);
-			else
-				fittedSVs = vertexReco->vertices(
-						primaries_, fitTracks,
-						*beamSpot);
-		    }	break;
-		  }
-		  // build combined SV information and filter
-		  SVBuilder svBuilder(pv, jetDir, withPVError, minTrackWeight);
-		  std::remove_copy_if(boost::make_transform_iterator(
-					  fittedSVs.begin(), svBuilder),
-				      boost::make_transform_iterator(
-					  fittedSVs.end(), svBuilder),
-				      std::back_inserter(SVs),
-				      SVFilter(vertexFilter, pv, jetDir));
-
-		}else{
-		  if( useSVClustering || useFatJets ) {
-		      size_t jetIdx = ( iterJets - trackIPTagInfos->begin() );
-		
-		      for(size_t iExtSv = 0; iExtSv < clusteredSVs.at(jetIdx).size(); iExtSv++){
-			 const VTX & extVertex = (*extSecVertex)[ clusteredSVs.at(jetIdx).at(iExtSv) ];
-			 if( extVertex.p4().M() < 0.3 )
-			   continue;
-			 extAssoCollection.push_back( extVertex );
-		      }
-		  }
-		  else {
-		      for(size_t iExtSv = 0; iExtSv < extSecVertex->size(); iExtSv++){
-			 const VTX & extVertex = (*extSecVertex)[iExtSv];
-			 if( Geom::deltaR2( ( position(extVertex) - pv.position() ), (extSVDeltaRToJet > 0) ? jetDir : -jetDir ) > extSVDeltaRToJet*extSVDeltaRToJet || extVertex.p4().M() < 0.3 )
-			   continue;
-			 extAssoCollection.push_back( extVertex );
-			
-		      }
-		  }
-		  // build combined SV information and filter
-		  SVBuilder svBuilder(pv, jetDir, withPVError, minTrackWeight);
-		  std::remove_copy_if(boost::make_transform_iterator( extAssoCollection.begin(), svBuilder),
-				    boost::make_transform_iterator(extAssoCollection.end(), svBuilder),
-				    std::back_inserter(SVs),
-				    SVFilter(vertexFilter, pv, jetDir));
-                }
-		// clean up now unneeded collections
-		gtPred.reset();
-		ghostTrack.reset();
-		gtStates.clear();
-		fitTracks.clear();
-		fittedSVs.clear();
-		extAssoCollection.clear();
-
-		// sort SVs by importance
-		
-		std::vector<unsigned int> vtxIndices = vertexSorting(SVs);
-
-		std::vector<typename TemplatedSecondaryVertexTagInfo<IPTI,VTX>::VertexData> svData;
-
-		svData.resize(vtxIndices.size());
-		for(unsigned int idx = 0; idx < vtxIndices.size(); idx++) {
-			const SecondaryVertex &sv = SVs[vtxIndices[idx]];
-
-			svData[idx].vertex = sv;
-			svData[idx].dist1d = sv.dist1d();
-                        svData[idx].dist2d = sv.dist2d();
-			svData[idx].dist3d = sv.dist3d();
-			svData[idx].direction = flightDirection(pv,sv);
-			// mark tracks successfully used in vertex fit
-			markUsedTracks(trackData,trackRefs,sv,idx);
-		}
-
-		// fill result into tag infos
-
-		tagInfos->push_back(
-			TemplatedSecondaryVertexTagInfo<IPTI,VTX>(
-				trackData, svData, SVs.size(),
-				edm::Ref<std::vector<IPTI> >(trackIPTagInfos,
-					iterJets - trackIPTagInfos->begin())));
-	}
-
-	event.put(std::move(tagInfos));
+template <class IPTI, class VTX>
+TemplatedSecondaryVertexProducer<IPTI, VTX>::~TemplatedSecondaryVertexProducer() {}
+
+template <class IPTI, class VTX>
+void TemplatedSecondaryVertexProducer<IPTI, VTX>::produce(edm::Event &event, const edm::EventSetup &es) {
+  //	typedef std::map<TrackBaseRef, TransientTrack,
+  //	                 RefToBaseLess<Track> > TransientTrackMap;
+  //How about good old pointers?
+  typedef std::map<const Track *, TransientTrack> TransientTrackMap;
+
+  edm::ESHandle<TransientTrackBuilder> trackBuilder;
+  es.get<TransientTrackRecord>().get("TransientTrackBuilder", trackBuilder);
+
+  edm::Handle<std::vector<IPTI> > trackIPTagInfos;
+  event.getByToken(token_trackIPTagInfo, trackIPTagInfos);
+
+  // External Sec Vertex collection (e.g. for IVF usage)
+  edm::Handle<edm::View<VTX> > extSecVertex;
+  if (useExternalSV)
+    event.getByToken(token_extSVCollection, extSecVertex);
+
+  edm::Handle<edm::View<reco::Jet> > fatJetsHandle;
+  edm::Handle<edm::View<reco::Jet> > groomedFatJetsHandle;
+  if (useFatJets) {
+    event.getByToken(token_fatJets, fatJetsHandle);
+
+    if (useGroomedFatJets) {
+      event.getByToken(token_groomedFatJets, groomedFatJetsHandle);
+
+      if (groomedFatJetsHandle->size() > fatJetsHandle->size())
+        edm::LogError("TooManyGroomedJets")
+            << "There are more groomed (" << groomedFatJetsHandle->size() << ") than original fat jets ("
+            << fatJetsHandle->size() << "). Please check that the two jet collections belong to each other.";
+    }
+  }
+
+  edm::Handle<BeamSpot> beamSpot;
+  unsigned int bsCovSrc[7] = {
+      0,
+  };
+  double sigmaZ = 0.0, beamWidth = 0.0;
+  switch (constraint) {
+    case CONSTRAINT_PV_BEAMSPOT_SIZE:
+      event.getByToken(token_BeamSpot, beamSpot);
+      bsCovSrc[3] = bsCovSrc[4] = bsCovSrc[5] = bsCovSrc[6] = 1;
+      sigmaZ = beamSpot->sigmaZ();
+      beamWidth = beamSpot->BeamWidthX();
+      break;
+
+    case CONSTRAINT_PV_BS_Z_ERRORS_SCALED:
+      event.getByToken(token_BeamSpot, beamSpot);
+      bsCovSrc[0] = bsCovSrc[1] = 2;
+      bsCovSrc[3] = bsCovSrc[4] = bsCovSrc[5] = 1;
+      sigmaZ = beamSpot->sigmaZ();
+      break;
+
+    case CONSTRAINT_PV_ERROR_SCALED:
+      bsCovSrc[0] = bsCovSrc[1] = bsCovSrc[2] = 2;
+      break;
+
+    case CONSTRAINT_BEAMSPOT:
+    case CONSTRAINT_PV_PRIMARIES_IN_FIT:
+      event.getByToken(token_BeamSpot, beamSpot);
+      break;
+
+    default:
+        /* nothing */;
+  }
+
+  // ------------------------------------ SV clustering START --------------------------------------------
+  std::vector<std::vector<int> > clusteredSVs(trackIPTagInfos->size(), std::vector<int>());
+  if (useExternalSV && useSVClustering && !trackIPTagInfos->empty()) {
+    // vector of constituents for reclustering jets and "ghost" SVs
+    std::vector<fastjet::PseudoJet> fjInputs;
+    // loop over all input jets and collect all their constituents
+    if (useFatJets) {
+      for (edm::View<reco::Jet>::const_iterator it = fatJetsHandle->begin(); it != fatJetsHandle->end(); ++it) {
+        std::vector<edm::Ptr<reco::Candidate> > constituents = it->getJetConstituents();
+        std::vector<edm::Ptr<reco::Candidate> >::const_iterator m;
+        for (m = constituents.begin(); m != constituents.end(); ++m) {
+          reco::CandidatePtr constit = *m;
+          if (constit->pt() == 0) {
+            edm::LogWarning("NullTransverseMomentum") << "dropping input candidate with pt=0";
+            continue;
+          }
+          fjInputs.push_back(fastjet::PseudoJet(constit->px(), constit->py(), constit->pz(), constit->energy()));
+        }
+      }
+    } else {
+      for (typename std::vector<IPTI>::const_iterator it = trackIPTagInfos->begin(); it != trackIPTagInfos->end();
+           ++it) {
+        std::vector<edm::Ptr<reco::Candidate> > constituents = it->jet()->getJetConstituents();
+        std::vector<edm::Ptr<reco::Candidate> >::const_iterator m;
+        for (m = constituents.begin(); m != constituents.end(); ++m) {
+          reco::CandidatePtr constit = *m;
+          if (constit->pt() == 0) {
+            edm::LogWarning("NullTransverseMomentum") << "dropping input candidate with pt=0";
+            continue;
+          }
+          fjInputs.push_back(fastjet::PseudoJet(constit->px(), constit->py(), constit->pz(), constit->energy()));
+        }
+      }
+    }
+    // insert "ghost" SVs in the vector of constituents
+    for (typename edm::View<VTX>::const_iterator it = extSecVertex->begin(); it != extSecVertex->end(); ++it) {
+      const reco::Vertex &pv = *(trackIPTagInfos->front().primaryVertex());
+      GlobalVector dir = flightDirection(pv, *it);
+      dir = dir.unit();
+      fastjet::PseudoJet p(
+          dir.x(), dir.y(), dir.z(), dir.mag());  // using SV flight direction so treating SV as massless
+      if (useSVMomentum)
+        p = fastjet::PseudoJet(it->p4().px(), it->p4().py(), it->p4().pz(), it->p4().energy());
+      p *= ghostRescaling;  // rescale SV direction/momentum
+      p.set_user_info(new VertexInfo(it - extSecVertex->begin()));
+      fjInputs.push_back(p);
+    }
+
+    // define jet clustering sequence
+    fjClusterSeq = ClusterSequencePtr(new fastjet::ClusterSequence(fjInputs, *fjJetDefinition));
+    // recluster jet constituents and inserted "ghosts"
+    std::vector<fastjet::PseudoJet> inclusiveJets = fastjet::sorted_by_pt(fjClusterSeq->inclusive_jets(jetPtMin));
+
+    if (useFatJets) {
+      if (inclusiveJets.size() < fatJetsHandle->size())
+        edm::LogError("TooFewReclusteredJets")
+            << "There are fewer reclustered (" << inclusiveJets.size() << ") than original fat jets ("
+            << fatJetsHandle->size()
+            << "). Please check that the jet algorithm and jet size match those used for the original jet collection.";
+
+      // match reclustered and original fat jets
+      std::vector<int> reclusteredIndices;
+      matchReclusteredJets<edm::View<reco::Jet> >(fatJetsHandle, inclusiveJets, reclusteredIndices, "fat");
+
+      // match groomed and original fat jets
+      std::vector<int> groomedIndices;
+      if (useGroomedFatJets)
+        matchGroomedJets(fatJetsHandle, groomedFatJetsHandle, groomedIndices);
+
+      // match subjets and original fat jets
+      std::vector<std::vector<int> > subjetIndices;
+      if (useGroomedFatJets)
+        matchSubjets(groomedIndices, groomedFatJetsHandle, trackIPTagInfos, subjetIndices);
+      else
+        matchSubjets(fatJetsHandle, trackIPTagInfos, subjetIndices);
+
+      // collect clustered SVs
+      for (size_t i = 0; i < fatJetsHandle->size(); ++i) {
+        if (reclusteredIndices.at(i) < 0)
+          continue;  // continue if matching reclustered to original jets failed
+
+        if (fatJetsHandle->at(i).pt() == 0)  // continue if the original jet has Pt=0
+        {
+          edm::LogWarning("NullTransverseMomentum")
+              << "The original fat jet " << i << " has Pt=0. This is not expected so the jet will be skipped.";
+          continue;
+        }
+
+        if (subjetIndices.at(i).empty())
+          continue;  // continue if the original jet does not have subjets assigned
+
+        // since the "ghosts" are extremely soft, the configuration and ordering of the reclustered and original fat jets should in principle stay the same
+        if ((std::abs(inclusiveJets.at(reclusteredIndices.at(i)).pt() - fatJetsHandle->at(i).pt()) /
+             fatJetsHandle->at(i).pt()) > relPtTolerance) {
+          if (fatJetsHandle->at(i).pt() < 10.)  // special handling for low-Pt jets (Pt<10 GeV)
+            edm::LogWarning("JetPtMismatchAtLowPt")
+                << "The reclustered and original fat jet " << i << " have different Pt's ("
+                << inclusiveJets.at(reclusteredIndices.at(i)).pt() << " vs " << fatJetsHandle->at(i).pt()
+                << " GeV, respectively).\n"
+                << "Please check that the jet algorithm and jet size match those used for the original fat jet "
+                   "collection and also make sure the original fat jets are uncorrected. In addition, make sure you "
+                   "are not using CaloJets which are presently not supported.\n"
+                << "Since the mismatch is at low Pt, it is ignored and only a warning is issued.\n"
+                << "\nIn extremely rare instances the mismatch could be caused by a difference in the machine "
+                   "precision in which case make sure the original jet collection is produced and reclustering is "
+                   "performed in the same job.";
+          else
+            edm::LogError("JetPtMismatch")
+                << "The reclustered and original fat jet " << i << " have different Pt's ("
+                << inclusiveJets.at(reclusteredIndices.at(i)).pt() << " vs " << fatJetsHandle->at(i).pt()
+                << " GeV, respectively).\n"
+                << "Please check that the jet algorithm and jet size match those used for the original fat jet "
+                   "collection and also make sure the original fat jets are uncorrected. In addition, make sure you "
+                   "are not using CaloJets which are presently not supported.\n"
+                << "\nIn extremely rare instances the mismatch could be caused by a difference in the machine "
+                   "precision in which case make sure the original jet collection is produced and reclustering is "
+                   "performed in the same job.";
+        }
+
+        // get jet constituents
+        std::vector<fastjet::PseudoJet> constituents = inclusiveJets.at(reclusteredIndices.at(i)).constituents();
+
+        std::vector<int> svIndices;
+        // loop over jet constituents and try to find "ghosts"
+        for (std::vector<fastjet::PseudoJet>::const_iterator it = constituents.begin(); it != constituents.end();
+             ++it) {
+          if (!it->has_user_info())
+            continue;  // skip if not a "ghost"
+
+          svIndices.push_back(it->user_info<VertexInfo>().vertexIndex());
+        }
+
+        // loop over clustered SVs and assign them to different subjets based on smallest dR
+        for (size_t sv = 0; sv < svIndices.size(); ++sv) {
+          const reco::Vertex &pv = *(trackIPTagInfos->front().primaryVertex());
+          const VTX &extSV = (*extSecVertex)[svIndices.at(sv)];
+          GlobalVector dir = flightDirection(pv, extSV);
+          dir = dir.unit();
+          fastjet::PseudoJet p(
+              dir.x(), dir.y(), dir.z(), dir.mag());  // using SV flight direction so treating SV as massless
+          if (useSVMomentum)
+            p = fastjet::PseudoJet(extSV.p4().px(), extSV.p4().py(), extSV.p4().pz(), extSV.p4().energy());
+
+          std::vector<double> dR2toSubjets;
+
+          for (size_t sj = 0; sj < subjetIndices.at(i).size(); ++sj)
+            dR2toSubjets.push_back(Geom::deltaR2(p.rapidity(),
+                                                 p.phi_std(),
+                                                 trackIPTagInfos->at(subjetIndices.at(i).at(sj)).jet()->rapidity(),
+                                                 trackIPTagInfos->at(subjetIndices.at(i).at(sj)).jet()->phi()));
+
+          // find the closest subjet
+          int closestSubjetIdx =
+              std::distance(dR2toSubjets.begin(), std::min_element(dR2toSubjets.begin(), dR2toSubjets.end()));
+
+          clusteredSVs.at(subjetIndices.at(i).at(closestSubjetIdx)).push_back(svIndices.at(sv));
+        }
+      }
+    } else {
+      if (inclusiveJets.size() < trackIPTagInfos->size())
+        edm::LogError("TooFewReclusteredJets")
+            << "There are fewer reclustered (" << inclusiveJets.size() << ") than original jets ("
+            << trackIPTagInfos->size()
+            << "). Please check that the jet algorithm and jet size match those used for the original jet collection.";
+
+      // match reclustered and original jets
+      std::vector<int> reclusteredIndices;
+      matchReclusteredJets<std::vector<IPTI> >(trackIPTagInfos, inclusiveJets, reclusteredIndices);
+
+      // collect clustered SVs
+      for (size_t i = 0; i < trackIPTagInfos->size(); ++i) {
+        if (reclusteredIndices.at(i) < 0)
+          continue;  // continue if matching reclustered to original jets failed
+
+        if (trackIPTagInfos->at(i).jet()->pt() == 0)  // continue if the original jet has Pt=0
+        {
+          edm::LogWarning("NullTransverseMomentum")
+              << "The original jet " << i << " has Pt=0. This is not expected so the jet will be skipped.";
+          continue;
+        }
+
+        // since the "ghosts" are extremely soft, the configuration and ordering of the reclustered and original jets should in principle stay the same
+        if ((std::abs(inclusiveJets.at(reclusteredIndices.at(i)).pt() - trackIPTagInfos->at(i).jet()->pt()) /
+             trackIPTagInfos->at(i).jet()->pt()) > relPtTolerance) {
+          if (trackIPTagInfos->at(i).jet()->pt() < 10.)  // special handling for low-Pt jets (Pt<10 GeV)
+            edm::LogWarning("JetPtMismatchAtLowPt")
+                << "The reclustered and original jet " << i << " have different Pt's ("
+                << inclusiveJets.at(reclusteredIndices.at(i)).pt() << " vs " << trackIPTagInfos->at(i).jet()->pt()
+                << " GeV, respectively).\n"
+                << "Please check that the jet algorithm and jet size match those used for the original jet collection "
+                   "and also make sure the original jets are uncorrected. In addition, make sure you are not using "
+                   "CaloJets which are presently not supported.\n"
+                << "Since the mismatch is at low Pt, it is ignored and only a warning is issued.\n"
+                << "\nIn extremely rare instances the mismatch could be caused by a difference in the machine "
+                   "precision in which case make sure the original jet collection is produced and reclustering is "
+                   "performed in the same job.";
+          else
+            edm::LogError("JetPtMismatch")
+                << "The reclustered and original jet " << i << " have different Pt's ("
+                << inclusiveJets.at(reclusteredIndices.at(i)).pt() << " vs " << trackIPTagInfos->at(i).jet()->pt()
+                << " GeV, respectively).\n"
+                << "Please check that the jet algorithm and jet size match those used for the original jet collection "
+                   "and also make sure the original jets are uncorrected. In addition, make sure you are not using "
+                   "CaloJets which are presently not supported.\n"
+                << "\nIn extremely rare instances the mismatch could be caused by a difference in the machine "
+                   "precision in which case make sure the original jet collection is produced and reclustering is "
+                   "performed in the same job.";
+        }
+
+        // get jet constituents
+        std::vector<fastjet::PseudoJet> constituents = inclusiveJets.at(reclusteredIndices.at(i)).constituents();
+
+        // loop over jet constituents and try to find "ghosts"
+        for (std::vector<fastjet::PseudoJet>::const_iterator it = constituents.begin(); it != constituents.end();
+             ++it) {
+          if (!it->has_user_info())
+            continue;  // skip if not a "ghost"
+          // push back clustered SV indices
+          clusteredSVs.at(i).push_back(it->user_info<VertexInfo>().vertexIndex());
+        }
+      }
+    }
+  }
+  // case where fat jets are used to associate SVs to subjets but no SV clustering is performed
+  else if (useExternalSV && !useSVClustering && !trackIPTagInfos->empty() && useFatJets) {
+    // match groomed and original fat jets
+    std::vector<int> groomedIndices;
+    if (useGroomedFatJets)
+      matchGroomedJets(fatJetsHandle, groomedFatJetsHandle, groomedIndices);
+
+    // match subjets and original fat jets
+    std::vector<std::vector<int> > subjetIndices;
+    if (useGroomedFatJets)
+      matchSubjets(groomedIndices, groomedFatJetsHandle, trackIPTagInfos, subjetIndices);
+    else
+      matchSubjets(fatJetsHandle, trackIPTagInfos, subjetIndices);
+
+    // loop over fat jets
+    for (size_t i = 0; i < fatJetsHandle->size(); ++i) {
+      if (fatJetsHandle->at(i).pt() == 0)  // continue if the original jet has Pt=0
+      {
+        edm::LogWarning("NullTransverseMomentum")
+            << "The original fat jet " << i << " has Pt=0. This is not expected so the jet will be skipped.";
+        continue;
+      }
+
+      if (subjetIndices.at(i).empty())
+        continue;  // continue if the original jet does not have subjets assigned
+
+      // loop over SVs, associate them to fat jets based on dR cone and
+      // then assign them to the closets subjet in dR
+      for (typename edm::View<VTX>::const_iterator it = extSecVertex->begin(); it != extSecVertex->end(); ++it) {
+        size_t sv = (it - extSecVertex->begin());
+
+        const reco::Vertex &pv = *(trackIPTagInfos->front().primaryVertex());
+        const VTX &extSV = (*extSecVertex)[sv];
+        GlobalVector dir = flightDirection(pv, extSV);
+        GlobalVector jetDir(fatJetsHandle->at(i).px(), fatJetsHandle->at(i).py(), fatJetsHandle->at(i).pz());
+        // skip SVs outside the dR cone
+        if (Geom::deltaR2(dir, jetDir) > rParam * rParam)  // here using the jet clustering rParam as a dR cut
+          continue;
+
+        dir = dir.unit();
+        fastjet::PseudoJet p(
+            dir.x(), dir.y(), dir.z(), dir.mag());  // using SV flight direction so treating SV as massless
+        if (useSVMomentum)
+          p = fastjet::PseudoJet(extSV.p4().px(), extSV.p4().py(), extSV.p4().pz(), extSV.p4().energy());
+
+        std::vector<double> dR2toSubjets;
+
+        for (size_t sj = 0; sj < subjetIndices.at(i).size(); ++sj)
+          dR2toSubjets.push_back(Geom::deltaR2(p.rapidity(),
+                                               p.phi_std(),
+                                               trackIPTagInfos->at(subjetIndices.at(i).at(sj)).jet()->rapidity(),
+                                               trackIPTagInfos->at(subjetIndices.at(i).at(sj)).jet()->phi()));
+
+        // find the closest subjet
+        int closestSubjetIdx =
+            std::distance(dR2toSubjets.begin(), std::min_element(dR2toSubjets.begin(), dR2toSubjets.end()));
+
+        clusteredSVs.at(subjetIndices.at(i).at(closestSubjetIdx)).push_back(sv);
+      }
+    }
+  }
+  // ------------------------------------ SV clustering END ----------------------------------------------
+
+  std::unique_ptr<ConfigurableVertexReconstructor> vertexReco;
+  std::unique_ptr<GhostTrackVertexFinder> vertexRecoGT;
+  if (useGhostTrack)
+    vertexRecoGT.reset(
+        new GhostTrackVertexFinder(vtxRecoPSet.getParameter<double>("maxFitChi2"),
+                                   vtxRecoPSet.getParameter<double>("mergeThreshold"),
+                                   vtxRecoPSet.getParameter<double>("primcut"),
+                                   vtxRecoPSet.getParameter<double>("seccut"),
+                                   getGhostTrackFitType(vtxRecoPSet.getParameter<std::string>("fitType"))));
+  else
+    vertexReco.reset(new ConfigurableVertexReconstructor(vtxRecoPSet));
+
+  TransientTrackMap primariesMap;
+
+  // result secondary vertices
+
+  auto tagInfos = std::make_unique<Product>();
+
+  for (typename std::vector<IPTI>::const_iterator iterJets = trackIPTagInfos->begin();
+       iterJets != trackIPTagInfos->end();
+       ++iterJets) {
+    TrackDataVector trackData;
+    //		      std::cout << "Jet " << iterJets-trackIPTagInfos->begin() << std::endl;
+
+    const Vertex &pv = *iterJets->primaryVertex();
+
+    std::set<TransientTrack> primaries;
+    if (constraint == CONSTRAINT_PV_PRIMARIES_IN_FIT) {
+      for (Vertex::trackRef_iterator iter = pv.tracks_begin(); iter != pv.tracks_end(); ++iter) {
+        TransientTrackMap::iterator pos = primariesMap.lower_bound(iter->get());
+
+        if (pos != primariesMap.end() && pos->first == iter->get())
+          primaries.insert(pos->second);
+        else {
+          TransientTrack track = trackBuilder->build(iter->castTo<TrackRef>());
+          primariesMap.insert(pos, std::make_pair(iter->get(), track));
+          primaries.insert(track);
+        }
+      }
+    }
+
+    edm::RefToBase<Jet> jetRef = iterJets->jet();
+
+    GlobalVector jetDir(jetRef->momentum().x(), jetRef->momentum().y(), jetRef->momentum().z());
+
+    std::vector<std::size_t> indices = iterJets->sortedIndexes(sortCriterium);
+
+    input_container trackRefs = iterJets->sortedTracks(indices);
+
+    const std::vector<reco::btag::TrackIPData> &ipData = iterJets->impactParameterData();
+
+    // build transient tracks used for vertex reconstruction
+
+    std::vector<TransientTrack> fitTracks;
+    std::vector<GhostTrackState> gtStates;
+    std::unique_ptr<GhostTrackPrediction> gtPred;
+    if (useGhostTrack)
+      gtPred.reset(new GhostTrackPrediction(*iterJets->ghostTrack()));
+
+    for (unsigned int i = 0; i < indices.size(); i++) {
+      typedef typename TemplatedSecondaryVertexTagInfo<IPTI, VTX>::IndexedTrackData IndexedTrackData;
+
+      const input_item &trackRef = trackRefs[i];
+
+      trackData.push_back(IndexedTrackData());
+      trackData.back().first = indices[i];
+
+      // select tracks for SV finder
+
+      if (!trackSelector(
+              *reco::btag::toTrack(trackRef), ipData[indices[i]], *jetRef, RecoVertex::convertPos(pv.position()))) {
+        trackData.back().second.svStatus = TemplatedSecondaryVertexTagInfo<IPTI, VTX>::TrackData::trackSelected;
+        continue;
+      }
+
+      TransientTrackMap::const_iterator pos = primariesMap.find(reco::btag::toTrack((trackRef)));
+      TransientTrack fitTrack;
+      if (pos != primariesMap.end()) {
+        primaries.erase(pos->second);
+        fitTrack = pos->second;
+      } else
+        fitTrack = trackBuilder->build(trackRef);
+      fitTracks.push_back(fitTrack);
+
+      trackData.back().second.svStatus = TemplatedSecondaryVertexTagInfo<IPTI, VTX>::TrackData::trackUsedForVertexFit;
+
+      if (useGhostTrack) {
+        GhostTrackState gtState(fitTrack);
+        GlobalPoint pos = ipData[indices[i]].closestToGhostTrack;
+        gtState.linearize(*gtPred, true, gtPred->lambda(pos));
+        gtState.setWeight(ipData[indices[i]].ghostTrackWeight);
+        gtStates.push_back(gtState);
+      }
+    }
+
+    std::unique_ptr<GhostTrack> ghostTrack;
+    if (useGhostTrack)
+      ghostTrack.reset(new GhostTrack(
+          GhostTrackPrediction(
+              RecoVertex::convertPos(pv.position()),
+              RecoVertex::convertError(pv.error()),
+              GlobalVector(iterJets->ghostTrack()->px(), iterJets->ghostTrack()->py(), iterJets->ghostTrack()->pz()),
+              0.05),
+          *gtPred,
+          gtStates,
+          iterJets->ghostTrack()->chi2(),
+          iterJets->ghostTrack()->ndof()));
+
+    // perform actual vertex finding
+
+    std::vector<VTX> extAssoCollection;
+    std::vector<TransientVertex> fittedSVs;
+    std::vector<SecondaryVertex> SVs;
+    if (!useExternalSV) {
+      switch (constraint) {
+        case CONSTRAINT_NONE:
+          if (useGhostTrack)
+            fittedSVs = vertexRecoGT->vertices(pv, *ghostTrack);
+          else
+            fittedSVs = vertexReco->vertices(fitTracks);
+          break;
+
+        case CONSTRAINT_BEAMSPOT:
+          if (useGhostTrack)
+            fittedSVs = vertexRecoGT->vertices(pv, *beamSpot, *ghostTrack);
+          else
+            fittedSVs = vertexReco->vertices(fitTracks, *beamSpot);
+          break;
+
+        case CONSTRAINT_PV_BEAMSPOT_SIZE:
+        case CONSTRAINT_PV_BS_Z_ERRORS_SCALED:
+        case CONSTRAINT_PV_ERROR_SCALED: {
+          BeamSpot::CovarianceMatrix cov;
+          for (unsigned int i = 0; i < 7; i++) {
+            unsigned int covSrc = bsCovSrc[i];
+            for (unsigned int j = 0; j < 7; j++) {
+              double v = 0.0;
+              if (!covSrc || bsCovSrc[j] != covSrc)
+                v = 0.0;
+              else if (covSrc == 1)
+                v = beamSpot->covariance(i, j);
+              else if (j < 3 && i < 3)
+                v = pv.covariance(i, j) * constraintScaling;
+              cov(i, j) = v;
+            }
+          }
+
+          BeamSpot bs(pv.position(),
+                      sigmaZ,
+                      beamSpot.isValid() ? beamSpot->dxdz() : 0.,
+                      beamSpot.isValid() ? beamSpot->dydz() : 0.,
+                      beamWidth,
+                      cov,
+                      BeamSpot::Unknown);
+
+          if (useGhostTrack)
+            fittedSVs = vertexRecoGT->vertices(pv, bs, *ghostTrack);
+          else
+            fittedSVs = vertexReco->vertices(fitTracks, bs);
+        } break;
+
+        case CONSTRAINT_PV_PRIMARIES_IN_FIT: {
+          std::vector<TransientTrack> primaries_(primaries.begin(), primaries.end());
+          if (useGhostTrack)
+            fittedSVs = vertexRecoGT->vertices(pv, *beamSpot, primaries_, *ghostTrack);
+          else
+            fittedSVs = vertexReco->vertices(primaries_, fitTracks, *beamSpot);
+        } break;
+      }
+      // build combined SV information and filter
+      SVBuilder svBuilder(pv, jetDir, withPVError, minTrackWeight);
+      std::remove_copy_if(boost::make_transform_iterator(fittedSVs.begin(), svBuilder),
+                          boost::make_transform_iterator(fittedSVs.end(), svBuilder),
+                          std::back_inserter(SVs),
+                          SVFilter(vertexFilter, pv, jetDir));
+
+    } else {
+      if (useSVClustering || useFatJets) {
+        size_t jetIdx = (iterJets - trackIPTagInfos->begin());
+
+        for (size_t iExtSv = 0; iExtSv < clusteredSVs.at(jetIdx).size(); iExtSv++) {
+          const VTX &extVertex = (*extSecVertex)[clusteredSVs.at(jetIdx).at(iExtSv)];
+          if (extVertex.p4().M() < 0.3)
+            continue;
+          extAssoCollection.push_back(extVertex);
+        }
+      } else {
+        for (size_t iExtSv = 0; iExtSv < extSecVertex->size(); iExtSv++) {
+          const VTX &extVertex = (*extSecVertex)[iExtSv];
+          if (Geom::deltaR2((position(extVertex) - pv.position()), (extSVDeltaRToJet > 0) ? jetDir : -jetDir) >
+                  extSVDeltaRToJet * extSVDeltaRToJet ||
+              extVertex.p4().M() < 0.3)
+            continue;
+          extAssoCollection.push_back(extVertex);
+        }
+      }
+      // build combined SV information and filter
+      SVBuilder svBuilder(pv, jetDir, withPVError, minTrackWeight);
+      std::remove_copy_if(boost::make_transform_iterator(extAssoCollection.begin(), svBuilder),
+                          boost::make_transform_iterator(extAssoCollection.end(), svBuilder),
+                          std::back_inserter(SVs),
+                          SVFilter(vertexFilter, pv, jetDir));
+    }
+    // clean up now unneeded collections
+    gtPred.reset();
+    ghostTrack.reset();
+    gtStates.clear();
+    fitTracks.clear();
+    fittedSVs.clear();
+    extAssoCollection.clear();
+
+    // sort SVs by importance
+
+    std::vector<unsigned int> vtxIndices = vertexSorting(SVs);
+
+    std::vector<typename TemplatedSecondaryVertexTagInfo<IPTI, VTX>::VertexData> svData;
+
+    svData.resize(vtxIndices.size());
+    for (unsigned int idx = 0; idx < vtxIndices.size(); idx++) {
+      const SecondaryVertex &sv = SVs[vtxIndices[idx]];
+
+      svData[idx].vertex = sv;
+      svData[idx].dist1d = sv.dist1d();
+      svData[idx].dist2d = sv.dist2d();
+      svData[idx].dist3d = sv.dist3d();
+      svData[idx].direction = flightDirection(pv, sv);
+      // mark tracks successfully used in vertex fit
+      markUsedTracks(trackData, trackRefs, sv, idx);
+    }
+
+    // fill result into tag infos
+
+    tagInfos->push_back(TemplatedSecondaryVertexTagInfo<IPTI, VTX>(
+        trackData,
+        svData,
+        SVs.size(),
+        edm::Ref<std::vector<IPTI> >(trackIPTagInfos, iterJets - trackIPTagInfos->begin())));
+  }
+
+  event.put(std::move(tagInfos));
 }
 
 //Need specialized template because reco::Vertex iterators are TrackBase and it is a mess to make general
 template <>
-void  TemplatedSecondaryVertexProducer<TrackIPTagInfo,reco::Vertex>::markUsedTracks(TrackDataVector & trackData, const input_container & trackRefs, const SecondaryVertex & sv,size_t idx)
-{
-	for(Vertex::trackRef_iterator iter = sv.tracks_begin();	iter != sv.tracks_end(); ++iter) {
-		if (sv.trackWeight(*iter) < minTrackWeight)
-			continue;
+void TemplatedSecondaryVertexProducer<TrackIPTagInfo, reco::Vertex>::markUsedTracks(TrackDataVector &trackData,
+                                                                                    const input_container &trackRefs,
+                                                                                    const SecondaryVertex &sv,
+                                                                                    size_t idx) {
+  for (Vertex::trackRef_iterator iter = sv.tracks_begin(); iter != sv.tracks_end(); ++iter) {
+    if (sv.trackWeight(*iter) < minTrackWeight)
+      continue;
 
-		typename input_container::const_iterator pos =
-			std::find(trackRefs.begin(), trackRefs.end(),
-					iter->castTo<input_item>());
+    typename input_container::const_iterator pos =
+        std::find(trackRefs.begin(), trackRefs.end(), iter->castTo<input_item>());
 
-		if (pos == trackRefs.end() ) {
-			if(!useExternalSV)
-				throw cms::Exception("TrackNotFound")
-					<< "Could not find track from secondary "
-					"vertex in original tracks."
-					<< std::endl;
-		} else {
-			unsigned int index = pos - trackRefs.begin();
-			trackData[index].second.svStatus =
-				(btag::TrackData::Status)
-				((unsigned int)btag::TrackData::trackAssociatedToVertex + idx);
-		}
-	}
+    if (pos == trackRefs.end()) {
+      if (!useExternalSV)
+        throw cms::Exception("TrackNotFound") << "Could not find track from secondary "
+                                                 "vertex in original tracks."
+                                              << std::endl;
+    } else {
+      unsigned int index = pos - trackRefs.begin();
+      trackData[index].second.svStatus =
+          (btag::TrackData::Status)((unsigned int)btag::TrackData::trackAssociatedToVertex + idx);
+    }
+  }
 }
 template <>
-void  TemplatedSecondaryVertexProducer<CandIPTagInfo,reco::VertexCompositePtrCandidate>::markUsedTracks(TrackDataVector & trackData, const input_container & trackRefs, const SecondaryVertex & sv,size_t idx)
-{
-	for(typename input_container::const_iterator iter = sv.daughterPtrVector().begin(); iter != sv.daughterPtrVector().end(); ++iter)
-	{
-		typename input_container::const_iterator pos =
-			std::find(trackRefs.begin(), trackRefs.end(), *iter);
+void TemplatedSecondaryVertexProducer<CandIPTagInfo, reco::VertexCompositePtrCandidate>::markUsedTracks(
+    TrackDataVector &trackData, const input_container &trackRefs, const SecondaryVertex &sv, size_t idx) {
+  for (typename input_container::const_iterator iter = sv.daughterPtrVector().begin();
+       iter != sv.daughterPtrVector().end();
+       ++iter) {
+    typename input_container::const_iterator pos = std::find(trackRefs.begin(), trackRefs.end(), *iter);
 
-		if (pos != trackRefs.end() )
-		{
-			unsigned int index = pos - trackRefs.begin();
-			trackData[index].second.svStatus =
-				(btag::TrackData::Status)
-				((unsigned int)btag::TrackData::trackAssociatedToVertex + idx);
-		}
-	}
-}
-
-
-template <>
-typename TemplatedSecondaryVertexProducer<TrackIPTagInfo,reco::Vertex>::SecondaryVertex  
-TemplatedSecondaryVertexProducer<TrackIPTagInfo,reco::Vertex>::SVBuilder::operator () (const TransientVertex &sv) const
-{
-	if(!sv.originalTracks().empty() && sv.originalTracks()[0].trackBaseRef().isNonnull())
-		return SecondaryVertex(pv, sv, direction, withPVError);
-	else
-	{
-		edm::LogError("UnexpectedInputs") << "Building from Candidates, should not happen!";
-		return SecondaryVertex(pv, sv, direction, withPVError);
-	}
+    if (pos != trackRefs.end()) {
+      unsigned int index = pos - trackRefs.begin();
+      trackData[index].second.svStatus =
+          (btag::TrackData::Status)((unsigned int)btag::TrackData::trackAssociatedToVertex + idx);
+    }
+  }
 }
 
 template <>
-typename TemplatedSecondaryVertexProducer<CandIPTagInfo,reco::VertexCompositePtrCandidate>::SecondaryVertex
-TemplatedSecondaryVertexProducer<CandIPTagInfo,reco::VertexCompositePtrCandidate>::SVBuilder::operator () (const TransientVertex &sv) const
-{
-	if(!sv.originalTracks().empty() && sv.originalTracks()[0].trackBaseRef().isNonnull())
-	{
-		edm::LogError("UnexpectedInputs") << "Building from Tracks, should not happen!";
-		VertexCompositePtrCandidate vtxCompPtrCand;
-		
-		vtxCompPtrCand.setCovariance(sv.vertexState().error().matrix());
-		vtxCompPtrCand.setChi2AndNdof(sv.totalChiSquared(), sv.degreesOfFreedom());
-		vtxCompPtrCand.setVertex(Candidate::Point(sv.position().x(),sv.position().y(),sv.position().z()));
-		
-		return SecondaryVertex(pv, vtxCompPtrCand, direction, withPVError);
-	}
-	else
-	{
-		VertexCompositePtrCandidate vtxCompPtrCand;
-		
-		vtxCompPtrCand.setCovariance(sv.vertexState().error().matrix());
-		vtxCompPtrCand.setChi2AndNdof(sv.totalChiSquared(), sv.degreesOfFreedom());
-		vtxCompPtrCand.setVertex(Candidate::Point(sv.position().x(),sv.position().y(),sv.position().z()));
-		
-		Candidate::LorentzVector p4;
-		for(std::vector<reco::TransientTrack>::const_iterator tt = sv.originalTracks().begin(); tt != sv.originalTracks().end(); ++tt)
-		{
-			if (sv.trackWeight(*tt) < minTrackWeight)
-				continue;
-			
-			const CandidatePtrTransientTrack* cptt = dynamic_cast<const CandidatePtrTransientTrack*>(tt->basicTransientTrack());
-			if ( cptt==nullptr )
-				edm::LogError("DynamicCastingFailed") << "Casting of TransientTrack to CandidatePtrTransientTrack failed!";
-			else
-			{
-				p4 += cptt->candidate()->p4();
-				vtxCompPtrCand.addDaughter(cptt->candidate());
-			}
-		}
-		vtxCompPtrCand.setP4(p4);
-		
-		return SecondaryVertex(pv, vtxCompPtrCand, direction, withPVError);
-	}
+typename TemplatedSecondaryVertexProducer<TrackIPTagInfo, reco::Vertex>::SecondaryVertex
+TemplatedSecondaryVertexProducer<TrackIPTagInfo, reco::Vertex>::SVBuilder::operator()(const TransientVertex &sv) const {
+  if (!sv.originalTracks().empty() && sv.originalTracks()[0].trackBaseRef().isNonnull())
+    return SecondaryVertex(pv, sv, direction, withPVError);
+  else {
+    edm::LogError("UnexpectedInputs") << "Building from Candidates, should not happen!";
+    return SecondaryVertex(pv, sv, direction, withPVError);
+  }
+}
+
+template <>
+typename TemplatedSecondaryVertexProducer<CandIPTagInfo, reco::VertexCompositePtrCandidate>::SecondaryVertex
+TemplatedSecondaryVertexProducer<CandIPTagInfo, reco::VertexCompositePtrCandidate>::SVBuilder::operator()(
+    const TransientVertex &sv) const {
+  if (!sv.originalTracks().empty() && sv.originalTracks()[0].trackBaseRef().isNonnull()) {
+    edm::LogError("UnexpectedInputs") << "Building from Tracks, should not happen!";
+    VertexCompositePtrCandidate vtxCompPtrCand;
+
+    vtxCompPtrCand.setCovariance(sv.vertexState().error().matrix());
+    vtxCompPtrCand.setChi2AndNdof(sv.totalChiSquared(), sv.degreesOfFreedom());
+    vtxCompPtrCand.setVertex(Candidate::Point(sv.position().x(), sv.position().y(), sv.position().z()));
+
+    return SecondaryVertex(pv, vtxCompPtrCand, direction, withPVError);
+  } else {
+    VertexCompositePtrCandidate vtxCompPtrCand;
+
+    vtxCompPtrCand.setCovariance(sv.vertexState().error().matrix());
+    vtxCompPtrCand.setChi2AndNdof(sv.totalChiSquared(), sv.degreesOfFreedom());
+    vtxCompPtrCand.setVertex(Candidate::Point(sv.position().x(), sv.position().y(), sv.position().z()));
+
+    Candidate::LorentzVector p4;
+    for (std::vector<reco::TransientTrack>::const_iterator tt = sv.originalTracks().begin();
+         tt != sv.originalTracks().end();
+         ++tt) {
+      if (sv.trackWeight(*tt) < minTrackWeight)
+        continue;
+
+      const CandidatePtrTransientTrack *cptt =
+          dynamic_cast<const CandidatePtrTransientTrack *>(tt->basicTransientTrack());
+      if (cptt == nullptr)
+        edm::LogError("DynamicCastingFailed") << "Casting of TransientTrack to CandidatePtrTransientTrack failed!";
+      else {
+        p4 += cptt->candidate()->p4();
+        vtxCompPtrCand.addDaughter(cptt->candidate());
+      }
+    }
+    vtxCompPtrCand.setP4(p4);
+
+    return SecondaryVertex(pv, vtxCompPtrCand, direction, withPVError);
+  }
 }
 
 // ------------ method that matches reclustered and original jets based on minimum dR ------------
-template<class IPTI,class VTX>
-template<class CONTAINER>
-void TemplatedSecondaryVertexProducer<IPTI,VTX>::matchReclusteredJets(const edm::Handle<CONTAINER>& jets,
-                                                                      const std::vector<fastjet::PseudoJet>& reclusteredJets,
-                                                                      std::vector<int>& matchedIndices,
-                                                                      const std::string& jetType)
-{
-   std::string type = ( !jetType.empty() ? jetType + " " : jetType );
+template <class IPTI, class VTX>
+template <class CONTAINER>
+void TemplatedSecondaryVertexProducer<IPTI, VTX>::matchReclusteredJets(
+    const edm::Handle<CONTAINER> &jets,
+    const std::vector<fastjet::PseudoJet> &reclusteredJets,
+    std::vector<int> &matchedIndices,
+    const std::string &jetType) {
+  std::string type = (!jetType.empty() ? jetType + " " : jetType);
 
-   std::vector<bool> matchedLocks(reclusteredJets.size(),false);
+  std::vector<bool> matchedLocks(reclusteredJets.size(), false);
 
-   for(size_t j=0; j<jets->size(); ++j)
-   {
-     double matchedDR2 = 1e9;
-     int matchedIdx = -1;
+  for (size_t j = 0; j < jets->size(); ++j) {
+    double matchedDR2 = 1e9;
+    int matchedIdx = -1;
 
-     for(size_t rj=0; rj<reclusteredJets.size(); ++rj)
-     {
-       if( matchedLocks.at(rj) ) continue; // skip jets that have already been matched
+    for (size_t rj = 0; rj < reclusteredJets.size(); ++rj) {
+      if (matchedLocks.at(rj))
+        continue;  // skip jets that have already been matched
 
-       double tempDR2 = Geom::deltaR2( toJet(jets->at(j))->rapidity(), toJet(jets->at(j))->phi(), reclusteredJets.at(rj).rapidity(), reclusteredJets.at(rj).phi_std() );
-       if( tempDR2 < matchedDR2 )
-       {
-         matchedDR2 = tempDR2;
-         matchedIdx = rj;
-       }
-     }
+      double tempDR2 = Geom::deltaR2(toJet(jets->at(j))->rapidity(),
+                                     toJet(jets->at(j))->phi(),
+                                     reclusteredJets.at(rj).rapidity(),
+                                     reclusteredJets.at(rj).phi_std());
+      if (tempDR2 < matchedDR2) {
+        matchedDR2 = tempDR2;
+        matchedIdx = rj;
+      }
+    }
 
-     if( matchedIdx>=0 )
-     {
-       if ( matchedDR2 > rParam*rParam )
-       {
-         edm::LogError("JetMatchingFailed") << "Matched reclustered jet " << matchedIdx << " and original " << type << "jet " << j <<" are separated by dR=" << sqrt(matchedDR2) << " which is greater than the jet size R=" << rParam << ".\n"
-                                            << "This is not expected so please check that the jet algorithm and jet size match those used for the original " << type << "jet collection.";
-       }
-       else
-         matchedLocks.at(matchedIdx) = true;
-     }
-     else
-       edm::LogError("JetMatchingFailed") << "Matching reclustered to original " << type << "jets failed. Please check that the jet algorithm and jet size match those used for the original " << type << "jet collection.";
+    if (matchedIdx >= 0) {
+      if (matchedDR2 > rParam * rParam) {
+        edm::LogError("JetMatchingFailed") << "Matched reclustered jet " << matchedIdx << " and original " << type
+                                           << "jet " << j << " are separated by dR=" << sqrt(matchedDR2)
+                                           << " which is greater than the jet size R=" << rParam << ".\n"
+                                           << "This is not expected so please check that the jet algorithm and jet "
+                                              "size match those used for the original "
+                                           << type << "jet collection.";
+      } else
+        matchedLocks.at(matchedIdx) = true;
+    } else
+      edm::LogError("JetMatchingFailed")
+          << "Matching reclustered to original " << type
+          << "jets failed. Please check that the jet algorithm and jet size match those used for the original " << type
+          << "jet collection.";
 
-     matchedIndices.push_back(matchedIdx);
-   }
+    matchedIndices.push_back(matchedIdx);
+  }
 }
 
 // ------------ method that matches groomed and original jets based on minimum dR ------------
-template<class IPTI,class VTX>
-void TemplatedSecondaryVertexProducer<IPTI,VTX>::matchGroomedJets(const edm::Handle<edm::View<reco::Jet> >& jets,
-                                                                  const edm::Handle<edm::View<reco::Jet> >& groomedJets,
-                                                                  std::vector<int>& matchedIndices)
-{
-   std::vector<bool> jetLocks(jets->size(),false);
-   std::vector<int>  jetIndices;
+template <class IPTI, class VTX>
+void TemplatedSecondaryVertexProducer<IPTI, VTX>::matchGroomedJets(const edm::Handle<edm::View<reco::Jet> > &jets,
+                                                                   const edm::Handle<edm::View<reco::Jet> > &groomedJets,
+                                                                   std::vector<int> &matchedIndices) {
+  std::vector<bool> jetLocks(jets->size(), false);
+  std::vector<int> jetIndices;
 
-   for(size_t gj=0; gj<groomedJets->size(); ++gj)
-   {
-     double matchedDR2 = 1e9;
-     int matchedIdx = -1;
+  for (size_t gj = 0; gj < groomedJets->size(); ++gj) {
+    double matchedDR2 = 1e9;
+    int matchedIdx = -1;
 
-     if( groomedJets->at(gj).pt()>0. ) // skip pathological cases of groomed jets with Pt=0
-     {
-       for(size_t j=0; j<jets->size(); ++j)
-       {
-         if( jetLocks.at(j) ) continue; // skip jets that have already been matched
+    if (groomedJets->at(gj).pt() > 0.)  // skip pathological cases of groomed jets with Pt=0
+    {
+      for (size_t j = 0; j < jets->size(); ++j) {
+        if (jetLocks.at(j))
+          continue;  // skip jets that have already been matched
 
-         double tempDR2 = Geom::deltaR2( jets->at(j).rapidity(), jets->at(j).phi(), groomedJets->at(gj).rapidity(), groomedJets->at(gj).phi() );
-         if( tempDR2 < matchedDR2 )
-         {
-           matchedDR2 = tempDR2;
-           matchedIdx = j;
-         }
-       }
-     }
+        double tempDR2 = Geom::deltaR2(
+            jets->at(j).rapidity(), jets->at(j).phi(), groomedJets->at(gj).rapidity(), groomedJets->at(gj).phi());
+        if (tempDR2 < matchedDR2) {
+          matchedDR2 = tempDR2;
+          matchedIdx = j;
+        }
+      }
+    }
 
-     if( matchedIdx>=0 )
-     {
-       if ( matchedDR2 > rParam*rParam )
-       {
-         edm::LogWarning("MatchedJetsFarApart") << "Matched groomed jet " << gj << " and original jet " << matchedIdx <<" are separated by dR=" << sqrt(matchedDR2) << " which is greater than the jet size R=" << rParam << ".\n"
-                                                << "This is not expected so the matching of these two jets has been discarded. Please check that the two jet collections belong to each other.";
-         matchedIdx = -1;
-       }
-       else
-         jetLocks.at(matchedIdx) = true;
-     }
-     jetIndices.push_back(matchedIdx);
-   }
+    if (matchedIdx >= 0) {
+      if (matchedDR2 > rParam * rParam) {
+        edm::LogWarning("MatchedJetsFarApart")
+            << "Matched groomed jet " << gj << " and original jet " << matchedIdx
+            << " are separated by dR=" << sqrt(matchedDR2) << " which is greater than the jet size R=" << rParam
+            << ".\n"
+            << "This is not expected so the matching of these two jets has been discarded. Please check that the two "
+               "jet collections belong to each other.";
+        matchedIdx = -1;
+      } else
+        jetLocks.at(matchedIdx) = true;
+    }
+    jetIndices.push_back(matchedIdx);
+  }
 
-   for(size_t j=0; j<jets->size(); ++j)
-   {
-     std::vector<int>::iterator matchedIndex = std::find( jetIndices.begin(), jetIndices.end(), j );
+  for (size_t j = 0; j < jets->size(); ++j) {
+    std::vector<int>::iterator matchedIndex = std::find(jetIndices.begin(), jetIndices.end(), j);
 
-     matchedIndices.push_back( matchedIndex != jetIndices.end() ? std::distance(jetIndices.begin(),matchedIndex) : -1 );
-   }
+    matchedIndices.push_back(matchedIndex != jetIndices.end() ? std::distance(jetIndices.begin(), matchedIndex) : -1);
+  }
 }
 
 // ------------ method that matches subjets and original fat jets ------------
-template<class IPTI,class VTX>
-void TemplatedSecondaryVertexProducer<IPTI,VTX>::matchSubjets(const std::vector<int>& groomedIndices,
-                                                              const edm::Handle<edm::View<reco::Jet> >& groomedJets,
-                                                              const edm::Handle<std::vector<IPTI> >& subjets,
-                                                              std::vector<std::vector<int> >& matchedIndices)
-{
-   for(size_t g=0; g<groomedIndices.size(); ++g)
-   {
-     std::vector<int> subjetIndices;
+template <class IPTI, class VTX>
+void TemplatedSecondaryVertexProducer<IPTI, VTX>::matchSubjets(const std::vector<int> &groomedIndices,
+                                                               const edm::Handle<edm::View<reco::Jet> > &groomedJets,
+                                                               const edm::Handle<std::vector<IPTI> > &subjets,
+                                                               std::vector<std::vector<int> > &matchedIndices) {
+  for (size_t g = 0; g < groomedIndices.size(); ++g) {
+    std::vector<int> subjetIndices;
 
-     if( groomedIndices.at(g)>=0 )
-     {
-       for(size_t s=0; s<groomedJets->at(groomedIndices.at(g)).numberOfDaughters(); ++s)
-       {
-         const edm::Ptr<reco::Candidate> & subjet = groomedJets->at(groomedIndices.at(g)).daughterPtr(s);
+    if (groomedIndices.at(g) >= 0) {
+      for (size_t s = 0; s < groomedJets->at(groomedIndices.at(g)).numberOfDaughters(); ++s) {
+        const edm::Ptr<reco::Candidate> &subjet = groomedJets->at(groomedIndices.at(g)).daughterPtr(s);
 
-         for(size_t sj=0; sj<subjets->size(); ++sj)
-         {
-           const edm::RefToBase<reco::Jet> &subjetRef = subjets->at(sj).jet();
-           if( subjet == edm::Ptr<reco::Candidate>( subjetRef.id(), subjetRef.get(), subjetRef.key() ) )
-           {
-             subjetIndices.push_back(sj);
-             break;
-           }
-         }
-       }
+        for (size_t sj = 0; sj < subjets->size(); ++sj) {
+          const edm::RefToBase<reco::Jet> &subjetRef = subjets->at(sj).jet();
+          if (subjet == edm::Ptr<reco::Candidate>(subjetRef.id(), subjetRef.get(), subjetRef.key())) {
+            subjetIndices.push_back(sj);
+            break;
+          }
+        }
+      }
 
-       if( subjetIndices.empty() )
-         edm::LogError("SubjetMatchingFailed") << "Matching subjets to original fat jets failed. Please check that the groomed fat jet and subjet collections belong to each other.";
+      if (subjetIndices.empty())
+        edm::LogError("SubjetMatchingFailed") << "Matching subjets to original fat jets failed. Please check that the "
+                                                 "groomed fat jet and subjet collections belong to each other.";
 
-       matchedIndices.push_back(subjetIndices);
-     }
-     else
-       matchedIndices.push_back(subjetIndices);
-   }
+      matchedIndices.push_back(subjetIndices);
+    } else
+      matchedIndices.push_back(subjetIndices);
+  }
 }
 
 // ------------ method that matches subjets and original fat jets ------------
-template<class IPTI,class VTX>
-void TemplatedSecondaryVertexProducer<IPTI,VTX>::matchSubjets(const edm::Handle<edm::View<reco::Jet> >& fatJets,
-                                                              const edm::Handle<std::vector<IPTI> >& subjets,
-                                                              std::vector<std::vector<int> >& matchedIndices)
-{
-   for(size_t fj=0; fj<fatJets->size(); ++fj)
-   {
-     std::vector<int> subjetIndices;
-     size_t nSubjetCollections = 0;
-     size_t nSubjets = 0;
+template <class IPTI, class VTX>
+void TemplatedSecondaryVertexProducer<IPTI, VTX>::matchSubjets(const edm::Handle<edm::View<reco::Jet> > &fatJets,
+                                                               const edm::Handle<std::vector<IPTI> > &subjets,
+                                                               std::vector<std::vector<int> > &matchedIndices) {
+  for (size_t fj = 0; fj < fatJets->size(); ++fj) {
+    std::vector<int> subjetIndices;
+    size_t nSubjetCollections = 0;
+    size_t nSubjets = 0;
 
-     const pat::Jet * fatJet = dynamic_cast<const pat::Jet *>( fatJets->ptrAt(fj).get() );
+    const pat::Jet *fatJet = dynamic_cast<const pat::Jet *>(fatJets->ptrAt(fj).get());
 
-     if( !fatJet )
-     {
-       if( fj==0 ) edm::LogError("WrongJetType") << "Wrong jet type for input fat jets. Please check that the input fat jets are of the pat::Jet type.";
+    if (!fatJet) {
+      if (fj == 0)
+        edm::LogError("WrongJetType")
+            << "Wrong jet type for input fat jets. Please check that the input fat jets are of the pat::Jet type.";
 
-       matchedIndices.push_back(subjetIndices);
-       continue;
-     }
-     else
-     {
-       nSubjetCollections = fatJet->subjetCollectionNames().size();
+      matchedIndices.push_back(subjetIndices);
+      continue;
+    } else {
+      nSubjetCollections = fatJet->subjetCollectionNames().size();
 
-       if( nSubjetCollections>0 )
-       {
-         for(size_t coll=0; coll<nSubjetCollections; ++coll)
-         {
-           const pat::JetPtrCollection & fatJetSubjets = fatJet->subjets(coll);
+      if (nSubjetCollections > 0) {
+        for (size_t coll = 0; coll < nSubjetCollections; ++coll) {
+          const pat::JetPtrCollection &fatJetSubjets = fatJet->subjets(coll);
 
-           for(size_t fjsj=0; fjsj<fatJetSubjets.size(); ++fjsj)
-           {
-             ++nSubjets;
+          for (size_t fjsj = 0; fjsj < fatJetSubjets.size(); ++fjsj) {
+            ++nSubjets;
 
-             for(size_t sj=0; sj<subjets->size(); ++sj)
-             {
-               const pat::Jet * subJet = dynamic_cast<const pat::Jet *>( subjets->at(sj).jet().get() );
+            for (size_t sj = 0; sj < subjets->size(); ++sj) {
+              const pat::Jet *subJet = dynamic_cast<const pat::Jet *>(subjets->at(sj).jet().get());
 
-               if( !subJet )
-               {
-                 if( fj==0 && coll==0 && fjsj==0 && sj==0 ) edm::LogError("WrongJetType") << "Wrong jet type for input subjets. Please check that the input subjets are of the pat::Jet type.";
+              if (!subJet) {
+                if (fj == 0 && coll == 0 && fjsj == 0 && sj == 0)
+                  edm::LogError("WrongJetType") << "Wrong jet type for input subjets. Please check that the input "
+                                                   "subjets are of the pat::Jet type.";
 
-                 break;
-               }
-               else
-               {
-                 if( subJet->originalObjectRef() == fatJetSubjets.at(fjsj)->originalObjectRef() )
-                 {
-                   subjetIndices.push_back(sj);
-                   break;
-                 }
-               }
-             }
-           }
-         }
+                break;
+              } else {
+                if (subJet->originalObjectRef() == fatJetSubjets.at(fjsj)->originalObjectRef()) {
+                  subjetIndices.push_back(sj);
+                  break;
+                }
+              }
+            }
+          }
+        }
 
-         if( subjetIndices.empty() && nSubjets > 0)
-           edm::LogError("SubjetMatchingFailed") << "Matching subjets to fat jets failed. Please check that the fat jet and subjet collections belong to each other.";
+        if (subjetIndices.empty() && nSubjets > 0)
+          edm::LogError("SubjetMatchingFailed") << "Matching subjets to fat jets failed. Please check that the fat jet "
+                                                   "and subjet collections belong to each other.";
 
-         matchedIndices.push_back(subjetIndices);
-       }
-       else
-         matchedIndices.push_back(subjetIndices);
-     }
-   }
+        matchedIndices.push_back(subjetIndices);
+      } else
+        matchedIndices.push_back(subjetIndices);
+    }
+  }
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module ------------
-template<class IPTI,class VTX>
-void TemplatedSecondaryVertexProducer<IPTI,VTX>::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
-
+template <class IPTI, class VTX>
+void TemplatedSecondaryVertexProducer<IPTI, VTX>::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<double>("extSVDeltaRToJet",0.3);
-  desc.add<edm::InputTag>("beamSpotTag",edm::InputTag("offlineBeamSpot"));
+  desc.add<double>("extSVDeltaRToJet", 0.3);
+  desc.add<edm::InputTag>("beamSpotTag", edm::InputTag("offlineBeamSpot"));
   {
     edm::ParameterSetDescription vertexReco;
-    vertexReco.add<double>("primcut",1.8);
-    vertexReco.add<double>("seccut",6.0);
-    vertexReco.add<std::string>("finder","avr");
-    vertexReco.addOptionalNode( edm::ParameterDescription<double>("minweight",0.5, true) and
-                                edm::ParameterDescription<double>("weightthreshold",0.001, true) and
-                                edm::ParameterDescription<bool>("smoothing",false, true), true );
-    vertexReco.addOptionalNode( edm::ParameterDescription<double>("maxFitChi2",10.0, true) and
-                                edm::ParameterDescription<double>("mergeThreshold",3.0, true) and
-                                edm::ParameterDescription<std::string>("fitType","RefitGhostTrackWithVertices", true), true );
-    desc.add<edm::ParameterSetDescription>("vertexReco",vertexReco);
+    vertexReco.add<double>("primcut", 1.8);
+    vertexReco.add<double>("seccut", 6.0);
+    vertexReco.add<std::string>("finder", "avr");
+    vertexReco.addOptionalNode(edm::ParameterDescription<double>("minweight", 0.5, true) and
+                                   edm::ParameterDescription<double>("weightthreshold", 0.001, true) and
+                                   edm::ParameterDescription<bool>("smoothing", false, true),
+                               true);
+    vertexReco.addOptionalNode(
+        edm::ParameterDescription<double>("maxFitChi2", 10.0, true) and
+            edm::ParameterDescription<double>("mergeThreshold", 3.0, true) and
+            edm::ParameterDescription<std::string>("fitType", "RefitGhostTrackWithVertices", true),
+        true);
+    desc.add<edm::ParameterSetDescription>("vertexReco", vertexReco);
   }
   {
     edm::ParameterSetDescription vertexSelection;
-    vertexSelection.add<std::string>("sortCriterium","dist3dError");
-    desc.add<edm::ParameterSetDescription>("vertexSelection",vertexSelection);
+    vertexSelection.add<std::string>("sortCriterium", "dist3dError");
+    desc.add<edm::ParameterSetDescription>("vertexSelection", vertexSelection);
   }
-  desc.add<std::string>("constraint","BeamSpot");
-  desc.add<edm::InputTag>("trackIPTagInfos",edm::InputTag("impactParameterTagInfos"));
+  desc.add<std::string>("constraint", "BeamSpot");
+  desc.add<edm::InputTag>("trackIPTagInfos", edm::InputTag("impactParameterTagInfos"));
   {
     edm::ParameterSetDescription vertexCuts;
-    vertexCuts.add<double>("distSig3dMax",99999.9);
-    vertexCuts.add<double>("fracPV",0.65);
-    vertexCuts.add<double>("distVal2dMax",2.5);
-    vertexCuts.add<bool>("useTrackWeights",true);
-    vertexCuts.add<double>("maxDeltaRToJetAxis",0.4);
+    vertexCuts.add<double>("distSig3dMax", 99999.9);
+    vertexCuts.add<double>("fracPV", 0.65);
+    vertexCuts.add<double>("distVal2dMax", 2.5);
+    vertexCuts.add<bool>("useTrackWeights", true);
+    vertexCuts.add<double>("maxDeltaRToJetAxis", 0.4);
     {
       edm::ParameterSetDescription v0Filter;
-      v0Filter.add<double>("k0sMassWindow",0.05);
-      vertexCuts.add<edm::ParameterSetDescription>("v0Filter",v0Filter);
+      v0Filter.add<double>("k0sMassWindow", 0.05);
+      vertexCuts.add<edm::ParameterSetDescription>("v0Filter", v0Filter);
     }
-    vertexCuts.add<double>("distSig2dMin",3.0);
-    vertexCuts.add<unsigned int>("multiplicityMin",2);
-    vertexCuts.add<double>("distVal2dMin",0.01);
-    vertexCuts.add<double>("distSig2dMax",99999.9);
-    vertexCuts.add<double>("distVal3dMax",99999.9);
-    vertexCuts.add<double>("minimumTrackWeight",0.5);
-    vertexCuts.add<double>("distVal3dMin",-99999.9);
-    vertexCuts.add<double>("massMax",6.5);
-    vertexCuts.add<double>("distSig3dMin",-99999.9);
-    desc.add<edm::ParameterSetDescription>("vertexCuts",vertexCuts);
+    vertexCuts.add<double>("distSig2dMin", 3.0);
+    vertexCuts.add<unsigned int>("multiplicityMin", 2);
+    vertexCuts.add<double>("distVal2dMin", 0.01);
+    vertexCuts.add<double>("distSig2dMax", 99999.9);
+    vertexCuts.add<double>("distVal3dMax", 99999.9);
+    vertexCuts.add<double>("minimumTrackWeight", 0.5);
+    vertexCuts.add<double>("distVal3dMin", -99999.9);
+    vertexCuts.add<double>("massMax", 6.5);
+    vertexCuts.add<double>("distSig3dMin", -99999.9);
+    desc.add<edm::ParameterSetDescription>("vertexCuts", vertexCuts);
   }
-  desc.add<bool>("useExternalSV",false);
-  desc.add<double>("minimumTrackWeight",0.5);
-  desc.add<bool>("usePVError",true);
+  desc.add<bool>("useExternalSV", false);
+  desc.add<double>("minimumTrackWeight", 0.5);
+  desc.add<bool>("usePVError", true);
   {
     edm::ParameterSetDescription trackSelection;
-    trackSelection.add<double>("b_pT",0.3684);
-    trackSelection.add<double>("max_pT",500);
-    trackSelection.add<bool>("useVariableJTA",false);
-    trackSelection.add<double>("maxDecayLen",99999.9);
-    trackSelection.add<double>("sip3dValMin",-99999.9);
-    trackSelection.add<double>("max_pT_dRcut",0.1);
-    trackSelection.add<double>("a_pT",0.005263);
-    trackSelection.add<unsigned int>("totalHitsMin",8);
-    trackSelection.add<double>("jetDeltaRMax",0.3);
-    trackSelection.add<double>("a_dR",-0.001053);
-    trackSelection.add<double>("maxDistToAxis",0.2);
-    trackSelection.add<double>("ptMin",1.0);
-    trackSelection.add<std::string>("qualityClass","any");
-    trackSelection.add<unsigned int>("pixelHitsMin",2);
-    trackSelection.add<double>("sip2dValMax",99999.9);
-    trackSelection.add<double>("max_pT_trackPTcut",3);
-    trackSelection.add<double>("sip2dValMin",-99999.9);
-    trackSelection.add<double>("normChi2Max",99999.9);
-    trackSelection.add<double>("sip3dValMax",99999.9);
-    trackSelection.add<double>("sip3dSigMin",-99999.9);
-    trackSelection.add<double>("min_pT",120);
-    trackSelection.add<double>("min_pT_dRcut",0.5);
-    trackSelection.add<double>("sip2dSigMax",99999.9);
-    trackSelection.add<double>("sip3dSigMax",99999.9);
-    trackSelection.add<double>("sip2dSigMin",-99999.9);
-    trackSelection.add<double>("b_dR",0.6263);
-    desc.add<edm::ParameterSetDescription>("trackSelection",trackSelection);
+    trackSelection.add<double>("b_pT", 0.3684);
+    trackSelection.add<double>("max_pT", 500);
+    trackSelection.add<bool>("useVariableJTA", false);
+    trackSelection.add<double>("maxDecayLen", 99999.9);
+    trackSelection.add<double>("sip3dValMin", -99999.9);
+    trackSelection.add<double>("max_pT_dRcut", 0.1);
+    trackSelection.add<double>("a_pT", 0.005263);
+    trackSelection.add<unsigned int>("totalHitsMin", 8);
+    trackSelection.add<double>("jetDeltaRMax", 0.3);
+    trackSelection.add<double>("a_dR", -0.001053);
+    trackSelection.add<double>("maxDistToAxis", 0.2);
+    trackSelection.add<double>("ptMin", 1.0);
+    trackSelection.add<std::string>("qualityClass", "any");
+    trackSelection.add<unsigned int>("pixelHitsMin", 2);
+    trackSelection.add<double>("sip2dValMax", 99999.9);
+    trackSelection.add<double>("max_pT_trackPTcut", 3);
+    trackSelection.add<double>("sip2dValMin", -99999.9);
+    trackSelection.add<double>("normChi2Max", 99999.9);
+    trackSelection.add<double>("sip3dValMax", 99999.9);
+    trackSelection.add<double>("sip3dSigMin", -99999.9);
+    trackSelection.add<double>("min_pT", 120);
+    trackSelection.add<double>("min_pT_dRcut", 0.5);
+    trackSelection.add<double>("sip2dSigMax", 99999.9);
+    trackSelection.add<double>("sip3dSigMax", 99999.9);
+    trackSelection.add<double>("sip2dSigMin", -99999.9);
+    trackSelection.add<double>("b_dR", 0.6263);
+    desc.add<edm::ParameterSetDescription>("trackSelection", trackSelection);
   }
-  desc.add<std::string>("trackSort","sip3dSig");
-  desc.add<edm::InputTag>("extSVCollection",edm::InputTag("secondaryVertices"));
-  desc.addOptionalNode( edm::ParameterDescription<bool>("useSVClustering",false, true) and
-                        edm::ParameterDescription<std::string>("jetAlgorithm", true) and
-                        edm::ParameterDescription<double>("rParam", true), true );
-  desc.addOptional<bool>("useSVMomentum",false);
-  desc.addOptional<double>("ghostRescaling",1e-18);
-  desc.addOptional<double>("relPtTolerance",1e-03);
+  desc.add<std::string>("trackSort", "sip3dSig");
+  desc.add<edm::InputTag>("extSVCollection", edm::InputTag("secondaryVertices"));
+  desc.addOptionalNode(edm::ParameterDescription<bool>("useSVClustering", false, true) and
+                           edm::ParameterDescription<std::string>("jetAlgorithm", true) and
+                           edm::ParameterDescription<double>("rParam", true),
+                       true);
+  desc.addOptional<bool>("useSVMomentum", false);
+  desc.addOptional<double>("ghostRescaling", 1e-18);
+  desc.addOptional<double>("relPtTolerance", 1e-03);
   desc.addOptional<edm::InputTag>("fatJets");
   desc.addOptional<edm::InputTag>("groomedFatJets");
   descriptions.addDefault(desc);
 }
 
 //define this as a plug-in
-typedef TemplatedSecondaryVertexProducer<TrackIPTagInfo,reco::Vertex> SecondaryVertexProducer;
-typedef TemplatedSecondaryVertexProducer<CandIPTagInfo,reco::VertexCompositePtrCandidate> CandSecondaryVertexProducer;
+typedef TemplatedSecondaryVertexProducer<TrackIPTagInfo, reco::Vertex> SecondaryVertexProducer;
+typedef TemplatedSecondaryVertexProducer<CandIPTagInfo, reco::VertexCompositePtrCandidate> CandSecondaryVertexProducer;
 
 DEFINE_FWK_MODULE(SecondaryVertexProducer);
 DEFINE_FWK_MODULE(CandSecondaryVertexProducer);
-

--- a/RecoBTag/SecondaryVertex/src/CandidateBoostedDoubleSecondaryVertexComputer.cc
+++ b/RecoBTag/SecondaryVertex/src/CandidateBoostedDoubleSecondaryVertexComputer.cc
@@ -8,51 +8,69 @@
 #include "DataFormats/BTauReco/interface/BoostedDoubleSVTagInfo.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h"
 
-
-CandidateBoostedDoubleSecondaryVertexComputer::CandidateBoostedDoubleSecondaryVertexComputer(const edm::ParameterSet & parameters) :
-  useCondDB_(parameters.getParameter<bool>("useCondDB")),
-  gbrForestLabel_(parameters.existsAs<std::string>("gbrForestLabel") ? parameters.getParameter<std::string>("gbrForestLabel") : ""),
-  weightFile_(parameters.existsAs<edm::FileInPath>("weightFile") ? parameters.getParameter<edm::FileInPath>("weightFile") : edm::FileInPath()),
-  useGBRForest_(parameters.existsAs<bool>("useGBRForest") ? parameters.getParameter<bool>("useGBRForest") : false),
-  useAdaBoost_(parameters.existsAs<bool>("useAdaBoost") ? parameters.getParameter<bool>("useAdaBoost") : false)
-{
+CandidateBoostedDoubleSecondaryVertexComputer::CandidateBoostedDoubleSecondaryVertexComputer(
+    const edm::ParameterSet& parameters)
+    : useCondDB_(parameters.getParameter<bool>("useCondDB")),
+      gbrForestLabel_(parameters.existsAs<std::string>("gbrForestLabel")
+                          ? parameters.getParameter<std::string>("gbrForestLabel")
+                          : ""),
+      weightFile_(parameters.existsAs<edm::FileInPath>("weightFile")
+                      ? parameters.getParameter<edm::FileInPath>("weightFile")
+                      : edm::FileInPath()),
+      useGBRForest_(parameters.existsAs<bool>("useGBRForest") ? parameters.getParameter<bool>("useGBRForest") : false),
+      useAdaBoost_(parameters.existsAs<bool>("useAdaBoost") ? parameters.getParameter<bool>("useAdaBoost") : false) {
   uses(0, "svTagInfos");
 
   mvaID.reset(new TMVAEvaluator());
 }
 
-void CandidateBoostedDoubleSecondaryVertexComputer::initialize(const JetTagComputerRecord & record)
-{
+void CandidateBoostedDoubleSecondaryVertexComputer::initialize(const JetTagComputerRecord& record) {
   // variable names and order need to be the same as in the training
   std::vector<std::string> variables({"z_ratio",
-                                      "trackSipdSig_3","trackSipdSig_2","trackSipdSig_1","trackSipdSig_0",
-                                      "trackSipdSig_1_0","trackSipdSig_0_0","trackSipdSig_1_1","trackSipdSig_0_1",
-                                      "trackSip2dSigAboveCharm_0","trackSip2dSigAboveBottom_0","trackSip2dSigAboveBottom_1",
-                                      "tau0_trackEtaRel_0","tau0_trackEtaRel_1","tau0_trackEtaRel_2",
-                                      "tau1_trackEtaRel_0","tau1_trackEtaRel_1","tau1_trackEtaRel_2",
-                                      "tau_vertexMass_0","tau_vertexEnergyRatio_0","tau_vertexDeltaR_0","tau_flightDistance2dSig_0",
-                                      "tau_vertexMass_1","tau_vertexEnergyRatio_1","tau_flightDistance2dSig_1",
-                                      "jetNTracks","nSV"});
+                                      "trackSipdSig_3",
+                                      "trackSipdSig_2",
+                                      "trackSipdSig_1",
+                                      "trackSipdSig_0",
+                                      "trackSipdSig_1_0",
+                                      "trackSipdSig_0_0",
+                                      "trackSipdSig_1_1",
+                                      "trackSipdSig_0_1",
+                                      "trackSip2dSigAboveCharm_0",
+                                      "trackSip2dSigAboveBottom_0",
+                                      "trackSip2dSigAboveBottom_1",
+                                      "tau0_trackEtaRel_0",
+                                      "tau0_trackEtaRel_1",
+                                      "tau0_trackEtaRel_2",
+                                      "tau1_trackEtaRel_0",
+                                      "tau1_trackEtaRel_1",
+                                      "tau1_trackEtaRel_2",
+                                      "tau_vertexMass_0",
+                                      "tau_vertexEnergyRatio_0",
+                                      "tau_vertexDeltaR_0",
+                                      "tau_flightDistance2dSig_0",
+                                      "tau_vertexMass_1",
+                                      "tau_vertexEnergyRatio_1",
+                                      "tau_flightDistance2dSig_1",
+                                      "jetNTracks",
+                                      "nSV"});
   // book TMVA readers
   std::vector<std::string> spectators({"massPruned", "flavour", "nbHadrons", "ptPruned", "etaPruned"});
 
-  if (useCondDB_)
-  {
-     const GBRWrapperRcd & gbrWrapperRecord = record.getRecord<GBRWrapperRcd>();
+  if (useCondDB_) {
+    const GBRWrapperRcd& gbrWrapperRecord = record.getRecord<GBRWrapperRcd>();
 
-     edm::ESHandle<GBRForest> gbrForestHandle;
-     gbrWrapperRecord.get(gbrForestLabel_.c_str(), gbrForestHandle);
+    edm::ESHandle<GBRForest> gbrForestHandle;
+    gbrWrapperRecord.get(gbrForestLabel_.c_str(), gbrForestHandle);
 
-     mvaID->initializeGBRForest(gbrForestHandle.product(), variables, spectators, useAdaBoost_);
-  }
-  else
-    mvaID->initialize("Color:Silent:Error", "BDT", weightFile_.fullPath(), variables, spectators, useGBRForest_, useAdaBoost_);
+    mvaID->initializeGBRForest(gbrForestHandle.product(), variables, spectators, useAdaBoost_);
+  } else
+    mvaID->initialize(
+        "Color:Silent:Error", "BDT", weightFile_.fullPath(), variables, spectators, useGBRForest_, useAdaBoost_);
 }
 
-float CandidateBoostedDoubleSecondaryVertexComputer::discriminator(const TagInfoHelper & tagInfo) const
-{
+float CandidateBoostedDoubleSecondaryVertexComputer::discriminator(const TagInfoHelper& tagInfo) const {
   // get the TagInfo
-  const reco::BoostedDoubleSVTagInfo & bdsvTagInfo = tagInfo.get<reco::BoostedDoubleSVTagInfo>(0);
+  const reco::BoostedDoubleSVTagInfo& bdsvTagInfo = tagInfo.get<reco::BoostedDoubleSVTagInfo>(0);
 
   // get the TaggingVariables
   const reco::TaggingVariableList vars = bdsvTagInfo.taggingVariables();
@@ -60,7 +78,7 @@ float CandidateBoostedDoubleSecondaryVertexComputer::discriminator(const TagInfo
   // default discriminator value
   float value = -10.;
 
-  std::map<std::string,float> inputs;
+  std::map<std::string, float> inputs;
   inputs["z_ratio"] = vars.get(reco::btau::z_ratio);
   inputs["trackSipdSig_3"] = vars.get(reco::btau::trackSip3dSig_3);
   inputs["trackSipdSig_2"] = vars.get(reco::btau::trackSip3dSig_2);

--- a/RecoBTag/SecondaryVertex/src/CombinedSVComputer.cc
+++ b/RecoBTag/SecondaryVertex/src/CombinedSVComputer.cc
@@ -2,275 +2,240 @@
 
 using namespace reco;
 
-
-inline edm::ParameterSet CombinedSVComputer::dropDeltaR(const edm::ParameterSet &pset) const
-{
-	edm::ParameterSet psetCopy(pset);
-	psetCopy.addParameter<double>("jetDeltaRMax", 99999.0);
-	return psetCopy;
+inline edm::ParameterSet CombinedSVComputer::dropDeltaR(const edm::ParameterSet &pset) const {
+  edm::ParameterSet psetCopy(pset);
+  psetCopy.addParameter<double>("jetDeltaRMax", 99999.0);
+  return psetCopy;
 }
 
-CombinedSVComputer::CombinedSVComputer(const edm::ParameterSet &params) :
-	trackFlip(params.getParameter<bool>("trackFlip")),
-	vertexFlip(params.getParameter<bool>("vertexFlip")),
-	charmCut(params.getParameter<double>("charmCut")),
-	sortCriterium(TrackSorting::getCriterium(params.getParameter<std::string>("trackSort"))),
-	trackSelector(params.getParameter<edm::ParameterSet>("trackSelection")),
-	trackNoDeltaRSelector(dropDeltaR(params.getParameter<edm::ParameterSet>("trackSelection"))),
-	trackPseudoSelector(params.getParameter<edm::ParameterSet>("trackPseudoSelection")),
-	pseudoMultiplicityMin(params.getParameter<unsigned int>("pseudoMultiplicityMin")),
-	trackMultiplicityMin(params.getParameter<unsigned int>("trackMultiplicityMin")),
-	minTrackWeight(params.getParameter<double>("minimumTrackWeight")),
-	useTrackWeights(params.getParameter<bool>("useTrackWeights")),
-	vertexMassCorrection(params.getParameter<bool>("correctVertexMass")),
-	pseudoVertexV0Filter(params.getParameter<edm::ParameterSet>("pseudoVertexV0Filter")),
-	trackPairV0Filter(params.getParameter<edm::ParameterSet>("trackPairV0Filter"))
-{
+CombinedSVComputer::CombinedSVComputer(const edm::ParameterSet &params)
+    : trackFlip(params.getParameter<bool>("trackFlip")),
+      vertexFlip(params.getParameter<bool>("vertexFlip")),
+      charmCut(params.getParameter<double>("charmCut")),
+      sortCriterium(TrackSorting::getCriterium(params.getParameter<std::string>("trackSort"))),
+      trackSelector(params.getParameter<edm::ParameterSet>("trackSelection")),
+      trackNoDeltaRSelector(dropDeltaR(params.getParameter<edm::ParameterSet>("trackSelection"))),
+      trackPseudoSelector(params.getParameter<edm::ParameterSet>("trackPseudoSelection")),
+      pseudoMultiplicityMin(params.getParameter<unsigned int>("pseudoMultiplicityMin")),
+      trackMultiplicityMin(params.getParameter<unsigned int>("trackMultiplicityMin")),
+      minTrackWeight(params.getParameter<double>("minimumTrackWeight")),
+      useTrackWeights(params.getParameter<bool>("useTrackWeights")),
+      vertexMassCorrection(params.getParameter<bool>("correctVertexMass")),
+      pseudoVertexV0Filter(params.getParameter<edm::ParameterSet>("pseudoVertexV0Filter")),
+      trackPairV0Filter(params.getParameter<edm::ParameterSet>("trackPairV0Filter")) {}
 
+inline double CombinedSVComputer::flipValue(double value, bool vertex) const {
+  return (vertex ? vertexFlip : trackFlip) ? -value : value;
 }
 
-inline double CombinedSVComputer::flipValue(double value, bool vertex) const
-{
-	return (vertex ? vertexFlip : trackFlip) ? -value : value;
+inline CombinedSVComputer::IterationRange CombinedSVComputer::flipIterate(int size, bool vertex) const {
+  IterationRange range;
+  if (vertex ? vertexFlip : trackFlip) {
+    range.begin = size - 1;
+    range.end = -1;
+    range.increment = -1;
+  } else {
+    range.begin = 0;
+    range.end = size;
+    range.increment = +1;
+  }
+
+  return range;
 }
 
-inline CombinedSVComputer::IterationRange CombinedSVComputer::flipIterate(
-						int size, bool vertex) const
-{
-	IterationRange range;
-	if (vertex ? vertexFlip : trackFlip) {
-		range.begin = size - 1;
-		range.end = -1;
-		range.increment = -1;
-	} else {
-		range.begin = 0;
-		range.end = size;
-		range.increment = +1;
-	}
+const btag::TrackIPData &CombinedSVComputer::threshTrack(const CandIPTagInfo &trackIPTagInfo,
+                                                         const btag::SortCriteria sort,
+                                                         const reco::Jet &jet,
+                                                         const GlobalPoint &pv) const {
+  const CandIPTagInfo::input_container &tracks = trackIPTagInfo.selectedTracks();
+  const std::vector<btag::TrackIPData> &ipData = trackIPTagInfo.impactParameterData();
+  std::vector<std::size_t> indices = trackIPTagInfo.sortedIndexes(sort);
 
-	return range;
+  IterationRange range = flipIterate(indices.size(), false);
+  TrackKinematics kin;
+  range_for(i, range) {
+    std::size_t idx = indices[i];
+    const btag::TrackIPData &data = ipData[idx];
+    const CandidatePtr &track = tracks[idx];
+
+    if (!trackNoDeltaRSelector(track, data, jet, pv))
+      continue;
+
+    kin.add(track);
+    if (kin.vectorSum().M() > charmCut)
+      return data;
+  }
+  if (trackFlip) {
+    static const btag::TrackIPData dummy = {GlobalPoint(),
+                                            GlobalPoint(),
+                                            Measurement1D(1.0, 1.0),
+                                            Measurement1D(1.0, 1.0),
+                                            Measurement1D(1.0, 1.0),
+                                            Measurement1D(1.0, 1.0),
+                                            0.};
+    return dummy;
+  } else {
+    static const btag::TrackIPData dummy = {GlobalPoint(),
+                                            GlobalPoint(),
+                                            Measurement1D(-1.0, 1.0),
+                                            Measurement1D(-1.0, 1.0),
+                                            Measurement1D(-1.0, 1.0),
+                                            Measurement1D(-1.0, 1.0),
+                                            0.};
+    return dummy;
+  }
 }
 
-const btag::TrackIPData &
-CombinedSVComputer::threshTrack(const CandIPTagInfo &trackIPTagInfo,
-                                const btag::SortCriteria sort,
-                                const reco::Jet &jet,
-                                const GlobalPoint &pv) const
-{
-        const CandIPTagInfo::input_container &tracks =
-                                        trackIPTagInfo.selectedTracks();
-        const std::vector<btag::TrackIPData> &ipData =
-                                        trackIPTagInfo.impactParameterData();
-        std::vector<std::size_t> indices = trackIPTagInfo.sortedIndexes(sort);
+const btag::TrackIPData &CombinedSVComputer::threshTrack(const TrackIPTagInfo &trackIPTagInfo,
+                                                         const btag::SortCriteria sort,
+                                                         const reco::Jet &jet,
+                                                         const GlobalPoint &pv) const {
+  const edm::RefVector<TrackCollection> &tracks = trackIPTagInfo.selectedTracks();
+  const std::vector<btag::TrackIPData> &ipData = trackIPTagInfo.impactParameterData();
+  std::vector<std::size_t> indices = trackIPTagInfo.sortedIndexes(sort);
 
-        IterationRange range = flipIterate(indices.size(), false);
-        TrackKinematics kin;
-        range_for(i, range) {
-                std::size_t idx = indices[i];
-                const btag::TrackIPData &data = ipData[idx];
-                const CandidatePtr &track = tracks[idx];
+  IterationRange range = flipIterate(indices.size(), false);
+  TrackKinematics kin;
+  range_for(i, range) {
+    std::size_t idx = indices[i];
+    const btag::TrackIPData &data = ipData[idx];
+    const Track &track = *tracks[idx];
 
-                if (!trackNoDeltaRSelector(track, data, jet, pv))
-                        continue;
+    if (!trackNoDeltaRSelector(track, data, jet, pv))
+      continue;
 
-                kin.add(track);
-                if (kin.vectorSum().M() > charmCut)
-                        return data;
+    kin.add(track);
+    if (kin.vectorSum().M() > charmCut)
+      return data;
+  }
+
+  if (trackFlip) {
+    static const btag::TrackIPData dummy = {GlobalPoint(),
+                                            GlobalPoint(),
+                                            Measurement1D(1.0, 1.0),
+                                            Measurement1D(1.0, 1.0),
+                                            Measurement1D(1.0, 1.0),
+                                            Measurement1D(1.0, 1.0),
+                                            0.};
+    return dummy;
+  } else {
+    static const btag::TrackIPData dummy = {GlobalPoint(),
+                                            GlobalPoint(),
+                                            Measurement1D(-1.0, 1.0),
+                                            Measurement1D(-1.0, 1.0),
+                                            Measurement1D(-1.0, 1.0),
+                                            Measurement1D(-1.0, 1.0),
+                                            0.};
+    return dummy;
+  }
+}
+
+TaggingVariableList CombinedSVComputer::operator()(const TrackIPTagInfo &ipInfo,
+                                                   const SecondaryVertexTagInfo &svInfo) const {
+  using namespace ROOT::Math;
+
+  edm::RefToBase<Jet> jet = ipInfo.jet();
+  math::XYZVector jetDir = jet->momentum().Unit();
+  TaggingVariableList vars;
+
+  TrackKinematics vertexKinematics;
+
+  double vtx_track_ptSum = 0.;
+  double vtx_track_ESum = 0.;
+
+  // the following is specific depending on the type of vertex
+  int vtx = -1;
+  unsigned int numberofvertextracks = 0;
+
+  IterationRange range = flipIterate(svInfo.nVertices(), true);
+  range_for(i, range) {
+    numberofvertextracks = numberofvertextracks + (svInfo.secondaryVertex(i)).nTracks();
+
+    const Vertex &vertex = svInfo.secondaryVertex(i);
+    bool hasRefittedTracks = vertex.hasRefittedTracks();
+    for (reco::Vertex::trackRef_iterator track = vertex.tracks_begin(); track != vertex.tracks_end(); track++) {
+      double w = vertex.trackWeight(*track);
+      if (w < minTrackWeight)
+        continue;
+      if (hasRefittedTracks) {
+        const Track actualTrack = vertex.refittedTrack(*track);
+        vertexKinematics.add(actualTrack, w);
+        vars.insert(btau::trackEtaRel, reco::btau::etaRel(jetDir, actualTrack.momentum()), true);
+        if (vtx < 0)  // calculate this only for the first vertex
+        {
+          vtx_track_ptSum += std::sqrt(actualTrack.momentum().Perp2());
+          vtx_track_ESum += std::sqrt(actualTrack.momentum().Mag2() + ROOT::Math::Square(ParticleMasses::piPlus));
         }
-        if(trackFlip){
-          static const btag::TrackIPData dummy = {
-	    GlobalPoint(),
-	    GlobalPoint(),
-	    Measurement1D(1.0, 1.0),
-	    Measurement1D(1.0, 1.0),
-	    Measurement1D(1.0, 1.0),
-	    Measurement1D(1.0, 1.0),
-	    0.
-          };
-          return dummy;
+      } else {
+        vertexKinematics.add(**track, w);
+        vars.insert(btau::trackEtaRel, reco::btau::etaRel(jetDir, (*track)->momentum()), true);
+        if (vtx < 0)  // calculate this only for the first vertex
+        {
+          vtx_track_ptSum += std::sqrt((*track)->momentum().Perp2());
+          vtx_track_ESum += std::sqrt((*track)->momentum().Mag2() + ROOT::Math::Square(ParticleMasses::piPlus));
         }
-        else{
-          static const btag::TrackIPData dummy = {
-	    GlobalPoint(),
-	    GlobalPoint(),
-	    Measurement1D(-1.0, 1.0),
-	    Measurement1D(-1.0, 1.0),
-	    Measurement1D(-1.0, 1.0),
-	    Measurement1D(-1.0, 1.0),
-	    0.
-          };
-          return dummy;
-        }
+      }
+    }
 
+    if (vtx < 0)
+      vtx = i;
+  }
+  if (vtx >= 0) {
+    vars.insert(btau::vertexNTracks, numberofvertextracks, true);
+    vars.insert(btau::vertexFitProb, (svInfo.secondaryVertex(vtx)).normalizedChi2(), true);
+  }
 
+  // after we collected vertex information we let the common code complete the job
+  fillCommonVariables(vars, vertexKinematics, ipInfo, svInfo, vtx_track_ptSum, vtx_track_ESum);
+
+  vars.finalize();
+  return vars;
 }
 
-const btag::TrackIPData &
-CombinedSVComputer::threshTrack(const TrackIPTagInfo &trackIPTagInfo,
-                                const btag::SortCriteria sort,
-                                const reco::Jet &jet,
-                                const GlobalPoint &pv) const
-{
-	const edm::RefVector<TrackCollection> &tracks =
-					trackIPTagInfo.selectedTracks();
-	const std::vector<btag::TrackIPData> &ipData =
-					trackIPTagInfo.impactParameterData();
-	std::vector<std::size_t> indices = trackIPTagInfo.sortedIndexes(sort);
+TaggingVariableList CombinedSVComputer::operator()(const CandIPTagInfo &ipInfo,
+                                                   const CandSecondaryVertexTagInfo &svInfo) const {
+  using namespace ROOT::Math;
 
-	IterationRange range = flipIterate(indices.size(), false);
-	TrackKinematics kin;
-	range_for(i, range) {
-		std::size_t idx = indices[i];
-		const btag::TrackIPData &data = ipData[idx];
-		const Track &track = *tracks[idx];
+  edm::RefToBase<Jet> jet = ipInfo.jet();
+  math::XYZVector jetDir = jet->momentum().Unit();
+  TaggingVariableList vars;
 
-		if (!trackNoDeltaRSelector(track, data, jet, pv))
-			continue;
+  TrackKinematics vertexKinematics;
 
-		kin.add(track);
-		if (kin.vectorSum().M() > charmCut) 
-			return data;
-	}
+  double vtx_track_ptSum = 0.;
+  double vtx_track_ESum = 0.;
 
-        if(trackFlip){
-          static const btag::TrackIPData dummy = {
-	    GlobalPoint(),
-	    GlobalPoint(),
-	    Measurement1D(1.0, 1.0),
-	    Measurement1D(1.0, 1.0),
-	    Measurement1D(1.0, 1.0),
-	    Measurement1D(1.0, 1.0),
-	    0.
-          };
-          return dummy;
-        }
-        else{
-          static const btag::TrackIPData dummy = {
-	    GlobalPoint(),
-	    GlobalPoint(),
-	    Measurement1D(-1.0, 1.0),
-	    Measurement1D(-1.0, 1.0),
-	    Measurement1D(-1.0, 1.0),
-	    Measurement1D(-1.0, 1.0),
-            0.
-          };
-          return dummy;
-        }
+  // the following is specific depending on the type of vertex
+  int vtx = -1;
+  unsigned int numberofvertextracks = 0;
 
+  IterationRange range = flipIterate(svInfo.nVertices(), true);
+  range_for(i, range) {
+    numberofvertextracks = numberofvertextracks + (svInfo.secondaryVertex(i)).numberOfSourceCandidatePtrs();
+
+    const reco::VertexCompositePtrCandidate &vertex = svInfo.secondaryVertex(i);
+    const std::vector<CandidatePtr> &tracks = vertex.daughterPtrVector();
+    for (std::vector<CandidatePtr>::const_iterator track = tracks.begin(); track != tracks.end(); ++track) {
+      vertexKinematics.add(*track);
+      vars.insert(btau::trackEtaRel, reco::btau::etaRel(jetDir, (*track)->momentum()), true);
+      if (vtx < 0)  // calculate this only for the first vertex
+      {
+        vtx_track_ptSum += std::sqrt((*track)->momentum().Perp2());
+        vtx_track_ESum += std::sqrt((*track)->momentum().Mag2() + ROOT::Math::Square(ParticleMasses::piPlus));
+      }
+    }
+
+    if (vtx < 0)
+      vtx = i;
+  }
+  if (vtx >= 0) {
+    vars.insert(btau::vertexNTracks, numberofvertextracks, true);
+    vars.insert(btau::vertexFitProb, (svInfo.secondaryVertex(vtx)).vertexNormalizedChi2(), true);
+  }
+
+  // after we collected vertex information we let the common code complete the job
+  fillCommonVariables(vars, vertexKinematics, ipInfo, svInfo, vtx_track_ptSum, vtx_track_ESum);
+
+  vars.finalize();
+  return vars;
 }
-
-
-TaggingVariableList
-CombinedSVComputer::operator () (const TrackIPTagInfo &ipInfo,
-                                 const SecondaryVertexTagInfo &svInfo) const
-{
-	using namespace ROOT::Math;
-
-	edm::RefToBase<Jet> jet = ipInfo.jet();
-	math::XYZVector jetDir = jet->momentum().Unit();
-	TaggingVariableList vars;
-
-        TrackKinematics vertexKinematics;
-	
-	double vtx_track_ptSum = 0.;
-	double vtx_track_ESum  = 0.;
-	
-	// the following is specific depending on the type of vertex
-        int vtx = -1;
-        unsigned int numberofvertextracks = 0;
-
-	IterationRange range = flipIterate(svInfo.nVertices(), true);
-	range_for(i, range) {
-
-		numberofvertextracks = numberofvertextracks + (svInfo.secondaryVertex(i)).nTracks();
-
-		const Vertex &vertex = svInfo.secondaryVertex(i);
-		bool hasRefittedTracks = vertex.hasRefittedTracks();
-		for(reco::Vertex::trackRef_iterator track = vertex.tracks_begin(); track != vertex.tracks_end(); track++) {
-			double w = vertex.trackWeight(*track);
-			if (w < minTrackWeight)
-				continue;
-			if (hasRefittedTracks) {
-				const Track actualTrack = vertex.refittedTrack(*track);
-				vertexKinematics.add(actualTrack, w);
-				vars.insert(btau::trackEtaRel, reco::btau::etaRel(jetDir,actualTrack.momentum()), true);
-				if(vtx < 0) // calculate this only for the first vertex
-				{
-					vtx_track_ptSum += std::sqrt(actualTrack.momentum().Perp2());
-					vtx_track_ESum  += std::sqrt(actualTrack.momentum().Mag2() + ROOT::Math::Square(ParticleMasses::piPlus));
-				}
-			} else {
-				vertexKinematics.add(**track, w);
-				vars.insert(btau::trackEtaRel, reco::btau::etaRel(jetDir,(*track)->momentum()), true);
-				if(vtx < 0) // calculate this only for the first vertex
-				{
-					vtx_track_ptSum += std::sqrt((*track)->momentum().Perp2());
-					vtx_track_ESum  += std::sqrt((*track)->momentum().Mag2() + ROOT::Math::Square(ParticleMasses::piPlus));
-				}
-			}
-		}
-		
-		if (vtx < 0) vtx = i;
-        }
-	if(vtx>=0){
-		vars.insert(btau::vertexNTracks, numberofvertextracks, true);
-		vars.insert(btau::vertexFitProb,(svInfo.secondaryVertex(vtx)).normalizedChi2(), true);
-	}
-
-	// after we collected vertex information we let the common code complete the job
-	fillCommonVariables(vars,vertexKinematics,ipInfo,svInfo,vtx_track_ptSum,vtx_track_ESum);
-
-	vars.finalize();
-	return vars;
-}
-
-TaggingVariableList
-CombinedSVComputer::operator () (const CandIPTagInfo &ipInfo,
-                                 const CandSecondaryVertexTagInfo &svInfo) const
-{
-        using namespace ROOT::Math;
-
-        edm::RefToBase<Jet> jet = ipInfo.jet();
-        math::XYZVector jetDir = jet->momentum().Unit();
-        TaggingVariableList vars;
-
-        TrackKinematics vertexKinematics;
-	
-	double vtx_track_ptSum = 0.;
-	double vtx_track_ESum  = 0.;
-	
-	// the following is specific depending on the type of vertex
-        int vtx = -1;
-        unsigned int numberofvertextracks = 0;
-
-	IterationRange range = flipIterate(svInfo.nVertices(), true);
-	range_for(i, range) {
-
-		numberofvertextracks = numberofvertextracks + (svInfo.secondaryVertex(i)).numberOfSourceCandidatePtrs();
-
-		const reco::VertexCompositePtrCandidate &vertex = svInfo.secondaryVertex(i);
-		const std::vector<CandidatePtr> & tracks = vertex.daughterPtrVector();
-		for(std::vector<CandidatePtr>::const_iterator track = tracks.begin(); track != tracks.end(); ++track) {
-			vertexKinematics.add(*track);
-			vars.insert(btau::trackEtaRel, reco::btau::etaRel(jetDir,(*track)->momentum()), true);
-			if(vtx < 0) // calculate this only for the first vertex
-			{
-				vtx_track_ptSum += std::sqrt((*track)->momentum().Perp2());
-				vtx_track_ESum  += std::sqrt((*track)->momentum().Mag2() + ROOT::Math::Square(ParticleMasses::piPlus));
-			}
-		}
-		
-		if (vtx < 0) vtx = i;
-	}
-	if(vtx>=0){
-		vars.insert(btau::vertexNTracks, numberofvertextracks, true);
-		vars.insert(btau::vertexFitProb,(svInfo.secondaryVertex(vtx)).vertexNormalizedChi2(), true);
-	}
-	
-	// after we collected vertex information we let the common code complete the job
-	fillCommonVariables(vars,vertexKinematics,ipInfo,svInfo,vtx_track_ptSum,vtx_track_ESum);
-	
-	vars.finalize();
-	return vars;
-}
-

--- a/RecoBTag/SecondaryVertex/src/CombinedSVSoftLeptonComputer.cc
+++ b/RecoBTag/SecondaryVertex/src/CombinedSVSoftLeptonComputer.cc
@@ -3,9 +3,5 @@
 using namespace reco;
 using namespace std;
 
-
-CombinedSVSoftLeptonComputer::CombinedSVSoftLeptonComputer(const edm::ParameterSet &params) :
-	CombinedSVComputer(params),
-	SoftLeptonFlip(params.getParameter<bool>("SoftLeptonFlip"))
-{
-}
+CombinedSVSoftLeptonComputer::CombinedSVSoftLeptonComputer(const edm::ParameterSet &params)
+    : CombinedSVComputer(params), SoftLeptonFlip(params.getParameter<bool>("SoftLeptonFlip")) {}

--- a/RecoBTag/SecondaryVertex/src/GhostTrackComputer.cc
+++ b/RecoBTag/SecondaryVertex/src/GhostTrackComputer.cc
@@ -18,7 +18,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/BTauReco/interface/TrackIPTagInfo.h"
-#include "DataFormats/BTauReco/interface/SecondaryVertexTagInfo.h"  
+#include "DataFormats/BTauReco/interface/SecondaryVertexTagInfo.h"
 #include "DataFormats/BTauReco/interface/TaggingVariable.h"
 #include "DataFormats/BTauReco/interface/VertexTypes.h"
 #include "DataFormats/BTauReco/interface/ParticleMasses.h"
@@ -32,517 +32,457 @@
 
 using namespace reco;
 
-static edm::ParameterSet dropDeltaR(const edm::ParameterSet &pset)
-{
-	edm::ParameterSet psetCopy(pset);
-	psetCopy.addParameter<double>("jetDeltaRMax", 99999.0);
-	return psetCopy;
+static edm::ParameterSet dropDeltaR(const edm::ParameterSet &pset) {
+  edm::ParameterSet psetCopy(pset);
+  psetCopy.addParameter<double>("jetDeltaRMax", 99999.0);
+  return psetCopy;
 }
 
-GhostTrackComputer::GhostTrackComputer(const edm::ParameterSet &params) :
-	charmCut(params.getParameter<double>("charmCut")),
-	sortCriterium(TrackSorting::getCriterium(params.getParameter<std::string>("trackSort"))),
-	trackSelector(params.getParameter<edm::ParameterSet>("trackSelection")),
-	trackNoDeltaRSelector(dropDeltaR(params.getParameter<edm::ParameterSet>("trackSelection"))),
-	minTrackWeight(params.getParameter<double>("minimumTrackWeight")),
-	trackPairV0Filter(params.getParameter<edm::ParameterSet>("trackPairV0Filter"))
-{
+GhostTrackComputer::GhostTrackComputer(const edm::ParameterSet &params)
+    : charmCut(params.getParameter<double>("charmCut")),
+      sortCriterium(TrackSorting::getCriterium(params.getParameter<std::string>("trackSort"))),
+      trackSelector(params.getParameter<edm::ParameterSet>("trackSelection")),
+      trackNoDeltaRSelector(dropDeltaR(params.getParameter<edm::ParameterSet>("trackSelection"))),
+      minTrackWeight(params.getParameter<double>("minimumTrackWeight")),
+      trackPairV0Filter(params.getParameter<edm::ParameterSet>("trackPairV0Filter")) {}
+
+const btag::TrackIPData &GhostTrackComputer::threshTrack(const TrackIPTagInfo &trackIPTagInfo,
+                                                         const btag::SortCriteria sort,
+                                                         const reco::Jet &jet,
+                                                         const GlobalPoint &pv) const {
+  const edm::RefVector<TrackCollection> &tracks = trackIPTagInfo.selectedTracks();
+  const std::vector<btag::TrackIPData> &ipData = trackIPTagInfo.impactParameterData();
+  std::vector<std::size_t> indices = trackIPTagInfo.sortedIndexes(sort);
+
+  TrackKinematics kin;
+  for (std::vector<std::size_t>::const_iterator iter = indices.begin(); iter != indices.end(); ++iter) {
+    const btag::TrackIPData &data = ipData[*iter];
+    const Track &track = *tracks[*iter];
+
+    if (!trackNoDeltaRSelector(track, data, jet, pv))
+      continue;
+
+    kin.add(track);
+    if (kin.vectorSum().M() > charmCut)
+      return data;
+  }
+
+  static const btag::TrackIPData dummy = {GlobalPoint(),
+                                          GlobalPoint(),
+                                          Measurement1D(-1.0, 1.0),
+                                          Measurement1D(-1.0, 1.0),
+                                          Measurement1D(-1.0, 1.0),
+                                          Measurement1D(-1.0, 1.0),
+                                          0.};
+  return dummy;
 }
 
-const btag::TrackIPData &
-GhostTrackComputer::threshTrack(const TrackIPTagInfo &trackIPTagInfo,
-                                const btag::SortCriteria sort,
-                                const reco::Jet &jet,
-                                const GlobalPoint &pv) const
-{
-	const edm::RefVector<TrackCollection> &tracks =
-					trackIPTagInfo.selectedTracks();
-	const std::vector<btag::TrackIPData> &ipData =
-					trackIPTagInfo.impactParameterData();
-	std::vector<std::size_t> indices = trackIPTagInfo.sortedIndexes(sort);
+const btag::TrackIPData &GhostTrackComputer::threshTrack(const CandIPTagInfo &trackIPTagInfo,
+                                                         const btag::SortCriteria sort,
+                                                         const reco::Jet &jet,
+                                                         const GlobalPoint &pv) const {
+  const CandIPTagInfo::input_container &tracks = trackIPTagInfo.selectedTracks();
+  const std::vector<btag::TrackIPData> &ipData = trackIPTagInfo.impactParameterData();
+  std::vector<std::size_t> indices = trackIPTagInfo.sortedIndexes(sort);
 
-	TrackKinematics kin;
-	for(std::vector<std::size_t>::const_iterator iter = indices.begin();
-	    iter != indices.end(); ++iter) {
-		const btag::TrackIPData &data = ipData[*iter];
-		const Track &track = *tracks[*iter];
+  TrackKinematics kin;
+  for (std::vector<std::size_t>::const_iterator iter = indices.begin(); iter != indices.end(); ++iter) {
+    const btag::TrackIPData &data = ipData[*iter];
+    const CandidatePtr &track = tracks[*iter];
 
-		if (!trackNoDeltaRSelector(track, data, jet, pv))
-			continue;
+    if (!trackNoDeltaRSelector(track, data, jet, pv))
+      continue;
 
-		kin.add(track);
-		if (kin.vectorSum().M() > charmCut) 
-			return data;
-	}
+    kin.add(track);
+    if (kin.vectorSum().M() > charmCut)
+      return data;
+  }
 
-	static const btag::TrackIPData dummy = {
- 		GlobalPoint(),
-		GlobalPoint(),
-		Measurement1D(-1.0, 1.0),
-		Measurement1D(-1.0, 1.0),
-		Measurement1D(-1.0, 1.0),
-		Measurement1D(-1.0, 1.0),
-		0.
-	};
-	return dummy;
+  static const btag::TrackIPData dummy = {GlobalPoint(),
+                                          GlobalPoint(),
+                                          Measurement1D(-1.0, 1.0),
+                                          Measurement1D(-1.0, 1.0),
+                                          Measurement1D(-1.0, 1.0),
+                                          Measurement1D(-1.0, 1.0),
+                                          0.};
+  return dummy;
 }
 
-const btag::TrackIPData &
-GhostTrackComputer::threshTrack(const CandIPTagInfo &trackIPTagInfo,
-                                const btag::SortCriteria sort,
-                                const reco::Jet &jet,
-                                const GlobalPoint &pv) const
-{
-        const CandIPTagInfo::input_container &tracks =
-                                        trackIPTagInfo.selectedTracks();
-        const std::vector<btag::TrackIPData> &ipData =
-                                        trackIPTagInfo.impactParameterData();
-        std::vector<std::size_t> indices = trackIPTagInfo.sortedIndexes(sort);
-
-        TrackKinematics kin;
-        for(std::vector<std::size_t>::const_iterator iter = indices.begin(); iter != indices.end(); ++iter) {
-        const btag::TrackIPData &data = ipData[*iter];
-        const CandidatePtr &track = tracks[*iter];
-
-        if (!trackNoDeltaRSelector(track, data, jet, pv))
-               continue;
-
-        kin.add(track);
-        if (kin.vectorSum().M() > charmCut)
-               return data;
-        }
-
-        static const btag::TrackIPData dummy = {
-                GlobalPoint(),
-                GlobalPoint(),
-                Measurement1D(-1.0, 1.0),
-                Measurement1D(-1.0, 1.0),
-                Measurement1D(-1.0, 1.0),
-                Measurement1D(-1.0, 1.0),
-                0.
-        };
-        return dummy;
+static void addMeas(std::pair<double, double> &sum, Measurement1D meas) {
+  double weight = 1. / meas.error();
+  weight *= weight;
+  sum.first += weight * meas.value();
+  sum.second += weight;
 }
 
-static void addMeas(std::pair<double, double> &sum, Measurement1D meas)
-{
-	double weight = 1. / meas.error();
-	weight *= weight;
-	sum.first += weight * meas.value();
-	sum.second += weight;
+TaggingVariableList GhostTrackComputer::operator()(const TrackIPTagInfo &ipInfo,
+                                                   const SecondaryVertexTagInfo &svInfo) const {
+  using namespace ROOT::Math;
+
+  edm::RefToBase<Jet> jet = ipInfo.jet();
+  math::XYZVector jetDir = jet->momentum().Unit();
+  bool havePv = ipInfo.primaryVertex().isNonnull();
+  GlobalPoint pv;
+  if (havePv)
+    pv = GlobalPoint(ipInfo.primaryVertex()->x(), ipInfo.primaryVertex()->y(), ipInfo.primaryVertex()->z());
+
+  btag::Vertices::VertexType vtxType = btag::Vertices::NoVertex;
+
+  TaggingVariableList vars;
+
+  vars.insert(btau::jetPt, jet->pt(), true);
+  vars.insert(btau::jetEta, jet->eta(), true);
+
+  TrackKinematics allKinematics;
+  TrackKinematics vertexKinematics;
+  TrackKinematics trackKinematics;
+
+  std::pair<double, double> vertexDist2D, vertexDist3D;
+  std::pair<double, double> tracksDist2D, tracksDist3D;
+
+  unsigned int nVertices = 0;
+  unsigned int nVertexTracks = 0;
+  unsigned int nTracks = 0;
+  for (unsigned int i = 0; i < svInfo.nVertices(); i++) {
+    const Vertex &vertex = svInfo.secondaryVertex(i);
+    bool hasRefittedTracks = vertex.hasRefittedTracks();
+    TrackRefVector tracks = svInfo.vertexTracks(i);
+    unsigned int n = 0;
+    for (TrackRefVector::const_iterator track = tracks.begin(); track != tracks.end(); track++)
+      if (svInfo.trackWeight(i, *track) >= minTrackWeight)
+        n++;
+
+    if (n < 1)
+      continue;
+    bool isTrackVertex = (n == 1);
+    ++*(isTrackVertex ? &nTracks : &nVertices);
+
+    addMeas(*(isTrackVertex ? &tracksDist2D : &vertexDist2D), svInfo.flightDistance(i, true));
+    addMeas(*(isTrackVertex ? &tracksDist3D : &vertexDist3D), svInfo.flightDistance(i, false));
+
+    TrackKinematics &kin = isTrackVertex ? trackKinematics : vertexKinematics;
+    for (TrackRefVector::const_iterator track = tracks.begin(); track != tracks.end(); track++) {
+      float w = svInfo.trackWeight(i, *track);
+      if (w < minTrackWeight)
+        continue;
+      if (hasRefittedTracks) {
+        Track actualTrack = vertex.refittedTrack(*track);
+        kin.add(actualTrack, w);
+        vars.insert(btau::trackEtaRel, reco::btau::etaRel(jetDir, actualTrack.momentum()), true);
+      } else {
+        kin.add(**track, w);
+        vars.insert(btau::trackEtaRel, reco::btau::etaRel(jetDir, (*track)->momentum()), true);
+      }
+      if (!isTrackVertex)
+        nVertexTracks++;
+    }
+  }
+
+  Measurement1D dist2D, dist3D;
+  if (nVertices) {
+    vtxType = btag::Vertices::RecoVertex;
+
+    if (nVertices == 1 && nTracks) {
+      vertexDist2D.first += tracksDist2D.first;
+      vertexDist2D.second += tracksDist2D.second;
+      vertexDist3D.first += tracksDist3D.first;
+      vertexDist3D.second += tracksDist3D.second;
+      vertexKinematics += trackKinematics;
+    }
+
+    dist2D = Measurement1D(vertexDist2D.first / vertexDist2D.second, std::sqrt(1. / vertexDist2D.second));
+    dist3D = Measurement1D(vertexDist3D.first / vertexDist3D.second, std::sqrt(1. / vertexDist3D.second));
+
+    vars.insert(btau::jetNSecondaryVertices, nVertices, true);
+    vars.insert(btau::vertexNTracks, nVertexTracks, true);
+  } else if (nTracks) {
+    vtxType = btag::Vertices::PseudoVertex;
+    vertexKinematics = trackKinematics;
+
+    dist2D = Measurement1D(tracksDist2D.first / tracksDist2D.second, std::sqrt(1. / tracksDist2D.second));
+    dist3D = Measurement1D(tracksDist3D.first / tracksDist3D.second, std::sqrt(1. / tracksDist3D.second));
+  }
+
+  if (nVertices || nTracks) {
+    vars.insert(btau::flightDistance2dVal, dist2D.value(), true);
+    vars.insert(btau::flightDistance2dSig, dist2D.significance(), true);
+    vars.insert(btau::flightDistance3dVal, dist3D.value(), true);
+    vars.insert(btau::flightDistance3dSig, dist3D.significance(), true);
+    vars.insert(btau::vertexJetDeltaR, Geom::deltaR(svInfo.flightDirection(0), jetDir), true);
+    vars.insert(btau::jetNSingleTrackVertices, nTracks, true);
+  }
+
+  std::vector<std::size_t> indices = ipInfo.sortedIndexes(sortCriterium);
+  const std::vector<btag::TrackIPData> &ipData = ipInfo.impactParameterData();
+  const edm::RefVector<TrackCollection> &tracks = ipInfo.selectedTracks();
+
+  TrackRef trackPairV0Test[2];
+  for (unsigned int i = 0; i < indices.size(); i++) {
+    std::size_t idx = indices[i];
+    const btag::TrackIPData &data = ipData[idx];
+    const TrackRef &trackRef = tracks[idx];
+    const Track &track = *trackRef;
+
+    // filter track
+
+    if (!trackSelector(track, data, *jet, pv))
+      continue;
+
+    // add track to kinematics for all tracks in jet
+
+    allKinematics.add(track);
+
+    // check against all other tracks for V0 track pairs
+
+    trackPairV0Test[0] = tracks[idx];
+    bool ok = true;
+    for (unsigned int j = 0; j < indices.size(); j++) {
+      if (i == j)
+        continue;
+
+      std::size_t pairIdx = indices[j];
+      const btag::TrackIPData &pairTrackData = ipData[pairIdx];
+      const TrackRef &pairTrackRef = tracks[pairIdx];
+      const Track &pairTrack = *pairTrackRef;
+
+      if (!trackSelector(pairTrack, pairTrackData, *jet, pv))
+        continue;
+
+      trackPairV0Test[1] = pairTrackRef;
+      if (!trackPairV0Filter(trackPairV0Test, 2)) {
+        ok = false;
+        break;
+      }
+    }
+    if (!ok)
+      continue;
+
+    // add track variables
+
+    const math::XYZVector &trackMom = track.momentum();
+    double trackMag = std::sqrt(trackMom.Mag2());
+
+    vars.insert(btau::trackSip3dVal, data.ip3d.value(), true);
+    vars.insert(btau::trackSip3dSig, data.ip3d.significance(), true);
+    vars.insert(btau::trackSip2dVal, data.ip2d.value(), true);
+    vars.insert(btau::trackSip2dSig, data.ip2d.significance(), true);
+    vars.insert(btau::trackJetDistVal, data.distanceToJetAxis.value(), true);
+    vars.insert(btau::trackGhostTrackDistVal, data.distanceToGhostTrack.value(), true);
+    vars.insert(btau::trackGhostTrackDistSig, data.distanceToGhostTrack.significance(), true);
+    vars.insert(btau::trackGhostTrackWeight, data.ghostTrackWeight, true);
+    vars.insert(btau::trackDecayLenVal, havePv ? (data.closestToGhostTrack - pv).mag() : -1.0, true);
+
+    vars.insert(btau::trackMomentum, trackMag, true);
+    vars.insert(btau::trackEta, trackMom.Eta(), true);
+
+    vars.insert(btau::trackChi2, track.normalizedChi2(), true);
+    vars.insert(btau::trackNPixelHits, track.hitPattern().pixelLayersWithMeasurement(), true);
+    vars.insert(btau::trackNTotalHits, track.hitPattern().trackerLayersWithMeasurement(), true);
+    vars.insert(btau::trackPtRel, VectorUtil::Perp(trackMom, jetDir), true);
+    vars.insert(btau::trackDeltaR, VectorUtil::DeltaR(trackMom, jetDir), true);
+  }
+
+  vars.insert(btau::vertexCategory, vtxType, true);
+  vars.insert(btau::trackSumJetDeltaR, VectorUtil::DeltaR(allKinematics.vectorSum(), jetDir), true);
+  vars.insert(btau::trackSumJetEtRatio, allKinematics.vectorSum().Et() / ipInfo.jet()->et(), true);
+  vars.insert(
+      btau::trackSip3dSigAboveCharm, threshTrack(ipInfo, reco::btag::IP3DSig, *jet, pv).ip3d.significance(), true);
+  vars.insert(
+      btau::trackSip2dSigAboveCharm, threshTrack(ipInfo, reco::btag::IP2DSig, *jet, pv).ip2d.significance(), true);
+
+  if (vtxType != btag::Vertices::NoVertex) {
+    const math::XYZTLorentzVector &allSum = allKinematics.vectorSum();
+    const math::XYZTLorentzVector &vertexSum = vertexKinematics.vectorSum();
+
+    vars.insert(btau::vertexMass, vertexSum.M(), true);
+    if (allKinematics.numberOfTracks())
+      vars.insert(btau::vertexEnergyRatio, vertexSum.E() / allSum.E(), true);
+    else
+      vars.insert(btau::vertexEnergyRatio, 1, true);
+  }
+
+  vars.finalize();
+
+  return vars;
 }
 
-TaggingVariableList
-GhostTrackComputer::operator () (const TrackIPTagInfo &ipInfo,
-                                 const SecondaryVertexTagInfo &svInfo) const
-{
-	using namespace ROOT::Math;
+TaggingVariableList GhostTrackComputer::operator()(const CandIPTagInfo &ipInfo,
+                                                   const CandSecondaryVertexTagInfo &svInfo) const {
+  using namespace ROOT::Math;
 
-	edm::RefToBase<Jet> jet = ipInfo.jet();
-	math::XYZVector jetDir = jet->momentum().Unit();
-	bool havePv = ipInfo.primaryVertex().isNonnull();
-	GlobalPoint pv;
-	if (havePv)
-		pv = GlobalPoint(ipInfo.primaryVertex()->x(),
-		                 ipInfo.primaryVertex()->y(),
-		                 ipInfo.primaryVertex()->z());
+  edm::RefToBase<Jet> jet = ipInfo.jet();
+  math::XYZVector jetDir = jet->momentum().Unit();
+  bool havePv = ipInfo.primaryVertex().isNonnull();
+  GlobalPoint pv;
+  if (havePv)
+    pv = GlobalPoint(ipInfo.primaryVertex()->x(), ipInfo.primaryVertex()->y(), ipInfo.primaryVertex()->z());
 
-	btag::Vertices::VertexType vtxType = btag::Vertices::NoVertex;
+  btag::Vertices::VertexType vtxType = btag::Vertices::NoVertex;
 
-	TaggingVariableList vars;
+  TaggingVariableList vars;
 
-	vars.insert(btau::jetPt, jet->pt(), true);
-	vars.insert(btau::jetEta, jet->eta(), true);
+  vars.insert(btau::jetPt, jet->pt(), true);
+  vars.insert(btau::jetEta, jet->eta(), true);
 
-	TrackKinematics allKinematics;
-	TrackKinematics vertexKinematics;
-	TrackKinematics trackKinematics;
+  TrackKinematics allKinematics;
+  TrackKinematics vertexKinematics;
+  TrackKinematics trackKinematics;
 
-	std::pair<double, double> vertexDist2D, vertexDist3D;
-	std::pair<double, double> tracksDist2D, tracksDist3D;
+  std::pair<double, double> vertexDist2D, vertexDist3D;
+  std::pair<double, double> tracksDist2D, tracksDist3D;
 
-	unsigned int nVertices = 0;
-	unsigned int nVertexTracks = 0;
-	unsigned int nTracks = 0;
-	for(unsigned int i = 0; i < svInfo.nVertices(); i++) {
-		const Vertex &vertex = svInfo.secondaryVertex(i);
-		bool hasRefittedTracks = vertex.hasRefittedTracks();
-		TrackRefVector tracks = svInfo.vertexTracks(i);
-		unsigned int n = 0;
-		for(TrackRefVector::const_iterator track = tracks.begin();
-		    track != tracks.end(); track++)
-			if (svInfo.trackWeight(i, *track) >= minTrackWeight)
-				n++;
+  unsigned int nVertices = 0;
+  unsigned int nVertexTracks = 0;
+  unsigned int nTracks = 0;
+  for (unsigned int i = 0; i < svInfo.nVertices(); i++) {
+    const reco::VertexCompositePtrCandidate &vertex = svInfo.secondaryVertex(i);
+    const std::vector<CandidatePtr> &tracks = vertex.daughterPtrVector();
+    unsigned int n = 0;
+    for (std::vector<CandidatePtr>::const_iterator track = tracks.begin(); track != tracks.end(); ++track)
+      n++;
 
-		if (n < 1)
-			continue;
-		bool isTrackVertex = (n == 1);
-		++*(isTrackVertex ? &nTracks : &nVertices);
+    if (n < 1)
+      continue;
+    bool isTrackVertex = (n == 1);
+    ++*(isTrackVertex ? &nTracks : &nVertices);
 
-		addMeas(*(isTrackVertex ? &tracksDist2D : &vertexDist2D),
-					svInfo.flightDistance(i, true));
-		addMeas(*(isTrackVertex ? &tracksDist3D : &vertexDist3D),
-					svInfo.flightDistance(i, false));
+    addMeas(*(isTrackVertex ? &tracksDist2D : &vertexDist2D), svInfo.flightDistance(i, true));
+    addMeas(*(isTrackVertex ? &tracksDist3D : &vertexDist3D), svInfo.flightDistance(i, false));
 
-		TrackKinematics &kin = isTrackVertex ? trackKinematics
-		                                     : vertexKinematics;
-		for(TrackRefVector::const_iterator track = tracks.begin();
-		    track != tracks.end(); track++) {
-			float w = svInfo.trackWeight(i, *track);
-			if (w < minTrackWeight)
-				continue;
-			if (hasRefittedTracks) {
-				Track actualTrack =
-						vertex.refittedTrack(*track);
-				kin.add(actualTrack, w);
-				vars.insert(btau::trackEtaRel, reco::btau::etaRel(jetDir,
-						actualTrack.momentum()), true);
-			} else {
-				kin.add(**track, w);
-				vars.insert(btau::trackEtaRel, reco::btau::etaRel(jetDir,
-						(*track)->momentum()), true);
-			}
-			if (!isTrackVertex)
-				nVertexTracks++;
-		}
-	}
+    TrackKinematics &kin = isTrackVertex ? trackKinematics : vertexKinematics;
 
-	Measurement1D dist2D, dist3D;
-	if (nVertices) {
-		vtxType = btag::Vertices::RecoVertex;
+    for (std::vector<CandidatePtr>::const_iterator track = tracks.begin(); track != tracks.end(); ++track) {
+      kin.add(*track);
+      vars.insert(btau::trackEtaRel, reco::btau::etaRel(jetDir, (*track)->momentum()), true);
+      if (!isTrackVertex)
+        nVertexTracks++;
+    }
+  }
 
-		if (nVertices == 1 && nTracks) {
-			vertexDist2D.first += tracksDist2D.first;
-			vertexDist2D.second += tracksDist2D.second;
-			vertexDist3D.first += tracksDist3D.first;
-			vertexDist3D.second += tracksDist3D.second;
-			vertexKinematics += trackKinematics;
-		}
+  Measurement1D dist2D, dist3D;
+  if (nVertices) {
+    vtxType = btag::Vertices::RecoVertex;
 
-		dist2D = Measurement1D(
-				vertexDist2D.first / vertexDist2D.second,
-				std::sqrt(1. / vertexDist2D.second));
-		dist3D = Measurement1D(
-				vertexDist3D.first / vertexDist3D.second,
-				std::sqrt(1. / vertexDist3D.second));
+    if (nVertices == 1 && nTracks) {
+      vertexDist2D.first += tracksDist2D.first;
+      vertexDist2D.second += tracksDist2D.second;
+      vertexDist3D.first += tracksDist3D.first;
+      vertexDist3D.second += tracksDist3D.second;
+      vertexKinematics += trackKinematics;
+    }
 
-		vars.insert(btau::jetNSecondaryVertices, nVertices, true);
-		vars.insert(btau::vertexNTracks, nVertexTracks, true);
-	} else if (nTracks) {
-		vtxType = btag::Vertices::PseudoVertex;
-		vertexKinematics = trackKinematics;
+    dist2D = Measurement1D(vertexDist2D.first / vertexDist2D.second, std::sqrt(1. / vertexDist2D.second));
+    dist3D = Measurement1D(vertexDist3D.first / vertexDist3D.second, std::sqrt(1. / vertexDist3D.second));
 
-		dist2D = Measurement1D(
-				tracksDist2D.first / tracksDist2D.second,
-				std::sqrt(1. / tracksDist2D.second));
-		dist3D = Measurement1D(
-				tracksDist3D.first / tracksDist3D.second,
-				std::sqrt(1. / tracksDist3D.second));
-	}
+    vars.insert(btau::jetNSecondaryVertices, nVertices, true);
+    vars.insert(btau::vertexNTracks, nVertexTracks, true);
+  } else if (nTracks) {
+    vtxType = btag::Vertices::PseudoVertex;
+    vertexKinematics = trackKinematics;
 
-	if (nVertices || nTracks) {
-		vars.insert(btau::flightDistance2dVal, dist2D.value(), true);
-		vars.insert(btau::flightDistance2dSig, dist2D.significance(), true);
-		vars.insert(btau::flightDistance3dVal, dist3D.value(), true);
-		vars.insert(btau::flightDistance3dSig, dist3D.significance(), true);
-		vars.insert(btau::vertexJetDeltaR,
-		            Geom::deltaR(svInfo.flightDirection(0), jetDir),true);
-		vars.insert(btau::jetNSingleTrackVertices, nTracks, true);
-	}
+    dist2D = Measurement1D(tracksDist2D.first / tracksDist2D.second, std::sqrt(1. / tracksDist2D.second));
+    dist3D = Measurement1D(tracksDist3D.first / tracksDist3D.second, std::sqrt(1. / tracksDist3D.second));
+  }
 
-	std::vector<std::size_t> indices = ipInfo.sortedIndexes(sortCriterium);
-	const std::vector<btag::TrackIPData> &ipData =
-						ipInfo.impactParameterData();
-	const edm::RefVector<TrackCollection> &tracks =
-						ipInfo.selectedTracks();
+  if (nVertices || nTracks) {
+    vars.insert(btau::flightDistance2dVal, dist2D.value(), true);
+    vars.insert(btau::flightDistance2dSig, dist2D.significance(), true);
+    vars.insert(btau::flightDistance3dVal, dist3D.value(), true);
+    vars.insert(btau::flightDistance3dSig, dist3D.significance(), true);
+    vars.insert(btau::vertexJetDeltaR, Geom::deltaR(svInfo.flightDirection(0), jetDir), true);
+    vars.insert(btau::jetNSingleTrackVertices, nTracks, true);
+  }
 
-	TrackRef trackPairV0Test[2];
-	for(unsigned int i = 0; i < indices.size(); i++) {
-		std::size_t idx = indices[i];
-		const btag::TrackIPData &data = ipData[idx];
-		const TrackRef &trackRef = tracks[idx];
-		const Track &track = *trackRef;
+  std::vector<std::size_t> indices = ipInfo.sortedIndexes(sortCriterium);
+  const std::vector<btag::TrackIPData> &ipData = ipInfo.impactParameterData();
+  const CandIPTagInfo::input_container &tracks = ipInfo.selectedTracks();
 
-		// filter track
-
-		if (!trackSelector(track, data, *jet, pv))
-			continue;
-
-		// add track to kinematics for all tracks in jet
-
-		allKinematics.add(track);
-
-		// check against all other tracks for V0 track pairs
-
-		trackPairV0Test[0] = tracks[idx];
-		bool ok = true;
-		for(unsigned int j = 0; j < indices.size(); j++) {
-			if (i == j)
-				continue;
-
-			std::size_t pairIdx = indices[j];
-			const btag::TrackIPData &pairTrackData =
-							ipData[pairIdx];
-			const TrackRef &pairTrackRef = tracks[pairIdx];
-			const Track &pairTrack = *pairTrackRef;
-
-			if (!trackSelector(pairTrack, pairTrackData, *jet, pv))
-				continue;
-
-			trackPairV0Test[1] = pairTrackRef;
-			if (!trackPairV0Filter(trackPairV0Test, 2)) {
-				ok = false;
-				break;
-			}
-		}
-		if (!ok)
-			continue;
-
-		// add track variables
-
-		const math::XYZVector& trackMom = track.momentum();
-		double trackMag = std::sqrt(trackMom.Mag2());
-
-		vars.insert(btau::trackSip3dVal, data.ip3d.value(), true);
-		vars.insert(btau::trackSip3dSig, data.ip3d.significance(), true);
-		vars.insert(btau::trackSip2dVal, data.ip2d.value(), true);
-		vars.insert(btau::trackSip2dSig, data.ip2d.significance(), true);
-		vars.insert(btau::trackJetDistVal, data.distanceToJetAxis.value(), true);
-		vars.insert(btau::trackGhostTrackDistVal, data.distanceToGhostTrack.value(), true);
-		vars.insert(btau::trackGhostTrackDistSig, data.distanceToGhostTrack.significance(), true);
-		vars.insert(btau::trackGhostTrackWeight, data.ghostTrackWeight, true);
-		vars.insert(btau::trackDecayLenVal, havePv ? (data.closestToGhostTrack - pv).mag() : -1.0, true);
-
-		vars.insert(btau::trackMomentum, trackMag, true);
-		vars.insert(btau::trackEta, trackMom.Eta(), true);
-
-		vars.insert(btau::trackChi2, track.normalizedChi2(), true);
-		vars.insert(btau::trackNPixelHits, track.hitPattern().pixelLayersWithMeasurement(), true);
-		vars.insert(btau::trackNTotalHits, track.hitPattern().trackerLayersWithMeasurement(), true);
-		vars.insert(btau::trackPtRel, VectorUtil::Perp(trackMom, jetDir), true);
-		vars.insert(btau::trackDeltaR, VectorUtil::DeltaR(trackMom, jetDir), true);
-	} 
-
-	vars.insert(btau::vertexCategory, vtxType, true);
-	vars.insert(btau::trackSumJetDeltaR,
-	            VectorUtil::DeltaR(allKinematics.vectorSum(), jetDir), true);
-	vars.insert(btau::trackSumJetEtRatio,
-	            allKinematics.vectorSum().Et() / ipInfo.jet()->et(), true);
-	vars.insert(btau::trackSip3dSigAboveCharm,
-	            threshTrack(ipInfo, reco::btag::IP3DSig, *jet, pv)
-	            					.ip3d.significance(),
-	            true);
-	vars.insert(btau::trackSip2dSigAboveCharm,
-	            threshTrack(ipInfo, reco::btag::IP2DSig, *jet, pv)
-	            					.ip2d.significance(),
-	            true);
-
-	if (vtxType != btag::Vertices::NoVertex) {
-		const math::XYZTLorentzVector& allSum = allKinematics.vectorSum();
-		const math::XYZTLorentzVector& vertexSum = vertexKinematics.vectorSum();
-
-		vars.insert(btau::vertexMass, vertexSum.M(), true);
-		if (allKinematics.numberOfTracks())
-			vars.insert(btau::vertexEnergyRatio,
-			            vertexSum.E() / allSum.E(), true);
-		else
-			vars.insert(btau::vertexEnergyRatio, 1, true);
-	}
-
-	vars.finalize();
-
-	return vars;
-}
-
-TaggingVariableList
-GhostTrackComputer::operator () (const CandIPTagInfo &ipInfo,
-                                 const CandSecondaryVertexTagInfo &svInfo) const
-{
-	using namespace ROOT::Math;
-
-	edm::RefToBase<Jet> jet = ipInfo.jet();
-	math::XYZVector jetDir = jet->momentum().Unit();
-	bool havePv = ipInfo.primaryVertex().isNonnull();
-	GlobalPoint pv;
-	if (havePv)
-		pv = GlobalPoint(ipInfo.primaryVertex()->x(),
-		                 ipInfo.primaryVertex()->y(),
-		                 ipInfo.primaryVertex()->z());
-
-	btag::Vertices::VertexType vtxType = btag::Vertices::NoVertex;
-
-	TaggingVariableList vars;
-
-	vars.insert(btau::jetPt, jet->pt(), true);
-	vars.insert(btau::jetEta, jet->eta(), true);
-
-	TrackKinematics allKinematics;
-	TrackKinematics vertexKinematics;
-	TrackKinematics trackKinematics;
-
-	std::pair<double, double> vertexDist2D, vertexDist3D;
-	std::pair<double, double> tracksDist2D, tracksDist3D;
-
-	unsigned int nVertices = 0;
-	unsigned int nVertexTracks = 0;
-	unsigned int nTracks = 0;
-	for(unsigned int i = 0; i < svInfo.nVertices(); i++) {
-		const reco::VertexCompositePtrCandidate &vertex = svInfo.secondaryVertex(i);
-		const std::vector<CandidatePtr> & tracks = vertex.daughterPtrVector();
-		unsigned int n = 0;
-		for(std::vector<CandidatePtr>::const_iterator track = tracks.begin(); track != tracks.end(); ++track)
-				n++;
-
-		if (n < 1)
-			continue;
-		bool isTrackVertex = (n == 1);
-		++*(isTrackVertex ? &nTracks : &nVertices);
-
-		addMeas(*(isTrackVertex ? &tracksDist2D : &vertexDist2D),
-					svInfo.flightDistance(i, true));
-		addMeas(*(isTrackVertex ? &tracksDist3D : &vertexDist3D),
-					svInfo.flightDistance(i, false));
-
-		TrackKinematics &kin = isTrackVertex ? trackKinematics : vertexKinematics;
-
-		for(std::vector<CandidatePtr>::const_iterator track = tracks.begin(); track != tracks.end(); ++track) {
-			kin.add(*track);
-				vars.insert(btau::trackEtaRel, reco::btau::etaRel(jetDir, (*track)->momentum()), true);
-			if (!isTrackVertex)
-				nVertexTracks++;
-		}
-	}
-
-	Measurement1D dist2D, dist3D;
-	if (nVertices) {
-		vtxType = btag::Vertices::RecoVertex;
-
-		if (nVertices == 1 && nTracks) {
-			vertexDist2D.first += tracksDist2D.first;
-			vertexDist2D.second += tracksDist2D.second;
-			vertexDist3D.first += tracksDist3D.first;
-			vertexDist3D.second += tracksDist3D.second;
-			vertexKinematics += trackKinematics;
-		}
-
-		dist2D = Measurement1D(
-				vertexDist2D.first / vertexDist2D.second,
-				std::sqrt(1. / vertexDist2D.second));
-		dist3D = Measurement1D(
-				vertexDist3D.first / vertexDist3D.second,
-				std::sqrt(1. / vertexDist3D.second));
-
-		vars.insert(btau::jetNSecondaryVertices, nVertices, true);
-		vars.insert(btau::vertexNTracks, nVertexTracks, true);
-	} else if (nTracks) {
-		vtxType = btag::Vertices::PseudoVertex;
-		vertexKinematics = trackKinematics;
-
-		dist2D = Measurement1D(
-				tracksDist2D.first / tracksDist2D.second,
-				std::sqrt(1. / tracksDist2D.second));
-		dist3D = Measurement1D(
-				tracksDist3D.first / tracksDist3D.second,
-				std::sqrt(1. / tracksDist3D.second));
-	}
-
-	if (nVertices || nTracks) {
-		vars.insert(btau::flightDistance2dVal, dist2D.value(), true);
-		vars.insert(btau::flightDistance2dSig, dist2D.significance(), true);
-		vars.insert(btau::flightDistance3dVal, dist3D.value(), true);
-		vars.insert(btau::flightDistance3dSig, dist3D.significance(), true);
-		vars.insert(btau::vertexJetDeltaR, Geom::deltaR(svInfo.flightDirection(0), jetDir),true);
-		vars.insert(btau::jetNSingleTrackVertices, nTracks, true);
-	}
-
-	std::vector<std::size_t> indices = ipInfo.sortedIndexes(sortCriterium);
-	const std::vector<btag::TrackIPData> &ipData = ipInfo.impactParameterData();
-	const CandIPTagInfo::input_container &tracks = ipInfo.selectedTracks();
-
-  const Track * trackPairV0Test[2];
-	for(unsigned int i = 0; i < indices.size(); i++) {
-		std::size_t idx = indices[i];
-		const btag::TrackIPData &data = ipData[idx];
-    const Track * trackPtr = reco::btag::toTrack(tracks[idx]);
+  const Track *trackPairV0Test[2];
+  for (unsigned int i = 0; i < indices.size(); i++) {
+    std::size_t idx = indices[i];
+    const btag::TrackIPData &data = ipData[idx];
+    const Track *trackPtr = reco::btag::toTrack(tracks[idx]);
     const Track &track = *trackPtr;
 
-		// filter track
+    // filter track
 
-		if (!trackSelector(track, data, *jet, pv))
-			continue;
+    if (!trackSelector(track, data, *jet, pv))
+      continue;
 
-		// add track to kinematics for all tracks in jet
+    // add track to kinematics for all tracks in jet
 
-		allKinematics.add(track);
+    allKinematics.add(track);
 
-		// check against all other tracks for V0 track pairs
+    // check against all other tracks for V0 track pairs
 
-		trackPairV0Test[0] = reco::btag::toTrack(tracks[idx]);
-		bool ok = true;
-		for(unsigned int j = 0; j < indices.size(); j++) {
-			if (i == j)
-				continue;
+    trackPairV0Test[0] = reco::btag::toTrack(tracks[idx]);
+    bool ok = true;
+    for (unsigned int j = 0; j < indices.size(); j++) {
+      if (i == j)
+        continue;
 
-			std::size_t pairIdx = indices[j];
-			const btag::TrackIPData &pairTrackData = ipData[pairIdx];
-      const Track * pairTrackPtr = reco::btag::toTrack(tracks[pairIdx]);
+      std::size_t pairIdx = indices[j];
+      const btag::TrackIPData &pairTrackData = ipData[pairIdx];
+      const Track *pairTrackPtr = reco::btag::toTrack(tracks[pairIdx]);
       const Track &pairTrack = *pairTrackPtr;
 
-			if (!trackSelector(pairTrack, pairTrackData, *jet, pv))
-				continue;
+      if (!trackSelector(pairTrack, pairTrackData, *jet, pv))
+        continue;
 
       trackPairV0Test[1] = pairTrackPtr;
-			if (!trackPairV0Filter(trackPairV0Test, 2)) {
-				ok = false;
-				break;
-			}
-		}
-		if (!ok)
-			continue;
+      if (!trackPairV0Filter(trackPairV0Test, 2)) {
+        ok = false;
+        break;
+      }
+    }
+    if (!ok)
+      continue;
 
-		// add track variables
+    // add track variables
 
-		const math::XYZVector& trackMom = track.momentum();
-		double trackMag = std::sqrt(trackMom.Mag2());
+    const math::XYZVector &trackMom = track.momentum();
+    double trackMag = std::sqrt(trackMom.Mag2());
 
-		vars.insert(btau::trackSip3dVal, data.ip3d.value(), true);
-		vars.insert(btau::trackSip3dSig, data.ip3d.significance(), true);
-		vars.insert(btau::trackSip2dVal, data.ip2d.value(), true);
-		vars.insert(btau::trackSip2dSig, data.ip2d.significance(), true);
-		vars.insert(btau::trackJetDistVal, data.distanceToJetAxis.value(), true);
-		vars.insert(btau::trackGhostTrackDistVal, data.distanceToGhostTrack.value(), true);
-		vars.insert(btau::trackGhostTrackDistSig, data.distanceToGhostTrack.significance(), true);
-		vars.insert(btau::trackGhostTrackWeight, data.ghostTrackWeight, true);
-		vars.insert(btau::trackDecayLenVal, havePv ? (data.closestToGhostTrack - pv).mag() : -1.0, true);
+    vars.insert(btau::trackSip3dVal, data.ip3d.value(), true);
+    vars.insert(btau::trackSip3dSig, data.ip3d.significance(), true);
+    vars.insert(btau::trackSip2dVal, data.ip2d.value(), true);
+    vars.insert(btau::trackSip2dSig, data.ip2d.significance(), true);
+    vars.insert(btau::trackJetDistVal, data.distanceToJetAxis.value(), true);
+    vars.insert(btau::trackGhostTrackDistVal, data.distanceToGhostTrack.value(), true);
+    vars.insert(btau::trackGhostTrackDistSig, data.distanceToGhostTrack.significance(), true);
+    vars.insert(btau::trackGhostTrackWeight, data.ghostTrackWeight, true);
+    vars.insert(btau::trackDecayLenVal, havePv ? (data.closestToGhostTrack - pv).mag() : -1.0, true);
 
-		vars.insert(btau::trackMomentum, trackMag, true);
-		vars.insert(btau::trackEta, trackMom.Eta(), true);
+    vars.insert(btau::trackMomentum, trackMag, true);
+    vars.insert(btau::trackEta, trackMom.Eta(), true);
 
-		vars.insert(btau::trackChi2, track.normalizedChi2(), true);
-		vars.insert(btau::trackNPixelHits, track.hitPattern().pixelLayersWithMeasurement(), true);
-		vars.insert(btau::trackNTotalHits, track.hitPattern().trackerLayersWithMeasurement(), true);
-		vars.insert(btau::trackPtRel, VectorUtil::Perp(trackMom, jetDir), true);
-		vars.insert(btau::trackDeltaR, VectorUtil::DeltaR(trackMom, jetDir), true);
-	} 
+    vars.insert(btau::trackChi2, track.normalizedChi2(), true);
+    vars.insert(btau::trackNPixelHits, track.hitPattern().pixelLayersWithMeasurement(), true);
+    vars.insert(btau::trackNTotalHits, track.hitPattern().trackerLayersWithMeasurement(), true);
+    vars.insert(btau::trackPtRel, VectorUtil::Perp(trackMom, jetDir), true);
+    vars.insert(btau::trackDeltaR, VectorUtil::DeltaR(trackMom, jetDir), true);
+  }
 
-	vars.insert(btau::vertexCategory, vtxType, true);
-	vars.insert(btau::trackSumJetDeltaR, VectorUtil::DeltaR(allKinematics.vectorSum(), jetDir), true);
-	vars.insert(btau::trackSumJetEtRatio, allKinematics.vectorSum().Et() / ipInfo.jet()->et(), true);
-	vars.insert(btau::trackSip3dSigAboveCharm, threshTrack(ipInfo, reco::btag::IP3DSig, *jet, pv).ip3d.significance(), true);
-	vars.insert(btau::trackSip2dSigAboveCharm, threshTrack(ipInfo, reco::btag::IP2DSig, *jet, pv).ip2d.significance(), true);
+  vars.insert(btau::vertexCategory, vtxType, true);
+  vars.insert(btau::trackSumJetDeltaR, VectorUtil::DeltaR(allKinematics.vectorSum(), jetDir), true);
+  vars.insert(btau::trackSumJetEtRatio, allKinematics.vectorSum().Et() / ipInfo.jet()->et(), true);
+  vars.insert(
+      btau::trackSip3dSigAboveCharm, threshTrack(ipInfo, reco::btag::IP3DSig, *jet, pv).ip3d.significance(), true);
+  vars.insert(
+      btau::trackSip2dSigAboveCharm, threshTrack(ipInfo, reco::btag::IP2DSig, *jet, pv).ip2d.significance(), true);
 
-	if (vtxType != btag::Vertices::NoVertex) {
-		const math::XYZTLorentzVector& allSum = allKinematics.vectorSum();
-		const math::XYZTLorentzVector& vertexSum = vertexKinematics.vectorSum();
+  if (vtxType != btag::Vertices::NoVertex) {
+    const math::XYZTLorentzVector &allSum = allKinematics.vectorSum();
+    const math::XYZTLorentzVector &vertexSum = vertexKinematics.vectorSum();
 
-		vars.insert(btau::vertexMass, vertexSum.M(), true);
-		if (allKinematics.numberOfTracks())
-			vars.insert(btau::vertexEnergyRatio, vertexSum.E() / allSum.E(), true);
-		else
-			vars.insert(btau::vertexEnergyRatio, 1, true);
-	}
+    vars.insert(btau::vertexMass, vertexSum.M(), true);
+    if (allKinematics.numberOfTracks())
+      vars.insert(btau::vertexEnergyRatio, vertexSum.E() / allSum.E(), true);
+    else
+      vars.insert(btau::vertexEnergyRatio, 1, true);
+  }
 
-	vars.finalize();
+  vars.finalize();
 
-	return vars;
+  return vars;
 }

--- a/RecoBTag/SecondaryVertex/src/TemplatedSecondaryVertex.cc
+++ b/RecoBTag/SecondaryVertex/src/TemplatedSecondaryVertex.cc
@@ -13,200 +13,174 @@
 
 namespace reco {
 
-template <>
-TemplatedSecondaryVertex<reco::VertexCompositePtrCandidate>::operator reco::Vertex() {
-CovarianceMatrix err;
-fillVertexCovariance(err);
-return reco::Vertex(Vertex::Point(vertex()), err, vertexChi2(), vertexNdof(),numberOfSourceCandidatePtrs());
-}
+  template <>
+  TemplatedSecondaryVertex<reco::VertexCompositePtrCandidate>::operator reco::Vertex() {
+    CovarianceMatrix err;
+    fillVertexCovariance(err);
+    return reco::Vertex(Vertex::Point(vertex()), err, vertexChi2(), vertexNdof(), numberOfSourceCandidatePtrs());
+  }
 
-//it should be better without if it compiles
-/*template <>
+  //it should be better without if it compiles
+  /*template <>
 TemplatedSecondaryVertex<reco::Vertex>::operator reco::Vertex() {
 return reco::Vertex(this);
 }*/
-template <>
-Measurement1D
-TemplatedSecondaryVertex<reco::VertexCompositePtrCandidate>::computeDist1d(const Vertex &pv, const VertexCompositePtrCandidate &sv,
-                               const GlobalVector &direction, bool withPVError)
-{
-        typedef ROOT::Math::SVector<double, 3> SVector1;
-        typedef ROOT::Math::SMatrix<double, 3, 3,
-                        ROOT::Math::MatRepSym<double, 3> > SMatrixSym1;
-        CovarianceMatrix covariance;
-        sv.fillVertexCovariance(covariance);
-        SMatrixSym1 cov = covariance;
-        if (withPVError)
-                cov += pv.covariance();
-        SVector1 vector(0,0,sv.vertex().Z() - pv.position().Z());
-        
-        double dist = ROOT::Math::Mag(vector);
-        double error = ROOT::Math::Similarity(cov, vector);
-        if (error > 0.0 && dist > 1.0e-9)
-                error = std::sqrt(error) / dist; 
-        else
-                error = -1.0;
-        if ((vector[0] * direction.x() +
-             vector[1] * direction.y() +
-             vector[2] * direction.z()) < 0.0)
-                dist = -dist;
-        return Measurement1D(dist, error);                      
-}
+  template <>
+  Measurement1D TemplatedSecondaryVertex<reco::VertexCompositePtrCandidate>::computeDist1d(
+      const Vertex &pv, const VertexCompositePtrCandidate &sv, const GlobalVector &direction, bool withPVError) {
+    typedef ROOT::Math::SVector<double, 3> SVector1;
+    typedef ROOT::Math::SMatrix<double, 3, 3, ROOT::Math::MatRepSym<double, 3> > SMatrixSym1;
+    CovarianceMatrix covariance;
+    sv.fillVertexCovariance(covariance);
+    SMatrixSym1 cov = covariance;
+    if (withPVError)
+      cov += pv.covariance();
+    SVector1 vector(0, 0, sv.vertex().Z() - pv.position().Z());
 
-template <>
-Measurement1D
-TemplatedSecondaryVertex<reco::VertexCompositePtrCandidate>::computeDist2d(const Vertex &pv, const VertexCompositePtrCandidate &sv,
-                               const GlobalVector &direction, bool withPVError)
-{
-	typedef ROOT::Math::SVector<double, 2> SVector2;
-	typedef ROOT::Math::SMatrix<double, 2, 2,
-			ROOT::Math::MatRepSym<double, 2> > SMatrixSym2;
-	CovarianceMatrix covariance;
-	sv.fillVertexCovariance(covariance);
+    double dist = ROOT::Math::Mag(vector);
+    double error = ROOT::Math::Similarity(cov, vector);
+    if (error > 0.0 && dist > 1.0e-9)
+      error = std::sqrt(error) / dist;
+    else
+      error = -1.0;
+    if ((vector[0] * direction.x() + vector[1] * direction.y() + vector[2] * direction.z()) < 0.0)
+      dist = -dist;
+    return Measurement1D(dist, error);
+  }
 
-	SMatrixSym2 cov = covariance.Sub<SMatrixSym2>(0, 0);
-	if (withPVError)
-		cov += pv.covariance().Sub<SMatrixSym2>(0, 0);
+  template <>
+  Measurement1D TemplatedSecondaryVertex<reco::VertexCompositePtrCandidate>::computeDist2d(
+      const Vertex &pv, const VertexCompositePtrCandidate &sv, const GlobalVector &direction, bool withPVError) {
+    typedef ROOT::Math::SVector<double, 2> SVector2;
+    typedef ROOT::Math::SMatrix<double, 2, 2, ROOT::Math::MatRepSym<double, 2> > SMatrixSym2;
+    CovarianceMatrix covariance;
+    sv.fillVertexCovariance(covariance);
 
-	SVector2 vector(sv.vertex().X() - pv.position().X(),
-	                sv.vertex().Y() - pv.position().Y());
-	double dist = ROOT::Math::Mag(vector);
-	double error = ROOT::Math::Similarity(cov, vector);
-	if (error > 0.0 && dist > 1.0e-9)
-		error = std::sqrt(error) / dist;
-	else
-		error = -1.0;
+    SMatrixSym2 cov = covariance.Sub<SMatrixSym2>(0, 0);
+    if (withPVError)
+      cov += pv.covariance().Sub<SMatrixSym2>(0, 0);
 
-	if ((vector[0] * direction.x() +
-	     vector[1] * direction.y()) < 0.0)
-		dist = -dist;
+    SVector2 vector(sv.vertex().X() - pv.position().X(), sv.vertex().Y() - pv.position().Y());
+    double dist = ROOT::Math::Mag(vector);
+    double error = ROOT::Math::Similarity(cov, vector);
+    if (error > 0.0 && dist > 1.0e-9)
+      error = std::sqrt(error) / dist;
+    else
+      error = -1.0;
 
-	return Measurement1D(dist, error);
-}
-template <>
-Measurement1D
-TemplatedSecondaryVertex<reco::VertexCompositePtrCandidate>::computeDist3d(const Vertex &pv, const VertexCompositePtrCandidate &sv,
-                               const GlobalVector &direction, bool withPVError)
-{
-	typedef ROOT::Math::SVector<double, 3> SVector3;
-	typedef ROOT::Math::SMatrix<double, 3, 3,
-			ROOT::Math::MatRepSym<double, 3> > SMatrixSym3;
-	CovarianceMatrix covariance;
-        sv.fillVertexCovariance(covariance);
+    if ((vector[0] * direction.x() + vector[1] * direction.y()) < 0.0)
+      dist = -dist;
 
-	SMatrixSym3 cov = covariance;
-	if (withPVError)
-		cov += pv.covariance();
+    return Measurement1D(dist, error);
+  }
+  template <>
+  Measurement1D TemplatedSecondaryVertex<reco::VertexCompositePtrCandidate>::computeDist3d(
+      const Vertex &pv, const VertexCompositePtrCandidate &sv, const GlobalVector &direction, bool withPVError) {
+    typedef ROOT::Math::SVector<double, 3> SVector3;
+    typedef ROOT::Math::SMatrix<double, 3, 3, ROOT::Math::MatRepSym<double, 3> > SMatrixSym3;
+    CovarianceMatrix covariance;
+    sv.fillVertexCovariance(covariance);
 
-	SVector3 vector(sv.vertex().X() - pv.position().X(),
-	                sv.vertex().Y() - pv.position().Y(),
-	                sv.vertex().Z() - pv.position().Z());
+    SMatrixSym3 cov = covariance;
+    if (withPVError)
+      cov += pv.covariance();
 
-	double dist = ROOT::Math::Mag(vector);
-	double error = ROOT::Math::Similarity(cov, vector);
-	if (error > 0.0 && dist > 1.0e-9)
-		error = std::sqrt(error) / dist;
-	else
-		error = -1.0;
+    SVector3 vector(
+        sv.vertex().X() - pv.position().X(), sv.vertex().Y() - pv.position().Y(), sv.vertex().Z() - pv.position().Z());
 
-	if ((vector[0] * direction.x() +
-	     vector[1] * direction.y() +
-	     vector[2] * direction.z()) < 0.0)
-		dist = -dist;
+    double dist = ROOT::Math::Mag(vector);
+    double error = ROOT::Math::Similarity(cov, vector);
+    if (error > 0.0 && dist > 1.0e-9)
+      error = std::sqrt(error) / dist;
+    else
+      error = -1.0;
 
-	return Measurement1D(dist, error);
-}
+    if ((vector[0] * direction.x() + vector[1] * direction.y() + vector[2] * direction.z()) < 0.0)
+      dist = -dist;
 
-template <>
-Measurement1D
-TemplatedSecondaryVertex<reco::Vertex>::computeDist1d(const Vertex &pv, const Vertex &sv,
-                               const GlobalVector &direction, bool withPVError)
-{
-        typedef ROOT::Math::SVector<double, 3> SVector1;
-        typedef ROOT::Math::SMatrix<double, 3, 3,
-                        ROOT::Math::MatRepSym<double, 3> > SMatrixSym1;
+    return Measurement1D(dist, error);
+  }
 
-        SMatrixSym1 cov = sv.covariance();
-        if (withPVError)
-                cov += pv.covariance(); 
+  template <>
+  Measurement1D TemplatedSecondaryVertex<reco::Vertex>::computeDist1d(const Vertex &pv,
+                                                                      const Vertex &sv,
+                                                                      const GlobalVector &direction,
+                                                                      bool withPVError) {
+    typedef ROOT::Math::SVector<double, 3> SVector1;
+    typedef ROOT::Math::SMatrix<double, 3, 3, ROOT::Math::MatRepSym<double, 3> > SMatrixSym1;
 
-        SVector1 vector(0.0,0.0,sv.position().Z() - pv.position().Z());
+    SMatrixSym1 cov = sv.covariance();
+    if (withPVError)
+      cov += pv.covariance();
 
-        double dist = ROOT::Math::Mag(vector);
-        double error = ROOT::Math::Similarity(cov, vector);
-        if (error > 0.0 && dist > 1.0e-9)
-                error = std::sqrt(error) / dist;
-        else
-                error = -1.0;
+    SVector1 vector(0.0, 0.0, sv.position().Z() - pv.position().Z());
 
-        if ((vector[0] * direction.x() +
-             vector[1] * direction.y() +
-             vector[2] * direction.z()) < 0.0)
-                dist = -dist;
+    double dist = ROOT::Math::Mag(vector);
+    double error = ROOT::Math::Similarity(cov, vector);
+    if (error > 0.0 && dist > 1.0e-9)
+      error = std::sqrt(error) / dist;
+    else
+      error = -1.0;
 
-        return Measurement1D(dist, error);
-}
+    if ((vector[0] * direction.x() + vector[1] * direction.y() + vector[2] * direction.z()) < 0.0)
+      dist = -dist;
 
+    return Measurement1D(dist, error);
+  }
 
-template <>
-Measurement1D
-TemplatedSecondaryVertex<reco::Vertex>::computeDist2d(const Vertex &pv, const Vertex &sv,
-                               const GlobalVector &direction, bool withPVError)
-{
-	typedef ROOT::Math::SVector<double, 2> SVector2;
-	typedef ROOT::Math::SMatrix<double, 2, 2,
-			ROOT::Math::MatRepSym<double, 2> > SMatrixSym2;
+  template <>
+  Measurement1D TemplatedSecondaryVertex<reco::Vertex>::computeDist2d(const Vertex &pv,
+                                                                      const Vertex &sv,
+                                                                      const GlobalVector &direction,
+                                                                      bool withPVError) {
+    typedef ROOT::Math::SVector<double, 2> SVector2;
+    typedef ROOT::Math::SMatrix<double, 2, 2, ROOT::Math::MatRepSym<double, 2> > SMatrixSym2;
 
-	SMatrixSym2 cov = sv.covariance().Sub<SMatrixSym2>(0, 0);
-	if (withPVError)
-		cov += pv.covariance().Sub<SMatrixSym2>(0, 0);
+    SMatrixSym2 cov = sv.covariance().Sub<SMatrixSym2>(0, 0);
+    if (withPVError)
+      cov += pv.covariance().Sub<SMatrixSym2>(0, 0);
 
-	SVector2 vector(sv.position().X() - pv.position().X(),
-	                sv.position().Y() - pv.position().Y());
+    SVector2 vector(sv.position().X() - pv.position().X(), sv.position().Y() - pv.position().Y());
 
-	double dist = ROOT::Math::Mag(vector);
-	double error = ROOT::Math::Similarity(cov, vector);
-	if (error > 0.0 && dist > 1.0e-9)
-		error = std::sqrt(error) / dist;
-	else
-		error = -1.0;
+    double dist = ROOT::Math::Mag(vector);
+    double error = ROOT::Math::Similarity(cov, vector);
+    if (error > 0.0 && dist > 1.0e-9)
+      error = std::sqrt(error) / dist;
+    else
+      error = -1.0;
 
-	if ((vector[0] * direction.x() +
-	     vector[1] * direction.y()) < 0.0)
-		dist = -dist;
+    if ((vector[0] * direction.x() + vector[1] * direction.y()) < 0.0)
+      dist = -dist;
 
-	return Measurement1D(dist, error);
-}
-template <>
-Measurement1D
-TemplatedSecondaryVertex<reco::Vertex>::computeDist3d(const Vertex &pv, const Vertex &sv,
-                               const GlobalVector &direction, bool withPVError)
-{
-	typedef ROOT::Math::SVector<double, 3> SVector3;
-	typedef ROOT::Math::SMatrix<double, 3, 3,
-			ROOT::Math::MatRepSym<double, 3> > SMatrixSym3;
+    return Measurement1D(dist, error);
+  }
+  template <>
+  Measurement1D TemplatedSecondaryVertex<reco::Vertex>::computeDist3d(const Vertex &pv,
+                                                                      const Vertex &sv,
+                                                                      const GlobalVector &direction,
+                                                                      bool withPVError) {
+    typedef ROOT::Math::SVector<double, 3> SVector3;
+    typedef ROOT::Math::SMatrix<double, 3, 3, ROOT::Math::MatRepSym<double, 3> > SMatrixSym3;
 
-	SMatrixSym3 cov = sv.covariance();
-	if (withPVError)
-		cov += pv.covariance();
+    SMatrixSym3 cov = sv.covariance();
+    if (withPVError)
+      cov += pv.covariance();
 
-	SVector3 vector(sv.position().X() - pv.position().X(),
-	                sv.position().Y() - pv.position().Y(),
-	                sv.position().Z() - pv.position().Z());
+    SVector3 vector(sv.position().X() - pv.position().X(),
+                    sv.position().Y() - pv.position().Y(),
+                    sv.position().Z() - pv.position().Z());
 
-	double dist = ROOT::Math::Mag(vector);
-	double error = ROOT::Math::Similarity(cov, vector);
-	if (error > 0.0 && dist > 1.0e-9)
-		error = std::sqrt(error) / dist;
-	else
-		error = -1.0;
+    double dist = ROOT::Math::Mag(vector);
+    double error = ROOT::Math::Similarity(cov, vector);
+    if (error > 0.0 && dist > 1.0e-9)
+      error = std::sqrt(error) / dist;
+    else
+      error = -1.0;
 
-	if ((vector[0] * direction.x() +
-	     vector[1] * direction.y() +
-	     vector[2] * direction.z()) < 0.0)
-		dist = -dist;
+    if ((vector[0] * direction.x() + vector[1] * direction.y() + vector[2] * direction.z()) < 0.0)
+      dist = -dist;
 
-	return Measurement1D(dist, error);
-}
+    return Measurement1D(dist, error);
+  }
 
-}
+}  // namespace reco

--- a/RecoBTag/SecondaryVertex/src/TrackSelector.cc
+++ b/RecoBTag/SecondaryVertex/src/TrackSelector.cc
@@ -29,7 +29,7 @@ TrackSelector::TrackSelector(const edm::ParameterSet &params) :
 	std::string qualityClass =
 			params.getParameter<std::string>("qualityClass");
 	if (qualityClass == "any" || qualityClass == "Any" ||
-	    qualityClass == "ANY" || qualityClass == "") {
+	    qualityClass == "ANY" || qualityClass.empty()) {
 		selectQuality = false;
 		quality = reco::TrackBase::undefQuality;
 	} else {

--- a/RecoBTag/SecondaryVertex/src/TrackSelector.cc
+++ b/RecoBTag/SecondaryVertex/src/TrackSelector.cc
@@ -6,117 +6,87 @@
 
 #include "RecoBTag/SecondaryVertex/interface/TrackSelector.h"
 
-using namespace reco; 
+using namespace reco;
 
-TrackSelector::TrackSelector(const edm::ParameterSet &params) :
-	minPixelHits(params.getParameter<unsigned int>("pixelHitsMin")),
-	minTotalHits(params.getParameter<unsigned int>("totalHitsMin")),
-	minPt(params.getParameter<double>("ptMin")),
-	maxNormChi2(params.getParameter<double>("normChi2Max")),
-	maxJetDeltaR(params.getParameter<double>("jetDeltaRMax")),
-	maxDistToAxis(params.getParameter<double>("maxDistToAxis")),
-	maxDecayLen(params.getParameter<double>("maxDecayLen")),
-	sip2dValMin(params.getParameter<double>("sip2dValMin")),
-	sip2dValMax(params.getParameter<double>("sip2dValMax")),
-	sip2dSigMin(params.getParameter<double>("sip2dSigMin")),
-	sip2dSigMax(params.getParameter<double>("sip2dSigMax")),
-	sip3dValMin(params.getParameter<double>("sip3dValMin")),
-	sip3dValMax(params.getParameter<double>("sip3dValMax")),
-	sip3dSigMin(params.getParameter<double>("sip3dSigMin")),
-	sip3dSigMax(params.getParameter<double>("sip3dSigMax")),
-	useVariableJTA_(params.existsAs<bool>("useVariableJTA") ?  params.getParameter<bool>("useVariableJTA") : false)
-{
-	std::string qualityClass =
-			params.getParameter<std::string>("qualityClass");
-	if (qualityClass == "any" || qualityClass == "Any" ||
-	    qualityClass == "ANY" || qualityClass.empty()) {
-		selectQuality = false;
-		quality = reco::TrackBase::undefQuality;
-	} else {
-		selectQuality = true;
-		quality = reco::TrackBase::qualityByName(qualityClass);
-	}
-	if (useVariableJTA_){
-	  varJTApars = {
-	    params.getParameter<double>("a_dR"),
-	    params.getParameter<double>("b_dR"),
-	    params.getParameter<double>("a_pT"),
-	    params.getParameter<double>("b_pT"),
-	    params.getParameter<double>("min_pT"),  
-	    params.getParameter<double>("max_pT"),
-	    params.getParameter<double>("min_pT_dRcut"),  
-	    params.getParameter<double>("max_pT_dRcut"),
-	    params.getParameter<double>("max_pT_trackPTcut") };
-	}
+TrackSelector::TrackSelector(const edm::ParameterSet &params)
+    : minPixelHits(params.getParameter<unsigned int>("pixelHitsMin")),
+      minTotalHits(params.getParameter<unsigned int>("totalHitsMin")),
+      minPt(params.getParameter<double>("ptMin")),
+      maxNormChi2(params.getParameter<double>("normChi2Max")),
+      maxJetDeltaR(params.getParameter<double>("jetDeltaRMax")),
+      maxDistToAxis(params.getParameter<double>("maxDistToAxis")),
+      maxDecayLen(params.getParameter<double>("maxDecayLen")),
+      sip2dValMin(params.getParameter<double>("sip2dValMin")),
+      sip2dValMax(params.getParameter<double>("sip2dValMax")),
+      sip2dSigMin(params.getParameter<double>("sip2dSigMin")),
+      sip2dSigMax(params.getParameter<double>("sip2dSigMax")),
+      sip3dValMin(params.getParameter<double>("sip3dValMin")),
+      sip3dValMax(params.getParameter<double>("sip3dValMax")),
+      sip3dSigMin(params.getParameter<double>("sip3dSigMin")),
+      sip3dSigMax(params.getParameter<double>("sip3dSigMax")),
+      useVariableJTA_(params.existsAs<bool>("useVariableJTA") ? params.getParameter<bool>("useVariableJTA") : false) {
+  std::string qualityClass = params.getParameter<std::string>("qualityClass");
+  if (qualityClass == "any" || qualityClass == "Any" || qualityClass == "ANY" || qualityClass.empty()) {
+    selectQuality = false;
+    quality = reco::TrackBase::undefQuality;
+  } else {
+    selectQuality = true;
+    quality = reco::TrackBase::qualityByName(qualityClass);
+  }
+  if (useVariableJTA_) {
+    varJTApars = {params.getParameter<double>("a_dR"),
+                  params.getParameter<double>("b_dR"),
+                  params.getParameter<double>("a_pT"),
+                  params.getParameter<double>("b_pT"),
+                  params.getParameter<double>("min_pT"),
+                  params.getParameter<double>("max_pT"),
+                  params.getParameter<double>("min_pT_dRcut"),
+                  params.getParameter<double>("max_pT_dRcut"),
+                  params.getParameter<double>("max_pT_trackPTcut")};
+  }
 }
 
-bool
-TrackSelector::operator () (const Track &track,
-                            const btag::TrackIPData &ipData,
-                            const Jet &jet,
-                            const GlobalPoint &pv) const
-{
-
- 
+bool TrackSelector::operator()(const Track &track,
+                               const btag::TrackIPData &ipData,
+                               const Jet &jet,
+                               const GlobalPoint &pv) const {
   bool jtaPassed = false;
   if (useVariableJTA_) {
-    jtaPassed = TrackIPTagInfo::passVariableJTA( varJTApars,
-					jet.pt(),track.pt(),
-					reco::deltaR(jet.momentum(),track.momentum()));
-  }
-  else  jtaPassed = true;
+    jtaPassed = TrackIPTagInfo::passVariableJTA(
+        varJTApars, jet.pt(), track.pt(), reco::deltaR(jet.momentum(), track.momentum()));
+  } else
+    jtaPassed = true;
 
-  return track.pt() >= minPt &&
-    reco::deltaR2(jet.momentum(),
-		       track.momentum()) < maxJetDeltaR*maxJetDeltaR &&
-    jtaPassed &&
-    trackSelection(track, ipData, jet, pv);
+  return track.pt() >= minPt && reco::deltaR2(jet.momentum(), track.momentum()) < maxJetDeltaR * maxJetDeltaR &&
+         jtaPassed && trackSelection(track, ipData, jet, pv);
 }
 
-bool
-TrackSelector::operator () (const CandidatePtr &track,
-                            const btag::TrackIPData &ipData,
-                            const Jet &jet,
-                            const GlobalPoint &pv) const
-{
-
- 
+bool TrackSelector::operator()(const CandidatePtr &track,
+                               const btag::TrackIPData &ipData,
+                               const Jet &jet,
+                               const GlobalPoint &pv) const {
   bool jtaPassed = false;
   if (useVariableJTA_) {
-    jtaPassed = TrackIPTagInfo::passVariableJTA( varJTApars,
-					jet.pt(),track->pt(),
-					reco::deltaR(jet.momentum(),track->momentum()));
-  }
-  else  jtaPassed = true;
+    jtaPassed = TrackIPTagInfo::passVariableJTA(
+        varJTApars, jet.pt(), track->pt(), reco::deltaR(jet.momentum(), track->momentum()));
+  } else
+    jtaPassed = true;
 
-  return track->pt() >= minPt &&
-    reco::deltaR2(jet.momentum(),
-		       track->momentum()) < maxJetDeltaR*maxJetDeltaR &&
-    jtaPassed &&
-    trackSelection(*reco::btag::toTrack(track), ipData, jet, pv);
+  return track->pt() >= minPt && reco::deltaR2(jet.momentum(), track->momentum()) < maxJetDeltaR * maxJetDeltaR &&
+         jtaPassed && trackSelection(*reco::btag::toTrack(track), ipData, jet, pv);
 }
 
-bool
-TrackSelector::trackSelection(const Track &track,
-                              const btag::TrackIPData &ipData,
-                              const Jet &jet,
-                              const GlobalPoint &pv) const
-{
-
+bool TrackSelector::trackSelection(const Track &track,
+                                   const btag::TrackIPData &ipData,
+                                   const Jet &jet,
+                                   const GlobalPoint &pv) const {
   return (!selectQuality || track.quality(quality)) &&
-    (minPixelHits <= 0 ||
-     track.hitPattern().numberOfValidPixelHits() >= (int)minPixelHits) &&
-    (minTotalHits <= 0 ||
-     track.hitPattern().numberOfValidHits() >= (int)minTotalHits) &&
-    track.normalizedChi2() < maxNormChi2 &&
-    std::abs(ipData.distanceToJetAxis.value()) <= maxDistToAxis &&
-    (ipData.closestToJetAxis - pv).mag() <= maxDecayLen &&
-    ipData.ip2d.value()        >= sip2dValMin &&
-    ipData.ip2d.value()        <= sip2dValMax &&
-    ipData.ip2d.significance() >= sip2dSigMin &&
-    ipData.ip2d.significance() <= sip2dSigMax &&
-    ipData.ip3d.value()        >= sip3dValMin &&
-    ipData.ip3d.value()        <= sip3dValMax &&
-    ipData.ip3d.significance() >= sip3dSigMin &&
-    ipData.ip3d.significance() <= sip3dSigMax;
+         (minPixelHits <= 0 || track.hitPattern().numberOfValidPixelHits() >= (int)minPixelHits) &&
+         (minTotalHits <= 0 || track.hitPattern().numberOfValidHits() >= (int)minTotalHits) &&
+         track.normalizedChi2() < maxNormChi2 && std::abs(ipData.distanceToJetAxis.value()) <= maxDistToAxis &&
+         (ipData.closestToJetAxis - pv).mag() <= maxDecayLen && ipData.ip2d.value() >= sip2dValMin &&
+         ipData.ip2d.value() <= sip2dValMax && ipData.ip2d.significance() >= sip2dSigMin &&
+         ipData.ip2d.significance() <= sip2dSigMax && ipData.ip3d.value() >= sip3dValMin &&
+         ipData.ip3d.value() <= sip3dValMax && ipData.ip3d.significance() >= sip3dSigMin &&
+         ipData.ip3d.significance() <= sip3dSigMax;
 }

--- a/RecoBTag/SecondaryVertex/src/TrackSorting.cc
+++ b/RecoBTag/SecondaryVertex/src/TrackSorting.cc
@@ -8,21 +8,19 @@
 
 using namespace reco;
 
-reco::btag::SortCriteria TrackSorting::getCriterium(const std::string &name)
-{
-	using namespace reco::btag;
-	if (name == "sip3dSig")
-		return IP3DSig;
-	if (name == "prob3d")
-		return Prob3D;
-	if (name == "sip2dSig")
-		return IP2DSig;
-	if (name == "prob2d")
-		return Prob2D;
-	if (name == "sip2dVal")
-		return IP2DValue;
+reco::btag::SortCriteria TrackSorting::getCriterium(const std::string &name) {
+  using namespace reco::btag;
+  if (name == "sip3dSig")
+    return IP3DSig;
+  if (name == "prob3d")
+    return Prob3D;
+  if (name == "sip2dSig")
+    return IP2DSig;
+  if (name == "prob2d")
+    return Prob2D;
+  if (name == "sip2dVal")
+    return IP2DValue;
 
-	throw cms::Exception("InvalidArgument")
-		<< "Identifier \"" << name << "\" does not represent a valid "
-		<< "track sorting criterium." << std::endl;
+  throw cms::Exception("InvalidArgument") << "Identifier \"" << name << "\" does not represent a valid "
+                                          << "track sorting criterium." << std::endl;
 }

--- a/RecoBTag/SecondaryVertex/src/V0Filter.cc
+++ b/RecoBTag/SecondaryVertex/src/V0Filter.cc
@@ -5,84 +5,69 @@
 #include "DataFormats/Math/interface/LorentzVector.h"
 #include "RecoBTag/SecondaryVertex/interface/V0Filter.h"
 
-using namespace reco; 
+using namespace reco;
 
-V0Filter::V0Filter(const edm::ParameterSet &params) :
-	k0sMassWindow(params.getParameter<double>("k0sMassWindow"))
-{
+V0Filter::V0Filter(const edm::ParameterSet &params) : k0sMassWindow(params.getParameter<double>("k0sMassWindow")) {}
+
+bool V0Filter::operator()(const reco::Track *const *tracks, unsigned int n) const {
+  // only check for K0s for now
+
+  if (n != 2)
+    return true;
+
+  if (tracks[0]->charge() * tracks[1]->charge() > 0)
+    return true;
+
+  ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> > vec1;
+  ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> > vec2;
+
+  vec1.SetPx(tracks[0]->px());
+  vec1.SetPy(tracks[0]->py());
+  vec1.SetPz(tracks[0]->pz());
+  vec1.SetM(ParticleMasses::piPlus);
+
+  vec2.SetPx(tracks[1]->px());
+  vec2.SetPy(tracks[1]->py());
+  vec2.SetPz(tracks[1]->pz());
+  vec2.SetM(ParticleMasses::piPlus);
+
+  double invariantMass = (vec1 + vec2).M();
+  if (std::abs(invariantMass - ParticleMasses::k0) < k0sMassWindow)
+    return false;
+
+  return true;
 }
 
-bool
-V0Filter::operator () (const reco::Track *const *tracks, unsigned int n) const
-{
-	// only check for K0s for now
+bool V0Filter::operator()(const reco::TrackRef *tracks, unsigned int n) const {
+  std::vector<const reco::Track *> trackPtrs(n);
+  for (unsigned int i = 0; i < n; i++)
+    trackPtrs[i] = &*tracks[i];
 
-	if (n != 2)
-		return true;
-
-	if (tracks[0]->charge() * tracks[1]->charge() > 0)
-		return true;
-
-	ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> > vec1;
-	ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> > vec2;
-
-	vec1.SetPx(tracks[0]->px());
-	vec1.SetPy(tracks[0]->py());
-	vec1.SetPz(tracks[0]->pz());
-	vec1.SetM(ParticleMasses::piPlus);
-
-	vec2.SetPx(tracks[1]->px());
-	vec2.SetPy(tracks[1]->py());
-	vec2.SetPz(tracks[1]->pz());
-	vec2.SetM(ParticleMasses::piPlus);
-
-	double invariantMass = (vec1 + vec2).M();
-	if (std::abs(invariantMass - ParticleMasses::k0) < k0sMassWindow)
-		return false;
-
-	return true;
+  return (*this)(&trackPtrs[0], n);
 }
 
-bool
-V0Filter::operator () (const reco::TrackRef *tracks, unsigned int n) const
-{
-	std::vector<const reco::Track*> trackPtrs(n);
-	for(unsigned int i = 0; i < n; i++)
-		trackPtrs[i] = &*tracks[i];
+bool V0Filter::operator()(const std::vector<reco::CandidatePtr> &tracks) const {
+  if (tracks.size() != 2)
+    return true;
 
-	return (*this)(&trackPtrs[0], n);
+  if (tracks[0]->charge() * tracks[1]->charge() > 0)
+    return true;
+
+  double invariantMass = (tracks[0]->p4() + tracks[1]->p4()).M();
+  if (std::abs(invariantMass - ParticleMasses::k0) < k0sMassWindow)
+    return false;
+
+  return true;
 }
 
-bool
-V0Filter::operator () (const std::vector<reco::CandidatePtr> & tracks) const
-{
-	if (tracks.size() != 2)
-		return true;
-
-	if (tracks[0]->charge() * tracks[1]->charge() > 0)
-		return true;
-	
-	double invariantMass = (tracks[0]->p4()+tracks[1]->p4()).M();
-	if (std::abs(invariantMass - ParticleMasses::k0) < k0sMassWindow)
-		return false;
-
-	return true;
+bool V0Filter::operator()(const std::vector<const reco::Track *> &tracks) const {
+  return (*this)(&tracks[0], tracks.size());
 }
 
-bool
-V0Filter::operator () (const std::vector<const reco::Track *> & tracks) const
-{
-	return (*this)(&tracks[0], tracks.size());
+bool V0Filter::operator()(const reco::Track *tracks, unsigned int n) const {
+  std::vector<const reco::Track *> trackPtrs(n);
+  for (unsigned int i = 0; i < n; i++)
+    trackPtrs[i] = &tracks[i];
+
+  return (*this)(&trackPtrs[0], n);
 }
-
-
-bool
-V0Filter::operator () (const reco::Track *tracks, unsigned int n) const
-{
-	std::vector<const reco::Track*> trackPtrs(n);
-	for(unsigned int i = 0; i < n; i++)
-		trackPtrs[i] = &tracks[i];
-
-	return (*this)(&trackPtrs[0], n);
-}
-

--- a/RecoLocalCalo/CaloTowersCreator/interface/CaloTowersCreationAlgo.h
+++ b/RecoLocalCalo/CaloTowersCreator/interface/CaloTowersCreationAlgo.h
@@ -25,7 +25,6 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include <tuple>
 
-
 #include <map>
 class CaloTowerTopology;
 class HcalTopology;
@@ -48,70 +47,116 @@ class DetId;
 
 class CaloTowersCreationAlgo {
 public:
-
-  int nalgo=-1;
+  int nalgo = -1;
 
   CaloTowersCreationAlgo();
 
-  CaloTowersCreationAlgo(double EBthreshold, double EEthreshold, 
+  CaloTowersCreationAlgo(double EBthreshold,
+                         double EEthreshold,
 
-    bool useEtEBTreshold, bool useEtEETreshold,
-    bool useSymEBTreshold, bool useSymEETreshold,				    
+                         bool useEtEBTreshold,
+                         bool useEtEETreshold,
+                         bool useSymEBTreshold,
+                         bool useSymEETreshold,
 
-    double HcalThreshold,
-    double HBthreshold, double HBthreshold1, double HBthreshold2,
-    double HESthreshold, double HESthreshold1,
-    double HEDthreshold, double HEDthreshold1, 
-    double HOthreshold0, double HOthresholdPlus1, double HOthresholdMinus1,  
-    double HOthresholdPlus2, double HOthresholdMinus2,
-    double HF1threshold, double HF2threshold, 
-    double EBweight, double EEweight,
-    double HBweight, double HESweight, double HEDweight, 
-    double HOweight, double HF1weight, double HF2weight,
-    double EcutTower, double EBSumThreshold, double EESumThreshold, bool useHO,
-    // (for momentum reconstruction algorithm)
-    int momConstrMethod,
-    double momHBDepth,
-    double momHEDepth,
-    double momEBDepth,
-    double momEEDepth,
-	int hcalPhase=0
-    );
-  
-  CaloTowersCreationAlgo(double EBthreshold, double EEthreshold, 
+                         double HcalThreshold,
+                         double HBthreshold,
+                         double HBthreshold1,
+                         double HBthreshold2,
+                         double HESthreshold,
+                         double HESthreshold1,
+                         double HEDthreshold,
+                         double HEDthreshold1,
+                         double HOthreshold0,
+                         double HOthresholdPlus1,
+                         double HOthresholdMinus1,
+                         double HOthresholdPlus2,
+                         double HOthresholdMinus2,
+                         double HF1threshold,
+                         double HF2threshold,
+                         double EBweight,
+                         double EEweight,
+                         double HBweight,
+                         double HESweight,
+                         double HEDweight,
+                         double HOweight,
+                         double HF1weight,
+                         double HF2weight,
+                         double EcutTower,
+                         double EBSumThreshold,
+                         double EESumThreshold,
+                         bool useHO,
+                         // (for momentum reconstruction algorithm)
+                         int momConstrMethod,
+                         double momHBDepth,
+                         double momHEDepth,
+                         double momEBDepth,
+                         double momEEDepth,
+                         int hcalPhase = 0);
 
-    bool useEtEBTreshold, bool useEtEETreshold,
-    bool useSymEBTreshold, bool useSymEETreshold,
+  CaloTowersCreationAlgo(double EBthreshold,
+                         double EEthreshold,
 
-    double HcalThreshold,
-    double HBthreshold, double HBthreshold1, double HBthreshold2,
-    double HESthreshold, double HESthreshold1,
-    double HEDthreshold, double HEDthreshold1,
-    double HOthreshold0, double HOthresholdPlus1, double HOthresholdMinus1,  
-    double HOthresholdPlus2, double HOthresholdMinus2, 
-    double HF1threshold, double HF2threshold,
-    const std::vector<double> & EBGrid, const std::vector<double> & EBWeights,
-    const std::vector<double> & EEGrid, const std::vector<double> & EEWeights,
-    const std::vector<double> & HBGrid, const std::vector<double> & HBWeights,
-    const std::vector<double> & HESGrid, const std::vector<double> & HESWeights,
-    const std::vector<double> & HEDGrid, const std::vector<double> & HEDWeights,
-    const std::vector<double> & HOGrid, const std::vector<double> & HOWeights,
-    const std::vector<double> & HF1Grid, const std::vector<double> & HF1Weights,
-    const std::vector<double> & HF2Grid, const std::vector<double> & HF2Weights,
-    double EBweight, double EEweight,
-    double HBweight, double HESweight, double HEDweight, 
-    double HOweight, double HF1weight, double HF2weight,
-    double EcutTower, double EBSumThreshold, double EESumThreshold, bool useHO,
-    // (for momentum reconstruction algorithm)
-    int momConstrMethod,
-    double momHBDepth,
-    double momHEDepth,
-    double momEBDepth,
-    double momEEDepth,
-	int hcalPhase=0
-);
-  
-  void setGeometry(const CaloTowerTopology* cttopo, const CaloTowerConstituentsMap* ctmap, const HcalTopology* htopo, const CaloGeometry* geo);
+                         bool useEtEBTreshold,
+                         bool useEtEETreshold,
+                         bool useSymEBTreshold,
+                         bool useSymEETreshold,
+
+                         double HcalThreshold,
+                         double HBthreshold,
+                         double HBthreshold1,
+                         double HBthreshold2,
+                         double HESthreshold,
+                         double HESthreshold1,
+                         double HEDthreshold,
+                         double HEDthreshold1,
+                         double HOthreshold0,
+                         double HOthresholdPlus1,
+                         double HOthresholdMinus1,
+                         double HOthresholdPlus2,
+                         double HOthresholdMinus2,
+                         double HF1threshold,
+                         double HF2threshold,
+                         const std::vector<double>& EBGrid,
+                         const std::vector<double>& EBWeights,
+                         const std::vector<double>& EEGrid,
+                         const std::vector<double>& EEWeights,
+                         const std::vector<double>& HBGrid,
+                         const std::vector<double>& HBWeights,
+                         const std::vector<double>& HESGrid,
+                         const std::vector<double>& HESWeights,
+                         const std::vector<double>& HEDGrid,
+                         const std::vector<double>& HEDWeights,
+                         const std::vector<double>& HOGrid,
+                         const std::vector<double>& HOWeights,
+                         const std::vector<double>& HF1Grid,
+                         const std::vector<double>& HF1Weights,
+                         const std::vector<double>& HF2Grid,
+                         const std::vector<double>& HF2Weights,
+                         double EBweight,
+                         double EEweight,
+                         double HBweight,
+                         double HESweight,
+                         double HEDweight,
+                         double HOweight,
+                         double HF1weight,
+                         double HF2weight,
+                         double EcutTower,
+                         double EBSumThreshold,
+                         double EESumThreshold,
+                         bool useHO,
+                         // (for momentum reconstruction algorithm)
+                         int momConstrMethod,
+                         double momHBDepth,
+                         double momHEDepth,
+                         double momEBDepth,
+                         double momEEDepth,
+                         int hcalPhase = 0);
+
+  void setGeometry(const CaloTowerTopology* cttopo,
+                   const CaloTowerConstituentsMap* ctmap,
+                   const HcalTopology* htopo,
+                   const CaloGeometry* geo);
 
   // pass the containers of channels status from the event record (stored in DB)
   // these are called in  CaloTowersCreator
@@ -127,10 +172,9 @@ public:
   void begin();
   void process(const HBHERecHitCollection& hbhe);
   void process(const HORecHitCollection& ho);
-  void process(const HFRecHitCollection& hf); 
-  void process(const EcalRecHitCollection& ecal); 
-  
-  
+  void process(const HFRecHitCollection& hf);
+  void process(const EcalRecHitCollection& ecal);
+
   void process(const CaloTowerCollection& ctc);
 
   void finish(CaloTowerCollection& destCollection);
@@ -147,117 +191,110 @@ public:
   void setHF1EScale(double scale);
   void setHF2EScale(double scale);
 
-
   // Assign to categories based on info from DB and RecHit status
   // Called in assignHit to check if the energy should be added to
   // calotower, and how to flag the channel
   unsigned int hcalChanStatusForCaloTower(const CaloRecHit* hit);
-  std::tuple<unsigned int,bool> ecalChanStatusForCaloTower(const EcalRecHit* hit);
+  std::tuple<unsigned int, bool> ecalChanStatusForCaloTower(const EcalRecHit* hit);
 
   // Channel flagging is based on acceptable severity levels specified in the
   // configuration file. These methods are used to pass the values read in
   // CaloTowersCreator
-  // 
+  //
   // from DB
-  void setHcalAcceptSeverityLevel(unsigned int level) {theHcalAcceptSeverityLevel = level;} 
-  void setEcalSeveritiesToBeExcluded(const std::vector<int>& ecalSev ) {theEcalSeveritiesToBeExcluded= ecalSev;} 
+  void setHcalAcceptSeverityLevel(unsigned int level) { theHcalAcceptSeverityLevel = level; }
+  void setEcalSeveritiesToBeExcluded(const std::vector<int>& ecalSev) { theEcalSeveritiesToBeExcluded = ecalSev; }
 
   // flag to use recovered hits
-  void setRecoveredHcalHitsAreUsed(bool flag) {theRecoveredHcalHitsAreUsed = flag; };
-  void setRecoveredEcalHitsAreUsed(bool flag) {theRecoveredEcalHitsAreUsed = flag; };
+  void setRecoveredHcalHitsAreUsed(bool flag) { theRecoveredHcalHitsAreUsed = flag; };
+  void setRecoveredEcalHitsAreUsed(bool flag) { theRecoveredEcalHitsAreUsed = flag; };
 
   //  severety level calculator for HCAL
-  void setHcalSevLvlComputer(const HcalSeverityLevelComputer* c) {theHcalSevLvlComputer = c; };
+  void setHcalSevLvlComputer(const HcalSeverityLevelComputer* c) { theHcalSevLvlComputer = c; };
 
   // severity level calculator for ECAL
-  void setEcalSevLvlAlgo(const EcalSeverityLevelAlgo* a) { theEcalSevLvlAlgo =  a; }
-
+  void setEcalSevLvlAlgo(const EcalSeverityLevelAlgo* a) { theEcalSevLvlAlgo = a; }
 
   // The following are needed for creating towers from rechits excluded from the  ------------------------------------
   // default reconstructions
 
- // NB! Controls if rejected hits shold be used instead of the default!!!
-  void setUseRejectedHitsOnly(bool flag) { useRejectedHitsOnly = flag; } 
+  // NB! Controls if rejected hits shold be used instead of the default!!!
+  void setUseRejectedHitsOnly(bool flag) { useRejectedHitsOnly = flag; }
 
-  void setHcalAcceptSeverityLevelForRejectedHit(unsigned int level) {theHcalAcceptSeverityLevelForRejectedHit = level;} 
-  //  void setEcalAcceptSeverityLevelForRejectedHit(unsigned int level) {theEcalAcceptSeverityLevelForRejectedHit = level;} 
-  void SetEcalSeveritiesToBeUsedInBadTowers(const std::vector<int>& ecalSev ) {theEcalSeveritiesToBeUsedInBadTowers= ecalSev;} 
+  void setHcalAcceptSeverityLevelForRejectedHit(unsigned int level) {
+    theHcalAcceptSeverityLevelForRejectedHit = level;
+  }
+  //  void setEcalAcceptSeverityLevelForRejectedHit(unsigned int level) {theEcalAcceptSeverityLevelForRejectedHit = level;}
+  void SetEcalSeveritiesToBeUsedInBadTowers(const std::vector<int>& ecalSev) {
+    theEcalSeveritiesToBeUsedInBadTowers = ecalSev;
+  }
 
-
-  void setUseRejectedRecoveredHcalHits(bool flag) {useRejectedRecoveredHcalHits = flag; };
-  void setUseRejectedRecoveredEcalHits(bool flag) {useRejectedRecoveredEcalHits = flag; };
-  void setMissingHcalRescaleFactorForEcal(float factor) {missingHcalRescaleFactorForEcal = factor; };
+  void setUseRejectedRecoveredHcalHits(bool flag) { useRejectedRecoveredHcalHits = flag; };
+  void setUseRejectedRecoveredEcalHits(bool flag) { useRejectedRecoveredEcalHits = flag; };
+  void setMissingHcalRescaleFactorForEcal(float factor) { missingHcalRescaleFactorForEcal = factor; };
 
   //-------------------------------------------------------------------------------------------------------------------
 
-
-
   // set the EE EB handles
-  
+
   void setEbHandle(const edm::Handle<EcalRecHitCollection> eb) { theEbHandle = eb; }
   void setEeHandle(const edm::Handle<EcalRecHitCollection> ee) { theEeHandle = ee; }
 
-
-
-
-  // Add methods to get the seperate positions for ECAL/HCAL 
+  // Add methods to get the seperate positions for ECAL/HCAL
   // used in constructing the 4-vectors using new methods
-  GlobalPoint emCrystalShwrPos (DetId detId, float fracDepth); 
+  GlobalPoint emCrystalShwrPos(DetId detId, float fracDepth);
   GlobalPoint hadSegmentShwrPos(DetId detId, float fracDepth);
   // "effective" point for the EM/HAD shower in CaloTower
   //  position based on non-zero energy cells
-  GlobalPoint hadShwrPos(const std::vector<std::pair<DetId,float> >& metaContains,
-    float fracDepth, double hadE);
-  GlobalPoint emShwrPos(const std::vector<std::pair<DetId,float> >& metaContains, 
-    float fracDepth, double totEmE);
+  GlobalPoint hadShwrPos(const std::vector<std::pair<DetId, float>>& metaContains, float fracDepth, double hadE);
+  GlobalPoint emShwrPos(const std::vector<std::pair<DetId, float>>& metaContains, float fracDepth, double totEmE);
 
   // overloaded function to get had position based on all had cells in the tower
   GlobalPoint hadShwrPos(CaloTowerDetId id, float fracDepth);
   GlobalPoint hadShwPosFromCells(DetId frontCell, DetId backCell, float fracDepth);
 
   // for Chris
-  GlobalPoint emShwrLogWeightPos(const std::vector<std::pair<DetId,float> >& metaContains, 
-    float fracDepth, double totEmE);
-
+  GlobalPoint emShwrLogWeightPos(const std::vector<std::pair<DetId, float>>& metaContains,
+                                 float fracDepth,
+                                 double totEmE);
 
 private:
-
   struct MetaTower {
-    MetaTower(){}
-    bool empty() const { return metaConstituents.empty();}
+    MetaTower() {}
+    bool empty() const { return metaConstituents.empty(); }
     // contains also energy of RecHit
-    std::vector< std::pair<DetId, float> > metaConstituents;
+    std::vector<std::pair<DetId, float>> metaConstituents;
     CaloTowerDetId id;
-    float E=0, E_em=0, E_had=0, E_outer=0;
-    float emSumTimeTimesE=0, hadSumTimeTimesE=0, emSumEForTime=0, hadSumEForTime=0; // Sum(Energy x Timing) : intermediate container
+    float E = 0, E_em = 0, E_had = 0, E_outer = 0;
+    float emSumTimeTimesE = 0, hadSumTimeTimesE = 0, emSumEForTime = 0,
+          hadSumEForTime = 0;  // Sum(Energy x Timing) : intermediate container
 
     // needed to set CaloTower status word
-    int numBadEcalCells=0, numRecEcalCells=0, numProbEcalCells=0, numBadHcalCells=0, numRecHcalCells=0, numProbHcalCells=0; 
-
- };
+    int numBadEcalCells = 0, numRecEcalCells = 0, numProbEcalCells = 0, numBadHcalCells = 0, numRecHcalCells = 0,
+        numProbHcalCells = 0;
+  };
 
   /// adds a single hit to the tower
   void assignHitEcal(const EcalRecHit* recHit);
   void assignHitHcal(const CaloRecHit* recHit);
 
-  void rescale(const CaloTower * ct);
+  void rescale(const CaloTower* ct);
 
   /// looks for a given tower in the internal cache.  If it can't find it, it makes it.
-  MetaTower & find(const CaloTowerDetId & id);
-  
+  MetaTower& find(const CaloTowerDetId& id);
+
   /// helper method to look up the appropriate threshold & weight
-  void getThresholdAndWeight(const DetId & detId, double & threshold, double & weight) const;
+  void getThresholdAndWeight(const DetId& detId, double& threshold, double& weight) const;
 
   double theEBthreshold, theEEthreshold;
   bool theUseEtEBTresholdFlag, theUseEtEETresholdFlag;
-  bool theUseSymEBTresholdFlag,theUseSymEETresholdFlag;
-  
-  
-  double  theHcalThreshold;
+  bool theUseSymEBTresholdFlag, theUseSymEETresholdFlag;
+
+  double theHcalThreshold;
 
   double theHBthreshold, theHBthreshold1, theHBthreshold2;
-  double theHESthreshold, theHESthreshold1; 
-  double theHEDthreshold, theHEDthreshold1; 
+  double theHESthreshold, theHESthreshold1;
+  double theHEDthreshold, theHEDthreshold1;
   double theHOthreshold0, theHOthresholdPlus1, theHOthresholdMinus1;
   double theHOthresholdPlus2, theHOthresholdMinus2, theHF1threshold, theHF2threshold;
   std::vector<double> theEBGrid, theEBWeights;
@@ -286,7 +323,7 @@ private:
   const CaloTowerConstituentsMap* theTowerConstituentsMap;
   const CaloSubdetectorGeometry* theTowerGeometry;
 
-  // for checking the status of ECAL and HCAL channels stored in the DB 
+  // for checking the status of ECAL and HCAL channels stored in the DB
   const EcalChannelStatus* theEcalChStatus;
   const HcalChannelQuality* theHcalChStatus;
 
@@ -296,9 +333,8 @@ private:
   // calculator for severity level for ECAL
   const EcalSeverityLevelAlgo* theEcalSevLvlAlgo;
 
-  
   // fields that hold the information passed from the CaloTowersCreator configuration file:
-  // controll what is considered bad/recovered/problematic channel for CaloTower purposes 
+  // controll what is considered bad/recovered/problematic channel for CaloTower purposes
   //
   unsigned int theHcalAcceptSeverityLevel;
   std::vector<int> theEcalSeveritiesToBeExcluded;
@@ -312,7 +348,6 @@ private:
   unsigned int theHcalAcceptSeverityLevelForRejectedHit;
   std::vector<int> theEcalSeveritiesToBeUsedInBadTowers;
 
-
   unsigned int useRejectedRecoveredHcalHits;
   unsigned int useRejectedRecoveredEcalHits;
 
@@ -323,7 +358,7 @@ private:
   bool theHOIsUsed;
 
   // Switches and paramters for CaloTower 4-momentum assignment
-  // "depth" variables do not affect all algorithms 
+  // "depth" variables do not affect all algorithms
   int theMomConstrMethod;
   double theMomHBDepth;
   double theMomHEDepth;
@@ -333,17 +368,16 @@ private:
   // compactify timing info
   int compactTime(float time);
 
-  void convert(const CaloTowerDetId& id, const MetaTower& mt, CaloTowerCollection & collection);
-  
+  void convert(const CaloTowerDetId& id, const MetaTower& mt, CaloTowerCollection& collection);
 
   // internal map
   typedef std::vector<MetaTower> MetaTowerMap;
   MetaTowerMap theTowerMap;
-  unsigned int theTowerMapSize=0;
+  unsigned int theTowerMapSize = 0;
 
   // Number of channels in the tower that were not used in RecHit production (dead/off,...).
-  // These channels are added to the other "bad" channels found in the recHit collection. 
-  typedef std::map<CaloTowerDetId, std::pair<short int,bool>> HcalDropChMap;
+  // These channels are added to the other "bad" channels found in the recHit collection.
+  typedef std::map<CaloTowerDetId, std::pair<short int, bool>> HcalDropChMap;
   HcalDropChMap hcalDropChMap;
 
   // Number of bad Ecal channel in each tower
@@ -352,18 +386,17 @@ private:
 
   // clasification of channels in tower construction: the category definition is
   // affected by the setting in the configuration file
-  // 
-  enum ctHitCategory {GoodChan = 0, BadChan = 1, RecoveredChan = 2, ProblematicChan = 3, IgnoredChan = 99 };
-
+  //
+  enum ctHitCategory { GoodChan = 0, BadChan = 1, RecoveredChan = 2, ProblematicChan = 3, IgnoredChan = 99 };
 
   // the EE and EB collections for ecal anomalous cell info
-   
+
   edm::Handle<EcalRecHitCollection> theEbHandle;
   edm::Handle<EcalRecHitCollection> theEeHandle;
-  
+
   int theHcalPhase;
 
-  std::vector<HcalDetId>          ids_;
+  std::vector<HcalDetId> ids_;
 };
 
 #endif

--- a/RecoLocalCalo/CaloTowersCreator/interface/EScales.h
+++ b/RecoLocalCalo/CaloTowersCreator/interface/EScales.h
@@ -3,23 +3,22 @@
 
 #include <string>
 
-struct EScales{
-  double HBPiOvere=0;
-  double HESPiOvere=0;
-  double HEDPiOvere=0;
-  double HOPiOvere=0;
-  double HF1PiOvere=0;
-  double HF2PiOvere=0;
-  double EBScale=0;
-  double EEScale=0;
-  double HBScale=0;
-  double HESScale=0;
-  double HEDScale=0;
-  double HOScale=0;
-  double HF1Scale=0;
-  double HF2Scale=0;
+struct EScales {
+  double HBPiOvere = 0;
+  double HESPiOvere = 0;
+  double HEDPiOvere = 0;
+  double HOPiOvere = 0;
+  double HF1PiOvere = 0;
+  double HF2PiOvere = 0;
+  double EBScale = 0;
+  double EEScale = 0;
+  double HBScale = 0;
+  double HESScale = 0;
+  double HEDScale = 0;
+  double HOScale = 0;
+  double HF1Scale = 0;
+  double HF2Scale = 0;
   std::string instanceLabel;
 };
 
 #endif
-

--- a/RecoLocalCalo/CaloTowersCreator/interface/HcalMaterials.h
+++ b/RecoLocalCalo/CaloTowersCreator/interface/HcalMaterials.h
@@ -3,39 +3,42 @@
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include <boost/cstdint.hpp>
-#include  <vector>
+#include <vector>
 // place to implement a real working class for material corrections
 
 class HcalMaterial {
- public:
-  float getValue ( float Energy){return 1.;}
-//  void putValue (unsigned long fId, std::pair<std::vector <float>, std::vector <float> > fArray);
+public:
+  float getValue(float Energy) { return 1.; }
+  //  void putValue (unsigned long fId, std::pair<std::vector <float>, std::vector <float> > fArray);
 
-  HcalMaterial (unsigned long fId, const std::pair < std::vector <float>, std::vector <float> >& fCorrs) //:
-//   mId (fId),
-//   mCorrs (fCorrs)
-{ mId=fId;mCorrs=fCorrs;}
+  HcalMaterial(unsigned long fId, const std::pair<std::vector<float>, std::vector<float> >& fCorrs)  //:
+  //   mId (fId),
+  //   mCorrs (fCorrs)
+  {
+    mId = fId;
+    mCorrs = fCorrs;
+  }
 
-  unsigned long mmId(void){return mId;}
+  unsigned long mmId(void) { return mId; }
 
- private:
- unsigned long mId;
- std::pair<std::vector <float>, std::vector <float> > mCorrs;
+private:
+  unsigned long mId;
+  std::pair<std::vector<float>, std::vector<float> > mCorrs;
 };
 
 class HcalMaterials {
- public:
-  HcalMaterials ();
+public:
+  HcalMaterials();
   ~HcalMaterials();
 
-  float getValue (DetId fId, float energy);
-  void putValue (DetId fId, const std::pair<std::vector <float>, std::vector <float> >& fArray);
+  float getValue(DetId fId, float energy);
+  void putValue(DetId fId, const std::pair<std::vector<float>, std::vector<float> >& fArray);
 
   typedef HcalMaterial Item;
-  typedef std::vector <Item> Container;
- private:
-  Container mItems;
+  typedef std::vector<Item> Container;
 
+private:
+  Container mItems;
 };
 
 #endif

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowerCandidateCreator.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowerCandidateCreator.cc
@@ -11,47 +11,44 @@ using namespace edm;
 using namespace reco;
 using namespace std;
 
-CaloTowerCandidateCreator::CaloTowerCandidateCreator( const ParameterSet & p ) 
-  :
-  mVerbose (p.getUntrackedParameter<int> ("verbose", 0)),
-  mEtThreshold (p.getParameter<double> ("minimumEt")),
-  mEThreshold (p.getParameter<double> ("minimumE"))
-{
-  tok_src_ = consumes<CaloTowerCollection> (p.getParameter<edm::InputTag> ("src"));
+CaloTowerCandidateCreator::CaloTowerCandidateCreator(const ParameterSet& p)
+    : mVerbose(p.getUntrackedParameter<int>("verbose", 0)),
+      mEtThreshold(p.getParameter<double>("minimumEt")),
+      mEThreshold(p.getParameter<double>("minimumE")) {
+  tok_src_ = consumes<CaloTowerCollection>(p.getParameter<edm::InputTag>("src"));
 
   produces<CandidateCollection>();
 }
 
-CaloTowerCandidateCreator::~CaloTowerCandidateCreator() {
-}
+CaloTowerCandidateCreator::~CaloTowerCandidateCreator() {}
 
-void CaloTowerCandidateCreator::produce( Event& evt, const EventSetup& ) {
+void CaloTowerCandidateCreator::produce(Event& evt, const EventSetup&) {
   Handle<CaloTowerCollection> caloTowers;
-  evt.getByToken( tok_src_, caloTowers );
-  
+  evt.getByToken(tok_src_, caloTowers);
+
   auto cands = std::make_unique<CandidateCollection>();
-  cands->reserve( caloTowers->size() );
+  cands->reserve(caloTowers->size());
   unsigned idx = 0;
-  for (; idx < caloTowers->size (); idx++) {
-    const CaloTower* cal = &((*caloTowers) [idx]);
+  for (; idx < caloTowers->size(); idx++) {
+    const CaloTower* cal = &((*caloTowers)[idx]);
     if (mVerbose >= 2) {
-      std::cout << "CaloTowerCandidateCreator::produce-> " << idx << " tower et/eta/phi/e: " 
-		<< cal->et() << '/' << cal->eta() << '/' << cal->phi() << '/' << cal->energy() << " is...";
+      std::cout << "CaloTowerCandidateCreator::produce-> " << idx << " tower et/eta/phi/e: " << cal->et() << '/'
+                << cal->eta() << '/' << cal->phi() << '/' << cal->energy() << " is...";
     }
-    if (cal->et() >= mEtThreshold && cal->energy() >= mEThreshold ) {
-      math::PtEtaPhiMLorentzVector p( cal->et(), cal->eta(), cal->phi(), 0 );
-      RecoCaloTowerCandidate * c = 
-	new RecoCaloTowerCandidate( 0, Candidate::LorentzVector( p ) );
-      c->setCaloTower (CaloTowerRef( caloTowers, idx) );
-      cands->push_back( c );
-      if (mVerbose >= 2) std::cout << "accepted: pT/eta/phi:" << c->pt() << '/' << c->eta() <<  '/' << c->phi() <<std::endl;
-    }
-    else {
-      if (mVerbose >= 2) std::cout << "rejected" << std::endl;
+    if (cal->et() >= mEtThreshold && cal->energy() >= mEThreshold) {
+      math::PtEtaPhiMLorentzVector p(cal->et(), cal->eta(), cal->phi(), 0);
+      RecoCaloTowerCandidate* c = new RecoCaloTowerCandidate(0, Candidate::LorentzVector(p));
+      c->setCaloTower(CaloTowerRef(caloTowers, idx));
+      cands->push_back(c);
+      if (mVerbose >= 2)
+        std::cout << "accepted: pT/eta/phi:" << c->pt() << '/' << c->eta() << '/' << c->phi() << std::endl;
+    } else {
+      if (mVerbose >= 2)
+        std::cout << "rejected" << std::endl;
     }
   }
   if (mVerbose >= 1) {
-    std::cout << "CaloTowerCandidateCreator::produce-> " << cands->size () << " candidates created" << std::endl;
+    std::cout << "CaloTowerCandidateCreator::produce-> " << cands->size() << " candidates created" << std::endl;
   }
   evt.put(std::move(cands));
 }

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowerCandidateCreator.h
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowerCandidateCreator.h
@@ -17,17 +17,16 @@
 #include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
 #include <string>
 
-
 class CaloTowerCandidateCreator : public edm::stream::EDProducer<> {
- public:
+public:
   /// constructor from parameter set
-  CaloTowerCandidateCreator( const edm::ParameterSet & );
+  CaloTowerCandidateCreator(const edm::ParameterSet&);
   /// destructor
   ~CaloTowerCandidateCreator() override;
 
- private:
+private:
   /// process one event
-  void produce( edm::Event& e, const edm::EventSetup& ) override;
+  void produce(edm::Event& e, const edm::EventSetup&) override;
   /// verbosity
   int mVerbose;
   /// token of source collection

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreationAlgo.cc
@@ -12,365 +12,394 @@
 //#define EDM_ML_DEBUG
 
 CaloTowersCreationAlgo::CaloTowersCreationAlgo()
- : theEBthreshold(-1000.),
-   theEEthreshold(-1000.),
+    : theEBthreshold(-1000.),
+      theEEthreshold(-1000.),
 
-   theUseEtEBTresholdFlag(false),
-   theUseEtEETresholdFlag(false),
-   theUseSymEBTresholdFlag(false),
-   theUseSymEETresholdFlag(false),
+      theUseEtEBTresholdFlag(false),
+      theUseEtEETresholdFlag(false),
+      theUseSymEBTresholdFlag(false),
+      theUseSymEETresholdFlag(false),
 
+      theHcalThreshold(-1000.),
+      theHBthreshold(-1000.),
+      theHBthreshold1(-1000.),
+      theHBthreshold2(-1000.),
+      theHESthreshold(-1000.),
+      theHESthreshold1(-1000.),
+      theHEDthreshold(-1000.),
+      theHEDthreshold1(-1000.),
+      theHOthreshold0(-1000.),
+      theHOthresholdPlus1(-1000.),
+      theHOthresholdMinus1(-1000.),
+      theHOthresholdPlus2(-1000.),
+      theHOthresholdMinus2(-1000.),
+      theHF1threshold(-1000.),
+      theHF2threshold(-1000.),
+      theEBGrid(std::vector<double>(5, 10.)),
+      theEBWeights(std::vector<double>(5, 1.)),
+      theEEGrid(std::vector<double>(5, 10.)),
+      theEEWeights(std::vector<double>(5, 1.)),
+      theHBGrid(std::vector<double>(5, 10.)),
+      theHBWeights(std::vector<double>(5, 1.)),
+      theHESGrid(std::vector<double>(5, 10.)),
+      theHESWeights(std::vector<double>(5, 1.)),
+      theHEDGrid(std::vector<double>(5, 10.)),
+      theHEDWeights(std::vector<double>(5, 1.)),
+      theHOGrid(std::vector<double>(5, 10.)),
+      theHOWeights(std::vector<double>(5, 1.)),
+      theHF1Grid(std::vector<double>(5, 10.)),
+      theHF1Weights(std::vector<double>(5, 1.)),
+      theHF2Grid(std::vector<double>(5, 10.)),
+      theHF2Weights(std::vector<double>(5, 1.)),
+      theEBweight(1.),
+      theEEweight(1.),
+      theHBweight(1.),
+      theHESweight(1.),
+      theHEDweight(1.),
+      theHOweight(1.),
+      theHF1weight(1.),
+      theHF2weight(1.),
+      theEcutTower(-1000.),
+      theEBSumThreshold(-1000.),
+      theEESumThreshold(-1000.),
+      theEBEScale(50.),
+      theEEEScale(50.),
+      theHBEScale(50.),
+      theHESEScale(50.),
+      theHEDEScale(50.),
+      theHOEScale(50.),
+      theHF1EScale(50.),
+      theHF2EScale(50.),
+      theHcalTopology(nullptr),
+      theGeometry(nullptr),
+      theTowerConstituentsMap(nullptr),
+      theHcalAcceptSeverityLevel(0),
+      theRecoveredHcalHitsAreUsed(false),
+      theRecoveredEcalHitsAreUsed(false),
+      useRejectedHitsOnly(false),
+      theHcalAcceptSeverityLevelForRejectedHit(0),
+      useRejectedRecoveredHcalHits(0),
+      useRejectedRecoveredEcalHits(0),
+      missingHcalRescaleFactorForEcal(0.),
+      theHOIsUsed(true),
+      // (for momentum reconstruction algorithm)
+      theMomConstrMethod(0),
+      theMomHBDepth(0.),
+      theMomHEDepth(0.),
+      theMomEBDepth(0.),
+      theMomEEDepth(0.),
+      theHcalPhase(0) {}
 
-   theHcalThreshold(-1000.),
-   theHBthreshold(-1000.),
-   theHBthreshold1(-1000.),
-   theHBthreshold2(-1000.),
-   theHESthreshold(-1000.),
-   theHESthreshold1(-1000.),
-   theHEDthreshold(-1000.),
-   theHEDthreshold1(-1000.),
-   theHOthreshold0(-1000.),  
-   theHOthresholdPlus1(-1000.),   
-   theHOthresholdMinus1(-1000.),  
-   theHOthresholdPlus2(-1000.),
-   theHOthresholdMinus2(-1000.),   
-   theHF1threshold(-1000.),
-   theHF2threshold(-1000.),
-   theEBGrid(std::vector<double>(5,10.)),
-   theEBWeights(std::vector<double>(5,1.)),
-   theEEGrid(std::vector<double>(5,10.)),
-   theEEWeights(std::vector<double>(5,1.)),
-   theHBGrid(std::vector<double>(5,10.)),
-   theHBWeights(std::vector<double>(5,1.)),
-   theHESGrid(std::vector<double>(5,10.)),
-   theHESWeights(std::vector<double>(5,1.)),
-   theHEDGrid(std::vector<double>(5,10.)),
-   theHEDWeights(std::vector<double>(5,1.)),
-   theHOGrid(std::vector<double>(5,10.)),
-   theHOWeights(std::vector<double>(5,1.)),
-   theHF1Grid(std::vector<double>(5,10.)),
-   theHF1Weights(std::vector<double>(5,1.)),
-   theHF2Grid(std::vector<double>(5,10.)),
-   theHF2Weights(std::vector<double>(5,1.)),
-   theEBweight(1.),
-   theEEweight(1.),
-   theHBweight(1.),
-   theHESweight(1.),
-   theHEDweight(1.),
-   theHOweight(1.),
-   theHF1weight(1.),
-   theHF2weight(1.),
-   theEcutTower(-1000.),
-   theEBSumThreshold(-1000.),
-   theEESumThreshold(-1000.),
-   theEBEScale(50.),
-   theEEEScale(50.),
-   theHBEScale(50.),
-   theHESEScale(50.),
-   theHEDEScale(50.),
-   theHOEScale(50.),
-   theHF1EScale(50.),
-   theHF2EScale(50.),
-   theHcalTopology(nullptr),
-   theGeometry(nullptr),
-   theTowerConstituentsMap(nullptr),
-   theHcalAcceptSeverityLevel(0),
-   theRecoveredHcalHitsAreUsed(false),
-   theRecoveredEcalHitsAreUsed(false),
-   useRejectedHitsOnly(false),
-   theHcalAcceptSeverityLevelForRejectedHit(0),
-   useRejectedRecoveredHcalHits(0),
-   useRejectedRecoveredEcalHits(0),
-   missingHcalRescaleFactorForEcal(0.),
-   theHOIsUsed(true),
-   // (for momentum reconstruction algorithm)
-   theMomConstrMethod(0),
-   theMomHBDepth(0.),
-   theMomHEDepth(0.),
-   theMomEBDepth(0.),
-   theMomEEDepth(0.),
-   theHcalPhase(0)
-{
-}
+CaloTowersCreationAlgo::CaloTowersCreationAlgo(double EBthreshold,
+                                               double EEthreshold,
 
-CaloTowersCreationAlgo::CaloTowersCreationAlgo(double EBthreshold, double EEthreshold, 
+                                               bool useEtEBTreshold,
+                                               bool useEtEETreshold,
+                                               bool useSymEBTreshold,
+                                               bool useSymEETreshold,
 
-					       bool useEtEBTreshold,
-					       bool useEtEETreshold,
-					       bool useSymEBTreshold,
-					       bool useSymEETreshold,				    
+                                               double HcalThreshold,
+                                               double HBthreshold,
+                                               double HBthreshold1,
+                                               double HBthreshold2,
+                                               double HESthreshold,
+                                               double HESthreshold1,
+                                               double HEDthreshold,
+                                               double HEDthreshold1,
+                                               double HOthreshold0,
+                                               double HOthresholdPlus1,
+                                               double HOthresholdMinus1,
+                                               double HOthresholdPlus2,
+                                               double HOthresholdMinus2,
+                                               double HF1threshold,
+                                               double HF2threshold,
+                                               double EBweight,
+                                               double EEweight,
+                                               double HBweight,
+                                               double HESweight,
+                                               double HEDweight,
+                                               double HOweight,
+                                               double HF1weight,
+                                               double HF2weight,
+                                               double EcutTower,
+                                               double EBSumThreshold,
+                                               double EESumThreshold,
+                                               bool useHO,
+                                               // (momentum reconstruction algorithm)
+                                               int momConstrMethod,
+                                               double momHBDepth,
+                                               double momHEDepth,
+                                               double momEBDepth,
+                                               double momEEDepth,
+                                               int hcalPhase)
 
-					       double HcalThreshold,
-					       double HBthreshold, double HBthreshold1, double HBthreshold2,
-                                               double HESthreshold, double HESthreshold1, 
-                                               double HEDthreshold, double HEDthreshold1,
-					       double HOthreshold0, double HOthresholdPlus1, double HOthresholdMinus1,  
-					       double HOthresholdPlus2, double HOthresholdMinus2, 
-					       double HF1threshold, double HF2threshold,
-					       double EBweight, double EEweight,
-					       double HBweight, double HESweight, double HEDweight,
-					       double HOweight, double HF1weight, double HF2weight,
-					       double EcutTower, double EBSumThreshold, double EESumThreshold,
-					       bool useHO,
-					       // (momentum reconstruction algorithm)
-					       int momConstrMethod,
-					       double momHBDepth,
-					       double momHEDepth,
-					       double momEBDepth,
-					       double momEEDepth,
-                           int hcalPhase)
+    : theEBthreshold(EBthreshold),
+      theEEthreshold(EEthreshold),
 
-  : theEBthreshold(EBthreshold),
-    theEEthreshold(EEthreshold),
+      theUseEtEBTresholdFlag(useEtEBTreshold),
+      theUseEtEETresholdFlag(useEtEETreshold),
+      theUseSymEBTresholdFlag(useSymEBTreshold),
+      theUseSymEETresholdFlag(useSymEETreshold),
 
-    theUseEtEBTresholdFlag(useEtEBTreshold),
-    theUseEtEETresholdFlag(useEtEETreshold),
-    theUseSymEBTresholdFlag(useSymEBTreshold),
-    theUseSymEETresholdFlag(useSymEETreshold),
+      theHcalThreshold(HcalThreshold),
+      theHBthreshold(HBthreshold),
+      theHBthreshold1(HBthreshold1),
+      theHBthreshold2(HBthreshold2),
+      theHESthreshold(HESthreshold),
+      theHESthreshold1(HESthreshold1),
+      theHEDthreshold(HEDthreshold),
+      theHEDthreshold1(HEDthreshold1),
+      theHOthreshold0(HOthreshold0),
+      theHOthresholdPlus1(HOthresholdPlus1),
+      theHOthresholdMinus1(HOthresholdMinus1),
+      theHOthresholdPlus2(HOthresholdPlus2),
+      theHOthresholdMinus2(HOthresholdMinus2),
+      theHF1threshold(HF1threshold),
+      theHF2threshold(HF2threshold),
+      theEBGrid(std::vector<double>(5, 10.)),
+      theEBWeights(std::vector<double>(5, 1.)),
+      theEEGrid(std::vector<double>(5, 10.)),
+      theEEWeights(std::vector<double>(5, 1.)),
+      theHBGrid(std::vector<double>(5, 10.)),
+      theHBWeights(std::vector<double>(5, 1.)),
+      theHESGrid(std::vector<double>(5, 10.)),
+      theHESWeights(std::vector<double>(5, 1.)),
+      theHEDGrid(std::vector<double>(5, 10.)),
+      theHEDWeights(std::vector<double>(5, 1.)),
+      theHOGrid(std::vector<double>(5, 10.)),
+      theHOWeights(std::vector<double>(5, 1.)),
+      theHF1Grid(std::vector<double>(5, 10.)),
+      theHF1Weights(std::vector<double>(5, 1.)),
+      theHF2Grid(std::vector<double>(5, 10.)),
+      theHF2Weights(std::vector<double>(5, 1.)),
+      theEBweight(EBweight),
+      theEEweight(EEweight),
+      theHBweight(HBweight),
+      theHESweight(HESweight),
+      theHEDweight(HEDweight),
+      theHOweight(HOweight),
+      theHF1weight(HF1weight),
+      theHF2weight(HF2weight),
+      theEcutTower(EcutTower),
+      theEBSumThreshold(EBSumThreshold),
+      theEESumThreshold(EESumThreshold),
+      theEBEScale(50.),
+      theEEEScale(50.),
+      theHBEScale(50.),
+      theHESEScale(50.),
+      theHEDEScale(50.),
+      theHOEScale(50.),
+      theHF1EScale(50.),
+      theHF2EScale(50.),
+      theHcalTopology(nullptr),
+      theGeometry(nullptr),
+      theTowerConstituentsMap(nullptr),
+      theHcalAcceptSeverityLevel(0),
+      theRecoveredHcalHitsAreUsed(false),
+      theRecoveredEcalHitsAreUsed(false),
+      useRejectedHitsOnly(false),
+      theHcalAcceptSeverityLevelForRejectedHit(0),
+      useRejectedRecoveredHcalHits(0),
+      useRejectedRecoveredEcalHits(0),
+      missingHcalRescaleFactorForEcal(0.),
+      theHOIsUsed(useHO),
+      // (momentum reconstruction algorithm)
+      theMomConstrMethod(momConstrMethod),
+      theMomHBDepth(momHBDepth),
+      theMomHEDepth(momHEDepth),
+      theMomEBDepth(momEBDepth),
+      theMomEEDepth(momEEDepth),
+      theHcalPhase(hcalPhase) {}
 
-    theHcalThreshold(HcalThreshold),
-    theHBthreshold(HBthreshold),
-    theHBthreshold1(HBthreshold1),
-    theHBthreshold2(HBthreshold2),
-    theHESthreshold(HESthreshold),
-    theHESthreshold1(HESthreshold1),
-    theHEDthreshold(HEDthreshold),
-    theHEDthreshold1(HEDthreshold1),
-    theHOthreshold0(HOthreshold0), 
-    theHOthresholdPlus1(HOthresholdPlus1),
-    theHOthresholdMinus1(HOthresholdMinus1),
-    theHOthresholdPlus2(HOthresholdPlus2),
-    theHOthresholdMinus2(HOthresholdMinus2),
-    theHF1threshold(HF1threshold),
-    theHF2threshold(HF2threshold),
-    theEBGrid(std::vector<double>(5,10.)),
-    theEBWeights(std::vector<double>(5,1.)),
-    theEEGrid(std::vector<double>(5,10.)),
-    theEEWeights(std::vector<double>(5,1.)),
-    theHBGrid(std::vector<double>(5,10.)),
-    theHBWeights(std::vector<double>(5,1.)),
-    theHESGrid(std::vector<double>(5,10.)),
-    theHESWeights(std::vector<double>(5,1.)),
-    theHEDGrid(std::vector<double>(5,10.)),
-    theHEDWeights(std::vector<double>(5,1.)),
-    theHOGrid(std::vector<double>(5,10.)),
-    theHOWeights(std::vector<double>(5,1.)),
-    theHF1Grid(std::vector<double>(5,10.)),
-    theHF1Weights(std::vector<double>(5,1.)),
-    theHF2Grid(std::vector<double>(5,10.)),
-    theHF2Weights(std::vector<double>(5,1.)),
-    theEBweight(EBweight),
-    theEEweight(EEweight),
-    theHBweight(HBweight),
-    theHESweight(HESweight),
-    theHEDweight(HEDweight),
-    theHOweight(HOweight),
-    theHF1weight(HF1weight),
-    theHF2weight(HF2weight),
-    theEcutTower(EcutTower),
-    theEBSumThreshold(EBSumThreshold),
-    theEESumThreshold(EESumThreshold),
-    theEBEScale(50.),
-    theEEEScale(50.),
-    theHBEScale(50.),
-    theHESEScale(50.),
-    theHEDEScale(50.),
-    theHOEScale(50.),
-    theHF1EScale(50.),
-    theHF2EScale(50.),
-    theHcalTopology(nullptr),
-    theGeometry(nullptr),
-    theTowerConstituentsMap(nullptr),
-    theHcalAcceptSeverityLevel(0),
-    theRecoveredHcalHitsAreUsed(false),
-    theRecoveredEcalHitsAreUsed(false),
-    useRejectedHitsOnly(false),
-    theHcalAcceptSeverityLevelForRejectedHit(0),
-    useRejectedRecoveredHcalHits(0),
-    useRejectedRecoveredEcalHits(0),
-    missingHcalRescaleFactorForEcal(0.),
-    theHOIsUsed(useHO),
-    // (momentum reconstruction algorithm)
-    theMomConstrMethod(momConstrMethod),
-    theMomHBDepth(momHBDepth),
-    theMomHEDepth(momHEDepth),
-    theMomEBDepth(momEBDepth),
-    theMomEEDepth(momEEDepth),
-    theHcalPhase(hcalPhase)
-{
-}
+CaloTowersCreationAlgo::CaloTowersCreationAlgo(double EBthreshold,
+                                               double EEthreshold,
+                                               bool useEtEBTreshold,
+                                               bool useEtEETreshold,
+                                               bool useSymEBTreshold,
+                                               bool useSymEETreshold,
 
-CaloTowersCreationAlgo::CaloTowersCreationAlgo(double EBthreshold, double EEthreshold, 
-       bool useEtEBTreshold,
-       bool useEtEETreshold,
-       bool useSymEBTreshold,
-       bool useSymEETreshold,
+                                               double HcalThreshold,
+                                               double HBthreshold,
+                                               double HBthreshold1,
+                                               double HBthreshold2,
+                                               double HESthreshold,
+                                               double HESthreshold1,
+                                               double HEDthreshold,
+                                               double HEDthreshold1,
+                                               double HOthreshold0,
+                                               double HOthresholdPlus1,
+                                               double HOthresholdMinus1,
+                                               double HOthresholdPlus2,
+                                               double HOthresholdMinus2,
+                                               double HF1threshold,
+                                               double HF2threshold,
+                                               const std::vector<double>& EBGrid,
+                                               const std::vector<double>& EBWeights,
+                                               const std::vector<double>& EEGrid,
+                                               const std::vector<double>& EEWeights,
+                                               const std::vector<double>& HBGrid,
+                                               const std::vector<double>& HBWeights,
+                                               const std::vector<double>& HESGrid,
+                                               const std::vector<double>& HESWeights,
+                                               const std::vector<double>& HEDGrid,
+                                               const std::vector<double>& HEDWeights,
+                                               const std::vector<double>& HOGrid,
+                                               const std::vector<double>& HOWeights,
+                                               const std::vector<double>& HF1Grid,
+                                               const std::vector<double>& HF1Weights,
+                                               const std::vector<double>& HF2Grid,
+                                               const std::vector<double>& HF2Weights,
+                                               double EBweight,
+                                               double EEweight,
+                                               double HBweight,
+                                               double HESweight,
+                                               double HEDweight,
+                                               double HOweight,
+                                               double HF1weight,
+                                               double HF2weight,
+                                               double EcutTower,
+                                               double EBSumThreshold,
+                                               double EESumThreshold,
+                                               bool useHO,
+                                               // (for the momentum construction algorithm)
+                                               int momConstrMethod,
+                                               double momHBDepth,
+                                               double momHEDepth,
+                                               double momEBDepth,
+                                               double momEEDepth,
+                                               int hcalPhase)
 
-       double HcalThreshold,
-       double HBthreshold, double HBthreshold1, double HBthreshold2,
-       double HESthreshold, double HESthreshold1, 
-       double HEDthreshold, double HEDthreshold1,
-       double HOthreshold0, double HOthresholdPlus1, double HOthresholdMinus1,  
-       double HOthresholdPlus2, double HOthresholdMinus2,  
-       double HF1threshold, double HF2threshold,
-       const std::vector<double> & EBGrid, const std::vector<double> & EBWeights,
-       const std::vector<double> & EEGrid, const std::vector<double> & EEWeights,
-       const std::vector<double> & HBGrid, const std::vector<double> & HBWeights,
-       const std::vector<double> & HESGrid, const std::vector<double> & HESWeights,
-       const std::vector<double> & HEDGrid, const std::vector<double> & HEDWeights,
-       const std::vector<double> & HOGrid, const std::vector<double> & HOWeights,
-       const std::vector<double> & HF1Grid, const std::vector<double> & HF1Weights,
-       const std::vector<double> & HF2Grid, const std::vector<double> & HF2Weights,
-       double EBweight, double EEweight,
-       double HBweight, double HESweight, double HEDweight,
-       double HOweight, double HF1weight, double HF2weight,
-       double EcutTower, double EBSumThreshold, double EESumThreshold,
-       bool useHO,
-       // (for the momentum construction algorithm)
-       int momConstrMethod,
-       double momHBDepth,
-       double momHEDepth,
-       double momEBDepth,
-       double momEEDepth,
-       int hcalPhase)
+    : theEBthreshold(EBthreshold),
+      theEEthreshold(EEthreshold),
 
-  : theEBthreshold(EBthreshold),
-    theEEthreshold(EEthreshold),
+      theUseEtEBTresholdFlag(useEtEBTreshold),
+      theUseEtEETresholdFlag(useEtEETreshold),
+      theUseSymEBTresholdFlag(useSymEBTreshold),
+      theUseSymEETresholdFlag(useSymEETreshold),
 
-    theUseEtEBTresholdFlag(useEtEBTreshold),
-    theUseEtEETresholdFlag(useEtEETreshold),
-    theUseSymEBTresholdFlag(useSymEBTreshold),
-    theUseSymEETresholdFlag(useSymEETreshold),
-
-    theHcalThreshold(HcalThreshold),
-    theHBthreshold(HBthreshold),
-    theHBthreshold1(HBthreshold1),
-    theHBthreshold2(HBthreshold2),
-    theHESthreshold(HESthreshold),
-    theHESthreshold1(HESthreshold1),
-    theHEDthreshold(HEDthreshold),
-    theHEDthreshold1(HEDthreshold1),
-    theHOthreshold0(HOthreshold0), 
-    theHOthresholdPlus1(HOthresholdPlus1),
-    theHOthresholdMinus1(HOthresholdMinus1),
-    theHOthresholdPlus2(HOthresholdPlus2),
-    theHOthresholdMinus2(HOthresholdMinus2),
-    theHF1threshold(HF1threshold),
-    theHF2threshold(HF2threshold),
-    theEBGrid(EBGrid),
-    theEBWeights(EBWeights),
-    theEEGrid(EEGrid),
-    theEEWeights(EEWeights),
-    theHBGrid(HBGrid),
-    theHBWeights(HBWeights),
-    theHESGrid(HESGrid),
-    theHESWeights(HESWeights),
-    theHEDGrid(HEDGrid),
-    theHEDWeights(HEDWeights),
-    theHOGrid(HOGrid),
-    theHOWeights(HOWeights),
-    theHF1Grid(HF1Grid),
-    theHF1Weights(HF1Weights),
-    theHF2Grid(HF2Grid),
-    theHF2Weights(HF2Weights),
-    theEBweight(EBweight),
-    theEEweight(EEweight),
-    theHBweight(HBweight),
-    theHESweight(HESweight),
-    theHEDweight(HEDweight),
-    theHOweight(HOweight),
-    theHF1weight(HF1weight),
-    theHF2weight(HF2weight),
-    theEcutTower(EcutTower),
-    theEBSumThreshold(EBSumThreshold),
-    theEESumThreshold(EESumThreshold),
-    theEBEScale(50.),
-    theEEEScale(50.),
-    theHBEScale(50.),
-    theHESEScale(50.),
-    theHEDEScale(50.),
-    theHOEScale(50.),
-    theHF1EScale(50.),
-    theHF2EScale(50.),
-    theHcalTopology(nullptr),
-    theGeometry(nullptr),
-    theTowerConstituentsMap(nullptr),
-    theHcalAcceptSeverityLevel(0),
-    theRecoveredHcalHitsAreUsed(false),
-    theRecoveredEcalHitsAreUsed(false),
-    useRejectedHitsOnly(false),
-    theHcalAcceptSeverityLevelForRejectedHit(0),
-    useRejectedRecoveredHcalHits(0),
-    useRejectedRecoveredEcalHits(0),
-    missingHcalRescaleFactorForEcal(0.),
-    theHOIsUsed(useHO),
-    // (momentum reconstruction algorithm)
-    theMomConstrMethod(momConstrMethod),
-    theMomHBDepth(momHBDepth),
-    theMomHEDepth(momHEDepth),
-    theMomEBDepth(momEBDepth),
-    theMomEEDepth(momEEDepth),
-    theHcalPhase(hcalPhase)
-{
+      theHcalThreshold(HcalThreshold),
+      theHBthreshold(HBthreshold),
+      theHBthreshold1(HBthreshold1),
+      theHBthreshold2(HBthreshold2),
+      theHESthreshold(HESthreshold),
+      theHESthreshold1(HESthreshold1),
+      theHEDthreshold(HEDthreshold),
+      theHEDthreshold1(HEDthreshold1),
+      theHOthreshold0(HOthreshold0),
+      theHOthresholdPlus1(HOthresholdPlus1),
+      theHOthresholdMinus1(HOthresholdMinus1),
+      theHOthresholdPlus2(HOthresholdPlus2),
+      theHOthresholdMinus2(HOthresholdMinus2),
+      theHF1threshold(HF1threshold),
+      theHF2threshold(HF2threshold),
+      theEBGrid(EBGrid),
+      theEBWeights(EBWeights),
+      theEEGrid(EEGrid),
+      theEEWeights(EEWeights),
+      theHBGrid(HBGrid),
+      theHBWeights(HBWeights),
+      theHESGrid(HESGrid),
+      theHESWeights(HESWeights),
+      theHEDGrid(HEDGrid),
+      theHEDWeights(HEDWeights),
+      theHOGrid(HOGrid),
+      theHOWeights(HOWeights),
+      theHF1Grid(HF1Grid),
+      theHF1Weights(HF1Weights),
+      theHF2Grid(HF2Grid),
+      theHF2Weights(HF2Weights),
+      theEBweight(EBweight),
+      theEEweight(EEweight),
+      theHBweight(HBweight),
+      theHESweight(HESweight),
+      theHEDweight(HEDweight),
+      theHOweight(HOweight),
+      theHF1weight(HF1weight),
+      theHF2weight(HF2weight),
+      theEcutTower(EcutTower),
+      theEBSumThreshold(EBSumThreshold),
+      theEESumThreshold(EESumThreshold),
+      theEBEScale(50.),
+      theEEEScale(50.),
+      theHBEScale(50.),
+      theHESEScale(50.),
+      theHEDEScale(50.),
+      theHOEScale(50.),
+      theHF1EScale(50.),
+      theHF2EScale(50.),
+      theHcalTopology(nullptr),
+      theGeometry(nullptr),
+      theTowerConstituentsMap(nullptr),
+      theHcalAcceptSeverityLevel(0),
+      theRecoveredHcalHitsAreUsed(false),
+      theRecoveredEcalHitsAreUsed(false),
+      useRejectedHitsOnly(false),
+      theHcalAcceptSeverityLevelForRejectedHit(0),
+      useRejectedRecoveredHcalHits(0),
+      useRejectedRecoveredEcalHits(0),
+      missingHcalRescaleFactorForEcal(0.),
+      theHOIsUsed(useHO),
+      // (momentum reconstruction algorithm)
+      theMomConstrMethod(momConstrMethod),
+      theMomHBDepth(momHBDepth),
+      theMomHEDepth(momHEDepth),
+      theMomEBDepth(momEBDepth),
+      theMomEEDepth(momEEDepth),
+      theHcalPhase(hcalPhase) {
   // static int N = 0;
-  // std::cout << "VI Algo " << ++N << std::endl; 
+  // std::cout << "VI Algo " << ++N << std::endl;
   // nalgo=N;
 }
 
-
-void CaloTowersCreationAlgo::setGeometry(const CaloTowerTopology* cttopo, const CaloTowerConstituentsMap* ctmap, const HcalTopology* htopo, const CaloGeometry* geo) {
+void CaloTowersCreationAlgo::setGeometry(const CaloTowerTopology* cttopo,
+                                         const CaloTowerConstituentsMap* ctmap,
+                                         const HcalTopology* htopo,
+                                         const CaloGeometry* geo) {
   theTowerTopology = cttopo;
   theTowerConstituentsMap = ctmap;
   theHcalTopology = htopo;
   theGeometry = geo;
-  theTowerGeometry=geo->getSubdetectorGeometry(DetId::Calo,CaloTowerDetId::SubdetId);
-  
+  theTowerGeometry = geo->getSubdetectorGeometry(DetId::Calo, CaloTowerDetId::SubdetId);
+
   //initialize ecal bad channel map
-  ecalBadChs.resize(theTowerTopology->sizeForDenseIndexing(),0);
+  ecalBadChs.resize(theTowerTopology->sizeForDenseIndexing(), 0);
 }
 
 void CaloTowersCreationAlgo::begin() {
   theTowerMap.clear();
-  theTowerMapSize=0;
+  theTowerMapSize = 0;
   //hcalDropChMap.clear();
 }
 
-void CaloTowersCreationAlgo::process(const HBHERecHitCollection& hbhe) { 
-  for(HBHERecHitCollection::const_iterator hbheItr = hbhe.begin();
-      hbheItr != hbhe.end(); ++hbheItr)
+void CaloTowersCreationAlgo::process(const HBHERecHitCollection& hbhe) {
+  for (HBHERecHitCollection::const_iterator hbheItr = hbhe.begin(); hbheItr != hbhe.end(); ++hbheItr)
     assignHitHcal(&(*hbheItr));
 }
 
-void CaloTowersCreationAlgo::process(const HORecHitCollection& ho) { 
-  for(HORecHitCollection::const_iterator hoItr = ho.begin();
-      hoItr != ho.end(); ++hoItr)
+void CaloTowersCreationAlgo::process(const HORecHitCollection& ho) {
+  for (HORecHitCollection::const_iterator hoItr = ho.begin(); hoItr != ho.end(); ++hoItr)
     assignHitHcal(&(*hoItr));
-}  
+}
 
-void CaloTowersCreationAlgo::process(const HFRecHitCollection& hf) { 
-  for(HFRecHitCollection::const_iterator hfItr = hf.begin();
-      hfItr != hf.end(); ++hfItr)  
+void CaloTowersCreationAlgo::process(const HFRecHitCollection& hf) {
+  for (HFRecHitCollection::const_iterator hfItr = hf.begin(); hfItr != hf.end(); ++hfItr)
     assignHitHcal(&(*hfItr));
 }
 
-void CaloTowersCreationAlgo::process(const EcalRecHitCollection& ec) { 
-  for(EcalRecHitCollection::const_iterator ecItr = ec.begin();
-      ecItr != ec.end(); ++ecItr)  
+void CaloTowersCreationAlgo::process(const EcalRecHitCollection& ec) {
+  for (EcalRecHitCollection::const_iterator ecItr = ec.begin(); ecItr != ec.end(); ++ecItr)
     assignHitEcal(&(*ecItr));
 }
 
 // this method should not be used any more as the towers in the changed format
 // can not be properly rescaled with the "rescale" method.
 // "rescale was replaced by "rescaleTowers"
-// 
+//
 void CaloTowersCreationAlgo::process(const CaloTowerCollection& ctc) {
-  for(CaloTowerCollection::const_iterator ctcItr = ctc.begin();
-      ctcItr != ctc.end(); ++ctcItr) { 
+  for (CaloTowerCollection::const_iterator ctcItr = ctc.begin(); ctcItr != ctc.end(); ++ctcItr) {
     rescale(&(*ctcItr));
-    }
+  }
 }
-
-
 
 void CaloTowersCreationAlgo::finish(CaloTowerCollection& result) {
   // now copy this map into the final collection
@@ -379,110 +408,115 @@ void CaloTowersCreationAlgo::finish(CaloTowerCollection& result) {
   //  if (!theEbHandle.isValid()) std::cout << "VI ebHandle not valid" << std::endl;
   // if (!theEeHandle.isValid()) std::cout << "VI eeHandle not valid" << std::endl;
 
-  for(auto const & mt : theTowerMap ) { 
-    // Convert only if there is at least one constituent in the metatower. 
+  for (auto const& mt : theTowerMap) {
+    // Convert only if there is at least one constituent in the metatower.
     // The check of constituents size in the coverted tower is still needed!
-    if (!mt.empty() ) { convert(mt.id, mt, result); } // ++k;}	
+    if (!mt.empty()) {
+      convert(mt.id, mt, result);
+    }  // ++k;}
   }
-  
+
   // assert(k==theTowerMapSize);
   // std::cout << "VI TowerMap " << theTowerMapSize << " " << k << std::endl;
-  
-  theTowerMap.clear(); // save the memory
-  theTowerMapSize=0;
+
+  theTowerMap.clear();  // save the memory
+  theTowerMapSize = 0;
 }
 
-
 void CaloTowersCreationAlgo::rescaleTowers(const CaloTowerCollection& ctc, CaloTowerCollection& ctcResult) {
+  for (CaloTowerCollection::const_iterator ctcItr = ctc.begin(); ctcItr != ctc.end(); ++ctcItr) {
+    CaloTowerDetId twrId = ctcItr->id();
+    double newE_em = ctcItr->emEnergy();
+    double newE_had = ctcItr->hadEnergy();
+    double newE_outer = ctcItr->outerEnergy();
 
-    for (CaloTowerCollection::const_iterator ctcItr = ctc.begin();
-      ctcItr != ctc.end(); ++ctcItr) { 
-      
-      CaloTowerDetId  twrId = ctcItr->id(); 
-      double newE_em    = ctcItr->emEnergy();
-      double newE_had   = ctcItr->hadEnergy();
-      double newE_outer = ctcItr->outerEnergy(); 
+    double threshold = 0.0;  // not used: we do not change thresholds
+    double weight = 1.0;
 
-      double threshold = 0.0; // not used: we do not change thresholds
-      double weight    = 1.0;
+    // HF
+    if (ctcItr->ietaAbs() >= theTowerTopology->firstHFRing()) {
+      double E_short = 0.5 * newE_had;           // from the definitions for HF
+      double E_long = newE_em + 0.5 * newE_had;  //
+      // scale
+      E_long *= theHF1weight;
+      E_short *= theHF2weight;
+      // convert
+      newE_em = E_long - E_short;
+      newE_had = 2.0 * E_short;
+    }
 
-      // HF
-      if (ctcItr->ietaAbs()>=theTowerTopology->firstHFRing()) {
-        double E_short = 0.5 * newE_had;             // from the definitions for HF
-        double E_long  = newE_em + 0.5 * newE_had;   //
-        // scale
-        E_long  *= theHF1weight;
-        E_short *= theHF2weight;
-        // convert
-        newE_em  = E_long - E_short;
-        newE_had = 2.0 * E_short;
+    else {  // barrel/endcap
+
+      // find if its in EB, or EE; determine from first ecal constituent found
+      for (unsigned int iConst = 0; iConst < ctcItr->constituentsSize(); ++iConst) {
+        DetId constId = ctcItr->constituent(iConst);
+        if (constId.det() != DetId::Ecal)
+          continue;
+        getThresholdAndWeight(constId, threshold, weight);
+        newE_em *= weight;
+        break;
+      }
+      // HO
+      for (unsigned int iConst = 0; iConst < ctcItr->constituentsSize(); ++iConst) {
+        DetId constId = ctcItr->constituent(iConst);
+        if (constId.det() != DetId::Hcal)
+          continue;
+        if (HcalDetId(constId).subdet() != HcalOuter)
+          continue;
+        getThresholdAndWeight(constId, threshold, weight);
+        newE_outer *= weight;
+        break;
+      }
+      // HB/HE
+      for (unsigned int iConst = 0; iConst < ctcItr->constituentsSize(); ++iConst) {
+        DetId constId = ctcItr->constituent(iConst);
+        if (constId.det() != DetId::Hcal)
+          continue;
+        if (HcalDetId(constId).subdet() == HcalOuter)
+          continue;
+        getThresholdAndWeight(constId, threshold, weight);
+        newE_had *= weight;
+        if (ctcItr->ietaAbs() > theTowerTopology->firstHERing())
+          newE_outer *= weight;
+        break;
       }
 
-      else {   // barrel/endcap
-
-        // find if its in EB, or EE; determine from first ecal constituent found
-        for (unsigned int iConst = 0; iConst < ctcItr->constituentsSize(); ++iConst) {
-          DetId constId = ctcItr->constituent(iConst);
-          if (constId.det()!=DetId::Ecal) continue;
-          getThresholdAndWeight(constId, threshold, weight);
-          newE_em *= weight;
-          break;
-        }
-        // HO
-        for (unsigned int iConst = 0; iConst < ctcItr->constituentsSize(); ++iConst) {
-          DetId constId = ctcItr->constituent(iConst);
-          if (constId.det()!=DetId::Hcal) continue;
-          if (HcalDetId(constId).subdet()!=HcalOuter) continue;
-          getThresholdAndWeight(constId, threshold, weight);
-          newE_outer *= weight;
-          break;
-        }
-        // HB/HE
-        for (unsigned int iConst = 0; iConst < ctcItr->constituentsSize(); ++iConst) {
-          DetId constId = ctcItr->constituent(iConst);
-          if (constId.det()!=DetId::Hcal) continue;
-          if (HcalDetId(constId).subdet()==HcalOuter) continue;
-          getThresholdAndWeight(constId, threshold, weight);
-          newE_had *= weight;
-          if (ctcItr->ietaAbs()>theTowerTopology->firstHERing()) newE_outer *= weight;
-          break;
-        }
-        
-    }   // barrel/endcap region
+    }  // barrel/endcap region
 
     // now make the new tower
 
-    double newE_hadTot = (theHOIsUsed &&  twrId.ietaAbs()<=theTowerTopology->lastHORing())? newE_had+newE_outer : newE_had;
+    double newE_hadTot =
+        (theHOIsUsed && twrId.ietaAbs() <= theTowerTopology->lastHORing()) ? newE_had + newE_outer : newE_had;
 
-    GlobalPoint  emPoint = ctcItr->emPosition(); 
-    GlobalPoint hadPoint = ctcItr->emPosition(); 
+    GlobalPoint emPoint = ctcItr->emPosition();
+    GlobalPoint hadPoint = ctcItr->emPosition();
 
-    double f_em  = 1.0/cosh(emPoint.eta());
-    double f_had = 1.0/cosh(hadPoint.eta());
+    double f_em = 1.0 / cosh(emPoint.eta());
+    double f_had = 1.0 / cosh(hadPoint.eta());
 
     CaloTower::PolarLorentzVector towerP4;
 
-    if (ctcItr->ietaAbs()<theTowerTopology->firstHFRing()) {
-      if (newE_em>0)     towerP4 += CaloTower::PolarLorentzVector(newE_em*f_em,   emPoint.eta(),  emPoint.phi(),  0); 
-      if (newE_hadTot>0) towerP4 += CaloTower::PolarLorentzVector(newE_hadTot*f_had, hadPoint.eta(), hadPoint.phi(), 0); 
-    }
-    else {
+    if (ctcItr->ietaAbs() < theTowerTopology->firstHFRing()) {
+      if (newE_em > 0)
+        towerP4 += CaloTower::PolarLorentzVector(newE_em * f_em, emPoint.eta(), emPoint.phi(), 0);
+      if (newE_hadTot > 0)
+        towerP4 += CaloTower::PolarLorentzVector(newE_hadTot * f_had, hadPoint.eta(), hadPoint.phi(), 0);
+    } else {
       double newE_tot = newE_em + newE_had;
       // for HF we use common point for ecal, hcal shower positions regardless of the method
-      if (newE_tot>0) towerP4 += CaloTower::PolarLorentzVector(newE_tot*f_had, hadPoint.eta(), hadPoint.phi(), 0);
+      if (newE_tot > 0)
+        towerP4 += CaloTower::PolarLorentzVector(newE_tot * f_had, hadPoint.eta(), hadPoint.phi(), 0);
     }
-
-
 
     CaloTower rescaledTower(twrId, newE_em, newE_had, newE_outer, -1, -1, towerP4, emPoint, hadPoint);
     // copy the timings, have to convert back to int, 1 unit = 0.01 ns
-    rescaledTower.setEcalTime( int(ctcItr->ecalTime()*100.0 + 0.5) );
-    rescaledTower.setHcalTime( int(ctcItr->hcalTime()*100.0 + 0.5) );
+    rescaledTower.setEcalTime(int(ctcItr->ecalTime() * 100.0 + 0.5));
+    rescaledTower.setHcalTime(int(ctcItr->hcalTime() * 100.0 + 0.5));
     //add topology info
     rescaledTower.setHcalSubdet(theTowerTopology->lastHBRing(),
                                 theTowerTopology->lastHERing(),
                                 theTowerTopology->lastHFRing(),
-                                theTowerTopology->lastHORing() );
+                                theTowerTopology->lastHORing());
 
     std::vector<DetId> contains;
     for (unsigned int iConst = 0; iConst < ctcItr->constituentsSize(); ++iConst) {
@@ -494,20 +528,16 @@ void CaloTowersCreationAlgo::rescaleTowers(const CaloTowerCollection& ctc, CaloT
 
     ctcResult.push_back(rescaledTower);
 
-    } // end of loop over towers
-
-
+  }  // end of loop over towers
 }
 
-
-void CaloTowersCreationAlgo::assignHitHcal(const CaloRecHit * recHit) {
+void CaloTowersCreationAlgo::assignHitHcal(const CaloRecHit* recHit) {
   DetId detId = recHit->detid();
   DetId detIdF(detId);
   if (detId.det() == DetId::Hcal && theHcalTopology->getMergePositionFlag()) {
     detIdF = theHcalTopology->idFront(HcalDetId(detId));
 #ifdef EDM_ML_DEBUG
-    std::cout << "AssignHitHcal DetId " << HcalDetId(detId) << " Front " 
-	      << HcalDetId(detIdF) << std::endl;
+    std::cout << "AssignHitHcal DetId " << HcalDetId(detId) << " Front " << HcalDetId(detIdF) << std::endl;
 #endif
   }
 
@@ -515,148 +545,145 @@ void CaloTowersCreationAlgo::assignHitHcal(const CaloRecHit * recHit) {
 
   // this is for skipping channls: mostly needed for the creation of
   // bad towers from hits i the bad channel collections.
-  if (chStatusForCT==CaloTowersCreationAlgo::IgnoredChan) return;
+  if (chStatusForCT == CaloTowersCreationAlgo::IgnoredChan)
+    return;
 
   double threshold, weight;
   getThresholdAndWeight(detId, threshold, weight);
 
-  double energy = recHit->energy();  // original RecHit energy is used to apply thresholds  
+  double energy = recHit->energy();  // original RecHit energy is used to apply thresholds
   double e = energy * weight;        // energies scaled by user weight: used in energy assignments
-        
+
   // SPECIAL handling of tower 28 merged depths --> half into tower 28 and half into tower 29
   bool merge(false);
-  if (detIdF.det()==DetId::Hcal && 
-      HcalDetId(detIdF).subdet()==HcalEndcap &&
-      (theHcalPhase==0 || theHcalPhase==1) &&
+  if (detIdF.det() == DetId::Hcal && HcalDetId(detIdF).subdet() == HcalEndcap &&
+      (theHcalPhase == 0 || theHcalPhase == 1) &&
       //HcalDetId(detId).depth()==3 &&
-      HcalDetId(detIdF).ietaAbs()==theHcalTopology->lastHERing()-1) {
+      HcalDetId(detIdF).ietaAbs() == theHcalTopology->lastHERing() - 1) {
     merge = theHcalTopology->mergedDepth29(HcalDetId(detIdF));
 #ifdef EDM_ML_DEBUG
     std::cout << "Merge " << HcalDetId(detIdF) << ":" << merge << std::endl;
 #endif
   }
   if (merge) {
-
     //////////////////////////////    unsigned int chStatusForCT = hcalChanStatusForCaloTower(recHit);
-    
+
     // bad channels are counted regardless of energy threshold
 
     if (chStatusForCT == CaloTowersCreationAlgo::BadChan) {
       CaloTowerDetId towerDetId = theTowerConstituentsMap->towerOf(detId);
-      if (towerDetId.null()) return;
-      MetaTower & tower28 = find(towerDetId);
-      CaloTowerDetId towerDetId29(towerDetId.ieta()+towerDetId.zside(),
-				  towerDetId.iphi());
-      MetaTower & tower29 = find(towerDetId29);
+      if (towerDetId.null())
+        return;
+      MetaTower& tower28 = find(towerDetId);
+      CaloTowerDetId towerDetId29(towerDetId.ieta() + towerDetId.zside(), towerDetId.iphi());
+      MetaTower& tower29 = find(towerDetId29);
       tower28.numBadHcalCells += 1;
       tower29.numBadHcalCells += 1;
     }
 
-    else if (0.5*energy >= threshold) {  // not bad channel: use energy if above threshold
-      
+    else if (0.5 * energy >= threshold) {  // not bad channel: use energy if above threshold
+
       CaloTowerDetId towerDetId = theTowerConstituentsMap->towerOf(detId);
-      if (towerDetId.null()) return;
-      MetaTower & tower28 = find(towerDetId);
-      CaloTowerDetId towerDetId29(towerDetId.ieta()+towerDetId.zside(),
-				  towerDetId.iphi());
-      MetaTower & tower29 = find(towerDetId29);
-	
+      if (towerDetId.null())
+        return;
+      MetaTower& tower28 = find(towerDetId);
+      CaloTowerDetId towerDetId29(towerDetId.ieta() + towerDetId.zside(), towerDetId.iphi());
+      MetaTower& tower29 = find(towerDetId29);
+
       if (chStatusForCT == CaloTowersCreationAlgo::RecoveredChan) {
-	tower28.numRecHcalCells += 1;
-	tower29.numRecHcalCells += 1;	  
-      }
-      else if (chStatusForCT == CaloTowersCreationAlgo::ProblematicChan) {
-	tower28.numProbHcalCells += 1;
-	tower29.numProbHcalCells += 1;
+        tower28.numRecHcalCells += 1;
+        tower29.numRecHcalCells += 1;
+      } else if (chStatusForCT == CaloTowersCreationAlgo::ProblematicChan) {
+        tower28.numProbHcalCells += 1;
+        tower29.numProbHcalCells += 1;
       }
 
       // NOTE DIVIDE BY 2!!!
       double e28 = 0.5 * e;
       double e29 = 0.5 * e;
-	
+
       tower28.E_had += e28;
       tower28.E += e28;
-      std::pair<DetId,float> mc(detId,e28);
+      std::pair<DetId, float> mc(detId, e28);
       tower28.metaConstituents.push_back(mc);
-	
+
       tower29.E_had += e29;
       tower29.E += e29;
       tower29.metaConstituents.push_back(mc);
-      
-      // time info: do not use in averaging if timing error is found: need 
+
+      // time info: do not use in averaging if timing error is found: need
       // full set of status info to implement: use only "good" channels for now
 
       if (chStatusForCT == CaloTowersCreationAlgo::GoodChan) {
-	tower28.hadSumTimeTimesE += ( e28 * recHit->time() );
-	tower28.hadSumEForTime   += e28;
-	tower29.hadSumTimeTimesE += ( e29 * recHit->time() );
-	tower29.hadSumEForTime   += e29;
+        tower28.hadSumTimeTimesE += (e28 * recHit->time());
+        tower28.hadSumEForTime += e28;
+        tower29.hadSumTimeTimesE += (e29 * recHit->time());
+        tower29.hadSumEForTime += e29;
       }
-	
+
       // store the energy in layer 3 also in E_outer
       tower28.E_outer += e28;
       tower29.E_outer += e29;
-    } // not a "bad" hit
-  }  // end of special case 
-  
+    }  // not a "bad" hit
+  }    // end of special case
+
   else {
     HcalDetId hcalDetId(detId);
-    
+
     ///////////////////////      unsigned int chStatusForCT = hcalChanStatusForCaloTower(recHit);
 
-    if(hcalDetId.subdet() == HcalOuter) {
-
+    if (hcalDetId.subdet() == HcalOuter) {
       CaloTowerDetId towerDetId = theTowerConstituentsMap->towerOf(detId);
-      if (towerDetId.null()) return;
-      MetaTower & tower = find(towerDetId);
+      if (towerDetId.null())
+        return;
+      MetaTower& tower = find(towerDetId);
 
       if (chStatusForCT == CaloTowersCreationAlgo::BadChan) {
-          if (theHOIsUsed) tower.numBadHcalCells += 1;
+        if (theHOIsUsed)
+          tower.numBadHcalCells += 1;
       }
-      
+
       else if (energy >= threshold) {
-        tower.E_outer += e; // store HO energy even if HO is not used
+        tower.E_outer += e;  // store HO energy even if HO is not used
         // add energy of the tower and/or flag if theHOIsUsed
-        if(theHOIsUsed) {
+        if (theHOIsUsed) {
           tower.E += e;
-          
+
           if (chStatusForCT == CaloTowersCreationAlgo::RecoveredChan) {
             tower.numRecHcalCells += 1;
-          }
-          else if (chStatusForCT == CaloTowersCreationAlgo::ProblematicChan) {
+          } else if (chStatusForCT == CaloTowersCreationAlgo::ProblematicChan) {
             tower.numProbHcalCells += 1;
           }
-        } // HO is used
-      
-        
+        }  // HO is used
+
         // add HO to constituents even if it is not used: JetMET wants to keep these towers
-        std::pair<DetId,float> mc(detId,e);
-        tower.metaConstituents.push_back(mc);   
+        std::pair<DetId, float> mc(detId, e);
+        tower.metaConstituents.push_back(mc);
 
-      } // not a bad channel, energy above threshold
-    
-    }  // HO hit 
-    
+      }  // not a bad channel, energy above threshold
+
+    }  // HO hit
+
     // HF calculates EM fraction differently
-    else if(hcalDetId.subdet() == HcalForward) {
-
+    else if (hcalDetId.subdet() == HcalForward) {
       if (chStatusForCT == CaloTowersCreationAlgo::BadChan) {
         CaloTowerDetId towerDetId = theTowerConstituentsMap->towerOf(detId);
-        if (towerDetId.null()) return;
-        MetaTower & tower = find(towerDetId);
+        if (towerDetId.null())
+          return;
+        MetaTower& tower = find(towerDetId);
         tower.numBadHcalCells += 1;
       }
-      
-      else if (energy >= threshold)  {
+
+      else if (energy >= threshold) {
         CaloTowerDetId towerDetId = theTowerConstituentsMap->towerOf(detId);
-        if (towerDetId.null()) return;
-        MetaTower & tower = find(towerDetId);
+        if (towerDetId.null())
+          return;
+        MetaTower& tower = find(towerDetId);
 
         if (hcalDetId.depth() == 1) {
           // long fiber, so E_EM = E(Long) - E(Short)
           tower.E_em += e;
-        } 
-        else {
+        } else {
           // short fiber, EHAD = 2 * E(Short)
           tower.E_em -= e;
           tower.E_had += 2. * e;
@@ -664,208 +691,206 @@ void CaloTowersCreationAlgo::assignHitHcal(const CaloRecHit * recHit) {
         tower.E += e;
         if (chStatusForCT == CaloTowersCreationAlgo::RecoveredChan) {
           tower.numRecHcalCells += 1;
-        }
-        else if (chStatusForCT == CaloTowersCreationAlgo::ProblematicChan) {
+        } else if (chStatusForCT == CaloTowersCreationAlgo::ProblematicChan) {
           tower.numProbHcalCells += 1;
         }
-        
+
         // put the timing in HCAL -> have to check timing errors when available
         // for now use only good channels
         if (chStatusForCT == CaloTowersCreationAlgo::GoodChan) {
-          tower.hadSumTimeTimesE += ( e * recHit->time() );
-          tower.hadSumEForTime   += e;
+          tower.hadSumTimeTimesE += (e * recHit->time());
+          tower.hadSumEForTime += e;
         }
 
-        std::pair<DetId,float> mc(detId,e);
-        tower.metaConstituents.push_back(mc);            
+        std::pair<DetId, float> mc(detId, e);
+        tower.metaConstituents.push_back(mc);
 
-      } // not a bad HF channel, energy above threshold
-    
-    } // HF hit
-    
+      }  // not a bad HF channel, energy above threshold
+
+    }  // HF hit
+
     else {
       // HCAL situation normal in HB/HE
       if (chStatusForCT == CaloTowersCreationAlgo::BadChan) {
         CaloTowerDetId towerDetId = theTowerConstituentsMap->towerOf(detId);
-        if (towerDetId.null()) return;
-        MetaTower & tower = find(towerDetId);
+        if (towerDetId.null())
+          return;
+        MetaTower& tower = find(towerDetId);
         tower.numBadHcalCells += 1;
-      }
-      else if (energy >= threshold) {
+      } else if (energy >= threshold) {
         CaloTowerDetId towerDetId = theTowerConstituentsMap->towerOf(detId);
-        if (towerDetId.null()) return;
-        MetaTower & tower = find(towerDetId);
+        if (towerDetId.null())
+          return;
+        MetaTower& tower = find(towerDetId);
         tower.E_had += e;
         tower.E += e;
         if (chStatusForCT == CaloTowersCreationAlgo::RecoveredChan) {
           tower.numRecHcalCells += 1;
-        }
-        else if (chStatusForCT == CaloTowersCreationAlgo::ProblematicChan) {
+        } else if (chStatusForCT == CaloTowersCreationAlgo::ProblematicChan) {
           tower.numProbHcalCells += 1;
         }
-        
+
         // Timing information: need specific accessors
         // for now use only good channels
         if (chStatusForCT == CaloTowersCreationAlgo::GoodChan) {
-          tower.hadSumTimeTimesE += ( e * recHit->time() );
-          tower.hadSumEForTime   += e;
+          tower.hadSumTimeTimesE += (e * recHit->time());
+          tower.hadSumEForTime += e;
         }
         // store energy in highest depth for towers 18-27 (for electron,photon ID in endcap)
         // also, store energy in HE part of tower 16 (for JetMET cleanup)
         HcalDetId hcalDetId(detId);
-        if (hcalDetId.subdet()==HcalEndcap){
-          if(theHcalPhase==0) {
-            if ( (hcalDetId.depth()==2 && hcalDetId.ietaAbs()>=18 && hcalDetId.ietaAbs()<27) ||
-                 (hcalDetId.depth()==3 && hcalDetId.ietaAbs()==27) ||
-                 (hcalDetId.depth()==3 && hcalDetId.ietaAbs()==16) ) {
+        if (hcalDetId.subdet() == HcalEndcap) {
+          if (theHcalPhase == 0) {
+            if ((hcalDetId.depth() == 2 && hcalDetId.ietaAbs() >= 18 && hcalDetId.ietaAbs() < 27) ||
+                (hcalDetId.depth() == 3 && hcalDetId.ietaAbs() == 27) ||
+                (hcalDetId.depth() == 3 && hcalDetId.ietaAbs() == 16)) {
               tower.E_outer += e;
             }
           }
           //combine depths in phase0-like way
-          else if(theHcalPhase==1) {
-            if ( (hcalDetId.depth()>=3 && hcalDetId.ietaAbs()>=18 && hcalDetId.ietaAbs()<26) ||
-                 (hcalDetId.depth()>=4 && (hcalDetId.ietaAbs()==26 || hcalDetId.ietaAbs()==27)) ||
-                 (hcalDetId.depth()==3 && hcalDetId.ietaAbs()==17) ||
-                 (hcalDetId.depth()==4 && hcalDetId.ietaAbs()==16) ) {
+          else if (theHcalPhase == 1) {
+            if ((hcalDetId.depth() >= 3 && hcalDetId.ietaAbs() >= 18 && hcalDetId.ietaAbs() < 26) ||
+                (hcalDetId.depth() >= 4 && (hcalDetId.ietaAbs() == 26 || hcalDetId.ietaAbs() == 27)) ||
+                (hcalDetId.depth() == 3 && hcalDetId.ietaAbs() == 17) ||
+                (hcalDetId.depth() == 4 && hcalDetId.ietaAbs() == 16)) {
               tower.E_outer += e;
             }
           }
         }
 
-        std::pair<DetId,float> mc(detId,e);
-        tower.metaConstituents.push_back(mc);   
-     
-      }   // not a "bad" channel, energy above threshold
-    
-    } // channel in HBHE (excluding twrs 28,29)
-    
+        std::pair<DetId, float> mc(detId, e);
+        tower.metaConstituents.push_back(mc);
+
+      }  // not a "bad" channel, energy above threshold
+
+    }  // channel in HBHE (excluding twrs 28,29)
+
   }  // recHit normal case (not in HE towers 28,29)
 
 }  // end of assignHitHcal method
 
-void CaloTowersCreationAlgo::assignHitEcal(const EcalRecHit * recHit) {
+void CaloTowersCreationAlgo::assignHitEcal(const EcalRecHit* recHit) {
   DetId detId = recHit->detid();
 
   unsigned int chStatusForCT;
-  bool ecalIsBad=false;
-  std::tie(chStatusForCT,ecalIsBad) = ecalChanStatusForCaloTower(recHit);
+  bool ecalIsBad = false;
+  std::tie(chStatusForCT, ecalIsBad) = ecalChanStatusForCaloTower(recHit);
 
   // this is for skipping channls: mostly needed for the creation of
   // bad towers from hits i the bad channel collections.
-  if (chStatusForCT==CaloTowersCreationAlgo::IgnoredChan) return;
+  if (chStatusForCT == CaloTowersCreationAlgo::IgnoredChan)
+    return;
 
   double threshold, weight;
   getThresholdAndWeight(detId, threshold, weight);
 
-  double energy = recHit->energy();  // original RecHit energy is used to apply thresholds  
+  double energy = recHit->energy();  // original RecHit energy is used to apply thresholds
   double e = energy * weight;        // energies scaled by user weight: used in energy assignments
-        
+
   /////////////////////////////      unsigned int chStatusForCT = ecalChanStatusForCaloTower(recHit);
-  
-  // For ECAL we count all bad channels after the metatower is complete 
+
+  // For ECAL we count all bad channels after the metatower is complete
 
   // Include options for symmetric thresholds and cut on Et
   // for ECAL RecHits
 
   bool passEmThreshold = false;
-  
-  if (detId.subdetId() == EcalBarrel) {
-    if (theUseEtEBTresholdFlag) energy /= cosh( (theGeometry->getGeometry(detId)->getPosition()).eta() ) ;
-    if (theUseSymEBTresholdFlag) passEmThreshold = (fabs(energy) >= threshold);
-    else  passEmThreshold = (energy >= threshold);
 
-  }
-  else if (detId.subdetId() == EcalEndcap) {
-    if (theUseEtEETresholdFlag) energy /= cosh( (theGeometry->getGeometry(detId)->getPosition()).eta() ) ;
-    if (theUseSymEETresholdFlag) passEmThreshold = (fabs(energy) >= threshold);
-    else  passEmThreshold = (energy >= threshold);
+  if (detId.subdetId() == EcalBarrel) {
+    if (theUseEtEBTresholdFlag)
+      energy /= cosh((theGeometry->getGeometry(detId)->getPosition()).eta());
+    if (theUseSymEBTresholdFlag)
+      passEmThreshold = (fabs(energy) >= threshold);
+    else
+      passEmThreshold = (energy >= threshold);
+
+  } else if (detId.subdetId() == EcalEndcap) {
+    if (theUseEtEETresholdFlag)
+      energy /= cosh((theGeometry->getGeometry(detId)->getPosition()).eta());
+    if (theUseSymEETresholdFlag)
+      passEmThreshold = (fabs(energy) >= threshold);
+    else
+      passEmThreshold = (energy >= threshold);
   }
 
   CaloTowerDetId towerDetId = theTowerConstituentsMap->towerOf(detId);
-  if (towerDetId.null()) return;
-  MetaTower & tower = find(towerDetId);
-
+  if (towerDetId.null())
+    return;
+  MetaTower& tower = find(towerDetId);
 
   // count bad cells and avoid double counting with those from DB (Recovered are counted bad)
 
   // somehow misses some
-  // if ( (chStatusForCT == CaloTowersCreationAlgo::BadChan) & (!ecalIsBad) ) ++tower.numBadEcalCells; 
+  // if ( (chStatusForCT == CaloTowersCreationAlgo::BadChan) & (!ecalIsBad) ) ++tower.numBadEcalCells;
 
   // a bit slower...
-  if ( chStatusForCT == CaloTowersCreationAlgo::BadChan ) {
+  if (chStatusForCT == CaloTowersCreationAlgo::BadChan) {
     auto thisEcalSevLvl = theEcalSevLvlAlgo->severityLevel(detId);
     // check if the Ecal severity is ok to keep
-    auto sevit = std::find(theEcalSeveritiesToBeExcluded.begin(),
-    		       theEcalSeveritiesToBeExcluded.end(),
-    		       thisEcalSevLvl);
-    if (sevit==theEcalSeveritiesToBeExcluded.end()) ++tower.numBadEcalCells;  // notinDB
+    auto sevit = std::find(theEcalSeveritiesToBeExcluded.begin(), theEcalSeveritiesToBeExcluded.end(), thisEcalSevLvl);
+    if (sevit == theEcalSeveritiesToBeExcluded.end())
+      ++tower.numBadEcalCells;  // notinDB
   }
-  
 
   //      if (chStatusForCT != CaloTowersCreationAlgo::BadChan && energy >= threshold) {
   if (chStatusForCT != CaloTowersCreationAlgo::BadChan && passEmThreshold) {
-
     tower.E_em += e;
     tower.E += e;
-    
-    if (chStatusForCT == CaloTowersCreationAlgo::RecoveredChan)  {
-      tower.numRecEcalCells += 1;  
-    }
-    else if (chStatusForCT == CaloTowersCreationAlgo::ProblematicChan) {
+
+    if (chStatusForCT == CaloTowersCreationAlgo::RecoveredChan) {
+      tower.numRecEcalCells += 1;
+    } else if (chStatusForCT == CaloTowersCreationAlgo::ProblematicChan) {
       tower.numProbEcalCells += 1;
     }
-    
+
     // change when full status info is available
     // for now use only good channels
-    
+
     // add e>0 check (new options allow e<0)
-    if (chStatusForCT == CaloTowersCreationAlgo::GoodChan && e>0 ) {
-      tower.emSumTimeTimesE += ( e * recHit->time() );
-      tower.emSumEForTime   += e;  // see above
+    if (chStatusForCT == CaloTowersCreationAlgo::GoodChan && e > 0) {
+      tower.emSumTimeTimesE += (e * recHit->time());
+      tower.emSumEForTime += e;  // see above
     }
 
-    std::pair<DetId,float> mc(detId,e);
+    std::pair<DetId, float> mc(detId, e);
     tower.metaConstituents.push_back(mc);
   }
 }  // end of assignHitEcal method
 
-
-
-
-// This method is not flexible enough for the new CaloTower format. 
-// For now make a quick compatibility "fix" : WILL NOT WORK CORRECTLY with anything 
+// This method is not flexible enough for the new CaloTower format.
+// For now make a quick compatibility "fix" : WILL NOT WORK CORRECTLY with anything
 // except the default simple p4 assignment!!!
 // Must be rewritten for full functionality.
-void CaloTowersCreationAlgo::rescale(const CaloTower * ct) {
+void CaloTowersCreationAlgo::rescale(const CaloTower* ct) {
   double threshold, weight;
   CaloTowerDetId towerDetId = theTowerConstituentsMap->towerOf(ct->id());
-  if (towerDetId.null()) return;
-  MetaTower & tower = find(towerDetId);
+  if (towerDetId.null())
+    return;
+  MetaTower& tower = find(towerDetId);
 
   tower.E_em = 0.;
   tower.E_had = 0.;
   tower.E_outer = 0.;
-  for (unsigned int i=0; i<ct->constituentsSize(); i++) {
+  for (unsigned int i = 0; i < ct->constituentsSize(); i++) {
     DetId detId = ct->constituent(i);
     getThresholdAndWeight(detId, threshold, weight);
     DetId::Detector det = detId.det();
-    if(det == DetId::Ecal) {
-      tower.E_em = ct->emEnergy()*weight;
-    }
-    else {
+    if (det == DetId::Ecal) {
+      tower.E_em = ct->emEnergy() * weight;
+    } else {
       HcalDetId hcalDetId(detId);
-      if(hcalDetId.subdet() == HcalForward) {
-        if (hcalDetId.depth()==1) tower.E_em = ct->emEnergy()*weight;
-        if (hcalDetId.depth()==2) tower.E_had = ct->hadEnergy()*weight;
-      }
-      else if(hcalDetId.subdet() == HcalOuter) {
-        tower.E_outer = ct->outerEnergy()*weight;
-      }
-      else {
-        tower.E_had = ct->hadEnergy()*weight;
+      if (hcalDetId.subdet() == HcalForward) {
+        if (hcalDetId.depth() == 1)
+          tower.E_em = ct->emEnergy() * weight;
+        if (hcalDetId.depth() == 2)
+          tower.E_had = ct->hadEnergy() * weight;
+      } else if (hcalDetId.subdet() == HcalOuter) {
+        tower.E_outer = ct->outerEnergy() * weight;
+      } else {
+        tower.E_had = ct->hadEnergy() * weight;
       }
     }
-    tower.E = tower.E_had+tower.E_em+tower.E_outer;
+    tower.E = tower.E_had + tower.E_em + tower.E_outer;
 
     // this is to be compliant with the new MetaTower setup
     // used only for the default simple vector assignment
@@ -874,256 +899,262 @@ void CaloTowersCreationAlgo::rescale(const CaloTower * ct) {
   }
 
   // preserve time inforamtion
-  tower.emSumTimeTimesE  = ct->ecalTime();
+  tower.emSumTimeTimesE = ct->ecalTime();
   tower.hadSumTimeTimesE = ct->hcalTime();
   tower.emSumEForTime = 1.0;
   tower.hadSumEForTime = 1.0;
 }
 
-
-CaloTowersCreationAlgo::MetaTower & CaloTowersCreationAlgo::find(const CaloTowerDetId & detId) {
+CaloTowersCreationAlgo::MetaTower& CaloTowersCreationAlgo::find(const CaloTowerDetId& detId) {
   if (theTowerMap.empty()) {
     theTowerMap.resize(theTowerTopology->sizeForDenseIndexing());
   }
-  
-  auto & mt = theTowerMap[theTowerTopology->denseIndex(detId)]; 
-  
+
+  auto& mt = theTowerMap[theTowerTopology->denseIndex(detId)];
+
   if (mt.empty()) {
-    mt.id=detId;
-    mt.metaConstituents.reserve(detId.ietaAbs()<theTowerTopology->firstHFRing() ? 12 : 2);
+    mt.id = detId;
+    mt.metaConstituents.reserve(detId.ietaAbs() < theTowerTopology->firstHFRing() ? 12 : 2);
     ++theTowerMapSize;
   }
-  
+
   return mt;
 }
 
+void CaloTowersCreationAlgo::convert(const CaloTowerDetId& id, const MetaTower& mt, CaloTowerCollection& collection) {
+  assert(id.rawId() != 0);
 
-void CaloTowersCreationAlgo::convert(const CaloTowerDetId& id, const MetaTower& mt,
-                                     CaloTowerCollection & collection) 
-{
-    assert(id.rawId()!=0);
+  double ecalThres = (id.ietaAbs() <= 17) ? (theEBSumThreshold) : (theEESumThreshold);
+  double E = mt.E;
+  double E_em = mt.E_em;
+  double E_had = mt.E_had;
+  double E_outer = mt.E_outer;
 
-    double ecalThres=(id.ietaAbs()<=17)?(theEBSumThreshold):(theEESumThreshold);
-    double E=mt.E;
-    double E_em=mt.E_em;
-    double E_had=mt.E_had;
-    double E_outer=mt.E_outer;
+  // Note: E_outer is used to save HO energy OR energy in the outermost depths in endcap region
+  // In the methods with separate treatment of EM and HAD components:
+  //  - HO is not used to determine direction, however HO energy is added to get "total had energy"
+  //  => Check if the tower is within HO coverage before adding E_outer to the "total had" energy
+  //     else the energy will be double counted
+  // When summing up the energy of the tower these checks are performed in the loops over RecHits
 
-    // Note: E_outer is used to save HO energy OR energy in the outermost depths in endcap region
-    // In the methods with separate treatment of EM and HAD components:
-    //  - HO is not used to determine direction, however HO energy is added to get "total had energy"
-    //  => Check if the tower is within HO coverage before adding E_outer to the "total had" energy
-    //     else the energy will be double counted
-    // When summing up the energy of the tower these checks are performed in the loops over RecHits
+  std::vector<std::pair<DetId, float> > metaContains = mt.metaConstituents;
+  if (id.ietaAbs() < theTowerTopology->firstHFRing() && E_em < ecalThres) {  // ignore EM threshold in HF
+    E -= E_em;
+    E_em = 0;
+    std::vector<std::pair<DetId, float> > metaContains_noecal;
 
-    std::vector<std::pair<DetId,float> > metaContains=mt.metaConstituents;
-    if (id.ietaAbs()<theTowerTopology->firstHFRing() && E_em<ecalThres) { // ignore EM threshold in HF
-      E-=E_em;
-      E_em=0;
-      std::vector<std::pair<DetId,float> > metaContains_noecal;
+    for (std::vector<std::pair<DetId, float> >::iterator i = metaContains.begin(); i != metaContains.end(); ++i)
+      if (i->first.det() != DetId::Ecal)
+        metaContains_noecal.push_back(*i);
+    metaContains.swap(metaContains_noecal);
+  }
+  if (id.ietaAbs() < theTowerTopology->firstHFRing() && E_had < theHcalThreshold) {
+    E -= E_had;
 
-    for (std::vector<std::pair<DetId,float> >::iterator i=metaContains.begin(); i!=metaContains.end(); ++i) 
-	        if (i->first.det()!=DetId::Ecal) metaContains_noecal.push_back(*i);
-      metaContains.swap(metaContains_noecal);
+    if (theHOIsUsed && id.ietaAbs() <= theTowerTopology->lastHORing())
+      E -= E_outer;  // not subtracted before, think it should be done
+
+    E_had = 0;
+    E_outer = 0;
+    std::vector<std::pair<DetId, float> > metaContains_nohcal;
+
+    for (std::vector<std::pair<DetId, float> >::iterator i = metaContains.begin(); i != metaContains.end(); ++i)
+      if (i->first.det() != DetId::Hcal)
+        metaContains_nohcal.push_back(*i);
+    metaContains.swap(metaContains_nohcal);
+  }
+
+  if (metaContains.empty())
+    return;
+
+  if (missingHcalRescaleFactorForEcal > 0 && E_had == 0 && E_em > 0) {
+    auto match = hcalDropChMap.find(id);
+    if (match != hcalDropChMap.end() && match->second.second) {
+      E_had = missingHcalRescaleFactorForEcal * E_em;
+      E += E_had;
     }
-    if (id.ietaAbs()<theTowerTopology->firstHFRing() && E_had<theHcalThreshold) {
-      E-=E_had;
+  }
 
-      if (theHOIsUsed && id.ietaAbs()<=theTowerTopology->lastHORing())  E-=E_outer; // not subtracted before, think it should be done
-     
-      E_had=0;
-      E_outer=0;
-      std::vector<std::pair<DetId,float> > metaContains_nohcal;
+  double E_had_tot = (theHOIsUsed && id.ietaAbs() <= theTowerTopology->lastHORing()) ? E_had + E_outer : E_had;
 
-      for (std::vector<std::pair<DetId,float> >::iterator i=metaContains.begin(); i!=metaContains.end(); ++i) 
-        if (i->first.det()!=DetId::Hcal) metaContains_nohcal.push_back(*i);
-      metaContains.swap(metaContains_nohcal);
-    }
+  // create CaloTower using the selected algorithm
 
-    if(metaContains.empty()) return;
+  GlobalPoint emPoint, hadPoint;
 
-    if (missingHcalRescaleFactorForEcal > 0 && E_had == 0 && E_em > 0) {
-        auto match = hcalDropChMap.find(id);
-        if (match != hcalDropChMap.end() && match->second.second) {
-            E_had = missingHcalRescaleFactorForEcal * E_em;
-            E += E_had;
-        }
-    }
+  // this is actually a 4D vector
+  Basic3DVectorF towerP4;
+  bool massless = true;
+  // float mass1=0;
+  float mass2 = 0;
 
-    double E_had_tot = (theHOIsUsed && id.ietaAbs()<=theTowerTopology->lastHORing())? E_had+E_outer : E_had;
+  // conditional assignment of depths for barrel/endcap
+  // Some additional tuning may be required in the transitional region
+  // 14<|iEta|<19
+  double momEmDepth = 0.;
+  double momHadDepth = 0.;
+  if (id.ietaAbs() <= 17) {
+    momHadDepth = theMomHBDepth;
+    momEmDepth = theMomEBDepth;
+  } else {
+    momHadDepth = theMomHEDepth;
+    momEmDepth = theMomEEDepth;
+  }
 
-
-    // create CaloTower using the selected algorithm
-
-    GlobalPoint emPoint, hadPoint;
-
-    // this is actually a 4D vector
-    Basic3DVectorF towerP4;
-    bool massless=true;
-    // float mass1=0;
-    float mass2=0;
-
-    // conditional assignment of depths for barrel/endcap
-    // Some additional tuning may be required in the transitional region
-    // 14<|iEta|<19
-    double momEmDepth = 0.;
-    double momHadDepth = 0.;
-    if (id.ietaAbs()<=17) {
-      momHadDepth = theMomHBDepth;
-      momEmDepth  = theMomEBDepth;
-    }
-    else {
-      momHadDepth = theMomHEDepth;
-      momEmDepth  = theMomEEDepth;
-    }
-
-
-
-    switch (theMomConstrMethod) {
-      
+  switch (theMomConstrMethod) {
       // FIXME  : move to simple cartesian algebra
-    case 0 :
-      {  // Simple 4-momentum assignment
-	GlobalPoint p=theTowerGeometry->getGeometry(id)->getPosition();
-	towerP4 = p.basicVector().unit();
-	towerP4[3] = 1.f;  // energy
-	towerP4 *=E;
-	
-	// double pf=1.0/cosh(p.eta());
-	// if (E>0) towerP4 = CaloTower::PolarLorentzVector(E*pf, p.eta(), p.phi(), 0);
-	
-	emPoint  = p;   
-	hadPoint = p;
-      }  // end case 0
-      break;
-      
-    case 1 :
-      {   // separate 4-vectors for ECAL, HCAL, add to get the 4-vector of the tower (=>tower has mass!)
-	if (id.ietaAbs()<theTowerTopology->firstHFRing()) {
-          Basic3DVectorF emP4;
-	  if (E_em>0) {
-	    emPoint   = emShwrPos(metaContains, momEmDepth, E_em);
-	    emP4 = emPoint.basicVector().unit();
-	    emP4[3] = 1.f;  // energy
-	    towerP4 = emP4*E_em;
-	    
-	    // double emPf = 1.0/cosh(emPoint.eta());
-	    // towerP4 += CaloTower::PolarLorentzVector(E_em*emPf, emPoint.eta(), emPoint.phi(), 0); 
-	  }
-	  if ( (E_had + E_outer) >0) {
-            massless = (E_em<=0);
-	    hadPoint  = hadShwrPos(id, momHadDepth);
-	    auto lP4 = hadPoint.basicVector().unit();
-	    lP4[3] = 1.f;  // energy
-            if (!massless) {
-              auto diff = lP4-emP4;  mass2 = std::sqrt(E_em*E_had_tot*diff.mag2()); 
-            }
-	    lP4 *=E_had_tot;
-	    towerP4 +=lP4;
-            /*
+    case 0: {  // Simple 4-momentum assignment
+      GlobalPoint p = theTowerGeometry->getGeometry(id)->getPosition();
+      towerP4 = p.basicVector().unit();
+      towerP4[3] = 1.f;  // energy
+      towerP4 *= E;
+
+      // double pf=1.0/cosh(p.eta());
+      // if (E>0) towerP4 = CaloTower::PolarLorentzVector(E*pf, p.eta(), p.phi(), 0);
+
+      emPoint = p;
+      hadPoint = p;
+    }  // end case 0
+    break;
+
+    case 1: {  // separate 4-vectors for ECAL, HCAL, add to get the 4-vector of the tower (=>tower has mass!)
+      if (id.ietaAbs() < theTowerTopology->firstHFRing()) {
+        Basic3DVectorF emP4;
+        if (E_em > 0) {
+          emPoint = emShwrPos(metaContains, momEmDepth, E_em);
+          emP4 = emPoint.basicVector().unit();
+          emP4[3] = 1.f;  // energy
+          towerP4 = emP4 * E_em;
+
+          // double emPf = 1.0/cosh(emPoint.eta());
+          // towerP4 += CaloTower::PolarLorentzVector(E_em*emPf, emPoint.eta(), emPoint.phi(), 0);
+        }
+        if ((E_had + E_outer) > 0) {
+          massless = (E_em <= 0);
+          hadPoint = hadShwrPos(id, momHadDepth);
+          auto lP4 = hadPoint.basicVector().unit();
+          lP4[3] = 1.f;  // energy
+          if (!massless) {
+            auto diff = lP4 - emP4;
+            mass2 = std::sqrt(E_em * E_had_tot * diff.mag2());
+          }
+          lP4 *= E_had_tot;
+          towerP4 += lP4;
+          /*
             if (!massless) {
                auto p = towerP4;
                double m2 = double(p[3]*p[3]) - double(p[0]*p[0])+double(p[1]*p[1])+double(p[2]*p[2]); mass1 = m2>0 ? std::sqrt(m2) : 0;
             }	    
             */
-	    // double hadPf = 1.0/cosh(hadPoint.eta());	  
-	    // if (E_had_tot>0) {
-	    //  towerP4 += CaloTower::PolarLorentzVector(E_had_tot*hadPf, hadPoint.eta(), hadPoint.phi(), 0); 
-	    // }
-	  }
-	}
-	else {  // forward detector: use the CaloTower position 
-	  GlobalPoint p=theTowerGeometry->getGeometry(id)->getPosition();
-	  towerP4 = p.basicVector().unit();
-	  towerP4[3] = 1.f;  // energy
-	  towerP4 *=E;
-	  // double pf=1.0/cosh(p.eta());
-	  // if (E>0) towerP4 = CaloTower::PolarLorentzVector(E*pf, p.eta(), p.phi(), 0);  // simple momentum assignment, same position
-	  emPoint  = p;   
-	  hadPoint = p;
-	}
-      }  // end case 1
-      break;
-      
-    case 2:
-      {   // use ECAL position for the tower (when E_cal>0), else default CaloTower position (massless tower)
-	if (id.ietaAbs()<theTowerTopology->firstHFRing()) {
-	  if (E_em>0)  emPoint = emShwrLogWeightPos(metaContains, momEmDepth, E_em);
-	  else emPoint = theTowerGeometry->getGeometry(id)->getPosition();
-	  towerP4 = emPoint.basicVector().unit();
-	  towerP4[3] = 1.f;  // energy
-	  towerP4 *=E;
-	  
-	  // double sumPf = 1.0/cosh(emPoint.eta());
-	  /// if (E>0) towerP4 = CaloTower::PolarLorentzVector(E*sumPf, emPoint.eta(), emPoint.phi(), 0); 
-	  
-	  hadPoint = emPoint;
-	}
-	else {  // forward detector: use the CaloTower position 
-	  GlobalPoint p=theTowerGeometry->getGeometry(id)->getPosition();
-	  towerP4 = p.basicVector().unit();
-	  towerP4[3] = 1.f;  // energy
-	  towerP4 *=E;
-	  
-	  // double pf=1.0/cosh(p.eta());
-	  // if (E>0) towerP4 = CaloTower::PolarLorentzVector(E*pf, p.eta(), p.phi(), 0);  // simple momentum assignment, same position
-	  emPoint  = p;   
-	  hadPoint = p;
-	}
-      }   // end case 2
-      break;
-      
-    }  // end of decision on p4 reconstruction method
-    
-    
-    // insert in collection (remove and return if below threshold)
-    if UNLIKELY ( (towerP4[3]==0) & (E_outer>0)  ) {
-        float val = theHOIsUsed ? 0 : 1E-9; // to keep backwards compatibility for theHOIsUsed == true
-        collection.emplace_back(id, E_em, E_had, E_outer, -1, -1, CaloTower::PolarLorentzVector(val,hadPoint.eta(), hadPoint.phi(),0),  emPoint, hadPoint); 
-    } else {
-      collection.emplace_back(id, E_em, E_had, E_outer, -1, -1, GlobalVector(towerP4), towerP4[3], mass2, emPoint, hadPoint);
+          // double hadPf = 1.0/cosh(hadPoint.eta());
+          // if (E_had_tot>0) {
+          //  towerP4 += CaloTower::PolarLorentzVector(E_had_tot*hadPf, hadPoint.eta(), hadPoint.phi(), 0);
+          // }
+        }
+      } else {  // forward detector: use the CaloTower position
+        GlobalPoint p = theTowerGeometry->getGeometry(id)->getPosition();
+        towerP4 = p.basicVector().unit();
+        towerP4[3] = 1.f;  // energy
+        towerP4 *= E;
+        // double pf=1.0/cosh(p.eta());
+        // if (E>0) towerP4 = CaloTower::PolarLorentzVector(E*pf, p.eta(), p.phi(), 0);  // simple momentum assignment, same position
+        emPoint = p;
+        hadPoint = p;
+      }
+    }  // end case 1
+    break;
+
+    case 2: {  // use ECAL position for the tower (when E_cal>0), else default CaloTower position (massless tower)
+      if (id.ietaAbs() < theTowerTopology->firstHFRing()) {
+        if (E_em > 0)
+          emPoint = emShwrLogWeightPos(metaContains, momEmDepth, E_em);
+        else
+          emPoint = theTowerGeometry->getGeometry(id)->getPosition();
+        towerP4 = emPoint.basicVector().unit();
+        towerP4[3] = 1.f;  // energy
+        towerP4 *= E;
+
+        // double sumPf = 1.0/cosh(emPoint.eta());
+        /// if (E>0) towerP4 = CaloTower::PolarLorentzVector(E*sumPf, emPoint.eta(), emPoint.phi(), 0);
+
+        hadPoint = emPoint;
+      } else {  // forward detector: use the CaloTower position
+        GlobalPoint p = theTowerGeometry->getGeometry(id)->getPosition();
+        towerP4 = p.basicVector().unit();
+        towerP4[3] = 1.f;  // energy
+        towerP4 *= E;
+
+        // double pf=1.0/cosh(p.eta());
+        // if (E>0) towerP4 = CaloTower::PolarLorentzVector(E*pf, p.eta(), p.phi(), 0);  // simple momentum assignment, same position
+        emPoint = p;
+        hadPoint = p;
+      }
+    }  // end case 2
+    break;
+
+  }  // end of decision on p4 reconstruction method
+
+  // insert in collection (remove and return if below threshold)
+  if
+    UNLIKELY((towerP4[3] == 0) & (E_outer > 0)) {
+      float val = theHOIsUsed ? 0 : 1E-9;  // to keep backwards compatibility for theHOIsUsed == true
+      collection.emplace_back(id,
+                              E_em,
+                              E_had,
+                              E_outer,
+                              -1,
+                              -1,
+                              CaloTower::PolarLorentzVector(val, hadPoint.eta(), hadPoint.phi(), 0),
+                              emPoint,
+                              hadPoint);
     }
-    auto & caloTower = collection.back();
+  else {
+    collection.emplace_back(
+        id, E_em, E_had, E_outer, -1, -1, GlobalVector(towerP4), towerP4[3], mass2, emPoint, hadPoint);
+  }
+  auto& caloTower = collection.back();
 
-    // if (!massless) std::cout << "massive " << id <<' ' << mass1 <<' ' << mass2 <<' ' <<  caloTower.mass() << std::endl;
-    // std::cout << "CaloTowerVI " <<theMomConstrMethod <<' ' << id <<' '<< E_em <<' '<< E_had <<' '<< E_outer <<' '<< GlobalVector(towerP4) <<' '<< towerP4[3] <<' '<< emPoint <<' '<< hadPoint << std::endl;
-    //if (towerP4[3]==0) std::cout << "CaloTowerVIzero " << theEcutTower << ' ' << collection.back().eta() <<' '<< collection.back().phi() << std::endl;
+  // if (!massless) std::cout << "massive " << id <<' ' << mass1 <<' ' << mass2 <<' ' <<  caloTower.mass() << std::endl;
+  // std::cout << "CaloTowerVI " <<theMomConstrMethod <<' ' << id <<' '<< E_em <<' '<< E_had <<' '<< E_outer <<' '<< GlobalVector(towerP4) <<' '<< towerP4[3] <<' '<< emPoint <<' '<< hadPoint << std::endl;
+  //if (towerP4[3]==0) std::cout << "CaloTowerVIzero " << theEcutTower << ' ' << collection.back().eta() <<' '<< collection.back().phi() << std::endl;
 
-    if(caloTower.energy() < theEcutTower) { collection.pop_back(); return;}
-    
-    // set the timings
-    float  ecalTime = (mt.emSumEForTime>0)?   mt.emSumTimeTimesE/mt.emSumEForTime  : -9999;
-    float  hcalTime = (mt.hadSumEForTime>0)?  mt.hadSumTimeTimesE/mt.hadSumEForTime : -9999;
-    caloTower.setEcalTime(compactTime(ecalTime));
-    caloTower.setHcalTime(compactTime(hcalTime));
-    //add topology info
-    caloTower.setHcalSubdet(theTowerTopology->lastHBRing(),
-                            theTowerTopology->lastHERing(),
-                            theTowerTopology->lastHFRing(),
-                            theTowerTopology->lastHORing() );
+  if (caloTower.energy() < theEcutTower) {
+    collection.pop_back();
+    return;
+  }
 
-    // set the CaloTower status word =====================================
-    // Channels must be counter exclusively in the defined cathegories
-    // "Bad" channels (not used in energy assignment) can be flagged during
-    // CaloTower creation only if specified in the configuration file
+  // set the timings
+  float ecalTime = (mt.emSumEForTime > 0) ? mt.emSumTimeTimesE / mt.emSumEForTime : -9999;
+  float hcalTime = (mt.hadSumEForTime > 0) ? mt.hadSumTimeTimesE / mt.hadSumEForTime : -9999;
+  caloTower.setEcalTime(compactTime(ecalTime));
+  caloTower.setHcalTime(compactTime(hcalTime));
+  //add topology info
+  caloTower.setHcalSubdet(theTowerTopology->lastHBRing(),
+                          theTowerTopology->lastHERing(),
+                          theTowerTopology->lastHFRing(),
+                          theTowerTopology->lastHORing());
 
-    unsigned int numBadHcalChan  = mt.numBadHcalCells;
-    //    unsigned int numBadEcalChan  = mt.numBadEcalCells;
-    unsigned int numBadEcalChan  = 0;   //
+  // set the CaloTower status word =====================================
+  // Channels must be counter exclusively in the defined cathegories
+  // "Bad" channels (not used in energy assignment) can be flagged during
+  // CaloTower creation only if specified in the configuration file
 
-    unsigned int numRecHcalChan  = mt.numRecHcalCells;
-    unsigned int numRecEcalChan  = mt.numRecEcalCells;
-    unsigned int numProbHcalChan = mt.numProbHcalCells;
-    unsigned int numProbEcalChan = mt.numProbEcalCells;
+  unsigned int numBadHcalChan = mt.numBadHcalCells;
+  //    unsigned int numBadEcalChan  = mt.numBadEcalCells;
+  unsigned int numBadEcalChan = 0;  //
 
-    // now add dead/off/... channels not used in RecHit reconstruction for HCAL 
-    HcalDropChMap::iterator dropChItr = hcalDropChMap.find(id);
-    if (dropChItr != hcalDropChMap.end()) numBadHcalChan += dropChItr->second.first;
-    
+  unsigned int numRecHcalChan = mt.numRecHcalCells;
+  unsigned int numRecEcalChan = mt.numRecEcalCells;
+  unsigned int numProbHcalChan = mt.numProbHcalCells;
+  unsigned int numProbEcalChan = mt.numProbEcalCells;
 
-    // for ECAL the number of all bad channels is obtained here -----------------------
+  // now add dead/off/... channels not used in RecHit reconstruction for HCAL
+  HcalDropChMap::iterator dropChItr = hcalDropChMap.find(id);
+  if (dropChItr != hcalDropChMap.end())
+    numBadHcalChan += dropChItr->second.first;
 
-    /*
+  // for ECAL the number of all bad channels is obtained here -----------------------
+
+  /*
     // old hyper slow algorithm    
     // get all possible constituents of the tower
     std::vector<DetId> allConstituents = theTowerConstituentsMap->constituentsOf(id);
@@ -1170,202 +1201,210 @@ void CaloTowersCreationAlgo::convert(const CaloTowerDetId& id, const MetaTower& 
 		 << " " << mt.numBadEcalCells << " " << mt.numRecEcalCells << std::endl;
      }
      */
-     
-     numBadEcalChan =  ecalBadChs[theTowerTopology->denseIndex(id)]+mt.numBadEcalCells; // - mt.numRecEcalCells
 
-    //--------------------------------------------------------------------------------------
+  numBadEcalChan = ecalBadChs[theTowerTopology->denseIndex(id)] + mt.numBadEcalCells;  // - mt.numRecEcalCells
 
-    caloTower.setCaloTowerStatus(numBadHcalChan, numBadEcalChan,	 
-			      numRecHcalChan, numRecEcalChan,	 
-			      numProbHcalChan, numProbEcalChan);
-  
-    double maxCellE = -999.0; // for storing the hottest cell E in the calotower
+  //--------------------------------------------------------------------------------------
 
-    std::vector<DetId> contains;
-    contains.reserve(metaContains.size());
-    for (std::vector<std::pair<DetId,float> >::iterator i=metaContains.begin(); i!=metaContains.end(); ++i) {
+  caloTower.setCaloTowerStatus(
+      numBadHcalChan, numBadEcalChan, numRecHcalChan, numRecEcalChan, numProbHcalChan, numProbEcalChan);
 
-      contains.push_back(i->first);
+  double maxCellE = -999.0;  // for storing the hottest cell E in the calotower
 
-      if (maxCellE < i->second) {
-	// need an extra check because of the funny towers that are empty except for the presence of an HO
-	// hit in the constituents (JetMET wanted them saved)
-	// This constituent is only used for storing the tower, but should not be concidered as a hot cell canditate for
-	// configurations with useHO = false
+  std::vector<DetId> contains;
+  contains.reserve(metaContains.size());
+  for (std::vector<std::pair<DetId, float> >::iterator i = metaContains.begin(); i != metaContains.end(); ++i) {
+    contains.push_back(i->first);
 
+    if (maxCellE < i->second) {
+      // need an extra check because of the funny towers that are empty except for the presence of an HO
+      // hit in the constituents (JetMET wanted them saved)
+      // This constituent is only used for storing the tower, but should not be concidered as a hot cell canditate for
+      // configurations with useHO = false
 
-	if (i->first.det()==DetId::Ecal) {  // ECAL
-	  maxCellE = i->second;
-	}	
-	else {  // HCAL
-	  if (HcalDetId(i->first).subdet() != HcalOuter) 
-	    maxCellE = i->second;
-	  else if (theHOIsUsed) maxCellE = i->second;
-	}
+      if (i->first.det() == DetId::Ecal) {  // ECAL
+        maxCellE = i->second;
+      } else {  // HCAL
+        if (HcalDetId(i->first).subdet() != HcalOuter)
+          maxCellE = i->second;
+        else if (theHOIsUsed)
+          maxCellE = i->second;
+      }
 
-      } // found higher E cell
+    }  // found higher E cell
 
-    } // loop over matacontains
+  }  // loop over matacontains
 
-    caloTower.setConstituents(std::move(contains));
-    caloTower.setHottestCellE(maxCellE);
+  caloTower.setConstituents(std::move(contains));
+  caloTower.setHottestCellE(maxCellE);
 
-    // std::cout << "CaloTowerVI " << nalgo << ' ' << caloTower.id() << ((inEcals[1]==1) ? "EE " : " " )  << caloTower.pt() << ' ' << caloTower.et() << ' ' << caloTower.mass() << ' '
-    //           << caloTower.constituentsSize() <<' '<< caloTower.towerStatusWord() << std::endl;
+  // std::cout << "CaloTowerVI " << nalgo << ' ' << caloTower.id() << ((inEcals[1]==1) ? "EE " : " " )  << caloTower.pt() << ' ' << caloTower.et() << ' ' << caloTower.mass() << ' '
+  //           << caloTower.constituentsSize() <<' '<< caloTower.towerStatusWord() << std::endl;
+}
 
-} 
-
-
-
-void CaloTowersCreationAlgo::getThresholdAndWeight(const DetId & detId, double & threshold, double & weight) const {
+void CaloTowersCreationAlgo::getThresholdAndWeight(const DetId& detId, double& threshold, double& weight) const {
   DetId::Detector det = detId.det();
-  weight=0; // in case the hit is not identified
+  weight = 0;  // in case the hit is not identified
 
-  if(det == DetId::Ecal) {
+  if (det == DetId::Ecal) {
     // may or may not be EB.  We'll find out.
 
     EcalSubdetector subdet = (EcalSubdetector)(detId.subdetId());
-    if(subdet == EcalBarrel) {
+    if (subdet == EcalBarrel) {
       threshold = theEBthreshold;
       weight = theEBweight;
       if (weight <= 0.) {
-        ROOT::Math::Interpolator my(theEBGrid,theEBWeights,ROOT::Math::Interpolation::kAKIMA);
+        ROOT::Math::Interpolator my(theEBGrid, theEBWeights, ROOT::Math::Interpolation::kAKIMA);
         weight = my.Eval(theEBEScale);
       }
-    }
-    else if(subdet == EcalEndcap) {
+    } else if (subdet == EcalEndcap) {
       threshold = theEEthreshold;
       weight = theEEweight;
       if (weight <= 0.) {
-        ROOT::Math::Interpolator my(theEEGrid,theEEWeights,ROOT::Math::Interpolation::kAKIMA);
+        ROOT::Math::Interpolator my(theEEGrid, theEEWeights, ROOT::Math::Interpolation::kAKIMA);
         weight = my.Eval(theEEEScale);
       }
     }
-  }
-  else if(det == DetId::Hcal) {
+  } else if (det == DetId::Hcal) {
     HcalDetId hcalDetId(detId);
     HcalSubdetector subdet = hcalDetId.subdet();
-    int depth =  hcalDetId.depth();   
+    int depth = hcalDetId.depth();
 
-    if(subdet == HcalBarrel) {
+    if (subdet == HcalBarrel) {
       threshold = (depth == 1) ? theHBthreshold1 : (depth == 2) ? theHBthreshold2 : theHBthreshold;
       weight = theHBweight;
       if (weight <= 0.) {
-        ROOT::Math::Interpolator my(theHBGrid,theHBWeights,ROOT::Math::Interpolation::kAKIMA);
+        ROOT::Math::Interpolator my(theHBGrid, theHBWeights, ROOT::Math::Interpolation::kAKIMA);
         weight = my.Eval(theHBEScale);
       }
     }
-    
-    else if(subdet == HcalEndcap) {
+
+    else if (subdet == HcalEndcap) {
       // check if it's single or double tower
-      if(hcalDetId.ietaAbs() < theHcalTopology->firstHEDoublePhiRing()) {
+      if (hcalDetId.ietaAbs() < theHcalTopology->firstHEDoublePhiRing()) {
         threshold = (depth == 1) ? theHESthreshold1 : theHESthreshold;
         weight = theHESweight;
         if (weight <= 0.) {
-          ROOT::Math::Interpolator my(theHESGrid,theHESWeights,ROOT::Math::Interpolation::kAKIMA);
+          ROOT::Math::Interpolator my(theHESGrid, theHESWeights, ROOT::Math::Interpolation::kAKIMA);
           weight = my.Eval(theHESEScale);
         }
-      }
-      else {        
+      } else {
         threshold = (depth == 1) ? theHEDthreshold1 : theHEDthreshold;
         weight = theHEDweight;
         if (weight <= 0.) {
-          ROOT::Math::Interpolator my(theHEDGrid,theHEDWeights,ROOT::Math::Interpolation::kAKIMA);
+          ROOT::Math::Interpolator my(theHEDGrid, theHEDWeights, ROOT::Math::Interpolation::kAKIMA);
           weight = my.Eval(theHEDEScale);
         }
       }
     }
-    
-    else if(subdet == HcalOuter) {
+
+    else if (subdet == HcalOuter) {
       //check if it's ring 0 or +1 or +2 or -1 or -2
-      if(hcalDetId.ietaAbs() <= 4) threshold = theHOthreshold0;
-      else if(hcalDetId.ieta() < 0) {
-	// set threshold for ring -1 or -2
-	threshold = (hcalDetId.ietaAbs() <= 10) ?  theHOthresholdMinus1 : theHOthresholdMinus2;
+      if (hcalDetId.ietaAbs() <= 4)
+        threshold = theHOthreshold0;
+      else if (hcalDetId.ieta() < 0) {
+        // set threshold for ring -1 or -2
+        threshold = (hcalDetId.ietaAbs() <= 10) ? theHOthresholdMinus1 : theHOthresholdMinus2;
       } else {
-	// set threshold for ring +1 or +2
-	threshold = (hcalDetId.ietaAbs() <= 10) ?  theHOthresholdPlus1 : theHOthresholdPlus2;
+        // set threshold for ring +1 or +2
+        threshold = (hcalDetId.ietaAbs() <= 10) ? theHOthresholdPlus1 : theHOthresholdPlus2;
       }
       weight = theHOweight;
       if (weight <= 0.) {
-        ROOT::Math::Interpolator my(theHOGrid,theHOWeights,ROOT::Math::Interpolation::kAKIMA);
+        ROOT::Math::Interpolator my(theHOGrid, theHOWeights, ROOT::Math::Interpolation::kAKIMA);
         weight = my.Eval(theHOEScale);
       }
-    } 
+    }
 
-    else if(subdet == HcalForward) {
-      if(hcalDetId.depth() == 1) {
+    else if (subdet == HcalForward) {
+      if (hcalDetId.depth() == 1) {
         threshold = theHF1threshold;
         weight = theHF1weight;
         if (weight <= 0.) {
-          ROOT::Math::Interpolator my(theHF1Grid,theHF1Weights,ROOT::Math::Interpolation::kAKIMA);
+          ROOT::Math::Interpolator my(theHF1Grid, theHF1Weights, ROOT::Math::Interpolation::kAKIMA);
           weight = my.Eval(theHF1EScale);
         }
       } else {
         threshold = theHF2threshold;
         weight = theHF2weight;
         if (weight <= 0.) {
-          ROOT::Math::Interpolator my(theHF2Grid,theHF2Weights,ROOT::Math::Interpolation::kAKIMA);
+          ROOT::Math::Interpolator my(theHF2Grid, theHF2Weights, ROOT::Math::Interpolation::kAKIMA);
           weight = my.Eval(theHF2EScale);
         }
       }
     }
-  }
-  else {
+  } else {
     edm::LogError("CaloTowersCreationAlgo") << "Bad cell: " << det << std::endl;
   }
 }
 
-void CaloTowersCreationAlgo::setEBEScale(double scale){
-  if (scale>0.00001) *&theEBEScale = scale;
-  else *&theEBEScale = 50.;
+void CaloTowersCreationAlgo::setEBEScale(double scale) {
+  if (scale > 0.00001)
+    *&theEBEScale = scale;
+  else
+    *&theEBEScale = 50.;
 }
 
-void CaloTowersCreationAlgo::setEEEScale(double scale){
-  if (scale>0.00001) *&theEEEScale = scale;
-  else *&theEEEScale = 50.;
+void CaloTowersCreationAlgo::setEEEScale(double scale) {
+  if (scale > 0.00001)
+    *&theEEEScale = scale;
+  else
+    *&theEEEScale = 50.;
 }
 
-void CaloTowersCreationAlgo::setHBEScale(double scale){
-  if (scale>0.00001) *&theHBEScale = scale;
-  else *&theHBEScale = 50.;
+void CaloTowersCreationAlgo::setHBEScale(double scale) {
+  if (scale > 0.00001)
+    *&theHBEScale = scale;
+  else
+    *&theHBEScale = 50.;
 }
 
-void CaloTowersCreationAlgo::setHESEScale(double scale){
-  if (scale>0.00001) *&theHESEScale = scale;
-  else *&theHESEScale = 50.;
+void CaloTowersCreationAlgo::setHESEScale(double scale) {
+  if (scale > 0.00001)
+    *&theHESEScale = scale;
+  else
+    *&theHESEScale = 50.;
 }
 
-void CaloTowersCreationAlgo::setHEDEScale(double scale){
-  if (scale>0.00001) *&theHEDEScale = scale;
-  else *&theHEDEScale = 50.;
+void CaloTowersCreationAlgo::setHEDEScale(double scale) {
+  if (scale > 0.00001)
+    *&theHEDEScale = scale;
+  else
+    *&theHEDEScale = 50.;
 }
 
-void CaloTowersCreationAlgo::setHOEScale(double scale){
-  if (scale>0.00001) *&theHOEScale = scale;
-  else *&theHOEScale = 50.;
+void CaloTowersCreationAlgo::setHOEScale(double scale) {
+  if (scale > 0.00001)
+    *&theHOEScale = scale;
+  else
+    *&theHOEScale = 50.;
 }
 
-void CaloTowersCreationAlgo::setHF1EScale(double scale){
-  if (scale>0.00001) *&theHF1EScale = scale;
-  else *&theHF1EScale = 50.;
+void CaloTowersCreationAlgo::setHF1EScale(double scale) {
+  if (scale > 0.00001)
+    *&theHF1EScale = scale;
+  else
+    *&theHF1EScale = 50.;
 }
 
-void CaloTowersCreationAlgo::setHF2EScale(double scale){
-  if (scale>0.00001) *&theHF2EScale = scale;
-  else *&theHF2EScale = 50.;
+void CaloTowersCreationAlgo::setHF2EScale(double scale) {
+  if (scale > 0.00001)
+    *&theHF2EScale = scale;
+  else
+    *&theHF2EScale = 50.;
 }
-
 
 GlobalPoint CaloTowersCreationAlgo::emCrystalShwrPos(DetId detId, float fracDepth) {
   auto cellGeometry = theGeometry->getGeometry(detId);
   GlobalPoint point = cellGeometry->getPosition();  // face of the cell
 
-  if (fracDepth<=0) return point;
-  if (fracDepth>1) fracDepth=1;
+  if (fracDepth <= 0)
+    return point;
+  if (fracDepth > 1)
+    fracDepth = 1;
 
   const GlobalPoint& backPoint = cellGeometry->getBackPoint();
-  point += fracDepth * (backPoint-point);
+  point += fracDepth * (backPoint - point);
 
   return point;
 }
@@ -1375,18 +1414,17 @@ GlobalPoint CaloTowersCreationAlgo::hadSegmentShwrPos(DetId detId, float fracDep
   return emCrystalShwrPos(detId, fracDepth);
 }
 
-
-GlobalPoint CaloTowersCreationAlgo::hadShwrPos(const std::vector<std::pair<DetId,float> >& metaContains,
-                                               float fracDepth, double hadE) {
-                                                  
+GlobalPoint CaloTowersCreationAlgo::hadShwrPos(const std::vector<std::pair<DetId, float> >& metaContains,
+                                               float fracDepth,
+                                               double hadE) {
   // this is based on available RecHits, can lead to different actual depths if
   // hits in multi-depth towers are not all there
 #ifdef EDM_ML_DEBUG
-  std::cout << "hadShwrPos called with " << metaContains.size()
-	    << " elements and energy " << hadE << ":" << fracDepth
-	    << std::endl;
+  std::cout << "hadShwrPos called with " << metaContains.size() << " elements and energy " << hadE << ":" << fracDepth
+            << std::endl;
 #endif
-  if (hadE<=0) return GlobalPoint(0,0,0);
+  if (hadE <= 0)
+    return GlobalPoint(0, 0, 0);
 
   double hadX = 0.0;
   double hadY = 0.0;
@@ -1394,11 +1432,13 @@ GlobalPoint CaloTowersCreationAlgo::hadShwrPos(const std::vector<std::pair<DetId
 
   int nConst = 0;
 
-  std::vector<std::pair<DetId,float> >::const_iterator mc_it = metaContains.begin();
-  for (; mc_it!=metaContains.end(); ++mc_it) {
-    if (mc_it->first.det() != DetId::Hcal) continue;
+  std::vector<std::pair<DetId, float> >::const_iterator mc_it = metaContains.begin();
+  for (; mc_it != metaContains.end(); ++mc_it) {
+    if (mc_it->first.det() != DetId::Hcal)
+      continue;
     // do not use HO for deirection calculations for now
-    if (HcalDetId(mc_it->first).subdet() == HcalOuter) continue;
+    if (HcalDetId(mc_it->first).subdet() == HcalOuter)
+      continue;
     ++nConst;
 
     GlobalPoint p = hadSegmentShwrPos(mc_it->first, fracDepth);
@@ -1410,12 +1450,10 @@ GlobalPoint CaloTowersCreationAlgo::hadShwrPos(const std::vector<std::pair<DetId
     hadZ += p.z();
   }
 
-   return GlobalPoint(hadX/nConst, hadY/nConst, hadZ/nConst);
+  return GlobalPoint(hadX / nConst, hadY / nConst, hadZ / nConst);
 }
 
-
 GlobalPoint CaloTowersCreationAlgo::hadShwrPos(CaloTowerDetId towerId, float fracDepth) {
-
   // set depth using geometry of cells that are associated with the
   // tower (regardless if they have non-zero energies)
 
@@ -1423,63 +1461,71 @@ GlobalPoint CaloTowersCreationAlgo::hadShwrPos(CaloTowerDetId towerId, float fra
 #ifdef EDM_ML_DEBUG
   std::cout << "hadShwrPos " << towerId << " frac " << fracDepth << std::endl;
 #endif
-  if      (fracDepth < 0) fracDepth = 0;
-  else if (fracDepth > 1) fracDepth = 1;
+  if (fracDepth < 0)
+    fracDepth = 0;
+  else if (fracDepth > 1)
+    fracDepth = 1;
 
-  GlobalPoint point(0,0,0);
+  GlobalPoint point(0, 0, 0);
 
   int iEta = towerId.ieta();
   int iPhi = towerId.iphi();
 
   HcalDetId frontCellId, backCellId;
 
-  if(towerId.ietaAbs() >= theTowerTopology->firstHFRing()){
+  if (towerId.ietaAbs() >= theTowerTopology->firstHFRing()) {
     // forward, take the geometry for long fibers
-    frontCellId = HcalDetId(HcalForward, towerId.zside()*theTowerTopology->convertCTtoHcal(abs(iEta)), iPhi, 1);
-    backCellId  = HcalDetId(HcalForward, towerId.zside()*theTowerTopology->convertCTtoHcal(abs(iEta)), iPhi, 1);    
-  }
-  else {
+    frontCellId = HcalDetId(HcalForward, towerId.zside() * theTowerTopology->convertCTtoHcal(abs(iEta)), iPhi, 1);
+    backCellId = HcalDetId(HcalForward, towerId.zside() * theTowerTopology->convertCTtoHcal(abs(iEta)), iPhi, 1);
+  } else {
     //use constituents map
     std::vector<DetId> items = theTowerConstituentsMap->constituentsOf(towerId);
     int frontDepth = 1000;
     int backDepth = -1000;
-    for(unsigned i = 0; i < items.size(); i++){
-      if(items[i].det()!=DetId::Hcal) continue;
+    for (unsigned i = 0; i < items.size(); i++) {
+      if (items[i].det() != DetId::Hcal)
+        continue;
       HcalDetId hid(items[i]);
-      if(hid.subdet() == HcalOuter) continue;
-      if(!theHcalTopology->validHcal(hid,2)) continue;
-	  
-      if (theHcalTopology->idFront(hid).depth()<frontDepth) { 
-	frontCellId = hid; 
-	frontDepth  = theHcalTopology->idFront(hid).depth();
+      if (hid.subdet() == HcalOuter)
+        continue;
+      if (!theHcalTopology->validHcal(hid, 2))
+        continue;
+
+      if (theHcalTopology->idFront(hid).depth() < frontDepth) {
+        frontCellId = hid;
+        frontDepth = theHcalTopology->idFront(hid).depth();
       }
-      if (theHcalTopology->idBack(hid).depth()>backDepth) { 
-	backCellId = hid; 
-	backDepth  = theHcalTopology->idBack(hid).depth();
+      if (theHcalTopology->idBack(hid).depth() > backDepth) {
+        backCellId = hid;
+        backDepth = theHcalTopology->idBack(hid).depth();
       }
     }
 #ifdef EDM_ML_DEBUG
-    std::cout << "Front " << frontCellId << " Back " << backCellId
-	      << " Depths " << frontDepth << ":" << backDepth << std::endl;
+    std::cout << "Front " << frontCellId << " Back " << backCellId << " Depths " << frontDepth << ":" << backDepth
+              << std::endl;
 #endif
     //fix for tower 28/29 - no tower 29 at highest depths
-    if(towerId.ietaAbs()==theTowerTopology->lastHERing() && (theHcalPhase==0 || theHcalPhase==1)){
-      CaloTowerDetId towerId28(towerId.ieta()-towerId.zside(),towerId.iphi());
+    if (towerId.ietaAbs() == theTowerTopology->lastHERing() && (theHcalPhase == 0 || theHcalPhase == 1)) {
+      CaloTowerDetId towerId28(towerId.ieta() - towerId.zside(), towerId.iphi());
       std::vector<DetId> items28 = theTowerConstituentsMap->constituentsOf(towerId28);
 #ifdef EDM_ML_DEBUG
-      std::cout << towerId28 << " with " << items28.size() <<" constituents:";
-      for (unsigned k=0; k<items28.size(); ++k)
-	if (items28[k].det()==DetId::Hcal) std::cout << " " << HcalDetId(items28[k]);
+      std::cout << towerId28 << " with " << items28.size() << " constituents:";
+      for (unsigned k = 0; k < items28.size(); ++k)
+        if (items28[k].det() == DetId::Hcal)
+          std::cout << " " << HcalDetId(items28[k]);
       std::cout << std::endl;
 #endif
-      for(unsigned i = 0; i < items28.size(); i++){
-        if(items28[i].det()!=DetId::Hcal) continue;
+      for (unsigned i = 0; i < items28.size(); i++) {
+        if (items28[i].det() != DetId::Hcal)
+          continue;
         HcalDetId hid(items28[i]);
-	if(hid.subdet() == HcalOuter) continue;
-		
-        if(theHcalTopology->idBack(hid).depth()>backDepth) { 
-	  backCellId = hid; 
-	  backDepth  = theHcalTopology->idBack(hid).depth(); }
+        if (hid.subdet() == HcalOuter)
+          continue;
+
+        if (theHcalTopology->idBack(hid).depth() > backDepth) {
+          backCellId = hid;
+          backDepth = theHcalTopology->idBack(hid).depth();
+        }
       }
     }
 #ifdef EDM_ML_DEBUG
@@ -1492,9 +1538,8 @@ GlobalPoint CaloTowersCreationAlgo::hadShwrPos(CaloTowerDetId towerId, float fra
 }
 
 GlobalPoint CaloTowersCreationAlgo::hadShwPosFromCells(DetId frontCellId, DetId backCellId, float fracDepth) {
-
-   // uses the "front" and "back" cells
-   // to determine the axis. point set by the predefined depth.
+  // uses the "front" and "back" cells
+  // to determine the axis. point set by the predefined depth.
 
   HcalDetId hid1(frontCellId), hid2(backCellId);
   if (theHcalTopology->getMergePositionFlag()) {
@@ -1509,9 +1554,9 @@ GlobalPoint CaloTowersCreationAlgo::hadShwPosFromCells(DetId frontCellId, DetId 
   }
 
   auto frontCellGeometry = theGeometry->getGeometry(DetId(hid1));
-  auto backCellGeometry  = theGeometry->getGeometry(DetId(hid2));
+  auto backCellGeometry = theGeometry->getGeometry(DetId(hid2));
 
-  GlobalPoint point     = frontCellGeometry->getPosition();
+  GlobalPoint point = frontCellGeometry->getPosition();
   const GlobalPoint& backPoint = backCellGeometry->getBackPoint();
 
   point += fracDepth * (backPoint - point);
@@ -1519,11 +1564,11 @@ GlobalPoint CaloTowersCreationAlgo::hadShwPosFromCells(DetId frontCellId, DetId 
   return point;
 }
 
-
-GlobalPoint CaloTowersCreationAlgo::emShwrPos(const std::vector<std::pair<DetId,float> >& metaContains, 
-                                              float fracDepth, double emE) {
-
-  if (emE<=0) return GlobalPoint(0,0,0);
+GlobalPoint CaloTowersCreationAlgo::emShwrPos(const std::vector<std::pair<DetId, float> >& metaContains,
+                                              float fracDepth,
+                                              double emE) {
+  if (emE <= 0)
+    return GlobalPoint(0, 0, 0);
 
   double emX = 0.0;
   double emY = 0.0;
@@ -1531,28 +1576,27 @@ GlobalPoint CaloTowersCreationAlgo::emShwrPos(const std::vector<std::pair<DetId,
 
   double eSum = 0;
 
-  std::vector<std::pair<DetId,float> >::const_iterator mc_it = metaContains.begin();
-  for (; mc_it!=metaContains.end(); ++mc_it) {
-    if (mc_it->first.det() != DetId::Ecal) continue;
+  std::vector<std::pair<DetId, float> >::const_iterator mc_it = metaContains.begin();
+  for (; mc_it != metaContains.end(); ++mc_it) {
+    if (mc_it->first.det() != DetId::Ecal)
+      continue;
     GlobalPoint p = emCrystalShwrPos(mc_it->first, fracDepth);
     double e = mc_it->second;
 
-    if (e>0) {
+    if (e > 0) {
       emX += p.x() * e;
       emY += p.y() * e;
       emZ += p.z() * e;
       eSum += e;
     }
-
   }
 
-   return GlobalPoint(emX/eSum, emY/eSum, emZ/eSum);
+  return GlobalPoint(emX / eSum, emY / eSum, emZ / eSum);
 }
 
-
-GlobalPoint CaloTowersCreationAlgo::emShwrLogWeightPos(const std::vector<std::pair<DetId,float> >& metaContains, 
-						       float fracDepth, double emE) {
-
+GlobalPoint CaloTowersCreationAlgo::emShwrLogWeightPos(const std::vector<std::pair<DetId, float> >& metaContains,
+                                                       float fracDepth,
+                                                       double emE) {
   double emX = 0.0;
   double emY = 0.0;
   double emZ = 0.0;
@@ -1562,55 +1606,47 @@ GlobalPoint CaloTowersCreationAlgo::emShwrLogWeightPos(const std::vector<std::pa
   double sumEmE = 0;  // add crystals with E/E_EM > 1.5%
   double crystalThresh = 0.015 * emE;
 
-  std::vector<std::pair<DetId,float> >::const_iterator mc_it = metaContains.begin();
-  for (; mc_it!=metaContains.end(); ++mc_it) {
-    if (mc_it->second < 0) continue;
-    if (mc_it->first.det() == DetId::Ecal && mc_it->second > crystalThresh) sumEmE += mc_it->second;
+  std::vector<std::pair<DetId, float> >::const_iterator mc_it = metaContains.begin();
+  for (; mc_it != metaContains.end(); ++mc_it) {
+    if (mc_it->second < 0)
+      continue;
+    if (mc_it->first.det() == DetId::Ecal && mc_it->second > crystalThresh)
+      sumEmE += mc_it->second;
   }
 
-  for (mc_it = metaContains.begin(); mc_it!=metaContains.end(); ++mc_it) {
-    
-    if (mc_it->first.det() != DetId::Ecal || mc_it->second < crystalThresh) continue;
-    
+  for (mc_it = metaContains.begin(); mc_it != metaContains.end(); ++mc_it) {
+    if (mc_it->first.det() != DetId::Ecal || mc_it->second < crystalThresh)
+      continue;
+
     GlobalPoint p = emCrystalShwrPos(mc_it->first, fracDepth);
 
-    weight = 4.2 + log(mc_it->second/sumEmE);
+    weight = 4.2 + log(mc_it->second / sumEmE);
     sumWeights += weight;
-      
+
     emX += p.x() * weight;
     emY += p.y() * weight;
     emZ += p.z() * weight;
   }
 
-   return GlobalPoint(emX/sumWeights, emY/sumWeights, emZ/sumWeights);
+  return GlobalPoint(emX / sumWeights, emY / sumWeights, emZ / sumWeights);
 }
-
-
-
-
 
 int CaloTowersCreationAlgo::compactTime(float time) {
+  const float timeUnit = 0.01;  // discretization (ns)
 
-  const float timeUnit = 0.01; // discretization (ns)
+  if (time > 300.0)
+    return 30000;
+  if (time < -300.0)
+    return -30000;
 
-  if (time>  300.0) return  30000;
-  if (time< -300.0) return -30000;
-
-  return int(time/timeUnit + 0.5);
-
+  return int(time / timeUnit + 0.5);
 }
-
-
 
 //========================================================
 //
-// Bad/anomolous cell handling 
-
-
-
+// Bad/anomolous cell handling
 
 void CaloTowersCreationAlgo::makeHcalDropChMap() {
-
   // This method fills the map of number of dead channels for the calotower,
   // The key of the map is CaloTowerDetId.
   // By definition these channels are not going to be in the RecHit collections.
@@ -1618,96 +1654,91 @@ void CaloTowersCreationAlgo::makeHcalDropChMap() {
   std::vector<DetId> allChanInStatusCont = theHcalChStatus->getAllChannels();
 
 #ifdef EDM_ML_DEBUG
-  std::cout << "DropChMap with " << allChanInStatusCont.size() << " channels"
-	    << std::endl;
+  std::cout << "DropChMap with " << allChanInStatusCont.size() << " channels" << std::endl;
 #endif
-  for (std::vector<DetId>::iterator it = allChanInStatusCont.begin(); it!=allChanInStatusCont.end(); ++it) {
+  for (std::vector<DetId>::iterator it = allChanInStatusCont.begin(); it != allChanInStatusCont.end(); ++it) {
     const uint32_t dbStatusFlag = theHcalChStatus->getValues(*it)->getValue();
     if (theHcalSevLvlComputer->dropChannel(dbStatusFlag)) {
-
       DetId id = theHcalTopology->mergedDepthDetId(HcalDetId(*it));
-      
+
       CaloTowerDetId twrId = theTowerConstituentsMap->towerOf(id);
-      
-      hcalDropChMap[twrId].first +=1;
-      
+
+      hcalDropChMap[twrId].first += 1;
+
       HcalDetId hid(*it);
-	  
+
       // special case for tower 29: if HCAL hit is in depth 3 add to twr 29 as well
-      if (hid.subdet()==HcalEndcap &&
-	  (theHcalPhase==0 || theHcalPhase==1) &&
-	  hid.ietaAbs()==theHcalTopology->lastHERing()-1) {
-	bool merge = theHcalTopology->mergedDepth29(hid);
-	if (merge) {
-          CaloTowerDetId twrId29(twrId.ieta()+twrId.zside(), twrId.iphi());
-          hcalDropChMap[twrId29].first +=1;
-	}
+      if (hid.subdet() == HcalEndcap && (theHcalPhase == 0 || theHcalPhase == 1) &&
+          hid.ietaAbs() == theHcalTopology->lastHERing() - 1) {
+        bool merge = theHcalTopology->mergedDepth29(hid);
+        if (merge) {
+          CaloTowerDetId twrId29(twrId.ieta() + twrId.zside(), twrId.iphi());
+          hcalDropChMap[twrId29].first += 1;
+        }
       }
     }
   }
   // now I know how many bad channels, but I also need to know if there's any good ones
   if (missingHcalRescaleFactorForEcal > 0) {
-      for (auto & pair : hcalDropChMap) {
-          if (pair.second.first == 0) continue; // unexpected, but just in case
-          int ngood = 0, nbad = 0;
-          for (DetId id : theTowerConstituentsMap->constituentsOf(pair.first)) {
-              if (id.det() != DetId::Hcal) continue;
-              HcalDetId hid(id);
-              if (hid.subdet() != HcalBarrel && hid.subdet() != HcalEndcap) continue;
-              const uint32_t dbStatusFlag = theHcalChStatus->getValues(id)->getValue();
-              if (dbStatusFlag == 0 || ! theHcalSevLvlComputer->dropChannel(dbStatusFlag)) {
-                  ngood += 1;
-              } else {
-                  nbad += 1; // recount, since pair.second.first may include HO
-              }
-          }
-          if (nbad > 0 && nbad >= ngood) {
-              //uncomment for debug (may be useful to tune the criteria above)
-              //CaloTowerDetId id(pair.first);
-              //std::cout << "CaloTower at ieta = " << id.ieta() << ", iphi " << id.iphi() << ": set Hcal as not efficient (ngood =" << ngood << ", nbad = " << nbad << ")" << std::endl;
-              pair.second.second = true;
-          }
+    for (auto& pair : hcalDropChMap) {
+      if (pair.second.first == 0)
+        continue;  // unexpected, but just in case
+      int ngood = 0, nbad = 0;
+      for (DetId id : theTowerConstituentsMap->constituentsOf(pair.first)) {
+        if (id.det() != DetId::Hcal)
+          continue;
+        HcalDetId hid(id);
+        if (hid.subdet() != HcalBarrel && hid.subdet() != HcalEndcap)
+          continue;
+        const uint32_t dbStatusFlag = theHcalChStatus->getValues(id)->getValue();
+        if (dbStatusFlag == 0 || !theHcalSevLvlComputer->dropChannel(dbStatusFlag)) {
+          ngood += 1;
+        } else {
+          nbad += 1;  // recount, since pair.second.first may include HO
+        }
       }
+      if (nbad > 0 && nbad >= ngood) {
+        //uncomment for debug (may be useful to tune the criteria above)
+        //CaloTowerDetId id(pair.first);
+        //std::cout << "CaloTower at ieta = " << id.ieta() << ", iphi " << id.iphi() << ": set Hcal as not efficient (ngood =" << ngood << ", nbad = " << nbad << ")" << std::endl;
+        pair.second.second = true;
+      }
+    }
   }
 }
 
-
 void CaloTowersCreationAlgo::makeEcalBadChs() {
-
   // std::cout << "VI making EcalBadChs ";
 
   // for ECAL the number of all bad channels is obtained here -----------------------
-  
-  for (auto ind=0U; ind<theTowerTopology->sizeForDenseIndexing(); ++ind) {
-    
-    auto & numBadEcalChan = ecalBadChs[ind];
-    numBadEcalChan=0;
+
+  for (auto ind = 0U; ind < theTowerTopology->sizeForDenseIndexing(); ++ind) {
+    auto& numBadEcalChan = ecalBadChs[ind];
+    numBadEcalChan = 0;
     auto id = theTowerTopology->detIdFromDenseIndex(ind);
-    
+
     // this is utterly slow... (can be optmized if really needed)
-    
+
     // get all possible constituents of the tower
     std::vector<DetId> allConstituents = theTowerConstituentsMap->constituentsOf(id);
-    
-    for (std::vector<DetId>::iterator ac_it=allConstituents.begin(); 
-	 ac_it!=allConstituents.end(); ++ac_it) {
-      
-      if (ac_it->det()!=DetId::Ecal) continue;
-      
-      auto thisEcalSevLvl = theEcalSevLvlAlgo->severityLevel( *ac_it);
-      
+
+    for (std::vector<DetId>::iterator ac_it = allConstituents.begin(); ac_it != allConstituents.end(); ++ac_it) {
+      if (ac_it->det() != DetId::Ecal)
+        continue;
+
+      auto thisEcalSevLvl = theEcalSevLvlAlgo->severityLevel(*ac_it);
+
       // check if the Ecal severity is ok to keep
-      std::vector<int>::const_iterator sevit = std::find(theEcalSeveritiesToBeExcluded.begin(),
-							 theEcalSeveritiesToBeExcluded.end(),
-							 thisEcalSevLvl);
-      if (sevit!=theEcalSeveritiesToBeExcluded.end()) {
-	++numBadEcalChan;
+      std::vector<int>::const_iterator sevit =
+          std::find(theEcalSeveritiesToBeExcluded.begin(), theEcalSeveritiesToBeExcluded.end(), thisEcalSevLvl);
+      if (sevit != theEcalSeveritiesToBeExcluded.end()) {
+        ++numBadEcalChan;
       }
     }
-    
+
     // if (0!=numBadEcalChan) std::cout << id << ":" << numBadEcalChan << ", ";
   }
-  
+
   /*
   int tot=0;
   for (auto ind=0U; ind<theTowerTopology->sizeForDenseIndexing(); ++ind) {
@@ -1715,46 +1746,37 @@ void CaloTowersCreationAlgo::makeEcalBadChs() {
   }
   std::cout << " | " << tot << std::endl;
   */
-
 }
-
 
 //////  Get status of the channel contributing to the tower
 
 unsigned int CaloTowersCreationAlgo::hcalChanStatusForCaloTower(const CaloRecHit* hit) {
-
   HcalDetId hid(hit->detid());
-  DetId  id = theHcalTopology->idFront(hid);
+  DetId id = theHcalTopology->idFront(hid);
 #ifdef EDM_ML_DEBUG
-  std::cout << "ChanStatusForCaloTower for " << hid << " to " << HcalDetId(id)
-	    << std::endl;
+  std::cout << "ChanStatusForCaloTower for " << hid << " to " << HcalDetId(id) << std::endl;
 #endif
   const uint32_t recHitFlag = hit->flags();
   const uint32_t dbStatusFlag = theHcalChStatus->getValues(id)->getValue();
-  
-  int severityLevel = theHcalSevLvlComputer->getSeverityLevel(id, recHitFlag, dbStatusFlag); 
-  bool isRecovered  = theHcalSevLvlComputer->recoveredRecHit(id, recHitFlag);
 
+  int severityLevel = theHcalSevLvlComputer->getSeverityLevel(id, recHitFlag, dbStatusFlag);
+  bool isRecovered = theHcalSevLvlComputer->recoveredRecHit(id, recHitFlag);
 
   // For use with hits rejected in the default reconstruction
   if (useRejectedHitsOnly) {
-    
     if (!isRecovered) {
-
       if (severityLevel <= int(theHcalAcceptSeverityLevel) ||
-	  severityLevel > int(theHcalAcceptSeverityLevelForRejectedHit)) return CaloTowersCreationAlgo::IgnoredChan;
-      // this hit was either already accepted or is worse than 
-    }    
-    else {
-      
+          severityLevel > int(theHcalAcceptSeverityLevelForRejectedHit))
+        return CaloTowersCreationAlgo::IgnoredChan;
+      // this hit was either already accepted or is worse than
+    } else {
       if (theRecoveredHcalHitsAreUsed || !useRejectedRecoveredHcalHits) {
-	// skip recovered hits either because they were already used or because there was an explicit instruction
-	return CaloTowersCreationAlgo::IgnoredChan;
+        // skip recovered hits either because they were already used or because there was an explicit instruction
+        return CaloTowersCreationAlgo::IgnoredChan;
+      } else if (useRejectedRecoveredHcalHits) {
+        return CaloTowersCreationAlgo::RecoveredChan;
       }
-      else if (useRejectedRecoveredHcalHits) {
-	return CaloTowersCreationAlgo::RecoveredChan;
-      }  
-  
+
     }  // recovered channels
 
     // clasify channels as problematic: no good hits are supposed to be present in the
@@ -1763,32 +1785,23 @@ unsigned int CaloTowersCreationAlgo::hcalChanStatusForCaloTower(const CaloRecHit
 
   }  // treatment of rejected hits
 
-
-
-
   // this is for the regular reconstruction sequence
 
-  if (severityLevel == 0) return CaloTowersCreationAlgo::GoodChan;
+  if (severityLevel == 0)
+    return CaloTowersCreationAlgo::GoodChan;
 
   if (isRecovered) {
-    return (theRecoveredHcalHitsAreUsed) ? 
-      CaloTowersCreationAlgo::RecoveredChan : CaloTowersCreationAlgo::BadChan;
-  }
-  else {
+    return (theRecoveredHcalHitsAreUsed) ? CaloTowersCreationAlgo::RecoveredChan : CaloTowersCreationAlgo::BadChan;
+  } else {
     if (severityLevel > int(theHcalAcceptSeverityLevel)) {
       return CaloTowersCreationAlgo::BadChan;
-    }
-    else {
+    } else {
       return CaloTowersCreationAlgo::ProblematicChan;
     }
-  }  
-
+  }
 }
 
-
-
-std::tuple<unsigned int,bool>  CaloTowersCreationAlgo::ecalChanStatusForCaloTower(const EcalRecHit* hit) {
-
+std::tuple<unsigned int, bool> CaloTowersCreationAlgo::ecalChanStatusForCaloTower(const EcalRecHit* hit) {
   // const DetId id = hit->detid();
 
   //  uint16_t dbStatus = theEcalChStatus->find(id)->getStatusCode();
@@ -1797,14 +1810,13 @@ std::tuple<unsigned int,bool>  CaloTowersCreationAlgo::ecalChanStatusForCaloTowe
   // The methods above will become private and cannot be usef for flagging ecal spikes.
   // Use the recommended interface - we leave the parameters for spilke removal to be specified by ECAL.
 
-
   //  int severityLevel = 999;
 
-  EcalRecHit const & rh = *reinterpret_cast<EcalRecHit const *>(hit);
+  EcalRecHit const& rh = *reinterpret_cast<EcalRecHit const*>(hit);
   int severityLevel = theEcalSevLvlAlgo->severityLevel(rh);
 
-//  if      (id.subdetId() == EcalBarrel) severityLevel = theEcalSevLvlAlgo->severityLevel( id, *theEbHandle);//, *theEcalChStatus);
-//  else if (id.subdetId() == EcalEndcap) severityLevel = theEcalSevLvlAlgo->severityLevel( id, *theEeHandle);//, *theEcalChStatus);
+  //  if      (id.subdetId() == EcalBarrel) severityLevel = theEcalSevLvlAlgo->severityLevel( id, *theEbHandle);//, *theEcalChStatus);
+  //  else if (id.subdetId() == EcalEndcap) severityLevel = theEcalSevLvlAlgo->severityLevel( id, *theEeHandle);//, *theEcalChStatus);
 
   // there should be no other ECAL types used in this reconstruction
 
@@ -1813,7 +1825,7 @@ std::tuple<unsigned int,bool>  CaloTowersCreationAlgo::ecalChanStatusForCaloTowe
   // for CaloTowers depends on the specified maximum acceptabel severity and therefore cannnot
   // be exact correspondence between the two. ECAL has additional categories describing modes of failure.)
   // This approach is different from the initial idea and from
-  // the implementation for HCAL. Still make the logic similar to HCAL so that one has the ability to 
+  // the implementation for HCAL. Still make the logic similar to HCAL so that one has the ability to
   // exclude problematic channels as defined by ECAL.
   // For definitions of ECAL severity levels see RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h
 
@@ -1823,57 +1835,46 @@ std::tuple<unsigned int,bool>  CaloTowersCreationAlgo::ecalChanStatusForCaloTowe
 
   // check if the severity is compatible with our configuration
   // This applies to the "default" tower cleaning
-  std::vector<int>::const_iterator sevit = std::find(theEcalSeveritiesToBeExcluded.begin(),
-						     theEcalSeveritiesToBeExcluded.end(),
-						     severityLevel);
-  bool accepted = (sevit==theEcalSeveritiesToBeExcluded.end()) ;
+  std::vector<int>::const_iterator sevit =
+      std::find(theEcalSeveritiesToBeExcluded.begin(), theEcalSeveritiesToBeExcluded.end(), severityLevel);
+  bool accepted = (sevit == theEcalSeveritiesToBeExcluded.end());
 
   // For use with hits that were rejected in the regular reconstruction:
   // This is for creating calotowers with lower level of cleaning by merging
   // the information from the default towers and a collection of towers created from
-  // bad rechits 
- 
+  // bad rechits
 
   if (useRejectedHitsOnly) {
-    
     if (!isRecovered) {
-
-      if (accepted  ||
-	  std::find(theEcalSeveritiesToBeUsedInBadTowers.begin(), theEcalSeveritiesToBeUsedInBadTowers.end(), severityLevel)
-	  == theEcalSeveritiesToBeUsedInBadTowers.end())
-	return std::make_tuple(CaloTowersCreationAlgo::IgnoredChan,isBad);
+      if (accepted || std::find(theEcalSeveritiesToBeUsedInBadTowers.begin(),
+                                theEcalSeveritiesToBeUsedInBadTowers.end(),
+                                severityLevel) == theEcalSeveritiesToBeUsedInBadTowers.end())
+        return std::make_tuple(CaloTowersCreationAlgo::IgnoredChan, isBad);
       // this hit was either already accepted, or is not eligible for inclusion
-    }    
-    else {
-      
+    } else {
       if (theRecoveredEcalHitsAreUsed || !useRejectedRecoveredEcalHits) {
-	// skip recovered hits either because they were already used or because there was an explicit instruction
-	return std::make_tuple(CaloTowersCreationAlgo::IgnoredChan,isBad);;
+        // skip recovered hits either because they were already used or because there was an explicit instruction
+        return std::make_tuple(CaloTowersCreationAlgo::IgnoredChan, isBad);
+        ;
+      } else if (useRejectedRecoveredEcalHits) {
+        return std::make_tuple(CaloTowersCreationAlgo::RecoveredChan, isBad);
       }
-      else if (useRejectedRecoveredEcalHits) {
-	return std::make_tuple(CaloTowersCreationAlgo::RecoveredChan,isBad);
-      }  
-  
+
     }  // recovered channels
 
     // clasify channels as problematic
-    return std::make_tuple(CaloTowersCreationAlgo::ProblematicChan,isBad);
+    return std::make_tuple(CaloTowersCreationAlgo::ProblematicChan, isBad);
 
   }  // treatment of rejected hits
 
-
-
   // for normal reconstruction
-  if (severityLevel == EcalSeverityLevel::kGood) return std::make_tuple(CaloTowersCreationAlgo::GoodChan,false);
+  if (severityLevel == EcalSeverityLevel::kGood)
+    return std::make_tuple(CaloTowersCreationAlgo::GoodChan, false);
 
   if (isRecovered) {
-    return  std::make_tuple( (theRecoveredEcalHitsAreUsed) ? 
-     CaloTowersCreationAlgo::RecoveredChan : CaloTowersCreationAlgo::BadChan, true);
-  }  
-  else {
-    return  std::make_tuple(accepted ? CaloTowersCreationAlgo::ProblematicChan : CaloTowersCreationAlgo::BadChan,isBad);
-
+    return std::make_tuple(
+        (theRecoveredEcalHitsAreUsed) ? CaloTowersCreationAlgo::RecoveredChan : CaloTowersCreationAlgo::BadChan, true);
+  } else {
+    return std::make_tuple(accepted ? CaloTowersCreationAlgo::ProblematicChan : CaloTowersCreationAlgo::BadChan, isBad);
   }
-
-
 }

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.cc
@@ -10,87 +10,83 @@
 
 //#define EDM_ML_DEBUG
 
-CaloTowersCreator::CaloTowersCreator(const edm::ParameterSet& conf) : 
-  algo_(conf.getParameter<double>("EBThreshold"),
-	conf.getParameter<double>("EEThreshold"),
+CaloTowersCreator::CaloTowersCreator(const edm::ParameterSet& conf)
+    : algo_(conf.getParameter<double>("EBThreshold"),
+            conf.getParameter<double>("EEThreshold"),
 
-	conf.getParameter<bool>("UseEtEBTreshold"),
-	conf.getParameter<bool>("UseEtEETreshold"),
-	conf.getParameter<bool>("UseSymEBTreshold"),
-	conf.getParameter<bool>("UseSymEETreshold"),
+            conf.getParameter<bool>("UseEtEBTreshold"),
+            conf.getParameter<bool>("UseEtEETreshold"),
+            conf.getParameter<bool>("UseSymEBTreshold"),
+            conf.getParameter<bool>("UseSymEETreshold"),
 
+            conf.getParameter<double>("HcalThreshold"),
+            conf.getParameter<double>("HBThreshold"),
+            conf.getParameter<double>("HBThreshold1"),
+            conf.getParameter<double>("HBThreshold2"),
+            conf.getParameter<double>("HESThreshold"),
+            conf.getParameter<double>("HESThreshold1"),
+            conf.getParameter<double>("HEDThreshold"),
+            conf.getParameter<double>("HEDThreshold1"),
+            conf.getParameter<double>("HOThreshold0"),
+            conf.getParameter<double>("HOThresholdPlus1"),
+            conf.getParameter<double>("HOThresholdMinus1"),
+            conf.getParameter<double>("HOThresholdPlus2"),
+            conf.getParameter<double>("HOThresholdMinus2"),
+            conf.getParameter<double>("HF1Threshold"),
+            conf.getParameter<double>("HF2Threshold"),
+            conf.getParameter<std::vector<double> >("EBGrid"),
+            conf.getParameter<std::vector<double> >("EBWeights"),
+            conf.getParameter<std::vector<double> >("EEGrid"),
+            conf.getParameter<std::vector<double> >("EEWeights"),
+            conf.getParameter<std::vector<double> >("HBGrid"),
+            conf.getParameter<std::vector<double> >("HBWeights"),
+            conf.getParameter<std::vector<double> >("HESGrid"),
+            conf.getParameter<std::vector<double> >("HESWeights"),
+            conf.getParameter<std::vector<double> >("HEDGrid"),
+            conf.getParameter<std::vector<double> >("HEDWeights"),
+            conf.getParameter<std::vector<double> >("HOGrid"),
+            conf.getParameter<std::vector<double> >("HOWeights"),
+            conf.getParameter<std::vector<double> >("HF1Grid"),
+            conf.getParameter<std::vector<double> >("HF1Weights"),
+            conf.getParameter<std::vector<double> >("HF2Grid"),
+            conf.getParameter<std::vector<double> >("HF2Weights"),
+            conf.getParameter<double>("EBWeight"),
+            conf.getParameter<double>("EEWeight"),
+            conf.getParameter<double>("HBWeight"),
+            conf.getParameter<double>("HESWeight"),
+            conf.getParameter<double>("HEDWeight"),
+            conf.getParameter<double>("HOWeight"),
+            conf.getParameter<double>("HF1Weight"),
+            conf.getParameter<double>("HF2Weight"),
+            conf.getParameter<double>("EcutTower"),
+            conf.getParameter<double>("EBSumThreshold"),
+            conf.getParameter<double>("EESumThreshold"),
+            conf.getParameter<bool>("UseHO"),
+            // (for momentum reconstruction algorithm)
+            conf.getParameter<int>("MomConstrMethod"),
+            conf.getParameter<double>("MomHBDepth"),
+            conf.getParameter<double>("MomHEDepth"),
+            conf.getParameter<double>("MomEBDepth"),
+            conf.getParameter<double>("MomEEDepth"),
+            conf.getParameter<int>("HcalPhase")),
 
-	conf.getParameter<double>("HcalThreshold"),
-	conf.getParameter<double>("HBThreshold"),
-	conf.getParameter<double>("HBThreshold1"),
-	conf.getParameter<double>("HBThreshold2"),
-	conf.getParameter<double>("HESThreshold"),
-	conf.getParameter<double>("HESThreshold1"),
-	conf.getParameter<double>("HEDThreshold"),
-	conf.getParameter<double>("HEDThreshold1"),
-	conf.getParameter<double>("HOThreshold0"),
-	conf.getParameter<double>("HOThresholdPlus1"),
-	conf.getParameter<double>("HOThresholdMinus1"),
-	conf.getParameter<double>("HOThresholdPlus2"),
-	conf.getParameter<double>("HOThresholdMinus2"),
-	conf.getParameter<double>("HF1Threshold"),
-	conf.getParameter<double>("HF2Threshold"),
-        conf.getParameter<std::vector<double> >("EBGrid"),
-        conf.getParameter<std::vector<double> >("EBWeights"),
-        conf.getParameter<std::vector<double> >("EEGrid"),
-        conf.getParameter<std::vector<double> >("EEWeights"),
-        conf.getParameter<std::vector<double> >("HBGrid"),
-        conf.getParameter<std::vector<double> >("HBWeights"),
-        conf.getParameter<std::vector<double> >("HESGrid"),
-        conf.getParameter<std::vector<double> >("HESWeights"),
-        conf.getParameter<std::vector<double> >("HEDGrid"),
-        conf.getParameter<std::vector<double> >("HEDWeights"),
-        conf.getParameter<std::vector<double> >("HOGrid"),
-        conf.getParameter<std::vector<double> >("HOWeights"),
-        conf.getParameter<std::vector<double> >("HF1Grid"),
-        conf.getParameter<std::vector<double> >("HF1Weights"),
-        conf.getParameter<std::vector<double> >("HF2Grid"),
-        conf.getParameter<std::vector<double> >("HF2Weights"),
-	conf.getParameter<double>("EBWeight"),
-	conf.getParameter<double>("EEWeight"),
-	conf.getParameter<double>("HBWeight"),
-	conf.getParameter<double>("HESWeight"),
-	conf.getParameter<double>("HEDWeight"),
-	conf.getParameter<double>("HOWeight"),
-	conf.getParameter<double>("HF1Weight"),
-	conf.getParameter<double>("HF2Weight"),
-	conf.getParameter<double>("EcutTower"),
-	conf.getParameter<double>("EBSumThreshold"),
-	conf.getParameter<double>("EESumThreshold"),
-	conf.getParameter<bool>("UseHO"),
-	// (for momentum reconstruction algorithm)
-        conf.getParameter<int>("MomConstrMethod"),
-        conf.getParameter<double>("MomHBDepth"),
-        conf.getParameter<double>("MomHEDepth"),
-        conf.getParameter<double>("MomEBDepth"),
-        conf.getParameter<double>("MomEEDepth"),
-        conf.getParameter<int>("HcalPhase")
-	),
+      ecalLabels_(conf.getParameter<std::vector<edm::InputTag> >("ecalInputs")),
+      allowMissingInputs_(conf.getParameter<bool>("AllowMissingInputs")),
 
-  ecalLabels_(conf.getParameter<std::vector<edm::InputTag> >("ecalInputs")),
-  allowMissingInputs_(conf.getParameter<bool>("AllowMissingInputs")),
+      theHcalAcceptSeverityLevel_(conf.getParameter<unsigned int>("HcalAcceptSeverityLevel")),
 
-  theHcalAcceptSeverityLevel_(conf.getParameter<unsigned int>("HcalAcceptSeverityLevel")),
+      theRecoveredHcalHitsAreUsed_(conf.getParameter<bool>("UseHcalRecoveredHits")),
+      theRecoveredEcalHitsAreUsed_(conf.getParameter<bool>("UseEcalRecoveredHits")),
 
-  theRecoveredHcalHitsAreUsed_(conf.getParameter<bool>("UseHcalRecoveredHits")),
-  theRecoveredEcalHitsAreUsed_(conf.getParameter<bool>("UseEcalRecoveredHits")),
+      // paramaters controlling the use of rejected hits
 
-  // paramaters controlling the use of rejected hits
+      useRejectedHitsOnly_(conf.getParameter<bool>("UseRejectedHitsOnly")),
 
-  useRejectedHitsOnly_(conf.getParameter<bool>("UseRejectedHitsOnly")),
+      theHcalAcceptSeverityLevelForRejectedHit_(
+          conf.getParameter<unsigned int>("HcalAcceptSeverityLevelForRejectedHit")),
 
-  theHcalAcceptSeverityLevelForRejectedHit_(conf.getParameter<unsigned int>("HcalAcceptSeverityLevelForRejectedHit")),
-
-
-  useRejectedRecoveredHcalHits_(conf.getParameter<bool>("UseRejectedRecoveredHcalHits")),
-  useRejectedRecoveredEcalHits_(conf.getParameter<bool>("UseRejectedRecoveredEcalHits"))
-
-
+      useRejectedRecoveredHcalHits_(conf.getParameter<bool>("UseRejectedRecoveredHcalHits")),
+      useRejectedRecoveredEcalHits_(conf.getParameter<bool>("UseRejectedRecoveredEcalHits"))
 
 {
   algo_.setMissingHcalRescaleFactorForEcal(conf.getParameter<double>("missingHcalRescaleFactorForEcal"));
@@ -101,38 +97,36 @@ CaloTowersCreator::CaloTowersCreator(const edm::ParameterSet& conf) :
   tok_hf_ = consumes<HFRecHitCollection>(conf.getParameter<edm::InputTag>("hfInput"));
 
   const unsigned nLabels = ecalLabels_.size();
-  for ( unsigned i=0; i != nLabels; i++ ) 
+  for (unsigned i = 0; i != nLabels; i++)
     toks_ecal_.push_back(consumes<EcalRecHitCollection>(ecalLabels_[i]));
 
-
-  EBEScale=eScales_.EBScale; 
-  EEEScale=eScales_.EEScale; 
-  HBEScale=eScales_.HBScale; 
-  HESEScale=eScales_.HESScale; 
-  HEDEScale=eScales_.HEDScale; 
-  HOEScale=eScales_.HOScale; 
-  HF1EScale=eScales_.HF1Scale; 
-  HF2EScale=eScales_.HF2Scale; 
+  EBEScale = eScales_.EBScale;
+  EEEScale = eScales_.EEScale;
+  HBEScale = eScales_.HBScale;
+  HESEScale = eScales_.HESScale;
+  HEDEScale = eScales_.HEDScale;
+  HOEScale = eScales_.HOScale;
+  HF1EScale = eScales_.HF1Scale;
+  HF2EScale = eScales_.HF2Scale;
 
   // get the Ecal severities to be excluded
-  const std::vector<std::string> severitynames = 
-    conf.getParameter<std::vector<std::string> >("EcalRecHitSeveritiesToBeExcluded");
+  const std::vector<std::string> severitynames =
+      conf.getParameter<std::vector<std::string> >("EcalRecHitSeveritiesToBeExcluded");
 
-   theEcalSeveritiesToBeExcluded_ =  StringToEnumValue<EcalSeverityLevel::SeverityLevel>(severitynames);
+  theEcalSeveritiesToBeExcluded_ = StringToEnumValue<EcalSeverityLevel::SeverityLevel>(severitynames);
 
   // get the Ecal severities to be used for bad towers
-   theEcalSeveritiesToBeUsedInBadTowers_ =  
-     StringToEnumValue<EcalSeverityLevel::SeverityLevel>(conf.getParameter<std::vector<std::string> >("EcalSeveritiesToBeUsedInBadTowers") );
+  theEcalSeveritiesToBeUsedInBadTowers_ = StringToEnumValue<EcalSeverityLevel::SeverityLevel>(
+      conf.getParameter<std::vector<std::string> >("EcalSeveritiesToBeUsedInBadTowers"));
 
-  if (eScales_.instanceLabel.empty()) produces<CaloTowerCollection>();
-  else produces<CaloTowerCollection>(eScales_.instanceLabel);
+  if (eScales_.instanceLabel.empty())
+    produces<CaloTowerCollection>();
+  else
+    produces<CaloTowerCollection>(eScales_.instanceLabel);
 
 #ifdef EDM_ML_DEBUG
-  std::cout << "VI Producer " 
-	    << (useRejectedHitsOnly_ ? "use rejectOnly " : " ")
-	    << (allowMissingInputs_ ? "allowMissing " : " " )
-	    <<  nLabels << ' ' << severitynames.size() 
-	    << std::endl;
+  std::cout << "VI Producer " << (useRejectedHitsOnly_ ? "use rejectOnly " : " ")
+            << (allowMissingInputs_ ? "allowMissing " : " ") << nLabels << ' ' << severitynames.size() << std::endl;
 #endif
 }
 
@@ -146,18 +140,18 @@ void CaloTowersCreator::produce(edm::Event& e, const edm::EventSetup& c) {
   c.get<HcalRecNumberingRecord>().get(htopo);
   c.get<HcalRecNumberingRecord>().get(cttopo);
   c.get<CaloGeometryRecord>().get(ctmap);
- 
+
   // ECAL channel status map ****************************************
   edm::ESHandle<EcalChannelStatus> ecalChStatus;
-  c.get<EcalChannelStatusRcd>().get( ecalChStatus );
+  c.get<EcalChannelStatusRcd>().get(ecalChStatus);
   const EcalChannelStatus* dbEcalChStatus = ecalChStatus.product();
- 
+
   // HCAL channel status map ****************************************
-  edm::ESHandle<HcalChannelQuality> hcalChStatus;    
-  c.get<HcalChannelQualityRcd>().get( "withTopo", hcalChStatus );
-    
+  edm::ESHandle<HcalChannelQuality> hcalChStatus;
+  c.get<HcalChannelQualityRcd>().get("withTopo", hcalChStatus);
+
   const HcalChannelQuality* dbHcalChStatus = hcalChStatus.product();
-    
+
   // Assignment of severity levels **********************************
   edm::ESHandle<HcalSeverityLevelComputer> hcalSevLvlComputerHndl;
   c.get<HcalSeverityLevelComputerRcd>().get(hcalSevLvlComputerHndl);
@@ -167,7 +161,6 @@ void CaloTowersCreator::produce(edm::Event& e, const edm::EventSetup& c) {
   c.get<EcalSeverityLevelAlgoRcd>().get(ecalSevLvlAlgoHndl);
   const EcalSeverityLevelAlgo* ecalSevLvlAlgo = ecalSevLvlAlgoHndl.product();
 
-  
   algo_.setEBEScale(EBEScale);
   algo_.setEEEScale(EEEScale);
   algo_.setHBEScale(HBEScale);
@@ -176,13 +169,13 @@ void CaloTowersCreator::produce(edm::Event& e, const edm::EventSetup& c) {
   algo_.setHOEScale(HOEScale);
   algo_.setHF1EScale(HF1EScale);
   algo_.setHF2EScale(HF2EScale);
-  algo_.setGeometry(cttopo.product(),ctmap.product(),htopo.product(),pG.product());
+  algo_.setGeometry(cttopo.product(), ctmap.product(), htopo.product(), pG.product());
 
   // for treatment of problematic and anomalous cells
 
   algo_.setHcalChStatusFromDB(dbHcalChStatus);
   algo_.setEcalChStatusFromDB(dbEcalChStatus);
-   
+
   algo_.setHcalAcceptSeverityLevel(theHcalAcceptSeverityLevel_);
   algo_.setEcalSeveritiesToBeExcluded(theEcalSeveritiesToBeExcluded_);
 
@@ -192,62 +185,59 @@ void CaloTowersCreator::produce(edm::Event& e, const edm::EventSetup& c) {
   algo_.setHcalSevLvlComputer(hcalSevLvlComputer);
   algo_.setEcalSevLvlAlgo(ecalSevLvlAlgo);
 
-
   algo_.setUseRejectedHitsOnly(useRejectedHitsOnly_);
 
   algo_.setHcalAcceptSeverityLevelForRejectedHit(theHcalAcceptSeverityLevelForRejectedHit_);
-  algo_.SetEcalSeveritiesToBeUsedInBadTowers (theEcalSeveritiesToBeUsedInBadTowers_);
+  algo_.SetEcalSeveritiesToBeUsedInBadTowers(theEcalSeveritiesToBeUsedInBadTowers_);
 
   algo_.setUseRejectedRecoveredHcalHits(useRejectedRecoveredHcalHits_);
   algo_.setUseRejectedRecoveredEcalHits(useRejectedRecoveredEcalHits_);
 
 #ifdef EDM_ML_DEBUG
-  std::cout << "VI Produce: " 
-	    << (useRejectedHitsOnly_ ? "use rejectOnly " : " ")
-	    << (allowMissingInputs_ ? "allowMissing " : " " )
-	    << (theRecoveredEcalHitsAreUsed_ ? "use RecoveredEcal ": " " )
-	    <<  toks_ecal_.size()
-	    << ' ' << theEcalSeveritiesToBeExcluded_.size()
-	    << ' ' << theEcalSeveritiesToBeUsedInBadTowers_.size() 
-	    << std::endl;
+  std::cout << "VI Produce: " << (useRejectedHitsOnly_ ? "use rejectOnly " : " ")
+            << (allowMissingInputs_ ? "allowMissing " : " ")
+            << (theRecoveredEcalHitsAreUsed_ ? "use RecoveredEcal " : " ") << toks_ecal_.size() << ' '
+            << theEcalSeveritiesToBeExcluded_.size() << ' ' << theEcalSeveritiesToBeUsedInBadTowers_.size()
+            << std::endl;
 #endif
 
-  algo_.begin(); // clear the internal buffer
+  algo_.begin();  // clear the internal buffer
 
   // can't chain these in a big OR statement, or else it'll
   // get triggered for each of the first three events
   bool check1 = hcalSevLevelWatcher_.check(c);
   bool check2 = hcalChStatusWatcher_.check(c);
   bool check3 = caloTowerConstituentsWatcher_.check(c);
-  if(check1 || check2 || check3)
-  {
+  if (check1 || check2 || check3) {
     algo_.makeHcalDropChMap();
   }
 
   // check ecal SevLev
-  if (ecalSevLevelWatcher_.check(c)) algo_.makeEcalBadChs();
+  if (ecalSevLevelWatcher_.check(c))
+    algo_.makeEcalBadChs();
 
   // ----------------------------------------------------------
-  // For ecal error handling need to 
-  // have access to the EB and EE collections at the end of 
+  // For ecal error handling need to
+  // have access to the EB and EE collections at the end of
   // tower reconstruction.
 
   edm::Handle<EcalRecHitCollection> ebHandle;
   edm::Handle<EcalRecHitCollection> eeHandle;
 
-  for (std::vector<edm::EDGetTokenT<EcalRecHitCollection> >::const_iterator i=toks_ecal_.begin(); 
-       i!=toks_ecal_.end(); i++) {
-    
+  for (std::vector<edm::EDGetTokenT<EcalRecHitCollection> >::const_iterator i = toks_ecal_.begin();
+       i != toks_ecal_.end();
+       i++) {
     edm::Handle<EcalRecHitCollection> ec_tmp;
-    
-    if (! e.getByToken(*i,ec_tmp) ) continue;
-    if (ec_tmp->empty()) continue;
+
+    if (!e.getByToken(*i, ec_tmp))
+      continue;
+    if (ec_tmp->empty())
+      continue;
 
     // check if this is EB or EE
-    if ( (ec_tmp->begin()->detid()).subdetId() == EcalBarrel ) {
+    if ((ec_tmp->begin()->detid()).subdetId() == EcalBarrel) {
       ebHandle = ec_tmp;
-    }
-    else if ((ec_tmp->begin()->detid()).subdetId() == EcalEndcap) {
+    } else if ((ec_tmp->begin()->detid()).subdetId() == EcalEndcap) {
       eeHandle = ec_tmp;
     }
   }
@@ -261,22 +251,26 @@ void CaloTowersCreator::produce(edm::Event& e, const edm::EventSetup& c) {
 
   // Step A/C: Get Inputs and process (repeatedly)
   edm::Handle<HBHERecHitCollection> hbhe;
-  present=e.getByToken(tok_hbhe_,hbhe);
-  if (present || !allowMissingInputs_)  algo_.process(*hbhe);
+  present = e.getByToken(tok_hbhe_, hbhe);
+  if (present || !allowMissingInputs_)
+    algo_.process(*hbhe);
 
   edm::Handle<HORecHitCollection> ho;
-  present=e.getByToken(tok_ho_,ho);
-  if (present || !allowMissingInputs_) algo_.process(*ho);
+  present = e.getByToken(tok_ho_, ho);
+  if (present || !allowMissingInputs_)
+    algo_.process(*ho);
 
   edm::Handle<HFRecHitCollection> hf;
-  present=e.getByToken(tok_hf_,hf);
-  if (present || !allowMissingInputs_) algo_.process(*hf);
+  present = e.getByToken(tok_hf_, hf);
+  if (present || !allowMissingInputs_)
+    algo_.process(*hf);
 
   std::vector<edm::EDGetTokenT<EcalRecHitCollection> >::const_iterator i;
-  for (i=toks_ecal_.begin(); i!=toks_ecal_.end(); i++) {
+  for (i = toks_ecal_.begin(); i != toks_ecal_.end(); i++) {
     edm::Handle<EcalRecHitCollection> ec;
-    present=e.getByToken(*i,ec);
-    if (present || !allowMissingInputs_) algo_.process(*ec);
+    present = e.getByToken(*i, ec);
+    if (present || !allowMissingInputs_)
+      algo_.process(*ec);
   }
 
   // Step B: Create empty output
@@ -286,97 +280,99 @@ void CaloTowersCreator::produce(edm::Event& e, const edm::EventSetup& c) {
   algo_.finish(*prod);
 
 #ifdef EDM_ML_DEBUG
-  int totc=0; float totE=0;
+  int totc = 0;
+  float totE = 0;
   reco::LeafCandidate::LorentzVector totP4;
-  for (auto const & tw : (*prod) ) { 
-    totc += tw.constituents().size(); 
-    totE+=tw.energy(); 
-    totP4+=tw.p4();
-    std::cout << "CaloTowerCreator: " << tw.id() << " with E " << tw.energy()
-	      << " and " << tw.constituents().size() << " constituents\n";
+  for (auto const& tw : (*prod)) {
+    totc += tw.constituents().size();
+    totE += tw.energy();
+    totP4 += tw.p4();
+    std::cout << "CaloTowerCreator: " << tw.id() << " with E " << tw.energy() << " and " << tw.constituents().size()
+              << " constituents\n";
   }
   std::cout << "VI " << (*prod).size() << " " << totc << " " << totE << " " << totP4 << std::endl;
 #endif
 
   // Step D: Put into the event
-  if (eScales_.instanceLabel.empty()) e.put(std::move(prod));
-  else e.put(std::move(prod),eScales_.instanceLabel);
-
-
+  if (eScales_.instanceLabel.empty())
+    e.put(std::move(prod));
+  else
+    e.put(std::move(prod), eScales_.instanceLabel);
 }
 
 void CaloTowersCreator::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-	edm::ParameterSetDescription desc;
-	desc.add<double>("EBSumThreshold", 0.2);
-	desc.add<double>("HF2Weight", 1.0);
-	desc.add<double>("EBWeight", 1.0);
-	desc.add<double>("EESumThreshold", 0.45);
-	desc.add<double>("HOThreshold0", 1.1);
-	desc.add<double>("HOThresholdPlus1", 3.5);
-	desc.add<double>("HOThresholdMinus1", 3.5);
-	desc.add<double>("HOThresholdPlus2", 3.5);
-	desc.add<double>("HOThresholdMinus2", 3.5);
-	desc.add<double>("HBThreshold", 0.7);
-	desc.add<double>("HBThreshold1", 0.7);
-	desc.add<double>("HBThreshold2", 0.7);
-	desc.add<double>("HF1Threshold", 0.5);
-	desc.add<double>("HEDWeight", 1.0);
-	desc.add<double>("EEWeight", 1.0);
-	desc.add<double>("HESWeight", 1.0);
-	desc.add<double>("HF1Weight", 1.0);
-	desc.add<double>("HOWeight", 1.0);
-	desc.add<double>("EBThreshold", 0.07);
-	desc.add<double>("EEThreshold", 0.3);
-	desc.add<double>("HcalThreshold", -1000.0);
-	desc.add<double>("HF2Threshold", 0.85);
-	desc.add<double>("HESThreshold", 0.8);
-	desc.add<double>("HESThreshold1", 0.8);
-	desc.add<double>("HEDThreshold", 0.8);
-	desc.add<double>("HEDThreshold1", 0.8);
-	desc.add<double>("EcutTower", -1000.0);
-	desc.add<double>("HBWeight", 1.0);
-	desc.add<double>("MomHBDepth", 0.2);
-	desc.add<double>("MomHEDepth", 0.4);   
-	desc.add<double>("MomEBDepth", 0.3);
-	desc.add<double>("MomEEDepth", 0.0);
-	desc.add<bool>("UseHO", true);
-	desc.add<bool>("UseEtEBTreshold", false);
-	desc.add<bool>("UseSymEBTreshold", true);
-	desc.add<bool>("UseEtEETreshold", false);
-	desc.add<bool>("UseSymEETreshold", true);
-	desc.add<bool>("UseHcalRecoveredHits", true);
-	desc.add<bool>("UseEcalRecoveredHits", false);
-	desc.add<bool>("UseRejectedHitsOnly", false);
-	desc.add<bool>("UseRejectedRecoveredHcalHits", true);
-	desc.add<bool>("UseRejectedRecoveredEcalHits", false);
-	desc.add<double>("missingHcalRescaleFactorForEcal", 0.0);
-	desc.add<bool>("AllowMissingInputs", false);
-	desc.add<std::vector<double> >("HBGrid", {-1.0, 1.0, 10.0, 100.0, 1000.0});
-	desc.add<std::vector<double> >("EEWeights", {1.0, 1.0, 1.0, 1.0, 1.0});
-	desc.add<std::vector<double> >("HF2Weights", {1.0, 1.0, 1.0, 1.0, 1.0});
-	desc.add<std::vector<double> >("HOWeights", {1.0, 1.0, 1.0, 1.0, 1.0});
-	desc.add<std::vector<double> >("EEGrid", {-1.0, 1.0, 10.0, 100.0, 1000.0});
-	desc.add<std::vector<double> >("HBWeights", {1.0, 1.0, 1.0, 1.0, 1.0});
-	desc.add<std::vector<double> >("HF2Grid", {-1.0, 1.0, 10.0, 100.0, 1000.0});
-	desc.add<std::vector<double> >("HEDWeights", {1.0, 1.0, 1.0, 1.0, 1.0});
-	desc.add<std::vector<double> >("HF1Grid", {-1.0, 1.0, 10.0, 100.0, 1000.0});
-	desc.add<std::vector<double> >("EBWeights", {1.0, 1.0, 1.0, 1.0, 1.0});
-	desc.add<std::vector<double> >("HF1Weights", {1.0, 1.0, 1.0, 1.0, 1.0});
-	desc.add<std::vector<double> >("HESGrid", {-1.0, 1.0, 10.0, 100.0, 1000.0});
-	desc.add<std::vector<double> >("HESWeights", {1.0, 1.0, 1.0, 1.0, 1.0});
-	desc.add<std::vector<double> >("HEDGrid", {-1.0, 1.0, 10.0, 100.0, 1000.0});
-	desc.add<std::vector<double> >("HOGrid", {-1.0, 1.0, 10.0, 100.0, 1000.0});
-	desc.add<std::vector<double> >("EBGrid", {-1.0, 1.0, 10.0, 100.0, 1000.0});
-	desc.add<edm::InputTag>("hfInput", edm::InputTag("hfreco"));
-	desc.add<edm::InputTag>("hbheInput", edm::InputTag("hbhereco"));
-	desc.add<edm::InputTag>("hoInput", edm::InputTag("horeco"));
-	desc.add<std::vector<edm::InputTag> >("ecalInputs", {edm::InputTag("ecalRecHit","EcalRecHitsEB"), edm::InputTag("ecalRecHit","EcalRecHitsEE")});
-	desc.add<int>("MomConstrMethod", 1);
-	desc.add<unsigned int>("HcalAcceptSeverityLevel", 9);
-	desc.add<std::vector<std::string> >("EcalRecHitSeveritiesToBeExcluded", {"kTime","kWeird","kBad"});
-	desc.add<unsigned int>("HcalAcceptSeverityLevelForRejectedHit", 9999);
-	desc.add<std::vector<std::string> >("EcalSeveritiesToBeUsedInBadTowers", {});
-	desc.add<int>("HcalPhase", 0);
+  edm::ParameterSetDescription desc;
+  desc.add<double>("EBSumThreshold", 0.2);
+  desc.add<double>("HF2Weight", 1.0);
+  desc.add<double>("EBWeight", 1.0);
+  desc.add<double>("EESumThreshold", 0.45);
+  desc.add<double>("HOThreshold0", 1.1);
+  desc.add<double>("HOThresholdPlus1", 3.5);
+  desc.add<double>("HOThresholdMinus1", 3.5);
+  desc.add<double>("HOThresholdPlus2", 3.5);
+  desc.add<double>("HOThresholdMinus2", 3.5);
+  desc.add<double>("HBThreshold", 0.7);
+  desc.add<double>("HBThreshold1", 0.7);
+  desc.add<double>("HBThreshold2", 0.7);
+  desc.add<double>("HF1Threshold", 0.5);
+  desc.add<double>("HEDWeight", 1.0);
+  desc.add<double>("EEWeight", 1.0);
+  desc.add<double>("HESWeight", 1.0);
+  desc.add<double>("HF1Weight", 1.0);
+  desc.add<double>("HOWeight", 1.0);
+  desc.add<double>("EBThreshold", 0.07);
+  desc.add<double>("EEThreshold", 0.3);
+  desc.add<double>("HcalThreshold", -1000.0);
+  desc.add<double>("HF2Threshold", 0.85);
+  desc.add<double>("HESThreshold", 0.8);
+  desc.add<double>("HESThreshold1", 0.8);
+  desc.add<double>("HEDThreshold", 0.8);
+  desc.add<double>("HEDThreshold1", 0.8);
+  desc.add<double>("EcutTower", -1000.0);
+  desc.add<double>("HBWeight", 1.0);
+  desc.add<double>("MomHBDepth", 0.2);
+  desc.add<double>("MomHEDepth", 0.4);
+  desc.add<double>("MomEBDepth", 0.3);
+  desc.add<double>("MomEEDepth", 0.0);
+  desc.add<bool>("UseHO", true);
+  desc.add<bool>("UseEtEBTreshold", false);
+  desc.add<bool>("UseSymEBTreshold", true);
+  desc.add<bool>("UseEtEETreshold", false);
+  desc.add<bool>("UseSymEETreshold", true);
+  desc.add<bool>("UseHcalRecoveredHits", true);
+  desc.add<bool>("UseEcalRecoveredHits", false);
+  desc.add<bool>("UseRejectedHitsOnly", false);
+  desc.add<bool>("UseRejectedRecoveredHcalHits", true);
+  desc.add<bool>("UseRejectedRecoveredEcalHits", false);
+  desc.add<double>("missingHcalRescaleFactorForEcal", 0.0);
+  desc.add<bool>("AllowMissingInputs", false);
+  desc.add<std::vector<double> >("HBGrid", {-1.0, 1.0, 10.0, 100.0, 1000.0});
+  desc.add<std::vector<double> >("EEWeights", {1.0, 1.0, 1.0, 1.0, 1.0});
+  desc.add<std::vector<double> >("HF2Weights", {1.0, 1.0, 1.0, 1.0, 1.0});
+  desc.add<std::vector<double> >("HOWeights", {1.0, 1.0, 1.0, 1.0, 1.0});
+  desc.add<std::vector<double> >("EEGrid", {-1.0, 1.0, 10.0, 100.0, 1000.0});
+  desc.add<std::vector<double> >("HBWeights", {1.0, 1.0, 1.0, 1.0, 1.0});
+  desc.add<std::vector<double> >("HF2Grid", {-1.0, 1.0, 10.0, 100.0, 1000.0});
+  desc.add<std::vector<double> >("HEDWeights", {1.0, 1.0, 1.0, 1.0, 1.0});
+  desc.add<std::vector<double> >("HF1Grid", {-1.0, 1.0, 10.0, 100.0, 1000.0});
+  desc.add<std::vector<double> >("EBWeights", {1.0, 1.0, 1.0, 1.0, 1.0});
+  desc.add<std::vector<double> >("HF1Weights", {1.0, 1.0, 1.0, 1.0, 1.0});
+  desc.add<std::vector<double> >("HESGrid", {-1.0, 1.0, 10.0, 100.0, 1000.0});
+  desc.add<std::vector<double> >("HESWeights", {1.0, 1.0, 1.0, 1.0, 1.0});
+  desc.add<std::vector<double> >("HEDGrid", {-1.0, 1.0, 10.0, 100.0, 1000.0});
+  desc.add<std::vector<double> >("HOGrid", {-1.0, 1.0, 10.0, 100.0, 1000.0});
+  desc.add<std::vector<double> >("EBGrid", {-1.0, 1.0, 10.0, 100.0, 1000.0});
+  desc.add<edm::InputTag>("hfInput", edm::InputTag("hfreco"));
+  desc.add<edm::InputTag>("hbheInput", edm::InputTag("hbhereco"));
+  desc.add<edm::InputTag>("hoInput", edm::InputTag("horeco"));
+  desc.add<std::vector<edm::InputTag> >(
+      "ecalInputs", {edm::InputTag("ecalRecHit", "EcalRecHitsEB"), edm::InputTag("ecalRecHit", "EcalRecHitsEE")});
+  desc.add<int>("MomConstrMethod", 1);
+  desc.add<unsigned int>("HcalAcceptSeverityLevel", 9);
+  desc.add<std::vector<std::string> >("EcalRecHitSeveritiesToBeExcluded", {"kTime", "kWeird", "kBad"});
+  desc.add<unsigned int>("HcalAcceptSeverityLevelForRejectedHit", 9999);
+  desc.add<std::vector<std::string> >("EcalSeveritiesToBeUsedInBadTowers", {});
+  desc.add<int>("HcalPhase", 0);
 
-	descriptions.addDefault(desc);
+  descriptions.addDefault(desc);
 }

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.h
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.h
@@ -18,21 +18,20 @@
   * Original author: J. Mans - Minnesota
   */
 
-// Now we allow for the creation of towers from 
+// Now we allow for the creation of towers from
 // rejected hists as well: requested by the MET group
 // for studies of the effect of noise clean up.
 
-class CaloTowersCreator : public  edm::stream::EDProducer<> {
+class CaloTowersCreator : public edm::stream::EDProducer<> {
 public:
   explicit CaloTowersCreator(const edm::ParameterSet& ps);
-  ~CaloTowersCreator() override { }
+  ~CaloTowersCreator() override {}
   void produce(edm::Event& e, const edm::EventSetup& c) override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   double EBEScale, EEEScale, HBEScale, HESEScale;
   double HEDEScale, HOEScale, HF1EScale, HF2EScale;
 
 private:
-
   static const std::vector<double>& getGridValues();
 
   CaloTowersCreationAlgo algo_;
@@ -43,30 +42,26 @@ private:
   std::vector<edm::EDGetTokenT<EcalRecHitCollection> > toks_ecal_;
   bool allowMissingInputs_;
 
-
   // more compact flags: all HCAL are combined
-  
+
   unsigned int theHcalAcceptSeverityLevel_;
   std::vector<int> theEcalSeveritiesToBeExcluded_;
-  
+
   // flag to use recovered hits
   bool theRecoveredHcalHitsAreUsed_;
   bool theRecoveredEcalHitsAreUsed_;
-
 
   // paramaters for creating towers from rejected hits
 
   bool useRejectedHitsOnly_;
   unsigned int theHcalAcceptSeverityLevelForRejectedHit_;
   //  for ECAL we have a list of problem flags
-   std::vector<int> theEcalSeveritiesToBeUsedInBadTowers_; 
-
-
+  std::vector<int> theEcalSeveritiesToBeUsedInBadTowers_;
 
   // Flags wheteher to use recovered hits for production of
-  // "bad towers". 
+  // "bad towers".
   // If the recoverd hits were already used for good towers,
-  // these flags have no effect. 
+  // these flags have no effect.
   // Note: These flags have no effect on the default tower reconstruction.
   bool useRejectedRecoveredHcalHits_;
   bool useRejectedRecoveredEcalHits_;
@@ -74,9 +69,8 @@ private:
   edm::ESWatcher<HcalSeverityLevelComputerRcd> hcalSevLevelWatcher_;
   edm::ESWatcher<HcalChannelQualityRcd> hcalChStatusWatcher_;
   edm::ESWatcher<IdealGeometryRecord> caloTowerConstituentsWatcher_;
-  edm::ESWatcher<EcalSeverityLevelAlgoRcd>  ecalSevLevelWatcher_;
+  edm::ESWatcher<EcalSeverityLevelAlgoRcd> ecalSevLevelWatcher_;
   EScales eScales_;
-
 };
 
 #endif

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersMerger.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersMerger.cc
@@ -2,7 +2,7 @@
 //
 // Package:    CaloTowersMerger
 // Class:      CaloTowersMerger
-// 
+//
 /**\class CaloTowersMerger CaloTowersMerger.cc RecoLocalCalo/CaloTowersMerger/src/CaloTowersMerger.cc
 
  Description: [one line class summary]
@@ -21,8 +21,6 @@
 // "regular" and "extra" towers
 // This functionality is subject to some restrictions
 // (see notes below)
-
-
 
 // system include files
 #include <memory>
@@ -52,10 +50,10 @@ public:
 
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
-      
+
   // ----------member data ---------------------------
 
-  edm::InputTag regularTowerTag,extraTowerTag;
+  edm::InputTag regularTowerTag, extraTowerTag;
   edm::EDGetTokenT<CaloTowerCollection> tok_reg_;
   edm::EDGetTokenT<CaloTowerCollection> tok_ext_;
 };
@@ -64,7 +62,6 @@ private:
 // constants, enums and typedefs
 //
 
-
 //
 // static data member definitions
 //
@@ -72,57 +69,49 @@ private:
 //
 // constructors and destructor
 //
-CaloTowersMerger::CaloTowersMerger(const edm::ParameterSet& iConfig)
-{
-  regularTowerTag=iConfig.getParameter<edm::InputTag>("regularTowerTag");
-  extraTowerTag=iConfig.getParameter<edm::InputTag>("extraTowerTag");
+CaloTowersMerger::CaloTowersMerger(const edm::ParameterSet& iConfig) {
+  regularTowerTag = iConfig.getParameter<edm::InputTag>("regularTowerTag");
+  extraTowerTag = iConfig.getParameter<edm::InputTag>("extraTowerTag");
 
   // register for data access
   tok_reg_ = consumes<CaloTowerCollection>(regularTowerTag);
   tok_ext_ = consumes<CaloTowerCollection>(extraTowerTag);
 
-   //register your products
-   produces<CaloTowerCollection>();
+  //register your products
+  produces<CaloTowerCollection>();
 }
 
-
-CaloTowersMerger::~CaloTowersMerger()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+CaloTowersMerger::~CaloTowersMerger() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-CaloTowersMerger::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-  edm::Handle<CaloTowerCollection> regTower,extraTower;
+void CaloTowersMerger::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<CaloTowerCollection> regTower, extraTower;
 
-  iEvent.getByToken(tok_reg_,regTower);
-  iEvent.getByToken(tok_ext_,extraTower);
+  iEvent.getByToken(tok_reg_, regTower);
+  iEvent.getByToken(tok_ext_, extraTower);
 
-  if (!regTower.isValid() && !extraTower.isValid()){
-    edm::LogError("CaloTowersMerger")<<"both input tag:"<<regularTowerTag<<" and "<<extraTowerTag<<" are invalid. empty merged collection";
+  if (!regTower.isValid() && !extraTower.isValid()) {
+    edm::LogError("CaloTowersMerger") << "both input tag:" << regularTowerTag << " and " << extraTowerTag
+                                      << " are invalid. empty merged collection";
     iEvent.put(std::make_unique<CaloTowerCollection>());
     return;
-  }else if (!regTower.isValid()  || !extraTower.isValid()){
+  } else if (!regTower.isValid() || !extraTower.isValid()) {
     if (!regTower.isValid() && extraTower.isValid())
-      regTower=extraTower;
+      regTower = extraTower;
     iEvent.put(std::make_unique<CaloTowerCollection>(*regTower));
     return;
-  }
-  else{
+  } else {
     //both valid input collections: merging
     auto output = std::make_unique<CaloTowerCollection>();
-    output->reserve(regTower->size()+extraTower->size());
-  
+    output->reserve(regTower->size() + extraTower->size());
+
     CaloTowerCollection::const_iterator rt_begin = regTower->begin();
     CaloTowerCollection::const_iterator rt_end = regTower->end();
     CaloTowerCollection::const_iterator rt_it = rt_begin;
@@ -131,48 +120,45 @@ CaloTowersMerger::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     std::vector<CaloTowerCollection::const_iterator> overlappingTowers;
     overlappingTowers.reserve(extraTower->size());
 
-    for (;rt_it!=rt_end;++rt_it){
+    for (; rt_it != rt_end; ++rt_it) {
       CaloTowerCollection::const_iterator et_it = extraTower->find(rt_it->id());
-      if (et_it != extraTower->end()){
-	//need to merge the components
-	//FIXME
+      if (et_it != extraTower->end()) {
+        //need to merge the components
+        //FIXME
 
-	/////	CaloTower mergedTower(*t1);
-	//one needs to merge t1 and t2 into mergedTower
-	//end FIXME
-	CaloTower mt = mergedTower(*rt_it, *et_it);
+        /////	CaloTower mergedTower(*t1);
+        //one needs to merge t1 and t2 into mergedTower
+        //end FIXME
+        CaloTower mt = mergedTower(*rt_it, *et_it);
 
-	output->push_back(mt);
-	overlappingTowers.push_back(et_it);
+        output->push_back(mt);
+        overlappingTowers.push_back(et_it);
 
-      }else{
-	//just copy the regular tower over
-	output->push_back(*rt_it);
+      } else {
+        //just copy the regular tower over
+        output->push_back(*rt_it);
       }
     }
     CaloTowerCollection::const_iterator et_begin = extraTower->begin();
     CaloTowerCollection::const_iterator et_end = extraTower->end();
-    CaloTowerCollection::const_iterator et_it=et_begin;
-    for (;et_it!=et_end;++et_it){
-      if (std::find(overlappingTowers.begin(),overlappingTowers.end(),et_it)==overlappingTowers.end())
-	//non overlapping tower
-	//copy the extra tower over
-	output->push_back(*et_it);
+    CaloTowerCollection::const_iterator et_it = et_begin;
+    for (; et_it != et_end; ++et_it) {
+      if (std::find(overlappingTowers.begin(), overlappingTowers.end(), et_it) == overlappingTowers.end())
+        //non overlapping tower
+        //copy the extra tower over
+        output->push_back(*et_it);
     }
     iEvent.put(std::move(output));
   }
-  
 }
-
 
 // Make a new tower by merging two towers containing exclusive hits
 // This cannot be done fully consistently and independent of the
 // creation mechnaism...
-// This functionlaity it to be used only for testing the effects 
+// This functionlaity it to be used only for testing the effects
 // of rejected bad hits.
 
 CaloTower CaloTowersMerger::mergedTower(const CaloTower& rt, const CaloTower& et) {
-
   double newOuterE = 0;
 
   // HO energies are always saved (even if useHO=false)
@@ -180,138 +166,128 @@ CaloTower CaloTowersMerger::mergedTower(const CaloTower& rt, const CaloTower& et
   // crude test if one has HO energy and the other not (possibly due to bad hit cleanup)
   // However: for |iEta|>15 E_outer has different meening:
   // it holds either the energy in the outer depths in HCAL, etc
-  
-  if (rt.ietaAbs()<16 && (fabs(rt.outerEnergy()-et.outerEnergy())<0.00001 ) ) {
+
+  if (rt.ietaAbs() < 16 && (fabs(rt.outerEnergy() - et.outerEnergy()) < 0.00001)) {
     // there is no differnce in the store HO energies
     newOuterE = rt.outerEnergy();
+  } else {
+    newOuterE = rt.outerEnergy() + et.outerEnergy();
   }
-  else {
-    newOuterE = rt.outerEnergy()+et.outerEnergy();
-  }
-
 
   bool rt_hasEcalConstit = false;
   bool et_hasEcalConstit = false;
-  
+
   bool rt_hasHcalConstit = false;
   bool et_hasHcalConstit = false;
 
-
   // check if there are HCAL/ECAL constituents in the towers
 
-  std::vector<DetId>::const_iterator rc_begin=rt.constituents().begin();
-  std::vector<DetId>::const_iterator rc_end=rt.constituents().end();
+  std::vector<DetId>::const_iterator rc_begin = rt.constituents().begin();
+  std::vector<DetId>::const_iterator rc_end = rt.constituents().end();
   std::vector<DetId>::const_iterator rc_it;
 
+  for (rc_it = rc_begin; rc_it != rc_end; ++rc_it) {
+    if (rc_it->det() == DetId::Hcal)
+      rt_hasHcalConstit = true;
+    break;
+  }
+  for (rc_it = rc_begin; rc_it != rc_end; ++rc_it) {
+    if (rc_it->det() == DetId::Ecal)
+      rt_hasEcalConstit = true;
+    break;
+  }
 
-   for (rc_it=rc_begin; rc_it!=rc_end; ++rc_it) {
-     if (rc_it->det()==DetId::Hcal) rt_hasHcalConstit=true;
-     break;
-   }
-   for (rc_it=rc_begin; rc_it!=rc_end; ++rc_it) {
-     if (rc_it->det()==DetId::Ecal) rt_hasEcalConstit=true;
-     break;
-   }
-
-  std::vector<DetId>::const_iterator ec_begin=et.constituents().begin();
-  std::vector<DetId>::const_iterator ec_end=et.constituents().end();
+  std::vector<DetId>::const_iterator ec_begin = et.constituents().begin();
+  std::vector<DetId>::const_iterator ec_end = et.constituents().end();
   std::vector<DetId>::const_iterator ec_it;
 
-   for (ec_it=ec_begin; ec_it!=ec_end; ++ec_it) {
-     if (ec_it->det()==DetId::Hcal) et_hasHcalConstit=true;
-     break;
-   }
-   for (ec_it=ec_begin; ec_it!=ec_end; ++ec_it) {
-     if (ec_it->det()==DetId::Ecal) et_hasEcalConstit=true;
-     break;
-   }
+  for (ec_it = ec_begin; ec_it != ec_end; ++ec_it) {
+    if (ec_it->det() == DetId::Hcal)
+      et_hasHcalConstit = true;
+    break;
+  }
+  for (ec_it = ec_begin; ec_it != ec_end; ++ec_it) {
+    if (ec_it->det() == DetId::Ecal)
+      et_hasEcalConstit = true;
+    break;
+  }
 
+  std::vector<DetId> combinedConstituents = rt.constituents();
+  for (ec_it = ec_begin; ec_it != ec_end; ++ec_it) {
+    // if properly resconstructed, the only possible overlap should be for HO hits that
+    // are always listed as constituents if above thereshold (old JetMET request)
+    if (std::find(combinedConstituents.begin(), combinedConstituents.end(), *ec_it) == combinedConstituents.end())
+      combinedConstituents.push_back(*ec_it);
+  }
 
-   std::vector<DetId> combinedConstituents = rt.constituents();
-   for (ec_it=ec_begin; ec_it!=ec_end; ++ec_it) {
-     // if properly resconstructed, the only possible overlap should be for HO hits that
-     // are always listed as constituents if above thereshold (old JetMET request)
-     if (std::find(combinedConstituents.begin(),combinedConstituents.end(), *ec_it)==combinedConstituents.end())
-       combinedConstituents.push_back(*ec_it);
-   }
+  GlobalPoint newEmPosition(0.0, 0.0, 0.0);
 
+  // The following assumes the current default
+  // momentum reconstruction method (1) and
+  // accepted rechits with some threshod >0
 
+  if (rt_hasEcalConstit && et_hasEcalConstit) {
+    if (rt.emEnergy() > 0 && et.emEnergy() > 0) {
+      double sumEmE = rt.emEnergy() + et.emEnergy();
 
-   GlobalPoint newEmPosition(0.0, 0.0, 0.0);
+      double x = rt.emEnergy() * rt.emPosition().x() + et.emEnergy() * et.emPosition().x();
+      double y = rt.emEnergy() * rt.emPosition().y() + et.emEnergy() * et.emPosition().y();
+      double z = rt.emEnergy() * rt.emPosition().z() + et.emEnergy() * et.emPosition().z();
 
-   // The following assumes the current default
-   // momentum reconstruction method (1) and 
-   // accepted rechits with some threshod >0
+      GlobalPoint weightedEmdPosition(x / sumEmE, y / sumEmE, z / sumEmE);
+      newEmPosition = weightedEmdPosition;
+    }
 
+  } else if (rt_hasEcalConstit && !et_hasEcalConstit) {
+    newEmPosition = rt.emPosition();
+  } else if (!rt_hasEcalConstit && et_hasEcalConstit) {
+    newEmPosition = et.emPosition();
+  }
 
-   if (rt_hasEcalConstit && et_hasEcalConstit) {
-    
-     if (rt.emEnergy()>0 && et.emEnergy()>0) {
-       double sumEmE = rt.emEnergy()+ et.emEnergy();
-       
-       double x =   rt.emEnergy()*rt.emPosition().x() + et.emEnergy()*et.emPosition().x();
-       double y =   rt.emEnergy()*rt.emPosition().y() + et.emEnergy()*et.emPosition().y();   
-       double z =   rt.emEnergy()*rt.emPosition().z() + et.emEnergy()*et.emPosition().z();
-      
-       GlobalPoint weightedEmdPosition(x/sumEmE,y/sumEmE,z/sumEmE);
-       newEmPosition = weightedEmdPosition;
-     }
-     
+  GlobalPoint newHadPosition(0.0, 0.0, 0.0);
+  // had positions are the same if there is at least one constituent
+  if (rt_hasHcalConstit) {
+    newHadPosition = rt.hadPosition();
+  } else if (et_hasHcalConstit) {
+    newHadPosition = et.hadPosition();
+  }
 
-   }
-   else if (rt_hasEcalConstit && !et_hasEcalConstit) {
-     newEmPosition = rt.emPosition();
-   }
-   else if (!rt_hasEcalConstit && et_hasEcalConstit) {
-     newEmPosition = et.emPosition();
-   }
-   
-   
-   GlobalPoint newHadPosition(0.0, 0.0, 0.0);
-   // had positions are the same if there is at least one constituent
-   if (rt_hasHcalConstit) {
-     newHadPosition = rt.hadPosition();
-   }
-   else if (et_hasHcalConstit) {
-     newHadPosition = et.hadPosition();
-   }
-   
+  // MAke the new tower and set all values
 
-   // MAke the new tower and set all values  
-    
-   CaloTower mergedTower(rt.id(), rt.emEnergy()+et.emEnergy(), rt.hadEnergy()+et.hadEnergy(), newOuterE, -1, -1, 
-			 rt.p4()+et.p4(), newEmPosition, newHadPosition);
-   
-   mergedTower.addConstituents(combinedConstituents);
+  CaloTower mergedTower(rt.id(),
+                        rt.emEnergy() + et.emEnergy(),
+                        rt.hadEnergy() + et.hadEnergy(),
+                        newOuterE,
+                        -1,
+                        -1,
+                        rt.p4() + et.p4(),
+                        newEmPosition,
+                        newHadPosition);
 
-   (rt.hottestCellE() > et.hottestCellE())?
-     mergedTower.setHottestCellE(rt.hottestCellE()) : 
-     mergedTower.setHottestCellE(et.hottestCellE());
+  mergedTower.addConstituents(combinedConstituents);
+
+  (rt.hottestCellE() > et.hottestCellE()) ? mergedTower.setHottestCellE(rt.hottestCellE())
+                                          : mergedTower.setHottestCellE(et.hottestCellE());
 
   unsigned int numBadHcalChan = rt.numBadHcalCells() - et.numProblematicHcalCells() - rt.numRecoveredHcalCells();
-   unsigned int numBadEcalChan = rt.numBadEcalCells() - et.numProblematicEcalCells() - rt.numRecoveredEcalCells();
+  unsigned int numBadEcalChan = rt.numBadEcalCells() - et.numProblematicEcalCells() - rt.numRecoveredEcalCells();
 
-   unsigned int numProbHcalChan = rt.numProblematicHcalCells() + et.numProblematicHcalCells();
-   unsigned int numProbEcalChan = rt.numProblematicEcalCells() + et.numProblematicEcalCells();
+  unsigned int numProbHcalChan = rt.numProblematicHcalCells() + et.numProblematicHcalCells();
+  unsigned int numProbEcalChan = rt.numProblematicEcalCells() + et.numProblematicEcalCells();
 
-   unsigned int numRecHcalChan = rt.numRecoveredHcalCells() + et.numRecoveredHcalCells();
-   unsigned int numRecEcalChan = rt.numRecoveredEcalCells() + et.numRecoveredEcalCells();
+  unsigned int numRecHcalChan = rt.numRecoveredHcalCells() + et.numRecoveredHcalCells();
+  unsigned int numRecEcalChan = rt.numRecoveredEcalCells() + et.numRecoveredEcalCells();
 
-   mergedTower.setCaloTowerStatus(numBadHcalChan, numBadEcalChan,    
-				  numRecHcalChan, numRecEcalChan,    
-				  numProbHcalChan, numProbEcalChan);
+  mergedTower.setCaloTowerStatus(
+      numBadHcalChan, numBadEcalChan, numRecHcalChan, numRecEcalChan, numProbHcalChan, numProbEcalChan);
 
-   // use timing from the good tower only (for now, in default reco we use information from good hits only)
-   // time is saved as integer but returned as float in (ns)
-   mergedTower.setEcalTime( int(rt.ecalTime()*100.0 + 0.5) );
-   mergedTower.setHcalTime( int(rt.hcalTime()*100.0 + 0.5) );
-
+  // use timing from the good tower only (for now, in default reco we use information from good hits only)
+  // time is saved as integer but returned as float in (ns)
+  mergedTower.setEcalTime(int(rt.ecalTime() * 100.0 + 0.5));
+  mergedTower.setHcalTime(int(rt.hcalTime() * 100.0 + 0.5));
 
   return mergedTower;
-
 }
-
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(CaloTowersMerger);

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersReCreator.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersReCreator.cc
@@ -3,54 +3,74 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-CaloTowersReCreator::CaloTowersReCreator(const edm::ParameterSet& conf) : 
-  algo_(0.,0., false, false, false, false, 0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,0.,// thresholds cannot be reapplied
-        conf.getParameter<std::vector<double> >("EBGrid"),
-        conf.getParameter<std::vector<double> >("EBWeights"),
-        conf.getParameter<std::vector<double> >("EEGrid"),
-        conf.getParameter<std::vector<double> >("EEWeights"),
-        conf.getParameter<std::vector<double> >("HBGrid"),
-        conf.getParameter<std::vector<double> >("HBWeights"),
-        conf.getParameter<std::vector<double> >("HESGrid"),
-        conf.getParameter<std::vector<double> >("HESWeights"),
-        conf.getParameter<std::vector<double> >("HEDGrid"),
-        conf.getParameter<std::vector<double> >("HEDWeights"),
-        conf.getParameter<std::vector<double> >("HOGrid"),
-        conf.getParameter<std::vector<double> >("HOWeights"),
-        conf.getParameter<std::vector<double> >("HF1Grid"),
-        conf.getParameter<std::vector<double> >("HF1Weights"),
-        conf.getParameter<std::vector<double> >("HF2Grid"),
-        conf.getParameter<std::vector<double> >("HF2Weights"),
-        conf.getParameter<double>("EBWeight"),
-        conf.getParameter<double>("EEWeight"),
-        conf.getParameter<double>("HBWeight"),
-        conf.getParameter<double>("HESWeight"),
-        conf.getParameter<double>("HEDWeight"),
-        conf.getParameter<double>("HOWeight"),
-        conf.getParameter<double>("HF1Weight"),
-        conf.getParameter<double>("HF2Weight"),
-        0.,0.,0.,
-        conf.getParameter<bool>("UseHO"),
-        // (these have no effect on recreation: here for compatibility)
-        conf.getParameter<int>("MomConstrMethod"),
-        conf.getParameter<double>("MomHBDepth"),
-        conf.getParameter<double>("MomHEDepth"),
-        conf.getParameter<double>("MomEBDepth"),
-        conf.getParameter<double>("MomEEDepth"),
-        conf.getParameter<int>("HcalPhase")
-        ),
-  allowMissingInputs_(false)
-{
+CaloTowersReCreator::CaloTowersReCreator(const edm::ParameterSet& conf)
+    : algo_(0.,
+            0.,
+            false,
+            false,
+            false,
+            false,
+            0.,
+            0.,
+            0.,
+            0.,
+            0.,
+            0.,
+            0.,
+            0.,
+            0.,
+            0.,
+            0.,
+            0.,
+            0.,
+            0.,
+            0.,  // thresholds cannot be reapplied
+            conf.getParameter<std::vector<double> >("EBGrid"),
+            conf.getParameter<std::vector<double> >("EBWeights"),
+            conf.getParameter<std::vector<double> >("EEGrid"),
+            conf.getParameter<std::vector<double> >("EEWeights"),
+            conf.getParameter<std::vector<double> >("HBGrid"),
+            conf.getParameter<std::vector<double> >("HBWeights"),
+            conf.getParameter<std::vector<double> >("HESGrid"),
+            conf.getParameter<std::vector<double> >("HESWeights"),
+            conf.getParameter<std::vector<double> >("HEDGrid"),
+            conf.getParameter<std::vector<double> >("HEDWeights"),
+            conf.getParameter<std::vector<double> >("HOGrid"),
+            conf.getParameter<std::vector<double> >("HOWeights"),
+            conf.getParameter<std::vector<double> >("HF1Grid"),
+            conf.getParameter<std::vector<double> >("HF1Weights"),
+            conf.getParameter<std::vector<double> >("HF2Grid"),
+            conf.getParameter<std::vector<double> >("HF2Weights"),
+            conf.getParameter<double>("EBWeight"),
+            conf.getParameter<double>("EEWeight"),
+            conf.getParameter<double>("HBWeight"),
+            conf.getParameter<double>("HESWeight"),
+            conf.getParameter<double>("HEDWeight"),
+            conf.getParameter<double>("HOWeight"),
+            conf.getParameter<double>("HF1Weight"),
+            conf.getParameter<double>("HF2Weight"),
+            0.,
+            0.,
+            0.,
+            conf.getParameter<bool>("UseHO"),
+            // (these have no effect on recreation: here for compatibility)
+            conf.getParameter<int>("MomConstrMethod"),
+            conf.getParameter<double>("MomHBDepth"),
+            conf.getParameter<double>("MomHEDepth"),
+            conf.getParameter<double>("MomEBDepth"),
+            conf.getParameter<double>("MomEEDepth"),
+            conf.getParameter<int>("HcalPhase")),
+      allowMissingInputs_(false) {
   tok_calo_ = consumes<CaloTowerCollection>(conf.getParameter<edm::InputTag>("caloLabel"));
 
-  EBEScale=conf.getParameter<double>("EBEScale");
-  EEEScale=conf.getParameter<double>("EEEScale");
-  HBEScale=conf.getParameter<double>("HBEScale");
-  HESEScale=conf.getParameter<double>("HESEScale");
-  HEDEScale=conf.getParameter<double>("HEDEScale");
-  HOEScale=conf.getParameter<double>("HOEScale");
-  HF1EScale=conf.getParameter<double>("HF1EScale");
-  HF2EScale=conf.getParameter<double>("HF2EScale");
+  EBEScale = conf.getParameter<double>("EBEScale");
+  EEEScale = conf.getParameter<double>("EEEScale");
+  HBEScale = conf.getParameter<double>("HBEScale");
+  HESEScale = conf.getParameter<double>("HESEScale");
+  HEDEScale = conf.getParameter<double>("HEDEScale");
+  HOEScale = conf.getParameter<double>("HOEScale");
+  HF1EScale = conf.getParameter<double>("HF1EScale");
+  HF2EScale = conf.getParameter<double>("HF2EScale");
   //  two notes:
   //  1) all this could go in a pset
   //  2) not clear the instanceLabel thing
@@ -77,14 +97,13 @@ void CaloTowersReCreator::produce(edm::Event& e, const edm::EventSetup& c) {
   algo_.setHOEScale(HOEScale);
   algo_.setHF1EScale(HF1EScale);
   algo_.setHF2EScale(HF2EScale);
-  algo_.setGeometry(cttopo.product(),ctmap.product(),htopo.product(),pG.product());
+  algo_.setGeometry(cttopo.product(), ctmap.product(), htopo.product(), pG.product());
 
-  algo_.begin(); // clear the internal buffer
-  
+  algo_.begin();  // clear the internal buffer
+
   // Step A/C: Get Inputs and process (repeatedly)
   edm::Handle<CaloTowerCollection> calt;
-  e.getByToken(tok_calo_,calt);
-
+  e.getByToken(tok_calo_, calt);
 
   // modified to rescale the CaloTowers directly
   // without going through metatowers

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersReCreator.h
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersReCreator.h
@@ -19,11 +19,12 @@
 class CaloTowersReCreator : public edm::stream::EDProducer<> {
 public:
   explicit CaloTowersReCreator(const edm::ParameterSet& ps);
-  ~CaloTowersReCreator() override { }
+  ~CaloTowersReCreator() override {}
   void produce(edm::Event& e, const edm::EventSetup& c) override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   double EBEScale, EEEScale, HBEScale, HESEScale;
   double HEDEScale, HOEScale, HF1EScale, HF2EScale;
+
 private:
   CaloTowersCreationAlgo algo_;
   edm::EDGetTokenT<CaloTowerCollection> tok_calo_;

--- a/RecoLocalCalo/CaloTowersCreator/src/HcalMaterials.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/HcalMaterials.cc
@@ -4,13 +4,13 @@
 
 HcalMaterials::HcalMaterials() {}
 
-HcalMaterials::~HcalMaterials(){}
+HcalMaterials::~HcalMaterials() {}
 
-float HcalMaterials::getValue (DetId fId, float energy) {
+float HcalMaterials::getValue(DetId fId, float energy) {
   // a real function should be added
   float value = 0.;
-  for(unsigned int iItem=0; iItem<mItems.size();iItem++){
-    if(fId.rawId()==mItems[iItem].mmId()){
+  for (unsigned int iItem = 0; iItem < mItems.size(); iItem++) {
+    if (fId.rawId() == mItems[iItem].mmId()) {
       value = mItems[iItem].getValue(energy);
       continue;
     }
@@ -18,9 +18,7 @@ float HcalMaterials::getValue (DetId fId, float energy) {
   return value;
 }
 
-void HcalMaterials::putValue (DetId fId, const std::pair< std::vector <float>,std::vector <float> >& fArray) {
-  Item item (fId.rawId (), fArray);
-  mItems.push_back (item);
+void HcalMaterials::putValue(DetId fId, const std::pair<std::vector<float>, std::vector<float> >& fArray) {
+  Item item(fId.rawId(), fArray);
+  mItems.push_back(item);
 }
-
-

--- a/RecoLocalCalo/CaloTowersCreator/src/SealModule.cc
+++ b/RecoLocalCalo/CaloTowersCreator/src/SealModule.cc
@@ -4,9 +4,8 @@
 #include "RecoLocalCalo/CaloTowersCreator/src/CaloTowersReCreator.h"
 #include "RecoLocalCalo/CaloTowersCreator/src/CaloTowerCandidateCreator.h"
 
-
-DEFINE_FWK_MODULE( CaloTowersCreator );
-DEFINE_FWK_MODULE( CaloTowersReCreator );
+DEFINE_FWK_MODULE(CaloTowersCreator);
+DEFINE_FWK_MODULE(CaloTowersReCreator);
 // remove following line after Jet/Met move to using
 // exclusively CaloTowers
-DEFINE_FWK_MODULE( CaloTowerCandidateCreator );
+DEFINE_FWK_MODULE(CaloTowerCandidateCreator);

--- a/RecoLocalTracker/ClusterParameterEstimator/interface/ClusterParameterEstimator.h
+++ b/RecoLocalTracker/ClusterParameterEstimator/interface/ClusterParameterEstimator.h
@@ -8,39 +8,39 @@
 #include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
-template <class T> 
+template <class T>
 class ClusterParameterEstimator {
-  
- public:
-  typedef std::pair<LocalPoint,LocalError>  LocalValues;
+public:
+  typedef std::pair<LocalPoint, LocalError> LocalValues;
   typedef std::vector<LocalValues> VLocalValues;
-  virtual LocalValues localParameters( const T&,const GeomDetUnit&) const = 0; 
-  virtual LocalValues localParameters( const T& cluster, const GeomDetUnit& gd, const LocalTrajectoryParameters&) const {
-    return localParameters(cluster,gd);
+  virtual LocalValues localParameters(const T&, const GeomDetUnit&) const = 0;
+  virtual LocalValues localParameters(const T& cluster, const GeomDetUnit& gd, const LocalTrajectoryParameters&) const {
+    return localParameters(cluster, gd);
   }
-  virtual LocalValues localParameters( const T& cluster, const GeomDetUnit& gd, const TrajectoryStateOnSurface& tsos) const {
-    return localParameters(cluster,gd,tsos.localParameters());
+  virtual LocalValues localParameters(const T& cluster,
+                                      const GeomDetUnit& gd,
+                                      const TrajectoryStateOnSurface& tsos) const {
+    return localParameters(cluster, gd, tsos.localParameters());
   }
-  virtual VLocalValues localParametersV( const T& cluster, const GeomDetUnit& gd) const {
+  virtual VLocalValues localParametersV(const T& cluster, const GeomDetUnit& gd) const {
     VLocalValues vlp;
-    vlp.push_back(localParameters(cluster,gd));
+    vlp.push_back(localParameters(cluster, gd));
     return vlp;
   }
-  virtual VLocalValues localParametersV( const T& cluster, const GeomDetUnit& gd, const TrajectoryStateOnSurface& tsos) const {
+  virtual VLocalValues localParametersV(const T& cluster,
+                                        const GeomDetUnit& gd,
+                                        const TrajectoryStateOnSurface& tsos) const {
     VLocalValues vlp;
-    vlp.push_back(localParameters(cluster,gd,tsos.localParameters()));
+    vlp.push_back(localParameters(cluster, gd, tsos.localParameters()));
     return vlp;
   }
-  
-  virtual ~ClusterParameterEstimator(){}
-  
+
+  virtual ~ClusterParameterEstimator() {}
+
   //methods needed by FastSim
-  virtual void enterLocalParameters(unsigned int id, std::pair<int,int>
-				    &row_col, LocalValues pos_err_info) const {}
-  virtual void enterLocalParameters(uint32_t id, uint16_t firstStrip,
-				    LocalValues pos_err_info) const {}
+  virtual void enterLocalParameters(unsigned int id, std::pair<int, int>& row_col, LocalValues pos_err_info) const {}
+  virtual void enterLocalParameters(uint32_t id, uint16_t firstStrip, LocalValues pos_err_info) const {}
   virtual void clearParameters() const {}
-  
 };
 
 #endif

--- a/RecoLocalTracker/ClusterParameterEstimator/interface/FakeCPE.h
+++ b/RecoLocalTracker/ClusterParameterEstimator/interface/FakeCPE.h
@@ -9,7 +9,6 @@
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 
-
 #include <cstdint>
 #include <unordered_map>
 
@@ -17,51 +16,53 @@
 
 class FakeCPE {
 public:
-
-  using LocalValues = std::pair<LocalPoint,LocalError>;
+  using LocalValues = std::pair<LocalPoint, LocalError>;
 
   // store position and error for each cluster...
   class Map {
-  public: 
-     using LocalValues = std::pair<LocalPoint,LocalError>;
-     void clear() {m_map.clear();}
-     void error(const GeomDetUnit& gd) const {edm::LogError("FakeCPE") << "hit not found in det " << gd.geographicalId().rawId();  }
-     template<typename Cluster>
-     void add(const Cluster& cluster, const GeomDetUnit& gd,LocalValues const & lv) { m_map[encode(cluster,gd)] = lv; }
+  public:
+    using LocalValues = std::pair<LocalPoint, LocalError>;
+    void clear() { m_map.clear(); }
+    void error(const GeomDetUnit& gd) const {
+      edm::LogError("FakeCPE") << "hit not found in det " << gd.geographicalId().rawId();
+    }
+    template <typename Cluster>
+    void add(const Cluster& cluster, const GeomDetUnit& gd, LocalValues const& lv) {
+      m_map[encode(cluster, gd)] = lv;
+    }
 
-     template<typename Cluster>
-     LocalValues const & get(const Cluster& cluster, const GeomDetUnit& gd) const {
-       auto p = m_map.find(encode(cluster,gd));
-       if (p!=m_map.end()) { return (*p).second; }
-       error(gd);
-       return dummy;
-     }
+    template <typename Cluster>
+    LocalValues const& get(const Cluster& cluster, const GeomDetUnit& gd) const {
+      auto p = m_map.find(encode(cluster, gd));
+      if (p != m_map.end()) {
+        return (*p).second;
+      }
+      error(gd);
+      return dummy;
+    }
 
-     static uint64_t encode(const SiPixelCluster& cluster, const GeomDetUnit& det) {
-          uint64_t u1 = det.geographicalId().rawId();
-          uint64_t u2 = cluster.minPixelRow();
-          uint64_t u3 = cluster.minPixelCol();
-          return (u1<<32) | (u2<<16) | u3;
-     }
-     static uint64_t encode(const SiStripCluster& cluster, const GeomDetUnit& det) {
-          uint64_t u1 = det.geographicalId().rawId();
-          uint64_t u2 = cluster.firstStrip();
-       	  return (u1<<32) | u2;
-     }
+    static uint64_t encode(const SiPixelCluster& cluster, const GeomDetUnit& det) {
+      uint64_t u1 = det.geographicalId().rawId();
+      uint64_t u2 = cluster.minPixelRow();
+      uint64_t u3 = cluster.minPixelCol();
+      return (u1 << 32) | (u2 << 16) | u3;
+    }
+    static uint64_t encode(const SiStripCluster& cluster, const GeomDetUnit& det) {
+      uint64_t u1 = det.geographicalId().rawId();
+      uint64_t u2 = cluster.firstStrip();
+      return (u1 << 32) | u2;
+    }
 
-  private: 
-     std::unordered_map<uint64_t,LocalValues> m_map;
-     LocalValues dummy;
+  private:
+    std::unordered_map<uint64_t, LocalValues> m_map;
+    LocalValues dummy;
   };
- 
 
-  Map & map() { return m_map;}
-  Map const & map() const { return m_map;}
+  Map& map() { return m_map; }
+  Map const& map() const { return m_map; }
 
 private:
-
   Map m_map;
-
 };
 
 #endif

--- a/RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h
+++ b/RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h
@@ -10,33 +10,30 @@
 
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitQuality.h"
-#include<tuple>
+#include <tuple>
 
-class PixelClusterParameterEstimator
-{
-  public:
+class PixelClusterParameterEstimator {
+public:
+  virtual ~PixelClusterParameterEstimator() {}
 
-  virtual ~PixelClusterParameterEstimator(){}
-  
-  typedef std::pair<LocalPoint,LocalError>  LocalValues;
+  typedef std::pair<LocalPoint, LocalError> LocalValues;
   typedef std::vector<LocalValues> VLocalValues;
 
-  using ReturnType = std::tuple<LocalPoint,LocalError,SiPixelRecHitQuality::QualWordType>;
+  using ReturnType = std::tuple<LocalPoint, LocalError, SiPixelRecHitQuality::QualWordType>;
 
   // here just to implement it in the clients;
   // to be properly implemented in the sub-classes in order to make them thread-safe
 
-  virtual ReturnType getParameters(const SiPixelCluster & cl, 
-                                   const GeomDetUnit    & det) const =0;
+  virtual ReturnType getParameters(const SiPixelCluster& cl, const GeomDetUnit& det) const = 0;
 
-  virtual ReturnType getParameters(const SiPixelCluster & cl, 
-				   const GeomDetUnit    & det, 
-				   const LocalTrajectoryParameters & ltp ) const =0;
+  virtual ReturnType getParameters(const SiPixelCluster& cl,
+                                   const GeomDetUnit& det,
+                                   const LocalTrajectoryParameters& ltp) const = 0;
 
-  virtual ReturnType getParameters(const SiPixelCluster & cl, 
-				   const GeomDetUnit    & det, 
-				   const TrajectoryStateOnSurface& tsos ) const {
-    return getParameters(cl,det,tsos.localParameters());
+  virtual ReturnType getParameters(const SiPixelCluster& cl,
+                                   const GeomDetUnit& det,
+                                   const TrajectoryStateOnSurface& tsos) const {
+    return getParameters(cl, det, tsos.localParameters());
   }
 
   virtual VLocalValues localParametersV(const SiPixelCluster& cluster, const GeomDetUnit& gd) const {
@@ -45,34 +42,30 @@ class PixelClusterParameterEstimator
     vlp.push_back(std::make_pair(std::get<0>(tuple), std::get<1>(tuple)));
     return vlp;
   }
-  virtual VLocalValues localParametersV(const SiPixelCluster& cluster, const GeomDetUnit& gd, TrajectoryStateOnSurface& tsos) const {
+  virtual VLocalValues localParametersV(const SiPixelCluster& cluster,
+                                        const GeomDetUnit& gd,
+                                        TrajectoryStateOnSurface& tsos) const {
     VLocalValues vlp;
-    ReturnType tuple = getParameters(cluster,  gd, tsos);
+    ReturnType tuple = getParameters(cluster, gd, tsos);
     vlp.push_back(std::make_pair(std::get<0>(tuple), std::get<1>(tuple)));
     return vlp;
   }
 
-
-  PixelClusterParameterEstimator() : clusterProbComputationFlag_(0){}
+  PixelClusterParameterEstimator() : clusterProbComputationFlag_(0) {}
 
   //--- Flag to control how SiPixelRecHits compute clusterProbability().
   //--- Note this is set via the configuration file, and it's simply passed
   //--- to each TSiPixelRecHit.
-  inline unsigned int clusterProbComputationFlag() const 
-    { 
-      return clusterProbComputationFlag_ ; 
-    }
-  
-  
-  protected:
- //--- A flag that could be used to change the behavior of
+  inline unsigned int clusterProbComputationFlag() const { return clusterProbComputationFlag_; }
+
+protected:
+  //--- A flag that could be used to change the behavior of
   //--- clusterProbability() in TSiPixelRecHit (the *transient* one).
   //--- The problem is that the transient hits are made after the CPE runs
   //--- and they don't get the access to the PSet, so we pass it via the
   //--- CPE itself...
   //
   unsigned int clusterProbComputationFlag_;
-
 };
 
 #endif

--- a/RecoLocalTracker/ClusterParameterEstimator/interface/PixelFakeCPE.h
+++ b/RecoLocalTracker/ClusterParameterEstimator/interface/PixelFakeCPE.h
@@ -10,44 +10,40 @@
 
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitQuality.h"
-#include<tuple>
-
+#include <tuple>
 
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/FakeCPE.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
 
 class PixelFakeCPE final : public PixelClusterParameterEstimator {
 public:
-
   PixelFakeCPE() = default;
   ~PixelFakeCPE() = default;
 
-  typedef std::pair<LocalPoint,LocalError>  LocalValues;
+  typedef std::pair<LocalPoint, LocalError> LocalValues;
   typedef std::vector<LocalValues> VLocalValues;
 
-  using ReturnType = std::tuple<LocalPoint,LocalError,SiPixelRecHitQuality::QualWordType>;
+  using ReturnType = std::tuple<LocalPoint, LocalError, SiPixelRecHitQuality::QualWordType>;
 
   // here just to implement it in the clients;
   // to be properly implemented in the sub-classes in order to make them thread-safe
 
-  ReturnType getParameters(const SiPixelCluster & cl, 
-                                   const GeomDetUnit    & det) const override {
-   auto const & lv = fakeCPE().map().get(cl,det);
-   return {lv.first,lv.second,0};
+  ReturnType getParameters(const SiPixelCluster &cl, const GeomDetUnit &det) const override {
+    auto const &lv = fakeCPE().map().get(cl, det);
+    return {lv.first, lv.second, 0};
   }
 
-  ReturnType getParameters(const SiPixelCluster & cl, 
-				   const GeomDetUnit    & det, 
-				   const LocalTrajectoryParameters &) const override{
-      return getParameters(cl,det);
-   }
+  ReturnType getParameters(const SiPixelCluster &cl,
+                           const GeomDetUnit &det,
+                           const LocalTrajectoryParameters &) const override {
+    return getParameters(cl, det);
+  }
 
-  void setFakeCPE(FakeCPE * iFakeCPE) { m_fakeCPE = iFakeCPE;} 
-  FakeCPE const & fakeCPE() const { return *m_fakeCPE; }
+  void setFakeCPE(FakeCPE *iFakeCPE) { m_fakeCPE = iFakeCPE; }
+  FakeCPE const &fakeCPE() const { return *m_fakeCPE; }
 
 private:
-  FakeCPE const * m_fakeCPE=nullptr;
-
+  FakeCPE const *m_fakeCPE = nullptr;
 };
 
 #endif

--- a/RecoLocalTracker/ClusterParameterEstimator/interface/StripClusterParameterEstimator.h
+++ b/RecoLocalTracker/ClusterParameterEstimator/interface/StripClusterParameterEstimator.h
@@ -16,58 +16,54 @@
 #include "CommonTools/Utils/interface/DynArray.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-
 /**
     A StripClusterParameterEstimator specific for strips
    also implements direct access to measurement frame, since that is needed during the track refitting
 
 **/
 
-class StripClusterParameterEstimator
-{
- public:
-  using LocalValues = std::pair<LocalPoint,LocalError>;
+class StripClusterParameterEstimator {
+public:
+  using LocalValues = std::pair<LocalPoint, LocalError>;
   using ALocalValues = DynArray<LocalValues>;
-  using AClusters =  DynArray<SiStripCluster const *>;
+  using AClusters = DynArray<SiStripCluster const*>;
   typedef std::vector<LocalValues> VLocalValues;
 
-  virtual void localParameters(AClusters const & clusters, ALocalValues & retValues, const GeomDetUnit& gd, const LocalTrajectoryParameters & ltp) const {
-  }
+  virtual void localParameters(AClusters const& clusters,
+                               ALocalValues& retValues,
+                               const GeomDetUnit& gd,
+                               const LocalTrajectoryParameters& ltp) const {}
 
-  
-  virtual LocalValues localParameters( const SiStripCluster&,const GeomDetUnit&) const {
-      return std::make_pair(LocalPoint(), LocalError());
+  virtual LocalValues localParameters(const SiStripCluster&, const GeomDetUnit&) const {
+    return std::make_pair(LocalPoint(), LocalError());
   }
-  virtual LocalValues localParameters( const SiStripCluster& cluster, const GeomDetUnit& gd, const LocalTrajectoryParameters&) const {
-    return localParameters(cluster,gd);
+  virtual LocalValues localParameters(const SiStripCluster& cluster,
+                                      const GeomDetUnit& gd,
+                                      const LocalTrajectoryParameters&) const {
+    return localParameters(cluster, gd);
   }
-  virtual LocalValues localParameters( const SiStripCluster& cluster, const GeomDetUnit& gd, const TrajectoryStateOnSurface& tsos) const {
-    return localParameters(cluster,gd,tsos.localParameters());
+  virtual LocalValues localParameters(const SiStripCluster& cluster,
+                                      const GeomDetUnit& gd,
+                                      const TrajectoryStateOnSurface& tsos) const {
+    return localParameters(cluster, gd, tsos.localParameters());
   }
-  virtual VLocalValues localParametersV( const SiStripCluster& cluster, const GeomDetUnit& gd) const {
+  virtual VLocalValues localParametersV(const SiStripCluster& cluster, const GeomDetUnit& gd) const {
     VLocalValues vlp;
-    vlp.push_back(localParameters(cluster,gd));
+    vlp.push_back(localParameters(cluster, gd));
     return vlp;
   }
-  virtual VLocalValues localParametersV( const SiStripCluster& cluster, const GeomDetUnit& gd, const TrajectoryStateOnSurface& tsos) const {
+  virtual VLocalValues localParametersV(const SiStripCluster& cluster,
+                                        const GeomDetUnit& gd,
+                                        const TrajectoryStateOnSurface& tsos) const {
     VLocalValues vlp;
-    vlp.push_back(localParameters(cluster,gd,tsos.localParameters()));
+    vlp.push_back(localParameters(cluster, gd, tsos.localParameters()));
     return vlp;
   }
 
-  
   // used by Validation....
-  virtual LocalVector driftDirection(const StripGeomDetUnit* ) const =0;
+  virtual LocalVector driftDirection(const StripGeomDetUnit*) const = 0;
 
-  virtual ~StripClusterParameterEstimator(){}
-  
-
-
+  virtual ~StripClusterParameterEstimator() {}
 };
 
-
 #endif
-
-
-
-

--- a/RecoLocalTracker/ClusterParameterEstimator/interface/StripFakeCPE.h
+++ b/RecoLocalTracker/ClusterParameterEstimator/interface/StripFakeCPE.h
@@ -16,40 +16,28 @@
 #include "CommonTools/Utils/interface/DynArray.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/FakeCPE.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/StripClusterParameterEstimator.h"
 
-class StripFakeCPE final : public StripClusterParameterEstimator
-{
- public:
-
-  StripFakeCPE() = default; 
+class StripFakeCPE final : public StripClusterParameterEstimator {
+public:
+  StripFakeCPE() = default;
   ~StripFakeCPE() override = default;
 
-  using LocalValues = std::pair<LocalPoint,LocalError>;
+  using LocalValues = std::pair<LocalPoint, LocalError>;
 
-  LocalValues localParameters( const SiStripCluster& cl , const GeomDetUnit& gd) const override {
-     return fakeCPE().map().get(cl,gd);
+  LocalValues localParameters(const SiStripCluster& cl, const GeomDetUnit& gd) const override {
+    return fakeCPE().map().get(cl, gd);
   }
 
   // used by Validation....
-  LocalVector driftDirection(const StripGeomDetUnit* ) const override { return LocalVector();}
+  LocalVector driftDirection(const StripGeomDetUnit*) const override { return LocalVector(); }
 
-  void setFakeCPE(FakeCPE * iFakeCPE) { m_fakeCPE = iFakeCPE;}
-  FakeCPE const & fakeCPE() const { return *m_fakeCPE; }
-
+  void setFakeCPE(FakeCPE* iFakeCPE) { m_fakeCPE = iFakeCPE; }
+  FakeCPE const& fakeCPE() const { return *m_fakeCPE; }
 
 private:
-
-  FakeCPE const * m_fakeCPE=nullptr;
-
-  
+  FakeCPE const* m_fakeCPE = nullptr;
 };
 
-
 #endif
-
-
-
-

--- a/RecoLocalTracker/ClusterParameterEstimator/src/module.cc
+++ b/RecoLocalTracker/ClusterParameterEstimator/src/module.cc
@@ -3,7 +3,6 @@
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/StripClusterParameterEstimator.h"
 
-
 //--- Now use the Framework macros to set it all up:
 //
 TYPELOOKUP_DATA_REG(PixelClusterParameterEstimator);

--- a/RecoVertex/AdaptiveVertexFinder/interface/AdaptiveVertexReconstructor.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/AdaptiveVertexReconstructor.h
@@ -8,7 +8,6 @@
 
 class AdaptiveVertexReconstructor : public VertexReconstructor {
 public:
-
   /***
    *
    * \paramname primcut sigma_cut for the first iteration
@@ -18,8 +17,7 @@ public:
    * stay in a fitted vertex
    * \paramname smoothing perform track smoothing?
    */
-  AdaptiveVertexReconstructor( float primcut = 2.0, float seccut = 6.0,
-                               float minweight = 0.5, bool smoothing = false );
+  AdaptiveVertexReconstructor(float primcut = 2.0, float seccut = 6.0, float minweight = 0.5, bool smoothing = false);
 
   ~AdaptiveVertexReconstructor() override;
 
@@ -30,55 +28,50 @@ public:
    *  double minweight
    *  for descriptions see 
    */
-  AdaptiveVertexReconstructor( const edm::ParameterSet & s );
+  AdaptiveVertexReconstructor(const edm::ParameterSet &s);
 
-  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> & v ) const override;
-  
-  std::vector<TransientVertex> 
-    vertices(const std::vector<reco::TransientTrack> &, const reco::BeamSpot & ) const override; 
-  
-  std::vector<TransientVertex> 
-    vertices(const std::vector<reco::TransientTrack> & primaries,
-             const std::vector<reco::TransientTrack> & tracks, 
-             const reco::BeamSpot & ) const override; 
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &v) const override;
 
-  AdaptiveVertexReconstructor * clone() const override {
-    return new AdaptiveVertexReconstructor( * this );
-  }
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &,
+                                        const reco::BeamSpot &) const override;
+
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &primaries,
+                                        const std::vector<reco::TransientTrack> &tracks,
+                                        const reco::BeamSpot &) const override;
+
+  AdaptiveVertexReconstructor *clone() const override { return new AdaptiveVertexReconstructor(*this); }
 
 private:
   /**
    *  the actual fit to avoid code duplication
    */
-  std::vector<TransientVertex> 
-    vertices( const std::vector<reco::TransientTrack> & primaries,
-              const std::vector<reco::TransientTrack> & trks,
-              const reco::BeamSpot &, bool has_primaries, bool usespot ) const; 
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &primaries,
+                                        const std::vector<reco::TransientTrack> &trks,
+                                        const reco::BeamSpot &,
+                                        bool has_primaries,
+                                        bool usespot) const;
 
   /**
    *  contrary to what its name has you believe, ::erase removes all
    *  newvtx.originalTracks() above theMinWeight from remainingtrks.
    */
-  void erase ( const TransientVertex & newvtx,
-             std::set < reco::TransientTrack > & remainingtrks, float w ) const;
+  void erase(const TransientVertex &newvtx, std::set<reco::TransientTrack> &remainingtrks, float w) const;
 
   /**
    *  cleanup reconstructed vertices. discard all with too few significant
    *  tracks.
    */
-  std::vector<TransientVertex> cleanUpVertices ( 
-      const std::vector < TransientVertex > & ) const;
+  std::vector<TransientVertex> cleanUpVertices(const std::vector<TransientVertex> &) const;
 
   /** setup the vertex fitters.
    */
-  void setupFitters ( float primcut, float primT, float primr,
-      float seccut, float secT, float secr, bool smoothing );
+  void setupFitters(float primcut, float primT, float primr, float seccut, float secT, float secr, bool smoothing);
 
-  TransientVertex cleanUp ( const TransientVertex & old ) const;
+  TransientVertex cleanUp(const TransientVertex &old) const;
 
 private:
-  AdaptiveVertexFitter * thePrimaryFitter; // one fitter for the primaries ...
-  AdaptiveVertexFitter * theSecondaryFitter; // ... and one for the rest.
+  AdaptiveVertexFitter *thePrimaryFitter;    // one fitter for the primaries ...
+  AdaptiveVertexFitter *theSecondaryFitter;  // ... and one for the rest.
 
   // the minimum weight for a track to stay in a vertex.
   float theMinWeight;

--- a/RecoVertex/AdaptiveVertexFinder/interface/SVTimeHelpers.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/SVTimeHelpers.h
@@ -1,35 +1,35 @@
 #ifndef __RecoVertex_AdaptiveVertexFinder_SVTimeHelpers_h__
-#define __RecoVertex_AdaptiveVertexFinder_SVTimeHelpers_h__ 
+#define __RecoVertex_AdaptiveVertexFinder_SVTimeHelpers_h__
 
 #include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 
 #include "FWCore/Utilities/interface/isFinite.h"
 
-namespace svhelper{
+namespace svhelper {
 
   inline void updateVertexTime(TransientVertex& vtx) {
     const auto& trks = vtx.originalTracks();
-    double meantime = 0., expv_x2 = 0., normw = 0., timecov = 0.;		  
-    for( const auto& trk : trks ) {
-      if( edm::isFinite(trk.timeExt()) ) {
-	const double time = trk.timeExt();
-	const double inverr = 1.0/trk.dtErrorExt();
-	const double w = inverr*inverr;
-	meantime += time*w;
-	expv_x2  += time*time*w;
-	normw    += w;
+    double meantime = 0., expv_x2 = 0., normw = 0., timecov = 0.;
+    for (const auto& trk : trks) {
+      if (edm::isFinite(trk.timeExt())) {
+        const double time = trk.timeExt();
+        const double inverr = 1.0 / trk.dtErrorExt();
+        const double w = inverr * inverr;
+        meantime += time * w;
+        expv_x2 += time * time * w;
+        normw += w;
       }
     }
-    if( normw > 0. ) {
-      meantime = meantime/normw;
-      expv_x2 = expv_x2/normw;
-      timecov = expv_x2 - meantime*meantime;
+    if (normw > 0.) {
+      meantime = meantime / normw;
+      expv_x2 = expv_x2 / normw;
+      timecov = expv_x2 - meantime * meantime;
       auto err = vtx.positionError().matrix4D();
-      err(3,3) = timecov/(double)trks.size();  
-      vtx = TransientVertex(vtx.position(),meantime,err,vtx.originalTracks(),vtx.totalChiSquared());
+      err(3, 3) = timecov / (double)trks.size();
+      vtx = TransientVertex(vtx.position(), meantime, err, vtx.originalTracks(), vtx.totalChiSquared());
     }
   }
-}
+}  // namespace svhelper
 
 #endif

--- a/RecoVertex/AdaptiveVertexFinder/interface/TTHelpers.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/TTHelpers.h
@@ -6,16 +6,19 @@
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 
-namespace tthelpers{
-inline reco::TransientTrack buildTT(edm::Handle<reco::TrackCollection> & tracks, edm::ESHandle<TransientTrackBuilder> &trackbuilder, unsigned int k) 
-{
-        reco::TrackRef ref(tracks, k);
-        return trackbuilder->build(ref);
-}
-inline reco::TransientTrack buildTT(edm::Handle<edm::View<reco::Candidate> > & tracks, edm::ESHandle<TransientTrackBuilder> &trackbuilder, unsigned int k)
-{
-	if((*tracks)[k].bestTrack() == nullptr) return reco::TransientTrack();
-        return trackbuilder->build(tracks->ptrAt(k));
-}
-}
+namespace tthelpers {
+  inline reco::TransientTrack buildTT(edm::Handle<reco::TrackCollection> &tracks,
+                                      edm::ESHandle<TransientTrackBuilder> &trackbuilder,
+                                      unsigned int k) {
+    reco::TrackRef ref(tracks, k);
+    return trackbuilder->build(ref);
+  }
+  inline reco::TransientTrack buildTT(edm::Handle<edm::View<reco::Candidate> > &tracks,
+                                      edm::ESHandle<TransientTrackBuilder> &trackbuilder,
+                                      unsigned int k) {
+    if ((*tracks)[k].bestTrack() == nullptr)
+      return reco::TransientTrack();
+    return trackbuilder->build(tracks->ptrAt(k));
+  }
+}  // namespace tthelpers
 #endif

--- a/RecoVertex/AdaptiveVertexFinder/interface/TrackVertexArbitration.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/TrackVertexArbitration.h
@@ -10,7 +10,6 @@
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/IPTools/interface/IPTools.h"
 
-
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -23,7 +22,6 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "RecoVertex/VertexTools/interface/VertexDistance3D.h"
-
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
@@ -48,248 +46,230 @@
 //#define VTXDEBUG
 
 namespace svhelper {
-  inline double cov33(const reco::Vertex & sv) { return sv.covariance(3,3); }
-  inline double cov33(const reco::VertexCompositePtrCandidate & sv) { return sv.vertexCovariance(3,3); }
-}
-
-
+  inline double cov33(const reco::Vertex &sv) { return sv.covariance(3, 3); }
+  inline double cov33(const reco::VertexCompositePtrCandidate &sv) { return sv.vertexCovariance(3, 3); }
+}  // namespace svhelper
 
 template <class VTX>
-class TrackVertexArbitration{
-    public:
-	TrackVertexArbitration(const edm::ParameterSet &params);
+class TrackVertexArbitration {
+public:
+  TrackVertexArbitration(const edm::ParameterSet &params);
 
+  std::vector<VTX> trackVertexArbitrator(edm::Handle<reco::BeamSpot> &beamSpot,
+                                         const reco::Vertex &pv,
+                                         std::vector<reco::TransientTrack> &selectedTracks,
+                                         std::vector<VTX> &secondaryVertices);
 
-	std::vector<VTX> trackVertexArbitrator(
-          edm::Handle<reco::BeamSpot> &beamSpot, 
-	  const reco::Vertex &pv,
-	  std::vector<reco::TransientTrack> & selectedTracks,
-	  std::vector<VTX> & secondaryVertices
-	);
-	
-	
-    private:
-	bool trackFilterArbitrator(const reco::TransientTrack &track) const;
+private:
+  bool trackFilterArbitrator(const reco::TransientTrack &track) const;
 
-	edm::InputTag				primaryVertexCollection;
-	edm::InputTag				secondaryVertexCollection;
-	edm::InputTag				trackCollection;
-        edm::InputTag                           beamSpotCollection;
-        double 					dRCut;
-        double					distCut;
-        double					sigCut;
-	double					dLenFraction;
-	double 					fitterSigmacut; // = 3.0;
-	double 					fitterTini; // = 256.;
-	double 					fitterRatio;//    = 0.25;
-	int 					trackMinLayers;
-	double					trackMinPt;
-	int					trackMinPixels;  
-	double                                  maxTimeSignificance;
-	double                                  sign;
+  edm::InputTag primaryVertexCollection;
+  edm::InputTag secondaryVertexCollection;
+  edm::InputTag trackCollection;
+  edm::InputTag beamSpotCollection;
+  double dRCut;
+  double distCut;
+  double sigCut;
+  double dLenFraction;
+  double fitterSigmacut;  // = 3.0;
+  double fitterTini;      // = 256.;
+  double fitterRatio;     //    = 0.25;
+  int trackMinLayers;
+  double trackMinPt;
+  int trackMinPixels;
+  double maxTimeSignificance;
+  double sign;
 };
 
 #include "DataFormats/GeometryVector/interface/VectorUtil.h"
 template <class VTX>
-TrackVertexArbitration<VTX>::TrackVertexArbitration(const edm::ParameterSet &params) :
-	primaryVertexCollection   (params.getParameter<edm::InputTag>("primaryVertices")),
-	secondaryVertexCollection (params.getParameter<edm::InputTag>("secondaryVertices")),
-	trackCollection           (params.getParameter<edm::InputTag>("tracks")),
-        beamSpotCollection        (params.getParameter<edm::InputTag>("beamSpot")),
-	dRCut                     (params.getParameter<double>("dRCut")),
-	distCut                   (params.getParameter<double>("distCut")),
-	sigCut                    (params.getParameter<double>("sigCut")),
-	dLenFraction              (params.getParameter<double>("dLenFraction")),
-	fitterSigmacut            (params.getParameter<double>("fitterSigmacut")),
-	fitterTini                (params.getParameter<double>("fitterTini")),
-	fitterRatio               (params.getParameter<double>("fitterRatio")),
-	trackMinLayers            (params.getParameter<int32_t>("trackMinLayers")),
-	trackMinPt                (params.getParameter<double>("trackMinPt")),
-	trackMinPixels            (params.getParameter<int32_t>("trackMinPixels")),
-	maxTimeSignificance       (params.getParameter<double>("maxTimeSignificance"))
-{
-        sign = 1.0;
-        if(dRCut < 0){sign = -1.0;}
-        dRCut*=dRCut;
+TrackVertexArbitration<VTX>::TrackVertexArbitration(const edm::ParameterSet &params)
+    : primaryVertexCollection(params.getParameter<edm::InputTag>("primaryVertices")),
+      secondaryVertexCollection(params.getParameter<edm::InputTag>("secondaryVertices")),
+      trackCollection(params.getParameter<edm::InputTag>("tracks")),
+      beamSpotCollection(params.getParameter<edm::InputTag>("beamSpot")),
+      dRCut(params.getParameter<double>("dRCut")),
+      distCut(params.getParameter<double>("distCut")),
+      sigCut(params.getParameter<double>("sigCut")),
+      dLenFraction(params.getParameter<double>("dLenFraction")),
+      fitterSigmacut(params.getParameter<double>("fitterSigmacut")),
+      fitterTini(params.getParameter<double>("fitterTini")),
+      fitterRatio(params.getParameter<double>("fitterRatio")),
+      trackMinLayers(params.getParameter<int32_t>("trackMinLayers")),
+      trackMinPt(params.getParameter<double>("trackMinPt")),
+      trackMinPixels(params.getParameter<int32_t>("trackMinPixels")),
+      maxTimeSignificance(params.getParameter<double>("maxTimeSignificance")) {
+  sign = 1.0;
+  if (dRCut < 0) {
+    sign = -1.0;
+  }
+  dRCut *= dRCut;
 }
 template <class VTX>
-bool TrackVertexArbitration<VTX>::trackFilterArbitrator(const reco::TransientTrack &track) const
-{
-	if(!track.isValid()) 
-		return false;
-        if (track.track().hitPattern().trackerLayersWithMeasurement() < trackMinLayers)
-                return false;
-        if (track.track().pt() < trackMinPt)
-                return false;
-        if (track.track().hitPattern().numberOfValidPixelHits() < trackMinPixels)
-                return false;
+bool TrackVertexArbitration<VTX>::trackFilterArbitrator(const reco::TransientTrack &track) const {
+  if (!track.isValid())
+    return false;
+  if (track.track().hitPattern().trackerLayersWithMeasurement() < trackMinLayers)
+    return false;
+  if (track.track().pt() < trackMinPt)
+    return false;
+  if (track.track().hitPattern().numberOfValidPixelHits() < trackMinPixels)
+    return false;
 
-        return true;
+  return true;
 }
 
-float trackWeight(const reco::Vertex & sv, const reco::TransientTrack &track) 
-{
+float trackWeight(const reco::Vertex &sv, const reco::TransientTrack &track) {
   return sv.trackWeight(track.trackBaseRef());
 }
-float trackWeight(const reco::VertexCompositePtrCandidate & sv, const reco::TransientTrack &tt) 
-{
-	const reco::CandidatePtrTransientTrack* cptt = dynamic_cast<const reco::CandidatePtrTransientTrack*>(tt.basicTransientTrack());
-	if ( cptt==nullptr )
-		edm::LogError("DynamicCastingFailed") << "Casting of TransientTrack to CandidatePtrTransientTrack failed!";
-	else
-	{
-	        const	reco::CandidatePtr & c=cptt->candidate();
-		if(std::find(sv.daughterPtrVector().begin(),sv.daughterPtrVector().end(),c)!= sv.daughterPtrVector().end()) 
-			return 1.0; 
-		else
-			return 0; 
-	}
-return 0;
+float trackWeight(const reco::VertexCompositePtrCandidate &sv, const reco::TransientTrack &tt) {
+  const reco::CandidatePtrTransientTrack *cptt =
+      dynamic_cast<const reco::CandidatePtrTransientTrack *>(tt.basicTransientTrack());
+  if (cptt == nullptr)
+    edm::LogError("DynamicCastingFailed") << "Casting of TransientTrack to CandidatePtrTransientTrack failed!";
+  else {
+    const reco::CandidatePtr &c = cptt->candidate();
+    if (std::find(sv.daughterPtrVector().begin(), sv.daughterPtrVector().end(), c) != sv.daughterPtrVector().end())
+      return 1.0;
+    else
+      return 0;
+  }
+  return 0;
 }
-
-
 
 template <class VTX>
-std::vector<VTX> TrackVertexArbitration<VTX>::trackVertexArbitrator(
-         edm::Handle<reco::BeamSpot> &beamSpot, 
-	 const reco::Vertex &pv,
-	 std::vector<reco::TransientTrack> & selectedTracks,
-	 std::vector<VTX> & secondaryVertices)
-{
-	using namespace reco;
+std::vector<VTX> TrackVertexArbitration<VTX>::trackVertexArbitrator(edm::Handle<reco::BeamSpot> &beamSpot,
+                                                                    const reco::Vertex &pv,
+                                                                    std::vector<reco::TransientTrack> &selectedTracks,
+                                                                    std::vector<VTX> &secondaryVertices) {
+  using namespace reco;
 
-	//std::cout << "PV: " << pv.position() << std::endl;
-        VertexDistance3D dist;
-  	AdaptiveVertexFitter theAdaptiveFitter(
-                                            GeometricAnnealing(fitterSigmacut, fitterTini, fitterRatio),
-                                            DefaultLinearizationPointFinder(),
-                                            KalmanVertexUpdator<5>(),
-                                            KalmanVertexTrackCompatibilityEstimator<5>(),
-                                            KalmanVertexSmoother() );
+  //std::cout << "PV: " << pv.position() << std::endl;
+  VertexDistance3D dist;
+  AdaptiveVertexFitter theAdaptiveFitter(GeometricAnnealing(fitterSigmacut, fitterTini, fitterRatio),
+                                         DefaultLinearizationPointFinder(),
+                                         KalmanVertexUpdator<5>(),
+                                         KalmanVertexTrackCompatibilityEstimator<5>(),
+                                         KalmanVertexSmoother());
 
+  std::vector<VTX> recoVertices;
+  VertexDistance3D vdist;
+  GlobalPoint ppv(pv.position().x(), pv.position().y(), pv.position().z());
 
+  std::unordered_map<unsigned int, Measurement1D> cachedIP;
+  for (typename std::vector<VTX>::const_iterator sv = secondaryVertices.begin(); sv != secondaryVertices.end(); ++sv) {
+    const double svTime(sv->t()), svTimeCov(svhelper::cov33(*sv));
+    const bool svHasTime = svTimeCov > 0.;
 
-	std::vector<VTX> recoVertices;
-        VertexDistance3D vdist;
-        GlobalPoint ppv(pv.position().x(),pv.position().y(),pv.position().z());
+    GlobalPoint ssv(sv->position().x(), sv->position().y(), sv->position().z());
+    GlobalVector flightDir = ssv - ppv;
+    //            std::cout << "Vertex : " << sv-secondaryVertices->begin() << " " << sv->position() << std::endl;
+    Measurement1D dlen =
+        vdist.distance(pv, VertexState(RecoVertex::convertPos(sv->position()), RecoVertex::convertError(sv->error())));
+    std::vector<reco::TransientTrack> selTracks;
+    for (unsigned int itrack = 0; itrack < selectedTracks.size(); itrack++) {
+      TransientTrack &tt = (selectedTracks)[itrack];
+      if (!trackFilterArbitrator(tt))
+        continue;
+      tt.setBeamSpot(*beamSpot);
+      float w = trackWeight(*sv, tt);
+      Measurement1D ipv;
+      if (cachedIP.count(itrack)) {
+        ipv = cachedIP[itrack];
+      } else {
+        std::pair<bool, Measurement1D> ipvp = IPTools::absoluteImpactParameter3D(tt, pv);
+        cachedIP[itrack] = ipvp.second;
+        ipv = ipvp.second;
+      }
 
-        std::unordered_map<unsigned int, Measurement1D> cachedIP;  
-        for(typename std::vector<VTX>::const_iterator sv = secondaryVertices.begin();
-	    sv != secondaryVertices.end(); ++sv) {
+      AnalyticalImpactPointExtrapolator extrapolator(tt.field());
+      TrajectoryStateOnSurface tsos =
+          extrapolator.extrapolate(tt.impactPointState(), RecoVertex::convertPos(sv->position()));
+      if (!tsos.isValid())
+        continue;
+      GlobalPoint refPoint = tsos.globalPosition();
+      GlobalError refPointErr = tsos.cartesianError().position();
+      Measurement1D isv =
+          dist.distance(VertexState(RecoVertex::convertPos(sv->position()), RecoVertex::convertError(sv->error())),
+                        VertexState(refPoint, refPointErr));
 
-	  const double svTime(sv->t()), svTimeCov(svhelper::cov33(*sv));
-          const bool svHasTime = svTimeCov > 0.;
-	    
-	    GlobalPoint ssv(sv->position().x(),sv->position().y(),sv->position().z());
-            GlobalVector flightDir = ssv-ppv;
-//            std::cout << "Vertex : " << sv-secondaryVertices->begin() << " " << sv->position() << std::endl;
-            Measurement1D dlen= vdist.distance(pv,VertexState(RecoVertex::convertPos(sv->position()),RecoVertex::convertError(sv->error())));
-            std::vector<reco::TransientTrack>  selTracks;
-	    for(unsigned int itrack = 0; itrack < selectedTracks.size(); itrack++){
-	        TransientTrack & tt = (selectedTracks)[itrack];
-	        if (!trackFilterArbitrator(tt))                         continue;
-                tt.setBeamSpot(*beamSpot);
-	        float w = trackWeight(*sv,tt);
- 	        Measurement1D ipv;
-		if( cachedIP.count(itrack) ) {
-		  ipv=cachedIP[itrack];
-		} else {
-		  std::pair<bool,Measurement1D> ipvp = IPTools::absoluteImpactParameter3D(tt,pv);
-		  cachedIP[itrack]=ipvp.second;
-		  ipv=ipvp.second;
-		}
-		
-		AnalyticalImpactPointExtrapolator extrapolator(tt.field());
-		TrajectoryStateOnSurface tsos = extrapolator.extrapolate(tt.impactPointState(), RecoVertex::convertPos(sv->position()));
-		if(! tsos.isValid()) continue;
-		GlobalPoint refPoint          = tsos.globalPosition();
-		GlobalError refPointErr       = tsos.cartesianError().position();
-		Measurement1D isv = dist.distance(VertexState(RecoVertex::convertPos(sv->position()),RecoVertex::convertError(sv->error())),VertexState(refPoint, refPointErr));	   
+      float dR = Geom::deltaR2(((sign > 0) ? flightDir : -flightDir),
+                               tt.track());  //.eta(), flightDir.phi(), tt.track().eta(), tt.track().phi());
 
-		float dR = Geom::deltaR2(( (sign > 0) ? flightDir : -flightDir),tt.track()); //.eta(), flightDir.phi(), tt.track().eta(), tt.track().phi());
-		
-		double timeSig = 0.;
-		if( svHasTime && edm::isFinite(tt.timeExt()) ) {
-		  double tError = std::sqrt( std::pow( tt.dtErrorExt(), 2 ) + svTimeCov );
-		  timeSig = std::abs(tt.timeExt() - svTime)/tError;
-		}
+      double timeSig = 0.;
+      if (svHasTime && edm::isFinite(tt.timeExt())) {
+        double tError = std::sqrt(std::pow(tt.dtErrorExt(), 2) + svTimeCov);
+        timeSig = std::abs(tt.timeExt() - svTime) / tError;
+      }
 
-                if( w > 0 || ( isv.significance() < sigCut && isv.value() < distCut && isv.value() < dlen.value()*dLenFraction && timeSig < maxTimeSignificance) )
-                {
-
-                  if(( isv.value() < ipv.value()  ) && isv.value() < distCut && isv.value() < dlen.value()*dLenFraction 
-                  && dR < dRCut && timeSig < maxTimeSignificance ) 
-                  {
+      if (w > 0 || (isv.significance() < sigCut && isv.value() < distCut && isv.value() < dlen.value() * dLenFraction &&
+                    timeSig < maxTimeSignificance)) {
+        if ((isv.value() < ipv.value()) && isv.value() < distCut && isv.value() < dlen.value() * dLenFraction &&
+            dR < dRCut && timeSig < maxTimeSignificance) {
 #ifdef VTXDEBUG
-                     if(w > 0.5) std::cout << " = ";
-                    else std::cout << " + ";
-#endif 
-                     selTracks.push_back(tt);
-                  } else
-                  {
-#ifdef VTXDEBUG
-                     if(w > 0.5 && isv.value() > ipv.value() ) std::cout << " - ";
-                  else std::cout << "   ";
+          if (w > 0.5)
+            std::cout << " = ";
+          else
+            std::cout << " + ";
 #endif
-                     //add also the tracks used in previous fitting that are still closer to Sv than Pv 
-                     if(w > 0.5 && isv.value() <= ipv.value() && dR < dRCut && timeSig < maxTimeSignificance) {  
-                       selTracks.push_back(tt);
+          selTracks.push_back(tt);
+        } else {
 #ifdef VTXDEBUG
-                       std::cout << " = ";
+          if (w > 0.5 && isv.value() > ipv.value())
+            std::cout << " - ";
+          else
+            std::cout << "   ";
 #endif
-                     }
-                     if(w > 0.5 && isv.value() <= ipv.value() && dR >= dRCut) {
+          //add also the tracks used in previous fitting that are still closer to Sv than Pv
+          if (w > 0.5 && isv.value() <= ipv.value() && dR < dRCut && timeSig < maxTimeSignificance) {
+            selTracks.push_back(tt);
 #ifdef VTXDEBUG
-                       std::cout << " - ";
+            std::cout << " = ";
 #endif
-
-                     }
-
-                    
-                  }
+          }
+          if (w > 0.5 && isv.value() <= ipv.value() && dR >= dRCut) {
+#ifdef VTXDEBUG
+            std::cout << " - ";
+#endif
+          }
+        }
 #ifdef VTXDEBUG
 
-                  std::cout << "t : " << itrack << " ref " << ref.key() << " w: " << w 
-                  << " svip: " << isv.significance() << " " << isv.value()  
-                  << " pvip: " << ipv.significance() << " " << ipv.value()  << " res " << tt.track().residualX(0)   << "," << tt.track().residualY(0) 
+        std::cout << "t : " << itrack << " ref " << ref.key() << " w: " << w << " svip: " << isv.significance() << " "
+                  << isv.value() << " pvip: " << ipv.significance() << " " << ipv.value() << " res "
+                  << tt.track().residualX(0) << "," << tt.track().residualY(0)
 //                  << " tpvip: " << itpv.second.significance() << " " << itpv.second.value()  << " dr: "   << dR << std::endl;
 #endif
- 
-                }
-               else
-                 {
+
+      } else {
 #ifdef VTXDEBUG
 
-                  std::cout << " . t : " << itrack << " ref " << ref.key()<<  " w: " << w 
-                  << " svip: " << isv.second.significance() << " " << isv.second.value()  
-                  << " pvip: " << ipv.significance() << " " << ipv.value()  << " dr: "   << dR << std::endl;
+        std::cout << " . t : " << itrack << " ref " << ref.key() << " w: " << w
+                  << " svip: " << isv.second.significance() << " " << isv.second.value()
+                  << " pvip: " << ipv.significance() << " " << ipv.value() << " dr: " << dR << std::endl;
 #endif
+      }
+    }
 
-                 }
-           }      
+    if (selTracks.size() >= 2) {
+      TransientVertex singleFitVertex;
+      singleFitVertex = theAdaptiveFitter.vertex(selTracks, ssv);
 
-           if(selTracks.size() >= 2)
-              { 
-             	 TransientVertex singleFitVertex;
-             	 singleFitVertex = theAdaptiveFitter.vertex(selTracks,ssv);
-		 
-              	if(singleFitVertex.isValid())  { 
-		  if( pv.covariance(3,3) > 0. ) svhelper::updateVertexTime(singleFitVertex);
-		  recoVertices.push_back(VTX(singleFitVertex));
-		  
+      if (singleFitVertex.isValid()) {
+        if (pv.covariance(3, 3) > 0.)
+          svhelper::updateVertexTime(singleFitVertex);
+        recoVertices.push_back(VTX(singleFitVertex));
 
 #ifdef VTXDEBUG
-                const VTX & extVertex = recoVertices.back();
-                      GlobalVector vtxDir = GlobalVector(extVertex.p4().X(),extVertex.p4().Y(),extVertex.p4().Z());
+        const VTX &extVertex = recoVertices.back();
+        GlobalVector vtxDir = GlobalVector(extVertex.p4().X(), extVertex.p4().Y(), extVertex.p4().Z());
 
-
-		std::cout << " pointing : " << Geom::deltaR(extVertex.position() - pv.position(), vtxDir) << std::endl;
+        std::cout << " pointing : " << Geom::deltaR(extVertex.position() - pv.position(), vtxDir) << std::endl;
 #endif
-		}
-              } 
-	}
-	return recoVertices;
+      }
+    }
+  }
+  return recoVertices;
 }
-
 
 #endif

--- a/RecoVertex/AdaptiveVertexFinder/interface/TracksClusteringFromDisplacedSeed.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/TracksClusteringFromDisplacedSeed.h
@@ -23,37 +23,30 @@
 //#define VTXDEBUG
 
 class TracksClusteringFromDisplacedSeed {
-    public:
-    struct Cluster 
-    {       
-      GlobalPoint seedPoint;      
-      reco::TransientTrack seedingTrack;
-      std::vector<reco::TransientTrack> tracks;
-    };
-	TracksClusteringFromDisplacedSeed(const edm::ParameterSet &params);
-	
-	
-        std::vector<Cluster> clusters(
-	  const reco::Vertex    &pv,
-	  const std::vector<reco::TransientTrack> & selectedTracks
-	 );
-	 
+public:
+  struct Cluster {
+    GlobalPoint seedPoint;
+    reco::TransientTrack seedingTrack;
+    std::vector<reco::TransientTrack> tracks;
+  };
+  TracksClusteringFromDisplacedSeed(const edm::ParameterSet &params);
 
-    private:
-	bool trackFilter(const reco::TrackRef &track) const;
-        std::pair<std::vector<reco::TransientTrack>,GlobalPoint> nearTracks(const reco::TransientTrack &seed, const std::vector<reco::TransientTrack> & tracks, const reco::Vertex & primaryVertex) const;
+  std::vector<Cluster> clusters(const reco::Vertex &pv, const std::vector<reco::TransientTrack> &selectedTracks);
 
-//	unsigned int				maxNTracks;
-        double 					max3DIPSignificance;
-        double 					max3DIPValue;
-        double 					min3DIPSignificance;
-        double 					min3DIPValue;
-        double 					clusterMaxDistance;
-        double 					clusterMaxSignificance;
-        double 					distanceRatio;
-        double 					clusterMinAngleCosine;
-	double                                  maxTimeSignificance;
+private:
+  bool trackFilter(const reco::TrackRef &track) const;
+  std::pair<std::vector<reco::TransientTrack>, GlobalPoint> nearTracks(const reco::TransientTrack &seed,
+                                                                       const std::vector<reco::TransientTrack> &tracks,
+                                                                       const reco::Vertex &primaryVertex) const;
 
-
+  //	unsigned int				maxNTracks;
+  double max3DIPSignificance;
+  double max3DIPValue;
+  double min3DIPSignificance;
+  double min3DIPValue;
+  double clusterMaxDistance;
+  double clusterMaxSignificance;
+  double distanceRatio;
+  double clusterMinAngleCosine;
+  double maxTimeSignificance;
 };
-

--- a/RecoVertex/AdaptiveVertexFinder/interface/VertexMerging.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/VertexMerging.h
@@ -15,17 +15,14 @@
 #include "RecoVertex/VertexTools/interface/VertexDistance3D.h"
 
 class VertexMerging {
-    public:
-	VertexMerging(const edm::ParameterSet &params);
-	
-	
-        reco::VertexCollection mergeVertex(reco::VertexCollection & secondaryVertices);
-	
-	
-    private:
-	bool trackFilter(const reco::TrackRef &track) const;
+public:
+  VertexMerging(const edm::ParameterSet &params);
 
-	double					maxFraction;
-	double					minSignificance;
+  reco::VertexCollection mergeVertex(reco::VertexCollection &secondaryVertices);
+
+private:
+  bool trackFilter(const reco::TrackRef &track) const;
+
+  double maxFraction;
+  double minSignificance;
 };
-

--- a/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.cc
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.cc
@@ -8,10 +8,9 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Common/interface/View.h"
 
-
-typedef TemplatedInclusiveVertexFinder<reco::TrackCollection,reco::Vertex> InclusiveVertexFinder;
-typedef TemplatedInclusiveVertexFinder<edm::View<reco::Candidate>,reco::VertexCompositePtrCandidate > InclusiveCandidateVertexFinder;
-
+typedef TemplatedInclusiveVertexFinder<reco::TrackCollection, reco::Vertex> InclusiveVertexFinder;
+typedef TemplatedInclusiveVertexFinder<edm::View<reco::Candidate>, reco::VertexCompositePtrCandidate>
+    InclusiveCandidateVertexFinder;
 
 DEFINE_FWK_MODULE(InclusiveVertexFinder);
 DEFINE_FWK_MODULE(InclusiveCandidateVertexFinder);

--- a/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.h
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.h
@@ -99,7 +99,7 @@ class TemplatedInclusiveVertexFinder : public edm::stream::EDProducer<> {
           }
 	}
 
-	virtual void produce(edm::Event &event, const edm::EventSetup &es) override;
+	void produce(edm::Event &event, const edm::EventSetup &es) override;
 
     private:
 	bool trackFilter(const reco::Track &track) const;
@@ -192,7 +192,7 @@ void TemplatedInclusiveVertexFinder<InputContainer,VTX>::produce(edm::Event &eve
 
 
         auto recoVertices = std::make_unique<Product>();
-        if(primaryVertices->size()!=0) {
+        if(!primaryVertices->empty()) {
      
 	const reco::Vertex &pv = (*primaryVertices)[0];
 	GlobalPoint ppv(pv.position().x(),pv.position().y(),pv.position().z());

--- a/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.h
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.h
@@ -39,275 +39,265 @@
 //#define VTXDEBUG 1
 template <class InputContainer, class VTX>
 class TemplatedInclusiveVertexFinder : public edm::stream::EDProducer<> {
-    public:
-	typedef std::vector<VTX> Product;
-	typedef typename InputContainer::value_type TRK;
-	TemplatedInclusiveVertexFinder(const edm::ParameterSet &params);
+public:
+  typedef std::vector<VTX> Product;
+  typedef typename InputContainer::value_type TRK;
+  TemplatedInclusiveVertexFinder(const edm::ParameterSet &params);
 
-	static void fillDescriptions(edm::ConfigurationDescriptions & cdesc) {
-	  edm::ParameterSetDescription pdesc;
-	  pdesc.add<edm::InputTag>("beamSpot",edm::InputTag("offlineBeamSpot"));
-	  pdesc.add<edm::InputTag>("primaryVertices",edm::InputTag("offlinePrimaryVertices"));
-          if( std::is_same<VTX,reco::Vertex>::value ) {
-            pdesc.add<edm::InputTag>("tracks",edm::InputTag("generalTracks"));
-            pdesc.add<unsigned int>("minHits",8);
-          } else if (  std::is_same<VTX,reco::VertexCompositePtrCandidate>::value ) {
-            pdesc.add<edm::InputTag>("tracks",edm::InputTag("particleFlow"));
-            pdesc.add<unsigned int>("minHits",0);
-          } else {
-            pdesc.add<edm::InputTag>("tracks",edm::InputTag("generalTracks"));
-          }	  
-	  
-	  pdesc.add<double>("maximumLongitudinalImpactParameter",0.3);
-	  pdesc.add<double>("maximumTimeSignificance",3.0);
-	  pdesc.add<double>("minPt",0.8);
-	  pdesc.add<unsigned int>("maxNTracks",30);
-	  //clusterizer pset
-	  edm::ParameterSetDescription clusterizer;
-	  clusterizer.add<double>("seedMax3DIPSignificance",9999.0);
-	  clusterizer.add<double>("seedMax3DIPValue",9999.0);
-	  clusterizer.add<double>("seedMin3DIPSignificance",1.2);
-	  clusterizer.add<double>("seedMin3DIPValue",0.005);
-	  clusterizer.add<double>("clusterMaxDistance",0.05);
-	  clusterizer.add<double>("clusterMaxSignificance",4.5);
-	  clusterizer.add<double>("distanceRatio",20.0);
-	  clusterizer.add<double>("clusterMinAngleCosine",0.5);
-	  clusterizer.add<double>("maxTimeSignificance",3.5);
-	  pdesc.add<edm::ParameterSetDescription>("clusterizer", clusterizer);
-	  // vertex and fitter config
-	  pdesc.add<double>("vertexMinAngleCosine",0.95);
-	  pdesc.add<double>("vertexMinDLen2DSig",2.5);
-	  pdesc.add<double>("vertexMinDLenSig",0.5);
-	  pdesc.add<double>("fitterSigmacut",3.0);
-	  pdesc.add<double>("fitterTini",256.0);
-	  pdesc.add<double>("fitterRatio",0.25);
-	  pdesc.add<bool>("useDirectVertexFitter",true);
-	  pdesc.add<bool>("useVertexReco",true);
-	  // vertexReco pset
-	  edm::ParameterSetDescription vertexReco;
-	  vertexReco.add<std::string>("finder", std::string("avr"));
-	  vertexReco.add<double>("primcut",1.0);
-	  vertexReco.add<double>("seccut",3.0);
-	  vertexReco.add<bool>("smoothing",true);
-          pdesc.add<edm::ParameterSetDescription>("vertexReco", vertexReco);
-          if( std::is_same<VTX,reco::Vertex>::value ) {
-            cdesc.add("inclusiveVertexFinderDefault",pdesc);
-          } else if ( std::is_same<VTX,reco::VertexCompositePtrCandidate>::value ) {
-            cdesc.add("inclusiveCandidateVertexFinderDefault",pdesc);
-          } else {
-            cdesc.addDefault(pdesc);
-          }
-	}
+  static void fillDescriptions(edm::ConfigurationDescriptions &cdesc) {
+    edm::ParameterSetDescription pdesc;
+    pdesc.add<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"));
+    pdesc.add<edm::InputTag>("primaryVertices", edm::InputTag("offlinePrimaryVertices"));
+    if (std::is_same<VTX, reco::Vertex>::value) {
+      pdesc.add<edm::InputTag>("tracks", edm::InputTag("generalTracks"));
+      pdesc.add<unsigned int>("minHits", 8);
+    } else if (std::is_same<VTX, reco::VertexCompositePtrCandidate>::value) {
+      pdesc.add<edm::InputTag>("tracks", edm::InputTag("particleFlow"));
+      pdesc.add<unsigned int>("minHits", 0);
+    } else {
+      pdesc.add<edm::InputTag>("tracks", edm::InputTag("generalTracks"));
+    }
 
-	void produce(edm::Event &event, const edm::EventSetup &es) override;
+    pdesc.add<double>("maximumLongitudinalImpactParameter", 0.3);
+    pdesc.add<double>("maximumTimeSignificance", 3.0);
+    pdesc.add<double>("minPt", 0.8);
+    pdesc.add<unsigned int>("maxNTracks", 30);
+    //clusterizer pset
+    edm::ParameterSetDescription clusterizer;
+    clusterizer.add<double>("seedMax3DIPSignificance", 9999.0);
+    clusterizer.add<double>("seedMax3DIPValue", 9999.0);
+    clusterizer.add<double>("seedMin3DIPSignificance", 1.2);
+    clusterizer.add<double>("seedMin3DIPValue", 0.005);
+    clusterizer.add<double>("clusterMaxDistance", 0.05);
+    clusterizer.add<double>("clusterMaxSignificance", 4.5);
+    clusterizer.add<double>("distanceRatio", 20.0);
+    clusterizer.add<double>("clusterMinAngleCosine", 0.5);
+    clusterizer.add<double>("maxTimeSignificance", 3.5);
+    pdesc.add<edm::ParameterSetDescription>("clusterizer", clusterizer);
+    // vertex and fitter config
+    pdesc.add<double>("vertexMinAngleCosine", 0.95);
+    pdesc.add<double>("vertexMinDLen2DSig", 2.5);
+    pdesc.add<double>("vertexMinDLenSig", 0.5);
+    pdesc.add<double>("fitterSigmacut", 3.0);
+    pdesc.add<double>("fitterTini", 256.0);
+    pdesc.add<double>("fitterRatio", 0.25);
+    pdesc.add<bool>("useDirectVertexFitter", true);
+    pdesc.add<bool>("useVertexReco", true);
+    // vertexReco pset
+    edm::ParameterSetDescription vertexReco;
+    vertexReco.add<std::string>("finder", std::string("avr"));
+    vertexReco.add<double>("primcut", 1.0);
+    vertexReco.add<double>("seccut", 3.0);
+    vertexReco.add<bool>("smoothing", true);
+    pdesc.add<edm::ParameterSetDescription>("vertexReco", vertexReco);
+    if (std::is_same<VTX, reco::Vertex>::value) {
+      cdesc.add("inclusiveVertexFinderDefault", pdesc);
+    } else if (std::is_same<VTX, reco::VertexCompositePtrCandidate>::value) {
+      cdesc.add("inclusiveCandidateVertexFinderDefault", pdesc);
+    } else {
+      cdesc.addDefault(pdesc);
+    }
+  }
 
-    private:
-	bool trackFilter(const reco::Track &track) const;
-        std::pair<std::vector<reco::TransientTrack>,GlobalPoint> nearTracks(const reco::TransientTrack &seed, const std::vector<reco::TransientTrack> & tracks, const reco::Vertex & primaryVertex) const;
+  void produce(edm::Event &event, const edm::EventSetup &es) override;
 
-	edm::EDGetTokenT<reco::BeamSpot> 	token_beamSpot; 
-	edm::EDGetTokenT<reco::VertexCollection> token_primaryVertex;
-	edm::EDGetTokenT<InputContainer>	token_tracks; 
-	unsigned int				minHits;
-	unsigned int				maxNTracks;
-	double					maxLIP;
-	double                                  maxTimeSig;
-        double 					minPt;
-        double 					vertexMinAngleCosine;
-        double 					vertexMinDLen2DSig;
-        double 					vertexMinDLenSig;
-	double					fitterSigmacut;
-	double  				fitterTini;
-	double 					fitterRatio;
-	bool 					useVertexFitter;
-	bool 					useVertexReco;
-	std::unique_ptr<VertexReconstructor>	vtxReco;
-	std::unique_ptr<TracksClusteringFromDisplacedSeed>	clusterizer;
+private:
+  bool trackFilter(const reco::Track &track) const;
+  std::pair<std::vector<reco::TransientTrack>, GlobalPoint> nearTracks(const reco::TransientTrack &seed,
+                                                                       const std::vector<reco::TransientTrack> &tracks,
+                                                                       const reco::Vertex &primaryVertex) const;
 
+  edm::EDGetTokenT<reco::BeamSpot> token_beamSpot;
+  edm::EDGetTokenT<reco::VertexCollection> token_primaryVertex;
+  edm::EDGetTokenT<InputContainer> token_tracks;
+  unsigned int minHits;
+  unsigned int maxNTracks;
+  double maxLIP;
+  double maxTimeSig;
+  double minPt;
+  double vertexMinAngleCosine;
+  double vertexMinDLen2DSig;
+  double vertexMinDLenSig;
+  double fitterSigmacut;
+  double fitterTini;
+  double fitterRatio;
+  bool useVertexFitter;
+  bool useVertexReco;
+  std::unique_ptr<VertexReconstructor> vtxReco;
+  std::unique_ptr<TracksClusteringFromDisplacedSeed> clusterizer;
 };
 template <class InputContainer, class VTX>
-TemplatedInclusiveVertexFinder<InputContainer,VTX>::TemplatedInclusiveVertexFinder(const edm::ParameterSet &params) :
-	minHits(params.getParameter<unsigned int>("minHits")),
-	maxNTracks(params.getParameter<unsigned int>("maxNTracks")),
-       	maxLIP(params.getParameter<double>("maximumLongitudinalImpactParameter")),
-	maxTimeSig(params.getParameter<double>("maximumTimeSignificance")),
- 	minPt(params.getParameter<double>("minPt")), //0.8
-        vertexMinAngleCosine(params.getParameter<double>("vertexMinAngleCosine")), //0.98
-        vertexMinDLen2DSig(params.getParameter<double>("vertexMinDLen2DSig")), //2.5
-        vertexMinDLenSig(params.getParameter<double>("vertexMinDLenSig")), //0.5
-        fitterSigmacut(params.getParameter<double>("fitterSigmacut")),
-        fitterTini(params.getParameter<double>("fitterTini")),
-        fitterRatio(params.getParameter<double>("fitterRatio")),
-	useVertexFitter(params.getParameter<bool>("useDirectVertexFitter")),
-	useVertexReco(params.getParameter<bool>("useVertexReco")),
-	vtxReco(new ConfigurableVertexReconstructor(params.getParameter<edm::ParameterSet>("vertexReco"))),
-        clusterizer(new TracksClusteringFromDisplacedSeed(params.getParameter<edm::ParameterSet>("clusterizer")))
+TemplatedInclusiveVertexFinder<InputContainer, VTX>::TemplatedInclusiveVertexFinder(const edm::ParameterSet &params)
+    : minHits(params.getParameter<unsigned int>("minHits")),
+      maxNTracks(params.getParameter<unsigned int>("maxNTracks")),
+      maxLIP(params.getParameter<double>("maximumLongitudinalImpactParameter")),
+      maxTimeSig(params.getParameter<double>("maximumTimeSignificance")),
+      minPt(params.getParameter<double>("minPt")),                                //0.8
+      vertexMinAngleCosine(params.getParameter<double>("vertexMinAngleCosine")),  //0.98
+      vertexMinDLen2DSig(params.getParameter<double>("vertexMinDLen2DSig")),      //2.5
+      vertexMinDLenSig(params.getParameter<double>("vertexMinDLenSig")),          //0.5
+      fitterSigmacut(params.getParameter<double>("fitterSigmacut")),
+      fitterTini(params.getParameter<double>("fitterTini")),
+      fitterRatio(params.getParameter<double>("fitterRatio")),
+      useVertexFitter(params.getParameter<bool>("useDirectVertexFitter")),
+      useVertexReco(params.getParameter<bool>("useVertexReco")),
+      vtxReco(new ConfigurableVertexReconstructor(params.getParameter<edm::ParameterSet>("vertexReco"))),
+      clusterizer(new TracksClusteringFromDisplacedSeed(params.getParameter<edm::ParameterSet>("clusterizer")))
 
 {
-	token_beamSpot = consumes<reco::BeamSpot>(params.getParameter<edm::InputTag>("beamSpot"));
-	token_primaryVertex = consumes<reco::VertexCollection>(params.getParameter<edm::InputTag>("primaryVertices"));
-	token_tracks = consumes<InputContainer>(params.getParameter<edm::InputTag>("tracks"));
-	produces<Product>();
-	//produces<reco::VertexCollection>("multi");
+  token_beamSpot = consumes<reco::BeamSpot>(params.getParameter<edm::InputTag>("beamSpot"));
+  token_primaryVertex = consumes<reco::VertexCollection>(params.getParameter<edm::InputTag>("primaryVertices"));
+  token_tracks = consumes<InputContainer>(params.getParameter<edm::InputTag>("tracks"));
+  produces<Product>();
+  //produces<reco::VertexCollection>("multi");
 }
 template <class InputContainer, class VTX>
-bool TemplatedInclusiveVertexFinder<InputContainer,VTX>::trackFilter(const reco::Track &track) const
-{
-	if (track.hitPattern().numberOfValidHits() < (int)minHits)
-		return false;
-	if (track.pt() < minPt )
-		return false;
- 
-	return true;
+bool TemplatedInclusiveVertexFinder<InputContainer, VTX>::trackFilter(const reco::Track &track) const {
+  if (track.hitPattern().numberOfValidHits() < (int)minHits)
+    return false;
+  if (track.pt() < minPt)
+    return false;
+
+  return true;
 }
 
 template <class InputContainer, class VTX>
-void TemplatedInclusiveVertexFinder<InputContainer,VTX>::produce(edm::Event &event, const edm::EventSetup &es)
-{
-	using namespace reco;
+void TemplatedInclusiveVertexFinder<InputContainer, VTX>::produce(edm::Event &event, const edm::EventSetup &es) {
+  using namespace reco;
 
   VertexDistance3D vdist;
   VertexDistanceXY vdist2d;
   MultiVertexFitter theMultiVertexFitter;
-  AdaptiveVertexFitter theAdaptiveFitter(
-                                            GeometricAnnealing(fitterSigmacut, fitterTini, fitterRatio),
-                                            DefaultLinearizationPointFinder(),
-                                            KalmanVertexUpdator<5>(),
-                                            KalmanVertexTrackCompatibilityEstimator<5>(),
-                                            KalmanVertexSmoother() );
+  AdaptiveVertexFitter theAdaptiveFitter(GeometricAnnealing(fitterSigmacut, fitterTini, fitterRatio),
+                                         DefaultLinearizationPointFinder(),
+                                         KalmanVertexUpdator<5>(),
+                                         KalmanVertexTrackCompatibilityEstimator<5>(),
+                                         KalmanVertexSmoother());
 
+  edm::Handle<BeamSpot> beamSpot;
+  event.getByToken(token_beamSpot, beamSpot);
 
-	edm::Handle<BeamSpot> beamSpot;
-	event.getByToken(token_beamSpot,beamSpot);
+  edm::Handle<VertexCollection> primaryVertices;
+  event.getByToken(token_primaryVertex, primaryVertices);
 
-	edm::Handle<VertexCollection> primaryVertices;
-	event.getByToken(token_primaryVertex, primaryVertices);
+  edm::Handle<InputContainer> tracks;
+  event.getByToken(token_tracks, tracks);
 
-	edm::Handle<InputContainer> tracks;
-	event.getByToken(token_tracks, tracks);
+  edm::ESHandle<TransientTrackBuilder> trackBuilder;
+  es.get<TransientTrackRecord>().get("TransientTrackBuilder", trackBuilder);
 
-	edm::ESHandle<TransientTrackBuilder> trackBuilder;
-	es.get<TransientTrackRecord>().get("TransientTrackBuilder",
-	                                   trackBuilder);
+  auto recoVertices = std::make_unique<Product>();
+  if (!primaryVertices->empty()) {
+    const reco::Vertex &pv = (*primaryVertices)[0];
+    GlobalPoint ppv(pv.position().x(), pv.position().y(), pv.position().z());
 
+    std::vector<TransientTrack> tts;
+    //Fill transient track vector
+    for (typename InputContainer::const_iterator track = tracks->begin(); track != tracks->end(); ++track) {
+      //TransientTrack tt = trackBuilder->build(ref);
+      //TrackRef ref(tracks, track - tracks->begin());
+      TransientTrack tt(tthelpers::buildTT(tracks, trackBuilder, track - tracks->begin()));
+      if (!tt.isValid())
+        continue;
+      if (!trackFilter(tt.track()))
+        continue;
+      if (std::abs(tt.track().dz(pv.position())) > maxLIP)
+        continue;
+      if (edm::isFinite(tt.timeExt()) && pv.covariance(3, 3) > 0.) {  // only apply if time available
+        auto tError = std::sqrt(std::pow(tt.dtErrorExt(), 2) + pv.covariance(3, 3));
+        auto dtSig = std::abs(tt.timeExt() - pv.t()) / tError;
+        if (dtSig > maxTimeSig)
+          continue;
+      }
+      tt.setBeamSpot(*beamSpot);
+      tts.push_back(tt);
+    }
+    std::vector<TracksClusteringFromDisplacedSeed::Cluster> clusters = clusterizer->clusters(pv, tts);
 
-        auto recoVertices = std::make_unique<Product>();
-        if(!primaryVertices->empty()) {
-     
-	const reco::Vertex &pv = (*primaryVertices)[0];
-	GlobalPoint ppv(pv.position().x(),pv.position().y(),pv.position().z());
-        
-	std::vector<TransientTrack> tts;
-        //Fill transient track vector 
-	for(typename InputContainer::const_iterator track = tracks->begin();
-	    track != tracks->end(); ++track) {
-//TransientTrack tt = trackBuilder->build(ref);
-//TrackRef ref(tracks, track - tracks->begin());
-		TransientTrack tt(tthelpers::buildTT(tracks,trackBuilder, track - tracks->begin()));
-		if(!tt.isValid()) continue;
-		if (!trackFilter(tt.track()))
-			continue;
-                if( std::abs(tt.track().dz(pv.position())) > maxLIP)
-			continue;
-		if( edm::isFinite(tt.timeExt()) && pv.covariance(3,3) > 0. ) { // only apply if time available
-		  auto tError = std::sqrt( std::pow(tt.dtErrorExt(),2) + pv.covariance(3,3) );
-		  auto dtSig = std::abs(tt.timeExt() - pv.t())/tError;
-		  if( dtSig > maxTimeSig ) continue;
-		}
-		tt.setBeamSpot(*beamSpot);
-		tts.push_back(tt);
-	}
-        std::vector<TracksClusteringFromDisplacedSeed::Cluster> clusters = clusterizer->clusters(pv,tts);
+    //Create BS object from PV to feed in the AVR
+    BeamSpot::CovarianceMatrix cov;
+    for (unsigned int i = 0; i < 7; i++) {
+      for (unsigned int j = 0; j < 7; j++) {
+        if (i < 3 && j < 3)
+          cov(i, j) = pv.covariance(i, j);
+        else
+          cov(i, j) = 0.0;
+      }
+    }
+    BeamSpot bs(pv.position(), 0.0, 0.0, 0.0, 0.0, cov, BeamSpot::Unknown);
 
-        //Create BS object from PV to feed in the AVR
-	BeamSpot::CovarianceMatrix cov;
-	for(unsigned int i = 0; i < 7; i++) {
-		for(unsigned int j = 0; j < 7; j++) {
-			if (i < 3 && j < 3)
-				cov(i, j) = pv.covariance(i, j);
-			else
-				cov(i, j) = 0.0;
-		}
-	}
-	BeamSpot bs(pv.position(), 0.0, 0.0, 0.0, 0.0, cov, BeamSpot::Unknown);
-
-
-        int i=0;
+    int i = 0;
 #ifdef VTXDEBUG
 
-	std::cout <<  "CLUSTERS " << clusters.size() << std::endl; 
+    std::cout << "CLUSTERS " << clusters.size() << std::endl;
 #endif
 
-	for(std::vector<TracksClusteringFromDisplacedSeed::Cluster>::iterator cluster = clusters.begin();
-	    cluster != clusters.end(); ++cluster,++i)
-        {
-                if(cluster->tracks.size() < 2 || cluster->tracks.size() > maxNTracks ) 
-		     continue;
-	 	std::vector<TransientVertex> vertices;
-		if(useVertexReco) {
-			vertices = vtxReco->vertices(cluster->tracks, bs);  // attempt with config given reconstructor
-		}
-                TransientVertex singleFitVertex;
-		if(useVertexFitter) {
-			singleFitVertex = theAdaptiveFitter.vertex(cluster->tracks,cluster->seedPoint); //attempt with direct fitting
-			if(singleFitVertex.isValid())
-				vertices.push_back(singleFitVertex);
-		}
-		
-		// for each transient vertex state determine if a time can be measured and fill covariance
-		if( pv.covariance(3,3) > 0. ) {
-		  for(auto& vtx : vertices) {		  
-		    svhelper::updateVertexTime(vtx);
-		  }
-		}
+    for (std::vector<TracksClusteringFromDisplacedSeed::Cluster>::iterator cluster = clusters.begin();
+         cluster != clusters.end();
+         ++cluster, ++i) {
+      if (cluster->tracks.size() < 2 || cluster->tracks.size() > maxNTracks)
+        continue;
+      std::vector<TransientVertex> vertices;
+      if (useVertexReco) {
+        vertices = vtxReco->vertices(cluster->tracks, bs);  // attempt with config given reconstructor
+      }
+      TransientVertex singleFitVertex;
+      if (useVertexFitter) {
+        singleFitVertex = theAdaptiveFitter.vertex(cluster->tracks, cluster->seedPoint);  //attempt with direct fitting
+        if (singleFitVertex.isValid())
+          vertices.push_back(singleFitVertex);
+      }
 
-		for(std::vector<TransientVertex>::const_iterator v = vertices.begin();
-		    v != vertices.end(); ++v) {
-			Measurement1D dlen= vdist.distance(pv,*v);
-			Measurement1D dlen2= vdist2d.distance(pv,*v);
-#ifdef VTXDEBUG
-			VTX vv(*v);
-			std::cout << "V chi2/n: " << v->normalisedChiSquared() << " ndof: " <<v->degreesOfFreedom() ;
-			std::cout << " dlen: " << dlen.value() << " error: " << dlen.error() << " signif: " << dlen.significance();
-			std::cout << " dlen2: " << dlen2.value() << " error2: " << dlen2.error() << " signif2: " << dlen2.significance();
-			std::cout << " pos: " << vv.position() << " error: " <<vv.xError() << " " << vv.yError() << " " << vv.zError() << std::endl;
-			std::cout << " time: " << vv.time() << " error: " << vv.tError() << std::endl;
-#endif
-			GlobalVector dir;  
-			std::vector<reco::TransientTrack> ts = v->originalTracks();
-			for(std::vector<reco::TransientTrack>::const_iterator i = ts.begin();
-					i != ts.end(); ++i) {
-				float w = v->trackWeight(*i);
-				if (w > 0.5) dir+=i->impactPointState().globalDirection();
-#ifdef VTXDEBUG
-				std::cout << "\t[" << (*i).track().pt() << ": "
-					<< (*i).track().eta() << ", "
-					<< (*i).track().phi() << "], "
-					<< w << std::endl;
-#endif
-                        }
-			GlobalPoint sv((*v).position().x(),(*v).position().y(),(*v).position().z());
-			float vscal = dir.unit().dot((sv-ppv).unit());
-			if(dlen.significance() > vertexMinDLenSig  &&
-			   ( (vertexMinAngleCosine > 0) ? (vscal > vertexMinAngleCosine) : (vscal < vertexMinAngleCosine) )
-			   &&  v->normalisedChiSquared() < 10 && dlen2.significance() > vertexMinDLen2DSig)
-			{	 
-				recoVertices->push_back(*v);
-
-#ifdef VTXDEBUG
-	                        std::cout << "ADDED" << std::endl;
-#endif
-                        }
-                      
-                   }
+      // for each transient vertex state determine if a time can be measured and fill covariance
+      if (pv.covariance(3, 3) > 0.) {
+        for (auto &vtx : vertices) {
+          svhelper::updateVertexTime(vtx);
         }
+      }
+
+      for (std::vector<TransientVertex>::const_iterator v = vertices.begin(); v != vertices.end(); ++v) {
+        Measurement1D dlen = vdist.distance(pv, *v);
+        Measurement1D dlen2 = vdist2d.distance(pv, *v);
+#ifdef VTXDEBUG
+        VTX vv(*v);
+        std::cout << "V chi2/n: " << v->normalisedChiSquared() << " ndof: " << v->degreesOfFreedom();
+        std::cout << " dlen: " << dlen.value() << " error: " << dlen.error() << " signif: " << dlen.significance();
+        std::cout << " dlen2: " << dlen2.value() << " error2: " << dlen2.error()
+                  << " signif2: " << dlen2.significance();
+        std::cout << " pos: " << vv.position() << " error: " << vv.xError() << " " << vv.yError() << " " << vv.zError()
+                  << std::endl;
+        std::cout << " time: " << vv.time() << " error: " << vv.tError() << std::endl;
+#endif
+        GlobalVector dir;
+        std::vector<reco::TransientTrack> ts = v->originalTracks();
+        for (std::vector<reco::TransientTrack>::const_iterator i = ts.begin(); i != ts.end(); ++i) {
+          float w = v->trackWeight(*i);
+          if (w > 0.5)
+            dir += i->impactPointState().globalDirection();
+#ifdef VTXDEBUG
+          std::cout << "\t[" << (*i).track().pt() << ": " << (*i).track().eta() << ", " << (*i).track().phi() << "], "
+                    << w << std::endl;
+#endif
+        }
+        GlobalPoint sv((*v).position().x(), (*v).position().y(), (*v).position().z());
+        float vscal = dir.unit().dot((sv - ppv).unit());
+        if (dlen.significance() > vertexMinDLenSig &&
+            ((vertexMinAngleCosine > 0) ? (vscal > vertexMinAngleCosine) : (vscal < vertexMinAngleCosine)) &&
+            v->normalisedChiSquared() < 10 && dlen2.significance() > vertexMinDLen2DSig) {
+          recoVertices->push_back(*v);
+
+#ifdef VTXDEBUG
+          std::cout << "ADDED" << std::endl;
+#endif
+        }
+      }
+    }
 #ifdef VTXDEBUG
 
-        std::cout <<  "Final put  " << recoVertices->size() << std::endl;
-#endif  
-        }
- 
-	event.put(std::move(recoVertices));
+    std::cout << "Final put  " << recoVertices->size() << std::endl;
+#endif
+  }
 
+  event.put(std::move(recoVertices));
 }
-#endif 
+#endif

--- a/RecoVertex/AdaptiveVertexFinder/plugins/TemplatedVertexArbitrator.h
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/TemplatedVertexArbitrator.h
@@ -88,7 +88,7 @@ class TemplatedVertexArbitrator : public edm::stream::EDProducer<> {
           }
 	}
 
-	virtual void produce(edm::Event &event, const edm::EventSetup &es) override ;
+	void produce(edm::Event &event, const edm::EventSetup &es) override ;
 
     private:
 	bool trackFilter(const reco::TrackRef &track) const;
@@ -125,7 +125,7 @@ void TemplatedVertexArbitrator<InputContainer,VTX>::produce(edm::Event &event, c
 	event.getByToken(token_primaryVertex, primaryVertices);
 
 	auto recoVertices = std::make_unique<Product>();
-	if(primaryVertices->size()!=0){ 
+	if(!primaryVertices->empty()){ 
 		const reco::Vertex &pv = (*primaryVertices)[0];
 
 		edm::Handle<InputContainer> tracks;

--- a/RecoVertex/AdaptiveVertexFinder/plugins/TemplatedVertexArbitrator.h
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/TemplatedVertexArbitrator.h
@@ -3,12 +3,10 @@
 #include <memory>
 #include <set>
 
-
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/IPTools/interface/IPTools.h"
-
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -23,7 +21,6 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "RecoVertex/VertexTools/interface/VertexDistance3D.h"
 
-
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
@@ -36,7 +33,6 @@
 #include "RecoVertex/KalmanVertexFit/interface/KalmanVertexSmoother.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
-
 #include "RecoVertex/ConfigurableVertexReco/interface/ConfigurableVertexReconstructor.h"
 #include "RecoVertex/AdaptiveVertexFinder/interface/TrackVertexArbitration.h"
 #include "DataFormats/Candidate/interface/VertexCompositePtrCandidate.h"
@@ -45,122 +41,110 @@
 
 //#define VTXDEBUG
 
-const unsigned int nTracks(const reco::Vertex & sv) {return sv.nTracks();}
-const unsigned int nTracks(const reco::VertexCompositePtrCandidate & sv) {return sv.numberOfSourceCandidatePtrs();}
+const unsigned int nTracks(const reco::Vertex &sv) { return sv.nTracks(); }
+const unsigned int nTracks(const reco::VertexCompositePtrCandidate &sv) { return sv.numberOfSourceCandidatePtrs(); }
 
 template <class InputContainer, class VTX>
 class TemplatedVertexArbitrator : public edm::stream::EDProducer<> {
-    public:
-	typedef std::vector<VTX> Product;
-	TemplatedVertexArbitrator(const edm::ParameterSet &params); 
+public:
+  typedef std::vector<VTX> Product;
+  TemplatedVertexArbitrator(const edm::ParameterSet &params);
 
-	static void fillDescriptions(edm::ConfigurationDescriptions & cdesc) {
-	  edm::ParameterSetDescription pdesc;
-	  pdesc.add<edm::InputTag>("beamSpot",edm::InputTag("offlineBeamSpot"));
-	  pdesc.add<edm::InputTag>("primaryVertices",edm::InputTag("offlinePrimaryVertices"));
-          if( std::is_same<VTX,reco::Vertex>::value ) {
-            pdesc.add<edm::InputTag>("tracks",edm::InputTag("generalTracks"));
-            pdesc.add<edm::InputTag>("secondaryVertices",edm::InputTag("vertexMerger"));
-          } else if (  std::is_same<VTX,reco::VertexCompositePtrCandidate>::value ) {
-            pdesc.add<edm::InputTag>("tracks",edm::InputTag("particleFlow"));
-            pdesc.add<edm::InputTag>("secondaryVertices",edm::InputTag("candidateVertexMerger"));
-          } else {
-            pdesc.add<edm::InputTag>("tracks",edm::InputTag("generalTracks"));
-            pdesc.add<edm::InputTag>("secondaryVertices",edm::InputTag("vertexMerger"));
-          }
-	  pdesc.add<double>("dLenFraction",0.333);
-	  pdesc.add<double>("dRCut",0.4);
-	  pdesc.add<double>("distCut",0.04);
-	  pdesc.add<double>("sigCut",5.0);
-	  pdesc.add<double>("fitterSigmacut",3.0);
-	  pdesc.add<double>("fitterTini",256);
-	  pdesc.add<double>("fitterRatio",0.25);
-	  pdesc.add<int>("trackMinLayers",4);
-	  pdesc.add<double>("trackMinPt",0.4);
-	  pdesc.add<int>("trackMinPixels",1);
-	  pdesc.add<double>("maxTimeSignificance",3.5);
-          if( std::is_same<VTX,reco::Vertex>::value ) {
-            cdesc.add("trackVertexArbitratorDefault",pdesc); 
-          } else if (  std::is_same<VTX,reco::VertexCompositePtrCandidate>::value ) {
-            cdesc.add("candidateVertexArbitratorDefault",pdesc); 
-          } else {
-            cdesc.addDefault(pdesc); 
-          }
-	}
+  static void fillDescriptions(edm::ConfigurationDescriptions &cdesc) {
+    edm::ParameterSetDescription pdesc;
+    pdesc.add<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot"));
+    pdesc.add<edm::InputTag>("primaryVertices", edm::InputTag("offlinePrimaryVertices"));
+    if (std::is_same<VTX, reco::Vertex>::value) {
+      pdesc.add<edm::InputTag>("tracks", edm::InputTag("generalTracks"));
+      pdesc.add<edm::InputTag>("secondaryVertices", edm::InputTag("vertexMerger"));
+    } else if (std::is_same<VTX, reco::VertexCompositePtrCandidate>::value) {
+      pdesc.add<edm::InputTag>("tracks", edm::InputTag("particleFlow"));
+      pdesc.add<edm::InputTag>("secondaryVertices", edm::InputTag("candidateVertexMerger"));
+    } else {
+      pdesc.add<edm::InputTag>("tracks", edm::InputTag("generalTracks"));
+      pdesc.add<edm::InputTag>("secondaryVertices", edm::InputTag("vertexMerger"));
+    }
+    pdesc.add<double>("dLenFraction", 0.333);
+    pdesc.add<double>("dRCut", 0.4);
+    pdesc.add<double>("distCut", 0.04);
+    pdesc.add<double>("sigCut", 5.0);
+    pdesc.add<double>("fitterSigmacut", 3.0);
+    pdesc.add<double>("fitterTini", 256);
+    pdesc.add<double>("fitterRatio", 0.25);
+    pdesc.add<int>("trackMinLayers", 4);
+    pdesc.add<double>("trackMinPt", 0.4);
+    pdesc.add<int>("trackMinPixels", 1);
+    pdesc.add<double>("maxTimeSignificance", 3.5);
+    if (std::is_same<VTX, reco::Vertex>::value) {
+      cdesc.add("trackVertexArbitratorDefault", pdesc);
+    } else if (std::is_same<VTX, reco::VertexCompositePtrCandidate>::value) {
+      cdesc.add("candidateVertexArbitratorDefault", pdesc);
+    } else {
+      cdesc.addDefault(pdesc);
+    }
+  }
 
-	void produce(edm::Event &event, const edm::EventSetup &es) override ;
+  void produce(edm::Event &event, const edm::EventSetup &es) override;
 
-    private:
-	bool trackFilter(const reco::TrackRef &track) const;
+private:
+  bool trackFilter(const reco::TrackRef &track) const;
 
-	edm::EDGetTokenT<reco::VertexCollection> token_primaryVertex;
-	edm::EDGetTokenT<Product> token_secondaryVertex;
-	edm::EDGetTokenT<InputContainer>	 token_tracks; 
-	edm::EDGetTokenT<reco::BeamSpot> 	 token_beamSpot; 
-	std::unique_ptr<TrackVertexArbitration<VTX> > theArbitrator;
+  edm::EDGetTokenT<reco::VertexCollection> token_primaryVertex;
+  edm::EDGetTokenT<Product> token_secondaryVertex;
+  edm::EDGetTokenT<InputContainer> token_tracks;
+  edm::EDGetTokenT<reco::BeamSpot> token_beamSpot;
+  std::unique_ptr<TrackVertexArbitration<VTX> > theArbitrator;
 };
 
-
 template <class InputContainer, class VTX>
-TemplatedVertexArbitrator<InputContainer,VTX>::TemplatedVertexArbitrator(const edm::ParameterSet &params)
-{
-	token_primaryVertex = consumes<reco::VertexCollection>(params.getParameter<edm::InputTag>("primaryVertices"));
-	token_secondaryVertex = consumes<Product>(params.getParameter<edm::InputTag>("secondaryVertices"));
-	token_beamSpot = consumes<reco::BeamSpot>(params.getParameter<edm::InputTag>("beamSpot"));
-	token_tracks = consumes<InputContainer>(params.getParameter<edm::InputTag>("tracks"));
-	produces<Product>();
-	theArbitrator.reset( new TrackVertexArbitration<VTX>(params) );
+TemplatedVertexArbitrator<InputContainer, VTX>::TemplatedVertexArbitrator(const edm::ParameterSet &params) {
+  token_primaryVertex = consumes<reco::VertexCollection>(params.getParameter<edm::InputTag>("primaryVertices"));
+  token_secondaryVertex = consumes<Product>(params.getParameter<edm::InputTag>("secondaryVertices"));
+  token_beamSpot = consumes<reco::BeamSpot>(params.getParameter<edm::InputTag>("beamSpot"));
+  token_tracks = consumes<InputContainer>(params.getParameter<edm::InputTag>("tracks"));
+  produces<Product>();
+  theArbitrator.reset(new TrackVertexArbitration<VTX>(params));
 }
 
 template <class InputContainer, class VTX>
-void TemplatedVertexArbitrator<InputContainer,VTX>::produce(edm::Event &event, const edm::EventSetup &es)
-{
-	using namespace reco;
+void TemplatedVertexArbitrator<InputContainer, VTX>::produce(edm::Event &event, const edm::EventSetup &es) {
+  using namespace reco;
 
-	edm::Handle<Product> secondaryVertices;
-	event.getByToken(token_secondaryVertex, secondaryVertices);
-	Product theSecVertexColl = *(secondaryVertices.product());
+  edm::Handle<Product> secondaryVertices;
+  event.getByToken(token_secondaryVertex, secondaryVertices);
+  Product theSecVertexColl = *(secondaryVertices.product());
 
-	edm::Handle<VertexCollection> primaryVertices;
-	event.getByToken(token_primaryVertex, primaryVertices);
+  edm::Handle<VertexCollection> primaryVertices;
+  event.getByToken(token_primaryVertex, primaryVertices);
 
-	auto recoVertices = std::make_unique<Product>();
-	if(!primaryVertices->empty()){ 
-		const reco::Vertex &pv = (*primaryVertices)[0];
+  auto recoVertices = std::make_unique<Product>();
+  if (!primaryVertices->empty()) {
+    const reco::Vertex &pv = (*primaryVertices)[0];
 
-		edm::Handle<InputContainer> tracks;
-		event.getByToken(token_tracks, tracks);
+    edm::Handle<InputContainer> tracks;
+    event.getByToken(token_tracks, tracks);
 
-		edm::ESHandle<TransientTrackBuilder> trackBuilder;
-		es.get<TransientTrackRecord>().get("TransientTrackBuilder",
-				trackBuilder);
+    edm::ESHandle<TransientTrackBuilder> trackBuilder;
+    es.get<TransientTrackRecord>().get("TransientTrackBuilder", trackBuilder);
 
-		edm::Handle<BeamSpot> beamSpot;
-		event.getByToken(token_beamSpot,beamSpot);
+    edm::Handle<BeamSpot> beamSpot;
+    event.getByToken(token_beamSpot, beamSpot);
 
-		std::vector<TransientTrack> selectedTracks;
-		for(typename InputContainer::const_iterator track = tracks->begin();
-				track != tracks->end(); ++track) {
-			 selectedTracks.push_back(tthelpers::buildTT(tracks,trackBuilder,track - tracks->begin()));
-		}
+    std::vector<TransientTrack> selectedTracks;
+    for (typename InputContainer::const_iterator track = tracks->begin(); track != tracks->end(); ++track) {
+      selectedTracks.push_back(tthelpers::buildTT(tracks, trackBuilder, track - tracks->begin()));
+    }
 
+    //        const edm::RefVector< TrackCollection > tracksForArbitration= selectedTracks;
+    Product theRecoVertices = theArbitrator->trackVertexArbitrator(beamSpot, pv, selectedTracks, theSecVertexColl);
 
-		//        const edm::RefVector< TrackCollection > tracksForArbitration= selectedTracks;
-		Product  theRecoVertices = theArbitrator->trackVertexArbitrator(beamSpot, pv, selectedTracks,
-				theSecVertexColl);
-
-		for(unsigned int ivtx=0; ivtx < theRecoVertices.size(); ivtx++){
-			if ( !(nTracks(theRecoVertices[ivtx]) > 1) ) continue;
-			recoVertices->push_back(theRecoVertices[ivtx]);
-		}
-
-	}	
-	event.put(std::move(recoVertices));
-
-
-
+    for (unsigned int ivtx = 0; ivtx < theRecoVertices.size(); ivtx++) {
+      if (!(nTracks(theRecoVertices[ivtx]) > 1))
+        continue;
+      recoVertices->push_back(theRecoVertices[ivtx]);
+    }
+  }
+  event.put(std::move(recoVertices));
 }
-
-
 
 #endif

--- a/RecoVertex/AdaptiveVertexFinder/plugins/VertexArbitrators.cc
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/VertexArbitrators.cc
@@ -14,10 +14,9 @@
 
 //#define VTXDEBUG
 
-
-typedef TemplatedVertexArbitrator<reco::TrackCollection,reco::Vertex> TrackVertexArbitrator;
-typedef TemplatedVertexArbitrator<edm::View<reco::Candidate>,reco::VertexCompositePtrCandidate> CandidateVertexArbitrator;
+typedef TemplatedVertexArbitrator<reco::TrackCollection, reco::Vertex> TrackVertexArbitrator;
+typedef TemplatedVertexArbitrator<edm::View<reco::Candidate>, reco::VertexCompositePtrCandidate>
+    CandidateVertexArbitrator;
 
 DEFINE_FWK_MODULE(TrackVertexArbitrator);
 DEFINE_FWK_MODULE(CandidateVertexArbitrator);
-

--- a/RecoVertex/AdaptiveVertexFinder/plugins/VertexMerger.cc
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/VertexMerger.cc
@@ -20,72 +20,61 @@
 
 template <class VTX>
 class TemplatedVertexMerger : public edm::stream::EDProducer<> {
-    public:
-	typedef std::vector<VTX> Product;
-	TemplatedVertexMerger(const edm::ParameterSet &params);
+public:
+  typedef std::vector<VTX> Product;
+  TemplatedVertexMerger(const edm::ParameterSet &params);
 
-	void produce(edm::Event &event, const edm::EventSetup &es) override;
+  void produce(edm::Event &event, const edm::EventSetup &es) override;
 
-    private:
-	bool trackFilter(const reco::TrackRef &track) const;
+private:
+  bool trackFilter(const reco::TrackRef &track) const;
 
-	edm::EDGetTokenT<Product> 	        token_secondaryVertex;
-	double					maxFraction;
-	double					minSignificance;
+  edm::EDGetTokenT<Product> token_secondaryVertex;
+  double maxFraction;
+  double minSignificance;
 };
 
 template <class VTX>
-TemplatedVertexMerger<VTX>::TemplatedVertexMerger(const edm::ParameterSet &params) :
-	maxFraction(params.getParameter<double>("maxFraction")),
-	minSignificance(params.getParameter<double>("minSignificance"))
-{
-	token_secondaryVertex = consumes<Product>(params.getParameter<edm::InputTag>("secondaryVertices"));
-	produces<Product>();
+TemplatedVertexMerger<VTX>::TemplatedVertexMerger(const edm::ParameterSet &params)
+    : maxFraction(params.getParameter<double>("maxFraction")),
+      minSignificance(params.getParameter<double>("minSignificance")) {
+  token_secondaryVertex = consumes<Product>(params.getParameter<edm::InputTag>("secondaryVertices"));
+  produces<Product>();
 }
 
 template <class VTX>
-void TemplatedVertexMerger<VTX>::produce(edm::Event &event, const edm::EventSetup &es)
-{
-	using namespace reco;
+void TemplatedVertexMerger<VTX>::produce(edm::Event &event, const edm::EventSetup &es) {
+  using namespace reco;
 
-	edm::Handle<Product> secondaryVertices;
-	event.getByToken(token_secondaryVertex, secondaryVertices);
+  edm::Handle<Product> secondaryVertices;
+  event.getByToken(token_secondaryVertex, secondaryVertices);
 
-        VertexDistance3D dist;
-	auto recoVertices = std::make_unique<Product>();
-	for(typename Product::const_iterator sv = secondaryVertices->begin();
-	    sv != secondaryVertices->end(); ++sv) {
-          recoVertices->push_back(*sv);
-        }
-       for(typename Product::iterator sv = recoVertices->begin();
-	    sv != recoVertices->end(); ++sv) {
+  VertexDistance3D dist;
+  auto recoVertices = std::make_unique<Product>();
+  for (typename Product::const_iterator sv = secondaryVertices->begin(); sv != secondaryVertices->end(); ++sv) {
+    recoVertices->push_back(*sv);
+  }
+  for (typename Product::iterator sv = recoVertices->begin(); sv != recoVertices->end(); ++sv) {
+    bool shared = false;
+    VertexState s1(RecoVertex::convertPos(sv->position()), RecoVertex::convertError(sv->error()));
+    for (typename Product::iterator sv2 = recoVertices->begin(); sv2 != recoVertices->end(); ++sv2) {
+      VertexState s2(RecoVertex::convertPos(sv2->position()), RecoVertex::convertError(sv2->error()));
+      double fr = vertexTools::computeSharedTracks(*sv2, *sv);
+      //        std::cout << sv2-recoVertices->begin() << " vs " << sv-recoVertices->begin() << " : " << fr << " "  <<  computeSharedTracks(*sv, *sv2) << " sig " << dist.distance(*sv,*sv2).significance() << std::endl;
+      //      std::cout << (fr > maxFraction) << " && " << (dist.distance(*sv,*sv2).significance() < 2)  <<  " && " <<  (sv-sv2!=0)  << " && " <<  (fr >= computeSharedTracks(*sv2, *sv))  << std::endl;
+      if (fr > maxFraction && dist.distance(s1, s2).significance() < minSignificance && sv - sv2 != 0 &&
+          fr >= vertexTools::computeSharedTracks(*sv, *sv2)) {
+        shared = true;
+        // std::cout << "shared " << sv-recoVertices->begin() << " and "  << sv2-recoVertices->begin() << " fractions: " << fr << " , "  << computeSharedTracks(*sv2, *sv) << " sig: " <<  dist.distance(*sv,*sv2).significance() <<  std::endl;
+      }
+    }
+    if (shared) {
+      sv = recoVertices->erase(sv) - 1;
+    }
+    //    std::cout << "it = " <<  sv-recoVertices->begin() << " new size is: " << recoVertices->size() <<   std::endl;
+  }
 
-        bool shared=false;
-	VertexState s1(RecoVertex::convertPos(sv->position()),RecoVertex::convertError(sv->error()));
-        for(typename Product::iterator sv2 = recoVertices->begin();
-	    sv2 != recoVertices->end(); ++sv2) {
-		  VertexState s2(RecoVertex::convertPos(sv2->position()),RecoVertex::convertError(sv2->error()));
-                  double fr=vertexTools::computeSharedTracks(*sv2, *sv);
-        //        std::cout << sv2-recoVertices->begin() << " vs " << sv-recoVertices->begin() << " : " << fr << " "  <<  computeSharedTracks(*sv, *sv2) << " sig " << dist.distance(*sv,*sv2).significance() << std::endl;
-          //      std::cout << (fr > maxFraction) << " && " << (dist.distance(*sv,*sv2).significance() < 2)  <<  " && " <<  (sv-sv2!=0)  << " && " <<  (fr >= computeSharedTracks(*sv2, *sv))  << std::endl;
-		if (fr > maxFraction && dist.distance(s1,s2).significance() < minSignificance && sv-sv2!=0 
-                    && fr >= vertexTools::computeSharedTracks(*sv, *sv2) )
-		  {
-                      shared=true; 
-                     // std::cout << "shared " << sv-recoVertices->begin() << " and "  << sv2-recoVertices->begin() << " fractions: " << fr << " , "  << computeSharedTracks(*sv2, *sv) << " sig: " <<  dist.distance(*sv,*sv2).significance() <<  std::endl;
-         
-                  }
-                 
-
-	}
-        if(shared) { sv=recoVertices->erase(sv)-1; }
-     //    std::cout << "it = " <<  sv-recoVertices->begin() << " new size is: " << recoVertices->size() <<   std::endl;
-       }
-
-	event.put(std::move(recoVertices));
-
-
-
+  event.put(std::move(recoVertices));
 }
 
 typedef TemplatedVertexMerger<reco::Vertex> VertexMerger;

--- a/RecoVertex/AdaptiveVertexFinder/src/AdaptiveVertexReconstructor.cc
+++ b/RecoVertex/AdaptiveVertexFinder/src/AdaptiveVertexReconstructor.cc
@@ -8,244 +8,213 @@
 
 using namespace std;
 
-TransientVertex AdaptiveVertexReconstructor::cleanUp ( const TransientVertex & old ) const
-{
-  vector < reco::TransientTrack > trks = old.originalTracks();
-  vector < reco::TransientTrack > newtrks;
+TransientVertex AdaptiveVertexReconstructor::cleanUp(const TransientVertex& old) const {
+  vector<reco::TransientTrack> trks = old.originalTracks();
+  vector<reco::TransientTrack> newtrks;
   TransientVertex::TransientTrackToFloatMap mp;
-  static const float minweight = 1.e-8; // discard all tracks with lower weight
-  for ( vector< reco::TransientTrack >::const_iterator i=trks.begin();
-        i!=trks.end() ; ++i )
-  {
-    if ( old.trackWeight ( *i ) > minweight )
-    {
-      newtrks.push_back ( *i );
-      mp[*i]=old.trackWeight ( *i );
+  static const float minweight = 1.e-8;  // discard all tracks with lower weight
+  for (vector<reco::TransientTrack>::const_iterator i = trks.begin(); i != trks.end(); ++i) {
+    if (old.trackWeight(*i) > minweight) {
+      newtrks.push_back(*i);
+      mp[*i] = old.trackWeight(*i);
     }
   }
 
   TransientVertex ret;
 
-  if ( old.hasPrior() )
-  {
-    VertexState priorstate ( old.priorPosition(), old.priorError() );
-    ret=TransientVertex ( priorstate, old.vertexState(), newtrks,
-        old.totalChiSquared(), old.degreesOfFreedom() );
+  if (old.hasPrior()) {
+    VertexState priorstate(old.priorPosition(), old.priorError());
+    ret = TransientVertex(priorstate, old.vertexState(), newtrks, old.totalChiSquared(), old.degreesOfFreedom());
   } else {
-    ret=TransientVertex ( old.vertexState(), newtrks,
-                          old.totalChiSquared(), old.degreesOfFreedom() );
+    ret = TransientVertex(old.vertexState(), newtrks, old.totalChiSquared(), old.degreesOfFreedom());
   }
-  ret.weightMap ( mp ); // set weight map
+  ret.weightMap(mp);  // set weight map
 
-  if ( old.hasRefittedTracks() )
-  {
+  if (old.hasRefittedTracks()) {
     // we have refitted tracks -- copy them!
-    vector < reco::TransientTrack > newrfs;
-    vector < reco::TransientTrack > oldrfs=old.refittedTracks();
-    vector < reco::TransientTrack >::const_iterator origtrkiter=trks.begin();
-    for ( vector< reco::TransientTrack >::const_iterator i=oldrfs.begin(); i!=oldrfs.end() ; ++i )
-    {
-      if ( old.trackWeight ( *origtrkiter ) > minweight )
-      {
-        newrfs.push_back ( *i );
+    vector<reco::TransientTrack> newrfs;
+    vector<reco::TransientTrack> oldrfs = old.refittedTracks();
+    vector<reco::TransientTrack>::const_iterator origtrkiter = trks.begin();
+    for (vector<reco::TransientTrack>::const_iterator i = oldrfs.begin(); i != oldrfs.end(); ++i) {
+      if (old.trackWeight(*origtrkiter) > minweight) {
+        newrfs.push_back(*i);
       }
       origtrkiter++;
     }
-    if ( !newrfs.empty() ) ret.refittedTracks ( newrfs ); // copy refitted tracks
+    if (!newrfs.empty())
+      ret.refittedTracks(newrfs);  // copy refitted tracks
   }
 
-  if ( ret.refittedTracks().size() > ret.originalTracks().size() )
-  {
-    edm::LogError("AdaptiveVertexReconstructor" )
-      << "More refitted tracks than original tracks!";
+  if (ret.refittedTracks().size() > ret.originalTracks().size()) {
+    edm::LogError("AdaptiveVertexReconstructor") << "More refitted tracks than original tracks!";
   }
 
   return ret;
 }
 
-void AdaptiveVertexReconstructor::erase (
-    const TransientVertex & newvtx,
-    set < reco::TransientTrack > & remainingtrks,
-    float w ) const
-{
+void AdaptiveVertexReconstructor::erase(const TransientVertex& newvtx,
+                                        set<reco::TransientTrack>& remainingtrks,
+                                        float w) const {
   /*
    * Erase tracks that are in newvtx from remainingtrks 
    * But erase only if trackweight > w
    */
-  const vector < reco::TransientTrack > & origtrks = newvtx.originalTracks();
-  for ( vector< reco::TransientTrack >::const_iterator i=origtrks.begin();
-        i!=origtrks.end(); ++i )
-  {
-    double weight = newvtx.trackWeight ( *i );
-    if ( weight > w )
-    {
-      remainingtrks.erase ( *i );
+  const vector<reco::TransientTrack>& origtrks = newvtx.originalTracks();
+  for (vector<reco::TransientTrack>::const_iterator i = origtrks.begin(); i != origtrks.end(); ++i) {
+    double weight = newvtx.trackWeight(*i);
+    if (weight > w) {
+      remainingtrks.erase(*i);
     };
   };
 }
 
-AdaptiveVertexReconstructor::AdaptiveVertexReconstructor(
-    float primcut, float seccut, float min_weight, bool smoothing ) :
-  thePrimaryFitter ( nullptr ), theSecondaryFitter ( nullptr ),
-       theMinWeight( min_weight ), theWeightThreshold ( 0.001 )
-{
-  setupFitters ( primcut, 256., 0.25, seccut, 256., 0.25, smoothing );
+AdaptiveVertexReconstructor::AdaptiveVertexReconstructor(float primcut, float seccut, float min_weight, bool smoothing)
+    : thePrimaryFitter(nullptr), theSecondaryFitter(nullptr), theMinWeight(min_weight), theWeightThreshold(0.001) {
+  setupFitters(primcut, 256., 0.25, seccut, 256., 0.25, smoothing);
 }
 
-AdaptiveVertexReconstructor::~AdaptiveVertexReconstructor()
-{
-  if ( thePrimaryFitter ) delete thePrimaryFitter;
-  if ( theSecondaryFitter ) delete theSecondaryFitter;
+AdaptiveVertexReconstructor::~AdaptiveVertexReconstructor() {
+  if (thePrimaryFitter)
+    delete thePrimaryFitter;
+  if (theSecondaryFitter)
+    delete theSecondaryFitter;
 }
 
-void AdaptiveVertexReconstructor::setupFitters ( float primcut, 
-    float primT, float primr, float seccut, float secT,
-    float secr, bool smoothing )
-{
-  VertexSmoother<5> * smoother ;
-  if ( smoothing )
-  {
+void AdaptiveVertexReconstructor::setupFitters(
+    float primcut, float primT, float primr, float seccut, float secT, float secr, bool smoothing) {
+  VertexSmoother<5>* smoother;
+  if (smoothing) {
     smoother = new KalmanVertexSmoother();
   } else {
     smoother = new DummyVertexSmoother<5>();
   }
 
-  if ( thePrimaryFitter ) delete thePrimaryFitter;
-  if ( theSecondaryFitter ) delete theSecondaryFitter;
+  if (thePrimaryFitter)
+    delete thePrimaryFitter;
+  if (theSecondaryFitter)
+    delete theSecondaryFitter;
 
   /*
   edm::LogError ("AdaptiveVertexReconstructor" )
     << "Tini and r are hardcoded now!";
     */
-  thePrimaryFitter = new AdaptiveVertexFitter ( GeometricAnnealing ( primcut, primT, primr ), DefaultLinearizationPointFinder(),
-      KalmanVertexUpdator<5>(), KalmanVertexTrackCompatibilityEstimator<5>(), *smoother );
-  thePrimaryFitter->setWeightThreshold ( theWeightThreshold );
+  thePrimaryFitter = new AdaptiveVertexFitter(GeometricAnnealing(primcut, primT, primr),
+                                              DefaultLinearizationPointFinder(),
+                                              KalmanVertexUpdator<5>(),
+                                              KalmanVertexTrackCompatibilityEstimator<5>(),
+                                              *smoother);
+  thePrimaryFitter->setWeightThreshold(theWeightThreshold);
   // if the primary fails, sth is wrong, so here we set a threshold on the weight.
-  theSecondaryFitter = new AdaptiveVertexFitter ( GeometricAnnealing ( seccut, secT, secr ), DefaultLinearizationPointFinder(),
-      KalmanVertexUpdator<5>(), 
-      KalmanVertexTrackCompatibilityEstimator<5>(), *smoother );
-  theSecondaryFitter->setWeightThreshold ( 0. );
-  // need to set it or else we have 
+  theSecondaryFitter = new AdaptiveVertexFitter(GeometricAnnealing(seccut, secT, secr),
+                                                DefaultLinearizationPointFinder(),
+                                                KalmanVertexUpdator<5>(),
+                                                KalmanVertexTrackCompatibilityEstimator<5>(),
+                                                *smoother);
+  theSecondaryFitter->setWeightThreshold(0.);
+  // need to set it or else we have
   // unwanted exceptions to deal with.
   // cleanup can come later!
   delete smoother;
 }
 
-AdaptiveVertexReconstructor::AdaptiveVertexReconstructor( const edm::ParameterSet & m )
-  : thePrimaryFitter(nullptr), theSecondaryFitter(nullptr), theMinWeight(0.5), theWeightThreshold ( 0.001 )
-{
+AdaptiveVertexReconstructor::AdaptiveVertexReconstructor(const edm::ParameterSet& m)
+    : thePrimaryFitter(nullptr), theSecondaryFitter(nullptr), theMinWeight(0.5), theWeightThreshold(0.001) {
   float primcut = 2.0;
   float seccut = 6.0;
-  bool smoothing=false;
+  bool smoothing = false;
   // float primT = 4096.;
   // float primr = 0.125;
   float primT = 256.;
   float primr = 0.25;
   float secT = 256.;
   float secr = 0.25;
-  
+
   try {
-    primcut =  m.getParameter<double>("primcut");
-    primT =  m.getParameter<double>("primT");
-    primr =  m.getParameter<double>("primr");
-    seccut =  m.getParameter<double>("seccut");
-    secT =  m.getParameter<double>("secT");
-    secr =  m.getParameter<double>("secr");
+    primcut = m.getParameter<double>("primcut");
+    primT = m.getParameter<double>("primT");
+    primr = m.getParameter<double>("primr");
+    seccut = m.getParameter<double>("seccut");
+    secT = m.getParameter<double>("secT");
+    secr = m.getParameter<double>("secr");
     theMinWeight = m.getParameter<double>("minweight");
     theWeightThreshold = m.getParameter<double>("weightthreshold");
-    smoothing =  m.getParameter<bool>("smoothing");
-  } catch ( edm::Exception & e ) {
-    edm::LogError ("AdaptiveVertexReconstructor") << e.what();
+    smoothing = m.getParameter<bool>("smoothing");
+  } catch (edm::Exception& e) {
+    edm::LogError("AdaptiveVertexReconstructor") << e.what();
   }
 
-  setupFitters ( primcut, primT, primr, seccut, secT, secr, smoothing );
+  setupFitters(primcut, primT, primr, seccut, secT, secr, smoothing);
 }
 
-vector<TransientVertex> 
-    AdaptiveVertexReconstructor::vertices(const vector<reco::TransientTrack> & t, 
-        const reco::BeamSpot & s ) const
-{
-  return vertices ( vector<reco::TransientTrack>(), t, s, false, true );
+vector<TransientVertex> AdaptiveVertexReconstructor::vertices(const vector<reco::TransientTrack>& t,
+                                                              const reco::BeamSpot& s) const {
+  return vertices(vector<reco::TransientTrack>(), t, s, false, true);
 }
 
-vector<TransientVertex> 
-    AdaptiveVertexReconstructor::vertices(const vector<reco::TransientTrack> & primaries,
-       const vector<reco::TransientTrack > & tracks, const reco::BeamSpot & s ) const
-{
-  return vertices ( primaries, tracks, s, true, true );
+vector<TransientVertex> AdaptiveVertexReconstructor::vertices(const vector<reco::TransientTrack>& primaries,
+                                                              const vector<reco::TransientTrack>& tracks,
+                                                              const reco::BeamSpot& s) const {
+  return vertices(primaries, tracks, s, true, true);
 }
 
-
-vector<TransientVertex> AdaptiveVertexReconstructor::vertices (
-    const vector<reco::TransientTrack> & tracks ) const
-{
-  return vertices ( vector<reco::TransientTrack>(), tracks, reco::BeamSpot(), 
-                    false, false );
+vector<TransientVertex> AdaptiveVertexReconstructor::vertices(const vector<reco::TransientTrack>& tracks) const {
+  return vertices(vector<reco::TransientTrack>(), tracks, reco::BeamSpot(), false, false);
 }
 
-vector<TransientVertex> AdaptiveVertexReconstructor::vertices (
-    const vector<reco::TransientTrack> & primaries,
-    const vector<reco::TransientTrack> & tracks,
-    const reco::BeamSpot & s, bool has_primaries, bool usespot ) const
-{
-  vector < TransientVertex > ret;
-  set < reco::TransientTrack > remainingtrks;
+vector<TransientVertex> AdaptiveVertexReconstructor::vertices(const vector<reco::TransientTrack>& primaries,
+                                                              const vector<reco::TransientTrack>& tracks,
+                                                              const reco::BeamSpot& s,
+                                                              bool has_primaries,
+                                                              bool usespot) const {
+  vector<TransientVertex> ret;
+  set<reco::TransientTrack> remainingtrks;
 
-  copy(tracks.begin(), tracks.end(), 
-	    inserter(remainingtrks, remainingtrks.begin()));
+  copy(tracks.begin(), tracks.end(), inserter(remainingtrks, remainingtrks.begin()));
 
-  int ctr=0;
+  int ctr = 0;
   unsigned int n_tracks = remainingtrks.size();
 
   // cout << "[AdaptiveVertexReconstructor] DEBUG ::vertices!!" << endl;
   try {
-    while ( remainingtrks.size() > 1 )
-    {
+    while (remainingtrks.size() > 1) {
       /*
       cout << "[AdaptiveVertexReconstructor] next round: "
            << remainingtrks.size() << endl;
            */
       ctr++;
-      const AdaptiveVertexFitter * fitter = theSecondaryFitter;
-      if ( ret.empty() )
-      {
+      const AdaptiveVertexFitter* fitter = theSecondaryFitter;
+      if (ret.empty()) {
         fitter = thePrimaryFitter;
       };
-      vector < reco::TransientTrack > fittrks;
-      fittrks.reserve ( remainingtrks.size() );
+      vector<reco::TransientTrack> fittrks;
+      fittrks.reserve(remainingtrks.size());
 
       copy(remainingtrks.begin(), remainingtrks.end(), back_inserter(fittrks));
 
       TransientVertex tmpvtx;
-      if ( (ret.empty()) && has_primaries )
-      {
+      if ((ret.empty()) && has_primaries) {
         // add the primaries to the fitted tracks.
-        copy ( primaries.begin(), primaries.end(), back_inserter(fittrks) );
+        copy(primaries.begin(), primaries.end(), back_inserter(fittrks));
       }
-      if ( (ret.empty()) && usespot )
-      {
-        tmpvtx=fitter->vertex ( fittrks, s );
+      if ((ret.empty()) && usespot) {
+        tmpvtx = fitter->vertex(fittrks, s);
       } else {
-        tmpvtx=fitter->vertex ( fittrks );
+        tmpvtx = fitter->vertex(fittrks);
       }
-      TransientVertex newvtx = cleanUp ( tmpvtx );
-      ret.push_back ( newvtx );
-      erase ( newvtx, remainingtrks, theMinWeight );
-      if ( n_tracks == remainingtrks.size() )
-      {
-        if ( usespot )
-        {
+      TransientVertex newvtx = cleanUp(tmpvtx);
+      ret.push_back(newvtx);
+      erase(newvtx, remainingtrks, theMinWeight);
+      if (n_tracks == remainingtrks.size()) {
+        if (usespot) {
           // try once more without beamspot constraint!
-          usespot=false;
-          LogDebug("AdaptiveVertexReconstructor") 
-            << "no tracks in vertex. trying again without beamspot constraint!";
+          usespot = false;
+          LogDebug("AdaptiveVertexReconstructor") << "no tracks in vertex. trying again without beamspot constraint!";
           continue;
         }
-        LogDebug("AdaptiveVertexReconstructor") << "all tracks (" << n_tracks
-             << ") would be recycled for next fit. Trying with low threshold!";
-        erase ( newvtx, remainingtrks, 1.e-5 );
-        if ( n_tracks == remainingtrks.size() )
-        {
+        LogDebug("AdaptiveVertexReconstructor")
+            << "all tracks (" << n_tracks << ") would be recycled for next fit. Trying with low threshold!";
+        erase(newvtx, remainingtrks, 1.e-5);
+        if (n_tracks == remainingtrks.size()) {
           LogDebug("AdaptiveVertexReconstructor") << "low threshold didnt help! "
                                                   << "Discontinue procedure!";
           break;
@@ -255,35 +224,32 @@ vector<TransientVertex> AdaptiveVertexReconstructor::vertices (
       // cout << "[AdaptiveVertexReconstructor] erased" << endl;
       n_tracks = remainingtrks.size();
     };
-  } catch ( VertexException & v ) {
+  } catch (VertexException& v) {
     // Will catch all (not enough significant tracks exceptions.
     // in this case, the iteration can safely terminate.
   };
 
-  return cleanUpVertices ( ret );
+  return cleanUpVertices(ret);
 }
 
-vector<TransientVertex> AdaptiveVertexReconstructor::cleanUpVertices (
-    const vector < TransientVertex > & old ) const
-{
-  vector < TransientVertex > ret;
-  for ( vector< TransientVertex >::const_iterator i=old.begin(); i!=old.end() ; ++i )
-  {
-    if (!(i->hasTrackWeight()))
-    { // if we dont have track weights, we take the vtx
-      ret.push_back ( *i );
+vector<TransientVertex> AdaptiveVertexReconstructor::cleanUpVertices(const vector<TransientVertex>& old) const {
+  vector<TransientVertex> ret;
+  for (vector<TransientVertex>::const_iterator i = old.begin(); i != old.end(); ++i) {
+    if (!(i->hasTrackWeight())) {  // if we dont have track weights, we take the vtx
+      ret.push_back(*i);
       continue;
     }
 
     // maybe this should be replaced with asking for the ndf ...
     // e.g. if ( ndf > - 1. )
-    int nsig=0; // number of significant tracks. 
+    int nsig = 0;  // number of significant tracks.
     TransientVertex::TransientTrackToFloatMap wm = i->weightMap();
-    for ( TransientVertex::TransientTrackToFloatMap::const_iterator w=wm.begin(); w!=wm.end() ; ++w )
-    {
-      if (w->second > theWeightThreshold) nsig++;
+    for (TransientVertex::TransientTrackToFloatMap::const_iterator w = wm.begin(); w != wm.end(); ++w) {
+      if (w->second > theWeightThreshold)
+        nsig++;
     }
-    if ( nsig > 1 ) ret.push_back ( *i );
+    if (nsig > 1)
+      ret.push_back(*i);
   }
 
   return ret;

--- a/RecoVertex/AdaptiveVertexFinder/src/TracksClusteringFromDisplacedSeed.cc
+++ b/RecoVertex/AdaptiveVertexFinder/src/TracksClusteringFromDisplacedSeed.cc
@@ -2,136 +2,135 @@
 //#define VTXDEBUG 1
 #include "FWCore/Utilities/interface/isFinite.h"
 
-TracksClusteringFromDisplacedSeed::TracksClusteringFromDisplacedSeed(const edm::ParameterSet &params) :
-//	maxNTracks(params.getParameter<unsigned int>("maxNTracks")),
-	max3DIPSignificance(params.getParameter<double>("seedMax3DIPSignificance")),
-	max3DIPValue(params.getParameter<double>("seedMax3DIPValue")),
-	min3DIPSignificance(params.getParameter<double>("seedMin3DIPSignificance")),
-	min3DIPValue(params.getParameter<double>("seedMin3DIPValue")),
-	clusterMaxDistance(params.getParameter<double>("clusterMaxDistance")),
-        clusterMaxSignificance(params.getParameter<double>("clusterMaxSignificance")), //3
-        distanceRatio(params.getParameter<double>("distanceRatio")),//was clusterScale/densityFactor
-        clusterMinAngleCosine(params.getParameter<double>("clusterMinAngleCosine")), //0.0
-	maxTimeSignificance(params.getParameter<double>("maxTimeSignificance"))
+TracksClusteringFromDisplacedSeed::TracksClusteringFromDisplacedSeed(const edm::ParameterSet &params)
+    :  //	maxNTracks(params.getParameter<unsigned int>("maxNTracks")),
+      max3DIPSignificance(params.getParameter<double>("seedMax3DIPSignificance")),
+      max3DIPValue(params.getParameter<double>("seedMax3DIPValue")),
+      min3DIPSignificance(params.getParameter<double>("seedMin3DIPSignificance")),
+      min3DIPValue(params.getParameter<double>("seedMin3DIPValue")),
+      clusterMaxDistance(params.getParameter<double>("clusterMaxDistance")),
+      clusterMaxSignificance(params.getParameter<double>("clusterMaxSignificance")),  //3
+      distanceRatio(params.getParameter<double>("distanceRatio")),                    //was clusterScale/densityFactor
+      clusterMinAngleCosine(params.getParameter<double>("clusterMinAngleCosine")),    //0.0
+      maxTimeSignificance(params.getParameter<double>("maxTimeSignificance"))
 
-{
-	
-}
+{}
 
-std::pair<std::vector<reco::TransientTrack>,GlobalPoint> TracksClusteringFromDisplacedSeed::nearTracks(const reco::TransientTrack &seed, const std::vector<reco::TransientTrack> & tracks, const  reco::Vertex & primaryVertex) const
-{
-      VertexDistance3D distanceComputer;
-      GlobalPoint pv(primaryVertex.position().x(),primaryVertex.position().y(),primaryVertex.position().z());
-      std::vector<reco::TransientTrack> result;
-      TwoTrackMinimumDistance dist;
-      GlobalPoint seedingPoint;
-      float sumWeights=0;
-      std::pair<bool,Measurement1D> ipSeed = IPTools::absoluteImpactParameter3D(seed,primaryVertex);
-      float pvDistance = ipSeed.second.value();
-      for(std::vector<reco::TransientTrack>::const_iterator tt = tracks.begin();tt!=tracks.end(); ++tt )   {
+std::pair<std::vector<reco::TransientTrack>, GlobalPoint> TracksClusteringFromDisplacedSeed::nearTracks(
+    const reco::TransientTrack &seed,
+    const std::vector<reco::TransientTrack> &tracks,
+    const reco::Vertex &primaryVertex) const {
+  VertexDistance3D distanceComputer;
+  GlobalPoint pv(primaryVertex.position().x(), primaryVertex.position().y(), primaryVertex.position().z());
+  std::vector<reco::TransientTrack> result;
+  TwoTrackMinimumDistance dist;
+  GlobalPoint seedingPoint;
+  float sumWeights = 0;
+  std::pair<bool, Measurement1D> ipSeed = IPTools::absoluteImpactParameter3D(seed, primaryVertex);
+  float pvDistance = ipSeed.second.value();
+  for (std::vector<reco::TransientTrack>::const_iterator tt = tracks.begin(); tt != tracks.end(); ++tt) {
+    if (*tt == seed)
+      continue;
 
-       if(*tt==seed) continue;
+    if (dist.calculate(tt->impactPointState(), seed.impactPointState())) {
+      GlobalPoint ttPoint = dist.points().first;
+      GlobalError ttPointErr = tt->impactPointState().cartesianError().position();
+      GlobalPoint seedPosition = dist.points().second;
+      GlobalError seedPositionErr = seed.impactPointState().cartesianError().position();
+      Measurement1D m =
+          distanceComputer.distance(VertexState(seedPosition, seedPositionErr), VertexState(ttPoint, ttPointErr));
+      GlobalPoint cp(dist.crossingPoint());
 
-       if(dist.calculate(tt->impactPointState(),seed.impactPointState()))
-            {
-		 GlobalPoint ttPoint          = dist.points().first;
-		 GlobalError ttPointErr       = tt->impactPointState().cartesianError().position();
-	         GlobalPoint seedPosition     = dist.points().second;
-	         GlobalError seedPositionErr  = seed.impactPointState().cartesianError().position();
-                 Measurement1D m = distanceComputer.distance(VertexState(seedPosition,seedPositionErr), VertexState(ttPoint, ttPointErr));
-                 GlobalPoint cp(dist.crossingPoint()); 
+      double timeSig = 0.;
+      if (primaryVertex.covariance(3, 3) > 0. && edm::isFinite(seed.timeExt()) && edm::isFinite(tt->timeExt())) {
+        // apply only if time available and being used in vertexing
+        const double tError = std::sqrt(std::pow(seed.dtErrorExt(), 2) + std::pow(tt->dtErrorExt(), 2));
+        timeSig = std::abs(seed.timeExt() - tt->timeExt()) / tError;
+      }
 
-		 double timeSig = 0.;
-		 if( primaryVertex.covariance(3,3) > 0. && 
-		     edm::isFinite(seed.timeExt()) && edm::isFinite(tt->timeExt()) ) { 
-		   // apply only if time available and being used in vertexing
-		   const double tError = std::sqrt( std::pow(seed.dtErrorExt(),2) + std::pow(tt->dtErrorExt(),2) );
-		   timeSig = std::abs( seed.timeExt() - tt->timeExt() ) / tError;
-		 }
+      float distanceFromPV = (dist.points().second - pv).mag();
+      float distance = dist.distance();
+      GlobalVector trackDir2D(
+          tt->impactPointState().globalDirection().x(), tt->impactPointState().globalDirection().y(), 0.);
+      GlobalVector seedDir2D(
+          seed.impactPointState().globalDirection().x(), seed.impactPointState().globalDirection().y(), 0.);
+      //SK:UNUSED//    float dotprodTrackSeed2D = trackDir2D.unit().dot(seedDir2D.unit());
 
-                 float distanceFromPV =  (dist.points().second-pv).mag();
-                 float distance = dist.distance();
-		 GlobalVector trackDir2D(tt->impactPointState().globalDirection().x(),tt->impactPointState().globalDirection().y(),0.); 
-		 GlobalVector seedDir2D(seed.impactPointState().globalDirection().x(),seed.impactPointState().globalDirection().y(),0.); 
-		 //SK:UNUSED//    float dotprodTrackSeed2D = trackDir2D.unit().dot(seedDir2D.unit());
+      float dotprodTrack = (dist.points().first - pv).unit().dot(tt->impactPointState().globalDirection().unit());
+      float dotprodSeed = (dist.points().second - pv).unit().dot(seed.impactPointState().globalDirection().unit());
 
-                 float dotprodTrack = (dist.points().first-pv).unit().dot(tt->impactPointState().globalDirection().unit());
-                 float dotprodSeed = (dist.points().second-pv).unit().dot(seed.impactPointState().globalDirection().unit());
-
-                 float w = distanceFromPV*distanceFromPV/(pvDistance*distance);
-          	 bool selected = (m.significance() < clusterMaxSignificance && 
-				  ((clusterMinAngleCosine > 0) ? (dotprodSeed > clusterMinAngleCosine) : (dotprodSeed < clusterMinAngleCosine)) && //Angles between PV-PCAonSeed vectors and seed directions
-				  ((clusterMinAngleCosine > 0) ? (dotprodTrack > clusterMinAngleCosine) : (dotprodTrack < clusterMinAngleCosine)) && //Angles between PV-PCAonTrack vectors and track directions
-				  //dotprodTrackSeed2D > clusterMinAngleCosine && //Angle between track and seed
-				  //distance*clusterScale*tracks.size() < (distanceFromPV+pvDistance)*(distanceFromPV+pvDistance)/pvDistance && // cut scaling with track density
-				  distance*distanceRatio < distanceFromPV && // cut scaling with track density
-				  distance < clusterMaxDistance &&
-				  timeSig < maxTimeSignificance);  // absolute distance cut
+      float w = distanceFromPV * distanceFromPV / (pvDistance * distance);
+      bool selected =
+          (m.significance() < clusterMaxSignificance &&
+           ((clusterMinAngleCosine > 0)
+                ? (dotprodSeed > clusterMinAngleCosine)
+                : (dotprodSeed < clusterMinAngleCosine)) &&  //Angles between PV-PCAonSeed vectors and seed directions
+           ((clusterMinAngleCosine > 0)
+                ? (dotprodTrack > clusterMinAngleCosine)
+                : (dotprodTrack < clusterMinAngleCosine)) &&  //Angles between PV-PCAonTrack vectors and track directions
+           //dotprodTrackSeed2D > clusterMinAngleCosine && //Angle between track and seed
+           //distance*clusterScale*tracks.size() < (distanceFromPV+pvDistance)*(distanceFromPV+pvDistance)/pvDistance && // cut scaling with track density
+           distance * distanceRatio < distanceFromPV &&  // cut scaling with track density
+           distance < clusterMaxDistance &&
+           timeSig < maxTimeSignificance);  // absolute distance cut
 
 #ifdef VTXDEBUG
-            	    std::cout << tt->trackBaseRef().key() << " :  " << (selected?"+":" ")<< " " << m.significance() << " < " << clusterMaxSignificance <<  " &&  " << 
-                    dotprodSeed  << " > " <<  clusterMinAngleCosine << "  && " << 
-                    dotprodTrack  << " > " <<  clusterMinAngleCosine << "  && " << 
-                    dotprodTrackSeed2D  << " > " <<  clusterMinAngleCosine << "  &&  "  << 
-                    distance*distanceRatio  << " < " <<  distanceFromPV << "  crossingtoPV: " << distanceFromPV << " dis*scal " <<  distance*distanceRatio << "  <  " << distanceFromPV << " dist: " << distance << " < " << clusterMaxDistance << 
-			      << "timeSig: " << timeSig << std::endl; // cut scaling with track density
-#endif           
-                 if(selected)
-                 {
-                     result.push_back(*tt);
-                     seedingPoint = GlobalPoint(cp.x()*w+seedingPoint.x(),cp.y()*w+seedingPoint.y(),cp.z()*w+seedingPoint.z());  
-                     sumWeights+=w; 
-                 }
-            }
-       }
+      std::cout << tt->trackBaseRef().key() << " :  " << (selected ? "+" : " ") << " " << m.significance() << " < "
+                << clusterMaxSignificance << " &&  " << dotprodSeed << " > " << clusterMinAngleCosine << "  && "
+                << dotprodTrack << " > " << clusterMinAngleCosine << "  && " << dotprodTrackSeed2D << " > "
+                << clusterMinAngleCosine << "  &&  " << distance * distanceRatio << " < " << distanceFromPV
+                << "  crossingtoPV: " << distanceFromPV << " dis*scal " << distance * distanceRatio << "  <  "
+                << distanceFromPV << " dist: " << distance << " < " << clusterMaxDistance < < < <
+          "timeSig: " << timeSig << std::endl;  // cut scaling with track density
+#endif
+      if (selected) {
+        result.push_back(*tt);
+        seedingPoint =
+            GlobalPoint(cp.x() * w + seedingPoint.x(), cp.y() * w + seedingPoint.y(), cp.z() * w + seedingPoint.z());
+        sumWeights += w;
+      }
+    }
+  }
 
-   seedingPoint = GlobalPoint(seedingPoint.x()/sumWeights,seedingPoint.y()/sumWeights,seedingPoint.z()/sumWeights);
-   return std::pair<std::vector<reco::TransientTrack>,GlobalPoint>(result,seedingPoint);
-
+  seedingPoint =
+      GlobalPoint(seedingPoint.x() / sumWeights, seedingPoint.y() / sumWeights, seedingPoint.z() / sumWeights);
+  return std::pair<std::vector<reco::TransientTrack>, GlobalPoint>(result, seedingPoint);
 }
-
-
-
-
 
 std::vector<TracksClusteringFromDisplacedSeed::Cluster> TracksClusteringFromDisplacedSeed::clusters(
-	 const reco::Vertex &pv,
-	 const std::vector<reco::TransientTrack> & selectedTracks
- )
-{
-	using namespace reco;
-	std::vector<TransientTrack> seeds;
-	for(std::vector<TransientTrack>::const_iterator it = selectedTracks.begin(); it != selectedTracks.end(); it++){
-                std::pair<bool,Measurement1D> ip = IPTools::absoluteImpactParameter3D(*it,pv);
-                if(ip.first && ip.second.value() >= min3DIPValue && ip.second.significance() >= min3DIPSignificance && ip.second.value() <= max3DIPValue && ip.second.significance() <= max3DIPSignificance)
-                  { 
+    const reco::Vertex &pv, const std::vector<reco::TransientTrack> &selectedTracks) {
+  using namespace reco;
+  std::vector<TransientTrack> seeds;
+  for (std::vector<TransientTrack>::const_iterator it = selectedTracks.begin(); it != selectedTracks.end(); it++) {
+    std::pair<bool, Measurement1D> ip = IPTools::absoluteImpactParameter3D(*it, pv);
+    if (ip.first && ip.second.value() >= min3DIPValue && ip.second.significance() >= min3DIPSignificance &&
+        ip.second.value() <= max3DIPValue && ip.second.significance() <= max3DIPSignificance) {
 #ifdef VTXDEBUG
-                    std::cout << "new seed " <<  it-selectedTracks.begin() << " ref " << it->trackBaseRef().key()  << " " << ip.second.value() << " " << ip.second.significance() << " " << it->track().hitPattern().trackerLayersWithMeasurement() << " " << it->track().pt() << " " << it->track().eta() << std::endl;
+      std::cout << "new seed " << it - selectedTracks.begin() << " ref " << it->trackBaseRef().key() << " "
+                << ip.second.value() << " " << ip.second.significance() << " "
+                << it->track().hitPattern().trackerLayersWithMeasurement() << " " << it->track().pt() << " "
+                << it->track().eta() << std::endl;
 #endif
-                    seeds.push_back(*it);  
-                  }
- 
-	}
+      seeds.push_back(*it);
+    }
+  }
 
-        std::vector< Cluster > clusters;
-        int i = 0;
-	for(std::vector<TransientTrack>::const_iterator s = seeds.begin();
-	    s != seeds.end(); ++s, ++i)
-        {
+  std::vector<Cluster> clusters;
+  int i = 0;
+  for (std::vector<TransientTrack>::const_iterator s = seeds.begin(); s != seeds.end(); ++s, ++i) {
 #ifdef VTXDEBUG
-		std::cout << "Seed N. "<<i <<   std::endl;
-#endif // VTXDEBUG
-        	std::pair<std::vector<reco::TransientTrack>,GlobalPoint>  ntracks = nearTracks(*s,selectedTracks,pv);
-//	        std::cout << ntracks.first.size() << " " << ntracks.first.size()  << std::endl;
-//                if(ntracks.first.size() == 0 || ntracks.first.size() > maxNTracks ) continue;
-                ntracks.first.push_back(*s);
-	        Cluster aCl;
-                aCl.seedingTrack = *s;		
-                aCl.seedPoint = ntracks.second; 
-	        aCl.tracks = ntracks.first; 
-                clusters.push_back(aCl); 
-       }
-	 	
-return clusters;
-}
+    std::cout << "Seed N. " << i << std::endl;
+#endif  // VTXDEBUG
+    std::pair<std::vector<reco::TransientTrack>, GlobalPoint> ntracks = nearTracks(*s, selectedTracks, pv);
+    //	        std::cout << ntracks.first.size() << " " << ntracks.first.size()  << std::endl;
+    //                if(ntracks.first.size() == 0 || ntracks.first.size() > maxNTracks ) continue;
+    ntracks.first.push_back(*s);
+    Cluster aCl;
+    aCl.seedingTrack = *s;
+    aCl.seedPoint = ntracks.second;
+    aCl.tracks = ntracks.first;
+    clusters.push_back(aCl);
+  }
 
+  return clusters;
+}

--- a/RecoVertex/AdaptiveVertexFinder/src/VertexMerging.cc
+++ b/RecoVertex/AdaptiveVertexFinder/src/VertexMerging.cc
@@ -1,76 +1,50 @@
 #include "RecoVertex/AdaptiveVertexFinder/interface/VertexMerging.h"
 
+VertexMerging::VertexMerging(const edm::ParameterSet &params)
+    : maxFraction(params.getParameter<double>("maxFraction")),
+      minSignificance(params.getParameter<double>("minSignificance")) {}
 
-VertexMerging::VertexMerging(const edm::ParameterSet &params) :
-	maxFraction(params.getParameter<double>("maxFraction")),
-	minSignificance(params.getParameter<double>("minSignificance"))
-{
-	
+static double computeSharedTracks(const reco::Vertex &pv, const reco::Vertex &sv) {
+  std::set<reco::TrackRef> pvTracks;
+  for (std::vector<reco::TrackBaseRef>::const_iterator iter = pv.tracks_begin(); iter != pv.tracks_end(); iter++) {
+    if (pv.trackWeight(*iter) >= 0.5)
+      pvTracks.insert(iter->castTo<reco::TrackRef>());
+  }
+
+  unsigned int count = 0, total = 0;
+  for (std::vector<reco::TrackBaseRef>::const_iterator iter = sv.tracks_begin(); iter != sv.tracks_end(); iter++) {
+    if (sv.trackWeight(*iter) >= 0.5) {
+      total++;
+      count += pvTracks.count(iter->castTo<reco::TrackRef>());
+    }
+  }
+
+  return (double)count / (double)total;
 }
 
-static double computeSharedTracks(const reco::Vertex &pv,
-                                        const reco::Vertex &sv)
-{
-	std::set<reco::TrackRef> pvTracks;
-	for(std::vector<reco::TrackBaseRef>::const_iterator iter = pv.tracks_begin();
-	    iter != pv.tracks_end(); iter++) {
-		if (pv.trackWeight(*iter) >= 0.5)
-			pvTracks.insert(iter->castTo<reco::TrackRef>());
-	}
+reco::VertexCollection VertexMerging::mergeVertex(reco::VertexCollection &secondaryVertices) {
+  VertexDistance3D dist;
+  reco::VertexCollection recoVertices;
+  for (std::vector<reco::Vertex>::const_iterator sv = secondaryVertices.begin(); sv != secondaryVertices.end(); ++sv) {
+    recoVertices.push_back(*sv);
+  }
+  for (std::vector<reco::Vertex>::iterator sv = recoVertices.begin(); sv != recoVertices.end(); ++sv) {
+    bool shared = false;
+    for (std::vector<reco::Vertex>::iterator sv2 = recoVertices.begin(); sv2 != recoVertices.end(); ++sv2) {
+      double fr = computeSharedTracks(*sv2, *sv);
+      //        std::cout << sv2-recoVertices->begin() << " vs " << sv-recoVertices->begin() << " : " << fr << " "  <<  computeSharedTracks(*sv, *sv2) << " sig " << dist.distance(*sv,*sv2).significance() << std::endl;
+      //      std::cout << (fr > maxFraction) << " && " << (dist.distance(*sv,*sv2).significance() < 2)  <<  " && " <<  (sv-sv2!=0)  << " && " <<  (fr >= computeSharedTracks(*sv2, *sv))  << std::endl;
+      if (fr > maxFraction && dist.distance(*sv, *sv2).significance() < minSignificance && sv - sv2 != 0 &&
+          fr >= computeSharedTracks(*sv, *sv2)) {
+        shared = true;
+        // std::cout << "shared " << sv-recoVertices->begin() << " and "  << sv2-recoVertices->begin() << " fractions: " << fr << " , "  << computeSharedTracks(*sv2, *sv) << " sig: " <<  dist.distance(*sv,*sv2).significance() <<  std::endl;
+      }
+    }
+    if (shared) {
+      sv = recoVertices.erase(sv) - 1;
+    }
+    //    std::cout << "it = " <<  sv-recoVertices->begin() << " new size is: " << recoVertices->size() <<   std::endl;
+  }
 
-	unsigned int count = 0, total = 0;
-	for(std::vector<reco::TrackBaseRef>::const_iterator iter = sv.tracks_begin();
-	    iter != sv.tracks_end(); iter++) {
-		if (sv.trackWeight(*iter) >= 0.5) {
-			total++;
-			count += pvTracks.count(iter->castTo<reco::TrackRef>());
-		}
-	}
-
-	return (double)count / (double)total;
+  return recoVertices;
 }
-
-
-
-
-
-reco::VertexCollection VertexMerging::mergeVertex(
-	reco::VertexCollection & secondaryVertices){
-
-
-
-	
-        VertexDistance3D dist;
-	reco::VertexCollection recoVertices;
-	for(std::vector<reco::Vertex>::const_iterator sv = secondaryVertices.begin();
-	    sv != secondaryVertices.end(); ++sv) {
-          recoVertices.push_back(*sv);
-        }
-       for(std::vector<reco::Vertex>::iterator sv = recoVertices.begin();
-	    sv != recoVertices.end(); ++sv) {
-
-        bool shared=false;
-       for(std::vector<reco::Vertex>::iterator sv2 = recoVertices.begin();
-	    sv2 != recoVertices.end(); ++sv2) {
-                  double fr=computeSharedTracks(*sv2, *sv);
-        //        std::cout << sv2-recoVertices->begin() << " vs " << sv-recoVertices->begin() << " : " << fr << " "  <<  computeSharedTracks(*sv, *sv2) << " sig " << dist.distance(*sv,*sv2).significance() << std::endl;
-          //      std::cout << (fr > maxFraction) << " && " << (dist.distance(*sv,*sv2).significance() < 2)  <<  " && " <<  (sv-sv2!=0)  << " && " <<  (fr >= computeSharedTracks(*sv2, *sv))  << std::endl;
-		if (fr > maxFraction && dist.distance(*sv,*sv2).significance() < minSignificance && sv-sv2!=0 
-                    && fr >= computeSharedTracks(*sv, *sv2) )
-		  {
-                      shared=true; 
-                     // std::cout << "shared " << sv-recoVertices->begin() << " and "  << sv2-recoVertices->begin() << " fractions: " << fr << " , "  << computeSharedTracks(*sv2, *sv) << " sig: " <<  dist.distance(*sv,*sv2).significance() <<  std::endl;
-         
-                  }
-                 
-
-	}
-        if(shared) { sv=recoVertices.erase(sv)-1; }
-     //    std::cout << "it = " <<  sv-recoVertices->begin() << " new size is: " << recoVertices->size() <<   std::endl;
-       }
-
-	return recoVertices;
-
-
-}
-

--- a/TrackPropagation/RungeKutta/interface/RKPropagatorInR.h
+++ b/TrackPropagation/RungeKutta/interface/RKPropagatorInR.h
@@ -6,30 +6,24 @@
 
 class RKPropagatorInR final : public Propagator {
 public:
+  RKPropagatorInR(const MagVolume& vol, PropagationDirection dir = alongMomentum) : Propagator(dir), theVolume(&vol) {}
 
-  RKPropagatorInR( const MagVolume& vol, PropagationDirection dir = alongMomentum) : 
-    Propagator(dir), theVolume( &vol) {}
+  TrajectoryStateOnSurface myPropagate(const FreeTrajectoryState&, const Plane&) const;
 
-  TrajectoryStateOnSurface 
-  myPropagate (const FreeTrajectoryState&, const Plane&) const;
+  TrajectoryStateOnSurface myPropagate(const FreeTrajectoryState&, const Cylinder&) const;
 
-  TrajectoryStateOnSurface 
-  myPropagate (const FreeTrajectoryState&, const Cylinder&) const;
+  std::pair<TrajectoryStateOnSurface, double> propagateWithPath(const FreeTrajectoryState&,
+                                                                const Plane&) const override;
 
-  std::pair< TrajectoryStateOnSurface, double> 
-  propagateWithPath (const FreeTrajectoryState&, const Plane&) const override;
+  std::pair<TrajectoryStateOnSurface, double> propagateWithPath(const FreeTrajectoryState&,
+                                                                const Cylinder&) const override;
 
-  std::pair< TrajectoryStateOnSurface, double> 
-  propagateWithPath (const FreeTrajectoryState&, const Cylinder&) const override;
+  Propagator* clone() const override;
 
-  Propagator * clone() const override;
-
-  const MagneticField* magneticField() const override {return theVolume;}
+  const MagneticField* magneticField() const override { return theVolume; }
 
 private:
-
   const MagVolume* theVolume;
-
 };
 
 #endif

--- a/TrackPropagation/RungeKutta/interface/RKPropagatorInS.h
+++ b/TrackPropagation/RungeKutta/interface/RKPropagatorInS.h
@@ -10,7 +10,6 @@
 #include "MagneticField/VolumeGeometry/interface/MagVolume.h"
 #include "FWCore/Utilities/interface/Visibility.h"
 
-
 class GlobalTrajectoryParameters;
 class GlobalParametersWithPath;
 class MagVolume;
@@ -19,14 +18,12 @@ class CartesianStateAdaptor;
 
 class RKPropagatorInS final : public Propagator {
 public:
-
   // RKPropagatorInS( PropagationDirection dir = alongMomentum) : Propagator(dir), theVolume(0) {}
-  // tolerance (see below) used to be 1.e-5 --> this was observed to cause problems with convergence 
+  // tolerance (see below) used to be 1.e-5 --> this was observed to cause problems with convergence
   // when propagating to cylinder with large radius (~10 meter) MM 22/6/07
 
-  explicit RKPropagatorInS( const MagVolume& vol, PropagationDirection dir = alongMomentum,
-			    double tolerance = 5.e-5) : 
-    Propagator(dir), theVolume( &vol), theTolerance( tolerance) {}
+  explicit RKPropagatorInS(const MagVolume& vol, PropagationDirection dir = alongMomentum, double tolerance = 5.e-5)
+      : Propagator(dir), theVolume(&vol), theTolerance(tolerance) {}
 
   ~RKPropagatorInS() override {}
 
@@ -34,48 +31,45 @@ public:
   using Propagator::propagateWithPath;
 
 private:
-  std::pair< TrajectoryStateOnSurface, double> 
-  propagateWithPath (const FreeTrajectoryState&, const Plane&) const override;
+  std::pair<TrajectoryStateOnSurface, double> propagateWithPath(const FreeTrajectoryState&,
+                                                                const Plane&) const override;
 
-  std::pair< TrajectoryStateOnSurface, double> 
-  propagateWithPath (const FreeTrajectoryState&, const Cylinder&) const override;
-
-  
+  std::pair<TrajectoryStateOnSurface, double> propagateWithPath(const FreeTrajectoryState&,
+                                                                const Cylinder&) const override;
 
 public:
-  Propagator * clone() const override;
+  Propagator* clone() const override;
 
-  const MagneticField* magneticField() const override {return theVolume;}
+  const MagneticField* magneticField() const override { return theVolume; }
 
 private:
-
-  typedef std::pair<TrajectoryStateOnSurface,double>     TsosWP;
+  typedef std::pair<TrajectoryStateOnSurface, double> TsosWP;
 
   const MagVolume* theVolume;
-  double           theTolerance;
+  double theTolerance;
 
-  GlobalTrajectoryParameters gtpFromLocal( const Basic3DVector<float>& lpos,
-					   const Basic3DVector<float>& lmom,
-					   TrackCharge ch, const Surface& surf) const dso_internal;
+  GlobalTrajectoryParameters gtpFromLocal(const Basic3DVector<float>& lpos,
+                                          const Basic3DVector<float>& lmom,
+                                          TrackCharge ch,
+                                          const Surface& surf) const dso_internal;
 
-  GlobalTrajectoryParameters gtpFromVolumeLocal( const CartesianStateAdaptor& state, 
-						 TrackCharge charge) const  dso_internal;
-    
+  GlobalTrajectoryParameters gtpFromVolumeLocal(const CartesianStateAdaptor& state,
+                                                TrackCharge charge) const dso_internal;
+
   RKLocalFieldProvider fieldProvider() const;
-  RKLocalFieldProvider fieldProvider( const Cylinder& cyl) const dso_internal;
+  RKLocalFieldProvider fieldProvider(const Cylinder& cyl) const dso_internal;
 
-  PropagationDirection invertDirection( PropagationDirection dir) const dso_internal;
+  PropagationDirection invertDirection(PropagationDirection dir) const dso_internal;
 
-  Basic3DVector<double> rkPosition( const GlobalPoint& pos) const dso_internal;
-  Basic3DVector<double> rkMomentum( const GlobalVector& mom) const dso_internal;
-  GlobalPoint           globalPosition( const Basic3DVector<float>& pos) const dso_internal;
-  GlobalVector          globalMomentum( const Basic3DVector<float>& mom) const dso_internal;
+  Basic3DVector<double> rkPosition(const GlobalPoint& pos) const dso_internal;
+  Basic3DVector<double> rkMomentum(const GlobalVector& mom) const dso_internal;
+  GlobalPoint globalPosition(const Basic3DVector<float>& pos) const dso_internal;
+  GlobalVector globalMomentum(const Basic3DVector<float>& mom) const dso_internal;
 
-  GlobalParametersWithPath propagateParametersOnPlane( const FreeTrajectoryState& ts, 
-						       const Plane& plane) const dso_internal;
-  GlobalParametersWithPath propagateParametersOnCylinder( const FreeTrajectoryState& ts, 
-							  const Cylinder& cyl) const dso_internal;
-
+  GlobalParametersWithPath propagateParametersOnPlane(const FreeTrajectoryState& ts,
+                                                      const Plane& plane) const dso_internal;
+  GlobalParametersWithPath propagateParametersOnCylinder(const FreeTrajectoryState& ts,
+                                                         const Cylinder& cyl) const dso_internal;
 };
 
 #endif

--- a/TrackPropagation/RungeKutta/interface/RKPropagatorInZ.h
+++ b/TrackPropagation/RungeKutta/interface/RKPropagatorInZ.h
@@ -6,30 +6,24 @@
 
 class RKPropagatorInZ final : public Propagator {
 public:
+  RKPropagatorInZ(const MagVolume& vol, PropagationDirection dir = alongMomentum) : Propagator(dir), theVolume(&vol) {}
 
-  RKPropagatorInZ( const MagVolume& vol, PropagationDirection dir = alongMomentum) : 
-    Propagator(dir), theVolume( &vol) {}
+  TrajectoryStateOnSurface myPropagate(const FreeTrajectoryState&, const Plane&) const;
 
-  TrajectoryStateOnSurface 
-  myPropagate (const FreeTrajectoryState&, const Plane&) const;
+  TrajectoryStateOnSurface myPropagate(const FreeTrajectoryState&, const Cylinder&) const;
 
-  TrajectoryStateOnSurface 
-  myPropagate (const FreeTrajectoryState&, const Cylinder&) const;
+  std::pair<TrajectoryStateOnSurface, double> propagateWithPath(const FreeTrajectoryState&,
+                                                                const Plane&) const override;
 
-  std::pair< TrajectoryStateOnSurface, double> 
-  propagateWithPath (const FreeTrajectoryState&, const Plane&) const override;
+  std::pair<TrajectoryStateOnSurface, double> propagateWithPath(const FreeTrajectoryState&,
+                                                                const Cylinder&) const override;
 
-  std::pair< TrajectoryStateOnSurface, double> 
-  propagateWithPath (const FreeTrajectoryState&, const Cylinder&) const override;
+  Propagator* clone() const override;
 
-  Propagator * clone() const override;
-
-  const MagneticField* magneticField() const override {return theVolume;}
+  const MagneticField* magneticField() const override { return theVolume; }
 
 private:
-
   const MagVolume* theVolume;
-
 };
 
 #endif

--- a/TrackPropagation/RungeKutta/interface/defaultRKPropagator.h
+++ b/TrackPropagation/RungeKutta/interface/defaultRKPropagator.h
@@ -1,10 +1,8 @@
 #ifndef RKPropagatorDefault_H
 #define RKPropagatorDefault_H
 
-
 #include "TrackPropagation/RungeKutta/interface/RKPropagatorInS.h"
 #include "MagneticField/VolumeGeometry/interface/MagneticFieldProvider.h"
-
 
 namespace defaultRKPropagator {
 
@@ -13,45 +11,43 @@ namespace defaultRKPropagator {
   // not clear why we need all this
   class TrivialFieldProvider final : public MagneticFieldProvider<float> {
   public:
-    
-    TrivialFieldProvider (const MagneticField* field) : theField(field) {}
-    
-    LocalVectorType valueInTesla( const LocalPointType& lp) const override {
+    TrivialFieldProvider(const MagneticField* field) : theField(field) {}
+
+    LocalVectorType valueInTesla(const LocalPointType& lp) const override {
       // NOTE: the following transformation only works for the central volume
       // where global and local coordinates are numerically equal !
       GlobalPoint gp(lp.basicVector());
       return LocalVectorType(theField->inTesla(gp).basicVector());
     }
-    
-  private:  
+
+  private:
     const MagneticField* theField;
   };
-  
+
   class RKMagVolume final : public MagVolume {
   public:
-    RKMagVolume( const PositionType& pos, const RotationType& rot, 
-		 const MagneticFieldProvider<float> * mfp) :
-      MagVolume( pos, rot, mfp) {}
-    
-    bool inside( const GlobalPoint& gp, double tolerance=0.) const override {return true;}
-    
+    RKMagVolume(const PositionType& pos, const RotationType& rot, const MagneticFieldProvider<float>* mfp)
+        : MagVolume(pos, rot, mfp) {}
+
+    bool inside(const GlobalPoint& gp, double tolerance = 0.) const override { return true; }
+
     /// Access to volume faces - dummy implementation
-    const std::vector<VolumeSide>& faces() const override {return theFaces;}
-    
+    const std::vector<VolumeSide>& faces() const override { return theFaces; }
+
   private:
     std::vector<VolumeSide> theFaces;
   };
-  
+
   struct Product {
-    explicit Product(const MagneticField* field,PropagationDirection dir = alongMomentum, double tolerance = 5.e-5) : 
-      mpf(field), 
-      volume(MagVolume::PositionType(0,0,0), MagVolume::RotationType(), &mpf),
-      propagator(volume, dir, tolerance){}
+    explicit Product(const MagneticField* field, PropagationDirection dir = alongMomentum, double tolerance = 5.e-5)
+        : mpf(field),
+          volume(MagVolume::PositionType(0, 0, 0), MagVolume::RotationType(), &mpf),
+          propagator(volume, dir, tolerance) {}
     TrivialFieldProvider mpf;
     RKMagVolume volume;
     RKPropagator propagator;
   };
-  
-}
 
-#endif // RKPropagatorDefault
+}  // namespace defaultRKPropagator
+
+#endif  // RKPropagatorDefault

--- a/TrackPropagation/RungeKutta/src/AnalyticalErrorPropagation.h
+++ b/TrackPropagation/RungeKutta/src/AnalyticalErrorPropagation.h
@@ -11,38 +11,37 @@
 
 class Surface;
 
-inline
-std::pair<TrajectoryStateOnSurface,double>
-analyticalErrorPropagation( const FreeTrajectoryState& startingState, 
-		const Surface& surface, SurfaceSideDefinition::SurfaceSide side,
-		const GlobalTrajectoryParameters& destParameters, 
-		const double& s) {
-    if UNLIKELY(!startingState.hasError()) 
-       // return state without errors
-      return std::pair<TrajectoryStateOnSurface,double>(TrajectoryStateOnSurface(destParameters,surface,side),s);
+inline std::pair<TrajectoryStateOnSurface, double> analyticalErrorPropagation(
+    const FreeTrajectoryState& startingState,
+    const Surface& surface,
+    SurfaceSideDefinition::SurfaceSide side,
+    const GlobalTrajectoryParameters& destParameters,
+    const double& s) {
+  if
+    UNLIKELY(!startingState.hasError())
+  // return state without errors
+  return std::pair<TrajectoryStateOnSurface, double>(TrajectoryStateOnSurface(destParameters, surface, side), s);
 
-    //
-    // compute jacobian
-    //
+  //
+  // compute jacobian
+  //
 
-    // FIXME: Compute mean B field between startingState and destParameters and pass it to analyticalJacobian
-    //GlobalPoint xStart = startingState.position();
-    //GlobalPoint xDest = destParameters.position();
-    //GlobalVector h1  = destParameters.magneticFieldInInverseGeV(xStart);
-    //GlobalVector h2  = destParameters.magneticFieldInInverseGeV(xDest);
-    //GlobalVector h = 0.5*(h1+h2);
-    //LogDebug("RungeKutta") << "AnalyticalErrorPropagation: The Fields are: " << h1 << ", " << h2 << ", " << h ; 
-    
-    // 
-    AnalyticalCurvilinearJacobian analyticalJacobian(startingState.parameters(), 
-						     destParameters.position(), 
-						     destParameters.momentum(), s);
-    auto const & jacobian = analyticalJacobian.jacobian();
-    return std::pair<TrajectoryStateOnSurface,double>(
-              TrajectoryStateOnSurface(destParameters,
-                                        ROOT::Math::Similarity(jacobian, startingState.curvilinearError().matrix()),
-                                        surface,side),
-              s);
+  // FIXME: Compute mean B field between startingState and destParameters and pass it to analyticalJacobian
+  //GlobalPoint xStart = startingState.position();
+  //GlobalPoint xDest = destParameters.position();
+  //GlobalVector h1  = destParameters.magneticFieldInInverseGeV(xStart);
+  //GlobalVector h2  = destParameters.magneticFieldInInverseGeV(xDest);
+  //GlobalVector h = 0.5*(h1+h2);
+  //LogDebug("RungeKutta") << "AnalyticalErrorPropagation: The Fields are: " << h1 << ", " << h2 << ", " << h ;
+
+  //
+  AnalyticalCurvilinearJacobian analyticalJacobian(
+      startingState.parameters(), destParameters.position(), destParameters.momentum(), s);
+  auto const& jacobian = analyticalJacobian.jacobian();
+  return std::pair<TrajectoryStateOnSurface, double>(
+      TrajectoryStateOnSurface(
+          destParameters, ROOT::Math::Similarity(jacobian, startingState.curvilinearError().matrix()), surface, side),
+      s);
 }
 
 #endif

--- a/TrackPropagation/RungeKutta/src/CartesianLorentzForce.h
+++ b/TrackPropagation/RungeKutta/src/CartesianLorentzForce.h
@@ -7,43 +7,35 @@
 
 /// Derivative calculation for the 6D cartesian case.
 
-class dso_internal CartesianLorentzForce final : public RKDerivative<double,6> {
+class dso_internal CartesianLorentzForce final : public RKDerivative<double, 6> {
 public:
+  typedef RKDerivative<double, 6> Base;
+  typedef Base::Scalar Scalar;
+  typedef Base::Vector Vector;
 
-    typedef RKDerivative< double,6>             Base;
-    typedef Base::Scalar                        Scalar;
-    typedef Base::Vector                        Vector;
+  CartesianLorentzForce(const RKLocalFieldProvider& field, float ch) : theField(field), theCharge(ch) {}
 
-    CartesianLorentzForce( const RKLocalFieldProvider& field, float ch) : 
-	theField(field), theCharge(ch) {}
-
-    Vector operator()( Scalar z, const Vector& state) const override;
+  Vector operator()(Scalar z, const Vector& state) const override;
 
 private:
-
-    const RKLocalFieldProvider& theField;
-    float theCharge;
-
+  const RKLocalFieldProvider& theField;
+  float theCharge;
 };
 
-
 #include "CartesianStateAdaptor.h"
-inline
-CartesianLorentzForce::Vector
-CartesianLorentzForce::operator()( Scalar z, const Vector& state) const
-{
-    // derivatives in case S is the free parameter
-    CartesianStateAdaptor start(state);
-    auto bfield = theField.inTesla( RKLocalFieldProvider::LocalPoint(start.position()));
-    constexpr float k = 2.99792458e-3; // conversion to [cm]
+inline CartesianLorentzForce::Vector CartesianLorentzForce::operator()(Scalar z, const Vector& state) const {
+  // derivatives in case S is the free parameter
+  CartesianStateAdaptor start(state);
+  auto bfield = theField.inTesla(RKLocalFieldProvider::LocalPoint(start.position()));
+  constexpr float k = 2.99792458e-3;  // conversion to [cm]
 
-    /// Derivative d(pos)/ds is simply normalized momentum
-    auto dpos = start.momentum().unit();
+  /// Derivative d(pos)/ds is simply normalized momentum
+  auto dpos = start.momentum().unit();
 
-    /// Lorentz force in absence of electric field
-    auto dmom = (k*theCharge) * dpos.cross( bfield);
+  /// Lorentz force in absence of electric field
+  auto dmom = (k * theCharge) * dpos.cross(bfield);
 
-    return CartesianStateAdaptor::rkstate( dpos, dmom);
+  return CartesianStateAdaptor::rkstate(dpos, dmom);
 }
 
 #endif

--- a/TrackPropagation/RungeKutta/src/CartesianState.h
+++ b/TrackPropagation/RungeKutta/src/CartesianState.h
@@ -7,50 +7,43 @@
 
 class dso_internal CartesianState {
 public:
-
-  typedef double                            Scalar;
-  typedef Basic3DVector<Scalar>             Vector3D;
-  typedef VectorDoublet<Vector3D,Vector3D>  Vector;
+  typedef double Scalar;
+  typedef Basic3DVector<Scalar> Vector3D;
+  typedef VectorDoublet<Vector3D, Vector3D> Vector;
 
   CartesianState() {}
-  CartesianState( const Vector& v, Scalar s) : par_(v), charge_(s) {}
-  CartesianState( const Vector3D& pos, const Vector3D& mom, Scalar s) : 
-    par_(pos,mom), charge_(s) {}
+  CartesianState(const Vector& v, Scalar s) : par_(v), charge_(s) {}
+  CartesianState(const Vector3D& pos, const Vector3D& mom, Scalar s) : par_(pos, mom), charge_(s) {}
 
-  const Vector3D& position() const { return par_.first();}
-  const Vector3D& momentum() const { return par_.second();}
+  const Vector3D& position() const { return par_.first(); }
+  const Vector3D& momentum() const { return par_.second(); }
 
-  const Vector& parameters() const { return par_;}
+  const Vector& parameters() const { return par_; }
 
-  Scalar charge() const { return charge_;}
+  Scalar charge() const { return charge_; }
 
 private:
-
   Vector par_;
   Scalar charge_;
-
 };
 
-inline CartesianState
-operator+( const CartesianState& a, const CartesianState& b) {
-  return CartesianState(a.parameters()+b.parameters(), a.charge());
+inline CartesianState operator+(const CartesianState& a, const CartesianState& b) {
+  return CartesianState(a.parameters() + b.parameters(), a.charge());
 }
 
-inline CartesianState
-operator-( const CartesianState& a, const CartesianState& b) {
-  return CartesianState(a.parameters()-b.parameters(), a.charge());
+inline CartesianState operator-(const CartesianState& a, const CartesianState& b) {
+  return CartesianState(a.parameters() - b.parameters(), a.charge());
 }
 
-inline CartesianState operator*( const CartesianState& v, const CartesianState::Scalar& s) {
-  return CartesianState( v.parameters()*s, v.charge());
+inline CartesianState operator*(const CartesianState& v, const CartesianState::Scalar& s) {
+  return CartesianState(v.parameters() * s, v.charge());
 }
-inline CartesianState operator*( const CartesianState::Scalar& s, const CartesianState& v) {
-  return CartesianState( v.parameters()*s, v.charge());
-}
-
-inline CartesianState operator/( const CartesianState& v, const CartesianState::Scalar& s) {
-  return CartesianState( v.parameters()/s, v.charge());
+inline CartesianState operator*(const CartesianState::Scalar& s, const CartesianState& v) {
+  return CartesianState(v.parameters() * s, v.charge());
 }
 
+inline CartesianState operator/(const CartesianState& v, const CartesianState::Scalar& s) {
+  return CartesianState(v.parameters() / s, v.charge());
+}
 
 #endif

--- a/TrackPropagation/RungeKutta/src/CartesianStateAdaptor.h
+++ b/TrackPropagation/RungeKutta/src/CartesianStateAdaptor.h
@@ -6,40 +6,32 @@
 
 class dso_internal CartesianStateAdaptor {
 public:
+  typedef float Scalar;
+  typedef Basic3DVector<Scalar> Vector3D;
 
-    typedef float                             Scalar;
-    typedef Basic3DVector<Scalar>             Vector3D;
+  CartesianStateAdaptor(const RKSmallVector<double, 6>& rk) : pos_(rk[0], rk[1], rk[2]), mom_(rk[3], rk[4], rk[5]) {}
 
-    CartesianStateAdaptor( const RKSmallVector<double,6>& rk) :
-      pos_(rk[0], rk[1], rk[2]), mom_(rk[3], rk[4], rk[5]) {}
+  const Vector3D& position() const { return pos_; }
+  const Vector3D& momentum() const { return mom_; }
 
-    const Vector3D& position() const { return pos_;}
-    const Vector3D& momentum() const { return mom_;}
+  static Vector3D position(const RKSmallVector<double, 6>& rk) { return Vector3D(rk[0], rk[1], rk[2]); }
 
-    static Vector3D position(const RKSmallVector<double,6>& rk) {
-      return Vector3D(rk[0], rk[1], rk[2]);
-    }
+  static Vector3D momentum(const RKSmallVector<double, 6>& rk) { return Vector3D(rk[3], rk[4], rk[5]); }
 
-    static Vector3D momentum(const RKSmallVector<double,6>& rk) {
-      return Vector3D(rk[3], rk[4], rk[5]);
-    }
-
-    static RKSmallVector<double,6> rkstate( const Vector3D& pos, const Vector3D& mom) {
-	RKSmallVector<double,6> res;
-	res[0] = pos.x();
-	res[1] = pos.y();
-	res[2] = pos.z();
-	res[3] = mom.x();
-	res[4] = mom.y();
-	res[5] = mom.z();
-	return res;
-    }
+  static RKSmallVector<double, 6> rkstate(const Vector3D& pos, const Vector3D& mom) {
+    RKSmallVector<double, 6> res;
+    res[0] = pos.x();
+    res[1] = pos.y();
+    res[2] = pos.z();
+    res[3] = mom.x();
+    res[4] = mom.y();
+    res[5] = mom.z();
+    return res;
+  }
 
 private:
-
-    Vector3D pos_;
-    Vector3D mom_;
-
+  Vector3D pos_;
+  Vector3D mom_;
 };
 
 #endif

--- a/TrackPropagation/RungeKutta/src/CurvilinearLorentzForce.h
+++ b/TrackPropagation/RungeKutta/src/CurvilinearLorentzForce.h
@@ -7,21 +7,18 @@
 class RKLocalFieldProvider;
 
 template <typename T, int N>
-class dso_internal CurvilinearLorentzForce final : public RKDerivative<T,N> {
+class dso_internal CurvilinearLorentzForce final : public RKDerivative<T, N> {
 public:
+  typedef RKDerivative<T, N> Base;
+  typedef typename Base::Scalar Scalar;
+  typedef typename Base::Vector Vector;
 
-    typedef RKDerivative<T,N>                   Base;
-    typedef typename Base::Scalar               Scalar;
-    typedef typename Base::Vector               Vector;
+  CurvilinearLorentzForce(const RKLocalFieldProvider& field) : theField(field) {}
 
-    CurvilinearLorentzForce( const RKLocalFieldProvider& field) : theField(field) {}
-
-    Vector operator()( Scalar z, const Vector& state) const override;
+  Vector operator()(Scalar z, const Vector& state) const override;
 
 private:
-
-    const RKLocalFieldProvider& theField;
-
+  const RKLocalFieldProvider& theField;
 };
 
 #include "TrackPropagation/RungeKutta/src/CurvilinearLorentzForce.icc"

--- a/TrackPropagation/RungeKutta/src/CurvilinearLorentzForce.icc
+++ b/TrackPropagation/RungeKutta/src/CurvilinearLorentzForce.icc
@@ -7,7 +7,7 @@
 class CurvilinearLorentzForceException : public std::exception {
 public:
     CurvilinearLorentzForceException() throw() {}
-    virtual ~CurvilinearLorentzForceException() throw() {}
+    ~CurvilinearLorentzForceException() throw() override {}
 };
 
 

--- a/TrackPropagation/RungeKutta/src/CurvilinearLorentzForce.icc
+++ b/TrackPropagation/RungeKutta/src/CurvilinearLorentzForce.icc
@@ -6,39 +6,37 @@
 
 class CurvilinearLorentzForceException : public std::exception {
 public:
-    CurvilinearLorentzForceException() throw() {}
-    ~CurvilinearLorentzForceException() throw() override {}
+  CurvilinearLorentzForceException() throw() {}
+  ~CurvilinearLorentzForceException() throw() override {}
 };
 
-
 template <typename T, int N>
-typename CurvilinearLorentzForce<T,N>::Vector
-CurvilinearLorentzForce<T,N>::operator()( Scalar z, const Vector& state) const
-{
+typename CurvilinearLorentzForce<T, N>::Vector CurvilinearLorentzForce<T, N>::operator()(Scalar z,
+                                                                                         const Vector& state) const {
   // derivatives in case Z is the free parameter
 
-  RKLocalFieldProvider::Vector B = theField.inTesla( state[0], state[1], z);
-  double k = 2.99792458e-3; // conversion to [cm]
+  RKLocalFieldProvider::Vector B = theField.inTesla(state[0], state[1], z);
+  double k = 2.99792458e-3;  // conversion to [cm]
 
-//    cout << "CurvilinearLorentzForce: field at (" << state[0] << ", " 
-//         <<  state[1] << ", " << z << ") is " << B << endl;
+  //    cout << "CurvilinearLorentzForce: field at (" << state[0] << ", "
+  //         <<  state[1] << ", " << z << ") is " << B << endl;
 
   /// this should be changed when the ref frame of the solution is not the global one!
   //CurvilinearState::Vector3D B( MagneticField::inTesla(GlobalPoint(start.position())));
-   
+
   double dxdz = state[2];
   double dydz = state[3];
   double lambda = state[4];
 
-  double R = sqrt( 1.0 + dxdz*dxdz + dydz*dydz);
+  double R = sqrt(1.0 + dxdz * dxdz + dydz * dydz);
 
   // cout << "CurvilinearLorentzForce: R " << R << " dxdz " << dxdz << " dydz " << dydz << endl;
   if (R > 10) {
-      throw CurvilinearLorentzForceException();
+    throw CurvilinearLorentzForceException();
   }
 
-  double d2x_dz2 = k*lambda*R * (dxdz*dydz*B.x() - (1.0+dxdz*dxdz)*B.y() + dydz*B.z());
-  double d2y_dz2 = k*lambda*R * ((1+dydz*dydz)*B.x() - dxdz*dydz*B.y() - dxdz*B.z());
+  double d2x_dz2 = k * lambda * R * (dxdz * dydz * B.x() - (1.0 + dxdz * dxdz) * B.y() + dydz * B.z());
+  double d2y_dz2 = k * lambda * R * ((1 + dydz * dydz) * B.x() - dxdz * dydz * B.y() - dxdz * B.z());
 
   // the derivative of q/p is zero -- momentum conservation if no energy loss
   Vector res;

--- a/TrackPropagation/RungeKutta/src/CurvilinearState.h
+++ b/TrackPropagation/RungeKutta/src/CurvilinearState.h
@@ -20,75 +20,65 @@ The coordinate system is externally defined
 
 class dso_internal CurvilinearState {
 public:
-
-  typedef double                            Scalar;
-  typedef Basic2DVector<Scalar>             Vector2D;
-  typedef Basic3DVector<Scalar>             Vector3D;
-  typedef VectorDoublet<Vector2D,Vector3D>  Vector;
+  typedef double Scalar;
+  typedef Basic2DVector<Scalar> Vector2D;
+  typedef Basic3DVector<Scalar> Vector3D;
+  typedef VectorDoublet<Vector2D, Vector3D> Vector;
 
   CurvilinearState() {}
 
-  CurvilinearState( const Vector& v, Scalar z, Scalar pzsign) : 
-    par_(v), z_(z), pzSign_(pzsign) {}
+  CurvilinearState(const Vector& v, Scalar z, Scalar pzsign) : par_(v), z_(z), pzSign_(pzsign) {}
 
-  CurvilinearState( const Vector3D& pos, const Vector3D& p, Scalar ch) : 
-    par_(Vector2D(pos.x(),pos.y()), Vector3D( p.x()/p.z(), p.y()/p.z(), ch/p.mag())), 
-    z_(pos.z()), pzSign_(p.z()>0. ? 1.:-1.) {}
-       
-  const Vector3D position() const { 
-    return Vector3D(par_.first().x(),par_.first().y(),z_);
-  }
+  CurvilinearState(const Vector3D& pos, const Vector3D& p, Scalar ch)
+      : par_(Vector2D(pos.x(), pos.y()), Vector3D(p.x() / p.z(), p.y() / p.z(), ch / p.mag())),
+        z_(pos.z()),
+        pzSign_(p.z() > 0. ? 1. : -1.) {}
+
+  const Vector3D position() const { return Vector3D(par_.first().x(), par_.first().y(), z_); }
 
   const Vector3D momentum() const {
-    Scalar p = 1./fabs(par_.second().z());
-    if ( p>1.e9 )  p = 1.e9;
+    Scalar p = 1. / fabs(par_.second().z());
+    if (p > 1.e9)
+      p = 1.e9;
     Scalar dxdz = par_.second().x();
     Scalar dydz = par_.second().y();
-    Scalar dz = pzSign_/sqrt(1. + dxdz*dxdz + dydz*dydz);
-    Scalar dx = dz*dxdz;
-    Scalar dy = dz*dydz;
-    return Vector3D(dx*p, dy*p, dz*p);
+    Scalar dz = pzSign_ / sqrt(1. + dxdz * dxdz + dydz * dydz);
+    Scalar dx = dz * dxdz;
+    Scalar dy = dz * dydz;
+    return Vector3D(dx * p, dy * p, dz * p);
   }
 
-  const Vector& parameters() const { return par_;}
+  const Vector& parameters() const { return par_; }
 
-  Scalar charge() const { return par_.second().z()>0 ? 1 : -1;}
+  Scalar charge() const { return par_.second().z() > 0 ? 1 : -1; }
 
-  Scalar z() const {return z_;}
+  Scalar z() const { return z_; }
 
-  double pzSign() const {return pzSign_;}
+  double pzSign() const { return pzSign_; }
 
 private:
-
   Vector par_;
   Scalar z_;
-  Scalar pzSign_; ///< sign of local pz
-
+  Scalar pzSign_;  ///< sign of local pz
 };
 
-inline CurvilinearState
-operator+( const CurvilinearState& a, const CurvilinearState& b) {
-  return CurvilinearState(a.parameters()+b.parameters(), a.z()+b.z(), a.pzSign());
+inline CurvilinearState operator+(const CurvilinearState& a, const CurvilinearState& b) {
+  return CurvilinearState(a.parameters() + b.parameters(), a.z() + b.z(), a.pzSign());
 }
 
-inline CurvilinearState
-operator-( const CurvilinearState& a, const CurvilinearState& b) {
-  return CurvilinearState(a.parameters()-b.parameters(), a.z()-b.z(), a.pzSign());
+inline CurvilinearState operator-(const CurvilinearState& a, const CurvilinearState& b) {
+  return CurvilinearState(a.parameters() - b.parameters(), a.z() - b.z(), a.pzSign());
 }
 
-inline CurvilinearState operator*( const CurvilinearState& v, 
-				   const CurvilinearState::Scalar& s) {
-  return CurvilinearState( v.parameters()*s, v.z()*s, v.pzSign());
+inline CurvilinearState operator*(const CurvilinearState& v, const CurvilinearState::Scalar& s) {
+  return CurvilinearState(v.parameters() * s, v.z() * s, v.pzSign());
 }
-inline CurvilinearState operator*( const CurvilinearState::Scalar& s,
-				   const CurvilinearState& v) {
-  return CurvilinearState( v.parameters()*s, v.z()*s, v.pzSign());
+inline CurvilinearState operator*(const CurvilinearState::Scalar& s, const CurvilinearState& v) {
+  return CurvilinearState(v.parameters() * s, v.z() * s, v.pzSign());
 }
 
-inline CurvilinearState operator/( const CurvilinearState& v, 
-				   const CurvilinearState::Scalar& s) {
-  return CurvilinearState( v.parameters()/s, v.z()/s, v.pzSign());
+inline CurvilinearState operator/(const CurvilinearState& v, const CurvilinearState::Scalar& s) {
+  return CurvilinearState(v.parameters() / s, v.z() / s, v.pzSign());
 }
-
 
 #endif

--- a/TrackPropagation/RungeKutta/src/CylindricalLorentzForce.h
+++ b/TrackPropagation/RungeKutta/src/CylindricalLorentzForce.h
@@ -7,21 +7,18 @@
 class RKLocalFieldProvider;
 
 template <typename T, int N>
-class dso_internal CylindricalLorentzForce final : public RKDerivative<T,N> {
+class dso_internal CylindricalLorentzForce final : public RKDerivative<T, N> {
 public:
+  typedef RKDerivative<T, N> Base;
+  typedef typename Base::Scalar Scalar;
+  typedef typename Base::Vector Vector;
 
-    typedef RKDerivative<T,N>                   Base;
-    typedef typename Base::Scalar               Scalar;
-    typedef typename Base::Vector               Vector;
+  CylindricalLorentzForce(const RKLocalFieldProvider& field) : theField(field) {}
 
-    CylindricalLorentzForce( const RKLocalFieldProvider& field) : theField(field) {}
-
-    Vector operator()( Scalar r, const Vector& state) const override;
+  Vector operator()(Scalar r, const Vector& state) const override;
 
 private:
-
-    const RKLocalFieldProvider& theField;
-
+  const RKLocalFieldProvider& theField;
 };
 
 #include "TrackPropagation/RungeKutta/src/CylindricalLorentzForce.icc"

--- a/TrackPropagation/RungeKutta/src/CylindricalLorentzForce.icc
+++ b/TrackPropagation/RungeKutta/src/CylindricalLorentzForce.icc
@@ -8,7 +8,7 @@
 class CylindricalLorentzForceException : public std::exception {
 public:
     CylindricalLorentzForceException() throw() {}
-    virtual ~CylindricalLorentzForceException() throw() {}
+    ~CylindricalLorentzForceException() throw() override {}
 };
 
 

--- a/TrackPropagation/RungeKutta/src/CylindricalLorentzForce.icc
+++ b/TrackPropagation/RungeKutta/src/CylindricalLorentzForce.icc
@@ -7,52 +7,49 @@
 
 class CylindricalLorentzForceException : public std::exception {
 public:
-    CylindricalLorentzForceException() throw() {}
-    ~CylindricalLorentzForceException() throw() override {}
+  CylindricalLorentzForceException() throw() {}
+  ~CylindricalLorentzForceException() throw() override {}
 };
 
-
 template <typename T, int N>
-typename CylindricalLorentzForce<T,N>::Vector
-CylindricalLorentzForce<T,N>::operator()( Scalar r, const Vector& state) const
-{
-
-//    std::cout << "CylindricalLorentzForce called with r " << r << " state " << state << std::endl;
+typename CylindricalLorentzForce<T, N>::Vector CylindricalLorentzForce<T, N>::operator()(Scalar r,
+                                                                                         const Vector& state) const {
+  //    std::cout << "CylindricalLorentzForce called with r " << r << " state " << state << std::endl;
 
   // derivatives in case Radius is the free parameter
-  CylindricalState cstate( r, state, 1.);
-  LocalPoint pos( cstate.position());
-  RKLocalFieldProvider::Vector B = theField.inTesla( pos.x(), pos.y(), pos.z());
-  double k = 2.99792458e-3; // conversion to [cm]
-   
+  CylindricalState cstate(r, state, 1.);
+  LocalPoint pos(cstate.position());
+  RKLocalFieldProvider::Vector B = theField.inTesla(pos.x(), pos.y(), pos.z());
+  double k = 2.99792458e-3;  // conversion to [cm]
+
   double dphi_dr = state[2];
   double dz_dr = state[3];
   double lambda = state[4];
 
-  double Q = sqrt( 1.0 + dphi_dr*dphi_dr*r*r + dz_dr*dz_dr);
+  double Q = sqrt(1.0 + dphi_dr * dphi_dr * r * r + dz_dr * dz_dr);
 
-//  std::cout << "CylindricalLorentzForce: Q " << Q << " dphi_dr " << dphi_dr << " dz_dr " << dz_dr << std::endl;
+  //  std::cout << "CylindricalLorentzForce: Q " << Q << " dphi_dr " << dphi_dr << " dz_dr " << dz_dr << std::endl;
   if (Q > 1000) {
-      throw CylindricalLorentzForceException();
+    throw CylindricalLorentzForceException();
   }
 
   double sinphi = sin(state[0]);
   double cosphi = cos(state[0]);
-  double B_r   =  B.x()*cosphi + B.y()*sinphi;
-  double B_phi = -B.x()*sinphi + B.y()*cosphi;
+  double B_r = B.x() * cosphi + B.y() * sinphi;
+  double B_phi = -B.x() * sinphi + B.y() * cosphi;
   double dphi_dr2 = dphi_dr * dphi_dr;
 
-//  std::cout << "B_r " << B_r << " B_phi " << B_phi << " B.z() " << B.z() << std::endl;
+  //  std::cout << "B_r " << B_r << " B_phi " << B_phi << " B.z() " << B.z() << std::endl;
 
-  double d2phi_dr2 = -2/r * dphi_dr - r*dphi_dr*dphi_dr2 +
-      k*lambda*Q/r * (dz_dr*B_r + r*dphi_dr*dz_dr*B_phi - (1+r*r*dphi_dr2)*B.z());
+  double d2phi_dr2 = -2 / r * dphi_dr - r * dphi_dr * dphi_dr2 +
+                     k * lambda * Q / r * (dz_dr * B_r + r * dphi_dr * dz_dr * B_phi - (1 + r * r * dphi_dr2) * B.z());
 
-//  std::cout << "-2/r * dphi_dr - r*dphi_dr*dphi_dr2 " << -2/r * dphi_dr - r*dphi_dr*dphi_dr2
-//       << "  -k*lambda*Q/r * (1+r*r*dphi_dr2)*B.z() " <<  -k*lambda*Q/r * (1+r*r*dphi_dr2)*B.z() << std::endl;
+  //  std::cout << "-2/r * dphi_dr - r*dphi_dr*dphi_dr2 " << -2/r * dphi_dr - r*dphi_dr*dphi_dr2
+  //       << "  -k*lambda*Q/r * (1+r*r*dphi_dr2)*B.z() " <<  -k*lambda*Q/r * (1+r*r*dphi_dr2)*B.z() << std::endl;
 
-  double d2z_dr2 = -r*dphi_dr2*dz_dr +
-      k*lambda*Q * (-r*dphi_dr*B_r + (1+dz_dr*dz_dr)*B_phi - r*dphi_dr*dz_dr*B.z());
-      
+  double d2z_dr2 = -r * dphi_dr2 * dz_dr +
+                   k * lambda * Q * (-r * dphi_dr * B_r + (1 + dz_dr * dz_dr) * B_phi - r * dphi_dr * dz_dr * B.z());
+
   // the derivative of q/p is zero -- momentum conservation if no energy loss
   Vector res;
   res[0] = dphi_dr;
@@ -61,7 +58,7 @@ CylindricalLorentzForce<T,N>::operator()( Scalar r, const Vector& state) const
   res[3] = d2z_dr2;
   res[4] = 0;
 
-//  std::cout << "CylindricalLorentzForce: derivatives are " << res << std::endl;
+  //  std::cout << "CylindricalLorentzForce: derivatives are " << res << std::endl;
 
   return res;
 }

--- a/TrackPropagation/RungeKutta/src/CylindricalState.h
+++ b/TrackPropagation/RungeKutta/src/CylindricalState.h
@@ -22,69 +22,60 @@ The coordinate system is externally defined
 
 class dso_internal CylindricalState {
 public:
-
-  typedef double                                   Scalar;
-  typedef RKSmallVector<Scalar,5>                  Vector;
+  typedef double Scalar;
+  typedef RKSmallVector<Scalar, 5> Vector;
 
   CylindricalState() {}
 
-  CylindricalState( const LocalPoint& pos, const LocalVector& mom, Scalar ch) {
-      rho_ = pos.perp();
-      Scalar cosphi = pos.x() / rho_;
-      Scalar sinphi = pos.y() / rho_;
-      Scalar p_rho   =  mom.x() * cosphi + mom.y() * sinphi;
-      Scalar p_phi   = -mom.x() * sinphi + mom.y() * cosphi;
+  CylindricalState(const LocalPoint& pos, const LocalVector& mom, Scalar ch) {
+    rho_ = pos.perp();
+    Scalar cosphi = pos.x() / rho_;
+    Scalar sinphi = pos.y() / rho_;
+    Scalar p_rho = mom.x() * cosphi + mom.y() * sinphi;
+    Scalar p_phi = -mom.x() * sinphi + mom.y() * cosphi;
 
-      par_(0) = pos.phi();
-      par_(1) = pos.z();
-      par_(2) = p_phi / (p_rho * rho_);
-      par_(3) = mom.z() / p_rho;
-      par_(4) = ch / mom.mag();
+    par_(0) = pos.phi();
+    par_(1) = pos.z();
+    par_(2) = p_phi / (p_rho * rho_);
+    par_(3) = mom.z() / p_rho;
+    par_(4) = ch / mom.mag();
 
-      prSign_ = p_rho > 0 ? 1.0 : -1.0;
+    prSign_ = p_rho > 0 ? 1.0 : -1.0;
 
-      std::cout << "CylindricalState built from pos " << pos << " mom " << mom << " charge " << ch << std::endl;
-      std::cout << "p_rho " << p_rho << " p_phi " << p_phi << " dphi_drho " << par_(2) << std::endl;
-      std::cout << "Which results in                " << position() << " mom " << momentum() 
-	   << " charge " << charge() << std::endl;
+    std::cout << "CylindricalState built from pos " << pos << " mom " << mom << " charge " << ch << std::endl;
+    std::cout << "p_rho " << p_rho << " p_phi " << p_phi << " dphi_drho " << par_(2) << std::endl;
+    std::cout << "Which results in                " << position() << " mom " << momentum() << " charge " << charge()
+              << std::endl;
   }
-  
-  CylindricalState( Scalar rho, const Vector& par, Scalar prSign) :
-      par_(par), rho_(rho), prSign_(prSign) {}
 
+  CylindricalState(Scalar rho, const Vector& par, Scalar prSign) : par_(par), rho_(rho), prSign_(prSign) {}
 
-  const LocalPoint position() const { 
-      return LocalPoint( LocalPoint::Cylindrical( rho_, par_(0), par_(1)));
-  }
+  const LocalPoint position() const { return LocalPoint(LocalPoint::Cylindrical(rho_, par_(0), par_(1))); }
 
   const LocalVector momentum() const {
-      Scalar cosphi = cos( par_(0));
-      Scalar sinphi = sin( par_(0));
-      Scalar Q = sqrt(1 + rho_*rho_ * par_(2)*par_(2) + par_(3)*par_(3));
-      Scalar P = std::abs(1./par_(4));
-      Scalar p_rho = prSign_*P/Q;
-      Scalar p_phi = rho_*par_(2)*p_rho;
-      Scalar p_z   = par_(3)*p_rho;
-      LocalVector result( p_rho*cosphi - p_phi*sinphi,
-			  p_rho*sinphi + p_phi*cosphi,
-			  p_z);
-      return result;
+    Scalar cosphi = cos(par_(0));
+    Scalar sinphi = sin(par_(0));
+    Scalar Q = sqrt(1 + rho_ * rho_ * par_(2) * par_(2) + par_(3) * par_(3));
+    Scalar P = std::abs(1. / par_(4));
+    Scalar p_rho = prSign_ * P / Q;
+    Scalar p_phi = rho_ * par_(2) * p_rho;
+    Scalar p_z = par_(3) * p_rho;
+    LocalVector result(p_rho * cosphi - p_phi * sinphi, p_rho * sinphi + p_phi * cosphi, p_z);
+    return result;
   }
 
-  const Vector& parameters() const { return par_;}
+  const Vector& parameters() const { return par_; }
 
-  Scalar charge() const { return par_(4) > 0 ? 1 : -1;}
+  Scalar charge() const { return par_(4) > 0 ? 1 : -1; }
 
-  Scalar rho() const {return rho_;}
+  Scalar rho() const { return rho_; }
 
-  double prSign() const {return prSign_;}
+  double prSign() const { return prSign_; }
 
 private:
-
   Vector par_;
   Scalar rho_;
-  Scalar prSign_; ///< sign of local p_r
-
+  Scalar prSign_;  ///< sign of local p_r
 };
 
 #endif

--- a/TrackPropagation/RungeKutta/src/FrameChanger.h
+++ b/TrackPropagation/RungeKutta/src/FrameChanger.h
@@ -10,34 +10,28 @@ public:
   /** Moves the first argument ("plane") to the reference frame given by the second 
    *  argument ("frame"). The returned frame is not positioned globally!
    */
-    template <typename T>
-    static
-    Plane transformPlane( const Plane& plane, const GloballyPositioned<T>& frame) {
-        typedef GloballyPositioned<T>                  Frame;
-	typename Plane::RotationType rot = plane.rotation() * frame.rotation().transposed();
-	typename Frame::LocalPoint lpos = frame.toLocal(plane.position());
-	typename Plane::PositionType pos( lpos.basicVector()); // cheat!
-	return Plane(pos, rot);
-    }
+  template <typename T>
+  static Plane transformPlane(const Plane& plane, const GloballyPositioned<T>& frame) {
+    typedef GloballyPositioned<T> Frame;
+    typename Plane::RotationType rot = plane.rotation() * frame.rotation().transposed();
+    typename Frame::LocalPoint lpos = frame.toLocal(plane.position());
+    typename Plane::PositionType pos(lpos.basicVector());  // cheat!
+    return Plane(pos, rot);
+  }
 
-
-/** Moves the first argument ("plane") to the reference frame given by the second 
+  /** Moves the first argument ("plane") to the reference frame given by the second 
  *  argument ("frame"). The returned frame is not positioned globally!
  */
-    template <typename T, typename U>
-    static
-    GloballyPositioned<T> toFrame( const GloballyPositioned<T>& plane, 
-				   const GloballyPositioned<U>& frame) {
-	typedef GloballyPositioned<T>                  Plane;
-	typedef GloballyPositioned<U>                  Frame;
+  template <typename T, typename U>
+  static GloballyPositioned<T> toFrame(const GloballyPositioned<T>& plane, const GloballyPositioned<U>& frame) {
+    typedef GloballyPositioned<T> Plane;
+    typedef GloballyPositioned<U> Frame;
 
-	typename Plane::RotationType rot = plane.rotation() * frame.rotation().transposed();
-	typename Frame::LocalPoint lpos = frame.toLocal(plane.position());
-	typename Plane::PositionType pos( lpos.basicVector()); // cheat!
-	return Plane( pos, rot);
-
-    }
-
+    typename Plane::RotationType rot = plane.rotation() * frame.rotation().transposed();
+    typename Frame::LocalPoint lpos = frame.toLocal(plane.position());
+    typename Plane::PositionType pos(lpos.basicVector());  // cheat!
+    return Plane(pos, rot);
+  }
 };
 
 #endif

--- a/TrackPropagation/RungeKutta/src/GlobalParametersWithPath.h
+++ b/TrackPropagation/RungeKutta/src/GlobalParametersWithPath.h
@@ -7,18 +7,17 @@
 class dso_internal GlobalParametersWithPath {
 public:
   GlobalParametersWithPath() : gtp_(), s_(0), valid_(false) {}
-  GlobalParametersWithPath( const GlobalTrajectoryParameters& gtp, double s) : 
-    gtp_(gtp), s_(s), valid_(true) {}
-  GlobalParametersWithPath( const GlobalTrajectoryParameters& gtp, 
-			    double s, bool valid) : gtp_(gtp), s_(s), valid_(valid) {}
-		 
-  const GlobalTrajectoryParameters& parameters() const {return gtp_;}
+  GlobalParametersWithPath(const GlobalTrajectoryParameters& gtp, double s) : gtp_(gtp), s_(s), valid_(true) {}
+  GlobalParametersWithPath(const GlobalTrajectoryParameters& gtp, double s, bool valid)
+      : gtp_(gtp), s_(s), valid_(valid) {}
 
-  double pathLength() const {return s_;}
-  double s() const {return pathLength();}
+  const GlobalTrajectoryParameters& parameters() const { return gtp_; }
 
-  bool isValid() const {return valid_;}
-  operator bool() const {return valid_;}
+  double pathLength() const { return s_; }
+  double s() const { return pathLength(); }
+
+  bool isValid() const { return valid_; }
+  operator bool() const { return valid_; }
 
 private:
   GlobalTrajectoryParameters gtp_;

--- a/TrackPropagation/RungeKutta/src/PathToPlane2Order.cc
+++ b/TrackPropagation/RungeKutta/src/PathToPlane2Order.cc
@@ -5,60 +5,56 @@
 
 #include <iostream>
 
-std::pair<bool,double> 
-PathToPlane2Order::operator()( const Plane& plane, 
-			       const Vector3D& pos,
-			       const Vector3D& momentum,
-			       double charge,
-			       const PropagationDirection propDir)
-{
+std::pair<bool, double> PathToPlane2Order::operator()(const Plane& plane,
+                                                      const Vector3D& pos,
+                                                      const Vector3D& momentum,
+                                                      double charge,
+                                                      const PropagationDirection propDir) {
   // access to the field in field frame local coordinates
-    RKLocalFieldProvider::Vector B = theField.inTesla( pos.x(), pos.y(), pos.z());
+  RKLocalFieldProvider::Vector B = theField.inTesla(pos.x(), pos.y(), pos.z());
 
-    // Frame::GlobalVector localZ = Frame::GlobalVector( B.unit()); // local Z along field
-    // transform field axis to global frame
-    Frame::GlobalVector localZ = theFieldFrame->toGlobal( Frame::LocalVector( B.unit())); // local Z along field
+  // Frame::GlobalVector localZ = Frame::GlobalVector( B.unit()); // local Z along field
+  // transform field axis to global frame
+  Frame::GlobalVector localZ = theFieldFrame->toGlobal(Frame::LocalVector(B.unit()));  // local Z along field
 
-    Frame::GlobalVector localY = localZ.cross( Frame::GlobalVector( 1,0,0));
-    if (localY.mag() < 0.1) {
-	localY = localZ.cross( Frame::GlobalVector(0,1,0)).unit();
-    }
-    else {
-	localY = localY.unit();
-    }
-    Frame::GlobalVector localX = localY.cross(localZ);
+  Frame::GlobalVector localY = localZ.cross(Frame::GlobalVector(1, 0, 0));
+  if (localY.mag() < 0.1) {
+    localY = localZ.cross(Frame::GlobalVector(0, 1, 0)).unit();
+  } else {
+    localY = localY.unit();
+  }
+  Frame::GlobalVector localX = localY.cross(localZ);
 
+  Frame::PositionType fpos(theFieldFrame->toGlobal(Frame::LocalPoint(pos)));
+  Frame::RotationType frot(localX, localY, localZ);
+  // frame in which the field is along Z
+  Frame frame(fpos, frot);
 
-    Frame::PositionType fpos( theFieldFrame->toGlobal( Frame::LocalPoint(pos)));
-    Frame::RotationType frot( localX, localY, localZ);
-    // frame in which the field is along Z
-    Frame frame( fpos, frot);
-    
-    //    cout << "PathToPlane2Order frame " << frame.position() << endl << frame.rotation() << endl;
-    
-    // transform the position and direction to that frame
-    Frame::LocalPoint localPos = frame.toLocal( fpos); // same as LocalPoint(0,0,0)
+  //    cout << "PathToPlane2Order frame " << frame.position() << endl << frame.rotation() << endl;
 
-    //transform momentum from field frame to new frame via global frame
-    Frame::GlobalVector gmom( theFieldFrame->toGlobal( Frame::LocalVector(momentum)));
-    Frame::LocalVector localMom = frame.toLocal( gmom); 
+  // transform the position and direction to that frame
+  Frame::LocalPoint localPos = frame.toLocal(fpos);  // same as LocalPoint(0,0,0)
 
-    // transform the plane to the same frame
-    Plane localPlane =  FrameChanger::transformPlane( plane, frame);
-/*
+  //transform momentum from field frame to new frame via global frame
+  Frame::GlobalVector gmom(theFieldFrame->toGlobal(Frame::LocalVector(momentum)));
+  Frame::LocalVector localMom = frame.toLocal(gmom);
+
+  // transform the plane to the same frame
+  Plane localPlane = FrameChanger::transformPlane(plane, frame);
+  /*
      cout << "PathToPlane2Order input plane       " << plane.position() << endl 
  	 << plane.rotation() << endl;
      cout << "PathToPlane2Order transformed plane " << localPlane->position() << endl 
  	 << localPlane->rotation() << endl;
 */
-    double k = 2.99792458e-3;
-    double transverseMomentum = localMom.perp();   // transverse to the field
-    if (!(transverseMomentum != 0) ) {  // if (!(x!=0)) will trap both 0 and NaN
-      //LogDebug("PathToPlane2Order_ZeroMomentum") << "Momentum transverse to the field is zero or Nan (" << transverseMomentum << ")\n";
-        return std::pair<bool,double>(false,0);
-    }
-    double curvature = -k * charge * B.mag() / transverseMomentum;
-/*
+  double k = 2.99792458e-3;
+  double transverseMomentum = localMom.perp();  // transverse to the field
+  if (!(transverseMomentum != 0)) {             // if (!(x!=0)) will trap both 0 and NaN
+    //LogDebug("PathToPlane2Order_ZeroMomentum") << "Momentum transverse to the field is zero or Nan (" << transverseMomentum << ")\n";
+    return std::pair<bool, double>(false, 0);
+  }
+  double curvature = -k * charge * B.mag() / transverseMomentum;
+  /*
      cout << "PathToPlane2Order curvature " << curvature << endl;
      cout << "transverseMomentum " << transverseMomentum << endl;
      cout << "B.mag() " << B.mag() << endl;
@@ -68,15 +64,14 @@ PathToPlane2Order::operator()( const Plane& plane,
      cout << "localPos " << localPos << endl;
      cout << "localMom " << localMom << endl;
 */
-/*
+  /*
     cout << "PathToPlane2Order: local pos " << localPos << " mom " << localMom 
 	 << " curvature " << curvature << endl;
     cout << "PathToPlane2Order: local plane pos " << localPlane->position() 
 	 << " normal " << localPlane->normalVector() << endl;
 */
-    HelixArbitraryPlaneCrossing crossing( localPos.basicVector(), localMom.basicVector(), 
-					  curvature, propDir);
-    std::pair<bool,double> res = crossing.pathLength(localPlane);
+  HelixArbitraryPlaneCrossing crossing(localPos.basicVector(), localMom.basicVector(), curvature, propDir);
+  std::pair<bool, double> res = crossing.pathLength(localPlane);
 
-    return res;
+  return res;
 }

--- a/TrackPropagation/RungeKutta/src/PathToPlane2Order.h
+++ b/TrackPropagation/RungeKutta/src/PathToPlane2Order.h
@@ -20,35 +20,36 @@ class RKLocalFieldProvider;
 
 class dso_internal PathToPlane2Order {
 public:
+  typedef Plane::Scalar Scalar;
+  typedef Basic3DVector<Scalar> Vector3D;
+  typedef GloballyPositioned<Scalar> Frame;
 
-    typedef Plane::Scalar                                Scalar;
-    typedef Basic3DVector<Scalar>                        Vector3D;
-    typedef GloballyPositioned<Scalar>                   Frame;
+  PathToPlane2Order(const RKLocalFieldProvider& fld, const Frame* fieldFrame)
+      : theField(fld), theFieldFrame(fieldFrame) {}
 
-    PathToPlane2Order( const RKLocalFieldProvider& fld, const Frame* fieldFrame) : 
-      theField(fld), theFieldFrame(fieldFrame) {}
+  /// the position and momentum are local in the FieldFrame;
+  /// the plane is in the global frame
+  std::pair<bool, double> operator()(const Plane& plane,
+                                     const Vector3D& position,
+                                     const Vector3D& momentum,
+                                     double charge,
+                                     const PropagationDirection propDir = alongMomentum);
 
-    /// the position and momentum are local in the FieldFrame;
-    /// the plane is in the global frame
-    std::pair<bool,double> operator()( const Plane& plane, 
-				       const Vector3D& position,
-				       const Vector3D& momentum,
-				       double charge,
-				       const PropagationDirection propDir = alongMomentum);
-
-    std::pair<bool,double> operator()( const Plane& plane, 
-				       const GlobalPoint& position,
-				       const GlobalVector& momentum,
-				       double charge,
-				       const PropagationDirection propDir = alongMomentum) {
-	return operator()( plane, theFieldFrame->toLocal(position).basicVector(), 
-			   theFieldFrame->toLocal(momentum).basicVector(), charge, propDir);
-    }
+  std::pair<bool, double> operator()(const Plane& plane,
+                                     const GlobalPoint& position,
+                                     const GlobalVector& momentum,
+                                     double charge,
+                                     const PropagationDirection propDir = alongMomentum) {
+    return operator()(plane,
+                      theFieldFrame->toLocal(position).basicVector(),
+                      theFieldFrame->toLocal(momentum).basicVector(),
+                      charge,
+                      propDir);
+  }
 
 private:
-
-    const RKLocalFieldProvider& theField;
-    const Frame*                theFieldFrame;
+  const RKLocalFieldProvider& theField;
+  const Frame* theFieldFrame;
 };
 
 #endif

--- a/TrackPropagation/RungeKutta/src/RK4OneStep.cc
+++ b/TrackPropagation/RungeKutta/src/RK4OneStep.cc
@@ -3,21 +3,20 @@
 
 #include <iostream>
 
-CartesianState
-RK4OneStep::operator()( const CartesianState& start, const RKCartesianDerivative& deriv,
-			double step) const
-{
-  double s0 = 0; // derivatives do't depend on absolute value of the integration variable
-  CartesianState k1 = step * deriv( s0, start);
-  CartesianState k2 = step * deriv( s0+step/2, start+k1/2);
-  CartesianState k3 = step * deriv( s0+step/2, start+k2/2);
-  CartesianState k4 = step * deriv( s0+step, start+k3);
-/*
+CartesianState RK4OneStep::operator()(const CartesianState& start,
+                                      const RKCartesianDerivative& deriv,
+                                      double step) const {
+  double s0 = 0;  // derivatives do't depend on absolute value of the integration variable
+  CartesianState k1 = step * deriv(s0, start);
+  CartesianState k2 = step * deriv(s0 + step / 2, start + k1 / 2);
+  CartesianState k3 = step * deriv(s0 + step / 2, start + k2 / 2);
+  CartesianState k4 = step * deriv(s0 + step, start + k3);
+  /*
   std::cout << "k1 = " << k1.position() << k1.momentum() << std::endl;
   std::cout << "k2 = " << k2.position() << k2.momentum() << std::endl;
   std::cout << "k3 = " << k3.position() << k3.momentum() << std::endl;
   std::cout << "k4 = " << k4.position() << k4.momentum() << std::endl;
 */
-  CartesianState result = start + k1/6 + k2/3 + k3/3 + k4/6;
+  CartesianState result = start + k1 / 6 + k2 / 3 + k3 / 3 + k4 / 6;
   return result;
 }

--- a/TrackPropagation/RungeKutta/src/RK4OneStep.h
+++ b/TrackPropagation/RungeKutta/src/RK4OneStep.h
@@ -8,14 +8,9 @@ class RKCartesianDerivative;
 
 class dso_internal RK4OneStep {
 public:
-
-  CartesianState
-  operator()( const CartesianState& start, const RKCartesianDerivative& deriv,
-	      double step) const;
-
+  CartesianState operator()(const CartesianState& start, const RKCartesianDerivative& deriv, double step) const;
 
   //  DeltaState errorEstimate();
-
 };
 
 #endif

--- a/TrackPropagation/RungeKutta/src/RK4OneStepTempl.h
+++ b/TrackPropagation/RungeKutta/src/RK4OneStepTempl.h
@@ -7,28 +7,24 @@
 
 template <typename T, int N>
 class dso_internal RK4OneStepTempl {
- public:
+public:
+  typedef T Scalar;
+  typedef RKSmallVector<T, N> Vector;
 
-    typedef T                                   Scalar;
-    typedef RKSmallVector<T,N>                  Vector;
+  Vector operator()(Scalar startPar, const Vector& startState, const RKDerivative<T, N>& deriv, Scalar step) const {
+    // cout << "RK4OneStepTempl: starting from " << startPar << startState << endl;
 
-  
-    Vector operator()( Scalar startPar, const Vector& startState,
-		       const RKDerivative<T,N>& deriv, Scalar step) const {
+    Vector k1 = step * deriv(startPar, startState);
+    Vector k2 = step * deriv(startPar + step / 2, startState + k1 / 2);
+    Vector k3 = step * deriv(startPar + step / 2, startState + k2 / 2);
+    Vector k4 = step * deriv(startPar + step, startState + k3);
 
- 	// cout << "RK4OneStepTempl: starting from " << startPar << startState << endl;
+    Vector result = startState + k1 / 6 + k2 / 3 + k3 / 3 + k4 / 6;
 
-	Vector k1 = step * deriv( startPar, startState);
-	Vector k2 = step * deriv( startPar+step/2, startState+k1/2);
-	Vector k3 = step * deriv( startPar+step/2, startState+k2/2);
-	Vector k4 = step * deriv( startPar+step, startState+k3);
+    // cout << "RK4OneStepTempl: result for step " << step << " is " << result << endl;
 
-	Vector result = startState + k1/6 + k2/3 + k3/3 + k4/6;
-
- 	// cout << "RK4OneStepTempl: result for step " << step << " is " << result << endl;
-
-	return result;
-    }
+    return result;
+  }
 };
 
 #endif

--- a/TrackPropagation/RungeKutta/src/RK4PreciseStep.cc
+++ b/TrackPropagation/RungeKutta/src/RK4PreciseStep.cc
@@ -3,69 +3,62 @@
 //#include "Utilities/UI/interface/SimpleConfigurable.h"
 #include <iostream>
 
-CartesianState
-RK4PreciseStep::operator()( const CartesianState& start, const RKCartesianDerivative& deriv,
-			    double step, double eps) const
-{
-    const double Safety = 0.9;
-    double remainigStep = step;
-    double stepSize = step;
-    CartesianState currentStart = start;
-    int nsteps = 0;
-    std::pair<CartesianState, double> tryStep;
+CartesianState RK4PreciseStep::operator()(const CartesianState& start,
+                                          const RKCartesianDerivative& deriv,
+                                          double step,
+                                          double eps) const {
+  const double Safety = 0.9;
+  double remainigStep = step;
+  double stepSize = step;
+  CartesianState currentStart = start;
+  int nsteps = 0;
+  std::pair<CartesianState, double> tryStep;
 
-    do {
-	tryStep = stepWithAccuracy( currentStart, deriv, stepSize);
-	nsteps++;
-	if (tryStep.second <eps) {
-	    if (remainigStep - stepSize < eps/2) {
-		if (verbose()) std::cout << "Accuracy reached, and full step taken in " 
-				    << nsteps << " steps" << std::endl;
-		return tryStep.first; // we are there
-	    }
-	    else {
-		remainigStep -= stepSize;
-                // increase step size
-		double factor =  std::min( Safety * pow( fabs(eps/tryStep.second),0.2), 4.);
-		stepSize = std::min( stepSize*factor, remainigStep);
-		currentStart = tryStep.first;
-		if (verbose()) std::cout << "Accuracy reached, but " << remainigStep 
-		     << " remain after " << nsteps << " steps. Step size increased by " 
-		     << factor << " to " << stepSize << std::endl;
-	    }
-	}
-	else {
-	    // decrease step size
-	    double factor =  std::max( Safety * pow( fabs(eps/tryStep.second),0.25), 0.1);
-	    stepSize *= factor;
-	    if (verbose()) std::cout << "Accuracy not yet reached: delta = " << tryStep.second
-		 << ", step reduced by " << factor << " to " << stepSize 
-		 << ", (R,z)= " << currentStart.position().perp() 
-		 << ", " << currentStart.position().z() << std::endl;
-	}
-    } while (remainigStep > eps/2);
+  do {
+    tryStep = stepWithAccuracy(currentStart, deriv, stepSize);
+    nsteps++;
+    if (tryStep.second < eps) {
+      if (remainigStep - stepSize < eps / 2) {
+        if (verbose())
+          std::cout << "Accuracy reached, and full step taken in " << nsteps << " steps" << std::endl;
+        return tryStep.first;  // we are there
+      } else {
+        remainigStep -= stepSize;
+        // increase step size
+        double factor = std::min(Safety * pow(fabs(eps / tryStep.second), 0.2), 4.);
+        stepSize = std::min(stepSize * factor, remainigStep);
+        currentStart = tryStep.first;
+        if (verbose())
+          std::cout << "Accuracy reached, but " << remainigStep << " remain after " << nsteps
+                    << " steps. Step size increased by " << factor << " to " << stepSize << std::endl;
+      }
+    } else {
+      // decrease step size
+      double factor = std::max(Safety * pow(fabs(eps / tryStep.second), 0.25), 0.1);
+      stepSize *= factor;
+      if (verbose())
+        std::cout << "Accuracy not yet reached: delta = " << tryStep.second << ", step reduced by " << factor << " to "
+                  << stepSize << ", (R,z)= " << currentStart.position().perp() << ", " << currentStart.position().z()
+                  << std::endl;
+    }
+  } while (remainigStep > eps / 2);
 
-    return tryStep.first;
+  return tryStep.first;
 }
 
-std::pair<CartesianState, double>
-RK4PreciseStep::stepWithAccuracy( const CartesianState& start, const RKCartesianDerivative& deriv,
-				  double step) const
-{
-    RK4OneStep solver;
-    CartesianState one(solver(start, deriv, step));
-    CartesianState firstHalf(solver(start, deriv, step/2));
-    CartesianState secondHalf(solver(firstHalf, deriv, step/2));
-    double diff = distance(one, secondHalf);
-    return std::pair<CartesianState, double>(secondHalf,diff);
+std::pair<CartesianState, double> RK4PreciseStep::stepWithAccuracy(const CartesianState& start,
+                                                                   const RKCartesianDerivative& deriv,
+                                                                   double step) const {
+  RK4OneStep solver;
+  CartesianState one(solver(start, deriv, step));
+  CartesianState firstHalf(solver(start, deriv, step / 2));
+  CartesianState secondHalf(solver(firstHalf, deriv, step / 2));
+  double diff = distance(one, secondHalf);
+  return std::pair<CartesianState, double>(secondHalf, diff);
 }
 
-double RK4PreciseStep::distance( const CartesianState& a, const CartesianState& b) const
-{
-    return (a.position() - b.position()).mag() + (a.momentum() - b.momentum()).mag() / b.momentum().mag();
+double RK4PreciseStep::distance(const CartesianState& a, const CartesianState& b) const {
+  return (a.position() - b.position()).mag() + (a.momentum() - b.momentum()).mag() / b.momentum().mag();
 }
 
-bool RK4PreciseStep::verbose() const
-{
-  return true;
-}
+bool RK4PreciseStep::verbose() const { return true; }

--- a/TrackPropagation/RungeKutta/src/RK4PreciseStep.h
+++ b/TrackPropagation/RungeKutta/src/RK4PreciseStep.h
@@ -9,20 +9,19 @@ class RKCartesianDerivative;
 
 class dso_internal RK4PreciseStep {
 public:
+  CartesianState operator()(const CartesianState& start,
+                            const RKCartesianDerivative& deriv,
+                            double step,
+                            double eps) const;
 
-  CartesianState
-  operator()( const CartesianState& start, const RKCartesianDerivative& deriv,
-	      double step, double eps) const;
+  double distance(const CartesianState& a, const CartesianState& b) const;
 
-  double distance( const CartesianState& a, const CartesianState& b) const;
-
-  std::pair<CartesianState, double>
-  stepWithAccuracy( const CartesianState& start, const RKCartesianDerivative& deriv, double step) const;
+  std::pair<CartesianState, double> stepWithAccuracy(const CartesianState& start,
+                                                     const RKCartesianDerivative& deriv,
+                                                     double step) const;
 
 private:
-
   bool verbose() const;
-
 };
 
 #endif

--- a/TrackPropagation/RungeKutta/src/RKAdaptiveSolver.h
+++ b/TrackPropagation/RungeKutta/src/RKAdaptiveSolver.h
@@ -4,24 +4,22 @@
 #include "FWCore/Utilities/interface/Visibility.h"
 #include "RKSolver.h"
 
-// 
+//
 // A Variable Order Runge-Kutta Method for Initial Value Problems with ...
 // www.elegio.it/mc2/rk/doc/p201-cash-karp.pdf
-template <typename T, 
-	  template <typename,int> class StepWithPrec, 
-	  int N>
-class dso_internal RKAdaptiveSolver final : public RKSolver<T,N> {
+template <typename T, template <typename, int> class StepWithPrec, int N>
+class dso_internal RKAdaptiveSolver final : public RKSolver<T, N> {
 public:
+  typedef RKSolver<T, N> Base;
+  typedef typename Base::Scalar Scalar;
+  typedef typename Base::Vector Vector;
 
-    typedef RKSolver<T,N>                       Base;
-    typedef typename Base::Scalar               Scalar;
-    typedef typename Base::Vector               Vector;
-
-    Vector operator()( Scalar startPar, const Vector& startState,
-			       Scalar step, const RKDerivative<T,N>& deriv,
-			       const RKDistance<T,N>& dist,
-			       float eps) override;
-
+  Vector operator()(Scalar startPar,
+                    const Vector& startState,
+                    Scalar step,
+                    const RKDerivative<T, N>& deriv,
+                    const RKDistance<T, N>& dist,
+                    float eps) override;
 };
 
 #include "TrackPropagation/RungeKutta/src/RKAdaptiveSolver.icc"

--- a/TrackPropagation/RungeKutta/src/RKAdaptiveSolver.icc
+++ b/TrackPropagation/RungeKutta/src/RKAdaptiveSolver.icc
@@ -1,7 +1,6 @@
 #include "RKAdaptiveSolver.h"
 #include <cmath>
 
-
 namespace RKDetails {
   // From http://martin.ankerl.com/2012/01/25/optimized-approximative-pow-in-c-and-cpp/
   // good at 10%
@@ -9,78 +8,77 @@ namespace RKDetails {
     union {
       double d;
       int x[2];
-    } u = { a };
+    } u = {a};
     u.x[1] = (int)(b * (u.x[1] - 1072632447) + 1072632447);
     u.x[0] = 0;
     return u.d;
   }
 
+}  // namespace RKDetails
 
-
-}
-
-template <typename T, 
-	  template <typename,int> class StepWithPrec, 
-	  int N>
-typename  RKAdaptiveSolver<T, StepWithPrec, N>::Vector
-RKAdaptiveSolver<T,StepWithPrec,N>::operator()( Scalar startPar, const Vector& startState,
-						     Scalar step, const RKDerivative<T,N>& deriv,
-						     const RKDistance<T,N>& dist,
-						     float eps)
-{
+template <typename T, template <typename, int> class StepWithPrec, int N>
+typename RKAdaptiveSolver<T, StepWithPrec, N>::Vector RKAdaptiveSolver<T, StepWithPrec, N>::operator()(
+    Scalar startPar,
+    const Vector& startState,
+    Scalar step,
+    const RKDerivative<T, N>& deriv,
+    const RKDistance<T, N>& dist,
+    float eps) {
   using namespace RKDetails;
   constexpr float Safety = 0.9;
   double remainigStep = step;
-  double stepSize = step;   // attempt to solve in one step
-  Scalar currentPar   = startPar;
+  double stepSize = step;  // attempt to solve in one step
+  Scalar currentPar = startPar;
   Vector currentStart = startState;
   int nsteps = 0;
   std::pair<Vector, Scalar> tryStep;
-  
-  StepWithPrec<T,N> stepWithAccuracy;
-  
+
+  StepWithPrec<T, N> stepWithAccuracy;
+
   do {
-    tryStep = stepWithAccuracy( currentPar, currentStart, deriv, dist, stepSize);
+    tryStep = stepWithAccuracy(currentPar, currentStart, deriv, dist, stepSize);
     float acc = tryStep.second;
     //assert(eps>0);
     // assert(acc>=0);
     nsteps++;
-    if (acc <eps || std::abs(stepSize) < std::abs(remainigStep)*0.1f) {
-      if (std::abs(remainigStep - stepSize) < 0.5f*eps) {
-	//	if (verbose()) std::cout << "Accuracy reached, and full step taken in " 
-	//		    << nsteps << " steps" << std::endl;
-	return tryStep.first; // we are there
+    if (acc < eps || std::abs(stepSize) < std::abs(remainigStep) * 0.1f) {
+      if (std::abs(remainigStep - stepSize) < 0.5f * eps) {
+        //	if (verbose()) std::cout << "Accuracy reached, and full step taken in "
+        //		    << nsteps << " steps" << std::endl;
+        return tryStep.first;  // we are there
       } else {
-	remainigStep -= stepSize;
-	currentPar += stepSize;
-	// increase step size
-	// double factor =  std::min( Safety * pow( std::fabs(eps/tryStep.second),0.2), 4.); // gives division by 0 FPE
-	const float cut = std::pow(4.f/Safety,5.f);
-	// float factor =  (eps < cut*acc) ? Safety * std::pow(eps/acc,0.2f) : 4.f;      
-	float factor =  (eps < cut*acc) ? Safety * fastPow(eps/acc,0.2) : 4.f;      
-	// stepSize = std::min( stepSize*factor, remainigStep);
+        remainigStep -= stepSize;
+        currentPar += stepSize;
+        // increase step size
+        // double factor =  std::min( Safety * pow( std::fabs(eps/tryStep.second),0.2), 4.); // gives division by 0 FPE
+        const float cut = std::pow(4.f / Safety, 5.f);
+        // float factor =  (eps < cut*acc) ? Safety * std::pow(eps/acc,0.2f) : 4.f;
+        float factor = (eps < cut * acc) ? Safety * fastPow(eps / acc, 0.2) : 4.f;
+        // stepSize = std::min( stepSize*factor, remainigStep);
         double absRemainingStep = std::abs(remainigStep);
-	double absSize =  std::min( std::abs(stepSize*factor), absRemainingStep);
-	if (absSize < 0.05f* absRemainingStep ) absSize =  0.05f* absRemainingStep;
-	stepSize = std::copysign(absSize,stepSize);
-	currentStart = tryStep.first;
-	//if (verbose()) std::cout << "Accuracy reached, but " << remainigStep 
-	//     << " remain after " << nsteps << " steps. Step size increased by " 
-	//     << factor << " to " << stepSize << std::endl;
+        double absSize = std::min(std::abs(stepSize * factor), absRemainingStep);
+        if (absSize < 0.05f * absRemainingStep)
+          absSize = 0.05f * absRemainingStep;
+        stepSize = std::copysign(absSize, stepSize);
+        currentStart = tryStep.first;
+        //if (verbose()) std::cout << "Accuracy reached, but " << remainigStep
+        //     << " remain after " << nsteps << " steps. Step size increased by "
+        //     << factor << " to " << stepSize << std::endl;
       }
-    }    else {
+    } else {
       // decrease step size
-      constexpr float cut =  Safety*Safety*Safety*Safety*100*100;
-      float factor =
-	( cut*eps > acc) ?
-	// Safety * std::sqrt(std::sqrt(eps/acc)) : 0.1f;
- 	Safety * fastPow(eps/acc,0.25) : 0.1f;
+      constexpr float cut = Safety * Safety * Safety * Safety * 100 * 100;
+      float factor = (cut * eps > acc) ?
+                                       // Safety * std::sqrt(std::sqrt(eps/acc)) : 0.1f;
+                         Safety * fastPow(eps / acc, 0.25)
+                                       : 0.1f;
       stepSize *= factor;
-      if (std::abs(stepSize) < 0.05f*std::abs(remainigStep)) stepSize = 0.05f*remainigStep;
+      if (std::abs(stepSize) < 0.05f * std::abs(remainigStep))
+        stepSize = 0.05f * remainigStep;
       // if (verbose()) std::cout << "Accuracy not yet reached: delta = " << tryStep.second
       //	 << ", step reduced by " << factor << " to " << stepSize << std::endl;
     }
-  } while (std::abs(remainigStep) > eps*0.5f);
-  
+  } while (std::abs(remainigStep) > eps * 0.5f);
+
   return tryStep.first;
 }

--- a/TrackPropagation/RungeKutta/src/RKCartesianDerivative.h
+++ b/TrackPropagation/RungeKutta/src/RKCartesianDerivative.h
@@ -5,11 +5,9 @@
 
 class dso_internal RKCartesianDerivative {
 public:
- 
   virtual ~RKCartesianDerivative() {}
 
-  virtual CartesianState operator()( double step, const CartesianState& start) const = 0;
-
+  virtual CartesianState operator()(double step, const CartesianState& start) const = 0;
 };
 
 #endif

--- a/TrackPropagation/RungeKutta/src/RKCartesianDistance.h
+++ b/TrackPropagation/RungeKutta/src/RKCartesianDistance.h
@@ -11,21 +11,18 @@
 
 /// Estimator of the distance between two state vectors, e.g. for convergence test
 
-class dso_internal RKCartesianDistance final : public RKDistance<double,6> {
+class dso_internal RKCartesianDistance final : public RKDistance<double, 6> {
 public:
- 
-  typedef double                                 Scalar;
-  typedef RKSmallVector<double,6>                Vector;
+  typedef double Scalar;
+  typedef RKSmallVector<double, 6> Vector;
 
   ~RKCartesianDistance() override {}
 
-  Scalar operator()( const Vector& rka, const Vector& rkb, const Scalar& s) const override {
+  Scalar operator()(const Vector& rka, const Vector& rkb, const Scalar& s) const override {
     CartesianStateAdaptor a(rka), b(rkb);
 
-    return (a.position()-b.position()).mag() + 
-      (a.momentum() - b.momentum()).mag() / b.momentum().mag();
+    return (a.position() - b.position()).mag() + (a.momentum() - b.momentum()).mag() / b.momentum().mag();
   }
- 
 };
 
 #endif

--- a/TrackPropagation/RungeKutta/src/RKCurvilinearDistance.h
+++ b/TrackPropagation/RungeKutta/src/RKCurvilinearDistance.h
@@ -7,30 +7,28 @@
 #include "RKSmallVector.h"
 
 template <typename T, int N>
-class dso_internal RKCurvilinearDistance : public RKDistance<T,N> {
+class dso_internal RKCurvilinearDistance : public RKDistance<T, N> {
 public:
- 
-  typedef T                                   Scalar;
-  typedef RKSmallVector<T,N>                  Vector;
+  typedef T Scalar;
+  typedef RKSmallVector<T, N> Vector;
 
   ~RKCurvilinearDistance() override {}
 
-  Scalar operator()( const Vector& a, const Vector& b, const Scalar& s) const override {
-      Basic3DVector<Scalar> amom = momentum(a);
-      Basic3DVector<Scalar> bmom = momentum(b);
+  Scalar operator()(const Vector& a, const Vector& b, const Scalar& s) const override {
+    Basic3DVector<Scalar> amom = momentum(a);
+    Basic3DVector<Scalar> bmom = momentum(b);
 
-    return sqrt( sqr(a(0)-b(0)) + sqr(a(1)-b(1))) + (amom - bmom).mag() / bmom.mag();
+    return sqrt(sqr(a(0) - b(0)) + sqr(a(1) - b(1))) + (amom - bmom).mag() / bmom.mag();
   }
 
-  Basic3DVector<Scalar> momentum( const Vector& v) const {
-      Scalar k = sqrt(1 + sqr(v(2)) + sqr(v(3)));
-      Scalar p = std::abs(1 / v(4));
-      Scalar pz = p/k;
-      return Basic3DVector<Scalar>( v(2)*pz, v(3)*pz, pz);
+  Basic3DVector<Scalar> momentum(const Vector& v) const {
+    Scalar k = sqrt(1 + sqr(v(2)) + sqr(v(3)));
+    Scalar p = std::abs(1 / v(4));
+    Scalar pz = p / k;
+    return Basic3DVector<Scalar>(v(2) * pz, v(3) * pz, pz);
   }
 
-  T sqr(const T& t) const {return t*t;}
- 
+  T sqr(const T& t) const { return t * t; }
 };
 
 #endif

--- a/TrackPropagation/RungeKutta/src/RKCylindricalDistance.h
+++ b/TrackPropagation/RungeKutta/src/RKCylindricalDistance.h
@@ -6,21 +6,19 @@
 #include "CylindricalState.h"
 
 template <typename T, int N>
-class dso_internal RKCylindricalDistance final : public RKDistance<T,N> {
+class dso_internal RKCylindricalDistance final : public RKDistance<T, N> {
 public:
- 
-  typedef T                                   Scalar;
-  typedef RKSmallVector<T,N>                  Vector;
+  typedef T Scalar;
+  typedef RKSmallVector<T, N> Vector;
 
   ~RKCylindricalDistance() override {}
 
-  Scalar operator()( const Vector& a, const Vector& b, const Scalar& rho) const override {
-      CylindricalState astate(rho,a,1.);
-      CylindricalState bstate(rho,b,1.);
-      return (astate.position()-bstate.position()).mag() +
-	  (astate.momentum()-bstate.momentum()).mag() / bstate.momentum().mag();
+  Scalar operator()(const Vector& a, const Vector& b, const Scalar& rho) const override {
+    CylindricalState astate(rho, a, 1.);
+    CylindricalState bstate(rho, b, 1.);
+    return (astate.position() - bstate.position()).mag() +
+           (astate.momentum() - bstate.momentum()).mag() / bstate.momentum().mag();
   }
- 
 };
 
 #endif

--- a/TrackPropagation/RungeKutta/src/RKDerivative.h
+++ b/TrackPropagation/RungeKutta/src/RKDerivative.h
@@ -6,20 +6,17 @@
 
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
 
-
-/// Base class for derivative calculation. 
+/// Base class for derivative calculation.
 
 template <typename T, int N>
 class dso_internal RKDerivative {
 public:
- 
-  typedef T                                   Scalar;
-  typedef RKSmallVector<T,N>                  Vector;
+  typedef T Scalar;
+  typedef RKSmallVector<T, N> Vector;
 
   virtual ~RKDerivative() {}
 
-  virtual Vector operator()( Scalar startPar, const Vector& startState) const = 0;
-
+  virtual Vector operator()(Scalar startPar, const Vector& startState) const = 0;
 };
 
 #endif

--- a/TrackPropagation/RungeKutta/src/RKDistance.h
+++ b/TrackPropagation/RungeKutta/src/RKDistance.h
@@ -7,14 +7,12 @@
 template <typename T, int N>
 class dso_internal RKDistance {
 public:
- 
-  typedef T                                   Scalar;
-  typedef RKSmallVector<T,N>                  Vector;
+  typedef T Scalar;
+  typedef RKSmallVector<T, N> Vector;
 
   virtual ~RKDistance() {}
 
-  virtual Scalar operator()( const Vector& a, const Vector& b, const Scalar& s) const = 0;
-
+  virtual Scalar operator()(const Vector& a, const Vector& b, const Scalar& s) const = 0;
 };
 
 #endif

--- a/TrackPropagation/RungeKutta/src/RKLocalFieldProvider.cc
+++ b/TrackPropagation/RungeKutta/src/RKLocalFieldProvider.cc
@@ -3,19 +3,16 @@
 #include "MagneticField/VolumeGeometry/interface/MagVolume.h"
 #include "FWCore/Utilities/interface/Likely.h"
 
-RKLocalFieldProvider::RKLocalFieldProvider( const MagVolume& vol) :
-  theVolume( vol), theFrame(vol), transform_(false) {}
+RKLocalFieldProvider::RKLocalFieldProvider(const MagVolume& vol) : theVolume(vol), theFrame(vol), transform_(false) {}
 
-RKLocalFieldProvider::RKLocalFieldProvider( const MagVolume& vol, const Frame& frame) :
-  theVolume( vol), theFrame(frame), transform_(true) {}
+RKLocalFieldProvider::RKLocalFieldProvider(const MagVolume& vol, const Frame& frame)
+    : theVolume(vol), theFrame(frame), transform_(true) {}
 
-RKLocalFieldProvider::Vector RKLocalFieldProvider::inTesla( const LocalPoint& lp) const 
-{
-  if UNLIKELY(transform_) {
-      LocalPoint vlp( theVolume.toLocal( theFrame.toGlobal( lp)));
-      return theFrame.toLocal( theVolume.toGlobal( theVolume.fieldInTesla( vlp))).basicVector();
+RKLocalFieldProvider::Vector RKLocalFieldProvider::inTesla(const LocalPoint& lp) const {
+  if
+    UNLIKELY(transform_) {
+      LocalPoint vlp(theVolume.toLocal(theFrame.toGlobal(lp)));
+      return theFrame.toLocal(theVolume.toGlobal(theVolume.fieldInTesla(vlp))).basicVector();
     }
-  return theVolume.fieldInTesla( lp).basicVector();
-
+  return theVolume.fieldInTesla(lp).basicVector();
 }
-

--- a/TrackPropagation/RungeKutta/src/RKLocalFieldProvider.h
+++ b/TrackPropagation/RungeKutta/src/RKLocalFieldProvider.h
@@ -8,43 +8,35 @@ class MagVolume;
 
 class dso_internal RKLocalFieldProvider {
 public:
+  typedef GloballyPositioned<float> Frame;
+  typedef Frame::GlobalVector GlobalVector;
+  typedef Frame::GlobalPoint GlobalPoint;
+  typedef Frame::LocalVector LocalVector;
+  typedef Frame::LocalPoint LocalPoint;
+  typedef Frame::PositionType Position;
+  typedef Frame::RotationType Rotation;
+  typedef GlobalVector::BasicVectorType Vector;
 
-    typedef GloballyPositioned<float>            Frame;
-    typedef Frame::GlobalVector                  GlobalVector;
-    typedef Frame::GlobalPoint                   GlobalPoint;
-    typedef Frame::LocalVector                   LocalVector;
-    typedef Frame::LocalPoint                    LocalPoint;
-    typedef Frame::PositionType                  Position;
-    typedef Frame::RotationType                  Rotation;
-    typedef GlobalVector::BasicVectorType        Vector;
+  /// Local field access to the MagVolume field, in the MagVolume frame
+  explicit RKLocalFieldProvider(const MagVolume& vol);
 
-    /// Local field access to the MagVolume field, in the MagVolume frame
-    explicit RKLocalFieldProvider( const MagVolume& vol);
+  /// Local field access to the MagVolume field, transformed to the "frame" frame
+  RKLocalFieldProvider(const MagVolume& vol, const Frame& frame);
 
-    /// Local field access to the MagVolume field, transformed to the "frame" frame
-    RKLocalFieldProvider( const MagVolume& vol, const Frame& frame);
+  /// the argument lp is in the local frame specified in the constructor
+  Vector inTesla(const LocalPoint& lp) const;
 
-    /// the argument lp is in the local frame specified in the constructor
-    Vector inTesla( const LocalPoint& lp) const;
+  Vector inTesla(double x, double y, double z) const { return inTesla(LocalPoint(x, y, z)); }
 
-    Vector inTesla( double x, double y, double z) const {
-	return inTesla( LocalPoint(x,y,z));
-    }
+  Vector inTesla(const Vector& v) const { return inTesla(LocalPoint(v)); }
 
-    Vector inTesla( const Vector& v) const {
-	return inTesla( LocalPoint(v));
-    }
-
-    /// The reference frame in which the field is defined
-    const Frame& frame() const {return theFrame;}
+  /// The reference frame in which the field is defined
+  const Frame& frame() const { return theFrame; }
 
 private:
-
-    const MagVolume & theVolume;
-    const Frame&     theFrame;
-    bool             transform_;
-
-
+  const MagVolume& theVolume;
+  const Frame& theFrame;
+  bool transform_;
 };
 
 #endif

--- a/TrackPropagation/RungeKutta/src/RKOne4OrderStep.h
+++ b/TrackPropagation/RungeKutta/src/RKOne4OrderStep.h
@@ -10,25 +10,26 @@
 template <typename T, int N>
 class dso_internal RKOne4OrderStep {
 public:
+  typedef T Scalar;
+  typedef RKSmallVector<T, N> Vector;
 
-  typedef T                                   Scalar;
-  typedef RKSmallVector<T,N>                  Vector;
-
-  std::pair< Vector, T> 
-  operator()( Scalar startPar, const Vector& startState,
-	      const RKDerivative<T,N>& deriv,
-	      const RKDistance<T,N>& dist, Scalar step) {
+  std::pair<Vector, T> operator()(Scalar startPar,
+                                  const Vector& startState,
+                                  const RKDerivative<T, N>& deriv,
+                                  const RKDistance<T, N>& dist,
+                                  Scalar step) {
     const Scalar huge = 1.e5;  // ad hoc protection against infinities, must be done better!
     const Scalar hugediff = 100.;
 
-    RK4OneStepTempl<T,N> solver;
-    Vector one(       solver(startPar, startState, deriv, step));
-    if (std::abs(one[0])>huge || std::abs(one(1))>huge) return std::pair<Vector, Scalar>(one,hugediff);
+    RK4OneStepTempl<T, N> solver;
+    Vector one(solver(startPar, startState, deriv, step));
+    if (std::abs(one[0]) > huge || std::abs(one(1)) > huge)
+      return std::pair<Vector, Scalar>(one, hugediff);
 
-    Vector firstHalf( solver(startPar, startState, deriv, step/2));
-    Vector secondHalf(solver(startPar+step/2, firstHalf, deriv, step/2));
-    Scalar diff = dist(one, secondHalf, startPar+step);
-    return std::pair<Vector, Scalar>(secondHalf,diff);
+    Vector firstHalf(solver(startPar, startState, deriv, step / 2));
+    Vector secondHalf(solver(startPar + step / 2, firstHalf, deriv, step / 2));
+    Scalar diff = dist(one, secondHalf, startPar + step);
+    return std::pair<Vector, Scalar>(secondHalf, diff);
   }
 };
 #endif

--- a/TrackPropagation/RungeKutta/src/RKOneCashKarpStep.h
+++ b/TrackPropagation/RungeKutta/src/RKOneCashKarpStep.h
@@ -9,19 +9,17 @@
 #include <utility>
 
 template <typename T, int N>
-class dso_internal RKOneCashKarpStep // : RKStepWithPrecision 
+class dso_internal RKOneCashKarpStep  // : RKStepWithPrecision
 {
 public:
+  typedef T Scalar;
+  typedef RKSmallVector<T, N> Vector;
 
-  typedef T                                   Scalar;
-  typedef RKSmallVector<T,N>                  Vector;
-
-  std::pair< Vector, T> 
-  operator()( Scalar startPar, const Vector& startState,
-	      const RKDerivative<T,N>& deriv,
-	      const RKDistance<T,N>& dist, Scalar step);
-  
-
+  std::pair<Vector, T> operator()(Scalar startPar,
+                                  const Vector& startState,
+                                  const RKDerivative<T, N>& deriv,
+                                  const RKDistance<T, N>& dist,
+                                  Scalar step);
 };
 
 #include "TrackPropagation/RungeKutta/src/RKOneCashKarpStep.icc"

--- a/TrackPropagation/RungeKutta/src/RKOneCashKarpStep.icc
+++ b/TrackPropagation/RungeKutta/src/RKOneCashKarpStep.icc
@@ -1,30 +1,27 @@
 template <typename T, int N>
-std::pair< typename RKOneCashKarpStep<T,N>::Vector, T> 
-RKOneCashKarpStep<T,N>::operator()( Scalar x, const Vector& v,
-				    const RKDerivative<T,N>& deriv,
-				    const RKDistance<T,N>& dist, Scalar step)
-{
-  const Scalar a2=0.2, a3=0.3, a4=0.6, a5=1., a6=7./8.;
-  const Scalar b21=0.2;
-  const Scalar b31=3./40., b32=9./40.;
-  const Scalar b41=0.3,    b42=-0.9,  b43=1.2;
-  const Scalar b51=-11./54., b52=5./2., b53=-70./27., b54=35./27.;
-  const Scalar b61=1631./55296., b62=175./512., b63=575./13824., b64=44275./110592., b65=253./4096.;
-  const Scalar c1=37./378., c3=250./621., c4=125./594., c6=512./1771.;
+std::pair<typename RKOneCashKarpStep<T, N>::Vector, T> RKOneCashKarpStep<T, N>::operator()(
+    Scalar x, const Vector& v, const RKDerivative<T, N>& deriv, const RKDistance<T, N>& dist, Scalar step) {
+  const Scalar a2 = 0.2, a3 = 0.3, a4 = 0.6, a5 = 1., a6 = 7. / 8.;
+  const Scalar b21 = 0.2;
+  const Scalar b31 = 3. / 40., b32 = 9. / 40.;
+  const Scalar b41 = 0.3, b42 = -0.9, b43 = 1.2;
+  const Scalar b51 = -11. / 54., b52 = 5. / 2., b53 = -70. / 27., b54 = 35. / 27.;
+  const Scalar b61 = 1631. / 55296., b62 = 175. / 512., b63 = 575. / 13824., b64 = 44275. / 110592., b65 = 253. / 4096.;
+  const Scalar c1 = 37. / 378., c3 = 250. / 621., c4 = 125. / 594., c6 = 512. / 1771.;
   // removed unused variables c2=0, c5=0 MM 25/6/07
-  const Scalar d1=2825./27648., d3=18575./48384., d4=13525./55296., d5=277./14336., d6=0.25;
+  const Scalar d1 = 2825. / 27648., d3 = 18575. / 48384., d4 = 13525. / 55296., d5 = 277. / 14336., d6 = 0.25;
   // reomved unused variable d2=0
 
-  Vector k1 = step*deriv( x, v);
-  Vector k2 = step*deriv( x+a2*step, v + b21*k1);
-  Vector k3 = step*deriv( x+a3*step, v + b31*k1 + b32*k2);
-  Vector k4 = step*deriv( x+a4*step, v + b41*k1 + b42*k2 + b43*k3);
-  Vector k5 = step*deriv( x+a5*step, v + b51*k1 + b52*k2 + b53*k3 + b54*k4);
-  Vector k6 = step*deriv( x+a6*step, v + b61*k1 + b62*k2 + b63*k3 + b64*k4 + b65*k5);
+  Vector k1 = step * deriv(x, v);
+  Vector k2 = step * deriv(x + a2 * step, v + b21 * k1);
+  Vector k3 = step * deriv(x + a3 * step, v + b31 * k1 + b32 * k2);
+  Vector k4 = step * deriv(x + a4 * step, v + b41 * k1 + b42 * k2 + b43 * k3);
+  Vector k5 = step * deriv(x + a5 * step, v + b51 * k1 + b52 * k2 + b53 * k3 + b54 * k4);
+  Vector k6 = step * deriv(x + a6 * step, v + b61 * k1 + b62 * k2 + b63 * k3 + b64 * k4 + b65 * k5);
 
-  Vector r5 = v + c1*k1 + c3*k3 + c4*k4 +         c6*k6;
-  Vector r4 = v + d1*k1 + d3*k3 + d4*k4 + d5*k5 + d6*k6;
-  return std::pair<Vector,T>( r5, dist(r4,r5,x+step));
+  Vector r5 = v + c1 * k1 + c3 * k3 + c4 * k4 + c6 * k6;
+  Vector r4 = v + d1 * k1 + d3 * k3 + d4 * k4 + d5 * k5 + d6 * k6;
+  return std::pair<Vector, T>(r5, dist(r4, r5, x + step));
 }
 
 /* array implementation may be faster, but is tricky (needs triangular matrix etc.)

--- a/TrackPropagation/RungeKutta/src/RKPropagatorInR.cc
+++ b/TrackPropagation/RungeKutta/src/RKPropagatorInR.cc
@@ -11,66 +11,56 @@
 #include "CylindricalState.h"
 #include "MagneticField/VolumeGeometry/interface/MagVolume.h"
 
-TrajectoryStateOnSurface 
-RKPropagatorInR::myPropagate (const FreeTrajectoryState& ts, const Cylinder& cyl) const
-{
+TrajectoryStateOnSurface RKPropagatorInR::myPropagate(const FreeTrajectoryState& ts, const Cylinder& cyl) const {
   //typedef RK4PreciseSolver<double,5>           Solver;
-    typedef RKAdaptiveSolver<double,RKOne4OrderStep, 5>     Solver;
-    //typedef RKAdaptiveSolver<Scalar,RKOneCashKarpStep, 5>   Solver;
-    typedef double                                          Scalar;
-    typedef Solver::Vector                                  RKVector;
+  typedef RKAdaptiveSolver<double, RKOne4OrderStep, 5> Solver;
+  //typedef RKAdaptiveSolver<Scalar,RKOneCashKarpStep, 5>   Solver;
+  typedef double Scalar;
+  typedef Solver::Vector RKVector;
 
-    GlobalPoint pos( ts.position());
-    GlobalVector mom( ts.momentum());
+  GlobalPoint pos(ts.position());
+  GlobalVector mom(ts.momentum());
 
-    LocalPoint startpos = cyl.toLocal(pos);
-    LocalVector startmom = cyl.toLocal(mom);
+  LocalPoint startpos = cyl.toLocal(pos);
+  LocalVector startmom = cyl.toLocal(mom);
 
-    CylindricalState startState( startpos, startmom, ts.charge());
-    const RKVector& start = startState.parameters();
+  CylindricalState startState(startpos, startmom, ts.charge());
+  const RKVector& start = startState.parameters();
 
-    RKLocalFieldProvider localField( *theVolume, cyl);
-    CylindricalLorentzForce<double,5> deriv(localField);
-    RKCylindricalDistance<double,5> dist;
-    double eps = 1.e-5;
-    Solver solver;
-    try {
-	Scalar step = cyl.radius() - startState.rho();
-	RKVector rkresult = solver( startState.rho(), start, step, deriv, dist, eps);
-	CylindricalState endState( cyl.radius(), rkresult, startState.prSign());
-	return TrajectoryStateOnSurface( GlobalTrajectoryParameters( cyl.toGlobal( endState.position()), 
-								     cyl.toGlobal( endState.momentum()),
-								     TrackCharge(endState.charge()), 
-								     theVolume),
-					 cyl);
-    }
-    catch (CylindricalLorentzForceException& e) {
-        // the propagation failed due to momentum almost parallel to the plane.
-        // This does not mean the propagation is impossible, but it should be done
-	// in a different parametrization (e.g. s)  
-	return TrajectoryStateOnSurface();
-    }
-}
-
-TrajectoryStateOnSurface 
-RKPropagatorInR::myPropagate (const FreeTrajectoryState&, const Plane&) const
-{
+  RKLocalFieldProvider localField(*theVolume, cyl);
+  CylindricalLorentzForce<double, 5> deriv(localField);
+  RKCylindricalDistance<double, 5> dist;
+  double eps = 1.e-5;
+  Solver solver;
+  try {
+    Scalar step = cyl.radius() - startState.rho();
+    RKVector rkresult = solver(startState.rho(), start, step, deriv, dist, eps);
+    CylindricalState endState(cyl.radius(), rkresult, startState.prSign());
+    return TrajectoryStateOnSurface(GlobalTrajectoryParameters(cyl.toGlobal(endState.position()),
+                                                               cyl.toGlobal(endState.momentum()),
+                                                               TrackCharge(endState.charge()),
+                                                               theVolume),
+                                    cyl);
+  } catch (CylindricalLorentzForceException& e) {
+    // the propagation failed due to momentum almost parallel to the plane.
+    // This does not mean the propagation is impossible, but it should be done
+    // in a different parametrization (e.g. s)
     return TrajectoryStateOnSurface();
+  }
 }
 
-std::pair< TrajectoryStateOnSurface, double> 
-RKPropagatorInR::propagateWithPath (const FreeTrajectoryState&, const Plane&) const
-{
-    return std::pair< TrajectoryStateOnSurface, double>();
+TrajectoryStateOnSurface RKPropagatorInR::myPropagate(const FreeTrajectoryState&, const Plane&) const {
+  return TrajectoryStateOnSurface();
 }
 
-std::pair< TrajectoryStateOnSurface, double> 
-RKPropagatorInR::propagateWithPath (const FreeTrajectoryState&, const Cylinder&) const
-{
-    return std::pair< TrajectoryStateOnSurface, double>();
+std::pair<TrajectoryStateOnSurface, double> RKPropagatorInR::propagateWithPath(const FreeTrajectoryState&,
+                                                                               const Plane&) const {
+  return std::pair<TrajectoryStateOnSurface, double>();
 }
 
-Propagator * RKPropagatorInR::clone() const
-{
-    return new RKPropagatorInR(*this);
+std::pair<TrajectoryStateOnSurface, double> RKPropagatorInR::propagateWithPath(const FreeTrajectoryState&,
+                                                                               const Cylinder&) const {
+  return std::pair<TrajectoryStateOnSurface, double>();
 }
+
+Propagator* RKPropagatorInR::clone() const { return new RKPropagatorInR(*this); }

--- a/TrackPropagation/RungeKutta/src/RKPropagatorInS.cc
+++ b/TrackPropagation/RungeKutta/src/RKPropagatorInS.cc
@@ -22,108 +22,106 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Likely.h"
 
+std::pair<TrajectoryStateOnSurface, double> RKPropagatorInS::propagateWithPath(const FreeTrajectoryState& fts,
+                                                                               const Plane& plane) const {
+  GlobalParametersWithPath gp = propagateParametersOnPlane(fts, plane);
+  if
+    UNLIKELY(!gp) return TsosWP(TrajectoryStateOnSurface(), 0.);
 
-std::pair<TrajectoryStateOnSurface,double>
-RKPropagatorInS::propagateWithPath(const FreeTrajectoryState& fts, 
-				   const Plane& plane) const
-{
-  GlobalParametersWithPath gp =  propagateParametersOnPlane( fts, plane);
-  if UNLIKELY(!gp) return TsosWP(TrajectoryStateOnSurface(),0.);
-
-  SurfaceSideDefinition::SurfaceSide side = PropagationDirectionFromPath()(gp.s(),propagationDirection())==alongMomentum 
-    ? SurfaceSideDefinition::beforeSurface : SurfaceSideDefinition::afterSurface;
-  return  analyticalErrorPropagation( fts, plane, side, gp.parameters(),gp.s());
+  SurfaceSideDefinition::SurfaceSide side =
+      PropagationDirectionFromPath()(gp.s(), propagationDirection()) == alongMomentum
+          ? SurfaceSideDefinition::beforeSurface
+          : SurfaceSideDefinition::afterSurface;
+  return analyticalErrorPropagation(fts, plane, side, gp.parameters(), gp.s());
 }
 
-std::pair< TrajectoryStateOnSurface, double> 
-RKPropagatorInS::propagateWithPath (const FreeTrajectoryState& fts, const Cylinder& cyl) const
-{
-  GlobalParametersWithPath gp =  propagateParametersOnCylinder( fts, cyl);
-  if  UNLIKELY(!gp) return TsosWP(TrajectoryStateOnSurface(),0.);
+std::pair<TrajectoryStateOnSurface, double> RKPropagatorInS::propagateWithPath(const FreeTrajectoryState& fts,
+                                                                               const Cylinder& cyl) const {
+  GlobalParametersWithPath gp = propagateParametersOnCylinder(fts, cyl);
+  if
+    UNLIKELY(!gp) return TsosWP(TrajectoryStateOnSurface(), 0.);
 
-  SurfaceSideDefinition::SurfaceSide side = PropagationDirectionFromPath()(gp.s(),propagationDirection())==alongMomentum 
-    ? SurfaceSideDefinition::beforeSurface : SurfaceSideDefinition::afterSurface;
-  return analyticalErrorPropagation( fts, cyl, side, gp.parameters(),gp.s());
-  
+  SurfaceSideDefinition::SurfaceSide side =
+      PropagationDirectionFromPath()(gp.s(), propagationDirection()) == alongMomentum
+          ? SurfaceSideDefinition::beforeSurface
+          : SurfaceSideDefinition::afterSurface;
+  return analyticalErrorPropagation(fts, cyl, side, gp.parameters(), gp.s());
 }
 
-GlobalParametersWithPath
-RKPropagatorInS::propagateParametersOnPlane( const FreeTrajectoryState& ts, 
-					     const Plane& plane) const
-{
-
-  GlobalPoint gpos( ts.position());
-  GlobalVector gmom( ts.momentum());
+GlobalParametersWithPath RKPropagatorInS::propagateParametersOnPlane(const FreeTrajectoryState& ts,
+                                                                     const Plane& plane) const {
+  GlobalPoint gpos(ts.position());
+  GlobalVector gmom(ts.momentum());
   double startZ = plane.localZ(gpos);
   // (transverse) curvature
   double rho = ts.transverseCurvature();
   //
-  // Straight line approximation? |rho|<1.e-10 equivalent to ~ 1um 
+  // Straight line approximation? |rho|<1.e-10 equivalent to ~ 1um
   // difference in transversal position at 10m.
   //
-  if  UNLIKELY( fabs(rho)<1.e-10 ) {
-    //
-    // Instantiate auxiliary object for finding intersection.
-    // Frame-independant point and vector are created explicitely to 
-    // avoid confusing gcc (refuses to compile with temporary objects
-    // in the constructor).
-    //
-    LogDebug("RKPropagatorInS")<<" startZ = "<<startZ;
+  if
+    UNLIKELY(fabs(rho) < 1.e-10) {
+      //
+      // Instantiate auxiliary object for finding intersection.
+      // Frame-independant point and vector are created explicitely to
+      // avoid confusing gcc (refuses to compile with temporary objects
+      // in the constructor).
+      //
+      LogDebug("RKPropagatorInS") << " startZ = " << startZ;
 
-    if UNLIKELY(fabs(startZ) < 1e-5){  
-      LogDebug("RKPropagatorInS")<< "Propagation is not performed: state is already on final surface.";
-      GlobalTrajectoryParameters res( gpos, gmom, ts.charge(), 
-				      theVolume);
-      return GlobalParametersWithPath( res, 0.0);
+      if
+        UNLIKELY(fabs(startZ) < 1e-5) {
+          LogDebug("RKPropagatorInS") << "Propagation is not performed: state is already on final surface.";
+          GlobalTrajectoryParameters res(gpos, gmom, ts.charge(), theVolume);
+          return GlobalParametersWithPath(res, 0.0);
+        }
+
+      StraightLinePlaneCrossing::PositionType pos(gpos);
+      StraightLinePlaneCrossing::DirectionType dir(gmom);
+      StraightLinePlaneCrossing planeCrossing(pos, dir, propagationDirection());
+      //
+      // get solution
+      //
+      std::pair<bool, double> propResult = planeCrossing.pathLength(plane);
+      if
+        LIKELY(propResult.first && theVolume != nullptr) {
+          double s = propResult.second;
+          // point (reconverted to GlobalPoint)
+          GlobalPoint x(planeCrossing.position(s));
+          GlobalTrajectoryParameters res(x, gmom, ts.charge(), theVolume);
+          return GlobalParametersWithPath(res, s);
+        }
+      //do someting
+      LogDebug("RKPropagatorInS") << "Straight line propgation to plane failed !!";
+      return GlobalParametersWithPath();
     }
-
-    StraightLinePlaneCrossing::PositionType pos(gpos);
-    StraightLinePlaneCrossing::DirectionType dir(gmom);
-    StraightLinePlaneCrossing planeCrossing(pos,dir, propagationDirection());
-    //
-    // get solution
-    //
-    std::pair<bool,double> propResult = planeCrossing.pathLength(plane);
-    if LIKELY( propResult.first && theVolume !=nullptr) {
-      double s = propResult.second;
-      // point (reconverted to GlobalPoint)
-      GlobalPoint x (planeCrossing.position(s));
-      GlobalTrajectoryParameters res( x, gmom, ts.charge(), theVolume);
-      return GlobalParametersWithPath( res, s);
-      }
-    //do someting
-    LogDebug("RKPropagatorInS")<< "Straight line propgation to plane failed !!"; 
-    return GlobalParametersWithPath( );
-
-  }
-
 
 #ifdef EDM_ML_DEBUG
   if (theVolume != 0) {
-    LogDebug("RKPropagatorInS")  << "RKPropagatorInS: starting prop to plane in volume with pos " << theVolume->position()
-	      << " Z axis " << theVolume->toGlobal( LocalVector(0,0,1)) ;
+    LogDebug("RKPropagatorInS") << "RKPropagatorInS: starting prop to plane in volume with pos "
+                                << theVolume->position() << " Z axis " << theVolume->toGlobal(LocalVector(0, 0, 1));
 
-    LogDebug("RKPropagatorInS")  << "The starting position is " << ts.position() << " (global) "
-	      << theVolume->toLocal(ts.position()) << " (local) " ;
-  
+    LogDebug("RKPropagatorInS") << "The starting position is " << ts.position() << " (global) "
+                                << theVolume->toLocal(ts.position()) << " (local) ";
+
     FrameChanger changer;
-    auto localPlane = changer.transformPlane( plane, *theVolume);
-    LogDebug("RKPropagatorInS")  << "The plane position is " << plane.position() << " (global) "
-	      << localPlane.position() << " (local) " ;
+    auto localPlane = changer.transformPlane(plane, *theVolume);
+    LogDebug("RKPropagatorInS") << "The plane position is " << plane.position() << " (global) " << localPlane.position()
+                                << " (local) ";
 
-    LogDebug("RKPropagatorInS")  << "The initial distance to plane is " << plane.localZ( ts.position()) ;
+    LogDebug("RKPropagatorInS") << "The initial distance to plane is " << plane.localZ(ts.position());
 
-    StraightLinePlaneCrossing cross( ts.position().basicVector(), ts.momentum().basicVector());
-    std::pair<bool,double> res3 = cross.pathLength(plane);
-    LogDebug("RKPropagatorInS")  << "straight line distance " << res3.first << " " << res3.second ;
+    StraightLinePlaneCrossing cross(ts.position().basicVector(), ts.momentum().basicVector());
+    std::pair<bool, double> res3 = cross.pathLength(plane);
+    LogDebug("RKPropagatorInS") << "straight line distance " << res3.first << " " << res3.second;
   }
 #endif
 
-  typedef RKAdaptiveSolver<double,RKOneCashKarpStep, 6>   Solver;
-  typedef Solver::Vector                                  RKVector;
-  
-  RKLocalFieldProvider field( fieldProvider());
-  PathToPlane2Order pathLength( field, &field.frame());
+  typedef RKAdaptiveSolver<double, RKOneCashKarpStep, 6> Solver;
+  typedef Solver::Vector RKVector;
+
+  RKLocalFieldProvider field(fieldProvider());
+  PathToPlane2Order pathLength(field, &field.frame());
   CartesianLorentzForce deriv(field, ts.charge());
 
   RKCartesianDistance dist;
@@ -133,59 +131,55 @@ RKPropagatorInS::propagateParametersOnPlane( const FreeTrajectoryState& ts,
   PropagationDirection currentDirection = propagationDirection();
 
   // in magVolume frame
-  RKVector start( CartesianStateAdaptor::rkstate( rkPosition(gpos), rkMomentum(gmom)));
+  RKVector start(CartesianStateAdaptor::rkstate(rkPosition(gpos), rkMomentum(gmom)));
   int safeGuard = 0;
-  while (safeGuard++<100) {
+  while (safeGuard++ < 100) {
     CartesianStateAdaptor startState(start);
 
-    std::pair<bool,double> path = pathLength( plane, startState.position(), 
-					      startState.momentum(), 
-					      (double) ts.charge(), currentDirection);
-    if  UNLIKELY(!path.first) { 
-      LogDebug("RKPropagatorInS")  << "RKPropagatorInS: Path length calculation to plane failed!" 
-				   << "...distance to plane " << plane.localZ( globalPosition(startState.position()))
-				   << "...Local starting position in volume " << startState.position() 
-				   << "...Magnetic field " << field.inTesla( startState.position()) ;
+    std::pair<bool, double> path =
+        pathLength(plane, startState.position(), startState.momentum(), (double)ts.charge(), currentDirection);
+    if
+      UNLIKELY(!path.first) {
+        LogDebug("RKPropagatorInS") << "RKPropagatorInS: Path length calculation to plane failed!"
+                                    << "...distance to plane " << plane.localZ(globalPosition(startState.position()))
+                                    << "...Local starting position in volume " << startState.position()
+                                    << "...Magnetic field " << field.inTesla(startState.position());
 
+        return GlobalParametersWithPath();
+      }
 
-      return GlobalParametersWithPath();
-    }
-
-    LogDebug("RKPropagatorInS")  << "RKPropagatorInS: Path lenght to plane is " << path.second ;
-   
+    LogDebug("RKPropagatorInS") << "RKPropagatorInS: Path lenght to plane is " << path.second;
 
     double sstep = path.second;
-    if  UNLIKELY( std::abs(sstep) < eps) {
-      LogDebug("RKPropagatorInS")  << "On-surface accuracy not reached, but pathLength calculation says we are there! "
-		 << "path " << path.second << " distance to plane is " << startZ ;
-      GlobalTrajectoryParameters res( gtpFromVolumeLocal( startState, ts.charge()));
-      return GlobalParametersWithPath( res, stot);
-    }
+    if
+      UNLIKELY(std::abs(sstep) < eps) {
+        LogDebug("RKPropagatorInS") << "On-surface accuracy not reached, but pathLength calculation says we are there! "
+                                    << "path " << path.second << " distance to plane is " << startZ;
+        GlobalTrajectoryParameters res(gtpFromVolumeLocal(startState, ts.charge()));
+        return GlobalParametersWithPath(res, stot);
+      }
 
-    LogDebug("RKPropagatorInS")  << "RKPropagatorInS: Solving for " << sstep 
-	      << " current distance to plane is " << startZ ;
+    LogDebug("RKPropagatorInS") << "RKPropagatorInS: Solving for " << sstep << " current distance to plane is "
+                                << startZ;
 
-    RKVector rkresult = solver( 0, start, sstep, deriv, dist, eps);
+    RKVector rkresult = solver(0, start, sstep, deriv, dist, eps);
     stot += sstep;
-    CartesianStateAdaptor cur( rkresult);
-    double remainingZ = plane.localZ( globalPosition(cur.position()));
+    CartesianStateAdaptor cur(rkresult);
+    double remainingZ = plane.localZ(globalPosition(cur.position()));
 
-    if ( fabs(remainingZ) < eps) {
-      LogDebug("RKPropagatorInS")  << "On-surface accuracy reached! " << remainingZ ;
-      GlobalTrajectoryParameters res( gtpFromVolumeLocal( cur, ts.charge()));
-      return GlobalParametersWithPath( res, stot);
+    if (fabs(remainingZ) < eps) {
+      LogDebug("RKPropagatorInS") << "On-surface accuracy reached! " << remainingZ;
+      GlobalTrajectoryParameters res(gtpFromVolumeLocal(cur, ts.charge()));
+      return GlobalParametersWithPath(res, stot);
     }
 
     start = rkresult;
 
     if (remainingZ * startZ > 0) {
-      LogDebug("RKPropagatorInS")  << "Accuracy not reached yet, trying in same direction again " 
-		<< remainingZ ;
-    }
-    else {
-      LogDebug("RKPropagatorInS")  << "Accuracy not reached yet, trying in opposite direction " 
-		<< remainingZ ;
-      currentDirection = invertDirection( currentDirection);
+      LogDebug("RKPropagatorInS") << "Accuracy not reached yet, trying in same direction again " << remainingZ;
+    } else {
+      LogDebug("RKPropagatorInS") << "Accuracy not reached yet, trying in opposite direction " << remainingZ;
+      currentDirection = invertDirection(currentDirection);
     }
     startZ = remainingZ;
   }
@@ -194,200 +188,180 @@ RKPropagatorInS::propagateParametersOnPlane( const FreeTrajectoryState& ts,
   return GlobalParametersWithPath();
 }
 
-GlobalParametersWithPath
-RKPropagatorInS::propagateParametersOnCylinder( const FreeTrajectoryState& ts, 
-						const Cylinder& cyl) const {
+GlobalParametersWithPath RKPropagatorInS::propagateParametersOnCylinder(const FreeTrajectoryState& ts,
+                                                                        const Cylinder& cyl) const {
+  typedef RKAdaptiveSolver<double, RKOneCashKarpStep, 6> Solver;
+  typedef Solver::Vector RKVector;
 
-  typedef RKAdaptiveSolver<double,RKOneCashKarpStep, 6>   Solver;
-  typedef Solver::Vector                                  RKVector;
-  
-  
   const GlobalPoint& sp = cyl.position();
-  if UNLIKELY(sp.x()!=0. || sp.y()!=0.) {
-      throw PropagationException("Cannot propagate to an arbitrary cylinder");
-    }
-  
-  GlobalPoint gpos( ts.position());
-  GlobalVector gmom( ts.momentum());
+  if
+    UNLIKELY(sp.x() != 0. || sp.y() != 0.) { throw PropagationException("Cannot propagate to an arbitrary cylinder"); }
+
+  GlobalPoint gpos(ts.position());
+  GlobalVector gmom(ts.momentum());
   LocalPoint pos(cyl.toLocal(gpos));
   LocalVector mom(cyl.toLocal(gmom));
   double startR = cyl.radius() - pos.perp();
-  
+
   // LogDebug("RKPropagatorInS")  << "RKPropagatorInS: starting from FTS " << ts ;
-  
-  
+
   // (transverse) curvature
   double rho = ts.transverseCurvature();
   //
-  // Straight line approximation? |rho|<1.e-10 equivalent to ~ 1um 
+  // Straight line approximation? |rho|<1.e-10 equivalent to ~ 1um
   // difference in transversal position at 10m.
   //
-  if  UNLIKELY( fabs(rho)<1.e-10 ) {
+  if
+    UNLIKELY(fabs(rho) < 1.e-10) {
       //
       // Instantiate auxiliary object for finding intersection.
-      // Frame-independant point and vector are created explicitely to 
+      // Frame-independant point and vector are created explicitely to
       // avoid confusing gcc (refuses to compile with temporary objects
       // in the constructor).
       //
-      
-      StraightLineBarrelCylinderCrossing cylCrossing(gpos,gmom,propagationDirection());
-      
+
+      StraightLineBarrelCylinderCrossing cylCrossing(gpos, gmom, propagationDirection());
+
       //
       // get solution
       //
-      std::pair<bool,double> propResult = cylCrossing.pathLength(cyl);
-      if  LIKELY( propResult.first && theVolume !=nullptr) {
-	  double s = propResult.second;
-	  // point (reconverted to GlobalPoint)
-	  GlobalPoint x (cylCrossing.position(s));
-	  GlobalTrajectoryParameters res( x, gmom, ts.charge(), theVolume);
-	  LogDebug("RKPropagatorInS")  << "Straight line propagation to cylinder succeeded !!";
-	  return GlobalParametersWithPath( res, s);
-	} 
-      
-      //do someting 
-      edm::LogError("RKPropagatorInS")  <<"Straight line propagation to cylinder failed !!";
-      return GlobalParametersWithPath( );
-      
+      std::pair<bool, double> propResult = cylCrossing.pathLength(cyl);
+      if
+        LIKELY(propResult.first && theVolume != nullptr) {
+          double s = propResult.second;
+          // point (reconverted to GlobalPoint)
+          GlobalPoint x(cylCrossing.position(s));
+          GlobalTrajectoryParameters res(x, gmom, ts.charge(), theVolume);
+          LogDebug("RKPropagatorInS") << "Straight line propagation to cylinder succeeded !!";
+          return GlobalParametersWithPath(res, s);
+        }
+
+      //do someting
+      edm::LogError("RKPropagatorInS") << "Straight line propagation to cylinder failed !!";
+      return GlobalParametersWithPath();
     }
-  
-  
-  RKLocalFieldProvider field( fieldProvider(cyl));
+
+  RKLocalFieldProvider field(fieldProvider(cyl));
   // StraightLineCylinderCrossing pathLength( pos, mom, propagationDirection());
   CartesianLorentzForce deriv(field, ts.charge());
-  
+
   RKCartesianDistance dist;
   double eps = theTolerance;
   Solver solver;
   double stot = 0;
   PropagationDirection currentDirection = propagationDirection();
-  
-  RKVector start( CartesianStateAdaptor::rkstate( pos.basicVector(), mom.basicVector()));
+
+  RKVector start(CartesianStateAdaptor::rkstate(pos.basicVector(), mom.basicVector()));
   int safeGuard = 0;
-  while (safeGuard++<100) {
+  while (safeGuard++ < 100) {
     CartesianStateAdaptor startState(start);
-    StraightLineCylinderCrossing pathLength( LocalPoint(startState.position()), 
-					     LocalVector(startState.momentum()), 
-					     currentDirection, eps);
-    
-    std::pair<bool,double> path = pathLength.pathLength( cyl);
-    if  UNLIKELY(!path.first) { 
-	LogDebug("RKPropagatorInS")  << "RKPropagatorInS: Path length calculation to cylinder failed!" 
-				     << "Radius " << cyl.radius() << " pos.perp() " << LocalPoint(startState.position()).perp() ;
-	return GlobalParametersWithPath();
+    StraightLineCylinderCrossing pathLength(
+        LocalPoint(startState.position()), LocalVector(startState.momentum()), currentDirection, eps);
+
+    std::pair<bool, double> path = pathLength.pathLength(cyl);
+    if
+      UNLIKELY(!path.first) {
+        LogDebug("RKPropagatorInS") << "RKPropagatorInS: Path length calculation to cylinder failed!"
+                                    << "Radius " << cyl.radius() << " pos.perp() "
+                                    << LocalPoint(startState.position()).perp();
+        return GlobalParametersWithPath();
       }
-    
-    LogDebug("RKPropagatorInS")  << "RKPropagatorInS: Path lenght to cylinder is " << path.second 
-				 << " from point (R,z) " << startState.position().perp() 
-				 << ", " << startState.position().z()
-				 << " to R " << cyl.radius() 
-      ;
-    
-    
+
+    LogDebug("RKPropagatorInS") << "RKPropagatorInS: Path lenght to cylinder is " << path.second << " from point (R,z) "
+                                << startState.position().perp() << ", " << startState.position().z() << " to R "
+                                << cyl.radius();
+
     double sstep = path.second;
-    if  UNLIKELY( std::abs(sstep) < eps) {
-	LogDebug("RKPropagatorInS")  << "accuracy not reached, but pathLength calculation says we are there! "
-				     << path.second ;
-	
-	GlobalTrajectoryParameters res( gtpFromLocal( startState.position(), 
-						      startState.momentum(), 
-						      ts.charge(), cyl));
-	return GlobalParametersWithPath( res, stot);
+    if
+      UNLIKELY(std::abs(sstep) < eps) {
+        LogDebug("RKPropagatorInS") << "accuracy not reached, but pathLength calculation says we are there! "
+                                    << path.second;
+
+        GlobalTrajectoryParameters res(gtpFromLocal(startState.position(), startState.momentum(), ts.charge(), cyl));
+        return GlobalParametersWithPath(res, stot);
       }
-    
-    LogDebug("RKPropagatorInS")  << "RKPropagatorInS: Solving for " << sstep 
-				 << " current distance to cylinder is " << startR ;
-    
-    RKVector rkresult = solver( 0, start, sstep, deriv, dist, eps);
+
+    LogDebug("RKPropagatorInS") << "RKPropagatorInS: Solving for " << sstep << " current distance to cylinder is "
+                                << startR;
+
+    RKVector rkresult = solver(0, start, sstep, deriv, dist, eps);
     stot += sstep;
-    CartesianStateAdaptor cur( rkresult);
+    CartesianStateAdaptor cur(rkresult);
     double remainingR = cyl.radius() - cur.position().perp();
 
-    if ( fabs(remainingR) < eps) {
-      LogDebug("RKPropagatorInS")  << "Accuracy reached! " << remainingR ;
-      GlobalTrajectoryParameters res( gtpFromLocal( cur.position(), 
-						    cur.momentum(), 
-						    ts.charge(), cyl));
-      return GlobalParametersWithPath( res, stot);
+    if (fabs(remainingR) < eps) {
+      LogDebug("RKPropagatorInS") << "Accuracy reached! " << remainingR;
+      GlobalTrajectoryParameters res(gtpFromLocal(cur.position(), cur.momentum(), ts.charge(), cyl));
+      return GlobalParametersWithPath(res, stot);
     }
-    
+
     start = rkresult;
     if (remainingR * startR > 0) {
-      LogDebug("RKPropagatorInS")  << "Accuracy not reached yet, trying in same direction again " 
-				   << remainingR ;
-    }
-    else {
-      LogDebug("RKPropagatorInS")  << "Accuracy not reached yet, trying in opposite direction " 
-				   << remainingR ;
-      currentDirection = invertDirection( currentDirection);
+      LogDebug("RKPropagatorInS") << "Accuracy not reached yet, trying in same direction again " << remainingR;
+    } else {
+      LogDebug("RKPropagatorInS") << "Accuracy not reached yet, trying in opposite direction " << remainingR;
+      currentDirection = invertDirection(currentDirection);
     }
     startR = remainingR;
   }
-  
+
   edm::LogError("FailedPropagation") << " too many iterations trying to reach cylinder ";
   return GlobalParametersWithPath();
 }
 
+Propagator* RKPropagatorInS::clone() const { return new RKPropagatorInS(*this); }
 
-Propagator * RKPropagatorInS::clone() const
-{
-    return new RKPropagatorInS(*this);
+GlobalTrajectoryParameters RKPropagatorInS::gtpFromLocal(const Basic3DVector<float>& lpos,
+                                                         const Basic3DVector<float>& lmom,
+                                                         TrackCharge ch,
+                                                         const Surface& surf) const {
+  return GlobalTrajectoryParameters(surf.toGlobal(LocalPoint(lpos)), surf.toGlobal(LocalVector(lmom)), ch, theVolume);
 }
 
-GlobalTrajectoryParameters RKPropagatorInS::gtpFromLocal( const Basic3DVector<float>& lpos,
-							  const Basic3DVector<float>& lmom,
-							  TrackCharge ch, const Surface& surf) const
-{
-    return GlobalTrajectoryParameters( surf.toGlobal( LocalPoint( lpos)),
-				       surf.toGlobal( LocalVector( lmom)), ch, theVolume);
+RKLocalFieldProvider RKPropagatorInS::fieldProvider() const { return RKLocalFieldProvider(*theVolume); }
+
+RKLocalFieldProvider RKPropagatorInS::fieldProvider(const Cylinder& cyl) const {
+  return RKLocalFieldProvider(*theVolume, cyl);
 }
 
-RKLocalFieldProvider RKPropagatorInS::fieldProvider() const
-{
-  return RKLocalFieldProvider( *theVolume);
+PropagationDirection RKPropagatorInS::invertDirection(PropagationDirection dir) const {
+  if (dir == anyDirection)
+    return dir;
+  return (dir == alongMomentum ? oppositeToMomentum : alongMomentum);
 }
 
-RKLocalFieldProvider RKPropagatorInS::fieldProvider( const Cylinder& cyl) const
-{
-  return RKLocalFieldProvider( *theVolume, cyl);
+Basic3DVector<double> RKPropagatorInS::rkPosition(const GlobalPoint& pos) const {
+  if (theVolume != nullptr)
+    return theVolume->toLocal(pos).basicVector();
+  else
+    return pos.basicVector();
 }
 
-PropagationDirection RKPropagatorInS::invertDirection( PropagationDirection dir) const
-{
-  if (dir == anyDirection) return dir;
-  return ( dir == alongMomentum ? oppositeToMomentum : alongMomentum);
+Basic3DVector<double> RKPropagatorInS::rkMomentum(const GlobalVector& mom) const {
+  if (theVolume != nullptr)
+    return theVolume->toLocal(mom).basicVector();
+  else
+    return mom.basicVector();
 }
 
-Basic3DVector<double> RKPropagatorInS::rkPosition( const GlobalPoint& pos) const
-{
-  if (theVolume != nullptr) return theVolume->toLocal( pos).basicVector();
-  else return pos.basicVector();
+GlobalPoint RKPropagatorInS::globalPosition(const Basic3DVector<float>& pos) const {
+  if (theVolume != nullptr)
+    return theVolume->toGlobal(LocalPoint(pos));
+  else
+    return GlobalPoint(pos);
 }
 
-Basic3DVector<double> RKPropagatorInS::rkMomentum( const GlobalVector& mom) const
+GlobalVector RKPropagatorInS::globalMomentum(const Basic3DVector<float>& mom) const
+
 {
-  if (theVolume != nullptr) return theVolume->toLocal( mom).basicVector();
-  else return mom.basicVector();
+  if (theVolume != nullptr)
+    return theVolume->toGlobal(LocalVector(mom));
+  else
+    return GlobalVector(mom);
 }
 
-GlobalPoint RKPropagatorInS::globalPosition( const Basic3DVector<float>& pos) const
-{
-  if (theVolume != nullptr) return theVolume->toGlobal( LocalPoint(pos));
-  else return GlobalPoint(pos);
-}
-
-GlobalVector RKPropagatorInS::globalMomentum( const Basic3DVector<float>& mom) const
-
-{
-  if (theVolume != nullptr) return theVolume->toGlobal( LocalVector(mom));
-  else return GlobalVector(mom);
-}
-
-GlobalTrajectoryParameters 
-RKPropagatorInS::gtpFromVolumeLocal( const CartesianStateAdaptor& state, 
-				     TrackCharge charge) const
-{
-  return GlobalTrajectoryParameters( globalPosition(state.position()), 
-				     globalMomentum(state.momentum()), 
-				     charge, theVolume);
+GlobalTrajectoryParameters RKPropagatorInS::gtpFromVolumeLocal(const CartesianStateAdaptor& state,
+                                                               TrackCharge charge) const {
+  return GlobalTrajectoryParameters(
+      globalPosition(state.position()), globalMomentum(state.momentum()), charge, theVolume);
 }

--- a/TrackPropagation/RungeKutta/src/RKPropagatorInZ.cc
+++ b/TrackPropagation/RungeKutta/src/RKPropagatorInZ.cc
@@ -9,74 +9,65 @@
 #include "RKOne4OrderStep.h"
 #include "RKOneCashKarpStep.h"
 
-TrajectoryStateOnSurface 
-RKPropagatorInZ::myPropagate (const FreeTrajectoryState& ts, const Plane& plane) const
-{
+TrajectoryStateOnSurface RKPropagatorInZ::myPropagate(const FreeTrajectoryState& ts, const Plane& plane) const {
   //typedef RK4PreciseSolver<double,5>           Solver;
   //typedef RKAdaptiveSolver<double,RKOne4OrderStep, 5>   Solver;
-    typedef RKAdaptiveSolver<double,RKOneCashKarpStep, 5>   Solver;
-    typedef Solver::Vector                       RKVector;
+  typedef RKAdaptiveSolver<double, RKOneCashKarpStep, 5> Solver;
+  typedef Solver::Vector RKVector;
 
-    GlobalPoint pos( ts.position());
-    GlobalVector mom( ts.momentum());
+  GlobalPoint pos(ts.position());
+  GlobalVector mom(ts.momentum());
 
-    // cout << "RKPropagatorInZ: starting from FTS " << ts << endl;
+  // cout << "RKPropagatorInZ: starting from FTS " << ts << endl;
 
-    LocalPoint startpos = plane.toLocal(pos);
-    LocalVector startmom = plane.toLocal(mom);
-    double pzSign = startmom.z() > 0 ? 1.0 : -1.0;
+  LocalPoint startpos = plane.toLocal(pos);
+  LocalVector startmom = plane.toLocal(mom);
+  double pzSign = startmom.z() > 0 ? 1.0 : -1.0;
 
-    // cout << "In local plane coordinates: " << startpos << ", momentum " << startmom << endl;
+  // cout << "In local plane coordinates: " << startpos << ", momentum " << startmom << endl;
 
-    RKVector start;
-    start(0) = startpos.x();
-    start(1) = startpos.y();
-    start(2) = startmom.x()/startmom.z();
-    start(3) = startmom.y()/startmom.z();
-    start(4) = pzSign * ts.charge() / startmom.mag();
+  RKVector start;
+  start(0) = startpos.x();
+  start(1) = startpos.y();
+  start(2) = startmom.x() / startmom.z();
+  start(3) = startmom.y() / startmom.z();
+  start(4) = pzSign * ts.charge() / startmom.mag();
 
-    // cout << "RKPropagatorInZ: Solving with par " <<  startpos.z() << " and state " << start << endl;
+  // cout << "RKPropagatorInZ: Solving with par " <<  startpos.z() << " and state " << start << endl;
 
-    RKLocalFieldProvider localField( *theVolume, plane);
+  RKLocalFieldProvider localField(*theVolume, plane);
 
-    CurvilinearLorentzForce<double,5> deriv(localField);
-    RKCurvilinearDistance<double,5> dist;
-    double eps = 1.e-5;
-    Solver solver;
-    try {
-	RKVector rkresult = solver( startpos.z(), start, -startpos.z(), deriv, dist, eps);
+  CurvilinearLorentzForce<double, 5> deriv(localField);
+  RKCurvilinearDistance<double, 5> dist;
+  double eps = 1.e-5;
+  Solver solver;
+  try {
+    RKVector rkresult = solver(startpos.z(), start, -startpos.z(), deriv, dist, eps);
 
-	return TrajectoryStateOnSurface( LocalTrajectoryParameters( rkresult(4), rkresult(2), rkresult(3),
-								    rkresult(0), rkresult(1), pzSign),
-					 plane, theVolume);
-    }
-    catch (CurvilinearLorentzForceException& e) {
-        // the propagation failed due to momentum almost parallel to the plane.
-        // This does not mean the propagation is impossible, but it should be done
-	// in a different parametrization (e.g. s)  
-	return TrajectoryStateOnSurface();
-    }
-}
-
-TrajectoryStateOnSurface 
-RKPropagatorInZ::myPropagate (const FreeTrajectoryState&, const Cylinder&) const
-{
+    return TrajectoryStateOnSurface(
+        LocalTrajectoryParameters(rkresult(4), rkresult(2), rkresult(3), rkresult(0), rkresult(1), pzSign),
+        plane,
+        theVolume);
+  } catch (CurvilinearLorentzForceException& e) {
+    // the propagation failed due to momentum almost parallel to the plane.
+    // This does not mean the propagation is impossible, but it should be done
+    // in a different parametrization (e.g. s)
     return TrajectoryStateOnSurface();
+  }
 }
 
-std::pair< TrajectoryStateOnSurface, double> 
-RKPropagatorInZ::propagateWithPath (const FreeTrajectoryState&, const Plane&) const
-{
-    return std::pair< TrajectoryStateOnSurface, double>();
+TrajectoryStateOnSurface RKPropagatorInZ::myPropagate(const FreeTrajectoryState&, const Cylinder&) const {
+  return TrajectoryStateOnSurface();
 }
 
-std::pair< TrajectoryStateOnSurface, double> 
-RKPropagatorInZ::propagateWithPath (const FreeTrajectoryState&, const Cylinder&) const
-{
-    return std::pair< TrajectoryStateOnSurface, double>();
+std::pair<TrajectoryStateOnSurface, double> RKPropagatorInZ::propagateWithPath(const FreeTrajectoryState&,
+                                                                               const Plane&) const {
+  return std::pair<TrajectoryStateOnSurface, double>();
 }
 
-Propagator * RKPropagatorInZ::clone() const
-{
-    return new RKPropagatorInZ(*this);
+std::pair<TrajectoryStateOnSurface, double> RKPropagatorInZ::propagateWithPath(const FreeTrajectoryState&,
+                                                                               const Cylinder&) const {
+  return std::pair<TrajectoryStateOnSurface, double>();
 }
+
+Propagator* RKPropagatorInZ::clone() const { return new RKPropagatorInZ(*this); }

--- a/TrackPropagation/RungeKutta/src/RKSmallVector.h
+++ b/TrackPropagation/RungeKutta/src/RKSmallVector.h
@@ -7,9 +7,9 @@
 #define SMATRIX_USE_CONSTEXPR
 #include <Math/SVector.h>
 
-
 #include <iostream>
 
-template<typename T, int N> using RKSmallVector =  ROOT::Math::SVector<T,N>;
+template <typename T, int N>
+using RKSmallVector = ROOT::Math::SVector<T, N>;
 
 #endif

--- a/TrackPropagation/RungeKutta/src/RKSolver.h
+++ b/TrackPropagation/RungeKutta/src/RKSolver.h
@@ -1,7 +1,6 @@
 #ifndef RKSolver_H
 #define RKSolver_H
 
-
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
 
 #include "RKSmallVector.h"
@@ -13,24 +12,23 @@
 template <typename T, int N>
 class dso_internal RKSolver {
 public:
+  typedef T Scalar;
+  typedef RKSmallVector<T, N> Vector;
 
-    typedef T                                   Scalar;
-    typedef RKSmallVector<T,N>                  Vector;
+  virtual ~RKSolver() {}
 
-    virtual ~RKSolver() {}
-
-/** Advance starting state (startPar,startState) by step.
+  /** Advance starting state (startPar,startState) by step.
  *  The accuracy of the result should be better than eps.
  *  The accuracy is computed as the distance (using the "dist" argument)
  *  between different internal estimates of the resulting state.
  *  The "deriv" argument computes the derivatives.
  */
-    virtual Vector operator()( Scalar startPar, const Vector& startState,
-			       Scalar step, const RKDerivative<T,N>& deriv,
-			       const RKDistance<T,N>& dist,
-			       float eps) = 0;
-
-
+  virtual Vector operator()(Scalar startPar,
+                            const Vector& startState,
+                            Scalar step,
+                            const RKDerivative<T, N>& deriv,
+                            const RKDistance<T, N>& dist,
+                            float eps) = 0;
 };
 
 #endif

--- a/TrackPropagation/RungeKutta/src/VectorDoublet.h
+++ b/TrackPropagation/RungeKutta/src/VectorDoublet.h
@@ -7,81 +7,76 @@
 template <class V1, class V2>
 class dso_internal VectorDoublet {
 public:
-
   typedef typename V1::ScalarType Scalar1;
   typedef typename V2::ScalarType Scalar2;
 
   VectorDoublet() {}
-  VectorDoublet( const V1& a, const V2& b) : a_(a), b_(b) {}
+  VectorDoublet(const V1& a, const V2& b) : a_(a), b_(b) {}
 
-  const V1& first() const {return a_;}
-  const V2& second() const {return b_;}
+  const V1& first() const { return a_; }
+  const V2& second() const { return b_; }
 
-  VectorDoublet& operator+= ( const VectorDoublet& v) {
+  VectorDoublet& operator+=(const VectorDoublet& v) {
     a_ += v.first();
     b_ += v.second();
     return *this;
-  } 
-  VectorDoublet& operator-= ( const VectorDoublet& v) {
+  }
+  VectorDoublet& operator-=(const VectorDoublet& v) {
     a_ -= v.first();
     b_ -= v.second();
     return *this;
-  } 
+  }
 
-  VectorDoublet operator-() const { return VectorDoublet( -a_, -b_);}
+  VectorDoublet operator-() const { return VectorDoublet(-a_, -b_); }
 
   template <class T>
-  VectorDoublet& operator*= ( const T& t) {
+  VectorDoublet& operator*=(const T& t) {
     a_ *= t;
     b_ *= t;
     return *this;
-  } 
+  }
   template <class T>
-  VectorDoublet& operator/= ( const T& t) {
+  VectorDoublet& operator/=(const T& t) {
     a_ /= t;
     b_ /= t;
     return *this;
-  } 
+  }
 
-  typename PreciseFloatType<Scalar1,Scalar2>::Type dot( const VectorDoublet& v) const { 
-    return first()*v.first() + second()*v.second();
+  typename PreciseFloatType<Scalar1, Scalar2>::Type dot(const VectorDoublet& v) const {
+    return first() * v.first() + second() * v.second();
   }
 
 private:
-
   V1 a_;
   V2 b_;
-
 };
 
 /// vector sum and subtraction
 template <class V1, class V2>
-inline VectorDoublet<V1,V2>
-operator+( const VectorDoublet<V1,V2>& a, const VectorDoublet<V1,V2>& b) {
-  return VectorDoublet<V1,V2>(a.first()+b.first(), a.second()+b.second());
+inline VectorDoublet<V1, V2> operator+(const VectorDoublet<V1, V2>& a, const VectorDoublet<V1, V2>& b) {
+  return VectorDoublet<V1, V2>(a.first() + b.first(), a.second() + b.second());
 }
 
 template <class V1, class V2>
-inline VectorDoublet<V1,V2>
-operator-( const VectorDoublet<V1,V2>& a, const VectorDoublet<V1,V2>& b) {
-  return VectorDoublet<V1,V2>(a.first()-b.first(), a.second()-b.second());
+inline VectorDoublet<V1, V2> operator-(const VectorDoublet<V1, V2>& a, const VectorDoublet<V1, V2>& b) {
+  return VectorDoublet<V1, V2>(a.first() - b.first(), a.second() - b.second());
 }
 
 /** Multiplication by scalar, does not change the precision of the vector.
  *  The return type is the same as the type of the vector argument.
  */
 template <class V1, class V2, class Scalar>
-inline VectorDoublet<V1,V2> operator*( const VectorDoublet<V1,V2>& v, const Scalar& s) {
-  return VectorDoublet<V1,V2>( v.first()*s, v.second()*s);
+inline VectorDoublet<V1, V2> operator*(const VectorDoublet<V1, V2>& v, const Scalar& s) {
+  return VectorDoublet<V1, V2>(v.first() * s, v.second() * s);
 }
 template <class V1, class V2, class Scalar>
-inline VectorDoublet<V1,V2> operator*( const Scalar& s, const VectorDoublet<V1,V2>& v) {
-  return VectorDoublet<V1,V2>( v.first()*s, v.second()*s);
+inline VectorDoublet<V1, V2> operator*(const Scalar& s, const VectorDoublet<V1, V2>& v) {
+  return VectorDoublet<V1, V2>(v.first() * s, v.second() * s);
 }
 
 template <class V1, class V2, class Scalar>
-inline VectorDoublet<V1,V2> operator/( const VectorDoublet<V1,V2>& v, const Scalar& s) {
-  return VectorDoublet<V1,V2>( v.first()/s, v.second()/s);
+inline VectorDoublet<V1, V2> operator/(const VectorDoublet<V1, V2>& v, const Scalar& s) {
+  return VectorDoublet<V1, V2>(v.first() / s, v.second() / s);
 }
 
 #endif

--- a/TrackPropagation/RungeKutta/test/RKTest.cc
+++ b/TrackPropagation/RungeKutta/test/RKTest.cc
@@ -31,12 +31,10 @@
 #include "TrackingTools/GeomPropagators/interface/AnalyticalPropagator.h"
 #include "TrackPropagation/RungeKutta/interface/defaultRKPropagator.h"
 
-class RKTestField GCC11_FINAL : public MagneticField
-{
- public:
-  virtual GlobalVector inTesla ( const GlobalPoint& ) const {return GlobalVector(0,0,4);}
+class RKTestField GCC11_FINAL : public MagneticField {
+public:
+  virtual GlobalVector inTesla(const GlobalPoint&) const { return GlobalVector(0, 0, 4); }
 };
-
 
 using namespace std;
 
@@ -44,119 +42,107 @@ class RKTest : public edm::EDAnalyzer {
 public:
   RKTest(const edm::ParameterSet& pset) {}
 
-  ~RKTest(){}
+  ~RKTest() {}
 
-  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup){
+  virtual void analyze(const edm::Event& event, const edm::EventSetup& setup) {
     using namespace edm;
     ESHandle<MagneticField> magfield;
     setup.get<IdealMagneticFieldRecord>().get(magfield);
 
-    propagateInCentralVolume( &(*magfield));
+    propagateInCentralVolume(&(*magfield));
   }
 
 private:
-
   typedef TrajectoryStateOnSurface TSOS;
 
-  void propagateInCentralVolume( const MagneticField* field) const;
-  Surface::RotationType rotation( const GlobalVector& zAxis) const;
-
+  void propagateInCentralVolume(const MagneticField* field) const;
+  Surface::RotationType rotation(const GlobalVector& zAxis) const;
 };
 
-
-
-void RKTest::propagateInCentralVolume( const MagneticField* field) const
-{
-
+void RKTest::propagateInCentralVolume(const MagneticField* field) const {
   // RKTestField is used internally in RKTestPropagator
   // In the following code "field" or "&TestField" are interchangeable
   // They should give identical field values if "field" is produced by VolumeBasedMagneticField
   // with the non-default option "useParametrizedTrackerField = true"
-  
-  RKTestField TestField; // Not needed if you want to use field instead of &TestField
+
+  RKTestField TestField;  // Not needed if you want to use field instead of &TestField
 
   //  RKTestPropagator RKprop ( &TestField, alongMomentum );
   //AnalyticalPropagator ANprop  ( &TestField, alongMomentum);
-  defaultRKPropagator::Product  prod( field, alongMomentum, 5.e-5); auto & RKprop = prod.propagator;
-  AnalyticalPropagator ANprop  ( field, alongMomentum);
+  defaultRKPropagator::Product prod(field, alongMomentum, 5.e-5);
+  auto& RKprop = prod.propagator;
+  AnalyticalPropagator ANprop(field, alongMomentum);
 
+  for (float phi = -3.14; phi < 3.14; phi += 0.5) {
+    for (float costh = -0.99; costh < +0.99; costh += 0.3) {
+      //Define starting position and momentum
+      float sinth = sqrt(1 - costh * costh);
+      for (float p = 0.5; p < 12; p += 1.) {
+        GlobalVector startingMomentum(p * sin(phi) * sinth, p * cos(phi) * sinth, p * costh);
+        for (float z = -100.; z < 100.; z += 10.) {
+          GlobalPoint startingPosition(0, 0, z);
+          //Define starting plane
+          PlaneBuilder pb;
+          Surface::RotationType rot = rotation(startingMomentum);
+          PlaneBuilder::ReturnType startingPlane = pb.plane(startingPosition, rot);
+          // Define end plane
+          for (float d = 10.; d < 150.; d += 10.) {
+            cout << "And now trying costh, phi, p, z, dist = " << costh << ", " << phi << ", " << p << ", " << z << ", "
+                 << d << endl;
 
-  for (float phi = -3.14; phi<3.14 ; phi+=0.5) {
-    for (float costh = -0.99; costh<+0.99 ; costh+=0.3) {
-       //Define starting position and momentum
-      float sinth = sqrt(1-costh*costh);
-      for (float p=0.5; p<12; p+=1.) {
-	GlobalVector startingMomentum(p*sin(phi)*sinth,p*cos(phi)*sinth,p*costh);
-	for (float z=-100.; z<100.;z+=10.) {
-	  GlobalPoint startingPosition(0,0,z);
-	  //Define starting plane
-	  PlaneBuilder pb;
-	  Surface::RotationType rot = rotation(startingMomentum);
-	  PlaneBuilder::ReturnType startingPlane = pb.plane( startingPosition, rot);
-	  // Define end plane
-	  for (float d=10.; d<150.;d+=10.) {
-	    cout << "And now trying costh, phi, p, z, dist = " 
-		 << costh << ", " << phi
-		 << ", " << p 
-		 << ", " << z
-		 << ", " << d << endl;
-      
-     
-	    float propDistance = d; // 100 cm
-	    GlobalPoint targetPos = startingPosition + propDistance*startingMomentum.unit();
-	    PlaneBuilder::ReturnType EndPlane = pb.plane( targetPos, rot);
-	    // Define error matrix
-	    ROOT::Math::SMatrixIdentity id;
-	    AlgebraicSymMatrix55 C(id);
-	    C *= 0.01;
-	    CurvilinearTrajectoryError err(C);
-	    
-	    TSOS startingStateP( GlobalTrajectoryParameters(startingPosition, 
-							    startingMomentum, 1, &TestField), 
-				 err, *startingPlane);
-	    
-	    TSOS startingStateM( GlobalTrajectoryParameters(startingPosition, 
-							    startingMomentum, -1, &TestField), 
-				 err, *startingPlane);
-	    
-	    try {
-	      TSOS trackStateP = RKprop.propagate( startingStateP, *EndPlane);
-	      if (trackStateP.isValid())
-		cout << "Succesfully finished Positive track propagation  -------------- with RK: " << trackStateP.globalPosition() << endl;
-	      TSOS trackStateP2 = ANprop.propagate( startingStateP, *EndPlane);
-	      if (trackStateP2.isValid())
-		cout << "Succesfully finished Positive track propagation  -------------- with AN: " << trackStateP2.globalPosition() << endl;
-	    } catch (MagVolumeOutsideValidity & duh){
-	      cout << "MagVolumeOutsideValidity not properly caught!! Lost this track " << endl;
-	    }
-	    
-	    try {
-	      TSOS trackStateM = RKprop.propagate( startingStateM, *EndPlane);
-	      if (trackStateM.isValid())
-		cout << "Succesfully finished Negative track propagation  -------------- with RK: " << trackStateM.globalPosition() << endl;
-	      TSOS trackStateM2 = ANprop.propagate( startingStateM, *EndPlane);
-	      if (trackStateM2.isValid())
-	      cout << "Succesfully finished Negative track propagation  -------------- with AN: " << trackStateM2.globalPosition() << endl;
-	    } catch (MagVolumeOutsideValidity & duh){
-	      cout <<  "MagVolumeOutsideValidity not properly caught!! Lost this track " << endl;
-	    }
-	  }
-	}
+            float propDistance = d;  // 100 cm
+            GlobalPoint targetPos = startingPosition + propDistance * startingMomentum.unit();
+            PlaneBuilder::ReturnType EndPlane = pb.plane(targetPos, rot);
+            // Define error matrix
+            ROOT::Math::SMatrixIdentity id;
+            AlgebraicSymMatrix55 C(id);
+            C *= 0.01;
+            CurvilinearTrajectoryError err(C);
+
+            TSOS startingStateP(
+                GlobalTrajectoryParameters(startingPosition, startingMomentum, 1, &TestField), err, *startingPlane);
+
+            TSOS startingStateM(
+                GlobalTrajectoryParameters(startingPosition, startingMomentum, -1, &TestField), err, *startingPlane);
+
+            try {
+              TSOS trackStateP = RKprop.propagate(startingStateP, *EndPlane);
+              if (trackStateP.isValid())
+                cout << "Succesfully finished Positive track propagation  -------------- with RK: "
+                     << trackStateP.globalPosition() << endl;
+              TSOS trackStateP2 = ANprop.propagate(startingStateP, *EndPlane);
+              if (trackStateP2.isValid())
+                cout << "Succesfully finished Positive track propagation  -------------- with AN: "
+                     << trackStateP2.globalPosition() << endl;
+            } catch (MagVolumeOutsideValidity& duh) {
+              cout << "MagVolumeOutsideValidity not properly caught!! Lost this track " << endl;
+            }
+
+            try {
+              TSOS trackStateM = RKprop.propagate(startingStateM, *EndPlane);
+              if (trackStateM.isValid())
+                cout << "Succesfully finished Negative track propagation  -------------- with RK: "
+                     << trackStateM.globalPosition() << endl;
+              TSOS trackStateM2 = ANprop.propagate(startingStateM, *EndPlane);
+              if (trackStateM2.isValid())
+                cout << "Succesfully finished Negative track propagation  -------------- with AN: "
+                     << trackStateM2.globalPosition() << endl;
+            } catch (MagVolumeOutsideValidity& duh) {
+              cout << "MagVolumeOutsideValidity not properly caught!! Lost this track " << endl;
+            }
+          }
+        }
       }
-    }     
+    }
   }
   cout << " Succesfully reached the END of this test !!!!!!!!!! " << endl;
 }
 
-Surface::RotationType RKTest::rotation( const GlobalVector& zDir) const
-{
+Surface::RotationType RKTest::rotation(const GlobalVector& zDir) const {
   GlobalVector zAxis = zDir.unit();
-  GlobalVector yAxis( zAxis.y(), -zAxis.x(), 0); 
-  GlobalVector xAxis = yAxis.cross( zAxis);
-  return Surface::RotationType( xAxis, yAxis, zAxis);
+  GlobalVector yAxis(zAxis.y(), -zAxis.x(), 0);
+  GlobalVector xAxis = yAxis.cross(zAxis);
+  return Surface::RotationType(xAxis, yAxis, zAxis);
 }
-    
-    
-    DEFINE_FWK_MODULE(RKTest);
-    
-    
+
+DEFINE_FWK_MODULE(RKTest);

--- a/TrackingTools/RecoGeometry/interface/GlobalDetLayerGeometry.h
+++ b/TrackingTools/RecoGeometry/interface/GlobalDetLayerGeometry.h
@@ -17,19 +17,18 @@
 
 class DetLayer;
 
-class GlobalDetLayerGeometry: public DetLayerGeometry {
- public:
-  GlobalDetLayerGeometry(const GeometricSearchTracker* tracker,
-			const MuonDetLayerGeometry* muon):
-  tracker_(tracker),muon_(muon),mtd_(nullptr){};
+class GlobalDetLayerGeometry : public DetLayerGeometry {
+public:
+  GlobalDetLayerGeometry(const GeometricSearchTracker* tracker, const MuonDetLayerGeometry* muon)
+      : tracker_(tracker), muon_(muon), mtd_(nullptr){};
 
   GlobalDetLayerGeometry(const GeometricSearchTracker* tracker,
-			 const MuonDetLayerGeometry* muon,
-			 const MTDDetLayerGeometry* mtd):
-  tracker_(tracker),muon_(muon),mtd_(mtd){};
-	
-	~GlobalDetLayerGeometry() override {}
-  
+                         const MuonDetLayerGeometry* muon,
+                         const MTDDetLayerGeometry* mtd)
+      : tracker_(tracker), muon_(muon), mtd_(mtd){};
+
+  ~GlobalDetLayerGeometry() override {}
+
   /*
   const std::vector<DetLayer*>& allLayers() const =0;
   const std::vector<DetLayer*>& barrelLayers() const =0;
@@ -37,15 +36,13 @@ class GlobalDetLayerGeometry: public DetLayerGeometry {
   const std::vector<DetLayer*>& posForwardLayers() const =0;
   */
 
-
   /// Give the DetId of a module, returns the pointer to the corresponding DetLayer
   const DetLayer* idToLayer(const DetId& detId) const override;
- 
- private:
+
+private:
   const GeometricSearchTracker* tracker_;
   const MuonDetLayerGeometry* muon_;
   const MTDDetLayerGeometry* mtd_;
 };
-
 
 #endif

--- a/TrackingTools/RecoGeometry/interface/RecoGeometryRecord.h
+++ b/TrackingTools/RecoGeometry/interface/RecoGeometryRecord.h
@@ -12,11 +12,12 @@
 
 #include "boost/mpl/vector.hpp"
 
+class RecoGeometryRecord
+    : public edm::eventsetup::DependentRecordImplementation<
+          RecoGeometryRecord,
+          boost::mpl::vector<TrackerRecoGeometryRecord, MuonRecoGeometryRecord, MTDRecoGeometryRecord
+                             //,NavigationSchoolRecord,
+                             //IdealMagneticFieldRecord
+                             > > {};
 
-class RecoGeometryRecord : public edm::eventsetup::DependentRecordImplementation<RecoGeometryRecord,
-  boost::mpl::vector<TrackerRecoGeometryRecord,MuonRecoGeometryRecord,MTDRecoGeometryRecord
-			   //,NavigationSchoolRecord,
-			   //IdealMagneticFieldRecord
-  > > {};
-
-#endif 
+#endif

--- a/TrackingTools/RecoGeometry/plugins/DetLayerGeometryESProducer.cc
+++ b/TrackingTools/RecoGeometry/plugins/DetLayerGeometryESProducer.cc
@@ -5,24 +5,20 @@
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 
-
 #include <memory>
 #include <string>
 
 using namespace edm;
 
-DetLayerGeometryESProducer::DetLayerGeometryESProducer(const edm::ParameterSet & p) 
-{
+DetLayerGeometryESProducer::DetLayerGeometryESProducer(const edm::ParameterSet& p) {
   std::string myName = p.getParameter<std::string>("ComponentName");
-  setWhatProduced(this,myName);
+  setWhatProduced(this, myName);
 }
- 
+
 DetLayerGeometryESProducer::~DetLayerGeometryESProducer() {}
 
-std::unique_ptr<DetLayerGeometry> 
-DetLayerGeometryESProducer::produce(const RecoGeometryRecord & iRecord){ 
+std::unique_ptr<DetLayerGeometry> DetLayerGeometryESProducer::produce(const RecoGeometryRecord& iRecord) {
   return std::make_unique<DetLayerGeometry>();
 }
-
 
 DEFINE_FWK_EVENTSETUP_MODULE(DetLayerGeometryESProducer);

--- a/TrackingTools/RecoGeometry/plugins/DetLayerGeometryESProducer.h
+++ b/TrackingTools/RecoGeometry/plugins/DetLayerGeometryESProducer.h
@@ -7,12 +7,11 @@
 #include "TrackingTools/DetLayers/interface/DetLayerGeometry.h"
 #include <memory>
 
-class  DetLayerGeometryESProducer: public edm::ESProducer{
- public:
-  DetLayerGeometryESProducer(const edm::ParameterSet & p);
-  ~DetLayerGeometryESProducer() override; 
+class DetLayerGeometryESProducer : public edm::ESProducer {
+public:
+  DetLayerGeometryESProducer(const edm::ParameterSet &p);
+  ~DetLayerGeometryESProducer() override;
   std::unique_ptr<DetLayerGeometry> produce(const RecoGeometryRecord &);
 };
-
 
 #endif

--- a/TrackingTools/RecoGeometry/plugins/GlobalDetLayerGeometryESProducer.cc
+++ b/TrackingTools/RecoGeometry/plugins/GlobalDetLayerGeometryESProducer.cc
@@ -10,40 +10,36 @@
 
 using namespace edm;
 
-GlobalDetLayerGeometryESProducer::GlobalDetLayerGeometryESProducer(const edm::ParameterSet & p) 
-{
+GlobalDetLayerGeometryESProducer::GlobalDetLayerGeometryESProducer(const edm::ParameterSet& p) {
   std::string myName = p.getParameter<std::string>("ComponentName");
-  setWhatProduced(this,myName);
+  setWhatProduced(this, myName);
 }
- 
+
 GlobalDetLayerGeometryESProducer::~GlobalDetLayerGeometryESProducer() {}
 
-std::unique_ptr<DetLayerGeometry> 
-GlobalDetLayerGeometryESProducer::produce(const RecoGeometryRecord & iRecord){ 
-  
-  edm::ESHandle<GeometricSearchTracker> tracker;  
+std::unique_ptr<DetLayerGeometry> GlobalDetLayerGeometryESProducer::produce(const RecoGeometryRecord& iRecord) {
+  edm::ESHandle<GeometricSearchTracker> tracker;
   edm::ESHandle<MuonDetLayerGeometry> muon;
   edm::ESHandle<MTDDetLayerGeometry> mtd;
 
   iRecord.getRecord<TrackerRecoGeometryRecord>().get(tracker);
   iRecord.getRecord<MuonRecoGeometryRecord>().get(muon);
-  
+
   // get the MTD if it is available
-  if(auto mtdRecord = iRecord.tryToGetRecord<MTDRecoGeometryRecord>()) {
+  if (auto mtdRecord = iRecord.tryToGetRecord<MTDRecoGeometryRecord>()) {
     mtdRecord->get(mtd);
-    if(!mtd.isValid()) {
+    if (!mtd.isValid()) {
       LogInfo("GlobalDetLayergGeometryBuilder") << "No MTD geometry is available.";
-    } 
+    }
   } else {
     LogInfo("GlobalDetLayerGeometryBuilder") << "No MTDDigiGeometryRecord is available.";
   }
 
   // if we've got MTD initialize it
-  if( mtd.isValid() ) return std::make_unique<GlobalDetLayerGeometry>(tracker.product(), muon.product(), mtd.product());
+  if (mtd.isValid())
+    return std::make_unique<GlobalDetLayerGeometry>(tracker.product(), muon.product(), mtd.product());
 
   return std::make_unique<GlobalDetLayerGeometry>(tracker.product(), muon.product());
-
 }
-
 
 DEFINE_FWK_EVENTSETUP_MODULE(GlobalDetLayerGeometryESProducer);

--- a/TrackingTools/RecoGeometry/plugins/GlobalDetLayerGeometryESProducer.h
+++ b/TrackingTools/RecoGeometry/plugins/GlobalDetLayerGeometryESProducer.h
@@ -7,12 +7,11 @@
 #include "TrackingTools/RecoGeometry/interface/GlobalDetLayerGeometry.h"
 #include <memory>
 
-class  GlobalDetLayerGeometryESProducer: public edm::ESProducer{
- public:
-  GlobalDetLayerGeometryESProducer(const edm::ParameterSet & p);
-  ~GlobalDetLayerGeometryESProducer() override; 
+class GlobalDetLayerGeometryESProducer : public edm::ESProducer {
+public:
+  GlobalDetLayerGeometryESProducer(const edm::ParameterSet &p);
+  ~GlobalDetLayerGeometryESProducer() override;
   std::unique_ptr<DetLayerGeometry> produce(const RecoGeometryRecord &);
 };
-
 
 #endif

--- a/TrackingTools/RecoGeometry/src/GlobalDetLayerGeometry.cc
+++ b/TrackingTools/RecoGeometry/src/GlobalDetLayerGeometry.cc
@@ -2,20 +2,18 @@
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
 #include "FWCore/Utilities/interface/typelookup.h"
 
-const DetLayer* 
-GlobalDetLayerGeometry::idToLayer(const DetId& detId) const{
-  if(detId.det() == DetId::Tracker) return tracker_->idToLayer(detId);
-  else if(detId.det() == DetId::Muon) return muon_->idToLayer(detId);
-  else if(mtd_ != nullptr && 
-	  detId.det() == DetId::Forward &&
-	  detId.subdetId() == FastTime ) return mtd_->idToLayer(detId);
-  else{
-    throw cms::Exception("DetLayers") 
-      << "Error: called GlobalDetLayerGeometry::idToLayer() for a detId which is neither Tracker nor Muon " << (mtd_ == nullptr ? "" : "nor MTD ")
-      << detId;      
+const DetLayer* GlobalDetLayerGeometry::idToLayer(const DetId& detId) const {
+  if (detId.det() == DetId::Tracker)
+    return tracker_->idToLayer(detId);
+  else if (detId.det() == DetId::Muon)
+    return muon_->idToLayer(detId);
+  else if (mtd_ != nullptr && detId.det() == DetId::Forward && detId.subdetId() == FastTime)
+    return mtd_->idToLayer(detId);
+  else {
+    throw cms::Exception("DetLayers")
+        << "Error: called GlobalDetLayerGeometry::idToLayer() for a detId which is neither Tracker nor Muon "
+        << (mtd_ == nullptr ? "" : "nor MTD ") << detId;
   }
-
 }
-
 
 TYPELOOKUP_DATA_REG(GlobalDetLayerGeometry);


### PR DESCRIPTION

Applying code-format for CMSSW category reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/300//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


