### PR TITLE
Remove lastLayerEE/FH magic numbers and use RecHitTools instead

### DIFF
--- a/RecoLocalCalo/HGCalRecAlgos/interface/ClusterTools.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/ClusterTools.h
@@ -56,7 +56,6 @@ namespace hgcal {
     RecHitTools rhtools_;
     const edm::EDGetTokenT<HGCRecHitCollection> eetok, fhtok, bhtok;
     const HGCRecHitCollection *eerh_, *fhrh_, *bhrh_;
-    static const int lastLayerEE = 28;
   };
 }
 

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCal3DClustering.h
@@ -85,9 +85,6 @@ private:
   std::vector<float> zees; /*!< vector to contain z position of each layer. */
   std::unique_ptr<hgcal::ClusterTools> clusterTools; /*!< instance of tools to simplify cluster access. */
   hgcal::RecHitTools rhtools_; /*!< instance of tools to access RecHit information. */
-  static const unsigned int lastLayerEE = 28;
-  static const unsigned int lastLayerFH = 40;
-  static const unsigned int lastLayerBH = 52;
 
 };
 

--- a/RecoLocalCalo/HGCalRecAlgos/interface/HGCalDepthPreClusterer.h
+++ b/RecoLocalCalo/HGCalRecAlgos/interface/HGCalDepthPreClusterer.h
@@ -8,6 +8,7 @@
 
 #include <list>
 
+#include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 #include "RecoLocalCalo/HGCalRecAlgos/interface/ClusterTools.h"
 
 class HGCalDepthPreClusterer
@@ -26,7 +27,10 @@ public:
   }
 
   void getEvent(const edm::Event& ev) { clusterTools->getEvent(ev); }
-  void getEventSetup(const edm::EventSetup& es) { clusterTools->getEventSetup(es); }
+  void getEventSetup(const edm::EventSetup& es) {
+    clusterTools->getEventSetup(es);
+    rhtools_.getEventSetup(es);
+  }
 
   typedef std::vector<reco::BasicCluster> ClusterCollection;
   //  typedef std::vector<reco::BasicCluster> MultiCluster;
@@ -39,10 +43,7 @@ private:
   bool realSpaceCone; /*!< flag to use cartesian space clustering. */
 
   std::unique_ptr<hgcal::ClusterTools> clusterTools;
-
-  static const unsigned int lastLayerEE = 28;
-  static const unsigned int lastLayerFH = 40;
-  static const unsigned int lastLayerBH = 52;
+  hgcal::RecHitTools rhtools_; /*!< instance of tools to access RecHit information. */
 
 };
 

--- a/RecoLocalCalo/HGCalRecAlgos/src/ClusterTools.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/ClusterTools.cc
@@ -132,7 +132,7 @@ double ClusterTools::getMultiClusterEnergy(const reco::HGCalMultiCluster& clu) c
 
 bool ClusterTools::getWidths(const reco::CaloCluster & clus,double & sigmaetaeta, double & sigmaphiphi, double & sigmaetaetal, double & sigmaphiphil ) const {
 
-  if (getLayer(clus.hitsAndFractions()[0].first) > lastLayerEE) return false;
+  if (getLayer(clus.hitsAndFractions()[0].first) > (int) rhtools_.lastLayerEE()) return false;
   const math::XYZPoint & position(clus.position());
   unsigned nhit=clus.hitsAndFractions().size();
 

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCal3DClustering.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCal3DClustering.cc
@@ -80,11 +80,9 @@ std::vector<reco::HGCalMultiCluster> HGCal3DClustering::makeClusters(const reco:
 	std::array<double,3> to{ {0.,0.,zees[j]} };
 	layerIntersection(to,from);
         unsigned int layer = j > maxlayer ? (j-(maxlayer+1)) : j; //maps back from index used for KD trees to actual layer
-        float radius = 9999.;
-        if(layer <= lastLayerEE) radius = radii[0];
-        else if(layer <= lastLayerFH) radius = radii[1];
-        else if(layer <= lastLayerBH) radius = radii[2];
-        else assert(radius<100. && "nonsense layer value - cannot assign multicluster radius");
+        float radius = radii[2];
+        if(layer <= rhtools_.lastLayerEE()) radius = radii[0];
+        else if(layer <= rhtools_.lastLayerFH()) radius = radii[1];
         float radius2 = radius*radius;
 	KDTreeBox search_box(float(to[0])-radius,float(to[0])+radius,
 			     float(to[1])-radius,float(to[1])+radius);

--- a/RecoLocalCalo/HGCalRecAlgos/src/HGCalDepthPreClusterer.cc
+++ b/RecoLocalCalo/HGCalRecAlgos/src/HGCalDepthPreClusterer.cc
@@ -53,11 +53,10 @@ std::vector<reco::HGCalMultiCluster> HGCalDepthPreClusterer::makePreClusters(con
           else distanceCheck = dist2(thecls[es[i]],thecls[es[j]]);
           DetId detid = thecls[es[j]]->hitsAndFractions()[0].first();
           unsigned int layer = clusterTools->getLayer(detid);
-          float radius2 = 9999.;
-          if(layer <= lastLayerEE) radius2 = radii[0]*radii[0];
-          else if(layer <= lastLayerFH) radius2 = radii[1]*radii[1];
-          else if(layer <= lastLayerBH) radius2 = radii[2]*radii[2];
-          else assert(radius2<100. && "nonsense layer value - cannot assign multicluster radius");
+          float radius = radii[2];
+          if(layer <= rhtools_.lastLayerEE()) radius = radii[0];
+          else if(layer <= rhtools_.lastLayerFH()) radius = radii[1];
+          float radius2 = radius*radius;
 	  if( distanceCheck<radius2 && int(thecls[es[j]]->z()*vused[i])>0 ) {
 	    temp.push_back(thecls[es[j]]);
 	    vused[j]=vused[i];


### PR DESCRIPTION
#### PR description:

This PR cleans up the use of magic numbers, namely `lastLayerEE`, `lastLayerFH`, and `lastLayerBH`, using the constants provided by `RecHitTools` instead. Since there is no `lastLayerBH()`, I changed the conditional logic about removing a few assert statements and made only minimal code changes.

#### PR validation:

I ran the checks detailed at http://cms-sw.github.io/PRWorkflow.html

Closes #25472

FYI @kpedro88 