### PR TITLE
remove unused non-const static in CastorJetIDHelper

### DIFF
--- a/RecoJets/JetProducers/interface/CastorJetIDHelper.h
+++ b/RecoJets/JetProducers/interface/CastorJetIDHelper.h
@@ -50,7 +50,6 @@ namespace reco {
       double sigmaz_;
       int nTowers_;
 
-      static int sanity_checks_left_;
     };
   }
 }


### PR DESCRIPTION
the static counter is flagged by the static analyzer.

It was not used since the code was introduced in 2010
https://github.com/cms-sw/cmssw/commit/c25fa4b356130d5571d0bff32eaa9810b489494c#diff-9c9ca0e3c96abd35198e0ebb4962564b

