### PR TITLE
Running code-format for alca-db

### DIFF
--- a/CondFormats/GeometryObjects/interface/CSCRecoDigiParameters.h
+++ b/CondFormats/GeometryObjects/interface/CSCRecoDigiParameters.h
@@ -16,18 +16,16 @@
 #include <vector>
 
 class CSCRecoDigiParameters {
-
 public:
-  CSCRecoDigiParameters() { } 
-  ~CSCRecoDigiParameters() { }
+  CSCRecoDigiParameters() {}
+  ~CSCRecoDigiParameters() {}
 
-  std::vector<int> pUserParOffset; // where the fupars for a ch. type start in the fupars blob.
-  std::vector<int> pUserParSize; // size of the fupars.  if known, then both this and the above can go.
+  std::vector<int> pUserParOffset;  // where the fupars for a ch. type start in the fupars blob.
+  std::vector<int> pUserParSize;    // size of the fupars.  if known, then both this and the above can go.
   std::vector<int> pChamberType;
-  std::vector<float> pfupars;   // user parameters
+  std::vector<float> pfupars;  // user parameters
 
   COND_SERIALIZABLE;
 };
 
 #endif
-

--- a/CondFormats/GeometryObjects/interface/HcalParameters.h
+++ b/CondFormats/GeometryObjects/interface/HcalParameters.h
@@ -4,11 +4,9 @@
 #include "CondFormats/Serialization/interface/Serializable.h"
 
 class HcalParameters {
-
 public:
-  
-  HcalParameters( void ) { }
-  ~HcalParameters( void ) { }
+  HcalParameters(void) {}
+  ~HcalParameters(void) {}
 
   struct LayerItem {
     unsigned int layer;
@@ -18,7 +16,7 @@ public:
 
   std::vector<double> rHB;
   std::vector<double> drHB;
-  std::vector<double> zHE;    
+  std::vector<double> zHE;
   std::vector<double> dzHE;
   std::vector<double> zHO;
 
@@ -37,33 +35,33 @@ public:
   std::vector<double> etaTable;
   std::vector<double> rTable;
   std::vector<double> phibin;
-  std::vector<double> phitable;  
+  std::vector<double> phitable;
   std::vector<double> etaRange;
   std::vector<double> gparHF;
-  std::vector<double> Layer0Wt;  
+  std::vector<double> Layer0Wt;
   std::vector<double> HBGains;
   std::vector<double> HEGains;
   std::vector<double> HFGains;
   std::vector<double> etaTableHF;
-  double              dzVcal;
-  
-  std::vector<int>    maxDepth;
-  std::vector<int>    modHB;
-  std::vector<int>    modHE;
-  std::vector<int>    layHB;
-  std::vector<int>    layHE;
+  double dzVcal;
 
-  std::vector<int>    etaMin;
-  std::vector<int>    etaMax;
-  std::vector<int>    noff;
-  std::vector<int>    HBShift;
-  std::vector<int>    HEShift;
-  std::vector<int>    HFShift;
+  std::vector<int> maxDepth;
+  std::vector<int> modHB;
+  std::vector<int> modHE;
+  std::vector<int> layHB;
+  std::vector<int> layHE;
 
-  std::vector<int>    etagroup;
-  std::vector<int>    phigroup;
+  std::vector<int> etaMin;
+  std::vector<int> etaMax;
+  std::vector<int> noff;
+  std::vector<int> HBShift;
+  std::vector<int> HEShift;
+  std::vector<int> HFShift;
+
+  std::vector<int> etagroup;
+  std::vector<int> phigroup;
   std::vector<LayerItem> layerGroupEtaSim, layerGroupEtaRec;
-  int                 topologyMode;
+  int topologyMode;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/GeometryObjects/interface/PCaloGeometry.h
+++ b/CondFormats/GeometryObjects/interface/PCaloGeometry.h
@@ -6,30 +6,28 @@
 #include <vector>
 #include <cstdint>
 
-class PCaloGeometry{
-
- public:
+class PCaloGeometry {
+public:
   PCaloGeometry();
-  PCaloGeometry(std::vector<float> const & ,
-		std::vector<float> const & ,
-		std::vector<uint32_t> const &,
-		std::vector<uint32_t> const & );
-    
+  PCaloGeometry(std::vector<float> const &,
+                std::vector<float> const &,
+                std::vector<uint32_t> const &,
+                std::vector<uint32_t> const &);
+
   ~PCaloGeometry(){};
 
-  std::vector<float> const &  getTranslation() const { return m_translation; }
-  std::vector<float> const & getDimension() const { return m_dimension; }
-  std::vector<uint32_t> const & getIndexes() const { return m_indexes; }
-  std::vector<uint32_t> const & getDenseIndices() const { return m_dins; }
+  std::vector<float> const &getTranslation() const { return m_translation; }
+  std::vector<float> const &getDimension() const { return m_dimension; }
+  std::vector<uint32_t> const &getIndexes() const { return m_indexes; }
+  std::vector<uint32_t> const &getDenseIndices() const { return m_dins; }
 
- private:
-  std::vector<float>    m_translation ;
-  std::vector<float>    m_dimension   ;
-  std::vector<uint32_t> m_indexes     ;
-  std::vector<uint32_t> m_dins        ;
+private:
+  std::vector<float> m_translation;
+  std::vector<float> m_dimension;
+  std::vector<uint32_t> m_indexes;
+  std::vector<uint32_t> m_dins;
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif
-

--- a/CondFormats/GeometryObjects/interface/PGeometricDet.h
+++ b/CondFormats/GeometryObjects/interface/PGeometricDet.h
@@ -6,15 +6,14 @@
 #include <vector>
 #include <string>
 
-class PGeometricDet{
+class PGeometricDet {
+public:
+  PGeometricDet(){};
+  ~PGeometricDet(){};
 
- public:
-  PGeometricDet() { };
-  ~PGeometricDet() { };
-
-  struct Item{  
-    std::string _name; // save only the name, not the namespace.
-    std::string _ns; // save only the name, not the namespace.
+  struct Item {
+    std::string _name;  // save only the name, not the namespace.
+    std::string _ns;    // save only the name, not the namespace.
 
     double _x;
     double _y;
@@ -23,7 +22,8 @@ class PGeometricDet{
     double _rho;
     // fill as you will but intent is rotation matrix A where first number is row and second number is column
     double _a11, _a12, _a13, _a21, _a22, _a23, _a31, _a32, _a33;
-    double _params0,_params1,_params2,_params3,_params4,_params5,_params6,_params7,_params8,_params9,_params10;
+    double _params0, _params1, _params2, _params3, _params4, _params5, _params6, _params7, _params8, _params9,
+        _params10;
     double _radLength;
     double _xi;
     double _pixROCRows;
@@ -31,27 +31,25 @@ class PGeometricDet{
     double _pixROCx;
     double _pixROCy;
     double _siliconAPVNum;
-    
-    int _level; // goes like 1, 2, 3, 4, 4, 4, 3, 4, 4, 3, 4, 4, 4, 1, 2, 3, etc.
+
+    int _level;  // goes like 1, 2, 3, 4, 4, 4, 3, 4, 4, 3, 4, 4, 4, 1, 2, 3, etc.
     int _shape;
     //  nav_type _ddd; DO NOT SAVE!
     //  DDName _ddname; DO NOT SAVE!
     int _type;
 
     int _numnt;
-    int _nt0, _nt1, _nt2, _nt3, _nt4, _nt5, _nt6 , _nt7, _nt8, _nt9, _nt10;
-    
-    int _geographicalID; // to be converted to DetId
+    int _nt0, _nt1, _nt2, _nt3, _nt4, _nt5, _nt6, _nt7, _nt8, _nt9, _nt10;
+
+    int _geographicalID;  // to be converted to DetId
     bool _stereo;
-  
-  COND_SERIALIZABLE;
-};
+
+    COND_SERIALIZABLE;
+  };
 
   std::vector<Item> pgeomdets_;
 
-
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif
-

--- a/CondFormats/GeometryObjects/interface/PGeometricDetExtra.h
+++ b/CondFormats/GeometryObjects/interface/PGeometricDetExtra.h
@@ -6,30 +6,27 @@
 #include <vector>
 #include <string>
 
-class PGeometricDetExtra{
+class PGeometricDetExtra {
+public:
+  PGeometricDetExtra(){};
+  ~PGeometricDetExtra(){};
 
- public:
-  PGeometricDetExtra() { };
-  ~PGeometricDetExtra() { };
-
-  struct Item{  
-    int _geographicalId; // to be converted to DetId
+  struct Item {
+    int _geographicalId;  // to be converted to DetId
     //  std::vector< DDExpandedNode > _parents; DO NOT SAVE!
     //GeoHistory _parents;
     double _volume;
     double _density;
     double _weight;
-    int    _copy;
+    int _copy;
     std::string _material;
-  
-  COND_SERIALIZABLE;
-};
+
+    COND_SERIALIZABLE;
+  };
 
   std::vector<Item> pgdes_;
 
-
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif
-

--- a/CondFormats/GeometryObjects/interface/PGeometricTimingDet.h
+++ b/CondFormats/GeometryObjects/interface/PGeometricTimingDet.h
@@ -6,15 +6,14 @@
 #include <vector>
 #include <string>
 
-class PGeometricTimingDet{
+class PGeometricTimingDet {
+public:
+  PGeometricTimingDet(){};
+  ~PGeometricTimingDet(){};
 
- public:
-  PGeometricTimingDet() { };
-  ~PGeometricTimingDet() { };
-
-  struct Item{  
-    std::string name_; // save only the name, not the namespace.
-    std::string ns_; // save only the name, not the namespace.
+  struct Item {
+    std::string name_;  // save only the name, not the namespace.
+    std::string ns_;    // save only the name, not the namespace.
 
     double x_;
     double y_;
@@ -23,7 +22,8 @@ class PGeometricTimingDet{
     double rho_;
     // fill as you will but intent is rotation matrix A where first number is row and second number is column
     double a11_, a12_, a13_, a21_, a22_, a23_, a31_, a32_, a33_;
-    double params_0,params_1,params_2,params_3,params_4,params_5,params_6,params_7,params_8,params_9,params_10;
+    double params_0, params_1, params_2, params_3, params_4, params_5, params_6, params_7, params_8, params_9,
+        params_10;
     double radLength_;
     double xi_;
     double pixROCRows_;
@@ -31,8 +31,8 @@ class PGeometricTimingDet{
     double pixROCx_;
     double pixROCy_;
     double siliconAPVNum_;
-    
-    int level_; // goes like 1, 2, 3, 4, 4, 4, 3, 4, 4, 3, 4, 4, 4, 1, 2, 3, etc.
+
+    int level_;  // goes like 1, 2, 3, 4, 4, 4, 3, 4, 4, 3, 4, 4, 4, 1, 2, 3, etc.
     int shape_;
     //  nav_type _ddd; DO NOT SAVE!
     //  DDName _ddname; DO NOT SAVE!
@@ -40,18 +40,16 @@ class PGeometricTimingDet{
 
     int numnt_;
     int nt0_, nt1_, nt2_, nt3_, nt4_, nt5_, nt6_, nt7_, nt8_, nt9_, nt10_;
-    
-    int geographicalID_; // to be converted to DetId
+
+    int geographicalID_;  // to be converted to DetId
     bool stereo_;
-  
-  COND_SERIALIZABLE;
-};
+
+    COND_SERIALIZABLE;
+  };
 
   std::vector<Item> pgeomdets_;
 
-
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif
-

--- a/CondFormats/GeometryObjects/interface/PGeometricTimingDetExtra.h
+++ b/CondFormats/GeometryObjects/interface/PGeometricTimingDetExtra.h
@@ -6,30 +6,27 @@
 #include <vector>
 #include <string>
 
-class PGeometricTimingDetExtra{
+class PGeometricTimingDetExtra {
+public:
+  PGeometricTimingDetExtra(){};
+  ~PGeometricTimingDetExtra(){};
 
- public:
-  PGeometricTimingDetExtra() { };
-  ~PGeometricTimingDetExtra() { };
-
-  struct Item{  
-    int geographicalId_; // to be converted to DetId
+  struct Item {
+    int geographicalId_;  // to be converted to DetId
     //  std::vector< DDExpandedNode > parents_; DO NOT SAVE!
     //GeoHistory _parents;
     double volume_;
     double density_;
     double weight_;
-    int    copy_;
+    int copy_;
     std::string material_;
-  
-  COND_SERIALIZABLE;
-};
+
+    COND_SERIALIZABLE;
+  };
 
   std::vector<Item> pgdes_;
 
-
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif
-

--- a/CondFormats/GeometryObjects/interface/PHGCalParameters.h
+++ b/CondFormats/GeometryObjects/interface/PHGCalParameters.h
@@ -7,70 +7,68 @@
 #include <unordered_map>
 
 class PHGCalParameters {
-
 public:
+  PHGCalParameters(void) {}
+  ~PHGCalParameters(void) {}
 
-  PHGCalParameters( void ) {}
-  ~PHGCalParameters( void ) {}
+  std::string name_;
+  std::vector<double> cellSize_;
+  std::vector<double> moduleBlS_;
+  std::vector<double> moduleTlS_;
+  std::vector<double> moduleHS_;
+  std::vector<double> moduleDzS_;
+  std::vector<double> moduleAlphaS_;
+  std::vector<double> moduleCellS_;
+  std::vector<double> moduleBlR_;
+  std::vector<double> moduleTlR_;
+  std::vector<double> moduleHR_;
+  std::vector<double> moduleDzR_;
+  std::vector<double> moduleAlphaR_;
+  std::vector<double> moduleCellR_;
+  std::vector<double> trformTranX_;
+  std::vector<double> trformTranY_;
+  std::vector<double> trformTranZ_;
+  std::vector<double> trformRotXX_;
+  std::vector<double> trformRotYX_;
+  std::vector<double> trformRotZX_;
+  std::vector<double> trformRotXY_;
+  std::vector<double> trformRotYY_;
+  std::vector<double> trformRotZY_;
+  std::vector<double> trformRotXZ_;
+  std::vector<double> trformRotYZ_;
+  std::vector<double> trformRotZZ_;
+  std::vector<double> zLayerHex_;
+  std::vector<double> rMinLayHex_;
+  std::vector<double> rMaxLayHex_;
+  std::vector<double> waferPosX_;
+  std::vector<double> waferPosY_;
+  std::vector<double> cellFineX_;
+  std::vector<double> cellFineY_;
+  std::vector<double> cellCoarseX_;
+  std::vector<double> cellCoarseY_;
+  std::vector<double> boundR_;
+  std::vector<int> moduleLayS_;
+  std::vector<int> moduleLayR_;
+  std::vector<int> layer_;
+  std::vector<int> layerIndex_;
+  std::vector<int> layerGroup_;
+  std::vector<int> cellFactor_;
+  std::vector<int> depth_;
+  std::vector<int> depthIndex_;
+  std::vector<int> depthLayerF_;
+  std::vector<int> waferCopy_;
+  std::vector<int> waferTypeL_;
+  std::vector<int> waferTypeT_;
+  std::vector<int> layerGroupM_;
+  std::vector<int> layerGroupO_;
+  std::vector<uint32_t> trformIndex_;
+  double waferR_;
+  std::vector<double> slopeMin_;
+  int nCells_;
+  int nSectors_;
+  int mode_;
+  std::vector<std::unordered_map<uint32_t, uint32_t> > copiesInLayers_;
 
-  std::string              name_;
-  std::vector<double>      cellSize_;
-  std::vector<double>      moduleBlS_;
-  std::vector<double>      moduleTlS_;
-  std::vector<double>      moduleHS_;
-  std::vector<double>      moduleDzS_;
-  std::vector<double>      moduleAlphaS_;
-  std::vector<double>      moduleCellS_;
-  std::vector<double>      moduleBlR_;
-  std::vector<double>      moduleTlR_;
-  std::vector<double>      moduleHR_;
-  std::vector<double>      moduleDzR_;
-  std::vector<double>      moduleAlphaR_;
-  std::vector<double>      moduleCellR_;
-  std::vector<double>      trformTranX_;
-  std::vector<double>      trformTranY_;
-  std::vector<double>      trformTranZ_;
-  std::vector<double>      trformRotXX_;
-  std::vector<double>      trformRotYX_;
-  std::vector<double>      trformRotZX_;
-  std::vector<double>      trformRotXY_;
-  std::vector<double>      trformRotYY_;
-  std::vector<double>      trformRotZY_;
-  std::vector<double>      trformRotXZ_;
-  std::vector<double>      trformRotYZ_;
-  std::vector<double>      trformRotZZ_;
-  std::vector<double>      zLayerHex_;
-  std::vector<double>      rMinLayHex_;
-  std::vector<double>      rMaxLayHex_;
-  std::vector<double>      waferPosX_;
-  std::vector<double>      waferPosY_;
-  std::vector<double>      cellFineX_;
-  std::vector<double>      cellFineY_;
-  std::vector<double>      cellCoarseX_;
-  std::vector<double>      cellCoarseY_;
-  std::vector<double>      boundR_;
-  std::vector<int>         moduleLayS_;
-  std::vector<int>         moduleLayR_;
-  std::vector<int>         layer_;
-  std::vector<int>         layerIndex_;
-  std::vector<int>         layerGroup_;
-  std::vector<int>         cellFactor_; 
-  std::vector<int>         depth_;
-  std::vector<int>         depthIndex_;
-  std::vector<int>         depthLayerF_;
-  std::vector<int>         waferCopy_;
-  std::vector<int>         waferTypeL_;
-  std::vector<int>         waferTypeT_;
-  std::vector<int>         layerGroupM_;
-  std::vector<int>         layerGroupO_;
-  std::vector<uint32_t>    trformIndex_;
-  double                   waferR_;
-  std::vector<double>      slopeMin_;
-  int                      nCells_;
-  int                      nSectors_;
-  int                      mode_;
-  std::vector< std::unordered_map<uint32_t, uint32_t> > copiesInLayers_;
-  
   COND_SERIALIZABLE;
 };
 

--- a/CondFormats/GeometryObjects/interface/PMTDParameters.h
+++ b/CondFormats/GeometryObjects/interface/PMTDParameters.h
@@ -3,24 +3,22 @@
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-class PMTDParameters
-{
- public:
-  PMTDParameters( void ) { } 
-  ~PMTDParameters( void ) { }
+class PMTDParameters {
+public:
+  PMTDParameters(void) {}
+  ~PMTDParameters(void) {}
 
-  struct Item
-  {
+  struct Item {
     int id_;
     std::vector<int> vpars_;
-    
+
     COND_SERIALIZABLE;
   };
 
   std::vector<Item> vitems_;
   std::vector<int> vpars_;
   int topologyMode_;
-  
+
   COND_SERIALIZABLE;
 };
 

--- a/CondFormats/GeometryObjects/interface/PTrackerParameters.h
+++ b/CondFormats/GeometryObjects/interface/PTrackerParameters.h
@@ -3,23 +3,21 @@
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
-class PTrackerParameters
-{
- public:
-  PTrackerParameters( void ) { } 
-  ~PTrackerParameters( void ) { }
+class PTrackerParameters {
+public:
+  PTrackerParameters(void) {}
+  ~PTrackerParameters(void) {}
 
-  struct Item
-  {
+  struct Item {
     int id;
     std::vector<int> vpars;
-    
+
     COND_SERIALIZABLE;
   };
 
   std::vector<Item> vitems;
   std::vector<int> vpars;
-  
+
   COND_SERIALIZABLE;
 };
 

--- a/CondFormats/GeometryObjects/interface/RecoIdealGeometry.h
+++ b/CondFormats/GeometryObjects/interface/RecoIdealGeometry.h
@@ -26,107 +26,99 @@
  */
 
 class RecoIdealGeometry {
- public:
+public:
+  RecoIdealGeometry() {}
+  ~RecoIdealGeometry() {}
 
-  RecoIdealGeometry() { }
-  ~RecoIdealGeometry() { }
-
-  bool insert( DetId id, const std::vector<double>& trans, const std::vector<double>& rot, const std::vector<double>& pars ) {
-    if ( trans.size() != 3 || rot.size() != 9 ) return false;
+  bool insert(DetId id,
+              const std::vector<double>& trans,
+              const std::vector<double>& rot,
+              const std::vector<double>& pars) {
+    if (trans.size() != 3 || rot.size() != 9)
+      return false;
     pDetIds.push_back(id);
-    pNumShapeParms.push_back(pars.size()); // number of shape specific parameters.
-    pParsIndex.push_back(pPars.size()); // start of this guys "blob"
+    pNumShapeParms.push_back(pars.size());  // number of shape specific parameters.
+    pParsIndex.push_back(pPars.size());     // start of this guys "blob"
     pPars.reserve(pPars.size() + trans.size() + rot.size() + pars.size());
-    std::copy ( trans.begin(), trans.end(), std::back_inserter(pPars));
-    std::copy ( rot.begin(), rot.end(), std::back_inserter(pPars));
-    std::copy ( pars.begin(), pars.end(), std::back_inserter(pPars));
+    std::copy(trans.begin(), trans.end(), std::back_inserter(pPars));
+    std::copy(rot.begin(), rot.end(), std::back_inserter(pPars));
+    std::copy(pars.begin(), pars.end(), std::back_inserter(pPars));
     return true;
   }
 
-  bool insert( DetId id, const std::vector<double>& trans, const std::vector<double>& rot, const std::vector<double>& pars, const std::vector<std::string>& spars ) {
-    if ( trans.size() != 3 || rot.size() != 9 ) return false;
+  bool insert(DetId id,
+              const std::vector<double>& trans,
+              const std::vector<double>& rot,
+              const std::vector<double>& pars,
+              const std::vector<std::string>& spars) {
+    if (trans.size() != 3 || rot.size() != 9)
+      return false;
     pDetIds.push_back(id);
-    pNumShapeParms.push_back(pars.size()); // number of shape specific parameters.
-    pParsIndex.push_back(pPars.size()); // start of this guys "blob"
+    pNumShapeParms.push_back(pars.size());  // number of shape specific parameters.
+    pParsIndex.push_back(pPars.size());     // start of this guys "blob"
     pPars.reserve(pPars.size() + trans.size() + rot.size() + pars.size());
-    std::copy ( trans.begin(), trans.end(), std::back_inserter(pPars));
-    std::copy ( rot.begin(), rot.end(), std::back_inserter(pPars));
-    std::copy ( pars.begin(), pars.end(), std::back_inserter(pPars));
+    std::copy(trans.begin(), trans.end(), std::back_inserter(pPars));
+    std::copy(rot.begin(), rot.end(), std::back_inserter(pPars));
+    std::copy(pars.begin(), pars.end(), std::back_inserter(pPars));
 
     sNumsParms.push_back(spars.size());
     sParsIndex.push_back(strPars.size());
-    strPars.reserve(strPars.size()+spars.size());
-    std::copy ( spars.begin(), spars.end(), std::back_inserter(strPars));
+    strPars.reserve(strPars.size() + spars.size());
+    std::copy(spars.begin(), spars.end(), std::back_inserter(strPars));
     return true;
   }
 
-  size_t size() { 
-    assert ( (pDetIds.size() == pNumShapeParms.size()) && (pNumShapeParms.size() == pParsIndex.size()) );
-    return pDetIds.size(); 
+  size_t size() {
+    assert((pDetIds.size() == pNumShapeParms.size()) && (pNumShapeParms.size() == pParsIndex.size()));
+    return pDetIds.size();
   }
 
   // HOW to use this stuff... first, get hold of the reference to the detIds like:
   // const std::vector<double>& myds = classofthistype.detIds()
-  // Then iterate over the detIds using 
-  // for ( size_t it = 0 ; it < myds.size(); ++it ) 
+  // Then iterate over the detIds using
+  // for ( size_t it = 0 ; it < myds.size(); ++it )
   // and ask for the parts ...
   // {
   //   std::vector<double>::const_iterator xyzB = classofthistype.transStart(it);
   //   std::vector<double>::const_iterator xyzE = classofthistype.transEnd(it);
   // }
-  const std::vector<DetId>& detIds () const {
-    return pDetIds;
-  }
+  const std::vector<DetId>& detIds() const { return pDetIds; }
 
-  std::vector<double>::const_iterator tranStart( size_t ind ) const { 
-     return pPars.begin() + pParsIndex[ind]; 
-  }
+  std::vector<double>::const_iterator tranStart(size_t ind) const { return pPars.begin() + pParsIndex[ind]; }
 
-  std::vector<double>::const_iterator tranEnd ( size_t ind ) const { 
-     return pPars.begin() + pParsIndex[ind] + 3; 
-  }
+  std::vector<double>::const_iterator tranEnd(size_t ind) const { return pPars.begin() + pParsIndex[ind] + 3; }
 
-  std::vector<double>::const_iterator rotStart ( size_t ind ) const {
-    return pPars.begin() + pParsIndex[ind] + 3;
-  }
+  std::vector<double>::const_iterator rotStart(size_t ind) const { return pPars.begin() + pParsIndex[ind] + 3; }
 
-  std::vector<double>::const_iterator rotEnd ( size_t ind ) const {
-    return pPars.begin() + pParsIndex[ind] + 3 + 9;
-  }
+  std::vector<double>::const_iterator rotEnd(size_t ind) const { return pPars.begin() + pParsIndex[ind] + 3 + 9; }
 
-  std::vector<double>::const_iterator shapeStart ( size_t ind ) const {
-    return pPars.begin() + pParsIndex[ind] + 3 + 9;
-  }
+  std::vector<double>::const_iterator shapeStart(size_t ind) const { return pPars.begin() + pParsIndex[ind] + 3 + 9; }
 
-  std::vector<double>::const_iterator shapeEnd ( size_t ind ) const {
+  std::vector<double>::const_iterator shapeEnd(size_t ind) const {
     return pPars.begin() + pParsIndex[ind] + 3 + 9 + pNumShapeParms[ind];
   }
 
-  std::vector<std::string>::const_iterator strStart ( size_t ind ) const {
-    return strPars.begin() + sParsIndex[ind];
-  }
+  std::vector<std::string>::const_iterator strStart(size_t ind) const { return strPars.begin() + sParsIndex[ind]; }
 
-  std::vector<std::string>::const_iterator strEnd ( size_t ind ) const {
+  std::vector<std::string>::const_iterator strEnd(size_t ind) const {
     return strPars.begin() + sParsIndex[ind] + sNumsParms[ind];
   }
 
-
- private:    
+private:
   // translation always 3; rotation 9 for now; pars depends on shape_type.
   std::vector<DetId> pDetIds;
 
   std::vector<double> pPars;  // trans, rot then shape parms.
   // 0 for first pDetId, 3 + 9 + number of shape parameters for second & etc.
   // just save pPars size BEFORE adding next stuff.
-  std::vector<int> pParsIndex; 
-  std::vector<int> pNumShapeParms; // save the number of shape parameters.
+  std::vector<int> pParsIndex;
+  std::vector<int> pNumShapeParms;  // save the number of shape parameters.
 
   std::vector<std::string> strPars;
   std::vector<int> sParsIndex;
   std::vector<int> sNumsParms;
 
- COND_SERIALIZABLE;
+  COND_SERIALIZABLE;
 };
 
 #endif
-

--- a/CondFormats/GeometryObjects/src/PCaloGeometry.cc
+++ b/CondFormats/GeometryObjects/src/PCaloGeometry.cc
@@ -1,14 +1,10 @@
 #include "CondFormats/GeometryObjects/interface/PCaloGeometry.h"
 #include <iostream>
 
-PCaloGeometry::PCaloGeometry(){}
+PCaloGeometry::PCaloGeometry() {}
 
-PCaloGeometry::PCaloGeometry( std::vector<float>    const & tra ,
-			      std::vector<float>    const & dim , 
-			      std::vector<uint32_t> const & ind , 
-			      std::vector<uint32_t> const & din  ) :
-  m_translation(tra),
-  m_dimension(dim),
-  m_indexes(ind),
-  m_dins(din) {}
-
+PCaloGeometry::PCaloGeometry(std::vector<float> const& tra,
+                             std::vector<float> const& dim,
+                             std::vector<uint32_t> const& ind,
+                             std::vector<uint32_t> const& din)
+    : m_translation(tra), m_dimension(dim), m_indexes(ind), m_dins(din) {}

--- a/CondFormats/GeometryObjects/src/T_EventSetup_PCaloGeometry.cc
+++ b/CondFormats/GeometryObjects/src/T_EventSetup_PCaloGeometry.cc
@@ -2,4 +2,3 @@
 #include "FWCore/Utilities/interface/typelookup.h"
 
 TYPELOOKUP_DATA_REG(PCaloGeometry);
-

--- a/CondFormats/GeometryObjects/src/T_EventSetup_PGeometricDet.cc
+++ b/CondFormats/GeometryObjects/src/T_EventSetup_PGeometricDet.cc
@@ -2,4 +2,3 @@
 #include "FWCore/Utilities/interface/typelookup.h"
 
 TYPELOOKUP_DATA_REG(PGeometricDet);
-

--- a/CondFormats/GeometryObjects/src/T_EventSetup_PGeometricDetExtra.cc
+++ b/CondFormats/GeometryObjects/src/T_EventSetup_PGeometricDetExtra.cc
@@ -2,4 +2,3 @@
 #include "FWCore/Utilities/interface/typelookup.h"
 
 TYPELOOKUP_DATA_REG(PGeometricDetExtra);
-

--- a/CondFormats/GeometryObjects/src/T_EventSetup_PGeometricTimingDet.cc
+++ b/CondFormats/GeometryObjects/src/T_EventSetup_PGeometricTimingDet.cc
@@ -2,4 +2,3 @@
 #include "FWCore/Utilities/interface/typelookup.h"
 
 TYPELOOKUP_DATA_REG(PGeometricTimingDet);
-

--- a/CondFormats/GeometryObjects/src/T_EventSetup_PGeometricTimingDetExtra.cc
+++ b/CondFormats/GeometryObjects/src/T_EventSetup_PGeometricTimingDetExtra.cc
@@ -2,4 +2,3 @@
 #include "FWCore/Utilities/interface/typelookup.h"
 
 TYPELOOKUP_DATA_REG(PGeometricTimingDetExtra);
-

--- a/CondFormats/GeometryObjects/src/classes.h
+++ b/CondFormats/GeometryObjects/src/classes.h
@@ -9,4 +9,3 @@
 #include "CondFormats/GeometryObjects/interface/PMTDParameters.h"
 #include "CondFormats/GeometryObjects/interface/HcalParameters.h"
 #include "CondFormats/GeometryObjects/interface/PHGCalParameters.h"
-

--- a/CondFormats/GeometryObjects/test/testSerializationGeometryObjects.cpp
+++ b/CondFormats/GeometryObjects/test/testSerializationGeometryObjects.cpp
@@ -2,22 +2,21 @@
 
 #include "CondFormats/GeometryObjects/src/headers.h"
 
-int main()
-{
-    testSerialization<CSCRecoDigiParameters>();
-    testSerialization<PCaloGeometry>();
-    testSerialization<PGeometricDet>();
-    //testSerialization<PGeometricDet::Item>(); has uninitialized booleans
-    testSerialization<PGeometricDetExtra>();
-    testSerialization<PGeometricDetExtra::Item>();
-    testSerialization<RecoIdealGeometry>();
-    testSerialization<std::vector<PGeometricDet::Item>>();
-    testSerialization<std::vector<PGeometricDetExtra::Item>>();
-    testSerialization<PTrackerParameters>();
-    testSerialization<PTrackerParameters::Item>();
-    testSerialization<HcalParameters>();
-    testSerialization<PHGCalParameters>();
-    testSerialization<PMTDParameters>();
+int main() {
+  testSerialization<CSCRecoDigiParameters>();
+  testSerialization<PCaloGeometry>();
+  testSerialization<PGeometricDet>();
+  //testSerialization<PGeometricDet::Item>(); has uninitialized booleans
+  testSerialization<PGeometricDetExtra>();
+  testSerialization<PGeometricDetExtra::Item>();
+  testSerialization<RecoIdealGeometry>();
+  testSerialization<std::vector<PGeometricDet::Item>>();
+  testSerialization<std::vector<PGeometricDetExtra::Item>>();
+  testSerialization<PTrackerParameters>();
+  testSerialization<PTrackerParameters::Item>();
+  testSerialization<HcalParameters>();
+  testSerialization<PHGCalParameters>();
+  testSerialization<PMTDParameters>();
 
-    return 0;
+  return 0;
 }


### PR DESCRIPTION

Applying code-format for CMSSW category alca,db.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/304//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


