### PR TITLE
Backport of "Turn off Cluster Repair for 0T data (26940)"

### DIFF
--- a/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
+++ b/CalibTracker/SiPixelESProducers/plugins/SiPixel2DTemplateDBObjectESProducer.cc
@@ -39,19 +39,9 @@ std::shared_ptr<const SiPixel2DTemplateDBObject> SiPixel2DTemplateDBObjectESProd
 	GlobalPoint center(0.0, 0.0, 0.0);
 	float theMagField = magfield.product()->inTesla(center).mag();
 
-    std::string label = "numerator";   // The correct default
-	//  std::string label = "denominator"; // Outdated. Used for MC in older GT's
-	//  std::string label = "";      // Outdated. Old default 
+        std::string label = "numerator";   // The correct default
+	if(theMagField>=4.1 || theMagField<-0.1) edm::LogWarning("UnexpectedMagneticFieldUsingDefaultPixel2DTemplate") << "Magnetic field is " << theMagField;
 
-	if(     theMagField>=-0.1 && theMagField<1.0 ) label = "0T";
-	else if(theMagField>=1.0  && theMagField<2.5 ) label = "2T";
-	else if(theMagField>=2.5  && theMagField<3.25) label = "3T";
-	else if(theMagField>=3.25 && theMagField<3.65) label = "35T";
-	else if(theMagField>=3.9  && theMagField<4.1 ) label = "4T";
-	else {
-		//label = "3.8T";
-		if(theMagField>=4.1 || theMagField<-0.1) edm::LogWarning("UnexpectedMagneticFieldUsingDefaultPixel2DTemplate") << "Magnetic field is " << theMagField;
-	}
 	ESHandle<SiPixel2DTemplateDBObject> dbobject;
 	iRecord.getRecord<SiPixel2DTemplateDBObjectRcd>().get(label,dbobject);
 

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -81,14 +81,18 @@ PixelCPEClusterRepair::PixelCPEClusterRepair(edm::ParameterSet const & conf,
 	 << "\nERROR: Template ID " << forwardTemplateID_ << " not loaded correctly from text file. Reconstruction will fail.\n\n";
    }
    
-   templateDBobject2D_ = templateDBobject2D;
-   fill2DTemplIDs();
-   speed_ = conf.getParameter<int>( "speed");
-   LogDebug("PixelCPEClusterRepair::PixelCPEClusterRepair:") <<
-   "Template speed = " << speed_ << "\n";
-   
-   UseClusterSplitter_ = conf.getParameter<bool>("UseClusterSplitter");   
+   GlobalPoint center(0.0, 0.0, 0.0);
+   float theMagField = mag->inTesla(center).mag();
 
+   if(theMagField>=3.65 && theMagField<3.9){
+     templateDBobject2D_ = templateDBobject2D;
+     fill2DTemplIDs();
+     speed_ = conf.getParameter<int>( "speed");
+     LogDebug("PixelCPEClusterRepair::PixelCPEClusterRepair:") <<
+       "Template speed = " << speed_ << "\n";
+   }
+
+   UseClusterSplitter_ = conf.getParameter<bool>("UseClusterSplitter");   
 
 
    maxSizeMismatchInY_ = conf.getParameter<double>("MaxSizeMismatchInY");
@@ -102,6 +106,11 @@ PixelCPEClusterRepair::PixelCPEClusterRepair(edm::ParameterSet const & conf,
    recommend2D_.reserve(str_recommend2D.size());
    for (auto & str: str_recommend2D){
      recommend2D_.push_back(str);
+   }
+
+   // do not recommend 2D if theMagField!=3.8
+   if(theMagField>=3.65 && theMagField<3.9){
+     recommend2D_.clear();
    }
 
    // run CR on damaged clusters (and not only on edge hits)

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEClusterRepair.cc
@@ -81,15 +81,16 @@ PixelCPEClusterRepair::PixelCPEClusterRepair(edm::ParameterSet const & conf,
 	 << "\nERROR: Template ID " << forwardTemplateID_ << " not loaded correctly from text file. Reconstruction will fail.\n\n";
    }
    
+   speed_ = conf.getParameter<int>( "speed");
+   LogDebug("PixelCPEClusterRepair::PixelCPEClusterRepair:") <<
+   "Template speed = " << speed_ << "\n";
+
    GlobalPoint center(0.0, 0.0, 0.0);
    float theMagField = mag->inTesla(center).mag();
 
    if(theMagField>=3.65 && theMagField<3.9){
      templateDBobject2D_ = templateDBobject2D;
      fill2DTemplIDs();
-     speed_ = conf.getParameter<int>( "speed");
-     LogDebug("PixelCPEClusterRepair::PixelCPEClusterRepair:") <<
-       "Template speed = " << speed_ << "\n";
    }
 
    UseClusterSplitter_ = conf.getParameter<bool>("UseClusterSplitter");   
@@ -109,7 +110,7 @@ PixelCPEClusterRepair::PixelCPEClusterRepair(edm::ParameterSet const & conf,
    }
 
    // do not recommend 2D if theMagField!=3.8
-   if(theMagField>=3.65 && theMagField<3.9){
+   if(theMagField<3.65 || theMagField > 3.9){
      recommend2D_.clear();
    }
 

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
@@ -11,8 +11,8 @@ TTRHBuilderAngleAndTemplate = cms.ESProducer("TkTransientTrackingRecHitBuilderES
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(TTRHBuilderAngleAndTemplate, Phase2StripCPE = cms.string('Phase2StripCPE'))
 
-# uncomment these two lines to turn on Cluster Repair CPE
-from Configuration.StandardSequences.MagneticField_cff import *
+#Turn on cluster repair if not running at 0T
+from Configuration.StandardSequences.MagneticField_cff import ParabolicParametrizedMagneticFieldProducer
 if ParabolicParametrizedMagneticFieldProducer.valueOverride != 0:
     from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
     phase1Pixel.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = cms.string('PixelCPEClusterRepair'))

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
@@ -11,8 +11,8 @@ TTRHBuilderAngleAndTemplate = cms.ESProducer("TkTransientTrackingRecHitBuilderES
 from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU140
 trackingPhase2PU140.toModify(TTRHBuilderAngleAndTemplate, Phase2StripCPE = cms.string('Phase2StripCPE'))
 
-#Turn on cluster repair if not running at 0T
-from Configuration.StandardSequences.MagneticField_cff import ParabolicParametrizedMagneticFieldProducer
+# uncomment these two lines to turn on Cluster Repair CPE
+from Configuration.StandardSequences.MagneticField_cff import *
 if ParabolicParametrizedMagneticFieldProducer.valueOverride != 0:
     from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
     phase1Pixel.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = cms.string('PixelCPEClusterRepair'))

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
@@ -12,6 +12,8 @@ from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU
 trackingPhase2PU140.toModify(TTRHBuilderAngleAndTemplate, Phase2StripCPE = cms.string('Phase2StripCPE'))
 
 # uncomment these two lines to turn on Cluster Repair CPE
-from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-phase1Pixel.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = cms.string('PixelCPEClusterRepair'))
+from Configuration.StandardSequences.MagneticField_cff import *
+if ParabolicParametrizedMagneticFieldProducer.valueOverride != 0:
+    from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+    phase1Pixel.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = cms.string('PixelCPEClusterRepair'))
 

--- a/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
+++ b/RecoTracker/TransientTrackingRecHit/python/TTRHBuilderWithTemplate_cfi.py
@@ -12,8 +12,6 @@ from Configuration.Eras.Modifier_trackingPhase2PU140_cff import trackingPhase2PU
 trackingPhase2PU140.toModify(TTRHBuilderAngleAndTemplate, Phase2StripCPE = cms.string('Phase2StripCPE'))
 
 # uncomment these two lines to turn on Cluster Repair CPE
-from Configuration.StandardSequences.MagneticField_cff import *
-if ParabolicParametrizedMagneticFieldProducer.valueOverride != 0:
-    from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
-    phase1Pixel.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = cms.string('PixelCPEClusterRepair'))
+from Configuration.Eras.Modifier_phase1Pixel_cff import phase1Pixel
+phase1Pixel.toModify(TTRHBuilderAngleAndTemplate, PixelCPE = cms.string('PixelCPEClusterRepair'))
 


### PR DESCRIPTION
This is a backport of [PR 26940](https://github.com/cms-sw/cmssw/pull/26940). This is fix to allow running on 0T data will be needed in 10_6_X at some point. Likely for future tier 0 replays. 