### PR TITLE
TkAl All in One tool: don't import crabWrapper

### DIFF
--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -11,7 +11,6 @@ import fnmatch
 import six
 import Alignment.OfflineValidation.TkAlAllInOneTool.configTemplates \
     as configTemplates
-import Alignment.OfflineValidation.TkAlAllInOneTool.crabWrapper as crabWrapper
 from Alignment.OfflineValidation.TkAlAllInOneTool.TkAlExceptions \
     import AllInOneError
 from Alignment.OfflineValidation.TkAlAllInOneTool.helperFunctions \


### PR DESCRIPTION
#### PR description:

Basically: don't mess with the environment.  This caused 10+ messages like
```
sh: module: line 1: syntax error: unexpected end of file
sh: error importing function definition for `BASH_FUNC_module'
```
every time we ran the code.

On slc7 this was a more serious issue, because these lines were added to the output of the call to [dasgoclient](https://github.com/cms-sw/cmssw/blob/5b62bf9f89f2df1e899a0d5c813efe6c1c5b35e5/Utilities/General/python/cmssw_das_client.py#L85) and causing it not to parse because it wasn't a valid json string.

<!-- Please replace this text with a description of the feature proposed or problem addressed, what changes are expected in the output if any, what other PRs or externals it depends upon if any -->

#### PR validation:

Certain segments of validateAlignments won't work anymore because they're missing this import, but we don't use the configuration options that lead to those sections.  Gregor Mittag tried to implement crab a long time ago but it never worked properly.  I am not deleting crabWrapper and associated functionality from `validateAlignments.py` yet in case this conflicts with the condor migration, but if it doesn't, as far as I'm concerned someone can go ahead and delete it.

@adewit @connorpa @mmusich 


#### if this PR is a backport please specify the original PR:

