### PR TITLE
Running code-format for reconstruction

### DIFF
--- a/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelDataFormatter.h
+++ b/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelDataFormatter.h
@@ -32,9 +32,9 @@
  */
 //
 
-#include "DataFormats/CTPPSDigi/interface/CTPPSPixelDigi.h" 
-#include "DataFormats/CTPPSDigi/interface/CTPPSPixelDataError.h" 
-#include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelDAQMapping.h" 
+#include "DataFormats/CTPPSDigi/interface/CTPPSPixelDigi.h"
+#include "DataFormats/CTPPSDigi/interface/CTPPSPixelDataError.h"
+#include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelDAQMapping.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 
 #include "EventFilter/CTPPSRawToDigi/interface/RPixErrorChecker.h"
@@ -47,9 +47,7 @@ class FEDRawData;
 class RPixErrorChecker;
 
 class CTPPSPixelDataFormatter {
-
 public:
-
   typedef edm::DetSetVector<CTPPSPixelDigi> Collection;
 
   typedef std::map<int, FEDRawData> RawData;
@@ -61,19 +59,15 @@ public:
   typedef uint32_t Word32;
   typedef uint64_t Word64;
 
-  CTPPSPixelDataFormatter(std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo> const &mapping);
+  CTPPSPixelDataFormatter(std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo> const& mapping);
 
   void setErrorStatus(bool theErrorStatus);
 
   int nWords() const { return m_WordCounter; }
 
-  void interpretRawData( bool& errorsInEvent, int fedId,  const FEDRawData & data, Collection & digis, Errors & errors);
-
-
+  void interpretRawData(bool& errorsInEvent, int fedId, const FEDRawData& data, Collection& digis, Errors& errors);
 
 private:
-
-
   mutable int m_WordCounter;
 
   bool m_IncludeErrors;
@@ -81,14 +75,12 @@ private:
 
   int m_ADC_shift, m_PXID_shift, m_DCOL_shift, m_ROC_shift, m_LINK_shift;
   Word32 m_LINK_mask, m_ROC_mask, m_DCOL_mask, m_PXID_mask, m_ADC_mask;
-  
 
   int checkError(const Word32& data) const;
 
   std::string print(const Word64& word) const;
 
-  const std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo> &m_Mapping;
-
+  const std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo>& m_Mapping;
 };
 
 #endif

--- a/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelRawToDigi.h
+++ b/EventFilter/CTPPSRawToDigi/interface/CTPPSPixelRawToDigi.h
@@ -18,29 +18,26 @@
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
-
 class CTPPSPixelRawToDigi : public edm::stream::EDProducer<> {
 public:
-
-  explicit CTPPSPixelRawToDigi( const edm::ParameterSet& );
+  explicit CTPPSPixelRawToDigi(const edm::ParameterSet&);
 
   ~CTPPSPixelRawToDigi() override;
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
   /// get data, convert to digis attach againe to Event
-  void produce( edm::Event&, const edm::EventSetup& ) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
-
   edm::ParameterSet config_;
 
-  edm::EDGetTokenT<FEDRawDataCollection> FEDRawDataCollection_; 
+  edm::EDGetTokenT<FEDRawDataCollection> FEDRawDataCollection_;
 
   std::set<unsigned int> fedIds_;
 
   edm::InputTag label_;
- 
+
   std::string mappingLabel_;
 
   bool includeErrors_;

--- a/EventFilter/CTPPSRawToDigi/interface/CounterChecker.h
+++ b/EventFilter/CTPPSRawToDigi/interface/CounterChecker.h
@@ -25,87 +25,84 @@
  *\brief Class for finding the most popular both EC and BC counter, and filling the conversion
  * status 'wrong EC/BC number' for frames with different value.
  */
-class CounterChecker 
-{
-  public:
-    typedef unsigned short word;
+class CounterChecker {
+public:
+  typedef unsigned short word;
 
-    typedef std::map<word, std::vector<TotemFramePosition> > CounterMap;
+  typedef std::map<word, std::vector<TotemFramePosition> > CounterMap;
 
-    enum CheckerType {BCChecker, ECChecker};
-  
-    /**
+  enum CheckerType { BCChecker, ECChecker };
+
+  /**
      * \param t: CounterChecker::ECCounter or CounterChecker::BCCounter. On that, depends whether
      * checker will fill wrong EC or BC rogress error.
      * \param name: name
      * \param min: minimal required number of frames to search for the most frequent one
      */
-    CounterChecker(CheckerType _type = CounterChecker::BCChecker, const std::string &_name="",
-      unsigned int _min=0, double _fraction=0., unsigned int _verbosity=0) : type(_type),
-      name(_name), min(_min), fraction(_fraction), verbosity(_verbosity) {}
+  CounterChecker(CheckerType _type = CounterChecker::BCChecker,
+                 const std::string &_name = "",
+                 unsigned int _min = 0,
+                 double _fraction = 0.,
+                 unsigned int _verbosity = 0)
+      : type(_type), name(_name), min(_min), fraction(_fraction), verbosity(_verbosity) {}
 
-    /// add new value to map, counter takes value of EC or BC number
-    void Fill(word counter, TotemFramePosition fr);
+  /// add new value to map, counter takes value of EC or BC number
+  void Fill(word counter, TotemFramePosition fr);
 
-    /// summarizes and fill the status (wrong EC and BC progress error for some frames)
-    template<typename T>
-    void Analyze(T &status, bool error, std::ostream &es);
-  
-  private:
-    class Comparer
-    {
-      public:
-        typedef unsigned short word;
-        bool operator()(const std::pair<word, std::vector<TotemFramePosition> > &a, const std::pair<word, std::vector<TotemFramePosition> > &b)
-        {
-          return a.second.size() < b.second.size();
-        }
-    };  
+  /// summarizes and fill the status (wrong EC and BC progress error for some frames)
+  template <typename T>
+  void Analyze(T &status, bool error, std::ostream &es);
 
-    /// counter value -> list of frames with this value
-    CounterMap relationMap;
+private:
+  class Comparer {
+  public:
+    typedef unsigned short word;
+    bool operator()(const std::pair<word, std::vector<TotemFramePosition> > &a,
+                    const std::pair<word, std::vector<TotemFramePosition> > &b) {
+      return a.second.size() < b.second.size();
+    }
+  };
 
-    /// EC or BC counter checker
-    CheckerType type;
+  /// counter value -> list of frames with this value
+  CounterMap relationMap;
 
-    /// the name of this check, used in error messages
-    std::string name;
+  /// EC or BC counter checker
+  CheckerType type;
 
-    /// minimal required number of frames to search for the most frequent one
-    unsigned int min;
-  
-    /// the most frequent value is accepted only provided its sub-sample size is greater than the
-    /// specified fraction of the full sample
-    double fraction;
-  
-    /// level of verbosity
-    unsigned int verbosity;
+  /// the name of this check, used in error messages
+  std::string name;
+
+  /// minimal required number of frames to search for the most frequent one
+  unsigned int min;
+
+  /// the most frequent value is accepted only provided its sub-sample size is greater than the
+  /// specified fraction of the full sample
+  double fraction;
+
+  /// level of verbosity
+  unsigned int verbosity;
 };
 
 //-------------------------------------------------------------------------------------------------
 
-template<typename T>
-void CounterChecker::Analyze(T &status, bool error, std::ostream &es) 
-{
+template <typename T>
+void CounterChecker::Analyze(T &status, bool error, std::ostream &es) {
   word mostFrequentCounter = 0;
   word mostFrequentSize = 0;
   unsigned int totalFrames = 0;
 
   // finding the most frequent counter
-  for (CounterMap::iterator iter = relationMap.begin(); iter != relationMap.end(); iter++)
-  {
+  for (CounterMap::iterator iter = relationMap.begin(); iter != relationMap.end(); iter++) {
     unsigned int iterSize = iter->second.size();
     totalFrames += iterSize;
 
-    if (iterSize > mostFrequentSize)
-    {
+    if (iterSize > mostFrequentSize) {
       mostFrequentCounter = iter->first;
       mostFrequentSize = iter->second.size();
     }
   }
 
-  if (totalFrames < min)
-  {
+  if (totalFrames < min) {
     if (verbosity > 0)
       es << "Too few frames to determine the most frequent " << name << " value.";
 
@@ -113,31 +110,26 @@ void CounterChecker::Analyze(T &status, bool error, std::ostream &es)
   }
 
   // if there are too few frames with the most frequent value
-  if ((float)mostFrequentSize/(float)totalFrames < fraction)
-  {
+  if ((float)mostFrequentSize / (float)totalFrames < fraction) {
     if (verbosity > 0)
       es << "The most frequent " << name << " value is doubtful - variance is too high.";
 
     return;
   }
 
-  for (CounterMap::iterator iter = relationMap.begin(); iter != relationMap.end(); iter++)
-  {
-    if (iter->first != mostFrequentCounter)
-    {
-      for (std::vector<TotemFramePosition>::iterator fr = iter->second.begin(); fr !=  iter->second.end(); fr++)
-      {
-        if (error)
-        {
-          if (type == ECChecker) 
+  for (CounterMap::iterator iter = relationMap.begin(); iter != relationMap.end(); iter++) {
+    if (iter->first != mostFrequentCounter) {
+      for (std::vector<TotemFramePosition>::iterator fr = iter->second.begin(); fr != iter->second.end(); fr++) {
+        if (error) {
+          if (type == ECChecker)
             status[*fr].status.setECProgressError();
-          if (type == BCChecker) 
-            status[*fr].status.setBCProgressError();    
+          if (type == BCChecker)
+            status[*fr].status.setBCProgressError();
         }
 
         if (verbosity > 0)
           es << "Frame at " << *fr << ": " << name << " number " << iter->first
-            << " is different from the most frequent one " << mostFrequentCounter << std::endl;
+             << " is different from the most frequent one " << mostFrequentCounter << std::endl;
       }
     }
   }

--- a/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/DiamondVFATFrame.h
@@ -14,50 +14,36 @@
 #include <cstddef>
 #include <cstdint>
 
-#include "EventFilter/CTPPSRawToDigi/interface/VFATFrame.h" 
-
+#include "EventFilter/CTPPSRawToDigi/interface/VFATFrame.h"
 
 /** 
  * This class intended to handle the timing infromation of diamond VFAT frame
 **/
-class DiamondVFATFrame : public VFATFrame
-{
-  
-  public:
-    DiamondVFATFrame(const word* inputData = nullptr)
-    {}
-    ~DiamondVFATFrame() override {}
+class DiamondVFATFrame : public VFATFrame {
+public:
+  DiamondVFATFrame(const word* inputData = nullptr) {}
+  ~DiamondVFATFrame() override {}
 
-    /// get timing infromation
-    uint32_t getLeadingEdgeTime() const
-    {
-      uint32_t time = ((data[7]&0x1f)<<16)+data[8];
-      time = (time & 0xFFE7FFFF) << 2 | (time & 0x00180000) >> 19;    //HPTDC inperpolation bits are MSB but should be LSB.... ask HPTDC designers...
-      return time;     
-    }
+  /// get timing infromation
+  uint32_t getLeadingEdgeTime() const {
+    uint32_t time = ((data[7] & 0x1f) << 16) + data[8];
+    time = (time & 0xFFE7FFFF) << 2 |
+           (time & 0x00180000) >> 19;  //HPTDC inperpolation bits are MSB but should be LSB.... ask HPTDC designers...
+    return time;
+  }
 
-    uint32_t getTrailingEdgeTime() const
-    {
-      uint32_t time = ((data[5]&0x1f)<<16)+data[6];
-      time = (time & 0xFFE7FFFF) << 2 | (time & 0x00180000) >> 19;   //HPTDC inperpolation bits are MSB but should be LSB.... ask HPTDC designers...
-      return time;
-    }
-    
-    uint32_t getThresholdVoltage() const
-    {
-      return ((data[3]&0x7ff)<<16)+data[4];
-    }
+  uint32_t getTrailingEdgeTime() const {
+    uint32_t time = ((data[5] & 0x1f) << 16) + data[6];
+    time = (time & 0xFFE7FFFF) << 2 |
+           (time & 0x00180000) >> 19;  //HPTDC inperpolation bits are MSB but should be LSB.... ask HPTDC designers...
+    return time;
+  }
 
-    VFATFrame::word getMultihit() const
-    {
-      return data[2] & 0x01;
-    }
+  uint32_t getThresholdVoltage() const { return ((data[3] & 0x7ff) << 16) + data[4]; }
 
-    VFATFrame::word getHptdcErrorFlag() const
-    {
-      return data[1] & 0xFFFF;
-    }
+  VFATFrame::word getMultihit() const { return data[2] & 0x01; }
 
-};                                                                     
+  VFATFrame::word getHptdcErrorFlag() const { return data[1] & 0xFFFF; }
+};
 
 #endif

--- a/EventFilter/CTPPSRawToDigi/interface/RPixErrorChecker.h
+++ b/EventFilter/CTPPSRawToDigi/interface/RPixErrorChecker.h
@@ -12,12 +12,10 @@
 
 class FEDRawData;
 
-enum State { InvalidLinkId, InvalidROCId, InvalidPixelId, Unknown};
+enum State { InvalidLinkId, InvalidROCId, InvalidPixelId, Unknown };
 
 class RPixErrorChecker {
-
 public:
-
   typedef uint32_t Word32;
   typedef uint64_t Word64;
 
@@ -25,19 +23,19 @@ public:
   typedef std::map<uint32_t, DetErrors> Errors;
 
   static constexpr int CRC_bits = 1;
-  static constexpr int ROC_bits  = 5;
+  static constexpr int ROC_bits = 5;
   static constexpr int DCOL_bits = 5;
   static constexpr int PXID_bits = 8;
-  static constexpr int ADC_bits  = 8;
+  static constexpr int ADC_bits = 8;
   static constexpr int OMIT_ERR_bits = 1;
-  
+
   static constexpr int CRC_shift = 2;
-  static constexpr int ADC_shift  = 0;
+  static constexpr int ADC_shift = 0;
   static constexpr int PXID_shift = ADC_shift + ADC_bits;
   static constexpr int DCOL_shift = PXID_shift + PXID_bits;
-  static constexpr int ROC_shift  = DCOL_shift + DCOL_bits;
+  static constexpr int ROC_shift = DCOL_shift + DCOL_bits;
   static constexpr int OMIT_ERR_shift = 20;
- 
+
   static constexpr Word32 dummyDetId = 0xffffffff;
 
   static constexpr Word64 CRC_mask = ~(~RPixErrorChecker::Word64(0) << CRC_bits);
@@ -45,7 +43,6 @@ public:
   static constexpr Word32 OMIT_ERR_mask = ~(~RPixErrorChecker::Word32(0) << OMIT_ERR_bits);
 
 public:
-
   RPixErrorChecker();
 
   void setErrorStatus(bool errorStatus);
@@ -61,12 +58,7 @@ public:
   void conversionError(int fedId, uint32_t iD, const State& state, const Word32& errorWord, Errors& errors) const;
 
 private:
-
-
   bool includeErrors_;
-  
-
-
 };
 
 #endif

--- a/EventFilter/CTPPSRawToDigi/interface/RawDataUnpacker.h
+++ b/EventFilter/CTPPSRawToDigi/interface/RawDataUnpacker.h
@@ -20,49 +20,62 @@
 
 //----------------------------------------------------------------------------------------------------
 
-namespace ctpps
-{
+namespace ctpps {
   /// \brief Collection of code for unpacking of TOTEM raw-data.
-  class RawDataUnpacker
-  {
-    public:
-      typedef uint64_t word;
+  class RawDataUnpacker {
+  public:
+    typedef uint64_t word;
 
-      /// VFAT transmission modes
-      enum { vmCluster = 0x80, vmRaw = 0x90, vmDiamondCompact = 0xB0 };
+    /// VFAT transmission modes
+    enum { vmCluster = 0x80, vmRaw = 0x90, vmDiamondCompact = 0xB0 };
 
-      // list of headers for all words encountered in diamond data frames
-      static constexpr unsigned int VFAT_DIAMOND_HEADER_OF_WORD_2 = 0x7800;
-      static constexpr unsigned int VFAT_DIAMOND_HEADER_OF_WORD_3 = 0x7000;
-      static constexpr unsigned int VFAT_DIAMOND_HEADER_OF_WORD_5 = 0x6800;
-      static constexpr unsigned int VFAT_DIAMOND_HEADER_OF_WORD_7 = 0x6000;
-      static constexpr unsigned int VFAT_HEADER_OF_EC = 0xC000;
+    // list of headers for all words encountered in diamond data frames
+    static constexpr unsigned int VFAT_DIAMOND_HEADER_OF_WORD_2 = 0x7800;
+    static constexpr unsigned int VFAT_DIAMOND_HEADER_OF_WORD_3 = 0x7000;
+    static constexpr unsigned int VFAT_DIAMOND_HEADER_OF_WORD_5 = 0x6800;
+    static constexpr unsigned int VFAT_DIAMOND_HEADER_OF_WORD_7 = 0x6000;
+    static constexpr unsigned int VFAT_HEADER_OF_EC = 0xC000;
 
-      RawDataUnpacker() {}
+    RawDataUnpacker() {}
 
-      RawDataUnpacker(const edm::ParameterSet &conf);
+    RawDataUnpacker(const edm::ParameterSet &conf);
 
-      /// Unpack data from FED with fedId into `coll' collection.
-      int run(int fedId, const FEDRawData &data, std::vector<TotemFEDInfo> &fedInfoColl, SimpleVFATFrameCollection &coll) const;
+    /// Unpack data from FED with fedId into `coll' collection.
+    int run(int fedId,
+            const FEDRawData &data,
+            std::vector<TotemFEDInfo> &fedInfoColl,
+            SimpleVFATFrameCollection &coll) const;
 
-      /// Process one Opto-Rx (or LoneG) frame.
-      int processOptoRxFrame(const word *buf, unsigned int frameSize, TotemFEDInfo &fedInfo, SimpleVFATFrameCollection *fc) const;
+    /// Process one Opto-Rx (or LoneG) frame.
+    int processOptoRxFrame(const word *buf,
+                           unsigned int frameSize,
+                           TotemFEDInfo &fedInfo,
+                           SimpleVFATFrameCollection *fc) const;
 
-      /// Process one Opto-Rx frame in serial (old) format
-      int processOptoRxFrameSerial(const word *buffer, unsigned int frameSize, SimpleVFATFrameCollection *fc) const;
+    /// Process one Opto-Rx frame in serial (old) format
+    int processOptoRxFrameSerial(const word *buffer, unsigned int frameSize, SimpleVFATFrameCollection *fc) const;
 
-      /// Process one Opto-Rx frame in parallel (new) format
-      int processOptoRxFrameParallel(const word *buffer, unsigned int frameSize, TotemFEDInfo &fedInfo, SimpleVFATFrameCollection *fc) const;
+    /// Process one Opto-Rx frame in parallel (new) format
+    int processOptoRxFrameParallel(const word *buffer,
+                                   unsigned int frameSize,
+                                   TotemFEDInfo &fedInfo,
+                                   SimpleVFATFrameCollection *fc) const;
 
-      /// Process one Opto-Rx frame that contains SAMPIC frames
-      int processOptoRxFrameSampic(const word *buffer, unsigned int frameSize, TotemFEDInfo &fedInfo, SimpleVFATFrameCollection *fc) const;
+    /// Process one Opto-Rx frame that contains SAMPIC frames
+    int processOptoRxFrameSampic(const word *buffer,
+                                 unsigned int frameSize,
+                                 TotemFEDInfo &fedInfo,
+                                 SimpleVFATFrameCollection *fc) const;
 
-      /// Process data from one VFAT in parallel (new) format
-      int processVFATDataParallel(const uint16_t *buf, unsigned int maxWords, unsigned int OptoRxId, SimpleVFATFrameCollection *fc) const;
+    /// Process data from one VFAT in parallel (new) format
+    int processVFATDataParallel(const uint16_t *buf,
+                                unsigned int maxWords,
+                                unsigned int OptoRxId,
+                                SimpleVFATFrameCollection *fc) const;
 
-    private:
-      unsigned char verbosity;
+  private:
+    unsigned char verbosity;
   };
-}
+}  // namespace ctpps
 
 #endif

--- a/EventFilter/CTPPSRawToDigi/interface/RawToDigiConverter.h
+++ b/EventFilter/CTPPSRawToDigi/interface/RawToDigiConverter.h
@@ -23,63 +23,71 @@
 #include "DataFormats/CTPPSDigi/interface/TotemTimingDigi.h"
 
 /// \brief Collection of code to convert TOTEM raw data into digi.
-class RawToDigiConverter
-{
-  public:
-    RawToDigiConverter(const edm::ParameterSet &conf);
+class RawToDigiConverter {
+public:
+  RawToDigiConverter(const edm::ParameterSet &conf);
 
-    /// Creates RP digi.
-    void run(const VFATFrameCollection &coll, const TotemDAQMapping &mapping, const TotemAnalysisMask &mask,
-      edm::DetSetVector<TotemRPDigi> &digi, edm::DetSetVector<TotemVFATStatus> &status);
+  /// Creates RP digi.
+  void run(const VFATFrameCollection &coll,
+           const TotemDAQMapping &mapping,
+           const TotemAnalysisMask &mask,
+           edm::DetSetVector<TotemRPDigi> &digi,
+           edm::DetSetVector<TotemVFATStatus> &status);
 
-    /// Creates Diamond digi.
-    void run(const VFATFrameCollection &coll, const TotemDAQMapping &mapping, const TotemAnalysisMask &mask,
-      edm::DetSetVector<CTPPSDiamondDigi> &digi, edm::DetSetVector<TotemVFATStatus> &status);
+  /// Creates Diamond digi.
+  void run(const VFATFrameCollection &coll,
+           const TotemDAQMapping &mapping,
+           const TotemAnalysisMask &mask,
+           edm::DetSetVector<CTPPSDiamondDigi> &digi,
+           edm::DetSetVector<TotemVFATStatus> &status);
 
-    /// Creates Totem Timing digi.
-    void run(const VFATFrameCollection &coll, const TotemDAQMapping &mapping, const TotemAnalysisMask &mask,
-      edm::DetSetVector<TotemTimingDigi> &digi, edm::DetSetVector<TotemVFATStatus> &status);
+  /// Creates Totem Timing digi.
+  void run(const VFATFrameCollection &coll,
+           const TotemDAQMapping &mapping,
+           const TotemAnalysisMask &mask,
+           edm::DetSetVector<TotemTimingDigi> &digi,
+           edm::DetSetVector<TotemVFATStatus> &status);
 
-    /// Print error summaries.
-    void printSummaries() const;
+  /// Print error summaries.
+  void printSummaries() const;
 
-  private:
-    struct Record
-    {
-      const TotemVFATInfo *info;
-      const VFATFrame *frame;
-      TotemVFATStatus status;
-    };
+private:
+  struct Record {
+    const TotemVFATInfo *info;
+    const VFATFrame *frame;
+    TotemVFATStatus status;
+  };
 
-    unsigned char verbosity;
+  unsigned char verbosity;
 
-    unsigned int printErrorSummary;
-    unsigned int printUnknownFrameSummary;
+  unsigned int printErrorSummary;
+  unsigned int printUnknownFrameSummary;
 
-    enum TestFlag { tfNoTest, tfWarn, tfErr };
+  enum TestFlag { tfNoTest, tfWarn, tfErr };
 
-    /// flags for which tests to run
-    unsigned int testFootprint;
-    unsigned int testCRC;
-    unsigned int testID;
-    unsigned int testECRaw;
-    unsigned int testECDAQ;
-    unsigned int testECMostFrequent;
-    unsigned int testBCMostFrequent;
+  /// flags for which tests to run
+  unsigned int testFootprint;
+  unsigned int testCRC;
+  unsigned int testID;
+  unsigned int testECRaw;
+  unsigned int testECDAQ;
+  unsigned int testECMostFrequent;
+  unsigned int testBCMostFrequent;
 
-    /// the minimal required number of frames to determine the most frequent counter value
-    unsigned int EC_min, BC_min;
+  /// the minimal required number of frames to determine the most frequent counter value
+  unsigned int EC_min, BC_min;
 
-    /// the minimal required (relative) occupancy of the most frequent counter value to be accepted
-    double EC_fraction, BC_fraction;
+  /// the minimal required (relative) occupancy of the most frequent counter value to be accepted
+  double EC_fraction, BC_fraction;
 
-    /// error summaries
-    std::map<TotemFramePosition, std::map<TotemVFATStatus, unsigned int> > errorSummary;
-    std::map<TotemFramePosition, unsigned int> unknownSummary;
+  /// error summaries
+  std::map<TotemFramePosition, std::map<TotemVFATStatus, unsigned int> > errorSummary;
+  std::map<TotemFramePosition, unsigned int> unknownSummary;
 
-    /// Common processing for all VFAT based sub-systems.
-    void runCommon(const VFATFrameCollection &input, const TotemDAQMapping &mapping,
-      std::map<TotemFramePosition, Record> &records);
+  /// Common processing for all VFAT based sub-systems.
+  void runCommon(const VFATFrameCollection &input,
+                 const TotemDAQMapping &mapping,
+                 std::map<TotemFramePosition, Record> &records);
 };
 
 #endif

--- a/EventFilter/CTPPSRawToDigi/interface/SimpleVFATFrameCollection.h
+++ b/EventFilter/CTPPSRawToDigi/interface/SimpleVFATFrameCollection.h
@@ -7,7 +7,6 @@
 *    
 ****************************************************************************/
 
-
 #ifndef EventFilter_CTPPSRawToDigi_SimpleVFATFrameCollection
 #define EventFilter_CTPPSRawToDigi_SimpleVFATFrameCollection
 
@@ -18,50 +17,34 @@
 /**
  * A basic implementation of VFAT frame collection, as map: TotemFramePosition --> VFATFrame.
 **/
-class SimpleVFATFrameCollection : public VFATFrameCollection
-{
-  protected:
-    typedef std::map<TotemFramePosition, VFATFrame> MapType;
+class SimpleVFATFrameCollection : public VFATFrameCollection {
+protected:
+  typedef std::map<TotemFramePosition, VFATFrame> MapType;
 
-    MapType data;
+  MapType data;
 
-    value_type BeginIterator() const override;
-    value_type NextIterator(const value_type&) const override;
-    bool IsEndIterator(const value_type&) const override;
+  value_type BeginIterator() const override;
+  value_type NextIterator(const value_type&) const override;
+  bool IsEndIterator(const value_type&) const override;
 
-  public:
-    SimpleVFATFrameCollection();
-    ~SimpleVFATFrameCollection() override;
+public:
+  SimpleVFATFrameCollection();
+  ~SimpleVFATFrameCollection() override;
 
-    const VFATFrame* GetFrameByID(unsigned int ID) const override;
-    const VFATFrame* GetFrameByIndex(TotemFramePosition index) const override;
+  const VFATFrame* GetFrameByID(unsigned int ID) const override;
+  const VFATFrame* GetFrameByIndex(TotemFramePosition index) const override;
 
-    unsigned int Size() const override
-    {
-      return data.size();
-    }
+  unsigned int Size() const override { return data.size(); }
 
-    bool Empty() const override
-    {
-      return (data.empty());
-    }
+  bool Empty() const override { return (data.empty()); }
 
-    void Insert(const TotemFramePosition &index, const VFATFrame &frame)
-    {
-      data.insert({index, frame});
-    }
+  void Insert(const TotemFramePosition& index, const VFATFrame& frame) { data.insert({index, frame}); }
 
-    /// inserts an empty (default) frame to the given position and returns pointer to the frame
-    VFATFrame* InsertEmptyFrame(TotemFramePosition index)
-    {
-      return &data.insert({index, VFATFrame()}).first->second;
-    }
+  /// inserts an empty (default) frame to the given position and returns pointer to the frame
+  VFATFrame* InsertEmptyFrame(TotemFramePosition index) { return &data.insert({index, VFATFrame()}).first->second; }
 
-    /// cleans completely the collection
-    void Clear()
-    {
-      data.clear();
-    }
+  /// cleans completely the collection
+  void Clear() { data.clear(); }
 };
 
 #endif

--- a/EventFilter/CTPPSRawToDigi/interface/TotemSampicFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/TotemSampicFrame.h
@@ -18,33 +18,32 @@
 
 #include "EventFilter/CTPPSRawToDigi/interface/VFATFrame.h"
 
-enum TotemSampicConstant
-{
- hwId_Position = 0, // hwId_Size = 1,
+enum TotemSampicConstant {
+  hwId_Position = 0,  // hwId_Size = 1,
   controlBits0_Position = 1,
   controlBits1_Position = 2,
   controlBits2_Position = 3,
   controlBits3_Position = 4,
   controlBits4_Position = 5,
   controlBits5_Position = 6,
-  fpgaTime_Position = 7, // fpgaTime_Size = 5,
-  timestampA_Position = 12, // timestampA_Size = 2,
-  timestampB_Position = 14, // timestampB_Size = 2,
-  cellInfo_Position = 16, // cellInfo_Size = 2,
-  planeChannelId_Position = 18, // planeChannelId_Size = 1,
-  reserved_Position = 19, // reserved_Size = 5,
+  fpgaTime_Position = 7,         // fpgaTime_Size = 5,
+  timestampA_Position = 12,      // timestampA_Size = 2,
+  timestampB_Position = 14,      // timestampB_Size = 2,
+  cellInfo_Position = 16,        // cellInfo_Size = 2,
+  planeChannelId_Position = 18,  // planeChannelId_Size = 1,
+  reserved_Position = 19,        // reserved_Size = 5,
 
-  boardId_Position = 0, // boardId_Size = 1,
-  l1ATimestamp_Position = 1, // l1ATimestamp_Size = 5,
-  bunchNumber_Position = 6, // bunchNumber_Size = 2,
-  orbitNumber_Position = 8, // orbitNumber_Size = 4,
-  eventNumber_Position = 12, // eventNumber_Size = 4,
-  channelMap_Position = 16, // channelMap_Size = 2,
-  l1ALatency_Position = 18, // l1ALatency_Size = 2,
-  numberOfSamples_Position = 20, // numberOfSamples_Size = 1,
-  offsetOfSamples_Position = 21, // offsetOfSamples_Size = 1,
-  fwVersion_Position = 22, // fwVersion_Size = 1,
-  pllInfo_Position = 23, // pllInfo_Size = 1,
+  boardId_Position = 0,           // boardId_Size = 1,
+  l1ATimestamp_Position = 1,      // l1ATimestamp_Size = 5,
+  bunchNumber_Position = 6,       // bunchNumber_Size = 2,
+  orbitNumber_Position = 8,       // orbitNumber_Size = 4,
+  eventNumber_Position = 12,      // eventNumber_Size = 4,
+  channelMap_Position = 16,       // channelMap_Size = 2,
+  l1ALatency_Position = 18,       // l1ALatency_Size = 2,
+  numberOfSamples_Position = 20,  // numberOfSamples_Size = 1,
+  offsetOfSamples_Position = 21,  // offsetOfSamples_Size = 1,
+  fwVersion_Position = 22,        // fwVersion_Size = 1,
+  pllInfo_Position = 23,          // pllInfo_Size = 1,
 
   numberOfSamples = 24,
   controlBits3 = 0x69,
@@ -53,14 +52,13 @@ enum TotemSampicConstant
 };
 
 template <typename T>
-T grayToBinary( const T& gcode_data )
-{
-    //b[0] = g[0]
-  T binary = gcode_data & ( 0x0001 << ( 8*sizeof(T) - 1 ) ); // MSB is the same
+T grayToBinary(const T& gcode_data) {
+  //b[0] = g[0]
+  T binary = gcode_data & (0x0001 << (8 * sizeof(T) - 1));  // MSB is the same
 
   //b[i] = g[i] xor b[i-1]
-  for (unsigned short int i = 1; i < 8*sizeof(T); ++i)
-    binary |= ( gcode_data ^ ( binary >> 1 ) ) & (0x0001 << ( 8*sizeof(T) - i - 1 ) );
+  for (unsigned short int i = 1; i < 8 * sizeof(T); ++i)
+    binary |= (gcode_data ^ (binary >> 1)) & (0x0001 << (8 * sizeof(T) - i - 1));
 
   return binary;
 }
@@ -68,228 +66,215 @@ T grayToBinary( const T& gcode_data )
 /**
  * This class is intended to handle the timing infromation of SAMPIC in the TOTEM implementation
 **/
-class TotemSampicFrame
-{
-  public:
-    TotemSampicFrame( const uint8_t* chInfoPtr, const uint8_t* chDataPtr, const uint8_t* eventInfoPtr ) :
-      totemSampicInfoPtr_( chInfoPtr ), totemSampicDataPtr_( chDataPtr ), totemSampicEventInfoPtr_( eventInfoPtr ),
-      status_( 0 ) {
-      if ( chInfoPtr != nullptr && chDataPtr != nullptr && eventInfoPtr != nullptr && totemSampicInfoPtr_[ TotemSampicConstant::controlBits3_Position ] == TotemSampicConstant::controlBits3 )
-          status_ = 1;
+class TotemSampicFrame {
+public:
+  TotemSampicFrame(const uint8_t* chInfoPtr, const uint8_t* chDataPtr, const uint8_t* eventInfoPtr)
+      : totemSampicInfoPtr_(chInfoPtr),
+        totemSampicDataPtr_(chDataPtr),
+        totemSampicEventInfoPtr_(eventInfoPtr),
+        status_(0) {
+    if (chInfoPtr != nullptr && chDataPtr != nullptr && eventInfoPtr != nullptr &&
+        totemSampicInfoPtr_[TotemSampicConstant::controlBits3_Position] == TotemSampicConstant::controlBits3)
+      status_ = 1;
+  }
+  ~TotemSampicFrame() {}
+
+  /// Prints the frame.
+  /// If binary is true, binary format is used.
+  void printRaw(bool binary = false) const {
+    std::cout << "Event Info: " << std::endl;
+    printRawBuffer((uint16_t*)totemSampicEventInfoPtr_);
+
+    std::cout << "Channel Info: " << std::endl;
+    printRawBuffer((uint16_t*)totemSampicInfoPtr_);
+
+    std::cout << "Channel Data: " << std::endl;
+    printRawBuffer((uint16_t*)totemSampicDataPtr_);
+  }
+
+  void print() const {
+    std::bitset<16> bitsChannelMap(getChannelMap());
+    std::bitset<16> bitsPLLInfo(getPLLInfo());
+    std::cout << "TotemSampicFrame:\nEvent:"
+              << "\nHardwareId (Event):\t" << std::hex << (unsigned int)getEventHardwareId() << "\nL1A Timestamp:\t"
+              << std::dec << getL1ATimestamp() << "\nL1A Latency:\t" << std::dec << getL1ALatency()
+              << "\nBunch Number:\t" << std::dec << getBunchNumber() << "\nOrbit Number:\t" << std::dec
+              << getOrbitNumber() << "\nEvent Number:\t" << std::dec << getEventNumber() << "\nChannels fired:\t"
+              << std::hex << bitsChannelMap.to_string() << "\nNumber of Samples:\t" << std::dec
+              << getNumberOfSentSamples() << "\nOffset of Samples:\t" << std::dec << (int)getOffsetOfSamples()
+              << "\nFW Version:\t" << std::hex << (int)getFWVersion() << "\nChannel:\nHardwareId:\t" << std::hex
+              << (unsigned int)getHardwareId() << "\nFPGATimestamp:\t" << std::dec << getFPGATimestamp()
+              << "\nTimestampA:\t" << std::dec << getTimestampA() << "\nTimestampB:\t" << std::dec << getTimestampB()
+              << "\nCellInfo:\t" << std::dec << getCellInfo() << "\nPlane:\t" << std::dec << getDetPlane()
+              << "\nChannel:\t" << std::dec << getDetChannel() << "\nPLL Info:\t" << bitsPLLInfo.to_string()
+              << std::endl
+              << std::endl;
+  }
+
+  // All getters
+  inline uint8_t getHardwareId() const {
+    uint8_t tmp = 0;
+    if (status_)
+      tmp = totemSampicInfoPtr_[TotemSampicConstant::hwId_Position];
+    return tmp;
+  }
+
+  inline uint64_t getFPGATimestamp() const {
+    uint64_t tmp = 0;
+    if (status_) {
+      tmp = *((const uint64_t*)(totemSampicInfoPtr_ + TotemSampicConstant::fpgaTime_Position)) & 0xFFFFFFFFFF;
     }
-    ~TotemSampicFrame() {}
+    return tmp;
+  }
 
-    /// Prints the frame.
-    /// If binary is true, binary format is used.
-    void printRaw( bool binary = false ) const {
-      std::cout << "Event Info: " << std::endl;
-      printRawBuffer( (uint16_t*) totemSampicEventInfoPtr_ );
-
-      std::cout << "Channel Info: " << std::endl;
-      printRawBuffer( (uint16_t*) totemSampicInfoPtr_ );
-
-      std::cout << "Channel Data: " << std::endl;
-      printRawBuffer( (uint16_t*) totemSampicDataPtr_ );
+  inline uint16_t getTimestampA() const {
+    uint16_t tmp = 0;
+    if (status_) {
+      tmp = *((const uint16_t*)(totemSampicInfoPtr_ + TotemSampicConstant::timestampA_Position));
     }
+    tmp = 0xFFF - tmp;
+    return grayToBinary<uint16_t>(tmp);
+  }
 
-    void print() const {
-      std::bitset<16> bitsChannelMap( getChannelMap() );
-      std::bitset<16> bitsPLLInfo( getPLLInfo() );
-      std::cout << "TotemSampicFrame:\nEvent:"
-          << "\nHardwareId (Event):\t" << std::hex << (unsigned int) getEventHardwareId()
-          << "\nL1A Timestamp:\t" << std::dec << getL1ATimestamp()
-          << "\nL1A Latency:\t" << std::dec << getL1ALatency()
-          << "\nBunch Number:\t" << std::dec << getBunchNumber()
-          << "\nOrbit Number:\t" << std::dec << getOrbitNumber()
-          << "\nEvent Number:\t" << std::dec << getEventNumber()
-          << "\nChannels fired:\t" << std::hex << bitsChannelMap.to_string()
-          << "\nNumber of Samples:\t" << std::dec << getNumberOfSentSamples()
-          << "\nOffset of Samples:\t" << std::dec << (int) getOffsetOfSamples()
-          << "\nFW Version:\t" << std::hex << (int) getFWVersion()
-          << "\nChannel:\nHardwareId:\t" << std::hex << (unsigned int) getHardwareId()
-          << "\nFPGATimestamp:\t" << std::dec << getFPGATimestamp()
-          << "\nTimestampA:\t" << std::dec << getTimestampA()
-          << "\nTimestampB:\t" << std::dec << getTimestampB()
-          << "\nCellInfo:\t" << std::dec << getCellInfo()
-          << "\nPlane:\t" << std::dec << getDetPlane()
-          << "\nChannel:\t" << std::dec << getDetChannel()
-          << "\nPLL Info:\t" << bitsPLLInfo.to_string()
-          << std::endl << std::endl;
+  inline uint16_t getTimestampB() const {
+    uint16_t tmp = 0;
+    if (status_) {
+      tmp = *((const uint16_t*)(totemSampicInfoPtr_ + TotemSampicConstant::timestampB_Position));
     }
+    return grayToBinary<uint16_t>(tmp);
+  }
 
-    // All getters
-    inline uint8_t getHardwareId() const {
-      uint8_t tmp = 0;
-      if ( status_ ) tmp = totemSampicInfoPtr_[ TotemSampicConstant::hwId_Position ];
-      return tmp;
+  inline uint16_t getCellInfo() const {
+    uint16_t tmp = 0;
+    if (status_)
+      tmp = *((const uint16_t*)(totemSampicInfoPtr_ + TotemSampicConstant::cellInfo_Position));
+    return tmp & TotemSampicConstant::cellInfo_Mask;
+  }
+
+  inline int getDetPlane() const {
+    int tmp = 0;
+    if (status_)
+      tmp = (totemSampicInfoPtr_[planeChannelId_Position] & 0xF0) >> 4;
+    return tmp;
+  }
+
+  inline int getDetChannel() const {
+    int tmp = 0;
+    if (status_)
+      tmp = totemSampicInfoPtr_[planeChannelId_Position] & 0x0F;
+    return tmp;
+  }
+
+  const std::vector<uint8_t> getSamples() const {
+    std::vector<uint8_t> samples;
+    if (status_) {
+      samples.assign(totemSampicDataPtr_, totemSampicDataPtr_ + TotemSampicConstant::numberOfSamples);
+      for (auto it = samples.begin(); it != samples.end(); ++it)
+        *it = grayToBinary<uint8_t>(*it);
     }
+    return samples;
+  }
 
-    inline uint64_t getFPGATimestamp() const {
-      uint64_t tmp = 0;
-      if ( status_ ) {
-        tmp = *( ( const uint64_t* ) ( totemSampicInfoPtr_ + TotemSampicConstant::fpgaTime_Position ) ) & 0xFFFFFFFFFF;
-      }
-      return tmp;
+  inline unsigned int getNumberOfSamples() const { return status_ * TotemSampicConstant::numberOfSamples; }
+
+  // Event Info
+  inline uint8_t getEventHardwareId() const {
+    uint8_t tmp = 0;
+    if (status_)
+      tmp = totemSampicEventInfoPtr_[TotemSampicConstant::boardId_Position];
+    return tmp;
+  }
+
+  inline uint64_t getL1ATimestamp() const {
+    uint64_t tmp = 0;
+    if (status_) {
+      tmp = *((const uint64_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::l1ATimestamp_Position)) & 0xFFFFFFFFFF;
     }
+    return tmp;
+  }
 
-    inline uint16_t getTimestampA() const {
-      uint16_t tmp = 0;
-      if ( status_ ) {
-        tmp = *( ( const uint16_t* ) ( totemSampicInfoPtr_ + TotemSampicConstant::timestampA_Position ) );
-      }
-      tmp = 0xFFF - tmp;
-      return grayToBinary<uint16_t> ( tmp );
+  inline uint16_t getBunchNumber() const {
+    uint16_t tmp = 0;
+    if (status_)
+      tmp = *((const uint16_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::bunchNumber_Position));
+    return tmp;
+  }
+
+  inline uint32_t getOrbitNumber() const {
+    uint32_t tmp = 0;
+    if (status_)
+      tmp = *((const uint32_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::orbitNumber_Position));
+    return tmp;
+  }
+
+  inline uint32_t getEventNumber() const {
+    uint32_t tmp = 0;
+    if (status_)
+      tmp = *((const uint32_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::eventNumber_Position));
+    return tmp;
+  }
+
+  inline uint16_t getChannelMap() const {
+    uint16_t tmp = 0;
+    if (status_)
+      tmp = *((const uint16_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::channelMap_Position));
+    return tmp;
+  }
+
+  inline uint16_t getL1ALatency() const {
+    uint16_t tmp = 0;
+    if (status_)
+      tmp = *((const uint16_t*)(totemSampicEventInfoPtr_ + TotemSampicConstant::l1ALatency_Position));
+    return tmp;
+  }
+
+  inline uint8_t getNumberOfSentSamples() const {
+    uint8_t tmp = 0;
+    if (status_)
+      tmp = totemSampicEventInfoPtr_[TotemSampicConstant::numberOfSamples_Position];
+    return tmp;
+  }
+
+  inline uint8_t getOffsetOfSamples() const {
+    uint8_t tmp = 0;
+    if (status_)
+      tmp = totemSampicEventInfoPtr_[TotemSampicConstant::offsetOfSamples_Position];
+    return tmp;
+  }
+
+  inline uint8_t getPLLInfo() const {
+    uint8_t tmp = 0;
+    if (status_)
+      tmp = totemSampicEventInfoPtr_[pllInfo_Position];
+    return tmp;
+  }
+
+  inline uint8_t getFWVersion() const {
+    uint8_t tmp = 0;
+    if (status_)
+      tmp = totemSampicEventInfoPtr_[fwVersion_Position];
+    return tmp;
+  }
+
+  inline bool valid() const { return status_ != 0; }
+
+protected:
+  const uint8_t* totemSampicInfoPtr_;
+  const uint8_t* totemSampicDataPtr_;
+  const uint8_t* totemSampicEventInfoPtr_;
+
+  int status_;
+
+  inline void printRawBuffer(const uint16_t* buffer, const bool binary = false, const unsigned int size = 12) const {
+    for (unsigned int i = 0; i < size; i++) {
+      if (binary) {
+        std::bitset<16> bits(*(buffer++));
+        std::cout << bits.to_string() << std::endl;
+      } else
+        std::cout << std::setfill('0') << std::setw(4) << std::hex << *(buffer++) << std::endl;
     }
-
-    inline uint16_t getTimestampB() const {
-      uint16_t tmp = 0;
-      if ( status_ ) {
-        tmp = *( ( const uint16_t* ) ( totemSampicInfoPtr_ + TotemSampicConstant::timestampB_Position ) );
-      }
-      return grayToBinary<uint16_t> ( tmp );
-    }
-
-    inline uint16_t getCellInfo() const {
-      uint16_t tmp = 0;
-      if ( status_ )
-        tmp = *( ( const uint16_t* ) ( totemSampicInfoPtr_ + TotemSampicConstant::cellInfo_Position ) );
-      return tmp & TotemSampicConstant::cellInfo_Mask;
-    }
-
-    inline int getDetPlane() const {
-      int tmp = 0;
-      if ( status_ )
-        tmp = ( totemSampicInfoPtr_[ planeChannelId_Position ] & 0xF0 ) >> 4;
-      return tmp;
-    }
-
-    inline int getDetChannel() const {
-      int tmp = 0;
-      if ( status_ )
-        tmp = totemSampicInfoPtr_[ planeChannelId_Position ] & 0x0F;
-      return tmp;
-    }
-
-    const std::vector<uint8_t> getSamples() const {
-      std::vector<uint8_t> samples;
-      if ( status_ ) {
-        samples.assign( totemSampicDataPtr_, totemSampicDataPtr_ + TotemSampicConstant::numberOfSamples );
-        for ( auto it = samples.begin(); it != samples.end(); ++it )
-          *it = grayToBinary<uint8_t>( *it );
-      }
-      return samples;
-    }
-
-    inline unsigned int getNumberOfSamples() const {
-      return status_ * TotemSampicConstant::numberOfSamples;
-    }
-
-    // Event Info
-    inline uint8_t getEventHardwareId() const {
-      uint8_t tmp = 0;
-      if ( status_ )
-        tmp = totemSampicEventInfoPtr_[ TotemSampicConstant::boardId_Position ];
-      return tmp;
-    }
-
-    inline uint64_t getL1ATimestamp() const {
-      uint64_t tmp = 0;
-      if ( status_ ) {
-        tmp = *( ( const uint64_t* ) ( totemSampicEventInfoPtr_ + TotemSampicConstant::l1ATimestamp_Position ) ) & 0xFFFFFFFFFF;
-      }
-      return tmp;
-    }
-
-    inline uint16_t getBunchNumber() const
-    {
-      uint16_t tmp = 0;
-      if ( status_ )
-        tmp = *( ( const uint16_t* ) ( totemSampicEventInfoPtr_ + TotemSampicConstant::bunchNumber_Position ) );
-      return tmp;
-    }
-
-    inline uint32_t getOrbitNumber() const
-    {
-      uint32_t tmp = 0;
-      if ( status_ )
-        tmp = *( ( const uint32_t* ) ( totemSampicEventInfoPtr_ + TotemSampicConstant::orbitNumber_Position ) );
-      return tmp;
-    }
-
-    inline uint32_t getEventNumber() const
-    {
-      uint32_t tmp = 0;
-      if ( status_ )
-        tmp = *( ( const uint32_t* ) ( totemSampicEventInfoPtr_ + TotemSampicConstant::eventNumber_Position ) );
-      return tmp;
-    }
-
-    inline uint16_t getChannelMap() const
-    {
-      uint16_t tmp = 0;
-      if ( status_ )
-        tmp = *( ( const uint16_t* ) ( totemSampicEventInfoPtr_ + TotemSampicConstant::channelMap_Position ) );
-      return tmp;
-    }
-
-    inline uint16_t getL1ALatency() const
-    {
-      uint16_t tmp = 0;
-      if ( status_ )
-        tmp = *( ( const uint16_t* ) ( totemSampicEventInfoPtr_ + TotemSampicConstant::l1ALatency_Position ) );
-      return tmp;
-    }
-
-    inline uint8_t getNumberOfSentSamples() const
-    {
-      uint8_t tmp = 0;
-      if ( status_ ) tmp = totemSampicEventInfoPtr_[ TotemSampicConstant::numberOfSamples_Position ];
-      return tmp;
-    }
-
-    inline uint8_t getOffsetOfSamples() const
-    {
-      uint8_t tmp = 0;
-      if ( status_ ) tmp = totemSampicEventInfoPtr_[ TotemSampicConstant::offsetOfSamples_Position ];
-      return tmp;
-    }
-
-    inline uint8_t getPLLInfo() const {
-      uint8_t tmp = 0;
-      if ( status_ ) tmp = totemSampicEventInfoPtr_[ pllInfo_Position ];
-      return tmp;
-    }
-
-    inline uint8_t getFWVersion() const {
-      uint8_t tmp = 0;
-      if ( status_ ) tmp = totemSampicEventInfoPtr_[ fwVersion_Position ];
-      return tmp;
-    }
-
-    inline bool valid() const {
-      return status_ != 0;
-    }
-
-  protected:
-    const uint8_t* totemSampicInfoPtr_;
-    const uint8_t* totemSampicDataPtr_;
-    const uint8_t* totemSampicEventInfoPtr_;
-
-    int status_;
-
-    inline void printRawBuffer( const uint16_t* buffer, const bool binary = false, const unsigned int size = 12 ) const {
-      for ( unsigned int i = 0; i < size; i++ ) {
-        if ( binary ) {
-          std::bitset<16> bits( *( buffer++ ) );
-          std::cout << bits.to_string() << std::endl;
-        }
-        else
-          std::cout << std::setfill( '0' ) << std::setw( 4 ) << std::hex << *( buffer++ ) << std::endl;
-      }
-      std::cout << std::endl;
-    }
-
+    std::cout << std::endl;
+  }
 };
-
 
 #endif

--- a/EventFilter/CTPPSRawToDigi/interface/VFATFrame.h
+++ b/EventFilter/CTPPSRawToDigi/interface/VFATFrame.h
@@ -16,149 +16,96 @@
 /**
  * Representation of VFAT frame plus extra info added by DAQ.
 **/
-class VFATFrame
-{
-  public:
-    typedef uint16_t word;
-  public:
-    VFATFrame(const word* _data = nullptr);
+class VFATFrame {
+public:
+  typedef uint16_t word;
 
-    VFATFrame(const VFATFrame& copy)
-    {
-      setData(copy.data);
-      presenceFlags = copy.presenceFlags;
-      daqErrorFlags = copy.daqErrorFlags;
-      numberOfClusters = copy.numberOfClusters;
+public:
+  VFATFrame(const word* _data = nullptr);
 
-    }
+  VFATFrame(const VFATFrame& copy) {
+    setData(copy.data);
+    presenceFlags = copy.presenceFlags;
+    daqErrorFlags = copy.daqErrorFlags;
+    numberOfClusters = copy.numberOfClusters;
+  }
 
-    virtual ~VFATFrame() {}
+  virtual ~VFATFrame() {}
 
-    /// Copies a memory block to data buffer.
-    void setData(const word *_data);
+  /// Copies a memory block to data buffer.
+  void setData(const word* _data);
 
-    VFATFrame::word* getData()
-    {
-      return data;
-    }
-    
-    const VFATFrame::word* getData() const
-    {
-      return data;
-    }
+  VFATFrame::word* getData() { return data; }
 
-    /// Returns Bunch Crossing number (BC<11:0>).
-    VFATFrame::word getBC() const
-    {
-      return data[11] & 0x0FFF;
-    }
+  const VFATFrame::word* getData() const { return data; }
 
-    /// Returns Event Counter (EV<7:0>).
-    VFATFrame::word getEC() const
-    {
-      return (data[10] & 0x0FF0) >> 4;
-    }
+  /// Returns Bunch Crossing number (BC<11:0>).
+  VFATFrame::word getBC() const { return data[11] & 0x0FFF; }
 
-    /// Returns flags.
-    VFATFrame::word getFlags() const
-    {
-      return data[10] & 0x000F;
-    }
+  /// Returns Event Counter (EV<7:0>).
+  VFATFrame::word getEC() const { return (data[10] & 0x0FF0) >> 4; }
 
-    /// Returns ChipID (ChipID<11:0>).
-    VFATFrame::word getChipID() const
-    {
-      return data[9] & 0x0FFF;
-    }
+  /// Returns flags.
+  VFATFrame::word getFlags() const { return data[10] & 0x000F; }
 
-    /// Returns the CRC.
-    VFATFrame::word getCRC() const
-    {
-      return data[0];
-    }
-   
+  /// Returns ChipID (ChipID<11:0>).
+  VFATFrame::word getChipID() const { return data[9] & 0x0FFF; }
 
-    /// Sets presence flags.
-    void setPresenceFlags(uint8_t v)
-    {
-      presenceFlags = v;
-    }
+  /// Returns the CRC.
+  VFATFrame::word getCRC() const { return data[0]; }
 
-    /// Returns true if the BC word is present in the frame.
-    bool isBCPresent() const
-    {
-      return presenceFlags & 0x1;
-    }
+  /// Sets presence flags.
+  void setPresenceFlags(uint8_t v) { presenceFlags = v; }
 
-    /// Returns true if the EC word is present in the frame.
-    bool isECPresent() const
-    {
-      return presenceFlags & 0x2;
-    }
+  /// Returns true if the BC word is present in the frame.
+  bool isBCPresent() const { return presenceFlags & 0x1; }
 
-    /// Returns true if the ID word is present in the frame.
-    bool isIDPresent() const
-    {
-      return presenceFlags & 0x4;
-    }
+  /// Returns true if the EC word is present in the frame.
+  bool isECPresent() const { return presenceFlags & 0x2; }
 
-    /// Returns true if the CRC word is present in the frame.
-    bool isCRCPresent() const
-    {
-      return presenceFlags & 0x8;
-    }
+  /// Returns true if the ID word is present in the frame.
+  bool isIDPresent() const { return presenceFlags & 0x4; }
 
-    /// Returns true if the CRC word is present in the frame.
-    bool isNumberOfClustersPresent() const
-    {
-      return presenceFlags & 0x10;
-    }
+  /// Returns true if the CRC word is present in the frame.
+  bool isCRCPresent() const { return presenceFlags & 0x8; }
 
-    /// Sets DAQ error flags.
-    void setDAQErrorFlags(uint8_t v)
-    {
-      daqErrorFlags = v;
-    }
+  /// Returns true if the CRC word is present in the frame.
+  bool isNumberOfClustersPresent() const { return presenceFlags & 0x10; }
 
-    void setNumberOfClusters(uint8_t v)
-    {
-      numberOfClusters = v;
-    }
+  /// Sets DAQ error flags.
+  void setDAQErrorFlags(uint8_t v) { daqErrorFlags = v; }
 
-    /// Returns the number of clusters as given by the "0xD0 frame".
-    /// Returns 0, if not available.
-    uint8_t getNumberOfClusters() const
-    {
-      return numberOfClusters;
-    }
+  void setNumberOfClusters(uint8_t v) { numberOfClusters = v; }
 
-    /// Checks the fixed bits in the frame.
-    /// Returns false if any of the groups (in BC, EC and ID words) is present but wrong.
-    bool checkFootprint() const;
+  /// Returns the number of clusters as given by the "0xD0 frame".
+  /// Returns 0, if not available.
+  uint8_t getNumberOfClusters() const { return numberOfClusters; }
 
+  /// Checks the fixed bits in the frame.
+  /// Returns false if any of the groups (in BC, EC and ID words) is present but wrong.
+  bool checkFootprint() const;
 
-    /// Checks the validity of frame (CRC and daqErrorFlags).
-    /// Returns false if daqErrorFlags is non-zero.
-    /// Returns false if the CRC is present and invalid.
-    virtual bool checkCRC() const;
+  /// Checks the validity of frame (CRC and daqErrorFlags).
+  /// Returns false if daqErrorFlags is non-zero.
+  /// Returns false if the CRC is present and invalid.
+  virtual bool checkCRC() const;
 
-    /// Checks if channel number 'channel' was active.
-    /// Returns positive number if it was active, 0 otherwise.
-    virtual bool channelActive(unsigned char channel) const
-    {
-      return ( data[1 + (channel / 16)] & (1 << (channel % 16)) ) ? true : false;
-    }
+  /// Checks if channel number 'channel' was active.
+  /// Returns positive number if it was active, 0 otherwise.
+  virtual bool channelActive(unsigned char channel) const {
+    return (data[1 + (channel / 16)] & (1 << (channel % 16))) ? true : false;
+  }
 
-    /// Returns list  of active channels.
-    /// It's more efficient than the channelActive(char) for events with low channel occupancy.
-    virtual std::vector<unsigned char> getActiveChannels() const;
+  /// Returns list  of active channels.
+  /// It's more efficient than the channelActive(char) for events with low channel occupancy.
+  virtual std::vector<unsigned char> getActiveChannels() const;
 
-    /// Prints the frame.
-    /// If binary is true, binary format is used.
-    void Print(bool binary = false) const;
+  /// Prints the frame.
+  /// If binary is true, binary format is used.
+  void Print(bool binary = false) const;
 
-  protected:
-    /** Raw data frame as sent by electronics.
+protected:
+  /** Raw data frame as sent by electronics.
     * The container is organized as follows (reversed Figure 8 at page 23 of VFAT2 manual):
     * \verbatim
     * buffer index   content       size
@@ -170,25 +117,26 @@ class VFATFrame
     *   11           BC            4 constant bits (1010) + 12 bits
     * \endverbatim
     **/
-    word data[12];
-  private: 
-    /// Flag indicating the presence of various components.
-    ///   bit 1: "BC word" (buffer index 11)
-    ///   bit 2: "EC word" (buffer index 10)
-    ///   bit 3: "ID word" (buffer index 9)
-    ///   bit 4: "CRC word" (buffer index 0)
-    ///   bit 5: "number of clusters word" (prefix 0xD0)
-    uint8_t presenceFlags;
+  word data[12];
 
-    /// Error flag as given by certain versions of DAQ.
-    uint8_t daqErrorFlags;
+private:
+  /// Flag indicating the presence of various components.
+  ///   bit 1: "BC word" (buffer index 11)
+  ///   bit 2: "EC word" (buffer index 10)
+  ///   bit 3: "ID word" (buffer index 9)
+  ///   bit 4: "CRC word" (buffer index 0)
+  ///   bit 5: "number of clusters word" (prefix 0xD0)
+  uint8_t presenceFlags;
 
-    /// Number of clusters.
-    /// Only available in cluster mode and if the number of clusters exceeds a limit (10).
-    uint8_t numberOfClusters;
+  /// Error flag as given by certain versions of DAQ.
+  uint8_t daqErrorFlags;
 
-    /// internaly used to check CRC
-    static word calculateCRC(word crc_in, word dato);
-};                                                                     
+  /// Number of clusters.
+  /// Only available in cluster mode and if the number of clusters exceeds a limit (10).
+  uint8_t numberOfClusters;
+
+  /// internaly used to check CRC
+  static word calculateCRC(word crc_in, word dato);
+};
 
 #endif

--- a/EventFilter/CTPPSRawToDigi/interface/VFATFrameCollection.h
+++ b/EventFilter/CTPPSRawToDigi/interface/VFATFrameCollection.h
@@ -6,7 +6,6 @@
 *    
 ****************************************************************************/
 
-
 #ifndef EventFilter_CTPPSRawToDigi_VFATFrameCollection
 #define EventFilter_CTPPSRawToDigi_VFATFrameCollection
 
@@ -19,70 +18,67 @@
 /**
  * Interface class for VFAT-frame collections.
 **/
-class VFATFrameCollection 
-{
-  public:
-    VFATFrameCollection() {}
-    virtual ~VFATFrameCollection() {}
+class VFATFrameCollection {
+public:
+  VFATFrameCollection() {}
+  virtual ~VFATFrameCollection() {}
 
-    /// returns pointer to frame with ID, performs NO duplicity check (if there is precisely one frame with this 12bit ID)
-    virtual const VFATFrame* GetFrameByID(unsigned int ID) const = 0;
+  /// returns pointer to frame with ID, performs NO duplicity check (if there is precisely one frame with this 12bit ID)
+  virtual const VFATFrame* GetFrameByID(unsigned int ID) const = 0;
 
-    /// returns frame at given position in Slink frame
-    virtual const VFATFrame* GetFrameByIndex(TotemFramePosition index) const = 0;
+  /// returns frame at given position in Slink frame
+  virtual const VFATFrame* GetFrameByIndex(TotemFramePosition index) const = 0;
 
-    /// returns frame at given position in Slink frame and checks 12bit ID
-    virtual const VFATFrame* GetFrameByIndexID(TotemFramePosition index, unsigned int ID);
+  /// returns frame at given position in Slink frame and checks 12bit ID
+  virtual const VFATFrame* GetFrameByIndexID(TotemFramePosition index, unsigned int ID);
 
-    /// return the number of VFAT frames in the collection
-    virtual unsigned int Size() const = 0;
+  /// return the number of VFAT frames in the collection
+  virtual unsigned int Size() const = 0;
 
-    /// returns whether the collection is empty
-    virtual bool Empty() const = 0;
+  /// returns whether the collection is empty
+  virtual bool Empty() const = 0;
 
-    /// pair: frame DAQ position, frame data
-    typedef std::pair<TotemFramePosition, const VFATFrame*> value_type;
+  /// pair: frame DAQ position, frame data
+  typedef std::pair<TotemFramePosition, const VFATFrame*> value_type;
 
-    /// the VFATFrameCollection interator
-    class Iterator {
-      protected:
-        /// interator value
-        value_type value;
-
-        /// the pointer to the collection
-        const VFATFrameCollection* collection;
-
-      public:
-        /// constructor, automatically sets the iterator to the beginning
-        Iterator(const VFATFrameCollection* c = nullptr) : collection(c)
-          { if (collection) value = collection->BeginIterator(); }
-
-        /// returns the DAQ position of the current element
-        TotemFramePosition Position()
-          { return value.first; }
-
-        /// returns the frame data of the current element
-        const VFATFrame* Data()
-          { return value.second; }
-
-        /// shifts the iterator
-        void Next()
-          { value = collection->NextIterator(value); }
-
-        /// returns whether the iterator points over the end of the collection
-        bool IsEnd()
-          { return collection->IsEndIterator(value); }
-    };
-    
+  /// the VFATFrameCollection interator
+  class Iterator {
   protected:
-    /// returns the beginning of the collection
-    virtual value_type BeginIterator() const = 0;
+    /// interator value
+    value_type value;
+
+    /// the pointer to the collection
+    const VFATFrameCollection* collection;
+
+  public:
+    /// constructor, automatically sets the iterator to the beginning
+    Iterator(const VFATFrameCollection* c = nullptr) : collection(c) {
+      if (collection)
+        value = collection->BeginIterator();
+    }
+
+    /// returns the DAQ position of the current element
+    TotemFramePosition Position() { return value.first; }
+
+    /// returns the frame data of the current element
+    const VFATFrame* Data() { return value.second; }
 
     /// shifts the iterator
-    virtual value_type NextIterator(const value_type&) const = 0;
+    void Next() { value = collection->NextIterator(value); }
 
-    /// checks whether the iterator points over the end of the collection
-    virtual bool IsEndIterator(const value_type&) const = 0;
+    /// returns whether the iterator points over the end of the collection
+    bool IsEnd() { return collection->IsEndIterator(value); }
+  };
+
+protected:
+  /// returns the beginning of the collection
+  virtual value_type BeginIterator() const = 0;
+
+  /// shifts the iterator
+  virtual value_type NextIterator(const value_type&) const = 0;
+
+  /// checks whether the iterator points over the end of the collection
+  virtual bool IsEndIterator(const value_type&) const = 0;
 };
 
 #endif

--- a/EventFilter/CTPPSRawToDigi/plugins/CTPPSPixelRawToDigi.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/CTPPSPixelRawToDigi.cc
@@ -2,7 +2,6 @@
  * adapting to CTPPS pixel detector March 2017 - F.Ferro
  */
 
-
 #include "EventFilter/CTPPSRawToDigi/interface/CTPPSPixelRawToDigi.h"
 
 #include "DataFormats/Common/interface/Handle.h"
@@ -22,66 +21,57 @@
 
 using namespace std;
 
-
-CTPPSPixelRawToDigi::CTPPSPixelRawToDigi( const edm::ParameterSet& conf ) 
-  : config_(conf)
+CTPPSPixelRawToDigi::CTPPSPixelRawToDigi(const edm::ParameterSet& conf)
+    : config_(conf)
 
 {
+  FEDRawDataCollection_ = consumes<FEDRawDataCollection>(config_.getParameter<edm::InputTag>("inputLabel"));
 
-  FEDRawDataCollection_ = consumes <FEDRawDataCollection> (config_.getParameter<edm::InputTag>("inputLabel"));
+  produces<edm::DetSetVector<CTPPSPixelDigi>>();
 
+  includeErrors_ = config_.getParameter<bool>("includeErrors");
+  mappingLabel_ = config_.getParameter<std::string>("mappingLabel");
 
-  produces< edm::DetSetVector<CTPPSPixelDigi> >();
-
-  includeErrors_ = config_.getParameter<bool> ("includeErrors");
-  mappingLabel_ = config_.getParameter<std::string> ("mappingLabel"); 
-
-  if(includeErrors_){
-    produces< edm::DetSetVector<CTPPSPixelDataError> >();
+  if (includeErrors_) {
+    produces<edm::DetSetVector<CTPPSPixelDataError>>();
   }
 }
 
-
 CTPPSPixelRawToDigi::~CTPPSPixelRawToDigi() {
-  edm::LogInfo("CTPPSPixelRawToDigi")  << " CTPPSPixelRawToDigi destructor!";
-
+  edm::LogInfo("CTPPSPixelRawToDigi") << " CTPPSPixelRawToDigi destructor!";
 }
 
 void CTPPSPixelRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<bool>("includeErrors",true);
-  desc.add<edm::InputTag>("inputLabel",edm::InputTag("rawDataCollector"));
-  desc.add<std::string>("mappingLabel","RPix");
+  desc.add<bool>("includeErrors", true);
+  desc.add<edm::InputTag>("inputLabel", edm::InputTag("rawDataCollector"));
+  desc.add<std::string>("mappingLabel", "RPix");
   descriptions.add("ctppsPixelDigis", desc);
 }
 
-
-void CTPPSPixelRawToDigi::produce( edm::Event& ev,
-				   const edm::EventSetup& es) 
-{
-
+void CTPPSPixelRawToDigi::produce(edm::Event& ev, const edm::EventSetup& es) {
   edm::Handle<FEDRawDataCollection> buffers;
   ev.getByToken(FEDRawDataCollection_, buffers);
 
   edm::ESHandle<CTPPSPixelDAQMapping> mapping;
 
-  bool data_exist=false;
-  for(int fed = FEDNumbering::MINCTPPSPixelsFEDID; fed <=  FEDNumbering::MAXCTPPSPixelsFEDID; fed++){
-    const FEDRawData& tempRawData = buffers->FEDData( fed );
-    if(tempRawData.size()!=0){
-      data_exist=true;
+  bool data_exist = false;
+  for (int fed = FEDNumbering::MINCTPPSPixelsFEDID; fed <= FEDNumbering::MAXCTPPSPixelsFEDID; fed++) {
+    const FEDRawData& tempRawData = buffers->FEDData(fed);
+    if (tempRawData.size() != 0) {
+      data_exist = true;
       break;
     }
   }
-/// create product (digis & errors)
+  /// create product (digis & errors)
   auto collection = std::make_unique<edm::DetSetVector<CTPPSPixelDigi>>();
 
   auto errorcollection = std::make_unique<edm::DetSetVector<CTPPSPixelDataError>>();
 
-  if(data_exist){
-  es.get<CTPPSPixelDAQMappingRcd>().get( mapping);
+  if (data_exist) {
+    es.get<CTPPSPixelDAQMappingRcd>().get(mapping);
 
-    fedIds_   = mapping->fedIds();
+    fedIds_ = mapping->fedIds();
 
     CTPPSPixelDataFormatter formatter(mapping->ROCMapping);
     formatter.setErrorStatus(includeErrors_);
@@ -89,43 +79,43 @@ void CTPPSPixelRawToDigi::produce( edm::Event& ev,
     bool errorsInEvent = false;
     CTPPSPixelDataFormatter::DetErrors nodeterrors;
 
-
     for (auto aFed = fedIds_.begin(); aFed != fedIds_.end(); ++aFed) {
       int fedId = *aFed;
-      
-      edm::LogInfo("CTPPSPixelRawToDigi")<< " PRODUCE DIGI FOR FED: " <<  dec <<fedId << endl;
+
+      edm::LogInfo("CTPPSPixelRawToDigi") << " PRODUCE DIGI FOR FED: " << dec << fedId << endl;
 
       CTPPSPixelDataFormatter::Errors errors;
-/// get event data for this fed
-      const FEDRawData& fedRawData = buffers->FEDData( fedId );
-      
-      formatter.interpretRawData( errorsInEvent, fedId, fedRawData, *collection, errors);
-    
-      if(includeErrors_) {
-	for(auto const &is : errors){ 
-	  uint32_t errordetid = is.first;
-	/// errors given dummy detId must be sorted by Fed
-	  if (errordetid==RPixErrorChecker::dummyDetId) {          
-	    nodeterrors.insert( nodeterrors.end(), errors[errordetid].begin(), errors[errordetid].end() );
-	  } else {
-	    edm::DetSet<CTPPSPixelDataError>& errorDetSet = errorcollection->find_or_insert(errordetid);
-	    errorDetSet.data.insert(errorDetSet.data.end(), is.second.begin(), is.second.end());	  
-	  }
-	}
+      /// get event data for this fed
+      const FEDRawData& fedRawData = buffers->FEDData(fedId);
+
+      formatter.interpretRawData(errorsInEvent, fedId, fedRawData, *collection, errors);
+
+      if (includeErrors_) {
+        for (auto const& is : errors) {
+          uint32_t errordetid = is.first;
+          /// errors given dummy detId must be sorted by Fed
+          if (errordetid == RPixErrorChecker::dummyDetId) {
+            nodeterrors.insert(nodeterrors.end(), errors[errordetid].begin(), errors[errordetid].end());
+          } else {
+            edm::DetSet<CTPPSPixelDataError>& errorDetSet = errorcollection->find_or_insert(errordetid);
+            errorDetSet.data.insert(errorDetSet.data.end(), is.second.begin(), is.second.end());
+          }
+        }
       }
     }
 
-    if(includeErrors_) {
+    if (includeErrors_) {
       errorcollection->find_or_insert(RPixErrorChecker::dummyDetId).data = nodeterrors;
     }
-    if (errorsInEvent) LogDebug("CTPPSPixelRawToDigi") << "Error words were stored in this event";
+    if (errorsInEvent)
+      LogDebug("CTPPSPixelRawToDigi") << "Error words were stored in this event";
   }
-///send digis and errors back to framework 
+  ///send digis and errors back to framework
   ev.put(std::move(collection));
 
-  if(includeErrors_){
+  if (includeErrors_) {
     ev.put(std::move(errorcollection));
   }
 }
 
-DEFINE_FWK_MODULE( CTPPSPixelRawToDigi);
+DEFINE_FWK_MODULE(CTPPSPixelRawToDigi);

--- a/EventFilter/CTPPSRawToDigi/plugins/TotemTriggerRawToDigi.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/TotemTriggerRawToDigi.cc
@@ -24,21 +24,20 @@
 
 //----------------------------------------------------------------------------------------------------
 
-class TotemTriggerRawToDigi : public edm::stream::EDProducer<>
-{
-  public:
-    explicit TotemTriggerRawToDigi(const edm::ParameterSet&);
-    ~TotemTriggerRawToDigi() override;
+class TotemTriggerRawToDigi : public edm::stream::EDProducer<> {
+public:
+  explicit TotemTriggerRawToDigi(const edm::ParameterSet &);
+  ~TotemTriggerRawToDigi() override;
 
-    void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
 
-  private:
-    unsigned int fedId;
+private:
+  unsigned int fedId;
 
-    edm::EDGetTokenT<FEDRawDataCollection> fedDataToken;
+  edm::EDGetTokenT<FEDRawDataCollection> fedDataToken;
 
-    /// Process one LoneG frame.
-    int ProcessLoneGFrame(uint64_t *oBuf, unsigned long size, TotemTriggerCounters &data);
+  /// Process one LoneG frame.
+  int ProcessLoneGFrame(uint64_t *oBuf, unsigned long size, TotemTriggerCounters &data);
 };
 
 //----------------------------------------------------------------------------------------------------
@@ -48,9 +47,8 @@ using namespace std;
 
 //----------------------------------------------------------------------------------------------------
 
-TotemTriggerRawToDigi::TotemTriggerRawToDigi(const edm::ParameterSet &conf):
-  fedId(conf.getParameter<unsigned int>("fedId"))
-{
+TotemTriggerRawToDigi::TotemTriggerRawToDigi(const edm::ParameterSet &conf)
+    : fedId(conf.getParameter<unsigned int>("fedId")) {
   fedDataToken = consumes<FEDRawDataCollection>(conf.getParameter<edm::InputTag>("rawDataTag"));
 
   if (fedId == 0)
@@ -61,14 +59,11 @@ TotemTriggerRawToDigi::TotemTriggerRawToDigi(const edm::ParameterSet &conf):
 
 //----------------------------------------------------------------------------------------------------
 
-TotemTriggerRawToDigi::~TotemTriggerRawToDigi()
-{
-}
+TotemTriggerRawToDigi::~TotemTriggerRawToDigi() {}
 
 //----------------------------------------------------------------------------------------------------
 
-void TotemTriggerRawToDigi::produce(edm::Event& event, const edm::EventSetup &es)
-{
+void TotemTriggerRawToDigi::produce(edm::Event &event, const edm::EventSetup &es) {
   // raw data handle
   edm::Handle<FEDRawDataCollection> rawData;
   event.getByToken(fedDataToken, rawData);
@@ -78,8 +73,8 @@ void TotemTriggerRawToDigi::produce(edm::Event& event, const edm::EventSetup &es
 
   // unpack trigger data
   const FEDRawData &data = rawData->FEDData(fedId);
-  uint64_t *buf = (uint64_t *) data.data();
-  unsigned int sizeInWords = data.size() / 8; // bytes -> words
+  uint64_t *buf = (uint64_t *)data.data();
+  unsigned int sizeInWords = data.size() / 8;  // bytes -> words
   if (data.size() > 0)
     ProcessLoneGFrame(buf + 2, sizeInWords - 4, totemTriggerCounters);
 
@@ -89,12 +84,10 @@ void TotemTriggerRawToDigi::produce(edm::Event& event, const edm::EventSetup &es
 
 //----------------------------------------------------------------------------------------------------
 
-int TotemTriggerRawToDigi::ProcessLoneGFrame(uint64_t *oBuf, unsigned long size, TotemTriggerCounters &td)
-{
-  if (size != 20)
-  {
-    LogError("Totem") << "Error in TotemTriggerRawToDigi::ProcessLoneGFrame > " <<
-      "Wrong LoneG frame size: " << size << " (shall be 20)." << endl;
+int TotemTriggerRawToDigi::ProcessLoneGFrame(uint64_t *oBuf, unsigned long size, TotemTriggerCounters &td) {
+  if (size != 20) {
+    LogError("Totem") << "Error in TotemTriggerRawToDigi::ProcessLoneGFrame > "
+                      << "Wrong LoneG frame size: " << size << " (shall be 20)." << endl;
     return 1;
   }
 
@@ -103,11 +96,10 @@ int TotemTriggerRawToDigi::ProcessLoneGFrame(uint64_t *oBuf, unsigned long size,
   for (unsigned int i = 0; i < 5; i++)
     buf[i] = 0;
 
-  for (unsigned int i = 0; i < 20; i++)
-  {
-      int row = i / 4;
-      int col = i % 4;
-      buf[row] |= (oBuf[i] & 0xFFFF) << (col * 16);
+  for (unsigned int i = 0; i < 20; i++) {
+    int row = i / 4;
+    int col = i % 4;
+    buf[row] |= (oBuf[i] & 0xFFFF) << (col * 16);
   }
 
   td.type = (buf[0] >> 56) & 0xF;
@@ -126,14 +118,11 @@ int TotemTriggerRawToDigi::ProcessLoneGFrame(uint64_t *oBuf, unsigned long size,
 
 #ifdef DEBUG
   printf(">> RawDataUnpacker::ProcessLoneGFrame > size = %li\n", size);
-  printf("\ttype = %x, event number = %x, bunch number = %x, id = %x\n",
-    td.type, td.event_num, td.bunch_num, td.src_id);
-  printf("\torbit number = %x, revision = %x\n",
-    td.orbit_num, td.revision_num);
-  printf("\trun number = %x, trigger number = %x\n",
-    td.run_num, td.trigger_num);
-  printf("\tinhibited triggers = %x, input status bits = %x\n",
-    td.inhibited_triggers_num, td.input_status_bits);
+  printf(
+      "\ttype = %x, event number = %x, bunch number = %x, id = %x\n", td.type, td.event_num, td.bunch_num, td.src_id);
+  printf("\torbit number = %x, revision = %x\n", td.orbit_num, td.revision_num);
+  printf("\trun number = %x, trigger number = %x\n", td.run_num, td.trigger_num);
+  printf("\tinhibited triggers = %x, input status bits = %x\n", td.inhibited_triggers_num, td.input_status_bits);
 #endif
 
   return 0;

--- a/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
+++ b/EventFilter/CTPPSRawToDigi/plugins/TotemVFATRawToDigi.cc
@@ -37,29 +37,28 @@
 
 //----------------------------------------------------------------------------------------------------
 
-class TotemVFATRawToDigi : public edm::stream::EDProducer<>
-{
-  public:
-    explicit TotemVFATRawToDigi(const edm::ParameterSet&);
-    ~TotemVFATRawToDigi() override;
+class TotemVFATRawToDigi : public edm::stream::EDProducer<> {
+public:
+  explicit TotemVFATRawToDigi(const edm::ParameterSet &);
+  ~TotemVFATRawToDigi() override;
 
-    void produce(edm::Event&, const edm::EventSetup&) override;
-    void endStream() override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
+  void endStream() override;
 
-  private:
-    std::string subSystemName;
+private:
+  std::string subSystemName;
 
-    enum { ssUndefined, ssTrackingStrip, ssTimingDiamond, ssTotemTiming } subSystem;
+  enum { ssUndefined, ssTrackingStrip, ssTimingDiamond, ssTotemTiming } subSystem;
 
-    std::vector<unsigned int> fedIds;
+  std::vector<unsigned int> fedIds;
 
-    edm::EDGetTokenT<FEDRawDataCollection> fedDataToken;
+  edm::EDGetTokenT<FEDRawDataCollection> fedDataToken;
 
-    ctpps::RawDataUnpacker rawDataUnpacker;
-    RawToDigiConverter rawToDigiConverter;
+  ctpps::RawDataUnpacker rawDataUnpacker;
+  RawToDigiConverter rawToDigiConverter;
 
-    template <typename DigiType>
-    void run(edm::Event&, const edm::EventSetup&);
+  template <typename DigiType>
+  void run(edm::Event &, const edm::EventSetup &);
 };
 
 //----------------------------------------------------------------------------------------------------
@@ -69,13 +68,12 @@ using namespace std;
 
 //----------------------------------------------------------------------------------------------------
 
-TotemVFATRawToDigi::TotemVFATRawToDigi(const edm::ParameterSet &conf):
-  subSystemName(conf.getParameter<string>("subSystem")),
-  subSystem(ssUndefined),
-  fedIds(conf.getParameter< vector<unsigned int> >("fedIds")),
-  rawDataUnpacker(conf.getParameterSet("RawUnpacking")),
-  rawToDigiConverter(conf.getParameterSet("RawToDigi"))
-{
+TotemVFATRawToDigi::TotemVFATRawToDigi(const edm::ParameterSet &conf)
+    : subSystemName(conf.getParameter<string>("subSystem")),
+      subSystem(ssUndefined),
+      fedIds(conf.getParameter<vector<unsigned int>>("fedIds")),
+      rawDataUnpacker(conf.getParameterSet("RawUnpacking")),
+      rawToDigiConverter(conf.getParameterSet("RawToDigi")) {
   fedDataToken = consumes<FEDRawDataCollection>(conf.getParameter<edm::InputTag>("rawDataTag"));
 
   // validate chosen subSystem
@@ -87,20 +85,21 @@ TotemVFATRawToDigi::TotemVFATRawToDigi(const edm::ParameterSet &conf):
     subSystem = ssTotemTiming;
 
   if (subSystem == ssUndefined)
-    throw cms::Exception("TotemVFATRawToDigi::TotemVFATRawToDigi") << "Unknown sub-system string " << subSystemName << "." << endl;
+    throw cms::Exception("TotemVFATRawToDigi::TotemVFATRawToDigi")
+        << "Unknown sub-system string " << subSystemName << "." << endl;
 
   // FED (OptoRx) headers and footers
-  produces< vector<TotemFEDInfo> >(subSystemName);
+  produces<vector<TotemFEDInfo>>(subSystemName);
 
   // declare products
   if (subSystem == ssTrackingStrip)
-    produces< DetSetVector<TotemRPDigi> >(subSystemName);
+    produces<DetSetVector<TotemRPDigi>>(subSystemName);
 
   else if (subSystem == ssTimingDiamond)
-    produces< DetSetVector<CTPPSDiamondDigi> >(subSystemName);
+    produces<DetSetVector<CTPPSDiamondDigi>>(subSystemName);
 
   else if (subSystem == ssTotemTiming)
-    produces< DetSetVector<TotemTimingDigi> >(subSystemName);
+    produces<DetSetVector<TotemTimingDigi>>(subSystemName);
 
   // set default IDs
   if (fedIds.empty()) {
@@ -118,40 +117,37 @@ TotemVFATRawToDigi::TotemVFATRawToDigi(const edm::ParameterSet &conf):
     }
 
     else if (subSystem == ssTotemTiming) {
-      for (int id = FEDNumbering::MINTotemRPTimingVerticalFEDID; id <= FEDNumbering::MAXTotemRPTimingVerticalFEDID; ++id)
+      for (int id = FEDNumbering::MINTotemRPTimingVerticalFEDID; id <= FEDNumbering::MAXTotemRPTimingVerticalFEDID;
+           ++id)
         fedIds.push_back(id);
     }
   }
 
   // conversion status
-  produces< DetSetVector<TotemVFATStatus> >(subSystemName);
+  produces<DetSetVector<TotemVFATStatus>>(subSystemName);
 }
 
 //----------------------------------------------------------------------------------------------------
 
-TotemVFATRawToDigi::~TotemVFATRawToDigi()
-{
-}
+TotemVFATRawToDigi::~TotemVFATRawToDigi() {}
 
 //----------------------------------------------------------------------------------------------------
 
-void TotemVFATRawToDigi::produce(edm::Event& event, const edm::EventSetup &es)
-{
+void TotemVFATRawToDigi::produce(edm::Event &event, const edm::EventSetup &es) {
   if (subSystem == ssTrackingStrip)
-    run< DetSetVector<TotemRPDigi> >(event, es);
+    run<DetSetVector<TotemRPDigi>>(event, es);
 
   else if (subSystem == ssTimingDiamond)
-    run< DetSetVector<CTPPSDiamondDigi> >(event, es);
+    run<DetSetVector<CTPPSDiamondDigi>>(event, es);
 
   else if (subSystem == ssTotemTiming)
-    run< DetSetVector<TotemTimingDigi> >(event, es);
+    run<DetSetVector<TotemTimingDigi>>(event, es);
 }
 
 //----------------------------------------------------------------------------------------------------
 
 template <typename DigiType>
-void TotemVFATRawToDigi::run(edm::Event& event, const edm::EventSetup &es)
-{
+void TotemVFATRawToDigi::run(edm::Event &event, const edm::EventSetup &es) {
   // get DAQ mapping
   ESHandle<TotemDAQMapping> mapping;
   es.get<TotemReadoutRcd>().get(subSystemName, mapping);
@@ -171,8 +167,7 @@ void TotemVFATRawToDigi::run(edm::Event& event, const edm::EventSetup &es)
 
   // raw-data unpacking
   SimpleVFATFrameCollection vfatCollection;
-  for (const auto &fedId : fedIds)
-  {
+  for (const auto &fedId : fedIds) {
     const FEDRawData &data = rawData->FEDData(fedId);
     if (data.size() > 0)
       rawDataUnpacker.run(fedId, data, fedInfo, vfatCollection);
@@ -189,9 +184,6 @@ void TotemVFATRawToDigi::run(edm::Event& event, const edm::EventSetup &es)
 
 //----------------------------------------------------------------------------------------------------
 
-void TotemVFATRawToDigi::endStream()
-{
-  rawToDigiConverter.printSummaries();
-}
+void TotemVFATRawToDigi::endStream() { rawToDigiConverter.printSummaries(); }
 
 DEFINE_FWK_MODULE(TotemVFATRawToDigi);

--- a/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CTPPSPixelDataFormatter.cc
@@ -4,7 +4,7 @@
 #include "DataFormats/FEDRawData/interface/FEDHeader.h"
 #include "DataFormats/FEDRawData/interface/FEDTrailer.h"
 
-#include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelROC.h" //KS
+#include "CondFormats/CTPPSReadoutObjects/interface/CTPPSPixelROC.h"  //KS
 
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -17,181 +17,179 @@ using namespace edm;
 
 namespace {
   constexpr int m_LINK_bits = 6;
-  constexpr int m_ROC_bits  = 5;
+  constexpr int m_ROC_bits = 5;
   constexpr int m_DCOL_bits = 5;
   constexpr int m_PXID_bits = 8;
-  constexpr int m_ADC_bits  = 8;
+  constexpr int m_ADC_bits = 8;
   constexpr int min_Dcol = 0;
   constexpr int max_Dcol = 25;
   constexpr int min_Pixid = 2;
   constexpr int max_Pixid = 161;
   constexpr int maxRocIndex = 3;
   constexpr int maxLinkIndex = 13;
-}
+}  // namespace
 
-CTPPSPixelDataFormatter::CTPPSPixelDataFormatter(std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo> const &mapping)  :  m_WordCounter(0), m_Mapping(mapping)
-{
+CTPPSPixelDataFormatter::CTPPSPixelDataFormatter(std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo> const& mapping)
+    : m_WordCounter(0), m_Mapping(mapping) {
   int s32 = sizeof(Word32);
   int s64 = sizeof(Word64);
-  int s8  = sizeof(char);
-  if ( s8 != 1 || s32 != 4*s8 || s64 != 2*s32) {
-    LogError("UnexpectedSizes")
-      <<" unexpected sizes: "
-      <<"  size of char is: " << s8
-      <<", size of Word32 is: " << s32
-      <<", size of Word64 is: " << s64
-      <<", send exception" ;
+  int s8 = sizeof(char);
+  if (s8 != 1 || s32 != 4 * s8 || s64 != 2 * s32) {
+    LogError("UnexpectedSizes") << " unexpected sizes: "
+                                << "  size of char is: " << s8 << ", size of Word32 is: " << s32
+                                << ", size of Word64 is: " << s64 << ", send exception";
   }
 
   m_IncludeErrors = false;
 
-  m_ADC_shift  = 0;
+  m_ADC_shift = 0;
   m_PXID_shift = m_ADC_shift + m_ADC_bits;
   m_DCOL_shift = m_PXID_shift + m_PXID_bits;
-  m_ROC_shift  = m_DCOL_shift + m_DCOL_bits;
-
+  m_ROC_shift = m_DCOL_shift + m_DCOL_bits;
 
   m_LINK_shift = m_ROC_shift + m_ROC_bits;
   m_LINK_mask = ~(~CTPPSPixelDataFormatter::Word32(0) << m_LINK_bits);
-  m_ROC_mask  = ~(~CTPPSPixelDataFormatter::Word32(0) << m_ROC_bits);    
+  m_ROC_mask = ~(~CTPPSPixelDataFormatter::Word32(0) << m_ROC_bits);
 
   m_DCOL_mask = ~(~CTPPSPixelDataFormatter::Word32(0) << m_DCOL_bits);
   m_PXID_mask = ~(~CTPPSPixelDataFormatter::Word32(0) << m_PXID_bits);
-  m_ADC_mask  = ~(~CTPPSPixelDataFormatter::Word32(0) << m_ADC_bits);
-
+  m_ADC_mask = ~(~CTPPSPixelDataFormatter::Word32(0) << m_ADC_bits);
 }
 
-
-void CTPPSPixelDataFormatter::setErrorStatus(bool errorStatus)
-{
+void CTPPSPixelDataFormatter::setErrorStatus(bool errorStatus) {
   m_IncludeErrors = errorStatus;
   m_ErrorCheck.setErrorStatus(m_IncludeErrors);
 }
 
+void CTPPSPixelDataFormatter::interpretRawData(
+    bool& errorsInEvent, int fedId, const FEDRawData& rawData, Collection& digis, Errors& errors) {
+  int nWords = rawData.size() / sizeof(Word64);
+  if (nWords == 0)
+    return;
 
-void CTPPSPixelDataFormatter::interpretRawData(  bool& errorsInEvent, int fedId, const FEDRawData& rawData, 
-						 Collection & digis, Errors & errors)
-{
+  /// check CRC bit
+  const Word64* trailer = reinterpret_cast<const Word64*>(rawData.data()) + (nWords - 1);
+  if (!m_ErrorCheck.checkCRC(errorsInEvent, fedId, trailer, errors))
+    return;
 
-  int nWords = rawData.size()/sizeof(Word64);
-  if (nWords==0) return;
-
-/// check CRC bit
-  const Word64* trailer = reinterpret_cast<const Word64* >(rawData.data())+(nWords-1);  
-  if(!m_ErrorCheck.checkCRC(errorsInEvent, fedId, trailer, errors)) return;
-
-/// check headers
-  const Word64* header = reinterpret_cast<const Word64* >(rawData.data()); header--;
+  /// check headers
+  const Word64* header = reinterpret_cast<const Word64*>(rawData.data());
+  header--;
   bool moreHeaders = true;
   while (moreHeaders) {
     header++;
-    LogTrace("")<<"HEADER:  " <<  print(*header);
+    LogTrace("") << "HEADER:  " << print(*header);
     bool headerStatus = m_ErrorCheck.checkHeader(errorsInEvent, fedId, header, errors);
     moreHeaders = headerStatus;
   }
 
-/// check trailers
+  /// check trailers
   bool moreTrailers = true;
   trailer++;
   while (moreTrailers) {
     trailer--;
-    LogTrace("")<<"TRAILER: " <<  print(*trailer);
+    LogTrace("") << "TRAILER: " << print(*trailer);
     bool trailerStatus = m_ErrorCheck.checkTrailer(errorsInEvent, fedId, nWords, trailer, errors);
     moreTrailers = trailerStatus;
   }
 
-/// data words
-  m_WordCounter += 2*(nWords-2);
-  LogTrace("")<<"data words: "<< (trailer-header-1);
+  /// data words
+  m_WordCounter += 2 * (nWords - 2);
+  LogTrace("") << "data words: " << (trailer - header - 1);
 
   int link = -1;
-  int roc  = -1;
+  int roc = -1;
 
-  bool skipROC=false;
+  bool skipROC = false;
 
-  edm::DetSet<CTPPSPixelDigi> * detDigis=nullptr;
+  edm::DetSet<CTPPSPixelDigi>* detDigis = nullptr;
 
-  const  Word32 * bw =(const  Word32 *)(header+1);
-  const  Word32 * ew =(const  Word32 *)(trailer);
-  if ( *(ew-1) == 0 ) { ew--;  m_WordCounter--;}
+  const Word32* bw = (const Word32*)(header + 1);
+  const Word32* ew = (const Word32*)(trailer);
+  if (*(ew - 1) == 0) {
+    ew--;
+    m_WordCounter--;
+  }
   for (auto word = bw; word < ew; ++word) {
-    LogTrace("")<<"DATA: " <<  print(*word);
+    LogTrace("") << "DATA: " << print(*word);
 
     auto ww = *word;
-    if UNLIKELY(ww==0) { m_WordCounter--; continue;}
-    int nlink = (ww >> m_LINK_shift) & m_LINK_mask; 
-    int nroc  = (ww >> m_ROC_shift) & m_ROC_mask;
+    if
+      UNLIKELY(ww == 0) {
+        m_WordCounter--;
+        continue;
+      }
+    int nlink = (ww >> m_LINK_shift) & m_LINK_mask;
+    int nroc = (ww >> m_ROC_shift) & m_ROC_mask;
 
     int FMC = 0;
-    uint32_t iD = RPixErrorChecker::dummyDetId;//0xFFFFFFFF; //dummyDetId
-    int convroc = nroc-1;
+    uint32_t iD = RPixErrorChecker::dummyDetId;  //0xFFFFFFFF; //dummyDetId
+    int convroc = nroc - 1;
     CTPPSPixelFramePosition fPos(fedId, FMC, nlink, convroc);
     std::map<CTPPSPixelFramePosition, CTPPSPixelROCInfo>::const_iterator mit;
     mit = m_Mapping.find(fPos);
 
-    if (mit == m_Mapping.end()){      
-      if(nlink >= maxLinkIndex){
-	m_ErrorCheck.conversionError(fedId, iD, InvalidLinkId, ww, errors);
+    if (mit == m_Mapping.end()) {
+      if (nlink >= maxLinkIndex) {
+        m_ErrorCheck.conversionError(fedId, iD, InvalidLinkId, ww, errors);
+      } else if ((nroc - 1) >= maxRocIndex) {
+        m_ErrorCheck.conversionError(fedId, iD, InvalidROCId, ww, errors);
+      } else {
+        m_ErrorCheck.conversionError(fedId, iD, Unknown, ww, errors);
       }
-      else if((nroc-1)>=maxRocIndex){
-	m_ErrorCheck.conversionError(fedId, iD, InvalidROCId, ww, errors);
-      }else{
-	m_ErrorCheck.conversionError(fedId, iD, Unknown, ww, errors);
-      }
-      continue; //skip word
+      continue;  //skip word
     }
 
     CTPPSPixelROCInfo rocInfo = (*mit).second;
     iD = rocInfo.iD;
     CTPPSPixelROC rocp(iD, rocInfo.roc, convroc);
 
-    if ( (nlink!=link) | (nroc!=roc) ) {  // new roc
-      link = nlink; roc=nroc;
+    if ((nlink != link) | (nroc != roc)) {  // new roc
+      link = nlink;
+      roc = nroc;
 
-      skipROC = LIKELY((roc-1)<maxRocIndex) ? false : !m_ErrorCheck.checkROC(errorsInEvent, fedId, iD,  ww, errors); 
-      if (skipROC) continue;
+      skipROC = LIKELY((roc - 1) < maxRocIndex) ? false : !m_ErrorCheck.checkROC(errorsInEvent, fedId, iD, ww, errors);
+      if (skipROC)
+        continue;
 
       auto rawId = rocp.rawId();
 
       detDigis = &digis.find_or_insert(rawId);
-      if ( (*detDigis).empty() ) (*detDigis).data.reserve(32); // avoid the first relocations
-
+      if ((*detDigis).empty())
+        (*detDigis).data.reserve(32);  // avoid the first relocations
     }
-  
-    int adc  = (ww >> m_ADC_shift) & m_ADC_mask;
- 
+
+    int adc = (ww >> m_ADC_shift) & m_ADC_mask;
+
     int dcol = (ww >> m_DCOL_shift) & m_DCOL_mask;
     int pxid = (ww >> m_PXID_shift) & m_PXID_mask;
 
-    if(dcol<min_Dcol || dcol>max_Dcol || pxid<min_Pixid || pxid>max_Pixid){
-      edm::LogError("CTPPSPixelDataFormatter")<< " unphysical dcol and/or pxid "  << " nllink=" << nlink 
-					      << " nroc="<< nroc << " adc=" << adc << " dcol=" << dcol << " pxid=" << pxid;
+    if (dcol < min_Dcol || dcol > max_Dcol || pxid < min_Pixid || pxid > max_Pixid) {
+      edm::LogError("CTPPSPixelDataFormatter")
+          << " unphysical dcol and/or pxid "
+          << " nllink=" << nlink << " nroc=" << nroc << " adc=" << adc << " dcol=" << dcol << " pxid=" << pxid;
 
       m_ErrorCheck.conversionError(fedId, iD, InvalidPixelId, ww, errors);
 
       continue;
     }
 
-    std::pair<int,int> rocPixel;
-    std::pair<int,int> modPixel;
+    std::pair<int, int> rocPixel;
+    std::pair<int, int> modPixel;
 
-    rocPixel = std::make_pair(dcol,pxid);
+    rocPixel = std::make_pair(dcol, pxid);
 
     modPixel = rocp.toGlobalfromDcol(rocPixel);
 
     CTPPSPixelDigi testdigi(modPixel.first, modPixel.second, adc);
 
-    if(detDigis)
-    (*detDigis).data.emplace_back( modPixel.first, modPixel.second, adc); 
- 
+    if (detDigis)
+      (*detDigis).data.emplace_back(modPixel.first, modPixel.second, adc);
   }
-
 }
 
-
-std::string CTPPSPixelDataFormatter::print(const  Word64 & word) const
-{
+std::string CTPPSPixelDataFormatter::print(const Word64& word) const {
   std::ostringstream str;
-  str  <<"word64:  " << reinterpret_cast<const std::bitset<64>&> (word);
+  str << "word64:  " << reinterpret_cast<const std::bitset<64>&>(word);
   return str.str();
 }

--- a/EventFilter/CTPPSRawToDigi/src/CounterChecker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/CounterChecker.cc
@@ -15,10 +15,9 @@ using namespace std;
 
 //-------------------------------------------------------------------------------------------------
 
-void CounterChecker::Fill(word counter, TotemFramePosition fr)
-{
+void CounterChecker::Fill(word counter, TotemFramePosition fr) {
   pair<CounterMap::iterator, bool> ret;
-  
+
   vector<TotemFramePosition> list;
   list.push_back(fr);
   ret = relationMap.insert(pair<word, vector<TotemFramePosition> >(counter, list));

--- a/EventFilter/CTPPSRawToDigi/src/RPixErrorChecker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RPixErrorChecker.cc
@@ -7,25 +7,18 @@
 
 using namespace edm;
 
-constexpr RPixErrorChecker::Word32 RPixErrorChecker::dummyDetId ;
+constexpr RPixErrorChecker::Word32 RPixErrorChecker::dummyDetId;
 
-RPixErrorChecker::RPixErrorChecker() 
-{
-  includeErrors_ = false;
-}
+RPixErrorChecker::RPixErrorChecker() { includeErrors_ = false; }
 
-void RPixErrorChecker::setErrorStatus(bool errorStatus)
-{
-  includeErrors_ = errorStatus;
-}
+void RPixErrorChecker::setErrorStatus(bool errorStatus) { includeErrors_ = errorStatus; }
 
-bool RPixErrorChecker::checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer,  Errors& errors) const
-{
+bool RPixErrorChecker::checkCRC(bool& errorsInEvent, int fedId, const Word64* trailer, Errors& errors) const {
   int CRC_BIT = (*trailer >> CRC_shift) & CRC_mask;
-  if (CRC_BIT == 0) return true;
+  if (CRC_BIT == 0)
+    return true;
   errorsInEvent = true;
-  LogDebug("CRCCheck")
-    <<"CRC check failed,  errorType = 39";
+  LogDebug("CRCCheck") << "CRC check failed,  errorType = 39";
   if (includeErrors_) {
     int errorType = 39;
     CTPPSPixelDataError error(*trailer, errorType, fedId);
@@ -34,14 +27,13 @@ bool RPixErrorChecker::checkCRC(bool& errorsInEvent, int fedId, const Word64* tr
   return false;
 }
 
-bool RPixErrorChecker::checkHeader(bool& errorsInEvent, int fedId, const Word64* header,  Errors& errors) const
-{
-  FEDHeader fedHeader( reinterpret_cast<const unsigned char*>(header));
-  if ( !fedHeader.check() ) return false; 
-  if ( fedHeader.sourceID() != fedId) { 
+bool RPixErrorChecker::checkHeader(bool& errorsInEvent, int fedId, const Word64* header, Errors& errors) const {
+  FEDHeader fedHeader(reinterpret_cast<const unsigned char*>(header));
+  if (!fedHeader.check())
+    return false;
+  if (fedHeader.sourceID() != fedId) {
     LogDebug("CTPPSPixelDataFormatter::interpretRawData, fedHeader.sourceID() != fedId")
-      <<", sourceID = " <<fedHeader.sourceID()
-      <<", fedId = "<<fedId<<", errorType = 32"; 
+        << ", sourceID = " << fedHeader.sourceID() << ", fedId = " << fedId << ", errorType = 32";
     errorsInEvent = true;
     if (includeErrors_) {
       int errorType = 32;
@@ -52,24 +44,23 @@ bool RPixErrorChecker::checkHeader(bool& errorsInEvent, int fedId, const Word64*
   return fedHeader.moreHeaders();
 }
 
-bool RPixErrorChecker::checkTrailer(bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer,  Errors& errors) const
-{
+bool RPixErrorChecker::checkTrailer(
+    bool& errorsInEvent, int fedId, unsigned int nWords, const Word64* trailer, Errors& errors) const {
   FEDTrailer fedTrailer(reinterpret_cast<const unsigned char*>(trailer));
-  if ( !fedTrailer.check()) { 
-    if(includeErrors_) {
+  if (!fedTrailer.check()) {
+    if (includeErrors_) {
       int errorType = 33;
       CTPPSPixelDataError error(*trailer, errorType, fedId);
       errors[dummyDetId].push_back(error);
     }
     errorsInEvent = true;
-    LogDebug("FedTrailerCheck")
-      <<"fedTrailer.check failed, Fed: " << fedId << ", errorType = 33";
-    return false; 
-  } 
-  if ( fedTrailer.fragmentLength()!= nWords) {
-    LogDebug("FedTrailerLenght")<< "fedTrailer.fragmentLength()!= nWords !! Fed: " << fedId << ", errorType = 34";
+    LogDebug("FedTrailerCheck") << "fedTrailer.check failed, Fed: " << fedId << ", errorType = 33";
+    return false;
+  }
+  if (fedTrailer.fragmentLength() != nWords) {
+    LogDebug("FedTrailerLenght") << "fedTrailer.fragmentLength()!= nWords !! Fed: " << fedId << ", errorType = 34";
     errorsInEvent = true;
-    if(includeErrors_) {
+    if (includeErrors_) {
       int errorType = 34;
       CTPPSPixelDataError error(*trailer, errorType, fedId);
       errors[dummyDetId].push_back(error);
@@ -78,97 +69,101 @@ bool RPixErrorChecker::checkTrailer(bool& errorsInEvent, int fedId, unsigned int
   return fedTrailer.moreTrailers();
 }
 
-bool RPixErrorChecker::checkROC(bool& errorsInEvent, int fedId, uint32_t iD, const Word32& errorWord,  Errors& errors) const
-{
+bool RPixErrorChecker::checkROC(
+    bool& errorsInEvent, int fedId, uint32_t iD, const Word32& errorWord, Errors& errors) const {
   int errorType = (errorWord >> ROC_shift) & ERROR_mask;
-  if LIKELY(errorType<25) return true;
+  if
+    LIKELY(errorType < 25) return true;
 
   switch (errorType) {
-  case(25) : {
-    LogDebug("")<<"  invalid ROC=25 found (errorType=25)";
-    errorsInEvent = true;
-    break;
-  }
-  case(26) : {
-    LogDebug("")<<"  gap word found (errorType=26)";
-    return false;
-  }
-  case(27) : {
-    LogDebug("")<<"  dummy word found (errorType=27)";
-    return false;
-  }
-  case(28) : {
-    LogDebug("")<<"  error fifo nearly full (errorType=28)";
-    errorsInEvent = true;
-    break;
-  }
-  case(29) : {
-    LogDebug("")<<"  timeout on a channel (errorType=29)";
-    errorsInEvent = true;
-    if ((errorWord >> OMIT_ERR_shift) & OMIT_ERR_mask) {
-      LogDebug("")<<"  ...first errorType=29 error, this gets masked out";
+    case (25): {
+      LogDebug("") << "  invalid ROC=25 found (errorType=25)";
+      errorsInEvent = true;
+      break;
+    }
+    case (26): {
+      LogDebug("") << "  gap word found (errorType=26)";
       return false;
     }
-    break;
-  }
-  case(30) : {
-    LogDebug("")<<"  TBM error trailer (errorType=30)";
-    errorsInEvent = true;
-    break;
-  }
-  case(31) : {
-    LogDebug("")<<"  event number error (errorType=31)";
-    errorsInEvent = true;
-    break;
-  }
-  default: return true;
+    case (27): {
+      LogDebug("") << "  dummy word found (errorType=27)";
+      return false;
+    }
+    case (28): {
+      LogDebug("") << "  error fifo nearly full (errorType=28)";
+      errorsInEvent = true;
+      break;
+    }
+    case (29): {
+      LogDebug("") << "  timeout on a channel (errorType=29)";
+      errorsInEvent = true;
+      if ((errorWord >> OMIT_ERR_shift) & OMIT_ERR_mask) {
+        LogDebug("") << "  ...first errorType=29 error, this gets masked out";
+        return false;
+      }
+      break;
+    }
+    case (30): {
+      LogDebug("") << "  TBM error trailer (errorType=30)";
+      errorsInEvent = true;
+      break;
+    }
+    case (31): {
+      LogDebug("") << "  event number error (errorType=31)";
+      errorsInEvent = true;
+      break;
+    }
+    default:
+      return true;
   };
 
- if(includeErrors_) {
- /// check to see if overflow error for type 30, change type to 40 if so
-   if(errorType==30) {
-     uint32_t stateMach_bits      = 4;
-     uint32_t stateMach_shift     = 8;
-     uint32_t stateMach_mask = ~(~uint32_t(0) << stateMach_bits);
-     uint32_t stateMach = (errorWord >> stateMach_shift) & stateMach_mask;
-     if( stateMach==4 || stateMach==9 ) errorType = 40;
-   }
+  if (includeErrors_) {
+    /// check to see if overflow error for type 30, change type to 40 if so
+    if (errorType == 30) {
+      uint32_t stateMach_bits = 4;
+      uint32_t stateMach_shift = 8;
+      uint32_t stateMach_mask = ~(~uint32_t(0) << stateMach_bits);
+      uint32_t stateMach = (errorWord >> stateMach_shift) & stateMach_mask;
+      if (stateMach == 4 || stateMach == 9)
+        errorType = 40;
+    }
 
- /// store error
-   CTPPSPixelDataError error(errorWord, errorType, fedId);
+    /// store error
+    CTPPSPixelDataError error(errorWord, errorType, fedId);
 
-   errors[iD].push_back(error);
-}
+    errors[iD].push_back(error);
+  }
 
   return false;
 }
 
-void RPixErrorChecker::conversionError(int fedId, uint32_t iD, const State& state, const Word32& errorWord, Errors& errors) const
-{
+void RPixErrorChecker::conversionError(
+    int fedId, uint32_t iD, const State& state, const Word32& errorWord, Errors& errors) const {
   int errorType = 0;
-  
-  switch (state) {
-  case(InvalidLinkId) : {
-    LogDebug("ErrorChecker::conversionError") << " Fed: " << fedId << "  invalid channel Id (errorType=35)";
-    errorType = 35;
-    break;
-  }
-  case(InvalidROCId) : {
-    LogDebug("ErrorChecker::conversionError")<< " Fed: " << fedId << "  invalid ROC Id (errorType=36)";
-    errorType = 36;
-    break;
-  }
-  case(InvalidPixelId) : {
-    LogDebug("ErrorChecker::conversionError")<< " Fed: " << fedId << "  invalid dcol/pixel value (errorType=37)";
-    errorType = 37;
-    break;
-  }
 
-  default: LogDebug("ErrorChecker::conversionError")<<"  cabling check returned unexpected result, status = "<< state;
+  switch (state) {
+    case (InvalidLinkId): {
+      LogDebug("ErrorChecker::conversionError") << " Fed: " << fedId << "  invalid channel Id (errorType=35)";
+      errorType = 35;
+      break;
+    }
+    case (InvalidROCId): {
+      LogDebug("ErrorChecker::conversionError") << " Fed: " << fedId << "  invalid ROC Id (errorType=36)";
+      errorType = 36;
+      break;
+    }
+    case (InvalidPixelId): {
+      LogDebug("ErrorChecker::conversionError") << " Fed: " << fedId << "  invalid dcol/pixel value (errorType=37)";
+      errorType = 37;
+      break;
+    }
+
+    default:
+      LogDebug("ErrorChecker::conversionError") << "  cabling check returned unexpected result, status = " << state;
   };
 
-  if(includeErrors_ && errorType>0){
+  if (includeErrors_ && errorType > 0) {
     CTPPSPixelDataError error(errorWord, errorType, fedId);
-    errors[iD].push_back(error); 
+    errors[iD].push_back(error);
   }
 }

--- a/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawDataUnpacker.cc
@@ -19,35 +19,37 @@ using namespace ctpps;
 
 //----------------------------------------------------------------------------------------------------
 
-RawDataUnpacker::RawDataUnpacker(const edm::ParameterSet& iConfig) :
-  verbosity(iConfig.getUntrackedParameter<unsigned int>("verbosity", 0))
-{}
+RawDataUnpacker::RawDataUnpacker(const edm::ParameterSet &iConfig)
+    : verbosity(iConfig.getUntrackedParameter<unsigned int>("verbosity", 0)) {}
 
 //----------------------------------------------------------------------------------------------------
 
-int RawDataUnpacker::run(int fedId, const FEDRawData &data, vector<TotemFEDInfo> &fedInfoColl, SimpleVFATFrameCollection &coll) const
-{
-  unsigned int size_in_words = data.size() / 8; // bytes -> words
-  if (size_in_words < 2)
-  {
+int RawDataUnpacker::run(int fedId,
+                         const FEDRawData &data,
+                         vector<TotemFEDInfo> &fedInfoColl,
+                         SimpleVFATFrameCollection &coll) const {
+  unsigned int size_in_words = data.size() / 8;  // bytes -> words
+  if (size_in_words < 2) {
     if (verbosity)
-      LogWarning("Totem") << "Error in RawDataUnpacker::run > " <<
-        "Data in FED " << fedId << " too short (size = " << size_in_words << " words).";
+      LogWarning("Totem") << "Error in RawDataUnpacker::run > "
+                          << "Data in FED " << fedId << " too short (size = " << size_in_words << " words).";
     return 1;
   }
 
   fedInfoColl.push_back(TotemFEDInfo(fedId));
 
-  return processOptoRxFrame((const word *) data.data(), size_in_words, fedInfoColl.back(), &coll);
+  return processOptoRxFrame((const word *)data.data(), size_in_words, fedInfoColl.back(), &coll);
 }
 
 //----------------------------------------------------------------------------------------------------
 
-int RawDataUnpacker::processOptoRxFrame(const word *buf, unsigned int frameSize, TotemFEDInfo &fedInfo, SimpleVFATFrameCollection *fc) const
-{
+int RawDataUnpacker::processOptoRxFrame(const word *buf,
+                                        unsigned int frameSize,
+                                        TotemFEDInfo &fedInfo,
+                                        SimpleVFATFrameCollection *fc) const {
   // get OptoRx metadata
   unsigned long long head = buf[0];
-  unsigned long long foot = buf[frameSize-1];
+  unsigned long long foot = buf[frameSize - 1];
 
   fedInfo.setHeader(head);
   fedInfo.setFooter(foot);
@@ -65,21 +67,22 @@ int RawDataUnpacker::processOptoRxFrame(const word *buf, unsigned int frameSize,
   unsigned int fSize = (foot >> 32) & 0x3FF;
 
   // check header and footer structure
-  if (boe != 5 || h0 != 0 || eoe != 10 || f0 != 0 || fSize != frameSize)
-  {
+  if (boe != 5 || h0 != 0 || eoe != 10 || f0 != 0 || fSize != frameSize) {
     if (verbosity)
-      LogWarning("Totem") << "Error in RawDataUnpacker::processOptoRxFrame > " << "Wrong structure of OptoRx header/footer: "
-        << "BOE=" << boe << ", H0=" << h0 << ", EOE=" << eoe << ", F0=" << f0
-        << ", size (OptoRx)=" << fSize << ", size (DATE)=" << frameSize
-        << ". OptoRxID=" << optoRxId << ". Skipping frame." << endl;
+      LogWarning("Totem") << "Error in RawDataUnpacker::processOptoRxFrame > "
+                          << "Wrong structure of OptoRx header/footer: "
+                          << "BOE=" << boe << ", H0=" << h0 << ", EOE=" << eoe << ", F0=" << f0
+                          << ", size (OptoRx)=" << fSize << ", size (DATE)=" << frameSize << ". OptoRxID=" << optoRxId
+                          << ". Skipping frame." << endl;
     return 0;
   }
 
-  LogDebug( "Totem" ) << "RawDataUnpacker::processOptoRxFrame: "
-    << "OptoRxId = " << optoRxId << ", BX = " << bx << ", LV1 = " << lv1 << ", frameSize = " << frameSize;
+  LogDebug("Totem") << "RawDataUnpacker::processOptoRxFrame: "
+                    << "OptoRxId = " << optoRxId << ", BX = " << bx << ", LV1 = " << lv1
+                    << ", frameSize = " << frameSize;
 
-  if (optoRxId >= FEDNumbering::MINTotemRPTimingVerticalFEDID && optoRxId <= FEDNumbering::MAXTotemRPTimingVerticalFEDID)
-  {
+  if (optoRxId >= FEDNumbering::MINTotemRPTimingVerticalFEDID &&
+      optoRxId <= FEDNumbering::MAXTotemRPTimingVerticalFEDID) {
     processOptoRxFrameSampic(buf, frameSize, fedInfo, fc);
     return 0;
   }
@@ -91,19 +94,22 @@ int RawDataUnpacker::processOptoRxFrame(const word *buf, unsigned int frameSize,
     case 2:
     case 3:
       return processOptoRxFrameParallel(buf, frameSize, fedInfo, fc);
-    default: break;
+    default:
+      break;
   }
 
   if (verbosity)
-    LogWarning("Totem") << "Error in RawDataUnpacker::processOptoRxFrame > " << "Unknown FOV = " << fov << endl;
+    LogWarning("Totem") << "Error in RawDataUnpacker::processOptoRxFrame > "
+                        << "Unknown FOV = " << fov << endl;
 
   return 0;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-int RawDataUnpacker::processOptoRxFrameSerial(const word *buf, unsigned int frameSize, SimpleVFATFrameCollection *fc) const
-{
+int RawDataUnpacker::processOptoRxFrameSerial(const word *buf,
+                                              unsigned int frameSize,
+                                              SimpleVFATFrameCollection *fc) const {
   // get OptoRx metadata
   unsigned int optoRxId = (buf[0] >> 8) & 0xFFF;
 
@@ -112,39 +118,36 @@ int RawDataUnpacker::processOptoRxFrameSerial(const word *buf, unsigned int fram
 
   // process all sub-frames
   unsigned int errorCounter = 0;
-  for (unsigned int r = 0; r < subFrames; ++r)
-  {
-    for (unsigned int c = 0; c < 4; ++c)
-    {
+  for (unsigned int r = 0; r < subFrames; ++r) {
+    for (unsigned int c = 0; c < 4; ++c) {
       unsigned int head = (buf[1 + 194 * r] >> (16 * c)) & 0xFFFF;
       unsigned int foot = (buf[194 + 194 * r] >> (16 * c)) & 0xFFFF;
 
-      LogDebug( "Totem" )
-        << "r = " << r << ", c = " << c << ": "
-        << "S = " << ( head & 0x1 ) << ", BOF = " << ( head >> 12 ) << ", EOF = " << ( foot >> 12 )
-        << ", ID = " << ( ( head >> 8 ) & 0xF ) << ", ID' = " << ( ( foot >> 8) & 0xF );
+      LogDebug("Totem") << "r = " << r << ", c = " << c << ": "
+                        << "S = " << (head & 0x1) << ", BOF = " << (head >> 12) << ", EOF = " << (foot >> 12)
+                        << ", ID = " << ((head >> 8) & 0xF) << ", ID' = " << ((foot >> 8) & 0xF);
 
       // stop if this GOH is NOT active
       if ((head & 0x1) == 0)
         continue;
 
-      LogDebug( "Totem" )
-        << "Header active (" << head << " -> " << ( head & 0x1 ) << ").";
+      LogDebug("Totem") << "Header active (" << head << " -> " << (head & 0x1) << ").";
 
       // check structure
-      if (head >> 12 != 0x4 || foot >> 12 != 0xB || ((head >> 8) & 0xF) != ((foot >> 8) & 0xF))
-      {
+      if (head >> 12 != 0x4 || foot >> 12 != 0xB || ((head >> 8) & 0xF) != ((foot >> 8) & 0xF)) {
         std::ostringstream oss;
         if (head >> 12 != 0x4)
           oss << "\n\tHeader is not 0x4 as expected (0x" << std::hex << head << ").";
         if (foot >> 12 != 0xB)
           oss << "\n\tFooter is not 0xB as expected (0x" << std::hex << foot << ").";
         if (((head >> 8) & 0xF) != ((foot >> 8) & 0xF))
-          oss << "\n\tIncompatible GOH IDs in header (0x" << std::hex << ( ( head >> 8 ) & 0xF ) << ") and footer (0x" << std::hex << ( ( foot >> 8 ) & 0xF ) << ").";
+          oss << "\n\tIncompatible GOH IDs in header (0x" << std::hex << ((head >> 8) & 0xF) << ") and footer (0x"
+              << std::hex << ((foot >> 8) & 0xF) << ").";
 
         if (verbosity)
-          LogWarning("Totem") << "Error in RawDataUnpacker::processOptoRxFrame > " << "Wrong payload structure (in GOH block row " << r <<
-            " and column " << c << ") in OptoRx frame ID " << optoRxId << ". GOH block omitted." << oss.str() << endl;
+          LogWarning("Totem") << "Error in RawDataUnpacker::processOptoRxFrame > "
+                              << "Wrong payload structure (in GOH block row " << r << " and column " << c
+                              << ") in OptoRx frame ID " << optoRxId << ". GOH block omitted." << oss.str() << endl;
 
         errorCounter++;
         continue;
@@ -152,30 +155,26 @@ int RawDataUnpacker::processOptoRxFrameSerial(const word *buf, unsigned int fram
 
       // allocate memory for VFAT frames
       unsigned int goh = (head >> 8) & 0xF;
-      vector<VFATFrame::word*> dataPtrs;
-      for (unsigned int fi = 0; fi < 16; fi++)
-      {
+      vector<VFATFrame::word *> dataPtrs;
+      for (unsigned int fi = 0; fi < 16; fi++) {
         TotemFramePosition fp(0, 0, optoRxId, goh, fi);
-        dataPtrs.push_back( fc->InsertEmptyFrame(fp)->getData() );
+        dataPtrs.push_back(fc->InsertEmptyFrame(fp)->getData());
       }
 
-
-      LogDebug( "Totem" ).log( [&] (auto& l) {
-          l << "transposing GOH block at prefix: " << ( optoRxId*192+goh*16 ) << ", dataPtrs = ";
-          for(auto p: dataPtrs) {
-            l<< p<<" ";
-          }
-        });
+      LogDebug("Totem").log([&](auto &l) {
+        l << "transposing GOH block at prefix: " << (optoRxId * 192 + goh * 16) << ", dataPtrs = ";
+        for (auto p : dataPtrs) {
+          l << p << " ";
+        }
+      });
       // deserialization
-      for (int i = 0; i < 192; i++)
-      {
+      for (int i = 0; i < 192; i++) {
         int iword = 11 - i / 16;  // number of current word (11...0)
         int ibit = 15 - i % 16;   // number of current bit (15...0)
         unsigned int w = (buf[i + 2 + 194 * r] >> (16 * c)) & 0xFFFF;
 
         // Fill the current bit of the current word of all VFAT frames
-        for (int idx = 0; idx < 16; idx++)
-        {
+        for (int idx = 0; idx < 16; idx++) {
           if (w & (1 << idx))
             dataPtrs[idx][iword] |= (1 << ibit);
         }
@@ -188,26 +187,27 @@ int RawDataUnpacker::processOptoRxFrameSerial(const word *buf, unsigned int fram
 
 //----------------------------------------------------------------------------------------------------
 
-int RawDataUnpacker::processOptoRxFrameParallel(const word *buf, unsigned int frameSize, TotemFEDInfo &fedInfo, SimpleVFATFrameCollection *fc) const
-{
+int RawDataUnpacker::processOptoRxFrameParallel(const word *buf,
+                                                unsigned int frameSize,
+                                                TotemFEDInfo &fedInfo,
+                                                SimpleVFATFrameCollection *fc) const {
   // get OptoRx metadata
   unsigned long long head = buf[0];
   unsigned int optoRxId = (head >> 8) & 0xFFF;
 
   // recast data as buffer or 16bit words, skip header
-  const uint16_t *payload = (const uint16_t *) (buf + 1);
+  const uint16_t *payload = (const uint16_t *)(buf + 1);
 
   // read in OrbitCounter block
-  const uint32_t *ocPtr = (const uint32_t *) payload;
+  const uint32_t *ocPtr = (const uint32_t *)payload;
   fedInfo.setOrbitCounter(*ocPtr);
   payload += 2;
 
   // size in 16bit words, without header, footer and orbit counter block
-  unsigned int nWords = (frameSize-2) * 4 - 2;
+  unsigned int nWords = (frameSize - 2) * 4 - 2;
 
   // process all VFAT data
-  for (unsigned int offset = 0; offset < nWords;)
-  {
+  for (unsigned int offset = 0; offset < nWords;) {
     unsigned int wordsProcessed = processVFATDataParallel(payload + offset, nWords, optoRxId, fc);
     offset += wordsProcessed;
   }
@@ -217,8 +217,10 @@ int RawDataUnpacker::processOptoRxFrameParallel(const word *buf, unsigned int fr
 
 //----------------------------------------------------------------------------------------------------
 
-int RawDataUnpacker::processVFATDataParallel(const uint16_t *buf, unsigned int maxWords, unsigned int optoRxId, SimpleVFATFrameCollection *fc) const
-{
+int RawDataUnpacker::processVFATDataParallel(const uint16_t *buf,
+                                             unsigned int maxWords,
+                                             unsigned int optoRxId,
+                                             SimpleVFATFrameCollection *fc) const {
   // start counting processed words
   unsigned int wordsProcessed = 1;
 
@@ -228,11 +230,10 @@ int RawDataUnpacker::processVFATDataParallel(const uint16_t *buf, unsigned int m
 
   // check header flag
   unsigned int hFlag = (buf[0] >> 8) & 0xFF;
-  if (hFlag != vmCluster && hFlag != vmRaw && hFlag != vmDiamondCompact)
-  {
+  if (hFlag != vmCluster && hFlag != vmRaw && hFlag != vmDiamondCompact) {
     if (verbosity)
       LogWarning("Totem") << "Error in RawDataUnpacker::processVFATDataParallel > "
-        << "Unknown header flag " << hFlag << ". Skipping this word." << endl;
+                          << "Unknown header flag " << hFlag << ". Skipping this word." << endl;
     return wordsProcessed;
   }
 
@@ -277,7 +278,8 @@ int RawDataUnpacker::processVFATDataParallel(const uint16_t *buf, unsigned int m
   switch (hFlag) {
     case vmCluster: {
       unsigned int nCl = 0;
-      while ( (buf[wordsProcessed + nCl] >> 12) != 0xF && ( wordsProcessed + nCl < maxWords ) ) nCl++;
+      while ((buf[wordsProcessed + nCl] >> 12) != 0xF && (wordsProcessed + nCl < maxWords))
+        nCl++;
       wordsProcessed += nCl;
     } break;
     case vmRaw:
@@ -285,7 +287,8 @@ int RawDataUnpacker::processVFATDataParallel(const uint16_t *buf, unsigned int m
       break;
     case vmDiamondCompact: {
       wordsProcessed--;
-      while ( (buf[wordsProcessed] & 0xFFF0)!= 0xF000 && ( wordsProcessed < maxWords ) ) wordsProcessed++;
+      while ((buf[wordsProcessed] & 0xFFF0) != 0xF000 && (wordsProcessed < maxWords))
+        wordsProcessed++;
     } break;
   }
 
@@ -300,15 +303,13 @@ int RawDataUnpacker::processVFATDataParallel(const uint16_t *buf, unsigned int m
   bool skipFrame = false;
   stringstream ess;
 
-  if (tSig != 0xF)
-  {
+  if (tSig != 0xF) {
     if (verbosity)
       ess << "    Wrong trailer signature (" << tSig << ")." << endl;
     skipFrame = true;
   }
 
-  if (tErrFlags != 0)
-  {
+  if (tErrFlags != 0) {
     if (verbosity)
       ess << "    Error flags not zero (" << tErrFlags << ")." << endl;
     skipFrame = true;
@@ -316,35 +317,33 @@ int RawDataUnpacker::processVFATDataParallel(const uint16_t *buf, unsigned int m
 
   wordsProcessed++;
 
-  if (tSize != wordsProcessed)
-  {
+  if (tSize != wordsProcessed) {
     if (verbosity)
-        ess << "    Trailer size (" << tSize << ") does not match with words processed (" << wordsProcessed << ")." << endl;
+      ess << "    Trailer size (" << tSize << ") does not match with words processed (" << wordsProcessed << ")."
+          << endl;
     skipFrame = true;
   }
 
-  if (skipFrame)
-  {
+  if (skipFrame) {
     if (verbosity)
       LogWarning("Totem") << "Error in RawDataUnpacker::processVFATDataParallel > Frame at " << fp
-        << " has the following problems and will be skipped.\n" << endl << ess.rdbuf();
+                          << " has the following problems and will be skipped.\n"
+                          << endl
+                          << ess.rdbuf();
 
     return wordsProcessed;
   }
 
   // get channel data - cluster mode
-  if (hFlag == vmCluster)
-  {
-    for (unsigned int nCl = 0; (buf[dataOffset + nCl] >> 12) != 0xF && ( dataOffset + nCl < maxWords ); ++nCl)
-    {
+  if (hFlag == vmCluster) {
+    for (unsigned int nCl = 0; (buf[dataOffset + nCl] >> 12) != 0xF && (dataOffset + nCl < maxWords); ++nCl) {
       const uint16_t &w = buf[dataOffset + nCl];
       unsigned int upperBlock = w >> 8;
       unsigned int clSize = upperBlock & 0x7F;
       unsigned int clPos = (w >> 0) & 0xFF;
 
       // special case: upperBlock=0xD0 => numberOfClusters
-      if (upperBlock == 0xD0)
-      {
+      if (upperBlock == 0xD0) {
         presenceFlags |= 0x10;
         f.setNumberOfClusters(clPos);
         continue;
@@ -358,18 +357,15 @@ int RawDataUnpacker::processVFATDataParallel(const uint16_t *buf, unsigned int m
       //  convention - range <pos, pos-size+1>
       signed int chMax = clPos;
       signed int chMin = clPos - clSize + 1;
-      if (chMax < 0 || chMax > 127 || chMin < 0 || chMin > 127 || chMin > chMax)
-      {
+      if (chMax < 0 || chMax > 127 || chMin < 0 || chMin > 127 || chMin > chMax) {
         if (verbosity)
           LogWarning("Totem") << "Error in RawDataUnpacker::processVFATDataParallel > "
-            << "Invalid cluster (pos=" << clPos
-            << ", size=" << clSize << ", min=" << chMin << ", max=" << chMax << ") at " << fp
-            <<". Skipping this cluster." << endl;
+                              << "Invalid cluster (pos=" << clPos << ", size=" << clSize << ", min=" << chMin
+                              << ", max=" << chMax << ") at " << fp << ". Skipping this cluster." << endl;
         continue;
       }
 
-      for (signed int ch = chMin; ch <= chMax; ch++)
-      {
+      for (signed int ch = chMin; ch <= chMax; ch++) {
         unsigned int wi = ch / 16;
         unsigned int bi = ch % 16;
         fd[wi + 1] |= (1 << bi);
@@ -378,8 +374,7 @@ int RawDataUnpacker::processVFATDataParallel(const uint16_t *buf, unsigned int m
   }
 
   // get channel data and CRC - raw mode
-  if (hFlag == vmRaw)
-  {
+  if (hFlag == vmRaw) {
     for (unsigned int i = 0; i < 8; i++)
       fd[8 - i] = buf[dataOffset + i];
 
@@ -389,15 +384,14 @@ int RawDataUnpacker::processVFATDataParallel(const uint16_t *buf, unsigned int m
   }
 
   // get channel data for diamond compact mode
-  if (hFlag == vmDiamondCompact)
-  {
-    for (unsigned int i = 1; (buf[i+1] & 0xFFF0)!= 0xF000 && ( i+1 < maxWords ); i++) {
-      if ( ( buf[i] & 0xF000 ) == VFAT_HEADER_OF_EC ) {
+  if (hFlag == vmDiamondCompact) {
+    for (unsigned int i = 1; (buf[i + 1] & 0xFFF0) != 0xF000 && (i + 1 < maxWords); i++) {
+      if ((buf[i] & 0xF000) == VFAT_HEADER_OF_EC) {
         // Event Counter word is found
         fd[10] = buf[i];
         continue;
       }
-      switch ( buf[i] & 0xF800 ) {
+      switch (buf[i] & 0xF800) {
         case VFAT_DIAMOND_HEADER_OF_WORD_2:
           // word 2 of the diamond VFAT frame is found
           fd[1] = buf[i + 1];
@@ -434,51 +428,50 @@ int RawDataUnpacker::processVFATDataParallel(const uint16_t *buf, unsigned int m
 
 //----------------------------------------------------------------------------------------------------
 
-int RawDataUnpacker::processOptoRxFrameSampic(const word *buf, unsigned int frameSize, TotemFEDInfo &fedInfo, SimpleVFATFrameCollection *fc) const
-{
+int RawDataUnpacker::processOptoRxFrameSampic(const word *buf,
+                                              unsigned int frameSize,
+                                              TotemFEDInfo &fedInfo,
+                                              SimpleVFATFrameCollection *fc) const {
   unsigned int optoRxId = (buf[0] >> 8) & 0xFFF;
 
-  LogDebug( "RawDataUnpacker::processOptoRxFrameSampic" )
-    << "Processing sampic frame: OptoRx " << optoRxId << "   framesize: " << frameSize;
+  LogDebug("RawDataUnpacker::processOptoRxFrameSampic")
+      << "Processing sampic frame: OptoRx " << optoRxId << "   framesize: " << frameSize;
 
   unsigned int orbitCounterVFATFrameWords = 6;
   unsigned int sizeofVFATPayload = 12;
 
-  const VFATFrame::word *VFATFrameWordPtr = (const VFATFrame::word *) buf;
+  const VFATFrame::word *VFATFrameWordPtr = (const VFATFrame::word *)buf;
   VFATFrameWordPtr += orbitCounterVFATFrameWords - 1;
 
-  LogDebug( "RawDataUnpacker::processOptoRxFrameSampic" )
-    << "Framesize: " << frameSize << "\tframes: " << frameSize/(sizeofVFATPayload+2);
+  LogDebug("RawDataUnpacker::processOptoRxFrameSampic")
+      << "Framesize: " << frameSize << "\tframes: " << frameSize / (sizeofVFATPayload + 2);
 
-  unsigned int nWords = (frameSize-2) * 4 - 2;
+  unsigned int nWords = (frameSize - 2) * 4 - 2;
 
-  for (unsigned int i=1; i*(sizeofVFATPayload+2)<nWords; ++i) {
+  for (unsigned int i = 1; i * (sizeofVFATPayload + 2) < nWords; ++i) {
     // compile frame position
     // NOTE: DAQ group uses terms GOH and fiber in the other way
     unsigned int fiberIdx = (*(++VFATFrameWordPtr)) & 0xF;
     unsigned int gohIdx = (*VFATFrameWordPtr >> 4) & 0xF;
     TotemFramePosition fp(0, 0, optoRxId, gohIdx, fiberIdx);
 
-    LogDebug( "RawDataUnpacker::processOptoRxFrameSampic" )
-      << "OptoRx: " << optoRxId << " Goh: " << gohIdx << " Idx: " << fiberIdx;
+    LogDebug("RawDataUnpacker::processOptoRxFrameSampic")
+        << "OptoRx: " << optoRxId << " Goh: " << gohIdx << " Idx: " << fiberIdx;
 
     // prepare temporary VFAT frame
     VFATFrame frame(++VFATFrameWordPtr);
     VFATFrameWordPtr += sizeofVFATPayload;
 
-    if ( *(VFATFrameWordPtr) != 0xf00e ) {
-      edm::LogError( "RawDataUnpacker::processOptoRxFrameSampic" )
-        << "Wrong trailer " << *VFATFrameWordPtr;
+    if (*(VFATFrameWordPtr) != 0xf00e) {
+      edm::LogError("RawDataUnpacker::processOptoRxFrameSampic") << "Wrong trailer " << *VFATFrameWordPtr;
       continue;
     }
     // save frame to output
     frame.setPresenceFlags(1);
     fc->Insert(fp, frame);
 
-    LogDebug( "RawDataUnpacker::processOptoRxFrameSampic" )
-      << "Trailer: " << std::hex << *VFATFrameWordPtr;
+    LogDebug("RawDataUnpacker::processOptoRxFrameSampic") << "Trailer: " << std::hex << *VFATFrameWordPtr;
   }
 
   return 0;
 }
-

--- a/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
+++ b/EventFilter/CTPPSRawToDigi/src/RawToDigiConverter.cc
@@ -24,48 +24,44 @@ using namespace edm;
 
 //----------------------------------------------------------------------------------------------------
 
-RawToDigiConverter::RawToDigiConverter(const edm::ParameterSet &conf) :
-  verbosity(conf.getUntrackedParameter<unsigned int>("verbosity", 0)),
-  printErrorSummary(conf.getUntrackedParameter<unsigned int>("printErrorSummary", 1)),
-  printUnknownFrameSummary(conf.getUntrackedParameter<unsigned int>("printUnknownFrameSummary", 1)),
+RawToDigiConverter::RawToDigiConverter(const edm::ParameterSet &conf)
+    : verbosity(conf.getUntrackedParameter<unsigned int>("verbosity", 0)),
+      printErrorSummary(conf.getUntrackedParameter<unsigned int>("printErrorSummary", 1)),
+      printUnknownFrameSummary(conf.getUntrackedParameter<unsigned int>("printUnknownFrameSummary", 1)),
 
-  testFootprint(conf.getParameter<unsigned int>("testFootprint")),
-  testCRC(conf.getParameter<unsigned int>("testCRC")),
-  testID(conf.getParameter<unsigned int>("testID")),
-  testECMostFrequent(conf.getParameter<unsigned int>("testECMostFrequent")),
-  testBCMostFrequent(conf.getParameter<unsigned int>("testBCMostFrequent")),
+      testFootprint(conf.getParameter<unsigned int>("testFootprint")),
+      testCRC(conf.getParameter<unsigned int>("testCRC")),
+      testID(conf.getParameter<unsigned int>("testID")),
+      testECMostFrequent(conf.getParameter<unsigned int>("testECMostFrequent")),
+      testBCMostFrequent(conf.getParameter<unsigned int>("testBCMostFrequent")),
 
-  EC_min(conf.getUntrackedParameter<unsigned int>("EC_min", 10)),
-  BC_min(conf.getUntrackedParameter<unsigned int>("BC_min", 10)),
+      EC_min(conf.getUntrackedParameter<unsigned int>("EC_min", 10)),
+      BC_min(conf.getUntrackedParameter<unsigned int>("BC_min", 10)),
 
-  EC_fraction(conf.getUntrackedParameter<double>("EC_fraction", 0.6)),
-  BC_fraction(conf.getUntrackedParameter<double>("BC_fraction", 0.6))
-{
-}
+      EC_fraction(conf.getUntrackedParameter<double>("EC_fraction", 0.6)),
+      BC_fraction(conf.getUntrackedParameter<double>("BC_fraction", 0.6)) {}
 
 //----------------------------------------------------------------------------------------------------
 
-void RawToDigiConverter::runCommon(const VFATFrameCollection &input, const TotemDAQMapping &mapping,
-      map<TotemFramePosition, RawToDigiConverter::Record> &records)
-{
+void RawToDigiConverter::runCommon(const VFATFrameCollection &input,
+                                   const TotemDAQMapping &mapping,
+                                   map<TotemFramePosition, RawToDigiConverter::Record> &records) {
   // EC and BC checks (wrt. the most frequent value), BC checks per subsystem
   CounterChecker ECChecker(CounterChecker::ECChecker, "EC", EC_min, EC_fraction, verbosity);
   CounterChecker BCChecker(CounterChecker::BCChecker, "BC", BC_min, BC_fraction, verbosity);
 
   // initialise structure merging vfat frame data with the mapping
-  for (auto &p : mapping.VFATMapping)
-  {
+  for (auto &p : mapping.VFATMapping) {
     TotemVFATStatus st;
     st.setMissing(true);
-    records[p.first] = { &p.second, nullptr,  st };
+    records[p.first] = {&p.second, nullptr, st};
   }
 
   // event error message buffer
   stringstream ees;
 
   // associate data frames with records
-  for (VFATFrameCollection::Iterator fr(&input); !fr.IsEnd(); fr.Next())
-  {
+  for (VFATFrameCollection::Iterator fr(&input); !fr.IsEnd(); fr.Next()) {
     // frame error message buffer
     stringstream fes;
 
@@ -74,8 +70,7 @@ void RawToDigiConverter::runCommon(const VFATFrameCollection &input, const Totem
 
     // skip data frames not listed in the DAQ mapping
     auto records_it = records.find(fr.Position());
-    if (records_it == records.end())
-    {
+    if (records_it == records.end()) {
       unknownSummary[fr.Position()]++;
       continue;
     }
@@ -88,54 +83,47 @@ void RawToDigiConverter::runCommon(const VFATFrameCollection &input, const Totem
     record.status.setNumberOfClusters(record.frame->getNumberOfClusters());
 
     // check footprint
-    if (testFootprint != tfNoTest && !record.frame->checkFootprint())
-    {
+    if (testFootprint != tfNoTest && !record.frame->checkFootprint()) {
       problemsPresent = true;
 
       if (verbosity > 0)
         fes << "    invalid footprint" << endl;
 
-      if (testFootprint == tfErr)
-      {
+      if (testFootprint == tfErr) {
         record.status.setFootprintError();
         stopProcessing = true;
       }
     }
 
     // check CRC
-    if (testCRC != tfNoTest && !record.frame->checkCRC())
-    {
+    if (testCRC != tfNoTest && !record.frame->checkCRC()) {
       problemsPresent = true;
 
       if (verbosity > 0)
         fes << "    CRC failure" << endl;
 
-      if (testCRC == tfErr)
-      {
+      if (testCRC == tfErr) {
         record.status.setCRCError();
         stopProcessing = true;
       }
     }
     // check the id mismatch
-    if (testID != tfNoTest && record.frame->isIDPresent() && (record.frame->getChipID() & 0xFFF) != (record.info->hwID & 0xFFF))
-    {
+    if (testID != tfNoTest && record.frame->isIDPresent() &&
+        (record.frame->getChipID() & 0xFFF) != (record.info->hwID & 0xFFF)) {
       if (verbosity > 0)
-        fes << "    ID mismatch (data: 0x" << hex << record.frame->getChipID()
-          << ", mapping: 0x" << record.info->hwID  << dec << ", symbId: " << record.info->symbolicID.symbolicID << ")" << endl;
+        fes << "    ID mismatch (data: 0x" << hex << record.frame->getChipID() << ", mapping: 0x" << record.info->hwID
+            << dec << ", symbId: " << record.info->symbolicID.symbolicID << ")" << endl;
 
-      if (testID == tfErr)
-      {
+      if (testID == tfErr) {
         record.status.setIDMismatch();
         stopProcessing = true;
       }
     }
 
     // if there were errors, put the information to ees buffer
-    if (verbosity > 0 && problemsPresent)
-    {
+    if (verbosity > 0 && problemsPresent) {
       string message = (stopProcessing) ? "(and will be dropped)" : "(but will be used though)";
-      if (verbosity > 2)
-      {
+      if (verbosity > 2) {
         ees << "  Frame at " << fr.Position() << " seems corrupted " << message << ":" << endl;
         ees << fes.rdbuf();
       } else
@@ -162,31 +150,28 @@ void RawToDigiConverter::runCommon(const VFATFrameCollection &input, const Totem
     BCChecker.Analyze(records, (testBCMostFrequent == tfErr), ees);
 
   // add error message for missing frames
-  if (verbosity > 1)
-  {
-    for (const auto &p : records)
-    {
+  if (verbosity > 1) {
+    for (const auto &p : records) {
       if (p.second.status.isMissing())
         ees << "Frame for VFAT " << p.first << " is not present in the data." << endl;
     }
   }
 
   // print error message
-  if (verbosity > 0 && !ees.rdbuf()->str().empty())
-  {
+  if (verbosity > 0 && !ees.rdbuf()->str().empty()) {
     if (verbosity > 1)
-      LogWarning("Totem") << "Error in RawToDigiConverter::runCommon > " << "event contains the following problems:" << endl << ees.rdbuf() << endl;
+      LogWarning("Totem") << "Error in RawToDigiConverter::runCommon > "
+                          << "event contains the following problems:" << endl
+                          << ees.rdbuf() << endl;
     else
-      LogWarning("Totem") << "Error in RawToDigiConverter::runCommon > " << "event contains problems." << endl;
+      LogWarning("Totem") << "Error in RawToDigiConverter::runCommon > "
+                          << "event contains problems." << endl;
   }
 
   // increase error counters
-  if (printErrorSummary)
-  {
-    for (const auto &it : records)
-    {
-      if (!it.second.status.isOK())
-      {
+  if (printErrorSummary) {
+    for (const auto &it : records) {
+      if (!it.second.status.isOK()) {
         auto &m = errorSummary[it.first];
         m[it.second.status]++;
       }
@@ -197,9 +182,10 @@ void RawToDigiConverter::runCommon(const VFATFrameCollection &input, const Totem
 //----------------------------------------------------------------------------------------------------
 
 void RawToDigiConverter::run(const VFATFrameCollection &input,
-  const TotemDAQMapping &mapping, const TotemAnalysisMask &analysisMask,
-  DetSetVector<TotemRPDigi> &rpData, DetSetVector<TotemVFATStatus> &finalStatus)
-{
+                             const TotemDAQMapping &mapping,
+                             const TotemAnalysisMask &analysisMask,
+                             DetSetVector<TotemRPDigi> &rpData,
+                             DetSetVector<TotemVFATStatus> &finalStatus) {
   // structure merging vfat frame data with the mapping
   map<TotemFramePosition, Record> records;
 
@@ -207,8 +193,7 @@ void RawToDigiConverter::run(const VFATFrameCollection &input,
   runCommon(input, mapping, records);
 
   // second loop over data
-  for (auto &p : records)
-  {
+  for (auto &p : records) {
     Record &record = p.second;
 
     // calculate ids
@@ -220,15 +205,13 @@ void RawToDigiConverter::run(const VFATFrameCollection &input,
     record.status.setChipPosition(chipPosition);
 
     // produce digi only for good frames
-    if (record.status.isOK())
-    {
+    if (record.status.isOK()) {
       // find analysis mask (needs a default=no mask, if not in present the mapping)
       TotemVFATAnalysisMask anMa;
       anMa.fullMask = false;
 
       auto analysisIter = analysisMask.analysisMask.find(record.info->symbolicID);
-      if (analysisIter != analysisMask.analysisMask.end())
-      {
+      if (analysisIter != analysisMask.analysisMask.end()) {
         // if there is some information about masked channels - save it into conversionStatus
         anMa = analysisIter->second;
         if (anMa.fullMask)
@@ -241,11 +224,9 @@ void RawToDigiConverter::run(const VFATFrameCollection &input,
       unsigned short offset = chipPosition * 128;
       const vector<unsigned char> &activeChannels = record.frame->getActiveChannels();
 
-      for (auto ch : activeChannels)
-      {
+      for (auto ch : activeChannels) {
         // skip masked channels
-        if (!anMa.fullMask && anMa.maskedChannels.find(ch) == anMa.maskedChannels.end())
-        {
+        if (!anMa.fullMask && anMa.maskedChannels.find(ch) == anMa.maskedChannels.end()) {
           DetSet<TotemRPDigi> &digiDetSet = rpData.find_or_insert(detId);
           digiDetSet.push_back(TotemRPDigi(offset + ch));
         }
@@ -260,9 +241,11 @@ void RawToDigiConverter::run(const VFATFrameCollection &input,
 
 //----------------------------------------------------------------------------------------------------
 
-void RawToDigiConverter::run(const VFATFrameCollection &coll, const TotemDAQMapping &mapping, const TotemAnalysisMask &mask,
-      edm::DetSetVector<CTPPSDiamondDigi> &digi, edm::DetSetVector<TotemVFATStatus> &status)
-{
+void RawToDigiConverter::run(const VFATFrameCollection &coll,
+                             const TotemDAQMapping &mapping,
+                             const TotemAnalysisMask &mask,
+                             edm::DetSetVector<CTPPSDiamondDigi> &digi,
+                             edm::DetSetVector<TotemVFATStatus> &status) {
   // structure merging vfat frame data with the mapping
   map<TotemFramePosition, Record> records;
 
@@ -270,24 +253,26 @@ void RawToDigiConverter::run(const VFATFrameCollection &coll, const TotemDAQMapp
   runCommon(coll, mapping, records);
 
   // second loop over data
-  for (auto &p : records)
-  {
+  for (auto &p : records) {
     Record &record = p.second;
 
     // calculate ids
     CTPPSDiamondDetId detId(record.info->symbolicID.symbolicID);
 
-    if (record.status.isOK())
-    {
+    if (record.status.isOK()) {
       const VFATFrame *fr = record.frame;
-      const DiamondVFATFrame *diamondframe = static_cast<const DiamondVFATFrame*>(fr);
+      const DiamondVFATFrame *diamondframe = static_cast<const DiamondVFATFrame *>(fr);
 
       // update Event Counter in status
       record.status.setEC(record.frame->getEC() & 0xFF);
 
       // create the digi
       DetSet<CTPPSDiamondDigi> &digiDetSet = digi.find_or_insert(detId);
-      digiDetSet.push_back(CTPPSDiamondDigi(diamondframe->getLeadingEdgeTime(),diamondframe->getTrailingEdgeTime(),diamondframe->getThresholdVoltage(),diamondframe->getMultihit(),diamondframe->getHptdcErrorFlag()));
+      digiDetSet.push_back(CTPPSDiamondDigi(diamondframe->getLeadingEdgeTime(),
+                                            diamondframe->getTrailingEdgeTime(),
+                                            diamondframe->getThresholdVoltage(),
+                                            diamondframe->getMultihit(),
+                                            diamondframe->getHptdcErrorFlag()));
     }
 
     // save status
@@ -298,9 +283,11 @@ void RawToDigiConverter::run(const VFATFrameCollection &coll, const TotemDAQMapp
 
 //----------------------------------------------------------------------------------------------------
 
-void RawToDigiConverter::run(const VFATFrameCollection &coll, const TotemDAQMapping &mapping, const TotemAnalysisMask &mask,
-      edm::DetSetVector<TotemTimingDigi> &digi, edm::DetSetVector<TotemVFATStatus> &status)
-{
+void RawToDigiConverter::run(const VFATFrameCollection &coll,
+                             const TotemDAQMapping &mapping,
+                             const TotemAnalysisMask &mask,
+                             edm::DetSetVector<TotemTimingDigi> &digi,
+                             edm::DetSetVector<TotemVFATStatus> &status) {
   // structure merging vfat frame data with the mapping
   map<TotemFramePosition, Record> records;
 
@@ -308,73 +295,95 @@ void RawToDigiConverter::run(const VFATFrameCollection &coll, const TotemDAQMapp
   runCommon(coll, mapping, records);
 
   // second loop over data
-  for (auto &p : records)
-  {
+  for (auto &p : records) {
     Record &record = p.second;
-    if (!record.status.isOK()) continue;
+    if (!record.status.isOK())
+      continue;
 
-    const TotemFramePosition* framepos = &p.first;
+    const TotemFramePosition *framepos = &p.first;
 
-    if(((framepos->getIdxInFiber()%2)==0)&&(framepos->getIdxInFiber()<14))
-    {
+    if (((framepos->getIdxInFiber() % 2) == 0) && (framepos->getIdxInFiber() < 14)) {
       //corresponding channel data are always in the neighbouring idx in fiber
 
-      TotemFramePosition frameposdata(framepos->getSubSystemId(),framepos->getTOTFEDId(),framepos->getOptoRxId(),framepos->getGOHId(),(framepos->getIdxInFiber()+1));
-      TotemFramePosition frameposEvtInfo(framepos->getSubSystemId(),framepos->getTOTFEDId(),framepos->getOptoRxId(),framepos->getGOHId(),0xe);
+      TotemFramePosition frameposdata(framepos->getSubSystemId(),
+                                      framepos->getTOTFEDId(),
+                                      framepos->getOptoRxId(),
+                                      framepos->getGOHId(),
+                                      (framepos->getIdxInFiber() + 1));
+      TotemFramePosition frameposEvtInfo(
+          framepos->getSubSystemId(), framepos->getTOTFEDId(), framepos->getOptoRxId(), framepos->getGOHId(), 0xe);
 
       auto channelwaveformPtr = records.find(frameposdata);
       auto eventInfoPtr = records.find(frameposEvtInfo);
 
-      if ( channelwaveformPtr != records.end() && eventInfoPtr != records.end() )
-      {
+      if (channelwaveformPtr != records.end() && eventInfoPtr != records.end()) {
         Record &channelwaveform = records[frameposdata];
         Record &eventInfo = records[frameposEvtInfo];
 
         // Extract all the waveform information from the raw data
-        TotemSampicFrame totemSampicFrame((const uint8_t*) record.frame->getData(), (const uint8_t*) channelwaveform.frame->getData(), (const uint8_t*) eventInfo.frame->getData());
+        TotemSampicFrame totemSampicFrame((const uint8_t *)record.frame->getData(),
+                                          (const uint8_t *)channelwaveform.frame->getData(),
+                                          (const uint8_t *)eventInfo.frame->getData());
 
-        if (totemSampicFrame.valid())
-        {
+        if (totemSampicFrame.valid()) {
           // create the digi
-          TotemTimingEventInfo eventInfoTmp( totemSampicFrame.getEventHardwareId(), totemSampicFrame.getL1ATimestamp(), totemSampicFrame.getBunchNumber(), totemSampicFrame.getOrbitNumber(), totemSampicFrame.getEventNumber(), totemSampicFrame.getChannelMap(), totemSampicFrame.getL1ALatency(), totemSampicFrame.getNumberOfSentSamples(), totemSampicFrame.getOffsetOfSamples(), totemSampicFrame.getPLLInfo() );
-          TotemTimingDigi digiTmp( totemSampicFrame.getHardwareId(), totemSampicFrame.getFPGATimestamp(), totemSampicFrame.getTimestampA(), totemSampicFrame.getTimestampB(), totemSampicFrame.getCellInfo(), totemSampicFrame.getSamples(), eventInfoTmp);
+          TotemTimingEventInfo eventInfoTmp(totemSampicFrame.getEventHardwareId(),
+                                            totemSampicFrame.getL1ATimestamp(),
+                                            totemSampicFrame.getBunchNumber(),
+                                            totemSampicFrame.getOrbitNumber(),
+                                            totemSampicFrame.getEventNumber(),
+                                            totemSampicFrame.getChannelMap(),
+                                            totemSampicFrame.getL1ALatency(),
+                                            totemSampicFrame.getNumberOfSentSamples(),
+                                            totemSampicFrame.getOffsetOfSamples(),
+                                            totemSampicFrame.getPLLInfo());
+          TotemTimingDigi digiTmp(totemSampicFrame.getHardwareId(),
+                                  totemSampicFrame.getFPGATimestamp(),
+                                  totemSampicFrame.getTimestampA(),
+                                  totemSampicFrame.getTimestampB(),
+                                  totemSampicFrame.getCellInfo(),
+                                  totemSampicFrame.getSamples(),
+                                  eventInfoTmp);
           // calculate ids
           TotemTimingDetId detId(record.info->symbolicID.symbolicID);
 
-          const TotemDAQMapping::TotemTimingPlaneChannelPair SWpair = mapping.getTimingChannel( totemSampicFrame.getHardwareId() );
+          const TotemDAQMapping::TotemTimingPlaneChannelPair SWpair =
+              mapping.getTimingChannel(totemSampicFrame.getHardwareId());
           // for FW Version > 0 plane and channel are encoded in the dataframe
-          if ( totemSampicFrame.getFWVersion() < 0x30 )  // Mapping not present in HW, read from SW for FW versions < 3.0
+          if (totemSampicFrame.getFWVersion() < 0x30)  // Mapping not present in HW, read from SW for FW versions < 3.0
           {
-            if ( SWpair.plane == -1 || SWpair.channel == -1 )
-            {
-              if (verbosity>0)
-                LogWarning("Totem") << "Error in RawToDigiConverter::TotemTiming > " << "HwId not recognized!  hwId: " << std::hex << (unsigned int) totemSampicFrame.getHardwareId() << endl;
+            if (SWpair.plane == -1 || SWpair.channel == -1) {
+              if (verbosity > 0)
+                LogWarning("Totem") << "Error in RawToDigiConverter::TotemTiming > "
+                                    << "HwId not recognized!  hwId: " << std::hex
+                                    << (unsigned int)totemSampicFrame.getHardwareId() << endl;
+            } else {
+              detId.setPlane(SWpair.plane % 4);
+              detId.setChannel(SWpair.channel);
+              detId.setRP(SWpair.plane / 4);  // Top:0 or Bottom:1
             }
-            else
-            {
-              detId.setPlane( SWpair.plane % 4);
-              detId.setChannel( SWpair.channel );
-              detId.setRP( SWpair.plane / 4 ); // Top:0 or Bottom:1
-            }
-          }
-          else // Mapping read from HW, checked by SW
+          } else  // Mapping read from HW, checked by SW
           {
             const int HWplane = totemSampicFrame.getDetPlane() % 16;
             const int HWchannel = totemSampicFrame.getDetChannel() % 16;
 
-            if ( SWpair.plane == -1 || SWpair.channel == -1 )
-            {
-              if ( verbosity>0 )
-                LogWarning("Totem") << "Warning in RawToDigiConverter::TotemTiming > " << "HwId not recognized!  hwId: " << std::hex << (unsigned int) totemSampicFrame.getHardwareId() << "\tUsing plane and ch from HW without check!" << endl;
+            if (SWpair.plane == -1 || SWpair.channel == -1) {
+              if (verbosity > 0)
+                LogWarning("Totem") << "Warning in RawToDigiConverter::TotemTiming > "
+                                    << "HwId not recognized!  hwId: " << std::hex
+                                    << (unsigned int)totemSampicFrame.getHardwareId()
+                                    << "\tUsing plane and ch from HW without check!" << endl;
+            } else {
+              if (verbosity > 0 && (SWpair.plane != HWplane || SWpair.channel != HWchannel))
+                LogWarning("Totem") << "Warning in RawToDigiConverter::TotemTiming > "
+                                    << "Hw mapping different from SW mapping. hwId: " << std::hex
+                                    << (unsigned int)totemSampicFrame.getHardwareId() << "HW: " << std::dec << HWplane
+                                    << ":" << HWchannel << "\tSW " << SWpair.plane << ":" << SWpair.channel
+                                    << "\tUsing plane and ch from HW!" << endl;
             }
-            else
-            {
-              if ( verbosity>0 && ( SWpair.plane != HWplane || SWpair.channel != HWchannel ) )
-                LogWarning("Totem") << "Warning in RawToDigiConverter::TotemTiming > " << "Hw mapping different from SW mapping. hwId: " << std::hex << (unsigned int) totemSampicFrame.getHardwareId() << "HW: " << std::dec << HWplane << ":" << HWchannel << "\tSW " << SWpair.plane << ":" << SWpair.channel << "\tUsing plane and ch from HW!" << endl;
-            }
-            detId.setPlane( HWplane % 4 );
-            detId.setChannel( HWchannel );
-            detId.setRP( HWplane / 4 ); // Top:0 or Bottom:1
+            detId.setPlane(HWplane % 4);
+            detId.setChannel(HWchannel);
+            detId.setRP(HWplane / 4);  // Top:0 or Bottom:1
           }
 
           DetSet<TotemTimingDigi> &digiDetSet = digi.find_or_insert(detId);
@@ -385,42 +394,39 @@ void RawToDigiConverter::run(const VFATFrameCollection &coll, const TotemDAQMapp
   }
 }
 
-
 //----------------------------------------------------------------------------------------------------
 
-void RawToDigiConverter::printSummaries() const
-{
+void RawToDigiConverter::printSummaries() const {
   // print error summary
-  if (printErrorSummary)
-  {
-    if (!errorSummary.empty())
-    {
+  if (printErrorSummary) {
+    if (!errorSummary.empty()) {
       stringstream ees;
-      for (const auto &vit : errorSummary)
-      {
+      for (const auto &vit : errorSummary) {
         ees << vit.first << endl;
 
         for (const auto &it : vit.second)
           ees << "    " << it.first << " : " << it.second << endl;
       }
 
-      LogWarning("Totem") << "RawToDigiConverter: error summary (error signature : number of such events)\n" << endl << ees.rdbuf();
+      LogWarning("Totem") << "RawToDigiConverter: error summary (error signature : number of such events)\n"
+                          << endl
+                          << ees.rdbuf();
     } else {
       LogInfo("Totem") << "RawToDigiConverter: no errors to be reported.";
     }
   }
 
   // print summary of unknown frames (found in data but not in the mapping)
-  if (printUnknownFrameSummary)
-  {
-    if (!unknownSummary.empty())
-    {
+  if (printUnknownFrameSummary) {
+    if (!unknownSummary.empty()) {
       stringstream ees;
       for (const auto &it : unknownSummary)
         ees << "  " << it.first << " : " << it.second << endl;
 
-      LogWarning("Totem") << "RawToDigiConverter: frames found in data, but not in the mapping (frame position : number of events)\n"
-        << endl << ees.rdbuf();
+      LogWarning("Totem")
+          << "RawToDigiConverter: frames found in data, but not in the mapping (frame position : number of events)\n"
+          << endl
+          << ees.rdbuf();
     } else {
       LogInfo("Totem") << "RawToDigiConverter: no unknown frames to be reported.";
     }

--- a/EventFilter/CTPPSRawToDigi/src/SimpleVFATFrameCollection.cc
+++ b/EventFilter/CTPPSRawToDigi/src/SimpleVFATFrameCollection.cc
@@ -6,28 +6,21 @@
 *    
 ****************************************************************************/
 
-
 #include "EventFilter/CTPPSRawToDigi/interface/SimpleVFATFrameCollection.h"
 
 //----------------------------------------------------------------------------------------------------
 
 using namespace std;
 
-SimpleVFATFrameCollection::SimpleVFATFrameCollection()
-{
-}
+SimpleVFATFrameCollection::SimpleVFATFrameCollection() {}
 
 //----------------------------------------------------------------------------------------------------
 
-SimpleVFATFrameCollection::~SimpleVFATFrameCollection()
-{
-  data.clear();
-}
+SimpleVFATFrameCollection::~SimpleVFATFrameCollection() { data.clear(); }
 
 //----------------------------------------------------------------------------------------------------
 
-const VFATFrame* SimpleVFATFrameCollection::GetFrameByID(unsigned int ID) const
-{
+const VFATFrame* SimpleVFATFrameCollection::GetFrameByID(unsigned int ID) const {
   // first convert ID to 12bit form
   ID = ID & 0xFFF;
 
@@ -41,8 +34,7 @@ const VFATFrame* SimpleVFATFrameCollection::GetFrameByID(unsigned int ID) const
 
 //----------------------------------------------------------------------------------------------------
 
-const VFATFrame* SimpleVFATFrameCollection::GetFrameByIndex(TotemFramePosition index) const
-{
+const VFATFrame* SimpleVFATFrameCollection::GetFrameByIndex(TotemFramePosition index) const {
   MapType::const_iterator it = data.find(index);
   if (it != data.end())
     return &(it->second);
@@ -52,16 +44,14 @@ const VFATFrame* SimpleVFATFrameCollection::GetFrameByIndex(TotemFramePosition i
 
 //----------------------------------------------------------------------------------------------------
 
-VFATFrameCollection::value_type SimpleVFATFrameCollection::BeginIterator() const
-{
+VFATFrameCollection::value_type SimpleVFATFrameCollection::BeginIterator() const {
   MapType::const_iterator it = data.begin();
   return (it == data.end()) ? value_type(TotemFramePosition(), nullptr) : value_type(it->first, &it->second);
 }
 
 //----------------------------------------------------------------------------------------------------
 
-VFATFrameCollection::value_type SimpleVFATFrameCollection::NextIterator(const value_type &value) const
-{
+VFATFrameCollection::value_type SimpleVFATFrameCollection::NextIterator(const value_type& value) const {
   if (!value.second)
     return value;
 
@@ -73,7 +63,4 @@ VFATFrameCollection::value_type SimpleVFATFrameCollection::NextIterator(const va
 
 //----------------------------------------------------------------------------------------------------
 
-bool SimpleVFATFrameCollection::IsEndIterator(const value_type &value) const
-{
-  return (value.second == nullptr);
-}
+bool SimpleVFATFrameCollection::IsEndIterator(const value_type& value) const { return (value.second == nullptr); }

--- a/EventFilter/CTPPSRawToDigi/src/VFATFrame.cc
+++ b/EventFilter/CTPPSRawToDigi/src/VFATFrame.cc
@@ -15,10 +15,10 @@
 
 //----------------------------------------------------------------------------------------------------
 
-VFATFrame::VFATFrame(const VFATFrame::word *_data) :
-  presenceFlags(15),    // by default BC, EC, ID and CRC are present
-  daqErrorFlags(0),     // by default, no DAQ error
-  numberOfClusters(0)   // no clusters by default
+VFATFrame::VFATFrame(const VFATFrame::word *_data)
+    : presenceFlags(15),   // by default BC, EC, ID and CRC are present
+      daqErrorFlags(0),    // by default, no DAQ error
+      numberOfClusters(0)  // no clusters by default
 {
   if (_data)
     setData(_data);
@@ -28,19 +28,14 @@ VFATFrame::VFATFrame(const VFATFrame::word *_data) :
 
 //----------------------------------------------------------------------------------------------------
 
-void VFATFrame::setData(const VFATFrame::word *_data)
-{
-  memcpy(data, _data, 24);
-}
+void VFATFrame::setData(const VFATFrame::word *_data) { memcpy(data, _data, 24); }
 
 //----------------------------------------------------------------------------------------------------
 
-std::vector<unsigned char> VFATFrame::getActiveChannels() const
-{
+std::vector<unsigned char> VFATFrame::getActiveChannels() const {
   std::vector<unsigned char> channels;
 
-  for (int i = 0; i < 8; i++)
-  {
+  for (int i = 0; i < 8; i++) {
     // quick check
     if (!data[1 + i])
       continue;
@@ -48,10 +43,9 @@ std::vector<unsigned char> VFATFrame::getActiveChannels() const
     // go throug bits
     word mask;
     char offset;
-    for (mask = 1 << 15, offset = 15; mask; mask >>= 1, offset--)
-    {
+    for (mask = 1 << 15, offset = 15; mask; mask >>= 1, offset--) {
       if (data[1 + i] & mask)
-        channels.push_back( i * 16 + offset );
+        channels.push_back(i * 16 + offset);
     }
   }
 
@@ -60,8 +54,7 @@ std::vector<unsigned char> VFATFrame::getActiveChannels() const
 
 //----------------------------------------------------------------------------------------------------
 
-bool VFATFrame::checkFootprint() const
-{
+bool VFATFrame::checkFootprint() const {
   if (isIDPresent() && (data[9] & 0xF000) != 0xE000)
     return false;
 
@@ -76,14 +69,13 @@ bool VFATFrame::checkFootprint() const
 
 //----------------------------------------------------------------------------------------------------
 
-bool VFATFrame::checkCRC() const
-{
+bool VFATFrame::checkCRC() const {
   // check DAQ error flags
   if (daqErrorFlags != 0)
     return false;
 
   // return true if CRC not present
-  if (! isCRCPresent())
+  if (!isCRCPresent())
     return true;
 
   // compare CRC
@@ -91,32 +83,30 @@ bool VFATFrame::checkCRC() const
 
   for (int i = 11; i >= 1; i--)
     crc_fin = calculateCRC(crc_fin, data[i]);
-  
+
   return (crc_fin == data[0]);
 }
 
 //----------------------------------------------------------------------------------------------------
 
-VFATFrame::word VFATFrame::calculateCRC(VFATFrame::word crc_in, VFATFrame::word dato)
-{
+VFATFrame::word VFATFrame::calculateCRC(VFATFrame::word crc_in, VFATFrame::word dato) {
   word v = 0x0001;
-  word mask = 0x0001;    
-  bool d=false;
+  word mask = 0x0001;
+  bool d = false;
   word crc_temp = crc_in;
   unsigned char datalen = 16;
 
-  for (int i = 0; i < datalen; i++)
-  {
+  for (int i = 0; i < datalen; i++) {
     if (dato & v)
       d = true;
     else
       d = false;
-      
-    if ((crc_temp & mask)^d)
-      crc_temp = crc_temp>>1 ^ 0x8408;
+
+    if ((crc_temp & mask) ^ d)
+      crc_temp = crc_temp >> 1 ^ 0x8408;
     else
-      crc_temp = crc_temp>>1;
-       
+      crc_temp = crc_temp >> 1;
+
     v <<= 1;
   }
 
@@ -125,16 +115,12 @@ VFATFrame::word VFATFrame::calculateCRC(VFATFrame::word crc_in, VFATFrame::word 
 
 //----------------------------------------------------------------------------------------------------
 
-void VFATFrame::Print(bool binary) const
-{
-  if (binary)
-  {
-    for (int i = 0; i < 12; i++)
-    {
+void VFATFrame::Print(bool binary) const {
+  if (binary) {
+    for (int i = 0; i < 12; i++) {
       const word &w = data[11 - i];
       word mask = (1 << 15);
-      for (int j = 0; j < 16; j++)
-      {
+      for (int j = 0; j < 16; j++) {
         if (w & mask)
           printf("1");
         else
@@ -146,7 +132,12 @@ void VFATFrame::Print(bool binary) const
       printf("\n");
     }
   } else {
-    printf("ID = %03x, BC = %04u, EC = %03u, flags = %2u, CRC = %04x ", getChipID(), getBC(), getEC(), getFlags(), getCRC());
+    printf("ID = %03x, BC = %04u, EC = %03u, flags = %2u, CRC = %04x ",
+           getChipID(),
+           getBC(),
+           getEC(),
+           getFlags(),
+           getCRC());
 
     if (checkCRC())
       printf("(  OK), footprint ");

--- a/EventFilter/CTPPSRawToDigi/src/VFATFrameCollection.cc
+++ b/EventFilter/CTPPSRawToDigi/src/VFATFrameCollection.cc
@@ -6,13 +6,11 @@
 *    
 ****************************************************************************/
 
-
 #include "EventFilter/CTPPSRawToDigi/interface/VFATFrameCollection.h"
 
 //----------------------------------------------------------------------------------------------------
-    
-const VFATFrame* VFATFrameCollection::GetFrameByIndexID(TotemFramePosition index, unsigned int ID)
-{
+
+const VFATFrame* VFATFrameCollection::GetFrameByIndexID(TotemFramePosition index, unsigned int ID) {
   const VFATFrame* returnframe = GetFrameByIndex(index);
   if (returnframe == nullptr)
     return nullptr;

--- a/EventFilter/CTPPSRawToDigi/test/TotemVFATFrameAnalyzer.cc
+++ b/EventFilter/CTPPSRawToDigi/test/TotemVFATFrameAnalyzer.cc
@@ -25,24 +25,22 @@
 
 //----------------------------------------------------------------------------------------------------
 
-class TotemVFATFrameAnalyzer : public edm::global::EDAnalyzer<>
-{
-  public:
-    explicit TotemVFATFrameAnalyzer(const edm::ParameterSet&);
-    ~TotemVFATFrameAnalyzer();
+class TotemVFATFrameAnalyzer : public edm::global::EDAnalyzer<> {
+public:
+  explicit TotemVFATFrameAnalyzer(const edm::ParameterSet &);
+  ~TotemVFATFrameAnalyzer();
 
-    virtual void analyze(edm::StreamID, const edm::Event &, const edm::EventSetup &) const override;
+  virtual void analyze(edm::StreamID, const edm::Event &, const edm::EventSetup &) const override;
 
-  private:
+private:
+  std::vector<unsigned int> fedIds;
 
-    std::vector<unsigned int> fedIds;
+  edm::EDGetTokenT<FEDRawDataCollection> fedDataToken;
 
-    edm::EDGetTokenT<FEDRawDataCollection> fedDataToken;
+  ctpps::RawDataUnpacker rawDataUnpacker;
 
-    ctpps::RawDataUnpacker rawDataUnpacker;
-
-    template <typename DigiType>
-    void run(edm::Event&, const edm::EventSetup&);
+  template <typename DigiType>
+  void run(edm::Event &, const edm::EventSetup &);
 };
 
 //----------------------------------------------------------------------------------------------------
@@ -52,23 +50,19 @@ using namespace std;
 
 //----------------------------------------------------------------------------------------------------
 
-TotemVFATFrameAnalyzer::TotemVFATFrameAnalyzer(const edm::ParameterSet &conf):
-  fedIds(conf.getParameter< vector<unsigned int> >("fedIds")),
-  rawDataUnpacker(conf.getParameterSet("RawUnpacking"))
-{
+TotemVFATFrameAnalyzer::TotemVFATFrameAnalyzer(const edm::ParameterSet &conf)
+    : fedIds(conf.getParameter<vector<unsigned int> >("fedIds")),
+      rawDataUnpacker(conf.getParameterSet("RawUnpacking")) {
   fedDataToken = consumes<FEDRawDataCollection>(conf.getParameter<edm::InputTag>("rawDataTag"));
 }
 
 //----------------------------------------------------------------------------------------------------
 
-TotemVFATFrameAnalyzer::~TotemVFATFrameAnalyzer()
-{
-}
+TotemVFATFrameAnalyzer::~TotemVFATFrameAnalyzer() {}
 
 //----------------------------------------------------------------------------------------------------
 
-void TotemVFATFrameAnalyzer::analyze(edm::StreamID, const edm::Event& event, const edm::EventSetup &) const
-{
+void TotemVFATFrameAnalyzer::analyze(edm::StreamID, const edm::Event &event, const edm::EventSetup &) const {
   // raw data handle
   edm::Handle<FEDRawDataCollection> rawData;
   event.getByToken(fedDataToken, rawData);
@@ -76,19 +70,19 @@ void TotemVFATFrameAnalyzer::analyze(edm::StreamID, const edm::Event& event, con
   // raw-data unpacking
   vector<TotemFEDInfo> fedInfo;
   SimpleVFATFrameCollection vfatCollection;
-  for (const auto &fedId : fedIds)
-  {
+  for (const auto &fedId : fedIds) {
     const FEDRawData &data = rawData->FEDData(fedId);
     if (data.size() > 0)
       rawDataUnpacker.run(fedId, data, fedInfo, vfatCollection);
   }
 
   // print VFAT frames
-  cout << endl << "----------------------------------------------------------------------------------------------------" << endl;
+  cout << endl
+       << "----------------------------------------------------------------------------------------------------"
+       << endl;
   cout << event.id() << endl;
 
-  for (VFATFrameCollection::Iterator fr(&vfatCollection); !fr.IsEnd(); fr.Next())
-  {
+  for (VFATFrameCollection::Iterator fr(&vfatCollection); !fr.IsEnd(); fr.Next()) {
     cout << fr.Position() << " > ";
     fr.Data()->Print();
   }

--- a/RecoEgamma/EgammaElectronAlgos/interface/BarrelMeasurementEstimator.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/BarrelMeasurementEstimator.h
@@ -27,41 +27,39 @@
 
 #include <utility>
 
+class BarrelMeasurementEstimator : public MeasurementEstimator {
+public:
+  BarrelMeasurementEstimator() {}
+  BarrelMeasurementEstimator(float phiMin, float phiMax, float zMin, float zMax)
+      : thePhiMin(phiMin), thePhiMax(phiMax), theZMin(zMin), theZMax(zMax) {}
 
-class BarrelMeasurementEstimator : public MeasurementEstimator
- {
-  public:
+  void setPhiRange(float dummyphiMin, float dummyphiMax) {
+    thePhiMin = dummyphiMin;
+    thePhiMax = dummyphiMax;
+  }
+  void setZRange(float zmin, float zmax) {
+    theZMin = zmin;
+    theZMax = zmax;
+  }
 
-    BarrelMeasurementEstimator()
-     {}
-    BarrelMeasurementEstimator(float phiMin, float phiMax, float zMin, float zMax )
-     : thePhiMin(phiMin), thePhiMax(phiMax), theZMin(zMin), theZMax(zMax)
-     {}
+  // zero value indicates incompatible ts - hit pair
+  std::pair<bool, double> estimate(const TrajectoryStateOnSurface& ts, const TrackingRecHit& hit) const override;
+  virtual std::pair<bool, double> estimate(const TrajectoryStateOnSurface& ts, const GlobalPoint& gp) const;
+  virtual std::pair<bool, double> estimate(const GlobalPoint& vprim,
+                                           const TrajectoryStateOnSurface& ts,
+                                           const GlobalPoint& gp) const;
+  bool estimate(const TrajectoryStateOnSurface& ts, const BoundPlane& plane) const override;
 
-    void setPhiRange( float dummyphiMin , float dummyphiMax )
-     { thePhiMin = dummyphiMin ; thePhiMax = dummyphiMax ; }
-    void setZRange( float zmin, float zmax )
-     { theZMin=zmin ; theZMax=zmax ; }
+  BarrelMeasurementEstimator* clone() const override { return new BarrelMeasurementEstimator(*this); }
 
-    // zero value indicates incompatible ts - hit pair
-    std::pair<bool,double> estimate( const TrajectoryStateOnSurface & ts, const TrackingRecHit & hit ) const override ;
-    virtual std::pair<bool,double> estimate( const TrajectoryStateOnSurface & ts, const GlobalPoint & gp ) const ;
-    virtual std::pair<bool,double> estimate( const GlobalPoint & vprim, const TrajectoryStateOnSurface & ts, const GlobalPoint & gp ) const ;
-    bool estimate( const TrajectoryStateOnSurface & ts, const BoundPlane & plane) const override ;
+  MeasurementEstimator::Local2DVector maximalLocalDisplacement(const TrajectoryStateOnSurface& ts,
+                                                               const BoundPlane& plane) const override;
 
-    BarrelMeasurementEstimator* clone() const override
-     { return new BarrelMeasurementEstimator(*this) ; }
+private:
+  float thePhiMin;
+  float thePhiMax;
+  float theZMin;
+  float theZMax;
+};
 
-    MeasurementEstimator::Local2DVector
-    maximalLocalDisplacement( const TrajectoryStateOnSurface & ts, const BoundPlane & plane) const override ;
-
-  private:
-
-    float thePhiMin ;
-    float thePhiMax ;
-    float theZMin ;
-    float theZMax ;
-
- } ;
-
-#endif // BarrelMeasurementEstimator_H
+#endif  // BarrelMeasurementEstimator_H

--- a/RecoEgamma/EgammaElectronAlgos/interface/EgAmbiguityTools.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/EgAmbiguityTools.h
@@ -7,24 +7,25 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 
-namespace EgAmbiguityTools
-{
+namespace EgAmbiguityTools {
   // for clusters
-  float sharedEnergy( reco::CaloCluster const& clu1, reco::CaloCluster const& clu2,
-                      EcalRecHitCollection const& barrelRecHits,
-                      EcalRecHitCollection const& endcapRecHits ) ;
-  float sharedEnergy( reco::SuperClusterRef const& sc1, reco::SuperClusterRef const& sc2,
-                      EcalRecHitCollection const& barrelRecHits,
-                      EcalRecHitCollection const& endcapRecHits ) ;
+  float sharedEnergy(reco::CaloCluster const& clu1,
+                     reco::CaloCluster const& clu2,
+                     EcalRecHitCollection const& barrelRecHits,
+                     EcalRecHitCollection const& endcapRecHits);
+  float sharedEnergy(reco::SuperClusterRef const& sc1,
+                     reco::SuperClusterRef const& sc2,
+                     EcalRecHitCollection const& barrelRecHits,
+                     EcalRecHitCollection const& endcapRecHits);
 
   // for tracks
-  int sharedHits( reco::GsfTrackRef const&, reco::GsfTrackRef const& ) ;
-  int sharedDets( reco::GsfTrackRef const&, reco::GsfTrackRef const& ) ;
+  int sharedHits(reco::GsfTrackRef const&, reco::GsfTrackRef const&);
+  int sharedDets(reco::GsfTrackRef const&, reco::GsfTrackRef const&);
 
   // electrons comparison
-  bool isBetter( reco::GsfElectron const&, reco::GsfElectron const& ) ;
-  bool isInnerMost( reco::GsfElectron const&, reco::GsfElectron const& ) ;
+  bool isBetter(reco::GsfElectron const&, reco::GsfElectron const&);
+  bool isInnerMost(reco::GsfElectron const&, reco::GsfElectron const&);
 
-}
+}  // namespace EgAmbiguityTools
 
 #endif

--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronClassification.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronClassification.h
@@ -10,30 +10,21 @@
 //#include "ElectronPhoton/EgammaAnalysis/interface/EgammaCorrector.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 
+class ElectronClassification {
+public:
+  ElectronClassification() {}
 
-class ElectronClassification
-{
- public:
+  void classify(reco::GsfElectron&);
+  void refineWithPflow(reco::GsfElectron&);
 
-  ElectronClassification(){}
+private:
+  //  void classify(const reco::GsfElectron &);
 
-  void classify( reco::GsfElectron & ) ;
-  void refineWithPflow( reco::GsfElectron & ) ;
+  //  bool isInCrack(float eta) const;
+  //  bool isInEtaGaps(float eta) const;
+  //  bool isInPhiGaps(float phi) const;
 
- private:
-
-//  void classify(const reco::GsfElectron &);
-
-//  bool isInCrack(float eta) const;
-//  bool isInEtaGaps(float eta) const;
-//  bool isInPhiGaps(float phi) const;
-
-//  reco::GsfElectron::Classification electronClass_;
-
+  //  reco::GsfElectron::Classification electronClass_;
 };
 
 #endif
-
-
-
-

--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronEnergyCorrector.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronEnergyCorrector.h
@@ -5,40 +5,32 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 
-class EcalClusterFunctionBaseClass ;
+class EcalClusterFunctionBaseClass;
 
-class ElectronEnergyCorrector
- {
-  public:
+class ElectronEnergyCorrector {
+public:
+  ElectronEnergyCorrector(EcalClusterFunctionBaseClass *crackCorrectionFunction)
+      : crackCorrectionFunction_(crackCorrectionFunction) {}
 
-    ElectronEnergyCorrector( EcalClusterFunctionBaseClass * crackCorrectionFunction )
-     : crackCorrectionFunction_(crackCorrectionFunction) {}
+  void classBasedParameterizationEnergy(reco::GsfElectron &, const reco::BeamSpot &bs);
+  void classBasedParameterizationUncertainty(reco::GsfElectron &);
+  void simpleParameterizationUncertainty(reco::GsfElectron &);
 
-    void classBasedParameterizationEnergy( reco::GsfElectron &, const reco::BeamSpot & bs ) ;
-    void classBasedParameterizationUncertainty( reco::GsfElectron & ) ;
-    void simpleParameterizationUncertainty( reco::GsfElectron & ) ;
+private:
+  double fEtaBarrelBad(double scEta) const;
+  double fEtaBarrelGood(double scEta) const;
+  double fEtaEndcapBad(double scEta) const;
+  double fEtaEndcapGood(double scEta) const;
 
-  private:
+  // new corrections (N. Chanon et al.)
+  float fEta(float energy, float eta, int algorithm) const;
+  //float fBrem (float e,  float eta, int algorithm) const ;
+  //float fEtEta(float et, float eta, int algorithm) const ;
+  float fBremEta(float sigmaPhiSigmaEta, float eta, int algorithm, reco::GsfElectron::Classification cl) const;
+  float fEt(float et, int algorithm, reco::GsfElectron::Classification cl) const;
+  float fEnergy(float e, int algorithm, reco::GsfElectron::Classification cl) const;
 
-    double fEtaBarrelBad( double scEta ) const ;
-    double fEtaBarrelGood( double scEta ) const ;
-    double fEtaEndcapBad( double scEta ) const ;
-    double fEtaEndcapGood( double scEta ) const ;
-
-    // new corrections (N. Chanon et al.)
-    float fEta  (float energy, float eta, int algorithm) const ;
-    //float fBrem (float e,  float eta, int algorithm) const ;
-    //float fEtEta(float et, float eta, int algorithm) const ;
-    float fBremEta(float sigmaPhiSigmaEta, float eta, int algorithm, reco::GsfElectron::Classification cl ) const ;
-    float fEt(float et, int algorithm, reco::GsfElectron::Classification cl ) const ;
-    float fEnergy(float e, int algorithm, reco::GsfElectron::Classification cl ) const ;
-
-    EcalClusterFunctionBaseClass * crackCorrectionFunction_ ;
-
- } ;
+  EcalClusterFunctionBaseClass *crackCorrectionFunction_;
+};
 
 #endif
-
-
-
-

--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronHcalHelper.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronHcalHelper.h
@@ -2,8 +2,8 @@
 #ifndef ElectronHcalHelper_h
 #define ElectronHcalHelper_h
 
-class EgammaHcalIsolation ;
-class EgammaTowerIsolation ;
+class EgammaHcalIsolation;
+class EgammaTowerIsolation;
 
 #include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
@@ -19,62 +19,57 @@ class EgammaTowerIsolation ;
 class EgammaHadTower;
 
 class ElectronHcalHelper {
-  public:
-  
+public:
   struct Configuration {
     // common parameters
     double hOverEConeSize;
-    
+
     // strategy
     bool useTowers, checkHcalStatus;
-    
+
     // specific parameters if use towers
-    edm::EDGetTokenT<CaloTowerCollection> hcalTowers; 
-    double hOverEPtMin ;            // min tower Et for H/E evaluation
-    
+    edm::EDGetTokenT<CaloTowerCollection> hcalTowers;
+    double hOverEPtMin;  // min tower Et for H/E evaluation
+
     // specific parameters if use rechits
-    edm::EDGetTokenT<HBHERecHitCollection> hcalRecHits ;
-    double hOverEHBMinE ;
-    double hOverEHFMinE ;
-  } ;
-  
-  ElectronHcalHelper( const Configuration & ) ;
-  void checkSetup( const edm::EventSetup & ) ;
-  void readEvent( const edm::Event & ) ;
-  ~ElectronHcalHelper() ;
-  
-  double hcalESum( const reco::SuperCluster & , const std::vector<CaloTowerDetId> * excludeTowers = nullptr) const;
-  double hcalESumDepth1( const reco::SuperCluster &, const std::vector<CaloTowerDetId> * excludeTowers = nullptr) const;
-  double hcalESumDepth2( const reco::SuperCluster & ,const std::vector<CaloTowerDetId> * excludeTowers = nullptr ) const;
-  double hOverEConeSize() const { return cfg_.hOverEConeSize ; }
-  
+    edm::EDGetTokenT<HBHERecHitCollection> hcalRecHits;
+    double hOverEHBMinE;
+    double hOverEHFMinE;
+  };
+
+  ElectronHcalHelper(const Configuration &);
+  void checkSetup(const edm::EventSetup &);
+  void readEvent(const edm::Event &);
+  ~ElectronHcalHelper();
+
+  double hcalESum(const reco::SuperCluster &, const std::vector<CaloTowerDetId> *excludeTowers = nullptr) const;
+  double hcalESumDepth1(const reco::SuperCluster &, const std::vector<CaloTowerDetId> *excludeTowers = nullptr) const;
+  double hcalESumDepth2(const reco::SuperCluster &, const std::vector<CaloTowerDetId> *excludeTowers = nullptr) const;
+  double hOverEConeSize() const { return cfg_.hOverEConeSize; }
+
   // Behind clusters
-  std::vector<CaloTowerDetId> hcalTowersBehindClusters( const reco::SuperCluster & sc ) const;
-  double hcalESumDepth1BehindClusters( const std::vector<CaloTowerDetId> & towers ) const;
-  double hcalESumDepth2BehindClusters( const std::vector<CaloTowerDetId> & towers ) const;
+  std::vector<CaloTowerDetId> hcalTowersBehindClusters(const reco::SuperCluster &sc) const;
+  double hcalESumDepth1BehindClusters(const std::vector<CaloTowerDetId> &towers) const;
+  double hcalESumDepth2BehindClusters(const std::vector<CaloTowerDetId> &towers) const;
 
-  // forward EgammaHadTower methods, if checkHcalStatus is enabled, using towers and H/E 
+  // forward EgammaHadTower methods, if checkHcalStatus is enabled, using towers and H/E
   // otherwise, return true
-  bool hasActiveHcal( const reco::SuperCluster & sc ) const;
+  bool hasActiveHcal(const reco::SuperCluster &sc) const;
 
- private:
-  
-  const Configuration cfg_ ;
-  
+private:
+  const Configuration cfg_;
+
   // event setup data (rechits strategy)
-  unsigned long long caloGeomCacheId_ ;
-  edm::ESHandle<CaloGeometry> caloGeom_ ;
-  
-  // event data (rechits strategy)    
-  EgammaHcalIsolation * hcalIso_ ;
-  
-  // event data (towers strategy)    
-  EgammaTowerIsolation * towerIso1_ ;
-  EgammaTowerIsolation * towerIso2_ ;
-  EgammaHadTower * hadTower_;
+  unsigned long long caloGeomCacheId_;
+  edm::ESHandle<CaloGeometry> caloGeom_;
+
+  // event data (rechits strategy)
+  EgammaHcalIsolation *hcalIso_;
+
+  // event data (towers strategy)
+  EgammaTowerIsolation *towerIso1_;
+  EgammaTowerIsolation *towerIso2_;
+  EgammaHadTower *hadTower_;
 };
 
 #endif
-
-
-

--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronMomentumCorrector.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronMomentumCorrector.h
@@ -16,18 +16,16 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 
-class ElectronMomentumCorrector
-{
- public:
-
+class ElectronMomentumCorrector {
+public:
   //  ElectronMomentumCorrector(){newMomentum_=CLHEP::HepLorentzVector();}
-   // ElectronMomentumCorrector(){ newMomentum_= math::XYZTLorentzVector();}
-   ElectronMomentumCorrector() {}
-   //virtual
-   ~ElectronMomentumCorrector(){}
+  // ElectronMomentumCorrector(){ newMomentum_= math::XYZTLorentzVector();}
+  ElectronMomentumCorrector() {}
+  //virtual
+  ~ElectronMomentumCorrector() {}
 
-   //virtual
-   void correct(reco::GsfElectron &, TrajectoryStateOnSurface &);
+  //virtual
+  void correct(reco::GsfElectron &, TrajectoryStateOnSurface &);
 
   //DC: USED ??
   ////  CLHEP::HepLorentzVector getBestMomentum() const {return newMomentum_;}
@@ -35,19 +33,13 @@ class ElectronMomentumCorrector
   //float getSCEnergyError() const {return errorEnergy_;}
   //float getTrackMomentumError() const {return errorTrackMomentum_;}
 
- private:
-
+private:
   float energyError(float E, float *par) const;
 
   //  CLHEP::HepLorentzVector newMomentum_;
   //math::XYZTLorentzVector newMomentum_;
   //float errorEnergy_;
   //float errorTrackMomentum_;
-
 };
 
 #endif
-
-
-
-

--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronSeedGenerator.h
@@ -38,7 +38,6 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 
-
 class PropagatorWithMaterial;
 class KFUpdator;
 class PixelHitMatcher;
@@ -46,10 +45,8 @@ class MeasurementTracker;
 class NavigationSchool;
 class TrackerTopology;
 
-class ElectronSeedGenerator
-{
- public:
-
+class ElectronSeedGenerator {
+public:
   struct Tokens {
     edm::EDGetTokenT<std::vector<reco::Vertex> > token_vtx;
     edm::EDGetTokenT<reco::BeamSpot> token_bs;
@@ -57,29 +54,42 @@ class ElectronSeedGenerator
   };
 
   typedef edm::OwnVector<TrackingRecHit> PRecHitContainer;
-  typedef TransientTrackingRecHit::ConstRecHitPointer   ConstRecHitPointer;
-  typedef TransientTrackingRecHit::RecHitPointer        RecHitPointer;
-  typedef TransientTrackingRecHit::RecHitContainer      RecHitContainer;
+  typedef TransientTrackingRecHit::ConstRecHitPointer ConstRecHitPointer;
+  typedef TransientTrackingRecHit::RecHitPointer RecHitPointer;
+  typedef TransientTrackingRecHit::RecHitContainer RecHitContainer;
 
-  ElectronSeedGenerator(const edm::ParameterSet&,
-			const Tokens&);
+  ElectronSeedGenerator(const edm::ParameterSet&, const Tokens&);
   ~ElectronSeedGenerator();
 
   void setupES(const edm::EventSetup& setup);
-  void run(
-    edm::Event&, const edm::EventSetup& setup,
-    const reco::SuperClusterRefVector &, const std::vector<float> & hoe1s, const std::vector<float> & hoe2s,
-    const std::vector<const TrajectorySeedCollection *>& seedsV, reco::ElectronSeedCollection&);
+  void run(edm::Event&,
+           const edm::EventSetup& setup,
+           const reco::SuperClusterRefVector&,
+           const std::vector<float>& hoe1s,
+           const std::vector<float>& hoe2s,
+           const std::vector<const TrajectorySeedCollection*>& seedsV,
+           reco::ElectronSeedCollection&);
 
- private:
-
-  void seedsFromThisCluster( edm::Ref<reco::SuperClusterCollection> seedCluster, float hoe1, float hoe2, reco::ElectronSeedCollection & out, const TrackerTopology *tTopo ) ;
-  void seedsFromRecHits( std::vector<std::pair<RecHitWithDist,ConstRecHitPointer> > & elePixelHits, PropagationDirection & dir, 
-                         const GlobalPoint & vertexPos, const reco::ElectronSeed::CaloClusterRef & cluster, reco::ElectronSeedCollection & out, bool positron ) ;
-  void seedsFromTrajectorySeeds( const std::vector<SeedWithInfo> & elePixelSeeds, const reco::ElectronSeed::CaloClusterRef & cluster, 
-                                 float hoe1, float hoe2, reco::ElectronSeedCollection & out, bool positron ) ;
-  void addSeed( reco::ElectronSeed & seed, const SeedWithInfo * info, bool positron, reco::ElectronSeedCollection & out ) ;
-  bool prepareElTrackSeed( ConstRecHitPointer outerhit,ConstRecHitPointer innerhit, const GlobalPoint & vertexPos) ;
+private:
+  void seedsFromThisCluster(edm::Ref<reco::SuperClusterCollection> seedCluster,
+                            float hoe1,
+                            float hoe2,
+                            reco::ElectronSeedCollection& out,
+                            const TrackerTopology* tTopo);
+  void seedsFromRecHits(std::vector<std::pair<RecHitWithDist, ConstRecHitPointer> >& elePixelHits,
+                        PropagationDirection& dir,
+                        const GlobalPoint& vertexPos,
+                        const reco::ElectronSeed::CaloClusterRef& cluster,
+                        reco::ElectronSeedCollection& out,
+                        bool positron);
+  void seedsFromTrajectorySeeds(const std::vector<SeedWithInfo>& elePixelSeeds,
+                                const reco::ElectronSeed::CaloClusterRef& cluster,
+                                float hoe1,
+                                float hoe2,
+                                reco::ElectronSeedCollection& out,
+                                bool positron);
+  void addSeed(reco::ElectronSeed& seed, const SeedWithInfo* info, bool positron, reco::ElectronSeedCollection& out);
+  bool prepareElTrackSeed(ConstRecHitPointer outerhit, ConstRecHitPointer innerhit, const GlobalPoint& vertexPos);
 
   bool dynamicphiroad_;
   bool fromTrackerSeeds_;
@@ -93,52 +103,49 @@ class ElectronSeedGenerator
 
   float lowPtThreshold_;
   float highPtThreshold_;
-  float nSigmasDeltaZ1_; // first z window size if not using the reco vertex
-  float deltaZ1WithVertex_; // first z window size when using the reco vertex
+  float nSigmasDeltaZ1_;     // first z window size if not using the reco vertex
+  float deltaZ1WithVertex_;  // first z window size when using the reco vertex
   float sizeWindowENeg_;
-  float phiMin2B_ ;
-  float phiMax2B_ ;
-  float phiMin2F_ ;
-  float phiMax2F_ ;
+  float phiMin2B_;
+  float phiMax2B_;
+  float phiMin2F_;
+  float phiMax2F_;
   float deltaPhi1Low_, deltaPhi1High_;
   float deltaPhi2B_;
   float deltaPhi2F_;
 
   // so that deltaPhi1 = deltaPhi1Coef1_ + deltaPhi1Coef2_/clusterEnergyT
-  double deltaPhi1Coef1_ ;
-  double deltaPhi1Coef2_ ;
+  double deltaPhi1Coef1_;
+  double deltaPhi1Coef2_;
 
-  PixelHitMatcher *myMatchEle;
-  PixelHitMatcher *myMatchPos;
+  PixelHitMatcher* myMatchEle;
+  PixelHitMatcher* myMatchPos;
 
   const std::vector<const TrajectorySeedCollection*>* theInitialSeedCollV = nullptr;
 
-  edm::ESHandle<MagneticField>                theMagField;
-  edm::ESHandle<TrackerGeometry>              theTrackerGeometry;
+  edm::ESHandle<MagneticField> theMagField;
+  edm::ESHandle<TrackerGeometry> theTrackerGeometry;
   //edm::ESHandle<GeometricSearchTracker>       theGeomSearchTracker;
-  KFUpdator * theUpdator;
-  PropagatorWithMaterial * thePropagator;
+  KFUpdator* theUpdator;
+  PropagatorWithMaterial* thePropagator;
 
   std::string theMeasurementTrackerName;
-  const MeasurementTracker*     theMeasurementTracker;
+  const MeasurementTracker* theMeasurementTracker;
   edm::EDGetTokenT<MeasurementTrackerEvent> theMeasurementTrackerEventTag;
 
-  const NavigationSchool*       theNavigationSchool;
+  const NavigationSchool* theNavigationSchool;
 
-  const edm::EventSetup *theSetup;
-  
+  const edm::EventSetup* theSetup;
 
   PRecHitContainer recHits_;
   PTrajectoryStateOnDet pts_;
 
   // keep cacheIds to get records only when necessary
   unsigned long long cacheIDMagField_;
-//  unsigned long long cacheIDGeom_;
+  //  unsigned long long cacheIDGeom_;
   unsigned long long cacheIDNavSchool_;
   unsigned long long cacheIDCkfComp_;
   unsigned long long cacheIDTrkGeom_;
 };
 
-#endif // ElectronSeedGenerator_H
-
-
+#endif  // ElectronSeedGenerator_H

--- a/RecoEgamma/EgammaElectronAlgos/interface/ElectronUtilities.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ElectronUtilities.h
@@ -7,56 +7,74 @@
 #include "DataFormats/Math/interface/Vector3D.h"
 #include "DataFormats/Math/interface/normalizedPhi.h"
 
-
 //===============================================================
 // Convert between flavors of points and vectors,
 // assuming existence of x(), y() and z().
 //===============================================================
 
 template <typename Type1, typename Type2>
-void ele_convert( const Type1 & obj1, Type2 & obj2 )
- { obj2 = Type2(obj1.x(),obj1.y(),obj1.z()) ; }
-
+void ele_convert(const Type1& obj1, Type2& obj2) {
+  obj2 = Type2(obj1.x(), obj1.y(), obj1.z());
+}
 
 //===============================================================
 // When wanting to compute and compare several characteristics of
 // one or two points, relatively to a given origin
 //===============================================================
 
-class EleRelPoint
- {
-  public :
-    EleRelPoint( const math::XYZPoint & p, const math::XYZPoint & origin ) : relP_(p.x()-origin.x(),p.y()-origin.y(),p.z()-origin.z()) {}
-    EleRelPoint( const GlobalPoint & p, const math::XYZPoint & origin ) : relP_(p.x()-origin.x(),p.y()-origin.y(),p.z()-origin.z()) {}
-    EleRelPoint( const math::XYZPoint & p, const GlobalPoint & origin ) : relP_(p.x()-origin.x(),p.y()-origin.y(),p.z()-origin.z()) {}
-    EleRelPoint( const GlobalPoint & p, const GlobalPoint & origin ) : relP_(p.x()-origin.x(),p.y()-origin.y(),p.z()-origin.z()) {}
-    double eta() { return relP_.eta() ; }
-    double phi() { return normalizedPhi(relP_.phi()) ; }
-    double perp() { return std::sqrt(relP_.x()*relP_.x()+relP_.y()*relP_.y()) ; }
-  private :
-    math::XYZVector relP_ ;
- } ;
+class EleRelPoint {
+public:
+  EleRelPoint(const math::XYZPoint& p, const math::XYZPoint& origin)
+      : relP_(p.x() - origin.x(), p.y() - origin.y(), p.z() - origin.z()) {}
+  EleRelPoint(const GlobalPoint& p, const math::XYZPoint& origin)
+      : relP_(p.x() - origin.x(), p.y() - origin.y(), p.z() - origin.z()) {}
+  EleRelPoint(const math::XYZPoint& p, const GlobalPoint& origin)
+      : relP_(p.x() - origin.x(), p.y() - origin.y(), p.z() - origin.z()) {}
+  EleRelPoint(const GlobalPoint& p, const GlobalPoint& origin)
+      : relP_(p.x() - origin.x(), p.y() - origin.y(), p.z() - origin.z()) {}
+  double eta() { return relP_.eta(); }
+  double phi() { return normalizedPhi(relP_.phi()); }
+  double perp() { return std::sqrt(relP_.x() * relP_.x() + relP_.y() * relP_.y()); }
 
-class EleRelPointPair
- {
-  public :
-    EleRelPointPair( const math::XYZPoint & p1, const math::XYZPoint & p2, const math::XYZPoint & origin ) : relP1_(p1.x()-origin.x(),p1.y()-origin.y(),p1.z()-origin.z()), relP2_(p2.x()-origin.x(),p2.y()-origin.y(),p2.z()-origin.z()) {}
-    EleRelPointPair( const GlobalPoint & p1, const math::XYZPoint & p2, const math::XYZPoint & origin ) : relP1_(p1.x()-origin.x(),p1.y()-origin.y(),p1.z()-origin.z()), relP2_(p2.x()-origin.x(),p2.y()-origin.y(),p2.z()-origin.z()) {}
-    EleRelPointPair( const math::XYZPoint & p1, const GlobalPoint & p2, const math::XYZPoint & origin ) : relP1_(p1.x()-origin.x(),p1.y()-origin.y(),p1.z()-origin.z()), relP2_(p2.x()-origin.x(),p2.y()-origin.y(),p2.z()-origin.z()) {}
-    EleRelPointPair( const math::XYZPoint & p1, const math::XYZPoint & p2, const GlobalPoint & origin ) : relP1_(p1.x()-origin.x(),p1.y()-origin.y(),p1.z()-origin.z()), relP2_(p2.x()-origin.x(),p2.y()-origin.y(),p2.z()-origin.z()) {}
-    EleRelPointPair( const GlobalPoint & p1, const GlobalPoint & p2, const math::XYZPoint & origin ) : relP1_(p1.x()-origin.x(),p1.y()-origin.y(),p1.z()-origin.z()), relP2_(p2.x()-origin.x(),p2.y()-origin.y(),p2.z()-origin.z()) {}
-    EleRelPointPair( const math::XYZPoint & p1, const GlobalPoint & p2, const GlobalPoint & origin ) : relP1_(p1.x()-origin.x(),p1.y()-origin.y(),p1.z()-origin.z()), relP2_(p2.x()-origin.x(),p2.y()-origin.y(),p2.z()-origin.z()) {}
-    EleRelPointPair( const GlobalPoint & p1, const math::XYZPoint & p2, const GlobalPoint & origin ) : relP1_(p1.x()-origin.x(),p1.y()-origin.y(),p1.z()-origin.z()), relP2_(p2.x()-origin.x(),p2.y()-origin.y(),p2.z()-origin.z()) {}
-    EleRelPointPair( const GlobalPoint & p1, const GlobalPoint & p2, const GlobalPoint & origin ) : relP1_(p1.x()-origin.x(),p1.y()-origin.y(),p1.z()-origin.z()), relP2_(p2.x()-origin.x(),p2.y()-origin.y(),p2.z()-origin.z()) {}
-    auto dEta() { return (relP1_.eta()-relP2_.eta()) ; }
-    auto dPhi() { return normalizedPhi(relP1_.barePhi()-relP2_.barePhi()) ; }
-    auto dZ() { return (relP1_.z()-relP2_.z()) ; }
-    auto dPerp() { return (relP1_.perp()-relP2_.perp()) ; }
-  private :
-    GlobalVector relP1_ ;
-    GlobalVector relP2_ ;
- } ;
+private:
+  math::XYZVector relP_;
+};
 
+class EleRelPointPair {
+public:
+  EleRelPointPair(const math::XYZPoint& p1, const math::XYZPoint& p2, const math::XYZPoint& origin)
+      : relP1_(p1.x() - origin.x(), p1.y() - origin.y(), p1.z() - origin.z()),
+        relP2_(p2.x() - origin.x(), p2.y() - origin.y(), p2.z() - origin.z()) {}
+  EleRelPointPair(const GlobalPoint& p1, const math::XYZPoint& p2, const math::XYZPoint& origin)
+      : relP1_(p1.x() - origin.x(), p1.y() - origin.y(), p1.z() - origin.z()),
+        relP2_(p2.x() - origin.x(), p2.y() - origin.y(), p2.z() - origin.z()) {}
+  EleRelPointPair(const math::XYZPoint& p1, const GlobalPoint& p2, const math::XYZPoint& origin)
+      : relP1_(p1.x() - origin.x(), p1.y() - origin.y(), p1.z() - origin.z()),
+        relP2_(p2.x() - origin.x(), p2.y() - origin.y(), p2.z() - origin.z()) {}
+  EleRelPointPair(const math::XYZPoint& p1, const math::XYZPoint& p2, const GlobalPoint& origin)
+      : relP1_(p1.x() - origin.x(), p1.y() - origin.y(), p1.z() - origin.z()),
+        relP2_(p2.x() - origin.x(), p2.y() - origin.y(), p2.z() - origin.z()) {}
+  EleRelPointPair(const GlobalPoint& p1, const GlobalPoint& p2, const math::XYZPoint& origin)
+      : relP1_(p1.x() - origin.x(), p1.y() - origin.y(), p1.z() - origin.z()),
+        relP2_(p2.x() - origin.x(), p2.y() - origin.y(), p2.z() - origin.z()) {}
+  EleRelPointPair(const math::XYZPoint& p1, const GlobalPoint& p2, const GlobalPoint& origin)
+      : relP1_(p1.x() - origin.x(), p1.y() - origin.y(), p1.z() - origin.z()),
+        relP2_(p2.x() - origin.x(), p2.y() - origin.y(), p2.z() - origin.z()) {}
+  EleRelPointPair(const GlobalPoint& p1, const math::XYZPoint& p2, const GlobalPoint& origin)
+      : relP1_(p1.x() - origin.x(), p1.y() - origin.y(), p1.z() - origin.z()),
+        relP2_(p2.x() - origin.x(), p2.y() - origin.y(), p2.z() - origin.z()) {}
+  EleRelPointPair(const GlobalPoint& p1, const GlobalPoint& p2, const GlobalPoint& origin)
+      : relP1_(p1.x() - origin.x(), p1.y() - origin.y(), p1.z() - origin.z()),
+        relP2_(p2.x() - origin.x(), p2.y() - origin.y(), p2.z() - origin.z()) {}
+  auto dEta() { return (relP1_.eta() - relP2_.eta()); }
+  auto dPhi() { return normalizedPhi(relP1_.barePhi() - relP2_.barePhi()); }
+  auto dZ() { return (relP1_.z() - relP2_.z()); }
+  auto dPerp() { return (relP1_.perp() - relP2_.perp()); }
+
+private:
+  GlobalVector relP1_;
+  GlobalVector relP2_;
+};
 
 //===============================================================
 // Low level functions for the computing of characteristics
@@ -66,12 +84,13 @@ class EleRelPointPair
 //===============================================================
 
 template <typename PointType>
-double relative_eta( const PointType & p, const PointType & origin )
- { return (p-origin).eta() ; }
+double relative_eta(const PointType& p, const PointType& origin) {
+  return (p - origin).eta();
+}
 
 template <typename PointType>
-double relative_phi( const PointType & p, const PointType & origin )
- { return normalizedPhi((p-origin).phi()) ; }
-
+double relative_phi(const PointType& p, const PointType& origin) {
+  return normalizedPhi((p - origin).phi());
+}
 
 #endif

--- a/RecoEgamma/EgammaElectronAlgos/interface/EnergyUncertaintyElectronSpecific.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/EnergyUncertaintyElectronSpecific.h
@@ -14,29 +14,24 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 
-class EnergyUncertaintyElectronSpecific
- {
-  public:
+class EnergyUncertaintyElectronSpecific {
+public:
+  //EnergyUncertaintyElectronSpecific( const edm::ParameterSet& config);
+  EnergyUncertaintyElectronSpecific();
+  ~EnergyUncertaintyElectronSpecific();
 
-   //EnergyUncertaintyElectronSpecific( const edm::ParameterSet& config);
-   EnergyUncertaintyElectronSpecific();
-   ~EnergyUncertaintyElectronSpecific();
+  void init(const edm::EventSetup& theEventSetup);
+  //void calculate( edm::Event& evt, reco::Electron &, int subdet,const reco::VertexCollection& vtxcol,const edm::EventSetup& iSetup) ;
+  //double applyCrackCorrection(const reco::SuperCluster &cl, EcalClusterFunctionBaseClass* crackCorrectionFunction);
 
-   void init(const edm::EventSetup& theEventSetup );
-   //void calculate( edm::Event& evt, reco::Electron &, int subdet,const reco::VertexCollection& vtxcol,const edm::EventSetup& iSetup) ;
-   //double applyCrackCorrection(const reco::SuperCluster &cl, EcalClusterFunctionBaseClass* crackCorrectionFunction);
+  double computeElectronEnergyUncertainty(reco::GsfElectron::Classification c, double eta, double brem, double energy);
 
-   double computeElectronEnergyUncertainty( reco::GsfElectron::Classification c, double eta, double brem, double energy);
-
-  private:
-
-   double computeElectronEnergyUncertainty_golden(double eta, double brem, double energy);
-   double computeElectronEnergyUncertainty_bigbrem(double eta, double brem, double energy);
-   double computeElectronEnergyUncertainty_showering(double eta, double brem, double energy);
-   double computeElectronEnergyUncertainty_cracks(double eta, double brem, double energy);
-   double computeElectronEnergyUncertainty_badtrack(double eta, double brem, double energy);
-
-
- } ;
+private:
+  double computeElectronEnergyUncertainty_golden(double eta, double brem, double energy);
+  double computeElectronEnergyUncertainty_bigbrem(double eta, double brem, double energy);
+  double computeElectronEnergyUncertainty_showering(double eta, double brem, double energy);
+  double computeElectronEnergyUncertainty_cracks(double eta, double brem, double energy);
+  double computeElectronEnergyUncertainty_badtrack(double eta, double brem, double energy);
+};
 
 #endif

--- a/RecoEgamma/EgammaElectronAlgos/interface/FTSFromVertexToPointFactory.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/FTSFromVertexToPointFactory.h
@@ -4,7 +4,7 @@
 //
 // Package:    EgammaElectronAlgos
 // Class:      FTSFromVertexToPointFactory
-// 
+//
 /**
  *  Generates a FreeTrajectoryState from a given measured point, vertex
  *  momentum and charge.
@@ -26,9 +26,13 @@
 
 class MagneticField;
 
-class FTSFromVertexToPointFactory{
+class FTSFromVertexToPointFactory {
 public:
-  static FreeTrajectoryState get( MagneticField const & magField, GlobalPoint const & xmeas, GlobalPoint const & xvert, float momentum, TrackCharge charge);
+  static FreeTrajectoryState get(MagneticField const& magField,
+                                 GlobalPoint const& xmeas,
+                                 GlobalPoint const& xvert,
+                                 float momentum,
+                                 TrackCharge charge);
 };
 
 #endif

--- a/RecoEgamma/EgammaElectronAlgos/interface/ForwardMeasurementEstimator.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/ForwardMeasurementEstimator.h
@@ -23,45 +23,45 @@
 #include "DataFormats/GeometrySurface/interface/BoundPlane.h"
 #include <utility>
 
-class ForwardMeasurementEstimator
- : public MeasurementEstimator
- {
-  public:
+class ForwardMeasurementEstimator : public MeasurementEstimator {
+public:
+  ForwardMeasurementEstimator() {}
+  ForwardMeasurementEstimator(float phiMin, float phiMax, float rMin, float rMax)
+      : thePhiMin(phiMin), thePhiMax(phiMax), theRMin(rMin), theRMax(rMax) {}
 
-    ForwardMeasurementEstimator()
-     {}
-    ForwardMeasurementEstimator(float phiMin, float phiMax, float rMin, float rMax )
-     : thePhiMin(phiMin), thePhiMax( phiMax), theRMin(rMin), theRMax(rMax)
-     {}
+  void setPhiRange(float dummyphiMin, float dummyphiMax) {
+    thePhiMin = dummyphiMin;
+    thePhiMax = dummyphiMax;
+  }
+  void setRRange(float rmin, float rmax) {
+    theRMin = rmin;
+    theRMax = rmax;
+  }
+  void setRRangeI(float rmin, float rmax) {
+    theRMinI = rmin;
+    theRMaxI = rmax;
+  }
 
-    void setPhiRange(float dummyphiMin , float dummyphiMax )
-     { thePhiMin = dummyphiMin ; thePhiMax = dummyphiMax ; }
-    void setRRange(float rmin, float rmax )
-     { theRMin = rmin ; theRMax = rmax ; }
-    void setRRangeI( float rmin, float rmax )
-     { theRMinI = rmin ; theRMaxI = rmax ; }
+  // zero value indicates incompatible ts - hit pair
+  std::pair<bool, double> estimate(const TrajectoryStateOnSurface& ts, const TrackingRecHit& hit) const override;
+  virtual std::pair<bool, double> estimate(const TrajectoryStateOnSurface& ts, const GlobalPoint& gp) const;
+  virtual std::pair<bool, double> estimate(const GlobalPoint& vprim,
+                                           const TrajectoryStateOnSurface& ts,
+                                           const GlobalPoint& gp) const;
+  bool estimate(const TrajectoryStateOnSurface& ts, const BoundPlane& plane) const override;
 
-    // zero value indicates incompatible ts - hit pair
-    std::pair<bool,double> estimate( const TrajectoryStateOnSurface & ts, const TrackingRecHit & hit ) const override ;
-    virtual std::pair<bool,double> estimate( const TrajectoryStateOnSurface & ts, const GlobalPoint & gp ) const ;
-    virtual std::pair<bool,double> estimate( const GlobalPoint & vprim, const TrajectoryStateOnSurface & ts, const GlobalPoint & gp ) const ;
-    bool estimate( const TrajectoryStateOnSurface & ts, const BoundPlane & plane ) const override ;
+  ForwardMeasurementEstimator* clone() const override { return new ForwardMeasurementEstimator(*this); }
 
-    ForwardMeasurementEstimator* clone() const override
-     { return new ForwardMeasurementEstimator(*this) ; }
+  MeasurementEstimator::Local2DVector maximalLocalDisplacement(const TrajectoryStateOnSurface& ts,
+                                                               const BoundPlane& plane) const override;
 
-    MeasurementEstimator::Local2DVector
-    maximalLocalDisplacement( const TrajectoryStateOnSurface & ts, const BoundPlane & plane) const override ;
+private:
+  float thePhiMin;
+  float thePhiMax;
+  float theRMin;
+  float theRMax;
+  float theRMinI;
+  float theRMaxI;
+};
 
-  private :
-
-    float thePhiMin ;
-    float thePhiMax ;
-    float theRMin ;
-    float theRMax ;
-    float theRMinI ;
-    float theRMaxI ;
-
- } ;
-
-#endif // ForwardMeasurementEstimator_H
+#endif  // ForwardMeasurementEstimator_H

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -7,7 +7,7 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronCoreFwd.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h" 
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "DataFormats/EgammaCandidates/interface/Conversion.h"
 #include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
@@ -46,339 +46,323 @@
 #include <list>
 #include <string>
 
-
 class GsfElectronAlgo {
+public:
+  struct InputTagsConfiguration {
+    edm::EDGetTokenT<reco::GsfElectronCollection> previousGsfElectrons;
+    edm::EDGetTokenT<reco::GsfElectronCollection> pflowGsfElectronsTag;
+    edm::EDGetTokenT<reco::GsfElectronCoreCollection> gsfElectronCores;
+    edm::EDGetTokenT<CaloTowerCollection> hcalTowersTag;
+    edm::EDGetTokenT<reco::SuperClusterCollection> barrelSuperClusters;
+    edm::EDGetTokenT<reco::SuperClusterCollection> endcapSuperClusters;
+    //edm::EDGetTokenT tracks ;
+    edm::EDGetTokenT<EcalRecHitCollection> barrelRecHitCollection;
+    edm::EDGetTokenT<EcalRecHitCollection> endcapRecHitCollection;
+    edm::EDGetTokenT<reco::ElectronSeedCollection> seedsTag;
+    edm::EDGetTokenT<reco::TrackCollection> ctfTracks;
+    edm::EDGetTokenT<reco::BeamSpot> beamSpotTag;
+    edm::EDGetTokenT<reco::GsfPFRecTrackCollection> gsfPfRecTracksTag;
+    edm::EDGetTokenT<reco::VertexCollection> vtxCollectionTag;
+    edm::EDGetTokenT<reco::ConversionCollection> conversions;
 
-  public:
+    //IsoVals (PF and EcalDriven)
+    edm::ParameterSet pfIsoVals;
+    edm::ParameterSet edIsoVals;
+  };
 
-    struct InputTagsConfiguration
-     {
-       edm::EDGetTokenT<reco::GsfElectronCollection> previousGsfElectrons ;
-       edm::EDGetTokenT<reco::GsfElectronCollection> pflowGsfElectronsTag ;
-       edm::EDGetTokenT<reco::GsfElectronCoreCollection> gsfElectronCores ;
-       edm::EDGetTokenT<CaloTowerCollection> hcalTowersTag ;
-       edm::EDGetTokenT<reco::SuperClusterCollection> barrelSuperClusters ;
-       edm::EDGetTokenT<reco::SuperClusterCollection> endcapSuperClusters ;
-      //edm::EDGetTokenT tracks ;
-       edm::EDGetTokenT<EcalRecHitCollection> barrelRecHitCollection ;
-       edm::EDGetTokenT<EcalRecHitCollection> endcapRecHitCollection ;
-       edm::EDGetTokenT<reco::ElectronSeedCollection> seedsTag ;
-       edm::EDGetTokenT<reco::TrackCollection> ctfTracks ;
-       edm::EDGetTokenT<reco::BeamSpot> beamSpotTag ;
-       edm::EDGetTokenT<reco::GsfPFRecTrackCollection> gsfPfRecTracksTag ;
-       edm::EDGetTokenT<reco::VertexCollection> vtxCollectionTag;
-       edm::EDGetTokenT<reco::ConversionCollection> conversions;
+  struct StrategyConfiguration {
+    bool useGsfPfRecTracks;
+    // if true, electron preselection is applied
+    bool applyPreselection;
+    // if true, electron level escale corrections are
+    // used on top of the cluster level corrections
+    bool ecalDrivenEcalEnergyFromClassBasedParameterization;
+    bool ecalDrivenEcalErrorFromClassBasedParameterization;
+    bool pureTrackerDrivenEcalErrorFromSimpleParameterization;
+    // ambiguity solving
+    bool applyAmbResolution;              // if not true, ambiguity solving is not applied
+    unsigned ambSortingStrategy;          // 0:isBetter, 1:isInnerMost
+    unsigned ambClustersOverlapStrategy;  // 0:sc adresses, 1:bc shared energy
+    // if true, trackerDriven electrons are added
+    bool addPflowElectrons;
+    // for backward compatibility
+    bool ctfTracksCheck;
+    bool gedElectronMode;
+    float PreSelectMVA;
+    float MaxElePtForOnlyMVA;
+    // GED-Regression (ECAL and combination)
+    bool useEcalRegression;
+    bool useCombinationRegression;
+    //heavy ion in 2015 has no conversions and so cant fill conv vtx fit prob so this bool
+    //stops it from being filled
+    bool fillConvVtxFitProb;
+  };
 
-      //IsoVals (PF and EcalDriven)
-      edm::ParameterSet pfIsoVals;
-      edm::ParameterSet edIsoVals;
+  struct CutsConfiguration {
+    // minimum SC Et
+    double minSCEtBarrel;
+    double minSCEtEndcaps;
+    // maximum E/p where E is the supercluster corrected energy and p the track momentum at innermost state
+    double maxEOverPBarrel;
+    double maxEOverPEndcaps;
+    // minimum E/p where E is the supercluster corrected energy and p the track momentum at innermost state
+    double minEOverPBarrel;
+    double minEOverPEndcaps;
 
-     } ;
+    // H/E
+    double maxHOverEBarrelCone;
+    double maxHOverEEndcapsCone;
+    double maxHBarrelCone;
+    double maxHEndcapsCone;
+    double maxHOverEBarrelTower;
+    double maxHOverEEndcapsTower;
+    double maxHBarrelTower;
+    double maxHEndcapsTower;
 
-    struct StrategyConfiguration
-     {
-      bool useGsfPfRecTracks ;
-      // if true, electron preselection is applied
-      bool applyPreselection ;
-      // if true, electron level escale corrections are
-      // used on top of the cluster level corrections
-      bool ecalDrivenEcalEnergyFromClassBasedParameterization ;
-      bool ecalDrivenEcalErrorFromClassBasedParameterization ;
-      bool pureTrackerDrivenEcalErrorFromSimpleParameterization ;
-      // ambiguity solving
-      bool applyAmbResolution  ; // if not true, ambiguity solving is not applied
-      unsigned ambSortingStrategy  ; // 0:isBetter, 1:isInnerMost
-      unsigned ambClustersOverlapStrategy  ; // 0:sc adresses, 1:bc shared energy
-      // if true, trackerDriven electrons are added
-      bool addPflowElectrons ;
-      // for backward compatibility
-      bool ctfTracksCheck ;
-      bool gedElectronMode;
-      float PreSelectMVA;	
-      float MaxElePtForOnlyMVA;
-      // GED-Regression (ECAL and combination)
-      bool useEcalRegression;
-      bool useCombinationRegression;  
-      //heavy ion in 2015 has no conversions and so cant fill conv vtx fit prob so this bool
-      //stops it from being filled
-      bool fillConvVtxFitProb;
-     } ;
+    // maximum eta difference between the supercluster position and the track position at the closest impact to the supercluster
+    double maxDeltaEtaBarrel;
+    double maxDeltaEtaEndcaps;
 
-    struct CutsConfiguration
-     {
-      // minimum SC Et
-      double minSCEtBarrel ;
-      double minSCEtEndcaps ;
-      // maximum E/p where E is the supercluster corrected energy and p the track momentum at innermost state
-      double maxEOverPBarrel ;
-      double maxEOverPEndcaps ;
-      // minimum E/p where E is the supercluster corrected energy and p the track momentum at innermost state
-      double minEOverPBarrel ;
-      double minEOverPEndcaps ;
+    // maximum phi difference between the supercluster position and the track position at the closest impact to the supercluster
+    // position to the supercluster
+    double maxDeltaPhiBarrel;
+    double maxDeltaPhiEndcaps;
 
-      // H/E
-      double maxHOverEBarrelCone ;
-      double maxHOverEEndcapsCone ;
-      double maxHBarrelCone ;
-      double maxHEndcapsCone ;
-      double maxHOverEBarrelTower ;
-      double maxHOverEEndcapsTower ;
-      double maxHBarrelTower ;
-      double maxHEndcapsTower ;
+    // maximum sigma ieta ieta
+    double maxSigmaIetaIetaBarrel;
+    double maxSigmaIetaIetaEndcaps;
+    // maximum fbrem
 
-      // maximum eta difference between the supercluster position and the track position at the closest impact to the supercluster
-      double maxDeltaEtaBarrel ;
-      double maxDeltaEtaEndcaps ;
+    double maxFbremBarrel;
+    double maxFbremEndcaps;
 
-      // maximum phi difference between the supercluster position and the track position at the closest impact to the supercluster
-      // position to the supercluster
-      double maxDeltaPhiBarrel ;
-      double maxDeltaPhiEndcaps ;
+    // fiducial regions
+    bool isBarrel;
+    bool isEndcaps;
+    bool isFiducial;
 
-      // maximum sigma ieta ieta
-      double maxSigmaIetaIetaBarrel ;
-      double maxSigmaIetaIetaEndcaps ;
-      // maximum fbrem
+    // BDT output (if available)
+    double minMVA;
+    double minMvaByPassForIsolated;
 
-      double maxFbremBarrel ;
-      double maxFbremEndcaps ;
+    // transverse impact parameter wrt beam spot
+    double maxTIP;
 
-      // fiducial regions
-      bool isBarrel ;
-      bool isEndcaps ;
-      bool isFiducial ;
+    // only make sense for ecal driven electrons
+    bool seedFromTEC;
+  };
 
-      // BDT output (if available)
-      double minMVA ;
-      double minMvaByPassForIsolated ;
+  // Ecal rec hits
+  struct EcalRecHitsConfiguration {
+    std::vector<int> recHitFlagsToBeExcludedBarrel;
+    std::vector<int> recHitFlagsToBeExcludedEndcaps;
+    std::vector<int> recHitSeverityToBeExcludedBarrel;
+    std::vector<int> recHitSeverityToBeExcludedEndcaps;
+    //int severityLevelCut ;
+  };
 
-      // transverse impact parameter wrt beam spot
-      double maxTIP ;
+  // isolation variables parameters
+  struct IsolationConfiguration {
+    double intRadiusHcal;
+    double etMinHcal;
+    double intRadiusEcalBarrel;
+    double intRadiusEcalEndcaps;
+    double jurassicWidth;
+    double etMinBarrel;
+    double eMinBarrel;
+    double etMinEndcaps;
+    double eMinEndcaps;
+    bool vetoClustered;
+    bool useNumCrystals;
+  };
 
-      // only make sense for ecal driven electrons
-      bool seedFromTEC ;
-     } ;
+  GsfElectronAlgo(const InputTagsConfiguration&,
+                  const StrategyConfiguration&,
+                  const CutsConfiguration& cutsCfg,
+                  const CutsConfiguration& cutsCfgPflow,
+                  const ElectronHcalHelper::Configuration& hcalCfg,
+                  const ElectronHcalHelper::Configuration& hcalCfgPflow,
+                  const IsolationConfiguration&,
+                  const EcalRecHitsConfiguration&,
+                  std::unique_ptr<EcalClusterFunctionBaseClass> superClusterErrorFunction,
+                  std::unique_ptr<EcalClusterFunctionBaseClass> crackCorrectionFunction,
+                  const RegressionHelper::Configuration& regCfg,
+                  const edm::ParameterSet& tkIsol03Cfg,
+                  const edm::ParameterSet& tkIsol04Cfg,
+                  const edm::ParameterSet& tkIsolHEEP03Cfg,
+                  const edm::ParameterSet& tkIsolHEEP04Cfg
 
-    // Ecal rec hits
-    struct EcalRecHitsConfiguration
-     {
-      std::vector<int> recHitFlagsToBeExcludedBarrel ;
-      std::vector<int> recHitFlagsToBeExcludedEndcaps ;
-      std::vector<int> recHitSeverityToBeExcludedBarrel ;
-      std::vector<int> recHitSeverityToBeExcludedEndcaps ;
-      //int severityLevelCut ;
-     } ;
+  );
 
-    // isolation variables parameters
-    struct IsolationConfiguration
-     {
-      double intRadiusHcal ;
-      double etMinHcal ;
-      double intRadiusEcalBarrel ;
-      double intRadiusEcalEndcaps ;
-      double jurassicWidth ;
-      double etMinBarrel ;
-      double eMinBarrel ;
-      double etMinEndcaps ;
-      double eMinEndcaps ;
-      bool vetoClustered ;
-      bool useNumCrystals ;
-     } ;
+  // main methods
+  void completeElectrons(reco::GsfElectronCollection& electrons,  // do not redo cloned electrons done previously
+                         edm::Event const& event,
+                         edm::EventSetup const& eventSetup,
+                         const gsfAlgoHelpers::HeavyObjectCache* hoc);
 
-    GsfElectronAlgo
-     (
-      const InputTagsConfiguration &,
-      const StrategyConfiguration &,
-      const CutsConfiguration & cutsCfg,
-      const CutsConfiguration & cutsCfgPflow,
-      const ElectronHcalHelper::Configuration & hcalCfg,
-      const ElectronHcalHelper::Configuration & hcalCfgPflow,
-      const IsolationConfiguration &,
-      const EcalRecHitsConfiguration &,
-      std::unique_ptr<EcalClusterFunctionBaseClass> superClusterErrorFunction,
-      std::unique_ptr<EcalClusterFunctionBaseClass> crackCorrectionFunction,
-      const RegressionHelper::Configuration & regCfg,
-      const edm::ParameterSet& tkIsol03Cfg,
-      const edm::ParameterSet& tkIsol04Cfg,
-      const edm::ParameterSet& tkIsolHEEP03Cfg,
-      const edm::ParameterSet& tkIsolHEEP04Cfg
-      
-      ) ;
+private:
+  // internal structures
 
-    // main methods
-    void completeElectrons( reco::GsfElectronCollection & electrons, // do not redo cloned electrons done previously
-                            edm::Event const& event,
-                            edm::EventSetup const& eventSetup,
-                            const gsfAlgoHelpers::HeavyObjectCache* hoc);
+  //===================================================================
+  // GsfElectronAlgo::GeneralData
+  //===================================================================
 
-  private :
+  // general data and helpers
+  struct GeneralData {
+    // configurables
+    const InputTagsConfiguration inputCfg;
+    const StrategyConfiguration strategyCfg;
+    const CutsConfiguration cutsCfg;
+    const CutsConfiguration cutsCfgPflow;
+    const IsolationConfiguration isoCfg;
+    const EcalRecHitsConfiguration recHitsCfg;
 
-    // internal structures
+    // additional configuration and helpers
+    ElectronHcalHelper hcalHelper;
+    ElectronHcalHelper hcalHelperPflow;
+    std::unique_ptr<EcalClusterFunctionBaseClass> superClusterErrorFunction;
+    std::unique_ptr<EcalClusterFunctionBaseClass> crackCorrectionFunction;
+    RegressionHelper regHelper;
+  };
 
-    //===================================================================
-    // GsfElectronAlgo::GeneralData
-    //===================================================================
+  //===================================================================
+  // GsfElectronAlgo::EventSetupData
+  //===================================================================
 
-    // general data and helpers
-    struct GeneralData
-     {
-      // configurables
-      const InputTagsConfiguration inputCfg ;
-      const StrategyConfiguration strategyCfg ;
-      const CutsConfiguration cutsCfg ;
-      const CutsConfiguration cutsCfgPflow ;
-      const IsolationConfiguration isoCfg ;
-      const EcalRecHitsConfiguration recHitsCfg ;
+  struct EventSetupData {
+    EventSetupData();
 
-      // additional configuration and helpers
-      ElectronHcalHelper hcalHelper;
-      ElectronHcalHelper hcalHelperPflow ;
-      std::unique_ptr<EcalClusterFunctionBaseClass> superClusterErrorFunction ;
-      std::unique_ptr<EcalClusterFunctionBaseClass> crackCorrectionFunction ;
-      RegressionHelper regHelper;
-     } ;
+    unsigned long long cacheIDGeom;
+    unsigned long long cacheIDTopo;
+    unsigned long long cacheIDTDGeom;
+    unsigned long long cacheIDMagField;
+    unsigned long long cacheSevLevel;
 
-    //===================================================================
-    // GsfElectronAlgo::EventSetupData
-    //===================================================================
+    edm::ESHandle<MagneticField> magField;
+    edm::ESHandle<CaloGeometry> caloGeom;
+    edm::ESHandle<CaloTopology> caloTopo;
+    edm::ESHandle<TrackerGeometry> trackerHandle;
+    edm::ESHandle<EcalSeverityLevelAlgo> sevLevel;
 
-    struct EventSetupData
-     {
-       EventSetupData() ;
+    std::unique_ptr<const MultiTrajectoryStateTransform> mtsTransform;
+    std::unique_ptr<GsfConstraintAtVertex> constraintAtVtx;
+  };
 
-       unsigned long long cacheIDGeom ;
-       unsigned long long cacheIDTopo ;
-       unsigned long long cacheIDTDGeom ;
-       unsigned long long cacheIDMagField ;
-       unsigned long long cacheSevLevel ;
+  //===================================================================
+  // GsfElectronAlgo::EventData
+  //===================================================================
 
-       edm::ESHandle<MagneticField> magField ;
-       edm::ESHandle<CaloGeometry> caloGeom ;
-       edm::ESHandle<CaloTopology> caloTopo ;
-       edm::ESHandle<TrackerGeometry> trackerHandle ;
-       edm::ESHandle<EcalSeverityLevelAlgo> sevLevel;
+  struct EventData {
+    // utilities
+    void retreiveOriginalTrackCollections(const reco::TrackRef&, const reco::GsfTrackRef&);
 
-       std::unique_ptr<const MultiTrajectoryStateTransform> mtsTransform ;
-       std::unique_ptr<GsfConstraintAtVertex> constraintAtVtx ;
-    } ;
+    // general
+    edm::Event const* event;
+    const reco::BeamSpot* beamspot;
 
-    //===================================================================
-    // GsfElectronAlgo::EventData
-    //===================================================================
+    // input collections
+    edm::Handle<reco::GsfElectronCollection> previousElectrons;
+    edm::Handle<reco::GsfElectronCollection> pflowElectrons;
+    edm::Handle<reco::GsfElectronCoreCollection> coreElectrons;
+    edm::Handle<EcalRecHitCollection> barrelRecHits;
+    edm::Handle<EcalRecHitCollection> endcapRecHits;
+    edm::Handle<reco::TrackCollection> currentCtfTracks;
+    edm::Handle<reco::ElectronSeedCollection> seeds;
+    edm::Handle<reco::GsfPFRecTrackCollection> gsfPfRecTracks;
+    edm::Handle<reco::VertexCollection> vertices;
+    edm::Handle<reco::ConversionCollection> conversions;
 
-    struct EventData
-     {
-      // utilities
-      void retreiveOriginalTrackCollections
-       ( const reco::TrackRef &, const reco::GsfTrackRef & ) ;
+    // isolation helpers
+    EgammaTowerIsolation hadDepth1Isolation03, hadDepth1Isolation04;
+    EgammaTowerIsolation hadDepth2Isolation03, hadDepth2Isolation04;
+    EgammaTowerIsolation hadDepth1Isolation03Bc, hadDepth1Isolation04Bc;
+    EgammaTowerIsolation hadDepth2Isolation03Bc, hadDepth2Isolation04Bc;
+    EgammaRecHitIsolation ecalBarrelIsol03, ecalBarrelIsol04;
+    EgammaRecHitIsolation ecalEndcapIsol03, ecalEndcapIsol04;
 
-      // general
-      edm::Event const* event ;
-      const reco::BeamSpot * beamspot ;
+    //Isolation Value Maps for PF and EcalDriven electrons
+    typedef std::vector<edm::Handle<edm::ValueMap<double> > > IsolationValueMaps;
+    IsolationValueMaps pfIsolationValues;
+    IsolationValueMaps edIsolationValues;
 
-      // input collections
-      edm::Handle<reco::GsfElectronCollection> previousElectrons ;
-      edm::Handle<reco::GsfElectronCollection> pflowElectrons ;
-      edm::Handle<reco::GsfElectronCoreCollection> coreElectrons ;
-      edm::Handle<EcalRecHitCollection> barrelRecHits ;
-      edm::Handle<EcalRecHitCollection> endcapRecHits ;
-      edm::Handle<reco::TrackCollection> currentCtfTracks ;
-      edm::Handle<reco::ElectronSeedCollection> seeds ;
-      edm::Handle<reco::GsfPFRecTrackCollection> gsfPfRecTracks ;
-      edm::Handle<reco::VertexCollection> vertices;
-      edm::Handle<reco::ConversionCollection> conversions;
+    edm::Handle<reco::TrackCollection> originalCtfTracks;
+    edm::Handle<reco::GsfTrackCollection> originalGsfTracks;
 
-      // isolation helpers
-      EgammaTowerIsolation hadDepth1Isolation03, hadDepth1Isolation04 ;
-      EgammaTowerIsolation hadDepth2Isolation03, hadDepth2Isolation04 ;
-      EgammaTowerIsolation hadDepth1Isolation03Bc, hadDepth1Isolation04Bc ;
-      EgammaTowerIsolation hadDepth2Isolation03Bc, hadDepth2Isolation04Bc ;
-      EgammaRecHitIsolation ecalBarrelIsol03, ecalBarrelIsol04 ;
-      EgammaRecHitIsolation ecalEndcapIsol03, ecalEndcapIsol04 ;
+    bool originalCtfTrackCollectionRetreived = false;
+    bool originalGsfTrackCollectionRetreived = false;
+  };
 
-      //Isolation Value Maps for PF and EcalDriven electrons
-      typedef std::vector< edm::Handle< edm::ValueMap<double> > > IsolationValueMaps;
-      IsolationValueMaps pfIsolationValues;
-      IsolationValueMaps edIsolationValues;
+  //===================================================================
+  // GsfElectronAlgo::ElectronData
+  //===================================================================
 
-      edm::Handle<reco::TrackCollection> originalCtfTracks ;
-      edm::Handle<reco::GsfTrackCollection> originalGsfTracks ;
+  struct ElectronData {
+    // Refs to subproducts
+    const reco::GsfElectronCoreRef coreRef;
+    const reco::GsfTrackRef gsfTrackRef;
+    const reco::SuperClusterRef superClusterRef;
+    reco::TrackRef ctfTrackRef;
+    float shFracInnerHits;
+    const reco::BeamSpot beamSpot;
 
-      bool originalCtfTrackCollectionRetreived = false ;
-      bool originalGsfTrackCollectionRetreived = false ;
-     } ;
+    // constructors
+    ElectronData(const reco::GsfElectronCoreRef& core, const reco::BeamSpot& bs);
 
-    //===================================================================
-    // GsfElectronAlgo::ElectronData
-    //===================================================================
+    // utilities
+    void computeCharge(int& charge, reco::GsfElectron::ChargeInfo& info);
+    reco::CaloClusterPtr getEleBasicCluster(MultiTrajectoryStateTransform const&);
+    bool calculateTSOS(MultiTrajectoryStateTransform const&, GsfConstraintAtVertex const&);
+    void calculateMode();
+    reco::Candidate::LorentzVector calculateMomentum();
 
-    struct ElectronData
-     {
-      // Refs to subproducts
-      const reco::GsfElectronCoreRef coreRef ;
-      const reco::GsfTrackRef gsfTrackRef ;
-      const reco::SuperClusterRef superClusterRef ;
-      reco::TrackRef ctfTrackRef ;
-      float shFracInnerHits ;
-      const reco::BeamSpot beamSpot ;
+    // TSOS
+    TrajectoryStateOnSurface innTSOS;
+    TrajectoryStateOnSurface outTSOS;
+    TrajectoryStateOnSurface vtxTSOS;
+    TrajectoryStateOnSurface sclTSOS;
+    TrajectoryStateOnSurface seedTSOS;
+    TrajectoryStateOnSurface eleTSOS;
+    TrajectoryStateOnSurface constrainedVtxTSOS;
 
-      // constructors
-      ElectronData
-       ( const reco::GsfElectronCoreRef & core,
-         const reco::BeamSpot & bs ) ;
+    // mode
+    GlobalVector innMom, seedMom, eleMom, sclMom, vtxMom, outMom;
+    GlobalPoint innPos, seedPos, elePos, sclPos, vtxPos, outPos;
+    GlobalVector vtxMomWithConstraint;
+  };
 
-      // utilities
-      void computeCharge( int & charge, reco::GsfElectron::ChargeInfo & info ) ;
-      reco::CaloClusterPtr getEleBasicCluster( MultiTrajectoryStateTransform const& ) ;
-      bool calculateTSOS( MultiTrajectoryStateTransform const&, GsfConstraintAtVertex const& ) ;
-      void calculateMode() ;
-      reco::Candidate::LorentzVector calculateMomentum() ;
+  GeneralData generalData_;
+  EventSetupData eventSetupData_;
 
-      // TSOS
-      TrajectoryStateOnSurface innTSOS ;
-      TrajectoryStateOnSurface outTSOS ;
-      TrajectoryStateOnSurface vtxTSOS ;
-      TrajectoryStateOnSurface sclTSOS ;
-      TrajectoryStateOnSurface seedTSOS ;
-      TrajectoryStateOnSurface eleTSOS ;
-      TrajectoryStateOnSurface constrainedVtxTSOS ;
+  EleTkIsolFromCands tkIsol03Calc_;
+  EleTkIsolFromCands tkIsol04Calc_;
+  EleTkIsolFromCands tkIsolHEEP03Calc_;
+  EleTkIsolFromCands tkIsolHEEP04Calc_;
 
-      // mode
-      GlobalVector innMom, seedMom, eleMom, sclMom, vtxMom, outMom ;
-      GlobalPoint innPos, seedPos, elePos, sclPos, vtxPos, outPos ;
-      GlobalVector vtxMomWithConstraint ;
-     } ;
+  void checkSetup(edm::EventSetup const& eventSetup);
+  EventData beginEvent(edm::Event const& event);
 
-    GeneralData generalData_ ;
-    EventSetupData eventSetupData_ ;
+  void createElectron(reco::GsfElectronCollection& electrons,
+                      ElectronData& electronData,
+                      EventData& eventData,
+                      const gsfAlgoHelpers::HeavyObjectCache*);
 
-    EleTkIsolFromCands tkIsol03Calc_;
-    EleTkIsolFromCands tkIsol04Calc_;
-    EleTkIsolFromCands tkIsolHEEP03Calc_;
-    EleTkIsolFromCands tkIsolHEEP04Calc_;
+  void setMVAepiBasedPreselectionFlag(reco::GsfElectron& ele);
+  void setCutBasedPreselectionFlag(reco::GsfElectron& ele, const reco::BeamSpot&);
 
-    void checkSetup( edm::EventSetup const& eventSetup ) ;
-    EventData beginEvent( edm::Event const& event ) ;
+  template <bool full5x5>
+  void calculateShowerShape(const reco::SuperClusterRef&,
+                            ElectronHcalHelper const& hcalHelper,
+                            reco::GsfElectron::ShowerShape&,
+                            EventData const& eventData);
+  void calculateSaturationInfo(const reco::SuperClusterRef&,
+                               reco::GsfElectron::SaturationInfo&,
+                               EventData const& eventData);
 
-    void createElectron(reco::GsfElectronCollection & electrons, ElectronData & electronData, EventData & eventData, const gsfAlgoHelpers::HeavyObjectCache*) ;
+  // associations
+  const reco::SuperClusterRef getTrSuperCluster(const reco::GsfTrackRef& trackRef);
 
-    void setMVAepiBasedPreselectionFlag(reco::GsfElectron & ele);
-    void setCutBasedPreselectionFlag( reco::GsfElectron & ele, const reco::BeamSpot & ) ;
+  // Pixel match variables
+  void setPixelMatchInfomation(reco::GsfElectron&);
+};
 
-    template<bool full5x5>
-    void calculateShowerShape( const reco::SuperClusterRef &,
-                               ElectronHcalHelper const& hcalHelper,
-                               reco::GsfElectron::ShowerShape &,
-                               EventData const& eventData );
-    void calculateSaturationInfo(const reco::SuperClusterRef&, reco::GsfElectron::SaturationInfo&,
-                                 EventData const& eventData);
-
-    // associations
-    const reco::SuperClusterRef getTrSuperCluster( const reco::GsfTrackRef & trackRef ) ;
-    
-    // Pixel match variables
-    void setPixelMatchInfomation(reco::GsfElectron &) ;
-    
- } ;
-
-#endif // GsfElectronAlgo_H
+#endif  // GsfElectronAlgo_H

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgoHeavyObjectCache.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgoHeavyObjectCache.h
@@ -13,6 +13,6 @@ namespace gsfAlgoHelpers {
     std::unique_ptr<const SoftElectronMVAEstimator> sElectronMVAEstimator;
     std::unique_ptr<const ElectronMVAEstimator> iElectronMVAEstimator;
   };
-}
+}  // namespace gsfAlgoHelpers
 
 #endif

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronTools.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronTools.h
@@ -9,10 +9,9 @@ namespace gsfElectronTools {
 
   // From Puneeth Kalavase : returns the CTF track that has the highest fraction
   // of shared hits in Pixels and the inner strip tracker with the electron Track
-  std::pair<reco::TrackRef,float> getClosestCtfToGsf( reco::GsfTrackRef const&,
-                                                      edm::Handle<reco::TrackCollection> const& ctfTracksH );
+  std::pair<reco::TrackRef, float> getClosestCtfToGsf(reco::GsfTrackRef const&,
+                                                      edm::Handle<reco::TrackCollection> const& ctfTracksH);
 
-}
-
+}  // namespace gsfElectronTools
 
 #endif

--- a/RecoEgamma/EgammaElectronAlgos/interface/PixelHitMatcher.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/PixelHitMatcher.h
@@ -50,188 +50,184 @@ class GeometricSearchTracker;
 class TrackerGeometry;
 class TrackerTopology;
 
-namespace std{
-  template<>
-    struct hash<std::pair<const GeomDet*,GlobalPoint> > {
-      std::size_t operator()(const std::pair<const GeomDet*,GlobalPoint>& g) const {
-	auto h1 = std::hash<unsigned long long>()((unsigned long long)g.first);
-        unsigned long long k; memcpy(&k, &g.second,sizeof(k));
-        auto h2 = std::hash<unsigned long long>()(k);
-        return h1 ^ (h2 << 1);
-      }
-    };
-}
+namespace std {
+  template <>
+  struct hash<std::pair<const GeomDet*, GlobalPoint> > {
+    std::size_t operator()(const std::pair<const GeomDet*, GlobalPoint>& g) const {
+      auto h1 = std::hash<unsigned long long>()((unsigned long long)g.first);
+      unsigned long long k;
+      memcpy(&k, &g.second, sizeof(k));
+      auto h2 = std::hash<unsigned long long>()(k);
+      return h1 ^ (h2 << 1);
+    }
+  };
+}  // namespace std
 
-class RecHitWithDist
- {
-  public :
+class RecHitWithDist {
+public:
+  typedef TransientTrackingRecHit::ConstRecHitPointer ConstRecHitPointer;
+  typedef TransientTrackingRecHit::RecHitPointer RecHitPointer;
+  typedef TransientTrackingRecHit::RecHitContainer RecHitContainer;
 
-    typedef TransientTrackingRecHit::ConstRecHitPointer   ConstRecHitPointer;
-    typedef TransientTrackingRecHit::RecHitPointer        RecHitPointer;
-    typedef TransientTrackingRecHit::RecHitContainer      RecHitContainer;
-    
+  RecHitWithDist(ConstRecHitPointer rh, float& dphi) : rh_(rh), dphi_(dphi) {}
 
-    RecHitWithDist( ConstRecHitPointer rh, float & dphi )
-     : rh_(rh), dphi_(dphi)
-     {}
+  ConstRecHitPointer recHit() const { return rh_; }
+  float dPhi() const { return dphi_; }
 
-    ConstRecHitPointer recHit() const { return rh_ ; }
-    float dPhi() const { return dphi_ ; }
+  void invert() { dphi_ *= -1.; }
 
-    void invert() { dphi_*=-1. ; }
+private:
+  ConstRecHitPointer rh_;
+  float dphi_;
+};
 
-  private :
+class RecHitWithInfo {
+public:
+  typedef TransientTrackingRecHit::ConstRecHitPointer ConstRecHitPointer;
+  typedef TransientTrackingRecHit::RecHitPointer RecHitPointer;
+  typedef TransientTrackingRecHit::RecHitContainer RecHitContainer;
 
-    ConstRecHitPointer rh_ ;
-    float dphi_ ;
+  RecHitWithInfo(ConstRecHitPointer rh,
+                 int subDet = 0,
+                 float dRz = std::numeric_limits<float>::infinity(),
+                 float dPhi = std::numeric_limits<float>::infinity())
+      : rh_(rh), subDet_(subDet), dRz_(dRz), dPhi_(dPhi) {}
 
- } ;
+  ConstRecHitPointer recHit() const { return rh_; }
+  int subDet() const { return subDet_; }
+  float dRz() const { return dRz_; }
+  float dPhi() const { return dPhi_; }
 
+  void invert() { dPhi_ *= -1.; }
 
-class RecHitWithInfo
- {
-  public :
+private:
+  ConstRecHitPointer rh_;
+  int subDet_;
+  float dRz_;
+  float dPhi_;
+};
 
-    typedef TransientTrackingRecHit::ConstRecHitPointer   ConstRecHitPointer ;
-    typedef TransientTrackingRecHit::RecHitPointer        RecHitPointer ;
-    typedef TransientTrackingRecHit::RecHitContainer      RecHitContainer ;
+class SeedWithInfo {
+public:
+  SeedWithInfo(TrajectorySeed seed,
+               unsigned char hitsMask,
+               int subDet2,
+               float dRz2,
+               float dPhi2,
+               int subDet1,
+               float dRz1,
+               float dPhi1)
+      : seed_(seed),
+        hitsMask_(hitsMask),
+        subDet2_(subDet2),
+        dRz2_(dRz2),
+        dPhi2_(dPhi2),
+        subDet1_(subDet1),
+        dRz1_(dRz1),
+        dPhi1_(dPhi1) {}
 
-    RecHitWithInfo( ConstRecHitPointer rh, int subDet =0,
-       float dRz = std::numeric_limits<float>::infinity(),
-       float dPhi = std::numeric_limits<float>::infinity() )
-     : rh_(rh), subDet_(subDet), dRz_(dRz), dPhi_(dPhi)
-     {}
+  const TrajectorySeed& seed() const { return seed_; }
+  unsigned char hitsMask() const { return hitsMask_; }
 
-    ConstRecHitPointer recHit() const { return rh_; }
-    int subDet() const { return subDet_ ; }
-    float dRz() const { return dRz_ ; }
-    float dPhi() const { return dPhi_ ; }
+  int subDet2() const { return subDet2_; }
+  float dRz2() const { return dRz2_; }
+  float dPhi2() const { return dPhi2_; }
 
-    void invert() { dPhi_*=-1. ; }
+  int subDet1() const { return subDet1_; }
+  float dRz1() const { return dRz1_; }
+  float dPhi1() const { return dPhi1_; }
 
-  private:
+private:
+  TrajectorySeed seed_;
+  unsigned char hitsMask_;
+  int subDet2_;
+  float dRz2_;
+  float dPhi2_;
+  int subDet1_;
+  float dRz1_;
+  float dPhi1_;
+};
 
-    ConstRecHitPointer rh_;
-    int subDet_ ;
-    float dRz_ ;
-    float dPhi_ ;
+class PixelHitMatcher {
+public:
+  typedef TransientTrackingRecHit::ConstRecHitPointer ConstRecHitPointer;
+  typedef TransientTrackingRecHit::RecHitPointer RecHitPointer;
+  typedef TransientTrackingRecHit::RecHitContainer RecHitContainer;
+  // Next typedef uses double in ROOT 6 rather than Double32_t due to a bug in ROOT 5,
+  // which otherwise would make ROOT5 files unreadable in ROOT6.  This does not increase
+  // the size on disk, because due to the bug, double was actually stored on disk in ROOT 5.
+  typedef ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double> > REPPoint;
 
- } ;
+  PixelHitMatcher(float phi1min,
+                  float phi1max,
+                  //float phi2min, float phi2max,
+                  float phi2minB,
+                  float phi2maxB,
+                  float phi2minF,
+                  float phi2maxF,
+                  float z2minB,
+                  float z2maxB,
+                  float r2minF,
+                  float r2maxF,
+                  float rMinI,
+                  float rMaxI,
+                  bool searchInTIDTEC);
 
-class SeedWithInfo
- {
-  public :
+  virtual ~PixelHitMatcher();
+  void setES(const MagneticField*,
+             const MeasurementTracker* theMeasurementTracker,
+             const TrackerGeometry* trackerGeometry);
 
-    SeedWithInfo( TrajectorySeed seed, unsigned char hitsMask, int subDet2, float dRz2, float dPhi2 , int subDet1, float dRz1, float dPhi1)
-     : seed_(seed), hitsMask_(hitsMask),
-       subDet2_(subDet2), dRz2_(dRz2), dPhi2_(dPhi2),
-       subDet1_(subDet1), dRz1_(dRz1), dPhi1_(dPhi1)
-     {}
+  void setEvent(const MeasurementTrackerEvent& event);
 
-    const TrajectorySeed & seed() const { return seed_ ; }
-    unsigned char hitsMask() const { return hitsMask_ ; }
+  std::vector<SeedWithInfo> compatibleSeeds(const std::vector<const TrajectorySeedCollection*>& seedsV,
+                                            const GlobalPoint& xmeas,
+                                            const GlobalPoint& vprim,
+                                            float energy,
+                                            float charge);
 
-    int subDet2() const { return subDet2_ ; }
-    float dRz2() const { return dRz2_ ; }
-    float dPhi2() const { return dPhi2_ ; }
+  std::vector<std::pair<RecHitWithDist, ConstRecHitPointer> > compatibleHits(const GlobalPoint& xmeas,
+                                                                             const GlobalPoint& vprim,
+                                                                             float energy,
+                                                                             float charge,
+                                                                             const TrackerTopology* tTopo,
+                                                                             const NavigationSchool& navigationSchool);
 
-    int subDet1() const { return subDet1_ ; }
-    float dRz1() const { return dRz1_ ; }
-    float dPhi1() const { return dPhi1_ ; }
+  std::vector<CLHEP::Hep3Vector> predicted1Hits();
+  std::vector<CLHEP::Hep3Vector> predicted2Hits();
 
-  private :
+  void set1stLayer(float dummyphi1min, float dummyphi1max);
+  void set1stLayerZRange(float zmin1, float zmax1);
+  //void set2ndLayer( float dummyphi2min, float dummyphi2max ) ;
+  void set2ndLayer(float dummyphi2minB, float dummyphi2maxB, float dummyphi2minF, float dummyphi2maxF);
 
-    TrajectorySeed seed_ ;
-    unsigned char hitsMask_ ;
-    int subDet2_ ;
-    float dRz2_ ;
-    float dPhi2_ ;
-    int subDet1_ ;
-    float dRz1_ ;
-    float dPhi1_ ;
- } ;
+  float getVertex();
+  void setUseRecoVertex(bool val);
 
-class PixelHitMatcher
- {
-  public :
+private:
+  RecHitContainer hitsInTrack;
 
-    typedef TransientTrackingRecHit::ConstRecHitPointer   ConstRecHitPointer;
-    typedef TransientTrackingRecHit::RecHitPointer        RecHitPointer;
-    typedef TransientTrackingRecHit::RecHitContainer      RecHitContainer;
-    // Next typedef uses double in ROOT 6 rather than Double32_t due to a bug in ROOT 5,
-    // which otherwise would make ROOT5 files unreadable in ROOT6.  This does not increase
-    // the size on disk, because due to the bug, double was actually stored on disk in ROOT 5.
-    typedef ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double> > REPPoint;
+  std::vector<CLHEP::Hep3Vector> pred1Meas;
+  std::vector<CLHEP::Hep3Vector> pred2Meas;
+  BarrelMeasurementEstimator meas1stBLayer;
+  BarrelMeasurementEstimator meas2ndBLayer;
+  ForwardMeasurementEstimator meas1stFLayer;
+  ForwardMeasurementEstimator meas2ndFLayer;
+  PropagatorWithMaterial* prop1stLayer;
+  PropagatorWithMaterial* prop2ndLayer;
+  const GeometricSearchTracker* theGeometricSearchTracker;
+  const MeasurementTrackerEvent* theTrackerEvent;
+  const MeasurementTracker* theTracker;
+  LayerMeasurements theLayerMeasurements;
+  const MagneticField* theMagField;
+  const TrackerGeometry* theTrackerGeometry;
 
-    PixelHitMatcher
-     ( float phi1min, float phi1max,
-       //float phi2min, float phi2max,
-       float phi2minB, float phi2maxB, float phi2minF, float phi2maxF,
-		   float z2minB, float z2maxB, float r2minF, float r2maxF,
-		   float rMinI, float rMaxI, bool searchInTIDTEC ) ;
+  float vertex_;
 
-    virtual ~PixelHitMatcher() ;
-    void setES( const MagneticField *, const MeasurementTracker * theMeasurementTracker, const TrackerGeometry * trackerGeometry ) ;
-
-    void setEvent( const MeasurementTrackerEvent & event ) ;
-
-    std::vector<SeedWithInfo>
-    compatibleSeeds
-      ( const std::vector<const TrajectorySeedCollection *>& seedsV, const GlobalPoint & xmeas,
-        const GlobalPoint & vprim, float energy, float charge ) ;
-
-
-    std::vector<std::pair<RecHitWithDist,ConstRecHitPointer> >
-    compatibleHits(const GlobalPoint& xmeas, const GlobalPoint& vprim, 
-		   float energy, float charge,
-		   const TrackerTopology *tTopo,
-                   const NavigationSchool& navigationSchool) ;
-
-
-    std::vector<CLHEP::Hep3Vector> predicted1Hits() ;
-    std::vector<CLHEP::Hep3Vector> predicted2Hits();
-
-    void set1stLayer( float dummyphi1min, float dummyphi1max ) ;
-    void set1stLayerZRange( float zmin1, float zmax1 ) ;
-    //void set2ndLayer( float dummyphi2min, float dummyphi2max ) ;
-    void set2ndLayer( float dummyphi2minB, float dummyphi2maxB, float dummyphi2minF, float dummyphi2maxF ) ;
-
-    float getVertex() ;
-    void setUseRecoVertex( bool val ) ;
-
-  private :
-
-    RecHitContainer hitsInTrack ;
-
-    std::vector<CLHEP::Hep3Vector> pred1Meas ;
-    std::vector<CLHEP::Hep3Vector> pred2Meas ;
-    BarrelMeasurementEstimator meas1stBLayer ;
-    BarrelMeasurementEstimator meas2ndBLayer ;
-    ForwardMeasurementEstimator meas1stFLayer ;
-    ForwardMeasurementEstimator meas2ndFLayer ;
-    PropagatorWithMaterial * prop1stLayer ;
-    PropagatorWithMaterial * prop2ndLayer ;
-    const GeometricSearchTracker * theGeometricSearchTracker ;
-    const MeasurementTrackerEvent *theTrackerEvent;
-    const MeasurementTracker      *theTracker;
-    LayerMeasurements theLayerMeasurements ;
-    const MagneticField* theMagField ;
-    const TrackerGeometry * theTrackerGeometry ;
-
-    float vertex_;
-
-    bool searchInTIDTEC_ ;
-    bool useRecoVertex_ ;
-    std::unordered_map<std::pair<const GeomDet*,GlobalPoint>, TrajectoryStateOnSurface> mapTsos2_fast_;    
-    std::vector<GlobalPoint> hit_gp_map_;    
-} ;
+  bool searchInTIDTEC_;
+  bool useRecoVertex_;
+  std::unordered_map<std::pair<const GeomDet*, GlobalPoint>, TrajectoryStateOnSurface> mapTsos2_fast_;
+  std::vector<GlobalPoint> hit_gp_map_;
+};
 
 #endif
-
-
-
-
-
-
-
-

--- a/RecoEgamma/EgammaElectronAlgos/interface/PixelMatchNextLayers.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/PixelMatchNextLayers.h
@@ -4,7 +4,7 @@
 //
 // Package:    EgammaElectronAlgos
 // Class:      PixelMatchNextLayers
-// 
+//
 /**\class PixelMatchNextLayers EgammaElectronAlgos/PixelMatchNextLayers
 
  Description: class to find the compatible hits in the next layer
@@ -17,7 +17,7 @@
 //         Created:  Mon Mar 27 13:22:06 CEST 2006
 //
 //
-#include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h" 
+#include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 #include "CLHEP/Vector/ThreeVector.h"
 #include "RecoEgamma/EgammaElectronAlgos/interface/BarrelMeasurementEstimator.h"
@@ -32,33 +32,28 @@ class TrackerTopology;
 class NavigationSchool;
 
 class PixelMatchNextLayers {
-
 public:
-  PixelMatchNextLayers(const LayerMeasurements * theLayerMeasurements, const DetLayer* ilayer, FreeTrajectoryState & aFTS,
-	                        const PropagatorWithMaterial *aProp, 
-		       const BarrelMeasurementEstimator *aBarrelMeas,
-		       const ForwardMeasurementEstimator *aForwardMeas,
-		       const TrackerTopology *tTopo,
-                       const NavigationSchool& navigationSchool,
-		       bool searchInTIDTEC);
+  PixelMatchNextLayers(const LayerMeasurements *theLayerMeasurements,
+                       const DetLayer *ilayer,
+                       FreeTrajectoryState &aFTS,
+                       const PropagatorWithMaterial *aProp,
+                       const BarrelMeasurementEstimator *aBarrelMeas,
+                       const ForwardMeasurementEstimator *aForwardMeas,
+                       const TrackerTopology *tTopo,
+                       const NavigationSchool &navigationSchool,
+                       bool searchInTIDTEC);
   std::vector<TrajectoryMeasurement> measurementsInNextLayers() const;
   std::vector<TrajectoryMeasurement> badMeasurementsInNextLayers() const;
-  //RC vector<TSiPixelRecHit> hitsInNextLayers() const;  
-  //In this way we are losing the information about the kind of the ReferenceCounted TTRH? 
-  TransientTrackingRecHit::RecHitContainer hitsInNextLayers() const;  
+  //RC vector<TSiPixelRecHit> hitsInNextLayers() const;
+  //In this way we are losing the information about the kind of the ReferenceCounted TTRH?
+  TransientTrackingRecHit::RecHitContainer hitsInNextLayers() const;
   std::vector<CLHEP::Hep3Vector> predictionInNextLayers() const;
 
-  
 private:
-                                                        
   std::vector<TrajectoryMeasurement> measurementsHere;
-  std::vector<TrajectoryMeasurement> badMeasurementsHere;  
+  std::vector<TrajectoryMeasurement> badMeasurementsHere;
   TransientTrackingRecHit::RecHitContainer hitsHere;
-  std::vector<CLHEP::Hep3Vector> predictionHere; 
+  std::vector<CLHEP::Hep3Vector> predictionHere;
 };
 
 #endif
-
-
-
-

--- a/RecoEgamma/EgammaElectronAlgos/interface/RegressionHelper.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/RegressionHelper.h
@@ -20,44 +20,41 @@
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 
-
 class RegressionHelper {
-  public:
-  struct Configuration
-  {
-      // weight files for the regression
+public:
+  struct Configuration {
+    // weight files for the regression
     std::vector<std::string> ecalRegressionWeightLabels;
-    bool ecalWeightsFromDB ;
+    bool ecalWeightsFromDB;
     std::vector<std::string> ecalRegressionWeightFiles;
     std::vector<std::string> combinationRegressionWeightLabels;
     bool combinationWeightsFromDB;
     std::vector<std::string> combinationRegressionWeightFiles;
   };
-  
-  RegressionHelper( const Configuration & ) ;
-  void checkSetup( const edm::EventSetup & ) ;
-  void readEvent( const edm::Event & ) ;
-  void applyEcalRegression(reco::GsfElectron & electron,
-			   const edm::Handle<reco::VertexCollection>& vertices,
-			   const edm::Handle<EcalRecHitCollection>& rechitsEB,
-			   const edm::Handle<EcalRecHitCollection>& rechitsEE) const;
 
-  void applyCombinationRegression(reco::GsfElectron & ele) const;
-  ~RegressionHelper() ;
+  RegressionHelper(const Configuration&);
+  void checkSetup(const edm::EventSetup&);
+  void readEvent(const edm::Event&);
+  void applyEcalRegression(reco::GsfElectron& electron,
+                           const edm::Handle<reco::VertexCollection>& vertices,
+                           const edm::Handle<EcalRecHitCollection>& rechitsEB,
+                           const edm::Handle<EcalRecHitCollection>& rechitsEE) const;
 
- private:
-  void getEcalRegression(const reco::SuperCluster & sc,
-			 const edm::Handle<reco::VertexCollection>& vertices,
-			 const edm::Handle<EcalRecHitCollection>& rechitsEB,
-			 const edm::Handle<EcalRecHitCollection>& rechitsEE,
-			 double & energyFactor,
-			 double & errorFactor) const ;
-  
- private:
-  
-  const Configuration cfg_ ;
-  const CaloTopology * caloTopology_;
-  const CaloGeometry * caloGeometry_;
+  void applyCombinationRegression(reco::GsfElectron& ele) const;
+  ~RegressionHelper();
+
+private:
+  void getEcalRegression(const reco::SuperCluster& sc,
+                         const edm::Handle<reco::VertexCollection>& vertices,
+                         const edm::Handle<EcalRecHitCollection>& rechitsEB,
+                         const edm::Handle<EcalRecHitCollection>& rechitsEE,
+                         double& energyFactor,
+                         double& errorFactor) const;
+
+private:
+  const Configuration cfg_;
+  const CaloTopology* caloTopology_;
+  const CaloGeometry* caloGeometry_;
   bool ecalRegressionInitialized_;
   bool combinationRegressionInitialized_;
 
@@ -66,15 +63,11 @@ class RegressionHelper {
   unsigned long long regressionCacheId_;
 
   //  edm::ESHandle<GBRForest> ecalRegBarrel_ ;
-  const GBRForest * ecalRegBarrel_ ;
-  const GBRForest * ecalRegEndcap_ ;
-  const GBRForest * ecalRegErrorBarrel_ ;  
-  const GBRForest * ecalRegErrorEndcap_ ;  
-  const GBRForest * combinationReg_ ;
-   
+  const GBRForest* ecalRegBarrel_;
+  const GBRForest* ecalRegEndcap_;
+  const GBRForest* ecalRegErrorBarrel_;
+  const GBRForest* ecalRegErrorEndcap_;
+  const GBRForest* combinationReg_;
 };
 
 #endif
-
-
-

--- a/RecoEgamma/EgammaElectronAlgos/interface/SeedFilter.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/SeedFilter.h
@@ -27,30 +27,29 @@
 class SeedGeneratorFromRegionHits;
 class MagneticField;
 class MeasurementTrackerEvent;
-namespace edm { class ConsumesCollector; }
+namespace edm {
+  class ConsumesCollector;
+}
 
 class SeedFilter {
- public:
-
+public:
   struct Tokens {
     edm::EDGetTokenT<std::vector<reco::Vertex> > token_vtx;
     edm::EDGetTokenT<reco::BeamSpot> token_bs;
   };
 
-  SeedFilter(const edm::ParameterSet& conf,
-	     const Tokens& tokens,
-	     edm::ConsumesCollector& iC);
+  SeedFilter(const edm::ParameterSet& conf, const Tokens& tokens, edm::ConsumesCollector& iC);
   ~SeedFilter();
 
-  void seeds(edm::Event&, const edm::EventSetup&, const reco::SuperClusterRef &, TrajectorySeedCollection *);
+  void seeds(edm::Event&, const edm::EventSetup&, const reco::SuperClusterRef&, TrajectorySeedCollection*);
 
- private:
+private:
   std::unique_ptr<SeedGeneratorFromRegionHits> combinatorialSeedGenerator;
 
   // remove them FIXME
   double dr_, deta_, dphi_, pt_;
 
-  double ptmin_, vertexz_, originradius_,  halflength_, deltaEta_, deltaPhi_;
+  double ptmin_, vertexz_, originradius_, halflength_, deltaEta_, deltaPhi_;
   bool useZvertex_;
   //  edm::InputTag BSProducer_;  //FIXME?
   edm::EDGetTokenT<std::vector<reco::Vertex> > vertexSrc_;
@@ -64,6 +63,4 @@ class SeedFilter {
   edm::EDGetTokenT<MeasurementTrackerEvent> measurementTrackerToken_;
 };
 
-#endif // SeedFilter_H
-
-
+#endif  // SeedFilter_H

--- a/RecoEgamma/EgammaElectronAlgos/interface/SiStripElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/SiStripElectronAlgo.h
@@ -4,7 +4,7 @@
 //
 // Package:     EgammaElectronAlgos
 // Class  :     SiStripElectronAlgo
-// 
+//
 /**\class SiStripElectronAlgo SiStripElectronAlgo.h RecoEgamma/EgammaElectronAlgos/interface/SiStripElectronAlgo.h
 
  Description: <one line class summary>
@@ -31,7 +31,7 @@
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h" 
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
@@ -55,139 +55,138 @@
 
 class TrackerTopology;
 
-class SiStripElectronAlgo
-{
+class SiStripElectronAlgo {
+public:
+  SiStripElectronAlgo(unsigned int maxHitsOnDetId,
+                      double originUncertainty,
+                      double phiBandWidth,
+                      double maxNormResid,
+                      unsigned int minHits,
+                      double maxReducedChi2);
 
-   public:
-      SiStripElectronAlgo(unsigned int maxHitsOnDetId,
-			  double originUncertainty,
-			  double phiBandWidth,
-			  double maxNormResid,
-			  unsigned int minHits,
-			  double maxReducedChi2);
+  virtual ~SiStripElectronAlgo();
 
-      virtual ~SiStripElectronAlgo();
+  // ---------- const member functions ---------------------
 
-      // ---------- const member functions ---------------------
+  // ---------- static member functions --------------------
 
-      // ---------- static member functions --------------------
+  // ---------- member functions ---------------------------
 
-      // ---------- member functions ---------------------------
+  void prepareEvent(const edm::ESHandle<TrackerGeometry>& tracker,
+                    const edm::Handle<SiStripRecHit2DCollection>& rphiHits,
+                    const edm::Handle<SiStripRecHit2DCollection>& stereoHits,
+                    const edm::Handle<SiStripMatchedRecHit2DCollection>& matchedHits,
+                    const edm::ESHandle<MagneticField>& magneticField);
 
-      void prepareEvent(const edm::ESHandle<TrackerGeometry>& tracker,
-			const edm::Handle<SiStripRecHit2DCollection>& rphiHits,
-			const edm::Handle<SiStripRecHit2DCollection>& stereoHits,
-			const edm::Handle<SiStripMatchedRecHit2DCollection>& matchedHits,
-			const edm::ESHandle<MagneticField>& magneticField);
+  // returns true iff an electron/positron was found
+  // and inserts SiStripElectron and trackCandidate into electronOut and trackCandidateOut
+  bool findElectron(reco::SiStripElectronCollection& electronOut,
+                    TrackCandidateCollection& trackCandidateOut,
+                    const reco::SuperClusterRef& superclusterIn,
+                    const TrackerTopology* tTopo);
 
-      // returns true iff an electron/positron was found
-      // and inserts SiStripElectron and trackCandidate into electronOut and trackCandidateOut
-      bool findElectron(reco::SiStripElectronCollection& electronOut,
-			TrackCandidateCollection& trackCandidateOut,
-			const reco::SuperClusterRef& superclusterIn,
-			const TrackerTopology *tTopo);
+private:
+  SiStripElectronAlgo(const SiStripElectronAlgo&);  // stop default
 
-   private:
-      SiStripElectronAlgo(const SiStripElectronAlgo&); // stop default
+  const SiStripElectronAlgo& operator=(const SiStripElectronAlgo&);  // stop default
 
-      const SiStripElectronAlgo& operator=(const SiStripElectronAlgo&); // stop default
+  // inserts pointers to good hits into hitPointersOut
+  // selects hits on DetIds that have no more than maxHitsOnDetId_
+  // selects from stereo if stereo == true, rphi otherwise
+  // selects from TID or TEC if endcap == true, TIB or TOB otherwise
+  void coarseHitSelection(std::vector<const SiStripRecHit2D*>& hitPointersOut,
+                          const TrackerTopology* tTopo,
+                          bool stereo,
+                          bool endcap);
+  void coarseBarrelMonoHitSelection(std::vector<const SiStripRecHit2D*>& monoHitPointersOut);
+  void coarseEndcapMonoHitSelection(std::vector<const SiStripRecHit2D*>& monoHitPointersOut);
+  void coarseMatchedHitSelection(std::vector<const SiStripMatchedRecHit2D*>& coarseMatchedHitPointersOut);
 
-      // inserts pointers to good hits into hitPointersOut
-      // selects hits on DetIds that have no more than maxHitsOnDetId_
-      // selects from stereo if stereo == true, rphi otherwise
-      // selects from TID or TEC if endcap == true, TIB or TOB otherwise
-      void coarseHitSelection(std::vector<const SiStripRecHit2D*>& hitPointersOut,
-			      const TrackerTopology *tTopo,
-			      bool stereo, bool endcap);
-      void coarseBarrelMonoHitSelection(std::vector<const SiStripRecHit2D*>& monoHitPointersOut );
-      void coarseEndcapMonoHitSelection(std::vector<const SiStripRecHit2D*>& monoHitPointersOut );
-      void coarseMatchedHitSelection(std::vector<const SiStripMatchedRecHit2D*>& coarseMatchedHitPointersOut);
+  // projects a phi band of width phiBandWidth_ from supercluster into tracker (given a chargeHypothesis)
+  // fills *_pos_ or *_neg_ member data with the results
+  // returns true iff the electron/positron passes cuts
+  bool projectPhiBand(float chargeHypothesis,
+                      const reco::SuperClusterRef& superclusterIn,
+                      const TrackerTopology* tTopo);
 
+  double unwrapPhi(double phi) const {
+    while (phi > M_PI) {
+      phi -= 2. * M_PI;
+    }
+    while (phi < -M_PI) {
+      phi += 2. * M_PI;
+    }
+    return phi;
+  }
 
-      // projects a phi band of width phiBandWidth_ from supercluster into tracker (given a chargeHypothesis)
-      // fills *_pos_ or *_neg_ member data with the results
-      // returns true iff the electron/positron passes cuts
-      bool projectPhiBand(float chargeHypothesis, 
-			  const reco::SuperClusterRef& superclusterIn,
-			  const TrackerTopology *tTopo);
+  // ---------- member data --------------------------------
 
-      double unwrapPhi(double phi) const {
-	 while (phi > M_PI) { phi -= 2.*M_PI; }
-	 while (phi < -M_PI) { phi += 2.*M_PI; }
-	 return phi;
-      }
+  // parameters
+  unsigned int maxHitsOnDetId_;
+  double originUncertainty_;
+  double phiBandWidth_;
+  double maxNormResid_;
+  unsigned int minHits_;
+  double maxReducedChi2_;
 
-      // ---------- member data --------------------------------
+  // changes with each event
+  const TrackerGeometry* tracker_p_;
+  const SiStripRecHit2DCollection* rphiHits_p_;
+  const SiStripRecHit2DCollection* stereoHits_p_;
+  const SiStripMatchedRecHit2DCollection* matchedHits_p_;
+  const MagneticField* magneticField_p_;
 
-      // parameters
-      unsigned int maxHitsOnDetId_;
-      double originUncertainty_;
-      double phiBandWidth_;
-      double maxNormResid_;
-      unsigned int minHits_;
-      double maxReducedChi2_;
+  const edm::Handle<SiStripRecHit2DCollection>* rphiHits_hp_;
+  const edm::Handle<SiStripRecHit2DCollection>* stereoHits_hp_;
+  const edm::Handle<SiStripMatchedRecHit2DCollection>* matchedHits_hp_;
 
-      // changes with each event
-      const TrackerGeometry* tracker_p_;
-      const SiStripRecHit2DCollection* rphiHits_p_;
-      const SiStripRecHit2DCollection* stereoHits_p_;
-      const SiStripMatchedRecHit2DCollection* matchedHits_p_;
-      const MagneticField* magneticField_p_;
+  std::map<const SiStripRecHit2D*, unsigned int> rphiKey_;
+  std::map<const SiStripRecHit2D*, unsigned int> stereoKey_;
+  std::map<const SiStripMatchedRecHit2D*, unsigned int> matchedKey_;
 
-      const edm::Handle<SiStripRecHit2DCollection>* rphiHits_hp_;
-      const edm::Handle<SiStripRecHit2DCollection>* stereoHits_hp_;
-      const edm::Handle<SiStripMatchedRecHit2DCollection>* matchedHits_hp_;
+  std::map<const TrackingRecHit*, bool> hitUsed_;
+  std::map<const TrackingRecHit*, bool> matchedHitUsed_;
 
+  double redchi2_pos_;
+  GlobalPoint position_pos_;
+  GlobalVector momentum_pos_;
+  const SiStripRecHit2D* innerhit_pos_;
+  std::vector<const TrackingRecHit*> outputHits_pos_;
+  std::vector<SiStripRecHit2D> outputRphiHits_pos_;
+  std::vector<SiStripRecHit2D> outputStereoHits_pos_;
+  std::vector<SiStripRecHit2D> outputMatchedHits_neg_;
 
-      std::map<const SiStripRecHit2D*, unsigned int> rphiKey_;
-      std::map<const SiStripRecHit2D*, unsigned int> stereoKey_;
-      std::map<const SiStripMatchedRecHit2D*, unsigned int> matchedKey_;
+  double phiVsRSlope_pos_;
+  double slope_pos_;
+  double intercept_pos_;
+  double chi2_pos_;
+  int ndof_pos_;
+  double correct_pT_pos_;
+  double pZ_pos_;
+  double zVsRSlope_pos_;
+  unsigned int numberOfMatchedHits_pos_;
+  unsigned int numberOfStereoHits_pos_;
+  unsigned int numberOfBarrelRphiHits_pos_;
+  unsigned int numberOfEndcapZphiHits_pos_;
 
-      std::map<const TrackingRecHit*, bool> hitUsed_;
-      std::map<const TrackingRecHit*, bool> matchedHitUsed_;
-
-
-      double redchi2_pos_;
-      GlobalPoint position_pos_;
-      GlobalVector momentum_pos_;
-      const SiStripRecHit2D* innerhit_pos_;
-      std::vector<const TrackingRecHit*> outputHits_pos_;
-      std::vector<SiStripRecHit2D> outputRphiHits_pos_;
-      std::vector<SiStripRecHit2D> outputStereoHits_pos_;
-      std::vector<SiStripRecHit2D> outputMatchedHits_neg_;
-
-      double phiVsRSlope_pos_;
-      double slope_pos_;
-      double intercept_pos_;
-      double chi2_pos_;
-      int ndof_pos_;
-      double correct_pT_pos_;
-      double pZ_pos_;
-      double zVsRSlope_pos_;
-      unsigned int numberOfMatchedHits_pos_;
-      unsigned int numberOfStereoHits_pos_;
-      unsigned int numberOfBarrelRphiHits_pos_;
-      unsigned int numberOfEndcapZphiHits_pos_;
-      
-      double redchi2_neg_;
-      GlobalPoint position_neg_;
-      GlobalVector momentum_neg_;
-      const SiStripRecHit2D* innerhit_neg_;
-      std::vector<const TrackingRecHit*> outputHits_neg_;
-      std::vector<SiStripRecHit2D> outputRphiHits_neg_;
-      std::vector<SiStripRecHit2D> outputStereoHits_neg_;
-      double phiVsRSlope_neg_;
-      double slope_neg_;
-      double intercept_neg_;
-      double chi2_neg_;
-      int ndof_neg_;
-      double correct_pT_neg_;
-      double pZ_neg_;
-      double zVsRSlope_neg_;
-      unsigned numberOfStereoHits_neg_;
-      unsigned numberOfBarrelRphiHits_neg_;
-      unsigned numberOfEndcapZphiHits_neg_;
+  double redchi2_neg_;
+  GlobalPoint position_neg_;
+  GlobalVector momentum_neg_;
+  const SiStripRecHit2D* innerhit_neg_;
+  std::vector<const TrackingRecHit*> outputHits_neg_;
+  std::vector<SiStripRecHit2D> outputRphiHits_neg_;
+  std::vector<SiStripRecHit2D> outputStereoHits_neg_;
+  double phiVsRSlope_neg_;
+  double slope_neg_;
+  double intercept_neg_;
+  double chi2_neg_;
+  int ndof_neg_;
+  double correct_pT_neg_;
+  double pZ_neg_;
+  double zVsRSlope_neg_;
+  unsigned numberOfStereoHits_neg_;
+  unsigned numberOfBarrelRphiHits_neg_;
+  unsigned numberOfEndcapZphiHits_neg_;
 };
-
 
 #endif

--- a/RecoEgamma/EgammaElectronAlgos/interface/SiStripElectronSeedGenerator.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/SiStripElectronSeedGenerator.h
@@ -43,7 +43,7 @@
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
-#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h" 
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 
 #include "RecoTracker/MeasurementDet/interface/MeasurementTracker.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
@@ -60,66 +60,81 @@ class MeasurementTrackerEvent;
 class NavigationSchool;
 class SiStripRecHitMatcher;
 
-class SiStripElectronSeedGenerator
-{
+class SiStripElectronSeedGenerator {
 public:
-  
   struct Tokens {
     edm::EDGetTokenT<reco::BeamSpot> token_bs;
     edm::EDGetTokenT<MeasurementTrackerEvent> token_mte;
   };
 
   typedef edm::OwnVector<TrackingRecHit> PRecHitContainer;
-  typedef TransientTrackingRecHit::ConstRecHitPointer  ConstRecHitPointer;
-  typedef TransientTrackingRecHit::RecHitPointer       RecHitPointer;
-  typedef TransientTrackingRecHit::RecHitContainer     RecHitContainer;
+  typedef TransientTrackingRecHit::ConstRecHitPointer ConstRecHitPointer;
+  typedef TransientTrackingRecHit::RecHitPointer RecHitPointer;
+  typedef TransientTrackingRecHit::RecHitContainer RecHitContainer;
 
-  SiStripElectronSeedGenerator(const edm::ParameterSet&,
-			       const Tokens&);
+  SiStripElectronSeedGenerator(const edm::ParameterSet&, const Tokens&);
 
   ~SiStripElectronSeedGenerator();
 
   void setupES(const edm::EventSetup& setup);
-  void run(edm::Event&, const edm::EventSetup& setup,
-	   const edm::Handle<reco::SuperClusterCollection>&,
-	   reco::ElectronSeedCollection&);
+  void run(edm::Event&,
+           const edm::EventSetup& setup,
+           const edm::Handle<reco::SuperClusterCollection>&,
+           reco::ElectronSeedCollection&);
 
 private:
   double normalPhi(double phi) const {
-    while (phi > 2.* M_PI) { phi -= 2.*M_PI; }
-    while (phi < 0) { phi += 2.*M_PI; }
+    while (phi > 2. * M_PI) {
+      phi -= 2. * M_PI;
+    }
+    while (phi < 0) {
+      phi += 2. * M_PI;
+    }
     return phi;
   }
 
-  double phiDiff(double phi1, double phi2){
+  double phiDiff(double phi1, double phi2) {
     double result = normalPhi(phi1) - normalPhi(phi2);
-    if(result > M_PI) result -= 2*M_PI;
-    if(result < -M_PI) result += 2*M_PI;
+    if (result > M_PI)
+      result -= 2 * M_PI;
+    if (result < -M_PI)
+      result += 2 * M_PI;
     return result;
   }
 
   double unwrapPhi(double phi) const {
-    while (phi > M_PI) { phi -= 2.*M_PI; }
-    while (phi < -M_PI) { phi += 2.*M_PI; }
+    while (phi > M_PI) {
+      phi -= 2. * M_PI;
+    }
+    while (phi < -M_PI) {
+      phi += 2. * M_PI;
+    }
     return phi;
   }
 
-  void findSeedsFromCluster(edm::Ref<reco::SuperClusterCollection>, edm::Handle<reco::BeamSpot>,
-                            const MeasurementTrackerEvent &trackerData,
-			    reco::ElectronSeedCollection&);
+  void findSeedsFromCluster(edm::Ref<reco::SuperClusterCollection>,
+                            edm::Handle<reco::BeamSpot>,
+                            const MeasurementTrackerEvent& trackerData,
+                            reco::ElectronSeedCollection&);
 
   int whichSubdetector(std::vector<const SiStripMatchedRecHit2D*>::const_iterator hit);
 
-  bool preselection(GlobalPoint position,GlobalPoint superCluster,double phiVsRSlope, int hitLayer);
+  bool preselection(GlobalPoint position, GlobalPoint superCluster, double phiVsRSlope, int hitLayer);
   //hitLayer: 1 = TIB, 2 = TID, 3 = TEC, 4 = Mono
 
   bool checkHitsAndTSOS(std::vector<const SiStripMatchedRecHit2D*>::const_iterator hit1,
-			std::vector<const SiStripMatchedRecHit2D*>::const_iterator hit2,
-			double scr,double scz,double pT,double scEta);
+                        std::vector<const SiStripMatchedRecHit2D*>::const_iterator hit2,
+                        double scr,
+                        double scz,
+                        double pT,
+                        double scEta);
 
   bool altCheckHitsAndTSOS(std::vector<const SiStripMatchedRecHit2D*>::const_iterator hit1,
-			   std::vector<const SiStripRecHit2D*>::const_iterator hit2,
-			   double scr,double scz,double pT,double scEta);
+                           std::vector<const SiStripRecHit2D*>::const_iterator hit2,
+                           double scr,
+                           double scz,
+                           double pT,
+                           double scEta);
 
   const SiStripMatchedRecHit2D* matchedHitConverter(ConstRecHitPointer crhp);
   const SiStripRecHit2D* backupHitConverter(ConstRecHitPointer crhp);
@@ -139,8 +154,8 @@ private:
   std::string theMeasurementTrackerName;
   const MeasurementTracker* theMeasurementTracker;
   edm::EDGetTokenT<MeasurementTrackerEvent> theMeasurementTrackerEventTag;
-  const edm::EventSetup *theSetup;
-  
+  const edm::EventSetup* theSetup;
+
   PRecHitContainer recHits_;
   PTrajectoryStateOnDet pts_;
 
@@ -175,9 +190,6 @@ private:
   int tecMaxHits_;
   int monoMaxHits_;
   int maxSeeds_;
-
 };
 
-#endif // SiStripElectronSeedGenerator_H
-
-
+#endif  // SiStripElectronSeedGenerator_H

--- a/RecoEgamma/EgammaElectronAlgos/interface/TrajSeedMatcher.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/TrajSeedMatcher.h
@@ -1,12 +1,11 @@
 #ifndef RecoEgamma_EgammaElectronAlgos_TrajSeedMatcher_h
 #define RecoEgamma_EgammaElectronAlgos_TrajSeedMatcher_h
 
-
 //******************************************************************************
 //
 // Part of the refactorisation of of the E/gamma pixel matching for 2017 pixels
-// This refactorisation converts the monolithic  approach to a series of 
-// independent producer modules, with each modules performing  a specific 
+// This refactorisation converts the monolithic  approach to a series of
+// independent producer modules, with each modules performing  a specific
 // job as recommended by the 2017 tracker framework
 //
 //
@@ -15,14 +14,11 @@
 // It is also aware of how many layers the supercluster trajectory passed through
 // and uses that information to determine how many hits to require
 // Other than that, its a direct port and follows what PixelHitMatcher did
-// 
+//
 //
 // Author : Sam Harper (RAL), 2017
 //
 //*******************************************************************************
-
-
-
 
 #include "FWCore/Framework/interface/ESHandle.h"
 
@@ -40,75 +36,78 @@
 
 #include <unordered_map>
 
-namespace edm{
+namespace edm {
   class EventSetup;
   class ConfigurationDescriptions;
   class ParameterSet;
   class ParameterSetDescription;
-}
+}  // namespace edm
 
 class FreeTrajectoryState;
 class TrackingRecHit;
-
 
 //stolen from PixelHitMatcher
 //decide if its evil or not later
 //actually I think the answer is, yes, yes its evil
 //maybe replace with less evil?
-namespace std{
-  template<>
-    struct hash<std::pair<int,GlobalPoint> > {
-    std::size_t operator()(const std::pair<int,GlobalPoint>& g) const {
+namespace std {
+  template <>
+  struct hash<std::pair<int, GlobalPoint> > {
+    std::size_t operator()(const std::pair<int, GlobalPoint>& g) const {
       auto h1 = std::hash<unsigned long long>()((unsigned long long)g.first);
-      unsigned long long k; memcpy(&k, &g.second,sizeof(k));
+      unsigned long long k;
+      memcpy(&k, &g.second, sizeof(k));
       auto h2 = std::hash<unsigned long long>()(k);
       return h1 ^ (h2 << 1);
-      }
+    }
   };
-}
+}  // namespace std
 
 class TrajSeedMatcher {
 public:
   class SCHitMatch {
   public:
-    SCHitMatch():detId_(0),
-	      dRZ_(std::numeric_limits<float>::max()),
-	      dPhi_(std::numeric_limits<float>::max()),
-	      hit_(nullptr),
-	      et_(0),eta_(0),phi_(0),charge_(0),nrClus_(0){}
+    SCHitMatch()
+        : detId_(0),
+          dRZ_(std::numeric_limits<float>::max()),
+          dPhi_(std::numeric_limits<float>::max()),
+          hit_(nullptr),
+          et_(0),
+          eta_(0),
+          phi_(0),
+          charge_(0),
+          nrClus_(0) {}
 
     //does not set charge,et,nrclus
-    SCHitMatch(const GlobalPoint& vtxPos,
-	    const TrajectoryStateOnSurface& trajState,
-	    const TrackingRecHit& hit
-	    );
-    ~SCHitMatch()=default;
+    SCHitMatch(const GlobalPoint& vtxPos, const TrajectoryStateOnSurface& trajState, const TrackingRecHit& hit);
+    ~SCHitMatch() = default;
 
-    void setExtra(float et, float eta, float phi, int charge, int nrClus){
-      et_=et;
-      eta_=eta;
-      phi_=phi;
-      charge_=charge;
-      nrClus_=nrClus;
+    void setExtra(float et, float eta, float phi, int charge, int nrClus) {
+      et_ = et;
+      eta_ = eta;
+      phi_ = phi;
+      charge_ = charge;
+      nrClus_ = nrClus;
     }
-    
-    int subdetId()const{return detId_.subdetId();}
-    DetId detId()const{return detId_;}
-    float dRZ()const{return dRZ_;}
-    float dPhi()const{return dPhi_;}
-    const GlobalPoint& hitPos()const{return hitPos_;}
-    float et()const{return et_;}
-    float eta()const{return eta_;}
-    float phi()const{return phi_;}
-    int charge()const{return charge_;}
-    int nrClus()const{return nrClus_;}
-    const TrackingRecHit* hit()const{return hit_;}
+
+    int subdetId() const { return detId_.subdetId(); }
+    DetId detId() const { return detId_; }
+    float dRZ() const { return dRZ_; }
+    float dPhi() const { return dPhi_; }
+    const GlobalPoint& hitPos() const { return hitPos_; }
+    float et() const { return et_; }
+    float eta() const { return eta_; }
+    float phi() const { return phi_; }
+    int charge() const { return charge_; }
+    int nrClus() const { return nrClus_; }
+    const TrackingRecHit* hit() const { return hit_; }
+
   private:
     DetId detId_;
     GlobalPoint hitPos_;
     float dRZ_;
-    float dPhi_;    
-    const TrackingRecHit* hit_; //we do not own this
+    float dPhi_;
+    const TrackingRecHit* hit_;  //we do not own this
     //extra quanities which are set later
     float et_;
     float eta_;
@@ -117,41 +116,37 @@ public:
     int nrClus_;
   };
 
- 
-
   struct MatchInfo {
   public:
     DetId detId;
-    float dRZPos,dRZNeg;
-    float dPhiPos,dPhiNeg;
-    
-    MatchInfo(const DetId& iDetId,
-	      float iDRZPos, float iDRZNeg,
-	      float iDPhiPos, float iDPhiNeg):
-      detId(iDetId),dRZPos(iDRZPos),dRZNeg(iDRZNeg),
-      dPhiPos(iDPhiPos),dPhiNeg(iDPhiNeg){}
+    float dRZPos, dRZNeg;
+    float dPhiPos, dPhiNeg;
+
+    MatchInfo(const DetId& iDetId, float iDRZPos, float iDRZNeg, float iDPhiPos, float iDPhiNeg)
+        : detId(iDetId), dRZPos(iDRZPos), dRZNeg(iDRZNeg), dPhiPos(iDPhiPos), dPhiNeg(iDPhiNeg) {}
   };
 
   class SeedWithInfo {
   public:
     SeedWithInfo(const TrajectorySeed& seed,
-		 const std::vector<SCHitMatch>& posCharge,
-		 const std::vector<SCHitMatch>& negCharge,
-		 int nrValidLayers);
-    ~SeedWithInfo()=default;
-    
-    const TrajectorySeed& seed()const{return seed_;}
-    float dRZPos(size_t hitNr)const{return getVal(hitNr,&MatchInfo::dRZPos);}
-    float dRZNeg(size_t hitNr)const{return getVal(hitNr,&MatchInfo::dRZNeg);}
-    float dPhiPos(size_t hitNr)const{return getVal(hitNr,&MatchInfo::dPhiPos);}
-    float dPhiNeg(size_t hitNr)const{return getVal(hitNr,&MatchInfo::dPhiNeg);}
-    DetId detId(size_t hitNr)const{return hitNr<matchInfo_.size() ? matchInfo_[hitNr].detId : DetId(0);}
-    size_t nrMatchedHits()const{return matchInfo_.size();}
-    const std::vector<MatchInfo>& matches()const{return matchInfo_;}
-    int nrValidLayers()const{return nrValidLayers_;}
+                 const std::vector<SCHitMatch>& posCharge,
+                 const std::vector<SCHitMatch>& negCharge,
+                 int nrValidLayers);
+    ~SeedWithInfo() = default;
+
+    const TrajectorySeed& seed() const { return seed_; }
+    float dRZPos(size_t hitNr) const { return getVal(hitNr, &MatchInfo::dRZPos); }
+    float dRZNeg(size_t hitNr) const { return getVal(hitNr, &MatchInfo::dRZNeg); }
+    float dPhiPos(size_t hitNr) const { return getVal(hitNr, &MatchInfo::dPhiPos); }
+    float dPhiNeg(size_t hitNr) const { return getVal(hitNr, &MatchInfo::dPhiNeg); }
+    DetId detId(size_t hitNr) const { return hitNr < matchInfo_.size() ? matchInfo_[hitNr].detId : DetId(0); }
+    size_t nrMatchedHits() const { return matchInfo_.size(); }
+    const std::vector<MatchInfo>& matches() const { return matchInfo_; }
+    int nrValidLayers() const { return nrValidLayers_; }
+
   private:
-    float getVal(size_t hitNr,float MatchInfo::*val)const{
-      return hitNr<matchInfo_.size() ? matchInfo_[hitNr].*val : std::numeric_limits<float>::max();
+    float getVal(size_t hitNr, float MatchInfo::*val) const {
+      return hitNr < matchInfo_.size() ? matchInfo_[hitNr].*val : std::numeric_limits<float>::max();
     }
 
   private:
@@ -162,106 +157,115 @@ public:
 
   class MatchingCuts {
   public:
-    MatchingCuts(){}
-    virtual ~MatchingCuts(){}
-    virtual bool operator()(const SCHitMatch& scHitMatch)const=0;
+    MatchingCuts() {}
+    virtual ~MatchingCuts() {}
+    virtual bool operator()(const SCHitMatch& scHitMatch) const = 0;
   };
 
   class MatchingCutsV1 : public MatchingCuts {
   public:
     explicit MatchingCutsV1(const edm::ParameterSet& pset);
-    bool operator()(const SCHitMatch& scHitMatch)const override;
+    bool operator()(const SCHitMatch& scHitMatch) const override;
+
   private:
-    float getDRZCutValue(const float scEt, const float scEta)const;
+    float getDRZCutValue(const float scEt, const float scEta) const;
+
   private:
     const double dPhiMax_;
     const double dRZMax_;
     const double dRZMaxLowEtThres_;
-    const std::vector<double> dRZMaxLowEtEtaBins_; 
-    const std::vector<double> dRZMaxLowEt_; 
+    const std::vector<double> dRZMaxLowEtEtaBins_;
+    const std::vector<double> dRZMaxLowEt_;
   };
 
   class MatchingCutsV2 : public MatchingCuts {
   public:
     explicit MatchingCutsV2(const edm::ParameterSet& pset);
-    bool operator()(const SCHitMatch& scHitMatch)const override;
+    bool operator()(const SCHitMatch& scHitMatch) const override;
+
   private:
-    size_t getBinNr(float eta)const;
-    float getCutValue(float et, float highEt, float highEtThres, float lowEtGrad)const{
-      return  highEt + std::min(0.f,et-highEtThres)*lowEtGrad;
+    size_t getBinNr(float eta) const;
+    float getCutValue(float et, float highEt, float highEtThres, float lowEtGrad) const {
+      return highEt + std::min(0.f, et - highEtThres) * lowEtGrad;
     }
+
   private:
-    std::vector<double> dPhiHighEt_,dPhiHighEtThres_,dPhiLowEtGrad_;
-    std::vector<double> dRZHighEt_,dRZHighEtThres_,dRZLowEtGrad_;
+    std::vector<double> dPhiHighEt_, dPhiHighEtThres_, dPhiLowEtGrad_;
+    std::vector<double> dRZHighEt_, dRZHighEtThres_, dRZLowEtGrad_;
     std::vector<double> etaBins_;
   };
 
-
-public:  
+public:
   explicit TrajSeedMatcher(const edm::ParameterSet& pset);
-  ~TrajSeedMatcher()=default;
+  ~TrajSeedMatcher() = default;
 
   static edm::ParameterSetDescription makePSetDescription();
 
   void doEventSetup(const edm::EventSetup& iSetup);
-  
-  std::vector<TrajSeedMatcher::SeedWithInfo>
-  compatibleSeeds(const TrajectorySeedCollection& seeds, const GlobalPoint& candPos,
-		  const GlobalPoint & vprim, const float energy);
 
-  void setMeasTkEvtHandle(edm::Handle<MeasurementTrackerEvent> handle){measTkEvt_=std::move(handle);}
-  
+  std::vector<TrajSeedMatcher::SeedWithInfo> compatibleSeeds(const TrajectorySeedCollection& seeds,
+                                                             const GlobalPoint& candPos,
+                                                             const GlobalPoint& vprim,
+                                                             const float energy);
+
+  void setMeasTkEvtHandle(edm::Handle<MeasurementTrackerEvent> handle) { measTkEvt_ = std::move(handle); }
+
 private:
-  
-  std::vector<SCHitMatch> processSeed(const TrajectorySeed& seed, const GlobalPoint& candPos,
-				   const GlobalPoint & vprim, const float energy, const int charge );
+  std::vector<SCHitMatch> processSeed(const TrajectorySeed& seed,
+                                      const GlobalPoint& candPos,
+                                      const GlobalPoint& vprim,
+                                      const float energy,
+                                      const int charge);
 
-  static float getZVtxFromExtrapolation(const GlobalPoint& primeVtxPos, const GlobalPoint& hitPos,
-					const GlobalPoint& candPos);
-  
-  bool passTrajPreSel(const GlobalPoint& hitPos,const GlobalPoint& candPos)const;
-  
+  static float getZVtxFromExtrapolation(const GlobalPoint& primeVtxPos,
+                                        const GlobalPoint& hitPos,
+                                        const GlobalPoint& candPos);
+
+  bool passTrajPreSel(const GlobalPoint& hitPos, const GlobalPoint& candPos) const;
+
   TrajSeedMatcher::SCHitMatch matchFirstHit(const TrajectorySeed& seed,
-					    const TrajectoryStateOnSurface& trajState,
-					    const GlobalPoint& vtxPos,
-					    const PropagatorWithMaterial& propagator);
+                                            const TrajectoryStateOnSurface& trajState,
+                                            const GlobalPoint& vtxPos,
+                                            const PropagatorWithMaterial& propagator);
 
   TrajSeedMatcher::SCHitMatch match2ndToNthHit(const TrajectorySeed& seed,
-					       const FreeTrajectoryState& trajState,
-					       const size_t hitNr,	
-					       const GlobalPoint& prevHitPos,
-					       const GlobalPoint& vtxPos,
-					       const PropagatorWithMaterial& propagator);
-  
+                                               const FreeTrajectoryState& trajState,
+                                               const size_t hitNr,
+                                               const GlobalPoint& prevHitPos,
+                                               const GlobalPoint& vtxPos,
+                                               const PropagatorWithMaterial& propagator);
+
   const TrajectoryStateOnSurface& getTrajStateFromVtx(const TrackingRecHit& hit,
-						      const TrajectoryStateOnSurface& initialState,
-						      const PropagatorWithMaterial& propagator);
+                                                      const TrajectoryStateOnSurface& initialState,
+                                                      const PropagatorWithMaterial& propagator);
 
   const TrajectoryStateOnSurface& getTrajStateFromPoint(const TrackingRecHit& hit,
-							const FreeTrajectoryState& initialState,
-							const GlobalPoint& point,
-							const PropagatorWithMaterial& propagator);
+                                                        const FreeTrajectoryState& initialState,
+                                                        const GlobalPoint& point,
+                                                        const PropagatorWithMaterial& propagator);
 
   void clearCache();
 
-  bool passesMatchSel(const SCHitMatch& hit, const size_t hitNr)const;
+  bool passesMatchSel(const SCHitMatch& hit, const size_t hitNr) const;
 
-  int getNrValidLayersAlongTraj(const SCHitMatch& hit1, const SCHitMatch& hit2,
-				const GlobalPoint& candPos,
-				const GlobalPoint & vprim, 
-				const float energy, const int charge);
+  int getNrValidLayersAlongTraj(const SCHitMatch& hit1,
+                                const SCHitMatch& hit2,
+                                const GlobalPoint& candPos,
+                                const GlobalPoint& vprim,
+                                const float energy,
+                                const int charge);
 
-  int getNrValidLayersAlongTraj(const DetId& hitId,
-				const TrajectoryStateOnSurface& hitTrajState)const;
-				
-  bool layerHasValidHits(const DetLayer& layer,const TrajectoryStateOnSurface& hitSurState,
-			 const Propagator& propToLayerFromState)const;
-  
-  size_t getNrHitsRequired(const int nrValidLayers)const;
-    
+  int getNrValidLayersAlongTraj(const DetId& hitId, const TrajectoryStateOnSurface& hitTrajState) const;
+
+  bool layerHasValidHits(const DetLayer& layer,
+                         const TrajectoryStateOnSurface& hitSurState,
+                         const Propagator& propToLayerFromState) const;
+
+  size_t getNrHitsRequired(const int nrValidLayers) const;
+
 private:
   static constexpr float kElectronMass_ = 0.000511;
-  static constexpr float kPhiCut_ = -0.801144;//cos(2.5)
+  static constexpr float kPhiCut_ = -0.801144;  //cos(2.5)
   std::unique_ptr<PropagatorWithMaterial> forwardPropagator_;
   std::unique_ptr<PropagatorWithMaterial> backwardPropagator_;
   unsigned long long cacheIDMagField_;
@@ -274,21 +278,20 @@ private:
 
   bool useRecoVertex_;
   std::vector<std::unique_ptr<MatchingCuts> > matchingCuts_;
-  
-  //these two varibles determine how hits we require 
+
+  //these two varibles determine how hits we require
   //based on how many valid layers we had
   //right now we always need atleast two hits
-  //also highly dependent on the seeds you pass in 
+  //also highly dependent on the seeds you pass in
   //which also require a given number of hits
   const std::vector<unsigned int> minNrHits_;
   const std::vector<int> minNrHitsValidLayerBins_;
 
-  std::unordered_map<int,TrajectoryStateOnSurface> trajStateFromVtxPosChargeCache_;
-  std::unordered_map<int,TrajectoryStateOnSurface> trajStateFromVtxNegChargeCache_;
+  std::unordered_map<int, TrajectoryStateOnSurface> trajStateFromVtxPosChargeCache_;
+  std::unordered_map<int, TrajectoryStateOnSurface> trajStateFromVtxNegChargeCache_;
 
-  std::unordered_map<std::pair<int,GlobalPoint>,TrajectoryStateOnSurface> trajStateFromPointPosChargeCache_;
-  std::unordered_map<std::pair<int,GlobalPoint>,TrajectoryStateOnSurface> trajStateFromPointNegChargeCache_;
-
+  std::unordered_map<std::pair<int, GlobalPoint>, TrajectoryStateOnSurface> trajStateFromPointPosChargeCache_;
+  std::unordered_map<std::pair<int, GlobalPoint>, TrajectoryStateOnSurface> trajStateFromPointNegChargeCache_;
 };
 
 #endif

--- a/RecoEgamma/EgammaElectronAlgos/src/EgAmbiguityTools.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/EgAmbiguityTools.cc
@@ -7,191 +7,174 @@
 
 #include <algorithm>
 
-using namespace edm ;
-using namespace std ;
-using namespace reco ;
+using namespace edm;
+using namespace std;
+using namespace reco;
 
-namespace EgAmbiguityTools
-{
+namespace EgAmbiguityTools {
 
-bool isBetter( reco::GsfElectron const& e1, reco::GsfElectron const& e2 )
- { return (std::abs(e1.eSuperClusterOverP()-1) < std::abs(e2.eSuperClusterOverP() - 1)) ; }
+  bool isBetter(reco::GsfElectron const& e1, reco::GsfElectron const& e2) {
+    return (std::abs(e1.eSuperClusterOverP() - 1) < std::abs(e2.eSuperClusterOverP() - 1));
+  }
 
-bool isInnerMost( reco::GsfElectron const& e1, reco::GsfElectron const& e2)
-{
+  bool isInnerMost(reco::GsfElectron const& e1, reco::GsfElectron const& e2) {
     // retreive first valid hit
-    int gsfHitCounter1 = 0 ;
-    for(auto const& elHit : e1.gsfTrack()->recHits())
-    {
-        if (elHit->isValid()) break;
-        gsfHitCounter1++;
+    int gsfHitCounter1 = 0;
+    for (auto const& elHit : e1.gsfTrack()->recHits()) {
+      if (elHit->isValid())
+        break;
+      gsfHitCounter1++;
     }
 
-    int gsfHitCounter2 = 0 ;
-    for(auto const& elHit : e2.gsfTrack()->recHits())
-    {
-        if (elHit->isValid()) break;
-        gsfHitCounter2++;
+    int gsfHitCounter2 = 0;
+    for (auto const& elHit : e2.gsfTrack()->recHits()) {
+      if (elHit->isValid())
+        break;
+      gsfHitCounter2++;
     }
 
     uint32_t gsfHit1 = e1.gsfTrack()->hitPattern().getHitPattern(HitPattern::TRACK_HITS, gsfHitCounter1);
     uint32_t gsfHit2 = e2.gsfTrack()->hitPattern().getHitPattern(HitPattern::TRACK_HITS, gsfHitCounter2);
 
-    if (HitPattern::getSubStructure(gsfHit1) != HitPattern::getSubStructure(gsfHit2)){
-        return (HitPattern::getSubStructure(gsfHit1) < HitPattern::getSubStructure(gsfHit2));
-    }else if (HitPattern::getLayer(gsfHit1) != HitPattern::getLayer(gsfHit2)){
-        return (HitPattern::getLayer(gsfHit1) < HitPattern::getLayer(gsfHit2));
-    }else{
-        return isBetter(e1, e2);
+    if (HitPattern::getSubStructure(gsfHit1) != HitPattern::getSubStructure(gsfHit2)) {
+      return (HitPattern::getSubStructure(gsfHit1) < HitPattern::getSubStructure(gsfHit2));
+    } else if (HitPattern::getLayer(gsfHit1) != HitPattern::getLayer(gsfHit2)) {
+      return (HitPattern::getLayer(gsfHit1) < HitPattern::getLayer(gsfHit2));
+    } else {
+      return isBetter(e1, e2);
     }
-}
+  }
 
-int sharedHits(const GsfTrackRef & gsfTrackRef1, const GsfTrackRef & gsfTrackRef2 )
-{
-  //get the Hit Pattern for the gsfTracks
-  HitPattern const& gsfHitPattern1 = gsfTrackRef1->hitPattern();
-  HitPattern const& gsfHitPattern2 = gsfTrackRef2->hitPattern();
-
-  unsigned int shared = 0;
-
-  int gsfHitCounter1 = 0;
-  for(trackingRecHit_iterator elHitsIt1 = gsfTrackRef1->recHitsBegin();
-          elHitsIt1 != gsfTrackRef1->recHitsEnd(); elHitsIt1++, gsfHitCounter1++) {
-      if(!(*elHitsIt1)->isValid()){
-          //count only valid Hits
-          continue;
-      }
-      //if (gsfHitCounter1>1) continue; // test only the first hit of the track 1
-      uint32_t gsfHit = gsfHitPattern1.getHitPattern(HitPattern::TRACK_HITS, gsfHitCounter1);
-      if(!(HitPattern::pixelHitFilter(gsfHit)
-                  || HitPattern::stripTIBHitFilter(gsfHit)
-                  || HitPattern::stripTOBHitFilter(gsfHit)
-                  || HitPattern::stripTECHitFilter(gsfHit)
-                  || HitPattern::stripTIDHitFilter(gsfHit))){
-          continue;
-      }
-
-      int gsfHitsCounter2 = 0;
-      for(trackingRecHit_iterator gsfHitsIt2 = gsfTrackRef2->recHitsBegin();
-              gsfHitsIt2 != gsfTrackRef2->recHitsEnd(); gsfHitsIt2++, gsfHitsCounter2++) {
-          if(!(**gsfHitsIt2).isValid()){
-              //count only valid Hits
-              continue;
-          }
-          uint32_t gsfHit2 = gsfHitPattern2.getHitPattern(HitPattern::TRACK_HITS, gsfHitsCounter2);
-          if(!(HitPattern::pixelHitFilter(gsfHit2)
-                      || HitPattern::stripTIBHitFilter(gsfHit2)
-                      || HitPattern::stripTOBHitFilter(gsfHit2)
-                      || HitPattern::stripTECHitFilter(gsfHit2)
-                      || HitPattern::stripTIDHitFilter(gsfHit2))){
-              continue;
-          }
-          if((*elHitsIt1)->sharesInput(&(**gsfHitsIt2), TrackingRecHit::some)) {
-              //if (comp.equals(&(**elHitsIt1),&(**gsfHitsIt2))) {
-              ////std::cout << "found shared hit " << gsfHit2 << std::endl;
-              shared++;
-          }
-      }//gsfHits2 iterator
-  }//gsfHits1 iterator
-
-  //std::cout << "[sharedHits] number of shared hits " << shared << std::endl;
-  return shared;
-}
-
-int sharedDets(const GsfTrackRef& gsfTrackRef1, const GsfTrackRef& gsfTrackRef2 )
-{
+  int sharedHits(const GsfTrackRef& gsfTrackRef1, const GsfTrackRef& gsfTrackRef2) {
     //get the Hit Pattern for the gsfTracks
-    const HitPattern &gsfHitPattern1 = gsfTrackRef1->hitPattern();
-    const HitPattern &gsfHitPattern2 = gsfTrackRef2->hitPattern();
+    HitPattern const& gsfHitPattern1 = gsfTrackRef1->hitPattern();
+    HitPattern const& gsfHitPattern2 = gsfTrackRef2->hitPattern();
 
     unsigned int shared = 0;
 
     int gsfHitCounter1 = 0;
-    for(trackingRecHit_iterator elHitsIt1 = gsfTrackRef1->recHitsBegin();
-            elHitsIt1 != gsfTrackRef1->recHitsEnd(); elHitsIt1++, gsfHitCounter1++) {
-        if(!((**elHitsIt1).isValid())){
-            //count only valid Hits
-            continue;
+    for (trackingRecHit_iterator elHitsIt1 = gsfTrackRef1->recHitsBegin(); elHitsIt1 != gsfTrackRef1->recHitsEnd();
+         elHitsIt1++, gsfHitCounter1++) {
+      if (!(*elHitsIt1)->isValid()) {
+        //count only valid Hits
+        continue;
+      }
+      //if (gsfHitCounter1>1) continue; // test only the first hit of the track 1
+      uint32_t gsfHit = gsfHitPattern1.getHitPattern(HitPattern::TRACK_HITS, gsfHitCounter1);
+      if (!(HitPattern::pixelHitFilter(gsfHit) || HitPattern::stripTIBHitFilter(gsfHit) ||
+            HitPattern::stripTOBHitFilter(gsfHit) || HitPattern::stripTECHitFilter(gsfHit) ||
+            HitPattern::stripTIDHitFilter(gsfHit))) {
+        continue;
+      }
+
+      int gsfHitsCounter2 = 0;
+      for (trackingRecHit_iterator gsfHitsIt2 = gsfTrackRef2->recHitsBegin(); gsfHitsIt2 != gsfTrackRef2->recHitsEnd();
+           gsfHitsIt2++, gsfHitsCounter2++) {
+        if (!(**gsfHitsIt2).isValid()) {
+          //count only valid Hits
+          continue;
         }
-        //if (gsfHitCounter1>1) continue; // to test only the first hit of the track 1
-        uint32_t gsfHit = gsfHitPattern1.getHitPattern(HitPattern::TRACK_HITS, gsfHitCounter1);
-        if(!(HitPattern::pixelHitFilter(gsfHit)
-                    || HitPattern::stripTIBHitFilter(gsfHit)
-                    || HitPattern::stripTOBHitFilter(gsfHit)
-                    || HitPattern::stripTECHitFilter(gsfHit)
-                    || HitPattern::stripTIDHitFilter(gsfHit)))
-        {
-            continue;
+        uint32_t gsfHit2 = gsfHitPattern2.getHitPattern(HitPattern::TRACK_HITS, gsfHitsCounter2);
+        if (!(HitPattern::pixelHitFilter(gsfHit2) || HitPattern::stripTIBHitFilter(gsfHit2) ||
+              HitPattern::stripTOBHitFilter(gsfHit2) || HitPattern::stripTECHitFilter(gsfHit2) ||
+              HitPattern::stripTIDHitFilter(gsfHit2))) {
+          continue;
+        }
+        if ((*elHitsIt1)->sharesInput(&(**gsfHitsIt2), TrackingRecHit::some)) {
+          //if (comp.equals(&(**elHitsIt1),&(**gsfHitsIt2))) {
+          ////std::cout << "found shared hit " << gsfHit2 << std::endl;
+          shared++;
+        }
+      }  //gsfHits2 iterator
+    }    //gsfHits1 iterator
+
+    //std::cout << "[sharedHits] number of shared hits " << shared << std::endl;
+    return shared;
+  }
+
+  int sharedDets(const GsfTrackRef& gsfTrackRef1, const GsfTrackRef& gsfTrackRef2) {
+    //get the Hit Pattern for the gsfTracks
+    const HitPattern& gsfHitPattern1 = gsfTrackRef1->hitPattern();
+    const HitPattern& gsfHitPattern2 = gsfTrackRef2->hitPattern();
+
+    unsigned int shared = 0;
+
+    int gsfHitCounter1 = 0;
+    for (trackingRecHit_iterator elHitsIt1 = gsfTrackRef1->recHitsBegin(); elHitsIt1 != gsfTrackRef1->recHitsEnd();
+         elHitsIt1++, gsfHitCounter1++) {
+      if (!((**elHitsIt1).isValid())) {
+        //count only valid Hits
+        continue;
+      }
+      //if (gsfHitCounter1>1) continue; // to test only the first hit of the track 1
+      uint32_t gsfHit = gsfHitPattern1.getHitPattern(HitPattern::TRACK_HITS, gsfHitCounter1);
+      if (!(HitPattern::pixelHitFilter(gsfHit) || HitPattern::stripTIBHitFilter(gsfHit) ||
+            HitPattern::stripTOBHitFilter(gsfHit) || HitPattern::stripTECHitFilter(gsfHit) ||
+            HitPattern::stripTIDHitFilter(gsfHit))) {
+        continue;
+      }
+
+      int gsfHitsCounter2 = 0;
+      for (trackingRecHit_iterator gsfHitsIt2 = gsfTrackRef2->recHitsBegin(); gsfHitsIt2 != gsfTrackRef2->recHitsEnd();
+           gsfHitsIt2++, gsfHitsCounter2++) {
+        if (!((**gsfHitsIt2).isValid())) {
+          //count only valid Hits!
+          continue;
         }
 
-        int gsfHitsCounter2 = 0;
-        for(trackingRecHit_iterator gsfHitsIt2 = gsfTrackRef2->recHitsBegin();
-                gsfHitsIt2 != gsfTrackRef2->recHitsEnd(); gsfHitsIt2++, gsfHitsCounter2++) {
-            if(!((**gsfHitsIt2).isValid())){
-                //count only valid Hits!
-                continue;
-            }
-
-            uint32_t gsfHit2 = gsfHitPattern2.getHitPattern(HitPattern::TRACK_HITS, gsfHitsCounter2);
-            if(!(HitPattern::pixelHitFilter(gsfHit2)
-                        || HitPattern::stripTIBHitFilter(gsfHit2)
-                        || HitPattern::stripTOBHitFilter(gsfHit2)
-                        || HitPattern::stripTECHitFilter(gsfHit2)
-                        || HitPattern::stripTIDHitFilter(gsfHit2) )
-              ) continue;
-            if ((**elHitsIt1).geographicalId() == (**gsfHitsIt2).geographicalId()) shared++;
-        }//gsfHits2 iterator
-    }//gsfHits1 iterator
+        uint32_t gsfHit2 = gsfHitPattern2.getHitPattern(HitPattern::TRACK_HITS, gsfHitsCounter2);
+        if (!(HitPattern::pixelHitFilter(gsfHit2) || HitPattern::stripTIBHitFilter(gsfHit2) ||
+              HitPattern::stripTOBHitFilter(gsfHit2) || HitPattern::stripTECHitFilter(gsfHit2) ||
+              HitPattern::stripTIDHitFilter(gsfHit2)))
+          continue;
+        if ((**elHitsIt1).geographicalId() == (**gsfHitsIt2).geographicalId())
+          shared++;
+      }  //gsfHits2 iterator
+    }    //gsfHits1 iterator
 
     //std::cout << "[sharedHits] number of shared dets " << shared << std::endl;
     //return shared/min(gsfTrackRef1->numberOfValidHits(),gsfTrackRef2->numberOfValidHits());
     return shared;
+  }
 
-}
+  float sharedEnergy(CaloCluster const& clu1,
+                     CaloCluster const& clu2,
+                     EcalRecHitCollection const& barrelRecHits,
+                     EcalRecHitCollection const& endcapRecHits) {
+    double fractionShared = 0;
 
-float sharedEnergy( CaloCluster const& clu1, CaloCluster const& clu2,
-                    EcalRecHitCollection const& barrelRecHits,
-                    EcalRecHitCollection const& endcapRecHits )
-{
+    for (auto const& h1 : clu1.hitsAndFractions()) {
+      for (auto const& h2 : clu2.hitsAndFractions()) {
+        if (h1.first != h2.first)
+          continue;
 
-  double fractionShared = 0;
-
-  for(auto const& h1 : clu1.hitsAndFractions()) {
-
-    for(auto const& h2 : clu2.hitsAndFractions()) {
-
-      if ( h1.first != h2.first ) continue;
-
-      // here we have common Xtal id
-      EcalRecHitCollection::const_iterator itt;
-      if (h1.first.subdetId() == EcalBarrel) {
-        if ((itt=barrelRecHits.find(h1.first))!=barrelRecHits.end())
-        fractionShared += itt->energy();
-      } else if (h1.first.subdetId() == EcalEndcap) {
-        if ((itt=endcapRecHits.find(h1.first))!=endcapRecHits.end())
-        fractionShared += itt->energy();
+        // here we have common Xtal id
+        EcalRecHitCollection::const_iterator itt;
+        if (h1.first.subdetId() == EcalBarrel) {
+          if ((itt = barrelRecHits.find(h1.first)) != barrelRecHits.end())
+            fractionShared += itt->energy();
+        } else if (h1.first.subdetId() == EcalEndcap) {
+          if ((itt = endcapRecHits.find(h1.first)) != endcapRecHits.end())
+            fractionShared += itt->energy();
+        }
       }
-
     }
+
+    //std::cout << "[sharedEnergy] shared energy /min(energy1,energy2) " << fractionShared << std::endl;
+    return fractionShared;
   }
 
-  //std::cout << "[sharedEnergy] shared energy /min(energy1,energy2) " << fractionShared << std::endl;
-  return fractionShared;
-
-}
-
-float sharedEnergy( SuperClusterRef const& sc1, SuperClusterRef const& sc2,
-                    EcalRecHitCollection const& barrelRecHits,
-                    EcalRecHitCollection const& endcapRecHits )
-{
-  double energyShared = 0;
-  for(CaloCluster_iterator icl1=sc1->clustersBegin();icl1!=sc1->clustersEnd(); icl1++) {
-    for(CaloCluster_iterator icl2=sc2->clustersBegin();icl2!=sc2->clustersEnd(); icl2++) {
-      energyShared += sharedEnergy(**icl1,**icl2,barrelRecHits,endcapRecHits );
+  float sharedEnergy(SuperClusterRef const& sc1,
+                     SuperClusterRef const& sc2,
+                     EcalRecHitCollection const& barrelRecHits,
+                     EcalRecHitCollection const& endcapRecHits) {
+    double energyShared = 0;
+    for (CaloCluster_iterator icl1 = sc1->clustersBegin(); icl1 != sc1->clustersEnd(); icl1++) {
+      for (CaloCluster_iterator icl2 = sc2->clustersBegin(); icl2 != sc2->clustersEnd(); icl2++) {
+        energyShared += sharedEnergy(**icl1, **icl2, barrelRecHits, endcapRecHits);
+      }
     }
+    return energyShared;
   }
-  return energyShared;
 
-}
-
-}
+}  // namespace EgAmbiguityTools

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronClassification.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronClassification.cc
@@ -2,7 +2,6 @@
 
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 
-
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 //===================================================================
@@ -13,45 +12,43 @@
 
 using namespace reco;
 
-void ElectronClassification::classify( GsfElectron & electron )
- {
-  if ((!electron.isEB())&&(!electron.isEE()))
-   {
-    edm::LogWarning("")
-      << "ElectronClassification::init(): Undefined electron, eta = "
-      << electron.eta() << "!!!!" ;
-    electron.setClassification(GsfElectron::UNKNOWN) ;
-    return ;
-   }
+void ElectronClassification::classify(GsfElectron& electron) {
+  if ((!electron.isEB()) && (!electron.isEE())) {
+    edm::LogWarning("") << "ElectronClassification::init(): Undefined electron, eta = " << electron.eta() << "!!!!";
+    electron.setClassification(GsfElectron::UNKNOWN);
+    return;
+  }
 
-  if ( electron.isEBEEGap() || electron.isEBEtaGap() || electron.isEERingGap() )
-   {
-    electron.setClassification(GsfElectron::GAP) ;
-    return ;
-   }
+  if (electron.isEBEEGap() || electron.isEBEtaGap() || electron.isEERingGap()) {
+    electron.setClassification(GsfElectron::GAP);
+    return;
+  }
 
   //float pin  = electron.trackMomentumAtVtx().R() ;
-  float fbrem = electron.trackFbrem() ;
-  int nbrem = electron.numberOfBrems() ;
+  float fbrem = electron.trackFbrem();
+  int nbrem = electron.numberOfBrems();
 
-  if (nbrem == 0 && fbrem < 0.5) // part (pin - scEnergy)/pin < 0.1 removed - M.D.
-   { electron.setClassification(GsfElectron::GOLDEN) ; }
-  else if (nbrem == 0 && fbrem >= 0.5) // part (pin - scEnergy)/pin < 0.1 removed - M.D.
-   { electron.setClassification(GsfElectron::BIGBREM) ; }
-  else
-   { electron.setClassification(GsfElectron::SHOWERING) ; }
+  if (nbrem == 0 && fbrem < 0.5)  // part (pin - scEnergy)/pin < 0.1 removed - M.D.
+  {
+    electron.setClassification(GsfElectron::GOLDEN);
+  } else if (nbrem == 0 && fbrem >= 0.5)  // part (pin - scEnergy)/pin < 0.1 removed - M.D.
+  {
+    electron.setClassification(GsfElectron::BIGBREM);
+  } else {
+    electron.setClassification(GsfElectron::SHOWERING);
+  }
+}
 
- }
+void ElectronClassification::refineWithPflow(GsfElectron& electron) {
+  if ((!electron.isEB()) && (!electron.isEE())) {
+    return;
+  }
 
-void ElectronClassification::refineWithPflow( GsfElectron & electron )
- {
-  if ((!electron.isEB())&&(!electron.isEE()))
-   { return ; }
+  if (electron.isEBEEGap() || electron.isEBEtaGap() || electron.isEERingGap()) {
+    return;
+  }
 
-  if ( electron.isEBEEGap() || electron.isEBEtaGap() || electron.isEERingGap() )
-   { return ; }
-
-  if ((electron.superClusterFbrem()-electron.trackFbrem())>=0.15)
-   { electron.setClassification(GsfElectron::BADTRACK) ; }
- }
-
+  if ((electron.superClusterFbrem() - electron.trackFbrem()) >= 0.15) {
+    electron.setClassification(GsfElectron::BADTRACK);
+  }
+}

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronEnergyCorrector.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronEnergyCorrector.cc
@@ -6,7 +6,6 @@
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "TMath.h"
 
-
 /****************************************************************************
  *
  * Classification based eta corrections for the ecal cluster energy
@@ -17,403 +16,395 @@
  *
  ****************************************************************************/
 
-void ElectronEnergyCorrector::classBasedParameterizationUncertainty( reco::GsfElectron & electron )
- {
-  EnergyUncertaintyElectronSpecific uncertainty ;
-  double energyError = 999. ;
-  double ecalEnergy = electron.correctedEcalEnergy() ;
-  double eleEta = electron.superCluster()->eta() ;
-  double brem = electron.superCluster()->etaWidth()/electron.superCluster()->phiWidth() ;
-  energyError =  uncertainty.computeElectronEnergyUncertainty(electron.classification(),eleEta,brem,ecalEnergy) ;
-  electron.setCorrectedEcalEnergyError(energyError) ;
- }
+void ElectronEnergyCorrector::classBasedParameterizationUncertainty(reco::GsfElectron& electron) {
+  EnergyUncertaintyElectronSpecific uncertainty;
+  double energyError = 999.;
+  double ecalEnergy = electron.correctedEcalEnergy();
+  double eleEta = electron.superCluster()->eta();
+  double brem = electron.superCluster()->etaWidth() / electron.superCluster()->phiWidth();
+  energyError = uncertainty.computeElectronEnergyUncertainty(electron.classification(), eleEta, brem, ecalEnergy);
+  electron.setCorrectedEcalEnergyError(energyError);
+}
 
-float energyError( float E, float * par )
- { return sqrt( pow(par[0]/sqrt(E),2) + pow(par[1]/E,2) + pow(par[2],2) ) ; }
+float energyError(float E, float* par) { return sqrt(pow(par[0] / sqrt(E), 2) + pow(par[1] / E, 2) + pow(par[2], 2)); }
 
-void ElectronEnergyCorrector::simpleParameterizationUncertainty( reco::GsfElectron & electron )
- {
-  double error = 999. ;
-  double ecalEnergy = electron.correctedEcalEnergy() ;
+void ElectronEnergyCorrector::simpleParameterizationUncertainty(reco::GsfElectron& electron) {
+  double error = 999.;
+  double ecalEnergy = electron.correctedEcalEnergy();
 
-  if (electron.isEB())
-   {
-    float parEB[3] = { 5.24e-02,  2.01e-01, 1.00e-02} ;
-    error =  ecalEnergy*energyError(ecalEnergy,parEB) ;
-   }
-  else if (electron.isEE())
-   {
-    float parEE[3] = { 1.46e-01, 9.21e-01, 1.94e-03} ;
-    error =  ecalEnergy*energyError(ecalEnergy,parEE) ;
-   }
-  else
-   { edm::LogWarning("ElectronEnergyCorrector::simpleParameterizationUncertainty")<<"nor barrel neither endcap electron !" ; }
+  if (electron.isEB()) {
+    float parEB[3] = {5.24e-02, 2.01e-01, 1.00e-02};
+    error = ecalEnergy * energyError(ecalEnergy, parEB);
+  } else if (electron.isEE()) {
+    float parEE[3] = {1.46e-01, 9.21e-01, 1.94e-03};
+    error = ecalEnergy * energyError(ecalEnergy, parEE);
+  } else {
+    edm::LogWarning("ElectronEnergyCorrector::simpleParameterizationUncertainty")
+        << "nor barrel neither endcap electron !";
+  }
 
-  electron.setCorrectedEcalEnergyError(error) ;
- }
+  electron.setCorrectedEcalEnergyError(error);
+}
 
-void ElectronEnergyCorrector::classBasedParameterizationEnergy
- ( reco::GsfElectron & electron, const reco::BeamSpot & bs )
- {
-  if (electron.isEcalEnergyCorrected())
-   {
-	  edm::LogWarning("ElectronEnergyCorrector::classBasedParameterizationEnergy")<<"already done" ;
-	  return ;
-   }
+void ElectronEnergyCorrector::classBasedParameterizationEnergy(reco::GsfElectron& electron, const reco::BeamSpot& bs) {
+  if (electron.isEcalEnergyCorrected()) {
+    edm::LogWarning("ElectronEnergyCorrector::classBasedParameterizationEnergy") << "already done";
+    return;
+  }
 
-  reco::GsfElectron::Classification elClass = electron.classification() ;
-  if ( (elClass <= reco::GsfElectron::UNKNOWN) ||
-	     (elClass>reco::GsfElectron::GAP) )
-   {
-	  edm::LogWarning("ElectronEnergyCorrector::classBasedParameterizationEnergy")<<"unexpected classification" ;
-	  return ;
-   }
+  reco::GsfElectron::Classification elClass = electron.classification();
+  if ((elClass <= reco::GsfElectron::UNKNOWN) || (elClass > reco::GsfElectron::GAP)) {
+    edm::LogWarning("ElectronEnergyCorrector::classBasedParameterizationEnergy") << "unexpected classification";
+    return;
+  }
 
   // new corrections from N. Chanon et al., taken from EcalClusterCorrectionObjectSpecific.cc
   float corr = 1.;
   float corr2 = 1.;
-  float energy = electron.superCluster()->energy() ;
+  float energy = electron.superCluster()->energy();
 
   //int subdet = electron.superCluster()->seed()->hitsAndFractions()[0].first.subdetId();
 
-  if (electron.isEB())
-   {
-    float cetacorr = fEta(electron.superCluster()->rawEnergy(), electron.superCluster()->eta(), 0)/electron.superCluster()->rawEnergy();
-    energy = electron.superCluster()->rawEnergy()*cetacorr; //previously in CMSSW
+  if (electron.isEB()) {
+    float cetacorr = fEta(electron.superCluster()->rawEnergy(), electron.superCluster()->eta(), 0) /
+                     electron.superCluster()->rawEnergy();
+    energy = electron.superCluster()->rawEnergy() * cetacorr;  //previously in CMSSW
     //energy = superCluster.rawEnergy()*fEta(e5x5, superCluster.seed()->eta(), 0)/e5x5;
-   }
-  else if (electron.isEE())
-   {
-    energy = electron.superCluster()->rawEnergy()+electron.superCluster()->preshowerEnergy();
-   }
-  else
-   { edm::LogWarning("ElectronEnergyCorrector::classBasedParameterizationEnergy")<<"nor barrel neither endcap electron !" ; }
+  } else if (electron.isEE()) {
+    energy = electron.superCluster()->rawEnergy() + electron.superCluster()->preshowerEnergy();
+  } else {
+    edm::LogWarning("ElectronEnergyCorrector::classBasedParameterizationEnergy")
+        << "nor barrel neither endcap electron !";
+  }
 
-  corr = fBremEta(electron.superCluster()->phiWidth()/electron.superCluster()->etaWidth(), electron.superCluster()->eta(), 0,elClass);
+  corr = fBremEta(electron.superCluster()->phiWidth() / electron.superCluster()->etaWidth(),
+                  electron.superCluster()->eta(),
+                  0,
+                  elClass);
 
-  float et = energy*TMath::Sin(2*TMath::ATan(TMath::Exp(-electron.superCluster()->eta())))/corr;
+  float et = energy * TMath::Sin(2 * TMath::ATan(TMath::Exp(-electron.superCluster()->eta()))) / corr;
 
-  if (electron.isEB()) { corr2 = corr * fEt(et, 0,elClass) ; }
-  else if (electron.isEE()) { corr2 = corr * fEnergy(energy/corr, 1,elClass) ; }
-  else { edm::LogWarning("ElectronEnergyCorrector::classBasedParameterizationEnergy")<<"nor barrel neither endcap electron !" ; }
+  if (electron.isEB()) {
+    corr2 = corr * fEt(et, 0, elClass);
+  } else if (electron.isEE()) {
+    corr2 = corr * fEnergy(energy / corr, 1, elClass);
+  } else {
+    edm::LogWarning("ElectronEnergyCorrector::classBasedParameterizationEnergy")
+        << "nor barrel neither endcap electron !";
+  }
 
-  float newEnergy = energy/corr2;
+  float newEnergy = energy / corr2;
 
   // cracks
-  double crackcor = 1. ;
-  for ( reco::CaloCluster_iterator
-        cIt = electron.superCluster()->clustersBegin() ;
-        cIt != electron.superCluster()->clustersEnd() ;
-        ++cIt )
-   {
-    const reco::CaloClusterPtr cc = *cIt ;
-    crackcor *=
-     ( electron.superCluster()->rawEnergy()
-       + cc->energy()*(crackCorrectionFunction_->getValue(*cc)-1.) )
-     / electron.superCluster()->rawEnergy() ;
-   }
-  newEnergy *= crackcor ;
+  double crackcor = 1.;
+  for (reco::CaloCluster_iterator cIt = electron.superCluster()->clustersBegin();
+       cIt != electron.superCluster()->clustersEnd();
+       ++cIt) {
+    const reco::CaloClusterPtr cc = *cIt;
+    crackcor *= (electron.superCluster()->rawEnergy() + cc->energy() * (crackCorrectionFunction_->getValue(*cc) - 1.)) /
+                electron.superCluster()->rawEnergy();
+  }
+  newEnergy *= crackcor;
 
   // register final value
-  electron.setCorrectedEcalEnergy(newEnergy) ;
-
- }
+  electron.setCorrectedEcalEnergy(newEnergy);
+}
 
 // main correction function
 // new corrections: taken from EcalClusterCorrectionObjectSpecific.cc (N. Chanon et al.)
 // this is to prepare for class based corrections, for the time being the parameters are the same as for the SC corrections
 // code fully duplicated here, to be improved; electron means algorithm==0 and mode==0
 
-float ElectronEnergyCorrector::fEta(float energy, float eta, int algorithm) const
-{
-
+float ElectronEnergyCorrector::fEta(float energy, float eta, int algorithm) const {
   // corrections for electrons
-  if (algorithm!=0) {
-    edm::LogWarning("ElectronEnergyCorrector::fEta")<<"algorithm should be 0 for electrons !" ;
+  if (algorithm != 0) {
+    edm::LogWarning("ElectronEnergyCorrector::fEta") << "algorithm should be 0 for electrons !";
     return energy;
   }
   //std::cout << "fEta function" << std::endl;
 
   // this correction is setup only for EB
-  if ( algorithm != 0 ) return energy;
+  if (algorithm != 0)
+    return energy;
 
-  float ieta = fabs(eta)*(5/0.087);
+  float ieta = fabs(eta) * (5 / 0.087);
   // bypass the DB reading for the time being
   //float p0 = (params_->params())[0];  // should be 40.2198
   //float p1 = (params_->params())[1];  // should be -3.03103e-6
-  float p0 = 40.2198 ;
-  float p1 = -3.03103e-6 ;
+  float p0 = 40.2198;
+  float p1 = -3.03103e-6;
 
   //std::cout << "ieta=" << ieta << std::endl;
 
   float correctedEnergy = energy;
-  if ( ieta < p0 ) correctedEnergy = energy;
-  else             correctedEnergy = energy/(1.0 + p1*(ieta-p0)*(ieta-p0));
+  if (ieta < p0)
+    correctedEnergy = energy;
+  else
+    correctedEnergy = energy / (1.0 + p1 * (ieta - p0) * (ieta - p0));
   //std::cout << "ECEC fEta = " << correctedEnergy << std::endl;
   return correctedEnergy;
+}
 
- }
-
-float ElectronEnergyCorrector::fBremEta
- ( float sigmaPhiSigmaEta, float eta, int algorithm, reco::GsfElectron::Classification cl ) const
- {
+float ElectronEnergyCorrector::fBremEta(float sigmaPhiSigmaEta,
+                                        float eta,
+                                        int algorithm,
+                                        reco::GsfElectron::Classification cl) const {
   // corrections for electrons
-  if (algorithm!=0)
-   {
-    edm::LogWarning("ElectronEnergyCorrector::fBremEta")<<"algorithm should be 0 for electrons !" ;
-    return 1. ;
-   }
+  if (algorithm != 0) {
+    edm::LogWarning("ElectronEnergyCorrector::fBremEta") << "algorithm should be 0 for electrons !";
+    return 1.;
+  }
 
-  const float etaCrackMin = 1.44 ;
-  const float etaCrackMax = 1.56 ;
+  const float etaCrackMin = 1.44;
+  const float etaCrackMax = 1.56;
 
   //STD
-  const int nBinsEta = 14 ;
-  float leftEta[nBinsEta] = { 0.02, 0.25, 0.46, 0.81, 0.91, 1.01, 1.16, etaCrackMax, 1.653, 1.8, 2.0, 2.2, 2.3, 2.4 } ;
-  float rightEta[nBinsEta] = { 0.25, 0.42, 0.77, 0.91, 1.01, 1.13, etaCrackMin, 1.653, 1.8, 2.0, 2.2, 2.3, 2.4, 2.5 } ;
+  const int nBinsEta = 14;
+  float leftEta[nBinsEta] = {0.02, 0.25, 0.46, 0.81, 0.91, 1.01, 1.16, etaCrackMax, 1.653, 1.8, 2.0, 2.2, 2.3, 2.4};
+  float rightEta[nBinsEta] = {0.25, 0.42, 0.77, 0.91, 1.01, 1.13, etaCrackMin, 1.653, 1.8, 2.0, 2.2, 2.3, 2.4, 2.5};
 
   // eta = 0
-  if ( TMath::Abs(eta) < leftEta[0] ) { eta = 0.02 ; }
+  if (TMath::Abs(eta) < leftEta[0]) {
+    eta = 0.02;
+  }
 
   // outside acceptance
-  if ( TMath::Abs(eta) >= rightEta[nBinsEta-1] ) { eta = 2.49 ; } //if (DBG) std::cout << " WARNING [applyScCorrections]: TMath::Abs(eta)  >=  rightEta[nBinsEta-1] " << std::endl;}
+  if (TMath::Abs(eta) >= rightEta[nBinsEta - 1]) {
+    eta = 2.49;
+  }  //if (DBG) std::cout << " WARNING [applyScCorrections]: TMath::Abs(eta)  >=  rightEta[nBinsEta-1] " << std::endl;}
 
-  int tmpEta = -1 ;
-  for (int iEta = 0; iEta < nBinsEta; ++iEta)
-   {
-    if ( leftEta[iEta] <= TMath::Abs(eta) && TMath::Abs(eta) <rightEta[iEta] )
-     { tmpEta = iEta ; }
-   }
+  int tmpEta = -1;
+  for (int iEta = 0; iEta < nBinsEta; ++iEta) {
+    if (leftEta[iEta] <= TMath::Abs(eta) && TMath::Abs(eta) < rightEta[iEta]) {
+      tmpEta = iEta;
+    }
+  }
 
-  float xcorr[nBinsEta][reco::GsfElectron::GAP+1] =
-   {
-     { 1.00227,  1.00227,  1.00227,  1.00227,  1.00227  },
-     { 1.00252,  1.00252,  1.00252,  1.00252,  1.00252  },
-     { 1.00225,  1.00225,  1.00225,  1.00225,  1.00225  },
-     { 1.00159,  1.00159,  1.00159,  1.00159,  1.00159  },
-     { 0.999475, 0.999475, 0.999475, 0.999475, 0.999475 },
-     { 0.997203, 0.997203, 0.997203, 0.997203, 0.997203 },
-     { 0.993886, 0.993886, 0.993886, 0.993886, 0.993886 },
-     { 0.971262, 0.971262, 0.971262, 0.971262, 0.971262 },
-     { 0.975922, 0.975922, 0.975922, 0.975922, 0.975922 },
-     { 0.979087, 0.979087, 0.979087, 0.979087, 0.979087 },
-     { 0.98495,  0.98495,  0.98495,  0.98495,  0.98495  },
-     { 0.98781,  0.98781,  0.98781,  0.98781,  0.98781  },
-     { 0.989546, 0.989546, 0.989546, 0.989546, 0.989546 },
-     { 0.989638, 0.989638, 0.989638, 0.989638, 0.989638 }
-   } ;
+  float xcorr[nBinsEta][reco::GsfElectron::GAP + 1] = {{1.00227, 1.00227, 1.00227, 1.00227, 1.00227},
+                                                       {1.00252, 1.00252, 1.00252, 1.00252, 1.00252},
+                                                       {1.00225, 1.00225, 1.00225, 1.00225, 1.00225},
+                                                       {1.00159, 1.00159, 1.00159, 1.00159, 1.00159},
+                                                       {0.999475, 0.999475, 0.999475, 0.999475, 0.999475},
+                                                       {0.997203, 0.997203, 0.997203, 0.997203, 0.997203},
+                                                       {0.993886, 0.993886, 0.993886, 0.993886, 0.993886},
+                                                       {0.971262, 0.971262, 0.971262, 0.971262, 0.971262},
+                                                       {0.975922, 0.975922, 0.975922, 0.975922, 0.975922},
+                                                       {0.979087, 0.979087, 0.979087, 0.979087, 0.979087},
+                                                       {0.98495, 0.98495, 0.98495, 0.98495, 0.98495},
+                                                       {0.98781, 0.98781, 0.98781, 0.98781, 0.98781},
+                                                       {0.989546, 0.989546, 0.989546, 0.989546, 0.989546},
+                                                       {0.989638, 0.989638, 0.989638, 0.989638, 0.989638}};
 
-  float par0[nBinsEta][reco::GsfElectron::GAP+1] =
-   {
-     { 0.994949, 1.00718, 1.00718, 1.00556, 1.00718 },
-     { 1.009,  1.00713,  1.00713,  1.00248,  1.00713 },
-     { 0.999395, 1.00641,  1.00641,  1.00293,  1.00641 },
-     { 0.988662, 1.00761,  1.001,  0.99972,  1.00761 },
-     { 0.998443, 1.00682,  1.001,  1.00282, 1.00682 },
-     { 1.00285,  1.0073,  1.001,  1.00396,  1.0073 },
-     { 0.993053, 1.00462,  1.01341,  1.00184,  1.00462 },
-     { 1.10561,  0.972798, 1.02835,  0.995218, 0.972798 },
-     { 0.893741, 0.981672, 0.98982,  1.01712,  0.981672 },
-     { 0.911123, 0.98251,  1.03466,  1.00824,  0.98251 },
-     { 0.981931, 0.986123, 0.954295, 1.0202,  0.986123 },
-     { 0.905634, 0.990124, 0.928934, 0.998492, 0.990124 },
-     { 0.919343, 0.990187, 0.967526, 0.963923, 0.990187 },
-     { 0.844783, 0.99372,  0.923808, 0.953001, 0.99372 }
-   } ;
+  float par0[nBinsEta][reco::GsfElectron::GAP + 1] = {{0.994949, 1.00718, 1.00718, 1.00556, 1.00718},
+                                                      {1.009, 1.00713, 1.00713, 1.00248, 1.00713},
+                                                      {0.999395, 1.00641, 1.00641, 1.00293, 1.00641},
+                                                      {0.988662, 1.00761, 1.001, 0.99972, 1.00761},
+                                                      {0.998443, 1.00682, 1.001, 1.00282, 1.00682},
+                                                      {1.00285, 1.0073, 1.001, 1.00396, 1.0073},
+                                                      {0.993053, 1.00462, 1.01341, 1.00184, 1.00462},
+                                                      {1.10561, 0.972798, 1.02835, 0.995218, 0.972798},
+                                                      {0.893741, 0.981672, 0.98982, 1.01712, 0.981672},
+                                                      {0.911123, 0.98251, 1.03466, 1.00824, 0.98251},
+                                                      {0.981931, 0.986123, 0.954295, 1.0202, 0.986123},
+                                                      {0.905634, 0.990124, 0.928934, 0.998492, 0.990124},
+                                                      {0.919343, 0.990187, 0.967526, 0.963923, 0.990187},
+                                                      {0.844783, 0.99372, 0.923808, 0.953001, 0.99372}};
 
-  float par1[nBinsEta][reco::GsfElectron::GAP+1] =
-   {
-     { 0.0111034, -0.00187886, -0.00187886, -0.00289304, -0.00187886 },
-     { -0.00969012, -0.00227574, -0.00227574, -0.00182187, -0.00227574 },
-     { 0.00389454,  -0.00259935,  -0.00259935, -0.00211059, -0.00259935 },
-     { 0.017095, -0.00433692, -0.00302335, -0.00241385, -0.00433692 },
-     { -0.00049009, -0.00551324,  -0.00302335, -0.00532352, -0.00551324 },
-     { -0.00252723, -0.00799669,  -0.00302335, -0.00823109, -0.00799669 },
-     { 0.00332567,  -0.00870057,  -0.0170581,  -0.011482,  -0.00870057 },
-     { -0.213285,  -0.000771577, -0.036007,  -0.0187526,  -0.000771577 },
-     { 0.1741,  -0.00202028,  -0.0233995,  -0.0302066,  -0.00202028 },
-     { 0.152794,  0.00441308,  -0.0468563,  -0.0158817,  0.00441308 },
-     { 0.0351465,  0.00832913,  0.0358028,  -0.0233262,  0.00832913 },
-     { 0.185781,  0.00742879,  0.08858,  0.00568078,  0.00742879 },
-     { 0.153088,  0.0094608,  0.0489979,  0.0491897,  0.0094608 },
-     { 0.296681,  0.00560406,  0.106492,  0.0652007,  0.00560406 }
-   } ;
+  float par1[nBinsEta][reco::GsfElectron::GAP + 1] = {{0.0111034, -0.00187886, -0.00187886, -0.00289304, -0.00187886},
+                                                      {-0.00969012, -0.00227574, -0.00227574, -0.00182187, -0.00227574},
+                                                      {0.00389454, -0.00259935, -0.00259935, -0.00211059, -0.00259935},
+                                                      {0.017095, -0.00433692, -0.00302335, -0.00241385, -0.00433692},
+                                                      {-0.00049009, -0.00551324, -0.00302335, -0.00532352, -0.00551324},
+                                                      {-0.00252723, -0.00799669, -0.00302335, -0.00823109, -0.00799669},
+                                                      {0.00332567, -0.00870057, -0.0170581, -0.011482, -0.00870057},
+                                                      {-0.213285, -0.000771577, -0.036007, -0.0187526, -0.000771577},
+                                                      {0.1741, -0.00202028, -0.0233995, -0.0302066, -0.00202028},
+                                                      {0.152794, 0.00441308, -0.0468563, -0.0158817, 0.00441308},
+                                                      {0.0351465, 0.00832913, 0.0358028, -0.0233262, 0.00832913},
+                                                      {0.185781, 0.00742879, 0.08858, 0.00568078, 0.00742879},
+                                                      {0.153088, 0.0094608, 0.0489979, 0.0491897, 0.0094608},
+                                                      {0.296681, 0.00560406, 0.106492, 0.0652007, 0.00560406}};
 
-  float par2[nBinsEta][reco::GsfElectron::GAP+1] =
-   {
-     { -0.00330844, 0, 0, 5.62441e-05,  0 },
-     { 0.00329373,  0,  0,  -0.000113883,  0 },
-     { -0.00104661,  0,  0,  -0.000152794,  0 },
-     { -0.0060409,  0,  -0.000257724, -0.000202099,  0 },
-     { -0.000742866, 0,  -0.000257724, -2.06003e-05,  0 },
-     { -0.00205425,  0,  -0.000257724, 3.84179e-05,   0 },
-     { -0.00350757,  0,  0.000590483,  0.000323723,   0 },
-     { 0.0794596,  -0.00276696, 0.00205854,  0.000356716,   -0.00276696 },
-     { -0.092436,  -0.00471028, 0.00062096,  0.00088347,   -0.00471028 },
-     { -0.0855029,  -0.00809139, 0.00284102,  -0.00366903,   -0.00809139 },
-     { -0.0306209,  -0.00944584, -0.0145892,  -0.00176969,   -0.00944584 },
-     { -0.0996414,  -0.00960462, -0.0328264,  -0.00983844,   -0.00960462 },
-     { -0.0784107,  -0.010172,  -0.0256722,  -0.0215133,   -0.010172 },
-     { -0.145815,  -0.00943169, -0.0414525,  -0.027087,   -0.00943169 }
-   } ;
+  float par2[nBinsEta][reco::GsfElectron::GAP + 1] = {{-0.00330844, 0, 0, 5.62441e-05, 0},
+                                                      {0.00329373, 0, 0, -0.000113883, 0},
+                                                      {-0.00104661, 0, 0, -0.000152794, 0},
+                                                      {-0.0060409, 0, -0.000257724, -0.000202099, 0},
+                                                      {-0.000742866, 0, -0.000257724, -2.06003e-05, 0},
+                                                      {-0.00205425, 0, -0.000257724, 3.84179e-05, 0},
+                                                      {-0.00350757, 0, 0.000590483, 0.000323723, 0},
+                                                      {0.0794596, -0.00276696, 0.00205854, 0.000356716, -0.00276696},
+                                                      {-0.092436, -0.00471028, 0.00062096, 0.00088347, -0.00471028},
+                                                      {-0.0855029, -0.00809139, 0.00284102, -0.00366903, -0.00809139},
+                                                      {-0.0306209, -0.00944584, -0.0145892, -0.00176969, -0.00944584},
+                                                      {-0.0996414, -0.00960462, -0.0328264, -0.00983844, -0.00960462},
+                                                      {-0.0784107, -0.010172, -0.0256722, -0.0215133, -0.010172},
+                                                      {-0.145815, -0.00943169, -0.0414525, -0.027087, -0.00943169}};
 
-  float sigmaPhiSigmaEtaMin[reco::GsfElectron::GAP+1] = { 0.8, 0.8, 0.8, 0.8, 0.8 } ;
-  float sigmaPhiSigmaEtaMax[reco::GsfElectron::GAP+1] = { 5., 5., 5., 5., 5. } ;
-  float sigmaPhiSigmaEtaFit[reco::GsfElectron::GAP+1] = { 1.2, 1.2, 1.2, 1.2, 1.2 } ;
+  float sigmaPhiSigmaEtaMin[reco::GsfElectron::GAP + 1] = {0.8, 0.8, 0.8, 0.8, 0.8};
+  float sigmaPhiSigmaEtaMax[reco::GsfElectron::GAP + 1] = {5., 5., 5., 5., 5.};
+  float sigmaPhiSigmaEtaFit[reco::GsfElectron::GAP + 1] = {1.2, 1.2, 1.2, 1.2, 1.2};
 
   // extra protections
   // fix sigmaPhiSigmaEta boundaries
-  if ( sigmaPhiSigmaEta < sigmaPhiSigmaEtaMin[cl] )
-   { sigmaPhiSigmaEta = sigmaPhiSigmaEtaMin[cl] ; }
-  if ( sigmaPhiSigmaEta > sigmaPhiSigmaEtaMax[cl]  )
-   { sigmaPhiSigmaEta = sigmaPhiSigmaEtaMax[cl] ; }
+  if (sigmaPhiSigmaEta < sigmaPhiSigmaEtaMin[cl]) {
+    sigmaPhiSigmaEta = sigmaPhiSigmaEtaMin[cl];
+  }
+  if (sigmaPhiSigmaEta > sigmaPhiSigmaEtaMax[cl]) {
+    sigmaPhiSigmaEta = sigmaPhiSigmaEtaMax[cl];
+  }
 
   // In eta cracks/gaps
-  if ( tmpEta == -1 ) // need to interpolate
-   {
-    float tmpInter = 1 ;
-    for ( int iEta = 0 ; iEta < nBinsEta-1 ; ++iEta )
-     {
-      if ( rightEta[iEta] <= TMath::Abs(eta) && TMath::Abs(eta) <leftEta[iEta+1] )
-       {
-        if ( sigmaPhiSigmaEta >= sigmaPhiSigmaEtaFit[cl] )
-         {
-	        tmpInter =
-	         ( par0[iEta][cl] +
-	           sigmaPhiSigmaEta*par1[iEta][cl] +
-	           sigmaPhiSigmaEta*sigmaPhiSigmaEta*par2[iEta][cl] +
-             par0[iEta+1][cl] +
-             sigmaPhiSigmaEta*par1[iEta+1][cl] +
-             sigmaPhiSigmaEta*sigmaPhiSigmaEta*par2[iEta+1][cl] ) / 2. ;
-         }
-	      else tmpInter = (xcorr[iEta][cl] + xcorr[iEta+1][cl])/2. ;
-       }
-     }
-    return tmpInter ;
-   }
+  if (tmpEta == -1)  // need to interpolate
+  {
+    float tmpInter = 1;
+    for (int iEta = 0; iEta < nBinsEta - 1; ++iEta) {
+      if (rightEta[iEta] <= TMath::Abs(eta) && TMath::Abs(eta) < leftEta[iEta + 1]) {
+        if (sigmaPhiSigmaEta >= sigmaPhiSigmaEtaFit[cl]) {
+          tmpInter =
+              (par0[iEta][cl] + sigmaPhiSigmaEta * par1[iEta][cl] +
+               sigmaPhiSigmaEta * sigmaPhiSigmaEta * par2[iEta][cl] + par0[iEta + 1][cl] +
+               sigmaPhiSigmaEta * par1[iEta + 1][cl] + sigmaPhiSigmaEta * sigmaPhiSigmaEta * par2[iEta + 1][cl]) /
+              2.;
+        } else
+          tmpInter = (xcorr[iEta][cl] + xcorr[iEta + 1][cl]) / 2.;
+      }
+    }
+    return tmpInter;
+  }
 
-  if (sigmaPhiSigmaEta >= sigmaPhiSigmaEtaFit[cl])
-   { return par0[tmpEta][cl] + sigmaPhiSigmaEta*par1[tmpEta][cl] + sigmaPhiSigmaEta*sigmaPhiSigmaEta*par2[tmpEta][cl] ; }
-  else
-   { return xcorr[tmpEta][cl] ; }
+  if (sigmaPhiSigmaEta >= sigmaPhiSigmaEtaFit[cl]) {
+    return par0[tmpEta][cl] + sigmaPhiSigmaEta * par1[tmpEta][cl] +
+           sigmaPhiSigmaEta * sigmaPhiSigmaEta * par2[tmpEta][cl];
+  } else {
+    return xcorr[tmpEta][cl];
+  }
 
-  return 1. ;
- }
-
-float ElectronEnergyCorrector::fEt(float ET, int algorithm, reco::GsfElectron::Classification cl ) const
- {
-  if (algorithm==0) //Electrons EB
-   {
-    const float parClassIndep[5] = { 0.97213, 0.999528, 5.61192e-06, 0.0143269, -17.1776 } ;
-    const float par[reco::GsfElectron::GAP+1][5] =
-     {
-       { 0.974327, 0.996127, 5.99401e-05, 0.159813, -3.80392 },
-       { 0.97213, 0.999528, 5.61192e-06, 0.0143269, -17.1776 },
-       { 0.940666, 0.988894, 0.00017474, 0.25603, -4.58153 },
-       { 0.969526, 0.98572, 0.000193842, 4.21548, -1.37159 },
-       { parClassIndep[0], parClassIndep[1], parClassIndep[2], parClassIndep[3], parClassIndep[4] }
-     } ;
-    if ( ET > 200 ) { ET = 200 ; }
-    if ( ET > 100 ) { return (parClassIndep[1]+ET*parClassIndep[2]) * (1-parClassIndep[3]*exp(ET/parClassIndep[4])) ; }
-    if ( ET >= 10 ) { return (par[cl][1]+ET*par[cl][2]) * (1-par[cl][3]*exp(ET/par[cl][4])) ; }
-    if ( ET >=5 ) { return par[cl][0] ; }
-    return 1. ;
-   }
-  else if (algorithm==1) //Electrons EE
-   {
-    float par[reco::GsfElectron::GAP+1][5] =
-     {
-       { 0.930081, 0.996683, 3.54079e-05, 0.0460187, -23.2461 },
-       { 0.930081, 0.996683, 3.54079e-05, 0.0460187, -23.2461 },
-       { 0.930081, 0.996683, 3.54079e-05, 0.0460187, -23.2461 },
-       { 0.930081, 0.996683, 3.54079e-05, 0.0460187, -23.2461 },
-       { 0.930081, 0.996683, 3.54079e-05, 0.0460187, -23.2461 }
-     };
-    if ( ET > 200 ) { ET = 200 ; }
-    if ( ET < 5 ) { return 1. ; }
-    if ( 5 <= ET && ET < 10 ) { return par[cl][0] ; }
-    if ( 10 <= ET && ET <= 200 ) { return ( par[cl][1]  + ET*par[cl][2])*(1-par[cl][3]*exp(ET/par[cl][4])) ; }
-   }
-  else
-   { edm::LogWarning("ElectronEnergyCorrector::fEt")<<"algorithm should be 0 or 1 for electrons !" ; }
-  return 1. ;
- }
-
-float ElectronEnergyCorrector::fEnergy(float E, int algorithm, reco::GsfElectron::Classification cl ) const
- {
-  if (algorithm==0) // Electrons EB
-   { return 1. ; }
-  else if (algorithm==1) // Electrons EE
-   {
-    float par0[reco::GsfElectron::GAP+1] = { 400, 400, 400, 400, 400 } ;
-    float par1[reco::GsfElectron::GAP+1] = { 0.999545, 0.982475, 0.986217, 0.996763, 0.982475 } ;
-    float par2[reco::GsfElectron::GAP+1] = { 1.26568e-05, 4.95413e-05, 5.02161e-05, 2.8485e-06, 4.95413e-05 } ;
-    float par3[reco::GsfElectron::GAP+1] = { 0.0696757, 0.16886, 0.115317, 0.12098, 0.16886 } ;
-    float par4[reco::GsfElectron::GAP+1] = { -54.3468, -30.1517, -26.3805, -62.0538, -30.1517 } ;
-
-    if ( E > par0[cl] ) { E = par0[cl] ; }
-    if ( E < 0 ) { return 1. ; }
-    if ( 0 <= E && E <= par0[cl] ) { return (par1[cl] + E*par2[cl] )*(1- par3[cl]*exp(E/par4[cl] )) ; }
-   }
-  else
-   { edm::LogWarning("ElectronEnergyCorrector::fEnergy")<<"algorithm should be 0 or 1 for electrons !" ; }
   return 1.;
- }
+}
 
+float ElectronEnergyCorrector::fEt(float ET, int algorithm, reco::GsfElectron::Classification cl) const {
+  if (algorithm == 0)  //Electrons EB
+  {
+    const float parClassIndep[5] = {0.97213, 0.999528, 5.61192e-06, 0.0143269, -17.1776};
+    const float par[reco::GsfElectron::GAP + 1][5] = {
+        {0.974327, 0.996127, 5.99401e-05, 0.159813, -3.80392},
+        {0.97213, 0.999528, 5.61192e-06, 0.0143269, -17.1776},
+        {0.940666, 0.988894, 0.00017474, 0.25603, -4.58153},
+        {0.969526, 0.98572, 0.000193842, 4.21548, -1.37159},
+        {parClassIndep[0], parClassIndep[1], parClassIndep[2], parClassIndep[3], parClassIndep[4]}};
+    if (ET > 200) {
+      ET = 200;
+    }
+    if (ET > 100) {
+      return (parClassIndep[1] + ET * parClassIndep[2]) * (1 - parClassIndep[3] * exp(ET / parClassIndep[4]));
+    }
+    if (ET >= 10) {
+      return (par[cl][1] + ET * par[cl][2]) * (1 - par[cl][3] * exp(ET / par[cl][4]));
+    }
+    if (ET >= 5) {
+      return par[cl][0];
+    }
+    return 1.;
+  } else if (algorithm == 1)  //Electrons EE
+  {
+    float par[reco::GsfElectron::GAP + 1][5] = {{0.930081, 0.996683, 3.54079e-05, 0.0460187, -23.2461},
+                                                {0.930081, 0.996683, 3.54079e-05, 0.0460187, -23.2461},
+                                                {0.930081, 0.996683, 3.54079e-05, 0.0460187, -23.2461},
+                                                {0.930081, 0.996683, 3.54079e-05, 0.0460187, -23.2461},
+                                                {0.930081, 0.996683, 3.54079e-05, 0.0460187, -23.2461}};
+    if (ET > 200) {
+      ET = 200;
+    }
+    if (ET < 5) {
+      return 1.;
+    }
+    if (5 <= ET && ET < 10) {
+      return par[cl][0];
+    }
+    if (10 <= ET && ET <= 200) {
+      return (par[cl][1] + ET * par[cl][2]) * (1 - par[cl][3] * exp(ET / par[cl][4]));
+    }
+  } else {
+    edm::LogWarning("ElectronEnergyCorrector::fEt") << "algorithm should be 0 or 1 for electrons !";
+  }
+  return 1.;
+}
+
+float ElectronEnergyCorrector::fEnergy(float E, int algorithm, reco::GsfElectron::Classification cl) const {
+  if (algorithm == 0)  // Electrons EB
+  {
+    return 1.;
+  } else if (algorithm == 1)  // Electrons EE
+  {
+    float par0[reco::GsfElectron::GAP + 1] = {400, 400, 400, 400, 400};
+    float par1[reco::GsfElectron::GAP + 1] = {0.999545, 0.982475, 0.986217, 0.996763, 0.982475};
+    float par2[reco::GsfElectron::GAP + 1] = {1.26568e-05, 4.95413e-05, 5.02161e-05, 2.8485e-06, 4.95413e-05};
+    float par3[reco::GsfElectron::GAP + 1] = {0.0696757, 0.16886, 0.115317, 0.12098, 0.16886};
+    float par4[reco::GsfElectron::GAP + 1] = {-54.3468, -30.1517, -26.3805, -62.0538, -30.1517};
+
+    if (E > par0[cl]) {
+      E = par0[cl];
+    }
+    if (E < 0) {
+      return 1.;
+    }
+    if (0 <= E && E <= par0[cl]) {
+      return (par1[cl] + E * par2[cl]) * (1 - par3[cl] * exp(E / par4[cl]));
+    }
+  } else {
+    edm::LogWarning("ElectronEnergyCorrector::fEnergy") << "algorithm should be 0 or 1 for electrons !";
+  }
+  return 1.;
+}
 
 //==========================================================================
 //
 //==========================================================================
 
-double ElectronEnergyCorrector::fEtaBarrelGood( double scEta ) const
- {
+double ElectronEnergyCorrector::fEtaBarrelGood(double scEta) const {
   // f(eta) for the first 3 classes (0, 10 and 20) (estimated from 1Mevt single e sample)
   // Ivica's new corrections 01/06
-  float p0 =  1.00149e+00 ;
-  float p1 = -2.06622e-03 ;
-  float p2 = -1.08793e-02 ;
-  float p3 =  1.54392e-02 ;
-  float p4 = -1.02056e-02 ;
-  double x  = (double) std::abs(scEta) ;
-  return p0 + p1*x + p2*x*x + p3*x*x*x + p4*x*x*x*x ;
- }
+  float p0 = 1.00149e+00;
+  float p1 = -2.06622e-03;
+  float p2 = -1.08793e-02;
+  float p3 = 1.54392e-02;
+  float p4 = -1.02056e-02;
+  double x = (double)std::abs(scEta);
+  return p0 + p1 * x + p2 * x * x + p3 * x * x * x + p4 * x * x * x * x;
+}
 
-double ElectronEnergyCorrector::fEtaBarrelBad(double scEta) const
- {
+double ElectronEnergyCorrector::fEtaBarrelBad(double scEta) const {
   // f(eta) for the class = 30 (estimated from 1Mevt single e sample)
   // Ivica's new corrections 01/06
-  float p0 =  9.99063e-01;
+  float p0 = 9.99063e-01;
   float p1 = -2.63341e-02;
-  float p2 =  5.16054e-02;
+  float p2 = 5.16054e-02;
   float p3 = -4.95976e-02;
-  float p4 =  3.62304e-03;
-  double x  = (double) std::abs(scEta) ;
-  return p0 + p1*x + p2*x*x + p3*x*x*x + p4*x*x*x*x ;
- }
+  float p4 = 3.62304e-03;
+  double x = (double)std::abs(scEta);
+  return p0 + p1 * x + p2 * x * x + p3 * x * x * x + p4 * x * x * x * x;
+}
 
-double ElectronEnergyCorrector::fEtaEndcapGood( double scEta ) const
- {
+double ElectronEnergyCorrector::fEtaEndcapGood(double scEta) const {
   // f(eta) for the first 3 classes (100, 110 and 120)
   // Ivica's new corrections 01/06
-  float p0 = -8.51093e-01 ;
-  float p1 =  3.54266e+00 ;
-  float p2 = -2.59288e+00 ;
-  float p3 = 8.58945e-01 ;
-  float p4 = -1.07844e-01 ;
-  double x  = (double) std::abs(scEta) ;
-  return p0 + p1*x + p2*x*x + p3*x*x*x + p4*x*x*x*x ;
- }
+  float p0 = -8.51093e-01;
+  float p1 = 3.54266e+00;
+  float p2 = -2.59288e+00;
+  float p3 = 8.58945e-01;
+  float p4 = -1.07844e-01;
+  double x = (double)std::abs(scEta);
+  return p0 + p1 * x + p2 * x * x + p3 * x * x * x + p4 * x * x * x * x;
+}
 
-double ElectronEnergyCorrector::fEtaEndcapBad( double scEta ) const
- {
+double ElectronEnergyCorrector::fEtaEndcapBad(double scEta) const {
   // f(eta) for the class = 130-134
   // Ivica's new corrections 01/06
-  float p0 =        -4.25221e+00 ;
-  float p1 =         1.01936e+01 ;
-  float p2 =        -7.48247e+00 ;
-  float p3 =         2.45520e+00 ;
-  float p4 =        -3.02872e-01 ;
-  double x  = (double) std::abs(scEta);
-  return p0 + p1*x + p2*x*x + p3*x*x*x + p4*x*x*x*x ;
- }
-
+  float p0 = -4.25221e+00;
+  float p1 = 1.01936e+01;
+  float p2 = -7.48247e+00;
+  float p3 = 2.45520e+00;
+  float p4 = -3.02872e-01;
+  double x = (double)std::abs(scEta);
+  return p0 + p1 * x + p2 * x * x + p3 * x * x * x + p4 * x * x * x * x;
+}

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronHcalHelper.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronHcalHelper.cc
@@ -6,131 +6,124 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-using namespace reco ;
+using namespace reco;
 
-ElectronHcalHelper::ElectronHcalHelper( const Configuration & cfg  )
-  : cfg_(cfg), caloGeomCacheId_(0), hcalIso_(nullptr), towerIso1_(nullptr), towerIso2_(nullptr),hadTower_(nullptr) 
-{  }
+ElectronHcalHelper::ElectronHcalHelper(const Configuration& cfg)
+    : cfg_(cfg), caloGeomCacheId_(0), hcalIso_(nullptr), towerIso1_(nullptr), towerIso2_(nullptr), hadTower_(nullptr) {}
 
-void ElectronHcalHelper::checkSetup( const edm::EventSetup & es )
- {
+void ElectronHcalHelper::checkSetup(const edm::EventSetup& es) {
+  if (cfg_.hOverEConeSize == 0) {
+    return;
+  }
 
-  if (cfg_.hOverEConeSize==0)
-   { return ; }
+  if (cfg_.useTowers) {
+    delete hadTower_;
+    hadTower_ = new EgammaHadTower(es);
+  } else {
+    unsigned long long newCaloGeomCacheId_ = es.get<CaloGeometryRecord>().cacheIdentifier();
+    if (caloGeomCacheId_ != newCaloGeomCacheId_) {
+      caloGeomCacheId_ = newCaloGeomCacheId_;
+      es.get<CaloGeometryRecord>().get(caloGeom_);
+    }
+  }
+}
 
-  if (cfg_.useTowers)
-   {
-    delete hadTower_ ;
-    hadTower_ = new EgammaHadTower(es) ;
-   }
-  else
-   {
-    unsigned long long newCaloGeomCacheId_
-     = es.get<CaloGeometryRecord>().cacheIdentifier() ;
-    if (caloGeomCacheId_!=newCaloGeomCacheId_)
-     {
-      caloGeomCacheId_ = newCaloGeomCacheId_ ;
-      es.get<CaloGeometryRecord>().get(caloGeom_) ;
-     }
-   }
- }
+void ElectronHcalHelper::readEvent(const edm::Event& evt) {
+  if (cfg_.hOverEConeSize == 0) {
+    return;
+  }
 
-void ElectronHcalHelper::readEvent( const edm::Event & evt )
- {
-  if (cfg_.hOverEConeSize==0)
-   { return ; }
+  if (cfg_.useTowers) {
+    delete towerIso1_;
+    towerIso1_ = nullptr;
+    delete towerIso2_;
+    towerIso2_ = nullptr;
 
-  if (cfg_.useTowers)
-   {
-    delete towerIso1_ ; towerIso1_ = nullptr ;
-    delete towerIso2_ ; towerIso2_ = nullptr ;
-
-    edm::Handle<CaloTowerCollection> towersH_ ;
-    if (!evt.getByToken(cfg_.hcalTowers,towersH_)){
-      edm::LogError("ElectronHcalHelper::readEvent")
-	<<"failed to get the hcal towers"; 
+    edm::Handle<CaloTowerCollection> towersH_;
+    if (!evt.getByToken(cfg_.hcalTowers, towersH_)) {
+      edm::LogError("ElectronHcalHelper::readEvent") << "failed to get the hcal towers";
     }
     hadTower_->setTowerCollection(towersH_.product());
-    towerIso1_ = new EgammaTowerIsolation(cfg_.hOverEConeSize,0.,cfg_.hOverEPtMin,1,towersH_.product()) ;
-    towerIso2_ = new EgammaTowerIsolation(cfg_.hOverEConeSize,0.,cfg_.hOverEPtMin,2,towersH_.product()) ;
-   }
-  else
-   {
-    delete hcalIso_ ; hcalIso_ = nullptr ;
+    towerIso1_ = new EgammaTowerIsolation(cfg_.hOverEConeSize, 0., cfg_.hOverEPtMin, 1, towersH_.product());
+    towerIso2_ = new EgammaTowerIsolation(cfg_.hOverEConeSize, 0., cfg_.hOverEPtMin, 2, towersH_.product());
+  } else {
+    delete hcalIso_;
+    hcalIso_ = nullptr;
 
     edm::Handle<HBHERecHitCollection> hbhe_;
-    if (!evt.getByToken(cfg_.hcalRecHits,hbhe_)) { 
-      edm::LogError("ElectronHcalHelper::readEvent")
-	<<"failed to get the rechits";
+    if (!evt.getByToken(cfg_.hcalRecHits, hbhe_)) {
+      edm::LogError("ElectronHcalHelper::readEvent") << "failed to get the rechits";
     }
 
-    hcalIso_ = new EgammaHcalIsolation(cfg_.hOverEConeSize,0.,cfg_.hOverEHBMinE,cfg_.hOverEHFMinE,0.,0.,caloGeom_, *hbhe_) ;
-   }
- }
+    hcalIso_ = new EgammaHcalIsolation(
+        cfg_.hOverEConeSize, 0., cfg_.hOverEHBMinE, cfg_.hOverEHFMinE, 0., 0., caloGeom_, *hbhe_);
+  }
+}
 
-std::vector<CaloTowerDetId> ElectronHcalHelper::hcalTowersBehindClusters( const reco::SuperCluster & sc ) const
- { return hadTower_->towersOf(sc) ; }
+std::vector<CaloTowerDetId> ElectronHcalHelper::hcalTowersBehindClusters(const reco::SuperCluster& sc) const {
+  return hadTower_->towersOf(sc);
+}
 
-double ElectronHcalHelper::hcalESumDepth1BehindClusters( const std::vector<CaloTowerDetId> & towers ) const
- { return hadTower_->getDepth1HcalESum(towers) ; }
+double ElectronHcalHelper::hcalESumDepth1BehindClusters(const std::vector<CaloTowerDetId>& towers) const {
+  return hadTower_->getDepth1HcalESum(towers);
+}
 
-double ElectronHcalHelper::hcalESumDepth2BehindClusters( const std::vector<CaloTowerDetId> & towers ) const
- { return hadTower_->getDepth2HcalESum(towers) ; }
+double ElectronHcalHelper::hcalESumDepth2BehindClusters(const std::vector<CaloTowerDetId>& towers) const {
+  return hadTower_->getDepth2HcalESum(towers);
+}
 
-double ElectronHcalHelper::hcalESum( const SuperCluster & sc, const std::vector<CaloTowerDetId > * excludeTowers ) const
- {
-  if (cfg_.hOverEConeSize==0)
-   { return 0 ; }
-  if (cfg_.useTowers)
-    { return(hcalESumDepth1(sc,excludeTowers)+hcalESumDepth2(sc,excludeTowers)) ; }
-  else
-   { return hcalIso_->getHcalESum(&sc) ; }
- }
+double ElectronHcalHelper::hcalESum(const SuperCluster& sc, const std::vector<CaloTowerDetId>* excludeTowers) const {
+  if (cfg_.hOverEConeSize == 0) {
+    return 0;
+  }
+  if (cfg_.useTowers) {
+    return (hcalESumDepth1(sc, excludeTowers) + hcalESumDepth2(sc, excludeTowers));
+  } else {
+    return hcalIso_->getHcalESum(&sc);
+  }
+}
 
-double ElectronHcalHelper::hcalESumDepth1( const SuperCluster & sc ,const std::vector<CaloTowerDetId > * excludeTowers ) const
- {
-  if (cfg_.hOverEConeSize==0)
-   { return 0 ; }
-  if (cfg_.useTowers)
-    { return towerIso1_->getTowerESum(&sc, excludeTowers) ; }
-  else
-   { return hcalIso_->getHcalESumDepth1(&sc) ; }
- }
+double ElectronHcalHelper::hcalESumDepth1(const SuperCluster& sc,
+                                          const std::vector<CaloTowerDetId>* excludeTowers) const {
+  if (cfg_.hOverEConeSize == 0) {
+    return 0;
+  }
+  if (cfg_.useTowers) {
+    return towerIso1_->getTowerESum(&sc, excludeTowers);
+  } else {
+    return hcalIso_->getHcalESumDepth1(&sc);
+  }
+}
 
-double ElectronHcalHelper::hcalESumDepth2( const SuperCluster & sc ,const std::vector<CaloTowerDetId > * excludeTowers  ) const
- {
-  if (cfg_.hOverEConeSize==0)
-   { return 0 ; }
-  if (cfg_.useTowers)
-    { return towerIso2_->getTowerESum(&sc, excludeTowers) ; }
-  else
-   { return hcalIso_->getHcalESumDepth2(&sc) ; }
- }
+double ElectronHcalHelper::hcalESumDepth2(const SuperCluster& sc,
+                                          const std::vector<CaloTowerDetId>* excludeTowers) const {
+  if (cfg_.hOverEConeSize == 0) {
+    return 0;
+  }
+  if (cfg_.useTowers) {
+    return towerIso2_->getTowerESum(&sc, excludeTowers);
+  } else {
+    return hcalIso_->getHcalESumDepth2(&sc);
+  }
+}
 
-bool ElectronHcalHelper::hasActiveHcal( const reco::SuperCluster & sc ) const
- {
-     if (cfg_.checkHcalStatus && cfg_.hOverEConeSize != 0 && cfg_.useTowers) {
-         return hadTower_->hasActiveHcal( sc );
-     } else {
-         return true;
-     }
- }
+bool ElectronHcalHelper::hasActiveHcal(const reco::SuperCluster& sc) const {
+  if (cfg_.checkHcalStatus && cfg_.hOverEConeSize != 0 && cfg_.useTowers) {
+    return hadTower_->hasActiveHcal(sc);
+  } else {
+    return true;
+  }
+}
 
-
-ElectronHcalHelper::~ElectronHcalHelper()
- {
-  if (cfg_.hOverEConeSize==0)
-   { return ; }
-  if (cfg_.useTowers)
-   {
-    delete towerIso1_ ;
-    delete towerIso2_ ;
+ElectronHcalHelper::~ElectronHcalHelper() {
+  if (cfg_.hOverEConeSize == 0) {
+    return;
+  }
+  if (cfg_.useTowers) {
+    delete towerIso1_;
+    delete towerIso2_;
     delete hadTower_;
-   }
-  else
-   {
-    delete hcalIso_ ;
-   }
- }
-
-
+  } else {
+    delete hcalIso_;
+  }
+}

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronMomentumCorrector.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronMomentumCorrector.cc
@@ -1,10 +1,8 @@
 #include "RecoEgamma/EgammaElectronAlgos/interface/ElectronMomentumCorrector.h"
 
-
 #include "TrackingTools/GsfTools/interface/MultiGaussianState1D.h"
 #include "TrackingTools/GsfTools/interface/GaussianSumUtilities1D.h"
 #include "TrackingTools/GsfTools/interface/MultiGaussianStateTransform.h"
-
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -24,191 +22,199 @@
  *
  ****************************************************************************/
 
-
-void ElectronMomentumCorrector::correct( reco::GsfElectron & electron, TrajectoryStateOnSurface & vtxTsos )
- {
-  if (electron.p4Error(reco::GsfElectron::P4_COMBINATION)!= 999.)
-   {
-    edm::LogWarning("ElectronMomentumCorrector::correct")<<"already done" ;
-    return ;
-   }
+void ElectronMomentumCorrector::correct(reco::GsfElectron& electron, TrajectoryStateOnSurface& vtxTsos) {
+  if (electron.p4Error(reco::GsfElectron::P4_COMBINATION) != 999.) {
+    edm::LogWarning("ElectronMomentumCorrector::correct") << "already done";
+    return;
+  }
 
   //math::XYZTLorentzVector newMomentum = electron.p4() ; // default
-  int elClass = electron.classification() ;
+  int elClass = electron.classification();
 
   // irrelevant classification
-  if ( (elClass <= reco::GsfElectron::UNKNOWN) ||
-	   (elClass>reco::GsfElectron::GAP) )
-   {
-    edm::LogWarning("ElectronMomentumCorrector::correct")<<"unexpected classification" ;
-    return ;
-   }
-
+  if ((elClass <= reco::GsfElectron::UNKNOWN) || (elClass > reco::GsfElectron::GAP)) {
+    edm::LogWarning("ElectronMomentumCorrector::correct") << "unexpected classification";
+    return;
+  }
 
   //=======================================================================================
   // cluster energy
   //=======================================================================================
 
-  float scEnergy = electron.correctedEcalEnergy() ;
-  float errorEnergy = electron.correctedEcalEnergyError() ;
-
+  float scEnergy = electron.correctedEcalEnergy();
+  float errorEnergy = electron.correctedEcalEnergyError();
 
   //=======================================================================================
   // track  momentum
   //=======================================================================================
 
   // basic values
-  float trackMomentum  = electron.trackMomentumAtVtx().R() ;
+  float trackMomentum = electron.trackMomentumAtVtx().R();
   //float errorTrackMomentum = 999. ;
 
   // tracker momentum scale corrections (Mykhailo Dalchenko)
-  double scale=1.;
-  if (electron.isEB()){
-    if (elClass==0) {scale = 1./(0.00104*sqrt(trackMomentum)+1);}
-    if (elClass==1) {scale = 1./(0.0017*sqrt(trackMomentum)+0.9986);}
-    if (elClass==3) {scale = 1./(1.004 - 0.00021*trackMomentum);}
-    if (elClass==4) {scale = 0.995;}
-  } else if (electron.isEE()){
-    if (elClass==3){scale = 1./(1.01432-0.00201872*trackMomentum+0.0000142621*trackMomentum*trackMomentum);}
-    if (elClass==4){scale = 1./(0.996859-0.000345347*trackMomentum);}
+  double scale = 1.;
+  if (electron.isEB()) {
+    if (elClass == 0) {
+      scale = 1. / (0.00104 * sqrt(trackMomentum) + 1);
+    }
+    if (elClass == 1) {
+      scale = 1. / (0.0017 * sqrt(trackMomentum) + 0.9986);
+    }
+    if (elClass == 3) {
+      scale = 1. / (1.004 - 0.00021 * trackMomentum);
+    }
+    if (elClass == 4) {
+      scale = 0.995;
+    }
+  } else if (electron.isEE()) {
+    if (elClass == 3) {
+      scale = 1. / (1.01432 - 0.00201872 * trackMomentum + 0.0000142621 * trackMomentum * trackMomentum);
+    }
+    if (elClass == 4) {
+      scale = 1. / (0.996859 - 0.000345347 * trackMomentum);
+    }
   }
-  if (scale<0.) scale = 1.;  // CC added protection
-  trackMomentum = trackMomentum*scale ;
+  if (scale < 0.)
+    scale = 1.;  // CC added protection
+  trackMomentum = trackMomentum * scale;
 
   // error (must be done after trackMomentum rescaling)
-  MultiGaussianState1D qpState(MultiGaussianStateTransform::multiState1D(vtxTsos,0)) ;
-  GaussianSumUtilities1D qpUtils(qpState) ;
-  float errorTrackMomentum = trackMomentum*trackMomentum*sqrt(qpUtils.mode().variance()) ;
-
+  MultiGaussianState1D qpState(MultiGaussianStateTransform::multiState1D(vtxTsos, 0));
+  GaussianSumUtilities1D qpUtils(qpState);
+  float errorTrackMomentum = trackMomentum * trackMomentum * sqrt(qpUtils.mode().variance());
 
   //=======================================================================================
   // combination
   //=======================================================================================
 
-  float finalMomentum = electron.p4().t(); // initial
+  float finalMomentum = electron.p4().t();  // initial
   float finalMomentumError = 999.;
 
   // first check for large errors
 
-  if (errorTrackMomentum/trackMomentum > 0.5 && errorEnergy/scEnergy <= 0.5) {
-    finalMomentum = scEnergy;    finalMomentumError = errorEnergy;
-   }
-  else if (errorTrackMomentum/trackMomentum <= 0.5 && errorEnergy/scEnergy > 0.5){
-    finalMomentum = trackMomentum;  finalMomentumError = errorTrackMomentum;
-   }
-  else if (errorTrackMomentum/trackMomentum > 0.5 && errorEnergy/scEnergy > 0.5){
-    if (errorTrackMomentum/trackMomentum < errorEnergy/scEnergy) {
-      finalMomentum = trackMomentum; finalMomentumError = errorTrackMomentum;
-     }
-    else{
-      finalMomentum = scEnergy; finalMomentumError = errorEnergy;
-     }
+  if (errorTrackMomentum / trackMomentum > 0.5 && errorEnergy / scEnergy <= 0.5) {
+    finalMomentum = scEnergy;
+    finalMomentumError = errorEnergy;
+  } else if (errorTrackMomentum / trackMomentum <= 0.5 && errorEnergy / scEnergy > 0.5) {
+    finalMomentum = trackMomentum;
+    finalMomentumError = errorTrackMomentum;
+  } else if (errorTrackMomentum / trackMomentum > 0.5 && errorEnergy / scEnergy > 0.5) {
+    if (errorTrackMomentum / trackMomentum < errorEnergy / scEnergy) {
+      finalMomentum = trackMomentum;
+      finalMomentumError = errorTrackMomentum;
+    } else {
+      finalMomentum = scEnergy;
+      finalMomentumError = errorEnergy;
+    }
   }
 
   // then apply the combination algorithm
   else {
-
-     // calculate E/p and corresponding error
+    // calculate E/p and corresponding error
     float eOverP = scEnergy / trackMomentum;
-    float errorEOverP = sqrt(
-			     (errorEnergy/trackMomentum)*(errorEnergy/trackMomentum) +
-			     (scEnergy*errorTrackMomentum/trackMomentum/trackMomentum)*
-			     (scEnergy*errorTrackMomentum/trackMomentum/trackMomentum));
+    float errorEOverP = sqrt((errorEnergy / trackMomentum) * (errorEnergy / trackMomentum) +
+                             (scEnergy * errorTrackMomentum / trackMomentum / trackMomentum) *
+                                 (scEnergy * errorTrackMomentum / trackMomentum / trackMomentum));
 
-//    if ( eOverP  > 1 + 2.5*errorEOverP )
-//     {
-//      finalMomentum = scEnergy; finalMomentumError = errorEnergy;
-//      if ((elClass==reco::GsfElectron::GOLDEN) && electron.isEB() && (eOverP<1.15))
-//        {
-//          if (scEnergy<15) {finalMomentum = trackMomentum ; finalMomentumError = errorTrackMomentum;}
-//        }
-//     }
-//    else if ( eOverP < 1 - 2.5*errorEOverP )
-//     {
-//      finalMomentum = scEnergy; finalMomentumError = errorEnergy;
-//      if (elClass==reco::GsfElectron::SHOWERING)
-//       {
-//	      if (electron.isEB())
-//	       {
-//		      if (scEnergy<18)
-//		       { finalMomentum = trackMomentum; finalMomentumError = errorTrackMomentum; }
-//	       }
-//	      else if (electron.isEE())
-//	       {
-//          if (scEnergy<13)
-//           {finalMomentum = trackMomentum; finalMomentumError = errorTrackMomentum;}
-//	       }
-//	      else
-//	       { edm::LogWarning("ElectronMomentumCorrector::correct")<<"nor barrel neither endcap electron ?!" ; }
-//	     }
-//	    else if (electron.isGap())
-//	     {
-//	      if (scEnergy<60)
-//	       { finalMomentum = trackMomentum; finalMomentumError = errorTrackMomentum ; }
-//	     }
-//      }
+    //    if ( eOverP  > 1 + 2.5*errorEOverP )
+    //     {
+    //      finalMomentum = scEnergy; finalMomentumError = errorEnergy;
+    //      if ((elClass==reco::GsfElectron::GOLDEN) && electron.isEB() && (eOverP<1.15))
+    //        {
+    //          if (scEnergy<15) {finalMomentum = trackMomentum ; finalMomentumError = errorTrackMomentum;}
+    //        }
+    //     }
+    //    else if ( eOverP < 1 - 2.5*errorEOverP )
+    //     {
+    //      finalMomentum = scEnergy; finalMomentumError = errorEnergy;
+    //      if (elClass==reco::GsfElectron::SHOWERING)
+    //       {
+    //	      if (electron.isEB())
+    //	       {
+    //		      if (scEnergy<18)
+    //		       { finalMomentum = trackMomentum; finalMomentumError = errorTrackMomentum; }
+    //	       }
+    //	      else if (electron.isEE())
+    //	       {
+    //          if (scEnergy<13)
+    //           {finalMomentum = trackMomentum; finalMomentumError = errorTrackMomentum;}
+    //	       }
+    //	      else
+    //	       { edm::LogWarning("ElectronMomentumCorrector::correct")<<"nor barrel neither endcap electron ?!" ; }
+    //	     }
+    //	    else if (electron.isGap())
+    //	     {
+    //	      if (scEnergy<60)
+    //	       { finalMomentum = trackMomentum; finalMomentumError = errorTrackMomentum ; }
+    //	     }
+    //      }
 
-    bool eleIsNotInCombination = false ;
-    if ( (eOverP  > 1 + 2.5*errorEOverP) || (eOverP  < 1 - 2.5*errorEOverP) || (eOverP < 0.8) || (eOverP > 1.3) )
-     { eleIsNotInCombination = true ; }
-    if (eleIsNotInCombination)
-     {
-      if (eOverP > 1)
-       { finalMomentum = scEnergy ; finalMomentumError = errorEnergy ; }
-      else
-       {
-        if (elClass == reco::GsfElectron::GOLDEN)
-         { finalMomentum = scEnergy; finalMomentumError = errorEnergy; }
-        if (elClass == reco::GsfElectron::BIGBREM)
-         {
-          if (scEnergy<36)
-           { finalMomentum = trackMomentum ; finalMomentumError = errorTrackMomentum ; }
-          else
-           { finalMomentum = scEnergy ; finalMomentumError = errorEnergy ; }
-         }
-        if (elClass == reco::GsfElectron::BADTRACK)
-         { finalMomentum = scEnergy; finalMomentumError = errorEnergy ; }
-        if (elClass == reco::GsfElectron::SHOWERING)
-         {
-          if (scEnergy<30)
-           { finalMomentum = trackMomentum ; finalMomentumError = errorTrackMomentum; }
-          else
-           { finalMomentum = scEnergy; finalMomentumError = errorEnergy;}
-         }
-        if (elClass == reco::GsfElectron::GAP)
-         {
-          if (scEnergy<60)
-           { finalMomentum = trackMomentum ; finalMomentumError = errorTrackMomentum ; }
-          else
-           { finalMomentum = scEnergy; finalMomentumError = errorEnergy ; }
-         }
-       }
-     }
+    bool eleIsNotInCombination = false;
+    if ((eOverP > 1 + 2.5 * errorEOverP) || (eOverP < 1 - 2.5 * errorEOverP) || (eOverP < 0.8) || (eOverP > 1.3)) {
+      eleIsNotInCombination = true;
+    }
+    if (eleIsNotInCombination) {
+      if (eOverP > 1) {
+        finalMomentum = scEnergy;
+        finalMomentumError = errorEnergy;
+      } else {
+        if (elClass == reco::GsfElectron::GOLDEN) {
+          finalMomentum = scEnergy;
+          finalMomentumError = errorEnergy;
+        }
+        if (elClass == reco::GsfElectron::BIGBREM) {
+          if (scEnergy < 36) {
+            finalMomentum = trackMomentum;
+            finalMomentumError = errorTrackMomentum;
+          } else {
+            finalMomentum = scEnergy;
+            finalMomentumError = errorEnergy;
+          }
+        }
+        if (elClass == reco::GsfElectron::BADTRACK) {
+          finalMomentum = scEnergy;
+          finalMomentumError = errorEnergy;
+        }
+        if (elClass == reco::GsfElectron::SHOWERING) {
+          if (scEnergy < 30) {
+            finalMomentum = trackMomentum;
+            finalMomentumError = errorTrackMomentum;
+          } else {
+            finalMomentum = scEnergy;
+            finalMomentumError = errorEnergy;
+          }
+        }
+        if (elClass == reco::GsfElectron::GAP) {
+          if (scEnergy < 60) {
+            finalMomentum = trackMomentum;
+            finalMomentumError = errorTrackMomentum;
+          } else {
+            finalMomentum = scEnergy;
+            finalMomentumError = errorEnergy;
+          }
+        }
+      }
+    }
 
-    else
-     {
+    else {
       // combination
-      finalMomentum = (scEnergy/errorEnergy/errorEnergy + trackMomentum/errorTrackMomentum/errorTrackMomentum) /
-        (1/errorEnergy/errorEnergy + 1/errorTrackMomentum/errorTrackMomentum);
-      float finalMomentumVariance = 1 / (1/errorEnergy/errorEnergy + 1/errorTrackMomentum/errorTrackMomentum);
+      finalMomentum = (scEnergy / errorEnergy / errorEnergy + trackMomentum / errorTrackMomentum / errorTrackMomentum) /
+                      (1 / errorEnergy / errorEnergy + 1 / errorTrackMomentum / errorTrackMomentum);
+      float finalMomentumVariance = 1 / (1 / errorEnergy / errorEnergy + 1 / errorTrackMomentum / errorTrackMomentum);
       finalMomentumError = sqrt(finalMomentumVariance);
-     }
-
+    }
   }
-
 
   //=======================================================================================
   // final set
   //=======================================================================================
 
-  math::XYZTLorentzVector oldMomentum = electron.p4() ;
-  math::XYZTLorentzVector newMomentum = math::XYZTLorentzVector
-   ( oldMomentum.x()*finalMomentum/oldMomentum.t(),
-     oldMomentum.y()*finalMomentum/oldMomentum.t(),
-     oldMomentum.z()*finalMomentum/oldMomentum.t(),
-     finalMomentum ) ;
+  math::XYZTLorentzVector oldMomentum = electron.p4();
+  math::XYZTLorentzVector newMomentum = math::XYZTLorentzVector(oldMomentum.x() * finalMomentum / oldMomentum.t(),
+                                                                oldMomentum.y() * finalMomentum / oldMomentum.t(),
+                                                                oldMomentum.z() * finalMomentum / oldMomentum.t(),
+                                                                finalMomentum);
 
-  electron.correctMomentum(newMomentum,errorTrackMomentum,finalMomentumError);
-
- }
-
+  electron.correctMomentum(newMomentum, errorTrackMomentum, finalMomentumError);
+}

--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
@@ -43,216 +43,220 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
 #include <vector>
 #include <utility>
-
 
 #ifdef COUNT_ElectronSeeds
 namespace {
   struct Count {
-    long long s=0;
-    long long n=0;
-    ~Count() { std::cout << "ElectronSeeds res " << s<<'/'<<n << std::endl;}
+    long long s = 0;
+    long long n = 0;
+    ~Count() { std::cout << "ElectronSeeds res " << s << '/' << n << std::endl; }
   };
 
   Count stcount;
-}
+}  // namespace
 #endif
 
-
-
-ElectronSeedGenerator::ElectronSeedGenerator(const edm::ParameterSet &pset,
-				      const ElectronSeedGenerator::Tokens& ts)
- : dynamicphiroad_(pset.getParameter<bool>("dynamicPhiRoad")),
-   fromTrackerSeeds_(pset.getParameter<bool>("fromTrackerSeeds")),
-   useRecoVertex_(false),
-   verticesTag_(ts.token_vtx),
-   beamSpotTag_(ts.token_bs),
-   lowPtThreshold_(pset.getParameter<double>("LowPtThreshold")),
-   highPtThreshold_(pset.getParameter<double>("HighPtThreshold")),
-   nSigmasDeltaZ1_(pset.getParameter<double>("nSigmasDeltaZ1")),
-   deltaZ1WithVertex_(0.5),
-   sizeWindowENeg_(pset.getParameter<double>("SizeWindowENeg")),
-   deltaPhi1Low_(pset.getParameter<double>("DeltaPhi1Low")),
-   deltaPhi1High_(pset.getParameter<double>("DeltaPhi1High")),
-   deltaPhi1Coef1_(0.), deltaPhi1Coef2_(0.),
-   myMatchEle(nullptr), myMatchPos(nullptr),
-   thePropagator(nullptr),
-   theMeasurementTracker(nullptr),
-   theMeasurementTrackerEventTag(ts.token_measTrkEvt),
-   theSetup(nullptr), 
-   cacheIDMagField_(0),/*cacheIDGeom_(0),*/cacheIDNavSchool_(0),cacheIDCkfComp_(0),cacheIDTrkGeom_(0)
-{
+ElectronSeedGenerator::ElectronSeedGenerator(const edm::ParameterSet &pset, const ElectronSeedGenerator::Tokens &ts)
+    : dynamicphiroad_(pset.getParameter<bool>("dynamicPhiRoad")),
+      fromTrackerSeeds_(pset.getParameter<bool>("fromTrackerSeeds")),
+      useRecoVertex_(false),
+      verticesTag_(ts.token_vtx),
+      beamSpotTag_(ts.token_bs),
+      lowPtThreshold_(pset.getParameter<double>("LowPtThreshold")),
+      highPtThreshold_(pset.getParameter<double>("HighPtThreshold")),
+      nSigmasDeltaZ1_(pset.getParameter<double>("nSigmasDeltaZ1")),
+      deltaZ1WithVertex_(0.5),
+      sizeWindowENeg_(pset.getParameter<double>("SizeWindowENeg")),
+      deltaPhi1Low_(pset.getParameter<double>("DeltaPhi1Low")),
+      deltaPhi1High_(pset.getParameter<double>("DeltaPhi1High")),
+      deltaPhi1Coef1_(0.),
+      deltaPhi1Coef2_(0.),
+      myMatchEle(nullptr),
+      myMatchPos(nullptr),
+      thePropagator(nullptr),
+      theMeasurementTracker(nullptr),
+      theMeasurementTrackerEventTag(ts.token_measTrkEvt),
+      theSetup(nullptr),
+      cacheIDMagField_(0),
+      /*cacheIDGeom_(0),*/ cacheIDNavSchool_(0),
+      cacheIDCkfComp_(0),
+      cacheIDTrkGeom_(0) {
   // so that deltaPhi1 = deltaPhi1Coef1_ + deltaPhi1Coef2_/clusterEnergyT
-  if (dynamicphiroad_)
-    {
-      deltaPhi1Coef2_ = (deltaPhi1Low_-deltaPhi1High_)/(1./lowPtThreshold_-1./highPtThreshold_) ;
-      deltaPhi1Coef1_ = deltaPhi1Low_ - deltaPhi1Coef2_/lowPtThreshold_ ;
-    }
-  
-  theMeasurementTrackerName = pset.getParameter<std::string>("measurementTrackerName"); 
-  
+  if (dynamicphiroad_) {
+    deltaPhi1Coef2_ = (deltaPhi1Low_ - deltaPhi1High_) / (1. / lowPtThreshold_ - 1. / highPtThreshold_);
+    deltaPhi1Coef1_ = deltaPhi1Low_ - deltaPhi1Coef2_ / lowPtThreshold_;
+  }
+
+  theMeasurementTrackerName = pset.getParameter<std::string>("measurementTrackerName");
+
   // use of reco vertex
   useRecoVertex_ = pset.getParameter<bool>("useRecoVertex");
   deltaZ1WithVertex_ = pset.getParameter<double>("deltaZ1WithVertex");
-  
+
   // new B/F configurables
-  deltaPhi2B_ = pset.getParameter<double>("DeltaPhi2B") ;
-  deltaPhi2F_ = pset.getParameter<double>("DeltaPhi2F") ;
+  deltaPhi2B_ = pset.getParameter<double>("DeltaPhi2B");
+  deltaPhi2F_ = pset.getParameter<double>("DeltaPhi2F");
 
-  phiMin2B_ = pset.getParameter<double>("PhiMin2B") ;
-  phiMin2F_ = pset.getParameter<double>("PhiMin2F") ;
+  phiMin2B_ = pset.getParameter<double>("PhiMin2B");
+  phiMin2F_ = pset.getParameter<double>("PhiMin2F");
 
-  phiMax2B_ = pset.getParameter<double>("PhiMax2B") ;
-  phiMax2F_ = pset.getParameter<double>("PhiMax2F") ;
+  phiMax2B_ = pset.getParameter<double>("PhiMax2B");
+  phiMax2F_ = pset.getParameter<double>("PhiMax2F");
 
   // Instantiate the pixel hit matchers
-  myMatchEle = new PixelHitMatcher
-   ( pset.getParameter<double>("ePhiMin1"),
-		 pset.getParameter<double>("ePhiMax1"),
-		 phiMin2B_, phiMax2B_, phiMin2F_, phiMax2F_,
-     pset.getParameter<double>("z2MinB"),
-     pset.getParameter<double>("z2MaxB"),
-     pset.getParameter<double>("r2MinF"),
-     pset.getParameter<double>("r2MaxF"),
-     pset.getParameter<double>("rMinI"),
-     pset.getParameter<double>("rMaxI"),
-     pset.getParameter<bool>("searchInTIDTEC") ) ;
+  myMatchEle = new PixelHitMatcher(pset.getParameter<double>("ePhiMin1"),
+                                   pset.getParameter<double>("ePhiMax1"),
+                                   phiMin2B_,
+                                   phiMax2B_,
+                                   phiMin2F_,
+                                   phiMax2F_,
+                                   pset.getParameter<double>("z2MinB"),
+                                   pset.getParameter<double>("z2MaxB"),
+                                   pset.getParameter<double>("r2MinF"),
+                                   pset.getParameter<double>("r2MaxF"),
+                                   pset.getParameter<double>("rMinI"),
+                                   pset.getParameter<double>("rMaxI"),
+                                   pset.getParameter<bool>("searchInTIDTEC"));
 
-  myMatchPos = new PixelHitMatcher
-   ( pset.getParameter<double>("pPhiMin1"),
-		 pset.getParameter<double>("pPhiMax1"),
-		 phiMin2B_, phiMax2B_, phiMin2F_, phiMax2F_,
-     pset.getParameter<double>("z2MinB"),
-     pset.getParameter<double>("z2MaxB"),
-     pset.getParameter<double>("r2MinF"),
-     pset.getParameter<double>("r2MaxF"),
-     pset.getParameter<double>("rMinI"),
-     pset.getParameter<double>("rMaxI"),
-     pset.getParameter<bool>("searchInTIDTEC") ) ;
+  myMatchPos = new PixelHitMatcher(pset.getParameter<double>("pPhiMin1"),
+                                   pset.getParameter<double>("pPhiMax1"),
+                                   phiMin2B_,
+                                   phiMax2B_,
+                                   phiMin2F_,
+                                   phiMax2F_,
+                                   pset.getParameter<double>("z2MinB"),
+                                   pset.getParameter<double>("z2MaxB"),
+                                   pset.getParameter<double>("r2MinF"),
+                                   pset.getParameter<double>("r2MaxF"),
+                                   pset.getParameter<double>("rMinI"),
+                                   pset.getParameter<double>("rMaxI"),
+                                   pset.getParameter<bool>("searchInTIDTEC"));
 
-  theUpdator = new KFUpdator() ;
+  theUpdator = new KFUpdator();
 }
 
-ElectronSeedGenerator::~ElectronSeedGenerator()
- {
-  delete myMatchEle ;
-  delete myMatchPos ;
-  delete thePropagator ;
-  delete theUpdator ;
- }
+ElectronSeedGenerator::~ElectronSeedGenerator() {
+  delete myMatchEle;
+  delete myMatchPos;
+  delete thePropagator;
+  delete theUpdator;
+}
 
-void ElectronSeedGenerator::setupES(const edm::EventSetup& setup) {
-
+void ElectronSeedGenerator::setupES(const edm::EventSetup &setup) {
   // get records if necessary (called once per event)
-  bool tochange=false;
+  bool tochange = false;
 
-  if (cacheIDMagField_!=setup.get<IdealMagneticFieldRecord>().cacheIdentifier()) {
+  if (cacheIDMagField_ != setup.get<IdealMagneticFieldRecord>().cacheIdentifier()) {
     setup.get<IdealMagneticFieldRecord>().get(theMagField);
-    cacheIDMagField_=setup.get<IdealMagneticFieldRecord>().cacheIdentifier();
-    if (thePropagator) delete thePropagator;
-    thePropagator = new PropagatorWithMaterial(alongMomentum,.000511,&(*theMagField));
-    tochange=true;
+    cacheIDMagField_ = setup.get<IdealMagneticFieldRecord>().cacheIdentifier();
+    if (thePropagator)
+      delete thePropagator;
+    thePropagator = new PropagatorWithMaterial(alongMomentum, .000511, &(*theMagField));
+    tochange = true;
   }
 
-  if (!fromTrackerSeeds_ && cacheIDCkfComp_!=setup.get<CkfComponentsRecord>().cacheIdentifier()) {
+  if (!fromTrackerSeeds_ && cacheIDCkfComp_ != setup.get<CkfComponentsRecord>().cacheIdentifier()) {
     edm::ESHandle<MeasurementTracker> measurementTrackerHandle;
-    setup.get<CkfComponentsRecord>().get(theMeasurementTrackerName,measurementTrackerHandle);
-    cacheIDCkfComp_=setup.get<CkfComponentsRecord>().cacheIdentifier();
+    setup.get<CkfComponentsRecord>().get(theMeasurementTrackerName, measurementTrackerHandle);
+    cacheIDCkfComp_ = setup.get<CkfComponentsRecord>().cacheIdentifier();
     theMeasurementTracker = measurementTrackerHandle.product();
-    tochange=true;
+    tochange = true;
   }
 
   //edm::ESHandle<TrackerGeometry> trackerGeometryHandle;
-  if (cacheIDTrkGeom_!=setup.get<TrackerDigiGeometryRecord>().cacheIdentifier()) {
-    cacheIDTrkGeom_=setup.get<TrackerDigiGeometryRecord>().cacheIdentifier();
+  if (cacheIDTrkGeom_ != setup.get<TrackerDigiGeometryRecord>().cacheIdentifier()) {
+    cacheIDTrkGeom_ = setup.get<TrackerDigiGeometryRecord>().cacheIdentifier();
     setup.get<TrackerDigiGeometryRecord>().get(theTrackerGeometry);
-    tochange=true; //FIXME
+    tochange = true;  //FIXME
   }
 
   if (tochange) {
-    myMatchEle->setES(&(*theMagField),theMeasurementTracker,theTrackerGeometry.product());
-    myMatchPos->setES(&(*theMagField),theMeasurementTracker,theTrackerGeometry.product());
+    myMatchEle->setES(&(*theMagField), theMeasurementTracker, theTrackerGeometry.product());
+    myMatchPos->setES(&(*theMagField), theMeasurementTracker, theTrackerGeometry.product());
   }
 
-  if (cacheIDNavSchool_!=setup.get<NavigationSchoolRecord>().cacheIdentifier()) {
+  if (cacheIDNavSchool_ != setup.get<NavigationSchoolRecord>().cacheIdentifier()) {
     edm::ESHandle<NavigationSchool> nav;
     setup.get<NavigationSchoolRecord>().get("SimpleNavigationSchool", nav);
-    cacheIDNavSchool_=setup.get<NavigationSchoolRecord>().cacheIdentifier();
+    cacheIDNavSchool_ = setup.get<NavigationSchoolRecord>().cacheIdentifier();
     theNavigationSchool = nav.product();
   }
 
-//  if (cacheIDGeom_!=setup.get<TrackerRecoGeometryRecord>().cacheIdentifier()) {
-//    setup.get<TrackerRecoGeometryRecord>().get( theGeomSearchTracker );
-//    cacheIDGeom_=setup.get<TrackerRecoGeometryRecord>().cacheIdentifier();
-//  }
-
+  //  if (cacheIDGeom_!=setup.get<TrackerRecoGeometryRecord>().cacheIdentifier()) {
+  //    setup.get<TrackerRecoGeometryRecord>().get( theGeomSearchTracker );
+  //    cacheIDGeom_=setup.get<TrackerRecoGeometryRecord>().cacheIdentifier();
+  //  }
 }
 
-void display_seed( const std::string & title1, const std::string & title2, const reco::ElectronSeed & seed, edm::ESHandle<TrackerGeometry> trackerGeometry )
- {
-  const PTrajectoryStateOnDet & startingState = seed.startingState() ;
-  const LocalTrajectoryParameters & parameters = startingState.parameters() ;
-  std::cout<<title1
-    <<" ("<<seed.subDet2()<<"/"<<seed.dRz2()<<"/"<<seed.dPhi2()<<")"
-    <<" ("<<seed.direction()<<"/"<<startingState.detId()<<"/"<<startingState.surfaceSide()<<"/"<<parameters.charge()<<"/"<<parameters.position()<<"/"<<parameters.momentum()<<")"
-    <<std::endl ;
- }
+void display_seed(const std::string &title1,
+                  const std::string &title2,
+                  const reco::ElectronSeed &seed,
+                  edm::ESHandle<TrackerGeometry> trackerGeometry) {
+  const PTrajectoryStateOnDet &startingState = seed.startingState();
+  const LocalTrajectoryParameters &parameters = startingState.parameters();
+  std::cout << title1 << " (" << seed.subDet2() << "/" << seed.dRz2() << "/" << seed.dPhi2() << ")"
+            << " (" << seed.direction() << "/" << startingState.detId() << "/" << startingState.surfaceSide() << "/"
+            << parameters.charge() << "/" << parameters.position() << "/" << parameters.momentum() << ")" << std::endl;
+}
 
-bool equivalent( const TrajectorySeed & s1, const TrajectorySeed & s2 )
- {
-  if (s1.nHits()!=s2.nHits()) return false ;
+bool equivalent(const TrajectorySeed &s1, const TrajectorySeed &s2) {
+  if (s1.nHits() != s2.nHits())
+    return false;
 
-  unsigned int nHits ;
-  TrajectorySeed::range r1 = s1.recHits(), r2 = s2.recHits() ;
-  TrajectorySeed::const_iterator i1, i2 ;
-  for ( i1=r1.first, i2=r2.first, nHits=0 ; i1!=r1.second ; ++i1, ++i2, ++nHits )
-   {
-    if ( !i1->isValid() || !i2->isValid() ) return false ;
-    if ( i1->geographicalId()!=i2->geographicalId() ) return false ;
-    if ( ! ( i1->localPosition()==i2->localPosition() ) ) return false ;
-   }
+  unsigned int nHits;
+  TrajectorySeed::range r1 = s1.recHits(), r2 = s2.recHits();
+  TrajectorySeed::const_iterator i1, i2;
+  for (i1 = r1.first, i2 = r2.first, nHits = 0; i1 != r1.second; ++i1, ++i2, ++nHits) {
+    if (!i1->isValid() || !i2->isValid())
+      return false;
+    if (i1->geographicalId() != i2->geographicalId())
+      return false;
+    if (!(i1->localPosition() == i2->localPosition()))
+      return false;
+  }
 
-  return true ;
- }
+  return true;
+}
 
-void  ElectronSeedGenerator::run
- ( edm::Event & e, const edm::EventSetup & setup,
-   const reco::SuperClusterRefVector & sclRefs, const std::vector<float> & hoe1s, const std::vector<float> & hoe2s,
-   const std::vector<const TrajectorySeedCollection *>& seedsV, reco::ElectronSeedCollection & out )
- {
-   theInitialSeedCollV = &seedsV;
-//  bool duplicateTrajectorySeeds =false ;
-//  unsigned int i,j ;
-//  for (i=0;i<seeds->size();++i)
-//    for (j=i+1;j<seeds->size();++j)
-//     {
-//      const TrajectorySeed & s1 =(*seeds)[i] ;
-//      const TrajectorySeed & s2 =(*seeds)[j] ;
-//      if ( equivalent(s1,s2) )
-//       {
-//        const PTrajectoryStateOnDet & ss1 = s1.startingState() ;
-//        const LocalTrajectoryParameters & p1 = ss1.parameters() ;
-//        const PTrajectoryStateOnDet & ss2 = s2.startingState() ;
-//        const LocalTrajectoryParameters & p2 = ss2.parameters() ;
-//        duplicateTrajectorySeeds = true ;
-//        std::cout<<"Same hits for "
-//          <<"\n  s["<<i<<"] ("<<s1.direction()<<"/"<<ss1.detId()<<"/"<<ss1.surfaceSide()<<"/"<<p1.charge()<<"/"<<p1.position()<<"/"<<p1.momentum()<<")"
-//          <<"\n  s["<<j<<"] ("<<s2.direction()<<"/"<<ss2.detId()<<"/"<<ss2.surfaceSide()<<"/"<<p2.charge()<<"/"<<p2.position()<<"/"<<p2.momentum()<<")"
-//          <<std::endl ;
-//       }
-//     }
-//  if (duplicateTrajectorySeeds)
-//   { edm::LogWarning("ElectronSeedGenerator|DuplicateTrajectorySeeds")<<"We see several identical trajectory seeds." ; }
+void ElectronSeedGenerator::run(edm::Event &e,
+                                const edm::EventSetup &setup,
+                                const reco::SuperClusterRefVector &sclRefs,
+                                const std::vector<float> &hoe1s,
+                                const std::vector<float> &hoe2s,
+                                const std::vector<const TrajectorySeedCollection *> &seedsV,
+                                reco::ElectronSeedCollection &out) {
+  theInitialSeedCollV = &seedsV;
+  //  bool duplicateTrajectorySeeds =false ;
+  //  unsigned int i,j ;
+  //  for (i=0;i<seeds->size();++i)
+  //    for (j=i+1;j<seeds->size();++j)
+  //     {
+  //      const TrajectorySeed & s1 =(*seeds)[i] ;
+  //      const TrajectorySeed & s2 =(*seeds)[j] ;
+  //      if ( equivalent(s1,s2) )
+  //       {
+  //        const PTrajectoryStateOnDet & ss1 = s1.startingState() ;
+  //        const LocalTrajectoryParameters & p1 = ss1.parameters() ;
+  //        const PTrajectoryStateOnDet & ss2 = s2.startingState() ;
+  //        const LocalTrajectoryParameters & p2 = ss2.parameters() ;
+  //        duplicateTrajectorySeeds = true ;
+  //        std::cout<<"Same hits for "
+  //          <<"\n  s["<<i<<"] ("<<s1.direction()<<"/"<<ss1.detId()<<"/"<<ss1.surfaceSide()<<"/"<<p1.charge()<<"/"<<p1.position()<<"/"<<p1.momentum()<<")"
+  //          <<"\n  s["<<j<<"] ("<<s2.direction()<<"/"<<ss2.detId()<<"/"<<ss2.surfaceSide()<<"/"<<p2.charge()<<"/"<<p2.position()<<"/"<<p2.momentum()<<")"
+  //          <<std::endl ;
+  //       }
+  //     }
+  //  if (duplicateTrajectorySeeds)
+  //   { edm::LogWarning("ElectronSeedGenerator|DuplicateTrajectorySeeds")<<"We see several identical trajectory seeds." ; }
 
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHand;
   setup.get<TrackerTopologyRcd>().get(tTopoHand);
-  const TrackerTopology *tTopo=tTopoHand.product();
+  const TrackerTopology *tTopo = tTopoHand.product();
 
-  theSetup= &setup;
-
+  theSetup = &setup;
 
   // Step A: set Event for the TrajectoryBuilder
   edm::Handle<MeasurementTrackerEvent> data;
@@ -262,355 +266,327 @@ void  ElectronSeedGenerator::run
 
   // get the beamspot from the Event:
   //e.getByType(theBeamSpot);
-  e.getByToken(beamSpotTag_,theBeamSpot);
+  e.getByToken(beamSpotTag_, theBeamSpot);
 
   // if required get the vertices
-  if (useRecoVertex_) e.getByToken(verticesTag_,theVertices);
+  if (useRecoVertex_)
+    e.getByToken(verticesTag_, theVertices);
 
-  if (!fromTrackerSeeds_)
-   { throw cms::Exception("NotSupported") << "Here in ElectronSeedGenerator " << __FILE__ << ":" << __LINE__ << " I would like to do theMeasurementTracker->update(e); but that no longer makes sense.\n"; 
-   }
+  if (!fromTrackerSeeds_) {
+    throw cms::Exception("NotSupported")
+        << "Here in ElectronSeedGenerator " << __FILE__ << ":" << __LINE__
+        << " I would like to do theMeasurementTracker->update(e); but that no longer makes sense.\n";
+  }
 
-  for  (unsigned int i=0;i<sclRefs.size();++i) {
+  for (unsigned int i = 0; i < sclRefs.size(); ++i) {
     // Find the seeds
     recHits_.clear();
 
-    LogDebug ("ElectronSeedGenerator") << "new cluster, calling seedsFromThisCluster";
-    seedsFromThisCluster(sclRefs[i],hoe1s[i],hoe2s[i],out,tTopo);
+    LogDebug("ElectronSeedGenerator") << "new cluster, calling seedsFromThisCluster";
+    seedsFromThisCluster(sclRefs[i], hoe1s[i], hoe2s[i], out, tTopo);
   }
 
-  LogDebug ("ElectronSeedGenerator") << ": For event "<<e.id();
-  LogDebug ("ElectronSeedGenerator") <<"Nr of superclusters after filter: "<<sclRefs.size()
-   <<", no. of ElectronSeeds found  = " << out.size();
+  LogDebug("ElectronSeedGenerator") << ": For event " << e.id();
+  LogDebug("ElectronSeedGenerator") << "Nr of superclusters after filter: " << sclRefs.size()
+                                    << ", no. of ElectronSeeds found  = " << out.size();
 
 #ifdef COUNT_ElectronSeeds
-   stcount.s+=sclRefs.size();
-   stcount.n+=out.size();
+  stcount.s += sclRefs.size();
+  stcount.n += out.size();
 #endif
-
 }
 
-void ElectronSeedGenerator::seedsFromThisCluster
-( edm::Ref<reco::SuperClusterCollection> seedCluster,
-  float hoe1, float hoe2,
-  reco::ElectronSeedCollection & out, const TrackerTopology *tTopo )
-{
-  float clusterEnergy = seedCluster->energy() ;
-  GlobalPoint clusterPos
-    ( seedCluster->position().x(),
-      seedCluster->position().y(),
-      seedCluster->position().z() ) ;
-  reco::ElectronSeed::CaloClusterRef caloCluster(seedCluster) ;
+void ElectronSeedGenerator::seedsFromThisCluster(edm::Ref<reco::SuperClusterCollection> seedCluster,
+                                                 float hoe1,
+                                                 float hoe2,
+                                                 reco::ElectronSeedCollection &out,
+                                                 const TrackerTopology *tTopo) {
+  float clusterEnergy = seedCluster->energy();
+  GlobalPoint clusterPos(seedCluster->position().x(), seedCluster->position().y(), seedCluster->position().z());
+  reco::ElectronSeed::CaloClusterRef caloCluster(seedCluster);
 
   //LogDebug("") << "[ElectronSeedGenerator::seedsFromThisCluster] new supercluster with energy: " << clusterEnergy ;
   //LogDebug("") << "[ElectronSeedGenerator::seedsFromThisCluster] and position: " << clusterPos ;
 
-  if (dynamicphiroad_)
-   {
-    float clusterEnergyT = clusterEnergy / cosh( EleRelPoint(clusterPos,theBeamSpot->position()).eta() ) ;
+  if (dynamicphiroad_) {
+    float clusterEnergyT = clusterEnergy / cosh(EleRelPoint(clusterPos, theBeamSpot->position()).eta());
 
-    float deltaPhi1 ;
-    if (clusterEnergyT < lowPtThreshold_)
-     { deltaPhi1= deltaPhi1Low_ ; }
-    else if (clusterEnergyT > highPtThreshold_)
-     { deltaPhi1= deltaPhi1High_ ; }
-    else
-     { deltaPhi1 = deltaPhi1Coef1_ + deltaPhi1Coef2_/clusterEnergyT ; }
+    float deltaPhi1;
+    if (clusterEnergyT < lowPtThreshold_) {
+      deltaPhi1 = deltaPhi1Low_;
+    } else if (clusterEnergyT > highPtThreshold_) {
+      deltaPhi1 = deltaPhi1High_;
+    } else {
+      deltaPhi1 = deltaPhi1Coef1_ + deltaPhi1Coef2_ / clusterEnergyT;
+    }
 
-    float ephimin1 = -deltaPhi1*sizeWindowENeg_ ;
-    float ephimax1 =  deltaPhi1*(1.-sizeWindowENeg_);
-    float pphimin1 = -deltaPhi1*(1.-sizeWindowENeg_);
-    float pphimax1 =  deltaPhi1*sizeWindowENeg_;
+    float ephimin1 = -deltaPhi1 * sizeWindowENeg_;
+    float ephimax1 = deltaPhi1 * (1. - sizeWindowENeg_);
+    float pphimin1 = -deltaPhi1 * (1. - sizeWindowENeg_);
+    float pphimax1 = deltaPhi1 * sizeWindowENeg_;
 
-    float phimin2B  = -deltaPhi2B_/2. ;
-    float phimax2B  =  deltaPhi2B_/2. ;
-    float phimin2F  = -deltaPhi2F_/2. ;
-    float phimax2F  =  deltaPhi2F_/2. ;
+    float phimin2B = -deltaPhi2B_ / 2.;
+    float phimax2B = deltaPhi2B_ / 2.;
+    float phimin2F = -deltaPhi2F_ / 2.;
+    float phimax2F = deltaPhi2F_ / 2.;
 
+    myMatchEle->set1stLayer(ephimin1, ephimax1);
+    myMatchPos->set1stLayer(pphimin1, pphimax1);
+    myMatchEle->set2ndLayer(phimin2B, phimax2B, phimin2F, phimax2F);
+    myMatchPos->set2ndLayer(phimin2B, phimax2B, phimin2F, phimax2F);
+  }
 
-    myMatchEle->set1stLayer(ephimin1,ephimax1);
-    myMatchPos->set1stLayer(pphimin1,pphimax1);
-    myMatchEle->set2ndLayer(phimin2B,phimax2B, phimin2F,phimax2F);
-    myMatchPos->set2ndLayer(phimin2B,phimax2B, phimin2F,phimax2F);
-   }
+  PropagationDirection dir = alongMomentum;
 
-  PropagationDirection dir = alongMomentum ;
+  if (!useRecoVertex_)  // here use the beam spot position
+  {
+    double sigmaZ = theBeamSpot->sigmaZ();
+    double sigmaZ0Error = theBeamSpot->sigmaZ0Error();
+    double sq = sqrt(sigmaZ * sigmaZ + sigmaZ0Error * sigmaZ0Error);
+    double myZmin1 = theBeamSpot->position().z() - nSigmasDeltaZ1_ * sq;
+    double myZmax1 = theBeamSpot->position().z() + nSigmasDeltaZ1_ * sq;
 
-  if (!useRecoVertex_) // here use the beam spot position
-   {
-    double sigmaZ=theBeamSpot->sigmaZ();
-    double sigmaZ0Error=theBeamSpot->sigmaZ0Error();
-    double sq=sqrt(sigmaZ*sigmaZ+sigmaZ0Error*sigmaZ0Error);
-    double myZmin1=theBeamSpot->position().z()-nSigmasDeltaZ1_*sq;
-    double myZmax1=theBeamSpot->position().z()+nSigmasDeltaZ1_*sq;
+    GlobalPoint vertexPos;
+    ele_convert(theBeamSpot->position(), vertexPos);
 
-    GlobalPoint vertexPos ;
-    ele_convert(theBeamSpot->position(),vertexPos) ;
+    myMatchEle->set1stLayerZRange(myZmin1, myZmax1);
+    myMatchPos->set1stLayerZRange(myZmin1, myZmax1);
 
-    myMatchEle->set1stLayerZRange(myZmin1,myZmax1);
-    myMatchPos->set1stLayerZRange(myZmin1,myZmax1);
-
-    if (!fromTrackerSeeds_)
-     {
+    if (!fromTrackerSeeds_) {
       // try electron
-      std::vector<std::pair<RecHitWithDist,ConstRecHitPointer> > elePixelHits
-       = myMatchEle->compatibleHits(clusterPos,vertexPos,
-				    clusterEnergy,-1., tTopo, *theNavigationSchool) ;
-      GlobalPoint eleVertex(theBeamSpot->position().x(),theBeamSpot->position().y(),myMatchEle->getVertex()) ;
-      seedsFromRecHits(elePixelHits,dir,eleVertex,caloCluster,out,false) ;
+      std::vector<std::pair<RecHitWithDist, ConstRecHitPointer> > elePixelHits =
+          myMatchEle->compatibleHits(clusterPos, vertexPos, clusterEnergy, -1., tTopo, *theNavigationSchool);
+      GlobalPoint eleVertex(theBeamSpot->position().x(), theBeamSpot->position().y(), myMatchEle->getVertex());
+      seedsFromRecHits(elePixelHits, dir, eleVertex, caloCluster, out, false);
       // try positron
-      std::vector<std::pair<RecHitWithDist,ConstRecHitPointer> > posPixelHits
-	= myMatchPos->compatibleHits(clusterPos,vertexPos,clusterEnergy,1.,tTopo, *theNavigationSchool) ;
-      GlobalPoint posVertex(theBeamSpot->position().x(),theBeamSpot->position().y(),myMatchPos->getVertex()) ;
-      seedsFromRecHits(posPixelHits,dir,posVertex,caloCluster,out,true) ;
-     }
-    else
-     {
+      std::vector<std::pair<RecHitWithDist, ConstRecHitPointer> > posPixelHits =
+          myMatchPos->compatibleHits(clusterPos, vertexPos, clusterEnergy, 1., tTopo, *theNavigationSchool);
+      GlobalPoint posVertex(theBeamSpot->position().x(), theBeamSpot->position().y(), myMatchPos->getVertex());
+      seedsFromRecHits(posPixelHits, dir, posVertex, caloCluster, out, true);
+    } else {
       // try electron
-      std::vector<SeedWithInfo> elePixelSeeds
-       = myMatchEle->compatibleSeeds(*theInitialSeedCollV,clusterPos,vertexPos,clusterEnergy,-1.) ;
-      seedsFromTrajectorySeeds(elePixelSeeds,caloCluster,hoe1,hoe2,out,false) ;
+      std::vector<SeedWithInfo> elePixelSeeds =
+          myMatchEle->compatibleSeeds(*theInitialSeedCollV, clusterPos, vertexPos, clusterEnergy, -1.);
+      seedsFromTrajectorySeeds(elePixelSeeds, caloCluster, hoe1, hoe2, out, false);
       // try positron
-      std::vector<SeedWithInfo> posPixelSeeds
-       = myMatchPos->compatibleSeeds(*theInitialSeedCollV,clusterPos,vertexPos,clusterEnergy,1.) ;
-      seedsFromTrajectorySeeds(posPixelSeeds,caloCluster,hoe1,hoe2,out,true) ;
-     }
+      std::vector<SeedWithInfo> posPixelSeeds =
+          myMatchPos->compatibleSeeds(*theInitialSeedCollV, clusterPos, vertexPos, clusterEnergy, 1.);
+      seedsFromTrajectorySeeds(posPixelSeeds, caloCluster, hoe1, hoe2, out, true);
+    }
 
-   }
-  else // here we use the reco vertices
-   {
+  } else  // here we use the reco vertices
+  {
+    myMatchEle->setUseRecoVertex(true);  //Hit matchers need to know that the vertex is known
+    myMatchPos->setUseRecoVertex(true);
 
-    myMatchEle->setUseRecoVertex(true) ; //Hit matchers need to know that the vertex is known
-    myMatchPos->setUseRecoVertex(true) ;
+    const std::vector<reco::Vertex> *vtxCollection = theVertices.product();
+    std::vector<reco::Vertex>::const_iterator vtxIter;
+    for (vtxIter = vtxCollection->begin(); vtxIter != vtxCollection->end(); vtxIter++) {
+      GlobalPoint vertexPos(vtxIter->position().x(), vtxIter->position().y(), vtxIter->position().z());
+      double myZmin1, myZmax1;
+      if (vertexPos.z() == theBeamSpot->position().z()) {  // in case vetex not found
+        double sigmaZ = theBeamSpot->sigmaZ();
+        double sigmaZ0Error = theBeamSpot->sigmaZ0Error();
+        double sq = sqrt(sigmaZ * sigmaZ + sigmaZ0Error * sigmaZ0Error);
+        myZmin1 = theBeamSpot->position().z() - nSigmasDeltaZ1_ * sq;
+        myZmax1 = theBeamSpot->position().z() + nSigmasDeltaZ1_ * sq;
+      } else {  // a vertex has been recoed
+        myZmin1 = vtxIter->position().z() - deltaZ1WithVertex_;
+        myZmax1 = vtxIter->position().z() + deltaZ1WithVertex_;
+      }
 
-    const  std::vector<reco::Vertex> * vtxCollection = theVertices.product() ;
-    std::vector<reco::Vertex>::const_iterator vtxIter ;
-    for (vtxIter = vtxCollection->begin(); vtxIter != vtxCollection->end() ; vtxIter++)
-     {
+      myMatchEle->set1stLayerZRange(myZmin1, myZmax1);
+      myMatchPos->set1stLayerZRange(myZmin1, myZmax1);
 
-      GlobalPoint vertexPos(vtxIter->position().x(),vtxIter->position().y(),vtxIter->position().z());
-      double myZmin1, myZmax1 ;
-      if (vertexPos.z()==theBeamSpot->position().z())
-       { // in case vetex not found
-        double sigmaZ=theBeamSpot->sigmaZ();
-        double sigmaZ0Error=theBeamSpot->sigmaZ0Error();
-        double sq=sqrt(sigmaZ*sigmaZ+sigmaZ0Error*sigmaZ0Error);
-        myZmin1=theBeamSpot->position().z()-nSigmasDeltaZ1_*sq;
-        myZmax1=theBeamSpot->position().z()+nSigmasDeltaZ1_*sq;
-       }
-      else
-       { // a vertex has been recoed
-        myZmin1=vtxIter->position().z()-deltaZ1WithVertex_;
-        myZmax1=vtxIter->position().z()+deltaZ1WithVertex_;
-       }
-
-      myMatchEle->set1stLayerZRange(myZmin1,myZmax1);
-      myMatchPos->set1stLayerZRange(myZmin1,myZmax1);
-
-      if (!fromTrackerSeeds_)
-       {
+      if (!fromTrackerSeeds_) {
         // try electron
-        std::vector<std::pair<RecHitWithDist,ConstRecHitPointer> > elePixelHits
-	  = myMatchEle->compatibleHits(clusterPos,vertexPos,clusterEnergy,-1.,tTopo, *theNavigationSchool) ;
-        seedsFromRecHits(elePixelHits,dir,vertexPos,caloCluster,out,false) ;
+        std::vector<std::pair<RecHitWithDist, ConstRecHitPointer> > elePixelHits =
+            myMatchEle->compatibleHits(clusterPos, vertexPos, clusterEnergy, -1., tTopo, *theNavigationSchool);
+        seedsFromRecHits(elePixelHits, dir, vertexPos, caloCluster, out, false);
         // try positron
-	      std::vector<std::pair<RecHitWithDist,ConstRecHitPointer> > posPixelHits
-		= myMatchPos->compatibleHits(clusterPos,vertexPos,clusterEnergy,1.,tTopo, *theNavigationSchool) ;
-        seedsFromRecHits(posPixelHits,dir,vertexPos,caloCluster,out,true) ;
-       }
-      else
-       {
+        std::vector<std::pair<RecHitWithDist, ConstRecHitPointer> > posPixelHits =
+            myMatchPos->compatibleHits(clusterPos, vertexPos, clusterEnergy, 1., tTopo, *theNavigationSchool);
+        seedsFromRecHits(posPixelHits, dir, vertexPos, caloCluster, out, true);
+      } else {
         // try electron
-        std::vector<SeedWithInfo> elePixelSeeds
-         = myMatchEle->compatibleSeeds(*theInitialSeedCollV,clusterPos,vertexPos,clusterEnergy,-1.) ;
-        seedsFromTrajectorySeeds(elePixelSeeds,caloCluster,hoe1,hoe2,out,false) ;
+        std::vector<SeedWithInfo> elePixelSeeds =
+            myMatchEle->compatibleSeeds(*theInitialSeedCollV, clusterPos, vertexPos, clusterEnergy, -1.);
+        seedsFromTrajectorySeeds(elePixelSeeds, caloCluster, hoe1, hoe2, out, false);
         // try positron
-        std::vector<SeedWithInfo> posPixelSeeds
-         = myMatchPos->compatibleSeeds(*theInitialSeedCollV,clusterPos,vertexPos,clusterEnergy,1.) ;
-        seedsFromTrajectorySeeds(posPixelSeeds,caloCluster,hoe1,hoe2,out,true) ;
-       }
-     }
-   }
+        std::vector<SeedWithInfo> posPixelSeeds =
+            myMatchPos->compatibleSeeds(*theInitialSeedCollV, clusterPos, vertexPos, clusterEnergy, 1.);
+        seedsFromTrajectorySeeds(posPixelSeeds, caloCluster, hoe1, hoe2, out, true);
+      }
+    }
+  }
 
-  return ;
- }
+  return;
+}
 
-void ElectronSeedGenerator::seedsFromRecHits
- ( std::vector<std::pair<RecHitWithDist,ConstRecHitPointer> > & pixelHits,
-   PropagationDirection & dir,
-   const GlobalPoint & vertexPos, const reco::ElectronSeed::CaloClusterRef & cluster,
-   reco::ElectronSeedCollection & out,
-   bool positron )
- {
-  if (!pixelHits.empty())
-   { LogDebug("ElectronSeedGenerator") << "Compatible "<<(positron?"positron":"electron")<<" hits found." ; }
+void ElectronSeedGenerator::seedsFromRecHits(std::vector<std::pair<RecHitWithDist, ConstRecHitPointer> > &pixelHits,
+                                             PropagationDirection &dir,
+                                             const GlobalPoint &vertexPos,
+                                             const reco::ElectronSeed::CaloClusterRef &cluster,
+                                             reco::ElectronSeedCollection &out,
+                                             bool positron) {
+  if (!pixelHits.empty()) {
+    LogDebug("ElectronSeedGenerator") << "Compatible " << (positron ? "positron" : "electron") << " hits found.";
+  }
 
-  std::vector<std::pair<RecHitWithDist,ConstRecHitPointer> >::iterator v ;
-  for ( v = pixelHits.begin() ; v != pixelHits.end() ; v++ )
-   {
-    if (!positron)
-     { (*v).first.invert() ; }
-    if (!prepareElTrackSeed((*v).first.recHit(),(*v).second,vertexPos))
-     { continue ; }
-    reco::ElectronSeed seed(pts_,recHits_,dir) ;
-    seed.setCaloCluster(cluster) ;
-    addSeed(seed,nullptr,positron,out) ;
-   }
- }
+  std::vector<std::pair<RecHitWithDist, ConstRecHitPointer> >::iterator v;
+  for (v = pixelHits.begin(); v != pixelHits.end(); v++) {
+    if (!positron) {
+      (*v).first.invert();
+    }
+    if (!prepareElTrackSeed((*v).first.recHit(), (*v).second, vertexPos)) {
+      continue;
+    }
+    reco::ElectronSeed seed(pts_, recHits_, dir);
+    seed.setCaloCluster(cluster);
+    addSeed(seed, nullptr, positron, out);
+  }
+}
 
-void ElectronSeedGenerator::seedsFromTrajectorySeeds
- ( const std::vector<SeedWithInfo> & pixelSeeds,
-   const reco::ElectronSeed::CaloClusterRef & cluster,
-   float hoe1, float hoe2,
-   reco::ElectronSeedCollection & out,
-   bool positron )
- {
-  if (!pixelSeeds.empty())
-   { LogDebug("ElectronSeedGenerator") << "Compatible "<<(positron?"positron":"electron")<<" seeds found." ; }
+void ElectronSeedGenerator::seedsFromTrajectorySeeds(const std::vector<SeedWithInfo> &pixelSeeds,
+                                                     const reco::ElectronSeed::CaloClusterRef &cluster,
+                                                     float hoe1,
+                                                     float hoe2,
+                                                     reco::ElectronSeedCollection &out,
+                                                     bool positron) {
+  if (!pixelSeeds.empty()) {
+    LogDebug("ElectronSeedGenerator") << "Compatible " << (positron ? "positron" : "electron") << " seeds found.";
+  }
 
   std::vector<SeedWithInfo>::const_iterator s;
-  for ( s = pixelSeeds.begin() ; s != pixelSeeds.end() ; s++ )
-   {
-    reco::ElectronSeed seed(s->seed()) ;
+  for (s = pixelSeeds.begin(); s != pixelSeeds.end(); s++) {
+    reco::ElectronSeed seed(s->seed());
     seed.setCaloCluster(cluster);
     seed.initTwoHitSeed(s->hitsMask());
-    addSeed(seed,&*s,positron,out) ;
-   }
- }
+    addSeed(seed, &*s, positron, out);
+  }
+}
 
-void ElectronSeedGenerator::addSeed
- ( reco::ElectronSeed & seed,
-   const SeedWithInfo * info,
-   bool positron,
-   reco::ElectronSeedCollection & out )
- {
-  if (!info)
-    { out.emplace_back(seed) ; return ; }
+void ElectronSeedGenerator::addSeed(reco::ElectronSeed &seed,
+                                    const SeedWithInfo *info,
+                                    bool positron,
+                                    reco::ElectronSeedCollection &out) {
+  if (!info) {
+    out.emplace_back(seed);
+    return;
+  }
 
-  if (positron)
-   { seed.setPosAttributes(info->dRz2(),info->dPhi2(),info->dRz1(),info->dPhi1()) ; }
-  else
-   { seed.setNegAttributes(info->dRz2(),info->dPhi2(),info->dRz1(),info->dPhi1()) ; }
-  reco::ElectronSeedCollection::iterator resItr ;
-  for ( resItr=out.begin() ; resItr!=out.end() ; ++resItr )
-   {
-    if ( (seed.caloCluster().key()==resItr->caloCluster().key()) &&
-         (seed.hitsMask()==resItr->hitsMask()) &&
-         equivalent(seed,*resItr) )
-     {
-      if (positron)
-       {
-        if ( resItr->dRz2Pos()==std::numeric_limits<float>::infinity() &&
-             resItr->dRz2()!=std::numeric_limits<float>::infinity() )
-         {
-          resItr->setPosAttributes(info->dRz2(),info->dPhi2(),info->dRz1(),info->dPhi1()) ;
-          seed.setNegAttributes(resItr->dRz2(),resItr->dPhi2(),resItr->dRz1(),resItr->dPhi1()) ;
-          break ;
-         }
-        else
-         {
-          if ( resItr->dRz2Pos()!=std::numeric_limits<float>::infinity() )
-           {
-            if ( resItr->dRz2Pos()!=seed.dRz2Pos() )
-             {
+  if (positron) {
+    seed.setPosAttributes(info->dRz2(), info->dPhi2(), info->dRz1(), info->dPhi1());
+  } else {
+    seed.setNegAttributes(info->dRz2(), info->dPhi2(), info->dRz1(), info->dPhi1());
+  }
+  reco::ElectronSeedCollection::iterator resItr;
+  for (resItr = out.begin(); resItr != out.end(); ++resItr) {
+    if ((seed.caloCluster().key() == resItr->caloCluster().key()) && (seed.hitsMask() == resItr->hitsMask()) &&
+        equivalent(seed, *resItr)) {
+      if (positron) {
+        if (resItr->dRz2Pos() == std::numeric_limits<float>::infinity() &&
+            resItr->dRz2() != std::numeric_limits<float>::infinity()) {
+          resItr->setPosAttributes(info->dRz2(), info->dPhi2(), info->dRz1(), info->dPhi1());
+          seed.setNegAttributes(resItr->dRz2(), resItr->dPhi2(), resItr->dRz1(), resItr->dPhi1());
+          break;
+        } else {
+          if (resItr->dRz2Pos() != std::numeric_limits<float>::infinity()) {
+            if (resItr->dRz2Pos() != seed.dRz2Pos()) {
               edm::LogWarning("ElectronSeedGenerator|BadValue")
-               <<"this similar old seed already has another dRz2Pos"
-               <<"\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: "<<(unsigned int)resItr->hitsMask()<<"/"<<resItr->dRz2()<<"/"<<resItr->dPhi2()<<"/"<<resItr->dRz2Pos()<<"/"<<resItr->dPhi2Pos()
-               <<"\nnew seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: "<<(unsigned int)seed.hitsMask()<<"/"<<seed.dRz2()<<"/"<<seed.dPhi2()<<"/"<<seed.dRz2Pos()<<"/"<<seed.dPhi2Pos() ;
-             }
-//            else
-//             {
-//              edm::LogWarning("ElectronSeedGenerator|UnexpectedValue")
-//               <<"this old seed already knows its dRz2Pos, we suspect duplicates in input trajectry seeds"
-//               <<"\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: "<<(unsigned int)resItr->hitsMask()<<"/"<<resItr->dRz2()<<"/"<<resItr->dPhi2()<<"/"<<resItr->dRz2Pos()<<"/"<<resItr->dPhi2Pos()
-//               <<"\nnew seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: "<<(unsigned int)seed.hitsMask()<<"/"<<seed.dRz2()<<"/"<<seed.dPhi2()<<"/"<<seed.dRz2Pos()<<"/"<<seed.dPhi2Pos() ;
-//             }
+                  << "this similar old seed already has another dRz2Pos"
+                  << "\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)resItr->hitsMask() << "/"
+                  << resItr->dRz2() << "/" << resItr->dPhi2() << "/" << resItr->dRz2Pos() << "/" << resItr->dPhi2Pos()
+                  << "\nnew seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)seed.hitsMask() << "/"
+                  << seed.dRz2() << "/" << seed.dPhi2() << "/" << seed.dRz2Pos() << "/" << seed.dPhi2Pos();
             }
-//          if (resItr->dRz2()==std::numeric_limits<float>::infinity())
-//           {
-//            edm::LogWarning("ElectronSeedGenerator|BadValue")
-//             <<"this old seed has no dRz2, we suspect duplicates in input trajectry seeds"
-//             <<"\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: "<<(unsigned int)resItr->hitsMask()<<"/"<<resItr->dRz2()<<"/"<<resItr->dPhi2()<<"/"<<resItr->dRz2Pos()<<"/"<<resItr->dPhi2Pos()
-//             <<"\nnew seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: "<<(unsigned int)seed.hitsMask()<<"/"<<seed.dRz2()<<"/"<<seed.dPhi2()<<"/"<<seed.dRz2Pos()<<"/"<<seed.dPhi2Pos() ;
-//           }
-         }
-       }
-      else
-       {
-        if ( resItr->dRz2()==std::numeric_limits<float>::infinity()
-          && resItr->dRz2Pos()!=std::numeric_limits<float>::infinity() )
-         {
-          resItr->setNegAttributes(info->dRz2(),info->dPhi2(),info->dRz1(),info->dPhi1()) ;
-          seed.setPosAttributes(resItr->dRz2Pos(),resItr->dPhi2Pos(),resItr->dRz1Pos(),resItr->dPhi1Pos()) ;
-          break ;
-         }
-        else
-         {
-          if ( resItr->dRz2()!=std::numeric_limits<float>::infinity() )
-           {
-            if (resItr->dRz2()!=seed.dRz2())
-             {
+            //            else
+            //             {
+            //              edm::LogWarning("ElectronSeedGenerator|UnexpectedValue")
+            //               <<"this old seed already knows its dRz2Pos, we suspect duplicates in input trajectry seeds"
+            //               <<"\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: "<<(unsigned int)resItr->hitsMask()<<"/"<<resItr->dRz2()<<"/"<<resItr->dPhi2()<<"/"<<resItr->dRz2Pos()<<"/"<<resItr->dPhi2Pos()
+            //               <<"\nnew seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: "<<(unsigned int)seed.hitsMask()<<"/"<<seed.dRz2()<<"/"<<seed.dPhi2()<<"/"<<seed.dRz2Pos()<<"/"<<seed.dPhi2Pos() ;
+            //             }
+          }
+          //          if (resItr->dRz2()==std::numeric_limits<float>::infinity())
+          //           {
+          //            edm::LogWarning("ElectronSeedGenerator|BadValue")
+          //             <<"this old seed has no dRz2, we suspect duplicates in input trajectry seeds"
+          //             <<"\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: "<<(unsigned int)resItr->hitsMask()<<"/"<<resItr->dRz2()<<"/"<<resItr->dPhi2()<<"/"<<resItr->dRz2Pos()<<"/"<<resItr->dPhi2Pos()
+          //             <<"\nnew seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: "<<(unsigned int)seed.hitsMask()<<"/"<<seed.dRz2()<<"/"<<seed.dPhi2()<<"/"<<seed.dRz2Pos()<<"/"<<seed.dPhi2Pos() ;
+          //           }
+        }
+      } else {
+        if (resItr->dRz2() == std::numeric_limits<float>::infinity() &&
+            resItr->dRz2Pos() != std::numeric_limits<float>::infinity()) {
+          resItr->setNegAttributes(info->dRz2(), info->dPhi2(), info->dRz1(), info->dPhi1());
+          seed.setPosAttributes(resItr->dRz2Pos(), resItr->dPhi2Pos(), resItr->dRz1Pos(), resItr->dPhi1Pos());
+          break;
+        } else {
+          if (resItr->dRz2() != std::numeric_limits<float>::infinity()) {
+            if (resItr->dRz2() != seed.dRz2()) {
               edm::LogWarning("ElectronSeedGenerator|BadValue")
-               <<"this old seed already has another dRz2"
-               <<"\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: "<<(unsigned int)resItr->hitsMask()<<"/"<<resItr->dRz2()<<"/"<<resItr->dPhi2()<<"/"<<resItr->dRz2Pos()<<"/"<<resItr->dPhi2Pos()
-               <<"\nnew seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: "<<(unsigned int)seed.hitsMask()<<"/"<<seed.dRz2()<<"/"<<seed.dPhi2()<<"/"<<seed.dRz2Pos()<<"/"<<seed.dPhi2Pos() ;
-             }
-    //        else
-    //         {
-    //          edm::LogWarning("ElectronSeedGenerator|UnexpectedValue")
-    //           <<"this old seed already knows its dRz2, we suspect duplicates in input trajectry seeds"
-    //           <<"\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: "<<(unsigned int)resItr->hitsMask()<<"/"<<resItr->dRz2()<<"/"<<resItr->dPhi2()<<"/"<<resItr->dRz2Pos()<<"/"<<resItr->dPhi2Pos()
-    //           <<"\nnew seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: "<<(unsigned int)seed.hitsMask()<<"/"<<seed.dRz2()<<"/"<<seed.dPhi2()<<"/"<<seed.dRz2Pos()<<"/"<<seed.dPhi2Pos() ;
-    //          seed.setPosAttributes(resItr->dRz2Pos(),resItr->dPhi2Pos(),resItr->dRz1Pos(),resItr->dPhi1Pos()) ;
-    //         }
-           }
-//          if (resItr->dRz2Pos()==std::numeric_limits<float>::infinity())
-//           {
-//            edm::LogWarning("ElectronSeedGenerator|BadValue")
-//             <<"this old seed has no dRz2Pos"
-//             <<"\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: "<<(unsigned int)resItr->hitsMask()<<"/"<<resItr->dRz2()<<"/"<<resItr->dPhi2()<<"/"<<resItr->dRz2Pos()<<"/"<<resItr->dPhi2Pos()
-//             <<"\nnew seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: "<<(unsigned int)seed.hitsMask()<<"/"<<seed.dRz2()<<"/"<<seed.dPhi2()<<"/"<<seed.dRz2Pos()<<"/"<<seed.dPhi2Pos() ;
-//           }
-         }
-       }
-     }
-   }
+                  << "this old seed already has another dRz2"
+                  << "\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)resItr->hitsMask() << "/"
+                  << resItr->dRz2() << "/" << resItr->dPhi2() << "/" << resItr->dRz2Pos() << "/" << resItr->dPhi2Pos()
+                  << "\nnew seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: " << (unsigned int)seed.hitsMask() << "/"
+                  << seed.dRz2() << "/" << seed.dPhi2() << "/" << seed.dRz2Pos() << "/" << seed.dPhi2Pos();
+            }
+            //        else
+            //         {
+            //          edm::LogWarning("ElectronSeedGenerator|UnexpectedValue")
+            //           <<"this old seed already knows its dRz2, we suspect duplicates in input trajectry seeds"
+            //           <<"\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: "<<(unsigned int)resItr->hitsMask()<<"/"<<resItr->dRz2()<<"/"<<resItr->dPhi2()<<"/"<<resItr->dRz2Pos()<<"/"<<resItr->dPhi2Pos()
+            //           <<"\nnew seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: "<<(unsigned int)seed.hitsMask()<<"/"<<seed.dRz2()<<"/"<<seed.dPhi2()<<"/"<<seed.dRz2Pos()<<"/"<<seed.dPhi2Pos() ;
+            //          seed.setPosAttributes(resItr->dRz2Pos(),resItr->dPhi2Pos(),resItr->dRz1Pos(),resItr->dPhi1Pos()) ;
+            //         }
+          }
+          //          if (resItr->dRz2Pos()==std::numeric_limits<float>::infinity())
+          //           {
+          //            edm::LogWarning("ElectronSeedGenerator|BadValue")
+          //             <<"this old seed has no dRz2Pos"
+          //             <<"\nold seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: "<<(unsigned int)resItr->hitsMask()<<"/"<<resItr->dRz2()<<"/"<<resItr->dPhi2()<<"/"<<resItr->dRz2Pos()<<"/"<<resItr->dPhi2Pos()
+          //             <<"\nnew seed mask/dRz2/dPhi2/dRz2Pos/dPhi2Pos: "<<(unsigned int)seed.hitsMask()<<"/"<<seed.dRz2()<<"/"<<seed.dPhi2()<<"/"<<seed.dRz2Pos()<<"/"<<seed.dPhi2Pos() ;
+          //           }
+        }
+      }
+    }
+  }
 
-  out.emplace_back(seed) ;
- }
+  out.emplace_back(seed);
+}
 
-bool ElectronSeedGenerator::prepareElTrackSeed
- ( ConstRecHitPointer innerhit,
-   ConstRecHitPointer outerhit,
-   const GlobalPoint& vertexPos )
- {
-
+bool ElectronSeedGenerator::prepareElTrackSeed(ConstRecHitPointer innerhit,
+                                               ConstRecHitPointer outerhit,
+                                               const GlobalPoint &vertexPos) {
   // debug prints
-  LogDebug("") <<"[ElectronSeedGenerator::prepareElTrackSeed] inner PixelHit   x,y,z "<<innerhit->globalPosition();
-  LogDebug("") <<"[ElectronSeedGenerator::prepareElTrackSeed] outer PixelHit   x,y,z "<<outerhit->globalPosition();
+  LogDebug("") << "[ElectronSeedGenerator::prepareElTrackSeed] inner PixelHit   x,y,z " << innerhit->globalPosition();
+  LogDebug("") << "[ElectronSeedGenerator::prepareElTrackSeed] outer PixelHit   x,y,z " << outerhit->globalPosition();
 
   recHits_.clear();
 
-  SiPixelRecHit *pixhit=nullptr;
-  SiStripMatchedRecHit2D *striphit=nullptr;
-  const SiPixelRecHit* constpixhit = dynamic_cast <const SiPixelRecHit*> (innerhit->hit());
+  SiPixelRecHit *pixhit = nullptr;
+  SiStripMatchedRecHit2D *striphit = nullptr;
+  const SiPixelRecHit *constpixhit = dynamic_cast<const SiPixelRecHit *>(innerhit->hit());
   if (constpixhit) {
-    pixhit=new SiPixelRecHit(*constpixhit);
+    pixhit = new SiPixelRecHit(*constpixhit);
     recHits_.push_back(pixhit);
-  } else  return false;
-  constpixhit =  dynamic_cast <const SiPixelRecHit *> (outerhit->hit());
+  } else
+    return false;
+  constpixhit = dynamic_cast<const SiPixelRecHit *>(outerhit->hit());
   if (constpixhit) {
-    pixhit=new SiPixelRecHit(*constpixhit);
+    pixhit = new SiPixelRecHit(*constpixhit);
     recHits_.push_back(pixhit);
   } else {
-    const SiStripMatchedRecHit2D * conststriphit=dynamic_cast <const SiStripMatchedRecHit2D *> (outerhit->hit());
+    const SiStripMatchedRecHit2D *conststriphit = dynamic_cast<const SiStripMatchedRecHit2D *>(outerhit->hit());
     if (conststriphit) {
       striphit = new SiStripMatchedRecHit2D(*conststriphit);
       recHits_.push_back(striphit);
-    } else return false;
+    } else
+      return false;
   }
 
-  typedef TrajectoryStateOnSurface     TSOS;
+  typedef TrajectoryStateOnSurface TSOS;
 
   // FIXME to be optimized outside the loop
   edm::ESHandle<MagneticField> bfield;
@@ -618,24 +594,26 @@ bool ElectronSeedGenerator::prepareElTrackSeed
   float nomField = bfield->nominalValue();
 
   // make a spiral
-  FastHelix helix(outerhit->globalPosition(),innerhit->globalPosition(),vertexPos,nomField,&*bfield);
-  if ( !helix.isValid()) {
+  FastHelix helix(outerhit->globalPosition(), innerhit->globalPosition(), vertexPos, nomField, &*bfield);
+  if (!helix.isValid()) {
     return false;
   }
   FreeTrajectoryState fts(helix.stateAtVertex());
-  TSOS propagatedState = thePropagator->propagate(fts,innerhit->det()->surface()) ;
+  TSOS propagatedState = thePropagator->propagate(fts, innerhit->det()->surface());
   if (!propagatedState.isValid())
     return false;
   TSOS updatedState = theUpdator->update(propagatedState, *innerhit);
 
-  TSOS propagatedState_out = thePropagator->propagate(updatedState,outerhit->det()->surface()) ;
+  TSOS propagatedState_out = thePropagator->propagate(updatedState, outerhit->det()->surface());
   if (!propagatedState_out.isValid())
     return false;
   TSOS updatedState_out = theUpdator->update(propagatedState_out, *outerhit);
   // debug prints
-  LogDebug("") <<"[ElectronSeedGenerator::prepareElTrackSeed] final TSOS, position: "<<updatedState_out.globalPosition()<<" momentum: "<<updatedState_out.globalMomentum();
-  LogDebug("") <<"[ElectronSeedGenerator::prepareElTrackSeed] final TSOS Pt: "<<updatedState_out.globalMomentum().perp();
-  pts_ =  trajectoryStateTransform::persistentState(updatedState_out, outerhit->geographicalId().rawId());
+  LogDebug("") << "[ElectronSeedGenerator::prepareElTrackSeed] final TSOS, position: "
+               << updatedState_out.globalPosition() << " momentum: " << updatedState_out.globalMomentum();
+  LogDebug("") << "[ElectronSeedGenerator::prepareElTrackSeed] final TSOS Pt: "
+               << updatedState_out.globalMomentum().perp();
+  pts_ = trajectoryStateTransform::persistentState(updatedState_out, outerhit->geographicalId().rawId());
 
   return true;
- }
+}

--- a/RecoEgamma/EgammaElectronAlgos/src/EnergyUncertaintyElectronSpecific.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/EnergyUncertaintyElectronSpecific.cc
@@ -3,642 +3,427 @@
 
 #include <iostream>
 
+EnergyUncertaintyElectronSpecific::EnergyUncertaintyElectronSpecific() {}
 
-EnergyUncertaintyElectronSpecific::EnergyUncertaintyElectronSpecific() {
+EnergyUncertaintyElectronSpecific::~EnergyUncertaintyElectronSpecific() {}
+
+void EnergyUncertaintyElectronSpecific::init(const edm::EventSetup& theEventSetup) {}
+
+double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty(reco::GsfElectron::Classification c,
+                                                                           double eta,
+                                                                           double brem,
+                                                                           double energy) {
+  if (c == reco::GsfElectron::GOLDEN)
+    return computeElectronEnergyUncertainty_golden(eta, brem, energy);
+  if (c == reco::GsfElectron::BIGBREM)
+    return computeElectronEnergyUncertainty_bigbrem(eta, brem, energy);
+  if (c == reco::GsfElectron::SHOWERING)
+    return computeElectronEnergyUncertainty_showering(eta, brem, energy);
+  if (c == reco::GsfElectron::BADTRACK)
+    return computeElectronEnergyUncertainty_badtrack(eta, brem, energy);
+  if (c == reco::GsfElectron::GAP)
+    return computeElectronEnergyUncertainty_cracks(eta, brem, energy);
+  throw cms::Exception("GsfElectronAlgo|InternalError") << "unknown classification";
 }
 
-EnergyUncertaintyElectronSpecific::~EnergyUncertaintyElectronSpecific()
- {}
+double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_golden(double eta,
+                                                                                  double brem,
+                                                                                  double energy) {
+  double et = energy / cosh(eta);
 
-void EnergyUncertaintyElectronSpecific::init(  const edm::EventSetup& theEventSetup )
- {}
+  constexpr int nBinsEta = 5;
+  constexpr Double_t EtaBins[nBinsEta + 1] = {0.0, 0.4, 0.8, 1.5, 2.0, 2.5};
 
-double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty( reco::GsfElectron::Classification c, double eta, double brem, double energy)
- {
-  if (c == reco::GsfElectron::GOLDEN) return computeElectronEnergyUncertainty_golden(eta,brem,energy) ;
-  if (c == reco::GsfElectron::BIGBREM) return computeElectronEnergyUncertainty_bigbrem(eta,brem,energy) ;
-  if (c == reco::GsfElectron::SHOWERING) return computeElectronEnergyUncertainty_showering(eta,brem,energy) ;
-  if (c == reco::GsfElectron::BADTRACK) return computeElectronEnergyUncertainty_badtrack(eta,brem,energy) ;
-  if (c == reco::GsfElectron::GAP) return computeElectronEnergyUncertainty_cracks(eta,brem,energy) ;
-  throw cms::Exception("GsfElectronAlgo|InternalError")<<"unknown classification" ;
- }
+  constexpr int nBinsBrem = 6;
+  constexpr Double_t BremBins[nBinsBrem + 1] = {0.8, 1.0, 1.1, 1.2, 1.3, 1.5, 8.0};
 
-double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_golden(double eta, double brem, double energy){
+  constexpr float par0[nBinsEta][nBinsBrem] = {{0.00567891, 0.0065673, 0.00574742, 0.00542964, 0.00523293, 0.00547518},
 
-  double et = energy/cosh(eta);
+                                               {0.00552517, 0.00611188, 0.0062729, 0.00574846, 0.00447373, 0.00595789},
 
-  constexpr int nBinsEta=5;
-  constexpr Double_t EtaBins[nBinsEta+1]  = {0.0, 0.4, 0.8, 1.5, 2.0, 2.5};
+                                               {0.00356679, 0.00503827, 0.00328016, 0.00592303, 0.00512479, 0.00484166},
 
-  constexpr int nBinsBrem=6;
-  constexpr Double_t BremBins[nBinsBrem+1]= {0.8,  1.0, 1.1, 1.2, 1.3, 1.5, 8.0};
+                                               {0.0109195, 0.0102361, 0.0101576, 0.0120683, 0.0155326, 0.0225035},
 
-  constexpr float par0[nBinsEta][nBinsBrem] = {
-    {0.00567891,
-     0.0065673,
-     0.00574742,
-     0.00542964,
-     0.00523293,
-     0.00547518},
-
-    {0.00552517,
-     0.00611188,
-     0.0062729,
-     0.00574846,
-     0.00447373,
-     0.00595789},
-
-    {0.00356679,
-     0.00503827,
-     0.00328016,
-     0.00592303,
-     0.00512479,
-     0.00484166},
-
-    {0.0109195,
-     0.0102361,
-     0.0101576,
-     0.0120683,
-     0.0155326,
-     0.0225035},
-
-    {0.0109632,
-     0.0103342,
-     0.0103486,
-     0.00862762,
-     0.0111448,
-     0.0146648}};
+                                               {0.0109632, 0.0103342, 0.0103486, 0.00862762, 0.0111448, 0.0146648}};
 
   static_assert(par0[0][0] == 0.00567891f);
   static_assert(par0[0][1] == 0.0065673f);
   static_assert(par0[1][3] == 0.00574846f);
 
-  constexpr float par1[nBinsEta][nBinsBrem] = {
-    {0.238685,
-     0.193642,
-     0.249171,
-     0.259997,
-     0.310505,
-     0.390506},
+  constexpr float par1[nBinsEta][nBinsBrem] = {{0.238685, 0.193642, 0.249171, 0.259997, 0.310505, 0.390506},
 
-    {0.288736,
-     0.312303,
-     0.294717,
-     0.294491,
-     0.379178,
-     0.38164},
+                                               {0.288736, 0.312303, 0.294717, 0.294491, 0.379178, 0.38164},
 
-    {0.456456,
-     0.394912,
-     0.541713,
-     0.401744,
-     0.483151,
-     0.657995},
+                                               {0.456456, 0.394912, 0.541713, 0.401744, 0.483151, 0.657995},
 
-    {1.13803,
-     1.39866,
-     1.51353,
-     1.48587,
-     1.49732,
-     1.82363},
+                                               {1.13803, 1.39866, 1.51353, 1.48587, 1.49732, 1.82363},
 
-    {0.458212,
-     0.628761,
-     0.659144,
-     0.929563,
-     1.06724,
-     1.6427}};
+                                               {0.458212, 0.628761, 0.659144, 0.929563, 1.06724, 1.6427}};
 
-  constexpr float par2[nBinsEta][nBinsBrem] = {
-    {2.12035,
-     3.41493,
-     1.7401,
-     1.46234,
-     0.233226,
-     -2.78168},
+  constexpr float par2[nBinsEta][nBinsBrem] = {{2.12035, 3.41493, 1.7401, 1.46234, 0.233226, -2.78168},
 
-    {1.30552,
-     0.137905,
-     0.653793,
-     0.790746,
-     -1.42584,
-     -2.34653},
+                                               {1.30552, 0.137905, 0.653793, 0.790746, -1.42584, -2.34653},
 
-    {0.610716,
-     0.778879,
-     -1.58577,
-     1.45098,
-     -0.0985911,
-     -3.47167},
-    {
-      -3.48281,
-      -6.4736,
-      -8.03308,
-      -7.55974,
-      -7.98843,
-      -10.1027},
+                                               {0.610716, 0.778879, -1.58577, 1.45098, -0.0985911, -3.47167},
+                                               {-3.48281, -6.4736, -8.03308, -7.55974, -7.98843, -10.1027},
 
-    {0.995183,
-     -2.42889,
-     -2.14073,
-     -6.27768,
-     -7.68512,
-     -13.3504}};
+                                               {0.995183, -2.42889, -2.14073, -6.27768, -7.68512, -13.3504}};
 
   Int_t iEtaSl = -1;
-  for (Int_t iEta = 0; iEta < nBinsEta; ++iEta){
-    if ( EtaBins[iEta] <= fabs(eta) && fabs(eta) <EtaBins[iEta+1] ){
+  for (Int_t iEta = 0; iEta < nBinsEta; ++iEta) {
+    if (EtaBins[iEta] <= fabs(eta) && fabs(eta) < EtaBins[iEta + 1]) {
       iEtaSl = iEta;
     }
   }
 
   Int_t iBremSl = -1;
-  for (Int_t iBrem = 0; iBrem < nBinsBrem; ++iBrem){
-    if ( BremBins[iBrem] <= brem && brem <BremBins[iBrem+1] ){
+  for (Int_t iBrem = 0; iBrem < nBinsBrem; ++iBrem) {
+    if (BremBins[iBrem] <= brem && brem < BremBins[iBrem + 1]) {
       iBremSl = iBrem;
     }
   }
 
-  if (fabs(eta)>2.5) iEtaSl = nBinsEta-1;
-  if (brem<BremBins[0]) iBremSl = 0;
-  if (brem>BremBins[nBinsBrem-1]) iBremSl = nBinsBrem-1;
+  if (fabs(eta) > 2.5)
+    iEtaSl = nBinsEta - 1;
+  if (brem < BremBins[0])
+    iBremSl = 0;
+  if (brem > BremBins[nBinsBrem - 1])
+    iBremSl = nBinsBrem - 1;
 
-  if(iEtaSl == -1) {
-    edm::LogError("BadRange")<<"Bad eta value: "<<eta<<" in computeElectronEnergyUncertainty_golden";
+  if (iEtaSl == -1) {
+    edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeElectronEnergyUncertainty_golden";
     return 0;
   }
 
-  if(iBremSl == -1) {
-    edm::LogError("BadRange")<<"Bad brem value: "<<brem<<" in computeElectronEnergyUncertainty_golden";
+  if (iBremSl == -1) {
+    edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeElectronEnergyUncertainty_golden";
     return 0;
   }
 
   float uncertainty = 0;
-  if (et<5) uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl]/(5-par2[iEtaSl][iBremSl]);
-  if (et>100) uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl]/(100-par2[iEtaSl][iBremSl]);
+  if (et < 5)
+    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (5 - par2[iEtaSl][iBremSl]);
+  if (et > 100)
+    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (100 - par2[iEtaSl][iBremSl]);
 
-  if (et>5 && et<100) uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl]/(et-par2[iEtaSl][iBremSl]);
+  if (et > 5 && et < 100)
+    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (et - par2[iEtaSl][iBremSl]);
 
-  return (uncertainty*energy);
-
+  return (uncertainty * energy);
 }
 
-double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_bigbrem(double eta, double brem, double energy){
+double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_bigbrem(double eta,
+                                                                                   double brem,
+                                                                                   double energy) {
+  const double et = energy / cosh(eta);
 
-  const double et = energy/cosh(eta);
+  constexpr int nBinsEta = 4;
+  constexpr Double_t EtaBins[nBinsEta + 1] = {0.0, 0.8, 1.5, 2.0, 2.5};
 
-  constexpr int nBinsEta=4;
-  constexpr Double_t EtaBins[nBinsEta+1]  = {0.0,  0.8,  1.5,  2.0,  2.5};
+  constexpr int nBinsBrem = 1;
+  constexpr Double_t BremBins[nBinsBrem + 1] = {0.8, 8.0};
 
-  constexpr int nBinsBrem=1;
-  constexpr Double_t BremBins[nBinsBrem+1]= {0.8,  8.0};
+  constexpr float par0[nBinsEta][nBinsBrem] = {{0.00593389}, {0.00266954}, {0.00500623}, {0.00841038}};
 
-  constexpr float par0[nBinsEta][nBinsBrem] =
-    {{0.00593389}, {0.00266954},
-     {0.00500623}, {0.00841038} };
+  constexpr float par1[nBinsEta][nBinsBrem] = {{0.178275}, {0.811415}, {2.34018}, {1.06851}};
 
-  constexpr float par1[nBinsEta][nBinsBrem] =
-    {{0.178275},
-     {0.811415},
-     {2.34018},
-     {1.06851}};
+  constexpr float par2[nBinsEta][nBinsBrem] = {{-7.28273}, {-1.66063}, {-11.0129}, {-4.1259}};
 
-  constexpr float par2[nBinsEta][nBinsBrem] =
-    {{-7.28273},
-     {-1.66063},
-     {-11.0129},
-     {-4.1259}};
-
-  constexpr float par3[nBinsEta][nBinsBrem] =
-    {{13.2632},
-     {1.03555},
-     {-0.200323},
-     {-0.0646195}};
-
+  constexpr float par3[nBinsEta][nBinsBrem] = {{13.2632}, {1.03555}, {-0.200323}, {-0.0646195}};
 
   Int_t iEtaSl = -1;
-  for (Int_t iEta = 0; iEta < nBinsEta; ++iEta){
-    if ( EtaBins[iEta] <= fabs(eta) && fabs(eta) <EtaBins[iEta+1] ){
+  for (Int_t iEta = 0; iEta < nBinsEta; ++iEta) {
+    if (EtaBins[iEta] <= fabs(eta) && fabs(eta) < EtaBins[iEta + 1]) {
       iEtaSl = iEta;
     }
   }
 
   Int_t iBremSl = -1;
-  for (Int_t iBrem = 0; iBrem < nBinsBrem; ++iBrem){
-    if ( BremBins[iBrem] <= brem && brem <BremBins[iBrem+1] ){
+  for (Int_t iBrem = 0; iBrem < nBinsBrem; ++iBrem) {
+    if (BremBins[iBrem] <= brem && brem < BremBins[iBrem + 1]) {
       iBremSl = iBrem;
     }
   }
 
-  if (fabs(eta)>2.5) iEtaSl = nBinsEta-1;
-  if (brem<BremBins[0]) iBremSl = 0;
-  if (brem>BremBins[nBinsBrem-1]) iBremSl = nBinsBrem-1;
+  if (fabs(eta) > 2.5)
+    iEtaSl = nBinsEta - 1;
+  if (brem < BremBins[0])
+    iBremSl = 0;
+  if (brem > BremBins[nBinsBrem - 1])
+    iBremSl = nBinsBrem - 1;
 
-  if(iEtaSl == -1) {
-    edm::LogError("BadRange")<<"Bad eta value: "<<eta<<" in computeElectronEnergyUncertainty_bigbrem";
+  if (iEtaSl == -1) {
+    edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeElectronEnergyUncertainty_bigbrem";
     return 0;
   }
 
-  if(iBremSl == -1) {
-    edm::LogError("BadRange")<<"Bad brem value: "<<brem<<" in computeElectronEnergyUncertainty_bigbrem";
+  if (iBremSl == -1) {
+    edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeElectronEnergyUncertainty_bigbrem";
     return 0;
   }
 
   float uncertainty = 0;
-  if (et<5) uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl]/(5-par2[iEtaSl][iBremSl]) + par3[iEtaSl][iBremSl]/((5-par2[iEtaSl][iBremSl])*(5-par2[iEtaSl][iBremSl]));
-  if (et>100) uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl]/(100-par2[iEtaSl][iBremSl]) + par3[iEtaSl][iBremSl]/((100-par2[iEtaSl][iBremSl])*(100-par2[iEtaSl][iBremSl]));
+  if (et < 5)
+    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (5 - par2[iEtaSl][iBremSl]) +
+                  par3[iEtaSl][iBremSl] / ((5 - par2[iEtaSl][iBremSl]) * (5 - par2[iEtaSl][iBremSl]));
+  if (et > 100)
+    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (100 - par2[iEtaSl][iBremSl]) +
+                  par3[iEtaSl][iBremSl] / ((100 - par2[iEtaSl][iBremSl]) * (100 - par2[iEtaSl][iBremSl]));
 
-  if (et>5 && et<100) uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl]/(et-par2[iEtaSl][iBremSl]) + par3[iEtaSl][iBremSl]/((et-par2[iEtaSl][iBremSl])*(et-par2[iEtaSl][iBremSl]));
+  if (et > 5 && et < 100)
+    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (et - par2[iEtaSl][iBremSl]) +
+                  par3[iEtaSl][iBremSl] / ((et - par2[iEtaSl][iBremSl]) * (et - par2[iEtaSl][iBremSl]));
 
-  return (uncertainty*energy);
-
+  return (uncertainty * energy);
 }
-double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_badtrack(double eta, double brem, double energy){
+double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_badtrack(double eta,
+                                                                                    double brem,
+                                                                                    double energy) {
+  const double et = energy / cosh(eta);
 
-  const double et = energy/cosh(eta);
+  constexpr int nBinsEta = 4;
+  constexpr Double_t EtaBins[nBinsEta + 1] = {0.0, 0.7, 1.3, 1.8, 2.5};
 
-  constexpr int nBinsEta=4;
-  constexpr Double_t EtaBins[nBinsEta+1]  = {0.0, 0.7, 1.3, 1.8, 2.5};
+  constexpr int nBinsBrem = 1;
+  constexpr Double_t BremBins[nBinsBrem + 1] = {0.8, 8.0};
 
-  constexpr int nBinsBrem=1;
-  constexpr Double_t BremBins[nBinsBrem+1]= {0.8,  8.0};
+  constexpr float par0[nBinsEta][nBinsBrem] = {{0.00601311}, {0.0059814}, {0.00953032}, {0.00728618}};
 
-  constexpr float par0[nBinsEta][nBinsBrem] =
-    {{0.00601311},
-     {0.0059814},
-     {0.00953032},
-     {0.00728618}};
+  constexpr float par1[nBinsEta][nBinsBrem] = {{0.390988}, {1.02668}, {2.27491}, {2.08268}};
 
-  constexpr float par1[nBinsEta][nBinsBrem] =
-    {{ 0.390988},
-     {1.02668},
-     {2.27491},
-     {2.08268}};
+  constexpr float par2[nBinsEta][nBinsBrem] = {{-4.11919}, {-2.87477}, {-7.61675}, {-8.66756}};
 
-  constexpr float par2[nBinsEta][nBinsBrem] =
-    {{-4.11919},
-     {-2.87477},
-     {-7.61675},
-     {-8.66756}};
-
-  constexpr float par3[nBinsEta][nBinsBrem]=
-    {{4.61671},
-     {0.163447},
-     {-0.335786},
-     {-1.27831}};
+  constexpr float par3[nBinsEta][nBinsBrem] = {{4.61671}, {0.163447}, {-0.335786}, {-1.27831}};
 
   Int_t iEtaSl = -1;
-  for (Int_t iEta = 0; iEta < nBinsEta; ++iEta){
-    if ( EtaBins[iEta] <= fabs(eta) && fabs(eta) <EtaBins[iEta+1] ){
+  for (Int_t iEta = 0; iEta < nBinsEta; ++iEta) {
+    if (EtaBins[iEta] <= fabs(eta) && fabs(eta) < EtaBins[iEta + 1]) {
       iEtaSl = iEta;
     }
   }
 
   Int_t iBremSl = -1;
-  for (Int_t iBrem = 0; iBrem < nBinsBrem; ++iBrem){
-    if ( BremBins[iBrem] <= brem && brem <BremBins[iBrem+1] ){
+  for (Int_t iBrem = 0; iBrem < nBinsBrem; ++iBrem) {
+    if (BremBins[iBrem] <= brem && brem < BremBins[iBrem + 1]) {
       iBremSl = iBrem;
     }
   }
 
-  if (fabs(eta)>2.5) iEtaSl = nBinsEta-1;
-  if (brem<BremBins[0]) iBremSl = 0;
-  if (brem>BremBins[nBinsBrem-1]) iBremSl = nBinsBrem-1;
+  if (fabs(eta) > 2.5)
+    iEtaSl = nBinsEta - 1;
+  if (brem < BremBins[0])
+    iBremSl = 0;
+  if (brem > BremBins[nBinsBrem - 1])
+    iBremSl = nBinsBrem - 1;
 
-  if(iEtaSl == -1) {
-    edm::LogError("BadRange")<<"Bad eta value: "<<eta<<" in computeElectronEnergyUncertainty_badtrack";
+  if (iEtaSl == -1) {
+    edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeElectronEnergyUncertainty_badtrack";
     return 0;
   }
 
-  if(iBremSl == -1) {
-    edm::LogError("BadRange")<<"Bad brem value: "<<brem<<" in computeElectronEnergyUncertainty_badtrack";
+  if (iBremSl == -1) {
+    edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeElectronEnergyUncertainty_badtrack";
     return 0;
   }
 
   float uncertainty = 0;
-  if (et<5) uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl]/(5-par2[iEtaSl][iBremSl]) + par3[iEtaSl][iBremSl]/((5-par2[iEtaSl][iBremSl])*(5-par2[iEtaSl][iBremSl]));
-  if (et>100) uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl]/(100-par2[iEtaSl][iBremSl]) + par3[iEtaSl][iBremSl]/((100-par2[iEtaSl][iBremSl])*(100-par2[iEtaSl][iBremSl]));
+  if (et < 5)
+    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (5 - par2[iEtaSl][iBremSl]) +
+                  par3[iEtaSl][iBremSl] / ((5 - par2[iEtaSl][iBremSl]) * (5 - par2[iEtaSl][iBremSl]));
+  if (et > 100)
+    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (100 - par2[iEtaSl][iBremSl]) +
+                  par3[iEtaSl][iBremSl] / ((100 - par2[iEtaSl][iBremSl]) * (100 - par2[iEtaSl][iBremSl]));
 
-  if (et>5 && et<100) uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl]/(et-par2[iEtaSl][iBremSl]) + par3[iEtaSl][iBremSl]/((et-par2[iEtaSl][iBremSl])*(et-par2[iEtaSl][iBremSl]));
+  if (et > 5 && et < 100)
+    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (et - par2[iEtaSl][iBremSl]) +
+                  par3[iEtaSl][iBremSl] / ((et - par2[iEtaSl][iBremSl]) * (et - par2[iEtaSl][iBremSl]));
 
-  return (uncertainty*energy);
-
+  return (uncertainty * energy);
 }
 
-double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_showering(double eta, double brem, double energy){
+double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_showering(double eta,
+                                                                                     double brem,
+                                                                                     double energy) {
+  const double et = energy / cosh(eta);
 
-  const double et = energy/cosh(eta);
+  constexpr int nBinsEta = 4;
+  constexpr Double_t EtaBins[nBinsEta + 1] = {0.0, 0.8, 1.2, 1.7, 2.5};
 
-  constexpr int nBinsEta=4;
-  constexpr Double_t EtaBins[nBinsEta+1]  = {0.0,  0.8,  1.2,  1.7,  2.5};
+  constexpr int nBinsBrem = 5;
+  constexpr Double_t BremBins[nBinsBrem + 1] = {0.8, 1.8, 2.2, 3.0, 4.0, 8.0};
 
-  constexpr int nBinsBrem=5;
-  constexpr Double_t BremBins[nBinsBrem+1]= {0.8,  1.8,  2.2,  3.0,  4.0,  8.0};
+  constexpr float par0[nBinsEta][nBinsBrem] = {{0.0049351, 0.00566155, 0.0051397, 0.00468481, 0.00444475},
 
-  constexpr float par0[nBinsEta][nBinsBrem]= {
-    {0.0049351,
-     0.00566155,
-     0.0051397,
-     0.00468481,
-     0.00444475},
+                                               {0.00201762, 0.00431475, 0.00501004, 0.00632666, 0.00636704},
 
-    {0.00201762,
-     0.00431475,
-     0.00501004,
-     0.00632666,
-     0.00636704},
+                                               {-0.00729396, 0.00539783, 0.00608149, 0.00465335, 0.00642685},
 
-    {-0.00729396,
-     0.00539783,
-     0.00608149,
-     0.00465335,
-     0.00642685},
+                                               {0.0149449, 0.0216691, 0.0255957, 0.0206101, 0.0180508}};
 
-    {0.0149449,
-     0.0216691,
-     0.0255957,
-     0.0206101,
-     0.0180508} };
+  constexpr float par1[nBinsEta][nBinsBrem] = {{0.579925, 0.496137, 0.551947, 0.63011, 0.684261},
 
-  constexpr float par1[nBinsEta][nBinsBrem] = {
-    {0.579925,
-     0.496137,
-     0.551947,
-     0.63011,
-     0.684261},
+                                               {0.914762, 0.824483, 0.888521, 0.960241, 1.25728},
 
-    {0.914762,
-     0.824483,
-     0.888521,
-     0.960241,
-     1.25728},
+                                               {3.24295, 1.72935, 1.80606, 2.13562, 2.07592},
 
-    {3.24295,
-     1.72935,
-     1.80606,
-     2.13562,
-     2.07592},
+                                               {1.00448, 1.18393, 0.00775295, 2.59246, 3.1099}};
 
-    {1.00448,
-     1.18393,
-     0.00775295,
-     2.59246,
-     3.1099}};
+  constexpr float par2[nBinsEta][nBinsBrem] = {{-9.33987, -5.52543, -7.30079, -6.7722, -4.67614},
 
-  constexpr float par2[nBinsEta][nBinsBrem] = {
-    {-9.33987,
-     -5.52543,
-     -7.30079,
-     -6.7722,
-     -4.67614},
+                                               {-4.48042, -5.02885, -4.77311, -3.36742, -5.53561},
 
-    {-4.48042,
-     -5.02885,
-     -4.77311,
-     -3.36742,
-     -5.53561},
+                                               {-17.1458, -5.92807, -6.67563, -10.1105, -7.50257},
 
-    {-17.1458,
-     -5.92807,
-     -6.67563,
-     -10.1105,
-     -7.50257},
+                                               {-2.09368, -4.56674, -44.2722, -13.1702, -13.6208}};
 
-    {-2.09368,
-     -4.56674,
-     -44.2722,
-     -13.1702,
-     -13.6208}};
+  constexpr float par3[nBinsEta][nBinsBrem] = {{1.62129, 1.19101, 1.89701, 1.81614, 1.64415},
 
-  constexpr float par3[nBinsEta][nBinsBrem] = {
-    {1.62129,
-     1.19101,
-     1.89701,
-     1.81614,
-     1.64415},
+                                               {-1.50473, -0.153502, -0.355145, -1.16499, -0.864123},
 
-    {-1.50473,
-     -0.153502,
-     -0.355145,
-     -1.16499,
-     -0.864123},
+                                               {-4.69711, -2.18733, -0.922401, -0.230781, -2.91515},
 
-    {-4.69711,
-     -2.18733,
-     -0.922401,
-     -0.230781,
-     -2.91515},
-
-    {0.455037,
-     -0.601872,
-     241.516,
-     -2.35024,
-     -2.11069}};
+                                               {0.455037, -0.601872, 241.516, -2.35024, -2.11069}};
 
   Int_t iEtaSl = -1;
-  for (Int_t iEta = 0; iEta < nBinsEta; ++iEta){
-    if ( EtaBins[iEta] <= fabs(eta) && fabs(eta) <EtaBins[iEta+1] ){
+  for (Int_t iEta = 0; iEta < nBinsEta; ++iEta) {
+    if (EtaBins[iEta] <= fabs(eta) && fabs(eta) < EtaBins[iEta + 1]) {
       iEtaSl = iEta;
     }
   }
 
   Int_t iBremSl = -1;
-  for (Int_t iBrem = 0; iBrem < nBinsBrem; ++iBrem){
-    if ( BremBins[iBrem] <= brem && brem <BremBins[iBrem+1] ){
+  for (Int_t iBrem = 0; iBrem < nBinsBrem; ++iBrem) {
+    if (BremBins[iBrem] <= brem && brem < BremBins[iBrem + 1]) {
       iBremSl = iBrem;
     }
   }
 
-  if (fabs(eta)>2.5) iEtaSl = nBinsEta-1;
-  if (brem<BremBins[0]) iBremSl = 0;
-  if (brem>BremBins[nBinsBrem-1]) iBremSl = nBinsBrem-1;
+  if (fabs(eta) > 2.5)
+    iEtaSl = nBinsEta - 1;
+  if (brem < BremBins[0])
+    iBremSl = 0;
+  if (brem > BremBins[nBinsBrem - 1])
+    iBremSl = nBinsBrem - 1;
 
-  if(iEtaSl == -1) {
-    edm::LogError("BadRange")<<"Bad eta value: "<<eta<<" in computeElectronEnergyUncertainty_showering";
+  if (iEtaSl == -1) {
+    edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeElectronEnergyUncertainty_showering";
     return 0;
   }
 
-  if(iBremSl == -1) {
-    edm::LogError("BadRange")<<"Bad brem value: "<<brem<<" in computeElectronEnergyUncertainty_showering";
+  if (iBremSl == -1) {
+    edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeElectronEnergyUncertainty_showering";
     return 0;
   }
 
   float uncertainty = 0;
-  if (et<5) uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl]/(5-par2[iEtaSl][iBremSl]) + par3[iEtaSl][iBremSl]/((5-par2[iEtaSl][iBremSl])*(5-par2[iEtaSl][iBremSl]));
-  if (et>100) uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl]/(100-par2[iEtaSl][iBremSl]) + par3[iEtaSl][iBremSl]/((100-par2[iEtaSl][iBremSl])*(100-par2[iEtaSl][iBremSl]));
+  if (et < 5)
+    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (5 - par2[iEtaSl][iBremSl]) +
+                  par3[iEtaSl][iBremSl] / ((5 - par2[iEtaSl][iBremSl]) * (5 - par2[iEtaSl][iBremSl]));
+  if (et > 100)
+    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (100 - par2[iEtaSl][iBremSl]) +
+                  par3[iEtaSl][iBremSl] / ((100 - par2[iEtaSl][iBremSl]) * (100 - par2[iEtaSl][iBremSl]));
 
-  if (et>5 && et<100) uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl]/(et-par2[iEtaSl][iBremSl]) + par3[iEtaSl][iBremSl]/((et-par2[iEtaSl][iBremSl])*(et-par2[iEtaSl][iBremSl]));
+  if (et > 5 && et < 100)
+    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (et - par2[iEtaSl][iBremSl]) +
+                  par3[iEtaSl][iBremSl] / ((et - par2[iEtaSl][iBremSl]) * (et - par2[iEtaSl][iBremSl]));
 
-  return (uncertainty*energy);
-
+  return (uncertainty * energy);
 }
 
-double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_cracks(double eta, double brem, double energy){
+double EnergyUncertaintyElectronSpecific::computeElectronEnergyUncertainty_cracks(double eta,
+                                                                                  double brem,
+                                                                                  double energy) {
+  const double et = energy / cosh(eta);
 
-  const double et = energy/cosh(eta);
+  constexpr int nBinsEta = 5;
+  constexpr Double_t EtaBins[nBinsEta + 1] = {0.0, 0.42, 0.78, 1.2, 1.52, 1.65};
 
-  constexpr int nBinsEta=5;
-  constexpr Double_t EtaBins[nBinsEta+1]  = {0.0, 0.42, 0.78, 1.2, 1.52, 1.65};
-
-  constexpr int nBinsBrem=6;
-  constexpr Double_t BremBins[nBinsBrem+1]= {0.8, 1.2, 1.5, 2.1, 3., 4, 8.0};
+  constexpr int nBinsBrem = 6;
+  constexpr Double_t BremBins[nBinsBrem + 1] = {0.8, 1.2, 1.5, 2.1, 3., 4, 8.0};
 
   constexpr float par0[nBinsEta][nBinsBrem] = {
-    {0.0139815,
-     0.00550839,
-     0.0108292,
-     0.00596201,
-     -0.00498136,
-     0.000621696},
-    
-    {0.00467498,
-     0.00808463,
-     0.00546665,
-     0.00506318,
-     0.00608425,
-     -4.45641e-06},
+      {0.0139815, 0.00550839, 0.0108292, 0.00596201, -0.00498136, 0.000621696},
 
-    {0.00971734,
-     0.00063951,
-     -0.0121618,
-     -0.00604365,
-     0.00492161,
-     -0.00143907},
+      {0.00467498, 0.00808463, 0.00546665, 0.00506318, 0.00608425, -4.45641e-06},
 
-    {-0.0844907,
-     -0.0592498,
-     -0.0828631,
-     -0.0740798,
-     -0.0698045,
-     -0.0699518},
+      {0.00971734, 0.00063951, -0.0121618, -0.00604365, 0.00492161, -0.00143907},
 
-    {-0.0999971,
-     -0.0999996,
-     -0.0989356,
-     -0.0999965,
-     -0.0833049,
-     -0.020072}};
+      {-0.0844907, -0.0592498, -0.0828631, -0.0740798, -0.0698045, -0.0699518},
 
-  constexpr float par1[nBinsEta][nBinsBrem] = {
-    {0.569273,
-     0.674654,
-     0.523128,
-     1.02501,
-     1.75645,
-     0.955191},
+      {-0.0999971, -0.0999996, -0.0989356, -0.0999965, -0.0833049, -0.020072}};
 
-    {0.697951,
-     0.580628,
-     0.814515,
-     0.819975,
-     0.829616,
-     1.18952},
+  constexpr float par1[nBinsEta][nBinsBrem] = {{0.569273, 0.674654, 0.523128, 1.02501, 1.75645, 0.955191},
 
-    {3.79446,
-     2.47472,
-     5.12931,
-     3.42497,
-     1.84123,
-     2.3773},
+                                               {0.697951, 0.580628, 0.814515, 0.819975, 0.829616, 1.18952},
 
-    {19.9999,
-     10.4079,
-     16.6273,
-     15.9316,
-     15.4883,
-     14.7306},
+                                               {3.79446, 2.47472, 5.12931, 3.42497, 1.84123, 2.3773},
 
-    {15.9122,
-     18.5882,
-     19.9996,
-     19.9999,
-     18.2281,
-     8.1587}};
+                                               {19.9999, 10.4079, 16.6273, 15.9316, 15.4883, 14.7306},
 
-  constexpr float par2[nBinsEta][nBinsBrem] = {
-    {-4.31243,
-     -3.071,
-     -2.56702,
-     -7.74555,
-     -21.3726,
-     -6.2189},
+                                               {15.9122, 18.5882, 19.9996, 19.9999, 18.2281, 8.1587}};
 
-    {-6.56009,
-     -3.66067,
-     -7.8275,
-     -6.01641,
-     -7.85456,
-     -8.27071},
+  constexpr float par2[nBinsEta][nBinsBrem] = {{-4.31243, -3.071, -2.56702, -7.74555, -21.3726, -6.2189},
 
-    {-49.9996,
-     -25.0724,
-     -49.985,
-     -28.1932,
-     -10.6485,
-     -15.4014},
+                                               {-6.56009, -3.66067, -7.8275, -6.01641, -7.85456, -8.27071},
 
-    {-39.9444,
-     -25.1133,
-     -49.9999,
-     -50,
-     -49.9998,
-     -49.9998},
+                                               {-49.9996, -25.0724, -49.985, -28.1932, -10.6485, -15.4014},
 
-    {-30.1268,
-     -42.6113,
-     -46.6999,
-     -47.074,
-     -49.9995,
-     -25.2897}};
+                                               {-39.9444, -25.1133, -49.9999, -50, -49.9998, -49.9998},
 
+                                               {-30.1268, -42.6113, -46.6999, -47.074, -49.9995, -25.2897}};
 
-  static_assert(par0[0][3]==0.00596201f);
-  static_assert(par1[0][3]==1.02501f);
-  static_assert(par2[0][3]==-7.74555f);
+  static_assert(par0[0][3] == 0.00596201f);
+  static_assert(par1[0][3] == 1.02501f);
+  static_assert(par2[0][3] == -7.74555f);
 
+  static_assert(par0[2][4] == 0.00492161f);
+  static_assert(par1[2][4] == 1.84123f);
+  static_assert(par2[2][4] == -10.6485f);
 
-  static_assert(par0[2][4]==0.00492161f);
-  static_assert(par1[2][4]==1.84123f);
-  static_assert(par2[2][4]==-10.6485f);
-
-  static_assert(par0[4][3]==-0.0999965f);
-  static_assert(par1[4][3]==19.9999f);
-  static_assert(par2[4][3]==-47.074f);
+  static_assert(par0[4][3] == -0.0999965f);
+  static_assert(par1[4][3] == 19.9999f);
+  static_assert(par2[4][3] == -47.074f);
 
   Int_t iEtaSl = -1;
-  for (Int_t iEta = 0; iEta < nBinsEta; ++iEta){
-    if ( EtaBins[iEta] <= fabs(eta) && fabs(eta) <EtaBins[iEta+1] ){
+  for (Int_t iEta = 0; iEta < nBinsEta; ++iEta) {
+    if (EtaBins[iEta] <= fabs(eta) && fabs(eta) < EtaBins[iEta + 1]) {
       iEtaSl = iEta;
     }
   }
 
   Int_t iBremSl = -1;
-  for (Int_t iBrem = 0; iBrem < nBinsBrem; ++iBrem){
-    if ( BremBins[iBrem] <= brem && brem <BremBins[iBrem+1] ){
+  for (Int_t iBrem = 0; iBrem < nBinsBrem; ++iBrem) {
+    if (BremBins[iBrem] <= brem && brem < BremBins[iBrem + 1]) {
       iBremSl = iBrem;
     }
   }
 
-  if (fabs(eta)>2.5) iEtaSl = nBinsEta-1;
-  if (brem<BremBins[0]) iBremSl = 0;
-  if (brem>BremBins[nBinsBrem-1]) iBremSl = nBinsBrem-1;
+  if (fabs(eta) > 2.5)
+    iEtaSl = nBinsEta - 1;
+  if (brem < BremBins[0])
+    iBremSl = 0;
+  if (brem > BremBins[nBinsBrem - 1])
+    iBremSl = nBinsBrem - 1;
 
-  if(iEtaSl == -1) {
-    edm::LogError("BadRange")<<"Bad eta value: "<<eta<<" in computeElectronEnergyUncertainty_cracks";
+  if (iEtaSl == -1) {
+    edm::LogError("BadRange") << "Bad eta value: " << eta << " in computeElectronEnergyUncertainty_cracks";
     return 0;
   }
 
-  if(iBremSl == -1) {
-    edm::LogError("BadRange")<<"Bad brem value: "<<brem<<" in computeElectronEnergyUncertainty_cracks";
+  if (iBremSl == -1) {
+    edm::LogError("BadRange") << "Bad brem value: " << brem << " in computeElectronEnergyUncertainty_cracks";
     return 0;
   }
 
   float uncertainty = 0;
-  if (et<5) uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl]/(5-par2[iEtaSl][iBremSl]);
-  if (et>100) uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl]/(100-par2[iEtaSl][iBremSl]);
+  if (et < 5)
+    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (5 - par2[iEtaSl][iBremSl]);
+  if (et > 100)
+    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (100 - par2[iEtaSl][iBremSl]);
 
-  if (et>5 && et<100) uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl]/(et-par2[iEtaSl][iBremSl]);
+  if (et > 5 && et < 100)
+    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (et - par2[iEtaSl][iBremSl]);
 
-  return (uncertainty*energy);
-
+  return (uncertainty * energy);
 }

--- a/RecoEgamma/EgammaElectronAlgos/src/FTSFromVertexToPointFactory.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/FTSFromVertexToPointFactory.cc
@@ -2,7 +2,7 @@
 //
 // Package:    EgammaElectronAlgos
 // Class:      FTSFromVertexToPointFactory
-// 
+//
 /**\class FTSFromVertexToPointFactory EgammaElectronAlgos/FTSFromVertexToPointFactory
 
  Description: Utility class to create FTS from supercluster
@@ -18,38 +18,35 @@
 #include "RecoEgamma/EgammaElectronAlgos/interface/FTSFromVertexToPointFactory.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 
-
-FreeTrajectoryState FTSFromVertexToPointFactory::get( MagneticField const & magField, 
-                                                      GlobalPoint const & xmeas, 
-                                                      GlobalPoint const & xvert, 
-                                                      float momentum, 
-                                                      TrackCharge charge )
-{
+FreeTrajectoryState FTSFromVertexToPointFactory::get(MagneticField const& magField,
+                                                     GlobalPoint const& xmeas,
+                                                     GlobalPoint const& xvert,
+                                                     float momentum,
+                                                     TrackCharge charge) {
   auto magFieldAtPoint = magField.inTesla(xmeas);
   auto BInTesla = magFieldAtPoint.z();
   GlobalVector xdiff = xmeas - xvert;
-  auto mom = momentum*xdiff.unit();
+  auto mom = momentum * xdiff.unit();
   auto pt = mom.perp();
   auto pz = mom.z();
   auto pxOld = mom.x();
   auto pyOld = mom.y();
 
-
-  auto curv = (BInTesla*0.29979f*0.01f)/pt;
+  auto curv = (BInTesla * 0.29979f * 0.01f) / pt;
 
   // stays as doc...
   // auto alpha = std::asin(0.5f*xdiff.perp()*curv);
   // auto ca = std::cos(float(charge)*alpha);
   // auto sa = std::sin(float(charge)*alpha);
- 
-  auto sa = 0.5f*xdiff.perp()*curv*float(charge);
-  auto ca = sqrt(1.f-sa*sa); 
 
-  auto pxNew =   ca*pxOld + sa*pyOld;
-  auto pyNew =  -sa*pxOld + ca*pyOld;
-  GlobalVector pNew(pxNew, pyNew, pz);  
+  auto sa = 0.5f * xdiff.perp() * curv * float(charge);
+  auto ca = sqrt(1.f - sa * sa);
 
-  GlobalTrajectoryParameters gp(xmeas, pNew, charge, & magField, std::move(magFieldAtPoint));
-  
+  auto pxNew = ca * pxOld + sa * pyOld;
+  auto pyNew = -sa * pxOld + ca * pyOld;
+  GlobalVector pNew(pxNew, pyNew, pz);
+
+  GlobalTrajectoryParameters gp(xmeas, pNew, charge, &magField, std::move(magFieldAtPoint));
+
   return FreeTrajectoryState(gp);
 }

--- a/RecoEgamma/EgammaElectronAlgos/src/ForwardMeasurementEstimator.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ForwardMeasurementEstimator.cc
@@ -24,49 +24,48 @@
 #include "DataFormats/Math/interface/normalizedPhi.h"
 
 // zero value indicates incompatible ts - hit pair
-std::pair<bool,double> ForwardMeasurementEstimator::estimate( const TrajectoryStateOnSurface& ts,
-							      const TrackingRecHit& hit) const {
+std::pair<bool, double> ForwardMeasurementEstimator::estimate(const TrajectoryStateOnSurface& ts,
+                                                              const TrackingRecHit& hit) const {
   LocalPoint lp = hit.localPosition();
-  GlobalPoint gp = hit.det()->surface().toGlobal( lp);
-  return estimate(ts,gp);
+  GlobalPoint gp = hit.det()->surface().toGlobal(lp);
+  return estimate(ts, gp);
 }
 
-std::pair<bool,double> ForwardMeasurementEstimator::estimate( const TrajectoryStateOnSurface& ts, const GlobalPoint &gp) const {
-
+std::pair<bool, double> ForwardMeasurementEstimator::estimate(const TrajectoryStateOnSurface& ts,
+                                                              const GlobalPoint& gp) const {
   float tsR = ts.globalParameters().position().perp();
   float rhR = gp.perp();
   float rDiff = tsR - rhR;
   float rMin = theRMin;
   float rMax = theRMax;
   float myZ = gp.z();
-  if( (std::abs(myZ)> 70.f)  &  (std::abs(myZ)<170.f)) {
+  if ((std::abs(myZ) > 70.f) & (std::abs(myZ) < 170.f)) {
     rMin = theRMinI;
     rMax = theRMaxI;
   }
-  if( rDiff >= rMax || rDiff <= rMin ) return std::pair<bool,double>(false,0.);
-  
+  if (rDiff >= rMax || rDiff <= rMin)
+    return std::pair<bool, double>(false, 0.);
+
   float tsPhi = ts.globalParameters().position().barePhi();
   float rhPhi = gp.barePhi();
-  
+
   float myPhimin = thePhiMin;
   float myPhimax = thePhiMax;
 
   float phiDiff = normalizedPhi(tsPhi - rhPhi);
 
-  if ( (phiDiff < myPhimax) & (phiDiff > myPhimin) ) {
-    return std::pair<bool,double>(true,1.);
+  if ((phiDiff < myPhimax) & (phiDiff > myPhimin)) {
+    return std::pair<bool, double>(true, 1.);
   } else {
-    return std::pair<bool,double>(false,0.);
+    return std::pair<bool, double>(false, 0.);
   }
 }
 
-std::pair<bool,double> ForwardMeasurementEstimator::estimate
- ( const GlobalPoint& vprim,
-   const TrajectoryStateOnSurface& absolute_ts,
-   const GlobalPoint & absolute_gp ) const
- {
-  GlobalVector ts = absolute_ts.globalParameters().position() - vprim ;
-  GlobalVector gp = absolute_gp - vprim ;
+std::pair<bool, double> ForwardMeasurementEstimator::estimate(const GlobalPoint& vprim,
+                                                              const TrajectoryStateOnSurface& absolute_ts,
+                                                              const GlobalPoint& absolute_gp) const {
+  GlobalVector ts = absolute_ts.globalParameters().position() - vprim;
+  GlobalVector gp = absolute_gp - vprim;
 
   float rhR = gp.perp();
   float tsR = ts.perp();
@@ -74,32 +73,31 @@ std::pair<bool,double> ForwardMeasurementEstimator::estimate
   float rMin = theRMin;
   float rMax = theRMax;
   float myZ = gp.z();
-  if( (std::abs(myZ)> 70.f) &  (std::abs(myZ)<170.f) ) {
+  if ((std::abs(myZ) > 70.f) & (std::abs(myZ) < 170.f)) {
     rMin = theRMinI;
     rMax = theRMaxI;
   }
-  
-  if( (rDiff >= rMax) | (rDiff <= rMin) ) return std::pair<bool,double>(false,0.);
-  
+
+  if ((rDiff >= rMax) | (rDiff <= rMin))
+    return std::pair<bool, double>(false, 0.);
+
   float tsPhi = ts.barePhi();
-  float rhPhi = gp.barePhi();  
-  
+  float rhPhi = gp.barePhi();
+
   float myPhimin = thePhiMin;
-  float myPhimax = thePhiMax;  
+  float myPhimax = thePhiMax;
 
-  float phiDiff = normalizedPhi(rhPhi - tsPhi) ;  
+  float phiDiff = normalizedPhi(rhPhi - tsPhi);
 
-  if ( phiDiff < myPhimax && phiDiff > myPhimin )
-   { return std::pair<bool,double>(true,1.) ; }
-  else
-   { return std::pair<bool,double>(false,0.) ; }
+  if (phiDiff < myPhimax && phiDiff > myPhimin) {
+    return std::pair<bool, double>(true, 1.);
+  } else {
+    return std::pair<bool, double>(false, 0.);
+  }
 }
 
-bool ForwardMeasurementEstimator::estimate
- ( const TrajectoryStateOnSurface & ts,
-   const BoundPlane & plane ) const
- {
-  typedef std::pair<float,float> Range ;
+bool ForwardMeasurementEstimator::estimate(const TrajectoryStateOnSurface& ts, const BoundPlane& plane) const {
+  typedef std::pair<float, float> Range;
 
   GlobalPoint trajPos(ts.globalParameters().position());
 
@@ -109,27 +107,20 @@ bool ForwardMeasurementEstimator::estimate
   Range trajRRange(trajPos.perp() - r1, trajPos.perp() + r2);
   Range trajPhiRange(trajPos.phi() - std::abs(thePhiMin), trajPos.phi() + std::abs(thePhiMax));
 
-  if(rangesIntersect(trajRRange, plane.rSpan()) &&
-     rangesIntersect(trajPhiRange, plane.phiSpan(), [](auto x,auto y){ return Geom::phiLess(x, y);}))
-   { return true ; }
-  else
-   { return false ; }
+  if (rangesIntersect(trajRRange, plane.rSpan()) &&
+      rangesIntersect(trajPhiRange, plane.phiSpan(), [](auto x, auto y) { return Geom::phiLess(x, y); })) {
+    return true;
+  } else {
+    return false;
+  }
 }
 
-MeasurementEstimator::Local2DVector
-ForwardMeasurementEstimator::maximalLocalDisplacement
- ( const TrajectoryStateOnSurface & ts,
-   const BoundPlane & plane) const
- {
+MeasurementEstimator::Local2DVector ForwardMeasurementEstimator::maximalLocalDisplacement(
+    const TrajectoryStateOnSurface& ts, const BoundPlane& plane) const {
   float nSigmaCut = 3.;
-  if ( ts.hasError())
-   {
+  if (ts.hasError()) {
     LocalError le = ts.localError().positionError();
-    return Local2DVector( std::sqrt(le.xx())*nSigmaCut, std::sqrt(le.yy())*nSigmaCut);
-   }
-  else
-    return Local2DVector(999999,999999) ;
- }
-
-
-
+    return Local2DVector(std::sqrt(le.xx()) * nSigmaCut, std::sqrt(le.yy()) * nSigmaCut);
+  } else
+    return Local2DVector(999999, 999999);
+}

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -32,669 +32,736 @@
 #include "RecoEgamma/EgammaTools/interface/ConversionFinder.h"
 #include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
 
-
 #include <Math/Point3D.h>
 #include <sstream>
 #include <algorithm>
 
-
-using namespace edm ;
-using namespace reco ;
-
+using namespace edm;
+using namespace reco;
 
 GsfElectronAlgo::EventSetupData::EventSetupData()
- : cacheIDGeom(0), cacheIDTopo(0), cacheIDTDGeom(0), cacheIDMagField(0),
-   cacheSevLevel(0), mtsTransform(nullptr), constraintAtVtx(nullptr)
- {}
+    : cacheIDGeom(0),
+      cacheIDTopo(0),
+      cacheIDTDGeom(0),
+      cacheIDMagField(0),
+      cacheSevLevel(0),
+      mtsTransform(nullptr),
+      constraintAtVtx(nullptr) {}
 
-void GsfElectronAlgo::EventData::retreiveOriginalTrackCollections
- ( const reco::TrackRef & ctfTrack, const reco::GsfTrackRef & gsfTrack )
- {
-  if ((!originalCtfTrackCollectionRetreived)&&(ctfTrack.isNonnull()))
-   {
-    event->get(ctfTrack.id(),originalCtfTracks) ;
-    originalCtfTrackCollectionRetreived = true ;
-   }
-  if ((!originalGsfTrackCollectionRetreived)&&(gsfTrack.isNonnull()))
-   {
-    event->get(gsfTrack.id(),originalGsfTracks) ;
-    originalGsfTrackCollectionRetreived = true ;
-   }
- }
+void GsfElectronAlgo::EventData::retreiveOriginalTrackCollections(const reco::TrackRef& ctfTrack,
+                                                                  const reco::GsfTrackRef& gsfTrack) {
+  if ((!originalCtfTrackCollectionRetreived) && (ctfTrack.isNonnull())) {
+    event->get(ctfTrack.id(), originalCtfTracks);
+    originalCtfTrackCollectionRetreived = true;
+  }
+  if ((!originalGsfTrackCollectionRetreived) && (gsfTrack.isNonnull())) {
+    event->get(gsfTrack.id(), originalGsfTracks);
+    originalGsfTrackCollectionRetreived = true;
+  }
+}
 
+GsfElectronAlgo::ElectronData::ElectronData(const reco::GsfElectronCoreRef& core, const reco::BeamSpot& bs)
+    : coreRef(core),
+      gsfTrackRef(coreRef->gsfTrack()),
+      superClusterRef(coreRef->superCluster()),
+      ctfTrackRef(coreRef->ctfTrack()),
+      shFracInnerHits(coreRef->ctfGsfOverlap()),
+      beamSpot(bs) {}
 
-GsfElectronAlgo::ElectronData::ElectronData
- ( const reco::GsfElectronCoreRef & core,
-   const reco::BeamSpot & bs )
- : coreRef(core),
-   gsfTrackRef(coreRef->gsfTrack()),
-   superClusterRef(coreRef->superCluster()),
-   ctfTrackRef(coreRef->ctfTrack()), shFracInnerHits(coreRef->ctfGsfOverlap()),
-   beamSpot(bs)
- {}
-
-
-void GsfElectronAlgo::ElectronData::computeCharge
- ( int & charge, GsfElectron::ChargeInfo & info )
- {
+void GsfElectronAlgo::ElectronData::computeCharge(int& charge, GsfElectron::ChargeInfo& info) {
   // determine charge from SC
-  GlobalPoint orig, scpos ;
-  ele_convert(beamSpot.position(),orig) ;
-  ele_convert(superClusterRef->position(),scpos) ;
-  GlobalVector scvect(scpos-orig) ;
-  GlobalPoint inntkpos = innTSOS.globalPosition() ;
-  GlobalVector inntkvect = GlobalVector(inntkpos-orig) ;
-  float dPhiInnEle=normalizedPhi(scvect.barePhi()-inntkvect.barePhi()) ;
-  if(dPhiInnEle>0) info.scPixCharge = -1 ;
-  else info.scPixCharge = 1 ;
+  GlobalPoint orig, scpos;
+  ele_convert(beamSpot.position(), orig);
+  ele_convert(superClusterRef->position(), scpos);
+  GlobalVector scvect(scpos - orig);
+  GlobalPoint inntkpos = innTSOS.globalPosition();
+  GlobalVector inntkvect = GlobalVector(inntkpos - orig);
+  float dPhiInnEle = normalizedPhi(scvect.barePhi() - inntkvect.barePhi());
+  if (dPhiInnEle > 0)
+    info.scPixCharge = -1;
+  else
+    info.scPixCharge = 1;
 
   // flags
-  int chargeGsf = gsfTrackRef->charge() ;
-  info.isGsfScPixConsistent = ((chargeGsf*info.scPixCharge)>0) ;
-  info.isGsfCtfConsistent = (ctfTrackRef.isNonnull()&&((chargeGsf*ctfTrackRef->charge())>0)) ;
-  info.isGsfCtfScPixConsistent = (info.isGsfScPixConsistent&&info.isGsfCtfConsistent) ;
+  int chargeGsf = gsfTrackRef->charge();
+  info.isGsfScPixConsistent = ((chargeGsf * info.scPixCharge) > 0);
+  info.isGsfCtfConsistent = (ctfTrackRef.isNonnull() && ((chargeGsf * ctfTrackRef->charge()) > 0));
+  info.isGsfCtfScPixConsistent = (info.isGsfScPixConsistent && info.isGsfCtfConsistent);
 
   // default charge
-  if (info.isGsfScPixConsistent||ctfTrackRef.isNull())
-   { charge = info.scPixCharge ; }
-  else
-   { charge = ctfTrackRef->charge() ; }
- }
+  if (info.isGsfScPixConsistent || ctfTrackRef.isNull()) {
+    charge = info.scPixCharge;
+  } else {
+    charge = ctfTrackRef->charge();
+  }
+}
 
-CaloClusterPtr GsfElectronAlgo::ElectronData::getEleBasicCluster( MultiTrajectoryStateTransform const& mtsTransform )
- {
-  CaloClusterPtr eleRef ;
-  TrajectoryStateOnSurface tempTSOS ;
-  TrajectoryStateOnSurface outTSOS = mtsTransform.outerStateOnSurface(*gsfTrackRef) ;
-  float dphimin = 1.e30 ;
-  for(auto const& bc : superClusterRef->clusters())
-   {
-    GlobalPoint posclu(bc->position().x(),bc->position().y(),bc->position().z()) ;
-    tempTSOS = mtsTransform.extrapolatedState(outTSOS,posclu) ;
-    if (!tempTSOS.isValid()) tempTSOS=outTSOS ;
-    GlobalPoint extrap = tempTSOS.globalPosition() ;
-    float dphi = EleRelPointPair(posclu,extrap,beamSpot.position()).dPhi() ;
-    if (std::abs(dphi)<dphimin)
-     {
-      dphimin = std::abs(dphi) ;
+CaloClusterPtr GsfElectronAlgo::ElectronData::getEleBasicCluster(MultiTrajectoryStateTransform const& mtsTransform) {
+  CaloClusterPtr eleRef;
+  TrajectoryStateOnSurface tempTSOS;
+  TrajectoryStateOnSurface outTSOS = mtsTransform.outerStateOnSurface(*gsfTrackRef);
+  float dphimin = 1.e30;
+  for (auto const& bc : superClusterRef->clusters()) {
+    GlobalPoint posclu(bc->position().x(), bc->position().y(), bc->position().z());
+    tempTSOS = mtsTransform.extrapolatedState(outTSOS, posclu);
+    if (!tempTSOS.isValid())
+      tempTSOS = outTSOS;
+    GlobalPoint extrap = tempTSOS.globalPosition();
+    float dphi = EleRelPointPair(posclu, extrap, beamSpot.position()).dPhi();
+    if (std::abs(dphi) < dphimin) {
+      dphimin = std::abs(dphi);
       eleRef = bc;
-      eleTSOS = tempTSOS ;
-     }
-   }
-  return eleRef ;
- }
+      eleTSOS = tempTSOS;
+    }
+  }
+  return eleRef;
+}
 
-bool GsfElectronAlgo::ElectronData::calculateTSOS
- ( MultiTrajectoryStateTransform const& mtsTransform, GsfConstraintAtVertex const& constraintAtVtx )
- {
+bool GsfElectronAlgo::ElectronData::calculateTSOS(MultiTrajectoryStateTransform const& mtsTransform,
+                                                  GsfConstraintAtVertex const& constraintAtVtx) {
   //at innermost point
   innTSOS = mtsTransform.innerStateOnSurface(*gsfTrackRef);
-  if (!innTSOS.isValid()) return false;
+  if (!innTSOS.isValid())
+    return false;
 
   //at vertex
   // innermost state propagation to the beam spot position
-  GlobalPoint bsPos ;
-  ele_convert(beamSpot.position(),bsPos) ;
-  vtxTSOS = mtsTransform.extrapolatedState(innTSOS,bsPos) ;
-  if (!vtxTSOS.isValid()) vtxTSOS=innTSOS;
+  GlobalPoint bsPos;
+  ele_convert(beamSpot.position(), bsPos);
+  vtxTSOS = mtsTransform.extrapolatedState(innTSOS, bsPos);
+  if (!vtxTSOS.isValid())
+    vtxTSOS = innTSOS;
 
   //at seed
   outTSOS = mtsTransform.outerStateOnSurface(*gsfTrackRef);
-  if (!outTSOS.isValid()) return false;
+  if (!outTSOS.isValid())
+    return false;
 
   //    TrajectoryStateOnSurface seedTSOS
   seedTSOS = mtsTransform.extrapolatedState(outTSOS,
-           GlobalPoint(superClusterRef->seed()->position().x(),
-               superClusterRef->seed()->position().y(),
-                 superClusterRef->seed()->position().z()));
-  if (!seedTSOS.isValid()) seedTSOS=outTSOS;
+                                            GlobalPoint(superClusterRef->seed()->position().x(),
+                                                        superClusterRef->seed()->position().y(),
+                                                        superClusterRef->seed()->position().z()));
+  if (!seedTSOS.isValid())
+    seedTSOS = outTSOS;
 
   // at scl
-  sclTSOS = mtsTransform.extrapolatedState(innTSOS,GlobalPoint(superClusterRef->x(),superClusterRef->y(),superClusterRef->z()));
-  if (!sclTSOS.isValid()) sclTSOS=outTSOS;
+  sclTSOS = mtsTransform.extrapolatedState(
+      innTSOS, GlobalPoint(superClusterRef->x(), superClusterRef->y(), superClusterRef->z()));
+  if (!sclTSOS.isValid())
+    sclTSOS = outTSOS;
 
   // constrained momentum
-  constrainedVtxTSOS = constraintAtVtx.constrainAtBeamSpot(*gsfTrackRef,beamSpot);
+  constrainedVtxTSOS = constraintAtVtx.constrainAtBeamSpot(*gsfTrackRef, beamSpot);
 
-  return true ;
- }
+  return true;
+}
 
-void GsfElectronAlgo::ElectronData::calculateMode()
- {
-  multiTrajectoryStateMode::momentumFromModeCartesian(innTSOS,innMom) ;
-  multiTrajectoryStateMode::positionFromModeCartesian(innTSOS,innPos) ;
-  multiTrajectoryStateMode::momentumFromModeCartesian(seedTSOS,seedMom) ;
-  multiTrajectoryStateMode::positionFromModeCartesian(seedTSOS,seedPos) ;
-  multiTrajectoryStateMode::momentumFromModeCartesian(eleTSOS,eleMom) ;
-  multiTrajectoryStateMode::positionFromModeCartesian(eleTSOS,elePos) ;
-  multiTrajectoryStateMode::momentumFromModeCartesian(sclTSOS,sclMom) ;
-  multiTrajectoryStateMode::positionFromModeCartesian(sclTSOS,sclPos) ;
-  multiTrajectoryStateMode::momentumFromModeCartesian(vtxTSOS,vtxMom) ;
-  multiTrajectoryStateMode::positionFromModeCartesian(vtxTSOS,vtxPos) ;
-  multiTrajectoryStateMode::momentumFromModeCartesian(outTSOS,outMom);
-  multiTrajectoryStateMode::positionFromModeCartesian(outTSOS,outPos) ;
-  multiTrajectoryStateMode::momentumFromModeCartesian(constrainedVtxTSOS,vtxMomWithConstraint);
- }
+void GsfElectronAlgo::ElectronData::calculateMode() {
+  multiTrajectoryStateMode::momentumFromModeCartesian(innTSOS, innMom);
+  multiTrajectoryStateMode::positionFromModeCartesian(innTSOS, innPos);
+  multiTrajectoryStateMode::momentumFromModeCartesian(seedTSOS, seedMom);
+  multiTrajectoryStateMode::positionFromModeCartesian(seedTSOS, seedPos);
+  multiTrajectoryStateMode::momentumFromModeCartesian(eleTSOS, eleMom);
+  multiTrajectoryStateMode::positionFromModeCartesian(eleTSOS, elePos);
+  multiTrajectoryStateMode::momentumFromModeCartesian(sclTSOS, sclMom);
+  multiTrajectoryStateMode::positionFromModeCartesian(sclTSOS, sclPos);
+  multiTrajectoryStateMode::momentumFromModeCartesian(vtxTSOS, vtxMom);
+  multiTrajectoryStateMode::positionFromModeCartesian(vtxTSOS, vtxPos);
+  multiTrajectoryStateMode::momentumFromModeCartesian(outTSOS, outMom);
+  multiTrajectoryStateMode::positionFromModeCartesian(outTSOS, outPos);
+  multiTrajectoryStateMode::momentumFromModeCartesian(constrainedVtxTSOS, vtxMomWithConstraint);
+}
 
-Candidate::LorentzVector GsfElectronAlgo::ElectronData::calculateMomentum()
- {
-  double scale = superClusterRef->energy()/vtxMom.mag() ;
-  return Candidate::LorentzVector
-   ( vtxMom.x()*scale,vtxMom.y()*scale,vtxMom.z()*scale,
-     superClusterRef->energy() ) ;
- }
+Candidate::LorentzVector GsfElectronAlgo::ElectronData::calculateMomentum() {
+  double scale = superClusterRef->energy() / vtxMom.mag();
+  return Candidate::LorentzVector(
+      vtxMom.x() * scale, vtxMom.y() * scale, vtxMom.z() * scale, superClusterRef->energy());
+}
 
 void GsfElectronAlgo::calculateSaturationInfo(const reco::SuperClusterRef& theClus,
                                               reco::GsfElectron::SaturationInfo& si,
-                                              EventData const& eventData)
-{
-  const reco::CaloCluster & seedCluster = *(theClus->seed()) ;
+                                              EventData const& eventData) {
+  const reco::CaloCluster& seedCluster = *(theClus->seed());
   DetId seedXtalId = seedCluster.seed();
   int detector = seedXtalId.subdetId();
-  const EcalRecHitCollection* ecalRecHits = nullptr ;
-  if (detector==EcalBarrel)
-    ecalRecHits = eventData.barrelRecHits.product() ;
+  const EcalRecHitCollection* ecalRecHits = nullptr;
+  if (detector == EcalBarrel)
+    ecalRecHits = eventData.barrelRecHits.product();
   else
-    ecalRecHits = eventData.endcapRecHits.product() ;
-  
+    ecalRecHits = eventData.endcapRecHits.product();
+
   int nSaturatedXtals = 0;
   bool isSeedSaturated = false;
-  for (auto&& hitFractionPair : theClus->hitsAndFractions()) {    
+  for (auto&& hitFractionPair : theClus->hitsAndFractions()) {
     auto&& ecalRecHit = ecalRecHits->find(hitFractionPair.first);
-    if (ecalRecHit == ecalRecHits->end()) continue;
+    if (ecalRecHit == ecalRecHits->end())
+      continue;
     if (ecalRecHit->checkFlag(EcalRecHit::Flags::kSaturated)) {
       nSaturatedXtals++;
       if (seedXtalId == ecalRecHit->detid())
-	isSeedSaturated = true;
+        isSeedSaturated = true;
     }
   }
   si.nSaturatedXtals = nSaturatedXtals;
   si.isSeedSaturated = isSeedSaturated;
-
 }
 
-template<bool full5x5>
-void GsfElectronAlgo::calculateShowerShape( const reco::SuperClusterRef & theClus,
-                                            ElectronHcalHelper const& hcalHelper,
-                                            reco::GsfElectron::ShowerShape & showerShape,
-                                            EventData const& eventData)
- {
-
+template <bool full5x5>
+void GsfElectronAlgo::calculateShowerShape(const reco::SuperClusterRef& theClus,
+                                           ElectronHcalHelper const& hcalHelper,
+                                           reco::GsfElectron::ShowerShape& showerShape,
+                                           EventData const& eventData) {
   using ClusterTools = EcalClusterToolsT<full5x5>;
 
-  const reco::CaloCluster & seedCluster = *(theClus->seed()) ;
+  const reco::CaloCluster& seedCluster = *(theClus->seed());
   // temporary, till CaloCluster->seed() is made available
-  DetId seedXtalId = seedCluster.hitsAndFractions()[0].first ;
-  int detector = seedXtalId.subdetId() ;
+  DetId seedXtalId = seedCluster.hitsAndFractions()[0].first;
+  int detector = seedXtalId.subdetId();
 
-  const CaloTopology * topology = eventSetupData_.caloTopo.product() ;
-  const CaloGeometry * geometry = eventSetupData_.caloGeom.product() ;
-  const EcalRecHitCollection * recHits = nullptr ;
-  std::vector<int> recHitFlagsToBeExcluded ;
-  std::vector<int> recHitSeverityToBeExcluded ;
-  if (detector==EcalBarrel)
-   {
-    recHits = eventData.barrelRecHits.product() ;
-    recHitFlagsToBeExcluded = generalData_.recHitsCfg.recHitFlagsToBeExcludedBarrel ;
-    recHitSeverityToBeExcluded = generalData_.recHitsCfg.recHitSeverityToBeExcludedBarrel ;
-   }
-  else
-   {
-    recHits = eventData.endcapRecHits.product() ;
-    recHitFlagsToBeExcluded = generalData_.recHitsCfg.recHitFlagsToBeExcludedEndcaps ;
-    recHitSeverityToBeExcluded = generalData_.recHitsCfg.recHitSeverityToBeExcludedEndcaps ;
-   }
+  const CaloTopology* topology = eventSetupData_.caloTopo.product();
+  const CaloGeometry* geometry = eventSetupData_.caloGeom.product();
+  const EcalRecHitCollection* recHits = nullptr;
+  std::vector<int> recHitFlagsToBeExcluded;
+  std::vector<int> recHitSeverityToBeExcluded;
+  if (detector == EcalBarrel) {
+    recHits = eventData.barrelRecHits.product();
+    recHitFlagsToBeExcluded = generalData_.recHitsCfg.recHitFlagsToBeExcludedBarrel;
+    recHitSeverityToBeExcluded = generalData_.recHitsCfg.recHitSeverityToBeExcludedBarrel;
+  } else {
+    recHits = eventData.endcapRecHits.product();
+    recHitFlagsToBeExcluded = generalData_.recHitsCfg.recHitFlagsToBeExcludedEndcaps;
+    recHitSeverityToBeExcluded = generalData_.recHitsCfg.recHitSeverityToBeExcludedEndcaps;
+  }
 
-  std::vector<float> covariances = ClusterTools::covariances(seedCluster,recHits,topology,geometry) ;
-  std::vector<float> localCovariances = ClusterTools::localCovariances(seedCluster,recHits,topology) ;
-  showerShape.sigmaEtaEta = sqrt(covariances[0]) ;
-  showerShape.sigmaIetaIeta = sqrt(localCovariances[0]) ;
-  if (!edm::isNotFinite(localCovariances[2])) showerShape.sigmaIphiIphi = sqrt(localCovariances[2]) ;
-  showerShape.e1x5 = ClusterTools::e1x5(seedCluster,recHits,topology)  ;
-  showerShape.e2x5Max = ClusterTools::e2x5Max(seedCluster,recHits,topology)  ;
-  showerShape.e5x5 = ClusterTools::e5x5(seedCluster,recHits,topology) ;
-  showerShape.r9 = ClusterTools::e3x3(seedCluster,recHits,topology)/theClus->rawEnergy() ;
+  std::vector<float> covariances = ClusterTools::covariances(seedCluster, recHits, topology, geometry);
+  std::vector<float> localCovariances = ClusterTools::localCovariances(seedCluster, recHits, topology);
+  showerShape.sigmaEtaEta = sqrt(covariances[0]);
+  showerShape.sigmaIetaIeta = sqrt(localCovariances[0]);
+  if (!edm::isNotFinite(localCovariances[2]))
+    showerShape.sigmaIphiIphi = sqrt(localCovariances[2]);
+  showerShape.e1x5 = ClusterTools::e1x5(seedCluster, recHits, topology);
+  showerShape.e2x5Max = ClusterTools::e2x5Max(seedCluster, recHits, topology);
+  showerShape.e5x5 = ClusterTools::e5x5(seedCluster, recHits, topology);
+  showerShape.r9 = ClusterTools::e3x3(seedCluster, recHits, topology) / theClus->rawEnergy();
 
   const float scale = full5x5 ? showerShape.e5x5 : theClus->energy();
 
-  showerShape.hcalDepth1OverEcal = hcalHelper.hcalESumDepth1(*theClus)/theClus->energy() ;
-  showerShape.hcalDepth2OverEcal = hcalHelper.hcalESumDepth2(*theClus)/theClus->energy() ;
-  showerShape.hcalTowersBehindClusters = hcalHelper.hcalTowersBehindClusters(*theClus) ;
-  showerShape.hcalDepth1OverEcalBc = hcalHelper.hcalESumDepth1BehindClusters(showerShape.hcalTowersBehindClusters)/scale ;
-  showerShape.hcalDepth2OverEcalBc = hcalHelper.hcalESumDepth2BehindClusters(showerShape.hcalTowersBehindClusters)/scale ;
-  showerShape.invalidHcal = (showerShape.hcalDepth1OverEcalBc == 0 && 
-                             showerShape.hcalDepth2OverEcalBc == 0 &&
+  showerShape.hcalDepth1OverEcal = hcalHelper.hcalESumDepth1(*theClus) / theClus->energy();
+  showerShape.hcalDepth2OverEcal = hcalHelper.hcalESumDepth2(*theClus) / theClus->energy();
+  showerShape.hcalTowersBehindClusters = hcalHelper.hcalTowersBehindClusters(*theClus);
+  showerShape.hcalDepth1OverEcalBc =
+      hcalHelper.hcalESumDepth1BehindClusters(showerShape.hcalTowersBehindClusters) / scale;
+  showerShape.hcalDepth2OverEcalBc =
+      hcalHelper.hcalESumDepth2BehindClusters(showerShape.hcalTowersBehindClusters) / scale;
+  showerShape.invalidHcal = (showerShape.hcalDepth1OverEcalBc == 0 && showerShape.hcalDepth2OverEcalBc == 0 &&
                              !hcalHelper.hasActiveHcal(*theClus));
-  
+
   // extra shower shapes
-  const float see_by_spp = showerShape.sigmaIetaIeta*showerShape.sigmaIphiIphi;
-  if(  see_by_spp > 0 ) {
+  const float see_by_spp = showerShape.sigmaIetaIeta * showerShape.sigmaIphiIphi;
+  if (see_by_spp > 0) {
     showerShape.sigmaIetaIphi = localCovariances[1] / see_by_spp;
-  } else if ( localCovariances[1] > 0 ) {
+  } else if (localCovariances[1] > 0) {
     showerShape.sigmaIetaIphi = 1.f;
   } else {
     showerShape.sigmaIetaIphi = -1.f;
   }
-  showerShape.eMax          = ClusterTools::eMax(seedCluster,recHits);
-  showerShape.e2nd          = ClusterTools::e2nd(seedCluster,recHits);
-  showerShape.eTop          = ClusterTools::eTop(seedCluster,recHits,topology);
-  showerShape.eLeft         = ClusterTools::eLeft(seedCluster,recHits,topology);
-  showerShape.eRight        = ClusterTools::eRight(seedCluster,recHits,topology);
-  showerShape.eBottom       = ClusterTools::eBottom(seedCluster,recHits,topology);
+  showerShape.eMax = ClusterTools::eMax(seedCluster, recHits);
+  showerShape.e2nd = ClusterTools::e2nd(seedCluster, recHits);
+  showerShape.eTop = ClusterTools::eTop(seedCluster, recHits, topology);
+  showerShape.eLeft = ClusterTools::eLeft(seedCluster, recHits, topology);
+  showerShape.eRight = ClusterTools::eRight(seedCluster, recHits, topology);
+  showerShape.eBottom = ClusterTools::eBottom(seedCluster, recHits, topology);
 
-  showerShape.e2x5Left = ClusterTools::e2x5Left(seedCluster,recHits,topology);
-  showerShape.e2x5Right = ClusterTools::e2x5Right(seedCluster,recHits,topology);
-  showerShape.e2x5Top = ClusterTools::e2x5Top(seedCluster,recHits,topology);
-  showerShape.e2x5Bottom = ClusterTools::e2x5Bottom(seedCluster,recHits,topology);
- }
-
+  showerShape.e2x5Left = ClusterTools::e2x5Left(seedCluster, recHits, topology);
+  showerShape.e2x5Right = ClusterTools::e2x5Right(seedCluster, recHits, topology);
+  showerShape.e2x5Top = ClusterTools::e2x5Top(seedCluster, recHits, topology);
+  showerShape.e2x5Bottom = ClusterTools::e2x5Bottom(seedCluster, recHits, topology);
+}
 
 //===================================================================
 // GsfElectronAlgo
 //===================================================================
 
-GsfElectronAlgo::GsfElectronAlgo
- ( const InputTagsConfiguration & inputCfg,
-   const StrategyConfiguration & strategyCfg,
-   const CutsConfiguration & cutsCfg,
-   const CutsConfiguration & cutsCfgPflow,
-   const ElectronHcalHelper::Configuration & hcalCfg,
-   const ElectronHcalHelper::Configuration & hcalCfgPflow,
-   const IsolationConfiguration & isoCfg,
-   const EcalRecHitsConfiguration & recHitsCfg,
-   std::unique_ptr<EcalClusterFunctionBaseClass> superClusterErrorFunction,
-   std::unique_ptr<EcalClusterFunctionBaseClass> crackCorrectionFunction,
-   const RegressionHelper::Configuration & regCfg,
-   const edm::ParameterSet& tkIsol03Cfg,
-   const edm::ParameterSet& tkIsol04Cfg,
-   const edm::ParameterSet& tkIsolHEEP03Cfg,
-   const edm::ParameterSet& tkIsolHEEP04Cfg
+GsfElectronAlgo::GsfElectronAlgo(const InputTagsConfiguration& inputCfg,
+                                 const StrategyConfiguration& strategyCfg,
+                                 const CutsConfiguration& cutsCfg,
+                                 const CutsConfiguration& cutsCfgPflow,
+                                 const ElectronHcalHelper::Configuration& hcalCfg,
+                                 const ElectronHcalHelper::Configuration& hcalCfgPflow,
+                                 const IsolationConfiguration& isoCfg,
+                                 const EcalRecHitsConfiguration& recHitsCfg,
+                                 std::unique_ptr<EcalClusterFunctionBaseClass> superClusterErrorFunction,
+                                 std::unique_ptr<EcalClusterFunctionBaseClass> crackCorrectionFunction,
+                                 const RegressionHelper::Configuration& regCfg,
+                                 const edm::ParameterSet& tkIsol03Cfg,
+                                 const edm::ParameterSet& tkIsol04Cfg,
+                                 const edm::ParameterSet& tkIsolHEEP03Cfg,
+                                 const edm::ParameterSet& tkIsolHEEP04Cfg
 
- )
-: generalData_{inputCfg,strategyCfg,cutsCfg,cutsCfgPflow,isoCfg,recHitsCfg,hcalCfg,hcalCfgPflow,std::move(superClusterErrorFunction),std::move(crackCorrectionFunction),regCfg},
-   eventSetupData_{},
-   tkIsol03Calc_(tkIsol03Cfg),tkIsol04Calc_(tkIsol04Cfg),
-   tkIsolHEEP03Calc_(tkIsolHEEP03Cfg),tkIsolHEEP04Calc_(tkIsolHEEP04Cfg)
-  
- {}
+                                 )
+    : generalData_{inputCfg,
+                   strategyCfg,
+                   cutsCfg,
+                   cutsCfgPflow,
+                   isoCfg,
+                   recHitsCfg,
+                   hcalCfg,
+                   hcalCfgPflow,
+                   std::move(superClusterErrorFunction),
+                   std::move(crackCorrectionFunction),
+                   regCfg},
+      eventSetupData_{},
+      tkIsol03Calc_(tkIsol03Cfg),
+      tkIsol04Calc_(tkIsol04Cfg),
+      tkIsolHEEP03Calc_(tkIsolHEEP03Cfg),
+      tkIsolHEEP04Calc_(tkIsolHEEP04Cfg)
 
-void GsfElectronAlgo::checkSetup( const edm::EventSetup & es )
- {
+{}
+
+void GsfElectronAlgo::checkSetup(const edm::EventSetup& es) {
   // get EventSetupRecords if needed
-  const bool updateField = eventSetupData_.cacheIDMagField!=es.get<IdealMagneticFieldRecord>().cacheIdentifier();
-  if (updateField){
-    eventSetupData_.cacheIDMagField=es.get<IdealMagneticFieldRecord>().cacheIdentifier();
+  const bool updateField = eventSetupData_.cacheIDMagField != es.get<IdealMagneticFieldRecord>().cacheIdentifier();
+  if (updateField) {
+    eventSetupData_.cacheIDMagField = es.get<IdealMagneticFieldRecord>().cacheIdentifier();
     es.get<IdealMagneticFieldRecord>().get(eventSetupData_.magField);
   }
 
-  const bool updateGeometry = eventSetupData_.cacheIDTDGeom!=es.get<TrackerDigiGeometryRecord>().cacheIdentifier();
-  if (updateGeometry){
-    eventSetupData_.cacheIDTDGeom=es.get<TrackerDigiGeometryRecord>().cacheIdentifier();
+  const bool updateGeometry = eventSetupData_.cacheIDTDGeom != es.get<TrackerDigiGeometryRecord>().cacheIdentifier();
+  if (updateGeometry) {
+    eventSetupData_.cacheIDTDGeom = es.get<TrackerDigiGeometryRecord>().cacheIdentifier();
     es.get<TrackerDigiGeometryRecord>().get(eventSetupData_.trackerHandle);
   }
 
-  if ( updateField || updateGeometry ) {
-    eventSetupData_.mtsTransform = std::make_unique<MultiTrajectoryStateTransform>(eventSetupData_.trackerHandle.product(),eventSetupData_.magField.product());
-    eventSetupData_.constraintAtVtx = std::make_unique<GsfConstraintAtVertex>(es) ;
+  if (updateField || updateGeometry) {
+    eventSetupData_.mtsTransform = std::make_unique<MultiTrajectoryStateTransform>(
+        eventSetupData_.trackerHandle.product(), eventSetupData_.magField.product());
+    eventSetupData_.constraintAtVtx = std::make_unique<GsfConstraintAtVertex>(es);
   }
 
-  if (eventSetupData_.cacheIDGeom!=es.get<CaloGeometryRecord>().cacheIdentifier()){
-    eventSetupData_.cacheIDGeom=es.get<CaloGeometryRecord>().cacheIdentifier();
+  if (eventSetupData_.cacheIDGeom != es.get<CaloGeometryRecord>().cacheIdentifier()) {
+    eventSetupData_.cacheIDGeom = es.get<CaloGeometryRecord>().cacheIdentifier();
     es.get<CaloGeometryRecord>().get(eventSetupData_.caloGeom);
   }
 
-  if (eventSetupData_.cacheIDTopo!=es.get<CaloTopologyRecord>().cacheIdentifier()){
-    eventSetupData_.cacheIDTopo=es.get<CaloTopologyRecord>().cacheIdentifier();
+  if (eventSetupData_.cacheIDTopo != es.get<CaloTopologyRecord>().cacheIdentifier()) {
+    eventSetupData_.cacheIDTopo = es.get<CaloTopologyRecord>().cacheIdentifier();
     es.get<CaloTopologyRecord>().get(eventSetupData_.caloTopo);
   }
 
-  generalData_.hcalHelper.checkSetup(es) ;
-  generalData_.hcalHelperPflow.checkSetup(es) ;
-  if(generalData_.strategyCfg.useEcalRegression || generalData_.strategyCfg.useCombinationRegression)
+  generalData_.hcalHelper.checkSetup(es);
+  generalData_.hcalHelperPflow.checkSetup(es);
+  if (generalData_.strategyCfg.useEcalRegression || generalData_.strategyCfg.useCombinationRegression)
     generalData_.regHelper.checkSetup(es);
 
+  if (generalData_.superClusterErrorFunction) {
+    generalData_.superClusterErrorFunction->init(es);
+  }
+  if (generalData_.crackCorrectionFunction) {
+    generalData_.crackCorrectionFunction->init(es);
+  }
 
-  if (generalData_.superClusterErrorFunction)
-   { generalData_.superClusterErrorFunction->init(es) ; }
-  if (generalData_.crackCorrectionFunction)
-   { generalData_.crackCorrectionFunction->init(es) ; }
-
-  if(eventSetupData_.cacheSevLevel != es.get<EcalSeverityLevelAlgoRcd>().cacheIdentifier()){
+  if (eventSetupData_.cacheSevLevel != es.get<EcalSeverityLevelAlgoRcd>().cacheIdentifier()) {
     eventSetupData_.cacheSevLevel = es.get<EcalSeverityLevelAlgoRcd>().cacheIdentifier();
     es.get<EcalSeverityLevelAlgoRcd>().get(eventSetupData_.sevLevel);
   }
- }
+}
 
-
-GsfElectronAlgo::EventData GsfElectronAlgo::beginEvent( edm::Event const& event )
- {
+GsfElectronAlgo::EventData GsfElectronAlgo::beginEvent(edm::Event const& event) {
   // prepare access to hcal data
-  generalData_.hcalHelper.readEvent(event) ;
-  generalData_.hcalHelperPflow.readEvent(event) ;
+  generalData_.hcalHelper.readEvent(event);
+  generalData_.hcalHelperPflow.readEvent(event);
 
-  auto const& towers = event.get(generalData_.inputCfg.hcalTowersTag) ;
+  auto const& towers = event.get(generalData_.inputCfg.hcalTowersTag);
 
   // Isolation algos
-  float egHcalIsoConeSizeOutSmall=0.3, egHcalIsoConeSizeOutLarge=0.4;
-  float egHcalIsoConeSizeIn=generalData_.isoCfg.intRadiusHcal,egHcalIsoPtMin=generalData_.isoCfg.etMinHcal;
-  int egHcalDepth1=1, egHcalDepth2=2;
+  float egHcalIsoConeSizeOutSmall = 0.3, egHcalIsoConeSizeOutLarge = 0.4;
+  float egHcalIsoConeSizeIn = generalData_.isoCfg.intRadiusHcal, egHcalIsoPtMin = generalData_.isoCfg.etMinHcal;
+  int egHcalDepth1 = 1, egHcalDepth2 = 2;
 
-  float egIsoConeSizeOutSmall=0.3, egIsoConeSizeOutLarge=0.4, egIsoJurassicWidth=generalData_.isoCfg.jurassicWidth;
-  float egIsoPtMinBarrel=generalData_.isoCfg.etMinBarrel,egIsoEMinBarrel=generalData_.isoCfg.eMinBarrel, egIsoConeSizeInBarrel=generalData_.isoCfg.intRadiusEcalBarrel;
-  float egIsoPtMinEndcap=generalData_.isoCfg.etMinEndcaps,egIsoEMinEndcap=generalData_.isoCfg.eMinEndcaps, egIsoConeSizeInEndcap=generalData_.isoCfg.intRadiusEcalEndcaps;
+  float egIsoConeSizeOutSmall = 0.3, egIsoConeSizeOutLarge = 0.4,
+        egIsoJurassicWidth = generalData_.isoCfg.jurassicWidth;
+  float egIsoPtMinBarrel = generalData_.isoCfg.etMinBarrel, egIsoEMinBarrel = generalData_.isoCfg.eMinBarrel,
+        egIsoConeSizeInBarrel = generalData_.isoCfg.intRadiusEcalBarrel;
+  float egIsoPtMinEndcap = generalData_.isoCfg.etMinEndcaps, egIsoEMinEndcap = generalData_.isoCfg.eMinEndcaps,
+        egIsoConeSizeInEndcap = generalData_.isoCfg.intRadiusEcalEndcaps;
 
   auto barrelRecHits = event.getHandle(generalData_.inputCfg.barrelRecHitCollection);
   auto endcapRecHits = event.getHandle(generalData_.inputCfg.endcapRecHitCollection);
 
   EventData eventData{
-      .event             = &event,
-      .beamspot          = &event.get(generalData_.inputCfg.beamSpotTag),
+      .event = &event,
+      .beamspot = &event.get(generalData_.inputCfg.beamSpotTag),
       .previousElectrons = event.getHandle(generalData_.inputCfg.previousGsfElectrons),
-      .pflowElectrons    = event.getHandle(generalData_.inputCfg.pflowGsfElectronsTag),
-      .coreElectrons     = event.getHandle(generalData_.inputCfg.gsfElectronCores),
-      .barrelRecHits     = barrelRecHits,
-      .endcapRecHits     = endcapRecHits,
-      .currentCtfTracks  = event.getHandle(generalData_.inputCfg.ctfTracks),
-      .seeds             = event.getHandle(generalData_.inputCfg.seedsTag),
-      .gsfPfRecTracks    = generalData_.strategyCfg.useGsfPfRecTracks ? event.getHandle(generalData_.inputCfg.gsfPfRecTracksTag) : edm::Handle<reco::GsfPFRecTrackCollection>{},
-      .vertices          = event.getHandle(generalData_.inputCfg.vtxCollectionTag),
-      .conversions       = generalData_.strategyCfg.fillConvVtxFitProb ? event.getHandle(generalData_.inputCfg.conversions) : edm::Handle<reco::ConversionCollection>(),
-      .hadDepth1Isolation03 = EgammaTowerIsolation(egHcalIsoConeSizeOutSmall,egHcalIsoConeSizeIn,egHcalIsoPtMin,egHcalDepth1,&towers),
-      .hadDepth1Isolation04 = EgammaTowerIsolation(egHcalIsoConeSizeOutLarge,egHcalIsoConeSizeIn,egHcalIsoPtMin,egHcalDepth1,&towers),
-      .hadDepth2Isolation03 = EgammaTowerIsolation(egHcalIsoConeSizeOutSmall,egHcalIsoConeSizeIn,egHcalIsoPtMin,egHcalDepth2,&towers),
-      .hadDepth2Isolation04 = EgammaTowerIsolation(egHcalIsoConeSizeOutLarge,egHcalIsoConeSizeIn,egHcalIsoPtMin,egHcalDepth2,&towers),
-      .hadDepth1Isolation03Bc = EgammaTowerIsolation(egHcalIsoConeSizeOutSmall,0.,egHcalIsoPtMin,egHcalDepth1,&towers),
-      .hadDepth1Isolation04Bc = EgammaTowerIsolation(egHcalIsoConeSizeOutLarge,0.,egHcalIsoPtMin,egHcalDepth1,&towers),
-      .hadDepth2Isolation03Bc = EgammaTowerIsolation(egHcalIsoConeSizeOutSmall,0.,egHcalIsoPtMin,egHcalDepth2,&towers),
-      .hadDepth2Isolation04Bc = EgammaTowerIsolation(egHcalIsoConeSizeOutLarge,0.,egHcalIsoPtMin,egHcalDepth2,&towers),
-      .ecalBarrelIsol03 = EgammaRecHitIsolation(egIsoConeSizeOutSmall,egIsoConeSizeInBarrel,egIsoJurassicWidth,egIsoPtMinBarrel,egIsoEMinBarrel,eventSetupData_.caloGeom,*barrelRecHits,eventSetupData_.sevLevel.product(),DetId::Ecal),
-      .ecalBarrelIsol04 = EgammaRecHitIsolation(egIsoConeSizeOutLarge,egIsoConeSizeInBarrel,egIsoJurassicWidth,egIsoPtMinBarrel,egIsoEMinBarrel,eventSetupData_.caloGeom,*barrelRecHits,eventSetupData_.sevLevel.product(),DetId::Ecal),
-      .ecalEndcapIsol03 = EgammaRecHitIsolation(egIsoConeSizeOutSmall,egIsoConeSizeInEndcap,egIsoJurassicWidth,egIsoPtMinEndcap,egIsoEMinEndcap,eventSetupData_.caloGeom,*endcapRecHits,eventSetupData_.sevLevel.product(),DetId::Ecal),
-      .ecalEndcapIsol04 = EgammaRecHitIsolation(egIsoConeSizeOutLarge,egIsoConeSizeInEndcap,egIsoJurassicWidth,egIsoPtMinEndcap,egIsoEMinEndcap,eventSetupData_.caloGeom,*endcapRecHits,eventSetupData_.sevLevel.product(),DetId::Ecal)
-  } ;
+      .pflowElectrons = event.getHandle(generalData_.inputCfg.pflowGsfElectronsTag),
+      .coreElectrons = event.getHandle(generalData_.inputCfg.gsfElectronCores),
+      .barrelRecHits = barrelRecHits,
+      .endcapRecHits = endcapRecHits,
+      .currentCtfTracks = event.getHandle(generalData_.inputCfg.ctfTracks),
+      .seeds = event.getHandle(generalData_.inputCfg.seedsTag),
+      .gsfPfRecTracks = generalData_.strategyCfg.useGsfPfRecTracks
+                            ? event.getHandle(generalData_.inputCfg.gsfPfRecTracksTag)
+                            : edm::Handle<reco::GsfPFRecTrackCollection>{},
+      .vertices = event.getHandle(generalData_.inputCfg.vtxCollectionTag),
+      .conversions = generalData_.strategyCfg.fillConvVtxFitProb ? event.getHandle(generalData_.inputCfg.conversions)
+                                                                 : edm::Handle<reco::ConversionCollection>(),
+      .hadDepth1Isolation03 =
+          EgammaTowerIsolation(egHcalIsoConeSizeOutSmall, egHcalIsoConeSizeIn, egHcalIsoPtMin, egHcalDepth1, &towers),
+      .hadDepth1Isolation04 =
+          EgammaTowerIsolation(egHcalIsoConeSizeOutLarge, egHcalIsoConeSizeIn, egHcalIsoPtMin, egHcalDepth1, &towers),
+      .hadDepth2Isolation03 =
+          EgammaTowerIsolation(egHcalIsoConeSizeOutSmall, egHcalIsoConeSizeIn, egHcalIsoPtMin, egHcalDepth2, &towers),
+      .hadDepth2Isolation04 =
+          EgammaTowerIsolation(egHcalIsoConeSizeOutLarge, egHcalIsoConeSizeIn, egHcalIsoPtMin, egHcalDepth2, &towers),
+      .hadDepth1Isolation03Bc =
+          EgammaTowerIsolation(egHcalIsoConeSizeOutSmall, 0., egHcalIsoPtMin, egHcalDepth1, &towers),
+      .hadDepth1Isolation04Bc =
+          EgammaTowerIsolation(egHcalIsoConeSizeOutLarge, 0., egHcalIsoPtMin, egHcalDepth1, &towers),
+      .hadDepth2Isolation03Bc =
+          EgammaTowerIsolation(egHcalIsoConeSizeOutSmall, 0., egHcalIsoPtMin, egHcalDepth2, &towers),
+      .hadDepth2Isolation04Bc =
+          EgammaTowerIsolation(egHcalIsoConeSizeOutLarge, 0., egHcalIsoPtMin, egHcalDepth2, &towers),
+      .ecalBarrelIsol03 = EgammaRecHitIsolation(egIsoConeSizeOutSmall,
+                                                egIsoConeSizeInBarrel,
+                                                egIsoJurassicWidth,
+                                                egIsoPtMinBarrel,
+                                                egIsoEMinBarrel,
+                                                eventSetupData_.caloGeom,
+                                                *barrelRecHits,
+                                                eventSetupData_.sevLevel.product(),
+                                                DetId::Ecal),
+      .ecalBarrelIsol04 = EgammaRecHitIsolation(egIsoConeSizeOutLarge,
+                                                egIsoConeSizeInBarrel,
+                                                egIsoJurassicWidth,
+                                                egIsoPtMinBarrel,
+                                                egIsoEMinBarrel,
+                                                eventSetupData_.caloGeom,
+                                                *barrelRecHits,
+                                                eventSetupData_.sevLevel.product(),
+                                                DetId::Ecal),
+      .ecalEndcapIsol03 = EgammaRecHitIsolation(egIsoConeSizeOutSmall,
+                                                egIsoConeSizeInEndcap,
+                                                egIsoJurassicWidth,
+                                                egIsoPtMinEndcap,
+                                                egIsoEMinEndcap,
+                                                eventSetupData_.caloGeom,
+                                                *endcapRecHits,
+                                                eventSetupData_.sevLevel.product(),
+                                                DetId::Ecal),
+      .ecalEndcapIsol04 = EgammaRecHitIsolation(egIsoConeSizeOutLarge,
+                                                egIsoConeSizeInEndcap,
+                                                egIsoJurassicWidth,
+                                                egIsoPtMinEndcap,
+                                                egIsoEMinEndcap,
+                                                eventSetupData_.caloGeom,
+                                                *endcapRecHits,
+                                                eventSetupData_.sevLevel.product(),
+                                                DetId::Ecal)};
 
   eventData.ecalBarrelIsol03.setUseNumCrystals(generalData_.isoCfg.useNumCrystals);
   eventData.ecalBarrelIsol03.setVetoClustered(generalData_.isoCfg.vetoClustered);
-  eventData.ecalBarrelIsol03.doSeverityChecks(eventData.barrelRecHits.product(),generalData_.recHitsCfg.recHitSeverityToBeExcludedBarrel);
+  eventData.ecalBarrelIsol03.doSeverityChecks(eventData.barrelRecHits.product(),
+                                              generalData_.recHitsCfg.recHitSeverityToBeExcludedBarrel);
   eventData.ecalBarrelIsol03.doFlagChecks(generalData_.recHitsCfg.recHitFlagsToBeExcludedBarrel);
   eventData.ecalBarrelIsol04.setUseNumCrystals(generalData_.isoCfg.useNumCrystals);
   eventData.ecalBarrelIsol04.setVetoClustered(generalData_.isoCfg.vetoClustered);
-  eventData.ecalBarrelIsol04.doSeverityChecks(eventData.barrelRecHits.product(),generalData_.recHitsCfg.recHitSeverityToBeExcludedBarrel);
+  eventData.ecalBarrelIsol04.doSeverityChecks(eventData.barrelRecHits.product(),
+                                              generalData_.recHitsCfg.recHitSeverityToBeExcludedBarrel);
   eventData.ecalBarrelIsol04.doFlagChecks(generalData_.recHitsCfg.recHitFlagsToBeExcludedBarrel);
   eventData.ecalEndcapIsol03.setUseNumCrystals(generalData_.isoCfg.useNumCrystals);
   eventData.ecalEndcapIsol03.setVetoClustered(generalData_.isoCfg.vetoClustered);
-  eventData.ecalEndcapIsol03.doSeverityChecks(eventData.endcapRecHits.product(),generalData_.recHitsCfg.recHitSeverityToBeExcludedEndcaps);
+  eventData.ecalEndcapIsol03.doSeverityChecks(eventData.endcapRecHits.product(),
+                                              generalData_.recHitsCfg.recHitSeverityToBeExcludedEndcaps);
   eventData.ecalEndcapIsol03.doFlagChecks(generalData_.recHitsCfg.recHitFlagsToBeExcludedEndcaps);
   eventData.ecalEndcapIsol04.setUseNumCrystals(generalData_.isoCfg.useNumCrystals);
   eventData.ecalEndcapIsol04.setVetoClustered(generalData_.isoCfg.vetoClustered);
-  eventData.ecalEndcapIsol04.doSeverityChecks(eventData.endcapRecHits.product(),generalData_.recHitsCfg.recHitSeverityToBeExcludedEndcaps);
+  eventData.ecalEndcapIsol04.doSeverityChecks(eventData.endcapRecHits.product(),
+                                              generalData_.recHitsCfg.recHitSeverityToBeExcludedEndcaps);
   eventData.ecalEndcapIsol04.doFlagChecks(generalData_.recHitsCfg.recHitFlagsToBeExcludedEndcaps);
-  
+
   return eventData;
- }
+}
 
-
-void GsfElectronAlgo::completeElectrons( reco::GsfElectronCollection & electrons,
-                                         edm::Event const& event,
-                                         edm::EventSetup const& eventSetup,
-                                         const gsfAlgoHelpers::HeavyObjectCache* hoc )
- {
+void GsfElectronAlgo::completeElectrons(reco::GsfElectronCollection& electrons,
+                                        edm::Event const& event,
+                                        edm::EventSetup const& eventSetup,
+                                        const gsfAlgoHelpers::HeavyObjectCache* hoc) {
   checkSetup(eventSetup);
   auto eventData = beginEvent(event);
 
-  const GsfElectronCoreCollection * coreCollection = eventData.coreElectrons.product() ;
-  for ( unsigned int i=0 ; i<coreCollection->size() ; ++i )
-   {
+  const GsfElectronCoreCollection* coreCollection = eventData.coreElectrons.product();
+  for (unsigned int i = 0; i < coreCollection->size(); ++i) {
     // check there is no existing electron with this core
-    const GsfElectronCoreRef coreRef = edm::Ref<GsfElectronCoreCollection>(eventData.coreElectrons,i) ;
-    bool coreFound = false ;
-    for(auto const& ele : electrons)
-     {
-      if (ele.core()==coreRef)
-       {
-        coreFound = true ;
-        break ;
-       }
-     }
-    if (coreFound) continue ;
+    const GsfElectronCoreRef coreRef = edm::Ref<GsfElectronCoreCollection>(eventData.coreElectrons, i);
+    bool coreFound = false;
+    for (auto const& ele : electrons) {
+      if (ele.core() == coreRef) {
+        coreFound = true;
+        break;
+      }
+    }
+    if (coreFound)
+      continue;
 
     // check there is a super-cluster
-    if (coreRef->superCluster().isNull()) continue ;
+    if (coreRef->superCluster().isNull())
+      continue;
 
     // prepare internal structure for electron specific data
-    ElectronData electronData(coreRef,*eventData.beamspot) ;
+    ElectronData electronData(coreRef, *eventData.beamspot);
 
     // calculate and check Trajectory StatesOnSurface....
-    if ( !electronData.calculateTSOS( *eventSetupData_.mtsTransform, *eventSetupData_.constraintAtVtx ) ) continue ;
+    if (!electronData.calculateTSOS(*eventSetupData_.mtsTransform, *eventSetupData_.constraintAtVtx))
+      continue;
 
-    createElectron(electrons, electronData, eventData, hoc) ;
+    createElectron(electrons, electronData, eventData, hoc);
 
-   } // loop over tracks
+  }  // loop over tracks
+}
 
- }
-
-
-void GsfElectronAlgo::setCutBasedPreselectionFlag( GsfElectron & ele, const reco::BeamSpot & bs )
- {
+void GsfElectronAlgo::setCutBasedPreselectionFlag(GsfElectron& ele, const reco::BeamSpot& bs) {
   // default value
-  ele.setPassCutBasedPreselection(false) ;
+  ele.setPassCutBasedPreselection(false);
 
   // kind of seeding
-  bool eg = ele.core()->ecalDrivenSeed() ;
-  bool pf = ele.core()->trackerDrivenSeed() && !ele.core()->ecalDrivenSeed() ;
+  bool eg = ele.core()->ecalDrivenSeed();
+  bool pf = ele.core()->trackerDrivenSeed() && !ele.core()->ecalDrivenSeed();
   bool gedMode = generalData_.strategyCfg.gedElectronMode;
-  if (eg&&pf) { throw cms::Exception("GsfElectronAlgo|BothEcalAndPureTrackerDriven")<<"An electron cannot be both egamma and purely pflow" ; }
-  if ((!eg)&&(!pf)) { throw cms::Exception("GsfElectronAlgo|NeitherEcalNorPureTrackerDriven")<<"An electron cannot be neither egamma nor purely pflow" ; }
+  if (eg && pf) {
+    throw cms::Exception("GsfElectronAlgo|BothEcalAndPureTrackerDriven")
+        << "An electron cannot be both egamma and purely pflow";
+  }
+  if ((!eg) && (!pf)) {
+    throw cms::Exception("GsfElectronAlgo|NeitherEcalNorPureTrackerDriven")
+        << "An electron cannot be neither egamma nor purely pflow";
+  }
 
-  const CutsConfiguration * cfg = ((eg||gedMode)?&generalData_.cutsCfg:&generalData_.cutsCfgPflow);
+  const CutsConfiguration* cfg = ((eg || gedMode) ? &generalData_.cutsCfg : &generalData_.cutsCfgPflow);
 
   // Et cut
-  double etaValue = EleRelPoint(ele.superCluster()->position(),bs.position()).eta() ;
-  double etValue = ele.superCluster()->energy()/cosh(etaValue) ;
-  LogTrace("GsfElectronAlgo") << "Et : " << etValue ;
-  if (ele.isEB() && (etValue < cfg->minSCEtBarrel)) return ;
-  if (ele.isEE() && (etValue < cfg->minSCEtEndcaps)) return ;
+  double etaValue = EleRelPoint(ele.superCluster()->position(), bs.position()).eta();
+  double etValue = ele.superCluster()->energy() / cosh(etaValue);
+  LogTrace("GsfElectronAlgo") << "Et : " << etValue;
+  if (ele.isEB() && (etValue < cfg->minSCEtBarrel))
+    return;
+  if (ele.isEE() && (etValue < cfg->minSCEtEndcaps))
+    return;
   LogTrace("GsfElectronAlgo") << "Et criteria are satisfied";
 
   // E/p cut
-  double eopValue = ele.eSuperClusterOverP() ;
-  LogTrace("GsfElectronAlgo") << "E/p : " << eopValue ;
-  if (ele.isEB() && (eopValue > cfg->maxEOverPBarrel)) return ;
-  if (ele.isEE() && (eopValue > cfg->maxEOverPEndcaps)) return ;
-  if (ele.isEB() && (eopValue < cfg->minEOverPBarrel)) return ;
-  if (ele.isEE() && (eopValue < cfg->minEOverPEndcaps)) return ;
+  double eopValue = ele.eSuperClusterOverP();
+  LogTrace("GsfElectronAlgo") << "E/p : " << eopValue;
+  if (ele.isEB() && (eopValue > cfg->maxEOverPBarrel))
+    return;
+  if (ele.isEE() && (eopValue > cfg->maxEOverPEndcaps))
+    return;
+  if (ele.isEB() && (eopValue < cfg->minEOverPBarrel))
+    return;
+  if (ele.isEE() && (eopValue < cfg->minEOverPEndcaps))
+    return;
   LogTrace("GsfElectronAlgo") << "E/p criteria are satisfied";
 
   // HoE cuts
   LogTrace("GsfElectronAlgo") << "HoE1 : " << ele.hcalDepth1OverEcal() << ", HoE2 : " << ele.hcalDepth2OverEcal();
   double hoeCone = ele.hcalOverEcal();
   double hoeTower = ele.hcalOverEcalBc();
-  const reco::CaloCluster & seedCluster = *(ele.superCluster()->seed()) ;
-  int detector = seedCluster.hitsAndFractions()[0].first.subdetId() ;
-  bool HoEveto = false ;
+  const reco::CaloCluster& seedCluster = *(ele.superCluster()->seed());
+  int detector = seedCluster.hitsAndFractions()[0].first.subdetId();
+  bool HoEveto = false;
   double scle = ele.superCluster()->energy();
 
-  if (detector==EcalBarrel) HoEveto =
-      hoeCone*scle<cfg->maxHBarrelCone || hoeTower*scle<cfg->maxHBarrelTower ||
-     hoeCone<cfg->maxHOverEBarrelCone || hoeTower<cfg->maxHOverEBarrelTower;
-  else if (detector==EcalEndcap) HoEveto =
-      hoeCone*scle<cfg->maxHEndcapsCone || hoeTower*scle<cfg->maxHEndcapsTower ||
-     hoeCone<cfg->maxHOverEEndcapsCone || hoeTower<cfg->maxHOverEEndcapsTower;
+  if (detector == EcalBarrel)
+    HoEveto = hoeCone * scle < cfg->maxHBarrelCone || hoeTower * scle < cfg->maxHBarrelTower ||
+              hoeCone < cfg->maxHOverEBarrelCone || hoeTower < cfg->maxHOverEBarrelTower;
+  else if (detector == EcalEndcap)
+    HoEveto = hoeCone * scle < cfg->maxHEndcapsCone || hoeTower * scle < cfg->maxHEndcapsTower ||
+              hoeCone < cfg->maxHOverEEndcapsCone || hoeTower < cfg->maxHOverEEndcapsTower;
 
-  if ( !HoEveto ) return ;
+  if (!HoEveto)
+    return;
   LogTrace("GsfElectronAlgo") << "H/E criteria are satisfied";
 
   // delta eta criteria
-  double deta = ele.deltaEtaSuperClusterTrackAtVtx() ;
-  LogTrace("GsfElectronAlgo") << "delta eta : " << deta ;
-  if (ele.isEB() && (std::abs(deta) > cfg->maxDeltaEtaBarrel)) return ;
-  if (ele.isEE() && (std::abs(deta) > cfg->maxDeltaEtaEndcaps)) return ;
+  double deta = ele.deltaEtaSuperClusterTrackAtVtx();
+  LogTrace("GsfElectronAlgo") << "delta eta : " << deta;
+  if (ele.isEB() && (std::abs(deta) > cfg->maxDeltaEtaBarrel))
+    return;
+  if (ele.isEE() && (std::abs(deta) > cfg->maxDeltaEtaEndcaps))
+    return;
   LogTrace("GsfElectronAlgo") << "Delta eta criteria are satisfied";
 
   // delta phi criteria
   double dphi = ele.deltaPhiSuperClusterTrackAtVtx();
   LogTrace("GsfElectronAlgo") << "delta phi : " << dphi;
-  if (ele.isEB() && (std::abs(dphi) > cfg->maxDeltaPhiBarrel)) return ;
-  if (ele.isEE() && (std::abs(dphi) > cfg->maxDeltaPhiEndcaps)) return ;
+  if (ele.isEB() && (std::abs(dphi) > cfg->maxDeltaPhiBarrel))
+    return;
+  if (ele.isEE() && (std::abs(dphi) > cfg->maxDeltaPhiEndcaps))
+    return;
   LogTrace("GsfElectronAlgo") << "Delta phi criteria are satisfied";
 
   // sigma ieta ieta
   LogTrace("GsfElectronAlgo") << "sigma ieta ieta : " << ele.sigmaIetaIeta();
-  if (ele.isEB() && (ele.sigmaIetaIeta() > cfg->maxSigmaIetaIetaBarrel)) return ;
-  if (ele.isEE() && (ele.sigmaIetaIeta() > cfg->maxSigmaIetaIetaEndcaps)) return ;
+  if (ele.isEB() && (ele.sigmaIetaIeta() > cfg->maxSigmaIetaIetaBarrel))
+    return;
+  if (ele.isEE() && (ele.sigmaIetaIeta() > cfg->maxSigmaIetaIetaEndcaps))
+    return;
   LogTrace("GsfElectronAlgo") << "Sigma ieta ieta criteria are satisfied";
 
   // fiducial
-  if (!ele.isEB() && cfg->isBarrel) return ;
-  if (!ele.isEE() && cfg->isEndcaps) return ;
-  if (cfg->isFiducial && (ele.isEBEEGap()||ele.isEBEtaGap()||ele.isEBPhiGap()||ele.isEERingGap()||ele.isEEDeeGap())) return ;
+  if (!ele.isEB() && cfg->isBarrel)
+    return;
+  if (!ele.isEE() && cfg->isEndcaps)
+    return;
+  if (cfg->isFiducial &&
+      (ele.isEBEEGap() || ele.isEBEtaGap() || ele.isEBPhiGap() || ele.isEERingGap() || ele.isEEDeeGap()))
+    return;
   LogTrace("GsfElectronAlgo") << "Fiducial flags criteria are satisfied";
 
   // seed in TEC
-  edm::RefToBase<TrajectorySeed> seed = ele.gsfTrack()->extra()->seedRef() ;
-  ElectronSeedRef elseed = seed.castTo<ElectronSeedRef>() ;
-  if (eg && !generalData_.cutsCfg.seedFromTEC)
-   {
-    if (elseed.isNull())
-     { throw cms::Exception("GsfElectronAlgo|NotElectronSeed")<<"The GsfTrack seed is not an ElectronSeed ?!" ; }
-    else
-     { if (elseed->subDet2()==6) return ; }
-   }
+  edm::RefToBase<TrajectorySeed> seed = ele.gsfTrack()->extra()->seedRef();
+  ElectronSeedRef elseed = seed.castTo<ElectronSeedRef>();
+  if (eg && !generalData_.cutsCfg.seedFromTEC) {
+    if (elseed.isNull()) {
+      throw cms::Exception("GsfElectronAlgo|NotElectronSeed") << "The GsfTrack seed is not an ElectronSeed ?!";
+    } else {
+      if (elseed->subDet2() == 6)
+        return;
+    }
+  }
 
   // transverse impact parameter
-  if (std::abs(ele.gsfTrack()->dxy(bs.position()))>cfg->maxTIP) return ;
-  LogTrace("GsfElectronAlgo") << "TIP criterion is satisfied" ;
+  if (std::abs(ele.gsfTrack()->dxy(bs.position())) > cfg->maxTIP)
+    return;
+  LogTrace("GsfElectronAlgo") << "TIP criterion is satisfied";
 
-  LogTrace("GsfElectronAlgo") << "All cut based criteria are satisfied" ;
-  ele.setPassCutBasedPreselection(true) ;
- }
+  LogTrace("GsfElectronAlgo") << "All cut based criteria are satisfied";
+  ele.setPassCutBasedPreselection(true);
+}
 
-
-void GsfElectronAlgo::createElectron(reco::GsfElectronCollection & electrons, ElectronData & electronData, EventData & eventData, const gsfAlgoHelpers::HeavyObjectCache* hoc)
- {
+void GsfElectronAlgo::createElectron(reco::GsfElectronCollection& electrons,
+                                     ElectronData& electronData,
+                                     EventData& eventData,
+                                     const gsfAlgoHelpers::HeavyObjectCache* hoc) {
   // eventually check ctf track
   if (generalData_.strategyCfg.ctfTracksCheck && electronData.ctfTrackRef.isNull()) {
-    electronData.ctfTrackRef = gsfElectronTools::getClosestCtfToGsf( electronData.gsfTrackRef,
-                                                                       eventData.currentCtfTracks ).first;
+    electronData.ctfTrackRef =
+        gsfElectronTools::getClosestCtfToGsf(electronData.gsfTrackRef, eventData.currentCtfTracks).first;
   }
 
   // charge ID
-  int eleCharge ;
-  GsfElectron::ChargeInfo eleChargeInfo ;
-  electronData.computeCharge(eleCharge,eleChargeInfo) ;
+  int eleCharge;
+  GsfElectron::ChargeInfo eleChargeInfo;
+  electronData.computeCharge(eleCharge, eleChargeInfo);
 
   // electron basic cluster
-  CaloClusterPtr elbcRef = electronData.getEleBasicCluster(*eventSetupData_.mtsTransform) ;
+  CaloClusterPtr elbcRef = electronData.getEleBasicCluster(*eventSetupData_.mtsTransform);
 
   // Seed cluster
-  const reco::CaloCluster & seedCluster = *(electronData.superClusterRef->seed()) ;
+  const reco::CaloCluster& seedCluster = *(electronData.superClusterRef->seed());
 
   // seed Xtal
   // temporary, till CaloCluster->seed() is made available
-  DetId seedXtalId = seedCluster.hitsAndFractions()[0].first ;
+  DetId seedXtalId = seedCluster.hitsAndFractions()[0].first;
 
-  electronData.calculateMode() ;
-
+  electronData.calculateMode();
 
   //====================================================
   // Candidate attributes
   //====================================================
 
-  Candidate::LorentzVector momentum = electronData.calculateMomentum() ;
-
+  Candidate::LorentzVector momentum = electronData.calculateMomentum();
 
   //====================================================
   // Track-Cluster Matching
   //====================================================
 
-  reco::GsfElectron::TrackClusterMatching tcMatching ;
-  tcMatching.electronCluster = elbcRef ;
-  tcMatching.eSuperClusterOverP = (electronData.vtxMom.mag()>0)?(electronData.superClusterRef->energy()/electronData.vtxMom.mag()):(-1.) ;
-  tcMatching.eSeedClusterOverP = (electronData.vtxMom.mag()>0.)?(seedCluster.energy()/electronData.vtxMom.mag()):(-1) ;
-  tcMatching.eSeedClusterOverPout = (electronData.seedMom.mag()>0.)?(seedCluster.energy()/electronData.seedMom.mag()):(-1.) ;
-  tcMatching.eEleClusterOverPout = (electronData.eleMom.mag()>0.)?(elbcRef->energy()/electronData.eleMom.mag()):(-1.) ;
+  reco::GsfElectron::TrackClusterMatching tcMatching;
+  tcMatching.electronCluster = elbcRef;
+  tcMatching.eSuperClusterOverP =
+      (electronData.vtxMom.mag() > 0) ? (electronData.superClusterRef->energy() / electronData.vtxMom.mag()) : (-1.);
+  tcMatching.eSeedClusterOverP =
+      (electronData.vtxMom.mag() > 0.) ? (seedCluster.energy() / electronData.vtxMom.mag()) : (-1);
+  tcMatching.eSeedClusterOverPout =
+      (electronData.seedMom.mag() > 0.) ? (seedCluster.energy() / electronData.seedMom.mag()) : (-1.);
+  tcMatching.eEleClusterOverPout =
+      (electronData.eleMom.mag() > 0.) ? (elbcRef->energy() / electronData.eleMom.mag()) : (-1.);
 
-  EleRelPointPair scAtVtx(electronData.superClusterRef->position(),electronData.sclPos,eventData.beamspot->position()) ;
-  tcMatching.deltaEtaSuperClusterAtVtx = scAtVtx.dEta() ;
-  tcMatching.deltaPhiSuperClusterAtVtx = scAtVtx.dPhi() ;
+  EleRelPointPair scAtVtx(
+      electronData.superClusterRef->position(), electronData.sclPos, eventData.beamspot->position());
+  tcMatching.deltaEtaSuperClusterAtVtx = scAtVtx.dEta();
+  tcMatching.deltaPhiSuperClusterAtVtx = scAtVtx.dPhi();
 
-  EleRelPointPair seedAtCalo(seedCluster.position(),electronData.seedPos,eventData.beamspot->position()) ;
-  tcMatching.deltaEtaSeedClusterAtCalo = seedAtCalo.dEta() ;
-  tcMatching.deltaPhiSeedClusterAtCalo = seedAtCalo.dPhi() ;
+  EleRelPointPair seedAtCalo(seedCluster.position(), electronData.seedPos, eventData.beamspot->position());
+  tcMatching.deltaEtaSeedClusterAtCalo = seedAtCalo.dEta();
+  tcMatching.deltaPhiSeedClusterAtCalo = seedAtCalo.dPhi();
 
-  EleRelPointPair ecAtCalo(elbcRef->position(),electronData.elePos,eventData.beamspot->position()) ;
-  tcMatching.deltaEtaEleClusterAtCalo = ecAtCalo.dEta() ;
-  tcMatching.deltaPhiEleClusterAtCalo = ecAtCalo.dPhi() ;
-
+  EleRelPointPair ecAtCalo(elbcRef->position(), electronData.elePos, eventData.beamspot->position());
+  tcMatching.deltaEtaEleClusterAtCalo = ecAtCalo.dEta();
+  tcMatching.deltaPhiEleClusterAtCalo = ecAtCalo.dPhi();
 
   //=======================================================
   // Track extrapolations
   //=======================================================
 
-  reco::GsfElectron::TrackExtrapolations tkExtra ;
-  ele_convert(electronData.vtxPos,tkExtra.positionAtVtx) ;
-  ele_convert(electronData.sclPos,tkExtra.positionAtCalo) ;
-  ele_convert(electronData.vtxMom,tkExtra.momentumAtVtx) ;
-  ele_convert(electronData.sclMom,tkExtra.momentumAtCalo) ;
-  ele_convert(electronData.seedMom,tkExtra.momentumOut) ;
-  ele_convert(electronData.eleMom,tkExtra.momentumAtEleClus) ;
-  ele_convert(electronData.vtxMomWithConstraint,tkExtra.momentumAtVtxWithConstraint) ;
-
+  reco::GsfElectron::TrackExtrapolations tkExtra;
+  ele_convert(electronData.vtxPos, tkExtra.positionAtVtx);
+  ele_convert(electronData.sclPos, tkExtra.positionAtCalo);
+  ele_convert(electronData.vtxMom, tkExtra.momentumAtVtx);
+  ele_convert(electronData.sclMom, tkExtra.momentumAtCalo);
+  ele_convert(electronData.seedMom, tkExtra.momentumOut);
+  ele_convert(electronData.eleMom, tkExtra.momentumAtEleClus);
+  ele_convert(electronData.vtxMomWithConstraint, tkExtra.momentumAtVtxWithConstraint);
 
   //=======================================================
   // Closest Ctf Track
   //=======================================================
 
-  reco::GsfElectron::ClosestCtfTrack ctfInfo ;
-  ctfInfo.ctfTrack = electronData.ctfTrackRef  ;
-  ctfInfo.shFracInnerHits = electronData.shFracInnerHits ;
-
+  reco::GsfElectron::ClosestCtfTrack ctfInfo;
+  ctfInfo.ctfTrack = electronData.ctfTrackRef;
+  ctfInfo.shFracInnerHits = electronData.shFracInnerHits;
 
   //====================================================
   // FiducialFlags, using nextToBoundary definition of gaps
   //====================================================
 
-  reco::GsfElectron::FiducialFlags fiducialFlags ;
-  int region   = seedXtalId.det();
-  int detector = seedXtalId.subdetId() ;
-  double feta=std::abs(electronData.superClusterRef->position().eta()) ;
-  if (detector==EcalBarrel)
-   {
-    fiducialFlags.isEB = true ;
+  reco::GsfElectron::FiducialFlags fiducialFlags;
+  int region = seedXtalId.det();
+  int detector = seedXtalId.subdetId();
+  double feta = std::abs(electronData.superClusterRef->position().eta());
+  if (detector == EcalBarrel) {
+    fiducialFlags.isEB = true;
     EBDetId ebdetid(seedXtalId);
-    if (EBDetId::isNextToEtaBoundary(ebdetid))
-     {
-      if (ebdetid.ietaAbs()==85)
-       { fiducialFlags.isEBEEGap = true ; }
-      else
-       { fiducialFlags.isEBEtaGap = true ; }
-     }
-    if (EBDetId::isNextToPhiBoundary(ebdetid))
-     { fiducialFlags.isEBPhiGap = true ; }
-   }
-  else if (detector==EcalEndcap)
-   {
-    fiducialFlags.isEE = true ;
+    if (EBDetId::isNextToEtaBoundary(ebdetid)) {
+      if (ebdetid.ietaAbs() == 85) {
+        fiducialFlags.isEBEEGap = true;
+      } else {
+        fiducialFlags.isEBEtaGap = true;
+      }
+    }
+    if (EBDetId::isNextToPhiBoundary(ebdetid)) {
+      fiducialFlags.isEBPhiGap = true;
+    }
+  } else if (detector == EcalEndcap) {
+    fiducialFlags.isEE = true;
     EEDetId eedetid(seedXtalId);
-    if (EEDetId::isNextToRingBoundary(eedetid))
-     {
-      if (std::abs(feta)<2.)
-       { fiducialFlags.isEBEEGap = true ; }
-      else
-       { fiducialFlags.isEERingGap = true ; }
-     }
-    if (EEDetId::isNextToDBoundary(eedetid))
-     { fiducialFlags.isEEDeeGap = true ; }
-   }
-  else if ( EcalTools::isHGCalDet((DetId::Detector)region) )
-   {
-    fiducialFlags.isEE = true ;
-    //HGCalDetId eeDetid(seedXtalId);    
+    if (EEDetId::isNextToRingBoundary(eedetid)) {
+      if (std::abs(feta) < 2.) {
+        fiducialFlags.isEBEEGap = true;
+      } else {
+        fiducialFlags.isEERingGap = true;
+      }
+    }
+    if (EEDetId::isNextToDBoundary(eedetid)) {
+      fiducialFlags.isEEDeeGap = true;
+    }
+  } else if (EcalTools::isHGCalDet((DetId::Detector)region)) {
+    fiducialFlags.isEE = true;
+    //HGCalDetId eeDetid(seedXtalId);
     // fill in fiducial information when we know how to use it...
-   }
-  else
-   { throw cms::Exception("GsfElectronAlgo|UnknownXtalRegion")<<"createElectron(): do not know if it is a barrel or endcap seed cluster !!!!" ; }
-
+  } else {
+    throw cms::Exception("GsfElectronAlgo|UnknownXtalRegion")
+        << "createElectron(): do not know if it is a barrel or endcap seed cluster !!!!";
+  }
 
   //====================================================
   // SaturationInfo
@@ -709,22 +776,24 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection & electrons, El
 
   reco::GsfElectron::ShowerShape showerShape;
   reco::GsfElectron::ShowerShape full5x5_showerShape;
-  if( !EcalTools::isHGCalDet((DetId::Detector)region) ) {
+  if (!EcalTools::isHGCalDet((DetId::Detector)region)) {
     const bool pflow = !(electronData.coreRef->ecalDrivenSeed());
     auto const& hcalHelper = pflow ? generalData_.hcalHelperPflow : generalData_.hcalHelper;
-    calculateShowerShape<false>(electronData.superClusterRef,hcalHelper,showerShape,eventData) ;    
-    calculateShowerShape<true>(electronData.superClusterRef,hcalHelper,full5x5_showerShape,eventData) ;
+    calculateShowerShape<false>(electronData.superClusterRef, hcalHelper, showerShape, eventData);
+    calculateShowerShape<true>(electronData.superClusterRef, hcalHelper, full5x5_showerShape, eventData);
   }
 
   //====================================================
   // ConversionRejection
   //====================================================
 
-  eventData.retreiveOriginalTrackCollections(electronData.ctfTrackRef,electronData.coreRef->gsfTrack()) ;
+  eventData.retreiveOriginalTrackCollections(electronData.ctfTrackRef, electronData.coreRef->gsfTrack());
 
-  double BInTesla = eventSetupData_.magField->inTesla(GlobalPoint(0.,0.,0.)).z() ;
-  edm::Handle<reco::TrackCollection> ctfTracks = eventData.originalCtfTracks ;
-  if (!ctfTracks.isValid()) { ctfTracks = eventData.currentCtfTracks ; }
+  double BInTesla = eventSetupData_.magField->inTesla(GlobalPoint(0., 0., 0.)).z();
+  edm::Handle<reco::TrackCollection> ctfTracks = eventData.originalCtfTracks;
+  if (!ctfTracks.isValid()) {
+    ctfTracks = eventData.currentCtfTracks;
+  }
 
   // values of conversionInfo.flag
   // -9999 : Partner track was not found
@@ -732,189 +801,188 @@ void GsfElectronAlgo::createElectron(reco::GsfElectronCollection & electrons, El
   // 1     : Partner track found in the CTF collection using
   // 2     : Partner track found in the GSF collection using
   // 3     : Partner track found in the GSF collection using the electron's GSF track
-  ConversionInfo conversionInfo = egammaTools::getConversionInfo
-   (*electronData.coreRef,ctfTracks,eventData.originalGsfTracks,BInTesla) ;
+  ConversionInfo conversionInfo =
+      egammaTools::getConversionInfo(*electronData.coreRef, ctfTracks, eventData.originalGsfTracks, BInTesla);
 
-  reco::GsfElectron::ConversionRejection conversionVars ;
-  conversionVars.flags = conversionInfo.flag  ;
-  conversionVars.dist = conversionInfo.dist  ;
-  conversionVars.dcot = conversionInfo.dcot  ;
-  conversionVars.radius = conversionInfo.radiusOfConversion  ;
-  if(generalData_.strategyCfg.fillConvVtxFitProb){
+  reco::GsfElectron::ConversionRejection conversionVars;
+  conversionVars.flags = conversionInfo.flag;
+  conversionVars.dist = conversionInfo.dist;
+  conversionVars.dcot = conversionInfo.dcot;
+  conversionVars.radius = conversionInfo.radiusOfConversion;
+  if (generalData_.strategyCfg.fillConvVtxFitProb) {
     //this is an intentionally bugged version which ignores the GsfTrack
-    //this is a bug which was introduced in reduced e/gamma where the GsfTrack gets 
+    //this is a bug which was introduced in reduced e/gamma where the GsfTrack gets
     //relinked to a new collection which means it can no longer match the conversion
     //as it matches based on product/id
     //we keep this defination for the MVAs
-    const auto matchedConv =  ConversionTools::matchedConversion(electronData.coreRef->ctfTrack(),
-								 *eventData.conversions,
-								 eventData.beamspot->position(),
-								 2.0,1e-6,0);
+    const auto matchedConv = ConversionTools::matchedConversion(
+        electronData.coreRef->ctfTrack(), *eventData.conversions, eventData.beamspot->position(), 2.0, 1e-6, 0);
     conversionVars.vtxFitProb = ConversionTools::getVtxFitProb(matchedConv);
   }
-  if ((conversionVars.flags==0)or(conversionVars.flags==1))
-    conversionVars.partner = TrackBaseRef(conversionInfo.conversionPartnerCtfTk)  ;
-  else if ((conversionVars.flags==2)or(conversionVars.flags==3))
-    conversionVars.partner = TrackBaseRef(conversionInfo.conversionPartnerGsfTk)  ;
-
+  if ((conversionVars.flags == 0) or (conversionVars.flags == 1))
+    conversionVars.partner = TrackBaseRef(conversionInfo.conversionPartnerCtfTk);
+  else if ((conversionVars.flags == 2) or (conversionVars.flags == 3))
+    conversionVars.partner = TrackBaseRef(conversionInfo.conversionPartnerGsfTk);
 
   //====================================================
   // Go !
   //====================================================
 
-  electrons.emplace_back( eleCharge,eleChargeInfo,electronData.coreRef,
-       tcMatching, tkExtra, ctfInfo,
-       fiducialFlags,showerShape, full5x5_showerShape,
-       conversionVars, saturationInfo ) ;
-  auto & ele = electrons.back();
+  electrons.emplace_back(eleCharge,
+                         eleChargeInfo,
+                         electronData.coreRef,
+                         tcMatching,
+                         tkExtra,
+                         ctfInfo,
+                         fiducialFlags,
+                         showerShape,
+                         full5x5_showerShape,
+                         conversionVars,
+                         saturationInfo);
+  auto& ele = electrons.back();
   // Will be overwritten later in the case of the regression
-  ele.setCorrectedEcalEnergyError(generalData_.superClusterErrorFunction->getValue(*(ele.superCluster()),0)) ;
-  ele.setP4(GsfElectron::P4_FROM_SUPER_CLUSTER,momentum,0,true) ;
-  
+  ele.setCorrectedEcalEnergyError(generalData_.superClusterErrorFunction->getValue(*(ele.superCluster()), 0));
+  ele.setP4(GsfElectron::P4_FROM_SUPER_CLUSTER, momentum, 0, true);
+
   //====================================================
   // brems fractions
   //====================================================
 
-  if (electronData.innMom.mag()>0.)
-   { ele.setTrackFbrem((electronData.innMom.mag()-electronData.outMom.mag())/electronData.innMom.mag()) ; }
+  if (electronData.innMom.mag() > 0.) {
+    ele.setTrackFbrem((electronData.innMom.mag() - electronData.outMom.mag()) / electronData.innMom.mag());
+  }
 
   // the supercluster is the refined one The seed is not necessarily the first cluster
   // hence the use of the electronCluster
-  SuperClusterRef sc = ele.superCluster() ;
-  if (!(sc.isNull()))
-   {
-    CaloClusterPtr cl = ele.electronCluster() ;
-    if (sc->clustersSize()>1)
-     { 
-       float pf_fbrem =( sc->energy() - cl->energy() ) / sc->energy();
-       ele.setSuperClusterFbrem( pf_fbrem ) ;
-     }
-    else
-      { 
-	ele.setSuperClusterFbrem(0) ; 
-      }
-   }
+  SuperClusterRef sc = ele.superCluster();
+  if (!(sc.isNull())) {
+    CaloClusterPtr cl = ele.electronCluster();
+    if (sc->clustersSize() > 1) {
+      float pf_fbrem = (sc->energy() - cl->energy()) / sc->energy();
+      ele.setSuperClusterFbrem(pf_fbrem);
+    } else {
+      ele.setSuperClusterFbrem(0);
+    }
+  }
 
   //====================================================
   // classification and corrections
   //====================================================
   // classification
-  ElectronClassification theClassifier ;
-  theClassifier.classify(ele) ;
-  theClassifier.refineWithPflow(ele) ;
+  ElectronClassification theClassifier;
+  theClassifier.classify(ele);
+  theClassifier.refineWithPflow(ele);
   // ecal energy
-  ElectronEnergyCorrector theEnCorrector(generalData_.crackCorrectionFunction.get()) ;
-  if (generalData_.strategyCfg.useEcalRegression) // new 
-    { 
-      generalData_.regHelper.applyEcalRegression(ele,
-						   eventData.vertices,
-						   eventData.barrelRecHits,
-						   eventData.endcapRecHits);
-    }
-  else  // original implementation
-    {
-      if( !EcalTools::isHGCalDet((DetId::Detector)region) ) {
-        if (ele.core()->ecalDrivenSeed())
-         {
-          if (generalData_.strategyCfg.ecalDrivenEcalEnergyFromClassBasedParameterization)
-            { theEnCorrector.classBasedParameterizationEnergy(ele,*eventData.beamspot) ; }
-          if (generalData_.strategyCfg.ecalDrivenEcalErrorFromClassBasedParameterization)
-            { theEnCorrector.classBasedParameterizationUncertainty(ele) ; }
-         }
-        else
-         {
-          if (generalData_.strategyCfg.pureTrackerDrivenEcalErrorFromSimpleParameterization)
-            { theEnCorrector.simpleParameterizationUncertainty(ele) ; }
-         }
+  ElectronEnergyCorrector theEnCorrector(generalData_.crackCorrectionFunction.get());
+  if (generalData_.strategyCfg.useEcalRegression)  // new
+  {
+    generalData_.regHelper.applyEcalRegression(
+        ele, eventData.vertices, eventData.barrelRecHits, eventData.endcapRecHits);
+  } else  // original implementation
+  {
+    if (!EcalTools::isHGCalDet((DetId::Detector)region)) {
+      if (ele.core()->ecalDrivenSeed()) {
+        if (generalData_.strategyCfg.ecalDrivenEcalEnergyFromClassBasedParameterization) {
+          theEnCorrector.classBasedParameterizationEnergy(ele, *eventData.beamspot);
+        }
+        if (generalData_.strategyCfg.ecalDrivenEcalErrorFromClassBasedParameterization) {
+          theEnCorrector.classBasedParameterizationUncertainty(ele);
+        }
+      } else {
+        if (generalData_.strategyCfg.pureTrackerDrivenEcalErrorFromSimpleParameterization) {
+          theEnCorrector.simpleParameterizationUncertainty(ele);
+        }
       }
     }
-  
+  }
+
   // momentum
   // Keep the default correction running first. The track momentum error is computed in there
-  if (ele.core()->ecalDrivenSeed())
-    {
-      ElectronMomentumCorrector theMomCorrector;
-      theMomCorrector.correct(ele,electronData.vtxTSOS);
-    }
-  if(generalData_.strategyCfg.useCombinationRegression)  // new 
-    {
-      generalData_.regHelper.applyCombinationRegression(ele);
-    }
+  if (ele.core()->ecalDrivenSeed()) {
+    ElectronMomentumCorrector theMomCorrector;
+    theMomCorrector.correct(ele, electronData.vtxTSOS);
+  }
+  if (generalData_.strategyCfg.useCombinationRegression)  // new
+  {
+    generalData_.regHelper.applyCombinationRegression(ele);
+  }
 
   //====================================================
   // now isolation variables
   //====================================================
 
-  reco::GsfElectron::IsolationVariables dr03, dr04 ;
-  dr03.tkSumPt = tkIsol03Calc_.calIsolPt(*ele.gsfTrack(),*eventData.currentCtfTracks);
-  dr04.tkSumPt = tkIsol04Calc_.calIsolPt(*ele.gsfTrack(),*eventData.currentCtfTracks);
-  dr03.tkSumPtHEEP = tkIsolHEEP03Calc_.calIsolPt(*ele.gsfTrack(),*eventData.currentCtfTracks);
-  dr04.tkSumPtHEEP = tkIsolHEEP04Calc_.calIsolPt(*ele.gsfTrack(),*eventData.currentCtfTracks);
+  reco::GsfElectron::IsolationVariables dr03, dr04;
+  dr03.tkSumPt = tkIsol03Calc_.calIsolPt(*ele.gsfTrack(), *eventData.currentCtfTracks);
+  dr04.tkSumPt = tkIsol04Calc_.calIsolPt(*ele.gsfTrack(), *eventData.currentCtfTracks);
+  dr03.tkSumPtHEEP = tkIsolHEEP03Calc_.calIsolPt(*ele.gsfTrack(), *eventData.currentCtfTracks);
+  dr04.tkSumPtHEEP = tkIsolHEEP04Calc_.calIsolPt(*ele.gsfTrack(), *eventData.currentCtfTracks);
 
-  if( !EcalTools::isHGCalDet((DetId::Detector)region) ) {
-    dr03.hcalDepth1TowerSumEt = eventData.hadDepth1Isolation03.getTowerEtSum(&ele) ;
-    dr03.hcalDepth2TowerSumEt = eventData.hadDepth2Isolation03.getTowerEtSum(&ele) ;
-    dr03.hcalDepth1TowerSumEtBc = eventData.hadDepth1Isolation03Bc.getTowerEtSum(&ele,&(showerShape.hcalTowersBehindClusters)) ;
-    dr03.hcalDepth2TowerSumEtBc = eventData.hadDepth2Isolation03Bc.getTowerEtSum(&ele,&(showerShape.hcalTowersBehindClusters)) ;
+  if (!EcalTools::isHGCalDet((DetId::Detector)region)) {
+    dr03.hcalDepth1TowerSumEt = eventData.hadDepth1Isolation03.getTowerEtSum(&ele);
+    dr03.hcalDepth2TowerSumEt = eventData.hadDepth2Isolation03.getTowerEtSum(&ele);
+    dr03.hcalDepth1TowerSumEtBc =
+        eventData.hadDepth1Isolation03Bc.getTowerEtSum(&ele, &(showerShape.hcalTowersBehindClusters));
+    dr03.hcalDepth2TowerSumEtBc =
+        eventData.hadDepth2Isolation03Bc.getTowerEtSum(&ele, &(showerShape.hcalTowersBehindClusters));
     dr03.ecalRecHitSumEt = eventData.ecalBarrelIsol03.getEtSum(&ele);
-    dr03.ecalRecHitSumEt += eventData.ecalEndcapIsol03.getEtSum(&ele);    
+    dr03.ecalRecHitSumEt += eventData.ecalEndcapIsol03.getEtSum(&ele);
     dr04.hcalDepth1TowerSumEt = eventData.hadDepth1Isolation04.getTowerEtSum(&ele);
     dr04.hcalDepth2TowerSumEt = eventData.hadDepth2Isolation04.getTowerEtSum(&ele);
-    dr04.hcalDepth1TowerSumEtBc = eventData.hadDepth1Isolation04Bc.getTowerEtSum(&ele,&(showerShape.hcalTowersBehindClusters)) ;
-    dr04.hcalDepth2TowerSumEtBc = eventData.hadDepth2Isolation04Bc.getTowerEtSum(&ele,&(showerShape.hcalTowersBehindClusters)) ;
+    dr04.hcalDepth1TowerSumEtBc =
+        eventData.hadDepth1Isolation04Bc.getTowerEtSum(&ele, &(showerShape.hcalTowersBehindClusters));
+    dr04.hcalDepth2TowerSumEtBc =
+        eventData.hadDepth2Isolation04Bc.getTowerEtSum(&ele, &(showerShape.hcalTowersBehindClusters));
     dr04.ecalRecHitSumEt = eventData.ecalBarrelIsol04.getEtSum(&ele);
     dr04.ecalRecHitSumEt += eventData.ecalEndcapIsol04.getEtSum(&ele);
   }
   ele.setIsolation03(dr03);
   ele.setIsolation04(dr04);
 
-
   //====================================================
   // preselection flag
   //====================================================
 
-  setCutBasedPreselectionFlag(ele,*eventData.beamspot) ;
+  setCutBasedPreselectionFlag(ele, *eventData.beamspot);
   //setting mva flag, currently GedGsfElectron and GsfElectron pre-selection flags have desynced
   //this is for GedGsfElectrons, GsfElectrons (ie old pre 7X std reco) resets this later on
   //in the function "addPfInfo"
   //yes this is awful, we'll fix it once we work out how to...
-  float mvaValue = hoc->sElectronMVAEstimator->mva( ele,*(eventData.vertices));
-  ele.setPassMvaPreselection(mvaValue>generalData_.strategyCfg.PreSelectMVA);
+  float mvaValue = hoc->sElectronMVAEstimator->mva(ele, *(eventData.vertices));
+  ele.setPassMvaPreselection(mvaValue > generalData_.strategyCfg.PreSelectMVA);
 
   //====================================================
   // Pixel match variables
   //====================================================
-  setPixelMatchInfomation(ele) ;
+  setPixelMatchInfomation(ele);
 
-  LogTrace("GsfElectronAlgo")<<"Constructed new electron with energy  "<< ele.p4().e() ;
- }
-
+  LogTrace("GsfElectronAlgo") << "Constructed new electron with energy  " << ele.p4().e();
+}
 
 // Pixel match variables
-void GsfElectronAlgo::setPixelMatchInfomation(reco::GsfElectron & ele){
-  int sd1     = 0 ;
-  int sd2     = 0 ;
-  float dPhi1 = 0 ;
-  float dPhi2 = 0 ;
-  float dRz1  = 0 ;
-  float dRz2  = 0 ;
+void GsfElectronAlgo::setPixelMatchInfomation(reco::GsfElectron& ele) {
+  int sd1 = 0;
+  int sd2 = 0;
+  float dPhi1 = 0;
+  float dPhi2 = 0;
+  float dRz1 = 0;
+  float dRz2 = 0;
   edm::RefToBase<TrajectorySeed> seed = ele.gsfTrack()->extra()->seedRef();
   ElectronSeedRef elseed = seed.castTo<ElectronSeedRef>();
-  if(seed.isNull()){}
-  else{
-    if(elseed.isNull()){}
-    else{
-      sd1     = elseed->subDet1() ;
-      sd2     = elseed->subDet2() ;
-      dPhi1 = (ele.charge()>0) ? elseed->dPhi1Pos() : elseed->dPhi1() ;
-      dPhi2 = (ele.charge()>0) ? elseed->dPhi2Pos() : elseed->dPhi2() ;
-      dRz1  = (ele.charge()>0) ? elseed->dRz1Pos () : elseed->dRz1 () ;
-      dRz2  = (ele.charge()>0) ? elseed->dRz2Pos () : elseed->dRz2 () ;
+  if (seed.isNull()) {
+  } else {
+    if (elseed.isNull()) {
+    } else {
+      sd1 = elseed->subDet1();
+      sd2 = elseed->subDet2();
+      dPhi1 = (ele.charge() > 0) ? elseed->dPhi1Pos() : elseed->dPhi1();
+      dPhi2 = (ele.charge() > 0) ? elseed->dPhi2Pos() : elseed->dPhi2();
+      dRz1 = (ele.charge() > 0) ? elseed->dRz1Pos() : elseed->dRz1();
+      dRz2 = (ele.charge() > 0) ? elseed->dRz2Pos() : elseed->dRz2();
     }
   }
-  ele.setPixelMatchSubdetectors(sd1,sd2) ;
-  ele.setPixelMatchDPhi1(dPhi1) ;
-  ele.setPixelMatchDPhi2(dPhi2) ;
-  ele.setPixelMatchDRz1 (dRz1 ) ;
-  ele.setPixelMatchDRz2 (dRz2 ) ;
+  ele.setPixelMatchSubdetectors(sd1, sd2);
+  ele.setPixelMatchDPhi1(dPhi1);
+  ele.setPixelMatchDPhi2(dPhi2);
+  ele.setPixelMatchDRz1(dRz1);
+  ele.setPixelMatchDRz2(dRz2);
 }

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgoHeavyObjectCache.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgoHeavyObjectCache.cc
@@ -4,13 +4,11 @@ namespace gsfAlgoHelpers {
   HeavyObjectCache::HeavyObjectCache(const edm::ParameterSet& conf) {
     // soft electron MVA
     SoftElectronMVAEstimator::Configuration sconfig;
-    sconfig.vweightsfiles = 
-      conf.getParameter<std::vector<std::string> >("SoftElecMVAFilesString");
+    sconfig.vweightsfiles = conf.getParameter<std::vector<std::string> >("SoftElecMVAFilesString");
     sElectronMVAEstimator.reset(new SoftElectronMVAEstimator(sconfig));
     // isolated electron MVA
     ElectronMVAEstimator::Configuration iconfig;
-    iconfig.vweightsfiles  =
-      conf.getParameter<std::vector<std::string> >("ElecMVAFilesString");
-    iElectronMVAEstimator.reset(new ElectronMVAEstimator(iconfig));    
+    iconfig.vweightsfiles = conf.getParameter<std::vector<std::string> >("ElecMVAFilesString");
+    iElectronMVAEstimator.reset(new ElectronMVAEstimator(iconfig));
   }
-}
+}  // namespace gsfAlgoHelpers

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronTools.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronTools.cc
@@ -8,97 +8,94 @@
 
 namespace gsfElectronTools {
 
-  using namespace reco ;
+  using namespace reco;
 
   //=======================================================================================
   // Code from Puneeth Kalavase
   //=======================================================================================
 
-  std::pair<TrackRef,float> getClosestCtfToGsf( GsfTrackRef const& gsfTrackRef,
-                                                edm::Handle<reco::TrackCollection> const& ctfTracksH )
-  {
+  std::pair<TrackRef, float> getClosestCtfToGsf(GsfTrackRef const& gsfTrackRef,
+                                                edm::Handle<reco::TrackCollection> const& ctfTracksH) {
     float maxFracShared = 0;
-    TrackRef ctfTrackRef = TrackRef() ;
-    const TrackCollection * ctfTrackCollection = ctfTracksH.product() ;
+    TrackRef ctfTrackRef = TrackRef();
+    const TrackCollection* ctfTrackCollection = ctfTracksH.product();
 
     // get the Hit Pattern for the gsfTrack
     const HitPattern& gsfHitPattern = gsfTrackRef->hitPattern();
 
     unsigned int counter = 0;
-    for (auto  ctfTkIter = ctfTrackCollection->begin();
-          ctfTkIter != ctfTrackCollection->end() ; ctfTkIter++, counter++ )
-     {
-
+    for (auto ctfTkIter = ctfTrackCollection->begin(); ctfTkIter != ctfTrackCollection->end(); ctfTkIter++, counter++) {
       double dEta = gsfTrackRef->eta() - ctfTkIter->eta();
       double dPhi = gsfTrackRef->phi() - ctfTkIter->phi();
       double pi = acos(-1.);
-      if(std::abs(dPhi) > pi) dPhi = 2*pi - std::abs(dPhi);
+      if (std::abs(dPhi) > pi)
+        dPhi = 2 * pi - std::abs(dPhi);
 
       // dont want to look at every single track in the event!
-      if(sqrt(dEta*dEta + dPhi*dPhi) > 0.3) continue;
+      if (sqrt(dEta * dEta + dPhi * dPhi) > 0.3)
+        continue;
 
-      unsigned int shared = 0 ;
-      int gsfHitCounter = 0 ;
-      int numGsfInnerHits = 0 ;
-      int numCtfInnerHits = 0 ;
+      unsigned int shared = 0;
+      int gsfHitCounter = 0;
+      int numGsfInnerHits = 0;
+      int numCtfInnerHits = 0;
       // get the CTF Track Hit Pattern
       const HitPattern& ctfHitPattern = ctfTkIter->hitPattern();
 
-      for ( auto elHitsIt = gsfTrackRef->recHitsBegin() ;
-            elHitsIt != gsfTrackRef->recHitsEnd() ;
-            elHitsIt++, gsfHitCounter++ )
-       {
-        if(!((**elHitsIt).isValid()))  //count only valid Hits
-         { continue ; }
+      for (auto elHitsIt = gsfTrackRef->recHitsBegin(); elHitsIt != gsfTrackRef->recHitsEnd();
+           elHitsIt++, gsfHitCounter++) {
+        if (!((**elHitsIt).isValid()))  //count only valid Hits
+        {
+          continue;
+        }
 
         // look only in the pixels/TIB/TID
         uint32_t gsfHit = gsfHitPattern.getHitPattern(HitPattern::TRACK_HITS, gsfHitCounter);
-        if (!(HitPattern::pixelHitFilter(gsfHit) ||
-            HitPattern::stripTIBHitFilter(gsfHit) ||
-            HitPattern::stripTIDHitFilter(gsfHit)))
-         { continue ; }
+        if (!(HitPattern::pixelHitFilter(gsfHit) || HitPattern::stripTIBHitFilter(gsfHit) ||
+              HitPattern::stripTIDHitFilter(gsfHit))) {
+          continue;
+        }
 
-        numGsfInnerHits++ ;
+        numGsfInnerHits++;
 
-        int ctfHitsCounter = 0 ;
-        numCtfInnerHits = 0 ;
-        for ( auto ctfHitsIt = ctfTkIter->recHitsBegin() ;
-              ctfHitsIt != ctfTkIter->recHitsEnd() ;
-              ctfHitsIt++, ctfHitsCounter++ )
-         {
-          if(!((**ctfHitsIt).isValid())) //count only valid Hits!
-           { continue ; }
+        int ctfHitsCounter = 0;
+        numCtfInnerHits = 0;
+        for (auto ctfHitsIt = ctfTkIter->recHitsBegin(); ctfHitsIt != ctfTkIter->recHitsEnd();
+             ctfHitsIt++, ctfHitsCounter++) {
+          if (!((**ctfHitsIt).isValid()))  //count only valid Hits!
+          {
+            continue;
+          }
 
-        uint32_t ctfHit = ctfHitPattern.getHitPattern(HitPattern::TRACK_HITS, ctfHitsCounter);
-        if(!(HitPattern::pixelHitFilter(ctfHit) ||
-              HitPattern::stripTIBHitFilter(ctfHit) ||
-              HitPattern::stripTIDHitFilter(ctfHit)))
-         { continue ; }
+          uint32_t ctfHit = ctfHitPattern.getHitPattern(HitPattern::TRACK_HITS, ctfHitsCounter);
+          if (!(HitPattern::pixelHitFilter(ctfHit) || HitPattern::stripTIBHitFilter(ctfHit) ||
+                HitPattern::stripTIDHitFilter(ctfHit))) {
+            continue;
+          }
 
-        numCtfInnerHits++ ;
+          numCtfInnerHits++;
 
-          if( (**elHitsIt).sharesInput(&(**ctfHitsIt),TrackingRecHit::all) )
-           {
-            shared++ ;
-            break ;
-           }
+          if ((**elHitsIt).sharesInput(&(**ctfHitsIt), TrackingRecHit::all)) {
+            shared++;
+            break;
+          }
 
-         } //ctfHits iterator
+        }  //ctfHits iterator
 
-       } //gsfHits iterator
+      }  //gsfHits iterator
 
-      if ((numGsfInnerHits==0)||(numCtfInnerHits==0))
-       { continue ; }
+      if ((numGsfInnerHits == 0) || (numCtfInnerHits == 0)) {
+        continue;
+      }
 
-      if ( static_cast<float>(shared)/std::min(numGsfInnerHits,numCtfInnerHits) > maxFracShared )
-       {
-        maxFracShared = static_cast<float>(shared)/std::min(numGsfInnerHits, numCtfInnerHits);
-        ctfTrackRef = TrackRef(ctfTracksH,counter);
-       }
+      if (static_cast<float>(shared) / std::min(numGsfInnerHits, numCtfInnerHits) > maxFracShared) {
+        maxFracShared = static_cast<float>(shared) / std::min(numGsfInnerHits, numCtfInnerHits);
+        ctfTrackRef = TrackRef(ctfTracksH, counter);
+      }
 
-     } //ctfTrack iterator
+    }  //ctfTrack iterator
 
-    return make_pair(ctfTrackRef,maxFracShared) ;
+    return make_pair(ctfTrackRef, maxFracShared);
   }
 
-}
+}  // namespace gsfElectronTools

--- a/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
@@ -13,111 +13,115 @@
 #include <typeinfo>
 #include <bitset>
 
-using namespace reco ;
-using namespace std ;
+using namespace reco;
+using namespace std;
 
-PixelHitMatcher::PixelHitMatcher
- ( float phi1min, float phi1max,
-   float phi2minB, float phi2maxB, float phi2minF, float phi2maxF,
-   float z2minB, float z2maxB, float r2minF, float r2maxF,
-   float rMinI, float rMaxI, bool searchInTIDTEC)
- : //zmin1 and zmax1 are dummy at this moment, set from beamspot later
-   meas1stBLayer(phi1min,phi1max,0.,0.), meas2ndBLayer(phi2minB,phi2maxB,z2minB,z2maxB),
-   meas1stFLayer(phi1min,phi1max,0.,0.), meas2ndFLayer(phi2minF,phi2maxF,r2minF,r2maxF),
-   prop1stLayer(nullptr), prop2ndLayer(nullptr),theGeometricSearchTracker(nullptr),theTrackerEvent(nullptr),theTracker(nullptr),vertex_(0.),
-   searchInTIDTEC_(searchInTIDTEC), useRecoVertex_(false)
- {
-  meas1stFLayer.setRRangeI(rMinI,rMaxI) ;
-  meas2ndFLayer.setRRangeI(rMinI,rMaxI) ;
- }
+PixelHitMatcher::PixelHitMatcher(float phi1min,
+                                 float phi1max,
+                                 float phi2minB,
+                                 float phi2maxB,
+                                 float phi2minF,
+                                 float phi2maxF,
+                                 float z2minB,
+                                 float z2maxB,
+                                 float r2minF,
+                                 float r2maxF,
+                                 float rMinI,
+                                 float rMaxI,
+                                 bool searchInTIDTEC)
+    :  //zmin1 and zmax1 are dummy at this moment, set from beamspot later
+      meas1stBLayer(phi1min, phi1max, 0., 0.),
+      meas2ndBLayer(phi2minB, phi2maxB, z2minB, z2maxB),
+      meas1stFLayer(phi1min, phi1max, 0., 0.),
+      meas2ndFLayer(phi2minF, phi2maxF, r2minF, r2maxF),
+      prop1stLayer(nullptr),
+      prop2ndLayer(nullptr),
+      theGeometricSearchTracker(nullptr),
+      theTrackerEvent(nullptr),
+      theTracker(nullptr),
+      vertex_(0.),
+      searchInTIDTEC_(searchInTIDTEC),
+      useRecoVertex_(false) {
+  meas1stFLayer.setRRangeI(rMinI, rMaxI);
+  meas2ndFLayer.setRRangeI(rMinI, rMaxI);
+}
 
-PixelHitMatcher::~PixelHitMatcher()
- {
-  delete prop1stLayer ;
-  delete prop2ndLayer ;
- }
+PixelHitMatcher::~PixelHitMatcher() {
+  delete prop1stLayer;
+  delete prop2ndLayer;
+}
 
-void PixelHitMatcher::set1stLayer( float dummyphi1min, float dummyphi1max )
- {
-  meas1stBLayer.setPhiRange(dummyphi1min,dummyphi1max) ;
-  meas1stFLayer.setPhiRange(dummyphi1min,dummyphi1max) ;
- }
+void PixelHitMatcher::set1stLayer(float dummyphi1min, float dummyphi1max) {
+  meas1stBLayer.setPhiRange(dummyphi1min, dummyphi1max);
+  meas1stFLayer.setPhiRange(dummyphi1min, dummyphi1max);
+}
 
-void PixelHitMatcher::set1stLayerZRange( float zmin1, float zmax1 )
- {
-  meas1stBLayer.setZRange(zmin1,zmax1) ;
-  meas1stFLayer.setRRange(zmin1,zmax1) ;
- }
+void PixelHitMatcher::set1stLayerZRange(float zmin1, float zmax1) {
+  meas1stBLayer.setZRange(zmin1, zmax1);
+  meas1stFLayer.setRRange(zmin1, zmax1);
+}
 
-void PixelHitMatcher::set2ndLayer( float dummyphi2minB, float dummyphi2maxB, float dummyphi2minF, float dummyphi2maxF )
- {
-  meas2ndBLayer.setPhiRange(dummyphi2minB,dummyphi2maxB) ;
-  meas2ndFLayer.setPhiRange(dummyphi2minF,dummyphi2maxF) ;
- }
+void PixelHitMatcher::set2ndLayer(float dummyphi2minB, float dummyphi2maxB, float dummyphi2minF, float dummyphi2maxF) {
+  meas2ndBLayer.setPhiRange(dummyphi2minB, dummyphi2maxB);
+  meas2ndFLayer.setPhiRange(dummyphi2minF, dummyphi2maxF);
+}
 
-void PixelHitMatcher::setUseRecoVertex( bool val )
- { useRecoVertex_ = val ; }
+void PixelHitMatcher::setUseRecoVertex(bool val) { useRecoVertex_ = val; }
 
-void PixelHitMatcher::setEvent( const MeasurementTrackerEvent & trackerData ) 
- {
-    theTrackerEvent = & trackerData;
-    theLayerMeasurements = LayerMeasurements(*theTracker,*theTrackerEvent);
- }
-void PixelHitMatcher::setES
- ( const MagneticField * magField,
-   const MeasurementTracker * theMeasurementTracker,
-   const TrackerGeometry * trackerGeometry )
- {
-  if (theMeasurementTracker)
-   {
+void PixelHitMatcher::setEvent(const MeasurementTrackerEvent &trackerData) {
+  theTrackerEvent = &trackerData;
+  theLayerMeasurements = LayerMeasurements(*theTracker, *theTrackerEvent);
+}
+void PixelHitMatcher::setES(const MagneticField *magField,
+                            const MeasurementTracker *theMeasurementTracker,
+                            const TrackerGeometry *trackerGeometry) {
+  if (theMeasurementTracker) {
     theTracker = theMeasurementTracker;
-    theGeometricSearchTracker=theMeasurementTracker->geometricSearchTracker() ;
-   }
+    theGeometricSearchTracker = theMeasurementTracker->geometricSearchTracker();
+  }
 
-  theMagField = magField ;
-  theTrackerGeometry = trackerGeometry ;
-  float mass=.000511 ; // electron propagation
-  if (prop1stLayer) delete prop1stLayer ;
-  prop1stLayer = new PropagatorWithMaterial(oppositeToMomentum,mass,theMagField) ;
-  if (prop2ndLayer) delete prop2ndLayer ;
-  prop2ndLayer = new PropagatorWithMaterial(alongMomentum,mass,theMagField) ;
- }
+  theMagField = magField;
+  theTrackerGeometry = trackerGeometry;
+  float mass = .000511;  // electron propagation
+  if (prop1stLayer)
+    delete prop1stLayer;
+  prop1stLayer = new PropagatorWithMaterial(oppositeToMomentum, mass, theMagField);
+  if (prop2ndLayer)
+    delete prop2ndLayer;
+  prop2ndLayer = new PropagatorWithMaterial(alongMomentum, mass, theMagField);
+}
 
-vector<CLHEP::Hep3Vector> PixelHitMatcher::predicted1Hits()
- { return pred1Meas ; }
+vector<CLHEP::Hep3Vector> PixelHitMatcher::predicted1Hits() { return pred1Meas; }
 
-vector<CLHEP::Hep3Vector> PixelHitMatcher::predicted2Hits()
- { return pred2Meas ; }
+vector<CLHEP::Hep3Vector> PixelHitMatcher::predicted2Hits() { return pred2Meas; }
 
-float PixelHitMatcher::getVertex()
- { return vertex_ ; }
+float PixelHitMatcher::getVertex() { return vertex_; }
 
+std::vector<SeedWithInfo> PixelHitMatcher::compatibleSeeds(const std::vector<const TrajectorySeedCollection *> &seedsV,
+                                                           const GlobalPoint &xmeas,
+                                                           const GlobalPoint &vprim,
+                                                           float energy,
+                                                           float fcharge) {
+  typedef std::unordered_map<const GeomDet *, TrajectoryStateOnSurface> DetTsosAssoc;
+  typedef std::unordered_map<std::pair<const GeomDet *, GlobalPoint>, TrajectoryStateOnSurface> PosTsosAssoc;
+  const int charge = int(fcharge);
 
-std::vector<SeedWithInfo>
-PixelHitMatcher::compatibleSeeds
-( const std::vector<const TrajectorySeedCollection *>& seedsV, const GlobalPoint & xmeas,
-   const GlobalPoint & vprim, float energy, float fcharge )
- {
-   typedef std::unordered_map<const GeomDet *, TrajectoryStateOnSurface> DetTsosAssoc;
-   typedef std::unordered_map<std::pair<const GeomDet*,GlobalPoint>, TrajectoryStateOnSurface> PosTsosAssoc;
-   const int charge = int(fcharge) ;
+  // auto xmeas_phi = xmeas.barePhi();
+  auto xmeas_r = xmeas.perp();
 
-   // auto xmeas_phi = xmeas.barePhi();
-   auto xmeas_r = xmeas.perp();
-   
-   const float phicut = std::cos(2.5);
-
+  const float phicut = std::cos(2.5);
 
   FreeTrajectoryState fts = FTSFromVertexToPointFactory::get(*theMagField, xmeas, vprim, energy, charge);
   PerpendicularBoundPlaneBuilder bpb;
   TrajectoryStateOnSurface tsos(fts, *bpb(fts.position(), fts.momentum()));
-  
-  std::vector<SeedWithInfo> result ;
-  unsigned int allSeedsSize = 0;
-  for (auto const sc : seedsV) allSeedsSize += sc->size();
 
-  mapTsos2_fast_.clear();  
-  mapTsos2_fast_.reserve(allSeedsSize) ;
+  std::vector<SeedWithInfo> result;
+  unsigned int allSeedsSize = 0;
+  for (auto const sc : seedsV)
+    allSeedsSize += sc->size();
+
+  mapTsos2_fast_.clear();
+  mapTsos2_fast_.reserve(allSeedsSize);
 
   // std::vector<TrajectoryStateOnSurface> vTsos(theTrackerGeometry->dets().size());
   // TrajectoryStateOnSurface vTsos[theTrackerGeometry->dets().size()];
@@ -125,59 +129,65 @@ PixelHitMatcher::compatibleSeeds
   auto ndets = theTrackerGeometry->dets().size();
 
   int iTsos[ndets];
-  for ( auto & i : iTsos) i=-1;
-  std::vector<TrajectoryStateOnSurface> vTsos; vTsos.reserve(allSeedsSize);
+  for (auto &i : iTsos)
+    i = -1;
+  std::vector<TrajectoryStateOnSurface> vTsos;
+  vTsos.reserve(allSeedsSize);
 
   for (const auto seeds : seedsV) {
-    for(const auto& seed : *seeds) {
+    for (const auto &seed : *seeds) {
       hit_gp_map_.clear();
-      if( seed.nHits() > 9 ) {
-        edm::LogWarning("GsfElectronAlgo|UnexpectedSeed") <<"We cannot deal with seeds having more than 9 hits." ;
+      if (seed.nHits() > 9) {
+        edm::LogWarning("GsfElectronAlgo|UnexpectedSeed") << "We cannot deal with seeds having more than 9 hits.";
         continue;
       }
-      
-      const TrajectorySeed::range& hits = seed.recHits();
+
+      const TrajectorySeed::range &hits = seed.recHits();
       // cache the global points
-      
-      for( auto it = hits.first; it != hits.second; ++it ) {
-        hit_gp_map_.emplace_back(it->globalPosition());      
+
+      for (auto it = hits.first; it != hits.second; ++it) {
+        hit_gp_map_.emplace_back(it->globalPosition());
       }
-      
-      //iterate on the hits 
-      auto he =  hits.second -1;   
-      for( auto it1 = hits.first; it1 < he; ++it1 ) {
-        if( !it1->isValid() ) continue;
-        auto  idx1 = std::distance(hits.first,it1);
+
+      //iterate on the hits
+      auto he = hits.second - 1;
+      for (auto it1 = hits.first; it1 < he; ++it1) {
+        if (!it1->isValid())
+          continue;
+        auto idx1 = std::distance(hits.first, it1);
         const DetId id1 = it1->geographicalId();
         const GeomDet *geomdet1 = it1->det();
-        
+
         auto ix1 = geomdet1->gdetIndex();
-        
+
         /*  VI: this generates regression (other cut is just in phi). in my opinion it is safe and makes sense
             auto away = geomdet1->position().basicVector().dot(xmeas.basicVector()) <0;
             if (away) continue;
         */
-        
-        const GlobalPoint& hit1Pos = hit_gp_map_[idx1];
-        auto dt = hit1Pos.x()*xmeas.x()+hit1Pos.y()*xmeas.y();
-        if (dt<0) continue;
-        if (dt<phicut*(xmeas_r*hit1Pos.perp())) continue;
-        
-        if(iTsos[ix1]<0)   {
+
+        const GlobalPoint &hit1Pos = hit_gp_map_[idx1];
+        auto dt = hit1Pos.x() * xmeas.x() + hit1Pos.y() * xmeas.y();
+        if (dt < 0)
+          continue;
+        if (dt < phicut * (xmeas_r * hit1Pos.perp()))
+          continue;
+
+        if (iTsos[ix1] < 0) {
           iTsos[ix1] = vTsos.size();
-          vTsos.push_back(prop1stLayer->propagate(tsos,geomdet1->surface()));
+          vTsos.push_back(prop1stLayer->propagate(tsos, geomdet1->surface()));
         }
         auto tsos1 = &vTsos[iTsos[ix1]];
-        
-        if( !tsos1->isValid() ) continue;
-        std::pair<bool, double> est = ( id1.subdetId() % 2 ? 
-                                        meas1stBLayer.estimate(vprim, *tsos1, hit1Pos) :
-                                        meas1stFLayer.estimate(vprim, *tsos1, hit1Pos)  );
-        if( !est.first ) continue;
-        EleRelPointPair pp1(hit1Pos,tsos1->globalParameters().position(),vprim);
-        const math::XYZPoint relHit1Pos(hit1Pos-vprim), relTSOSPos(tsos1->globalParameters().position() - vprim);
+
+        if (!tsos1->isValid())
+          continue;
+        std::pair<bool, double> est = (id1.subdetId() % 2 ? meas1stBLayer.estimate(vprim, *tsos1, hit1Pos)
+                                                          : meas1stFLayer.estimate(vprim, *tsos1, hit1Pos));
+        if (!est.first)
+          continue;
+        EleRelPointPair pp1(hit1Pos, tsos1->globalParameters().position(), vprim);
+        const math::XYZPoint relHit1Pos(hit1Pos - vprim), relTSOSPos(tsos1->globalParameters().position() - vprim);
         const int subDet1 = id1.subdetId();
-        const float dRz1 = ( id1.subdetId()%2 ? pp1.dZ() : pp1.dPerp() );
+        const float dRz1 = (id1.subdetId() % 2 ? pp1.dZ() : pp1.dPerp());
         const float dPhi1 = pp1.dPhi();
         // setup our vertex
         double zVertex;
@@ -187,65 +197,64 @@ PixelHitMatcher::compatibleSeeds
           const double pxHit1z = hit1Pos.z();
           const double pxHit1x = hit1Pos.x();
           const double pxHit1y = hit1Pos.y();
-          const double r1diff = std::sqrt( (pxHit1x-vprim.x())*(pxHit1x-vprim.x()) + 
-                                           (pxHit1y-vprim.y())*(pxHit1y-vprim.y())   );
-          const double r2diff = std::sqrt( (xmeas.x()-pxHit1x)*(xmeas.x()-pxHit1x) + 
-                                           (xmeas.y()-pxHit1y)*(xmeas.y()-pxHit1y)   );
-          zVertex = pxHit1z - r1diff*(xmeas.z()-pxHit1z)/r2diff;
-        } else { 
+          const double r1diff =
+              std::sqrt((pxHit1x - vprim.x()) * (pxHit1x - vprim.x()) + (pxHit1y - vprim.y()) * (pxHit1y - vprim.y()));
+          const double r2diff =
+              std::sqrt((xmeas.x() - pxHit1x) * (xmeas.x() - pxHit1x) + (xmeas.y() - pxHit1y) * (xmeas.y() - pxHit1y));
+          zVertex = pxHit1z - r1diff * (xmeas.z() - pxHit1z) / r2diff;
+        } else {
           // here use rather the reco vertex z position
-          zVertex = vprim.z(); 
+          zVertex = vprim.z();
         }
-        GlobalPoint vertex(vprim.x(),vprim.y(),zVertex);
-        FreeTrajectoryState fts2 = FTSFromVertexToPointFactory::get(*theMagField, hit1Pos, vertex, energy, charge) ;
+        GlobalPoint vertex(vprim.x(), vprim.y(), zVertex);
+        FreeTrajectoryState fts2 = FTSFromVertexToPointFactory::get(*theMagField, hit1Pos, vertex, energy, charge);
         // now find the matching hit
-        for( auto it2 = it1+1; it2 != hits.second; ++it2 ) {
-          if( !it2->isValid() ) continue;
-          auto idx2 = std::distance(hits.first,it2);
+        for (auto it2 = it1 + 1; it2 != hits.second; ++it2) {
+          if (!it2->isValid())
+            continue;
+          auto idx2 = std::distance(hits.first, it2);
           const DetId id2 = it2->geographicalId();
           const GeomDet *geomdet2 = it2->det();
-          const std::pair<const GeomDet *,GlobalPoint> det_key(geomdet2,hit1Pos);	
-          const TrajectoryStateOnSurface* tsos2;
+          const std::pair<const GeomDet *, GlobalPoint> det_key(geomdet2, hit1Pos);
+          const TrajectoryStateOnSurface *tsos2;
           auto tsos2_itr = mapTsos2_fast_.find(det_key);
-          if( tsos2_itr != mapTsos2_fast_.end() ) {
+          if (tsos2_itr != mapTsos2_fast_.end()) {
             tsos2 = &(tsos2_itr->second);
           } else {
-            auto empl_result =
-              mapTsos2_fast_.emplace(det_key,prop2ndLayer->propagate(fts2,geomdet2->surface()));
+            auto empl_result = mapTsos2_fast_.emplace(det_key, prop2ndLayer->propagate(fts2, geomdet2->surface()));
             tsos2 = &(empl_result.first->second);
           }
-          if( !tsos2->isValid() ) continue;
-          const GlobalPoint& hit2Pos = hit_gp_map_[idx2];
-          std::pair<bool,double> est2  = ( id2.subdetId()%2 ? 
-                                           meas2ndBLayer.estimate(vertex, *tsos2,hit2Pos) :
-                                           meas2ndFLayer.estimate(vertex, *tsos2,hit2Pos)   );
+          if (!tsos2->isValid())
+            continue;
+          const GlobalPoint &hit2Pos = hit_gp_map_[idx2];
+          std::pair<bool, double> est2 = (id2.subdetId() % 2 ? meas2ndBLayer.estimate(vertex, *tsos2, hit2Pos)
+                                                             : meas2ndFLayer.estimate(vertex, *tsos2, hit2Pos));
           if (est2.first) {
-            EleRelPointPair pp2(hit2Pos,tsos2->globalParameters().position(),vertex) ;
+            EleRelPointPair pp2(hit2Pos, tsos2->globalParameters().position(), vertex);
             const int subDet2 = id2.subdetId();
-            const float dRz2 = (subDet2%2==1)?pp2.dZ():pp2.dPerp();
+            const float dRz2 = (subDet2 % 2 == 1) ? pp2.dZ() : pp2.dPerp();
             const float dPhi2 = pp2.dPhi();
-            const unsigned char hitsMask = (1<<idx1)|(1<<idx2);
-            result.push_back(SeedWithInfo(seed,hitsMask,subDet2,dRz2,dPhi2,subDet1,dRz1,dPhi1)) ;
+            const unsigned char hitsMask = (1 << idx1) | (1 << idx2);
+            result.push_back(SeedWithInfo(seed, hitsMask, subDet2, dRz2, dPhi2, subDet1, dRz1, dPhi1));
           }
-        }// inner loop on hits
-      }// outer loop on hits
-    }// loop on seeds  
-  }//loop on vector of seeds
-  mapTsos2_fast_.clear() ;
- 
-  return result ;
- }
+        }  // inner loop on hits
+      }    // outer loop on hits
+    }      // loop on seeds
+  }        //loop on vector of seeds
+  mapTsos2_fast_.clear();
+
+  return result;
+}
 
 //========================= OBSOLETE ? =========================
 
-vector< pair< RecHitWithDist, PixelHitMatcher::ConstRecHitPointer > >
-PixelHitMatcher::compatibleHits
- ( const GlobalPoint & xmeas,
-   const GlobalPoint & vprim,
-   float energy, float fcharge,
-   const TrackerTopology *tTopo,
-   const NavigationSchool& navigationSchool)
- {
+vector<pair<RecHitWithDist, PixelHitMatcher::ConstRecHitPointer> > PixelHitMatcher::compatibleHits(
+    const GlobalPoint &xmeas,
+    const GlobalPoint &vprim,
+    float energy,
+    float fcharge,
+    const TrackerTopology *tTopo,
+    const NavigationSchool &navigationSchool) {
   float SCl_phi = xmeas.phi();
 
   int charge = int(fcharge);
@@ -261,193 +270,198 @@ PixelHitMatcher::compatibleHits
   pred1Meas.clear();
   pred2Meas.clear();
 
-  auto firstLayer = theGeometricSearchTracker->pixelBarrelLayers().begin(); 
+  auto firstLayer = theGeometricSearchTracker->pixelBarrelLayers().begin();
 
-  FreeTrajectoryState fts = FTSFromVertexToPointFactory::get(*theMagField,xmeas, vprim, energy, charge);
+  FreeTrajectoryState fts = FTSFromVertexToPointFactory::get(*theMagField, xmeas, vprim, energy, charge);
 
   PerpendicularBoundPlaneBuilder bpb;
   TrajectoryStateOnSurface tsos(fts, *bpb(fts.position(), fts.momentum()));
 
   if (tsos.isValid()) {
     vector<TrajectoryMeasurement> pixelMeasurements =
-      theLayerMeasurements.measurements(**firstLayer,tsos,
-					 *prop1stLayer, meas1stBLayer);
+        theLayerMeasurements.measurements(**firstLayer, tsos, *prop1stLayer, meas1stBLayer);
 
-    LogDebug("") <<"[PixelHitMatcher::compatibleHits] nbr of hits compatible with extrapolation to first layer: " << pixelMeasurements.size();
-    for (aMeas m=pixelMeasurements.begin(); m!=pixelMeasurements.end(); m++){
-     if (m->recHit()->isValid()) {
-       float localDphi = normalizedPhi(SCl_phi-m->forwardPredictedState().globalPosition().barePhi()) ;
-       if(std::abs(localDphi)>2.5)continue;
-	CLHEP::Hep3Vector prediction(m->forwardPredictedState().globalPosition().x(),
-			      m->forwardPredictedState().globalPosition().y(),
-			      m->forwardPredictedState().globalPosition().z());
-	LogDebug("") << "[PixelHitMatcher::compatibleHits] compatible hit position " << m->recHit()->globalPosition();
-	LogDebug("") << "[PixelHitMatcher::compatibleHits] predicted position " << m->forwardPredictedState().globalPosition();
-	pred1Meas.push_back( prediction);
+    LogDebug("") << "[PixelHitMatcher::compatibleHits] nbr of hits compatible with extrapolation to first layer: "
+                 << pixelMeasurements.size();
+    for (aMeas m = pixelMeasurements.begin(); m != pixelMeasurements.end(); m++) {
+      if (m->recHit()->isValid()) {
+        float localDphi = normalizedPhi(SCl_phi - m->forwardPredictedState().globalPosition().barePhi());
+        if (std::abs(localDphi) > 2.5)
+          continue;
+        CLHEP::Hep3Vector prediction(m->forwardPredictedState().globalPosition().x(),
+                                     m->forwardPredictedState().globalPosition().y(),
+                                     m->forwardPredictedState().globalPosition().z());
+        LogDebug("") << "[PixelHitMatcher::compatibleHits] compatible hit position " << m->recHit()->globalPosition();
+        LogDebug("") << "[PixelHitMatcher::compatibleHits] predicted position "
+                     << m->forwardPredictedState().globalPosition();
+        pred1Meas.push_back(prediction);
 
-	validMeasurements.push_back(*m);
+        validMeasurements.push_back(*m);
 
-	LogDebug("") <<"[PixelHitMatcher::compatibleHits] Found a rechit in layer ";
-	const BarrelDetLayer *bdetl = dynamic_cast<const BarrelDetLayer *>(*firstLayer);
-	if (bdetl) {
-	  LogDebug("") <<" with radius "<<bdetl->specificSurface().radius();
-	}
-	else  LogDebug("") <<"Could not downcast!!";
-     }
+        LogDebug("") << "[PixelHitMatcher::compatibleHits] Found a rechit in layer ";
+        const BarrelDetLayer *bdetl = dynamic_cast<const BarrelDetLayer *>(*firstLayer);
+        if (bdetl) {
+          LogDebug("") << " with radius " << bdetl->specificSurface().radius();
+        } else
+          LogDebug("") << "Could not downcast!!";
+      }
     }
-
 
     // check if there are compatible 1st hits in the second layer
     firstLayer++;
 
     vector<TrajectoryMeasurement> pixel2Measurements =
-      theLayerMeasurements.measurements(**firstLayer,tsos,
-					 *prop1stLayer, meas1stBLayer);
+        theLayerMeasurements.measurements(**firstLayer, tsos, *prop1stLayer, meas1stBLayer);
 
-    for (aMeas m=pixel2Measurements.begin(); m!=pixel2Measurements.end(); m++){
+    for (aMeas m = pixel2Measurements.begin(); m != pixel2Measurements.end(); m++) {
       if (m->recHit()->isValid()) {
-	float localDphi = normalizedPhi(SCl_phi-m->forwardPredictedState().globalPosition().barePhi()) ;
-	if(std::abs(localDphi)>2.5)continue;
+        float localDphi = normalizedPhi(SCl_phi - m->forwardPredictedState().globalPosition().barePhi());
+        if (std::abs(localDphi) > 2.5)
+          continue;
         CLHEP::Hep3Vector prediction(m->forwardPredictedState().globalPosition().x(),
-			      m->forwardPredictedState().globalPosition().y(),
-			      m->forwardPredictedState().globalPosition().z());
-	pred1Meas.push_back( prediction);
-        LogDebug("")  << "[PixelHitMatcher::compatibleHits] compatible hit position " << m->recHit()->globalPosition() << endl;
-        LogDebug("") << "[PixelHitMatcher::compatibleHits] predicted position " << m->forwardPredictedState().globalPosition() << endl;
+                                     m->forwardPredictedState().globalPosition().y(),
+                                     m->forwardPredictedState().globalPosition().z());
+        pred1Meas.push_back(prediction);
+        LogDebug("") << "[PixelHitMatcher::compatibleHits] compatible hit position " << m->recHit()->globalPosition()
+                     << endl;
+        LogDebug("") << "[PixelHitMatcher::compatibleHits] predicted position "
+                     << m->forwardPredictedState().globalPosition() << endl;
 
-	validMeasurements.push_back(*m);
-	LogDebug("") <<"[PixelHitMatcher::compatibleHits] Found a rechit in layer ";
-	const BarrelDetLayer *bdetl = dynamic_cast<const BarrelDetLayer *>(*firstLayer);
-	if (bdetl) {
-	  LogDebug("") <<" with radius "<<bdetl->specificSurface().radius();
-	}
-	else  LogDebug("") <<"Could not downcast!!";
+        validMeasurements.push_back(*m);
+        LogDebug("") << "[PixelHitMatcher::compatibleHits] Found a rechit in layer ";
+        const BarrelDetLayer *bdetl = dynamic_cast<const BarrelDetLayer *>(*firstLayer);
+        if (bdetl) {
+          LogDebug("") << " with radius " << bdetl->specificSurface().radius();
+        } else
+          LogDebug("") << "Could not downcast!!";
       }
-
     }
   }
-
 
   // check if there are compatible 1st hits the forward disks
 
   TrajectoryStateOnSurface tsosfwd(fts, *bpb(fts.position(), fts.momentum()));
   if (tsosfwd.isValid()) {
-
-    for (int i=0; i<2; i++) {
+    for (int i = 0; i < 2; i++) {
       auto flayer = i == 0 ? theGeometricSearchTracker->posPixelForwardLayers().begin()
                            : theGeometricSearchTracker->negPixelForwardLayers().begin();
 
-      if (i==0 && xmeas.z() < -100. ) continue;
-      if (i==1 && xmeas.z() > 100. ) continue;
+      if (i == 0 && xmeas.z() < -100.)
+        continue;
+      if (i == 1 && xmeas.z() > 100.)
+        continue;
 
       vector<TrajectoryMeasurement> pixelMeasurements =
-	theLayerMeasurements.measurements(**flayer, tsosfwd,
-					   *prop1stLayer, meas1stFLayer);
+          theLayerMeasurements.measurements(**flayer, tsosfwd, *prop1stLayer, meas1stFLayer);
 
-      for (aMeas m=pixelMeasurements.begin(); m!=pixelMeasurements.end(); m++){
-	if (m->recHit()->isValid()) {
-	  float localDphi = normalizedPhi(SCl_phi-m->forwardPredictedState().globalPosition().barePhi());
-	  if(std::abs(localDphi)>2.5)continue;
-	  CLHEP::Hep3Vector prediction(m->forwardPredictedState().globalPosition().x(),
-				m->forwardPredictedState().globalPosition().y(),
-				m->forwardPredictedState().globalPosition().z());
-	  pred1Meas.push_back( prediction);
+      for (aMeas m = pixelMeasurements.begin(); m != pixelMeasurements.end(); m++) {
+        if (m->recHit()->isValid()) {
+          float localDphi = normalizedPhi(SCl_phi - m->forwardPredictedState().globalPosition().barePhi());
+          if (std::abs(localDphi) > 2.5)
+            continue;
+          CLHEP::Hep3Vector prediction(m->forwardPredictedState().globalPosition().x(),
+                                       m->forwardPredictedState().globalPosition().y(),
+                                       m->forwardPredictedState().globalPosition().z());
+          pred1Meas.push_back(prediction);
 
-	  validMeasurements.push_back(*m);
-	}
+          validMeasurements.push_back(*m);
+        }
       }
 
       //check if there are compatible 1st hits the outer forward disks
       if (searchInTIDTEC_) {
-	flayer++;
+        flayer++;
 
-	vector<TrajectoryMeasurement> pixel2Measurements =
-	  theLayerMeasurements.measurements(**flayer, tsosfwd,
-					     *prop1stLayer, meas1stFLayer);
+        vector<TrajectoryMeasurement> pixel2Measurements =
+            theLayerMeasurements.measurements(**flayer, tsosfwd, *prop1stLayer, meas1stFLayer);
 
-	for (aMeas m=pixel2Measurements.begin(); m!=pixel2Measurements.end(); m++){
-	  if (m->recHit()->isValid()) {
-	    float localDphi = normalizedPhi(SCl_phi-m->forwardPredictedState().globalPosition().barePhi()) ;
-	    if(std::abs(localDphi)>2.5)continue;
-	    CLHEP::Hep3Vector prediction(m->forwardPredictedState().globalPosition().x(),
-				  m->forwardPredictedState().globalPosition().y(),
-				  m->forwardPredictedState().globalPosition().z());
-	    pred1Meas.push_back( prediction);
+        for (aMeas m = pixel2Measurements.begin(); m != pixel2Measurements.end(); m++) {
+          if (m->recHit()->isValid()) {
+            float localDphi = normalizedPhi(SCl_phi - m->forwardPredictedState().globalPosition().barePhi());
+            if (std::abs(localDphi) > 2.5)
+              continue;
+            CLHEP::Hep3Vector prediction(m->forwardPredictedState().globalPosition().x(),
+                                         m->forwardPredictedState().globalPosition().y(),
+                                         m->forwardPredictedState().globalPosition().z());
+            pred1Meas.push_back(prediction);
 
-	    validMeasurements.push_back(*m);
-	  }
-	  //	else{std::cout<<" hit non valid "<<std::endl; }
-	}  //end 1st hit in outer f disk
+            validMeasurements.push_back(*m);
+          }
+          //	else{std::cout<<" hit non valid "<<std::endl; }
+        }  //end 1st hit in outer f disk
       }
     }
   }
 
   // now we have the vector of all valid measurements of the first point
-  for (unsigned i=0; i<validMeasurements.size(); i++){
+  for (unsigned i = 0; i < validMeasurements.size(); i++) {
+    const DetLayer *newLayer =
+        theGeometricSearchTracker->detLayer(validMeasurements[i].recHit()->det()->geographicalId());
 
-    const DetLayer * newLayer = theGeometricSearchTracker->detLayer(validMeasurements[i].recHit()->det()->geographicalId());
-
-    double zVertex ;
-    if (!useRecoVertex_)
-     {
+    double zVertex;
+    if (!useRecoVertex_) {
       // we don't know the z vertex position, get it from linear extrapolation
       // compute the z vertex from the cluster point and the found pixel hit
-      double pxHit1z = validMeasurements[i].recHit()->det()->surface().toGlobal(
-        validMeasurements[i].recHit()->localPosition()).z();
-      double pxHit1x = validMeasurements[i].recHit()->det()->surface().toGlobal(
-        validMeasurements[i].recHit()->localPosition()).x();
-      double pxHit1y = validMeasurements[i].recHit()->det()->surface().toGlobal(
-        validMeasurements[i].recHit()->localPosition()).y();
-      double r1diff = (pxHit1x-vprim.x())*(pxHit1x-vprim.x()) + (pxHit1y-vprim.y())*(pxHit1y-vprim.y());
-      r1diff=sqrt(r1diff);
-      double r2diff = (xmeas.x()-pxHit1x)*(xmeas.x()-pxHit1x) + (xmeas.y()-pxHit1y)*(xmeas.y()-pxHit1y);
-      r2diff=sqrt(r2diff);
-      zVertex = pxHit1z - r1diff*(xmeas.z()-pxHit1z)/r2diff;
-     }
-    else
-     {
+      double pxHit1z =
+          validMeasurements[i].recHit()->det()->surface().toGlobal(validMeasurements[i].recHit()->localPosition()).z();
+      double pxHit1x =
+          validMeasurements[i].recHit()->det()->surface().toGlobal(validMeasurements[i].recHit()->localPosition()).x();
+      double pxHit1y =
+          validMeasurements[i].recHit()->det()->surface().toGlobal(validMeasurements[i].recHit()->localPosition()).y();
+      double r1diff = (pxHit1x - vprim.x()) * (pxHit1x - vprim.x()) + (pxHit1y - vprim.y()) * (pxHit1y - vprim.y());
+      r1diff = sqrt(r1diff);
+      double r2diff = (xmeas.x() - pxHit1x) * (xmeas.x() - pxHit1x) + (xmeas.y() - pxHit1y) * (xmeas.y() - pxHit1y);
+      r2diff = sqrt(r2diff);
+      zVertex = pxHit1z - r1diff * (xmeas.z() - pxHit1z) / r2diff;
+    } else {
       // here we use the reco vertex z position
       zVertex = vprim.z();
-     }
+    }
 
-    if (i==0)
-     { vertex_ = zVertex; }
+    if (i == 0) {
+      vertex_ = zVertex;
+    }
 
-    GlobalPoint vertexPred(vprim.x(),vprim.y(),zVertex) ;
-    GlobalPoint hitPos( validMeasurements[i].recHit()->det()->surface().toGlobal( validMeasurements[i].recHit()->localPosition() ) ) ;
+    GlobalPoint vertexPred(vprim.x(), vprim.y(), zVertex);
+    GlobalPoint hitPos(
+        validMeasurements[i].recHit()->det()->surface().toGlobal(validMeasurements[i].recHit()->localPosition()));
 
     FreeTrajectoryState secondFTS = FTSFromVertexToPointFactory::get(*theMagField, hitPos, vertexPred, energy, charge);
 
-    PixelMatchNextLayers secondHit(&theLayerMeasurements, newLayer, secondFTS,
-				   prop2ndLayer, &meas2ndBLayer,&meas2ndFLayer,
-				   tTopo,navigationSchool,searchInTIDTEC_);
+    PixelMatchNextLayers secondHit(&theLayerMeasurements,
+                                   newLayer,
+                                   secondFTS,
+                                   prop2ndLayer,
+                                   &meas2ndBLayer,
+                                   &meas2ndFLayer,
+                                   tTopo,
+                                   navigationSchool,
+                                   searchInTIDTEC_);
     vector<CLHEP::Hep3Vector> predictions = secondHit.predictionInNextLayers();
 
-    for (unsigned it = 0; it < predictions.size(); it++) pred2Meas.push_back(predictions[it]);
+    for (unsigned it = 0; it < predictions.size(); it++)
+      pred2Meas.push_back(predictions[it]);
 
     // we may get more than one valid second measurements here even for single electrons:
     // two hits from the same layer/disk (detector overlap) or from the loop over the
     // next layers in EPMatchLoopNextLayers. Take only the 1st hit.
 
-    if(!secondHit.measurementsInNextLayers().empty()){
-      for(unsigned int shit=0; shit<secondHit.measurementsInNextLayers().size(); shit++)
-      	{
-	  float dphi = normalizedPhi(pred1Meas[i].phi()-validMeasurements[i].recHit()->globalPosition().barePhi()) ;
-	  if (std::abs(dphi)<2.5)
-	    {
-	      ConstRecHitPointer pxrh = validMeasurements[i].recHit();
-	      RecHitWithDist rh(pxrh,dphi);
+    if (!secondHit.measurementsInNextLayers().empty()) {
+      for (unsigned int shit = 0; shit < secondHit.measurementsInNextLayers().size(); shit++) {
+        float dphi = normalizedPhi(pred1Meas[i].phi() - validMeasurements[i].recHit()->globalPosition().barePhi());
+        if (std::abs(dphi) < 2.5) {
+          ConstRecHitPointer pxrh = validMeasurements[i].recHit();
+          RecHitWithDist rh(pxrh, dphi);
 
-	      //  pxrh = secondHit.measurementsInNextLayers()[0].recHit();
-	      pxrh = secondHit.measurementsInNextLayers()[shit].recHit();
+          //  pxrh = secondHit.measurementsInNextLayers()[0].recHit();
+          pxrh = secondHit.measurementsInNextLayers()[shit].recHit();
 
-	      pair<RecHitWithDist,ConstRecHitPointer> compatiblePair = pair<RecHitWithDist,ConstRecHitPointer>(rh,pxrh) ;
-	      result.push_back(compatiblePair);
-	      break;
-	    }
-	}
+          pair<RecHitWithDist, ConstRecHitPointer> compatiblePair = pair<RecHitWithDist, ConstRecHitPointer>(rh, pxrh);
+          result.push_back(compatiblePair);
+          break;
+        }
+      }
     }
   }
   return result;
 }
-

--- a/RecoEgamma/EgammaElectronAlgos/src/PixelMatchNextLayers.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/PixelMatchNextLayers.cc
@@ -2,7 +2,7 @@
 //
 // Package:    EgammaElectronAlgos
 // Class:      PixelMatchNextLayers
-// 
+//
 /**\class PixelMatchNextLayers EgammaElectronAlgos/PixelMatchNextLayers
 
  Description: class to find the compatible hits in the next layer
@@ -18,158 +18,126 @@
 
 #include "TrackingTools/DetLayers/interface/DetLayer.h"
 #include "TrackingTools/DetLayers/interface/NavigationSchool.h"
-#include "TrackingTools/MeasurementDet/interface/LayerMeasurements.h" 
+#include "TrackingTools/MeasurementDet/interface/LayerMeasurements.h"
 #include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
 #include "RecoEgamma/EgammaElectronAlgos/interface/PixelMatchNextLayers.h"
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
-#include <iostream> 
+#include <iostream>
 #include <algorithm>
 
- 
-PixelMatchNextLayers::PixelMatchNextLayers(const LayerMeasurements * theLayerMeasurements,const DetLayer* ilayer, 
-					   FreeTrajectoryState & aFTS,
-					   const PropagatorWithMaterial *aProp,  
-					   const BarrelMeasurementEstimator *aBarrelMeas,
-					   const ForwardMeasurementEstimator *aForwardMeas,
-					   const TrackerTopology *tTopo,
-                                           const NavigationSchool& navigationSchool,
-					   bool searchInTIDTEC)
- {
-
+PixelMatchNextLayers::PixelMatchNextLayers(const LayerMeasurements *theLayerMeasurements,
+                                           const DetLayer *ilayer,
+                                           FreeTrajectoryState &aFTS,
+                                           const PropagatorWithMaterial *aProp,
+                                           const BarrelMeasurementEstimator *aBarrelMeas,
+                                           const ForwardMeasurementEstimator *aForwardMeas,
+                                           const TrackerTopology *tTopo,
+                                           const NavigationSchool &navigationSchool,
+                                           bool searchInTIDTEC) {
   typedef std::vector<TrajectoryMeasurement>::const_iterator aMeas;
-  std::vector<const DetLayer*> allayers;
-  std::vector<const DetLayer*> nl = navigationSchool.nextLayers(*ilayer, aFTS, alongMomentum);
-  for (std::vector<const DetLayer*>::const_iterator il = nl.begin(); il != nl.end(); il++) {
+  std::vector<const DetLayer *> allayers;
+  std::vector<const DetLayer *> nl = navigationSchool.nextLayers(*ilayer, aFTS, alongMomentum);
+  for (std::vector<const DetLayer *>::const_iterator il = nl.begin(); il != nl.end(); il++) {
     allayers.push_back(*il);
-    std::vector<const DetLayer*> n2l = navigationSchool.nextLayers(**il, aFTS, alongMomentum);
-    for (std::vector<const DetLayer*>::const_iterator i2l = n2l.begin(); i2l != n2l.end(); i2l++) {
+    std::vector<const DetLayer *> n2l = navigationSchool.nextLayers(**il, aFTS, alongMomentum);
+    for (std::vector<const DetLayer *>::const_iterator i2l = n2l.begin(); i2l != n2l.end(); i2l++) {
       allayers.push_back(*i2l);
     }
   }
 
-  const TrajectoryStateOnSurface tsos(aFTS,ilayer->surface());
-  
-  if (tsos.isValid()) 
-    {    
-      for (std::vector<const DetLayer*>::const_iterator il = allayers.begin(); il != allayers.end(); il++) 
-	{
-	  if ( GeomDetEnumerators::isTrackerPixel((*il)->subDetector()) ) {
-	    
-	    std::vector<TrajectoryMeasurement> pixelMeasurements;
-	    if (GeomDetEnumerators::isBarrel((*il)->subDetector())) {
-	      pixelMeasurements = theLayerMeasurements->measurements( **il, tsos , *aProp, *aBarrelMeas); 
-	    } else {
-	      pixelMeasurements = theLayerMeasurements->measurements( **il, tsos, *aProp, *aForwardMeas);
-	    }
-	    for (aMeas m=pixelMeasurements.begin(); m!=pixelMeasurements.end(); m++){
-	      if (m == pixelMeasurements.begin()){
-		CLHEP::Hep3Vector prediction(m->forwardPredictedState().globalPosition().x(),
-				      m->forwardPredictedState().globalPosition().y(),
-				      m->forwardPredictedState().globalPosition().z());
-		predictionHere.push_back( prediction);
-	      }
-	      if (m->recHit()->isValid()) {
-		measurementsHere.push_back( *m);
-		hitsHere.push_back( m->recHit());
+  const TrajectoryStateOnSurface tsos(aFTS, ilayer->surface());
 
-		//std::cout<<"\n SH B-D "<<std::endl;
+  if (tsos.isValid()) {
+    for (std::vector<const DetLayer *>::const_iterator il = allayers.begin(); il != allayers.end(); il++) {
+      if (GeomDetEnumerators::isTrackerPixel((*il)->subDetector())) {
+        std::vector<TrajectoryMeasurement> pixelMeasurements;
+        if (GeomDetEnumerators::isBarrel((*il)->subDetector())) {
+          pixelMeasurements = theLayerMeasurements->measurements(**il, tsos, *aProp, *aBarrelMeas);
+        } else {
+          pixelMeasurements = theLayerMeasurements->measurements(**il, tsos, *aProp, *aForwardMeas);
+        }
+        for (aMeas m = pixelMeasurements.begin(); m != pixelMeasurements.end(); m++) {
+          if (m == pixelMeasurements.begin()) {
+            CLHEP::Hep3Vector prediction(m->forwardPredictedState().globalPosition().x(),
+                                         m->forwardPredictedState().globalPosition().y(),
+                                         m->forwardPredictedState().globalPosition().z());
+            predictionHere.push_back(prediction);
+          }
+          if (m->recHit()->isValid()) {
+            measurementsHere.push_back(*m);
+            hitsHere.push_back(m->recHit());
 
-	      } else {
-		badMeasurementsHere.push_back( *m);
-	      }
-	    }
-	  }
-	  if (searchInTIDTEC) {	  
-	  //additional search in the TID layers
-	  if ( ((*il)->subDetector())==GeomDetEnumerators::TID && (ilayer->location()) == GeomDetEnumerators::endcap)
-	    {
-	      std::vector<TrajectoryMeasurement> pixelMeasurements;
-	      pixelMeasurements = theLayerMeasurements->measurements( (**il), tsos , *aProp, *aForwardMeas); 
-	      
-	      for (aMeas m=pixelMeasurements.begin(); m!=pixelMeasurements.end(); m++)
-		{
-		  // limit search in first ring
-		  if (tTopo->tidRing(m->recHit()->geographicalId()) > 1) continue;
-		  if (m == pixelMeasurements.begin())
-		    {
-		      CLHEP::Hep3Vector prediction(m->forwardPredictedState().globalPosition().x(),
-					    m->forwardPredictedState().globalPosition().y(),
-					    m->forwardPredictedState().globalPosition().z());
-		      predictionHere.push_back( prediction);
-		    }
-		  if (m->recHit()->isValid()) 
-		    {
-		      measurementsHere.push_back( *m);
-		      hitsHere.push_back(m->recHit());
-		    }
-		  // else{ std::cout<<" 2H not valid "<<std::endl;}
-		}
-	    } //end of TID search
-	  
-	  //additional search in the TEC layers
-	  if ( ((*il)->subDetector())==GeomDetEnumerators::TEC && (ilayer->location()) == GeomDetEnumerators::endcap)
-	    {
-	      std::vector<TrajectoryMeasurement> pixelMeasurements;
-	      pixelMeasurements = theLayerMeasurements->measurements( (**il), tsos , *aProp, *aForwardMeas); 
-	      	      
-	      for (aMeas m=pixelMeasurements.begin(); m!=pixelMeasurements.end(); m++)
-		{
-		  // limit search in first ring and first third wheels
-		  if (tTopo->tecRing(m->recHit()->geographicalId()) > 1) continue;
-		  if (tTopo->tecWheel(m->recHit()->geographicalId()) > 3) continue;
-		  if (m == pixelMeasurements.begin())
-		    {
-		      CLHEP::Hep3Vector prediction(m->forwardPredictedState().globalPosition().x(),
-					    m->forwardPredictedState().globalPosition().y(),
-					    m->forwardPredictedState().globalPosition().z());
-		      predictionHere.push_back( prediction);
-		    }
-		  if (m->recHit()->isValid()) 
-		    {
-		      measurementsHere.push_back( *m);
-		      hitsHere.push_back(m->recHit());
+            //std::cout<<"\n SH B-D "<<std::endl;
 
-		      //std::cout<<"\n SH TEC "<<std::endl;
+          } else {
+            badMeasurementsHere.push_back(*m);
+          }
+        }
+      }
+      if (searchInTIDTEC) {
+        //additional search in the TID layers
+        if (((*il)->subDetector()) == GeomDetEnumerators::TID && (ilayer->location()) == GeomDetEnumerators::endcap) {
+          std::vector<TrajectoryMeasurement> pixelMeasurements;
+          pixelMeasurements = theLayerMeasurements->measurements((**il), tsos, *aProp, *aForwardMeas);
 
-		    }
-		  // else{ std::cout<<" 2H not valid "<<std::endl;}
-		}
-	    } //end of TEC search
-	  }
-	}
-    } 
+          for (aMeas m = pixelMeasurements.begin(); m != pixelMeasurements.end(); m++) {
+            // limit search in first ring
+            if (tTopo->tidRing(m->recHit()->geographicalId()) > 1)
+              continue;
+            if (m == pixelMeasurements.begin()) {
+              CLHEP::Hep3Vector prediction(m->forwardPredictedState().globalPosition().x(),
+                                           m->forwardPredictedState().globalPosition().y(),
+                                           m->forwardPredictedState().globalPosition().z());
+              predictionHere.push_back(prediction);
+            }
+            if (m->recHit()->isValid()) {
+              measurementsHere.push_back(*m);
+              hitsHere.push_back(m->recHit());
+            }
+            // else{ std::cout<<" 2H not valid "<<std::endl;}
+          }
+        }  //end of TID search
+
+        //additional search in the TEC layers
+        if (((*il)->subDetector()) == GeomDetEnumerators::TEC && (ilayer->location()) == GeomDetEnumerators::endcap) {
+          std::vector<TrajectoryMeasurement> pixelMeasurements;
+          pixelMeasurements = theLayerMeasurements->measurements((**il), tsos, *aProp, *aForwardMeas);
+
+          for (aMeas m = pixelMeasurements.begin(); m != pixelMeasurements.end(); m++) {
+            // limit search in first ring and first third wheels
+            if (tTopo->tecRing(m->recHit()->geographicalId()) > 1)
+              continue;
+            if (tTopo->tecWheel(m->recHit()->geographicalId()) > 3)
+              continue;
+            if (m == pixelMeasurements.begin()) {
+              CLHEP::Hep3Vector prediction(m->forwardPredictedState().globalPosition().x(),
+                                           m->forwardPredictedState().globalPosition().y(),
+                                           m->forwardPredictedState().globalPosition().z());
+              predictionHere.push_back(prediction);
+            }
+            if (m->recHit()->isValid()) {
+              measurementsHere.push_back(*m);
+              hitsHere.push_back(m->recHit());
+
+              //std::cout<<"\n SH TEC "<<std::endl;
+            }
+            // else{ std::cout<<" 2H not valid "<<std::endl;}
+          }
+        }  //end of TEC search
+      }
+    }
+  }
 }
 
-  
-std::vector<TrajectoryMeasurement> PixelMatchNextLayers::measurementsInNextLayers() const {
-
-  return measurementsHere;
-}
+std::vector<TrajectoryMeasurement> PixelMatchNextLayers::measurementsInNextLayers() const { return measurementsHere; }
 
 std::vector<TrajectoryMeasurement> PixelMatchNextLayers::badMeasurementsInNextLayers() const {
-
   return badMeasurementsHere;
 }
 
-TransientTrackingRecHit::RecHitContainer PixelMatchNextLayers::hitsInNextLayers() const {
+TransientTrackingRecHit::RecHitContainer PixelMatchNextLayers::hitsInNextLayers() const { return hitsHere; }
 
-  return hitsHere;
-}
-
-std::vector<CLHEP::Hep3Vector> PixelMatchNextLayers::predictionInNextLayers() const {
-
-  return predictionHere;
-}
-
-
-
-
-
-
-
-
-
-
+std::vector<CLHEP::Hep3Vector> PixelMatchNextLayers::predictionInNextLayers() const { return predictionHere; }

--- a/RecoEgamma/EgammaElectronAlgos/src/RegressionHelper.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/RegressionHelper.cc
@@ -8,242 +8,229 @@
 #include "TVector2.h"
 #include "TFile.h"
 
-RegressionHelper::RegressionHelper( const Configuration & config):
-  cfg_(config),ecalRegressionInitialized_(false),combinationRegressionInitialized_(false),
-  caloTopologyCacheId_(0), caloGeometryCacheId_(0),regressionCacheId_(0)
-{;}
+RegressionHelper::RegressionHelper(const Configuration& config)
+    : cfg_(config),
+      ecalRegressionInitialized_(false),
+      combinationRegressionInitialized_(false),
+      caloTopologyCacheId_(0),
+      caloGeometryCacheId_(0),
+      regressionCacheId_(0) {
+  ;
+}
 
-RegressionHelper::~RegressionHelper(){;}
+RegressionHelper::~RegressionHelper() { ; }
 
-void RegressionHelper::applyEcalRegression(reco::GsfElectron & ele,
-					   const edm::Handle<reco::VertexCollection>& vertices,
-					   const edm::Handle<EcalRecHitCollection>& rechitsEB,
-					   const edm::Handle<EcalRecHitCollection>& rechitsEE) const {
+void RegressionHelper::applyEcalRegression(reco::GsfElectron& ele,
+                                           const edm::Handle<reco::VertexCollection>& vertices,
+                                           const edm::Handle<EcalRecHitCollection>& rechitsEB,
+                                           const edm::Handle<EcalRecHitCollection>& rechitsEE) const {
   double cor, err;
   getEcalRegression(*ele.superCluster(), vertices, rechitsEB, rechitsEE, cor, err);
   ele.setCorrectedEcalEnergy(cor * ele.superCluster()->correctedEnergy());
-  ele.setCorrectedEcalEnergyError( err * ele.superCluster()->correctedEnergy());	
-
+  ele.setCorrectedEcalEnergyError(err * ele.superCluster()->correctedEnergy());
 }
 
-void RegressionHelper::checkSetup(const edm::EventSetup & es) {
+void RegressionHelper::checkSetup(const edm::EventSetup& es) {
+  // Topology
+  unsigned long long newCaloTopologyCacheId = es.get<CaloTopologyRecord>().cacheIdentifier();
+  if (!caloTopologyCacheId_ || (caloTopologyCacheId_ != newCaloTopologyCacheId)) {
+    caloTopologyCacheId_ = newCaloTopologyCacheId;
+    edm::ESHandle<CaloTopology> caloTopo;
+    es.get<CaloTopologyRecord>().get(caloTopo);
+    caloTopology_ = &(*caloTopo);
+  }
 
-  // Topology 
-  unsigned long long newCaloTopologyCacheId 
-    = es.get<CaloTopologyRecord>().cacheIdentifier() ;
-  if (!caloTopologyCacheId_ || ( caloTopologyCacheId_ != newCaloTopologyCacheId ) )
-    {
-      caloTopologyCacheId_ = newCaloTopologyCacheId;
-      edm::ESHandle<CaloTopology> caloTopo;
-      es.get<CaloTopologyRecord>().get(caloTopo);
-      caloTopology_ = &(*caloTopo);
-    }
-    
   // Geometry
-  unsigned long long newCaloGeometryCacheId
-    = es.get<CaloGeometryRecord>().cacheIdentifier() ;
-  if (!caloGeometryCacheId_ || ( caloGeometryCacheId_ != newCaloGeometryCacheId ) ) 
-    {
-      caloGeometryCacheId_ = newCaloGeometryCacheId;
-      edm::ESHandle<CaloGeometry> caloGeom;
-      es.get<CaloGeometryRecord>().get(caloGeom);
-      caloGeometry_ = &(*caloGeom);
-    }
+  unsigned long long newCaloGeometryCacheId = es.get<CaloGeometryRecord>().cacheIdentifier();
+  if (!caloGeometryCacheId_ || (caloGeometryCacheId_ != newCaloGeometryCacheId)) {
+    caloGeometryCacheId_ = newCaloGeometryCacheId;
+    edm::ESHandle<CaloGeometry> caloGeom;
+    es.get<CaloGeometryRecord>().get(caloGeom);
+    caloGeometry_ = &(*caloGeom);
+  }
 
-  // Ecal regression 
-  
+  // Ecal regression
+
   // if at least one of the set of weights come from the DB
-  if(cfg_.ecalWeightsFromDB)
-    {
-      unsigned long long newRegressionCacheId
-	= es.get<GBRWrapperRcd>().cacheIdentifier() ;
-      if ( !regressionCacheId_ || (newRegressionCacheId != regressionCacheId_ ) ) {
-	
-	const GBRWrapperRcd& gbrRcd = es.get<GBRWrapperRcd>();
+  if (cfg_.ecalWeightsFromDB) {
+    unsigned long long newRegressionCacheId = es.get<GBRWrapperRcd>().cacheIdentifier();
+    if (!regressionCacheId_ || (newRegressionCacheId != regressionCacheId_)) {
+      const GBRWrapperRcd& gbrRcd = es.get<GBRWrapperRcd>();
 
-	// ECAL barrel
-	edm::ESHandle<GBRForest> ecalRegBarrelH;
-	gbrRcd.get(cfg_.ecalRegressionWeightLabels[0].c_str(),ecalRegBarrelH);
-	ecalRegBarrel_ = &(*ecalRegBarrelH);
-	
-	// ECAL endcaps
-	edm::ESHandle<GBRForest> ecalRegEndcapH;
-	gbrRcd.get(cfg_.ecalRegressionWeightLabels[1].c_str(),ecalRegEndcapH);
-	ecalRegEndcap_= &(*ecalRegEndcapH);
-	
-	// ECAL barrel error
-	edm::ESHandle<GBRForest> ecalRegErrorBarrelH;
-	gbrRcd.get(cfg_.ecalRegressionWeightLabels[2].c_str(),ecalRegErrorBarrelH);
-	ecalRegErrorBarrel_ = &(*ecalRegErrorBarrelH);
-	
-	// ECAL endcap error
-	edm::ESHandle<GBRForest> ecalRegErrorEndcapH;
-	gbrRcd.get(cfg_.ecalRegressionWeightLabels[3].c_str(),ecalRegErrorEndcapH);
-	ecalRegErrorEndcap_ = &(*ecalRegErrorEndcapH);
-	
-	ecalRegressionInitialized_ = true;
+      // ECAL barrel
+      edm::ESHandle<GBRForest> ecalRegBarrelH;
+      gbrRcd.get(cfg_.ecalRegressionWeightLabels[0].c_str(), ecalRegBarrelH);
+      ecalRegBarrel_ = &(*ecalRegBarrelH);
+
+      // ECAL endcaps
+      edm::ESHandle<GBRForest> ecalRegEndcapH;
+      gbrRcd.get(cfg_.ecalRegressionWeightLabels[1].c_str(), ecalRegEndcapH);
+      ecalRegEndcap_ = &(*ecalRegEndcapH);
+
+      // ECAL barrel error
+      edm::ESHandle<GBRForest> ecalRegErrorBarrelH;
+      gbrRcd.get(cfg_.ecalRegressionWeightLabels[2].c_str(), ecalRegErrorBarrelH);
+      ecalRegErrorBarrel_ = &(*ecalRegErrorBarrelH);
+
+      // ECAL endcap error
+      edm::ESHandle<GBRForest> ecalRegErrorEndcapH;
+      gbrRcd.get(cfg_.ecalRegressionWeightLabels[3].c_str(), ecalRegErrorEndcapH);
+      ecalRegErrorEndcap_ = &(*ecalRegErrorEndcapH);
+
+      ecalRegressionInitialized_ = true;
+    }
+  }
+  if (cfg_.combinationWeightsFromDB) {
+    // Combination
+    if (cfg_.combinationWeightsFromDB) {
+      unsigned long long newRegressionCacheId = es.get<GBRWrapperRcd>().cacheIdentifier();
+      if (!regressionCacheId_ || (newRegressionCacheId != regressionCacheId_)) {
+        const GBRWrapperRcd& gbrRcd = es.get<GBRWrapperRcd>();
+
+        edm::ESHandle<GBRForest> combinationRegH;
+        gbrRcd.get(cfg_.combinationRegressionWeightLabels[0].c_str(), combinationRegH);
+        combinationReg_ = &(*combinationRegH);
+
+        combinationRegressionInitialized_ = true;
       }
     }
-  if( cfg_.combinationWeightsFromDB) 
-    {
-
-	// Combination
-	if(cfg_.combinationWeightsFromDB) 
-	  {
-	    unsigned long long newRegressionCacheId
-	      = es.get<GBRWrapperRcd>().cacheIdentifier() ;
-	    if ( !regressionCacheId_ || (newRegressionCacheId != regressionCacheId_ ) ) {
-
-	      const GBRWrapperRcd& gbrRcd = es.get<GBRWrapperRcd>();
-
-	      edm::ESHandle<GBRForest> combinationRegH;
-	      gbrRcd.get(cfg_.combinationRegressionWeightLabels[0].c_str(),combinationRegH);
-	      combinationReg_ = &(*combinationRegH);
-	      
-	      combinationRegressionInitialized_ = true;
-	    }
-	  }
-    }
+  }
 
   // read weights from file - for debugging. Even if it is one single files, 4 files should b set in the vector
-  if(!cfg_.ecalWeightsFromDB && !ecalRegressionInitialized_ &&
-     !cfg_.ecalRegressionWeightFiles.empty() ) {
-    TFile file0 (edm::FileInPath(cfg_.ecalRegressionWeightFiles[0].c_str()).fullPath().c_str());
+  if (!cfg_.ecalWeightsFromDB && !ecalRegressionInitialized_ && !cfg_.ecalRegressionWeightFiles.empty()) {
+    TFile file0(edm::FileInPath(cfg_.ecalRegressionWeightFiles[0].c_str()).fullPath().c_str());
     ecalRegBarrel_ = (const GBRForest*)file0.Get(cfg_.ecalRegressionWeightLabels[0].c_str());
     file0.Close();
-    TFile file1 (edm::FileInPath(cfg_.ecalRegressionWeightFiles[1].c_str()).fullPath().c_str());
+    TFile file1(edm::FileInPath(cfg_.ecalRegressionWeightFiles[1].c_str()).fullPath().c_str());
     ecalRegEndcap_ = (const GBRForest*)file1.Get(cfg_.ecalRegressionWeightLabels[1].c_str());
     file1.Close();
-    TFile file2 (edm::FileInPath(cfg_.ecalRegressionWeightFiles[2].c_str()).fullPath().c_str());
+    TFile file2(edm::FileInPath(cfg_.ecalRegressionWeightFiles[2].c_str()).fullPath().c_str());
     ecalRegErrorBarrel_ = (const GBRForest*)file2.Get(cfg_.ecalRegressionWeightLabels[2].c_str());
     file2.Close();
-    TFile file3 (edm::FileInPath(cfg_.ecalRegressionWeightFiles[3].c_str()).fullPath().c_str());
+    TFile file3(edm::FileInPath(cfg_.ecalRegressionWeightFiles[3].c_str()).fullPath().c_str());
     ecalRegErrorEndcap_ = (const GBRForest*)file3.Get(cfg_.ecalRegressionWeightLabels[3].c_str());
     ecalRegressionInitialized_ = true;
     file3.Close();
   }
-  
-  if(!cfg_.combinationWeightsFromDB && !combinationRegressionInitialized_ && 
-     !cfg_.combinationRegressionWeightFiles.empty() ) 
-    {
-      TFile file0 (edm::FileInPath(cfg_.combinationRegressionWeightFiles[0].c_str()).fullPath().c_str());
-      combinationReg_ = (const GBRForest*)file0.Get(cfg_.combinationRegressionWeightLabels[0].c_str());
-      combinationRegressionInitialized_ = true;
-      file0.Close();
-    }
-  
+
+  if (!cfg_.combinationWeightsFromDB && !combinationRegressionInitialized_ &&
+      !cfg_.combinationRegressionWeightFiles.empty()) {
+    TFile file0(edm::FileInPath(cfg_.combinationRegressionWeightFiles[0].c_str()).fullPath().c_str());
+    combinationReg_ = (const GBRForest*)file0.Get(cfg_.combinationRegressionWeightLabels[0].c_str());
+    combinationRegressionInitialized_ = true;
+    file0.Close();
+  }
 }
 
-void RegressionHelper::readEvent( const edm::Event &) {;}
+void RegressionHelper::readEvent(const edm::Event&) { ; }
 
-void RegressionHelper::getEcalRegression(const reco::SuperCluster & sc,
-					 const edm::Handle<reco::VertexCollection>& vertices,
-					 const edm::Handle<EcalRecHitCollection>& rechitsEB,
-					 const edm::Handle<EcalRecHitCollection>& rechitsEE,
-					 double & energyFactor, double & errorFactor) const {
-  
+void RegressionHelper::getEcalRegression(const reco::SuperCluster& sc,
+                                         const edm::Handle<reco::VertexCollection>& vertices,
+                                         const edm::Handle<EcalRecHitCollection>& rechitsEB,
+                                         const edm::Handle<EcalRecHitCollection>& rechitsEE,
+                                         double& energyFactor,
+                                         double& errorFactor) const {
   energyFactor = -999.;
   errorFactor = -999.;
 
   std::vector<float> rInputs;
   EcalRegressionData regData;
-  regData.fill(sc,rechitsEB.product(),rechitsEE.product(),caloGeometry_,caloTopology_,vertices.product());
+  regData.fill(sc, rechitsEB.product(), rechitsEE.product(), caloGeometry_, caloTopology_, vertices.product());
   regData.fillVec(rInputs);
-  if(sc.seed()->hitsAndFractions()[0].first.subdetId()==EcalBarrel){
+  if (sc.seed()->hitsAndFractions()[0].first.subdetId() == EcalBarrel) {
     energyFactor = ecalRegBarrel_->GetResponse(&rInputs[0]);
     errorFactor = ecalRegErrorBarrel_->GetResponse(&rInputs[0]);
-  }else if(sc.seed()->hitsAndFractions()[0].first.subdetId()==EcalEndcap){  
+  } else if (sc.seed()->hitsAndFractions()[0].first.subdetId() == EcalEndcap) {
     energyFactor = ecalRegEndcap_->GetResponse(&rInputs[0]);
     errorFactor = ecalRegErrorEndcap_->GetResponse(&rInputs[0]);
-  }else{
+  } else {
     throw cms::Exception("RegressionHelper::calculateRegressedEnergy")
-      << "Supercluster seed is either EB nor EE!" << std::endl;
+        << "Supercluster seed is either EB nor EE!" << std::endl;
   }
-
 }
 
-void RegressionHelper::applyCombinationRegression(reco::GsfElectron & ele) const
-{
+void RegressionHelper::applyCombinationRegression(reco::GsfElectron& ele) const {
   float energy = ele.correctedEcalEnergy();
   float energyError = ele.correctedEcalEnergyError();
   float momentum = ele.trackMomentumAtVtx().R();
   float momentumError = ele.trackMomentumError();
   int elClass = -1;
-  
+
   switch (ele.classification()) {
-  case reco::GsfElectron::GOLDEN:
-    elClass = 0;
-    break;
-  case reco::GsfElectron::BIGBREM:
-    elClass = 1;
-    break;
-  case reco::GsfElectron::BADTRACK:
-    elClass = 2;
-    break;
-  case  reco::GsfElectron::SHOWERING:
-    elClass = 3;
-    break;
-  case reco::GsfElectron::GAP:
-    elClass = 4;
-    break;
-  default:
-    elClass = -1;
+    case reco::GsfElectron::GOLDEN:
+      elClass = 0;
+      break;
+    case reco::GsfElectron::BIGBREM:
+      elClass = 1;
+      break;
+    case reco::GsfElectron::BADTRACK:
+      elClass = 2;
+      break;
+    case reco::GsfElectron::SHOWERING:
+      elClass = 3;
+      break;
+    case reco::GsfElectron::GAP:
+      elClass = 4;
+      break;
+    default:
+      elClass = -1;
   }
 
-
   bool isEcalDriven = ele.ecalDriven();
-  bool isTrackerDriven =  ele.trackerDrivenSeed();
+  bool isTrackerDriven = ele.trackerDrivenSeed();
   bool isEB = ele.isEB();
-  
+
   // compute relative errors and ratio of errors
   float energyRelError = energyError / energy;
   float momentumRelError = momentumError / momentum;
   float errorRatio = energyRelError / momentumRelError;
 
   // calculate E/p and corresponding error
-  float eOverP = energy / momentum;  
-  float eOverPerror = eOverP*std::hypot(energyRelError,momentumRelError);
-  
+  float eOverP = energy / momentum;
+  float eOverPerror = eOverP * std::hypot(energyRelError, momentumRelError);
+
   // fill input variables
-  std::vector<float> regressionInputs ;
-  regressionInputs.resize(11,0.);
-  
-  regressionInputs[0]  = energy;
-  regressionInputs[1]  = energyRelError;
-  regressionInputs[2]  = momentum;
-  regressionInputs[3]  = momentumRelError;
-  regressionInputs[4]  = errorRatio;
-  regressionInputs[5]  = eOverP;
-  regressionInputs[6]  = eOverPerror;
-  regressionInputs[7]  = static_cast<float>(isEcalDriven);
-  regressionInputs[8]  = static_cast<float>(isTrackerDriven);
-  regressionInputs[9]  = static_cast<float>(elClass);
+  std::vector<float> regressionInputs;
+  regressionInputs.resize(11, 0.);
+
+  regressionInputs[0] = energy;
+  regressionInputs[1] = energyRelError;
+  regressionInputs[2] = momentum;
+  regressionInputs[3] = momentumRelError;
+  regressionInputs[4] = errorRatio;
+  regressionInputs[5] = eOverP;
+  regressionInputs[6] = eOverPerror;
+  regressionInputs[7] = static_cast<float>(isEcalDriven);
+  regressionInputs[8] = static_cast<float>(isTrackerDriven);
+  regressionInputs[9] = static_cast<float>(elClass);
   regressionInputs[10] = static_cast<float>(isEB);
-  
+
   // retrieve combination weight
   float weight = 0.;
-  if(eOverP>0.025 
-     &&fabs(momentum-energy)<15.*sqrt(momentumError*momentumError + energyError*energyError)
-     ) // protection against crazy track measurement
-    {
-      weight = combinationReg_->GetResponse(regressionInputs.data());
-      if(weight>1.) weight = 1.;
-      else if(weight<0.) weight = 0.;
-    }
-  
-  float combinedMomentum = weight*momentum + (1.-weight)*energy;
-  float combinedMomentumError = sqrt(weight*weight*momentumError*momentumError + (1.-weight)*(1.-weight)*energyError*energyError);
-  
+  if (eOverP > 0.025 &&
+      fabs(momentum - energy) < 15. * sqrt(momentumError * momentumError +
+                                           energyError * energyError))  // protection against crazy track measurement
+  {
+    weight = combinationReg_->GetResponse(regressionInputs.data());
+    if (weight > 1.)
+      weight = 1.;
+    else if (weight < 0.)
+      weight = 0.;
+  }
+
+  float combinedMomentum = weight * momentum + (1. - weight) * energy;
+  float combinedMomentumError =
+      sqrt(weight * weight * momentumError * momentumError + (1. - weight) * (1. - weight) * energyError * energyError);
+
   // FIXME : pure tracker electrons have track momentum error of 999.
   // If the combination try to combine such electrons then the original combined momentum is kept
-  if(momentumError!=999. || weight==0.)
-    {
-      math::XYZTLorentzVector oldMomentum = ele.p4() ;
-      math::XYZTLorentzVector newMomentum(oldMomentum.x()*combinedMomentum/oldMomentum.t(),
-					  oldMomentum.y()*combinedMomentum/oldMomentum.t(),
-					  oldMomentum.z()*combinedMomentum/oldMomentum.t(),
-					  combinedMomentum);
-      
-      ele.setP4(reco::GsfElectron::P4_COMBINATION,newMomentum,combinedMomentumError,true);
-    }  
+  if (momentumError != 999. || weight == 0.) {
+    math::XYZTLorentzVector oldMomentum = ele.p4();
+    math::XYZTLorentzVector newMomentum(oldMomentum.x() * combinedMomentum / oldMomentum.t(),
+                                        oldMomentum.y() * combinedMomentum / oldMomentum.t(),
+                                        oldMomentum.z() * combinedMomentum / oldMomentum.t(),
+                                        combinedMomentum);
+
+    ele.setP4(reco::GsfElectron::P4_COMBINATION, newMomentum, combinedMomentumError, true);
+  }
 }

--- a/RecoEgamma/EgammaElectronAlgos/src/SeedFilter.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/SeedFilter.cc
@@ -4,7 +4,6 @@
 #include "RecoEgamma/EgammaElectronAlgos/interface/SeedFilter.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
 
-
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 
@@ -32,20 +31,17 @@
 using namespace std;
 using namespace reco;
 
-SeedFilter::SeedFilter(const edm::ParameterSet& conf,
-		       const SeedFilter::Tokens& tokens,
-		       edm::ConsumesCollector& iC)
- {
+SeedFilter::SeedFilter(const edm::ParameterSet& conf, const SeedFilter::Tokens& tokens, edm::ConsumesCollector& iC) {
   edm::LogInfo("EtaPhiRegionSeedFactory") << "Enter the EtaPhiRegionSeedFactory";
   edm::ParameterSet regionPSet = conf.getParameter<edm::ParameterSet>("RegionPSet");
 
-  ptmin_        = regionPSet.getParameter<double>("ptMin");
+  ptmin_ = regionPSet.getParameter<double>("ptMin");
   originradius_ = regionPSet.getParameter<double>("originRadius");
-  halflength_   = regionPSet.getParameter<double>("originHalfLength");
-  deltaEta_     = regionPSet.getParameter<double>("deltaEtaRegion");
-  deltaPhi_     = regionPSet.getParameter<double>("deltaPhiRegion");
-  useZvertex_   = regionPSet.getParameter<bool>("useZInVertex");
-  vertexSrc_    = tokens.token_vtx;
+  halflength_ = regionPSet.getParameter<double>("originHalfLength");
+  deltaEta_ = regionPSet.getParameter<double>("deltaEtaRegion");
+  deltaPhi_ = regionPSet.getParameter<double>("deltaPhiRegion");
+  useZvertex_ = regionPSet.getParameter<bool>("useZInVertex");
+  vertexSrc_ = tokens.token_vtx;
 
   // setup orderedhits setup (in order to tell seed generator to use pairs/triplets, which layers)
   edm::ParameterSet hitsfactoryPSet = conf.getParameter<edm::ParameterSet>("OrderedHitsFactoryPSet");
@@ -60,7 +56,7 @@ SeedFilter::SeedFilter(const edm::ParameterSet& conf,
   // please consider changing the type of useOnDemandTracker to a
   // string corresponding to the UseMeasurementTracker enumeration
   int tmp = hitsfactoryPSet.getUntrackedParameter<int>("useOnDemandTracker");
-  if(tmp < -1 || tmp > 1)
+  if (tmp < -1 || tmp > 1)
     throw cms::Exception("Configuration") << "SeedFilter: useOnDemandTracker must be -1, 0, or 1; got " << tmp;
   hitsfactoryMode_ = RectangularEtaPhiTrackingRegion::intToUseMeasurementTracker(tmp);
 
@@ -68,20 +64,25 @@ SeedFilter::SeedFilter(const edm::ParameterSet& conf,
   edm::ParameterSet seedCreatorPSet = conf.getParameter<edm::ParameterSet>("SeedCreatorPSet");
   std::string seedCreatorType = seedCreatorPSet.getParameter<std::string>("ComponentName");
 
-  combinatorialSeedGenerator = std::make_unique<SeedGeneratorFromRegionHits>(std::unique_ptr<OrderedHitsGenerator>{OrderedHitsGeneratorFactory::get()->create(hitsfactoryName, hitsfactoryPSet, iC)},
-                                                                             nullptr,
-                                                                             std::unique_ptr<SeedCreator>{SeedCreatorFactory::get()->create(seedCreatorType, seedCreatorPSet)}
-				                  	       );
-  beamSpotTag_ = tokens.token_bs; ;
-  if(hitsfactoryMode_ != RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever) {
-    measurementTrackerToken_ = iC.consumes<MeasurementTrackerEvent>(conf.getParameter<edm::InputTag>("measurementTrackerEvent"));
+  combinatorialSeedGenerator = std::make_unique<SeedGeneratorFromRegionHits>(
+      std::unique_ptr<OrderedHitsGenerator>{
+          OrderedHitsGeneratorFactory::get()->create(hitsfactoryName, hitsfactoryPSet, iC)},
+      nullptr,
+      std::unique_ptr<SeedCreator>{SeedCreatorFactory::get()->create(seedCreatorType, seedCreatorPSet)});
+  beamSpotTag_ = tokens.token_bs;
+  ;
+  if (hitsfactoryMode_ != RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever) {
+    measurementTrackerToken_ =
+        iC.consumes<MeasurementTrackerEvent>(conf.getParameter<edm::InputTag>("measurementTrackerEvent"));
   }
 }
 
 SeedFilter::~SeedFilter() = default;
 
-void SeedFilter::seeds(edm::Event& e, const edm::EventSetup& setup, const reco::SuperClusterRef &scRef, TrajectorySeedCollection *output) {
-
+void SeedFilter::seeds(edm::Event& e,
+                       const edm::EventSetup& setup,
+                       const reco::SuperClusterRef& scRef,
+                       TrajectorySeedCollection* output) {
   setup.get<IdealMagneticFieldRecord>().get(theMagField);
   auto seedColl = std::make_unique<TrajectorySeedCollection>();
 
@@ -105,8 +106,8 @@ void SeedFilter::seeds(edm::Event& e, const edm::EventSetup& setup, const reco::
   if (e.getByToken(vertexSrc_, h_vertices)) {
     vertices = *(h_vertices.product());
   } else {
-	  LogDebug("SeedFilter") << "SeedFilter::seeds"
-				  << "No vertex collection found: using beam-spot";
+    LogDebug("SeedFilter") << "SeedFilter::seeds"
+                           << "No vertex collection found: using beam-spot";
   }
 
   if (!vertices.empty() && useZvertex_) {
@@ -116,18 +117,18 @@ void SeedFilter::seeds(edm::Event& e, const edm::EventSetup& setup, const reco::
   } else {
     edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
     //e.getByType(recoBeamSpotHandle);
-    e.getByToken(beamSpotTag_,recoBeamSpotHandle);
+    e.getByToken(beamSpotTag_, recoBeamSpotHandle);
     // gets its position
     const reco::BeamSpot::Point& BSPosition = recoBeamSpotHandle->position();
     double sigmaZ = recoBeamSpotHandle->sigmaZ();
     double sigmaZ0Error = recoBeamSpotHandle->sigmaZ0Error();
-    double sq=sqrt(sigmaZ*sigmaZ+sigmaZ0Error*sigmaZ0Error);
+    double sq = sqrt(sigmaZ * sigmaZ + sigmaZ0Error * sigmaZ0Error);
     vtxPos = GlobalPoint(BSPosition.x(), BSPosition.y(), BSPosition.z());
-    deltaZVertex = 3*sq;
+    deltaZVertex = 3 * sq;
   }
 
-  const MeasurementTrackerEvent *measurementTracker = nullptr;
-  if(!measurementTrackerToken_.isUninitialized()) {
+  const MeasurementTrackerEvent* measurementTracker = nullptr;
+  if (!measurementTrackerToken_.isUninitialized()) {
     edm::Handle<MeasurementTrackerEvent> hmte;
     e.getByToken(measurementTrackerToken_, hmte);
     measurementTracker = hmte.product();
@@ -142,25 +143,25 @@ void SeedFilter::seeds(edm::Event& e, const edm::EventSetup& setup, const reco::
   // EtaPhiRegion and seeds for electron hypothesis
   //===============================================
 
-  TrackCharge aCharge = -1 ;
+  TrackCharge aCharge = -1;
   FreeTrajectoryState fts = FTSFromVertexToPointFactory::get(*theMagField, clusterPos, vtxPos, energy, aCharge);
 
-  RectangularEtaPhiTrackingRegion etaphiRegionMinus(fts.momentum(),
-                                                    vtxPos,
-                                                    ptmin_,
-                                                    originradius_,
-                                                    deltaZVertex,
-						    //                                                    deltaEta_,
-						    //                                                    deltaPhi_,-1);
-						    RectangularEtaPhiTrackingRegion::Margin(std::abs(deltaEta_),std::abs(deltaEta_)),
-						    RectangularEtaPhiTrackingRegion::Margin(std::abs(deltaPhi_),std::abs(deltaPhi_))
-						    ,hitsfactoryMode_,
-						    true, /*default in header*/
-						    measurementTracker
-						    );
+  RectangularEtaPhiTrackingRegion etaphiRegionMinus(
+      fts.momentum(),
+      vtxPos,
+      ptmin_,
+      originradius_,
+      deltaZVertex,
+      //                                                    deltaEta_,
+      //                                                    deltaPhi_,-1);
+      RectangularEtaPhiTrackingRegion::Margin(std::abs(deltaEta_), std::abs(deltaEta_)),
+      RectangularEtaPhiTrackingRegion::Margin(std::abs(deltaPhi_), std::abs(deltaPhi_)),
+      hitsfactoryMode_,
+      true, /*default in header*/
+      measurementTracker);
   combinatorialSeedGenerator->run(*seedColl, etaphiRegionMinus, e, setup);
 
-  for (unsigned int i = 0; i<seedColl->size(); ++i)
+  for (unsigned int i = 0; i < seedColl->size(); ++i)
     output->push_back((*seedColl)[i]);
 
   seedColl->clear();
@@ -169,26 +170,26 @@ void SeedFilter::seeds(edm::Event& e, const edm::EventSetup& setup, const reco::
   // EtaPhiRegion and seeds for positron hypothesis
   //===============================================
 
-  TrackCharge aChargep = 1 ;
+  TrackCharge aChargep = 1;
   fts = FTSFromVertexToPointFactory::get(*theMagField, clusterPos, vtxPos, energy, aChargep);
 
-  RectangularEtaPhiTrackingRegion etaphiRegionPlus(fts.momentum(),
-                                                   vtxPos,
-                                                   ptmin_,
-                                                   originradius_,
-                                                   deltaZVertex,
-						   //                                                   deltaEta_,
-						   //                                                   deltaPhi_,-1);
-						    RectangularEtaPhiTrackingRegion::Margin(std::abs(deltaEta_),std::abs(deltaEta_)),
-						    RectangularEtaPhiTrackingRegion::Margin(std::abs(deltaPhi_),std::abs(deltaPhi_))
-						    ,hitsfactoryMode_
-						   ,true, /*default in header*/
-						   measurementTracker
-						   );
+  RectangularEtaPhiTrackingRegion etaphiRegionPlus(
+      fts.momentum(),
+      vtxPos,
+      ptmin_,
+      originradius_,
+      deltaZVertex,
+      //                                                   deltaEta_,
+      //                                                   deltaPhi_,-1);
+      RectangularEtaPhiTrackingRegion::Margin(std::abs(deltaEta_), std::abs(deltaEta_)),
+      RectangularEtaPhiTrackingRegion::Margin(std::abs(deltaPhi_), std::abs(deltaPhi_)),
+      hitsfactoryMode_,
+      true, /*default in header*/
+      measurementTracker);
 
   combinatorialSeedGenerator->run(*seedColl, etaphiRegionPlus, e, setup);
 
-  for (unsigned int i = 0; i<seedColl->size(); ++i){
+  for (unsigned int i = 0; i < seedColl->size(); ++i) {
     TrajectorySeed::range r = (*seedColl)[i].recHits();
     // first Hit
     TrajectorySeed::const_iterator it = r.first;
@@ -198,7 +199,7 @@ void SeedFilter::seeds(edm::Event& e, const edm::EventSetup& setup, const reco::
     const TrackingRecHit* a2 = &(*it);
     // check if the seed is already in the collection
     bool isInCollection = false;
-    for(unsigned int j=0; j<output->size(); ++j) {
+    for (unsigned int j = 0; j < output->size(); ++j) {
       TrajectorySeed::range r = (*seedColl)[i].recHits();
       // first Hit
       TrajectorySeed::const_iterator it = r.first;
@@ -207,8 +208,8 @@ void SeedFilter::seeds(edm::Event& e, const edm::EventSetup& setup, const reco::
       it++;
       const TrackingRecHit* b2 = &(*it);
       if ((b1->sharesInput(a1, TrackingRecHit::all)) && (b2->sharesInput(a2, TrackingRecHit::all))) {
-	isInCollection = true;
-	break;
+        isInCollection = true;
+        break;
       }
     }
     if (!isInCollection)
@@ -217,4 +218,3 @@ void SeedFilter::seeds(edm::Event& e, const edm::EventSetup& setup, const reco::
 
   seedColl->clear();
 }
-

--- a/RecoEgamma/EgammaElectronAlgos/src/SiStripElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/SiStripElectronAlgo.cc
@@ -2,7 +2,7 @@
 //
 // Package:     EgammaElectronAlgos
 // Class  :     SiStripElectronAlgo
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -17,14 +17,12 @@
 #include "RecoEgamma/EgammaElectronAlgos/interface/SiStripElectronAlgo.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
 #include "DataFormats/TrajectorySeed/interface/PropagationDirection.h"
 #include "DataFormats/TrackerRecHit2D/interface/TrackingRecHitLessFromGlobalPosition.h"
 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
-
 
 //
 // constants, enums and typedefs
@@ -35,43 +33,35 @@
 //
 namespace {
   struct CompareHits {
-    CompareHits( const TrackingRecHitLessFromGlobalPosition& iLess ) :
-      less_(iLess) {}
-    bool operator()(const TrackingRecHit* iLHS, const TrackingRecHit* iRHS) {
-      return less_(*iLHS,*iRHS);
-    }
-	 
+    CompareHits(const TrackingRecHitLessFromGlobalPosition& iLess) : less_(iLess) {}
+    bool operator()(const TrackingRecHit* iLHS, const TrackingRecHit* iRHS) { return less_(*iLHS, *iRHS); }
+
     TrackingRecHitLessFromGlobalPosition less_;
   };
-}
-
+}  // namespace
 
 //
 // constructors and destructor
 //
 SiStripElectronAlgo::SiStripElectronAlgo(unsigned int maxHitsOnDetId,
-					 double originUncertainty,
-					 double phiBandWidth,
-					 double maxNormResid,
-					 unsigned int minHits,
-					 double maxReducedChi2)
-  : maxHitsOnDetId_(maxHitsOnDetId)
-  , originUncertainty_(originUncertainty)
-  , phiBandWidth_(phiBandWidth)
-  , maxNormResid_(maxNormResid)
-  , minHits_(minHits)
-  , maxReducedChi2_(maxReducedChi2)
-{
-}
+                                         double originUncertainty,
+                                         double phiBandWidth,
+                                         double maxNormResid,
+                                         unsigned int minHits,
+                                         double maxReducedChi2)
+    : maxHitsOnDetId_(maxHitsOnDetId),
+      originUncertainty_(originUncertainty),
+      phiBandWidth_(phiBandWidth),
+      maxNormResid_(maxNormResid),
+      minHits_(minHits),
+      maxReducedChi2_(maxReducedChi2) {}
 
 // SiStripElectronAlgo::SiStripElectronAlgo(const SiStripElectronAlgo& rhs)
 // {
 //    // do actual copying here;
 // }
 
-SiStripElectronAlgo::~SiStripElectronAlgo()
-{
-}
+SiStripElectronAlgo::~SiStripElectronAlgo() {}
 
 //
 // assignment operators
@@ -90,12 +80,11 @@ SiStripElectronAlgo::~SiStripElectronAlgo()
 //
 
 void SiStripElectronAlgo::prepareEvent(const edm::ESHandle<TrackerGeometry>& tracker,
-				       const edm::Handle<SiStripRecHit2DCollection>& rphiHits,
-				       const edm::Handle<SiStripRecHit2DCollection>& stereoHits,
-				       const edm::Handle<SiStripMatchedRecHit2DCollection>& matchedHits,
-				       const edm::ESHandle<MagneticField>& magneticField)
-{
-  LogDebug("") << " In prepareEvent " ; 
+                                       const edm::Handle<SiStripRecHit2DCollection>& rphiHits,
+                                       const edm::Handle<SiStripRecHit2DCollection>& stereoHits,
+                                       const edm::Handle<SiStripMatchedRecHit2DCollection>& matchedHits,
+                                       const edm::ESHandle<MagneticField>& magneticField) {
+  LogDebug("") << " In prepareEvent ";
 
   tracker_p_ = tracker.product();
   rphiHits_p_ = rphiHits.product();
@@ -114,236 +103,292 @@ void SiStripElectronAlgo::prepareEvent(const edm::ESHandle<TrackerGeometry>& tra
   matchedHitUsed_.clear();
 
   unsigned int counter = 0;
-  for (SiStripRecHit2DCollection::DataContainer::const_iterator it = rphiHits_p_->data().begin();  it != rphiHits_p_->data().end();  ++it) {
+  for (SiStripRecHit2DCollection::DataContainer::const_iterator it = rphiHits_p_->data().begin();
+       it != rphiHits_p_->data().end();
+       ++it) {
     rphiKey_[&(*it)] = counter;
     hitUsed_[&(*it)] = false;
     counter++;
   }
 
   counter = 0;
-  for (SiStripRecHit2DCollection::DataContainer::const_iterator it = stereoHits_p_->data().begin();  it != stereoHits_p_->data().end();  ++it) {
+  for (SiStripRecHit2DCollection::DataContainer::const_iterator it = stereoHits_p_->data().begin();
+       it != stereoHits_p_->data().end();
+       ++it) {
     stereoKey_[&(*it)] = counter;
     hitUsed_[&(*it)] = false;
     counter++;
   }
 
   counter = 0;
-  for (SiStripMatchedRecHit2DCollection::DataContainer::const_iterator it = matchedHits_p_->data().begin();  it != matchedHits_p_->data().end();  ++it) {
+  for (SiStripMatchedRecHit2DCollection::DataContainer::const_iterator it = matchedHits_p_->data().begin();
+       it != matchedHits_p_->data().end();
+       ++it) {
     matchedKey_[&(*it)] = counter;
     matchedHitUsed_[&(*it)] = false;
     counter++;
   }
-  
-  LogDebug("") << " Leaving prepareEvent " ;
+
+  LogDebug("") << " Leaving prepareEvent ";
 }
-
-
 
 // returns true iff an electron was found
 // inserts electrons and trackcandiates into electronOut and trackCandidateOut
 bool SiStripElectronAlgo::findElectron(reco::SiStripElectronCollection& electronOut,
-				       TrackCandidateCollection& trackCandidateOut,
-				       const reco::SuperClusterRef& superclusterIn,
-				       const TrackerTopology *tTopo)
-{
+                                       TrackCandidateCollection& trackCandidateOut,
+                                       const reco::SuperClusterRef& superclusterIn,
+                                       const TrackerTopology* tTopo) {
   // Try each of the two charge hypotheses, but only take one
   bool electronSuccess = projectPhiBand(-1., superclusterIn, tTopo);
-  bool positronSuccess = projectPhiBand( 1., superclusterIn, tTopo);
+  bool positronSuccess = projectPhiBand(1., superclusterIn, tTopo);
 
   // electron hypothesis did better than electron
-  if ((electronSuccess  &&  !positronSuccess)  ||
-      (electronSuccess  &&  positronSuccess  &&  redchi2_neg_ <= redchi2_pos_)) {
-      
+  if ((electronSuccess && !positronSuccess) || (electronSuccess && positronSuccess && redchi2_neg_ <= redchi2_pos_)) {
     // Initial uncertainty for tracking
     AlgebraicSymMatrix55 errors;  // makes 5x5 matrix, indexed from (0,0) to (44)
-    errors(0,0) = 3.;      // uncertainty**2 in 1/momentum
-    errors(1,1) = 0.01;    // uncertainty**2 in lambda (lambda == pi/2 - polar angle theta)
-    errors(2,2) = 0.0001;  // uncertainty**2 in phi
-    errors(3,3) = 0.01;    // uncertainty**2 in x_transverse (where x is in cm)
-    errors(4,4) = 0.01;    // uncertainty**2 in y_transverse (where y is in cm)
+    errors(0, 0) = 3.;            // uncertainty**2 in 1/momentum
+    errors(1, 1) = 0.01;          // uncertainty**2 in lambda (lambda == pi/2 - polar angle theta)
+    errors(2, 2) = 0.0001;        // uncertainty**2 in phi
+    errors(3, 3) = 0.01;          // uncertainty**2 in x_transverse (where x is in cm)
+    errors(4, 4) = 0.01;          // uncertainty**2 in y_transverse (where y is in cm)
 
-#ifdef EDM_ML_DEBUG 
+#ifdef EDM_ML_DEBUG
     // JED Debugging possible double hit sort problem
     std::ostringstream debugstr6;
-    debugstr6 << " HERE BEFORE SORT electron case " << " \n" ;
-    for (std::vector<const TrackingRecHit*>::iterator itHit=outputHits_neg_.begin(); 
-	 itHit != outputHits_neg_.end(); ++itHit) {
-      debugstr6 <<" HIT "<<((*itHit)->geographicalId()).rawId()<<" \n"
-		<<"    Local Position: "<<(*itHit)->localPosition()<<" \n"
-		<<"    Global Rho:  "
-		<<(((TrackingGeometry*)(tracker_p_))->idToDet((*itHit)->geographicalId())->surface().toGlobal((*itHit)->localPosition()).perp())
-		<<" Phi "
-		<<(((TrackingGeometry*)(tracker_p_))->idToDet((*itHit)->geographicalId())->surface().toGlobal((*itHit)->localPosition()).phi())
-		<< " Z "
-		<<(((TrackingGeometry*)(tracker_p_))->idToDet((*itHit)->geographicalId())->surface().toGlobal((*itHit)->localPosition()).z())<< " \n";
+    debugstr6 << " HERE BEFORE SORT electron case "
+              << " \n";
+    for (std::vector<const TrackingRecHit*>::iterator itHit = outputHits_neg_.begin(); itHit != outputHits_neg_.end();
+         ++itHit) {
+      debugstr6 << " HIT " << ((*itHit)->geographicalId()).rawId() << " \n"
+                << "    Local Position: " << (*itHit)->localPosition() << " \n"
+                << "    Global Rho:  "
+                << (((TrackingGeometry*)(tracker_p_))
+                        ->idToDet((*itHit)->geographicalId())
+                        ->surface()
+                        .toGlobal((*itHit)->localPosition())
+                        .perp())
+                << " Phi "
+                << (((TrackingGeometry*)(tracker_p_))
+                        ->idToDet((*itHit)->geographicalId())
+                        ->surface()
+                        .toGlobal((*itHit)->localPosition())
+                        .phi())
+                << " Z "
+                << (((TrackingGeometry*)(tracker_p_))
+                        ->idToDet((*itHit)->geographicalId())
+                        ->surface()
+                        .toGlobal((*itHit)->localPosition())
+                        .z())
+                << " \n";
     }
-    // end of dump 
-    
-    
-    
-    // JED call dump 
-    debugstr6 << " Calling sort alongMomentum " << " \n"; 
-#endif   
- 
-    std::sort(outputHits_neg_.begin(), outputHits_neg_.end(),
-    	      CompareHits(TrackingRecHitLessFromGlobalPosition(((TrackingGeometry*)(tracker_p_)), alongMomentum)));
-    
-#ifdef EDM_ML_DEBUG 
-    debugstr6 << " Done with sort " << " \n";
-    
-    debugstr6 << " HERE AFTER SORT electron case " << " \n";
-    for (std::vector<const TrackingRecHit*>::iterator itHit=outputHits_neg_.begin(); 
-	 itHit != outputHits_neg_.end(); ++itHit) {
-      debugstr6 <<" HIT "<<((*itHit)->geographicalId()).rawId()<<" \n"
-		<<"    Local Position: "<<(*itHit)->localPosition()<<" \n"
-		<<"    Global Rho:  "
-		<<(((TrackingGeometry*)(tracker_p_))->idToDet((*itHit)->geographicalId())->surface().toGlobal((*itHit)->localPosition()).perp())
-		<<" Phi "
-		<<(((TrackingGeometry*)(tracker_p_))->idToDet((*itHit)->geographicalId())->surface().toGlobal((*itHit)->localPosition()).phi())
-		<< " Z "
-		<<(((TrackingGeometry*)(tracker_p_))->idToDet((*itHit)->geographicalId())->surface().toGlobal((*itHit)->localPosition()).z())<< " \n";; 
-    }
-    // end of dump 
+    // end of dump
 
-    LogDebug("")<< debugstr6.str();
+    // JED call dump
+    debugstr6 << " Calling sort alongMomentum "
+              << " \n";
 #endif
-    
+
+    std::sort(outputHits_neg_.begin(),
+              outputHits_neg_.end(),
+              CompareHits(TrackingRecHitLessFromGlobalPosition(((TrackingGeometry*)(tracker_p_)), alongMomentum)));
+
+#ifdef EDM_ML_DEBUG
+    debugstr6 << " Done with sort "
+              << " \n";
+
+    debugstr6 << " HERE AFTER SORT electron case "
+              << " \n";
+    for (std::vector<const TrackingRecHit*>::iterator itHit = outputHits_neg_.begin(); itHit != outputHits_neg_.end();
+         ++itHit) {
+      debugstr6 << " HIT " << ((*itHit)->geographicalId()).rawId() << " \n"
+                << "    Local Position: " << (*itHit)->localPosition() << " \n"
+                << "    Global Rho:  "
+                << (((TrackingGeometry*)(tracker_p_))
+                        ->idToDet((*itHit)->geographicalId())
+                        ->surface()
+                        .toGlobal((*itHit)->localPosition())
+                        .perp())
+                << " Phi "
+                << (((TrackingGeometry*)(tracker_p_))
+                        ->idToDet((*itHit)->geographicalId())
+                        ->surface()
+                        .toGlobal((*itHit)->localPosition())
+                        .phi())
+                << " Z "
+                << (((TrackingGeometry*)(tracker_p_))
+                        ->idToDet((*itHit)->geographicalId())
+                        ->surface()
+                        .toGlobal((*itHit)->localPosition())
+                        .z())
+                << " \n";
+      ;
+    }
+    // end of dump
+
+    LogDebug("") << debugstr6.str();
+#endif
+
     //create an OwnVector needed by the classes which will be stored to the Event
     edm::OwnVector<TrackingRecHit> hits;
-    for(std::vector<const TrackingRecHit*>::iterator itHit =outputHits_neg_.begin();
-	itHit != outputHits_neg_.end();
-	++itHit) {
-      hits.push_back( (*itHit)->clone());
-      if( !(hitUsed_.find(*itHit) != hitUsed_.end()) ) {
-	LogDebug("") << " Assert failure " ;
-	assert(hitUsed_.find(*itHit) != hitUsed_.end());
+    for (std::vector<const TrackingRecHit*>::iterator itHit = outputHits_neg_.begin(); itHit != outputHits_neg_.end();
+         ++itHit) {
+      hits.push_back((*itHit)->clone());
+      if (!(hitUsed_.find(*itHit) != hitUsed_.end())) {
+        LogDebug("") << " Assert failure ";
+        assert(hitUsed_.find(*itHit) != hitUsed_.end());
       }
       hitUsed_[*itHit] = true;
     }
-    
-    TrajectoryStateOnSurface state(
-				   GlobalTrajectoryParameters(position_neg_, momentum_neg_, -1, magneticField_p_),
-				   CurvilinearTrajectoryError(errors),
-				   tracker_p_->idToDet(innerhit_neg_->geographicalId())->surface());
-    
-    
-    PTrajectoryStateOnDet const & PTraj = trajectoryStateTransform::persistentState(state, innerhit_neg_->geographicalId().rawId());
+
+    TrajectoryStateOnSurface state(GlobalTrajectoryParameters(position_neg_, momentum_neg_, -1, magneticField_p_),
+                                   CurvilinearTrajectoryError(errors),
+                                   tracker_p_->idToDet(innerhit_neg_->geographicalId())->surface());
+
+    PTrajectoryStateOnDet const& PTraj =
+        trajectoryStateTransform::persistentState(state, innerhit_neg_->geographicalId().rawId());
     TrajectorySeed trajectorySeed(PTraj, hits, alongMomentum);
     trackCandidateOut.push_back(TrackCandidate(hits, trajectorySeed, PTraj));
-    
+
     electronOut.push_back(reco::SiStripElectron(superclusterIn,
-						-1,
-						outputRphiHits_neg_,
-						outputStereoHits_neg_,
-						phiVsRSlope_neg_,
-						slope_neg_,
-						intercept_neg_ + superclusterIn->position().phi(),
-						chi2_neg_,
-						ndof_neg_,
-						correct_pT_neg_,
-						pZ_neg_,
-						zVsRSlope_neg_,
-						numberOfStereoHits_neg_,
-						numberOfBarrelRphiHits_neg_,
-						numberOfEndcapZphiHits_neg_));
-    
+                                                -1,
+                                                outputRphiHits_neg_,
+                                                outputStereoHits_neg_,
+                                                phiVsRSlope_neg_,
+                                                slope_neg_,
+                                                intercept_neg_ + superclusterIn->position().phi(),
+                                                chi2_neg_,
+                                                ndof_neg_,
+                                                correct_pT_neg_,
+                                                pZ_neg_,
+                                                zVsRSlope_neg_,
+                                                numberOfStereoHits_neg_,
+                                                numberOfBarrelRphiHits_neg_,
+                                                numberOfEndcapZphiHits_neg_));
+
     return true;
   }
-  
+
   // positron hypothesis did better than electron
-  if ((!electronSuccess  &&  positronSuccess)  ||
-      (electronSuccess  &&  positronSuccess  &&  redchi2_neg_ > redchi2_pos_)) {
-      
+  if ((!electronSuccess && positronSuccess) || (electronSuccess && positronSuccess && redchi2_neg_ > redchi2_pos_)) {
     // Initial uncertainty for tracking
     AlgebraicSymMatrix55 errors;  // same as abovr
-    errors(0,0) = 3.;      // uncertainty**2 in 1/momentum
-    errors(1,1) = 0.01;    // uncertainty**2 in lambda (lambda == pi/2 - polar angle theta)
-    errors(2,2) = 0.0001;  // uncertainty**2 in phi
-    errors(3,3) = 0.01;    // uncertainty**2 in x_transverse (where x is in cm)
-    errors(4,4) = 0.01;    // uncertainty**2 in y_transverse (where y is in cm)
+    errors(0, 0) = 3.;            // uncertainty**2 in 1/momentum
+    errors(1, 1) = 0.01;          // uncertainty**2 in lambda (lambda == pi/2 - polar angle theta)
+    errors(2, 2) = 0.0001;        // uncertainty**2 in phi
+    errors(3, 3) = 0.01;          // uncertainty**2 in x_transverse (where x is in cm)
+    errors(4, 4) = 0.01;          // uncertainty**2 in y_transverse (where y is in cm)
 
-#ifdef EDM_ML_DEBUG 
+#ifdef EDM_ML_DEBUG
     // JED Debugging possible double hit sort problem
     std::ostringstream debugstr7;
-    debugstr7 << " HERE BEFORE SORT Positron case " << " \n";
-    for (std::vector<const TrackingRecHit*>::iterator itHit = outputHits_pos_.begin(); 
-	 itHit != outputHits_pos_.end(); ++itHit) {
-      debugstr7 <<" HIT "<<((*itHit)->geographicalId()).rawId()<<" \n"
-		<<"    Local Position: "<<(*itHit)->localPosition()<<" \n"
-		<<"    Global Rho:  "
-		<<(((TrackingGeometry*)(tracker_p_))->idToDet((*itHit)->geographicalId())->surface().toGlobal((*itHit)->localPosition()).perp())
-		<<" Phi "
-		<<(((TrackingGeometry*)(tracker_p_))->idToDet((*itHit)->geographicalId())->surface().toGlobal((*itHit)->localPosition()).phi())
-		<< " Z "
-		<<(((TrackingGeometry*)(tracker_p_))->idToDet((*itHit)->geographicalId())->surface().toGlobal((*itHit)->localPosition()).z())<< " \n";
+    debugstr7 << " HERE BEFORE SORT Positron case "
+              << " \n";
+    for (std::vector<const TrackingRecHit*>::iterator itHit = outputHits_pos_.begin(); itHit != outputHits_pos_.end();
+         ++itHit) {
+      debugstr7 << " HIT " << ((*itHit)->geographicalId()).rawId() << " \n"
+                << "    Local Position: " << (*itHit)->localPosition() << " \n"
+                << "    Global Rho:  "
+                << (((TrackingGeometry*)(tracker_p_))
+                        ->idToDet((*itHit)->geographicalId())
+                        ->surface()
+                        .toGlobal((*itHit)->localPosition())
+                        .perp())
+                << " Phi "
+                << (((TrackingGeometry*)(tracker_p_))
+                        ->idToDet((*itHit)->geographicalId())
+                        ->surface()
+                        .toGlobal((*itHit)->localPosition())
+                        .phi())
+                << " Z "
+                << (((TrackingGeometry*)(tracker_p_))
+                        ->idToDet((*itHit)->geographicalId())
+                        ->surface()
+                        .toGlobal((*itHit)->localPosition())
+                        .z())
+                << " \n";
     }
-    // end of dump 
-    
-    debugstr7 << " Calling sort alongMomentum " << " \n"; 
+    // end of dump
+
+    debugstr7 << " Calling sort alongMomentum "
+              << " \n";
 #endif
-    
-    std::sort(outputHits_pos_.begin(), outputHits_pos_.end(),
-	      CompareHits(TrackingRecHitLessFromGlobalPosition(((TrackingGeometry*)(tracker_p_)), alongMomentum)));
-    
-#ifdef EDM_ML_DEBUG 
-    debugstr7 << " Done with sort " << " \n";
-    
+
+    std::sort(outputHits_pos_.begin(),
+              outputHits_pos_.end(),
+              CompareHits(TrackingRecHitLessFromGlobalPosition(((TrackingGeometry*)(tracker_p_)), alongMomentum)));
+
+#ifdef EDM_ML_DEBUG
+    debugstr7 << " Done with sort "
+              << " \n";
+
     // JED Debugging possible double hit sort problem
-    debugstr7 << " HERE AFTER SORT Positron case " << " \n";
-    for (std::vector<const TrackingRecHit*>::iterator itHit = outputHits_pos_.begin(); 
-	 itHit != outputHits_pos_.end(); ++itHit) {
-      debugstr7 <<" HIT "<<((*itHit)->geographicalId()).rawId()<<" \n"
-		<<"    Local Position: "<<(*itHit)->localPosition()<<" \n"
-		<<"    Global Rho:  "
-		<<(((TrackingGeometry*)(tracker_p_))->idToDet((*itHit)->geographicalId())->surface().toGlobal((*itHit)->localPosition()).perp())
-		<<" Phi "
-		<<(((TrackingGeometry*)(tracker_p_))->idToDet((*itHit)->geographicalId())->surface().toGlobal((*itHit)->localPosition()).phi())
-		<< " Z "
-		<<(((TrackingGeometry*)(tracker_p_))->idToDet((*itHit)->geographicalId())->surface().toGlobal((*itHit)->localPosition()).z())<< " \n"; 
+    debugstr7 << " HERE AFTER SORT Positron case "
+              << " \n";
+    for (std::vector<const TrackingRecHit*>::iterator itHit = outputHits_pos_.begin(); itHit != outputHits_pos_.end();
+         ++itHit) {
+      debugstr7 << " HIT " << ((*itHit)->geographicalId()).rawId() << " \n"
+                << "    Local Position: " << (*itHit)->localPosition() << " \n"
+                << "    Global Rho:  "
+                << (((TrackingGeometry*)(tracker_p_))
+                        ->idToDet((*itHit)->geographicalId())
+                        ->surface()
+                        .toGlobal((*itHit)->localPosition())
+                        .perp())
+                << " Phi "
+                << (((TrackingGeometry*)(tracker_p_))
+                        ->idToDet((*itHit)->geographicalId())
+                        ->surface()
+                        .toGlobal((*itHit)->localPosition())
+                        .phi())
+                << " Z "
+                << (((TrackingGeometry*)(tracker_p_))
+                        ->idToDet((*itHit)->geographicalId())
+                        ->surface()
+                        .toGlobal((*itHit)->localPosition())
+                        .z())
+                << " \n";
     }
-    // end of dump 
+    // end of dump
     LogDebug("") << debugstr7.str();
 #endif
 
     //create an OwnVector needed by the classes which will be stored to the Event
     edm::OwnVector<TrackingRecHit> hits;
-    for(std::vector<const TrackingRecHit*>::iterator itHit =outputHits_pos_.begin();
-	itHit != outputHits_pos_.end();
-	++itHit) {
-      hits.push_back( (*itHit)->clone());
+    for (std::vector<const TrackingRecHit*>::iterator itHit = outputHits_pos_.begin(); itHit != outputHits_pos_.end();
+         ++itHit) {
+      hits.push_back((*itHit)->clone());
       assert(hitUsed_.find(*itHit) != hitUsed_.end());
       hitUsed_[*itHit] = true;
     }
-    
-    TrajectoryStateOnSurface state(
-				   GlobalTrajectoryParameters(position_pos_, momentum_pos_, 1, magneticField_p_),
-				   CurvilinearTrajectoryError(errors),
-				   tracker_p_->idToDet(innerhit_pos_->geographicalId())->surface());
-    
-    
-    PTrajectoryStateOnDet const & PTraj = trajectoryStateTransform::persistentState(state, innerhit_pos_->geographicalId().rawId());
+
+    TrajectoryStateOnSurface state(GlobalTrajectoryParameters(position_pos_, momentum_pos_, 1, magneticField_p_),
+                                   CurvilinearTrajectoryError(errors),
+                                   tracker_p_->idToDet(innerhit_pos_->geographicalId())->surface());
+
+    PTrajectoryStateOnDet const& PTraj =
+        trajectoryStateTransform::persistentState(state, innerhit_pos_->geographicalId().rawId());
     TrajectorySeed trajectorySeed(PTraj, hits, alongMomentum);
     trackCandidateOut.push_back(TrackCandidate(hits, trajectorySeed, PTraj));
-    
+
     electronOut.push_back(reco::SiStripElectron(superclusterIn,
-						1,
-						outputRphiHits_pos_,
-						outputStereoHits_pos_,
-						phiVsRSlope_pos_,
-						slope_pos_,
-						intercept_pos_ + superclusterIn->position().phi(),
-						chi2_pos_,
-						ndof_pos_,
-						correct_pT_pos_,
-						pZ_pos_,
-						zVsRSlope_pos_,
-						numberOfStereoHits_pos_,
-						numberOfBarrelRphiHits_pos_,
-						numberOfEndcapZphiHits_pos_));
-    
+                                                1,
+                                                outputRphiHits_pos_,
+                                                outputStereoHits_pos_,
+                                                phiVsRSlope_pos_,
+                                                slope_pos_,
+                                                intercept_pos_ + superclusterIn->position().phi(),
+                                                chi2_pos_,
+                                                ndof_pos_,
+                                                correct_pT_pos_,
+                                                pZ_pos_,
+                                                zVsRSlope_pos_,
+                                                numberOfStereoHits_pos_,
+                                                numberOfBarrelRphiHits_pos_,
+                                                numberOfEndcapZphiHits_pos_));
+
     return true;
   }
-  
+
   return false;
 }
 
@@ -352,9 +397,9 @@ bool SiStripElectronAlgo::findElectron(reco::SiStripElectronCollection& electron
 // selects from stereo if stereo == true, rphi otherwise
 // selects from TID or TEC if endcap == true, TIB or TOB otherwise
 void SiStripElectronAlgo::coarseHitSelection(std::vector<const SiStripRecHit2D*>& hitPointersOut,
-					     const TrackerTopology *tTopo,
-					     bool stereo, bool endcap)
-{
+                                             const TrackerTopology* tTopo,
+                                             bool stereo,
+                                             bool endcap) {
   // This function is not time-efficient.  If you want to improve the
   // speed of the algorithm, you'll probably want to change this
   // function.  There may be a more efficienct way to extract hits,
@@ -365,7 +410,7 @@ void SiStripElectronAlgo::coarseHitSelection(std::vector<const SiStripRecHit2D*>
 
   // Loop over the detector ids
   SiStripRecHit2DCollection::const_iterator itdet = (stereo ? stereoHits_p_->begin() : rphiHits_p_->begin());
-  SiStripRecHit2DCollection::const_iterator eddet = (stereo ? stereoHits_p_->end()   : rphiHits_p_->end()  );
+  SiStripRecHit2DCollection::const_iterator eddet = (stereo ? stereoHits_p_->end() : rphiHits_p_->end());
   for (; itdet != eddet; ++itdet) {
     // Get the hits on this detector id
     SiStripRecHit2DCollection::DetSet hits = *itdet;
@@ -373,105 +418,106 @@ void SiStripElectronAlgo::coarseHitSelection(std::vector<const SiStripRecHit2D*>
 
     // Count the number of hits on this detector id
     unsigned int numberOfHits = hits.size();
-      
+
     // Only take the hits if there aren't too many
     // (Would it be better to loop only once, fill a temporary list,
     // and copy that if numberOfHits <= maxHitsOnDetId_?)
     if (numberOfHits <= maxHitsOnDetId_) {
-      for (SiStripRecHit2DCollection::DetSet::const_iterator hit = hits.begin();  
-           hit != hits.end();  ++hit) {
+      for (SiStripRecHit2DCollection::DetSet::const_iterator hit = hits.begin(); hit != hits.end(); ++hit) {
         // check that hit is valid first !
-	if(!(*hit).isValid()) {
-	  LogDebug("") << " InValid hit skipped in coarseHitSelection " << std::endl ;
-	  continue ;
-	}
+        if (!(*hit).isValid()) {
+          LogDebug("") << " InValid hit skipped in coarseHitSelection " << std::endl;
+          continue;
+        }
         std::string theDet = "null";
-        bool isStereoDet = false ;
-        if(tracker_p_->idToDetUnit(hit->geographicalId())->type().subDetector() == GeomDetEnumerators::TIB) { 
-          theDet = "TIB" ;
-          if(tTopo->tibStereo(id)==1) { isStereoDet = true ; }
-        } else if
-          (tracker_p_->idToDetUnit(hit->geographicalId())->type().subDetector() == GeomDetEnumerators::TOB) { 
-          theDet = "TOB" ;
-          if(tTopo->tobStereo(id)==1) { isStereoDet = true ; }
-        }else if
-          (tracker_p_->idToDetUnit(hit->geographicalId())->type().subDetector() == GeomDetEnumerators::TID) { 
-          theDet = "TID" ;
-          if(tTopo->tidStereo(id)==1) { isStereoDet = true ; }
-        }else if
-          (tracker_p_->idToDetUnit(hit->geographicalId())->type().subDetector() == GeomDetEnumerators::TEC) { 
-          theDet = "TEC" ;
-          if(tTopo->tecStereo(id)==1) { isStereoDet = true ; }
+        bool isStereoDet = false;
+        if (tracker_p_->idToDetUnit(hit->geographicalId())->type().subDetector() == GeomDetEnumerators::TIB) {
+          theDet = "TIB";
+          if (tTopo->tibStereo(id) == 1) {
+            isStereoDet = true;
+          }
+        } else if (tracker_p_->idToDetUnit(hit->geographicalId())->type().subDetector() == GeomDetEnumerators::TOB) {
+          theDet = "TOB";
+          if (tTopo->tobStereo(id) == 1) {
+            isStereoDet = true;
+          }
+        } else if (tracker_p_->idToDetUnit(hit->geographicalId())->type().subDetector() == GeomDetEnumerators::TID) {
+          theDet = "TID";
+          if (tTopo->tidStereo(id) == 1) {
+            isStereoDet = true;
+          }
+        } else if (tracker_p_->idToDetUnit(hit->geographicalId())->type().subDetector() == GeomDetEnumerators::TEC) {
+          theDet = "TEC";
+          if (tTopo->tecStereo(id) == 1) {
+            isStereoDet = true;
+          }
         } else {
-          LogDebug("") << " UHOH BIG PROBLEM - Unrecognized SI Layer" ;
-          LogDebug("") << " Det "<< theDet ;
-          assert(1!=1) ;
+          LogDebug("") << " UHOH BIG PROBLEM - Unrecognized SI Layer";
+          LogDebug("") << " Det " << theDet;
+          assert(1 != 1);
         }
 
-	if ((endcap  &&  stereo && (theDet=="TID" || theDet== "TEC") && isStereoDet ) ||
-            (endcap  &&  !stereo && (theDet=="TID" || theDet== "TEC") && !isStereoDet )  ||
-            (!endcap  && stereo && (theDet=="TIB" || theDet=="TOB") &&  isStereoDet )    ||
-            (!endcap  &&  !stereo && (theDet=="TIB" || theDet=="TOB" )&& !isStereoDet )
-            ) {  
-              
+        if ((endcap && stereo && (theDet == "TID" || theDet == "TEC") && isStereoDet) ||
+            (endcap && !stereo && (theDet == "TID" || theDet == "TEC") && !isStereoDet) ||
+            (!endcap && stereo && (theDet == "TIB" || theDet == "TOB") && isStereoDet) ||
+            (!endcap && !stereo && (theDet == "TIB" || theDet == "TOB") && !isStereoDet)) {
+          hitPointersOut.push_back(&(*hit));
 
-	  hitPointersOut.push_back(&(*hit));
-
-	} // end if this is the right subdetector
-      } // end loop over hits
-    } // end if this detector id doesn't have too many hits on it
-  } // end loop over detector ids
+        }  // end if this is the right subdetector
+      }    // end loop over hits
+    }      // end if this detector id doesn't have too many hits on it
+  }        // end loop over detector ids
 }
 
 // select all matched hits for now
 
-void SiStripElectronAlgo::coarseMatchedHitSelection(std::vector<const SiStripMatchedRecHit2D*>& coarseMatchedHitPointersOut)
-{
-  
+void SiStripElectronAlgo::coarseMatchedHitSelection(
+    std::vector<const SiStripMatchedRecHit2D*>& coarseMatchedHitPointersOut) {
   // Loop over the detector ids
   SiStripMatchedRecHit2DCollection::const_iterator itdet = matchedHits_p_->begin(), eddet = matchedHits_p_->end();
   for (; itdet != eddet; ++itdet) {
-    
     // Get the hits on this detector id
-    SiStripMatchedRecHit2DCollection::DetSet hits = *itdet ;
-    
+    SiStripMatchedRecHit2DCollection::DetSet hits = *itdet;
+
     // Count the number of hits on this detector id
     unsigned int numberOfHits = 0;
-    for (SiStripMatchedRecHit2DCollection::DetSet::const_iterator hit = hits.begin();  hit != hits.end();  ++hit) {
-      if ( !((hit->geographicalId()).subdetId() == StripSubdetector::TIB) &&
-           !( (hit->geographicalId()).subdetId() == StripSubdetector::TOB )) { break;}
+    for (SiStripMatchedRecHit2DCollection::DetSet::const_iterator hit = hits.begin(); hit != hits.end(); ++hit) {
+      if (!((hit->geographicalId()).subdetId() == StripSubdetector::TIB) &&
+          !((hit->geographicalId()).subdetId() == StripSubdetector::TOB)) {
+        break;
+      }
       numberOfHits++;
-      if (numberOfHits > maxHitsOnDetId_) { break; }
+      if (numberOfHits > maxHitsOnDetId_) {
+        break;
+      }
     }
-    
+
     // Only take the hits if there aren't too many
     if (numberOfHits <= maxHitsOnDetId_) {
-      for (SiStripMatchedRecHit2DCollection::DetSet::const_iterator hit = hits.begin();  hit != hits.end();  ++hit) {
-	if(!(*hit).isValid()) {
-	  LogDebug("") << " InValid hit skipped in coarseMatchedHitSelection " << std::endl ;
-	  continue ;
-	}
-        if ( !((hit->geographicalId()).subdetId() == StripSubdetector::TIB) &&
-             !( (hit->geographicalId()).subdetId() == StripSubdetector::TOB )) { break;}
-        
+      for (SiStripMatchedRecHit2DCollection::DetSet::const_iterator hit = hits.begin(); hit != hits.end(); ++hit) {
+        if (!(*hit).isValid()) {
+          LogDebug("") << " InValid hit skipped in coarseMatchedHitSelection " << std::endl;
+          continue;
+        }
+        if (!((hit->geographicalId()).subdetId() == StripSubdetector::TIB) &&
+            !((hit->geographicalId()).subdetId() == StripSubdetector::TOB)) {
+          break;
+        }
+
         coarseMatchedHitPointersOut.push_back(&(*hit));
-      } // end loop over hits
-      
-    } // end if this detector id doesn't have too many hits on it
-  } // end loop over detector ids
-  
+      }  // end loop over hits
 
-}// end of matchedHitSelection
+    }  // end if this detector id doesn't have too many hits on it
+  }    // end loop over detector ids
 
-
-
+}  // end of matchedHitSelection
 
 // projects a phi band of width phiBandWidth_ from supercluster into tracker (given a chargeHypothesis)
 // fills *_pos_ or *_neg_ member data with the results
 // returns true iff the electron/positron passes cuts
-bool SiStripElectronAlgo::projectPhiBand(float chargeHypothesis, const reco::SuperClusterRef& superclusterIn,
-					 const TrackerTopology *tTopo)
-{
+bool SiStripElectronAlgo::projectPhiBand(float chargeHypothesis,
+                                         const reco::SuperClusterRef& superclusterIn,
+                                         const TrackerTopology* tTopo) {
   // This algorithm projects a phi band into the tracker three times:
   // (a) for all stereo hits, (b) for barrel rphi hits, and (c) for
   // endcap zphi hits.  While accumulating stereo hits in step (a),
@@ -481,32 +527,31 @@ bool SiStripElectronAlgo::projectPhiBand(float chargeHypothesis, const reco::Sup
   // and we can convert the z of zphi hits into r to apply the phi
   // band cut.  (We don't take advantage of the endcap strips'
   // segmentation in r.)
-  // 
+  //
   // As we project a phi band into the tracker, we count hits within
   // that band and performs a linear fit for phi vs r.  The number of
   // hits and reduced chi^2 from the fit are used to select a good
   // candidate.
 
   // set limits on Si hits - smallest error that makes sense = 1 micron ?
-  static const double rphiHitSmallestError = 0.0001 ;
-  static const double stereoHitSmallestError = 0.0001 ;
-  //not used since endcap is not implemented  
+  static const double rphiHitSmallestError = 0.0001;
+  static const double stereoHitSmallestError = 0.0001;
+  //not used since endcap is not implemented
   // static const double zphiHitSmallestError = 0.0001 ;
 
-
-  static const double stereoPitchAngle = 0.100 ; // stereo angle in rad
-  static const double cos2SiPitchAngle = cos(stereoPitchAngle)*cos(stereoPitchAngle) ;
-  static const double sin2SiPitchAngle = sin(stereoPitchAngle)*sin(stereoPitchAngle) ;
+  static const double stereoPitchAngle = 0.100;  // stereo angle in rad
+  static const double cos2SiPitchAngle = cos(stereoPitchAngle) * cos(stereoPitchAngle);
+  static const double sin2SiPitchAngle = sin(stereoPitchAngle) * sin(stereoPitchAngle);
   // overall misalignment fudge to be added in quad to position errors.
   // this is a rough approx to values reported in tracking meet 5/16/2007
-  static const double rphiErrFudge = 0.0200 ;
-  static const double stereoErrFudge = 0.0200 ;
+  static const double rphiErrFudge = 0.0200;
+  static const double stereoErrFudge = 0.0200;
 
   // max chi2 of a hit on an SiDet relative to the prediction
-  static const double chi2HitMax = 25.0 ;
+  static const double chi2HitMax = 25.0;
 
   // Minimum number of hits to consider on a candidate
-  static const unsigned int nHitsLeftMinimum = 3  ;
+  static const unsigned int nHitsLeftMinimum = 3;
 
   // Create and fill vectors of pointers to hits
   std::vector<const SiStripRecHit2D*> stereoHits;
@@ -514,32 +559,35 @@ bool SiStripElectronAlgo::projectPhiBand(float chargeHypothesis, const reco::Sup
   std::vector<const SiStripRecHit2D*> zphiEndcapHits;
 
   //                                 stereo? endcap?
-  coarseHitSelection(stereoHits, tTopo,    true,   false);
+  coarseHitSelection(stereoHits, tTopo, true, false);
 
   // skip endcap stereo for now
   //  LogDebug("") << " Getting endcap stereo hits " ;
   // coarseHitSelection(stereoHits,     true,   true);
 
   std::ostringstream debugstr1;
-  debugstr1 << " Getting barrel rphi hits " << " \n" ;
+  debugstr1 << " Getting barrel rphi hits "
+            << " \n";
 
-  coarseHitSelection(rphiBarrelHits, tTopo, false,  false);
+  coarseHitSelection(rphiBarrelHits, tTopo, false, false);
 
   //  LogDebug("") << " Getting endcap zphi hits " ;
   //  coarseHitSelection(zphiEndcapHits, false,  true);
 
-  debugstr1 << " Getting matched hits "  << " \n" ;
+  debugstr1 << " Getting matched hits "
+            << " \n";
   std::vector<const SiStripMatchedRecHit2D*> matchedHits;
   coarseMatchedHitSelection(matchedHits);
 
-
   // Determine how to project from the supercluster into the tracker
   double energy = superclusterIn->energy();
-  double pT = energy * superclusterIn->position().rho()/sqrt(superclusterIn->x()*superclusterIn->x() +
-							     superclusterIn->y()*superclusterIn->y() +
-							     superclusterIn->z()*superclusterIn->z());
+  double pT = energy * superclusterIn->position().rho() /
+              sqrt(superclusterIn->x() * superclusterIn->x() + superclusterIn->y() * superclusterIn->y() +
+                   superclusterIn->z() * superclusterIn->z());
   // cf Jackson p. 581-2, a little geometry
-  double phiVsRSlope = -3.00e-3 * chargeHypothesis * magneticField_p_->inTesla(GlobalPoint(superclusterIn->x(), superclusterIn->y(), 0.)).z() / pT / 2.;
+  double phiVsRSlope = -3.00e-3 * chargeHypothesis *
+                       magneticField_p_->inTesla(GlobalPoint(superclusterIn->x(), superclusterIn->y(), 0.)).z() / pT /
+                       2.;
 
   // Shorthand for supercluster radius, z
   const double scr = superclusterIn->position().rho();
@@ -558,228 +606,212 @@ bool SiStripElectronAlgo::projectPhiBand(float chargeHypothesis, const reco::Sup
   double zSlopeFitNumer = 0.;
   double zSlopeFitDenom = 0.;
 
-  
-  debugstr1 << " There are a total of " << stereoHits.size()  << " stereoHits in this event " << " \n" 
-	    << " There are a total of " <<  rphiBarrelHits.size() << " rphiBarrelHits in this event " << " \n"
-	    << " There are a total of " <<  zphiEndcapHits.size() << " zphiEndcapHits in this event " << " \n\n";
+  debugstr1 << " There are a total of " << stereoHits.size() << " stereoHits in this event "
+            << " \n"
+            << " There are a total of " << rphiBarrelHits.size() << " rphiBarrelHits in this event "
+            << " \n"
+            << " There are a total of " << zphiEndcapHits.size() << " zphiEndcapHits in this event "
+            << " \n\n";
 
+  LogDebug("") << debugstr1.str();
 
-  LogDebug("") << debugstr1.str() ;
-  
   /////////////////
-
 
   // Loop over all matched hits
   // make a list of good matched rechits.
   // in the stereo and rphi loops check to see if the hit is associated with a matchedhit
-  LogDebug("") << " Loop over matched hits " << " \n";
+  LogDebug("") << " Loop over matched hits "
+               << " \n";
 
-  for (std::vector<const SiStripMatchedRecHit2D*>::const_iterator hit = matchedHits.begin() ;
-       hit != matchedHits.end() ; ++ hit) {
-    
+  for (std::vector<const SiStripMatchedRecHit2D*>::const_iterator hit = matchedHits.begin(); hit != matchedHits.end();
+       ++hit) {
     assert(matchedHitUsed_.find(*hit) != matchedHitUsed_.end());
 
     if (!matchedHitUsed_[*hit]) {
-
       // Calculate the 3-D position of this hit
       GlobalPoint position = tracker_p_->idToDet((*hit)->geographicalId())->surface().toGlobal((*hit)->localPosition());
-      double r = sqrt(position.x()*position.x() + position.y()*position.y());
+      double r = sqrt(position.x() * position.x() + position.y() * position.y());
       double phi = unwrapPhi(position.phi() - superclusterIn->position().phi());  // phi is relative to supercluster
       double z = position.z();
 
       // Cut a triangle in the z-r plane using the supercluster's eta/dip angle information
       // and the fact that the electron originated *near* the origin
-      if ((-originUncertainty_ + (scz + originUncertainty_)*(r/scr)) < z  &&  z < (originUncertainty_ + (scz - originUncertainty_)*(r/scr))) {
-	 
-	// Cut a narrow band around the supercluster's projection in phi
-	if (unwrapPhi((r-scr)*phiVsRSlope - phiBandWidth_) < phi  &&  phi < unwrapPhi((r-scr)*phiVsRSlope + phiBandWidth_)) {
-	 
-
-	  matcheduselist.push_back(true);
+      if ((-originUncertainty_ + (scz + originUncertainty_) * (r / scr)) < z &&
+          z < (originUncertainty_ + (scz - originUncertainty_) * (r / scr))) {
+        // Cut a narrow band around the supercluster's projection in phi
+        if (unwrapPhi((r - scr) * phiVsRSlope - phiBandWidth_) < phi &&
+            phi < unwrapPhi((r - scr) * phiVsRSlope + phiBandWidth_)) {
+          matcheduselist.push_back(true);
           matchedhitlist.push_back(*hit);
-	  
 
+          // Use this hit to fit z(r)
+          zSlopeFitNumer += -(scr - r) * (z - scz);
+          zSlopeFitDenom += (scr - r) * (scr - r);
 
-	  // Use this hit to fit z(r)
-	  zSlopeFitNumer += -(scr - r) * (z - scz);
-	  zSlopeFitDenom += (scr - r) * (scr - r);
-	    
-	} // end cut on phi band
-      } // end cut on electron originating *near* the origin
-    } // end assign disjoint sets of hits to electrons
-  } // end loop over matched hits
+        }  // end cut on phi band
+      }    // end cut on electron originating *near* the origin
+    }      // end assign disjoint sets of hits to electrons
+  }        // end loop over matched hits
 
   // Calculate the linear fit for z(r)
   double zVsRSlope;
   if (zSlopeFitDenom > 0.) {
     zVsRSlope = zSlopeFitNumer / zSlopeFitDenom;
-  }
-  else {
+  } else {
     // zVsRSlope assumes electron is from origin if there were no stereo hits
-    zVsRSlope = scz/scr;
+    zVsRSlope = scz / scr;
   }
 
   //  // Loop over all stereo hits
-  LogDebug("") << " Loop over stereo hits" << " \n";
+  LogDebug("") << " Loop over stereo hits"
+               << " \n";
 
   // check if the stereo hit is matched to one of the matched hit
   unsigned int numberOfStereoHits = 0;
-  for (std::vector<const SiStripRecHit2D*>::const_iterator hit = stereoHits.begin();  hit != stereoHits.end();  ++hit) {
+  for (std::vector<const SiStripRecHit2D*>::const_iterator hit = stereoHits.begin(); hit != stereoHits.end(); ++hit) {
     assert(hitUsed_.find(*hit) != hitUsed_.end());
 
     // Calculate the 3-D position of this hit
     GlobalPoint position = tracker_p_->idToDet((*hit)->geographicalId())->surface().toGlobal((*hit)->localPosition());
-    double r_stereo = sqrt(position.x()*position.x() + position.y()*position.y());
-    double phi_stereo = unwrapPhi(position.phi() - superclusterIn->position().phi());  // phi is relative to supercluster
+    double r_stereo = sqrt(position.x() * position.x() + position.y() * position.y());
+    double phi_stereo =
+        unwrapPhi(position.phi() - superclusterIn->position().phi());  // phi is relative to supercluster
     //    double z_stereo = position.z();
 
     // stereo is has a pitch of 100 mrad - so consider both components
-    double r_stereo_err = sqrt((*hit)->localPositionError().xx()*cos2SiPitchAngle +
-                               (*hit)->localPositionError().yy()*sin2SiPitchAngle ) ; 
-
-
+    double r_stereo_err = sqrt((*hit)->localPositionError().xx() * cos2SiPitchAngle +
+                               (*hit)->localPositionError().yy() * sin2SiPitchAngle);
 
     // make sure that the error for this hit is sensible, ie > 1 micron
     // otherwise skip this hit
-    if(r_stereo_err > stereoHitSmallestError ) {
-      r_stereo_err = sqrt(r_stereo_err*r_stereo_err+stereoErrFudge*stereoErrFudge);
- 
-      OmniClusterRef const & stereocluster=(*hit)->omniClusterRef();
-    
-      bool thisHitIsMatched = false ;
+    if (r_stereo_err > stereoHitSmallestError) {
+      r_stereo_err = sqrt(r_stereo_err * r_stereo_err + stereoErrFudge * stereoErrFudge);
+
+      OmniClusterRef const& stereocluster = (*hit)->omniClusterRef();
+
+      bool thisHitIsMatched = false;
 
       if (!hitUsed_[*hit]) {
- 
-	unsigned int matcheduselist_size = matcheduselist.size();
-	for (unsigned int i = 0;  i < matcheduselist_size;  i++) {
-	  if (matcheduselist[i]) {
-            OmniClusterRef const &  mystereocluster = matchedhitlist[i]->stereoClusterRef();
-	    if( stereocluster == mystereocluster ) {
-	      thisHitIsMatched = true ;
-	      //    LogDebug("")<< "     This hit is matched " << tracker_p_->idToDet(matchedhitlist[i]->stereoHit()->geographicalId())->surface().toGlobal(matchedhitlist[i]->stereoHit()->localPosition()) << std::endl;
-	      //      break ;
-	    }
-	  } // check if matcheduselist okay 
-	}// loop over matched hits 
-      
-	if(thisHitIsMatched) {
-	  // Use this hit to fit phi(r)
-	  uselist.push_back(true);
-	  rlist.push_back(r_stereo);
-	  philist.push_back(phi_stereo);
-	  w2list.push_back(1./(r_stereo_err/r_stereo)/(r_stereo_err/r_stereo));  // weight**2 == 1./uncertainty**2
-	  typelist.push_back(0);
-	  hitlist.push_back(*hit);
-	} // thisHitIsMatched
-      } //  if(!hitUsed)
+        unsigned int matcheduselist_size = matcheduselist.size();
+        for (unsigned int i = 0; i < matcheduselist_size; i++) {
+          if (matcheduselist[i]) {
+            OmniClusterRef const& mystereocluster = matchedhitlist[i]->stereoClusterRef();
+            if (stereocluster == mystereocluster) {
+              thisHitIsMatched = true;
+              //    LogDebug("")<< "     This hit is matched " << tracker_p_->idToDet(matchedhitlist[i]->stereoHit()->geographicalId())->surface().toGlobal(matchedhitlist[i]->stereoHit()->localPosition()) << std::endl;
+              //      break ;
+            }
+          }  // check if matcheduselist okay
+        }    // loop over matched hits
 
-    } //  end of check on hit position error size 
+        if (thisHitIsMatched) {
+          // Use this hit to fit phi(r)
+          uselist.push_back(true);
+          rlist.push_back(r_stereo);
+          philist.push_back(phi_stereo);
+          w2list.push_back(1. / (r_stereo_err / r_stereo) /
+                           (r_stereo_err / r_stereo));  // weight**2 == 1./uncertainty**2
+          typelist.push_back(0);
+          hitlist.push_back(*hit);
+        }  // thisHitIsMatched
+      }    //  if(!hitUsed)
 
-  } // end loop over stereo hits
-  
-  LogDebug("") << " There are " << uselist.size()  << " good hits after stereo loop "  ;
- 
+    }  //  end of check on hit position error size
+
+  }  // end loop over stereo hits
+
+  LogDebug("") << " There are " << uselist.size() << " good hits after stereo loop ";
 
   // Loop over barrel rphi hits
-  LogDebug("") << " Looping over barrel rphi hits " ;
-  unsigned int rphiMatchedCounter = 0 ;
-  unsigned int rphiUnMatchedCounter = 0 ;
+  LogDebug("") << " Looping over barrel rphi hits ";
+  unsigned int rphiMatchedCounter = 0;
+  unsigned int rphiUnMatchedCounter = 0;
   unsigned int numberOfBarrelRphiHits = 0;
-  for (std::vector<const SiStripRecHit2D*>::const_iterator hit = rphiBarrelHits.begin();  hit != rphiBarrelHits.end();  ++hit) {
+  for (std::vector<const SiStripRecHit2D*>::const_iterator hit = rphiBarrelHits.begin(); hit != rphiBarrelHits.end();
+       ++hit) {
     assert(hitUsed_.find(*hit) != hitUsed_.end());
     // Calculate the 2.5-D position of this hit
     GlobalPoint position = tracker_p_->idToDet((*hit)->geographicalId())->surface().toGlobal((*hit)->localPosition());
-    double r = sqrt(position.x()*position.x() + position.y()*position.y());
+    double r = sqrt(position.x() * position.x() + position.y() * position.y());
     double phi = unwrapPhi(position.phi() - superclusterIn->position().phi());  // phi is relative to supercluster
     double z = position.z();
-    double r_mono_err = sqrt((*hit)->localPositionError().xx()) ;
+    double r_mono_err = sqrt((*hit)->localPositionError().xx());
 
     // only consider hits with errors that make sense
-    if( r_mono_err > rphiHitSmallestError) {
+    if (r_mono_err > rphiHitSmallestError) {
       // inflate the reported error
-      r_mono_err=sqrt(r_mono_err*r_mono_err+rphiErrFudge*rphiErrFudge);
+      r_mono_err = sqrt(r_mono_err * r_mono_err + rphiErrFudge * rphiErrFudge);
 
-      OmniClusterRef const & monocluster=(*hit)->omniClusterRef();
-    
+      OmniClusterRef const& monocluster = (*hit)->omniClusterRef();
 
       if (!hitUsed_[*hit]) {
-	if( (tracker_p_->idToDetUnit((*hit)->geographicalId())->type().subDetector() == GeomDetEnumerators::TIB  && 
-	     (tTopo->tibLayer((*hit)->geographicalId())==1 || tTopo->tibLayer((*hit)->geographicalId())==2)) || 
-	    (tracker_p_->idToDetUnit((*hit)->geographicalId())->type().subDetector() == GeomDetEnumerators::TOB  
-	     && (tTopo->tobLayer((*hit)->geographicalId())==1 || tTopo->tobLayer((*hit)->geographicalId())==2)) ) {
-	  bool thisHitIsMatched = false ;
-	  unsigned int matcheduselist_size = matcheduselist.size();
-	  for (unsigned int i = 0;  i < matcheduselist_size;  i++) {
-	    if (matcheduselist[i]) {
-              OmniClusterRef const &  mymonocluster = matchedhitlist[i]->monoClusterRef();
-	      if( monocluster == mymonocluster ) {
-		thisHitIsMatched = true ;
-	      } 
-	    } // check if matcheduselist okay 
-	  }// loop over matched hits 
-        
-        
-	  if( thisHitIsMatched ) {
-	    // Use this hit to fit phi(r)
-	    uselist.push_back(true);
-	    rlist.push_back(r);
-	    philist.push_back(phi);
-	    w2list.push_back(1./(r_mono_err/r)/(r_mono_err/r));  // weight**2 == 1./uncertainty**2
-	    typelist.push_back(1);
-	    hitlist.push_back(*hit);
-	    rphiMatchedCounter++;
-	  } // end of matched hit check
+        if ((tracker_p_->idToDetUnit((*hit)->geographicalId())->type().subDetector() == GeomDetEnumerators::TIB &&
+             (tTopo->tibLayer((*hit)->geographicalId()) == 1 || tTopo->tibLayer((*hit)->geographicalId()) == 2)) ||
+            (tracker_p_->idToDetUnit((*hit)->geographicalId())->type().subDetector() == GeomDetEnumerators::TOB &&
+             (tTopo->tobLayer((*hit)->geographicalId()) == 1 || tTopo->tobLayer((*hit)->geographicalId()) == 2))) {
+          bool thisHitIsMatched = false;
+          unsigned int matcheduselist_size = matcheduselist.size();
+          for (unsigned int i = 0; i < matcheduselist_size; i++) {
+            if (matcheduselist[i]) {
+              OmniClusterRef const& mymonocluster = matchedhitlist[i]->monoClusterRef();
+              if (monocluster == mymonocluster) {
+                thisHitIsMatched = true;
+              }
+            }  // check if matcheduselist okay
+          }    // loop over matched hits
 
-	} else {
+          if (thisHitIsMatched) {
+            // Use this hit to fit phi(r)
+            uselist.push_back(true);
+            rlist.push_back(r);
+            philist.push_back(phi);
+            w2list.push_back(1. / (r_mono_err / r) / (r_mono_err / r));  // weight**2 == 1./uncertainty**2
+            typelist.push_back(1);
+            hitlist.push_back(*hit);
+            rphiMatchedCounter++;
+          }  // end of matched hit check
 
+        } else {
+          // The expected z position of this hit, according to the z(r) fit
+          double zFit = zVsRSlope * (r - scr) + scz;
 
-	  // The expected z position of this hit, according to the z(r) fit
-	  double zFit = zVsRSlope * (r - scr) + scz;
-        
-	  // Cut on the Z of the strip
-	  // TIB strips are 11 cm long, TOB strips are 19 cm long (can I get these from a function?)
-	  if ((tracker_p_->idToDetUnit((*hit)->geographicalId())->type().subDetector() == GeomDetEnumerators::TIB  && 
-	       std::abs(z - zFit) < 12.)  ||
-	      (tracker_p_->idToDetUnit((*hit)->geographicalId())->type().subDetector() == GeomDetEnumerators::TOB  && 
-	       std::abs(z - zFit) < 20.)    ) {
-          
-	    // Cut a narrow band around the supercluster's projection in phi
-	    if (unwrapPhi((r-scr)*phiVsRSlope - phiBandWidth_) < phi  &&  phi < unwrapPhi((r-scr)*phiVsRSlope + phiBandWidth_)) {
-            
-	      // Use this hit to fit phi(r)
-	      uselist.push_back(true);
-	      rlist.push_back(r);
-	      philist.push_back(phi);
-	      w2list.push_back(1./(r_mono_err/r)/(r_mono_err/r));  // weight**2 == 1./uncertainty**2
-	      typelist.push_back(1);
-	      hitlist.push_back(*hit);
-	      rphiUnMatchedCounter++;
-            
-	    } // end cut on phi band
-	  } // end cut on strip z
-	} // loop over TIB/TOB layer 1,2 
-      } // end assign disjoint sets of hits to electrons
-    } // end of check on rphi hit position error size
-  } // end loop over barrel rphi hits
+          // Cut on the Z of the strip
+          // TIB strips are 11 cm long, TOB strips are 19 cm long (can I get these from a function?)
+          if ((tracker_p_->idToDetUnit((*hit)->geographicalId())->type().subDetector() == GeomDetEnumerators::TIB &&
+               std::abs(z - zFit) < 12.) ||
+              (tracker_p_->idToDetUnit((*hit)->geographicalId())->type().subDetector() == GeomDetEnumerators::TOB &&
+               std::abs(z - zFit) < 20.)) {
+            // Cut a narrow band around the supercluster's projection in phi
+            if (unwrapPhi((r - scr) * phiVsRSlope - phiBandWidth_) < phi &&
+                phi < unwrapPhi((r - scr) * phiVsRSlope + phiBandWidth_)) {
+              // Use this hit to fit phi(r)
+              uselist.push_back(true);
+              rlist.push_back(r);
+              philist.push_back(phi);
+              w2list.push_back(1. / (r_mono_err / r) / (r_mono_err / r));  // weight**2 == 1./uncertainty**2
+              typelist.push_back(1);
+              hitlist.push_back(*hit);
+              rphiUnMatchedCounter++;
 
-  LogDebug("") << " There are " << rphiMatchedCounter <<" matched rphi hits"; 
-  LogDebug("") << " There are " << rphiUnMatchedCounter <<" unmatched rphi hits";
-  LogDebug("") << " There are " << uselist.size() << " good stereo+rphi hits " ;
+            }  // end cut on phi band
+          }    // end cut on strip z
+        }      // loop over TIB/TOB layer 1,2
+      }        // end assign disjoint sets of hits to electrons
+    }          // end of check on rphi hit position error size
+  }            // end loop over barrel rphi hits
 
-
-
-
-
+  LogDebug("") << " There are " << rphiMatchedCounter << " matched rphi hits";
+  LogDebug("") << " There are " << rphiUnMatchedCounter << " unmatched rphi hits";
+  LogDebug("") << " There are " << uselist.size() << " good stereo+rphi hits ";
 
   ////////////////
 
   // Loop over endcap zphi hits
-  LogDebug("") << " Looping over barrel zphi hits " ;
-
+  LogDebug("") << " Looping over barrel zphi hits ";
 
   unsigned int numberOfEndcapZphiHits = 0;
-  for (std::vector<const SiStripRecHit2D*>::const_iterator hit = zphiEndcapHits.begin();  
-       hit != zphiEndcapHits.end();  ++hit) {
+  for (std::vector<const SiStripRecHit2D*>::const_iterator hit = zphiEndcapHits.begin(); hit != zphiEndcapHits.end();
+       ++hit) {
     assert(hitUsed_.find(*hit) != hitUsed_.end());
     if (!hitUsed_[*hit]) {
       // Calculate the 2.5-D position of this hit
@@ -789,196 +821,190 @@ bool SiStripElectronAlgo::projectPhiBand(float chargeHypothesis, const reco::Sup
       //      double r=sqrt(position.x()*position.x()+position.y()*position.y()) ;
 
       // The expected r position of this hit, according to the z(r) fit
-      double rFit = (z - scz)/zVsRSlope + scr;
+      double rFit = (z - scz) / zVsRSlope + scr;
 
       // I don't know the r widths of the endcap strips, otherwise I
       // would apply a cut on r similar to the rphi z cut
 
       // Cut a narrow band around the supercluster's projection in phi,
       // and be sure the hit isn't in a reflected band (extrapolation of large z differences into negative r)
-      if (rFit > 0.  &&
-	  unwrapPhi((rFit-scr)*phiVsRSlope - phiBandWidth_) < phi  &&  phi < unwrapPhi((rFit-scr)*phiVsRSlope + phiBandWidth_)) {
+      if (rFit > 0. && unwrapPhi((rFit - scr) * phiVsRSlope - phiBandWidth_) < phi &&
+          phi < unwrapPhi((rFit - scr) * phiVsRSlope + phiBandWidth_)) {
+        // Use this hit to fit phi(r)
+        uselist.push_back(true);
+        rlist.push_back(rFit);
+        philist.push_back(phi);
+        w2list.push_back(1. / (0.05 / rFit) / (0.05 / rFit));  // weight**2 == 1./uncertainty**2
+        typelist.push_back(2);
+        hitlist.push_back(*hit);
 
-	// Use this hit to fit phi(r)
-	uselist.push_back(true);
-	rlist.push_back(rFit);
-	philist.push_back(phi);
-	w2list.push_back(1./(0.05/rFit)/(0.05/rFit));  // weight**2 == 1./uncertainty**2
-	typelist.push_back(2);
-	hitlist.push_back(*hit);
+      }  // end cut on phi band
+    }    // end assign disjoint sets of hits to electrons
+  }      // end loop over endcap zphi hits
 
-      } // end cut on phi band
-    } // end assign disjoint sets of hits to electrons
-  } // end loop over endcap zphi hits
- 
-  LogDebug("") << " There are " << uselist.size() << " good stereo+rphi+zphi hits " ;
+  LogDebug("") << " There are " << uselist.size() << " good stereo+rphi+zphi hits ";
   //////////////////////
 
-#ifdef EDM_ML_DEBUG 
+#ifdef EDM_ML_DEBUG
   std::ostringstream debugstr5;
-  debugstr5 << " List of hits before uniqification " << " \n" ;
-  for (unsigned int i = 0;  i < uselist.size();  i++) {
-    if ( uselist[i] ) {
+  debugstr5 << " List of hits before uniqification "
+            << " \n";
+  for (unsigned int i = 0; i < uselist.size(); i++) {
+    if (uselist[i]) {
       const SiStripRecHit2D* hit = hitlist[i];
-      debugstr5 << " DetID " << ((hit)->geographicalId()).rawId()
-		<< " R " << rlist[i] 
-		<< " Phi " << philist[i]
-		<< " Weight " << w2list[i] 
-		<< " PhiPred " << (rlist[i]-scr)*phiVsRSlope  
-		<< " Chi2 " << (philist[i]-(rlist[i]-scr)*phiVsRSlope)*(philist[i]-(rlist[i]-scr)*phiVsRSlope)*w2list[i]
-		<< " \n" ;
+      debugstr5 << " DetID " << ((hit)->geographicalId()).rawId() << " R " << rlist[i] << " Phi " << philist[i]
+                << " Weight " << w2list[i] << " PhiPred " << (rlist[i] - scr) * phiVsRSlope << " Chi2 "
+                << (philist[i] - (rlist[i] - scr) * phiVsRSlope) * (philist[i] - (rlist[i] - scr) * phiVsRSlope) *
+                       w2list[i]
+                << " \n";
     }
   }
-  debugstr5 << " \n\n\n" ;
-  
-  debugstr5 << " Counting number of unique detectors " << " \n" ;
+  debugstr5 << " \n\n\n";
 
-  debugstr5 << " These are all the detectors with hits " << " \n";
+  debugstr5 << " Counting number of unique detectors "
+            << " \n";
+
+  debugstr5 << " These are all the detectors with hits "
+            << " \n";
 #endif
   // Loop over hits, and find the best hit for each SiDetUnit - keep only those
   // get a list of DetIds in uselist
-  std::vector<uint32_t> detIdList ;
+  std::vector<uint32_t> detIdList;
 
-  for (unsigned int i = 0;  i < uselist.size();  i++) {
+  for (unsigned int i = 0; i < uselist.size(); i++) {
     if (uselist[i]) {
       const SiStripRecHit2D* hit = hitlist[i];
-      uint32_t detIDUsed = ((hit)->geographicalId()).rawId() ;
-#ifdef EDM_ML_DEBUG 
-      debugstr5<< " DetId " << detIDUsed << "\n";
+      uint32_t detIDUsed = ((hit)->geographicalId()).rawId();
+#ifdef EDM_ML_DEBUG
+      debugstr5 << " DetId " << detIDUsed << "\n";
 #endif
-      detIdList.push_back(detIDUsed) ;
+      detIdList.push_back(detIDUsed);
     }
   }
 
-#ifdef EDM_ML_DEBUG 
+#ifdef EDM_ML_DEBUG
   debugstr5 << " There are " << detIdList.size() << " hits on detectors \n";
 #endif
   // now sort and then uniq this list of detId
   std::sort(detIdList.begin(), detIdList.end());
-  detIdList.erase(
-		  std::unique(detIdList.begin(), detIdList.end()), detIdList.end());
-#ifdef EDM_ML_DEBUG 
+  detIdList.erase(std::unique(detIdList.begin(), detIdList.end()), detIdList.end());
+#ifdef EDM_ML_DEBUG
   debugstr5 << " There are " << detIdList.size() << " unique detectors \n";
 #endif
   //now we have a list of unique detectors used
 
-
-#ifdef EDM_ML_DEBUG 
-  debugstr5 << " Looping over detectors to choose best hit " << " \n";
+#ifdef EDM_ML_DEBUG
+  debugstr5 << " Looping over detectors to choose best hit "
+            << " \n";
 #endif
   // Loop over detectors ID and hits to create list of hits on same DetId
-  for (unsigned int idet = 0 ; idet < detIdList.size() ; idet++ ) {
-    for (unsigned int i = 0;  i+1 < uselist.size();  i++) {
+  for (unsigned int idet = 0; idet < detIdList.size(); idet++) {
+    for (unsigned int i = 0; i + 1 < uselist.size(); i++) {
       if (uselist[i]) {
-	// Get Chi2 of this hit relative to predicted hit
-	const SiStripRecHit2D* hit1 = hitlist[i];
-	double r_hit1 = rlist[i];
-	double phi_hit1 = philist[i];
-	double w2_hit1 = w2list[i] ;
-	double phi_pred1 = (r_hit1-scr)*phiVsRSlope ; 
-	double chi1 = (phi_hit1-phi_pred1)*(phi_hit1-phi_pred1)*w2_hit1;
-	if(detIdList[idet]== ((hit1)->geographicalId()).rawId()) {
-	  for (unsigned int j = i+1;  j < uselist.size();  j++) {
-	    if (uselist[j]) {
-	      const SiStripRecHit2D* hit2 = hitlist[j];
-	      if(detIdList[idet]== ((hit2)->geographicalId()).rawId()) {
-#ifdef EDM_ML_DEBUG 
-		debugstr5 << " Found 2 hits on same Si Detector " 
-			  << ((hit2)->geographicalId()).rawId() << "\n";
+        // Get Chi2 of this hit relative to predicted hit
+        const SiStripRecHit2D* hit1 = hitlist[i];
+        double r_hit1 = rlist[i];
+        double phi_hit1 = philist[i];
+        double w2_hit1 = w2list[i];
+        double phi_pred1 = (r_hit1 - scr) * phiVsRSlope;
+        double chi1 = (phi_hit1 - phi_pred1) * (phi_hit1 - phi_pred1) * w2_hit1;
+        if (detIdList[idet] == ((hit1)->geographicalId()).rawId()) {
+          for (unsigned int j = i + 1; j < uselist.size(); j++) {
+            if (uselist[j]) {
+              const SiStripRecHit2D* hit2 = hitlist[j];
+              if (detIdList[idet] == ((hit2)->geographicalId()).rawId()) {
+#ifdef EDM_ML_DEBUG
+                debugstr5 << " Found 2 hits on same Si Detector " << ((hit2)->geographicalId()).rawId() << "\n";
 #endif
-		// Get Chi2 of this hit relative to predicted hit
-		double r_hit2 = rlist[j];
-		double phi_hit2 = philist[j];
-		double w2_hit2 = w2list[j] ;
-		double phi_pred2 = (r_hit2-scr)*phiVsRSlope ; 
-		double chi2 = (phi_hit2-phi_pred2)*(phi_hit2-phi_pred2)*w2_hit2;
-#ifdef EDM_ML_DEBUG 
-		debugstr5 << " Chi1 " << chi1 << " Chi2 " << chi2 <<"\n";
+                // Get Chi2 of this hit relative to predicted hit
+                double r_hit2 = rlist[j];
+                double phi_hit2 = philist[j];
+                double w2_hit2 = w2list[j];
+                double phi_pred2 = (r_hit2 - scr) * phiVsRSlope;
+                double chi2 = (phi_hit2 - phi_pred2) * (phi_hit2 - phi_pred2) * w2_hit2;
+#ifdef EDM_ML_DEBUG
+                debugstr5 << " Chi1 " << chi1 << " Chi2 " << chi2 << "\n";
 #endif
-		if( chi1< chi2 ){
-		  uselist[j] = false;
-		}else{
-		  uselist[i] = false;
-		}
+                if (chi1 < chi2) {
+                  uselist[j] = false;
+                } else {
+                  uselist[i] = false;
+                }
 
-	      } // end of Det check
-	    } // end of j- usehit check
-	  } // end of j hit list loop
-	  
-	} // end of detector check
-      } // end of uselist check
-    } // end of i-hit list loop
+              }  // end of Det check
+            }    // end of j- usehit check
+          }      // end of j hit list loop
 
+        }  // end of detector check
+      }    // end of uselist check
+    }      // end of i-hit list loop
 
-  } // end of DetId loop
+  }  // end of DetId loop
 
-
-  
-  // now let's through out hits with a predicted chi > chi2HitMax 
-  for ( unsigned int i = 0;  i < uselist.size();  i++ ) { 
-    if ( uselist[i] ) { 
-      double localchi2 = (philist[i]-(rlist[i]-scr)*phiVsRSlope)*(philist[i]-(rlist[i]-scr)*phiVsRSlope)*w2list[i] ;
-      if(localchi2 > chi2HitMax ) {
-#ifdef EDM_ML_DEBUG 
+  // now let's through out hits with a predicted chi > chi2HitMax
+  for (unsigned int i = 0; i < uselist.size(); i++) {
+    if (uselist[i]) {
+      double localchi2 =
+          (philist[i] - (rlist[i] - scr) * phiVsRSlope) * (philist[i] - (rlist[i] - scr) * phiVsRSlope) * w2list[i];
+      if (localchi2 > chi2HitMax) {
+#ifdef EDM_ML_DEBUG
         const SiStripRecHit2D* hit = hitlist[i];
- 	debugstr5 << " Throwing out "
-		  <<" DetID " << ((hit)->geographicalId()).rawId()
-		  << " R " << rlist[i] 
-		  << " Phi " << philist[i]
-		  << " Weight " << w2list[i] 
-		  << " PhiPred " << (rlist[i]-scr)*phiVsRSlope  
-		  << " Chi2 " << (philist[i]-(rlist[i]-scr)*phiVsRSlope)*(philist[i]-(rlist[i]-scr)*phiVsRSlope)*w2list[i]
-		  << " \n" ;
+        debugstr5 << " Throwing out "
+                  << " DetID " << ((hit)->geographicalId()).rawId() << " R " << rlist[i] << " Phi " << philist[i]
+                  << " Weight " << w2list[i] << " PhiPred " << (rlist[i] - scr) * phiVsRSlope << " Chi2 "
+                  << (philist[i] - (rlist[i] - scr) * phiVsRSlope) * (philist[i] - (rlist[i] - scr) * phiVsRSlope) *
+                         w2list[i]
+                  << " \n";
 #endif
-	uselist[i]=false ;
+        uselist[i] = false;
       }
     }
   }
 
-#ifdef EDM_ML_DEBUG 
-  debugstr5 << " List of hits after uniqification " << " \n" ;
-  for (unsigned int i = 0;  i < uselist.size();  i++) {
-    if ( uselist[i] ) {
+#ifdef EDM_ML_DEBUG
+  debugstr5 << " List of hits after uniqification "
+            << " \n";
+  for (unsigned int i = 0; i < uselist.size(); i++) {
+    if (uselist[i]) {
       const SiStripRecHit2D* hit = hitlist[i];
-      debugstr5 << " DetID " << ((hit)->geographicalId()).rawId()
-		<< " R " << rlist[i] 
-		<< " Phi " << philist[i]
-		<< " Weight " << w2list[i] 
-		<< " PhiPred " << (rlist[i]-scr)*phiVsRSlope  
-		<< " Chi2 " << (philist[i]-(rlist[i]-scr)*phiVsRSlope)*(philist[i]-(rlist[i]-scr)*phiVsRSlope)*w2list[i]
-		<< " \n" ;
+      debugstr5 << " DetID " << ((hit)->geographicalId()).rawId() << " R " << rlist[i] << " Phi " << philist[i]
+                << " Weight " << w2list[i] << " PhiPred " << (rlist[i] - scr) * phiVsRSlope << " Chi2 "
+                << (philist[i] - (rlist[i] - scr) * phiVsRSlope) * (philist[i] - (rlist[i] - scr) * phiVsRSlope) *
+                       w2list[i]
+                << " \n";
     }
   }
-  debugstr5 << " \n\n\n" ;
+  debugstr5 << " \n\n\n";
 #endif
 
   // need to check that there are more than 2 hits left here!
-  unsigned int nHitsLeft =0;
-  for (unsigned int i = 0;  i < uselist.size();  i++) {
-    if ( uselist[i] ) {
+  unsigned int nHitsLeft = 0;
+  for (unsigned int i = 0; i < uselist.size(); i++) {
+    if (uselist[i]) {
       nHitsLeft++;
     }
   }
-  if(nHitsLeft < nHitsLeftMinimum ) {
-#ifdef EDM_ML_DEBUG 
-    debugstr5 << " Too few hits "<< nHitsLeft 
-	      << " left - return false " << " \n";
+  if (nHitsLeft < nHitsLeftMinimum) {
+#ifdef EDM_ML_DEBUG
+    debugstr5 << " Too few hits " << nHitsLeft << " left - return false "
+              << " \n";
 #endif
-    return false ;
+    return false;
   }
-#ifdef EDM_ML_DEBUG 
+#ifdef EDM_ML_DEBUG
   LogDebug("") << debugstr5.str();
 #endif
   /////////////////////
-  
+
   // Calculate a linear phi(r) fit and drop hits until the biggest contributor to chi^2 is less than maxNormResid_
   bool done = false;
-  double intercept = 0 ;
-  double slope = 0 ;
+  double intercept = 0;
+  double slope = 0;
   double chi2 = 0;
 
   std::ostringstream debugstr4;
-  debugstr4 <<" Calc of phi(r) "<<" \n";
+  debugstr4 << " Calc of phi(r) "
+            << " \n";
 
   while (!done) {
     // Use an iterative update of <psi>, <r> etc instead in an
@@ -986,108 +1012,97 @@ bool SiStripElectronAlgo::projectPhiBand(float chargeHypothesis, const reco::Sup
     // The linear fit  psi = slope*r + intercept
     //             slope is (<psi*r>-<psi>*<r>) / (<r^2>-<r>^2>)
     //             intercept is <psi> - slope*<r>
-    
-    double phiBar   = 0.;
-    double phiBarOld   = 0.;
-    double rBar  = 0.;
-    double rBarOld  = 0.;
+
+    double phiBar = 0.;
+    double phiBarOld = 0.;
+    double rBar = 0.;
+    double rBarOld = 0.;
     double r2Bar = 0.;
     double r2BarOld = 0.;
     double phirBar = 0.;
     double phirBarOld = 0.;
     double totalWeight = 0.;
-    double totalWeightOld = 0.; 
+    double totalWeightOld = 0.;
     unsigned int uselist_size = uselist.size();
-    for (unsigned int i = 0;  i < uselist_size;  i++) {
+    for (unsigned int i = 0; i < uselist_size; i++) {
       if (uselist[i]) {
         double r = rlist[i];
         double phi = philist[i];
         double weight2 = w2list[i];
-	
-        totalWeight = totalWeightOld + weight2 ;
-	
+
+        totalWeight = totalWeightOld + weight2;
+
         //weight2 is 1/sigma^2. Typically sigma is 100micron pitch
         // over root(12) = 30 microns so weight2 is about 10^5-10^6
-	
-        double totalWeightRatio = totalWeightOld/totalWeight ;
-        double localWeightRatio = weight2/totalWeight ;
-	
-        phiBar = phiBarOld*totalWeightRatio + phi*localWeightRatio ; 
-        rBar = rBarOld*totalWeightRatio + r*localWeightRatio ; 
-        r2Bar= r2BarOld*totalWeightRatio + r*r*localWeightRatio ; 
-        phirBar = phirBarOld*totalWeightRatio + phi*r*localWeightRatio ;
-	
-	totalWeightOld = totalWeight ;
-        phiBarOld = phiBar ;
-        rBarOld = rBar ;
-        r2BarOld = r2Bar ;
-        phirBarOld = phirBar ;  
-#ifdef EDM_ML_DEBUG 
-	debugstr4 << " totalWeight " << totalWeight 
-                  << " totalWeightRatio " << totalWeightRatio
-                  << " localWeightRatio "<< localWeightRatio
-                  << " phiBar " << phiBar
-                  << " rBar " << rBar 
-                  << " r2Bar " << r2Bar
-                  << " phirBar " << phirBar 
-                  << " \n ";
+
+        double totalWeightRatio = totalWeightOld / totalWeight;
+        double localWeightRatio = weight2 / totalWeight;
+
+        phiBar = phiBarOld * totalWeightRatio + phi * localWeightRatio;
+        rBar = rBarOld * totalWeightRatio + r * localWeightRatio;
+        r2Bar = r2BarOld * totalWeightRatio + r * r * localWeightRatio;
+        phirBar = phirBarOld * totalWeightRatio + phi * r * localWeightRatio;
+
+        totalWeightOld = totalWeight;
+        phiBarOld = phiBar;
+        rBarOld = rBar;
+        r2BarOld = r2Bar;
+        phirBarOld = phirBar;
+#ifdef EDM_ML_DEBUG
+        debugstr4 << " totalWeight " << totalWeight << " totalWeightRatio " << totalWeightRatio << " localWeightRatio "
+                  << localWeightRatio << " phiBar " << phiBar << " rBar " << rBar << " r2Bar " << r2Bar << " phirBar "
+                  << phirBar << " \n ";
 #endif
 
-      } // end of use hit loop
-    } // end of hit loop to calculate a linear fit
-    slope = (phirBar-phiBar*rBar)/(r2Bar-rBar*rBar);
-    intercept = phiBar-slope*rBar ;
+      }  // end of use hit loop
+    }    // end of hit loop to calculate a linear fit
+    slope = (phirBar - phiBar * rBar) / (r2Bar - rBar * rBar);
+    intercept = phiBar - slope * rBar;
 
-    debugstr4 << " end of loop slope " << slope 
-              << " intercept " << intercept << " \n";
+    debugstr4 << " end of loop slope " << slope << " intercept " << intercept << " \n";
 
     // Calculate chi^2
     chi2 = 0.;
     double biggest_normresid = -1.;
     unsigned int biggest_index = 0;
-    for (unsigned int i = 0;  i < uselist_size;  i++) {
+    for (unsigned int i = 0; i < uselist_size; i++) {
       if (uselist[i]) {
-	double r = rlist[i];
-	double phi = philist[i];
-	double weight2 = w2list[i];
+        double r = rlist[i];
+        double phi = philist[i];
+        double weight2 = w2list[i];
 
-	double normresid = weight2 * (phi - intercept - slope*r)*(phi - intercept - slope*r);
-	chi2 += normresid;
+        double normresid = weight2 * (phi - intercept - slope * r) * (phi - intercept - slope * r);
+        chi2 += normresid;
 
-	if (normresid > biggest_normresid) {
-	  biggest_normresid = normresid;
-	  biggest_index = i;
-	}
+        if (normresid > biggest_normresid) {
+          biggest_normresid = normresid;
+          biggest_index = i;
+        }
       }
-    } // end loop over hits to calculate chi^2 and find its biggest contributer
+    }  // end loop over hits to calculate chi^2 and find its biggest contributer
 
     if (biggest_normresid > maxNormResid_) {
 #ifdef EDM_ML_DEBUG
-      debugstr4 << "Dropping hit from fit due to Chi2 " << " \n" ;
+      debugstr4 << "Dropping hit from fit due to Chi2 "
+                << " \n";
       const SiStripRecHit2D* hit = hitlist[biggest_index];
-      debugstr4 << " DetID " << ((hit)->geographicalId()).rawId()
-		<< " R " << rlist[biggest_index]
-		<< " Phi " << philist[biggest_index]
-		<< " Weight " << w2list[biggest_index]
-		<< " PhiPred " << (rlist[biggest_index]-scr)*phiVsRSlope  
-		<< " Chi2 " << (philist[biggest_index]-(rlist[biggest_index]-scr)*phiVsRSlope)*(philist[biggest_index]-(rlist[biggest_index]-scr)*phiVsRSlope)*w2list[biggest_index] 
-		<< " normresid " <<  biggest_normresid
-		<< " \n\n";
+      debugstr4 << " DetID " << ((hit)->geographicalId()).rawId() << " R " << rlist[biggest_index] << " Phi "
+                << philist[biggest_index] << " Weight " << w2list[biggest_index] << " PhiPred "
+                << (rlist[biggest_index] - scr) * phiVsRSlope << " Chi2 "
+                << (philist[biggest_index] - (rlist[biggest_index] - scr) * phiVsRSlope) *
+                       (philist[biggest_index] - (rlist[biggest_index] - scr) * phiVsRSlope) * w2list[biggest_index]
+                << " normresid " << biggest_normresid << " \n\n";
 #endif
       uselist[biggest_index] = false;
-    }
-    else {
+    } else {
       done = true;
     }
-  } // end loop over trial fits
-#ifdef EDM_ML_DEBUG 
-  debugstr4 <<" Fit " 
-            << " Intercept  " << intercept
-            << " slope " << slope 
-            << " chi2 " << chi2
-            << " \n" ;
+  }  // end loop over trial fits
+#ifdef EDM_ML_DEBUG
+  debugstr4 << " Fit "
+            << " Intercept  " << intercept << " slope " << slope << " chi2 " << chi2 << " \n";
 
-  LogDebug("") <<   debugstr4.str() ;
+  LogDebug("") << debugstr4.str();
 #endif
 
   // Now we have intercept, slope, and chi2; uselist to tell us which hits are used, and hitlist for the hits
@@ -1102,52 +1117,49 @@ bool SiStripElectronAlgo::projectPhiBand(float chargeHypothesis, const reco::Sup
   std::vector<SiStripRecHit2D> outputRphiHits;
   std::vector<SiStripRecHit2D> outputStereoHits;
 
-  typedef edm::Ref<SiStripRecHit2DCollection,SiStripRecHit2D> SiStripRecHit2DRef;
+  typedef edm::Ref<SiStripRecHit2DCollection, SiStripRecHit2D> SiStripRecHit2DRef;
 
-
-  for (unsigned int i = 0;  i < uselist.size();  i++) {
+  for (unsigned int i = 0; i < uselist.size(); i++) {
     if (uselist[i]) {
       double r = rlist[i];
       const SiStripRecHit2D* hit = hitlist[i];
 
       // Keep track of the innermost hit
-      if (innerhit == (SiStripRecHit2D*)nullptr  ||  r < innerhitRadius) {
-	innerhit = hit;
-	innerhitRadius = r;
+      if (innerhit == (SiStripRecHit2D*)nullptr || r < innerhitRadius) {
+        innerhit = hit;
+        innerhitRadius = r;
       }
-	 
+
       if (typelist[i] == 0) {
-	numberOfStereoHits++;
+        numberOfStereoHits++;
 
-	// Copy this hit for the TrajectorySeed
-	outputHits.push_back(hit);
-	outputStereoHits.push_back(*hit);
-      }
-      else if (typelist[i] == 1) {
-	numberOfBarrelRphiHits++;
+        // Copy this hit for the TrajectorySeed
+        outputHits.push_back(hit);
+        outputStereoHits.push_back(*hit);
+      } else if (typelist[i] == 1) {
+        numberOfBarrelRphiHits++;
 
-	// Copy this hit for the TrajectorySeed
-	outputHits.push_back(hit);
-	outputRphiHits.push_back(*hit);
-      }
-      else if (typelist[i] == 2) {
-	numberOfEndcapZphiHits++;
+        // Copy this hit for the TrajectorySeed
+        outputHits.push_back(hit);
+        outputRphiHits.push_back(*hit);
+      } else if (typelist[i] == 2) {
+        numberOfEndcapZphiHits++;
 
-	// Copy this hit for the TrajectorySeed
-	outputHits.push_back(hit);
-	outputRphiHits.push_back(*hit);
+        // Copy this hit for the TrajectorySeed
+        outputHits.push_back(hit);
+        outputRphiHits.push_back(*hit);
       }
     }
-  } // end loop over all hits, after having culled the ones with big residuals
+  }  // end loop over all hits, after having culled the ones with big residuals
 
   unsigned int totalNumberOfHits = numberOfStereoHits + numberOfBarrelRphiHits + numberOfEndcapZphiHits;
   double reducedChi2 = (totalNumberOfHits > 2 ? chi2 / (totalNumberOfHits - 2) : 1e10);
 
   // Select this candidate if it passes minHits_ and maxReducedChi2_ cuts
-  if (innerhit != nullptr && totalNumberOfHits >= minHits_  &&  reducedChi2 <= maxReducedChi2_) {
+  if (innerhit != nullptr && totalNumberOfHits >= minHits_ && reducedChi2 <= maxReducedChi2_) {
     // GlobalTrajectoryParameters evaluated at the position of the innerhit
     GlobalPoint position;
-    if( nullptr != tracker_p_ ) {
+    if (nullptr != tracker_p_) {
       position = tracker_p_->idToDet(innerhit->geographicalId())->surface().toGlobal(innerhit->localPosition());
     } else {
       throw cms::Exception("projectPhiBand") << "Pointer to tracker product is null!";
@@ -1160,13 +1172,14 @@ bool SiStripElectronAlgo::projectPhiBand(float chargeHypothesis, const reco::Sup
     double correct_pT = pT * phiVsRSlope / slope;
 
     // Our phi(r) linear fit returns phi relative to the supercluster phi for a given radius
-    double phi = intercept + slope*sqrt(position.x()*position.x() + position.y()*position.y()) + superclusterIn->position().phi();
+    double phi = intercept + slope * sqrt(position.x() * position.x() + position.y() * position.y()) +
+                 superclusterIn->position().phi();
 
     // Our z(r) linear fit gives us a better measurement of eta/dip angle
     double pZ = correct_pT * zVsRSlope;
 
     // Now we can construct a trajectory momentum out of linear fits to hits
-    GlobalVector momentum = GlobalVector(correct_pT*cos(phi), correct_pT*sin(phi), pZ);
+    GlobalVector momentum = GlobalVector(correct_pT * cos(phi), correct_pT * sin(phi), pZ);
 
     if (chargeHypothesis > 0.) {
       redchi2_pos_ = chi2 / double(totalNumberOfHits - 2);
@@ -1187,8 +1200,7 @@ bool SiStripElectronAlgo::projectPhiBand(float chargeHypothesis, const reco::Sup
       numberOfStereoHits_pos_ = numberOfStereoHits;
       numberOfBarrelRphiHits_pos_ = numberOfBarrelRphiHits;
       numberOfEndcapZphiHits_pos_ = numberOfEndcapZphiHits;
-    }
-    else {
+    } else {
       redchi2_neg_ = chi2 / double(totalNumberOfHits - 2);
       position_neg_ = position;
       momentum_neg_ = momentum;
@@ -1209,12 +1221,12 @@ bool SiStripElectronAlgo::projectPhiBand(float chargeHypothesis, const reco::Sup
       numberOfEndcapZphiHits_neg_ = numberOfEndcapZphiHits;
     }
 
-    LogDebug("") << " return from projectFindBand with True \n" << std::endl ;
+    LogDebug("") << " return from projectFindBand with True \n" << std::endl;
     return true;
-  } // end if this is a good electron candidate
+  }  // end if this is a good electron candidate
 
   // Signal for a failed electron candidate
-  LogDebug("") << " return from projectFindBand with False \n" << std::endl ;
+  LogDebug("") << " return from projectFindBand with False \n" << std::endl;
   return false;
 }
 
@@ -1225,4 +1237,3 @@ bool SiStripElectronAlgo::projectPhiBand(float chargeHypothesis, const reco::Sup
 //
 // static member functions
 //
- 

--- a/RecoEgamma/EgammaElectronAlgos/src/SiStripElectronSeedGenerator.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/SiStripElectronSeedGenerator.cc
@@ -19,8 +19,6 @@ Description: SiStrip-driven electron seed finding algorithm.
 
 #include "DataFormats/EgammaReco/interface/ElectronSeed.h"
 
-
-
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -44,40 +42,44 @@ Description: SiStrip-driven electron seed finding algorithm.
 #include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 
-
 #include "RecoEgamma/EgammaElectronAlgos/interface/SiStripElectronSeedGenerator.h"
 
-SiStripElectronSeedGenerator::SiStripElectronSeedGenerator(const edm::ParameterSet &pset, const SiStripElectronSeedGenerator::Tokens& tokens)
- : beamSpotTag_(tokens.token_bs),
-   theUpdator(nullptr),thePropagator(nullptr),theMeasurementTracker(nullptr),
-   theMeasurementTrackerEventTag(tokens.token_mte),
-   theSetup(nullptr), theMatcher_(nullptr),
-   cacheIDMagField_(0),cacheIDCkfComp_(0),cacheIDTrkGeom_(0),
-   tibOriginZCut_(pset.getParameter<double>("tibOriginZCut")),
-   tidOriginZCut_(pset.getParameter<double>("tidOriginZCut")),
-   tecOriginZCut_(pset.getParameter<double>("tecOriginZCut")),
-   monoOriginZCut_(pset.getParameter<double>("monoOriginZCut")),
-   tibDeltaPsiCut_(pset.getParameter<double>("tibDeltaPsiCut")),
-   tidDeltaPsiCut_(pset.getParameter<double>("tidDeltaPsiCut")),
-   tecDeltaPsiCut_(pset.getParameter<double>("tecDeltaPsiCut")),
-   monoDeltaPsiCut_(pset.getParameter<double>("monoDeltaPsiCut")),
-   tibPhiMissHit2Cut_(pset.getParameter<double>("tibPhiMissHit2Cut")),
-   tidPhiMissHit2Cut_(pset.getParameter<double>("tidPhiMissHit2Cut")),
-   tecPhiMissHit2Cut_(pset.getParameter<double>("tecPhiMissHit2Cut")),
-   monoPhiMissHit2Cut_(pset.getParameter<double>("monoPhiMissHit2Cut")),
-   tibZMissHit2Cut_(pset.getParameter<double>("tibZMissHit2Cut")),
-   tidRMissHit2Cut_(pset.getParameter<double>("tidRMissHit2Cut")),
-   tecRMissHit2Cut_(pset.getParameter<double>("tecRMissHit2Cut")),
-   tidEtaUsage_(pset.getParameter<double>("tidEtaUsage")),
-   tidMaxHits_(pset.getParameter<int>("tidMaxHits")),
-   tecMaxHits_(pset.getParameter<int>("tecMaxHits")),
-   monoMaxHits_(pset.getParameter<int>("monoMaxHits")),
-   maxSeeds_(pset.getParameter<int>("maxSeeds"))
-{
+SiStripElectronSeedGenerator::SiStripElectronSeedGenerator(const edm::ParameterSet& pset,
+                                                           const SiStripElectronSeedGenerator::Tokens& tokens)
+    : beamSpotTag_(tokens.token_bs),
+      theUpdator(nullptr),
+      thePropagator(nullptr),
+      theMeasurementTracker(nullptr),
+      theMeasurementTrackerEventTag(tokens.token_mte),
+      theSetup(nullptr),
+      theMatcher_(nullptr),
+      cacheIDMagField_(0),
+      cacheIDCkfComp_(0),
+      cacheIDTrkGeom_(0),
+      tibOriginZCut_(pset.getParameter<double>("tibOriginZCut")),
+      tidOriginZCut_(pset.getParameter<double>("tidOriginZCut")),
+      tecOriginZCut_(pset.getParameter<double>("tecOriginZCut")),
+      monoOriginZCut_(pset.getParameter<double>("monoOriginZCut")),
+      tibDeltaPsiCut_(pset.getParameter<double>("tibDeltaPsiCut")),
+      tidDeltaPsiCut_(pset.getParameter<double>("tidDeltaPsiCut")),
+      tecDeltaPsiCut_(pset.getParameter<double>("tecDeltaPsiCut")),
+      monoDeltaPsiCut_(pset.getParameter<double>("monoDeltaPsiCut")),
+      tibPhiMissHit2Cut_(pset.getParameter<double>("tibPhiMissHit2Cut")),
+      tidPhiMissHit2Cut_(pset.getParameter<double>("tidPhiMissHit2Cut")),
+      tecPhiMissHit2Cut_(pset.getParameter<double>("tecPhiMissHit2Cut")),
+      monoPhiMissHit2Cut_(pset.getParameter<double>("monoPhiMissHit2Cut")),
+      tibZMissHit2Cut_(pset.getParameter<double>("tibZMissHit2Cut")),
+      tidRMissHit2Cut_(pset.getParameter<double>("tidRMissHit2Cut")),
+      tecRMissHit2Cut_(pset.getParameter<double>("tecRMissHit2Cut")),
+      tidEtaUsage_(pset.getParameter<double>("tidEtaUsage")),
+      tidMaxHits_(pset.getParameter<int>("tidMaxHits")),
+      tecMaxHits_(pset.getParameter<int>("tecMaxHits")),
+      monoMaxHits_(pset.getParameter<int>("monoMaxHits")),
+      maxSeeds_(pset.getParameter<int>("maxSeeds")) {
   // use of a theMeasurementTrackerName
-  if (pset.exists("measurementTrackerName"))
-   { theMeasurementTrackerName = pset.getParameter<std::string>("measurementTrackerName") ; }
-  
+  if (pset.exists("measurementTrackerName")) {
+    theMeasurementTrackerName = pset.getParameter<std::string>("measurementTrackerName");
+  }
 
   // new beamSpot tag
   /*
@@ -86,72 +88,65 @@ SiStripElectronSeedGenerator::SiStripElectronSeedGenerator(const edm::ParameterS
   */
 
   theUpdator = new KFUpdator();
-  theEstimator = new Chi2MeasurementEstimator(30,3);
+  theEstimator = new Chi2MeasurementEstimator(30, 3);
 }
-
 
 SiStripElectronSeedGenerator::~SiStripElectronSeedGenerator() {
   delete thePropagator;
   delete theUpdator;
 }
 
-
 void SiStripElectronSeedGenerator::setupES(const edm::EventSetup& setup) {
-
-  if (cacheIDMagField_!=setup.get<IdealMagneticFieldRecord>().cacheIdentifier()) {
+  if (cacheIDMagField_ != setup.get<IdealMagneticFieldRecord>().cacheIdentifier()) {
     setup.get<IdealMagneticFieldRecord>().get(theMagField);
-    cacheIDMagField_=setup.get<IdealMagneticFieldRecord>().cacheIdentifier();
-    if (thePropagator) delete thePropagator;
-    thePropagator = new PropagatorWithMaterial(alongMomentum,.000511,&(*theMagField));
+    cacheIDMagField_ = setup.get<IdealMagneticFieldRecord>().cacheIdentifier();
+    if (thePropagator)
+      delete thePropagator;
+    thePropagator = new PropagatorWithMaterial(alongMomentum, .000511, &(*theMagField));
   }
 
-  if (cacheIDCkfComp_!=setup.get<CkfComponentsRecord>().cacheIdentifier()) {
-    setup.get<CkfComponentsRecord>().get(theMeasurementTrackerName,measurementTrackerHandle);
-    cacheIDCkfComp_=setup.get<CkfComponentsRecord>().cacheIdentifier();
+  if (cacheIDCkfComp_ != setup.get<CkfComponentsRecord>().cacheIdentifier()) {
+    setup.get<CkfComponentsRecord>().get(theMeasurementTrackerName, measurementTrackerHandle);
+    cacheIDCkfComp_ = setup.get<CkfComponentsRecord>().cacheIdentifier();
     theMeasurementTracker = measurementTrackerHandle.product();
   }
 
-  if (cacheIDTrkGeom_!=setup.get<TrackerDigiGeometryRecord>().cacheIdentifier()) {
+  if (cacheIDTrkGeom_ != setup.get<TrackerDigiGeometryRecord>().cacheIdentifier()) {
     setup.get<TrackerDigiGeometryRecord>().get(trackerGeometryHandle);
-    cacheIDTrkGeom_=setup.get<TrackerDigiGeometryRecord>().cacheIdentifier();
+    cacheIDTrkGeom_ = setup.get<TrackerDigiGeometryRecord>().cacheIdentifier();
   }
-
 }
 
-void  SiStripElectronSeedGenerator::run(edm::Event& e, const edm::EventSetup& setup,
-					const edm::Handle<reco::SuperClusterCollection> &clusters,
-					reco::ElectronSeedCollection & out) {
-  theSetup= &setup;
+void SiStripElectronSeedGenerator::run(edm::Event& e,
+                                       const edm::EventSetup& setup,
+                                       const edm::Handle<reco::SuperClusterCollection>& clusters,
+                                       reco::ElectronSeedCollection& out) {
+  theSetup = &setup;
 
-  e.getByToken(beamSpotTag_,theBeamSpot);
+  e.getByToken(beamSpotTag_, theBeamSpot);
   edm::Handle<MeasurementTrackerEvent> data;
   e.getByToken(theMeasurementTrackerEventTag, data);
 
-
-  for  (unsigned int i=0;i<clusters->size();++i) {
-    edm::Ref<reco::SuperClusterCollection> theClusB(clusters,i);
+  for (unsigned int i = 0; i < clusters->size(); ++i) {
+    edm::Ref<reco::SuperClusterCollection> theClusB(clusters, i);
     // Find the seeds
-    LogDebug ("run") << "new cluster, calling findSeedsFromCluster";
-    findSeedsFromCluster(theClusB,theBeamSpot,*data,out);
+    LogDebug("run") << "new cluster, calling findSeedsFromCluster";
+    findSeedsFromCluster(theClusB, theBeamSpot, *data, out);
   }
 
-  LogDebug ("run") << ": For event "<<e.id();
-  LogDebug ("run") <<"Nr of superclusters: "<<clusters->size()
-		   <<", no. of ElectronSeeds found  = " << out.size();
+  LogDebug("run") << ": For event " << e.id();
+  LogDebug("run") << "Nr of superclusters: " << clusters->size() << ", no. of ElectronSeeds found  = " << out.size();
 }
 
-
 // Find seeds using a supercluster
-void SiStripElectronSeedGenerator::findSeedsFromCluster
- ( edm::Ref<reco::SuperClusterCollection> seedCluster,
-   edm::Handle<reco::BeamSpot> bs,
-   const MeasurementTrackerEvent & trackerData,
-	 reco::ElectronSeedCollection & result )
- {
+void SiStripElectronSeedGenerator::findSeedsFromCluster(edm::Ref<reco::SuperClusterCollection> seedCluster,
+                                                        edm::Handle<reco::BeamSpot> bs,
+                                                        const MeasurementTrackerEvent& trackerData,
+                                                        reco::ElectronSeedCollection& result) {
   // clear the member vectors of good hits
-  layer1Hits_.clear() ;
-  layer2Hits_.clear() ;
-  backupLayer2Hits_.clear() ;
+  layer1Hits_.clear();
+  layer2Hits_.clear();
+  backupLayer2Hits_.clear();
 
   using namespace std;
 
@@ -160,9 +155,11 @@ void SiStripElectronSeedGenerator::findSeedsFromCluster
   double scEta = seedCluster->eta();
 
   double scz = sCposition.z();
-  double scr = sqrt(pow(sCposition.x(),2)+pow(sCposition.y(),2));
+  double scr = sqrt(pow(sCposition.x(), 2) + pow(sCposition.y(), 2));
 
-  double pT = sCenergy * seedCluster->position().rho()/sqrt(seedCluster->x()*seedCluster->x()+seedCluster->y()*seedCluster->y()+seedCluster->z()*seedCluster->z());
+  double pT = sCenergy * seedCluster->position().rho() /
+              sqrt(seedCluster->x() * seedCluster->x() + seedCluster->y() * seedCluster->y() +
+                   seedCluster->z() * seedCluster->z());
 
   // FIXME use nominal field (see below)
   double magneticField = 3.8;
@@ -170,10 +167,9 @@ void SiStripElectronSeedGenerator::findSeedsFromCluster
   // cf Jackson p. 581-2, a little geometry
   double phiVsRSlope = -3.00e-3 * magneticField / pT / 2.;
 
-
   //Need to create TSOS to feed MeasurementTracker
-  GlobalPoint beamSpot(bs->x0(),bs->y0(),bs->z0());
-  GlobalPoint superCluster(sCposition.x(),sCposition.y(),sCposition.z());
+  GlobalPoint beamSpot(bs->x0(), bs->y0(), bs->z0());
+  GlobalPoint superCluster(sCposition.x(), sCposition.y(), sCposition.z());
   double r0 = beamSpot.perp();
   double z0 = beamSpot.z();
 
@@ -184,16 +180,19 @@ void SiStripElectronSeedGenerator::findSeedsFromCluster
 
   int chargeHypothesis;
   double chargeSelector = sCenergy - (int)sCenergy;
-  if(chargeSelector >= 0.5) chargeHypothesis = -1;
-  else {chargeHypothesis = 1;}
+  if (chargeSelector >= 0.5)
+    chargeHypothesis = -1;
+  else {
+    chargeHypothesis = 1;
+  }
 
   //Use BeamSpot and SC position to estimate 3rd point
   double rFake = 25.;
-  double phiFake = phiDiff(superCluster.phi(),chargeHypothesis * phiVsRSlope * (scr - rFake));
-  double zFake = (rFake*(scz-z0)-r0*scz+scr*z0)/(scr-r0);
+  double phiFake = phiDiff(superCluster.phi(), chargeHypothesis * phiVsRSlope * (scr - rFake));
+  double zFake = (rFake * (scz - z0) - r0 * scz + scr * z0) / (scr - r0);
   double xFake = rFake * cos(phiFake);
   double yFake = rFake * sin(phiFake);
-  GlobalPoint fakePoint(xFake,yFake,zFake);
+  GlobalPoint fakePoint(xFake, yFake, zFake);
 
   // FIXME optmize, move outside loop
   edm::ESHandle<MagneticField> bfield;
@@ -201,14 +200,14 @@ void SiStripElectronSeedGenerator::findSeedsFromCluster
   float nomField = bfield->nominalValue();
 
   //Use 3 points to make helix
-  FastHelix initialHelix(superCluster,fakePoint,beamSpot,nomField,&*bfield);
+  FastHelix initialHelix(superCluster, fakePoint, beamSpot, nomField, &*bfield);
 
   //Use helix to get FTS
   FreeTrajectoryState initialFTS(initialHelix.stateAtVertex());
 
   //Use FTS and BeamSpot to create TSOS
   TransverseImpactPointExtrapolator* tipe = new TransverseImpactPointExtrapolator(*thePropagator);
-  TrajectoryStateOnSurface initialTSOS = tipe->extrapolate(initialFTS,beamSpot);
+  TrajectoryStateOnSurface initialTSOS = tipe->extrapolate(initialFTS, beamSpot);
 
   //Use GST to retrieve hits from various DetLayers using layerMeasurements class
   const GeometricSearchTracker* gst = theMeasurementTracker->geometricSearchTracker();
@@ -219,11 +218,11 @@ void SiStripElectronSeedGenerator::findSeedsFromCluster
 
   std::vector<const ForwardDetLayer*> tecLayers;
   std::vector<const ForwardDetLayer*> tidLayers;
-  if(scEta < 0){
+  if (scEta < 0) {
     tecLayers = gst->negTecLayers();
     tidLayers = gst->negTidLayers();
   }
-  if(scEta > 0){
+  if (scEta > 0) {
     tecLayers = gst->posTecLayers();
     tidLayers = gst->posTidLayers();
   }
@@ -261,297 +260,342 @@ void SiStripElectronSeedGenerator::findSeedsFromCluster
   LayerMeasurements layerMeasurements(*theMeasurementTracker, trackerData);
 
   std::vector<TrajectoryMeasurement> tib1measurements;
-  if(useDL.at(0)) tib1measurements = layerMeasurements.measurements(*tib1,initialTSOS,*thePropagator,*theEstimator);
+  if (useDL.at(0))
+    tib1measurements = layerMeasurements.measurements(*tib1, initialTSOS, *thePropagator, *theEstimator);
   std::vector<TrajectoryMeasurement> tib2measurements;
-  if(useDL.at(1)) tib2measurements = layerMeasurements.measurements(*tib2,initialTSOS,*thePropagator,*theEstimator);
+  if (useDL.at(1))
+    tib2measurements = layerMeasurements.measurements(*tib2, initialTSOS, *thePropagator, *theEstimator);
 
   //Basic idea: Retrieve hits from a given DetLayer
   //Check if it is a Matched Hit and satisfies some cuts
   //If yes, accept hit for seed making
 
-  for(std::vector<TrajectoryMeasurement>::const_iterator tmIter = tib1measurements.begin(); tmIter != tib1measurements.end(); ++ tmIter){
+  for (std::vector<TrajectoryMeasurement>::const_iterator tmIter = tib1measurements.begin();
+       tmIter != tib1measurements.end();
+       ++tmIter) {
     ConstRecHitPointer hit = tmIter->recHit();
     const SiStripMatchedRecHit2D* matchedHit = matchedHitConverter(hit);
-    if(matchedHit){
-      GlobalPoint position = trackerGeometryHandle->idToDet(matchedHit->geographicalId())->surface().toGlobal(matchedHit->localPosition());
-      if(preselection(position, superCluster, phiVsRSlope, 1)){
-	hasLay1Hit = true;
-	layer1Hits_.push_back(matchedHit);
+    if (matchedHit) {
+      GlobalPoint position =
+          trackerGeometryHandle->idToDet(matchedHit->geographicalId())->surface().toGlobal(matchedHit->localPosition());
+      if (preselection(position, superCluster, phiVsRSlope, 1)) {
+        hasLay1Hit = true;
+        layer1Hits_.push_back(matchedHit);
       }
     }
   }
 
-  for(std::vector<TrajectoryMeasurement>::const_iterator tmIter = tib2measurements.begin(); tmIter != tib2measurements.end(); ++ tmIter){
+  for (std::vector<TrajectoryMeasurement>::const_iterator tmIter = tib2measurements.begin();
+       tmIter != tib2measurements.end();
+       ++tmIter) {
     ConstRecHitPointer hit = tmIter->recHit();
     const SiStripMatchedRecHit2D* matchedHit = matchedHitConverter(hit);
-    if(matchedHit){
-      GlobalPoint position = trackerGeometryHandle->idToDet(matchedHit->geographicalId())->surface().toGlobal(matchedHit->localPosition());
-      if(preselection(position, superCluster, phiVsRSlope, 1)){
-	hasLay2Hit = true;
-	layer2Hits_.push_back(matchedHit);
+    if (matchedHit) {
+      GlobalPoint position =
+          trackerGeometryHandle->idToDet(matchedHit->geographicalId())->surface().toGlobal(matchedHit->localPosition());
+      if (preselection(position, superCluster, phiVsRSlope, 1)) {
+        hasLay2Hit = true;
+        layer2Hits_.push_back(matchedHit);
       }
     }
   }
 
-  if(!(hasLay1Hit && hasLay2Hit)) useTID = true;
-  if(std::abs(scEta) > tidEtaUsage_) useTID = true;
+  if (!(hasLay1Hit && hasLay2Hit))
+    useTID = true;
+  if (std::abs(scEta) > tidEtaUsage_)
+    useTID = true;
   std::vector<TrajectoryMeasurement> tid1measurements;
-  if(useDL.at(2) && useTID) tid1measurements = layerMeasurements.measurements(*tid1,initialTSOS,*thePropagator,*theEstimator);
+  if (useDL.at(2) && useTID)
+    tid1measurements = layerMeasurements.measurements(*tid1, initialTSOS, *thePropagator, *theEstimator);
   std::vector<TrajectoryMeasurement> tid2measurements;
-  if(useDL.at(3) && useTID) tid2measurements = layerMeasurements.measurements(*tid2,initialTSOS,*thePropagator,*theEstimator);
+  if (useDL.at(3) && useTID)
+    tid2measurements = layerMeasurements.measurements(*tid2, initialTSOS, *thePropagator, *theEstimator);
   std::vector<TrajectoryMeasurement> tid3measurements;
-  if(useDL.at(4) && useTID) tid3measurements = layerMeasurements.measurements(*tid3,initialTSOS,*thePropagator,*theEstimator);
+  if (useDL.at(4) && useTID)
+    tid3measurements = layerMeasurements.measurements(*tid3, initialTSOS, *thePropagator, *theEstimator);
 
-  for(std::vector<TrajectoryMeasurement>::const_iterator tmIter = tid1measurements.begin(); tmIter != tid1measurements.end(); ++ tmIter){
-    if(tid1MHC < tidMaxHits_){
-    ConstRecHitPointer hit = tmIter->recHit();
-    const SiStripMatchedRecHit2D* matchedHit = matchedHitConverter(hit);
-    if(matchedHit){
-      GlobalPoint position = trackerGeometryHandle->idToDet(matchedHit->geographicalId())->surface().toGlobal(matchedHit->localPosition());
-      if(preselection(position, superCluster, phiVsRSlope, 2)){
-	tid1MHC++;
-	hasLay1Hit = true;
-	layer1Hits_.push_back(matchedHit);
-	hasLay2Hit = true;
-	layer2Hits_.push_back(matchedHit);
+  for (std::vector<TrajectoryMeasurement>::const_iterator tmIter = tid1measurements.begin();
+       tmIter != tid1measurements.end();
+       ++tmIter) {
+    if (tid1MHC < tidMaxHits_) {
+      ConstRecHitPointer hit = tmIter->recHit();
+      const SiStripMatchedRecHit2D* matchedHit = matchedHitConverter(hit);
+      if (matchedHit) {
+        GlobalPoint position = trackerGeometryHandle->idToDet(matchedHit->geographicalId())
+                                   ->surface()
+                                   .toGlobal(matchedHit->localPosition());
+        if (preselection(position, superCluster, phiVsRSlope, 2)) {
+          tid1MHC++;
+          hasLay1Hit = true;
+          layer1Hits_.push_back(matchedHit);
+          hasLay2Hit = true;
+          layer2Hits_.push_back(matchedHit);
+        }
+      } else if (useDL.at(8) && tid1BHC < monoMaxHits_) {
+        const SiStripRecHit2D* backupHit = backupHitConverter(hit);
+        if (backupHit) {
+          GlobalPoint position = trackerGeometryHandle->idToDet(backupHit->geographicalId())
+                                     ->surface()
+                                     .toGlobal(backupHit->localPosition());
+          if (preselection(position, superCluster, phiVsRSlope, 4) && position.perp() > 37.) {
+            tid1BHC++;
+            hasBackupHit = true;
+            backupLayer2Hits_.push_back(backupHit);
+          }
+        }
       }
-    }else if(useDL.at(8) && tid1BHC < monoMaxHits_){
-      const SiStripRecHit2D* backupHit = backupHitConverter(hit);
-      if(backupHit){
-	GlobalPoint position = trackerGeometryHandle->idToDet(backupHit->geographicalId())->surface().toGlobal(backupHit->localPosition());
-	if(preselection(position, superCluster, phiVsRSlope, 4) && position.perp() > 37.){
-	  tid1BHC++;
-	  hasBackupHit = true;
-	  backupLayer2Hits_.push_back(backupHit);
-	}
-      }
-    }
     }
   }
 
-  for(std::vector<TrajectoryMeasurement>::const_iterator tmIter = tid2measurements.begin(); tmIter != tid2measurements.end(); ++ tmIter){
-    if(tid2MHC < tidMaxHits_){
-    ConstRecHitPointer hit = tmIter->recHit();
-    const SiStripMatchedRecHit2D* matchedHit = matchedHitConverter(hit);
-    if(matchedHit){
-      GlobalPoint position = trackerGeometryHandle->idToDet(matchedHit->geographicalId())->surface().toGlobal(matchedHit->localPosition());
-      if(preselection(position, superCluster, phiVsRSlope, 2)){
-	tid2MHC++;
-	hasLay1Hit = true;
-	layer1Hits_.push_back(matchedHit);
-	hasLay2Hit = true;
-	layer2Hits_.push_back(matchedHit);
+  for (std::vector<TrajectoryMeasurement>::const_iterator tmIter = tid2measurements.begin();
+       tmIter != tid2measurements.end();
+       ++tmIter) {
+    if (tid2MHC < tidMaxHits_) {
+      ConstRecHitPointer hit = tmIter->recHit();
+      const SiStripMatchedRecHit2D* matchedHit = matchedHitConverter(hit);
+      if (matchedHit) {
+        GlobalPoint position = trackerGeometryHandle->idToDet(matchedHit->geographicalId())
+                                   ->surface()
+                                   .toGlobal(matchedHit->localPosition());
+        if (preselection(position, superCluster, phiVsRSlope, 2)) {
+          tid2MHC++;
+          hasLay1Hit = true;
+          layer1Hits_.push_back(matchedHit);
+          hasLay2Hit = true;
+          layer2Hits_.push_back(matchedHit);
+        }
+      } else if (useDL.at(8) && tid2BHC < monoMaxHits_) {
+        const SiStripRecHit2D* backupHit = backupHitConverter(hit);
+        if (backupHit) {
+          GlobalPoint position = trackerGeometryHandle->idToDet(backupHit->geographicalId())
+                                     ->surface()
+                                     .toGlobal(backupHit->localPosition());
+          if (preselection(position, superCluster, phiVsRSlope, 4) && position.perp() > 37.) {
+            tid2BHC++;
+            hasBackupHit = true;
+            backupLayer2Hits_.push_back(backupHit);
+          }
+        }
       }
-    }else if(useDL.at(8) && tid2BHC < monoMaxHits_){
-      const SiStripRecHit2D* backupHit = backupHitConverter(hit);
-      if(backupHit){
-	GlobalPoint position = trackerGeometryHandle->idToDet(backupHit->geographicalId())->surface().toGlobal(backupHit->localPosition());
-	if(preselection(position, superCluster, phiVsRSlope, 4) && position.perp() > 37.){
-	  tid2BHC++;
-	  hasBackupHit = true;
-	  backupLayer2Hits_.push_back(backupHit);
-	}
-      }
-    }
     }
   }
 
-  for(std::vector<TrajectoryMeasurement>::const_iterator tmIter = tid3measurements.begin(); tmIter != tid3measurements.end(); ++ tmIter){
-    if(tid3MHC < tidMaxHits_){
-    ConstRecHitPointer hit = tmIter->recHit();
-    const SiStripMatchedRecHit2D* matchedHit = matchedHitConverter(hit);
-    if(matchedHit){
-      GlobalPoint position = trackerGeometryHandle->idToDet(matchedHit->geographicalId())->surface().toGlobal(matchedHit->localPosition());
-      if(preselection(position, superCluster, phiVsRSlope, 2)){
-	tid3MHC++;
-	hasLay1Hit = true;
-	layer1Hits_.push_back(matchedHit);
-	hasLay2Hit = true;
-	layer2Hits_.push_back(matchedHit);
+  for (std::vector<TrajectoryMeasurement>::const_iterator tmIter = tid3measurements.begin();
+       tmIter != tid3measurements.end();
+       ++tmIter) {
+    if (tid3MHC < tidMaxHits_) {
+      ConstRecHitPointer hit = tmIter->recHit();
+      const SiStripMatchedRecHit2D* matchedHit = matchedHitConverter(hit);
+      if (matchedHit) {
+        GlobalPoint position = trackerGeometryHandle->idToDet(matchedHit->geographicalId())
+                                   ->surface()
+                                   .toGlobal(matchedHit->localPosition());
+        if (preselection(position, superCluster, phiVsRSlope, 2)) {
+          tid3MHC++;
+          hasLay1Hit = true;
+          layer1Hits_.push_back(matchedHit);
+          hasLay2Hit = true;
+          layer2Hits_.push_back(matchedHit);
+        }
+      } else if (useDL.at(8) && tid3BHC < monoMaxHits_) {
+        const SiStripRecHit2D* backupHit = backupHitConverter(hit);
+        if (backupHit) {
+          GlobalPoint position = trackerGeometryHandle->idToDet(backupHit->geographicalId())
+                                     ->surface()
+                                     .toGlobal(backupHit->localPosition());
+          if (preselection(position, superCluster, phiVsRSlope, 4) && position.perp() > 37.) {
+            tid3BHC++;
+            hasBackupHit = true;
+            backupLayer2Hits_.push_back(backupHit);
+          }
+        }
       }
-    }else if(useDL.at(8) && tid3BHC < monoMaxHits_){
-      const SiStripRecHit2D* backupHit = backupHitConverter(hit);
-      if(backupHit){
-	GlobalPoint position = trackerGeometryHandle->idToDet(backupHit->geographicalId())->surface().toGlobal(backupHit->localPosition());
-	if(preselection(position, superCluster, phiVsRSlope, 4) && position.perp() > 37.){
-	  tid3BHC++;
-	  hasBackupHit = true;
-	  backupLayer2Hits_.push_back(backupHit);
-	}
-      }
-    }
     }
   }
 
   std::vector<TrajectoryMeasurement> tec1measurements;
-  if(useDL.at(5)) tec1measurements = layerMeasurements.measurements(*tec1,initialTSOS,*thePropagator,*theEstimator);
+  if (useDL.at(5))
+    tec1measurements = layerMeasurements.measurements(*tec1, initialTSOS, *thePropagator, *theEstimator);
   std::vector<TrajectoryMeasurement> tec2measurements;
-  if(useDL.at(6)) tec2measurements = layerMeasurements.measurements(*tec2,initialTSOS,*thePropagator,*theEstimator);
+  if (useDL.at(6))
+    tec2measurements = layerMeasurements.measurements(*tec2, initialTSOS, *thePropagator, *theEstimator);
   std::vector<TrajectoryMeasurement> tec3measurements;
-  if(useDL.at(7)) tec3measurements = layerMeasurements.measurements(*tec3,initialTSOS,*thePropagator,*theEstimator);
+  if (useDL.at(7))
+    tec3measurements = layerMeasurements.measurements(*tec3, initialTSOS, *thePropagator, *theEstimator);
 
-  for(std::vector<TrajectoryMeasurement>::const_iterator tmIter = tec1measurements.begin(); tmIter != tec1measurements.end(); ++ tmIter){
-    if(tec1MHC < tecMaxHits_){
-    ConstRecHitPointer hit = tmIter->recHit();
-    const SiStripMatchedRecHit2D* matchedHit = matchedHitConverter(hit);
-    if(matchedHit){
-      GlobalPoint position = trackerGeometryHandle->idToDet(matchedHit->geographicalId())->surface().toGlobal(matchedHit->localPosition());
-      if(preselection(position, superCluster, phiVsRSlope, 3)){
-	tec1MHC++;
-	hasLay1Hit = true;
-	layer1Hits_.push_back(matchedHit);
-	hasLay2Hit = true;
-	layer2Hits_.push_back(matchedHit);
+  for (std::vector<TrajectoryMeasurement>::const_iterator tmIter = tec1measurements.begin();
+       tmIter != tec1measurements.end();
+       ++tmIter) {
+    if (tec1MHC < tecMaxHits_) {
+      ConstRecHitPointer hit = tmIter->recHit();
+      const SiStripMatchedRecHit2D* matchedHit = matchedHitConverter(hit);
+      if (matchedHit) {
+        GlobalPoint position = trackerGeometryHandle->idToDet(matchedHit->geographicalId())
+                                   ->surface()
+                                   .toGlobal(matchedHit->localPosition());
+        if (preselection(position, superCluster, phiVsRSlope, 3)) {
+          tec1MHC++;
+          hasLay1Hit = true;
+          layer1Hits_.push_back(matchedHit);
+          hasLay2Hit = true;
+          layer2Hits_.push_back(matchedHit);
+        }
       }
-    }
     }
   }
 
-  for(std::vector<TrajectoryMeasurement>::const_iterator tmIter = tec2measurements.begin(); tmIter != tec2measurements.end(); ++ tmIter){
-    if(tec2MHC < tecMaxHits_){
-    ConstRecHitPointer hit = tmIter->recHit();
-    const SiStripMatchedRecHit2D* matchedHit = matchedHitConverter(hit);
-    if(matchedHit){
-      GlobalPoint position = trackerGeometryHandle->idToDet(matchedHit->geographicalId())->surface().toGlobal(matchedHit->localPosition());
-      if(preselection(position, superCluster, phiVsRSlope, 3)){
-	tec2MHC++;
-	hasLay1Hit = true;
-	layer1Hits_.push_back(matchedHit);
-	hasLay2Hit = true;
-	layer2Hits_.push_back(matchedHit);
+  for (std::vector<TrajectoryMeasurement>::const_iterator tmIter = tec2measurements.begin();
+       tmIter != tec2measurements.end();
+       ++tmIter) {
+    if (tec2MHC < tecMaxHits_) {
+      ConstRecHitPointer hit = tmIter->recHit();
+      const SiStripMatchedRecHit2D* matchedHit = matchedHitConverter(hit);
+      if (matchedHit) {
+        GlobalPoint position = trackerGeometryHandle->idToDet(matchedHit->geographicalId())
+                                   ->surface()
+                                   .toGlobal(matchedHit->localPosition());
+        if (preselection(position, superCluster, phiVsRSlope, 3)) {
+          tec2MHC++;
+          hasLay1Hit = true;
+          layer1Hits_.push_back(matchedHit);
+          hasLay2Hit = true;
+          layer2Hits_.push_back(matchedHit);
+        }
       }
-    }
     }
   }
 
-  for(std::vector<TrajectoryMeasurement>::const_iterator tmIter = tec3measurements.begin(); tmIter != tec3measurements.end(); ++ tmIter){
-    if(tec3MHC < tecMaxHits_){
-    ConstRecHitPointer hit = tmIter->recHit();
-    const SiStripMatchedRecHit2D* matchedHit = matchedHitConverter(hit);
-    if(matchedHit){
-      GlobalPoint position = trackerGeometryHandle->idToDet(matchedHit->geographicalId())->surface().toGlobal(matchedHit->localPosition());
-      if(preselection(position, superCluster, phiVsRSlope, 3)){
-	tec3MHC++;
-	hasLay2Hit = true;
-	layer2Hits_.push_back(matchedHit);
+  for (std::vector<TrajectoryMeasurement>::const_iterator tmIter = tec3measurements.begin();
+       tmIter != tec3measurements.end();
+       ++tmIter) {
+    if (tec3MHC < tecMaxHits_) {
+      ConstRecHitPointer hit = tmIter->recHit();
+      const SiStripMatchedRecHit2D* matchedHit = matchedHitConverter(hit);
+      if (matchedHit) {
+        GlobalPoint position = trackerGeometryHandle->idToDet(matchedHit->geographicalId())
+                                   ->surface()
+                                   .toGlobal(matchedHit->localPosition());
+        if (preselection(position, superCluster, phiVsRSlope, 3)) {
+          tec3MHC++;
+          hasLay2Hit = true;
+          layer2Hits_.push_back(matchedHit);
+        }
       }
-    }
     }
   }
 
   // We have 2 arrays of hits, combine them to form seeds
-  if( hasLay1Hit && hasLay2Hit ){
+  if (hasLay1Hit && hasLay2Hit) {
+    for (std::vector<const SiStripMatchedRecHit2D*>::const_iterator hit1 = layer1Hits_.begin();
+         hit1 != layer1Hits_.end();
+         ++hit1) {
+      for (std::vector<const SiStripMatchedRecHit2D*>::const_iterator hit2 = layer2Hits_.begin();
+           hit2 != layer2Hits_.end();
+           ++hit2) {
+        if (seedCounter < maxSeeds_) {
+          if (checkHitsAndTSOS(hit1, hit2, scr, scz, pT, scEta)) {
+            seedCounter++;
 
-    for (std::vector<const SiStripMatchedRecHit2D*>::const_iterator hit1 = layer1Hits_.begin() ; hit1!= layer1Hits_.end(); ++hit1) {
-      for (std::vector<const SiStripMatchedRecHit2D*>::const_iterator hit2 = layer2Hits_.begin() ; hit2!= layer2Hits_.end(); ++hit2) {
+            recHits_.clear();
 
-	if(seedCounter < maxSeeds_){
+            SiStripMatchedRecHit2D* hit;
+            hit = new SiStripMatchedRecHit2D(*(dynamic_cast<const SiStripMatchedRecHit2D*>(*hit1)));
+            recHits_.push_back(hit);
+            hit = new SiStripMatchedRecHit2D(*(dynamic_cast<const SiStripMatchedRecHit2D*>(*hit2)));
+            recHits_.push_back(hit);
 
-	  if(checkHitsAndTSOS(hit1,hit2,scr,scz,pT,scEta)) {
+            PropagationDirection dir = alongMomentum;
+            reco::ElectronSeed seed(pts_, recHits_, dir);
+            reco::ElectronSeed::CaloClusterRef caloCluster(seedCluster);
+            seed.setCaloCluster(caloCluster);
+            result.push_back(seed);
+          }
+        }
 
-	    seedCounter++;
+      }  // end of hit 2 loop
 
-	    recHits_.clear();
+    }  // end of hit 1 loop
 
-	    SiStripMatchedRecHit2D *hit;
-	    hit=new SiStripMatchedRecHit2D(*(dynamic_cast <const SiStripMatchedRecHit2D *> (*hit1) ) );
-	    recHits_.push_back(hit);
-	    hit=new SiStripMatchedRecHit2D(*(dynamic_cast <const SiStripMatchedRecHit2D *> (*hit2) ) );
-	    recHits_.push_back(hit);
-
-	    PropagationDirection dir = alongMomentum;
-	    reco::ElectronSeed seed(pts_,recHits_,dir) ;
-	    reco::ElectronSeed::CaloClusterRef caloCluster(seedCluster) ;
-	    seed.setCaloCluster(caloCluster) ;
-	    result.push_back(seed);
-
-	  }
-
-	}
-
-      }// end of hit 2 loop
-
-    }// end of hit 1 loop
-
-  }//end of seed making
+  }  //end of seed making
 
   //Make seeds using TID Ring 3 if necessary
 
-  if(hasLay1Hit && hasBackupHit && seedCounter == 0){
+  if (hasLay1Hit && hasBackupHit && seedCounter == 0) {
+    for (std::vector<const SiStripMatchedRecHit2D*>::const_iterator hit1 = layer1Hits_.begin();
+         hit1 != layer1Hits_.end();
+         ++hit1) {
+      for (std::vector<const SiStripRecHit2D*>::const_iterator hit2 = backupLayer2Hits_.begin();
+           hit2 != backupLayer2Hits_.end();
+           ++hit2) {
+        if (seedCounter < maxSeeds_) {
+          if (altCheckHitsAndTSOS(hit1, hit2, scr, scz, pT, scEta)) {
+            seedCounter++;
 
-    for (std::vector<const SiStripMatchedRecHit2D*>::const_iterator hit1 = layer1Hits_.begin() ; hit1!= layer1Hits_.end(); ++hit1) {
-      for (std::vector<const SiStripRecHit2D*>::const_iterator hit2 = backupLayer2Hits_.begin() ; hit2!= backupLayer2Hits_.end(); ++hit2) {
+            recHits_.clear();
 
-	if(seedCounter < maxSeeds_){
+            SiStripMatchedRecHit2D* innerHit;
+            innerHit = new SiStripMatchedRecHit2D(*(dynamic_cast<const SiStripMatchedRecHit2D*>(*hit1)));
+            recHits_.push_back(innerHit);
+            SiStripRecHit2D* outerHit;
+            outerHit = new SiStripRecHit2D(*(dynamic_cast<const SiStripRecHit2D*>(*hit2)));
+            recHits_.push_back(outerHit);
 
-	  if(altCheckHitsAndTSOS(hit1,hit2,scr,scz,pT,scEta)) {
+            PropagationDirection dir = alongMomentum;
+            reco::ElectronSeed seed(pts_, recHits_, dir);
+            reco::ElectronSeed::CaloClusterRef caloCluster(seedCluster);
+            seed.setCaloCluster(caloCluster);
+            result.push_back(seed);
+          }
+        }
 
-	    seedCounter++;
+      }  // end of hit 2 loop
 
-	    recHits_.clear();
+    }  // end of hit 1 loop
 
-	    SiStripMatchedRecHit2D *innerHit;
-	    innerHit=new SiStripMatchedRecHit2D(*(dynamic_cast <const SiStripMatchedRecHit2D *> (*hit1) ) );
-	    recHits_.push_back(innerHit);
-	    SiStripRecHit2D *outerHit;
-	    outerHit=new SiStripRecHit2D(*(dynamic_cast <const SiStripRecHit2D *> (*hit2) ) );
-	    recHits_.push_back(outerHit);
+  }  // end of backup seed making
 
-	    PropagationDirection dir = alongMomentum;
-	    reco::ElectronSeed seed(pts_,recHits_,dir) ;
-	    reco::ElectronSeed::CaloClusterRef caloCluster(seedCluster) ;
-	    seed.setCaloCluster(caloCluster) ;
-	    result.push_back(seed);
-
-	  }
-
-	}
-
-      }// end of hit 2 loop
-
-    }// end of hit 1 loop
-
-  }// end of backup seed making
-
-} // end of findSeedsFromCluster
-
-
+}  // end of findSeedsFromCluster
 
 bool SiStripElectronSeedGenerator::checkHitsAndTSOS(std::vector<const SiStripMatchedRecHit2D*>::const_iterator hit1,
-						    std::vector<const SiStripMatchedRecHit2D*>::const_iterator hit2,
-						    double rc,double zc,double pT,double scEta) {
-
+                                                    std::vector<const SiStripMatchedRecHit2D*>::const_iterator hit2,
+                                                    double rc,
+                                                    double zc,
+                                                    double pT,
+                                                    double scEta) {
   bool seedCutsSatisfied = false;
 
   using namespace std;
 
-  GlobalPoint hit1Pos = trackerGeometryHandle->idToDet((*hit1)->geographicalId())->surface().toGlobal((*hit1)->localPosition());
-  double r1 = sqrt(hit1Pos.x()*hit1Pos.x() + hit1Pos.y()*hit1Pos.y());
+  GlobalPoint hit1Pos =
+      trackerGeometryHandle->idToDet((*hit1)->geographicalId())->surface().toGlobal((*hit1)->localPosition());
+  double r1 = sqrt(hit1Pos.x() * hit1Pos.x() + hit1Pos.y() * hit1Pos.y());
   double phi1 = hit1Pos.phi();
-  double z1=hit1Pos.z();
+  double z1 = hit1Pos.z();
 
-  GlobalPoint hit2Pos = trackerGeometryHandle->idToDet((*hit2)->geographicalId())->surface().toGlobal((*hit2)->localPosition());
-  double r2 = sqrt(hit2Pos.x()*hit2Pos.x() + hit2Pos.y()*hit2Pos.y());
+  GlobalPoint hit2Pos =
+      trackerGeometryHandle->idToDet((*hit2)->geographicalId())->surface().toGlobal((*hit2)->localPosition());
+  double r2 = sqrt(hit2Pos.x() * hit2Pos.x() + hit2Pos.y() * hit2Pos.y());
   double phi2 = hit2Pos.phi();
   double z2 = hit2Pos.z();
 
-  if(r2 > r1 && (std::abs(z2) > std::abs(z1) || std::abs(scEta) < 0.25)) {
-
+  if (r2 > r1 && (std::abs(z2) > std::abs(z1) || std::abs(scEta) < 0.25)) {
     //Consider the circle made of IP and Hit 1; Calculate it's radius using pT
 
-    double curv = pT*100*.877;
+    double curv = pT * 100 * .877;
 
     //Predict phi of hit 2
-    double a = (r2-r1)/(2*curv);
-    double b = phiDiff(phi2,phi1);
+    double a = (r2 - r1) / (2 * curv);
+    double b = phiDiff(phi2, phi1);
     //UB added '=0' to avoid compiler warning
-    double phiMissHit2=0;
-    if(std::abs(b - a)<std::abs(b + a)) phiMissHit2 = b - a;
-    if(std::abs(b - a)>std::abs(b + a)) phiMissHit2 = b + a;
+    double phiMissHit2 = 0;
+    if (std::abs(b - a) < std::abs(b + a))
+      phiMissHit2 = b - a;
+    if (std::abs(b - a) > std::abs(b + a))
+      phiMissHit2 = b + a;
 
-    double zMissHit2 = z2 - (r2*(zc-z1)-r1*zc+rc*z1)/(rc-r1);
+    double zMissHit2 = z2 - (r2 * (zc - z1) - r1 * zc + rc * z1) / (rc - r1);
 
-    double rPredHit2 = r1 + (rc-r1)/(zc-z1)*(z2-z1);
+    double rPredHit2 = r1 + (rc - r1) / (zc - z1) * (z2 - z1);
     double rMissHit2 = r2 - rPredHit2;
 
     int subdetector = whichSubdetector(hit2);
@@ -559,169 +603,193 @@ bool SiStripElectronSeedGenerator::checkHitsAndTSOS(std::vector<const SiStripMat
     bool zDiff = true;
     double zVar1 = std::abs(z1);
     double zVar2 = std::abs(z2 - z1);
-    if(zVar1 > 75 && zVar1 < 95 && (zVar2 > 18 || zVar2 < 5)) zDiff = false;
-    if(zVar1 > 100 && zVar1 < 110 && (zVar2 > 35 || zVar2 < 5)) zDiff = false;
-    if(zVar1 > 125 && zVar1 < 150 && (zVar2 > 18 || zVar2 < 5)) zDiff = false;
+    if (zVar1 > 75 && zVar1 < 95 && (zVar2 > 18 || zVar2 < 5))
+      zDiff = false;
+    if (zVar1 > 100 && zVar1 < 110 && (zVar2 > 35 || zVar2 < 5))
+      zDiff = false;
+    if (zVar1 > 125 && zVar1 < 150 && (zVar2 > 18 || zVar2 < 5))
+      zDiff = false;
 
-    if(subdetector == 1){
+    if (subdetector == 1) {
       int tibExtraCut = 0;
-      if(r1 > 23 && r1 < 28 && r2 > 31 && r2 < 37) tibExtraCut = 1;
-      if(std::abs(phiMissHit2) < tibPhiMissHit2Cut_ && std::abs(zMissHit2) < tibZMissHit2Cut_ && tibExtraCut == 1) seedCutsSatisfied = true;
-    }else if(subdetector == 2){
+      if (r1 > 23 && r1 < 28 && r2 > 31 && r2 < 37)
+        tibExtraCut = 1;
+      if (std::abs(phiMissHit2) < tibPhiMissHit2Cut_ && std::abs(zMissHit2) < tibZMissHit2Cut_ && tibExtraCut == 1)
+        seedCutsSatisfied = true;
+    } else if (subdetector == 2) {
       int tidExtraCut = 0;
-      if(r1 > 23 && r1 < 34 && r2 > 26 && r2 < 42) tidExtraCut = 1;
-      if(std::abs(phiMissHit2) < tidPhiMissHit2Cut_ && std::abs(rMissHit2) < tidRMissHit2Cut_ && tidExtraCut == 1 && zDiff) seedCutsSatisfied = true;
-    }else if(subdetector == 3){
+      if (r1 > 23 && r1 < 34 && r2 > 26 && r2 < 42)
+        tidExtraCut = 1;
+      if (std::abs(phiMissHit2) < tidPhiMissHit2Cut_ && std::abs(rMissHit2) < tidRMissHit2Cut_ && tidExtraCut == 1 &&
+          zDiff)
+        seedCutsSatisfied = true;
+    } else if (subdetector == 3) {
       int tecExtraCut = 0;
-      if(r1 > 23 && r1 < 32 && r2 > 26 && r2 < 42) tecExtraCut = 1;
-      if(std::abs(phiMissHit2) < tecPhiMissHit2Cut_ && std::abs(rMissHit2) < tecRMissHit2Cut_ && tecExtraCut == 1 && zDiff) seedCutsSatisfied = true;
+      if (r1 > 23 && r1 < 32 && r2 > 26 && r2 < 42)
+        tecExtraCut = 1;
+      if (std::abs(phiMissHit2) < tecPhiMissHit2Cut_ && std::abs(rMissHit2) < tecRMissHit2Cut_ && tecExtraCut == 1 &&
+          zDiff)
+        seedCutsSatisfied = true;
     }
-
   }
 
-  if(!seedCutsSatisfied) return false;
+  if (!seedCutsSatisfied)
+    return false;
 
   // seed checks borrowed from pixel-based algoritm
 
-
-
   typedef TrajectoryStateOnSurface TSOS;
 
-  double vertexZ = z1 - (r1 * (zc - z1) ) / (rc - r1);
-  GlobalPoint eleVertex(0.,0.,vertexZ);
+  double vertexZ = z1 - (r1 * (zc - z1)) / (rc - r1);
+  GlobalPoint eleVertex(0., 0., vertexZ);
 
-   // FIXME optimize: move outside loop
-    edm::ESHandle<MagneticField> bfield;
-    theSetup->get<IdealMagneticFieldRecord>().get(bfield);
-    float nomField = bfield->nominalValue();
+  // FIXME optimize: move outside loop
+  edm::ESHandle<MagneticField> bfield;
+  theSetup->get<IdealMagneticFieldRecord>().get(bfield);
+  float nomField = bfield->nominalValue();
 
   // make a spiral
-  FastHelix helix(hit2Pos,hit1Pos,eleVertex,nomField,&*bfield);
-  if (!helix.isValid()) return false;
+  FastHelix helix(hit2Pos, hit1Pos, eleVertex, nomField, &*bfield);
+  if (!helix.isValid())
+    return false;
 
   FreeTrajectoryState fts(helix.stateAtVertex());
-  TSOS propagatedState = thePropagator->propagate(fts,(*hit1)->det()->surface());
+  TSOS propagatedState = thePropagator->propagate(fts, (*hit1)->det()->surface());
 
-  if (!propagatedState.isValid()) return false;
+  if (!propagatedState.isValid())
+    return false;
 
   TSOS updatedState = theUpdator->update(propagatedState, **hit1);
-  TSOS propagatedState_out = thePropagator->propagate(fts,(*hit2)->det()->surface()) ;
+  TSOS propagatedState_out = thePropagator->propagate(fts, (*hit2)->det()->surface());
 
-  if (!propagatedState_out.isValid()) return false;
+  if (!propagatedState_out.isValid())
+    return false;
 
   // the seed has now passed all the cuts
 
   TSOS updatedState_out = theUpdator->update(propagatedState_out, **hit2);
 
-  pts_ =  trajectoryStateTransform::persistentState(updatedState_out, (*hit2)->geographicalId().rawId());
+  pts_ = trajectoryStateTransform::persistentState(updatedState_out, (*hit2)->geographicalId().rawId());
 
   return true;
 }
 
 bool SiStripElectronSeedGenerator::altCheckHitsAndTSOS(std::vector<const SiStripMatchedRecHit2D*>::const_iterator hit1,
-						       std::vector<const SiStripRecHit2D*>::const_iterator hit2,
-						       double rc,double zc,double pT,double scEta) {
-
+                                                       std::vector<const SiStripRecHit2D*>::const_iterator hit2,
+                                                       double rc,
+                                                       double zc,
+                                                       double pT,
+                                                       double scEta) {
   bool seedCutSatisfied = false;
 
   using namespace std;
 
-  GlobalPoint hit1Pos = trackerGeometryHandle->idToDet((*hit1)->geographicalId())->surface().toGlobal((*hit1)->localPosition());
-  double r1 = sqrt(hit1Pos.x()*hit1Pos.x() + hit1Pos.y()*hit1Pos.y());
+  GlobalPoint hit1Pos =
+      trackerGeometryHandle->idToDet((*hit1)->geographicalId())->surface().toGlobal((*hit1)->localPosition());
+  double r1 = sqrt(hit1Pos.x() * hit1Pos.x() + hit1Pos.y() * hit1Pos.y());
   double phi1 = hit1Pos.phi();
-  double z1=hit1Pos.z();
+  double z1 = hit1Pos.z();
 
-  GlobalPoint hit2Pos = trackerGeometryHandle->idToDet((*hit2)->geographicalId())->surface().toGlobal((*hit2)->localPosition());
-  double r2 = sqrt(hit2Pos.x()*hit2Pos.x() + hit2Pos.y()*hit2Pos.y());
+  GlobalPoint hit2Pos =
+      trackerGeometryHandle->idToDet((*hit2)->geographicalId())->surface().toGlobal((*hit2)->localPosition());
+  double r2 = sqrt(hit2Pos.x() * hit2Pos.x() + hit2Pos.y() * hit2Pos.y());
   double phi2 = hit2Pos.phi();
   double z2 = hit2Pos.z();
 
-  if(r2 > r1 && std::abs(z2) > std::abs(z1)) {
-
+  if (r2 > r1 && std::abs(z2) > std::abs(z1)) {
     //Consider the circle made of IP and Hit 1; Calculate it's radius using pT
 
-    double curv = pT*100*.877;
+    double curv = pT * 100 * .877;
 
     //Predict phi of hit 2
-    double a = (r2-r1)/(2*curv);
-    double b = phiDiff(phi2,phi1);
+    double a = (r2 - r1) / (2 * curv);
+    double b = phiDiff(phi2, phi1);
     double phiMissHit2 = 0;
-    if(std::abs(b - a)<std::abs(b + a)) phiMissHit2 = b - a;
-    if(std::abs(b - a)>std::abs(b + a)) phiMissHit2 = b + a;
+    if (std::abs(b - a) < std::abs(b + a))
+      phiMissHit2 = b - a;
+    if (std::abs(b - a) > std::abs(b + a))
+      phiMissHit2 = b + a;
 
-    if(std::abs(phiMissHit2) < monoPhiMissHit2Cut_) seedCutSatisfied = true;
-
+    if (std::abs(phiMissHit2) < monoPhiMissHit2Cut_)
+      seedCutSatisfied = true;
   }
 
-  if(!seedCutSatisfied) return false;
+  if (!seedCutSatisfied)
+    return false;
 
   // seed checks borrowed from pixel-based algoritm
 
- 
-
-
   typedef TrajectoryStateOnSurface TSOS;
 
-  double vertexZ = z1 - (r1 * (zc - z1) ) / (rc - r1);
-  GlobalPoint eleVertex(0.,0.,vertexZ);
+  double vertexZ = z1 - (r1 * (zc - z1)) / (rc - r1);
+  GlobalPoint eleVertex(0., 0., vertexZ);
 
-   // FIXME optimize: move outside loop
-    edm::ESHandle<MagneticField> bfield;
-    theSetup->get<IdealMagneticFieldRecord>().get(bfield);
-    float nomField = bfield->nominalValue();
+  // FIXME optimize: move outside loop
+  edm::ESHandle<MagneticField> bfield;
+  theSetup->get<IdealMagneticFieldRecord>().get(bfield);
+  float nomField = bfield->nominalValue();
 
   // make a spiral
-  FastHelix helix(hit2Pos,hit1Pos,eleVertex,nomField,&*bfield);
-  if (!helix.isValid()) return false;
+  FastHelix helix(hit2Pos, hit1Pos, eleVertex, nomField, &*bfield);
+  if (!helix.isValid())
+    return false;
 
   FreeTrajectoryState fts(helix.stateAtVertex());
-  TSOS propagatedState = thePropagator->propagate(fts,(*hit1)->det()->surface());
+  TSOS propagatedState = thePropagator->propagate(fts, (*hit1)->det()->surface());
 
-  if (!propagatedState.isValid()) return false;
+  if (!propagatedState.isValid())
+    return false;
 
   TSOS updatedState = theUpdator->update(propagatedState, **hit1);
-  TSOS propagatedState_out = thePropagator->propagate(fts,(*hit2)->det()->surface()) ;
+  TSOS propagatedState_out = thePropagator->propagate(fts, (*hit2)->det()->surface());
 
-  if (!propagatedState_out.isValid()) return false;
+  if (!propagatedState_out.isValid())
+    return false;
 
   // the seed has now passed all the cuts
 
   TSOS updatedState_out = theUpdator->update(propagatedState_out, **hit2);
 
-  pts_ =  trajectoryStateTransform::persistentState(updatedState_out, (*hit2)->geographicalId().rawId());
+  pts_ = trajectoryStateTransform::persistentState(updatedState_out, (*hit2)->geographicalId().rawId());
 
   return true;
 }
 
-
-bool SiStripElectronSeedGenerator::preselection(GlobalPoint position,GlobalPoint superCluster,double phiVsRSlope,int hitLayer){
+bool SiStripElectronSeedGenerator::preselection(GlobalPoint position,
+                                                GlobalPoint superCluster,
+                                                double phiVsRSlope,
+                                                int hitLayer) {
   double r = position.perp();
   double phi = position.phi();
   double z = position.z();
   double scr = superCluster.perp();
   double scphi = superCluster.phi();
   double scz = superCluster.z();
-  double psi = phiDiff(phi,scphi);
-  double deltaPsi = psi - (scr-r)*phiVsRSlope;
-  double antiDeltaPsi = psi - (r-scr)*phiVsRSlope;
+  double psi = phiDiff(phi, scphi);
+  double deltaPsi = psi - (scr - r) * phiVsRSlope;
+  double antiDeltaPsi = psi - (r - scr) * phiVsRSlope;
   double dP;
-  if (std::abs(deltaPsi)<std::abs(antiDeltaPsi)){
+  if (std::abs(deltaPsi) < std::abs(antiDeltaPsi)) {
     dP = deltaPsi;
-  }else{
+  } else {
     dP = antiDeltaPsi;
   }
-  double originZ = (scr*z - r*scz)/(scr-r);
+  double originZ = (scr * z - r * scz) / (scr - r);
 
   bool result = false;
 
-  if(hitLayer == 1){
-    if(std::abs(originZ) < tibOriginZCut_ && std::abs(dP) < tibDeltaPsiCut_) result = true;
-  }else if(hitLayer == 2){
-    if(std::abs(originZ) < tidOriginZCut_ && std::abs(dP) < tidDeltaPsiCut_) result = true;
-  }else if(hitLayer == 3){
-    if(std::abs(originZ) < tecOriginZCut_ && std::abs(dP) < tecDeltaPsiCut_) result = true;
-  }else if(hitLayer == 4){
-    if(std::abs(originZ) < monoOriginZCut_ && std::abs(dP) < monoDeltaPsiCut_) result = true;
+  if (hitLayer == 1) {
+    if (std::abs(originZ) < tibOriginZCut_ && std::abs(dP) < tibDeltaPsiCut_)
+      result = true;
+  } else if (hitLayer == 2) {
+    if (std::abs(originZ) < tidOriginZCut_ && std::abs(dP) < tidDeltaPsiCut_)
+      result = true;
+  } else if (hitLayer == 3) {
+    if (std::abs(originZ) < tecOriginZCut_ && std::abs(dP) < tecDeltaPsiCut_)
+      result = true;
+  } else if (hitLayer == 4) {
+    if (std::abs(originZ) < monoOriginZCut_ && std::abs(dP) < monoDeltaPsiCut_)
+      result = true;
   }
 
   return result;
@@ -729,80 +797,77 @@ bool SiStripElectronSeedGenerator::preselection(GlobalPoint position,GlobalPoint
 
 // Helper algorithms
 
-int SiStripElectronSeedGenerator::whichSubdetector(std::vector<const SiStripMatchedRecHit2D*>::const_iterator hit){
+int SiStripElectronSeedGenerator::whichSubdetector(std::vector<const SiStripMatchedRecHit2D*>::const_iterator hit) {
   int result = 0;
-  if(((*hit)->geographicalId()).subdetId() == StripSubdetector::TIB){
+  if (((*hit)->geographicalId()).subdetId() == StripSubdetector::TIB) {
     result = 1;
-  }else if(((*hit)->geographicalId()).subdetId() == StripSubdetector::TID){
+  } else if (((*hit)->geographicalId()).subdetId() == StripSubdetector::TID) {
     result = 2;
-  }else if(((*hit)->geographicalId()).subdetId() == StripSubdetector::TEC){
+  } else if (((*hit)->geographicalId()).subdetId() == StripSubdetector::TEC) {
     result = 3;
   }
   return result;
 }
 
-const SiStripMatchedRecHit2D* SiStripElectronSeedGenerator::matchedHitConverter(ConstRecHitPointer crhp){
+const SiStripMatchedRecHit2D* SiStripElectronSeedGenerator::matchedHitConverter(ConstRecHitPointer crhp) {
   const TrackingRecHit* trh = crhp->hit();
   const SiStripMatchedRecHit2D* matchedHit = dynamic_cast<const SiStripMatchedRecHit2D*>(trh);
   return matchedHit;
 }
 
-const SiStripRecHit2D* SiStripElectronSeedGenerator::backupHitConverter(ConstRecHitPointer crhp){
+const SiStripRecHit2D* SiStripElectronSeedGenerator::backupHitConverter(ConstRecHitPointer crhp) {
   const TrackingRecHit* trh = crhp->hit();
   const SiStripRecHit2D* backupHit = dynamic_cast<const SiStripRecHit2D*>(trh);
   return backupHit;
 }
 
-std::vector<bool> SiStripElectronSeedGenerator::useDetLayer(double scEta){
+std::vector<bool> SiStripElectronSeedGenerator::useDetLayer(double scEta) {
   std::vector<bool> useDetLayer;
   double variable = std::abs(scEta);
-  if(variable > 0 && variable < 1.8){
+  if (variable > 0 && variable < 1.8) {
     useDetLayer.push_back(true);
-  }else{
+  } else {
     useDetLayer.push_back(false);
   }
-  if(variable > 0 && variable < 1.5){
+  if (variable > 0 && variable < 1.5) {
     useDetLayer.push_back(true);
-  }else{
+  } else {
     useDetLayer.push_back(false);
   }
-  if(variable > 1 && variable < 2.1){
+  if (variable > 1 && variable < 2.1) {
     useDetLayer.push_back(true);
-  }else{
+  } else {
     useDetLayer.push_back(false);
   }
-  if(variable > 1 && variable < 2.2){
+  if (variable > 1 && variable < 2.2) {
     useDetLayer.push_back(true);
-  }else{
+  } else {
     useDetLayer.push_back(false);
   }
-  if(variable > 1 && variable < 2.3){
+  if (variable > 1 && variable < 2.3) {
     useDetLayer.push_back(true);
-  }else{
+  } else {
     useDetLayer.push_back(false);
   }
-  if(variable > 1.8 && variable < 2.5){
+  if (variable > 1.8 && variable < 2.5) {
     useDetLayer.push_back(true);
-  }else{
+  } else {
     useDetLayer.push_back(false);
   }
-  if(variable > 1.8 && variable < 2.5){
+  if (variable > 1.8 && variable < 2.5) {
     useDetLayer.push_back(true);
-  }else{
+  } else {
     useDetLayer.push_back(false);
   }
-  if(variable > 1.8 && variable < 2.5){
+  if (variable > 1.8 && variable < 2.5) {
     useDetLayer.push_back(true);
-  }else{
+  } else {
     useDetLayer.push_back(false);
   }
-  if(variable > 1.2 && variable < 1.6){
+  if (variable > 1.2 && variable < 1.6) {
     useDetLayer.push_back(true);
-  }else{
+  } else {
     useDetLayer.push_back(false);
   }
   return useDetLayer;
 }
-
-
-

--- a/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/TrajSeedMatcher.cc
@@ -11,7 +11,7 @@
 
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 #include "TrackingTools/RecoGeometry/interface/RecoGeometryRecord.h"
-#include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h" 
+#include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
 
 #include "RecoTracker/Record/interface/NavigationSchoolRecord.h"
 
@@ -20,113 +20,108 @@
 
 constexpr float TrajSeedMatcher::kElectronMass_;
 
-TrajSeedMatcher::TrajSeedMatcher(const edm::ParameterSet& pset):
-  cacheIDMagField_(0),
-  minNrHits_(pset.getParameter<std::vector<unsigned int> >("minNrHits")),
-  minNrHitsValidLayerBins_(pset.getParameter<std::vector<int> >("minNrHitsValidLayerBins"))
-{
+TrajSeedMatcher::TrajSeedMatcher(const edm::ParameterSet& pset)
+    : cacheIDMagField_(0),
+      minNrHits_(pset.getParameter<std::vector<unsigned int> >("minNrHits")),
+      minNrHitsValidLayerBins_(pset.getParameter<std::vector<int> >("minNrHitsValidLayerBins")) {
   useRecoVertex_ = pset.getParameter<bool>("useRecoVertex");
   navSchoolLabel_ = pset.getParameter<std::string>("navSchool");
   detLayerGeomLabel_ = pset.getParameter<std::string>("detLayerGeom");
-  const auto cutsPSets=pset.getParameter<std::vector<edm::ParameterSet> >("matchingCuts");
-  for(const auto & cutPSet : cutsPSets){
-    int version=cutPSet.getParameter<int>("version");
-    switch(version){
-    case 1:
-      matchingCuts_.emplace_back(std::make_unique<MatchingCutsV1>(cutPSet));
-      break;
-    case 2:
-      matchingCuts_.emplace_back(std::make_unique<MatchingCutsV2>(cutPSet));
-      break;
-    default:
-      throw cms::Exception("InvalidConfig") <<" Error TrajSeedMatcher::TrajSeedMatcher pixel match cuts version "<<version<<" not recognised"<<std::endl;
+  const auto cutsPSets = pset.getParameter<std::vector<edm::ParameterSet> >("matchingCuts");
+  for (const auto& cutPSet : cutsPSets) {
+    int version = cutPSet.getParameter<int>("version");
+    switch (version) {
+      case 1:
+        matchingCuts_.emplace_back(std::make_unique<MatchingCutsV1>(cutPSet));
+        break;
+      case 2:
+        matchingCuts_.emplace_back(std::make_unique<MatchingCutsV2>(cutPSet));
+        break;
+      default:
+        throw cms::Exception("InvalidConfig") << " Error TrajSeedMatcher::TrajSeedMatcher pixel match cuts version "
+                                              << version << " not recognised" << std::endl;
     }
   }
- 
-  if(minNrHitsValidLayerBins_.size()+1!=minNrHits_.size()){  
-    throw cms::Exception("InvalidConfig")<<" TrajSeedMatcher::TrajSeedMatcher minNrHitsValidLayerBins should be 1 less than minNrHits when its "<<minNrHitsValidLayerBins_.size()<<" vs "<<minNrHits_.size();
+
+  if (minNrHitsValidLayerBins_.size() + 1 != minNrHits_.size()) {
+    throw cms::Exception("InvalidConfig")
+        << " TrajSeedMatcher::TrajSeedMatcher minNrHitsValidLayerBins should be 1 less than minNrHits when its "
+        << minNrHitsValidLayerBins_.size() << " vs " << minNrHits_.size();
   }
 }
 
-edm::ParameterSetDescription TrajSeedMatcher::makePSetDescription()
-{
+edm::ParameterSetDescription TrajSeedMatcher::makePSetDescription() {
   edm::ParameterSetDescription desc;
-  desc.add<bool>("useRecoVertex",false);
-  desc.add<std::string>("navSchool","SimpleNavigationSchool");
-  desc.add<std::string>("detLayerGeom","hltESPGlobalDetLayerGeometry");
-  desc.add<std::vector<int> >("minNrHitsValidLayerBins",{4});
-  desc.add<std::vector<unsigned int> >("minNrHits",{2,3});
-  
+  desc.add<bool>("useRecoVertex", false);
+  desc.add<std::string>("navSchool", "SimpleNavigationSchool");
+  desc.add<std::string>("detLayerGeom", "hltESPGlobalDetLayerGeometry");
+  desc.add<std::vector<int> >("minNrHitsValidLayerBins", {4});
+  desc.add<std::vector<unsigned int> >("minNrHits", {2, 3});
+
   edm::ParameterSetDescription cutsDesc;
-  auto cutDescCases = 
-    1 >> 
-    (edm::ParameterDescription<double>("dPhiMax",0.04,true) and
-     edm::ParameterDescription<double>("dRZMax",0.09,true) and
-     edm::ParameterDescription<double>("dRZMaxLowEtThres",20.,true) and
-     edm::ParameterDescription<std::vector<double> >("dRZMaxLowEtEtaBins",std::vector<double>{1.,1.5},true) and
-     edm::ParameterDescription<std::vector<double> >("dRZMaxLowEt",std::vector<double>{0.09,0.15,0.09},true)) or
-    2 >> 
-    (edm::ParameterDescription<std::vector<double> >("dPhiMaxHighEt",{0.003},true) and
-     edm::ParameterDescription<std::vector<double> >("dPhiMaxHighEtThres",{0.0},true) and
-     edm::ParameterDescription<std::vector<double> >("dPhiMaxLowEtGrad",{0.0},true) and
-     edm::ParameterDescription<std::vector<double> >("dRZMaxHighEt",{0.005},true) and
-     edm::ParameterDescription<std::vector<double> >("dRZMaxHighEtThres",{30},true) and
-     edm::ParameterDescription<std::vector<double> >("dRZMaxLowEtGrad",{-0.002},true) and
-     edm::ParameterDescription<std::vector<double> >("etaBins",{},true));
-  cutsDesc.ifValue(edm::ParameterDescription<int>("version",1,true), std::move(cutDescCases));
+  auto cutDescCases = 1 >> (edm::ParameterDescription<double>("dPhiMax", 0.04, true) and
+                            edm::ParameterDescription<double>("dRZMax", 0.09, true) and
+                            edm::ParameterDescription<double>("dRZMaxLowEtThres", 20., true) and
+                            edm::ParameterDescription<std::vector<double> >(
+                                "dRZMaxLowEtEtaBins", std::vector<double>{1., 1.5}, true) and
+                            edm::ParameterDescription<std::vector<double> >(
+                                "dRZMaxLowEt", std::vector<double>{0.09, 0.15, 0.09}, true)) or
+                      2 >> (edm::ParameterDescription<std::vector<double> >("dPhiMaxHighEt", {0.003}, true) and
+                            edm::ParameterDescription<std::vector<double> >("dPhiMaxHighEtThres", {0.0}, true) and
+                            edm::ParameterDescription<std::vector<double> >("dPhiMaxLowEtGrad", {0.0}, true) and
+                            edm::ParameterDescription<std::vector<double> >("dRZMaxHighEt", {0.005}, true) and
+                            edm::ParameterDescription<std::vector<double> >("dRZMaxHighEtThres", {30}, true) and
+                            edm::ParameterDescription<std::vector<double> >("dRZMaxLowEtGrad", {-0.002}, true) and
+                            edm::ParameterDescription<std::vector<double> >("etaBins", {}, true));
+  cutsDesc.ifValue(edm::ParameterDescription<int>("version", 1, true), std::move(cutDescCases));
 
   edm::ParameterSet defaults;
-  defaults.addParameter<double>("dPhiMax",0.04);
-  defaults.addParameter<double>("dRZMax",0.09);
-  defaults.addParameter<double>("dRZMaxLowEtThres",0.09);
-  defaults.addParameter<std::vector<double> >("dRZMaxLowEtEtaBins",std::vector<double>{1.,1.5});
-  defaults.addParameter<std::vector<double> >("dRZMaxLowEt",std::vector<double>{0.09,0.09,0.09});
-  defaults.addParameter<int>("version",1);
-  desc.addVPSet("matchingCuts",cutsDesc,std::vector<edm::ParameterSet>{defaults,defaults,defaults});
+  defaults.addParameter<double>("dPhiMax", 0.04);
+  defaults.addParameter<double>("dRZMax", 0.09);
+  defaults.addParameter<double>("dRZMaxLowEtThres", 0.09);
+  defaults.addParameter<std::vector<double> >("dRZMaxLowEtEtaBins", std::vector<double>{1., 1.5});
+  defaults.addParameter<std::vector<double> >("dRZMaxLowEt", std::vector<double>{0.09, 0.09, 0.09});
+  defaults.addParameter<int>("version", 1);
+  desc.addVPSet("matchingCuts", cutsDesc, std::vector<edm::ParameterSet>{defaults, defaults, defaults});
   return desc;
 }
 
-void TrajSeedMatcher::doEventSetup(const edm::EventSetup& iSetup)
-{
-  if (cacheIDMagField_!=iSetup.get<IdealMagneticFieldRecord>().cacheIdentifier()) {
+void TrajSeedMatcher::doEventSetup(const edm::EventSetup& iSetup) {
+  if (cacheIDMagField_ != iSetup.get<IdealMagneticFieldRecord>().cacheIdentifier()) {
     iSetup.get<IdealMagneticFieldRecord>().get(magField_);
-    cacheIDMagField_=iSetup.get<IdealMagneticFieldRecord>().cacheIdentifier();
-    forwardPropagator_=std::make_unique<PropagatorWithMaterial>(alongMomentum,kElectronMass_,&*(magField_));
-    backwardPropagator_=std::make_unique<PropagatorWithMaterial>(oppositeToMomentum,kElectronMass_,&*(magField_));
+    cacheIDMagField_ = iSetup.get<IdealMagneticFieldRecord>().cacheIdentifier();
+    forwardPropagator_ = std::make_unique<PropagatorWithMaterial>(alongMomentum, kElectronMass_, &*(magField_));
+    backwardPropagator_ = std::make_unique<PropagatorWithMaterial>(oppositeToMomentum, kElectronMass_, &*(magField_));
   }
-  iSetup.get<NavigationSchoolRecord>().get(navSchoolLabel_,navSchool_);
-  iSetup.get<RecoGeometryRecord>().get(detLayerGeomLabel_,detLayerGeom_);
+  iSetup.get<NavigationSchoolRecord>().get(navSchoolLabel_, navSchool_);
+  iSetup.get<RecoGeometryRecord>().get(detLayerGeomLabel_, detLayerGeom_);
 }
 
-
-std::vector<TrajSeedMatcher::SeedWithInfo>
-TrajSeedMatcher::compatibleSeeds(const TrajectorySeedCollection& seeds, const GlobalPoint& candPos,
-				  const GlobalPoint & vprim, const float energy)
-{
-  if(!forwardPropagator_ || !backwardPropagator_ || !magField_.isValid()){
-    throw cms::Exception("LogicError") <<__FUNCTION__<<" can not make pixel seeds as event setup has not properly been called";
+std::vector<TrajSeedMatcher::SeedWithInfo> TrajSeedMatcher::compatibleSeeds(const TrajectorySeedCollection& seeds,
+                                                                            const GlobalPoint& candPos,
+                                                                            const GlobalPoint& vprim,
+                                                                            const float energy) {
+  if (!forwardPropagator_ || !backwardPropagator_ || !magField_.isValid()) {
+    throw cms::Exception("LogicError") << __FUNCTION__
+                                       << " can not make pixel seeds as event setup has not properly been called";
   }
 
   clearCache();
-  
+
   std::vector<SeedWithInfo> matchedSeeds;
-  for(const auto& seed : seeds) {
-    std::vector<SCHitMatch> matchedHitsNeg = processSeed(seed,candPos,vprim,energy,-1);
-    std::vector<SCHitMatch> matchedHitsPos = processSeed(seed,candPos,vprim,energy,+1);
+  for (const auto& seed : seeds) {
+    std::vector<SCHitMatch> matchedHitsNeg = processSeed(seed, candPos, vprim, energy, -1);
+    std::vector<SCHitMatch> matchedHitsPos = processSeed(seed, candPos, vprim, energy, +1);
     int nrValidLayersPos = 0;
     int nrValidLayersNeg = 0;
-    if(matchedHitsNeg.size()>=2){
-      nrValidLayersNeg = getNrValidLayersAlongTraj(matchedHitsNeg[0],
-						   matchedHitsNeg[1],
-						   candPos,vprim,energy,-1);
+    if (matchedHitsNeg.size() >= 2) {
+      nrValidLayersNeg = getNrValidLayersAlongTraj(matchedHitsNeg[0], matchedHitsNeg[1], candPos, vprim, energy, -1);
     }
-    if(matchedHitsPos.size()>=2){
-      nrValidLayersPos = getNrValidLayersAlongTraj(matchedHitsPos[0],
-						   matchedHitsPos[1],
-						   candPos,vprim,energy,+1);
+    if (matchedHitsPos.size() >= 2) {
+      nrValidLayersPos = getNrValidLayersAlongTraj(matchedHitsPos[0], matchedHitsPos[1], candPos, vprim, energy, +1);
     }
-    
-    int nrValidLayers = std::max(nrValidLayersNeg,nrValidLayersPos);
+
+    int nrValidLayers = std::max(nrValidLayersNeg, nrValidLayersPos);
     size_t nrHitsRequired = getNrHitsRequired(nrValidLayers);
     //so we require the number of hits to exactly match, this is because we currently do not
     //do any duplicate cleaning for the input seeds
@@ -134,15 +129,12 @@ TrajSeedMatcher::compatibleSeeds(const TrajectorySeedCollection& seeds, const Gl
     //so if you did >=nrHitsRequired, you would get the same seed multiple times
     //ideally we should fix this and clean our input seed collection so each seed is only in once
     //also it should be studied what impact having a 3rd hit has on a GsfTrack
-    //ie will we get a significantly different result seeding with a hit pair 
+    //ie will we get a significantly different result seeding with a hit pair
     //and the same the hit pair with a 3rd hit added
     //in that case, perhaps it should be >=
-    if(matchedHitsNeg.size()==nrHitsRequired ||
-       matchedHitsPos.size()==nrHitsRequired){
-      matchedSeeds.push_back({seed,matchedHitsPos,matchedHitsNeg,nrValidLayers});
+    if (matchedHitsNeg.size() == nrHitsRequired || matchedHitsPos.size() == nrHitsRequired) {
+      matchedSeeds.push_back({seed, matchedHitsPos, matchedHitsNeg, nrValidLayers});
     }
-    
-
   }
   return matchedSeeds;
 }
@@ -150,337 +142,347 @@ TrajSeedMatcher::compatibleSeeds(const TrajectorySeedCollection& seeds, const Gl
 //checks if the hits of the seed match within requested selection
 //matched hits are required to be consecutive, as soon as hit isnt matched,
 //the function returns, it doesnt allow skipping hits
-std::vector<TrajSeedMatcher::SCHitMatch>
-TrajSeedMatcher::processSeed(const TrajectorySeed& seed, const GlobalPoint& candPos,
-			     const GlobalPoint & vprim, const float energy, const int charge )
-{
+std::vector<TrajSeedMatcher::SCHitMatch> TrajSeedMatcher::processSeed(const TrajectorySeed& seed,
+                                                                      const GlobalPoint& candPos,
+                                                                      const GlobalPoint& vprim,
+                                                                      const float energy,
+                                                                      const int charge) {
   const float candEta = candPos.eta();
-  const float candEt = energy*std::sin(candPos.theta());
-  
+  const float candEt = energy * std::sin(candPos.theta());
+
   FreeTrajectoryState trajStateFromVtx = FTSFromVertexToPointFactory::get(*magField_, candPos, vprim, energy, charge);
   PerpendicularBoundPlaneBuilder bpb;
-  TrajectoryStateOnSurface initialTrajState(trajStateFromVtx,*bpb(trajStateFromVtx.position(), 
-								  trajStateFromVtx.momentum()));
- 
+  TrajectoryStateOnSurface initialTrajState(trajStateFromVtx,
+                                            *bpb(trajStateFromVtx.position(), trajStateFromVtx.momentum()));
+
   std::vector<SCHitMatch> matchedHits;
-  SCHitMatch firstHit = matchFirstHit(seed,initialTrajState,vprim,*backwardPropagator_);
-  firstHit.setExtra(candEt,candEta,candPos.phi(),charge,1);
-  if(passesMatchSel(firstHit,0)){
+  SCHitMatch firstHit = matchFirstHit(seed, initialTrajState, vprim, *backwardPropagator_);
+  firstHit.setExtra(candEt, candEta, candPos.phi(), charge, 1);
+  if (passesMatchSel(firstHit, 0)) {
     matchedHits.push_back(firstHit);
 
     //now we can figure out the z vertex
-    double zVertex = useRecoVertex_ ? vprim.z() : getZVtxFromExtrapolation(vprim,firstHit.hitPos(),candPos);
-    GlobalPoint vertex(vprim.x(),vprim.y(),zVertex);
-    
-    FreeTrajectoryState firstHitFreeTraj = FTSFromVertexToPointFactory::get(*magField_, firstHit.hitPos(), 
-									    vertex, energy, charge) ;
- 
+    double zVertex = useRecoVertex_ ? vprim.z() : getZVtxFromExtrapolation(vprim, firstHit.hitPos(), candPos);
+    GlobalPoint vertex(vprim.x(), vprim.y(), zVertex);
+
+    FreeTrajectoryState firstHitFreeTraj =
+        FTSFromVertexToPointFactory::get(*magField_, firstHit.hitPos(), vertex, energy, charge);
+
     GlobalPoint prevHitPos = firstHit.hitPos();
-    for(size_t hitNr=1;hitNr<matchingCuts_.size() && hitNr<seed.nHits();hitNr++){
-      SCHitMatch hit = match2ndToNthHit(seed,firstHitFreeTraj,hitNr,prevHitPos,vertex,*forwardPropagator_);
-      hit.setExtra(candEt,candEta,candPos.phi(),charge,1);
-      if(passesMatchSel(hit,hitNr)){
-	matchedHits.push_back(hit);
-	prevHitPos = hit.hitPos();
-      }else break;
+    for (size_t hitNr = 1; hitNr < matchingCuts_.size() && hitNr < seed.nHits(); hitNr++) {
+      SCHitMatch hit = match2ndToNthHit(seed, firstHitFreeTraj, hitNr, prevHitPos, vertex, *forwardPropagator_);
+      hit.setExtra(candEt, candEta, candPos.phi(), charge, 1);
+      if (passesMatchSel(hit, hitNr)) {
+        matchedHits.push_back(hit);
+        prevHitPos = hit.hitPos();
+      } else
+        break;
     }
   }
   return matchedHits;
 }
 
 // compute the z vertex from the candidate position and the found pixel hit
-float TrajSeedMatcher::getZVtxFromExtrapolation(const GlobalPoint& primeVtxPos, const GlobalPoint& hitPos,
-						const GlobalPoint& candPos)
-{
-  auto sq = [](float x){return x*x;};
-  auto calRDiff = [sq](const GlobalPoint& p1,const GlobalPoint& p2){
-    return std::sqrt(sq(p2.x()-p1.x()) + sq(p2.y()-p1.y()));
+float TrajSeedMatcher::getZVtxFromExtrapolation(const GlobalPoint& primeVtxPos,
+                                                const GlobalPoint& hitPos,
+                                                const GlobalPoint& candPos) {
+  auto sq = [](float x) { return x * x; };
+  auto calRDiff = [sq](const GlobalPoint& p1, const GlobalPoint& p2) {
+    return std::sqrt(sq(p2.x() - p1.x()) + sq(p2.y() - p1.y()));
   };
-  const double r1Diff = calRDiff(primeVtxPos,hitPos);
-  const double r2Diff = calRDiff(hitPos,candPos);
-  return hitPos.z() - r1Diff*(candPos.z()-hitPos.z())/r2Diff;
+  const double r1Diff = calRDiff(primeVtxPos, hitPos);
+  const double r2Diff = calRDiff(hitPos, candPos);
+  return hitPos.z() - r1Diff * (candPos.z() - hitPos.z()) / r2Diff;
 }
 
-bool TrajSeedMatcher::passTrajPreSel(const GlobalPoint& hitPos, const GlobalPoint& candPos)const
-{
-  float dt = hitPos.x()*candPos.x()+hitPos.y()*candPos.y();
-  if (dt<0) return false;
-  if (dt<kPhiCut_*(candPos.perp()*hitPos.perp())) return false;
+bool TrajSeedMatcher::passTrajPreSel(const GlobalPoint& hitPos, const GlobalPoint& candPos) const {
+  float dt = hitPos.x() * candPos.x() + hitPos.y() * candPos.y();
+  if (dt < 0)
+    return false;
+  if (dt < kPhiCut_ * (candPos.perp() * hitPos.perp()))
+    return false;
   return true;
 }
 
 const TrajectoryStateOnSurface& TrajSeedMatcher::getTrajStateFromVtx(const TrackingRecHit& hit,
-								     const TrajectoryStateOnSurface& initialState,
-								     const PropagatorWithMaterial& propagator)
-{
-  auto& trajStateFromVtxCache = initialState.charge()==1 ? trajStateFromVtxPosChargeCache_ :
-                                                           trajStateFromVtxNegChargeCache_;
+                                                                     const TrajectoryStateOnSurface& initialState,
+                                                                     const PropagatorWithMaterial& propagator) {
+  auto& trajStateFromVtxCache =
+      initialState.charge() == 1 ? trajStateFromVtxPosChargeCache_ : trajStateFromVtxNegChargeCache_;
 
   auto key = hit.det()->gdetIndex();
   auto res = trajStateFromVtxCache.find(key);
-  if(res!=trajStateFromVtxCache.end()) return res->second;
-  else{ //doesnt exist, need to make it
+  if (res != trajStateFromVtxCache.end())
+    return res->second;
+  else {  //doesnt exist, need to make it
     //FIXME: check for efficiency
-    auto val = trajStateFromVtxCache.emplace(key,propagator.propagate(initialState,hit.det()->surface()));
+    auto val = trajStateFromVtxCache.emplace(key, propagator.propagate(initialState, hit.det()->surface()));
     return val.first->second;
   }
 }
 
 const TrajectoryStateOnSurface& TrajSeedMatcher::getTrajStateFromPoint(const TrackingRecHit& hit,
-								       const FreeTrajectoryState& initialState,
-								       const GlobalPoint& point,
-								       const PropagatorWithMaterial& propagator)
-{
-  
-  auto& trajStateFromPointCache = initialState.charge()==1 ? trajStateFromPointPosChargeCache_ :
-                                                             trajStateFromPointNegChargeCache_;
+                                                                       const FreeTrajectoryState& initialState,
+                                                                       const GlobalPoint& point,
+                                                                       const PropagatorWithMaterial& propagator) {
+  auto& trajStateFromPointCache =
+      initialState.charge() == 1 ? trajStateFromPointPosChargeCache_ : trajStateFromPointNegChargeCache_;
 
-  auto key = std::make_pair(hit.det()->gdetIndex(),point);
+  auto key = std::make_pair(hit.det()->gdetIndex(), point);
   auto res = trajStateFromPointCache.find(key);
-  if(res!=trajStateFromPointCache.end()) return res->second;
-  else{ //doesnt exist, need to make it
+  if (res != trajStateFromPointCache.end())
+    return res->second;
+  else {  //doesnt exist, need to make it
     //FIXME: check for efficiency
-    auto val = trajStateFromPointCache.emplace(key,propagator.propagate(initialState,hit.det()->surface()));
+    auto val = trajStateFromPointCache.emplace(key, propagator.propagate(initialState, hit.det()->surface()));
     return val.first->second;
   }
 }
 
 TrajSeedMatcher::SCHitMatch TrajSeedMatcher::matchFirstHit(const TrajectorySeed& seed,
-							   const TrajectoryStateOnSurface& initialState,
-							   const GlobalPoint& vtxPos,
-							   const PropagatorWithMaterial& propagator)
-{
+                                                           const TrajectoryStateOnSurface& initialState,
+                                                           const GlobalPoint& vtxPos,
+                                                           const PropagatorWithMaterial& propagator) {
   const TrajectorySeed::range& hits = seed.recHits();
   auto hitIt = hits.first;
 
-  if(hitIt->isValid()){
-    const TrajectoryStateOnSurface& trajStateFromVtx = getTrajStateFromVtx(*hitIt,initialState,propagator);
-    if(trajStateFromVtx.isValid()) return SCHitMatch(vtxPos,trajStateFromVtx,*hitIt);  
+  if (hitIt->isValid()) {
+    const TrajectoryStateOnSurface& trajStateFromVtx = getTrajStateFromVtx(*hitIt, initialState, propagator);
+    if (trajStateFromVtx.isValid())
+      return SCHitMatch(vtxPos, trajStateFromVtx, *hitIt);
   }
   return SCHitMatch();
 }
 
 TrajSeedMatcher::SCHitMatch TrajSeedMatcher::match2ndToNthHit(const TrajectorySeed& seed,
-							   const FreeTrajectoryState& initialState,
-							   const size_t hitNr,
-							   const GlobalPoint& prevHitPos,
-							   const GlobalPoint& vtxPos,
-							   const PropagatorWithMaterial& propagator)
-{
+                                                              const FreeTrajectoryState& initialState,
+                                                              const size_t hitNr,
+                                                              const GlobalPoint& prevHitPos,
+                                                              const GlobalPoint& vtxPos,
+                                                              const PropagatorWithMaterial& propagator) {
   const TrajectorySeed::range& hits = seed.recHits();
-  auto hitIt = hits.first+hitNr;
-  
-  if(hitIt->isValid()){
-    const TrajectoryStateOnSurface& trajState = getTrajStateFromPoint(*hitIt,initialState,prevHitPos,propagator);
-    
-    if(trajState.isValid()){
-      return SCHitMatch(vtxPos,trajState,*hitIt);  
+  auto hitIt = hits.first + hitNr;
+
+  if (hitIt->isValid()) {
+    const TrajectoryStateOnSurface& trajState = getTrajStateFromPoint(*hitIt, initialState, prevHitPos, propagator);
+
+    if (trajState.isValid()) {
+      return SCHitMatch(vtxPos, trajState, *hitIt);
     }
   }
   return SCHitMatch();
-  
 }
 
-void TrajSeedMatcher::clearCache()
-{
+void TrajSeedMatcher::clearCache() {
   trajStateFromVtxPosChargeCache_.clear();
   trajStateFromVtxNegChargeCache_.clear();
   trajStateFromPointPosChargeCache_.clear();
   trajStateFromPointNegChargeCache_.clear();
 }
 
-bool TrajSeedMatcher::passesMatchSel(const TrajSeedMatcher::SCHitMatch& hit, const size_t hitNr)const
-{
-  if(hitNr<matchingCuts_.size()){
+bool TrajSeedMatcher::passesMatchSel(const TrajSeedMatcher::SCHitMatch& hit, const size_t hitNr) const {
+  if (hitNr < matchingCuts_.size()) {
     return (*matchingCuts_[hitNr])(hit);
-  }else{
-    throw cms::Exception("LogicError") <<" Error, attempting to apply selection to hit "<<hitNr<<" but only cuts for "<<matchingCuts_.size()<<" defined";
+  } else {
+    throw cms::Exception("LogicError") << " Error, attempting to apply selection to hit " << hitNr
+                                       << " but only cuts for " << matchingCuts_.size() << " defined";
   }
 }
 
-int TrajSeedMatcher::getNrValidLayersAlongTraj(const SCHitMatch& hit1, const SCHitMatch& hit2,
-						const GlobalPoint& candPos,
-						const GlobalPoint & vprim, 
-						const float energy, const int charge)
-{
-  double zVertex = useRecoVertex_ ? vprim.z() : getZVtxFromExtrapolation(vprim,hit1.hitPos(),candPos);
-  GlobalPoint vertex(vprim.x(),vprim.y(),zVertex);
-  
-  FreeTrajectoryState firstHitFreeTraj = FTSFromVertexToPointFactory::get(*magField_,hit1.hitPos(), 
-									  vertex, energy, charge);
-  const TrajectoryStateOnSurface& secondHitTraj = getTrajStateFromPoint(*hit2.hit(),firstHitFreeTraj,hit1.hitPos(),*forwardPropagator_);
-  return getNrValidLayersAlongTraj(hit2.hit()->geographicalId(),secondHitTraj); 
+int TrajSeedMatcher::getNrValidLayersAlongTraj(const SCHitMatch& hit1,
+                                               const SCHitMatch& hit2,
+                                               const GlobalPoint& candPos,
+                                               const GlobalPoint& vprim,
+                                               const float energy,
+                                               const int charge) {
+  double zVertex = useRecoVertex_ ? vprim.z() : getZVtxFromExtrapolation(vprim, hit1.hitPos(), candPos);
+  GlobalPoint vertex(vprim.x(), vprim.y(), zVertex);
+
+  FreeTrajectoryState firstHitFreeTraj =
+      FTSFromVertexToPointFactory::get(*magField_, hit1.hitPos(), vertex, energy, charge);
+  const TrajectoryStateOnSurface& secondHitTraj =
+      getTrajStateFromPoint(*hit2.hit(), firstHitFreeTraj, hit1.hitPos(), *forwardPropagator_);
+  return getNrValidLayersAlongTraj(hit2.hit()->geographicalId(), secondHitTraj);
 }
 
-int TrajSeedMatcher::getNrValidLayersAlongTraj(const DetId& hitId, const TrajectoryStateOnSurface& hitTrajState)const
-{
-  
+int TrajSeedMatcher::getNrValidLayersAlongTraj(const DetId& hitId, const TrajectoryStateOnSurface& hitTrajState) const {
   const DetLayer* detLayer = detLayerGeom_->idToLayer(hitId);
-  if(detLayer==nullptr) return 0;
+  if (detLayer == nullptr)
+    return 0;
 
   const FreeTrajectoryState& hitFreeState = *hitTrajState.freeState();
-  const std::vector<const DetLayer*> inLayers  = navSchool_->compatibleLayers(*detLayer,hitFreeState,oppositeToMomentum); 
-  const std::vector<const DetLayer*> outLayers = navSchool_->compatibleLayers(*detLayer,hitFreeState,alongMomentum); 
-  
-  int nrValidLayers=1; //because our current hit is also valid and wont be included in the count otherwise
-  int nrPixInLayers=0;
-  int nrPixOutLayers=0;
-  for(auto layer : inLayers){
-    if(GeomDetEnumerators::isTrackerPixel(layer->subDetector())){ 
+  const std::vector<const DetLayer*> inLayers =
+      navSchool_->compatibleLayers(*detLayer, hitFreeState, oppositeToMomentum);
+  const std::vector<const DetLayer*> outLayers = navSchool_->compatibleLayers(*detLayer, hitFreeState, alongMomentum);
+
+  int nrValidLayers = 1;  //because our current hit is also valid and wont be included in the count otherwise
+  int nrPixInLayers = 0;
+  int nrPixOutLayers = 0;
+  for (auto layer : inLayers) {
+    if (GeomDetEnumerators::isTrackerPixel(layer->subDetector())) {
       nrPixInLayers++;
-      if(layerHasValidHits(*layer,hitTrajState,*backwardPropagator_)) nrValidLayers++;  
+      if (layerHasValidHits(*layer, hitTrajState, *backwardPropagator_))
+        nrValidLayers++;
     }
   }
-  for(auto layer : outLayers){
-    if(GeomDetEnumerators::isTrackerPixel(layer->subDetector())){ 
+  for (auto layer : outLayers) {
+    if (GeomDetEnumerators::isTrackerPixel(layer->subDetector())) {
       nrPixOutLayers++;
-      if(layerHasValidHits(*layer,hitTrajState,*forwardPropagator_)) nrValidLayers++;  
+      if (layerHasValidHits(*layer, hitTrajState, *forwardPropagator_))
+        nrValidLayers++;
     }
   }
   return nrValidLayers;
 }
-						 
-bool TrajSeedMatcher::layerHasValidHits(const DetLayer& layer, const TrajectoryStateOnSurface& hitSurState,
-					const Propagator& propToLayerFromState)const
-{
+
+bool TrajSeedMatcher::layerHasValidHits(const DetLayer& layer,
+                                        const TrajectoryStateOnSurface& hitSurState,
+                                        const Propagator& propToLayerFromState) const {
   //FIXME: do not hardcode with werid magic numbers stolen from ancient tracking code
   //its taken from https://cmssdt.cern.ch/dxr/CMSSW/source/RecoTracker/TrackProducer/interface/TrackProducerBase.icc#165
   //which inspires this code
-  Chi2MeasurementEstimator estimator(30.,-3.0,0.5,2.0,0.5,1.e12);  // same as defauts....
-  
-  const std::vector<GeometricSearchDet::DetWithState>& detWithState = layer.compatibleDets(hitSurState,propToLayerFromState,estimator);
-  if(detWithState.empty()) return false;
-  else{
+  Chi2MeasurementEstimator estimator(30., -3.0, 0.5, 2.0, 0.5, 1.e12);  // same as defauts....
+
+  const std::vector<GeometricSearchDet::DetWithState>& detWithState =
+      layer.compatibleDets(hitSurState, propToLayerFromState, estimator);
+  if (detWithState.empty())
+    return false;
+  else {
     DetId id = detWithState.front().first->geographicalId();
     MeasurementDetWithData measDet = measTkEvt_->idToDet(id);
-    if(measDet.isActive()) return true;
-    else return false;
+    if (measDet.isActive())
+      return true;
+    else
+      return false;
   }
 }
 
-
-size_t TrajSeedMatcher::getNrHitsRequired(const int nrValidLayers)const
-{
-  for(size_t binNr=0;binNr<minNrHitsValidLayerBins_.size();binNr++){
-    if(nrValidLayers<minNrHitsValidLayerBins_[binNr]) return minNrHits_[binNr];
+size_t TrajSeedMatcher::getNrHitsRequired(const int nrValidLayers) const {
+  for (size_t binNr = 0; binNr < minNrHitsValidLayerBins_.size(); binNr++) {
+    if (nrValidLayers < minNrHitsValidLayerBins_[binNr])
+      return minNrHits_[binNr];
   }
   return minNrHits_.back();
-  
 }
 
 TrajSeedMatcher::SCHitMatch::SCHitMatch(const GlobalPoint& vtxPos,
-					const TrajectoryStateOnSurface& trajState,
-					const TrackingRecHit& hit):
-  detId_(hit.geographicalId()),
-  hitPos_(hit.globalPosition()),
-  hit_(&hit),
-  et_(0),eta_(0),phi_(0),charge_(0),nrClus_(0)
-{
-  EleRelPointPair pointPair(hitPos_,trajState.globalParameters().position(),vtxPos);
-  dRZ_ = detId_.subdetId()==PixelSubdetector::PixelBarrel ? pointPair.dZ() : pointPair.dPerp();
+                                        const TrajectoryStateOnSurface& trajState,
+                                        const TrackingRecHit& hit)
+    : detId_(hit.geographicalId()),
+      hitPos_(hit.globalPosition()),
+      hit_(&hit),
+      et_(0),
+      eta_(0),
+      phi_(0),
+      charge_(0),
+      nrClus_(0) {
+  EleRelPointPair pointPair(hitPos_, trajState.globalParameters().position(), vtxPos);
+  dRZ_ = detId_.subdetId() == PixelSubdetector::PixelBarrel ? pointPair.dZ() : pointPair.dPerp();
   dPhi_ = pointPair.dPhi();
 }
-    
 
-TrajSeedMatcher::SeedWithInfo::
-SeedWithInfo(const TrajectorySeed& seed,
-	     const std::vector<SCHitMatch>& posCharge,
-	     const std::vector<SCHitMatch>& negCharge,
-	     int nrValidLayers):
-  seed_(seed),nrValidLayers_(nrValidLayers)
-{
-  size_t nrHitsMax = std::max(posCharge.size(),negCharge.size());
-  for(size_t hitNr=0;hitNr<nrHitsMax;hitNr++){
-    DetId detIdPos = hitNr<posCharge.size() ? posCharge[hitNr].detId() : DetId(0);
-    float dRZPos = hitNr<posCharge.size() ? posCharge[hitNr].dRZ() : std::numeric_limits<float>::max();
-    float dPhiPos = hitNr<posCharge.size() ? posCharge[hitNr].dPhi() : std::numeric_limits<float>::max();
+TrajSeedMatcher::SeedWithInfo::SeedWithInfo(const TrajectorySeed& seed,
+                                            const std::vector<SCHitMatch>& posCharge,
+                                            const std::vector<SCHitMatch>& negCharge,
+                                            int nrValidLayers)
+    : seed_(seed), nrValidLayers_(nrValidLayers) {
+  size_t nrHitsMax = std::max(posCharge.size(), negCharge.size());
+  for (size_t hitNr = 0; hitNr < nrHitsMax; hitNr++) {
+    DetId detIdPos = hitNr < posCharge.size() ? posCharge[hitNr].detId() : DetId(0);
+    float dRZPos = hitNr < posCharge.size() ? posCharge[hitNr].dRZ() : std::numeric_limits<float>::max();
+    float dPhiPos = hitNr < posCharge.size() ? posCharge[hitNr].dPhi() : std::numeric_limits<float>::max();
 
-    DetId detIdNeg = hitNr<negCharge.size() ? negCharge[hitNr].detId() : DetId(0);
-    float dRZNeg = hitNr<negCharge.size() ? negCharge[hitNr].dRZ() : std::numeric_limits<float>::max();
-    float dPhiNeg = hitNr<negCharge.size() ? negCharge[hitNr].dPhi() : std::numeric_limits<float>::max();
-    
-    if(detIdPos!=detIdNeg && (detIdPos.rawId()!=0 && detIdNeg.rawId()!=0)){
-      cms::Exception("LogicError")<<" error in "<<__FILE__<<", "<<__LINE__<<" hits to be combined have different detIDs, this should not be possible and nothing good will come of it";
+    DetId detIdNeg = hitNr < negCharge.size() ? negCharge[hitNr].detId() : DetId(0);
+    float dRZNeg = hitNr < negCharge.size() ? negCharge[hitNr].dRZ() : std::numeric_limits<float>::max();
+    float dPhiNeg = hitNr < negCharge.size() ? negCharge[hitNr].dPhi() : std::numeric_limits<float>::max();
+
+    if (detIdPos != detIdNeg && (detIdPos.rawId() != 0 && detIdNeg.rawId() != 0)) {
+      cms::Exception("LogicError")
+          << " error in " << __FILE__ << ", " << __LINE__
+          << " hits to be combined have different detIDs, this should not be possible and nothing good will come of it";
     }
-    DetId detId = detIdPos.rawId()!=0 ? detIdPos : detIdNeg;
-    matchInfo_.push_back(MatchInfo(detId,dRZPos,dRZNeg,dPhiPos,dPhiNeg));
+    DetId detId = detIdPos.rawId() != 0 ? detIdPos : detIdNeg;
+    matchInfo_.push_back(MatchInfo(detId, dRZPos, dRZNeg, dPhiPos, dPhiNeg));
   }
 }
 
-TrajSeedMatcher::MatchingCutsV1::MatchingCutsV1(const edm::ParameterSet& pset):
-  dPhiMax_(pset.getParameter<double>("dPhiMax")),
-  dRZMax_(pset.getParameter<double>("dRZMax")),
-  dRZMaxLowEtThres_(pset.getParameter<double>("dRZMaxLowEtThres")),
-  dRZMaxLowEtEtaBins_(pset.getParameter<std::vector<double> >("dRZMaxLowEtEtaBins")),
-  dRZMaxLowEt_(pset.getParameter<std::vector<double> >("dRZMaxLowEt"))
-{
-  if(dRZMaxLowEtEtaBins_.size()+1!=dRZMaxLowEt_.size()){
-    throw cms::Exception("InvalidConfig")<<" dRZMaxLowEtEtaBins should be 1 less than dRZMaxLowEt when its "<<dRZMaxLowEtEtaBins_.size()<<" vs "<<dRZMaxLowEt_.size();
+TrajSeedMatcher::MatchingCutsV1::MatchingCutsV1(const edm::ParameterSet& pset)
+    : dPhiMax_(pset.getParameter<double>("dPhiMax")),
+      dRZMax_(pset.getParameter<double>("dRZMax")),
+      dRZMaxLowEtThres_(pset.getParameter<double>("dRZMaxLowEtThres")),
+      dRZMaxLowEtEtaBins_(pset.getParameter<std::vector<double> >("dRZMaxLowEtEtaBins")),
+      dRZMaxLowEt_(pset.getParameter<std::vector<double> >("dRZMaxLowEt")) {
+  if (dRZMaxLowEtEtaBins_.size() + 1 != dRZMaxLowEt_.size()) {
+    throw cms::Exception("InvalidConfig") << " dRZMaxLowEtEtaBins should be 1 less than dRZMaxLowEt when its "
+                                          << dRZMaxLowEtEtaBins_.size() << " vs " << dRZMaxLowEt_.size();
   }
 }
 
-bool TrajSeedMatcher::MatchingCutsV1::operator()(const TrajSeedMatcher::SCHitMatch& scHitMatch)const
-{
-  if(dPhiMax_>=0 && std::abs(scHitMatch.dPhi()) > dPhiMax_) return false;
-  
-  const float dRZMax = getDRZCutValue(scHitMatch.et(),scHitMatch.eta());
-  if(dRZMax_>=0 && std::abs(scHitMatch.dRZ()) > dRZMax) return false;
-	       
+bool TrajSeedMatcher::MatchingCutsV1::operator()(const TrajSeedMatcher::SCHitMatch& scHitMatch) const {
+  if (dPhiMax_ >= 0 && std::abs(scHitMatch.dPhi()) > dPhiMax_)
+    return false;
+
+  const float dRZMax = getDRZCutValue(scHitMatch.et(), scHitMatch.eta());
+  if (dRZMax_ >= 0 && std::abs(scHitMatch.dRZ()) > dRZMax)
+    return false;
+
   return true;
 }
 
-float TrajSeedMatcher::MatchingCutsV1::getDRZCutValue(const float scEt, const float scEta)const
-{
-  if(scEt>=dRZMaxLowEtThres_) return dRZMax_;
-  else{
+float TrajSeedMatcher::MatchingCutsV1::getDRZCutValue(const float scEt, const float scEta) const {
+  if (scEt >= dRZMaxLowEtThres_)
+    return dRZMax_;
+  else {
     const float absEta = std::abs(scEta);
-    for(size_t etaNr=0;etaNr<dRZMaxLowEtEtaBins_.size();etaNr++){
-      if(absEta<dRZMaxLowEtEtaBins_[etaNr]) return dRZMaxLowEt_[etaNr];
+    for (size_t etaNr = 0; etaNr < dRZMaxLowEtEtaBins_.size(); etaNr++) {
+      if (absEta < dRZMaxLowEtEtaBins_[etaNr])
+        return dRZMaxLowEt_[etaNr];
     }
     return dRZMaxLowEt_.back();
   }
 }
 
-TrajSeedMatcher::MatchingCutsV2::MatchingCutsV2(const edm::ParameterSet& pset):
-  dPhiHighEt_(pset.getParameter<std::vector<double> >("dPhiMaxHighEt")),
-  dPhiHighEtThres_(pset.getParameter<std::vector<double> >("dPhiMaxHighEtThres")),
-  dPhiLowEtGrad_(pset.getParameter<std::vector<double> >("dPhiMaxLowEtGrad")),
-  dRZHighEt_(pset.getParameter<std::vector<double> >("dRZMaxHighEt")),
-  dRZHighEtThres_(pset.getParameter<std::vector<double> >("dRZMaxHighEtThres")),
-  dRZLowEtGrad_(pset.getParameter<std::vector<double> >("dRZMaxLowEtGrad")),
-  etaBins_(pset.getParameter<std::vector<double> >("etaBins"))
-{
-  auto binSizeCheck = [](size_t sizeEtaBins,const std::vector<double>& vec,const std::string& name){
-    if(vec.size()!=sizeEtaBins+1){ 
-      throw cms::Exception("InvalidConfig")<<" when constructing TrajSeedMatcher::MatchingCutsV2 "<< name<<" has "<<vec.size()<<" bins, it should be equal to #bins of etaBins+1"<<sizeEtaBins+1;
+TrajSeedMatcher::MatchingCutsV2::MatchingCutsV2(const edm::ParameterSet& pset)
+    : dPhiHighEt_(pset.getParameter<std::vector<double> >("dPhiMaxHighEt")),
+      dPhiHighEtThres_(pset.getParameter<std::vector<double> >("dPhiMaxHighEtThres")),
+      dPhiLowEtGrad_(pset.getParameter<std::vector<double> >("dPhiMaxLowEtGrad")),
+      dRZHighEt_(pset.getParameter<std::vector<double> >("dRZMaxHighEt")),
+      dRZHighEtThres_(pset.getParameter<std::vector<double> >("dRZMaxHighEtThres")),
+      dRZLowEtGrad_(pset.getParameter<std::vector<double> >("dRZMaxLowEtGrad")),
+      etaBins_(pset.getParameter<std::vector<double> >("etaBins")) {
+  auto binSizeCheck = [](size_t sizeEtaBins, const std::vector<double>& vec, const std::string& name) {
+    if (vec.size() != sizeEtaBins + 1) {
+      throw cms::Exception("InvalidConfig")
+          << " when constructing TrajSeedMatcher::MatchingCutsV2 " << name << " has " << vec.size()
+          << " bins, it should be equal to #bins of etaBins+1" << sizeEtaBins + 1;
     }
   };
-  binSizeCheck(etaBins_.size(),dPhiHighEt_,"dPhiMaxHighEt");
-  binSizeCheck(etaBins_.size(),dPhiHighEtThres_,"dPhiMaxHighEtThres");
-  binSizeCheck(etaBins_.size(),dPhiLowEtGrad_,"dPhiMaxLowEtGrad");
-  binSizeCheck(etaBins_.size(),dRZHighEt_,"dRZMaxHighEt");
-  binSizeCheck(etaBins_.size(),dRZHighEtThres_,"dRZMaxHighEtThres");
-  binSizeCheck(etaBins_.size(),dRZLowEtGrad_,"dRZMaxLowEtGrad");
+  binSizeCheck(etaBins_.size(), dPhiHighEt_, "dPhiMaxHighEt");
+  binSizeCheck(etaBins_.size(), dPhiHighEtThres_, "dPhiMaxHighEtThres");
+  binSizeCheck(etaBins_.size(), dPhiLowEtGrad_, "dPhiMaxLowEtGrad");
+  binSizeCheck(etaBins_.size(), dRZHighEt_, "dRZMaxHighEt");
+  binSizeCheck(etaBins_.size(), dRZHighEtThres_, "dRZMaxHighEtThres");
+  binSizeCheck(etaBins_.size(), dRZLowEtGrad_, "dRZMaxLowEtGrad");
 }
 
-bool TrajSeedMatcher::MatchingCutsV2::operator()(const TrajSeedMatcher::SCHitMatch& scHitMatch)const
-{
-  size_t binNr=getBinNr(scHitMatch.eta());
-  float dPhiMax = getCutValue(scHitMatch.et(),dPhiHighEt_[binNr],dPhiHighEtThres_[binNr],dPhiLowEtGrad_[binNr]); 
-  if(dPhiMax>=0 && std::abs(scHitMatch.dPhi()) > dPhiMax) return false;  
-  float dRZMax = getCutValue(scHitMatch.et(),dRZHighEt_[binNr],dRZHighEtThres_[binNr],dRZLowEtGrad_[binNr]);
-  if(dRZMax>=0 && std::abs(scHitMatch.dRZ()) > dRZMax) return false;
-  
+bool TrajSeedMatcher::MatchingCutsV2::operator()(const TrajSeedMatcher::SCHitMatch& scHitMatch) const {
+  size_t binNr = getBinNr(scHitMatch.eta());
+  float dPhiMax = getCutValue(scHitMatch.et(), dPhiHighEt_[binNr], dPhiHighEtThres_[binNr], dPhiLowEtGrad_[binNr]);
+  if (dPhiMax >= 0 && std::abs(scHitMatch.dPhi()) > dPhiMax)
+    return false;
+  float dRZMax = getCutValue(scHitMatch.et(), dRZHighEt_[binNr], dRZHighEtThres_[binNr], dRZLowEtGrad_[binNr]);
+  if (dRZMax >= 0 && std::abs(scHitMatch.dRZ()) > dRZMax)
+    return false;
+
   return true;
 }
 
 //eta bins is exactly 1 smaller than the vectors which will be accessed by this bin nr
-size_t TrajSeedMatcher::MatchingCutsV2::getBinNr(float eta)const
-{
+size_t TrajSeedMatcher::MatchingCutsV2::getBinNr(float eta) const {
   const float absEta = std::abs(eta);
-  for(size_t etaNr=0;etaNr<etaBins_.size();etaNr++){
-    if(absEta<etaBins_[etaNr]) return etaNr;
+  for (size_t etaNr = 0; etaNr < etaBins_.size(); etaNr++) {
+    if (absEta < etaBins_[etaNr])
+      return etaNr;
   }
   return etaBins_.size();
 }
-

--- a/RecoEgamma/EgammaHFProducers/plugins/HFClusterAlgo.cc
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFClusterAlgo.cc
@@ -2,7 +2,7 @@
 #include <sstream>
 #include <iostream>
 #include <algorithm>
-#include <list> 
+#include <list>
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/METReco/interface/HcalCaloFlagLabels.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
@@ -16,402 +16,395 @@ using namespace reco;
  * $Id:version 1.2
  */
 
-
-HFClusterAlgo::HFClusterAlgo() 
-{
-  m_isMC=true; // safest
-  
+HFClusterAlgo::HFClusterAlgo() {
+  m_isMC = true;  // safest
 }
 
 class CompareHFCompleteHitET {
 public:
-  bool operator()(const HFClusterAlgo::HFCompleteHit& h1,const HFClusterAlgo::HFCompleteHit& h2) const {
-    return h1.et>h2.et;
+  bool operator()(const HFClusterAlgo::HFCompleteHit& h1, const HFClusterAlgo::HFCompleteHit& h2) const {
+    return h1.et > h2.et;
   }
 };
 
 class CompareHFCore {
 public:
-  bool operator()(const double c1,const double c2) const {
-    return c1>c2;
-  }
+  bool operator()(const double c1, const double c2) const { return c1 > c2; }
 };
 
-static int indexByEta(HcalDetId id) {
-  return (id.zside()>0)?(id.ietaAbs()-29+13):(41-id.ietaAbs());
-}
-static const double MCMaterialCorrections_3XX[] = {  1.000,1.000,1.105,0.970,0.965,0.975,0.956,0.958,0.981,1.005,0.986,1.086,1.000,
-						 1.000,1.086,0.986,1.005,0.981,0.958,0.956,0.975,0.965,0.970,1.105,1.000,1.000 };
+static int indexByEta(HcalDetId id) { return (id.zside() > 0) ? (id.ietaAbs() - 29 + 13) : (41 - id.ietaAbs()); }
+static const double MCMaterialCorrections_3XX[] = {1.000, 1.000, 1.105, 0.970, 0.965, 0.975, 0.956, 0.958, 0.981,
+                                                   1.005, 0.986, 1.086, 1.000, 1.000, 1.086, 0.986, 1.005, 0.981,
+                                                   0.958, 0.956, 0.975, 0.965, 0.970, 1.105, 1.000, 1.000};
 
-    
-
-void HFClusterAlgo::setup(double minTowerEnergy, double seedThreshold,double maximumSL,double maximumRenergy,
-			  bool usePMTflag,bool usePulseflag, bool forcePulseFlagMC, int correctionSet){
-  m_seedThreshold=seedThreshold;
-  m_minTowerEnergy=minTowerEnergy;
-  m_maximumSL=maximumSL;
-  m_usePMTFlag=usePMTflag;
-  m_usePulseFlag=usePulseflag;
-  m_forcePulseFlagMC=forcePulseFlagMC;
-  m_maximumRenergy=maximumRenergy;
+void HFClusterAlgo::setup(double minTowerEnergy,
+                          double seedThreshold,
+                          double maximumSL,
+                          double maximumRenergy,
+                          bool usePMTflag,
+                          bool usePulseflag,
+                          bool forcePulseFlagMC,
+                          int correctionSet) {
+  m_seedThreshold = seedThreshold;
+  m_minTowerEnergy = minTowerEnergy;
+  m_maximumSL = maximumSL;
+  m_usePMTFlag = usePMTflag;
+  m_usePulseFlag = usePulseflag;
+  m_forcePulseFlagMC = forcePulseFlagMC;
+  m_maximumRenergy = maximumRenergy;
   m_correctionSet = correctionSet;
 
-  for(int ii=0;ii<13;ii++){
+  for (int ii = 0; ii < 13; ii++) {
     m_cutByEta.push_back(-1);
     m_seedmnEta.push_back(99);
     m_seedMXeta.push_back(-1);
   }
- for(int ii=0;ii<73;ii++){
-    double minphi=0.0872664*(ii-1);
-    double maxphi=0.0872664*(ii+1);
+  for (int ii = 0; ii < 73; ii++) {
+    double minphi = 0.0872664 * (ii - 1);
+    double maxphi = 0.0872664 * (ii + 1);
     while (minphi < -M_PI)
-      minphi+=2*M_PI;
+      minphi += 2 * M_PI;
     while (minphi > M_PI)
-      minphi-=2*M_PI;
+      minphi -= 2 * M_PI;
     while (maxphi < -M_PI)
-      maxphi+=2*M_PI;
+      maxphi += 2 * M_PI;
     while (maxphi > M_PI)
-      maxphi-=2*M_PI;
-    if(ii==37)
-      minphi=-3.1415904;
+      maxphi -= 2 * M_PI;
+    if (ii == 37)
+      minphi = -3.1415904;
     m_seedmnPhi.push_back(minphi);
     m_seedMXphi.push_back(maxphi);
- }
- 
- // always set all the corrections to one...
- for (int ii=0; ii<13*2; ii++) 
-   m_correctionByEta.push_back(1.0);
- if (m_correctionSet==1) { // corrections for material from MC
-   for (int ii=0; ii<13*2; ii++) 
-     m_correctionByEta[ii]=MCMaterialCorrections_3XX[ii];
- } 
+  }
+
+  // always set all the corrections to one...
+  for (int ii = 0; ii < 13 * 2; ii++)
+    m_correctionByEta.push_back(1.0);
+  if (m_correctionSet == 1) {  // corrections for material from MC
+    for (int ii = 0; ii < 13 * 2; ii++)
+      m_correctionByEta[ii] = MCMaterialCorrections_3XX[ii];
+  }
 }
 
 /** Analyze the hits */
-void HFClusterAlgo::clusterize(const HFRecHitCollection& hf, 
-			       const CaloGeometry& geomO,
-			       HFEMClusterShapeCollection& clusterShapes,
-			       SuperClusterCollection& SuperClusters) {
-  
+void HFClusterAlgo::clusterize(const HFRecHitCollection& hf,
+                               const CaloGeometry& geomO,
+                               HFEMClusterShapeCollection& clusterShapes,
+                               SuperClusterCollection& SuperClusters) {
   const CaloGeometry* geom(&geomO);
   std::vector<HFCompleteHit> protoseeds, seeds;
-  HFRecHitCollection::const_iterator j,j2;
+  HFRecHitCollection::const_iterator j, j2;
   std::vector<HFCompleteHit>::iterator i;
   std::vector<HFCompleteHit>::iterator k;
   int dP, dE, PWrap;
-  bool isok=true;
+  bool isok = true;
   HFEMClusterShape clusShp;
- 
-  SuperCluster Sclus;
-  bool doCluster=false;
-  
-  for (j=hf.begin(); j!= hf.end(); j++)  {
-    const int aieta=j->id().ietaAbs();
-    int iz=(aieta-29);
-    // only long fibers and not 29,40,41 allowed to be considered as seeds
-    if (j->id().depth()!=1) continue;
-    if (aieta==40 || aieta==41 || aieta==29) continue;
-   
 
-    if (iz<0 || iz>12) {
+  SuperCluster Sclus;
+  bool doCluster = false;
+
+  for (j = hf.begin(); j != hf.end(); j++) {
+    const int aieta = j->id().ietaAbs();
+    int iz = (aieta - 29);
+    // only long fibers and not 29,40,41 allowed to be considered as seeds
+    if (j->id().depth() != 1)
+      continue;
+    if (aieta == 40 || aieta == 41 || aieta == 29)
+      continue;
+
+    if (iz < 0 || iz > 12) {
       edm::LogWarning("HFClusterAlgo") << "Strange invalid HF hit: " << j->id();
       continue;
     }
 
-    if (m_cutByEta[iz]<0) {
-      double eta=geom->getPosition(j->id()).eta();
-      m_cutByEta[iz]=m_seedThreshold*cosh(eta); // convert ET to E for this ring
-      auto ccg=geom->getGeometry(j->id()); 
-      const CaloCellGeometry::CornersVec& CellCorners=ccg->getCorners();
-      for(size_t sc=0;sc<CellCorners.size();sc++){
-	if(fabs(CellCorners[sc].z())<1200){
-	  if(fabs(CellCorners[sc].eta())<m_seedmnEta[iz])m_seedmnEta[iz]=fabs(CellCorners[sc].eta());
-	  if(fabs(CellCorners[sc].eta())>m_seedMXeta[iz])m_seedMXeta[iz]=fabs(CellCorners[sc].eta());
-	}
+    if (m_cutByEta[iz] < 0) {
+      double eta = geom->getPosition(j->id()).eta();
+      m_cutByEta[iz] = m_seedThreshold * cosh(eta);  // convert ET to E for this ring
+      auto ccg = geom->getGeometry(j->id());
+      const CaloCellGeometry::CornersVec& CellCorners = ccg->getCorners();
+      for (size_t sc = 0; sc < CellCorners.size(); sc++) {
+        if (fabs(CellCorners[sc].z()) < 1200) {
+          if (fabs(CellCorners[sc].eta()) < m_seedmnEta[iz])
+            m_seedmnEta[iz] = fabs(CellCorners[sc].eta());
+          if (fabs(CellCorners[sc].eta()) > m_seedMXeta[iz])
+            m_seedMXeta[iz] = fabs(CellCorners[sc].eta());
+        }
       }
     }
-    double elong=j->energy()*m_correctionByEta[indexByEta(j->id())];
-    if (elong>m_cutByEta[iz]) {
-      j2=hf.find(HcalDetId(HcalForward,j->id().ieta(),j->id().iphi(),2));
-      double eshort=(j2==hf.end())?(0):(j2->energy());
-      if (j2!=hf.end())
-         eshort*=m_correctionByEta[indexByEta(j2->id())];
-      if (((elong-eshort)/(elong+eshort))>m_maximumSL) continue;
+    double elong = j->energy() * m_correctionByEta[indexByEta(j->id())];
+    if (elong > m_cutByEta[iz]) {
+      j2 = hf.find(HcalDetId(HcalForward, j->id().ieta(), j->id().iphi(), 2));
+      double eshort = (j2 == hf.end()) ? (0) : (j2->energy());
+      if (j2 != hf.end())
+        eshort *= m_correctionByEta[indexByEta(j2->id())];
+      if (((elong - eshort) / (elong + eshort)) > m_maximumSL)
+        continue;
       //if ((m_usePMTFlag)&&(j->flagField(4,1))) continue;
       //if ((m_usePulseFlag)&&(j->flagField(1,1))) continue;
-      if(isPMTHit(*j)) continue;
+      if (isPMTHit(*j))
+        continue;
 
       HFCompleteHit ahit;
-      double eta=geom->getPosition(j->id()).eta();
-      ahit.id=j->id();
-      ahit.energy=elong;
-      ahit.et=ahit.energy/cosh(eta);
+      double eta = geom->getPosition(j->id()).eta();
+      ahit.id = j->id();
+      ahit.energy = elong;
+      ahit.et = ahit.energy / cosh(eta);
       protoseeds.push_back(ahit);
     }
   }
 
-  if(!protoseeds.empty()){   
+  if (!protoseeds.empty()) {
     std::sort(protoseeds.begin(), protoseeds.end(), CompareHFCompleteHitET());
-    for (i=protoseeds.begin(); i!= protoseeds.end(); i++)  {
-      isok=true;
-      doCluster=false;
+    for (i = protoseeds.begin(); i != protoseeds.end(); i++) {
+      isok = true;
+      doCluster = false;
 
-      if ( (i==protoseeds.begin()) && (isok) ) {
-	doCluster=true;
-      }else {
-	// check for overlap with existing clusters 
-	for (k=seeds.begin(); isok && k!=seeds.end(); k++) { //i->hits, k->seeds
-	  
-	  for (dE=-2; dE<=2; dE++)
-	    for (dP=-4;dP<=4; dP+=2) {
-	      PWrap=k->id.iphi()+dP;	
-	      if (PWrap<0) 
-		PWrap+=72;
-	      if (PWrap>72)
-		PWrap-=72;
-	      
-	      if ( (i->id.iphi()==PWrap) && (i->id.ieta()==k->id.ieta()+dE))
-		isok = false;
-	    }
-	}
-	if (isok) {
-	  doCluster=true;
-	}
+      if ((i == protoseeds.begin()) && (isok)) {
+        doCluster = true;
+      } else {
+        // check for overlap with existing clusters
+        for (k = seeds.begin(); isok && k != seeds.end(); k++) {  //i->hits, k->seeds
+
+          for (dE = -2; dE <= 2; dE++)
+            for (dP = -4; dP <= 4; dP += 2) {
+              PWrap = k->id.iphi() + dP;
+              if (PWrap < 0)
+                PWrap += 72;
+              if (PWrap > 72)
+                PWrap -= 72;
+
+              if ((i->id.iphi() == PWrap) && (i->id.ieta() == k->id.ieta() + dE))
+                isok = false;
+            }
+        }
+        if (isok) {
+          doCluster = true;
+        }
       }
-      if (doCluster) { 
-	seeds.push_back(*i);
+      if (doCluster) {
+        seeds.push_back(*i);
 
-	bool clusterOk=makeCluster( i->id(),hf, geom,clusShp,Sclus);
-	if (clusterOk) { // cluster is _not_ ok if seed is rejected due to other cuts
-	  clusterShapes.push_back(clusShp);
-	  SuperClusters.push_back(Sclus);
-	}
-
+        bool clusterOk = makeCluster(i->id(), hf, geom, clusShp, Sclus);
+        if (clusterOk) {  // cluster is _not_ ok if seed is rejected due to other cuts
+          clusterShapes.push_back(clusShp);
+          SuperClusters.push_back(Sclus);
+        }
       }
-    }//end protoseed loop
-  }//end if seeCount
+    }  //end protoseed loop
+  }    //end if seeCount
 }
 
-
 bool HFClusterAlgo::makeCluster(const HcalDetId& seedid,
-				const HFRecHitCollection& hf, 
-				const CaloGeometry* geom,
-				HFEMClusterShape& clusShp,
-				SuperCluster& Sclus)  {
-			
+                                const HFRecHitCollection& hf,
+                                const CaloGeometry* geom,
+                                HFEMClusterShape& clusShp,
+                                SuperCluster& Sclus) {
+  double w = 0;  //sum over all log E's
+  double wgt = 0;
+  double w_e = 0;  //sum over ieat*energy
+  double w_x = 0;
+  double w_y = 0;
+  double w_z = 0;
+  double wp_e = 0;  //sum over iphi*energy
+  double e_e = 0;   //nonwieghted eta sum
+  double e_ep = 0;  //nonweighted phi sum
 
-  double w=0;//sum over all log E's
-  double wgt=0;
-  double w_e=0;//sum over ieat*energy
-  double w_x=0;
-  double w_y=0;
-  double w_z=0;
-  double wp_e=0;//sum over iphi*energy
-  double e_e=0;//nonwieghted eta sum
-  double e_ep=0; //nonweighted phi sum
- 
-  double l_3=0;//sum for enenergy in 3x3 long fibers etc.
-  double s_3=0;
-  double l_5=0;
-  double s_5=0;
-  double l_1=0;
-  double s_1=0;
+  double l_3 = 0;  //sum for enenergy in 3x3 long fibers etc.
+  double s_3 = 0;
+  double l_5 = 0;
+  double s_5 = 0;
+  double l_1 = 0;
+  double s_1 = 0;
   int de, dp, phiWrap;
-  double l_1e=0;
-  const GlobalPoint& sp=geom->getPosition(seedid);
+  double l_1e = 0;
+  const GlobalPoint& sp = geom->getPosition(seedid);
   std::vector<double> coreCanid;
   std::vector<double>::const_iterator ci;
-  HFRecHitCollection::const_iterator is,il;
-  std::vector<DetId> usedHits; 
- 
-  HFRecHitCollection::const_iterator si;
-  HcalDetId sid(HcalForward,seedid.ieta(),seedid.iphi(),1);
-  si=hf.find(sid);  
+  HFRecHitCollection::const_iterator is, il;
+  std::vector<DetId> usedHits;
 
-  bool clusterOk=true; // assume the best to start...
+  HFRecHitCollection::const_iterator si;
+  HcalDetId sid(HcalForward, seedid.ieta(), seedid.iphi(), 1);
+  si = hf.find(sid);
+
+  bool clusterOk = true;  // assume the best to start...
 
   // lots happens here
   // edge type 1 has 40/41 in 3x3 and 5x5
-  bool edge_type1=seedid.ietaAbs()==39 && (seedid.iphi()%4)==3;
+  bool edge_type1 = seedid.ietaAbs() == 39 && (seedid.iphi() % 4) == 3;
 
-  double e_seed=si->energy()*m_correctionByEta[indexByEta(si->id())];
-  
-  for (de=-2; de<=2; de++)
-    for (dp=-4;dp<=4; dp+=2) {
-      phiWrap=seedid.iphi()+dp;	
-      if (phiWrap<0) 
-        phiWrap+=72;
-      if (phiWrap>72)
-        phiWrap-=72;
+  double e_seed = si->energy() * m_correctionByEta[indexByEta(si->id())];
 
-  
+  for (de = -2; de <= 2; de++)
+    for (dp = -4; dp <= 4; dp += 2) {
+      phiWrap = seedid.iphi() + dp;
+      if (phiWrap < 0)
+        phiWrap += 72;
+      if (phiWrap > 72)
+        phiWrap -= 72;
+
       /* Handling of phi-width change problems */
-      if (edge_type1 && de==seedid.zside()) {
-	if (dp==-2) { // we want it in the 3x3
-	  phiWrap-=2;
-	  if (phiWrap<0) 
-	    phiWrap+=72;
-	} 
-	else if (dp==-4) {
-	  continue; // but not double counted in 5x5
-	}
+      if (edge_type1 && de == seedid.zside()) {
+        if (dp == -2) {  // we want it in the 3x3
+          phiWrap -= 2;
+          if (phiWrap < 0)
+            phiWrap += 72;
+        } else if (dp == -4) {
+          continue;  // but not double counted in 5x5
+        }
       }
 
-      HcalDetId idl(HcalForward,seedid.ieta()+de,phiWrap,1);
-      HcalDetId ids(HcalForward,seedid.ieta()+de,phiWrap,2);
+      HcalDetId idl(HcalForward, seedid.ieta() + de, phiWrap, 1);
+      HcalDetId ids(HcalForward, seedid.ieta() + de, phiWrap, 2);
 
-	
-      il=hf.find(idl);
-      is=hf.find(ids);        
+      il = hf.find(idl);
+      is = hf.find(ids);
 
+      double e_long = 1.0;
+      double e_short = 0.0;
+      if (il != hf.end())
+        e_long = il->energy() * m_correctionByEta[indexByEta(il->id())];
+      if (e_long <= m_minTowerEnergy)
+        e_long = 0.0;
+      if (is != hf.end())
+        e_short = is->energy() * m_correctionByEta[indexByEta(is->id())];
+      if (e_short <= m_minTowerEnergy)
+        e_short = 0.0;
+      double eRatio = (e_long - e_short) / std::max(1.0, (e_long + e_short));
 
-
-
-      double e_long=1.0; 
-      double e_short=0.0; 
-      if (il!=hf.end()) e_long=il->energy()*m_correctionByEta[indexByEta(il->id())];
-      if (e_long <= m_minTowerEnergy) e_long=0.0;
-      if (is!=hf.end()) e_short=is->energy()*m_correctionByEta[indexByEta(is->id())];
-      if (e_short <= m_minTowerEnergy) e_short=0.0;
-      double eRatio=(e_long-e_short)/std::max(1.0,(e_long+e_short));
-	
       // require S/L > a minimum amount for inclusion
-      if ((abs(eRatio) > m_maximumSL)&&(std::max(e_long,e_short) > m_maximumRenergy)) {
-	if (dp==0 && de==0) clusterOk=false; // somehow, the seed is hosed
-	continue;
+      if ((abs(eRatio) > m_maximumSL) && (std::max(e_long, e_short) > m_maximumRenergy)) {
+        if (dp == 0 && de == 0)
+          clusterOk = false;  // somehow, the seed is hosed
+        continue;
       }
-	 
-      if((il!=hf.end())&&(isPMTHit(*il))){
-	if (dp==0 && de==0) clusterOk=false; // somehow, the seed is hosed
-	continue;//continue to next hit, do not include this one in cluster
+
+      if ((il != hf.end()) && (isPMTHit(*il))) {
+        if (dp == 0 && de == 0)
+          clusterOk = false;  // somehow, the seed is hosed
+        continue;             //continue to next hit, do not include this one in cluster
       }
-	
 
+      if (e_long > m_minTowerEnergy && il != hf.end()) {
+        // record usage
+        usedHits.push_back(idl.rawId());
+        // always in the 5x5
+        l_5 += e_long;
+        // maybe in the 3x3
+        if ((de > -2) && (de < 2) && (dp > -4) && (dp < 4)) {
+          l_3 += e_long;
 
+          // sometimes in the 1x1
+          if ((dp == 0) && (de == 0)) {
+            l_1 = e_long;
+          }
 
+          // maybe in the core?
+          if ((de > -2) && (de < 2) && (dp > -4) && (dp < 4) && (e_long > (.5 * e_seed))) {
+            coreCanid.push_back(e_long);
+          }
 
-      if (e_long > m_minTowerEnergy && il!=hf.end()) {
+          // position calculation
+          const GlobalPoint& p = geom->getPosition(idl);
 
-	// record usage
-	usedHits.push_back(idl.rawId());
-	// always in the 5x5
-	l_5+=e_long;
-	// maybe in the 3x3
-	if ((de>-2)&&(de<2)&&(dp>-4)&&(dp<4)) {
-	  l_3+=e_long;
-	
-	  // sometimes in the 1x1
-	  if ((dp==0)&&(de==0)) {
-	    l_1=e_long;
-	  }
+          double d_p = p.phi() - sp.phi();
+          while (d_p < -M_PI)
+            d_p += 2 * M_PI;
+          while (d_p > M_PI)
+            d_p -= 2 * M_PI;
+          double d_e = p.eta() - sp.eta();
 
-	  // maybe in the core?
-	  if ((de>-2)&&(de<2)&&(dp>-4)&&(dp<4)&&(e_long>(.5*e_seed))) {
-	    coreCanid.push_back(e_long);
-	  }
-	  
-	  // position calculation
-	  const GlobalPoint& p=geom->getPosition(idl);
-          
-	  double d_p = p.phi()-sp.phi();
-	  while (d_p < -M_PI)
-	    d_p+=2*M_PI;
-	  while (d_p > M_PI)
-	    d_p-=2*M_PI;
-	  double d_e = p.eta()-sp.eta();
-	  
-	  wgt=log((e_long));
-	  if (wgt>0){
-	    w+=wgt;
-	    w_e+=(d_e)*wgt;
-	    wp_e+=(d_p)*wgt;
-	    e_e+=d_e;
-	    e_ep+=d_p;
-	   
-	    w_x+=(p.x())*wgt;//(p.x()-sp.x())*wgt;
-	    w_y+=(p.y())*wgt;
-	    w_z+=(p.z())*wgt;
-	  }
-	}
+          wgt = log((e_long));
+          if (wgt > 0) {
+            w += wgt;
+            w_e += (d_e)*wgt;
+            wp_e += (d_p)*wgt;
+            e_e += d_e;
+            e_ep += d_p;
+
+            w_x += (p.x()) * wgt;  //(p.x()-sp.x())*wgt;
+            w_y += (p.y()) * wgt;
+            w_z += (p.z()) * wgt;
+          }
+        }
       } else {
-	if (dp==0 && de==0) clusterOk=false; // somehow, the seed is hosed
+        if (dp == 0 && de == 0)
+          clusterOk = false;  // somehow, the seed is hosed
       }
-	
-      if (e_short > m_minTowerEnergy && is!=hf.end()) {
-	// record usage
-	usedHits.push_back(ids.rawId());
-	// always in the 5x5
-	s_5+=e_short;
-	// maybe in the 3x3
-	if ((de>-2)&&(de<2)&&(dp>-4)&&(dp<4)) {
-	  s_3+=e_short;
-	}
-	// sometimes in the 1x1
-	if ((dp==0)&&(de==0)) {
-	  s_1=e_short;
-	}
+
+      if (e_short > m_minTowerEnergy && is != hf.end()) {
+        // record usage
+        usedHits.push_back(ids.rawId());
+        // always in the 5x5
+        s_5 += e_short;
+        // maybe in the 3x3
+        if ((de > -2) && (de < 2) && (dp > -4) && (dp < 4)) {
+          s_3 += e_short;
+        }
+        // sometimes in the 1x1
+        if ((dp == 0) && (de == 0)) {
+          s_1 = e_short;
+        }
       }
     }
 
-
-  if (!clusterOk) return false;
+  if (!clusterOk)
+    return false;
 
   //Core sorting done here
   std::sort(coreCanid.begin(), coreCanid.end(), CompareHFCore());
-  for (ci=coreCanid.begin();ci!=coreCanid.end();ci++){
-    if(ci==coreCanid.begin()){
-      l_1e=*ci;
-    }else if (*ci>.5*l_1e){
-      l_1e+=*ci;
+  for (ci = coreCanid.begin(); ci != coreCanid.end(); ci++) {
+    if (ci == coreCanid.begin()) {
+      l_1e = *ci;
+    } else if (*ci > .5 * l_1e) {
+      l_1e += *ci;
     }
-  }//core sorting end 
-  
-  double z_=w_z/w;    
-  double x_=w_x/w;
-  double y_=w_y/w;
-  math::XYZPoint xyzclus(x_,y_,z_);
+  }  //core sorting end
+
+  double z_ = w_z / w;
+  double x_ = w_x / w;
+  double y_ = w_y / w;
+  math::XYZPoint xyzclus(x_, y_, z_);
   //calcualte position, final
-  double eta=xyzclus.eta();//w_e/w+sp.eta();
-  
-  double phi=xyzclus.phi();//(wp_e/w)+sp.phi();
-  
+  double eta = xyzclus.eta();  //w_e/w+sp.eta();
+
+  double phi = xyzclus.phi();  //(wp_e/w)+sp.phi();
+
   while (phi < -M_PI)
-    phi+=2*M_PI;
+    phi += 2 * M_PI;
   while (phi > M_PI)
-    phi-=2*M_PI;
-  
+    phi -= 2 * M_PI;
+
   //calculate cell phi and cell eta
-  int idx= fabs(seedid.ieta())-29;
-  int ipx=seedid.iphi();
-  double Cphi =(phi-m_seedmnPhi[ipx])/(m_seedMXphi[ipx]-m_seedmnPhi[ipx]);
-  double Ceta=(fabs(eta)- m_seedmnEta[idx])/(m_seedMXeta[idx]-m_seedmnEta[idx]);
-    
+  int idx = fabs(seedid.ieta()) - 29;
+  int ipx = seedid.iphi();
+  double Cphi = (phi - m_seedmnPhi[ipx]) / (m_seedMXphi[ipx] - m_seedmnPhi[ipx]);
+  double Ceta = (fabs(eta) - m_seedmnEta[idx]) / (m_seedMXeta[idx] - m_seedmnEta[idx]);
+
   //return  HFEMClusterShape, SuperCluster
-  HFEMClusterShape myClusShp(l_1, s_1, l_3, s_3, l_5,s_5, l_1e,Ceta, Cphi,seedid);
+  HFEMClusterShape myClusShp(l_1, s_1, l_3, s_3, l_5, s_5, l_1e, Ceta, Cphi, seedid);
   clusShp = myClusShp;
-      
-  SuperCluster MySclus(l_3,xyzclus);
-  Sclus=MySclus;
+
+  SuperCluster MySclus(l_3, xyzclus);
+  Sclus = MySclus;
 
   return clusterOk;
-  
 }
-bool HFClusterAlgo::isPMTHit(const HFRecHit& hfr){
+bool HFClusterAlgo::isPMTHit(const HFRecHit& hfr) {
+  bool pmthit = false;
 
-  bool pmthit=false;
-
-  if((hfr.flagField(HcalCaloFlagLabels::HFLongShort))&&(m_usePMTFlag)) pmthit=true;
+  if ((hfr.flagField(HcalCaloFlagLabels::HFLongShort)) && (m_usePMTFlag))
+    pmthit = true;
   if (!(m_isMC && !m_forcePulseFlagMC))
-    if((hfr.flagField(HcalCaloFlagLabels::HFDigiTime))&&(m_usePulseFlag)) pmthit=true;
- 
+    if ((hfr.flagField(HcalCaloFlagLabels::HFDigiTime)) && (m_usePulseFlag))
+      pmthit = true;
+
   return pmthit;
 }
 void HFClusterAlgo::resetForRun() {
-  edm::LogInfo("HFClusterAlgo")<<"Resetting for Run!";
-  for(int ii=0;ii<13;ii++){
+  edm::LogInfo("HFClusterAlgo") << "Resetting for Run!";
+  for (int ii = 0; ii < 13; ii++) {
     m_cutByEta.push_back(-1);
     m_seedmnEta.push_back(99);
     m_seedMXeta.push_back(-1);
   }
 }
-

--- a/RecoEgamma/EgammaHFProducers/plugins/HFClusterAlgo.h
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFClusterAlgo.h
@@ -20,29 +20,35 @@
 //$Id:HFClusterAlgo.h,v 1.2 2007/09/19 09:52 K. Klapoetke Minnesota
 
 class HFClusterAlgo {
- public:
-  HFClusterAlgo(); 
+public:
+  HFClusterAlgo();
 
-  void setup(double minTowerEnergy, double seedThreshold,double maximumSL,double m_maximumRenergy,bool usePMTflag,bool usePulseflag, bool forcePulseFlagMC, int correctionSet);
+  void setup(double minTowerEnergy,
+             double seedThreshold,
+             double maximumSL,
+             double m_maximumRenergy,
+             bool usePMTflag,
+             bool usePulseflag,
+             bool forcePulseFlagMC,
+             int correctionSet);
 
-  void isMC(bool isMC) { m_isMC=isMC; }
+  void isMC(bool isMC) { m_isMC = isMC; }
 
   /** Analyze the hits */
-  void clusterize(const HFRecHitCollection& hf, 
-		  const CaloGeometry& geom,
-		  reco::HFEMClusterShapeCollection& clusters,
-		  reco::SuperClusterCollection& SuperClusters);
-  
+  void clusterize(const HFRecHitCollection& hf,
+                  const CaloGeometry& geom,
+                  reco::HFEMClusterShapeCollection& clusters,
+                  reco::SuperClusterCollection& SuperClusters);
 
   void resetForRun();
 
- private:
+private:
   friend class CompareHFCompleteHitET;
   friend class CompareHFCore;
- 
-  double m_minTowerEnergy, m_seedThreshold,m_maximumSL,m_maximumRenergy;
+
+  double m_minTowerEnergy, m_seedThreshold, m_maximumSL, m_maximumRenergy;
   bool m_usePMTFlag;
-  bool m_usePulseFlag,m_forcePulseFlagMC;
+  bool m_usePulseFlag, m_forcePulseFlagMC;
   bool m_isMC;
   int m_correctionSet;
   std::vector<double> m_cutByEta;
@@ -57,10 +63,10 @@ class HFClusterAlgo {
   };
   bool isPMTHit(const HFRecHit& hfr);
   bool makeCluster(const HcalDetId& seedid,
-		   const HFRecHitCollection& hf, 
-		   const CaloGeometry* geom,
-		   reco::HFEMClusterShape& clusShp,
-		   reco::SuperCluster& SClus);
+                   const HFRecHitCollection& hf,
+                   const CaloGeometry* geom,
+                   reco::HFEMClusterShape& clusShp,
+                   reco::SuperCluster& SClus);
 };
 
-#endif 
+#endif

--- a/RecoEgamma/EgammaHFProducers/plugins/HFEGammaSLCorrector.cc
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFEGammaSLCorrector.cc
@@ -3,52 +3,52 @@
 
 namespace hf_egamma {
 
-	double eSeLCorrected(double es, double el, double pc, double px, double py){
-		double x  = log(el/100) ;
-		double y  = es / el ;
-		return pc + px*x + py*y ;
-	}
+  double eSeLCorrected(double es, double el, double pc, double px, double py) {
+    double x = log(el / 100);
+    double y = es / el;
+    return pc + px * x + py * y;
+  }
 
-	double eSeLCorrected(double es, double el, int era){
-		double pc=0.0,px=0.0,py=0.0;
+  double eSeLCorrected(double es, double el, int era) {
+    double pc = 0.0, px = 0.0, py = 0.0;
 
-		switch (era) {	
-			case (0): //Data 41
-				pc = -1.02388e-1 ;
-				px = -1.51130e-1 ;
-				py =  9.88514e-1 ;
-				break;
-			case (1): //Fall 10 MC
-				pc = -4.06012e-2 ;
-				px = -1.34769e-1 ;
-				py =  9.90877e-1 ;
-				break;
-			case (2): //Spring 11 MC
-				pc =   5.98732e-3 ;
-				px =  -1.74767e-1 ;
-				py =   9.84610e-1 ;
-				break;
-			case (3): //Summer 11 MC
-				pc =  -0.036416 ;
-				px =  -0.195854 ;
-				py =  0.980633 ;
-				break;
-	            	case (4): //July 5 Data
-	                        pc = -0.008077 ;
-                                px = -0.216002 ;
-		                py = 0.976393 ;
-				break;
-		}
+    switch (era) {
+      case (0):  //Data 41
+        pc = -1.02388e-1;
+        px = -1.51130e-1;
+        py = 9.88514e-1;
+        break;
+      case (1):  //Fall 10 MC
+        pc = -4.06012e-2;
+        px = -1.34769e-1;
+        py = 9.90877e-1;
+        break;
+      case (2):  //Spring 11 MC
+        pc = 5.98732e-3;
+        px = -1.74767e-1;
+        py = 9.84610e-1;
+        break;
+      case (3):  //Summer 11 MC
+        pc = -0.036416;
+        px = -0.195854;
+        py = 0.980633;
+        break;
+      case (4):  //July 5 Data
+        pc = -0.008077;
+        px = -0.216002;
+        py = 0.976393;
+        break;
+    }
 
-		//After fitting the 2D histogram, we find a y-intercept b, a slope m, 
-		//and a point x0 around which we choose to rotate the data points. We 
-		//will map (x,y) --> (x,y') where y' = pc + px*x + py*y, with 
-		//pc = sin(atan(m))*x0 - cos(atan(m))*(m*x0+b), px = -sin(atan(m)), 
-		//and py = cos(atan(m)). This transformation preserves the x-value of the 
-		//data point and takes y' to be the y-value of the original point after it 
-		//is rotated through angle atan(m) (to flatten the line of best fit) and 
-		//transposed vertically downward by b (to make the line of best fit coincide with the x-axis).
+    //After fitting the 2D histogram, we find a y-intercept b, a slope m,
+    //and a point x0 around which we choose to rotate the data points. We
+    //will map (x,y) --> (x,y') where y' = pc + px*x + py*y, with
+    //pc = sin(atan(m))*x0 - cos(atan(m))*(m*x0+b), px = -sin(atan(m)),
+    //and py = cos(atan(m)). This transformation preserves the x-value of the
+    //data point and takes y' to be the y-value of the original point after it
+    //is rotated through angle atan(m) (to flatten the line of best fit) and
+    //transposed vertically downward by b (to make the line of best fit coincide with the x-axis).
 
-		return eSeLCorrected(es, el, pc, px, py) ;
-	}
-}
+    return eSeLCorrected(es, el, pc, px, py);
+  }
+}  // namespace hf_egamma

--- a/RecoEgamma/EgammaHFProducers/plugins/HFEGammaSLCorrector.h
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFEGammaSLCorrector.h
@@ -3,12 +3,11 @@
 
 namespace hf_egamma {
 
-	double eSeLCorrected(double es, double el, double m, double b);
+  double eSeLCorrected(double es, double el, double m, double b);
 
-	//enum CorrectionEra { ce_Fall10, ce_Spring11, ce_Summer11, ce_Data41 };
+  //enum CorrectionEra { ce_Fall10, ce_Spring11, ce_Summer11, ce_Data41 };
 
-	double eSeLCorrected(double es, double el, int era);
-}
+  double eSeLCorrected(double es, double el, int era);
+}  // namespace hf_egamma
 
-#endif // HFEGamma_SL_CORRECTOR
-
+#endif  // HFEGamma_SL_CORRECTOR

--- a/RecoEgamma/EgammaHFProducers/plugins/HFEMClusterProducer.cc
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFEMClusterProducer.cc
@@ -1,7 +1,7 @@
 //Package:    EgammaHFProdcers
 // Class  :    HFEMClusterProducer
 // Original Author:  Kevin Klapoetke (minnesota)
-//        
+//
 // $Id: HFEMClusterProducer.cc,v 1.2 2007/09/19 Kevin Klapoetke
 //
 
@@ -11,52 +11,50 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "RecoEgamma/EgammaHFProducers/plugins/HFEMClusterProducer.h"
 using namespace reco;
-HFEMClusterProducer::HFEMClusterProducer(edm::ParameterSet const& conf): hfreco_(consumes<HFRecHitCollection>(conf.getParameter<edm::InputTag>("hits"))) {
+HFEMClusterProducer::HFEMClusterProducer(edm::ParameterSet const& conf)
+    : hfreco_(consumes<HFRecHitCollection>(conf.getParameter<edm::InputTag>("hits"))) {
   produces<reco::HFEMClusterShapeCollection>();
   produces<reco::BasicClusterCollection>();
   produces<reco::SuperClusterCollection>();
-  produces<reco::HFEMClusterShapeAssociationCollection>(); 
+  produces<reco::HFEMClusterShapeAssociationCollection>();
   algo_.setup(conf.getParameter<double>("minTowerEnergy"),
-	      conf.getParameter<double>("seedThresholdET"),
-	      conf.getParameter<double>("maximumSL"),
-	      conf.getParameter<double>("maximumRenergy"),
-	      conf.getParameter<bool>("usePMTFlag"),
-	      conf.getParameter<bool>("usePulseFlag"),
-	      conf.getParameter<bool>("forcePulseFlagMC"),
-	      conf.getParameter<int>("correctionType"));
+              conf.getParameter<double>("seedThresholdET"),
+              conf.getParameter<double>("maximumSL"),
+              conf.getParameter<double>("maximumRenergy"),
+              conf.getParameter<bool>("usePMTFlag"),
+              conf.getParameter<bool>("usePulseFlag"),
+              conf.getParameter<bool>("forcePulseFlagMC"),
+              conf.getParameter<int>("correctionType"));
 }
 
-void HFEMClusterProducer::produce(edm::Event & e, edm::EventSetup const& iSetup) {  
-  
+void HFEMClusterProducer::produce(edm::Event& e, edm::EventSetup const& iSetup) {
   edm::Handle<HFRecHitCollection> hf_hits;
-  
-  e.getByToken(hfreco_,hf_hits);
-  
+
+  e.getByToken(hfreco_, hf_hits);
+
   edm::ESHandle<CaloGeometry> geometry;
   iSetup.get<CaloGeometryRecord>().get(geometry);
-  
+
   // create return data
   auto retdata1 = std::make_unique<HFEMClusterShapeCollection>();
   auto retdata2 = std::make_unique<SuperClusterCollection>();
 
   algo_.isMC(!e.isRealData());
- 
- 
+
   algo_.clusterize(*hf_hits, *geometry, *retdata1, *retdata2);
   edm::OrphanHandle<reco::SuperClusterCollection> SupHandle;
   edm::OrphanHandle<reco::HFEMClusterShapeCollection> ShapeHandle;
 
   // put the results
-  ShapeHandle=e.put(std::move(retdata1));
-  SupHandle=e.put(std::move(retdata2));
+  ShapeHandle = e.put(std::move(retdata1));
+  SupHandle = e.put(std::move(retdata2));
 
   auto retdata3 = std::make_unique<HFEMClusterShapeAssociationCollection>(SupHandle, ShapeHandle);
 
-  for (unsigned int i=0; i < ShapeHandle->size();i++){
-    retdata3->insert(edm::Ref<reco::SuperClusterCollection>(SupHandle,i),edm::Ref<reco::HFEMClusterShapeCollection>(ShapeHandle,i));
+  for (unsigned int i = 0; i < ShapeHandle->size(); i++) {
+    retdata3->insert(edm::Ref<reco::SuperClusterCollection>(SupHandle, i),
+                     edm::Ref<reco::HFEMClusterShapeCollection>(ShapeHandle, i));
   }
 
-
   e.put(std::move(retdata3));
-
 }

--- a/RecoEgamma/EgammaHFProducers/plugins/HFEMClusterProducer.h
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFEMClusterProducer.h
@@ -3,7 +3,7 @@
 //Package:    EgammaHFProdcers
 // Class  :    HFClusterProducer
 // Original Author:  Kevin Klapoetke (minnesota)
-//        
+//
 // $Id: HFClusterProducer.h,v 1.2 2007/09/19 Kevin Klapoetke
 //
 #include "HFClusterAlgo.h"
@@ -16,7 +16,8 @@ class HFEMClusterProducer : public edm::stream::EDProducer<> {
 public:
   explicit HFEMClusterProducer(edm::ParameterSet const& conf);
   void produce(edm::Event& e, edm::EventSetup const& iSetup) override;
-  void beginRun(edm::Run const &, edm::EventSetup const&) final { algo_.resetForRun(); }
+  void beginRun(edm::Run const&, edm::EventSetup const&) final { algo_.resetForRun(); }
+
 private:
   edm::EDGetToken hfreco_;
   HFClusterAlgo algo_;

--- a/RecoEgamma/EgammaHFProducers/plugins/HFRecoEcalCandidateAlgo.cc
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFRecoEcalCandidateAlgo.cc
@@ -19,134 +19,130 @@
 using namespace std;
 using namespace reco;
 
-HFRecoEcalCandidateAlgo::HFRecoEcalCandidateAlgo(bool correct,double e9e25Cut,double intercept2DCut,double intercept2DSlope,
-						 const std::vector<double>& e1e9Cut,
-						 const std::vector<double>& eCOREe9Cut,
-						 const std::vector<double>& eSeLCut,
-						 const reco::HFValueStruct hfvv				
-) :
-  m_correct(correct), 
-  m_e9e25Cut(e9e25Cut),
-  m_intercept2DCut(intercept2DCut),
-  m_intercept2DSlope(intercept2DSlope),
-  m_e1e9Cuthi(e1e9Cut[1]),
-  m_eCOREe9Cuthi(eCOREe9Cut[1]),
-  m_eSeLCuthi(eSeLCut[1]),
-  m_e1e9Cutlo(e1e9Cut[0]),
-  m_eCOREe9Cutlo(eCOREe9Cut[0]),
-  m_eSeLCutlo(eSeLCut[0]),
-  m_era(4), 
-  m_hfvv(hfvv)
-{
-}
+HFRecoEcalCandidateAlgo::HFRecoEcalCandidateAlgo(bool correct,
+                                                 double e9e25Cut,
+                                                 double intercept2DCut,
+                                                 double intercept2DSlope,
+                                                 const std::vector<double>& e1e9Cut,
+                                                 const std::vector<double>& eCOREe9Cut,
+                                                 const std::vector<double>& eSeLCut,
+                                                 const reco::HFValueStruct hfvv)
+    : m_correct(correct),
+      m_e9e25Cut(e9e25Cut),
+      m_intercept2DCut(intercept2DCut),
+      m_intercept2DSlope(intercept2DSlope),
+      m_e1e9Cuthi(e1e9Cut[1]),
+      m_eCOREe9Cuthi(eCOREe9Cut[1]),
+      m_eSeLCuthi(eSeLCut[1]),
+      m_e1e9Cutlo(e1e9Cut[0]),
+      m_eCOREe9Cutlo(eCOREe9Cut[0]),
+      m_eSeLCutlo(eSeLCut[0]),
+      m_era(4),
+      m_hfvv(hfvv) {}
 
-RecoEcalCandidate HFRecoEcalCandidateAlgo::correctEPosition(const SuperCluster& original , const HFEMClusterShape& shape,int nvtx) const {
- double corEta=original.eta();
+RecoEcalCandidate HFRecoEcalCandidateAlgo::correctEPosition(const SuperCluster& original,
+                                                            const HFEMClusterShape& shape,
+                                                            int nvtx) const {
+  double corEta = original.eta();
   //piece-wise log energy correction to eta
-  double logel=log(shape.eLong3x3()/100.0);
-  double lowC= 0.00911;
+  double logel = log(shape.eLong3x3() / 100.0);
+  double lowC = 0.00911;
   double hiC = 0.0193;
-  double logSlope    = 0.0146;
-  double logIntercept=-0.00988;
-  double sgn=(original.eta()>0)?(1.0):(-1.0);
-  if(logel<=1.25)corEta+=(lowC)*sgn;
-  else if((logel>1.25)&&(logel<=2))corEta+=(logIntercept+logSlope*logel)*sgn;
-  else if(logel>2)corEta+=hiC*sgn;
+  double logSlope = 0.0146;
+  double logIntercept = -0.00988;
+  double sgn = (original.eta() > 0) ? (1.0) : (-1.0);
+  if (logel <= 1.25)
+    corEta += (lowC)*sgn;
+  else if ((logel > 1.25) && (logel <= 2))
+    corEta += (logIntercept + logSlope * logel) * sgn;
+  else if (logel > 2)
+    corEta += hiC * sgn;
   //poly-3 cell eta correction to eta (de)
-  double p0= 0.0125;
-  double p1=-0.0475;
-  double p2= 0.0732;
-  double p3=-0.0506;
-  double de= sgn*(p0+(p1*(shape.CellEta()))+(p2*(shape.CellEta()*shape.CellEta()))+(p3*(shape.CellEta()*shape.CellEta()*shape.CellEta())));
-  corEta+=de;
- 
-  double corPhi=original.phi();
+  double p0 = 0.0125;
+  double p1 = -0.0475;
+  double p2 = 0.0732;
+  double p3 = -0.0506;
+  double de = sgn * (p0 + (p1 * (shape.CellEta())) + (p2 * (shape.CellEta() * shape.CellEta())) +
+                     (p3 * (shape.CellEta() * shape.CellEta() * shape.CellEta())));
+  corEta += de;
+
+  double corPhi = original.phi();
   //poly-3 cell phi correction to phi (dp)
-  p0= 0.0115;
-  p1=-0.0394;
-  p2= 0.0486;
-  p3=-0.0335;
-  double dp =p0+(p1*(shape.CellPhi()))+(p2*(shape.CellPhi()*shape.CellPhi()))+(p3*(shape.CellPhi()*shape.CellPhi()*shape.CellPhi()));
-  corPhi+=dp;
-  
- 
-  double corEnergy= original.energy();
+  p0 = 0.0115;
+  p1 = -0.0394;
+  p2 = 0.0486;
+  p3 = -0.0335;
+  double dp = p0 + (p1 * (shape.CellPhi())) + (p2 * (shape.CellPhi() * shape.CellPhi())) +
+              (p3 * (shape.CellPhi() * shape.CellPhi() * shape.CellPhi()));
+  corPhi += dp;
+
+  double corEnergy = original.energy();
   //energy corrections
   //flat correction for using only long fibers
-  double energyCorrect=0.7397;
-  corEnergy= corEnergy/energyCorrect; 
-  //corection based on ieta for pileup and general 
+  double energyCorrect = 0.7397;
+  corEnergy = corEnergy / energyCorrect;
+  //corection based on ieta for pileup and general
   //find ieta
-  int ieta=0;
-  double etabounds[30]={
-    2.846,2.957,3.132,3.307,3.482,
-    3.657,3.833,4.006,4.184,4.357,
-    4.532,4.709,4.882,5.184};
-  for (int kk=0;kk<=12;kk++){
-    if((fabs(corEta) < etabounds[kk+1])&&(fabs(corEta) > etabounds[kk])){
-      ieta = (corEta > 0)?(kk+29):(-kk-29);
+  int ieta = 0;
+  double etabounds[30] = {
+      2.846, 2.957, 3.132, 3.307, 3.482, 3.657, 3.833, 4.006, 4.184, 4.357, 4.532, 4.709, 4.882, 5.184};
+  for (int kk = 0; kk <= 12; kk++) {
+    if ((fabs(corEta) < etabounds[kk + 1]) && (fabs(corEta) > etabounds[kk])) {
+      ieta = (corEta > 0) ? (kk + 29) : (-kk - 29);
     }
   }
   //check if ieta is in bounds, should be [-41, -29] U [29, 41]
-  if (ieta != 0) corEnergy=(m_hfvv.PUSlope(ieta)*1.0*(nvtx-1)+m_hfvv.PUIntercept(ieta)*1.0)*corEnergy*1.0*m_hfvv.EnCor(ieta);
+  if (ieta != 0)
+    corEnergy = (m_hfvv.PUSlope(ieta) * 1.0 * (nvtx - 1) + m_hfvv.PUIntercept(ieta) * 1.0) * corEnergy * 1.0 *
+                m_hfvv.EnCor(ieta);
 
-  //re-calculate the energy vector  
-  double corPx=corEnergy*cos(corPhi)/cosh(corEta);
-  double corPy=corEnergy*sin(corPhi)/cosh(corEta);
-  double corPz=corEnergy*tanh(corEta);
-  
+  //re-calculate the energy vector
+  double corPx = corEnergy * cos(corPhi) / cosh(corEta);
+  double corPy = corEnergy * sin(corPhi) / cosh(corEta);
+  double corPz = corEnergy * tanh(corEta);
+
   //make the candidate
-  RecoEcalCandidate corCand(0,
-			    math::XYZTLorentzVector(corPx,corPy,corPz,corEnergy),
-			    math::XYZPoint(0,0,0));
-  
+  RecoEcalCandidate corCand(0, math::XYZTLorentzVector(corPx, corPy, corPz, corEnergy), math::XYZPoint(0, 0, 0));
+
   return corCand;
 }
 
 void HFRecoEcalCandidateAlgo::produce(const edm::Handle<SuperClusterCollection>& SuperClusters,
-				      const HFEMClusterShapeAssociationCollection& AssocShapes,
-				      RecoEcalCandidateCollection& RecoECand,
-				      int nvtx) const {
-  
-  
-  
-  //get super's and cluster shapes and associations 
-  for (unsigned int i=0; i < SuperClusters->size(); ++i) {
-    const SuperCluster& supClus=(*SuperClusters)[i];    
-    reco::SuperClusterRef theClusRef=edm::Ref<SuperClusterCollection>(SuperClusters,i);
-    const HFEMClusterShapeRef clusShapeRef=AssocShapes.find(theClusRef)->val;
-    const HFEMClusterShape& clusShape=*clusShapeRef;
-    
+                                      const HFEMClusterShapeAssociationCollection& AssocShapes,
+                                      RecoEcalCandidateCollection& RecoECand,
+                                      int nvtx) const {
+  //get super's and cluster shapes and associations
+  for (unsigned int i = 0; i < SuperClusters->size(); ++i) {
+    const SuperCluster& supClus = (*SuperClusters)[i];
+    reco::SuperClusterRef theClusRef = edm::Ref<SuperClusterCollection>(SuperClusters, i);
+    const HFEMClusterShapeRef clusShapeRef = AssocShapes.find(theClusRef)->val;
+    const HFEMClusterShape& clusShape = *clusShapeRef;
+
     // basic candidate
-    double px=supClus.energy()*cos(supClus.phi())/cosh(supClus.eta());
-    double py=supClus.energy()*sin(supClus.phi())/cosh(supClus.eta());
-    double pz=supClus.energy()*tanh(supClus.eta());
-    RecoEcalCandidate theCand(0,
-			      math::XYZTLorentzVector(px,py,pz,supClus.energy()),
-			      math::XYZPoint(0,0,0));
-    
+    double px = supClus.energy() * cos(supClus.phi()) / cosh(supClus.eta());
+    double py = supClus.energy() * sin(supClus.phi()) / cosh(supClus.eta());
+    double pz = supClus.energy() * tanh(supClus.eta());
+    RecoEcalCandidate theCand(0, math::XYZTLorentzVector(px, py, pz, supClus.energy()), math::XYZPoint(0, 0, 0));
+
     // correct it?
     if (m_correct)
-      theCand=correctEPosition(supClus,clusShape,nvtx);
+      theCand = correctEPosition(supClus, clusShape, nvtx);
 
-    double e9e25=clusShape.eLong3x3()/clusShape.eLong5x5();
-    double e1e9=clusShape.eLong1x1()/clusShape.eLong3x3();
-    double eSeL=hf_egamma::eSeLCorrected(clusShape.eShort3x3(),clusShape.eLong3x3(),4);
-    double var2d=(clusShape.eCOREe9()-(eSeL*m_intercept2DSlope));
- 
-    bool isAcceptable=true;
-    isAcceptable=isAcceptable && (e9e25> m_e9e25Cut);
-    isAcceptable=isAcceptable && (var2d > m_intercept2DCut);
-    isAcceptable=isAcceptable && ((e1e9< m_e1e9Cuthi)&&(e1e9> m_e1e9Cutlo));
-    isAcceptable=isAcceptable && ((clusShape.eCOREe9()< m_eCOREe9Cuthi)&&(clusShape.eCOREe9()>  m_eCOREe9Cutlo));
-    isAcceptable=isAcceptable && ((clusShape.eSeL()<m_eSeLCuthi)&&(clusShape.eSeL()>  m_eSeLCutlo));
-   
-    
-    if(isAcceptable){
+    double e9e25 = clusShape.eLong3x3() / clusShape.eLong5x5();
+    double e1e9 = clusShape.eLong1x1() / clusShape.eLong3x3();
+    double eSeL = hf_egamma::eSeLCorrected(clusShape.eShort3x3(), clusShape.eLong3x3(), 4);
+    double var2d = (clusShape.eCOREe9() - (eSeL * m_intercept2DSlope));
 
+    bool isAcceptable = true;
+    isAcceptable = isAcceptable && (e9e25 > m_e9e25Cut);
+    isAcceptable = isAcceptable && (var2d > m_intercept2DCut);
+    isAcceptable = isAcceptable && ((e1e9 < m_e1e9Cuthi) && (e1e9 > m_e1e9Cutlo));
+    isAcceptable = isAcceptable && ((clusShape.eCOREe9() < m_eCOREe9Cuthi) && (clusShape.eCOREe9() > m_eCOREe9Cutlo));
+    isAcceptable = isAcceptable && ((clusShape.eSeL() < m_eSeLCuthi) && (clusShape.eSeL() > m_eSeLCutlo));
+
+    if (isAcceptable) {
       theCand.setSuperCluster(theClusRef);
       RecoECand.push_back(theCand);
     }
   }
 }
- 

--- a/RecoEgamma/EgammaHFProducers/plugins/HFRecoEcalCandidateAlgo.h
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFRecoEcalCandidateAlgo.h
@@ -22,24 +22,25 @@
 
 class HFRecoEcalCandidateAlgo {
 public:
-  HFRecoEcalCandidateAlgo(bool correct, 
-			  double e9e25Cut,
-			  double intercept2DCut,
-			  double intercept2DSlope,
-			  const std::vector<double>& e1e9Cut,
-			  const std::vector<double>& eCOREe9Cut,
-			  const std::vector<double>& eSeLCut,
-			  const reco::HFValueStruct hfvv);
-  
+  HFRecoEcalCandidateAlgo(bool correct,
+                          double e9e25Cut,
+                          double intercept2DCut,
+                          double intercept2DSlope,
+                          const std::vector<double>& e1e9Cut,
+                          const std::vector<double>& eCOREe9Cut,
+                          const std::vector<double>& eSeLCut,
+                          const reco::HFValueStruct hfvv);
+
   /** Analyze the hits */
   void produce(const edm::Handle<reco::SuperClusterCollection>& SuperClusters,
-	       const reco::HFEMClusterShapeAssociationCollection& AssocShapes,
-	       reco::RecoEcalCandidateCollection& RecoECand,
-	       int nvtx) const;
-  
-  
- private:
-  reco::RecoEcalCandidate correctEPosition(const reco::SuperCluster& original, const reco::HFEMClusterShape& shape, int nvtx) const;
+               const reco::HFEMClusterShapeAssociationCollection& AssocShapes,
+               reco::RecoEcalCandidateCollection& RecoECand,
+               int nvtx) const;
+
+private:
+  reco::RecoEcalCandidate correctEPosition(const reco::SuperCluster& original,
+                                           const reco::HFEMClusterShape& shape,
+                                           int nvtx) const;
 
   const bool m_correct;
   const double m_e9e25Cut;
@@ -53,7 +54,6 @@ public:
   const double m_eSeLCutlo;
   const int m_era;
   const reco::HFValueStruct m_hfvv;
- 
 };
 
-#endif 
+#endif

--- a/RecoEgamma/EgammaHFProducers/plugins/HFRecoEcalCandidateProducer.cc
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFRecoEcalCandidateProducer.cc
@@ -28,82 +28,70 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-HFRecoEcalCandidateProducer::HFRecoEcalCandidateProducer(edm::ParameterSet const& conf):
-  defaultDB_(std::vector<double>()),
-  hfclustersSC_(consumes<reco::SuperClusterCollection>(conf.getParameter<edm::InputTag>("hfclusters"))),
-  hfclustersHFEM_(consumes<reco::HFEMClusterShapeAssociationCollection>(conf.getParameter<edm::InputTag>("hfclusters"))),
-  
-  HFDBversion_(conf.existsAs<int>("HFDBversion") ? conf.getParameter<int>("HFDBversion"):99),//do nothing
-  HFDBvector_(conf.existsAs<std::vector<double> >("HFDBvector") ? conf.getParameter<std::vector<double> >("HFDBvector"):defaultDB_),
-  doPU_(false),
-  Cut2D_(conf.getParameter<double>("intercept2DCut")),
-  defaultSlope2D_((Cut2D_<=0.83)?(0.475):((Cut2D_>0.83 && Cut2D_<=0.9)?(0.275):(0.2))),//fix for hlt unable to add slope variable now
-  hfvars_(HFDBversion_,HFDBvector_),
-  algo_(conf.existsAs<bool>("Correct") ? conf.getParameter<bool>("Correct") : true,
-	conf.getParameter<double>("e9e25Cut"),
-	conf.getParameter<double>("intercept2DCut"),
-	conf.existsAs<double>("intercept2DSlope") ? conf.getParameter<double>("intercept2DSlope") : defaultSlope2D_,
-	conf.getParameter<std::vector<double> >("e1e9Cut"),
-	conf.getParameter<std::vector<double> >("eCOREe9Cut"),
-	conf.getParameter<std::vector<double> >("eSeLCut"),
-	hfvars_) 
-{
-  if(conf.existsAs<edm::InputTag>("VertexCollection")){
+HFRecoEcalCandidateProducer::HFRecoEcalCandidateProducer(edm::ParameterSet const& conf)
+    : defaultDB_(std::vector<double>()),
+      hfclustersSC_(consumes<reco::SuperClusterCollection>(conf.getParameter<edm::InputTag>("hfclusters"))),
+      hfclustersHFEM_(
+          consumes<reco::HFEMClusterShapeAssociationCollection>(conf.getParameter<edm::InputTag>("hfclusters"))),
+
+      HFDBversion_(conf.existsAs<int>("HFDBversion") ? conf.getParameter<int>("HFDBversion") : 99),  //do nothing
+      HFDBvector_(conf.existsAs<std::vector<double> >("HFDBvector")
+                      ? conf.getParameter<std::vector<double> >("HFDBvector")
+                      : defaultDB_),
+      doPU_(false),
+      Cut2D_(conf.getParameter<double>("intercept2DCut")),
+      defaultSlope2D_(
+          (Cut2D_ <= 0.83)
+              ? (0.475)
+              : ((Cut2D_ > 0.83 && Cut2D_ <= 0.9) ? (0.275) : (0.2))),  //fix for hlt unable to add slope variable now
+      hfvars_(HFDBversion_, HFDBvector_),
+      algo_(conf.existsAs<bool>("Correct") ? conf.getParameter<bool>("Correct") : true,
+            conf.getParameter<double>("e9e25Cut"),
+            conf.getParameter<double>("intercept2DCut"),
+            conf.existsAs<double>("intercept2DSlope") ? conf.getParameter<double>("intercept2DSlope") : defaultSlope2D_,
+            conf.getParameter<std::vector<double> >("e1e9Cut"),
+            conf.getParameter<std::vector<double> >("eCOREe9Cut"),
+            conf.getParameter<std::vector<double> >("eSeLCut"),
+            hfvars_) {
+  if (conf.existsAs<edm::InputTag>("VertexCollection")) {
     vertices_ = consumes<reco::VertexCollection>(conf.getParameter<edm::InputTag>("VertexCollection"));
-  }else vertices_ = consumes<reco::VertexCollection>(edm::InputTag("offlinePrimaryVertices"));
+  } else
+    vertices_ = consumes<reco::VertexCollection>(edm::InputTag("offlinePrimaryVertices"));
 
   produces<reco::RecoEcalCandidateCollection>();
+}
 
-} 
-
-void HFRecoEcalCandidateProducer::produce(edm::Event & e, edm::EventSetup const& iSetup) {  
-  
-  
+void HFRecoEcalCandidateProducer::produce(edm::Event& e, edm::EventSetup const& iSetup) {
   edm::Handle<reco::SuperClusterCollection> super_clus;
   edm::Handle<reco::HFEMClusterShapeAssociationCollection> hf_assoc;
- 
-  e.getByToken(hfclustersSC_,super_clus);
-  e.getByToken(hfclustersHFEM_,hf_assoc);
- 
+
+  e.getByToken(hfclustersSC_, super_clus);
+  e.getByToken(hfclustersHFEM_, hf_assoc);
+
   int nvertex = 0;
-  if(HFDBversion_!=99){
-    edm:: Handle<reco::VertexCollection> pvHandle;
+  if (HFDBversion_ != 99) {
+    edm::Handle<reco::VertexCollection> pvHandle;
     e.getByToken(vertices_, pvHandle);
-    const reco::VertexCollection & vertices = *pvHandle.product();
+    const reco::VertexCollection& vertices = *pvHandle.product();
     static const int minNDOF = 4;
     static const double maxAbsZ = 15.0;
     static const double maxd0 = 2.0;
-    
+
     //count verticies
-  
-    for(reco::VertexCollection::const_iterator vit = vertices.begin(); vit != vertices.end(); ++vit){
-      if(vit->ndof() > minNDOF && ((maxAbsZ <= 0) || fabs(vit->z()) <= maxAbsZ) && ((maxd0 <= 0) || fabs(vit->position().rho()) <= maxd0)) 
-	nvertex++;
+
+    for (reco::VertexCollection::const_iterator vit = vertices.begin(); vit != vertices.end(); ++vit) {
+      if (vit->ndof() > minNDOF && ((maxAbsZ <= 0) || fabs(vit->z()) <= maxAbsZ) &&
+          ((maxd0 <= 0) || fabs(vit->position().rho()) <= maxd0))
+        nvertex++;
     }
-  }else{
+  } else {
     nvertex = 1;
   }
-
-  
 
   // create return data
   auto retdata1 = std::make_unique<reco::RecoEcalCandidateCollection>();
 
-  
-  algo_.produce(super_clus,*hf_assoc,*retdata1,nvertex);
- 
+  algo_.produce(super_clus, *hf_assoc, *retdata1, nvertex);
+
   e.put(std::move(retdata1));
-
 }
-
-
-
-
-
-
-
-
-
-
-
-

--- a/RecoEgamma/EgammaHFProducers/plugins/HFRecoEcalCandidateProducer.h
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFRecoEcalCandidateProducer.h
@@ -1,9 +1,9 @@
 #ifndef RECOLOCALCALO_HFCLUSTERPRODUCER_HFRECOECALCANDIDATEPRODUCER_H
-#define RECOLOCALCALO_HFCLUSTERPRODUCER_HFRECOECALCANDIDATEPRODUCER_H 1// -*- C++ -*-
+#define RECOLOCALCALO_HFCLUSTERPRODUCER_HFRECOECALCANDIDATEPRODUCER_H 1  // -*- C++ -*-
 //
 // Package:    EgammaHFProducers
 // Class:      HFRecoEcalCandidateProducers
-// 
+//
 /**\class HFRecoEcalCandidateProducers.h HFRecoEcalCandidateProducers.cc  
 */
 //
@@ -22,15 +22,16 @@
 #include "HFValueStruct.h"
 
 class HFRecoEcalCandidateProducer : public edm::stream::EDProducer<> {
- public:
+public:
   explicit HFRecoEcalCandidateProducer(edm::ParameterSet const& conf);
   void produce(edm::Event& e, edm::EventSetup const& iSetup) override;
- private:
-  std::vector<double> defaultDB_; 
-  edm::EDGetToken hfclustersSC_,hfclustersHFEM_,vertices_;
+
+private:
+  std::vector<double> defaultDB_;
+  edm::EDGetToken hfclustersSC_, hfclustersHFEM_, vertices_;
   int HFDBversion_;
   std::vector<double> HFDBvector_;
-  bool doPU_; 
+  bool doPU_;
   double Cut2D_;
   double defaultSlope2D_;
   reco::HFValueStruct hfvars_;

--- a/RecoEgamma/EgammaHFProducers/plugins/HFValueStruct.cc
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFValueStruct.cc
@@ -1,38 +1,33 @@
-  
+
 #include "HFValueStruct.h"
 #include <cstdio>
 #include <cstdlib>
 //version -1 will take information from DB (NOT DONE YET)
 //version 0 has energy corrections on, everything else off
 //version 1 has energy correction, and pile up slope and interceept on
-// version 2+ will use defaults of 'do nothing' 
+// version 2+ will use defaults of 'do nothing'
 //
 //
 //
 
-
-reco::HFValueStruct::HFValueStruct(const int& version, const std::vector<double>& vect): v_(version),hfvv_(vect) {
+reco::HFValueStruct::HFValueStruct(const int& version, const std::vector<double>& vect) : v_(version), hfvv_(vect) {
   //if(v_==-1) hfvv_=SetHfvvFromDB_();
   //v==99 will always give defaults
-  
+
   //version control, add in versions as they appear!!
-  if(v_==0 || v_==1) doEnCor_=true;
-  else  doEnCor_=false;
-  
-  if(v_==1) doPU_=true;
-  else doPU_=false;
-  
-  
+  if (v_ == 0 || v_ == 1)
+    doEnCor_ = true;
+  else
+    doEnCor_ = false;
+
+  if (v_ == 1)
+    doPU_ = true;
+  else
+    doPU_ = false;
 }
 
-
-
-int reco::HFValueStruct::indexByIeta(int& ieta)const{
-  return (ieta>0)?(abs(ieta)-29+13):(41-abs(ieta));
-}
-int reco::HFValueStruct::ietaByIndex(int& indx)const{
-  return (indx>13)?(indx+29-13):(indx-41);
-}
+int reco::HFValueStruct::indexByIeta(int& ieta) const { return (ieta > 0) ? (abs(ieta) - 29 + 13) : (41 - abs(ieta)); }
+int reco::HFValueStruct::ietaByIndex(int& indx) const { return (indx > 13) ? (indx + 29 - 13) : (indx - 41); }
 //version 0
 // EnCor=energy corrections,default 1.0, 26 slots
 
@@ -41,76 +36,91 @@ int reco::HFValueStruct::ietaByIndex(int& indx)const{
 
 //PUIntercept= intercept  slope for pile up corrections,default 1.0, 26 slots, 0,1,12,13,24,25 are all defaults always
 
-
-
-
 // returns single value by index
 
-double reco::HFValueStruct::EnCor(int ieta)const{
-  int indx=indexByIeta(ieta);
-  if(doEnCor_) return hfvv_[indx];
-  else return 1.0;}
-double reco::HFValueStruct::PUSlope(int ieta)const{
-  int indx=indexByIeta(ieta)+26;
-  if(doPU_) return hfvv_[indx];
-  else return 0.0;}
-double reco::HFValueStruct::PUIntercept(int ieta)const{
-  int indx=indexByIeta(ieta)+52;
-  if(doPU_) return hfvv_[indx];
-  else return 1.0;}
+double reco::HFValueStruct::EnCor(int ieta) const {
+  int indx = indexByIeta(ieta);
+  if (doEnCor_)
+    return hfvv_[indx];
+  else
+    return 1.0;
+}
+double reco::HFValueStruct::PUSlope(int ieta) const {
+  int indx = indexByIeta(ieta) + 26;
+  if (doPU_)
+    return hfvv_[indx];
+  else
+    return 0.0;
+}
+double reco::HFValueStruct::PUIntercept(int ieta) const {
+  int indx = indexByIeta(ieta) + 52;
+  if (doPU_)
+    return hfvv_[indx];
+  else
+    return 1.0;
+}
 
 // sets single value by index
-void reco::HFValueStruct::setEnCor(int ieta,double val){
-  int indx=indexByIeta(ieta);
-  hfvv_[indx]=val;}
-void reco::HFValueStruct::setPUSlope(int ieta,double val){
-  int indx=indexByIeta(ieta)+26;
-  hfvv_[indx]=val;}
-void reco::HFValueStruct::setPUIntercept(int ieta,double val){
-  int indx=indexByIeta(ieta)+52;
-  hfvv_[indx]=val;}
-
-
+void reco::HFValueStruct::setEnCor(int ieta, double val) {
+  int indx = indexByIeta(ieta);
+  hfvv_[indx] = val;
+}
+void reco::HFValueStruct::setPUSlope(int ieta, double val) {
+  int indx = indexByIeta(ieta) + 26;
+  hfvv_[indx] = val;
+}
+void reco::HFValueStruct::setPUIntercept(int ieta, double val) {
+  int indx = indexByIeta(ieta) + 52;
+  hfvv_[indx] = val;
+}
 
 // returns whole vector
-std::vector<double> reco::HFValueStruct::EnCor()const{
+std::vector<double> reco::HFValueStruct::EnCor() const {
   std::vector<double> vct;
-  if(doEnCor_){
-    for(int ii=0;ii<13;ii++)
+  if (doEnCor_) {
+    for (int ii = 0; ii < 13; ii++)
       vct.push_back(hfvv_[ii]);
-  }else{
-    for(int ii=0;ii<13;ii++)
+  } else {
+    for (int ii = 0; ii < 13; ii++)
       vct.push_back(1.0);
   }
-  return vct;}
+  return vct;
+}
 
-std::vector<double> reco::HFValueStruct::PUSlope()const{
+std::vector<double> reco::HFValueStruct::PUSlope() const {
   std::vector<double> vct;
-  if(doPU_){
-    for(int ii=0;ii<13;ii++)
-      vct.push_back(hfvv_[ii+26]);
-  }else{
-    for(int ii=0;ii<13;ii++)
+  if (doPU_) {
+    for (int ii = 0; ii < 13; ii++)
+      vct.push_back(hfvv_[ii + 26]);
+  } else {
+    for (int ii = 0; ii < 13; ii++)
       vct.push_back(0.0);
   }
-  return vct;}
+  return vct;
+}
 
-std::vector<double> reco::HFValueStruct::PUIntercept()const{	
+std::vector<double> reco::HFValueStruct::PUIntercept() const {
   std::vector<double> vct;
-  if(doPU_){
-    for(int ii=0;ii<13;ii++)
-      vct.push_back(hfvv_[ii+52]);
-  }else{
-    for(int ii=0;ii<13;ii++)
+  if (doPU_) {
+    for (int ii = 0; ii < 13; ii++)
+      vct.push_back(hfvv_[ii + 52]);
+  } else {
+    for (int ii = 0; ii < 13; ii++)
       vct.push_back(1.0);
   }
-  return vct;}
+  return vct;
+}
 
 // set whole vector
-void reco::HFValueStruct::setEnCor(const std::vector<double>& val){
-  for(int ii=0;ii<13;ii++) hfvv_[ii]=val[ii];}
-void reco::HFValueStruct::setPUSlope(const std::vector<double>& val){
-  for(int ii=0;ii<13;ii++) hfvv_[ii+26]=val[ii];}
-void reco::HFValueStruct::setPUIntercept(const std::vector<double>& val){
-  for(int ii=0;ii<13;ii++) hfvv_[ii+52]=val[ii];
+void reco::HFValueStruct::setEnCor(const std::vector<double>& val) {
+  for (int ii = 0; ii < 13; ii++)
+    hfvv_[ii] = val[ii];
+}
+void reco::HFValueStruct::setPUSlope(const std::vector<double>& val) {
+  for (int ii = 0; ii < 13; ii++)
+    hfvv_[ii + 26] = val[ii];
+}
+void reco::HFValueStruct::setPUIntercept(const std::vector<double>& val) {
+  for (int ii = 0; ii < 13; ii++)
+    hfvv_[ii + 52] = val[ii];
 }

--- a/RecoEgamma/EgammaHFProducers/plugins/HFValueStruct.h
+++ b/RecoEgamma/EgammaHFProducers/plugins/HFValueStruct.h
@@ -5,51 +5,41 @@
 #include <vector>
 #include <Rtypes.h>
 
-
 namespace reco {
-  
-  
+
   class HFValueStruct {
   public:
-    
-
-    
     HFValueStruct() {}
     HFValueStruct(const int& version, const std::vector<double>& vect);
     // returns single value by index
-    
-      double EnCor(int ieta)const;
-      double PUSlope(int ieta)const;
-      double PUIntercept(int ieta)const;
-      
-// sets single value by index
-      void setEnCor(int ieta,double val);
-      void setPUSlope(int ieta,double val);
-      void setPUIntercept(int ieta,double val);
-   
 
-    
+    double EnCor(int ieta) const;
+    double PUSlope(int ieta) const;
+    double PUIntercept(int ieta) const;
+
+    // sets single value by index
+    void setEnCor(int ieta, double val);
+    void setPUSlope(int ieta, double val);
+    void setPUIntercept(int ieta, double val);
+
     // returns whole vector
-      std::vector<double> EnCor()const;
-      std::vector<double> PUSlope()const;
-      std::vector<double> PUIntercept()const;
-      
-      // set whole vector
-      void setEnCor(const std::vector<double>& val);
-      void setPUSlope(const std::vector<double>& val);
-      void setPUIntercept(const std::vector<double>& val);
-      
-      
-      
+    std::vector<double> EnCor() const;
+    std::vector<double> PUSlope() const;
+    std::vector<double> PUIntercept() const;
+
+    // set whole vector
+    void setEnCor(const std::vector<double>& val);
+    void setPUSlope(const std::vector<double>& val);
+    void setPUIntercept(const std::vector<double>& val);
+
   private:
-      int v_;
-      std::vector<double> hfvv_;
-      //std::vector<double> SetHfvvFromDB_();  //will need when in database
-      bool doEnCor_,doPU_;
-      
-      int indexByIeta(int& ieta)const;
-      int ietaByIndex(int& indx)const;
-      
+    int v_;
+    std::vector<double> hfvv_;
+    //std::vector<double> SetHfvvFromDB_();  //will need when in database
+    bool doEnCor_, doPU_;
+
+    int indexByIeta(int& ieta) const;
+    int ietaByIndex(int& indx) const;
   };
-}
+}  // namespace reco
 #endif

--- a/RecoEgamma/EgammaHFProducers/plugins/HLTHFRecoEcalCandidateProducer.cc
+++ b/RecoEgamma/EgammaHFProducers/plugins/HLTHFRecoEcalCandidateProducer.cc
@@ -28,56 +28,41 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-HLTHFRecoEcalCandidateProducer::HLTHFRecoEcalCandidateProducer(edm::ParameterSet const& conf):
-  hfclusters_(conf.getParameter<edm::InputTag>("hfclusters")),
-  HFDBversion_(conf.existsAs<bool>("HFDBversion") ? conf.getParameter<int>("HFDBversion"):99),//do nothing
-  HFDBvector_(conf.existsAs<bool>("HFDBvector") ? conf.getParameter<std::vector<double> >("HFDBvector"):std::vector<double>{}),
-  Cut2D_(conf.getParameter<double>("intercept2DCut")),
-  defaultSlope2D_((Cut2D_<=0.83)?(0.475):((Cut2D_>0.83 && Cut2D_<=0.9)?(0.275):(0.2))),//fix for hlt unable to add slope variable now
-  hfvars_(HFDBversion_,HFDBvector_),
-  algo_(conf.existsAs<bool>("Correct") ? conf.getParameter<bool>("Correct") :true,
-	conf.getParameter<double>("e9e25Cut"),
-	conf.getParameter<double>("intercept2DCut"),
-	conf.existsAs<bool>("intercept2DSlope") ? conf.getParameter<double>("intercept2DSlope") : defaultSlope2D_,
-	conf.getParameter<std::vector<double> >("e1e9Cut"),
-	conf.getParameter<std::vector<double> >("eCOREe9Cut"),
-	conf.getParameter<std::vector<double> >("eSeLCut"),
-	hfvars_
-) {
-
+HLTHFRecoEcalCandidateProducer::HLTHFRecoEcalCandidateProducer(edm::ParameterSet const& conf)
+    : hfclusters_(conf.getParameter<edm::InputTag>("hfclusters")),
+      HFDBversion_(conf.existsAs<bool>("HFDBversion") ? conf.getParameter<int>("HFDBversion") : 99),  //do nothing
+      HFDBvector_(conf.existsAs<bool>("HFDBvector") ? conf.getParameter<std::vector<double> >("HFDBvector")
+                                                    : std::vector<double>{}),
+      Cut2D_(conf.getParameter<double>("intercept2DCut")),
+      defaultSlope2D_(
+          (Cut2D_ <= 0.83)
+              ? (0.475)
+              : ((Cut2D_ > 0.83 && Cut2D_ <= 0.9) ? (0.275) : (0.2))),  //fix for hlt unable to add slope variable now
+      hfvars_(HFDBversion_, HFDBvector_),
+      algo_(conf.existsAs<bool>("Correct") ? conf.getParameter<bool>("Correct") : true,
+            conf.getParameter<double>("e9e25Cut"),
+            conf.getParameter<double>("intercept2DCut"),
+            conf.existsAs<bool>("intercept2DSlope") ? conf.getParameter<double>("intercept2DSlope") : defaultSlope2D_,
+            conf.getParameter<std::vector<double> >("e1e9Cut"),
+            conf.getParameter<std::vector<double> >("eCOREe9Cut"),
+            conf.getParameter<std::vector<double> >("eSeLCut"),
+            hfvars_) {
   produces<reco::RecoEcalCandidateCollection>();
+}
 
-} 
-
-void HLTHFRecoEcalCandidateProducer::produce(edm::StreamID sid, edm::Event & e, edm::EventSetup const& iSetup) const {  
-  
-  
+void HLTHFRecoEcalCandidateProducer::produce(edm::StreamID sid, edm::Event& e, edm::EventSetup const& iSetup) const {
   edm::Handle<reco::SuperClusterCollection> super_clus;
   edm::Handle<reco::HFEMClusterShapeAssociationCollection> hf_assoc;
- 
-  e.getByLabel(hfclusters_,super_clus);
-  e.getByLabel(hfclusters_,hf_assoc);
- 
+
+  e.getByLabel(hfclusters_, super_clus);
+  e.getByLabel(hfclusters_, hf_assoc);
+
   int nvertex = 1;
-   
+
   // create return data
   auto retdata1 = std::make_unique<reco::RecoEcalCandidateCollection>();
 
-  
-  algo_.produce(super_clus,*hf_assoc,*retdata1,nvertex);
- 
+  algo_.produce(super_clus, *hf_assoc, *retdata1, nvertex);
+
   e.put(std::move(retdata1));
-
 }
-
-
-
-
-
-
-
-
-
-
-
-

--- a/RecoEgamma/EgammaHFProducers/plugins/HLTHFRecoEcalCandidateProducer.h
+++ b/RecoEgamma/EgammaHFProducers/plugins/HLTHFRecoEcalCandidateProducer.h
@@ -1,9 +1,9 @@
 #ifndef RECOLOCALCALO_HFCLUSTERPRODUCER_HLTHFRECOECALCANDIDATEPRODUCER_H
-#define RECOLOCALCALO_HFCLUSTERPRODUCER_HLTHFRECOECALCANDIDATEPRODUCER_H 1// -*- C++ -*-
+#define RECOLOCALCALO_HFCLUSTERPRODUCER_HLTHFRECOECALCANDIDATEPRODUCER_H 1  // -*- C++ -*-
 //
 // Package:    EgammaHFProducers
 // Class:      HFRecoEcalCandidateProducers
-// 
+//
 /**\class HFRecoEcalCandidateProducers.h HFRecoEcalCandidateProducers.cc  
 */
 //
@@ -22,11 +22,12 @@
 #include "HFValueStruct.h"
 
 class HLTHFRecoEcalCandidateProducer : public edm::global::EDProducer<> {
- public:
+public:
   explicit HLTHFRecoEcalCandidateProducer(edm::ParameterSet const& conf);
   void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
- private:
-  const edm::InputTag hfclusters_,vertices_;
+
+private:
+  const edm::InputTag hfclusters_, vertices_;
   const int HFDBversion_;
   const std::vector<double> HFDBvector_;
   const double Cut2D_;

--- a/RecoEgamma/EgammaHFProducers/plugins/SealModule.cc
+++ b/RecoEgamma/EgammaHFProducers/plugins/SealModule.cc
@@ -5,7 +5,5 @@
 #include "HFEMClusterProducer.h"
 #include "HFRecoEcalCandidateProducer.h"
 
-
-
 DEFINE_FWK_MODULE(HFEMClusterProducer);
 DEFINE_FWK_MODULE(HFRecoEcalCandidateProducer);

--- a/RecoEgamma/EgammaIsolationAlgos/interface/EGHcalRecHitSelector.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EGHcalRecHitSelector.h
@@ -17,20 +17,21 @@
 class EGHcalRecHitSelector {
 public:
   explicit EGHcalRecHitSelector(const edm::ParameterSet& config);
-  ~EGHcalRecHitSelector(){}
-  
-  template<typename CollType>
-  void addDetIds(const reco::SuperCluster& superClus,const HBHERecHitCollection& recHits,
-		 CollType& detIdsToStore)const;
+  ~EGHcalRecHitSelector() {}
 
-  void setup(const edm::EventSetup& iSetup){iSetup.get<CaloGeometryRecord>().get(towerMap_);}
+  template <typename CollType>
+  void addDetIds(const reco::SuperCluster& superClus,
+                 const HBHERecHitCollection& recHits,
+                 CollType& detIdsToStore) const;
+
+  void setup(const edm::EventSetup& iSetup) { iSetup.get<CaloGeometryRecord>().get(towerMap_); }
 
   static edm::ParameterSetDescription makePSetDescription();
 
 private:
-  static int calDIPhi(int iPhi1,int iPhi2);
-  static int calDIEta(int iEta1,int iEta2);
-  float getMinEnergyHCAL_(HcalDetId id)const;
+  static int calDIPhi(int iPhi1, int iPhi2);
+  static int calDIEta(int iEta1, int iEta2);
+  float getMinEnergyHCAL_(HcalDetId id) const;
 
   int maxDIEta_;
   int maxDIPhi_;
@@ -39,34 +40,34 @@ private:
   float minEnergyHEDefault_;
 
   edm::ESHandle<CaloTowerConstituentsMap> towerMap_;
-
 };
 
 template <typename CollType>
-void EGHcalRecHitSelector::
-addDetIds(const reco::SuperCluster& superClus,const HBHERecHitCollection& recHits,
-	  CollType& detIdsToStore)const
-{
+void EGHcalRecHitSelector::addDetIds(const reco::SuperCluster& superClus,
+                                     const HBHERecHitCollection& recHits,
+                                     CollType& detIdsToStore) const {
   DetId seedId = superClus.seed()->seed();
-  if(seedId.det() != DetId::Ecal && seedId.det() != DetId::Forward) {
-    edm::LogError("EgammaIsoHcalDetIdCollectionProducerError") << "Somehow the supercluster has a seed which is not ECAL, something is badly wrong";
+  if (seedId.det() != DetId::Ecal && seedId.det() != DetId::Forward) {
+    edm::LogError("EgammaIsoHcalDetIdCollectionProducerError")
+        << "Somehow the supercluster has a seed which is not ECAL, something is badly wrong";
     return;
   }
   //so we are using CaloTowers to get the iEta/iPhi of the HCAL rec hit behind the seed cluster, this might go funny on tower 28 but shouldnt matter there
- 
-  if( seedId.det() == DetId::Forward ) return;
 
-  CaloTowerDetId towerId(towerMap_->towerOf(seedId)); 
+  if (seedId.det() == DetId::Forward)
+    return;
+
+  CaloTowerDetId towerId(towerMap_->towerOf(seedId));
   int seedHcalIEta = towerId.ieta();
   int seedHcalIPhi = towerId.iphi();
 
-  for(auto& recHit : recHits){
-    int dIEtaAbs = std::abs(calDIEta(seedHcalIEta,recHit.id().ieta()));
-    int dIPhiAbs = std::abs(calDIPhi(seedHcalIPhi,recHit.id().iphi()));
-  
-    if(dIEtaAbs<=maxDIEta_ && dIPhiAbs<=maxDIPhi_ && recHit.energy()>getMinEnergyHCAL_(recHit.id())) detIdsToStore.insert(detIdsToStore.end(),recHit.id().rawId());
+  for (auto& recHit : recHits) {
+    int dIEtaAbs = std::abs(calDIEta(seedHcalIEta, recHit.id().ieta()));
+    int dIPhiAbs = std::abs(calDIPhi(seedHcalIPhi, recHit.id().iphi()));
+
+    if (dIEtaAbs <= maxDIEta_ && dIPhiAbs <= maxDIPhi_ && recHit.energy() > getMinEnergyHCAL_(recHit.id()))
+      detIdsToStore.insert(detIdsToStore.end(), recHit.id().rawId());
   }
 }
-
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/interface/EcalPFClusterIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EcalPFClusterIsolation.h
@@ -8,45 +8,43 @@
 // Institute: UCSD
 //*****************************************************************************
 
-
 //#include "FWCore/Framework/interface/Frameworkfwd.h"
 //#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 // #include "FWCore/Framework/interface/Event.h"
 // #include "FWCore/Framework/interface/MakerMacros.h"
- 
+
 // #include "FWCore/ParameterSet/interface/ParameterSet.h"
- 
+
 #include "DataFormats/RecoCandidate/interface/RecoEcalCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoEcalCandidateIsolation.h"
- 
+
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateIsolation.h"
- 
+
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
 
 #include <vector>
 
-template<typename T1>
+template <typename T1>
 class EcalPFClusterIsolation {
- public:
-
+public:
   typedef std::vector<T1> T1Collection;
   typedef edm::Ref<T1Collection> T1Ref;
 
   EcalPFClusterIsolation(double drMax,
-			 double drVetoBarrel,
-			 double drVetoEndcap,
-			 double etaStripBarrel,
-			 double etaStripEndcap,
-			 double energyBarrel,
-			 double energyEndcap);
-  
+                         double drVetoBarrel,
+                         double drVetoEndcap,
+                         double etaStripBarrel,
+                         double etaStripEndcap,
+                         double energyBarrel,
+                         double energyEndcap);
+
   ~EcalPFClusterIsolation();
   double getSum(T1Ref, edm::Handle<std::vector<reco::PFCluster> >);
-  
- private:
+
+private:
   bool computedRVeto(T1Ref candRef, reco::PFClusterRef pfclu);
 
   double drVeto2_;
@@ -57,7 +55,6 @@ class EcalPFClusterIsolation {
   const double etaStripEndcap_;
   const double energyBarrel_;
   const double energyEndcap_;
-
 };
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/interface/EgammaEcalIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EgammaEcalIsolation.h
@@ -14,7 +14,6 @@
 //=============================================================================
 //*****************************************************************************
 
-
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
@@ -24,35 +23,27 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
-class EgammaEcalIsolation
-{
-
-   public:
-
+class EgammaEcalIsolation {
+public:
   EgammaEcalIsolation(double extRadius,
-		      double etLow,
-		      const reco::BasicClusterCollection* ,
-		      const reco::SuperClusterCollection*);
-
+                      double etLow,
+                      const reco::BasicClusterCollection*,
+                      const reco::SuperClusterCollection*);
 
   ~EgammaEcalIsolation();
-  
+
   double getEcalEtSum(const reco::Candidate*);
- private:
-  
+
+private:
   // ---------- member data --------------------------------
-  
-  // Parameters of isolation cone geometry. 
+
+  // Parameters of isolation cone geometry.
   // Photon case
   double etMin;
   double conesize;
 
   const reco::BasicClusterCollection* basicClusterCollection_;
   const reco::SuperClusterCollection* superClusterCollection_;
-
-
 };
-
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/interface/EgammaHadTower.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EgammaHadTower.h
@@ -15,32 +15,30 @@
 class HcalChannelQuality;
 
 class EgammaHadTower {
- public:
+public:
+  enum HoeMode { SingleTower = 0, TowersBehindCluster = 1 };
 
-  enum HoeMode{SingleTower=0,TowersBehindCluster=1};
-
-  EgammaHadTower(const edm::EventSetup &es,HoeMode mode=SingleTower);
-  ~EgammaHadTower(){;}
-  double getDepth1HcalESum( const reco::SuperCluster & sc ) const ;
-  double getDepth2HcalESum( const reco::SuperCluster & sc ) const ;
-  double getDepth1HcalESum( const std::vector<CaloTowerDetId> & towers ) const ;
-  double getDepth2HcalESum( const std::vector<CaloTowerDetId> & towers ) const ;
-  std::vector<CaloTowerDetId> towersOf(const reco::SuperCluster& sc) const ;
-  CaloTowerDetId  towerOf(const reco::CaloCluster& cluster) const ;
+  EgammaHadTower(const edm::EventSetup& es, HoeMode mode = SingleTower);
+  ~EgammaHadTower() { ; }
+  double getDepth1HcalESum(const reco::SuperCluster& sc) const;
+  double getDepth2HcalESum(const reco::SuperCluster& sc) const;
+  double getDepth1HcalESum(const std::vector<CaloTowerDetId>& towers) const;
+  double getDepth2HcalESum(const std::vector<CaloTowerDetId>& towers) const;
+  std::vector<CaloTowerDetId> towersOf(const reco::SuperCluster& sc) const;
+  CaloTowerDetId towerOf(const reco::CaloCluster& cluster) const;
   void setTowerCollection(const CaloTowerCollection* towercollection);
-  bool hasActiveHcal( const reco::SuperCluster & sc ) const ;
-  bool hasActiveHcal( const std::vector<CaloTowerDetId> & towers ) const ;
+  bool hasActiveHcal(const reco::SuperCluster& sc) const;
+  bool hasActiveHcal(const std::vector<CaloTowerDetId>& towers) const;
 
-
- private:
-  const CaloTowerConstituentsMap * towerMap_;
+private:
+  const CaloTowerConstituentsMap* towerMap_;
   HoeMode mode_;
-  const CaloTowerCollection * towerCollection_;
+  const CaloTowerCollection* towerCollection_;
   unsigned int NMaxClusters_;
-  const HcalChannelQuality * hcalQuality_;
-  const HcalTopology * hcalTopology_;
+  const HcalChannelQuality* hcalQuality_;
+  const HcalTopology* hcalTopology_;
 };
 
-bool ClusterGreaterThan(const reco::CaloClusterPtr& c1, const reco::CaloClusterPtr& c2) ;
+bool ClusterGreaterThan(const reco::CaloClusterPtr& c1, const reco::CaloClusterPtr& c2);
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/interface/EgammaHcalIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EgammaHcalIsolation.h
@@ -24,80 +24,87 @@
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 
 //Sum helper functions
-double scaleToE(const double& eta);
-double scaleToEt(const double& eta);
-
+double scaleToE(const double &eta);
+double scaleToEt(const double &eta);
 
 class EgammaHcalIsolation {
-    public:
+public:
+  enum HcalDepth { AllDepths = 0, Depth1 = 1, Depth2 = 2 };
 
-        enum HcalDepth{AllDepths=0,Depth1=1,Depth2=2};
+  //constructors
+  EgammaHcalIsolation(double extRadius,
+                      double intRadius,
+                      double eLowB,
+                      double eLowE,
+                      double etLowB,
+                      double etLowE,
+                      edm::ESHandle<CaloGeometry> theCaloGeom,
+                      const HBHERecHitCollection &mhbhe);
 
-        //constructors
-        EgammaHcalIsolation (
-                double extRadius,
-                double intRadius,
-                double eLowB,
-                double eLowE,
-                double etLowB,
-                double etLowE,
-                edm::ESHandle<CaloGeometry> theCaloGeom ,
-                const HBHERecHitCollection&  mhbhe
-                );
+  //destructor
+  ~EgammaHcalIsolation();
 
-        //destructor 
-        ~EgammaHcalIsolation() ;
+  //AllDepths
+  double getHcalESum(const reco::Candidate *c) const { return getHcalESum(c->get<reco::SuperClusterRef>().get()); }
+  double getHcalEtSum(const reco::Candidate *c) const { return getHcalEtSum(c->get<reco::SuperClusterRef>().get()); }
+  double getHcalESum(const reco::SuperCluster *sc) const { return getHcalESum(sc->position()); }
+  double getHcalEtSum(const reco::SuperCluster *sc) const { return getHcalEtSum(sc->position()); }
+  double getHcalESum(const math::XYZPoint &p) const { return getHcalESum(GlobalPoint(p.x(), p.y(), p.z())); }
+  double getHcalEtSum(const math::XYZPoint &p) const { return getHcalEtSum(GlobalPoint(p.x(), p.y(), p.z())); }
+  double getHcalESum(const GlobalPoint &pclu) const { return getHcalSum(pclu, AllDepths, &scaleToE); }
+  double getHcalEtSum(const GlobalPoint &pclu) const { return getHcalSum(pclu, AllDepths, &scaleToEt); }
 
-        //AllDepths
-        double getHcalESum (const reco::Candidate *c)     const { return getHcalESum(c->get<reco::SuperClusterRef>().get()); } 
-        double getHcalEtSum(const reco::Candidate *c)     const { return getHcalEtSum(c->get<reco::SuperClusterRef>().get()); } 
-        double getHcalESum (const reco::SuperCluster *sc) const { return getHcalESum(sc->position()); } 
-        double getHcalEtSum(const reco::SuperCluster *sc) const { return getHcalEtSum(sc->position()); } 
-        double getHcalESum (const math::XYZPoint &p)      const { return getHcalESum(GlobalPoint(p.x(),p.y(),p.z())); } 
-        double getHcalEtSum(const math::XYZPoint &p)      const { return getHcalEtSum(GlobalPoint(p.x(),p.y(),p.z())); } 
-        double getHcalESum (const GlobalPoint &pclu)      const { return getHcalSum(pclu,AllDepths,&scaleToE); } 
-        double getHcalEtSum(const GlobalPoint &pclu)      const { return getHcalSum(pclu,AllDepths,&scaleToEt); }
+  //Depth1
+  double getHcalESumDepth1(const reco::Candidate *c) const {
+    return getHcalESumDepth1(c->get<reco::SuperClusterRef>().get());
+  }
+  double getHcalEtSumDepth1(const reco::Candidate *c) const {
+    return getHcalEtSumDepth1(c->get<reco::SuperClusterRef>().get());
+  }
+  double getHcalESumDepth1(const reco::SuperCluster *sc) const { return getHcalESumDepth1(sc->position()); }
+  double getHcalEtSumDepth1(const reco::SuperCluster *sc) const { return getHcalEtSumDepth1(sc->position()); }
+  double getHcalESumDepth1(const math::XYZPoint &p) const {
+    return getHcalESumDepth1(GlobalPoint(p.x(), p.y(), p.z()));
+  }
+  double getHcalEtSumDepth1(const math::XYZPoint &p) const {
+    return getHcalEtSumDepth1(GlobalPoint(p.x(), p.y(), p.z()));
+  }
+  double getHcalESumDepth1(const GlobalPoint &pclu) const { return getHcalSum(pclu, Depth1, &scaleToE); }
+  double getHcalEtSumDepth1(const GlobalPoint &pclu) const { return getHcalSum(pclu, Depth1, &scaleToEt); }
 
-        //Depth1
-        double getHcalESumDepth1 (const reco::Candidate *c)     const { return getHcalESumDepth1(c->get<reco::SuperClusterRef>().get()); } 
-        double getHcalEtSumDepth1(const reco::Candidate *c)     const { return getHcalEtSumDepth1(c->get<reco::SuperClusterRef>().get()); } 
-        double getHcalESumDepth1 (const reco::SuperCluster *sc) const { return getHcalESumDepth1(sc->position()); } 
-        double getHcalEtSumDepth1(const reco::SuperCluster *sc) const { return getHcalEtSumDepth1(sc->position()); } 
-        double getHcalESumDepth1 (const math::XYZPoint &p)      const { return getHcalESumDepth1(GlobalPoint(p.x(),p.y(),p.z())); } 
-        double getHcalEtSumDepth1(const math::XYZPoint &p)      const { return getHcalEtSumDepth1(GlobalPoint(p.x(),p.y(),p.z())); } 
-        double getHcalESumDepth1 (const GlobalPoint &pclu)      const { return getHcalSum(pclu,Depth1,&scaleToE); } 
-        double getHcalEtSumDepth1(const GlobalPoint &pclu)      const { return getHcalSum(pclu,Depth1,&scaleToEt); }
+  //Depth2
+  double getHcalESumDepth2(const reco::Candidate *c) const {
+    return getHcalESumDepth2(c->get<reco::SuperClusterRef>().get());
+  }
+  double getHcalEtSumDepth2(const reco::Candidate *c) const {
+    return getHcalEtSumDepth2(c->get<reco::SuperClusterRef>().get());
+  }
+  double getHcalESumDepth2(const reco::SuperCluster *sc) const { return getHcalESumDepth2(sc->position()); }
+  double getHcalEtSumDepth2(const reco::SuperCluster *sc) const { return getHcalEtSumDepth2(sc->position()); }
+  double getHcalESumDepth2(const math::XYZPoint &p) const {
+    return getHcalESumDepth2(GlobalPoint(p.x(), p.y(), p.z()));
+  }
+  double getHcalEtSumDepth2(const math::XYZPoint &p) const {
+    return getHcalEtSumDepth2(GlobalPoint(p.x(), p.y(), p.z()));
+  }
+  double getHcalESumDepth2(const GlobalPoint &pclu) const { return getHcalSum(pclu, Depth2, &scaleToE); }
+  double getHcalEtSumDepth2(const GlobalPoint &pclu) const { return getHcalSum(pclu, Depth2, &scaleToEt); }
 
-        //Depth2
-        double getHcalESumDepth2 (const reco::Candidate *c)     const { return getHcalESumDepth2(c->get<reco::SuperClusterRef>().get()); } 
-        double getHcalEtSumDepth2(const reco::Candidate *c)     const { return getHcalEtSumDepth2(c->get<reco::SuperClusterRef>().get()); } 
-        double getHcalESumDepth2 (const reco::SuperCluster *sc) const { return getHcalESumDepth2(sc->position()); } 
-        double getHcalEtSumDepth2(const reco::SuperCluster *sc) const { return getHcalEtSumDepth2(sc->position()); } 
-        double getHcalESumDepth2 (const math::XYZPoint &p)      const { return getHcalESumDepth2(GlobalPoint(p.x(),p.y(),p.z())); } 
-        double getHcalEtSumDepth2(const math::XYZPoint &p)      const { return getHcalEtSumDepth2(GlobalPoint(p.x(),p.y(),p.z())); } 
-        double getHcalESumDepth2 (const GlobalPoint &pclu)      const { return getHcalSum(pclu,Depth2,&scaleToE); } 
-        double getHcalEtSumDepth2(const GlobalPoint &pclu)      const { return getHcalSum(pclu,Depth2,&scaleToEt); }
+private:
+  bool isDepth2(const DetId &) const;
+  double getHcalSum(const GlobalPoint &, const HcalDepth &, double (*)(const double &)) const;
 
+  double extRadius_;
+  double intRadius_;
+  double eLowB_;
+  double eLowE_;
+  double etLowB_;
+  double etLowE_;
 
-    private:
+  edm::ESHandle<CaloGeometry> theCaloGeom_;
+  const HBHERecHitCollection &mhbhe_;
 
-        
-        bool isDepth2(const DetId&) const;
-        double getHcalSum(const GlobalPoint&, const HcalDepth&, double(*)(const double&) ) const;
-
-        double extRadius_ ;
-        double intRadius_ ;
-        double eLowB_ ;
-        double eLowE_ ;
-        double etLowB_ ;
-        double etLowE_ ;
-
-
-        edm::ESHandle<CaloGeometry>  theCaloGeom_ ;
-        const HBHERecHitCollection&  mhbhe_ ;
-
-        CaloDualConeSelector<HBHERecHit>* doubleConeSel_;
-
+  CaloDualConeSelector<HBHERecHit> *doubleConeSel_;
 };
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/interface/EgammaRange.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EgammaRange.h
@@ -11,33 +11,41 @@
 
 namespace egammaisolation {
 
-template<class T> class EgammaRange : public std::pair<T,T> {
-public:
+  template <class T>
+  class EgammaRange : public std::pair<T, T> {
+  public:
+    EgammaRange() {}
 
-  EgammaRange() { }
+    EgammaRange(const T& aMin, const T& aMax) : std::pair<T, T>(aMin, aMax) {}
 
-  EgammaRange(const T & aMin, const T & aMax) : std::pair<T,T> (aMin,aMax) { }
+    EgammaRange(const std::pair<T, T>& aPair) : std::pair<T, T>(aPair) {}
 
-  EgammaRange(const std::pair<T,T> & aPair ) : std::pair<T,T> (aPair) { }  
+    const T& min() const { return this->first; }
 
-  const T & min() const { return this->first; }
+    const T& max() const { return this->second; }
 
-  const T & max() const { return this->second; }
+    T mean() const { return (this->first + this->second) / 2.; }
 
-  T mean() const { return (this->first+this->second)/2.; }
+    bool empty() const { return (this->second < this->first); }
 
-  bool empty() const { return (this->second < this->first); }
+    bool inside(const T& value) const {
+      if (value < this->first || this->second < value)
+        return false;
+      else
+        return true;
+    }
 
-  bool inside(const T & value) const {
-    if (value < this->first || this->second < value)  return false; else  return true;
-  }
+    void sort() {
+      if (empty())
+        std::swap(this->first, this->second);
+    }
+  };
 
-  void sort() { if (empty() ) std::swap(this->first,this->second); }
-};
+}  // namespace egammaisolation
 
+template <class T>
+std::ostream& operator<<(std::ostream& out, const egammaisolation::EgammaRange<T>& r) {
+  return out << "(" << r.min() << "," << r.max() << ")";
 }
-
-template <class T> std::ostream & operator<<( std::ostream& out, const egammaisolation::EgammaRange<T>& r) 
-{ return out << "("<<r.min()<<","<<r.max()<<")"; }
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/interface/EgammaRecHitIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EgammaRecHitIsolation.h
@@ -26,30 +26,28 @@
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 
 class EgammaRecHitIsolation {
- public:
-  
+public:
   //constructors
-  EgammaRecHitIsolation (double extRadius,
-                         double intRadius,
-                         double etaSlice,
-                         double etLow,
-                         double eLow,
-                         edm::ESHandle<CaloGeometry> ,
-                         const EcalRecHitCollection&,
-                         const EcalSeverityLevelAlgo*,
-                         DetId::Detector detector);
-  
-  double getEtSum(const reco::Candidate * emObject) const {return getSum_(emObject,true);}
-  double getEnergySum(const reco::Candidate * emObject) const{ return  getSum_(emObject,false);}
+  EgammaRecHitIsolation(double extRadius,
+                        double intRadius,
+                        double etaSlice,
+                        double etLow,
+                        double eLow,
+                        edm::ESHandle<CaloGeometry>,
+                        const EcalRecHitCollection&,
+                        const EcalSeverityLevelAlgo*,
+                        DetId::Detector detector);
 
-  double getEtSum(const reco::SuperCluster* emObject ) const {return getSum_(emObject,true);}
-  double getEnergySum(const reco::SuperCluster * emObject) const{ return  getSum_(emObject,false);}
+  double getEtSum(const reco::Candidate* emObject) const { return getSum_(emObject, true); }
+  double getEnergySum(const reco::Candidate* emObject) const { return getSum_(emObject, false); }
 
-  void setUseNumCrystals(bool b=true) { useNumCrystals_ = b; }
-  void setVetoClustered(bool b=true) { vetoClustered_ = b; }
-  void doSeverityChecks(const EcalRecHitCollection *const recHits,
-			const std::vector<int>& v) { 
-    ecalBarHits_ = recHits; 
+  double getEtSum(const reco::SuperCluster* emObject) const { return getSum_(emObject, true); }
+  double getEnergySum(const reco::SuperCluster* emObject) const { return getSum_(emObject, false); }
+
+  void setUseNumCrystals(bool b = true) { useNumCrystals_ = b; }
+  void setVetoClustered(bool b = true) { vetoClustered_ = b; }
+  void doSeverityChecks(const EcalRecHitCollection* const recHits, const std::vector<int>& v) {
+    ecalBarHits_ = recHits;
     severitiesexcl_.clear();
     severitiesexcl_.insert(severitiesexcl_.begin(), v.begin(), v.end());
     std::sort(severitiesexcl_.begin(), severitiesexcl_.end());
@@ -58,30 +56,29 @@ class EgammaRecHitIsolation {
   void doFlagChecks(const std::vector<int>& v) {
     flags_.clear();
     flags_.insert(flags_.begin(), v.begin(), v.end());
-    std::sort(flags_.begin(), flags_.end() );
+    std::sort(flags_.begin(), flags_.end());
   }
 
-  //destructor 
-  ~EgammaRecHitIsolation() ;
-  
- private:
-  double getSum_(const reco::Candidate *, bool returnEt ) const;
-  double getSum_(const reco::SuperCluster *, bool returnEt ) const;
+  //destructor
+  ~EgammaRecHitIsolation();
 
-  double extRadius_ ;
-  double intRadius_ ;
+private:
+  double getSum_(const reco::Candidate*, bool returnEt) const;
+  double getSum_(const reco::SuperCluster*, bool returnEt) const;
+
+  double extRadius_;
+  double intRadius_;
   double etaSlice_;
-  double etLow_ ;
-  double eLow_ ;
+  double etLow_;
+  double eLow_;
 
-  
-  edm::ESHandle<CaloGeometry>  theCaloGeom_ ;
-  const EcalRecHitCollection&  caloHits_ ;
+  edm::ESHandle<CaloGeometry> theCaloGeom_;
+  const EcalRecHitCollection& caloHits_;
   const EcalSeverityLevelAlgo* sevLevel_;
 
   bool useNumCrystals_;
   bool vetoClustered_;
-  const EcalRecHitCollection *ecalBarHits_;
+  const EcalRecHitCollection* ecalBarHits_;
   //const EcalChannelStatus *chStatus_;
   std::vector<int> severitiesexcl_;
   //int severityLevelCut_;
@@ -90,7 +87,7 @@ class EgammaRecHitIsolation {
   //float spIdThreshold_;
   std::vector<int> flags_;
 
-  const CaloSubdetectorGeometry* subdet_[2]; // barrel+endcap
+  const CaloSubdetectorGeometry* subdet_[2];  // barrel+endcap
 };
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/interface/EgammaTowerIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EgammaTowerIsolation.h
@@ -12,15 +12,13 @@
 //=============================================================================
 //*****************************************************************************
 
-#include<vector>
-
+#include <vector>
 
 //CMSSW includes
 #include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
 #include "DataFormats/RecoCandidate/interface/RecoCandidate.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 #include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
-
 
 #include <cmath>
 #include <algorithm>
@@ -29,20 +27,16 @@
 
 #include "DataFormats/Math/interface/deltaR.h"
 
-
-
 /*
   for each set of cuts it will compute Et for all, depth1 and depth2 twice:
   one between inner and outer and once inside outer vetoid the tower to excude
 
  */
-template<unsigned int NC>
+template <unsigned int NC>
 class EgammaTowerIsolationNew {
- public:
-
+public:
   struct Sum {
-    Sum(): he{0},h2{0},heBC{0},h2BC{0}
-    {}
+    Sum() : he{0}, h2{0}, heBC{0}, h2BC{0} {}
     float he[NC];
     float h2[NC];
     float heBC[NC];
@@ -54,50 +48,50 @@ class EgammaTowerIsolationNew {
 
   //constructors
 
-  EgammaTowerIsolationNew () : nt(0){}
-  EgammaTowerIsolationNew (float extRadius[NC],
-			   float intRadius[NC],
-			   CaloTowerCollection const & towers) ;
- 
+  EgammaTowerIsolationNew() : nt(0) {}
+  EgammaTowerIsolationNew(float extRadius[NC], float intRadius[NC], CaloTowerCollection const& towers);
 
-  ~EgammaTowerIsolationNew() { delete[] mem;}
-  
-  void compute(bool et, Sum&sum, reco::Candidate const & cand,  CaloTowerDetId const * first,  CaloTowerDetId const * last) const {
-    reco::SuperCluster const & sc =  *cand.get<reco::SuperClusterRef>().get();
-    return compute(et,sum,sc,first,last);
+  ~EgammaTowerIsolationNew() { delete[] mem; }
+
+  void compute(
+      bool et, Sum& sum, reco::Candidate const& cand, CaloTowerDetId const* first, CaloTowerDetId const* last) const {
+    reco::SuperCluster const& sc = *cand.get<reco::SuperClusterRef>().get();
+    return compute(et, sum, sc, first, last);
   }
-  void compute(bool et, Sum &sum, reco::SuperCluster const & sc,  CaloTowerDetId const * first,  CaloTowerDetId const * last) const;
+  void compute(
+      bool et, Sum& sum, reco::SuperCluster const& sc, CaloTowerDetId const* first, CaloTowerDetId const* last) const;
 
-  void setRadius(float const extRadius[NC],float const intRadius[NC]) {
-    for (std::size_t i=0; i!=NCuts; ++i) {
-      extRadius2_[i]=extRadius[i]*extRadius[i];
-      intRadius2_[i]=intRadius[i]*intRadius[i];
+  void setRadius(float const extRadius[NC], float const intRadius[NC]) {
+    for (std::size_t i = 0; i != NCuts; ++i) {
+      extRadius2_[i] = extRadius[i] * extRadius[i];
+      intRadius2_[i] = intRadius[i] * intRadius[i];
     }
-    maxEta = *std::max_element(extRadius,extRadius+NC);
+    maxEta = *std::max_element(extRadius, extRadius + NC);
   }
 
 public:
+  float extRadius2_[NCuts];
+  float intRadius2_[NCuts];
 
-  float extRadius2_[NCuts] ;
-  float intRadius2_[NCuts] ;
-  
   float maxEta;
   //SOA
   const uint32_t nt;
-  float * eta;
-  float * phi;
-  float * he;
-  float * h2;
-  float * st;
-  uint32_t * id;
-  uint32_t * mem=nullptr;
+  float* eta;
+  float* phi;
+  float* he;
+  float* h2;
+  float* st;
+  uint32_t* id;
+  uint32_t* mem = nullptr;
   void initSoa() {
-    mem = new uint32_t[nt*6];
-    eta = (float*)(mem); phi = eta+nt; he = phi+nt; h2 = he+nt; st = h2+nt;
+    mem = new uint32_t[nt * 6];
+    eta = (float*)(mem);
+    phi = eta + nt;
+    he = phi + nt;
+    h2 = he + nt;
+    st = h2 + nt;
     id = (uint32_t*)(st) + nt;
- }
-  
-  
+  }
 };
 
 /*#define ETISTATDEBUG*/
@@ -105,67 +99,64 @@ public:
 namespace etiStat {
 
   struct Count {
-    std::atomic<uint32_t> create=0;
-    std::atomic<uint32_t> comp=0;
-    std::atomic<uint32_t> span=0;
+    std::atomic<uint32_t> create = 0;
+    std::atomic<uint32_t> comp = 0;
+    std::atomic<uint32_t> span = 0;
     static Count count;
     ~Count();
   };
 
-}
+}  // namespace etiStat
 #endif
 
-template<unsigned int NC>
-inline
-EgammaTowerIsolationNew<NC>::EgammaTowerIsolationNew(float extRadius[NC],
-						     float intRadius[NC],
-						     CaloTowerCollection const & towers) :
-  maxEta(*std::max_element(extRadius,extRadius+NC)),
-  nt(towers.size()) {
-  if (nt==0) return;
+template <unsigned int NC>
+inline EgammaTowerIsolationNew<NC>::EgammaTowerIsolationNew(float extRadius[NC],
+                                                            float intRadius[NC],
+                                                            CaloTowerCollection const& towers)
+    : maxEta(*std::max_element(extRadius, extRadius + NC)), nt(towers.size()) {
+  if (nt == 0)
+    return;
   initSoa();
 
 #ifdef ETISTATDEBUG
   etiStat::Count::count.create++;
 #endif
-  
-  for (std::size_t i=0; i!=NCuts; ++i) {
-    extRadius2_[i]=extRadius[i]*extRadius[i];
-    intRadius2_[i]=intRadius[i]*intRadius[i];
+
+  for (std::size_t i = 0; i != NCuts; ++i) {
+    extRadius2_[i] = extRadius[i] * extRadius[i];
+    intRadius2_[i] = intRadius[i] * intRadius[i];
   }
-  
+
   // sort in eta  (kd-tree anoverkill,does not vectorize...)
   uint32_t index[nt];
-  #ifdef __clang__
+#ifdef __clang__
   std::vector<float> e(nt);
-  #else
+#else
   float e[nt];
-  #endif
-  for (std::size_t k=0; k!=nt; ++k) {
-    e[k]=towers[k].eta();
-    index[k]=k;
-    std::push_heap(index,index+k+1,[&e](uint32_t i, uint32_t j){ return e[i]<e[j];});
+#endif
+  for (std::size_t k = 0; k != nt; ++k) {
+    e[k] = towers[k].eta();
+    index[k] = k;
+    std::push_heap(index, index + k + 1, [&e](uint32_t i, uint32_t j) { return e[i] < e[j]; });
   }
-  std::sort_heap(index,index+nt,[&e](uint32_t i, uint32_t j){ return e[i]<e[j];});
-  
-  
-  for (std::size_t i=0;i!=nt; ++i) {
+  std::sort_heap(index, index + nt, [&e](uint32_t i, uint32_t j) { return e[i] < e[j]; });
+
+  for (std::size_t i = 0; i != nt; ++i) {
     auto j = index[i];
-    eta[i]=towers[j].eta();
-    phi[i]=towers[j].phi();
-    id[i]=towers[j].id();
-    st[i] =  1.f/std::cosh(eta[i]); // std::sin(towers[j].theta());   //;
+    eta[i] = towers[j].eta();
+    phi[i] = towers[j].phi();
+    id[i] = towers[j].id();
+    st[i] = 1.f / std::cosh(eta[i]);  // std::sin(towers[j].theta());   //;
     he[i] = towers[j].hadEnergy();
     h2[i] = towers[j].hadEnergyHeOuterLayer();
   }
 }
 
-
-template<unsigned int NC>
-inline
-void
-EgammaTowerIsolationNew<NC>::compute(bool et, Sum &sum, reco::SuperCluster const & sc,  CaloTowerDetId const * first,  CaloTowerDetId const * last) const {
-  if (nt==0) return;
+template <unsigned int NC>
+inline void EgammaTowerIsolationNew<NC>::compute(
+    bool et, Sum& sum, reco::SuperCluster const& sc, CaloTowerDetId const* first, CaloTowerDetId const* last) const {
+  if (nt == 0)
+    return;
 
 #ifdef ETISTATDEBUG
   etiStat::Count::count.comp++;
@@ -174,30 +165,29 @@ EgammaTowerIsolationNew<NC>::compute(bool et, Sum &sum, reco::SuperCluster const
   float candEta = sc.eta();
   float candPhi = sc.phi();
 
-  
-  auto lb = std::lower_bound(eta,eta+nt,candEta-maxEta);
-  auto ub = std::upper_bound(lb,eta+nt,candEta+maxEta);
-  uint32_t il = lb-eta;
-  uint32_t iu = std::min(nt,uint32_t(ub-eta+1));
-  
+  auto lb = std::lower_bound(eta, eta + nt, candEta - maxEta);
+  auto ub = std::upper_bound(lb, eta + nt, candEta + maxEta);
+  uint32_t il = lb - eta;
+  uint32_t iu = std::min(nt, uint32_t(ub - eta + 1));
+
 #ifdef ETISTATDEBUG
-  etiStat::Count::count.span += (iu-il);
+  etiStat::Count::count.span += (iu - il);
 #endif
 
   // should be restricted in eta....
-  for (std::size_t i=il;i!=iu; ++i) {
-    float dr2 = reco::deltaR2(candEta,candPhi,eta[i], phi[i]);
+  for (std::size_t i = il; i != iu; ++i) {
+    float dr2 = reco::deltaR2(candEta, candPhi, eta[i], phi[i]);
     float tt = et ? st[i] : 1.f;
-    for (std::size_t j=0; j!=NCuts; ++j) {
-      if (dr2<extRadius2_[j]) {
-	if (dr2>=intRadius2_[j]) {
-	  sum.he[j] +=he[i]*tt;
-	  sum.h2[j] +=h2[i]*tt;
-	}
-	if(std::find(first,last,id[i]) == last) {
-	  sum.heBC[j] +=he[i]*tt;
-	  sum.h2BC[j] +=h2[i]*tt;
-	}
+    for (std::size_t j = 0; j != NCuts; ++j) {
+      if (dr2 < extRadius2_[j]) {
+        if (dr2 >= intRadius2_[j]) {
+          sum.he[j] += he[i] * tt;
+          sum.h2[j] += h2[i] * tt;
+        }
+        if (std::find(first, last, id[i]) == last) {
+          sum.heBC[j] += he[i] * tt;
+          sum.h2BC[j] += h2[i] * tt;
+        }
       }
     }
   }
@@ -205,40 +195,35 @@ EgammaTowerIsolationNew<NC>::compute(bool et, Sum &sum, reco::SuperCluster const
 
 class EgammaTowerIsolation {
 public:
-  
-  enum HcalDepth{AllDepths=-1,Undefined=0,Depth1=1,Depth2=2};
-  
-  //constructors
-  EgammaTowerIsolation (float extRadiusI,
-			float intRadiusI,
-			float etLow,
-			signed int depth,
-			const CaloTowerCollection* towers );
-  
-  double getTowerEtSum (const reco::Candidate* cand, const std::vector<CaloTowerDetId> * detIdToExclude=nullptr ) const{
-    reco::SuperCluster const & sc =  *cand->get<reco::SuperClusterRef>().get();
-    return getSum(true,sc,detIdToExclude);
-  }
-  double  getTowerESum (const reco::Candidate* cand, const std::vector<CaloTowerDetId> * detIdToExclude=nullptr) const{
-    reco::SuperCluster const & sc =  *cand->get<reco::SuperClusterRef>().get();
-    return getSum(false,sc,detIdToExclude);
-  }
-  double getTowerEtSum (reco::SuperCluster const * sc, const std::vector<CaloTowerDetId> * detIdToExclude=nullptr ) const{
-    return getSum(true,*sc,detIdToExclude);
-  }
-  double  getTowerESum (reco::SuperCluster const * sc, const std::vector<CaloTowerDetId> * detIdToExclude=nullptr) const{
-    return getSum(false,*sc,detIdToExclude);
-  }
-  private:
-  double getSum (bool et, reco::SuperCluster const & sc, const std::vector<CaloTowerDetId> * detIdToExclude) const;
+  enum HcalDepth { AllDepths = -1, Undefined = 0, Depth1 = 1, Depth2 = 2 };
 
-  
+  //constructors
+  EgammaTowerIsolation(
+      float extRadiusI, float intRadiusI, float etLow, signed int depth, const CaloTowerCollection* towers);
+
+  double getTowerEtSum(const reco::Candidate* cand, const std::vector<CaloTowerDetId>* detIdToExclude = nullptr) const {
+    reco::SuperCluster const& sc = *cand->get<reco::SuperClusterRef>().get();
+    return getSum(true, sc, detIdToExclude);
+  }
+  double getTowerESum(const reco::Candidate* cand, const std::vector<CaloTowerDetId>* detIdToExclude = nullptr) const {
+    reco::SuperCluster const& sc = *cand->get<reco::SuperClusterRef>().get();
+    return getSum(false, sc, detIdToExclude);
+  }
+  double getTowerEtSum(reco::SuperCluster const* sc,
+                       const std::vector<CaloTowerDetId>* detIdToExclude = nullptr) const {
+    return getSum(true, *sc, detIdToExclude);
+  }
+  double getTowerESum(reco::SuperCluster const* sc, const std::vector<CaloTowerDetId>* detIdToExclude = nullptr) const {
+    return getSum(false, *sc, detIdToExclude);
+  }
+
+private:
+  double getSum(bool et, reco::SuperCluster const& sc, const std::vector<CaloTowerDetId>* detIdToExclude) const;
+
 private:
   signed int depth_;
   float extRadius;
   float intRadius;
 };
-
-
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/interface/EgammaTrackSelector.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EgammaTrackSelector.h
@@ -10,48 +10,61 @@
 
 namespace egammaisolation {
 
-
   class EgammaTrackSelector {
   public:
-
     typedef egammaisolation::EgammaRange<float> Range;
     typedef std::list<const reco::Track*> result_type;
     typedef edm::View<reco::Track> input_type;
     typedef reco::TrackBase::Point BeamPoint;
 
     enum { dz = 0, vz, bs, vtx };
-  
+
     //!config parameters
     struct Parameters {
       Parameters()
-	:  zRange(-1e6,1e6), rRange(-1e6,1e6), dir(0,0), drMax(1e3), beamPoint(0,0,0),
-	   nHitsMin(0), chi2NdofMax(1e64), chi2ProbMin(-1.), ptMin(-1) {}
-      Parameters(const Range& dz, const double d0Max, const reco::isodeposit::Direction& dirC, double rMax, 
-		 const BeamPoint& point  = BeamPoint(0,0,0))
-	: zRange(dz), rRange(Range(0,d0Max)), dir(dirC), drMax(rMax), beamPoint(point),
-	  nHitsMin(0), chi2NdofMax(1e64), chi2ProbMin(-1.), ptMin(-1) {}
-      Range        zRange;  //! range in z
-      Range        rRange;  //! range in d0 or dxy (abs value)
-      reco::isodeposit::Direction       dir;  //! direction of the selection cone
-      double        drMax;      //! cone size
-      BeamPoint beamPoint;      //! beam spot position
-      unsigned int  nHitsMin;      //! nValidHits >= nHitsMin
-      double  chi2NdofMax;      //! max value of normalized chi2
-      double  chi2ProbMin;      //! ChiSquaredProbability( chi2, ndf ) > chi2ProbMin
-      double        ptMin;      //! tk.pt>ptMin
-      int           dzOption;  //! which dz cut to use
+          : zRange(-1e6, 1e6),
+            rRange(-1e6, 1e6),
+            dir(0, 0),
+            drMax(1e3),
+            beamPoint(0, 0, 0),
+            nHitsMin(0),
+            chi2NdofMax(1e64),
+            chi2ProbMin(-1.),
+            ptMin(-1) {}
+      Parameters(const Range& dz,
+                 const double d0Max,
+                 const reco::isodeposit::Direction& dirC,
+                 double rMax,
+                 const BeamPoint& point = BeamPoint(0, 0, 0))
+          : zRange(dz),
+            rRange(Range(0, d0Max)),
+            dir(dirC),
+            drMax(rMax),
+            beamPoint(point),
+            nHitsMin(0),
+            chi2NdofMax(1e64),
+            chi2ProbMin(-1.),
+            ptMin(-1) {}
+      Range zRange;                     //! range in z
+      Range rRange;                     //! range in d0 or dxy (abs value)
+      reco::isodeposit::Direction dir;  //! direction of the selection cone
+      double drMax;                     //! cone size
+      BeamPoint beamPoint;              //! beam spot position
+      unsigned int nHitsMin;            //! nValidHits >= nHitsMin
+      double chi2NdofMax;               //! max value of normalized chi2
+      double chi2ProbMin;               //! ChiSquaredProbability( chi2, ndf ) > chi2ProbMin
+      double ptMin;                     //! tk.pt>ptMin
+      int dzOption;                     //! which dz cut to use
     };
 
+    EgammaTrackSelector(const Parameters& pars) : thePars(pars) {}
 
-    EgammaTrackSelector(const Parameters& pars) : thePars(pars) { } 
-
-      result_type operator()(const input_type & tracks) const;
-
+    result_type operator()(const input_type& tracks) const;
 
   private:
-      Parameters thePars;
-  }; 
+    Parameters thePars;
+  };
 
-}
+}  // namespace egammaisolation
 
-#endif 
+#endif

--- a/RecoEgamma/EgammaIsolationAlgos/interface/EleTkIsolFromCands.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/EleTkIsolFromCands.h
@@ -10,24 +10,24 @@
 //author S. Harper (RAL)
 //this class does a simple calculation of the track isolation for a track with eta,
 //phi and z vtx (typically the GsfTrack of the electron). It uses
-//PFPackedCandidates as proxies for the tracks. It now has been upgraded to 
+//PFPackedCandidates as proxies for the tracks. It now has been upgraded to
 //take general tracks as input also
 //
-//Note: due to rounding and space saving issues, the isolation calculated on tracks and 
+//Note: due to rounding and space saving issues, the isolation calculated on tracks and
 //PFPackedCandidates will differ slightly even if the same cuts are used. These differences
 //are thought to be inconsquencial but as such its important to remake the PFPackedCandidates
 //in RECO/AOD if you want to be consistant with miniAOD
 //
-//The track version is more for variables that are stored in the electron rather than 
+//The track version is more for variables that are stored in the electron rather than
 //objects which are recomputed on the fly for AOD/miniAOD
 //
-//Note, the tracks in miniAOD have additional cuts on and are missing algo information so this 
+//Note, the tracks in miniAOD have additional cuts on and are missing algo information so this
 //has to be taken into account when using them
 
-//new for 9X: 
+//new for 9X:
 //  1) its now possible to use generalTracks as input
 //  2) adapted to 9X PF packed candidate improvements
-//  2a) the PF packed candidates now store the pt of the track in addition to the pt of the 
+//  2a) the PF packed candidates now store the pt of the track in addition to the pt of the
 //      candidate. This means there is no need to pass in the electron collection any more
 //      to try and undo the electron e/p combination when the candidate is an electron
 //  2b) we now not only store the GsfTrack of the electron but also the general track of the electron
@@ -35,17 +35,16 @@
 //         packedPFCandidates : all PF candidates (with the track for ele candidates being the gsftrack)
 //         lostTracks : all tracks which were not made into a PFCandidate but passed some preselection
 //         lostTracks::eleTracks : KF electron tracks
-//      as such to avoid double counting the GSF and KF versions of an electron track, we now need to 
+//      as such to avoid double counting the GSF and KF versions of an electron track, we now need to
 //      specify if the electron PF candidates are to be rejected in the sum over that collection or not.
 //      Note in all this, I'm not concerned about the electron in questions track, that will be rejected,
 //      I'm concerned about near by fake electrons which have been recoed by PF
 //      This is handled by the PIDVeto, which obviously is only used/required when using PFCandidates
 
-
 class EleTkIsolFromCands {
 public:
-  enum class PIDVeto{
-    NONE=0,
+  enum class PIDVeto {
+    NONE = 0,
     ELES,
     NONELES,
   };
@@ -66,44 +65,50 @@ private:
     static edm::ParameterSetDescription pSetDescript();
   };
 
-  TrkCuts barrelCuts_,endcapCuts_;
+  TrkCuts barrelCuts_, endcapCuts_;
 
 public:
   explicit EleTkIsolFromCands(const edm::ParameterSet& para);
-  EleTkIsolFromCands(const EleTkIsolFromCands&)=default;
-  ~EleTkIsolFromCands()=default;
-  EleTkIsolFromCands& operator=(const EleTkIsolFromCands&)=default;
+  EleTkIsolFromCands(const EleTkIsolFromCands&) = default;
+  ~EleTkIsolFromCands() = default;
+  EleTkIsolFromCands& operator=(const EleTkIsolFromCands&) = default;
 
   static edm::ParameterSetDescription pSetDescript();
 
-  std::pair<int,double> calIsol(const reco::TrackBase& trk,const pat::PackedCandidateCollection& cands,const PIDVeto=PIDVeto::NONE)const;
-  std::pair<int,double> calIsol(const double eleEta,const double elePhi,const double eleVZ,
-				const pat::PackedCandidateCollection& cands,const PIDVeto=PIDVeto::NONE)const;
+  std::pair<int, double> calIsol(const reco::TrackBase& trk,
+                                 const pat::PackedCandidateCollection& cands,
+                                 const PIDVeto = PIDVeto::NONE) const;
+  std::pair<int, double> calIsol(const double eleEta,
+                                 const double elePhi,
+                                 const double eleVZ,
+                                 const pat::PackedCandidateCollection& cands,
+                                 const PIDVeto = PIDVeto::NONE) const;
 
-  
-  std::pair<int,double> calIsol(const reco::TrackBase& trk,const reco::TrackCollection& tracks)const;
-  std::pair<int,double> calIsol(const double eleEta,const double elePhi,const double eleVZ,
-				const reco::TrackCollection& tracks)const;
-  
+  std::pair<int, double> calIsol(const reco::TrackBase& trk, const reco::TrackCollection& tracks) const;
+  std::pair<int, double> calIsol(const double eleEta,
+                                 const double elePhi,
+                                 const double eleVZ,
+                                 const reco::TrackCollection& tracks) const;
+
   //little helper function for the four calIsol functions for it to directly return the pt
-  template<typename ...Args> 
-  double calIsolPt(Args && ...args)const{return calIsol(std::forward<Args>(args)...).second;}
-  
+  template <typename... Args>
+  double calIsolPt(Args&&... args) const {
+    return calIsol(std::forward<Args>(args)...).second;
+  }
+
   static PIDVeto pidVetoFromStr(const std::string& vetoStr);
-  static bool passPIDVeto(const int pdgId,const EleTkIsolFromCands::PIDVeto pidVeto);
+  static bool passPIDVeto(const int pdgId, const EleTkIsolFromCands::PIDVeto pidVeto);
 
 private:
   static bool passTrkSel(const reco::TrackBase& trk,
-			 const double trkPt,
-			 const TrkCuts& cuts,
-			 const double eleEta,const double elePhi,
-			 const double eleVZ);
+                         const double trkPt,
+                         const TrkCuts& cuts,
+                         const double eleEta,
+                         const double elePhi,
+                         const double eleVZ);
   //no qualities specified, accept all, ORed
-  static bool passQual(const reco::TrackBase& trk,
-		       const std::vector<reco::TrackBase::TrackQuality>& quals);
-  static bool passAlgo(const reco::TrackBase& trk,
-		       const std::vector<reco::TrackBase::TrackAlgorithm>& algosToRej);
+  static bool passQual(const reco::TrackBase& trk, const std::vector<reco::TrackBase::TrackQuality>& quals);
+  static bool passAlgo(const reco::TrackBase& trk, const std::vector<reco::TrackBase::TrackAlgorithm>& algosToRej);
 };
-
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/interface/ElectronTkIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/ElectronTkIsolation.h
@@ -15,115 +15,113 @@
 //Root includes
 #include "TObjArray.h"
 
-//CMSSW includes 
+//CMSSW includes
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaTrackSelector.h"
 
-#include<string>
-
+#include <string>
 
 class ElectronTkIsolation {
- public:
-  
+public:
   //constructors
-  ElectronTkIsolation ( double extRadius,
-			double intRadius,
-			double ptLow,
-			double lip,
-			double drb,
-			const reco::TrackCollection* trackCollection,
-			reco::TrackBase::Point beamPoint) :
-  extRadius_(extRadius),
-  intRadiusBarrel_(intRadius),
-  intRadiusEndcap_(intRadius),
-  stripBarrel_(0.0),
-  stripEndcap_(0.0),
-  ptLow_(ptLow),
-  lip_(lip),
-  drb_(drb),
-  trackCollection_(trackCollection),
-  beamPoint_(beamPoint) {
-        setAlgosToReject();
-        setDzOption("vz");
-
+  ElectronTkIsolation(double extRadius,
+                      double intRadius,
+                      double ptLow,
+                      double lip,
+                      double drb,
+                      const reco::TrackCollection* trackCollection,
+                      reco::TrackBase::Point beamPoint)
+      : extRadius_(extRadius),
+        intRadiusBarrel_(intRadius),
+        intRadiusEndcap_(intRadius),
+        stripBarrel_(0.0),
+        stripEndcap_(0.0),
+        ptLow_(ptLow),
+        lip_(lip),
+        drb_(drb),
+        trackCollection_(trackCollection),
+        beamPoint_(beamPoint) {
+    setAlgosToReject();
+    setDzOption("vz");
   }
 
-  ElectronTkIsolation ( double extRadius,
-                        double intRadiusBarrel,
-			            double intRadiusEndcap,
-			            double stripBarrel,
-			            double stripEndcap,			
-                        double ptLow,
-                        double lip,
-                        double drb,
-                        const reco::TrackCollection* trackCollection,
-                        reco::TrackBase::Point beamPoint) :
-  extRadius_(extRadius),
-  intRadiusBarrel_(intRadiusBarrel),
-  intRadiusEndcap_(intRadiusEndcap),
-  stripBarrel_(stripBarrel),
-  stripEndcap_(stripEndcap),
-  ptLow_(ptLow),
-  lip_(lip),
-  drb_(drb),
-  trackCollection_(trackCollection),
-  beamPoint_(beamPoint) {
-        setAlgosToReject();
-        setDzOption("vz");
-
+  ElectronTkIsolation(double extRadius,
+                      double intRadiusBarrel,
+                      double intRadiusEndcap,
+                      double stripBarrel,
+                      double stripEndcap,
+                      double ptLow,
+                      double lip,
+                      double drb,
+                      const reco::TrackCollection* trackCollection,
+                      reco::TrackBase::Point beamPoint)
+      : extRadius_(extRadius),
+        intRadiusBarrel_(intRadiusBarrel),
+        intRadiusEndcap_(intRadiusEndcap),
+        stripBarrel_(stripBarrel),
+        stripEndcap_(stripEndcap),
+        ptLow_(ptLow),
+        lip_(lip),
+        drb_(drb),
+        trackCollection_(trackCollection),
+        beamPoint_(beamPoint) {
+    setAlgosToReject();
+    setDzOption("vz");
   }
 
-  ElectronTkIsolation ( double extRadius,
-                        double intRadiusBarrel,
-			            double intRadiusEndcap,
-			            double stripBarrel,
-			            double stripEndcap,			
-                        double ptLow,
-                        double lip,
-                        double drb,
-                        const reco::TrackCollection*,
-                        reco::TrackBase::Point beamPoint,
-                        const std::string&) ;
+  ElectronTkIsolation(double extRadius,
+                      double intRadiusBarrel,
+                      double intRadiusEndcap,
+                      double stripBarrel,
+                      double stripEndcap,
+                      double ptLow,
+                      double lip,
+                      double drb,
+                      const reco::TrackCollection*,
+                      reco::TrackBase::Point beamPoint,
+                      const std::string&);
 
-  //destructor 
-  ~ElectronTkIsolation() ;
- 
+  //destructor
+  ~ElectronTkIsolation();
+
   //methods
 
-    void setDzOption(const std::string &s) {
-        if( ! s.compare("dz") )      dzOption_ = egammaisolation::EgammaTrackSelector::dz;
-        else if( ! s.compare("vz") ) dzOption_ = egammaisolation::EgammaTrackSelector::vz;
-        else if( ! s.compare("bs") ) dzOption_ = egammaisolation::EgammaTrackSelector::bs;
-        else if( ! s.compare("vtx") )dzOption_ = egammaisolation::EgammaTrackSelector::vtx;
-        else                         dzOption_ = egammaisolation::EgammaTrackSelector::dz;
-    }
+  void setDzOption(const std::string& s) {
+    if (!s.compare("dz"))
+      dzOption_ = egammaisolation::EgammaTrackSelector::dz;
+    else if (!s.compare("vz"))
+      dzOption_ = egammaisolation::EgammaTrackSelector::vz;
+    else if (!s.compare("bs"))
+      dzOption_ = egammaisolation::EgammaTrackSelector::bs;
+    else if (!s.compare("vtx"))
+      dzOption_ = egammaisolation::EgammaTrackSelector::vtx;
+    else
+      dzOption_ = egammaisolation::EgammaTrackSelector::dz;
+  }
 
-  int getNumberTracks(const reco::GsfElectron*) const ;
-  double getPtTracks (const reco::GsfElectron*) const ;
-  std::pair<int,double>getIso(const reco::GsfElectron*) const;
-  std::pair<int,double>getIso(const reco::Track*) const ;
+  int getNumberTracks(const reco::GsfElectron*) const;
+  double getPtTracks(const reco::GsfElectron*) const;
+  std::pair<int, double> getIso(const reco::GsfElectron*) const;
+  std::pair<int, double> getIso(const reco::Track*) const;
 
- private:
-
-  bool passAlgo(const reco::TrackBase& trk)const;
+private:
+  bool passAlgo(const reco::TrackBase& trk) const;
   void setAlgosToReject();
-  double extRadius_ ;
-  double intRadiusBarrel_ ;
-  double intRadiusEndcap_ ;
-  double stripBarrel_ ;
-  double stripEndcap_ ;
-  double ptLow_ ;
-  double lip_ ;
+  double extRadius_;
+  double intRadiusBarrel_;
+  double intRadiusEndcap_;
+  double stripBarrel_;
+  double stripEndcap_;
+  double ptLow_;
+  double lip_;
   double drb_;
-  std::vector<int> algosToReject_; //vector is sorted
-  const reco::TrackCollection *trackCollection_ ;
+  std::vector<int> algosToReject_;  //vector is sorted
+  const reco::TrackCollection* trackCollection_;
   reco::TrackBase::Point beamPoint_;
 
   int dzOption_;
-
-  
 };
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/interface/HcalPFClusterIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/HcalPFClusterIsolation.h
@@ -13,26 +13,25 @@
 
 #include <vector>
 
-template<typename T1>
+template <typename T1>
 class HcalPFClusterIsolation {
- public:
-
+public:
   typedef std::vector<T1> T1Collection;
   typedef edm::Ref<T1Collection> T1Ref;
 
   HcalPFClusterIsolation(double drMax,
-			 double drVetoBarrel,
-			 double drVetoEndcap,
-			 double etaStripBarrel,
-			 double etaStripEndcap,
-			 double energyBarrel,
-			 double energyEndcap,
-			 bool useEt);
-  
-  ~HcalPFClusterIsolation();
-  double getSum(const T1Ref candRef, const std::vector<edm::Handle<reco::PFClusterCollection>>& clusterHandles);  
+                         double drVetoBarrel,
+                         double drVetoEndcap,
+                         double etaStripBarrel,
+                         double etaStripEndcap,
+                         double energyBarrel,
+                         double energyEndcap,
+                         bool useEt);
 
- private:
+  ~HcalPFClusterIsolation();
+  double getSum(const T1Ref candRef, const std::vector<edm::Handle<reco::PFClusterCollection>>& clusterHandles);
+
+private:
   const double drMax_;
   const double drVetoBarrel_;
   const double drVetoEndcap_;
@@ -41,7 +40,6 @@ class HcalPFClusterIsolation {
   const double energyBarrel_;
   const double energyEndcap_;
   const bool useEt_;
-
 };
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/interface/PFBlockBasedIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/PFBlockBasedIsolation.h
@@ -4,10 +4,8 @@
 // Authors: N. Marinelli Univ. of Notre Dame
 //--------------------------------------------------------------------------------------------------
 
-
 #ifndef PFBlockBasedIsolation_H
 #define PFBlockBasedIsolation_H
-
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -25,49 +23,36 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 
-
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-namespace reco{
+namespace reco {
   class PFBlockElementCluster;
 }
 
-class PFBlockBasedIsolation{
- public:
+class PFBlockBasedIsolation {
+public:
   PFBlockBasedIsolation();
-
 
   ~PFBlockBasedIsolation();
 
-
-
   void setup(const edm::ParameterSet& conf);
-  
 
+public:
+  std::vector<reco::PFCandidateRef> calculate(math::XYZTLorentzVectorD p4,
+                                              const reco::PFCandidateRef pfEGCand,
+                                              const edm::Handle<reco::PFCandidateCollection> pfCandidateHandle);
 
- public:
-
-  
-
-    std::vector<reco::PFCandidateRef> calculate(math::XYZTLorentzVectorD p4,
-		 const reco::PFCandidateRef pfEGCand,
-		 const edm::Handle<reco::PFCandidateCollection> pfCandidateHandle);
-
-
-private:  
+private:
   const reco::PFBlockElementCluster* getHighestEtECALCluster(const reco::PFCandidate& pfCand);
-  bool passesCleaningPhoton(const  reco::PFCandidateRef& pfCand,const reco::PFCandidateRef& pfEGCand);
-  bool passesCleaningNeutralHadron(const  reco::PFCandidateRef& pfCand,const reco::PFCandidateRef& pfEGCand);
-  
-  bool passesCleaningChargedHadron(const reco::PFCandidateRef& pfCand,const reco::PFCandidateRef& pfEGCand);
-  bool elementPassesCleaning(const reco::PFCandidateRef& pfCand,const reco::PFCandidateRef& pfEGCand);
-  
- private:
+  bool passesCleaningPhoton(const reco::PFCandidateRef& pfCand, const reco::PFCandidateRef& pfEGCand);
+  bool passesCleaningNeutralHadron(const reco::PFCandidateRef& pfCand, const reco::PFCandidateRef& pfEGCand);
 
- double coneSize_;
-     
+  bool passesCleaningChargedHadron(const reco::PFCandidateRef& pfCand, const reco::PFCandidateRef& pfEGCand);
+  bool elementPassesCleaning(const reco::PFCandidateRef& pfCand, const reco::PFCandidateRef& pfEGCand);
 
+private:
+  double coneSize_;
 };
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/interface/PhotonTkIsolation.h
+++ b/RecoEgamma/EgammaIsolationAlgos/interface/PhotonTkIsolation.h
@@ -19,123 +19,107 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaTrackSelector.h"
 
-
-
-
 class PhotonTkIsolation {
- public:
-  
+public:
   //constructors
-  PhotonTkIsolation (float extRadius,
-		     float intRadius,
-		     float etLow,
-		     float lip,
-		     float drb,
-		     const reco::TrackCollection* trackCollection,
-		     reco::TrackBase::Point beamPoint) :
-    extRadius2_(extRadius*extRadius),
-    intRadiusBarrel2_(intRadius*intRadius),
-    intRadiusEndcap2_(intRadius*intRadius),
-    stripBarrel_(0.0),
-    stripEndcap_(0.0),
-    etLow_(etLow),
-    lip_(lip),
-    drb_(drb),
-    trackCollection_(trackCollection),
-    beamPoint_(beamPoint) {
-    
+  PhotonTkIsolation(float extRadius,
+                    float intRadius,
+                    float etLow,
+                    float lip,
+                    float drb,
+                    const reco::TrackCollection* trackCollection,
+                    reco::TrackBase::Point beamPoint)
+      : extRadius2_(extRadius * extRadius),
+        intRadiusBarrel2_(intRadius * intRadius),
+        intRadiusEndcap2_(intRadius * intRadius),
+        stripBarrel_(0.0),
+        stripEndcap_(0.0),
+        etLow_(etLow),
+        lip_(lip),
+        drb_(drb),
+        trackCollection_(trackCollection),
+        beamPoint_(beamPoint) {
     setDzOption("vz");
-
-  }
-  
-  PhotonTkIsolation (float extRadius,
-                     float intRadius,
-                     float strip,
-                     float etLow,
-                     float lip,
-                     float drb,
-                     const reco::TrackCollection* trackCollection,
-                     reco::TrackBase::Point beamPoint) :
-    extRadius2_(extRadius*extRadius),
-    intRadiusBarrel2_(intRadius*intRadius),
-    intRadiusEndcap2_(intRadius*intRadius),
-    stripBarrel_(strip),
-    stripEndcap_(strip),
-    etLow_(etLow),
-    lip_(lip),
-    drb_(drb),
-    trackCollection_(trackCollection),
-    beamPoint_(beamPoint) {
-    
-    setDzOption("vz");
-    
   }
 
-  
-  PhotonTkIsolation (float extRadius,
-                     float intRadiusBarrel,
-		     float intRadiusEndcap,
-		     float stripBarrel,
-                     float stripEndcap,		
-                     float etLow,
-                     float lip,
-                     float drb,
-                     const reco::TrackCollection* trackCollection,
-                     reco::TrackBase::Point beamPoint) :
-    extRadius2_(extRadius*extRadius),
-    intRadiusBarrel2_(intRadiusBarrel*intRadiusBarrel),
-    intRadiusEndcap2_(intRadiusEndcap*intRadiusEndcap),
-    stripBarrel_(stripBarrel),
-    stripEndcap_(stripEndcap),
-    etLow_(etLow),
-    lip_(lip),
-    drb_(drb),
-    trackCollection_(trackCollection),
-    beamPoint_(beamPoint) {
-    
+  PhotonTkIsolation(float extRadius,
+                    float intRadius,
+                    float strip,
+                    float etLow,
+                    float lip,
+                    float drb,
+                    const reco::TrackCollection* trackCollection,
+                    reco::TrackBase::Point beamPoint)
+      : extRadius2_(extRadius * extRadius),
+        intRadiusBarrel2_(intRadius * intRadius),
+        intRadiusEndcap2_(intRadius * intRadius),
+        stripBarrel_(strip),
+        stripEndcap_(strip),
+        etLow_(etLow),
+        lip_(lip),
+        drb_(drb),
+        trackCollection_(trackCollection),
+        beamPoint_(beamPoint) {
     setDzOption("vz");
-    
   }
-  
-  
-  
-  PhotonTkIsolation (float extRadius,
-                     float intRadiusBarrel,
-		     float intRadiusEndcap,
-		     float stripBarrel,
-                     float stripEndcap,		
-                     float etLow,
-                     float lip,
-                     float drb,
-                     const reco::TrackCollection*,
-                     reco::TrackBase::Point beamPoint,
-                     const std::string&) ;
-  
-  //destructor 
-  ~PhotonTkIsolation() ;
+
+  PhotonTkIsolation(float extRadius,
+                    float intRadiusBarrel,
+                    float intRadiusEndcap,
+                    float stripBarrel,
+                    float stripEndcap,
+                    float etLow,
+                    float lip,
+                    float drb,
+                    const reco::TrackCollection* trackCollection,
+                    reco::TrackBase::Point beamPoint)
+      : extRadius2_(extRadius * extRadius),
+        intRadiusBarrel2_(intRadiusBarrel * intRadiusBarrel),
+        intRadiusEndcap2_(intRadiusEndcap * intRadiusEndcap),
+        stripBarrel_(stripBarrel),
+        stripEndcap_(stripEndcap),
+        etLow_(etLow),
+        lip_(lip),
+        drb_(drb),
+        trackCollection_(trackCollection),
+        beamPoint_(beamPoint) {
+    setDzOption("vz");
+  }
+
+  PhotonTkIsolation(float extRadius,
+                    float intRadiusBarrel,
+                    float intRadiusEndcap,
+                    float stripBarrel,
+                    float stripEndcap,
+                    float etLow,
+                    float lip,
+                    float drb,
+                    const reco::TrackCollection*,
+                    reco::TrackBase::Point beamPoint,
+                    const std::string&);
+
+  //destructor
+  ~PhotonTkIsolation();
   //methods
 
-  std::pair<int,float>getIso(const reco::Candidate*) const ;
-  
+  std::pair<int, float> getIso(const reco::Candidate*) const;
 
-  void setDzOption(const std::string &s);
+  void setDzOption(const std::string& s);
+
 private:
-  
-  float extRadius2_ ;
-  float intRadiusBarrel2_ ;
-  float intRadiusEndcap2_ ;
+  float extRadius2_;
+  float intRadiusBarrel2_;
+  float intRadiusEndcap2_;
   float stripBarrel_;
   float stripEndcap_;
-  float etLow_ ;
-  float lip_ ;
+  float etLow_;
+  float lip_;
   float drb_;
 
-  const reco::TrackCollection *trackCollection_ ;
+  const reco::TrackCollection* trackCollection_;
   reco::TrackBase::Point beamPoint_;
 
   int dzOption_;
-
-
 };
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaEcalExtractor.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaEcalExtractor.cc
@@ -20,9 +20,11 @@
 using namespace egammaisolation;
 using namespace reco::isodeposit;
 
-EgammaEcalExtractor::~EgammaEcalExtractor(){}
+EgammaEcalExtractor::~EgammaEcalExtractor() {}
 
-reco::IsoDeposit EgammaEcalExtractor::deposit(const edm::Event & ev, const edm::EventSetup & evSetup, const reco::Candidate & candidate) const {
+reco::IsoDeposit EgammaEcalExtractor::deposit(const edm::Event &ev,
+                                              const edm::EventSetup &evSetup,
+                                              const reco::Candidate &candidate) const {
   edm::Handle<reco::SuperClusterCollection> superClusterCollectionH;
   edm::Handle<reco::BasicClusterCollection> basicClusterCollectionH;
   ev.getByToken(superClusterToken_, superClusterCollectionH);
@@ -31,69 +33,70 @@ reco::IsoDeposit EgammaEcalExtractor::deposit(const edm::Event & ev, const edm::
   reco::SuperClusterRef sc = candidate.get<reco::SuperClusterRef>();
   math::XYZPoint position = sc->position();
   // match the photon hybrid supercluster with those with Algo==0 (island)
-  double delta1=1000.;
-  double deltacur=1000.;
-  const reco::SuperCluster *matchedsupercluster=nullptr;
+  double delta1 = 1000.;
+  double deltacur = 1000.;
+  const reco::SuperCluster *matchedsupercluster = nullptr;
   bool MATCHEDSC = false;
 
   Direction candDir(position.eta(), position.phi());
-  reco::IsoDeposit deposit(candDir );
-  deposit.setVeto( reco::IsoDeposit::Veto(candDir, 0) ); // no veto is needed for this deposit
-  deposit.addCandEnergy(sc->energy()*sin(2*atan(exp(-sc->eta()))));
+  reco::IsoDeposit deposit(candDir);
+  deposit.setVeto(reco::IsoDeposit::Veto(candDir, 0));  // no veto is needed for this deposit
+  deposit.addCandEnergy(sc->energy() * sin(2 * atan(exp(-sc->eta()))));
 
-  for(reco::SuperClusterCollection::const_iterator scItr = superClusterCollectionH->begin(); scItr != superClusterCollectionH->end(); ++scItr){
-
+  for (reco::SuperClusterCollection::const_iterator scItr = superClusterCollectionH->begin();
+       scItr != superClusterCollectionH->end();
+       ++scItr) {
     const reco::SuperCluster *supercluster = &(*scItr);
 
-    if(supercluster->seed()->algo() == 0){
+    if (supercluster->seed()->algo() == 0) {
       deltacur = ROOT::Math::VectorUtil::DeltaR(supercluster->position(), position);
       if (deltacur < delta1) {
-        delta1=deltacur;
-	matchedsupercluster = supercluster;
-	MATCHEDSC = true;
+        delta1 = deltacur;
+        matchedsupercluster = supercluster;
+        MATCHEDSC = true;
       }
     }
   }
 
-  const reco::BasicCluster *cluster= nullptr;
+  const reco::BasicCluster *cluster = nullptr;
 
   //loop over basic clusters
-  for(reco::BasicClusterCollection::const_iterator cItr = basicClusterCollectionH->begin(); cItr != basicClusterCollectionH->end(); ++cItr){
-
+  for (reco::BasicClusterCollection::const_iterator cItr = basicClusterCollectionH->begin();
+       cItr != basicClusterCollectionH->end();
+       ++cItr) {
     cluster = &(*cItr);
-//    double ebc_bcchi2 = cluster->chi2();
-    int    ebc_bcalgo = cluster->algo();
-    double ebc_bce    = cluster->energy();
-    double ebc_bceta  = cluster->eta();
-    double ebc_bcet   = ebc_bce*sin(2*atan(exp(ebc_bceta)));
+    //    double ebc_bcchi2 = cluster->chi2();
+    int ebc_bcalgo = cluster->algo();
+    double ebc_bce = cluster->energy();
+    double ebc_bceta = cluster->eta();
+    double ebc_bcet = ebc_bce * sin(2 * atan(exp(ebc_bceta)));
     double newDelta = 0.;
 
     if (ebc_bcet > etMin_ && ebc_bcalgo == 0) {
-//      if (ebc_bcchi2 < 30.) {
+      //      if (ebc_bcchi2 < 30.) {
 
-	if(MATCHEDSC || !scmatch_ ){  //skip selection if user wants to fill all superclusters
-	  bool inSuperCluster = false;
+      if (MATCHEDSC || !scmatch_) {  //skip selection if user wants to fill all superclusters
+        bool inSuperCluster = false;
 
-	  if( scmatch_ ){ // only try the matching if needed
-	    reco::CaloCluster_iterator theEclust = matchedsupercluster->clustersBegin();
-	    // loop over the basic clusters of the matched supercluster
-	    for(;theEclust != matchedsupercluster->clustersEnd(); ++theEclust) {
-	    if ((**theEclust) ==  (*cluster) ) inSuperCluster = true;
-	    }
-	  }
-	  if (!inSuperCluster || !scmatch_ ) {  //skip selection if user wants to fill all superclusters
-	    newDelta=ROOT::Math::VectorUtil::DeltaR(cluster->position(),position);
-	    if(newDelta < conesize_) {
-              deposit.addDeposit( Direction(cluster->eta(), cluster->phi()), ebc_bcet);
-	    }
-	  }
-	}
-//      } // matches ebc_bcchi2
-    } // matches ebc_bcet && ebc_bcalgo
-
+        if (scmatch_) {  // only try the matching if needed
+          reco::CaloCluster_iterator theEclust = matchedsupercluster->clustersBegin();
+          // loop over the basic clusters of the matched supercluster
+          for (; theEclust != matchedsupercluster->clustersEnd(); ++theEclust) {
+            if ((**theEclust) == (*cluster))
+              inSuperCluster = true;
+          }
+        }
+        if (!inSuperCluster || !scmatch_) {  //skip selection if user wants to fill all superclusters
+          newDelta = ROOT::Math::VectorUtil::DeltaR(cluster->position(), position);
+          if (newDelta < conesize_) {
+            deposit.addDeposit(Direction(cluster->eta(), cluster->phi()), ebc_bcet);
+          }
+        }
+      }
+      //      } // matches ebc_bcchi2
+    }  // matches ebc_bcet && ebc_bcalgo
   }
 
   //  std::cout << "Will return ecalIsol = " << ecalIsol << std::endl;
   return deposit;
-
 }

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaEcalExtractor.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaEcalExtractor.h
@@ -14,7 +14,6 @@
 //=============================================================================
 //*****************************************************************************
 
-
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 #include "DataFormats/EgammaReco/interface/BasicClusterFwd.h"
@@ -37,39 +36,44 @@
 
 namespace egammaisolation {
 
-    class EgammaEcalExtractor : public reco::isodeposit::IsoDepositExtractor  {
-        public:
-            EgammaEcalExtractor(const edm::ParameterSet& par, edm::ConsumesCollector && iC) :
-              EgammaEcalExtractor(par, iC) {}
-            EgammaEcalExtractor(const edm::ParameterSet& par, edm::ConsumesCollector & iC) :
-                    etMin_(par.getParameter<double>("etMin")),
-                    conesize_(par.getParameter<double>("extRadius")),
-	            scmatch_(par.getParameter<bool>("superClusterMatch")),
-                    basicClusterToken_(iC.consumes<reco::BasicClusterCollection>(par.getParameter<edm::InputTag>("basicClusters"))),
-                    superClusterToken_(iC.consumes<reco::SuperClusterCollection>(par.getParameter<edm::InputTag>("superClusters"))) { }
+  class EgammaEcalExtractor : public reco::isodeposit::IsoDepositExtractor {
+  public:
+    EgammaEcalExtractor(const edm::ParameterSet& par, edm::ConsumesCollector&& iC) : EgammaEcalExtractor(par, iC) {}
+    EgammaEcalExtractor(const edm::ParameterSet& par, edm::ConsumesCollector& iC)
+        : etMin_(par.getParameter<double>("etMin")),
+          conesize_(par.getParameter<double>("extRadius")),
+          scmatch_(par.getParameter<bool>("superClusterMatch")),
+          basicClusterToken_(
+              iC.consumes<reco::BasicClusterCollection>(par.getParameter<edm::InputTag>("basicClusters"))),
+          superClusterToken_(
+              iC.consumes<reco::SuperClusterCollection>(par.getParameter<edm::InputTag>("superClusters"))) {}
 
+    ~EgammaEcalExtractor() override;
 
-            ~EgammaEcalExtractor() override;
+    void fillVetos(const edm::Event& ev, const edm::EventSetup& evSetup, const reco::TrackCollection& tracks) override {
+    }
+    reco::IsoDeposit deposit(const edm::Event& ev,
+                             const edm::EventSetup& evSetup,
+                             const reco::Track& track) const override {
+      throw cms::Exception("Configuration Error")
+          << "This extractor " << (typeid(this).name()) << " is not made for tracks";
+    }
+    reco::IsoDeposit deposit(const edm::Event& ev,
+                             const edm::EventSetup& evSetup,
+                             const reco::Candidate& c) const override;
 
-            void fillVetos(const edm::Event & ev, const edm::EventSetup & evSetup, const reco::TrackCollection & tracks) override { }
-            reco::IsoDeposit deposit(const edm::Event & ev, const edm::EventSetup & evSetup, const reco::Track & track) const override {
-                throw cms::Exception("Configuration Error") << "This extractor " << (typeid(this).name()) << " is not made for tracks";
-            }
-            reco::IsoDeposit deposit(const edm::Event & ev, const edm::EventSetup & evSetup, const reco::Candidate & c) const override ;
+  private:
+    // ---------- member data --------------------------------
 
-        private:
+    // Parameters of isolation cone geometry.
+    // Photon case
+    double etMin_;
+    double conesize_;
+    bool scmatch_;  // true-> reject basic clusters matched to the superclsuter
+                    // false-> fill all basic clusters
+    edm::EDGetTokenT<reco::BasicClusterCollection> basicClusterToken_;
+    edm::EDGetTokenT<reco::SuperClusterCollection> superClusterToken_;
+  };
 
-            // ---------- member data --------------------------------
-
-            // Parameters of isolation cone geometry.
-            // Photon case
-            double etMin_;
-            double conesize_;
-	    bool scmatch_;  // true-> reject basic clusters matched to the superclsuter
-                            // false-> fill all basic clusters
-            edm::EDGetTokenT<reco::BasicClusterCollection> basicClusterToken_;
-            edm::EDGetTokenT<reco::SuperClusterCollection> superClusterToken_;
-    };
-
-}
+}  // namespace egammaisolation
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaEcalPFClusterIsolationProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaEcalPFClusterIsolationProducer.h
@@ -17,22 +17,21 @@
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
 
-template<typename T1>
+template <typename T1>
 class EgammaEcalPFClusterIsolationProducer : public edm::stream::EDProducer<> {
- public:
-
+public:
   typedef std::vector<T1> T1Collection;
   typedef edm::Ref<T1Collection> T1Ref;
   explicit EgammaEcalPFClusterIsolationProducer(const edm::ParameterSet&);
   ~EgammaEcalPFClusterIsolationProducer() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
- 
-  void produce(edm::Event&, const edm::EventSetup&) override;
- private:
 
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+private:
   const edm::EDGetTokenT<T1Collection> emObjectProducer_;
   const edm::EDGetTokenT<reco::PFClusterCollection> pfClusterProducer_;
-  
+
   const double drMax_;
   const double drVetoBarrel_;
   const double drVetoEndcap_;

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaEcalRecHitIsolationProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaEcalRecHitIsolationProducer.cc
@@ -6,7 +6,6 @@
 //=============================================================================
 //*****************************************************************************
 
-
 #include "RecoEgamma/EgammaIsolationAlgos/plugins/EgammaEcalRecHitIsolationProducer.h"
 
 // Framework
@@ -28,64 +27,55 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h"
 
-EgammaEcalRecHitIsolationProducer::EgammaEcalRecHitIsolationProducer(const edm::ParameterSet& config) : conf_(config)
-{
- // use configuration file to setup input/output collection names
- //inputs 
-  emObjectProducer_               = conf_.getParameter<edm::InputTag>("emObjectProducer");
-  ecalBarrelRecHitProducer_       = conf_.getParameter<edm::InputTag>("ecalBarrelRecHitProducer");
-  ecalBarrelRecHitCollection_     = conf_.getParameter<edm::InputTag>("ecalBarrelRecHitCollection");
-  ecalEndcapRecHitProducer_       = conf_.getParameter<edm::InputTag>("ecalEndcapRecHitProducer");
-  ecalEndcapRecHitCollection_     = conf_.getParameter<edm::InputTag>("ecalEndcapRecHitCollection");
+EgammaEcalRecHitIsolationProducer::EgammaEcalRecHitIsolationProducer(const edm::ParameterSet& config) : conf_(config) {
+  // use configuration file to setup input/output collection names
+  //inputs
+  emObjectProducer_ = conf_.getParameter<edm::InputTag>("emObjectProducer");
+  ecalBarrelRecHitProducer_ = conf_.getParameter<edm::InputTag>("ecalBarrelRecHitProducer");
+  ecalBarrelRecHitCollection_ = conf_.getParameter<edm::InputTag>("ecalBarrelRecHitCollection");
+  ecalEndcapRecHitProducer_ = conf_.getParameter<edm::InputTag>("ecalEndcapRecHitProducer");
+  ecalEndcapRecHitCollection_ = conf_.getParameter<edm::InputTag>("ecalEndcapRecHitCollection");
 
   //vetos
-  egIsoPtMinBarrel_               = conf_.getParameter<double>("etMinBarrel");
-  egIsoEMinBarrel_                = conf_.getParameter<double>("eMinBarrel");
-  egIsoPtMinEndcap_               = conf_.getParameter<double>("etMinEndcap");
-  egIsoEMinEndcap_                = conf_.getParameter<double>("eMinEndcap");
-  egIsoConeSizeInBarrel_          = conf_.getParameter<double>("intRadiusBarrel");
-  egIsoConeSizeInEndcap_          = conf_.getParameter<double>("intRadiusEndcap");
-  egIsoConeSizeOut_               = conf_.getParameter<double>("extRadius");
-  egIsoJurassicWidth_             = conf_.getParameter<double>("jurassicWidth");
-
-
+  egIsoPtMinBarrel_ = conf_.getParameter<double>("etMinBarrel");
+  egIsoEMinBarrel_ = conf_.getParameter<double>("eMinBarrel");
+  egIsoPtMinEndcap_ = conf_.getParameter<double>("etMinEndcap");
+  egIsoEMinEndcap_ = conf_.getParameter<double>("eMinEndcap");
+  egIsoConeSizeInBarrel_ = conf_.getParameter<double>("intRadiusBarrel");
+  egIsoConeSizeInEndcap_ = conf_.getParameter<double>("intRadiusEndcap");
+  egIsoConeSizeOut_ = conf_.getParameter<double>("extRadius");
+  egIsoJurassicWidth_ = conf_.getParameter<double>("jurassicWidth");
 
   // options
-  useIsolEt_      = conf_.getParameter<bool>("useIsolEt");
-  tryBoth_        = conf_.getParameter<bool>("tryBoth");
-  subtract_       = conf_.getParameter<bool>("subtract");
+  useIsolEt_ = conf_.getParameter<bool>("useIsolEt");
+  tryBoth_ = conf_.getParameter<bool>("tryBoth");
+  subtract_ = conf_.getParameter<bool>("subtract");
   useNumCrystals_ = conf_.getParameter<bool>("useNumCrystals");
-  vetoClustered_  = conf_.getParameter<bool>("vetoClustered");
+  vetoClustered_ = conf_.getParameter<bool>("vetoClustered");
 
   //register your products
-  produces < edm::ValueMap<double> >();
+  produces<edm::ValueMap<double>>();
 }
 
-
-EgammaEcalRecHitIsolationProducer::~EgammaEcalRecHitIsolationProducer(){}
-
+EgammaEcalRecHitIsolationProducer::~EgammaEcalRecHitIsolationProducer() {}
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-EgammaEcalRecHitIsolationProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-
-
+void EgammaEcalRecHitIsolationProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Get the  filtered objects
-  edm::Handle< edm::View<reco::Candidate> > emObjectHandle;
-  iEvent.getByLabel(emObjectProducer_,emObjectHandle);
-    
+  edm::Handle<edm::View<reco::Candidate>> emObjectHandle;
+  iEvent.getByLabel(emObjectProducer_, emObjectHandle);
+
   // Next get Ecal hits barrel
-  edm::Handle<EcalRecHitCollection> ecalBarrelRecHitHandle; //EcalRecHitCollection is a typedef to 
-  iEvent.getByLabel(ecalBarrelRecHitProducer_.label(),ecalBarrelRecHitCollection_.label(), ecalBarrelRecHitHandle);
+  edm::Handle<EcalRecHitCollection> ecalBarrelRecHitHandle;  //EcalRecHitCollection is a typedef to
+  iEvent.getByLabel(ecalBarrelRecHitProducer_.label(), ecalBarrelRecHitCollection_.label(), ecalBarrelRecHitHandle);
 
   // Next get Ecal hits endcap
   edm::Handle<EcalRecHitCollection> ecalEndcapRecHitHandle;
-  iEvent.getByLabel(ecalEndcapRecHitProducer_.label(), ecalEndcapRecHitCollection_.label(),ecalEndcapRecHitHandle);
+  iEvent.getByLabel(ecalEndcapRecHitProducer_.label(), ecalEndcapRecHitCollection_.label(), ecalEndcapRecHitHandle);
 
   edm::ESHandle<EcalSeverityLevelAlgo> sevlv;
   iSetup.get<EcalSeverityLevelAlgoRcd>().get(sevlv);
@@ -99,58 +89,80 @@ EgammaEcalRecHitIsolationProducer::produce(edm::Event& iEvent, const edm::EventS
   //reco::CandViewDoubleAssociations* isoMap = new reco::CandViewDoubleAssociations( reco::CandidateBaseRefProd( emObjectHandle ) );
   auto isoMap = std::make_unique<edm::ValueMap<double>>();
   edm::ValueMap<double>::Filler filler(*isoMap);
-  std::vector<double> retV(emObjectHandle->size(),0);
+  std::vector<double> retV(emObjectHandle->size(), 0);
 
-  EgammaRecHitIsolation ecalBarrelIsol(egIsoConeSizeOut_,egIsoConeSizeInBarrel_,egIsoJurassicWidth_,egIsoPtMinBarrel_,egIsoEMinBarrel_,caloGeom,*ecalBarrelRecHitHandle,sevLevel,DetId::Ecal);
+  EgammaRecHitIsolation ecalBarrelIsol(egIsoConeSizeOut_,
+                                       egIsoConeSizeInBarrel_,
+                                       egIsoJurassicWidth_,
+                                       egIsoPtMinBarrel_,
+                                       egIsoEMinBarrel_,
+                                       caloGeom,
+                                       *ecalBarrelRecHitHandle,
+                                       sevLevel,
+                                       DetId::Ecal);
   ecalBarrelIsol.setUseNumCrystals(useNumCrystals_);
   ecalBarrelIsol.setVetoClustered(vetoClustered_);
 
-  EgammaRecHitIsolation ecalEndcapIsol(egIsoConeSizeOut_,egIsoConeSizeInEndcap_,egIsoJurassicWidth_,egIsoPtMinEndcap_,egIsoEMinEndcap_,caloGeom,*ecalEndcapRecHitHandle,sevLevel,DetId::Ecal);
+  EgammaRecHitIsolation ecalEndcapIsol(egIsoConeSizeOut_,
+                                       egIsoConeSizeInEndcap_,
+                                       egIsoJurassicWidth_,
+                                       egIsoPtMinEndcap_,
+                                       egIsoEMinEndcap_,
+                                       caloGeom,
+                                       *ecalEndcapRecHitHandle,
+                                       sevLevel,
+                                       DetId::Ecal);
   ecalEndcapIsol.setUseNumCrystals(useNumCrystals_);
   ecalEndcapIsol.setVetoClustered(vetoClustered_);
-  
-  
-  for( size_t i = 0 ; i < emObjectHandle->size(); ++i) {
-    
+
+  for (size_t i = 0; i < emObjectHandle->size(); ++i) {
     //i need to know if its in the barrel/endcap so I get the supercluster handle to find out the detector eta
     //this might not be the best way, are we guaranteed that eta<1.5 is barrel
     //this can be safely replaced by another method which determines where the emobject is
-    //then we either get the isolation Et or isolation Energy depending on user selection 
-    double isoValue =0.;
-    
+    //then we either get the isolation Et or isolation Energy depending on user selection
+    double isoValue = 0.;
+
     reco::SuperClusterRef superClus = emObjectHandle->at(i).get<reco::SuperClusterRef>();
 
-    if(tryBoth_){ //barrel + endcap
-      if(useIsolEt_) isoValue =  ecalBarrelIsol.getEtSum(&(emObjectHandle->at(i))) + ecalEndcapIsol.getEtSum(&(emObjectHandle->at(i)));
-      else           isoValue =  ecalBarrelIsol.getEnergySum(&(emObjectHandle->at(i))) + ecalEndcapIsol.getEnergySum(&(emObjectHandle->at(i)));
-    }
-    else if( fabs(superClus->eta())<1.479) { //barrel
-      if(useIsolEt_) isoValue =  ecalBarrelIsol.getEtSum(&(emObjectHandle->at(i)));
-      else           isoValue =  ecalBarrelIsol.getEnergySum(&(emObjectHandle->at(i)));
-    }
-    else{ //endcap
-      if(useIsolEt_) isoValue =  ecalEndcapIsol.getEtSum(&(emObjectHandle->at(i)));
-      else           isoValue =  ecalEndcapIsol.getEnergySum(&(emObjectHandle->at(i)));
+    if (tryBoth_) {  //barrel + endcap
+      if (useIsolEt_)
+        isoValue =
+            ecalBarrelIsol.getEtSum(&(emObjectHandle->at(i))) + ecalEndcapIsol.getEtSum(&(emObjectHandle->at(i)));
+      else
+        isoValue = ecalBarrelIsol.getEnergySum(&(emObjectHandle->at(i))) +
+                   ecalEndcapIsol.getEnergySum(&(emObjectHandle->at(i)));
+    } else if (fabs(superClus->eta()) < 1.479) {  //barrel
+      if (useIsolEt_)
+        isoValue = ecalBarrelIsol.getEtSum(&(emObjectHandle->at(i)));
+      else
+        isoValue = ecalBarrelIsol.getEnergySum(&(emObjectHandle->at(i)));
+    } else {  //endcap
+      if (useIsolEt_)
+        isoValue = ecalEndcapIsol.getEtSum(&(emObjectHandle->at(i)));
+      else
+        isoValue = ecalEndcapIsol.getEnergySum(&(emObjectHandle->at(i)));
     }
 
     //we subtract off the electron energy here as well
-    double subtractVal=0;
+    double subtractVal = 0;
 
-    if(useIsolEt_) subtractVal = superClus.get()->rawEnergy()*sin(2*atan(exp(-superClus.get()->eta())));
-    else           subtractVal = superClus.get()->rawEnergy();
-    
-    if(subtract_) isoValue-= subtractVal;
-    
-    retV[i]=isoValue;
+    if (useIsolEt_)
+      subtractVal = superClus.get()->rawEnergy() * sin(2 * atan(exp(-superClus.get()->eta())));
+    else
+      subtractVal = superClus.get()->rawEnergy();
+
+    if (subtract_)
+      isoValue -= subtractVal;
+
+    retV[i] = isoValue;
     //all done, isolation is now in the map
 
-  }//end of loop over em objects
-  
-  filler.insert(emObjectHandle,retV.begin(),retV.end());
+  }  //end of loop over em objects
+
+  filler.insert(emObjectHandle, retV.begin(), retV.end());
   filler.fill();
 
   iEvent.put(std::move(isoMap));
-
 }
 
 //define this as a plug-in

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaEcalRecHitIsolationProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaEcalRecHitIsolationProducer.h
@@ -12,7 +12,6 @@
 // -*- C++ -*-
 //
 
-
 // system include files
 #include <memory>
 
@@ -32,39 +31,38 @@
 //
 
 class EgammaEcalRecHitIsolationProducer : public edm::stream::EDProducer<> {
-   public:
-      explicit EgammaEcalRecHitIsolationProducer(const edm::ParameterSet&);
-      ~EgammaEcalRecHitIsolationProducer() override;
+public:
+  explicit EgammaEcalRecHitIsolationProducer(const edm::ParameterSet&);
+  ~EgammaEcalRecHitIsolationProducer() override;
 
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-      void produce(edm::Event&, const edm::EventSetup&) override;
-   private:
-      // ----------member data ---------------------------
+private:
+  // ----------member data ---------------------------
 
   edm::InputTag emObjectProducer_;
   edm::InputTag ecalBarrelRecHitProducer_;
-  edm::InputTag ecalBarrelRecHitCollection_;  
+  edm::InputTag ecalBarrelRecHitCollection_;
   edm::InputTag ecalEndcapRecHitProducer_;
   edm::InputTag ecalEndcapRecHitCollection_;
- 
-  double egIsoPtMinBarrel_; //minimum Et noise cut
-  double egIsoEMinBarrel_;  //minimum E noise cut
-  double egIsoPtMinEndcap_; //minimum Et noise cut
-  double egIsoEMinEndcap_;  //minimum E noise cut
-  double egIsoConeSizeOut_; //outer cone size
-  double egIsoConeSizeInBarrel_; //inner cone size
-  double egIsoConeSizeInEndcap_; //inner cone size
-  double egIsoJurassicWidth_ ; // exclusion strip width for jurassic veto
 
-  bool useIsolEt_; //switch for isolEt rather than isolE
-  bool tryBoth_ ; // use rechits from barrel + endcap 
-  bool subtract_ ; // subtract SC energy (allows veto cone of zero size)
+  double egIsoPtMinBarrel_;       //minimum Et noise cut
+  double egIsoEMinBarrel_;        //minimum E noise cut
+  double egIsoPtMinEndcap_;       //minimum Et noise cut
+  double egIsoEMinEndcap_;        //minimum E noise cut
+  double egIsoConeSizeOut_;       //outer cone size
+  double egIsoConeSizeInBarrel_;  //inner cone size
+  double egIsoConeSizeInEndcap_;  //inner cone size
+  double egIsoJurassicWidth_;     // exclusion strip width for jurassic veto
 
-  bool useNumCrystals_ ; // veto on number of crystals
-  bool vetoClustered_ ;  // veto all clusterd rechits
+  bool useIsolEt_;  //switch for isolEt rather than isolE
+  bool tryBoth_;    // use rechits from barrel + endcap
+  bool subtract_;   // subtract SC energy (allows veto cone of zero size)
+
+  bool useNumCrystals_;  // veto on number of crystals
+  bool vetoClustered_;   // veto all clusterd rechits
 
   edm::ParameterSet conf_;
-
 };
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaElectronTkIsolationProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaElectronTkIsolationProducer.cc
@@ -6,7 +6,6 @@
 //=============================================================================
 //*****************************************************************************
 
-
 // Framework
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -20,65 +19,68 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/Candidate/interface/CandAssociation.h"
 
-
 #include "RecoEgamma/EgammaIsolationAlgos/plugins/EgammaElectronTkIsolationProducer.h"
 #include "RecoEgamma/EgammaIsolationAlgos/interface/ElectronTkIsolation.h"
 
-EgammaElectronTkIsolationProducer::EgammaElectronTkIsolationProducer(const edm::ParameterSet& config) : conf_(config)
-{
+EgammaElectronTkIsolationProducer::EgammaElectronTkIsolationProducer(const edm::ParameterSet& config) : conf_(config) {
   // use configuration file to setup input/output collection names
-  electronProducer_               = conf_.getParameter<edm::InputTag>("electronProducer");
-  
-  trackProducer_           = conf_.getParameter<edm::InputTag>("trackProducer");
-  beamspotProducer_        = conf_.getParameter<edm::InputTag>("BeamspotProducer");
+  electronProducer_ = conf_.getParameter<edm::InputTag>("electronProducer");
 
-  ptMin_                = conf_.getParameter<double>("ptMin");
-  intRadiusBarrel_      = conf_.getParameter<double>("intRadiusBarrel");
-  intRadiusEndcap_      = conf_.getParameter<double>("intRadiusEndcap");
-  stripBarrel_          = conf_.getParameter<double>("stripBarrel");
-  stripEndcap_          = conf_.getParameter<double>("stripEndcap");
-  extRadius_            = conf_.getParameter<double>("extRadius");
-  maxVtxDist_           = conf_.getParameter<double>("maxVtxDist");
-  drb_                  = conf_.getParameter<double>("maxVtxDistXY");
+  trackProducer_ = conf_.getParameter<edm::InputTag>("trackProducer");
+  beamspotProducer_ = conf_.getParameter<edm::InputTag>("BeamspotProducer");
+
+  ptMin_ = conf_.getParameter<double>("ptMin");
+  intRadiusBarrel_ = conf_.getParameter<double>("intRadiusBarrel");
+  intRadiusEndcap_ = conf_.getParameter<double>("intRadiusEndcap");
+  stripBarrel_ = conf_.getParameter<double>("stripBarrel");
+  stripEndcap_ = conf_.getParameter<double>("stripEndcap");
+  extRadius_ = conf_.getParameter<double>("extRadius");
+  maxVtxDist_ = conf_.getParameter<double>("maxVtxDist");
+  drb_ = conf_.getParameter<double>("maxVtxDistXY");
 
   //register your products
-  produces < edm::ValueMap<double> >();
-
+  produces<edm::ValueMap<double>>();
 }
 
-EgammaElectronTkIsolationProducer::~EgammaElectronTkIsolationProducer(){}
+EgammaElectronTkIsolationProducer::~EgammaElectronTkIsolationProducer() {}
 
-
-								       
-void EgammaElectronTkIsolationProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void EgammaElectronTkIsolationProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Get the  filtered objects
-  edm::Handle< reco::GsfElectronCollection> electronHandle;
-  iEvent.getByLabel(electronProducer_,electronHandle);
-  
+  edm::Handle<reco::GsfElectronCollection> electronHandle;
+  iEvent.getByLabel(electronProducer_, electronHandle);
+
   //get the tracks
   edm::Handle<reco::TrackCollection> tracks;
-  iEvent.getByLabel(trackProducer_,tracks);
+  iEvent.getByLabel(trackProducer_, tracks);
   const reco::TrackCollection* trackCollection = tracks.product();
-  
+
   //prepare product
   auto isoMap = std::make_unique<edm::ValueMap<double>>();
   edm::ValueMap<double>::Filler filler(*isoMap);
-  std::vector<double> retV(electronHandle->size(),0);
- 
+  std::vector<double> retV(electronHandle->size(), 0);
+
   edm::Handle<reco::BeamSpot> beamSpotH;
-  iEvent.getByLabel(beamspotProducer_,beamSpotH);
+  iEvent.getByLabel(beamspotProducer_, beamSpotH);
   reco::TrackBase::Point beamspot = beamSpotH->position();
- 
-  ElectronTkIsolation myTkIsolation (extRadius_,intRadiusBarrel_,intRadiusEndcap_,stripBarrel_,stripEndcap_,ptMin_,maxVtxDist_,drb_,trackCollection,beamspot) ;
-  
-  for(unsigned int i = 0 ; i < electronHandle->size(); ++i ){
+
+  ElectronTkIsolation myTkIsolation(extRadius_,
+                                    intRadiusBarrel_,
+                                    intRadiusEndcap_,
+                                    stripBarrel_,
+                                    stripEndcap_,
+                                    ptMin_,
+                                    maxVtxDist_,
+                                    drb_,
+                                    trackCollection,
+                                    beamspot);
+
+  for (unsigned int i = 0; i < electronHandle->size(); ++i) {
     double isoValue = myTkIsolation.getPtTracks(&(electronHandle->at(i)));
     retV[i] = isoValue;
   }
-  
+
   //fill and insert valuemap
-  filler.insert(electronHandle,retV.begin(),retV.end());
+  filler.insert(electronHandle, retV.begin(), retV.end());
   filler.fill();
   iEvent.put(std::move(isoMap));
 }

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaElectronTkIsolationProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaElectronTkIsolationProducer.h
@@ -18,13 +18,13 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class EgammaElectronTkIsolationProducer : public edm::stream::EDProducer<> {
- public:
+public:
   explicit EgammaElectronTkIsolationProducer(const edm::ParameterSet&);
   ~EgammaElectronTkIsolationProducer() override;
-  
+
   void produce(edm::Event&, const edm::EventSetup&) override;
 
- private:
+private:
   edm::InputTag electronProducer_;
   edm::InputTag trackProducer_;
   edm::InputTag beamspotProducer_;
@@ -37,10 +37,8 @@ class EgammaElectronTkIsolationProducer : public edm::stream::EDProducer<> {
   double extRadius_;
   double maxVtxDist_;
   double drb_;
-  
+
   edm::ParameterSet conf_;
-
 };
-
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaElectronTkNumIsolationProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaElectronTkNumIsolationProducer.cc
@@ -6,7 +6,6 @@
 //=============================================================================
 //*****************************************************************************
 
-
 // Framework
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -20,66 +19,70 @@
 #include "DataFormats/Candidate/interface/CandAssociation.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 
-
 #include "RecoEgamma/EgammaIsolationAlgos/plugins/EgammaElectronTkNumIsolationProducer.h"
 #include "RecoEgamma/EgammaIsolationAlgos/interface/ElectronTkIsolation.h"
 
-EgammaElectronTkNumIsolationProducer::EgammaElectronTkNumIsolationProducer(const edm::ParameterSet& config) :
-  // use configuration file to setup input/output collection names
-  electronProducer_     (config.getParameter<edm::InputTag>("electronProducer")),
-  
-  trackProducer_        (config.getParameter<edm::InputTag>("trackProducer")),
-  beamspotProducer_     (config.getParameter<edm::InputTag>("BeamspotProducer")),
+EgammaElectronTkNumIsolationProducer::EgammaElectronTkNumIsolationProducer(const edm::ParameterSet& config)
+    :  // use configuration file to setup input/output collection names
+      electronProducer_(config.getParameter<edm::InputTag>("electronProducer")),
 
-  ptMin_                (config.getParameter<double>("ptMin")),
-  intRadiusBarrel_      (config.getParameter<double>("intRadiusBarrel")),
-  intRadiusEndcap_      (config.getParameter<double>("intRadiusEndcap")),
-  stripBarrel_          (config.getParameter<double>("stripBarrel")),
-  stripEndcap_          (config.getParameter<double>("stripEndcap")),
-  extRadius_            (config.getParameter<double>("extRadius")),
-  maxVtxDist_           (config.getParameter<double>("maxVtxDist")),
-  drb_                  (config.getParameter<double>("maxVtxDistXY"))
-{
+      trackProducer_(config.getParameter<edm::InputTag>("trackProducer")),
+      beamspotProducer_(config.getParameter<edm::InputTag>("BeamspotProducer")),
 
+      ptMin_(config.getParameter<double>("ptMin")),
+      intRadiusBarrel_(config.getParameter<double>("intRadiusBarrel")),
+      intRadiusEndcap_(config.getParameter<double>("intRadiusEndcap")),
+      stripBarrel_(config.getParameter<double>("stripBarrel")),
+      stripEndcap_(config.getParameter<double>("stripEndcap")),
+      extRadius_(config.getParameter<double>("extRadius")),
+      maxVtxDist_(config.getParameter<double>("maxVtxDist")),
+      drb_(config.getParameter<double>("maxVtxDistXY")) {
   //register your products
-  produces < edm::ValueMap<int> >();
-
+  produces<edm::ValueMap<int>>();
 }
 
-EgammaElectronTkNumIsolationProducer::~EgammaElectronTkNumIsolationProducer(){}
+EgammaElectronTkNumIsolationProducer::~EgammaElectronTkNumIsolationProducer() {}
 
-
-								       
-void EgammaElectronTkNumIsolationProducer::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSetup& iSetup) const
-{
+void EgammaElectronTkNumIsolationProducer::produce(edm::StreamID sid,
+                                                   edm::Event& iEvent,
+                                                   const edm::EventSetup& iSetup) const {
   // Get the  filtered objects
-  edm::Handle< reco::GsfElectronCollection> electronHandle;
-  iEvent.getByLabel(electronProducer_,electronHandle);
-  
+  edm::Handle<reco::GsfElectronCollection> electronHandle;
+  iEvent.getByLabel(electronProducer_, electronHandle);
+
   //get the tracks
   edm::Handle<reco::TrackCollection> tracks;
-  iEvent.getByLabel(trackProducer_,tracks);
+  iEvent.getByLabel(trackProducer_, tracks);
   const reco::TrackCollection* trackCollection = tracks.product();
 
   //prepare product
   auto isoMap = std::make_unique<edm::ValueMap<int>>();
   edm::ValueMap<int>::Filler filler(*isoMap);
-  std::vector<int> retV(electronHandle->size(),0);
+  std::vector<int> retV(electronHandle->size(), 0);
 
-  //get beamspot 
+  //get beamspot
   edm::Handle<reco::BeamSpot> beamSpotH;
-  iEvent.getByLabel(beamspotProducer_,beamSpotH);
+  iEvent.getByLabel(beamspotProducer_, beamSpotH);
   reco::TrackBase::Point beamspot = beamSpotH->position();
-  
-  ElectronTkIsolation myTkIsolation (extRadius_,intRadiusBarrel_,intRadiusEndcap_,stripBarrel_,stripEndcap_,ptMin_,maxVtxDist_,drb_,trackCollection,beamspot) ;
-  
-  for(unsigned int i = 0 ; i < electronHandle->size(); ++i ){
+
+  ElectronTkIsolation myTkIsolation(extRadius_,
+                                    intRadiusBarrel_,
+                                    intRadiusEndcap_,
+                                    stripBarrel_,
+                                    stripEndcap_,
+                                    ptMin_,
+                                    maxVtxDist_,
+                                    drb_,
+                                    trackCollection,
+                                    beamspot);
+
+  for (unsigned int i = 0; i < electronHandle->size(); ++i) {
     int isoValue = myTkIsolation.getNumberTracks(&(electronHandle->at(i)));
     retV[i] = isoValue;
   }
 
   //fill and insert valuemap
-  filler.insert(electronHandle,retV.begin(),retV.end());
+  filler.insert(electronHandle, retV.begin(), retV.end());
   filler.fill();
   iEvent.put(std::move(isoMap));
 }

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaElectronTkNumIsolationProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaElectronTkNumIsolationProducer.h
@@ -17,18 +17,14 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
-
-
 class EgammaElectronTkNumIsolationProducer : public edm::global::EDProducer<> {
-
- public:
+public:
   explicit EgammaElectronTkNumIsolationProducer(const edm::ParameterSet&);
   ~EgammaElectronTkNumIsolationProducer() override;
-  
+
   void produce(edm::StreamID sid, edm::Event&, const edm::EventSetup&) const override;
 
- private:
+private:
   const edm::InputTag electronProducer_;
   const edm::InputTag trackProducer_;
   const edm::InputTag beamspotProducer_;
@@ -41,8 +37,6 @@ class EgammaElectronTkNumIsolationProducer : public edm::global::EDProducer<> {
   const double extRadius_;
   const double maxVtxDist_;
   const double drb_;
-
 };
-
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaHcalExtractor.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaHcalExtractor.h
@@ -31,35 +31,33 @@
 #include "DataFormats/RecoCandidate/interface/IsoDeposit.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 
-
-
-
 namespace egammaisolation {
 
-   class EgammaHcalExtractor  : public reco::isodeposit::IsoDepositExtractor {
-      public:
-         EgammaHcalExtractor ( const edm::ParameterSet& par, edm::ConsumesCollector && iC ) :
-           EgammaHcalExtractor(par, iC) {}
-         EgammaHcalExtractor ( const edm::ParameterSet& par, edm::ConsumesCollector & iC );
+  class EgammaHcalExtractor : public reco::isodeposit::IsoDepositExtractor {
+  public:
+    EgammaHcalExtractor(const edm::ParameterSet& par, edm::ConsumesCollector&& iC) : EgammaHcalExtractor(par, iC) {}
+    EgammaHcalExtractor(const edm::ParameterSet& par, edm::ConsumesCollector& iC);
 
-         ~EgammaHcalExtractor() override ;
+    ~EgammaHcalExtractor() override;
 
-         void fillVetos(const edm::Event & ev, const edm::EventSetup & evSetup,
-                                 const reco::TrackCollection & tracks) override { }
-         reco::IsoDeposit deposit(const edm::Event & ev, const edm::EventSetup & evSetup,
-                                             const reco::Track & track) const override {
-            throw cms::Exception("Configuration Error") <<
-                     "This extractor " << (typeid(this).name()) << " is not made for tracks";
-         }
-         reco::IsoDeposit deposit(const edm::Event & ev, const edm::EventSetup & evSetup,
-                                              const reco::Candidate & c) const override ;
+    void fillVetos(const edm::Event& ev, const edm::EventSetup& evSetup, const reco::TrackCollection& tracks) override {
+    }
+    reco::IsoDeposit deposit(const edm::Event& ev,
+                             const edm::EventSetup& evSetup,
+                             const reco::Track& track) const override {
+      throw cms::Exception("Configuration Error")
+          << "This extractor " << (typeid(this).name()) << " is not made for tracks";
+    }
+    reco::IsoDeposit deposit(const edm::Event& ev,
+                             const edm::EventSetup& evSetup,
+                             const reco::Candidate& c) const override;
 
-      private:
-         double extRadius_ ;
-         double intRadius_ ;
-         double etLow_ ;
+  private:
+    double extRadius_;
+    double intRadius_;
+    double etLow_;
 
-         edm::EDGetTokenT<HBHERecHitCollection> hcalRecHitProducerToken_;
-   };
-}
+    edm::EDGetTokenT<HBHERecHitCollection> hcalRecHitProducerToken_;
+  };
+}  // namespace egammaisolation
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaHcalPFClusterIsolationProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaHcalPFClusterIsolationProducer.cc
@@ -17,43 +17,47 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
-#include <typeinfo> 
+#include <typeinfo>
 
-template<typename T1>
-EgammaHcalPFClusterIsolationProducer<T1>::EgammaHcalPFClusterIsolationProducer(const edm::ParameterSet& config): 
+template <typename T1>
+EgammaHcalPFClusterIsolationProducer<T1>::EgammaHcalPFClusterIsolationProducer(const edm::ParameterSet& config)
+    :
 
-  emObjectProducer_       (consumes<T1Collection>(config.getParameter<edm::InputTag>("candidateProducer"))),
-  pfClusterProducerHCAL_  (consumes<reco::PFClusterCollection>(config.getParameter<edm::InputTag>("pfClusterProducerHCAL"))),
-  pfClusterProducerHFEM_  (consumes<reco::PFClusterCollection>(config.getParameter<edm::InputTag>("pfClusterProducerHFEM"))),
-  pfClusterProducerHFHAD_ (consumes<reco::PFClusterCollection>(config.getParameter<edm::InputTag>("pfClusterProducerHFHAD"))),
-  useHF_                  (config.getParameter<bool>("useHF")),
-  drMax_                  (config.getParameter<double>("drMax")),
-  drVetoBarrel_           (config.getParameter<double>("drVetoBarrel")),
-  drVetoEndcap_           (config.getParameter<double>("drVetoEndcap")),
-  etaStripBarrel_         (config.getParameter<double>("etaStripBarrel")),
-  etaStripEndcap_         (config.getParameter<double>("etaStripEndcap")),
-  energyBarrel_           (config.getParameter<double>("energyBarrel")),
-  energyEndcap_           (config.getParameter<double>("energyEndcap")),
-  useEt_                  (config.getParameter<bool>("useEt")) {
-
-  produces <edm::ValueMap<float>>();
+      emObjectProducer_(consumes<T1Collection>(config.getParameter<edm::InputTag>("candidateProducer"))),
+      pfClusterProducerHCAL_(
+          consumes<reco::PFClusterCollection>(config.getParameter<edm::InputTag>("pfClusterProducerHCAL"))),
+      pfClusterProducerHFEM_(
+          consumes<reco::PFClusterCollection>(config.getParameter<edm::InputTag>("pfClusterProducerHFEM"))),
+      pfClusterProducerHFHAD_(
+          consumes<reco::PFClusterCollection>(config.getParameter<edm::InputTag>("pfClusterProducerHFHAD"))),
+      useHF_(config.getParameter<bool>("useHF")),
+      drMax_(config.getParameter<double>("drMax")),
+      drVetoBarrel_(config.getParameter<double>("drVetoBarrel")),
+      drVetoEndcap_(config.getParameter<double>("drVetoEndcap")),
+      etaStripBarrel_(config.getParameter<double>("etaStripBarrel")),
+      etaStripEndcap_(config.getParameter<double>("etaStripEndcap")),
+      energyBarrel_(config.getParameter<double>("energyBarrel")),
+      energyEndcap_(config.getParameter<double>("energyEndcap")),
+      useEt_(config.getParameter<bool>("useEt")) {
+  produces<edm::ValueMap<float>>();
 }
 
-template<typename T1>
-EgammaHcalPFClusterIsolationProducer<T1>::~EgammaHcalPFClusterIsolationProducer()
-{}
+template <typename T1>
+EgammaHcalPFClusterIsolationProducer<T1>::~EgammaHcalPFClusterIsolationProducer() {}
 
-template<typename T1>
+template <typename T1>
 void EgammaHcalPFClusterIsolationProducer<T1>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("candidateProducer", edm::InputTag("gedGsfElectrons"));
-  desc.add<edm::InputTag>("pfClusterProducerHCAL", edm::InputTag("particleFlowClusterHCAL")); 
-  desc.ifValue(edm::ParameterDescription<bool>("useHF", false, true),
-               true >> (edm::ParameterDescription<edm::InputTag>("pfClusterProducerHFEM", edm::InputTag("hltParticleFlowClusterHFEM"), true) and
-                        edm::ParameterDescription<edm::InputTag>("pfClusterProducerHFHAD", edm::InputTag("hltParticleFlowClusterHFHAD"), true)) or
-               false >> (edm::ParameterDescription<edm::InputTag>("pfClusterProducerHFEM", edm::InputTag(""), true) and
-                         edm::ParameterDescription<edm::InputTag>("pfClusterProducerHFHAD", edm::InputTag(""), true)));
+  desc.add<edm::InputTag>("pfClusterProducerHCAL", edm::InputTag("particleFlowClusterHCAL"));
+  desc.ifValue(
+      edm::ParameterDescription<bool>("useHF", false, true),
+      true >> (edm::ParameterDescription<edm::InputTag>(
+                   "pfClusterProducerHFEM", edm::InputTag("hltParticleFlowClusterHFEM"), true) and
+               edm::ParameterDescription<edm::InputTag>(
+                   "pfClusterProducerHFHAD", edm::InputTag("hltParticleFlowClusterHFHAD"), true)) or
+          false >> (edm::ParameterDescription<edm::InputTag>("pfClusterProducerHFEM", edm::InputTag(""), true) and
+                    edm::ParameterDescription<edm::InputTag>("pfClusterProducerHFHAD", edm::InputTag(""), true)));
   desc.add<double>("drMax", 0.3);
   desc.add<double>("drVetoBarrel", 0.0);
   desc.add<double>("drVetoEndcap", 0.0);
@@ -65,15 +69,14 @@ void EgammaHcalPFClusterIsolationProducer<T1>::fillDescriptions(edm::Configurati
   descriptions.add(defaultModuleLabel<EgammaHcalPFClusterIsolationProducer<T1>>(), desc);
 }
 
-template<typename T1>
+template <typename T1>
 void EgammaHcalPFClusterIsolationProducer<T1>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-
   edm::Handle<T1Collection> emObjectHandle;
   iEvent.getByToken(emObjectProducer_, emObjectHandle);
 
   auto isoMap = std::make_unique<edm::ValueMap<float>>();
   edm::ValueMap<float>::Filler filler(*isoMap);
-  std::vector<float> retV(emObjectHandle->size(),0);
+  std::vector<float> retV(emObjectHandle->size(), 0);
 
   std::vector<edm::Handle<reco::PFClusterCollection>> clusterHandles;
   edm::Handle<reco::PFClusterCollection> clusterHandle;
@@ -89,14 +92,15 @@ void EgammaHcalPFClusterIsolationProducer<T1>::produce(edm::Event& iEvent, const
     clusterHandles.push_back(clusterHandle);
   }
 
-  HcalPFClusterIsolation<T1> isoAlgo(drMax_, drVetoBarrel_, drVetoEndcap_, etaStripBarrel_, etaStripEndcap_, energyBarrel_, energyEndcap_, useEt_);
-  
+  HcalPFClusterIsolation<T1> isoAlgo(
+      drMax_, drVetoBarrel_, drVetoEndcap_, etaStripBarrel_, etaStripEndcap_, energyBarrel_, energyEndcap_, useEt_);
+
   for (unsigned int iReco = 0; iReco < emObjectHandle->size(); iReco++) {
     T1Ref candRef(emObjectHandle, iReco);
     retV[iReco] = isoAlgo.getSum(candRef, clusterHandles);
   }
-  
-  filler.insert(emObjectHandle,retV.begin(),retV.end());
+
+  filler.insert(emObjectHandle, retV.begin(), retV.end());
   filler.fill();
 
   iEvent.put(std::move(isoMap));

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaHcalPFClusterIsolationProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaHcalPFClusterIsolationProducer.h
@@ -17,19 +17,18 @@
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
 
-template<typename T1>
+template <typename T1>
 class EgammaHcalPFClusterIsolationProducer : public edm::stream::EDProducer<> {
- public:
-
+public:
   typedef std::vector<T1> T1Collection;
   typedef edm::Ref<T1Collection> T1Ref;
   explicit EgammaHcalPFClusterIsolationProducer(const edm::ParameterSet&);
   ~EgammaHcalPFClusterIsolationProducer() override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
- 
-  void produce(edm::Event&, const edm::EventSetup&) override;
- private:
 
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+private:
   const edm::EDGetTokenT<T1Collection> emObjectProducer_;
   const edm::EDGetTokenT<reco::PFClusterCollection> pfClusterProducerHCAL_;
   const edm::EDGetTokenT<reco::PFClusterCollection> pfClusterProducerHFEM_;

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaIsoESDetIdCollectionProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaIsoESDetIdCollectionProducer.cc
@@ -6,137 +6,115 @@
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/DetId/interface/DetIdCollection.h"
 
+EgammaIsoESDetIdCollectionProducer::EgammaIsoESDetIdCollectionProducer(const edm::ParameterSet& iConfig) {
+  eeClusToESMapToken_ =
+      consumes<reco::PFCluster::EEtoPSAssociation>(iConfig.getParameter<edm::InputTag>("eeClusToESMapLabel"));
 
-EgammaIsoESDetIdCollectionProducer::EgammaIsoESDetIdCollectionProducer(const edm::ParameterSet& iConfig) 
-{
-
-  eeClusToESMapToken_ = 
-    consumes<reco::PFCluster::EEtoPSAssociation>(iConfig.getParameter< edm::InputTag > ("eeClusToESMapLabel"));
-  
   ecalPFClustersToken_ =
-    consumes<reco::PFClusterCollection>(iConfig.getParameter<edm::InputTag>("ecalPFClustersLabel"));
-  elesToken_ = 
-	  consumes<reco::GsfElectronCollection>(iConfig.getParameter< edm::InputTag >("elesLabel"));
+      consumes<reco::PFClusterCollection>(iConfig.getParameter<edm::InputTag>("ecalPFClustersLabel"));
+  elesToken_ = consumes<reco::GsfElectronCollection>(iConfig.getParameter<edm::InputTag>("elesLabel"));
 
-  phosToken_ = 
-  	  consumes<reco::PhotonCollection>(iConfig.getParameter< edm::InputTag >("phosLabel"));
+  phosToken_ = consumes<reco::PhotonCollection>(iConfig.getParameter<edm::InputTag>("phosLabel"));
 
-  superClustersToken_ = 
-          consumes<reco::SuperClusterCollection>(iConfig.getParameter< edm::InputTag >("superClustersLabel"));
+  superClustersToken_ =
+      consumes<reco::SuperClusterCollection>(iConfig.getParameter<edm::InputTag>("superClustersLabel"));
 
   minSCEt_ = iConfig.getParameter<double>("minSCEt");
   minEleEt_ = iConfig.getParameter<double>("minEleEt");
   minPhoEt_ = iConfig.getParameter<double>("minPhoEt");
-  
 
   interestingDetIdCollection_ = iConfig.getParameter<std::string>("interestingDetIdCollection");
-  
+
   maxDR_ = iConfig.getParameter<double>("maxDR");
 
-   //register your products
-  produces< DetIdCollection > (interestingDetIdCollection_) ;
-
-
+  //register your products
+  produces<DetIdCollection>(interestingDetIdCollection_);
 }
 
-
-void EgammaIsoESDetIdCollectionProducer::beginRun (edm::Run const& run, const edm::EventSetup & iSetup)  
-{
-  
-}
+void EgammaIsoESDetIdCollectionProducer::beginRun(edm::Run const& run, const edm::EventSetup& iSetup) {}
 
 // ------------ method called to produce the data  ------------
-void
-EgammaIsoESDetIdCollectionProducer::produce (edm::Event& iEvent, 
-                                const edm::EventSetup& iSetup)
-{
-
-   // take BasicClusters
+void EgammaIsoESDetIdCollectionProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // take BasicClusters
   edm::Handle<reco::SuperClusterCollection> superClusters;
   iEvent.getByToken(superClustersToken_, superClusters);
-  
+
   edm::Handle<reco::GsfElectronCollection> eles;
-  iEvent.getByToken(elesToken_,eles);
-  
+  iEvent.getByToken(elesToken_, eles);
+
   edm::Handle<reco::PhotonCollection> phos;
-  iEvent.getByToken(phosToken_,phos);
+  iEvent.getByToken(phosToken_, phos);
 
   edm::Handle<reco::PFCluster::EEtoPSAssociation> eeClusToESMap;
-  iEvent.getByToken(eeClusToESMapToken_,eeClusToESMap);
+  iEvent.getByToken(eeClusToESMapToken_, eeClusToESMap);
 
   edm::Handle<reco::PFClusterCollection> ecalPFClusters;
-  iEvent.getByToken(ecalPFClustersToken_,ecalPFClusters);
+  iEvent.getByToken(ecalPFClustersToken_, ecalPFClusters);
 
   //Create empty output collections
   std::vector<DetId> indexToStore;
   indexToStore.reserve(100);
 
-  if(eles.isValid() && eeClusToESMap.isValid() && ecalPFClusters.isValid()){
-    for(auto& ele : *eles){
-   
-      float scEt = ele.superCluster()->energy()*std::sin(ele.superCluster()->position().theta());
-      if(scEt > minEleEt_ || ele.et()> minEleEt_) addDetIds(*ele.superCluster(),*ecalPFClusters,*eeClusToESMap,indexToStore);
+  if (eles.isValid() && eeClusToESMap.isValid() && ecalPFClusters.isValid()) {
+    for (auto& ele : *eles) {
+      float scEt = ele.superCluster()->energy() * std::sin(ele.superCluster()->position().theta());
+      if (scEt > minEleEt_ || ele.et() > minEleEt_)
+        addDetIds(*ele.superCluster(), *ecalPFClusters, *eeClusToESMap, indexToStore);
     }
   }
-  if(phos.isValid() && eeClusToESMap.isValid() && ecalPFClusters.isValid()){
-    for(auto& pho : *phos){
-      float scEt = pho.superCluster()->energy()*std::sin(pho.superCluster()->position().theta());
-      if(scEt > minPhoEt_ || pho.et()> minPhoEt_) addDetIds(*pho.superCluster(),*ecalPFClusters,*eeClusToESMap,indexToStore);
+  if (phos.isValid() && eeClusToESMap.isValid() && ecalPFClusters.isValid()) {
+    for (auto& pho : *phos) {
+      float scEt = pho.superCluster()->energy() * std::sin(pho.superCluster()->position().theta());
+      if (scEt > minPhoEt_ || pho.et() > minPhoEt_)
+        addDetIds(*pho.superCluster(), *ecalPFClusters, *eeClusToESMap, indexToStore);
     }
   }
-  if(superClusters.isValid() && eeClusToESMap.isValid() && ecalPFClusters.isValid()){
-    for(auto& sc : *superClusters){
-      float scEt = sc.energy()*std::sin(sc.position().theta());
-      if(scEt > minSCEt_) addDetIds(sc,*ecalPFClusters,*eeClusToESMap,indexToStore);
+  if (superClusters.isValid() && eeClusToESMap.isValid() && ecalPFClusters.isValid()) {
+    for (auto& sc : *superClusters) {
+      float scEt = sc.energy() * std::sin(sc.position().theta());
+      if (scEt > minSCEt_)
+        addDetIds(sc, *ecalPFClusters, *eeClusToESMap, indexToStore);
     }
   }
-  
-  //unify the vector
-  std::sort(indexToStore.begin(),indexToStore.end());
-  std::unique(indexToStore.begin(),indexToStore.end());
-  
-  auto detIdCollection = std::make_unique<DetIdCollection>(indexToStore);
-   
-  iEvent.put(std::move(detIdCollection), interestingDetIdCollection_ );
 
+  //unify the vector
+  std::sort(indexToStore.begin(), indexToStore.end());
+  std::unique(indexToStore.begin(), indexToStore.end());
+
+  auto detIdCollection = std::make_unique<DetIdCollection>(indexToStore);
+
+  iEvent.put(std::move(detIdCollection), interestingDetIdCollection_);
 }
 
-
-
-
 //find all clusters within dR2<maxDR2_ of supercluster and then save det id's of hits of all es clusters matched to said ecal clusters
-void
-EgammaIsoESDetIdCollectionProducer::addDetIds(const reco::SuperCluster& superClus,reco::PFClusterCollection clusters,const reco::PFCluster::EEtoPSAssociation& eeClusToESMap,std::vector<DetId>& detIdsToStore)
-{
-  
+void EgammaIsoESDetIdCollectionProducer::addDetIds(const reco::SuperCluster& superClus,
+                                                   reco::PFClusterCollection clusters,
+                                                   const reco::PFCluster::EEtoPSAssociation& eeClusToESMap,
+                                                   std::vector<DetId>& detIdsToStore) {
   const float scEta = superClus.eta();
   //  if(std::abs(scEta)+maxDR_<1.5) return; //not possible to have a endcap cluster, let alone one with preshower (eta>1.65) so exit without checking further
   const float scPhi = superClus.phi();
 
-  const float maxDR2=maxDR_*maxDR_;
+  const float maxDR2 = maxDR_ * maxDR_;
 
-  for (size_t clusNr=0;clusNr<clusters.size();clusNr++){
+  for (size_t clusNr = 0; clusNr < clusters.size(); clusNr++) {
     const reco::PFCluster& clus = clusters[clusNr];
-    if(clus.layer()==PFLayer::ECAL_ENDCAP &&
-       reco::deltaR2(scEta,scPhi,clus.eta(),clus.phi())<maxDR2){
-    
-       auto keyVal = std::make_pair(clusNr,edm::Ptr<reco::PFCluster>());
-       const auto esClusters = std::equal_range(eeClusToESMap.begin(),eeClusToESMap.end(),keyVal,
-						[](const reco::PFCluster::EEtoPSAssociation::value_type& rhs, //roll on c++14, auto & lambda 4 evar!
-						   const reco::PFCluster::EEtoPSAssociation::value_type& lhs)->
-						bool{return rhs.first<lhs.first;}
-						);
-       //   std::cout <<"cluster "<<clus.eta()<<"  had "<<std::distance(esClusters.first,esClusters.second)<<" es clusters"<<std::endl;
-       for(auto esIt = esClusters.first;esIt!=esClusters.second;++esIt){
-	 //	 std::cout <<"es clus "<<esIt->second->hitsAndFractions().size()<<std::endl;
-	 for(const auto& hitAndFrac : esIt->second->hitsAndFractions()){
-	   detIdsToStore.push_back(hitAndFrac.first);
-	 }
-       }
+    if (clus.layer() == PFLayer::ECAL_ENDCAP && reco::deltaR2(scEta, scPhi, clus.eta(), clus.phi()) < maxDR2) {
+      auto keyVal = std::make_pair(clusNr, edm::Ptr<reco::PFCluster>());
+      const auto esClusters = std::equal_range(
+          eeClusToESMap.begin(),
+          eeClusToESMap.end(),
+          keyVal,
+          [](const reco::PFCluster::EEtoPSAssociation::value_type& rhs,  //roll on c++14, auto & lambda 4 evar!
+             const reco::PFCluster::EEtoPSAssociation::value_type& lhs) -> bool { return rhs.first < lhs.first; });
+      //   std::cout <<"cluster "<<clus.eta()<<"  had "<<std::distance(esClusters.first,esClusters.second)<<" es clusters"<<std::endl;
+      for (auto esIt = esClusters.first; esIt != esClusters.second; ++esIt) {
+        //	 std::cout <<"es clus "<<esIt->second->hitsAndFractions().size()<<std::endl;
+        for (const auto& hitAndFrac : esIt->second->hitsAndFractions()) {
+          detIdsToStore.push_back(hitAndFrac.first);
+        }
+      }
 
-    }//end of endcap & dR check
-  }//end of cluster loop
- 
-  
-
+    }  //end of endcap & dR check
+  }    //end of cluster loop
 }

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaIsoESDetIdCollectionProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaIsoESDetIdCollectionProducer.h
@@ -1,12 +1,11 @@
 #ifndef RECOEGAMMA_EGAMMAISOLATIONALGOS_EGAMMAISOESDETIDCOLLECTIONPRODUCER_H
 #define RECOEGAMMA_EGAMMAISOLATIONALGOS_EGAMMAISOESDETIDCOLLECTIONPRODUCER_H
 
-
 // -*- C++ -*-
 //
 // Package:    EgammaIsoESDetIdCollectionProducer
 // Class:      EgammaIsoESDetIdCollectionProducer
-// 
+//
 /**\class EgammaIsoESDetIdCollectionProducer 
 
 author: Sam Harper (inspired by InterestingDetIdProducer)
@@ -15,8 +14,6 @@ Make a collection of detids to be kept in a AOD rechit collection
 These are all the ES DetIds of ES PFClusters associated to all PF clusters within dR of ele/pho/sc
 The aim is to save enough preshower info in the AOD to remake the PF clusters near an ele/pho/sc
 */
-
-
 
 // system include files
 #include <memory>
@@ -43,28 +40,30 @@ class EgammaIsoESDetIdCollectionProducer : public edm::stream::EDProducer<> {
 public:
   //! ctor
   explicit EgammaIsoESDetIdCollectionProducer(const edm::ParameterSet&);
-  void beginRun (edm::Run const&, const edm::EventSetup&) final;
+  void beginRun(edm::Run const&, const edm::EventSetup&) final;
   //! producer
-  void produce(edm::Event &, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
-  void addDetIds(const reco::SuperCluster& superClus,reco::PFClusterCollection clusters,const reco::PFCluster::EEtoPSAssociation& eeClusToESMap,std::vector<DetId>& detIdsToStore);
+  void addDetIds(const reco::SuperCluster& superClus,
+                 reco::PFClusterCollection clusters,
+                 const reco::PFCluster::EEtoPSAssociation& eeClusToESMap,
+                 std::vector<DetId>& detIdsToStore);
 
   // ----------member data ---------------------------
-  edm::EDGetTokenT<reco::PFCluster::EEtoPSAssociation>         eeClusToESMapToken_;
+  edm::EDGetTokenT<reco::PFCluster::EEtoPSAssociation> eeClusToESMapToken_;
   edm::EDGetTokenT<reco::PFClusterCollection> ecalPFClustersToken_;
   edm::EDGetTokenT<reco::SuperClusterCollection> superClustersToken_;
   edm::EDGetTokenT<reco::GsfElectronCollection> elesToken_;
   edm::EDGetTokenT<reco::PhotonCollection> phosToken_;
 
   std::string interestingDetIdCollection_;
- 
+
   float minSCEt_;
   float minEleEt_;
   float minPhoEt_;
 
   float maxDR_;
-    
 };
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaIsoHcalDetIdCollectionProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaIsoHcalDetIdCollectionProducer.cc
@@ -6,104 +6,91 @@
 #include "DataFormats/DetId/interface/DetIdCollection.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 
-EgammaIsoHcalDetIdCollectionProducer::EgammaIsoHcalDetIdCollectionProducer(const edm::ParameterSet& iConfig):
-  hcalHitSelector_(iConfig.getParameter<edm::ParameterSet>("hitSelection"))
-{
+EgammaIsoHcalDetIdCollectionProducer::EgammaIsoHcalDetIdCollectionProducer(const edm::ParameterSet& iConfig)
+    : hcalHitSelector_(iConfig.getParameter<edm::ParameterSet>("hitSelection")) {
+  recHitsToken_ = consumes<HBHERecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitsLabel"));
+  elesToken_ = consumes<reco::GsfElectronCollection>(iConfig.getParameter<edm::InputTag>("elesLabel"));
 
-  recHitsToken_ = 
-	  consumes<HBHERecHitCollection>(iConfig.getParameter< edm::InputTag > ("recHitsLabel"));
-  elesToken_ = 
-	  consumes<reco::GsfElectronCollection>(iConfig.getParameter< edm::InputTag >("elesLabel"));
+  phosToken_ = consumes<reco::PhotonCollection>(iConfig.getParameter<edm::InputTag>("phosLabel"));
 
-  phosToken_ = 
-  	  consumes<reco::PhotonCollection>(iConfig.getParameter< edm::InputTag >("phosLabel"));
-
-  superClustersToken_ = 
-          consumes<reco::SuperClusterCollection>(iConfig.getParameter< edm::InputTag >("superClustersLabel"));
+  superClustersToken_ =
+      consumes<reco::SuperClusterCollection>(iConfig.getParameter<edm::InputTag>("superClustersLabel"));
 
   minSCEt_ = iConfig.getParameter<double>("minSCEt");
   minEleEt_ = iConfig.getParameter<double>("minEleEt");
   minPhoEt_ = iConfig.getParameter<double>("minPhoEt");
-  
 
   interestingDetIdCollection_ = iConfig.getParameter<std::string>("interestingDetIdCollection");
-  
-   //register your products
-  produces< DetIdCollection > (interestingDetIdCollection_) ;
+
+  //register your products
+  produces<DetIdCollection>(interestingDetIdCollection_);
 }
 
-void EgammaIsoHcalDetIdCollectionProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
-{
+void EgammaIsoHcalDetIdCollectionProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("recHitsLabel",edm::InputTag("hbhereco"));
-  desc.add<edm::InputTag>("elesLabel",edm::InputTag("gedGsfElectrons"));
-  desc.add<edm::InputTag>("phosLabel",edm::InputTag("gedPhotons"));
-  desc.add<edm::InputTag>("superClustersLabel",edm::InputTag("particleFlowEGamma"));
-  desc.add<double>("minSCEt",20);
-  desc.add<double>("minEleEt",20);
-  desc.add<double>("minPhoEt",20);
-  desc.add<std::string>("interestingDetIdCollection","");
-  desc.add<edm::ParameterSetDescription>("hitSelection",EGHcalRecHitSelector::makePSetDescription());
-  descriptions.add(("interestingGedEgammaIsoHCALDetId"), desc); 
+  desc.add<edm::InputTag>("recHitsLabel", edm::InputTag("hbhereco"));
+  desc.add<edm::InputTag>("elesLabel", edm::InputTag("gedGsfElectrons"));
+  desc.add<edm::InputTag>("phosLabel", edm::InputTag("gedPhotons"));
+  desc.add<edm::InputTag>("superClustersLabel", edm::InputTag("particleFlowEGamma"));
+  desc.add<double>("minSCEt", 20);
+  desc.add<double>("minEleEt", 20);
+  desc.add<double>("minPhoEt", 20);
+  desc.add<std::string>("interestingDetIdCollection", "");
+  desc.add<edm::ParameterSetDescription>("hitSelection", EGHcalRecHitSelector::makePSetDescription());
+  descriptions.add(("interestingGedEgammaIsoHCALDetId"), desc);
 }
 
-
-void EgammaIsoHcalDetIdCollectionProducer::beginRun (edm::Run const& run, const edm::EventSetup & iSetup)  
-{
+void EgammaIsoHcalDetIdCollectionProducer::beginRun(edm::Run const& run, const edm::EventSetup& iSetup) {
   hcalHitSelector_.setup(iSetup);
 }
 
 // ------------ method called to produce the data  ------------
-void
-EgammaIsoHcalDetIdCollectionProducer::produce (edm::Event& iEvent, 
-                                const edm::EventSetup& iSetup)
-{
+void EgammaIsoHcalDetIdCollectionProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<reco::SuperClusterCollection> superClusters;
   iEvent.getByToken(superClustersToken_, superClusters);
-  
+
   edm::Handle<reco::GsfElectronCollection> eles;
-  iEvent.getByToken(elesToken_,eles);
-  
+  iEvent.getByToken(elesToken_, eles);
+
   edm::Handle<reco::PhotonCollection> phos;
-  iEvent.getByToken(phosToken_,phos);
+  iEvent.getByToken(phosToken_, phos);
 
   edm::Handle<HBHERecHitCollection> recHits;
-  iEvent.getByToken(recHitsToken_,recHits);
+  iEvent.getByToken(recHitsToken_, recHits);
 
   std::vector<DetId> indexToStore;
   indexToStore.reserve(100);
 
-  if(eles.isValid() && recHits.isValid()){
-    for(auto& ele : *eles){
-      float scEt = ele.superCluster()->energy()*std::sin(ele.superCluster()->position().theta());
-      if(scEt > minEleEt_ || ele.et()> minEleEt_){
-	hcalHitSelector_.addDetIds(*ele.superCluster(),*recHits,indexToStore);
+  if (eles.isValid() && recHits.isValid()) {
+    for (auto& ele : *eles) {
+      float scEt = ele.superCluster()->energy() * std::sin(ele.superCluster()->position().theta());
+      if (scEt > minEleEt_ || ele.et() > minEleEt_) {
+        hcalHitSelector_.addDetIds(*ele.superCluster(), *recHits, indexToStore);
       }
     }
   }
-  if(phos.isValid() && recHits.isValid()){
-    for(auto& pho : *phos){
-      float scEt = pho.superCluster()->energy()*std::sin(pho.superCluster()->position().theta());
-      if(scEt > minPhoEt_ || pho.et()> minPhoEt_){
-	hcalHitSelector_.addDetIds(*pho.superCluster(),*recHits,indexToStore);
+  if (phos.isValid() && recHits.isValid()) {
+    for (auto& pho : *phos) {
+      float scEt = pho.superCluster()->energy() * std::sin(pho.superCluster()->position().theta());
+      if (scEt > minPhoEt_ || pho.et() > minPhoEt_) {
+        hcalHitSelector_.addDetIds(*pho.superCluster(), *recHits, indexToStore);
       }
     }
   }
-  if(superClusters.isValid() && recHits.isValid()){
-    for(auto& sc : *superClusters){
-      float scEt = sc.energy()*std::sin(sc.position().theta());
-      if(scEt > minSCEt_){
-	hcalHitSelector_.addDetIds(sc,*recHits,indexToStore);
+  if (superClusters.isValid() && recHits.isValid()) {
+    for (auto& sc : *superClusters) {
+      float scEt = sc.energy() * std::sin(sc.position().theta());
+      if (scEt > minSCEt_) {
+        hcalHitSelector_.addDetIds(sc, *recHits, indexToStore);
       }
     }
   }
-  
-  //unify the vector
-  std::sort(indexToStore.begin(),indexToStore.end());
-  std::unique(indexToStore.begin(),indexToStore.end());
-  
-  auto detIdCollection = std::make_unique<DetIdCollection>(indexToStore);
-   
-  iEvent.put(std::move(detIdCollection), interestingDetIdCollection_ );
 
+  //unify the vector
+  std::sort(indexToStore.begin(), indexToStore.end());
+  std::unique(indexToStore.begin(), indexToStore.end());
+
+  auto detIdCollection = std::make_unique<DetIdCollection>(indexToStore);
+
+  iEvent.put(std::move(detIdCollection), interestingDetIdCollection_);
 }

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaIsoHcalDetIdCollectionProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaIsoHcalDetIdCollectionProducer.h
@@ -1,12 +1,11 @@
 #ifndef RECOEGAMMA_EGAMMAISOLATIONALGOS_EGAMMAISOHCALDETIDCOLLECTIONPRODUCER_H
 #define RECOEGAMMA_EGAMMAISOLATIONALGOS_EGAMMAISOHCALDETIDCOLLECTIONPRODUCER_H
 
-
 // -*- C++ -*-
 //
 // Package:    EgammaIsoHcalDetIdCollectionProducer
 // Class:      EgammaIsoHcalDetIdCollectionProducer
-// 
+//
 /**\class EgammaIsoHcalDetIdCollectionProducer 
 Original author: Sam Harper (RAL)
  
@@ -14,8 +13,6 @@ Make a collection of detids to be kept tipically in a AOD rechit collection
 Modified from the ECAL version "InterestingDetIdCollectionProducer" to be HCAL
 
 */
-
-
 
 // system include files
 #include <memory>
@@ -39,32 +36,28 @@ Modified from the ECAL version "InterestingDetIdCollectionProducer" to be HCAL
 
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EGHcalRecHitSelector.h"
 
-
 class EgammaIsoHcalDetIdCollectionProducer : public edm::stream::EDProducer<> {
 public:
   explicit EgammaIsoHcalDetIdCollectionProducer(const edm::ParameterSet&);
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-  void beginRun (edm::Run const&, const edm::EventSetup&) final;
-  void produce(edm::Event &, const edm::EventSetup&) override;
-
-
+  void beginRun(edm::Run const&, const edm::EventSetup&) final;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
   // ----------member data ---------------------------
-  edm::EDGetTokenT<HBHERecHitCollection>         recHitsToken_;
+  edm::EDGetTokenT<HBHERecHitCollection> recHitsToken_;
   edm::EDGetTokenT<reco::SuperClusterCollection> superClustersToken_;
   edm::EDGetTokenT<reco::GsfElectronCollection> elesToken_;
   edm::EDGetTokenT<reco::PhotonCollection> phosToken_;
 
   std::string interestingDetIdCollection_;
- 
+
   float minSCEt_;
   float minEleEt_;
   float minPhoEt_;
 
   EGHcalRecHitSelector hcalHitSelector_;
-  
 };
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaPhotonTkIsolationProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaPhotonTkIsolationProducer.cc
@@ -6,7 +6,6 @@
 //=============================================================================
 //*****************************************************************************
 
-
 #include "RecoEgamma/EgammaIsolationAlgos/plugins/EgammaPhotonTkIsolationProducer.h"
 
 // Framework
@@ -22,72 +21,73 @@
 
 #include "RecoEgamma/EgammaIsolationAlgos/interface/PhotonTkIsolation.h"
 
+EgammaPhotonTkIsolationProducer::EgammaPhotonTkIsolationProducer(const edm::ParameterSet& config)
+    :
 
-EgammaPhotonTkIsolationProducer::EgammaPhotonTkIsolationProducer(const edm::ParameterSet& config) :
+      // use configuration file to setup input/output collection names
+      photonProducer_(config.getParameter<edm::InputTag>("photonProducer")),
 
-    // use configuration file to setup input/output collection names
-    photonProducer_       (config.getParameter<edm::InputTag>("photonProducer")),
-  
-    trackProducer_        (config.getParameter<edm::InputTag>("trackProducer")),
-    beamspotProducer_     (config.getParameter<edm::InputTag>("BeamspotProducer")),
+      trackProducer_(config.getParameter<edm::InputTag>("trackProducer")),
+      beamspotProducer_(config.getParameter<edm::InputTag>("BeamspotProducer")),
 
-    ptMin_                (config.getParameter<double>("ptMin")),
-    intRadiusBarrel_      (config.getParameter<double>("intRadiusBarrel")),
-    intRadiusEndcap_      (config.getParameter<double>("intRadiusEndcap")),
-    stripBarrel_          (config.getParameter<double>("stripBarrel")),
-    stripEndcap_          (config.getParameter<double>("stripEndcap")),
-    extRadius_            (config.getParameter<double>("extRadius")),
-    maxVtxDist_           (config.getParameter<double>("maxVtxDist")),
-    drb_                  (config.getParameter<double>("maxVtxDistXY"))
-{
-
+      ptMin_(config.getParameter<double>("ptMin")),
+      intRadiusBarrel_(config.getParameter<double>("intRadiusBarrel")),
+      intRadiusEndcap_(config.getParameter<double>("intRadiusEndcap")),
+      stripBarrel_(config.getParameter<double>("stripBarrel")),
+      stripEndcap_(config.getParameter<double>("stripEndcap")),
+      extRadius_(config.getParameter<double>("extRadius")),
+      maxVtxDist_(config.getParameter<double>("maxVtxDist")),
+      drb_(config.getParameter<double>("maxVtxDistXY")) {
   //register your products
-  produces < edm::ValueMap<double> >();
+  produces<edm::ValueMap<double>>();
 }
 
-
-EgammaPhotonTkIsolationProducer::~EgammaPhotonTkIsolationProducer(){}
-
+EgammaPhotonTkIsolationProducer::~EgammaPhotonTkIsolationProducer() {}
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-EgammaPhotonTkIsolationProducer::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSetup& iSetup) const
-{
-  
+void EgammaPhotonTkIsolationProducer::produce(edm::StreamID sid,
+                                              edm::Event& iEvent,
+                                              const edm::EventSetup& iSetup) const {
   // Get the  filtered objects
-  edm::Handle< edm::View<reco::Candidate> > photonHandle;
-  iEvent.getByLabel(photonProducer_,photonHandle);
-  
+  edm::Handle<edm::View<reco::Candidate>> photonHandle;
+  iEvent.getByLabel(photonProducer_, photonHandle);
+
   //get the tracks
   edm::Handle<reco::TrackCollection> tracks;
-  iEvent.getByLabel(trackProducer_,tracks);
+  iEvent.getByLabel(trackProducer_, tracks);
   const reco::TrackCollection* trackCollection = tracks.product();
 
   edm::Handle<reco::BeamSpot> beamSpotH;
-  iEvent.getByLabel(beamspotProducer_,beamSpotH);
+  iEvent.getByLabel(beamspotProducer_, beamSpotH);
   reco::TrackBase::Point beamspot = beamSpotH->position();
 
   //prepare product
   auto isoMap = std::make_unique<edm::ValueMap<double>>();
   edm::ValueMap<double>::Filler filler(*isoMap);
-  std::vector<double> retV(photonHandle->size(),0);
+  std::vector<double> retV(photonHandle->size(), 0);
 
-  PhotonTkIsolation myTkIsolation (extRadius_,intRadiusBarrel_,intRadiusEndcap_,stripBarrel_,stripEndcap_,ptMin_,maxVtxDist_,drb_,trackCollection,beamspot) ;
+  PhotonTkIsolation myTkIsolation(extRadius_,
+                                  intRadiusBarrel_,
+                                  intRadiusEndcap_,
+                                  stripBarrel_,
+                                  stripEndcap_,
+                                  ptMin_,
+                                  maxVtxDist_,
+                                  drb_,
+                                  trackCollection,
+                                  beamspot);
 
-  for(unsigned int i = 0 ; i < photonHandle->size(); ++i ){
+  for (unsigned int i = 0; i < photonHandle->size(); ++i) {
     double isoValue = myTkIsolation.getIso(&(photonHandle->at(i))).second;
     retV[i] = isoValue;
   }
-   
+
   //fill and insert valuemap
-  filler.insert(photonHandle,retV.begin(),retV.end());
+  filler.insert(photonHandle, retV.begin(), retV.end());
   filler.fill();
   iEvent.put(std::move(isoMap));
-
 }
-
-

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaPhotonTkIsolationProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaPhotonTkIsolationProducer.h
@@ -18,13 +18,13 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class EgammaPhotonTkIsolationProducer : public edm::global::EDProducer<> {
- public:
+public:
   explicit EgammaPhotonTkIsolationProducer(const edm::ParameterSet&);
   ~EgammaPhotonTkIsolationProducer() override;
-  
+
   void produce(edm::StreamID sid, edm::Event&, const edm::EventSetup&) const override;
 
- private:
+private:
   const edm::InputTag photonProducer_;
   const edm::InputTag trackProducer_;
   const edm::InputTag beamspotProducer_;
@@ -37,10 +37,8 @@ class EgammaPhotonTkIsolationProducer : public edm::global::EDProducer<> {
   const double extRadius_;
   const double maxVtxDist_;
   const double drb_;
-  
+
   const edm::ParameterSet conf_;
-
 };
-
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaPhotonTkNumIsolationProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaPhotonTkNumIsolationProducer.cc
@@ -6,7 +6,6 @@
 //=============================================================================
 //*****************************************************************************
 
-
 #include "RecoEgamma/EgammaIsolationAlgos/plugins/EgammaPhotonTkNumIsolationProducer.h"
 
 // Framework
@@ -19,76 +18,76 @@
 
 #include "RecoEgamma/EgammaIsolationAlgos/interface/PhotonTkIsolation.h"
 
+EgammaPhotonTkNumIsolationProducer::EgammaPhotonTkNumIsolationProducer(const edm::ParameterSet& config)
+    :
 
-EgammaPhotonTkNumIsolationProducer::EgammaPhotonTkNumIsolationProducer(const edm::ParameterSet& config) :
+      // use configuration file to setup input/output collection names
+      photonProducer_(config.getParameter<edm::InputTag>("photonProducer")),
 
-    // use configuration file to setup input/output collection names
-    photonProducer_       (config.getParameter<edm::InputTag>("photonProducer")),
-  
-    trackProducer_        (config.getParameter<edm::InputTag>("trackProducer")),
-    beamspotProducer_     (config.getParameter<edm::InputTag>("BeamspotProducer")),
+      trackProducer_(config.getParameter<edm::InputTag>("trackProducer")),
+      beamspotProducer_(config.getParameter<edm::InputTag>("BeamspotProducer")),
 
-    ptMin_                (config.getParameter<double>("ptMin")),
-    intRadiusBarrel_      (config.getParameter<double>("intRadiusBarrel")),
-    intRadiusEndcap_      (config.getParameter<double>("intRadiusEndcap")),
-    stripBarrel_          (config.getParameter<double>("stripBarrel")),
-    stripEndcap_          (config.getParameter<double>("stripEndcap")),
-    extRadius_            (config.getParameter<double>("extRadius")),
-    maxVtxDist_           (config.getParameter<double>("maxVtxDist")),
-    drb_                  (config.getParameter<double>("maxVtxDistXY"))
+      ptMin_(config.getParameter<double>("ptMin")),
+      intRadiusBarrel_(config.getParameter<double>("intRadiusBarrel")),
+      intRadiusEndcap_(config.getParameter<double>("intRadiusEndcap")),
+      stripBarrel_(config.getParameter<double>("stripBarrel")),
+      stripEndcap_(config.getParameter<double>("stripEndcap")),
+      extRadius_(config.getParameter<double>("extRadius")),
+      maxVtxDist_(config.getParameter<double>("maxVtxDist")),
+      drb_(config.getParameter<double>("maxVtxDistXY"))
 
 {
   //register your products
-  produces < edm::ValueMap<int> >();
+  produces<edm::ValueMap<int>>();
 }
 
-
-EgammaPhotonTkNumIsolationProducer::~EgammaPhotonTkNumIsolationProducer(){}
-
+EgammaPhotonTkNumIsolationProducer::~EgammaPhotonTkNumIsolationProducer() {}
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-EgammaPhotonTkNumIsolationProducer::produce(edm::StreamID sid, edm::Event& iEvent, const edm::EventSetup& iSetup) const
-{
-  
+void EgammaPhotonTkNumIsolationProducer::produce(edm::StreamID sid,
+                                                 edm::Event& iEvent,
+                                                 const edm::EventSetup& iSetup) const {
   // Get the  filtered objects
-  edm::Handle< edm::View<reco::Candidate> > photonHandle;
-  iEvent.getByLabel(photonProducer_,photonHandle);
-  
+  edm::Handle<edm::View<reco::Candidate>> photonHandle;
+  iEvent.getByLabel(photonProducer_, photonHandle);
+
   //get the tracks
   edm::Handle<reco::TrackCollection> tracks;
-  iEvent.getByLabel(trackProducer_,tracks);
+  iEvent.getByLabel(trackProducer_, tracks);
   const reco::TrackCollection* trackCollection = tracks.product();
 
   //get beamspot
   edm::Handle<reco::BeamSpot> beamSpotH;
-  iEvent.getByLabel(beamspotProducer_,beamSpotH);
+  iEvent.getByLabel(beamspotProducer_, beamSpotH);
   reco::TrackBase::Point beamspot = beamSpotH->position();
 
   //prepare product
   auto isoMap = std::make_unique<edm::ValueMap<int>>();
   edm::ValueMap<int>::Filler filler(*isoMap);
-  std::vector<int> retV(photonHandle->size(),0);
+  std::vector<int> retV(photonHandle->size(), 0);
 
-  PhotonTkIsolation myTkIsolation(extRadius_,intRadiusBarrel_,intRadiusEndcap_,stripBarrel_,stripEndcap_,ptMin_,maxVtxDist_,drb_,trackCollection,beamspot) ;
+  PhotonTkIsolation myTkIsolation(extRadius_,
+                                  intRadiusBarrel_,
+                                  intRadiusEndcap_,
+                                  stripBarrel_,
+                                  stripEndcap_,
+                                  ptMin_,
+                                  maxVtxDist_,
+                                  drb_,
+                                  trackCollection,
+                                  beamspot);
 
-  for(unsigned int i = 0 ; i < photonHandle->size(); ++i ){
+  for (unsigned int i = 0; i < photonHandle->size(); ++i) {
     int isoValue = myTkIsolation.getIso(&(photonHandle->at(i))).first;
     retV[i] = isoValue;
   }
-   
-
 
   //fill and insert valuemap
-  filler.insert(photonHandle,retV.begin(),retV.end());
+  filler.insert(photonHandle, retV.begin(), retV.end());
   filler.fill();
   iEvent.put(std::move(isoMap));
-
-
 }
-
-

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaPhotonTkNumIsolationProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaPhotonTkNumIsolationProducer.h
@@ -18,14 +18,13 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class EgammaPhotonTkNumIsolationProducer : public edm::global::EDProducer<> {
- public:
+public:
   explicit EgammaPhotonTkNumIsolationProducer(const edm::ParameterSet&);
   ~EgammaPhotonTkNumIsolationProducer() override;
-  
+
   void produce(edm::StreamID sid, edm::Event&, const edm::EventSetup&) const override;
 
- private:
-
+private:
   const edm::InputTag photonProducer_;
   const edm::InputTag trackProducer_;
   const edm::InputTag beamspotProducer_;
@@ -38,8 +37,6 @@ class EgammaPhotonTkNumIsolationProducer : public edm::global::EDProducer<> {
   const double extRadius_;
   const double maxVtxDist_;
   const double drb_;
-
 };
-
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaRecHitExtractor.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaRecHitExtractor.cc
@@ -38,53 +38,47 @@ using namespace std;
 using namespace egammaisolation;
 using namespace reco::isodeposit;
 
-EgammaRecHitExtractor::EgammaRecHitExtractor(const edm::ParameterSet& par, edm::ConsumesCollector & iC) :
-    etMin_(par.getParameter<double>("etMin")),
-    energyMin_(par.getParameter<double>("energyMin")),
-    extRadius_(par.getParameter<double>("extRadius")),
-    intRadius_(par.getParameter<double>("intRadius")),
-    intStrip_(par.getParameter<double>("intStrip")),
-    barrelEcalHitsTag_(par.getParameter<edm::InputTag>("barrelEcalHits")),
-    endcapEcalHitsTag_(par.getParameter<edm::InputTag>("endcapEcalHits")),
-    barrelEcalHitsToken_(iC.consumes<EcalRecHitCollection>(barrelEcalHitsTag_)),
-    endcapEcalHitsToken_(iC.consumes<EcalRecHitCollection>(endcapEcalHitsTag_)),
-    fakeNegativeDeposit_(par.getParameter<bool>("subtractSuperClusterEnergy")),
-    tryBoth_(par.getParameter<bool>("tryBoth")),
-    vetoClustered_(par.getParameter<bool>("vetoClustered")),
-    sameTag_(false)
-    //severityLevelCut_(par.getParameter<int>("severityLevelCut"))
-    //severityRecHitThreshold_(par.getParameter<double>("severityRecHitThreshold")),
-    //spIdString_(par.getParameter<std::string>("spikeIdString")),
-    //spIdThreshold_(par.getParameter<double>("spikeIdThreshold")),
+EgammaRecHitExtractor::EgammaRecHitExtractor(const edm::ParameterSet& par, edm::ConsumesCollector& iC)
+    : etMin_(par.getParameter<double>("etMin")),
+      energyMin_(par.getParameter<double>("energyMin")),
+      extRadius_(par.getParameter<double>("extRadius")),
+      intRadius_(par.getParameter<double>("intRadius")),
+      intStrip_(par.getParameter<double>("intStrip")),
+      barrelEcalHitsTag_(par.getParameter<edm::InputTag>("barrelEcalHits")),
+      endcapEcalHitsTag_(par.getParameter<edm::InputTag>("endcapEcalHits")),
+      barrelEcalHitsToken_(iC.consumes<EcalRecHitCollection>(barrelEcalHitsTag_)),
+      endcapEcalHitsToken_(iC.consumes<EcalRecHitCollection>(endcapEcalHitsTag_)),
+      fakeNegativeDeposit_(par.getParameter<bool>("subtractSuperClusterEnergy")),
+      tryBoth_(par.getParameter<bool>("tryBoth")),
+      vetoClustered_(par.getParameter<bool>("vetoClustered")),
+      sameTag_(false)
+//severityLevelCut_(par.getParameter<int>("severityLevelCut"))
+//severityRecHitThreshold_(par.getParameter<double>("severityRecHitThreshold")),
+//spIdString_(par.getParameter<std::string>("spikeIdString")),
+//spIdThreshold_(par.getParameter<double>("spikeIdThreshold")),
 {
+  const std::vector<std::string> flagnamesEB = par.getParameter<std::vector<std::string> >("RecHitFlagToBeExcludedEB");
 
-  const std::vector<std::string> flagnamesEB =
-    par.getParameter<std::vector<std::string> >("RecHitFlagToBeExcludedEB");
+  const std::vector<std::string> flagnamesEE = par.getParameter<std::vector<std::string> >("RecHitFlagToBeExcludedEE");
 
-  const std::vector<std::string> flagnamesEE =
-    par.getParameter<std::vector<std::string> >("RecHitFlagToBeExcludedEE");
+  flagsexclEB_ = StringToEnumValue<EcalRecHit::Flags>(flagnamesEB);
 
-  flagsexclEB_=
-    StringToEnumValue<EcalRecHit::Flags>(flagnamesEB);
-
-  flagsexclEE_=
-    StringToEnumValue<EcalRecHit::Flags>(flagnamesEE);
+  flagsexclEE_ = StringToEnumValue<EcalRecHit::Flags>(flagnamesEE);
 
   const std::vector<std::string> severitynamesEB =
-    par.getParameter<std::vector<std::string> >("RecHitSeverityToBeExcludedEB");
+      par.getParameter<std::vector<std::string> >("RecHitSeverityToBeExcludedEB");
 
-  severitiesexclEB_=
-    StringToEnumValue<EcalSeverityLevel::SeverityLevel>(severitynamesEB);
+  severitiesexclEB_ = StringToEnumValue<EcalSeverityLevel::SeverityLevel>(severitynamesEB);
 
   const std::vector<std::string> severitynamesEE =
-    par.getParameter<std::vector<std::string> >("RecHitSeverityToBeExcludedEE");
+      par.getParameter<std::vector<std::string> >("RecHitSeverityToBeExcludedEE");
 
-  severitiesexclEE_=
-    StringToEnumValue<EcalSeverityLevel::SeverityLevel>(severitynamesEE);
+  severitiesexclEE_ = StringToEnumValue<EcalSeverityLevel::SeverityLevel>(severitynamesEE);
 
   if ((intRadius_ != 0.0) && (fakeNegativeDeposit_)) {
-    throw cms::Exception("Configuration Error") << "EgammaRecHitExtractor: " <<
-      "If you use 'subtractSuperClusterEnergy', you *must* set 'intRadius' to ZERO; it does not make sense, otherwise.";
+    throw cms::Exception("Configuration Error") << "EgammaRecHitExtractor: "
+                                                << "If you use 'subtractSuperClusterEnergy', you *must* set "
+                                                   "'intRadius' to ZERO; it does not make sense, otherwise.";
   }
   std::string isoVariable = par.getParameter<std::string>("isolationVariable");
   if (isoVariable == "et") {
@@ -92,23 +86,25 @@ EgammaRecHitExtractor::EgammaRecHitExtractor(const edm::ParameterSet& par, edm::
   } else if (isoVariable == "energy") {
     useEt_ = false;
   } else {
-    throw cms::Exception("Configuration Error") << "EgammaRecHitExtractor: isolationVariable '" << isoVariable << "' not known. "
-						<< " Supported values are 'et', 'energy'. ";
+    throw cms::Exception("Configuration Error")
+        << "EgammaRecHitExtractor: isolationVariable '" << isoVariable << "' not known. "
+        << " Supported values are 'et', 'energy'. ";
   }
-  if (endcapEcalHitsTag_.encode() ==  barrelEcalHitsTag_.encode()) {
+  if (endcapEcalHitsTag_.encode() == barrelEcalHitsTag_.encode()) {
     sameTag_ = true;
     if (tryBoth_) {
-      edm::LogWarning("EgammaRecHitExtractor") << "If you have configured 'barrelRecHits' == 'endcapRecHits', so I'm switching 'tryBoth' to FALSE.";
+      edm::LogWarning("EgammaRecHitExtractor")
+          << "If you have configured 'barrelRecHits' == 'endcapRecHits', so I'm switching 'tryBoth' to FALSE.";
       tryBoth_ = false;
     }
   }
 }
 
-EgammaRecHitExtractor::~EgammaRecHitExtractor()
-{}
+EgammaRecHitExtractor::~EgammaRecHitExtractor() {}
 
-reco::IsoDeposit EgammaRecHitExtractor::deposit(const edm::Event & iEvent,
-						const edm::EventSetup & iSetup, const reco::Candidate &emObject ) const {
+reco::IsoDeposit EgammaRecHitExtractor::deposit(const edm::Event& iEvent,
+                                                const edm::EventSetup& iSetup,
+                                                const reco::Candidate& emObject) const {
   edm::ESHandle<CaloGeometry> pG;
   iSetup.get<CaloGeometryRecord>().get(pG);
 
@@ -121,8 +117,8 @@ reco::IsoDeposit EgammaRecHitExtractor::deposit(const edm::Event & iEvent,
   const EcalSeverityLevelAlgo* sevLevel = sevlv.product();
 
   const CaloGeometry* caloGeom = pG.product();
-  const CaloSubdetectorGeometry* barrelgeom = caloGeom->getSubdetectorGeometry(DetId::Ecal,EcalBarrel);
-  const CaloSubdetectorGeometry* endcapgeom = caloGeom->getSubdetectorGeometry(DetId::Ecal,EcalEndcap);
+  const CaloSubdetectorGeometry* barrelgeom = caloGeom->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
+  const CaloSubdetectorGeometry* endcapgeom = caloGeom->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
 
   static const std::string metname = "EgammaIsolationAlgos|EgammaRecHitExtractor";
 
@@ -139,19 +135,19 @@ reco::IsoDeposit EgammaRecHitExtractor::deposit(const edm::Event & iEvent,
   math::XYZPoint caloPosition = sc->position();
 
   Direction candDir(caloPosition.eta(), caloPosition.phi());
-  reco::IsoDeposit deposit( candDir );
-  deposit.setVeto( reco::IsoDeposit::Veto(candDir, intRadius_) );
-  double sinTheta = sin(2*atan(exp(-sc->eta())));
-  deposit.addCandEnergy(sc->energy() * (useEt_ ? sinTheta : 1.0)) ;
+  reco::IsoDeposit deposit(candDir);
+  deposit.setVeto(reco::IsoDeposit::Veto(candDir, intRadius_));
+  double sinTheta = sin(2 * atan(exp(-sc->eta())));
+  deposit.addCandEnergy(sc->energy() * (useEt_ ? sinTheta : 1.0));
 
   // subtract supercluster if desired
   double fakeEnergy = -sc->rawEnergy();
   if (fakeNegativeDeposit_) {
-    deposit.addDeposit(candDir, fakeEnergy * (useEt_ ?  sinTheta : 1.0)); // not exactly clean...
+    deposit.addDeposit(candDir, fakeEnergy * (useEt_ ? sinTheta : 1.0));  // not exactly clean...
   }
 
   // fill rechits
-  bool inBarrel = sameTag_ || ( abs(sc->eta()) < 1.479 ); //check for barrel. If only one collection is used, use barrel
+  bool inBarrel = sameTag_ || (abs(sc->eta()) < 1.479);  //check for barrel. If only one collection is used, use barrel
   if (inBarrel || tryBoth_) {
     collect(deposit, sc, barrelgeom, caloGeom, *barrelEcalRecHitsH, sevLevel, true);
   }
@@ -163,88 +159,84 @@ reco::IsoDeposit EgammaRecHitExtractor::deposit(const edm::Event & iEvent,
   return deposit;
 }
 
-void EgammaRecHitExtractor::collect(reco::IsoDeposit &deposit,
+void EgammaRecHitExtractor::collect(reco::IsoDeposit& deposit,
                                     const reco::SuperClusterRef& sc,
-				    const CaloSubdetectorGeometry* subdet,
+                                    const CaloSubdetectorGeometry* subdet,
                                     const CaloGeometry* caloGeom,
-                                    const EcalRecHitCollection &hits,
+                                    const EcalRecHitCollection& hits,
                                     //const EcalChannelStatus* chStatus,
                                     const EcalSeverityLevelAlgo* sevLevel,
                                     bool barrel) const {
+  GlobalPoint caloPosition(sc->position().x(), sc->position().y(), sc->position().z());
+  CaloSubdetectorGeometry::DetIdSet chosen = subdet->getCells(caloPosition, extRadius_);
+  EcalRecHitCollection::const_iterator j = hits.end();
+  double caloeta = caloPosition.eta();
+  double calophi = caloPosition.phi();
+  double r2 = intRadius_ * intRadius_;
 
-  GlobalPoint caloPosition(sc->position().x(), sc->position().y() , sc->position().z());
-  CaloSubdetectorGeometry::DetIdSet chosen = subdet->getCells(caloPosition,extRadius_);
-  EcalRecHitCollection::const_iterator j=hits.end();
-  double caloeta=caloPosition.eta();
-  double calophi=caloPosition.phi();
-  double r2 = intRadius_*intRadius_;
+  std::vector<std::pair<DetId, float> >::const_iterator rhIt;
 
-  std::vector< std::pair<DetId, float> >::const_iterator rhIt;
-
-
-  for (CaloSubdetectorGeometry::DetIdSet::const_iterator i = chosen.begin(), end = chosen.end() ; i != end;  ++i)  {
+  for (CaloSubdetectorGeometry::DetIdSet::const_iterator i = chosen.begin(), end = chosen.end(); i != end; ++i) {
     j = hits.find(*i);
     if (j != hits.end()) {
-      const  GlobalPoint & position = caloGeom->getPosition(*i);
+      const GlobalPoint& position = caloGeom->getPosition(*i);
       double eta = position.eta();
       double phi = position.phi();
       double energy = j->energy();
-      double et = energy*position.perp()/position.mag();
-      double phiDiff= reco::deltaPhi(phi,calophi);
+      double et = energy * position.perp() / position.mag();
+      double phiDiff = reco::deltaPhi(phi, calophi);
 
       //check if we are supposed to veto clustered and then do so
-      if(vetoClustered_) {
+      if (vetoClustered_) {
+        //Loop over basic clusters:
+        bool isClustered = false;
+        for (reco::CaloCluster_iterator bcIt = sc->clustersBegin(); bcIt != sc->clustersEnd(); ++bcIt) {
+          for (rhIt = (*bcIt)->hitsAndFractions().begin(); rhIt != (*bcIt)->hitsAndFractions().end(); ++rhIt) {
+            if (rhIt->first == *i)
+              isClustered = true;
+            if (isClustered)
+              break;
+          }
+          if (isClustered)
+            break;
+        }  //end loop over basic clusters
 
-	//Loop over basic clusters:
-	bool isClustered = false;
-	for(    reco::CaloCluster_iterator bcIt = sc->clustersBegin();bcIt != sc->clustersEnd(); ++bcIt) {
-	  for(rhIt = (*bcIt)->hitsAndFractions().begin();rhIt != (*bcIt)->hitsAndFractions().end(); ++rhIt) {
-	    if( rhIt->first == *i ) isClustered = true;
-	    if( isClustered ) break;
-	  }
-	  if( isClustered ) break;
-	} //end loop over basic clusters
-
-	if(isClustered) continue;
+        if (isClustered)
+          continue;
       }  //end if removeClustered
 
       std::vector<int>::const_iterator sit;
       int severityFlag = sevLevel->severityLevel(j->detid(), hits);
       if (barrel) {
-	sit = std::find(severitiesexclEB_.begin(), severitiesexclEB_.end(), severityFlag);
-	if (sit != severitiesexclEB_.end())
-	  continue;
+        sit = std::find(severitiesexclEB_.begin(), severitiesexclEB_.end(), severityFlag);
+        if (sit != severitiesexclEB_.end())
+          continue;
       } else {
-	sit = std::find(severitiesexclEE_.begin(), severitiesexclEE_.end(), severityFlag);
-	if (sit != severitiesexclEE_.end())
-	  continue;
+        sit = std::find(severitiesexclEE_.begin(), severitiesexclEE_.end(), severityFlag);
+        if (sit != severitiesexclEE_.end())
+          continue;
       }
 
       if (barrel) {
-	// new rechit flag checks
-	if (!j->checkFlag(EcalRecHit::kGood)) {
-	  if (j->checkFlags(flagsexclEB_)) {
-	    continue;
-	  }
-	}
+        // new rechit flag checks
+        if (!j->checkFlag(EcalRecHit::kGood)) {
+          if (j->checkFlags(flagsexclEB_)) {
+            continue;
+          }
+        }
       } else {
-	// new rechit flag checks
-	if (!j->checkFlag(EcalRecHit::kGood)) {
-	  if (j->checkFlags(flagsexclEE_)) {
-	    continue;
-	  }
-	}
+        // new rechit flag checks
+        if (!j->checkFlag(EcalRecHit::kGood)) {
+          if (j->checkFlags(flagsexclEE_)) {
+            continue;
+          }
+        }
       }
 
-      if(et > etMin_
-	 && energy > energyMin_  //Changed to fabs - then changed back to energy
-	 && fabs(eta-caloeta) > intStrip_
-	 && (eta-caloeta)*(eta-caloeta) + phiDiff*phiDiff >r2 ) {
-
-	deposit.addDeposit( Direction(eta, phi), (useEt_ ? et : energy));
+      if (et > etMin_ && energy > energyMin_  //Changed to fabs - then changed back to energy
+          && fabs(eta - caloeta) > intStrip_ && (eta - caloeta) * (eta - caloeta) + phiDiff * phiDiff > r2) {
+        deposit.addDeposit(Direction(eta, phi), (useEt_ ? et : energy));
       }
     }
   }
 }
-
-

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaRecHitExtractor.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaRecHitExtractor.h
@@ -40,39 +40,45 @@ namespace egammaisolation {
 
   class EgammaRecHitExtractor : public reco::isodeposit::IsoDepositExtractor {
   public:
-    EgammaRecHitExtractor(const edm::ParameterSet& par, edm::ConsumesCollector && iC) :
-      EgammaRecHitExtractor(par, iC) {}
-    EgammaRecHitExtractor(const edm::ParameterSet& par, edm::ConsumesCollector & iC);
-    ~EgammaRecHitExtractor() override ;
-    void fillVetos(const edm::Event & ev, const edm::EventSetup & evSetup, const reco::TrackCollection & tracks) override { }
-    reco::IsoDeposit deposit(const edm::Event & ev, const edm::EventSetup & evSetup, const reco::Track & track) const override {
-      throw cms::Exception("Configuration Error") << "This extractor " << (typeid(this).name()) << " is not made for tracks";
+    EgammaRecHitExtractor(const edm::ParameterSet& par, edm::ConsumesCollector&& iC) : EgammaRecHitExtractor(par, iC) {}
+    EgammaRecHitExtractor(const edm::ParameterSet& par, edm::ConsumesCollector& iC);
+    ~EgammaRecHitExtractor() override;
+    void fillVetos(const edm::Event& ev, const edm::EventSetup& evSetup, const reco::TrackCollection& tracks) override {
     }
-    reco::IsoDeposit deposit(const edm::Event & ev, const edm::EventSetup & evSetup, const reco::Candidate & c) const override ;
+    reco::IsoDeposit deposit(const edm::Event& ev,
+                             const edm::EventSetup& evSetup,
+                             const reco::Track& track) const override {
+      throw cms::Exception("Configuration Error")
+          << "This extractor " << (typeid(this).name()) << " is not made for tracks";
+    }
+    reco::IsoDeposit deposit(const edm::Event& ev,
+                             const edm::EventSetup& evSetup,
+                             const reco::Candidate& c) const override;
 
   private:
-    void collect(reco::IsoDeposit &deposit,
-		 const reco::SuperClusterRef& sc, const CaloSubdetectorGeometry* subdet,
-		 const CaloGeometry* caloGeom,
-		 const EcalRecHitCollection &hits,
-		 //const EcalChannelStatus* chStatus,
-		 const EcalSeverityLevelAlgo* sevLevel,
-		 bool barrel) const;
+    void collect(reco::IsoDeposit& deposit,
+                 const reco::SuperClusterRef& sc,
+                 const CaloSubdetectorGeometry* subdet,
+                 const CaloGeometry* caloGeom,
+                 const EcalRecHitCollection& hits,
+                 //const EcalChannelStatus* chStatus,
+                 const EcalSeverityLevelAlgo* sevLevel,
+                 bool barrel) const;
 
-    double etMin_ ;
-    double energyMin_ ;
-    double extRadius_ ;
-    double intRadius_ ;
-    double intStrip_ ;
+    double etMin_;
+    double energyMin_;
+    double extRadius_;
+    double intRadius_;
+    double intStrip_;
     edm::InputTag barrelEcalHitsTag_;
     edm::InputTag endcapEcalHitsTag_;
     edm::EDGetTokenT<EcalRecHitCollection> barrelEcalHitsToken_;
     edm::EDGetTokenT<EcalRecHitCollection> endcapEcalHitsToken_;
     bool fakeNegativeDeposit_;
-    bool  tryBoth_;
-    bool  useEt_;
-    bool  vetoClustered_;
-    bool  sameTag_;
+    bool tryBoth_;
+    bool useEt_;
+    bool vetoClustered_;
+    bool sameTag_;
     //int   severityLevelCut_;
     //float severityRecHitThreshold_;
     //std::string spIdString_;
@@ -84,5 +90,5 @@ namespace egammaisolation {
     std::vector<int> flagsexclEB_;
     std::vector<int> flagsexclEE_;
   };
-}
+}  // namespace egammaisolation
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaTowerExtractor.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaTowerExtractor.cc
@@ -13,7 +13,6 @@
 //ROOT includes
 #include <Math/VectorUtil.h>
 
-
 //CMSSW includes
 #include "RecoEgamma/EgammaIsolationAlgos/plugins/EgammaTowerExtractor.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
@@ -23,52 +22,58 @@
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 #include "DataFormats/CaloTowers/interface/CaloTower.h"
 
-using namespace ROOT::Math::VectorUtil ;
+using namespace ROOT::Math::VectorUtil;
 
 using namespace egammaisolation;
 using namespace reco::isodeposit;
 
-EgammaTowerExtractor::~EgammaTowerExtractor(){}
+EgammaTowerExtractor::~EgammaTowerExtractor() {}
 
-reco::IsoDeposit EgammaTowerExtractor::deposit(const edm::Event & iEvent,
-        const edm::EventSetup & iSetup, const reco::Candidate &emObject ) const {
+reco::IsoDeposit EgammaTowerExtractor::deposit(const edm::Event &iEvent,
+                                               const edm::EventSetup &iSetup,
+                                               const reco::Candidate &emObject) const {
+  edm::Handle<CaloTowerCollection> towercollectionH;
+  iEvent.getByToken(caloTowerToken, towercollectionH);
 
-    edm::Handle<CaloTowerCollection> towercollectionH;
-    iEvent.getByToken(caloTowerToken, towercollectionH);
+  //Take the SC position
+  reco::SuperClusterRef sc = emObject.get<reco::SuperClusterRef>();
+  math::XYZPoint caloPosition = sc->position();
 
-    //Take the SC position
-    reco::SuperClusterRef sc = emObject.get<reco::SuperClusterRef>();
-    math::XYZPoint caloPosition = sc->position();
+  Direction candDir(caloPosition.eta(), caloPosition.phi());
+  reco::IsoDeposit deposit(candDir);
+  deposit.setVeto(reco::IsoDeposit::Veto(candDir, intRadius_));
+  deposit.addCandEnergy(sc->energy() * sin(2 * atan(exp(-sc->eta()))));
 
-    Direction candDir(caloPosition.eta(), caloPosition.phi());
-    reco::IsoDeposit deposit( candDir );
-    deposit.setVeto( reco::IsoDeposit::Veto(candDir, intRadius_) );
-    deposit.addCandEnergy(sc->energy()*sin(2*atan(exp(-sc->eta()))));
+  //loop over tracks
+  for (CaloTowerCollection::const_iterator trItr = towercollectionH->begin(), trEnd = towercollectionH->end();
+       trItr != trEnd;
+       ++trItr) {
+    double depEt = 0;
+    //the hcal can be seperated into different depths
+    //currently it is setup to check that the depth is valid in constructor
+    //if the depth is not valid it fails gracefully
+    //small bug fix, hadEnergyHeInnerLater returns zero for towers which are only depth 1
+    //but we want Depth1 isolation to include these so we have to manually check for this
+    if (depth_ == AllDepths)
+      depEt = trItr->hadEt();
+    else if (depth_ == Depth1)
+      depEt = trItr->ietaAbs() < 18 || trItr->ietaAbs() > 29
+                  ? trItr->hadEt()
+                  : trItr->hadEnergyHeInnerLayer() * sin(trItr->p4().theta());
+    else if (depth_ == Depth2)
+      depEt = trItr->hadEnergyHeOuterLayer() * sin(trItr->p4().theta());
 
-    //loop over tracks
-    for(CaloTowerCollection::const_iterator trItr = towercollectionH->begin(), trEnd = towercollectionH->end(); trItr != trEnd; ++trItr){
-      double depEt  = 0;
-      //the hcal can be seperated into different depths
-      //currently it is setup to check that the depth is valid in constructor
-      //if the depth is not valid it fails gracefully
-      //small bug fix, hadEnergyHeInnerLater returns zero for towers which are only depth 1
-      //but we want Depth1 isolation to include these so we have to manually check for this
-      if(depth_==AllDepths) depEt = trItr->hadEt();
-      else if(depth_==Depth1) depEt = trItr->ietaAbs()<18 || trItr->ietaAbs()>29 ? trItr->hadEt() : trItr->hadEnergyHeInnerLayer()*sin(trItr->p4().theta());
-      else if(depth_==Depth2) depEt = trItr->hadEnergyHeOuterLayer()*sin(trItr->p4().theta());
+    if (depEt < etLow_)
+      continue;
 
-      if ( depEt < etLow_ )  continue ;
+    Direction towerDir(trItr->eta(), trItr->phi());
+    double dR2 = candDir.deltaR2(towerDir);
 
+    if (dR2 < extRadius2_) {
+      deposit.addDeposit(towerDir, depEt);
+    }
 
-        Direction towerDir( trItr->eta(), trItr->phi() );
-        double dR2 = candDir.deltaR2(towerDir);
+  }  //end loop over tracks
 
-        if (dR2 < extRadius2_) {
-            deposit.addDeposit( towerDir, depEt);
-        }
-
-    }//end loop over tracks
-
-    return deposit;
+  return deposit;
 }
-

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaTowerIsolationProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaTowerIsolationProducer.cc
@@ -6,7 +6,6 @@
 //=============================================================================
 //*****************************************************************************
 
-
 #include "RecoEgamma/EgammaIsolationAlgos/plugins/EgammaTowerIsolationProducer.h"
 
 // Framework
@@ -20,41 +19,33 @@
 
 #include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
 
+EgammaTowerIsolationProducer::EgammaTowerIsolationProducer(const edm::ParameterSet& config) : conf_(config) {
+  // use configuration file to setup input/output collection names
+  emObjectProducer_ = conf_.getParameter<edm::InputTag>("emObjectProducer");
 
-EgammaTowerIsolationProducer::EgammaTowerIsolationProducer(const edm::ParameterSet& config) : conf_(config)
-{
- // use configuration file to setup input/output collection names
-  emObjectProducer_               = conf_.getParameter<edm::InputTag>("emObjectProducer");
+  towerProducer_ = conf_.getParameter<edm::InputTag>("towerProducer");
 
-  towerProducer_           = conf_.getParameter<edm::InputTag>("towerProducer");
-
-  egHcalIsoPtMin_               = conf_.getParameter<double>("etMin");
-  egHcalIsoConeSizeIn_          = conf_.getParameter<double>("intRadius");
-  egHcalIsoConeSizeOut_         = conf_.getParameter<double>("extRadius");
-  egHcalDepth_                  = conf_.getParameter<int>("Depth");
-
+  egHcalIsoPtMin_ = conf_.getParameter<double>("etMin");
+  egHcalIsoConeSizeIn_ = conf_.getParameter<double>("intRadius");
+  egHcalIsoConeSizeOut_ = conf_.getParameter<double>("extRadius");
+  egHcalDepth_ = conf_.getParameter<int>("Depth");
 
   //register your products
-  produces < edm::ValueMap<double> >();
+  produces<edm::ValueMap<double>>();
 }
 
-
-EgammaTowerIsolationProducer::~EgammaTowerIsolationProducer(){}
-
+EgammaTowerIsolationProducer::~EgammaTowerIsolationProducer() {}
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-EgammaTowerIsolationProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-  
+void EgammaTowerIsolationProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // Get the  filtered objects
-  edm::Handle< edm::View<reco::Candidate> > emObjectHandle;
-  iEvent.getByLabel(emObjectProducer_,emObjectHandle);
-  
+  edm::Handle<edm::View<reco::Candidate>> emObjectHandle;
+  iEvent.getByLabel(emObjectProducer_, emObjectHandle);
+
   // Get the barrel hcal hits
   edm::Handle<CaloTowerCollection> towerHandle;
   iEvent.getByLabel(towerProducer_, towerHandle);
@@ -62,24 +53,19 @@ EgammaTowerIsolationProducer::produce(edm::Event& iEvent, const edm::EventSetup&
 
   auto isoMap = std::make_unique<edm::ValueMap<double>>();
   edm::ValueMap<double>::Filler filler(*isoMap);
-  std::vector<double> retV(emObjectHandle->size(),0);
+  std::vector<double> retV(emObjectHandle->size(), 0);
 
-  EgammaTowerIsolation myHadIsolation(egHcalIsoConeSizeOut_,
-			      egHcalIsoConeSizeIn_,
-			      egHcalIsoPtMin_,
-			      egHcalDepth_,	      
-			      towers) ;
+  EgammaTowerIsolation myHadIsolation(
+      egHcalIsoConeSizeOut_, egHcalIsoConeSizeIn_, egHcalIsoPtMin_, egHcalDepth_, towers);
 
-  
-  for( size_t i = 0 ; i < emObjectHandle->size(); ++i) {
+  for (size_t i = 0; i < emObjectHandle->size(); ++i) {
     double isoValue = myHadIsolation.getTowerEtSum(&(emObjectHandle->at(i)));
-    retV[i]=isoValue;
+    retV[i] = isoValue;
   }
 
-  filler.insert(emObjectHandle,retV.begin(),retV.end());
+  filler.insert(emObjectHandle, retV.begin(), retV.end());
   filler.fill();
   iEvent.put(std::move(isoMap));
-
 }
 
 //define this as a plug-in

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaTowerIsolationProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaTowerIsolationProducer.h
@@ -12,7 +12,6 @@
 // -*- C++ -*-
 //
 
-
 // system include files
 #include <memory>
 
@@ -32,14 +31,14 @@
 //
 
 class EgammaTowerIsolationProducer : public edm::stream::EDProducer<> {
-   public:
-      explicit EgammaTowerIsolationProducer(const edm::ParameterSet&);
-      ~EgammaTowerIsolationProducer() override;
+public:
+  explicit EgammaTowerIsolationProducer(const edm::ParameterSet&);
+  ~EgammaTowerIsolationProducer() override;
 
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-      void produce(edm::Event&, const edm::EventSetup&) override;
-   private:
-      // ----------member data ---------------------------
+private:
+  // ----------member data ---------------------------
 
   edm::InputTag emObjectProducer_;
   edm::InputTag towerProducer_;
@@ -50,7 +49,6 @@ class EgammaTowerIsolationProducer : public edm::stream::EDProducer<> {
   signed int egHcalDepth_;
 
   edm::ParameterSet conf_;
-
 };
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaTrackExtractor.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaTrackExtractor.cc
@@ -25,125 +25,146 @@ using namespace reco;
 using namespace egammaisolation;
 using reco::isodeposit::Direction;
 
-EgammaTrackExtractor::EgammaTrackExtractor( const ParameterSet& par, edm::ConsumesCollector & iC ) :
-    theTrackCollectionToken(iC.consumes<View<Track> >(par.getParameter<edm::InputTag>("inputTrackCollection"))),
-    theDepositLabel(par.getUntrackedParameter<std::string>("DepositLabel")),
-    theDiff_r(par.getParameter<double>("Diff_r")),
-    theDiff_z(par.getParameter<double>("Diff_z")),
-    theDR_Max(par.getParameter<double>("DR_Max")),
-    theDR_Veto(par.getParameter<double>("DR_Veto")),
-    theBeamlineOption(par.getParameter<std::string>("BeamlineOption")),
-    theBeamSpotToken(iC.mayConsume<reco::BeamSpot>(par.getParameter<edm::InputTag>("BeamSpotLabel"))),
-    theNHits_Min(par.getParameter<unsigned int>("NHits_Min")),
-    theChi2Ndof_Max(par.getParameter<double>("Chi2Ndof_Max")),
-    theChi2Prob_Min(par.getParameter<double>("Chi2Prob_Min")),
-    thePt_Min(par.getParameter<double>("Pt_Min")),
-    dzOptionString(par.getParameter<std::string>("dzOption"))
-{
-    if( ! dzOptionString.compare("dz") )      dzOption = EgammaTrackSelector::dz;
-    else if( ! dzOptionString.compare("vz") ) dzOption = EgammaTrackSelector::vz;
-    else if( ! dzOptionString.compare("bs") ) dzOption = EgammaTrackSelector::bs;
-    else if( ! dzOptionString.compare("vtx") )dzOption = EgammaTrackSelector::vtx;
-    else                                      dzOption = EgammaTrackSelector::dz;
-
+EgammaTrackExtractor::EgammaTrackExtractor(const ParameterSet& par, edm::ConsumesCollector& iC)
+    : theTrackCollectionToken(iC.consumes<View<Track> >(par.getParameter<edm::InputTag>("inputTrackCollection"))),
+      theDepositLabel(par.getUntrackedParameter<std::string>("DepositLabel")),
+      theDiff_r(par.getParameter<double>("Diff_r")),
+      theDiff_z(par.getParameter<double>("Diff_z")),
+      theDR_Max(par.getParameter<double>("DR_Max")),
+      theDR_Veto(par.getParameter<double>("DR_Veto")),
+      theBeamlineOption(par.getParameter<std::string>("BeamlineOption")),
+      theBeamSpotToken(iC.mayConsume<reco::BeamSpot>(par.getParameter<edm::InputTag>("BeamSpotLabel"))),
+      theNHits_Min(par.getParameter<unsigned int>("NHits_Min")),
+      theChi2Ndof_Max(par.getParameter<double>("Chi2Ndof_Max")),
+      theChi2Prob_Min(par.getParameter<double>("Chi2Prob_Min")),
+      thePt_Min(par.getParameter<double>("Pt_Min")),
+      dzOptionString(par.getParameter<std::string>("dzOption")) {
+  if (!dzOptionString.compare("dz"))
+    dzOption = EgammaTrackSelector::dz;
+  else if (!dzOptionString.compare("vz"))
+    dzOption = EgammaTrackSelector::vz;
+  else if (!dzOptionString.compare("bs"))
+    dzOption = EgammaTrackSelector::bs;
+  else if (!dzOptionString.compare("vtx"))
+    dzOption = EgammaTrackSelector::vtx;
+  else
+    dzOption = EgammaTrackSelector::dz;
 }
 
-reco::IsoDeposit::Vetos EgammaTrackExtractor::vetos(const edm::Event & ev,
-        const edm::EventSetup & evSetup, const reco::Track & track) const
-{
-    reco::isodeposit::Direction dir(track.eta(),track.phi());
-    return reco::IsoDeposit::Vetos(1,veto(dir));
+reco::IsoDeposit::Vetos EgammaTrackExtractor::vetos(const edm::Event& ev,
+                                                    const edm::EventSetup& evSetup,
+                                                    const reco::Track& track) const {
+  reco::isodeposit::Direction dir(track.eta(), track.phi());
+  return reco::IsoDeposit::Vetos(1, veto(dir));
 }
 
-reco::IsoDeposit::Veto EgammaTrackExtractor::veto(const reco::IsoDeposit::Direction & dir) const
-{
-    reco::IsoDeposit::Veto result;
-    result.vetoDir = dir;
-    result.dR = theDR_Veto;
-    return result;
+reco::IsoDeposit::Veto EgammaTrackExtractor::veto(const reco::IsoDeposit::Direction& dir) const {
+  reco::IsoDeposit::Veto result;
+  result.vetoDir = dir;
+  result.dR = theDR_Veto;
+  return result;
 }
 
-IsoDeposit EgammaTrackExtractor::deposit(const Event & event, const EventSetup & eventSetup, const Candidate & candTk) const
-{
-    static const std::string metname = "EgammaIsolationAlgos|EgammaTrackExtractor";
+IsoDeposit EgammaTrackExtractor::deposit(const Event& event,
+                                         const EventSetup& eventSetup,
+                                         const Candidate& candTk) const {
+  static const std::string metname = "EgammaIsolationAlgos|EgammaTrackExtractor";
 
-    reco::isodeposit::Direction candDir;
-    double dzCut=0;
+  reco::isodeposit::Direction candDir;
+  double dzCut = 0;
 
-    reco::TrackBase::Point beamPoint(0,0, 0);
-    if (theBeamlineOption == "BeamSpotFromEvent"){
-        //pick beamSpot
-        reco::BeamSpot beamSpot;
-        edm::Handle<reco::BeamSpot> beamSpotH;
+  reco::TrackBase::Point beamPoint(0, 0, 0);
+  if (theBeamlineOption == "BeamSpotFromEvent") {
+    //pick beamSpot
+    reco::BeamSpot beamSpot;
+    edm::Handle<reco::BeamSpot> beamSpotH;
 
-        event.getByToken(theBeamSpotToken,beamSpotH);
+    event.getByToken(theBeamSpotToken, beamSpotH);
 
-        if (beamSpotH.isValid()){
-            beamPoint = beamSpotH->position();
-        }
+    if (beamSpotH.isValid()) {
+      beamPoint = beamSpotH->position();
     }
+  }
 
-    Handle<View<Track> > tracksH;
-    event.getByToken(theTrackCollectionToken, tracksH);
+  Handle<View<Track> > tracksH;
+  event.getByToken(theTrackCollectionToken, tracksH);
 
-    if( candTk.isElectron() ){
-        const reco::GsfElectron* elec = dynamic_cast<const reco::GsfElectron*>(&candTk);
-        candDir = reco::isodeposit::Direction(elec->gsfTrack()->eta(), elec->gsfTrack()->phi());
+  if (candTk.isElectron()) {
+    const reco::GsfElectron* elec = dynamic_cast<const reco::GsfElectron*>(&candTk);
+    candDir = reco::isodeposit::Direction(elec->gsfTrack()->eta(), elec->gsfTrack()->phi());
+  } else {
+    candDir = reco::isodeposit::Direction(candTk.eta(), candTk.phi());
+  }
+
+  IsoDeposit deposit(candDir);
+  deposit.setVeto(veto(candDir));
+  deposit.addCandEnergy(candTk.et());
+
+  View<Track>::const_iterator itrTr = tracksH->begin();
+  View<Track>::const_iterator trEnd = tracksH->end();
+  for (itrTr = tracksH->begin(); itrTr != trEnd; ++itrTr) {
+    if (candDir.deltaR(reco::isodeposit::Direction(itrTr->eta(), itrTr->phi())) > theDR_Max)
+      continue;
+
+    if (itrTr->normalizedChi2() > theChi2Ndof_Max)
+      continue;
+
+    if (itrTr->pt() < thePt_Min)
+      continue;
+
+    if (theChi2Prob_Min > 0 && ChiSquaredProbability(itrTr->chi2(), itrTr->ndof()) < theChi2Prob_Min)
+      continue;
+
+    if (theNHits_Min > 0 && itrTr->numberOfValidHits() < theNHits_Min)
+      continue;
+
+    if (candTk.isElectron()) {
+      const reco::GsfElectron* elec = dynamic_cast<const reco::GsfElectron*>(&candTk);
+      switch (dzOption) {
+        case EgammaTrackSelector::dz:
+          dzCut = elec->gsfTrack()->dz() - itrTr->dz();
+          break;
+        case EgammaTrackSelector::vz:
+          dzCut = elec->gsfTrack()->vz() - itrTr->vz();
+          break;
+        case EgammaTrackSelector::bs:
+          dzCut = elec->gsfTrack()->dz(beamPoint) - itrTr->dz(beamPoint);
+          break;
+        case EgammaTrackSelector::vtx:
+          dzCut = itrTr->dz(elec->gsfTrack()->vertex());
+          break;
+        default:
+          dzCut = elec->gsfTrack()->vz() - itrTr->vz();
+          break;
+      }
     } else {
-        candDir = reco::isodeposit::Direction(candTk.eta(), candTk.phi());
+      switch (dzOption) {
+        case EgammaTrackSelector::dz:
+          dzCut = (*itrTr).dz() - candTk.vertex().z();
+          break;
+        case EgammaTrackSelector::vz:
+          dzCut = (*itrTr).vz() - candTk.vertex().z();
+          break;
+        case EgammaTrackSelector::bs:
+          dzCut = (*itrTr).dz(beamPoint) - candTk.vertex().z();
+          break;
+        case EgammaTrackSelector::vtx:
+          dzCut = (*itrTr).dz(candTk.vertex());
+          break;
+        default:
+          dzCut = (*itrTr).vz() - candTk.vertex().z();
+          break;
+      }
     }
 
-    IsoDeposit deposit(candDir );
-    deposit.setVeto( veto(candDir) );
-    deposit.addCandEnergy(candTk.et());
+    if (fabs(dzCut) > theDiff_z)
+      continue;
 
-    View<Track>::const_iterator itrTr = tracksH->begin();
-    View<Track>::const_iterator trEnd = tracksH->end();
-    for (itrTr = tracksH->begin();itrTr != trEnd; ++itrTr) {
+    if (fabs(itrTr->dxy(beamPoint)) > theDiff_r)
+      continue;
 
-        if(candDir.deltaR( reco::isodeposit::Direction(itrTr->eta(),itrTr->phi()) ) > theDR_Max )
-            continue;
+    deposit.addDeposit(reco::isodeposit::Direction(itrTr->eta(), itrTr->phi()), itrTr->pt());
+  }
 
-        if(itrTr->normalizedChi2() > theChi2Ndof_Max)
-            continue;
-
-        if(itrTr->pt() < thePt_Min)
-            continue;
-
-        if(theChi2Prob_Min > 0 && ChiSquaredProbability(itrTr->chi2(), itrTr->ndof()) < theChi2Prob_Min )
-            continue;
-
-        if(theNHits_Min > 0 && itrTr->numberOfValidHits() < theNHits_Min)
-            continue;
-
-        if( candTk.isElectron() ){
-            const reco::GsfElectron* elec = dynamic_cast<const reco::GsfElectron*>(&candTk);
-            switch(dzOption) {
-                case EgammaTrackSelector::dz : dzCut = elec->gsfTrack()->dz() - itrTr->dz() ; break;
-                case EgammaTrackSelector::vz : dzCut = elec->gsfTrack()->vz() - itrTr->vz() ; break;
-                case EgammaTrackSelector::bs : dzCut = elec->gsfTrack()->dz(beamPoint) - itrTr->dz(beamPoint) ; break;
-                case EgammaTrackSelector::vtx: dzCut = itrTr->dz(elec->gsfTrack()->vertex()) ; break;
-                default: dzCut = elec->gsfTrack()->vz() - itrTr->vz() ; break;
-            }
-        } else {
-            switch(dzOption) {
-                case EgammaTrackSelector::dz : dzCut = (*itrTr).dz() - candTk.vertex().z() ; break;
-                case EgammaTrackSelector::vz : dzCut = (*itrTr).vz() - candTk.vertex().z() ; break;
-                case EgammaTrackSelector::bs : dzCut = (*itrTr).dz(beamPoint) - candTk.vertex().z() ; break;
-                case EgammaTrackSelector::vtx: dzCut = (*itrTr).dz(candTk.vertex()); break;
-                default : dzCut = (*itrTr).vz() - candTk.vertex().z(); break;
-            }
-        }
-
-        if(fabs(dzCut) > theDiff_z)
-            continue;
-
-        if(fabs(itrTr->dxy(beamPoint) ) > theDiff_r)
-            continue;
-
-        deposit.addDeposit(reco::isodeposit::Direction(itrTr->eta(), itrTr->phi()), itrTr->pt());
-
-    }
-
-    return deposit;
+  return deposit;
 }

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaTrackExtractor.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EgammaTrackExtractor.h
@@ -4,7 +4,6 @@
 #include <string>
 #include <vector>
 
-
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/RecoCandidate/interface/IsoDeposit.h"
@@ -16,58 +15,58 @@
 
 namespace egammaisolation {
 
-class EgammaTrackExtractor : public reco::isodeposit::IsoDepositExtractor {
+  class EgammaTrackExtractor : public reco::isodeposit::IsoDepositExtractor {
+  public:
+    EgammaTrackExtractor(){};
+    EgammaTrackExtractor(const edm::ParameterSet& par, edm::ConsumesCollector&& iC) : EgammaTrackExtractor(par, iC) {}
+    EgammaTrackExtractor(const edm::ParameterSet& par, edm::ConsumesCollector& iC);
 
-public:
+    ~EgammaTrackExtractor() override {}
 
-  EgammaTrackExtractor(){};
-  EgammaTrackExtractor(const edm::ParameterSet& par, edm::ConsumesCollector && iC) :
-    EgammaTrackExtractor(par, iC) {}
-  EgammaTrackExtractor(const edm::ParameterSet& par, edm::ConsumesCollector & iC);
+    void fillVetos(const edm::Event& ev, const edm::EventSetup& evSetup, const reco::TrackCollection& track) override {}
 
-  ~EgammaTrackExtractor() override{}
+    virtual reco::IsoDeposit::Vetos vetos(const edm::Event& ev,
+                                          const edm::EventSetup& evSetup,
+                                          const reco::Track& track) const;
 
-  void fillVetos (const edm::Event & ev,
-      const edm::EventSetup & evSetup, const reco::TrackCollection & track) override {}
+    reco::IsoDeposit deposit(const edm::Event& ev,
+                             const edm::EventSetup& evSetup,
+                             const reco::Track& muon) const override {
+      edm::LogWarning("EgammaIsolationAlgos|EgammaTrackExtractor")
+          << "This Function is not implemented, bad IsoDeposit Returned";
+      return reco::IsoDeposit(reco::isodeposit::Direction(1, 1));
+    }
 
-  virtual reco::IsoDeposit::Vetos vetos(const edm::Event & ev,
-      const edm::EventSetup & evSetup, const reco::Track & track)const;
+    reco::IsoDeposit deposit(const edm::Event& ev,
+                             const edm::EventSetup& evSetup,
+                             const reco::Candidate& muon) const override;
 
-  reco::IsoDeposit deposit (const edm::Event & ev,
-      const edm::EventSetup & evSetup, const reco::Track & muon) const override {
-        edm::LogWarning("EgammaIsolationAlgos|EgammaTrackExtractor")
-           << "This Function is not implemented, bad IsoDeposit Returned";
-        return reco::IsoDeposit( reco::isodeposit::Direction(1,1) );
-      }
+  private:
+    reco::IsoDeposit::Veto veto(const reco::IsoDeposit::Direction& dir) const;
 
-  reco::IsoDeposit deposit (const edm::Event & ev,
-      const edm::EventSetup & evSetup, const reco::Candidate & muon) const override;
+  private:
+    // Parameter set
+    edm::EDGetTokenT<edm::View<reco::Track> > theTrackCollectionToken;  //! Track Collection Label
+    std::string theDepositLabel;                                        //! name for deposit
+    double minCandEt_;                                                  //! minimum candidate et
+    double theDiff_r;                                                   //! transverse distance to vertex
+    double theDiff_z;                                                   //! z distance to vertex
+    double theDR_Max;                                                   //! Maximum cone angle for deposits
+    double theDR_Veto;                                                  //! Veto cone angle
+    std::string theBeamlineOption;                                      //! "NONE", "BeamSpotFromEvent"
+    edm::InputTag barrelEcalHitsTag_;
+    edm::InputTag endcapEcalHitsTag_;
+    edm::EDGetTokenT<reco::BeamSpot> theBeamSpotToken;  //! BeamSpot name
+    unsigned int theNHits_Min;                          //! trk.numberOfValidHits >= theNHits_Min
+    double theChi2Ndof_Max;                             //! trk.normalizedChi2 < theChi2Ndof_Max
+    double theChi2Prob_Min;                             //! ChiSquaredProbability(trk.chi2,trk.ndof) > theChi2Prob_Min
+    double thePt_Min;                                   //! min track pt to include into iso deposit
+    std::vector<double> paramForIsolBarrel_;  //! Barrel requirements to determine if isolated for selective filling
+    std::vector<double> paramForIsolEndcap_;  //! Endcap requirements to determine if isolated for selective filling
+    std::string dzOptionString;
+    int dzOption;
+  };
 
-private:
-  reco::IsoDeposit::Veto veto( const reco::IsoDeposit::Direction & dir) const;
-private:
-  // Parameter set
-  edm::EDGetTokenT<edm::View<reco::Track> > theTrackCollectionToken;      //! Track Collection Label
-  std::string theDepositLabel;              //! name for deposit
-  double minCandEt_;                         //! minimum candidate et
-  double theDiff_r;                         //! transverse distance to vertex
-  double theDiff_z;                         //! z distance to vertex
-  double theDR_Max;                         //! Maximum cone angle for deposits
-  double theDR_Veto;                        //! Veto cone angle
-  std::string theBeamlineOption;            //! "NONE", "BeamSpotFromEvent"
-  edm::InputTag barrelEcalHitsTag_;
-  edm::InputTag endcapEcalHitsTag_;
-  edm::EDGetTokenT<reco::BeamSpot> theBeamSpotToken;           //! BeamSpot name
-  unsigned int theNHits_Min;                        //! trk.numberOfValidHits >= theNHits_Min
-  double theChi2Ndof_Max;                   //! trk.normalizedChi2 < theChi2Ndof_Max
-  double theChi2Prob_Min;                   //! ChiSquaredProbability(trk.chi2,trk.ndof) > theChi2Prob_Min
-  double thePt_Min;                         //! min track pt to include into iso deposit
-  std::vector<double> paramForIsolBarrel_;   //! Barrel requirements to determine if isolated for selective filling
-  std::vector<double> paramForIsolEndcap_;   //! Endcap requirements to determine if isolated for selective filling
-  std::string dzOptionString;
-  int dzOption;
-};
-
-}
+}  // namespace egammaisolation
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EleIsoDetIdCollectionProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EleIsoDetIdCollectionProducer.cc
@@ -28,146 +28,137 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h"
 
-EleIsoDetIdCollectionProducer::EleIsoDetIdCollectionProducer(const edm::ParameterSet& iConfig) :
-            recHitsToken_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag > ("recHitsLabel"))),
-	    emObjectToken_(consumes<reco::GsfElectronCollection>(iConfig.getParameter< edm::InputTag > ("emObjectLabel"))),
-	    recHitsLabel_(iConfig.getParameter< edm::InputTag > ("recHitsLabel")),
-	    emObjectLabel_(iConfig.getParameter< edm::InputTag > ("emObjectLabel")),
-            energyCut_(iConfig.getParameter<double>("energyCut")),
-            etCut_(iConfig.getParameter<double>("etCut")),
-            etCandCut_(iConfig.getParameter<double> ("etCandCut")),
-            outerRadius_(iConfig.getParameter<double>("outerRadius")),
-            innerRadius_(iConfig.getParameter<double>("innerRadius")),
-            interestingDetIdCollection_(iConfig.getParameter<std::string>("interestingDetIdCollection"))
- {
+EleIsoDetIdCollectionProducer::EleIsoDetIdCollectionProducer(const edm::ParameterSet& iConfig)
+    : recHitsToken_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitsLabel"))),
+      emObjectToken_(consumes<reco::GsfElectronCollection>(iConfig.getParameter<edm::InputTag>("emObjectLabel"))),
+      recHitsLabel_(iConfig.getParameter<edm::InputTag>("recHitsLabel")),
+      emObjectLabel_(iConfig.getParameter<edm::InputTag>("emObjectLabel")),
+      energyCut_(iConfig.getParameter<double>("energyCut")),
+      etCut_(iConfig.getParameter<double>("etCut")),
+      etCandCut_(iConfig.getParameter<double>("etCandCut")),
+      outerRadius_(iConfig.getParameter<double>("outerRadius")),
+      innerRadius_(iConfig.getParameter<double>("innerRadius")),
+      interestingDetIdCollection_(iConfig.getParameter<std::string>("interestingDetIdCollection")) {
+  const std::vector<std::string> flagnamesEB =
+      iConfig.getParameter<std::vector<std::string> >("RecHitFlagToBeExcludedEB");
 
-   const std::vector<std::string> flagnamesEB = 
-     iConfig.getParameter<std::vector<std::string> >("RecHitFlagToBeExcludedEB");
-   
-   const std::vector<std::string> flagnamesEE =
-     iConfig.getParameter<std::vector<std::string> >("RecHitFlagToBeExcludedEE");
-   
-   flagsexclEB_= 
-     StringToEnumValue<EcalRecHit::Flags>(flagnamesEB);
-   
-   flagsexclEE_=
-     StringToEnumValue<EcalRecHit::Flags>(flagnamesEE);
-   
-   const std::vector<std::string> severitynamesEB = 
-     iConfig.getParameter<std::vector<std::string> >("RecHitSeverityToBeExcludedEB");
-   
-   severitiesexclEB_= 
-     StringToEnumValue<EcalSeverityLevel::SeverityLevel>(severitynamesEB);
+  const std::vector<std::string> flagnamesEE =
+      iConfig.getParameter<std::vector<std::string> >("RecHitFlagToBeExcludedEE");
 
-   const std::vector<std::string> severitynamesEE = 
-     iConfig.getParameter<std::vector<std::string> >("RecHitSeverityToBeExcludedEE");
-   
-   severitiesexclEE_= 
-     StringToEnumValue<EcalSeverityLevel::SeverityLevel>(severitynamesEE);
-   
-   //register your products
-   produces< DetIdCollection > (interestingDetIdCollection_) ;
+  flagsexclEB_ = StringToEnumValue<EcalRecHit::Flags>(flagnamesEB);
+
+  flagsexclEE_ = StringToEnumValue<EcalRecHit::Flags>(flagnamesEE);
+
+  const std::vector<std::string> severitynamesEB =
+      iConfig.getParameter<std::vector<std::string> >("RecHitSeverityToBeExcludedEB");
+
+  severitiesexclEB_ = StringToEnumValue<EcalSeverityLevel::SeverityLevel>(severitynamesEB);
+
+  const std::vector<std::string> severitynamesEE =
+      iConfig.getParameter<std::vector<std::string> >("RecHitSeverityToBeExcludedEE");
+
+  severitiesexclEE_ = StringToEnumValue<EcalSeverityLevel::SeverityLevel>(severitynamesEE);
+
+  //register your products
+  produces<DetIdCollection>(interestingDetIdCollection_);
 }
 
-EleIsoDetIdCollectionProducer::~EleIsoDetIdCollectionProducer() 
-{}
+EleIsoDetIdCollectionProducer::~EleIsoDetIdCollectionProducer() {}
 
-void EleIsoDetIdCollectionProducer::beginJob () 
-{}
+void EleIsoDetIdCollectionProducer::beginJob() {}
 
 // ------------ method called to produce the data  ------------
-    void
-EleIsoDetIdCollectionProducer::produce (edm::Event& iEvent, const edm::EventSetup& iSetup) {
-    using namespace edm;
-    using namespace std;
+void EleIsoDetIdCollectionProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  using namespace std;
 
-    //Get EM Object
-    Handle<reco::GsfElectronCollection> emObjectH;
-    iEvent.getByToken(emObjectToken_,emObjectH);
+  //Get EM Object
+  Handle<reco::GsfElectronCollection> emObjectH;
+  iEvent.getByToken(emObjectToken_, emObjectH);
 
-    // take EcalRecHits
-    Handle<EcalRecHitCollection> recHitsH;
-    iEvent.getByToken(recHitsToken_,recHitsH);
+  // take EcalRecHits
+  Handle<EcalRecHitCollection> recHitsH;
+  iEvent.getByToken(recHitsToken_, recHitsH);
 
-    edm::ESHandle<CaloGeometry> pG;
-    iSetup.get<CaloGeometryRecord>().get(pG);    
-    const CaloGeometry* caloGeom = pG.product();
+  edm::ESHandle<CaloGeometry> pG;
+  iSetup.get<CaloGeometryRecord>().get(pG);
+  const CaloGeometry* caloGeom = pG.product();
 
-    //Get the channel status from the db
-    //edm::ESHandle<EcalChannelStatus> chStatus;
-    //iSetup.get<EcalChannelStatusRcd>().get(chStatus);
+  //Get the channel status from the db
+  //edm::ESHandle<EcalChannelStatus> chStatus;
+  //iSetup.get<EcalChannelStatusRcd>().get(chStatus);
 
-    edm::ESHandle<EcalSeverityLevelAlgo> sevlv;
-    iSetup.get<EcalSeverityLevelAlgoRcd>().get(sevlv);
-    const EcalSeverityLevelAlgo* sevLevel = sevlv.product();
+  edm::ESHandle<EcalSeverityLevelAlgo> sevlv;
+  iSetup.get<EcalSeverityLevelAlgoRcd>().get(sevlv);
+  const EcalSeverityLevelAlgo* sevLevel = sevlv.product();
 
-    CaloDualConeSelector<EcalRecHit> *doubleConeSel_ = nullptr;
-    if(recHitsLabel_.instance() == "EcalRecHitsEB")
-        doubleConeSel_= new CaloDualConeSelector<EcalRecHit>(innerRadius_,outerRadius_, &*pG, DetId::Ecal, EcalBarrel);
-    else if(recHitsLabel_.instance() == "EcalRecHitsEE")
-        doubleConeSel_= new CaloDualConeSelector<EcalRecHit>(innerRadius_,outerRadius_, &*pG, DetId::Ecal, EcalEndcap);
+  CaloDualConeSelector<EcalRecHit>* doubleConeSel_ = nullptr;
+  if (recHitsLabel_.instance() == "EcalRecHitsEB")
+    doubleConeSel_ = new CaloDualConeSelector<EcalRecHit>(innerRadius_, outerRadius_, &*pG, DetId::Ecal, EcalBarrel);
+  else if (recHitsLabel_.instance() == "EcalRecHitsEE")
+    doubleConeSel_ = new CaloDualConeSelector<EcalRecHit>(innerRadius_, outerRadius_, &*pG, DetId::Ecal, EcalEndcap);
 
-    //Create empty output collections
-    auto detIdCollection = std::make_unique<DetIdCollection>();
+  //Create empty output collections
+  auto detIdCollection = std::make_unique<DetIdCollection>();
 
-    reco::GsfElectronCollection::const_iterator emObj;
-    if(doubleConeSel_) { //if cone selector was created
-        for (emObj = emObjectH->begin(); emObj != emObjectH->end();  emObj++) { //Loop over candidates
+  reco::GsfElectronCollection::const_iterator emObj;
+  if (doubleConeSel_) {                                                     //if cone selector was created
+    for (emObj = emObjectH->begin(); emObj != emObjectH->end(); emObj++) {  //Loop over candidates
 
-            if(emObj->et() < etCandCut_) continue; //don't calculate if object hasn't enough energy
-            
-            GlobalPoint pclu (emObj->caloPosition().x(),emObj->caloPosition().y(),emObj->caloPosition().z());
-            doubleConeSel_->selectCallback(pclu, *recHitsH, [&](const EcalRecHit& recIt) {
-              if (recIt.energy() < energyCut_) 
-                return;  //dont fill if below E noise value
+      if (emObj->et() < etCandCut_)
+        continue;  //don't calculate if object hasn't enough energy
 
-              double et = recIt.energy() * 
-                caloGeom->getPosition(recIt.detid()).perp() / 
-                caloGeom->getPosition(recIt.detid()).mag();
+      GlobalPoint pclu(emObj->caloPosition().x(), emObj->caloPosition().y(), emObj->caloPosition().z());
+      doubleConeSel_->selectCallback(pclu, *recHitsH, [&](const EcalRecHit& recIt) {
+        if (recIt.energy() < energyCut_)
+          return;  //dont fill if below E noise value
 
-              bool isBarrel = false;
-              if (fabs(caloGeom->getPosition(recIt.detid()).eta() < 1.479)) 
-                isBarrel = true;
-              
-              if (et < etCut_) 
-                return;  //dont fill if below ET noise value
+        double et =
+            recIt.energy() * caloGeom->getPosition(recIt.detid()).perp() / caloGeom->getPosition(recIt.detid()).mag();
 
-              std::vector<int>::const_iterator sit;
-              int severityFlag = sevLevel->severityLevel(recIt.detid(), *recHitsH);
-              if (isBarrel) {
-                sit = std::find(severitiesexclEB_.begin(), severitiesexclEB_.end(), severityFlag);
-                if (sit != severitiesexclEB_.end())
-                  return;
-              } else {
-                sit = std::find(severitiesexclEE_.begin(), severitiesexclEE_.end(), severityFlag);
-                if (sit != severitiesexclEE_.end())
-                  return;
-              }
+        bool isBarrel = false;
+        if (fabs(caloGeom->getPosition(recIt.detid()).eta() < 1.479))
+          isBarrel = true;
 
-              if (isBarrel) {
-                // new rechit flag checks
-                if (!(recIt.checkFlag(EcalRecHit::kGood))) {
-                  if (recIt.checkFlags(flagsexclEB_)) {                
-                    return;
-                  }
-                }
-              } else {
-                // new rechit flag checks
-                if (!(recIt.checkFlag(EcalRecHit::kGood))) {
-                  if (recIt.checkFlags(flagsexclEE_)) {                
-                    return;
-                  }
-                }
-              }
+        if (et < etCut_)
+          return;  //dont fill if below ET noise value
 
-              if (std::find(detIdCollection->begin(),detIdCollection->end(),recIt.detid()) == detIdCollection->end()) 
-                detIdCollection->push_back(recIt.detid()); 
-            }); //end rechits
-            
-        } //end candidates
-        
-        delete doubleConeSel_;
-    } //end if cone selector was created
-    
-    iEvent.put(std::move(detIdCollection), interestingDetIdCollection_ );
+        std::vector<int>::const_iterator sit;
+        int severityFlag = sevLevel->severityLevel(recIt.detid(), *recHitsH);
+        if (isBarrel) {
+          sit = std::find(severitiesexclEB_.begin(), severitiesexclEB_.end(), severityFlag);
+          if (sit != severitiesexclEB_.end())
+            return;
+        } else {
+          sit = std::find(severitiesexclEE_.begin(), severitiesexclEE_.end(), severityFlag);
+          if (sit != severitiesexclEE_.end())
+            return;
+        }
+
+        if (isBarrel) {
+          // new rechit flag checks
+          if (!(recIt.checkFlag(EcalRecHit::kGood))) {
+            if (recIt.checkFlags(flagsexclEB_)) {
+              return;
+            }
+          }
+        } else {
+          // new rechit flag checks
+          if (!(recIt.checkFlag(EcalRecHit::kGood))) {
+            if (recIt.checkFlags(flagsexclEE_)) {
+              return;
+            }
+          }
+        }
+
+        if (std::find(detIdCollection->begin(), detIdCollection->end(), recIt.detid()) == detIdCollection->end())
+          detIdCollection->push_back(recIt.detid());
+      });  //end rechits
+
+    }  //end candidates
+
+    delete doubleConeSel_;
+  }  //end if cone selector was created
+
+  iEvent.put(std::move(detIdCollection), interestingDetIdCollection_);
 }

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/EleIsoDetIdCollectionProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/EleIsoDetIdCollectionProducer.h
@@ -5,7 +5,7 @@
 //
 // Package:    EleIsoDetIdCollectionProducer
 // Class:      EleIsoDetIdCollectionProducer
-// 
+//
 /**\class EleIsoDetIdCollectionProducer 
 Original author: Matthew LeBourgeois PH/CMG
 Modified from :
@@ -15,8 +15,6 @@ by Paolo Meridiani PH/CMG
 Implementation:
  <Notes on implementation>
 */
-
-
 
 // system include files
 #include <memory>
@@ -32,31 +30,31 @@ Implementation:
 class CaloTopology;
 
 class EleIsoDetIdCollectionProducer : public edm::stream::EDProducer<> {
-   public:
-      //! ctor
-      explicit EleIsoDetIdCollectionProducer(const edm::ParameterSet&);
-      ~EleIsoDetIdCollectionProducer() override;
-      void beginJob ();
-      //! producer
-      void produce(edm::Event &, const edm::EventSetup&) override;
+public:
+  //! ctor
+  explicit EleIsoDetIdCollectionProducer(const edm::ParameterSet &);
+  ~EleIsoDetIdCollectionProducer() override;
+  void beginJob();
+  //! producer
+  void produce(edm::Event &, const edm::EventSetup &) override;
 
-   private:
-      // ----------member data ---------------------------
-      edm::EDGetToken recHitsToken_;
-      edm::EDGetToken emObjectToken_; 
-      edm::InputTag recHitsLabel_;
-      edm::InputTag emObjectLabel_;
-      double energyCut_;
-      double etCut_;
-      double etCandCut_;
-      double outerRadius_;
-      double innerRadius_;
-      std::string interestingDetIdCollection_;
+private:
+  // ----------member data ---------------------------
+  edm::EDGetToken recHitsToken_;
+  edm::EDGetToken emObjectToken_;
+  edm::InputTag recHitsLabel_;
+  edm::InputTag emObjectLabel_;
+  double energyCut_;
+  double etCut_;
+  double etCandCut_;
+  double outerRadius_;
+  double innerRadius_;
+  std::string interestingDetIdCollection_;
 
-      std::vector<int> severitiesexclEB_;
-      std::vector<int> severitiesexclEE_;
-      std::vector<int> flagsexclEB_;
-      std::vector<int> flagsexclEE_;
+  std::vector<int> severitiesexclEB_;
+  std::vector<int> severitiesexclEE_;
+  std::vector<int> flagsexclEB_;
+  std::vector<int> flagsexclEE_;
 };
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/GamIsoDetIdCollectionProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/GamIsoDetIdCollectionProducer.cc
@@ -28,145 +28,136 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h"
 
-GamIsoDetIdCollectionProducer::GamIsoDetIdCollectionProducer(const edm::ParameterSet& iConfig) :
-            recHitsToken_(consumes<EcalRecHitCollection>(iConfig.getParameter< edm::InputTag > ("recHitsLabel"))),
-	    emObjectToken_(consumes<reco::PhotonCollection>(iConfig.getParameter< edm::InputTag > ("emObjectLabel"))),
-	    //the labels are still used to decide if its endcap or barrel...
-            recHitsLabel_(iConfig.getParameter< edm::InputTag > ("recHitsLabel")),
-	    emObjectLabel_(iConfig.getParameter< edm::InputTag > ("emObjectLabel")),
-            energyCut_(iConfig.getParameter<double>("energyCut")),
-            etCut_(iConfig.getParameter<double>("etCut")),
-            etCandCut_(iConfig.getParameter<double> ("etCandCut")),
-            outerRadius_(iConfig.getParameter<double>("outerRadius")),
-            innerRadius_(iConfig.getParameter<double>("innerRadius")),
-            interestingDetIdCollection_(iConfig.getParameter<std::string>("interestingDetIdCollection"))
-   {
+GamIsoDetIdCollectionProducer::GamIsoDetIdCollectionProducer(const edm::ParameterSet& iConfig)
+    : recHitsToken_(consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitsLabel"))),
+      emObjectToken_(consumes<reco::PhotonCollection>(iConfig.getParameter<edm::InputTag>("emObjectLabel"))),
+      //the labels are still used to decide if its endcap or barrel...
+      recHitsLabel_(iConfig.getParameter<edm::InputTag>("recHitsLabel")),
+      emObjectLabel_(iConfig.getParameter<edm::InputTag>("emObjectLabel")),
+      energyCut_(iConfig.getParameter<double>("energyCut")),
+      etCut_(iConfig.getParameter<double>("etCut")),
+      etCandCut_(iConfig.getParameter<double>("etCandCut")),
+      outerRadius_(iConfig.getParameter<double>("outerRadius")),
+      innerRadius_(iConfig.getParameter<double>("innerRadius")),
+      interestingDetIdCollection_(iConfig.getParameter<std::string>("interestingDetIdCollection")) {
+  const std::vector<std::string> flagnamesEB =
+      iConfig.getParameter<std::vector<std::string> >("RecHitFlagToBeExcludedEB");
 
-     const std::vector<std::string> flagnamesEB = 
-       iConfig.getParameter<std::vector<std::string> >("RecHitFlagToBeExcludedEB");
-     
-     const std::vector<std::string> flagnamesEE =
-       iConfig.getParameter<std::vector<std::string> >("RecHitFlagToBeExcludedEE");
-     
-     flagsexclEB_= 
-       StringToEnumValue<EcalRecHit::Flags>(flagnamesEB);
-     
-     flagsexclEE_=
-       StringToEnumValue<EcalRecHit::Flags>(flagnamesEE);
-     
-     const std::vector<std::string> severitynamesEB = 
-       iConfig.getParameter<std::vector<std::string> >("RecHitSeverityToBeExcludedEB");
-     
-     severitiesexclEB_= 
-       StringToEnumValue<EcalSeverityLevel::SeverityLevel>(severitynamesEB);
+  const std::vector<std::string> flagnamesEE =
+      iConfig.getParameter<std::vector<std::string> >("RecHitFlagToBeExcludedEE");
 
-     const std::vector<std::string> severitynamesEE = 
-       iConfig.getParameter<std::vector<std::string> >("RecHitSeverityToBeExcludedEE");
-     
-     severitiesexclEE_= 
-       StringToEnumValue<EcalSeverityLevel::SeverityLevel>(severitynamesEE);
-     
-    //register your products
-    produces< DetIdCollection > (interestingDetIdCollection_) ;
+  flagsexclEB_ = StringToEnumValue<EcalRecHit::Flags>(flagnamesEB);
+
+  flagsexclEE_ = StringToEnumValue<EcalRecHit::Flags>(flagnamesEE);
+
+  const std::vector<std::string> severitynamesEB =
+      iConfig.getParameter<std::vector<std::string> >("RecHitSeverityToBeExcludedEB");
+
+  severitiesexclEB_ = StringToEnumValue<EcalSeverityLevel::SeverityLevel>(severitynamesEB);
+
+  const std::vector<std::string> severitynamesEE =
+      iConfig.getParameter<std::vector<std::string> >("RecHitSeverityToBeExcludedEE");
+
+  severitiesexclEE_ = StringToEnumValue<EcalSeverityLevel::SeverityLevel>(severitynamesEE);
+
+  //register your products
+  produces<DetIdCollection>(interestingDetIdCollection_);
 }
 
-GamIsoDetIdCollectionProducer::~GamIsoDetIdCollectionProducer() 
-{}
+GamIsoDetIdCollectionProducer::~GamIsoDetIdCollectionProducer() {}
 
-void GamIsoDetIdCollectionProducer::beginJob () 
-{}
+void GamIsoDetIdCollectionProducer::beginJob() {}
 
 // ------------ method called to produce the data  ------------
-    void
-GamIsoDetIdCollectionProducer::produce (edm::Event& iEvent, 
-        const edm::EventSetup& iSetup)
-{
-    using namespace edm;
-    using namespace std;
+void GamIsoDetIdCollectionProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  using namespace std;
 
-    //Get EM Object
-    Handle<reco::PhotonCollection> emObjectH;
-    iEvent.getByToken(emObjectToken_,emObjectH);
+  //Get EM Object
+  Handle<reco::PhotonCollection> emObjectH;
+  iEvent.getByToken(emObjectToken_, emObjectH);
 
-    // take EcalRecHits
-    Handle<EcalRecHitCollection> recHitsH;
-    iEvent.getByToken(recHitsToken_,recHitsH);
+  // take EcalRecHits
+  Handle<EcalRecHitCollection> recHitsH;
+  iEvent.getByToken(recHitsToken_, recHitsH);
 
-    edm::ESHandle<CaloGeometry> pG;
-    iSetup.get<CaloGeometryRecord>().get(pG);    
-    const CaloGeometry* caloGeom = pG.product();
+  edm::ESHandle<CaloGeometry> pG;
+  iSetup.get<CaloGeometryRecord>().get(pG);
+  const CaloGeometry* caloGeom = pG.product();
 
-    edm::ESHandle<EcalSeverityLevelAlgo> sevlv;
-    iSetup.get<EcalSeverityLevelAlgoRcd>().get(sevlv);
-    const EcalSeverityLevelAlgo* sevLevel = sevlv.product();
+  edm::ESHandle<EcalSeverityLevelAlgo> sevlv;
+  iSetup.get<EcalSeverityLevelAlgoRcd>().get(sevlv);
+  const EcalSeverityLevelAlgo* sevLevel = sevlv.product();
 
-    CaloDualConeSelector<EcalRecHit> *doubleConeSel_ = nullptr;
-    if(recHitsLabel_.instance() == "EcalRecHitsEB")
-        doubleConeSel_= new CaloDualConeSelector<EcalRecHit>(innerRadius_,outerRadius_, &*pG, DetId::Ecal, EcalBarrel);
-    else if(recHitsLabel_.instance() == "EcalRecHitsEE")
-        doubleConeSel_= new CaloDualConeSelector<EcalRecHit>(innerRadius_,outerRadius_, &*pG, DetId::Ecal, EcalEndcap);
+  CaloDualConeSelector<EcalRecHit>* doubleConeSel_ = nullptr;
+  if (recHitsLabel_.instance() == "EcalRecHitsEB")
+    doubleConeSel_ = new CaloDualConeSelector<EcalRecHit>(innerRadius_, outerRadius_, &*pG, DetId::Ecal, EcalBarrel);
+  else if (recHitsLabel_.instance() == "EcalRecHitsEE")
+    doubleConeSel_ = new CaloDualConeSelector<EcalRecHit>(innerRadius_, outerRadius_, &*pG, DetId::Ecal, EcalEndcap);
 
-    //Create empty output collections
-    auto detIdCollection = std::make_unique<DetIdCollection>();
+  //Create empty output collections
+  auto detIdCollection = std::make_unique<DetIdCollection>();
 
-    reco::PhotonCollection::const_iterator emObj;
-    if(doubleConeSel_) { //if cone selector was created
-        for (emObj = emObjectH->begin(); emObj != emObjectH->end();  emObj++) { //Loop over candidates
+  reco::PhotonCollection::const_iterator emObj;
+  if (doubleConeSel_) {                                                     //if cone selector was created
+    for (emObj = emObjectH->begin(); emObj != emObjectH->end(); emObj++) {  //Loop over candidates
 
-            if(emObj->et() < etCandCut_) continue;
-            
-            GlobalPoint pclu (emObj->caloPosition().x(),emObj->caloPosition().y(),emObj->caloPosition().z());
-            doubleConeSel_->selectCallback(pclu, *recHitsH, [&](const EcalRecHit& recHitRef) {
-                const EcalRecHit* recIt = &recHitRef;
+      if (emObj->et() < etCandCut_)
+        continue;
 
-                if ( (recIt->energy()) < energyCut_) return;  //dont fill if below E noise value
+      GlobalPoint pclu(emObj->caloPosition().x(), emObj->caloPosition().y(), emObj->caloPosition().z());
+      doubleConeSel_->selectCallback(pclu, *recHitsH, [&](const EcalRecHit& recHitRef) {
+        const EcalRecHit* recIt = &recHitRef;
 
-                double et = recIt->energy() *
-                            caloGeom->getPosition(recIt->detid()).perp() /
-                            caloGeom->getPosition(recIt->detid()).mag();
-                
-                if ( et < etCut_) return;  //dont fill if below ET noise value
+        if ((recIt->energy()) < energyCut_)
+          return;  //dont fill if below E noise value
 
-                bool isBarrel = false;
-                if (fabs(caloGeom->getPosition(recIt->detid()).eta() < 1.479)) 
-                  isBarrel = true;
+        double et = recIt->energy() * caloGeom->getPosition(recIt->detid()).perp() /
+                    caloGeom->getPosition(recIt->detid()).mag();
 
-                int severityFlag = sevLevel->severityLevel(recIt->detid(), *recHitsH);
-                std::vector<int>::const_iterator sit;
-                if (isBarrel) {
-                  sit = std::find(severitiesexclEB_.begin(), severitiesexclEB_.end(), severityFlag);
-                  if (sit!= severitiesexclEB_.end())
-                    return;
-                } else {
-                  sit = std::find(severitiesexclEE_.begin(), severitiesexclEE_.end(), severityFlag);
-                  if (sit!= severitiesexclEE_.end())
-                    return;
-                }
+        if (et < etCut_)
+          return;  //dont fill if below ET noise value
 
-                if (isBarrel) {
-                  // new rechit flag checks
-                  if (!recIt->checkFlag(EcalRecHit::kGood)) {
-                    if (recIt->checkFlags(flagsexclEB_)) {                
-                      return;
-                    }
-                  }
-                } else {
-                  // new rechit flag checks
-                  if (!recIt->checkFlag(EcalRecHit::kGood)) {
-                    if (recIt->checkFlags(flagsexclEE_)) {                
-                      return;
-                    }
-                  }
-                }
+        bool isBarrel = false;
+        if (fabs(caloGeom->getPosition(recIt->detid()).eta() < 1.479))
+          isBarrel = true;
 
-                if(std::find(detIdCollection->begin(),detIdCollection->end(),recIt->detid()) == detIdCollection->end()) 
-                    detIdCollection->push_back(recIt->detid());
-            }); //end rechits
+        int severityFlag = sevLevel->severityLevel(recIt->detid(), *recHitsH);
+        std::vector<int>::const_iterator sit;
+        if (isBarrel) {
+          sit = std::find(severitiesexclEB_.begin(), severitiesexclEB_.end(), severityFlag);
+          if (sit != severitiesexclEB_.end())
+            return;
+        } else {
+          sit = std::find(severitiesexclEE_.begin(), severitiesexclEE_.end(), severityFlag);
+          if (sit != severitiesexclEE_.end())
+            return;
+        }
 
-        } //end candidates
+        if (isBarrel) {
+          // new rechit flag checks
+          if (!recIt->checkFlag(EcalRecHit::kGood)) {
+            if (recIt->checkFlags(flagsexclEB_)) {
+              return;
+            }
+          }
+        } else {
+          // new rechit flag checks
+          if (!recIt->checkFlag(EcalRecHit::kGood)) {
+            if (recIt->checkFlags(flagsexclEE_)) {
+              return;
+            }
+          }
+        }
 
-        delete doubleConeSel_;
-    } //end if cone selector was created
-    
-    iEvent.put(std::move(detIdCollection), interestingDetIdCollection_ );
+        if (std::find(detIdCollection->begin(), detIdCollection->end(), recIt->detid()) == detIdCollection->end())
+          detIdCollection->push_back(recIt->detid());
+      });  //end rechits
+
+    }  //end candidates
+
+    delete doubleConeSel_;
+  }  //end if cone selector was created
+
+  iEvent.put(std::move(detIdCollection), interestingDetIdCollection_);
 }

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/GamIsoDetIdCollectionProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/GamIsoDetIdCollectionProducer.h
@@ -5,7 +5,7 @@
 //
 // Package:    GamIsoDetIdCollectionProducer
 // Class:      GamIsoDetIdCollectionProducer
-// 
+//
 /**\class GamIsoDetIdCollectionProducer 
 Original author: Matthew LeBourgeois PH/CMG
 Modified from :
@@ -15,8 +15,6 @@ by Paolo Meridiani PH/CMG
 Implementation:
  <Notes on implementation>
 */
-
-
 
 // system include files
 #include <memory>
@@ -37,33 +35,31 @@ Implementation:
 class CaloTopology;
 
 class GamIsoDetIdCollectionProducer : public edm::stream::EDProducer<> {
-   public:
-      //! ctor
-      explicit GamIsoDetIdCollectionProducer(const edm::ParameterSet&);
-      ~GamIsoDetIdCollectionProducer() override;
-      void beginJob ();
-      //! producer
-      void produce(edm::Event &, const edm::EventSetup&) override;
+public:
+  //! ctor
+  explicit GamIsoDetIdCollectionProducer(const edm::ParameterSet &);
+  ~GamIsoDetIdCollectionProducer() override;
+  void beginJob();
+  //! producer
+  void produce(edm::Event &, const edm::EventSetup &) override;
 
-   private:
-      // ----------member data ---------------------------
-      edm::EDGetTokenT<EcalRecHitCollection> recHitsToken_;
-      edm::EDGetTokenT<reco::PhotonCollection> emObjectToken_;
-      edm::InputTag recHitsLabel_;
-      edm::InputTag emObjectLabel_;
-      double energyCut_;
-      double etCut_;
-      double etCandCut_;
-      double outerRadius_;
-      double innerRadius_;
-      std::string interestingDetIdCollection_;
+private:
+  // ----------member data ---------------------------
+  edm::EDGetTokenT<EcalRecHitCollection> recHitsToken_;
+  edm::EDGetTokenT<reco::PhotonCollection> emObjectToken_;
+  edm::InputTag recHitsLabel_;
+  edm::InputTag emObjectLabel_;
+  double energyCut_;
+  double etCut_;
+  double etCandCut_;
+  double outerRadius_;
+  double innerRadius_;
+  std::string interestingDetIdCollection_;
 
-      std::vector<int> severitiesexclEB_;
-      std::vector<int> severitiesexclEE_;
-      std::vector<int> flagsexclEB_;
-      std::vector<int> flagsexclEE_;
+  std::vector<int> severitiesexclEB_;
+  std::vector<int> severitiesexclEE_;
+  std::vector<int> flagsexclEB_;
+  std::vector<int> flagsexclEE_;
 };
 
 #endif
-
-

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/ParticleBasedIsoProducer.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/ParticleBasedIsoProducer.cc
@@ -5,113 +5,88 @@
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 
-
-
 ParticleBasedIsoProducer::ParticleBasedIsoProducer(const edm::ParameterSet& conf) : conf_(conf) {
+  photonTmpProducer_ = conf_.getParameter<edm::InputTag>("photonTmpProducer");
+  photonProducer_ = conf_.getParameter<edm::InputTag>("photonProducer");
+  electronProducer_ = conf_.getParameter<edm::InputTag>("electronProducer");
+  electronTmpProducer_ = conf_.getParameter<edm::InputTag>("electronTmpProducer");
 
-  photonTmpProducer_       = conf_.getParameter<edm::InputTag>("photonTmpProducer");
-  photonProducer_       = conf_.getParameter<edm::InputTag>("photonProducer");
-  electronProducer_     = conf_.getParameter<edm::InputTag>("electronProducer");
-  electronTmpProducer_     = conf_.getParameter<edm::InputTag>("electronTmpProducer");
+  photonProducerT_ = consumes<reco::PhotonCollection>(photonProducer_);
 
-  photonProducerT_   = 
-    consumes<reco::PhotonCollection>(photonProducer_);
+  photonTmpProducerT_ = consumes<reco::PhotonCollection>(photonTmpProducer_);
 
+  electronProducerT_ = consumes<reco::GsfElectronCollection>(electronProducer_);
 
-  photonTmpProducerT_   = 
-    consumes<reco::PhotonCollection>(photonTmpProducer_);
+  electronTmpProducerT_ = consumes<reco::GsfElectronCollection>(electronTmpProducer_);
 
+  pfCandidates_ = consumes<reco::PFCandidateCollection>(conf_.getParameter<edm::InputTag>("pfCandidates"));
 
-  electronProducerT_   = 
-    consumes<reco::GsfElectronCollection>(electronProducer_);
+  pfEgammaCandidates_ = consumes<reco::PFCandidateCollection>(conf_.getParameter<edm::InputTag>("pfEgammaCandidates"));
 
-  electronTmpProducerT_   = 
-    consumes<reco::GsfElectronCollection>(electronTmpProducer_);
+  valueMapPFCandPhoton_ = conf_.getParameter<std::string>("valueMapPhoToEG");
+  valueMapPFCandEle_ = conf_.getParameter<std::string>("valueMapEleToEG");
 
-  pfCandidates_      = 
-    consumes<reco::PFCandidateCollection>(conf_.getParameter<edm::InputTag>("pfCandidates"));
-  
-  pfEgammaCandidates_      = 
-    consumes<reco::PFCandidateCollection>(conf_.getParameter<edm::InputTag>("pfEgammaCandidates"));
+  valMapPFCandToPhoton_ =
+      consumes<edm::ValueMap<reco::PhotonRef>>(edm::InputTag("gedPhotonsTmp", valueMapPFCandPhoton_));
 
-  valueMapPFCandPhoton_ = conf_.getParameter<std::string>("valueMapPhoToEG");  
-  valueMapPFCandEle_    = conf_.getParameter<std::string>("valueMapEleToEG");
-
-  valMapPFCandToPhoton_ = 
-    consumes<edm::ValueMap<reco::PhotonRef> >(edm::InputTag("gedPhotonsTmp",valueMapPFCandPhoton_));
-
-  valMapPFCandToEle_ = 
-    consumes<edm::ValueMap<reco::GsfElectronRef> >(edm::InputTag("gedGsfElectronsTmp",valueMapPFCandEle_));
+  valMapPFCandToEle_ =
+      consumes<edm::ValueMap<reco::GsfElectronRef>>(edm::InputTag("gedGsfElectronsTmp", valueMapPFCandEle_));
 
   valueMapPhoPFCandIso_ = conf_.getParameter<std::string>("valueMapPhoPFblockIso");
   valueMapElePFCandIso_ = conf_.getParameter<std::string>("valueMapElePFblockIso");
 
-
-  produces< edm::ValueMap<std::vector<reco::PFCandidateRef> > >  (valueMapPhoPFCandIso_); 
-  produces< edm::ValueMap<std::vector<reco::PFCandidateRef> > > (valueMapElePFCandIso_); 
-
+  produces<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(valueMapPhoPFCandIso_);
+  produces<edm::ValueMap<std::vector<reco::PFCandidateRef>>>(valueMapElePFCandIso_);
 }
 
-ParticleBasedIsoProducer::~ParticleBasedIsoProducer() {
+ParticleBasedIsoProducer::~ParticleBasedIsoProducer() {}
 
-
+void ParticleBasedIsoProducer::beginRun(const edm::Run& run, const edm::EventSetup& c) {
+  thePFBlockBasedIsolation_ = new PFBlockBasedIsolation();
+  edm::ParameterSet pfBlockBasedIsolationSetUp = conf_.getParameter<edm::ParameterSet>("pfBlockBasedIsolationSetUp");
+  thePFBlockBasedIsolation_->setup(pfBlockBasedIsolationSetUp);
 }
 
-
-void ParticleBasedIsoProducer::beginRun(const edm::Run & run, const edm::EventSetup& c) {
-
-    thePFBlockBasedIsolation_ = new PFBlockBasedIsolation();
-    edm::ParameterSet pfBlockBasedIsolationSetUp = conf_.getParameter<edm::ParameterSet>("pfBlockBasedIsolationSetUp"); 
-    thePFBlockBasedIsolation_ ->setup(pfBlockBasedIsolationSetUp);
-
-}
-
-void ParticleBasedIsoProducer::endRun(const edm::Run & run, const edm::EventSetup& c) {
-
+void ParticleBasedIsoProducer::endRun(const edm::Run& run, const edm::EventSetup& c) {
   delete thePFBlockBasedIsolation_;
-
 }
-
-
 
 void ParticleBasedIsoProducer::produce(edm::Event& theEvent, const edm::EventSetup& c) {
-
   edm::Handle<reco::PhotonCollection> photonHandle;
-  theEvent.getByToken(photonProducerT_,photonHandle);
+  theEvent.getByToken(photonProducerT_, photonHandle);
 
   edm::Handle<reco::PhotonCollection> photonTmpHandle;
-  theEvent.getByToken(photonTmpProducerT_,photonTmpHandle);
+  theEvent.getByToken(photonTmpProducerT_, photonTmpHandle);
 
   edm::Handle<reco::GsfElectronCollection> electronTmpHandle;
-  theEvent.getByToken(electronTmpProducerT_,electronTmpHandle);
+  theEvent.getByToken(electronTmpProducerT_, electronTmpHandle);
 
   edm::Handle<reco::GsfElectronCollection> electronHandle;
-  theEvent.getByToken(electronProducerT_,electronHandle);
-  
+  theEvent.getByToken(electronProducerT_, electronHandle);
+
   edm::Handle<reco::PFCandidateCollection> pfEGCandidateHandle;
   // Get the  PF refined cluster  collection
-  theEvent.getByToken(pfEgammaCandidates_,pfEGCandidateHandle);
-  
+  theEvent.getByToken(pfEgammaCandidates_, pfEGCandidateHandle);
+
   edm::Handle<reco::PFCandidateCollection> pfCandidateHandle;
   // Get the  PF candidates collection
-  theEvent.getByToken(pfCandidates_,pfCandidateHandle);
-  
+  theEvent.getByToken(pfCandidates_, pfCandidateHandle);
+
   edm::ValueMap<reco::PhotonRef> pfEGCandToPhotonMap;
-  edm::Handle<edm::ValueMap<reco::PhotonRef> > pfEGCandToPhotonMapHandle;
-  theEvent.getByToken(valMapPFCandToPhoton_,pfEGCandToPhotonMapHandle);
+  edm::Handle<edm::ValueMap<reco::PhotonRef>> pfEGCandToPhotonMapHandle;
+  theEvent.getByToken(valMapPFCandToPhoton_, pfEGCandToPhotonMapHandle);
   pfEGCandToPhotonMap = *(pfEGCandToPhotonMapHandle.product());
 
   edm::ValueMap<reco::GsfElectronRef> pfEGCandToElectronMap;
-  edm::Handle<edm::ValueMap<reco::GsfElectronRef> > pfEGCandToElectronMapHandle;
-  theEvent.getByToken(valMapPFCandToEle_,pfEGCandToElectronMapHandle);
+  edm::Handle<edm::ValueMap<reco::GsfElectronRef>> pfEGCandToElectronMapHandle;
+  theEvent.getByToken(valMapPFCandToEle_, pfEGCandToElectronMapHandle);
   pfEGCandToElectronMap = *(pfEGCandToElectronMapHandle.product());
 
   std::vector<std::vector<reco::PFCandidateRef>> pfCandIsoPairVecPho;
 
-  ///// Isolation for photons 
+  ///// Isolation for photons
   //  std::cout << " ParticleBasedIsoProducer  photonHandle size " << photonHandle->size() << std::endl;
-  for(unsigned int lSC=0; lSC < photonTmpHandle->size(); lSC++) {
-
+  for (unsigned int lSC = 0; lSC < photonTmpHandle->size(); lSC++) {
     reco::PhotonRef phoRef(reco::PhotonRef(photonTmpHandle, lSC));
 
     // loop over the unbiased candidates to retrieve the ref to the unbiased candidate corresponding to this photon
@@ -119,100 +94,77 @@ void ParticleBasedIsoProducer::produce(edm::Event& theEvent, const edm::EventSet
     reco::PFCandidateRef pfEGCandRef;
 
     std::vector<reco::PFCandidateRef> pfCandIsoPairPho;
-    for(unsigned int lCand=0; lCand < nObj; lCand++) {
-      pfEGCandRef=reco::PFCandidateRef(pfEGCandidateHandle,lCand);
-      reco::PhotonRef myPho= (pfEGCandToPhotonMap)[pfEGCandRef];
-      
-      if ( myPho.isNonnull() ) {
-	//std::cout << "ParticleBasedIsoProducer photons PF SC " << pfEGCandRef->superClusterRef()->energy() << " Photon SC " << myPho->superCluster()->energy() << std::endl;
-	if (myPho != phoRef) continue;
-	//	std::cout << " ParticleBasedIsoProducer photons This is my egammaunbiased guy energy " <<  pfEGCandRef->superClusterRef()->energy() << std::endl;
-	pfCandIsoPairPho=thePFBlockBasedIsolation_->calculate (myPho->p4(),  pfEGCandRef, pfCandidateHandle);
-	
-	/////// debug
-	//	for ( std::vector<reco::PFCandidateRef>::const_iterator iPair=pfCandIsoPairPho.begin(); iPair<pfCandIsoPairPho.end(); iPair++) {
-	// float dR= deltaR(myPho->eta(),  myPho->phi(), (*iPair)->eta(),  (*iPair)->phi() );
-	// std::cout << " ParticleBasedIsoProducer photons  checking the pfCand bool pair " << (*iPair)->particleId() << " dR " << dR << " pt " <<  (*iPair)->pt() << std::endl; 
-	//	}
-	
-	
+    for (unsigned int lCand = 0; lCand < nObj; lCand++) {
+      pfEGCandRef = reco::PFCandidateRef(pfEGCandidateHandle, lCand);
+      reco::PhotonRef myPho = (pfEGCandToPhotonMap)[pfEGCandRef];
+
+      if (myPho.isNonnull()) {
+        //std::cout << "ParticleBasedIsoProducer photons PF SC " << pfEGCandRef->superClusterRef()->energy() << " Photon SC " << myPho->superCluster()->energy() << std::endl;
+        if (myPho != phoRef)
+          continue;
+        //	std::cout << " ParticleBasedIsoProducer photons This is my egammaunbiased guy energy " <<  pfEGCandRef->superClusterRef()->energy() << std::endl;
+        pfCandIsoPairPho = thePFBlockBasedIsolation_->calculate(myPho->p4(), pfEGCandRef, pfCandidateHandle);
+
+        /////// debug
+        //	for ( std::vector<reco::PFCandidateRef>::const_iterator iPair=pfCandIsoPairPho.begin(); iPair<pfCandIsoPairPho.end(); iPair++) {
+        // float dR= deltaR(myPho->eta(),  myPho->phi(), (*iPair)->eta(),  (*iPair)->phi() );
+        // std::cout << " ParticleBasedIsoProducer photons  checking the pfCand bool pair " << (*iPair)->particleId() << " dR " << dR << " pt " <<  (*iPair)->pt() << std::endl;
+        //	}
       }
-      
     }
-    
-    pfCandIsoPairVecPho.push_back(pfCandIsoPairPho); 
+
+    pfCandIsoPairVecPho.push_back(pfCandIsoPairPho);
   }
- 
 
-
-  ////////////isolation for electrons 
+  ////////////isolation for electrons
   std::vector<std::vector<reco::PFCandidateRef>> pfCandIsoPairVecEle;
   //  std::cout << " ParticleBasedIsoProducer  electronHandle size " << electronHandle->size() << std::endl;
-  for(unsigned int lSC=0; lSC < electronTmpHandle->size(); lSC++) {
+  for (unsigned int lSC = 0; lSC < electronTmpHandle->size(); lSC++) {
     reco::GsfElectronRef eleRef(reco::GsfElectronRef(electronTmpHandle, lSC));
-    
+
     // loop over the unbiased candidates to retrieve the ref to the unbiased candidate corresponding to this electron
     unsigned nObj = pfEGCandidateHandle->size();
     reco::PFCandidateRef pfEGCandRef;
-    
+
     std::vector<reco::PFCandidateRef> pfCandIsoPairEle;
-    for(unsigned int lCand=0; lCand < nObj; lCand++) {
-      pfEGCandRef=reco::PFCandidateRef(pfEGCandidateHandle,lCand);
-      reco::GsfElectronRef myEle= (pfEGCandToElectronMap)[pfEGCandRef];
-      
-      if ( myEle.isNonnull() ) {
-	//	std::cout << "ParticleBasedIsoProducer Electorns PF SC " << pfEGCandRef->superClusterRef()->energy() << " Electron SC " << myEle->superCluster()->energy() << std::endl;
-	if (myEle != eleRef) continue;
-	
-	//math::XYZVector candidateMomentum(myEle->p4().px(),myEle->p4().py(),myEle->p4().pz());
-	//math::XYZVector myDir=candidateMomentum.Unit();
-	//	std::cout << " ParticleBasedIsoProducer  Electrons This is my egammaunbiased guy energy " <<  pfEGCandRef->superClusterRef()->energy()  << std::endl;
-	//  std::cout << " Ele  direction " << myDir << " eta " << myEle->eta() << " phi " << myEle->phi() << std::endl;
-	pfCandIsoPairEle=thePFBlockBasedIsolation_->calculate (myEle->p4(),  pfEGCandRef, pfCandidateHandle);
-	/////// debug
-	//for ( std::vector<reco::PFCandidateRef>::const_iterator iPair=pfCandIsoPairEle.begin(); iPair<pfCandIsoPairEle.end(); iPair++) {
-	// float dR= deltaR(myEle->eta(),  myEle->phi(), (*iPair)->eta(),  (*iPair)->phi() );
-	// std::cout << " ParticleBasedIsoProducer Electron  checking the pfCand bool pair " << (*iPair)->particleId() << " dR " << dR << " pt " <<  (*iPair)->pt() << " eta " << (*iPair)->eta() << " phi " << (*iPair)->phi() <<  std::endl; 
-	//	}
-	
-	
+    for (unsigned int lCand = 0; lCand < nObj; lCand++) {
+      pfEGCandRef = reco::PFCandidateRef(pfEGCandidateHandle, lCand);
+      reco::GsfElectronRef myEle = (pfEGCandToElectronMap)[pfEGCandRef];
+
+      if (myEle.isNonnull()) {
+        //	std::cout << "ParticleBasedIsoProducer Electorns PF SC " << pfEGCandRef->superClusterRef()->energy() << " Electron SC " << myEle->superCluster()->energy() << std::endl;
+        if (myEle != eleRef)
+          continue;
+
+        //math::XYZVector candidateMomentum(myEle->p4().px(),myEle->p4().py(),myEle->p4().pz());
+        //math::XYZVector myDir=candidateMomentum.Unit();
+        //	std::cout << " ParticleBasedIsoProducer  Electrons This is my egammaunbiased guy energy " <<  pfEGCandRef->superClusterRef()->energy()  << std::endl;
+        //  std::cout << " Ele  direction " << myDir << " eta " << myEle->eta() << " phi " << myEle->phi() << std::endl;
+        pfCandIsoPairEle = thePFBlockBasedIsolation_->calculate(myEle->p4(), pfEGCandRef, pfCandidateHandle);
+        /////// debug
+        //for ( std::vector<reco::PFCandidateRef>::const_iterator iPair=pfCandIsoPairEle.begin(); iPair<pfCandIsoPairEle.end(); iPair++) {
+        // float dR= deltaR(myEle->eta(),  myEle->phi(), (*iPair)->eta(),  (*iPair)->phi() );
+        // std::cout << " ParticleBasedIsoProducer Electron  checking the pfCand bool pair " << (*iPair)->particleId() << " dR " << dR << " pt " <<  (*iPair)->pt() << " eta " << (*iPair)->eta() << " phi " << (*iPair)->phi() <<  std::endl;
+        //	}
       }
-      
     }
-    
-    pfCandIsoPairVecEle.push_back(pfCandIsoPairEle); 
-}
- 
 
-
-
+    pfCandIsoPairVecEle.push_back(pfCandIsoPairEle);
+  }
 
   auto phoToPFCandIsoMap_p = std::make_unique<edm::ValueMap<std::vector<reco::PFCandidateRef>>>();
-  edm::ValueMap<std::vector<reco::PFCandidateRef>>::Filler 
-    fillerPhotons(*phoToPFCandIsoMap_p);
-  
-  //// fill the isolation value map for photons
-  fillerPhotons.insert(photonHandle,pfCandIsoPairVecPho.begin(),pfCandIsoPairVecPho.end());
-  fillerPhotons.fill(); 
-  theEvent.put(std::move(phoToPFCandIsoMap_p),valueMapPhoPFCandIso_);
+  edm::ValueMap<std::vector<reco::PFCandidateRef>>::Filler fillerPhotons(*phoToPFCandIsoMap_p);
 
+  //// fill the isolation value map for photons
+  fillerPhotons.insert(photonHandle, pfCandIsoPairVecPho.begin(), pfCandIsoPairVecPho.end());
+  fillerPhotons.fill();
+  theEvent.put(std::move(phoToPFCandIsoMap_p), valueMapPhoPFCandIso_);
 
   auto eleToPFCandIsoMap_p = std::make_unique<edm::ValueMap<std::vector<reco::PFCandidateRef>>>();
-  edm::ValueMap<std::vector<reco::PFCandidateRef>>::Filler 
-    fillerElectrons(*eleToPFCandIsoMap_p);
-  
-  //// fill the isolation value map for electrons 
-  fillerElectrons.insert(electronHandle,pfCandIsoPairVecEle.begin(),pfCandIsoPairVecEle.end());
-  fillerElectrons.fill(); 
-  theEvent.put(std::move(eleToPFCandIsoMap_p),valueMapElePFCandIso_);
+  edm::ValueMap<std::vector<reco::PFCandidateRef>>::Filler fillerElectrons(*eleToPFCandIsoMap_p);
 
-
-
-
-
-
-
-
-
- 
+  //// fill the isolation value map for electrons
+  fillerElectrons.insert(electronHandle, pfCandIsoPairVecEle.begin(), pfCandIsoPairVecEle.end());
+  fillerElectrons.fill();
+  theEvent.put(std::move(eleToPFCandIsoMap_p), valueMapElePFCandIso_);
 }

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/ParticleBasedIsoProducer.h
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/ParticleBasedIsoProducer.h
@@ -14,46 +14,41 @@
 
 #include "DataFormats/Common/interface/ValueMap.h"
 
-
-class ParticleBasedIsoProducer : public edm::stream::EDProducer<>
-{
- public:
-
+class ParticleBasedIsoProducer : public edm::stream::EDProducer<> {
+public:
   ParticleBasedIsoProducer(const edm::ParameterSet& conf);
   ~ParticleBasedIsoProducer() override;
-  
-  void beginRun (edm::Run const& r, edm::EventSetup const & es) override;
-  void endRun(edm::Run const&,  edm::EventSetup const&) override;
+
+  void beginRun(edm::Run const& r, edm::EventSetup const& es) override;
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
   void produce(edm::Event& e, const edm::EventSetup& c) override;
-   
- private:
- 
- edm::ParameterSet conf_;
- std::string photonCollection_;
- std::string electronCollection_;
 
- edm::InputTag  photonProducer_; 
- edm::InputTag  photonTmpProducer_;
+private:
+  edm::ParameterSet conf_;
+  std::string photonCollection_;
+  std::string electronCollection_;
 
- edm::InputTag  electronProducer_; 
- edm::InputTag  electronTmpProducer_; 
+  edm::InputTag photonProducer_;
+  edm::InputTag photonTmpProducer_;
 
- edm::EDGetTokenT<reco::PhotonCollection> photonProducerT_;
- edm::EDGetTokenT<reco::PhotonCollection> photonTmpProducerT_;
- edm::EDGetTokenT<reco::GsfElectronCollection> electronProducerT_;
- edm::EDGetTokenT<reco::GsfElectronCollection> electronTmpProducerT_;
- edm::EDGetTokenT<reco::PFCandidateCollection> pfEgammaCandidates_;
- edm::EDGetTokenT<reco::PFCandidateCollection> pfCandidates_;
- edm::EDGetTokenT<edm::ValueMap<reco::PhotonRef> > valMapPFCandToPhoton_;
- edm::EDGetTokenT<edm::ValueMap<reco::GsfElectronRef> > valMapPFCandToEle_;
+  edm::InputTag electronProducer_;
+  edm::InputTag electronTmpProducer_;
 
- std::string valueMapPFCandPhoton_;
- std::string valueMapPhoPFCandIso_;
- std::string valueMapPFCandEle_;
- std::string valueMapElePFCandIso_;
+  edm::EDGetTokenT<reco::PhotonCollection> photonProducerT_;
+  edm::EDGetTokenT<reco::PhotonCollection> photonTmpProducerT_;
+  edm::EDGetTokenT<reco::GsfElectronCollection> electronProducerT_;
+  edm::EDGetTokenT<reco::GsfElectronCollection> electronTmpProducerT_;
+  edm::EDGetTokenT<reco::PFCandidateCollection> pfEgammaCandidates_;
+  edm::EDGetTokenT<reco::PFCandidateCollection> pfCandidates_;
+  edm::EDGetTokenT<edm::ValueMap<reco::PhotonRef> > valMapPFCandToPhoton_;
+  edm::EDGetTokenT<edm::ValueMap<reco::GsfElectronRef> > valMapPFCandToEle_;
 
- PFBlockBasedIsolation* thePFBlockBasedIsolation_;
+  std::string valueMapPFCandPhoton_;
+  std::string valueMapPhoPFCandIso_;
+  std::string valueMapPFCandEle_;
+  std::string valueMapElePFCandIso_;
 
+  PFBlockBasedIsolation* thePFBlockBasedIsolation_;
 };
 
 #endif

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/isolation_cones/ElectronPFIsolationWithConeVeto.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/isolation_cones/ElectronPFIsolationWithConeVeto.cc
@@ -22,7 +22,6 @@
 
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 
-
 #include <unordered_map>
 
 namespace reco {
@@ -35,74 +34,69 @@ namespace pat {
 
 class ElectronPFIsolationWithConeVeto : public citk::IsolationConeDefinitionBase {
 public:
-  ElectronPFIsolationWithConeVeto(const edm::ParameterSet& c) :
-    citk::IsolationConeDefinitionBase(c),
-    _vetoConeSize2EB(std::pow(c.getParameter<double>("VetoConeSizeBarrel"),2.0)),
-    _vetoConeSize2EE(std::pow(c.getParameter<double>("VetoConeSizeEndcaps"),2.0)),
-    _miniAODVertexCodes(c.getParameter<std::vector<unsigned> >("miniAODVertexCodes")),
-    _isolateAgainst(c.getParameter<std::string>("isolateAgainst")) {
+  ElectronPFIsolationWithConeVeto(const edm::ParameterSet& c)
+      : citk::IsolationConeDefinitionBase(c),
+        _vetoConeSize2EB(std::pow(c.getParameter<double>("VetoConeSizeBarrel"), 2.0)),
+        _vetoConeSize2EE(std::pow(c.getParameter<double>("VetoConeSizeEndcaps"), 2.0)),
+        _miniAODVertexCodes(c.getParameter<std::vector<unsigned> >("miniAODVertexCodes")),
+        _isolateAgainst(c.getParameter<std::string>("isolateAgainst")) {
     char buf[50];
-    sprintf(buf,"BarVeto%.2f-EndVeto%.2f",
-	    std::sqrt(_vetoConeSize2EB),
-	    std::sqrt(_vetoConeSize2EE));
+    sprintf(buf, "BarVeto%.2f-EndVeto%.2f", std::sqrt(_vetoConeSize2EB), std::sqrt(_vetoConeSize2EE));
     _additionalCode = std::string(buf);
     auto decimal = _additionalCode.find('.');
-    while( decimal != std::string::npos ) {
-      _additionalCode.erase(decimal,1);
+    while (decimal != std::string::npos) {
+      _additionalCode.erase(decimal, 1);
       decimal = _additionalCode.find('.');
-    }    
+    }
   }
   ElectronPFIsolationWithConeVeto(const ElectronPFIsolationWithConeVeto&) = delete;
-  ElectronPFIsolationWithConeVeto& operator=(const ElectronPFIsolationWithConeVeto&) =delete;
-  
+  ElectronPFIsolationWithConeVeto& operator=(const ElectronPFIsolationWithConeVeto&) = delete;
+
   void setConsumes(edm::ConsumesCollector) override {}
 
-  bool isInIsolationCone(const reco::CandidatePtr& physob,
-			 const reco::CandidatePtr& other) const final;
-  
+  bool isInIsolationCone(const reco::CandidatePtr& physob, const reco::CandidatePtr& other) const final;
+
   //! Destructor
   ~ElectronPFIsolationWithConeVeto() override{};
-  
-private:    
-  const float _vetoConeSize2EB, _vetoConeSize2EE;  
+
+private:
+  const float _vetoConeSize2EB, _vetoConeSize2EE;
   const std::vector<unsigned> _miniAODVertexCodes;
   const std::string _isolateAgainst;
   edm::EDGetTokenT<reco::VertexCollection> _vtxToken;
 };
 
 DEFINE_EDM_PLUGIN(CITKIsolationConeDefinitionFactory,
-		  ElectronPFIsolationWithConeVeto,
-		  "ElectronPFIsolationWithConeVeto");
+                  ElectronPFIsolationWithConeVeto,
+                  "ElectronPFIsolationWithConeVeto");
 
-bool ElectronPFIsolationWithConeVeto::
-isInIsolationCone(const reco::CandidatePtr& physob,
-		  const reco::CandidatePtr& iso_obj  ) const {
+bool ElectronPFIsolationWithConeVeto::isInIsolationCone(const reco::CandidatePtr& physob,
+                                                        const reco::CandidatePtr& iso_obj) const {
   reco::GsfElectronPtr eleref(physob);
   pat::PackedCandidatePtr aspacked(iso_obj);
   reco::PFCandidatePtr aspf(iso_obj);
   const reco::CaloClusterPtr& seed = eleref->superCluster()->seed();
-  bool isEB = ( seed->seed().subdetId() == EcalBarrel );
-  const float deltar2 = reco::deltaR2(*physob,*iso_obj);  
-  const float vetoConeSize2 = ( isEB ? _vetoConeSize2EB : _vetoConeSize2EE );
+  bool isEB = (seed->seed().subdetId() == EcalBarrel);
+  const float deltar2 = reco::deltaR2(*physob, *iso_obj);
+  const float vetoConeSize2 = (isEB ? _vetoConeSize2EB : _vetoConeSize2EE);
   bool result = true;
-  if( aspacked.isNonnull() && aspacked.get() ) {    
-    if( aspacked->charge() != 0 ) {
+  if (aspacked.isNonnull() && aspacked.get()) {
+    if (aspacked->charge() != 0) {
       bool is_vertex_allowed = false;
-      for( const unsigned vtxtype : _miniAODVertexCodes ) {
-	if( vtxtype == aspacked->fromPV() ) {
-	  is_vertex_allowed = true;
-	  break;
-	}
-      }      
-      result = result && ( is_vertex_allowed );
+      for (const unsigned vtxtype : _miniAODVertexCodes) {
+        if (vtxtype == aspacked->fromPV()) {
+          is_vertex_allowed = true;
+          break;
+        }
+      }
+      result = result && (is_vertex_allowed);
     }
-    result = result && ( deltar2 > vetoConeSize2 && deltar2 < _coneSize2 );
-  } else if ( aspf.isNonnull() && aspf.get() ) {    
-    result = result && ( deltar2 > vetoConeSize2 && deltar2 < _coneSize2 );
+    result = result && (deltar2 > vetoConeSize2 && deltar2 < _coneSize2);
+  } else if (aspf.isNonnull() && aspf.get()) {
+    result = result && (deltar2 > vetoConeSize2 && deltar2 < _coneSize2);
   } else {
-    throw cms::Exception("InvalidIsolationInput")
-      << "The supplied candidate to be used as isolation "
-      << "was neither a reco::PFCandidate nor a pat::PackedCandidate!";
+    throw cms::Exception("InvalidIsolationInput") << "The supplied candidate to be used as isolation "
+                                                  << "was neither a reco::PFCandidate nor a pat::PackedCandidate!";
   }
   return result;
 }

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/isolation_cones/ElectronPFIsolationWithMapBasedVeto.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/isolation_cones/ElectronPFIsolationWithMapBasedVeto.cc
@@ -28,7 +28,6 @@
 
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 
-
 #include <unordered_map>
 namespace reco {
   typedef edm::Ptr<reco::GsfElectron> GsfElectronPtr;
@@ -37,135 +36,122 @@ namespace reco {
 namespace pat {
   typedef edm::Ptr<pat::PackedCandidate> PackedCandidatePtr;
   typedef edm::Ptr<pat::Electron> patElectronPtr;
-}
-namespace{
-	// This template function finds whether theCandidate is in thefootprint
-	// // collection. It is templated to be able to handle both reco and pat
-	// // photons (from AOD and miniAOD, respectively).
-	//
-	template <class T, class U>
-	bool isInFootprint(const T& thefootprint, const U& theCandidate) 
-	{
-	    for ( auto itr = thefootprint.begin(); itr != thefootprint.end(); ++itr ) 
-    	    { 
-      	      if( itr->key() == theCandidate.key() ) return true;
-   	    }
- 	    return false;
-	}
-        //This function is needed because pfNoPileUpCandidates have changed keys, 
-        ////and thus the solution is to use sourceCandidatePtr(0) 
-        // // This function *shouldn't be used for packedCandidate*
-       template <class T, class U>
-        bool isInFootprintAlternative(const T& thefootprint, const U& theCandidate)
-        {
-            for ( auto itr = thefootprint.begin(); itr != thefootprint.end(); ++itr )
-            {
-              if( itr->key() == theCandidate->sourceCandidatePtr(0).key() ) return true;
-            }
-            return false;
-        }
+}  // namespace pat
+namespace {
+  // This template function finds whether theCandidate is in thefootprint
+  // // collection. It is templated to be able to handle both reco and pat
+  // // photons (from AOD and miniAOD, respectively).
+  //
+  template <class T, class U>
+  bool isInFootprint(const T& thefootprint, const U& theCandidate) {
+    for (auto itr = thefootprint.begin(); itr != thefootprint.end(); ++itr) {
+      if (itr->key() == theCandidate.key())
+        return true;
+    }
+    return false;
+  }
+  //This function is needed because pfNoPileUpCandidates have changed keys,
+  ////and thus the solution is to use sourceCandidatePtr(0)
+  // // This function *shouldn't be used for packedCandidate*
+  template <class T, class U>
+  bool isInFootprintAlternative(const T& thefootprint, const U& theCandidate) {
+    for (auto itr = thefootprint.begin(); itr != thefootprint.end(); ++itr) {
+      if (itr->key() == theCandidate->sourceCandidatePtr(0).key())
+        return true;
+    }
+    return false;
+  }
 
-}
+}  // namespace
 class ElectronPFIsolationWithMapBasedVeto : public citk::IsolationConeDefinitionBase {
 public:
-  ElectronPFIsolationWithMapBasedVeto(const edm::ParameterSet& c) :
-    citk::IsolationConeDefinitionBase(c),
-    _isolateAgainst(c.getParameter<std::string>("isolateAgainst")), //isolate against either h+, h0 or gamma
-    _miniAODVertexCodes(c.getParameter<std::vector<unsigned> >("miniAODVertexCodes")), //quality flags to be used for association with the vertex configurable, the vertex can be chosen
-    _particleBasedIsolation(c.getParameter<edm::InputTag>("particleBasedIsolation")){} // particle based isolation map (used for footprint removal)
-        
-  ElectronPFIsolationWithMapBasedVeto(const ElectronPFIsolationWithMapBasedVeto&) = delete;
-  ElectronPFIsolationWithMapBasedVeto& operator=(const ElectronPFIsolationWithMapBasedVeto&) =delete;
+  ElectronPFIsolationWithMapBasedVeto(const edm::ParameterSet& c)
+      : citk::IsolationConeDefinitionBase(c),
+        _isolateAgainst(c.getParameter<std::string>("isolateAgainst")),  //isolate against either h+, h0 or gamma
+        _miniAODVertexCodes(c.getParameter<std::vector<unsigned> >(
+            "miniAODVertexCodes")),  //quality flags to be used for association with the vertex configurable, the vertex can be chosen
+        _particleBasedIsolation(c.getParameter<edm::InputTag>("particleBasedIsolation")) {
+  }  // particle based isolation map (used for footprint removal)
 
-  bool isInIsolationCone(const reco::CandidatePtr& photon,
-			 const reco::CandidatePtr& other) const final;
-  
-   
+  ElectronPFIsolationWithMapBasedVeto(const ElectronPFIsolationWithMapBasedVeto&) = delete;
+  ElectronPFIsolationWithMapBasedVeto& operator=(const ElectronPFIsolationWithMapBasedVeto&) = delete;
+
+  bool isInIsolationCone(const reco::CandidatePtr& photon, const reco::CandidatePtr& other) const final;
+
   // this object is needed for reco case
- edm::Handle< edm::ValueMap<std::vector<reco::PFCandidateRef > > > particleBasedIsolationMap;			 
- edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef > > > particleBasedIsolationToken_;
- 
- void getEventInfo(const edm::Event& iEvent) override
-  {
-      iEvent.getByToken(particleBasedIsolationToken_, particleBasedIsolationMap); 
-  };			 
-  
-  
+  edm::Handle<edm::ValueMap<std::vector<reco::PFCandidateRef> > > particleBasedIsolationMap;
+  edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef> > > particleBasedIsolationToken_;
+
+  void getEventInfo(const edm::Event& iEvent) override {
+    iEvent.getByToken(particleBasedIsolationToken_, particleBasedIsolationMap);
+  };
+
   //As far as I understand now, the object particleBasedIsolationMap should be fixed, so we don't configure the name
-  void setConsumes(edm::ConsumesCollector iC) override
-  {
-      particleBasedIsolationToken_ = iC.mayConsume<edm::ValueMap<std::vector<reco::PFCandidateRef > > >(_particleBasedIsolation);
+  void setConsumes(edm::ConsumesCollector iC) override {
+    particleBasedIsolationToken_ =
+        iC.mayConsume<edm::ValueMap<std::vector<reco::PFCandidateRef> > >(_particleBasedIsolation);
   }
 
   //! Destructor
   ~ElectronPFIsolationWithMapBasedVeto() override{};
-  
-  
-private:    
+
+private:
   const std::string _isolateAgainst, _vertexCollection;
   const std::vector<unsigned> _miniAODVertexCodes;
   const edm::InputTag _particleBasedIsolation;
-
-  
 };
 
 DEFINE_EDM_PLUGIN(CITKIsolationConeDefinitionFactory,
-		  ElectronPFIsolationWithMapBasedVeto,
-		  "ElectronPFIsolationWithMapBasedVeto");
-
+                  ElectronPFIsolationWithMapBasedVeto,
+                  "ElectronPFIsolationWithMapBasedVeto");
 
 //This function defines whether particular PFCandidate is inside of isolation cone of photon or not by checking deltaR and whether footprint removal for this candidate should be done. Additionally, for miniAOD charged hadrons from the PV are considered. *** For AOD this should be done by the corresponding sequence beforehand!!! ***
- 
-bool ElectronPFIsolationWithMapBasedVeto::isInIsolationCone(const reco::CandidatePtr& electron,  const reco::CandidatePtr& pfCandidate  ) const {
- 
+
+bool ElectronPFIsolationWithMapBasedVeto::isInIsolationCone(const reco::CandidatePtr& electron,
+                                                            const reco::CandidatePtr& pfCandidate) const {
   //convert the electron and candidate objects to the corresponding pat or reco objects. What is used depends on what is user running on: miniAOD or AOD
   pat::patElectronPtr aspat_electronptr(electron);
-  
+
   pat::PackedCandidatePtr aspacked(pfCandidate);
   reco::PFCandidatePtr aspf(pfCandidate);
 
-  
   bool inFootprint = false;
   bool result = true;
-  const float deltar2 = reco::deltaR2(*electron,*pfCandidate); //calculate deltaR2 distance between PFCandidate and photon
-  
+  const float deltar2 =
+      reco::deltaR2(*electron, *pfCandidate);  //calculate deltaR2 distance between PFCandidate and photon
+
   // dealing here with patObjects: miniAOD case
-  if ( aspacked.get() )    
-  {
-    inFootprint = isInFootprint(aspat_electronptr ->associatedPackedPFCandidates(),aspacked);
-    
+  if (aspacked.get()) {
+    inFootprint = isInFootprint(aspat_electronptr->associatedPackedPFCandidates(), aspacked);
+
     //checking if the charged candidates come from the appropriate vertex
-    if( aspacked->charge() != 0 ) 
-    {
+    if (aspacked->charge() != 0) {
       bool is_vertex_allowed = false;
-      for( const unsigned vtxtype : _miniAODVertexCodes ) 
-      {
-      	if( vtxtype == aspacked->fromPV() ) {
-      	  is_vertex_allowed = true;
-      	  break;
-      	}
-      }      
-    
-     result &= (is_vertex_allowed);
+      for (const unsigned vtxtype : _miniAODVertexCodes) {
+        if (vtxtype == aspacked->fromPV()) {
+          is_vertex_allowed = true;
+          break;
+        }
+      }
+
+      result &= (is_vertex_allowed);
     }
-     //return true if the candidate is inside the cone and not in the footprint
+    //return true if the candidate is inside the cone and not in the footprint
     result &= deltar2 < _coneSize2 && (!inFootprint);
-   }
-  
-  // dealing here with recoObjects: AOD case
-  else if ( aspf.get())
-  {
-      inFootprint = isInFootprintAlternative((*particleBasedIsolationMap)[electron], pfCandidate); 
-      //return true if the candidate is inside the cone and not in the footprint
-      result &= deltar2 < _coneSize2 && (!inFootprint);
   }
-  
+
+  // dealing here with recoObjects: AOD case
+  else if (aspf.get()) {
+    inFootprint = isInFootprintAlternative((*particleBasedIsolationMap)[electron], pfCandidate);
+    //return true if the candidate is inside the cone and not in the footprint
+    result &= deltar2 < _coneSize2 && (!inFootprint);
+  }
+
   // throw exception if it is not a patObject or recoObject
   else {
-    throw cms::Exception("InvalidIsolationInput")
-      << "The supplied candidate to be used as isolation "
-      << "was neither a reco::Photon nor a pat::Photon!";
+    throw cms::Exception("InvalidIsolationInput") << "The supplied candidate to be used as isolation "
+                                                  << "was neither a reco::Photon nor a pat::Photon!";
   }
-  
+
   return result;
 }

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/isolation_cones/PhotonPFIsolationWithConeVeto.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/isolation_cones/PhotonPFIsolationWithConeVeto.cc
@@ -22,7 +22,6 @@
 
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 
-
 #include <unordered_map>
 
 namespace reco {
@@ -35,76 +34,69 @@ namespace pat {
 
 class PhotonPFIsolationWithConeVeto : public citk::IsolationConeDefinitionBase {
 public:
-  PhotonPFIsolationWithConeVeto(const edm::ParameterSet& c) :
-    citk::IsolationConeDefinitionBase(c),
-    _vetoConeSize2EB(std::pow(c.getParameter<double>("VetoConeSizeBarrel"),2.0)),
-    _vetoConeSize2EE(std::pow(c.getParameter<double>("VetoConeSizeEndcaps"),2.0)),
-    _miniAODVertexCodes(c.getParameter<std::vector<unsigned> >("miniAODVertexCodes")),
-    _vertexIndex(c.getParameter<int> ("vertexIndex")),
-    _isolateAgainst(c.getParameter<std::string>("isolateAgainst")) {
+  PhotonPFIsolationWithConeVeto(const edm::ParameterSet& c)
+      : citk::IsolationConeDefinitionBase(c),
+        _vetoConeSize2EB(std::pow(c.getParameter<double>("VetoConeSizeBarrel"), 2.0)),
+        _vetoConeSize2EE(std::pow(c.getParameter<double>("VetoConeSizeEndcaps"), 2.0)),
+        _miniAODVertexCodes(c.getParameter<std::vector<unsigned> >("miniAODVertexCodes")),
+        _vertexIndex(c.getParameter<int>("vertexIndex")),
+        _isolateAgainst(c.getParameter<std::string>("isolateAgainst")) {
     char buf[50];
-    sprintf(buf,"BarVeto%.2f-EndVeto%.2f",
-	    std::sqrt(_vetoConeSize2EB),
-	    std::sqrt(_vetoConeSize2EE));
+    sprintf(buf, "BarVeto%.2f-EndVeto%.2f", std::sqrt(_vetoConeSize2EB), std::sqrt(_vetoConeSize2EE));
     _additionalCode = std::string(buf);
     auto decimal = _additionalCode.find('.');
-    while( decimal != std::string::npos ) {
-      _additionalCode.erase(decimal,1);
+    while (decimal != std::string::npos) {
+      _additionalCode.erase(decimal, 1);
       decimal = _additionalCode.find('.');
-    }    
+    }
   }
   PhotonPFIsolationWithConeVeto(const PhotonPFIsolationWithConeVeto&) = delete;
-  PhotonPFIsolationWithConeVeto& operator=(const PhotonPFIsolationWithConeVeto&) =delete;
-  
+  PhotonPFIsolationWithConeVeto& operator=(const PhotonPFIsolationWithConeVeto&) = delete;
+
   void setConsumes(edm::ConsumesCollector) override {}
 
-  bool isInIsolationCone(const reco::CandidatePtr& photon,
-			 const reco::CandidatePtr& pfCandidate) const final;
-  
+  bool isInIsolationCone(const reco::CandidatePtr& photon, const reco::CandidatePtr& pfCandidate) const final;
+
   //! Destructor
   ~PhotonPFIsolationWithConeVeto() override{};
-  
-private:    
-  const float _vetoConeSize2EB, _vetoConeSize2EE;  
+
+private:
+  const float _vetoConeSize2EB, _vetoConeSize2EE;
   const std::vector<unsigned> _miniAODVertexCodes;
   const unsigned _vertexIndex;
   const std::string _isolateAgainst;
   edm::EDGetTokenT<reco::VertexCollection> _vtxToken;
 };
 
-DEFINE_EDM_PLUGIN(CITKIsolationConeDefinitionFactory,
-		  PhotonPFIsolationWithConeVeto,
-		  "PhotonPFIsolationWithConeVeto");
+DEFINE_EDM_PLUGIN(CITKIsolationConeDefinitionFactory, PhotonPFIsolationWithConeVeto, "PhotonPFIsolationWithConeVeto");
 
-bool PhotonPFIsolationWithConeVeto::
-isInIsolationCone(const reco::CandidatePtr& photon,
-		  const reco::CandidatePtr& pfCandidate  ) const {
+bool PhotonPFIsolationWithConeVeto::isInIsolationCone(const reco::CandidatePtr& photon,
+                                                      const reco::CandidatePtr& pfCandidate) const {
   reco::recoPhotonPtr photonref(photon);
   pat::PackedCandidatePtr aspacked(pfCandidate);
   reco::PFCandidatePtr aspf(pfCandidate);
   const reco::CaloClusterPtr& seed = photonref->superCluster()->seed();
-  bool isEB = ( seed->seed().subdetId() == EcalBarrel );
-  const float deltar2 = reco::deltaR2(*photon,*pfCandidate);  
-  const float vetoConeSize2 = ( isEB ? _vetoConeSize2EB : _vetoConeSize2EE );
+  bool isEB = (seed->seed().subdetId() == EcalBarrel);
+  const float deltar2 = reco::deltaR2(*photon, *pfCandidate);
+  const float vetoConeSize2 = (isEB ? _vetoConeSize2EB : _vetoConeSize2EE);
   bool result = true;
-  if( aspacked.isNonnull() && aspacked.get() ) {    
-    if( aspacked->charge() != 0 ) {
+  if (aspacked.isNonnull() && aspacked.get()) {
+    if (aspacked->charge() != 0) {
       bool is_vertex_allowed = false;
-      for( const unsigned vtxtype : _miniAODVertexCodes ) {
-	if( vtxtype == aspacked->fromPV(_vertexIndex) ) {
-	  is_vertex_allowed = true;
-	  break;
-	}
-      }      
-      result &= ( is_vertex_allowed );
+      for (const unsigned vtxtype : _miniAODVertexCodes) {
+        if (vtxtype == aspacked->fromPV(_vertexIndex)) {
+          is_vertex_allowed = true;
+          break;
+        }
+      }
+      result &= (is_vertex_allowed);
     }
-    result &= deltar2 > vetoConeSize2 && deltar2 < _coneSize2 ;
-  } else if ( aspf.isNonnull() && aspf.get() ) {    
+    result &= deltar2 > vetoConeSize2 && deltar2 < _coneSize2;
+  } else if (aspf.isNonnull() && aspf.get()) {
     result &= deltar2 > vetoConeSize2 && deltar2 < _coneSize2;
   } else {
-    throw cms::Exception("InvalidIsolationInput")
-      << "The supplied candidate to be used as isolation "
-      << "was neither a reco::PFCandidate nor a pat::PackedCandidate!";
+    throw cms::Exception("InvalidIsolationInput") << "The supplied candidate to be used as isolation "
+                                                  << "was neither a reco::PFCandidate nor a pat::PackedCandidate!";
   }
   return result;
 }

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/isolation_cones/PhotonPFIsolationWithMapBasedVeto.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/isolation_cones/PhotonPFIsolationWithMapBasedVeto.cc
@@ -26,7 +26,6 @@
 
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 
-
 #include <unordered_map>
 
 namespace reco {
@@ -36,139 +35,125 @@ namespace reco {
 namespace pat {
   typedef edm::Ptr<pat::Photon> patPhotonPtr;
   typedef edm::Ptr<pat::PackedCandidate> PackedCandidatePtr;
-}
+}  // namespace pat
 
 namespace {
-	// This template function finds whether theCandidate is in thefootprint
-	// collection. It is templated to be able to handle both reco and pat
-	// photons (from AOD and miniAOD, respectively).	
-	template <class T, class U>
-	bool isInFootprint(const T& thefootprint, const U& theCandidate) 
-	{
-	    for ( auto itr = thefootprint.begin(); itr != thefootprint.end(); ++itr ) 
-	    {
-	      if( itr->key() == theCandidate.key() ) return true;
-	     }
-	    return false;
-	}
-	
-	//This function is needed because pfNoPileUpCandidates have changed keys, 
-	//and thus the solution is to use sourceCandidatePtr(0) 
-	// This function *shouldn't be used for packedCandidate*
-	template <class T, class U>
-	bool isInFootprintAlternative(const T& thefootprint, const U& theCandidate) 
-	{
-	    for ( auto itr = thefootprint.begin(); itr != thefootprint.end(); ++itr ) 
-	    {
-	      if( itr->key() == theCandidate->sourceCandidatePtr(0).key() ) return true;
-	    }
-	    return false;
-	}
-}
+  // This template function finds whether theCandidate is in thefootprint
+  // collection. It is templated to be able to handle both reco and pat
+  // photons (from AOD and miniAOD, respectively).
+  template <class T, class U>
+  bool isInFootprint(const T& thefootprint, const U& theCandidate) {
+    for (auto itr = thefootprint.begin(); itr != thefootprint.end(); ++itr) {
+      if (itr->key() == theCandidate.key())
+        return true;
+    }
+    return false;
+  }
+
+  //This function is needed because pfNoPileUpCandidates have changed keys,
+  //and thus the solution is to use sourceCandidatePtr(0)
+  // This function *shouldn't be used for packedCandidate*
+  template <class T, class U>
+  bool isInFootprintAlternative(const T& thefootprint, const U& theCandidate) {
+    for (auto itr = thefootprint.begin(); itr != thefootprint.end(); ++itr) {
+      if (itr->key() == theCandidate->sourceCandidatePtr(0).key())
+        return true;
+    }
+    return false;
+  }
+}  // namespace
 
 class PhotonPFIsolationWithMapBasedVeto : public citk::IsolationConeDefinitionBase {
 public:
-  PhotonPFIsolationWithMapBasedVeto(const edm::ParameterSet& c) :
-    citk::IsolationConeDefinitionBase(c),
-    _isolateAgainst(c.getParameter<std::string>("isolateAgainst")), //isolate against either h+, h0 or gamma
-    _miniAODVertexCodes(c.getParameter<std::vector<unsigned> >("miniAODVertexCodes")), //quality flags to be used for association with the vertex configurable, the vertex can be chosen
-    _vertexIndex(c.getParameter<int> ("vertexIndex")),//vertex of interest
-    _particleBasedIsolation(c.getParameter<edm::InputTag>("particleBasedIsolation")){} 
-        
-  PhotonPFIsolationWithMapBasedVeto(const PhotonPFIsolationWithMapBasedVeto&) = delete;
-  PhotonPFIsolationWithMapBasedVeto& operator=(const PhotonPFIsolationWithMapBasedVeto&) =delete;
+  PhotonPFIsolationWithMapBasedVeto(const edm::ParameterSet& c)
+      : citk::IsolationConeDefinitionBase(c),
+        _isolateAgainst(c.getParameter<std::string>("isolateAgainst")),  //isolate against either h+, h0 or gamma
+        _miniAODVertexCodes(c.getParameter<std::vector<unsigned> >(
+            "miniAODVertexCodes")),  //quality flags to be used for association with the vertex configurable, the vertex can be chosen
+        _vertexIndex(c.getParameter<int>("vertexIndex")),  //vertex of interest
+        _particleBasedIsolation(c.getParameter<edm::InputTag>("particleBasedIsolation")) {}
 
-  bool isInIsolationCone(const reco::CandidatePtr& photon,
-			 const reco::CandidatePtr& pfCandidate) const final;
-  
-   
+  PhotonPFIsolationWithMapBasedVeto(const PhotonPFIsolationWithMapBasedVeto&) = delete;
+  PhotonPFIsolationWithMapBasedVeto& operator=(const PhotonPFIsolationWithMapBasedVeto&) = delete;
+
+  bool isInIsolationCone(const reco::CandidatePtr& photon, const reco::CandidatePtr& pfCandidate) const final;
+
   // this object is needed for reco case
- edm::Handle< edm::ValueMap<std::vector<reco::PFCandidateRef > > > particleBasedIsolationMap;			 
- edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef > > > particleBasedIsolationToken_;
- 
- void getEventInfo(const edm::Event& iEvent) override
-  {
-      iEvent.getByToken(particleBasedIsolationToken_, particleBasedIsolationMap); 
-  };			 
-  
-  
+  edm::Handle<edm::ValueMap<std::vector<reco::PFCandidateRef> > > particleBasedIsolationMap;
+  edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef> > > particleBasedIsolationToken_;
+
+  void getEventInfo(const edm::Event& iEvent) override {
+    iEvent.getByToken(particleBasedIsolationToken_, particleBasedIsolationMap);
+  };
+
   //As far as I understand now, the object particleBasedIsolationMap should be fixed, so we don't configure the name
-  void setConsumes(edm::ConsumesCollector iC) override
-  {
-      particleBasedIsolationToken_ = iC.mayConsume<edm::ValueMap<std::vector<reco::PFCandidateRef > > >(_particleBasedIsolation);
+  void setConsumes(edm::ConsumesCollector iC) override {
+    particleBasedIsolationToken_ =
+        iC.mayConsume<edm::ValueMap<std::vector<reco::PFCandidateRef> > >(_particleBasedIsolation);
   }
 
   //! Destructor
   ~PhotonPFIsolationWithMapBasedVeto() override{};
-  
-  
-private:    
+
+private:
   const std::string _isolateAgainst, _vertexCollection;
   const std::vector<unsigned> _miniAODVertexCodes;
   const unsigned _vertexIndex;
   const edm::InputTag _particleBasedIsolation;
-
-  
 };
 
 DEFINE_EDM_PLUGIN(CITKIsolationConeDefinitionFactory,
-		  PhotonPFIsolationWithMapBasedVeto,
-		  "PhotonPFIsolationWithMapBasedVeto");
-
+                  PhotonPFIsolationWithMapBasedVeto,
+                  "PhotonPFIsolationWithMapBasedVeto");
 
 //This function defines whether particular PFCandidate is inside of isolation cone of photon or not by checking deltaR and whether footprint removal for this candidate should be done. Additionally, for miniAOD charged hadrons from the PV are considered. *** For AOD this should be done by the corresponding sequence beforehand!!! ***
- 
-bool PhotonPFIsolationWithMapBasedVeto::isInIsolationCone(const reco::CandidatePtr& photon,  const reco::CandidatePtr& pfCandidate  ) const {
- 
+
+bool PhotonPFIsolationWithMapBasedVeto::isInIsolationCone(const reco::CandidatePtr& photon,
+                                                          const reco::CandidatePtr& pfCandidate) const {
   //convert the photon and candidate objects to the corresponding pat or reco objects. What is used depends on what is user running on: miniAOD or AOD
   pat::patPhotonPtr aspat_photonptr(photon);
-  
+
   pat::PackedCandidatePtr aspacked(pfCandidate);
   reco::PFCandidatePtr aspf(pfCandidate);
 
-  
   bool inFootprint = false;
   bool result = true;
-  const float deltar2 = reco::deltaR2(*photon,*pfCandidate); //calculate deltaR2 distance between PFCandidate and photon
-  
+  const float deltar2 =
+      reco::deltaR2(*photon, *pfCandidate);  //calculate deltaR2 distance between PFCandidate and photon
+
   // dealing here with patObjects: miniAOD case
-  if ( aspacked.get() )    
-  {
-    inFootprint = isInFootprint(aspat_photonptr ->associatedPackedPFCandidates(),aspacked);
-    
+  if (aspacked.get()) {
+    inFootprint = isInFootprint(aspat_photonptr->associatedPackedPFCandidates(), aspacked);
+
     //checking if the charged candidates come from the appropriate vertex
-    if( aspacked->charge() != 0 ) 
-    {
+    if (aspacked->charge() != 0) {
       bool is_vertex_allowed = false;
-      for( const unsigned vtxtype : _miniAODVertexCodes ) 
-      {
-	     if( vtxtype == aspacked->fromPV(_vertexIndex) ) {
-	         is_vertex_allowed = true;
-	         break;
-	       }
-      }      
-    
-     result &= (is_vertex_allowed);
+      for (const unsigned vtxtype : _miniAODVertexCodes) {
+        if (vtxtype == aspacked->fromPV(_vertexIndex)) {
+          is_vertex_allowed = true;
+          break;
+        }
+      }
+
+      result &= (is_vertex_allowed);
     }
-     //return true if the candidate is inside the cone and not in the footprint
+    //return true if the candidate is inside the cone and not in the footprint
     result &= deltar2 < _coneSize2 && (!inFootprint);
 
-   }
-  
-  // dealing here with recoObjects: AOD case
-  else if ( aspf.get() && aspf.isNonnull())
-  { 
-     inFootprint = isInFootprintAlternative((*particleBasedIsolationMap)[photon], aspf); 
-     result &=  deltar2 < _coneSize2 && (!inFootprint);
-     
   }
-  
+
+  // dealing here with recoObjects: AOD case
+  else if (aspf.get() && aspf.isNonnull()) {
+    inFootprint = isInFootprintAlternative((*particleBasedIsolationMap)[photon], aspf);
+    result &= deltar2 < _coneSize2 && (!inFootprint);
+
+  }
+
   // throw exception if it is not a patObject or recoObject
   else {
-    throw cms::Exception("InvalidIsolationInput")
-      << "The supplied candidate to be used as isolation "
-      << "was neither a reco::Photon nor a pat::Photon!";
+    throw cms::Exception("InvalidIsolationInput") << "The supplied candidate to be used as isolation "
+                                                  << "was neither a reco::Photon nor a pat::Photon!";
   }
-  
+
   return result;
 }

--- a/RecoEgamma/EgammaIsolationAlgos/plugins/module.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/plugins/module.cc
@@ -1,7 +1,6 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
 #include "PhysicsTools/IsolationAlgos/interface/IsoDepositExtractor.h"
 #include "PhysicsTools/IsolationAlgos/interface/IsoDepositExtractorFactory.h"
 #include "EgammaTrackExtractor.h"
@@ -9,10 +8,10 @@
 #include "EgammaHcalExtractor.h"
 #include "EgammaTowerExtractor.h"
 #include "EgammaRecHitExtractor.h"
-DEFINE_EDM_PLUGIN(IsoDepositExtractorFactory, egammaisolation::EgammaTrackExtractor,  "EgammaTrackExtractor");
-DEFINE_EDM_PLUGIN(IsoDepositExtractorFactory, egammaisolation::EgammaEcalExtractor,   "EgammaEcalExtractor");
-DEFINE_EDM_PLUGIN(IsoDepositExtractorFactory, egammaisolation::EgammaHcalExtractor,   "EgammaHcalExtractor");
-DEFINE_EDM_PLUGIN(IsoDepositExtractorFactory, egammaisolation::EgammaTowerExtractor,  "EgammaTowerExtractor");
+DEFINE_EDM_PLUGIN(IsoDepositExtractorFactory, egammaisolation::EgammaTrackExtractor, "EgammaTrackExtractor");
+DEFINE_EDM_PLUGIN(IsoDepositExtractorFactory, egammaisolation::EgammaEcalExtractor, "EgammaEcalExtractor");
+DEFINE_EDM_PLUGIN(IsoDepositExtractorFactory, egammaisolation::EgammaHcalExtractor, "EgammaHcalExtractor");
+DEFINE_EDM_PLUGIN(IsoDepositExtractorFactory, egammaisolation::EgammaTowerExtractor, "EgammaTowerExtractor");
 DEFINE_EDM_PLUGIN(IsoDepositExtractorFactory, egammaisolation::EgammaRecHitExtractor, "EgammaRecHitExtractor");
 
 #include "EgammaEcalRecHitIsolationProducer.h"
@@ -40,4 +39,3 @@ DEFINE_FWK_MODULE(EleIsoDetIdCollectionProducer);
 DEFINE_FWK_MODULE(GamIsoDetIdCollectionProducer);
 DEFINE_FWK_MODULE(EgammaIsoHcalDetIdCollectionProducer);
 DEFINE_FWK_MODULE(EgammaIsoESDetIdCollectionProducer);
-

--- a/RecoEgamma/EgammaIsolationAlgos/src/EGHcalRecHitSelector.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EGHcalRecHitSelector.cc
@@ -1,53 +1,52 @@
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EGHcalRecHitSelector.h"
 
-#include<limits>
+#include <limits>
 
-EGHcalRecHitSelector::EGHcalRecHitSelector(const edm::ParameterSet& config):
-  maxDIEta_(config.getParameter<int>("maxDIEta")),
-  maxDIPhi_(config.getParameter<int>("maxDIPhi")),
-  minEnergyHB_(config.getParameter<double>("minEnergyHB")),
-  minEnergyHEDepth1_(config.getParameter<double>("minEnergyHEDepth1")),
-  minEnergyHEDefault_(config.getParameter<double>("minEnergyHEDefault"))
-{
+EGHcalRecHitSelector::EGHcalRecHitSelector(const edm::ParameterSet& config)
+    : maxDIEta_(config.getParameter<int>("maxDIEta")),
+      maxDIPhi_(config.getParameter<int>("maxDIPhi")),
+      minEnergyHB_(config.getParameter<double>("minEnergyHB")),
+      minEnergyHEDepth1_(config.getParameter<double>("minEnergyHEDepth1")),
+      minEnergyHEDefault_(config.getParameter<double>("minEnergyHEDefault")) {}
 
+edm::ParameterSetDescription EGHcalRecHitSelector::makePSetDescription() {
+  edm::ParameterSetDescription desc;
+  desc.add<int>("maxDIEta", 5);
+  desc.add<int>("maxDIPhi", 5);
+  desc.add<double>("minEnergyHB", 0.8);
+  desc.add<double>("minEnergyHEDepth1", 0.1);
+  desc.add<double>("minEnergyHEDefault", 0.2);
+  return desc;
 }
 
-edm::ParameterSetDescription EGHcalRecHitSelector::makePSetDescription()
-{
- edm::ParameterSetDescription desc;
- desc.add<int>("maxDIEta",5);
- desc.add<int>("maxDIPhi",5);
- desc.add<double>("minEnergyHB",0.8);
- desc.add<double>("minEnergyHEDepth1",0.1);
- desc.add<double>("minEnergyHEDefault",0.2);
- return desc; 
-}
-
-int EGHcalRecHitSelector::calDIEta(int iEta1,int iEta2)
-{  
-  int dEta = iEta1-iEta2;
-  if(iEta1*iEta2<0) {//-ve to +ve transistion and no crystal at zero
-    if(dEta<0) dEta++;
-    else dEta--;
+int EGHcalRecHitSelector::calDIEta(int iEta1, int iEta2) {
+  int dEta = iEta1 - iEta2;
+  if (iEta1 * iEta2 < 0) {  //-ve to +ve transistion and no crystal at zero
+    if (dEta < 0)
+      dEta++;
+    else
+      dEta--;
   }
   return dEta;
 }
 
-
-int EGHcalRecHitSelector::calDIPhi(int iPhi1,int iPhi2)
-{
-  int dPhi = iPhi1-iPhi2;
-  if(dPhi>72/2) dPhi-=72;
-  else if(dPhi<-72/2) dPhi+=72;
+int EGHcalRecHitSelector::calDIPhi(int iPhi1, int iPhi2) {
+  int dPhi = iPhi1 - iPhi2;
+  if (dPhi > 72 / 2)
+    dPhi -= 72;
+  else if (dPhi < -72 / 2)
+    dPhi += 72;
   return dPhi;
 }
 
-float EGHcalRecHitSelector::getMinEnergyHCAL_(HcalDetId id)const
-{
-  if(id.subdetId()==HcalBarrel) return minEnergyHB_;
-  else if(id.subdetId()==HcalEndcap){
-    if(id.depth()==1) return minEnergyHEDepth1_;
-    else return minEnergyHEDefault_;
-  }else return std::numeric_limits<float>::max();
-
+float EGHcalRecHitSelector::getMinEnergyHCAL_(HcalDetId id) const {
+  if (id.subdetId() == HcalBarrel)
+    return minEnergyHB_;
+  else if (id.subdetId() == HcalEndcap) {
+    if (id.depth() == 1)
+      return minEnergyHEDepth1_;
+    else
+      return minEnergyHEDefault_;
+  } else
+    return std::numeric_limits<float>::max();
 }

--- a/RecoEgamma/EgammaIsolationAlgos/src/EcalPFClusterIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EcalPFClusterIsolation.cc
@@ -15,56 +15,55 @@
 
 #include <DataFormats/Math/interface/deltaR.h>
 
-template<typename T1>
+template <typename T1>
 EcalPFClusterIsolation<T1>::EcalPFClusterIsolation(double drMax,
-						   double drVetoBarrel,
-						   double drVetoEndcap,
-						   double etaStripBarrel,
-						   double etaStripEndcap,
-						   double energyBarrel,
-						   double energyEndcap):
-  drMax_(drMax),
-  drVetoBarrel_(drVetoBarrel),
-  drVetoEndcap_(drVetoEndcap),
-  etaStripBarrel_(etaStripBarrel),
-  etaStripEndcap_(etaStripEndcap),
-  energyBarrel_(energyBarrel),
-  energyEndcap_(energyEndcap)
-{}
+                                                   double drVetoBarrel,
+                                                   double drVetoEndcap,
+                                                   double etaStripBarrel,
+                                                   double etaStripEndcap,
+                                                   double energyBarrel,
+                                                   double energyEndcap)
+    : drMax_(drMax),
+      drVetoBarrel_(drVetoBarrel),
+      drVetoEndcap_(drVetoEndcap),
+      etaStripBarrel_(etaStripBarrel),
+      etaStripEndcap_(etaStripEndcap),
+      energyBarrel_(energyBarrel),
+      energyEndcap_(energyEndcap) {}
 
-template<typename T1>
-EcalPFClusterIsolation<T1>::~EcalPFClusterIsolation() 
-{}
+template <typename T1>
+EcalPFClusterIsolation<T1>::~EcalPFClusterIsolation() {}
 
-template<typename T1>
+template <typename T1>
 double EcalPFClusterIsolation<T1>::getSum(const T1Ref candRef, edm::Handle<reco::PFClusterCollection> clusterHandle) {
-  
   drVeto2_ = -1.;
   float etaStrip = -1;
- 
+
   if (fabs(candRef->eta()) < 1.479) {
-    drVeto2_ = drVetoBarrel_*drVetoBarrel_;
+    drVeto2_ = drVetoBarrel_ * drVetoBarrel_;
     etaStrip = etaStripBarrel_;
   } else {
-    drVeto2_ = drVetoEndcap_*drVetoEndcap_;
+    drVeto2_ = drVetoEndcap_ * drVetoEndcap_;
     etaStrip = etaStripEndcap_;
   }
-   
+
   float etSum = 0;
-  for (size_t i=0; i<clusterHandle->size(); i++) {
+  for (size_t i = 0; i < clusterHandle->size(); i++) {
     reco::PFClusterRef pfclu(clusterHandle, i);
 
     if (fabs(candRef->eta()) < 1.479) {
       if (fabs(pfclu->pt()) < energyBarrel_)
-	continue;
+        continue;
     } else {
       if (fabs(pfclu->energy()) < energyEndcap_)
-	continue;
+        continue;
     }
-    
+
     float dEta = fabs(candRef->eta() - pfclu->eta());
-    if(dEta < etaStrip) continue;
-    if (not computedRVeto(candRef, pfclu)) continue;
+    if (dEta < etaStrip)
+      continue;
+    if (not computedRVeto(candRef, pfclu))
+      continue;
 
     etSum += pfclu->pt();
   }
@@ -72,18 +71,19 @@ double EcalPFClusterIsolation<T1>::getSum(const T1Ref candRef, edm::Handle<reco:
   return etSum;
 }
 
-template<typename T1>
+template <typename T1>
 bool EcalPFClusterIsolation<T1>::computedRVeto(T1Ref candRef, reco::PFClusterRef pfclu) {
-
   float dR2 = deltaR2(candRef->eta(), candRef->phi(), pfclu->eta(), pfclu->phi());
-  if(dR2 > (drMax_*drMax_))
+  if (dR2 > (drMax_ * drMax_))
     return false;
 
   if (candRef->superCluster().isNonnull()) {
     // Exclude clusters that are part of the candidate
-    for (reco::CaloCluster_iterator it = candRef->superCluster()->clustersBegin(); it != candRef->superCluster()->clustersEnd(); ++it) {
+    for (reco::CaloCluster_iterator it = candRef->superCluster()->clustersBegin();
+         it != candRef->superCluster()->clustersEnd();
+         ++it) {
       if ((*it)->seed() == pfclu->seed()) {
-	return false;
+        return false;
       }
     }
   }
@@ -91,11 +91,10 @@ bool EcalPFClusterIsolation<T1>::computedRVeto(T1Ref candRef, reco::PFClusterRef
   return true;
 }
 
-template<>
+template <>
 bool EcalPFClusterIsolation<reco::RecoChargedCandidate>::computedRVeto(T1Ref candRef, reco::PFClusterRef pfclu) {
-
   float dR2 = deltaR2(candRef->eta(), candRef->phi(), pfclu->eta(), pfclu->phi());
-  if(dR2 > (drMax_*drMax_) || dR2 < drVeto2_)
+  if (dR2 > (drMax_ * drMax_) || dR2 < drVeto2_)
     return false;
   else
     return true;

--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaEcalIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaEcalIsolation.cc
@@ -17,100 +17,88 @@
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaEcalIsolation.h"
 #include "DataFormats/RecoCandidate/interface/RecoCandidate.h"
 
-using namespace ROOT::Math::VectorUtil ;
+using namespace ROOT::Math::VectorUtil;
 
+EgammaEcalIsolation::EgammaEcalIsolation(double extRadius,
+                                         double etLow,
+                                         const reco::BasicClusterCollection* basicClusterCollection,
+                                         const reco::SuperClusterCollection* superClusterCollection)
+    : etMin(etLow),
+      conesize(extRadius),
+      basicClusterCollection_(basicClusterCollection),
+      superClusterCollection_(superClusterCollection) {}
 
-EgammaEcalIsolation::EgammaEcalIsolation (double extRadius,
-					  double etLow,
-					  const reco::BasicClusterCollection* basicClusterCollection,
-					  const reco::SuperClusterCollection* superClusterCollection):
-  etMin(etLow),
-  conesize(extRadius),
-  basicClusterCollection_(basicClusterCollection),
-  superClusterCollection_(superClusterCollection)
-{
-}
+EgammaEcalIsolation::~EgammaEcalIsolation() {}
 
-EgammaEcalIsolation::~EgammaEcalIsolation(){}
-
-double EgammaEcalIsolation::getEcalEtSum(const reco::Candidate* candidate){
-
-  
-  double ecalIsol=0.;
+double EgammaEcalIsolation::getEcalEtSum(const reco::Candidate* candidate) {
+  double ecalIsol = 0.;
   reco::SuperClusterRef sc = candidate->get<reco::SuperClusterRef>();
-  math::XYZVector position(sc.get()->position().x(),
-		   sc.get()->position().y(),
-		   sc.get()->position().z());
-  
+  math::XYZVector position(sc.get()->position().x(), sc.get()->position().y(), sc.get()->position().z());
+
   // match the photon hybrid supercluster with those with Algo==0 (island)
-  double delta1=1000.;
-  double deltacur=1000.;
-  const reco::SuperCluster *matchedsupercluster=nullptr;
+  double delta1 = 1000.;
+  double deltacur = 1000.;
+  const reco::SuperCluster* matchedsupercluster = nullptr;
   bool MATCHEDSC = false;
-  
-  for(reco::SuperClusterCollection::const_iterator scItr = superClusterCollection_->begin(); scItr != superClusterCollection_->end(); ++scItr){
-    
-    const reco::SuperCluster *supercluster = &(*scItr);
- 
-    math::XYZVector currentPosition(supercluster->position().x(),
-		     supercluster->position().y(),
-		     supercluster->position().z());
- 
-    
-    if(supercluster->seed()->algo() == 0){
-      deltacur = DeltaR(currentPosition, position); 
-      
+
+  for (reco::SuperClusterCollection::const_iterator scItr = superClusterCollection_->begin();
+       scItr != superClusterCollection_->end();
+       ++scItr) {
+    const reco::SuperCluster* supercluster = &(*scItr);
+
+    math::XYZVector currentPosition(
+        supercluster->position().x(), supercluster->position().y(), supercluster->position().z());
+
+    if (supercluster->seed()->algo() == 0) {
+      deltacur = DeltaR(currentPosition, position);
+
       if (deltacur < delta1) {
-        delta1=deltacur;
-	matchedsupercluster = supercluster;
-	MATCHEDSC = true;
+        delta1 = deltacur;
+        matchedsupercluster = supercluster;
+        MATCHEDSC = true;
       }
     }
   }
 
-  const reco::BasicCluster *cluster= nullptr;
-  
+  const reco::BasicCluster* cluster = nullptr;
+
   //loop over basic clusters
-  for(reco::BasicClusterCollection::const_iterator cItr = basicClusterCollection_->begin(); cItr != basicClusterCollection_->end(); ++cItr){
- 
+  for (reco::BasicClusterCollection::const_iterator cItr = basicClusterCollection_->begin();
+       cItr != basicClusterCollection_->end();
+       ++cItr) {
     cluster = &(*cItr);
-//    double ebc_bcchi2 = cluster->chi2();
-    int   ebc_bcalgo = cluster->algo();
-    double ebc_bce    = cluster->energy();
-    double ebc_bceta  = cluster->eta();
-    double ebc_bcet   = ebc_bce*sin(2*atan(exp(ebc_bceta)));
+    //    double ebc_bcchi2 = cluster->chi2();
+    int ebc_bcalgo = cluster->algo();
+    double ebc_bce = cluster->energy();
+    double ebc_bceta = cluster->eta();
+    double ebc_bcet = ebc_bce * sin(2 * atan(exp(ebc_bceta)));
     double newDelta = 0.;
 
-
     if (ebc_bcet > etMin && ebc_bcalgo == 0) {
-  //    if (ebc_bcchi2 < 30.) {
-	
-	if(MATCHEDSC){
-	  bool inSuperCluster = false;
+      //    if (ebc_bcchi2 < 30.) {
 
-	  reco::CaloCluster_iterator theEclust = matchedsupercluster->clustersBegin();
-	  // loop over the basic clusters of the matched supercluster
-	  for(;theEclust != matchedsupercluster->clustersEnd();
-	      theEclust++) {
-	    if ((**theEclust) ==  (*cluster) ) inSuperCluster = true;
-	  }
-	  if (!inSuperCluster) {
+      if (MATCHEDSC) {
+        bool inSuperCluster = false;
 
-	    math::XYZVector basicClusterPosition(cluster->position().x(),
-						  cluster->position().y(),
-						  cluster->position().z());
-	    newDelta=DeltaR(basicClusterPosition,position);
-	    if(newDelta < conesize) {
-	      ecalIsol+=ebc_bcet;
-	    }
-	  }
-	}
-//      } // matches ebc_bcchi2
-    } // matches ebc_bcet && ebc_bcalgo
-
+        reco::CaloCluster_iterator theEclust = matchedsupercluster->clustersBegin();
+        // loop over the basic clusters of the matched supercluster
+        for (; theEclust != matchedsupercluster->clustersEnd(); theEclust++) {
+          if ((**theEclust) == (*cluster))
+            inSuperCluster = true;
+        }
+        if (!inSuperCluster) {
+          math::XYZVector basicClusterPosition(
+              cluster->position().x(), cluster->position().y(), cluster->position().z());
+          newDelta = DeltaR(basicClusterPosition, position);
+          if (newDelta < conesize) {
+            ecalIsol += ebc_bcet;
+          }
+        }
+      }
+      //      } // matches ebc_bcchi2
+    }  // matches ebc_bcet && ebc_bcalgo
   }
-  
-  //  std::cout << "Will return ecalIsol = " << ecalIsol << std::endl; 
+
+  //  std::cout << "Will return ecalIsol = " << ecalIsol << std::endl;
   return ecalIsol;
-  
 }

--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaHadTower.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaHadTower.cc
@@ -17,29 +17,28 @@
 
 //#define EDM_ML_DEBUG
 
-EgammaHadTower::EgammaHadTower(const edm::EventSetup &es,HoeMode mode):mode_(mode) {
+EgammaHadTower::EgammaHadTower(const edm::EventSetup& es, HoeMode mode) : mode_(mode) {
   edm::ESHandle<CaloTowerConstituentsMap> ctmaph;
   es.get<CaloGeometryRecord>().get(ctmaph);
   towerMap_ = &(*ctmaph);
   NMaxClusters_ = 4;
 
   edm::ESHandle<HcalChannelQuality> hQuality;
-  es.get<HcalChannelQualityRcd>().get("withTopo",hQuality);
+  es.get<HcalChannelQualityRcd>().get("withTopo", hQuality);
   hcalQuality_ = hQuality.product();
 
   edm::ESHandle<HcalTopology> hcalTopology;
-  es.get<HcalRecNumberingRecord>().get( hcalTopology ); 
+  es.get<HcalRecNumberingRecord>().get(hcalTopology);
   hcalTopology_ = hcalTopology.product();
-
 }
 
-CaloTowerDetId  EgammaHadTower::towerOf(const reco::CaloCluster& cluster) const {
+CaloTowerDetId EgammaHadTower::towerOf(const reco::CaloCluster& cluster) const {
   DetId detid = cluster.seed();
-  if(detid.det() != DetId::Ecal) {
-    // Basic clusters of hybrid super-cluster do not have the seed set; take the first DetId instead 
+  if (detid.det() != DetId::Ecal) {
+    // Basic clusters of hybrid super-cluster do not have the seed set; take the first DetId instead
     // Should be checked . The single Tower Mode should be favoured until fixed
     detid = cluster.hitsAndFractions()[0].first;
-    if(detid.det() != DetId::Ecal) {
+    if (detid.det() != DetId::Ecal) {
       CaloTowerDetId tower;
       return tower;
     }
@@ -48,148 +47,138 @@ CaloTowerDetId  EgammaHadTower::towerOf(const reco::CaloCluster& cluster) const 
   return id;
 }
 
-std::vector<CaloTowerDetId>  EgammaHadTower::towersOf(const reco::SuperCluster& sc) const {
+std::vector<CaloTowerDetId> EgammaHadTower::towersOf(const reco::SuperCluster& sc) const {
   std::vector<CaloTowerDetId> towers;
-  std::vector<reco::CaloClusterPtr>  orderedClusters;
+  std::vector<reco::CaloClusterPtr> orderedClusters;
 
   // in this mode, check only the tower behind the seed
-  if ( mode_ == SingleTower ) {
+  if (mode_ == SingleTower) {
     towers.push_back(towerOf(*sc.seed()));
   }
 
   // in this mode check the towers behind each basic cluster
-  if ( mode_ == TowersBehindCluster ) {
+  if (mode_ == TowersBehindCluster) {
     // Loop on the basic clusters
     reco::CaloCluster_iterator it = sc.clustersBegin();
     reco::CaloCluster_iterator itend = sc.clustersEnd();
 
-    for ( ; it !=itend; ++it) {
+    for (; it != itend; ++it) {
       orderedClusters.push_back(*it);
     }
-    std::sort(orderedClusters.begin(),orderedClusters.end(),ClusterGreaterThan);
-    unsigned nclusters=orderedClusters.size();
-    for ( unsigned iclus =0 ; iclus <nclusters && iclus < NMaxClusters_; ++iclus) {
+    std::sort(orderedClusters.begin(), orderedClusters.end(), ClusterGreaterThan);
+    unsigned nclusters = orderedClusters.size();
+    for (unsigned iclus = 0; iclus < nclusters && iclus < NMaxClusters_; ++iclus) {
       // Get the tower
       CaloTowerDetId id = towerOf(*(orderedClusters[iclus]));
 #ifdef EDM_ML_DEBUG
-      std:: cout << "CaloTowerId " << id << std::endl;
+      std::cout << "CaloTowerId " << id << std::endl;
 #endif
-      std::vector<CaloTowerDetId>::const_iterator itcheck=find(towers.begin(),towers.end(),id);
-      if( itcheck == towers.end() ) {
-	towers.push_back(id);
+      std::vector<CaloTowerDetId>::const_iterator itcheck = find(towers.begin(), towers.end(), id);
+      if (itcheck == towers.end()) {
+        towers.push_back(id);
       }
     }
   }
-//  if(towers.size() > 4) {
-//    std::cout << " NTOWERS " << towers.size() << " ";
-//    for(unsigned i=0; i<towers.size() ; ++i) {
-//      std::cout << towers[i] << " ";
-//    }
-//    std::cout <<  std::endl;
-//    for ( unsigned iclus=0 ; iclus < orderedClusters.size(); ++iclus) {
-//      // Get the tower
-//      CaloTowerDetId id = towerOf(*(orderedClusters[iclus]));
-//      std::cout << " Pos " << orderedClusters[iclus]->position() << " " << orderedClusters[iclus]->energy() << " " << id ;
-//    }
-//    std::cout << std::endl;
-//  }
+  //  if(towers.size() > 4) {
+  //    std::cout << " NTOWERS " << towers.size() << " ";
+  //    for(unsigned i=0; i<towers.size() ; ++i) {
+  //      std::cout << towers[i] << " ";
+  //    }
+  //    std::cout <<  std::endl;
+  //    for ( unsigned iclus=0 ; iclus < orderedClusters.size(); ++iclus) {
+  //      // Get the tower
+  //      CaloTowerDetId id = towerOf(*(orderedClusters[iclus]));
+  //      std::cout << " Pos " << orderedClusters[iclus]->position() << " " << orderedClusters[iclus]->energy() << " " << id ;
+  //    }
+  //    std::cout << std::endl;
+  //  }
   return towers;
 }
 
-double EgammaHadTower::getDepth1HcalESum(const std::vector<CaloTowerDetId> & towers) const {
-  double esum=0.;
+double EgammaHadTower::getDepth1HcalESum(const std::vector<CaloTowerDetId>& towers) const {
+  double esum = 0.;
   CaloTowerCollection::const_iterator trItr = towerCollection_->begin();
   CaloTowerCollection::const_iterator trItrEnd = towerCollection_->end();
-  for( ;  trItr != trItrEnd ; ++trItr){
+  for (; trItr != trItrEnd; ++trItr) {
     std::vector<CaloTowerDetId>::const_iterator itcheck = find(towers.begin(), towers.end(), trItr->id());
-    if( itcheck != towers.end() ) {
-      esum += trItr->ietaAbs()<18 || trItr->ietaAbs()>29 ? trItr->hadEnergy() : trItr->hadEnergyHeInnerLayer() ;
+    if (itcheck != towers.end()) {
+      esum += trItr->ietaAbs() < 18 || trItr->ietaAbs() > 29 ? trItr->hadEnergy() : trItr->hadEnergyHeInnerLayer();
     }
   }
   return esum;
 }
 
-double EgammaHadTower::getDepth2HcalESum(const std::vector<CaloTowerDetId> & towers) const {
-  double esum=0.;
+double EgammaHadTower::getDepth2HcalESum(const std::vector<CaloTowerDetId>& towers) const {
+  double esum = 0.;
   CaloTowerCollection::const_iterator trItr = towerCollection_->begin();
   CaloTowerCollection::const_iterator trItrEnd = towerCollection_->end();
-  for( ;  trItr != trItrEnd ; ++trItr){
+  for (; trItr != trItrEnd; ++trItr) {
     std::vector<CaloTowerDetId>::const_iterator itcheck = find(towers.begin(), towers.end(), trItr->id());
-    if( itcheck != towers.end() ) {
+    if (itcheck != towers.end()) {
       esum += trItr->hadEnergyHeOuterLayer();
     }
   }
   return esum;
 }
 
-bool EgammaHadTower::hasActiveHcal( const std::vector<CaloTowerDetId> & towers ) const {
-
+bool EgammaHadTower::hasActiveHcal(const std::vector<CaloTowerDetId>& towers) const {
   bool active = false;
-  int statusMask = ((1<<HcalChannelStatus::HcalCellOff) | (1<<HcalChannelStatus::HcalCellMask) | (1<<HcalChannelStatus::HcalCellDead));
+  int statusMask = ((1 << HcalChannelStatus::HcalCellOff) | (1 << HcalChannelStatus::HcalCellMask) |
+                    (1 << HcalChannelStatus::HcalCellDead));
 #ifdef EDM_ML_DEBUG
-  std::cout << "DEBUG: hasActiveHcal called with " << towers.size() 
-	    << " detids. First tower detid ieta " << towers.front().ieta() 
-	    << " iphi " << towers.front().iphi() << std::endl;
+  std::cout << "DEBUG: hasActiveHcal called with " << towers.size() << " detids. First tower detid ieta "
+            << towers.front().ieta() << " iphi " << towers.front().iphi() << std::endl;
 #endif
   for (auto towerid : towers) {
-      unsigned int ngood = 0, nbad = 0;
-      for (DetId id : towerMap_->constituentsOf(towerid)) {
-          if (id.det() != DetId::Hcal) {
-              continue;
-          }
-          HcalDetId hid(id);
-          if (hid.subdet() != HcalBarrel && hid.subdet() != HcalEndcap) continue;
+    unsigned int ngood = 0, nbad = 0;
+    for (DetId id : towerMap_->constituentsOf(towerid)) {
+      if (id.det() != DetId::Hcal) {
+        continue;
+      }
+      HcalDetId hid(id);
+      if (hid.subdet() != HcalBarrel && hid.subdet() != HcalEndcap)
+        continue;
 #ifdef EDM_ML_DEBUG
-          std::cout << "EgammaHadTower DetId " << std::hex << id.rawId() 
-		    << "  hid.rawId  " << hid.rawId() << std::dec   
-		    << "   sub " << hid.subdet() << "   ieta " << hid.ieta() 
-		    << "   iphi " << hid.iphi() 
-		    << "   depth " << hid.depth() << std::endl;
+      std::cout << "EgammaHadTower DetId " << std::hex << id.rawId() << "  hid.rawId  " << hid.rawId() << std::dec
+                << "   sub " << hid.subdet() << "   ieta " << hid.ieta() << "   iphi " << hid.iphi() << "   depth "
+                << hid.depth() << std::endl;
 #endif
-	  // Sunanda's fix for 2017 Plan1   
-          // and removed protection 
-          int status = hcalQuality_->getValues((DetId)(hcalTopology_->idFront(HcalDetId(id))),/*throwOnFail=*/true)->getValue();
+      // Sunanda's fix for 2017 Plan1
+      // and removed protection
+      int status =
+          hcalQuality_->getValues((DetId)(hcalTopology_->idFront(HcalDetId(id))), /*throwOnFail=*/true)->getValue();
 
 #ifdef EDM_ML_DEBUG
-	  std::cout << "channels status = " << std::hex << status << std::dec 
-		    << "  int value = " <<  status << std::endl;
+      std::cout << "channels status = " << std::hex << status << std::dec << "  int value = " << status << std::endl;
 #endif
 
-          if (status & statusMask) {
+      if (status & statusMask) {
 #ifdef EDM_ML_DEBUG
-	    std::cout << "          BAD!" << std::endl;
+        std::cout << "          BAD!" << std::endl;
 #endif
-              nbad++;
-          } else {
-              ngood++;
-          }
+        nbad++;
+      } else {
+        ngood++;
       }
+    }
 #ifdef EDM_ML_DEBUG
-      std::cout << "    overall ngood " << ngood << " nbad " << nbad << "\n";
+    std::cout << "    overall ngood " << ngood << " nbad " << nbad << "\n";
 #endif
-      if (nbad == 0 || (ngood > 0 && nbad < ngood)) {
-          active = true;
-      }
+    if (nbad == 0 || (ngood > 0 && nbad < ngood)) {
+      active = true;
+    }
   }
   return active;
 }
 
-double EgammaHadTower::getDepth1HcalESum( const reco::SuperCluster& sc ) const {
-  return getDepth1HcalESum(towersOf(sc)) ;
-}
+double EgammaHadTower::getDepth1HcalESum(const reco::SuperCluster& sc) const { return getDepth1HcalESum(towersOf(sc)); }
 
-double EgammaHadTower::getDepth2HcalESum( const reco::SuperCluster& sc ) const {
-  return getDepth2HcalESum(towersOf(sc)) ;
-}
+double EgammaHadTower::getDepth2HcalESum(const reco::SuperCluster& sc) const { return getDepth2HcalESum(towersOf(sc)); }
 
 void EgammaHadTower::setTowerCollection(const CaloTowerCollection* towerCollection) {
   towerCollection_ = towerCollection;
 }
 
-bool EgammaHadTower::hasActiveHcal( const reco::SuperCluster & sc ) const {
-    return hasActiveHcal(towersOf(sc)) ;
-}
+bool EgammaHadTower::hasActiveHcal(const reco::SuperCluster& sc) const { return hasActiveHcal(towersOf(sc)); }
 
-bool ClusterGreaterThan(const reco::CaloClusterPtr& c1, const reco::CaloClusterPtr& c2)  {
-  return (*c1 > *c2);
-}
+bool ClusterGreaterThan(const reco::CaloClusterPtr& c1, const reco::CaloClusterPtr& c2) { return (*c1 > *c2); }

--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaHcalIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaHcalIsolation.cc
@@ -23,76 +23,73 @@
 using namespace std;
 
 double scaleToE(const double& eta) { return 1.0; }
-double scaleToEt(const double& eta) { return sin(2*atan(exp(-eta))); }
+double scaleToEt(const double& eta) { return sin(2 * atan(exp(-eta))); }
 
-EgammaHcalIsolation::EgammaHcalIsolation (
-        double extRadius,
-        double intRadius,
-        double eLowB,
-        double eLowE,
-        double etLowB,
-        double etLowE,
-        edm::ESHandle<CaloGeometry> theCaloGeom ,
-        const HBHERecHitCollection&  mhbhe
-) :
-  extRadius_(extRadius),
-  intRadius_(intRadius),
-  eLowB_(eLowB),
-  eLowE_(eLowE),
-  etLowB_(etLowB),
-  etLowE_(etLowE),
-  theCaloGeom_(theCaloGeom) ,  
-  mhbhe_(mhbhe)
-{
-    //set up the geometry and selector
-    const CaloGeometry* caloGeom = theCaloGeom_.product();
-    doubleConeSel_ = new CaloDualConeSelector<HBHERecHit>(intRadius_ ,extRadius_, caloGeom, DetId::Hcal);
+EgammaHcalIsolation::EgammaHcalIsolation(double extRadius,
+                                         double intRadius,
+                                         double eLowB,
+                                         double eLowE,
+                                         double etLowB,
+                                         double etLowE,
+                                         edm::ESHandle<CaloGeometry> theCaloGeom,
+                                         const HBHERecHitCollection& mhbhe)
+    : extRadius_(extRadius),
+      intRadius_(intRadius),
+      eLowB_(eLowB),
+      eLowE_(eLowE),
+      etLowB_(etLowB),
+      etLowE_(etLowE),
+      theCaloGeom_(theCaloGeom),
+      mhbhe_(mhbhe) {
+  //set up the geometry and selector
+  const CaloGeometry* caloGeom = theCaloGeom_.product();
+  doubleConeSel_ = new CaloDualConeSelector<HBHERecHit>(intRadius_, extRadius_, caloGeom, DetId::Hcal);
 }
 
-EgammaHcalIsolation::~EgammaHcalIsolation ()
-{
-    delete doubleConeSel_;
-}
+EgammaHcalIsolation::~EgammaHcalIsolation() { delete doubleConeSel_; }
 
-double EgammaHcalIsolation::getHcalSum(const GlobalPoint &pclu, const HcalDepth &depth,
-                                       double(*scale)(const double&) ) const
-{
-    double sum = 0.;
-    if (! mhbhe_.empty()) 
-    {
-        //Compute the HCAL energy behind ECAL
-        doubleConeSel_->selectCallback(pclu, mhbhe_, [this, &sum, &depth, &scale](const HBHERecHit& i) {
-            double eta = theCaloGeom_.product()->getPosition(i.detid()).eta();
-            HcalDetId hcalDetId(i.detid());
-            if(hcalDetId.subdet() == HcalBarrel &&              //Is it in the barrel?
-               i.energy() > eLowB_ &&                          //Does it pass the min energy?
-               i.energy()*scaleToEt(eta) > etLowB_ &&          //Does it pass the min et?
-               (depth == AllDepths || depth == Depth1)) {                    //Are we asking for the first depth?
-                    sum += i.energy() * scale(eta);
-            }
-            if(hcalDetId.subdet() == HcalEndcap &&              //Is it in the endcap?
-               i.energy() > eLowE_ &&                          //Does it pass the min energy?
-               i.energy()*scaleToEt(eta) > etLowE_ ) {         //Does it pass the min et?
-               switch(depth) {                                  //Which depth?
-                    case AllDepths: sum += i.energy() * scale(eta); break;
-                    case Depth1: sum += (isDepth2(i.detid())) ? 0 : i.energy() * scale(eta); break;
-                    case Depth2: sum += (isDepth2(i.detid())) ? i.energy() * scale(eta) : 0; break;
-               }
-            }
-        });
-    } 
+double EgammaHcalIsolation::getHcalSum(const GlobalPoint& pclu,
+                                       const HcalDepth& depth,
+                                       double (*scale)(const double&)) const {
+  double sum = 0.;
+  if (!mhbhe_.empty()) {
+    //Compute the HCAL energy behind ECAL
+    doubleConeSel_->selectCallback(pclu, mhbhe_, [this, &sum, &depth, &scale](const HBHERecHit& i) {
+      double eta = theCaloGeom_.product()->getPosition(i.detid()).eta();
+      HcalDetId hcalDetId(i.detid());
+      if (hcalDetId.subdet() == HcalBarrel &&         //Is it in the barrel?
+          i.energy() > eLowB_ &&                      //Does it pass the min energy?
+          i.energy() * scaleToEt(eta) > etLowB_ &&    //Does it pass the min et?
+          (depth == AllDepths || depth == Depth1)) {  //Are we asking for the first depth?
+        sum += i.energy() * scale(eta);
+      }
+      if (hcalDetId.subdet() == HcalEndcap &&       //Is it in the endcap?
+          i.energy() > eLowE_ &&                    //Does it pass the min energy?
+          i.energy() * scaleToEt(eta) > etLowE_) {  //Does it pass the min et?
+        switch (depth) {                            //Which depth?
+          case AllDepths:
+            sum += i.energy() * scale(eta);
+            break;
+          case Depth1:
+            sum += (isDepth2(i.detid())) ? 0 : i.energy() * scale(eta);
+            break;
+          case Depth2:
+            sum += (isDepth2(i.detid())) ? i.energy() * scale(eta) : 0;
+            break;
+        }
+      }
+    });
+  }
 
-    return sum ;
+  return sum;
 }
 
 bool EgammaHcalIsolation::isDepth2(const DetId& detId) const {
-    
-    if( (HcalDetId(detId).depth()==2 && HcalDetId(detId).ietaAbs()>=18 && HcalDetId(detId).ietaAbs()<27) ||
-        (HcalDetId(detId).depth()==3 && HcalDetId(detId).ietaAbs()==27) ) {
+  if ((HcalDetId(detId).depth() == 2 && HcalDetId(detId).ietaAbs() >= 18 && HcalDetId(detId).ietaAbs() < 27) ||
+      (HcalDetId(detId).depth() == 3 && HcalDetId(detId).ietaAbs() == 27)) {
+    return true;
 
-        return true;
-
-   } else {
-        return false;
-   }
+  } else {
+    return false;
+  }
 }

--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaRecHitIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaRecHitIsolation.cc
@@ -29,256 +29,253 @@
 
 using namespace std;
 
-EgammaRecHitIsolation::EgammaRecHitIsolation (double extRadius,
-                                              double intRadius,
-                                              double etaSlice,
-                                              double etLow,
-                                              double eLow,
-                                              edm::ESHandle<CaloGeometry> theCaloGeom,
-                                              const EcalRecHitCollection& caloHits,
-                                              const EcalSeverityLevelAlgo* sl,
-                                              DetId::Detector detector):  // not used anymore, kept for compatibility
-    extRadius_(extRadius),
-    intRadius_(intRadius),
-    etaSlice_(etaSlice),
-    etLow_(etLow),
-    eLow_(eLow),
-    theCaloGeom_(theCaloGeom) ,  
-    caloHits_(caloHits),
-    sevLevel_(sl),
-    useNumCrystals_(false),
-    vetoClustered_(false),
-    ecalBarHits_(nullptr),
-    //chStatus_(0),
-    severitiesexcl_(0),
-    //severityRecHitThreshold_(0),
-    //spId_(EcalSeverityLevelAlgo::kSwissCross),
-    //spIdThreshold_(0),
-    flags_(0)
-{
-    //set up the geometry and selector
-    const CaloGeometry* caloGeom = theCaloGeom_.product();
-    subdet_[0] = caloGeom->getSubdetectorGeometry(DetId::Ecal,EcalBarrel);
-    subdet_[1] = caloGeom->getSubdetectorGeometry(DetId::Ecal,EcalEndcap);
-
+EgammaRecHitIsolation::EgammaRecHitIsolation(double extRadius,
+                                             double intRadius,
+                                             double etaSlice,
+                                             double etLow,
+                                             double eLow,
+                                             edm::ESHandle<CaloGeometry> theCaloGeom,
+                                             const EcalRecHitCollection& caloHits,
+                                             const EcalSeverityLevelAlgo* sl,
+                                             DetId::Detector detector)
+    :  // not used anymore, kept for compatibility
+      extRadius_(extRadius),
+      intRadius_(intRadius),
+      etaSlice_(etaSlice),
+      etLow_(etLow),
+      eLow_(eLow),
+      theCaloGeom_(theCaloGeom),
+      caloHits_(caloHits),
+      sevLevel_(sl),
+      useNumCrystals_(false),
+      vetoClustered_(false),
+      ecalBarHits_(nullptr),
+      //chStatus_(0),
+      severitiesexcl_(0),
+      //severityRecHitThreshold_(0),
+      //spId_(EcalSeverityLevelAlgo::kSwissCross),
+      //spIdThreshold_(0),
+      flags_(0) {
+  //set up the geometry and selector
+  const CaloGeometry* caloGeom = theCaloGeom_.product();
+  subdet_[0] = caloGeom->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
+  subdet_[1] = caloGeom->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
 }
 
-EgammaRecHitIsolation::~EgammaRecHitIsolation ()
-{}
+EgammaRecHitIsolation::~EgammaRecHitIsolation() {}
 
-double EgammaRecHitIsolation::getSum_(const reco::Candidate* emObject,bool returnEt) const {
-  
+double EgammaRecHitIsolation::getSum_(const reco::Candidate* emObject, bool returnEt) const {
   double energySum = 0.;
-  if (! caloHits_.empty()) {
+  if (!caloHits_.empty()) {
     //Take the SC position
     reco::SuperClusterRef sc = emObject->get<reco::SuperClusterRef>();
-    math::XYZPoint const & theCaloPosition = sc.get()->position();
-    GlobalPoint pclu (theCaloPosition.x () ,
-		      theCaloPosition.y () ,
-		      theCaloPosition.z () );
+    math::XYZPoint const& theCaloPosition = sc.get()->position();
+    GlobalPoint pclu(theCaloPosition.x(), theCaloPosition.y(), theCaloPosition.z());
     float etaclus = pclu.eta();
     float phiclus = pclu.phi();
-    float r2 = intRadius_*intRadius_;
-    
-    std::vector< std::pair<DetId, float> >::const_iterator rhIt;
-    
-    for(int subdetnr=0; subdetnr<=1 ; subdetnr++){  // look in barrel and endcap
-      if( nullptr == subdet_[subdetnr] ) continue;
+    float r2 = intRadius_ * intRadius_;
 
-      CaloSubdetectorGeometry::DetIdSet chosen = subdet_[subdetnr]->getCells(pclu,extRadius_);// select cells around cluster
+    std::vector<std::pair<DetId, float> >::const_iterator rhIt;
+
+    for (int subdetnr = 0; subdetnr <= 1; subdetnr++) {  // look in barrel and endcap
+      if (nullptr == subdet_[subdetnr])
+        continue;
+
+      CaloSubdetectorGeometry::DetIdSet chosen =
+          subdet_[subdetnr]->getCells(pclu, extRadius_);  // select cells around cluster
       EcalRecHitCollection::const_iterator j = caloHits_.end();
 
-      for (CaloSubdetectorGeometry::DetIdSet::const_iterator  i = chosen.begin ();i != chosen.end (); ++i){ //loop selected cells
-	j = caloHits_.find(*i); // find selected cell among rechits
-	if(j != caloHits_.end()) { // add rechit only if available 
-	  auto cell  = theCaloGeom_->getGeometry(*i);
-	  float eta = cell->etaPos();
-	  float phi = cell->phiPos();
-	  float etaDiff = eta - etaclus;
-	  float phiDiff= reco::deltaPhi(phi,phiclus);
-	  float energy = j->energy();
+      for (CaloSubdetectorGeometry::DetIdSet::const_iterator i = chosen.begin(); i != chosen.end();
+           ++i) {                    //loop selected cells
+        j = caloHits_.find(*i);      // find selected cell among rechits
+        if (j != caloHits_.end()) {  // add rechit only if available
+          auto cell = theCaloGeom_->getGeometry(*i);
+          float eta = cell->etaPos();
+          float phi = cell->phiPos();
+          float etaDiff = eta - etaclus;
+          float phiDiff = reco::deltaPhi(phi, phiclus);
+          float energy = j->energy();
 
-	  if(useNumCrystals_) {
-	    if(fabs(etaclus) < 1.479) {  // Barrel num crystals, crystal width = 0.0174
-	      if (fabs(etaDiff) < 0.0174*etaSlice_) 
-		continue;  
-	      //if (sqrt(etaDiff*etaDiff + phiDiff*phiDiff) < 0.0174*intRadius_) 
-	      //continue; 
-	      if ((etaDiff*etaDiff + phiDiff*phiDiff) < 0.00030276*r2) 
-		continue; 
-	    } else {                       // Endcap num crystals, crystal width = 0.00864*fabs(sinh(eta))
-	      if (fabs(etaDiff) < 0.00864*fabs(sinh(eta))*etaSlice_) 
-		continue;  
-	      //if (sqrt(etaDiff*etaDiff + phiDiff*phiDiff) < 0.00864*fabs(sinh(eta))*intRadius_) 
-	      //	continue; 
-	      if ((etaDiff*etaDiff + phiDiff*phiDiff) < (0.000037325*(cosh(2*eta)-1)*r2))
-	      	continue; 
-	    }
-	  } else {
-	    if (fabs(etaDiff) < etaSlice_) 
-	      continue;  // jurassic strip cut
-	    if (etaDiff*etaDiff + phiDiff*phiDiff < r2) 
-	      continue; // jurassic exclusion cone cut
-	  }
-	  //Check if RecHit is in SC
-	  if(vetoClustered_) {
-	    
-	    //Loop over basic clusters:
-	    bool isClustered = false;
-	    for(reco::CaloCluster_iterator bcIt = sc->clustersBegin();bcIt != sc->clustersEnd(); ++bcIt) {
-	      for(rhIt = (*bcIt)->hitsAndFractions().begin();rhIt != (*bcIt)->hitsAndFractions().end(); ++rhIt) {
-		if(rhIt->first == *i)
-		  isClustered = true;
-		if(isClustered) 
-		  break;
-	      }
-	      
-	      if(isClustered) 
-		break;
-	    } //end loop over basic clusters
-	    
-	    if(isClustered) 
-	      continue;
-	  }  //end if removeClustered
-	  
-	  
-	  
-	  
-	  //std::cout << "detid " << j->detid() << std::endl;
-	  int severityFlag = ecalBarHits_ == nullptr ? -1 : sevLevel_->severityLevel(j->detid(), *ecalBarHits_);
-	  std::vector<int>::const_iterator sit = std::find(severitiesexcl_.begin(), 
-							   severitiesexcl_.end(), 
-							   severityFlag);
+          if (useNumCrystals_) {
+            if (fabs(etaclus) < 1.479) {  // Barrel num crystals, crystal width = 0.0174
+              if (fabs(etaDiff) < 0.0174 * etaSlice_)
+                continue;
+              //if (sqrt(etaDiff*etaDiff + phiDiff*phiDiff) < 0.0174*intRadius_)
+              //continue;
+              if ((etaDiff * etaDiff + phiDiff * phiDiff) < 0.00030276 * r2)
+                continue;
+            } else {  // Endcap num crystals, crystal width = 0.00864*fabs(sinh(eta))
+              if (fabs(etaDiff) < 0.00864 * fabs(sinh(eta)) * etaSlice_)
+                continue;
+              //if (sqrt(etaDiff*etaDiff + phiDiff*phiDiff) < 0.00864*fabs(sinh(eta))*intRadius_)
+              //	continue;
+              if ((etaDiff * etaDiff + phiDiff * phiDiff) < (0.000037325 * (cosh(2 * eta) - 1) * r2))
+                continue;
+            }
+          } else {
+            if (fabs(etaDiff) < etaSlice_)
+              continue;  // jurassic strip cut
+            if (etaDiff * etaDiff + phiDiff * phiDiff < r2)
+              continue;  // jurassic exclusion cone cut
+          }
+          //Check if RecHit is in SC
+          if (vetoClustered_) {
+            //Loop over basic clusters:
+            bool isClustered = false;
+            for (reco::CaloCluster_iterator bcIt = sc->clustersBegin(); bcIt != sc->clustersEnd(); ++bcIt) {
+              for (rhIt = (*bcIt)->hitsAndFractions().begin(); rhIt != (*bcIt)->hitsAndFractions().end(); ++rhIt) {
+                if (rhIt->first == *i)
+                  isClustered = true;
+                if (isClustered)
+                  break;
+              }
 
-	  if (sit!= severitiesexcl_.end())
-	    continue;
-	  
-	  // new rechit flag checks
-	  //std::vector<int>::const_iterator vit = std::find(flags_.begin(), 
-	  //						   flags_.end(),
-	  //						   j->recoFlag());
-	  //if (vit != flags_.end()) 
-	  //  continue;
-	  if (!j->checkFlag(EcalRecHit::kGood)) {
-	    if (j->checkFlags(flags_)) {                
-	      continue;
-	    }
-	  }
-	  
-	  float et = energy*std::sqrt(cell->getPosition().perp2()/cell->getPosition().mag2());
-	  if ( et > etLow_ && energy > eLow_) { //Changed energy --> fabs(energy) - now changed back to energy
-	    if(returnEt) 
-	      energySum += et;
-	    else 
-	      energySum += energy;
-	  }
-	  
-	}                //End if not end of list
-      }                  //End loop over rechits
-    }                    //End loop over barrel/endcap
-  }                        //End if caloHits_
-  
+              if (isClustered)
+                break;
+            }  //end loop over basic clusters
+
+            if (isClustered)
+              continue;
+          }  //end if removeClustered
+
+          //std::cout << "detid " << j->detid() << std::endl;
+          int severityFlag = ecalBarHits_ == nullptr ? -1 : sevLevel_->severityLevel(j->detid(), *ecalBarHits_);
+          std::vector<int>::const_iterator sit =
+              std::find(severitiesexcl_.begin(), severitiesexcl_.end(), severityFlag);
+
+          if (sit != severitiesexcl_.end())
+            continue;
+
+          // new rechit flag checks
+          //std::vector<int>::const_iterator vit = std::find(flags_.begin(),
+          //						   flags_.end(),
+          //						   j->recoFlag());
+          //if (vit != flags_.end())
+          //  continue;
+          if (!j->checkFlag(EcalRecHit::kGood)) {
+            if (j->checkFlags(flags_)) {
+              continue;
+            }
+          }
+
+          float et = energy * std::sqrt(cell->getPosition().perp2() / cell->getPosition().mag2());
+          if (et > etLow_ && energy > eLow_) {  //Changed energy --> fabs(energy) - now changed back to energy
+            if (returnEt)
+              energySum += et;
+            else
+              energySum += energy;
+          }
+
+        }  //End if not end of list
+      }    //End loop over rechits
+    }      //End loop over barrel/endcap
+  }        //End if caloHits_
+
   return energySum;
 }
-
-
 
 double EgammaRecHitIsolation::getSum_(const reco::SuperCluster* sc, bool returnEt) const {
-
   double energySum = 0.;
-  if (! caloHits_.empty()){
+  if (!caloHits_.empty()) {
     //Take the SC position
- 
+
     const math::XYZPoint& theCaloPosition = sc->position();
-    GlobalPoint pclu (theCaloPosition.x () ,
-		      theCaloPosition.y () ,
-		      theCaloPosition.z () );
+    GlobalPoint pclu(theCaloPosition.x(), theCaloPosition.y(), theCaloPosition.z());
     double etaclus = pclu.eta();
     double phiclus = pclu.phi();
-    double r2 = intRadius_*intRadius_;
-    
-    std::vector< std::pair<DetId, float> >::const_iterator rhIt;
-    
-    
-    for(int subdetnr=0; subdetnr<=1 ; subdetnr++){  // look in barrel and endcap
-      if( nullptr == subdet_[subdetnr] ) continue;
-      CaloSubdetectorGeometry::DetIdSet chosen = subdet_[subdetnr]->getCells(pclu,extRadius_);// select cells around cluster
-      EcalRecHitCollection::const_iterator j=caloHits_.end();
-      for (CaloSubdetectorGeometry::DetIdSet::const_iterator  i = chosen.begin ();i!= chosen.end ();++i){//loop selected cells
-	
-	j=caloHits_.find(*i); // find selected cell among rechits
-	if( j!=caloHits_.end()){ // add rechit only if available 
-	  const  GlobalPoint & position = (theCaloGeom_.product())->getPosition(*i);
-	  double eta = position.eta();
-	  double phi = position.phi();
-	  double etaDiff = eta - etaclus;
-	  double phiDiff= reco::deltaPhi(phi,phiclus);
-	  double energy = j->energy();
-	  
-	  if(useNumCrystals_) {
-	    if( fabs(etaclus) < 1.479 ) {  // Barrel num crystals, crystal width = 0.0174
-	      if ( fabs(etaDiff) < 0.0174*etaSlice_) continue;  
-	      // if ( sqrt(etaDiff*etaDiff + phiDiff*phiDiff) < 0.0174*intRadius_) continue; 
-	      if ((etaDiff*etaDiff + phiDiff*phiDiff) < 0.00030276*r2) continue;
-	    } else {                       // Endcap num crystals, crystal width = 0.00864*fabs(sinh(eta))
-	      if ( fabs(etaDiff) < 0.00864*fabs(sinh(eta))*etaSlice_) continue;  
-	      // if ( sqrt(etaDiff*etaDiff + phiDiff*phiDiff) < 0.00864*fabs(sinh(eta))*intRadius_) continue; 
-	      if ((etaDiff*etaDiff + phiDiff*phiDiff) < (0.000037325*(cosh(2*eta)-1)*r2)) continue;
-	    }
-	  } else {
-	    if ( fabs(etaDiff) < etaSlice_) continue;  // jurassic strip cut
-	    if ( etaDiff*etaDiff + phiDiff*phiDiff < r2) continue; // jurassic exclusion cone cut
-	  }
-	  
-	  //Check if RecHit is in SC
-	  if(vetoClustered_) {
-	    
-	    //Loop over basic clusters:
-	    bool isClustered = false;
-	    for(reco::CaloCluster_iterator bcIt = sc->clustersBegin();bcIt != sc->clustersEnd(); ++bcIt) {
-	      for(rhIt = (*bcIt)->hitsAndFractions().begin();rhIt != (*bcIt)->hitsAndFractions().end(); ++rhIt) {
-		if( rhIt->first == *i ) isClustered = true;
-		if( isClustered ) break;
-	      }
-	      if( isClustered ) break;
-	    } //end loop over basic clusters
-	    
-	    if(isClustered) continue;
-	  }  //end if removeClustered
-	  
-	  
-	  int severityFlag = sevLevel_->severityLevel(j->detid(), *ecalBarHits_);
-	  std::vector<int>::const_iterator sit = std::find(severitiesexcl_.begin(), 
-							   severitiesexcl_.end(), 
-							   severityFlag);
-	  
-	  if (sit!= severitiesexcl_.end())
-	    continue;
-	  
-	  // new rechit flag checks
-	  //std::vector<int>::const_iterator vit = std::find(flags_.begin(), 
-	  //						   flags_.end(),
-	  //						   j->recoFlag());
-	  //if (vit != flags_.end()) 
-	  //  continue;
-	  if (!j->checkFlag(EcalRecHit::kGood)) {
-	    if (j->checkFlags(flags_)) {                
-	      continue;
-	    }
-	  }
-	  
-	  
-	  double et = energy*position.perp()/position.mag();
-	  if ( et > etLow_ && energy > eLow_){ //Changed energy --> fabs(energy) -- then changed into energy
-	    if(returnEt) energySum+=et;
-	    else energySum+=energy;
-	  }
-	  
-	}                //End if not end of list
-      }                  //End loop over rechits
-    }                    //End loop over barrel/endcap
-  }                      //End if caloHits_
+    double r2 = intRadius_ * intRadius_;
+
+    std::vector<std::pair<DetId, float> >::const_iterator rhIt;
+
+    for (int subdetnr = 0; subdetnr <= 1; subdetnr++) {  // look in barrel and endcap
+      if (nullptr == subdet_[subdetnr])
+        continue;
+      CaloSubdetectorGeometry::DetIdSet chosen =
+          subdet_[subdetnr]->getCells(pclu, extRadius_);  // select cells around cluster
+      EcalRecHitCollection::const_iterator j = caloHits_.end();
+      for (CaloSubdetectorGeometry::DetIdSet::const_iterator i = chosen.begin(); i != chosen.end();
+           ++i) {  //loop selected cells
+
+        j = caloHits_.find(*i);      // find selected cell among rechits
+        if (j != caloHits_.end()) {  // add rechit only if available
+          const GlobalPoint& position = (theCaloGeom_.product())->getPosition(*i);
+          double eta = position.eta();
+          double phi = position.phi();
+          double etaDiff = eta - etaclus;
+          double phiDiff = reco::deltaPhi(phi, phiclus);
+          double energy = j->energy();
+
+          if (useNumCrystals_) {
+            if (fabs(etaclus) < 1.479) {  // Barrel num crystals, crystal width = 0.0174
+              if (fabs(etaDiff) < 0.0174 * etaSlice_)
+                continue;
+              // if ( sqrt(etaDiff*etaDiff + phiDiff*phiDiff) < 0.0174*intRadius_) continue;
+              if ((etaDiff * etaDiff + phiDiff * phiDiff) < 0.00030276 * r2)
+                continue;
+            } else {  // Endcap num crystals, crystal width = 0.00864*fabs(sinh(eta))
+              if (fabs(etaDiff) < 0.00864 * fabs(sinh(eta)) * etaSlice_)
+                continue;
+              // if ( sqrt(etaDiff*etaDiff + phiDiff*phiDiff) < 0.00864*fabs(sinh(eta))*intRadius_) continue;
+              if ((etaDiff * etaDiff + phiDiff * phiDiff) < (0.000037325 * (cosh(2 * eta) - 1) * r2))
+                continue;
+            }
+          } else {
+            if (fabs(etaDiff) < etaSlice_)
+              continue;  // jurassic strip cut
+            if (etaDiff * etaDiff + phiDiff * phiDiff < r2)
+              continue;  // jurassic exclusion cone cut
+          }
+
+          //Check if RecHit is in SC
+          if (vetoClustered_) {
+            //Loop over basic clusters:
+            bool isClustered = false;
+            for (reco::CaloCluster_iterator bcIt = sc->clustersBegin(); bcIt != sc->clustersEnd(); ++bcIt) {
+              for (rhIt = (*bcIt)->hitsAndFractions().begin(); rhIt != (*bcIt)->hitsAndFractions().end(); ++rhIt) {
+                if (rhIt->first == *i)
+                  isClustered = true;
+                if (isClustered)
+                  break;
+              }
+              if (isClustered)
+                break;
+            }  //end loop over basic clusters
+
+            if (isClustered)
+              continue;
+          }  //end if removeClustered
+
+          int severityFlag = sevLevel_->severityLevel(j->detid(), *ecalBarHits_);
+          std::vector<int>::const_iterator sit =
+              std::find(severitiesexcl_.begin(), severitiesexcl_.end(), severityFlag);
+
+          if (sit != severitiesexcl_.end())
+            continue;
+
+          // new rechit flag checks
+          //std::vector<int>::const_iterator vit = std::find(flags_.begin(),
+          //						   flags_.end(),
+          //						   j->recoFlag());
+          //if (vit != flags_.end())
+          //  continue;
+          if (!j->checkFlag(EcalRecHit::kGood)) {
+            if (j->checkFlags(flags_)) {
+              continue;
+            }
+          }
+
+          double et = energy * position.perp() / position.mag();
+          if (et > etLow_ && energy > eLow_) {  //Changed energy --> fabs(energy) -- then changed into energy
+            if (returnEt)
+              energySum += et;
+            else
+              energySum += energy;
+          }
+
+        }  //End if not end of list
+      }    //End loop over rechits
+    }      //End loop over barrel/endcap
+  }        //End if caloHits_
 
   return energySum;
 }
-

--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaTowerIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaTowerIsolation.cc
@@ -8,69 +8,71 @@
 
 //CMSSW includes
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaTowerIsolation.h"
-#include<cassert>
+#include <cassert>
 #include <memory>
 
 #ifdef ETISTATDEBUG
 // #include<iostream>
 namespace etiStat {
-  Count::~Count() { 
-    //    std::cout << "\nEgammaTowerIsolationNew " << create << "/" << comp << "/" << float(span)/float(comp)  
+  Count::~Count() {
+    //    std::cout << "\nEgammaTowerIsolationNew " << create << "/" << comp << "/" << float(span)/float(comp)
     //	      << std::endl<< std::endl;
-    }
+  }
 
   Count Count::count;
-}
+}  // namespace etiStat
 #endif
 
 namespace {
-  struct TLS {   
-    std::unique_ptr<EgammaTowerIsolationNew<1>> newAlgo=nullptr;;
-    const CaloTowerCollection* oldTowers=nullptr;;
-    uint32_t id15=0;
+  struct TLS {
+    std::unique_ptr<EgammaTowerIsolationNew<1>> newAlgo = nullptr;
+    ;
+    const CaloTowerCollection* oldTowers = nullptr;
+    ;
+    uint32_t id15 = 0;
   };
   thread_local TLS tls;
-}
+}  // namespace
 
-EgammaTowerIsolation::EgammaTowerIsolation (float extRadiusI,
-					    float intRadiusI,
-					    float etLow,
-					    signed int depth,
-					    const CaloTowerCollection* towers ) :  
-  depth_(depth), 
-  extRadius(extRadiusI),
-  intRadius(intRadiusI)
-{
-  assert(0==etLow);
+EgammaTowerIsolation::EgammaTowerIsolation(
+    float extRadiusI, float intRadiusI, float etLow, signed int depth, const CaloTowerCollection* towers)
+    : depth_(depth), extRadius(extRadiusI), intRadius(intRadiusI) {
+  assert(0 == etLow);
 
   // extremely poor in quality  (test of performance)
-  if (tls.newAlgo.get()==nullptr ||  towers!=tls.oldTowers || towers->size()!=tls.newAlgo->nt || (towers->size()>15 && (*towers)[15].id()!=tls.id15)) {
-    tls.newAlgo = std::make_unique<EgammaTowerIsolationNew<1>>(&extRadius,&intRadius,*towers);
-    tls.oldTowers=towers;
-    tls.id15 = towers->size()>15 ? (*towers)[15].id() : 0;
+  if (tls.newAlgo.get() == nullptr || towers != tls.oldTowers || towers->size() != tls.newAlgo->nt ||
+      (towers->size() > 15 && (*towers)[15].id() != tls.id15)) {
+    tls.newAlgo = std::make_unique<EgammaTowerIsolationNew<1>>(&extRadius, &intRadius, *towers);
+    tls.oldTowers = towers;
+    tls.id15 = towers->size() > 15 ? (*towers)[15].id() : 0;
   }
 }
 
-
-double  EgammaTowerIsolation::getSum (bool et, reco::SuperCluster const & sc, const std::vector<CaloTowerDetId> * detIdToExclude) const{
-
-  if (nullptr!=detIdToExclude) assert(0==intRadius);
+double EgammaTowerIsolation::getSum(bool et,
+                                    reco::SuperCluster const& sc,
+                                    const std::vector<CaloTowerDetId>* detIdToExclude) const {
+  if (nullptr != detIdToExclude)
+    assert(0 == intRadius);
 
   // hack
-  tls.newAlgo->setRadius(&extRadius,&intRadius);
+  tls.newAlgo->setRadius(&extRadius, &intRadius);
 
   EgammaTowerIsolationNew<1>::Sum sum;
-  tls.newAlgo->compute(et, sum, sc, 
-		  (detIdToExclude==nullptr) ? nullptr : &((*detIdToExclude).front()),
-		  (detIdToExclude==nullptr) ? nullptr : (&(*detIdToExclude).back())+1
-		  );
-  
-  switch(depth_){
-  case AllDepths: return detIdToExclude==nullptr ? sum.he[0] : sum.heBC[0]; 
-  case Depth1: return detIdToExclude==nullptr ? sum.he[0]-sum.h2[0] : sum.heBC[0]-sum.h2BC[0]; 
-  case Depth2:return detIdToExclude==nullptr ? sum.h2[0] : sum.h2BC[0]; 
-  default: return 0;
+  tls.newAlgo->compute(et,
+                       sum,
+                       sc,
+                       (detIdToExclude == nullptr) ? nullptr : &((*detIdToExclude).front()),
+                       (detIdToExclude == nullptr) ? nullptr : (&(*detIdToExclude).back()) + 1);
+
+  switch (depth_) {
+    case AllDepths:
+      return detIdToExclude == nullptr ? sum.he[0] : sum.heBC[0];
+    case Depth1:
+      return detIdToExclude == nullptr ? sum.he[0] - sum.h2[0] : sum.heBC[0] - sum.h2BC[0];
+    case Depth2:
+      return detIdToExclude == nullptr ? sum.h2[0] : sum.h2BC[0];
+    default:
+      return 0;
   }
   return 0;
 }
-

--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaTrackSelector.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaTrackSelector.cc
@@ -5,51 +5,64 @@
 using namespace egammaisolation;
 using namespace reco;
 
-EgammaTrackSelector::result_type EgammaTrackSelector::operator()(const EgammaTrackSelector::input_type & tracks) const
-{
+EgammaTrackSelector::result_type EgammaTrackSelector::operator()(const EgammaTrackSelector::input_type& tracks) const {
   static const std::string metname = "EgammaIsolationAlgos|EgammaTrackSelector";
   result_type result;
   for (input_type::const_iterator it = tracks.begin(); it != tracks.end(); it++) {
-
     //! pick/read variables in order to cut down on unnecessary calls
     //! someone will have some fun reading the log if Debug is on
     //! the biggest reason is the numberOfValidHits call (the rest are not as costly)
 
     float tZ;
-    switch(thePars.dzOption) {
-        case dz : tZ = it->dz();                  break;
-        case vz : tZ = it->vz();                  break;
-        case bs : tZ = it->dz(thePars.beamPoint); break;
-        default : tZ = it->vz();                  break;
+    switch (thePars.dzOption) {
+      case dz:
+        tZ = it->dz();
+        break;
+      case vz:
+        tZ = it->vz();
+        break;
+      case bs:
+        tZ = it->dz(thePars.beamPoint);
+        break;
+      default:
+        tZ = it->vz();
+        break;
     }
 
     float tPt = it->pt();
-    //float tD0 = fabs(it->d0());  //currently not used.  
+    //float tD0 = fabs(it->d0());  //currently not used.
     float tD0Cor = fabs(it->dxy(thePars.beamPoint));
     float tEta = it->eta();
     float tPhi = it->phi();
     float tChi2Ndof = it->normalizedChi2();
-  
+
     //! access to the remaining vars is slow
 
-    if ( !thePars.zRange.inside( tZ ) ) continue; 
-    if ( tPt < thePars.ptMin ) continue;
-    if ( !thePars.rRange.inside( tD0Cor) ) continue;
-    if ( thePars.dir.deltaR( reco::isodeposit::Direction(tEta, tPhi) ) > thePars.drMax ) continue;
-    if ( tChi2Ndof > thePars.chi2NdofMax ) continue;
+    if (!thePars.zRange.inside(tZ))
+      continue;
+    if (tPt < thePars.ptMin)
+      continue;
+    if (!thePars.rRange.inside(tD0Cor))
+      continue;
+    if (thePars.dir.deltaR(reco::isodeposit::Direction(tEta, tPhi)) > thePars.drMax)
+      continue;
+    if (tChi2Ndof > thePars.chi2NdofMax)
+      continue;
 
     //! skip if min Hits == 0; assumes any track has at least one valid hit
-    if (thePars.nHitsMin > 0 ){
+    if (thePars.nHitsMin > 0) {
       unsigned int tHits = it->numberOfValidHits();
-      if ( tHits < thePars.nHitsMin ) continue;
+      if (tHits < thePars.nHitsMin)
+        continue;
     }
 
     //! similarly here
-    if(thePars.chi2ProbMin > 0){
+    if (thePars.chi2ProbMin > 0) {
       float tChi2Prob = ChiSquaredProbability(it->chi2(), it->ndof());
-      if ( tChi2Prob < thePars.chi2ProbMin ) continue;
+      if (tChi2Prob < thePars.chi2ProbMin)
+        continue;
     }
     result.push_back(&*it);
-  } 
+  }
   return result;
 }

--- a/RecoEgamma/EgammaIsolationAlgos/src/EleTkIsolFromCands.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EleTkIsolFromCands.cc
@@ -2,10 +2,9 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
-EleTkIsolFromCands::TrkCuts::TrkCuts(const edm::ParameterSet& para)
-{
+EleTkIsolFromCands::TrkCuts::TrkCuts(const edm::ParameterSet& para) {
   minPt = para.getParameter<double>("minPt");
-  auto sq = [](double val){return val*val;};
+  auto sq = [](double val) { return val * val; };
   minDR2 = sq(para.getParameter<double>("minDR"));
   maxDR2 = sq(para.getParameter<double>("maxDR"));
   minDEta = para.getParameter<double>("minDEta");
@@ -13,178 +12,159 @@ EleTkIsolFromCands::TrkCuts::TrkCuts(const edm::ParameterSet& para)
   minHits = para.getParameter<int>("minHits");
   minPixelHits = para.getParameter<int>("minPixelHits");
   maxDPtPt = para.getParameter<double>("maxDPtPt");
-  
+
   auto qualNames = para.getParameter<std::vector<std::string> >("allowedQualities");
   auto algoNames = para.getParameter<std::vector<std::string> >("algosToReject");
 
-  for(auto& qualName : qualNames){
+  for (auto& qualName : qualNames) {
     allowedQualities.push_back(reco::TrackBase::qualityByName(qualName));
   }
-  for(auto& algoName : algoNames){
+  for (auto& algoName : algoNames) {
     algosToReject.push_back(reco::TrackBase::algoByName(algoName));
   }
-  std::sort(algosToReject.begin(),algosToReject.end());
-
+  std::sort(algosToReject.begin(), algosToReject.end());
 }
 
-edm::ParameterSetDescription EleTkIsolFromCands::TrkCuts::pSetDescript()
-{
+edm::ParameterSetDescription EleTkIsolFromCands::TrkCuts::pSetDescript() {
   edm::ParameterSetDescription desc;
-  desc.add<double>("minPt",1.0);
-  desc.add<double>("maxDR",0.3);
-  desc.add<double>("minDR",0.000);
-  desc.add<double>("minDEta",0.005);
-  desc.add<double>("maxDZ",0.1);
-  desc.add<double>("maxDPtPt",-1);
-  desc.add<int>("minHits",8);
-  desc.add<int>("minPixelHits",1);
+  desc.add<double>("minPt", 1.0);
+  desc.add<double>("maxDR", 0.3);
+  desc.add<double>("minDR", 0.000);
+  desc.add<double>("minDEta", 0.005);
+  desc.add<double>("maxDZ", 0.1);
+  desc.add<double>("maxDPtPt", -1);
+  desc.add<int>("minHits", 8);
+  desc.add<int>("minPixelHits", 1);
   desc.add<std::vector<std::string> >("allowedQualities");
   desc.add<std::vector<std::string> >("algosToReject");
   return desc;
 }
 
-EleTkIsolFromCands::EleTkIsolFromCands(const edm::ParameterSet& para):
-  barrelCuts_(para.getParameter<edm::ParameterSet>("barrelCuts")),
-  endcapCuts_(para.getParameter<edm::ParameterSet>("endcapCuts"))          
-{
-  
+EleTkIsolFromCands::EleTkIsolFromCands(const edm::ParameterSet& para)
+    : barrelCuts_(para.getParameter<edm::ParameterSet>("barrelCuts")),
+      endcapCuts_(para.getParameter<edm::ParameterSet>("endcapCuts")) {}
 
-}
-
-edm::ParameterSetDescription EleTkIsolFromCands::pSetDescript()
-{
+edm::ParameterSetDescription EleTkIsolFromCands::pSetDescript() {
   edm::ParameterSetDescription desc;
-  desc.add("barrelCuts",TrkCuts::pSetDescript());
-  desc.add("endcapCuts",TrkCuts::pSetDescript());
+  desc.add("barrelCuts", TrkCuts::pSetDescript());
+  desc.add("endcapCuts", TrkCuts::pSetDescript());
   return desc;
 }
 
-std::pair<int,double> 
-EleTkIsolFromCands::calIsol(const reco::TrackBase& eleTrk,
-			    const pat::PackedCandidateCollection& cands,
-			    const PIDVeto pidVeto)const
-{
-  return calIsol(eleTrk.eta(),eleTrk.phi(),eleTrk.vz(),cands,pidVeto);
+std::pair<int, double> EleTkIsolFromCands::calIsol(const reco::TrackBase& eleTrk,
+                                                   const pat::PackedCandidateCollection& cands,
+                                                   const PIDVeto pidVeto) const {
+  return calIsol(eleTrk.eta(), eleTrk.phi(), eleTrk.vz(), cands, pidVeto);
 }
 
-std::pair<int,double> 
-EleTkIsolFromCands::calIsol(const double eleEta,const double elePhi,
-			    const double eleVZ,
-			    const pat::PackedCandidateCollection& cands,
-			    const PIDVeto pidVeto)const
-{
-  double ptSum=0.;
-  int nrTrks=0;
+std::pair<int, double> EleTkIsolFromCands::calIsol(const double eleEta,
+                                                   const double elePhi,
+                                                   const double eleVZ,
+                                                   const pat::PackedCandidateCollection& cands,
+                                                   const PIDVeto pidVeto) const {
+  double ptSum = 0.;
+  int nrTrks = 0;
 
-  const TrkCuts& cuts = std::abs(eleEta)<1.5 ? barrelCuts_ : endcapCuts_;
-  
-  for(auto& cand  : cands){
-    if(cand.hasTrackDetails() && cand.charge()!=0 && passPIDVeto(cand.pdgId(),pidVeto)){
+  const TrkCuts& cuts = std::abs(eleEta) < 1.5 ? barrelCuts_ : endcapCuts_;
+
+  for (auto& cand : cands) {
+    if (cand.hasTrackDetails() && cand.charge() != 0 && passPIDVeto(cand.pdgId(), pidVeto)) {
       const reco::Track& trk = cand.pseudoTrack();
-      if(passTrkSel(trk,trk.pt(),cuts,eleEta,elePhi,eleVZ)){	
-	ptSum+=trk.pt();
-	nrTrks++;
+      if (passTrkSel(trk, trk.pt(), cuts, eleEta, elePhi, eleVZ)) {
+        ptSum += trk.pt();
+        nrTrks++;
       }
     }
   }
-  return {nrTrks,ptSum};	
+  return {nrTrks, ptSum};
 }
 
-
-
-std::pair<int,double> 
-EleTkIsolFromCands::calIsol(const reco::TrackBase& eleTrk,
-			    const reco::TrackCollection& tracks)const
-{
-  return calIsol(eleTrk.eta(),eleTrk.phi(),eleTrk.vz(),tracks);
+std::pair<int, double> EleTkIsolFromCands::calIsol(const reco::TrackBase& eleTrk,
+                                                   const reco::TrackCollection& tracks) const {
+  return calIsol(eleTrk.eta(), eleTrk.phi(), eleTrk.vz(), tracks);
 }
 
-std::pair<int,double> 
-EleTkIsolFromCands::calIsol(const double eleEta,const double elePhi,
-			    const double eleVZ,
-			    const reco::TrackCollection& tracks)const
-{
-  double ptSum=0.;
-  int nrTrks=0;
+std::pair<int, double> EleTkIsolFromCands::calIsol(const double eleEta,
+                                                   const double elePhi,
+                                                   const double eleVZ,
+                                                   const reco::TrackCollection& tracks) const {
+  double ptSum = 0.;
+  int nrTrks = 0;
 
-  const TrkCuts& cuts = std::abs(eleEta)<1.5 ? barrelCuts_ : endcapCuts_;
-  
-  for(auto& trk  : tracks){
-    if(passTrkSel(trk,trk.pt(),cuts,eleEta,elePhi,eleVZ)){	
-      ptSum+=trk.pt();
+  const TrkCuts& cuts = std::abs(eleEta) < 1.5 ? barrelCuts_ : endcapCuts_;
+
+  for (auto& trk : tracks) {
+    if (passTrkSel(trk, trk.pt(), cuts, eleEta, elePhi, eleVZ)) {
+      ptSum += trk.pt();
       nrTrks++;
     }
   }
-  return {nrTrks,ptSum};	
-}	
-
-bool EleTkIsolFromCands::passPIDVeto(const int pdgId,const EleTkIsolFromCands::PIDVeto veto)
-{
-  int pidAbs = std::abs(pdgId);
-  switch (veto){
-  case PIDVeto::NONE:
-    return true;
-  case PIDVeto::ELES:
-    if(pidAbs==11) return false;
-    else return true;
-  case PIDVeto::NONELES:
-    if(pidAbs==11) return true;
-    else return false;
-  }
-  throw cms::Exception("CodeError") <<
-    "invalid PIDVeto "<<static_cast<int>(veto)<<", "<<
-    "this is likely due to some static casting of invalid ints somewhere";
+  return {nrTrks, ptSum};
 }
 
-EleTkIsolFromCands::PIDVeto EleTkIsolFromCands::pidVetoFromStr(const std::string& vetoStr) 
-{
-  if(vetoStr=="NONE") return PIDVeto::NONE;
-  else if(vetoStr=="ELES") return PIDVeto::ELES;
-  else if(vetoStr=="NONELES") return PIDVeto::NONELES;
-  else{
-    throw cms::Exception("CodeError") <<"unrecognised string "<<vetoStr<<", either a typo or this function needs to be updated";
+bool EleTkIsolFromCands::passPIDVeto(const int pdgId, const EleTkIsolFromCands::PIDVeto veto) {
+  int pidAbs = std::abs(pdgId);
+  switch (veto) {
+    case PIDVeto::NONE:
+      return true;
+    case PIDVeto::ELES:
+      if (pidAbs == 11)
+        return false;
+      else
+        return true;
+    case PIDVeto::NONELES:
+      if (pidAbs == 11)
+        return true;
+      else
+        return false;
+  }
+  throw cms::Exception("CodeError") << "invalid PIDVeto " << static_cast<int>(veto) << ", "
+                                    << "this is likely due to some static casting of invalid ints somewhere";
+}
+
+EleTkIsolFromCands::PIDVeto EleTkIsolFromCands::pidVetoFromStr(const std::string& vetoStr) {
+  if (vetoStr == "NONE")
+    return PIDVeto::NONE;
+  else if (vetoStr == "ELES")
+    return PIDVeto::ELES;
+  else if (vetoStr == "NONELES")
+    return PIDVeto::NONELES;
+  else {
+    throw cms::Exception("CodeError") << "unrecognised string " << vetoStr
+                                      << ", either a typo or this function needs to be updated";
   }
 }
 
 bool EleTkIsolFromCands::passTrkSel(const reco::TrackBase& trk,
-				    const double trkPt,const TrkCuts& cuts,
-				    const double eleEta,const double elePhi,
-				    const double eleVZ)
-{
-  const float dR2 = reco::deltaR2(eleEta,elePhi,trk.eta(),trk.phi());
-  const float dEta = trk.eta()-eleEta;
+                                    const double trkPt,
+                                    const TrkCuts& cuts,
+                                    const double eleEta,
+                                    const double elePhi,
+                                    const double eleVZ) {
+  const float dR2 = reco::deltaR2(eleEta, elePhi, trk.eta(), trk.phi());
+  const float dEta = trk.eta() - eleEta;
   const float dZ = eleVZ - trk.vz();
 
-  return dR2>=cuts.minDR2 && dR2<=cuts.maxDR2 && 
-    std::abs(dEta)>=cuts.minDEta && 
-    std::abs(dZ)<cuts.maxDZ &&
-    trk.hitPattern().numberOfValidHits() >= cuts.minHits &&
-    trk.hitPattern().numberOfValidPixelHits() >=cuts.minPixelHits &&
-    (trk.ptError()/trkPt < cuts.maxDPtPt || cuts.maxDPtPt<0) && 
-    passQual(trk,cuts.allowedQualities) &&
-    passAlgo(trk,cuts.algosToReject) &&
-    trkPt > cuts.minPt;
+  return dR2 >= cuts.minDR2 && dR2 <= cuts.maxDR2 && std::abs(dEta) >= cuts.minDEta && std::abs(dZ) < cuts.maxDZ &&
+         trk.hitPattern().numberOfValidHits() >= cuts.minHits &&
+         trk.hitPattern().numberOfValidPixelHits() >= cuts.minPixelHits &&
+         (trk.ptError() / trkPt < cuts.maxDPtPt || cuts.maxDPtPt < 0) && passQual(trk, cuts.allowedQualities) &&
+         passAlgo(trk, cuts.algosToReject) && trkPt > cuts.minPt;
 }
-    
- 
-	
-bool EleTkIsolFromCands::
-passQual(const reco::TrackBase& trk,
-	 const std::vector<reco::TrackBase::TrackQuality>& quals)
-{
-  if(quals.empty()) return true;
 
-  for(auto qual : quals) {
-    if(trk.quality(qual)) return true;
+bool EleTkIsolFromCands::passQual(const reco::TrackBase& trk, const std::vector<reco::TrackBase::TrackQuality>& quals) {
+  if (quals.empty())
+    return true;
+
+  for (auto qual : quals) {
+    if (trk.quality(qual))
+      return true;
   }
 
-  return false;  
+  return false;
 }
 
-bool EleTkIsolFromCands::
-passAlgo(const reco::TrackBase& trk,
-	 const std::vector<reco::TrackBase::TrackAlgorithm>& algosToRej)
-{
-  return algosToRej.empty() || !std::binary_search(algosToRej.begin(),algosToRej.end(),trk.algo());
+bool EleTkIsolFromCands::passAlgo(const reco::TrackBase& trk,
+                                  const std::vector<reco::TrackBase::TrackAlgorithm>& algosToRej) {
+  return algosToRej.empty() || !std::binary_search(algosToRej.begin(), algosToRej.end(), trk.algo());
 }
-

--- a/RecoEgamma/EgammaIsolationAlgos/src/ElectronTkIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/ElectronTkIsolation.cc
@@ -20,114 +20,109 @@
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 
-using namespace ROOT::Math::VectorUtil ;
+using namespace ROOT::Math::VectorUtil;
 
-
-ElectronTkIsolation::ElectronTkIsolation (double extRadius,
-                                          double intRadiusBarrel,
-                                          double intRadiusEndcap,
-                                          double stripBarrel,
-                                          double stripEndcap,
-                                          double ptLow,
-                                          double lip,
-                                          double drb,
-                                          const reco::TrackCollection* trackCollection,
-                                          reco::TrackBase::Point beamPoint,
-                                          const std::string &dzOptionString) :
-  extRadius_(extRadius),
-  intRadiusBarrel_(intRadiusBarrel),
-  intRadiusEndcap_(intRadiusEndcap),
-  stripBarrel_(stripBarrel),
-  stripEndcap_(stripEndcap),
-  ptLow_(ptLow),
-  lip_(lip),
-  drb_(drb),
-  trackCollection_(trackCollection),
-  beamPoint_(beamPoint)
-{
-    setAlgosToReject();
-    setDzOption(dzOptionString);
+ElectronTkIsolation::ElectronTkIsolation(double extRadius,
+                                         double intRadiusBarrel,
+                                         double intRadiusEndcap,
+                                         double stripBarrel,
+                                         double stripEndcap,
+                                         double ptLow,
+                                         double lip,
+                                         double drb,
+                                         const reco::TrackCollection* trackCollection,
+                                         reco::TrackBase::Point beamPoint,
+                                         const std::string& dzOptionString)
+    : extRadius_(extRadius),
+      intRadiusBarrel_(intRadiusBarrel),
+      intRadiusEndcap_(intRadiusEndcap),
+      stripBarrel_(stripBarrel),
+      stripEndcap_(stripEndcap),
+      ptLow_(ptLow),
+      lip_(lip),
+      drb_(drb),
+      trackCollection_(trackCollection),
+      beamPoint_(beamPoint) {
+  setAlgosToReject();
+  setDzOption(dzOptionString);
 }
 
-ElectronTkIsolation::~ElectronTkIsolation ()
-{}
+ElectronTkIsolation::~ElectronTkIsolation() {}
 
-std::pair<int,double> ElectronTkIsolation::getIso(const reco::GsfElectron* electron) const {
+std::pair<int, double> ElectronTkIsolation::getIso(const reco::GsfElectron* electron) const {
   return getIso(&(*(electron->gsfTrack())));
 }
 
 // unified acces to isolations
-std::pair<int,double> ElectronTkIsolation::getIso(const reco::Track* tmpTrack) const  
-{
-  int counter  =0 ;
-  double ptSum =0.;
+std::pair<int, double> ElectronTkIsolation::getIso(const reco::Track* tmpTrack) const {
+  int counter = 0;
+  double ptSum = 0.;
   //Take the electron track
   //reco::GsfTrackRef tmpTrack = electron->gsfTrack() ;
-  math::XYZVector tmpElectronMomentumAtVtx = (*tmpTrack).momentum () ; 
+  math::XYZVector tmpElectronMomentumAtVtx = (*tmpTrack).momentum();
   double tmpElectronEtaAtVertex = (*tmpTrack).eta();
 
-
-  for ( reco::TrackCollection::const_iterator itrTr  = (*trackCollection_).begin() ; 
-	itrTr != (*trackCollection_).end()   ; 
-	++itrTr ) {
-
-    double this_pt  = (*itrTr).pt();
-    if ( this_pt < ptLow_ ) continue;
-
+  for (reco::TrackCollection::const_iterator itrTr = (*trackCollection_).begin(); itrTr != (*trackCollection_).end();
+       ++itrTr) {
+    double this_pt = (*itrTr).pt();
+    if (this_pt < ptLow_)
+      continue;
 
     double dzCut = 0;
-    switch( dzOption_ ) {
-        case egammaisolation::EgammaTrackSelector::dz : dzCut = fabs( (*itrTr).dz() - (*tmpTrack).dz() ); break;
-        case egammaisolation::EgammaTrackSelector::vz : dzCut = fabs( (*itrTr).vz() - (*tmpTrack).vz() ); break;
-        case egammaisolation::EgammaTrackSelector::bs : dzCut = fabs( (*itrTr).dz(beamPoint_) - (*tmpTrack).dz(beamPoint_) ); break;
-        case egammaisolation::EgammaTrackSelector::vtx: dzCut = fabs( (*itrTr).dz(tmpTrack->vertex()) ); break;
-        default : dzCut = fabs( (*itrTr).vz() - (*tmpTrack).vz() ); break;
+    switch (dzOption_) {
+      case egammaisolation::EgammaTrackSelector::dz:
+        dzCut = fabs((*itrTr).dz() - (*tmpTrack).dz());
+        break;
+      case egammaisolation::EgammaTrackSelector::vz:
+        dzCut = fabs((*itrTr).vz() - (*tmpTrack).vz());
+        break;
+      case egammaisolation::EgammaTrackSelector::bs:
+        dzCut = fabs((*itrTr).dz(beamPoint_) - (*tmpTrack).dz(beamPoint_));
+        break;
+      case egammaisolation::EgammaTrackSelector::vtx:
+        dzCut = fabs((*itrTr).dz(tmpTrack->vertex()));
+        break;
+      default:
+        dzCut = fabs((*itrTr).vz() - (*tmpTrack).vz());
+        break;
     }
-    if (dzCut > lip_ ) continue;
-    if (fabs( (*itrTr).dxy(beamPoint_) ) > drb_   ) continue;
-    double dr = ROOT::Math::VectorUtil::DeltaR(itrTr->momentum(),tmpElectronMomentumAtVtx) ;
+    if (dzCut > lip_)
+      continue;
+    if (fabs((*itrTr).dxy(beamPoint_)) > drb_)
+      continue;
+    double dr = ROOT::Math::VectorUtil::DeltaR(itrTr->momentum(), tmpElectronMomentumAtVtx);
     double deta = (*itrTr).eta() - tmpElectronEtaAtVertex;
     bool isBarrel = std::abs(tmpElectronEtaAtVertex) < 1.479;
     double intRadius = isBarrel ? intRadiusBarrel_ : intRadiusEndcap_;
     double strip = isBarrel ? stripBarrel_ : stripEndcap_;
-    if(dr < extRadius_ && dr>=intRadius && std::abs(deta) >=strip && passAlgo(*itrTr)){
-        
-        ++counter ;
-        ptSum += this_pt;
+    if (dr < extRadius_ && dr >= intRadius && std::abs(deta) >= strip && passAlgo(*itrTr)) {
+      ++counter;
+      ptSum += this_pt;
     }
 
-  }//end loop over tracks                 
-  
-  std::pair<int,double> retval;
-  retval.first  = counter;
+  }  //end loop over tracks
+
+  std::pair<int, double> retval;
+  retval.first = counter;
   retval.second = ptSum;
-  
+
   return retval;
 }
 
-
-int ElectronTkIsolation::getNumberTracks (const reco::GsfElectron* electron) const
-{  
+int ElectronTkIsolation::getNumberTracks(const reco::GsfElectron* electron) const {
   //counter for the tracks in the isolation cone
-  return getIso(electron).first ;
+  return getIso(electron).first;
 }
 
-double ElectronTkIsolation::getPtTracks (const reco::GsfElectron* electron) const
-{
-  return getIso(electron).second ;
-}
+double ElectronTkIsolation::getPtTracks(const reco::GsfElectron* electron) const { return getIso(electron).second; }
 
-
-bool ElectronTkIsolation::passAlgo(const reco::TrackBase& trk)const
-{
+bool ElectronTkIsolation::passAlgo(const reco::TrackBase& trk) const {
   int algo = trk.algo();
-  bool rejAlgo=std::binary_search(algosToReject_.begin(),algosToReject_.end(),algo);
-  return rejAlgo==false;
+  bool rejAlgo = std::binary_search(algosToReject_.begin(), algosToReject_.end(), algo);
+  return rejAlgo == false;
 }
 
-
-void ElectronTkIsolation::setAlgosToReject()
-{
-  algosToReject_={reco::TrackBase::jetCoreRegionalStep};
-  std::sort(algosToReject_.begin(),algosToReject_.end());
+void ElectronTkIsolation::setAlgosToReject() {
+  algosToReject_ = {reco::TrackBase::jetCoreRegionalStep};
+  std::sort(algosToReject_.begin(), algosToReject_.end());
 }

--- a/RecoEgamma/EgammaIsolationAlgos/src/HcalPFClusterIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/HcalPFClusterIsolation.cc
@@ -7,32 +7,30 @@
 
 #include <DataFormats/Math/interface/deltaR.h>
 
-template<typename T1>
+template <typename T1>
 HcalPFClusterIsolation<T1>::HcalPFClusterIsolation(double drMax,
-						   double drVetoBarrel,
-						   double drVetoEndcap,
-						   double etaStripBarrel,
-						   double etaStripEndcap,
-						   double energyBarrel,
-						   double energyEndcap,
-						   bool useEt):
-  drMax_(drMax),
-  drVetoBarrel_(drVetoBarrel),
-  drVetoEndcap_(drVetoEndcap),
-  etaStripBarrel_(etaStripBarrel),
-  etaStripEndcap_(etaStripEndcap),
-  energyBarrel_(energyBarrel),
-  energyEndcap_(energyEndcap),
-  useEt_(useEt)
-{}
+                                                   double drVetoBarrel,
+                                                   double drVetoEndcap,
+                                                   double etaStripBarrel,
+                                                   double etaStripEndcap,
+                                                   double energyBarrel,
+                                                   double energyEndcap,
+                                                   bool useEt)
+    : drMax_(drMax),
+      drVetoBarrel_(drVetoBarrel),
+      drVetoEndcap_(drVetoEndcap),
+      etaStripBarrel_(etaStripBarrel),
+      etaStripEndcap_(etaStripEndcap),
+      energyBarrel_(energyBarrel),
+      energyEndcap_(energyEndcap),
+      useEt_(useEt) {}
 
-template<typename T1>
-HcalPFClusterIsolation<T1>::~HcalPFClusterIsolation() 
-{}
+template <typename T1>
+HcalPFClusterIsolation<T1>::~HcalPFClusterIsolation() {}
 
-template<typename T1>
-double HcalPFClusterIsolation<T1>::getSum(const T1Ref candRef, const std::vector<edm::Handle<reco::PFClusterCollection>>& clusterHandles) { 
-  
+template <typename T1>
+double HcalPFClusterIsolation<T1>::getSum(const T1Ref candRef,
+                                          const std::vector<edm::Handle<reco::PFClusterCollection>>& clusterHandles) {
   double etSum = 0.;
 
   float etaStrip = 0;
@@ -44,35 +42,34 @@ double HcalPFClusterIsolation<T1>::getSum(const T1Ref candRef, const std::vector
     dRVeto = drVetoEndcap_;
     etaStrip = etaStripEndcap_;
   }
-  
 
-  for (unsigned int nHandle=0; nHandle<clusterHandles.size(); nHandle++) {
-    for(unsigned i=0; i<clusterHandles[nHandle]->size(); i++) {
+  for (unsigned int nHandle = 0; nHandle < clusterHandles.size(); nHandle++) {
+    for (unsigned i = 0; i < clusterHandles[nHandle]->size(); i++) {
       const reco::PFClusterRef pfclu(clusterHandles[nHandle], i);
-    
+
       if (fabs(candRef->eta()) < 1.479) {
-	if (fabs(pfclu->pt()) < energyBarrel_)
-	  continue;
+        if (fabs(pfclu->pt()) < energyBarrel_)
+          continue;
       } else {
-	if (fabs(pfclu->energy()) < energyEndcap_)
-	  continue;
+        if (fabs(pfclu->energy()) < energyEndcap_)
+          continue;
       }
-      
+
       float dEta = fabs(candRef->eta() - pfclu->eta());
-      if(dEta < etaStrip) 
-	continue;
-      
+      if (dEta < etaStrip)
+        continue;
+
       float dR = deltaR(candRef->eta(), candRef->phi(), pfclu->eta(), pfclu->phi());
-      if(dR > drMax_ || dR < dRVeto) 
-	continue;
-      
+      if (dR > drMax_ || dR < dRVeto)
+        continue;
+
       if (useEt_)
-	etSum += pfclu->pt();
+        etSum += pfclu->pt();
       else
-	etSum += pfclu->energy();
+        etSum += pfclu->energy();
     }
   }
-  
+
   return etSum;
 }
 

--- a/RecoEgamma/EgammaIsolationAlgos/src/PFBlockBasedIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/PFBlockBasedIsolation.cc
@@ -2,8 +2,6 @@
 #include <cmath>
 #include "DataFormats/Math/interface/deltaR.h"
 
-
-
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
@@ -25,140 +23,120 @@ PFBlockBasedIsolation::PFBlockBasedIsolation() {
   // Default Constructor.
 }
 
-
-
-
 //--------------------------------------------------------------------------------------------------
-PFBlockBasedIsolation::~PFBlockBasedIsolation()
-{
+PFBlockBasedIsolation::~PFBlockBasedIsolation() {}
 
-}
+void PFBlockBasedIsolation::setup(const edm::ParameterSet& conf) { coneSize_ = conf.getParameter<double>("coneSize"); }
 
-
-void  PFBlockBasedIsolation::setup ( const edm::ParameterSet& conf ) {
-
-  coneSize_             = conf.getParameter<double>("coneSize");  
-
-}
-
-
-std::vector<reco::PFCandidateRef>  PFBlockBasedIsolation::calculate(math::XYZTLorentzVectorD p4, const reco::PFCandidateRef pfEGCand, const edm::Handle<reco::PFCandidateCollection> pfCandidateHandle) {
-  
+std::vector<reco::PFCandidateRef> PFBlockBasedIsolation::calculate(
+    math::XYZTLorentzVectorD p4,
+    const reco::PFCandidateRef pfEGCand,
+    const edm::Handle<reco::PFCandidateCollection> pfCandidateHandle) {
   std::vector<reco::PFCandidateRef> myVec;
-  
-  math::XYZVector candidateMomentum(p4.px(),p4.py(),p4.pz());
-  math::XYZVector candidateDirection=candidateMomentum.Unit();
+
+  math::XYZVector candidateMomentum(p4.px(), p4.py(), p4.pz());
+  math::XYZVector candidateDirection = candidateMomentum.Unit();
 
   const reco::PFCandidate::ElementsInBlocks& theElementsInpfEGcand = (*pfEGCand).elementsInBlocks();
   reco::PFCandidate::ElementsInBlocks::const_iterator ieg = theElementsInpfEGcand.begin();
   const reco::PFBlockRef egblock = ieg->first;
 
-
   unsigned nObj = pfCandidateHandle->size();
-  for(unsigned int lCand=0; lCand < nObj; lCand++) {
-
-    reco::PFCandidateRef pfCandRef(reco::PFCandidateRef(pfCandidateHandle,lCand));
+  for (unsigned int lCand = 0; lCand < nObj; lCand++) {
+    reco::PFCandidateRef pfCandRef(reco::PFCandidateRef(pfCandidateHandle, lCand));
 
     float dR = 0.0;
-    if( coneSize_ < 10.0 ) {
-      dR = deltaR(candidateDirection.Eta(), candidateDirection.Phi(),  pfCandRef->eta(),   pfCandRef->phi());         
-      if ( dR> coneSize_ ) continue;
+    if (coneSize_ < 10.0) {
+      dR = deltaR(candidateDirection.Eta(), candidateDirection.Phi(), pfCandRef->eta(), pfCandRef->phi());
+      if (dR > coneSize_)
+        continue;
     }
 
     const reco::PFCandidate::ElementsInBlocks& theElementsInPFcand = pfCandRef->elementsInBlocks();
 
-    bool elementFound=false;
-    for (reco::PFCandidate::ElementsInBlocks::const_iterator ipf = theElementsInPFcand.begin(); ipf<theElementsInPFcand.end(); ++ipf) {
- 
-     if ( ipf->first == egblock && !elementFound ) {
-
-	  for (ieg = theElementsInpfEGcand.begin(); ieg<theElementsInpfEGcand.end(); ++ieg) {
-	    if ( ipf->second == ieg->second && !elementFound  ) {
-	      if(elementPassesCleaning(pfCandRef,pfEGCand)){
-		myVec.push_back(pfCandRef);    
-		elementFound=true;
-	      }
-	    }
-	  }
-	
-	
-	
+    bool elementFound = false;
+    for (reco::PFCandidate::ElementsInBlocks::const_iterator ipf = theElementsInPFcand.begin();
+         ipf < theElementsInPFcand.end();
+         ++ipf) {
+      if (ipf->first == egblock && !elementFound) {
+        for (ieg = theElementsInpfEGcand.begin(); ieg < theElementsInpfEGcand.end(); ++ieg) {
+          if (ipf->second == ieg->second && !elementFound) {
+            if (elementPassesCleaning(pfCandRef, pfEGCand)) {
+              myVec.push_back(pfCandRef);
+              elementFound = true;
+            }
+          }
+        }
       }
     }
-
-    
-
   }
-  
-
 
   return myVec;
+}
 
-
-
- }
-
-
-bool PFBlockBasedIsolation::elementPassesCleaning(const reco::PFCandidateRef& pfCand,const reco::PFCandidateRef& pfEGCand)
-{
-  if(pfCand->particleId()==reco::PFCandidate::h) return passesCleaningChargedHadron(pfCand,pfEGCand);
-  else if(pfCand->particleId()==reco::PFCandidate::h0) return passesCleaningNeutralHadron(pfCand,pfEGCand);
-  else if(pfCand->particleId()==reco::PFCandidate::gamma) return passesCleaningPhoton(pfCand,pfEGCand);
-  else return true; //doesnt really matter here as if its not a photon,neutral or charged it wont be included in isolation
+bool PFBlockBasedIsolation::elementPassesCleaning(const reco::PFCandidateRef& pfCand,
+                                                  const reco::PFCandidateRef& pfEGCand) {
+  if (pfCand->particleId() == reco::PFCandidate::h)
+    return passesCleaningChargedHadron(pfCand, pfEGCand);
+  else if (pfCand->particleId() == reco::PFCandidate::h0)
+    return passesCleaningNeutralHadron(pfCand, pfEGCand);
+  else if (pfCand->particleId() == reco::PFCandidate::gamma)
+    return passesCleaningPhoton(pfCand, pfEGCand);
+  else
+    return true;  //doesnt really matter here as if its not a photon,neutral or charged it wont be included in isolation
 }
 
 //currently the record of which candidates came from the charged hadron is acceptable, no further cleaning is needed
-bool PFBlockBasedIsolation::passesCleaningChargedHadron(const reco::PFCandidateRef& pfCand,const reco::PFCandidateRef& pfEGCand)
-{
+bool PFBlockBasedIsolation::passesCleaningChargedHadron(const reco::PFCandidateRef& pfCand,
+                                                        const reco::PFCandidateRef& pfEGCand) {
   return true;
 }
 
 //neutral hadrons are not part of the PF E/gamma reco, therefore they cant currently come from an electron/photon and so should be rejected
 //but we still think there may be some useful info here and given we can easily
 //fix this at AOD level, we will auto accept them for now and clean later
-bool PFBlockBasedIsolation::passesCleaningNeutralHadron(const  reco::PFCandidateRef& pfCand,const reco::PFCandidateRef& pfEGCand)
-{
+bool PFBlockBasedIsolation::passesCleaningNeutralHadron(const reco::PFCandidateRef& pfCand,
+                                                        const reco::PFCandidateRef& pfEGCand) {
   return true;
 }
 
 //the highest et ECAL element of the photon must match to the electron superclusters or one of its sub clusters
-bool PFBlockBasedIsolation::passesCleaningPhoton(const  reco::PFCandidateRef& pfCand,const reco::PFCandidateRef& pfEGCand)
-{
-  bool passesCleaning=false;
+bool PFBlockBasedIsolation::passesCleaningPhoton(const reco::PFCandidateRef& pfCand,
+                                                 const reco::PFCandidateRef& pfEGCand) {
+  bool passesCleaning = false;
   const reco::PFBlockElementCluster* ecalClusWithMaxEt = getHighestEtECALCluster(*pfCand);
-  if(ecalClusWithMaxEt){
-    if(ecalClusWithMaxEt->superClusterRef().isNonnull() && 
-       ecalClusWithMaxEt->superClusterRef()->seed()->seed()==pfEGCand->superClusterRef()->seed()->seed()){ //being sure to match, some concerned about different collections, shouldnt be but to be safe
-      passesCleaning=true;
-    }else{
-      for(auto cluster : pfEGCand->superClusterRef()->clusters()){
-	//the PF clusters there are in two different collections so cant reference match
-	//but we can match on the seed id, no clusters can share a seed so if the seeds are 
-	//equal, it must be the same cluster
-	if(ecalClusWithMaxEt->clusterRef()->seed()==cluster->seed()) {
-	  passesCleaning=true;
-	}
-      }//end of loop over clusters
+  if (ecalClusWithMaxEt) {
+    if (ecalClusWithMaxEt->superClusterRef().isNonnull() &&
+        ecalClusWithMaxEt->superClusterRef()->seed()->seed() ==
+            pfEGCand->superClusterRef()
+                ->seed()
+                ->seed()) {  //being sure to match, some concerned about different collections, shouldnt be but to be safe
+      passesCleaning = true;
+    } else {
+      for (auto cluster : pfEGCand->superClusterRef()->clusters()) {
+        //the PF clusters there are in two different collections so cant reference match
+        //but we can match on the seed id, no clusters can share a seed so if the seeds are
+        //equal, it must be the same cluster
+        if (ecalClusWithMaxEt->clusterRef()->seed() == cluster->seed()) {
+          passesCleaning = true;
+        }
+      }  //end of loop over clusters
     }
-  }//end of null check for highest ecal cluster
+  }  //end of null check for highest ecal cluster
   return passesCleaning;
-
 }
 
-
-const reco::PFBlockElementCluster* PFBlockBasedIsolation::getHighestEtECALCluster(const reco::PFCandidate& pfCand)
-{
-  float maxECALEt =-1;
-  const reco::PFBlockElement* maxEtECALCluster=nullptr;
+const reco::PFBlockElementCluster* PFBlockBasedIsolation::getHighestEtECALCluster(const reco::PFCandidate& pfCand) {
+  float maxECALEt = -1;
+  const reco::PFBlockElement* maxEtECALCluster = nullptr;
   const reco::PFCandidate::ElementsInBlocks& elementsInPFCand = pfCand.elementsInBlocks();
-  for(auto& elemIndx : elementsInPFCand){
-    const reco::PFBlockElement* elem = elemIndx.second<elemIndx.first->elements().size() ? &elemIndx.first->elements()[elemIndx.second] : nullptr;
-    if(elem && elem->type()==reco::PFBlockElement::ECAL && elem->clusterRef()->pt()>maxECALEt){
+  for (auto& elemIndx : elementsInPFCand) {
+    const reco::PFBlockElement* elem =
+        elemIndx.second < elemIndx.first->elements().size() ? &elemIndx.first->elements()[elemIndx.second] : nullptr;
+    if (elem && elem->type() == reco::PFBlockElement::ECAL && elem->clusterRef()->pt() > maxECALEt) {
       maxECALEt = elem->clusterRef()->pt();
       maxEtECALCluster = elem;
     }
-    
   }
   return dynamic_cast<const reco::PFBlockElementCluster*>(maxEtECALCluster);
-	
 }

--- a/RecoEgamma/EgammaIsolationAlgos/src/PhotonTkIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/PhotonTkIsolation.cc
@@ -26,97 +26,101 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/Candidate/interface/Particle.h"
 
-
-PhotonTkIsolation::PhotonTkIsolation (float extRadius,
-                                      float intRadiusBarrel,
-                                      float intRadiusEndcap,
-                                      float stripBarrel,
-                                      float stripEndcap,
-                                      float etLow,
-                                      float lip,
-                                      float drb,
-                                      const reco::TrackCollection* trackCollection,
-                                      reco::TrackBase::Point beamPoint,
-                                      const std::string &dzOptionString) :
-  extRadius2_(extRadius*extRadius),
-  intRadiusBarrel2_(intRadiusBarrel*intRadiusBarrel),
-  intRadiusEndcap2_(intRadiusEndcap*intRadiusEndcap),
-  stripBarrel_(stripBarrel),
-  stripEndcap_(stripEndcap),
-  etLow_(etLow),
-  lip_(lip),
-  drb_(drb),
-  trackCollection_(trackCollection),
-  beamPoint_(beamPoint)
-{
-    setDzOption(dzOptionString);
+PhotonTkIsolation::PhotonTkIsolation(float extRadius,
+                                     float intRadiusBarrel,
+                                     float intRadiusEndcap,
+                                     float stripBarrel,
+                                     float stripEndcap,
+                                     float etLow,
+                                     float lip,
+                                     float drb,
+                                     const reco::TrackCollection* trackCollection,
+                                     reco::TrackBase::Point beamPoint,
+                                     const std::string& dzOptionString)
+    : extRadius2_(extRadius * extRadius),
+      intRadiusBarrel2_(intRadiusBarrel * intRadiusBarrel),
+      intRadiusEndcap2_(intRadiusEndcap * intRadiusEndcap),
+      stripBarrel_(stripBarrel),
+      stripEndcap_(stripEndcap),
+      etLow_(etLow),
+      lip_(lip),
+      drb_(drb),
+      trackCollection_(trackCollection),
+      beamPoint_(beamPoint) {
+  setDzOption(dzOptionString);
 }
 
-void PhotonTkIsolation::setDzOption(const std::string &s) {
-  if( ! s.compare("dz") )      dzOption_ = egammaisolation::EgammaTrackSelector::dz;
-  else if( ! s.compare("vz") ) dzOption_ = egammaisolation::EgammaTrackSelector::vz;
-  else if( ! s.compare("bs") ) dzOption_ = egammaisolation::EgammaTrackSelector::bs;
-  else if( ! s.compare("vtx") )dzOption_ = egammaisolation::EgammaTrackSelector::vtx;
-  else                         dzOption_ = egammaisolation::EgammaTrackSelector::dz;
+void PhotonTkIsolation::setDzOption(const std::string& s) {
+  if (!s.compare("dz"))
+    dzOption_ = egammaisolation::EgammaTrackSelector::dz;
+  else if (!s.compare("vz"))
+    dzOption_ = egammaisolation::EgammaTrackSelector::vz;
+  else if (!s.compare("bs"))
+    dzOption_ = egammaisolation::EgammaTrackSelector::bs;
+  else if (!s.compare("vtx"))
+    dzOption_ = egammaisolation::EgammaTrackSelector::vtx;
+  else
+    dzOption_ = egammaisolation::EgammaTrackSelector::dz;
 }
 
-
-
-PhotonTkIsolation::~PhotonTkIsolation ()
-{
-}
-
-
+PhotonTkIsolation::~PhotonTkIsolation() {}
 
 // unified acces to isolations
-std::pair<int,float> PhotonTkIsolation::getIso(const reco::Candidate* photon ) const  
-{
-  int counter  =0 ;
-  float ptSum =0.;
-
+std::pair<int, float> PhotonTkIsolation::getIso(const reco::Candidate* photon) const {
+  int counter = 0;
+  float ptSum = 0.;
 
   //Take the photon position
   float photonEta = photon->eta();
 
   //loop over tracks
-  for(reco::TrackCollection::const_iterator trItr = trackCollection_->begin(); trItr != trackCollection_->end(); ++trItr){
-
-    //check z-distance of vertex 
+  for (reco::TrackCollection::const_iterator trItr = trackCollection_->begin(); trItr != trackCollection_->end();
+       ++trItr) {
+    //check z-distance of vertex
     float dzCut = 0;
-    switch( dzOption_ ) {
-        case egammaisolation::EgammaTrackSelector::dz : dzCut = fabs( (*trItr).dz() - photon->vertex().z() ); break;
-        case egammaisolation::EgammaTrackSelector::vz : dzCut = fabs( (*trItr).vz() - photon->vertex().z() ); break;
-        case egammaisolation::EgammaTrackSelector::bs : dzCut = fabs( (*trItr).dz(beamPoint_) - photon->vertex().z() ); break;
-        case egammaisolation::EgammaTrackSelector::vtx: dzCut = fabs( (*trItr).dz(photon->vertex())); break;
-        default : dzCut = fabs( (*trItr).vz() - photon->vertex().z() ); break;
+    switch (dzOption_) {
+      case egammaisolation::EgammaTrackSelector::dz:
+        dzCut = fabs((*trItr).dz() - photon->vertex().z());
+        break;
+      case egammaisolation::EgammaTrackSelector::vz:
+        dzCut = fabs((*trItr).vz() - photon->vertex().z());
+        break;
+      case egammaisolation::EgammaTrackSelector::bs:
+        dzCut = fabs((*trItr).dz(beamPoint_) - photon->vertex().z());
+        break;
+      case egammaisolation::EgammaTrackSelector::vtx:
+        dzCut = fabs((*trItr).dz(photon->vertex()));
+        break;
+      default:
+        dzCut = fabs((*trItr).vz() - photon->vertex().z());
+        break;
     }
-    if (dzCut > lip_ ) continue;
+    if (dzCut > lip_)
+      continue;
 
-    float this_pt  = (*trItr).pt();
-    if ( this_pt < etLow_ ) continue ;  
-    if (fabs( (*trItr).dxy(beamPoint_) ) > drb_   ) continue;// only consider tracks from the main vertex 
-    float dr2 = reco::deltaR2(*trItr,*photon) ;
-    float deta = (*trItr).eta() - photonEta ;
+    float this_pt = (*trItr).pt();
+    if (this_pt < etLow_)
+      continue;
+    if (fabs((*trItr).dxy(beamPoint_)) > drb_)
+      continue;  // only consider tracks from the main vertex
+    float dr2 = reco::deltaR2(*trItr, *photon);
+    float deta = (*trItr).eta() - photonEta;
     if (fabs(photonEta) < 1.479) {
-    	if(dr2 < extRadius2_ && dr2 >= intRadiusBarrel2_ && fabs(deta) >= stripBarrel_) 
-      	{
-	    ++counter;
-	    ptSum += this_pt;
-      	}
-    }
-    else {
-        if(dr2 < extRadius2_ && dr2 >= intRadiusEndcap2_ && fabs(deta) >= stripEndcap_)
-        {
-            ++counter;
-            ptSum += this_pt;
-        }
+      if (dr2 < extRadius2_ && dr2 >= intRadiusBarrel2_ && fabs(deta) >= stripBarrel_) {
+        ++counter;
+        ptSum += this_pt;
+      }
+    } else {
+      if (dr2 < extRadius2_ && dr2 >= intRadiusEndcap2_ && fabs(deta) >= stripEndcap_) {
+        ++counter;
+        ptSum += this_pt;
+      }
     }
 
-  }//end loop over tracks
+  }  //end loop over tracks
 
-  std::pair<int,float> retval;
-  retval.first  = counter;
-  retval.second = ptSum;  
+  std::pair<int, float> retval;
+  retval.first = counter;
+  retval.second = ptSum;
   return retval;
 }
-

--- a/RecoEgamma/EgammaIsolationAlgos/test/EgammaTowerIso_t.cpp
+++ b/RecoEgamma/EgammaIsolationAlgos/test/EgammaTowerIso_t.cpp
@@ -1,18 +1,15 @@
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaTowerIsolation.h"
 #include "DataFormats/RecoCandidate/interface/RecoCandidate.h"
 
-
 int main() {
-
   CaloTowerCollection towers;
 
-  float cutEx[2]{1.f,2.f}, cutIn[2]{0.5f,0.5f};
-  EgammaTowerIsolationNew<2> iso(cutEx,cutIn,towers);
+  float cutEx[2]{1.f, 2.f}, cutIn[2]{0.5f, 0.5f};
+  EgammaTowerIsolationNew<2> iso(cutEx, cutIn, towers);
 
   CaloTower cand;
   EgammaTowerIsolationNew<2>::Sum sum;
-  iso.compute(true,sum,cand,nullptr,nullptr);
+  iso.compute(true, sum, cand, nullptr, nullptr);
 
   return 0;
-
 }

--- a/RecoEgamma/EgammaIsolationAlgos/test/TestEgammaTowerIso.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/test/TestEgammaTowerIso.cc
@@ -7,53 +7,35 @@
 
 #include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
 
-
 struct TestEgammaTowerIsolation : public edm::EDAnalyzer {
+  explicit TestEgammaTowerIsolation(const edm::ParameterSet&) {}
+  ~TestEgammaTowerIsolation() {}
 
- explicit  TestEgammaTowerIsolation(const edm::ParameterSet&){}
-  ~TestEgammaTowerIsolation(){}
-  
   //  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  
-  
+
 private:
-  virtual void beginJob(){}
+  virtual void beginJob() {}
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob(){}
+  virtual void endJob() {}
 
-
-  std::string towerLabel="towerMaker";
-
-
-
+  std::string towerLabel = "towerMaker";
 };
 //define this as a plug-in
 DEFINE_FWK_MODULE(TestEgammaTowerIsolation);
-
 
 #include <iostream>
 void TestEgammaTowerIsolation::analyze(const edm::Event& iEvent, const edm::EventSetup&) {
   edm::Handle<CaloTowerCollection> towerHandle;
   iEvent.getByLabel(towerLabel, towerHandle);
-  const CaloTowerCollection & towers = *towerHandle.product();
-  
+  const CaloTowerCollection& towers = *towerHandle.product();
+
   std::cout << "\n new event\n " << towers.size() << std::endl;
 
   uint32_t nt = towers.size();
-  for ( uint32_t j=0;j!=nt; ++j) {
-    std:: cout << j << ": " << 
-      towers[j].eta() << ", " <<
-      towers[j].phi() << ", " <<
-      towers[j].id() << ", " <<
-      towers[j].ietaAbs() << ", " <<
-      std::sin(towers[j].theta()) << ", " <<
-      1./std::cosh(towers[j].eta()) << ", " <<
-      towers[j].hadEnergy() << ", " <<
-      towers[j].hadEnergyHeInnerLayer() << ", " <<
-      towers[j].hadEnergyHeOuterLayer() << ", " <<
-      std::endl;
+  for (uint32_t j = 0; j != nt; ++j) {
+    std::cout << j << ": " << towers[j].eta() << ", " << towers[j].phi() << ", " << towers[j].id() << ", "
+              << towers[j].ietaAbs() << ", " << std::sin(towers[j].theta()) << ", " << 1. / std::cosh(towers[j].eta())
+              << ", " << towers[j].hadEnergy() << ", " << towers[j].hadEnergyHeInnerLayer() << ", "
+              << towers[j].hadEnergyHeOuterLayer() << ", " << std::endl;
   }
-
-
-
 }

--- a/RecoMuon/GlobalTrackFinder/interface/GlobalMuonTrajectoryBuilder.h
+++ b/RecoMuon/GlobalTrackFinder/interface/GlobalMuonTrajectoryBuilder.h
@@ -15,39 +15,38 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
-namespace edm {class ParameterSet; class Event; class EventSetup; }
+namespace edm {
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
 class MuonServiceProxy;
 class Trajectory;
 
 class GlobalMuonTrajectoryBuilder : public GlobalTrajectoryBuilderBase {
+public:
+  /// constructor with Parameter Set and MuonServiceProxy
+  GlobalMuonTrajectoryBuilder(const edm::ParameterSet&, const MuonServiceProxy*, edm::ConsumesCollector&);
 
-  public:
+  /// destructor
+  ~GlobalMuonTrajectoryBuilder() override;
 
-    /// constructor with Parameter Set and MuonServiceProxy
-  GlobalMuonTrajectoryBuilder(const edm::ParameterSet&, const MuonServiceProxy*,edm::ConsumesCollector&);
-          
-    /// destructor
-    ~GlobalMuonTrajectoryBuilder() override;
+  using GlobalTrajectoryBuilderBase::trajectories;
 
-    using GlobalTrajectoryBuilderBase::trajectories;
+  /// reconstruct trajectories from standalone and tracker only Tracks
+  MuonTrajectoryBuilder::CandidateContainer trajectories(const TrackCand&) override;
 
-    /// reconstruct trajectories from standalone and tracker only Tracks    
-    MuonTrajectoryBuilder::CandidateContainer trajectories(const TrackCand&) override;
+  /// pass the Event to the algo at each event
+  void setEvent(const edm::Event&) override;
 
-    /// pass the Event to the algo at each event
-    void setEvent(const edm::Event&) override;
+private:
+  /// make a TrackCand collection using tracker Track, Trajectory information
+  std::vector<TrackCand> makeTkCandCollection(const TrackCand&) override;
 
-  private:
-  
-    /// make a TrackCand collection using tracker Track, Trajectory information
-    std::vector<TrackCand> makeTkCandCollection(const TrackCand&) override;
-
-  private:
-  
-    edm::InputTag theTkTrackLabel;
-    edm::EDGetTokenT<reco::TrackCollection> allTrackerTracksToken;
-    edm::Handle<reco::TrackCollection> allTrackerTracks;
-
+private:
+  edm::InputTag theTkTrackLabel;
+  edm::EDGetTokenT<reco::TrackCollection> allTrackerTracksToken;
+  edm::Handle<reco::TrackCollection> allTrackerTracks;
 };
 #endif

--- a/RecoMuon/TrackingTools/interface/DirectMuonTrajectoryBuilder.h
+++ b/RecoMuon/TrackingTools/interface/DirectMuonTrajectoryBuilder.h
@@ -16,30 +16,29 @@ class MuonServiceProxy;
 class SeedTransformer;
 class TrajectorySeed;
 
-namespace edm {class ParameterSet;}
+namespace edm {
+  class ParameterSet;
+}
 
-class DirectMuonTrajectoryBuilder: public MuonTrajectoryBuilder {
+class DirectMuonTrajectoryBuilder : public MuonTrajectoryBuilder {
+public:
+  /// constructor
+  DirectMuonTrajectoryBuilder(const edm::ParameterSet&, const MuonServiceProxy*);
 
- public:
-  
-    /// constructor
-  DirectMuonTrajectoryBuilder(const edm::ParameterSet&, 
-			      const MuonServiceProxy*);
-  
   /// destructor
   ~DirectMuonTrajectoryBuilder() override;
-  
-    /// return a container of the reconstructed trajectories compatible with a given seed
+
+  /// return a container of the reconstructed trajectories compatible with a given seed
   TrajectoryContainer trajectories(const TrajectorySeed&) override;
-  
+
   /// return a container reconstructed muons starting from a given track
   CandidateContainer trajectories(const TrackCand&) override;
-  
+
   /// pass the Event to the algo at each event
   void setEvent(const edm::Event& event) override;
-  
- private:
-     const MuonServiceProxy *theService;
-     SeedTransformer* theSeedTransformer;
+
+private:
+  const MuonServiceProxy* theService;
+  SeedTransformer* theSeedTransformer;
 };
 #endif

--- a/RecoMuon/TrackingTools/interface/MuonBestMeasurementFinder.h
+++ b/RecoMuon/TrackingTools/interface/MuonBestMeasurementFinder.h
@@ -22,35 +22,27 @@ class TrajectoryMeasurement;
 class MuonTransientTrackingRecHit;
 
 class MuonBestMeasurementFinder {
-  typedef std::vector<TrajectoryMeasurement*>    TMContainer;
-  typedef TMContainer::iterator                 TMIterator;
+  typedef std::vector<TrajectoryMeasurement*> TMContainer;
+  typedef TMContainer::iterator TMIterator;
 
 public:
-  
   /// Constructor
   MuonBestMeasurementFinder();
-  
+
   /// Destructor
   virtual ~MuonBestMeasurementFinder();
 
   // Operations
 
-   /// return the Tm with the best chi2: no cut applied.
-  TrajectoryMeasurement* findBestMeasurement(std::vector<TrajectoryMeasurement>& measC,
-					     const Propagator* propagator);
-  
-  std::pair<double,int> lookAtSubRecHits(TrajectoryMeasurement* measurement,
-					 const Propagator* propagator);
+  /// return the Tm with the best chi2: no cut applied.
+  TrajectoryMeasurement* findBestMeasurement(std::vector<TrajectoryMeasurement>& measC, const Propagator* propagator);
 
-  const MeasurementEstimator* estimator() const { return theEstimator;}
+  std::pair<double, int> lookAtSubRecHits(TrajectoryMeasurement* measurement, const Propagator* propagator);
+
+  const MeasurementEstimator* estimator() const { return theEstimator; }
 
 protected:
-
 private:
-
   const MeasurementEstimator* theEstimator;
-
 };
 #endif
-
-

--- a/RecoMuon/TrackingTools/interface/MuonCandidate.h
+++ b/RecoMuon/TrackingTools/interface/MuonCandidate.h
@@ -11,49 +11,38 @@
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include <vector>
 
+class MuonCandidate {
+public:
+  typedef std::vector<Trajectory*> TrajectoryContainer;
+  typedef std::vector<MuonCandidate*> CandidateContainer;
 
-class MuonCandidate { 
-  
-  public:
+public:
+  /// constructor
+  MuonCandidate(Trajectory* traj, const reco::TrackRef& muon, const reco::TrackRef& tracker, Trajectory* trackerTraj)
+      : theTrajectory(traj), theMuonTrack(muon), theTrackerTrack(tracker), theTrackerTrajectory(trackerTraj) {}
 
-    typedef std::vector<Trajectory*> TrajectoryContainer; 
-    typedef std::vector<MuonCandidate*> CandidateContainer;
+  MuonCandidate(Trajectory* traj, const reco::TrackRef& muon, const reco::TrackRef& tracker)
+      : theTrajectory(traj), theMuonTrack(muon), theTrackerTrack(tracker), theTrackerTrajectory(nullptr) {}
 
-  public:
-  
-    /// constructor
-    MuonCandidate(Trajectory* traj, 
-		  const reco::TrackRef& muon, 
-		  const reco::TrackRef& tracker,
-    		  Trajectory* trackerTraj) :
-      theTrajectory(traj), theMuonTrack(muon), theTrackerTrack(tracker), theTrackerTrajectory(trackerTraj) {} 
-    
-    MuonCandidate(Trajectory* traj, 
-                  const reco::TrackRef& muon, 
-                  const reco::TrackRef& tracker) :
-      theTrajectory(traj), theMuonTrack(muon), theTrackerTrack(tracker), theTrackerTrajectory(nullptr) {} 
-    
-    /// destructor
-    virtual ~MuonCandidate() { }
-  
-    /// return trajectory
-    Trajectory* trajectory() const { return theTrajectory; }
+  /// destructor
+  virtual ~MuonCandidate() {}
 
-    /// return muon track
-    const reco::TrackRef muonTrack() const { return theMuonTrack; }
+  /// return trajectory
+  Trajectory* trajectory() const { return theTrajectory; }
 
-    /// return tracker track
-    const reco::TrackRef trackerTrack() const { return theTrackerTrack; }
-    
-    /// return tracker trajectory
-    Trajectory* trackerTrajectory() const { return theTrackerTrajectory; }
-                 
-  private:
+  /// return muon track
+  const reco::TrackRef muonTrack() const { return theMuonTrack; }
 
-    Trajectory* theTrajectory;
-    reco::TrackRef theMuonTrack;
-    reco::TrackRef theTrackerTrack;
-    Trajectory* theTrackerTrajectory;
+  /// return tracker track
+  const reco::TrackRef trackerTrack() const { return theTrackerTrack; }
 
+  /// return tracker trajectory
+  Trajectory* trackerTrajectory() const { return theTrackerTrajectory; }
+
+private:
+  Trajectory* theTrajectory;
+  reco::TrackRef theMuonTrack;
+  reco::TrackRef theTrackerTrack;
+  Trajectory* theTrackerTrajectory;
 };
-#endif 
+#endif

--- a/RecoMuon/TrackingTools/interface/MuonChi2MeasurementEstimator.h
+++ b/RecoMuon/TrackingTools/interface/MuonChi2MeasurementEstimator.h
@@ -9,32 +9,24 @@
  *  \author Giorgia Mila - INFN Torino
  */
 
-
 #include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimatorBase.h"
 #include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
 
-
 class MuonChi2MeasurementEstimator : public Chi2MeasurementEstimatorBase {
- public:
-  
+public:
   /// Constructor detector indipendent
   MuonChi2MeasurementEstimator(double maxChi2, double nSigma = 3.);
-  
+
   /// Constructor detector dependent
   MuonChi2MeasurementEstimator(double dtMaxChi2, double cscMaxChi2, double rpcMaxChi2, double nSigma);
-  
+
   /// Chi2 estimator
-  std::pair<bool,double> estimate(const TrajectoryStateOnSurface&,
-					  const TrackingRecHit&) const override;
+  std::pair<bool, double> estimate(const TrajectoryStateOnSurface&, const TrackingRecHit&) const override;
 
-
- private:
-  
+private:
   Chi2MeasurementEstimator theDTChi2Estimator;
   Chi2MeasurementEstimator theCSCChi2Estimator;
   Chi2MeasurementEstimator theRPCChi2Estimator;
-
-
 };
 
 #endif

--- a/RecoMuon/TrackingTools/interface/MuonErrorMatrix.h
+++ b/RecoMuon/TrackingTools/interface/MuonErrorMatrix.h
@@ -12,10 +12,6 @@
  * \author Finn Rebassoo      UCSB
  */
 
-
-
-
-
 #include <TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h>
 #include <TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h>
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -25,86 +21,80 @@
 #include <TString.h>
 #include <TAxis.h>
 
-
-class MuonErrorMatrix{
- public:
+class MuonErrorMatrix {
+public:
   /// enum type to define if the class is used as a tool or to be created
-  enum action { use , constructor};
+  enum action { use, constructor };
   /// constructor from a parameter set
-  MuonErrorMatrix(const edm::ParameterSet & pset);
-  
+  MuonErrorMatrix(const edm::ParameterSet& pset);
+
   /// destructor
   ~MuonErrorMatrix();
 
   /// close the root file attached to the class
   void close();
-  
+
   /// main method to be used. Retrieve a 5x5 symetrical matrix according to parametrization of error or scale factor
-  CurvilinearTrajectoryError get(GlobalVector momentum,bool convolute=true);
+  CurvilinearTrajectoryError get(GlobalVector momentum, bool convolute = true);
   CurvilinearTrajectoryError getFast(GlobalVector momentum);
 
   /// multiply term by term the two matrix
-  static  void multiply(CurvilinearTrajectoryError & initial_error, const CurvilinearTrajectoryError & scale_error);
+  static void multiply(CurvilinearTrajectoryError& initial_error, const CurvilinearTrajectoryError& scale_error);
 
   /// divide term by term the two matrix
-  static  bool divide(CurvilinearTrajectoryError & num_error, const CurvilinearTrajectoryError & denom_error);
+  static bool divide(CurvilinearTrajectoryError& num_error, const CurvilinearTrajectoryError& denom_error);
 
   /// actually get access to the TProfile3D used for the parametrization
-  inline TProfile3D * get(int i , int j) {return Index(i,j);}
-  inline unsigned int index(int i, int j){return Pindex(i,j);}
+  inline TProfile3D* get(int i, int j) { return Index(i, j); }
+  inline unsigned int index(int i, int j) { return Pindex(i, j); }
 
   /// names of the variables of the 5x5 error matrix
   static const TString vars[5];
 
   /// provide the numerical value used. sigma or correlation factor
-  static double Term(const AlgebraicSymMatrix55 & curv, int i, int j);
+  static double Term(const AlgebraicSymMatrix55& curv, int i, int j);
 
   ///method to get the bin index, taking care of under/overlow: first(1)/last(GetNbins())returned
-  int findBin(TAxis * axis, double value);
+  int findBin(TAxis* axis, double value);
 
   /// convert sigma2/COV -> sigma/rho
-  void simpleTerm(const AlgebraicSymMatrix55 & input, AlgebraicSymMatrix55 & output);
-  
+  void simpleTerm(const AlgebraicSymMatrix55& input, AlgebraicSymMatrix55& output);
+
   ///convert sigma/rho -> sigma2/COV
-  void complicatedTerm(const AlgebraicSymMatrix55 & input, AlgebraicSymMatrix55 & output);
+  void complicatedTerm(const AlgebraicSymMatrix55& input, AlgebraicSymMatrix55& output);
 
   /// adjust the error matrix on the state
-  void adjust(FreeTrajectoryState & state);
+  void adjust(FreeTrajectoryState& state);
 
   /// adjust the error matrix on the state
-  void adjust(TrajectoryStateOnSurface & state);
+  void adjust(TrajectoryStateOnSurface& state);
 
- private:
+private:
   /// log category: "MuonErrorMatrix"
   std::string theCategory;
 
   /// the attached root file, where the parametrization is saved
-  TDirectory * theD;
-  /// 15 TProfile, each holding he parametrization of each term of the 5x5 
-  TProfile3D * theData[15];
-  TProfile3D * theData_fast[5][5];
+  TDirectory* theD;
+  /// 15 TProfile, each holding he parametrization of each term of the 5x5
+  TProfile3D* theData[15];
+  TProfile3D* theData_fast[5][5];
 
   /// decide whether to scale of to assigne terms
-  enum TermAction  { error, scale, assign };
-  TermAction theTermAction[15];  
+  enum TermAction { error, scale, assign };
+  TermAction theTermAction[15];
 
   /// internal methods to get the index of a matrix term.
-  inline int Pindex(int i , int j) {
-    static const int offset[5]={0,5,5+4,5+4+3,5+4+3+2};
-    return offset[i]+abs(j-i);}
+  inline int Pindex(int i, int j) {
+    static const int offset[5] = {0, 5, 5 + 4, 5 + 4 + 3, 5 + 4 + 3 + 2};
+    return offset[i] + abs(j - i);
+  }
   /// internal method to get access to the profiles
-  inline TProfile3D * Index(int i , int j) {
-    return theData[Pindex(i,j)];}
+  inline TProfile3D* Index(int i, int j) { return theData[Pindex(i, j)]; }
 
-
-  /// internal method that retreives the value of the parametrization for term i,j  
-  double Value(GlobalVector & momentum, int i, int j,bool convolute=true);
-  /// internal method that retreives the error on the value of the parametrization for term i,j  
-  double Rms(GlobalVector & momentum, int i, int j);
-  
-
+  /// internal method that retreives the value of the parametrization for term i,j
+  double Value(GlobalVector& momentum, int i, int j, bool convolute = true);
+  /// internal method that retreives the error on the value of the parametrization for term i,j
+  double Rms(GlobalVector& momentum, int i, int j);
 };
-
-
 
 #endif

--- a/RecoMuon/TrackingTools/interface/MuonPatternRecoDumper.h
+++ b/RecoMuon/TrackingTools/interface/MuonPatternRecoDumper.h
@@ -30,10 +30,9 @@ public:
 
   std::string dumpTSOS(const TrajectoryStateOnSurface& tsos) const;
 
-  std::string dumpMuonId(const DetId &id) const;
-protected:
+  std::string dumpMuonId(const DetId& id) const;
 
+protected:
 private:
 };
 #endif
-

--- a/RecoMuon/TrackingTools/interface/MuonSeedFromRecHits.h
+++ b/RecoMuon/TrackingTools/interface/MuonSeedFromRecHits.h
@@ -16,32 +16,31 @@
 #include "MagneticField/Engine/interface/MagneticField.h"
 class MuonSeedPtExtractor;
 
-class MuonSeedFromRecHits 
-{
+class MuonSeedFromRecHits {
 public:
   MuonSeedFromRecHits();
   virtual ~MuonSeedFromRecHits() {}
 
-  void setBField(const MagneticField * field) {theField = field;}
-  void setPtExtractor(const MuonSeedPtExtractor * extractor) {thePtExtractor = extractor;}
+  void setBField(const MagneticField* field) { theField = field; }
+  void setPtExtractor(const MuonSeedPtExtractor* extractor) { thePtExtractor = extractor; }
 
   void add(MuonTransientTrackingRecHit::MuonRecHitPointer hit) { theRhits.push_back(hit); }
   MuonTransientTrackingRecHit::ConstMuonRecHitPointer firstRecHit() const { return theRhits.front(); }
-  unsigned int nrhit() const { return  theRhits.size(); }
-  void clear() {theRhits.clear();}
+  unsigned int nrhit() const { return theRhits.size(); }
+  void clear() { theRhits.clear(); }
 
-  TrajectorySeed createSeed(float ptmean, float sptmean,
-			    MuonTransientTrackingRecHit::ConstMuonRecHitPointer last) const;
-  
-  protected:
+  TrajectorySeed createSeed(float ptmean,
+                            float sptmean,
+                            MuonTransientTrackingRecHit::ConstMuonRecHitPointer last) const;
+
+protected:
   typedef MuonTransientTrackingRecHit::MuonRecHitContainer MuonRecHitContainer;
   typedef MuonTransientTrackingRecHit::MuonRecHitPointer MuonRecHitPointer;
   typedef MuonTransientTrackingRecHit::ConstMuonRecHitPointer ConstMuonRecHitPointer;
 
   MuonTransientTrackingRecHit::MuonRecHitContainer theRhits;
-  const MagneticField * theField;
-  const MuonSeedPtExtractor * thePtExtractor;
-
+  const MagneticField* theField;
+  const MuonSeedPtExtractor* thePtExtractor;
 };
 
 #endif

--- a/RecoMuon/TrackingTools/interface/MuonSegmentMatcher.h
+++ b/RecoMuon/TrackingTools/interface/MuonSegmentMatcher.h
@@ -16,48 +16,49 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
-namespace edm {class Event; class EventSetup;}
-namespace reco {class TransientTrack;}
+namespace edm {
+  class Event;
+  class EventSetup;
+}  // namespace edm
+namespace reco {
+  class TransientTrack;
+}
 
 class MuonServiceProxy;
 
-class MuonSegmentMatcher { 
-
-  public:
-
-    /// constructor with Parameter Set and MuonServiceProxy
+class MuonSegmentMatcher {
+public:
+  /// constructor with Parameter Set and MuonServiceProxy
   MuonSegmentMatcher(const edm::ParameterSet&, edm::ConsumesCollector& iC);
-          
-    /// destructor
-    virtual ~MuonSegmentMatcher();
 
-    /// perform the matching
-    std::vector<const DTRecSegment4D*> matchDT (const reco::Track& muon, const edm::Event& event);
-   
-    std::vector<const CSCSegment*>     matchCSC(const reco::Track& muon, const edm::Event& event);
+  /// destructor
+  virtual ~MuonSegmentMatcher();
 
-    std::vector<const RPCRecHit*>     matchRPC(const reco::Track& muon, const edm::Event& event);
-  
-  protected:
+  /// perform the matching
+  std::vector<const DTRecSegment4D*> matchDT(const reco::Track& muon, const edm::Event& event);
 
-  private:
-	const MuonServiceProxy* theService;
-	const edm::Event* theEvent;
-	
-	edm::InputTag TKtrackTags_;
-	edm::InputTag trackTags_; //used to select what tracks to read from configuration file
-	edm::InputTag DTSegmentTags_;
-	edm::InputTag CSCSegmentTags_;
-	edm::InputTag RPCHitTags_;
+  std::vector<const CSCSegment*> matchCSC(const reco::Track& muon, const edm::Event& event);
 
-	edm::EDGetTokenT<DTRecSegment4DCollection> dtRecHitsToken;
-	edm::EDGetTokenT<CSCSegmentCollection> allSegmentsCSCToken;
-	edm::EDGetTokenT<RPCRecHitCollection> rpcRecHitsToken;
+  std::vector<const RPCRecHit*> matchRPC(const reco::Track& muon, const edm::Event& event);
 
-	double dtRadius_;
-	
-	bool dtTightMatch;
-	bool cscTightMatch;
+protected:
+private:
+  const MuonServiceProxy* theService;
+  const edm::Event* theEvent;
 
+  edm::InputTag TKtrackTags_;
+  edm::InputTag trackTags_;  //used to select what tracks to read from configuration file
+  edm::InputTag DTSegmentTags_;
+  edm::InputTag CSCSegmentTags_;
+  edm::InputTag RPCHitTags_;
+
+  edm::EDGetTokenT<DTRecSegment4DCollection> dtRecHitsToken;
+  edm::EDGetTokenT<CSCSegmentCollection> allSegmentsCSCToken;
+  edm::EDGetTokenT<RPCRecHitCollection> rpcRecHitsToken;
+
+  double dtRadius_;
+
+  bool dtTightMatch;
+  bool cscTightMatch;
 };
 #endif

--- a/RecoMuon/TrackingTools/interface/MuonServiceProxy.h
+++ b/RecoMuon/TrackingTools/interface/MuonServiceProxy.h
@@ -22,7 +22,10 @@
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "RecoMuon/Navigation/interface/MuonNavigationSchool.h"
 
-namespace edm {class ParameterSet; class EventSetup;}
+namespace edm {
+  class ParameterSet;
+  class EventSetup;
+}  // namespace edm
 
 class MuonServiceProxy {
 public:
@@ -33,41 +36,38 @@ public:
   virtual ~MuonServiceProxy();
 
   // Operations
-  
+
   /// update the services each event
   void update(const edm::EventSetup& setup);
 
   /// get the magnetic field
-  edm::ESHandle<MagneticField> magneticField() const {return theMGField;}
+  edm::ESHandle<MagneticField> magneticField() const { return theMGField; }
 
   /// get the tracking geometry
-  edm::ESHandle<GlobalTrackingGeometry> trackingGeometry() const {return theTrackingGeometry;}
+  edm::ESHandle<GlobalTrackingGeometry> trackingGeometry() const { return theTrackingGeometry; }
 
   /// get the detLayer geometry
-  edm::ESHandle<MuonDetLayerGeometry> detLayerGeometry() const {return theDetLayerGeometry;}
+  edm::ESHandle<MuonDetLayerGeometry> detLayerGeometry() const { return theDetLayerGeometry; }
 
   /// get the propagator
   edm::ESHandle<Propagator> propagator(std::string propagatorName) const;
 
   /// get the whole EventSetup
-  const edm::EventSetup &eventSetup() const {return *theEventSetup;}
-  
-  /// check if the MuonReco Geometry has been changed
-  bool isTrackingComponentsRecordChanged() const {return theChangeInTrackingComponentsRecord;}
-  
-  const MuonNavigationSchool *muonNavigationSchool() const{
-    return theSchool;
-  }
+  const edm::EventSetup& eventSetup() const { return *theEventSetup; }
 
- protected:
-  
- private:
-  typedef std::map<std::string,  edm::ESHandle<Propagator> > propagators;
-  
+  /// check if the MuonReco Geometry has been changed
+  bool isTrackingComponentsRecordChanged() const { return theChangeInTrackingComponentsRecord; }
+
+  const MuonNavigationSchool* muonNavigationSchool() const { return theSchool; }
+
+protected:
+private:
+  typedef std::map<std::string, edm::ESHandle<Propagator> > propagators;
+
   edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
   edm::ESHandle<MagneticField> theMGField;
   edm::ESHandle<MuonDetLayerGeometry> theDetLayerGeometry;
-  const edm::EventSetup *theEventSetup;
+  const edm::EventSetup* theEventSetup;
   bool theMuonNavigationFlag;
   bool theRPCLayer;
   bool theCSCLayer;
@@ -81,9 +81,7 @@ public:
   unsigned long long theCacheId_MG;
   unsigned long long theCacheId_DG;
   unsigned long long theCacheId_P;
-  
-  bool theChangeInTrackingComponentsRecord;
 
+  bool theChangeInTrackingComponentsRecord;
 };
 #endif
-

--- a/RecoMuon/TrackingTools/interface/MuonTrackFinder.h
+++ b/RecoMuon/TrackingTools/interface/MuonTrackFinder.h
@@ -17,7 +17,11 @@
 
 #include <vector>
 
-namespace edm {class ParameterSet; class Event; class EventSetup;}
+namespace edm {
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
 class TrackerTopology;
 
 class MuonTrajectoryBuilder;
@@ -25,55 +29,48 @@ class MuonTrajectoryCleaner;
 class MuonTrackLoader;
 
 class MuonTrackFinder {
+public:
+  typedef MuonCandidate::TrajectoryContainer TrajectoryContainer;
+  typedef MuonCandidate::CandidateContainer CandidateContainer;
+  typedef std::pair<const Trajectory*, reco::TrackRef> TrackCand;
 
-  public:
+public:
+  /// Constructor, with default cleaner. For the STA reconstruction the trackLoader must have the propagator.
+  MuonTrackFinder(MuonTrajectoryBuilder* ConcreteMuonTrajectoryBuilder, MuonTrackLoader* trackLoader);
 
-    typedef MuonCandidate::TrajectoryContainer TrajectoryContainer;
-    typedef MuonCandidate::CandidateContainer CandidateContainer;
-    typedef std::pair<const Trajectory*, reco::TrackRef> TrackCand;  
+  /// Constructor, with user-defined cleaner. For the STA reconstruction the trackLoader must have the propagator.
+  MuonTrackFinder(MuonTrajectoryBuilder* ConcreteMuonTrajectoryBuilder,
+                  MuonTrackLoader* trackLoader,
+                  MuonTrajectoryCleaner* cleaner);
 
-  public:
-  
-    /// Constructor, with default cleaner. For the STA reconstruction the trackLoader must have the propagator.
-    MuonTrackFinder(MuonTrajectoryBuilder* ConcreteMuonTrajectoryBuilder,
-		    MuonTrackLoader *trackLoader);
+  /// destructor
+  virtual ~MuonTrackFinder();
 
-    /// Constructor, with user-defined cleaner. For the STA reconstruction the trackLoader must have the propagator.
-    MuonTrackFinder(MuonTrajectoryBuilder* ConcreteMuonTrajectoryBuilder,
-		    MuonTrackLoader *trackLoader,
-		    MuonTrajectoryCleaner* cleaner);
-    
-    /// destructor
-    virtual ~MuonTrackFinder();
-  
-    /// reconstruct standalone tracks starting from a collection of seeds
-    edm::OrphanHandle<reco::TrackCollection> reconstruct(const edm::Handle<edm::View<TrajectorySeed> >&,
-                                                         edm::Event&,
-                                                         const edm::EventSetup&);
+  /// reconstruct standalone tracks starting from a collection of seeds
+  edm::OrphanHandle<reco::TrackCollection> reconstruct(const edm::Handle<edm::View<TrajectorySeed> >&,
+                                                       edm::Event&,
+                                                       const edm::EventSetup&);
 
-    /// reconstruct global tracks starting from a collection of
-    /// standalone tracks and one of trakectories. If the latter
-    /// is invalid, trajectories are refitted.
-    void reconstruct(const std::vector<TrackCand>&, edm::Event&, const edm::EventSetup&);
-    
- private:
-    
-    /// percolate the Event Setup
-    void setEvent(const edm::Event&);
+  /// reconstruct global tracks starting from a collection of
+  /// standalone tracks and one of trakectories. If the latter
+  /// is invalid, trajectories are refitted.
+  void reconstruct(const std::vector<TrackCand>&, edm::Event&, const edm::EventSetup&);
 
-    /// convert the trajectories into tracks and load them in to the event
-    edm::OrphanHandle<reco::TrackCollection> load(const TrajectoryContainer&, edm::Event&, const TrackerTopology &ttopo);
+private:
+  /// percolate the Event Setup
+  void setEvent(const edm::Event&);
 
-    /// convert the trajectories into tracks and load them in to the event
-    void load(const CandidateContainer&, edm::Event&, const TrackerTopology &ttopo);
+  /// convert the trajectories into tracks and load them in to the event
+  edm::OrphanHandle<reco::TrackCollection> load(const TrajectoryContainer&, edm::Event&, const TrackerTopology& ttopo);
 
-  private:
+  /// convert the trajectories into tracks and load them in to the event
+  void load(const CandidateContainer&, edm::Event&, const TrackerTopology& ttopo);
 
-    MuonTrajectoryBuilder* theTrajBuilder;
+private:
+  MuonTrajectoryBuilder* theTrajBuilder;
 
-    MuonTrajectoryCleaner* theTrajCleaner;
+  MuonTrajectoryCleaner* theTrajCleaner;
 
-    MuonTrackLoader* theTrackLoader;
-  
+  MuonTrackLoader* theTrackLoader;
 };
-#endif 
+#endif

--- a/RecoMuon/TrackingTools/interface/MuonTrackLoader.h
+++ b/RecoMuon/TrackingTools/interface/MuonTrackLoader.h
@@ -25,8 +25,11 @@
 
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
 
-
-namespace edm {class Event; class EventSetup; class ParameterSet;}
+namespace edm {
+  class Event;
+  class EventSetup;
+  class ParameterSet;
+}  // namespace edm
 
 class Trajectory;
 class Propagator;
@@ -38,76 +41,75 @@ class BarrelDetLayer;
 class TrackerTopology;
 
 class MuonTrackLoader {
-  public:
+public:
+  typedef MuonCandidate::TrajectoryContainer TrajectoryContainer;
+  typedef MuonCandidate::CandidateContainer CandidateContainer;
 
-    typedef MuonCandidate::TrajectoryContainer TrajectoryContainer;
-    typedef MuonCandidate::CandidateContainer CandidateContainer;
+  /// Constructor for the STA reco the args must be specify!
+  MuonTrackLoader(edm::ParameterSet& parameterSet,
+                  edm::ConsumesCollector& iC,
+                  const MuonServiceProxy* service = nullptr);
 
-    /// Constructor for the STA reco the args must be specify!
-    MuonTrackLoader(edm::ParameterSet &parameterSet,edm::ConsumesCollector& iC,  const MuonServiceProxy *service =nullptr);
+  /// Destructor
+  virtual ~MuonTrackLoader();
 
-    /// Destructor
-    virtual ~MuonTrackLoader();
-   
-    /// Convert the trajectories into tracks and load the tracks in the event
-    edm::OrphanHandle<reco::TrackCollection> loadTracks(const TrajectoryContainer&, 
-                                                        edm::Event&,
-                                                        const TrackerTopology& ttopo,
-                                                        const std::string& = "", 
-							bool = true);
+  /// Convert the trajectories into tracks and load the tracks in the event
+  edm::OrphanHandle<reco::TrackCollection> loadTracks(
+      const TrajectoryContainer&, edm::Event&, const TrackerTopology& ttopo, const std::string& = "", bool = true);
 
-    /// Convert the trajectories into tracks and load the tracks in the event
-    edm::OrphanHandle<reco::TrackCollection> loadTracks(const TrajectoryContainer&, 
-                                                        edm::Event&, std::vector<bool>&,
-                                                        const TrackerTopology& ttopo,
-							const std::string& = "",
-							bool = true);
+  /// Convert the trajectories into tracks and load the tracks in the event
+  edm::OrphanHandle<reco::TrackCollection> loadTracks(const TrajectoryContainer&,
+                                                      edm::Event&,
+                                                      std::vector<bool>&,
+                                                      const TrackerTopology& ttopo,
+                                                      const std::string& = "",
+                                                      bool = true);
 
-    /// Convert the trajectories into tracks and load the tracks in the event
-    edm::OrphanHandle<reco::TrackCollection> loadTracks(const TrajectoryContainer&, 
-                                                        edm::Event&,const std::vector<std::pair<Trajectory*, reco::TrackRef> >&,
-                                                        edm::Handle<reco::TrackCollection> const& trackHandle,
-                                                        const TrackerTopology& ttopo,
-							const std::string& = "", 
-							bool = true);
+  /// Convert the trajectories into tracks and load the tracks in the event
+  edm::OrphanHandle<reco::TrackCollection> loadTracks(const TrajectoryContainer&,
+                                                      edm::Event&,
+                                                      const std::vector<std::pair<Trajectory*, reco::TrackRef> >&,
+                                                      edm::Handle<reco::TrackCollection> const& trackHandle,
+                                                      const TrackerTopology& ttopo,
+                                                      const std::string& = "",
+                                                      bool = true);
 
-    /// Convert the trajectories into tracks and load the tracks in the event
-    edm::OrphanHandle<reco::MuonTrackLinksCollection> loadTracks(const CandidateContainer&,
-                                                                 edm::Event&,
-                                                                 const TrackerTopology& ttopo);
-  
-  private:
-    static std::vector<const TrackingRecHit*> unpackHit(const TrackingRecHit &hit);
+  /// Convert the trajectories into tracks and load the tracks in the event
+  edm::OrphanHandle<reco::MuonTrackLinksCollection> loadTracks(const CandidateContainer&,
+                                                               edm::Event&,
+                                                               const TrackerTopology& ttopo);
 
-    /// Build a track at the PCA WITHOUT any vertex constriant
-    std::pair<bool,reco::Track> buildTrackAtPCA(const Trajectory& trajectory, const reco::BeamSpot &) const;
+private:
+  static std::vector<const TrackingRecHit*> unpackHit(const TrackingRecHit& hit);
 
-    /// Takes a track at the PCA and applies the vertex constriant
-    std::pair<bool,reco::Track> buildTrackUpdatedAtPCA(const reco::Track& trackAtPCA, const reco::BeamSpot &) const;
+  /// Build a track at the PCA WITHOUT any vertex constriant
+  std::pair<bool, reco::Track> buildTrackAtPCA(const Trajectory& trajectory, const reco::BeamSpot&) const;
 
-    reco::TrackExtra buildTrackExtra(const Trajectory&) const;
+  /// Takes a track at the PCA and applies the vertex constriant
+  std::pair<bool, reco::Track> buildTrackUpdatedAtPCA(const reco::Track& trackAtPCA, const reco::BeamSpot&) const;
 
-    const MuonServiceProxy *theService;
+  reco::TrackExtra buildTrackExtra(const Trajectory&) const;
 
-    bool theUpdatingAtVtx;
-    MuonUpdatorAtVertex *theUpdatorAtVtx;
+  const MuonServiceProxy* theService;
 
-    bool theTrajectoryFlag;
+  bool theUpdatingAtVtx;
+  MuonUpdatorAtVertex* theUpdatorAtVtx;
 
-    bool theSmoothingStep;
-    std::string theSmootherName;
-    std::string theTrackerRecHitBuilderName;
-    std::unique_ptr<TrajectorySmoother> theSmoother;
-    TkClonerImpl hitCloner;
+  bool theTrajectoryFlag;
 
+  bool theSmoothingStep;
+  std::string theSmootherName;
+  std::string theTrackerRecHitBuilderName;
+  std::unique_ptr<TrajectorySmoother> theSmoother;
+  TkClonerImpl hitCloner;
 
-    edm::InputTag theBeamSpotInputTag; 
-    edm::EDGetTokenT<reco::BeamSpot> theBeamSpotToken;
+  edm::InputTag theBeamSpotInputTag;
+  edm::EDGetTokenT<reco::BeamSpot> theBeamSpotToken;
 
-    /// Label for L2SeededTracks
-    std::string theL2SeededTkLabel; 
-    bool thePutTkTrackFlag;
-    bool theSmoothTkTrackFlag;
-    bool theAllowNoVtxFlag;
+  /// Label for L2SeededTracks
+  std::string theL2SeededTkLabel;
+  bool thePutTkTrackFlag;
+  bool theSmoothTkTrackFlag;
+  bool theAllowNoVtxFlag;
 };
 #endif

--- a/RecoMuon/TrackingTools/interface/MuonTrajectoryBuilder.h
+++ b/RecoMuon/TrackingTools/interface/MuonTrajectoryBuilder.h
@@ -12,33 +12,33 @@
 #include "RecoMuon/TrackingTools/interface/MuonCandidate.h"
 #include <vector>
 
-namespace edm {class Event;}
+namespace edm {
+  class Event;
+}
 
 class TrajectorySeed;
 
 class MuonTrajectoryBuilder {
+public:
+  typedef MuonCandidate::TrajectoryContainer TrajectoryContainer;
+  typedef MuonCandidate::CandidateContainer CandidateContainer;
+  typedef std::pair<const Trajectory*, reco::TrackRef> TrackCand;
 
-  public:
-  
-    typedef MuonCandidate::TrajectoryContainer TrajectoryContainer;
-    typedef MuonCandidate::CandidateContainer CandidateContainer;
-    typedef std::pair<const Trajectory*, reco::TrackRef> TrackCand;
+  /// constructor
+  MuonTrajectoryBuilder() {}
 
-    /// constructor
-    MuonTrajectoryBuilder() {}
-  
-    /// destructor
-    virtual ~MuonTrajectoryBuilder() {}
+  /// destructor
+  virtual ~MuonTrajectoryBuilder() {}
 
-    /// return a container of the reconstructed trajectories compatible with a given seed
-    virtual TrajectoryContainer trajectories(const TrajectorySeed&) = 0;
+  /// return a container of the reconstructed trajectories compatible with a given seed
+  virtual TrajectoryContainer trajectories(const TrajectorySeed&) = 0;
 
-    /// return a container reconstructed muons starting from a given track
-    virtual CandidateContainer trajectories(const TrackCand&) = 0;
+  /// return a container reconstructed muons starting from a given track
+  virtual CandidateContainer trajectories(const TrackCand&) = 0;
 
-    /// pass the Event to the algo at each event
-    virtual void setEvent(const edm::Event& event) = 0;
-  
- private:
+  /// pass the Event to the algo at each event
+  virtual void setEvent(const edm::Event& event) = 0;
+
+private:
 };
 #endif

--- a/RecoMuon/TrackingTools/interface/MuonTrajectoryCleaner.h
+++ b/RecoMuon/TrackingTools/interface/MuonTrajectoryCleaner.h
@@ -14,10 +14,9 @@
 
 //class Event;
 class MuonTrajectoryCleaner {
- public:
+public:
   typedef MuonCandidate::TrajectoryContainer TrajectoryContainer;
   typedef MuonCandidate::CandidateContainer CandidateContainer;
-  
 
   /// Constructor
   MuonTrajectoryCleaner() : reportGhosts_(false) {}
@@ -26,21 +25,20 @@ class MuonTrajectoryCleaner {
   MuonTrajectoryCleaner(bool reportGhosts) : reportGhosts_(reportGhosts) {}
 
   /// Destructor
-  virtual ~MuonTrajectoryCleaner() {};
+  virtual ~MuonTrajectoryCleaner(){};
 
   // Operations
 
   /// Clean the trajectories container, erasing the (worst) clone trajectory
-  void clean(TrajectoryContainer &muonTrajectories, edm::Event& evt, const edm::Handle<edm::View<TrajectorySeed> >& seeds); //used by reference...
+  void clean(TrajectoryContainer& muonTrajectories,
+             edm::Event& evt,
+             const edm::Handle<edm::View<TrajectorySeed> >& seeds);  //used by reference...
 
   /// Clean the candidates container, erasing the (worst) clone trajectory
-  void clean(CandidateContainer &muonTrajectories); //used by reference...
+  void clean(CandidateContainer& muonTrajectories);  //used by reference...
 
 protected:
-
 private:
   bool reportGhosts_;
-
 };
 #endif
-

--- a/RecoMuon/TrackingTools/interface/MuonTrajectoryUpdator.h
+++ b/RecoMuon/TrackingTools/interface/MuonTrajectoryUpdator.h
@@ -27,124 +27,120 @@ class TrajectoryStateOnSurface;
 class TrajectoryStateUpdator;
 class DetLayer;
 
-namespace edm{class ParameterSet;}
+namespace edm {
+  class ParameterSet;
+}
 
 class MuonTrajectoryUpdator {
-  
- public:
-
+public:
   /// Constructor from Propagator and Parameter set
-  MuonTrajectoryUpdator(const edm::ParameterSet& par,
-			NavigationDirection fitDirection);
+  MuonTrajectoryUpdator(const edm::ParameterSet &par, NavigationDirection fitDirection);
 
   /// Constructor from Propagator, chi2 and the granularity flag
-  MuonTrajectoryUpdator(NavigationDirection fitDirection,
-			double chi2, int granularity);
-  
+  MuonTrajectoryUpdator(NavigationDirection fitDirection, double chi2, int granularity);
+
   /// Destructor
   virtual ~MuonTrajectoryUpdator();
-  
+
   // Operations
 
   /// update the Trajectory with the TrajectoryMeasurement
-  virtual std::pair<bool,TrajectoryStateOnSurface>  update(const TrajectoryMeasurement* measurement, 
-							   Trajectory& trajectory,
-							   const Propagator *propagator);
+  virtual std::pair<bool, TrajectoryStateOnSurface> update(const TrajectoryMeasurement *measurement,
+                                                           Trajectory &trajectory,
+                                                           const Propagator *propagator);
 
   /// accasso at the propagator
-  const MeasurementEstimator *estimator() const {return theEstimator;}
-  const TrajectoryStateUpdator *measurementUpdator() const {return theUpdator;}
+  const MeasurementEstimator *estimator() const { return theEstimator; }
+  const TrajectoryStateUpdator *measurementUpdator() const { return theUpdator; }
 
   /// get the max chi2 allowed
-  double maxChi2() const {return theMaxChi2 ;}
-  
+  double maxChi2() const { return theMaxChi2; }
+
   /// get the fit direction
-  NavigationDirection fitDirection() {return theFitDirection;}
+  NavigationDirection fitDirection() { return theFitDirection; }
 
   /// set max chi2
-  void setMaxChi2(double chi2) {theMaxChi2 = chi2;}
+  void setMaxChi2(double chi2) { theMaxChi2 = chi2; }
 
   /// set fit direction
-  void setFitDirection(NavigationDirection fitDirection) {theFitDirection = fitDirection;}
+  void setFitDirection(NavigationDirection fitDirection) { theFitDirection = fitDirection; }
 
   /// reset the theFirstTSOSFlag
   void makeFirstTime();
-  
- protected:
-  
- private:
 
+protected:
+private:
   /// Propagate the state to the hit surface if it's a multi hit RecHit.
   /// i.e.: if "current" is a sub-rechit of the mesurement (i.e. a 1/2D RecHit)
-  /// the state will be propagated to the surface where lies the "current" rechit 
-  TrajectoryStateOnSurface propagateState(const TrajectoryStateOnSurface& state,
-					  const TrajectoryMeasurement* measurement, 
-					  const TransientTrackingRecHit::ConstRecHitPointer& current,
-					  const Propagator *propagator) const;
-  
+  /// the state will be propagated to the surface where lies the "current" rechit
+  TrajectoryStateOnSurface propagateState(const TrajectoryStateOnSurface &state,
+                                          const TrajectoryMeasurement *measurement,
+                                          const TransientTrackingRecHit::ConstRecHitPointer &current,
+                                          const Propagator *propagator) const;
+
   ///  the max chi2 allowed
   double theMaxChi2;
-  
+
   /// the granularity
   /// if 0 4D-segments are used both for the DT and CSC,
   /// if 1 2D-segments are used for the DT and the 2D-points for the CSC
   /// if 2 the 1D rec hit for the DT are used, while the 2D rechit for the CSC are used
   /// Maybe in a second step there will be more than 3 option
   /// i.e. max granularity for DT but not for the CSC and the viceversa
-  int theGranularity; 
+  int theGranularity;
   // FIXME: ask Tim if the CSC segments can be used, since in ORCA they wasn't.
 
   /// Ordering along increasing radius (for DT rechits)
-  struct RadiusComparatorInOut{
+  struct RadiusComparatorInOut {
     bool operator()(const TransientTrackingRecHit::ConstRecHitPointer &a,
-		    const TransientTrackingRecHit::ConstRecHitPointer &b) const{ 
-      return a->det()->surface().position().perp() < b->det()->surface().position().perp(); 
-    }
-  };
-  
-  /// Ordering along decreasing radius (for DT rechits)
-  struct RadiusComparatorOutIn{
-    bool operator()(const TransientTrackingRecHit::ConstRecHitPointer &a, 
-		    const TransientTrackingRecHit::ConstRecHitPointer &b) const{ 
-      return a->det()->surface().position().perp() > b->det()->surface().position().perp();
-    }
-  };
-  
-  /// Ordering along increasing zed (for CSC rechits)
-  struct ZedComparatorInOut{  
-    bool operator()( const TransientTrackingRecHit::ConstRecHitPointer &a, 
-		     const TransientTrackingRecHit::ConstRecHitPointer &b) const{ 
-      return fabs(a->globalPosition().z()) < fabs(b->globalPosition().z()); 
-    }
-  };
-  
-  /// Ordering along decreasing zed (for CSC rechits)
-  struct ZedComparatorOutIn{
-    bool operator()( const TransientTrackingRecHit::ConstRecHitPointer &a, 
-		     const TransientTrackingRecHit::ConstRecHitPointer &b) const{ 
-      return fabs(a->globalPosition().z()) > fabs(b->globalPosition().z()); 
+                    const TransientTrackingRecHit::ConstRecHitPointer &b) const {
+      return a->det()->surface().position().perp() < b->det()->surface().position().perp();
     }
   };
 
-  void sort(TransientTrackingRecHit::ConstRecHitContainer&, const DetLayer*);
-  
+  /// Ordering along decreasing radius (for DT rechits)
+  struct RadiusComparatorOutIn {
+    bool operator()(const TransientTrackingRecHit::ConstRecHitPointer &a,
+                    const TransientTrackingRecHit::ConstRecHitPointer &b) const {
+      return a->det()->surface().position().perp() > b->det()->surface().position().perp();
+    }
+  };
+
+  /// Ordering along increasing zed (for CSC rechits)
+  struct ZedComparatorInOut {
+    bool operator()(const TransientTrackingRecHit::ConstRecHitPointer &a,
+                    const TransientTrackingRecHit::ConstRecHitPointer &b) const {
+      return fabs(a->globalPosition().z()) < fabs(b->globalPosition().z());
+    }
+  };
+
+  /// Ordering along decreasing zed (for CSC rechits)
+  struct ZedComparatorOutIn {
+    bool operator()(const TransientTrackingRecHit::ConstRecHitPointer &a,
+                    const TransientTrackingRecHit::ConstRecHitPointer &b) const {
+      return fabs(a->globalPosition().z()) > fabs(b->globalPosition().z());
+    }
+  };
+
+  void sort(TransientTrackingRecHit::ConstRecHitContainer &, const DetLayer *);
+
   /// Return the trajectory measurement. It handles both the fw and the bw propagation
-  TrajectoryMeasurement updateMeasurement( const TrajectoryStateOnSurface &propagatedTSOS, 
-					   const TrajectoryStateOnSurface &lastUpdatedTSOS, 
-					   const TransientTrackingRecHit::ConstRecHitPointer &recHit,
-					   const double &chi2, const DetLayer *detLayer, 
-					   const TrajectoryMeasurement *initialMeasurement);
-  
+  TrajectoryMeasurement updateMeasurement(const TrajectoryStateOnSurface &propagatedTSOS,
+                                          const TrajectoryStateOnSurface &lastUpdatedTSOS,
+                                          const TransientTrackingRecHit::ConstRecHitPointer &recHit,
+                                          const double &chi2,
+                                          const DetLayer *detLayer,
+                                          const TrajectoryMeasurement *initialMeasurement);
 
   // FIXME: change in a ESHandle
   MeasurementEstimator *theEstimator;
   TrajectoryStateUpdator *theUpdator;
 
-  // The fit direction.This is the global fit direction and it could be (LOCALLY!) different w.r.t. the 
+  // The fit direction.This is the global fit direction and it could be (LOCALLY!) different w.r.t. the
   // propagation direction embeeded in the propagator (i.e. when it is used in the "anyDirection" mode)
   // This data member is not set via parameter set since it must be consistent with the RefitterParameter.
   NavigationDirection theFitDirection;
-  
+
   // Parameters for the error rescaling
   bool theFirstTSOSFlag;
   bool theRescaleErrorFlag;
@@ -154,7 +150,5 @@ class MuonTrajectoryUpdator {
   bool useInvalidHits;
   // exclude RPC from the fit (but allows to keep it in the muon signal confirmation)
   bool theRPCExFlag;
-
 };
 #endif
-

--- a/RecoMuon/TrackingTools/interface/MuonUpdatorAtVertex.h
+++ b/RecoMuon/TrackingTools/interface/MuonUpdatorAtVertex.h
@@ -34,52 +34,48 @@ class MuonServiceProxy;
 
 #include <string>
 
-namespace edm {class ParameterSet; class Event;}
+namespace edm {
+  class ParameterSet;
+  class Event;
+}  // namespace edm
 
 class MuonUpdatorAtVertex {
 public:
   /// Constructor
-  MuonUpdatorAtVertex(const edm::ParameterSet& pset, const MuonServiceProxy *service);
+  MuonUpdatorAtVertex(const edm::ParameterSet &pset, const MuonServiceProxy *service);
 
   /// Destructor
   virtual ~MuonUpdatorAtVertex();
 
   // Operations
-  
+
   /// Propagate the state to the 2D-PCA
-  std::pair<bool,FreeTrajectoryState>
-    propagate(const TrajectoryStateOnSurface &tsos, const reco::BeamSpot & beamSpot) const;
+  std::pair<bool, FreeTrajectoryState> propagate(const TrajectoryStateOnSurface &tsos,
+                                                 const reco::BeamSpot &beamSpot) const;
 
   /// Applies the vertex constraint
-  std::pair<bool,FreeTrajectoryState> 
-    update(const reco::TransientTrack &track, const reco::BeamSpot & beamSpot) const;
-  
+  std::pair<bool, FreeTrajectoryState> update(const reco::TransientTrack &track, const reco::BeamSpot &beamSpot) const;
+
   /// Applies the vertex constraint
-  std::pair<bool,FreeTrajectoryState>
-    update(const FreeTrajectoryState& ftsAtVtx, const reco::BeamSpot & beamSpot) const;
+  std::pair<bool, FreeTrajectoryState> update(const FreeTrajectoryState &ftsAtVtx,
+                                              const reco::BeamSpot &beamSpot) const;
 
   /// Propagate to the 2D-PCA and apply the vertex constraint
-  std::pair<bool,FreeTrajectoryState>
-    propagateWithUpdate(const TrajectoryStateOnSurface &tsos,
-			const reco::BeamSpot & beamSpot) const;
+  std::pair<bool, FreeTrajectoryState> propagateWithUpdate(const TrajectoryStateOnSurface &tsos,
+                                                           const reco::BeamSpot &beamSpot) const;
 
   /// Propagate the state to the 2D-PCA (nominal CMS axis)
-  std::pair<bool,FreeTrajectoryState>
-    propagateToNominalLine(const TrajectoryStateOnSurface &tsos) const;
+  std::pair<bool, FreeTrajectoryState> propagateToNominalLine(const TrajectoryStateOnSurface &tsos) const;
 
   /// Propagate the state to the 2D-PCA (nominal CMS axis) - DEPRECATED -
-  std::pair<bool,FreeTrajectoryState>
-    propagate(const TrajectoryStateOnSurface &tsos) const __attribute__((deprecated));
-
-  
+  std::pair<bool, FreeTrajectoryState> propagate(const TrajectoryStateOnSurface &tsos) const
+      __attribute__((deprecated));
 
 protected:
-
 private:
-
   const MuonServiceProxy *theService;
   std::string thePropagatorName;
- 
+
   TransientTrackFromFTSFactory theTransientTrackFactory;
   SingleTrackVertexConstraint theConstrictor;
   double theChi2Cut;
@@ -87,4 +83,3 @@ private:
   GlobalError thePositionErrors;
 };
 #endif
-

--- a/RecoMuon/TrackingTools/interface/RecoMuonEnumerators.h
+++ b/RecoMuon/TrackingTools/interface/RecoMuonEnumerators.h
@@ -1,9 +1,9 @@
 #ifndef RecoMuon_TrackingTools_RecoMuonEnumerators_H
 #define RecoMuon_TrackingTools_RecoMuonEnumerators_H
 
-namespace recoMuon{
+namespace recoMuon {
   //  enum FitDirection{insideOut,outsideIn};
-  enum SeedPosition{in,out};
-}  
+  enum SeedPosition { in, out };
+}  // namespace recoMuon
 
-#endif 
+#endif

--- a/RecoMuon/TrackingTools/interface/SegmentsTrackAssociator.h
+++ b/RecoMuon/TrackingTools/interface/SegmentsTrackAssociator.h
@@ -1,7 +1,6 @@
 #ifndef SegmentsTrackAssociator_H
 #define SegmentsTrackAssociator_H
 
-
 /** \class SegmentsTrackAssociator
  *
  *  tool which take as input a muon track and return a vector 
@@ -9,7 +8,6 @@
  *
  *  \author C. Botta, G. Mila - INFN Torino
  */
-
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -20,7 +18,7 @@
 
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
-#include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h" 
+#include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
 #include "TrackingTools/DetLayers/interface/DetLayer.h"
 #include "TrackingTools/PatternTools/interface/TrajMeasLessEstim.h"
 #include "RecoMuon/TrackingTools/interface/MuonPatternRecoDumper.h"
@@ -32,33 +30,31 @@
 #include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
+namespace edm {
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
-
-namespace edm {class ParameterSet; class Event; class EventSetup;}
-
-
-class SegmentsTrackAssociator{
-  
+class SegmentsTrackAssociator {
 public:
-  
   /// Constructor
-  SegmentsTrackAssociator (const edm::ParameterSet& ,edm::ConsumesCollector& iC);
-  
-  /// Destructor 
+  SegmentsTrackAssociator(const edm::ParameterSet&, edm::ConsumesCollector& iC);
+
+  /// Destructor
   virtual ~SegmentsTrackAssociator();
 
   /// Get the analysis
-  MuonTransientTrackingRecHit::MuonRecHitContainer associate(const edm::Event&, const edm::EventSetup&, const reco::Track& );
-  
-  
+  MuonTransientTrackingRecHit::MuonRecHitContainer associate(const edm::Event&,
+                                                             const edm::EventSetup&,
+                                                             const reco::Track&);
 
 private:
-
   // the counters
   int numRecHit;
   int numRecHitDT;
   int numRecHitCSC;
-  
+
   // collection label
   edm::InputTag theDTSegmentLabel;
   edm::InputTag theCSCSegmentLabel;
@@ -67,11 +63,7 @@ private:
   edm::EDGetTokenT<DTRecSegment4DCollection> dtSegmentsToken;
   edm::EDGetTokenT<CSCSegmentCollection> cscSegmentsToken;
 
-
   std::string metname;
- 
-
-  
 };
 
 #endif

--- a/RecoMuon/TrackingTools/plugins/MuonErrorMatrixAdjuster.cc
+++ b/RecoMuon/TrackingTools/plugins/MuonErrorMatrixAdjuster.cc
@@ -16,166 +16,170 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
-MuonErrorMatrixAdjuster::MuonErrorMatrixAdjuster(const edm::ParameterSet& iConfig)
-{
-  theCategory="MuonErrorMatrixAdjuster";
+MuonErrorMatrixAdjuster::MuonErrorMatrixAdjuster(const edm::ParameterSet& iConfig) {
+  theCategory = "MuonErrorMatrixAdjuster";
   theInstanceName = iConfig.getParameter<std::string>("instanceName");
   //register your products
-  produces<reco::TrackCollection>( theInstanceName);
-  produces<TrackingRecHitCollection>(); 
+  produces<reco::TrackCollection>(theInstanceName);
+  produces<TrackingRecHitCollection>();
   produces<reco::TrackExtraCollection>();
-          
+
   theTrackLabel = iConfig.getParameter<edm::InputTag>("trackLabel");
   theRescale = iConfig.getParameter<bool>("rescale");
 
   theMatrixProvider_pset = iConfig.getParameter<edm::ParameterSet>("errorMatrix_pset");
 }
 
-
-MuonErrorMatrixAdjuster::~MuonErrorMatrixAdjuster()
-{
- 
+MuonErrorMatrixAdjuster::~MuonErrorMatrixAdjuster() {
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
-
 }
-
 
 //
 // member functions
 //
 
 //take the error matrix and rescale it or just replace it
-reco::TrackBase::CovarianceMatrix MuonErrorMatrixAdjuster::fix_cov_matrix(const reco::TrackBase::CovarianceMatrix& error_matrix,const GlobalVector& momentum)
-{   
+reco::TrackBase::CovarianceMatrix MuonErrorMatrixAdjuster::fix_cov_matrix(
+    const reco::TrackBase::CovarianceMatrix& error_matrix, const GlobalVector& momentum) {
   //CovarianceMatrix is template for SMatrix
-  reco::TrackBase::CovarianceMatrix revised_matrix( theMatrixProvider->get(momentum));
-   
-  if( theRescale){
+  reco::TrackBase::CovarianceMatrix revised_matrix(theMatrixProvider->get(momentum));
+
+  if (theRescale) {
     //rescale old error matrix up by a factor
-    multiply(revised_matrix,error_matrix); 
+    multiply(revised_matrix, error_matrix);
   }
   return revised_matrix;
 }
 
-void MuonErrorMatrixAdjuster::multiply(reco::TrackBase::CovarianceMatrix & revised_matrix, const reco::TrackBase::CovarianceMatrix & scale_matrix){
+void MuonErrorMatrixAdjuster::multiply(reco::TrackBase::CovarianceMatrix& revised_matrix,
+                                       const reco::TrackBase::CovarianceMatrix& scale_matrix) {
   //scale term by term the matrix
   // the true type of the matrix is such that [i][j] is the same memory object as [j][i]: looping i:0-5, j:0-5 double multiply the terms
   // need to loop only on i:0-5, j:i-5
-  for(int i = 0;i!=5;i++){for(int j = i;j!=5;j++){
-      revised_matrix(i,j)*=scale_matrix(i,j);
-    }}
+  for (int i = 0; i != 5; i++) {
+    for (int j = i; j != 5; j++) {
+      revised_matrix(i, j) *= scale_matrix(i, j);
+    }
+  }
 }
-bool MuonErrorMatrixAdjuster::divide(reco::TrackBase::CovarianceMatrix & num_matrix, const reco::TrackBase::CovarianceMatrix & denom_matrix){
+bool MuonErrorMatrixAdjuster::divide(reco::TrackBase::CovarianceMatrix& num_matrix,
+                                     const reco::TrackBase::CovarianceMatrix& denom_matrix) {
   //divide term by term the matrix
   // the true type of the matrix is such that [i][j] is the same memory object as [j][i]: looping i:0-5, j:0-5 double multiply the terms
   // need to loop only on i:0-5, j:i-5
-  for(int i = 0;i!=5;i++){for(int j = i;j!=5;j++){
-      if (denom_matrix(i,j)==0) return false;
-      num_matrix(i,j)/=denom_matrix(i,j);
-   }}
+  for (int i = 0; i != 5; i++) {
+    for (int j = i; j != 5; j++) {
+      if (denom_matrix(i, j) == 0)
+        return false;
+      num_matrix(i, j) /= denom_matrix(i, j);
+    }
+  }
   return true;
 }
 
-reco::Track MuonErrorMatrixAdjuster::makeTrack(const reco::Track & recotrack_orig,
-					  const FreeTrajectoryState & PCAstate){
+reco::Track MuonErrorMatrixAdjuster::makeTrack(const reco::Track& recotrack_orig, const FreeTrajectoryState& PCAstate) {
   //get the parameters of the track so I can reconstruct it
   double chi2 = recotrack_orig.chi2();
   double ndof = recotrack_orig.ndof();
   const math::XYZPoint& refpos = recotrack_orig.referencePoint();
   const math::XYZVector& mom = recotrack_orig.momentum();
   int charge = recotrack_orig.charge();
-  
-  reco::TrackBase::CovarianceMatrix covariance_matrix = fix_cov_matrix(recotrack_orig.covariance(),PCAstate.momentum());
 
-  LogDebug(theCategory)<<"chi2: "<<chi2
-		       <<"\n ndof: "<<ndof
-		       <<"\n refpos: "<<refpos
-		       <<"\n mom: "<<mom
-		       <<"\n charge: "<<charge
-		       <<"\n covariance:\n"<<recotrack_orig.covariance()
-		       <<"\n replaced by:\n"<<covariance_matrix;
+  reco::TrackBase::CovarianceMatrix covariance_matrix =
+      fix_cov_matrix(recotrack_orig.covariance(), PCAstate.momentum());
 
-  return reco::Track(chi2,ndof,refpos,mom,charge,covariance_matrix);
+  LogDebug(theCategory) << "chi2: " << chi2 << "\n ndof: " << ndof << "\n refpos: " << refpos << "\n mom: " << mom
+                        << "\n charge: " << charge << "\n covariance:\n"
+                        << recotrack_orig.covariance() << "\n replaced by:\n"
+                        << covariance_matrix;
+
+  return reco::Track(chi2, ndof, refpos, mom, charge, covariance_matrix);
 }
 
-reco::TrackExtra * MuonErrorMatrixAdjuster::makeTrackExtra(const reco::Track & recotrack_orig,
-						      reco::Track & recotrack,
-						      reco::TrackExtraCollection& TEcol){ 
+reco::TrackExtra* MuonErrorMatrixAdjuster::makeTrackExtra(const reco::Track& recotrack_orig,
+                                                          reco::Track& recotrack,
+                                                          reco::TrackExtraCollection& TEcol) {
   //get the 5x5 matrix of recotrack/recotrack_orig
   reco::TrackBase::CovarianceMatrix scale_matrix(recotrack.covariance());
-  if (!divide(scale_matrix,recotrack_orig.covariance())){
-    edm::LogError( theCategory)<<"original track error matrix has term ==0... skipping.";
-    return nullptr; }
-  
-  const reco::TrackExtraRef & trackExtra_orig = recotrack_orig.extra();
+  if (!divide(scale_matrix, recotrack_orig.covariance())) {
+    edm::LogError(theCategory) << "original track error matrix has term ==0... skipping.";
+    return nullptr;
+  }
+
+  const reco::TrackExtraRef& trackExtra_orig = recotrack_orig.extra();
   if (trackExtra_orig.isNull()) {
-    edm::LogError( theCategory)<<"original track has no track extra... skipping.";
-    return nullptr;}
+    edm::LogError(theCategory) << "original track has no track extra... skipping.";
+    return nullptr;
+  }
 
   //copy the outer state. rescaling the error matrix
   reco::TrackBase::CovarianceMatrix outerCov(trackExtra_orig->outerStateCovariance());
-  multiply(outerCov,scale_matrix);
+  multiply(outerCov, scale_matrix);
 
   //copy the inner state, rescaling the error matrix
   reco::TrackBase::CovarianceMatrix innerCov(trackExtra_orig->innerStateCovariance());
-  multiply(innerCov,scale_matrix);
+  multiply(innerCov, scale_matrix);
 
   //put the trackExtra
-  TEcol.push_back(reco::TrackExtra (trackExtra_orig->outerPosition(), trackExtra_orig->outerMomentum(), true,
-				    trackExtra_orig->innerPosition(), trackExtra_orig->innerMomentum(), true,
-				    outerCov, trackExtra_orig->outerDetId(),
-				    innerCov, trackExtra_orig->innerDetId(),
-				    trackExtra_orig->seedDirection()));
+  TEcol.push_back(reco::TrackExtra(trackExtra_orig->outerPosition(),
+                                   trackExtra_orig->outerMomentum(),
+                                   true,
+                                   trackExtra_orig->innerPosition(),
+                                   trackExtra_orig->innerMomentum(),
+                                   true,
+                                   outerCov,
+                                   trackExtra_orig->outerDetId(),
+                                   innerCov,
+                                   trackExtra_orig->innerDetId(),
+                                   trackExtra_orig->seedDirection()));
 
   //add a reference to the trackextra on the track
-  recotrack.setExtra(edm::Ref<reco::TrackExtraCollection>( theRefprodTE, theTEi++));
-  
+  recotrack.setExtra(edm::Ref<reco::TrackExtraCollection>(theRefprodTE, theTEi++));
+
   //return the reference to the last inserted then
   return &(TEcol.back());
 }
 
-
-bool MuonErrorMatrixAdjuster::attachRecHits(const reco::Track & recotrack_orig,
-				       reco::Track & recotrack,
-				       reco::TrackExtra & trackextra,
-                                       TrackingRecHitCollection& RHcol,
-                                       const TrackerTopology& ttopo){
+bool MuonErrorMatrixAdjuster::attachRecHits(const reco::Track& recotrack_orig,
+                                            reco::Track& recotrack,
+                                            reco::TrackExtra& trackextra,
+                                            TrackingRecHitCollection& RHcol,
+                                            const TrackerTopology& ttopo) {
   //loop over the hits of the original track
   trackingRecHit_iterator recHit = recotrack_orig.recHitsBegin();
   auto const firstHitIndex = theRHi;
-  for (; recHit!=recotrack_orig.recHitsEnd();++recHit){
+  for (; recHit != recotrack_orig.recHitsEnd(); ++recHit) {
     //clone it. this is meandatory
-    TrackingRecHit * hit = (*recHit)->clone();
-    
+    TrackingRecHit* hit = (*recHit)->clone();
+
     //put it on the new track
     recotrack.appendHitPattern(*hit, ttopo);
     //copy them in the new collection
     RHcol.push_back(hit);
     ++theRHi;
 
-  }//loop over original rechits
-  //do something with the trackextra 
-  trackextra.setHits(theRefprodRH, firstHitIndex, theRHi-firstHitIndex);
-  
-  return true; //if nothing fails
+  }  //loop over original rechits
+  //do something with the trackextra
+  trackextra.setHits(theRefprodRH, firstHitIndex, theRHi - firstHitIndex);
+
+  return true;  //if nothing fails
 }
 
-bool MuonErrorMatrixAdjuster::selectTrack(const reco::Track & recotrack_orig){return true;}
+bool MuonErrorMatrixAdjuster::selectTrack(const reco::Track& recotrack_orig) { return true; }
 
 // ------------ method called to produce the data  ------------
-void
-MuonErrorMatrixAdjuster::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void MuonErrorMatrixAdjuster::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
   //open a collection of track
   edm::Handle<reco::TrackCollection> tracks;
-  iEvent.getByLabel( theTrackLabel,tracks);
-  LogDebug( theCategory)<<"considering: "<<tracks->size()<<" uncorrected reco::Track from the event.("<< theTrackLabel<<")";
-  
+  iEvent.getByLabel(theTrackLabel, tracks);
+  LogDebug(theCategory) << "considering: " << tracks->size() << " uncorrected reco::Track from the event.("
+                        << theTrackLabel << ")";
+
   //get the mag field
-  iSetup.get<IdealMagneticFieldRecord>().get( theField);
+  iSetup.get<IdealMagneticFieldRecord>().get(theField);
 
   edm::ESHandle<TrackerTopology> httopo;
   iSetup.get<TrackerTopologyRcd>().get(httopo);
@@ -186,65 +190,62 @@ MuonErrorMatrixAdjuster::produce(edm::Event& iEvent, const edm::EventSetup& iSet
   auto TRHoutput = std::make_unique<TrackingRecHitCollection>();
   auto TEoutput = std::make_unique<reco::TrackExtraCollection>();
   theRefprodTE = iEvent.getRefBeforePut<reco::TrackExtraCollection>();
-  theTEi=0;
-  theRefprodRH =iEvent.getRefBeforePut<TrackingRecHitCollection>();
-  theRHi=0;
-  
-  
-  
-  for(unsigned int it=0;it!=tracks->size();it++)
-    {
-      const reco::Track & recotrack_orig = (*tracks)[it];
-      FreeTrajectoryState PCAstate = trajectoryStateTransform::initialFreeState(recotrack_orig, theField.product());
-      if (PCAstate.position().mag()==0)
-	{edm::LogError( theCategory)<<"invalid state from track initial state in "<< theTrackLabel <<". skipping.";continue;}
+  theTEi = 0;
+  theRefprodRH = iEvent.getRefBeforePut<TrackingRecHitCollection>();
+  theRHi = 0;
 
-      //create a reco::Track
-      reco::Track recotrack = makeTrack(recotrack_orig,PCAstate);
-      
-      //make a selection on the create reco::Track
-      if (!selectTrack(recotrack)) continue;
-      
-      Toutput->push_back(recotrack);
-      reco::Track & recotrackref = Toutput->back();
-      
-      //build the track extra
-      reco::TrackExtra * extra = makeTrackExtra(recotrack_orig,recotrackref,*TEoutput);
-      if (!extra){
-	edm::LogError( theCategory)<<"cannot create the track extra for this track.";
-	//pop the inserted track
-	Toutput->pop_back();
-	continue;}
-      
-      //attach the collection of rechits
-      if (!attachRecHits(recotrack_orig,recotrackref,*extra,*TRHoutput, ttopo)){
-	edm::LogError( theCategory)<<"cannot attach any rechits on this track";
-	//pop the inserted track
-	Toutput->pop_back();
-	//pop the track extra
-	TEoutput->pop_back();
-	theTEi--;
-	continue;}
-      
-    }//loop over the original reco tracks
-  
-  LogDebug( theCategory)<<"writing: "<<Toutput->size()<<" corrected reco::Track to the event.";
-  
+  for (unsigned int it = 0; it != tracks->size(); it++) {
+    const reco::Track& recotrack_orig = (*tracks)[it];
+    FreeTrajectoryState PCAstate = trajectoryStateTransform::initialFreeState(recotrack_orig, theField.product());
+    if (PCAstate.position().mag() == 0) {
+      edm::LogError(theCategory) << "invalid state from track initial state in " << theTrackLabel << ". skipping.";
+      continue;
+    }
+
+    //create a reco::Track
+    reco::Track recotrack = makeTrack(recotrack_orig, PCAstate);
+
+    //make a selection on the create reco::Track
+    if (!selectTrack(recotrack))
+      continue;
+
+    Toutput->push_back(recotrack);
+    reco::Track& recotrackref = Toutput->back();
+
+    //build the track extra
+    reco::TrackExtra* extra = makeTrackExtra(recotrack_orig, recotrackref, *TEoutput);
+    if (!extra) {
+      edm::LogError(theCategory) << "cannot create the track extra for this track.";
+      //pop the inserted track
+      Toutput->pop_back();
+      continue;
+    }
+
+    //attach the collection of rechits
+    if (!attachRecHits(recotrack_orig, recotrackref, *extra, *TRHoutput, ttopo)) {
+      edm::LogError(theCategory) << "cannot attach any rechits on this track";
+      //pop the inserted track
+      Toutput->pop_back();
+      //pop the track extra
+      TEoutput->pop_back();
+      theTEi--;
+      continue;
+    }
+
+  }  //loop over the original reco tracks
+
+  LogDebug(theCategory) << "writing: " << Toutput->size() << " corrected reco::Track to the event.";
+
   iEvent.put(std::move(Toutput), theInstanceName);
   iEvent.put(std::move(TEoutput));
   iEvent.put(std::move(TRHoutput));
-
 }
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
-MuonErrorMatrixAdjuster::beginJob()
-{
-  theMatrixProvider = new MuonErrorMatrix(theMatrixProvider_pset);
-}
+void MuonErrorMatrixAdjuster::beginJob() { theMatrixProvider = new MuonErrorMatrix(theMatrixProvider_pset); }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-MuonErrorMatrixAdjuster::endJob() {
-  if ( theMatrixProvider) delete theMatrixProvider;
+void MuonErrorMatrixAdjuster::endJob() {
+  if (theMatrixProvider)
+    delete theMatrixProvider;
 }

--- a/RecoMuon/TrackingTools/plugins/MuonErrorMatrixAdjuster.h
+++ b/RecoMuon/TrackingTools/plugins/MuonErrorMatrixAdjuster.h
@@ -14,7 +14,6 @@
  * \author Finn Rebassoo      UCSB
  */
 
-
 #include <memory>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
@@ -36,51 +35,52 @@ class MagneticField;
 class MuonErrorMatrix;
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 
-#include  <FWCore/Framework/interface/ESHandle.h>
+#include <FWCore/Framework/interface/ESHandle.h>
 
 //
 // class decleration
 //
 
 class MuonErrorMatrixAdjuster : public edm::EDProducer {
- public:
+public:
   /// constructor
   explicit MuonErrorMatrixAdjuster(const edm::ParameterSet&);
   /// destructor
   ~MuonErrorMatrixAdjuster() override;
-  
- private:
+
+private:
   /// framework method
-  void beginJob() override ;
+  void beginJob() override;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  void endJob() override ;
-  
-  /// return a corrected error matrix 
-  reco::TrackBase::CovarianceMatrix fix_cov_matrix(const reco::TrackBase::CovarianceMatrix& error_matrix, const GlobalVector& momentum);
+  void endJob() override;
+
+  /// return a corrected error matrix
+  reco::TrackBase::CovarianceMatrix fix_cov_matrix(const reco::TrackBase::CovarianceMatrix& error_matrix,
+                                                   const GlobalVector& momentum);
   /// mutliply revised_matrix (first argument)  by second matrix TERM by TERM
-  void multiply(reco::TrackBase::CovarianceMatrix & revised_matrix, const reco::TrackBase::CovarianceMatrix & scale_matrix);
+  void multiply(reco::TrackBase::CovarianceMatrix& revised_matrix,
+                const reco::TrackBase::CovarianceMatrix& scale_matrix);
   /// divide the num_matrix  (first argument) by second matrix, TERM by TERM
-  bool divide(reco::TrackBase::CovarianceMatrix & num_matrix, const reco::TrackBase::CovarianceMatrix & denom_matrix);
+  bool divide(reco::TrackBase::CovarianceMatrix& num_matrix, const reco::TrackBase::CovarianceMatrix& denom_matrix);
 
   /// create a corrected reco::Track from itself and trajectory state (redundant information)
-  reco::Track makeTrack(const reco::Track & recotrack_orig,
-			const FreeTrajectoryState & PCAstate);
+  reco::Track makeTrack(const reco::Track& recotrack_orig, const FreeTrajectoryState& PCAstate);
 
   /// make a selection on the reco:Track. (dummy for the moment)
-  bool selectTrack(const reco::Track & recotrack_orig);
+  bool selectTrack(const reco::Track& recotrack_orig);
 
   /// create a track extra for the newly created recotrack, scaling the outer/inner measurment error matrix by the scale matrix recotrack/recotrack_orig
-  reco::TrackExtra * makeTrackExtra(const reco::Track & recotrack_orig,
-				    reco::Track & recotrack,
-				    reco::TrackExtraCollection& TEcol);
+  reco::TrackExtra* makeTrackExtra(const reco::Track& recotrack_orig,
+                                   reco::Track& recotrack,
+                                   reco::TrackExtraCollection& TEcol);
 
   /// attached rechits to the newly created reco::Track and reco::TrackExtra
-  bool attachRecHits(const reco::Track & recotrack_orig,
-		     reco::Track & recotrack,
-		     reco::TrackExtra & trackextra,
-		     TrackingRecHitCollection& RHcol,
+  bool attachRecHits(const reco::Track& recotrack_orig,
+                     reco::Track& recotrack,
+                     reco::TrackExtra& trackextra,
+                     TrackingRecHitCollection& RHcol,
                      const TrackerTopology& ttopo);
-      
+
   // ----------member data ---------------------------
   /// log category: MuonErrorMatrixAdjuster
   std::string theCategory;
@@ -96,12 +96,11 @@ class MuonErrorMatrixAdjuster : public edm::EDProducer {
 
   /// holds the error matrix parametrization
   edm::ParameterSet theMatrixProvider_pset;
-  MuonErrorMatrix * theMatrixProvider;
-  
+  MuonErrorMatrix* theMatrixProvider;
 
   /// hold on to the magnetic field
   edm::ESHandle<MagneticField> theField;
-      
+
   /// get reference before put track extra to the event, in order to create edm::Ref
   edm::RefProd<reco::TrackExtraCollection> theRefprodTE;
   edm::Ref<reco::TrackExtraCollection>::key_type theTEi;
@@ -109,7 +108,6 @@ class MuonErrorMatrixAdjuster : public edm::EDProducer {
   /// get reference before put rechit to the event, in order to create edm::Ref
   edm::RefProd<TrackingRecHitCollection> theRefprodRH;
   edm::Ref<TrackingRecHitCollection>::key_type theRHi;
-
 };
 
 #endif

--- a/RecoMuon/TrackingTools/plugins/SealModules.cc
+++ b/RecoMuon/TrackingTools/plugins/SealModules.cc
@@ -5,8 +5,6 @@
 #include "FWCore/Utilities/interface/typelookup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
 #include "RecoMuon/TrackingTools/plugins/MuonErrorMatrixAdjuster.h"
-
 
 DEFINE_FWK_MODULE(MuonErrorMatrixAdjuster);

--- a/RecoMuon/TrackingTools/src/DirectMuonTrajectoryBuilder.cc
+++ b/RecoMuon/TrackingTools/src/DirectMuonTrajectoryBuilder.cc
@@ -15,125 +15,112 @@
 using namespace edm;
 using namespace std;
 
-
-DirectMuonTrajectoryBuilder::DirectMuonTrajectoryBuilder(const ParameterSet& par, 
-							 const MuonServiceProxy* service):theService(service){
-  
+DirectMuonTrajectoryBuilder::DirectMuonTrajectoryBuilder(const ParameterSet& par, const MuonServiceProxy* service)
+    : theService(service) {
   // The seed transformer (used to refit the seed and get the seed transient state)
   //  ParameterSet seedTransformerPSet = par.getParameter<ParameterSet>("SeedTransformerParameters");
   ParameterSet seedTransformerParameters = par.getParameter<ParameterSet>("SeedTransformerParameters");
   theSeedTransformer = new SeedTransformer(seedTransformerParameters);
 }
 
-DirectMuonTrajectoryBuilder::~DirectMuonTrajectoryBuilder(){
+DirectMuonTrajectoryBuilder::~DirectMuonTrajectoryBuilder() {
+  LogTrace("Muon|RecoMuon|DirectMuonTrajectoryBuilder") << "DirectMuonTrajectoryBuilder destructor called" << endl;
 
-  LogTrace("Muon|RecoMuon|DirectMuonTrajectoryBuilder") 
-    << "DirectMuonTrajectoryBuilder destructor called" << endl;
-  
-  if(theSeedTransformer) delete theSeedTransformer;
+  if (theSeedTransformer)
+    delete theSeedTransformer;
 }
 
-MuonTrajectoryBuilder::TrajectoryContainer 
-DirectMuonTrajectoryBuilder::trajectories(const TrajectorySeed& seed){
-  
+MuonTrajectoryBuilder::TrajectoryContainer DirectMuonTrajectoryBuilder::trajectories(const TrajectorySeed& seed) {
   // Set the services for the seed transformer
   theSeedTransformer->setServices(theService->eventSetup());
 
   const string metname = "Muon|RecoMuon|DirectMuonTrajectoryBuilder";
-  
+
   MuonTrajectoryBuilder::TrajectoryContainer trajectoryContainer;
-  
+
   vector<Trajectory> seedTrajectories = theSeedTransformer->seedTransform(seed);
-  
-  if(!seedTrajectories.empty())
-    for(vector<Trajectory>::const_iterator trajectory = seedTrajectories.begin(); trajectory!=seedTrajectories.end(); ++trajectory)
+
+  if (!seedTrajectories.empty())
+    for (vector<Trajectory>::const_iterator trajectory = seedTrajectories.begin(); trajectory != seedTrajectories.end();
+         ++trajectory)
       trajectoryContainer.push_back(new Trajectory(*trajectory));
-  else LogTrace(metname) << "Seed not refitted";
-    
-  
-  return  trajectoryContainer;
+  else
+    LogTrace(metname) << "Seed not refitted";
 
+  return trajectoryContainer;
 
-// std::pair<bool, Trajectory> 
-// SETFilter::bwfit_SET(const TrajectorySeed &trajectorySeed  , 
-// 				  const TransientTrackingRecHit::ConstRecHitContainer & trajRH,
-// 				  const TrajectoryStateOnSurface & firstTsos) {
-//   // get the actual fitter - Kalman fit
-//   theService->eventSetup().get<TrajectoryFitter::Record>().get(theBWLightFitterName, theBWLightFitter);
-//   vector<Trajectory> refitted;
-//   Trajectory trajectory;
-//   // the actual Kalman Fit
-//   refitted = theBWLightFitter->fit(trajectorySeed, trajRH, firstTsos);                                  
-//   if(!refitted.empty()){
-//     // under tests...
-//     bool applyPruning = false;
-//     if(applyPruning){
-//       double previousTheta = trajRH[0]->globalPosition().theta();
-//       double previousWeight = 0.;
-//       std::vector <double> weights(trajRH.size());
-//       std::vector <double> weight_diff(trajRH.size());
-//       for(unsigned int iRH = 0; iRH<trajRH.size();++iRH){
-// 	double weight = trajRH[iRH]->globalPosition().theta() - previousTheta;
-// 	weights.at(iRH)= weight;
-// 	double weightDiff = weight + previousWeight;
-// 	weight_diff.at(iRH) = weightDiff;
-// 	std::cout<<" iRH = "<<iRH<<" globPos"<< trajRH[iRH]->globalPosition()<<" weight = "<<weight<<" weightDiff = "<<weightDiff<<std::endl;
-// 	previousTheta = trajRH[iRH]->globalPosition().theta();
-// 	previousWeight = weight;
+  // std::pair<bool, Trajectory>
+  // SETFilter::bwfit_SET(const TrajectorySeed &trajectorySeed  ,
+  // 				  const TransientTrackingRecHit::ConstRecHitContainer & trajRH,
+  // 				  const TrajectoryStateOnSurface & firstTsos) {
+  //   // get the actual fitter - Kalman fit
+  //   theService->eventSetup().get<TrajectoryFitter::Record>().get(theBWLightFitterName, theBWLightFitter);
+  //   vector<Trajectory> refitted;
+  //   Trajectory trajectory;
+  //   // the actual Kalman Fit
+  //   refitted = theBWLightFitter->fit(trajectorySeed, trajRH, firstTsos);
+  //   if(!refitted.empty()){
+  //     // under tests...
+  //     bool applyPruning = false;
+  //     if(applyPruning){
+  //       double previousTheta = trajRH[0]->globalPosition().theta();
+  //       double previousWeight = 0.;
+  //       std::vector <double> weights(trajRH.size());
+  //       std::vector <double> weight_diff(trajRH.size());
+  //       for(unsigned int iRH = 0; iRH<trajRH.size();++iRH){
+  // 	double weight = trajRH[iRH]->globalPosition().theta() - previousTheta;
+  // 	weights.at(iRH)= weight;
+  // 	double weightDiff = weight + previousWeight;
+  // 	weight_diff.at(iRH) = weightDiff;
+  // 	std::cout<<" iRH = "<<iRH<<" globPos"<< trajRH[iRH]->globalPosition()<<" weight = "<<weight<<" weightDiff = "<<weightDiff<<std::endl;
+  // 	previousTheta = trajRH[iRH]->globalPosition().theta();
+  // 	previousWeight = weight;
 
-//       }
-//       Trajectory::DataContainer measurements_segments = refitted.front().measurements();
-//       if(measurements_segments.size() != trajRH.size()){
-// 	std::cout<<" measurements_segments.size() = "<<measurements_segments.size()<<
-// 	  " trajRH.size() = "<<trajRH.size()<<std::endl;
-// 	std::cout<<" THIS IS NOT SUPPOSED TO HAPPEN! CHECK THE CODE (pruning)"<<std::endl;
-//       }
-//       std::vector <int> badHits;
-//       TransientTrackingRecHit::ConstRecHitContainer trajRH_pruned;
-//       for(unsigned int iMeas = 0; iMeas<measurements_segments.size();++iMeas){
-// 	// we have to apply pruning on the base of intermed. chi2 of measurements
-// 	// and then refit again!
-// 	std::cout<<" after refitter : iMeas = "<<iMeas<<"  estimate() = "<< measurements_segments[iMeas].estimate()<<
-// 	  " globPos = "<< measurements_segments[iMeas].recHit()->globalPosition()<<std::endl;
-// 	//const TransientTrackingRecHit::ConstRecHitContainer trajRH_pruned;
-// 	bool pruningCondition = fabs(weights[iMeas])>0.0011 && fabs(weight_diff[iMeas])>0.0011;
-// 	std::cout<<" weights[iMeas] = "<<weights[iMeas]<<" weight_diff[iMeas] = "<<weight_diff[iMeas]<<" pruningCondition = "<<pruningCondition<<std::endl;
-// 	//bool pruningCondition = (measurements_segments[iMeas].estimate()>50);
-// 	if(iMeas && pruningCondition && measurements_segments.size() == trajRH.size()){// first is kept for technical reasons (for now)
-// 	  badHits.push_back(iMeas);
-// 	}
-// 	else{
-// 	  trajRH_pruned.push_back(trajRH[iMeas]);
-// 	}
-//       }
-//       if(float(measurements_segments.size())/float(badHits.size()) >0.5 &&
-// 	 measurements_segments.size() - badHits.size() > 6){
-// 	std::cout<<" this is pruning ; badHits.size() = "<<badHits.size()<<std::endl;
-// 	refitted = theBWLightFitter->fit(trajectorySeed, trajRH_pruned, firstTsos);  
-//       }
-//     }
-//     std::pair<bool, Trajectory> refitResult = make_pair(true,refitted.front());
-//     //return RefitResult(true,refitted.front());
-//     return refitResult;
-//   }
-//   else{
-//     //    std::cout<<" refitted.empty() = "<<refitted.empty()<<std::endl;
-//     std::pair<bool, Trajectory> refitResult = make_pair(false,trajectory);
-//     //return RefitResult(false,trajectory);
-//     return refitResult;
-//   }
+  //       }
+  //       Trajectory::DataContainer measurements_segments = refitted.front().measurements();
+  //       if(measurements_segments.size() != trajRH.size()){
+  // 	std::cout<<" measurements_segments.size() = "<<measurements_segments.size()<<
+  // 	  " trajRH.size() = "<<trajRH.size()<<std::endl;
+  // 	std::cout<<" THIS IS NOT SUPPOSED TO HAPPEN! CHECK THE CODE (pruning)"<<std::endl;
+  //       }
+  //       std::vector <int> badHits;
+  //       TransientTrackingRecHit::ConstRecHitContainer trajRH_pruned;
+  //       for(unsigned int iMeas = 0; iMeas<measurements_segments.size();++iMeas){
+  // 	// we have to apply pruning on the base of intermed. chi2 of measurements
+  // 	// and then refit again!
+  // 	std::cout<<" after refitter : iMeas = "<<iMeas<<"  estimate() = "<< measurements_segments[iMeas].estimate()<<
+  // 	  " globPos = "<< measurements_segments[iMeas].recHit()->globalPosition()<<std::endl;
+  // 	//const TransientTrackingRecHit::ConstRecHitContainer trajRH_pruned;
+  // 	bool pruningCondition = fabs(weights[iMeas])>0.0011 && fabs(weight_diff[iMeas])>0.0011;
+  // 	std::cout<<" weights[iMeas] = "<<weights[iMeas]<<" weight_diff[iMeas] = "<<weight_diff[iMeas]<<" pruningCondition = "<<pruningCondition<<std::endl;
+  // 	//bool pruningCondition = (measurements_segments[iMeas].estimate()>50);
+  // 	if(iMeas && pruningCondition && measurements_segments.size() == trajRH.size()){// first is kept for technical reasons (for now)
+  // 	  badHits.push_back(iMeas);
+  // 	}
+  // 	else{
+  // 	  trajRH_pruned.push_back(trajRH[iMeas]);
+  // 	}
+  //       }
+  //       if(float(measurements_segments.size())/float(badHits.size()) >0.5 &&
+  // 	 measurements_segments.size() - badHits.size() > 6){
+  // 	std::cout<<" this is pruning ; badHits.size() = "<<badHits.size()<<std::endl;
+  // 	refitted = theBWLightFitter->fit(trajectorySeed, trajRH_pruned, firstTsos);
+  //       }
+  //     }
+  //     std::pair<bool, Trajectory> refitResult = make_pair(true,refitted.front());
+  //     //return RefitResult(true,refitted.front());
+  //     return refitResult;
+  //   }
+  //   else{
+  //     //    std::cout<<" refitted.empty() = "<<refitted.empty()<<std::endl;
+  //     std::pair<bool, Trajectory> refitResult = make_pair(false,trajectory);
+  //     //return RefitResult(false,trajectory);
+  //     return refitResult;
+  //   }
 }
 
-
-MuonTrajectoryBuilder::CandidateContainer 
-DirectMuonTrajectoryBuilder::trajectories(const TrackCand&)
-{
+MuonTrajectoryBuilder::CandidateContainer DirectMuonTrajectoryBuilder::trajectories(const TrackCand&) {
   return MuonTrajectoryBuilder::CandidateContainer();
 }
 
-
-
-void DirectMuonTrajectoryBuilder::setEvent(const edm::Event& event){
-}
-
-
+void DirectMuonTrajectoryBuilder::setEvent(const edm::Event& event) {}

--- a/RecoMuon/TrackingTools/src/MuonBestMeasurementFinder.cc
+++ b/RecoMuon/TrackingTools/src/MuonBestMeasurementFinder.cc
@@ -23,114 +23,101 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
 using namespace std;
 
-MuonBestMeasurementFinder::MuonBestMeasurementFinder(){
-  
-  theEstimator = new Chi2MeasurementEstimator(100000.);
-}
+MuonBestMeasurementFinder::MuonBestMeasurementFinder() { theEstimator = new Chi2MeasurementEstimator(100000.); }
 
-MuonBestMeasurementFinder::~MuonBestMeasurementFinder(){
-  delete theEstimator;
-}
+MuonBestMeasurementFinder::~MuonBestMeasurementFinder() { delete theEstimator; }
 
-TrajectoryMeasurement* 
-MuonBestMeasurementFinder::findBestMeasurement(std::vector<TrajectoryMeasurement>& measC,
-					       const Propagator* propagator){
-  
+TrajectoryMeasurement* MuonBestMeasurementFinder::findBestMeasurement(std::vector<TrajectoryMeasurement>& measC,
+                                                                      const Propagator* propagator) {
   const std::string metname = "Muon|RecoMuon|MuonBestMeasurementFinder";
 
   TMContainer validMeasurements;
 
-  TrajectoryMeasurement* bestMeasurement=nullptr;
+  TrajectoryMeasurement* bestMeasurement = nullptr;
 
   // consider only valid TM
-  int NumValidMeas=0;
-  for ( vector<TrajectoryMeasurement>::iterator measurement = measC.begin(); 
-	measurement!= measC.end(); ++measurement ) {
+  int NumValidMeas = 0;
+  for (vector<TrajectoryMeasurement>::iterator measurement = measC.begin(); measurement != measC.end(); ++measurement) {
     if ((*measurement).recHit()->isValid()) {
       ++NumValidMeas;
       bestMeasurement = &(*measurement);
-      validMeasurements.push_back( &(*measurement) );
+      validMeasurements.push_back(&(*measurement));
     }
   }
 
-  // If we have just one (or zero) valid meas, return it at once 
+  // If we have just one (or zero) valid meas, return it at once
   // (or return null measurement)
-  if(NumValidMeas<=1) {
-    LogTrace(metname) << "MuonBestMeasurement: just " << NumValidMeas
-		      << " valid measurement ";
+  if (NumValidMeas <= 1) {
+    LogTrace(metname) << "MuonBestMeasurement: just " << NumValidMeas << " valid measurement ";
     return bestMeasurement;
   }
 
   TMIterator measurement;
-  double minChi2PerNDoF=1.E6;
+  double minChi2PerNDoF = 1.E6;
 
   // if there are more than one valid measurement, then sort them.
-  for ( measurement = validMeasurements.begin(); measurement!= validMeasurements.end(); measurement++ ) {
-
+  for (measurement = validMeasurements.begin(); measurement != validMeasurements.end(); measurement++) {
     TransientTrackingRecHit::ConstRecHitPointer muonRecHit = (*measurement)->recHit();
-    
-    // FIXME!! FIXME !! FIXME !!
-    pair<double,int> chi2Info = lookAtSubRecHits(*measurement, propagator);
 
-    double chi2PerNDoF = chi2Info.first/chi2Info.second;
+    // FIXME!! FIXME !! FIXME !!
+    pair<double, int> chi2Info = lookAtSubRecHits(*measurement, propagator);
+
+    double chi2PerNDoF = chi2Info.first / chi2Info.second;
     LogTrace(metname) << " The measurement has a chi2/npts " << chi2PerNDoF << " with dof = " << chi2Info.second
-		      << " \n Till now the best chi2 is " << minChi2PerNDoF;
-    
-    if ( chi2PerNDoF && chi2PerNDoF<minChi2PerNDoF ) {
-      minChi2PerNDoF = chi2PerNDoF;	
+                      << " \n Till now the best chi2 is " << minChi2PerNDoF;
+
+    if (chi2PerNDoF && chi2PerNDoF < minChi2PerNDoF) {
+      minChi2PerNDoF = chi2PerNDoF;
       bestMeasurement = *measurement;
     }
-    
   }
-  LogTrace(metname)<<"The final best chi2 is "<<minChi2PerNDoF<<endl;
+  LogTrace(metname) << "The final best chi2 is " << minChi2PerNDoF << endl;
   return bestMeasurement;
 }
 
-
-pair<double,int> MuonBestMeasurementFinder::lookAtSubRecHits(TrajectoryMeasurement* measurement,
-							     const Propagator* propagator){
-  
+pair<double, int> MuonBestMeasurementFinder::lookAtSubRecHits(TrajectoryMeasurement* measurement,
+                                                              const Propagator* propagator) {
   const std::string metname = "Muon|RecoMuon|MuonBestMeasurementFinder";
 
-  unsigned int npts=0;
+  unsigned int npts = 0;
   // unused  double thisChi2 = 0.;
 
   const TransientTrackingRecHit::ConstRecHitPointer& muonRecHit = measurement->recHit();
-  const TrajectoryStateOnSurface& predState = measurement->predictedState();                          // temporarily introduced by DT
-  std::pair<bool, double> sing_chi2 = estimator()->estimate( predState, *(muonRecHit.get()));  // temporarily introduced by DT
-  npts = 1;                                                                                    // temporarily introduced by DT
-  std::pair<double, int> result = pair<double, int>(sing_chi2.second, npts);                   // temporarily introduced by DT
-  
-//   // ask for the 2D-segments/2D-rechit                                                      // temporarily excluded by DT
-//   TransientTrackingRecHit::ConstRecHitContainer rhits_list = muonRecHit->transientHits();
-  
-//   LogTrace(metname)<<"Number of rechits in the measurement rechit: "<<rhits_list.size()<<endl;
-  
-//   // loop over them
-//   for (TransientTrackingRecHit::ConstRecHitContainer::const_iterator rhit = rhits_list.begin();
-//        rhit!= rhits_list.end(); ++rhit)
-//     if ((*rhit)->isValid() ) {
-//       LogTrace(metname)<<"Rechit dimension: "<<(*rhit)->dimension()<<endl;
-//       npts+=(*rhit)->dimension();
-      
-//       TrajectoryStateOnSurface predState;
-      
-//       if (!( (*rhit)->geographicalId() == muonRecHit->geographicalId() ) ){
-// 	predState = propagator->propagate(*measurement->predictedState().freeState(),
-// 					  (*rhit)->det()->surface()); 
-//       }
-//       else predState = measurement->predictedState();  
-      
-//       if ( predState.isValid() ) { 
-// 	std::pair<bool,double> sing_chi2 = estimator()->estimate( predState, *((*rhit).get()));
-// 	thisChi2 += sing_chi2.second ;
-// 	LogTrace(metname) << " single incremental chi2: " << sing_chi2.second;
-//       }
-//     }
-  
-//   pair<double,int> result = pair<double,int>(thisChi2,npts);
+  const TrajectoryStateOnSurface& predState = measurement->predictedState();  // temporarily introduced by DT
+  std::pair<bool, double> sing_chi2 =
+      estimator()->estimate(predState, *(muonRecHit.get()));                  // temporarily introduced by DT
+  npts = 1;                                                                   // temporarily introduced by DT
+  std::pair<double, int> result = pair<double, int>(sing_chi2.second, npts);  // temporarily introduced by DT
+
+  //   // ask for the 2D-segments/2D-rechit                                                      // temporarily excluded by DT
+  //   TransientTrackingRecHit::ConstRecHitContainer rhits_list = muonRecHit->transientHits();
+
+  //   LogTrace(metname)<<"Number of rechits in the measurement rechit: "<<rhits_list.size()<<endl;
+
+  //   // loop over them
+  //   for (TransientTrackingRecHit::ConstRecHitContainer::const_iterator rhit = rhits_list.begin();
+  //        rhit!= rhits_list.end(); ++rhit)
+  //     if ((*rhit)->isValid() ) {
+  //       LogTrace(metname)<<"Rechit dimension: "<<(*rhit)->dimension()<<endl;
+  //       npts+=(*rhit)->dimension();
+
+  //       TrajectoryStateOnSurface predState;
+
+  //       if (!( (*rhit)->geographicalId() == muonRecHit->geographicalId() ) ){
+  // 	predState = propagator->propagate(*measurement->predictedState().freeState(),
+  // 					  (*rhit)->det()->surface());
+  //       }
+  //       else predState = measurement->predictedState();
+
+  //       if ( predState.isValid() ) {
+  // 	std::pair<bool,double> sing_chi2 = estimator()->estimate( predState, *((*rhit).get()));
+  // 	thisChi2 += sing_chi2.second ;
+  // 	LogTrace(metname) << " single incremental chi2: " << sing_chi2.second;
+  //       }
+  //     }
+
+  //   pair<double,int> result = pair<double,int>(thisChi2,npts);
   return result;
 }

--- a/RecoMuon/TrackingTools/src/MuonChi2MeasurementEstimator.cc
+++ b/RecoMuon/TrackingTools/src/MuonChi2MeasurementEstimator.cc
@@ -14,45 +14,43 @@
 #include "DataFormats/Common/interface/getRef.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
- 
 
 MuonChi2MeasurementEstimator::MuonChi2MeasurementEstimator(double maxChi2, double nSigma)
-  :Chi2MeasurementEstimatorBase(maxChi2,nSigma), 
-   theDTChi2Estimator(maxChi2, nSigma), 
-   theCSCChi2Estimator(maxChi2, nSigma),
-   theRPCChi2Estimator(maxChi2, nSigma){}
+    : Chi2MeasurementEstimatorBase(maxChi2, nSigma),
+      theDTChi2Estimator(maxChi2, nSigma),
+      theCSCChi2Estimator(maxChi2, nSigma),
+      theRPCChi2Estimator(maxChi2, nSigma) {}
 
+MuonChi2MeasurementEstimator::MuonChi2MeasurementEstimator(double dtMaxChi2,
+                                                           double cscMaxChi2,
+                                                           double rpcMaxChi2,
+                                                           double nSigma = 3.)
+    : Chi2MeasurementEstimatorBase(dtMaxChi2, nSigma),
+      theDTChi2Estimator(dtMaxChi2, nSigma),
+      theCSCChi2Estimator(cscMaxChi2, nSigma),
+      theRPCChi2Estimator(rpcMaxChi2, nSigma) {}
 
-MuonChi2MeasurementEstimator::MuonChi2MeasurementEstimator(double dtMaxChi2, double cscMaxChi2, double rpcMaxChi2, double nSigma = 3.)
-  :Chi2MeasurementEstimatorBase(dtMaxChi2,nSigma),
-   theDTChi2Estimator(dtMaxChi2, nSigma), 
-   theCSCChi2Estimator(cscMaxChi2, nSigma),
-   theRPCChi2Estimator(rpcMaxChi2, nSigma){}
-
-
-std::pair<bool,double> 
-MuonChi2MeasurementEstimator::estimate(const TrajectoryStateOnSurface& tsos,
-				       const TrackingRecHit& recHit) const {
-  
+std::pair<bool, double> MuonChi2MeasurementEstimator::estimate(const TrajectoryStateOnSurface& tsos,
+                                                               const TrackingRecHit& recHit) const {
   DetId id = recHit.geographicalId();
-  
+
   // chi2 choise based on recHit provenance
-  if(id.det() == DetId::Muon){
-    if(id.subdetId() == MuonSubdetId::DT)
-      return theDTChi2Estimator.estimate(tsos,recHit);
-    else if(id.subdetId() == MuonSubdetId::CSC)
-      return theCSCChi2Estimator.estimate(tsos,recHit);
-    else if(id.subdetId() == MuonSubdetId::RPC) 
-      return theRPCChi2Estimator.estimate(tsos,recHit);
-    else{
+  if (id.det() == DetId::Muon) {
+    if (id.subdetId() == MuonSubdetId::DT)
+      return theDTChi2Estimator.estimate(tsos, recHit);
+    else if (id.subdetId() == MuonSubdetId::CSC)
+      return theCSCChi2Estimator.estimate(tsos, recHit);
+    else if (id.subdetId() == MuonSubdetId::RPC)
+      return theRPCChi2Estimator.estimate(tsos, recHit);
+    else {
       edm::LogWarning("Muon|RecoMuon|MuonChi2MeasurementEstimator")
-	<<"RecHit with MuonId but not with a SubDetId neither from DT, CSC or rpc. [Use the parameters used for DTs]";
-      return theDTChi2Estimator.estimate(tsos,recHit);
+          << "RecHit with MuonId but not with a SubDetId neither from DT, CSC or rpc. [Use the parameters used for "
+             "DTs]";
+      return theDTChi2Estimator.estimate(tsos, recHit);
     }
-  }
-  else{
+  } else {
     edm::LogWarning("Muon|RecoMuon|MuonChi2MeasurementEstimator")
-      <<"Rechit with a non-muon det id. [Use the parameters used for DTs]";
-    return theDTChi2Estimator.estimate(tsos,recHit);
+        << "Rechit with a non-muon det id. [Use the parameters used for DTs]";
+    return theDTChi2Estimator.estimate(tsos, recHit);
   }
 }

--- a/RecoMuon/TrackingTools/src/MuonErrorMatrix.cc
+++ b/RecoMuon/TrackingTools/src/MuonErrorMatrix.cc
@@ -12,228 +12,259 @@
 
 using namespace std;
 
-const TString MuonErrorMatrix::vars[5]={"#frac{q}{|p|}","#lambda","#varphi_{0}","X_{T}","Y_{T}"};
+const TString MuonErrorMatrix::vars[5] = {"#frac{q}{|p|}", "#lambda", "#varphi_{0}", "X_{T}", "Y_{T}"};
 
-MuonErrorMatrix::MuonErrorMatrix(const edm::ParameterSet & iConfig):theD(nullptr){
-  theCategory="MuonErrorMatrix";
+MuonErrorMatrix::MuonErrorMatrix(const edm::ParameterSet &iConfig) : theD(nullptr) {
+  theCategory = "MuonErrorMatrix";
   std::string action = iConfig.getParameter<std::string>("action");
 
-  bool madeFromCff=iConfig.exists("errorMatrixValuesPSet");
+  bool madeFromCff = iConfig.exists("errorMatrixValuesPSet");
   edm::ParameterSet errorMatrixValuesPSet;
 
   std::string fileName;
-  if (!madeFromCff){ fileName = iConfig.getParameter<std::string>("rootFileName");}
-  else { errorMatrixValuesPSet =iConfig.getParameter<edm::ParameterSet>("errorMatrixValuesPSet");}
-  MuonErrorMatrix::action a= use;
+  if (!madeFromCff) {
+    fileName = iConfig.getParameter<std::string>("rootFileName");
+  } else {
+    errorMatrixValuesPSet = iConfig.getParameter<edm::ParameterSet>("errorMatrixValuesPSet");
+  }
+  MuonErrorMatrix::action a = use;
 
-   int NPt=5;
-   std::vector<double> xBins;
-   double * xBinsArray = nullptr;
-   double minPt=1;
-   double maxPt=200;
-   int NEta=5;
-   std::vector<double> yBins;
-   double * yBinsArray =nullptr;
-   double minEta=0;
-   double maxEta=2.5;
-   int NPhi=1;
-   double minPhi=-TMath::Pi();
-   double maxPhi=TMath::Pi();
+  int NPt = 5;
+  std::vector<double> xBins;
+  double *xBinsArray = nullptr;
+  double minPt = 1;
+  double maxPt = 200;
+  int NEta = 5;
+  std::vector<double> yBins;
+  double *yBinsArray = nullptr;
+  double minEta = 0;
+  double maxEta = 2.5;
+  int NPhi = 1;
+  double minPhi = -TMath::Pi();
+  double maxPhi = TMath::Pi();
 
-  if (action!="use"){
+  if (action != "use") {
     a = constructor;
-    
+
     NPt = iConfig.getParameter<int>("NPt");
-    if (NPt!=0){
+    if (NPt != 0) {
       minPt = iConfig.getParameter<double>("minPt");
-      maxPt = iConfig.getParameter<double>("maxPt");}
-    else{
+      maxPt = iConfig.getParameter<double>("maxPt");
+    } else {
       xBins = iConfig.getParameter<std::vector<double> >("PtBins");
-      if (xBins.empty()){edm::LogError( theCategory)<<"Npt=0 and no entries in the vector. I will do aseg fault soon.";}
-      NPt = xBins.size()-1;
+      if (xBins.empty()) {
+        edm::LogError(theCategory) << "Npt=0 and no entries in the vector. I will do aseg fault soon.";
+      }
+      NPt = xBins.size() - 1;
       xBinsArray = &(xBins.front());
       minPt = xBins.front();
-      maxPt = xBins.back();}
+      maxPt = xBins.back();
+    }
 
     NEta = iConfig.getParameter<int>("NEta");
-    if (NEta!=0){
+    if (NEta != 0) {
       minEta = iConfig.getParameter<double>("minEta");
-      maxEta = iConfig.getParameter<double>("maxEta");}
-    else{
+      maxEta = iConfig.getParameter<double>("maxEta");
+    } else {
       yBins = iConfig.getParameter<std::vector<double> >("EtaBins");
-      if (yBins.empty()){edm::LogError( theCategory)<<"NEta=0 and no entries in the vector. I will do aseg fault soon.";}
-      NEta = yBins.size()-1;
+      if (yBins.empty()) {
+        edm::LogError(theCategory) << "NEta=0 and no entries in the vector. I will do aseg fault soon.";
+      }
+      NEta = yBins.size() - 1;
       yBinsArray = &(yBins.front());
       minEta = yBins.front();
-      maxEta = yBins.back();}
+      maxEta = yBins.back();
+    }
 
     NPhi = iConfig.getParameter<int>("NPhi");
     std::stringstream get(iConfig.getParameter<std::string>("minPhi"));
-    if (get.str() =="-Pi")
-      {	minPhi =-TMath::Pi();}
-    else if(get.str() =="Pi")
-      { minPhi =TMath::Pi();}
-    else { get>>minPhi;}
+    if (get.str() == "-Pi") {
+      minPhi = -TMath::Pi();
+    } else if (get.str() == "Pi") {
+      minPhi = TMath::Pi();
+    } else {
+      get >> minPhi;
+    }
     get.str(iConfig.getParameter<std::string>("maxPhi"));
-        if (get.str() =="-Pi")
-      {	maxPhi =-TMath::Pi();}
-    else if(get.str() =="Pi")
-      { maxPhi =TMath::Pi();}
-    else { get>>maxPhi;}
-  }//action!=use
-  else if (madeFromCff){
-
+    if (get.str() == "-Pi") {
+      maxPhi = -TMath::Pi();
+    } else if (get.str() == "Pi") {
+      maxPhi = TMath::Pi();
+    } else {
+      get >> maxPhi;
+    }
+  }  //action!=use
+  else if (madeFromCff) {
     xBins = errorMatrixValuesPSet.getParameter<std::vector<double> >("xAxis");
-    NPt = xBins.size()-1;
+    NPt = xBins.size() - 1;
     xBinsArray = &(xBins.front());
     minPt = xBins.front();
     maxPt = xBins.back();
-    
+
     yBins = errorMatrixValuesPSet.getParameter<std::vector<double> >("yAxis");
-    NEta = yBins.size()-1;
+    NEta = yBins.size() - 1;
     yBinsArray = &(yBins.front());
     minEta = yBins.front();
     maxEta = yBins.back();
 
     std::vector<double> zBins = errorMatrixValuesPSet.getParameter<std::vector<double> >("zAxis");
-    NPhi=1;
-    if (zBins.size()!=2){
-      edm::LogError(theCategory)<<"please specify a zAxis with 2 entries only. more bins not implemented yet.";}
-    minPhi=zBins.front();
-    maxPhi=zBins.back();
-
+    NPhi = 1;
+    if (zBins.size() != 2) {
+      edm::LogError(theCategory) << "please specify a zAxis with 2 entries only. more bins not implemented yet.";
+    }
+    minPhi = zBins.front();
+    maxPhi = zBins.back();
   }
 
-  if (a==use){
-    if (!madeFromCff){
-      edm::LogInfo(theCategory)<<"using an error matrix object from: "<<fileName;
+  if (a == use) {
+    if (!madeFromCff) {
+      edm::LogInfo(theCategory) << "using an error matrix object from: " << fileName;
       edm::FileInPath data(fileName);
       std::string fullpath = data.fullPath();
       gROOT->cd();
       theD = new TFile(fullpath.c_str());
       theD->SetWritable(false);
-    }else{
+    } else {
       static std::atomic<unsigned int> neverTheSame{0};
       std::stringstream dirName("MuonErrorMatrixDirectory");
-      dirName<<neverTheSame++;
-      edm::LogInfo(theCategory)<<"using an error matrix object from configuration file. putting memory histograms to: "<<dirName.str();
+      dirName << neverTheSame++;
+      edm::LogInfo(theCategory)
+          << "using an error matrix object from configuration file. putting memory histograms to: " << dirName.str();
       gROOT->cd();
-      theD = new TDirectory(dirName.str().c_str(),"transient directory to host MuonErrorMatrix TProfile3D");
+      theD = new TDirectory(dirName.str().c_str(), "transient directory to host MuonErrorMatrix TProfile3D");
       theD->SetWritable(false);
     }
+  } else {
+    edm::LogInfo(theCategory) << "creating  an error matrix object: " << fileName;
+    theD = new TFile(fileName.c_str(), "recreate");
   }
-  else{
-    edm::LogInfo(theCategory)<<"creating  an error matrix object: "<<fileName;
-    theD = new TFile(fileName.c_str(),"recreate");
+
+  if (a == use && !madeFromCff) {
+    gROOT->cd();
+  } else {
+    theD->cd();
   }
 
-  if (a==use && !madeFromCff ){gROOT->cd();}
-  else {theD->cd();}
+  for (int i = 0; i != 5; i++) {
+    for (int j = i; j != 5; j++) {
+      TString pfname(Form("pf3_V%1d%1d", i + 1, j + 1));
+      TProfile3D *pf = nullptr;
+      if (a == use && !madeFromCff) {
+        //read from the rootfile
+        edm::LogVerbatim(theCategory) << "getting " << pfname << " from " << fileName;
+        pf = (TProfile3D *)theD->Get(pfname);
+        theData[Pindex(i, j)] = pf;
+        theData_fast[i][j] = pf;
+        theData_fast[j][i] = pf;
+      } else {
+        //	  curvilinear coordinate system
+        //need to make some input parameter to be to change the number of bins
 
-  for (int i=0;i!=5;i++){for (int j=i;j!=5;j++){
-      TString pfname(Form("pf3_V%1d%1d",i+1,j+1));
-      TProfile3D * pf =nullptr;
-      if (a==use && !madeFromCff ){
-	//read from the rootfile
-	edm::LogVerbatim(theCategory)<<"getting "<<pfname<<" from "<<fileName;
-	pf = (TProfile3D *)theD->Get(pfname);
-	theData[Pindex(i,j)]=pf;
-	theData_fast[i][j]=pf;	  theData_fast[j][i]=pf;
+        TString pftitle;
+        if (i == j) {
+          pftitle = "#sigma_{" + vars[i] + "}";
+        } else {
+          pftitle = "#rho(" + vars[i] + "," + vars[j] + ")";
+        }
+        edm::LogVerbatim(theCategory) << "booking " << pfname << " into " << fileName;
+        pf = new TProfile3D(pfname, pftitle, NPt, minPt, maxPt, NEta, minEta, maxEta, NPhi, minPhi, maxPhi, "S");
+        pf->SetXTitle("muon p_{T} [GeV]");
+        pf->SetYTitle("muon |#eta|");
+        pf->SetZTitle("muon #varphi");
+
+        //set variable size binning
+        if (xBinsArray) {
+          pf->GetXaxis()->Set(NPt, xBinsArray);
+        }
+        if (yBinsArray) {
+          pf->GetYaxis()->Set(NEta, yBinsArray);
+        }
+
+        if (madeFromCff) {
+          edm::ParameterSet pSet = errorMatrixValuesPSet.getParameter<edm::ParameterSet>(pfname.Data());
+          //set the values from the configuration file itself
+          std::vector<double> values = pSet.getParameter<std::vector<double> >("values");
+          unsigned int iX = pf->GetNbinsX();
+          unsigned int iY = pf->GetNbinsY();
+          unsigned int iZ = pf->GetNbinsZ();
+          unsigned int continuous_i = 0;
+          for (unsigned int ix = 1; ix <= iX; ++ix) {
+            for (unsigned int iy = 1; iy <= iY; ++iy) {
+              for (unsigned int iz = 1; iz <= iZ; ++iz) {
+                LogTrace(theCategory) << "filling profile:"
+                                      << "\n pt (x)= " << pf->GetXaxis()->GetBinCenter(ix)
+                                      << "\n eta (y)= " << pf->GetYaxis()->GetBinCenter(iy)
+                                      << "\n phi (z)= " << pf->GetZaxis()->GetBinCenter(iz)
+                                      << "\n value= " << values[continuous_i];
+                pf->Fill(pf->GetXaxis()->GetBinCenter(ix),
+                         pf->GetYaxis()->GetBinCenter(iy),
+                         pf->GetZaxis()->GetBinCenter(iz),
+                         values[continuous_i++]);
+              }
+            }
+          }
+          //term action
+          std::string tAction = pSet.getParameter<std::string>("action");
+          if (tAction == "scale")
+            theTermAction[Pindex(i, j)] = scale;
+          else if (tAction == "assign")
+            theTermAction[Pindex(i, j)] = assign;
+          else {
+            edm::LogError(theCategory) << " wrong configuration: term action: " << tAction << " is not recognized.";
+            theTermAction[Pindex(i, j)] = error;
+          }
+        }
       }
-      else{
-	//	  curvilinear coordinate system
-	//need to make some input parameter to be to change the number of bins
 
-	TString pftitle;
-	if (i==j){pftitle="#sigma_{"+vars[i]+"}";}
-	else{pftitle="#rho("+vars[i]+","+vars[j]+")";}
-	edm::LogVerbatim(theCategory)<<"booking "<<pfname<<" into "<<fileName;
-	pf = new TProfile3D(pfname,pftitle,NPt,minPt,maxPt,NEta,minEta,maxEta,NPhi,minPhi,maxPhi,"S");	    
-	pf->SetXTitle("muon p_{T} [GeV]");
-	pf->SetYTitle("muon |#eta|");
-	pf->SetZTitle("muon #varphi");
-
-	//set variable size binning
-	if (xBinsArray){
-	  pf->GetXaxis()->Set(NPt,xBinsArray);}
-	if (yBinsArray){
-	  pf->GetYaxis()->Set(NEta,yBinsArray);}
-
-	if (madeFromCff){
-	  edm::ParameterSet pSet = errorMatrixValuesPSet.getParameter<edm::ParameterSet>(pfname.Data());
-	  //set the values from the configuration file itself
-	  std::vector<double> values = pSet.getParameter<std::vector<double> >("values");
-	  unsigned int iX=pf->GetNbinsX();
-	  unsigned int iY=pf->GetNbinsY();
-	  unsigned int iZ=pf->GetNbinsZ();
-	  unsigned int continuous_i=0;
-	  for(unsigned int ix=1;ix<=iX;++ix){
-	    for(unsigned int iy=1;iy<=iY;++iy){
-	      for(unsigned int iz=1;iz<=iZ;++iz){
-		LogTrace(theCategory)<<"filling profile:"
-				     <<"\n pt (x)= "<<pf->GetXaxis()->GetBinCenter(ix)
-				     <<"\n eta (y)= "<<pf->GetYaxis()->GetBinCenter(iy)
-				     <<"\n phi (z)= "<<pf->GetZaxis()->GetBinCenter(iz)
-				     <<"\n value= "<<values[continuous_i];
-		pf->Fill(pf->GetXaxis()->GetBinCenter(ix),
-			 pf->GetYaxis()->GetBinCenter(iy),
-			 pf->GetZaxis()->GetBinCenter(iz),
-			 values[continuous_i++]);
-	      }}}
-	  //term action
-	  std::string tAction = pSet.getParameter<std::string>("action");
-	  if (tAction == "scale")
-	    theTermAction[Pindex(i,j)] = scale;
-	  else if (tAction == "assign")
-	    theTermAction[Pindex(i,j)] = assign;
-	  else{
-	    edm::LogError(theCategory)<<" wrong configuration: term action: "<<tAction<<" is not recognized.";
-	    theTermAction[Pindex(i,j)] = error;
-	  }
-	  
-	}
+      LogDebug(theCategory) << " index " << i << ":" << j << " -> " << Pindex(i, j);
+      theData[Pindex(i, j)] = pf;
+      theData_fast[i][j] = pf;
+      theData_fast[j][i] = pf;
+      if (!pf) {
+        edm::LogError(theCategory) << " profile " << pfname << " in file " << fileName << " is not valid. exiting.";
+        exit(1);
       }
+    }
+  }
 
-      LogDebug(theCategory)<<" index "<<i<<":"<<j<<" -> "<<Pindex(i,j);
-      theData[Pindex(i,j)]=pf;
-      theData_fast[i][j]=pf;	  theData_fast[j][i]=pf;
-      if (!pf){
-	edm::LogError(theCategory)<<" profile "<<pfname<<" in file "<<fileName<<" is not valid. exiting.";
-	exit(1);
-      }
-    }}
-    
   //verify it
-  for (int i=0;i!=15;i++){ 
-    if (theData[i]) {edm::LogVerbatim(theCategory)<<i<<" :"<<theData[i]->GetName()
-						  <<" "<< theData[i]->GetTitle()<<std::endl;}}
- 
+  for (int i = 0; i != 15; i++) {
+    if (theData[i]) {
+      edm::LogVerbatim(theCategory) << i << " :" << theData[i]->GetName() << " " << theData[i]->GetTitle() << std::endl;
+    }
+  }
 }
 
 //void MuonErrorMatrix::writeIntoCFF(){}
 
-void MuonErrorMatrix::close(){
+void MuonErrorMatrix::close() {
   //close the file
-  if (theD){
+  if (theD) {
     theD->cd();
     //write to it first if constructor
-    if (theD->IsWritable()){
-      for (int i=0;i!=15;i++){ if (theData[i]) { theData[i]->Write();}}}
+    if (theD->IsWritable()) {
+      for (int i = 0; i != 15; i++) {
+        if (theData[i]) {
+          theData[i]->Write();
+        }
+      }
+    }
     theD->Close();
-  }}
-
-MuonErrorMatrix::~MuonErrorMatrix()  {
-  close();
+  }
 }
 
+MuonErrorMatrix::~MuonErrorMatrix() { close(); }
 
-
-CurvilinearTrajectoryError MuonErrorMatrix::get(GlobalVector momentum,bool convolute)  {
+CurvilinearTrajectoryError MuonErrorMatrix::get(GlobalVector momentum, bool convolute) {
   AlgebraicSymMatrix55 V;
   //retrieves a 55 matrix containing (i,i)^2 and (i,j)*(i,i)*(j,j)
-  for (int i=0;i!=5;i++){for (int j=i;j!=5;j++){
-      V(i,j) = Value(momentum,i,j,convolute);}}
-  return CurvilinearTrajectoryError(V);}
+  for (int i = 0; i != 5; i++) {
+    for (int j = i; j != 5; j++) {
+      V(i, j) = Value(momentum, i, j, convolute);
+    }
+  }
+  return CurvilinearTrajectoryError(V);
+}
 
 CurvilinearTrajectoryError MuonErrorMatrix::getFast(GlobalVector momentum) {
   //will be faster but make assumptions that could be broken at some point
@@ -245,31 +276,33 @@ CurvilinearTrajectoryError MuonErrorMatrix::getFast(GlobalVector momentum) {
   double phi = momentum.phi();
 
   //assume all the same axis in X,Y,Z
-  int iBin_x= findBin(theData_fast[0][0]->GetXaxis(),pT);
-  int iBin_y= findBin(theData_fast[0][0]->GetYaxis(),eta);
-  int iBin_z= findBin(theData_fast[0][0]->GetZaxis(),phi);
+  int iBin_x = findBin(theData_fast[0][0]->GetXaxis(), pT);
+  int iBin_y = findBin(theData_fast[0][0]->GetYaxis(), eta);
+  int iBin_z = findBin(theData_fast[0][0]->GetZaxis(), phi);
 
   //retreive values
-  double values[5][5]; //sigma_i and rho_ij
-  for (int i=0;i!=5;i++){for (int j=i;j!=5;j++){
-      values[i][j]=theData_fast[i][j]->GetBinContent(iBin_x, iBin_y, iBin_z);
-    }}
+  double values[5][5];  //sigma_i and rho_ij
+  for (int i = 0; i != 5; i++) {
+    for (int j = i; j != 5; j++) {
+      values[i][j] = theData_fast[i][j]->GetBinContent(iBin_x, iBin_y, iBin_z);
+    }
+  }
 
-  for (int i=0;i!=5;i++){for (int j=i;j!=5;j++){
-      if (i==j){
+  for (int i = 0; i != 5; i++) {
+    for (int j = i; j != 5; j++) {
+      if (i == j) {
         //sigma_i * sigma_i
-        V(i,j) = values[i][j];
-        V(i,j)*=V(i,j);
-      }
-      else{
+        V(i, j) = values[i][j];
+        V(i, j) *= V(i, j);
+      } else {
         //sigma_i * sigma_j * rho_ij
-        V(i,j) = values[i][i] * values[j][j] * values[i][j];
+        V(i, j) = values[i][i] * values[j][j] * values[i][j];
       }
-    }}
+    }
+  }
 
-  return CurvilinearTrajectoryError(V);}
-
-
+  return CurvilinearTrajectoryError(V);
+}
 
 /*CurvilinearTrajectoryError MuonErrorMatrix::get_random(GlobalVector momentum)  { 
   static TRandom2 rand;
@@ -286,246 +319,259 @@ CurvilinearTrajectoryError MuonErrorMatrix::getFast(GlobalVector momentum) {
       return CurvilinearTrajectoryError(V);  }
 */
 
-int MuonErrorMatrix::findBin(TAxis * axis, double value){
+int MuonErrorMatrix::findBin(TAxis *axis, double value) {
   //find the proper bin, protecting against under/over flow
   int result = axis->FindBin(value);
-  if (result <= 0) result=1; //protect against under flow
-  else if (result > axis->GetNbins() ) result = axis->GetNbins();
-  return result;}
-
-
-double MuonErrorMatrix::Value(GlobalVector & momentum, int i, int j,bool convolute)  {
-  double result=0;
-  TProfile3D * ij = Index(i,j);
-  if (!ij) {edm::LogError(theCategory)<<"cannot get the profile ("<<i<<":"<<j<<")"; return result;}
-  
-  double pT = momentum.perp();
-  double eta = fabs(momentum.eta());
-  double phi = momentum.phi();
-
-  int iBin_x= findBin(ij->GetXaxis(),pT);
-  int iBin_y= findBin(ij->GetYaxis(),eta);
-  int iBin_z= findBin(ij->GetZaxis(),phi);
-
-  if (convolute){
-  if (i!=j){
-    //return the covariance = correlation*sigma_1 *sigma_2;
-    TProfile3D * ii = Index(i,i);
-    TProfile3D * jj = Index(j,j);
-    if (!ii){edm::LogError(theCategory)<<"cannot get the profile ("<<i<<":"<<i<<")"; return result;}
-    if (!jj){edm::LogError(theCategory)<<"cannot get the profile ("<<j<<":"<<j<<")"; return result;}
-
-
-    int iBin_i_x = findBin(ii->GetXaxis(),pT);
-    int iBin_i_y = findBin(ii->GetYaxis(),eta);
-    int iBin_i_z = findBin(ii->GetZaxis(),phi);
-    int iBin_j_x = findBin(jj->GetXaxis(),pT);
-    int iBin_j_y = findBin(jj->GetYaxis(),eta);
-    int iBin_j_z = findBin(jj->GetZaxis(),phi);
-
-    double corr = ij->GetBinContent(iBin_x,iBin_y,iBin_z);
-    double sigma_1 = (ii->GetBinContent(iBin_i_x,iBin_i_y,iBin_i_z));
-    double sigma_2 = (jj->GetBinContent(iBin_j_x,iBin_j_y,iBin_j_z));
-
-    
-    result=corr*sigma_1*sigma_2;
-    LogDebug(theCategory)<<"for: (pT,eta,phi)=("<<pT<<", "<<eta<<", "<<phi<<") nterms are"
-			 <<"\nrho["<<i<<","<<j<<"]: "<<corr<<" ["<< iBin_x<<", "<<iBin_y<<", "<<iBin_z<<"]"
-			 <<"\nsigma["<<i<<","<<i<<"]: "<< sigma_1
-			 <<"\nsigma["<<j<<","<<j<<"]: "<< sigma_2
-			 <<"Covariance["<<i<<","<<j<<"] is: "<<result;
-    return result;
-  }
-  else{
-    //return the variance = sigma_1 **2
-    //    result=ij->GetBinContent(iBin);
-    result=ij->GetBinContent(iBin_x,iBin_y,iBin_z);
-    result*=result;
-    LogDebug(theCategory)<<"for: (pT,eta,phi)=("<<pT<<", "<<eta<<", "<<phi<<") sigma^2["<<i<<","<<j<<"] is: "<<result;
-    return result;
-  }
-  }else{
-    //do not convolute
-    result=ij->GetBinContent(iBin_x,iBin_y,iBin_z);
-    return result;
-  }
-}
-
-double MuonErrorMatrix::Rms(GlobalVector & momentum, int i, int j)  {
-  double result=0;
-  TProfile3D * ij = Index(i,j);
-  if (!ij){edm::LogError(theCategory)<<"cannot get the profile ("<<i<<":"<<i<<")"; return result;} 
-  double pT = momentum.perp();
-  double eta = fabs(momentum.eta());
-  double phi = momentum.phi();
-  
-  int iBin_x= ij->GetXaxis()->FindBin(pT);
-  int iBin_y= ij->GetYaxis()->FindBin(eta);
-  int iBin_z= ij->GetZaxis()->FindBin(phi);
-  result=ij->GetBinError(iBin_x,iBin_y,iBin_z);
-
-  LogDebug(theCategory)<<"for: (pT,eta,phi)=("<<pT<<", "<<eta<<", "<<phi<<") error["<<i<<","<<j<<"] is: "<<result;
+  if (result <= 0)
+    result = 1;  //protect against under flow
+  else if (result > axis->GetNbins())
+    result = axis->GetNbins();
   return result;
 }
 
-double MuonErrorMatrix::Term(const AlgebraicSymMatrix55 & curv, int i, int j){
+double MuonErrorMatrix::Value(GlobalVector &momentum, int i, int j, bool convolute) {
+  double result = 0;
+  TProfile3D *ij = Index(i, j);
+  if (!ij) {
+    edm::LogError(theCategory) << "cannot get the profile (" << i << ":" << j << ")";
+    return result;
+  }
+
+  double pT = momentum.perp();
+  double eta = fabs(momentum.eta());
+  double phi = momentum.phi();
+
+  int iBin_x = findBin(ij->GetXaxis(), pT);
+  int iBin_y = findBin(ij->GetYaxis(), eta);
+  int iBin_z = findBin(ij->GetZaxis(), phi);
+
+  if (convolute) {
+    if (i != j) {
+      //return the covariance = correlation*sigma_1 *sigma_2;
+      TProfile3D *ii = Index(i, i);
+      TProfile3D *jj = Index(j, j);
+      if (!ii) {
+        edm::LogError(theCategory) << "cannot get the profile (" << i << ":" << i << ")";
+        return result;
+      }
+      if (!jj) {
+        edm::LogError(theCategory) << "cannot get the profile (" << j << ":" << j << ")";
+        return result;
+      }
+
+      int iBin_i_x = findBin(ii->GetXaxis(), pT);
+      int iBin_i_y = findBin(ii->GetYaxis(), eta);
+      int iBin_i_z = findBin(ii->GetZaxis(), phi);
+      int iBin_j_x = findBin(jj->GetXaxis(), pT);
+      int iBin_j_y = findBin(jj->GetYaxis(), eta);
+      int iBin_j_z = findBin(jj->GetZaxis(), phi);
+
+      double corr = ij->GetBinContent(iBin_x, iBin_y, iBin_z);
+      double sigma_1 = (ii->GetBinContent(iBin_i_x, iBin_i_y, iBin_i_z));
+      double sigma_2 = (jj->GetBinContent(iBin_j_x, iBin_j_y, iBin_j_z));
+
+      result = corr * sigma_1 * sigma_2;
+      LogDebug(theCategory) << "for: (pT,eta,phi)=(" << pT << ", " << eta << ", " << phi << ") nterms are"
+                            << "\nrho[" << i << "," << j << "]: " << corr << " [" << iBin_x << ", " << iBin_y << ", "
+                            << iBin_z << "]"
+                            << "\nsigma[" << i << "," << i << "]: " << sigma_1 << "\nsigma[" << j << "," << j
+                            << "]: " << sigma_2 << "Covariance[" << i << "," << j << "] is: " << result;
+      return result;
+    } else {
+      //return the variance = sigma_1 **2
+      //    result=ij->GetBinContent(iBin);
+      result = ij->GetBinContent(iBin_x, iBin_y, iBin_z);
+      result *= result;
+      LogDebug(theCategory) << "for: (pT,eta,phi)=(" << pT << ", " << eta << ", " << phi << ") sigma^2[" << i << ","
+                            << j << "] is: " << result;
+      return result;
+    }
+  } else {
+    //do not convolute
+    result = ij->GetBinContent(iBin_x, iBin_y, iBin_z);
+    return result;
+  }
+}
+
+double MuonErrorMatrix::Rms(GlobalVector &momentum, int i, int j) {
+  double result = 0;
+  TProfile3D *ij = Index(i, j);
+  if (!ij) {
+    edm::LogError(theCategory) << "cannot get the profile (" << i << ":" << i << ")";
+    return result;
+  }
+  double pT = momentum.perp();
+  double eta = fabs(momentum.eta());
+  double phi = momentum.phi();
+
+  int iBin_x = ij->GetXaxis()->FindBin(pT);
+  int iBin_y = ij->GetYaxis()->FindBin(eta);
+  int iBin_z = ij->GetZaxis()->FindBin(phi);
+  result = ij->GetBinError(iBin_x, iBin_y, iBin_z);
+
+  LogDebug(theCategory) << "for: (pT,eta,phi)=(" << pT << ", " << eta << ", " << phi << ") error[" << i << "," << j
+                        << "] is: " << result;
+  return result;
+}
+
+double MuonErrorMatrix::Term(const AlgebraicSymMatrix55 &curv, int i, int j) {
   //return sigma or correlation factor
-  double result=0;
-  if (i==j){
-    result = curv(i,j);
-    if (result<0){
+  double result = 0;
+  if (i == j) {
+    result = curv(i, j);
+    if (result < 0) {
       //check validity of this guy
-      edm::LogError("MuonErrorMatrix")<<"invalid term in the error matrix.\n sii: "<< result;
-      return 0;}
-    return sqrt(result);}
-  else{
-    double si = curv(i,i);
-    double sj = curv(j,j);
+      edm::LogError("MuonErrorMatrix") << "invalid term in the error matrix.\n sii: " << result;
+      return 0;
+    }
+    return sqrt(result);
+  } else {
+    double si = curv(i, i);
+    double sj = curv(j, j);
 
-    if (si<=0 || sj<=0){
-      edm::LogError("MuonErrorMatrix")<<"invalid term in the error matrix.\n si: "
-				<<si<<" sj: "<<sj<<". result will be corrupted\n"<<curv;
-      return 0;}
+    if (si <= 0 || sj <= 0) {
+      edm::LogError("MuonErrorMatrix") << "invalid term in the error matrix.\n si: " << si << " sj: " << sj
+                                       << ". result will be corrupted\n"
+                                       << curv;
+      return 0;
+    }
 
-    si=sqrt(si);
-    sj=sqrt(sj);
+    si = sqrt(si);
+    sj = sqrt(sj);
     //check validity
 
-    return result = curv(i,j)/(si*sj);}
+    return result = curv(i, j) / (si * sj);
+  }
   //by default
   return 0;
 }
 
-
-void MuonErrorMatrix::multiply(CurvilinearTrajectoryError & initial_error, const CurvilinearTrajectoryError & scale_error){
+void MuonErrorMatrix::multiply(CurvilinearTrajectoryError &initial_error,
+                               const CurvilinearTrajectoryError &scale_error) {
   //scale term by term the matrix
-  const AlgebraicSymMatrix55 & scale_matrix=scale_error.matrix();
+  const AlgebraicSymMatrix55 &scale_matrix = scale_error.matrix();
   AlgebraicSymMatrix55 revised_matrix = initial_error.matrix();
   // the true type of the matrix is such that [i][j] is the same memory object as [j][i]: looping i:0-5, j:0-5 double multiply the terms
   // need to loop only on i:0-5, j:i-5
-  for(int i = 0;i!=5;i++){for(int j = i;j!=5;j++){
-      revised_matrix(i,j)*=scale_matrix(i,j);
-    }}
+  for (int i = 0; i != 5; i++) {
+    for (int j = i; j != 5; j++) {
+      revised_matrix(i, j) *= scale_matrix(i, j);
+    }
+  }
   initial_error = CurvilinearTrajectoryError(revised_matrix);
 }
-bool MuonErrorMatrix::divide(CurvilinearTrajectoryError & num_error, const CurvilinearTrajectoryError & denom_error){
+bool MuonErrorMatrix::divide(CurvilinearTrajectoryError &num_error, const CurvilinearTrajectoryError &denom_error) {
   //divide term by term the matrix
-  const AlgebraicSymMatrix55 & denom_matrix=denom_error.matrix();
+  const AlgebraicSymMatrix55 &denom_matrix = denom_error.matrix();
   AlgebraicSymMatrix55 num_matrix = num_error.matrix();
   // the true type of the matrix is such that [i][j] is the same memory object as [j][i]: looping i:0-5, j:0-5 double multiply the terms
   // need to loop only on i:0-5, j:i-5
-  for(int i = 0;i!=5;i++){for(int j = i;j!=5;j++){
-      if (denom_matrix(i,j)==0) return false;
-      num_matrix(i,j)/=denom_matrix(i,j);
-    }}
+  for (int i = 0; i != 5; i++) {
+    for (int j = i; j != 5; j++) {
+      if (denom_matrix(i, j) == 0)
+        return false;
+      num_matrix(i, j) /= denom_matrix(i, j);
+    }
+  }
   num_error = CurvilinearTrajectoryError(num_matrix);
   return true;
 }
 
-void MuonErrorMatrix::simpleTerm(const AlgebraicSymMatrix55 & input, AlgebraicSymMatrix55 & output){
-  for(int i = 0;i!=5;i++){for(int j = i;j!=5;j++){
-      if (i==j)
-	output(i,j) = sqrt(input(i,j)); //sigma
+void MuonErrorMatrix::simpleTerm(const AlgebraicSymMatrix55 &input, AlgebraicSymMatrix55 &output) {
+  for (int i = 0; i != 5; i++) {
+    for (int j = i; j != 5; j++) {
+      if (i == j)
+        output(i, j) = sqrt(input(i, j));  //sigma
       else
-	output(i,j) = input(i,j) / sqrt( input(i,i)* input(j,j)); //rho
-    }}
+        output(i, j) = input(i, j) / sqrt(input(i, i) * input(j, j));  //rho
+    }
+  }
 }
 
-void MuonErrorMatrix::complicatedTerm(const AlgebraicSymMatrix55 & input, AlgebraicSymMatrix55 & output){
-
-  for(int i = 0;i!=5;i++){for(int j = i;j!=5;j++){
-      if (i==j)
-	output(i,j) = input(i,j)*input(i,j); //sigma squared
+void MuonErrorMatrix::complicatedTerm(const AlgebraicSymMatrix55 &input, AlgebraicSymMatrix55 &output) {
+  for (int i = 0; i != 5; i++) {
+    for (int j = i; j != 5; j++) {
+      if (i == j)
+        output(i, j) = input(i, j) * input(i, j);  //sigma squared
       else
-	output(i,j) = input(i,j)*input(i,i)*input(j,j); //rho*sigma*sigma
-    }}
+        output(i, j) = input(i, j) * input(i, i) * input(j, j);  //rho*sigma*sigma
+    }
+  }
 }
 
-
-
-void MuonErrorMatrix::adjust(FreeTrajectoryState & state){
-
-  LogDebug(theCategory+"|Adjust")<<"state: \n"<<state;
+void MuonErrorMatrix::adjust(FreeTrajectoryState &state) {
+  LogDebug(theCategory + "|Adjust") << "state: \n" << state;
   AlgebraicSymMatrix55 simpleTerms;
   simpleTerm(state.curvilinearError(), simpleTerms);
   //the above contains sigma(i), rho(i,j)
-  LogDebug(theCategory+"|Adjust")<<"state sigma(i), rho(i,j): \n"<<simpleTerms;
+  LogDebug(theCategory + "|Adjust") << "state sigma(i), rho(i,j): \n" << simpleTerms;
 
-  AlgebraicSymMatrix55 simpleValues=get(state.momentum(),false).matrix();
-  LogDebug(theCategory+"|Adjust")<<"config: (i,i), (i,j): \n"<<simpleValues;
+  AlgebraicSymMatrix55 simpleValues = get(state.momentum(), false).matrix();
+  LogDebug(theCategory + "|Adjust") << "config: (i,i), (i,j): \n" << simpleValues;
 
-  for(int i = 0;i!=5;i++){for(int j = i;j!=5;j++){
+  for (int i = 0; i != 5; i++) {
+    for (int j = i; j != 5; j++) {
       //check on each term for desired action
-      switch(theTermAction[Pindex(i,j)]){
-      case scale: 
-	{
-	  simpleTerms(i,j) *= simpleValues(i,j);
-	  break;
-	}
-      case assign:
-	{
-	  simpleTerms(i,j) = simpleValues(i,j);
-	  break;
-	}
-      case error:
-	{
-	  edm::LogError(theCategory+"|Adjust")<<" cannot properly adjust for term: "<<i <<","<<j;
-	}
+      switch (theTermAction[Pindex(i, j)]) {
+        case scale: {
+          simpleTerms(i, j) *= simpleValues(i, j);
+          break;
+        }
+        case assign: {
+          simpleTerms(i, j) = simpleValues(i, j);
+          break;
+        }
+        case error: {
+          edm::LogError(theCategory + "|Adjust") << " cannot properly adjust for term: " << i << "," << j;
+        }
       }
-    }}
-  LogDebug(theCategory+"|Adjust")<<"updated state sigma(i), rho(i,j): \n"<<simpleTerms;
+    }
+  }
+  LogDebug(theCategory + "|Adjust") << "updated state sigma(i), rho(i,j): \n" << simpleTerms;
 
   AlgebraicSymMatrix55 finalTerms;
   complicatedTerm(simpleTerms, finalTerms);
-  LogDebug(theCategory+"|Adjust")<<"updated state COV(i,j): \n"<<finalTerms;  
-  
+  LogDebug(theCategory + "|Adjust") << "updated state COV(i,j): \n" << finalTerms;
+
   CurvilinearTrajectoryError oMat(finalTerms);
   state = FreeTrajectoryState(state.parameters(), oMat);
-  LogDebug(theCategory+"|Adjust")<<"updated state:\n"<<state;
+  LogDebug(theCategory + "|Adjust") << "updated state:\n" << state;
 }
 
-
-
-void MuonErrorMatrix::adjust(TrajectoryStateOnSurface & state){
-
+void MuonErrorMatrix::adjust(TrajectoryStateOnSurface &state) {
   AlgebraicSymMatrix55 simpleTerms;
   simpleTerm(state.curvilinearError(), simpleTerms);
-  LogDebug(theCategory+"|Adjust")<<"state sigma(i), rho(i,j): \n"<<simpleTerms;
+  LogDebug(theCategory + "|Adjust") << "state sigma(i), rho(i,j): \n" << simpleTerms;
 
-  AlgebraicSymMatrix55 simpleValues= get(state.globalMomentum(),false).matrix();
-  LogDebug(theCategory+"|Adjust")<<"config: (i,i), (i,j):\n"<<simpleValues;
+  AlgebraicSymMatrix55 simpleValues = get(state.globalMomentum(), false).matrix();
+  LogDebug(theCategory + "|Adjust") << "config: (i,i), (i,j):\n" << simpleValues;
 
-  for(int i = 0;i!=5;i++){for(int j = i;j!=5;j++){
+  for (int i = 0; i != 5; i++) {
+    for (int j = i; j != 5; j++) {
       //check on each term for desired action
-      switch(theTermAction[Pindex(i,j)]){
-      case scale: 
-	{
-	  simpleTerms(i,j) *= simpleValues(i,j);
-	  break;
-	}
-      case assign:
-	{
-	  simpleTerms(i,j) = simpleValues(i,j);
-	  break;
-	}
-      case error:
-	{
-	  edm::LogError(theCategory+"|Adjust")<<" cannot properly adjust for term: "<<i <<","<<j;
-	}
+      switch (theTermAction[Pindex(i, j)]) {
+        case scale: {
+          simpleTerms(i, j) *= simpleValues(i, j);
+          break;
+        }
+        case assign: {
+          simpleTerms(i, j) = simpleValues(i, j);
+          break;
+        }
+        case error: {
+          edm::LogError(theCategory + "|Adjust") << " cannot properly adjust for term: " << i << "," << j;
+        }
       }
-    }}
-  LogDebug(theCategory+"|Adjust")<<"updated state sigma(i), rho(i,j): \n"<<simpleTerms;
+    }
+  }
+  LogDebug(theCategory + "|Adjust") << "updated state sigma(i), rho(i,j): \n" << simpleTerms;
 
   AlgebraicSymMatrix55 finalTerms;
   complicatedTerm(simpleTerms, finalTerms);
-  LogDebug(theCategory+"|Adjust")<<"updated state COV(i,j): \n"<<finalTerms;  
+  LogDebug(theCategory + "|Adjust") << "updated state COV(i,j): \n" << finalTerms;
 
   CurvilinearTrajectoryError oMat(finalTerms);
-  state = TrajectoryStateOnSurface(state.weight(),
-                                   state.globalParameters(),
-				   oMat,
-				   state.surface(),
-				   state.surfaceSide()
-				  );
-  LogDebug(theCategory+"|Adjust")<<"updated state:\n"<<state;
+  state =
+      TrajectoryStateOnSurface(state.weight(), state.globalParameters(), oMat, state.surface(), state.surfaceSide());
+  LogDebug(theCategory + "|Adjust") << "updated state:\n" << state;
 }

--- a/RecoMuon/TrackingTools/src/MuonPatternRecoDumper.cc
+++ b/RecoMuon/TrackingTools/src/MuonPatternRecoDumper.cc
@@ -1,5 +1,5 @@
 
-// This Class Header 
+// This Class Header
 #include "RecoMuon/TrackingTools/interface/MuonPatternRecoDumper.h"
 
 // Collaborating Class Header
@@ -19,81 +19,71 @@
 
 using namespace std;
 
-// Constructor 
-MuonPatternRecoDumper::MuonPatternRecoDumper() {
-}
+// Constructor
+MuonPatternRecoDumper::MuonPatternRecoDumper() {}
 
 // Destructor
-MuonPatternRecoDumper::~MuonPatternRecoDumper() {
-}
+MuonPatternRecoDumper::~MuonPatternRecoDumper() {}
 
 // Operations
 
 string MuonPatternRecoDumper::dumpLayer(const DetLayer* layer) const {
   stringstream output;
-  
-  const BoundSurface* sur=nullptr;
-  const BoundCylinder* bc=nullptr;
-  const BoundDisk* bd=nullptr;
+
+  const BoundSurface* sur = nullptr;
+  const BoundCylinder* bc = nullptr;
+  const BoundDisk* bd = nullptr;
 
   sur = &(layer->surface());
-  if ( (bc = dynamic_cast<const BoundCylinder*>(sur)) ) {
+  if ((bc = dynamic_cast<const BoundCylinder*>(sur))) {
     output << "  Cylinder of radius: " << bc->radius() << endl;
-  }
-  else if ( (bd = dynamic_cast<const BoundDisk*>(sur)) ) {
-    output << "  Disk at: " <<  bd->position().z() << endl;
+  } else if ((bd = dynamic_cast<const BoundDisk*>(sur))) {
+    output << "  Disk at: " << bd->position().z() << endl;
   }
   return output.str();
 }
 
 string MuonPatternRecoDumper::dumpFTS(const FreeTrajectoryState& fts) const {
   stringstream output;
-  
-  output  << 
-    " pos: " << fts.position() << 
-    " radius: " << fts.position().perp() << endl << 
-    " charge*pt: " << fts.momentum().perp()*fts.parameters().charge() <<
-    " eta: " << fts.momentum().eta() <<
-    " phi: " << fts.momentum().phi() << endl;
+
+  output << " pos: " << fts.position() << " radius: " << fts.position().perp() << endl
+         << " charge*pt: " << fts.momentum().perp() * fts.parameters().charge() << " eta: " << fts.momentum().eta()
+         << " phi: " << fts.momentum().phi() << endl;
 
   return output.str();
 }
 
-string MuonPatternRecoDumper::dumpTSOS(const TrajectoryStateOnSurface& tsos) const{
+string MuonPatternRecoDumper::dumpTSOS(const TrajectoryStateOnSurface& tsos) const {
   stringstream output;
-  
-  output<<tsos<<endl;
-  output<<"dir: "<<tsos.globalDirection()<<endl;
-  output<<dumpFTS(*tsos.freeTrajectoryState());
+
+  output << tsos << endl;
+  output << "dir: " << tsos.globalDirection() << endl;
+  output << dumpFTS(*tsos.freeTrajectoryState());
 
   return output.str();
 }
 
-string MuonPatternRecoDumper::dumpMuonId(const DetId &id) const{
+string MuonPatternRecoDumper::dumpMuonId(const DetId& id) const {
   stringstream output;
-  
-  if(id.subdetId() == MuonSubdetId::DT ){
+
+  if (id.subdetId() == MuonSubdetId::DT) {
     DTWireId wireId(id.rawId());
 
-    output<<"(DT): "<<wireId<<endl;  
-  }
-  else if(id.subdetId() == MuonSubdetId::CSC){
+    output << "(DT): " << wireId << endl;
+  } else if (id.subdetId() == MuonSubdetId::CSC) {
     CSCDetId chamberId(id.rawId());
-    output<<"(CSC): "<<chamberId<<endl;  
-  }
-  else if(id.subdetId() == MuonSubdetId::GEM){
+    output << "(CSC): " << chamberId << endl;
+  } else if (id.subdetId() == MuonSubdetId::GEM) {
     GEMDetId chamberId(id.rawId());
-    output<<"(GEM): "<<chamberId<<endl;  
-  }
-  else if(id.subdetId() == MuonSubdetId::ME0){
+    output << "(GEM): " << chamberId << endl;
+  } else if (id.subdetId() == MuonSubdetId::ME0) {
     ME0DetId chamberId(id.rawId());
-    output<<"(ME0): "<<chamberId<<endl;  
-  }
-  else if(id.subdetId() == MuonSubdetId::RPC){
+    output << "(ME0): " << chamberId << endl;
+  } else if (id.subdetId() == MuonSubdetId::RPC) {
     RPCDetId chamberId(id.rawId());
-    output<<"(RPC): "<<chamberId<<endl;  
-  }
-  else output<<"The DetLayer is not a valid Muon DetLayer. ";
+    output << "(RPC): " << chamberId << endl;
+  } else
+    output << "The DetLayer is not a valid Muon DetLayer. ";
 
   return output.str();
 }

--- a/RecoMuon/TrackingTools/src/MuonTrackLoader.cc
+++ b/RecoMuon/TrackingTools/src/MuonTrackLoader.cc
@@ -39,73 +39,69 @@
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/Traj2TrackHits.h"
 
-
 using namespace edm;
 using namespace std;
 using namespace reco;
 
-std::vector<const TrackingRecHit*> MuonTrackLoader::unpackHit(const TrackingRecHit &hit)
-{
-    // get rec hit det id and rec hit type
-    DetId id = hit.geographicalId();
-    uint16_t detid = id.det();
+std::vector<const TrackingRecHit*> MuonTrackLoader::unpackHit(const TrackingRecHit& hit) {
+  // get rec hit det id and rec hit type
+  DetId id = hit.geographicalId();
+  uint16_t detid = id.det();
 
-    std::vector<const TrackingRecHit*> hits;
+  std::vector<const TrackingRecHit*> hits;
 
-    if (detid == DetId::Tracker) {
-    	hits.push_back(&hit);
-    } else if (detid == DetId::Muon) {
-        uint16_t subdet = id.subdetId();
-        if (subdet == (uint16_t) MuonSubdetId::DT) {
-            if (hit.dimension() == 1) { // DT rechit (granularity 2)
-                hits.push_back(&hit);
-            } else if (hit.dimension() > 1) { // 4D segment (granularity 0).
-                // Both 2 and 4 dim cases. MB4s have 2D, but formatted in 4D segment
-                // 4D --> 2D
-                std::vector<const TrackingRecHit*> seg2D = hit.recHits();
-                // load 1D hits (2D --> 1D)
-                for (std::vector<const TrackingRecHit*>::const_iterator it = seg2D.begin(); it != seg2D.end(); ++it) {
-                    std::vector<const TrackingRecHit*> hits1D = (*it)->recHits();
-                    copy(hits1D.begin(), hits1D.end(), back_inserter(hits));
-                }
-            }
-        } else if (subdet == (uint16_t) MuonSubdetId::CSC) {
-            if (hit.dimension() == 2) { // CSC rechit (granularity 2)
-                hits.push_back(&hit);
-            } else if (hit.dimension() == 4) { // 4D segment (granularity 0)
-                // load 2D hits (4D --> 1D)
-                hits = hit.recHits();
-            }
-        } else if (subdet == (uint16_t) MuonSubdetId::RPC) {
-            hits.push_back(&hit);
+  if (detid == DetId::Tracker) {
+    hits.push_back(&hit);
+  } else if (detid == DetId::Muon) {
+    uint16_t subdet = id.subdetId();
+    if (subdet == (uint16_t)MuonSubdetId::DT) {
+      if (hit.dimension() == 1) {  // DT rechit (granularity 2)
+        hits.push_back(&hit);
+      } else if (hit.dimension() > 1) {  // 4D segment (granularity 0).
+        // Both 2 and 4 dim cases. MB4s have 2D, but formatted in 4D segment
+        // 4D --> 2D
+        std::vector<const TrackingRecHit*> seg2D = hit.recHits();
+        // load 1D hits (2D --> 1D)
+        for (std::vector<const TrackingRecHit*>::const_iterator it = seg2D.begin(); it != seg2D.end(); ++it) {
+          std::vector<const TrackingRecHit*> hits1D = (*it)->recHits();
+          copy(hits1D.begin(), hits1D.end(), back_inserter(hits));
         }
-        else if (subdet == (uint16_t) MuonSubdetId::GEM) {
-	    if (hit.dimension() == 2) { // GEM rechit
-                hits.push_back(&hit);
-            } else if (hit.dimension() == 4) { // GEM segment
-                hits = hit.recHits();
-            }
-        }
-	else if (subdet == (uint16_t) MuonSubdetId::ME0) { //segment
-            hits = hit.recHits();
-        }
+      }
+    } else if (subdet == (uint16_t)MuonSubdetId::CSC) {
+      if (hit.dimension() == 2) {  // CSC rechit (granularity 2)
+        hits.push_back(&hit);
+      } else if (hit.dimension() == 4) {  // 4D segment (granularity 0)
+        // load 2D hits (4D --> 1D)
+        hits = hit.recHits();
+      }
+    } else if (subdet == (uint16_t)MuonSubdetId::RPC) {
+      hits.push_back(&hit);
+    } else if (subdet == (uint16_t)MuonSubdetId::GEM) {
+      if (hit.dimension() == 2) {  // GEM rechit
+        hits.push_back(&hit);
+      } else if (hit.dimension() == 4) {  // GEM segment
+        hits = hit.recHits();
+      }
+    } else if (subdet == (uint16_t)MuonSubdetId::ME0) {  //segment
+      hits = hit.recHits();
     }
-    return hits;
+  }
+  return hits;
 }
 
 // constructor (obsolete, should use eventSetUp not service..)
-MuonTrackLoader::MuonTrackLoader(ParameterSet &parameterSet, edm::ConsumesCollector& iC, const MuonServiceProxy *service): 
-  theService(service){
-
-
+MuonTrackLoader::MuonTrackLoader(ParameterSet& parameterSet,
+                                 edm::ConsumesCollector& iC,
+                                 const MuonServiceProxy* service)
+    : theService(service) {
   // option to do or not the smoothing step.
   // the trajectories which are passed to the track loader are supposed to be non-smoothed
   theSmoothingStep = parameterSet.getParameter<bool>("DoSmoothing");
-  if(theSmoothingStep)
-    theSmootherName = parameterSet.getParameter<string>("Smoother");  
+  if (theSmoothingStep)
+    theSmootherName = parameterSet.getParameter<string>("Smoother");
 
   theTrackerRecHitBuilderName = parameterSet.getParameter<std::string>("TTRHBuilder");
-  
+
   // update at vertex
   theUpdatingAtVtx = parameterSet.getParameter<bool>("VertexConstraint");
 
@@ -113,276 +109,271 @@ MuonTrackLoader::MuonTrackLoader(ParameterSet &parameterSet, edm::ConsumesCollec
   theBeamSpotInputTag = parameterSet.getParameter<edm::InputTag>("beamSpot");
   theBeamSpotToken = iC.consumes<reco::BeamSpot>(theBeamSpotInputTag);
 
-
   // Flag to put the trajectory into the event
-  theTrajectoryFlag = parameterSet.getUntrackedParameter<bool>("PutTrajectoryIntoEvent",true);
+  theTrajectoryFlag = parameterSet.getUntrackedParameter<bool>("PutTrajectoryIntoEvent", true);
 
-  theL2SeededTkLabel = parameterSet.getUntrackedParameter<string>("MuonSeededTracksInstance",string());
-  
+  theL2SeededTkLabel = parameterSet.getUntrackedParameter<string>("MuonSeededTracksInstance", string());
+
   ParameterSet updatorPar = parameterSet.getParameter<ParameterSet>("MuonUpdatorAtVertexParameters");
-  theUpdatorAtVtx = new MuonUpdatorAtVertex(updatorPar,service);
+  theUpdatorAtVtx = new MuonUpdatorAtVertex(updatorPar, service);
 
-  thePutTkTrackFlag = parameterSet.getUntrackedParameter<bool>("PutTkTrackIntoEvent",false);
-  theSmoothTkTrackFlag = parameterSet.getUntrackedParameter<bool>("SmoothTkTrack",false);
-  theAllowNoVtxFlag = parameterSet.getUntrackedParameter<bool>("AllowNoVertex",false);
+  thePutTkTrackFlag = parameterSet.getUntrackedParameter<bool>("PutTkTrackIntoEvent", false);
+  theSmoothTkTrackFlag = parameterSet.getUntrackedParameter<bool>("SmoothTkTrack", false);
+  theAllowNoVtxFlag = parameterSet.getUntrackedParameter<bool>("AllowNoVertex", false);
 }
 
-MuonTrackLoader::~MuonTrackLoader(){
-  if(theUpdatorAtVtx) delete theUpdatorAtVtx;
+MuonTrackLoader::~MuonTrackLoader() {
+  if (theUpdatorAtVtx)
+    delete theUpdatorAtVtx;
 }
 
-OrphanHandle<reco::TrackCollection> 
-MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
-			    Event& event, const TrackerTopology& ttopo, const string& instance, bool reallyDoSmoothing) {
+OrphanHandle<reco::TrackCollection> MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
+                                                                Event& event,
+                                                                const TrackerTopology& ttopo,
+                                                                const string& instance,
+                                                                bool reallyDoSmoothing) {
   std::vector<bool> dummyVecBool;
   return loadTracks(trajectories, event, dummyVecBool, ttopo, instance, reallyDoSmoothing);
 }
-  
-OrphanHandle<reco::TrackCollection> 
-MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
-			    Event& event,  std::vector<bool>& tkBoolVec, 
-                            const TrackerTopology& ttopo,
-			    const string& instance, bool reallyDoSmoothing) {
-  
+
+OrphanHandle<reco::TrackCollection> MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
+                                                                Event& event,
+                                                                std::vector<bool>& tkBoolVec,
+                                                                const TrackerTopology& ttopo,
+                                                                const string& instance,
+                                                                bool reallyDoSmoothing) {
   const bool doSmoothing = theSmoothingStep && reallyDoSmoothing;
-  
+
   const string metname = "Muon|RecoMuon|MuonTrackLoader";
-  
-  // the track collectios; they will be loaded in the event  
+
+  // the track collectios; they will be loaded in the event
   auto trackCollection = std::make_unique<reco::TrackCollection>();
   // ... and its reference into the event
   reco::TrackRefProd trackCollectionRefProd = event.getRefBeforePut<reco::TrackCollection>(instance);
-  
+
   // track collection for the tracks updated at vertex
   auto updatedAtVtxTrackCollection = std::make_unique<reco::TrackCollection>();
   // ... and its (eventually) reference into the event
   reco::TrackRefProd trackUpdatedCollectionRefProd;
-  if(theUpdatingAtVtx)  trackUpdatedCollectionRefProd = event.getRefBeforePut<reco::TrackCollection>(instance+"UpdatedAtVtx");
-  
+  if (theUpdatingAtVtx)
+    trackUpdatedCollectionRefProd = event.getRefBeforePut<reco::TrackCollection>(instance + "UpdatedAtVtx");
+
   // Association map between updated and non updated at vtx tracks
   auto trackToTrackmap = std::make_unique<reco::TrackToTrackMap>(trackCollectionRefProd, trackUpdatedCollectionRefProd);
-  
-  // the track extra collection, it will be loaded in the event  
+
+  // the track extra collection, it will be loaded in the event
   auto trackExtraCollection = std::make_unique<reco::TrackExtraCollection>();
   // ... and its reference into the event
   reco::TrackExtraRefProd trackExtraCollectionRefProd = event.getRefBeforePut<reco::TrackExtraCollection>(instance);
-  
-  // the rechit collection, it will be loaded in the event  
+
+  // the rechit collection, it will be loaded in the event
   auto recHitCollection = std::make_unique<TrackingRecHitCollection>();
   // ... and its reference into the event
   TrackingRecHitRefProd recHitCollectionRefProd = event.getRefBeforePut<TrackingRecHitCollection>(instance);
-  
+
   // Collection of Trajectory
   auto trajectoryCollection = std::make_unique<vector<Trajectory>>();
-  
+
   // don't waste any time...
-  if ( trajectories.empty() ) { 
-    event.put(std::move(recHitCollection),instance);
-    event.put(std::move(trackExtraCollection),instance);
-    if(theTrajectoryFlag) {
-      event.put(std::move(trajectoryCollection),instance);
+  if (trajectories.empty()) {
+    event.put(std::move(recHitCollection), instance);
+    event.put(std::move(trackExtraCollection), instance);
+    if (theTrajectoryFlag) {
+      event.put(std::move(trajectoryCollection), instance);
 
       // Association map between track and trajectory
       auto trajTrackMap = std::make_unique<TrajTrackAssociationCollection>();
-      event.put(std::move(trajTrackMap), instance );
+      event.put(std::move(trajTrackMap), instance);
     }
-    if(theUpdatingAtVtx){
+    if (theUpdatingAtVtx) {
       event.put(std::move(trackToTrackmap));
-      event.put(std::move(updatedAtVtxTrackCollection),instance+"UpdatedAtVtx");
+      event.put(std::move(updatedAtVtxTrackCollection), instance + "UpdatedAtVtx");
     }
-    return event.put(std::move(trackCollection),instance);
+    return event.put(std::move(trackCollection), instance);
   }
-  
+
   edm::Handle<reco::BeamSpot> beamSpot;
   event.getByToken(theBeamSpotToken, beamSpot);
 
   LogTrace(metname) << "Create the collection of Tracks";
-  
+
   reco::TrackRef::key_type trackIndex = 0;
   reco::TrackRef::key_type trackUpdatedIndex = 0;
-  
+
   reco::TrackExtraRef::key_type trackExtraIndex = 0;
-  
+
   edm::Ref<reco::TrackCollection>::key_type iTkRef = 0;
-  edm::Ref< std::vector<Trajectory> >::key_type iTjRef = 0;
+  edm::Ref<std::vector<Trajectory>>::key_type iTjRef = 0;
   std::map<unsigned int, unsigned int> tjTkMap;
-  
-  if(doSmoothing) {
+
+  if (doSmoothing) {
     edm::ESHandle<TrajectorySmoother> aSmoother;
-    theService->eventSetup().get<TrajectoryFitter::Record>().get(theSmootherName,aSmoother);
+    theService->eventSetup().get<TrajectoryFitter::Record>().get(theSmootherName, aSmoother);
     theSmoother.reset(aSmoother->clone());
     edm::ESHandle<TransientTrackingRecHitBuilder> theTrackerRecHitBuilder;
-    theService->eventSetup().get<TransientRecHitRecord>().get(theTrackerRecHitBuilderName,theTrackerRecHitBuilder);
+    theService->eventSetup().get<TransientRecHitRecord>().get(theTrackerRecHitBuilderName, theTrackerRecHitBuilder);
     theTrackerRecHitBuilder.product();
-    hitCloner = static_cast<TkTransientTrackingRecHitBuilder const *>(theTrackerRecHitBuilder.product())->cloner();
+    hitCloner = static_cast<TkTransientTrackingRecHitBuilder const*>(theTrackerRecHitBuilder.product())->cloner();
     theSmoother->setHitCloner(&hitCloner);
-  }  
-
+  }
 
   unsigned int tjCnt = 0;
-  for(TrajectoryContainer::const_iterator rawTrajectory = trajectories.begin();
-      rawTrajectory != trajectories.end(); ++rawTrajectory, ++tjCnt){
-    
-    Trajectory &trajectory = **rawTrajectory;
-    
-    if(doSmoothing){
+  for (TrajectoryContainer::const_iterator rawTrajectory = trajectories.begin(); rawTrajectory != trajectories.end();
+       ++rawTrajectory, ++tjCnt) {
+    Trajectory& trajectory = **rawTrajectory;
+
+    if (doSmoothing) {
       vector<Trajectory> trajectoriesSM = theSmoother->trajectories(**rawTrajectory);
-      
-      if(!trajectoriesSM.empty()) {
-	const edm::RefToBase<TrajectorySeed> tmpSeedRef = (**rawTrajectory).seedRef();
-	trajectory = trajectoriesSM.front();
+
+      if (!trajectoriesSM.empty()) {
+        const edm::RefToBase<TrajectorySeed> tmpSeedRef = (**rawTrajectory).seedRef();
+        trajectory = trajectoriesSM.front();
         trajectory.setSeedRef(tmpSeedRef);
-	LogDebug(metname) << "theSeedRef.isNonnull " << trajectory.seedRef().isNonnull();
+        LogDebug(metname) << "theSeedRef.isNonnull " << trajectory.seedRef().isNonnull();
       } else
-	LogInfo(metname)<<"The trajectory has not been smoothed!"<<endl;
+        LogInfo(metname) << "The trajectory has not been smoothed!" << endl;
     }
-    
-    if(theTrajectoryFlag) {
+
+    if (theTrajectoryFlag) {
       trajectoryCollection->push_back(trajectory);
       iTjRef++;
-    }    
-    
+    }
 
     // build the "bare" track from the trajectory.
     // This track has the parameters defined at PCA (no update)
-    pair<bool,reco::Track> resultOfTrackExtrapAtPCA = buildTrackAtPCA(trajectory, *beamSpot);
+    pair<bool, reco::Track> resultOfTrackExtrapAtPCA = buildTrackAtPCA(trajectory, *beamSpot);
 
     // Check if the extrapolation went well
-    if(!resultOfTrackExtrapAtPCA.first) {
+    if (!resultOfTrackExtrapAtPCA.first) {
       delete *rawTrajectory;
       continue;
     }
 
-
     // take the "bare" track at PCA
-    reco::Track &track = resultOfTrackExtrapAtPCA.second;
-    
+    reco::Track& track = resultOfTrackExtrapAtPCA.second;
+
     // build the "bare" track extra from the trajectory
-    reco::TrackExtra trackExtra = buildTrackExtra( trajectory );
-    
+    reco::TrackExtra trackExtra = buildTrackExtra(trajectory);
+
     // get the TrackExtraRef (persitent reference of the track extra)
-    reco::TrackExtraRef trackExtraRef(trackExtraCollectionRefProd, trackExtraIndex++ );
-    
+    reco::TrackExtraRef trackExtraRef(trackExtraCollectionRefProd, trackExtraIndex++);
+
     // set the persistent track-extra reference to the Track
     track.setExtra(trackExtraRef);
-    
+
     // build the updated-at-vertex track, starting from the previous track
-    pair<bool,reco::Track> updateResult(false,reco::Track());
-    
-    if(theUpdatingAtVtx){
+    pair<bool, reco::Track> updateResult(false, reco::Track());
+
+    if (theUpdatingAtVtx) {
       // build the "bare" track UPDATED at vtx
       updateResult = buildTrackUpdatedAtPCA(track, *beamSpot);
 
-      if(!updateResult.first) ++trackIndex;
-      else{
-	
-	// set the persistent track-extra reference to the Track
-	updateResult.second.setExtra(trackExtraRef);
-	
-	// Fill the map
-	trackToTrackmap->insert(reco::TrackRef(trackCollectionRefProd,trackIndex++),
-				reco::TrackRef(trackUpdatedCollectionRefProd,trackUpdatedIndex++));
+      if (!updateResult.first)
+        ++trackIndex;
+      else {
+        // set the persistent track-extra reference to the Track
+        updateResult.second.setExtra(trackExtraRef);
+
+        // Fill the map
+        trackToTrackmap->insert(reco::TrackRef(trackCollectionRefProd, trackIndex++),
+                                reco::TrackRef(trackUpdatedCollectionRefProd, trackUpdatedIndex++));
       }
     }
-    
 
     // get the transient rechit and co from the trajectory
     reco::TrackExtra::TrajParams trajParams;
     reco::TrackExtra::Chi2sFive chi2s;
     Traj2TrackHits t2t;
     auto ih = recHitCollection->size();
-    t2t(trajectory,*recHitCollection,trajParams,chi2s);
+    t2t(trajectory, *recHitCollection, trajParams, chi2s);
     auto ie = recHitCollection->size();
     // set the TrackingRecHitRef (persitent reference of the tracking rec hits)
-    trackExtra.setHits(recHitCollectionRefProd,ih,ie-ih);
-    trackExtra.setTrajParams(std::move(trajParams),std::move(chi2s));
-    assert(trackExtra.trajParams().size()==trackExtra.recHitsSize());
-
+    trackExtra.setHits(recHitCollectionRefProd, ih, ie - ih);
+    trackExtra.setTrajParams(std::move(trajParams), std::move(chi2s));
+    assert(trackExtra.trajParams().size() == trackExtra.recHitsSize());
 
     // Fill the hit pattern
-    for (;ih<ie; ++ih) {
-      auto const & hit = (*recHitCollection)[ih];
+    for (; ih < ie; ++ih) {
+      auto const& hit = (*recHitCollection)[ih];
       auto hits = MuonTrackLoader::unpackHit(hit);
       for (auto hh : hits) {
-          if UNLIKELY(!track.appendHitPattern(*hh, ttopo)) break;
+        if
+          UNLIKELY(!track.appendHitPattern(*hh, ttopo)) break;
       }
- 
-      if(theUpdatingAtVtx && updateResult.first){
+
+      if (theUpdatingAtVtx && updateResult.first) {
         for (auto hh : hits) {
-              if UNLIKELY(!updateResult.second.appendHitPattern(*hh, ttopo)) break;
+          if
+            UNLIKELY(!updateResult.second.appendHitPattern(*hh, ttopo)) break;
         }
       }
     }
 
     // fill the TrackExtraCollection
     trackExtraCollection->push_back(trackExtra);
-    
+
     // fill the TrackCollection
     trackCollection->push_back(track);
     iTkRef++;
-    LogTrace(metname) << "Debug Track being loaded pt "<< track.pt();
+    LogTrace(metname) << "Debug Track being loaded pt " << track.pt();
     // fill the TrackCollection updated at vtx
-    if(theUpdatingAtVtx && updateResult.first) 
+    if (theUpdatingAtVtx && updateResult.first)
       updatedAtVtxTrackCollection->push_back(updateResult.second);
-    
+
     // We don't need the original trajectory anymore.
-    // It has been copied by value in the trajectoryCollection, if 
+    // It has been copied by value in the trajectoryCollection, if
     // it is required to put it into the event.
     delete *rawTrajectory;
 
-    if(tkBoolVec.size()>tjCnt) tkBoolVec[tjCnt] = true;
-    if(theTrajectoryFlag) tjTkMap[iTjRef-1] = iTkRef-1;
+    if (tkBoolVec.size() > tjCnt)
+      tkBoolVec[tjCnt] = true;
+    if (theTrajectoryFlag)
+      tjTkMap[iTjRef - 1] = iTkRef - 1;
   }
-  
 
-  
   // Put the Collections in the event
   LogTrace(metname) << "put the Collections in the event";
-  event.put(std::move(recHitCollection),instance);
-  event.put(std::move(trackExtraCollection),instance);
+  event.put(std::move(recHitCollection), instance);
+  event.put(std::move(trackExtraCollection), instance);
 
   OrphanHandle<reco::TrackCollection> returnTrackHandle;
   OrphanHandle<reco::TrackCollection> nonUpdatedHandle;
-  if(theUpdatingAtVtx){
-    nonUpdatedHandle = event.put(std::move(trackCollection),instance);
+  if (theUpdatingAtVtx) {
+    nonUpdatedHandle = event.put(std::move(trackCollection), instance);
     event.put(std::move(trackToTrackmap));
-    returnTrackHandle = event.put(std::move(updatedAtVtxTrackCollection),instance+"UpdatedAtVtx");
-  }
-  else {
-    returnTrackHandle = event.put(std::move(trackCollection),instance);
+    returnTrackHandle = event.put(std::move(updatedAtVtxTrackCollection), instance + "UpdatedAtVtx");
+  } else {
+    returnTrackHandle = event.put(std::move(trackCollection), instance);
     nonUpdatedHandle = returnTrackHandle;
   }
 
-  if ( theTrajectoryFlag ) {
-    OrphanHandle<std::vector<Trajectory> > rTrajs = event.put(std::move(trajectoryCollection),instance);
+  if (theTrajectoryFlag) {
+    OrphanHandle<std::vector<Trajectory>> rTrajs = event.put(std::move(trajectoryCollection), instance);
 
     // Association map between track and trajectory
     auto trajTrackMap = std::make_unique<TrajTrackAssociationCollection>(rTrajs, nonUpdatedHandle);
-  
+
     // Now Create traj<->tracks association map
-    for ( std::map<unsigned int, unsigned int>::iterator i = tjTkMap.begin(); 
-          i != tjTkMap.end(); i++ ) {
-      trajTrackMap->insert( edm::Ref<std::vector<Trajectory> >( rTrajs, (*i).first ),
-                            edm::Ref<reco::TrackCollection>( nonUpdatedHandle, (*i).second ) );
+    for (std::map<unsigned int, unsigned int>::iterator i = tjTkMap.begin(); i != tjTkMap.end(); i++) {
+      trajTrackMap->insert(edm::Ref<std::vector<Trajectory>>(rTrajs, (*i).first),
+                           edm::Ref<reco::TrackCollection>(nonUpdatedHandle, (*i).second));
     }
-    event.put(std::move(trajTrackMap), instance );
+    event.put(std::move(trajTrackMap), instance);
   }
-  
+
   return returnTrackHandle;
 }
 
-OrphanHandle<reco::MuonTrackLinksCollection> 
-MuonTrackLoader::loadTracks(const CandidateContainer& muonCands,
-			    Event& event,
-                            const TrackerTopology& ttopo) {
-
+OrphanHandle<reco::MuonTrackLinksCollection> MuonTrackLoader::loadTracks(const CandidateContainer& muonCands,
+                                                                         Event& event,
+                                                                         const TrackerTopology& ttopo) {
   const string metname = "Muon|RecoMuon|MuonTrackLoader";
-  
+
   // the muon collection, it will be loaded in the event
   auto trackLinksCollection = std::make_unique<reco::MuonTrackLinksCollection>();
-  
+
   // don't waste any time...
-  if ( muonCands.empty() ) {
+  if (muonCands.empty()) {
     auto trackExtraCollection = std::make_unique<reco::TrackExtraCollection>();
     auto recHitCollection = std::make_unique<TrackingRecHitCollection>();
     auto trackCollection = std::make_unique<reco::TrackCollection>();
@@ -392,29 +383,33 @@ MuonTrackLoader::loadTracks(const CandidateContainer& muonCands,
     event.put(std::move(trackCollection));
 
     //need to also put the tracker tracks collection if requested
-    if(thePutTkTrackFlag){
+    if (thePutTkTrackFlag) {
       //will take care of putting nothing in the event but the empty collection
       TrajectoryContainer trackerTrajs;
       loadTracks(trackerTrajs, event, ttopo, theL2SeededTkLabel, theSmoothTkTrackFlag);
-    } 
+    }
 
     return event.put(std::move(trackLinksCollection));
   }
-  
+
   // get combined Trajectories
   TrajectoryContainer combinedTrajs;
   TrajectoryContainer trackerTrajs;
   for (CandidateContainer::const_iterator it = muonCands.begin(); it != muonCands.end(); ++it) {
     LogDebug(metname) << "Loader glbSeedRef " << (*it)->trajectory()->seedRef().isNonnull();
-    if ((*it)->trackerTrajectory() )  LogDebug(metname) << " " << "tkSeedRef " << (*it)->trackerTrajectory()->seedRef().isNonnull();
+    if ((*it)->trackerTrajectory())
+      LogDebug(metname) << " "
+                        << "tkSeedRef " << (*it)->trackerTrajectory()->seedRef().isNonnull();
 
     combinedTrajs.push_back((*it)->trajectory());
-    if ( thePutTkTrackFlag ) trackerTrajs.push_back((*it)->trackerTrajectory());
+    if (thePutTkTrackFlag)
+      trackerTrajs.push_back((*it)->trackerTrajectory());
 
     else {
-      if ((*it)->trackerTrajectory()) delete ((*it)->trackerTrajectory());
+      if ((*it)->trackerTrajectory())
+        delete ((*it)->trackerTrajectory());
     }
-  
+
     // // Create the links between sta and tracker tracks
     // reco::MuonTrackLinks links;
     // links.setStandAloneTrack((*it)->muonTrack());
@@ -422,39 +417,38 @@ MuonTrackLoader::loadTracks(const CandidateContainer& muonCands,
     // trackLinksCollection->push_back(links);
     // delete *it;
   }
-  
+
   // create the TrackCollection of combined Trajectories
   // FIXME: could this be done one track at a time in the previous loop?
   LogTrace(metname) << "Build combinedTracks";
-  std::vector<bool> combTksVec(combinedTrajs.size(), false); 
+  std::vector<bool> combTksVec(combinedTrajs.size(), false);
   OrphanHandle<reco::TrackCollection> combinedTracks = loadTracks(combinedTrajs, event, combTksVec, ttopo);
 
   OrphanHandle<reco::TrackCollection> trackerTracks;
-  std::vector<bool> trackerTksVec(trackerTrajs.size(), false); 
-  if(thePutTkTrackFlag) {
-    LogTrace(metname) << "Build trackerTracks: "
-		      << trackerTrajs.size();
+  std::vector<bool> trackerTksVec(trackerTrajs.size(), false);
+  if (thePutTkTrackFlag) {
+    LogTrace(metname) << "Build trackerTracks: " << trackerTrajs.size();
     trackerTracks = loadTracks(trackerTrajs, event, trackerTksVec, ttopo, theL2SeededTkLabel, theSmoothTkTrackFlag);
   } else {
     for (TrajectoryContainer::iterator it = trackerTrajs.begin(); it != trackerTrajs.end(); ++it) {
-        if(*it) delete *it;
+      if (*it)
+        delete *it;
     }
   }
 
   LogTrace(metname) << "Set the final links in the MuonTrackLinks collection";
 
   unsigned int candposition(0), position(0), tkposition(0);
-  //reco::TrackCollection::const_iterator glIt = combinedTracks->begin(), 
+  //reco::TrackCollection::const_iterator glIt = combinedTracks->begin(),
   //  glEnd = combinedTracks->end();
 
   for (CandidateContainer::const_iterator it = muonCands.begin(); it != muonCands.end(); ++it, ++candposition) {
-
     // The presence of the global track determines whether to fill the MuonTrackLinks or not
-    // N.B. We are assuming here that the global tracks in "combinedTracks" 
+    // N.B. We are assuming here that the global tracks in "combinedTracks"
     //      have the same order as the muon candidates in "muonCands"
     //      (except for possible missing tracks), which should always be the case...
     //if( glIt == glEnd ) break;
-    if(combTksVec[candposition]) {
+    if (combTksVec[candposition]) {
       reco::TrackRef combinedTR(combinedTracks, position++);
       //++glIt;
 
@@ -464,394 +458,389 @@ MuonTrackLoader::loadTracks(const CandidateContainer& muonCands,
       links.setTrackerTrack((*it)->trackerTrack());
       links.setGlobalTrack(combinedTR);
 
-      if(thePutTkTrackFlag && trackerTksVec[candposition]) {
-	reco::TrackRef trackerTR(trackerTracks, tkposition++);
-	links.setTrackerTrack(trackerTR);
+      if (thePutTkTrackFlag && trackerTksVec[candposition]) {
+        reco::TrackRef trackerTR(trackerTracks, tkposition++);
+        links.setTrackerTrack(trackerTR);
       }
 
       trackLinksCollection->push_back(links);
     }
 
-    else { // if no global track, still increment the tracker-track counter when appropriate
-      if(thePutTkTrackFlag && trackerTksVec[candposition]) tkposition++; 
+    else {  // if no global track, still increment the tracker-track counter when appropriate
+      if (thePutTkTrackFlag && trackerTksVec[candposition])
+        tkposition++;
     }
 
     delete *it;
   }
 
-  if( thePutTkTrackFlag && trackerTracks.isValid() && !(!combinedTracks->empty() && !trackerTracks->empty() ) )
-    LogWarning(metname)<<"The MuonTrackLinkCollection is incomplete"; 
-  
-  // put the MuonCollection in the event
-  LogTrace(metname) << "put the MuonCollection in the event" << "\n";
-  
-  return event.put(std::move(trackLinksCollection));
-} 
+  if (thePutTkTrackFlag && trackerTracks.isValid() && !(!combinedTracks->empty() && !trackerTracks->empty()))
+    LogWarning(metname) << "The MuonTrackLinkCollection is incomplete";
 
-OrphanHandle<reco::TrackCollection> 
-MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
-			    Event& event, const std::vector<std::pair<Trajectory*,reco::TrackRef> >& miniMap, Handle<reco::TrackCollection> const& trackHandle, const TrackerTopology& ttopo, const string& instance, bool reallyDoSmoothing) {
-  
+  // put the MuonCollection in the event
+  LogTrace(metname) << "put the MuonCollection in the event"
+                    << "\n";
+
+  return event.put(std::move(trackLinksCollection));
+}
+
+OrphanHandle<reco::TrackCollection> MuonTrackLoader::loadTracks(
+    const TrajectoryContainer& trajectories,
+    Event& event,
+    const std::vector<std::pair<Trajectory*, reco::TrackRef>>& miniMap,
+    Handle<reco::TrackCollection> const& trackHandle,
+    const TrackerTopology& ttopo,
+    const string& instance,
+    bool reallyDoSmoothing) {
   const bool doSmoothing = theSmoothingStep && reallyDoSmoothing;
-  
+
   const string metname = "Muon|RecoMuon|MuonTrackLoader|TevMuonTrackLoader";
 
-  LogDebug(metname)<<"TeV LoadTracks instance: " << instance;
-  
-  // the track collectios; they will be loaded in the event  
+  LogDebug(metname) << "TeV LoadTracks instance: " << instance;
+
+  // the track collectios; they will be loaded in the event
   auto trackCollection = std::make_unique<reco::TrackCollection>();
   // ... and its reference into the event
   reco::TrackRefProd trackCollectionRefProd = event.getRefBeforePut<reco::TrackCollection>(instance);
-    
+
   // Association map between GlobalMuons and TeVMuons
-  auto trackToTrackmap = std::make_unique<reco::TrackToTrackMap>(trackHandle,trackCollectionRefProd);
-   
-  // the track extra collection, it will be loaded in the event  
+  auto trackToTrackmap = std::make_unique<reco::TrackToTrackMap>(trackHandle, trackCollectionRefProd);
+
+  // the track extra collection, it will be loaded in the event
   auto trackExtraCollection = std::make_unique<reco::TrackExtraCollection>();
   // ... and its reference into the event
   reco::TrackExtraRefProd trackExtraCollectionRefProd = event.getRefBeforePut<reco::TrackExtraCollection>(instance);
-  
-  // the rechit collection, it will be loaded in the event  
+
+  // the rechit collection, it will be loaded in the event
   auto recHitCollection = std::make_unique<TrackingRecHitCollection>();
   // ... and its reference into the event
   TrackingRecHitRefProd recHitCollectionRefProd = event.getRefBeforePut<TrackingRecHitCollection>(instance);
-  
+
   // Collection of Trajectory
   auto trajectoryCollection = std::make_unique<std::vector<Trajectory>>();
-  
+
   // don't waste any time...
-  if ( trajectories.empty() ) { 
-    event.put(std::move(recHitCollection),instance);
-    event.put(std::move(trackExtraCollection),instance);
-    if(theTrajectoryFlag) {
-      event.put(std::move(trajectoryCollection),instance);
+  if (trajectories.empty()) {
+    event.put(std::move(recHitCollection), instance);
+    event.put(std::move(trackExtraCollection), instance);
+    if (theTrajectoryFlag) {
+      event.put(std::move(trajectoryCollection), instance);
 
       // Association map between track and trajectory
       auto trajTrackMap = std::make_unique<TrajTrackAssociationCollection>();
-      event.put(std::move(trajTrackMap), instance );
+      event.put(std::move(trajTrackMap), instance);
     }
     event.put(std::move(trackToTrackmap), instance);
-    return event.put(std::move(trackCollection),instance);
+    return event.put(std::move(trackCollection), instance);
   }
-  
+
   LogTrace(metname) << "Create the collection of Tracks";
-  
+
   edm::Handle<reco::BeamSpot> beamSpot;
-  event.getByToken(theBeamSpotToken,beamSpot);
+  event.getByToken(theBeamSpotToken, beamSpot);
 
   reco::TrackRef::key_type trackIndex = 0;
-  
+
   reco::TrackExtraRef::key_type trackExtraIndex = 0;
-  
+
   edm::Ref<reco::TrackCollection>::key_type iTkRef = 0;
-  edm::Ref< std::vector<Trajectory> >::key_type iTjRef = 0;
+  edm::Ref<std::vector<Trajectory>>::key_type iTjRef = 0;
   std::map<unsigned int, unsigned int> tjTkMap;
-  
-  if(doSmoothing) {
+
+  if (doSmoothing) {
     edm::ESHandle<TrajectorySmoother> aSmoother;
-    theService->eventSetup().get<TrajectoryFitter::Record>().get(theSmootherName,aSmoother);
+    theService->eventSetup().get<TrajectoryFitter::Record>().get(theSmootherName, aSmoother);
     theSmoother.reset(aSmoother->clone());
     edm::ESHandle<TransientTrackingRecHitBuilder> theTrackerRecHitBuilder;
-    theService->eventSetup().get<TransientRecHitRecord>().get(theTrackerRecHitBuilderName,theTrackerRecHitBuilder);
-    hitCloner = static_cast<TkTransientTrackingRecHitBuilder const *>(theTrackerRecHitBuilder.product())->cloner();
+    theService->eventSetup().get<TransientRecHitRecord>().get(theTrackerRecHitBuilderName, theTrackerRecHitBuilder);
+    hitCloner = static_cast<TkTransientTrackingRecHitBuilder const*>(theTrackerRecHitBuilder.product())->cloner();
     theSmoother->setHitCloner(&hitCloner);
   }
 
-  for(TrajectoryContainer::const_iterator rawTrajectory = trajectories.begin();
-      rawTrajectory != trajectories.end(); ++rawTrajectory){
-
+  for (TrajectoryContainer::const_iterator rawTrajectory = trajectories.begin(); rawTrajectory != trajectories.end();
+       ++rawTrajectory) {
     reco::TrackRef glbRef;
-    std::vector<std::pair<Trajectory*,reco::TrackRef> >::const_iterator mmit;
-    for(mmit = miniMap.begin();mmit!=miniMap.end();++mmit){
-      if(mmit->first == *rawTrajectory) glbRef = mmit->second;
+    std::vector<std::pair<Trajectory*, reco::TrackRef>>::const_iterator mmit;
+    for (mmit = miniMap.begin(); mmit != miniMap.end(); ++mmit) {
+      if (mmit->first == *rawTrajectory)
+        glbRef = mmit->second;
     }
-    
-    Trajectory &trajectory = **rawTrajectory;
-    
-    if(doSmoothing){
+
+    Trajectory& trajectory = **rawTrajectory;
+
+    if (doSmoothing) {
       vector<Trajectory> trajectoriesSM = theSmoother->trajectories(**rawTrajectory);
-      
-      if(!trajectoriesSM.empty()) {
-	const edm::RefToBase<TrajectorySeed> tmpSeedRef = (**rawTrajectory).seedRef();
-	trajectory = trajectoriesSM.front();
+
+      if (!trajectoriesSM.empty()) {
+        const edm::RefToBase<TrajectorySeed> tmpSeedRef = (**rawTrajectory).seedRef();
+        trajectory = trajectoriesSM.front();
         trajectory.setSeedRef(tmpSeedRef);
       } else
-	LogInfo(metname)<<"The trajectory has not been smoothed!"<<endl;
+        LogInfo(metname) << "The trajectory has not been smoothed!" << endl;
     }
-    
-    if(theTrajectoryFlag) {
+
+    if (theTrajectoryFlag) {
       trajectoryCollection->push_back(trajectory);
       iTjRef++;
-    }    
-    
+    }
+
     // build the "bare" track from the trajectory.
     // This track has the parameters defined at PCA (no update)
-    pair<bool,reco::Track> resultOfTrackExtrapAtPCA = buildTrackAtPCA(trajectory, *beamSpot);
-    
-    // Check if the extrapolation went well    
-    if(!resultOfTrackExtrapAtPCA.first) {
+    pair<bool, reco::Track> resultOfTrackExtrapAtPCA = buildTrackAtPCA(trajectory, *beamSpot);
+
+    // Check if the extrapolation went well
+    if (!resultOfTrackExtrapAtPCA.first) {
       delete *rawTrajectory;
       continue;
     }
-    
+
     // take the "bare" track at PCA
-    reco::Track &track = resultOfTrackExtrapAtPCA.second;
-    
+    reco::Track& track = resultOfTrackExtrapAtPCA.second;
+
     // build the "bare" track extra from the trajectory
-    reco::TrackExtra trackExtra = buildTrackExtra( trajectory );
-    
+    reco::TrackExtra trackExtra = buildTrackExtra(trajectory);
+
     // get the TrackExtraRef (persitent reference of the track extra)
-    reco::TrackExtraRef trackExtraRef(trackExtraCollectionRefProd, trackExtraIndex++ );
-    
+    reco::TrackExtraRef trackExtraRef(trackExtraCollectionRefProd, trackExtraIndex++);
+
     // set the persistent track-extra reference to the Track
     track.setExtra(trackExtraRef);
 
     // Fill the map
-    trackToTrackmap->insert(glbRef,
-			    reco::TrackRef(trackCollectionRefProd,trackIndex++));
+    trackToTrackmap->insert(glbRef, reco::TrackRef(trackCollectionRefProd, trackIndex++));
 
     // build the updated-at-vertex track, starting from the previous track
-    pair<bool,reco::Track> updateResult(false,reco::Track());
-            
+    pair<bool, reco::Track> updateResult(false, reco::Track());
+
     // get the transient rechit and co from the trajectory
     reco::TrackExtra::TrajParams trajParams;
     reco::TrackExtra::Chi2sFive chi2s;
     Traj2TrackHits t2t;
     auto ih = recHitCollection->size();
-    t2t(trajectory,*recHitCollection,trajParams,chi2s);
+    t2t(trajectory, *recHitCollection, trajParams, chi2s);
     auto ie = recHitCollection->size();
     // set the TrackingRecHitRef (persitent reference of the tracking rec hits)
-    trackExtra.setHits(recHitCollectionRefProd,ih,ie-ih);
-    trackExtra.setTrajParams(std::move(trajParams),std::move(chi2s));
-    assert(trackExtra.trajParams().size()==trackExtra.recHitsSize());
+    trackExtra.setHits(recHitCollectionRefProd, ih, ie - ih);
+    trackExtra.setTrajParams(std::move(trajParams), std::move(chi2s));
+    assert(trackExtra.trajParams().size() == trackExtra.recHitsSize());
 
     // Fill the hit pattern
-    for (;ih<ie; ++ih) {
-      auto const & hit = (*recHitCollection)[ih];
+    for (; ih < ie; ++ih) {
+      auto const& hit = (*recHitCollection)[ih];
       auto hits = MuonTrackLoader::unpackHit(hit);
       for (auto hh : hits) {
-          if UNLIKELY(!track.appendHitPattern(*hh, ttopo)) break;
+        if
+          UNLIKELY(!track.appendHitPattern(*hh, ttopo)) break;
       }
- 
-      if(theUpdatingAtVtx && updateResult.first){
+
+      if (theUpdatingAtVtx && updateResult.first) {
         for (auto hh : hits) {
-              if UNLIKELY(!updateResult.second.appendHitPattern(*hh, ttopo)) break;
+          if
+            UNLIKELY(!updateResult.second.appendHitPattern(*hh, ttopo)) break;
         }
       }
     }
 
     // fill the TrackExtraCollection
     trackExtraCollection->push_back(trackExtra);
-    
+
     // fill the TrackCollection
     trackCollection->push_back(track);
     iTkRef++;
-    LogTrace(metname) << "Debug Track being loaded pt "<< track.pt();
-    
+    LogTrace(metname) << "Debug Track being loaded pt " << track.pt();
+
     // We don't need the original trajectory anymore.
-    // It has been copied by value in the trajectoryCollection, if 
+    // It has been copied by value in the trajectoryCollection, if
     // it is required to put it into the event.
     delete *rawTrajectory;
 
-    if(theTrajectoryFlag) tjTkMap[iTjRef-1] = iTkRef-1;
+    if (theTrajectoryFlag)
+      tjTkMap[iTjRef - 1] = iTkRef - 1;
   }
-  
 
-  
   // Put the Collections in the event
   LogTrace(metname) << "put the Collections in the event";
-  event.put(std::move(recHitCollection),instance);
-  event.put(std::move(trackExtraCollection),instance);
+  event.put(std::move(recHitCollection), instance);
+  event.put(std::move(trackExtraCollection), instance);
 
   OrphanHandle<reco::TrackCollection> returnTrackHandle;
   OrphanHandle<reco::TrackCollection> nonUpdatedHandle;
-  if(theUpdatingAtVtx){
-  }
-  else {
-    event.put(std::move(trackToTrackmap),instance);
-    returnTrackHandle = event.put(std::move(trackCollection),instance);
+  if (theUpdatingAtVtx) {
+  } else {
+    event.put(std::move(trackToTrackmap), instance);
+    returnTrackHandle = event.put(std::move(trackCollection), instance);
     nonUpdatedHandle = returnTrackHandle;
   }
 
-  if ( theTrajectoryFlag ) {
-    OrphanHandle<std::vector<Trajectory> > rTrajs = event.put(std::move(trajectoryCollection),instance);
+  if (theTrajectoryFlag) {
+    OrphanHandle<std::vector<Trajectory>> rTrajs = event.put(std::move(trajectoryCollection), instance);
 
     // Association map between track and trajectory
     auto trajTrackMap = std::make_unique<TrajTrackAssociationCollection>(rTrajs, nonUpdatedHandle);
 
     // Now Create traj<->tracks association map
-    for ( std::map<unsigned int, unsigned int>::iterator i = tjTkMap.begin(); 
-          i != tjTkMap.end(); i++ ) {
-      trajTrackMap->insert( edm::Ref<std::vector<Trajectory> >( rTrajs, (*i).first ),
-                            edm::Ref<reco::TrackCollection>( nonUpdatedHandle, (*i).second ) );
+    for (std::map<unsigned int, unsigned int>::iterator i = tjTkMap.begin(); i != tjTkMap.end(); i++) {
+      trajTrackMap->insert(edm::Ref<std::vector<Trajectory>>(rTrajs, (*i).first),
+                           edm::Ref<reco::TrackCollection>(nonUpdatedHandle, (*i).second));
     }
-    event.put(std::move(trajTrackMap), instance );
+    event.put(std::move(trajTrackMap), instance);
   }
 
   return returnTrackHandle;
 }
 
-
-pair<bool,reco::Track> MuonTrackLoader::buildTrackAtPCA(const Trajectory& trajectory, const reco::BeamSpot &beamSpot) const {
-
+pair<bool, reco::Track> MuonTrackLoader::buildTrackAtPCA(const Trajectory& trajectory,
+                                                         const reco::BeamSpot& beamSpot) const {
   const string metname = "Muon|RecoMuon|MuonTrackLoader";
 
   MuonPatternRecoDumper debug;
-  
+
   // FIXME: check the prop direction
   TrajectoryStateOnSurface innerTSOS = trajectory.geometricalInnermostState();
-  
+
   // This is needed to extrapolate the tsos at vertex
   LogTrace(metname) << "Propagate to PCA...";
-  pair<bool,FreeTrajectoryState> 
-    extrapolationResult = theUpdatorAtVtx->propagate(innerTSOS, beamSpot);  
+  pair<bool, FreeTrajectoryState> extrapolationResult = theUpdatorAtVtx->propagate(innerTSOS, beamSpot);
   FreeTrajectoryState ftsAtVtx;
-  
-  if(extrapolationResult.first)
+
+  if (extrapolationResult.first)
     ftsAtVtx = extrapolationResult.second;
-  else{    
-    if(TrackerBounds::isInside(innerTSOS.globalPosition())){
+  else {
+    if (TrackerBounds::isInside(innerTSOS.globalPosition())) {
       LogInfo(metname) << "Track in the Tracker: taking the innermost state instead of the state at PCA";
       ftsAtVtx = *innerTSOS.freeState();
-    }
-    else{
-      if ( theAllowNoVtxFlag ) {
+    } else {
+      if (theAllowNoVtxFlag) {
         LogInfo(metname) << "Propagation to PCA failed, taking the innermost state instead of the state at PCA";
         ftsAtVtx = *innerTSOS.freeState();
       } else {
         LogInfo(metname) << "Stand Alone track: this track will be rejected";
-        return pair<bool,reco::Track>(false,reco::Track());
+        return pair<bool, reco::Track>(false, reco::Track());
       }
     }
   }
-    
+
   LogTrace(metname) << "TSOS after the extrapolation at vtx";
   LogTrace(metname) << debug.dumpFTS(ftsAtVtx);
-  
+
   GlobalPoint pca = ftsAtVtx.position();
-  math::XYZPoint persistentPCA(pca.x(),pca.y(),pca.z());
+  math::XYZPoint persistentPCA(pca.x(), pca.y(), pca.z());
   GlobalVector p = ftsAtVtx.momentum();
-  math::XYZVector persistentMomentum(p.x(),p.y(),p.z());
+  math::XYZVector persistentMomentum(p.x(), p.y(), p.z());
 
   bool bon = true;
-  if(fabs(theService->magneticField()->inTesla(GlobalPoint(0,0,0)).z()) < 0.01) bon=false;   
+  if (fabs(theService->magneticField()->inTesla(GlobalPoint(0, 0, 0)).z()) < 0.01)
+    bon = false;
   double ndof = trajectory.ndof(bon);
-  
-  reco::Track track(trajectory.chiSquared(), 
-		    ndof,
-		    persistentPCA,
-		    persistentMomentum,
-		    ftsAtVtx.charge(),
-		    ftsAtVtx.curvilinearError());
-  
-  return pair<bool,reco::Track>(true,track);
+
+  reco::Track track(
+      trajectory.chiSquared(), ndof, persistentPCA, persistentMomentum, ftsAtVtx.charge(), ftsAtVtx.curvilinearError());
+
+  return pair<bool, reco::Track>(true, track);
 }
 
-
-pair<bool,reco::Track> MuonTrackLoader::buildTrackUpdatedAtPCA(const reco::Track &track, const reco::BeamSpot &beamSpot) const {
-
+pair<bool, reco::Track> MuonTrackLoader::buildTrackUpdatedAtPCA(const reco::Track& track,
+                                                                const reco::BeamSpot& beamSpot) const {
   const string metname = "Muon|RecoMuon|MuonTrackLoader";
   MuonPatternRecoDumper debug;
- 
+
   // build the transient track
-  reco::TransientTrack transientTrack(track,
-				      &*theService->magneticField(),
-				      theService->trackingGeometry());
+  reco::TransientTrack transientTrack(track, &*theService->magneticField(), theService->trackingGeometry());
 
   LogTrace(metname) << "Apply the vertex constraint";
-  pair<bool,FreeTrajectoryState> updateResult = theUpdatorAtVtx->update(transientTrack,beamSpot);
+  pair<bool, FreeTrajectoryState> updateResult = theUpdatorAtVtx->update(transientTrack, beamSpot);
 
-  if(!updateResult.first){
-    return pair<bool,reco::Track>(false,reco::Track());
+  if (!updateResult.first) {
+    return pair<bool, reco::Track>(false, reco::Track());
   }
 
   LogTrace(metname) << "FTS after the vertex constraint";
-  FreeTrajectoryState &ftsAtVtx = updateResult.second;
+  FreeTrajectoryState& ftsAtVtx = updateResult.second;
 
   LogTrace(metname) << debug.dumpFTS(ftsAtVtx);
-  
+
   GlobalPoint pca = ftsAtVtx.position();
-  math::XYZPoint persistentPCA(pca.x(),pca.y(),pca.z());
+  math::XYZPoint persistentPCA(pca.x(), pca.y(), pca.z());
   GlobalVector p = ftsAtVtx.momentum();
-  math::XYZVector persistentMomentum(p.x(),p.y(),p.z());
-  
-  reco::Track updatedTrack(track.chi2(), 
-			   track.ndof(),
-			   persistentPCA,
-			   persistentMomentum,
-			   ftsAtVtx.charge(),
-			   ftsAtVtx.curvilinearError());
-  
-  return pair<bool,reco::Track>(true,updatedTrack);
+  math::XYZVector persistentMomentum(p.x(), p.y(), p.z());
+
+  reco::Track updatedTrack(
+      track.chi2(), track.ndof(), persistentPCA, persistentMomentum, ftsAtVtx.charge(), ftsAtVtx.curvilinearError());
+
+  return pair<bool, reco::Track>(true, updatedTrack);
 }
 
-
 reco::TrackExtra MuonTrackLoader::buildTrackExtra(const Trajectory& trajectory) const {
-
   const string metname = "Muon|RecoMuon|MuonTrackLoader";
 
   const Trajectory::RecHitContainer transRecHits = trajectory.recHits();
-  
+
   // put the collection of TrackingRecHit in the event
-  
+
   // sets the outermost and innermost TSOSs
   // FIXME: check it!
   TrajectoryStateOnSurface outerTSOS;
   TrajectoryStateOnSurface innerTSOS;
-  unsigned int innerId=0, outerId=0;
+  unsigned int innerId = 0, outerId = 0;
   TrajectoryMeasurement::ConstRecHitPointer outerRecHit;
   DetId outerDetId;
 
   if (trajectory.direction() == alongMomentum) {
-    LogTrace(metname)<<"alongMomentum";
+    LogTrace(metname) << "alongMomentum";
     outerTSOS = trajectory.lastMeasurement().updatedState();
     innerTSOS = trajectory.firstMeasurement().updatedState();
     outerId = trajectory.lastMeasurement().recHit()->geographicalId().rawId();
     innerId = trajectory.firstMeasurement().recHit()->geographicalId().rawId();
-    outerRecHit =  trajectory.lastMeasurement().recHit();
-    outerDetId =   trajectory.lastMeasurement().recHit()->geographicalId();
-  } 
-  else if (trajectory.direction() == oppositeToMomentum) {
-    LogTrace(metname)<<"oppositeToMomentum";
+    outerRecHit = trajectory.lastMeasurement().recHit();
+    outerDetId = trajectory.lastMeasurement().recHit()->geographicalId();
+  } else if (trajectory.direction() == oppositeToMomentum) {
+    LogTrace(metname) << "oppositeToMomentum";
     outerTSOS = trajectory.firstMeasurement().updatedState();
     innerTSOS = trajectory.lastMeasurement().updatedState();
     outerId = trajectory.firstMeasurement().recHit()->geographicalId().rawId();
     innerId = trajectory.lastMeasurement().recHit()->geographicalId().rawId();
-    outerRecHit =  trajectory.firstMeasurement().recHit();
-    outerDetId =   trajectory.firstMeasurement().recHit()->geographicalId();
-  }
-  else LogError(metname)<<"Wrong propagation direction!";
-  
-  const GeomDet *outerDet = theService->trackingGeometry()->idToDet(outerDetId);
+    outerRecHit = trajectory.firstMeasurement().recHit();
+    outerDetId = trajectory.firstMeasurement().recHit()->geographicalId();
+  } else
+    LogError(metname) << "Wrong propagation direction!";
+
+  const GeomDet* outerDet = theService->trackingGeometry()->idToDet(outerDetId);
   GlobalPoint outerTSOSPos = outerTSOS.globalParameters().position();
   bool inside = outerDet->surface().bounds().inside(outerDet->toLocal(outerTSOSPos));
 
-  
-  GlobalPoint hitPos = (outerRecHit->isValid()) ? outerRecHit->globalPosition() :  outerTSOS.globalParameters().position() ;
-  
-  if(!inside) {
-    LogTrace(metname)<<"The Global Muon outerMostMeasurementState is not compatible with the recHit detector! Setting outerMost postition to recHit position if recHit isValid: " << outerRecHit->isValid();
-    LogTrace(metname)<<"From " << outerTSOSPos << " to " <<  hitPos;
+  GlobalPoint hitPos =
+      (outerRecHit->isValid()) ? outerRecHit->globalPosition() : outerTSOS.globalParameters().position();
+
+  if (!inside) {
+    LogTrace(metname) << "The Global Muon outerMostMeasurementState is not compatible with the recHit detector! "
+                         "Setting outerMost postition to recHit position if recHit isValid: "
+                      << outerRecHit->isValid();
+    LogTrace(metname) << "From " << outerTSOSPos << " to " << hitPos;
   }
-  
-  
+
   //build the TrackExtra
-  GlobalPoint v = (inside) ? outerTSOSPos : hitPos ;
+  GlobalPoint v = (inside) ? outerTSOSPos : hitPos;
   GlobalVector p = outerTSOS.globalParameters().momentum();
-  math::XYZPoint  outpos( v.x(), v.y(), v.z() );   
-  math::XYZVector outmom( p.x(), p.y(), p.z() );
-  
+  math::XYZPoint outpos(v.x(), v.y(), v.z());
+  math::XYZVector outmom(p.x(), p.y(), p.z());
+
   v = innerTSOS.globalParameters().position();
   p = innerTSOS.globalParameters().momentum();
-  math::XYZPoint  inpos( v.x(), v.y(), v.z() );   
-  math::XYZVector inmom( p.x(), p.y(), p.z() );
+  math::XYZPoint inpos(v.x(), v.y(), v.z());
+  math::XYZVector inmom(p.x(), p.y(), p.z());
 
-  reco::TrackExtra trackExtra(outpos, outmom, true, inpos, inmom, true,
-                              outerTSOS.curvilinearError(), outerId,
-                              innerTSOS.curvilinearError(), innerId,
-			      trajectory.direction(),trajectory.seedRef());
-  
+  reco::TrackExtra trackExtra(outpos,
+                              outmom,
+                              true,
+                              inpos,
+                              inmom,
+                              true,
+                              outerTSOS.curvilinearError(),
+                              outerId,
+                              innerTSOS.curvilinearError(),
+                              innerId,
+                              trajectory.direction(),
+                              trajectory.seedRef());
+
   return trackExtra;
- 
 }
-

--- a/RecoMuon/TrackingTools/src/MuonTrajectoryCleaner.cc
+++ b/RecoMuon/TrackingTools/src/MuonTrajectoryCleaner.cc
@@ -10,14 +10,16 @@
 #include "DataFormats/Common/interface/RefToBase.h"
 #include "DataFormats/Common/interface/AssociationMap.h"
 #include "DataFormats/MuonSeed/interface/L2MuonTrajectorySeedCollection.h"
-#include "DataFormats/TrackingRecHit/interface/RecSegment.h" 
-#include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHitBreaker.h" 
+#include "DataFormats/TrackingRecHit/interface/RecSegment.h"
+#include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHitBreaker.h"
 
-using namespace std; 
+using namespace std;
 
 typedef edm::AssociationMap<edm::OneToMany<L2MuonTrajectorySeedCollection, L2MuonTrajectorySeedCollection> > L2SeedAssoc;
 
-void MuonTrajectoryCleaner::clean(TrajectoryContainer& trajC, edm::Event& event, const edm::Handle<edm::View<TrajectorySeed> >& seeds) {
+void MuonTrajectoryCleaner::clean(TrajectoryContainer& trajC,
+                                  edm::Event& event,
+                                  const edm::Handle<edm::View<TrajectorySeed> >& seeds) {
   const std::string metname = "Muon|RecoMuon|MuonTrajectoryCleaner";
 
   LogTrace(metname) << "Muon Trajectory Cleaner called" << endl;
@@ -25,9 +27,10 @@ void MuonTrajectoryCleaner::clean(TrajectoryContainer& trajC, edm::Event& event,
   TrajectoryContainer::iterator iter, jter;
   Trajectory::DataContainer::const_iterator m1, m2;
 
-  if ( trajC.empty() ) return;
-  
-  LogTrace(metname) << "Number of trajectories in the container: " <<trajC.size()<< endl;
+  if (trajC.empty())
+    return;
+
+  LogTrace(metname) << "Number of trajectories in the container: " << trajC.size() << endl;
 
   int i(0), j(0);
   int match(0);
@@ -38,128 +41,154 @@ void MuonTrajectoryCleaner::clean(TrajectoryContainer& trajC, edm::Event& event,
   // CAVEAT: vector<bool> is not a vector, its elements are not addressable!
   // This is fine as long as only operator [] is used as in this case.
   // cf. par 16.3.11
-  vector<bool> mask(trajC.size(),true);
-  
+  vector<bool> mask(trajC.size(), true);
+
   TrajectoryContainer result;
-  
-  for ( iter = trajC.begin(); iter != trajC.end(); iter++ ) {
-    if ( !mask[i] ) { i++; continue; }
-    if ( !(*iter)->isValid() || (*iter)->empty() ) {mask[i] = false; i++; continue; }
-    if(seedmap.count(i)==0) seedmap[i].push_back(i);
+
+  for (iter = trajC.begin(); iter != trajC.end(); iter++) {
+    if (!mask[i]) {
+      i++;
+      continue;
+    }
+    if (!(*iter)->isValid() || (*iter)->empty()) {
+      mask[i] = false;
+      i++;
+      continue;
+    }
+    if (seedmap.count(i) == 0)
+      seedmap[i].push_back(i);
     const Trajectory::DataContainer& meas1 = (*iter)->measurements();
-    j = i+1;
-    bool skipnext=false;
-    for ( jter = iter+1; jter != trajC.end(); jter++ ) {
-      if ( !mask[j] ) { j++; continue; }
-      if(seedmap.count(j)==0) seedmap[j].push_back(j);
+    j = i + 1;
+    bool skipnext = false;
+    for (jter = iter + 1; jter != trajC.end(); jter++) {
+      if (!mask[j]) {
+        j++;
+        continue;
+      }
+      if (seedmap.count(j) == 0)
+        seedmap[j].push_back(j);
       const Trajectory::DataContainer& meas2 = (*jter)->measurements();
       match = 0;
-      for( m1 = meas1.begin(); m1 != meas1.end(); m1++ ) {
-	for( m2 = meas2.begin(); m2 != meas2.end(); m2++ ) {
-	  if ( ( (*m1).recHit()->globalPosition() - (*m2).recHit()->globalPosition()).mag()< 10e-5 ) match++; 
-	} // end for( m2 ... )
-      } // end for( m1 ... )
-      
+      for (m1 = meas1.begin(); m1 != meas1.end(); m1++) {
+        for (m2 = meas2.begin(); m2 != meas2.end(); m2++) {
+          if (((*m1).recHit()->globalPosition() - (*m2).recHit()->globalPosition()).mag() < 10e-5)
+            match++;
+        }  // end for( m2 ... )
+      }    // end for( m1 ... )
+
       // FIXME Set Boff/on via cfg!
-      double chi2_dof_i = (*iter)->ndof() > 0 ? (*iter)->chiSquared()/(*iter)->ndof() : (*iter)->chiSquared()/1e-10;
-      double chi2_dof_j = (*jter)->ndof() > 0 ? (*jter)->chiSquared()/(*jter)->ndof() : (*jter)->chiSquared()/1e-10;
+      double chi2_dof_i = (*iter)->ndof() > 0 ? (*iter)->chiSquared() / (*iter)->ndof() : (*iter)->chiSquared() / 1e-10;
+      double chi2_dof_j = (*jter)->ndof() > 0 ? (*jter)->chiSquared() / (*jter)->ndof() : (*jter)->chiSquared() / 1e-10;
 
       LogTrace(metname) << " MuonTrajectoryCleaner:";
-      LogTrace(metname) << " * trajC " << i 
-			<< " (pT="<<(*iter)->lastMeasurement().updatedState().globalMomentum().perp() 
-			<< " GeV) - chi2/nDOF = " << (*iter)->chiSquared() << "/" << (*iter)->ndof() << " = " << chi2_dof_i;
-      LogTrace(metname)	<< "     - valid RH = " << (*iter)->foundHits() << " / total RH = " <<  (*iter)->measurements().size();
-      LogTrace(metname)	<< " * trajC " << j 
-			<< " (pT="<<(*jter)->lastMeasurement().updatedState().globalMomentum().perp() 
-			<< " GeV) - chi2/nDOF = " << (*jter)->chiSquared() << "/" << (*jter)->ndof() << " = " << chi2_dof_j;
-      LogTrace(metname)	<< "     - valid RH = " << (*jter)->foundHits() << " / total RH = " << (*jter)->measurements().size();
-      LogTrace(metname)	<< " *** Shared RecHits: " << match; 
+      LogTrace(metname) << " * trajC " << i
+                        << " (pT=" << (*iter)->lastMeasurement().updatedState().globalMomentum().perp()
+                        << " GeV) - chi2/nDOF = " << (*iter)->chiSquared() << "/" << (*iter)->ndof() << " = "
+                        << chi2_dof_i;
+      LogTrace(metname) << "     - valid RH = " << (*iter)->foundHits()
+                        << " / total RH = " << (*iter)->measurements().size();
+      LogTrace(metname) << " * trajC " << j
+                        << " (pT=" << (*jter)->lastMeasurement().updatedState().globalMomentum().perp()
+                        << " GeV) - chi2/nDOF = " << (*jter)->chiSquared() << "/" << (*jter)->ndof() << " = "
+                        << chi2_dof_j;
+      LogTrace(metname) << "     - valid RH = " << (*jter)->foundHits()
+                        << " / total RH = " << (*jter)->measurements().size();
+      LogTrace(metname) << " *** Shared RecHits: " << match;
 
-      int hit_diff =  (*iter)->foundHits() - (*jter)->foundHits() ;       
+      int hit_diff = (*iter)->foundHits() - (*jter)->foundHits();
       // If there are matches, reject the worst track
-      if ( match > 0 ) {
+      if (match > 0) {
         // If the difference in # of rechits is null then compare the chi2/ndf of the two trajectories
-        if ( abs(hit_diff) == 0  ) {
+        if (abs(hit_diff) == 0) {
+          double minPt = 3.5;
+          double dPt =
+              7.;  // i.e. considering 10% (conservative!) resolution at minPt it is ~ 10 sigma away from the central value
 
-	  double minPt = 3.5;
-	  double dPt = 7.;  // i.e. considering 10% (conservative!) resolution at minPt it is ~ 10 sigma away from the central value
+          double maxFraction = 0.95;
 
-	  double maxFraction = 0.95;
+          double fraction = (2. * match) / ((*iter)->measurements().size() + (*jter)->measurements().size());
+          int belowLimit = 0;
+          int above = 0;
 
-       	  double fraction = (2.*match)/((*iter)->measurements().size()+(*jter)->measurements().size());
-	  int belowLimit = 0;
-	  int above = 0;
+          if ((*jter)->lastMeasurement().updatedState().globalMomentum().perp() <= minPt)
+            ++belowLimit;
+          if ((*iter)->lastMeasurement().updatedState().globalMomentum().perp() <= minPt)
+            ++belowLimit;
 
-	  if((*jter)->lastMeasurement().updatedState().globalMomentum().perp() <= minPt) ++belowLimit; 
-	  if((*iter)->lastMeasurement().updatedState().globalMomentum().perp() <= minPt) ++belowLimit; 
-	 
-	  if((*jter)->lastMeasurement().updatedState().globalMomentum().perp() >= dPt) ++above; 
-	  if((*iter)->lastMeasurement().updatedState().globalMomentum().perp() >= dPt) ++above; 
-	  
+          if ((*jter)->lastMeasurement().updatedState().globalMomentum().perp() >= dPt)
+            ++above;
+          if ((*iter)->lastMeasurement().updatedState().globalMomentum().perp() >= dPt)
+            ++above;
 
-	  if(fraction >= maxFraction && belowLimit == 1 && above == 1){
-	    if((*iter)->lastMeasurement().updatedState().globalMomentum().perp() < minPt){
-	      mask[i] = false;
-	      skipnext=true;
-	      seedmap[j].insert(seedmap[j].end(), seedmap[i].begin(), seedmap[i].end());
-	      seedmap.erase(i);
-	      LogTrace(metname) << "Trajectory # " << i << " (pT="<<(*iter)->lastMeasurement().updatedState().globalMomentum().perp() 
-				<< " GeV) rejected because it has too low pt";
-	    } 
-	    else {
-	      mask[j] = false;
-	      seedmap[i].insert(seedmap[i].end(), seedmap[j].begin(), seedmap[j].end());
-	      seedmap.erase(j);
-	      LogTrace(metname) << "Trajectory # " << j << " (pT="<<(*jter)->lastMeasurement().updatedState().globalMomentum().perp() 
-				<< " GeV) rejected because it has too low pt";
-	    }
-	  }
-	  else{   
-	    if (chi2_dof_i  > chi2_dof_j) {
-	      mask[i] = false;
-	      skipnext=true;
-	      seedmap[j].insert(seedmap[j].end(), seedmap[i].begin(), seedmap[i].end());
-	      seedmap.erase(i);
-	      LogTrace(metname) << "Trajectory # " << i << " (pT="<<(*iter)->lastMeasurement().updatedState().globalMomentum().perp() << " GeV) rejected";
-	    }
-	    else{
-	      mask[j] = false;
-	      seedmap[i].insert(seedmap[i].end(), seedmap[j].begin(), seedmap[j].end());
-	      seedmap.erase(j);
-	      LogTrace(metname) << "Trajectory # " << j << " (pT="<<(*jter)->lastMeasurement().updatedState().globalMomentum().perp() << " GeV) rejected";
-	    }
-	  }
-	}
-        else { // different number of hits
-          if ( hit_diff < 0 ) {
-            mask[i] = false;
-            skipnext=true;
-	    seedmap[j].insert(seedmap[j].end(), seedmap[i].begin(), seedmap[i].end());
-	    seedmap.erase(i);
-	    LogTrace(metname) << "Trajectory # " << i << " (pT="<<(*iter)->lastMeasurement().updatedState().globalMomentum().perp() << " GeV) rejected";
+          if (fraction >= maxFraction && belowLimit == 1 && above == 1) {
+            if ((*iter)->lastMeasurement().updatedState().globalMomentum().perp() < minPt) {
+              mask[i] = false;
+              skipnext = true;
+              seedmap[j].insert(seedmap[j].end(), seedmap[i].begin(), seedmap[i].end());
+              seedmap.erase(i);
+              LogTrace(metname) << "Trajectory # " << i
+                                << " (pT=" << (*iter)->lastMeasurement().updatedState().globalMomentum().perp()
+                                << " GeV) rejected because it has too low pt";
+            } else {
+              mask[j] = false;
+              seedmap[i].insert(seedmap[i].end(), seedmap[j].begin(), seedmap[j].end());
+              seedmap.erase(j);
+              LogTrace(metname) << "Trajectory # " << j
+                                << " (pT=" << (*jter)->lastMeasurement().updatedState().globalMomentum().perp()
+                                << " GeV) rejected because it has too low pt";
+            }
+          } else {
+            if (chi2_dof_i > chi2_dof_j) {
+              mask[i] = false;
+              skipnext = true;
+              seedmap[j].insert(seedmap[j].end(), seedmap[i].begin(), seedmap[i].end());
+              seedmap.erase(i);
+              LogTrace(metname) << "Trajectory # " << i
+                                << " (pT=" << (*iter)->lastMeasurement().updatedState().globalMomentum().perp()
+                                << " GeV) rejected";
+            } else {
+              mask[j] = false;
+              seedmap[i].insert(seedmap[i].end(), seedmap[j].begin(), seedmap[j].end());
+              seedmap.erase(j);
+              LogTrace(metname) << "Trajectory # " << j
+                                << " (pT=" << (*jter)->lastMeasurement().updatedState().globalMomentum().perp()
+                                << " GeV) rejected";
+            }
           }
-          else { 
-	    mask[j] = false;
-	    seedmap[i].insert(seedmap[i].end(), seedmap[j].begin(), seedmap[j].end());
-	    seedmap.erase(j);
-	    LogTrace(metname) << "Trajectory # " << j << " (pT="<<(*jter)->lastMeasurement().updatedState().globalMomentum().perp() << " GeV) rejected";
-	  }
-        } 
+        } else {  // different number of hits
+          if (hit_diff < 0) {
+            mask[i] = false;
+            skipnext = true;
+            seedmap[j].insert(seedmap[j].end(), seedmap[i].begin(), seedmap[i].end());
+            seedmap.erase(i);
+            LogTrace(metname) << "Trajectory # " << i
+                              << " (pT=" << (*iter)->lastMeasurement().updatedState().globalMomentum().perp()
+                              << " GeV) rejected";
+          } else {
+            mask[j] = false;
+            seedmap[i].insert(seedmap[i].end(), seedmap[j].begin(), seedmap[j].end());
+            seedmap.erase(j);
+            LogTrace(metname) << "Trajectory # " << j
+                              << " (pT=" << (*jter)->lastMeasurement().updatedState().globalMomentum().perp()
+                              << " GeV) rejected";
+          }
+        }
       }
-      if(skipnext) break;
+      if (skipnext)
+        break;
       j++;
     }
     i++;
-    if(skipnext) continue;
+    if (skipnext)
+      continue;
   }
-  
 
   // Association map between the seed of the chosen trajectory and the seeds of the discarded trajectories
-  if(reportGhosts_) {
+  if (reportGhosts_) {
     LogTrace(metname) << " Creating map between chosen seed and ghost seeds." << std::endl;
 
     auto seedToSeedsMap = std::make_unique<L2SeedAssoc>();
-    if(!seeds->empty()) {
+    if (!seeds->empty()) {
       edm::Ptr<TrajectorySeed> ptr = seeds->ptrAt(0);
       edm::Handle<L2MuonTrajectorySeedCollection> seedsHandle;
       event.get(ptr.id(), seedsHandle);
@@ -168,29 +197,32 @@ void MuonTrajectoryCleaner::clean(TrajectoryContainer& trajC, edm::Event& event,
 
     int seedcnt(0);
 
-    for(map<int, vector<int> >::iterator itmap=seedmap.begin(); itmap!=seedmap.end(); ++itmap, ++seedcnt) {
+    for (map<int, vector<int> >::iterator itmap = seedmap.begin(); itmap != seedmap.end(); ++itmap, ++seedcnt) {
       edm::RefToBase<TrajectorySeed> tmpSeedRef1 = trajC[(*itmap).first]->seedRef();
-      edm::Ref<L2MuonTrajectorySeedCollection> tmpL2SeedRef1 = tmpSeedRef1.castTo<edm::Ref<L2MuonTrajectorySeedCollection> >();
+      edm::Ref<L2MuonTrajectorySeedCollection> tmpL2SeedRef1 =
+          tmpSeedRef1.castTo<edm::Ref<L2MuonTrajectorySeedCollection> >();
 
-      int tmpsize=(*itmap).second.size();
-      for(int cnt=0; cnt!=tmpsize; ++cnt) {
-	edm::RefToBase<TrajectorySeed> tmpSeedRef2 = trajC[(*itmap).second[cnt]]->seedRef();
-	edm::Ref<L2MuonTrajectorySeedCollection> tmpL2SeedRef2 = tmpSeedRef2.castTo<edm::Ref<L2MuonTrajectorySeedCollection> >();
-	seedToSeedsMap->insert(tmpL2SeedRef1, tmpL2SeedRef2);
+      int tmpsize = (*itmap).second.size();
+      for (int cnt = 0; cnt != tmpsize; ++cnt) {
+        edm::RefToBase<TrajectorySeed> tmpSeedRef2 = trajC[(*itmap).second[cnt]]->seedRef();
+        edm::Ref<L2MuonTrajectorySeedCollection> tmpL2SeedRef2 =
+            tmpSeedRef2.castTo<edm::Ref<L2MuonTrajectorySeedCollection> >();
+        seedToSeedsMap->insert(tmpL2SeedRef1, tmpL2SeedRef2);
       }
     }
 
     event.put(std::move(seedToSeedsMap), "");
 
-  } // end if(reportGhosts_)
+  }  // end if(reportGhosts_)
 
   i = 0;
-  for ( iter = trajC.begin(); iter != trajC.end(); iter++ ) {
-    if ( mask[i] ){
+  for (iter = trajC.begin(); iter != trajC.end(); iter++) {
+    if (mask[i]) {
       result.push_back(*iter);
-      LogTrace(metname) << "Keep trajectory with pT = " << (*iter)->lastMeasurement().updatedState().globalMomentum().perp() << " GeV";
-    }
-    else delete *iter;
+      LogTrace(metname) << "Keep trajectory with pT = "
+                        << (*iter)->lastMeasurement().updatedState().globalMomentum().perp() << " GeV";
+    } else
+      delete *iter;
     i++;
   }
 
@@ -201,21 +233,22 @@ void MuonTrajectoryCleaner::clean(TrajectoryContainer& trajC, edm::Event& event,
 //
 // clean CandidateContainer
 //
-void MuonTrajectoryCleaner::clean(CandidateContainer& candC){ 
+void MuonTrajectoryCleaner::clean(CandidateContainer& candC) {
   const std::string metname = "Muon|RecoMuon|MuonTrajectoryCleaner";
 
   LogTrace(metname) << "Muon Trajectory Cleaner called" << endl;
 
-  if ( candC.size() < 2 ) return;
+  if (candC.size() < 2)
+    return;
 
   CandidateContainer::iterator iter, jter;
   Trajectory::DataContainer::const_iterator m1, m2;
 
   const float deltaEta = 0.01;
   const float deltaPhi = 0.01;
-  const float deltaPt  = 1.0;
-  
-  LogTrace(metname) << "Number of muon candidates in the container: " <<candC.size()<< endl;
+  const float deltaPt = 1.0;
+
+  LogTrace(metname) << "Number of muon candidates in the container: " << candC.size() << endl;
 
   int i(0), j(0);
   int match(0);
@@ -224,113 +257,125 @@ void MuonTrajectoryCleaner::clean(CandidateContainer& candC){
   // CAVEAT: vector<bool> is not a vector, its elements are not addressable!
   // This is fine as long as only operator [] is used as in this case.
   // cf. par 16.3.11
-  vector<bool> mask(candC.size(),true);
-  
+  vector<bool> mask(candC.size(), true);
+
   CandidateContainer result;
-  
-  for ( iter = candC.begin(); iter != candC.end(); iter++ ) {
-    if ( !mask[i] ) { i++; continue; }
+
+  for (iter = candC.begin(); iter != candC.end(); iter++) {
+    if (!mask[i]) {
+      i++;
+      continue;
+    }
     const Trajectory::DataContainer& meas1 = (*iter)->trajectory()->measurements();
-    j = i+1;
-    bool skipnext=false;
+    j = i + 1;
+    bool skipnext = false;
 
     TrajectoryStateOnSurface innerTSOS;
 
     if ((*iter)->trajectory()->direction() == alongMomentum) {
       innerTSOS = (*iter)->trajectory()->firstMeasurement().updatedState();
-    } 
-    else if ((*iter)->trajectory()->direction() == oppositeToMomentum) { 
+    } else if ((*iter)->trajectory()->direction() == oppositeToMomentum) {
       innerTSOS = (*iter)->trajectory()->lastMeasurement().updatedState();
-	 }
-    if ( !(innerTSOS.isValid()) ) continue;
+    }
+    if (!(innerTSOS.isValid()))
+      continue;
     float pt1 = innerTSOS.globalMomentum().perp();
     float eta1 = innerTSOS.globalMomentum().eta();
     float phi1 = innerTSOS.globalMomentum().phi();
 
-    for ( jter = iter+1; jter != candC.end(); jter++ ) {
-      if ( !mask[j] ) { j++; continue; }
+    for (jter = iter + 1; jter != candC.end(); jter++) {
+      if (!mask[j]) {
+        j++;
+        continue;
+      }
       //UNUSED:      directionMatch = false;
       const Trajectory::DataContainer& meas2 = (*jter)->trajectory()->measurements();
       match = 0;
-      for ( m1 = meas1.begin(); m1 != meas1.end(); m1++ ) {
-        for ( m2 = meas2.begin(); m2 != meas2.end(); m2++ ) {
-          if ( (*m1).recHit()->isValid() && (*m2).recHit()->isValid() ) 
-	    if ( ( (*m1).recHit()->globalPosition() - (*m2).recHit()->globalPosition()).mag()< 10e-5 ) match++;
+      for (m1 = meas1.begin(); m1 != meas1.end(); m1++) {
+        for (m2 = meas2.begin(); m2 != meas2.end(); m2++) {
+          if ((*m1).recHit()->isValid() && (*m2).recHit()->isValid())
+            if (((*m1).recHit()->globalPosition() - (*m2).recHit()->globalPosition()).mag() < 10e-5)
+              match++;
         }
       }
-      
-      LogTrace(metname) 
-	<< " MuonTrajectoryCleaner: candC " << i << " chi2/nRH = " 
-	<< (*iter)->trajectory()->chiSquared() << "/" << (*iter)->trajectory()->foundHits() <<
-	" vs trajC " << j << " chi2/nRH = " << (*jter)->trajectory()->chiSquared() <<
-	"/" << (*jter)->trajectory()->foundHits() << " Shared RecHits: " << match;
 
-      TrajectoryStateOnSurface innerTSOS2;       
+      LogTrace(metname) << " MuonTrajectoryCleaner: candC " << i
+                        << " chi2/nRH = " << (*iter)->trajectory()->chiSquared() << "/"
+                        << (*iter)->trajectory()->foundHits() << " vs trajC " << j
+                        << " chi2/nRH = " << (*jter)->trajectory()->chiSquared() << "/"
+                        << (*jter)->trajectory()->foundHits() << " Shared RecHits: " << match;
+
+      TrajectoryStateOnSurface innerTSOS2;
       if ((*jter)->trajectory()->direction() == alongMomentum) {
         innerTSOS2 = (*jter)->trajectory()->firstMeasurement().updatedState();
-      }
-      else if ((*jter)->trajectory()->direction() == oppositeToMomentum) {
+      } else if ((*jter)->trajectory()->direction() == oppositeToMomentum) {
         innerTSOS2 = (*jter)->trajectory()->lastMeasurement().updatedState();
       }
-      if ( !(innerTSOS2.isValid()) ) continue;
+      if (!(innerTSOS2.isValid()))
+        continue;
 
       float pt2 = innerTSOS2.globalMomentum().perp();
       float eta2 = innerTSOS2.globalMomentum().eta();
       float phi2 = innerTSOS2.globalMomentum().phi();
 
-      float deta(fabs(eta1-eta2));
-      float dphi(fabs(Geom::Phi<float>(phi1)-Geom::Phi<float>(phi2)));
-      float dpt(fabs(pt1-pt2));
-      if ( dpt < deltaPt && deta < deltaEta && dphi < deltaPhi ) {
-	//UNUSED:        directionMatch = true;
-        LogTrace(metname)
-        << " MuonTrajectoryCleaner: candC " << i<<" and "<<j<< " direction matched: "
-        <<innerTSOS.globalMomentum()<<" and " <<innerTSOS2.globalMomentum();
+      float deta(fabs(eta1 - eta2));
+      float dphi(fabs(Geom::Phi<float>(phi1) - Geom::Phi<float>(phi2)));
+      float dpt(fabs(pt1 - pt2));
+      if (dpt < deltaPt && deta < deltaEta && dphi < deltaPhi) {
+        //UNUSED:        directionMatch = true;
+        LogTrace(metname) << " MuonTrajectoryCleaner: candC " << i << " and " << j
+                          << " direction matched: " << innerTSOS.globalMomentum() << " and "
+                          << innerTSOS2.globalMomentum();
       }
 
       // If there are matches, reject the worst track
-      bool hitsMatch = ((match > 0) && ((match/((*iter)->trajectory()->foundHits()) > 0.25) || (match/((*jter)->trajectory()->foundHits()) > 0.25))) ? true : false;
-      bool tracksMatch = 
-      ( ( (*iter)->trackerTrack() == (*jter)->trackerTrack() ) && 
-        ( deltaR<double>((*iter)->muonTrack()->eta(),(*iter)->muonTrack()->phi(), (*jter)->muonTrack()->eta(),(*jter)->muonTrack()->phi()) < 0.2) );
+      bool hitsMatch = ((match > 0) && ((match / ((*iter)->trajectory()->foundHits()) > 0.25) ||
+                                        (match / ((*jter)->trajectory()->foundHits()) > 0.25)))
+                           ? true
+                           : false;
+      bool tracksMatch =
+          (((*iter)->trackerTrack() == (*jter)->trackerTrack()) && (deltaR<double>((*iter)->muonTrack()->eta(),
+                                                                                   (*iter)->muonTrack()->phi(),
+                                                                                   (*jter)->muonTrack()->eta(),
+                                                                                   (*jter)->muonTrack()->phi()) < 0.2));
 
       //if ( ( tracksMatch ) || (hitsMatch > 0) || directionMatch ) {
-			if ( ( tracksMatch ) || (hitsMatch > 0) ) { 
-	if (  (*iter)->trajectory()->foundHits() == (*jter)->trajectory()->foundHits() ) {
-          if ( (*iter)->trajectory()->chiSquared() > (*jter)->trajectory()->chiSquared() ) {
+      if ((tracksMatch) || (hitsMatch > 0)) {
+        if ((*iter)->trajectory()->foundHits() == (*jter)->trajectory()->foundHits()) {
+          if ((*iter)->trajectory()->chiSquared() > (*jter)->trajectory()->chiSquared()) {
             mask[i] = false;
-            skipnext=true;
-          }
-          else mask[j] = false;
+            skipnext = true;
+          } else
+            mask[j] = false;
+        } else {  // different number of hits
+          if ((*iter)->trajectory()->foundHits() < (*jter)->trajectory()->foundHits()) {
+            mask[i] = false;
+            skipnext = true;
+          } else
+            mask[j] = false;
         }
-        else { // different number of hits
-          if ( (*iter)->trajectory()->foundHits() < (*jter)->trajectory()->foundHits() ) {
-	    mask[i] = false;
-            skipnext=true;
-          }
-          else mask[j] = false;
-	}
       }
-      if(skipnext) break;
+      if (skipnext)
+        break;
       j++;
     }
     i++;
-    if(skipnext) continue;
+    if (skipnext)
+      continue;
   }
-  
+
   i = 0;
-  for ( iter = candC.begin(); iter != candC.end(); iter++ ) {
-    if ( mask[i] ) {
-       result.push_back(*iter);
+  for (iter = candC.begin(); iter != candC.end(); iter++) {
+    if (mask[i]) {
+      result.push_back(*iter);
     } else {
-       delete (*iter)->trajectory();
-       delete (*iter)->trackerTrajectory();
-       delete *iter;
-    } 
+      delete (*iter)->trajectory();
+      delete (*iter)->trackerTrajectory();
+      delete *iter;
+    }
     i++;
   }
-  
+
   candC.clear();
   candC = result;
 }
-

--- a/RecoMuon/TrackingTools/src/MuonTrajectoryUpdator.cc
+++ b/RecoMuon/TrackingTools/src/MuonTrajectoryUpdator.cc
@@ -14,7 +14,6 @@
  *  Modified by D. Nash: ME0 Implementation
  */
 
-
 #include "RecoMuon/TrackingTools/interface/MuonTrajectoryUpdator.h"
 #include "RecoMuon/TrackingTools/interface/MuonPatternRecoDumper.h"
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
@@ -40,253 +39,241 @@ using namespace edm;
 using namespace std;
 
 /// Constructor from Propagator and Parameter set
-MuonTrajectoryUpdator::MuonTrajectoryUpdator(const edm::ParameterSet& par,
-					     NavigationDirection fitDirection): theFitDirection(fitDirection){
-  
+MuonTrajectoryUpdator::MuonTrajectoryUpdator(const edm::ParameterSet& par, NavigationDirection fitDirection)
+    : theFitDirection(fitDirection) {
   // The max allowed chi2 to accept a rechit in the fit
   theMaxChi2 = par.getParameter<double>("MaxChi2");
   theEstimator = new Chi2MeasurementEstimator(theMaxChi2);
-  
+
   // The KF updator
-  theUpdator= new KFUpdator();
+  theUpdator = new KFUpdator();
 
   // The granularity
   theGranularity = par.getParameter<int>("Granularity");
 
   // Rescale the error of the first state?
-  theRescaleErrorFlag =  par.getParameter<bool>("RescaleError");
+  theRescaleErrorFlag = par.getParameter<bool>("RescaleError");
 
-  if(theRescaleErrorFlag)
+  if (theRescaleErrorFlag)
     // The rescale factor
-    theRescaleFactor =  par.getParameter<double>("RescaleErrorFactor");
-  
+    theRescaleFactor = par.getParameter<double>("RescaleErrorFactor");
+
   // Use the invalid hits?
-  useInvalidHits =  par.getParameter<bool>("UseInvalidHits");
+  useInvalidHits = par.getParameter<bool>("UseInvalidHits");
 
   // Flag needed for the rescaling
   theFirstTSOSFlag = true;
 
   // Exlude RPC from the fit?
-   theRPCExFlag = par.getParameter<bool>("ExcludeRPCFromFit");
+  theRPCExFlag = par.getParameter<bool>("ExcludeRPCFromFit");
 }
 
-MuonTrajectoryUpdator::MuonTrajectoryUpdator( NavigationDirection fitDirection,
-					      double chi2, int granularity): theMaxChi2(chi2),
-									     theGranularity(granularity),
-									     theFitDirection(fitDirection){
+MuonTrajectoryUpdator::MuonTrajectoryUpdator(NavigationDirection fitDirection, double chi2, int granularity)
+    : theMaxChi2(chi2), theGranularity(granularity), theFitDirection(fitDirection) {
   theEstimator = new Chi2MeasurementEstimator(theMaxChi2);
-  
+
   // The KF updator
-  theUpdator= new KFUpdator();
+  theUpdator = new KFUpdator();
 }
 
 /// Destructor
-MuonTrajectoryUpdator::~MuonTrajectoryUpdator(){
+MuonTrajectoryUpdator::~MuonTrajectoryUpdator() {
   delete theEstimator;
   delete theUpdator;
 }
 
-void MuonTrajectoryUpdator::makeFirstTime(){
-  theFirstTSOSFlag = true;
-}
+void MuonTrajectoryUpdator::makeFirstTime() { theFirstTSOSFlag = true; }
 
-
-pair<bool,TrajectoryStateOnSurface> 
-MuonTrajectoryUpdator::update(const TrajectoryMeasurement* measurement,
-			      Trajectory& trajectory,
-			      const Propagator *propagator){
-  
+pair<bool, TrajectoryStateOnSurface> MuonTrajectoryUpdator::update(const TrajectoryMeasurement* measurement,
+                                                                   Trajectory& trajectory,
+                                                                   const Propagator* propagator) {
   const std::string metname = "Muon|RecoMuon|MuonTrajectoryUpdator";
 
   MuonPatternRecoDumper muonDumper;
 
   // Status of the updating
-  bool updated=false;
-  
-  if(!measurement) return pair<bool,TrajectoryStateOnSurface>(updated,TrajectoryStateOnSurface() );
+  bool updated = false;
+
+  if (!measurement)
+    return pair<bool, TrajectoryStateOnSurface>(updated, TrajectoryStateOnSurface());
 
   // measurement layer
-  const DetLayer* detLayer=measurement->layer();
+  const DetLayer* detLayer = measurement->layer();
 
-  // these are the 4D segment for the CSC/DT and a point for the RPC 
+  // these are the 4D segment for the CSC/DT and a point for the RPC
   TransientTrackingRecHit::ConstRecHitPointer muonRecHit = measurement->recHit();
- 
+
   // The KFUpdator takes TransientTrackingRecHits as arg.
   TransientTrackingRecHit::ConstRecHitContainer recHitsForFit =
-  MuonTransientTrackingRecHitBreaker::breakInSubRecHits(muonRecHit,theGranularity);
+      MuonTransientTrackingRecHitBreaker::breakInSubRecHits(muonRecHit, theGranularity);
 
   // sort the container in agreement with the porpagation direction
-  sort(recHitsForFit,detLayer);
-  
+  sort(recHitsForFit, detLayer);
+
   TrajectoryStateOnSurface lastUpdatedTSOS = measurement->predictedState();
-  
-  LogTrace(metname)<<"Number of rechits for the fit: "<<recHitsForFit.size()<<endl;
- 
+
+  LogTrace(metname) << "Number of rechits for the fit: " << recHitsForFit.size() << endl;
+
   TransientTrackingRecHit::ConstRecHitContainer::iterator recHit;
-  for(recHit = recHitsForFit.begin(); recHit != recHitsForFit.end(); ++recHit ) {
-    if ((*recHit)->isValid() ) {
-
+  for (recHit = recHitsForFit.begin(); recHit != recHitsForFit.end(); ++recHit) {
+    if ((*recHit)->isValid()) {
       // propagate the TSOS onto the rechit plane
-      TrajectoryStateOnSurface propagatedTSOS  = propagateState(lastUpdatedTSOS, measurement, 
-								*recHit, propagator);
-      
-      if ( propagatedTSOS.isValid() ) {
-        pair<bool,double> thisChi2 = estimator()->estimate(propagatedTSOS, *((*recHit).get()));
+      TrajectoryStateOnSurface propagatedTSOS = propagateState(lastUpdatedTSOS, measurement, *recHit, propagator);
 
-	LogTrace(metname) << "Estimation for Kalman Fit. Chi2: " << thisChi2.second;
+      if (propagatedTSOS.isValid()) {
+        pair<bool, double> thisChi2 = estimator()->estimate(propagatedTSOS, *((*recHit).get()));
 
-	// Is an RPC hit? Prepare the variable to possibly exluding it from the fit
-	bool wantIncludeThisHit = true;
-	if (theRPCExFlag && 
-	    (*recHit)->geographicalId().det() == DetId::Muon &&
-	    (*recHit)->geographicalId().subdetId() == MuonSubdetId::RPC){
-	  wantIncludeThisHit = false;	
-	  LogTrace(metname) << "This is an RPC hit and the present configuration is such that it will be excluded from the fit";
-	}
+        LogTrace(metname) << "Estimation for Kalman Fit. Chi2: " << thisChi2.second;
 
-	
+        // Is an RPC hit? Prepare the variable to possibly exluding it from the fit
+        bool wantIncludeThisHit = true;
+        if (theRPCExFlag && (*recHit)->geographicalId().det() == DetId::Muon &&
+            (*recHit)->geographicalId().subdetId() == MuonSubdetId::RPC) {
+          wantIncludeThisHit = false;
+          LogTrace(metname)
+              << "This is an RPC hit and the present configuration is such that it will be excluded from the fit";
+        }
+
         // The Chi2 cut was already applied in the estimator, which
         // returns 0 if the chi2 is bigger than the cut defined in its
         // constructor
-	if (thisChi2.first) {
-          updated=true;
-	  if (wantIncludeThisHit) { // This split is a trick to have the RPC hits counted as updatable (in used chamber counting), while are not actually included in the fit when the proper obtion is activated.
+        if (thisChi2.first) {
+          updated = true;
+          if (wantIncludeThisHit) {  // This split is a trick to have the RPC hits counted as updatable (in used chamber counting), while are not actually included in the fit when the proper obtion is activated.
 
-          LogTrace(metname) << endl 
-			    << "     Kalman Start" << "\n" << "\n";
-          LogTrace(metname) << "  Meas. Position : " << (**recHit).globalPosition() << "\n"
-			    << "  Pred. Position : " << propagatedTSOS.globalPosition()
-			    << "  Pred Direction : " << propagatedTSOS.globalDirection()<< endl;
+            LogTrace(metname) << endl
+                              << "     Kalman Start"
+                              << "\n"
+                              << "\n";
+            LogTrace(metname) << "  Meas. Position : " << (**recHit).globalPosition() << "\n"
+                              << "  Pred. Position : " << propagatedTSOS.globalPosition()
+                              << "  Pred Direction : " << propagatedTSOS.globalDirection() << endl;
 
-	  if(theRescaleErrorFlag && theFirstTSOSFlag){
-	    propagatedTSOS.rescaleError(theRescaleFactor);
-	    theFirstTSOSFlag = false;
-	  }
+            if (theRescaleErrorFlag && theFirstTSOSFlag) {
+              propagatedTSOS.rescaleError(theRescaleFactor);
+              theFirstTSOSFlag = false;
+            }
 
-          lastUpdatedTSOS = measurementUpdator()->update(propagatedTSOS,*((*recHit).get()));
+            lastUpdatedTSOS = measurementUpdator()->update(propagatedTSOS, *((*recHit).get()));
 
-          LogTrace(metname) << "  Fit   Position : " << lastUpdatedTSOS.globalPosition()
-			    << "  Fit  Direction : " << lastUpdatedTSOS.globalDirection()
-			    << "\n"
-			    << "  Fit position radius : " 
-			    << lastUpdatedTSOS.globalPosition().perp()
-			    << "filter updated" << endl;
-	  
-	  LogTrace(metname) << muonDumper.dumpTSOS(lastUpdatedTSOS);
-	  
-	  LogTrace(metname) << "\n\n     Kalman End" << "\n" << "\n";	      
-	  
-	  TrajectoryMeasurement && updatedMeasurement = updateMeasurement( propagatedTSOS, lastUpdatedTSOS, 
-									*recHit, thisChi2.second, detLayer, 
-									measurement);
-	  // FIXME: check!
-	  trajectory.push(std::move(updatedMeasurement), thisChi2.second);	
-	  }
-	  else {
-	    LogTrace(metname) << "  Compatible RecHit with good chi2 but made with RPC when it was decided to not include it in the fit"
-			      << "  --> trajectory NOT updated, invalid RecHit added." << endl;
-	      
-	    MuonTransientTrackingRecHit::MuonRecHitPointer invalidRhPtr = MuonTransientTrackingRecHit::specificBuild( (*recHit)->det(), (*recHit)->hit() );
-	    invalidRhPtr->invalidateHit();
-	    TrajectoryMeasurement invalidRhMeasurement(propagatedTSOS, propagatedTSOS, invalidRhPtr,  thisChi2.second, detLayer);
-	    trajectory.push(std::move(invalidRhMeasurement), thisChi2.second);	  	    
-	  }
-	}
-	else {
-          if(useInvalidHits) {
-            LogTrace(metname) << "  Compatible RecHit with too large chi2"
-			    << "  --> trajectory NOT updated, invalid RecHit added." << endl;
+            LogTrace(metname) << "  Fit   Position : " << lastUpdatedTSOS.globalPosition()
+                              << "  Fit  Direction : " << lastUpdatedTSOS.globalDirection() << "\n"
+                              << "  Fit position radius : " << lastUpdatedTSOS.globalPosition().perp()
+                              << "filter updated" << endl;
 
-	    MuonTransientTrackingRecHit::MuonRecHitPointer invalidRhPtr = MuonTransientTrackingRecHit::specificBuild( (*recHit)->det(), (*recHit)->hit() );
-	    invalidRhPtr->invalidateHit();
-	    TrajectoryMeasurement invalidRhMeasurement(propagatedTSOS, propagatedTSOS, invalidRhPtr, thisChi2.second, detLayer);
-	    trajectory.push(std::move(invalidRhMeasurement), thisChi2.second);	  
+            LogTrace(metname) << muonDumper.dumpTSOS(lastUpdatedTSOS);
+
+            LogTrace(metname) << "\n\n     Kalman End"
+                              << "\n"
+                              << "\n";
+
+            TrajectoryMeasurement&& updatedMeasurement =
+                updateMeasurement(propagatedTSOS, lastUpdatedTSOS, *recHit, thisChi2.second, detLayer, measurement);
+            // FIXME: check!
+            trajectory.push(std::move(updatedMeasurement), thisChi2.second);
+          } else {
+            LogTrace(metname) << "  Compatible RecHit with good chi2 but made with RPC when it was decided to not "
+                                 "include it in the fit"
+                              << "  --> trajectory NOT updated, invalid RecHit added." << endl;
+
+            MuonTransientTrackingRecHit::MuonRecHitPointer invalidRhPtr =
+                MuonTransientTrackingRecHit::specificBuild((*recHit)->det(), (*recHit)->hit());
+            invalidRhPtr->invalidateHit();
+            TrajectoryMeasurement invalidRhMeasurement(
+                propagatedTSOS, propagatedTSOS, invalidRhPtr, thisChi2.second, detLayer);
+            trajectory.push(std::move(invalidRhMeasurement), thisChi2.second);
           }
-	}
+        } else {
+          if (useInvalidHits) {
+            LogTrace(metname) << "  Compatible RecHit with too large chi2"
+                              << "  --> trajectory NOT updated, invalid RecHit added." << endl;
+
+            MuonTransientTrackingRecHit::MuonRecHitPointer invalidRhPtr =
+                MuonTransientTrackingRecHit::specificBuild((*recHit)->det(), (*recHit)->hit());
+            invalidRhPtr->invalidateHit();
+            TrajectoryMeasurement invalidRhMeasurement(
+                propagatedTSOS, propagatedTSOS, invalidRhPtr, thisChi2.second, detLayer);
+            trajectory.push(std::move(invalidRhMeasurement), thisChi2.second);
+          }
+        }
       }
     }
   }
   recHitsForFit.clear();
-  return pair<bool,TrajectoryStateOnSurface>(updated,lastUpdatedTSOS);
+  return pair<bool, TrajectoryStateOnSurface>(updated, lastUpdatedTSOS);
 }
 
-TrajectoryStateOnSurface 
-MuonTrajectoryUpdator::propagateState(const TrajectoryStateOnSurface& state,
-				      const TrajectoryMeasurement* measurement, 
-				      const TransientTrackingRecHit::ConstRecHitPointer  & current,
-				      const Propagator *propagator) const{
-
+TrajectoryStateOnSurface MuonTrajectoryUpdator::propagateState(
+    const TrajectoryStateOnSurface& state,
+    const TrajectoryMeasurement* measurement,
+    const TransientTrackingRecHit::ConstRecHitPointer& current,
+    const Propagator* propagator) const {
   const TransientTrackingRecHit::ConstRecHitPointer& mother = measurement->recHit();
 
-  if( current->geographicalId() == mother->geographicalId() )
+  if (current->geographicalId() == mother->geographicalId())
     return measurement->predictedState();
-  
-  const TrajectoryStateOnSurface  tsos =
-    propagator->propagate(state, current->det()->surface());
-  return tsos;
 
+  const TrajectoryStateOnSurface tsos = propagator->propagate(state, current->det()->surface());
+  return tsos;
 }
 
 // FIXME: would I a different threatment for the two prop dirrections??
-TrajectoryMeasurement MuonTrajectoryUpdator::updateMeasurement(  const TrajectoryStateOnSurface &propagatedTSOS, 
-								 const TrajectoryStateOnSurface &lastUpdatedTSOS, 
-								 const TransientTrackingRecHit::ConstRecHitPointer &recHit,
-								 const double &chi2, const DetLayer *detLayer, 
-								 const TrajectoryMeasurement *initialMeasurement){
-  return TrajectoryMeasurement(propagatedTSOS, lastUpdatedTSOS, 
-			       recHit,chi2,detLayer);
+TrajectoryMeasurement MuonTrajectoryUpdator::updateMeasurement(const TrajectoryStateOnSurface& propagatedTSOS,
+                                                               const TrajectoryStateOnSurface& lastUpdatedTSOS,
+                                                               const TransientTrackingRecHit::ConstRecHitPointer& recHit,
+                                                               const double& chi2,
+                                                               const DetLayer* detLayer,
+                                                               const TrajectoryMeasurement* initialMeasurement) {
+  return TrajectoryMeasurement(propagatedTSOS, lastUpdatedTSOS, recHit, chi2, detLayer);
 
-  //   // FIXME: put a better check! One could fit in first out-in and then in - out 
-  //   if(propagator()->propagationDirection() == alongMomentum) 
-  //     return TrajectoryMeasurement(propagatedTSOS, lastUpdatedTSOS, 
+  //   // FIXME: put a better check! One could fit in first out-in and then in - out
+  //   if(propagator()->propagationDirection() == alongMomentum)
+  //     return TrajectoryMeasurement(propagatedTSOS, lastUpdatedTSOS,
   // 				 recHit,thisChi2.second,detLayer);
-  
+
   //   // FIXME: Check this carefully!!
   //   else if(propagator()->propagationDirection() == oppositeToMomentum)
   //     return TrajectoryMeasurement(initialMeasurement->forwardPredictedState(),
-  // 				 propagatedTSOS, lastUpdatedTSOS, 
+  // 				 propagatedTSOS, lastUpdatedTSOS,
   // 				 recHit,thisChi2.second,detLayer);
   //   else{
   //     LogError("MuonTrajectoryUpdator::updateMeasurement") <<"Wrong propagation direction!!";
   //   }
 }
 
-
-void MuonTrajectoryUpdator::sort(TransientTrackingRecHit::ConstRecHitContainer& recHitsForFit, 
-				 const DetLayer* detLayer){
-  
-  if(detLayer->subDetector()==GeomDetEnumerators::DT){
-    if(fitDirection() == insideOut)
-      stable_sort(recHitsForFit.begin(),recHitsForFit.end(), RadiusComparatorInOut() );
-    else if(fitDirection() == outsideIn)
-      stable_sort(recHitsForFit.begin(),recHitsForFit.end(),RadiusComparatorOutIn() ); 
+void MuonTrajectoryUpdator::sort(TransientTrackingRecHit::ConstRecHitContainer& recHitsForFit,
+                                 const DetLayer* detLayer) {
+  if (detLayer->subDetector() == GeomDetEnumerators::DT) {
+    if (fitDirection() == insideOut)
+      stable_sort(recHitsForFit.begin(), recHitsForFit.end(), RadiusComparatorInOut());
+    else if (fitDirection() == outsideIn)
+      stable_sort(recHitsForFit.begin(), recHitsForFit.end(), RadiusComparatorOutIn());
     else
-      LogError("Muon|RecoMuon|MuonTrajectoryUpdator") <<"MuonTrajectoryUpdator::sort: Wrong propagation direction!!";
+      LogError("Muon|RecoMuon|MuonTrajectoryUpdator") << "MuonTrajectoryUpdator::sort: Wrong propagation direction!!";
   }
 
-  else if(detLayer->subDetector()==GeomDetEnumerators::CSC){
-    if(fitDirection() == insideOut)
-      stable_sort(recHitsForFit.begin(),recHitsForFit.end(), ZedComparatorInOut() );
-    else if(fitDirection() == outsideIn)
-      stable_sort(recHitsForFit.begin(),recHitsForFit.end(), ZedComparatorOutIn() );  
+  else if (detLayer->subDetector() == GeomDetEnumerators::CSC) {
+    if (fitDirection() == insideOut)
+      stable_sort(recHitsForFit.begin(), recHitsForFit.end(), ZedComparatorInOut());
+    else if (fitDirection() == outsideIn)
+      stable_sort(recHitsForFit.begin(), recHitsForFit.end(), ZedComparatorOutIn());
     else
-      LogError("Muon|RecoMuon|MuonTrajectoryUpdator") <<"MuonTrajectoryUpdator::sort: Wrong propagation direction!!";
+      LogError("Muon|RecoMuon|MuonTrajectoryUpdator") << "MuonTrajectoryUpdator::sort: Wrong propagation direction!!";
   }
 
-  else if(detLayer->subDetector()==GeomDetEnumerators::GEM){
-    if(fitDirection() == insideOut)
-      stable_sort(recHitsForFit.begin(),recHitsForFit.end(), ZedComparatorInOut() );
-    else if(fitDirection() == outsideIn)
-      stable_sort(recHitsForFit.begin(),recHitsForFit.end(), ZedComparatorOutIn() );  
+  else if (detLayer->subDetector() == GeomDetEnumerators::GEM) {
+    if (fitDirection() == insideOut)
+      stable_sort(recHitsForFit.begin(), recHitsForFit.end(), ZedComparatorInOut());
+    else if (fitDirection() == outsideIn)
+      stable_sort(recHitsForFit.begin(), recHitsForFit.end(), ZedComparatorOutIn());
     else
-      LogError("Muon|RecoMuon|MuonTrajectoryUpdator") <<"MuonTrajectoryUpdator::sort: Wrong propagation direction!!";
-  }
-  else if(detLayer->subDetector()==GeomDetEnumerators::ME0){
-    if(fitDirection() == insideOut)
-      stable_sort(recHitsForFit.begin(),recHitsForFit.end(), ZedComparatorInOut() );
-    else if(fitDirection() == outsideIn)
-      stable_sort(recHitsForFit.begin(),recHitsForFit.end(), ZedComparatorOutIn() );  
+      LogError("Muon|RecoMuon|MuonTrajectoryUpdator") << "MuonTrajectoryUpdator::sort: Wrong propagation direction!!";
+  } else if (detLayer->subDetector() == GeomDetEnumerators::ME0) {
+    if (fitDirection() == insideOut)
+      stable_sort(recHitsForFit.begin(), recHitsForFit.end(), ZedComparatorInOut());
+    else if (fitDirection() == outsideIn)
+      stable_sort(recHitsForFit.begin(), recHitsForFit.end(), ZedComparatorOutIn());
     else
-      LogError("Muon|RecoMuon|MuonTrajectoryUpdator") <<"MuonTrajectoryUpdator::sort: Wrong propagation direction!!";
+      LogError("Muon|RecoMuon|MuonTrajectoryUpdator") << "MuonTrajectoryUpdator::sort: Wrong propagation direction!!";
   }
 }

--- a/RecoMuon/TrackingTools/src/MuonUpdatorAtVertex.cc
+++ b/RecoMuon/TrackingTools/src/MuonUpdatorAtVertex.cc
@@ -25,27 +25,25 @@
 using namespace std;
 
 /// Constructor
-MuonUpdatorAtVertex::MuonUpdatorAtVertex(const edm::ParameterSet& pset,
-					 const MuonServiceProxy *service):theService(service){
-   
+MuonUpdatorAtVertex::MuonUpdatorAtVertex(const edm::ParameterSet &pset, const MuonServiceProxy *service)
+    : theService(service) {
   thePropagatorName = pset.getParameter<string>("Propagator");
-    
 
   // Errors on the Beam spot position
-  vector<double> errors = pset.getParameter< vector<double> >("BeamSpotPositionErrors");
-  if(errors.size() != 3) 
+  vector<double> errors = pset.getParameter<vector<double> >("BeamSpotPositionErrors");
+  if (errors.size() != 3)
     edm::LogError("Muon|RecoMuon|MuonUpdatorAtVertex")
-      <<"MuonUpdatorAtVertex::BeamSpotPositionErrors wrong number of parameters!!";
-  
+        << "MuonUpdatorAtVertex::BeamSpotPositionErrors wrong number of parameters!!";
+
   // assume:
-  // errors[0] = sigma(x) 
-  // errors[1] = sigma(y) 
+  // errors[0] = sigma(x)
+  // errors[1] = sigma(y)
   // errors[2] = sigma(z)
 
   AlgebraicSymMatrix33 mat;
-  mat(0,0) = errors[0]*errors[0];
-  mat(1,1) = errors[1]*errors[1];
-  mat(2,2) = errors[2]*errors[2];
+  mat(0, 0) = errors[0] * errors[0];
+  mat(1, 1) = errors[1] * errors[1];
+  mat(2, 2) = errors[2] * errors[2];
   GlobalError glbErrPos(mat);
 
   thePositionErrors = glbErrPos;
@@ -55,150 +53,127 @@ MuonUpdatorAtVertex::MuonUpdatorAtVertex(const edm::ParameterSet& pset,
 }
 
 /// Destructor
-MuonUpdatorAtVertex::~MuonUpdatorAtVertex(){}
+MuonUpdatorAtVertex::~MuonUpdatorAtVertex() {}
 
 // Operations
 
 /// Propagate the state to the PCA in 2D, i.e. to the beam line
-pair<bool,FreeTrajectoryState>
-MuonUpdatorAtVertex::propagate(const TrajectoryStateOnSurface &tsos, const reco::BeamSpot & beamSpot) const{
-
+pair<bool, FreeTrajectoryState> MuonUpdatorAtVertex::propagate(const TrajectoryStateOnSurface &tsos,
+                                                               const reco::BeamSpot &beamSpot) const {
   const string metname = "Muon|RecoMuon|MuonUpdatorAtVertex";
- 
-  if(TrackerBounds::isInside(tsos.globalPosition())){
+
+  if (TrackerBounds::isInside(tsos.globalPosition())) {
     LogTrace(metname) << "Trajectory inside the Tracker";
 
     TSCBLBuilderNoMaterial tscblBuilder;
-    TrajectoryStateClosestToBeamLine tscbl = tscblBuilder(*(tsos.freeState()),
-							  beamSpot);
+    TrajectoryStateClosestToBeamLine tscbl = tscblBuilder(*(tsos.freeState()), beamSpot);
 
-    if(tscbl.isValid())
-      return pair<bool,FreeTrajectoryState>(true,tscbl.trackStateAtPCA());
+    if (tscbl.isValid())
+      return pair<bool, FreeTrajectoryState>(true, tscbl.trackStateAtPCA());
     else
       edm::LogWarning(metname) << "Propagation to the PCA using TSCPBuilderNoMaterial failed!"
-			       << " This can cause a severe bug.";
-  }
-  else{
+                               << " This can cause a severe bug.";
+  } else {
     LogTrace(metname) << "Trajectory inside the muon system";
 
-    FreeTrajectoryState
-      result =  theService->propagator(thePropagatorName)->propagate(*tsos.freeState(),beamSpot);
-    
-    LogTrace(metname) << "MuonUpdatorAtVertex::propagate, path: "
-		      << result << " parameters: " << result.parameters();
-    
-    if(result.hasError()) 
-      return pair<bool,FreeTrajectoryState>(true,result);
+    FreeTrajectoryState result = theService->propagator(thePropagatorName)->propagate(*tsos.freeState(), beamSpot);
+
+    LogTrace(metname) << "MuonUpdatorAtVertex::propagate, path: " << result << " parameters: " << result.parameters();
+
+    if (result.hasError())
+      return pair<bool, FreeTrajectoryState>(true, result);
     else
       edm::LogInfo(metname) << "Propagation to the PCA failed!";
   }
-  return pair<bool,FreeTrajectoryState>(false,FreeTrajectoryState());
+  return pair<bool, FreeTrajectoryState>(false, FreeTrajectoryState());
 }
 
-
-pair<bool,FreeTrajectoryState>
-MuonUpdatorAtVertex::update(const reco::TransientTrack & track, const reco::BeamSpot & beamSpot) const{
-
+pair<bool, FreeTrajectoryState> MuonUpdatorAtVertex::update(const reco::TransientTrack &track,
+                                                            const reco::BeamSpot &beamSpot) const {
   const std::string metname = "Muon|RecoMuon|MuonUpdatorAtVertex";
-    
-  
-  pair<bool,FreeTrajectoryState> result(false,FreeTrajectoryState());
 
-  GlobalPoint spotPos(beamSpot.x0(),beamSpot.y0(),beamSpot.z0());
+  pair<bool, FreeTrajectoryState> result(false, FreeTrajectoryState());
+
+  GlobalPoint spotPos(beamSpot.x0(), beamSpot.y0(), beamSpot.z0());
 
   SingleTrackVertexConstraint::BTFtuple constrainedTransientTrack;
 
   // Temporary hack here. A fix in the SingleTrackVertexConstraint code
-  // is needed. Once available try&catch will be removed 
-  try{
-    constrainedTransientTrack = theConstrictor.constrain(track, 
-							 spotPos, 
-							 thePositionErrors);
-  }
-  catch(cms::Exception& e) {
+  // is needed. Once available try&catch will be removed
+  try {
+    constrainedTransientTrack = theConstrictor.constrain(track, spotPos, thePositionErrors);
+  } catch (cms::Exception &e) {
     edm::LogWarning(metname) << "cms::Exception caught in MuonUpdatorAtVertex::update\n"
-			     << "Exception from SingleTrackVertexConstraint\n"
-			     << e.explainSelf();
+                             << "Exception from SingleTrackVertexConstraint\n"
+                             << e.explainSelf();
     return result;
   }
 
-
-  if(constrainedTransientTrack.get<0>())
-    if(constrainedTransientTrack.get<2>() <= theChi2Cut) {
+  if (constrainedTransientTrack.get<0>())
+    if (constrainedTransientTrack.get<2>() <= theChi2Cut) {
       result.first = true;
       result.second = *constrainedTransientTrack.get<1>().impactPointState().freeState();
-    }
-    else
-      LogTrace(metname) << "Constraint at vertex failed: too large chi2"; 
+    } else
+      LogTrace(metname) << "Constraint at vertex failed: too large chi2";
   else
-    LogTrace(metname) << "Constraint at vertex failed"; 
-  
+    LogTrace(metname) << "Constraint at vertex failed";
+
   return result;
 }
 
-pair<bool,FreeTrajectoryState>
-MuonUpdatorAtVertex::update(const FreeTrajectoryState& ftsAtVtx, const reco::BeamSpot & beamSpot) const{
-  
-  return update(theTransientTrackFactory.build(ftsAtVtx),beamSpot);
+pair<bool, FreeTrajectoryState> MuonUpdatorAtVertex::update(const FreeTrajectoryState &ftsAtVtx,
+                                                            const reco::BeamSpot &beamSpot) const {
+  return update(theTransientTrackFactory.build(ftsAtVtx), beamSpot);
 }
 
+pair<bool, FreeTrajectoryState> MuonUpdatorAtVertex::propagateWithUpdate(const TrajectoryStateOnSurface &tsos,
+                                                                         const reco::BeamSpot &beamSpot) const {
+  pair<bool, FreeTrajectoryState> propagationResult = propagate(tsos, beamSpot);
 
-pair<bool,FreeTrajectoryState>
-MuonUpdatorAtVertex::propagateWithUpdate(const TrajectoryStateOnSurface &tsos, const reco::BeamSpot & beamSpot) const{
-  
-  pair<bool,FreeTrajectoryState>
-    propagationResult = propagate(tsos,beamSpot);
-
-  if(propagationResult.first){
+  if (propagationResult.first) {
     return update(propagationResult.second, beamSpot);
-  }
-  else{
+  } else {
     edm::LogInfo("Muon|RecoMuon|MuonUpdatorAtVertex") << "Constraint at vertex failed";
-    return pair<bool,FreeTrajectoryState>(false,FreeTrajectoryState());
+    return pair<bool, FreeTrajectoryState>(false, FreeTrajectoryState());
   }
 }
 
+std::pair<bool, FreeTrajectoryState> MuonUpdatorAtVertex::propagateToNominalLine(
+    const TrajectoryStateOnSurface &tsos) const {
+  const string metname = "Muon|RecoMuon|MuonUpdatorAtVertex";
 
- std::pair<bool,FreeTrajectoryState>
- MuonUpdatorAtVertex::propagateToNominalLine(const TrajectoryStateOnSurface &tsos) const{
-   
-   const string metname = "Muon|RecoMuon|MuonUpdatorAtVertex";
-   
-   if(TrackerBounds::isInside(tsos.globalPosition())){
-     LogTrace(metname) << "Trajectory inside the Tracker";
-     
-     TSCPBuilderNoMaterial tscpBuilder;
-     TrajectoryStateClosestToPoint tscp = tscpBuilder(*(tsos.freeState()),
-						     GlobalPoint(0.,0.,0.));
-    
-    if(tscp.isValid())
-      return pair<bool,FreeTrajectoryState>(true,tscp.theState());
+  if (TrackerBounds::isInside(tsos.globalPosition())) {
+    LogTrace(metname) << "Trajectory inside the Tracker";
+
+    TSCPBuilderNoMaterial tscpBuilder;
+    TrajectoryStateClosestToPoint tscp = tscpBuilder(*(tsos.freeState()), GlobalPoint(0., 0., 0.));
+
+    if (tscp.isValid())
+      return pair<bool, FreeTrajectoryState>(true, tscp.theState());
     else
       edm::LogWarning(metname) << "Propagation to the PCA using TSCPBuilderNoMaterial failed!"
-			       << " This can cause a severe bug.";
-  }
-  else{
+                               << " This can cause a severe bug.";
+  } else {
     LogTrace(metname) << "Trajectory inside the muon system";
 
     // Define a line using two 3D-points
-    GlobalPoint p1(0.,0.,-1500);
-    GlobalPoint p2(0.,0.,1500);
-    
-    pair<FreeTrajectoryState,double> 
-      result = theService->propagator(thePropagatorName)->propagateWithPath(*tsos.freeState(),p1,p2);
-    
-    LogTrace(metname) << "MuonUpdatorAtVertex::propagate, path: "
-		      << result.second << " parameters: " << result.first.parameters();
-    
-    if(result.first.hasError()) 
-      return pair<bool,FreeTrajectoryState>(true,result.first);
+    GlobalPoint p1(0., 0., -1500);
+    GlobalPoint p2(0., 0., 1500);
+
+    pair<FreeTrajectoryState, double> result =
+        theService->propagator(thePropagatorName)->propagateWithPath(*tsos.freeState(), p1, p2);
+
+    LogTrace(metname) << "MuonUpdatorAtVertex::propagate, path: " << result.second
+                      << " parameters: " << result.first.parameters();
+
+    if (result.first.hasError())
+      return pair<bool, FreeTrajectoryState>(true, result.first);
     else
-      edm::LogInfo(metname) << "Propagation to the PCA failed! Path: "<<result.second;
+      edm::LogInfo(metname) << "Propagation to the PCA failed! Path: " << result.second;
   }
-  return pair<bool,FreeTrajectoryState>(false,FreeTrajectoryState());  
+  return pair<bool, FreeTrajectoryState>(false, FreeTrajectoryState());
 }
 
-std::pair<bool,FreeTrajectoryState>
-MuonUpdatorAtVertex::propagate(const TrajectoryStateOnSurface &tsos) const{
+std::pair<bool, FreeTrajectoryState> MuonUpdatorAtVertex::propagate(const TrajectoryStateOnSurface &tsos) const {
   return propagateToNominalLine(tsos);
 }

--- a/RecoMuon/TrackingTools/src/SegmentsTrackAssociator.cc
+++ b/RecoMuon/TrackingTools/src/SegmentsTrackAssociator.cc
@@ -6,7 +6,6 @@
  *  \author C. Botta, G. Mila - INFN Torino
  */
 
-
 #include "RecoMuon/TrackingTools/interface/SegmentsTrackAssociator.h"
 
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
@@ -35,39 +34,32 @@
 using namespace edm;
 using namespace std;
 
-
-
-SegmentsTrackAssociator::SegmentsTrackAssociator(const ParameterSet& iConfig,edm::ConsumesCollector& iC)
-{
+SegmentsTrackAssociator::SegmentsTrackAssociator(const ParameterSet& iConfig, edm::ConsumesCollector& iC) {
   theDTSegmentLabel = iConfig.getUntrackedParameter<InputTag>("segmentsDt");
   theCSCSegmentLabel = iConfig.getUntrackedParameter<InputTag>("segmentsCSC");
   theSegmentContainerName = iConfig.getUntrackedParameter<InputTag>("SelectedSegments");
-    
-  numRecHit=0;
-  numRecHitDT=0;
-  numRecHitCSC=0;
+
+  numRecHit = 0;
+  numRecHitDT = 0;
+  numRecHitCSC = 0;
   metname = "SegmentsTrackAssociator";
 
-  dtSegmentsToken = iC.consumes<DTRecSegment4DCollection>(theDTSegmentLabel) ;
-  cscSegmentsToken = iC.consumes<CSCSegmentCollection>(theCSCSegmentLabel) ;
-
-
+  dtSegmentsToken = iC.consumes<DTRecSegment4DCollection>(theDTSegmentLabel);
+  cscSegmentsToken = iC.consumes<CSCSegmentCollection>(theCSCSegmentLabel);
 }
-
 
 SegmentsTrackAssociator::~SegmentsTrackAssociator() {}
 
-
-MuonTransientTrackingRecHit::MuonRecHitContainer SegmentsTrackAssociator::associate(const Event& iEvent, const EventSetup& iSetup, const reco::Track& Track){
-
+MuonTransientTrackingRecHit::MuonRecHitContainer SegmentsTrackAssociator::associate(const Event& iEvent,
+                                                                                    const EventSetup& iSetup,
+                                                                                    const reco::Track& Track) {
   // The segment collections
   Handle<DTRecSegment4DCollection> dtSegments;
-  iEvent.getByToken(dtSegmentsToken, dtSegments); 
+  iEvent.getByToken(dtSegmentsToken, dtSegments);
   Handle<CSCSegmentCollection> cscSegments;
   iEvent.getByToken(cscSegmentsToken, cscSegments);
   ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
   iSetup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry);
-  
 
   DTRecSegment4DCollection::const_iterator segment;
   CSCSegmentCollection::const_iterator segment2;
@@ -76,24 +68,21 @@ MuonTransientTrackingRecHit::MuonRecHitContainer SegmentsTrackAssociator::associ
   MuonTransientTrackingRecHit::MuonRecHitContainer selectedCscSegments;
 
   //loop over recHit
-  for(auto const& recHit : Track.recHits()) {
+  for (auto const& recHit : Track.recHits()) {
+    if (!recHit->isValid())
+      continue;
 
-    if(!recHit->isValid()) continue;
-
-    
     numRecHit++;
- 
+
     //get the detector Id
     DetId idRivHit = recHit->geographicalId();
-      
 
     // DT recHits
-    if (idRivHit.det() == DetId::Muon && idRivHit.subdetId() == MuonSubdetId::DT ) {
-
+    if (idRivHit.det() == DetId::Muon && idRivHit.subdetId() == MuonSubdetId::DT) {
       // get the RecHit Local Position
-      LocalPoint posTrackRecHit = recHit->localPosition(); 
+      LocalPoint posTrackRecHit = recHit->localPosition();
 
-      DTRecSegment4DCollection::range range; 	
+      DTRecSegment4DCollection::range range;
       numRecHitDT++;
 
       // get the chamber Id
@@ -102,138 +91,136 @@ MuonTransientTrackingRecHit::MuonRecHitContainer SegmentsTrackAssociator::associ
       range = dtSegments->get(chamberId);
 
       // loop over segments
-      for (segment = range.first; segment!=range.second; segment++){
+      for (segment = range.first; segment != range.second; segment++) {
+        DetId id = segment->geographicalId();
+        const GeomDet* det = theTrackingGeometry->idToDet(id);
+        vector<const TrackingRecHit*> segments2D = (&(*segment))->recHits();
+        // container for 4D segment recHits
+        vector<const TrackingRecHit*> dtRecHits;
 
-	DetId id = segment->geographicalId();
-	const GeomDet* det = theTrackingGeometry->idToDet(id);
-	vector<const TrackingRecHit*> segments2D = (&(*segment))->recHits();
-	// container for 4D segment recHits
-	vector <const TrackingRecHit*> dtRecHits;
+        for (vector<const TrackingRecHit*>::const_iterator segm2D = segments2D.begin(); segm2D != segments2D.end();
+             segm2D++) {
+          vector<const TrackingRecHit*> rHits1D = (*segm2D)->recHits();
+          for (int hit = 0; hit < int(rHits1D.size()); hit++) {
+            dtRecHits.push_back(rHits1D[hit]);
+          }
+        }
 
-	for(vector<const TrackingRecHit*>::const_iterator segm2D = segments2D.begin();
-	  segm2D != segments2D.end();
-	  segm2D++) {
+        // loop over the recHit checking if there's the recHit of the track
+        for (unsigned int hit = 0; hit < dtRecHits.size(); hit++) {
+          DetId idRivHitSeg = (*dtRecHits[hit]).geographicalId();
+          LocalPoint posDTSegment = segment->localPosition();
+          LocalPoint posSegDTRecHit = (*dtRecHits[hit]).localPosition();
 
-	  vector <const TrackingRecHit*> rHits1D = (*segm2D)->recHits();
-	  for (int hit=0; hit<int(rHits1D.size()); hit++){
-	    dtRecHits.push_back(rHits1D[hit]);
-	  }
+          double rDT = sqrt(pow((posSegDTRecHit.x() - posTrackRecHit.x()), 2) +
+                            pow((posSegDTRecHit.y() - posTrackRecHit.y()), 2) +
+                            pow((posSegDTRecHit.z() - posTrackRecHit.z()), 2));
 
-	}
-	
-	// loop over the recHit checking if there's the recHit of the track
-	for (unsigned int hit = 0; hit < dtRecHits.size(); hit++) { 	  
-	  
-	  DetId idRivHitSeg = (*dtRecHits[hit]).geographicalId();
-	  LocalPoint posDTSegment=  segment->localPosition();
-	  LocalPoint posSegDTRecHit = (*dtRecHits[hit]).localPosition(); 
-	  	    
-	  double rDT=sqrt(pow((posSegDTRecHit.x()-posTrackRecHit.x()),2) +pow((posSegDTRecHit.y()-posTrackRecHit.y()),2) + pow((posSegDTRecHit.z()-posTrackRecHit.z()),2));
-	  
-	  if (idRivHit == idRivHitSeg && rDT<0.0001){  
+          if (idRivHit == idRivHitSeg && rDT < 0.0001) {
+            if (selectedDtSegments.empty()) {
+              selectedDtSegments.push_back(MuonTransientTrackingRecHit::specificBuild(det, &*segment));
+              LogTrace(metname) << "First selected segment (from DT). Position : " << posDTSegment
+                                << "  Chamber : " << segment->chamberId();
+            } else {
+              int check = 0;
+              for (int segm = 0; segm < int(selectedDtSegments.size()); ++segm) {
+                double dist = sqrt(pow((((*(selectedDtSegments[segm])).localPosition()).x() - posDTSegment.x()), 2) +
+                                   pow((((*(selectedDtSegments[segm])).localPosition()).y() - posDTSegment.y()), 2) +
+                                   pow((((*(selectedDtSegments[segm])).localPosition()).z() - posDTSegment.z()), 2));
+                if (dist > 30)
+                  check++;
+              }
 
-	    if (selectedDtSegments.empty()){
-		selectedDtSegments.push_back(MuonTransientTrackingRecHit::specificBuild(det,&*segment));
-		LogTrace(metname) <<"First selected segment (from DT). Position : "<<posDTSegment<<"  Chamber : "<<segment->chamberId();
-	    }
-	    else{
-	      int check=0;
-	      for(int segm=0; segm < int(selectedDtSegments.size()); ++segm) {
-		double dist=sqrt(pow((((*(selectedDtSegments[segm])).localPosition()).x()-posDTSegment.x()),2) +pow((((*(selectedDtSegments[segm])).localPosition()).y()-posDTSegment.y()),2) + pow((((*(selectedDtSegments[segm])).localPosition()).z()-posDTSegment.z()),2));
-		if(dist>30) check++;
-	      }     
-		
-	      if(check==int(selectedDtSegments.size())){
-		selectedDtSegments.push_back(MuonTransientTrackingRecHit::specificBuild(det,&*segment));
-		LogTrace(metname) <<"New DT selected segment. Position : "<<posDTSegment<<"  Chamber : "<<segment->chamberId();
-	      }      
-	    }	
-	  } // check to tag the segment as "selected"
+              if (check == int(selectedDtSegments.size())) {
+                selectedDtSegments.push_back(MuonTransientTrackingRecHit::specificBuild(det, &*segment));
+                LogTrace(metname) << "New DT selected segment. Position : " << posDTSegment
+                                  << "  Chamber : " << segment->chamberId();
+              }
+            }
+          }  // check to tag the segment as "selected"
 
-	} // loop over segment recHits
+        }  // loop over segment recHits
 
-      } // loop over DT segments
+      }  // loop over DT segments
     }
-    
-   
+
     // CSC recHits
-    if (idRivHit.det() == DetId::Muon && idRivHit.subdetId() == MuonSubdetId::CSC ) {
-
+    if (idRivHit.det() == DetId::Muon && idRivHit.subdetId() == MuonSubdetId::CSC) {
       // get the RecHit Local Position
-      LocalPoint posTrackRecHit = recHit->localPosition(); 
+      LocalPoint posTrackRecHit = recHit->localPosition();
 
-      CSCSegmentCollection::range range; 
+      CSCSegmentCollection::range range;
       numRecHitCSC++;
 
       // get the chamber Id
       CSCDetId tempchamberId(idRivHit.rawId());
-      
+
       int ring = tempchamberId.ring();
       int station = tempchamberId.station();
       int endcap = tempchamberId.endcap();
-      int chamber = tempchamberId.chamber();	
+      int chamber = tempchamberId.chamber();
       CSCDetId chamberId(endcap, station, ring, chamber, 0);
-      
+
       // get the segments of the chamber
       range = cscSegments->get(chamberId);
       // loop over segments
-      for(segment2 = range.first; segment2!=range.second; segment2++){
+      for (segment2 = range.first; segment2 != range.second; segment2++) {
+        DetId id2 = segment2->geographicalId();
+        const GeomDet* det2 = theTrackingGeometry->idToDet(id2);
 
-	DetId id2 = segment2->geographicalId();
-	const GeomDet* det2 = theTrackingGeometry->idToDet(id2);
-	
-	// container for CSC segment recHits
-	vector<const TrackingRecHit*> cscRecHits = (&(*segment2))->recHits();
-	
-	// loop over the recHit checking if there's the recHit of the track	
-	for (unsigned int hit = 0; hit < cscRecHits.size(); hit++) { 
-  
-	  DetId idRivHitSeg = (*cscRecHits[hit]).geographicalId();
-	  LocalPoint posSegCSCRecHit = (*cscRecHits[hit]).localPosition(); 
-	  LocalPoint posCSCSegment=  segment2->localPosition();
-	    	  
-	  double rCSC=sqrt(pow((posSegCSCRecHit.x()-posTrackRecHit.x()),2) +pow((posSegCSCRecHit.y()-posTrackRecHit.y()),2) + pow((posSegCSCRecHit.z()-posTrackRecHit.z()),2));
+        // container for CSC segment recHits
+        vector<const TrackingRecHit*> cscRecHits = (&(*segment2))->recHits();
 
-	  if (idRivHit==idRivHitSeg && rCSC < 0.0001){
+        // loop over the recHit checking if there's the recHit of the track
+        for (unsigned int hit = 0; hit < cscRecHits.size(); hit++) {
+          DetId idRivHitSeg = (*cscRecHits[hit]).geographicalId();
+          LocalPoint posSegCSCRecHit = (*cscRecHits[hit]).localPosition();
+          LocalPoint posCSCSegment = segment2->localPosition();
 
-	    if (selectedCscSegments.empty()){
-	      selectedCscSegments.push_back(MuonTransientTrackingRecHit::specificBuild(det2,&*segment2));
-	      LogTrace(metname) <<"First selected segment (from CSC). Position: "<<posCSCSegment;
-	    }
-	    else{
-	      int check=0;
-	      for(int n=0; n< int(selectedCscSegments.size()); n++){
-		double dist = sqrt(pow(((*(selectedCscSegments[n])).localPosition().x()-posCSCSegment.x()),2) +pow(((*(selectedCscSegments[n])).localPosition().y()-posCSCSegment.y()),2) + pow(((*(selectedCscSegments[n])).localPosition().z()-posCSCSegment.z()),2));
-		if(dist>30) check++;
-	      }
-	      if(check==int(selectedCscSegments.size())){  
-		selectedCscSegments.push_back(MuonTransientTrackingRecHit::specificBuild(det2,&*segment2));
-		LogTrace(metname) <<"New CSC segment selected. Position : "<<posCSCSegment;	
-	      }
-	    }
-	    
-	  } // check to tag the segment as "selected"
-	    
-	} // loop over segment recHits
-	
-      } // loop over DT segments
-    } 
-      
-  } // loop over track recHits
-    
-  LogTrace(metname) <<"N recHit:"<<numRecHit;
-  numRecHit=0;
-  LogTrace(metname) <<"N recHit DT:"<<numRecHitDT;
-  numRecHitDT=0;
-  LogTrace(metname) <<"N recHit CSC:"<<numRecHitCSC;
-  numRecHitCSC=0;
-  
+          double rCSC = sqrt(pow((posSegCSCRecHit.x() - posTrackRecHit.x()), 2) +
+                             pow((posSegCSCRecHit.y() - posTrackRecHit.y()), 2) +
+                             pow((posSegCSCRecHit.z() - posTrackRecHit.z()), 2));
+
+          if (idRivHit == idRivHitSeg && rCSC < 0.0001) {
+            if (selectedCscSegments.empty()) {
+              selectedCscSegments.push_back(MuonTransientTrackingRecHit::specificBuild(det2, &*segment2));
+              LogTrace(metname) << "First selected segment (from CSC). Position: " << posCSCSegment;
+            } else {
+              int check = 0;
+              for (int n = 0; n < int(selectedCscSegments.size()); n++) {
+                double dist = sqrt(pow(((*(selectedCscSegments[n])).localPosition().x() - posCSCSegment.x()), 2) +
+                                   pow(((*(selectedCscSegments[n])).localPosition().y() - posCSCSegment.y()), 2) +
+                                   pow(((*(selectedCscSegments[n])).localPosition().z() - posCSCSegment.z()), 2));
+                if (dist > 30)
+                  check++;
+              }
+              if (check == int(selectedCscSegments.size())) {
+                selectedCscSegments.push_back(MuonTransientTrackingRecHit::specificBuild(det2, &*segment2));
+                LogTrace(metname) << "New CSC segment selected. Position : " << posCSCSegment;
+              }
+            }
+
+          }  // check to tag the segment as "selected"
+
+        }  // loop over segment recHits
+
+      }  // loop over DT segments
+    }
+
+  }  // loop over track recHits
+
+  LogTrace(metname) << "N recHit:" << numRecHit;
+  numRecHit = 0;
+  LogTrace(metname) << "N recHit DT:" << numRecHitDT;
+  numRecHitDT = 0;
+  LogTrace(metname) << "N recHit CSC:" << numRecHitCSC;
+  numRecHitCSC = 0;
+
   copy(selectedDtSegments.begin(), selectedDtSegments.end(), back_inserter(selectedSegments));
-  LogTrace(metname) <<"N selected Dt segments:"<<selectedDtSegments.size();
+  LogTrace(metname) << "N selected Dt segments:" << selectedDtSegments.size();
   copy(selectedCscSegments.begin(), selectedCscSegments.end(), back_inserter(selectedSegments));
-  LogTrace(metname) <<"N selected Csc segments:"<<selectedCscSegments.size();
-  LogTrace(metname) <<"N selected segments:"<<selectedSegments.size();
+  LogTrace(metname) << "N selected Csc segments:" << selectedCscSegments.size();
+  LogTrace(metname) << "N selected segments:" << selectedSegments.size();
 
   return selectedSegments;
-  
 }

--- a/RecoMuon/TrackingTools/test/MuonErrorMatrixAnalyzer.cc
+++ b/RecoMuon/TrackingTools/test/MuonErrorMatrixAnalyzer.cc
@@ -15,7 +15,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <cmath>
-#include "DataFormats/Math/interface/deltaPhi.h" 
+#include "DataFormats/Math/interface/deltaPhi.h"
 
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 
@@ -38,12 +38,11 @@
 //
 // constructors and destructor
 //
-MuonErrorMatrixAnalyzer::MuonErrorMatrixAnalyzer(const edm::ParameterSet& iConfig)
-{
-  theCategory="MuonErrorMatrixAnalyzer";
-   //now do what ever initialization is needed
+MuonErrorMatrixAnalyzer::MuonErrorMatrixAnalyzer(const edm::ParameterSet& iConfig) {
+  theCategory = "MuonErrorMatrixAnalyzer";
+  //now do what ever initialization is needed
   theTrackLabel = iConfig.getParameter<edm::InputTag>("trackLabel");
-  
+
   trackingParticleLabel = iConfig.getParameter<edm::InputTag>("trackingParticleLabel");
 
   //adding this for associator
@@ -54,103 +53,91 @@ MuonErrorMatrixAnalyzer::MuonErrorMatrixAnalyzer(const edm::ParameterSet& iConfi
   theErrorMatrixStore_Residual_pset = iConfig.getParameter<edm::ParameterSet>("errorMatrix_Residual_pset");
   theErrorMatrixStore_Pull_pset = iConfig.getParameter<edm::ParameterSet>("errorMatrix_Pull_pset");
 
-  thePlotFileName= iConfig.getParameter<std::string>("plotFileName");
+  thePlotFileName = iConfig.getParameter<std::string>("plotFileName");
 
   theRadius = iConfig.getParameter<double>("radius");
-  if (theRadius!=0){
-    GlobalPoint O(0,0,0);
+  if (theRadius != 0) {
+    GlobalPoint O(0, 0, 0);
     Surface::RotationType R;
-    refRSurface = Cylinder::build(theRadius,O,R);
+    refRSurface = Cylinder::build(theRadius, O, R);
     thePropagatorName = iConfig.getParameter<std::string>("propagatorName");
     theZ = iConfig.getParameter<double>("z");
-    if (theZ!=0){
+    if (theZ != 0) {
       //plane can only be specified if R is specified
-      GlobalPoint Opoz(0,0,theZ);
-      GlobalPoint Oneg(0,0,-theZ);
-      refZSurface[1] = Plane::build(Opoz,R);
-      refZSurface[0] = Plane::build(Oneg,R);
+      GlobalPoint Opoz(0, 0, theZ);
+      GlobalPoint Oneg(0, 0, -theZ);
+      refZSurface[1] = Plane::build(Opoz, R);
+      refZSurface[0] = Plane::build(Oneg, R);
     }
   }
 
-  theGaussianPullFitRange = iConfig.getUntrackedParameter<double>("gaussianPullFitRange",2.0);
+  theGaussianPullFitRange = iConfig.getUntrackedParameter<double>("gaussianPullFitRange", 2.0);
 }
 
-
-MuonErrorMatrixAnalyzer::~MuonErrorMatrixAnalyzer()
-{
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
+MuonErrorMatrixAnalyzer::~MuonErrorMatrixAnalyzer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
-
 // ------------ method called to for each event  ------------
-void
-MuonErrorMatrixAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-  if(theErrorMatrixStore_Reported){
-    analyze_from_errormatrix(iEvent,iSetup);
+void MuonErrorMatrixAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  if (theErrorMatrixStore_Reported) {
+    analyze_from_errormatrix(iEvent, iSetup);
   }
 
-  if(theErrorMatrixStore_Residual || theErrorMatrixStore_Pull){
-    analyze_from_pull(iEvent,iSetup);
+  if (theErrorMatrixStore_Residual || theErrorMatrixStore_Pull) {
+    analyze_from_pull(iEvent, iSetup);
   }
 }
 
-
-FreeTrajectoryState MuonErrorMatrixAnalyzer::refLocusState(const FreeTrajectoryState & fts){
-  if (theRadius ==0){
-    GlobalPoint vtx(0,0,0);
+FreeTrajectoryState MuonErrorMatrixAnalyzer::refLocusState(const FreeTrajectoryState& fts) {
+  if (theRadius == 0) {
+    GlobalPoint vtx(0, 0, 0);
     TSCPBuilderNoMaterial tscpBuilder;
-    FreeTrajectoryState PCAstate= tscpBuilder(fts,vtx).theState();
+    FreeTrajectoryState PCAstate = tscpBuilder(fts, vtx).theState();
     return PCAstate;
-  }
-  else{
+  } else {
     //go to the cylinder surface, along momentum
     TrajectoryStateOnSurface onRef = thePropagator->propagate(fts, *refRSurface);
 
-    if (!onRef.isValid()){
-      edm::LogError(theCategory)<<" cannot propagate to cylinder of radius: "<<theRadius;
+    if (!onRef.isValid()) {
+      edm::LogError(theCategory) << " cannot propagate to cylinder of radius: " << theRadius;
       //try out the plane if specified
-      if (theZ!=0){
-	onRef = thePropagator->propagate(fts, *(refZSurface[(fts.momentum().z()>0)]));
-	if (!onRef.isValid()){
-	  edm::LogError(theCategory)<<" cannot propagate to the plane of Z: "
-				    <<((fts.momentum().z()>0)?"+":"-")
-				    <<theZ<<" either.";
-	  return FreeTrajectoryState();
-	}//invalid state
-      }//z plane is set
-      else {return FreeTrajectoryState();}
-    }//invalid state
-    else if (fabs(onRef.globalPosition().z())>theZ && theZ!=0){
+      if (theZ != 0) {
+        onRef = thePropagator->propagate(fts, *(refZSurface[(fts.momentum().z() > 0)]));
+        if (!onRef.isValid()) {
+          edm::LogError(theCategory) << " cannot propagate to the plane of Z: "
+                                     << ((fts.momentum().z() > 0) ? "+" : "-") << theZ << " either.";
+          return FreeTrajectoryState();
+        }  //invalid state
+      }    //z plane is set
+      else {
+        return FreeTrajectoryState();
+      }
+    }  //invalid state
+    else if (fabs(onRef.globalPosition().z()) > theZ && theZ != 0) {
       //try out the plane
-      onRef = thePropagator->propagate(fts, *(refZSurface[(fts.momentum().z()>0)]));
-      if (!onRef.isValid()){
-	edm::LogError(theCategory)<<" cannot propagate to the plane of Z: "
-				  <<((fts.momentum().z()>0)?"+":"-")
-				  <<theZ<<" even though cylinder z indicates it should.";
-      }//invalid state
-    }//z further than the planes
+      onRef = thePropagator->propagate(fts, *(refZSurface[(fts.momentum().z() > 0)]));
+      if (!onRef.isValid()) {
+        edm::LogError(theCategory) << " cannot propagate to the plane of Z: " << ((fts.momentum().z() > 0) ? "+" : "-")
+                                   << theZ << " even though cylinder z indicates it should.";
+      }  //invalid state
+    }    //z further than the planes
 
-    LogDebug(theCategory)<<"reference state is:\n"<<onRef;
+    LogDebug(theCategory) << "reference state is:\n" << onRef;
 
     return (*onRef.freeState());
-  }// R=0
+  }  // R=0
 }
 
-
-void 
-  MuonErrorMatrixAnalyzer::analyze_from_errormatrix(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-
+void MuonErrorMatrixAnalyzer::analyze_from_errormatrix(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
 
-  if (theRadius!=0){
+  if (theRadius != 0) {
     //get a propagator
     iSetup.get<TrackingComponentsRecord>().get(thePropagatorName, thePropagator);
   }
@@ -160,598 +147,610 @@ void
 
   //open a collection of track
   edm::Handle<reco::TrackCollection> tracks;
-  iEvent.getByLabel(theTrackLabel,tracks);
-  
-  
+  iEvent.getByLabel(theTrackLabel, tracks);
+
   //loop over them
-  for (unsigned int it=0;it!=tracks->size();++it){
+  for (unsigned int it = 0; it != tracks->size(); ++it) {
+    //   take their initial free state
+    FreeTrajectoryState PCAstate = trajectoryStateTransform::initialFreeState((*tracks)[it], theField.product());
+    if (PCAstate.position().mag() == 0) {
+      edm::LogError(theCategory) << "invalid state from track initial state. skipping.\n" << PCAstate;
+      continue;
+    }
 
-     //   take their initial free state
-    FreeTrajectoryState PCAstate = trajectoryStateTransform::initialFreeState((*tracks)[it],theField.product());
-    if (PCAstate.position().mag()==0)
-      {edm::LogError(theCategory)<<"invalid state from track initial state. skipping.\n"<<PCAstate;continue;}
-    
-     FreeTrajectoryState trackRefState = refLocusState(PCAstate);
-     if ( trackRefState.position().mag()==0) continue;
-     
-     AlgebraicSymMatrix55 errorMatrix = trackRefState.curvilinearError().matrix();
+    FreeTrajectoryState trackRefState = refLocusState(PCAstate);
+    if (trackRefState.position().mag() == 0)
+      continue;
 
-     double pT=trackRefState.momentum().perp();
-     double eta=fabs(trackRefState.momentum().eta());
-     double phi=trackRefState.momentum().phi();
+    AlgebraicSymMatrix55 errorMatrix = trackRefState.curvilinearError().matrix();
 
-     LogDebug(theCategory)<<"error matrix:\n"<<errorMatrix
-			  <<"\n state: \n"
-                          <<trackRefState;
-     
-     //fill the TProfile3D
-     for (int i=0;i!=5;++i){ for(int j=i;j!=5;++j){
-	 //get the profile plot to fill
-	 TProfile3D * ij = theErrorMatrixStore_Reported->get(i,j);
-	 if (!ij){edm::LogError(theCategory)<<"cannot get profile "<<i<<" "<<j;  continue;}
+    double pT = trackRefState.momentum().perp();
+    double eta = fabs(trackRefState.momentum().eta());
+    double phi = trackRefState.momentum().phi();
 
-	 //get sigma squared or correlation factor
-	 double value=MuonErrorMatrix::Term(errorMatrix,i,j);
-	 ij->Fill(pT,eta,phi,value);
-     }}
+    LogDebug(theCategory) << "error matrix:\n" << errorMatrix << "\n state: \n" << trackRefState;
 
+    //fill the TProfile3D
+    for (int i = 0; i != 5; ++i) {
+      for (int j = i; j != 5; ++j) {
+        //get the profile plot to fill
+        TProfile3D* ij = theErrorMatrixStore_Reported->get(i, j);
+        if (!ij) {
+          edm::LogError(theCategory) << "cannot get profile " << i << " " << j;
+          continue;
+        }
+
+        //get sigma squared or correlation factor
+        double value = MuonErrorMatrix::Term(errorMatrix, i, j);
+        ij->Fill(pT, eta, phi, value);
+      }
+    }
   }
-}   
+}
 
-
-
-void 
-MuonErrorMatrixAnalyzer::analyze_from_pull(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void MuonErrorMatrixAnalyzer::analyze_from_pull(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
-
 
   //get the mag field
   iSetup.get<IdealMagneticFieldRecord>().get(theField);
 
   //open a collection of track
   edm::Handle<View<reco::Track> > tracks;
-  iEvent.getByLabel(theTrackLabel,tracks);
+  iEvent.getByLabel(theTrackLabel, tracks);
 
   //open a collection of Tracking particle
   edm::Handle<TrackingParticleCollection> TPtracks;
-  iEvent.getByLabel(trackingParticleLabel,TPtracks);
+  iEvent.getByLabel(trackingParticleLabel, TPtracks);
 
   //get the associator
   edm::Handle<reco::TrackToTrackingParticleAssociator> associator;
-  iEvent.getByLabel(theAssocLabel,associator);
+  iEvent.getByLabel(theAssocLabel, associator);
 
-  //associate  
-  reco::RecoToSimCollection recSimColl = associator->associateRecoToSim(tracks,TPtracks);
+  //associate
+  reco::RecoToSimCollection recSimColl = associator->associateRecoToSim(tracks, TPtracks);
 
-  LogDebug(theCategory)<<"I have found: "<<recSimColl.size()<<" associations in total.";
-  
-   
+  LogDebug(theCategory) << "I have found: " << recSimColl.size() << " associations in total.";
+
   int it = 0;
-  for (reco::RecoToSimCollection::const_iterator RtSit=recSimColl.begin();RtSit!=recSimColl.end();++RtSit){
+  for (reco::RecoToSimCollection::const_iterator RtSit = recSimColl.begin(); RtSit != recSimColl.end(); ++RtSit) {
     //what am I loop over ?
     //the line below this has a problem
     //    const reco::TrackRef & track = RtSit->key;
-    const std::vector<std::pair<TrackingParticleRef,double> > & tp = RtSit->val;
-     
+    const std::vector<std::pair<TrackingParticleRef, double> >& tp = RtSit->val;
+
     //what do I want to get from those
     FreeTrajectoryState sim_fts;
     FreeTrajectoryState trackPCAstate;
 
-    LogDebug(theCategory)<<"I have found: "<<tp.size()<<" tracking particle associated with this reco::Track.";
+    LogDebug(theCategory) << "I have found: " << tp.size() << " tracking particle associated with this reco::Track.";
 
-    if(tp.size()!=0)
-      {
-	//take the match with best quality
-	std::vector<std::pair<TrackingParticleRef,double> >::const_iterator vector_iterator = tp.begin();
-	const std::pair<TrackingParticleRef,double> & pair_in_vector = *vector_iterator;
-	//what am I looking at ?
-	const TrackingParticleRef & trp = pair_in_vector.first;
-	//the line below this has a syntax error
-	//double quality & = pair_in_vector.second;
-	//	 const TrackingParticle & best_associated_trackingparticle = trp.product();
+    if (tp.size() != 0) {
+      //take the match with best quality
+      std::vector<std::pair<TrackingParticleRef, double> >::const_iterator vector_iterator = tp.begin();
+      const std::pair<TrackingParticleRef, double>& pair_in_vector = *vector_iterator;
+      //what am I looking at ?
+      const TrackingParticleRef& trp = pair_in_vector.first;
+      //the line below this has a syntax error
+      //double quality & = pair_in_vector.second;
+      //	 const TrackingParticle & best_associated_trackingparticle = trp.product();
 
-	//	 work on the TrackingParticle
-	//get reference point and momentum to make fts
-	GlobalPoint position_sim_fts(trp->vx(),
-				 trp->vy(),
-				 trp->vz());
-	GlobalVector momentum_sim_fts(trp->px(),
-				  trp->py(),
-				  trp->pz());
-	int charge_sim = (int)trp->charge();
-	GlobalTrajectoryParameters par_sim(position_sim_fts,momentum_sim_fts,charge_sim,theField.product()); 
-	 
-	sim_fts = FreeTrajectoryState(par_sim);
-	   
-	//	   work on the reco::Track
-	trackPCAstate = trajectoryStateTransform::initialFreeState((*tracks)[it],theField.product());
-	if (trackPCAstate.position().mag()==0)
-	  {edm::LogError(theCategory)<<"invalid state from track initial state. skipping.\n"<<trackPCAstate;continue;}
+      //	 work on the TrackingParticle
+      //get reference point and momentum to make fts
+      GlobalPoint position_sim_fts(trp->vx(), trp->vy(), trp->vz());
+      GlobalVector momentum_sim_fts(trp->px(), trp->py(), trp->pz());
+      int charge_sim = (int)trp->charge();
+      GlobalTrajectoryParameters par_sim(position_sim_fts, momentum_sim_fts, charge_sim, theField.product());
 
-	//get then both at the reference locus
-        FreeTrajectoryState simRefState = refLocusState(sim_fts);
-        FreeTrajectoryState trackRefState = refLocusState(trackPCAstate);
+      sim_fts = FreeTrajectoryState(par_sim);
 
-        if (simRefState.position().mag()==0 || trackRefState.position().mag()==0 )
-          continue;
-	
-	GlobalVector momentum_sim = simRefState.momentum();
-	GlobalPoint point_sim = simRefState.position();
-	
-	GlobalVector momentum_track = trackRefState.momentum();
-	GlobalPoint point_track = trackRefState.position();
-	
-	//conversion from global to curvinlinear parameters for both reco and sim track
-	CurvilinearTrajectoryParameters sim_CTP(point_sim,momentum_sim,simRefState.charge());
-	CurvilinearTrajectoryParameters track_CTP(point_track,momentum_track,trackRefState.charge());
+      //	   work on the reco::Track
+      trackPCAstate = trajectoryStateTransform::initialFreeState((*tracks)[it], theField.product());
+      if (trackPCAstate.position().mag() == 0) {
+        edm::LogError(theCategory) << "invalid state from track initial state. skipping.\n" << trackPCAstate;
+        continue;
+      }
 
+      //get then both at the reference locus
+      FreeTrajectoryState simRefState = refLocusState(sim_fts);
+      FreeTrajectoryState trackRefState = refLocusState(trackPCAstate);
 
-	//These are the parameters for the CTP point
-	AlgebraicVector5 sim_CTP_vector = sim_CTP.vector();
-	AlgebraicVector5 track_CTP_vector = track_CTP.vector();
-	const AlgebraicSymMatrix55 & track_error =  trackRefState.curvilinearError().matrix();
+      if (simRefState.position().mag() == 0 || trackRefState.position().mag() == 0)
+        continue;
 
-	double pT_sim = simRefState.momentum().perp();
-	
-	//get the momentum, eta, phi here
-	double pT=trackRefState.momentum().perp();
-	double eta=fabs(trackRefState.momentum().eta());
-	double phi=trackRefState.momentum().phi();
-	
-	LogDebug(theCategory)<<"The sim pT for this association is: "<<pT_sim<<" GeV"
-			     <<"sim state: \n"<<simRefState
-			     <<"The track pT for this association is: "<<pT<<" GeV"
-			     <<"reco state: \n"<<trackRefState;
-	
-	//once have the momentum,eta,phi choose what bin it should go in
-	//how do i get the correct bin
-	double diff_i=0,diff_j=0;
-	for (unsigned int i=0;i!=5;++i){
-	      //do these if statements because if the parameter is phi it is not simply reco minus sim
-	  if(i!=2){ diff_i = sim_CTP_vector[i]-track_CTP_vector[i];}
-	  else { diff_i = deltaPhi(sim_CTP_vector[i],track_CTP_vector[i]); }
-	  
-	  for(unsigned int j=i;j<5;++j){
-	    //do these if statements because if the parameter is phi it is not simply reco minus sim  
-	    if(j!=2){ diff_j = sim_CTP_vector[j]-track_CTP_vector[j];}
-            else{ diff_j = deltaPhi(sim_CTP_vector[j],track_CTP_vector[j]);}
-	    
-	    //filling residual histograms   
-	    if (theErrorMatrixStore_Residual){
-	      unsigned int iH=theErrorMatrixStore_Residual->index(i,j);
-	      TProfile3D * ij = theErrorMatrixStore_Residual->get(i,j);
-	      if (!ij){edm::LogError(theCategory)<<i<<" "<<j<<" not vali indexes. TProfile3D not found."; continue;}
+      GlobalVector momentum_sim = simRefState.momentum();
+      GlobalPoint point_sim = simRefState.position();
 
-	      int iPt=theErrorMatrixStore_Residual->findBin(ij->GetXaxis(),pT)-1;// between 0 and maxbin-1;
-	      int iEta=theErrorMatrixStore_Residual->findBin(ij->GetYaxis(),eta)-1;// between 0 and maxbin-1;
-	      int iPhi=theErrorMatrixStore_Residual->findBin(ij->GetZaxis(),phi)-1;// between 0 and maxbin-1;
+      GlobalVector momentum_track = trackRefState.momentum();
+      GlobalPoint point_track = trackRefState.position();
 
-	      TH1ptr & theH = (theHist_array_residual[iH])[index(ij,iPt,iEta,iPhi)];
-	      
-	      if (i==j){
-		LogDebug(theCategory)<<"filling for: "<<i;
-		((TH1*)theH)->Fill(diff_i);
-	      }
-	      else{
-		LogDebug(theCategory)<<"filling for: "<<i<<" "<<j;
-		((TH2*)theH)->Fill(diff_i,diff_j);
-	      }
-	    }//filling residual histograms
-	    
-	    //filling pull histograms   
-	    if (theErrorMatrixStore_Pull){
-	      unsigned int iH=theErrorMatrixStore_Pull->index(i,j);
-              TProfile3D* ij=theErrorMatrixStore_Pull->get(i,j);
-              if (!ij){edm::LogError(theCategory)<<i<<" "<<j<<" not vali indexes. TProfile3D not found."; continue;}
+      //conversion from global to curvinlinear parameters for both reco and sim track
+      CurvilinearTrajectoryParameters sim_CTP(point_sim, momentum_sim, simRefState.charge());
+      CurvilinearTrajectoryParameters track_CTP(point_track, momentum_track, trackRefState.charge());
 
-	      int iPt=theErrorMatrixStore_Pull->findBin(ij->GetXaxis(),pT)-1;// between 0 and maxbin-1;
-	      int iEta=theErrorMatrixStore_Pull->findBin(ij->GetYaxis(),eta)-1;// between 0 and maxbin-1;
-	      int iPhi=theErrorMatrixStore_Pull->findBin(ij->GetZaxis(),phi)-1;// between 0 and maxbin-1;
-	      
-              TH1ptr & theH = (theHist_array_pull[iH])[index(ij,iPt,iEta,iPhi)];
-	      
-              if (i==j){
-                LogDebug(theCategory)<<"filling pulls for: "<<i;
-                ((TH1*)theH)->Fill(diff_i/sqrt(track_error(i,i)));
-              }
-              else{
-                LogDebug(theCategory)<<"filling pulls (2D) for: "<<i<<" "<<j;
-                ((TH2*)theH)->Fill(diff_i/sqrt(track_error(i,i)),diff_j/sqrt(track_error(j,j)));
-              }
-	    }// filling the pull histograms
+      //These are the parameters for the CTP point
+      AlgebraicVector5 sim_CTP_vector = sim_CTP.vector();
+      AlgebraicVector5 track_CTP_vector = track_CTP.vector();
+      const AlgebraicSymMatrix55& track_error = trackRefState.curvilinearError().matrix();
 
-	  }}//loop over all the 15 terms of the 5x5 matrix
-	
-      }//end of if (tp.size()!=0)
-    it++; }//end of loop over the map
+      double pT_sim = simRefState.momentum().perp();
 
+      //get the momentum, eta, phi here
+      double pT = trackRefState.momentum().perp();
+      double eta = fabs(trackRefState.momentum().eta());
+      double phi = trackRefState.momentum().phi();
+
+      LogDebug(theCategory) << "The sim pT for this association is: " << pT_sim << " GeV"
+                            << "sim state: \n"
+                            << simRefState << "The track pT for this association is: " << pT << " GeV"
+                            << "reco state: \n"
+                            << trackRefState;
+
+      //once have the momentum,eta,phi choose what bin it should go in
+      //how do i get the correct bin
+      double diff_i = 0, diff_j = 0;
+      for (unsigned int i = 0; i != 5; ++i) {
+        //do these if statements because if the parameter is phi it is not simply reco minus sim
+        if (i != 2) {
+          diff_i = sim_CTP_vector[i] - track_CTP_vector[i];
+        } else {
+          diff_i = deltaPhi(sim_CTP_vector[i], track_CTP_vector[i]);
+        }
+
+        for (unsigned int j = i; j < 5; ++j) {
+          //do these if statements because if the parameter is phi it is not simply reco minus sim
+          if (j != 2) {
+            diff_j = sim_CTP_vector[j] - track_CTP_vector[j];
+          } else {
+            diff_j = deltaPhi(sim_CTP_vector[j], track_CTP_vector[j]);
+          }
+
+          //filling residual histograms
+          if (theErrorMatrixStore_Residual) {
+            unsigned int iH = theErrorMatrixStore_Residual->index(i, j);
+            TProfile3D* ij = theErrorMatrixStore_Residual->get(i, j);
+            if (!ij) {
+              edm::LogError(theCategory) << i << " " << j << " not vali indexes. TProfile3D not found.";
+              continue;
+            }
+
+            int iPt = theErrorMatrixStore_Residual->findBin(ij->GetXaxis(), pT) - 1;    // between 0 and maxbin-1;
+            int iEta = theErrorMatrixStore_Residual->findBin(ij->GetYaxis(), eta) - 1;  // between 0 and maxbin-1;
+            int iPhi = theErrorMatrixStore_Residual->findBin(ij->GetZaxis(), phi) - 1;  // between 0 and maxbin-1;
+
+            TH1ptr& theH = (theHist_array_residual[iH])[index(ij, iPt, iEta, iPhi)];
+
+            if (i == j) {
+              LogDebug(theCategory) << "filling for: " << i;
+              ((TH1*)theH)->Fill(diff_i);
+            } else {
+              LogDebug(theCategory) << "filling for: " << i << " " << j;
+              ((TH2*)theH)->Fill(diff_i, diff_j);
+            }
+          }  //filling residual histograms
+
+          //filling pull histograms
+          if (theErrorMatrixStore_Pull) {
+            unsigned int iH = theErrorMatrixStore_Pull->index(i, j);
+            TProfile3D* ij = theErrorMatrixStore_Pull->get(i, j);
+            if (!ij) {
+              edm::LogError(theCategory) << i << " " << j << " not vali indexes. TProfile3D not found.";
+              continue;
+            }
+
+            int iPt = theErrorMatrixStore_Pull->findBin(ij->GetXaxis(), pT) - 1;    // between 0 and maxbin-1;
+            int iEta = theErrorMatrixStore_Pull->findBin(ij->GetYaxis(), eta) - 1;  // between 0 and maxbin-1;
+            int iPhi = theErrorMatrixStore_Pull->findBin(ij->GetZaxis(), phi) - 1;  // between 0 and maxbin-1;
+
+            TH1ptr& theH = (theHist_array_pull[iH])[index(ij, iPt, iEta, iPhi)];
+
+            if (i == j) {
+              LogDebug(theCategory) << "filling pulls for: " << i;
+              ((TH1*)theH)->Fill(diff_i / sqrt(track_error(i, i)));
+            } else {
+              LogDebug(theCategory) << "filling pulls (2D) for: " << i << " " << j;
+              ((TH2*)theH)->Fill(diff_i / sqrt(track_error(i, i)), diff_j / sqrt(track_error(j, j)));
+            }
+          }  // filling the pull histograms
+        }
+      }  //loop over all the 15 terms of the 5x5 matrix
+
+    }  //end of if (tp.size()!=0)
+    it++;
+  }  //end of loop over the map
 }
-  
-
-   
 
 // ------------ method called once each job just before starting event loop  ------------
 
-void 
-MuonErrorMatrixAnalyzer::beginJob()
-{
-  if (theErrorMatrixStore_Reported_pset.empty()){
-    theErrorMatrixStore_Reported =0;}
-  else{
+void MuonErrorMatrixAnalyzer::beginJob() {
+  if (theErrorMatrixStore_Reported_pset.empty()) {
+    theErrorMatrixStore_Reported = 0;
+  } else {
     //create the error matrix provider, saying that you want to construct the things from here
     theErrorMatrixStore_Reported = new MuonErrorMatrix(theErrorMatrixStore_Reported_pset);
   }
-  
-  if (theErrorMatrixStore_Residual_pset.empty()){
-    theErrorMatrixStore_Residual =0;}
-  else{
+
+  if (theErrorMatrixStore_Residual_pset.empty()) {
+    theErrorMatrixStore_Residual = 0;
+  } else {
     //create the error matrix provider for the alternative method
-    theErrorMatrixStore_Residual = new MuonErrorMatrix(theErrorMatrixStore_Residual_pset);  
-  }
-  
-  if (theErrorMatrixStore_Pull_pset.empty()){
-    theErrorMatrixStore_Pull =0;}
-  else{
-    //create the error matrix provider for the alternative method
-    theErrorMatrixStore_Pull = new MuonErrorMatrix(theErrorMatrixStore_Pull_pset);  
+    theErrorMatrixStore_Residual = new MuonErrorMatrix(theErrorMatrixStore_Residual_pset);
   }
 
+  if (theErrorMatrixStore_Pull_pset.empty()) {
+    theErrorMatrixStore_Pull = 0;
+  } else {
+    //create the error matrix provider for the alternative method
+    theErrorMatrixStore_Pull = new MuonErrorMatrix(theErrorMatrixStore_Pull_pset);
+  }
 
-  if (thePlotFileName ==""){
+  if (thePlotFileName == "") {
     thePlotFile = 0;
     //    thePlotDir=0;
     gROOT->cd();
-  }
-  else{
+  } else {
     edm::Service<TFileService> fs;
     //    thePlotDir = new TFileDirectory(fs->mkdir(thePlotFileName.c_str()));
-    thePlotFile = TFile::Open(thePlotFileName.c_str(),"recreate");
+    thePlotFile = TFile::Open(thePlotFileName.c_str(), "recreate");
     thePlotFile->cd();
     theBookKeeping = new TList;
   }
-  
+
   //book histograms in this section
   //you will get them back from their name
-     
-  //Since the bin size is only specified in ErrorMatrix.cc must get bin size from the TProfile3D   
+
+  //Since the bin size is only specified in ErrorMatrix.cc must get bin size from the TProfile3D
   //need to choose which TProfile to get bin content info from.
-     
-  //create the 15 histograms, 5 of them TH1F, 10 of them TH2F
-  if (theErrorMatrixStore_Residual){
-  for (unsigned int i=0;i!=5;++i){
-    for (unsigned int j=i;j<5;++j){
-      unsigned int iH=theErrorMatrixStore_Residual->index(i,j);
-      TProfile3D * ij = theErrorMatrixStore_Residual->get(i,j);
-      if (!ij){edm::LogError(theCategory)<<i<<" "<<j<<" not valid indexes. TProfile3D not found."; continue;}
-      unsigned int pTBin = (ij->GetNbinsX());
-      unsigned int etaBin = (ij->GetNbinsY());
-      unsigned int phiBin = (ij->GetNbinsZ());
-      //allocate memory for all the histograms, for the given matrix term
-      theHist_array_residual[iH]= new TH1ptr[maxIndex(ij)];
-	 
-      //book the histograms now
-      for(unsigned int iPt = 0;iPt<pTBin;++iPt){
-	for(unsigned int iEta = 0;iEta<etaBin;iEta++){
-	  for(unsigned int iPhi = 0;iPhi<phiBin;iPhi++){
-	    TString hname=Form("%s_%i_%i_%i",
-			       ij->GetName(),
-			       iPt,iEta,iPhi);
-	    LogDebug(theCategory)<<"preparing for: "<<hname<<"\n"
-				 <<"trying to access at: "<<index(ij,iPt,iEta,iPhi)
-				 <<"while maxIndex is: "<<maxIndex(ij);
-	    TH1ptr & theH = (theHist_array_residual[iH])[index(ij,iPt,iEta,iPhi)];
-	       
-	    const int bin[5] = { 100, 100, 100, 5000, 100};
-	    const double min[5] = {-0.05,-0.05,-0.1,-0.005,-10.};
-	    const double max[5] = {0.05,0.05,0.1,0.005,10.};
-
-	    if (i==j){
-	      //	      TString v(ErrorMatrix::vars[i]);
-	      TString htitle(Form("%s Pt:[%.1f,%.1f] Eta:[%.1f,%.1f] Phi:[%.1f,%.1f]",
-				  MuonErrorMatrix::vars[i].Data(),
-				  ij->GetXaxis()->GetBinLowEdge(iPt+1), ij->GetXaxis()->GetBinUpEdge(iPt+1),
-				  ij->GetYaxis()->GetBinLowEdge(iEta+1), ij->GetYaxis()->GetBinUpEdge(iEta+1),
-				  ij->GetZaxis()->GetBinLowEdge(iPhi+1), ij->GetZaxis()->GetBinUpEdge(iPhi+1)
-				  ));
-	      //diagonal term
-	      thePlotFile->cd();
-	      theH = new TH1F(hname,htitle,bin[i],min[i],max[i]);
-	      //	      theH = thePlotDir->make<TH1F>(hname,htitle,bin[i],min[i],max[i]);
-	      theBookKeeping->Add(theH);
-	      theH->SetXTitle("#Delta_{reco-gen}("+MuonErrorMatrix::vars[i]+")");
-
-	      LogDebug(theCategory)<<"creating a TH1F "<<hname<<" at: "<<theH; 
-	    }
-	    else{
-	      TString htitle(Form("%s Pt:[%.1f,%.1f] Eta:[%.1f,%.1f] Phi:[%.1f,%.1f]",
-				  ij->GetTitle(),
-				  ij->GetXaxis()->GetBinLowEdge(iPt+1), ij->GetXaxis()->GetBinUpEdge(iPt+1),
-				  ij->GetYaxis()->GetBinLowEdge(iEta+1), ij->GetYaxis()->GetBinUpEdge(iEta+1),
-				  ij->GetZaxis()->GetBinLowEdge(iPhi+1), ij->GetZaxis()->GetBinUpEdge(iPhi+1)
-				  ));
-	      thePlotFile->cd();
-	      theH = new TH2F(hname,htitle,bin[i],min[i],max[i],100,min[j],max[j]);
-	      //	      theH = thePlotDir->make<TH2F>(hname,htitle,bin[i],min[i],max[i],100,min[j],max[j]);
-	      theBookKeeping->Add(theH);
-	      theH->SetXTitle("#Delta_{reco-gen}("+MuonErrorMatrix::vars[i]+")");
-	      theH->SetYTitle("#Delta_{reco-gen}("+MuonErrorMatrix::vars[j]+")");
-	      
-	      LogDebug(theCategory)<<"creating a TH2 "<<hname<<" at: "<<theH; 
-	    }
-	  }}}//end of loop over the pt,eta,phi
-
-    }
-  }}
 
   //create the 15 histograms, 5 of them TH1F, 10 of them TH2F
-  if (theErrorMatrixStore_Pull){
-  for (unsigned int i=0;i!=5;++i){
-    for (unsigned int j=i;j<5;++j){
-      unsigned int iH=theErrorMatrixStore_Pull->index(i,j);
-      TProfile3D * ij = theErrorMatrixStore_Pull->get(i,j);
-      if (!ij){edm::LogError(theCategory)<<i<<" "<<j<<" not valid indexes. TProfile3D not found."; continue;}
-      unsigned int pTBin = (ij->GetNbinsX());
-      unsigned int etaBin = (ij->GetNbinsY());
-      unsigned int phiBin = (ij->GetNbinsZ());
-      //allocate memory for all the histograms, for the given matrix term
-      theHist_array_pull[iH]= new TH1ptr[maxIndex(ij)];
+  if (theErrorMatrixStore_Residual) {
+    for (unsigned int i = 0; i != 5; ++i) {
+      for (unsigned int j = i; j < 5; ++j) {
+        unsigned int iH = theErrorMatrixStore_Residual->index(i, j);
+        TProfile3D* ij = theErrorMatrixStore_Residual->get(i, j);
+        if (!ij) {
+          edm::LogError(theCategory) << i << " " << j << " not valid indexes. TProfile3D not found.";
+          continue;
+        }
+        unsigned int pTBin = (ij->GetNbinsX());
+        unsigned int etaBin = (ij->GetNbinsY());
+        unsigned int phiBin = (ij->GetNbinsZ());
+        //allocate memory for all the histograms, for the given matrix term
+        theHist_array_residual[iH] = new TH1ptr[maxIndex(ij)];
 
-      //book the histograms now
-      for(unsigned int iPt = 0;iPt<pTBin;++iPt){
-        for(unsigned int iEta = 0;iEta<etaBin;iEta++){
-          for(unsigned int iPhi = 0;iPhi<phiBin;iPhi++){
-            TString hname=Form("%s_p_%i_%i_%i",
-                               ij->GetName(),
-                               iPt,iEta,iPhi);
-            LogDebug(theCategory)<<"preparing for: "<<hname<<"\n"
-                                 <<"trying to access at: "<<index(ij,iPt,iEta,iPhi)
-                                 <<"while maxIndex is: "<<maxIndex(ij);
-            TH1ptr & theH = (theHist_array_pull[iH])[index(ij,iPt,iEta,iPhi)];
+        //book the histograms now
+        for (unsigned int iPt = 0; iPt < pTBin; ++iPt) {
+          for (unsigned int iEta = 0; iEta < etaBin; iEta++) {
+            for (unsigned int iPhi = 0; iPhi < phiBin; iPhi++) {
+              TString hname = Form("%s_%i_%i_%i", ij->GetName(), iPt, iEta, iPhi);
+              LogDebug(theCategory) << "preparing for: " << hname << "\n"
+                                    << "trying to access at: " << index(ij, iPt, iEta, iPhi)
+                                    << "while maxIndex is: " << maxIndex(ij);
+              TH1ptr& theH = (theHist_array_residual[iH])[index(ij, iPt, iEta, iPhi)];
 
-            const int bin[5] = { 200, 200, 200, 200, 200};
-            const double min[5] = {-10, -10, -10, -10, -10 };
-            const double max[5] = {10, 10, 10, 10, 10};
+              const int bin[5] = {100, 100, 100, 5000, 100};
+              const double min[5] = {-0.05, -0.05, -0.1, -0.005, -10.};
+              const double max[5] = {0.05, 0.05, 0.1, 0.005, 10.};
 
-            if (i==j){
-              //              TString v(ErrorMatrix::vars[i]);
-              TString htitle(Form("%s Pt:[%.1f,%.1f] Eta:[%.1f,%.1f] Phi:[%.1f,%.1f]",
-                                  MuonErrorMatrix::vars[i].Data(),
-                                  ij->GetXaxis()->GetBinLowEdge(iPt+1), ij->GetXaxis()->GetBinUpEdge(iPt+1),
-                                  ij->GetYaxis()->GetBinLowEdge(iEta+1), ij->GetYaxis()->GetBinUpEdge(iEta+1),
-                                  ij->GetZaxis()->GetBinLowEdge(iPhi+1), ij->GetZaxis()->GetBinUpEdge(iPhi+1)
-                                  ));
-              //diagonal term
-	      thePlotFile->cd();
-	      theH = new TH1F(hname,htitle,bin[i],min[i],max[i]);
-	      //	      theH = thePlotDir->make<TH1F>(hname,htitle,bin[i],min[i],max[i]);
-	      theBookKeeping->Add(theH);
-              theH->SetXTitle("#Delta_{reco-gen}/#sigma("+MuonErrorMatrix::vars[i]+")");
+              if (i == j) {
+                //	      TString v(ErrorMatrix::vars[i]);
+                TString htitle(Form("%s Pt:[%.1f,%.1f] Eta:[%.1f,%.1f] Phi:[%.1f,%.1f]",
+                                    MuonErrorMatrix::vars[i].Data(),
+                                    ij->GetXaxis()->GetBinLowEdge(iPt + 1),
+                                    ij->GetXaxis()->GetBinUpEdge(iPt + 1),
+                                    ij->GetYaxis()->GetBinLowEdge(iEta + 1),
+                                    ij->GetYaxis()->GetBinUpEdge(iEta + 1),
+                                    ij->GetZaxis()->GetBinLowEdge(iPhi + 1),
+                                    ij->GetZaxis()->GetBinUpEdge(iPhi + 1)));
+                //diagonal term
+                thePlotFile->cd();
+                theH = new TH1F(hname, htitle, bin[i], min[i], max[i]);
+                //	      theH = thePlotDir->make<TH1F>(hname,htitle,bin[i],min[i],max[i]);
+                theBookKeeping->Add(theH);
+                theH->SetXTitle("#Delta_{reco-gen}(" + MuonErrorMatrix::vars[i] + ")");
 
-              LogDebug(theCategory)<<"creating a TH1F "<<hname<<" at: "<<theH;
+                LogDebug(theCategory) << "creating a TH1F " << hname << " at: " << theH;
+              } else {
+                TString htitle(Form("%s Pt:[%.1f,%.1f] Eta:[%.1f,%.1f] Phi:[%.1f,%.1f]",
+                                    ij->GetTitle(),
+                                    ij->GetXaxis()->GetBinLowEdge(iPt + 1),
+                                    ij->GetXaxis()->GetBinUpEdge(iPt + 1),
+                                    ij->GetYaxis()->GetBinLowEdge(iEta + 1),
+                                    ij->GetYaxis()->GetBinUpEdge(iEta + 1),
+                                    ij->GetZaxis()->GetBinLowEdge(iPhi + 1),
+                                    ij->GetZaxis()->GetBinUpEdge(iPhi + 1)));
+                thePlotFile->cd();
+                theH = new TH2F(hname, htitle, bin[i], min[i], max[i], 100, min[j], max[j]);
+                //	      theH = thePlotDir->make<TH2F>(hname,htitle,bin[i],min[i],max[i],100,min[j],max[j]);
+                theBookKeeping->Add(theH);
+                theH->SetXTitle("#Delta_{reco-gen}(" + MuonErrorMatrix::vars[i] + ")");
+                theH->SetYTitle("#Delta_{reco-gen}(" + MuonErrorMatrix::vars[j] + ")");
+
+                LogDebug(theCategory) << "creating a TH2 " << hname << " at: " << theH;
+              }
             }
-            else{
-              TString htitle(Form("%s Pt:[%.1f,%.1f] Eta:[%.1f,%.1f] Phi:[%.1f,%.1f]",
-                                  ij->GetTitle(),
-                                  ij->GetXaxis()->GetBinLowEdge(iPt+1), ij->GetXaxis()->GetBinUpEdge(iPt+1),
-                                  ij->GetYaxis()->GetBinLowEdge(iEta+1), ij->GetYaxis()->GetBinUpEdge(iEta+1),
-                                  ij->GetZaxis()->GetBinLowEdge(iPhi+1), ij->GetZaxis()->GetBinUpEdge(iPhi+1)
-                                  ));
-	      thePlotFile->cd();
-	      theH = new TH2F(hname,htitle,bin[i],min[i],max[i],100,min[j],max[j]);
-	      //	      theH = thePlotDir->make<TH2F>(hname,htitle,bin[i],min[i],max[i],100,min[j],max[j]);
-	      theBookKeeping->Add(theH);
-              theH->SetXTitle("#Delta_{reco-gen}/#sigma("+MuonErrorMatrix::vars[i]+")");
-              theH->SetYTitle("#Delta_{reco-gen}/#sigma("+MuonErrorMatrix::vars[j]+")");
-
-              LogDebug(theCategory)<<"creating a TH2 "<<hname<<" at: "<<theH;
-            }
-          }}}//end of loop over the pt,eta,phi
+          }
+        }  //end of loop over the pt,eta,phi
+      }
     }
-  }}
+  }
 
+  //create the 15 histograms, 5 of them TH1F, 10 of them TH2F
+  if (theErrorMatrixStore_Pull) {
+    for (unsigned int i = 0; i != 5; ++i) {
+      for (unsigned int j = i; j < 5; ++j) {
+        unsigned int iH = theErrorMatrixStore_Pull->index(i, j);
+        TProfile3D* ij = theErrorMatrixStore_Pull->get(i, j);
+        if (!ij) {
+          edm::LogError(theCategory) << i << " " << j << " not valid indexes. TProfile3D not found.";
+          continue;
+        }
+        unsigned int pTBin = (ij->GetNbinsX());
+        unsigned int etaBin = (ij->GetNbinsY());
+        unsigned int phiBin = (ij->GetNbinsZ());
+        //allocate memory for all the histograms, for the given matrix term
+        theHist_array_pull[iH] = new TH1ptr[maxIndex(ij)];
 
-} 
+        //book the histograms now
+        for (unsigned int iPt = 0; iPt < pTBin; ++iPt) {
+          for (unsigned int iEta = 0; iEta < etaBin; iEta++) {
+            for (unsigned int iPhi = 0; iPhi < phiBin; iPhi++) {
+              TString hname = Form("%s_p_%i_%i_%i", ij->GetName(), iPt, iEta, iPhi);
+              LogDebug(theCategory) << "preparing for: " << hname << "\n"
+                                    << "trying to access at: " << index(ij, iPt, iEta, iPhi)
+                                    << "while maxIndex is: " << maxIndex(ij);
+              TH1ptr& theH = (theHist_array_pull[iH])[index(ij, iPt, iEta, iPhi)];
+
+              const int bin[5] = {200, 200, 200, 200, 200};
+              const double min[5] = {-10, -10, -10, -10, -10};
+              const double max[5] = {10, 10, 10, 10, 10};
+
+              if (i == j) {
+                //              TString v(ErrorMatrix::vars[i]);
+                TString htitle(Form("%s Pt:[%.1f,%.1f] Eta:[%.1f,%.1f] Phi:[%.1f,%.1f]",
+                                    MuonErrorMatrix::vars[i].Data(),
+                                    ij->GetXaxis()->GetBinLowEdge(iPt + 1),
+                                    ij->GetXaxis()->GetBinUpEdge(iPt + 1),
+                                    ij->GetYaxis()->GetBinLowEdge(iEta + 1),
+                                    ij->GetYaxis()->GetBinUpEdge(iEta + 1),
+                                    ij->GetZaxis()->GetBinLowEdge(iPhi + 1),
+                                    ij->GetZaxis()->GetBinUpEdge(iPhi + 1)));
+                //diagonal term
+                thePlotFile->cd();
+                theH = new TH1F(hname, htitle, bin[i], min[i], max[i]);
+                //	      theH = thePlotDir->make<TH1F>(hname,htitle,bin[i],min[i],max[i]);
+                theBookKeeping->Add(theH);
+                theH->SetXTitle("#Delta_{reco-gen}/#sigma(" + MuonErrorMatrix::vars[i] + ")");
+
+                LogDebug(theCategory) << "creating a TH1F " << hname << " at: " << theH;
+              } else {
+                TString htitle(Form("%s Pt:[%.1f,%.1f] Eta:[%.1f,%.1f] Phi:[%.1f,%.1f]",
+                                    ij->GetTitle(),
+                                    ij->GetXaxis()->GetBinLowEdge(iPt + 1),
+                                    ij->GetXaxis()->GetBinUpEdge(iPt + 1),
+                                    ij->GetYaxis()->GetBinLowEdge(iEta + 1),
+                                    ij->GetYaxis()->GetBinUpEdge(iEta + 1),
+                                    ij->GetZaxis()->GetBinLowEdge(iPhi + 1),
+                                    ij->GetZaxis()->GetBinUpEdge(iPhi + 1)));
+                thePlotFile->cd();
+                theH = new TH2F(hname, htitle, bin[i], min[i], max[i], 100, min[j], max[j]);
+                //	      theH = thePlotDir->make<TH2F>(hname,htitle,bin[i],min[i],max[i],100,min[j],max[j]);
+                theBookKeeping->Add(theH);
+                theH->SetXTitle("#Delta_{reco-gen}/#sigma(" + MuonErrorMatrix::vars[i] + ")");
+                theH->SetYTitle("#Delta_{reco-gen}/#sigma(" + MuonErrorMatrix::vars[j] + ")");
+
+                LogDebug(theCategory) << "creating a TH2 " << hname << " at: " << theH;
+              }
+            }
+          }
+        }  //end of loop over the pt,eta,phi
+      }
+    }
+  }
+}
 
 #include <TF2.h>
 
-MuonErrorMatrixAnalyzer::extractRes MuonErrorMatrixAnalyzer::extract(TH2 * h2){
+MuonErrorMatrixAnalyzer::extractRes MuonErrorMatrixAnalyzer::extract(TH2* h2) {
   extractRes res;
 
   //FIXME. no fitting procedure by default
-  if (h2->GetEntries()<1000000)
-    { 
-      LogDebug(theCategory)<<"basic method. not enough entries ("<<h2->GetEntries()<<")";
-      res.corr= h2->GetCorrelationFactor();
-      res.x = h2->GetRMS(1);
-      res.y = h2->GetRMS(2);
-      return res;}
-
+  if (h2->GetEntries() < 1000000) {
+    LogDebug(theCategory) << "basic method. not enough entries (" << h2->GetEntries() << ")";
+    res.corr = h2->GetCorrelationFactor();
+    res.x = h2->GetRMS(1);
+    res.y = h2->GetRMS(2);
+    return res;
+  }
 
   //make a copy while rebinning
-  int nX= std::max(1,h2->GetNbinsX()/40);
-  int nY= std::max(1,h2->GetNbinsY()/40);
-  LogDebug(theCategory)<<"rebinning: "<<h2->GetName()<<" by: "<<nX<<" "<<nY;
-  TH2 * h2r = h2->Rebin2D(nX,nY,"hnew");
-  
-  TString fname(h2->GetName());
-  fname+=+"_fit_f2";
-  TF2 * f2 = new TF2(fname,"[0]*exp(-0.5*(((x-[1])/[2])**2+((y-[3])/[4])**2 -2*[5]*(x-[1])*(y-[3])/([4]*[2])))",-10,10,-10,10);
-  f2->SetParameters(h2->Integral(),
-		    0,
-		    h2->GetRMS(1),
-		    0,
-		    h2->GetRMS(2),
-		    h2->GetCorrelationFactor());
-  f2->FixParameter(1,0);
-  f2->FixParameter(3,0);
-  
-  if (fabs(h2->GetCorrelationFactor())<0.001){
-    LogDebug(theCategory)<<"correlations neglected: "<<h2->GetCorrelationFactor()<<" for: "<<h2->GetName();
-    f2->FixParameter(5,0);}
-  else{f2->ReleaseParameter(5);}
-  
-  f2->SetParLimits(2,0,10*h2->GetRMS(1));
-  f2->SetParLimits(4,0,10*h2->GetRMS(2));
-  
-  h2r->Fit(fname,"nqL"); 
-  
-  res.corr= f2->GetParameter(5);
-  res.x= f2->GetParameter(2);
-  res.y= f2->GetParameter(4);
+  int nX = std::max(1, h2->GetNbinsX() / 40);
+  int nY = std::max(1, h2->GetNbinsY() / 40);
+  LogDebug(theCategory) << "rebinning: " << h2->GetName() << " by: " << nX << " " << nY;
+  TH2* h2r = h2->Rebin2D(nX, nY, "hnew");
 
-  LogDebug(theCategory)<<"\n variable: "<<h2->GetXaxis()->GetTitle()
-		       <<"\n RMS= "<<h2->GetRMS(1)
-		       <<"\n fit= "<<f2->GetParameter(2)
-		       <<"\n variable: "<<h2->GetYaxis()->GetTitle()
-		       <<"\n RMS= "<<h2->GetRMS(2)
-		       <<"\n fit= "<<f2->GetParameter(4)
-		       <<"\n correlation"
-		       <<"\n correlation factor= "<<h2->GetCorrelationFactor()
-		       <<"\n fit=                "<<f2->GetParameter(5);
-								  
+  TString fname(h2->GetName());
+  fname += +"_fit_f2";
+  TF2* f2 = new TF2(
+      fname, "[0]*exp(-0.5*(((x-[1])/[2])**2+((y-[3])/[4])**2 -2*[5]*(x-[1])*(y-[3])/([4]*[2])))", -10, 10, -10, 10);
+  f2->SetParameters(h2->Integral(), 0, h2->GetRMS(1), 0, h2->GetRMS(2), h2->GetCorrelationFactor());
+  f2->FixParameter(1, 0);
+  f2->FixParameter(3, 0);
+
+  if (fabs(h2->GetCorrelationFactor()) < 0.001) {
+    LogDebug(theCategory) << "correlations neglected: " << h2->GetCorrelationFactor() << " for: " << h2->GetName();
+    f2->FixParameter(5, 0);
+  } else {
+    f2->ReleaseParameter(5);
+  }
+
+  f2->SetParLimits(2, 0, 10 * h2->GetRMS(1));
+  f2->SetParLimits(4, 0, 10 * h2->GetRMS(2));
+
+  h2r->Fit(fname, "nqL");
+
+  res.corr = f2->GetParameter(5);
+  res.x = f2->GetParameter(2);
+  res.y = f2->GetParameter(4);
+
+  LogDebug(theCategory) << "\n variable: " << h2->GetXaxis()->GetTitle() << "\n RMS= " << h2->GetRMS(1)
+                        << "\n fit= " << f2->GetParameter(2) << "\n variable: " << h2->GetYaxis()->GetTitle()
+                        << "\n RMS= " << h2->GetRMS(2) << "\n fit= " << f2->GetParameter(4) << "\n correlation"
+                        << "\n correlation factor= " << h2->GetCorrelationFactor()
+                        << "\n fit=                " << f2->GetParameter(5);
+
   f2->Delete();
   h2r->Delete();
-  
-  return  res;
+
+  return res;
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-MuonErrorMatrixAnalyzer::endJob() {
-  LogDebug(theCategory)<<"endJob begins.";  
+void MuonErrorMatrixAnalyzer::endJob() {
+  LogDebug(theCategory) << "endJob begins.";
   //  std::cout<<"endJob of MuonErrorMatrixAnalyzer"<<std::endl;
   //evaluate the histograms to find the correlation factors and sigmas
 
-  if (theErrorMatrixStore_Reported){
+  if (theErrorMatrixStore_Reported) {
     //close the error matrix method object
     theErrorMatrixStore_Reported->close();
   }
 
   //write the file with all the plots in it.
-  TFile*   thePlotFile=0;
-  if(thePlotFileName!= ""){
+  TFile* thePlotFile = 0;
+  if (thePlotFileName != "") {
     //    std::cout<<"trying to write in: "<<thePlotFileName<<std::endl;
-    
-    thePlotFile = TFile::Open(thePlotFileName.c_str(),"recreate");
+
+    thePlotFile = TFile::Open(thePlotFileName.c_str(), "recreate");
     thePlotFile->cd();
     TListIter iter(theBookKeeping);
     //    std::cout<<"number of objects to write: "<<theBookKeeping->GetSize()<<std::endl;
-    TObject * o=0;
-    while( (o=iter.Next()) )
-      {
-	//	std::cout<<"writing: "<<o->GetName()<<" in file: "<<thePlotFile->GetName()<<std::endl;
-	o->Write();
-      }
+    TObject* o = 0;
+    while ((o = iter.Next())) {
+      //	std::cout<<"writing: "<<o->GetName()<<" in file: "<<thePlotFile->GetName()<<std::endl;
+      o->Write();
+    }
     //thePlotFile->Write();
-
   }
 
-  if (theErrorMatrixStore_Residual){
+  if (theErrorMatrixStore_Residual) {
     //extract the rms and correlation factor from the residual
-    for (unsigned int i=0;i!=5;++i){
-      for (unsigned int j=i;j<5;++j){
-	unsigned int iH=theErrorMatrixStore_Residual->index(i,j);
-	TProfile3D * ij = theErrorMatrixStore_Residual->get(i,j);
-	TProfile3D * ii = theErrorMatrixStore_Residual->get(i,i);
-	TProfile3D * jj = theErrorMatrixStore_Residual->get(j,j);
-	if (!ij){edm::LogError(theCategory)<<i<<" "<<j<<" not valid indexes. TProfile3D not found."; continue;}
-	if (!ii){edm::LogError(theCategory)<<i<<" "<<i<<" not valid indexes. TProfile3D not found."; continue;}
-	if (!jj){edm::LogError(theCategory)<<j<<" "<<j<<" not valid indexes. TProfile3D not found."; continue;}
-      
-	unsigned int pTBin = (ij->GetNbinsX());
-	unsigned int etaBin = (ij->GetNbinsY());
-	unsigned int phiBin = (ij->GetNbinsZ());
-      
-	//analyze the histograms now
-	for(unsigned int iPt = 0;iPt<pTBin;++iPt){
-	  for(unsigned int iEta = 0;iEta<etaBin;iEta++){
-	    for(unsigned int iPhi = 0;iPhi<phiBin;iPhi++){
-	    
-	      double pt = ij->GetXaxis()->GetBinCenter(iPt+1);
-	      double eta = ij->GetYaxis()->GetBinCenter(iEta+1);
-	      double phi = ij->GetZaxis()->GetBinCenter(iPhi+1);
+    for (unsigned int i = 0; i != 5; ++i) {
+      for (unsigned int j = i; j < 5; ++j) {
+        unsigned int iH = theErrorMatrixStore_Residual->index(i, j);
+        TProfile3D* ij = theErrorMatrixStore_Residual->get(i, j);
+        TProfile3D* ii = theErrorMatrixStore_Residual->get(i, i);
+        TProfile3D* jj = theErrorMatrixStore_Residual->get(j, j);
+        if (!ij) {
+          edm::LogError(theCategory) << i << " " << j << " not valid indexes. TProfile3D not found.";
+          continue;
+        }
+        if (!ii) {
+          edm::LogError(theCategory) << i << " " << i << " not valid indexes. TProfile3D not found.";
+          continue;
+        }
+        if (!jj) {
+          edm::LogError(theCategory) << j << " " << j << " not valid indexes. TProfile3D not found.";
+          continue;
+        }
 
-	    
-	      TH1ptr & theH = (theHist_array_residual[iH])[index(ij,iPt,iEta,iPhi)];
-	      LogDebug(theCategory)<<"extracting for: "<<pt<<" "<<eta<<" "<<phi
-				   <<"at index: "<<index(ij,iPt,iEta,iPhi)
-				   <<"while maxIndex is: "<<maxIndex(ij)
-				   <<"\n named: "<<theH->GetName();
-	      
-	      //FIXME. not using the i=j plots (TH1F)	    
-	      if (i!=j){
-		extractRes r = extract((TH2*) theH);
-		ii->Fill(pt,eta,phi,r.x);
-		jj->Fill(pt,eta,phi,r.y);
-		ij->Fill(pt,eta,phi,r.corr);
-		LogDebug(theCategory)<<"for: "<<theH->GetName()<<" rho is: "<<r.corr
-				     <<" sigma x= "<<r.x
-				     <<" sigma y= "<<r.y;
-	      }
+        unsigned int pTBin = (ij->GetNbinsX());
+        unsigned int etaBin = (ij->GetNbinsY());
+        unsigned int phiBin = (ij->GetNbinsZ());
 
-	      //please free the memory !!!
-	      LogDebug(theCategory)<<"freing memory of: "<<theH->GetName();
-	      theH->Delete();
-	      theH=0;
-	    }}}//end of loop over the pt,eta,phi
-      }}
-  
+        //analyze the histograms now
+        for (unsigned int iPt = 0; iPt < pTBin; ++iPt) {
+          for (unsigned int iEta = 0; iEta < etaBin; iEta++) {
+            for (unsigned int iPhi = 0; iPhi < phiBin; iPhi++) {
+              double pt = ij->GetXaxis()->GetBinCenter(iPt + 1);
+              double eta = ij->GetYaxis()->GetBinCenter(iEta + 1);
+              double phi = ij->GetZaxis()->GetBinCenter(iPhi + 1);
+
+              TH1ptr& theH = (theHist_array_residual[iH])[index(ij, iPt, iEta, iPhi)];
+              LogDebug(theCategory) << "extracting for: " << pt << " " << eta << " " << phi
+                                    << "at index: " << index(ij, iPt, iEta, iPhi)
+                                    << "while maxIndex is: " << maxIndex(ij) << "\n named: " << theH->GetName();
+
+              //FIXME. not using the i=j plots (TH1F)
+              if (i != j) {
+                extractRes r = extract((TH2*)theH);
+                ii->Fill(pt, eta, phi, r.x);
+                jj->Fill(pt, eta, phi, r.y);
+                ij->Fill(pt, eta, phi, r.corr);
+                LogDebug(theCategory) << "for: " << theH->GetName() << " rho is: " << r.corr << " sigma x= " << r.x
+                                      << " sigma y= " << r.y;
+              }
+
+              //please free the memory !!!
+              LogDebug(theCategory) << "freing memory of: " << theH->GetName();
+              theH->Delete();
+              theH = 0;
+            }
+          }
+        }  //end of loop over the pt,eta,phi
+      }
+    }
+
     theErrorMatrixStore_Residual->close();
   }
-  
 
-  if (theErrorMatrixStore_Pull){
+  if (theErrorMatrixStore_Pull) {
     // extract the scale factors from the pull distribution
-    TF1 * f = new TF1("fit_for_theErrorMatrixStore_Pull","gaus",-theGaussianPullFitRange,theGaussianPullFitRange);
+    TF1* f = new TF1("fit_for_theErrorMatrixStore_Pull", "gaus", -theGaussianPullFitRange, theGaussianPullFitRange);
 
-    for (unsigned int i=0;i!=5;++i){
-      for (unsigned int j=i;j<5;++j){
-	unsigned int iH=theErrorMatrixStore_Pull->index(i,j);
-	TProfile3D * ij = theErrorMatrixStore_Pull->get(i,j);
-	TProfile3D * ii = theErrorMatrixStore_Pull->get(i,i);
-	TProfile3D * jj = theErrorMatrixStore_Pull->get(j,j);
-	if (!ij){edm::LogError(theCategory)<<i<<" "<<j<<" not valid indexes. TProfile3D not found."; continue;}
-	if (!ii){edm::LogError(theCategory)<<i<<" "<<i<<" not valid indexes. TProfile3D not found."; continue;}
-	if (!jj){edm::LogError(theCategory)<<j<<" "<<j<<" not valid indexes. TProfile3D not found."; continue;}
+    for (unsigned int i = 0; i != 5; ++i) {
+      for (unsigned int j = i; j < 5; ++j) {
+        unsigned int iH = theErrorMatrixStore_Pull->index(i, j);
+        TProfile3D* ij = theErrorMatrixStore_Pull->get(i, j);
+        TProfile3D* ii = theErrorMatrixStore_Pull->get(i, i);
+        TProfile3D* jj = theErrorMatrixStore_Pull->get(j, j);
+        if (!ij) {
+          edm::LogError(theCategory) << i << " " << j << " not valid indexes. TProfile3D not found.";
+          continue;
+        }
+        if (!ii) {
+          edm::LogError(theCategory) << i << " " << i << " not valid indexes. TProfile3D not found.";
+          continue;
+        }
+        if (!jj) {
+          edm::LogError(theCategory) << j << " " << j << " not valid indexes. TProfile3D not found.";
+          continue;
+        }
 
-	unsigned int pTBin = (ij->GetNbinsX());
-	unsigned int etaBin = (ij->GetNbinsY());
-	unsigned int phiBin = (ij->GetNbinsZ());
+        unsigned int pTBin = (ij->GetNbinsX());
+        unsigned int etaBin = (ij->GetNbinsY());
+        unsigned int phiBin = (ij->GetNbinsZ());
 
-	//analyze the histograms now
-	for(unsigned int iPt = 0;iPt<pTBin;++iPt){
-	  for(unsigned int iEta = 0;iEta<etaBin;iEta++){
-	    for(unsigned int iPhi = 0;iPhi<phiBin;iPhi++){
+        //analyze the histograms now
+        for (unsigned int iPt = 0; iPt < pTBin; ++iPt) {
+          for (unsigned int iEta = 0; iEta < etaBin; iEta++) {
+            for (unsigned int iPhi = 0; iPhi < phiBin; iPhi++) {
+              double pt = ij->GetXaxis()->GetBinCenter(iPt + 1);
+              double eta = ij->GetYaxis()->GetBinCenter(iEta + 1);
+              double phi = ij->GetZaxis()->GetBinCenter(iPhi + 1);
 
-	      double pt = ij->GetXaxis()->GetBinCenter(iPt+1);
-	      double eta = ij->GetYaxis()->GetBinCenter(iEta+1);
-	      double phi = ij->GetZaxis()->GetBinCenter(iPhi+1);
+              TH1ptr& theH = (theHist_array_pull[iH])[index(ij, iPt, iEta, iPhi)];
+              LogDebug(theCategory) << "extracting for: " << pt << " " << eta << " " << phi
+                                    << "at index: " << index(ij, iPt, iEta, iPhi)
+                                    << "while maxIndex is: " << maxIndex(ij) << "\n named: " << theH->GetName();
+              double value = 0;
+              if (i != j) {
+                //off diag term. not implemented yet. fill with ones
+                ij->Fill(pt, eta, phi, 1.);
+              } else {
+                //diag term. perform a gaussian core fit (-2,2) to determine value
+                ((TH1*)theH)->Fit(f->GetName(), "qnL", "");
+                value = f->GetParameter(2);
+                LogDebug(theCategory) << "scale factor is: " << value;
+                ii->Fill(pt, eta, phi, value);
+              }
 
-
-	      TH1ptr & theH = (theHist_array_pull[iH])[index(ij,iPt,iEta,iPhi)];
-	      LogDebug(theCategory)<<"extracting for: "<<pt<<" "<<eta<<" "<<phi
-				   <<"at index: "<<index(ij,iPt,iEta,iPhi)
-				   <<"while maxIndex is: "<<maxIndex(ij)
-				   <<"\n named: "<<theH->GetName();
-	      double value=0;
-	      if (i!=j){
-		//off diag term. not implemented yet. fill with ones
-		ij->Fill(pt, eta, phi, 1.);
-	      }
-	      else{
-		//diag term. perform a gaussian core fit (-2,2) to determine value
-		((TH1*)theH)->Fit(f->GetName(),"qnL","");
-		value =f->GetParameter(2);
-		LogDebug(theCategory)<<"scale factor is: "<<value;
-		ii->Fill(pt,eta,phi,value);
-	      }
-
-	      //please free the memory !!!
-	      LogDebug(theCategory)<<"freing memory of: "<<theH->GetName();
-	      theH->Delete();
-	      theH=0;
-	    }}}//end of loop over the pt,eta,phi 
+              //please free the memory !!!
+              LogDebug(theCategory) << "freing memory of: " << theH->GetName();
+              theH->Delete();
+              theH = 0;
+            }
+          }
+        }  //end of loop over the pt,eta,phi
       }
     }
 
@@ -759,7 +758,7 @@ MuonErrorMatrixAnalyzer::endJob() {
   }
 
   //close the file with all the plots in it.
-  if(thePlotFile){thePlotFile->Close();}
-  
+  if (thePlotFile) {
+    thePlotFile->Close();
+  }
 }
-

--- a/RecoMuon/TrackingTools/test/MuonErrorMatrixAnalyzer.h
+++ b/RecoMuon/TrackingTools/test/MuonErrorMatrixAnalyzer.h
@@ -38,26 +38,23 @@ class Propagator;
 //
 
 class MuonErrorMatrixAnalyzer : public edm::EDAnalyzer {
- public:
-
+public:
   /// constructor
   explicit MuonErrorMatrixAnalyzer(const edm::ParameterSet&);
-   
+
   ///destructor
   ~MuonErrorMatrixAnalyzer();
-     
-     
- private:
+
+private:
   /// framework methods
-  virtual void beginJob() ;
+  virtual void beginJob();
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
   virtual void endJob();
-     
+
   /// produce error parametrization from reported errors
   void analyze_from_errormatrix(const edm::Event&, const edm::EventSetup&);
   /// produces error parametrization from the pull of track parameters
   void analyze_from_pull(const edm::Event&, const edm::EventSetup&);
-
 
   // ----------member data ---------------------------
   /// log category: "MuonErrorMatrixAnalyzer"
@@ -74,21 +71,19 @@ class MuonErrorMatrixAnalyzer : public edm::EDAnalyzer {
   edm::ESHandle<MagneticField> theField;
 
   /// class holder for the reported error parametrization
-  MuonErrorMatrix * theErrorMatrixStore_Reported;
+  MuonErrorMatrix* theErrorMatrixStore_Reported;
   edm::ParameterSet theErrorMatrixStore_Reported_pset;
 
   /// class holder for the empirical error parametrization from residual
-  MuonErrorMatrix * theErrorMatrixStore_Residual;
+  MuonErrorMatrix* theErrorMatrixStore_Residual;
   edm::ParameterSet theErrorMatrixStore_Residual_pset;
 
   /// class holder for the empirical error scale factor parametrization from pull
-  MuonErrorMatrix * theErrorMatrixStore_Pull;
+  MuonErrorMatrix* theErrorMatrixStore_Pull;
   edm::ParameterSet theErrorMatrixStore_Pull_pset;
-
 
   /// the range of the pull fit is [-theGaussianPullFitRange, theGaussianPullFitRange] [-2,2] by default
   double theGaussianPullFitRange;
-
 
   /// radius at which the comparison is made: =0 is using TSCPBuilderNoMaterial, !=0 is using the propagator
   double theRadius;
@@ -107,13 +102,12 @@ class MuonErrorMatrixAnalyzer : public edm::EDAnalyzer {
   edm::ESHandle<Propagator> thePropagator;
 
   /// put the free trajectory state to the TSCPBuilderNoMaterial or the cylinder surface
-  FreeTrajectoryState refLocusState(const FreeTrajectoryState &fts);
-
+  FreeTrajectoryState refLocusState(const FreeTrajectoryState& fts);
 
   /// control plot root file (auxiliary, configurable)
-  TFile * thePlotFile;
-  TFileDirectory * thePlotDir;
-  TList * theBookKeeping;
+  TFile* thePlotFile;
+  TFileDirectory* thePlotDir;
+  TList* theBookKeeping;
   std::string thePlotFileName;
 
   /// arrays of plots for the empirical error parametrization
@@ -122,15 +116,17 @@ class MuonErrorMatrixAnalyzer : public edm::EDAnalyzer {
   TH1ptr* theHist_array_pull[15];
 
   /// index whithin the array of plots
-  inline unsigned int index(TProfile3D * pf, unsigned int i ,unsigned int j,unsigned int k)   {return (((i*pf->GetNbinsY())+j) * pf->GetNbinsZ())+k;}
-  unsigned int maxIndex(TProfile3D * pf)  {return pf->GetNbinsX()*pf->GetNbinsY()*pf->GetNbinsZ();}
+  inline unsigned int index(TProfile3D* pf, unsigned int i, unsigned int j, unsigned int k) {
+    return (((i * pf->GetNbinsY()) + j) * pf->GetNbinsZ()) + k;
+  }
+  unsigned int maxIndex(TProfile3D* pf) { return pf->GetNbinsX() * pf->GetNbinsY() * pf->GetNbinsZ(); }
 
-  struct extractRes{
+  struct extractRes {
     double corr;
     double x;
     double y;
   };
   /// fit procedure to extract sigma_x sigma_y and correlation factor from 2D residual histogram
-  extractRes extract(TH2 * h2);
+  extractRes extract(TH2* h2);
 };
 #endif

--- a/RecoMuon/TrackingTools/test/SealModules.cc
+++ b/RecoMuon/TrackingTools/test/SealModules.cc
@@ -5,8 +5,6 @@
 #include "FWCore/Utilities/interface/typelookup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
 #include "RecoMuon/TrackingTools/test/MuonErrorMatrixAnalyzer.h"
-
 
 DEFINE_FWK_MODULE(MuonErrorMatrixAnalyzer);

--- a/RecoTracker/SingleTrackPattern/interface/CRackTrajectoryBuilder.h
+++ b/RecoTracker/SingleTrackPattern/interface/CRackTrajectoryBuilder.h
@@ -37,234 +37,213 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 
-
 //to sort hits by the det position
- class CompareDetY_plus {
- public:
-   CompareDetY_plus(const TrackerGeometry& tracker):_tracker(tracker){}
-   bool operator()( const TrackingRecHit *rh1,
-		    const TrackingRecHit *rh2)
-   {
-     const GeomDet* detPos1 = _tracker.idToDet(rh1->geographicalId());
-     const GeomDet* detPos2 = _tracker.idToDet(rh2->geographicalId());
+class CompareDetY_plus {
+public:
+  CompareDetY_plus(const TrackerGeometry& tracker) : _tracker(tracker) {}
+  bool operator()(const TrackingRecHit* rh1, const TrackingRecHit* rh2) {
+    const GeomDet* detPos1 = _tracker.idToDet(rh1->geographicalId());
+    const GeomDet* detPos2 = _tracker.idToDet(rh2->geographicalId());
 
-     const GlobalPoint& gp1 = detPos1->position();
-     const GlobalPoint& gp2 = detPos2->position();
-     
-     if (gp1.y()>gp2.y())
-       return true;
-     if (gp1.y()<gp2.y())
-       return false;
-     //  if (gp1.y()== gp2.y())
-     // 
-     return (rh1->geographicalId() < rh2->geographicalId());
-   };
-    private:
-   //   edm::ESHandle<TrackerGeometry> _tracker;
-   const TrackerGeometry& _tracker;
- };
+    const GlobalPoint& gp1 = detPos1->position();
+    const GlobalPoint& gp2 = detPos2->position();
 
- class CompareDetY_minus {
- public:
-   CompareDetY_minus(const TrackerGeometry& tracker):_tracker(tracker){}
-   bool operator()( const TrackingRecHit *rh1,
-		    const TrackingRecHit *rh2)
-   {
-     const GeomDet* detPos1 = _tracker.idToDet(rh1->geographicalId());
-     const GeomDet* detPos2 = _tracker.idToDet(rh2->geographicalId());
+    if (gp1.y() > gp2.y())
+      return true;
+    if (gp1.y() < gp2.y())
+      return false;
+    //  if (gp1.y()== gp2.y())
+    //
+    return (rh1->geographicalId() < rh2->geographicalId());
+  };
 
-     const GlobalPoint& gp1 = detPos1->position();
-     const GlobalPoint& gp2 = detPos2->position();
-     
-     if (gp1.y()<gp2.y())
-       return true;
-     if (gp1.y()>gp2.y())
-       return false;
-     //  if (gp1.y()== gp2.y())
-     // 
-     return (rh1->geographicalId() < rh2->geographicalId());
-   };
-    private:
-   //   edm::ESHandle<TrackerGeometry> _tracker;
-   const TrackerGeometry& _tracker;
- };
+private:
+  //   edm::ESHandle<TrackerGeometry> _tracker;
+  const TrackerGeometry& _tracker;
+};
+
+class CompareDetY_minus {
+public:
+  CompareDetY_minus(const TrackerGeometry& tracker) : _tracker(tracker) {}
+  bool operator()(const TrackingRecHit* rh1, const TrackingRecHit* rh2) {
+    const GeomDet* detPos1 = _tracker.idToDet(rh1->geographicalId());
+    const GeomDet* detPos2 = _tracker.idToDet(rh2->geographicalId());
+
+    const GlobalPoint& gp1 = detPos1->position();
+    const GlobalPoint& gp2 = detPos2->position();
+
+    if (gp1.y() < gp2.y())
+      return true;
+    if (gp1.y() > gp2.y())
+      return false;
+    //  if (gp1.y()== gp2.y())
+    //
+    return (rh1->geographicalId() < rh2->geographicalId());
+  };
+
+private:
+  //   edm::ESHandle<TrackerGeometry> _tracker;
+  const TrackerGeometry& _tracker;
+};
 
 #ifndef TrajectoryBuilder_CompareHitY
 #define TrajectoryBuilder_CompareHitY
 
 class CompareHitY {
- public:
-  CompareHitY(const TrackerGeometry& tracker):_tracker(tracker){}
-  bool operator()( const TrackingRecHit *rh1,
-		   const TrackingRecHit *rh2)
-  {
-    GlobalPoint gp1=_tracker.idToDet(rh1->geographicalId())->surface().toGlobal(rh1->localPosition());
-    GlobalPoint gp2=_tracker.idToDet(rh2->geographicalId())->surface().toGlobal(rh2->localPosition());
-    return gp1.y()<gp2.y();};
- private:
+public:
+  CompareHitY(const TrackerGeometry& tracker) : _tracker(tracker) {}
+  bool operator()(const TrackingRecHit* rh1, const TrackingRecHit* rh2) {
+    GlobalPoint gp1 = _tracker.idToDet(rh1->geographicalId())->surface().toGlobal(rh1->localPosition());
+    GlobalPoint gp2 = _tracker.idToDet(rh2->geographicalId())->surface().toGlobal(rh2->localPosition());
+    return gp1.y() < gp2.y();
+  };
+
+private:
   //   edm::ESHandle<TrackerGeometry> _tracker;
-   const TrackerGeometry& _tracker;
+  const TrackerGeometry& _tracker;
 };
 
- class CompareHitY_plus {
- public:
-   CompareHitY_plus(const TrackerGeometry& tracker):_tracker(tracker){}
-   bool operator()( const TrackingRecHit *rh1,
-		    const TrackingRecHit *rh2)
-   {
-     GlobalPoint gp1=_tracker.idToDet(rh1->geographicalId())->surface().toGlobal(rh1->localPosition());
-     GlobalPoint gp2=_tracker.idToDet(rh2->geographicalId())->surface().toGlobal(rh2->localPosition());
-     return gp1.y()>gp2.y();};
- private:
-   //   edm::ESHandle<TrackerGeometry> _tracker;
-   const TrackerGeometry& _tracker;
- };
+class CompareHitY_plus {
+public:
+  CompareHitY_plus(const TrackerGeometry& tracker) : _tracker(tracker) {}
+  bool operator()(const TrackingRecHit* rh1, const TrackingRecHit* rh2) {
+    GlobalPoint gp1 = _tracker.idToDet(rh1->geographicalId())->surface().toGlobal(rh1->localPosition());
+    GlobalPoint gp2 = _tracker.idToDet(rh2->geographicalId())->surface().toGlobal(rh2->localPosition());
+    return gp1.y() > gp2.y();
+  };
+
+private:
+  //   edm::ESHandle<TrackerGeometry> _tracker;
+  const TrackerGeometry& _tracker;
+};
 
 #endif
 
-class CRackTrajectoryBuilder 
-{
-//  using namespace std;
+class CRackTrajectoryBuilder {
+  //  using namespace std;
 
-  typedef TrajectoryStateOnSurface     TSOS;
-  typedef TrajectoryMeasurement        TM;
-  
+  typedef TrajectoryStateOnSurface TSOS;
+  typedef TrajectoryMeasurement TM;
+
   typedef std::vector<const TrackingRecHit*>::iterator TrackingRecHitIterator;
 
   typedef std::pair<TrackingRecHitIterator, TrackingRecHitIterator> TrackingRecHitRange;
   typedef std::vector<TrackingRecHitRange>::iterator TrackingRecHitRangeIterator;
 
-  //  typedef std::pair<TrackingRecHitIterator, TSOS> PairTrackingRecHitTsos; 
-  typedef std::pair<TrackingRecHitRangeIterator, TSOS> PairTrackingRecHitTsos; 
-  
- public:
+  //  typedef std::pair<TrackingRecHitIterator, TSOS> PairTrackingRecHitTsos;
+  typedef std::pair<TrackingRecHitRangeIterator, TSOS> PairTrackingRecHitTsos;
+
+public:
   class CompareDetByTraj;
   friend class CompareDetByTraj;
 
   class CompareDetByTraj {
   public:
-    CompareDetByTraj(const TSOS& tSos ):_tSos(tSos)
-    {};
-    bool operator()( const std::pair<TrackingRecHitRangeIterator, TSOS> rh1,
-		     const std::pair<TrackingRecHitRangeIterator, TSOS> rh2)
-    {
-      GlobalPoint gp1 =  rh1.second.globalPosition();
-      GlobalPoint gp2 =  rh2.second.globalPosition();
+    CompareDetByTraj(const TSOS& tSos) : _tSos(tSos){};
+    bool operator()(const std::pair<TrackingRecHitRangeIterator, TSOS> rh1,
+                    const std::pair<TrackingRecHitRangeIterator, TSOS> rh2) {
+      GlobalPoint gp1 = rh1.second.globalPosition();
+      GlobalPoint gp2 = rh2.second.globalPosition();
 
       GlobalPoint gpT = _tSos.globalPosition();
-      GlobalVector gpDiff1 = gp1-gpT;
-      GlobalVector gpDiff2 = gp2-gpT;
+      GlobalVector gpDiff1 = gp1 - gpT;
+      GlobalVector gpDiff2 = gp2 - gpT;
 
-     //this might have a better performance ...
-     //       float dist1 = ( gp1.x()-gpT.x() ) * ( gp1.x()-gpT.x() ) + ( gp1.y()-gpT.y() ) * ( gp1.y()-gpT.y() ) + ( gp1.z()-gpT.z() ) * ( gp1.z()-gpT.z() );
-     //       float dist2 = ( gp2.x()-gpT.x() ) * ( gp2.x()-gpT.x() ) + ( gp2.y()-gpT.y() ) * ( gp2.y()-gpT.y() ) + ( gp2.z()-gpT.z() ) * ( gp2.z()-gpT.z() );
-     //if ( dist1<dist2 )
+      //this might have a better performance ...
+      //       float dist1 = ( gp1.x()-gpT.x() ) * ( gp1.x()-gpT.x() ) + ( gp1.y()-gpT.y() ) * ( gp1.y()-gpT.y() ) + ( gp1.z()-gpT.z() ) * ( gp1.z()-gpT.z() );
+      //       float dist2 = ( gp2.x()-gpT.x() ) * ( gp2.x()-gpT.x() ) + ( gp2.y()-gpT.y() ) * ( gp2.y()-gpT.y() ) + ( gp2.z()-gpT.z() ) * ( gp2.z()-gpT.z() );
+      //if ( dist1<dist2 )
 
-     //     if ( gpDiff1.mag2() < gpDiff2.mag2() )
-     
+      //     if ( gpDiff1.mag2() < gpDiff2.mag2() )
 
-     float dist1 = gpDiff1 * _tSos.globalDirection();
-     float dist2 = gpDiff2 * _tSos.globalDirection();
+      float dist1 = gpDiff1 * _tSos.globalDirection();
+      float dist2 = gpDiff2 * _tSos.globalDirection();
 
-     if (dist1 < 0)
-       return false;
-     if ( dist1<dist2 )
-       return true;
-     
-     return false;
-   };
+      if (dist1 < 0)
+        return false;
+      if (dist1 < dist2)
+        return true;
+
+      return false;
+    };
+
   private:
     const TrajectoryStateOnSurface& _tSos;
   };
 
-
-
- public:
-  
+public:
   CRackTrajectoryBuilder(const edm::ParameterSet& conf);
   ~CRackTrajectoryBuilder();
 
   /// Runs the algorithm
-    
-    void run(const TrajectorySeedCollection &collseed,
-	     const SiStripRecHit2DCollection &collstereo,
-	     const SiStripRecHit2DCollection &collrphi ,
-	     const SiStripMatchedRecHit2DCollection &collmatched,
-	     const SiPixelRecHitCollection &collpixel,
-	     const edm::EventSetup& es,
-	     edm::Event& e,
-	     std::vector<Trajectory> &trajoutput);
 
-    void init(const edm::EventSetup& es,bool);
-    Trajectory createStartingTrajectory( const TrajectorySeed& seed) const;
+  void run(const TrajectorySeedCollection& collseed,
+           const SiStripRecHit2DCollection& collstereo,
+           const SiStripRecHit2DCollection& collrphi,
+           const SiStripMatchedRecHit2DCollection& collmatched,
+           const SiPixelRecHitCollection& collpixel,
+           const edm::EventSetup& es,
+           edm::Event& e,
+           std::vector<Trajectory>& trajoutput);
 
-    const TransientTrackingRecHitBuilder * hitBuilder() const {return RHBuilder;}
+  void init(const edm::EventSetup& es, bool);
+  Trajectory createStartingTrajectory(const TrajectorySeed& seed) const;
 
- private:
-    std::vector<TrajectoryMeasurement> seedMeasurements(const TrajectorySeed& seed) const;
- 
- 
-    std::vector<const TrackingRecHit*> SortHits(const SiStripRecHit2DCollection &collstereo,
-					   const SiStripRecHit2DCollection &collrphi ,
-					   const SiStripMatchedRecHit2DCollection &collmatched,
-					   const SiPixelRecHitCollection &collpixel,
-					   const TrajectorySeed &seed,
-					   const bool bAddSeedHits
-					   );
+  const TransientTrackingRecHitBuilder* hitBuilder() const { return RHBuilder; }
 
-    
-    //    std::vector<TrackingRecHitRange> SortByTrajectory (const std::vector<TrackingRecHitRange>& inputHits);
+private:
+  std::vector<TrajectoryMeasurement> seedMeasurements(const TrajectorySeed& seed) const;
 
+  std::vector<const TrackingRecHit*> SortHits(const SiStripRecHit2DCollection& collstereo,
+                                              const SiStripRecHit2DCollection& collrphi,
+                                              const SiStripMatchedRecHit2DCollection& collmatched,
+                                              const SiPixelRecHitCollection& collpixel,
+                                              const TrajectorySeed& seed,
+                                              const bool bAddSeedHits);
 
-    TSOS startingTSOS(const TrajectorySeed& seed)const;
-    void updateTrajectory( Trajectory& traj,
-			   const TM& tm,
-			   const TransientTrackingRecHit& hit) const;
-    
-    void AddHit(Trajectory &traj,
-		const std::vector<const TrackingRecHit*>&Hits,
-		Propagator *currPropagator
-		);
-    //		edm::OwnVector<TransientTrackingRecHit> hits);
-    bool qualityFilter(const Trajectory& traj);
+  //    std::vector<TrackingRecHitRange> SortByTrajectory (const std::vector<TrackingRecHitRange>& inputHits);
 
-    bool isDifferentStripReHit2D  (const SiStripRecHit2D& hitA, const  SiStripRecHit2D& hitB );
+  TSOS startingTSOS(const TrajectorySeed& seed) const;
+  void updateTrajectory(Trajectory& traj, const TM& tm, const TransientTrackingRecHit& hit) const;
 
-    std::pair<TrajectoryStateOnSurface, const GeomDet*>
-     innerState( const Trajectory& traj) const;
+  void AddHit(Trajectory& traj, const std::vector<const TrackingRecHit*>& Hits, Propagator* currPropagator);
+  //		edm::OwnVector<TransientTrackingRecHit> hits);
+  bool qualityFilter(const Trajectory& traj);
 
+  bool isDifferentStripReHit2D(const SiStripRecHit2D& hitA, const SiStripRecHit2D& hitB);
 
- 
- private:
-   edm::ESHandle<MagneticField> magfield;
-   edm::ESHandle<TrackerGeometry> tracker;
-   
-   PropagatorWithMaterial  *thePropagator;
-   PropagatorWithMaterial  *thePropagatorOp;
+  std::pair<TrajectoryStateOnSurface, const GeomDet*> innerState(const Trajectory& traj) const;
 
-//   AnalyticalPropagator *thePropagator;
-//   AnalyticalPropagator *thePropagatorOp;
+private:
+  edm::ESHandle<MagneticField> magfield;
+  edm::ESHandle<TrackerGeometry> tracker;
 
-   KFUpdator *theUpdator;
-   Chi2MeasurementEstimator *theEstimator;
-   const TransientTrackingRecHitBuilder *RHBuilder;
-   const KFTrajectorySmoother * theSmoother;
-   const KFTrajectoryFitter * theFitter;
-//   const KFTrajectoryFitter * theFitterOp;
+  PropagatorWithMaterial* thePropagator;
+  PropagatorWithMaterial* thePropagatorOp;
 
-   bool debug_info;
-   bool fastPropagation;
-   bool useMatchedHits;
+  //   AnalyticalPropagator *thePropagator;
+  //   AnalyticalPropagator *thePropagatorOp;
 
-   int theMinHits;
-   double chi2cut;
-   std::vector<Trajectory> trajFit;
-   //RC edm::OwnVector<const TransientTrackingRecHit> hits;
-   TransientTrackingRecHit::RecHitContainer  hits;
-   bool seed_plus;
-   std::string geometry;
-   std::string theBuilderName;
-//   TransientInitialStateEstimator*  theInitialState;
+  KFUpdator* theUpdator;
+  Chi2MeasurementEstimator* theEstimator;
+  const TransientTrackingRecHitBuilder* RHBuilder;
+  const KFTrajectorySmoother* theSmoother;
+  const KFTrajectoryFitter* theFitter;
+  //   const KFTrajectoryFitter * theFitterOp;
+
+  bool debug_info;
+  bool fastPropagation;
+  bool useMatchedHits;
+
+  int theMinHits;
+  double chi2cut;
+  std::vector<Trajectory> trajFit;
+  //RC edm::OwnVector<const TransientTrackingRecHit> hits;
+  TransientTrackingRecHit::RecHitContainer hits;
+  bool seed_plus;
+  std::string geometry;
+  std::string theBuilderName;
+  //   TransientInitialStateEstimator*  theInitialState;
 };
 
 #endif

--- a/RecoTracker/SingleTrackPattern/interface/CosmicTrackFinder.h
+++ b/RecoTracker/SingleTrackPattern/interface/CosmicTrackFinder.h
@@ -5,7 +5,6 @@
 // Class:      CosmicTrackFinder
 // Original Author:  Michele Pioppi-INFN perugia
 
-
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -16,60 +15,61 @@
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 
-namespace cms
-{
+namespace cms {
   class CompareTrajLay {
   public:
-    bool operator()(Trajectory *t1,
-		    Trajectory *t2){
+    bool operator()(Trajectory* t1, Trajectory* t2) {
       AnalHits(t1->recHits());
-      unsigned int alay=nlay;
+      unsigned int alay = nlay;
       AnalHits(t2->recHits());
-      unsigned int blay=nlay;
-      if (alay!=blay) return alay > blay;
-      if (t1->foundHits() != t2->foundHits()) 
-	return t1->foundHits()> t2->foundHits();
-      return t1->chiSquared()< t2->chiSquared();
+      unsigned int blay = nlay;
+      if (alay != blay)
+        return alay > blay;
+      if (t1->foundHits() != t2->foundHits())
+        return t1->foundHits() > t2->foundHits();
+      return t1->chiSquared() < t2->chiSquared();
       // std::cout<<"chi "<<t1.chiSquared()<<" "<<t2.chiSquared()<<std::endl;
       // return false;
     }
-    void  AnalHits(const std::vector< TransientTrackingRecHit::ConstRecHitPointer >& hits){
-      ltob1=false; ltob2=false; ltib1=false; ltib2=false;
+    void AnalHits(const std::vector<TransientTrackingRecHit::ConstRecHitPointer>& hits) {
+      ltob1 = false;
+      ltob2 = false;
+      ltib1 = false;
+      ltib2 = false;
       //     ConstRecHitIterator hit;
-      for(auto hit=hits.begin();hit!=hits.end();hit++){
-	unsigned int iid=(*hit)->hit()->geographicalId().rawId();
-	
-	int sub=(iid>>25)&0x7 ;
-	int lay=(iid>>16) & 0xF;
-	if ((lay==1)&&(sub==3)) ltib1=true;
-	if ((lay==2)&&(sub==3)) ltib2=true;
-	if ((lay==1)&&(sub==5)) ltob1=true;
-	if ((lay==2)&&(sub==5)) ltob2=true;
+      for (auto hit = hits.begin(); hit != hits.end(); hit++) {
+        unsigned int iid = (*hit)->hit()->geographicalId().rawId();
+
+        int sub = (iid >> 25) & 0x7;
+        int lay = (iid >> 16) & 0xF;
+        if ((lay == 1) && (sub == 3))
+          ltib1 = true;
+        if ((lay == 2) && (sub == 3))
+          ltib2 = true;
+        if ((lay == 1) && (sub == 5))
+          ltob1 = true;
+        if ((lay == 2) && (sub == 5))
+          ltob2 = true;
+      }
+      nlay = ltib1 + ltib2 + ltob1 + ltob2;
     }
-      nlay=ltib1+ltib2+ltob1+ltob2;
-      
-    }
-    
+
   private:
-    bool ltib1,ltib2,ltob1,ltob2;
+    bool ltib1, ltib2, ltob1, ltob2;
     unsigned int nlay;
-    
   };
   class CompareTrajChi {
   public:
-    bool operator()(Trajectory *t1,
-		    Trajectory *t2){
-      if (t1->foundHits() != t2->foundHits()) 
-	return t1->foundHits()> t2->foundHits();
-      return t1->chiSquared()< t2->chiSquared();  
+    bool operator()(Trajectory* t1, Trajectory* t2) {
+      if (t1->foundHits() != t2->foundHits())
+        return t1->foundHits() > t2->foundHits();
+      return t1->chiSquared() < t2->chiSquared();
     }
   };
-  class CosmicTrackFinder : public edm::stream::EDProducer<>
-  {
+  class CosmicTrackFinder : public edm::stream::EDProducer<> {
+    typedef TrajectoryStateOnSurface TSOS;
 
-    typedef TrajectoryStateOnSurface     TSOS;
   public:
-
     explicit CosmicTrackFinder(const edm::ParameterSet& conf);
 
     ~CosmicTrackFinder() override;
@@ -78,7 +78,7 @@ namespace cms
 
   private:
     CosmicTrajectoryBuilder cosmicTrajectoryBuilder_;
-    CRackTrajectoryBuilder  crackTrajectoryBuilder_;
+    CRackTrajectoryBuilder crackTrajectoryBuilder_;
     edm::ParameterSet conf_;
     std::string geometry;
     bool trinevents;
@@ -89,6 +89,6 @@ namespace cms
     edm::EDGetTokenT<SiPixelRecHitCollection> pixelRecHitsToken_;
     edm::EDGetTokenT<TrajectorySeedCollection> seedToken_;
   };
-}
+}  // namespace cms
 
 #endif

--- a/RecoTracker/SingleTrackPattern/interface/CosmicTrajectoryBuilder.h
+++ b/RecoTracker/SingleTrackPattern/interface/CosmicTrajectoryBuilder.h
@@ -42,107 +42,96 @@
 #define TrajectoryBuilder_CompareHitY
 
 class CompareHitY {
- public:
-   CompareHitY(const TrackerGeometry& tracker):_tracker(tracker){}
-   bool operator()( const TrackingRecHit *rh1,
-		    const TrackingRecHit *rh2)
-   {
-     GlobalPoint gp1=_tracker.idToDet(rh1->geographicalId())->surface().toGlobal(rh1->localPosition());
-     GlobalPoint gp2=_tracker.idToDet(rh2->geographicalId())->surface().toGlobal(rh2->localPosition());
-     return gp1.y()<gp2.y();};
- private:
-   //   edm::ESHandle<TrackerGeometry> _tracker;
-   const TrackerGeometry& _tracker;
+public:
+  CompareHitY(const TrackerGeometry &tracker) : _tracker(tracker) {}
+  bool operator()(const TrackingRecHit *rh1, const TrackingRecHit *rh2) {
+    GlobalPoint gp1 = _tracker.idToDet(rh1->geographicalId())->surface().toGlobal(rh1->localPosition());
+    GlobalPoint gp2 = _tracker.idToDet(rh2->geographicalId())->surface().toGlobal(rh2->localPosition());
+    return gp1.y() < gp2.y();
+  };
+
+private:
+  //   edm::ESHandle<TrackerGeometry> _tracker;
+  const TrackerGeometry &_tracker;
 };
- 
+
 class CompareHitY_plus {
- public:
-   CompareHitY_plus(const TrackerGeometry& tracker):_tracker(tracker){}
-   bool operator()( const TrackingRecHit *rh1,
-		    const TrackingRecHit *rh2)
-   {
-     GlobalPoint gp1=_tracker.idToDet(rh1->geographicalId())->surface().toGlobal(rh1->localPosition());
-     GlobalPoint gp2=_tracker.idToDet(rh2->geographicalId())->surface().toGlobal(rh2->localPosition());
-     return gp1.y()>gp2.y();};
- private:
-   //   edm::ESHandle<TrackerGeometry> _tracker;
-   const TrackerGeometry& _tracker;
+public:
+  CompareHitY_plus(const TrackerGeometry &tracker) : _tracker(tracker) {}
+  bool operator()(const TrackingRecHit *rh1, const TrackingRecHit *rh2) {
+    GlobalPoint gp1 = _tracker.idToDet(rh1->geographicalId())->surface().toGlobal(rh1->localPosition());
+    GlobalPoint gp2 = _tracker.idToDet(rh2->geographicalId())->surface().toGlobal(rh2->localPosition());
+    return gp1.y() > gp2.y();
+  };
+
+private:
+  //   edm::ESHandle<TrackerGeometry> _tracker;
+  const TrackerGeometry &_tracker;
 };
- 
+
 #endif
 
-class CosmicTrajectoryBuilder 
-{
+class CosmicTrajectoryBuilder {
+  typedef TrajectoryStateOnSurface TSOS;
+  typedef TrajectoryMeasurement TM;
 
-  typedef TrajectoryStateOnSurface     TSOS;
-  typedef TrajectoryMeasurement        TM;
-
- public:
-  
-  CosmicTrajectoryBuilder(const edm::ParameterSet& conf);
+public:
+  CosmicTrajectoryBuilder(const edm::ParameterSet &conf);
   ~CosmicTrajectoryBuilder();
 
   /// Runs the algorithm
-    
-    void run(const TrajectorySeedCollection &collseed,
-	     const SiStripRecHit2DCollection &collstereo,
-	     const SiStripRecHit2DCollection &collrphi ,
-	     const SiStripMatchedRecHit2DCollection &collmatched,
-	     const SiPixelRecHitCollection &collpixel,
-	     const edm::EventSetup& es,
-	     edm::Event& e,
-	     std::vector<Trajectory> &trajoutput);
 
-    void init(const edm::EventSetup& es,bool);
-    Trajectory createStartingTrajectory( const TrajectorySeed& seed) const;
+  void run(const TrajectorySeedCollection &collseed,
+           const SiStripRecHit2DCollection &collstereo,
+           const SiStripRecHit2DCollection &collrphi,
+           const SiStripMatchedRecHit2DCollection &collmatched,
+           const SiPixelRecHitCollection &collpixel,
+           const edm::EventSetup &es,
+           edm::Event &e,
+           std::vector<Trajectory> &trajoutput);
 
-    const TransientTrackingRecHitBuilder * hitBuilder() const {return RHBuilder;}
+  void init(const edm::EventSetup &es, bool);
+  Trajectory createStartingTrajectory(const TrajectorySeed &seed) const;
 
+  const TransientTrackingRecHitBuilder *hitBuilder() const { return RHBuilder; }
 
- private:
-    std::vector<TrajectoryMeasurement> seedMeasurements(const TrajectorySeed& seed) const;
- 
- 
-    std::vector<const TrackingRecHit*> SortHits(const SiStripRecHit2DCollection &collstereo,
-					   const SiStripRecHit2DCollection &collrphi ,
-					   const SiStripMatchedRecHit2DCollection &collmatched,
-					   const SiPixelRecHitCollection &collpixel,
-					   const TrajectorySeed &seed);
+private:
+  std::vector<TrajectoryMeasurement> seedMeasurements(const TrajectorySeed &seed) const;
 
-    TSOS startingTSOS(const TrajectorySeed& seed)const;
-    void updateTrajectory( Trajectory& traj,
-			   const TM& tm,
-			   const TransientTrackingRecHit& hit) const;
-    
-    void AddHit(Trajectory &traj,
-		const std::vector<const TrackingRecHit*>&Hits);
-    //		edm::OwnVector<TransientTrackingRecHit> hits);
-    bool qualityFilter(const Trajectory& traj);
+  std::vector<const TrackingRecHit *> SortHits(const SiStripRecHit2DCollection &collstereo,
+                                               const SiStripRecHit2DCollection &collrphi,
+                                               const SiStripMatchedRecHit2DCollection &collmatched,
+                                               const SiPixelRecHitCollection &collpixel,
+                                               const TrajectorySeed &seed);
 
+  TSOS startingTSOS(const TrajectorySeed &seed) const;
+  void updateTrajectory(Trajectory &traj, const TM &tm, const TransientTrackingRecHit &hit) const;
 
- private:
-   edm::ESHandle<MagneticField> magfield;
-   edm::ESHandle<TrackerGeometry> tracker;
-   
-   PropagatorWithMaterial  *thePropagator;
-   PropagatorWithMaterial  *thePropagatorOp;
-   KFUpdator *theUpdator;
-   Chi2MeasurementEstimator *theEstimator;
-   const TransientTrackingRecHitBuilder *RHBuilder;
-   TkClonerImpl hitCloner;
-   KFTrajectorySmoother * theSmoother;
-   KFTrajectoryFitter * theFitter;
- 
- 
+  void AddHit(Trajectory &traj, const std::vector<const TrackingRecHit *> &Hits);
+  //		edm::OwnVector<TransientTrackingRecHit> hits);
+  bool qualityFilter(const Trajectory &traj);
 
-   int theMinHits;
-   double chi2cut;
-   std::vector<Trajectory> trajFit;
-   //RC edm::OwnVector<const TransientTrackingRecHit> hits;
-   TransientTrackingRecHit::RecHitContainer  hits;
-   bool seed_plus;
-   std::string geometry;
-   std::string theBuilderName;
+private:
+  edm::ESHandle<MagneticField> magfield;
+  edm::ESHandle<TrackerGeometry> tracker;
+
+  PropagatorWithMaterial *thePropagator;
+  PropagatorWithMaterial *thePropagatorOp;
+  KFUpdator *theUpdator;
+  Chi2MeasurementEstimator *theEstimator;
+  const TransientTrackingRecHitBuilder *RHBuilder;
+  TkClonerImpl hitCloner;
+  KFTrajectorySmoother *theSmoother;
+  KFTrajectoryFitter *theFitter;
+
+  int theMinHits;
+  double chi2cut;
+  std::vector<Trajectory> trajFit;
+  //RC edm::OwnVector<const TransientTrackingRecHit> hits;
+  TransientTrackingRecHit::RecHitContainer hits;
+  bool seed_plus;
+  std::string geometry;
+  std::string theBuilderName;
 };
 
 #endif

--- a/RecoTracker/SingleTrackPattern/src/CRackTrajectoryBuilder.cc
+++ b/RecoTracker/SingleTrackPattern/src/CRackTrajectoryBuilder.cc
@@ -19,221 +19,183 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "TrackingTools/Records/interface/TrackingComponentsRecord.h" 
-#include "TrackingTools/Records/interface/TransientRecHitRecord.h" 
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "TrackingTools/TrackFitters/interface/TrajectoryStateWithArbitraryError.h"
-
 
 //#include "RecoTracker/CkfPattern/interface/TransientInitialStateEstimator.h"
 
 using namespace std;
 
-
 CRackTrajectoryBuilder::CRackTrajectoryBuilder(const edm::ParameterSet& conf) {
   //minimum number of hits per tracks
 
-  theMinHits=conf.getParameter<int>("MinHits");
+  theMinHits = conf.getParameter<int>("MinHits");
   //cut on chi2
-  chi2cut=conf.getParameter<double>("Chi2Cut");
-  edm::LogInfo("CosmicTrackFinder")<<"Minimum number of hits "<<theMinHits<<" Cut on Chi2= "<<chi2cut;
+  chi2cut = conf.getParameter<double>("Chi2Cut");
+  edm::LogInfo("CosmicTrackFinder") << "Minimum number of hits " << theMinHits << " Cut on Chi2= " << chi2cut;
 
-  debug_info=conf.getUntrackedParameter<bool>("debug", false);
-  fastPropagation=conf.getUntrackedParameter<bool>("fastPropagation", false);
-  useMatchedHits=conf.getUntrackedParameter<bool>("useMatchedHits", true);
+  debug_info = conf.getUntrackedParameter<bool>("debug", false);
+  fastPropagation = conf.getUntrackedParameter<bool>("fastPropagation", false);
+  useMatchedHits = conf.getUntrackedParameter<bool>("useMatchedHits", true);
 
-
-  geometry=conf.getUntrackedParameter<std::string>("GeometricStructure","STANDARD");
+  geometry = conf.getUntrackedParameter<std::string>("GeometricStructure", "STANDARD");
   theBuilderName = conf.getParameter<std::string>("TTRHBuilder");
-
-  
-
 }
-
 
 CRackTrajectoryBuilder::~CRackTrajectoryBuilder() {
-//  delete theInitialState;
+  //  delete theInitialState;
 }
 
-
-void CRackTrajectoryBuilder::init(const edm::EventSetup& es, bool seedplus){
-
-//  edm::ParameterSet tise_params = conf_.getParameter<edm::ParameterSet>("TransientInitialStateEstimatorParameters") ;
-// theInitialState          = new TransientInitialStateEstimator( es,tise_params);
+void CRackTrajectoryBuilder::init(const edm::EventSetup& es, bool seedplus) {
+  //  edm::ParameterSet tise_params = conf_.getParameter<edm::ParameterSet>("TransientInitialStateEstimatorParameters") ;
+  // theInitialState          = new TransientInitialStateEstimator( es,tise_params);
 
   //services
   es.get<IdealMagneticFieldRecord>().get(magfield);
   es.get<TrackerDigiGeometryRecord>().get(tracker);
-  
- 
-  
-  if (seedplus) { 	 
-    seed_plus=true; 	 
-    thePropagator=      new PropagatorWithMaterial(alongMomentum,0.1057,&(*magfield) ); 	 
-    thePropagatorOp=    new PropagatorWithMaterial(oppositeToMomentum,0.1057,&(*magfield) );} 	 
-  else {
-    seed_plus=false;
-    thePropagator=      new PropagatorWithMaterial(oppositeToMomentum,0.1057,&(*magfield) ); 	
-    thePropagatorOp=    new PropagatorWithMaterial(alongMomentum,0.1057,&(*magfield) );
+
+  if (seedplus) {
+    seed_plus = true;
+    thePropagator = new PropagatorWithMaterial(alongMomentum, 0.1057, &(*magfield));
+    thePropagatorOp = new PropagatorWithMaterial(oppositeToMomentum, 0.1057, &(*magfield));
+  } else {
+    seed_plus = false;
+    thePropagator = new PropagatorWithMaterial(oppositeToMomentum, 0.1057, &(*magfield));
+    thePropagatorOp = new PropagatorWithMaterial(alongMomentum, 0.1057, &(*magfield));
   }
-  
-  theUpdator=       new KFUpdator();
-//  theUpdator=       new KFStripUpdator();
-  theEstimator=     new Chi2MeasurementEstimator(chi2cut);
-  
+
+  theUpdator = new KFUpdator();
+  //  theUpdator=       new KFStripUpdator();
+  theEstimator = new Chi2MeasurementEstimator(chi2cut);
 
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
-  es.get<TransientRecHitRecord>().get(theBuilderName,theBuilder);
-  
+  es.get<TransientRecHitRecord>().get(theBuilderName, theBuilder);
 
-  RHBuilder=   theBuilder.product();
+  RHBuilder = theBuilder.product();
 
+  theFitter = new KFTrajectoryFitter(*thePropagator, *theUpdator, *theEstimator);
 
-
-
-  theFitter=        new KFTrajectoryFitter(*thePropagator,
-					   *theUpdator,	
-					   *theEstimator) ;
-  
-
-  theSmoother=      new KFTrajectorySmoother(*thePropagatorOp,
-					     *theUpdator,	
-					     *theEstimator);
-  
+  theSmoother = new KFTrajectorySmoother(*thePropagatorOp, *theUpdator, *theEstimator);
 }
 
-
-void CRackTrajectoryBuilder::run(const TrajectorySeedCollection &collseed,
-				  const SiStripRecHit2DCollection &collstereo,
-				  const SiStripRecHit2DCollection &collrphi ,
-				  const SiStripMatchedRecHit2DCollection &collmatched,
-				  const SiPixelRecHitCollection &collpixel,
-				  const edm::EventSetup& es,
-				  edm::Event& e,
-				  vector<Trajectory> &trajoutput)
-{
-
+void CRackTrajectoryBuilder::run(const TrajectorySeedCollection& collseed,
+                                 const SiStripRecHit2DCollection& collstereo,
+                                 const SiStripRecHit2DCollection& collrphi,
+                                 const SiStripMatchedRecHit2DCollection& collmatched,
+                                 const SiPixelRecHitCollection& collpixel,
+                                 const edm::EventSetup& es,
+                                 edm::Event& e,
+                                 vector<Trajectory>& trajoutput) {
   std::vector<Trajectory> trajSmooth;
   std::vector<Trajectory>::iterator trajIter;
-  
+
   TrajectorySeedCollection::const_iterator iseed;
-  unsigned int IS=0;
-  for(iseed=collseed.begin();iseed!=collseed.end();iseed++){
-    bool seedplus=((*iseed).direction()==alongMomentum);
-    init(es,seedplus);
+  unsigned int IS = 0;
+  for (iseed = collseed.begin(); iseed != collseed.end(); iseed++) {
+    bool seedplus = ((*iseed).direction() == alongMomentum);
+    init(es, seedplus);
     hits.clear();
     trajFit.clear();
     trajSmooth.clear();
 
     Trajectory startingTraj = createStartingTrajectory(*iseed);
-    Trajectory trajTmp; // used for the opposite direction
+    Trajectory trajTmp;  // used for the opposite direction
     Trajectory traj = startingTraj;
 
-   
     //first propagate track in opposite direction ...
     seed_plus = !seed_plus;
-    vector<const TrackingRecHit*> allHitsOppsite = SortHits(collstereo,collrphi,collmatched,collpixel, *iseed, true);
+    vector<const TrackingRecHit*> allHitsOppsite = SortHits(collstereo, collrphi, collmatched, collpixel, *iseed, true);
     seed_plus = !seed_plus;
-    if (!allHitsOppsite.empty())
-      {
-	//there are hits which are above the seed,
-	//cout << "Number of hits higher than seed " <<allHitsOppsite.size() << endl;	
-	
-	AddHit( traj, allHitsOppsite, thePropagatorOp);
-	
-	
-	if (debug_info)
-	  {
-	    cout << "Hits in opposite direction..." << endl;
-	    TransientTrackingRecHit::RecHitContainer::const_iterator iHit;
-	    for ( iHit = hits.begin(); iHit!=hits.end(); iHit++)
-	      {
-		cout <<  (**iHit).globalPosition() << endl;
-	      }
-	  }
-	
-	
-	// now add hist opposite to seed
-	//now crate new starting trajectory
-	reverse(hits.begin(), hits.end());
-	if (thePropagatorOp->propagate(traj.firstMeasurement().updatedState(),
-				       tracker->idToDet((hits.front())->geographicalId())->surface()).isValid()){
-	  TSOS startingStateNew =  //TrajectoryStateWithArbitraryError()//
-	    (thePropagatorOp->propagate(traj.firstMeasurement().updatedState(),
-					tracker->idToDet((hits.front())->geographicalId())->surface()));
-	  
-	  if (debug_info)
-	    {
-	      cout << "Hits in opposite direction reversed..." << endl;
-	      TransientTrackingRecHit::RecHitContainer::const_iterator iHit;
-	      for ( iHit = hits.begin(); iHit!=hits.end(); iHit++)
-		{
-		  cout <<  (**iHit).globalPosition() << endl;
-		}
-	    }
-	  
-	  const TrajectorySeed& tmpseed=traj.seed();
-	  trajTmp = theFitter->fit(tmpseed,hits, startingStateNew ).front();
-	  
-	  if(debug_info){
-	    cout << "Debugging show fitted hits" << endl;	    
-	        auto hitsFit= trajTmp.recHits();
-	        for(auto hit=hitsFit.begin();hit!=hitsFit.end();hit++){
-		  
-	          cout << RHBuilder->build( &(*(*hit)->hit()) )->globalPosition() << endl;
-	        }
-	  }
-	  
-	}
+    if (!allHitsOppsite.empty()) {
+      //there are hits which are above the seed,
+      //cout << "Number of hits higher than seed " <<allHitsOppsite.size() << endl;
+
+      AddHit(traj, allHitsOppsite, thePropagatorOp);
+
+      if (debug_info) {
+        cout << "Hits in opposite direction..." << endl;
+        TransientTrackingRecHit::RecHitContainer::const_iterator iHit;
+        for (iHit = hits.begin(); iHit != hits.end(); iHit++) {
+          cout << (**iHit).globalPosition() << endl;
+        }
       }
-    else 
-      {
-	if(debug_info) cout << "There are no hits in opposite direction ..." << endl;
+
+      // now add hist opposite to seed
+      //now crate new starting trajectory
+      reverse(hits.begin(), hits.end());
+      if (thePropagatorOp
+              ->propagate(traj.firstMeasurement().updatedState(),
+                          tracker->idToDet((hits.front())->geographicalId())->surface())
+              .isValid()) {
+        TSOS startingStateNew =  //TrajectoryStateWithArbitraryError()//
+            (thePropagatorOp->propagate(traj.firstMeasurement().updatedState(),
+                                        tracker->idToDet((hits.front())->geographicalId())->surface()));
+
+        if (debug_info) {
+          cout << "Hits in opposite direction reversed..." << endl;
+          TransientTrackingRecHit::RecHitContainer::const_iterator iHit;
+          for (iHit = hits.begin(); iHit != hits.end(); iHit++) {
+            cout << (**iHit).globalPosition() << endl;
+          }
+        }
+
+        const TrajectorySeed& tmpseed = traj.seed();
+        trajTmp = theFitter->fit(tmpseed, hits, startingStateNew).front();
+
+        if (debug_info) {
+          cout << "Debugging show fitted hits" << endl;
+          auto hitsFit = trajTmp.recHits();
+          for (auto hit = hitsFit.begin(); hit != hitsFit.end(); hit++) {
+            cout << RHBuilder->build(&(*(*hit)->hit()))->globalPosition() << endl;
+          }
+        }
       }
+    } else {
+      if (debug_info)
+        cout << "There are no hits in opposite direction ..." << endl;
+    }
 
     vector<const TrackingRecHit*> allHits;
-    if (trajTmp.foundHits())
-      {
-	traj = trajTmp;
-	allHits= SortHits(collstereo,collrphi,collmatched,collpixel,*iseed, false);	  
-      }
-    else
-      {
-	traj = startingTraj;
-	hits.clear();
-	allHits= SortHits(collstereo,collrphi,collmatched,collpixel,*iseed, true);	  
-      }
-    
-    AddHit( traj,allHits, thePropagator);
-    
-    
-    if(debug_info){
-      cout << "Debugging show All fitted hits" << endl;	    
-      auto hits= traj.recHits();
-	    for(auto hit=hits.begin();hit!=hits.end();hit++){
-	      
-	      cout << (*hit)->globalPosition() << endl;
-	    }
-
-	    cout << qualityFilter( traj) << " <- quality filter good?" << endl;
-	  }
-
-
-    if (debug_info) cout << "now do quality checks" << endl;
-    if ( qualityFilter( traj) ) {
-      const TrajectorySeed& tmpseed=traj.seed();
-      std::pair<TrajectoryStateOnSurface, const GeomDet*> initState =  innerState(traj); //theInitialState->innerState(traj);
-	if (initState.first.isValid())
-	      trajFit = theFitter->fit(tmpseed,hits, initState.first);
+    if (trajTmp.foundHits()) {
+      traj = trajTmp;
+      allHits = SortHits(collstereo, collrphi, collmatched, collpixel, *iseed, false);
+    } else {
+      traj = startingTraj;
+      hits.clear();
+      allHits = SortHits(collstereo, collrphi, collmatched, collpixel, *iseed, true);
     }
 
-    for (trajIter=trajFit.begin(); trajIter!=trajFit.end();trajIter++){
-      trajSmooth=theSmoother->trajectories((*trajIter));
-    }
-    for (trajIter= trajSmooth.begin(); trajIter!=trajSmooth.end();trajIter++){
-      if((*trajIter).isValid()){
+    AddHit(traj, allHits, thePropagator);
 
-	if (debug_info) cout << "adding track ... " << endl;
-	trajoutput.push_back((*trajIter));
+    if (debug_info) {
+      cout << "Debugging show All fitted hits" << endl;
+      auto hits = traj.recHits();
+      for (auto hit = hits.begin(); hit != hits.end(); hit++) {
+        cout << (*hit)->globalPosition() << endl;
+      }
+
+      cout << qualityFilter(traj) << " <- quality filter good?" << endl;
+    }
+
+    if (debug_info)
+      cout << "now do quality checks" << endl;
+    if (qualityFilter(traj)) {
+      const TrajectorySeed& tmpseed = traj.seed();
+      std::pair<TrajectoryStateOnSurface, const GeomDet*> initState =
+          innerState(traj);  //theInitialState->innerState(traj);
+      if (initState.first.isValid())
+        trajFit = theFitter->fit(tmpseed, hits, initState.first);
+    }
+
+    for (trajIter = trajFit.begin(); trajIter != trajFit.end(); trajIter++) {
+      trajSmooth = theSmoother->trajectories((*trajIter));
+    }
+    for (trajIter = trajSmooth.begin(); trajIter != trajSmooth.end(); trajIter++) {
+      if ((*trajIter).isValid()) {
+        if (debug_info)
+          cout << "adding track ... " << endl;
+        trajoutput.push_back((*trajIter));
       }
     }
     delete theUpdator;
@@ -243,611 +205,568 @@ void CRackTrajectoryBuilder::run(const TrajectorySeedCollection &collseed,
     delete theFitter;
     delete theSmoother;
     //Only the first 30 seeds are considered
-    if (IS>30) return;
+    if (IS > 30)
+      return;
     IS++;
-
   }
 }
 
-Trajectory CRackTrajectoryBuilder::createStartingTrajectory( const TrajectorySeed& seed) const
-{
-  Trajectory result( seed, seed.direction());
-  std::vector<TM> && seedMeas = seedMeasurements(seed);
-  for (auto i : seedMeas) result.push(std::move(i));
+Trajectory CRackTrajectoryBuilder::createStartingTrajectory(const TrajectorySeed& seed) const {
+  Trajectory result(seed, seed.direction());
+  std::vector<TM>&& seedMeas = seedMeasurements(seed);
+  for (auto i : seedMeas)
+    result.push(std::move(i));
   return result;
 }
 
-
-std::vector<TrajectoryMeasurement> 
-CRackTrajectoryBuilder::seedMeasurements(const TrajectorySeed& seed) const
-{
+std::vector<TrajectoryMeasurement> CRackTrajectoryBuilder::seedMeasurements(const TrajectorySeed& seed) const {
   std::vector<TrajectoryMeasurement> result;
   TrajectorySeed::range hitRange = seed.recHits();
-  for (TrajectorySeed::const_iterator ihit = hitRange.first; 
-       ihit != hitRange.second; ihit++) {
+  for (TrajectorySeed::const_iterator ihit = hitRange.first; ihit != hitRange.second; ihit++) {
     //RC TransientTrackingRecHit* recHit = RHBuilder->build(&(*ihit));
     TransientTrackingRecHit::RecHitPointer recHit = RHBuilder->build(&(*ihit));
-    const GeomDet* hitGeomDet = (&(*tracker))->idToDet( ihit->geographicalId());
-    TSOS invalidState( new BasicSingleTrajectoryState( hitGeomDet->surface()));
+    const GeomDet* hitGeomDet = (&(*tracker))->idToDet(ihit->geographicalId());
+    TSOS invalidState(new BasicSingleTrajectoryState(hitGeomDet->surface()));
 
     if (ihit == hitRange.second - 1) {
-      TSOS  updatedState=startingTSOS(seed);
+      TSOS updatedState = startingTSOS(seed);
       result.emplace_back(invalidState, updatedState, recHit);
 
-    } 
-    else {
+    } else {
       result.emplace_back(invalidState, recHit);
     }
-    
   }
 
   return result;
 }
 
-vector<const TrackingRecHit*> 
-CRackTrajectoryBuilder::SortHits(const SiStripRecHit2DCollection &collstereo,
-				  const SiStripRecHit2DCollection &collrphi ,
-				  const SiStripMatchedRecHit2DCollection &collmatched,
-				  const SiPixelRecHitCollection &collpixel,
-				  const TrajectorySeed &seed,
-				  const bool bAddSeedHits
-				  ){
-
-
+vector<const TrackingRecHit*> CRackTrajectoryBuilder::SortHits(const SiStripRecHit2DCollection& collstereo,
+                                                               const SiStripRecHit2DCollection& collrphi,
+                                                               const SiStripMatchedRecHit2DCollection& collmatched,
+                                                               const SiPixelRecHitCollection& collpixel,
+                                                               const TrajectorySeed& seed,
+                                                               const bool bAddSeedHits) {
   //The Hits with global y more than the seed are discarded
   //The Hits correspondign to the seed are discarded
   //At the end all the hits are sorted in y
   vector<const TrackingRecHit*> allHits;
 
   SiStripRecHit2DCollection::DataContainer::const_iterator istrip;
-  TrajectorySeed::range hRange= seed.recHits();
+  TrajectorySeed::range hRange = seed.recHits();
   TrajectorySeed::const_iterator ihit;
-  float yref=0.;
+  float yref = 0.;
 
-  if (debug_info) cout << "SEED " << startingTSOS(seed) << endl; 
-  if (debug_info) cout << "seed hits size " << seed.nHits() << endl;
-
+  if (debug_info)
+    cout << "SEED " << startingTSOS(seed) << endl;
+  if (debug_info)
+    cout << "seed hits size " << seed.nHits() << endl;
 
   //seed debugging:
- // GeomDet *seedDet =  tracker->idToDet(seed.startingState().detId());
+  // GeomDet *seedDet =  tracker->idToDet(seed.startingState().detId());
 
+  //  edm::LogInfo("CRackTrajectoryBuilder::SortHits") << "SEED " << seed.startingState();
 
-//  edm::LogInfo("CRackTrajectoryBuilder::SortHits") << "SEED " << seed.startingState(); 
-
-  edm::LogInfo("CRackTrajectoryBuilder::SortHits") << "SEED " << startingTSOS(seed); 
-//  edm::LogInfo("CRackTrajectoryBuilder::SortHits" << "seed hits size " << seed.nHits();
-
-
+  edm::LogInfo("CRackTrajectoryBuilder::SortHits") << "SEED " << startingTSOS(seed);
+  //  edm::LogInfo("CRackTrajectoryBuilder::SortHits" << "seed hits size " << seed.nHits();
 
   //  if (seed.nHits()<2)
   //  return allHits;
 
-  float_t yMin=0.;
-  float_t yMax=0.;
+  float_t yMin = 0.;
+  float_t yMax = 0.;
 
-  int seedHitSize= hRange.second - hRange.first;
+  int seedHitSize = hRange.second - hRange.first;
 
-  vector <int> detIDSeedMatched (seedHitSize);
-  vector <int> detIDSeedRphi (seedHitSize);
-  vector <int> detIDSeedStereo (seedHitSize);
+  vector<int> detIDSeedMatched(seedHitSize);
+  vector<int> detIDSeedRphi(seedHitSize);
+  vector<int> detIDSeedStereo(seedHitSize);
 
-  for (ihit = hRange.first; 
-       ihit != hRange.second; ihit++) {
-
-     // need to find track with lowest (seed_plus)/ highest y (seed_minus)
+  for (ihit = hRange.first; ihit != hRange.second; ihit++) {
+    // need to find track with lowest (seed_plus)/ highest y (seed_minus)
     // split matched hits ...
-   const SiStripMatchedRecHit2D* matchedhit=dynamic_cast<const SiStripMatchedRecHit2D*>(&(*ihit));
+    const SiStripMatchedRecHit2D* matchedhit = dynamic_cast<const SiStripMatchedRecHit2D*>(&(*ihit));
 
-   yref=RHBuilder->build(&(*ihit))->globalPosition().y();
-   if (ihit == hRange.first)
-     {
-        yMin = yref;
-	yMax = yref; 
-     }
+    yref = RHBuilder->build(&(*ihit))->globalPosition().y();
+    if (ihit == hRange.first) {
+      yMin = yref;
+      yMax = yref;
+    }
 
-   if (matchedhit)
-     {
-       auto m = matchedhit->monoHit();
-       auto s = matchedhit->stereoHit();
-       float_t yGlobRPhi   = RHBuilder->build(&m)->globalPosition().y();
-       float_t yGlobStereo = RHBuilder->build(&s)->globalPosition().y();
+    if (matchedhit) {
+      auto m = matchedhit->monoHit();
+      auto s = matchedhit->stereoHit();
+      float_t yGlobRPhi = RHBuilder->build(&m)->globalPosition().y();
+      float_t yGlobStereo = RHBuilder->build(&s)->globalPosition().y();
 
-       if (debug_info) cout << "Rphi ..." << yGlobRPhi << endl;
-       if (debug_info) cout << "Stereo ..." << yGlobStereo << endl;
+      if (debug_info)
+        cout << "Rphi ..." << yGlobRPhi << endl;
+      if (debug_info)
+        cout << "Stereo ..." << yGlobStereo << endl;
 
-       if ( yGlobStereo < yMin ) yMin = yGlobStereo;
-       if ( yGlobRPhi   < yMin ) yMin = yGlobRPhi;
+      if (yGlobStereo < yMin)
+        yMin = yGlobStereo;
+      if (yGlobRPhi < yMin)
+        yMin = yGlobRPhi;
 
-       if ( yGlobStereo > yMax ) yMax = yGlobStereo;
-       if ( yGlobRPhi   > yMax ) yMax = yGlobRPhi;
+      if (yGlobStereo > yMax)
+        yMax = yGlobStereo;
+      if (yGlobRPhi > yMax)
+        yMax = yGlobRPhi;
 
-       detIDSeedMatched.push_back (  matchedhit->geographicalId().rawId() );
-       detIDSeedRphi.push_back ( m.geographicalId().rawId() );
-       detIDSeedStereo.push_back ( s.geographicalId().rawId() );
+      detIDSeedMatched.push_back(matchedhit->geographicalId().rawId());
+      detIDSeedRphi.push_back(m.geographicalId().rawId());
+      detIDSeedStereo.push_back(s.geographicalId().rawId());
 
-      if (bAddSeedHits)
-	{
-	  if (useMatchedHits) 
-	    {
-	      
-	      hits.push_back((RHBuilder->build(&(*ihit)))); 
-	    }
-	  else
-	    {
-	      if ( ( (yGlobRPhi > yGlobStereo ) && seed_plus ) || ((yGlobRPhi < yGlobStereo ) && !seed_plus ))  
-		{
-		  hits.push_back((RHBuilder->build(&m)));
-		  hits.push_back((RHBuilder->build(&s)));
-		}
-	      else
-		{
-		  hits.push_back((RHBuilder->build(&s)));     
-		  hits.push_back((RHBuilder->build(&m)));
-		  
-		}
-	    }
-	}
-     }
-   else if (bAddSeedHits)
-     {
-       hits.push_back((RHBuilder->build(&(*ihit)))); 
-       detIDSeedRphi.push_back ( ihit->geographicalId().rawId() );
-       detIDSeedMatched.push_back ( -1 );
-       detIDSeedStereo.push_back ( -1 );
-       
-     }
-       
-   if ( yref < yMin ) yMin = yref;
-   if ( yref > yMax ) yMax = yref;
-   
-//    if (bAddSeedHits)
-//      hits.push_back((RHBuilder->build(&(*ihit)))); 
+      if (bAddSeedHits) {
+        if (useMatchedHits) {
+          hits.push_back((RHBuilder->build(&(*ihit))));
+        } else {
+          if (((yGlobRPhi > yGlobStereo) && seed_plus) || ((yGlobRPhi < yGlobStereo) && !seed_plus)) {
+            hits.push_back((RHBuilder->build(&m)));
+            hits.push_back((RHBuilder->build(&s)));
+          } else {
+            hits.push_back((RHBuilder->build(&s)));
+            hits.push_back((RHBuilder->build(&m)));
+          }
+        }
+      }
+    } else if (bAddSeedHits) {
+      hits.push_back((RHBuilder->build(&(*ihit))));
+      detIDSeedRphi.push_back(ihit->geographicalId().rawId());
+      detIDSeedMatched.push_back(-1);
+      detIDSeedStereo.push_back(-1);
+    }
 
-    LogDebug("CosmicTrackFinder")<<"SEED HITS"<<RHBuilder->build(&(*ihit))->globalPosition();
-    if (debug_info) cout <<"SEED HITS"<<RHBuilder->build(&(*ihit))->globalPosition() << endl;
-//    if (debug_info) cout <<"SEED HITS"<< seed.startingState().parameters() << endl;
+    if (yref < yMin)
+      yMin = yref;
+    if (yref > yMax)
+      yMax = yref;
 
+    //    if (bAddSeedHits)
+    //      hits.push_back((RHBuilder->build(&(*ihit))));
 
+    LogDebug("CosmicTrackFinder") << "SEED HITS" << RHBuilder->build(&(*ihit))->globalPosition();
+    if (debug_info)
+      cout << "SEED HITS" << RHBuilder->build(&(*ihit))->globalPosition() << endl;
+    //    if (debug_info) cout <<"SEED HITS"<< seed.startingState().parameters() << endl;
   }
-  
+
   yref = (seed_plus) ? yMin : yMax;
-  
+
   SiPixelRecHitCollection::DataContainer::const_iterator ipix;
-  for(ipix=collpixel.data().begin();ipix!=collpixel.data().end();ipix++){
-    float ych= RHBuilder->build(&(*ipix))->globalPosition().y();
-    if ((seed_plus && (ych<yref)) || (!(seed_plus) && (ych>yref)))
+  for (ipix = collpixel.data().begin(); ipix != collpixel.data().end(); ipix++) {
+    float ych = RHBuilder->build(&(*ipix))->globalPosition().y();
+    if ((seed_plus && (ych < yref)) || (!(seed_plus) && (ych > yref)))
       allHits.push_back(&(*ipix));
   }
 
-  if (useMatchedHits) // use matched
-    {
-        //add the matched hits ...
-      SiStripMatchedRecHit2DCollection::DataContainer::const_iterator istripm;
+  if (useMatchedHits)  // use matched
+  {
+    //add the matched hits ...
+    SiStripMatchedRecHit2DCollection::DataContainer::const_iterator istripm;
 
-      for(istripm=collmatched.data().begin();istripm!=collmatched.data().end();istripm++){
-	float ych= RHBuilder->build(&(*istripm))->globalPosition().y();
-	
-	int cDetId=istripm->geographicalId().rawId();
-	bool noSeedDet = ( detIDSeedMatched.end() == find (detIDSeedMatched.begin(), detIDSeedMatched.end(), cDetId ) ) ;
-	
-	if ( noSeedDet )
-	  if ((seed_plus && (ych<yref)) || (!(seed_plus) && (ych>yref)))
-	      allHits.push_back(&(*istripm));
-      }
+    for (istripm = collmatched.data().begin(); istripm != collmatched.data().end(); istripm++) {
+      float ych = RHBuilder->build(&(*istripm))->globalPosition().y();
 
-   //add the rpi hits, but only accept hits that are not matched hits
-      for(istrip=collrphi.data().begin();istrip!=collrphi.data().end();istrip++){
-	float ych= RHBuilder->build(&(*istrip))->globalPosition().y();
-	StripSubdetector monoDetId(istrip->geographicalId());
-	if (monoDetId.partnerDetId())
-	  {
-	    edm::LogInfo("CRackTrajectoryBuilder::SortHits")  << "this det belongs to a glued det " << ych << endl;
-	    continue;
-	  }
-	int cDetId=istrip->geographicalId().rawId();
-	bool noSeedDet = ( detIDSeedRphi.end()== find (detIDSeedRphi.begin(), detIDSeedRphi.end(), cDetId ) ) ;
-	if (noSeedDet)
-	  if ((seed_plus && (ych<yref)) || (!(seed_plus) && (ych>yref)))
-	    {
-	      
-	      bool hitIsUnique = true;
-	      //now 
-	      for(istripm=collmatched.data().begin();istripm!=collmatched.data().end();istripm++)
-		{
-		  //		 if ( isDifferentStripReHit2D ( *istrip, (istripm->stereoHit() ) ) == false)
-		  if ( isDifferentStripReHit2D ( *istrip, (istripm->monoHit() ) ) == false)
-		    {
-		      hitIsUnique = false;
-		      edm::LogInfo("CRackTrajectoryBuilder::SortHits")  << "rphi hit is in matched hits; y: " << ych << endl;
-		      break;
-		    }
-		} //end loop over all matched
-	      if (hitIsUnique)
-		{
-		  //      if (debug_info) cout << "adding rphi hit " << &(*istrip) << endl; 
-		  allHits.push_back(&(*istrip));   
-		}
-	    }
-      }
+      int cDetId = istripm->geographicalId().rawId();
+      bool noSeedDet = (detIDSeedMatched.end() == find(detIDSeedMatched.begin(), detIDSeedMatched.end(), cDetId));
 
-  
-    }
-  else // dont use matched ...
-    {
-      
-      for(istrip=collrphi.data().begin();istrip!=collrphi.data().end();istrip++){
-	float ych= RHBuilder->build(&(*istrip))->globalPosition().y();
-	if ((seed_plus && (ych<yref)) || (!(seed_plus) && (ych>yref)))
-	  allHits.push_back(&(*istrip));   
-      }
-
-      for(istrip=collstereo.data().begin();istrip!=collstereo.data().end();istrip++){
-	float ych= RHBuilder->build(&(*istrip))->globalPosition().y();
-	if ((seed_plus && (ych<yref)) || (!(seed_plus) && (ych>yref)))
-	  allHits.push_back(&(*istrip));
-      }
+      if (noSeedDet)
+        if ((seed_plus && (ych < yref)) || (!(seed_plus) && (ych > yref)))
+          allHits.push_back(&(*istripm));
     }
 
+    //add the rpi hits, but only accept hits that are not matched hits
+    for (istrip = collrphi.data().begin(); istrip != collrphi.data().end(); istrip++) {
+      float ych = RHBuilder->build(&(*istrip))->globalPosition().y();
+      StripSubdetector monoDetId(istrip->geographicalId());
+      if (monoDetId.partnerDetId()) {
+        edm::LogInfo("CRackTrajectoryBuilder::SortHits") << "this det belongs to a glued det " << ych << endl;
+        continue;
+      }
+      int cDetId = istrip->geographicalId().rawId();
+      bool noSeedDet = (detIDSeedRphi.end() == find(detIDSeedRphi.begin(), detIDSeedRphi.end(), cDetId));
+      if (noSeedDet)
+        if ((seed_plus && (ych < yref)) || (!(seed_plus) && (ych > yref))) {
+          bool hitIsUnique = true;
+          //now
+          for (istripm = collmatched.data().begin(); istripm != collmatched.data().end(); istripm++) {
+            //		 if ( isDifferentStripReHit2D ( *istrip, (istripm->stereoHit() ) ) == false)
+            if (isDifferentStripReHit2D(*istrip, (istripm->monoHit())) == false) {
+              hitIsUnique = false;
+              edm::LogInfo("CRackTrajectoryBuilder::SortHits") << "rphi hit is in matched hits; y: " << ych << endl;
+              break;
+            }
+          }  //end loop over all matched
+          if (hitIsUnique) {
+            //      if (debug_info) cout << "adding rphi hit " << &(*istrip) << endl;
+            allHits.push_back(&(*istrip));
+          }
+        }
+    }
 
+  } else  // dont use matched ...
+  {
+    for (istrip = collrphi.data().begin(); istrip != collrphi.data().end(); istrip++) {
+      float ych = RHBuilder->build(&(*istrip))->globalPosition().y();
+      if ((seed_plus && (ych < yref)) || (!(seed_plus) && (ych > yref)))
+        allHits.push_back(&(*istrip));
+    }
+
+    for (istrip = collstereo.data().begin(); istrip != collstereo.data().end(); istrip++) {
+      float ych = RHBuilder->build(&(*istrip))->globalPosition().y();
+      if ((seed_plus && (ych < yref)) || (!(seed_plus) && (ych > yref)))
+        allHits.push_back(&(*istrip));
+    }
+  }
 
   if (seed_plus)
-      stable_sort(allHits.begin(),allHits.end(),CompareHitY_plus(*tracker));
-  else 
-      stable_sort(allHits.begin(),allHits.end(),CompareHitY(*tracker));
+    stable_sort(allHits.begin(), allHits.end(), CompareHitY_plus(*tracker));
+  else
+    stable_sort(allHits.begin(), allHits.end(), CompareHitY(*tracker));
 
-  if (debug_info) 
-    {
-      if (debug_info) cout << "all hits" << endl;
+  if (debug_info) {
+    if (debug_info)
+      cout << "all hits" << endl;
 
-      //starting trajectory
-      Trajectory startingTraj = createStartingTrajectory(seed);
+    //starting trajectory
+    Trajectory startingTraj = createStartingTrajectory(seed);
 
-      if (debug_info) cout << "START " << startingTraj.lastMeasurement().updatedState() << endl;
-      if (debug_info) cout << "START  Err" << startingTraj.lastMeasurement().updatedState().localError().matrix() << endl;
+    if (debug_info)
+      cout << "START " << startingTraj.lastMeasurement().updatedState() << endl;
+    if (debug_info)
+      cout << "START  Err" << startingTraj.lastMeasurement().updatedState().localError().matrix() << endl;
 
+    vector<const TrackingRecHit*>::iterator iHit;
+    for (iHit = allHits.begin(); iHit < allHits.end(); iHit++) {
+      GlobalPoint gphit = RHBuilder->build(*iHit)->globalPosition();
+      if (debug_info)
+        cout << "GH " << gphit << endl;
 
-      vector<const TrackingRecHit*>::iterator iHit;
-      for (iHit=allHits.begin(); iHit<allHits.end(); iHit++)
-	{
-	      GlobalPoint gphit=RHBuilder->build(*iHit)->globalPosition();
-	      if (debug_info) cout << "GH " << gphit << endl;
-
-	      //      tracker->idToDet((*iHit)->geographicalId())->surface();
+      //      tracker->idToDet((*iHit)->geographicalId())->surface();
 
       TSOS prSt = thePropagator->propagate(startingTraj.lastMeasurement().updatedState(),
-      			  tracker->idToDet((*iHit)->geographicalId())->surface());
-	      
-	      if(prSt.isValid()) 
-		{
-      if (debug_info) cout << "PR " << prSt.globalPosition() << endl;
-      //if (debug_info) cout << "PR  Err" << prSt.localError().matrix() << endl;
-		  
-		}
-	      else
-		{
-		  if (debug_info) cout << "not valid" << endl;
-		}
-	}
-	      if (debug_info) cout << "all hits end" << endl;
-    }
+                                           tracker->idToDet((*iHit)->geographicalId())->surface());
 
+      if (prSt.isValid()) {
+        if (debug_info)
+          cout << "PR " << prSt.globalPosition() << endl;
+        //if (debug_info) cout << "PR  Err" << prSt.localError().matrix() << endl;
+
+      } else {
+        if (debug_info)
+          cout << "not valid" << endl;
+      }
+    }
+    if (debug_info)
+      cout << "all hits end" << endl;
+  }
 
   return allHits;
 }
 
-TrajectoryStateOnSurface
-CRackTrajectoryBuilder::startingTSOS(const TrajectorySeed& seed)const
-{
-  PTrajectoryStateOnDet pState( seed.startingState());
-  const GeomDet* gdet  = (&(*tracker))->idToDet(DetId(pState.detId()));
-  TSOS  State= trajectoryStateTransform::transientState( pState, &(gdet->surface()), 
-					   &(*magfield));
+TrajectoryStateOnSurface CRackTrajectoryBuilder::startingTSOS(const TrajectorySeed& seed) const {
+  PTrajectoryStateOnDet pState(seed.startingState());
+  const GeomDet* gdet = (&(*tracker))->idToDet(DetId(pState.detId()));
+  TSOS State = trajectoryStateTransform::transientState(pState, &(gdet->surface()), &(*magfield));
   return State;
-
 }
 
-void CRackTrajectoryBuilder::AddHit(Trajectory &traj,
-                                     const vector<const TrackingRecHit*>& _Hits, Propagator *currPropagator){
-   vector<const TrackingRecHit*> Hits = _Hits;
-   if ( Hits.empty() )
-     return;
-  
-   if (debug_info) cout << "CRackTrajectoryBuilder::AddHit" << endl;
-   if (debug_info) cout << "START " << traj.lastMeasurement().updatedState() << endl;
- 
-   vector <TrackingRecHitRange> hitRangeByDet;
-   TrackingRecHitIterator prevDet;
- 
-   prevDet = Hits.begin();
-   for( TrackingRecHitIterator iHit = Hits.begin(); iHit != Hits.end(); iHit++ )
-     {
-       if ( (*prevDet)->geographicalId() == (*iHit)->geographicalId() ) 
- 	continue;
-        
-       hitRangeByDet.push_back( make_pair( prevDet, iHit ) );
-       prevDet = iHit;
+void CRackTrajectoryBuilder::AddHit(Trajectory& traj,
+                                    const vector<const TrackingRecHit*>& _Hits,
+                                    Propagator* currPropagator) {
+  vector<const TrackingRecHit*> Hits = _Hits;
+  if (Hits.empty())
+    return;
+
+  if (debug_info)
+    cout << "CRackTrajectoryBuilder::AddHit" << endl;
+  if (debug_info)
+    cout << "START " << traj.lastMeasurement().updatedState() << endl;
+
+  vector<TrackingRecHitRange> hitRangeByDet;
+  TrackingRecHitIterator prevDet;
+
+  prevDet = Hits.begin();
+  for (TrackingRecHitIterator iHit = Hits.begin(); iHit != Hits.end(); iHit++) {
+    if ((*prevDet)->geographicalId() == (*iHit)->geographicalId())
+      continue;
+
+    hitRangeByDet.push_back(make_pair(prevDet, iHit));
+    prevDet = iHit;
+  }
+  hitRangeByDet.push_back(make_pair(prevDet, Hits.end()));
+
+  /// do the old version ....
+
+  if (fastPropagation) {
+    for (TrackingRecHitRangeIterator iHitRange = hitRangeByDet.begin(); iHitRange != hitRangeByDet.end(); iHitRange++) {
+      const TrackingRecHit* currHit = *(iHitRange->first);
+      DetId currDet = currHit->geographicalId();
+
+      TSOS prSt =
+          currPropagator->propagate(traj.lastMeasurement().updatedState(), tracker->idToDet(currDet)->surface());
+
+      if (!prSt.isValid()) {
+        if (debug_info)
+          cout << "Not Valid: PRST" << prSt.globalPosition();
+        //	      if (debug_info) cout << "Not Valid: HIT" << *currHit;
+
+        continue;
       }
-   hitRangeByDet.push_back( make_pair( prevDet, Hits.end() ) );
- 
-   /// do the old version ....
- 
-     if (fastPropagation) {
-       for( TrackingRecHitRangeIterator iHitRange = hitRangeByDet.begin(); iHitRange != hitRangeByDet.end(); iHitRange++ )
-         {
-            const TrackingRecHit *currHit = *(iHitRange->first);
- 	  DetId      currDet = currHit->geographicalId();
-  
-           TSOS prSt= currPropagator->propagate(traj.lastMeasurement().updatedState(),
- 					      tracker->idToDet(currDet)->surface());
-  
-           if ( !prSt.isValid())
- 	    {
- 	      if (debug_info) cout << "Not Valid: PRST" << prSt.globalPosition();
- //	      if (debug_info) cout << "Not Valid: HIT" << *currHit;
- 
- 
- 	      continue;
- 	    }
- 
-           TransientTrackingRecHit::RecHitPointer bestHit = RHBuilder->build( currHit );
-           double chi2min = theEstimator->estimate( prSt, *bestHit).second;
- 
-           if (debug_info) cout << "Size " << iHitRange->first - (*iHitRange).second << endl;
-           for( TrackingRecHitIterator iHit = (*iHitRange).first+1; iHit != iHitRange->second; iHit++ )
-             {
-               if (debug_info) cout << "loop3 " <<" "<< Hits.end() - iHit << endl;
- 
-               TransientTrackingRecHit::RecHitPointer tmpHit = RHBuilder->build( *iHit );
-               double currChi2 = theEstimator->estimate(prSt, *tmpHit).second;
-               if ( currChi2 < chi2min )
-                 {
-                   chi2min = currChi2;
-                   bestHit = tmpHit;
-                 }
-             }
-           //now we have check if the track can be added to the trajectory
-           if (debug_info) cout << chi2min << endl;
-           if (chi2min < chi2cut)
-             {
-               if (debug_info) cout << "chi2 fine : " << chi2min << endl;
-               TSOS UpdatedState= theUpdator->update( prSt, *bestHit );
-               if (UpdatedState.isValid()){
- 		hits.push_back(bestHit);
-                 traj.push( TM(prSt,UpdatedState, bestHit, chi2min) );
- 		if (debug_info) edm::LogInfo("CosmicTrackFinder") <<
-                   "STATE UPDATED WITH HIT AT POSITION "
- 		  
- 					      << bestHit->globalPosition()
-                                               <<UpdatedState<<" "
-                                               <<traj.chiSquared();
- 		if (debug_info) cout  <<
-                   "STATE UPDATED WITH HIT AT POSITION "
- 		  
- 					      << bestHit->globalPosition()
-                                               <<UpdatedState<<" "
-                                               <<traj.chiSquared();
-                 if (debug_info) cout << "State is valid ..." << endl;
- 		break; // now we need to 
-               }
-               else
-                 {
- 		  edm::LogWarning("CosmicTrackFinder")<<" State can not be updated with hit at position " << endl;
- 		  TSOS UpdatedState= theUpdator->update( prSt, *bestHit );
- 		  if (UpdatedState.isValid()){
- 		    cout  <<
- 		      "NOT! UPDATED WITH HIT AT POSITION "
- 		      
- 			  << bestHit->globalPosition()
- 			  <<UpdatedState<<" "
- 			  <<traj.chiSquared();
- 		    
- 		  }
- 		}
- 	    } 
-         }
-     } //simple version end
-     else 
-     {
-       //first sort the dets in the order they are traversed by the trajectory
-       // we need three loops:
-       // 1: loop as long as there can be an new hit added to the trajectory
-       // 2: loop over all dets that might be hit
-       // 3: loop over all hits on a certain det
-       
-       
-       std::vector < std::pair<TrackingRecHitRangeIterator, TSOS> > trackHitCandidates;
-       std::vector <std::pair<TrackingRecHitRangeIterator, TSOS> >::iterator iHitRange;
-       std::vector <uint32_t> processedDets;
-       do
- 	{
- 	  
- 	  //create vector of possibly hit detectors...
- 	  trackHitCandidates.clear();      
- 	  DetId currDet;
- 	  for( TrackingRecHitRangeIterator iHit = hitRangeByDet.begin(); iHit != hitRangeByDet.end(); iHit++ )
- 	    {
- 	      const TrackingRecHit *currHit = *(iHit->first);
- 	      currDet = currHit->geographicalId();
- 
- 	      if ( find(processedDets.begin(), processedDets.end(), currDet.rawId()) != processedDets.end() )
- 		continue;
- 	      
- 	      TSOS prSt= currPropagator->propagate(traj.lastMeasurement().updatedState(),
- 						tracker->idToDet(currDet)->surface());
- 	      if ( ( !prSt.isValid() ) ||  (theEstimator->Chi2MeasurementEstimatorBase::estimate(prSt,tracker->idToDet(currDet)->surface() ) == false) )
- //	      if ( ( !prSt.isValid() ) ||  (theEstimator->estimate(prSt,tracker->idToDet(currDet)->surface() ) == false) )  
- 		continue;
-     
- 	      trackHitCandidates.push_back(  make_pair(iHit, prSt) );
- 	    }
- 	  
- 	  if (trackHitCandidates.empty())
- 	  break;
- 
- 	  if (debug_info) cout << Hits.size() << " (int) trackHitCandidates.begin() " << trackHitCandidates.size() << endl;
- 	  if (debug_info) cout << "Before sorting ... " << endl; 
- 
- 	  if (debug_info)	  
- 	  for( iHitRange = trackHitCandidates.begin(); iHitRange != trackHitCandidates.end(); iHitRange++ )
- 	    {
- 	      if (debug_info) cout << (tracker->idToDet((*(iHitRange->first->first))->geographicalId()))->position();
- 	    }
- 	  if (debug_info) cout << endl;
- 	  
- 
- 	  stable_sort( trackHitCandidates.begin(), trackHitCandidates.end(), CompareDetByTraj(traj.lastMeasurement().updatedState())  );
- 	  
- 	  if (debug_info) cout << "After sorting ... " << endl; 
- 	  if (debug_info)
- 	    {
- 	    for( iHitRange = trackHitCandidates.begin(); iHitRange != trackHitCandidates.end(); iHitRange++ )
- 	      {
- 		if (debug_info) cout << (tracker->idToDet((*(iHitRange->first->first))->geographicalId()))->position();
- 	      }
- 	    cout << endl;
- 	    }
- 
- 	for( iHitRange = trackHitCandidates.begin(); iHitRange != trackHitCandidates.end(); iHitRange++ )      //loop over dets
- 	  {
- 	    
- 	    //now find the best hit of the detector
- 	    if (debug_info) cout << "loop2 " << trackHitCandidates.size()  <<" " << trackHitCandidates.end() - iHitRange << endl;
- 	    const TrackingRecHit *currHit = *(iHitRange->first->first);
- 	    
- 	    TransientTrackingRecHit::RecHitPointer bestHit = RHBuilder->build( currHit );
- 	    TSOS currPrSt = (*iHitRange).second;
- 	
- 	    if (debug_info) cout << "curr position" << bestHit->globalPosition();
- 	    for( TrackingRecHitIterator iHit = (*iHitRange).first->first+1; iHit != iHitRange->first->second; iHit++ )
- 	      {
- 		TransientTrackingRecHit::RecHitPointer tmpHit = RHBuilder->build( *iHit );
- 		if (debug_info) cout << "curr position" << tmpHit->globalPosition() ;
- 	  
- 	      }
- 	  }
- 	if (debug_info)	cout << "Cross check end ..." << endl;
- 
- 
- 	//just a simple test if the same hit can be added twice ...
- 	//      for( iHitRange = trackHitCandidates.begin(); iHitRange != trackHitCandidates.end(); iHitRange++ )      //loop over all hits
- 	
- 	//      break;
- 	
- 	for( iHitRange = trackHitCandidates.begin(); iHitRange != trackHitCandidates.end(); iHitRange++ )      //loop over detsall hits
- 	  {
- 	    
- 	    //now find the best hit of the detector
- 	    if (debug_info) cout << "loop2 " << trackHitCandidates.size()  <<" " << trackHitCandidates.end() - iHitRange << endl;
- 	    
- 	    const TrackingRecHit *currHit = *(iHitRange->first->first);
- 
- 	    processedDets.push_back(currHit->geographicalId().rawId());
- 	    
- 	    
- 	    TransientTrackingRecHit::RecHitPointer bestHit = RHBuilder->build( currHit );
- 
- 	    if (debug_info) cout << "curr position A" << bestHit->globalPosition() << endl;
- 	    TSOS currPrSt = (*iHitRange).second;
- 	    double chi2min = theEstimator->estimate( currPrSt, *bestHit).second;
- 
- 	    if (debug_info) cout << "Size " << iHitRange->first->second - (*iHitRange).first->first << endl; 
- 	    for( TrackingRecHitIterator iHit = (*iHitRange).first->first+1; iHit != iHitRange->first->second; iHit++ )
- 	      {
- 		if (debug_info) cout << "loop3 " <<" "<< Hits.end() - iHit << endl;
- 	      
- 		TransientTrackingRecHit::RecHitPointer tmpHit = RHBuilder->build( *iHit );
- 		if (debug_info) cout << "curr position B" << tmpHit->globalPosition() << endl;
- 		double currChi2 = theEstimator->estimate(currPrSt, *tmpHit).second;
- 		if ( currChi2 < chi2min )
- 		  {
- 		    if (debug_info) cout << "Is best hit" << endl;
- 		    chi2min = currChi2;
- 		    bestHit = tmpHit;
- 		  }
- 	      }
- 	    //now we have checked the det and can remove the entry from the vector...
- 	  
- 	    //if (debug_info) cout << "before erase ..." << endl;
- 	    //this is to slow ...
- 	    // hitRangeByDet.erase( (*iHitRange).first,(*iHitRange).first+1 );	  
- 	    //if (debug_info) cout << "after erase ..." << endl;
- 
- 	    if (debug_info) cout << chi2min << endl;
- 	    //if the track can be added to the trajectory 
- 	    if (chi2min < chi2cut)
- 	      {
- 		if (debug_info) cout << "chi2 fine : " << chi2min << endl;
- 
- 		//  if (debug_info) cout << "previaous state " << traj.lastMeasurement().updatedState() <<endl;
- 		TSOS UpdatedState= theUpdator->update( currPrSt, *bestHit );
- 		if (UpdatedState.isValid()){
- 
- 		  hits.push_back(bestHit);
- 		  traj.push( TM(currPrSt,UpdatedState, bestHit, chi2min) );
- 		  if (debug_info) edm::LogInfo("CosmicTrackFinder") <<
- 		    "STATE UPDATED WITH HIT AT POSITION "
- 		    //   <<tmphitbestdet->globalPosition()
- 						<<UpdatedState<<" "
- 						<<traj.chiSquared();
- 		  if (debug_info) cout << "Added Hit" << bestHit->globalPosition() << endl;
- 		  if (debug_info) cout << "State is valid ..." << UpdatedState << endl;
- 		  //cout << "updated state " << traj.lastMeasurement().updatedState() <<endl;
- 
- 		  //	      return; //break;
- 		  //
- 		  //	      TSOS prSt= currPropagator->propagate(traj.lastMeasurement().updatedState(),
- 		  //					      tracker->idToDet( bestHit->geographicalId() )->surface());
- 		  //	  
- 		  //	      if ( prSt.isValid())
- 		  //		cout << "the same hit can be added twice ..." << endl;	
- 		  //
- 		  
- 		  break;
- 		}
- 		else
- 		  {
- 		    if (debug_info) edm::LogWarning("CosmicTrackFinder")<<" State can not be updated with hit at position "
- 							<< bestHit->globalPosition();  
- 		    //		cout << "State can not be updated with hit at " << bestHit->globalPosition() << endl;
- 		  }
- 		continue;
- 	      }
- 	    else
- 	      {
- 		//      cout << "chi2 to big : " << chi2min << endl;
- 	      }
- 	    if (debug_info) cout << " continue 1 " << endl;
- 	  }
- 	//now we remove all already processed dets from the list ...
- 	// hitRangeByDet.erase( (*trackHitCandidates.begin()).first,(*iHitRange).first+1 );	  
- 
- 	if (debug_info) cout << " continue 2 " << endl;
-       }
-     //if this was the last exit
-     while ( iHitRange != trackHitCandidates.end() );
-     }
- 
- 
+
+      TransientTrackingRecHit::RecHitPointer bestHit = RHBuilder->build(currHit);
+      double chi2min = theEstimator->estimate(prSt, *bestHit).second;
+
+      if (debug_info)
+        cout << "Size " << iHitRange->first - (*iHitRange).second << endl;
+      for (TrackingRecHitIterator iHit = (*iHitRange).first + 1; iHit != iHitRange->second; iHit++) {
+        if (debug_info)
+          cout << "loop3 "
+               << " " << Hits.end() - iHit << endl;
+
+        TransientTrackingRecHit::RecHitPointer tmpHit = RHBuilder->build(*iHit);
+        double currChi2 = theEstimator->estimate(prSt, *tmpHit).second;
+        if (currChi2 < chi2min) {
+          chi2min = currChi2;
+          bestHit = tmpHit;
+        }
+      }
+      //now we have check if the track can be added to the trajectory
+      if (debug_info)
+        cout << chi2min << endl;
+      if (chi2min < chi2cut) {
+        if (debug_info)
+          cout << "chi2 fine : " << chi2min << endl;
+        TSOS UpdatedState = theUpdator->update(prSt, *bestHit);
+        if (UpdatedState.isValid()) {
+          hits.push_back(bestHit);
+          traj.push(TM(prSt, UpdatedState, bestHit, chi2min));
+          if (debug_info)
+            edm::LogInfo("CosmicTrackFinder") << "STATE UPDATED WITH HIT AT POSITION "
+
+                                              << bestHit->globalPosition() << UpdatedState << " " << traj.chiSquared();
+          if (debug_info)
+            cout << "STATE UPDATED WITH HIT AT POSITION "
+
+                 << bestHit->globalPosition() << UpdatedState << " " << traj.chiSquared();
+          if (debug_info)
+            cout << "State is valid ..." << endl;
+          break;  // now we need to
+        } else {
+          edm::LogWarning("CosmicTrackFinder") << " State can not be updated with hit at position " << endl;
+          TSOS UpdatedState = theUpdator->update(prSt, *bestHit);
+          if (UpdatedState.isValid()) {
+            cout << "NOT! UPDATED WITH HIT AT POSITION "
+
+                 << bestHit->globalPosition() << UpdatedState << " " << traj.chiSquared();
+          }
+        }
+      }
+    }
+  }  //simple version end
+  else {
+    //first sort the dets in the order they are traversed by the trajectory
+    // we need three loops:
+    // 1: loop as long as there can be an new hit added to the trajectory
+    // 2: loop over all dets that might be hit
+    // 3: loop over all hits on a certain det
+
+    std::vector<std::pair<TrackingRecHitRangeIterator, TSOS> > trackHitCandidates;
+    std::vector<std::pair<TrackingRecHitRangeIterator, TSOS> >::iterator iHitRange;
+    std::vector<uint32_t> processedDets;
+    do {
+      //create vector of possibly hit detectors...
+      trackHitCandidates.clear();
+      DetId currDet;
+      for (TrackingRecHitRangeIterator iHit = hitRangeByDet.begin(); iHit != hitRangeByDet.end(); iHit++) {
+        const TrackingRecHit* currHit = *(iHit->first);
+        currDet = currHit->geographicalId();
+
+        if (find(processedDets.begin(), processedDets.end(), currDet.rawId()) != processedDets.end())
+          continue;
+
+        TSOS prSt =
+            currPropagator->propagate(traj.lastMeasurement().updatedState(), tracker->idToDet(currDet)->surface());
+        if ((!prSt.isValid()) ||
+            (theEstimator->Chi2MeasurementEstimatorBase::estimate(prSt, tracker->idToDet(currDet)->surface()) == false))
+          //	      if ( ( !prSt.isValid() ) ||  (theEstimator->estimate(prSt,tracker->idToDet(currDet)->surface() ) == false) )
+          continue;
+
+        trackHitCandidates.push_back(make_pair(iHit, prSt));
+      }
+
+      if (trackHitCandidates.empty())
+        break;
+
+      if (debug_info)
+        cout << Hits.size() << " (int) trackHitCandidates.begin() " << trackHitCandidates.size() << endl;
+      if (debug_info)
+        cout << "Before sorting ... " << endl;
+
+      if (debug_info)
+        for (iHitRange = trackHitCandidates.begin(); iHitRange != trackHitCandidates.end(); iHitRange++) {
+          if (debug_info)
+            cout << (tracker->idToDet((*(iHitRange->first->first))->geographicalId()))->position();
+        }
+      if (debug_info)
+        cout << endl;
+
+      stable_sort(trackHitCandidates.begin(),
+                  trackHitCandidates.end(),
+                  CompareDetByTraj(traj.lastMeasurement().updatedState()));
+
+      if (debug_info)
+        cout << "After sorting ... " << endl;
+      if (debug_info) {
+        for (iHitRange = trackHitCandidates.begin(); iHitRange != trackHitCandidates.end(); iHitRange++) {
+          if (debug_info)
+            cout << (tracker->idToDet((*(iHitRange->first->first))->geographicalId()))->position();
+        }
+        cout << endl;
+      }
+
+      for (iHitRange = trackHitCandidates.begin(); iHitRange != trackHitCandidates.end(); iHitRange++)  //loop over dets
+      {
+        //now find the best hit of the detector
+        if (debug_info)
+          cout << "loop2 " << trackHitCandidates.size() << " " << trackHitCandidates.end() - iHitRange << endl;
+        const TrackingRecHit* currHit = *(iHitRange->first->first);
+
+        TransientTrackingRecHit::RecHitPointer bestHit = RHBuilder->build(currHit);
+        TSOS currPrSt = (*iHitRange).second;
+
+        if (debug_info)
+          cout << "curr position" << bestHit->globalPosition();
+        for (TrackingRecHitIterator iHit = (*iHitRange).first->first + 1; iHit != iHitRange->first->second; iHit++) {
+          TransientTrackingRecHit::RecHitPointer tmpHit = RHBuilder->build(*iHit);
+          if (debug_info)
+            cout << "curr position" << tmpHit->globalPosition();
+        }
+      }
+      if (debug_info)
+        cout << "Cross check end ..." << endl;
+
+      //just a simple test if the same hit can be added twice ...
+      //      for( iHitRange = trackHitCandidates.begin(); iHitRange != trackHitCandidates.end(); iHitRange++ )      //loop over all hits
+
+      //      break;
+
+      for (iHitRange = trackHitCandidates.begin(); iHitRange != trackHitCandidates.end();
+           iHitRange++)  //loop over detsall hits
+      {
+        //now find the best hit of the detector
+        if (debug_info)
+          cout << "loop2 " << trackHitCandidates.size() << " " << trackHitCandidates.end() - iHitRange << endl;
+
+        const TrackingRecHit* currHit = *(iHitRange->first->first);
+
+        processedDets.push_back(currHit->geographicalId().rawId());
+
+        TransientTrackingRecHit::RecHitPointer bestHit = RHBuilder->build(currHit);
+
+        if (debug_info)
+          cout << "curr position A" << bestHit->globalPosition() << endl;
+        TSOS currPrSt = (*iHitRange).second;
+        double chi2min = theEstimator->estimate(currPrSt, *bestHit).second;
+
+        if (debug_info)
+          cout << "Size " << iHitRange->first->second - (*iHitRange).first->first << endl;
+        for (TrackingRecHitIterator iHit = (*iHitRange).first->first + 1; iHit != iHitRange->first->second; iHit++) {
+          if (debug_info)
+            cout << "loop3 "
+                 << " " << Hits.end() - iHit << endl;
+
+          TransientTrackingRecHit::RecHitPointer tmpHit = RHBuilder->build(*iHit);
+          if (debug_info)
+            cout << "curr position B" << tmpHit->globalPosition() << endl;
+          double currChi2 = theEstimator->estimate(currPrSt, *tmpHit).second;
+          if (currChi2 < chi2min) {
+            if (debug_info)
+              cout << "Is best hit" << endl;
+            chi2min = currChi2;
+            bestHit = tmpHit;
+          }
+        }
+        //now we have checked the det and can remove the entry from the vector...
+
+        //if (debug_info) cout << "before erase ..." << endl;
+        //this is to slow ...
+        // hitRangeByDet.erase( (*iHitRange).first,(*iHitRange).first+1 );
+        //if (debug_info) cout << "after erase ..." << endl;
+
+        if (debug_info)
+          cout << chi2min << endl;
+        //if the track can be added to the trajectory
+        if (chi2min < chi2cut) {
+          if (debug_info)
+            cout << "chi2 fine : " << chi2min << endl;
+
+          //  if (debug_info) cout << "previaous state " << traj.lastMeasurement().updatedState() <<endl;
+          TSOS UpdatedState = theUpdator->update(currPrSt, *bestHit);
+          if (UpdatedState.isValid()) {
+            hits.push_back(bestHit);
+            traj.push(TM(currPrSt, UpdatedState, bestHit, chi2min));
+            if (debug_info)
+              edm::LogInfo("CosmicTrackFinder") << "STATE UPDATED WITH HIT AT POSITION "
+                                                //   <<tmphitbestdet->globalPosition()
+                                                << UpdatedState << " " << traj.chiSquared();
+            if (debug_info)
+              cout << "Added Hit" << bestHit->globalPosition() << endl;
+            if (debug_info)
+              cout << "State is valid ..." << UpdatedState << endl;
+            //cout << "updated state " << traj.lastMeasurement().updatedState() <<endl;
+
+            //	      return; //break;
+            //
+            //	      TSOS prSt= currPropagator->propagate(traj.lastMeasurement().updatedState(),
+            //					      tracker->idToDet( bestHit->geographicalId() )->surface());
+            //
+            //	      if ( prSt.isValid())
+            //		cout << "the same hit can be added twice ..." << endl;
+            //
+
+            break;
+          } else {
+            if (debug_info)
+              edm::LogWarning("CosmicTrackFinder")
+                  << " State can not be updated with hit at position " << bestHit->globalPosition();
+            //		cout << "State can not be updated with hit at " << bestHit->globalPosition() << endl;
+          }
+          continue;
+        } else {
+          //      cout << "chi2 to big : " << chi2min << endl;
+        }
+        if (debug_info)
+          cout << " continue 1 " << endl;
+      }
+      //now we remove all already processed dets from the list ...
+      // hitRangeByDet.erase( (*trackHitCandidates.begin()).first,(*iHitRange).first+1 );
+
+      if (debug_info)
+        cout << " continue 2 " << endl;
+    }
+    //if this was the last exit
+    while (iHitRange != trackHitCandidates.end());
+  }
 }
 
-
-bool 
-CRackTrajectoryBuilder::qualityFilter(const Trajectory& traj){
-  int ngoodhits=0;
-  if(geometry=="MTCC"){
-    auto hits= traj.recHits();
-    for(auto hit=hits.begin();hit!=hits.end();hit++){
-      unsigned int iid=(*hit)->hit()->geographicalId().rawId();
+bool CRackTrajectoryBuilder::qualityFilter(const Trajectory& traj) {
+  int ngoodhits = 0;
+  if (geometry == "MTCC") {
+    auto hits = traj.recHits();
+    for (auto hit = hits.begin(); hit != hits.end(); hit++) {
+      unsigned int iid = (*hit)->hit()->geographicalId().rawId();
       //CHECK FOR 3 hits r-phi
-      if(((iid>>0)&0x3)!=1) ngoodhits++;
+      if (((iid >> 0) & 0x3) != 1)
+        ngoodhits++;
     }
-  }
-  else ngoodhits=traj.foundHits();
-  
-  if ( ngoodhits >= theMinHits) {
+  } else
+    ngoodhits = traj.foundHits();
+
+  if (ngoodhits >= theMinHits) {
     return true;
-  }
-  else {
+  } else {
     return false;
   }
 }
@@ -855,15 +774,14 @@ CRackTrajectoryBuilder::qualityFilter(const Trajectory& traj){
 //----------------------------------------------------------------------------------------------------------
 // little helper function that returns false if both hits conatin the same information
 
-bool CRackTrajectoryBuilder::isDifferentStripReHit2D  (const SiStripRecHit2D& hitA, const  SiStripRecHit2D& hitB )
-{
-  if ( hitA.geographicalId() != hitB.geographicalId() )
+bool CRackTrajectoryBuilder::isDifferentStripReHit2D(const SiStripRecHit2D& hitA, const SiStripRecHit2D& hitB) {
+  if (hitA.geographicalId() != hitB.geographicalId())
     return true;
-  if ( hitA.localPosition().x() != hitB.localPosition().x() )
+  if (hitA.localPosition().x() != hitB.localPosition().x())
     return true;
-  if ( hitA.localPosition().y() != hitB.localPosition().y() )
+  if (hitA.localPosition().y() != hitB.localPosition().y())
     return true;
-  if ( hitA.localPosition().z() != hitB.localPosition().z() )
+  if (hitA.localPosition().z() != hitB.localPosition().z())
     return true;
 
   //  if (debug_info) cout << hitA.localPosition() << endl;
@@ -872,52 +790,46 @@ bool CRackTrajectoryBuilder::isDifferentStripReHit2D  (const SiStripRecHit2D& hi
   return false;
 }
 
-
-
 //----backfitting
-std::pair<TrajectoryStateOnSurface, const GeomDet*> 
-CRackTrajectoryBuilder::innerState( const Trajectory& traj) const
-{
+std::pair<TrajectoryStateOnSurface, const GeomDet*> CRackTrajectoryBuilder::innerState(const Trajectory& traj) const {
   int lastFitted = 999;
   int nhits = traj.foundHits();
-  if (nhits < lastFitted+1) lastFitted = nhits-1;
+  if (nhits < lastFitted + 1)
+    lastFitted = nhits - 1;
 
   std::vector<TrajectoryMeasurement> measvec = traj.measurements();
   TransientTrackingRecHit::ConstRecHitContainer firstHits;
 
   bool foundLast = false;
   int actualLast = -99;
-  for (int i=lastFitted; i >= 0; i--) {
-    if(measvec[i].recHit()->isValid()){
-      if(!foundLast){
-	actualLast = i; 
-	foundLast = true;
+  for (int i = lastFitted; i >= 0; i--) {
+    if (measvec[i].recHit()->isValid()) {
+      if (!foundLast) {
+        actualLast = i;
+        foundLast = true;
       }
-      firstHits.push_back( measvec[i].recHit());
+      firstHits.push_back(measvec[i].recHit());
     }
   }
   TSOS unscaledState = measvec[actualLast].updatedState();
-  AlgebraicSymMatrix55 C=ROOT::Math::SMatrixIdentity();
+  AlgebraicSymMatrix55 C = ROOT::Math::SMatrixIdentity();
   // C *= 100.;
 
-  TSOS startingState( unscaledState.localParameters(), LocalTrajectoryError(C),
-		      unscaledState.surface(),
-		      thePropagator->magneticField());
+  TSOS startingState(unscaledState.localParameters(),
+                     LocalTrajectoryError(C),
+                     unscaledState.surface(),
+                     thePropagator->magneticField());
 
   // cout << endl << "FitTester starts with state " << startingState << endl;
 
-  KFTrajectoryFitter backFitter( *thePropagator,
-				 KFUpdator(),
-				 Chi2MeasurementEstimator( 100., 3));
+  KFTrajectoryFitter backFitter(*thePropagator, KFUpdator(), Chi2MeasurementEstimator(100., 3));
 
-  PropagationDirection backFitDirection = traj.direction() == alongMomentum ? oppositeToMomentum: alongMomentum;
+  PropagationDirection backFitDirection = traj.direction() == alongMomentum ? oppositeToMomentum : alongMomentum;
 
   // only direction matters in this contest
-  TrajectorySeed fakeSeed = TrajectorySeed(PTrajectoryStateOnDet() , 
-					   edm::OwnVector<TrackingRecHit>(),
-					   backFitDirection);
+  TrajectorySeed fakeSeed = TrajectorySeed(PTrajectoryStateOnDet(), edm::OwnVector<TrackingRecHit>(), backFitDirection);
 
-  vector<Trajectory> fitres = backFitter.fit( fakeSeed, firstHits, startingState);
+  vector<Trajectory> fitres = backFitter.fit(fakeSeed, firstHits, startingState);
 
   if (fitres.size() != 1) {
     // cout << "FitTester: first hits fit failed!" << endl;
@@ -930,10 +842,8 @@ CRackTrajectoryBuilder::innerState( const Trajectory& traj) const
   //  cout << "FitTester: Fitted first state " << firstState << endl;
   //cout << "FitTester: chi2 = " << fitres[0].chiSquared() << endl;
 
-  TSOS initialState( firstState.localParameters(), LocalTrajectoryError(C),
-		     firstState.surface(),
-		     thePropagator->magneticField());
+  TSOS initialState(
+      firstState.localParameters(), LocalTrajectoryError(C), firstState.surface(), thePropagator->magneticField());
 
-  return std::pair<TrajectoryStateOnSurface, const GeomDet*>( initialState, 
-							      firstMeas.recHit()->det());
+  return std::pair<TrajectoryStateOnSurface, const GeomDet*>(initialState, firstMeas.recHit()->det());
 }

--- a/RecoTracker/SingleTrackPattern/src/CosmicTrackFinder.cc
+++ b/RecoTracker/SingleTrackPattern/src/CosmicTrackFinder.cc
@@ -23,37 +23,27 @@
 
 #include "RecoTracker/TransientTrackingRecHit/interface/Traj2TrackHits.h"
 
+namespace cms {
 
-namespace cms
-{
-
-  CosmicTrackFinder::CosmicTrackFinder(edm::ParameterSet const& conf) : 
-    cosmicTrajectoryBuilder_(conf) ,
-    crackTrajectoryBuilder_(conf)
-  {
-    geometry=conf.getUntrackedParameter<std::string>("GeometricStructure","STANDARD");
-    useHitsSplitting_=conf.getParameter<bool>("useHitsSplitting");
-    matchedrecHitsToken_ = consumes<SiStripMatchedRecHit2DCollection>(
-        conf.getParameter<edm::InputTag>("matchedRecHits"));
-    rphirecHitsToken_ = consumes<SiStripRecHit2DCollection>(
-        conf.getParameter<edm::InputTag>("rphirecHits"));
-    stereorecHitsToken_ = consumes<SiStripRecHit2DCollection>(
-        conf.getParameter<edm::InputTag>("stereorecHits"));
-    pixelRecHitsToken_ = consumes<SiPixelRecHitCollection>(
-        conf.getParameter<edm::InputTag>("pixelRecHits"));
-    seedToken_ = consumes<TrajectorySeedCollection>(
-        conf.getParameter<edm::InputTag>("cosmicSeeds"));
+  CosmicTrackFinder::CosmicTrackFinder(edm::ParameterSet const& conf)
+      : cosmicTrajectoryBuilder_(conf), crackTrajectoryBuilder_(conf) {
+    geometry = conf.getUntrackedParameter<std::string>("GeometricStructure", "STANDARD");
+    useHitsSplitting_ = conf.getParameter<bool>("useHitsSplitting");
+    matchedrecHitsToken_ =
+        consumes<SiStripMatchedRecHit2DCollection>(conf.getParameter<edm::InputTag>("matchedRecHits"));
+    rphirecHitsToken_ = consumes<SiStripRecHit2DCollection>(conf.getParameter<edm::InputTag>("rphirecHits"));
+    stereorecHitsToken_ = consumes<SiStripRecHit2DCollection>(conf.getParameter<edm::InputTag>("stereorecHits"));
+    pixelRecHitsToken_ = consumes<SiPixelRecHitCollection>(conf.getParameter<edm::InputTag>("pixelRecHits"));
+    seedToken_ = consumes<TrajectorySeedCollection>(conf.getParameter<edm::InputTag>("cosmicSeeds"));
 
     produces<TrackCandidateCollection>();
   }
 
-
   // Virtual destructor needed.
-  CosmicTrackFinder::~CosmicTrackFinder() { }  
+  CosmicTrackFinder::~CosmicTrackFinder() {}
 
   // Functions that gets called by framework every event
-  void CosmicTrackFinder::produce(edm::Event& e, const edm::EventSetup& es)
-  {
+  void CosmicTrackFinder::produce(edm::Event& e, const edm::EventSetup& es) {
     using namespace std;
 
     // retrieve seeds
@@ -62,25 +52,20 @@ namespace cms
 
     //retrieve PixelRecHits
     static const SiPixelRecHitCollection s_empty;
-    const SiPixelRecHitCollection *pixelHitCollection = &s_empty;
+    const SiPixelRecHitCollection* pixelHitCollection = &s_empty;
     edm::Handle<SiPixelRecHitCollection> pixelHits;
-    if (geometry!="MTCC" && (geometry!="CRACK" )) {
-      if( e.getByToken(pixelRecHitsToken_, pixelHits)) {
-	pixelHitCollection = pixelHits.product();
+    if (geometry != "MTCC" && (geometry != "CRACK")) {
+      if (e.getByToken(pixelRecHitsToken_, pixelHits)) {
+        pixelHitCollection = pixelHits.product();
       } else {
         Labels l;
         labelsForToken(pixelRecHitsToken_, l);
-	edm::LogWarning("CosmicTrackFinder")
-            << "Collection SiPixelRecHitCollection with InputTag "
-            << l.module
-            << " cannot be found, using empty collection of same type.";
+        edm::LogWarning("CosmicTrackFinder") << "Collection SiPixelRecHitCollection with InputTag " << l.module
+                                             << " cannot be found, using empty collection of same type.";
       }
     }
-    
-   
 
-
- //retrieve StripRecHits
+    //retrieve StripRecHits
     edm::Handle<SiStripMatchedRecHit2DCollection> matchedrecHits;
     e.getByToken(matchedrecHitsToken_, matchedrecHits);
     edm::Handle<SiStripRecHit2DCollection> rphirecHits;
@@ -95,67 +80,56 @@ namespace cms
     es.get<TrackerDigiGeometryRecord>().get(tracker);
     edm::LogVerbatim("CosmicTrackFinder") << "========== Cosmic Track Finder Info ==========";
     edm::LogVerbatim("CosmicTrackFinder") << " Numbers of Seeds " << (*seed).size();
-    if(!(*seed).empty()){
-
+    if (!(*seed).empty()) {
       std::vector<Trajectory> trajoutput;
-      
 
-      const TransientTrackingRecHitBuilder * hitBuilder = nullptr;
-      if(geometry!="CRACK" ) {
-        cosmicTrajectoryBuilder_.run(*seed,
-                                   *stereorecHits,
-                                   *rphirecHits,
-                                   *matchedrecHits,
-				   *pixelHitCollection,
-                                   es,
-                                   e,
-                                   trajoutput);
+      const TransientTrackingRecHitBuilder* hitBuilder = nullptr;
+      if (geometry != "CRACK") {
+        cosmicTrajectoryBuilder_.run(
+            *seed, *stereorecHits, *rphirecHits, *matchedrecHits, *pixelHitCollection, es, e, trajoutput);
         hitBuilder = cosmicTrajectoryBuilder_.hitBuilder();
       } else {
-        crackTrajectoryBuilder_.run(*seed,
-                                   *stereorecHits,
-                                   *rphirecHits,
-                                   *matchedrecHits,
-				   *pixelHitCollection,
-                                   es,
-                                   e,
-                                   trajoutput);
-	hitBuilder = crackTrajectoryBuilder_.hitBuilder();
+        crackTrajectoryBuilder_.run(
+            *seed, *stereorecHits, *rphirecHits, *matchedrecHits, *pixelHitCollection, es, e, trajoutput);
+        hitBuilder = crackTrajectoryBuilder_.hitBuilder();
       }
       assert(hitBuilder);
-      Traj2TrackHits t2t(hitBuilder,true);
+      Traj2TrackHits t2t(hitBuilder, true);
 
       edm::LogVerbatim("CosmicTrackFinder") << " Numbers of Temp Trajectories " << trajoutput.size();
       edm::LogVerbatim("CosmicTrackFinder") << "========== END Info ==========";
-      if(!trajoutput.empty()){
-
+      if (!trajoutput.empty()) {
         // crazyness...
-	std::vector<Trajectory*> tmpTraj;
-	std::vector<Trajectory>::iterator itr;
-	for (itr=trajoutput.begin();itr!=trajoutput.end();itr++)tmpTraj.push_back(&(*itr));
+        std::vector<Trajectory*> tmpTraj;
+        std::vector<Trajectory>::iterator itr;
+        for (itr = trajoutput.begin(); itr != trajoutput.end(); itr++)
+          tmpTraj.push_back(&(*itr));
 
-	//The best track is selected
-	//FOR MTCC the criteria are:
-	//1)# of layers,2) # of Hits,3)Chi2
-	if (geometry=="MTCC")  stable_sort(tmpTraj.begin(),tmpTraj.end(),CompareTrajLay());
-	else  stable_sort(tmpTraj.begin(),tmpTraj.end(),CompareTrajChi());
+        //The best track is selected
+        //FOR MTCC the criteria are:
+        //1)# of layers,2) # of Hits,3)Chi2
+        if (geometry == "MTCC")
+          stable_sort(tmpTraj.begin(), tmpTraj.end(), CompareTrajLay());
+        else
+          stable_sort(tmpTraj.begin(), tmpTraj.end(), CompareTrajChi());
 
         ///.....
 
-	const Trajectory  theTraj = *(*tmpTraj.begin());
-	bool seedplus=(theTraj.seed().direction()==alongMomentum);
+        const Trajectory theTraj = *(*tmpTraj.begin());
+        bool seedplus = (theTraj.seed().direction() == alongMomentum);
 
         // std::cout << "CosmicTrackFinder " <<"Reconstruction " <<  (seedplus ? "along" : "opposite to") << " momentum" << std::endl;
-        LogDebug("CosmicTrackFinder")<<"Reconstruction " <<  (seedplus ? "along" : "opposite to") << " momentum";
+        LogDebug("CosmicTrackFinder") << "Reconstruction " << (seedplus ? "along" : "opposite to") << " momentum";
 
-	/*
+        /*
 	// === the convention is to save always final tracks with hits sorted *along* momentum
         // --- this is NOT what was necessaraly happening before and not consistent with what done in standard CKF (this is a candidate not a track) 	
 	*/
-         edm::OwnVector<TrackingRecHit> recHits;
-         if(theTraj.direction() == alongMomentum) std::cout << "cosmic: along momentum... " << std::endl;
-         t2t(theTraj,recHits,useHitsSplitting_);
-         recHits.reverse();  // according to original code
+        edm::OwnVector<TrackingRecHit> recHits;
+        if (theTraj.direction() == alongMomentum)
+          std::cout << "cosmic: along momentum... " << std::endl;
+        t2t(theTraj, recHits, useHitsSplitting_);
+        recHits.reverse();  // according to original code
 
         /*
 	Trajectory::RecHitContainer thits;
@@ -170,48 +144,44 @@ namespace cms
 	}
        */
 
-	TSOS firstState;
-	unsigned int firstId;
+        TSOS firstState;
+        unsigned int firstId;
 
         // assume not along momentum....
-	firstState=theTraj.lastMeasurement().updatedState();
+        firstState = theTraj.lastMeasurement().updatedState();
         firstId = theTraj.lastMeasurement().recHitR().rawId();
-	//firstId = recHits.front().rawId();
+        //firstId = recHits.front().rawId();
 
-	/*
+        /*
 	cout << "firstState y, z: " << firstState.globalPosition().y() 
 	     << " , " << firstState.globalPosition().z() <<  endl;
 
 	*/
 
-	AlgebraicSymMatrix55 C = AlgebraicMatrixID();
-	TSOS startingState( firstState.localParameters(), LocalTrajectoryError(C),
-			    firstState.surface(),
-			    firstState.magneticField() );
+        AlgebraicSymMatrix55 C = AlgebraicMatrixID();
+        TSOS startingState(
+            firstState.localParameters(), LocalTrajectoryError(C), firstState.surface(), firstState.magneticField());
 
-	// protection againt invalid initial states
-	if (! firstState.isValid()) {
-	  edm::LogWarning("CosmicTrackFinder") << "invalid innerState, will not make TrackCandidate";
-	  edm::OrphanHandle<TrackCandidateCollection> rTrackCand = e.put(std::move(output));
-	  return;
-	}
+        // protection againt invalid initial states
+        if (!firstState.isValid()) {
+          edm::LogWarning("CosmicTrackFinder") << "invalid innerState, will not make TrackCandidate";
+          edm::OrphanHandle<TrackCandidateCollection> rTrackCand = e.put(std::move(output));
+          return;
+        }
 
         // FIXME in case of slitting this can happen see CkfTrackCandidateMakerBase
-	if(firstId != recHits.front().rawId()){
-	  edm::LogWarning("CosmicTrackFinder") <<"Mismatch in DetID of first hit: firstID= " <<firstId
-					       << "   DetId= " << recHits.front().geographicalId().rawId();
-	  edm::OrphanHandle<TrackCandidateCollection> rTrackCand = e.put(std::move(output));
-	  return;
-	}
+        if (firstId != recHits.front().rawId()) {
+          edm::LogWarning("CosmicTrackFinder") << "Mismatch in DetID of first hit: firstID= " << firstId
+                                               << "   DetId= " << recHits.front().geographicalId().rawId();
+          edm::OrphanHandle<TrackCandidateCollection> rTrackCand = e.put(std::move(output));
+          return;
+        }
 
-	PTrajectoryStateOnDet const &  state = trajectoryStateTransform::persistentState( startingState, firstId);
-	
-	
-	output->push_back(TrackCandidate(recHits,theTraj.seed(),state,theTraj.seedRef() ) );
-	
+        PTrajectoryStateOnDet const& state = trajectoryStateTransform::persistentState(startingState, firstId);
+
+        output->push_back(TrackCandidate(recHits, theTraj.seed(), state, theTraj.seedRef()));
       }
-
     }
     edm::OrphanHandle<TrackCandidateCollection> rTrackCand = e.put(std::move(output));
   }
-}
+}  // namespace cms

--- a/RecoTracker/SingleTrackPattern/src/CosmicTrajectoryBuilder.cc
+++ b/RecoTracker/SingleTrackPattern/src/CosmicTrajectoryBuilder.cc
@@ -14,105 +14,86 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "TrackingTools/Records/interface/TrackingComponentsRecord.h" 
-#include "TrackingTools/Records/interface/TransientRecHitRecord.h" 
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "TrackingTools/TrackFitters/interface/TrajectoryStateWithArbitraryError.h"
 using namespace std;
-CosmicTrajectoryBuilder::CosmicTrajectoryBuilder(const edm::ParameterSet& conf) {
+CosmicTrajectoryBuilder::CosmicTrajectoryBuilder(const edm::ParameterSet &conf) {
   //minimum number of hits per tracks
 
-  theMinHits=conf.getParameter<int>("MinHits");
+  theMinHits = conf.getParameter<int>("MinHits");
   //cut on chi2
-  chi2cut=conf.getParameter<double>("Chi2Cut");
-  edm::LogInfo("CosmicTrackFinder")<<"Minimum number of hits "<<theMinHits<<" Cut on Chi2= "<<chi2cut;
+  chi2cut = conf.getParameter<double>("Chi2Cut");
+  edm::LogInfo("CosmicTrackFinder") << "Minimum number of hits " << theMinHits << " Cut on Chi2= " << chi2cut;
 
-  geometry=conf.getUntrackedParameter<std::string>("GeometricStructure","STANDARD");
+  geometry = conf.getUntrackedParameter<std::string>("GeometricStructure", "STANDARD");
   theBuilderName = conf.getParameter<std::string>("TTRHBuilder");
 }
 
+CosmicTrajectoryBuilder::~CosmicTrajectoryBuilder() {}
 
-CosmicTrajectoryBuilder::~CosmicTrajectoryBuilder() {
-}
-
-
-void CosmicTrajectoryBuilder::init(const edm::EventSetup& es, bool seedplus){
-
+void CosmicTrajectoryBuilder::init(const edm::EventSetup &es, bool seedplus) {
   // FIXME: this is a memory leak generator
 
   //services
   es.get<IdealMagneticFieldRecord>().get(magfield);
   es.get<TrackerDigiGeometryRecord>().get(tracker);
-  
- 
-  
-  if (seedplus) { 	 
-    seed_plus=true; 	 
-    thePropagator=      new PropagatorWithMaterial(alongMomentum,0.1057,&(*magfield) ); 	 
-    thePropagatorOp=    new PropagatorWithMaterial(oppositeToMomentum,0.1057,&(*magfield) );} 	 
-  else {
-    seed_plus=false;
-    thePropagator=      new PropagatorWithMaterial(oppositeToMomentum,0.1057,&(*magfield) ); 	
-    thePropagatorOp=    new PropagatorWithMaterial(alongMomentum,0.1057,&(*magfield) );
+
+  if (seedplus) {
+    seed_plus = true;
+    thePropagator = new PropagatorWithMaterial(alongMomentum, 0.1057, &(*magfield));
+    thePropagatorOp = new PropagatorWithMaterial(oppositeToMomentum, 0.1057, &(*magfield));
+  } else {
+    seed_plus = false;
+    thePropagator = new PropagatorWithMaterial(oppositeToMomentum, 0.1057, &(*magfield));
+    thePropagatorOp = new PropagatorWithMaterial(alongMomentum, 0.1057, &(*magfield));
   }
-  
-  theUpdator=       new KFUpdator();
-  theEstimator=     new Chi2MeasurementEstimator(chi2cut);
-  
+
+  theUpdator = new KFUpdator();
+  theEstimator = new Chi2MeasurementEstimator(chi2cut);
 
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
-  es.get<TransientRecHitRecord>().get(theBuilderName,theBuilder);
-  
+  es.get<TransientRecHitRecord>().get(theBuilderName, theBuilder);
 
-  RHBuilder=   theBuilder.product();
+  RHBuilder = theBuilder.product();
   hitCloner = static_cast<TkTransientTrackingRecHitBuilder const *>(RHBuilder)->cloner();
 
-
-
-  theFitter=        new KFTrajectoryFitter(*thePropagator,
-					   *theUpdator,	
-					   *theEstimator) ;
+  theFitter = new KFTrajectoryFitter(*thePropagator, *theUpdator, *theEstimator);
   theFitter->setHitCloner(&hitCloner);
 
-  theSmoother=      new KFTrajectorySmoother(*thePropagatorOp,
-					     *theUpdator,	
-					     *theEstimator);
+  theSmoother = new KFTrajectorySmoother(*thePropagatorOp, *theUpdator, *theEstimator);
   theSmoother->setHitCloner(&hitCloner);
 }
 
 void CosmicTrajectoryBuilder::run(const TrajectorySeedCollection &collseed,
-				  const SiStripRecHit2DCollection &collstereo,
-				  const SiStripRecHit2DCollection &collrphi ,
-				  const SiStripMatchedRecHit2DCollection &collmatched,
-				  const SiPixelRecHitCollection &collpixel,
-				  const edm::EventSetup& es,
-				  edm::Event& e,
-				  vector<Trajectory> &trajoutput)
-{
-
- 
-
-
+                                  const SiStripRecHit2DCollection &collstereo,
+                                  const SiStripRecHit2DCollection &collrphi,
+                                  const SiStripMatchedRecHit2DCollection &collmatched,
+                                  const SiPixelRecHitCollection &collpixel,
+                                  const edm::EventSetup &es,
+                                  edm::Event &e,
+                                  vector<Trajectory> &trajoutput) {
   std::vector<Trajectory> trajSmooth;
   std::vector<Trajectory>::iterator trajIter;
-  
+
   TrajectorySeedCollection::const_iterator iseed;
-  unsigned int IS=0;
-  for(iseed=collseed.begin();iseed!=collseed.end();iseed++){
-    bool seedplus=((*iseed).direction()==alongMomentum);
-    init(es,seedplus);
+  unsigned int IS = 0;
+  for (iseed = collseed.begin(); iseed != collseed.end(); iseed++) {
+    bool seedplus = ((*iseed).direction() == alongMomentum);
+    init(es, seedplus);
     hits.clear();
     trajFit.clear();
     trajSmooth.clear();
     //order all the hits
-    vector<const TrackingRecHit*> allHits= SortHits(collstereo,collrphi,collmatched,collpixel,*iseed);
+    vector<const TrackingRecHit *> allHits = SortHits(collstereo, collrphi, collmatched, collpixel, *iseed);
     Trajectory startingTraj = createStartingTrajectory(*iseed);
-    AddHit(startingTraj,allHits);
-    for (trajIter=trajFit.begin(); trajIter!=trajFit.end();trajIter++){
-      trajSmooth=theSmoother->trajectories((*trajIter));
+    AddHit(startingTraj, allHits);
+    for (trajIter = trajFit.begin(); trajIter != trajFit.end(); trajIter++) {
+      trajSmooth = theSmoother->trajectories((*trajIter));
     }
-    for (trajIter= trajSmooth.begin(); trajIter!=trajSmooth.end();trajIter++){
-      if((*trajIter).isValid()){
-	trajoutput.push_back((*trajIter));
+    for (trajIter = trajSmooth.begin(); trajIter != trajSmooth.end(); trajIter++) {
+      if ((*trajIter).isValid()) {
+        trajoutput.push_back((*trajIter));
       }
     }
     delete theUpdator;
@@ -122,217 +103,189 @@ void CosmicTrajectoryBuilder::run(const TrajectorySeedCollection &collseed,
     delete theFitter;
     delete theSmoother;
     //Only the first 30 seeds are considered
-    if (IS>30) return;
+    if (IS > 30)
+      return;
     IS++;
-
   }
 }
 
-Trajectory CosmicTrajectoryBuilder::createStartingTrajectory( const TrajectorySeed& seed) const
-{
-  Trajectory result( seed, seed.direction()); 
-  std::vector<TM> && seedMeas = seedMeasurements(seed);
-  for (auto & i : seedMeas) result.push(std::move(i));
+Trajectory CosmicTrajectoryBuilder::createStartingTrajectory(const TrajectorySeed &seed) const {
+  Trajectory result(seed, seed.direction());
+  std::vector<TM> &&seedMeas = seedMeasurements(seed);
+  for (auto &i : seedMeas)
+    result.push(std::move(i));
   return result;
 }
 
-
-std::vector<TrajectoryMeasurement> 
-CosmicTrajectoryBuilder::seedMeasurements(const TrajectorySeed& seed) const
-{
+std::vector<TrajectoryMeasurement> CosmicTrajectoryBuilder::seedMeasurements(const TrajectorySeed &seed) const {
   std::vector<TrajectoryMeasurement> result;
   TrajectorySeed::range hitRange = seed.recHits();
-  for (TrajectorySeed::const_iterator ihit = hitRange.first; 
-       ihit != hitRange.second; ihit++) {
+  for (TrajectorySeed::const_iterator ihit = hitRange.first; ihit != hitRange.second; ihit++) {
     //RC TransientTrackingRecHit* recHit = RHBuilder->build(&(*ihit));
     TransientTrackingRecHit::RecHitPointer recHit = RHBuilder->build(&(*ihit));
-    const GeomDet* hitGeomDet = (&(*tracker))->idToDet( ihit->geographicalId());
-    TSOS invalidState(new BasicSingleTrajectoryState( hitGeomDet->surface()));
+    const GeomDet *hitGeomDet = (&(*tracker))->idToDet(ihit->geographicalId());
+    TSOS invalidState(new BasicSingleTrajectoryState(hitGeomDet->surface()));
 
     if (ihit == hitRange.second - 1) {
-      TSOS  updatedState=startingTSOS(seed);
+      TSOS updatedState = startingTSOS(seed);
       result.emplace_back(invalidState, updatedState, recHit);
-    } 
-    else {
+    } else {
       result.emplace_back(invalidState, recHit);
     }
-    
   }
 
   return result;
 }
 
-
-
-
-
-vector<const TrackingRecHit*> 
-CosmicTrajectoryBuilder::SortHits(const SiStripRecHit2DCollection &collstereo,
-				  const SiStripRecHit2DCollection &collrphi ,
-				  const SiStripMatchedRecHit2DCollection &collmatched,
-				  const SiPixelRecHitCollection &collpixel,
-				  const TrajectorySeed &seed){
-
-
+vector<const TrackingRecHit *> CosmicTrajectoryBuilder::SortHits(const SiStripRecHit2DCollection &collstereo,
+                                                                 const SiStripRecHit2DCollection &collrphi,
+                                                                 const SiStripMatchedRecHit2DCollection &collmatched,
+                                                                 const SiPixelRecHitCollection &collpixel,
+                                                                 const TrajectorySeed &seed) {
   //The Hits with global y more than the seed are discarded
   //The Hits correspondign to the seed are discarded
   //At the end all the hits are sorted in y
-  vector<const TrackingRecHit*> allHits;
+  vector<const TrackingRecHit *> allHits;
 
   SiStripRecHit2DCollection::DataContainer::const_iterator istrip;
-  TrajectorySeed::range hRange= seed.recHits();
+  TrajectorySeed::range hRange = seed.recHits();
   TrajectorySeed::const_iterator ihit;
-  float yref=0.;
-  for (ihit = hRange.first; 
-       ihit != hRange.second; ihit++) {
-    yref=RHBuilder->build(&(*ihit))->globalPosition().y();
-    hits.push_back((RHBuilder->build(&(*ihit)))); 
-    LogDebug("CosmicTrackFinder")<<"SEED HITS"<<RHBuilder->build(&(*ihit))->globalPosition();
+  float yref = 0.;
+  for (ihit = hRange.first; ihit != hRange.second; ihit++) {
+    yref = RHBuilder->build(&(*ihit))->globalPosition().y();
+    hits.push_back((RHBuilder->build(&(*ihit))));
+    LogDebug("CosmicTrackFinder") << "SEED HITS" << RHBuilder->build(&(*ihit))->globalPosition();
   }
 
-  
   SiPixelRecHitCollection::DataContainer::const_iterator ipix;
-  for(ipix=collpixel.data().begin();ipix!=collpixel.data().end();ipix++){
-    float ych= RHBuilder->build(&(*ipix))->globalPosition().y();
-    if ((seed_plus && (ych<yref)) || (!(seed_plus) && (ych>yref)))
+  for (ipix = collpixel.data().begin(); ipix != collpixel.data().end(); ipix++) {
+    float ych = RHBuilder->build(&(*ipix))->globalPosition().y();
+    if ((seed_plus && (ych < yref)) || (!(seed_plus) && (ych > yref)))
       allHits.push_back(&(*ipix));
   }
-  
-  for(istrip=collrphi.data().begin();istrip!=collrphi.data().end();istrip++){
-    float ych= RHBuilder->build(&(*istrip))->globalPosition().y();
-    if ((seed_plus && (ych<yref)) || (!(seed_plus) && (ych>yref)))
-      allHits.push_back(&(*istrip));   
+
+  for (istrip = collrphi.data().begin(); istrip != collrphi.data().end(); istrip++) {
+    float ych = RHBuilder->build(&(*istrip))->globalPosition().y();
+    if ((seed_plus && (ych < yref)) || (!(seed_plus) && (ych > yref)))
+      allHits.push_back(&(*istrip));
   }
-  
-  for(istrip=collstereo.data().begin();istrip!=collstereo.data().end();istrip++){
-    float ych= RHBuilder->build(&(*istrip))->globalPosition().y();
-    if ((seed_plus && (ych<yref)) || (!(seed_plus) && (ych>yref)))
+
+  for (istrip = collstereo.data().begin(); istrip != collstereo.data().end(); istrip++) {
+    float ych = RHBuilder->build(&(*istrip))->globalPosition().y();
+    if ((seed_plus && (ych < yref)) || (!(seed_plus) && (ych > yref)))
       allHits.push_back(&(*istrip));
   }
 
   if (seed_plus)
-    stable_sort(allHits.begin(),allHits.end(),CompareHitY_plus(*tracker));
-  else 
-    stable_sort(allHits.begin(),allHits.end(),CompareHitY(*tracker));
+    stable_sort(allHits.begin(), allHits.end(), CompareHitY_plus(*tracker));
+  else
+    stable_sort(allHits.begin(), allHits.end(), CompareHitY(*tracker));
 
   return allHits;
 }
 
-TrajectoryStateOnSurface
-CosmicTrajectoryBuilder::startingTSOS(const TrajectorySeed& seed)const
-{
-  PTrajectoryStateOnDet pState( seed.startingState());
-  const GeomDet* gdet  = (&(*tracker))->idToDet(DetId(pState.detId()));
-  TSOS  State= trajectoryStateTransform::transientState( pState, &(gdet->surface()), 
-					   &(*magfield));
+TrajectoryStateOnSurface CosmicTrajectoryBuilder::startingTSOS(const TrajectorySeed &seed) const {
+  PTrajectoryStateOnDet pState(seed.startingState());
+  const GeomDet *gdet = (&(*tracker))->idToDet(DetId(pState.detId()));
+  TSOS State = trajectoryStateTransform::transientState(pState, &(gdet->surface()), &(*magfield));
   return State;
-
 }
 
-void CosmicTrajectoryBuilder::AddHit(Trajectory &traj,
-				     const vector<const TrackingRecHit*>&Hits){
-
-
+void CosmicTrajectoryBuilder::AddHit(Trajectory &traj, const vector<const TrackingRecHit *> &Hits) {
   unsigned int icosm2;
   unsigned int ibestdet;
   float chi2min;
-  for (unsigned int icosmhit=0;icosmhit<Hits.size();icosmhit++){
-    GlobalPoint gphit=RHBuilder->build(Hits[icosmhit])->globalPosition();
-    unsigned int iraw= Hits[icosmhit]->geographicalId().rawId();
-    LogDebug("CosmicTrackFinder")<<" HIT POSITION "<< gphit;
+  for (unsigned int icosmhit = 0; icosmhit < Hits.size(); icosmhit++) {
+    GlobalPoint gphit = RHBuilder->build(Hits[icosmhit])->globalPosition();
+    unsigned int iraw = Hits[icosmhit]->geographicalId().rawId();
+    LogDebug("CosmicTrackFinder") << " HIT POSITION " << gphit;
     //RC TransientTrackingRecHit* tmphit=RHBuilder->build(Hits[icosmhit]);
-    TransientTrackingRecHit::RecHitPointer tmphit=RHBuilder->build(Hits[icosmhit]);
-     TSOS prSt= thePropagator->propagate(traj.lastMeasurement().updatedState(),
- 					tracker->idToDet(Hits[icosmhit]->geographicalId())->surface());
+    TransientTrackingRecHit::RecHitPointer tmphit = RHBuilder->build(Hits[icosmhit]);
+    TSOS prSt = thePropagator->propagate(traj.lastMeasurement().updatedState(),
+                                         tracker->idToDet(Hits[icosmhit]->geographicalId())->surface());
 
     //After propagating the trajectory to a detector,
     //find the most compatible hit in the det
-    chi2min=20000000;
-    ibestdet=1000;
-     if (prSt.isValid()){
-       LocalPoint  prLoc = prSt.localPosition();
-       LogDebug("CosmicTrackFinder") <<"STATE PROPAGATED AT DET "<<iraw<<" "<<prSt;
-       for(icosm2=icosmhit;icosm2<Hits.size();icosm2++){
+    chi2min = 20000000;
+    ibestdet = 1000;
+    if (prSt.isValid()) {
+      LocalPoint prLoc = prSt.localPosition();
+      LogDebug("CosmicTrackFinder") << "STATE PROPAGATED AT DET " << iraw << " " << prSt;
+      for (icosm2 = icosmhit; icosm2 < Hits.size(); icosm2++) {
+        if (iraw == Hits[icosm2]->geographicalId().rawId()) {
+          TransientTrackingRecHit::RecHitPointer tmphit = RHBuilder->build(Hits[icosm2]);
+          float contr = theEstimator->estimate(prSt, *tmphit).second;
+          if (contr < chi2min) {
+            chi2min = contr;
+            ibestdet = icosm2;
+          }
+          if (icosm2 != icosmhit)
+            icosmhit++;
 
-	 if (iraw==Hits[icosm2]->geographicalId().rawId()){	  
-	   TransientTrackingRecHit::RecHitPointer tmphit=RHBuilder->build(Hits[icosm2]);
-	   float contr= theEstimator->estimate(prSt, *tmphit).second;
-	   if (contr<chi2min) {
-	     chi2min=contr;
-	     ibestdet=icosm2;
-	   }
-	   if (icosm2!=icosmhit)	icosmhit++;
+        } else
+          icosm2 = Hits.size();
+      }
 
-	 }
-	 else  icosm2=Hits.size();
-       }
+      if (chi2min < chi2cut)
+        LogDebug("CosmicTrackFinder") << "Chi2 contribution for hit at "
+                                      << RHBuilder->build(Hits[ibestdet])->globalPosition() << " is " << chi2min;
 
-       if(chi2min<chi2cut) 
-	 LogDebug("CosmicTrackFinder")<<"Chi2 contribution for hit at "
-				      <<RHBuilder->build(Hits[ibestdet])->globalPosition()
-				      <<" is "<<chi2min;
+      if (traj.foundHits() < 3 && (chi2min < chi2cut)) {
+        //check on the first hit after the seed
+        GlobalVector ck = RHBuilder->build(Hits[ibestdet])->globalPosition() -
+                          traj.firstMeasurement().updatedState().globalPosition();
+        if ((abs(ck.x() / ck.y()) > 2) || (abs(ck.z() / ck.y()) > 2))
+          chi2min = 300;
+      }
+      if (chi2min < chi2cut) {
+        if (abs(prLoc.x()) < 25 && abs(prLoc.y()) < 25) {
+          TransientTrackingRecHit::RecHitPointer tmphitbestdet = RHBuilder->build(Hits[ibestdet]);
+          TSOS UpdatedState = theUpdator->update(prSt, *tmphitbestdet);
+          if (UpdatedState.isValid()) {
+            traj.push(TM(prSt, UpdatedState, RHBuilder->build(Hits[ibestdet]), chi2min));
+            LogDebug("CosmicTrackFinder") << "STATE UPDATED WITH HIT AT POSITION " << tmphitbestdet->globalPosition()
+                                          << UpdatedState << " " << traj.chiSquared();
 
-       if(traj.foundHits()<3 &&(chi2min<chi2cut)){
-	 //check on the first hit after the seed
- 	 GlobalVector ck=RHBuilder->build(Hits[ibestdet])->globalPosition()-
-	   traj.firstMeasurement().updatedState().globalPosition();
-	 if ((abs(ck.x()/ck.y())>2)||(abs(ck.z()/ck.y())>2))  chi2min=300;
-       }
-       if (chi2min<chi2cut){
-	 if ( abs(prLoc.x()) < 25  && abs(prLoc.y()) < 25 ){
-	   TransientTrackingRecHit::RecHitPointer tmphitbestdet=RHBuilder->build(Hits[ibestdet]);
-	   TSOS UpdatedState= theUpdator->update( prSt, *tmphitbestdet);
-	   if (UpdatedState.isValid()){
-
-	     traj.push(TM(prSt,UpdatedState,RHBuilder->build(Hits[ibestdet])
-			  , chi2min));
-	     LogDebug("CosmicTrackFinder") <<
-	       "STATE UPDATED WITH HIT AT POSITION "
-					   <<tmphitbestdet->globalPosition()
-					   <<UpdatedState<<" "
-					   <<traj.chiSquared();
-
-	     hits.push_back(tmphitbestdet);
-	   }
-	 }else LogDebug("CosmicTrackFinder")<<" Hits outside module surface "<< prLoc;
-       }else LogDebug("CosmicTrackFinder")<<" State can not be updated with hit at position " <<gphit;
-     }else LogDebug("CosmicTrackFinder")<<" State can not be propagated at det "<< iraw;    
+            hits.push_back(tmphitbestdet);
+          }
+        } else
+          LogDebug("CosmicTrackFinder") << " Hits outside module surface " << prLoc;
+      } else
+        LogDebug("CosmicTrackFinder") << " State can not be updated with hit at position " << gphit;
+    } else
+      LogDebug("CosmicTrackFinder") << " State can not be propagated at det " << iraw;
   }
-  
-  
 
-  if ( qualityFilter( traj)){
-    const TrajectorySeed& tmpseed=traj.seed();
-    if (thePropagatorOp->propagate(traj.lastMeasurement().updatedState(),
-				   tracker->idToDet((*hits.begin())->geographicalId())->surface()).isValid()){
-      TSOS startingState= 
-	thePropagatorOp->propagate(traj.lastMeasurement().updatedState(),
-				   tracker->idToDet((*hits.begin())->geographicalId())->surface());
-      
-      trajFit = theFitter->fit(tmpseed,hits, startingState );
+  if (qualityFilter(traj)) {
+    const TrajectorySeed &tmpseed = traj.seed();
+    if (thePropagatorOp
+            ->propagate(traj.lastMeasurement().updatedState(),
+                        tracker->idToDet((*hits.begin())->geographicalId())->surface())
+            .isValid()) {
+      TSOS startingState = thePropagatorOp->propagate(traj.lastMeasurement().updatedState(),
+                                                      tracker->idToDet((*hits.begin())->geographicalId())->surface());
+
+      trajFit = theFitter->fit(tmpseed, hits, startingState);
     }
   }
-  
 }
 
-
-bool 
-CosmicTrajectoryBuilder::qualityFilter(const Trajectory& traj){
-  int ngoodhits=0;
-  if(geometry=="MTCC"){
+bool CosmicTrajectoryBuilder::qualityFilter(const Trajectory &traj) {
+  int ngoodhits = 0;
+  if (geometry == "MTCC") {
     auto hits = traj.recHits();
-    for(auto hit=hits.begin();hit!=hits.end();hit++){
-      unsigned int iid=(*hit)->hit()->geographicalId().rawId();
+    for (auto hit = hits.begin(); hit != hits.end(); hit++) {
+      unsigned int iid = (*hit)->hit()->geographicalId().rawId();
       //CHECK FOR 3 hits r-phi
-      if(((iid>>0)&0x3)!=1) ngoodhits++;
+      if (((iid >> 0) & 0x3) != 1)
+        ngoodhits++;
     }
-  }
-  else ngoodhits=traj.foundHits();
-  
-  if ( ngoodhits >= theMinHits) {
+  } else
+    ngoodhits = traj.foundHits();
+
+  if (ngoodhits >= theMinHits) {
     return true;
-  }
-  else {
+  } else {
     return false;
   }
 }

--- a/RecoTracker/TkHitPairs/interface/CombinedHitPairGenerator.h
+++ b/RecoTracker/TkHitPairs/interface/CombinedHitPairGenerator.h
@@ -7,12 +7,14 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
-
 class TrackingRegion;
 class OrderedHitPairs;
 class HitPairGeneratorFromLayerPair;
 class SeedingLayerSetsHits;
-namespace edm { class Event; class EventSetup; }
+namespace edm {
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
 #include <memory>
 
@@ -25,21 +27,22 @@ public:
   typedef LayerHitMapCache LayerCacheType;
 
 public:
-  CombinedHitPairGenerator(const edm::ParameterSet & cfg, edm::ConsumesCollector& iC);
+  CombinedHitPairGenerator(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
   ~CombinedHitPairGenerator() override;
 
   /// form base class
-  void hitPairs( const TrackingRegion& reg, 
-      OrderedHitPairs & result, const edm::Event& ev, const edm::EventSetup& es) override;
+  void hitPairs(const TrackingRegion& reg,
+                OrderedHitPairs& result,
+                const edm::Event& ev,
+                const edm::EventSetup& es) override;
 
 private:
-  CombinedHitPairGenerator(const CombinedHitPairGenerator & cb); 
+  CombinedHitPairGenerator(const CombinedHitPairGenerator& cb);
 
   edm::EDGetTokenT<SeedingLayerSetsHits> theSeedingLayerToken;
 
-  LayerCacheType   theLayerCache;
+  LayerCacheType theLayerCache;
 
   std::unique_ptr<HitPairGeneratorFromLayerPair> theGenerator;
-
 };
 #endif

--- a/RecoTracker/TkHitPairs/interface/CosmicHitPairGenerator.h
+++ b/RecoTracker/TkHitPairs/interface/CosmicHitPairGenerator.h
@@ -10,35 +10,26 @@ class LayerWithHits;
 class DetLayer;
 class TrackingRegion;
 
-
 /** \class CosmicHitPairGenerator
  * Hides set of HitPairGeneratorFromLayerPair generators.
  */
 
 class CosmicHitPairGenerator {
-
-  typedef std::vector<std::unique_ptr<CosmicHitPairGeneratorFromLayerPair> >   Container;
+  typedef std::vector<std::unique_ptr<CosmicHitPairGeneratorFromLayerPair> > Container;
 
 public:
   CosmicHitPairGenerator(SeedLayerPairs& layers, const edm::EventSetup& iSetup);
   CosmicHitPairGenerator(SeedLayerPairs& layers);
 
-
   ~CosmicHitPairGenerator();
 
   /// add generators based on layers
-    //  void  add(const DetLayer* inner, const DetLayer* outer);
-    void  add(const LayerWithHits* inner, 
-	      const LayerWithHits* outer,
-	      const edm::EventSetup& iSetup);
+  //  void  add(const DetLayer* inner, const DetLayer* outer);
+  void add(const LayerWithHits* inner, const LayerWithHits* outer, const edm::EventSetup& iSetup);
   /// form base class
-  void hitPairs( const TrackingRegion& reg,
-		 OrderedHitPairs & prs,
-		 const edm::EventSetup& iSetup);
+  void hitPairs(const TrackingRegion& reg, OrderedHitPairs& prs, const edm::EventSetup& iSetup);
+
 private:
-
-
-  Container        theGenerators;
-
+  Container theGenerators;
 };
 #endif

--- a/RecoTracker/TkHitPairs/interface/CosmicHitPairGeneratorFromLayerPair.h
+++ b/RecoTracker/TkHitPairs/interface/CosmicHitPairGeneratorFromLayerPair.h
@@ -11,59 +11,52 @@
 class DetLayer;
 class TrackingRegion;
 class LayerWithHits;
- class CompareHitPairsY {
- public:
-   CompareHitPairsY(const edm::EventSetup& iSetup){    
-
-     iSetup.get<TrackerDigiGeometryRecord>().get(tracker);};
-   bool operator()( const OrderedHitPair& h1,
-		    const OrderedHitPair& h2)
-   {      
-     const TrackingRecHit * trh1i = h1.inner()->hit();
-     const TrackingRecHit * trh2i = h2.inner()->hit();
-     const TrackingRecHit * trh1o = h1.outer()->hit();
-     const TrackingRecHit * trh2o = h2.outer()->hit();
-     GlobalPoint in1p=tracker->idToDet(trh1i->geographicalId())->surface().toGlobal(trh1i->localPosition());
-     GlobalPoint in2p=tracker->idToDet(trh2i->geographicalId())->surface().toGlobal(trh2i->localPosition());
-     GlobalPoint ou1p=tracker->idToDet(trh1o->geographicalId())->surface().toGlobal(trh1o->localPosition());
-     GlobalPoint ou2p=tracker->idToDet(trh2o->geographicalId())->surface().toGlobal(trh2o->localPosition());
-     if (ou1p.y()*ou2p.y()<0) return ou1p.y()>ou2p.y();
-     else{
-       float dist1=100*std::abs(ou1p.z()-in1p.z())-std::abs(ou1p.y())-0.1*std::abs(in1p.y());
-       float dist2=100*std::abs(ou2p.z()-in2p.z())-std::abs(ou2p.y())-0.1*std::abs(in2p.y());
-       return dist1 < dist2;
-     }
-   }
- private:
-   edm::ESHandle<TrackerGeometry> tracker;
- };
-class CosmicHitPairGeneratorFromLayerPair {
-
+class CompareHitPairsY {
 public:
+  CompareHitPairsY(const edm::EventSetup& iSetup) { iSetup.get<TrackerDigiGeometryRecord>().get(tracker); };
+  bool operator()(const OrderedHitPair& h1, const OrderedHitPair& h2) {
+    const TrackingRecHit* trh1i = h1.inner()->hit();
+    const TrackingRecHit* trh2i = h2.inner()->hit();
+    const TrackingRecHit* trh1o = h1.outer()->hit();
+    const TrackingRecHit* trh2o = h2.outer()->hit();
+    GlobalPoint in1p = tracker->idToDet(trh1i->geographicalId())->surface().toGlobal(trh1i->localPosition());
+    GlobalPoint in2p = tracker->idToDet(trh2i->geographicalId())->surface().toGlobal(trh2i->localPosition());
+    GlobalPoint ou1p = tracker->idToDet(trh1o->geographicalId())->surface().toGlobal(trh1o->localPosition());
+    GlobalPoint ou2p = tracker->idToDet(trh2o->geographicalId())->surface().toGlobal(trh2o->localPosition());
+    if (ou1p.y() * ou2p.y() < 0)
+      return ou1p.y() > ou2p.y();
+    else {
+      float dist1 = 100 * std::abs(ou1p.z() - in1p.z()) - std::abs(ou1p.y()) - 0.1 * std::abs(in1p.y());
+      float dist2 = 100 * std::abs(ou2p.z() - in2p.z()) - std::abs(ou2p.y()) - 0.1 * std::abs(in2p.y());
+      return dist1 < dist2;
+    }
+  }
 
-
-  CosmicHitPairGeneratorFromLayerPair( 
-				const LayerWithHits* inner, 
-				const LayerWithHits* outer, 
-				const edm::EventSetup& iSetup);
+private:
+  edm::ESHandle<TrackerGeometry> tracker;
+};
+class CosmicHitPairGeneratorFromLayerPair {
+public:
+  CosmicHitPairGeneratorFromLayerPair(const LayerWithHits* inner,
+                                      const LayerWithHits* outer,
+                                      const edm::EventSetup& iSetup);
   ~CosmicHitPairGeneratorFromLayerPair();
 
-//  virtual OrderedHitPairs hitPairs( const TrackingRegion& region,const edm::EventSetup& iSetup ) {
-//    return HitPairGenerator::hitPairs(region, iSetup);
-//  }
-  void hitPairs( const TrackingRegion& ar, OrderedHitPairs & ap, const edm::EventSetup& iSetup);
+  //  virtual OrderedHitPairs hitPairs( const TrackingRegion& region,const edm::EventSetup& iSetup ) {
+  //    return HitPairGenerator::hitPairs(region, iSetup);
+  //  }
+  void hitPairs(const TrackingRegion& ar, OrderedHitPairs& ap, const edm::EventSetup& iSetup);
 
   const LayerWithHits* innerLayer() const { return theInnerLayer; }
   const LayerWithHits* outerLayer() const { return theOuterLayer; }
 
 private:
-  const TransientTrackingRecHitBuilder * TTRHbuilder;
+  const TransientTrackingRecHitBuilder* TTRHbuilder;
   const TrackerGeometry* trackerGeometry;
-  const LayerWithHits* theOuterLayer;  
-  const LayerWithHits* theInnerLayer; 
+  const LayerWithHits* theOuterLayer;
+  const LayerWithHits* theInnerLayer;
   const DetLayer* innerlay;
   const DetLayer* outerlay;
-
 };
 
 #endif

--- a/RecoTracker/TkHitPairs/interface/CosmicLayerPairs.h
+++ b/RecoTracker/TkHitPairs/interface/CosmicLayerPairs.h
@@ -16,60 +16,54 @@
 
 class TrackerTopology;
 
-class CosmicLayerPairs : public SeedLayerPairs{
+class CosmicLayerPairs : public SeedLayerPairs {
 public:
-  CosmicLayerPairs(std::string geometry):_geometry(geometry){};//:isFirstCall(true){};
+  CosmicLayerPairs(std::string geometry) : _geometry(geometry){};  //:isFirstCall(true){};
   ~CosmicLayerPairs() override;
   //  explicit PixelSeedLayerPairs(const edm::EventSetup& iSetup);
 
-
-
   //  virtual vector<LayerPair> operator()() const;
-  std::vector<SeedLayerPairs::LayerPair> operator()() override ;
+  std::vector<SeedLayerPairs::LayerPair> operator()() override;
   void init(const SiStripRecHit2DCollection &collstereo,
-             const SiStripRecHit2DCollection &collrphi,
-             const SiStripMatchedRecHit2DCollection &collmatched,
-             //std::string geometry,
-             const edm::EventSetup& iSetup);
+            const SiStripRecHit2DCollection &collrphi,
+            const SiStripMatchedRecHit2DCollection &collmatched,
+            //std::string geometry,
+            const edm::EventSetup &iSetup);
 
 private:
+  //bool isFirstCall;
+  std::string _geometry;
 
-   //bool isFirstCall;
-   std::string _geometry;
+  std::vector<BarrelDetLayer const *> bl;
+  std::vector<ForwardDetLayer const *> fpos;
+  std::vector<ForwardDetLayer const *> fneg;
+  edm::OwnVector<LayerWithHits> TECPlusLayerWithHits;
+  edm::OwnVector<LayerWithHits> TECMinusLayerWithHits;
+  edm::OwnVector<LayerWithHits> TIBLayerWithHits;
+  edm::OwnVector<LayerWithHits> TOBLayerWithHits;
+  edm::OwnVector<LayerWithHits> MTCCLayerWithHits;
+  edm::OwnVector<LayerWithHits> CRACKLayerWithHits;
 
-   std::vector<BarrelDetLayer const*> bl;
-   std::vector<ForwardDetLayer const*> fpos;
-   std::vector<ForwardDetLayer const*> fneg;
-   edm::OwnVector<LayerWithHits> TECPlusLayerWithHits;
-   edm::OwnVector<LayerWithHits> TECMinusLayerWithHits;
-   edm::OwnVector<LayerWithHits> TIBLayerWithHits;
-   edm::OwnVector<LayerWithHits> TOBLayerWithHits;
-   edm::OwnVector<LayerWithHits> MTCCLayerWithHits;
-   edm::OwnVector<LayerWithHits> CRACKLayerWithHits;
-
-   std::vector<const TrackingRecHit*> selectTECHit(const SiStripRecHit2DCollection &collrphi,
-                                                   const TrackerTopology& ttopo,
-                                                                int side,
-                                                                int disk);
-   std::vector<const TrackingRecHit*> selectTIBHit(const SiStripRecHit2DCollection &collrphi,
-                                                   const TrackerTopology& ttopo,
-								int layer);
-   std::vector<const TrackingRecHit*> selectTOBHit(const SiStripRecHit2DCollection &collrphi,
-                                                   const TrackerTopology& ttopo,
-                                                                int layer);
-   std::vector<const TrackingRecHit*> selectTECHit(const SiStripMatchedRecHit2DCollection &collmatch,
-                                                   const TrackerTopology& ttopo,
-                                                                int side,
-                                                                int disk);
-   std::vector<const TrackingRecHit*> selectTIBHit(const SiStripMatchedRecHit2DCollection &collmatch,
-                                                   const TrackerTopology& ttopo,
-                                                                int layer);
-   std::vector<const TrackingRecHit*> selectTOBHit(const SiStripMatchedRecHit2DCollection &collmatch,
-                                                   const TrackerTopology& ttopo,
-                                                                int layer);	
+  std::vector<const TrackingRecHit *> selectTECHit(const SiStripRecHit2DCollection &collrphi,
+                                                   const TrackerTopology &ttopo,
+                                                   int side,
+                                                   int disk);
+  std::vector<const TrackingRecHit *> selectTIBHit(const SiStripRecHit2DCollection &collrphi,
+                                                   const TrackerTopology &ttopo,
+                                                   int layer);
+  std::vector<const TrackingRecHit *> selectTOBHit(const SiStripRecHit2DCollection &collrphi,
+                                                   const TrackerTopology &ttopo,
+                                                   int layer);
+  std::vector<const TrackingRecHit *> selectTECHit(const SiStripMatchedRecHit2DCollection &collmatch,
+                                                   const TrackerTopology &ttopo,
+                                                   int side,
+                                                   int disk);
+  std::vector<const TrackingRecHit *> selectTIBHit(const SiStripMatchedRecHit2DCollection &collmatch,
+                                                   const TrackerTopology &ttopo,
+                                                   int layer);
+  std::vector<const TrackingRecHit *> selectTOBHit(const SiStripMatchedRecHit2DCollection &collmatch,
+                                                   const TrackerTopology &ttopo,
+                                                   int layer);
 };
-
-
-
 
 #endif

--- a/RecoTracker/TkHitPairs/interface/HitPairGenerator.h
+++ b/RecoTracker/TkHitPairs/interface/HitPairGenerator.h
@@ -15,28 +15,30 @@
 #include "FWCore/Utilities/interface/RunningAverage.h"
 
 class TrackingRegion;
-namespace edm { class Event; class EventSetup; }
+namespace edm {
+  class Event;
+  class EventSetup;
+}  // namespace edm
 
 class HitPairGenerator : public OrderedHitsGenerator {
 public:
+  explicit HitPairGenerator(unsigned int size = 4000);
+  HitPairGenerator(HitPairGenerator const& other) : localRA(other.localRA.mean()) {}
 
-  explicit HitPairGenerator(unsigned int size=4000);
-  HitPairGenerator(HitPairGenerator const & other) : localRA(other.localRA.mean()){}
+  ~HitPairGenerator() override {}
 
-  ~HitPairGenerator() override { }
+  const OrderedHitPairs& run(const TrackingRegion& region, const edm::Event& ev, const edm::EventSetup& es) override;
 
-  const OrderedHitPairs & run(
-    const TrackingRegion& region, const edm::Event & ev, const edm::EventSetup& es) override;
-
-  virtual void hitPairs( const TrackingRegion& reg, OrderedHitPairs & prs, 
-      const edm::Event & ev,  const edm::EventSetup& es) = 0;
+  virtual void hitPairs(const TrackingRegion& reg,
+                        OrderedHitPairs& prs,
+                        const edm::Event& ev,
+                        const edm::EventSetup& es) = 0;
 
   void clear() final;
 
 private:
   OrderedHitPairs thePairs;
   edm::RunningAverage localRA;
-
 };
 
 #endif

--- a/RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h
+++ b/RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h
@@ -9,9 +9,7 @@ class DetLayer;
 class TrackingRegion;
 
 class HitPairGeneratorFromLayerPair {
-
 public:
-
   typedef LayerHitMapCache LayerCacheType;
   typedef SeedingLayerSetsHits::SeedingLayerSet Layers;
   typedef SeedingLayerSetsHits::SeedingLayer Layer;
@@ -19,48 +17,54 @@ public:
   HitPairGeneratorFromLayerPair(unsigned int inner,
                                 unsigned int outer,
                                 LayerCacheType* layerCache,
-				unsigned int max=0);
+                                unsigned int max = 0);
 
   ~HitPairGeneratorFromLayerPair();
 
-  HitDoublets doublets( const TrackingRegion& reg,
-                        const edm::Event & ev,  const edm::EventSetup& es, Layers layers) {
+  HitDoublets doublets(const TrackingRegion& reg, const edm::Event& ev, const edm::EventSetup& es, Layers layers) {
     assert(theLayerCache);
     return doublets(reg, ev, es, layers, *theLayerCache);
   }
-  HitDoublets doublets( const TrackingRegion& reg,
-                        const edm::Event & ev,  const edm::EventSetup& es, const Layer& innerLayer, const Layer& outerLayer) {
+  HitDoublets doublets(const TrackingRegion& reg,
+                       const edm::Event& ev,
+                       const edm::EventSetup& es,
+                       const Layer& innerLayer,
+                       const Layer& outerLayer) {
     assert(theLayerCache);
     return doublets(reg, ev, es, innerLayer, outerLayer, *theLayerCache);
   }
-  HitDoublets doublets( const TrackingRegion& reg,
-                        const edm::Event & ev, const edm::EventSetup& es, Layers layers, LayerCacheType& layerCache) {
+  HitDoublets doublets(const TrackingRegion& reg,
+                       const edm::Event& ev,
+                       const edm::EventSetup& es,
+                       Layers layers,
+                       LayerCacheType& layerCache) {
     Layer innerLayerObj = innerLayer(layers);
     Layer outerLayerObj = outerLayer(layers);
     return doublets(reg, ev, es, innerLayerObj, outerLayerObj, layerCache);
   }
-  HitDoublets doublets( const TrackingRegion& reg,
-                        const edm::Event & ev,  const edm::EventSetup& es, const Layer& innerLayer, const Layer& outerLayer, LayerCacheType& layerCache);
-  
-  void hitPairs( const TrackingRegion& reg, OrderedHitPairs & prs,
-                 const edm::Event & ev,  const edm::EventSetup& es, Layers layers);
-  static void doublets(
-						      const TrackingRegion& region,
-						      const DetLayer & innerHitDetLayer,
-						      const DetLayer & outerHitDetLayer,
-						      const RecHitsSortedInPhi & innerHitsMap,
-						      const RecHitsSortedInPhi & outerHitsMap,
-						      const edm::EventSetup& iSetup,
-						      const unsigned int theMaxElement,
-						      HitDoublets & result);
+  HitDoublets doublets(const TrackingRegion& reg,
+                       const edm::Event& ev,
+                       const edm::EventSetup& es,
+                       const Layer& innerLayer,
+                       const Layer& outerLayer,
+                       LayerCacheType& layerCache);
 
-  
-  
+  void hitPairs(
+      const TrackingRegion& reg, OrderedHitPairs& prs, const edm::Event& ev, const edm::EventSetup& es, Layers layers);
+  static void doublets(const TrackingRegion& region,
+                       const DetLayer& innerHitDetLayer,
+                       const DetLayer& outerHitDetLayer,
+                       const RecHitsSortedInPhi& innerHitsMap,
+                       const RecHitsSortedInPhi& outerHitsMap,
+                       const edm::EventSetup& iSetup,
+                       const unsigned int theMaxElement,
+                       HitDoublets& result);
+
   Layer innerLayer(const Layers& layers) const { return layers[theInnerLayer]; }
   Layer outerLayer(const Layers& layers) const { return layers[theOuterLayer]; }
 
 private:
-  LayerCacheType *theLayerCache;
+  LayerCacheType* theLayerCache;
   const unsigned int theOuterLayer;
   const unsigned int theInnerLayer;
   const unsigned int theMaxElement;

--- a/RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h
+++ b/RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h
@@ -15,11 +15,8 @@ namespace ihd {
    */
   class RegionIndex {
   public:
-    RegionIndex(const TrackingRegion *reg, unsigned int ind):
-      region_(reg),
-      layerSetBeginIndex_(ind),
-      layerSetEndIndex_(ind)
-    {}
+    RegionIndex(const TrackingRegion* reg, unsigned int ind)
+        : region_(reg), layerSetBeginIndex_(ind), layerSetEndIndex_(ind) {}
     RegionIndex(RegionIndex&&) = default;
     RegionIndex& operator=(RegionIndex&&) = default;
 
@@ -34,10 +31,10 @@ namespace ihd {
     unsigned int layerSetEndIndex() const { return layerSetEndIndex_; }
 
   private:
-    const TrackingRegion *region_;    /// pointer to TrackingRegion (owned elsewhere)
+    const TrackingRegion* region_;  /// pointer to TrackingRegion (owned elsewhere)
     LayerHitMapCache cache_;
-    unsigned int layerSetBeginIndex_; /// index of the beginning of layer sets of this region
-    unsigned int layerSetEndIndex_;   /// index of the end (one-past-last) of layer sets of this region
+    unsigned int layerSetBeginIndex_;  /// index of the beginning of layer sets of this region
+    unsigned int layerSetEndIndex_;    /// index of the end (one-past-last) of layer sets of this region
   };
 
   /**
@@ -54,8 +51,12 @@ namespace ihd {
 
     // Taking T* to have compatible interface with IntermediateHitTriplets::RegionLayerSets
     template <typename TMP>
-    RegionLayerSets(const TrackingRegion* region, const LayerHitMapCache *cache, const TMP*, const_iterator begin, const_iterator end):
-      region_(region), cache_(cache), layerSetsBegin_(begin), layerSetsEnd_(end) {}
+    RegionLayerSets(const TrackingRegion* region,
+                    const LayerHitMapCache* cache,
+                    const TMP*,
+                    const_iterator begin,
+                    const_iterator end)
+        : region_(region), cache_(cache), layerSetsBegin_(begin), layerSetsEnd_(end) {}
 
     const TrackingRegion& region() const { return *region_; }
     const LayerHitMapCache& layerHitMapCache() const { return *cache_; }
@@ -66,8 +67,8 @@ namespace ihd {
     const_iterator cend() const { return end(); }
 
   private:
-    const TrackingRegion *region_;
-    const LayerHitMapCache *cache_;
+    const TrackingRegion* region_;
+    const LayerHitMapCache* cache_;
     const const_iterator layerSetsBegin_;
     const const_iterator layerSetsEnd_;
   };
@@ -80,14 +81,14 @@ namespace ihd {
    * \tparam ValueType   Type to be returned by operator*() (should be something inexpensive)
    * \tparam HitSetType  Type of the holder of data (currently IntermediateHitDoublets, IntermediateHitTriplets, or RegionsSeedingHitSets)
    */
-  template<typename ValueType, typename HitSetType>
+  template <typename ValueType, typename HitSetType>
   class const_iterator {
   public:
     using internal_iterator_type = typename std::vector<RegionIndex>::const_iterator;
     using value_type = ValueType;
     using difference_type = internal_iterator_type::difference_type;
 
-    const_iterator(const HitSetType *hst, internal_iterator_type iter): hitSets_(hst), iter_(iter) {}
+    const_iterator(const HitSetType* hst, internal_iterator_type iter) : hitSets_(hst), iter_(iter) {}
 
     value_type operator*() const {
       return value_type(&(iter_->region()),
@@ -97,7 +98,10 @@ namespace ihd {
                         hitSets_->layerSetsBegin() + iter_->layerSetEndIndex());
     }
 
-    const_iterator& operator++() { ++iter_; return *this; }
+    const_iterator& operator++() {
+      ++iter_;
+      return *this;
+    }
     const_iterator operator++(int) {
       const_iterator clone(*this);
       ++iter_;
@@ -108,10 +112,10 @@ namespace ihd {
     bool operator!=(const const_iterator& other) const { return !operator==(other); }
 
   private:
-    const HitSetType *hitSets_;
+    const HitSetType* hitSets_;
     internal_iterator_type iter_;
   };
-}
+}  // namespace ihd
 
 /**
  * Container of temporary information delivered from hit pair
@@ -140,10 +144,8 @@ public:
    */
   class LayerPairHitDoublets {
   public:
-    LayerPairHitDoublets(const SeedingLayerSetsHits::SeedingLayerSet& layerSet, HitDoublets&& doublets):
-      layerPair_(layerSet[0].index(), layerSet[1].index()),
-      doublets_(std::move(doublets))
-    {}
+    LayerPairHitDoublets(const SeedingLayerSetsHits::SeedingLayerSet& layerSet, HitDoublets&& doublets)
+        : layerPair_(layerSet[0].index(), layerSet[1].index()), doublets_(std::move(doublets)) {}
 
     const LayerPair& layerPair() const { return layerPair_; }
     SeedingLayerSetsHits::LayerIndex innerLayerIndex() const { return std::get<0>(layerPair_); }
@@ -152,8 +154,8 @@ public:
     const HitDoublets& doublets() const { return doublets_; }
 
   private:
-    LayerPair layerPair_;  /// pair of indices to the layer
-    HitDoublets doublets_; /// container of the doublets
+    LayerPair layerPair_;   /// pair of indices to the layer
+    HitDoublets doublets_;  /// container of the doublets
   };
 
   ////////////////////
@@ -171,8 +173,8 @@ public:
   /// Helper class enforcing correct way of filling the doublets of a region
   class RegionFiller {
   public:
-    RegionFiller(): obj_(nullptr) {}
-    explicit RegionFiller(IntermediateHitDoublets *obj): obj_(obj) {}
+    RegionFiller() : obj_(nullptr) {}
+    explicit RegionFiller(IntermediateHitDoublets* obj) : obj_(obj) {}
 
     ~RegionFiller() = default;
 
@@ -184,8 +186,9 @@ public:
       obj_->layerPairs_.emplace_back(layerSet, std::move(doublets));
       obj_->regions_.back().setLayerSetsEnd(obj_->layerPairs_.size());
     }
+
   private:
-    IntermediateHitDoublets *obj_;
+    IntermediateHitDoublets* obj_;
   };
 
   // allows declaring local variables with auto
@@ -193,16 +196,16 @@ public:
 
   ////////////////////
 
-  IntermediateHitDoublets(): seedingLayers_(nullptr) {}
-  explicit IntermediateHitDoublets(const SeedingLayerSetsHits *seedingLayers): seedingLayers_(seedingLayers) {}
-  IntermediateHitDoublets(const IntermediateHitDoublets& rh); // only to make ROOT dictionary generation happy
+  IntermediateHitDoublets() : seedingLayers_(nullptr) {}
+  explicit IntermediateHitDoublets(const SeedingLayerSetsHits* seedingLayers) : seedingLayers_(seedingLayers) {}
+  IntermediateHitDoublets(const IntermediateHitDoublets& rh);  // only to make ROOT dictionary generation happy
   IntermediateHitDoublets(IntermediateHitDoublets&&) = default;
   IntermediateHitDoublets& operator=(IntermediateHitDoublets&&) = default;
   ~IntermediateHitDoublets() = default;
 
   void reserve(size_t nregions, size_t nlayersets) {
     regions_.reserve(nregions);
-    layerPairs_.reserve(nregions*nlayersets);
+    layerPairs_.reserve(nregions * nlayersets);
   }
 
   void shrink_to_fit() {
@@ -210,7 +213,7 @@ public:
     layerPairs_.shrink_to_fit();
   }
 
-  RegionFiller beginRegion(const TrackingRegion *region) {
+  RegionFiller beginRegion(const TrackingRegion* region) {
     regions_.emplace_back(region, layerPairs_.size());
     return RegionFiller(this);
   }
@@ -232,10 +235,10 @@ public:
   std::vector<LayerPairHitDoublets>::const_iterator layerSetsEnd() const { return layerPairs_.end(); }
 
 private:
-  const SeedingLayerSetsHits *seedingLayers_;    /// Pointer to SeedingLayerSetsHits (owned elsewhere)
+  const SeedingLayerSetsHits* seedingLayers_;  /// Pointer to SeedingLayerSetsHits (owned elsewhere)
 
-  std::vector<RegionIndex> regions_;             /// Container of regions, each element has indices pointing to layerPairs_
-  std::vector<LayerPairHitDoublets> layerPairs_; /// Container of layer pairs and doublets for all regions
+  std::vector<RegionIndex> regions_;  /// Container of regions, each element has indices pointing to layerPairs_
+  std::vector<LayerPairHitDoublets> layerPairs_;  /// Container of layer pairs and doublets for all regions
 };
 
 #endif

--- a/RecoTracker/TkHitPairs/interface/LayerHitMapCache.h
+++ b/RecoTracker/TkHitPairs/interface/LayerHitMapCache.h
@@ -12,87 +12,88 @@
 #include "DataFormats/TrackingRecHit/interface/mayown_ptr.h"
 
 class LayerHitMapCache {
-
 private:
-
   class SimpleCache {
   public:
     using ValueType = RecHitsSortedInPhi;
     using KeyType = int;
-    SimpleCache(unsigned int initSize) : theContainer(initSize){}
+    SimpleCache(unsigned int initSize) : theContainer(initSize) {}
     SimpleCache(const SimpleCache&) = delete;
     SimpleCache& operator=(const SimpleCache&) = delete;
     SimpleCache(SimpleCache&&) = default;
     SimpleCache& operator=(SimpleCache&&) = default;
     ~SimpleCache() { clear(); }
     void resize(int size) { theContainer.resize(size); }
-    const ValueType*  get(KeyType key) const { return theContainer[key].get();}
+    const ValueType* get(KeyType key) const { return theContainer[key].get(); }
     /// add object to cache. It is caller responsibility to check that object is not yet there.
-    void add(KeyType key, ValueType * value) {
-      if (key>=int(theContainer.size())) resize(key+1);
+    void add(KeyType key, ValueType* value) {
+      if (key >= int(theContainer.size()))
+        resize(key + 1);
       theContainer[key].reset(value);
     }
     void extend(const SimpleCache& other) {
       // N.B. Here we assume that the lifetime of 'other' is longer than of 'this'.
-      if(other.theContainer.size() > theContainer.size())
+      if (other.theContainer.size() > theContainer.size())
         resize(other.theContainer.size());
 
-      for(size_t i=0, size=other.theContainer.size(); i != size; ++i) {
-        assert(get(i) == nullptr); // We don't want to override any existing value
-        theContainer[i].reset(*(other.get(i))); // pass by reference to denote that we don't own it
+      for (size_t i = 0, size = other.theContainer.size(); i != size; ++i) {
+        assert(get(i) == nullptr);               // We don't want to override any existing value
+        theContainer[i].reset(*(other.get(i)));  // pass by reference to denote that we don't own it
       }
     }
     /// emptify cache, delete values associated to Key
-    void clear() {      
-      for ( auto & v : theContainer)  { v.reset(); }
+    void clear() {
+      for (auto& v : theContainer) {
+        v.reset();
+      }
     }
+
   private:
     std::vector<mayown_ptr<ValueType> > theContainer;
   };
 
 private:
   typedef SimpleCache Cache;
+
 public:
-  LayerHitMapCache(unsigned int initSize=50) : theCache(initSize) { }
+  LayerHitMapCache(unsigned int initSize = 50) : theCache(initSize) {}
   LayerHitMapCache(LayerHitMapCache&&) = default;
   LayerHitMapCache& operator=(LayerHitMapCache&&) = default;
-  
 
   void clear() { theCache.clear(); }
 
-  void extend(const LayerHitMapCache& other) {
-    theCache.extend(other.theCache);
-  }
+  void extend(const LayerHitMapCache& other) { theCache.extend(other.theCache); }
 
   // Mainly for FastSim, overrides old hits if exists
-  RecHitsSortedInPhi *add(const SeedingLayerSetsHits::SeedingLayer& layer, std::unique_ptr<RecHitsSortedInPhi> hits) {
-    RecHitsSortedInPhi *ptr = hits.get();
+  RecHitsSortedInPhi* add(const SeedingLayerSetsHits::SeedingLayer& layer, std::unique_ptr<RecHitsSortedInPhi> hits) {
+    RecHitsSortedInPhi* ptr = hits.get();
     theCache.add(layer.index(), hits.release());
     return ptr;
   }
-  
-  const RecHitsSortedInPhi &
-  operator()(const SeedingLayerSetsHits::SeedingLayer& layer, const TrackingRegion & region,
-	     const edm::EventSetup & iSetup) {
+
+  const RecHitsSortedInPhi& operator()(const SeedingLayerSetsHits::SeedingLayer& layer,
+                                       const TrackingRegion& region,
+                                       const edm::EventSetup& iSetup) {
     int key = layer.index();
-    assert (key>=0);
-    const RecHitsSortedInPhi * lhm = theCache.get(key);
-    if (lhm==nullptr) {
-      auto tmp = add(layer, std::make_unique<RecHitsSortedInPhi>(region.hits(iSetup,layer), region.origin(), layer.detLayer()));
+    assert(key >= 0);
+    const RecHitsSortedInPhi* lhm = theCache.get(key);
+    if (lhm == nullptr) {
+      auto tmp = add(
+          layer, std::make_unique<RecHitsSortedInPhi>(region.hits(iSetup, layer), region.origin(), layer.detLayer()));
       tmp->theOrigin = region.origin();
       lhm = tmp;
-      LogDebug("LayerHitMapCache")<<" I got"<< lhm->all().second-lhm->all().first<<" hits in the cache for: "<<layer.detLayer();
-    }
-    else{
+      LogDebug("LayerHitMapCache") << " I got" << lhm->all().second - lhm->all().first
+                                   << " hits in the cache for: " << layer.detLayer();
+    } else {
       // std::cout << region.origin() << " " <<  lhm->theOrigin << std::endl;
-      LogDebug("LayerHitMapCache")<<" I got"<< lhm->all().second-lhm->all().first<<" hits FROM THE cache for: "<<layer.detLayer();
+      LogDebug("LayerHitMapCache") << " I got" << lhm->all().second - lhm->all().first
+                                   << " hits FROM THE cache for: " << layer.detLayer();
     }
     return *lhm;
   }
 
 private:
-  Cache theCache; 
+  Cache theCache;
 };
 
 #endif
-

--- a/RecoTracker/TkHitPairs/interface/LayerWithHits.h
+++ b/RecoTracker/TkHitPairs/interface/LayerWithHits.h
@@ -9,39 +9,33 @@
 #include "DataFormats/Common/interface/DetSetAlgorithm.h"
 #include "TrackingTools/DetLayers/interface/DetLayer.h"
 
-class LayerWithHits
-{
- public:
-  LayerWithHits(const DetLayer *dl,const std::vector<const TrackingRecHit*>& theInputHits):
-    theDetLayer(dl),theHits(theInputHits){}
-  
-  /// Usage: 
+class LayerWithHits {
+public:
+  LayerWithHits(const DetLayer* dl, const std::vector<const TrackingRecHit*>& theInputHits)
+      : theDetLayer(dl), theHits(theInputHits) {}
+
+  /// Usage:
   ///  edm::ESHandle<TrackerTopology> httopo;
   ///  iSetup.get<TrackerTopologyRcd>().get(httopo);
   ///  const TrackerTopology& ttopo = *httopo;
   ///  LayerWithHits( theLayer, collrphi, ttopo.tibDetIdLayerComparator(1) );
   template <typename DSTV, typename SEL>
-  LayerWithHits(const DetLayer *dl,
-                DSTV const & allhits,    
-                SEL  const & sel) 
-  {
+  LayerWithHits(const DetLayer* dl, DSTV const& allhits, SEL const& sel) {
     theDetLayer = dl;
-    edmNew::copyDetSetRange(allhits,theHits,sel);
-  } 
-
+    edmNew::copyDetSetRange(allhits, theHits, sel);
+  }
 
   //destructor
-  ~LayerWithHits(){}
-  
+  ~LayerWithHits() {}
+
   /// return the recHits of the Layer
-  const std::vector<const TrackingRecHit*>& recHits() const {return theHits;}
+  const std::vector<const TrackingRecHit*>& recHits() const { return theHits; }
 
   //detlayer
-  const  DetLayer* layer()  const {return theDetLayer;}
-  
- private:
+  const DetLayer* layer() const { return theDetLayer; }
+
+private:
   const DetLayer* theDetLayer;
   std::vector<const TrackingRecHit*> theHits;
 };
 #endif
-

--- a/RecoTracker/TkHitPairs/interface/OrderedHitPair.h
+++ b/RecoTracker/TkHitPairs/interface/OrderedHitPair.h
@@ -3,19 +3,16 @@
 
 #include "RecoTracker/TkSeedingLayers/interface/SeedingHitSet.h"
 
-
 class OrderedHitPair : public SeedingHitSet {
 public:
+  typedef SeedingHitSet::ConstRecHitPointer OuterRecHit;
+  typedef SeedingHitSet::ConstRecHitPointer InnerRecHit;
 
-  typedef SeedingHitSet::ConstRecHitPointer OuterRecHit; 
-  typedef SeedingHitSet::ConstRecHitPointer InnerRecHit; 
+  OrderedHitPair() {}
+  OrderedHitPair(const InnerRecHit& ih, const OuterRecHit& oh) : SeedingHitSet(ih, oh) {}
 
-  OrderedHitPair(){}
-  OrderedHitPair( const InnerRecHit & ih, const OuterRecHit & oh) : SeedingHitSet(ih, oh){}
- 
-  InnerRecHit  inner() const { return get(0); }
-  OuterRecHit  outer() const { return get(1); } 
+  InnerRecHit inner() const { return get(0); }
+  OuterRecHit outer() const { return get(1); }
 };
 
 #endif
-

--- a/RecoTracker/TkHitPairs/interface/OrderedHitPairs.h
+++ b/RecoTracker/TkHitPairs/interface/OrderedHitPairs.h
@@ -7,14 +7,10 @@
 
 class OrderedHitPairs : public std::vector<OrderedHitPair>, public OrderedSeedingHits {
 public:
-
-  ~OrderedHitPairs() override{}
+  ~OrderedHitPairs() override {}
 
   unsigned int size() const override { return std::vector<OrderedHitPair>::size(); }
 
-  const OrderedHitPair& operator[](unsigned int i) const override { 
-    return std::vector<OrderedHitPair>::operator[](i); 
-  }
-
+  const OrderedHitPair& operator[](unsigned int i) const override { return std::vector<OrderedHitPair>::operator[](i); }
 };
 #endif

--- a/RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h
+++ b/RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h
@@ -5,9 +5,9 @@
 #include "TrackingTools/DetLayers/interface/DetLayer.h"
 
 #include <vector>
-#include<array>
+#include <array>
 
-#include<cassert>
+#include <cassert>
 
 /** A RecHit container sorted in phi.
  *  Provides fast access for hits in a given phi window
@@ -16,38 +16,37 @@
 
 class RecHitsSortedInPhi {
 public:
-
-  typedef BaseTrackerRecHit const * Hit;
+  typedef BaseTrackerRecHit const* Hit;
 
   // A RecHit extension that caches the phi angle for fast access
   class HitWithPhi {
   public:
-    HitWithPhi( const Hit & hit) : theHit(hit), thePhi(hit->globalPosition().barePhi()) {}
-    HitWithPhi( const Hit & hit,float phi) : theHit(hit), thePhi(phi) {}
-    HitWithPhi( float phi) : theHit(nullptr), thePhi(phi) {}
-    float phi() const {return thePhi;}
-    Hit const & hit() const { return theHit;}
+    HitWithPhi(const Hit& hit) : theHit(hit), thePhi(hit->globalPosition().barePhi()) {}
+    HitWithPhi(const Hit& hit, float phi) : theHit(hit), thePhi(phi) {}
+    HitWithPhi(float phi) : theHit(nullptr), thePhi(phi) {}
+    float phi() const { return thePhi; }
+    Hit const& hit() const { return theHit; }
+
   private:
-    Hit   theHit;
+    Hit theHit;
     float thePhi;
   };
 
   struct HitLessPhi {
-    bool operator()( const HitWithPhi& a, const HitWithPhi& b) { return a.phi() < b.phi(); }
+    bool operator()(const HitWithPhi& a, const HitWithPhi& b) { return a.phi() < b.phi(); }
   };
-  typedef std::vector<HitWithPhi>::const_iterator      HitIter;
-  typedef std::pair<HitIter,HitIter>            Range;
+  typedef std::vector<HitWithPhi>::const_iterator HitIter;
+  typedef std::pair<HitIter, HitIter> Range;
 
-  using DoubleRange = std::array<int,4>;
-  
-  RecHitsSortedInPhi(const std::vector<Hit>& hits, GlobalPoint const & origin, DetLayer const * il);
+  using DoubleRange = std::array<int, 4>;
+
+  RecHitsSortedInPhi(const std::vector<Hit>& hits, GlobalPoint const& origin, DetLayer const* il);
 
   bool empty() const { return theHits.empty(); }
-  std::size_t size() const { return theHits.size();}
-
+  std::size_t size() const { return theHits.size(); }
 
   // Returns the hits in the phi range (phi in radians).
-  //  The phi interval ( phiMin, phiMax) defined as the signed path along the 
+  //  The phi interval ( phiMin, phiMax) defined as the signed path along the
   //  trigonometric circle from the point at phiMin to the point at phiMax
   //  must be positive and smaller than pi.
   //  At least one of phiMin, phiMax must be in (-pi,pi) range.
@@ -55,7 +54,7 @@ public:
   //  Examples of WRONG intervals: (-5,-4),(3,2), (4,3), (3.2,3.1), (-3,3), (4,5).
   //  Example of use: myHits = recHitsSortedInPhi( phi-deltaPhi, phi+deltaPhi);
   //
-  std::vector<Hit> hits( float phiMin, float phiMax) const;
+  std::vector<Hit> hits(float phiMin, float phiMax) const;
 
   // Same as above but the result is allocated by the caller and passed by reference.
   //  The caller is responsible for clearing of the container "result".
@@ -63,7 +62,7 @@ public:
   //  dominant CPU time of the "nice" method hits(phimin,phimax) is spent in
   //  memory allocation of the result!
   //
-  void hits( float phiMin, float phiMax, std::vector<Hit>& result) const;
+  void hits(float phiMin, float phiMax, std::vector<Hit>& result) const;
 
   // some above, just double range of indeces..
   DoubleRange doubleRange(float phiMin, float phiMax) const;
@@ -72,32 +71,30 @@ public:
   //  The arguments must satisfy -pi <= phiMin < phiMax <= pi
   //  No check is made for this.
   //
-  Range unsafeRange( float phiMin, float phiMax) const;
+  Range unsafeRange(float phiMin, float phiMax) const;
 
   std::vector<Hit> hits() const {
-    std::vector<Hit> result; result.reserve(theHits.size());
-    for (HitIter i=theHits.begin(); i!=theHits.end(); i++) result.push_back(i->hit());
+    std::vector<Hit> result;
+    result.reserve(theHits.size());
+    for (HitIter i = theHits.begin(); i != theHits.end(); i++)
+      result.push_back(i->hit());
     return result;
   }
 
-
-  Range all() const {
-    return Range(theHits.begin(), theHits.end());
-  }
+  Range all() const { return Range(theHits.begin(), theHits.end()); }
 
 public:
-  float       phi(int i) const { return theHits[i].phi();}
-  float       gv(int i) const { return isBarrel ? z[i] : gp(i).perp();}  // global v
-  float       rv(int i) const { return isBarrel ? u[i] : v[i];}  // dispaced r
-  GlobalPoint gp(int i) const { return GlobalPoint(x[i],y[i],z[i]);}
+  float phi(int i) const { return theHits[i].phi(); }
+  float gv(int i) const { return isBarrel ? z[i] : gp(i).perp(); }  // global v
+  float rv(int i) const { return isBarrel ? u[i] : v[i]; }          // dispaced r
+  GlobalPoint gp(int i) const { return GlobalPoint(x[i], y[i], z[i]); }
 
 public:
-
   GlobalPoint theOrigin;
 
   std::vector<HitWithPhi> theHits;
 
-  DetLayer const * layer;
+  DetLayer const* layer;
   bool isBarrel;
 
   std::vector<float> x;
@@ -112,14 +109,12 @@ public:
   std::vector<float> dv;
   std::vector<float> lphi;
 
-  static void copyResult( const Range& range, std::vector<Hit>& result) {
-    result.reserve(result.size()+(range.second-range.first));
-    for (HitIter i = range.first; i != range.second; i++) result.push_back( i->hit());
+  static void copyResult(const Range& range, std::vector<Hit>& result) {
+    result.reserve(result.size() + (range.second - range.first));
+    for (HitIter i = range.first; i != range.second; i++)
+      result.push_back(i->hit());
   }
-
 };
-
-
 
 /*
  *   a collection of hit pairs issued by a doublet search
@@ -128,52 +123,47 @@ public:
  */
 class HitDoublets {
 public:
-  enum layer { inner=0, outer=1};
+  enum layer { inner = 0, outer = 1 };
 
   using HitLayer = RecHitsSortedInPhi;
-  using Hit=RecHitsSortedInPhi::Hit;
-  using ADoublet = std::pair<int,int>;
-  
-  HitDoublets(  RecHitsSortedInPhi const & in,
-		RecHitsSortedInPhi const & out) :
-    layers{{&in,&out}}{}
-  
-  HitDoublets(HitDoublets && rh) : layers(std::move(rh.layers)), indeces(std::move(rh.indeces)){}
-  
-  void reserve(std::size_t s) { indeces.reserve(s);}
-  std::size_t size() const { return indeces.size();}
-  bool empty() const { return indeces.empty();}
-  void clear() { indeces.clear();}
-  void shrink_to_fit() {
-    indeces.shrink_to_fit();
-  }
-  
-  void add (int il, int ol) {
-    indeces.emplace_back(il,ol);
-  }
+  using Hit = RecHitsSortedInPhi::Hit;
+  using ADoublet = std::pair<int, int>;
 
-  int index(int i, layer l) const { return l==inner ? innerHitId(i) : outerHitId(i);}
-  DetLayer const * detLayer(layer l) const { return layers[l]->layer; }
-  HitLayer const & innerLayer() const { return *layers[inner];}
-  HitLayer const & outerLayer() const { return *layers[outer];}
-  int innerHitId(int i) const {return indeces[i].first;}
-  int outerHitId(int i) const {return indeces[i].second;}
-  Hit const & hit(int i, layer l) const { return layers[l]->theHits[index(i,l)].hit();}
-  float       phi(int i, layer l) const { return layers[l]->phi(index(i,l));}
-  float       rv(int i, layer l) const { return layers[l]->rv(index(i,l));}
-  float       r(int i, layer l) const { float xp = x(i,l); float yp = y(i,l);  return std::sqrt (xp*xp + yp*yp);}
-  float        z(int i, layer l) const { return layers[l]->z[index(i,l)];}
-  float        x(int i, layer l) const { return layers[l]->x[index(i,l)];}
-  float        y(int i, layer l) const { return layers[l]->y[index(i,l)];}
-  GlobalPoint gp(int i, layer l) const { return GlobalPoint(x(i,l),y(i,l),z(i,l));}
+  HitDoublets(RecHitsSortedInPhi const& in, RecHitsSortedInPhi const& out) : layers{{&in, &out}} {}
+
+  HitDoublets(HitDoublets&& rh) : layers(std::move(rh.layers)), indeces(std::move(rh.indeces)) {}
+
+  void reserve(std::size_t s) { indeces.reserve(s); }
+  std::size_t size() const { return indeces.size(); }
+  bool empty() const { return indeces.empty(); }
+  void clear() { indeces.clear(); }
+  void shrink_to_fit() { indeces.shrink_to_fit(); }
+
+  void add(int il, int ol) { indeces.emplace_back(il, ol); }
+
+  int index(int i, layer l) const { return l == inner ? innerHitId(i) : outerHitId(i); }
+  DetLayer const* detLayer(layer l) const { return layers[l]->layer; }
+  HitLayer const& innerLayer() const { return *layers[inner]; }
+  HitLayer const& outerLayer() const { return *layers[outer]; }
+  int innerHitId(int i) const { return indeces[i].first; }
+  int outerHitId(int i) const { return indeces[i].second; }
+  Hit const& hit(int i, layer l) const { return layers[l]->theHits[index(i, l)].hit(); }
+  float phi(int i, layer l) const { return layers[l]->phi(index(i, l)); }
+  float rv(int i, layer l) const { return layers[l]->rv(index(i, l)); }
+  float r(int i, layer l) const {
+    float xp = x(i, l);
+    float yp = y(i, l);
+    return std::sqrt(xp * xp + yp * yp);
+  }
+  float z(int i, layer l) const { return layers[l]->z[index(i, l)]; }
+  float x(int i, layer l) const { return layers[l]->x[index(i, l)]; }
+  float y(int i, layer l) const { return layers[l]->y[index(i, l)]; }
+  GlobalPoint gp(int i, layer l) const { return GlobalPoint(x(i, l), y(i, l), z(i, l)); }
 
 private:
+  std::array<RecHitsSortedInPhi const*, 2> layers;
 
-  std::array<RecHitsSortedInPhi const *,2> layers;
-
-
-  std::vector<ADoublet> indeces; // naturally sorted by outerId
-
+  std::vector<ADoublet> indeces;  // naturally sorted by outerId
 };
 
 #endif

--- a/RecoTracker/TkHitPairs/interface/RegionsSeedingHitSets.h
+++ b/RecoTracker/TkHitPairs/interface/RegionsSeedingHitSets.h
@@ -23,11 +23,12 @@ public:
   /// Helper class enforcing correct way of filling the doublets of a region
   class RegionFiller {
   public:
-    RegionFiller(): obj_(nullptr) {}
-    explicit RegionFiller(RegionsSeedingHitSets* obj): obj_(obj) {}
+    RegionFiller() : obj_(nullptr) {}
+    explicit RegionFiller(RegionsSeedingHitSets* obj) : obj_(obj) {}
 
     ~RegionFiller() {
-      if(obj_) obj_->regions_.back().setLayerSetsEnd(obj_->hitSets_.size());
+      if (obj_)
+        obj_->regions_.back().setLayerSetsEnd(obj_->hitSets_.size());
     }
 
     bool valid() const { return obj_ != nullptr; }
@@ -36,8 +37,9 @@ public:
     void emplace_back(Args&&... args) {
       obj_->hitSets_.emplace_back(std::forward<Args>(args)...);
     }
+
   private:
-    RegionsSeedingHitSets *obj_;
+    RegionsSeedingHitSets* obj_;
   };
 
   // allows declaring local variables with auto
@@ -61,7 +63,7 @@ public:
     hitSets_.shrink_to_fit();
   }
 
-  RegionFiller beginRegion(const TrackingRegion *region) {
+  RegionFiller beginRegion(const TrackingRegion* region) {
     regions_.emplace_back(region, hitSets_.size());
     return RegionFiller(this);
   }

--- a/RecoTracker/TkHitPairs/interface/SeedLayerPairs.h
+++ b/RecoTracker/TkHitPairs/interface/SeedLayerPairs.h
@@ -15,14 +15,11 @@ class LayerWithHits;
 
 class SeedLayerPairs {
 public:
+  typedef std::pair<const LayerWithHits*, const LayerWithHits*> LayerPair;
 
-  typedef std::pair< const LayerWithHits*, const LayerWithHits*>        LayerPair;
-
-  SeedLayerPairs() {};
-  virtual ~SeedLayerPairs() {};
-    virtual std::vector<LayerPair> operator()()= 0;
-  
-
+  SeedLayerPairs(){};
+  virtual ~SeedLayerPairs(){};
+  virtual std::vector<LayerPair> operator()() = 0;
 };
 
 #endif

--- a/RecoTracker/TkHitPairs/plugins/HitPairEDProducer.cc
+++ b/RecoTracker/TkHitPairs/plugins/HitPairEDProducer.cc
@@ -17,9 +17,11 @@
 #include "RecoTracker/TkHitPairs/interface/IntermediateHitDoublets.h"
 #include "RecoTracker/TkHitPairs/interface/RegionsSeedingHitSets.h"
 
-namespace { class ImplBase; }
+namespace {
+  class ImplBase;
+}
 
-class HitPairEDProducer: public edm::stream::EDProducer<> {
+class HitPairEDProducer : public edm::stream::EDProducer<> {
 public:
   HitPairEDProducer(const edm::ParameterSet& iConfig);
   ~HitPairEDProducer() override = default;
@@ -52,25 +54,23 @@ namespace {
     HitPairGeneratorFromLayerPair generator_;
     std::vector<unsigned> layerPairBegins_;
   };
-  ImplBase::ImplBase(const edm::ParameterSet& iConfig):
-    maxElement_(iConfig.getParameter<unsigned int>("maxElement")),
-    maxElementTotal_(iConfig.getParameter<unsigned int>("maxElementTotal")),
-    generator_(0, 1, nullptr, maxElement_), // these indices are dummy, TODO: cleanup HitPairGeneratorFromLayerPair
-    layerPairBegins_(iConfig.getParameter<std::vector<unsigned> >("layerPairs"))
-  {
-    if(layerPairBegins_.empty())
-      throw cms::Exception("Configuration") << "HitPairEDProducer requires at least index for layer pairs (layerPairs parameter), none was given";
+  ImplBase::ImplBase(const edm::ParameterSet& iConfig)
+      : maxElement_(iConfig.getParameter<unsigned int>("maxElement")),
+        maxElementTotal_(iConfig.getParameter<unsigned int>("maxElementTotal")),
+        generator_(0, 1, nullptr, maxElement_),  // these indices are dummy, TODO: cleanup HitPairGeneratorFromLayerPair
+        layerPairBegins_(iConfig.getParameter<std::vector<unsigned>>("layerPairs")) {
+    if (layerPairBegins_.empty())
+      throw cms::Exception("Configuration")
+          << "HitPairEDProducer requires at least index for layer pairs (layerPairs parameter), none was given";
   }
 
   /////
   template <typename T_SeedingHitSets, typename T_IntermediateHitDoublets, typename T_RegionLayers>
-  class Impl: public ImplBase {
+  class Impl : public ImplBase {
   public:
     template <typename... Args>
-    Impl(const edm::ParameterSet& iConfig, Args&&... args):
-      ImplBase(iConfig),
-      regionsLayers_(&layerPairBegins_, std::forward<Args>(args)...)
-    {}
+    Impl(const edm::ParameterSet& iConfig, Args&&... args)
+        : ImplBase(iConfig), regionsLayers_(&layerPairBegins_, std::forward<Args>(args)...) {}
     ~Impl() override = default;
 
     void produces(edm::ProducerBase& producer) const override {
@@ -84,7 +84,7 @@ namespace {
       auto seedingHitSetsProducer = T_SeedingHitSets(&localRA_);
       auto intermediateHitDoubletsProducer = T_IntermediateHitDoublets(regionsLayers.seedingLayerSetsHitsPtr());
 
-      if(!clusterCheckOk) {
+      if (!clusterCheckOk) {
         seedingHitSetsProducer.putEmpty(iEvent);
         intermediateHitDoubletsProducer.putEmpty(iEvent);
         return;
@@ -95,21 +95,25 @@ namespace {
 
       unsigned int nDoublets = 0;
 
-      for(const auto& regionLayers: regionsLayers) {
+      for (const auto& regionLayers : regionsLayers) {
         const TrackingRegion& region = regionLayers.region();
         auto hitCachePtr_filler_shs = seedingHitSetsProducer.beginRegion(&region, nullptr);
-        auto hitCachePtr_filler_ihd = intermediateHitDoubletsProducer.beginRegion(&region, std::get<0>(hitCachePtr_filler_shs));
+        auto hitCachePtr_filler_ihd =
+            intermediateHitDoubletsProducer.beginRegion(&region, std::get<0>(hitCachePtr_filler_shs));
         auto hitCachePtr = std::get<0>(hitCachePtr_filler_ihd);
 
-        for(SeedingLayerSetsHits::SeedingLayerSet layerSet: regionLayers.layerPairs()) {
+        for (SeedingLayerSetsHits::SeedingLayerSet layerSet : regionLayers.layerPairs()) {
           auto doublets = generator_.doublets(region, iEvent, iSetup, layerSet, *hitCachePtr);
-          LogTrace("HitPairEDProducer") << " created " << doublets.size() << " doublets for layers " << layerSet[0].index() << "," << layerSet[1].index();
-          if(doublets.empty()) continue; // don't bother if no pairs from these layers
+          LogTrace("HitPairEDProducer") << " created " << doublets.size() << " doublets for layers "
+                                        << layerSet[0].index() << "," << layerSet[1].index();
+          if (doublets.empty())
+            continue;  // don't bother if no pairs from these layers
           nDoublets += doublets.size();
-          if (nDoublets >= maxElementTotal_){
-            edm::LogError("TooManyPairs")<<"number of total pairs exceed maximum, no pairs produced";
+          if (nDoublets >= maxElementTotal_) {
+            edm::LogError("TooManyPairs") << "number of total pairs exceed maximum, no pairs produced";
             auto seedingHitSetsProducerDummy = T_SeedingHitSets(&localRA_);
-            auto intermediateHitDoubletsProducerDummy = T_IntermediateHitDoublets(regionsLayers.seedingLayerSetsHitsPtr());
+            auto intermediateHitDoubletsProducerDummy =
+                T_IntermediateHitDoublets(regionsLayers.seedingLayerSetsHitsPtr());
             seedingHitSetsProducerDummy.putEmpty(iEvent);
             intermediateHitDoubletsProducerDummy.putEmpty(iEvent);
             return;
@@ -130,16 +134,14 @@ namespace {
   /////
   class DoNothing {
   public:
-    DoNothing(const SeedingLayerSetsHits *) {}
-    DoNothing(edm::RunningAverage *) {}
+    DoNothing(const SeedingLayerSetsHits*) {}
+    DoNothing(edm::RunningAverage*) {}
 
-    static void produces(edm::ProducerBase&) {};
+    static void produces(edm::ProducerBase&){};
 
     void reserve(size_t) {}
 
-    auto beginRegion(const TrackingRegion *, LayerHitMapCache *ptr) {
-      return std::make_tuple(ptr, 0);
-    }
+    auto beginRegion(const TrackingRegion*, LayerHitMapCache* ptr) { return std::make_tuple(ptr, 0); }
 
     void fill(int, const HitDoublets&) {}
     void fill(int, const SeedingLayerSetsHits::SeedingLayerSet&, HitDoublets&&) {}
@@ -151,28 +153,21 @@ namespace {
   /////
   class ImplSeedingHitSets {
   public:
-    ImplSeedingHitSets(edm::RunningAverage *localRA):
-      seedingHitSets_(std::make_unique<RegionsSeedingHitSets>()),
-      localRA_(localRA)
-    {}
+    ImplSeedingHitSets(edm::RunningAverage* localRA)
+        : seedingHitSets_(std::make_unique<RegionsSeedingHitSets>()), localRA_(localRA) {}
 
-    static void produces(edm::ProducerBase& producer) {
-      producer.produces<RegionsSeedingHitSets>();
-    }
+    static void produces(edm::ProducerBase& producer) { producer.produces<RegionsSeedingHitSets>(); }
 
-    void reserve(size_t regionsSize) {
-      seedingHitSets_->reserve(regionsSize, localRA_->upper());
-    }
+    void reserve(size_t regionsSize) { seedingHitSets_->reserve(regionsSize, localRA_->upper()); }
 
-    auto beginRegion(const TrackingRegion *region, LayerHitMapCache *) {
+    auto beginRegion(const TrackingRegion* region, LayerHitMapCache*) {
       hitCacheTmp_.clear();
       return std::make_tuple(&hitCacheTmp_, seedingHitSets_->beginRegion(region));
     }
 
     void fill(RegionsSeedingHitSets::RegionFiller& filler, const HitDoublets& doublets) {
-      for(size_t i=0, size=doublets.size(); i<size; ++i) {
-        filler.emplace_back(doublets.hit(i, HitDoublets::inner),
-                            doublets.hit(i, HitDoublets::outer));
+      for (size_t i = 0, size = doublets.size(); i < size; ++i) {
+        filler.emplace_back(doublets.hit(i, HitDoublets::inner), doublets.hit(i, HitDoublets::outer));
       }
     }
 
@@ -182,38 +177,32 @@ namespace {
       putEmpty(iEvent);
     }
 
-    void putEmpty(edm::Event& iEvent) {
-      iEvent.put(std::move(seedingHitSets_));
-    }
+    void putEmpty(edm::Event& iEvent) { iEvent.put(std::move(seedingHitSets_)); }
 
   private:
     std::unique_ptr<RegionsSeedingHitSets> seedingHitSets_;
-    edm::RunningAverage *localRA_;
-    LayerHitMapCache hitCacheTmp_; // used if !produceIntermediateHitDoublets
+    edm::RunningAverage* localRA_;
+    LayerHitMapCache hitCacheTmp_;  // used if !produceIntermediateHitDoublets
   };
 
   /////
   class ImplIntermediateHitDoublets {
   public:
-    ImplIntermediateHitDoublets(const SeedingLayerSetsHits *layers):
-      intermediateHitDoublets_(std::make_unique<IntermediateHitDoublets>(layers)),
-      layers_(layers)
-    {}
+    ImplIntermediateHitDoublets(const SeedingLayerSetsHits* layers)
+        : intermediateHitDoublets_(std::make_unique<IntermediateHitDoublets>(layers)), layers_(layers) {}
 
-    static void produces(edm::ProducerBase& producer) {
-      producer.produces<IntermediateHitDoublets>();
-    }
+    static void produces(edm::ProducerBase& producer) { producer.produces<IntermediateHitDoublets>(); }
 
-    void reserve(size_t regionsSize) {
-      intermediateHitDoublets_->reserve(regionsSize, layers_->size());
-    }
+    void reserve(size_t regionsSize) { intermediateHitDoublets_->reserve(regionsSize, layers_->size()); }
 
-    auto beginRegion(const TrackingRegion *region, LayerHitMapCache *) {
+    auto beginRegion(const TrackingRegion* region, LayerHitMapCache*) {
       auto filler = intermediateHitDoublets_->beginRegion(region);
       return std::make_tuple(&(filler.layerHitMapCache()), std::move(filler));
     }
 
-    void fill(IntermediateHitDoublets::RegionFiller& filler, const SeedingLayerSetsHits::SeedingLayerSet& layerSet, HitDoublets&& doublets) {
+    void fill(IntermediateHitDoublets::RegionFiller& filler,
+              const SeedingLayerSetsHits::SeedingLayerSet& layerSet,
+              HitDoublets&& doublets) {
       filler.addDoublets(layerSet, std::move(doublets));
     }
 
@@ -222,13 +211,11 @@ namespace {
       putEmpty(iEvent);
     }
 
-    void putEmpty(edm::Event& iEvent) {
-      iEvent.put(std::move(intermediateHitDoublets_));
-    }
+    void putEmpty(edm::Event& iEvent) { iEvent.put(std::move(intermediateHitDoublets_)); }
 
   private:
     std::unique_ptr<IntermediateHitDoublets> intermediateHitDoublets_;
-    const SeedingLayerSetsHits *layers_;
+    const SeedingLayerSetsHits* layers_;
   };
 
   /////
@@ -237,15 +224,15 @@ namespace {
   public:
     class RegionLayers {
     public:
-      RegionLayers(const TrackingRegion *region, const std::vector<SeedingLayerSetsHits::SeedingLayerSet> *layerPairs):
-        region_(region), layerPairs_(layerPairs) {}
+      RegionLayers(const TrackingRegion* region, const std::vector<SeedingLayerSetsHits::SeedingLayerSet>* layerPairs)
+          : region_(region), layerPairs_(layerPairs) {}
 
       const TrackingRegion& region() const { return *region_; }
       const std::vector<SeedingLayerSetsHits::SeedingLayerSet>& layerPairs() const { return *layerPairs_; }
 
     private:
-      const TrackingRegion *region_;
-      const std::vector<SeedingLayerSetsHits::SeedingLayerSet> *layerPairs_;
+      const TrackingRegion* region_;
+      const std::vector<SeedingLayerSetsHits::SeedingLayerSet>* layerPairs_;
     };
 
     class EventTmp {
@@ -256,12 +243,16 @@ namespace {
         using value_type = RegionLayers;
         using difference_type = internal_iterator_type::difference_type;
 
-        const_iterator(internal_iterator_type iter, const std::vector<SeedingLayerSetsHits::SeedingLayerSet> *layerPairs):
-          iter_(iter), layerPairs_(layerPairs) {}
+        const_iterator(internal_iterator_type iter,
+                       const std::vector<SeedingLayerSetsHits::SeedingLayerSet>* layerPairs)
+            : iter_(iter), layerPairs_(layerPairs) {}
 
         value_type operator*() const { return value_type(&(*iter_), layerPairs_); }
 
-        const_iterator& operator++() { ++iter_; return *this; }
+        const_iterator& operator++() {
+          ++iter_;
+          return *this;
+        }
         const_iterator operator++(int) {
           const_iterator clone(*this);
           ++(*this);
@@ -273,53 +264,60 @@ namespace {
 
       private:
         internal_iterator_type iter_;
-        const std::vector<SeedingLayerSetsHits::SeedingLayerSet> *layerPairs_;
+        const std::vector<SeedingLayerSetsHits::SeedingLayerSet>* layerPairs_;
       };
 
-      EventTmp(const SeedingLayerSetsHits *seedingLayerSetsHits,
-               const edm::OwnVector<TrackingRegion> *regions,
-               const std::vector<unsigned>& layerPairBegins):
-        seedingLayerSetsHits_(seedingLayerSetsHits), regions_(regions) {
-
+      EventTmp(const SeedingLayerSetsHits* seedingLayerSetsHits,
+               const edm::OwnVector<TrackingRegion>* regions,
+               const std::vector<unsigned>& layerPairBegins)
+          : seedingLayerSetsHits_(seedingLayerSetsHits), regions_(regions) {
         // construct the pairs from the sets
-        if(seedingLayerSetsHits_->numberOfLayersInSet() > 2) {
-          for(const auto& layerSet: *seedingLayerSetsHits_) {
-            for(const auto pairBeginIndex: layerPairBegins) {
-              if(pairBeginIndex+1 >= seedingLayerSetsHits->numberOfLayersInSet()) {
-                throw cms::Exception("LogicError") << "Layer pair index " << pairBeginIndex << " is out of bounds, input SeedingLayerSetsHits has only " << seedingLayerSetsHits->numberOfLayersInSet() << " layers per set, and the index+1 must be < than the number of layers in set";
+        if (seedingLayerSetsHits_->numberOfLayersInSet() > 2) {
+          for (const auto& layerSet : *seedingLayerSetsHits_) {
+            for (const auto pairBeginIndex : layerPairBegins) {
+              if (pairBeginIndex + 1 >= seedingLayerSetsHits->numberOfLayersInSet()) {
+                throw cms::Exception("LogicError")
+                    << "Layer pair index " << pairBeginIndex
+                    << " is out of bounds, input SeedingLayerSetsHits has only "
+                    << seedingLayerSetsHits->numberOfLayersInSet()
+                    << " layers per set, and the index+1 must be < than the number of layers in set";
               }
 
               // Take only the requested pair of the set
-              SeedingLayerSetsHits::SeedingLayerSet pairCandidate = layerSet.slice(pairBeginIndex, pairBeginIndex+1);
+              SeedingLayerSetsHits::SeedingLayerSet pairCandidate = layerSet.slice(pairBeginIndex, pairBeginIndex + 1);
 
               // it would be trivial to use 128-bit bitfield for O(1) check
               // if a layer pair has been inserted, but let's test first how
               // a "straightforward" solution works
-              auto found = std::find_if(layerPairs.begin(), layerPairs.end(), [&](const SeedingLayerSetsHits::SeedingLayerSet& pair) {
-                  return pair[0].index() == pairCandidate[0].index() && pair[1].index() == pairCandidate[1].index();
-                });
-              if(found != layerPairs.end())
+              auto found = std::find_if(
+                  layerPairs.begin(), layerPairs.end(), [&](const SeedingLayerSetsHits::SeedingLayerSet& pair) {
+                    return pair[0].index() == pairCandidate[0].index() && pair[1].index() == pairCandidate[1].index();
+                  });
+              if (found != layerPairs.end())
                 continue;
 
               layerPairs.push_back(pairCandidate);
             }
           }
-        }
-        else {
-          if(layerPairBegins.size() != 1) {
-            throw cms::Exception("LogicError") << "With pairs of input layers, it doesn't make sense to specify more than one input layer pair, got " << layerPairBegins.size();
+        } else {
+          if (layerPairBegins.size() != 1) {
+            throw cms::Exception("LogicError")
+                << "With pairs of input layers, it doesn't make sense to specify more than one input layer pair, got "
+                << layerPairBegins.size();
           }
-          if(layerPairBegins[0] != 0) {
-            throw cms::Exception("LogicError") << "With pairs of input layers, it doesn't make sense to specify other input layer pair than 0; got " << layerPairBegins[0];
+          if (layerPairBegins[0] != 0) {
+            throw cms::Exception("LogicError")
+                << "With pairs of input layers, it doesn't make sense to specify other input layer pair than 0; got "
+                << layerPairBegins[0];
           }
 
           layerPairs.reserve(seedingLayerSetsHits->size());
-          for(const auto& set: *seedingLayerSetsHits)
+          for (const auto& set : *seedingLayerSetsHits)
             layerPairs.push_back(set);
         }
       }
 
-      const SeedingLayerSetsHits *seedingLayerSetsHitsPtr() const { return seedingLayerSetsHits_; }
+      const SeedingLayerSetsHits* seedingLayerSetsHitsPtr() const { return seedingLayerSetsHits_; }
 
       size_t regionsSize() const { return regions_->size(); }
 
@@ -329,36 +327,38 @@ namespace {
       const_iterator cend() const { return end(); }
 
     private:
-      const SeedingLayerSetsHits *seedingLayerSetsHits_;
-      const edm::OwnVector<TrackingRegion> *regions_;
+      const SeedingLayerSetsHits* seedingLayerSetsHits_;
+      const edm::OwnVector<TrackingRegion>* regions_;
       std::vector<SeedingLayerSetsHits::SeedingLayerSet> layerPairs;
     };
 
-    RegionsLayersSeparate(const std::vector<unsigned> *layerPairBegins,
+    RegionsLayersSeparate(const std::vector<unsigned>* layerPairBegins,
                           const edm::InputTag& seedingLayerTag,
                           const edm::InputTag& regionTag,
-                          edm::ConsumesCollector&& iC):
-      layerPairBegins_(layerPairBegins),
-      seedingLayerToken_(iC.consumes<SeedingLayerSetsHits>(seedingLayerTag)),
-      regionToken_(iC.consumes<edm::OwnVector<TrackingRegion> >(regionTag))
-    {}
+                          edm::ConsumesCollector&& iC)
+        : layerPairBegins_(layerPairBegins),
+          seedingLayerToken_(iC.consumes<SeedingLayerSetsHits>(seedingLayerTag)),
+          regionToken_(iC.consumes<edm::OwnVector<TrackingRegion>>(regionTag)) {}
 
     EventTmp beginEvent(const edm::Event& iEvent) const {
       edm::Handle<SeedingLayerSetsHits> hlayers;
       iEvent.getByToken(seedingLayerToken_, hlayers);
-      const auto *layers = hlayers.product();
-      if(layers->numberOfLayersInSet() < 2)
-        throw cms::Exception("LogicError") << "HitPairEDProducer expects SeedingLayerSetsHits::numberOfLayersInSet() to be >= 2, got " << layers->numberOfLayersInSet() << ". This is likely caused by a configuration error of this module, or SeedingLayersEDProducer.";
-      edm::Handle<edm::OwnVector<TrackingRegion> > hregions;
+      const auto* layers = hlayers.product();
+      if (layers->numberOfLayersInSet() < 2)
+        throw cms::Exception("LogicError")
+            << "HitPairEDProducer expects SeedingLayerSetsHits::numberOfLayersInSet() to be >= 2, got "
+            << layers->numberOfLayersInSet()
+            << ". This is likely caused by a configuration error of this module, or SeedingLayersEDProducer.";
+      edm::Handle<edm::OwnVector<TrackingRegion>> hregions;
       iEvent.getByToken(regionToken_, hregions);
 
       return EventTmp(layers, hregions.product(), *layerPairBegins_);
     }
 
   private:
-    const std::vector<unsigned> *layerPairBegins_;
+    const std::vector<unsigned>* layerPairBegins_;
     edm::EDGetTokenT<SeedingLayerSetsHits> seedingLayerToken_;
-    edm::EDGetTokenT<edm::OwnVector<TrackingRegion> > regionToken_;
+    edm::EDGetTokenT<edm::OwnVector<TrackingRegion>> regionToken_;
   };
 
   /////
@@ -370,14 +370,16 @@ namespace {
     public:
       using const_iterator = TrackingRegionsSeedingLayerSets::const_iterator;
 
-      explicit EventTmp(const TrackingRegionsSeedingLayerSets *regionsLayers):
-        regionsLayers_(regionsLayers) {
-        if(regionsLayers->seedingLayerSetsHits().numberOfLayersInSet() != 2) {
-          throw cms::Exception("LogicError") << "With trackingRegionsSeedingLayers input, the seeding layer sets may only contain layer pairs, now got sets with " << regionsLayers->seedingLayerSetsHits().numberOfLayersInSet() << " layers";
+      explicit EventTmp(const TrackingRegionsSeedingLayerSets* regionsLayers) : regionsLayers_(regionsLayers) {
+        if (regionsLayers->seedingLayerSetsHits().numberOfLayersInSet() != 2) {
+          throw cms::Exception("LogicError")
+              << "With trackingRegionsSeedingLayers input, the seeding layer sets may only contain layer pairs, now "
+                 "got sets with "
+              << regionsLayers->seedingLayerSetsHits().numberOfLayersInSet() << " layers";
         }
       }
 
-      const SeedingLayerSetsHits *seedingLayerSetsHitsPtr() const { return &(regionsLayers_->seedingLayerSetsHits()); }
+      const SeedingLayerSetsHits* seedingLayerSetsHitsPtr() const { return &(regionsLayers_->seedingLayerSetsHits()); }
 
       size_t regionsSize() const { return regionsLayers_->regionsSize(); }
 
@@ -387,19 +389,22 @@ namespace {
       const_iterator cend() const { return end(); }
 
     private:
-      const TrackingRegionsSeedingLayerSets *regionsLayers_;
+      const TrackingRegionsSeedingLayerSets* regionsLayers_;
     };
 
-    RegionsLayersTogether(const std::vector<unsigned> *layerPairBegins,
+    RegionsLayersTogether(const std::vector<unsigned>* layerPairBegins,
                           const edm::InputTag& regionLayerTag,
-                          edm::ConsumesCollector&& iC):
-      regionLayerToken_(iC.consumes<TrackingRegionsSeedingLayerSets>(regionLayerTag))
-    {
-      if(layerPairBegins->size() != 1) {
-        throw cms::Exception("LogicError") << "With trackingRegionsSeedingLayers mode, it doesn't make sense to specify more than one input layer pair, got " << layerPairBegins->size();
+                          edm::ConsumesCollector&& iC)
+        : regionLayerToken_(iC.consumes<TrackingRegionsSeedingLayerSets>(regionLayerTag)) {
+      if (layerPairBegins->size() != 1) {
+        throw cms::Exception("LogicError") << "With trackingRegionsSeedingLayers mode, it doesn't make sense to "
+                                              "specify more than one input layer pair, got "
+                                           << layerPairBegins->size();
       }
-      if((*layerPairBegins)[0] != 0) {
-        throw cms::Exception("LogicError") << "With trackingRegionsSeedingLayers mode, it doesn't make sense to specify other input layer pair than 0; got " << (*layerPairBegins)[0];
+      if ((*layerPairBegins)[0] != 0) {
+        throw cms::Exception("LogicError") << "With trackingRegionsSeedingLayers mode, it doesn't make sense to "
+                                              "specify other input layer pair than 0; got "
+                                           << (*layerPairBegins)[0];
       }
     }
 
@@ -412,51 +417,63 @@ namespace {
   private:
     edm::EDGetTokenT<TrackingRegionsSeedingLayerSets> regionLayerToken_;
   };
-}
-
-
+}  // namespace
 
 HitPairEDProducer::HitPairEDProducer(const edm::ParameterSet& iConfig) {
   auto layersTag = iConfig.getParameter<edm::InputTag>("seedingLayers");
   auto regionTag = iConfig.getParameter<edm::InputTag>("trackingRegions");
   auto regionLayerTag = iConfig.getParameter<edm::InputTag>("trackingRegionsSeedingLayers");
   const bool useRegionLayers = !regionLayerTag.label().empty();
-  if(useRegionLayers) {
-    if(!regionTag.label().empty()) {
-      throw cms::Exception("Configuration") << "HitPairEDProducer requires either trackingRegions or trackingRegionsSeedingLayers to be set, now both are set to non-empty value. Set the unneeded parameter to empty value.";
+  if (useRegionLayers) {
+    if (!regionTag.label().empty()) {
+      throw cms::Exception("Configuration")
+          << "HitPairEDProducer requires either trackingRegions or trackingRegionsSeedingLayers to be set, now both "
+             "are set to non-empty value. Set the unneeded parameter to empty value.";
     }
-    if(!layersTag.label().empty()) {
-      throw cms::Exception("Configuration") << "With non-empty trackingRegionsSeedingLayers, please set also seedingLayers to empty value to reduce confusion, because the parameter is not used";
+    if (!layersTag.label().empty()) {
+      throw cms::Exception("Configuration")
+          << "With non-empty trackingRegionsSeedingLayers, please set also seedingLayers to empty value to reduce "
+             "confusion, because the parameter is not used";
     }
   }
-  if(regionTag.label().empty() && regionLayerTag.label().empty()) {
-    throw cms::Exception("Configuration") << "HitPairEDProducer requires either trackingRegions or trackingRegionsSeedingLayers to be set, now both are set to empty value. Set the needed parameter to a non-empty value.";
+  if (regionTag.label().empty() && regionLayerTag.label().empty()) {
+    throw cms::Exception("Configuration")
+        << "HitPairEDProducer requires either trackingRegions or trackingRegionsSeedingLayers to be set, now both are "
+           "set to empty value. Set the needed parameter to a non-empty value.";
   }
 
   const bool produceSeedingHitSets = iConfig.getParameter<bool>("produceSeedingHitSets");
   const bool produceIntermediateHitDoublets = iConfig.getParameter<bool>("produceIntermediateHitDoublets");
 
-  if(produceSeedingHitSets && produceIntermediateHitDoublets) {
-    if(useRegionLayers) throw cms::Exception("Configuration") << "Mode 'trackingRegionsSeedingLayers' makes sense only with 'produceSeedingHitsSets', now also 'produceIntermediateHitDoublets is active";
-    impl_ = std::make_unique<::Impl<::ImplSeedingHitSets, ::ImplIntermediateHitDoublets, ::RegionsLayersSeparate>>(iConfig, layersTag, regionTag, consumesCollector());
-  }
-  else if(produceSeedingHitSets) {
-    if(useRegionLayers) {
-      impl_ = std::make_unique<::Impl<::ImplSeedingHitSets, ::DoNothing, ::RegionsLayersTogether>>(iConfig, regionLayerTag, consumesCollector());
+  if (produceSeedingHitSets && produceIntermediateHitDoublets) {
+    if (useRegionLayers)
+      throw cms::Exception("Configuration")
+          << "Mode 'trackingRegionsSeedingLayers' makes sense only with 'produceSeedingHitsSets', now also "
+             "'produceIntermediateHitDoublets is active";
+    impl_ = std::make_unique<::Impl<::ImplSeedingHitSets, ::ImplIntermediateHitDoublets, ::RegionsLayersSeparate>>(
+        iConfig, layersTag, regionTag, consumesCollector());
+  } else if (produceSeedingHitSets) {
+    if (useRegionLayers) {
+      impl_ = std::make_unique<::Impl<::ImplSeedingHitSets, ::DoNothing, ::RegionsLayersTogether>>(
+          iConfig, regionLayerTag, consumesCollector());
+    } else {
+      impl_ = std::make_unique<::Impl<::ImplSeedingHitSets, ::DoNothing, ::RegionsLayersSeparate>>(
+          iConfig, layersTag, regionTag, consumesCollector());
     }
-    else {
-      impl_ = std::make_unique<::Impl<::ImplSeedingHitSets, ::DoNothing, ::RegionsLayersSeparate>>(iConfig, layersTag, regionTag, consumesCollector());
-    }
-  }
-  else if(produceIntermediateHitDoublets) {
-    if(useRegionLayers) throw cms::Exception("Configuration") << "Mode 'trackingRegionsSeedingLayers' makes sense only with 'produceSeedingHitsSets', now 'produceIntermediateHitDoublets is active instead";
-    impl_ = std::make_unique<::Impl<::DoNothing, ::ImplIntermediateHitDoublets, ::RegionsLayersSeparate>>(iConfig, layersTag, regionTag, consumesCollector());
-  }
-  else
-    throw cms::Exception("Configuration") << "HitPairEDProducer requires either produceIntermediateHitDoublets or produceSeedingHitSets to be True. If neither are needed, just remove this module from your sequence/path as it doesn't do anything useful";
+  } else if (produceIntermediateHitDoublets) {
+    if (useRegionLayers)
+      throw cms::Exception("Configuration")
+          << "Mode 'trackingRegionsSeedingLayers' makes sense only with 'produceSeedingHitsSets', now "
+             "'produceIntermediateHitDoublets is active instead";
+    impl_ = std::make_unique<::Impl<::DoNothing, ::ImplIntermediateHitDoublets, ::RegionsLayersSeparate>>(
+        iConfig, layersTag, regionTag, consumesCollector());
+  } else
+    throw cms::Exception("Configuration")
+        << "HitPairEDProducer requires either produceIntermediateHitDoublets or produceSeedingHitSets to be True. If "
+           "neither are needed, just remove this module from your sequence/path as it doesn't do anything useful";
 
   auto clusterCheckTag = iConfig.getParameter<edm::InputTag>("clusterCheck");
-  if(!clusterCheckTag.label().empty())
+  if (!clusterCheckTag.label().empty())
     clusterCheckToken_ = consumes<bool>(clusterCheckTag);
 
   impl_->produces(*this);
@@ -465,22 +482,31 @@ HitPairEDProducer::HitPairEDProducer(const edm::ParameterSet& iConfig) {
 void HitPairEDProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
 
-  desc.add<edm::InputTag>("seedingLayers", edm::InputTag("seedingLayersEDProducer"))->setComment("Set this empty if 'trackingRegionsSeedingLayers' is non-empty");
-  desc.add<edm::InputTag>("trackingRegions", edm::InputTag("globalTrackingRegionFromBeamSpot"))->setComment("Input tracking regions when using all layer sets in 'seedingLayers' (conflicts with 'trackingRegionsSeedingLayers', set this empty to use the other)");
-  desc.add<edm::InputTag>("trackingRegionsSeedingLayers", edm::InputTag(""))->setComment("Input tracking regions and corresponding layer sets in case of dynamically limiting the seeding layers (conflicts with 'trackingRegions', set this empty to use the other; if using this set also 'seedingLayers' to empty)");
+  desc.add<edm::InputTag>("seedingLayers", edm::InputTag("seedingLayersEDProducer"))
+      ->setComment("Set this empty if 'trackingRegionsSeedingLayers' is non-empty");
+  desc.add<edm::InputTag>("trackingRegions", edm::InputTag("globalTrackingRegionFromBeamSpot"))
+      ->setComment(
+          "Input tracking regions when using all layer sets in 'seedingLayers' (conflicts with "
+          "'trackingRegionsSeedingLayers', set this empty to use the other)");
+  desc.add<edm::InputTag>("trackingRegionsSeedingLayers", edm::InputTag(""))
+      ->setComment(
+          "Input tracking regions and corresponding layer sets in case of dynamically limiting the seeding layers "
+          "(conflicts with 'trackingRegions', set this empty to use the other; if using this set also 'seedingLayers' "
+          "to empty)");
   desc.add<edm::InputTag>("clusterCheck", edm::InputTag("trackerClusterCheck"));
   desc.add<bool>("produceSeedingHitSets", false);
   desc.add<bool>("produceIntermediateHitDoublets", false);
   desc.add<unsigned int>("maxElement", 1000000);
   desc.add<unsigned int>("maxElementTotal", 50000000);
-  desc.add<std::vector<unsigned> >("layerPairs", std::vector<unsigned>{0})->setComment("Indices to the pairs of consecutive layers, i.e. 0 means (0,1), 1 (1,2) etc.");
+  desc.add<std::vector<unsigned>>("layerPairs", std::vector<unsigned>{0})
+      ->setComment("Indices to the pairs of consecutive layers, i.e. 0 means (0,1), 1 (1,2) etc.");
 
   descriptions.add("hitPairEDProducerDefault", desc);
 }
 
 void HitPairEDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   bool clusterCheckOk = true;
-  if(!clusterCheckToken_.isUninitialized()) {
+  if (!clusterCheckToken_.isUninitialized()) {
     edm::Handle<bool> hclusterCheck;
     iEvent.getByToken(clusterCheckToken_, hclusterCheck);
     clusterCheckOk = *hclusterCheck;

--- a/RecoTracker/TkHitPairs/plugins/SealModule.cc
+++ b/RecoTracker/TkHitPairs/plugins/SealModule.cc
@@ -1,10 +1,8 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
 #include "RecoTracker/TkTrackingRegions/interface/OrderedHitsGeneratorFactory.h"
 #include "RecoTracker/TkTrackingRegions/interface/OrderedHitsGenerator.h"
 #include "RecoTracker/TkHitPairs/interface/CombinedHitPairGenerator.h"
 
 DEFINE_EDM_PLUGIN(OrderedHitsGeneratorFactory, CombinedHitPairGenerator, "StandardHitPairGenerator");
-

--- a/RecoTracker/TkHitPairs/src/CombinedHitPairGenerator.cc
+++ b/RecoTracker/TkHitPairs/src/CombinedHitPairGenerator.cc
@@ -4,38 +4,37 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 
-CombinedHitPairGenerator::CombinedHitPairGenerator(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC):
-  theSeedingLayerToken(iC.consumes<SeedingLayerSetsHits>(cfg.getParameter<edm::InputTag>("SeedingLayers")))
-{
+CombinedHitPairGenerator::CombinedHitPairGenerator(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC)
+    : theSeedingLayerToken(iC.consumes<SeedingLayerSetsHits>(cfg.getParameter<edm::InputTag>("SeedingLayers"))) {
   theMaxElement = cfg.getParameter<unsigned int>("maxElement");
   theGenerator = std::make_unique<HitPairGeneratorFromLayerPair>(0, 1, &theLayerCache, theMaxElement);
 }
 
-CombinedHitPairGenerator::CombinedHitPairGenerator(const CombinedHitPairGenerator& cb):
-  theSeedingLayerToken(cb.theSeedingLayerToken),
-  theGenerator(std::make_unique<HitPairGeneratorFromLayerPair>(0, 1, &theLayerCache, cb.theMaxElement))
-{
+CombinedHitPairGenerator::CombinedHitPairGenerator(const CombinedHitPairGenerator& cb)
+    : theSeedingLayerToken(cb.theSeedingLayerToken),
+      theGenerator(std::make_unique<HitPairGeneratorFromLayerPair>(0, 1, &theLayerCache, cb.theMaxElement)) {
   theMaxElement = cb.theMaxElement;
 }
 
 CombinedHitPairGenerator::~CombinedHitPairGenerator() {}
 
-void CombinedHitPairGenerator::hitPairs(
-   const TrackingRegion& region, OrderedHitPairs  & result,
-   const edm::Event& ev, const edm::EventSetup& es)
-{
+void CombinedHitPairGenerator::hitPairs(const TrackingRegion& region,
+                                        OrderedHitPairs& result,
+                                        const edm::Event& ev,
+                                        const edm::EventSetup& es) {
   edm::Handle<SeedingLayerSetsHits> hlayers;
   ev.getByToken(theSeedingLayerToken, hlayers);
   const SeedingLayerSetsHits& layers = *hlayers;
-  if(layers.numberOfLayersInSet() != 2)
-    throw cms::Exception("Configuration") << "CombinedHitPairGenerator expects SeedingLayerSetsHits::numberOfLayersInSet() to be 2, got " << layers.numberOfLayersInSet();
+  if (layers.numberOfLayersInSet() != 2)
+    throw cms::Exception("Configuration")
+        << "CombinedHitPairGenerator expects SeedingLayerSetsHits::numberOfLayersInSet() to be 2, got "
+        << layers.numberOfLayersInSet();
 
-  for(SeedingLayerSetsHits::SeedingLayerSet layerSet: layers) {
-    theGenerator->hitPairs( region, result, ev, es, layerSet);
+  for (SeedingLayerSetsHits::SeedingLayerSet layerSet : layers) {
+    theGenerator->hitPairs(region, result, ev, es, layerSet);
   }
 
   theLayerCache.clear();
 
-  LogDebug("CombinedHitPairGenerator")<<" total number of pairs provided back CHPG : "<<result.size();
-
+  LogDebug("CombinedHitPairGenerator") << " total number of pairs provided back CHPG : " << result.size();
 }

--- a/RecoTracker/TkHitPairs/src/CosmicHitPairGenerator.cc
+++ b/RecoTracker/TkHitPairs/src/CosmicHitPairGenerator.cc
@@ -6,44 +6,27 @@
 
 using namespace std;
 
-
-CosmicHitPairGenerator::CosmicHitPairGenerator(SeedLayerPairs& layers,
-						   const edm::EventSetup& iSetup)
-{
-
+CosmicHitPairGenerator::CosmicHitPairGenerator(SeedLayerPairs& layers, const edm::EventSetup& iSetup) {
   vector<SeedLayerPairs::LayerPair> layerPairs = layers();
   vector<SeedLayerPairs::LayerPair>::const_iterator it;
   for (it = layerPairs.begin(); it != layerPairs.end(); it++) {
-    add( (*it).first, (*it).second,iSetup);
+    add((*it).first, (*it).second, iSetup);
   }
-
 }
 
+CosmicHitPairGenerator::~CosmicHitPairGenerator() {}
 
-
-CosmicHitPairGenerator::~CosmicHitPairGenerator()
-{
+void CosmicHitPairGenerator::add(const LayerWithHits* inner,
+                                 const LayerWithHits* outer,
+                                 const edm::EventSetup& iSetup) {
+  theGenerators.push_back(std::make_unique<CosmicHitPairGeneratorFromLayerPair>(inner, outer, iSetup));
 }
 
-
-void CosmicHitPairGenerator::add(
-				   const LayerWithHits *inner, const LayerWithHits *outer,
-				   const edm::EventSetup& iSetup) 
-{ 
-  theGenerators.push_back(std::make_unique<CosmicHitPairGeneratorFromLayerPair>( inner, outer, iSetup));
-}
-
-void CosmicHitPairGenerator::hitPairs(
-					const TrackingRegion& region, 
-					OrderedHitPairs & pairs,
-					const edm::EventSetup& iSetup)
-{
-
+void CosmicHitPairGenerator::hitPairs(const TrackingRegion& region,
+                                      OrderedHitPairs& pairs,
+                                      const edm::EventSetup& iSetup) {
   Container::const_iterator i;
-  for (i=theGenerators.begin(); i!=theGenerators.end(); i++) {
-    (**i).hitPairs( region, pairs, iSetup); 
+  for (i = theGenerators.begin(); i != theGenerators.end(); i++) {
+    (**i).hitPairs(region, pairs, iSetup);
   }
- 
 }
-
-

--- a/RecoTracker/TkHitPairs/src/CosmicHitPairGeneratorFromLayerPair.cc
+++ b/RecoTracker/TkHitPairs/src/CosmicHitPairGeneratorFromLayerPair.cc
@@ -12,37 +12,36 @@
 using namespace std;
 // typedef TransientTrackingRecHit::ConstRecHitPointer TkHitPairsCachedHit;
 
-CosmicHitPairGeneratorFromLayerPair::CosmicHitPairGeneratorFromLayerPair(const LayerWithHits* inner, 
-							     const LayerWithHits* outer, 
-									 //							     LayerCacheType* layerCache, 
-							     const edm::EventSetup& iSetup)
-  : TTRHbuilder(nullptr),trackerGeometry(nullptr),
-    //theLayerCache(*layerCache), 
-    theOuterLayer(outer), theInnerLayer(inner)
-{
-
+CosmicHitPairGeneratorFromLayerPair::CosmicHitPairGeneratorFromLayerPair(
+    const LayerWithHits* inner,
+    const LayerWithHits* outer,
+    //							     LayerCacheType* layerCache,
+    const edm::EventSetup& iSetup)
+    : TTRHbuilder(nullptr),
+      trackerGeometry(nullptr),
+      //theLayerCache(*layerCache),
+      theOuterLayer(outer),
+      theInnerLayer(inner) {
   edm::ESHandle<TrackerGeometry> tracker;
   iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
   trackerGeometry = tracker.product();
 }
 CosmicHitPairGeneratorFromLayerPair::~CosmicHitPairGeneratorFromLayerPair() {}
-void CosmicHitPairGeneratorFromLayerPair::hitPairs(
-  const TrackingRegion & region, OrderedHitPairs & result,
-  const edm::EventSetup& iSetup)
-{
-//  static int NSee = 0; static int Ntry = 0; static int Nacc = 0;
-
+void CosmicHitPairGeneratorFromLayerPair::hitPairs(const TrackingRegion& region,
+                                                   OrderedHitPairs& result,
+                                                   const edm::EventSetup& iSetup) {
+  //  static int NSee = 0; static int Ntry = 0; static int Nacc = 0;
 
   typedef OrderedHitPair::InnerRecHit InnerHit;
   typedef OrderedHitPair::OuterRecHit OuterHit;
 
+  if (theInnerLayer->recHits().empty())
+    return;
 
-  if (theInnerLayer->recHits().empty()) return;
-
-  if (theOuterLayer->recHits().empty()) return;
+  if (theOuterLayer->recHits().empty())
+    return;
   //  const DetLayer* innerlay=theOuterLayer->layer();
   // const BarrelDetLayer *pippo=dynamic_cast<const BarrelDetLayer*>(theOuterLayer->layer());
-
 
   // ************ Daniele
 
@@ -51,80 +50,71 @@ void CosmicHitPairGeneratorFromLayerPair::hitPairs(
   blay1 = dynamic_cast<const BarrelDetLayer*>(theInnerLayer->layer());
   blay2 = dynamic_cast<const BarrelDetLayer*>(theOuterLayer->layer());
 
-
-  bool seedfromoverlaps= false;
+  bool seedfromoverlaps = false;
   bool InTheBarrel = false;
   bool InTheForward = false;
   if (blay1 && blay2) {
     InTheBarrel = true;
-  }
-  else  InTheForward = true;
+  } else
+    InTheForward = true;
 
-  if (InTheBarrel){
-    float radius1 =dynamic_cast<const BarrelDetLayer*>(theInnerLayer->layer())->specificSurface().radius();
-    float radius2 =dynamic_cast<const BarrelDetLayer*>(theOuterLayer->layer())->specificSurface().radius();
-     seedfromoverlaps=(abs(radius1-radius2)<0.1) ? true : false;
+  if (InTheBarrel) {
+    float radius1 = dynamic_cast<const BarrelDetLayer*>(theInnerLayer->layer())->specificSurface().radius();
+    float radius2 = dynamic_cast<const BarrelDetLayer*>(theOuterLayer->layer())->specificSurface().radius();
+    seedfromoverlaps = (abs(radius1 - radius2) < 0.1) ? true : false;
   }
 
- 
   vector<OrderedHitPair> allthepairs;
   std::string builderName = "WithTrackAngle";
   edm::ESHandle<TransientTrackingRecHitBuilder> builder;
   iSetup.get<TransientRecHitRecord>().get(builderName, builder);
 
-  
+  for (auto ohh = theOuterLayer->recHits().begin(); ohh != theOuterLayer->recHits().end(); ohh++) {
+    for (auto ihh = theInnerLayer->recHits().begin(); ihh != theInnerLayer->recHits().end(); ihh++) {
+      auto oh = static_cast<BaseTrackerRecHit const* const>(*ohh);
+      auto ih = static_cast<BaseTrackerRecHit const* const>(*ihh);
 
-  for( auto ohh=theOuterLayer->recHits().begin();ohh!=theOuterLayer->recHits().end();ohh++){
-    for(auto ihh=theInnerLayer->recHits().begin();ihh!=theInnerLayer->recHits().end();ihh++){
-     auto oh = static_cast<BaseTrackerRecHit const * const>(*ohh);
-     auto ih = static_cast<BaseTrackerRecHit const * const>(*ihh);
-      
-      float z_diff =ih->globalPosition().z()-oh->globalPosition().z();
-      float inny=ih->globalPosition().y();
-      float outy=oh->globalPosition().y();
-      float innx=ih->globalPosition().x();
-      float outx=oh->globalPosition().x();;
-      float dxdy=abs((outx-innx)/(outy-inny));
-      float DeltaR=oh->globalPosition().perp()-ih->globalPosition().perp();;
-      
-      if( InTheBarrel && (abs(z_diff)<30) // && (outy > 0.) && (inny > 0.)
-	  //&&((abs(inny-outy))<30) 
-	  &&(dxdy<2)
-	  &&(inny*outy>0)
-	  && (abs(DeltaR)>0)) {
+      float z_diff = ih->globalPosition().z() - oh->globalPosition().z();
+      float inny = ih->globalPosition().y();
+      float outy = oh->globalPosition().y();
+      float innx = ih->globalPosition().x();
+      float outx = oh->globalPosition().x();
+      ;
+      float dxdy = abs((outx - innx) / (outy - inny));
+      float DeltaR = oh->globalPosition().perp() - ih->globalPosition().perp();
+      ;
 
-	//	cout << " ******** sono dentro inthebarrel *********** " << endl;
-	if (seedfromoverlaps){
-	  //this part of code works for MTCC
-	  // for the other geometries must be verified
-	  //Overlaps in the difference in z is decreased and the difference in phi is
-	  //less than 0.05
-	  if ((DeltaR<0)&&(abs(z_diff)<18)&&(abs(ih->globalPosition().phi()-oh->globalPosition().phi())<0.05)&&(dxdy<2)) result.push_back( OrderedHitPair(ih, oh));
-	}
-	else  result.push_back( OrderedHitPair( ih, oh));
-      
-	
-
-
+      if (InTheBarrel &&
+          (abs(z_diff) < 30)  // && (outy > 0.) && (inny > 0.)
+          //&&((abs(inny-outy))<30)
+          && (dxdy < 2) && (inny * outy > 0) && (abs(DeltaR) > 0)) {
+        //	cout << " ******** sono dentro inthebarrel *********** " << endl;
+        if (seedfromoverlaps) {
+          //this part of code works for MTCC
+          // for the other geometries must be verified
+          //Overlaps in the difference in z is decreased and the difference in phi is
+          //less than 0.05
+          if ((DeltaR < 0) && (abs(z_diff) < 18) &&
+              (abs(ih->globalPosition().phi() - oh->globalPosition().phi()) < 0.05) && (dxdy < 2))
+            result.push_back(OrderedHitPair(ih, oh));
+        } else
+          result.push_back(OrderedHitPair(ih, oh));
       }
-      if( InTheForward &&  (abs(z_diff) > 1.)) {
-	//	cout << " ******** sono dentro intheforward *********** " << endl;
-	result.push_back( OrderedHitPair(ih,oh));
+      if (InTheForward && (abs(z_diff) > 1.)) {
+        //	cout << " ******** sono dentro intheforward *********** " << endl;
+        result.push_back(OrderedHitPair(ih, oh));
       }
     }
   }
 
-//   stable_sort(allthepairs.begin(),allthepairs.end(),CompareHitPairsY(iSetup));
-//   //Seed from overlaps are saved only if 
-//   //no others have been saved
+  //   stable_sort(allthepairs.begin(),allthepairs.end(),CompareHitPairsY(iSetup));
+  //   //Seed from overlaps are saved only if
+  //   //no others have been saved
 
-//   if (allthepairs.size()>0) {
-//     if (seedfromoverlaps) {
-//       if (result.size()==0) result.push_back(allthepairs[0]);
-//     }
-//     else result.push_back(allthepairs[0]);
-//   }
-
-
+  //   if (allthepairs.size()>0) {
+  //     if (seedfromoverlaps) {
+  //       if (result.size()==0) result.push_back(allthepairs[0]);
+  //     }
+  //     else result.push_back(allthepairs[0]);
+  //   }
 }
-

--- a/RecoTracker/TkHitPairs/src/CosmicLayerPairs.cc
+++ b/RecoTracker/TkHitPairs/src/CosmicLayerPairs.cc
@@ -12,413 +12,392 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
-std::vector<SeedLayerPairs::LayerPair> CosmicLayerPairs::operator()() 
-{
+std::vector<SeedLayerPairs::LayerPair> CosmicLayerPairs::operator()() {
   std::vector<SeedLayerPairs::LayerPair> result;
 
-  if (_geometry=="STANDARD"){
-//      result.push_back( SeedLayerPairs::LayerPair(&TIBLayerWithHits[1], &TIBLayerWithHits[0]));
-//      result.push_back( SeedLayerPairs::LayerPair(&TIBLayerWithHits[2], &TIBLayerWithHits[0]));
+  if (_geometry == "STANDARD") {
+    //      result.push_back( SeedLayerPairs::LayerPair(&TIBLayerWithHits[1], &TIBLayerWithHits[0]));
+    //      result.push_back( SeedLayerPairs::LayerPair(&TIBLayerWithHits[2], &TIBLayerWithHits[0]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&TOBLayerWithHits[4], &TOBLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[4]));
+    result.push_back(SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&TOBLayerWithHits[4], &TOBLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[4]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[7], &TECPlusLayerWithHits[8]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[6], &TECPlusLayerWithHits[8]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[7], &TECPlusLayerWithHits[8]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[6], &TECPlusLayerWithHits[8]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[6], &TECPlusLayerWithHits[7]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[5], &TECPlusLayerWithHits[7]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[6], &TECPlusLayerWithHits[7]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[5], &TECPlusLayerWithHits[7]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[5], &TECPlusLayerWithHits[6]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[4], &TECPlusLayerWithHits[6]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[5], &TECPlusLayerWithHits[6]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[4], &TECPlusLayerWithHits[6]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[4], &TECPlusLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[3], &TECPlusLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[4], &TECPlusLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[3], &TECPlusLayerWithHits[5]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[3], &TECPlusLayerWithHits[4]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[2], &TECPlusLayerWithHits[4]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[3], &TECPlusLayerWithHits[4]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[2], &TECPlusLayerWithHits[4]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[2], &TECPlusLayerWithHits[3]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[1], &TECPlusLayerWithHits[3]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[2], &TECPlusLayerWithHits[3]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[1], &TECPlusLayerWithHits[3]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[1], &TECPlusLayerWithHits[2]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[0], &TECPlusLayerWithHits[2]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[1], &TECPlusLayerWithHits[2]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[0], &TECPlusLayerWithHits[2]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[0], &TECPlusLayerWithHits[1]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[0], &TECPlusLayerWithHits[1]));
 
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[7], &TECMinusLayerWithHits[8]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[6], &TECMinusLayerWithHits[8]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[7], &TECMinusLayerWithHits[8]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[6], &TECMinusLayerWithHits[8]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[6], &TECMinusLayerWithHits[7]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[5], &TECMinusLayerWithHits[7]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[6], &TECMinusLayerWithHits[7]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[5], &TECMinusLayerWithHits[7]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[5], &TECMinusLayerWithHits[6]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[4], &TECMinusLayerWithHits[6]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[5], &TECMinusLayerWithHits[6]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[4], &TECMinusLayerWithHits[6]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[4], &TECMinusLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[3], &TECMinusLayerWithHits[5]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[4], &TECMinusLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[3], &TECMinusLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[3], &TECMinusLayerWithHits[4]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[2], &TECMinusLayerWithHits[4]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[3], &TECMinusLayerWithHits[4]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[2], &TECMinusLayerWithHits[4]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[2], &TECMinusLayerWithHits[3]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[1], &TECMinusLayerWithHits[3]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[2], &TECMinusLayerWithHits[3]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[1], &TECMinusLayerWithHits[3]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[1], &TECMinusLayerWithHits[2]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[0], &TECMinusLayerWithHits[2]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[1], &TECMinusLayerWithHits[2]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[0], &TECMinusLayerWithHits[2]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[0], &TECMinusLayerWithHits[1]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[0], &TECMinusLayerWithHits[1]));
+  } else if (_geometry == "TECPAIRS_TOBTRIPLETS") {
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[7], &TECPlusLayerWithHits[8]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[6], &TECPlusLayerWithHits[8]));
 
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[6], &TECPlusLayerWithHits[7]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[5], &TECPlusLayerWithHits[7]));
 
-  } 
-  else if(_geometry=="TECPAIRS_TOBTRIPLETS"){
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[7], &TECPlusLayerWithHits[8]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[6], &TECPlusLayerWithHits[8]));
-    
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[6], &TECPlusLayerWithHits[7]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[5], &TECPlusLayerWithHits[7]));
-    
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[5], &TECPlusLayerWithHits[6]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[4], &TECPlusLayerWithHits[6]));
-    
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[4], &TECPlusLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[3], &TECPlusLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[5], &TECPlusLayerWithHits[6]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[4], &TECPlusLayerWithHits[6]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[3], &TECPlusLayerWithHits[4]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[2], &TECPlusLayerWithHits[4]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[4], &TECPlusLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[3], &TECPlusLayerWithHits[5]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[2], &TECPlusLayerWithHits[3]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[1], &TECPlusLayerWithHits[3]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[3], &TECPlusLayerWithHits[4]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[2], &TECPlusLayerWithHits[4]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[1], &TECPlusLayerWithHits[2]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[0], &TECPlusLayerWithHits[2]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[2], &TECPlusLayerWithHits[3]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[1], &TECPlusLayerWithHits[3]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[0], &TECPlusLayerWithHits[1]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[1], &TECPlusLayerWithHits[2]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[0], &TECPlusLayerWithHits[2]));
 
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[0], &TECPlusLayerWithHits[1]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[7], &TECMinusLayerWithHits[8]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[6], &TECMinusLayerWithHits[8]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[7], &TECMinusLayerWithHits[8]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[6], &TECMinusLayerWithHits[8]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[6], &TECMinusLayerWithHits[7]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[5], &TECMinusLayerWithHits[7]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[6], &TECMinusLayerWithHits[7]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[5], &TECMinusLayerWithHits[7]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[5], &TECMinusLayerWithHits[6]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[4], &TECMinusLayerWithHits[6]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[5], &TECMinusLayerWithHits[6]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[4], &TECMinusLayerWithHits[6]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[4], &TECMinusLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[3], &TECMinusLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[4], &TECMinusLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[3], &TECMinusLayerWithHits[5]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[3], &TECMinusLayerWithHits[4]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[2], &TECMinusLayerWithHits[4]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[3], &TECMinusLayerWithHits[4]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[2], &TECMinusLayerWithHits[4]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[2], &TECMinusLayerWithHits[3]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[1], &TECMinusLayerWithHits[3]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[2], &TECMinusLayerWithHits[3]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[1], &TECMinusLayerWithHits[3]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[1], &TECMinusLayerWithHits[2]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[0], &TECMinusLayerWithHits[2]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[1], &TECMinusLayerWithHits[2]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[0], &TECMinusLayerWithHits[2]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[0], &TECMinusLayerWithHits[1]));
-    
+    result.push_back(SeedLayerPairs::LayerPair(&TECMinusLayerWithHits[0], &TECMinusLayerWithHits[1]));
 
-  }
-  else if (_geometry=="MTCC"){
-    result.push_back( SeedLayerPairs::LayerPair(&MTCCLayerWithHits[1],&MTCCLayerWithHits[0]));
-    result.push_back( SeedLayerPairs::LayerPair(&MTCCLayerWithHits[2],&MTCCLayerWithHits[3]));
+  } else if (_geometry == "MTCC") {
+    result.push_back(SeedLayerPairs::LayerPair(&MTCCLayerWithHits[1], &MTCCLayerWithHits[0]));
+    result.push_back(SeedLayerPairs::LayerPair(&MTCCLayerWithHits[2], &MTCCLayerWithHits[3]));
     //IMPORTANT
     // The seed from overlaps must be at the end
-    result.push_back( SeedLayerPairs::LayerPair(&MTCCLayerWithHits[0],&MTCCLayerWithHits[0]));
-    result.push_back( SeedLayerPairs::LayerPair(&MTCCLayerWithHits[1],&MTCCLayerWithHits[1]));	
-  } 
-  else if (_geometry=="CRACK"){
+    result.push_back(SeedLayerPairs::LayerPair(&MTCCLayerWithHits[0], &MTCCLayerWithHits[0]));
+    result.push_back(SeedLayerPairs::LayerPair(&MTCCLayerWithHits[1], &MTCCLayerWithHits[1]));
+  } else if (_geometry == "CRACK") {
     //TODO: clean all this. Now this is a random choice of layers
-    result.push_back( SeedLayerPairs::LayerPair(&CRACKLayerWithHits[1],&CRACKLayerWithHits[0]));
-    result.push_back( SeedLayerPairs::LayerPair(&CRACKLayerWithHits[2],&CRACKLayerWithHits[0]));
-    result.push_back( SeedLayerPairs::LayerPair(&CRACKLayerWithHits[2],&CRACKLayerWithHits[1]));
-    result.push_back( SeedLayerPairs::LayerPair(&CRACKLayerWithHits[3],&CRACKLayerWithHits[2]));
-    result.push_back( SeedLayerPairs::LayerPair(&CRACKLayerWithHits[5],&CRACKLayerWithHits[4]));
-    result.push_back( SeedLayerPairs::LayerPair(&CRACKLayerWithHits[6],&CRACKLayerWithHits[4]));
-    result.push_back( SeedLayerPairs::LayerPair(&CRACKLayerWithHits[6],&CRACKLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&CRACKLayerWithHits[7],&CRACKLayerWithHits[6]));
-    result.push_back( SeedLayerPairs::LayerPair(&CRACKLayerWithHits[8],&CRACKLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&CRACKLayerWithHits[9],&CRACKLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&CRACKLayerWithHits[10],&CRACKLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&CRACKLayerWithHits[11],&CRACKLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&CRACKLayerWithHits[12],&CRACKLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&CRACKLayerWithHits[13],&CRACKLayerWithHits[5]));
-  } 
-  else if (_geometry=="TIBD+"){
-    result.push_back( SeedLayerPairs::LayerPair(&TIBLayerWithHits[1],&TIBLayerWithHits[0]));
-    result.push_back( SeedLayerPairs::LayerPair(&TIBLayerWithHits[2],&TIBLayerWithHits[3]));
-    result.push_back( SeedLayerPairs::LayerPair(&TIBLayerWithHits[0],&TIBLayerWithHits[0]));
-    result.push_back( SeedLayerPairs::LayerPair(&TIBLayerWithHits[1],&TIBLayerWithHits[1]));
-  } 
-  else if (_geometry=="TOB") {
-    result.push_back( SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&TOBLayerWithHits[4], &TOBLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[4]));
-    
-  } 
-  else if(_geometry=="TIBTOB") {
-    result.push_back( SeedLayerPairs::LayerPair(&TIBLayerWithHits[1], &TIBLayerWithHits[0]));
-    result.push_back( SeedLayerPairs::LayerPair(&TIBLayerWithHits[2], &TIBLayerWithHits[0]));
+    result.push_back(SeedLayerPairs::LayerPair(&CRACKLayerWithHits[1], &CRACKLayerWithHits[0]));
+    result.push_back(SeedLayerPairs::LayerPair(&CRACKLayerWithHits[2], &CRACKLayerWithHits[0]));
+    result.push_back(SeedLayerPairs::LayerPair(&CRACKLayerWithHits[2], &CRACKLayerWithHits[1]));
+    result.push_back(SeedLayerPairs::LayerPair(&CRACKLayerWithHits[3], &CRACKLayerWithHits[2]));
+    result.push_back(SeedLayerPairs::LayerPair(&CRACKLayerWithHits[5], &CRACKLayerWithHits[4]));
+    result.push_back(SeedLayerPairs::LayerPair(&CRACKLayerWithHits[6], &CRACKLayerWithHits[4]));
+    result.push_back(SeedLayerPairs::LayerPair(&CRACKLayerWithHits[6], &CRACKLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&CRACKLayerWithHits[7], &CRACKLayerWithHits[6]));
+    result.push_back(SeedLayerPairs::LayerPair(&CRACKLayerWithHits[8], &CRACKLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&CRACKLayerWithHits[9], &CRACKLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&CRACKLayerWithHits[10], &CRACKLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&CRACKLayerWithHits[11], &CRACKLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&CRACKLayerWithHits[12], &CRACKLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&CRACKLayerWithHits[13], &CRACKLayerWithHits[5]));
+  } else if (_geometry == "TIBD+") {
+    result.push_back(SeedLayerPairs::LayerPair(&TIBLayerWithHits[1], &TIBLayerWithHits[0]));
+    result.push_back(SeedLayerPairs::LayerPair(&TIBLayerWithHits[2], &TIBLayerWithHits[3]));
+    result.push_back(SeedLayerPairs::LayerPair(&TIBLayerWithHits[0], &TIBLayerWithHits[0]));
+    result.push_back(SeedLayerPairs::LayerPair(&TIBLayerWithHits[1], &TIBLayerWithHits[1]));
+  } else if (_geometry == "TOB") {
+    result.push_back(SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&TOBLayerWithHits[4], &TOBLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[4]));
 
-    result.push_back( SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&TOBLayerWithHits[4], &TOBLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[4]));
- 
+  } else if (_geometry == "TIBTOB") {
+    result.push_back(SeedLayerPairs::LayerPair(&TIBLayerWithHits[1], &TIBLayerWithHits[0]));
+    result.push_back(SeedLayerPairs::LayerPair(&TIBLayerWithHits[2], &TIBLayerWithHits[0]));
+
+    result.push_back(SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&TOBLayerWithHits[4], &TOBLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[4]));
+
+  } else if (_geometry == "TEC+") {
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[7], &TECPlusLayerWithHits[8]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[6], &TECPlusLayerWithHits[8]));
+
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[6], &TECPlusLayerWithHits[7]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[5], &TECPlusLayerWithHits[7]));
+
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[5], &TECPlusLayerWithHits[6]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[4], &TECPlusLayerWithHits[6]));
+
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[4], &TECPlusLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[3], &TECPlusLayerWithHits[5]));
+
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[3], &TECPlusLayerWithHits[4]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[2], &TECPlusLayerWithHits[4]));
+
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[2], &TECPlusLayerWithHits[3]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[1], &TECPlusLayerWithHits[3]));
+
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[2], &TECPlusLayerWithHits[1]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[2], &TECPlusLayerWithHits[0]));
+
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[1], &TECPlusLayerWithHits[0]));
+
+  } else if (_geometry == "CkfTIBD+") {
+    result.push_back(SeedLayerPairs::LayerPair(&TIBLayerWithHits[0], &TIBLayerWithHits[1]));
+    result.push_back(SeedLayerPairs::LayerPair(&TIBLayerWithHits[2], &TIBLayerWithHits[3]));
+  } else if (_geometry == "CkfTIBTOB") {
+    result.push_back(SeedLayerPairs::LayerPair(&TIBLayerWithHits[0], &TIBLayerWithHits[1]));
+    result.push_back(SeedLayerPairs::LayerPair(&TIBLayerWithHits[0], &TIBLayerWithHits[2]));
+
+    result.push_back(SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&TOBLayerWithHits[4], &TOBLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[4]));
+  } else if (_geometry == "CkfTIF3") {
+    result.push_back(SeedLayerPairs::LayerPair(&TIBLayerWithHits[0], &TIBLayerWithHits[1]));
+    result.push_back(SeedLayerPairs::LayerPair(&TIBLayerWithHits[0], &TIBLayerWithHits[2]));
+
+    result.push_back(SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&TOBLayerWithHits[4], &TOBLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[4]));
+
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[7], &TECPlusLayerWithHits[8]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[6], &TECPlusLayerWithHits[8]));
+
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[6], &TECPlusLayerWithHits[7]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[5], &TECPlusLayerWithHits[7]));
+
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[5], &TECPlusLayerWithHits[6]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[4], &TECPlusLayerWithHits[6]));
+
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[4], &TECPlusLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[3], &TECPlusLayerWithHits[5]));
+
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[3], &TECPlusLayerWithHits[4]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[2], &TECPlusLayerWithHits[4]));
+
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[2], &TECPlusLayerWithHits[3]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[1], &TECPlusLayerWithHits[3]));
+
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[1], &TECPlusLayerWithHits[2]));
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[0], &TECPlusLayerWithHits[2]));
+
+    result.push_back(SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[0], &TECPlusLayerWithHits[1]));
+
+  } else if (_geometry == "CkfTOB") {
+    result.push_back(SeedLayerPairs::LayerPair(&TOBLayerWithHits[0], &TOBLayerWithHits[1]));
+    result.push_back(SeedLayerPairs::LayerPair(&TOBLayerWithHits[0], &TOBLayerWithHits[2]));
+
+    result.push_back(SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[4]));
+    result.push_back(SeedLayerPairs::LayerPair(&TOBLayerWithHits[4], &TOBLayerWithHits[5]));
+    result.push_back(SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[5]));
+  } else {
+    throw cms::Exception("CosmicLayerPairs") << "The geometry " << _geometry << " is not implemented ";
   }
-  else if (_geometry=="TEC+") {
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[7], &TECPlusLayerWithHits[8]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[6], &TECPlusLayerWithHits[8]));
-    
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[6], &TECPlusLayerWithHits[7]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[5], &TECPlusLayerWithHits[7]));
-    
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[5], &TECPlusLayerWithHits[6]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[4], &TECPlusLayerWithHits[6]));
-    
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[4], &TECPlusLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[3], &TECPlusLayerWithHits[5]));
-    
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[3], &TECPlusLayerWithHits[4]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[2], &TECPlusLayerWithHits[4]));
-    
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[2], &TECPlusLayerWithHits[3]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[1], &TECPlusLayerWithHits[3]));
-    
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[2], &TECPlusLayerWithHits[1]));
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[2], &TECPlusLayerWithHits[0]));
-    
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[1], &TECPlusLayerWithHits[0]));
-    
-  }
-  else if (_geometry=="CkfTIBD+"){
-    result.push_back( SeedLayerPairs::LayerPair(&TIBLayerWithHits[0], &TIBLayerWithHits[1]));
-    result.push_back( SeedLayerPairs::LayerPair(&TIBLayerWithHits[2], &TIBLayerWithHits[3]));
-  } 
-  else if (_geometry=="CkfTIBTOB"){
-    result.push_back( SeedLayerPairs::LayerPair(&TIBLayerWithHits[0], &TIBLayerWithHits[1]));
-    result.push_back( SeedLayerPairs::LayerPair(&TIBLayerWithHits[0], &TIBLayerWithHits[2]));
-
-    result.push_back( SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&TOBLayerWithHits[4], &TOBLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[4]));
-  }
-  else if (_geometry=="CkfTIF3"){
-    result.push_back( SeedLayerPairs::LayerPair(&TIBLayerWithHits[0], &TIBLayerWithHits[1]));
-    result.push_back( SeedLayerPairs::LayerPair(&TIBLayerWithHits[0], &TIBLayerWithHits[2]));
-    
-    result.push_back( SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&TOBLayerWithHits[4], &TOBLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[4]));
-
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[7], &TECPlusLayerWithHits[8]));	
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[6], &TECPlusLayerWithHits[8]));	
-
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[6], &TECPlusLayerWithHits[7]));	
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[5], &TECPlusLayerWithHits[7]));
-	
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[5], &TECPlusLayerWithHits[6]));	
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[4], &TECPlusLayerWithHits[6]));	
-
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[4], &TECPlusLayerWithHits[5]));	
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[3], &TECPlusLayerWithHits[5]));	
-
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[3], &TECPlusLayerWithHits[4]));	
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[2], &TECPlusLayerWithHits[4]));	
-
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[2], &TECPlusLayerWithHits[3]));	
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[1], &TECPlusLayerWithHits[3]));	
-
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[1], &TECPlusLayerWithHits[2]));	
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[0], &TECPlusLayerWithHits[2]));	
-
-    result.push_back( SeedLayerPairs::LayerPair(&TECPlusLayerWithHits[0], &TECPlusLayerWithHits[1]));	
-
-  } 
-  else if (_geometry=="CkfTOB"){
-    result.push_back( SeedLayerPairs::LayerPair(&TOBLayerWithHits[0], &TOBLayerWithHits[1]));
-    result.push_back( SeedLayerPairs::LayerPair(&TOBLayerWithHits[0], &TOBLayerWithHits[2]));
-
-    result.push_back( SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[4]));	
-    result.push_back( SeedLayerPairs::LayerPair(&TOBLayerWithHits[4], &TOBLayerWithHits[5]));
-    result.push_back( SeedLayerPairs::LayerPair(&TOBLayerWithHits[3], &TOBLayerWithHits[5]));
-  } 
-  else {throw cms::Exception("CosmicLayerPairs") << "The geometry " << _geometry << " is not implemented ";}
   return result;
 }
-CosmicLayerPairs::~CosmicLayerPairs(){}
-
-
+CosmicLayerPairs::~CosmicLayerPairs() {}
 
 void CosmicLayerPairs::init(const SiStripRecHit2DCollection &collstereo,
-			    const SiStripRecHit2DCollection &collrphi, 
-			    const SiStripMatchedRecHit2DCollection &collmatched,
-			    //std::string geometry,
-			    const edm::EventSetup& iSetup){
-    ////std::cout << "initializing geometry " << geometry << std::endl;
-    //_geometry=geometry;
+                            const SiStripRecHit2DCollection &collrphi,
+                            const SiStripMatchedRecHit2DCollection &collmatched,
+                            //std::string geometry,
+                            const edm::EventSetup &iSetup) {
+  ////std::cout << "initializing geometry " << geometry << std::endl;
+  //_geometry=geometry;
   //if(isFirstCall){
-    //std::cout << "in isFirtsCall" << std::endl;
-    edm::ESHandle<GeometricSearchTracker> track;
-    iSetup.get<TrackerRecoGeometryRecord>().get( track );
-        //std::cout << "about to take barrel" << std::endl; 
-    bl=track->barrelLayers();
-	//std::cout << "barrel taken" << std::endl;
-    fpos=track->posTecLayers();
-	//std::cout << "pos forw taken" << std::endl;
-    fneg=track->negTecLayers();		
-	//std::cout << "neg forw taken" << std::endl;
+  //std::cout << "in isFirtsCall" << std::endl;
+  edm::ESHandle<GeometricSearchTracker> track;
+  iSetup.get<TrackerRecoGeometryRecord>().get(track);
+  //std::cout << "about to take barrel" << std::endl;
+  bl = track->barrelLayers();
+  //std::cout << "barrel taken" << std::endl;
+  fpos = track->posTecLayers();
+  //std::cout << "pos forw taken" << std::endl;
+  fneg = track->negTecLayers();
+  //std::cout << "neg forw taken" << std::endl;
   //isFirstCall=false;
 
-    edm::ESHandle<TrackerTopology> httopo;
-    iSetup.get<TrackerTopologyRcd>().get(httopo);
-    const TrackerTopology& ttopo = *httopo;
-    	
-    if (_geometry=="MTCC"){//we have to distinguish the MTCC and CRACK case because they have special geometries with different neumbering of layers
-	MTCCLayerWithHits.push_back(new LayerWithHits(bl[0], selectTIBHit(collrphi, ttopo, 1)));
-	MTCCLayerWithHits.push_back(new LayerWithHits(bl[1], selectTIBHit(collrphi, ttopo, 2)));
-	MTCCLayerWithHits.push_back(new LayerWithHits(bl[2], selectTOBHit(collrphi, ttopo, 1)));
-	MTCCLayerWithHits.push_back(new LayerWithHits(bl[3], selectTOBHit(collrphi, ttopo, 2)));
-	return;
-    }
-    if (_geometry=="CRACK"){
-        CRACKLayerWithHits.push_back(new LayerWithHits(bl[6], selectTOBHit(collmatched, ttopo, 7)));
-        CRACKLayerWithHits.push_back(new LayerWithHits(bl[5], selectTOBHit(collmatched, ttopo, 6)));
-        CRACKLayerWithHits.push_back(new LayerWithHits(bl[3], selectTOBHit(collmatched, ttopo, 4)));
-        CRACKLayerWithHits.push_back(new LayerWithHits(bl[2], selectTOBHit(collmatched, ttopo, 3)));
-        CRACKLayerWithHits.push_back(new LayerWithHits(bl[6], selectTOBHit(collrphi, ttopo, 7)));
-        CRACKLayerWithHits.push_back(new LayerWithHits(bl[5], selectTOBHit(collrphi, ttopo, 6)));
-        CRACKLayerWithHits.push_back(new LayerWithHits(bl[3], selectTOBHit(collrphi, ttopo, 4)));
-        CRACKLayerWithHits.push_back(new LayerWithHits(bl[2], selectTOBHit(collrphi, ttopo, 3)));
-        CRACKLayerWithHits.push_back(new LayerWithHits(bl[4], selectTOBHit(collrphi, ttopo, 5)));
-        CRACKLayerWithHits.push_back(new LayerWithHits(bl[1], selectTOBHit(collrphi, ttopo, 2)));
-        CRACKLayerWithHits.push_back(new LayerWithHits(bl[0], selectTOBHit(collrphi, ttopo, 1)));
-        CRACKLayerWithHits.push_back(new LayerWithHits(bl[4], selectTOBHit(collmatched, ttopo, 5)));
-        CRACKLayerWithHits.push_back(new LayerWithHits(bl[1], selectTOBHit(collmatched, ttopo, 2)));
-        CRACKLayerWithHits.push_back(new LayerWithHits(bl[0], selectTOBHit(collmatched, ttopo, 1)));
-	return;
-    }	
-    	
-    TIBLayerWithHits.push_back(new LayerWithHits(bl[3], selectTIBHit(collrphi, ttopo, 1)));  //layer
-        //std::cout << "TIB 0" << std::endl;
-    TIBLayerWithHits.push_back(new LayerWithHits(bl[4], selectTIBHit(collrphi, ttopo, 2)));
-        //std::cout << "TIB 1" << std::endl;
-    TIBLayerWithHits.push_back(new LayerWithHits(bl[5], selectTIBHit(collrphi, ttopo, 3)));
-        //std::cout << "TIB 2" << std::endl;
-    TIBLayerWithHits.push_back(new LayerWithHits(bl[6], selectTIBHit(collrphi, ttopo, 4)));
-        //std::cout << "TIB 3" << std::endl;
+  edm::ESHandle<TrackerTopology> httopo;
+  iSetup.get<TrackerTopologyRcd>().get(httopo);
+  const TrackerTopology &ttopo = *httopo;
 
-    TOBLayerWithHits.push_back(new LayerWithHits(bl[7], selectTOBHit(collrphi, ttopo, 1)));
-        //std::cout << "TOB 0" << std::endl;
-    TOBLayerWithHits.push_back(new LayerWithHits(bl[8], selectTOBHit(collrphi, ttopo, 2)));
-        //std::cout << "TOB 1" << std::endl;
-    TOBLayerWithHits.push_back(new LayerWithHits(bl[9], selectTOBHit(collrphi, ttopo, 3)));
-        //std::cout << "TOB 2" << std::endl;
-    TOBLayerWithHits.push_back(new LayerWithHits(bl[10], selectTOBHit(collrphi, ttopo, 4)));
-        //std::cout << "TOB 3" << std::endl;
-    TOBLayerWithHits.push_back(new LayerWithHits(bl[11], selectTOBHit(collrphi, ttopo, 5)));
-        //std::cout << "TOB 4" << std::endl;
-    TOBLayerWithHits.push_back(new LayerWithHits(bl[12], selectTOBHit(collrphi, ttopo, 6)));
-        //std::cout << "TOB 5" << std::endl;
+  if (_geometry ==
+      "MTCC") {  //we have to distinguish the MTCC and CRACK case because they have special geometries with different neumbering of layers
+    MTCCLayerWithHits.push_back(new LayerWithHits(bl[0], selectTIBHit(collrphi, ttopo, 1)));
+    MTCCLayerWithHits.push_back(new LayerWithHits(bl[1], selectTIBHit(collrphi, ttopo, 2)));
+    MTCCLayerWithHits.push_back(new LayerWithHits(bl[2], selectTOBHit(collrphi, ttopo, 1)));
+    MTCCLayerWithHits.push_back(new LayerWithHits(bl[3], selectTOBHit(collrphi, ttopo, 2)));
+    return;
+  }
+  if (_geometry == "CRACK") {
+    CRACKLayerWithHits.push_back(new LayerWithHits(bl[6], selectTOBHit(collmatched, ttopo, 7)));
+    CRACKLayerWithHits.push_back(new LayerWithHits(bl[5], selectTOBHit(collmatched, ttopo, 6)));
+    CRACKLayerWithHits.push_back(new LayerWithHits(bl[3], selectTOBHit(collmatched, ttopo, 4)));
+    CRACKLayerWithHits.push_back(new LayerWithHits(bl[2], selectTOBHit(collmatched, ttopo, 3)));
+    CRACKLayerWithHits.push_back(new LayerWithHits(bl[6], selectTOBHit(collrphi, ttopo, 7)));
+    CRACKLayerWithHits.push_back(new LayerWithHits(bl[5], selectTOBHit(collrphi, ttopo, 6)));
+    CRACKLayerWithHits.push_back(new LayerWithHits(bl[3], selectTOBHit(collrphi, ttopo, 4)));
+    CRACKLayerWithHits.push_back(new LayerWithHits(bl[2], selectTOBHit(collrphi, ttopo, 3)));
+    CRACKLayerWithHits.push_back(new LayerWithHits(bl[4], selectTOBHit(collrphi, ttopo, 5)));
+    CRACKLayerWithHits.push_back(new LayerWithHits(bl[1], selectTOBHit(collrphi, ttopo, 2)));
+    CRACKLayerWithHits.push_back(new LayerWithHits(bl[0], selectTOBHit(collrphi, ttopo, 1)));
+    CRACKLayerWithHits.push_back(new LayerWithHits(bl[4], selectTOBHit(collmatched, ttopo, 5)));
+    CRACKLayerWithHits.push_back(new LayerWithHits(bl[1], selectTOBHit(collmatched, ttopo, 2)));
+    CRACKLayerWithHits.push_back(new LayerWithHits(bl[0], selectTOBHit(collmatched, ttopo, 1)));
+    return;
+  }
 
+  TIBLayerWithHits.push_back(new LayerWithHits(bl[3], selectTIBHit(collrphi, ttopo, 1)));  //layer
+      //std::cout << "TIB 0" << std::endl;
+  TIBLayerWithHits.push_back(new LayerWithHits(bl[4], selectTIBHit(collrphi, ttopo, 2)));
+  //std::cout << "TIB 1" << std::endl;
+  TIBLayerWithHits.push_back(new LayerWithHits(bl[5], selectTIBHit(collrphi, ttopo, 3)));
+  //std::cout << "TIB 2" << std::endl;
+  TIBLayerWithHits.push_back(new LayerWithHits(bl[6], selectTIBHit(collrphi, ttopo, 4)));
+  //std::cout << "TIB 3" << std::endl;
 
-    TECPlusLayerWithHits.push_back(new LayerWithHits(fpos[0], selectTECHit(collrphi, ttopo, 2, 1)));  //side, disk
-	//std::cout << "wheel 0" << std::endl;
-    TECPlusLayerWithHits.push_back(new LayerWithHits(fpos[1], selectTECHit(collrphi, ttopo, 2, 2)));  
-	//std::cout << "wheel 1" << std::endl;
-    TECPlusLayerWithHits.push_back(new LayerWithHits(fpos[2], selectTECHit(collrphi, ttopo, 2, 3)));  
-	//std::cout << "wheel 2" << std::endl;
-    TECPlusLayerWithHits.push_back(new LayerWithHits(fpos[3], selectTECHit(collrphi, ttopo, 2, 4)));  
-	//std::cout << "wheel 3" << std::endl;
-    TECPlusLayerWithHits.push_back(new LayerWithHits(fpos[4], selectTECHit(collrphi, ttopo, 2, 5)));  
-	//std::cout << "wheel 4" << std::endl;
-    TECPlusLayerWithHits.push_back(new LayerWithHits(fpos[5], selectTECHit(collrphi, ttopo, 2, 6)));  
-	//std::cout << "wheel 5" << std::endl;
-    TECPlusLayerWithHits.push_back(new LayerWithHits(fpos[6], selectTECHit(collrphi, ttopo, 2, 7)));  
-	//std::cout << "wheel 6" << std::endl;
-    TECPlusLayerWithHits.push_back(new LayerWithHits(fpos[7], selectTECHit(collrphi, ttopo, 2, 8)));  
-	//std::cout << "wheel 7" << std::endl;
-    TECPlusLayerWithHits.push_back(new LayerWithHits(fpos[8], selectTECHit(collrphi, ttopo, 2, 9)));  
-	//std::cout << "wheel 8" << std::endl;
+  TOBLayerWithHits.push_back(new LayerWithHits(bl[7], selectTOBHit(collrphi, ttopo, 1)));
+  //std::cout << "TOB 0" << std::endl;
+  TOBLayerWithHits.push_back(new LayerWithHits(bl[8], selectTOBHit(collrphi, ttopo, 2)));
+  //std::cout << "TOB 1" << std::endl;
+  TOBLayerWithHits.push_back(new LayerWithHits(bl[9], selectTOBHit(collrphi, ttopo, 3)));
+  //std::cout << "TOB 2" << std::endl;
+  TOBLayerWithHits.push_back(new LayerWithHits(bl[10], selectTOBHit(collrphi, ttopo, 4)));
+  //std::cout << "TOB 3" << std::endl;
+  TOBLayerWithHits.push_back(new LayerWithHits(bl[11], selectTOBHit(collrphi, ttopo, 5)));
+  //std::cout << "TOB 4" << std::endl;
+  TOBLayerWithHits.push_back(new LayerWithHits(bl[12], selectTOBHit(collrphi, ttopo, 6)));
+  //std::cout << "TOB 5" << std::endl;
 
-    TECMinusLayerWithHits.push_back(new LayerWithHits(fneg[0], selectTECHit(collrphi, ttopo, 1, 1)));  //side, disk
-        //std::cout << "wheel 0" << std::endl;
-    TECMinusLayerWithHits.push_back(new LayerWithHits(fneg[1], selectTECHit(collrphi, ttopo, 1, 2)));
-        //std::cout << "wheel 1" << std::endl;
-    TECMinusLayerWithHits.push_back(new LayerWithHits(fneg[2], selectTECHit(collrphi, ttopo, 1, 3)));
-        //std::cout << "wheel 2" << std::endl;
-    TECMinusLayerWithHits.push_back(new LayerWithHits(fneg[3], selectTECHit(collrphi, ttopo, 1, 4)));
-        //std::cout << "wheel 3" << std::endl;
-    TECMinusLayerWithHits.push_back(new LayerWithHits(fneg[4], selectTECHit(collrphi, ttopo, 1, 5)));
-        //std::cout << "wheel 4" << std::endl;
-    TECMinusLayerWithHits.push_back(new LayerWithHits(fneg[5], selectTECHit(collrphi, ttopo, 1, 6)));
-        //std::cout << "wheel 5" << std::endl;
-    TECMinusLayerWithHits.push_back(new LayerWithHits(fneg[6], selectTECHit(collrphi, ttopo, 1, 7)));
-        //std::cout << "wheel 6" << std::endl;
-    TECMinusLayerWithHits.push_back(new LayerWithHits(fneg[7], selectTECHit(collrphi, ttopo, 1, 8)));
-        //std::cout << "wheel 7" << std::endl;
-    TECMinusLayerWithHits.push_back(new LayerWithHits(fneg[8], selectTECHit(collrphi, ttopo, 1, 9)));
-        //std::cout << "wheel 8" << std::endl;
+  TECPlusLayerWithHits.push_back(new LayerWithHits(fpos[0], selectTECHit(collrphi, ttopo, 2, 1)));  //side, disk
+      //std::cout << "wheel 0" << std::endl;
+  TECPlusLayerWithHits.push_back(new LayerWithHits(fpos[1], selectTECHit(collrphi, ttopo, 2, 2)));
+  //std::cout << "wheel 1" << std::endl;
+  TECPlusLayerWithHits.push_back(new LayerWithHits(fpos[2], selectTECHit(collrphi, ttopo, 2, 3)));
+  //std::cout << "wheel 2" << std::endl;
+  TECPlusLayerWithHits.push_back(new LayerWithHits(fpos[3], selectTECHit(collrphi, ttopo, 2, 4)));
+  //std::cout << "wheel 3" << std::endl;
+  TECPlusLayerWithHits.push_back(new LayerWithHits(fpos[4], selectTECHit(collrphi, ttopo, 2, 5)));
+  //std::cout << "wheel 4" << std::endl;
+  TECPlusLayerWithHits.push_back(new LayerWithHits(fpos[5], selectTECHit(collrphi, ttopo, 2, 6)));
+  //std::cout << "wheel 5" << std::endl;
+  TECPlusLayerWithHits.push_back(new LayerWithHits(fpos[6], selectTECHit(collrphi, ttopo, 2, 7)));
+  //std::cout << "wheel 6" << std::endl;
+  TECPlusLayerWithHits.push_back(new LayerWithHits(fpos[7], selectTECHit(collrphi, ttopo, 2, 8)));
+  //std::cout << "wheel 7" << std::endl;
+  TECPlusLayerWithHits.push_back(new LayerWithHits(fpos[8], selectTECHit(collrphi, ttopo, 2, 9)));
+  //std::cout << "wheel 8" << std::endl;
+
+  TECMinusLayerWithHits.push_back(new LayerWithHits(fneg[0], selectTECHit(collrphi, ttopo, 1, 1)));  //side, disk
+      //std::cout << "wheel 0" << std::endl;
+  TECMinusLayerWithHits.push_back(new LayerWithHits(fneg[1], selectTECHit(collrphi, ttopo, 1, 2)));
+  //std::cout << "wheel 1" << std::endl;
+  TECMinusLayerWithHits.push_back(new LayerWithHits(fneg[2], selectTECHit(collrphi, ttopo, 1, 3)));
+  //std::cout << "wheel 2" << std::endl;
+  TECMinusLayerWithHits.push_back(new LayerWithHits(fneg[3], selectTECHit(collrphi, ttopo, 1, 4)));
+  //std::cout << "wheel 3" << std::endl;
+  TECMinusLayerWithHits.push_back(new LayerWithHits(fneg[4], selectTECHit(collrphi, ttopo, 1, 5)));
+  //std::cout << "wheel 4" << std::endl;
+  TECMinusLayerWithHits.push_back(new LayerWithHits(fneg[5], selectTECHit(collrphi, ttopo, 1, 6)));
+  //std::cout << "wheel 5" << std::endl;
+  TECMinusLayerWithHits.push_back(new LayerWithHits(fneg[6], selectTECHit(collrphi, ttopo, 1, 7)));
+  //std::cout << "wheel 6" << std::endl;
+  TECMinusLayerWithHits.push_back(new LayerWithHits(fneg[7], selectTECHit(collrphi, ttopo, 1, 8)));
+  //std::cout << "wheel 7" << std::endl;
+  TECMinusLayerWithHits.push_back(new LayerWithHits(fneg[8], selectTECHit(collrphi, ttopo, 1, 9)));
+  //std::cout << "wheel 8" << std::endl;
 }
 
-std::vector<const TrackingRecHit*> CosmicLayerPairs::selectTECHit(const SiStripRecHit2DCollection &collrphi,
-                                                                  const TrackerTopology& ttopo,
-								int side,
-								int disk){
-	std::vector<const TrackingRecHit*> theChoosedHits;
-        edmNew::copyDetSetRange(collrphi, theChoosedHits, ttopo.tecDetIdWheelComparator(side,disk));
-	return theChoosedHits;
-	
+std::vector<const TrackingRecHit *> CosmicLayerPairs::selectTECHit(const SiStripRecHit2DCollection &collrphi,
+                                                                   const TrackerTopology &ttopo,
+                                                                   int side,
+                                                                   int disk) {
+  std::vector<const TrackingRecHit *> theChoosedHits;
+  edmNew::copyDetSetRange(collrphi, theChoosedHits, ttopo.tecDetIdWheelComparator(side, disk));
+  return theChoosedHits;
 }
 
-std::vector<const TrackingRecHit*> CosmicLayerPairs::selectTIBHit(const SiStripRecHit2DCollection &collrphi,
-                                                                  const TrackerTopology& ttopo,
-                                                                int layer){
-	std::vector<const TrackingRecHit*> theChoosedHits;
-        //std::cout << "in selectTIBHit" << std::endl;
-        edmNew::copyDetSetRange(collrphi,theChoosedHits, ttopo.tibDetIdLayerComparator(layer));
-        return theChoosedHits;
-
+std::vector<const TrackingRecHit *> CosmicLayerPairs::selectTIBHit(const SiStripRecHit2DCollection &collrphi,
+                                                                   const TrackerTopology &ttopo,
+                                                                   int layer) {
+  std::vector<const TrackingRecHit *> theChoosedHits;
+  //std::cout << "in selectTIBHit" << std::endl;
+  edmNew::copyDetSetRange(collrphi, theChoosedHits, ttopo.tibDetIdLayerComparator(layer));
+  return theChoosedHits;
 }
 
-std::vector<const TrackingRecHit*> CosmicLayerPairs::selectTOBHit(const SiStripRecHit2DCollection &collrphi,
-                                                                  const TrackerTopology& ttopo,
-                                                                int layer){
-	std::vector<const TrackingRecHit*> theChoosedHits;
-        //std::cout << "in selectTOBHit" << std::endl;
-        edmNew::copyDetSetRange(collrphi,theChoosedHits, ttopo.tobDetIdLayerComparator(layer));
-        return theChoosedHits;
+std::vector<const TrackingRecHit *> CosmicLayerPairs::selectTOBHit(const SiStripRecHit2DCollection &collrphi,
+                                                                   const TrackerTopology &ttopo,
+                                                                   int layer) {
+  std::vector<const TrackingRecHit *> theChoosedHits;
+  //std::cout << "in selectTOBHit" << std::endl;
+  edmNew::copyDetSetRange(collrphi, theChoosedHits, ttopo.tobDetIdLayerComparator(layer));
+  return theChoosedHits;
 }
 
-std::vector<const TrackingRecHit*> CosmicLayerPairs::selectTECHit(const SiStripMatchedRecHit2DCollection &collmatch,
-                                                                  const TrackerTopology& ttopo,
-                                                                int side,
-                                                                int disk){
-        std::vector<const TrackingRecHit*> theChoosedHits;
-        //std::cout << "in selectTECHit" << std::endl;
-        edmNew::copyDetSetRange(collmatch,theChoosedHits, ttopo.tecDetIdWheelComparator(side,disk));
-        return theChoosedHits;
-
+std::vector<const TrackingRecHit *> CosmicLayerPairs::selectTECHit(const SiStripMatchedRecHit2DCollection &collmatch,
+                                                                   const TrackerTopology &ttopo,
+                                                                   int side,
+                                                                   int disk) {
+  std::vector<const TrackingRecHit *> theChoosedHits;
+  //std::cout << "in selectTECHit" << std::endl;
+  edmNew::copyDetSetRange(collmatch, theChoosedHits, ttopo.tecDetIdWheelComparator(side, disk));
+  return theChoosedHits;
 }
 
-std::vector<const TrackingRecHit*> CosmicLayerPairs::selectTIBHit(const SiStripMatchedRecHit2DCollection &collmatch,
-                                                                  const TrackerTopology& ttopo,
-                                                                int layer){
-        std::vector<const TrackingRecHit*> theChoosedHits;
-        //std::cout << "in selectTIBHit" << std::endl;
-        edmNew::copyDetSetRange(collmatch,theChoosedHits, ttopo.tibDetIdLayerComparator(layer));
-        return theChoosedHits;
-
+std::vector<const TrackingRecHit *> CosmicLayerPairs::selectTIBHit(const SiStripMatchedRecHit2DCollection &collmatch,
+                                                                   const TrackerTopology &ttopo,
+                                                                   int layer) {
+  std::vector<const TrackingRecHit *> theChoosedHits;
+  //std::cout << "in selectTIBHit" << std::endl;
+  edmNew::copyDetSetRange(collmatch, theChoosedHits, ttopo.tibDetIdLayerComparator(layer));
+  return theChoosedHits;
 }
 
-std::vector<const TrackingRecHit*> CosmicLayerPairs::selectTOBHit(const SiStripMatchedRecHit2DCollection &collmatch,
-                                                                  const TrackerTopology& ttopo,
-                                                                int layer){
-        std::vector<const TrackingRecHit*> theChoosedHits;
-        //std::cout << "in selectTOBHit" << std::endl;
-        edmNew::copyDetSetRange(collmatch,theChoosedHits, ttopo.tobDetIdLayerComparator(layer));
-        return theChoosedHits;
+std::vector<const TrackingRecHit *> CosmicLayerPairs::selectTOBHit(const SiStripMatchedRecHit2DCollection &collmatch,
+                                                                   const TrackerTopology &ttopo,
+                                                                   int layer) {
+  std::vector<const TrackingRecHit *> theChoosedHits;
+  //std::cout << "in selectTOBHit" << std::endl;
+  edmNew::copyDetSetRange(collmatch, theChoosedHits, ttopo.tobDetIdLayerComparator(layer));
+  return theChoosedHits;
 }

--- a/RecoTracker/TkHitPairs/src/HitPairGenerator.cc
+++ b/RecoTracker/TkHitPairs/src/HitPairGenerator.cc
@@ -2,20 +2,19 @@
 
 HitPairGenerator::HitPairGenerator(unsigned int nSize) : localRA(nSize) {}
 
-const OrderedHitPairs & HitPairGenerator::run(
-    const TrackingRegion& region, const edm::Event & ev, const edm::EventSetup& es)
-{
-  assert(thePairs.empty()); assert(thePairs.capacity()==0);
+const OrderedHitPairs& HitPairGenerator::run(const TrackingRegion& region,
+                                             const edm::Event& ev,
+                                             const edm::EventSetup& es) {
+  assert(thePairs.empty());
+  assert(thePairs.capacity() == 0);
   thePairs.reserve(localRA.upper());
   hitPairs(region, thePairs, ev, es);
   thePairs.shrink_to_fit();
   return thePairs;
 }
 
-
-void HitPairGenerator::clear() 
-{
+void HitPairGenerator::clear() {
   localRA.update(thePairs.size());
-  thePairs.clear(); thePairs.shrink_to_fit();
+  thePairs.clear();
+  thePairs.shrink_to_fit();
 }
-

--- a/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
+++ b/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
@@ -19,9 +19,11 @@ using namespace std;
 typedef PixelRecoRange<float> Range;
 
 namespace {
-  template<class T> inline T sqr( T t) {return t*t;}
-}
-
+  template <class T>
+  inline T sqr(T t) {
+    return t * t;
+  }
+}  // namespace
 
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
@@ -29,90 +31,88 @@ namespace {
 #include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-HitPairGeneratorFromLayerPair::HitPairGeneratorFromLayerPair(
-							     unsigned int inner,
-							     unsigned int outer,
-							     LayerCacheType* layerCache,
-							     unsigned int max)
-  : theLayerCache(layerCache), theOuterLayer(outer), theInnerLayer(inner), theMaxElement(max)
-{
-}
+HitPairGeneratorFromLayerPair::HitPairGeneratorFromLayerPair(unsigned int inner,
+                                                             unsigned int outer,
+                                                             LayerCacheType* layerCache,
+                                                             unsigned int max)
+    : theLayerCache(layerCache), theOuterLayer(outer), theInnerLayer(inner), theMaxElement(max) {}
 
 HitPairGeneratorFromLayerPair::~HitPairGeneratorFromLayerPair() {}
 
 // devirtualizer
-#include<tuple>
+#include <tuple>
 namespace {
 
-  template<typename Algo>
+  template <typename Algo>
   struct Kernel {
-    using  Base = HitRZCompatibility;
-    void set(Base const * a) {
-      assert( a->algo()==Algo::me);
-      checkRZ=reinterpret_cast<Algo const *>(a);
+    using Base = HitRZCompatibility;
+    void set(Base const* a) {
+      assert(a->algo() == Algo::me);
+      checkRZ = reinterpret_cast<Algo const*>(a);
     }
-    
-    void operator()(int b, int e, const RecHitsSortedInPhi & innerHitsMap, bool * ok) const {
-      constexpr float nSigmaRZ = 3.46410161514f; // std::sqrt(12.f);
-      for (int i=b; i!=e; ++i) {
-	Range allowed = checkRZ->range(innerHitsMap.u[i]);
-	float vErr = nSigmaRZ * innerHitsMap.dv[i];
-	Range hitRZ(innerHitsMap.v[i]-vErr, innerHitsMap.v[i]+vErr);
-	Range crossRange = allowed.intersection(hitRZ);
-	ok[i-b] = ! crossRange.empty() ;
+
+    void operator()(int b, int e, const RecHitsSortedInPhi& innerHitsMap, bool* ok) const {
+      constexpr float nSigmaRZ = 3.46410161514f;  // std::sqrt(12.f);
+      for (int i = b; i != e; ++i) {
+        Range allowed = checkRZ->range(innerHitsMap.u[i]);
+        float vErr = nSigmaRZ * innerHitsMap.dv[i];
+        Range hitRZ(innerHitsMap.v[i] - vErr, innerHitsMap.v[i] + vErr);
+        Range crossRange = allowed.intersection(hitRZ);
+        ok[i - b] = !crossRange.empty();
       }
     }
-    Algo const * checkRZ;
-    
+    Algo const* checkRZ;
   };
 
+  template <typename... Args>
+  using Kernels = std::tuple<Kernel<Args>...>;
 
-  template<typename ... Args> using Kernels = std::tuple<Kernel<Args>...>;
+}  // namespace
 
+void HitPairGeneratorFromLayerPair::hitPairs(const TrackingRegion& region,
+                                             OrderedHitPairs& result,
+                                             const edm::Event& iEvent,
+                                             const edm::EventSetup& iSetup,
+                                             Layers layers) {
+  auto const& ds = doublets(region, iEvent, iSetup, layers);
+  for (std::size_t i = 0; i != ds.size(); ++i) {
+    result.push_back(OrderedHitPair(ds.hit(i, HitDoublets::inner), ds.hit(i, HitDoublets::outer)));
+  }
+  if (theMaxElement != 0 && result.size() >= theMaxElement) {
+    result.clear();
+    edm::LogError("TooManyPairs") << "number of pairs exceed maximum, no pairs produced";
+  }
 }
 
-
-void HitPairGeneratorFromLayerPair::hitPairs(
-					     const TrackingRegion & region, OrderedHitPairs & result,
-					     const edm::Event& iEvent, const edm::EventSetup& iSetup, Layers layers) {
-
-  auto const & ds = doublets(region, iEvent, iSetup, layers);
-  for (std::size_t i=0; i!=ds.size(); ++i) {
-    result.push_back( OrderedHitPair( ds.hit(i,HitDoublets::inner),ds.hit(i,HitDoublets::outer) ));
-  }
-  if (theMaxElement!=0 && result.size() >= theMaxElement){
-     result.clear();
-    edm::LogError("TooManyPairs")<<"number of pairs exceed maximum, no pairs produced";
-  }
-}
-
-HitDoublets HitPairGeneratorFromLayerPair::doublets( const TrackingRegion& region,
-                                                     const edm::Event & iEvent, const edm::EventSetup& iSetup, const Layer& innerLayer, const Layer& outerLayer,
-                                                     LayerCacheType& layerCache) {
-
-  const RecHitsSortedInPhi & innerHitsMap = layerCache(innerLayer, region, iSetup);
-  if (innerHitsMap.empty()) return HitDoublets(innerHitsMap,innerHitsMap);
+HitDoublets HitPairGeneratorFromLayerPair::doublets(const TrackingRegion& region,
+                                                    const edm::Event& iEvent,
+                                                    const edm::EventSetup& iSetup,
+                                                    const Layer& innerLayer,
+                                                    const Layer& outerLayer,
+                                                    LayerCacheType& layerCache) {
+  const RecHitsSortedInPhi& innerHitsMap = layerCache(innerLayer, region, iSetup);
+  if (innerHitsMap.empty())
+    return HitDoublets(innerHitsMap, innerHitsMap);
 
   const RecHitsSortedInPhi& outerHitsMap = layerCache(outerLayer, region, iSetup);
-  if (outerHitsMap.empty()) return HitDoublets(innerHitsMap,outerHitsMap);
-  HitDoublets result(innerHitsMap,outerHitsMap); result.reserve(std::max(innerHitsMap.size(),outerHitsMap.size()));
-  doublets(region,
-	   *innerLayer.detLayer(),*outerLayer.detLayer(),
-	   innerHitsMap,outerHitsMap,iSetup,theMaxElement,result);
-  
-  return result;
+  if (outerHitsMap.empty())
+    return HitDoublets(innerHitsMap, outerHitsMap);
+  HitDoublets result(innerHitsMap, outerHitsMap);
+  result.reserve(std::max(innerHitsMap.size(), outerHitsMap.size()));
+  doublets(
+      region, *innerLayer.detLayer(), *outerLayer.detLayer(), innerHitsMap, outerHitsMap, iSetup, theMaxElement, result);
 
+  return result;
 }
 
 void HitPairGeneratorFromLayerPair::doublets(const TrackingRegion& region,
-						    const DetLayer & innerHitDetLayer,
-						    const DetLayer & outerHitDetLayer,
-						    const RecHitsSortedInPhi & innerHitsMap,
-						    const RecHitsSortedInPhi & outerHitsMap,
-						    const edm::EventSetup& iSetup,
-						    const unsigned int theMaxElement,
-						    HitDoublets & result){
-
+                                             const DetLayer& innerHitDetLayer,
+                                             const DetLayer& outerHitDetLayer,
+                                             const RecHitsSortedInPhi& innerHitsMap,
+                                             const RecHitsSortedInPhi& outerHitsMap,
+                                             const edm::EventSetup& iSetup,
+                                             const unsigned int theMaxElement,
+                                             HitDoublets& result) {
   //  HitDoublets result(innerHitsMap,outerHitsMap); result.reserve(std::max(innerHitsMap.size(),outerHitsMap.size()));
   typedef RecHitsSortedInPhi::Hit Hit;
   InnerDeltaPhi deltaPhi(outerHitDetLayer, innerHitDetLayer, region, iSetup);
@@ -121,63 +121,66 @@ void HitPairGeneratorFromLayerPair::doublets(const TrackingRegion& region,
 
   // constexpr float nSigmaRZ = std::sqrt(12.f);
   constexpr float nSigmaPhi = 3.f;
-  for (int io = 0; io!=int(outerHitsMap.theHits.size()); ++io) {
-    if (!deltaPhi.prefilter(outerHitsMap.x[io],outerHitsMap.y[io])) continue;
-    Hit const & ohit =  outerHitsMap.theHits[io].hit();
-    PixelRecoRange<float> phiRange = deltaPhi(outerHitsMap.x[io],
-					      outerHitsMap.y[io],
-					      outerHitsMap.z[io],
-					      nSigmaPhi*outerHitsMap.drphi[io]
-					      );
+  for (int io = 0; io != int(outerHitsMap.theHits.size()); ++io) {
+    if (!deltaPhi.prefilter(outerHitsMap.x[io], outerHitsMap.y[io]))
+      continue;
+    Hit const& ohit = outerHitsMap.theHits[io].hit();
+    PixelRecoRange<float> phiRange =
+        deltaPhi(outerHitsMap.x[io], outerHitsMap.y[io], outerHitsMap.z[io], nSigmaPhi * outerHitsMap.drphi[io]);
 
-    if (phiRange.empty()) continue;
+    if (phiRange.empty())
+      continue;
 
-    const HitRZCompatibility *checkRZ = region.checkRZ(&innerHitDetLayer, ohit, iSetup, &outerHitDetLayer, 
-						       outerHitsMap.rv(io),outerHitsMap.z[io],
-						       outerHitsMap.isBarrel ? outerHitsMap.du[io] :  outerHitsMap.dv[io],
-						       outerHitsMap.isBarrel ? outerHitsMap.dv[io] :  outerHitsMap.du[io]
-						       );
-    if(!checkRZ) continue;
+    const HitRZCompatibility* checkRZ =
+        region.checkRZ(&innerHitDetLayer,
+                       ohit,
+                       iSetup,
+                       &outerHitDetLayer,
+                       outerHitsMap.rv(io),
+                       outerHitsMap.z[io],
+                       outerHitsMap.isBarrel ? outerHitsMap.du[io] : outerHitsMap.dv[io],
+                       outerHitsMap.isBarrel ? outerHitsMap.dv[io] : outerHitsMap.du[io]);
+    if (!checkRZ)
+      continue;
 
-    Kernels<HitZCheck,HitRCheck,HitEtaCheck> kernels;
+    Kernels<HitZCheck, HitRCheck, HitEtaCheck> kernels;
 
     auto innerRange = innerHitsMap.doubleRange(phiRange.min(), phiRange.max());
-    LogDebug("HitPairGeneratorFromLayerPair")<<
-      "preparing for combination of: "<< innerRange[1]-innerRange[0]+innerRange[3]-innerRange[2]
-				      <<" inner and: "<< outerHitsMap.theHits.size()<<" outter";
-    for(int j=0; j<3; j+=2) {
-      auto b = innerRange[j]; auto e=innerRange[j+1];
-      bool ok[e-b];
+    LogDebug("HitPairGeneratorFromLayerPair")
+        << "preparing for combination of: " << innerRange[1] - innerRange[0] + innerRange[3] - innerRange[2]
+        << " inner and: " << outerHitsMap.theHits.size() << " outter";
+    for (int j = 0; j < 3; j += 2) {
+      auto b = innerRange[j];
+      auto e = innerRange[j + 1];
+      bool ok[e - b];
       switch (checkRZ->algo()) {
-	case (HitRZCompatibility::zAlgo) :
-	  std::get<0>(kernels).set(checkRZ);
-	  std::get<0>(kernels)(b,e,innerHitsMap, ok);
-	  break;
-	case (HitRZCompatibility::rAlgo) :
-	  std::get<1>(kernels).set(checkRZ);
-	  std::get<1>(kernels)(b,e,innerHitsMap, ok);
-	  break;
-	case (HitRZCompatibility::etaAlgo) :
-	  std::get<2>(kernels).set(checkRZ);
-	  std::get<2>(kernels)(b,e,innerHitsMap, ok);
-	  break;
+        case (HitRZCompatibility::zAlgo):
+          std::get<0>(kernels).set(checkRZ);
+          std::get<0>(kernels)(b, e, innerHitsMap, ok);
+          break;
+        case (HitRZCompatibility::rAlgo):
+          std::get<1>(kernels).set(checkRZ);
+          std::get<1>(kernels)(b, e, innerHitsMap, ok);
+          break;
+        case (HitRZCompatibility::etaAlgo):
+          std::get<2>(kernels).set(checkRZ);
+          std::get<2>(kernels)(b, e, innerHitsMap, ok);
+          break;
       }
-      for (int i=0; i!=e-b; ++i) {
-	if (!ok[i]) continue;
-	if (theMaxElement!=0 && result.size() >= theMaxElement){
-	  result.clear();
-	  edm::LogError("TooManyPairs")<<"number of pairs exceed maximum, no pairs produced";
-	  delete checkRZ;
-	  return;
-	}
-        result.add(b+i,io);
+      for (int i = 0; i != e - b; ++i) {
+        if (!ok[i])
+          continue;
+        if (theMaxElement != 0 && result.size() >= theMaxElement) {
+          result.clear();
+          edm::LogError("TooManyPairs") << "number of pairs exceed maximum, no pairs produced";
+          delete checkRZ;
+          return;
+        }
+        result.add(b + i, io);
       }
     }
     delete checkRZ;
   }
-  LogDebug("HitPairGeneratorFromLayerPair")<<" total number of pairs provided back: "<<result.size();
+  LogDebug("HitPairGeneratorFromLayerPair") << " total number of pairs provided back: " << result.size();
   result.shrink_to_fit();
-
 }
-
-

--- a/RecoTracker/TkHitPairs/src/InnerDeltaPhi.cc
+++ b/RecoTracker/TkHitPairs/src/InnerDeltaPhi.cc
@@ -17,224 +17,220 @@ using namespace std;
 #ifdef VI_DEBUG
 namespace {
   struct Stat {
+    float xmin = 1.1;
+    float xmax = -1.1;
+    int nt = 0;
+    int nn = 0;
+    int nl = 0;
 
-   float xmin=1.1;
-   float xmax=-1.1;
-   int nt=0;
-   int nn=0;
-   int nl=0;
-
-   ~Stat() { std::cout << "ASIN " << xmin <<',' << xmax <<',' << nt <<','<< nn <<','<< nl << std::endl;}
-
+    ~Stat() { std::cout << "ASIN " << xmin << ',' << xmax << ',' << nt << ',' << nn << ',' << nl << std::endl; }
   };
 
   Stat stat;
 
-}
+}  // namespace
 
-namespace {
-  template <class T> 
-  inline T cropped_asin(T x) {
-    stat.nt++;
-    if (x<0.f) stat.nn++;
-    if (x>0.5f) stat.nl++;
-    stat.xmin = std::min(x,stat.xmin);
-    stat.xmax =	std::max(x,stat.xmax);
-    
-    return std::abs(x) <= 1 ? std::asin(x) : (x > 0 ? T(M_PI/2) : -T(M_PI/2));
-  }
-}
-#else // for icc
 namespace {
   template <class T>
   inline T cropped_asin(T x) {
-    return std::abs(x) <= 1 ? std::asin(x) : (x > 0 ? T(M_PI/2) : -T(M_PI/2));
-  }
-} 
-#endif
+    stat.nt++;
+    if (x < 0.f)
+      stat.nn++;
+    if (x > 0.5f)
+      stat.nl++;
+    stat.xmin = std::min(x, stat.xmin);
+    stat.xmax = std::max(x, stat.xmax);
 
+    return std::abs(x) <= 1 ? std::asin(x) : (x > 0 ? T(M_PI / 2) : -T(M_PI / 2));
+  }
+}  // namespace
+#else  // for icc
+namespace {
+  template <class T>
+  inline T cropped_asin(T x) {
+    return std::abs(x) <= 1 ? std::asin(x) : (x > 0 ? T(M_PI / 2) : -T(M_PI / 2));
+  }
+}  // namespace
+#endif
 
 namespace {
 
-  template <class T> inline T sqr( T t) {return t*t;}
-
-  // reasonable (5.e-4) only for |x|<0.7 then degrades..
-  template<typename T>
-  inline T f_asin07f(T x)  {
-
-   auto ret = 
-       1.f + (x*x) * (0.157549798488616943359375f + (x*x)*0.125192224979400634765625f);
-
-   return x*ret;
+  template <class T>
+  inline T sqr(T t) {
+    return t * t;
   }
 
-}
+  // reasonable (5.e-4) only for |x|<0.7 then degrades..
+  template <typename T>
+  inline T f_asin07f(T x) {
+    auto ret = 1.f + (x * x) * (0.157549798488616943359375f + (x * x) * 0.125192224979400634765625f);
 
+    return x * ret;
+  }
+
+}  // namespace
 
 #include "DataFormats/Math/interface/approx_atan2.h"
 
 namespace {
-  inline
-  float f_atan2f(float y, float x) { return unsafe_atan2f<7>(y,x); }
-  template<typename V> inline float f_phi(V v) { return f_atan2f(v.y(),v.x());}
-}
+  inline float f_atan2f(float y, float x) { return unsafe_atan2f<7>(y, x); }
+  template <typename V>
+  inline float f_phi(V v) {
+    return f_atan2f(v.y(), v.x());
+  }
+}  // namespace
 
-InnerDeltaPhi:: InnerDeltaPhi( const DetLayer& outlayer, const DetLayer& layer,
-                 const TrackingRegion & region,
-                 const edm::EventSetup& iSetup,
-                 bool precise, float extraTolerance) :
-    innerIsBarrel(layer.isBarrel()),
-    outerIsBarrel(outlayer.isBarrel()),
-    thePrecise(precise),
-    ol( outlayer.seqNum()), 
-    theROrigin(region.originRBound()),
-    theRLayer(0),
-    theThickness(0),
-    theExtraTolerance(extraTolerance),
-    theA(0),
-    theB(0),
-    theVtxZ(region.origin().z()),
-    thePtMin(region.ptMin()),
-    theVtx(region.origin().x(),region.origin().y()),
-    sigma(&layer,iSetup)
+InnerDeltaPhi::InnerDeltaPhi(const DetLayer& outlayer,
+                             const DetLayer& layer,
+                             const TrackingRegion& region,
+                             const edm::EventSetup& iSetup,
+                             bool precise,
+                             float extraTolerance)
+    : innerIsBarrel(layer.isBarrel()),
+      outerIsBarrel(outlayer.isBarrel()),
+      thePrecise(precise),
+      ol(outlayer.seqNum()),
+      theROrigin(region.originRBound()),
+      theRLayer(0),
+      theThickness(0),
+      theExtraTolerance(extraTolerance),
+      theA(0),
+      theB(0),
+      theVtxZ(region.origin().z()),
+      thePtMin(region.ptMin()),
+      theVtx(region.origin().x(), region.origin().y()),
+      sigma(&layer, iSetup)
 
 {
-  float zMinOrigin = theVtxZ-region.originZBound();
-  float zMaxOrigin = theVtxZ+region.originZBound();
-  theRCurvature = PixelRecoUtilities::bendingRadius(thePtMin,iSetup);
- 
+  float zMinOrigin = theVtxZ - region.originZBound();
+  float zMaxOrigin = theVtxZ + region.originZBound();
+  theRCurvature = PixelRecoUtilities::bendingRadius(thePtMin, iSetup);
 
-  if (innerIsBarrel) initBarrelLayer( layer);
-  else initForwardLayer( layer, zMinOrigin, zMaxOrigin);
+  if (innerIsBarrel)
+    initBarrelLayer(layer);
+  else
+    initForwardLayer(layer, zMinOrigin, zMaxOrigin);
 
-  if(outerIsBarrel) initBarrelMS(outlayer);
-  else  initForwardMS(outlayer);
-
+  if (outerIsBarrel)
+    initBarrelMS(outlayer);
+  else
+    initForwardMS(outlayer);
 }
 
-
 void InnerDeltaPhi::initBarrelMS(const DetLayer& outLayer) {
-    const BarrelDetLayer& bl = static_cast<const BarrelDetLayer&>(outLayer);
-    float rLayer = bl.specificSurface().radius();
-    auto zmax = 0.5f*outLayer.surface().bounds().length();
-    PixelRecoPointRZ zero(0., 0.);
-    PixelRecoPointRZ point1(rLayer, 0.);
-    PixelRecoPointRZ point2(rLayer, zmax);
-    auto scatt1 = 3.f*sigma(thePtMin,zero, point1, ol);
-    auto scatt2 = 3.f*sigma(thePtMin,zero, point2, ol);      
-    theDeltaScatt = (scatt2-scatt1)/zmax;
-    theScatt0 =	scatt1;
+  const BarrelDetLayer& bl = static_cast<const BarrelDetLayer&>(outLayer);
+  float rLayer = bl.specificSurface().radius();
+  auto zmax = 0.5f * outLayer.surface().bounds().length();
+  PixelRecoPointRZ zero(0., 0.);
+  PixelRecoPointRZ point1(rLayer, 0.);
+  PixelRecoPointRZ point2(rLayer, zmax);
+  auto scatt1 = 3.f * sigma(thePtMin, zero, point1, ol);
+  auto scatt2 = 3.f * sigma(thePtMin, zero, point2, ol);
+  theDeltaScatt = (scatt2 - scatt1) / zmax;
+  theScatt0 = scatt1;
 }
 
 void InnerDeltaPhi::initForwardMS(const DetLayer& outLayer) {
-    const ForwardDetLayer &fl = static_cast<const ForwardDetLayer&>(outLayer);
-    auto minR = fl.specificSurface().innerRadius();
-    auto maxR = fl.specificSurface().outerRadius();
-    auto layerZ = outLayer.position().z();
-    // compute min and max multiple scattering correction
-    PixelRecoPointRZ zero(0., theVtxZ);
-    PixelRecoPointRZ point1(minR, layerZ);
-    PixelRecoPointRZ point2(maxR, layerZ);
-    auto scatt1 = 3.f*sigma(thePtMin,zero, point1, ol);
-    auto scatt2 = 3.f*sigma(thePtMin,zero, point2, ol);
-    theDeltaScatt = (scatt2-scatt1)/(maxR-minR);
-    theScatt0 = scatt1 - theDeltaScatt*minR;
+  const ForwardDetLayer& fl = static_cast<const ForwardDetLayer&>(outLayer);
+  auto minR = fl.specificSurface().innerRadius();
+  auto maxR = fl.specificSurface().outerRadius();
+  auto layerZ = outLayer.position().z();
+  // compute min and max multiple scattering correction
+  PixelRecoPointRZ zero(0., theVtxZ);
+  PixelRecoPointRZ point1(minR, layerZ);
+  PixelRecoPointRZ point2(maxR, layerZ);
+  auto scatt1 = 3.f * sigma(thePtMin, zero, point1, ol);
+  auto scatt2 = 3.f * sigma(thePtMin, zero, point2, ol);
+  theDeltaScatt = (scatt2 - scatt1) / (maxR - minR);
+  theScatt0 = scatt1 - theDeltaScatt * minR;
 }
 
-
-
-void InnerDeltaPhi::initBarrelLayer( const DetLayer& layer) 
-{
-  const BarrelDetLayer& bl = static_cast<const BarrelDetLayer&>(layer); 
-  float rLayer = bl.specificSurface().radius(); 
+void InnerDeltaPhi::initBarrelLayer(const DetLayer& layer) {
+  const BarrelDetLayer& bl = static_cast<const BarrelDetLayer&>(layer);
+  float rLayer = bl.specificSurface().radius();
 
   // the maximal delta phi will be for the innermost hits
   theThickness = layer.surface().bounds().thickness();
-  theRLayer = rLayer - 0.5f*theThickness;
+  theRLayer = rLayer - 0.5f * theThickness;
 }
 
-void InnerDeltaPhi::initForwardLayer( const DetLayer& layer, 
-				 float zMinOrigin, float zMaxOrigin)
-{
-  const ForwardDetLayer &fl = static_cast<const ForwardDetLayer&>(layer);
+void InnerDeltaPhi::initForwardLayer(const DetLayer& layer, float zMinOrigin, float zMaxOrigin) {
+  const ForwardDetLayer& fl = static_cast<const ForwardDetLayer&>(layer);
   theRLayer = fl.specificSurface().innerRadius();
   float layerZ = layer.position().z();
   theThickness = layer.surface().bounds().thickness();
-  float layerZmin = layerZ > 0 ? layerZ-0.5f*theThickness: layerZ+0.5f*theThickness;
+  float layerZmin = layerZ > 0 ? layerZ - 0.5f * theThickness : layerZ + 0.5f * theThickness;
   theB = layerZ > 0 ? zMaxOrigin : zMinOrigin;
   theA = layerZmin - theB;
 }
 
-
-
-PixelRecoRange<float> InnerDeltaPhi::phiRange(const Point2D& hitXY,float hitZ,float errRPhi) const
-{
+PixelRecoRange<float> InnerDeltaPhi::phiRange(const Point2D& hitXY, float hitZ, float errRPhi) const {
   float rLayer = theRLayer;
   Point2D crossing;
 
-  Point2D dHit = hitXY-theVtx;
-  auto  dHitmag = dHit.mag();
-  float  dLayer = 0.;
+  Point2D dHit = hitXY - theVtx;
+  auto dHitmag = dHit.mag();
+  float dLayer = 0.;
   float dL = 0.;
 
   // track is crossing layer with angle such as:
   // this factor should be taken in computation of eror projection
   float cosCross = 0;
 
-
   //
   // compute crossing of stright track with inner layer
   //
   if (!innerIsBarrel) {
-    auto t = theA/(hitZ-theB); auto dt = std::abs(theThickness/(hitZ-theB));
-    crossing = theVtx + t*dHit;
-    rLayer =  crossing.mag();
-    dLayer = t*dHitmag;           dL = dt * dHitmag;
-    cosCross = std::abs( dHit.unit().dot(crossing.unit())); 
+    auto t = theA / (hitZ - theB);
+    auto dt = std::abs(theThickness / (hitZ - theB));
+    crossing = theVtx + t * dHit;
+    rLayer = crossing.mag();
+    dLayer = t * dHitmag;
+    dL = dt * dHitmag;
+    cosCross = std::abs(dHit.unit().dot(crossing.unit()));
   } else {
-
-  //
-  // compute crossing of track with layer
-  // dHit - from VTX to outer hit
-  // rLayer - layer radius
-  // dLayer - distance from VTX to inner layer in direction of dHit
-  // vect(rLayer) = vect(rVTX) + vect(dHit).unit * dLayer
-  //     rLayer^2 = (vect(rVTX) + vect(dHit).unit * dLayer)^2 and we have square eqation for dLayer 
-  //
-  // barrel case
-  //
+    //
+    // compute crossing of track with layer
+    // dHit - from VTX to outer hit
+    // rLayer - layer radius
+    // dLayer - distance from VTX to inner layer in direction of dHit
+    // vect(rLayer) = vect(rVTX) + vect(dHit).unit * dLayer
+    //     rLayer^2 = (vect(rVTX) + vect(dHit).unit * dLayer)^2 and we have square eqation for dLayer
+    //
+    // barrel case
+    //
     auto vtxmag2 = theVtx.mag2();
     if (vtxmag2 < 1.e-10f) {
       dLayer = rLayer;
-    }
-    else { 
+    } else {
       // there are cancellation here....
-      double var_c = vtxmag2-sqr(rLayer);
+      double var_c = vtxmag2 - sqr(rLayer);
       double var_b = theVtx.dot(dHit.unit());
-      double var_delta = sqr(var_b)-var_c;
-      if (var_delta <=0.) var_delta = 0;
-      dLayer = -var_b + std::sqrt(var_delta); //only the value along vector is OK. 
+      double var_delta = sqr(var_b) - var_c;
+      if (var_delta <= 0.)
+        var_delta = 0;
+      dLayer = -var_b + std::sqrt(var_delta);  //only the value along vector is OK.
     }
-    crossing = theVtx+ dHit.unit() * dLayer;
-    cosCross = std::abs( dHit.unit().dot(crossing.unit()));
-    dL = theThickness/cosCross; 
+    crossing = theVtx + dHit.unit() * dLayer;
+    cosCross = std::abs(dHit.unit().dot(crossing.unit()));
+    dL = theThickness / cosCross;
   }
 
-#ifdef USE_VECTORS_HERE 
-  cms_float32x4_t num{dHitmag,dLayer,theROrigin * (dHitmag-dLayer),1.f};
-  cms_float32x4_t den{2*theRCurvature,2*theRCurvature,dHitmag*dLayer,1.f};
-  auto phis = f_asin07f(num/den);
-  phis = phis*dLayer/(rLayer*cosCross);
-  auto deltaPhi = std::abs(phis[0]-phis[1]);
+#ifdef USE_VECTORS_HERE
+  cms_float32x4_t num{dHitmag, dLayer, theROrigin * (dHitmag - dLayer), 1.f};
+  cms_float32x4_t den{2 * theRCurvature, 2 * theRCurvature, dHitmag * dLayer, 1.f};
+  auto phis = f_asin07f(num / den);
+  phis = phis * dLayer / (rLayer * cosCross);
+  auto deltaPhi = std::abs(phis[0] - phis[1]);
   auto deltaPhiOrig = phis[2];
 #else
-#warning no vector!  
-  auto alphaHit = cropped_asin( dHitmag/(2*theRCurvature)); 
-  auto OdeltaPhi = std::abs( alphaHit - cropped_asin( dLayer/(2*theRCurvature)));
-  OdeltaPhi *= dLayer/(rLayer*cosCross);  
+#warning no vector!
+  auto alphaHit = cropped_asin(dHitmag / (2 * theRCurvature));
+  auto OdeltaPhi = std::abs(alphaHit - cropped_asin(dLayer / (2 * theRCurvature)));
+  OdeltaPhi *= dLayer / (rLayer * cosCross);
   // compute additional delta phi due to origin radius
-  auto OdeltaPhiOrig = cropped_asin( theROrigin * (dHitmag-dLayer) / (dHitmag*dLayer));
-  OdeltaPhiOrig *= dLayer/(rLayer*cosCross);
+  auto OdeltaPhiOrig = cropped_asin(theROrigin * (dHitmag - dLayer) / (dHitmag * dLayer));
+  OdeltaPhiOrig *= dLayer / (rLayer * cosCross);
   // std::cout << "dphi " << OdeltaPhi<<'/'<<OdeltaPhiOrig << ' ' << deltaPhi<<'/'<<deltaPhiOrig << std::endl;
 
   auto deltaPhi = OdeltaPhi;
@@ -243,25 +239,26 @@ PixelRecoRange<float> InnerDeltaPhi::phiRange(const Point2D& hitXY,float hitZ,fl
 
   // additinal angle due to not perpendicular stright line crossing  (for displaced beam)
   //  double dPhiCrossing = (cosCross > 0.9999) ? 0 : dL *  sqrt(1-sqr(cosCross))/ rLayer;
-  Point2D crossing2 = theVtx + dHit.unit()* (dLayer+dL);
+  Point2D crossing2 = theVtx + dHit.unit() * (dLayer + dL);
   auto phicross2 = f_phi(crossing2);
   auto phicross1 = f_phi(crossing);
-  auto dphicross = phicross2-phicross1;
-  if (dphicross < -float(M_PI)) dphicross += float(2*M_PI);
-  if (dphicross >  float(M_PI)) dphicross -= float(2*M_PI);
-  if (dphicross > float(M_PI/2)) dphicross = 0.;  // something wrong?
+  auto dphicross = phicross2 - phicross1;
+  if (dphicross < -float(M_PI))
+    dphicross += float(2 * M_PI);
+  if (dphicross > float(M_PI))
+    dphicross -= float(2 * M_PI);
+  if (dphicross > float(M_PI / 2))
+    dphicross = 0.;  // something wrong?
   phicross2 = phicross1 + dphicross;
-        
-
 
   // inner hit error taken as constant
   auto deltaPhiHit = theExtraTolerance / rLayer;
 
   // outer hit error
-  //   double deltaPhiHitOuter = errRPhi/rLayer; 
-  auto deltaPhiHitOuter = errRPhi/hitXY.mag();
+  //   double deltaPhiHitOuter = errRPhi/rLayer;
+  auto deltaPhiHitOuter = errRPhi / hitXY.mag();
 
-  auto margin = deltaPhi+deltaPhiOrig+deltaPhiHit+deltaPhiHitOuter ;
+  auto margin = deltaPhi + deltaPhiOrig + deltaPhiHit + deltaPhiHitOuter;
 
   if (thePrecise) {
     // add multiple scattering correction
@@ -270,21 +267,16 @@ PixelRecoRange<float> InnerDeltaPhi::phiRange(const Point2D& hitXY,float hitZ,fl
     PixelRecoPointRZ zero(0., theVtxZ);
     PixelRecoPointRZ point(hitXY.mag(), hitZ);
     auto scatt = 3.f*sigma(thePtMin,zero, point, ol); 
-    */   
+    */
 
-    auto w = outerIsBarrel ?  std::abs(hitZ) : hitXY.mag();
-    auto nscatt = theScatt0 + theDeltaScatt*w;
- 
+    auto w = outerIsBarrel ? std::abs(hitZ) : hitXY.mag();
+    auto nscatt = theScatt0 + theDeltaScatt * w;
+
     // std::cout << "scatt " << (outerIsBarrel ? "B" : "F") << (innerIsBarrel ? "B " : "F ")
     //          << scatt << ' ' << nscatt << ' ' << nscatt/scatt << std::endl;
 
-    margin += nscatt/ rLayer ;
+    margin += nscatt / rLayer;
   }
-  
-  return PixelRecoRange<float>( std::min(phicross1,phicross2)-margin, 
-                                std::max(phicross1,phicross2)+margin);
+
+  return PixelRecoRange<float>(std::min(phicross1, phicross2) - margin, std::max(phicross1, phicross2) + margin);
 }
-
-
-
-

--- a/RecoTracker/TkHitPairs/src/InnerDeltaPhi.h
+++ b/RecoTracker/TkHitPairs/src/InnerDeltaPhi.h
@@ -1,7 +1,7 @@
 #ifndef InnerDeltaPhi_H
 #define InnerDeltaPhi_H
 
-/** predict phi bending in layer for the tracks constratind by outer hit r-z */ 
+/** predict phi bending in layer for the tracks constratind by outer hit r-z */
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
@@ -10,35 +10,30 @@
 #include "FWCore/Utilities/interface/Visibility.h"
 #include "FWCore/Utilities/interface/Likely.h"
 
-
-
 class DetLayer;
-template<class T> class PixelRecoRange;
+template <class T>
+class PixelRecoRange;
 
 #include "DataFormats/GeometryVector/interface/Basic2DVector.h"
 
 class dso_hidden InnerDeltaPhi {
 public:
-
   typedef Basic2DVector<float> Point2D;
 
-  InnerDeltaPhi( const DetLayer& outlayer,const DetLayer& layer,
-                 const TrackingRegion & region,
-                 const edm::EventSetup& iSetup,
-                 bool precise = true,
-                 float extraTolerance = 0.f);
+  InnerDeltaPhi(const DetLayer& outlayer,
+                const DetLayer& layer,
+                const TrackingRegion& region,
+                const edm::EventSetup& iSetup,
+                bool precise = true,
+                float extraTolerance = 0.f);
 
+  bool prefilter(float xHit, float yHit) const { return xHit * xHit + yHit * yHit > theRLayer * theRLayer; }
 
-  bool prefilter( float xHit, float yHit) const {
-   return xHit*xHit + yHit*yHit > theRLayer*theRLayer;
-  }
-
-  PixelRecoRange<float> operator()( float xHit, float yHit, float zHit, float errRPhi) const {
-    return phiRange( Point2D(xHit,yHit), zHit, errRPhi); 
+  PixelRecoRange<float> operator()(float xHit, float yHit, float zHit, float errRPhi) const {
+    return phiRange(Point2D(xHit, yHit), zHit, errRPhi);
   }
 
 private:
-
   bool innerIsBarrel;
   bool outerIsBarrel;
   bool thePrecise;
@@ -60,19 +55,15 @@ private:
 
   Point2D theVtx;
 
-
   MultipleScatteringParametrisation sigma;
 
-
 private:
-
-  void initBarrelLayer( const DetLayer& layer);
-  void initForwardLayer( const DetLayer& layer, float zMinOrigin, float zMaxOrigin);
+  void initBarrelLayer(const DetLayer& layer);
+  void initForwardLayer(const DetLayer& layer, float zMinOrigin, float zMaxOrigin);
   void initBarrelMS(const DetLayer& outLayer);
   void initForwardMS(const DetLayer& outLayer);
 
-  PixelRecoRange<float> phiRange( const Point2D & hitXY, float zHit, float errRPhi) const;
-
+  PixelRecoRange<float> phiRange(const Point2D& hitXY, float zHit, float errRPhi) const;
 };
 
 #endif

--- a/RecoTracker/TkHitPairs/src/IntermediateHitDoublets.cc
+++ b/RecoTracker/TkHitPairs/src/IntermediateHitDoublets.cc
@@ -2,6 +2,6 @@
 #include "FWCore/Utilities/interface/Exception.h"
 
 IntermediateHitDoublets::IntermediateHitDoublets(const IntermediateHitDoublets& rh) {
-  throw cms::Exception("Not Implemented") << "The copy constructor of IntermediateHitDoublets should never be called. The function exists only to make ROOT dictionary generation happy.";
+  throw cms::Exception("Not Implemented") << "The copy constructor of IntermediateHitDoublets should never be called. "
+                                             "The function exists only to make ROOT dictionary generation happy.";
 }
-

--- a/RecoTracker/TkHitPairs/src/RecHitsSortedInPhi.cc
+++ b/RecoTracker/TkHitPairs/src/RecHitsSortedInPhi.cc
@@ -2,31 +2,34 @@
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
 
 #include <algorithm>
-#include<cassert>
+#include <cassert>
 
-
-
-RecHitsSortedInPhi::RecHitsSortedInPhi(const std::vector<Hit>& hits, GlobalPoint const & origin, DetLayer const * il) :
-  layer(il),
-  isBarrel(il->isBarrel()),
-  x(hits.size()),y(hits.size()),z(hits.size()),drphi(hits.size()),
-  u(hits.size()),v(hits.size()),du(hits.size()),dv(hits.size()),
-  lphi(hits.size())
-{
-
+RecHitsSortedInPhi::RecHitsSortedInPhi(const std::vector<Hit>& hits, GlobalPoint const& origin, DetLayer const* il)
+    : layer(il),
+      isBarrel(il->isBarrel()),
+      x(hits.size()),
+      y(hits.size()),
+      z(hits.size()),
+      drphi(hits.size()),
+      u(hits.size()),
+      v(hits.size()),
+      du(hits.size()),
+      dv(hits.size()),
+      lphi(hits.size()) {
   // standard region have origin as 0,0,z (not true!!!!0
   // cosmic region never used here
   // assert(origin.x()==0 && origin.y()==0);
 
   theHits.reserve(hits.size());
-  for (auto const & hp : hits) theHits.emplace_back(hp);
-  
-  std::sort( theHits.begin(), theHits.end(), HitLessPhi());
+  for (auto const& hp : hits)
+    theHits.emplace_back(hp);
 
-  for (unsigned int i=0; i!=theHits.size(); ++i) {
-    auto const & h = *theHits[i].hit();
-    auto const & gs = static_cast<BaseTrackerRecHit const &>(h).globalState();
-    auto loc = gs.position-origin.basicVector();
+  std::sort(theHits.begin(), theHits.end(), HitLessPhi());
+
+  for (unsigned int i = 0; i != theHits.size(); ++i) {
+    auto const& h = *theHits[i].hit();
+    auto const& gs = static_cast<BaseTrackerRecHit const&>(h).globalState();
+    auto loc = gs.position - origin.basicVector();
     float lr = loc.perp();
     // float lr = gs.position.perp();
     float lz = gs.position.z();
@@ -44,68 +47,56 @@ RecHitsSortedInPhi::RecHitsSortedInPhi(const std::vector<Hit>& hits, GlobalPoint
     dv[i] = isBarrel ? dz : dr;
     lphi[i] = loc.barePhi();
   }
-  
 }
-
 
 RecHitsSortedInPhi::DoubleRange RecHitsSortedInPhi::doubleRange(float phiMin, float phiMax) const {
-  Range r1,r2;
-  if ( phiMin < phiMax) {
-    if ( phiMin < -Geom::fpi()) {
-      r1 = unsafeRange( phiMin + Geom::ftwoPi(), Geom::fpi());
-      r2 = unsafeRange( -Geom::fpi(), phiMax);
+  Range r1, r2;
+  if (phiMin < phiMax) {
+    if (phiMin < -Geom::fpi()) {
+      r1 = unsafeRange(phiMin + Geom::ftwoPi(), Geom::fpi());
+      r2 = unsafeRange(-Geom::fpi(), phiMax);
+    } else if (phiMax > Geom::pi()) {
+      r1 = unsafeRange(phiMin, Geom::fpi());
+      r2 = unsafeRange(-Geom::fpi(), phiMax - Geom::ftwoPi());
+    } else {
+      r1 = unsafeRange(phiMin, phiMax);
+      r2 = Range(theHits.begin(), theHits.begin());
     }
-    else if (phiMax > Geom::pi()) {
-     r1 = unsafeRange( phiMin, Geom::fpi());
-     r2 = unsafeRange( -Geom::fpi(), phiMax-Geom::ftwoPi());
-    }
-    else {
-      r1 = unsafeRange( phiMin, phiMax);
-      r2 = Range(theHits.begin(),theHits.begin());
-    }
-  }
-  else {
-    r1 =unsafeRange( phiMin, Geom::fpi());
-    r2 =unsafeRange( -Geom::fpi(), phiMax);
+  } else {
+    r1 = unsafeRange(phiMin, Geom::fpi());
+    r2 = unsafeRange(-Geom::fpi(), phiMax);
   }
 
-  return (DoubleRange){{int(r1.first-theHits.begin()),int(r1.second-theHits.begin())
-	,int(r2.first-theHits.begin()),int(r2.second-theHits.begin())}};
+  return (DoubleRange){{int(r1.first - theHits.begin()),
+                        int(r1.second - theHits.begin()),
+                        int(r2.first - theHits.begin()),
+                        int(r2.second - theHits.begin())}};
 }
 
-
-void RecHitsSortedInPhi::hits( float phiMin, float phiMax, std::vector<Hit>& result) const
-{
-  if ( phiMin < phiMax) {
-    if ( phiMin < -Geom::fpi()) {
-      copyResult( unsafeRange( phiMin + Geom::ftwoPi(), Geom::fpi()), result);
-      copyResult( unsafeRange( -Geom::fpi(), phiMax), result);
+void RecHitsSortedInPhi::hits(float phiMin, float phiMax, std::vector<Hit>& result) const {
+  if (phiMin < phiMax) {
+    if (phiMin < -Geom::fpi()) {
+      copyResult(unsafeRange(phiMin + Geom::ftwoPi(), Geom::fpi()), result);
+      copyResult(unsafeRange(-Geom::fpi(), phiMax), result);
+    } else if (phiMax > Geom::pi()) {
+      copyResult(unsafeRange(phiMin, Geom::fpi()), result);
+      copyResult(unsafeRange(-Geom::fpi(), phiMax - Geom::ftwoPi()), result);
+    } else {
+      copyResult(unsafeRange(phiMin, phiMax), result);
     }
-    else if (phiMax > Geom::pi()) {
-      copyResult( unsafeRange( phiMin, Geom::fpi()), result);
-      copyResult( unsafeRange( -Geom::fpi(), phiMax-Geom::ftwoPi()), result);
-    }
-    else {
-      copyResult( unsafeRange( phiMin, phiMax), result);
-    }
-  }
-  else {
-    copyResult( unsafeRange( phiMin, Geom::fpi()), result);
-    copyResult( unsafeRange( -Geom::fpi(), phiMax), result);
+  } else {
+    copyResult(unsafeRange(phiMin, Geom::fpi()), result);
+    copyResult(unsafeRange(-Geom::fpi(), phiMax), result);
   }
 }
 
-std::vector<RecHitsSortedInPhi::Hit> RecHitsSortedInPhi::hits( float phiMin, float phiMax) const
-{
+std::vector<RecHitsSortedInPhi::Hit> RecHitsSortedInPhi::hits(float phiMin, float phiMax) const {
   std::vector<Hit> result;
-  hits( phiMin, phiMax, result);
+  hits(phiMin, phiMax, result);
   return result;
 }
 
-RecHitsSortedInPhi::Range 
-RecHitsSortedInPhi::unsafeRange( float phiMin, float phiMax) const
-{
-  auto low = std::lower_bound( theHits.begin(), theHits.end(), HitWithPhi(phiMin), HitLessPhi());
-  return Range( low,
-	       std::upper_bound(low, theHits.end(), HitWithPhi(phiMax), HitLessPhi()));
+RecHitsSortedInPhi::Range RecHitsSortedInPhi::unsafeRange(float phiMin, float phiMax) const {
+  auto low = std::lower_bound(theHits.begin(), theHits.end(), HitWithPhi(phiMin), HitLessPhi());
+  return Range(low, std::upper_bound(low, theHits.end(), HitWithPhi(phiMax), HitLessPhi()));
 }

--- a/RecoTracker/TkHitPairs/src/classes.h
+++ b/RecoTracker/TkHitPairs/src/classes.h
@@ -12,4 +12,4 @@ namespace RecoTracker_TkHitPairs {
     RegionsSeedingHitSets rshs;
     edm::Wrapper<RegionsSeedingHitSets> wrshs;
   };
-}
+}  // namespace RecoTracker_TkHitPairs

--- a/RecoTracker/TkHitPairs/test/testCompatKernel.cc
+++ b/RecoTracker/TkHitPairs/test/testCompatKernel.cc
@@ -7,44 +7,44 @@
 
 typedef PixelRecoRange<float> Range;
 
-
 // devirtualizer
-#include<tuple>
+#include <tuple>
 namespace {
 
-  template<typename Algo>
+  template <typename Algo>
   struct Kernel {
-    using  Base = HitRZCompatibility;
-    void set(Base const * a) {
-      assert( a->algo()==Algo::me);
-      checkRZ=reinterpret_cast<Algo const *>(a);
+    using Base = HitRZCompatibility;
+    void set(Base const *a) {
+      assert(a->algo() == Algo::me);
+      checkRZ = reinterpret_cast<Algo const *>(a);
     }
-    
-    void operator()(int b, int e, const RecHitsSortedInPhi & innerHitsMap, bool * ok) const {
-      constexpr float nSigmaRZ = 3.46410161514; // std::sqrt(12.f);
-      for (int i=b; i!=e; ++i) {
-	Range allowed = checkRZ->range(innerHitsMap.u[i]);
-	float vErr = nSigmaRZ * innerHitsMap.dv[i];
-	Range hitRZ(innerHitsMap.v[i]-vErr, innerHitsMap.v[i]+vErr);
-	Range crossRange = allowed.intersection(hitRZ);
-	ok[i-b] = ! crossRange.empty() ;
+
+    void operator()(int b, int e, const RecHitsSortedInPhi &innerHitsMap, bool *ok) const {
+      constexpr float nSigmaRZ = 3.46410161514;  // std::sqrt(12.f);
+      for (int i = b; i != e; ++i) {
+        Range allowed = checkRZ->range(innerHitsMap.u[i]);
+        float vErr = nSigmaRZ * innerHitsMap.dv[i];
+        Range hitRZ(innerHitsMap.v[i] - vErr, innerHitsMap.v[i] + vErr);
+        Range crossRange = allowed.intersection(hitRZ);
+        ok[i - b] = !crossRange.empty();
       }
     }
-    Algo const * checkRZ;
-    
+    Algo const *checkRZ;
   };
 
+  template <typename... Args>
+  using Kernels = std::tuple<Kernel<Args>...>;
 
-  template<typename ... Args> using Kernels = std::tuple<Kernel<Args>...>;
+}  // namespace
 
+void testR(HitRZCompatibility const *algo, int b, int e, const RecHitsSortedInPhi &innerHitsMap, bool *ok) {
+  Kernel<HitRCheck> k;
+  k.set(algo);
+  k(b, e, innerHitsMap, ok);
 }
 
-void testR(HitRZCompatibility const * algo, int b, int e, const RecHitsSortedInPhi & innerHitsMap, bool * ok) {
-  Kernel<HitRCheck> k; k.set(algo);
-  k(b,e, innerHitsMap,ok);
-}
-
-void testZ(HitRZCompatibility const * algo, int b, int e, const RecHitsSortedInPhi & innerHitsMap, bool * ok) {
-  Kernel<HitZCheck> k; k.set(algo);
-  k(b,e, innerHitsMap,ok);
+void testZ(HitRZCompatibility const *algo, int b, int e, const RecHitsSortedInPhi &innerHitsMap, bool *ok) {
+  Kernel<HitZCheck> k;
+  k.set(algo);
+  k(b, e, innerHitsMap, ok);
 }

--- a/RecoVertex/NuclearInteractionProducer/interface/NuclearInteractionEDProducer.h
+++ b/RecoVertex/NuclearInteractionProducer/interface/NuclearInteractionEDProducer.h
@@ -18,7 +18,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 
@@ -47,35 +46,33 @@ class NuclearVertexBuilder;
 class NuclearLikelihood;
 
 class NuclearInteractionEDProducer : public edm::stream::EDProducer<> {
-
 public:
-      typedef edm::RefVector<TrajectorySeedCollection> TrajectorySeedRefVector;
+  typedef edm::RefVector<TrajectorySeedCollection> TrajectorySeedRefVector;
 
-      explicit NuclearInteractionEDProducer(const edm::ParameterSet&);
-      ~NuclearInteractionEDProducer() override;
+  explicit NuclearInteractionEDProducer(const edm::ParameterSet&);
+  ~NuclearInteractionEDProducer() override;
 
-   private:
-      void produce(edm::Event&, const edm::EventSetup&) override;
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-      static bool isInside( const reco::TrackRef& track, const TrajectorySeedRefVector& seeds);
-      void findAdditionalSecondaryTracks( reco::NuclearInteraction& nucl,
-                                          const edm::Handle<reco::TrackCollection>& additionalSecTracks) const;
+  static bool isInside(const reco::TrackRef& track, const TrajectorySeedRefVector& seeds);
+  void findAdditionalSecondaryTracks(reco::NuclearInteraction& nucl,
+                                     const edm::Handle<reco::TrackCollection>& additionalSecTracks) const;
 
-      // ----------member data ---------------------------
-      edm::ParameterSet conf_;
-      edm::EDGetTokenT<reco::TrackCollection>	 token_primaryTrack; 
-      edm::EDGetTokenT<reco::TrackCollection>	 token_secondaryTrack; 
-      edm::EDGetTokenT<reco::TrackCollection>	 token_additionalSecTracks; 
-      edm::EDGetTokenT<TrajectoryCollection> token_primaryTrajectory; 
-      edm::EDGetTokenT<TrajTrackAssociationCollection> token_refMapH; 
-      edm::EDGetTokenT<TrajectoryToSeedsMap> token_nuclMapH; 
+  // ----------member data ---------------------------
+  edm::ParameterSet conf_;
+  edm::EDGetTokenT<reco::TrackCollection> token_primaryTrack;
+  edm::EDGetTokenT<reco::TrackCollection> token_secondaryTrack;
+  edm::EDGetTokenT<reco::TrackCollection> token_additionalSecTracks;
+  edm::EDGetTokenT<TrajectoryCollection> token_primaryTrajectory;
+  edm::EDGetTokenT<TrajTrackAssociationCollection> token_refMapH;
+  edm::EDGetTokenT<TrajectoryToSeedsMap> token_nuclMapH;
 
-      std::unique_ptr< NuclearVertexBuilder >  vertexBuilder;
-      std::unique_ptr< NuclearLikelihood >     likelihoodCalculator;
+  std::unique_ptr<NuclearVertexBuilder> vertexBuilder;
+  std::unique_ptr<NuclearLikelihood> likelihoodCalculator;
 
   edm::ESWatcher<IdealMagneticFieldRecord> magFieldWatcher_;
   edm::ESWatcher<TransientTrackRecord> transientTrackWatcher_;
-
 };
 
 #endif

--- a/RecoVertex/NuclearInteractionProducer/interface/NuclearLikelihood.h
+++ b/RecoVertex/NuclearInteractionProducer/interface/NuclearLikelihood.h
@@ -4,15 +4,14 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
 class NuclearLikelihood {
+public:
+  NuclearLikelihood() : likelihood_(0.0) {}
+  void calculate(const reco::Vertex& vtx);
+  double result() const { return likelihood_; }
 
-        public :
-            NuclearLikelihood():likelihood_(0.0) { }
-            void calculate( const reco::Vertex& vtx );
-            double result() const { return likelihood_; }
- 
-        private :
-            int secondaryTrackMaxHits(const reco::Vertex& vtx , int& id);
-            double likelihood_;
+private:
+  int secondaryTrackMaxHits(const reco::Vertex& vtx, int& id);
+  double likelihood_;
 };
 
 #endif

--- a/RecoVertex/NuclearInteractionProducer/interface/NuclearVertexBuilder.h
+++ b/RecoVertex/NuclearInteractionProducer/interface/NuclearVertexBuilder.h
@@ -14,58 +14,56 @@
 class FreeTrajectoryState;
 
 class NuclearVertexBuilder {
+public:
+  NuclearVertexBuilder(const MagneticField* mag,
+                       const TransientTrackBuilder* transientTkBuilder,
+                       const edm::ParameterSet& iConfig)
+      : theMagField(mag),
+        theTransientTrackBuilder(transientTkBuilder),
+        minDistFromPrim_(iConfig.getParameter<double>("minDistFromPrimary")),
+        chi2Cut_(iConfig.getParameter<double>("chi2Cut")),
+        DPtovPtCut_(iConfig.getParameter<double>("DPtovPtCut")),
+        minDistFromVtx_(iConfig.getParameter<double>("minDistFromVtx")),
+        shareFrac_(iConfig.getParameter<double>("shareFrac")) {}
 
-  public :
-       NuclearVertexBuilder( const MagneticField * mag, const TransientTrackBuilder* transientTkBuilder, const edm::ParameterSet& iConfig ) : 
-               theMagField(mag), 
-               theTransientTrackBuilder(transientTkBuilder), 
-               minDistFromPrim_( iConfig.getParameter<double>("minDistFromPrimary") ),
-               chi2Cut_(iConfig.getParameter<double>("chi2Cut")), 
-               DPtovPtCut_(iConfig.getParameter<double>("DPtovPtCut")),
-               minDistFromVtx_(iConfig.getParameter<double>("minDistFromVtx")),
-               shareFrac_(iConfig.getParameter<double>("shareFrac")){}
+  void build(const reco::TrackRef& primaryTrack, std::vector<reco::TrackRef>& secondaryTrack);
+  reco::Vertex getVertex() const { return the_vertex; }
+  bool isCompatible(const reco::TrackRef& secTrack) const;
+  void addSecondaryTrack(const reco::TrackRef& secTrack);
+  ClosestApproachInRPhi* closestApproach(const reco::TrackRef& primTrack, const reco::TrackRef& secTrack) const;
 
-       void build( const reco::TrackRef& primaryTrack, std::vector<reco::TrackRef>& secondaryTrack );
-       reco::Vertex  getVertex() const { return the_vertex; } 
-       bool isCompatible( const reco::TrackRef& secTrack ) const;
-       void addSecondaryTrack( const reco::TrackRef& secTrack );
-       ClosestApproachInRPhi* closestApproach( const reco::TrackRef& primTrack, const reco::TrackRef& secTrack ) const;
+private:
+  FreeTrajectoryState getTrajectory(const reco::TrackRef& track) const;
+  bool FillVertexWithCrossingPoint(const reco::TrackRef& primTrack, const std::vector<reco::TrackRef>& secTracks);
+  bool FillVertexWithAdaptVtxFitter(const reco::TrackRef& primTrack, const std::vector<reco::TrackRef>& secTracks);
+  void FillVertexWithLastPrimHit(const reco::TrackRef& primTrack, const std::vector<reco::TrackRef>& secTracks);
+  bool isGoodSecondaryTrack(const reco::TrackRef& primTrack, const reco::TrackRef& secTrack) const;
+  bool isGoodSecondaryTrack(const reco::TrackRef& secTrack,
+                            const reco::TrackRef& primTrack,
+                            const double& distOfClosestApp,
+                            const GlobalPoint& crossPoint) const;
+  void cleanTrackCollection(const reco::TrackRef& primTrack, std::vector<reco::TrackRef>& tC) const;
+  void checkEnergy(const reco::TrackRef& primTrack, std::vector<reco::TrackRef>& tC) const;
 
+  reco::Vertex the_vertex;
 
-  private :
-       FreeTrajectoryState getTrajectory(const reco::TrackRef& track) const;
-       bool FillVertexWithCrossingPoint(const reco::TrackRef& primTrack, const std::vector<reco::TrackRef>& secTracks);
-       bool FillVertexWithAdaptVtxFitter(const reco::TrackRef& primTrack, const std::vector<reco::TrackRef>& secTracks);
-       void FillVertexWithLastPrimHit(const reco::TrackRef& primTrack, const std::vector<reco::TrackRef>& secTracks);
-       bool isGoodSecondaryTrack( const reco::TrackRef& primTrack,  const reco::TrackRef& secTrack ) const;
-       bool isGoodSecondaryTrack( const reco::TrackRef& secTrack,
-                                  const reco::TrackRef& primTrack,
-                                  const double& distOfClosestApp,
-                                  const GlobalPoint& crossPoint ) const;
-       void cleanTrackCollection( const reco::TrackRef& primTrack,
-                                  std::vector<reco::TrackRef>& tC) const;
-       void checkEnergy( const reco::TrackRef& primTrack,
-                         std::vector<reco::TrackRef>& tC) const;
+  const MagneticField* theMagField;
+  const TransientTrackBuilder* theTransientTrackBuilder;
+  double minDistFromPrim_;
+  double chi2Cut_;
+  double DPtovPtCut_;
+  double minDistFromVtx_;
+  double shareFrac_;
 
-       reco::Vertex  the_vertex;
-
-
-       const MagneticField * theMagField;
-       const TransientTrackBuilder* theTransientTrackBuilder;
-       double minDistFromPrim_;
-       double chi2Cut_;
-       double DPtovPtCut_;
-       double minDistFromVtx_;
-       double shareFrac_;
-
-       class cmpTracks {
-          public:
-                bool operator () (const reco::TrackRef& a, const reco::TrackRef& b) {
-                  if( a->numberOfValidHits() != b->numberOfValidHits()) return (a->numberOfValidHits()> b->numberOfValidHits());
-                  else return (a->normalizedChi2()<b->normalizedChi2());
-                }
-        };
-
+  class cmpTracks {
+  public:
+    bool operator()(const reco::TrackRef& a, const reco::TrackRef& b) {
+      if (a->numberOfValidHits() != b->numberOfValidHits())
+        return (a->numberOfValidHits() > b->numberOfValidHits());
+      else
+        return (a->normalizedChi2() < b->normalizedChi2());
+    }
+  };
 };
 
 #endif

--- a/RecoVertex/NuclearInteractionProducer/plugins/NuclearInteractionEDProducer.cc
+++ b/RecoVertex/NuclearInteractionProducer/plugins/NuclearInteractionEDProducer.cc
@@ -6,20 +6,17 @@
 #include "RecoVertex/NuclearInteractionProducer/interface/NuclearVertexBuilder.h"
 #include "RecoVertex/NuclearInteractionProducer/interface/NuclearLikelihood.h"
 
-
 #include "FWCore/Framework/interface/EventSetup.h"
 
 namespace {
   void print(std::ostringstream& str, const reco::NuclearInteraction& nucl, const NuclearVertexBuilder& builder);
 }
 
-
-NuclearInteractionEDProducer::NuclearInteractionEDProducer(const edm::ParameterSet& iConfig) : 
-conf_(iConfig)
-{
+NuclearInteractionEDProducer::NuclearInteractionEDProducer(const edm::ParameterSet& iConfig) : conf_(iConfig) {
   token_primaryTrack = consumes<reco::TrackCollection>(iConfig.getParameter<std::string>("primaryProducer"));
   token_secondaryTrack = consumes<reco::TrackCollection>(iConfig.getParameter<std::string>("secondaryProducer"));
-  token_additionalSecTracks = consumes<reco::TrackCollection>(iConfig.getParameter<std::string>("additionalSecondaryProducer"));
+  token_additionalSecTracks =
+      consumes<reco::TrackCollection>(iConfig.getParameter<std::string>("additionalSecondaryProducer"));
   token_primaryTrajectory = consumes<TrajectoryCollection>(iConfig.getParameter<std::string>("primaryProducer"));
   token_refMapH = consumes<TrajTrackAssociationCollection>(iConfig.getParameter<std::string>("primaryProducer"));
   token_nuclMapH = consumes<TrajectoryToSeedsMap>(iConfig.getParameter<std::string>("seedsProducer"));
@@ -27,157 +24,156 @@ conf_(iConfig)
   produces<reco::NuclearInteractionCollection>();
 }
 
-NuclearInteractionEDProducer::~NuclearInteractionEDProducer()
-{
-}
+NuclearInteractionEDProducer::~NuclearInteractionEDProducer() {}
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-NuclearInteractionEDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-  if ( magFieldWatcher_.check(iSetup) || transientTrackWatcher_.check(iSetup) ) {
+void NuclearInteractionEDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  if (magFieldWatcher_.check(iSetup) || transientTrackWatcher_.check(iSetup)) {
     /// Get magnetic field
     edm::ESHandle<MagneticField> magField;
     iSetup.get<IdealMagneticFieldRecord>().get(magField);
 
     edm::ESHandle<TransientTrackBuilder> builder;
-    iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",builder);
+    iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", builder);
 
-    vertexBuilder = std::make_unique< NuclearVertexBuilder >(magField.product(), builder.product(), conf_);
-    likelihoodCalculator = std::make_unique< NuclearLikelihood >();
+    vertexBuilder = std::make_unique<NuclearVertexBuilder>(magField.product(), builder.product(), conf_);
+    likelihoodCalculator = std::make_unique<NuclearLikelihood>();
   }
 
-   /// Get the primary tracks
-   edm::Handle<reco::TrackCollection>  primaryTrackCollection;
-   iEvent.getByToken(token_primaryTrack, primaryTrackCollection);
+  /// Get the primary tracks
+  edm::Handle<reco::TrackCollection> primaryTrackCollection;
+  iEvent.getByToken(token_primaryTrack, primaryTrackCollection);
 
-   /// Get the primary trajectories (produced by the Refitter)
-   edm::Handle< TrajectoryCollection > primaryTrajectoryCollection;
-   iEvent.getByToken(token_primaryTrajectory, primaryTrajectoryCollection);
+  /// Get the primary trajectories (produced by the Refitter)
+  edm::Handle<TrajectoryCollection> primaryTrajectoryCollection;
+  iEvent.getByToken(token_primaryTrajectory, primaryTrajectoryCollection);
 
-   /// Get the AssociationMap between primary tracks and trajectories
-   edm::Handle< TrajTrackAssociationCollection > refMapH;
-   iEvent.getByToken(token_refMapH, refMapH);
-   const TrajTrackAssociationCollection& refMap = *(refMapH.product());
+  /// Get the AssociationMap between primary tracks and trajectories
+  edm::Handle<TrajTrackAssociationCollection> refMapH;
+  iEvent.getByToken(token_refMapH, refMapH);
+  const TrajTrackAssociationCollection& refMap = *(refMapH.product());
 
-   /// Get the AssociationMap between seeds and primary trajectories
-   edm::Handle<TrajectoryToSeedsMap>  nuclMapH;
-   iEvent.getByToken(token_nuclMapH, nuclMapH);
-   const TrajectoryToSeedsMap& nuclMap = *(nuclMapH.product());
+  /// Get the AssociationMap between seeds and primary trajectories
+  edm::Handle<TrajectoryToSeedsMap> nuclMapH;
+  iEvent.getByToken(token_nuclMapH, nuclMapH);
+  const TrajectoryToSeedsMap& nuclMap = *(nuclMapH.product());
 
-   /// Get the secondary tracks
-   edm::Handle<reco::TrackCollection>  secondaryTrackCollection;
-   iEvent.getByToken(token_secondaryTrack, secondaryTrackCollection);
+  /// Get the secondary tracks
+  edm::Handle<reco::TrackCollection> secondaryTrackCollection;
+  iEvent.getByToken(token_secondaryTrack, secondaryTrackCollection);
 
-   // Get eventual additional secondary tracks
-   edm::Handle<reco::TrackCollection>  additionalSecTracks;
-   iEvent.getByToken(token_additionalSecTracks, additionalSecTracks);
+  // Get eventual additional secondary tracks
+  edm::Handle<reco::TrackCollection> additionalSecTracks;
+  iEvent.getByToken(token_additionalSecTracks, additionalSecTracks);
 
-   /// Definition of the output
-   auto theNuclearInteractions = std::make_unique<reco::NuclearInteractionCollection>();
+  /// Definition of the output
+  auto theNuclearInteractions = std::make_unique<reco::NuclearInteractionCollection>();
 
-   typedef edm::Ref<TrajectoryCollection> TrajectoryRef;
+  typedef edm::Ref<TrajectoryCollection> TrajectoryRef;
 
-   /// Loop on all primary trajectories
-   for(unsigned int i = 0; i < primaryTrajectoryCollection->size() ; i++) {
+  /// Loop on all primary trajectories
+  for (unsigned int i = 0; i < primaryTrajectoryCollection->size(); i++) {
+    TrajectoryRef trajRef(primaryTrajectoryCollection, i);
 
-         TrajectoryRef  trajRef( primaryTrajectoryCollection, i );
+    /// 1. Get the primary track from the trajectory
+    TrajTrackAssociationCollection::const_iterator itPrimTrack = refMap.find(trajRef);
+    if (itPrimTrack == refMap.end() || (itPrimTrack->val).isNull())
+      continue;
+    const reco::TrackRef& primary_track = itPrimTrack->val;
 
-         /// 1. Get the primary track from the trajectory
-         TrajTrackAssociationCollection::const_iterator itPrimTrack = refMap.find( trajRef );
-         if( itPrimTrack == refMap.end() || (itPrimTrack->val).isNull() ) continue;
-         const reco::TrackRef& primary_track = itPrimTrack->val;
+    /// 2. Get the seeds from the trajectory
+    TrajectoryToSeedsMap::const_iterator itSeeds = nuclMap.find(trajRef);
+    if (itSeeds == nuclMap.end() || (itSeeds->val).isNull())
+      continue;
+    const TrajectorySeedRefVector& seeds = itSeeds->val;
 
-         /// 2. Get the seeds from the trajectory
-         TrajectoryToSeedsMap::const_iterator itSeeds = nuclMap.find( trajRef );
-         if( itSeeds == nuclMap.end() || (itSeeds->val).isNull()) continue; 
-         const TrajectorySeedRefVector& seeds = itSeeds->val;
+    /// 3. Get the secondary tracks
+    std::vector<reco::TrackRef> secondary_tracks;
+    for (unsigned int k = 0; k < secondaryTrackCollection->size(); k++) {
+      reco::TrackRef currentTrk(secondaryTrackCollection, k);
+      if (isInside(currentTrk, seeds))
+        secondary_tracks.push_back(currentTrk);
+    }
 
-         /// 3. Get the secondary tracks
-         std::vector<reco::TrackRef> secondary_tracks;
-         for( unsigned int k=0; k < secondaryTrackCollection->size(); k++) {
-                     reco::TrackRef currentTrk(secondaryTrackCollection, k);
-                     if( isInside( currentTrk, seeds ) ) secondary_tracks.push_back(currentTrk);
-         }
-              
-         /// 4. Get the vertex and the likelihood
-         vertexBuilder->build(primary_track, secondary_tracks);
-         likelihoodCalculator->calculate( vertexBuilder->getVertex() );
+    /// 4. Get the vertex and the likelihood
+    vertexBuilder->build(primary_track, secondary_tracks);
+    likelihoodCalculator->calculate(vertexBuilder->getVertex());
 
-         /// 5. Build the nuclear interaction
-         reco::NuclearInteraction nuclInter(seeds, vertexBuilder->getVertex(), likelihoodCalculator->result() );
+    /// 5. Build the nuclear interaction
+    reco::NuclearInteraction nuclInter(seeds, vertexBuilder->getVertex(), likelihoodCalculator->result());
 
-         /// 6. Search for additional secondary tracks in an other track collection
-         ///    and recompute the nuclear interaction
-         if( additionalSecTracks.isValid() )
-                 findAdditionalSecondaryTracks(nuclInter, additionalSecTracks); 
+    /// 6. Search for additional secondary tracks in an other track collection
+    ///    and recompute the nuclear interaction
+    if (additionalSecTracks.isValid())
+      findAdditionalSecondaryTracks(nuclInter, additionalSecTracks);
 
-         theNuclearInteractions->push_back( nuclInter );
+    theNuclearInteractions->push_back(nuclInter);
 
-         std::ostringstream  str;
-         print(str, nuclInter, *vertexBuilder);
-         edm::LogInfo("NuclearInteractionMaker") << str.str();
+    std::ostringstream str;
+    print(str, nuclInter, *vertexBuilder);
+    edm::LogInfo("NuclearInteractionMaker") << str.str();
+  }
 
-   }
-
-
-   LogDebug("NuclearInteractionMaker") << "End of NuclearInteractionMaker - Number of nuclear interactions found :" << theNuclearInteractions->size();
-   iEvent.put(std::move(theNuclearInteractions));
+  LogDebug("NuclearInteractionMaker") << "End of NuclearInteractionMaker - Number of nuclear interactions found :"
+                                      << theNuclearInteractions->size();
+  iEvent.put(std::move(theNuclearInteractions));
 }
 
 // ------ method used to check whether the seed of a track belong to the vector of seeds --
-bool NuclearInteractionEDProducer::isInside( const reco::TrackRef& track, const TrajectorySeedRefVector& seeds) {
-    unsigned int seedKey = track->seedRef().key();
-    for (unsigned int i=0; i< seeds.size(); i++) { if( seeds[i].key() == seedKey ) return true; }
-    return false;
+bool NuclearInteractionEDProducer::isInside(const reco::TrackRef& track, const TrajectorySeedRefVector& seeds) {
+  unsigned int seedKey = track->seedRef().key();
+  for (unsigned int i = 0; i < seeds.size(); i++) {
+    if (seeds[i].key() == seedKey)
+      return true;
+  }
+  return false;
 }
 
-void NuclearInteractionEDProducer::findAdditionalSecondaryTracks( reco::NuclearInteraction& nucl, 
-                                      const edm::Handle<reco::TrackCollection>& additionalSecTracks) const {
-      
-      LogDebug("NuclearInteractionMaker") << "Check if one of the " << additionalSecTracks->size() 
-                                          << " additional secondary track is compatible";
-      reco::TrackRefVector allSecondary;
-      for(unsigned int i=0; i< additionalSecTracks->size(); i++) {
-                 reco::TrackRef sec(additionalSecTracks, i);
-                 if( vertexBuilder->isCompatible( sec ) ) {
-                      // check if sec is already a secondary track (with id = tkId) 
-                      // else add this new track
-                      vertexBuilder->addSecondaryTrack( sec );
-                 }
-      }
-      likelihoodCalculator->calculate( vertexBuilder->getVertex() );
+void NuclearInteractionEDProducer::findAdditionalSecondaryTracks(
+    reco::NuclearInteraction& nucl, const edm::Handle<reco::TrackCollection>& additionalSecTracks) const {
+  LogDebug("NuclearInteractionMaker") << "Check if one of the " << additionalSecTracks->size()
+                                      << " additional secondary track is compatible";
+  reco::TrackRefVector allSecondary;
+  for (unsigned int i = 0; i < additionalSecTracks->size(); i++) {
+    reco::TrackRef sec(additionalSecTracks, i);
+    if (vertexBuilder->isCompatible(sec)) {
+      // check if sec is already a secondary track (with id = tkId)
+      // else add this new track
+      vertexBuilder->addSecondaryTrack(sec);
+    }
+  }
+  likelihoodCalculator->calculate(vertexBuilder->getVertex());
 
-      nucl = reco::NuclearInteraction(nucl.seeds(), vertexBuilder->getVertex(), likelihoodCalculator->result() );
+  nucl = reco::NuclearInteraction(nucl.seeds(), vertexBuilder->getVertex(), likelihoodCalculator->result());
 }
 
 // -- print out
 namespace {
-void print(std::ostringstream& out, const reco::NuclearInteraction& nucl, const NuclearVertexBuilder& builder) {
-   out<<"Nuclear Interaction with vertex position : (";
-   out<< nucl.vertex().position().x() << " , "
-      << nucl.vertex().position().y() << " , "
-      << nucl.vertex().position().z() << ")";
-   reco::TrackRef primTrack = (nucl.primaryTrack()).castTo<reco::TrackRef>();
-   out<<"\tLikelihood : " << nucl.likelihood() << std::endl;
-   out<<"\tPrimary Track : Pt = " << primTrack->pt() << "  - Nhits = "
-      << primTrack->numberOfValidHits() << std::endl;
-   out << "\tNumber of seeds : " << nucl.seedsSize() << std::endl;
-   out << "\tNumber of secondary Tracks : " << nucl.secondaryTracksSize() << std::endl;
-   int it=0;
-   for( reco::NuclearInteraction::trackRef_iterator itr_=nucl.secondaryTracks_begin(); itr_ != nucl.secondaryTracks_end(); itr_++, it++) {
-                reco::TrackRef secTrack = (*itr_).castTo<reco::TrackRef>();
-                ClosestApproachInRPhi* theApproach = builder.closestApproach(primTrack, secTrack);
-                out << "\t\t Secondary track " << it << " : Pt = " << (*itr_)->pt() 
-                    << " - Nhits = " << (*itr_)->numberOfValidHits()
-                    << " - Dist = " << theApproach->distance()
-                    << " - chi2 = " << (*itr_)->normalizedChi2() << std::endl;
-                delete theApproach;
-      }
-   out << "----------------" << std::endl;
-}
-}
+  void print(std::ostringstream& out, const reco::NuclearInteraction& nucl, const NuclearVertexBuilder& builder) {
+    out << "Nuclear Interaction with vertex position : (";
+    out << nucl.vertex().position().x() << " , " << nucl.vertex().position().y() << " , "
+        << nucl.vertex().position().z() << ")";
+    reco::TrackRef primTrack = (nucl.primaryTrack()).castTo<reco::TrackRef>();
+    out << "\tLikelihood : " << nucl.likelihood() << std::endl;
+    out << "\tPrimary Track : Pt = " << primTrack->pt() << "  - Nhits = " << primTrack->numberOfValidHits()
+        << std::endl;
+    out << "\tNumber of seeds : " << nucl.seedsSize() << std::endl;
+    out << "\tNumber of secondary Tracks : " << nucl.secondaryTracksSize() << std::endl;
+    int it = 0;
+    for (reco::NuclearInteraction::trackRef_iterator itr_ = nucl.secondaryTracks_begin();
+         itr_ != nucl.secondaryTracks_end();
+         itr_++, it++) {
+      reco::TrackRef secTrack = (*itr_).castTo<reco::TrackRef>();
+      ClosestApproachInRPhi* theApproach = builder.closestApproach(primTrack, secTrack);
+      out << "\t\t Secondary track " << it << " : Pt = " << (*itr_)->pt()
+          << " - Nhits = " << (*itr_)->numberOfValidHits() << " - Dist = " << theApproach->distance()
+          << " - chi2 = " << (*itr_)->normalizedChi2() << std::endl;
+      delete theApproach;
+    }
+    out << "----------------" << std::endl;
+  }
+}  // namespace

--- a/RecoVertex/NuclearInteractionProducer/src/NuclearLikelihood.cc
+++ b/RecoVertex/NuclearInteractionProducer/src/NuclearLikelihood.cc
@@ -1,27 +1,34 @@
 #include "RecoVertex/NuclearInteractionProducer/interface/NuclearLikelihood.h"
 
-void NuclearLikelihood::calculate( const reco::Vertex& vtx ) {
-      likelihood_ = 0.0;
-      if( vtx.isValid() ) {
-           if(vtx.tracksSize() > 1) {
-               likelihood_ = 0.3;
-               int idBest;
-               int secMaxHits = secondaryTrackMaxHits( vtx, idBest );
-               if( secMaxHits > 3 ) likelihood_ =0.5;
-               if( secMaxHits > 4 ) likelihood_ =0.7;
-               if( (*(vtx.tracks_begin()+idBest))->normalizedChi2() < 3.0) likelihood_=1.0;
-           }
-      }
+void NuclearLikelihood::calculate(const reco::Vertex& vtx) {
+  likelihood_ = 0.0;
+  if (vtx.isValid()) {
+    if (vtx.tracksSize() > 1) {
+      likelihood_ = 0.3;
+      int idBest;
+      int secMaxHits = secondaryTrackMaxHits(vtx, idBest);
+      if (secMaxHits > 3)
+        likelihood_ = 0.5;
+      if (secMaxHits > 4)
+        likelihood_ = 0.7;
+      if ((*(vtx.tracks_begin() + idBest))->normalizedChi2() < 3.0)
+        likelihood_ = 1.0;
+    }
+  }
 }
 
-int NuclearLikelihood::secondaryTrackMaxHits( const reco::Vertex& vtx , int& id) {
-      int maxHits = 0;
-      if( vtx.tracksSize() < 2 )  return 0;
-      int i=1;
-      for( reco::Vertex::trackRef_iterator it = vtx.tracks_begin()+1; it != vtx.tracks_end(); ++it){
-            int nhits = (*it)->numberOfValidHits();
-            if( nhits > maxHits ) { maxHits = nhits; id=i; }
-            i++;
-      }
-      return maxHits;
+int NuclearLikelihood::secondaryTrackMaxHits(const reco::Vertex& vtx, int& id) {
+  int maxHits = 0;
+  if (vtx.tracksSize() < 2)
+    return 0;
+  int i = 1;
+  for (reco::Vertex::trackRef_iterator it = vtx.tracks_begin() + 1; it != vtx.tracks_end(); ++it) {
+    int nhits = (*it)->numberOfValidHits();
+    if (nhits > maxHits) {
+      maxHits = nhits;
+      id = i;
+    }
+    i++;
+  }
+  return maxHits;
 }

--- a/RecoVertex/NuclearInteractionProducer/src/NuclearVertexBuilder.cc
+++ b/RecoVertex/NuclearInteractionProducer/src/NuclearVertexBuilder.cc
@@ -7,270 +7,282 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-void NuclearVertexBuilder::build( const reco::TrackRef& primTrack, std::vector<reco::TrackRef>& secTracks) {
+void NuclearVertexBuilder::build(const reco::TrackRef& primTrack, std::vector<reco::TrackRef>& secTracks) {
+  cleanTrackCollection(primTrack, secTracks);
+  std::sort(secTracks.begin(), secTracks.end(), cmpTracks());
+  checkEnergy(primTrack, secTracks);
 
-     cleanTrackCollection(primTrack, secTracks); 
-     std::sort(secTracks.begin(),secTracks.end(),cmpTracks());
-     checkEnergy(primTrack, secTracks);
-
-     if( !secTracks.empty()) {
-         if( FillVertexWithAdaptVtxFitter(primTrack, secTracks) ) return;
-         else if( FillVertexWithCrossingPoint(primTrack, secTracks) ) return;
-         else FillVertexWithLastPrimHit( primTrack, secTracks);
-     }
-     else {
-       // if no secondary tracks : vertex position = position of last rechit of the primary track 
-       FillVertexWithLastPrimHit( primTrack, secTracks);
-     }
+  if (!secTracks.empty()) {
+    if (FillVertexWithAdaptVtxFitter(primTrack, secTracks))
+      return;
+    else if (FillVertexWithCrossingPoint(primTrack, secTracks))
+      return;
+    else
+      FillVertexWithLastPrimHit(primTrack, secTracks);
+  } else {
+    // if no secondary tracks : vertex position = position of last rechit of the primary track
+    FillVertexWithLastPrimHit(primTrack, secTracks);
+  }
 }
-          
-FreeTrajectoryState NuclearVertexBuilder::getTrajectory(const reco::TrackRef& track) const
-{ 
-  GlobalPoint position(track->vertex().x(),
-                       track->vertex().y(),
-                       track->vertex().z());
 
-  GlobalVector momentum(track->momentum().x(),
-                        track->momentum().y(),
-                        track->momentum().z());
+FreeTrajectoryState NuclearVertexBuilder::getTrajectory(const reco::TrackRef& track) const {
+  GlobalPoint position(track->vertex().x(), track->vertex().y(), track->vertex().z());
 
-  GlobalTrajectoryParameters gtp(position,momentum,
-                                 track->charge(),theMagField);
-  
+  GlobalVector momentum(track->momentum().x(), track->momentum().y(), track->momentum().z());
+
+  GlobalTrajectoryParameters gtp(position, momentum, track->charge(), theMagField);
+
   FreeTrajectoryState fts(gtp);
 
-  return fts; 
-} 
-
-void NuclearVertexBuilder::FillVertexWithLastPrimHit(const reco::TrackRef& primTrack, const std::vector<reco::TrackRef>& secTracks) {
-   LogDebug("NuclearInteractionMaker") << "Vertex build from the end point of the primary track";
-       the_vertex = reco::Vertex(reco::Vertex::Point(primTrack->outerPosition().x(),
-                                         primTrack->outerPosition().y(),
-                                         primTrack->outerPosition().z()),
-                                         reco::Vertex::Error(), 0.,0.,0);
-       the_vertex.add(reco::TrackBaseRef( primTrack ), 1.0);
-       for( unsigned short i=0; i != secTracks.size(); i++) {
-             the_vertex.add(reco::TrackBaseRef( secTracks[i] ), 0.0);
-       }
+  return fts;
 }
 
-bool NuclearVertexBuilder::FillVertexWithAdaptVtxFitter(const reco::TrackRef& primTrack, const std::vector<reco::TrackRef>& secTracks) {
-         std::vector<reco::TransientTrack> transientTracks;
-         transientTracks.push_back( theTransientTrackBuilder->build(primTrack));
-         // get the secondary track with the max number of hits
-         for( unsigned short i=0; i != secTracks.size(); i++ ) {
-              transientTracks.push_back( theTransientTrackBuilder->build( secTracks[i]) );
-         }
-         if( transientTracks.size() == 1 ) return  false;
-         AdaptiveVertexFitter AVF;
-         try {
-            TransientVertex tv = AVF.vertex(transientTracks);
-            the_vertex = reco::Vertex(tv);
-         }
-         catch(VertexException& exception){
-            // AdaptivevertexFitter does not work
-            LogDebug("NuclearInteractionMaker") << exception.what() << "\n";
-            return false;
-         }
-         catch( cms::Exception& exception){
-            // AdaptivevertexFitter does not work
-            LogDebug("NuclearInteractionMaker") << exception.what() << "\n";
-            return false;
-         }
-         if( the_vertex.isValid() ) {
-              LogDebug("NuclearInteractionMaker") << "Try to build from AdaptiveVertexFitter with " << the_vertex.tracksSize() << " tracks";
-              return true;
-           }
-         else return false;
+void NuclearVertexBuilder::FillVertexWithLastPrimHit(const reco::TrackRef& primTrack,
+                                                     const std::vector<reco::TrackRef>& secTracks) {
+  LogDebug("NuclearInteractionMaker") << "Vertex build from the end point of the primary track";
+  the_vertex =
+      reco::Vertex(reco::Vertex::Point(
+                       primTrack->outerPosition().x(), primTrack->outerPosition().y(), primTrack->outerPosition().z()),
+                   reco::Vertex::Error(),
+                   0.,
+                   0.,
+                   0);
+  the_vertex.add(reco::TrackBaseRef(primTrack), 1.0);
+  for (unsigned short i = 0; i != secTracks.size(); i++) {
+    the_vertex.add(reco::TrackBaseRef(secTracks[i]), 0.0);
+  }
 }
 
-
-bool NuclearVertexBuilder::FillVertexWithCrossingPoint(const reco::TrackRef& primTrack, const std::vector<reco::TrackRef>& secTracks) {
-            // get the secondary track with the max number of hits
-            unsigned short maxHits = 0; int indice=-1;
-            for( unsigned short i=0; i < secTracks.size(); i++) {
-                   // Add references to daughters
-                   unsigned short nhits = secTracks[i]->numberOfValidHits();
-                   if( nhits > maxHits ) { maxHits = nhits; indice=i; }
-            }
-
-            // Closest points
-            if(indice == -1) return false;
-
-            ClosestApproachInRPhi* theApproach = closestApproach( primTrack, secTracks[indice]);
-            GlobalPoint crossing = theApproach->crossingPoint();
-            delete theApproach;
-
-            // Create vertex (creation point)
-            // TODO: add error
-            the_vertex = reco::Vertex(reco::Vertex::Point(crossing.x(),
-                                                          crossing.y(),
-                                                          crossing.z()),
-                                      reco::Vertex::Error(), 0.,0.,0);
-
-            the_vertex.add(reco::TrackBaseRef( primTrack ), 1.0);
-            for( unsigned short i=0; i < secTracks.size(); i++) {
-                 if( i==indice ) the_vertex.add(reco::TrackBaseRef( secTracks[i] ), 1.0);
-                 else the_vertex.add(reco::TrackBaseRef( secTracks[i] ), 0.0);
-            }
-            return true;
+bool NuclearVertexBuilder::FillVertexWithAdaptVtxFitter(const reco::TrackRef& primTrack,
+                                                        const std::vector<reco::TrackRef>& secTracks) {
+  std::vector<reco::TransientTrack> transientTracks;
+  transientTracks.push_back(theTransientTrackBuilder->build(primTrack));
+  // get the secondary track with the max number of hits
+  for (unsigned short i = 0; i != secTracks.size(); i++) {
+    transientTracks.push_back(theTransientTrackBuilder->build(secTracks[i]));
+  }
+  if (transientTracks.size() == 1)
+    return false;
+  AdaptiveVertexFitter AVF;
+  try {
+    TransientVertex tv = AVF.vertex(transientTracks);
+    the_vertex = reco::Vertex(tv);
+  } catch (VertexException& exception) {
+    // AdaptivevertexFitter does not work
+    LogDebug("NuclearInteractionMaker") << exception.what() << "\n";
+    return false;
+  } catch (cms::Exception& exception) {
+    // AdaptivevertexFitter does not work
+    LogDebug("NuclearInteractionMaker") << exception.what() << "\n";
+    return false;
+  }
+  if (the_vertex.isValid()) {
+    LogDebug("NuclearInteractionMaker") << "Try to build from AdaptiveVertexFitter with " << the_vertex.tracksSize()
+                                        << " tracks";
+    return true;
+  } else
+    return false;
 }
 
-ClosestApproachInRPhi* NuclearVertexBuilder::closestApproach( const reco::TrackRef& primTrack, const reco::TrackRef& secTrack )  const{
-            FreeTrajectoryState primTraj = getTrajectory(primTrack);
-            ClosestApproachInRPhi *theApproach = new ClosestApproachInRPhi();
-            FreeTrajectoryState secTraj = getTrajectory(secTrack);
-            bool status = theApproach->calculate(primTraj,secTraj);
-            if( status ) { return theApproach; }
-            else { 
-                   return nullptr;
-            }
-}
-
-bool NuclearVertexBuilder::isGoodSecondaryTrack( const reco::TrackRef& primTrack, const reco::TrackRef& secTrack ) const {
-           ClosestApproachInRPhi* theApproach = closestApproach(primTrack, secTrack);
-           bool result = false;
-           if(theApproach)
-             result = isGoodSecondaryTrack(secTrack, primTrack, theApproach->distance() , theApproach->crossingPoint());
-           delete theApproach;
-           return result;
-} 
-
-bool NuclearVertexBuilder::isGoodSecondaryTrack( const reco::TrackRef& secTrack, 
-                                                 const reco::TrackRef& primTrack, 
-                                                 const double& distOfClosestApp, 
-                                                 const GlobalPoint& crossPoint ) const {
-          float TRACKER_RADIUS=129;
-          double pt2 = secTrack->pt();
-          double Dpt2 = secTrack->ptError();
-          double p1 = primTrack->p();
-          double Dp1 = primTrack->qoverpError()*p1*p1;
-          double p2 = secTrack->p();
-          double Dp2 = secTrack->qoverpError()*p2*p2;
-          std::cout << "1)" << distOfClosestApp << " < " << minDistFromPrim_ << " " << (distOfClosestApp < minDistFromPrim_)  << "\n";
-          std::cout << "2)" << secTrack->normalizedChi2() << " < " << chi2Cut_ << " " << (secTrack->normalizedChi2() < chi2Cut_) << "\n";
-          std::cout << "3)" << crossPoint.perp() << " < " << TRACKER_RADIUS << " " << (crossPoint.perp() < TRACKER_RADIUS) << "\n";
-          std::cout << "4)" << (Dpt2/pt2) << " < " << DPtovPtCut_ << " " << ((Dpt2/pt2) < DPtovPtCut_)  << "\n";
-          std::cout << "5)" << (p2-2*Dp2) << " < " << (p1+2*Dp1) << " " << ((p2-2*Dp2) < (p1+2*Dp1))<< "\n";
-          if( distOfClosestApp < minDistFromPrim_ &&
-              secTrack->normalizedChi2() < chi2Cut_ && 
-              crossPoint.perp() < TRACKER_RADIUS && 
-              (Dpt2/pt2) < DPtovPtCut_ &&
-              (p2-2*Dp2) < (p1+2*Dp1)) return true;
-          else return false;
-}
-
-
-bool NuclearVertexBuilder::isCompatible( const reco::TrackRef& secTrack ) const{
-         
-         reco::TrackRef primTrack = (*(the_vertex.tracks_begin())).castTo<reco::TrackRef>();
-         ClosestApproachInRPhi *theApproach = closestApproach(primTrack, secTrack);
-         bool result = false;
-         if( theApproach ) {
-           GlobalPoint crp = theApproach->crossingPoint();
-           math::XYZPoint vtx = the_vertex.position();
-           float dist = sqrt((crp.x()-vtx.x())*(crp.x()-vtx.x()) +
-                        (crp.y()-vtx.y())*(crp.y()-vtx.y()) +
-                        (crp.z()-vtx.z())*(crp.z()-vtx.z()));
-
-           float distError = sqrt(the_vertex.xError()*the_vertex.xError() +
-                                  the_vertex.yError()*the_vertex.yError() +
-                                  the_vertex.zError()*the_vertex.zError());
- 
-           //std::cout << "Distance between Additional track and vertex =" << dist << " +/- " << distError << std::endl;
-           // TODO : add condition on distance between last rechit of the primary and the first rec hit of the secondary
- 
-           result = (isGoodSecondaryTrack(secTrack, primTrack, theApproach->distance(), crp) 
-                     && dist-distError<minDistFromVtx_);
-         }
-         delete theApproach;
-         return result;
-}
-
-void NuclearVertexBuilder::addSecondaryTrack( const reco::TrackRef& secTrack ) {
-        std::vector<reco::TrackRef> allSecondary;
-        for( reco::Vertex::trackRef_iterator it=the_vertex.tracks_begin()+1; it != the_vertex.tracks_end(); it++) {
-            allSecondary.push_back( (*it).castTo<reco::TrackRef>() );
-        } 
-        allSecondary.push_back( secTrack );
-        build( (*the_vertex.tracks_begin()).castTo<reco::TrackRef>(), allSecondary );
-}
-
-void NuclearVertexBuilder::cleanTrackCollection( const reco::TrackRef& primTrack, 
-                                                 std::vector<reco::TrackRef>& tC) const {
-
-    // inspired from FinalTrackSelector (S. Wagner) modified by P. Janot
-    LogDebug("NuclearInteractionMaker") << "cleanTrackCollection number of input tracks : " << tC.size();
-   std::map<reco::TrackRef const*, std::vector<const TrackingRecHit*>> rh;
-
-    // first remove bad quality tracks and create map
-    std::vector<bool> selected(tC.size(), false);
-    int i=0;
-    for(auto const& track : tC) {
-       if( isGoodSecondaryTrack(primTrack, track)) { 
-            selected[i]=true;
-            for(auto const& hit : track->recHits()) rh[&track].push_back(hit);
-        }
-       i++;
+bool NuclearVertexBuilder::FillVertexWithCrossingPoint(const reco::TrackRef& primTrack,
+                                                       const std::vector<reco::TrackRef>& secTracks) {
+  // get the secondary track with the max number of hits
+  unsigned short maxHits = 0;
+  int indice = -1;
+  for (unsigned short i = 0; i < secTracks.size(); i++) {
+    // Add references to daughters
+    unsigned short nhits = secTracks[i]->numberOfValidHits();
+    if (nhits > maxHits) {
+      maxHits = nhits;
+      indice = i;
     }
+  }
 
-    // then remove duplicated tracks
-    i=-1;
-    for(auto const& track : tC) {
-      i++;
-      int j=-1;
-      for(auto const& track2 : tC) {
-        j++;
-        if ((!selected[j])||(!selected[i]))continue;
-        if ((j<=i))continue;
-        int noverlap=0;
-        std::vector<const TrackingRecHit*>& iHits = rh[&track];
-        for ( unsigned ih=0; ih<iHits.size(); ++ih ) {
-          const TrackingRecHit* it = iHits[ih];
-          if (it->isValid()){
-            std::vector<const TrackingRecHit*>& jHits = rh[&track2];
-            for ( unsigned ih2=0; ih2<jHits.size(); ++ih2 ) {
+  // Closest points
+  if (indice == -1)
+    return false;
+
+  ClosestApproachInRPhi* theApproach = closestApproach(primTrack, secTracks[indice]);
+  GlobalPoint crossing = theApproach->crossingPoint();
+  delete theApproach;
+
+  // Create vertex (creation point)
+  // TODO: add error
+  the_vertex =
+      reco::Vertex(reco::Vertex::Point(crossing.x(), crossing.y(), crossing.z()), reco::Vertex::Error(), 0., 0., 0);
+
+  the_vertex.add(reco::TrackBaseRef(primTrack), 1.0);
+  for (unsigned short i = 0; i < secTracks.size(); i++) {
+    if (i == indice)
+      the_vertex.add(reco::TrackBaseRef(secTracks[i]), 1.0);
+    else
+      the_vertex.add(reco::TrackBaseRef(secTracks[i]), 0.0);
+  }
+  return true;
+}
+
+ClosestApproachInRPhi* NuclearVertexBuilder::closestApproach(const reco::TrackRef& primTrack,
+                                                             const reco::TrackRef& secTrack) const {
+  FreeTrajectoryState primTraj = getTrajectory(primTrack);
+  ClosestApproachInRPhi* theApproach = new ClosestApproachInRPhi();
+  FreeTrajectoryState secTraj = getTrajectory(secTrack);
+  bool status = theApproach->calculate(primTraj, secTraj);
+  if (status) {
+    return theApproach;
+  } else {
+    return nullptr;
+  }
+}
+
+bool NuclearVertexBuilder::isGoodSecondaryTrack(const reco::TrackRef& primTrack, const reco::TrackRef& secTrack) const {
+  ClosestApproachInRPhi* theApproach = closestApproach(primTrack, secTrack);
+  bool result = false;
+  if (theApproach)
+    result = isGoodSecondaryTrack(secTrack, primTrack, theApproach->distance(), theApproach->crossingPoint());
+  delete theApproach;
+  return result;
+}
+
+bool NuclearVertexBuilder::isGoodSecondaryTrack(const reco::TrackRef& secTrack,
+                                                const reco::TrackRef& primTrack,
+                                                const double& distOfClosestApp,
+                                                const GlobalPoint& crossPoint) const {
+  float TRACKER_RADIUS = 129;
+  double pt2 = secTrack->pt();
+  double Dpt2 = secTrack->ptError();
+  double p1 = primTrack->p();
+  double Dp1 = primTrack->qoverpError() * p1 * p1;
+  double p2 = secTrack->p();
+  double Dp2 = secTrack->qoverpError() * p2 * p2;
+  std::cout << "1)" << distOfClosestApp << " < " << minDistFromPrim_ << " " << (distOfClosestApp < minDistFromPrim_)
+            << "\n";
+  std::cout << "2)" << secTrack->normalizedChi2() << " < " << chi2Cut_ << " " << (secTrack->normalizedChi2() < chi2Cut_)
+            << "\n";
+  std::cout << "3)" << crossPoint.perp() << " < " << TRACKER_RADIUS << " " << (crossPoint.perp() < TRACKER_RADIUS)
+            << "\n";
+  std::cout << "4)" << (Dpt2 / pt2) << " < " << DPtovPtCut_ << " " << ((Dpt2 / pt2) < DPtovPtCut_) << "\n";
+  std::cout << "5)" << (p2 - 2 * Dp2) << " < " << (p1 + 2 * Dp1) << " " << ((p2 - 2 * Dp2) < (p1 + 2 * Dp1)) << "\n";
+  if (distOfClosestApp < minDistFromPrim_ && secTrack->normalizedChi2() < chi2Cut_ &&
+      crossPoint.perp() < TRACKER_RADIUS && (Dpt2 / pt2) < DPtovPtCut_ && (p2 - 2 * Dp2) < (p1 + 2 * Dp1))
+    return true;
+  else
+    return false;
+}
+
+bool NuclearVertexBuilder::isCompatible(const reco::TrackRef& secTrack) const {
+  reco::TrackRef primTrack = (*(the_vertex.tracks_begin())).castTo<reco::TrackRef>();
+  ClosestApproachInRPhi* theApproach = closestApproach(primTrack, secTrack);
+  bool result = false;
+  if (theApproach) {
+    GlobalPoint crp = theApproach->crossingPoint();
+    math::XYZPoint vtx = the_vertex.position();
+    float dist = sqrt((crp.x() - vtx.x()) * (crp.x() - vtx.x()) + (crp.y() - vtx.y()) * (crp.y() - vtx.y()) +
+                      (crp.z() - vtx.z()) * (crp.z() - vtx.z()));
+
+    float distError = sqrt(the_vertex.xError() * the_vertex.xError() + the_vertex.yError() * the_vertex.yError() +
+                           the_vertex.zError() * the_vertex.zError());
+
+    //std::cout << "Distance between Additional track and vertex =" << dist << " +/- " << distError << std::endl;
+    // TODO : add condition on distance between last rechit of the primary and the first rec hit of the secondary
+
+    result =
+        (isGoodSecondaryTrack(secTrack, primTrack, theApproach->distance(), crp) && dist - distError < minDistFromVtx_);
+  }
+  delete theApproach;
+  return result;
+}
+
+void NuclearVertexBuilder::addSecondaryTrack(const reco::TrackRef& secTrack) {
+  std::vector<reco::TrackRef> allSecondary;
+  for (reco::Vertex::trackRef_iterator it = the_vertex.tracks_begin() + 1; it != the_vertex.tracks_end(); it++) {
+    allSecondary.push_back((*it).castTo<reco::TrackRef>());
+  }
+  allSecondary.push_back(secTrack);
+  build((*the_vertex.tracks_begin()).castTo<reco::TrackRef>(), allSecondary);
+}
+
+void NuclearVertexBuilder::cleanTrackCollection(const reco::TrackRef& primTrack,
+                                                std::vector<reco::TrackRef>& tC) const {
+  // inspired from FinalTrackSelector (S. Wagner) modified by P. Janot
+  LogDebug("NuclearInteractionMaker") << "cleanTrackCollection number of input tracks : " << tC.size();
+  std::map<reco::TrackRef const*, std::vector<const TrackingRecHit*>> rh;
+
+  // first remove bad quality tracks and create map
+  std::vector<bool> selected(tC.size(), false);
+  int i = 0;
+  for (auto const& track : tC) {
+    if (isGoodSecondaryTrack(primTrack, track)) {
+      selected[i] = true;
+      for (auto const& hit : track->recHits())
+        rh[&track].push_back(hit);
+    }
+    i++;
+  }
+
+  // then remove duplicated tracks
+  i = -1;
+  for (auto const& track : tC) {
+    i++;
+    int j = -1;
+    for (auto const& track2 : tC) {
+      j++;
+      if ((!selected[j]) || (!selected[i]))
+        continue;
+      if ((j <= i))
+        continue;
+      int noverlap = 0;
+      std::vector<const TrackingRecHit*>& iHits = rh[&track];
+      for (unsigned ih = 0; ih < iHits.size(); ++ih) {
+        const TrackingRecHit* it = iHits[ih];
+        if (it->isValid()) {
+          std::vector<const TrackingRecHit*>& jHits = rh[&track2];
+          for (unsigned ih2 = 0; ih2 < jHits.size(); ++ih2) {
             const TrackingRecHit* jt = jHits[ih2];
-              if (jt->isValid()){
-                const TrackingRecHit* kt = jt;
-                if ( it->sharesInput(kt,TrackingRecHit::some) )noverlap++;
-               }
-             }
+            if (jt->isValid()) {
+              const TrackingRecHit* kt = jt;
+              if (it->sharesInput(kt, TrackingRecHit::some))
+                noverlap++;
+            }
           }
         }
-        float fi=float(noverlap)/float(track->recHitsSize()); 
-        float fj=float(noverlap)/float(track2->recHitsSize());
-        if ((fi>shareFrac_)||(fj>shareFrac_)){
-          if (fi<fj){
-            selected[j]=false;
-          }else{
-            if (fi>fj){
-              selected[i]=false;
-            }else{
-              if (track->normalizedChi2() > track2->normalizedChi2()){selected[i]=false;}else{selected[j]=false;}
-            }//end fi > or = fj
-          }//end fi < fj
-        }//end got a duplicate
-      }//end track2 loop
-    }//end track loop
+      }
+      float fi = float(noverlap) / float(track->recHitsSize());
+      float fj = float(noverlap) / float(track2->recHitsSize());
+      if ((fi > shareFrac_) || (fj > shareFrac_)) {
+        if (fi < fj) {
+          selected[j] = false;
+        } else {
+          if (fi > fj) {
+            selected[i] = false;
+          } else {
+            if (track->normalizedChi2() > track2->normalizedChi2()) {
+              selected[i] = false;
+            } else {
+              selected[j] = false;
+            }
+          }  //end fi > or = fj
+        }    //end fi < fj
+      }      //end got a duplicate
+    }        //end track2 loop
+  }          //end track loop
 
-   std::vector< reco::TrackRef > newTrackColl;
-   i=0;
-   for(auto const& track : tC) {
-         if( selected[i] ) newTrackColl.push_back(track);
-         ++i;
-   }
-   tC = newTrackColl;
+  std::vector<reco::TrackRef> newTrackColl;
+  i = 0;
+  for (auto const& track : tC) {
+    if (selected[i])
+      newTrackColl.push_back(track);
+    ++i;
+  }
+  tC = newTrackColl;
 }
 
-void NuclearVertexBuilder::checkEnergy( const reco::TrackRef& primTrack,
-                                        std::vector<reco::TrackRef>& tC) const {
-   float totalEnergy=0;
-   for(size_t i=0; i< tC.size(); ++i) {
-     totalEnergy += tC[i]->p();
-   }
-   if( totalEnergy > primTrack->p()+0.1*primTrack->p() ) {
-           tC.pop_back();
-           checkEnergy(primTrack,tC);
-   }
+void NuclearVertexBuilder::checkEnergy(const reco::TrackRef& primTrack, std::vector<reco::TrackRef>& tC) const {
+  float totalEnergy = 0;
+  for (size_t i = 0; i < tC.size(); ++i) {
+    totalEnergy += tC[i]->p();
+  }
+  if (totalEnergy > primTrack->p() + 0.1 * primTrack->p()) {
+    tC.pop_back();
+    checkEnergy(primTrack, tC);
+  }
 }

--- a/RecoVertex/V0Producer/src/V0Fitter.cc
+++ b/RecoVertex/V0Producer/src/V0Fitter.cc
@@ -35,122 +35,124 @@
 
 // pdg mass constants
 namespace {
-   const double piMass = 0.13957018;
-   const double piMassSquared = piMass*piMass;
-   const double protonMass = 0.938272046;
-   const double protonMassSquared = protonMass*protonMass;
-   const double kShortMass = 0.497614;
-   const double lambdaMass = 1.115683;
-}
+  const double piMass = 0.13957018;
+  const double piMassSquared = piMass * piMass;
+  const double protonMass = 0.938272046;
+  const double protonMassSquared = protonMass * protonMass;
+  const double kShortMass = 0.497614;
+  const double lambdaMass = 1.115683;
+}  // namespace
 
-typedef ROOT::Math::SMatrix<double, 3, 3, ROOT::Math::MatRepSym<double, 3> > SMatrixSym3D;
+typedef ROOT::Math::SMatrix<double, 3, 3, ROOT::Math::MatRepSym<double, 3>> SMatrixSym3D;
 typedef ROOT::Math::SVector<double, 3> SVector3;
 
-V0Fitter::V0Fitter(const edm::ParameterSet& theParameters, edm::ConsumesCollector && iC)
-{
-   token_beamSpot = iC.consumes<reco::BeamSpot>(theParameters.getParameter<edm::InputTag>("beamSpot"));
-   useVertex_ = theParameters.getParameter<bool>("useVertex");
-   token_vertices = iC.consumes<std::vector<reco::Vertex>>(theParameters.getParameter<edm::InputTag>("vertices"));
+V0Fitter::V0Fitter(const edm::ParameterSet& theParameters, edm::ConsumesCollector&& iC) {
+  token_beamSpot = iC.consumes<reco::BeamSpot>(theParameters.getParameter<edm::InputTag>("beamSpot"));
+  useVertex_ = theParameters.getParameter<bool>("useVertex");
+  token_vertices = iC.consumes<std::vector<reco::Vertex>>(theParameters.getParameter<edm::InputTag>("vertices"));
 
-   token_tracks = iC.consumes<reco::TrackCollection>(theParameters.getParameter<edm::InputTag>("trackRecoAlgorithm"));
-   vertexFitter_ = theParameters.getParameter<bool>("vertexFitter");
-   useRefTracks_ = theParameters.getParameter<bool>("useRefTracks");
-   
-   // whether to reconstruct KShorts
-   doKShorts_ = theParameters.getParameter<bool>("doKShorts");
-   // whether to reconstruct Lambdas
-   doLambdas_ = theParameters.getParameter<bool>("doLambdas");
+  token_tracks = iC.consumes<reco::TrackCollection>(theParameters.getParameter<edm::InputTag>("trackRecoAlgorithm"));
+  vertexFitter_ = theParameters.getParameter<bool>("vertexFitter");
+  useRefTracks_ = theParameters.getParameter<bool>("useRefTracks");
 
-   // cuts on initial track selection
-   tkChi2Cut_ = theParameters.getParameter<double>("tkChi2Cut");
-   tkNHitsCut_ = theParameters.getParameter<int>("tkNHitsCut");
-   tkPtCut_ = theParameters.getParameter<double>("tkPtCut");
-   tkIPSigXYCut_ = theParameters.getParameter<double>("tkIPSigXYCut");
-   tkIPSigZCut_ = theParameters.getParameter<double>("tkIPSigZCut");
-   
-   // cuts on vertex
-   vtxChi2Cut_ = theParameters.getParameter<double>("vtxChi2Cut");
-   vtxDecaySigXYZCut_ = theParameters.getParameter<double>("vtxDecaySigXYZCut");
-   vtxDecaySigXYCut_ = theParameters.getParameter<double>("vtxDecaySigXYCut");
-   // miscellaneous cuts
-   tkDCACut_ = theParameters.getParameter<double>("tkDCACut");
-   mPiPiCut_ = theParameters.getParameter<double>("mPiPiCut");
-   innerHitPosCut_ = theParameters.getParameter<double>("innerHitPosCut");
-   cosThetaXYCut_ = theParameters.getParameter<double>("cosThetaXYCut");
-   cosThetaXYZCut_ = theParameters.getParameter<double>("cosThetaXYZCut");
-   // cuts on the V0 candidate mass
-   kShortMassCut_ = theParameters.getParameter<double>("kShortMassCut");
-   lambdaMassCut_ = theParameters.getParameter<double>("lambdaMassCut");
+  // whether to reconstruct KShorts
+  doKShorts_ = theParameters.getParameter<bool>("doKShorts");
+  // whether to reconstruct Lambdas
+  doLambdas_ = theParameters.getParameter<bool>("doLambdas");
+
+  // cuts on initial track selection
+  tkChi2Cut_ = theParameters.getParameter<double>("tkChi2Cut");
+  tkNHitsCut_ = theParameters.getParameter<int>("tkNHitsCut");
+  tkPtCut_ = theParameters.getParameter<double>("tkPtCut");
+  tkIPSigXYCut_ = theParameters.getParameter<double>("tkIPSigXYCut");
+  tkIPSigZCut_ = theParameters.getParameter<double>("tkIPSigZCut");
+
+  // cuts on vertex
+  vtxChi2Cut_ = theParameters.getParameter<double>("vtxChi2Cut");
+  vtxDecaySigXYZCut_ = theParameters.getParameter<double>("vtxDecaySigXYZCut");
+  vtxDecaySigXYCut_ = theParameters.getParameter<double>("vtxDecaySigXYCut");
+  // miscellaneous cuts
+  tkDCACut_ = theParameters.getParameter<double>("tkDCACut");
+  mPiPiCut_ = theParameters.getParameter<double>("mPiPiCut");
+  innerHitPosCut_ = theParameters.getParameter<double>("innerHitPosCut");
+  cosThetaXYCut_ = theParameters.getParameter<double>("cosThetaXYCut");
+  cosThetaXYZCut_ = theParameters.getParameter<double>("cosThetaXYZCut");
+  // cuts on the V0 candidate mass
+  kShortMassCut_ = theParameters.getParameter<double>("kShortMassCut");
+  lambdaMassCut_ = theParameters.getParameter<double>("lambdaMassCut");
 }
 
 // method containing the algorithm for vertex reconstruction
-void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
-   reco::VertexCompositeCandidateCollection & theKshorts, reco::VertexCompositeCandidateCollection & theLambdas)
-{
-   using std::vector;
+void V0Fitter::fitAll(const edm::Event& iEvent,
+                      const edm::EventSetup& iSetup,
+                      reco::VertexCompositeCandidateCollection& theKshorts,
+                      reco::VertexCompositeCandidateCollection& theLambdas) {
+  using std::vector;
 
-   edm::Handle<reco::TrackCollection> theTrackHandle;
-   iEvent.getByToken(token_tracks, theTrackHandle);
-   if (theTrackHandle->empty()) return;
-   const reco::TrackCollection* theTrackCollection = theTrackHandle.product();   
+  edm::Handle<reco::TrackCollection> theTrackHandle;
+  iEvent.getByToken(token_tracks, theTrackHandle);
+  if (theTrackHandle->empty())
+    return;
+  const reco::TrackCollection* theTrackCollection = theTrackHandle.product();
 
-   edm::Handle<reco::BeamSpot> theBeamSpotHandle;
-   iEvent.getByToken(token_beamSpot, theBeamSpotHandle);
-   const reco::BeamSpot* theBeamSpot = theBeamSpotHandle.product();
-   math::XYZPoint referencePos(theBeamSpot->position());
-  
-   reco::Vertex referenceVtx;
-   if (useVertex_) {
-      edm::Handle<std::vector<reco::Vertex>> vertices;
-      iEvent.getByToken(token_vertices, vertices);
-      referenceVtx = vertices->at(0);
-      referencePos = referenceVtx.position();
-   }
+  edm::Handle<reco::BeamSpot> theBeamSpotHandle;
+  iEvent.getByToken(token_beamSpot, theBeamSpotHandle);
+  const reco::BeamSpot* theBeamSpot = theBeamSpotHandle.product();
+  math::XYZPoint referencePos(theBeamSpot->position());
 
-   edm::ESHandle<MagneticField> theMagneticFieldHandle;
-   iSetup.get<IdealMagneticFieldRecord>().get(theMagneticFieldHandle);
-   const MagneticField* theMagneticField = theMagneticFieldHandle.product();
+  reco::Vertex referenceVtx;
+  if (useVertex_) {
+    edm::Handle<std::vector<reco::Vertex>> vertices;
+    iEvent.getByToken(token_vertices, vertices);
+    referenceVtx = vertices->at(0);
+    referencePos = referenceVtx.position();
+  }
 
-   std::vector<reco::TrackRef> theTrackRefs;
-   std::vector<reco::TransientTrack> theTransTracks;
+  edm::ESHandle<MagneticField> theMagneticFieldHandle;
+  iSetup.get<IdealMagneticFieldRecord>().get(theMagneticFieldHandle);
+  const MagneticField* theMagneticField = theMagneticFieldHandle.product();
 
-   // fill vectors of TransientTracks and TrackRefs after applying preselection cuts
-   for (reco::TrackCollection::const_iterator iTk = theTrackCollection->begin(); iTk != theTrackCollection->end(); ++iTk) {
-      const reco::Track* tmpTrack = &(*iTk);
-      double ipsigXY = std::abs(tmpTrack->dxy(*theBeamSpot)/tmpTrack->dxyError());
-      if (useVertex_) ipsigXY = std::abs(tmpTrack->dxy(referencePos)/tmpTrack->dxyError());
-      double ipsigZ = std::abs(tmpTrack->dz(referencePos)/tmpTrack->dzError());
-      if (tmpTrack->normalizedChi2() < tkChi2Cut_ && tmpTrack->numberOfValidHits() >= tkNHitsCut_ &&
-          tmpTrack->pt() > tkPtCut_ && ipsigXY > tkIPSigXYCut_ && ipsigZ > tkIPSigZCut_) {
-         reco::TrackRef tmpRef(theTrackHandle, std::distance(theTrackCollection->begin(), iTk));
-         theTrackRefs.push_back(std::move(tmpRef));
-         reco::TransientTrack tmpTransient(*tmpRef, theMagneticField);
-         theTransTracks.push_back(std::move(tmpTransient));
-      }
-   }
-   // good tracks have now been selected for vertexing
+  std::vector<reco::TrackRef> theTrackRefs;
+  std::vector<reco::TransientTrack> theTransTracks;
 
-   // loop over tracks and vertex good charged track pairs
-   for (unsigned int trdx1 = 0; trdx1 < theTrackRefs.size(); ++trdx1) {
-   for (unsigned int trdx2 = trdx1 + 1; trdx2 < theTrackRefs.size(); ++trdx2) {
+  // fill vectors of TransientTracks and TrackRefs after applying preselection cuts
+  for (reco::TrackCollection::const_iterator iTk = theTrackCollection->begin(); iTk != theTrackCollection->end();
+       ++iTk) {
+    const reco::Track* tmpTrack = &(*iTk);
+    double ipsigXY = std::abs(tmpTrack->dxy(*theBeamSpot) / tmpTrack->dxyError());
+    if (useVertex_)
+      ipsigXY = std::abs(tmpTrack->dxy(referencePos) / tmpTrack->dxyError());
+    double ipsigZ = std::abs(tmpTrack->dz(referencePos) / tmpTrack->dzError());
+    if (tmpTrack->normalizedChi2() < tkChi2Cut_ && tmpTrack->numberOfValidHits() >= tkNHitsCut_ &&
+        tmpTrack->pt() > tkPtCut_ && ipsigXY > tkIPSigXYCut_ && ipsigZ > tkIPSigZCut_) {
+      reco::TrackRef tmpRef(theTrackHandle, std::distance(theTrackCollection->begin(), iTk));
+      theTrackRefs.push_back(std::move(tmpRef));
+      reco::TransientTrack tmpTransient(*tmpRef, theMagneticField);
+      theTransTracks.push_back(std::move(tmpTransient));
+    }
+  }
+  // good tracks have now been selected for vertexing
 
+  // loop over tracks and vertex good charged track pairs
+  for (unsigned int trdx1 = 0; trdx1 < theTrackRefs.size(); ++trdx1) {
+    for (unsigned int trdx2 = trdx1 + 1; trdx2 < theTrackRefs.size(); ++trdx2) {
       reco::TrackRef positiveTrackRef;
       reco::TrackRef negativeTrackRef;
       reco::TransientTrack* posTransTkPtr = nullptr;
       reco::TransientTrack* negTransTkPtr = nullptr;
 
       if (theTrackRefs[trdx1]->charge() < 0. && theTrackRefs[trdx2]->charge() > 0.) {
-         negativeTrackRef = theTrackRefs[trdx1];
-         positiveTrackRef = theTrackRefs[trdx2];
-         negTransTkPtr = &theTransTracks[trdx1];
-         posTransTkPtr = &theTransTracks[trdx2];
+        negativeTrackRef = theTrackRefs[trdx1];
+        positiveTrackRef = theTrackRefs[trdx2];
+        negTransTkPtr = &theTransTracks[trdx1];
+        posTransTkPtr = &theTransTracks[trdx2];
       } else if (theTrackRefs[trdx1]->charge() > 0. && theTrackRefs[trdx2]->charge() < 0.) {
-         negativeTrackRef = theTrackRefs[trdx2];
-         positiveTrackRef = theTrackRefs[trdx1];
-         negTransTkPtr = &theTransTracks[trdx2];
-         posTransTkPtr = &theTransTracks[trdx1];
+        negativeTrackRef = theTrackRefs[trdx2];
+        positiveTrackRef = theTrackRefs[trdx1];
+        negTransTkPtr = &theTransTracks[trdx2];
+        posTransTkPtr = &theTransTracks[trdx1];
       } else {
-         continue;
+        continue;
       }
 
       // measure distance between tracks at their closest approach
@@ -159,31 +161,38 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
       // in order to keep posState and negState from pointing to destructed objects
       auto const& posImpact = posTransTkPtr->impactPointTSCP();
       auto const& negImpact = negTransTkPtr->impactPointTSCP();
-      if (!posImpact.isValid() || !negImpact.isValid()) continue;
-      FreeTrajectoryState const & posState = posImpact.theState();
-      FreeTrajectoryState const & negState = negImpact.theState();
+      if (!posImpact.isValid() || !negImpact.isValid())
+        continue;
+      FreeTrajectoryState const& posState = posImpact.theState();
+      FreeTrajectoryState const& negState = negImpact.theState();
       ClosestApproachInRPhi cApp;
       cApp.calculate(posState, negState);
-      if (!cApp.status()) continue;
+      if (!cApp.status())
+        continue;
       float dca = std::abs(cApp.distance());
-      if (dca > tkDCACut_) continue;
+      if (dca > tkDCACut_)
+        continue;
 
       // the POCA should at least be in the sensitive volume
       GlobalPoint cxPt = cApp.crossingPoint();
-      if (sqrt(cxPt.x()*cxPt.x() + cxPt.y()*cxPt.y()) > 120. || std::abs(cxPt.z()) > 300.) continue;
+      if (sqrt(cxPt.x() * cxPt.x() + cxPt.y() * cxPt.y()) > 120. || std::abs(cxPt.z()) > 300.)
+        continue;
 
       // the tracks should at least point in the same quadrant
-      TrajectoryStateClosestToPoint const & posTSCP = posTransTkPtr->trajectoryStateClosestToPoint(cxPt);
-      TrajectoryStateClosestToPoint const & negTSCP = negTransTkPtr->trajectoryStateClosestToPoint(cxPt);
-      if (!posTSCP.isValid() || !negTSCP.isValid()) continue;
-      if (posTSCP.momentum().dot(negTSCP.momentum())  < 0) continue;
-     
+      TrajectoryStateClosestToPoint const& posTSCP = posTransTkPtr->trajectoryStateClosestToPoint(cxPt);
+      TrajectoryStateClosestToPoint const& negTSCP = negTransTkPtr->trajectoryStateClosestToPoint(cxPt);
+      if (!posTSCP.isValid() || !negTSCP.isValid())
+        continue;
+      if (posTSCP.momentum().dot(negTSCP.momentum()) < 0)
+        continue;
+
       // calculate mPiPi
       double totalE = sqrt(posTSCP.momentum().mag2() + piMassSquared) + sqrt(negTSCP.momentum().mag2() + piMassSquared);
-      double totalESq = totalE*totalE;
+      double totalESq = totalE * totalE;
       double totalPSq = (posTSCP.momentum() + negTSCP.momentum()).mag2();
       double mass = sqrt(totalESq - totalPSq);
-      if (mass > mPiPiCut_) continue;
+      if (mass > mPiPiCut_)
+        continue;
 
       // Fill the vector of TransientTracks to send to KVF
       std::vector<reco::TransientTrack> transTracks;
@@ -194,94 +203,108 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
       // create the vertex fitter object and vertex the tracks
       TransientVertex theRecoVertex;
       if (vertexFitter_) {
-         KalmanVertexFitter theKalmanFitter(useRefTracks_ == 0 ? false : true);
-         theRecoVertex = theKalmanFitter.vertex(transTracks);
+        KalmanVertexFitter theKalmanFitter(useRefTracks_ == 0 ? false : true);
+        theRecoVertex = theKalmanFitter.vertex(transTracks);
       } else if (!vertexFitter_) {
-         useRefTracks_ = false;
-         AdaptiveVertexFitter theAdaptiveFitter;
-         theRecoVertex = theAdaptiveFitter.vertex(transTracks);
+        useRefTracks_ = false;
+        AdaptiveVertexFitter theAdaptiveFitter;
+        theRecoVertex = theAdaptiveFitter.vertex(transTracks);
       }
-      if (!theRecoVertex.isValid()) continue;
-     
+      if (!theRecoVertex.isValid())
+        continue;
+
       reco::Vertex theVtx = theRecoVertex;
-      if (theVtx.normalizedChi2() > vtxChi2Cut_) continue;
+      if (theVtx.normalizedChi2() > vtxChi2Cut_)
+        continue;
       GlobalPoint vtxPos(theVtx.x(), theVtx.y(), theVtx.z());
 
       // 2D decay significance
       SMatrixSym3D totalCov = theBeamSpot->rotatedCovariance3D() + theVtx.covariance();
-      if (useVertex_) totalCov = referenceVtx.covariance() + theVtx.covariance();
-      SVector3 distVecXY(vtxPos.x()-referencePos.x(), vtxPos.y()-referencePos.y(), 0.);
+      if (useVertex_)
+        totalCov = referenceVtx.covariance() + theVtx.covariance();
+      SVector3 distVecXY(vtxPos.x() - referencePos.x(), vtxPos.y() - referencePos.y(), 0.);
       double distMagXY = ROOT::Math::Mag(distVecXY);
       double sigmaDistMagXY = sqrt(ROOT::Math::Similarity(totalCov, distVecXY)) / distMagXY;
-      if (distMagXY/sigmaDistMagXY < vtxDecaySigXYCut_) continue;
+      if (distMagXY / sigmaDistMagXY < vtxDecaySigXYCut_)
+        continue;
 
       // 3D decay significance
       if (vtxDecaySigXYZCut_ > 0.) {
-         SVector3 distVecXYZ(vtxPos.x()-referencePos.x(), vtxPos.y()-referencePos.y(), vtxPos.z()-referencePos.z());
-         double distMagXYZ = ROOT::Math::Mag(distVecXYZ);
-         double sigmaDistMagXYZ = sqrt(ROOT::Math::Similarity(totalCov, distVecXYZ)) / distMagXYZ;
-         if (distMagXYZ/sigmaDistMagXYZ < vtxDecaySigXYZCut_) continue;
+        SVector3 distVecXYZ(
+            vtxPos.x() - referencePos.x(), vtxPos.y() - referencePos.y(), vtxPos.z() - referencePos.z());
+        double distMagXYZ = ROOT::Math::Mag(distVecXYZ);
+        double sigmaDistMagXYZ = sqrt(ROOT::Math::Similarity(totalCov, distVecXYZ)) / distMagXYZ;
+        if (distMagXYZ / sigmaDistMagXYZ < vtxDecaySigXYZCut_)
+          continue;
       }
 
       // make sure the vertex radius is within the inner track hit radius
       if (innerHitPosCut_ > 0. && positiveTrackRef->innerOk()) {
-         reco::Vertex::Point posTkHitPos = positiveTrackRef->innerPosition();
-         double posTkHitPosD2 =  (posTkHitPos.x()-referencePos.x())*(posTkHitPos.x()-referencePos.x()) +
-            (posTkHitPos.y()-referencePos.y())*(posTkHitPos.y()-referencePos.y());
-         if (sqrt(posTkHitPosD2) < (distMagXY - sigmaDistMagXY*innerHitPosCut_)) continue;
+        reco::Vertex::Point posTkHitPos = positiveTrackRef->innerPosition();
+        double posTkHitPosD2 = (posTkHitPos.x() - referencePos.x()) * (posTkHitPos.x() - referencePos.x()) +
+                               (posTkHitPos.y() - referencePos.y()) * (posTkHitPos.y() - referencePos.y());
+        if (sqrt(posTkHitPosD2) < (distMagXY - sigmaDistMagXY * innerHitPosCut_))
+          continue;
       }
       if (innerHitPosCut_ > 0. && negativeTrackRef->innerOk()) {
-         reco::Vertex::Point negTkHitPos = negativeTrackRef->innerPosition();
-         double negTkHitPosD2 = (negTkHitPos.x()-referencePos.x())*(negTkHitPos.x()-referencePos.x()) +
-            (negTkHitPos.y()-referencePos.y())*(negTkHitPos.y()-referencePos.y());
-         if (sqrt(negTkHitPosD2) < (distMagXY - sigmaDistMagXY*innerHitPosCut_)) continue;
+        reco::Vertex::Point negTkHitPos = negativeTrackRef->innerPosition();
+        double negTkHitPosD2 = (negTkHitPos.x() - referencePos.x()) * (negTkHitPos.x() - referencePos.x()) +
+                               (negTkHitPos.y() - referencePos.y()) * (negTkHitPos.y() - referencePos.y());
+        if (sqrt(negTkHitPosD2) < (distMagXY - sigmaDistMagXY * innerHitPosCut_))
+          continue;
       }
-      
+
       std::unique_ptr<TrajectoryStateClosestToPoint> trajPlus;
       std::unique_ptr<TrajectoryStateClosestToPoint> trajMins;
       std::vector<reco::TransientTrack> theRefTracks;
       if (theRecoVertex.hasRefittedTracks()) {
-         theRefTracks = theRecoVertex.refittedTracks();
+        theRefTracks = theRecoVertex.refittedTracks();
       }
 
       if (useRefTracks_ && theRefTracks.size() > 1) {
-         reco::TransientTrack* thePositiveRefTrack = nullptr;
-         reco::TransientTrack* theNegativeRefTrack = nullptr;
-         for (std::vector<reco::TransientTrack>::iterator iTrack = theRefTracks.begin(); iTrack != theRefTracks.end(); ++iTrack) {
-            if (iTrack->track().charge() > 0.) {
-               thePositiveRefTrack = &*iTrack;
-            } else if (iTrack->track().charge() < 0.) {
-               theNegativeRefTrack = &*iTrack;
-            }
-         }
-         if (thePositiveRefTrack == nullptr || theNegativeRefTrack == nullptr) continue;
-         trajPlus.reset(new TrajectoryStateClosestToPoint(thePositiveRefTrack->trajectoryStateClosestToPoint(vtxPos)));
-         trajMins.reset(new TrajectoryStateClosestToPoint(theNegativeRefTrack->trajectoryStateClosestToPoint(vtxPos)));
+        reco::TransientTrack* thePositiveRefTrack = nullptr;
+        reco::TransientTrack* theNegativeRefTrack = nullptr;
+        for (std::vector<reco::TransientTrack>::iterator iTrack = theRefTracks.begin(); iTrack != theRefTracks.end();
+             ++iTrack) {
+          if (iTrack->track().charge() > 0.) {
+            thePositiveRefTrack = &*iTrack;
+          } else if (iTrack->track().charge() < 0.) {
+            theNegativeRefTrack = &*iTrack;
+          }
+        }
+        if (thePositiveRefTrack == nullptr || theNegativeRefTrack == nullptr)
+          continue;
+        trajPlus.reset(new TrajectoryStateClosestToPoint(thePositiveRefTrack->trajectoryStateClosestToPoint(vtxPos)));
+        trajMins.reset(new TrajectoryStateClosestToPoint(theNegativeRefTrack->trajectoryStateClosestToPoint(vtxPos)));
       } else {
-         trajPlus.reset(new TrajectoryStateClosestToPoint(posTransTkPtr->trajectoryStateClosestToPoint(vtxPos)));
-         trajMins.reset(new TrajectoryStateClosestToPoint(negTransTkPtr->trajectoryStateClosestToPoint(vtxPos)));
+        trajPlus.reset(new TrajectoryStateClosestToPoint(posTransTkPtr->trajectoryStateClosestToPoint(vtxPos)));
+        trajMins.reset(new TrajectoryStateClosestToPoint(negTransTkPtr->trajectoryStateClosestToPoint(vtxPos)));
       }
 
-      if (trajPlus.get() == nullptr || trajMins.get() == nullptr || !trajPlus->isValid() || !trajMins->isValid()) continue;
+      if (trajPlus.get() == nullptr || trajMins.get() == nullptr || !trajPlus->isValid() || !trajMins->isValid())
+        continue;
 
       GlobalVector positiveP(trajPlus->momentum());
       GlobalVector negativeP(trajMins->momentum());
       GlobalVector totalP(positiveP + negativeP);
 
       // 2D pointing angle
-      double dx = theVtx.x()-referencePos.x();
-      double dy = theVtx.y()-referencePos.y();
+      double dx = theVtx.x() - referencePos.x();
+      double dy = theVtx.y() - referencePos.y();
       double px = totalP.x();
       double py = totalP.y();
-      double angleXY = (dx*px+dy*py)/(sqrt(dx*dx+dy*dy)*sqrt(px*px+py*py));
-      if (angleXY < cosThetaXYCut_) continue;
+      double angleXY = (dx * px + dy * py) / (sqrt(dx * dx + dy * dy) * sqrt(px * px + py * py));
+      if (angleXY < cosThetaXYCut_)
+        continue;
 
       // 3D pointing angle
       if (cosThetaXYZCut_ > -1.) {
-         double dz = theVtx.z()-referencePos.z();
-         double pz = totalP.z();
-         double angleXYZ = (dx*px+dy*py+dz*pz)/(sqrt(dx*dx+dy*dy+dz*dz)*sqrt(px*px+py*py+pz*pz));
-         if (angleXYZ < cosThetaXYZCut_) continue;
+        double dz = theVtx.z() - referencePos.z();
+        double pz = totalP.z();
+        double angleXYZ =
+            (dx * px + dy * py + dz * pz) / (sqrt(dx * dx + dy * dy + dz * dz) * sqrt(px * px + py * py + pz * pz));
+        if (angleXYZ < cosThetaXYZCut_)
+          continue;
       }
 
       // calculate total energy of V0 3 ways: assume it's a kShort, a Lambda, or a LambdaBar.
@@ -309,68 +332,66 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
       reco::VertexCompositeCandidate* theLambdaBar = nullptr;
 
       if (doKShorts_) {
-         theKshort = new reco::VertexCompositeCandidate(0, kShortP4, vtx, vtxCov, vtxChi2, vtxNdof);
+        theKshort = new reco::VertexCompositeCandidate(0, kShortP4, vtx, vtxCov, vtxChi2, vtxNdof);
       }
       if (doLambdas_) {
-         if (positiveP.mag2() > negativeP.mag2()) {
-            theLambda = new reco::VertexCompositeCandidate(0, lambdaP4, vtx, vtxCov, vtxChi2, vtxNdof);
-         } else {
-            theLambdaBar = new reco::VertexCompositeCandidate(0, lambdaBarP4, vtx, vtxCov, vtxChi2, vtxNdof);
-         }
+        if (positiveP.mag2() > negativeP.mag2()) {
+          theLambda = new reco::VertexCompositeCandidate(0, lambdaP4, vtx, vtxCov, vtxChi2, vtxNdof);
+        } else {
+          theLambdaBar = new reco::VertexCompositeCandidate(0, lambdaBarP4, vtx, vtxCov, vtxChi2, vtxNdof);
+        }
       }
 
       // Create daughter candidates for the VertexCompositeCandidates
       reco::RecoChargedCandidate thePiPlusCand(
-         1, reco::Particle::LorentzVector(positiveP.x(), positiveP.y(), positiveP.z(), piPlusE), vtx);
+          1, reco::Particle::LorentzVector(positiveP.x(), positiveP.y(), positiveP.z(), piPlusE), vtx);
       thePiPlusCand.setTrack(positiveTrackRef);
-      
+
       reco::RecoChargedCandidate thePiMinusCand(
-         -1, reco::Particle::LorentzVector(negativeP.x(), negativeP.y(), negativeP.z(), piMinusE), vtx);
+          -1, reco::Particle::LorentzVector(negativeP.x(), negativeP.y(), negativeP.z(), piMinusE), vtx);
       thePiMinusCand.setTrack(negativeTrackRef);
-      
+
       reco::RecoChargedCandidate theProtonCand(
-         1, reco::Particle::LorentzVector(positiveP.x(), positiveP.y(), positiveP.z(), protonE), vtx);
+          1, reco::Particle::LorentzVector(positiveP.x(), positiveP.y(), positiveP.z(), protonE), vtx);
       theProtonCand.setTrack(positiveTrackRef);
 
       reco::RecoChargedCandidate theAntiProtonCand(
-         -1, reco::Particle::LorentzVector(negativeP.x(), negativeP.y(), negativeP.z(), antiProtonE), vtx);
+          -1, reco::Particle::LorentzVector(negativeP.x(), negativeP.y(), negativeP.z(), antiProtonE), vtx);
       theAntiProtonCand.setTrack(negativeTrackRef);
 
       AddFourMomenta addp4;
       // Store the daughter Candidates in the VertexCompositeCandidates if they pass mass cuts
       if (doKShorts_) {
-         theKshort->addDaughter(thePiPlusCand);
-         theKshort->addDaughter(thePiMinusCand);
-         theKshort->setPdgId(310);
-         addp4.set(*theKshort);
-         if (theKshort->mass() < kShortMass + kShortMassCut_ && theKshort->mass() > kShortMass - kShortMassCut_) {
-            theKshorts.push_back(std::move(*theKshort));
-         }
+        theKshort->addDaughter(thePiPlusCand);
+        theKshort->addDaughter(thePiMinusCand);
+        theKshort->setPdgId(310);
+        addp4.set(*theKshort);
+        if (theKshort->mass() < kShortMass + kShortMassCut_ && theKshort->mass() > kShortMass - kShortMassCut_) {
+          theKshorts.push_back(std::move(*theKshort));
+        }
       }
       if (doLambdas_ && theLambda) {
-         theLambda->addDaughter(theProtonCand);
-         theLambda->addDaughter(thePiMinusCand);
-         theLambda->setPdgId(3122);
-         addp4.set( *theLambda );
-         if (theLambda->mass() < lambdaMass + lambdaMassCut_ && theLambda->mass() > lambdaMass - lambdaMassCut_) {
-            theLambdas.push_back(std::move(*theLambda));
-         }
+        theLambda->addDaughter(theProtonCand);
+        theLambda->addDaughter(thePiMinusCand);
+        theLambda->setPdgId(3122);
+        addp4.set(*theLambda);
+        if (theLambda->mass() < lambdaMass + lambdaMassCut_ && theLambda->mass() > lambdaMass - lambdaMassCut_) {
+          theLambdas.push_back(std::move(*theLambda));
+        }
       } else if (doLambdas_ && theLambdaBar) {
-         theLambdaBar->addDaughter(theAntiProtonCand);
-         theLambdaBar->addDaughter(thePiPlusCand);
-         theLambdaBar->setPdgId(-3122);
-         addp4.set(*theLambdaBar);
-         if (theLambdaBar->mass() < lambdaMass + lambdaMassCut_ && theLambdaBar->mass() > lambdaMass - lambdaMassCut_) {
-            theLambdas.push_back(std::move(*theLambdaBar));
-         }
+        theLambdaBar->addDaughter(theAntiProtonCand);
+        theLambdaBar->addDaughter(thePiPlusCand);
+        theLambdaBar->setPdgId(-3122);
+        addp4.set(*theLambdaBar);
+        if (theLambdaBar->mass() < lambdaMass + lambdaMassCut_ && theLambdaBar->mass() > lambdaMass - lambdaMassCut_) {
+          theLambdas.push_back(std::move(*theLambdaBar));
+        }
       }
 
       delete theKshort;
       delete theLambda;
       delete theLambdaBar;
       theKshort = theLambda = theLambdaBar = nullptr;
-
     }
   }
 }
-

--- a/RecoVertex/V0Producer/src/V0Fitter.h
+++ b/RecoVertex/V0Producer/src/V0Fitter.h
@@ -2,7 +2,7 @@
 //
 // Package:    V0Producer
 // Class:      V0Fitter
-// 
+//
 /**\class V0Fitter V0Fitter.h RecoVertex/V0Producer/interface/V0Fitter.h
 
  Description: <one line class summary>
@@ -38,44 +38,43 @@
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 
 class dso_hidden V0Fitter {
+public:
+  V0Fitter(const edm::ParameterSet& theParams, edm::ConsumesCollector&& iC);
+  void fitAll(const edm::Event& iEvent,
+              const edm::EventSetup& iSetup,
+              reco::VertexCompositeCandidateCollection& k,
+              reco::VertexCompositeCandidateCollection& l);
 
-   public:
-      V0Fitter(const edm::ParameterSet& theParams, edm::ConsumesCollector && iC);
-      void fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup,
-         reco::VertexCompositeCandidateCollection & k, reco::VertexCompositeCandidateCollection & l);
+private:
+  bool vertexFitter_;
+  bool useRefTracks_;
+  bool doKShorts_;
+  bool doLambdas_;
 
-   private:
+  // cuts on initial track selection
+  double tkChi2Cut_;
+  int tkNHitsCut_;
+  double tkPtCut_;
+  double tkIPSigXYCut_;
+  double tkIPSigZCut_;
+  // cuts on the vertex
+  double vtxChi2Cut_;
+  double vtxDecaySigXYCut_;
+  double vtxDecaySigXYZCut_;
+  // miscellaneous cuts
+  double tkDCACut_;
+  double mPiPiCut_;
+  double innerHitPosCut_;
+  double cosThetaXYCut_;
+  double cosThetaXYZCut_;
+  // cuts on the V0 candidate mass
+  double kShortMassCut_;
+  double lambdaMassCut_;
 
-      bool vertexFitter_;
-      bool useRefTracks_;
-      bool doKShorts_;
-      bool doLambdas_;
-
-      // cuts on initial track selection
-      double tkChi2Cut_;
-      int tkNHitsCut_;
-      double tkPtCut_;
-      double tkIPSigXYCut_;
-      double tkIPSigZCut_;
-      // cuts on the vertex
-      double vtxChi2Cut_;
-      double vtxDecaySigXYCut_;
-      double vtxDecaySigXYZCut_;
-      // miscellaneous cuts
-      double tkDCACut_;
-      double mPiPiCut_;
-      double innerHitPosCut_;
-      double cosThetaXYCut_;
-      double cosThetaXYZCut_;
-      // cuts on the V0 candidate mass
-      double kShortMassCut_;
-      double lambdaMassCut_;
-
-      edm::EDGetTokenT<reco::TrackCollection> token_tracks;
-      edm::EDGetTokenT<reco::BeamSpot> token_beamSpot;
-      bool useVertex_;
-      edm::EDGetTokenT<std::vector<reco::Vertex>> token_vertices;
+  edm::EDGetTokenT<reco::TrackCollection> token_tracks;
+  edm::EDGetTokenT<reco::BeamSpot> token_beamSpot;
+  bool useVertex_;
+  edm::EDGetTokenT<std::vector<reco::Vertex>> token_vertices;
 };
 
 #endif
-

--- a/RecoVertex/V0Producer/src/V0Producer.cc
+++ b/RecoVertex/V0Producer/src/V0Producer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    V0Producer
 // Class:      V0Producer
-// 
+//
 /**\class V0Producer V0Producer.cc MyProducers/V0Producer/src/V0Producer.cc
 
  Description: <one line class summary>
@@ -15,8 +15,6 @@
 //         Created:  Fri May 18 22:57:40 CEST 2007
 //
 //
-
-
 
 #include <memory>
 
@@ -44,20 +42,15 @@ public:
 private:
   void produce(edm::Event&, const edm::EventSetup&) override;
 
-  V0Fitter theVees;      
+  V0Fitter theVees;
 };
 
-
 // Constructor
-V0Producer::V0Producer(const edm::ParameterSet& iConfig) :
-  theVees(iConfig, consumesCollector())
-{
-  produces< reco::VertexCompositeCandidateCollection >("Kshort");
-  produces< reco::VertexCompositeCandidateCollection >("Lambda");
+V0Producer::V0Producer(const edm::ParameterSet& iConfig) : theVees(iConfig, consumesCollector()) {
+  produces<reco::VertexCompositeCandidateCollection>("Kshort");
+  produces<reco::VertexCompositeCandidateCollection>("Lambda");
   //produces< reco::VertexCompositeCandidateCollection >("LambdaBar");
-
 }
-
 
 //
 // Methods
@@ -65,25 +58,23 @@ V0Producer::V0Producer(const edm::ParameterSet& iConfig) :
 
 // Producer Method
 void V0Producer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-   using namespace edm;
+  using namespace edm;
 
+  // Create auto_ptr for each collection to be stored in the Event
+  auto kShortCandidates = std::make_unique<reco::VertexCompositeCandidateCollection>();
 
-   // Create auto_ptr for each collection to be stored in the Event
-   auto kShortCandidates = std::make_unique<reco::VertexCompositeCandidateCollection>();
-
-   auto lambdaCandidates = std::make_unique<reco::VertexCompositeCandidateCollection>();
+  auto lambdaCandidates = std::make_unique<reco::VertexCompositeCandidateCollection>();
 
   // invoke the fitter which reconstructs the vertices and fills,
-   //  collections of Kshorts, Lambda0s
-   theVees.fitAll(iEvent, iSetup, *kShortCandidates, *lambdaCandidates);
+  //  collections of Kshorts, Lambda0s
+  theVees.fitAll(iEvent, iSetup, *kShortCandidates, *lambdaCandidates);
 
-
-   // Write the collections to the Event
-   kShortCandidates->shrink_to_fit(); iEvent.put(std::move(kShortCandidates), std::string("Kshort") );
-   lambdaCandidates->shrink_to_fit(); iEvent.put(std::move(lambdaCandidates), std::string("Lambda") );
-
+  // Write the collections to the Event
+  kShortCandidates->shrink_to_fit();
+  iEvent.put(std::move(kShortCandidates), std::string("Kshort"));
+  lambdaCandidates->shrink_to_fit();
+  iEvent.put(std::move(lambdaCandidates), std::string("Lambda"));
 }
-
 
 //define this as a plug-in
 #include "FWCore/PluginManager/interface/ModuleDef.h"

--- a/RecoVertex/V0Producer/test/V0Analyzer.cc
+++ b/RecoVertex/V0Producer/test/V0Analyzer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    V0Analyzer
 // Class:      V0Analyzer
-// 
+//
 /**\class V0Analyzer V0Analyzer.cc RecoVertex/V0Producer/test/V0Analyzer.cc
 
  Description: <one line class summary>
@@ -17,7 +17,6 @@
 //
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateClosestToPoint.h"
-
 
 // system include files
 #include <memory>
@@ -74,16 +73,15 @@
 //
 
 class V0Analyzer : public edm::EDAnalyzer {
-   public:
-      explicit V0Analyzer(const edm::ParameterSet&);
-      ~V0Analyzer();
+public:
+  explicit V0Analyzer(const edm::ParameterSet&);
+  ~V0Analyzer();
 
-
-   private:
+private:
   //virtual void beginJob() ;
   virtual void beginJob();
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  virtual void endJob();
 
   std::string algoLabel;
   std::string recoAlgoLabel;
@@ -141,9 +139,7 @@ class V0Analyzer : public edm::EDAnalyzer {
 
   std::ofstream hitsOut;
 
-
-
-      // ----------member data ---------------------------
+  // ----------member data ---------------------------
 };
 
 //
@@ -159,47 +155,32 @@ const double piMassSq = 0.019479101;
 //
 // constructors and destructor
 //
-V0Analyzer::V0Analyzer(const edm::ParameterSet& iConfig):
-  algoLabel(iConfig.getUntrackedParameter("recoAlgorithm",
-					  std::string("ctfV0Prod"))),
-  recoAlgoLabel(iConfig.getUntrackedParameter("trackingAlgo",
-			       std::string("ctfWithMaterialTracks"))),
-  SimTkLabel(iConfig.getUntrackedParameter("moduleLabelTk",
-					 std::string("g4SimHits"))), 
-  SimVtxLabel(iConfig.getUntrackedParameter("moduleLabelVtx",
-					    std::string("g4SimHits"))),
-  HistoFileName(iConfig.getUntrackedParameter("histoFileName",
-			       std::string("vtxAnalyzerHistos.root"))), 
-  V0CollectionName(iConfig.getUntrackedParameter("v0CollectionName",
-						 std::string("Kshort"))),
-  cmsswVersion(iConfig.getUntrackedParameter("cmsswVersion",
-					     std::string("200"))) {
-
-   //now do what ever initialization is needed
+V0Analyzer::V0Analyzer(const edm::ParameterSet& iConfig)
+    : algoLabel(iConfig.getUntrackedParameter("recoAlgorithm", std::string("ctfV0Prod"))),
+      recoAlgoLabel(iConfig.getUntrackedParameter("trackingAlgo", std::string("ctfWithMaterialTracks"))),
+      SimTkLabel(iConfig.getUntrackedParameter("moduleLabelTk", std::string("g4SimHits"))),
+      SimVtxLabel(iConfig.getUntrackedParameter("moduleLabelVtx", std::string("g4SimHits"))),
+      HistoFileName(iConfig.getUntrackedParameter("histoFileName", std::string("vtxAnalyzerHistos.root"))),
+      V0CollectionName(iConfig.getUntrackedParameter("v0CollectionName", std::string("Kshort"))),
+      cmsswVersion(iConfig.getUntrackedParameter("cmsswVersion", std::string("200"))) {
+  //now do what ever initialization is needed
   //theHistoFile = 0;
 
   numDiff1 = numDiff2 = 0;
 }
 
-
-V0Analyzer::~V0Analyzer()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-
+V0Analyzer::~V0Analyzer() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
 }
-
 
 //
 // member functions
 //
 
-
 // ------------ method called once each job just before starting event loop  ------------
 //void V0Analyzer::beginJob() {
 void V0Analyzer::beginJob() {
-
   using std::string;
 
   edm::Service<TFileService> fs;
@@ -215,256 +196,155 @@ void V0Analyzer::beginJob() {
   string massHistoLabelLong(algo + string(" Invariant Mass of K^{0}_{s}"));
   string massHistoLabelShort(vernum + string("K0sInvarMass"));
 
-  string decRadHistoLabelLong(algo 
-			      + string(" Distance of Decay Vtx from z-axis"));
+  string decRadHistoLabelLong(algo + string(" Distance of Decay Vtx from z-axis"));
   string decRadHistoLabelShort(vernum + string("K0sDecayRad"));
 
-  string etaEffHistoLabelLong(algo + 
-			      string(" Reconstruction Efficiency vs. #eta"));
+  string etaEffHistoLabelLong(algo + string(" Reconstruction Efficiency vs. #eta"));
   string etaEffHistoLabelShort(vernum + string("EffVsEta"));
 
-  string rhoEffHistoLabelLong(algo +
-			      string(" Reconstruction Efficiency vs. #rho"));
+  string rhoEffHistoLabelLong(algo + string(" Reconstruction Efficiency vs. #rho"));
   string rhoEffHistoLabelShort(vernum + string("EffVsRho"));
 
-  string rhoEffHistoLabel2Long(algo +
-			      string(" 2-Reconstruction Efficiency vs. #rho"));
+  string rhoEffHistoLabel2Long(algo + string(" 2-Reconstruction Efficiency vs. #rho"));
   string rhoEffHistoLabel2Short(vernum + string("EffVsRho2"));
 
-  string rhoEffHistoLabel3Long(algo +
-			      string(" 3-Reconstruction Efficiency vs. #rho"));
+  string rhoEffHistoLabel3Long(algo + string(" 3-Reconstruction Efficiency vs. #rho"));
   string rhoEffHistoLabel3Short(vernum + string("EffVsRho3"));
 
-  string rhoEffHistoLabel4Long(algo +
-			      string(" 4-Reconstruction Efficiency vs. #rho"));
+  string rhoEffHistoLabel4Long(algo + string(" 4-Reconstruction Efficiency vs. #rho"));
   string rhoEffHistoLabel4Short(vernum + string("EffVsRho4"));
 
-  string simRhoHistoLabelLong(algo +
-			      string(" Simulated K^{0}_{s} #rho"));
+  string simRhoHistoLabelLong(algo + string(" Simulated K^{0}_{s} #rho"));
   string simRhoHistoLabelShort(vernum + string("SimRho"));
 
-  string simRHistoLabelLong(algo +
-			      string(" Simulated K^{0}_{s} R"));
+  string simRHistoLabelLong(algo + string(" Simulated K^{0}_{s} R"));
   string simRHistoLabelShort(vernum + string("SimR"));
 
-  string simEtaHistoLabelLong(algo +
-			      string(" Simulated K^{0}_{s} #eta"));
+  string simEtaHistoLabelLong(algo + string(" Simulated K^{0}_{s} #eta"));
   string simEtaHistoLabelShort(vernum + string("SimEta"));
 
-  string kShortPtHistoLabelLong(algo +
-				string(" K^{0}_{s} P_{t}"));
+  string kShortPtHistoLabelLong(algo + string(" K^{0}_{s} P_{t}"));
   string kShortPtHistoLabelShort(vernum + string("K0sPt"));
 
-  string impactParamHistoLabelLong(algo+
-				   string(" Impact parameter of reco tracks"));
+  string impactParamHistoLabelLong(algo + string(" Impact parameter of reco tracks"));
   string impactParamHistoLabelShort(vernum + string("d0"));
 
-  string impactParamHisto2LabelLong(algo+
-			    string(" distance from beam line to reco tracks"));
+  string impactParamHisto2LabelLong(algo + string(" distance from beam line to reco tracks"));
   string impactParamHisto2LabelShort(vernum + string("d0Radial"));
 
-  string numSimKshortsHistoLabelLong(algo+
-				     string(" number of simulated Kshorts"));
+  string numSimKshortsHistoLabelLong(algo + string(" number of simulated Kshorts"));
   string numSimKshortsHistoLabelShort(vernum + string("numSimK0s"));
 
-  string numRecoKshortsHistoLabelLong(algo+
-				   string(" number of reconstructed Kshorts")); 
+  string numRecoKshortsHistoLabelLong(algo + string(" number of reconstructed Kshorts"));
   string numRecoKshortsHistoLabelShort(vernum + string("numRecoK0s"));
 
-  string innermostHitDistanceHistoLabelLong(algo+
-		  string(" distance between innermost hits of track pairs"));
+  string innermostHitDistanceHistoLabelLong(algo + string(" distance between innermost hits of track pairs"));
   string innermostHitDistanceHistoLabelShort(vernum + string("hitDist"));
 
   //-----------------------------------------
 
-  string s1massHistoLabelLong(algo+
-			      string(" m_{#pi #pi}, all tracks"));
+  string s1massHistoLabelLong(algo + string(" m_{#pi #pi}, all tracks"));
   string s1massHistoLabelShort(vernum + string("mPiPiS1"));
 
-  string s2massHistoLabelLong(algo+
-		    string(" m_{#pi #pi}, R_{vtx} > 0.1, #chi^2 < 1"));
+  string s2massHistoLabelLong(algo + string(" m_{#pi #pi}, R_{vtx} > 0.1, #chi^2 < 1"));
   string s2massHistoLabelShort(vernum + string("mPiPiS2"));
 
-  string s3massHistoLabelLong(algo+
-			      string(" m_{#pi #pi}, most cuts implemented"));
+  string s3massHistoLabelLong(algo + string(" m_{#pi #pi}, most cuts implemented"));
   string s3massHistoLabelShort(vernum + string("mPiPiS3"));
 
-  string s4massHistoLabelLong(algo+
-			      string(" m_{#pi #pi}, all cuts implemented"));
+  string s4massHistoLabelLong(algo + string(" m_{#pi #pi}, all cuts implemented"));
   string s4massHistoLabelShort(vernum + string("mPiPiS4"));
 
-  string vertexChi2HistoLabelLong(algo+
-				  string(" vertex #chi^{2}"));
+  string vertexChi2HistoLabelLong(algo + string(" vertex #chi^{2}"));
   string vertexChi2HistoLabelShort(vernum + string("vtxChi2"));
 
-  string rVtxHistoLabelLong(algo+
-			    string(" r_{vtx} of V^{0} decay - radial"));
+  string rVtxHistoLabelLong(algo + string(" r_{vtx} of V^{0} decay - radial"));
   string rVtxHistoLabelShort(vernum + string("rVtxRadial"));
 
-  string vtxSigHistoLabelLong(algo+
-			      string(" V^{0} vertex significance - radial"));
+  string vtxSigHistoLabelLong(algo + string(" V^{0} vertex significance - radial"));
   string vtxSigHistoLabelShort(vernum + string("VtxRadialSig"));
 
-  string rVtxHistoLabel2Long(algo+
-			    string(" r_{vtx} of V^{0} decay after hit cut"));
+  string rVtxHistoLabel2Long(algo + string(" r_{vtx} of V^{0} decay after hit cut"));
   string rVtxHistoLabel2Short(vernum + string("rVtxAfterHitCut"));
 
-  string vtxSigHistoLabel2Long(algo+
-			      string(" V^{0} vertex significance"));
+  string vtxSigHistoLabel2Long(algo + string(" V^{0} vertex significance"));
   string vtxSigHistoLabel2Short(vernum + string("VtxSphericalSig"));
 
-  string rErrorHistoLabelLong(algo+
-			      string(" Error in r_{vtx}"));
+  string rErrorHistoLabelLong(algo + string(" Error in r_{vtx}"));
   string rErrorHistoLabelShort(vernum + string("#sigma R"));
 
-  string tkPtHistoLabelLong(algo+
-			    string(" Track P_{t}"));
+  string tkPtHistoLabelLong(algo + string(" Track P_{t}"));
   string tkPtHistoLabelShort(vernum + string("tkPt"));
 
-  string k0sPtHistoLabelLong(algo+
-			     string(" Sim K0s P_{t}"));
+  string k0sPtHistoLabelLong(algo + string(" Sim K0s P_{t}"));
   string k0sPtHistoLabelShort(vernum + string("k0sPt"));
 
-  string tkChi2HistoLabelLong(algo+
-			      string(" Track #Chi^{2}"));
+  string tkChi2HistoLabelLong(algo + string(" Track #Chi^{2}"));
   string tkChi2HistoLabelShort(vernum + string("tkChi2"));
 
-  string sqrtTkChi2HistoLabelLong(algo+
-			      string(" sqrt of Track #Chi^{2}"));
+  string sqrtTkChi2HistoLabelLong(algo + string(" sqrt of Track #Chi^{2}"));
   string sqrtTkChi2HistoLabelShort(vernum + string("sqrtTkChi2"));
 
-  string tkEtaHistoLabelLong(algo+
-			     string(" Track #eta"));
+  string tkEtaHistoLabelLong(algo + string(" Track #eta"));
   string tkEtaHistoLabelShort(vernum + string("tkEta"));
 
-  string kShortEtaHistoLabelLong(algo+
-				 string(" K^{0}_{s} #eta"));
+  string kShortEtaHistoLabelLong(algo + string(" K^{0}_{s} #eta"));
   string kShortEtaHistoLabelShort(vernum + string("k0sEta"));
 
-  string numHitsHistoLabelLong(algo+
-			       string(" Number Of Hits Per Track"));
+  string numHitsHistoLabelLong(algo + string(" Number Of Hits Per Track"));
   string numHitsHistoLabelShort(vernum + string("numHits"));
 
-  string simTkMpipiHistoLabelLong(algo+
-			       string(" Sim Track Pairs m_{#pi #pi}"));
+  string simTkMpipiHistoLabelLong(algo + string(" Sim Track Pairs m_{#pi #pi}"));
   string simTkMpipiHistoLabelShort(vernum + string("simTkMpipi"));
 
-  simTkMpipiHisto = fs->make<TH1D>(simTkMpipiHistoLabelShort.c_str(),
-			     simTkMpipiHistoLabelLong.c_str(),
-			     100, 0., 2.);
+  simTkMpipiHisto = fs->make<TH1D>(simTkMpipiHistoLabelShort.c_str(), simTkMpipiHistoLabelLong.c_str(), 100, 0., 2.);
 
+  step1massHisto = fs->make<TH1D>(s1massHistoLabelShort.c_str(), s1massHistoLabelLong.c_str(), 100, 0., 2.);
+  step2massHisto = fs->make<TH1D>(s2massHistoLabelShort.c_str(), s2massHistoLabelLong.c_str(), 100, 0., 2.);
+  step3massHisto = fs->make<TH1D>(s3massHistoLabelShort.c_str(), s3massHistoLabelLong.c_str(), 100, 0., 2.);
+  step4massHisto = fs->make<TH1D>(s4massHistoLabelShort.c_str(), s4massHistoLabelLong.c_str(), 100, 0., 2.);
 
+  vertexChi2Histo = fs->make<TH1D>(vertexChi2HistoLabelShort.c_str(), vertexChi2HistoLabelLong.c_str(), 100, 0., 20.);
+  rVtxHisto1 = fs->make<TH1D>(rVtxHistoLabelShort.c_str(), rVtxHistoLabelLong.c_str(), 100, 0., 50.);
+  vtxSigHisto1 = fs->make<TH1D>(vtxSigHistoLabelShort.c_str(), vtxSigHistoLabelLong.c_str(), 100, 0., 100.);
+  rVtxHisto2 = fs->make<TH1D>(rVtxHistoLabel2Short.c_str(), rVtxHistoLabel2Long.c_str(), 100, 0., 50.);
+  vtxSigHisto2 = fs->make<TH1D>(vtxSigHistoLabel2Short.c_str(), vtxSigHistoLabel2Long.c_str(), 100, 0., 100.);
+  k0sPtHisto = fs->make<TH1D>(k0sPtHistoLabelShort.c_str(), k0sPtHistoLabelLong.c_str(), 100, 0., 20.);
 
-  step1massHisto = fs->make<TH1D>(s1massHistoLabelShort.c_str(),
-			    s1massHistoLabelLong.c_str(),
-			    100, 0., 2.);
-  step2massHisto = fs->make<TH1D>(s2massHistoLabelShort.c_str(),
-			    s2massHistoLabelLong.c_str(),
-			    100, 0., 2.);
-  step3massHisto = fs->make<TH1D>(s3massHistoLabelShort.c_str(),
-			    s3massHistoLabelLong.c_str(),
-			    100, 0., 2.);
-  step4massHisto = fs->make<TH1D>(s4massHistoLabelShort.c_str(),
-			    s4massHistoLabelLong.c_str(),
-			    100, 0., 2.);
+  rErrorHisto = fs->make<TH1D>(rErrorHistoLabelShort.c_str(), rErrorHistoLabelLong.c_str(), 1000, 0., 1.);
+  tkPtHisto = fs->make<TH1D>(tkPtHistoLabelShort.c_str(), tkPtHistoLabelLong.c_str(), 100, 0., 20.);
+  tkChi2Histo = fs->make<TH1D>(tkChi2HistoLabelShort.c_str(), tkChi2HistoLabelLong.c_str(), 100, 0., 20.);
+  sqrtTkChi2Histo = fs->make<TH1D>(sqrtTkChi2HistoLabelShort.c_str(), sqrtTkChi2HistoLabelLong.c_str(), 100, 0., 20.);
+  tkEtaHisto = fs->make<TH1D>(tkEtaHistoLabelShort.c_str(), tkEtaHistoLabelLong.c_str(), 100, -2.5, 2.5);
+  kShortEtaHisto = fs->make<TH1D>(kShortEtaHistoLabelShort.c_str(), kShortEtaHistoLabelLong.c_str(), 100, -2.5, 2.5);
+  numHitsHisto = fs->make<TH1D>(numHitsHistoLabelShort.c_str(), numHitsHistoLabelLong.c_str(), 20, 0., 20.);
 
-  vertexChi2Histo = fs->make<TH1D>(vertexChi2HistoLabelShort.c_str(),
-			     vertexChi2HistoLabelLong.c_str(),
-			     100, 0., 20.);
-  rVtxHisto1 = fs->make<TH1D>(rVtxHistoLabelShort.c_str(),
-		       rVtxHistoLabelLong.c_str(),
-		       100, 0., 50.);
-  vtxSigHisto1 = fs->make<TH1D>(vtxSigHistoLabelShort.c_str(),
-			 vtxSigHistoLabelLong.c_str(),
-			 100, 0., 100.);
-  rVtxHisto2 = fs->make<TH1D>(rVtxHistoLabel2Short.c_str(),
-		       rVtxHistoLabel2Long.c_str(),
-		       100, 0., 50.);
-  vtxSigHisto2 = fs->make<TH1D>(vtxSigHistoLabel2Short.c_str(),
-			 vtxSigHistoLabel2Long.c_str(),
-			 100, 0., 100.);
-  k0sPtHisto = fs->make<TH1D>(k0sPtHistoLabelShort.c_str(),
-		       k0sPtHistoLabelLong.c_str(),
-		       100, 0., 20.);
-
-  rErrorHisto = fs->make<TH1D>(rErrorHistoLabelShort.c_str(),
-			 rErrorHistoLabelLong.c_str(),
-			 1000, 0., 1.);
-  tkPtHisto = fs->make<TH1D>(tkPtHistoLabelShort.c_str(),
-		       tkPtHistoLabelLong.c_str(),
-		       100, 0., 20.);
-  tkChi2Histo = fs->make<TH1D>(tkChi2HistoLabelShort.c_str(),
-			 tkChi2HistoLabelLong.c_str(),
-			 100, 0., 20.);
-  sqrtTkChi2Histo = fs->make<TH1D>(sqrtTkChi2HistoLabelShort.c_str(),
-			 sqrtTkChi2HistoLabelLong.c_str(),
-			 100, 0., 20.);
-  tkEtaHisto = fs->make<TH1D>(tkEtaHistoLabelShort.c_str(),
-			tkEtaHistoLabelLong.c_str(),
-			100, -2.5, 2.5);
-  kShortEtaHisto = fs->make<TH1D>(kShortEtaHistoLabelShort.c_str(),
-			    kShortEtaHistoLabelLong.c_str(),
-			    100, -2.5, 2.5);
-  numHitsHisto = fs->make<TH1D>(numHitsHistoLabelShort.c_str(),
-			  numHitsHistoLabelLong.c_str(),
-			  20, 0., 20.);
-
-
-  myKshortMassHisto = fs->make<TH1D>(massHistoLabelShort.c_str(), 
-			       massHistoLabelLong.c_str(),
-			       100, 0.3, 0.7);
-  myDecayRadiusHisto = fs->make<TH1D>(decRadHistoLabelShort.c_str(), 
-				decRadHistoLabelLong.c_str(),
-				100, 0., 40.);
-  myRefitKshortMassHisto = fs->make<TH1D>((refit+massHistoLabelShort).c_str(), 
-				    (refit+massHistoLabelLong).c_str(),
-				    100, 0.3, 0.7);
-  myRefitDecayRadiusHisto = fs->make<TH1D>((refit+decRadHistoLabelShort).c_str(), 
-				     (refit+decRadHistoLabelLong).c_str(),
-				     100, 0., 40.);
-  myNativeParticleMassHisto = fs->make<TH1D>((native+massHistoLabelShort).c_str(),
-				       (refit+massHistoLabelLong).c_str(),
-				       300, 0.3, 1.8);
-  myEtaEfficiencyHisto = fs->make<TH1D>(etaEffHistoLabelShort.c_str(),
-				  etaEffHistoLabelLong.c_str(),
-				  40, -2.5, 2.5);
-  mySimEtaHisto = fs->make<TH1D>(simEtaHistoLabelShort.c_str(),
-			   simEtaHistoLabelLong.c_str(),
-			   40, -2.5, 2.5);
-  myRhoEfficiencyHisto = fs->make<TH1D>(rhoEffHistoLabelShort.c_str(),
-				  rhoEffHistoLabelLong.c_str(),
-				  60, 0., 60.);
-  myRhoEfficiencyHisto2 = fs->make<TH1D>(rhoEffHistoLabel2Short.c_str(),
-				  rhoEffHistoLabel2Long.c_str(),
-				  60, 0., 60.);
-  myRhoEfficiencyHisto3 = fs->make<TH1D>(rhoEffHistoLabel3Short.c_str(),
-				  rhoEffHistoLabel3Long.c_str(),
-				  60, 0., 60.);
-  myRhoEfficiencyHisto4 = fs->make<TH1D>(rhoEffHistoLabel4Short.c_str(),
-				  rhoEffHistoLabel4Long.c_str(),
-				  60, 0., 60.);
-  mySimRhoHisto = fs->make<TH1D>(simRhoHistoLabelShort.c_str(),
-			   simRhoHistoLabelLong.c_str(),
-			   60, 0., 60.);
-  myKshortPtHisto = fs->make<TH1D>(kShortPtHistoLabelShort.c_str(),
-			    kShortPtHistoLabelLong.c_str(),
-			    100, 0., 100.);
-  myImpactParameterHisto = fs->make<TH1D>(impactParamHistoLabelShort.c_str(),
-				    impactParamHistoLabelLong.c_str(),
-				    100, 0., 10.);
-  myImpactParameterHisto2 = fs->make<TH1D>(impactParamHisto2LabelShort.c_str(),
-				    impactParamHisto2LabelLong.c_str(),
-				    100, 0., 10.);
-  myNumSimKshortsHisto = fs->make<TH1D>(numSimKshortsHistoLabelShort.c_str(),
-				  numSimKshortsHistoLabelLong.c_str(),
-				  100, 0., 100.);
-  myNumRecoKshortsHisto = fs->make<TH1D>(numRecoKshortsHistoLabelShort.c_str(),
-				   numRecoKshortsHistoLabelLong.c_str(),
-				   100, 0., 100.);
-  myInnermostHitDistanceHisto = 
-    fs->make<TH1D>(innermostHitDistanceHistoLabelShort.c_str(),
-	     innermostHitDistanceHistoLabelLong.c_str(),
-	     100, 0., 10.);
+  myKshortMassHisto = fs->make<TH1D>(massHistoLabelShort.c_str(), massHistoLabelLong.c_str(), 100, 0.3, 0.7);
+  myDecayRadiusHisto = fs->make<TH1D>(decRadHistoLabelShort.c_str(), decRadHistoLabelLong.c_str(), 100, 0., 40.);
+  myRefitKshortMassHisto =
+      fs->make<TH1D>((refit + massHistoLabelShort).c_str(), (refit + massHistoLabelLong).c_str(), 100, 0.3, 0.7);
+  myRefitDecayRadiusHisto =
+      fs->make<TH1D>((refit + decRadHistoLabelShort).c_str(), (refit + decRadHistoLabelLong).c_str(), 100, 0., 40.);
+  myNativeParticleMassHisto =
+      fs->make<TH1D>((native + massHistoLabelShort).c_str(), (refit + massHistoLabelLong).c_str(), 300, 0.3, 1.8);
+  myEtaEfficiencyHisto = fs->make<TH1D>(etaEffHistoLabelShort.c_str(), etaEffHistoLabelLong.c_str(), 40, -2.5, 2.5);
+  mySimEtaHisto = fs->make<TH1D>(simEtaHistoLabelShort.c_str(), simEtaHistoLabelLong.c_str(), 40, -2.5, 2.5);
+  myRhoEfficiencyHisto = fs->make<TH1D>(rhoEffHistoLabelShort.c_str(), rhoEffHistoLabelLong.c_str(), 60, 0., 60.);
+  myRhoEfficiencyHisto2 = fs->make<TH1D>(rhoEffHistoLabel2Short.c_str(), rhoEffHistoLabel2Long.c_str(), 60, 0., 60.);
+  myRhoEfficiencyHisto3 = fs->make<TH1D>(rhoEffHistoLabel3Short.c_str(), rhoEffHistoLabel3Long.c_str(), 60, 0., 60.);
+  myRhoEfficiencyHisto4 = fs->make<TH1D>(rhoEffHistoLabel4Short.c_str(), rhoEffHistoLabel4Long.c_str(), 60, 0., 60.);
+  mySimRhoHisto = fs->make<TH1D>(simRhoHistoLabelShort.c_str(), simRhoHistoLabelLong.c_str(), 60, 0., 60.);
+  myKshortPtHisto = fs->make<TH1D>(kShortPtHistoLabelShort.c_str(), kShortPtHistoLabelLong.c_str(), 100, 0., 100.);
+  myImpactParameterHisto =
+      fs->make<TH1D>(impactParamHistoLabelShort.c_str(), impactParamHistoLabelLong.c_str(), 100, 0., 10.);
+  myImpactParameterHisto2 =
+      fs->make<TH1D>(impactParamHisto2LabelShort.c_str(), impactParamHisto2LabelLong.c_str(), 100, 0., 10.);
+  myNumSimKshortsHisto =
+      fs->make<TH1D>(numSimKshortsHistoLabelShort.c_str(), numSimKshortsHistoLabelLong.c_str(), 100, 0., 100.);
+  myNumRecoKshortsHisto =
+      fs->make<TH1D>(numRecoKshortsHistoLabelShort.c_str(), numRecoKshortsHistoLabelLong.c_str(), 100, 0., 100.);
+  myInnermostHitDistanceHisto = fs->make<TH1D>(
+      innermostHitDistanceHistoLabelShort.c_str(), innermostHitDistanceHistoLabelLong.c_str(), 100, 0., 10.);
 
   myEtaEfficiencyHisto->Sumw2();
   mySimEtaHisto->Sumw2();
@@ -475,17 +355,15 @@ void V0Analyzer::beginJob() {
   mySimRhoHisto->Sumw2();
 
   hitsOut.open("hitsOut.txt");
-
 }
 
 // ------------ method called to for each event  ------------
-void V0Analyzer::analyze(const edm::Event& iEvent, 
-			     const edm::EventSetup& iSetup) {
+void V0Analyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   //std::cout << std::endl << "@@@In module..." << std::endl;
   //std::cout << "Creating HANDLES..." << std::endl;
   using namespace edm;
   //Handle<reco::VertexCollection> theVtxHandle;
-  Handle< std::vector<reco::Vertex> > theVtxHandle;
+  Handle<std::vector<reco::Vertex> > theVtxHandle;
   //Handle< std::vector<reco::V0Candidate> > theCandHand;
   Handle<reco::VertexCompositeCandidateCollection> theCandHand;
   Handle<SimTrackContainer> SimTk;
@@ -499,7 +377,7 @@ void V0Analyzer::analyze(const edm::Event& iEvent,
   iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeomHandle);
 
   //const TrackerGeometry* trackerGeom = trackerGeomHandle.product();
-  
+
   //std::cout << "Getting by label..." << std::endl;
   iEvent.getByLabel(algoLabel, V0CollectionName, theCandHand);
   iEvent.getByLabel(SimTkLabel, SimTk);
@@ -512,27 +390,23 @@ void V0Analyzer::analyze(const edm::Event& iEvent,
   std::vector<SimTrack> theSimTracks;
   //std::vector<reco::V0Candidate> theKshorts;
   std::vector<reco::VertexCompositeCandidate> theKshorts;
-  theRecoTracks.insert( theRecoTracks.end(), RecoTk->begin(), RecoTk->end() );
-  theSimVerts.insert( theSimVerts.end(), SimVtx->begin(), SimVtx->end() );
-  theSimTracks.insert( theSimTracks.end(), SimTk->begin(), SimTk->end() );
-  theKshorts.insert( theKshorts.end(), theCandHand->begin(),
-		     theCandHand->end() );
-  std::cout << theRecoTracks.size() << " "
-	    << theSimVerts.size() << " "
-	    << theSimTracks.size() << " "
-	    << theKshorts.size() << std::endl;
+  theRecoTracks.insert(theRecoTracks.end(), RecoTk->begin(), RecoTk->end());
+  theSimVerts.insert(theSimVerts.end(), SimVtx->begin(), SimVtx->end());
+  theSimTracks.insert(theSimTracks.end(), SimTk->begin(), SimTk->end());
+  theKshorts.insert(theKshorts.end(), theCandHand->begin(), theCandHand->end());
+  std::cout << theRecoTracks.size() << " " << theSimVerts.size() << " " << theSimTracks.size() << " "
+            << theKshorts.size() << std::endl;
 
   // Done getting and filling
 
   // Count how many simulated K0s we have
   double numSimKshorts = 0.;
   double simRad = 0.;
-  for(unsigned int ndx1 = 0; ndx1 < theSimTracks.size(); ndx1++) {
-    if(theSimTracks[ndx1].type() == 310) {
+  for (unsigned int ndx1 = 0; ndx1 < theSimTracks.size(); ndx1++) {
+    if (theSimTracks[ndx1].type() == 310) {
       math::XYZTLorentzVectorD k0sP(theSimTracks[ndx1].momentum());
-      k0sPtHisto->Fill( sqrt(k0sP.Perp2()), 1. );
-      simRad = 
-	sqrt(theSimVerts[(theSimTracks[ndx1].vertIndex() + 1)].position().perp2());
+      k0sPtHisto->Fill(sqrt(k0sP.Perp2()), 1.);
+      simRad = sqrt(theSimVerts[(theSimTracks[ndx1].vertIndex() + 1)].position().perp2());
       numSimKshorts += 1.;
     }
   }
@@ -543,39 +417,32 @@ void V0Analyzer::analyze(const edm::Event& iEvent,
   // << std::endl;
 
   // loop over sim tracks and calculate m_pipi, and histogram it
-  for(unsigned int stkidx1 = 0; stkidx1 < theSimTracks.size(); stkidx1++) {
-    for(unsigned int stkidx2 = stkidx1 + 1; stkidx2 < theSimTracks.size();
-	stkidx2++) {
-      SimTrack *thePosSimTk = 0;
-      SimTrack *theNegSimTk = 0;
-      if( theSimTracks[stkidx1].charge() > 0. 
-	  && theSimTracks[stkidx2].charge() < 0. ) {
-	thePosSimTk = &theSimTracks[stkidx1];
-	theNegSimTk = &theSimTracks[stkidx2];
-      }
-      else if( theSimTracks[stkidx1].charge() < 0.
-	       && theSimTracks[stkidx2].charge() > 0. ) {
-	theNegSimTk = &theSimTracks[stkidx1];
-	thePosSimTk = &theSimTracks[stkidx2];
+  for (unsigned int stkidx1 = 0; stkidx1 < theSimTracks.size(); stkidx1++) {
+    for (unsigned int stkidx2 = stkidx1 + 1; stkidx2 < theSimTracks.size(); stkidx2++) {
+      SimTrack* thePosSimTk = 0;
+      SimTrack* theNegSimTk = 0;
+      if (theSimTracks[stkidx1].charge() > 0. && theSimTracks[stkidx2].charge() < 0.) {
+        thePosSimTk = &theSimTracks[stkidx1];
+        theNegSimTk = &theSimTracks[stkidx2];
+      } else if (theSimTracks[stkidx1].charge() < 0. && theSimTracks[stkidx2].charge() > 0.) {
+        theNegSimTk = &theSimTracks[stkidx1];
+        thePosSimTk = &theSimTracks[stkidx2];
       }
 
-      if(thePosSimTk && theNegSimTk) {
-	double posP2 = 
-	  thePosSimTk->momentum().px()*thePosSimTk->momentum().px()
-	  + thePosSimTk->momentum().py()*thePosSimTk->momentum().py()
-	  + thePosSimTk->momentum().pz()*thePosSimTk->momentum().pz();
-	double negP2 =
-	  theNegSimTk->momentum().px()*theNegSimTk->momentum().px()
-	  + theNegSimTk->momentum().py()*theNegSimTk->momentum().py()
-	  + theNegSimTk->momentum().pz()*theNegSimTk->momentum().pz();
-	double posE = sqrt(posP2 + piMassSq);
-	double negE = sqrt(negP2 + piMassSq);
-	double k0sE = posE + negE;
-	math::XYZTLorentzVectorD k0sMomentum(thePosSimTk->momentum()
-                                             +theNegSimTk->momentum());
-	k0sMomentum.SetE(k0sE);
-	double k0sInvMass = k0sMomentum.M();
-	simTkMpipiHisto->Fill(k0sInvMass, 1.);
+      if (thePosSimTk && theNegSimTk) {
+        double posP2 = thePosSimTk->momentum().px() * thePosSimTk->momentum().px() +
+                       thePosSimTk->momentum().py() * thePosSimTk->momentum().py() +
+                       thePosSimTk->momentum().pz() * thePosSimTk->momentum().pz();
+        double negP2 = theNegSimTk->momentum().px() * theNegSimTk->momentum().px() +
+                       theNegSimTk->momentum().py() * theNegSimTk->momentum().py() +
+                       theNegSimTk->momentum().pz() * theNegSimTk->momentum().pz();
+        double posE = sqrt(posP2 + piMassSq);
+        double negE = sqrt(negP2 + piMassSq);
+        double k0sE = posE + negE;
+        math::XYZTLorentzVectorD k0sMomentum(thePosSimTk->momentum() + theNegSimTk->momentum());
+        k0sMomentum.SetE(k0sE);
+        double k0sInvMass = k0sMomentum.M();
+        simTkMpipiHisto->Fill(k0sInvMass, 1.);
       }
       thePosSimTk = theNegSimTk = 0;
     }
@@ -583,57 +450,48 @@ void V0Analyzer::analyze(const edm::Event& iEvent,
 
   // Calculate sim k0s parameters from the sim decay vertex
   //double simRad = sqrt(theSimVerts[1].position().perp2());
-  double simCosTheta = theSimVerts[1].position().z()
-    / theSimVerts[1].position().mag();
-  double simEta = -log( tan( acos( simCosTheta)/2. ) );
+  double simCosTheta = theSimVerts[1].position().z() / theSimVerts[1].position().mag();
+  double simEta = -log(tan(acos(simCosTheta) / 2.));
 
   mySimRhoHisto->Fill(simRad, 1.);
   mySimEtaHisto->Fill(simEta, 1.);
 
-  
   //bool hasKshort = false;
   //bool hasLambda = false;
   //bool hasLambdaBar = false;
   //std::cout << theKshorts.size() << std::endl;
 
-  if( V0CollectionName == std::string("Kshort") ) {
-    myNumRecoKshortsHisto->Fill( (double) theKshorts.size(), 1. );
+  if (V0CollectionName == std::string("Kshort")) {
+    myNumRecoKshortsHisto->Fill((double)theKshorts.size(), 1.);
   }
 
   // Histogram the invariant mass (retrieved from the V0Candidate)
-  for(unsigned int ksndx_ = 0; ksndx_ < theKshorts.size(); ksndx_++) {
-    myNativeParticleMassHisto->Fill( theKshorts[ksndx_].mass() );
+  for (unsigned int ksndx_ = 0; ksndx_ < theKshorts.size(); ksndx_++) {
+    myNativeParticleMassHisto->Fill(theKshorts[ksndx_].mass());
   }
 
-
-  for(unsigned int ksndx = 0; ksndx < theKshorts.size(); ksndx++) {
+  for (unsigned int ksndx = 0; ksndx < theKshorts.size(); ksndx++) {
     std::vector<reco::RecoChargedCandidate> v0daughters;
     std::vector<reco::TrackRef> theDaughterTracks;
 
     for (unsigned int i = 0; i < theKshorts[ksndx].numberOfDaughters(); i++) {
-      v0daughters.push_back( *(dynamic_cast<reco::RecoChargedCandidate *> 
-			       (theKshorts[ksndx].daughter(i))) );
+      v0daughters.push_back(*(dynamic_cast<reco::RecoChargedCandidate*>(theKshorts[ksndx].daughter(i))));
     }
 
-    for(unsigned int j = 0; j < v0daughters.size(); j++) {
+    for (unsigned int j = 0; j < v0daughters.size(); j++) {
       theDaughterTracks.push_back(v0daughters[j].track());
     }
 
+    reco::TrackBase::Point beamSpot(0, 0, 0);
 
-    reco::TrackBase::Point beamSpot(0,0,0);
-
-    for(unsigned int k = 0; k < theDaughterTracks.size(); k++) {
-      myImpactParameterHisto->Fill( sqrt( theDaughterTracks[k]->dxy( beamSpot )
-				       * theDaughterTracks[k]->dxy( beamSpot )
-				       + theDaughterTracks[k]->dsz( beamSpot )
-				       * theDaughterTracks[k]->dsz( beamSpot )),
-				    1.);
+    for (unsigned int k = 0; k < theDaughterTracks.size(); k++) {
+      myImpactParameterHisto->Fill(sqrt(theDaughterTracks[k]->dxy(beamSpot) * theDaughterTracks[k]->dxy(beamSpot) +
+                                        theDaughterTracks[k]->dsz(beamSpot) * theDaughterTracks[k]->dsz(beamSpot)),
+                                   1.);
     }
-    
+
     //reco::Vertex k0s = theKshorts[ksndx].vertex();
-    reco::Particle::Point k0s(theKshorts[ksndx].vx(),
-			      theKshorts[ksndx].vy(),
-			      theKshorts[ksndx].vz());
+    reco::Particle::Point k0s(theKshorts[ksndx].vx(), theKshorts[ksndx].vy(), theKshorts[ksndx].vz());
 
     /*myKshortPtHisto->Fill(sqrt(theKshorts[ksndx].px() *
 			       theKshorts[ksndx].px() +
@@ -660,13 +518,13 @@ void V0Analyzer::analyze(const edm::Event& iEvent,
 
     //std::cout << "tracksSize()=" << k0s.tracksSize() << std::endl;
     //std::cout << "hasRefittedTracks()="<< k0s.hasRefittedTracks() << std::endl;
-    double decayRad = sqrt(k0s.x()*k0s.x() + k0s.y()*k0s.y());
+    double decayRad = sqrt(k0s.x() * k0s.x() + k0s.y() * k0s.y());
     myDecayRadiusHisto->Fill(decayRad);
-    
+
     GlobalPoint vtxPos(k0s.x(), k0s.y(), k0s.z());
     double recoRad = vtxPos.perp();
     double recoCosTheta = vtxPos.z() / vtxPos.mag();
-    double recoEta = -log( tan( acos( recoCosTheta )/2. ) );
+    double recoEta = -log(tan(acos(recoCosTheta) / 2.));
 
     double x_ = k0s.x();
     double y_ = k0s.y();
@@ -677,23 +535,20 @@ void V0Analyzer::analyze(const edm::Event& iEvent,
     //double sig01 = k0s.covariance(0,1);
     //double sig02 = k0s.covariance(0,2);
     //double sig12 = k0s.covariance(1,2);
-    double sig00 = theKshorts[ksndx].vertexCovariance(0,0);
-    double sig11 = theKshorts[ksndx].vertexCovariance(1,1);
-    double sig22 = theKshorts[ksndx].vertexCovariance(2,2);
-    double sig01 = theKshorts[ksndx].vertexCovariance(0,1);
-    double sig02 = theKshorts[ksndx].vertexCovariance(0,2);
-    double sig12 = theKshorts[ksndx].vertexCovariance(1,2);
+    double sig00 = theKshorts[ksndx].vertexCovariance(0, 0);
+    double sig11 = theKshorts[ksndx].vertexCovariance(1, 1);
+    double sig22 = theKshorts[ksndx].vertexCovariance(2, 2);
+    double sig01 = theKshorts[ksndx].vertexCovariance(0, 1);
+    double sig02 = theKshorts[ksndx].vertexCovariance(0, 2);
+    double sig12 = theKshorts[ksndx].vertexCovariance(1, 2);
 
     double vtxRSph = vtxPos.mag();
     double vtxR = vtxPos.perp();
     double vtxChi2 = theKshorts[ksndx].vertexChi2();
-    double vtxErrorSph =
-      sqrt( sig00*(x_*x_) + sig11*(y_*y_) + sig22*(z_*z_)
-	    + 2*(sig01*(x_*y_) + sig02*(x_*z_) + sig12*(y_*z_)) ) 
-      / vtxRSph;
-    double vtxError =
-      sqrt( sig00*(x_*x_) + sig11*(y_*y_)
-	    + 2*sig01*(x_*y_) ) / vtxR;
+    double vtxErrorSph = sqrt(sig00 * (x_ * x_) + sig11 * (y_ * y_) + sig22 * (z_ * z_) +
+                              2 * (sig01 * (x_ * y_) + sig02 * (x_ * z_) + sig12 * (y_ * z_))) /
+                         vtxRSph;
+    double vtxError = sqrt(sig00 * (x_ * x_) + sig11 * (y_ * y_) + 2 * sig01 * (x_ * y_)) / vtxR;
     double vtxSigSph = vtxRSph / vtxErrorSph;
     double vtxSig = vtxR / vtxError;
 
@@ -701,33 +556,27 @@ void V0Analyzer::analyze(const edm::Event& iEvent,
 
     using namespace reco;
     std::vector<reco::TrackRef> theVtxTrax;
-    for( unsigned int i = 0; i < v0daughters.size(); i++ ) {
-      theVtxTrax.push_back( v0daughters[i].track() );
+    for (unsigned int i = 0; i < v0daughters.size(); i++) {
+      theVtxTrax.push_back(v0daughters[i].track());
     }
 
     bool hitsOkay2 = true;
     bool tkChi2Cut = true;
-    if( theVtxTrax.size() == 2 ) {
-
-      if(theVtxTrax[0]->normalizedChi2() > 5. ||
-	 theVtxTrax[1]->normalizedChi2() > 5.) {
-	tkChi2Cut = false;
+    if (theVtxTrax.size() == 2) {
+      if (theVtxTrax[0]->normalizedChi2() > 5. || theVtxTrax[1]->normalizedChi2() > 5.) {
+        tkChi2Cut = false;
       }
 
-      GlobalPoint tk1hitPos(theVtxTrax[0]->innerPosition().x(),
-			    theVtxTrax[0]->innerPosition().y(),
-			    theVtxTrax[0]->innerPosition().z());
-      GlobalPoint tk2hitPos(theVtxTrax[1]->innerPosition().x(),
-			    theVtxTrax[1]->innerPosition().y(),
-			    theVtxTrax[1]->innerPosition().z());
+      GlobalPoint tk1hitPos(
+          theVtxTrax[0]->innerPosition().x(), theVtxTrax[0]->innerPosition().y(), theVtxTrax[0]->innerPosition().z());
+      GlobalPoint tk2hitPos(
+          theVtxTrax[1]->innerPosition().x(), theVtxTrax[1]->innerPosition().y(), theVtxTrax[1]->innerPosition().z());
       //if( tk1hitPos.perp() < (vtxR - 5.*vtxError)
-      if( tk1hitPos.mag() < (vtxRSph - 4.*vtxErrorSph)
-	  && theVtxTrax[0]->innerOk() ) {
-	hitsOkay2 = false;
+      if (tk1hitPos.mag() < (vtxRSph - 4. * vtxErrorSph) && theVtxTrax[0]->innerOk()) {
+        hitsOkay2 = false;
       }
-      if( tk2hitPos.mag() < (vtxRSph - 4.*vtxErrorSph) 
-	  && theVtxTrax[1]->innerOk() ) {
-	hitsOkay2 = false;
+      if (tk2hitPos.mag() < (vtxRSph - 4. * vtxErrorSph) && theVtxTrax[1]->innerOk()) {
+        hitsOkay2 = false;
       }
     }
 
@@ -736,11 +585,11 @@ void V0Analyzer::analyze(const edm::Event& iEvent,
     //std::cout << "theVtxTrax.size = " << theVtxTrax.size() << std::endl;
 
     //hitsOut << "theVtxTrax.size = " << theVtxTrax.size() << std::endl;
-    if( theVtxTrax.size() == 2 ) {
-      if( theVtxTrax[0]->recHitsSize() && theVtxTrax[1]->recHitsSize() ) {
-	double nHits1 = (double) theVtxTrax[0]->numberOfValidHits();
-	double nHits2 = (double) theVtxTrax[1]->numberOfValidHits();
-	/*
+    if (theVtxTrax.size() == 2) {
+      if (theVtxTrax[0]->recHitsSize() && theVtxTrax[1]->recHitsSize()) {
+        double nHits1 = (double)theVtxTrax[0]->numberOfValidHits();
+        double nHits2 = (double)theVtxTrax[1]->numberOfValidHits();
+        /*
 
 	double nHits1 = 0.;
 	double nHits2 = 0.;
@@ -782,29 +631,30 @@ void V0Analyzer::analyze(const edm::Event& iEvent,
 	    }
 	  }
 	  }*/
-	numHitsHisto->Fill(nHits1, 1.);
-	numHitsHisto->Fill(nHits2, 1.);
-	if(nHits1 < 8. || nHits2 < 8.) {
-	  nHitsCut = false;
-	}
+        numHitsHisto->Fill(nHits1, 1.);
+        numHitsHisto->Fill(nHits2, 1.);
+        if (nHits1 < 8. || nHits2 < 8.) {
+          nHitsCut = false;
+        }
       }
     }
-  
+
     //std::cout << "hitsOkay=" << hitsOkay << ", hitsOkay2=" << hitsOkay2
     //<< std::endl;
-    hitsOut << "hitsOkay=" << hitsOkay << ", hitsOkay2=" << hitsOkay2
-	    << std::endl;
-    if(!hitsOkay) ++numDiff1;
-    if(!hitsOkay2) ++numDiff2;
-    for(unsigned int ndx3 = 0; ndx3 < theRecoTracks.size(); ndx3++) {
+    hitsOut << "hitsOkay=" << hitsOkay << ", hitsOkay2=" << hitsOkay2 << std::endl;
+    if (!hitsOkay)
+      ++numDiff1;
+    if (!hitsOkay2)
+      ++numDiff2;
+    for (unsigned int ndx3 = 0; ndx3 < theRecoTracks.size(); ndx3++) {
       tkEtaHisto->Fill(theRecoTracks[ndx3].eta(), 1.);
       //tkChi2Histo->Fill(theRecoTracks[ndx3].normalizedChi2(), 1.);
     }
 
-    if(nHitsCut) {
-      for(unsigned int ndx3_1 = 0; ndx3_1 < theRecoTracks.size(); ndx3_1++) {
-	//tkEtaHisto->Fill(theRecoTracks[ndx3_1].eta(), 1.);
-	tkChi2Histo->Fill(theRecoTracks[ndx3_1].normalizedChi2(), 1.);
+    if (nHitsCut) {
+      for (unsigned int ndx3_1 = 0; ndx3_1 < theRecoTracks.size(); ndx3_1++) {
+        //tkEtaHisto->Fill(theRecoTracks[ndx3_1].eta(), 1.);
+        tkChi2Histo->Fill(theRecoTracks[ndx3_1].normalizedChi2(), 1.);
       }
     }
 
@@ -812,48 +662,47 @@ void V0Analyzer::analyze(const edm::Event& iEvent,
 
     //step1massHisto->Fill(theKshorts[ksndx].mass(), 1.);
     //if(hitsOkay2) {
-    if(vtxChi2 < 7. && nHitsCut && tkChi2Cut) {
+    if (vtxChi2 < 7. && nHitsCut && tkChi2Cut) {
       step1massHisto->Fill(theKshorts[ksndx].mass(), 1.);
       myRhoEfficiencyHisto->Fill(recoRad, 1.);
       rVtxHisto1->Fill(vtxR, 1.);
       //if(vtxR > 0.1) {
       //if(vtxR > 1.) {
-	step2massHisto->Fill(theKshorts[ksndx].mass(), 1.);
-	myRhoEfficiencyHisto2->Fill(recoRad, 1.);
-	vtxSigHisto1->Fill(vtxSig, 1.);
-	if(vtxSig > 20.) {
-	  step3massHisto->Fill(theKshorts[ksndx].mass(), 1.);
-	  myRhoEfficiencyHisto3->Fill(recoRad, 1.);
-	  if(hitsOkay) {
-	    step4massHisto->Fill(theKshorts[ksndx].mass(), 1.);
-	    rVtxHisto2->Fill(vtxR, 1.);
-	    myEtaEfficiencyHisto->Fill(recoEta, 1.);
-	    myRhoEfficiencyHisto4->Fill(recoRad, 1.);
-	  }
-	}
-	//}
+      step2massHisto->Fill(theKshorts[ksndx].mass(), 1.);
+      myRhoEfficiencyHisto2->Fill(recoRad, 1.);
+      vtxSigHisto1->Fill(vtxSig, 1.);
+      if (vtxSig > 20.) {
+        step3massHisto->Fill(theKshorts[ksndx].mass(), 1.);
+        myRhoEfficiencyHisto3->Fill(recoRad, 1.);
+        if (hitsOkay) {
+          step4massHisto->Fill(theKshorts[ksndx].mass(), 1.);
+          rVtxHisto2->Fill(vtxR, 1.);
+          myEtaEfficiencyHisto->Fill(recoEta, 1.);
+          myRhoEfficiencyHisto4->Fill(recoRad, 1.);
+        }
+      }
+      //}
     }
     //}
 
-    if(vtxChi2 < 1.) {
+    if (vtxChi2 < 1.) {
       //rVtxHisto2->Fill(vtxRSph, 1.);
-      if(vtxRSph > 0.1) {
-	vtxSigHisto2->Fill(vtxSigSph, 1.);
+      if (vtxRSph > 0.1) {
+        vtxSigHisto2->Fill(vtxSigSph, 1.);
       }
     }
 
     //theKshorts[ksndx]
 
-
     //if(theKshorts.size() < 2) {
 
     //}
-    
+
     //    std::vector<reco::Track> theRefTracks = k0s.refittedTracks();
     std::vector<reco::Track> theRefTracks;
     theRefTracks.push_back(*theDaughterTracks[0]);
     theRefTracks.push_back(*theDaughterTracks[1]);
-    
+
     /*for (unsigned int ndx = 0; ndx < theRefTracks.size(); ndx++) {
 
       std::cout << "IN LOOP, THIS ISN'T THE PROBLEM. " 
@@ -871,7 +720,6 @@ void V0Analyzer::analyze(const edm::Event& iEvent,
 					  + tmpTk.dsz( beamSpot )
 					  * tmpTk.dsz( beamSpot ) ), 1.);
 					  }*/
-    
 
     reco::TransientTrack refTemp1(theRefTracks[0], &(*bFieldHandle));
     reco::TransientTrack refTemp2(theRefTracks[1], &(*bFieldHandle));
@@ -883,34 +731,26 @@ void V0Analyzer::analyze(const edm::Event& iEvent,
 				&( *bFieldHandle ) );
     reco::TransientTrack temp2( *( tkBRef2.castTo<reco::TrackRef>() ),
     &( *bFieldHandle ) );*/
-    reco::TransientTrack temp1( *theDaughterTracks[0], &( *bFieldHandle) );
-    reco::TransientTrack temp2( *theDaughterTracks[1], &( *bFieldHandle) );
+    reco::TransientTrack temp1(*theDaughterTracks[0], &(*bFieldHandle));
+    reco::TransientTrack temp2(*theDaughterTracks[1], &(*bFieldHandle));
 
     math::XYZPoint tk1InnerHitPos = temp1.track().innerPosition();
     math::XYZPoint tk2InnerHitPos = temp2.track().innerPosition();
     math::XYZVector difference = tk2InnerHitPos - tk1InnerHitPos;
-    double dist = sqrt( difference.x()*difference.x()
-			+ difference.y()*difference.y()
-			+ difference.z()*difference.z() );
+    double dist =
+        sqrt(difference.x() * difference.x() + difference.y() * difference.y() + difference.z() * difference.z());
     myInnermostHitDistanceHisto->Fill(dist, 1.);
 
-    TrajectoryStateClosestToBeamLine
-      tscb1(temp1.stateAtBeamLine());
-    TrajectoryStateClosestToBeamLine
-      tscb2(temp2.stateAtBeamLine());
+    TrajectoryStateClosestToBeamLine tscb1(temp1.stateAtBeamLine());
+    TrajectoryStateClosestToBeamLine tscb2(temp2.stateAtBeamLine());
     myImpactParameterHisto2->Fill(tscb1.transverseImpactParameter().value(), 1.);
     myImpactParameterHisto2->Fill(tscb2.transverseImpactParameter().value(), 1.);
 
+    TrajectoryStateClosestToPoint tscpRef1(refTemp1.trajectoryStateClosestToPoint(vtxPos));
+    TrajectoryStateClosestToPoint tscpRef2(refTemp2.trajectoryStateClosestToPoint(vtxPos));
+    TrajectoryStateClosestToPoint tscp1(temp1.trajectoryStateClosestToPoint(vtxPos));
+    TrajectoryStateClosestToPoint tscp2(temp2.trajectoryStateClosestToPoint(vtxPos));
 
-    TrajectoryStateClosestToPoint
-      tscpRef1(refTemp1.trajectoryStateClosestToPoint(vtxPos));
-    TrajectoryStateClosestToPoint
-      tscpRef2(refTemp2.trajectoryStateClosestToPoint(vtxPos));
-    TrajectoryStateClosestToPoint
-      tscp1(temp1.trajectoryStateClosestToPoint(vtxPos));
-    TrajectoryStateClosestToPoint
-      tscp2(temp2.trajectoryStateClosestToPoint(vtxPos));
-    
     GlobalVector refTrack1P(tscpRef1.momentum());
     GlobalVector refTrack2P(tscpRef2.momentum());
     GlobalVector track1P(tscp1.momentum());
@@ -919,42 +759,27 @@ void V0Analyzer::analyze(const edm::Event& iEvent,
     // Find the total momentum of the tracks and its magnitude
     GlobalVector refTotalP(refTrack1P + refTrack2P);
     GlobalVector totalP(track1P + track2P);
-    double refPTotMag = sqrt(refTotalP.x()*refTotalP.x()
-			     +refTotalP.y()*refTotalP.y()
-			     +refTotalP.z()*refTotalP.z());
-    double pTotMag = sqrt(totalP.x()*totalP.x() 
-			  + totalP.y()*totalP.y()
-			  + totalP.z()*totalP.z());
+    double refPTotMag =
+        sqrt(refTotalP.x() * refTotalP.x() + refTotalP.y() * refTotalP.y() + refTotalP.z() * refTotalP.z());
+    double pTotMag = sqrt(totalP.x() * totalP.x() + totalP.y() * totalP.y() + totalP.z() * totalP.z());
 
     // Find the total energy of the tracks
-    double refETot = sqrt(refTrack1P.x()*refTrack1P.x()
-			  + refTrack1P.y()*refTrack1P.y()
-			  + refTrack1P.z()*refTrack1P.z()
-			  + piMassSq) 
-      + sqrt(refTrack2P.x()*refTrack2P.x()
-	     + refTrack2P.y()*refTrack2P.y()
-	     + refTrack2P.z()*refTrack2P.z()
-	     + piMassSq);
-    double eTot = sqrt(track1P.x()*track1P.x()
-		       + track1P.y()*track1P.y()
-		       + track1P.z()*track1P.z()
-		       + piMassSq) 
-      + sqrt(track2P.x()*track2P.x()
-	     + track2P.y()*track2P.y()
-	     + track2P.z()*track2P.z()
-	     + piMassSq);
+    double refETot = sqrt(refTrack1P.x() * refTrack1P.x() + refTrack1P.y() * refTrack1P.y() +
+                          refTrack1P.z() * refTrack1P.z() + piMassSq) +
+                     sqrt(refTrack2P.x() * refTrack2P.x() + refTrack2P.y() * refTrack2P.y() +
+                          refTrack2P.z() * refTrack2P.z() + piMassSq);
+    double eTot = sqrt(track1P.x() * track1P.x() + track1P.y() * track1P.y() + track1P.z() * track1P.z() + piMassSq) +
+                  sqrt(track2P.x() * track2P.x() + track2P.y() * track2P.y() + track2P.z() * track2P.z() + piMassSq);
 
     // Calculate the invariant mass
-    double refKShortMass = sqrt((refETot+refPTotMag)*(refETot-refPTotMag));
-    double kShortMass = sqrt((eTot+pTotMag) * (eTot-pTotMag));
+    double refKShortMass = sqrt((refETot + refPTotMag) * (refETot - refPTotMag));
+    double kShortMass = sqrt((eTot + pTotMag) * (eTot - pTotMag));
 
     myRefitKshortMassHisto->Fill(refKShortMass);
     myKshortMassHisto->Fill(kShortMass);
   }
   //std::cout << "At end of analyze() function" << std::endl;
 }
-
-
 
 // ------------ method called once each job just after ending the event loop  ------------
 void V0Analyzer::endJob() {
@@ -1023,12 +848,9 @@ void V0Analyzer::endJob() {
   //std::cout << "numDiff1 = " << numDiff1 << ", numDiff2 = "
   //<< numDiff2 << std::endl;
 
-  hitsOut << "numDiff1 = " << numDiff1 << ", numDiff2 = "
-	    << numDiff2 << std::endl;
-
+  hitsOut << "numDiff1 = " << numDiff1 << ", numDiff2 = " << numDiff2 << std::endl;
 
   hitsOut.close();
-
 }
 
 //define this as a plug-in


### PR DESCRIPTION

Applying code-format for CMSSW category reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/316//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


