### PR TITLE
Running code-format for alca-db-hlt

### DIFF
--- a/CondFormats/HLTObjects/interface/AlCaRecoTriggerBits.h
+++ b/CondFormats/HLTObjects/interface/AlCaRecoTriggerBits.h
@@ -18,7 +18,7 @@ public:
   /// Delimeter for composing paths to one string in DB:
   static const std::string::value_type delimeter_;
 
-  std::map<std::string,std::string> m_alcarecoToTrig;
+  std::map<std::string, std::string> m_alcarecoToTrig;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/HLTObjects/interface/HLTPrescaleTableCond.h
+++ b/CondFormats/HLTObjects/interface/HLTPrescaleTableCond.h
@@ -7,18 +7,17 @@
 
 namespace trigger {
   class HLTPrescaleTableCond {
-   public:
+  public:
     /// default c'tor
-    HLTPrescaleTableCond(): hltPrescaleTable_() { }
+    HLTPrescaleTableCond() : hltPrescaleTable_() {}
     /// payload c'tor
-    HLTPrescaleTableCond(const trigger::HLTPrescaleTable& hltPrescaleTable):
-	hltPrescaleTable_(hltPrescaleTable) { }
+    HLTPrescaleTableCond(const trigger::HLTPrescaleTable& hltPrescaleTable) : hltPrescaleTable_(hltPrescaleTable) {}
     /// trivial const accessor
-    const trigger::HLTPrescaleTable& hltPrescaleTable() const {return hltPrescaleTable_;}
+    const trigger::HLTPrescaleTable& hltPrescaleTable() const { return hltPrescaleTable_; }
     /// data member
     trigger::HLTPrescaleTable hltPrescaleTable_;
-    
+
     COND_SERIALIZABLE;
   };
-}
+}  // namespace trigger
 #endif

--- a/CondFormats/HLTObjects/src/AlCaRecoTriggerBits.cc
+++ b/CondFormats/HLTObjects/src/AlCaRecoTriggerBits.cc
@@ -1,38 +1,36 @@
 #include "CondFormats/HLTObjects/interface/AlCaRecoTriggerBits.h"
 
+AlCaRecoTriggerBits::AlCaRecoTriggerBits() {}
+AlCaRecoTriggerBits::~AlCaRecoTriggerBits() {}
 
-AlCaRecoTriggerBits::AlCaRecoTriggerBits(){}
-AlCaRecoTriggerBits::~AlCaRecoTriggerBits(){}
-
-const std::string::value_type AlCaRecoTriggerBits::delimeter_ = ';'; // separator
+const std::string::value_type AlCaRecoTriggerBits::delimeter_ = ';';  // separator
 
 //_____________________________________________________________________
-std::string AlCaRecoTriggerBits::compose(const std::vector<std::string> &paths) const
-{
+std::string AlCaRecoTriggerBits::compose(const std::vector<std::string> &paths) const {
   std::string mergedPaths;
-  for (std::vector<std::string>::const_iterator iPath = paths.begin();
-       iPath != paths.end(); ++iPath) {
-    if (iPath != paths.begin()) mergedPaths += delimeter_;
+  for (std::vector<std::string>::const_iterator iPath = paths.begin(); iPath != paths.end(); ++iPath) {
+    if (iPath != paths.begin())
+      mergedPaths += delimeter_;
     if (iPath->find(delimeter_) != std::string::npos) {
       // What to do in CondFormats?
       // cms::Exception? std::cerr? edm::LogError?
     }
     mergedPaths += *iPath;
   }
-  
-  // Special case: DB cannot store empty strings, see e.g. 
+
+  // Special case: DB cannot store empty strings, see e.g.
   // https://hypernews.cern.ch/HyperNews/CMS/get/database/674.html ,
   // so choose delimeter_ for that - it cannot appear in a path anyway.
-  if (mergedPaths.empty()) mergedPaths = delimeter_;
+  if (mergedPaths.empty())
+    mergedPaths = delimeter_;
 
   return mergedPaths;
 }
 
 //_____________________________________________________________________
-std::vector<std::string> AlCaRecoTriggerBits::decompose(const std::string &s) const
-{
+std::vector<std::string> AlCaRecoTriggerBits::decompose(const std::string &s) const {
   // decompose 's' into its parts that are separated by 'delimeter_'
-  // (similar as in 
+  // (similar as in
   //  Alignment/CommonAlignmentAlgorithm/src/AlignmentParameterSelector.cc)
 
   std::vector<std::string> result;
@@ -42,11 +40,11 @@ std::vector<std::string> AlCaRecoTriggerBits::decompose(const std::string &s) co
     while (true) {
       const std::string::size_type delimiterPos = s.find(delimeter_, previousPos);
       if (delimiterPos == std::string::npos) {
-        result.push_back(s.substr(previousPos)); // until end
+        result.push_back(s.substr(previousPos));  // until end
         break;
       }
       result.push_back(s.substr(previousPos, delimiterPos - previousPos));
-      previousPos = delimiterPos + 1; // +1: skip delim
+      previousPos = delimiterPos + 1;  // +1: skip delim
     }
   }
 

--- a/CondFormats/HLTObjects/src/classes.h
+++ b/CondFormats/HLTObjects/src/classes.h
@@ -1,3 +1,2 @@
 #include "CondFormats/HLTObjects/interface/AlCaRecoTriggerBits.h"
 #include "CondFormats/HLTObjects/interface/HLTPrescaleTableCond.h"
-

--- a/CondFormats/HLTObjects/src/headers.h
+++ b/CondFormats/HLTObjects/src/headers.h
@@ -1,4 +1,3 @@
 #include "CondFormats/HLTObjects/src/classes.h"
 
 #include "CondFormats/External/interface/HLTPrescaleTable.h"
-

--- a/CondFormats/HLTObjects/test/testSerializationHLTObjects.cpp
+++ b/CondFormats/HLTObjects/test/testSerializationHLTObjects.cpp
@@ -2,11 +2,10 @@
 
 #include "CondFormats/HLTObjects/src/headers.h"
 
-int main()
-{
-    testSerialization<AlCaRecoTriggerBits>();
-    testSerialization<std::pair<const std::string,std::vector<unsigned int>>>();
-    //testSerialization<trigger::HLTPrescaleTableCond>(); never serialized in the old DB
+int main() {
+  testSerialization<AlCaRecoTriggerBits>();
+  testSerialization<std::pair<const std::string, std::vector<unsigned int>>>();
+  //testSerialization<trigger::HLTPrescaleTableCond>(); never serialized in the old DB
 
-    return 0;
+  return 0;
 }


### PR DESCRIPTION

Applying code-format for CMSSW category alca,db,hlt.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/305//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


