### PR TITLE
Modernized DetIdAssociatorESProducer

### DIFF
--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorMuonSystemMap1D.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorMuonSystemMap1D.cc
@@ -25,6 +25,7 @@
 #include "TH2F.h"
 
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/Records/interface/DetIdAssociatorRecord.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "TrackingTools/TrackAssociator/interface/DetIdAssociator.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorMuonVsCurvature.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorMuonVsCurvature.cc
@@ -25,6 +25,7 @@
 #include "TH1F.h"
 
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/Records/interface/DetIdAssociatorRecord.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "TrackingTools/TrackAssociator/interface/DetIdAssociator.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"

--- a/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorSegmentDifferences.cc
+++ b/Alignment/CommonAlignmentMonitor/plugins/AlignmentMonitorSegmentDifferences.cc
@@ -25,6 +25,7 @@
 #include <sstream>
 
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/Records/interface/DetIdAssociatorRecord.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "TrackingTools/TrackAssociator/interface/DetIdAssociator.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"

--- a/Alignment/MuonAlignmentAlgorithms/plugins/MuonAlignmentFromReference.cc
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/MuonAlignmentFromReference.cc
@@ -33,6 +33,7 @@ Implementation:
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/Records/interface/DetIdAssociatorRecord.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"

--- a/Alignment/MuonAlignmentAlgorithms/test/StandAloneTest.cc
+++ b/Alignment/MuonAlignmentAlgorithms/test/StandAloneTest.cc
@@ -48,6 +48,7 @@
 #include "Alignment/MuonAlignmentAlgorithms/interface/MuonResidualsFromTrack.h"
 
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/Records/interface/DetIdAssociatorRecord.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "MagneticField/Engine/interface/MagneticField.h"

--- a/RecoJets/JetAssociationProducers/src/TrackExtrapolator.cc
+++ b/RecoJets/JetAssociationProducers/src/TrackExtrapolator.cc
@@ -1,5 +1,6 @@
 #include "RecoJets/JetAssociationProducers/interface/TrackExtrapolator.h"
 #include "TrackingTools/TrackAssociator/interface/DetIdAssociator.h"
+#include "TrackingTools/Records/interface/DetIdAssociatorRecord.h"
 
 #include <vector>
 

--- a/RecoJets/JetProducers/src/JetMuonHitsIDHelper.cc
+++ b/RecoJets/JetProducers/src/JetMuonHitsIDHelper.cc
@@ -7,6 +7,7 @@
 // #include "TrackingTools/TrackAssociator/interface/MuonDetIdAssociator.h"
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 #include "TrackingTools/TrackAssociator/interface/DetIdAssociator.h"
+#include "TrackingTools/Records/interface/DetIdAssociatorRecord.h"
 #include "DataFormats/DTRecHit/interface/DTRecHitCollection.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
 #include "DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h"

--- a/SUSYBSMAnalysis/HSCP/src/BetaCalculatorECAL.cc
+++ b/SUSYBSMAnalysis/HSCP/src/BetaCalculatorECAL.cc
@@ -6,6 +6,7 @@
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+#include "TrackingTools/Records/interface/DetIdAssociatorRecord.h"
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixStateInfo.h"
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
 

--- a/TrackingTools/TrackAssociator/interface/DetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/interface/DetIdAssociator.h
@@ -39,7 +39,6 @@
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixStateInfo.h"
 #include "TrackingTools/TrackAssociator/interface/FiducialVolume.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
-#include "TrackingTools/Records/interface/DetIdAssociatorRecord.h"
 #include <set>
 #include <vector>
 
