### PR TITLE
correct missing commas in dflt initializations for ghostTrack in IPProducer

### DIFF
--- a/RecoBTag/ImpactParameter/plugins/IPProducer.h
+++ b/RecoBTag/ImpactParameter/plugins/IPProducer.h
@@ -391,11 +391,11 @@ IPProducer<Container,Base,Helper>::produce(edm::Event& iEvent, const edm::EventS
                                                         VertexState(p2, e2));
            trackIP.ghostTrackWeight = pos->weight();
          } else {
-           trackIP.distanceToGhostTrack = Measurement1D(-1. -1.);
+           trackIP.distanceToGhostTrack = Measurement1D(0., -1.);
            trackIP.ghostTrackWeight = 0.;
          }
        } else {
-         trackIP.distanceToGhostTrack = Measurement1D(-1. -1.);
+         trackIP.distanceToGhostTrack = Measurement1D(0., -1.);
          trackIP.ghostTrackWeight = 1.;
        }
 


### PR DESCRIPTION

This is a follow up to https://github.com/cms-sw/cmssw/issues/26913#issuecomment-497027588

@ferencek 