### PR TITLE
DD4hep: Augment tested features and enable runing the tests without disabling biglibs

### DIFF
--- a/BigProducts/Simulation/BuildFile.xml
+++ b/BigProducts/Simulation/BuildFile.xml
@@ -15,6 +15,7 @@
 <use name="SimG4Core/SensitiveDetector"/>
 <use name="SimG4Core/PrintGeomInfo"/>
 <use name="SimRomanPot/SimFP420"/>
+<use name="SimG4Core/DD4hepGeometry"/>
 <use name="Validation/HcalHits"/>
 <use name="Validation/EcalHits"/>
 <use name="SimDataFormats/ValidationFormats"/>

--- a/SimG4Core/DD4hepGeometry/interface/DD4hep_DDDWorld.h
+++ b/SimG4Core/DD4hepGeometry/interface/DD4hep_DDDWorld.h
@@ -8,6 +8,7 @@ namespace cms {
   class DDDetector;
 }
 
+namespace cms {
 class DDDWorld {
 
  public:
@@ -26,5 +27,6 @@ class DDDWorld {
   void setAsWorld(G4VPhysicalVolume* pv);
   G4VPhysicalVolume* m_world;
 };
+}
 
 #endif

--- a/SimG4Core/DD4hepGeometry/src/DD4hep_DDDWorld.cc
+++ b/SimG4Core/DD4hepGeometry/src/DD4hep_DDDWorld.cc
@@ -64,7 +64,7 @@ DDDWorld::setAsWorld(G4VPhysicalVolume * pv) {
   if(kernel)
     kernel->DefineWorldVolume(pv);
   else
-    edm::LogError("SimG4CoreGeometry") << "No G4RunManagerKernel?";
+    edm::LogError("SimG4CoreGeometry") << "cms::DDDWorld::setAsWorld: No G4RunManagerKernel?";
 
   edm::LogInfo("SimG4CoreGeometry") << " World volume defined ";
 }
@@ -80,7 +80,7 @@ DDDWorld::workerSetAsWorld(G4VPhysicalVolume * pv) {
     transM->SetWorldForTracking(pv);
   }
   else
-    edm::LogError("SimG4CoreGeometry") << "No G4RunManagerKernel?";
+    edm::LogError("SimG4CoreGeometry") << "cms::DDDWorld::workerSetAsWorld: No G4RunManagerKernel?";
 
   edm::LogInfo("SimG4CoreGeometry") << " World volume defined (for worker) ";
 }


### PR DESCRIPTION
#### PR description:

* Add G4 production cuts testing, assure their repeatability
* Make sure the tests are run without disabling biglibs
* Move a new DDDWorld in a cms namespace

#### PR validation:

Automatically tested in IB integration by ```scram b runtests```

#### if this PR is a backport please specify the original PR:

no back port is needed