@@ -116,10 +115,7 @@ class DetIdAssociator{
    /// get active detector volume
    const FiducialVolume& volume() const;
 
-   virtual void setGeometry(const DetIdAssociatorRecord&) = 0;
    virtual const GeomDet* getGeomDet(const DetId&) const = 0;
-
-   virtual void setConditions(const DetIdAssociatorRecord&) {};
 
    virtual const char* name() const = 0;
    

--- a/TrackingTools/TrackAssociator/plugins/CaloDetIdAssociator.cc
+++ b/TrackingTools/TrackAssociator/plugins/CaloDetIdAssociator.cc
@@ -184,13 +184,6 @@ bool CaloDetIdAssociator::crossedElement(const GlobalPoint& point1,
    return false;
 }
 
-void CaloDetIdAssociator::setGeometry(const DetIdAssociatorRecord& iRecord)
-{
-  edm::ESHandle<CaloGeometry> geometryH;
-  iRecord.getRecord<CaloGeometryRecord>().get(geometryH);
-  setGeometry(geometryH.product());
-}
-
 void CaloDetIdAssociator::check_setup() const
 {
   DetIdAssociator::check_setup();

--- a/TrackingTools/TrackAssociator/plugins/CaloDetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/plugins/CaloDetIdAssociator.h
@@ -19,28 +19,17 @@
 //
 
 #include "TrackingTools/TrackAssociator/interface/DetIdAssociator.h"
-#include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "TrackingTools/Records/interface/DetIdAssociatorRecord.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class CaloDetIdAssociator: public DetIdAssociator{
  public:
    CaloDetIdAssociator():DetIdAssociator(72, 70 ,0.087),geometry_(nullptr){};
-   CaloDetIdAssociator(const int nPhi, const int nEta, const double etaBinSize)
-     :DetIdAssociator(nPhi, nEta, etaBinSize),geometry_(nullptr){};
-
-   CaloDetIdAssociator(const edm::ParameterSet& pSet)
-     :DetIdAssociator(pSet.getParameter<int>("nPhi"),pSet.getParameter<int>("nEta"),pSet.getParameter<double>("etaBinSize")),geometry_(nullptr){};
-   
-   virtual void setGeometry(const CaloGeometry* ptr) { geometry_ = ptr; };
-
-   void setGeometry(const DetIdAssociatorRecord& iRecord) override;
+ CaloDetIdAssociator(const int nPhi, const int nEta, const double etaBinSize, CaloGeometry const* geom)
+     :DetIdAssociator(nPhi, nEta, etaBinSize),geometry_(geom){};
 
    const GeomDet* getGeomDet(const DetId& id) const override { return nullptr; };
 

--- a/TrackingTools/TrackAssociator/plugins/CaloDetIdAssociatorMaker.cc
+++ b/TrackingTools/TrackAssociator/plugins/CaloDetIdAssociatorMaker.cc
@@ -1,0 +1,55 @@
+// -*- C++ -*-
+//
+// Package:     TrackingTools/TrackAssociator
+// Class  :     CaloDetIdAssociatorMaker
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Thu, 30 May 2019 15:05:57 GMT
+//
+
+// system include files
+
+// user include files
+#include "CaloDetIdAssociatorMaker.h"
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "TrackingTools/Records/interface/DetIdAssociatorRecord.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CaloDetIdAssociator.h"
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+CaloDetIdAssociatorMaker::CaloDetIdAssociatorMaker(edm::ParameterSet const& pSet,
+                                                   edm::ESConsumesCollectorT<DetIdAssociatorRecord>&& iCollector):
+  geomToken_{ iCollector.consumesFrom<CaloGeometry, CaloGeometryRecord>()},
+  etaBinSize{pSet.getParameter<double>("etaBinSize")},
+  nPhi{pSet.getParameter<int>("nPhi")},
+  nEta{pSet.getParameter<int>("nEta")}
+{
+}
+
+std::unique_ptr<DetIdAssociator> 
+CaloDetIdAssociatorMaker::make(const DetIdAssociatorRecord& iRecord) const {
+  return make(iRecord.get(geomToken_), nPhi, nEta, etaBinSize);
+}
+
+std::unique_ptr<DetIdAssociator> 
+CaloDetIdAssociatorMaker::make(CaloGeometry const& iGeom, int nPhi, int nEta, double etaBinSize ) const {
+  return std::unique_ptr<DetIdAssociator>(
+                                          new CaloDetIdAssociator(nPhi, nEta, etaBinSize, &iGeom)
+                                          );
+}
+
+

--- a/TrackingTools/TrackAssociator/plugins/CaloDetIdAssociatorMaker.h
+++ b/TrackingTools/TrackAssociator/plugins/CaloDetIdAssociatorMaker.h
@@ -1,0 +1,55 @@
+#ifndef TrackingTools_TrackAssociator_CaloDetIdAssociatorMaker_h
+#define TrackingTools_TrackAssociator_CaloDetIdAssociatorMaker_h
+// -*- C++ -*-
+//
+// Package:     TrackingTools/TrackAssociator
+// Class  :     CaloDetIdAssociatorMaker
+// 
+/**\class CaloDetIdAssociatorMaker CaloDetIdAssociatorMaker.h "CaloDetIdAssociatorMaker.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Thu, 30 May 2019 14:59:09 GMT
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESConsumesCollector.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "DetIdAssociatorMaker.h"
+
+// forward declarations
+class DetIdAssociator;
+class DetIdAssociatorRecord;
+class CaloGeometry;
+class CaloGeometryRecord;
+
+class CaloDetIdAssociatorMaker : public DetIdAssociatorMaker
+{
+  
+ public:
+  CaloDetIdAssociatorMaker(edm::ParameterSet const&,
+                           edm::ESConsumesCollectorT<DetIdAssociatorRecord>&& );
+  
+  // ---------- const member functions ---------------------
+  std::unique_ptr<DetIdAssociator> make(const DetIdAssociatorRecord&) const final;
+  
+ private:
+  virtual std::unique_ptr<DetIdAssociator> make(CaloGeometry const&, int nPhi, int nEta, double etaBinSize ) const;
+  const edm::ESGetToken<CaloGeometry, CaloGeometryRecord> geomToken_;
+  const double etaBinSize;
+  const int nPhi;
+  const int nEta;
+};
+
+
+#endif

--- a/TrackingTools/TrackAssociator/plugins/DetIdAssociatorFactory.h
+++ b/TrackingTools/TrackAssociator/plugins/DetIdAssociatorFactory.h
@@ -2,9 +2,10 @@
 #define TrackingTools_TrackAssociator_DetIdAssociatorFactory_h
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-#include "TrackingTools/TrackAssociator/interface/DetIdAssociator.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESConsumesCollector.h"
+#include "DetIdAssociatorMaker.h"
 
-typedef edmplugin::PluginFactory<DetIdAssociator * ( const edm::ParameterSet& pSet )> DetIdAssociatorFactory;
+typedef edmplugin::PluginFactory<DetIdAssociatorMaker * ( const edm::ParameterSet& pSet, edm::ESConsumesCollectorT<DetIdAssociatorRecord>&& )> DetIdAssociatorFactory;
 
 #endif

--- a/TrackingTools/TrackAssociator/plugins/DetIdAssociatorMaker.h
+++ b/TrackingTools/TrackAssociator/plugins/DetIdAssociatorMaker.h
@@ -1,0 +1,53 @@
+#ifndef TrackingTools_TrackAssociator_DetIdAssociatorMaker_h
+#define TrackingTools_TrackAssociator_DetIdAssociatorMaker_h
+// -*- C++ -*-
+//
+// Package:     TrackingTools/TrackAssociator
+// Class  :     DetIdAssociatorMaker
+// 
+/**\class DetIdAssociatorMaker DetIdAssociatorMaker.h "DetIdAssociatorMaker.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Thu, 30 May 2019 14:52:58 GMT
+//
+
+// system include files
+
+// user include files
+
+// forward declarations
+class DetIdAssociator;
+class DetIdAssociatorRecord;
+
+class DetIdAssociatorMaker
+{
+
+ public:
+  DetIdAssociatorMaker() = default;
+  virtual ~DetIdAssociatorMaker() = default;
+
+  // ---------- const member functions ---------------------
+  virtual std::unique_ptr<DetIdAssociator> make(const DetIdAssociatorRecord&) const = 0;
+  
+  // ---------- static member functions --------------------
+  
+  // ---------- member functions ---------------------------
+
+ private:
+  DetIdAssociatorMaker(const DetIdAssociatorMaker&) = delete;
+  
+  const DetIdAssociatorMaker& operator=(const DetIdAssociatorMaker&) = delete;
+  
+  // ---------- member data --------------------------------
+  
+};
+
+
+#endif

--- a/TrackingTools/TrackAssociator/plugins/EcalDetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/plugins/EcalDetIdAssociator.h
@@ -22,9 +22,9 @@
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 class EcalDetIdAssociator: public CaloDetIdAssociator{
  public:
-   EcalDetIdAssociator():CaloDetIdAssociator(360,300,0.02){};
+   EcalDetIdAssociator():CaloDetIdAssociator(360,300,0.02,nullptr){};
 
-   EcalDetIdAssociator(const edm::ParameterSet& pSet):CaloDetIdAssociator(pSet){};
+   using CaloDetIdAssociator::CaloDetIdAssociator;
 
    const char* name() const override { return "ECAL"; }
 

--- a/TrackingTools/TrackAssociator/plugins/EcalDetIdAssociatorMaker.h
+++ b/TrackingTools/TrackAssociator/plugins/EcalDetIdAssociatorMaker.h
@@ -1,0 +1,43 @@
+#ifndef TrackingTools_TrackAssociator_EcalDetIdAssociatorMaker_h
+#define TrackingTools_TrackAssociator_EcalDetIdAssociatorMaker_h
+// -*- C++ -*-
+//
+// Package:     TrackingTools/TrackAssociator
+// Class  :     EcalDetIdAssociatorMaker
+// 
+/**\class EcalDetIdAssociatorMaker EcalDetIdAssociatorMaker.h "EcalDetIdAssociatorMaker.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Thu, 30 May 2019 16:11:48 GMT
+//
+
+// system include files
+
+// user include files
+
+// forward declarations
+#include "CaloDetIdAssociatorMaker.h"
+#include "EcalDetIdAssociator.h"
+
+class EcalDetIdAssociatorMaker : public CaloDetIdAssociatorMaker
+{
+
+ public:
+  using CaloDetIdAssociatorMaker::CaloDetIdAssociatorMaker;
+  
+ private:
+  std::unique_ptr<DetIdAssociator> make(CaloGeometry const& geom, int nPhi, int nEta, double etaBinSize ) const final {
+    return std::unique_ptr<DetIdAssociator>( new EcalDetIdAssociator(nPhi,nEta, etaBinSize, &geom) );
+  }
+
+};
+
+
+#endif

--- a/TrackingTools/TrackAssociator/plugins/HODetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/plugins/HODetIdAssociator.h
@@ -22,9 +22,9 @@
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 class HODetIdAssociator: public CaloDetIdAssociator{
  public:
-   HODetIdAssociator():CaloDetIdAssociator(72,30,0.087){};
+   HODetIdAssociator():CaloDetIdAssociator(72,30,0.087, nullptr){};
 
-   HODetIdAssociator(const edm::ParameterSet& pSet):CaloDetIdAssociator(pSet){};
+   using CaloDetIdAssociator::CaloDetIdAssociator;
 
    const char* name() const override { return "HO"; }
 

--- a/TrackingTools/TrackAssociator/plugins/HODetIdAssociatorMaker.h
+++ b/TrackingTools/TrackAssociator/plugins/HODetIdAssociatorMaker.h
@@ -1,0 +1,43 @@
+#ifndef TrackingTools_TrackAssociator_HODetIdAssociatorMaker_h
+#define TrackingTools_TrackAssociator_HODetIdAssociatorMaker_h
+// -*- C++ -*-
+//
+// Package:     TrackingTools/TrackAssociator
+// Class  :     HODetIdAssociatorMaker
+// 
+/**\class HODetIdAssociatorMaker HODetIdAssociatorMaker.h "HODetIdAssociatorMaker.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Thu, 30 May 2019 16:11:48 GMT
+//
+
+// system include files
+
+// user include files
+
+// forward declarations
+#include "CaloDetIdAssociatorMaker.h"
+#include "HODetIdAssociator.h"
+
+class HODetIdAssociatorMaker : public CaloDetIdAssociatorMaker
+{
+
+ public:
+  using CaloDetIdAssociatorMaker::CaloDetIdAssociatorMaker;
+  
+ private:
+  std::unique_ptr<DetIdAssociator> make(CaloGeometry const& geom, int nPhi, int nEta, double etaBinSize ) const final {
+    return std::unique_ptr<DetIdAssociator>( new HODetIdAssociator(nPhi,nEta, etaBinSize, &geom) );
+  }
+
+};
+
+
+#endif

--- a/TrackingTools/TrackAssociator/plugins/HcalDetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/plugins/HcalDetIdAssociator.h
@@ -22,12 +22,12 @@
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 class HcalDetIdAssociator: public CaloDetIdAssociator{
  public:
-   HcalDetIdAssociator():CaloDetIdAssociator(72, 70 ,0.087){};
+   HcalDetIdAssociator():CaloDetIdAssociator(72, 70 ,0.087, nullptr){};
 
-   HcalDetIdAssociator(const edm::ParameterSet& pSet):CaloDetIdAssociator(pSet)
-    ,hcalReg_(pSet.getParameter<int> ("hcalRegion"))
-    {};
-   
+   HcalDetIdAssociator(int hcalReg, int nPhi, int nEta, double etaBinSize, CaloGeometry const* geom):
+     CaloDetIdAssociator(nPhi, nEta, etaBinSize, geom),
+     hcalReg_{hcalReg}{}
+
    const char* name() const override { return "HCAL"; }
 
  protected:

--- a/TrackingTools/TrackAssociator/plugins/HcalDetIdAssociatorMaker.cc
+++ b/TrackingTools/TrackAssociator/plugins/HcalDetIdAssociatorMaker.cc
@@ -1,0 +1,36 @@
+// -*- C++ -*-
+//
+// Package:     TrackingTools/TrackAssociator
+// Class  :     HcalDetIdAssociatorMaker
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Thu, 30 May 2019 15:05:57 GMT
+//
+
+// system include files
+
+// user include files
+#include "HcalDetIdAssociatorMaker.h"
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+HcalDetIdAssociatorMaker::HcalDetIdAssociatorMaker(edm::ParameterSet const& pSet,
+                                                   edm::ESConsumesCollectorT<DetIdAssociatorRecord>&& iCollector):
+  CaloDetIdAssociatorMaker(pSet,std::move(iCollector) ),
+  hcalReg_{pSet.getParameter<int> ("hcalRegion")}
+{
+}
+
+

--- a/TrackingTools/TrackAssociator/plugins/HcalDetIdAssociatorMaker.h
+++ b/TrackingTools/TrackAssociator/plugins/HcalDetIdAssociatorMaker.h
@@ -1,0 +1,45 @@
+#ifndef TrackingTools_TrackAssociator_HcalDetIdAssociatorMaker_h
+#define TrackingTools_TrackAssociator_HcalDetIdAssociatorMaker_h
+// -*- C++ -*-
+//
+// Package:     TrackingTools/TrackAssociator
+// Class  :     HcalDetIdAssociatorMaker
+// 
+/**\class HcalDetIdAssociatorMaker HcalDetIdAssociatorMaker.h "HcalDetIdAssociatorMaker.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Thu, 30 May 2019 16:11:48 GMT
+//
+
+// system include files
+
+// user include files
+
+// forward declarations
+#include "CaloDetIdAssociatorMaker.h"
+#include "HcalDetIdAssociator.h"
+
+class HcalDetIdAssociatorMaker : public CaloDetIdAssociatorMaker
+{
+
+ public:
+  HcalDetIdAssociatorMaker(edm::ParameterSet const&,
+                           edm::ESConsumesCollectorT<DetIdAssociatorRecord>&& );
+  
+ private:
+  std::unique_ptr<DetIdAssociator> make(CaloGeometry const& geom, int nPhi, int nEta, double etaBinSize ) const final {
+    return std::unique_ptr<DetIdAssociator>( new HcalDetIdAssociator(hcalReg_, nPhi,nEta, etaBinSize, &geom) );
+  }
+
+  const int hcalReg_;
+};
+
+
+#endif

--- a/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociator.cc
+++ b/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociator.cc
@@ -139,10 +139,3 @@ MuonDetIdAssociator::getDetIdPoints(const DetId& id, std::vector<GlobalPoint>& p
    
    return std::pair<const_iterator,const_iterator>(points.begin(),points.end());
 }
-
-void MuonDetIdAssociator::setGeometry(const DetIdAssociatorRecord& iRecord)
-{
-  edm::ESHandle<GlobalTrackingGeometry> geometryH;
-  iRecord.getRecord<GlobalTrackingGeometryRecord>().get(geometryH);
-  setGeometry(geometryH.product());
-}

--- a/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociator.h
@@ -26,30 +26,21 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "CondFormats/CSCObjects/interface/CSCBadChambers.h"
 
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-
 class MuonDetIdAssociator: public DetIdAssociator{
  public:
    MuonDetIdAssociator():DetIdAssociator(48, 48 , 0.125),geometry_(nullptr),cscbadchambers_(nullptr),includeBadChambers_(false){};
    MuonDetIdAssociator(const int nPhi, const int nEta, const double etaBinSize)
      :DetIdAssociator(nPhi, nEta, etaBinSize),geometry_(nullptr),cscbadchambers_(nullptr),includeBadChambers_(false){};
 
-   MuonDetIdAssociator(const edm::ParameterSet& pSet)
-     :DetIdAssociator(pSet.getParameter<int>("nPhi"),pSet.getParameter<int>("nEta"),pSet.getParameter<double>("etaBinSize")),geometry_(nullptr),cscbadchambers_(nullptr),includeBadChambers_(pSet.getParameter<bool>("includeBadChambers")),includeGEM_(pSet.getParameter<bool>("includeGEM")),includeME0_(pSet.getParameter<bool>("includeME0")){};
-   
+ MuonDetIdAssociator(int nPhi, int nEta, double etaBinSize, const GlobalTrackingGeometry* geom,
+                     const CSCBadChambers* badChambers, 
+                     bool includeBadChambers, bool includeGEM, bool includeME0)
+     :DetIdAssociator(nPhi, nEta, etaBinSize),geometry_(geom),cscbadchambers_(badChambers),
+    includeBadChambers_(includeBadChambers), includeGEM_(includeGEM), includeME0_(includeME0) {};
+
    virtual void setGeometry(const GlobalTrackingGeometry* ptr) { geometry_ = ptr; }
 
-   void setGeometry(const DetIdAssociatorRecord& iRecord) override;
-
    virtual void setCSCBadChambers(const CSCBadChambers* ptr) { cscbadchambers_ = ptr; }
-
-   void setConditions(const DetIdAssociatorRecord& iRecord) override{
-      edm::ESHandle<CSCBadChambers> cscbadchambersH;
-      iRecord.getRecord<CSCBadChambersRcd>().get(cscbadchambersH);
-      setCSCBadChambers(cscbadchambersH.product());
-   };
 
    const GeomDet* getGeomDet( const DetId& id ) const override;
 

--- a/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociatorMaker.cc
+++ b/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociatorMaker.cc
@@ -1,0 +1,58 @@
+// -*- C++ -*-
+//
+// Package:     TrackingTools/TrackAssociator
+// Class  :     MuonDetIdAssociatorMaker
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Thu, 30 May 2019 15:05:57 GMT
+//
+
+// system include files
+
+// user include files
+#include "MuonDetIdAssociatorMaker.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "TrackingTools/Records/interface/DetIdAssociatorRecord.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "MuonDetIdAssociator.h"
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+MuonDetIdAssociatorMaker::MuonDetIdAssociatorMaker(edm::ParameterSet const& pSet,
+                                                   edm::ESConsumesCollectorT<DetIdAssociatorRecord>&& iCollector):
+  etaBinSize{pSet.getParameter<double>("etaBinSize")},
+  nPhi{pSet.getParameter<int>("nPhi")},
+  nEta{pSet.getParameter<int>("nEta")},
+  includeBadChambers_{pSet.getParameter<bool>("includeBadChambers")},
+  includeGEM_{pSet.getParameter<bool>("includeGEM")},
+  includeME0_{pSet.getParameter<bool>("includeME0")}
+{
+  iCollector.setConsumes(geomToken_).setConsumes(badChambersToken_);
+}
+
+std::unique_ptr<DetIdAssociator> 
+MuonDetIdAssociatorMaker::make(const DetIdAssociatorRecord& iRecord) const {
+  return std::unique_ptr<DetIdAssociator>(
+                                          new MuonDetIdAssociator(nPhi, nEta, etaBinSize,
+                                                                  &iRecord.get(geomToken_),
+                                                                  &iRecord.get(badChambersToken_),
+                                                                  includeBadChambers_,
+                                                                  includeGEM_,
+                                                                  includeME0_)
+                                          );
+}
+
+

--- a/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociatorMaker.h
+++ b/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociatorMaker.h
@@ -1,0 +1,60 @@
+#ifndef TrackingTools_TrackAssociator_MuonDetIdAssociatorMaker_h
+#define TrackingTools_TrackAssociator_MuonDetIdAssociatorMaker_h
+// -*- C++ -*-
+//
+// Package:     TrackingTools/TrackAssociator
+// Class  :     MuonDetIdAssociatorMaker
+// 
+/**\class MuonDetIdAssociatorMaker MuonDetIdAssociatorMaker.h "MuonDetIdAssociatorMaker.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Thu, 30 May 2019 14:59:09 GMT
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESConsumesCollector.h"
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "DetIdAssociatorMaker.h"
+
+// forward declarations
+class DetIdAssociator;
+class DetIdAssociatorRecord;
+class GlobalTrackingGeometry;
+class GlobalTrackingGeometryRecord;
+class CSCBadChambers;
+class CSCBadChambersRcd;
+
+class MuonDetIdAssociatorMaker : public DetIdAssociatorMaker
+{
+  
+ public:
+  MuonDetIdAssociatorMaker(edm::ParameterSet const&,
+                           edm::ESConsumesCollectorT<DetIdAssociatorRecord>&& );
+  
+  // ---------- const member functions ---------------------
+  std::unique_ptr<DetIdAssociator> make(const DetIdAssociatorRecord&) const final;
+  
+ private:
+  edm::ESGetToken<GlobalTrackingGeometry, GlobalTrackingGeometryRecord> geomToken_;
+  edm::ESGetToken<CSCBadChambers, CSCBadChambersRcd> badChambersToken_;
+  const double etaBinSize;
+  const int nPhi;
+  const int nEta;
+  const bool includeBadChambers_;
+  const bool includeGEM_;
+  const bool includeME0_;
+};
+
+
+#endif

--- a/TrackingTools/TrackAssociator/plugins/PreshowerDetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/plugins/PreshowerDetIdAssociator.h
@@ -22,9 +22,9 @@
 
 class PreshowerDetIdAssociator: public CaloDetIdAssociator{
  public:
-   PreshowerDetIdAssociator():CaloDetIdAssociator(30,60,0.1){};
+   PreshowerDetIdAssociator():CaloDetIdAssociator(30,60,0.1,nullptr){};
 
-   PreshowerDetIdAssociator(const edm::ParameterSet& pSet):CaloDetIdAssociator(pSet){};
+   using CaloDetIdAssociator::CaloDetIdAssociator; 
      
    const char* name() const override { return "Preshower"; }
  protected:

--- a/TrackingTools/TrackAssociator/plugins/PreshowerDetIdAssociatorMaker.h
+++ b/TrackingTools/TrackAssociator/plugins/PreshowerDetIdAssociatorMaker.h
@@ -1,0 +1,43 @@
+#ifndef TrackingTools_TrackAssociator_PreshowerDetIdAssociatorMaker_h
+#define TrackingTools_TrackAssociator_PreshowerDetIdAssociatorMaker_h
+// -*- C++ -*-
+//
+// Package:     TrackingTools/TrackAssociator
+// Class  :     PreshowerDetIdAssociatorMaker
+// 
+/**\class PreshowerDetIdAssociatorMaker PreshowerDetIdAssociatorMaker.h "PreshowerDetIdAssociatorMaker.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Christopher Jones
+//         Created:  Thu, 30 May 2019 16:18:21 GMT
+//
+
+// system include files
+
+// user include files
+#include "CaloDetIdAssociatorMaker.h"
+#include "PreshowerDetIdAssociator.h"
+
+// forward declarations
+
+class PreshowerDetIdAssociatorMaker : public CaloDetIdAssociatorMaker
+{
+
+ public:
+  using CaloDetIdAssociatorMaker::CaloDetIdAssociatorMaker;
+
+ private:
+  std::unique_ptr<DetIdAssociator> make(CaloGeometry const& geom, int nPhi, int nEta, double etaBinSize ) const final {
+    return std::unique_ptr<DetIdAssociator>( new PreshowerDetIdAssociator(nPhi,nEta, etaBinSize, &geom) );
+  }
+
+};
+
+
+#endif

--- a/TrackingTools/TrackAssociator/plugins/modules.cc
+++ b/TrackingTools/TrackAssociator/plugins/modules.cc
@@ -5,17 +5,17 @@
 
 
 #include "DetIdAssociatorFactory.h"
-#include "EcalDetIdAssociator.h"
-#include "HcalDetIdAssociator.h"
-#include "HODetIdAssociator.h"
-#include "CaloDetIdAssociator.h"
-#include "MuonDetIdAssociator.h"
-#include "PreshowerDetIdAssociator.h"
+#include "EcalDetIdAssociatorMaker.h"
+#include "HcalDetIdAssociatorMaker.h"
+#include "HODetIdAssociatorMaker.h"
+#include "CaloDetIdAssociatorMaker.h"
+#include "MuonDetIdAssociatorMaker.h"
+#include "PreshowerDetIdAssociatorMaker.h"
 
-DEFINE_EDM_PLUGIN(DetIdAssociatorFactory, EcalDetIdAssociator, "EcalDetIdAssociator");
-DEFINE_EDM_PLUGIN(DetIdAssociatorFactory, HcalDetIdAssociator, "HcalDetIdAssociator");
-DEFINE_EDM_PLUGIN(DetIdAssociatorFactory, HODetIdAssociator, "HODetIdAssociator");
-DEFINE_EDM_PLUGIN(DetIdAssociatorFactory, CaloDetIdAssociator, "CaloDetIdAssociator");
-DEFINE_EDM_PLUGIN(DetIdAssociatorFactory, MuonDetIdAssociator, "MuonDetIdAssociator");
-DEFINE_EDM_PLUGIN(DetIdAssociatorFactory, PreshowerDetIdAssociator, "PreshowerDetIdAssociator");
+DEFINE_EDM_PLUGIN(DetIdAssociatorFactory, EcalDetIdAssociatorMaker, "EcalDetIdAssociator");
+DEFINE_EDM_PLUGIN(DetIdAssociatorFactory, HcalDetIdAssociatorMaker, "HcalDetIdAssociator");
+DEFINE_EDM_PLUGIN(DetIdAssociatorFactory, HODetIdAssociatorMaker, "HODetIdAssociator");
+DEFINE_EDM_PLUGIN(DetIdAssociatorFactory, CaloDetIdAssociatorMaker, "CaloDetIdAssociator");
+DEFINE_EDM_PLUGIN(DetIdAssociatorFactory, MuonDetIdAssociatorMaker, "MuonDetIdAssociator");
+DEFINE_EDM_PLUGIN(DetIdAssociatorFactory, PreshowerDetIdAssociatorMaker, "PreshowerDetIdAssociator");
 


### PR DESCRIPTION

#### PR description:

- removed framework constructs (e.g. ParameterSet and EventSetup records) from DetIdAssociators
- created DetIdAssociatorMakers which get configurations from the ParameterSet, set what EventSetup data products will be consumed and then create the appropriate DetIdAssociator.

#### PR validation:

The code compiles.

This is intended to be a refactoring so should not change any results.