### PR TITLE
Added consumes to GlobalDetLayerGeometryESProducer

### DIFF
--- a/TrackingTools/RecoGeometry/plugins/GlobalDetLayerGeometryESProducer.h
+++ b/TrackingTools/RecoGeometry/plugins/GlobalDetLayerGeometryESProducer.h
@@ -12,6 +12,11 @@ public:
   GlobalDetLayerGeometryESProducer(const edm::ParameterSet &p);
   ~GlobalDetLayerGeometryESProducer() override;
   std::unique_ptr<DetLayerGeometry> produce(const RecoGeometryRecord &);
+
+private:
+  edm::ESGetToken<GeometricSearchTracker, TrackerRecoGeometryRecord> trackerToken_;
+  edm::ESGetToken<MuonDetLayerGeometry, MuonRecoGeometryRecord> muonToken_;
+  edm::ESGetToken<MTDDetLayerGeometry, MTDRecoGeometryRecord> mtdToken_;
 };
 
 #endif


### PR DESCRIPTION
#### PR description:
- Added use of consumes
- Switched to using ESGetTokens.

#### PR validation:

The code compiles.

This in meant to be just a refactoring so no changes are expected.