### PR TITLE
Running code-format for reconstruction

### DIFF
--- a/DataFormats/ParticleFlowReco/interface/ConvBremSeed.h
+++ b/DataFormats/ParticleFlowReco/interface/ConvBremSeed.h
@@ -21,40 +21,30 @@
 
 namespace reco {
 
-
-class ConvBremSeed: public TrajectorySeed
- {
-  public :
-        
+  class ConvBremSeed : public TrajectorySeed {
+  public:
     typedef edm::OwnVector<TrackingRecHit> recHitContainer;
 
-
-    ConvBremSeed(){} 
+    ConvBremSeed() {}
     ~ConvBremSeed() override {}
-   
 
     /// Constructor from TrajectorySeed
-    ConvBremSeed( const TrajectorySeed & seed,edm::Ref<GsfPFRecTrackCollection> & pfgsf):
-      TrajectorySeed(seed), pfGsf_ (pfgsf){}
+    ConvBremSeed(const TrajectorySeed& seed, edm::Ref<GsfPFRecTrackCollection>& pfgsf)
+        : TrajectorySeed(seed), pfGsf_(pfgsf) {}
 
     /// reference to the GSDPFRecTrack
- 
-    GsfPFRecTrackRef GsfPFTrack() const {return pfGsf_;}
-    
 
+    GsfPFRecTrackRef GsfPFTrack() const { return pfGsf_; }
 
-    ConvBremSeed * clone() const override {return new ConvBremSeed( * this); }
+    ConvBremSeed* clone() const override { return new ConvBremSeed(*this); }
 
- private:
-    
+  private:
     //! Pointer to the electromagnetic super cluster.
-    GsfPFRecTrackRef  pfGsf_;
+    GsfPFRecTrackRef pfGsf_;
+  };
 
-  } ;
+  // Class ConvBremSeed
 
-
-// Class ConvBremSeed
-
-}// namespace reco
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/ConvBremSeedFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/ConvBremSeedFwd.h
@@ -17,6 +17,6 @@ namespace reco {
   typedef edm::RefVector<ConvBremSeedCollection> ConvBremSeedRefVector;
   /// iterator over a vector of reference to ConvBremSeed objects
   typedef ConvBremSeedRefVector::iterator convbremphltseed_iterator;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/GsfPFRecTrack.h
+++ b/DataFormats/ParticleFlowReco/interface/GsfPFRecTrack.h
@@ -21,54 +21,47 @@ namespace reco {
      \author Renaud Bruneliere, Michele Pioppi, Daniele Benedetti
      \date   July 2006
   */
-  class GsfPFRecTrack : public PFRecTrack
-  {
-
+  class GsfPFRecTrack : public PFRecTrack {
   public:
     GsfPFRecTrack(){};
     GsfPFRecTrack(double charge,
-               AlgoType_t algoType,
-               int trackId,
-               const reco::GsfTrackRef& gtrackref,
-               const edm::Ref<std::vector<PFRecTrack> >& kfpfrectrackref);
-
-  
+                  AlgoType_t algoType,
+                  int trackId,
+                  const reco::GsfTrackRef& gtrackref,
+                  const edm::Ref<std::vector<PFRecTrack> >& kfpfrectrackref);
 
     /// \return reference to corresponding gsftrack
-    const reco::GsfTrackRef& 
-      gsfTrackRef() const {return gsfTrackRef_;}
-    
+    const reco::GsfTrackRef& gsfTrackRef() const { return gsfTrackRef_; }
+
     /// \return reference to corresponding KF PFRecTrack  (only for GSF PFRecTrack)
-    const   edm::Ref<std::vector<PFRecTrack> >&
-      kfPFRecTrackRef() const  {return kfPFRecTrackRef_;} 
+    const edm::Ref<std::vector<PFRecTrack> >& kfPFRecTrackRef() const { return kfPFRecTrackRef_; }
     /// add a Bremsstrahlung photon
-    void addBrem( const reco::PFBrem& brem);
+    void addBrem(const reco::PFBrem& brem);
 
     /// calculate posrep_ once and for all for each brem
     void calculateBremPositionREP();
 
     /// \return the vector of PFBrem
-    const std::vector<reco::PFBrem>& PFRecBrem()const {return pfBremVec_;}
+    const std::vector<reco::PFBrem>& PFRecBrem() const { return pfBremVec_; }
 
     /// \return id
-    int trackId() const {return trackId_;}
-
+    int trackId() const { return trackId_; }
 
     /// \add PFRecTrackRef from conv Brems
     void addConvBremPFRecTrackRef(const reco::PFRecTrackRef& pfrectracksref);
 
     /// \return vector of PFRecTrackRef from Conv Brem
-    const std::vector<reco::PFRecTrackRef>& convBremPFRecTrackRef() const {return assoPFRecTrack_;}
+    const std::vector<reco::PFRecTrackRef>& convBremPFRecTrackRef() const { return assoPFRecTrack_; }
 
     /// \add GsfPFRecTrackRef from duplicates
-    void  addConvBremGsfPFRecTrackRef(const reco::GsfPFRecTrackRef& gsfpfrectracksref);
+    void addConvBremGsfPFRecTrackRef(const reco::GsfPFRecTrackRef& gsfpfrectracksref);
 
     /// \return vector of GsfPFRecTrackRef from duplicates
-    const std::vector<reco::GsfPFRecTrackRef>& convBremGsfPFRecTrackRef() const {return assoGsfPFRecTrack_;}
+    const std::vector<reco::GsfPFRecTrackRef>& convBremGsfPFRecTrackRef() const { return assoGsfPFRecTrack_; }
 
   private:
     /// reference to corresponding gsf track
-    reco::GsfTrackRef     gsfTrackRef_;
+    reco::GsfTrackRef gsfTrackRef_;
 
     ///ref to the corresponfing PfRecTrack with KF algo (only for PFRecTrack built from GSF track)
     reco::PFRecTrackRef kfPFRecTrackRef_;
@@ -78,7 +71,7 @@ namespace reco {
 
     /// vector of PFRecTrackRef from conv Brems
     std::vector<reco::PFRecTrackRef> assoPFRecTrack_;
-    
+
     /// vector of GsfPFRecTrackRef from duplicates
     std::vector<reco::GsfPFRecTrackRef> assoGsfPFRecTrack_;
 
@@ -86,7 +79,6 @@ namespace reco {
     int trackId_;
   };
 
-
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/GsfPFRecTrackFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/GsfPFRecTrackFwd.h
@@ -22,6 +22,6 @@ namespace reco {
 
   /// iterator over a vector of references to GsfPFRecTrack objects
   typedef GsfPFRecTrackRefVector::iterator gsfPfRecTrack_iterator;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/HGCalMultiCluster.h
+++ b/DataFormats/ParticleFlowReco/interface/HGCalMultiCluster.h
@@ -10,34 +10,26 @@
 
 namespace reco {
   class HGCalMultiCluster : public reco::PFCluster {
-    
   public:
     typedef edm::PtrVector<reco::BasicCluster>::const_iterator component_iterator;
     typedef edm::PtrVector<reco::BasicCluster> ClusterCollection;
-    
-  HGCalMultiCluster() : PFCluster() { this->setLayer(PFLayer::HGCAL); }
 
-  HGCalMultiCluster(double energy,
-                    double x, double y, double z,
-                    ClusterCollection &thecls);
-  
-  void push_back(const edm::Ptr<reco::BasicCluster> &b) {
-    myclusters.push_back(b);
-  }
-  
-  const edm::PtrVector<reco::BasicCluster>& clusters() const { return myclusters; }
+    HGCalMultiCluster() : PFCluster() { this->setLayer(PFLayer::HGCAL); }
 
-  unsigned int size() const { return myclusters.size(); }  
-  component_iterator begin() const { return myclusters.begin(); }
-  component_iterator end()   const { return myclusters.end(); }
-  
-  bool operator > (const HGCalMultiCluster& rhs) const { 
-    return (energy() > rhs.energy()); 
-  }
-  
-  private:  
-  edm::PtrVector<reco::BasicCluster> myclusters;
-  
+    HGCalMultiCluster(double energy, double x, double y, double z, ClusterCollection& thecls);
+
+    void push_back(const edm::Ptr<reco::BasicCluster>& b) { myclusters.push_back(b); }
+
+    const edm::PtrVector<reco::BasicCluster>& clusters() const { return myclusters; }
+
+    unsigned int size() const { return myclusters.size(); }
+    component_iterator begin() const { return myclusters.begin(); }
+    component_iterator end() const { return myclusters.end(); }
+
+    bool operator>(const HGCalMultiCluster& rhs) const { return (energy() > rhs.energy()); }
+
+  private:
+    edm::PtrVector<reco::BasicCluster> myclusters;
   };
-}
+}  // namespace reco
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFBlock.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlock.h
@@ -1,22 +1,18 @@
 #ifndef RecoParticleFlow_PFAlgo_PFBlock_h
-#define RecoParticleFlow_PFAlgo_PFBlock_h 
+#define RecoParticleFlow_PFAlgo_PFBlock_h
 
 #include <map>
 #include <iostream>
 
 /* #include "boost/graph/adjacency_matrix.hpp" */
 
-
 // #include "DataFormats/ParticleFlowReco/interface/PFBlockLink.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElement.h"
 // #include "DataFormats/ParticleFlowReco/interface/PFBlockParticle.h"
 #include "DataFormats/Common/interface/OwnVector.h"
 
-
-
 namespace reco {
 
-  
   /// \brief Block of elements
   /*!
     \author Colin Bernet
@@ -26,116 +22,87 @@ namespace reco {
     - a set of topologically connected elements.
     - a set of links between these elements
   */
-  
+
   class PFBlock {
-
-
   public:
-
     struct Link {
-      Link()   : distance(-1), test(0) {}
+      Link() : distance(-1), test(0) {}
       Link(float d, char t) : distance(d), test(t) {}
       float distance;
       char test;
     };
 
-    typedef edm::OwnVector< reco::PFBlockElement >::const_iterator IE;
+    typedef edm::OwnVector<reco::PFBlockElement>::const_iterator IE;
     /*     typedef std::vector< reco::PFBlockLink >::const_iterator IL; */
-    
+
     // typedef std::vector< std::vector<double> > LinkData;
-    typedef std::map< unsigned int,  Link >  LinkData;
-    
-    enum LinkTest {
-      LINKTEST_RECHIT,
-      LINKTEST_NLINKTEST,
-      LINKTEST_ALL
-    };
+    typedef std::map<unsigned int, Link> LinkData;
+
+    enum LinkTest { LINKTEST_RECHIT, LINKTEST_NLINKTEST, LINKTEST_ALL };
 
     PFBlock() {}
     // PFBlock(const PFBlock& other);
 
     /// add an element to the current PFBlock
     /// the block will keep a copy.
-    void addElement( reco::PFBlockElement* element );
-    
+    void addElement(reco::PFBlockElement* element);
+
     void bookLinkData();
 
-    /// makes the correspondance between a 2d element matrix and 
+    /// makes the correspondance between a 2d element matrix and
     /// the 1D vector which is the most compact way to store the matrix
     bool matrix2vector(unsigned i, unsigned j, unsigned& index) const;
 
     /// set a link between elements of indices i1 and i2, of "distance" dist
     /// the link is set in the linkData vector provided as an argument.
     /// As indicated by the 'const' statement, 'this' is not modified.
-    void setLink(unsigned i1, 
-		 unsigned i2, 
-		 double dist, 
-                 LinkData& linkData, 
-		 LinkTest  test=LINKTEST_RECHIT ) const;
+    void setLink(unsigned i1, unsigned i2, double dist, LinkData& linkData, LinkTest test = LINKTEST_RECHIT) const;
 
     /// lock an element ( unlink it from the others )
     /// Colin: this function is misleading
     /// void lock(unsigned i, LinkData& linkData ) const;
 
-
     /// fills a map with the elements associated to element i.
     /// elements are sorted by increasing distance.
     /// if specified, only the elements of type "type" will be considered
-    /// if specified, only the link calculated from a certain "test" will 
+    /// if specified, only the link calculated from a certain "test" will
     /// be considered: distance test, etc..
-    void associatedElements( unsigned i,
-                             const LinkData& linkData, 
-                             std::multimap<double, unsigned>& sortedAssociates,
-                             reco::PFBlockElement::Type type = PFBlockElement::NONE,
-			     LinkTest test=LINKTEST_RECHIT ) const; 
-      
+    void associatedElements(unsigned i,
+                            const LinkData& linkData,
+                            std::multimap<double, unsigned>& sortedAssociates,
+                            reco::PFBlockElement::Type type = PFBlockElement::NONE,
+                            LinkTest test = LINKTEST_RECHIT) const;
 
     /// \return distance of link
-    double dist(unsigned ie1, 
-		unsigned ie2, 
-		const LinkData& linkData, 
-		LinkTest  test ) const {
-      return dist(ie1,ie2,linkData);
+    double dist(unsigned ie1, unsigned ie2, const LinkData& linkData, LinkTest test) const {
+      return dist(ie1, ie2, linkData);
     }
 
     /// \return distance of link
-    double dist( unsigned ie1, 
-		 unsigned ie2, 
-                 const LinkData& linkData) const;
+    double dist(unsigned ie1, unsigned ie2, const LinkData& linkData) const;
 
     /// \return elements
-    const edm::OwnVector< reco::PFBlockElement >& elements() const {
-      return elements_;
-    }
+    const edm::OwnVector<reco::PFBlockElement>& elements() const { return elements_; }
 
     /// \return link data
-    const LinkData& linkData() const {
-      return linkData_;
-    }
+    const LinkData& linkData() const { return linkData_; }
 
     /// \return link data
-    LinkData& linkData() {
-      return linkData_;
-    }
+    LinkData& linkData() { return linkData_; }
 
   private:
-    
     /// \return size of linkData_, calculated from the number of elements
     unsigned linkDataSize() const;
-    
+
     /// link data (permanent)
-    LinkData                                        linkData_;
-     
-    /// all elements 
-    edm::OwnVector< reco::PFBlockElement >          elements_;
-        
+    LinkData linkData_;
+
+    /// all elements
+    edm::OwnVector<reco::PFBlockElement> elements_;
   };
 
-  std::ostream& operator<<( std::ostream& out, const PFBlock& co );
+  std::ostream& operator<<(std::ostream& out, const PFBlock& co);
 
-}
+}  // namespace reco
 
 #endif
-
-
-  

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElement.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElement.h
@@ -2,7 +2,7 @@
 #define __PFBlockElement__
 
 #include "DataFormats/ParticleFlowReco/interface/PFRecTrackFwd.h"
-#include "DataFormats/ParticleFlowReco/interface/PFDisplacedTrackerVertex.h" 
+#include "DataFormats/ParticleFlowReco/interface/PFDisplacedTrackerVertex.h"
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
@@ -11,76 +11,59 @@
 #include "DataFormats/Candidate/interface/VertexCompositeCandidate.h"
 #include "DataFormats/Candidate/interface/VertexCompositeCandidateFwd.h"
 
-#include "DataFormats/ParticleFlowReco/interface/PFMultilinksTC.h" // Glowinski & Gouzevitch
+#include "DataFormats/ParticleFlowReco/interface/PFMultilinksTC.h"  // Glowinski & Gouzevitch
 
 #include <iostream>
-
 
 namespace reco {
   class PFBlockElementCluster;
   class PFBlockElementTrack;
-  
-  
+
   /// \brief Abstract base class for a PFBlock element (track, cluster...)
-  /// 
-  /// this class contains a PFRecTrackRef of a 
+  ///
+  /// this class contains a PFRecTrackRef of a
   /// PFClusterRef, depending on the type of the element
   class PFBlockElement {
   public:
-    
     /// possible types for the element
     /// do not modify this enum if you don't know what you're doing!!!
-    enum Type { 
-      NONE=0,
-      TRACK=1, 
-      PS1=2, 
-      PS2=3, 
-      ECAL=4, 
-      HCAL=5,
-      GSF=6,
-      BREM=7,
-      HFEM=8,
-      HFHAD=9,
-      SC=10,
-      HO=11,
-      HGCAL=12,
-      kNBETypes=13
+    enum Type {
+      NONE = 0,
+      TRACK = 1,
+      PS1 = 2,
+      PS2 = 3,
+      ECAL = 4,
+      HCAL = 5,
+      GSF = 6,
+      BREM = 7,
+      HFEM = 8,
+      HFHAD = 9,
+      SC = 10,
+      HO = 11,
+      HGCAL = 12,
+      kNBETypes = 13
     };
 
-    enum TrackType {
-      DEFAULT=0,
-      T_FROM_DISP,
-      T_TO_DISP,
-      T_FROM_GAMMACONV,
-      MUON,
-      T_FROM_V0
-    };
+    enum TrackType { DEFAULT = 0, T_FROM_DISP, T_TO_DISP, T_FROM_GAMMACONV, MUON, T_FROM_V0 };
 
     /// standard constructor
-    PFBlockElement(Type type=NONE) :  
-      type_(type), 
-      locked_(false),
-      index_( static_cast<unsigned>(-1) ),
-      time_(0.f), timeError_(-1.f)
-    {
-    }
-
+    PFBlockElement(Type type = NONE)
+        : type_(type), locked_(false), index_(static_cast<unsigned>(-1)), time_(0.f), timeError_(-1.f) {}
 
     /// destructor
     virtual ~PFBlockElement() {}
-  
+
     /// print the object inside the element
-    virtual void Dump(std::ostream& out=std::cout, 
-                      const char* tab=" " ) const;
-    
+    virtual void Dump(std::ostream& out = std::cout, const char* tab = " ") const;
+
     /// necessary to have the edm::OwnVector<PFBlockElement> working
     virtual PFBlockElement* clone() const = 0;
-      
+
     /// lock element
-    void lock() {locked_ = true;}
+    void lock() { locked_ = true; }
 
     /// unlock element
-    void unLock() {locked_ = false;}
+    void unLock() { locked_ = false; }
 
     /// \return type
     Type type() const { return type_; }
@@ -89,48 +72,51 @@ namespace reco {
     virtual bool trackType(TrackType trType) const { return false; }
 
     /// \set the trackType
-    virtual void setTrackType(TrackType trType, bool value) { 
-             std::cout << "Error in PFBlockElement::setTrackType : this base class method is not implemented" << std::endl;}
+    virtual void setTrackType(TrackType trType, bool value) {
+      std::cout << "Error in PFBlockElement::setTrackType : this base class method is not implemented" << std::endl;
+    }
 
-    /// locked ? 
-    bool    locked() const {return locked_;}
-    
-    /// set index 
-    void     setIndex(unsigned index) { index_ = index; }
+    /// locked ?
+    bool locked() const { return locked_; }
+
+    /// set index
+    void setIndex(unsigned index) { index_ = index; }
 
     /// \return index
-    unsigned index() const {return index_;} 
+    unsigned index() const { return index_; }
 
-    virtual const reco::TrackRef& trackRef()  const {return nullTrack_; }
-    virtual const PFRecTrackRef& trackRefPF()  const {return nullPFRecTrack_; }
-    virtual const PFClusterRef& clusterRef() const {return nullPFCluster_; }
+    virtual const reco::TrackRef& trackRef() const { return nullTrack_; }
+    virtual const PFRecTrackRef& trackRefPF() const { return nullPFRecTrack_; }
+    virtual const PFClusterRef& clusterRef() const { return nullPFCluster_; }
     virtual const PFDisplacedTrackerVertexRef& displacedVertexRef(TrackType trType) const { return nullPFDispVertex_; }
-    virtual const ConversionRefVector&    convRefs() const { return nullConv_;}
+    virtual const ConversionRefVector& convRefs() const { return nullConv_; }
     virtual const MuonRef& muonRef() const { return nullMuon_; }
-    virtual const VertexCompositeCandidateRef& V0Ref()  const { return nullVertex_; }
-    virtual void setDisplacedVertexRef(const PFDisplacedTrackerVertexRef& niref, TrackType trType) { 
-      std::cout << "Error in PFBlockElement::setDisplacedVertexRef : this base class method is not implemented" << std::endl;}
-    virtual void setConversionRef(const ConversionRef& convRef, TrackType trType) { 
-      std::cout << "Error in PFBlockElement::setConversionRef : this base class method is not implemented" << std::endl;}
-    virtual void setMuonRef(const MuonRef& muref) { 
-      std::cout << "Error in PFBlockElement::setMuonRef : this base class method is not implemented" << std::endl;}
-    virtual void setV0Ref(const VertexCompositeCandidateRef& v0ref,TrackType trType) { 
-      
+    virtual const VertexCompositeCandidateRef& V0Ref() const { return nullVertex_; }
+    virtual void setDisplacedVertexRef(const PFDisplacedTrackerVertexRef& niref, TrackType trType) {
+      std::cout << "Error in PFBlockElement::setDisplacedVertexRef : this base class method is not implemented"
+                << std::endl;
+    }
+    virtual void setConversionRef(const ConversionRef& convRef, TrackType trType) {
+      std::cout << "Error in PFBlockElement::setConversionRef : this base class method is not implemented" << std::endl;
+    }
+    virtual void setMuonRef(const MuonRef& muref) {
+      std::cout << "Error in PFBlockElement::setMuonRef : this base class method is not implemented" << std::endl;
+    }
+    virtual void setV0Ref(const VertexCompositeCandidateRef& v0ref, TrackType trType) {
       std::cout << "Error in PFBlockElement::setV0Ref : this base class method is not implemented" << std::endl;
     }
 
-
     virtual bool isSecondary() const { return false; }
     virtual bool isPrimary() const { return false; }
-    virtual bool isLinkedToDisplacedVertex() const {return false;}
+    virtual bool isLinkedToDisplacedVertex() const { return false; }
 
     // Glowinski & Gouzevitch
-    void setMultilinks(const PFMultiLinksTC& ml) {multilinks_ = ml;}
-    void setIsValidMultilinks(bool isVal) {multilinks_.isValid = isVal;}
-    void setMultilinksList(const PFMultilinksType& links) {multilinks_.linkedClusters = links;}
-    
-    bool isMultilinksValide() const {return multilinks_.isValid;}
-    const PFMultilinksType& getMultilinks() const {return multilinks_.linkedClusters;}
+    void setMultilinks(const PFMultiLinksTC& ml) { multilinks_ = ml; }
+    void setIsValidMultilinks(bool isVal) { multilinks_.isValid = isVal; }
+    void setMultilinksList(const PFMultilinksType& links) { multilinks_.linkedClusters = links; }
+
+    bool isMultilinksValide() const { return multilinks_.isValid; }
+    const PFMultilinksType& getMultilinks() const { return multilinks_.linkedClusters; }
     // ! Glowinski & Gouzevitch
 
     /// do we have a valid time information
@@ -140,26 +126,28 @@ namespace reco {
     /// \return the timing uncertainty
     float timeError() const { return timeError_; }
     /// \set the timing information
-    void setTime(float time, float timeError = 0.f) { time_ = time; timeError_ = timeError; }
+    void setTime(float time, float timeError = 0.f) {
+      time_ = time;
+      timeError_ = timeError;
+    }
 
-  protected:  
-
+  protected:
     /// type, see PFBlockElementType
     /// \todo replace by a char ?
-    Type     type_;
+    Type type_;
 
-    /// locked flag. 
-    /// \todo can probably be transient. Could be replaced by a 
+    /// locked flag.
+    /// \todo can probably be transient. Could be replaced by a
     /// "remaining energy". IS THIS STILL USED ?
-    bool       locked_;
-    
-    /// index in block vector 
-    unsigned   index_;
+    bool locked_;
+
+    /// index in block vector
+    unsigned index_;
 
     // Glowinski & Gouzevitch
     PFMultiLinksTC multilinks_;
     // ! Glowinski & Gouzevitch
-    
+
     /// timing information (valid if timeError_ >= 0)
     float time_;
     /// timing information uncertainty (<0 if timing not available)
@@ -172,11 +160,9 @@ namespace reco {
     const static ConversionRefVector nullConv_;
     const static MuonRef nullMuon_;
     const static VertexCompositeCandidateRef nullVertex_;
-  
   };
 
-    std::ostream& operator<<( std::ostream& out, 
-                              const PFBlockElement& element );
+  std::ostream& operator<<(std::ostream& out, const PFBlockElement& element);
 
-}
+}  // namespace reco
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElementBrem.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElementBrem.h
@@ -10,61 +10,48 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 namespace reco {
-  
+
   /// \brief Track Element.
-  /// 
-  /// this class contains a reference to a PFRecTrack 
+  ///
+  /// this class contains a reference to a PFRecTrack
   class PFBlockElementBrem : public PFBlockElement {
   public:
+    PFBlockElementBrem() {}
 
-    PFBlockElementBrem() {} 
+    PFBlockElementBrem(const GsfPFRecTrackRef& gsfref,
+                       const double DeltaP,
+                       const double SigmaDeltaP,
+                       const unsigned int indTrajPoint);
 
-    PFBlockElementBrem(const GsfPFRecTrackRef& gsfref, const double DeltaP, const double SigmaDeltaP, const unsigned int indTrajPoint);
-
-      
     PFBlockElement* clone() const override { return new PFBlockElementBrem(*this); }
-    void Dump(std::ostream& out = std::cout, 
-              const char* tab = " " ) const override;
-    
+    void Dump(std::ostream& out = std::cout, const char* tab = " ") const override;
 
-    const GsfPFRecTrackRef& GsftrackRefPF() const {
-      return GsftrackRefPF_;
-    }
-    
+    const GsfPFRecTrackRef& GsftrackRefPF() const { return GsftrackRefPF_; }
+
     /// \return reference to the corresponding Track
-    const reco::GsfTrackRef& GsftrackRef() const {
-      return GsftrackRef_;
-    }
-    
-    const PFRecTrack & trackPF() const    
-      { return ((*GsftrackRefPF()).PFRecBrem()[(indPoint_-2)]);}     
-    
+    const reco::GsfTrackRef& GsftrackRef() const { return GsftrackRef_; }
 
-    double DeltaP() const {return deltaP_;}
-    double SigmaDeltaP() const {return sigmadeltaP_;}
-    unsigned int indTrajPoint() const {return indPoint_;}
+    const PFRecTrack& trackPF() const { return ((*GsftrackRefPF()).PFRecBrem()[(indPoint_ - 2)]); }
+
+    double DeltaP() const { return deltaP_; }
+    double SigmaDeltaP() const { return sigmadeltaP_; }
+    unsigned int indTrajPoint() const { return indPoint_; }
 
     /// \return position at ECAL entrance
-    const math::XYZPointF& positionAtECALEntrance() const {
-      return positionAtECALEntrance_;
-    }
-      
+    const math::XYZPointF& positionAtECALEntrance() const { return positionAtECALEntrance_; }
 
   private:
-    
     /// reference to the corresponding track (transient)
-    GsfPFRecTrackRef  GsftrackRefPF_;
-   
-    /// reference to the corresponding track 
+    GsfPFRecTrackRef GsftrackRefPF_;
+
+    /// reference to the corresponding track
     reco::GsfTrackRef GsftrackRef_;
-     
+
     double deltaP_;
     double sigmadeltaP_;
     unsigned int indPoint_;
-    math::XYZPointF        positionAtECALEntrance_;
- 
+    math::XYZPointF positionAtECALEntrance_;
   };
-}
+}  // namespace reco
 
 #endif
-

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElementCluster.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElementCluster.h
@@ -9,41 +9,35 @@
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 
 namespace reco {
-  
+
   /// \brief Cluster Element.
-  /// 
-  /// this class contains a reference to a PFCluster 
+  ///
+  /// this class contains a reference to a PFCluster
   class PFBlockElementCluster : public PFBlockElement {
   public:
-    PFBlockElementCluster() {} 
-    
+    PFBlockElementCluster() {}
+
     /// \brief constructor.
-    /// type must be equal to PS1, PS2, ECAL, HCAL. 
+    /// type must be equal to PS1, PS2, ECAL, HCAL.
     /// \todo add a protection against the other types...
-    PFBlockElementCluster(const PFClusterRef& ref, 
-                          PFBlockElement::Type type) 
-      : 
-      PFBlockElement(type),
-      clusterRef_( ref ) {}
-    
+    PFBlockElementCluster(const PFClusterRef& ref, PFBlockElement::Type type)
+        : PFBlockElement(type), clusterRef_(ref) {}
+
     PFBlockElement* clone() const override { return new PFBlockElementCluster(*this); }
-    
+
     /// \return reference to the corresponding cluster
-    const PFClusterRef&  clusterRef() const override {return clusterRef_;}
-    const SuperClusterRef& superClusterRef() const { return superClusterRef_;}
+    const PFClusterRef& clusterRef() const override { return clusterRef_; }
+    const SuperClusterRef& superClusterRef() const { return superClusterRef_; }
 
-    void setSuperClusterRef(const SuperClusterRef& ref) 
-    { superClusterRef_ = ref;}
+    void setSuperClusterRef(const SuperClusterRef& ref) { superClusterRef_ = ref; }
 
-    void Dump(std::ostream& out = std::cout, 
-              const char* tab = " " ) const override;
-  
+    void Dump(std::ostream& out = std::cout, const char* tab = " ") const override;
+
   private:
     /// reference to the corresponding cluster
-    PFClusterRef  clusterRef_;
+    PFClusterRef clusterRef_;
     SuperClusterRef superClusterRef_;
   };
-}
+}  // namespace reco
 
 #endif
-

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElementFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElementFwd.h
@@ -10,6 +10,6 @@ namespace reco {
   class PFBlockElement;
   class PFBlockElementCluster;
   class PFBlockElementTrack;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElementGsfTrack.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElementGsfTrack.h
@@ -11,87 +11,64 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 namespace reco {
-  
+
   /// \brief Track Element.
-  /// 
-  /// this class contains a reference to a PFRecTrack 
+  ///
+  /// this class contains a reference to a PFRecTrack
   class PFBlockElementGsfTrack : public PFBlockElement {
   public:
+    PFBlockElementGsfTrack() {}
 
-    PFBlockElementGsfTrack() {} 
-
-    PFBlockElementGsfTrack(const GsfPFRecTrackRef& gsfref, 
-			   const math::XYZTLorentzVector& Pin, 
-			   const math::XYZTLorentzVector& Pout);
+    PFBlockElementGsfTrack(const GsfPFRecTrackRef& gsfref,
+                           const math::XYZTLorentzVector& Pin,
+                           const math::XYZTLorentzVector& Pout);
 
     PFBlockElement* clone() const override { return new PFBlockElementGsfTrack(*this); }
-    
-    void Dump(std::ostream& out = std::cout, 
-              const char* tab = " " ) const override;
+
+    void Dump(std::ostream& out = std::cout, const char* tab = " ") const override;
 
     /// \return tracktype
-    bool trackType(TrackType trType) const override { 
-      return (trackType_>>trType) & 1; 
-    }
-      
+    bool trackType(TrackType trType) const override { return (trackType_ >> trType) & 1; }
+
     /// \set the trackType
     void setTrackType(TrackType trType, bool value) override {
-      if(value)  trackType_ = trackType_ | (1<<trType);
-      else trackType_ = trackType_ ^ (1<<trType);
+      if (value)
+        trackType_ = trackType_ | (1 << trType);
+      else
+        trackType_ = trackType_ ^ (1 << trType);
     }
-    
-    bool isSecondary() const override { 
-      return trackType(T_FROM_GAMMACONV); 
-    }
+
+    bool isSecondary() const override { return trackType(T_FROM_GAMMACONV); }
 
     /// \return reference to the corresponding PFGsfRecTrack
-    const GsfPFRecTrackRef& GsftrackRefPF() const {
-      return GsftrackRefPF_;
-    }
-    
+    const GsfPFRecTrackRef& GsftrackRefPF() const { return GsftrackRefPF_; }
+
     /// \return reference to the corresponding GsfTrack
-    const reco::GsfTrackRef& GsftrackRef() const {
-      return GsftrackRef_;
-    }
- 
-    
-    
-   
+    const reco::GsfTrackRef& GsftrackRef() const { return GsftrackRef_; }
+
     /// \return position at ECAL entrance
-    const math::XYZPointF& positionAtECALEntrance() const {
-      return positionAtECALEntrance_;
-    }
-    
+    const math::XYZPointF& positionAtECALEntrance() const { return positionAtECALEntrance_; }
 
+    const GsfPFRecTrack& GsftrackPF() const { return *GsftrackRefPF_; }
 
-    const GsfPFRecTrack & GsftrackPF() const { return *GsftrackRefPF_;}
-  
-    const math::XYZTLorentzVector& Pin() const    { return Pin_; }
-    const math::XYZTLorentzVector& Pout() const    { return Pout_; }
+    const math::XYZTLorentzVector& Pin() const { return Pin_; }
+    const math::XYZTLorentzVector& Pout() const { return Pout_; }
+
   private:
-    
-
-
     /// reference to the corresponding GSF track (transient)
-    GsfPFRecTrackRef  GsftrackRefPF_;
-    
-    /// reference to the corresponding GSF track 
+    GsfPFRecTrackRef GsftrackRefPF_;
+
+    /// reference to the corresponding GSF track
     reco::GsfTrackRef GsftrackRef_;
-    
-    
-    /// The CorrespondingKFTrackRef is needeed. 
+
+    /// The CorrespondingKFTrackRef is needeed.
     math::XYZTLorentzVector Pin_;
     math::XYZTLorentzVector Pout_;
-    unsigned int  trackType_; 
- 
+    unsigned int trackType_;
 
-   /// position at ECAL entrance
-    math::XYZPointF        positionAtECALEntrance_;
-    
-
-
+    /// position at ECAL entrance
+    math::XYZPointF positionAtECALEntrance_;
   };
-}
+}  // namespace reco
 
 #endif
-

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElementSuperCluster.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElementSuperCluster.h
@@ -8,88 +8,86 @@
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 
 namespace reco {
-  
+
   /// \brief Cluster Element.
-  /// 
-  /// this class contains a reference to a PFCluster 
+  ///
+  /// this class contains a reference to a PFCluster
   class PFBlockElementSuperCluster : public PFBlockElement {
   public:
-    PFBlockElementSuperCluster() {} 
-    
+    PFBlockElementSuperCluster() {}
+
     /// \brief constructor.
-    /// type must be equal to PS1, PS2, ECAL, HCAL. 
+    /// type must be equal to PS1, PS2, ECAL, HCAL.
     /// \todo add a protection against the other types...
-    PFBlockElementSuperCluster(const SuperClusterRef& ref) 
-      : 
-      PFBlockElement(PFBlockElement::SC),
-      superClusterRef_( ref ),
-      trackIso_(0.),
-      ecalIso_(0.),
-      hcalIso_(0.),
-      HoE_(0.),
-      fromGsfElectron_(false),
-      fromPhoton_(false),
-      fromPFSuperCluster_(false){}
-      
+    PFBlockElementSuperCluster(const SuperClusterRef& ref)
+        : PFBlockElement(PFBlockElement::SC),
+          superClusterRef_(ref),
+          trackIso_(0.),
+          ecalIso_(0.),
+          hcalIso_(0.),
+          HoE_(0.),
+          fromGsfElectron_(false),
+          fromPhoton_(false),
+          fromPFSuperCluster_(false) {}
+
     PFBlockElement* clone() const override { return new PFBlockElementSuperCluster(*this); }
-    
+
     /// \return reference to the corresponding cluster
-    const SuperClusterRef&  superClusterRef() const {return superClusterRef_;}
+    const SuperClusterRef& superClusterRef() const { return superClusterRef_; }
 
     /// \return reference to seeding photon
-    const PhotonRef& photonRef() const {return photonRef_;}
+    const PhotonRef& photonRef() const { return photonRef_; }
 
-    void Dump(std::ostream& out = std::cout, 
-              const char* tab = " " ) const override;
+    void Dump(std::ostream& out = std::cout, const char* tab = " ") const override;
 
     /// set the track Iso
-    void setTrackIso(float val) {trackIso_=val;}
+    void setTrackIso(float val) { trackIso_ = val; }
 
     /// set the ecal Iso
-    void setEcalIso(float val) {ecalIso_=val;}
+    void setEcalIso(float val) { ecalIso_ = val; }
 
     /// set the had Iso
-    void setHcalIso(float val) {hcalIso_=val;}
+    void setHcalIso(float val) { hcalIso_ = val; }
 
     /// set H/E
-    void setHoE(float val) {HoE_=val;}
+    void setHoE(float val) { HoE_ = val; }
 
     /// set provenance
-    void setFromGsfElectron(bool val) {fromGsfElectron_=val;}
+    void setFromGsfElectron(bool val) { fromGsfElectron_ = val; }
 
     /// set provenance
-    void setFromPhoton(bool val) {fromPhoton_=val;}
+    void setFromPhoton(bool val) { fromPhoton_ = val; }
 
     void setFromPFSuperCluster(bool val) { fromPFSuperCluster_ = val; }
-    
+
     /// set photonRef
-    void setPhotonRef(const PhotonRef & ref) {photonRef_ = ref ;}
+    void setPhotonRef(const PhotonRef& ref) { photonRef_ = ref; }
 
     /// \return the track isolation
-    float trackIso() const {return trackIso_;}
+    float trackIso() const { return trackIso_; }
 
     /// \return the ecal isolation
-    float ecalIso() const {return ecalIso_;}
-    
+    float ecalIso() const { return ecalIso_; }
+
     /// \return the had isolation
-    float hcalIso() const {return hcalIso_;}
+    float hcalIso() const { return hcalIso_; }
 
     /// \return Hoe
-    float hoverE() const {return HoE_;}
+    float hoverE() const { return HoE_; }
 
     /// \return provenance
-    bool fromGsfElectron() const {return fromGsfElectron_;}
+    bool fromGsfElectron() const { return fromGsfElectron_; }
 
     /// \return provenance
-    bool fromPhoton() const {return fromPhoton_;}
-    
+    bool fromPhoton() const { return fromPhoton_; }
+
     //SuperCluster comes from a PFSuperCluster (and can therefore be matched
     // by ref back to the initial PFClusters)
     bool fromPFSuperCluster() const { return fromPFSuperCluster_; }
 
   private:
     /// reference to the corresponding cluster
-    SuperClusterRef  superClusterRef_;
+    SuperClusterRef superClusterRef_;
     PhotonRef photonRef_;
 
     float trackIso_;
@@ -101,7 +99,6 @@ namespace reco {
     bool fromPhoton_;
     bool fromPFSuperCluster_;
   };
-}
+}  // namespace reco
 
 #endif
-

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElementSuperClusterFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElementSuperClusterFwd.h
@@ -2,10 +2,10 @@
 #define PFBlockElementSuperClusterFwd_H
 #include <vector>
 #include "DataFormats/Common/interface/Ref.h"
-namespace reco{
+namespace reco {
   class PFBlockElementSuperCluster;
   typedef std::vector<reco::PFBlockElementSuperCluster> PFBlockElementSuperClusterCollection;
   typedef edm::Ref<reco::PFBlockElementSuperClusterCollection> PFBlockElementSuperClusterRef;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h
@@ -10,142 +10,128 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 namespace reco {
-  
+
   /// \brief Track Element.
-  /// 
-  /// this class contains a reference to a PFRecTrack 
+  ///
+  /// this class contains a reference to a PFRecTrack
   class PFBlockElementTrack : public PFBlockElement {
   public:
-
-    PFBlockElementTrack() {} 
+    PFBlockElementTrack() {}
 
     PFBlockElementTrack(const PFRecTrackRef& ref);
 
     PFBlockElement* clone() const override { return new PFBlockElementTrack(*this); }
-    
-    void Dump(std::ostream& out = std::cout, 
-              const char* tab = " " ) const override;
+
+    void Dump(std::ostream& out = std::cout, const char* tab = " ") const override;
 
     /// \return tracktype
-    bool trackType(TrackType trType) const override { 
-      return (trackType_>>trType) & 1; 
-    }
+    bool trackType(TrackType trType) const override { return (trackType_ >> trType) & 1; }
 
     /// \set the trackType
     void setTrackType(TrackType trType, bool value) override {
-      if(value)  trackType_ = trackType_ | (1<<trType);
-      else trackType_ = trackType_ ^ (1<<trType);
+      if (value)
+        trackType_ = trackType_ | (1 << trType);
+      else
+        trackType_ = trackType_ ^ (1 << trType);
     }
-
 
     /// set position at ECAL entrance
-    void setPositionAtECALEntrance(float x, float y, float z) {
-      positionAtECALEntrance_.SetCoordinates(x, y, z);
-    }
- 
+    void setPositionAtECALEntrance(float x, float y, float z) { positionAtECALEntrance_.SetCoordinates(x, y, z); }
 
     /// \return position at ECAL entrance
-    const math::XYZPointF& positionAtECALEntrance() const {
-      return positionAtECALEntrance_;
-    }
-    
+    const math::XYZPointF& positionAtECALEntrance() const { return positionAtECALEntrance_; }
+
     /// \return reference to the corresponding PFRecTrack
     /// please do not use this function after the block production stage!
     const PFRecTrackRef& trackRefPF() const override { return trackRefPF_; }
-    
+
     /// \return reference to the corresponding Track
     const reco::TrackRef& trackRef() const override { return trackRef_; }
 
     /// check if the track is secondary
-    bool isSecondary() const override { 
-      return 
-	trackType(T_FROM_DISP) || 
-	trackType(T_FROM_GAMMACONV) || 
-	trackType(T_FROM_V0); 
+    bool isSecondary() const override {
+      return trackType(T_FROM_DISP) || trackType(T_FROM_GAMMACONV) || trackType(T_FROM_V0);
     }
 
-    bool isPrimary() const override{
-      return trackType(T_TO_DISP); 
-    }
+    bool isPrimary() const override { return trackType(T_TO_DISP); }
 
-    bool isLinkedToDisplacedVertex() const override{
-      return isSecondary() || isPrimary();
-    }
+    bool isLinkedToDisplacedVertex() const override { return isSecondary() || isPrimary(); }
 
     /// \return the displaced vertex associated
-    const PFDisplacedTrackerVertexRef& 
-      displacedVertexRef(TrackType trType) const override {
+    const PFDisplacedTrackerVertexRef& displacedVertexRef(TrackType trType) const override {
       if (trType == T_TO_DISP)
-	return displacedVertexDaughterRef_;
+        return displacedVertexDaughterRef_;
       else if (trType == T_FROM_DISP)
-	return displacedVertexMotherRef_;
-      else return nullPFDispVertex_;
+        return displacedVertexMotherRef_;
+      else
+        return nullPFDispVertex_;
     }
 
     /// \set the ref to the displaced vertex interaction
-    void setDisplacedVertexRef(const PFDisplacedTrackerVertexRef& niref, TrackType trType) override { 
-
+    void setDisplacedVertexRef(const PFDisplacedTrackerVertexRef& niref, TrackType trType) override {
       if (trType == T_TO_DISP) {
-	displacedVertexDaughterRef_ = niref; setTrackType(trType,true);}
-      else if (trType == T_FROM_DISP) {
-      	displacedVertexMotherRef_ = niref; setTrackType(trType,true);}
-    } 
-    
+        displacedVertexDaughterRef_ = niref;
+        setTrackType(trType, true);
+      } else if (trType == T_FROM_DISP) {
+        displacedVertexMotherRef_ = niref;
+        setTrackType(trType, true);
+      }
+    }
+
     /// \return reference to the corresponding Muon
     const reco::MuonRef& muonRef() const override { return muonRef_; }
 
     /// \set reference to the Muon
-    void setMuonRef(const MuonRef& muref) override { 
-      muonRef_=muref; setTrackType(MUON,true); 
+    void setMuonRef(const MuonRef& muref) override {
+      muonRef_ = muref;
+      setTrackType(MUON, true);
     }
 
     /// \return ref to original recoConversion
-    const ConversionRefVector& convRefs() const override {return convRefs_;} 
+    const ConversionRefVector& convRefs() const override { return convRefs_; }
 
     /// \set the ref to  gamma conversion
-    void setConversionRef(const ConversionRef& convRef, TrackType trType) override { 
-      convRefs_.push_back(convRef); setTrackType(trType,true); 
-    } 
+    void setConversionRef(const ConversionRef& convRef, TrackType trType) override {
+      convRefs_.push_back(convRef);
+      setTrackType(trType, true);
+    }
 
     /// \return ref to original V0
-    const VertexCompositeCandidateRef& V0Ref() const override {return v0Ref_;} 
+    const VertexCompositeCandidateRef& V0Ref() const override { return v0Ref_; }
 
     /// \set the ref to  V0
-    void setV0Ref(const VertexCompositeCandidateRef& V0Ref, TrackType trType) override { 
-      v0Ref_ = V0Ref; setTrackType(trType,true); 
-    } 
+    void setV0Ref(const VertexCompositeCandidateRef& V0Ref, TrackType trType) override {
+      v0Ref_ = V0Ref;
+      setTrackType(trType, true);
+    }
 
-
-    
   private:
-
     /// reference to the corresponding track (transient)
-    PFRecTrackRef  trackRefPF_;
+    PFRecTrackRef trackRefPF_;
 
-    /// reference to the corresponding track 
+    /// reference to the corresponding track
     reco::TrackRef trackRef_;
 
-    unsigned int  trackType_;
+    unsigned int trackType_;
 
     /// position at ECAL entrance
-    math::XYZPointF        positionAtECALEntrance_;
-    
+    math::XYZPointF positionAtECALEntrance_;
+
     /// reference to the corresponding pf displaced vertex where this track was created
-    PFDisplacedTrackerVertexRef  displacedVertexMotherRef_;
+    PFDisplacedTrackerVertexRef displacedVertexMotherRef_;
 
     /// reference to the corresponding pf displaced vertex which this track was created
-    PFDisplacedTrackerVertexRef  displacedVertexDaughterRef_;
-                                 
+    PFDisplacedTrackerVertexRef displacedVertexDaughterRef_;
+
     /// reference to the corresponding muon
     reco::MuonRef muonRef_;
 
     /// reference to reco conversion
-    ConversionRefVector convRefs_;      
+    ConversionRefVector convRefs_;
 
     /// reference to V0
     VertexCompositeCandidateRef v0Ref_;
   };
-}
+}  // namespace reco
 
 #endif
-

--- a/DataFormats/ParticleFlowReco/interface/PFBlockFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBlockFwd.h
@@ -2,7 +2,6 @@
 #define ParticleFlowReco_PFBlockFwd_h
 #include <vector>
 
-
 #include "DataFormats/Common/interface/Ref.h"
 /* #include "DataFormats/Common/interface/RefVector.h" */
 /* #include "DataFormats/Common/interface/RefProd.h" */
@@ -11,20 +10,19 @@ namespace reco {
   class PFBlock;
 
   /// collection of PFBlock objects
-  typedef std::vector<PFBlock> PFBlockCollection;  
-  
+  typedef std::vector<PFBlock> PFBlockCollection;
+
   /// collection of PFBlock objects
   typedef std::vector<PFBlock> PFBlockCollection;
-  
+
   /// persistent reference to PFCluster objects
   typedef edm::Ref<PFBlockCollection> PFBlockRef;
 
   /// handle to a block collection
   typedef edm::Handle<PFBlockCollection> PFBlockHandle;
 
-
   /// iterator over a vector of references to PFBlock objects
   /*   typedef PFBlockRefVector::iterator PFBlock_iterator; */
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFBrem.h
+++ b/DataFormats/ParticleFlowReco/interface/PFBrem.h
@@ -7,32 +7,22 @@
 
 namespace reco {
 
-  
   class PFBrem : public PFRecTrack {
-
   public:
- 
-    PFBrem(){}
-    PFBrem(double DP,
-	   double SigmaDP,
-	   unsigned int PointInd): 
-      deltaP_(DP),
-      sigmadeltaP_(SigmaDP),
-      indPoint_(PointInd) {}
-      
-      
-      double DeltaP() const {return deltaP_;}
-      double SigmaDeltaP() const {return sigmadeltaP_;}
-      unsigned int indTrajPoint() const {return indPoint_;}
+    PFBrem() {}
+    PFBrem(double DP, double SigmaDP, unsigned int PointInd)
+        : deltaP_(DP), sigmadeltaP_(SigmaDP), indPoint_(PointInd) {}
+
+    double DeltaP() const { return deltaP_; }
+    double SigmaDeltaP() const { return sigmadeltaP_; }
+    unsigned int indTrajPoint() const { return indPoint_; }
 
   private:
-      
-      double deltaP_;
-      double sigmadeltaP_;
-      unsigned int indPoint_;
+    double deltaP_;
+    double sigmadeltaP_;
+    unsigned int indPoint_;
   };
-  
-  
-}
+
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFCluster.h
+++ b/DataFormats/ParticleFlowReco/interface/PFCluster.h
@@ -6,7 +6,7 @@
 
 #include "Math/GenVector/PositionVector3D.h"
 #include "DataFormats/Math/interface/Point3D.h"
-#include "Rtypes.h" 
+#include "Rtypes.h"
 
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
@@ -18,7 +18,6 @@
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #include <atomic>
 #endif
-
 
 class PFClusterAlgo;
 
@@ -46,156 +45,141 @@ namespace reco {
   */
   class PFCluster : public CaloCluster {
   public:
-
-    typedef std::vector<std::pair<CaloClusterPtr::key_type,edm::Ptr<PFCluster> > > EEtoPSAssociation;
+    typedef std::vector<std::pair<CaloClusterPtr::key_type, edm::Ptr<PFCluster> > > EEtoPSAssociation;
     // Next typedef uses double in ROOT 6 rather than Double32_t due to a bug in ROOT 5,
     // which otherwise would make ROOT5 files unreadable in ROOT6.  This does not increase
     // the size on disk, because due to the bug, double was actually stored on disk in ROOT 5.
     typedef ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<double> > REPPoint;
-  
+
     PFCluster() : CaloCluster(CaloCluster::particleFlow), time_(-99.0), layer_(PFLayer::NONE), color_(1) {}
 
     /// constructor
-    PFCluster(PFLayer::Layer layer, double energy,
-	      double x, double y, double z );
+    PFCluster(PFLayer::Layer layer, double energy, double x, double y, double z);
 
     /// resets clusters parameters
     void reset();
 
     /// reset only hits and fractions
     void resetHitsAndFractions();
-    
+
     /// add a given fraction of the rechit
-    void addRecHitFraction( const reco::PFRecHitFraction& frac);
-    
+    void addRecHitFraction(const reco::PFRecHitFraction& frac);
+
     /// vector of rechit fractions
-    const std::vector< reco::PFRecHitFraction >& recHitFractions() const 
-      { return rechits_; }    
-    
+    const std::vector<reco::PFRecHitFraction>& recHitFractions() const { return rechits_; }
+
     /// set layer
-    void setLayer( PFLayer::Layer layer);
-    
+    void setLayer(PFLayer::Layer layer);
+
     /// cluster layer, see PFLayer.h in this directory
-    PFLayer::Layer  layer() const;
-    
+    PFLayer::Layer layer() const;
+
     /// cluster energy
-    double        energy() const {return energy_;}
+    double energy() const { return energy_; }
 
     /// \return cluster time
-    float time() const {return time_;}
+    float time() const { return time_; }
     /// \return the timing uncertainty
     float timeError() const { return timeError_; }
 
     /// cluster depth
-    double        depth() const {return depth_;}
+    double depth() const { return depth_; }
 
-    void         setTime(float time, float timeError=0) {time_ = time; timeError_ = timeError; }
-    void         setTimeError(float timeError) { timeError_ = timeError; }
-    void         setDepth(double depth) {depth_ = depth;}
-    
-    /// cluster position: rho, eta, phi
-    const REPPoint& positionREP() const {return posrep_;}
-    
-    /// computes posrep_ once and for all
-    void calculatePositionREP() {
-      posrep_.SetCoordinates( position_.Rho(), 
-			      position_.Eta(), 
-			      position_.Phi() ); 
+    void setTime(float time, float timeError = 0) {
+      time_ = time;
+      timeError_ = timeError;
     }
-    
+    void setTimeError(float timeError) { timeError_ = timeError; }
+    void setDepth(double depth) { depth_ = depth; }
+
+    /// cluster position: rho, eta, phi
+    const REPPoint& positionREP() const { return posrep_; }
+
+    /// computes posrep_ once and for all
+    void calculatePositionREP() { posrep_.SetCoordinates(position_.Rho(), position_.Eta(), position_.Phi()); }
+
     /// \todo move to PFClusterTools
-    static double getDepthCorrection(double energy, bool isBelowPS = false,
-				     bool isHadron = false);
-    
+    static double getDepthCorrection(double energy, bool isBelowPS = false, bool isHadron = false);
+
     /// set cluster color (for the PFRootEventManager display)
-    void         setColor(int color) {color_ = color;}
-    
+    void setColor(int color) { color_ = color; }
+
     /// \return color
-    int          color() const {return color_;}
-    
-    
+    int color() const { return color_; }
+
     PFCluster& operator=(const PFCluster&);
-    
+
     /// \todo move to PFClusterTools
-    static void setDepthCorParameters(int mode, 
-				      double a, double b, 
-				      double ap, double bp ) {
+    static void setDepthCorParameters(int mode, double a, double b, double ap, double bp) {
       depthCorMode_ = mode;
-      depthCorA_ = a; 
-      depthCorB_ = b; 
-      depthCorAp_ = ap; 
-      depthCorBp_ = bp; 
-    } 
-    
+      depthCorA_ = a;
+      depthCorB_ = b;
+      depthCorAp_ = ap;
+      depthCorBp_ = bp;
+    }
 
     /// some classes to make this fit into a template footprint
     /// for RecoPFClusterRefCandidate so we can make jets and MET
     /// out of PFClusters.
-    
+
     /// dummy charge
-    double charge() const { return 0;}
+    double charge() const { return 0; }
 
     /// transverse momentum, massless approximation
-    double pt() const { 
-      return (energy() * sin(position_.theta()));
-    }
+    double pt() const { return (energy() * sin(position_.theta())); }
 
     /// angle
-    double theta() const { 
-      return position_.theta();
-    }
-    
+    double theta() const { return position_.theta(); }
+
     /// dummy vertex access
-    math::XYZPoint const & vertex() const { 
-      return dummyVtx_;      
-    }
+    math::XYZPoint const& vertex() const { return dummyVtx_; }
     double vx() const { return vertex().x(); }
     double vy() const { return vertex().y(); }
-    double vz() const { return vertex().z(); }    
+    double vz() const { return vertex().z(); }
 
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
-    template<typename pruner>
+    template <typename pruner>
     void pruneUsing(pruner prune) {
       // remove_if+erase algo applied to both vectors...
-      auto iter = std::find_if_not(rechits_.begin(),rechits_.end(),prune);
-      if (iter==rechits_.end()) return;
-      auto first = iter-rechits_.begin();
-      for (auto i=first; ++i<int(rechits_.size());) {
-          if (prune(rechits_[i])) {
-            rechits_[first] = std::move(rechits_[i]);
-            hitsAndFractions_[first] = std::move(hitsAndFractions_[i]);
-            ++first;
-          }    
+      auto iter = std::find_if_not(rechits_.begin(), rechits_.end(), prune);
+      if (iter == rechits_.end())
+        return;
+      auto first = iter - rechits_.begin();
+      for (auto i = first; ++i < int(rechits_.size());) {
+        if (prune(rechits_[i])) {
+          rechits_[first] = std::move(rechits_[i]);
+          hitsAndFractions_[first] = std::move(hitsAndFractions_[i]);
+          ++first;
+        }
       }
-      rechits_.erase(rechits_.begin()+first,rechits_.end());
-      hitsAndFractions_.erase(hitsAndFractions_.begin()+first,hitsAndFractions_.end());
+      rechits_.erase(rechits_.begin() + first, rechits_.end());
+      hitsAndFractions_.erase(hitsAndFractions_.begin() + first, hitsAndFractions_.end());
     }
 #endif
-    
+
   private:
-    
     /// vector of rechit fractions (transient)
-    std::vector< reco::PFRecHitFraction >  rechits_;
-    
+    std::vector<reco::PFRecHitFraction> rechits_;
+
     /// cluster position: rho, eta, phi (transient)
-    REPPoint            posrep_;
+    REPPoint posrep_;
 
     ///Michalis :Add timing and depth information
     float time_, timeError_;
     double depth_;
 
     /// transient layer
-    PFLayer::Layer layer_; 
+    PFLayer::Layer layer_;
 
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
-     /// \todo move to PFClusterTools
-    static std::atomic<int>    depthCorMode_;
+    /// \todo move to PFClusterTools
+    static std::atomic<int> depthCorMode_;
 
     /// \todo move to PFClusterTools
     static std::atomic<double> depthCorA_;
 
     /// \todo move to PFClusterTools
-    static std::atomic<double> depthCorB_ ;
+    static std::atomic<double> depthCorB_;
 
     /// \todo move to PFClusterTools
     static std::atomic<double> depthCorAp_;
@@ -204,31 +188,29 @@ namespace reco {
     static std::atomic<double> depthCorBp_;
 #else
     /// \todo move to PFClusterTools
-    static int    depthCorMode_;
-    
+    static int depthCorMode_;
+
     /// \todo move to PFClusterTools
     static double depthCorA_;
-    
+
     /// \todo move to PFClusterTools
-    static double depthCorB_ ;
-    
+    static double depthCorB_;
+
     /// \todo move to PFClusterTools
     static double depthCorAp_;
-    
+
     /// \todo move to PFClusterTools
     static double depthCorBp_;
 #endif
-    
+
     static const math::XYZPoint dummyVtx_;
 
     /// color (transient)
-    int                 color_;
+    int color_;
   };
 
-  std::ostream& operator<<(std::ostream& out, 
-                           const PFCluster& cluster);
+  std::ostream& operator<<(std::ostream& out, const PFCluster& cluster);
 
-
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFClusterFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/PFClusterFwd.h
@@ -22,6 +22,6 @@ namespace reco {
 
   /// iterator over a vector of references to PFCluster objects
   typedef PFClusterRefVector::iterator PFCluster_iterator;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFConversion.h
+++ b/DataFormats/ParticleFlowReco/interface/PFConversion.h
@@ -1,7 +1,6 @@
 #ifndef DataFormats_ParticleFlowReco_PFConversion_h
 #define DataFormats_ParticleFlowReco_PFConversion_h
 
-
 #include "DataFormats/EgammaCandidates/interface/ConversionFwd.h"
 #include "DataFormats/EgammaCandidates/interface/Conversion.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecTrackFwd.h"
@@ -19,35 +18,27 @@ namespace reco {
   */
   class PFConversion {
   public:
-
-
- // Default constructor
+    // Default constructor
     PFConversion() {}
-  
 
     //    PFConversion(const reco::ConversionRef c);
     // PFConversion(const reco::ConversionRef c, const std::vector<reco::PFRecTrackRef>&  tr   );
 
-    PFConversion( reco::ConversionRef c);
-    PFConversion( const reco::ConversionRef& c, const std::vector<reco::PFRecTrackRef>&  tr   );
-
+    PFConversion(reco::ConversionRef c);
+    PFConversion(const reco::ConversionRef& c, const std::vector<reco::PFRecTrackRef>& tr);
 
     /// destructor
     ~PFConversion();
 
-    const reco::ConversionRef& originalConversion() const   {return originalConversion_;} 
-    const std::vector<reco::PFRecTrackRef>& pfTracks() const {return pfTracks_ ;} 
-    
+    const reco::ConversionRef& originalConversion() const { return originalConversion_; }
+    const std::vector<reco::PFRecTrackRef>& pfTracks() const { return pfTracks_; }
 
   private:
-
-    void addPFTrack( const reco::PFRecTrackRef & tr ) { pfTracks_.push_back(tr); }    
+    void addPFTrack(const reco::PFRecTrackRef& tr) { pfTracks_.push_back(tr); }
     reco::ConversionRef originalConversion_;
-    std::vector<reco::PFRecTrackRef>  pfTracks_;
-    
-
+    std::vector<reco::PFRecTrackRef> pfTracks_;
   };
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFConversionFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/PFConversionFwd.h
@@ -22,6 +22,6 @@ namespace reco {
 
   /// iterator over a vector of references to PFConversion objects
   typedef PFConversionRefVector::iterator PFConversion_iterator;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFDisplacedTrackerVertex.h
+++ b/DataFormats/ParticleFlowReco/interface/PFDisplacedTrackerVertex.h
@@ -12,35 +12,33 @@
 #include "DataFormats/ParticleFlowReco/interface/PFRecTrackFwd.h"
 
 namespace reco {
-class PFDisplacedTrackerVertex {
+  class PFDisplacedTrackerVertex {
+  public:
+    PFDisplacedTrackerVertex() {}
+    PFDisplacedTrackerVertex(const PFDisplacedVertexRef& nuclref, const PFRecTrackRefVector& pfRecTracks)
+        : displacedVertexRef_(nuclref), pfRecTracks_(pfRecTracks) {}
 
-  public :
-  
-   PFDisplacedTrackerVertex() {}
-   PFDisplacedTrackerVertex( const PFDisplacedVertexRef& nuclref, const PFRecTrackRefVector& pfRecTracks) : displacedVertexRef_(nuclref), pfRecTracks_(pfRecTracks) {}
+    const PFRecTrackRefVector& pfRecTracks() const { return pfRecTracks_; }
 
-     const PFRecTrackRefVector& pfRecTracks() const {return pfRecTracks_;}
+    const bool isIncomingTrack(const reco::PFRecTrackRef originalTrack) const {
+      reco::TrackBaseRef trackBaseRef(originalTrack->trackRef());
+      return displacedVertexRef_->isIncomingTrack(trackBaseRef);
+    }
 
-     const bool isIncomingTrack(const reco::PFRecTrackRef originalTrack) const {
-       reco::TrackBaseRef trackBaseRef(originalTrack->trackRef());
-       return displacedVertexRef_->isIncomingTrack(trackBaseRef);
-     }
+    const bool isOutgoingTrack(const reco::PFRecTrackRef originalTrack) const {
+      reco::TrackBaseRef trackBaseRef(originalTrack->trackRef());
+      return displacedVertexRef_->isOutgoingTrack(trackBaseRef);
+    }
 
-     const bool isOutgoingTrack(const reco::PFRecTrackRef originalTrack) const {
-       reco::TrackBaseRef trackBaseRef(originalTrack->trackRef());
-       return displacedVertexRef_->isOutgoingTrack(trackBaseRef);
-     }
+    const PFDisplacedVertexRef& displacedVertexRef() const { return displacedVertexRef_; }
 
-     const PFDisplacedVertexRef& displacedVertexRef() const {return displacedVertexRef_;}
-
-  private :
+  private:
     // Reference to the initial DisplacedTrackerVertex
     PFDisplacedVertexRef displacedVertexRef_;
-    
+
     // Collection of the secondary PFRecTracks
     PFRecTrackRefVector pfRecTracks_;
-
- };
+  };
 
   /// collection of DisplacedTrackerVertexs
   typedef std::vector<PFDisplacedTrackerVertex> PFDisplacedTrackerVertexCollection;
@@ -48,5 +46,5 @@ class PFDisplacedTrackerVertex {
   typedef edm::Ref<PFDisplacedTrackerVertexCollection> PFDisplacedTrackerVertexRef;
   /// vector of reference to Track in the same collection
   typedef edm::RefVector<PFDisplacedTrackerVertexCollection> PFDisplacedTrackerVertexRefVector;
-}
+}  // namespace reco
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFDisplacedVertex.h
+++ b/DataFormats/ParticleFlowReco/interface/PFDisplacedVertex.h
@@ -1,5 +1,5 @@
 #ifndef DataFormat_ParticleFlowReco_PFDisplacedVertex_h
-#define DataFormat_ParticleFlowReco_PFDisplacedVertex_h 
+#define DataFormat_ParticleFlowReco_PFDisplacedVertex_h
 
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
@@ -11,7 +11,6 @@
 
 namespace reco {
 
-  
   /// \brief Block of elements
   /*!
     \author Maxime Gouzevitch
@@ -20,37 +19,23 @@ namespace reco {
     A DisplacedVertex is an extension of Vector with some additionnal informations
     tracks's hit-vertex distances, tracks types and the expected vertex type.
   */
-  
-  class PFDisplacedVertex : public Vertex{
 
+  class PFDisplacedVertex : public Vertex {
   public:
-
     /// Information on the distance between track's hits and the Vertex
-    typedef std::pair <unsigned int, unsigned int> PFTrackHitInfo;
-    typedef std::pair <PFTrackHitInfo, PFTrackHitInfo> PFTrackHitFullInfo;
+    typedef std::pair<unsigned int, unsigned int> PFTrackHitInfo;
+    typedef std::pair<PFTrackHitInfo, PFTrackHitInfo> PFTrackHitFullInfo;
 
     /// Mass hypothesis enum
-    enum M_Hypo {
-      M_CUSTOM,
-      M_MASSLESS,
-      M_PION,
-      M_KAON,
-      M_LAMBDA
-    };
+    enum M_Hypo { M_CUSTOM, M_MASSLESS, M_PION, M_KAON, M_LAMBDA };
 
-
-    /// Classification of tracks according to the position with respect 
-    /// to the Vertex. A Merged track is a track which has at least 
-    /// two hits before and two hits after the vertex. It may come from 
+    /// Classification of tracks according to the position with respect
+    /// to the Vertex. A Merged track is a track which has at least
+    /// two hits before and two hits after the vertex. It may come from
     /// a primary track merged with a low quality secondary track.
-    enum VertexTrackType {
-      T_NOT_FROM_VERTEX,
-      T_TO_VERTEX,
-      T_FROM_VERTEX,
-      T_MERGED
-    };
+    enum VertexTrackType { T_NOT_FROM_VERTEX, T_TO_VERTEX, T_FROM_VERTEX, T_MERGED };
 
-    /// Classification of vertex according to different parameters such as the 
+    /// Classification of vertex according to different parameters such as the
     /// Number of tracks, the invariant mass etc...
     enum VertexType {
       ANY = 0,
@@ -72,7 +57,6 @@ namespace reco {
       BSM_VERTEX = 100
     };
 
-
     /// Default constructor
     PFDisplacedVertex();
 
@@ -80,160 +64,132 @@ namespace reco {
     PFDisplacedVertex(reco::Vertex&);
 
     /// Add a new track to the vertex
-    void addElement( const TrackBaseRef & r, const Track & refTrack, 
-		     const PFTrackHitFullInfo& hitInfo , 
-		     VertexTrackType trackType = T_NOT_FROM_VERTEX, float w=1.0 );
+    void addElement(const TrackBaseRef& r,
+                    const Track& refTrack,
+                    const PFTrackHitFullInfo& hitInfo,
+                    VertexTrackType trackType = T_NOT_FROM_VERTEX,
+                    float w = 1.0);
 
     /// Clean the tracks collection and all the associated collections
     void cleanTracks();
-    
+
     /// Set the type of this vertex
-    void setVertexType(VertexType vertexType) {vertexType_ = vertexType;}
+    void setVertexType(VertexType vertexType) { vertexType_ = vertexType; }
 
     /// Estimate the direction of the vertex. This function produced a unitary vector.
     /// It is calculated the axis linking the primary vertex of the event pvtx to this vertex
     void setPrimaryDirection(const math::XYZPoint& pvtx);
 
     /// Get the type of this vertex
-    VertexType vertexType(){return vertexType_;}
+    VertexType vertexType() { return vertexType_; }
 
-    const std::vector < PFTrackHitFullInfo > trackHitFullInfos() const
-      {return trackHitFullInfos_;}
+    const std::vector<PFTrackHitFullInfo> trackHitFullInfos() const { return trackHitFullInfos_; }
 
-    const std::vector <VertexTrackType> trackTypes() const
-      {return trackTypes_;}
-
+    const std::vector<VertexTrackType> trackTypes() const { return trackTypes_; }
 
     /// -------- Provide useful information -------- ///
 
     /// If a primary track was identified
-    const bool isTherePrimaryTracks() const 
-    {return isThereKindTracks(T_TO_VERTEX);}
+    const bool isTherePrimaryTracks() const { return isThereKindTracks(T_TO_VERTEX); }
 
     /// If a merged track was identified
-    const bool isThereMergedTracks() const
-    {return isThereKindTracks(T_MERGED);}
+    const bool isThereMergedTracks() const { return isThereKindTracks(T_MERGED); }
 
     /// If a secondary track was identified
-    const bool isThereSecondaryTracks() const
-    {return isThereKindTracks(T_FROM_VERTEX);}
+    const bool isThereSecondaryTracks() const { return isThereKindTracks(T_FROM_VERTEX); }
 
     /// If there is a track which was not identified
-    const bool isThereNotFromVertexTracks() const
-    {return isThereKindTracks(T_NOT_FROM_VERTEX);}
-
-
-
+    const bool isThereNotFromVertexTracks() const { return isThereKindTracks(T_NOT_FROM_VERTEX); }
 
     /// Is a primary track was identified
-    const bool isPrimaryTrack(const reco::TrackBaseRef& originalTrack) const 
-    {
+    const bool isPrimaryTrack(const reco::TrackBaseRef& originalTrack) const {
       size_t itrk = trackPosition(originalTrack);
       return isTrack(itrk, T_TO_VERTEX);
     }
 
     /// Is a secondary track was identified
-    const bool isSecondaryTrack(const reco::TrackBaseRef& originalTrack) const 
-    {
+    const bool isSecondaryTrack(const reco::TrackBaseRef& originalTrack) const {
       size_t itrk = trackPosition(originalTrack);
       return isTrack(itrk, T_FROM_VERTEX);
     }
 
     /// Is a secondary track was identified
-    const bool isMergedTrack(const reco::TrackBaseRef& originalTrack) const 
-    {
+    const bool isMergedTrack(const reco::TrackBaseRef& originalTrack) const {
       size_t itrk = trackPosition(originalTrack);
       return isTrack(itrk, T_MERGED);
     }
 
-    const PFTrackHitFullInfo trackHitFullInfo(const reco::TrackBaseRef& originalTrack) const{
+    const PFTrackHitFullInfo trackHitFullInfo(const reco::TrackBaseRef& originalTrack) const {
       size_t itrk = trackPosition(originalTrack);
       return trackHitFullInfos_[itrk];
     }
 
-
-
     /// Is primary or merged track
-    const bool isIncomingTrack(const reco::TrackBaseRef& originalTrack) const 
-    {
+    const bool isIncomingTrack(const reco::TrackBaseRef& originalTrack) const {
       size_t itrk = trackPosition(originalTrack);
       return isTrack(itrk, T_MERGED) || isTrack(itrk, T_TO_VERTEX);
     }
- 
+
     /// Is secondary track
-    const bool isOutgoingTrack(const reco::TrackBaseRef& originalTrack) const 
-    {
+    const bool isOutgoingTrack(const reco::TrackBaseRef& originalTrack) const {
       size_t itrk = trackPosition(originalTrack);
-      return isTrack(itrk, T_FROM_VERTEX);    
+      return isTrack(itrk, T_FROM_VERTEX);
     }
 
-
     /// Number of primary tracks was identified
-    const int nPrimaryTracks() const
-    {return nKindTracks(T_TO_VERTEX);}
+    const int nPrimaryTracks() const { return nKindTracks(T_TO_VERTEX); }
 
     /// Number of merged tracks was identified
-    const int nMergedTracks() const
-    {return nKindTracks(T_MERGED);}
+    const int nMergedTracks() const { return nKindTracks(T_MERGED); }
 
     /// Number of secondary tracks was identified
-    const int nSecondaryTracks() const
-    {return nKindTracks(T_FROM_VERTEX);}
+    const int nSecondaryTracks() const { return nKindTracks(T_FROM_VERTEX); }
 
     /// Number of tracks which was not identified
-    const int nNotFromVertexTracks() const
-    {return nKindTracks(T_NOT_FROM_VERTEX);}
+    const int nNotFromVertexTracks() const { return nKindTracks(T_NOT_FROM_VERTEX); }
 
     /// Number of tracks
-    const int nTracks() const {return trackTypes_.size();}
+    const int nTracks() const { return trackTypes_.size(); }
 
     //    const reco::VertexTrackType vertexTrackType(reco::TrackBaseRef tkRef) const;
 
     /// Momentum of secondary tracks calculated with a mass hypothesis. Some of those
     /// hypothesis are default: "PI" , "KAON", "LAMBDA", "MASSLESS", "CUSTOM"
     /// the value of custom shall be then provided in mass variable
-    const math::XYZTLorentzVector 
-      secondaryMomentum(std::string massHypo = "PI", 
-			bool useRefitted = true, double mass = 0.0) const 
-      {return momentum(massHypo, T_FROM_VERTEX, useRefitted, mass);}
+    const math::XYZTLorentzVector secondaryMomentum(std::string massHypo = "PI",
+                                                    bool useRefitted = true,
+                                                    double mass = 0.0) const {
+      return momentum(massHypo, T_FROM_VERTEX, useRefitted, mass);
+    }
 
     /// Momentum of primary or merged track calculated with a mass hypothesis.
-    const math::XYZTLorentzVector 
-      primaryMomentum(std::string massHypo = "PI", 
-		      bool useRefitted = true, double mass = 0.0) const
-      {return momentum(massHypo, T_TO_VERTEX, useRefitted, mass);}
-
-
+    const math::XYZTLorentzVector primaryMomentum(std::string massHypo = "PI",
+                                                  bool useRefitted = true,
+                                                  double mass = 0.0) const {
+      return momentum(massHypo, T_TO_VERTEX, useRefitted, mass);
+    }
 
     /// Momentum of secondary tracks calculated with a mass hypothesis. Some of those
     /// hypothesis are default: "PI" , "KAON", "LAMBDA", "MASSLESS", "CUSTOM"
     /// the value of custom shall be then provided in mass variable
-    const math::XYZTLorentzVector 
-      secondaryMomentum(M_Hypo massHypo, 
-			bool useRefitted = true, double mass = 0.0) const 
-      {return momentum(massHypo, T_FROM_VERTEX, useRefitted, mass);}
+    const math::XYZTLorentzVector secondaryMomentum(M_Hypo massHypo, bool useRefitted = true, double mass = 0.0) const {
+      return momentum(massHypo, T_FROM_VERTEX, useRefitted, mass);
+    }
 
     /// Momentum of primary or merged track calculated with a mass hypothesis.
-    const math::XYZTLorentzVector 
-      primaryMomentum(M_Hypo massHypo, 
-		      bool useRefitted = true, double mass = 0.0) const
-      {return momentum(massHypo, T_TO_VERTEX, useRefitted, mass);}
+    const math::XYZTLorentzVector primaryMomentum(M_Hypo massHypo, bool useRefitted = true, double mass = 0.0) const {
+      return momentum(massHypo, T_TO_VERTEX, useRefitted, mass);
+    }
 
-
-    void calcKinematics(){
+    void calcKinematics() {
       defaultPrimaryMomentum_ = momentum("PI", T_TO_VERTEX, false, 0.0);
       defaultSecondaryMomentum_ = momentum("PI", T_FROM_VERTEX, true, 0.0);
     }
 
-
-    const double secondaryPt() const 
-      {return defaultPrimaryMomentum_.Pt();}
+    const double secondaryPt() const { return defaultPrimaryMomentum_.Pt(); }
 
     /// Momentum of primary or merged track calculated with a mass hypothesis.
-    const double primaryPt() const
-      {return defaultSecondaryMomentum_.Pt();}
-
-
+    const double primaryPt() const { return defaultSecondaryMomentum_.Pt(); }
 
     /// Total Charge
     const int totalCharge() const;
@@ -242,29 +198,25 @@ namespace reco {
     /// And secondary momentum
     const double angle_io() const;
 
-
     /// Primary Direction
     const math::XYZVector primaryDirection() const;
 
-
-
-    bool isFake() const { return vertexType_ == FAKE;}
-    bool isLooper() const { return vertexType_ ==  LOOPER;}
-    bool isNucl() const { return vertexType_ ==  NUCL;}
-    bool isNucl_Loose() const { return vertexType_ ==  NUCL_LOOSE;}
-    bool isNucl_Kink() const { return vertexType_ ==   NUCL_KINK;}
-    bool isConv() const { return vertexType_ ==   CONVERSION;}
-    bool isConv_Loose() const { return vertexType_ ==   CONVERSION_LOOSE;}
-    bool isConvertedBremm() const { return vertexType_ ==   CONVERTED_BREMM;}
-    bool isK0() const { return vertexType_ ==   K0_DECAY;}
-    bool isLambda() const { return vertexType_ ==   LAMBDA_DECAY;}
-    bool isLambdaBar() const { return vertexType_ ==   LAMBDABAR_DECAY;}
-    bool isKplus() const { return vertexType_ ==   KPLUS_DECAY;}
-    bool isKminus() const { return vertexType_ ==   KMINUS_DECAY;}
-    bool isKplus_Loose() const { return vertexType_ ==   KPLUS_DECAY_LOOSE;}
-    bool isKminus_Loose() const { return vertexType_ ==   KMINUS_DECAY_LOOSE;}
-    bool isBSM() const { return vertexType_ ==   BSM_VERTEX;}
-
+    bool isFake() const { return vertexType_ == FAKE; }
+    bool isLooper() const { return vertexType_ == LOOPER; }
+    bool isNucl() const { return vertexType_ == NUCL; }
+    bool isNucl_Loose() const { return vertexType_ == NUCL_LOOSE; }
+    bool isNucl_Kink() const { return vertexType_ == NUCL_KINK; }
+    bool isConv() const { return vertexType_ == CONVERSION; }
+    bool isConv_Loose() const { return vertexType_ == CONVERSION_LOOSE; }
+    bool isConvertedBremm() const { return vertexType_ == CONVERTED_BREMM; }
+    bool isK0() const { return vertexType_ == K0_DECAY; }
+    bool isLambda() const { return vertexType_ == LAMBDA_DECAY; }
+    bool isLambdaBar() const { return vertexType_ == LAMBDABAR_DECAY; }
+    bool isKplus() const { return vertexType_ == KPLUS_DECAY; }
+    bool isKminus() const { return vertexType_ == KMINUS_DECAY; }
+    bool isKplus_Loose() const { return vertexType_ == KPLUS_DECAY_LOOSE; }
+    bool isKminus_Loose() const { return vertexType_ == KMINUS_DECAY_LOOSE; }
+    bool isBSM() const { return vertexType_ == BSM_VERTEX; }
 
     std::string nameVertexType() const;
 
@@ -272,7 +224,6 @@ namespace reco {
     void Dump(std::ostream& out = std::cout) const;
 
   private:
-
     /// --------- TOOLS -------------- ///
 
     /// Common tool used to know if there are tracks of a given Kind
@@ -282,46 +233,34 @@ namespace reco {
     const int nKindTracks(VertexTrackType) const;
 
     /// Common tool to calculate the momentum vector of tracks with a given Kind
-    const  math::XYZTLorentzVector momentum(std::string, 
-					    VertexTrackType,
-					    bool, double mass) const;
+    const math::XYZTLorentzVector momentum(std::string, VertexTrackType, bool, double mass) const;
 
     /// Common tool to calculate the momentum vector of tracks with a given Kind
-    const  math::XYZTLorentzVector momentum(M_Hypo massHypo, 
-					    VertexTrackType,
-					    bool, double mass) const;
+    const math::XYZTLorentzVector momentum(M_Hypo massHypo, VertexTrackType, bool, double mass) const;
 
     /// Get the mass with a given hypothesis
     const double getMass2(M_Hypo, double) const;
 
     const size_t trackPosition(const reco::TrackBaseRef& originalTrack) const;
 
-    const bool isTrack(size_t itrk, VertexTrackType T) const {
-      return  trackTypes_[itrk] == T;
-    }
-
+    const bool isTrack(size_t itrk, VertexTrackType T) const { return trackTypes_[itrk] == T; }
 
     /// -------- MEMBERS -------- ///
 
     /// This vertex type
     VertexType vertexType_;
 
-    /// Types of the tracks associated to the vertex 
-    std::vector < VertexTrackType > trackTypes_;
+    /// Types of the tracks associated to the vertex
+    std::vector<VertexTrackType> trackTypes_;
 
     /// Information on the distance between track's hits and the Vertex
-    std::vector < PFTrackHitFullInfo > trackHitFullInfos_;
+    std::vector<PFTrackHitFullInfo> trackHitFullInfos_;
 
     math::XYZVector primaryDirection_;
 
     math::XYZTLorentzVector defaultPrimaryMomentum_;
     math::XYZTLorentzVector defaultSecondaryMomentum_;
-
-    
   };
-}
+}  // namespace reco
 
 #endif
-
-
-  

--- a/DataFormats/ParticleFlowReco/interface/PFDisplacedVertexCandidate.h
+++ b/DataFormats/ParticleFlowReco/interface/PFDisplacedVertexCandidate.h
@@ -1,5 +1,5 @@
 #ifndef DataFormat_ParticleFlowReco_PFDisplacedVertexCandidate_h
-#define DataFormat_ParticleFlowReco_PFDisplacedVertexCandidate_h 
+#define DataFormat_ParticleFlowReco_PFDisplacedVertexCandidate_h
 
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
@@ -10,7 +10,6 @@
 
 namespace reco {
 
-  
   /// \brief A block of tracks linked together
   /*!
     \author Gouzevitch Maxime
@@ -25,42 +24,33 @@ namespace reco {
     ie. points Pm in the middle between two points P1 and P2 belonging 
     to tracks 1 and 2:  P1--Pm--P2
   */
-  
+
   class PFDisplacedVertexCandidate {
-
-
   public:
-
     /// A structure dedicated to describe the link between two tracks
-    /// containing a distance value and a Point where this distance 
+    /// containing a distance value and a Point where this distance
     /// is measurted.
     struct VertexLink {
-      VertexLink()   : distance_(-1), dcaPoint_(0,0,0), test_(0) {}
+      VertexLink() : distance_(-1), dcaPoint_(0, 0, 0), test_(0) {}
       VertexLink(float d, GlobalPoint p, char t) : distance_(d), dcaPoint_(p), test_(t) {}
       float distance_;
       GlobalPoint dcaPoint_;
       char test_;
     };
 
-    /// Test used for the track linkind. For the moment only DCA is used, 
+    /// Test used for the track linkind. For the moment only DCA is used,
     /// but other are possibles like distance between inner hits.
-    enum VertexLinkTest {
-      LINKTEST_DCA,
-      LINKTEST_DUMMY,
-      LINKTEST_ALL
-    };
+    enum VertexLinkTest { LINKTEST_DCA, LINKTEST_DUMMY, LINKTEST_ALL };
 
-    
-    typedef std::map< unsigned int, VertexLink >  VertexLinkData;
+    typedef std::map<unsigned int, VertexLink> VertexLinkData;
 
     /// A type to provide the information about the position of DCA Points
     /// or values of DCA.
-    typedef std::map< float, std::pair<int,int> > DistMap;
-    typedef std::vector< float > DistVector;
+    typedef std::map<float, std::pair<int, int> > DistMap;
+    typedef std::vector<float> DistVector;
 
     /// Default constructor
     PFDisplacedVertexCandidate();
-
 
     /// add a track Reference to the current Candidate
     void addElement(const TrackBaseRef);
@@ -68,18 +58,17 @@ namespace reco {
     /// set a link between elements of indices i1 and i2, of "distance" dist
     /// the link is set in the linkData vector provided as an argument.
     /// As indicated by the 'const' statement, 'this' is not modified.
-    void setLink(unsigned i1, 
-		 unsigned i2, 
-		 const float dist, 
-		 const GlobalPoint& dcaPoint,
-		 const VertexLinkTest test=LINKTEST_DCA );
+    void setLink(unsigned i1,
+                 unsigned i2,
+                 const float dist,
+                 const GlobalPoint& dcaPoint,
+                 const VertexLinkTest test = LINKTEST_DCA);
 
-    
     /// associate 2 elements
-    void associatedElements( const unsigned i,
-                             const VertexLinkData& vertexLinkData, 
-                             std::multimap<float, unsigned>& sortedAssociates,
-			     const VertexLinkTest test=LINKTEST_DCA ) const; 
+    void associatedElements(const unsigned i,
+                            const VertexLinkData& vertexLinkData,
+                            std::multimap<float, unsigned>& sortedAssociates,
+                            const VertexLinkTest test = LINKTEST_DCA) const;
 
     /// -------- Provide useful information -------- ///
 
@@ -92,74 +81,58 @@ namespace reco {
 
     /// \return the vector of DCA useful for DCA
     DistVector distVector() const;
-    
-    /// \return DCA point between two tracks
-    const GlobalPoint dcaPoint( unsigned ie1, unsigned ie2) const;
 
+    /// \return DCA point between two tracks
+    const GlobalPoint dcaPoint(unsigned ie1, unsigned ie2) const;
 
     /// A Vertex Candidate is valid if it has at least two tracks
-    bool isValid() const 
-      {return elements_.size()>1;}    
-
+    bool isValid() const { return elements_.size() > 1; }
 
     /// \return the reference to a given tracks
-    const TrackBaseRef& tref(unsigned ie) const 
-      {return elements_[ie];}
+    const TrackBaseRef& tref(unsigned ie) const { return elements_[ie]; }
 
     /// \return the vector of Refs to tracks
-    const std::vector < TrackBaseRef >& elements() const 
-      {return elements_;}
+    const std::vector<TrackBaseRef>& elements() const { return elements_; }
 
     /// \return the number of tracks associated to the candidate
-    unsigned nTracks() const 
-      {return elements_.size();}
- 
+    unsigned nTracks() const { return elements_.size(); }
 
     /// \return the map of link data
-    const VertexLinkData& vertexLinkData() const 
-      {return vertexLinkData_;}
+    const VertexLinkData& vertexLinkData() const { return vertexLinkData_; }
 
     /// cout function
     void Dump(std::ostream& out = std::cout) const;
 
   private:
-
     /// -------- Internal tools -------- ///
 
     /// \return distance of link between two tracks
-    const float dist( unsigned ie1, unsigned ie2) const;
+    const float dist(unsigned ie1, unsigned ie2) const;
 
     /// test if a link between two tracks is valid: value_link =! -1
-    bool testLink (unsigned ie1, unsigned ie2) const;
+    bool testLink(unsigned ie1, unsigned ie2) const;
 
     /// cout function
-    friend std::ostream& operator<<( std::ostream&, const PFDisplacedVertexCandidate& );
-    
-     
+    friend std::ostream& operator<<(std::ostream&, const PFDisplacedVertexCandidate&);
+
     /// -------- Storage of the information -------- ///
 
     /// Those are the tools from PFBlockAlgo
     /// \return size of linkData_, calculated from the number of elements
     unsigned vertexLinkDataSize() const;
 
-    /// makes the correspondance between a 2d element matrix and 
+    /// makes the correspondance between a 2d element matrix and
     /// the 1D vector which is the most compact way to store the matrix
     bool matrix2vector(unsigned i, unsigned j, unsigned& index) const;
-
 
     /// -------- MEMBERS -------- ///
 
     /// vector of refs to the associated tracks
-    std::vector < TrackBaseRef >          elements_;
+    std::vector<TrackBaseRef> elements_;
 
     /// map of links between tracks
-    VertexLinkData                        vertexLinkData_;
-
-
+    VertexLinkData vertexLinkData_;
   };
-}
+}  // namespace reco
 
 #endif
-
-
-  

--- a/DataFormats/ParticleFlowReco/interface/PFDisplacedVertexCandidateFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/PFDisplacedVertexCandidateFwd.h
@@ -10,14 +10,14 @@ namespace reco {
   class PFDisplacedVertexCandidate;
 
   /// collection of PFDisplacedVertexCandidate objects
-  typedef std::vector<PFDisplacedVertexCandidate> PFDisplacedVertexCandidateCollection;  
-    
+  typedef std::vector<PFDisplacedVertexCandidate> PFDisplacedVertexCandidateCollection;
+
   /// persistent reference to a PFDisplacedVertexCandidate objects
   typedef edm::Ref<PFDisplacedVertexCandidateCollection> PFDisplacedVertexCandidateRef;
 
   /// handle to a PFDisplacedVertexCandidate collection
   typedef edm::Handle<PFDisplacedVertexCandidateCollection> PFDisplacedVertexCandidateHandle;
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFDisplacedVertexFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/PFDisplacedVertexFwd.h
@@ -2,7 +2,6 @@
 #define ParticleFlowReco_PFDisplacedVertexFwd_h
 #include <vector>
 
-
 #include "DataFormats/Common/interface/Ref.h"
 /* #include "DataFormats/Common/interface/RefVector.h" */
 /* #include "DataFormats/Common/interface/RefProd.h" */
@@ -11,17 +10,16 @@ namespace reco {
   class PFDisplacedVertex;
 
   /// collection of PFDisplacedVertex objects
-  typedef std::vector<PFDisplacedVertex> PFDisplacedVertexCollection;    
-  
+  typedef std::vector<PFDisplacedVertex> PFDisplacedVertexCollection;
+
   /// persistent reference to a PFDisplacedVertex objects
   typedef edm::Ref<PFDisplacedVertexCollection> PFDisplacedVertexRef;
 
   /// handle to a PFDisplacedVertex collection
   typedef edm::Handle<PFDisplacedVertexCollection> PFDisplacedVertexHandle;
 
-
   /// iterator over a vector of references to PFDisplacedVertex objects
   /*   typedef PFDisplacedVertexRefVector::iterator PFDisplacedVertex_iterator; */
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFDisplacedVertexSeed.h
+++ b/DataFormats/ParticleFlowReco/interface/PFDisplacedVertexSeed.h
@@ -1,5 +1,5 @@
 #ifndef DataFormat_ParticleFlowReco_PFDisplacedVertexSeed_h
-#define DataFormat_ParticleFlowReco_PFDisplacedVertexSeed_h 
+#define DataFormat_ParticleFlowReco_PFDisplacedVertexSeed_h
 
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
@@ -7,11 +7,8 @@
 #include <vector>
 #include <iostream>
 
-
-
 namespace reco {
 
-  
   /// \brief Block of elements
   /*!
     \author Gouzevitch Maxime
@@ -24,11 +21,9 @@ namespace reco {
     - a set of Refs to tracks.
     - a Point which indicated the approximative position of the vertex.
   */
-  
+
   class PFDisplacedVertexSeed {
-
   public:
-
     /// Default constructor
     PFDisplacedVertexSeed();
 
@@ -40,51 +35,42 @@ namespace reco {
     void reserveElements(size_t);
 
     /// Add a track Ref to the Seed and recalculate the seedPoint with a new dcaPoint
-    /// A weight different from 1 may be assign to the new DCA point 
-    void updateSeedPoint(const GlobalPoint& dcaPoint, const TrackBaseRef, 
-			 const TrackBaseRef, double weight = 1);
+    /// A weight different from 1 may be assign to the new DCA point
+    void updateSeedPoint(const GlobalPoint& dcaPoint, const TrackBaseRef, const TrackBaseRef, double weight = 1);
 
     /// Merge two Seeds if their seed Points are close enough
     void mergeWith(const PFDisplacedVertexSeed& displacedVertex);
 
     /// Check if it is a new Seed
-    bool isEmpty() const {return (elements_.empty());}
+    bool isEmpty() const { return (elements_.empty()); }
 
-    /// \return vector of unique references to tracks 
-    const std::vector <TrackBaseRef>& elements() const 
-      {return elements_;}
+    /// \return vector of unique references to tracks
+    const std::vector<TrackBaseRef>& elements() const { return elements_; }
 
-    const double nTracks() const {return elements_.size();}
+    const double nTracks() const { return elements_.size(); }
 
     /// \return the seedPoint for the vertex fitting
-    const GlobalPoint& seedPoint() const {return seedPoint_;}
+    const GlobalPoint& seedPoint() const { return seedPoint_; }
 
     /// \return the total weight
-    const double totalWeight() const {return totalWeight_;}
+    const double totalWeight() const { return totalWeight_; }
 
     /// cout function
     void Dump(std::ostream& out = std::cout) const;
 
-
   private:
-
-
-    friend std::ostream& operator<<( std::ostream& out, const PFDisplacedVertexSeed& co );    
+    friend std::ostream& operator<<(std::ostream& out, const PFDisplacedVertexSeed& co);
 
     /// --------- MEMBERS ---------- ///
 
     /// Set of tracks refs associated to the seed
-    std::vector< TrackBaseRef>     elements_;
+    std::vector<TrackBaseRef> elements_;
     /// Seed point which indicated the approximative position of the vertex.
-    GlobalPoint                   seedPoint_;
-    /// Total weight of the points used to calculate the seed point. 
+    GlobalPoint seedPoint_;
+    /// Total weight of the points used to calculate the seed point.
     /// Necessary for UpdateSeed Point function
-    float                         totalWeight_;
-
+    float totalWeight_;
   };
-}
+}  // namespace reco
 
 #endif
-
-
-  

--- a/DataFormats/ParticleFlowReco/interface/PFDisplacedVertexSeedFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/PFDisplacedVertexSeedFwd.h
@@ -2,7 +2,6 @@
 #define ParticleFlowReco_PFDisplacedVertexSeedFwd_h
 #include <vector>
 
-
 #include "DataFormats/Common/interface/Ref.h"
 /* #include "DataFormats/Common/interface/RefVector.h" */
 /* #include "DataFormats/Common/interface/RefProd.h" */
@@ -11,18 +10,16 @@ namespace reco {
   class PFDisplacedVertexSeed;
 
   /// collection of PFDisplacedVertexSeed objects
-  typedef std::vector<PFDisplacedVertexSeed> PFDisplacedVertexSeedCollection;  
-  
-  
+  typedef std::vector<PFDisplacedVertexSeed> PFDisplacedVertexSeedCollection;
+
   /// persistent reference to a PFDisplacedVertexSeed objects
   typedef edm::Ref<PFDisplacedVertexSeedCollection> PFDisplacedVertexSeedRef;
 
   /// handle to a PFDisplacedVertexSeed collection
   typedef edm::Handle<PFDisplacedVertexSeedCollection> PFDisplacedVertexSeedHandle;
 
-
   /// iterator over a vector of references to PFDisplacedVertexSeed objects
   /*   typedef PFDisplacedVertexSeedRefVector::iterator PFDisplacedVertexSeed_iterator; */
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFLayer.h
+++ b/DataFormats/ParticleFlowReco/interface/PFLayer.h
@@ -3,7 +3,6 @@
 
 #include "DataFormats/CaloRecHit/interface/CaloID.h"
 
-
 /**\class PFLayer
    \brief layer definition for PFRecHit and PFCluster
    
@@ -19,8 +18,7 @@
 */
 
 class PFLayer {
-
- public:
+public:
   /// constructor
   PFLayer() {}
 
@@ -28,22 +26,23 @@ class PFLayer {
   ~PFLayer() {}
 
   /// layer definition
-  enum Layer {PS2          = -12, 
-              PS1          = -11,
-              ECAL_ENDCAP  = -2,
-              ECAL_BARREL  = -1,
-	      NONE         = 0,
-              HCAL_BARREL1 = 1,
-              HCAL_BARREL2 = 2,
-              HCAL_ENDCAP  = 3,
-              HF_EM        = 11,
-              HF_HAD       = 12,
-              HGCAL        = 13  // HGCal, could be EM or HAD
+  enum Layer {
+    PS2 = -12,
+    PS1 = -11,
+    ECAL_ENDCAP = -2,
+    ECAL_BARREL = -1,
+    NONE = 0,
+    HCAL_BARREL1 = 1,
+    HCAL_BARREL2 = 2,
+    HCAL_ENDCAP = 3,
+    HF_EM = 11,
+    HF_HAD = 12,
+    HGCAL = 13  // HGCal, could be EM or HAD
   };
 
-  static reco::CaloID  toCaloID( Layer layer);
-  
-  static Layer         fromCaloID( const reco::CaloID& id);
+  static reco::CaloID toCaloID(Layer layer);
+
+  static Layer fromCaloID(const reco::CaloID& id);
 };
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFMultilinksTC.h
+++ b/DataFormats/ParticleFlowReco/interface/PFMultilinksTC.h
@@ -1,27 +1,24 @@
 #ifndef __PFMultilinksTC__
 #define __PFMultilinksTC__
 
-// Done by Glowinski & Gouzevitch                                                                                                                                                   
+// Done by Glowinski & Gouzevitch
 
 #include <vector>
 
 namespace reco {
 
-  /// \brief Abstract This class is used by the KDTree Track / Ecal Cluster                                                                                                         
-  /// linker to store all found links.                                                                                                                                              
-  ///                                                                                                                                                                               
+  /// \brief Abstract This class is used by the KDTree Track / Ecal Cluster
+  /// linker to store all found links.
+  ///
   typedef std::vector<std::pair<double, double> > PFMultilinksType;
-  class PFMultiLinksTC
-  {
+  class PFMultiLinksTC {
   public:
-    bool                                        isValid;
-    PFMultilinksType                            linkedClusters;
+    bool isValid;
+    PFMultilinksType linkedClusters;
 
   public:
-    PFMultiLinksTC(bool isvalid = false) : isValid(isvalid)
-      {}
+    PFMultiLinksTC(bool isvalid = false) : isValid(isvalid) {}
   };
-}
-
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFNuclearInteraction.h
+++ b/DataFormats/ParticleFlowReco/interface/PFNuclearInteraction.h
@@ -12,16 +12,15 @@
 #include "DataFormats/ParticleFlowReco/interface/PFRecTrackFwd.h"
 
 namespace reco {
-class PFNuclearInteraction {
+  class PFNuclearInteraction {
+  public:
+    typedef NuclearInteraction::trackRef_iterator trackRef_iterator;
+    typedef PFRecTrackRefVector::const_iterator pfTrackref_iterator;
 
-  public :
-   typedef NuclearInteraction::trackRef_iterator trackRef_iterator;
-   typedef PFRecTrackRefVector::const_iterator   pfTrackref_iterator;
-
-  public :
-  
+  public:
     PFNuclearInteraction() {}
-    PFNuclearInteraction( const NuclearInteractionRef& nuclref, const PFRecTrackRefVector& pfSeconds) : nuclInterRef_(nuclref), pfSecTracks_(pfSeconds) {}
+    PFNuclearInteraction(const NuclearInteractionRef& nuclref, const PFRecTrackRefVector& pfSeconds)
+        : nuclInterRef_(nuclref), pfSecTracks_(pfSeconds) {}
 
     /// \return the base reference to the primary track
     const edm::RefToBase<reco::Track>& primaryTrack() const { return nuclInterRef_->primaryTrack(); }
@@ -37,22 +36,22 @@ class PFNuclearInteraction {
 
     /// \return last iterator over secondary PFRecTracks
     pfTrackref_iterator secPFRecTracks_end() const { return pfSecTracks_.end(); }
-     
+
     /// \return the likelihood
     double likelihood() const { return nuclInterRef_->likelihood(); }
 
     /// \return the initial nuclear interaction
     const NuclearInteractionRef& nuclInterRef() const { return nuclInterRef_; }
-    
+
     int secondaryTracksSize() const { return nuclInterRef_->secondaryTracksSize(); }
-  private :
+
+  private:
     // Reference to the initial NuclearInteraction
     NuclearInteractionRef nuclInterRef_;
-    
+
     // Collection of the secondary PFRecTracks
     PFRecTrackRefVector pfSecTracks_;
-
- };
+  };
 
   /// collection of NuclearInteractions
   typedef std::vector<PFNuclearInteraction> PFNuclearInteractionCollection;
@@ -60,5 +59,5 @@ class PFNuclearInteraction {
   typedef edm::Ref<PFNuclearInteractionCollection> PFNuclearInteractionRef;
   /// vector of reference to Track in the same collection
   typedef edm::RefVector<PFNuclearInteractionCollection> PFNuclearInteractionRefVector;
-}
+}  // namespace reco
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFRecHit.h
+++ b/DataFormats/ParticleFlowReco/interface/PFRecHit.h
@@ -18,7 +18,6 @@
 
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 
-
 namespace reco {
 
   /**\class PFRecHit
@@ -30,7 +29,6 @@ namespace reco {
      Feb 2014 [Michalis: 8 years later!Modifying the class to be able to generalize the neighbours for 3D calorimeters ]
   */
   class PFRecHit {
-
   public:
     using PositionType = GlobalPoint::BasicVectorType;
     using REPPoint = RhoEtaPhi;
@@ -39,73 +37,56 @@ namespace reco {
     using CornersVec = CaloCellGeometry::CornersVec;
 
     struct Neighbours {
-      using Pointer = unsigned int const *;
-      Neighbours(){}
-      Neighbours(Pointer ib, unsigned int n) : b(ib), e(ib+n){}
+      using Pointer = unsigned int const*;
+      Neighbours() {}
+      Neighbours(Pointer ib, unsigned int n) : b(ib), e(ib + n) {}
       Pointer b, e;
-      Pointer begin() const {return b;}
-      Pointer end() const {return e;}
-      unsigned int size() const { return e-b;}
+      Pointer begin() const { return b; }
+      Pointer end() const { return e; }
+      unsigned int size() const { return e - b; }
     };
-    
-    enum {
-      NONE=0
-    };
+
+    enum { NONE = 0 };
     /// default constructor. Sets energy and position to zero
-    PFRecHit(){}
+    PFRecHit() {}
 
-  PFRecHit(std::shared_ptr<const CaloCellGeometry> caloCell, 
-	   unsigned int detId, PFLayer::Layer layer,
-	   float energy) : caloCell_(std::move(caloCell)),  detId_(detId),
-      layer_(layer), energy_(energy){}
+    PFRecHit(std::shared_ptr<const CaloCellGeometry> caloCell, unsigned int detId, PFLayer::Layer layer, float energy)
+        : caloCell_(std::move(caloCell)), detId_(detId), layer_(layer), energy_(energy) {}
 
-
-    
     /// copy
     PFRecHit(const PFRecHit& other) = default;
     PFRecHit(PFRecHit&& other) = default;
-    PFRecHit & operator=(const PFRecHit& other) = default;
-    PFRecHit & operator=(PFRecHit&& other) = default;
-
+    PFRecHit& operator=(const PFRecHit& other) = default;
+    PFRecHit& operator=(PFRecHit&& other) = default;
 
     /// destructor
-    ~PFRecHit()=default;
+    ~PFRecHit() = default;
 
-    void setEnergy( float energy) { energy_ = energy; }
+    void setEnergy(float energy) { energy_ = energy; }
 
-
-    void addNeighbour(short x,short y, short z, unsigned int);
-    unsigned int getNeighbour(short x,short y, short z) const;
-    void setTime( double time) { time_ = time; }
-    void setDepth( int depth) { depth_ = depth; }
+    void addNeighbour(short x, short y, short z, unsigned int);
+    unsigned int getNeighbour(short x, short y, short z) const;
+    void setTime(double time) { time_ = time; }
+    void setDepth(int depth) { depth_ = depth; }
     void clearNeighbours() {
       neighbours_.clear();
       neighbourInfos_.clear();
       neighbours4_ = neighbours8_ = 0;
     }
 
-    Neighbours neighbours4() const {
-      return buildNeighbours(neighbours4_);
-    }
-    Neighbours neighbours8() const {
-	return buildNeighbours(neighbours8_);
-    }
+    Neighbours neighbours4() const { return buildNeighbours(neighbours4_); }
+    Neighbours neighbours8() const { return buildNeighbours(neighbours8_); }
 
-    Neighbours neighbours() const {
-      return buildNeighbours(neighbours_.size());
-    }
+    Neighbours neighbours() const { return buildNeighbours(neighbours_.size()); }
 
-    const std::vector<unsigned short>& neighbourInfos() {
-      return neighbourInfos_;
-    }
-
+    const std::vector<unsigned short>& neighbourInfos() { return neighbourInfos_; }
 
     /// calo cell
-    CaloCellGeometry const & caloCell() const { return  *(caloCell_.get()); }
+    CaloCellGeometry const& caloCell() const { return *(caloCell_.get()); }
     bool hasCaloCell() const { return (caloCell_ != nullptr); }
-    
+
     /// rechit detId
-    unsigned detId() const {return detId_;}
+    unsigned detId() const { return detId_; }
 
     /// rechit layer
     PFLayer::Layer layer() const { return layer_; }
@@ -113,75 +94,68 @@ namespace reco {
     /// rechit energy
     float energy() const { return energy_; }
 
-
     /// timing for cleaned hits
     float time() const { return time_; }
 
     /// depth for segemntation
-    int  depth() const { return depth_; }
+    int depth() const { return depth_; }
 
     /// rechit momentum transverse to the beam, squared.
-    double pt2() const { return energy_ * energy_ *
-	( position().perp2()/ position().mag2());}
-
+    double pt2() const { return energy_ * energy_ * (position().perp2() / position().mag2()); }
 
     /// rechit cell centre x, y, z
     PositionType const& position() const { return caloCell().getPosition().basicVector(); }
-    
-    RhoEtaPhi    const& positionREP() const { return caloCell().repPos(); }
+
+    RhoEtaPhi const& positionREP() const { return caloCell().repPos(); }
 
     /// rechit corners
-    CornersVec  const& getCornersXYZ() const { return caloCell().getCorners(); }    
+    CornersVec const& getCornersXYZ() const { return caloCell().getCorners(); }
 
-    RepCorners  const& getCornersREP() const { return caloCell().getCornersREP();}
- 
- 
+    RepCorners const& getCornersREP() const { return caloCell().getCornersREP(); }
+
     /// comparison >= operator
-    bool operator>=(const PFRecHit& rhs) const { return (energy_>=rhs.energy_); }
+    bool operator>=(const PFRecHit& rhs) const { return (energy_ >= rhs.energy_); }
 
     /// comparison > operator
-    bool operator> (const PFRecHit& rhs) const { return (energy_> rhs.energy_); }
+    bool operator>(const PFRecHit& rhs) const { return (energy_ > rhs.energy_); }
 
     /// comparison <= operator
-    bool operator<=(const PFRecHit& rhs) const { return (energy_<=rhs.energy_); }
+    bool operator<=(const PFRecHit& rhs) const { return (energy_ <= rhs.energy_); }
 
     /// comparison < operator
-    bool operator< (const PFRecHit& rhs) const { return (energy_< rhs.energy_); }
+    bool operator<(const PFRecHit& rhs) const { return (energy_ < rhs.energy_); }
 
- 
   private:
+    Neighbours buildNeighbours(unsigned int n) const { return Neighbours(&neighbours_.front(), n); }
 
-    Neighbours buildNeighbours(unsigned int n) const { return  Neighbours(&neighbours_.front(),n);}
-    
     /// cell geometry
-    std::shared_ptr<const CaloCellGeometry> caloCell_=nullptr;
- 
+    std::shared_ptr<const CaloCellGeometry> caloCell_ = nullptr;
+
     ///cell detid
-    unsigned  int        detId_=0;             
+    unsigned int detId_ = 0;
 
     /// rechit layer
-    PFLayer::Layer      layer_=PFLayer::NONE;
+    PFLayer::Layer layer_ = PFLayer::NONE;
 
-    /// rechit energy 
-    float              energy_=0;
+    /// rechit energy
+    float energy_ = 0;
 
     /// time
-    float              time_=-1;
+    float time_ = -1;
 
     /// depth
-    int      depth_=0;
+    int depth_ = 0;
 
-  
     /// indices to existing neighbours (1 common side)
-    std::vector< unsigned int > neighbours_;
-    std::vector< unsigned short >   neighbourInfos_;
+    std::vector<unsigned int> neighbours_;
+    std::vector<unsigned short> neighbourInfos_;
 
     //Caching the neighbours4/8 per request of Lindsey
     unsigned int neighbours4_ = 0;
     unsigned int neighbours8_ = 0;
   };
 
-}
+}  // namespace reco
 std::ostream& operator<<(std::ostream& out, const reco::PFRecHit& hit);
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h
+++ b/DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h
@@ -4,10 +4,9 @@
 #include <iostream>
 #include <vector>
 
-#include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h" 
+#include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
 
 namespace reco {
-  
 
   /**\class PFRecHitFraction
      \brief Fraction of a PFRecHit 
@@ -18,36 +17,28 @@ namespace reco {
   */
   class PFRecHitFraction {
   public:
-    
     /// default constructor
     PFRecHitFraction() : fraction_(-1) {}
-    
+
     /// constructor
-    PFRecHitFraction(const PFRecHitRef& recHitRef, 
-                     double fraction ) 
-      : recHitRef_(recHitRef), fraction_(fraction) {}
-    
+    PFRecHitFraction(const PFRecHitRef& recHitRef, double fraction) : recHitRef_(recHitRef), fraction_(fraction) {}
+
     /// \return index to rechit
-    const PFRecHitRef& recHitRef() const {return recHitRef_;} 
-    
+    const PFRecHitRef& recHitRef() const { return recHitRef_; }
+
     /// \return energy fraction
-    double fraction() const {return fraction_;}
-    
+    double fraction() const { return fraction_; }
+
   private:
-    
-    /// corresponding rechit 
-    PFRecHitRef  recHitRef_;
-    
+    /// corresponding rechit
+    PFRecHitRef recHitRef_;
+
     /// fraction of the rechit energy owned by the cluster
-    double    fraction_;
-    
+    double fraction_;
   };
 
-  std::ostream& operator<<(std::ostream& out,
-                           const PFRecHitFraction& hit);
-    
-}
+  std::ostream& operator<<(std::ostream& out, const PFRecHitFraction& hit);
 
-
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h
@@ -25,6 +25,6 @@ namespace reco {
 
   /// ref to base vector for dealing with views
   typedef edm::RefToBaseVector<reco::PFRecHit> PFRecHitBaseRefVector;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFRecTrack.h
+++ b/DataFormats/ParticleFlowReco/interface/PFRecTrack.h
@@ -20,26 +20,20 @@ namespace reco {
      \date   July 2006
   */
   class PFRecTrack : public PFTrack {
-
   public:
-    
     /// different types of fitting algorithms
     enum AlgoType_t {
       Unknown = 0,
-      KF = 1, // Kalman filter 
+      KF = 1,  // Kalman filter
       GSF = 2,
-      KF_ELCAND=3// Gaussian sum filter
+      KF_ELCAND = 3  // Gaussian sum filter
     };
 
     PFRecTrack();
-    ~PFRecTrack(){};  
-    PFRecTrack(double charge, 
-               AlgoType_t algoType, 
-               int trackId,
-               const reco::TrackRef& trackref );
-    
-    PFRecTrack(double charge,
-               AlgoType_t algoType);
+    ~PFRecTrack(){};
+    PFRecTrack(double charge, AlgoType_t algoType, int trackId, const reco::TrackRef& trackref);
+
+    PFRecTrack(double charge, AlgoType_t algoType);
 
     /*     PFRecTrack(const PFRecTrack& other); */
 
@@ -47,35 +41,31 @@ namespace reco {
     unsigned int algoType() const { return algoType_; }
 
     /// \return id
-    int trackId() const {return trackId_;}
+    int trackId() const { return trackId_; }
 
     /// \return reference to corresponding track
-    const reco::TrackRef& 
-      trackRef() const {return trackRef_;}
+    const reco::TrackRef& trackRef() const { return trackRef_; }
 
     /// \set the significance of the signed transverse impact parameter
-    void setSTIP(float STIP){STIP_=STIP;}
+    void setSTIP(float STIP) { STIP_ = STIP; }
 
     /// \return the significance of the signed transverse impact parameter
-    const float STIP() const{return STIP_;}
+    const float STIP() const { return STIP_; }
 
   private:
-
     /// type of fitting algorithm used to reconstruct the track
     AlgoType_t algoType_;
-    
+
     /// track id
     int trackId_;
 
     /// reference to corresponding track
-    reco::TrackRef        trackRef_;
+    reco::TrackRef trackRef_;
     float STIP_;
-
   };
 
-  std::ostream& operator<<(std::ostream& out, 
-                           const PFRecTrack& track);
+  std::ostream& operator<<(std::ostream& out, const PFRecTrack& track);
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFRecTrackFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/PFRecTrackFwd.h
@@ -22,6 +22,6 @@ namespace reco {
 
   /// iterator over a vector of references to PFRecTrack objects
   typedef PFRecTrackRefVector::iterator pfRecTrack_iterator;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFSimParticle.h
+++ b/DataFormats/ParticleFlowReco/interface/PFSimParticle.h
@@ -17,22 +17,22 @@ namespace reco {
      \date   July 2006
   */
   class PFSimParticle : public PFTrack {
-
   public:
-
     PFSimParticle();
-  
-    PFSimParticle(double charge, int pdgCode, 
-                  unsigned id, int motherId,
+
+    PFSimParticle(double charge,
+                  int pdgCode,
+                  unsigned id,
+                  int motherId,
                   const std::vector<int>& daughterIds,
-		  unsigned rectrackId,
-		  const std::vector<unsigned>& recHitContrib,
-		  const std::vector<double>&   recHitContribFrac );
+                  unsigned rectrackId,
+                  const std::vector<unsigned>& recHitContrib,
+                  const std::vector<double>& recHitContribFrac);
 
     PFSimParticle(const PFSimParticle& other);
 
     /// \return pdg code
-    int      pdgCode() const {return pdgCode_; }
+    int pdgCode() const { return pdgCode_; }
 
     /// \return id
     unsigned id() const { return id_; }
@@ -41,40 +41,33 @@ namespace reco {
     int motherId() const { return motherId_; }
 
     /// \return vector of daughter ids
-    const std::vector<int>& daughterIds() const {return daughterIds_;}
+    const std::vector<int>& daughterIds() const { return daughterIds_; }
 
-   //accessing MCTruth Matching Info
-    unsigned rectrackId() 
-      const {return rectrackId_;} 
-    std::vector<unsigned> recHitContrib() 
-      const {return recHitContrib_;} 
-    std::vector<double> recHitContribFrac() 
-      const {return recHitContribFrac_;} 
+    //accessing MCTruth Matching Info
+    unsigned rectrackId() const { return rectrackId_; }
+    std::vector<unsigned> recHitContrib() const { return recHitContrib_; }
+    std::vector<double> recHitContribFrac() const { return recHitContribFrac_; }
 
   private:
-    
-    /// pdg code 
-    int       pdgCode_;
+    /// pdg code
+    int pdgCode_;
 
     /// position in particle vector
-    unsigned  id_;
+    unsigned id_;
 
     /// id of mother particle. -1 if no mother
-    int  motherId_;
+    int motherId_;
 
     /// id of daughter particles (can be > 2 in hadron showers)
     std::vector<int> daughterIds_;
 
-    unsigned rectrackId_; 
-    std::vector<unsigned> recHitContrib_; 
-    std::vector<double>   recHitContribFrac_;
-
+    unsigned rectrackId_;
+    std::vector<unsigned> recHitContrib_;
+    std::vector<double> recHitContribFrac_;
   };
 
-  std::ostream& operator<<(std::ostream& out, 
-                           const PFSimParticle& track);
+  std::ostream& operator<<(std::ostream& out, const PFSimParticle& track);
 
-
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFSimParticleFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/PFSimParticleFwd.h
@@ -22,6 +22,6 @@ namespace reco {
 
   /// iterator over a vector of references to PFSimParticle objects
   typedef PFSimParticleRefVector::iterator pfParticle_iterator;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFSuperCluster.h
+++ b/DataFormats/ParticleFlowReco/interface/PFSuperCluster.h
@@ -8,8 +8,6 @@
 #include <iostream>
 #include <vector>
 
-
-
 class PFSuperClusterAlgo;
 
 namespace reco {
@@ -25,33 +23,28 @@ namespace reco {
   */
   class PFSuperCluster : public PFCluster {
   public:
-
-
-    PFSuperCluster(){}
+    PFSuperCluster() {}
 
     /// constructor
     PFSuperCluster(const edm::PtrVector<reco::PFCluster>& clusters);
-   
+
     /// resets clusters parameters
     void reset();
-    
+
     /// vector of clusters
-    const edm::PtrVector< reco::PFCluster >& clusters() const 
-      { return clusters_; }
-    
+    const edm::PtrVector<reco::PFCluster>& clusters() const { return clusters_; }
+
     PFSuperCluster& operator=(const PFSuperCluster&);
-    
+
   private:
-    
     /// vector of clusters
-    edm::PtrVector< reco::PFCluster >  clusters_;
-    
+    edm::PtrVector<reco::PFCluster> clusters_;
+
     friend class ::PFSuperClusterAlgo;
   };
 
-  std::ostream& operator<<(std::ostream& out, 
-                           const PFSuperCluster& cluster);
+  std::ostream& operator<<(std::ostream& out, const PFSuperCluster& cluster);
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFTrack.h
+++ b/DataFormats/ParticleFlowReco/interface/PFTrack.h
@@ -60,91 +60,83 @@ namespace reco {
      \author Renaud Bruneliere
      \date   July 2006
   */
-  class PFTrack
-    {
-    public:
-    
-      PFTrack();
-    
-      PFTrack(double charge);
+  class PFTrack {
+  public:
+    PFTrack();
 
-      PFTrack(const PFTrack& other);
-   
-      /// add a trajectory measurement
-      /// \todo throw an exception if the number of points is too large
-      void addPoint(const reco::PFTrajectoryPoint& trajPt);
+    PFTrack(double charge);
 
-      /// set a trajectory point
-      void setPoint(unsigned int index,
-                    const reco::PFTrajectoryPoint& measurement)
-        { trajectoryPoints_[index] = measurement; }
+    PFTrack(const PFTrack& other);
 
-      /// calculate posrep_ once and for all for each point
-      /// \todo where is posrep? profile and see if it's necessary.
-      void calculatePositionREP();
+    /// add a trajectory measurement
+    /// \todo throw an exception if the number of points is too large
+    void addPoint(const reco::PFTrajectoryPoint& trajPt);
 
-      /// \return electric charge
-      double charge() const { return charge_; }
+    /// set a trajectory point
+    void setPoint(unsigned int index, const reco::PFTrajectoryPoint& measurement) {
+      trajectoryPoints_[index] = measurement;
+    }
 
-      /// \return number of trajectory points
-      unsigned int nTrajectoryPoints() const 
-        { return trajectoryPoints_.size(); }
-    
-      /// \return number of trajectory measurements in tracker
-      unsigned int nTrajectoryMeasurements() const 
-        { return (indexOutermost_ ? indexOutermost_ - indexInnermost_ + 1 : 0); }
+    /// calculate posrep_ once and for all for each point
+    /// \todo where is posrep? profile and see if it's necessary.
+    void calculatePositionREP();
 
-      /// \return vector of trajectory points
-      const std::vector< reco::PFTrajectoryPoint >& trajectoryPoints() const 
-        { return trajectoryPoints_; }
-    
-      /// \return a trajectory point
-      const reco::PFTrajectoryPoint& trajectoryPoint(unsigned index) const 
-        { return trajectoryPoints_[index]; }
+    /// \return electric charge
+    double charge() const { return charge_; }
 
-      /// \return an extrapolated point 
-      /// \todo throw an exception in case of invalid point.
-      const reco::PFTrajectoryPoint& extrapolatedPoint(unsigned layerid) const; 
+    /// \return number of trajectory points
+    unsigned int nTrajectoryPoints() const { return trajectoryPoints_.size(); }
 
-      /// iterator on innermost tracker measurement
-      std::vector< reco::PFTrajectoryPoint >::const_iterator 
-        innermostMeasurement() const
-        { return trajectoryPoints_.begin() + indexInnermost_; }
-    
-      /// iterator on outermost tracker measurement
-      std::vector< reco::PFTrajectoryPoint >::const_iterator 
-        outermostMeasurement() const
-        { return trajectoryPoints_.begin() + indexOutermost_; }
-    
+    /// \return number of trajectory measurements in tracker
+    unsigned int nTrajectoryMeasurements() const {
+      return (indexOutermost_ ? indexOutermost_ - indexInnermost_ + 1 : 0);
+    }
 
-      void         setColor(int color) {color_ = color;}
-    
-      int          color() const { return color_; }    
+    /// \return vector of trajectory points
+    const std::vector<reco::PFTrajectoryPoint>& trajectoryPoints() const { return trajectoryPoints_; }
 
-    protected:
+    /// \return a trajectory point
+    const reco::PFTrajectoryPoint& trajectoryPoint(unsigned index) const { return trajectoryPoints_[index]; }
 
-      /// maximal number of tracking layers
-      static const unsigned int nMaxTrackingLayers_;
-  
-      /// charge
-      double charge_;
+    /// \return an extrapolated point
+    /// \todo throw an exception in case of invalid point.
+    const reco::PFTrajectoryPoint& extrapolatedPoint(unsigned layerid) const;
 
-      /// vector of trajectory points
-      std::vector< reco::PFTrajectoryPoint > trajectoryPoints_;
+    /// iterator on innermost tracker measurement
+    std::vector<reco::PFTrajectoryPoint>::const_iterator innermostMeasurement() const {
+      return trajectoryPoints_.begin() + indexInnermost_;
+    }
 
-      /// index innermost tracker measurement
-      unsigned int indexInnermost_;
+    /// iterator on outermost tracker measurement
+    std::vector<reco::PFTrajectoryPoint>::const_iterator outermostMeasurement() const {
+      return trajectoryPoints_.begin() + indexOutermost_;
+    }
 
-      /// index outermost tracker measurement
-      unsigned int indexOutermost_;
+    void setColor(int color) { color_ = color; }
 
-      /// color (transient)
-      int  color_;
+    int color() const { return color_; }
 
-    };
-    std::ostream& operator<<(std::ostream& out, 
-                             const PFTrack& track);
+  protected:
+    /// maximal number of tracking layers
+    static const unsigned int nMaxTrackingLayers_;
 
-}
+    /// charge
+    double charge_;
+
+    /// vector of trajectory points
+    std::vector<reco::PFTrajectoryPoint> trajectoryPoints_;
+
+    /// index innermost tracker measurement
+    unsigned int indexInnermost_;
+
+    /// index outermost tracker measurement
+    unsigned int indexOutermost_;
+
+    /// color (transient)
+    int color_;
+  };
+  std::ostream& operator<<(std::ostream& out, const PFTrack& track);
+
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFTrajectoryPoint.h
+++ b/DataFormats/ParticleFlowReco/interface/PFTrajectoryPoint.h
@@ -7,7 +7,7 @@
 #include <iosfwd>
 
 #include "DataFormats/Math/interface/Point3D.h"
-#include "Rtypes.h" 
+#include "Rtypes.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 #include "Math/GenVector/PositionVector3D.h"
 
@@ -24,7 +24,6 @@ namespace reco {
      \date   July 2006
   */
   class PFTrajectoryPoint {
-
   public:
     // Next typedef uses double in ROOT 6 rather than Double32_t due to a bug in ROOT 5,
     // which otherwise would make ROOT5 files unreadable in ROOT6.  This does not increase
@@ -35,16 +34,16 @@ namespace reco {
     enum LayerType {
       /// Point of closest approach from beam axis (initial point in the case of PFSimParticle)
       ClosestApproach = 0,
-      BeamPipeOrEndVertex = 1,       
+      BeamPipeOrEndVertex = 1,
       /// Preshower layer 1
-      PS1 = 2,             
+      PS1 = 2,
       /// Preshower layer 2
-      PS2 = 3,             
+      PS2 = 3,
       /// ECAL front face
-      ECALEntrance = 4,  
+      ECALEntrance = 4,
       /// expected maximum of the shower in ECAL, for an e/gamma particle
       /// \todo: add an ECALShowerMaxHadrons
-      ECALShowerMax = 5,   
+      ECALShowerMax = 5,
       /// HCAL front face
       HCALEntrance = 6,
       /// HCAL exit
@@ -58,12 +57,9 @@ namespace reco {
     /// default constructor. Set variables at default dummy values
     PFTrajectoryPoint();
 
-    /// \brief constructor from values. 
+    /// \brief constructor from values.
     /// set detId to -1 if this point is not from a tracker layer
-    PFTrajectoryPoint(int detId,
-                      int layer,
-                      const math::XYZPoint& posxyz, 
-                      const math::XYZTLorentzVector& momentum); 
+    PFTrajectoryPoint(int detId, int layer, const math::XYZPoint& posxyz, const math::XYZTLorentzVector& momentum);
 
     /// copy
     PFTrajectoryPoint(const PFTrajectoryPoint& other);
@@ -71,23 +67,26 @@ namespace reco {
     /// destructor
     virtual ~PFTrajectoryPoint();
 
-
     /// measurement detId
-    int detId() const    { return detId_; }
+    int detId() const { return detId_; }
 
     /// trajectory point layer
-    int layer() const    { return layer_; }
+    int layer() const { return layer_; }
 
-    /// is this point valid ? 
-    bool     isValid() const {
-      if( layer_ == -1 && detId_ == -1 ) return false;
-      else return true;
+    /// is this point valid ?
+    bool isValid() const {
+      if (layer_ == -1 && detId_ == -1)
+        return false;
+      else
+        return true;
     }
 
     /// is this point corresponding to an intersection with a tracker layer ?
     bool isTrackerLayer() const {
-      if(detId_ >= 0 ) return true; 
-      else return false;
+      if (detId_ >= 0)
+        return true;
+      else
+        return false;
     }
 
     /// cartesian position (x, y, z)
@@ -97,41 +96,37 @@ namespace reco {
     const REPPoint& positionREP() const { return posrep_; }
 
     /// calculate posrep_ once and for all
-    void calculatePositionREP() {
-      posrep_.SetCoordinates( posxyz_.Rho(), posxyz_.Eta(), posxyz_.Phi() );
-    }
+    void calculatePositionREP() { posrep_.SetCoordinates(posxyz_.Rho(), posxyz_.Eta(), posxyz_.Phi()); }
 
     /// 4-momenta quadrivector
-    const math::XYZTLorentzVector& momentum() const    { return momentum_; }
+    const math::XYZTLorentzVector& momentum() const { return momentum_; }
 
-    bool   operator==(const reco::PFTrajectoryPoint& other) const;
+    bool operator==(const reco::PFTrajectoryPoint& other) const;
 
     friend std::ostream& operator<<(std::ostream& out, const reco::PFTrajectoryPoint& trajPoint);
 
   private:
-
     /// \brief Is the measurement corresponding to a tracker layer?
     /// or was it obtained by propagating the track to a certain position?
     bool isTrackerLayer_;
 
     /// detid if measurement is corresponding to a tracker layer
-    int detId_;             
+    int detId_;
 
     /// propagated layer
     int layer_;
 
     /// cartesian position (x, y, z)
-    math::XYZPoint          posxyz_;
+    math::XYZPoint posxyz_;
 
     /// position in (rho, eta, phi) base (transient)
-    REPPoint                posrep_;
+    REPPoint posrep_;
 
     /// momentum quadrivector
     math::XYZTLorentzVector momentum_;
-
   };
 
-  std::ostream& operator<<(std::ostream& out, const reco::PFTrajectoryPoint& trajPoint); 
-}
+  std::ostream& operator<<(std::ostream& out, const reco::PFTrajectoryPoint& trajPoint);
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFV0.h
+++ b/DataFormats/ParticleFlowReco/interface/PFV0.h
@@ -13,43 +13,34 @@ class Conversion;
 
 namespace reco {
 
-
   class PFV0 {
   public:
+    /// Default constructor
+    PFV0() {}
 
-
- /// Default constructor
-    PFV0(){}
-    
     PFV0(const reco::VertexCompositeCandidateRef V0,
-	 const std::vector<reco::PFRecTrackRef>&  pftr,
-	 const std::vector<reco::TrackRef>&  tr):
-      originalV0_(V0),pfTracks_(pftr),tracks_(tr)
-      { }
-
-   
-
+         const std::vector<reco::PFRecTrackRef>& pftr,
+         const std::vector<reco::TrackRef>& tr)
+        : originalV0_(V0), pfTracks_(pftr), tracks_(tr) {}
 
     /// destructor
     ~PFV0(){};
 
     /// Ref to the original V0
-    const reco::VertexCompositeCandidateRef& originalV0() const   {return originalV0_;} 
-    
+    const reco::VertexCompositeCandidateRef& originalV0() const { return originalV0_; }
+
     /// Vector of a Refs of PFRecTrack
-    const std::vector<reco::PFRecTrackRef>& pfTracks() const {return pfTracks_ ;} 
+    const std::vector<reco::PFRecTrackRef>& pfTracks() const { return pfTracks_; }
 
     /// Vector of a Refs of Track
-    const std::vector<reco::TrackRef>& Tracks() const {return tracks_;} 
+    const std::vector<reco::TrackRef>& Tracks() const { return tracks_; }
 
   private:
-    
     reco::VertexCompositeCandidateRef originalV0_;
-    std::vector<reco::PFRecTrackRef>  pfTracks_;
-    std::vector<reco::TrackRef>  tracks_;
-
+    std::vector<reco::PFRecTrackRef> pfTracks_;
+    std::vector<reco::TrackRef> tracks_;
   };
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PFV0Fwd.h
+++ b/DataFormats/ParticleFlowReco/interface/PFV0Fwd.h
@@ -22,6 +22,6 @@ namespace reco {
 
   /// iterator over a vector of references to PFV0 objects
   typedef PFV0RefVector::iterator PFV0_iterator;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/ParticleFiltrationDecision.h
+++ b/DataFormats/ParticleFlowReco/interface/ParticleFiltrationDecision.h
@@ -9,7 +9,7 @@
 
 namespace pftools {
 
-/**
+  /**
  * @class ParticleFiltrationDecision
  * @brief Articulates the decision of the ParticleFilter in RecoParticleFlow/PFAnalyses.
  *
@@ -21,41 +21,32 @@ namespace pftools {
  * @date 	Added July 2009
  *
  */
-class ParticleFiltrationDecision {
-public:
-	ParticleFiltrationDecision() {};
-	virtual ~ParticleFiltrationDecision() {};
+  class ParticleFiltrationDecision {
+  public:
+    ParticleFiltrationDecision(){};
+    virtual ~ParticleFiltrationDecision(){};
 
-	/* Bit field to contain user-defined vetos */
-	char vetosPassed_;
+    /* Bit field to contain user-defined vetos */
+    char vetosPassed_;
 
-	/*User-defined string representing who made this */
-	std::string filtrationProvenance_;
+    /*User-defined string representing who made this */
+    std::string filtrationProvenance_;
 
-	enum TestbeamParticle {
-		PION, PROTON_KAON, PROTON, KAON, ELECTRON, MUON, NOISE, OTHER
-	};
+    enum TestbeamParticle { PION, PROTON_KAON, PROTON, KAON, ELECTRON, MUON, NOISE, OTHER };
 
-	/* This event contains a clean... */
-	TestbeamParticle type_;
+    /* This event contains a clean... */
+    TestbeamParticle type_;
+  };
 
-};
+  //Usual framework & EDM incantations
+  typedef std::vector<pftools::ParticleFiltrationDecision> ParticleFiltrationDecisionCollection;
 
-//Usual framework & EDM incantations
-typedef std::vector<pftools::ParticleFiltrationDecision>
-		ParticleFiltrationDecisionCollection;
+  typedef edm::Ref<ParticleFiltrationDecisionCollection> ParticleFiltrationDecisionRef;
+  typedef edm::RefProd<ParticleFiltrationDecisionCollection> ParticleFiltrationDecisionRefProd;
+  typedef edm::RefVector<ParticleFiltrationDecisionCollection> ParticleFiltrationDecisionRefVector;
+  typedef ParticleFiltrationDecisionRefVector::iterator particleFiltrationDecision_iterator;
+  typedef edm::RefToBase<pftools::ParticleFiltrationDecision> ParticleFiltrationDecisionBaseRef;
 
-typedef edm::Ref<ParticleFiltrationDecisionCollection>
-		ParticleFiltrationDecisionRef;
-typedef edm::RefProd<ParticleFiltrationDecisionCollection>
-		ParticleFiltrationDecisionRefProd;
-typedef edm::RefVector<ParticleFiltrationDecisionCollection>
-		ParticleFiltrationDecisionRefVector;
-typedef ParticleFiltrationDecisionRefVector::iterator
-		particleFiltrationDecision_iterator;
-typedef edm::RefToBase<pftools::ParticleFiltrationDecision>
-		ParticleFiltrationDecisionBaseRef;
-
-}
+}  // namespace pftools
 
 #endif /* PARTICLEFILTRATIONDECISION_H_ */

--- a/DataFormats/ParticleFlowReco/interface/PreId.h
+++ b/DataFormats/ParticleFlowReco/interface/PreId.h
@@ -9,33 +9,36 @@
 #include "DataFormats/ParticleFlowReco/interface/PFRecTrackFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
 
-namespace reco
-{
-  class PreId{
+namespace reco {
+  class PreId {
   public:
-        enum MatchingType {
-        NONE=0,
-	ECALMATCH=1,
-	ESMATCH=2,
-	TRACKFILTERING=3,
-	MVA=4,
-	FINAL=10
-    };
+    enum MatchingType { NONE = 0, ECALMATCH = 1, ESMATCH = 2, TRACKFILTERING = 3, MVA = 4, FINAL = 10 };
 
   public:
-  PreId(unsigned nselection=1):trackRef_(reco::TrackRef()),clusterRef_(reco::PFClusterRef()),
-      matchingEop_(-999.),EcalPos_(math::XYZPoint()),
-      meanShower_(math::XYZPoint()),gsfChi2_(-999.),
-      dpt_(0.),chi2Ratio_(0.){
-      matching_.resize(nselection,false);
-      mva_.resize(nselection,-999.);
-      geomMatching_.resize(5,-999.);
+    PreId(unsigned nselection = 1)
+        : trackRef_(reco::TrackRef()),
+          clusterRef_(reco::PFClusterRef()),
+          matchingEop_(-999.),
+          EcalPos_(math::XYZPoint()),
+          meanShower_(math::XYZPoint()),
+          gsfChi2_(-999.),
+          dpt_(0.),
+          chi2Ratio_(0.) {
+      matching_.resize(nselection, false);
+      mva_.resize(nselection, -999.);
+      geomMatching_.resize(5, -999.);
     }
-    void setTrack(reco::TrackRef trackref)     {
-      trackRef_ = trackref;
-    }
+    void setTrack(reco::TrackRef trackref) { trackRef_ = trackref; }
 
-    void setECALMatchingProperties(PFClusterRef clusterRef, const math::XYZPoint & ecalpos, const math::XYZPoint &meanShower, float deta,float dphi,float chieta,float chiphi, float chi2, float eop){
+    void setECALMatchingProperties(PFClusterRef clusterRef,
+                                   const math::XYZPoint &ecalpos,
+                                   const math::XYZPoint &meanShower,
+                                   float deta,
+                                   float dphi,
+                                   float chieta,
+                                   float chiphi,
+                                   float chi2,
+                                   float eop) {
       clusterRef_ = clusterRef;
       EcalPos_ = ecalpos;
       meanShower_ = meanShower;
@@ -44,77 +47,61 @@ namespace reco
       geomMatching_[2] = chieta;
       geomMatching_[3] = chiphi;
       geomMatching_[4] = chi2;
-      matchingEop_= eop;      
+      matchingEop_ = eop;
     }
-    
-    void setTrackProperties(float newchi2, float chi2ratio,float dpt){
-      gsfChi2_=newchi2;
+
+    void setTrackProperties(float newchi2, float chi2ratio, float dpt) {
+      gsfChi2_ = newchi2;
       chi2Ratio_ = chi2ratio;
       dpt_ = dpt;
     }
 
-    void setFinalDecision(bool accepted,unsigned n=0)
-    {
-      setMatching(FINAL,accepted,n);
+    void setFinalDecision(bool accepted, unsigned n = 0) { setMatching(FINAL, accepted, n); }
+    void setECALMatching(bool accepted, unsigned n = 0) { setMatching(ECALMATCH, accepted, n); }
+    void setESMatching(bool accepted, unsigned n = 0) { setMatching(ESMATCH, accepted, n); }
+    void setTrackFiltering(bool accepted, unsigned n = 0) { setMatching(TRACKFILTERING, accepted, n); }
+    void setMVA(bool accepted, float mva, unsigned n = 0) {
+      setMatching(MVA, accepted, n);
+      if (n < mva_.size())
+        mva_[n] = mva;
     }
-    void setECALMatching(bool accepted,unsigned n=0)
-    {
-      setMatching(ECALMATCH,accepted,n);
-    }
-    void setESMatching(bool accepted,unsigned n=0)
-    {
-      setMatching(ESMATCH,accepted,n);
-    }
-    void setTrackFiltering(bool accepted,unsigned n=0)
-    {
-      setMatching(TRACKFILTERING,accepted,n);
-    }
-    void setMVA(bool accepted,float mva,unsigned n=0)
-    {
-      setMatching(MVA,accepted,n);      
-      if(n<mva_.size())
-	mva_[n]=mva;
-    }
-    
-    void setMatching(MatchingType type,bool result,unsigned n=0);
-    bool matching(MatchingType type, unsigned n=0) const
-    {
-      if(n<matching_.size())
-	{
-	  return matching_[n] & (1 << type);
-	}
+
+    void setMatching(MatchingType type, bool result, unsigned n = 0);
+    bool matching(MatchingType type, unsigned n = 0) const {
+      if (n < matching_.size()) {
+        return matching_[n] & (1 << type);
+      }
       return false;
     }
 
     /// Access methods
-    inline const std::vector<float> & geomMatching() const {return geomMatching_;}
-    inline float eopMatch() const {return matchingEop_;}
-    inline float pt() const {return trackRef_->pt();}
-    inline float eta() const {return trackRef_->eta();}
-    inline float kfChi2() const {return trackRef_->normalizedChi2();}
-    inline float kfNHits() const {return trackRef_->found();}
+    inline const std::vector<float> &geomMatching() const { return geomMatching_; }
+    inline float eopMatch() const { return matchingEop_; }
+    inline float pt() const { return trackRef_->pt(); }
+    inline float eta() const { return trackRef_->eta(); }
+    inline float kfChi2() const { return trackRef_->normalizedChi2(); }
+    inline float kfNHits() const { return trackRef_->found(); }
 
-    const math::XYZPoint & ecalPos() const {return EcalPos_;}
-    const math::XYZPoint & meanShower() const {return meanShower_;}
-    
-    inline float chi2Ratio() const {return chi2Ratio_;}
-    inline float gsfChi2() const {return gsfChi2_;}
+    const math::XYZPoint &ecalPos() const { return EcalPos_; }
+    const math::XYZPoint &meanShower() const { return meanShower_; }
 
-    inline bool ecalMatching(unsigned n=0) const {return matching(ECALMATCH,n);}
-    inline bool esMatching(unsigned n=0) const {return matching(ESMATCH,n);}
-    inline bool trackFiltered(unsigned n=0) const {return matching(TRACKFILTERING,n);}
-    inline bool mvaSelected(unsigned n=0) const {return matching(MVA,n);}
-    inline bool preIded(unsigned n=0) const {return matching(FINAL,n);}
+    inline float chi2Ratio() const { return chi2Ratio_; }
+    inline float gsfChi2() const { return gsfChi2_; }
 
-    float mva(unsigned n=0) const;
-    inline float dpt() const {return dpt_;}
-    reco::TrackRef trackRef() const {return trackRef_;}
-    PFClusterRef clusterRef() const {return clusterRef_;}
+    inline bool ecalMatching(unsigned n = 0) const { return matching(ECALMATCH, n); }
+    inline bool esMatching(unsigned n = 0) const { return matching(ESMATCH, n); }
+    inline bool trackFiltered(unsigned n = 0) const { return matching(TRACKFILTERING, n); }
+    inline bool mvaSelected(unsigned n = 0) const { return matching(MVA, n); }
+    inline bool preIded(unsigned n = 0) const { return matching(FINAL, n); }
+
+    float mva(unsigned n = 0) const;
+    inline float dpt() const { return dpt_; }
+    reco::TrackRef trackRef() const { return trackRef_; }
+    PFClusterRef clusterRef() const { return clusterRef_; }
 
   private:
     reco::TrackRef trackRef_;
     PFClusterRef clusterRef_;
-    
 
     std::vector<float> geomMatching_;
     float matchingEop_;
@@ -126,11 +113,11 @@ namespace reco
     float chi2Ratio_;
     std::vector<float> mva_;
 
-//    bool goodpreid_;
-//    bool TkId_;
-//    bool EcalMatching_;
-//    bool PSMatching_;
+    //    bool goodpreid_;
+    //    bool TkId_;
+    //    bool EcalMatching_;
+    //    bool PSMatching_;
     std::vector<int> matching_;
   };
-} 
+}  // namespace reco
 #endif

--- a/DataFormats/ParticleFlowReco/interface/PreIdFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/PreIdFwd.h
@@ -2,10 +2,10 @@
 #define PreIdFwd_H
 #include <vector>
 #include "DataFormats/Common/interface/Ref.h"
-namespace reco{
+namespace reco {
   class PreId;
   typedef std::vector<reco::PreId> PreIdCollection;
   typedef edm::Ref<reco::PreIdCollection> PreIdRef;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/RecoPFClusterRefCandidate.h
+++ b/DataFormats/ParticleFlowReco/interface/RecoPFClusterRefCandidate.h
@@ -7,23 +7,19 @@
 
 namespace reco {
 
+  typedef LeafRefCandidateT RecoPFClusterRefCandidateBase;
 
-  typedef LeafRefCandidateT  RecoPFClusterRefCandidateBase;
-  
-
-  class RecoPFClusterRefCandidate : public  LeafRefCandidateT {
+  class RecoPFClusterRefCandidate : public LeafRefCandidateT {
   public:
     RecoPFClusterRefCandidate() : LeafRefCandidateT() {}
-    RecoPFClusterRefCandidate(PFClusterRef ref, float m) : LeafRefCandidateT( ref, m) {}
-    
+    RecoPFClusterRefCandidate(PFClusterRef ref, float m) : LeafRefCandidateT(ref, m) {}
+
     ~RecoPFClusterRefCandidate() override {}
 
-    RecoPFClusterRefCandidate * clone() const override { return new RecoPFClusterRefCandidate(*this);}
+    RecoPFClusterRefCandidate* clone() const override { return new RecoPFClusterRefCandidate(*this); }
 
-    reco::PFClusterRef pfCluster() const {
-      return getRef<reco::PFClusterRef>();
-    }
+    reco::PFClusterRef pfCluster() const { return getRef<reco::PFClusterRef>(); }
   };
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/RecoPFClusterRefCandidateFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/RecoPFClusterRefCandidateFwd.h
@@ -9,7 +9,7 @@
 namespace reco {
 
   /// collectin of LeafRefCandidateT<reco::TrackRef>  objects
-  typedef std::vector<RecoPFClusterRefCandidate > RecoPFClusterRefCandidateCollection;
+  typedef std::vector<RecoPFClusterRefCandidate> RecoPFClusterRefCandidateCollection;
 
   /// reference to an object in a collection of RecoPFClusterRefCandidate objects
   typedef edm::Ref<RecoPFClusterRefCandidateCollection> RecoPFClusterRefCandidateRef;
@@ -21,18 +21,18 @@ namespace reco {
   typedef edm::RefVector<RecoPFClusterRefCandidateCollection> RecoPFClusterRefCandidateRefVector;
 
   /// iterator over a vector of reference to RecoPFClusterRefCandidate objects
-  typedef RecoPFClusterRefCandidateRefVector::iterator recoPFClusterRefCandidate_iterator;  
+  typedef RecoPFClusterRefCandidateRefVector::iterator recoPFClusterRefCandidate_iterator;
 
   typedef edm::RefToBase<reco::Candidate> RecoPFClusterRefCandidateRefToBase;
 
-/*   /// this needs to go here, it's a class template in the DF/Candidate package */
-/*   /// that requires the knowledge of the DF/TrackReco dictionaries */
-/*   typedef std::vector<RecoPFClusterRefCandidateBase> RecoPFClusterRefCandidateBaseCollection; */
-/*   typedef edm::Ref<RecoPFClusterRefCandidateBaseCollection> RecoPFClusterRefCandidateBaseRef; */
-/*   typedef edm::RefVector<RecoPFClusterRefCandidateBaseCollection> RecoPFClusterRefCandidateBaseRefVector; */
-/*   typedef edm::RefProd<RecoPFClusterRefCandidateBaseCollection> RecoPFClusterRefCandidateBaseRefProd; */
-/*   typedef edm::RefToBase<reco::Candidate> RecoPFClusterRefCandidateBaseRefToBase; */
+  /*   /// this needs to go here, it's a class template in the DF/Candidate package */
+  /*   /// that requires the knowledge of the DF/TrackReco dictionaries */
+  /*   typedef std::vector<RecoPFClusterRefCandidateBase> RecoPFClusterRefCandidateBaseCollection; */
+  /*   typedef edm::Ref<RecoPFClusterRefCandidateBaseCollection> RecoPFClusterRefCandidateBaseRef; */
+  /*   typedef edm::RefVector<RecoPFClusterRefCandidateBaseCollection> RecoPFClusterRefCandidateBaseRefVector; */
+  /*   typedef edm::RefProd<RecoPFClusterRefCandidateBaseCollection> RecoPFClusterRefCandidateBaseRefProd; */
+  /*   typedef edm::RefToBase<reco::Candidate> RecoPFClusterRefCandidateBaseRefToBase; */
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/ParticleFlowReco/src/GsfPFRecTrack.cc
+++ b/DataFormats/ParticleFlowReco/src/GsfPFRecTrack.cc
@@ -1,40 +1,30 @@
 #include "DataFormats/ParticleFlowReco/interface/GsfPFRecTrack.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "Math/GenVector/PositionVector3D.h" 
-#include "DataFormats/Math/interface/Point3D.h" 
+#include "Math/GenVector/PositionVector3D.h"
+#include "DataFormats/Math/interface/Point3D.h"
 // #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace reco;
-GsfPFRecTrack::GsfPFRecTrack(double charge, 
-			     AlgoType_t algoType, 
-			     int trackId, 
-			     const reco::GsfTrackRef& gsftrackRef,
-			     const edm::Ref<std::vector<PFRecTrack> >& kfpfrectrackref) : 
-  PFRecTrack(charge,algoType),
-  gsfTrackRef_(gsftrackRef),
-  kfPFRecTrackRef_(kfpfrectrackref),
-  pfBremVec_(0)
-{
-trackId_=trackId;
+GsfPFRecTrack::GsfPFRecTrack(double charge,
+                             AlgoType_t algoType,
+                             int trackId,
+                             const reco::GsfTrackRef& gsftrackRef,
+                             const edm::Ref<std::vector<PFRecTrack> >& kfpfrectrackref)
+    : PFRecTrack(charge, algoType), gsfTrackRef_(gsftrackRef), kfPFRecTrackRef_(kfpfrectrackref), pfBremVec_(0) {
+  trackId_ = trackId;
 }
 
-void 
-GsfPFRecTrack::addBrem(const reco::PFBrem& brem){
-  pfBremVec_.push_back(brem);
-}
+void GsfPFRecTrack::addBrem(const reco::PFBrem& brem) { pfBremVec_.push_back(brem); }
 
-void 
-GsfPFRecTrack::calculateBremPositionREP() { 
-  for ( unsigned j=0; j<pfBremVec_.size(); ++j ) 
+void GsfPFRecTrack::calculateBremPositionREP() {
+  for (unsigned j = 0; j < pfBremVec_.size(); ++j)
     pfBremVec_[j].calculatePositionREP();
 }
 
-void 
-GsfPFRecTrack::addConvBremPFRecTrackRef(const reco::PFRecTrackRef& pfrectracksref){
+void GsfPFRecTrack::addConvBremPFRecTrackRef(const reco::PFRecTrackRef& pfrectracksref) {
   assoPFRecTrack_.push_back(pfrectracksref);
 }
 
-void 
-GsfPFRecTrack::addConvBremGsfPFRecTrackRef(const reco::GsfPFRecTrackRef& gsfpfrectracksref){
+void GsfPFRecTrack::addConvBremGsfPFRecTrackRef(const reco::GsfPFRecTrackRef& gsfpfrectracksref) {
   assoGsfPFRecTrack_.push_back(gsfpfrectracksref);
 }

--- a/DataFormats/ParticleFlowReco/src/HGCalMultiCluster.cc
+++ b/DataFormats/ParticleFlowReco/src/HGCalMultiCluster.cc
@@ -2,12 +2,7 @@
 
 using namespace reco;
 
-HGCalMultiCluster::HGCalMultiCluster(double energy,
-                                     double x, double y, double z,
-                                     ClusterCollection &thecls) :  
-  PFCluster(PFLayer::HGCAL, energy, x, y, z),
-  myclusters(thecls) {
+HGCalMultiCluster::HGCalMultiCluster(double energy, double x, double y, double z, ClusterCollection &thecls)
+    : PFCluster(PFLayer::HGCAL, energy, x, y, z), myclusters(thecls) {
   assert(!myclusters.empty() && "Invalid cluster collection, zero length.");
-  }
-
-  
+}

--- a/DataFormats/ParticleFlowReco/src/PFBlock.cc
+++ b/DataFormats/ParticleFlowReco/src/PFBlock.cc
@@ -8,174 +8,147 @@
 using namespace std;
 using namespace reco;
 
-
-void PFBlock::addElement(  PFBlockElement* element ) {
-  element->setIndex( elements_.size() );
+void PFBlock::addElement(PFBlockElement* element) {
+  element->setIndex(elements_.size());
   element->lock();
-  elements_.push_back( element->clone() ); 
-
+  elements_.push_back(element->clone());
 }
 
+void PFBlock::bookLinkData() {}
 
-void PFBlock::bookLinkData() {
+void PFBlock::setLink(unsigned i1, unsigned i2, double Dist, LinkData& linkData, LinkTest test) const {
+  assert(test < LINKTEST_ALL);
 
-}
-
-
-
-void PFBlock::setLink(unsigned i1, 
-		      unsigned i2, 
-		      double Dist,
-                      LinkData& linkData, 
-		      LinkTest test) const {
-  
-  assert( test<LINKTEST_ALL );
-  
   unsigned index = 0;
-  bool ok =  matrix2vector(i1,i2, index);
+  bool ok = matrix2vector(i1, i2, index);
 
-  if(ok) {
+  if (ok) {
     //ignore the  -1, -1 pair
-    if ( Dist > -0.5 ) {
-      Link & l = linkData[index];
-      l.distance=Dist;
+    if (Dist > -0.5) {
+      Link& l = linkData[index];
+      l.distance = Dist;
       l.test |= (1 << test);
-    }     else  //delete if existing
-      {
-	LinkData::iterator it = linkData.find(index);
-	if(it!=linkData.end()) linkData.erase(it);
-      }
+    } else  //delete if existing
+    {
+      LinkData::iterator it = linkData.find(index);
+      if (it != linkData.end())
+        linkData.erase(it);
+    }
 
   } else {
     assert(0);
   }
-  
 }
 
-
 // void PFBlock::lock(unsigned i, LinkData& linkData ) const {
-  
+
 //   assert( linkData.size() == linkDataSize() );
-  
+
 //   for(unsigned j=0; j<elements_.size(); j++) {
-    
+
 //     if(i==j) continue;
-    
+
 //     unsigned index = 0;
 //     bool ok =  matrix2vector(i,j, index);
 //     if(ok)
 //       linkData[index] = -1;
-//     else 
+//     else
 //       assert(0);
 //   }
 // }
 
-
-
-void PFBlock::associatedElements( unsigned i, 
-                                  const LinkData& linkData, 
-                                  multimap<double, unsigned>& sortedAssociates,
-                                  PFBlockElement::Type type,
-				  LinkTest test ) const {
-
+void PFBlock::associatedElements(unsigned i,
+                                 const LinkData& linkData,
+                                 multimap<double, unsigned>& sortedAssociates,
+                                 PFBlockElement::Type type,
+                                 LinkTest test) const {
   sortedAssociates.clear();
-  
+
   // i is too large
-  if( i > elements_.size() ) return;
+  if (i > elements_.size())
+    return;
   // assert(i>=0); i >= 0, since i is unsigned
-  
-  for(unsigned ie=0; ie<elements_.size(); ie++) {
-    
+
+  for (unsigned ie = 0; ie < elements_.size(); ie++) {
     // considered element itself
-    if( ie == i ) {
+    if (ie == i) {
       continue;
     }
     // not the right type
-    if(type !=  PFBlockElement::NONE && 
-       elements_[ie].type() != type ) {
+    if (type != PFBlockElement::NONE && elements_[ie].type() != type) {
       continue;
     }
 
     // Order the elements by increasing distance !
 
     unsigned index = 0;
-    if( !matrix2vector(i, ie, index) ) continue;
+    if (!matrix2vector(i, ie, index))
+      continue;
 
-    double c2=-1;
-    LinkData::const_iterator it =  linkData.find(index);
-    if ( it!=linkData.end() && 
-	 ( ( (1 << test ) & it->second.test) !=0 || (test == LINKTEST_ALL) ) ) 
-      c2= it->second.distance;
+    double c2 = -1;
+    LinkData::const_iterator it = linkData.find(index);
+    if (it != linkData.end() && (((1 << test) & it->second.test) != 0 || (test == LINKTEST_ALL)))
+      c2 = it->second.distance;
 
     // not associated
-    if( c2 < 0 ) { 
+    if (c2 < 0) {
       continue;
     }
 
-    sortedAssociates.insert( pair<double,unsigned>(c2, ie) );
+    sortedAssociates.insert(pair<double, unsigned>(c2, ie));
   }
-} 
+}
 
-bool PFBlock::matrix2vector( unsigned iindex, 
-			     unsigned jindex, 
-                             unsigned& index ) const {
-
+bool PFBlock::matrix2vector(unsigned iindex, unsigned jindex, unsigned& index) const {
   unsigned size = elements_.size();
-  if( iindex == jindex || 
-      iindex >=  size ||
-      jindex >=  size ) {
+  if (iindex == jindex || iindex >= size || jindex >= size) {
     return false;
   }
-  
-  if( iindex > jindex ) 
-    std::swap( iindex, jindex);
 
-  
-  index = jindex-iindex-1;
+  if (iindex > jindex)
+    std::swap(iindex, jindex);
 
-  if(iindex>0) {
-    index += iindex*size;
-    unsigned missing = iindex*(iindex+1)/2;
+  index = jindex - iindex - 1;
+
+  if (iindex > 0) {
+    index += iindex * size;
+    unsigned missing = iindex * (iindex + 1) / 2;
     index -= missing;
   }
-  
+
   return true;
 }
 
-
-double PFBlock::dist( unsigned ie1, unsigned ie2,
-                      const LinkData& linkData) const {
-
+double PFBlock::dist(unsigned ie1, unsigned ie2, const LinkData& linkData) const {
   double Dist = -1;
 
   unsigned index = 0;
-  if( !matrix2vector(ie1, ie2, index) ) return Dist;
-  LinkData::const_iterator it =  linkData.find(index);
-  if( it!=linkData.end() ) Dist= it->second.distance;
+  if (!matrix2vector(ie1, ie2, index))
+    return Dist;
+  LinkData::const_iterator it = linkData.find(index);
+  if (it != linkData.end())
+    Dist = it->second.distance;
 
   return Dist;
-
 }
 
+ostream& reco::operator<<(ostream& out, const reco::PFBlock& block) {
+  if (!out)
+    return out;
+  const edm::OwnVector<reco::PFBlockElement>& elements = block.elements();
+  out << "\t--- PFBlock ---  " << endl;
+  out << "\tnumber of elements: " << elements.size() << endl;
 
-ostream& reco::operator<<(  ostream& out, 
-                            const reco::PFBlock& block ) {
-
-  if(! out) return out;
-  const edm::OwnVector< reco::PFBlockElement >& elements = block.elements();
-  out<<"\t--- PFBlock ---  "<<endl;
-  out<<"\tnumber of elements: "<<elements.size()<<endl;
-  
   // Build element label (string) : elid from type, layer and occurence number
   // use stringstream instead of sprintf to concatenate string and integer into string
- 
-  vector <string> elid;
+
+  vector<string> elid;
   string s;
   stringstream ss;
   int iel = 0;
-  int iTK =0;
-  int iGSF =0;
-  int iBREM=0;
+  int iTK = 0;
+  int iGSF = 0;
+  int iBREM = 0;
   int iPS1 = 0;
   int iPS2 = 0;
   int iEE = 0;
@@ -188,169 +161,170 @@ ostream& reco::operator<<(  ostream& out,
   int iHO = 0;
 
   // for each element in turn
-  std::vector<bool> toPrint(elements.size(),static_cast<bool>(true));
-  for(unsigned ie=0; ie<elements.size(); ie++) {
-    
+  std::vector<bool> toPrint(elements.size(), static_cast<bool>(true));
+  for (unsigned ie = 0; ie < elements.size(); ie++) {
     PFBlockElement::Type type = elements[ie].type();
     std::multimap<double, unsigned> ecalElems;
-    switch(type){
-    case PFBlockElement::TRACK:
-      iTK++;
-      ss << "TK" << iTK;
-      break;
-    case PFBlockElement::GSF:
-      iGSF++;
-      ss << "GSF" << iGSF;
-      break;
-    case PFBlockElement::BREM:
-      block.associatedElements( ie,  block.linkData(),
-				ecalElems ,
-				reco::PFBlockElement::ECAL,
-				reco::PFBlock::LINKTEST_ALL );
-      iBREM++;
-      if ( !ecalElems.empty() ) { 
-	ss << "BR" << iBREM;
-      } else {
-	toPrint[ie] = false;
+    switch (type) {
+      case PFBlockElement::TRACK:
+        iTK++;
+        ss << "TK" << iTK;
+        break;
+      case PFBlockElement::GSF:
+        iGSF++;
+        ss << "GSF" << iGSF;
+        break;
+      case PFBlockElement::BREM:
+        block.associatedElements(
+            ie, block.linkData(), ecalElems, reco::PFBlockElement::ECAL, reco::PFBlock::LINKTEST_ALL);
+        iBREM++;
+        if (!ecalElems.empty()) {
+          ss << "BR" << iBREM;
+        } else {
+          toPrint[ie] = false;
+        }
+        break;
+      case PFBlockElement::SC:
+        iSC++;
+        ss << "SC" << iSC;
+        break;
+      default: {
+        PFClusterRef clusterref = elements[ie].clusterRef();
+        int layer = clusterref->layer();
+        switch (layer) {
+          case PFLayer::PS1:
+            iPS1++;
+            ss << "PV" << iPS1;
+            break;
+          case PFLayer::PS2:
+            iPS2++;
+            ss << "PH" << iPS2;
+            break;
+          case PFLayer::ECAL_ENDCAP:
+            iEE++;
+            ss << "EE" << iEE;
+            break;
+          case PFLayer::ECAL_BARREL:
+            iEB++;
+            ss << "EB" << iEB;
+            break;
+          case PFLayer::HCAL_ENDCAP:
+            iHE++;
+            ss << "HE" << iHE;
+            break;
+          case PFLayer::HCAL_BARREL1:
+            iHB++;
+            ss << "HB" << iHB;
+            break;
+          case PFLayer::HCAL_BARREL2:
+            iHO++;
+            ss << "HO" << iHO;
+            break;
+          case PFLayer::HF_EM:
+            iHFEM++;
+            ss << "FE" << iHFEM;
+            break;
+          case PFLayer::HF_HAD:
+            iHFHAD++;
+            ss << "FH" << iHFHAD;
+            break;
+          default:
+            iel++;
+            ss << "??" << iel;
+            break;
+        }
+        break;
       }
-      break;    
-    case PFBlockElement::SC:
-      iSC++;
-      ss << "SC" << iSC;
-      break;
-    default:{
-      PFClusterRef clusterref = elements[ie].clusterRef();
-      int layer = clusterref->layer();
-      switch (layer){
-      case PFLayer::PS1:
-        iPS1++;
-        ss << "PV" << iPS1;
-        break;
-      case PFLayer::PS2:
-        iPS2++;
-        ss << "PH" << iPS2;
-        break;
-      case PFLayer::ECAL_ENDCAP:
-        iEE++;
-        ss << "EE" << iEE;
-        break;
-      case PFLayer::ECAL_BARREL:
-        iEB++;
-        ss << "EB" << iEB;
-        break;
-      case PFLayer::HCAL_ENDCAP:
-        iHE++;
-        ss << "HE" << iHE;
-        break;
-      case PFLayer::HCAL_BARREL1:
-        iHB++;
-        ss << "HB" << iHB;
-        break;
-      case PFLayer::HCAL_BARREL2:
-        iHO++;
-        ss << "HO" << iHO;
-        break;
-      case PFLayer::HF_EM:
-        iHFEM++;
-        ss << "FE" << iHFEM;
-        break;
-      case PFLayer::HF_HAD:
-        iHFHAD++;
-        ss << "FH" << iHFHAD;
-	break;
-      default:
-        iel++;   
-        ss << "??" << iel;
-        break;
-      }
-      break;
-    }
     }
     s = ss.str();
-    elid.push_back( s );
+    elid.push_back(s);
     // clear stringstream
     ss.str("");
 
-    if ( toPrint[ie] ) out<<"\t"<< s <<" "<<elements[ie] <<endl;
+    if (toPrint[ie])
+      out << "\t" << s << " " << elements[ie] << endl;
   }
-  
-  out<<endl;
+
+  out << endl;
 
   int width = 6;
-  if( !block.linkData().empty() ) {
-    out<<endl<<"\tlink data (distance x 1000): "<<endl;
-    out<<setiosflags(ios::right);
-    out<<"\t" << setw(width) << " ";
-    for(unsigned ie=0; ie<elid.size(); ie++) 
-      if ( toPrint[ie] ) out <<setw(width)<< elid[ie];
-    out<<endl;  
-    out<<setiosflags(ios::fixed);
-    out<<setprecision(1);      
-  
-    for(unsigned i=0; i<block.elements().size(); i++) {
-      if ( !toPrint[i] ) continue;
-      out<<"\t";
-      out <<setw(width) << elid[i];
-      for(unsigned j=0; j<block.elements().size(); j++) {
-	if ( !toPrint[j] ) continue;
-        double Dist = block.dist(i,j, block.linkData());//,PFBlock::LINKTEST_ALL);
+  if (!block.linkData().empty()) {
+    out << endl << "\tlink data (distance x 1000): " << endl;
+    out << setiosflags(ios::right);
+    out << "\t" << setw(width) << " ";
+    for (unsigned ie = 0; ie < elid.size(); ie++)
+      if (toPrint[ie])
+        out << setw(width) << elid[ie];
+    out << endl;
+    out << setiosflags(ios::fixed);
+    out << setprecision(1);
 
-	// out<<setw(width)<< Dist*1000.;
-	if (Dist > -0.5) out<<setw(width)<< Dist*1000.; 
-        else  out <<setw(width)<< " ";
+    for (unsigned i = 0; i < block.elements().size(); i++) {
+      if (!toPrint[i])
+        continue;
+      out << "\t";
+      out << setw(width) << elid[i];
+      for (unsigned j = 0; j < block.elements().size(); j++) {
+        if (!toPrint[j])
+          continue;
+        double Dist = block.dist(i, j, block.linkData());  //,PFBlock::LINKTEST_ALL);
+
+        // out<<setw(width)<< Dist*1000.;
+        if (Dist > -0.5)
+          out << setw(width) << Dist * 1000.;
+        else
+          out << setw(width) << " ";
       }
-      out<<endl;
+      out << endl;
     }
 
-        
-    out<<endl<<"\tlink data (distance x 1000) for tracking links : "<<endl;
-    out<<setiosflags(ios::right);
-    out<<"\t" << setw(width) << " ";
-    for(unsigned ie=0; ie<elid.size(); ie++) 
-      if ( toPrint[ie] && 
-	   ( block.elements()[ie].type() == PFBlockElement::TRACK ||
-	     block.elements()[ie].type() == PFBlockElement::GSF )) 
-	out <<setw(width)<< elid[ie];
-    out<<endl;  
-    out<<setiosflags(ios::fixed);
-    out<<setprecision(1);      
-  
-    for(unsigned i=0; i<block.elements().size(); i++) {
-      if ( !toPrint[i] || 
-	   (block.elements()[i].type() != PFBlockElement::TRACK &&
-	    block.elements()[i].type() != PFBlockElement::GSF )) continue;
-      out<<"\t";
-      out <<setw(width) << elid[i];
-      for(unsigned j=0; j<block.elements().size(); j++) {
-	if ( !toPrint[j] || 
-	     (block.elements()[j].type() != PFBlockElement::TRACK &&
-	      block.elements()[j].type() != PFBlockElement::GSF )) continue;
-	double Dist = block.dist(i,j, block.linkData());//,PFBlock::LINKTEST_ALL);
+    out << endl << "\tlink data (distance x 1000) for tracking links : " << endl;
+    out << setiosflags(ios::right);
+    out << "\t" << setw(width) << " ";
+    for (unsigned ie = 0; ie < elid.size(); ie++)
+      if (toPrint[ie] &&
+          (block.elements()[ie].type() == PFBlockElement::TRACK || block.elements()[ie].type() == PFBlockElement::GSF))
+        out << setw(width) << elid[ie];
+    out << endl;
+    out << setiosflags(ios::fixed);
+    out << setprecision(1);
 
-	// out<<setw(width)<< Dist*1000.;
-	if (Dist > -0.5) out<<setw(width)<< Dist*1000.; 
-	else  out <<setw(width)<< " ";
+    for (unsigned i = 0; i < block.elements().size(); i++) {
+      if (!toPrint[i] ||
+          (block.elements()[i].type() != PFBlockElement::TRACK && block.elements()[i].type() != PFBlockElement::GSF))
+        continue;
+      out << "\t";
+      out << setw(width) << elid[i];
+      for (unsigned j = 0; j < block.elements().size(); j++) {
+        if (!toPrint[j] ||
+            (block.elements()[j].type() != PFBlockElement::TRACK && block.elements()[j].type() != PFBlockElement::GSF))
+          continue;
+        double Dist = block.dist(i, j, block.linkData());  //,PFBlock::LINKTEST_ALL);
+
+        // out<<setw(width)<< Dist*1000.;
+        if (Dist > -0.5)
+          out << setw(width) << Dist * 1000.;
+        else
+          out << setw(width) << " ";
       }
-      out<<endl;
+      out << endl;
     }
-    
-    out<<setprecision(3);  
-    out<<resetiosflags(ios::right|ios::fixed);
 
+    out << setprecision(3);
+    out << resetiosflags(ios::right | ios::fixed);
+
+  } else {
+    out << "\tno links." << endl;
   }
-  else {
-    out<<"\tno links."<<endl;
-  }
-  
+
   return out;
 }
- 
- 
+
 unsigned PFBlock::linkDataSize() const {
   unsigned n = elements_.size();
-  
+
   // number of possible undirected links between n elements.
   // reflective links impossible.
- 
-  return n*(n-1)/2; 
+
+  return n * (n - 1) / 2;
 }

--- a/DataFormats/ParticleFlowReco/src/PFBlockElement.cc
+++ b/DataFormats/ParticleFlowReco/src/PFBlockElement.cc
@@ -1,17 +1,16 @@
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElement.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementGsfTrack.h"
-#include "DataFormats/ParticleFlowReco/interface/PFBlockElementBrem.h"     
+#include "DataFormats/ParticleFlowReco/interface/PFBlockElementBrem.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementSuperCluster.h"
 
 const reco::TrackRef reco::PFBlockElement::nullTrack_ = reco::TrackRef();
 const reco::PFRecTrackRef reco::PFBlockElement::nullPFRecTrack_ = reco::PFRecTrackRef();
 const reco::PFClusterRef reco::PFBlockElement::nullPFCluster_ = reco::PFClusterRef();
-const reco::PFDisplacedTrackerVertexRef reco::PFBlockElement::nullPFDispVertex_ = 
-  reco::PFDisplacedTrackerVertexRef();
+const reco::PFDisplacedTrackerVertexRef reco::PFBlockElement::nullPFDispVertex_ = reco::PFDisplacedTrackerVertexRef();
 const reco::ConversionRefVector reco::PFBlockElement::nullConv_ = reco::ConversionRefVector();
-const reco::MuonRef  reco::PFBlockElement::nullMuon_ = reco::MuonRef();
+const reco::MuonRef reco::PFBlockElement::nullMuon_ = reco::MuonRef();
 const reco::VertexCompositeCandidateRef reco::PFBlockElement::nullVertex_ = reco::VertexCompositeCandidateRef();
 
 using namespace reco;
@@ -22,79 +21,70 @@ using namespace reco;
 //   return instanceCounter_;
 // }
 
-void PFBlockElement::Dump(std::ostream& out, 
-                          const char* pad) const {
-  if(!out) return;
-  out<<pad<<"base element";
+void PFBlockElement::Dump(std::ostream& out, const char* pad) const {
+  if (!out)
+    return;
+  out << pad << "base element";
 }
 
-std::ostream& reco::operator<<( std::ostream& out, 
-                                const PFBlockElement& element ) {
-  
-  if(! out) return out;
-  
-  out<<"element "<<element.index()<<"- type "<<element.type()<<" ";
-  
+std::ostream& reco::operator<<(std::ostream& out, const PFBlockElement& element) {
+  if (!out)
+    return out;
+
+  out << "element " << element.index() << "- type " << element.type() << " ";
+
   try {
-    switch(element.type()) {
-    case PFBlockElement::TRACK:
-      {
-        const reco::PFBlockElementTrack& et =
-          dynamic_cast<const reco::PFBlockElementTrack &>( element );
+    switch (element.type()) {
+      case PFBlockElement::TRACK: {
+        const reco::PFBlockElementTrack& et = dynamic_cast<const reco::PFBlockElementTrack&>(element);
         et.Dump(out);
-        if( et.trackType(PFBlockElement::T_FROM_DISP) ) out<<" from displaced;";
-        if( et.trackType(PFBlockElement::T_TO_DISP) ) out<<" to displaced;";
-	if( et.trackType(PFBlockElement::T_FROM_GAMMACONV) ) out<<" from gammaconv;";  
-	if( et.trackType(PFBlockElement::T_FROM_V0) ) out<<" from v0 decay;";  
+        if (et.trackType(PFBlockElement::T_FROM_DISP))
+          out << " from displaced;";
+        if (et.trackType(PFBlockElement::T_TO_DISP))
+          out << " to displaced;";
+        if (et.trackType(PFBlockElement::T_FROM_GAMMACONV))
+          out << " from gammaconv;";
+        if (et.trackType(PFBlockElement::T_FROM_V0))
+          out << " from v0 decay;";
         break;
       }
-    case PFBlockElement::ECAL:
-    case PFBlockElement::HCAL:
-    case PFBlockElement::HGCAL:
-    case PFBlockElement::HO: 
-    case PFBlockElement::HFEM:
-    case PFBlockElement::HFHAD:
-    case PFBlockElement::PS1:
-    case PFBlockElement::PS2:    
-      {
-        const reco::PFBlockElementCluster& ec =
-          dynamic_cast<const reco::PFBlockElementCluster &>( element );
+      case PFBlockElement::ECAL:
+      case PFBlockElement::HCAL:
+      case PFBlockElement::HGCAL:
+      case PFBlockElement::HO:
+      case PFBlockElement::HFEM:
+      case PFBlockElement::HFHAD:
+      case PFBlockElement::PS1:
+      case PFBlockElement::PS2: {
+        const reco::PFBlockElementCluster& ec = dynamic_cast<const reco::PFBlockElementCluster&>(element);
         ec.Dump(out);
         break;
       }
-    case PFBlockElement::GSF:
-      {
-	const reco::PFBlockElementGsfTrack& eg =
-          dynamic_cast<const reco::PFBlockElementGsfTrack &>( element );
+      case PFBlockElement::GSF: {
+        const reco::PFBlockElementGsfTrack& eg = dynamic_cast<const reco::PFBlockElementGsfTrack&>(element);
         eg.Dump(out);
-	out<<" from gsf;";
-	break;
+        out << " from gsf;";
+        break;
       }
-    case PFBlockElement::BREM:
-      {
-	const reco::PFBlockElementBrem& em =
-          dynamic_cast<const reco::PFBlockElementBrem &>( element );
+      case PFBlockElement::BREM: {
+        const reco::PFBlockElementBrem& em = dynamic_cast<const reco::PFBlockElementBrem&>(element);
         em.Dump(out);
-	out<<" from brem;";
-	break;
+        out << " from brem;";
+        break;
       }
-    case PFBlockElement::SC:
-      {
-	const reco::PFBlockElementSuperCluster& sc =
-          dynamic_cast<const reco::PFBlockElementSuperCluster &>( element );
+      case PFBlockElement::SC: {
+        const reco::PFBlockElementSuperCluster& sc = dynamic_cast<const reco::PFBlockElementSuperCluster&>(element);
         sc.Dump(out);
-	out<<" from SuperCluster;";
-	break;
+        out << " from SuperCluster;";
+        break;
       }
-    default:
-      out<<" unknown type"<<std::endl;
-      break;
+      default:
+        out << " unknown type" << std::endl;
+        break;
     }
+  } catch (std::exception& err) {
+    out << err.what() << std::endl;
   }
-  catch( std::exception& err) {
-    out<<err.what()<<std::endl;
-  }
-  
+
   return out;
 }
-

--- a/DataFormats/ParticleFlowReco/src/PFBlockElementBrem.cc
+++ b/DataFormats/ParticleFlowReco/src/PFBlockElementBrem.cc
@@ -1,6 +1,6 @@
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementBrem.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecTrack.h"
-#include "DataFormats/Common/interface/Ref.h" 
+#include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/ParticleFlowReco/interface/PFTrajectoryPoint.h"
 
@@ -9,46 +9,39 @@
 using namespace reco;
 using namespace std;
 
-
-PFBlockElementBrem::PFBlockElementBrem(const GsfPFRecTrackRef& gsfref, const double DeltaP, 
-				       const double SigmaDeltaP, const unsigned int indTrajPoint):
-  PFBlockElement( BREM ),
-  GsftrackRefPF_( gsfref ), 
-  GsftrackRef_( gsfref->gsfTrackRef() ),
-  deltaP_(DeltaP),
-  sigmadeltaP_(SigmaDeltaP),
-  indPoint_(indTrajPoint){
-
-  const reco::PFTrajectoryPoint& atECAL 
-    = ((*GsftrackRefPF()).PFRecBrem()[(indPoint_-2)]).extrapolatedPoint( reco::PFTrajectoryPoint::ECALEntrance );
-  if( atECAL.isValid() ) 
-    positionAtECALEntrance_.SetCoordinates( atECAL.position().x(),
-					    atECAL.position().y(),
-					    atECAL.position().z() );
-   
+PFBlockElementBrem::PFBlockElementBrem(const GsfPFRecTrackRef& gsfref,
+                                       const double DeltaP,
+                                       const double SigmaDeltaP,
+                                       const unsigned int indTrajPoint)
+    : PFBlockElement(BREM),
+      GsftrackRefPF_(gsfref),
+      GsftrackRef_(gsfref->gsfTrackRef()),
+      deltaP_(DeltaP),
+      sigmadeltaP_(SigmaDeltaP),
+      indPoint_(indTrajPoint) {
+  const reco::PFTrajectoryPoint& atECAL =
+      ((*GsftrackRefPF()).PFRecBrem()[(indPoint_ - 2)]).extrapolatedPoint(reco::PFTrajectoryPoint::ECALEntrance);
+  if (atECAL.isValid())
+    positionAtECALEntrance_.SetCoordinates(atECAL.position().x(), atECAL.position().y(), atECAL.position().z());
 }
 
+void PFBlockElementBrem::Dump(ostream& out, const char* tab) const {
+  if (!out)
+    return;
 
-void PFBlockElementBrem::Dump(ostream& out, 
-                               const char* tab ) const {
-  
-  if(! out ) return;
- 
-  if( !GsftrackRefPF_.isNull() ) {
-
+  if (!GsftrackRefPF_.isNull()) {
     double charge = 0.;
-    double dp =  deltaP_;
+    double dp = deltaP_;
     double sigmadp = sigmadeltaP_;
-    int indextrj = (indPoint_-2);
-    out<<setprecision(0);
-    out<<tab<<setw(7)<<"charge="<<setw(3)<<charge;
-    out<<setprecision(3);
-    out<<setiosflags(ios::right);
-    out<<setiosflags(ios::fixed);
-    out<<", DeltaP=  "<< dp;
-    out<<", SigmaDeltaP=  " << sigmadp;
-    out<<", Traj Point=  " << indextrj;
-    out<<resetiosflags(ios::right|ios::fixed); }
-
+    int indextrj = (indPoint_ - 2);
+    out << setprecision(0);
+    out << tab << setw(7) << "charge=" << setw(3) << charge;
+    out << setprecision(3);
+    out << setiosflags(ios::right);
+    out << setiosflags(ios::fixed);
+    out << ", DeltaP=  " << dp;
+    out << ", SigmaDeltaP=  " << sigmadp;
+    out << ", Traj Point=  " << indextrj;
+    out << resetiosflags(ios::right | ios::fixed);
+  }
 }
-

--- a/DataFormats/ParticleFlowReco/src/PFBlockElementCluster.cc
+++ b/DataFormats/ParticleFlowReco/src/PFBlockElementCluster.cc
@@ -1,6 +1,6 @@
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
-#include "DataFormats/Common/interface/Ref.h" 
+#include "DataFormats/Common/interface/Ref.h"
 #include "Math/Vector3D.h"
 
 #include <iomanip>
@@ -8,29 +8,28 @@
 using namespace reco;
 using namespace std;
 
-void PFBlockElementCluster::Dump(ostream& out, 
-                                 const char* tab ) const {
-  
-  if(! out ) return;
+void PFBlockElementCluster::Dump(ostream& out, const char* tab) const {
+  if (!out)
+    return;
   // need to convert the math::XYZPoint data member of the PFCluster class=
-  // to a displacement vector: 
-  ROOT::Math::DisplacementVector3D< ROOT::Math::Cartesian3D<double> , ROOT::Math::DefaultCoordinateSystemTag > 
-    clusterPos( clusterRef_->position().X(), clusterRef_->position().Y(),clusterRef_->position().Z() );
+  // to a displacement vector:
+  ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>, ROOT::Math::DefaultCoordinateSystemTag> clusterPos(
+      clusterRef_->position().X(), clusterRef_->position().Y(), clusterRef_->position().Z());
 
   clusterPos = clusterPos.Unit();
   double E = clusterRef_->energy();
   clusterPos *= E;
-  double ET = sqrt (clusterPos.X()*clusterPos.X() + clusterPos.Y()*clusterPos.Y());
+  double ET = sqrt(clusterPos.X() * clusterPos.X() + clusterPos.Y() * clusterPos.Y());
 
   out << setprecision(3);
-  out << tab<<setw(7)<<"layer="<<setw(3)<<clusterRef_->layer();
+  out << tab << setw(7) << "layer=" << setw(3) << clusterRef_->layer();
   out << setiosflags(ios::right);
   out << setiosflags(ios::fixed);
-  out << setw(4) <<", ET =" << setw(7) << ET;
-  out << setw(4) <<", E ="  << setw(7) << E;
+  out << setw(4) << ", ET =" << setw(7) << ET;
+  out << setw(4) << ", E =" << setw(7) << E;
   out << " (eta,phi,z)= (";
-  out << clusterRef_->position().Eta()<<",";
-  out << clusterRef_->position().Phi()<<",";
-  out << clusterRef_->position().Z()  <<")";
-  out << resetiosflags(ios::right|ios::fixed);
+  out << clusterRef_->position().Eta() << ",";
+  out << clusterRef_->position().Phi() << ",";
+  out << clusterRef_->position().Z() << ")";
+  out << resetiosflags(ios::right | ios::fixed);
 }

--- a/DataFormats/ParticleFlowReco/src/PFBlockElementGsfTrack.cc
+++ b/DataFormats/ParticleFlowReco/src/PFBlockElementGsfTrack.cc
@@ -1,6 +1,6 @@
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementGsfTrack.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecTrack.h"
-#include "DataFormats/Common/interface/Ref.h" 
+#include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/ParticleFlowReco/interface/PFTrajectoryPoint.h"
 
@@ -9,38 +9,29 @@
 using namespace reco;
 using namespace std;
 
+PFBlockElementGsfTrack::PFBlockElementGsfTrack(const GsfPFRecTrackRef& gsfref,
+                                               const math::XYZTLorentzVector& Pin,
+                                               const math::XYZTLorentzVector& Pout)
+    : PFBlockElement(GSF),
+      GsftrackRefPF_(gsfref),
+      GsftrackRef_(gsfref->gsfTrackRef()),
+      Pin_(Pin),
+      Pout_(Pout),
+      trackType_(0) {
+  if (gsfref.isNull())
+    throw cms::Exception("NullRef") << " PFBlockElementGsfTrack constructed from a null reference to PFGsfRecTrack.";
+  const reco::PFTrajectoryPoint& atECAL = gsfref->extrapolatedPoint(reco::PFTrajectoryPoint::ECALEntrance);
+  if (atECAL.isValid())
+    positionAtECALEntrance_.SetCoordinates(atECAL.position().x(), atECAL.position().y(), atECAL.position().z());
 
-PFBlockElementGsfTrack::PFBlockElementGsfTrack(const GsfPFRecTrackRef& gsfref, 
-					       const math::XYZTLorentzVector& Pin, 
-					       const math::XYZTLorentzVector& Pout ) : 
-  PFBlockElement( GSF ),
-  GsftrackRefPF_( gsfref ), 
-  GsftrackRef_( gsfref->gsfTrackRef() ),
-  Pin_(Pin),
-  Pout_(Pout),
-  trackType_(0){
-
-  if(gsfref.isNull() )
-    throw cms::Exception("NullRef")
-      <<" PFBlockElementGsfTrack constructed from a null reference to PFGsfRecTrack.";
-  const reco::PFTrajectoryPoint& atECAL 
-    = gsfref->extrapolatedPoint( reco::PFTrajectoryPoint::ECALEntrance );
-  if( atECAL.isValid() ) 
-    positionAtECALEntrance_.SetCoordinates( atECAL.position().x(),
-					    atECAL.position().y(),
-					    atECAL.position().z() );
-
-  
-  setTrackType( DEFAULT, true );      
+  setTrackType(DEFAULT, true);
 }
 
-void PFBlockElementGsfTrack::Dump(ostream& out, 
-                               const char* tab ) const {
-  
-  if(! out ) return;
- 
-  if( !GsftrackRefPF_.isNull() ) {
+void PFBlockElementGsfTrack::Dump(ostream& out, const char* tab) const {
+  if (!out)
+    return;
 
+  if (!GsftrackRefPF_.isNull()) {
     //    double charge = trackPF().charge;
     double charge = GsftrackRefPF_->charge();
     math::XYZTLorentzVector pin = Pin_;
@@ -51,20 +42,19 @@ void PFBlockElementGsfTrack::Dump(ostream& out,
     double ptout = pout.pt();
     double etaout = pout.eta();
     double phiout = pout.phi();
-    out<<setprecision(0);
-    out<<tab<<setw(7)<<"charge="<<setw(3)<<charge;
-    out<<setprecision(3);
-    out<<setiosflags(ios::right);
-    out<<setiosflags(ios::fixed);
-    out<<", Inner pT  ="<<setw(7)<<ptin;
-    out<<" Inner (eta,phi)= (";
-    out<< etain <<",";
-    out<< phiin <<")";
-    out<<", Outer pT  ="<<setw(7)<<ptout;
-    out<<" Outer (eta,phi)= (";
-    out<< etaout <<",";
-    out<< phiout <<")";
-    out<<resetiosflags(ios::right|ios::fixed); }
-
+    out << setprecision(0);
+    out << tab << setw(7) << "charge=" << setw(3) << charge;
+    out << setprecision(3);
+    out << setiosflags(ios::right);
+    out << setiosflags(ios::fixed);
+    out << ", Inner pT  =" << setw(7) << ptin;
+    out << " Inner (eta,phi)= (";
+    out << etain << ",";
+    out << phiin << ")";
+    out << ", Outer pT  =" << setw(7) << ptout;
+    out << " Outer (eta,phi)= (";
+    out << etaout << ",";
+    out << phiout << ")";
+    out << resetiosflags(ios::right | ios::fixed);
+  }
 }
-

--- a/DataFormats/ParticleFlowReco/src/PFBlockElementSuperCluster.cc
+++ b/DataFormats/ParticleFlowReco/src/PFBlockElementSuperCluster.cc
@@ -1,6 +1,6 @@
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementSuperCluster.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
-#include "DataFormats/Common/interface/Ref.h" 
+#include "DataFormats/Common/interface/Ref.h"
 #include "Math/Vector3D.h"
 
 #include <iomanip>
@@ -8,28 +8,27 @@
 using namespace reco;
 using namespace std;
 
-void PFBlockElementSuperCluster::Dump(ostream& out, 
-				      const char* tab ) const {
-  
-  if(! out ) return;
+void PFBlockElementSuperCluster::Dump(ostream& out, const char* tab) const {
+  if (!out)
+    return;
   // need to convert the math::XYZPoint data member of the PFCluster class=
-  // to a displacement vector: 
-  ROOT::Math::DisplacementVector3D< ROOT::Math::Cartesian3D<double> , ROOT::Math::DefaultCoordinateSystemTag > 
-    clusterPos( superClusterRef_->position().X(), superClusterRef_->position().Y(),superClusterRef_->position().Z() );
+  // to a displacement vector:
+  ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<double>, ROOT::Math::DefaultCoordinateSystemTag> clusterPos(
+      superClusterRef_->position().X(), superClusterRef_->position().Y(), superClusterRef_->position().Z());
 
   clusterPos = clusterPos.Unit();
   double E = superClusterRef_->energy();
   clusterPos *= E;
-  double ET = sqrt (clusterPos.X()*clusterPos.X() + clusterPos.Y()*clusterPos.Y());
+  double ET = sqrt(clusterPos.X() * clusterPos.X() + clusterPos.Y() * clusterPos.Y());
 
   out << setprecision(3);
   out << setiosflags(ios::right);
   out << setiosflags(ios::fixed);
-  out << setw(4) <<", ET =" << setw(7) << ET;
-  out << setw(4) <<", E ="  << setw(7) << E;
+  out << setw(4) << ", ET =" << setw(7) << ET;
+  out << setw(4) << ", E =" << setw(7) << E;
   out << " (eta,phi,z)= (";
-  out << superClusterRef_->position().Eta()<<",";
-  out << superClusterRef_->position().Phi()<<",";
-  out << superClusterRef_->position().Z()  <<")";
-  out << resetiosflags(ios::right|ios::fixed);
+  out << superClusterRef_->position().Eta() << ",";
+  out << superClusterRef_->position().Phi() << ",";
+  out << superClusterRef_->position().Z() << ")";
+  out << resetiosflags(ios::right | ios::fixed);
 }

--- a/DataFormats/ParticleFlowReco/src/PFBlockElementTrack.cc
+++ b/DataFormats/ParticleFlowReco/src/PFBlockElementTrack.cc
@@ -1,6 +1,6 @@
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecTrack.h"
-#include "DataFormats/Common/interface/Ref.h" 
+#include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/ParticleFlowReco/interface/PFTrajectoryPoint.h"
 
@@ -9,38 +9,26 @@
 using namespace reco;
 using namespace std;
 
+PFBlockElementTrack::PFBlockElementTrack(const PFRecTrackRef& ref)
+    : PFBlockElement(TRACK), trackRefPF_(ref), trackRef_(ref->trackRef()), trackType_(0) {
+  if (ref.isNull())
+    throw cms::Exception("NullRef") << " PFBlockElementTrack constructed from a null reference to PFRecTrack.";
 
-PFBlockElementTrack::PFBlockElementTrack(const PFRecTrackRef& ref) : 
-  PFBlockElement( TRACK ),
-  trackRefPF_( ref ), 
-  trackRef_( ref->trackRef() ),
-  trackType_(0) {
-  
+  const reco::PFTrajectoryPoint& atECAL = ref->extrapolatedPoint(reco::PFTrajectoryPoint::ECALEntrance);
 
-  if( ref.isNull() ) 
-    throw cms::Exception("NullRef")<<" PFBlockElementTrack constructed from a null reference to PFRecTrack.";
-  
-  const reco::PFTrajectoryPoint& atECAL 
-    = ref->extrapolatedPoint( reco::PFTrajectoryPoint::ECALEntrance );
-
-  if( atECAL.isValid() ) 
-    positionAtECALEntrance_.SetCoordinates( atECAL.position().x(),
-					    atECAL.position().y(),
-					    atECAL.position().z() );
-  // if the position at ecal entrance is invalid, 
+  if (atECAL.isValid())
+    positionAtECALEntrance_.SetCoordinates(atECAL.position().x(), atECAL.position().y(), atECAL.position().z());
+  // if the position at ecal entrance is invalid,
   // positionAtECALEntrance_ is initialized by default to 0,0,0
 
-  setTrackType( DEFAULT, true );      
-} 
+  setTrackType(DEFAULT, true);
+}
 
+void PFBlockElementTrack::Dump(ostream& out, const char* tab) const {
+  if (!out)
+    return;
 
-void PFBlockElementTrack::Dump(ostream& out, 
-                               const char* tab ) const {
-  
-  if(! out ) return;
-  
-  if( !trackRef_.isNull() ) {
-    
+  if (!trackRef_.isNull()) {
     double charge = trackRef_->charge();
     double pt = trackRef_->pt();
     double p = trackRef_->p();
@@ -49,30 +37,30 @@ void PFBlockElementTrack::Dump(ostream& out,
     double trackphi = trackRef_->phi();
 
     // COLIN
-    // the following lines rely on the presence of the PFRecTrack, 
-    // which for most people is not there (PFRecTracks are transient) 
+    // the following lines rely on the presence of the PFRecTrack,
+    // which for most people is not there (PFRecTracks are transient)
     // commented these lines out to remove the spurious error message
     // for the missing PFRecTrack product
-    //     const reco::PFTrajectoryPoint& atECAL 
+    //     const reco::PFTrajectoryPoint& atECAL
     //       = trackRefPF_->extrapolatedPoint( reco::PFTrajectoryPoint::ECALShowerMax );
-    //     // check if  reach ecal Shower max 
-    //     if( atECAL.isValid() ) { 
-    //       s = "  at ECAL shower max";  
+    //     // check if  reach ecal Shower max
+    //     if( atECAL.isValid() ) {
+    //       s = "  at ECAL shower max";
     //       tracketa = atECAL.position().Eta();
     //       trackphi = atECAL.position().Phi();
     //     }
-    
-    out<<setprecision(0);
-    out<<tab<<setw(7)<<"charge="<<setw(3)<<charge;
-    out<<setprecision(3);
-    out<<setiosflags(ios::right);
-    out<<setiosflags(ios::fixed);
-    out<<", pT ="<<setw(7)<<pt;
-    out<<", p ="<<setw(7)<<p;
-    out<<" (eta,phi)= (";
-    out<<tracketa<<",";
-    out<<trackphi<<")" << s;
-    
-    out<<resetiosflags(ios::right|ios::fixed);  
+
+    out << setprecision(0);
+    out << tab << setw(7) << "charge=" << setw(3) << charge;
+    out << setprecision(3);
+    out << setiosflags(ios::right);
+    out << setiosflags(ios::fixed);
+    out << ", pT =" << setw(7) << pt;
+    out << ", p =" << setw(7) << p;
+    out << " (eta,phi)= (";
+    out << tracketa << ",";
+    out << trackphi << ")" << s;
+
+    out << resetiosflags(ios::right | ios::fixed);
   }
 }

--- a/DataFormats/ParticleFlowReco/src/PFCluster.cc
+++ b/DataFormats/ParticleFlowReco/src/PFCluster.cc
@@ -4,130 +4,108 @@
 #include "Math/GenVector/etaMax.h"
 
 namespace {
-  
+
   // an implementation of Eta_FromRhoZ of root libraries using vdt
-  template<typename Scalar>
-  inline Scalar Eta_FromRhoZ_fast(Scalar rho, Scalar z) {    
+  template <typename Scalar>
+  inline Scalar Eta_FromRhoZ_fast(Scalar rho, Scalar z) {
     using namespace ROOT::Math;
     // value to control Taylor expansion of sqrt
-    const Scalar big_z_scaled =
-      std::pow(std::numeric_limits<Scalar>::epsilon(),static_cast<Scalar>(-.25));
-    if (rho > 0) {      
-      Scalar z_scaled = z/rho;
+    const Scalar big_z_scaled = std::pow(std::numeric_limits<Scalar>::epsilon(), static_cast<Scalar>(-.25));
+    if (rho > 0) {
+      Scalar z_scaled = z / rho;
       if (std::fabs(z_scaled) < big_z_scaled) {
-        return vdt::fast_log(z_scaled+std::sqrt(z_scaled*z_scaled+1.0));
+        return vdt::fast_log(z_scaled + std::sqrt(z_scaled * z_scaled + 1.0));
       } else {
         // apply correction using first order Taylor expansion of sqrt
-        return  z>0 ? vdt::fast_log(2.0*z_scaled + 0.5/z_scaled) : -vdt::fast_log(-2.0*z_scaled);
+        return z > 0 ? vdt::fast_log(2.0 * z_scaled + 0.5 / z_scaled) : -vdt::fast_log(-2.0 * z_scaled);
       }
     }
     // case vector has rho = 0
-    else if (z==0) {
+    else if (z == 0) {
       return 0;
-    }
-    else if (z>0) {
+    } else if (z > 0) {
       return z + etaMax<Scalar>();
-    }
-    else {
+    } else {
       return z - etaMax<Scalar>();
-    }    
+    }
   }
-}
+}  // namespace
 
 using namespace std;
 using namespace reco;
 
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
-std::atomic<int>    PFCluster::depthCorMode_{0};
+std::atomic<int> PFCluster::depthCorMode_{0};
 std::atomic<double> PFCluster::depthCorA_{0.89};
 std::atomic<double> PFCluster::depthCorB_{7.3};
 std::atomic<double> PFCluster::depthCorAp_{0.89};
 std::atomic<double> PFCluster::depthCorBp_{4.0};
 #else
-int    PFCluster::depthCorMode_ = 0;
+int PFCluster::depthCorMode_ = 0;
 double PFCluster::depthCorA_ = 0.89;
 double PFCluster::depthCorB_ = 7.3;
 double PFCluster::depthCorAp_ = 0.89;
 double PFCluster::depthCorBp_ = 4.0;
 #endif
 
+const math::XYZPoint PFCluster::dummyVtx_(0, 0, 0);
 
-const math::XYZPoint PFCluster::dummyVtx_(0,0,0);
-
-PFCluster::PFCluster(PFLayer::Layer layer, double energy,
-                     double x, double y, double z ) : 
-  CaloCluster( energy, 
-	       math::XYZPoint(x,y,z), 
-	       PFLayer::toCaloID(layer),
-	       CaloCluster::particleFlow ),
-  posrep_( position_.Rho(), position_.Eta(), position_.Phi() ),
-  time_(-99.),
-  depth_(0.),
-  layer_(layer),
-  color_(2)
-{  }
-  
+PFCluster::PFCluster(PFLayer::Layer layer, double energy, double x, double y, double z)
+    : CaloCluster(energy, math::XYZPoint(x, y, z), PFLayer::toCaloID(layer), CaloCluster::particleFlow),
+      posrep_(position_.Rho(), position_.Eta(), position_.Phi()),
+      time_(-99.),
+      depth_(0.),
+      layer_(layer),
+      color_(2) {}
 
 void PFCluster::reset() {
-  
   energy_ = 0;
   position_ *= 0;
   posrep_ *= 0;
-  time_=-99.;
+  time_ = -99.;
   layer_ = PFLayer::NONE;
   rechits_.clear();
 
   CaloCluster::reset();
-  
 }
 
 void PFCluster::resetHitsAndFractions() {
-
   rechits_.clear();
   hitsAndFractions_.clear();
-  
 }
 
-void PFCluster::addRecHitFraction( const reco::PFRecHitFraction& frac ) {
+void PFCluster::addRecHitFraction(const reco::PFRecHitFraction& frac) {
+  rechits_.push_back(frac);
 
-  rechits_.push_back( frac );
-
-  addHitAndFraction( frac.recHitRef()->detId(), 
-		     frac.fraction() );
+  addHitAndFraction(frac.recHitRef()->detId(), frac.fraction());
 }
 
-
-double PFCluster::getDepthCorrection(double energy, bool isBelowPS,
-                                     bool isHadron)
-{
+double PFCluster::getDepthCorrection(double energy, bool isBelowPS, bool isHadron) {
   double corrA = depthCorA_;
   double corrB = depthCorB_;
   if (isBelowPS) {
     corrA = depthCorAp_;
     corrB = depthCorBp_;
   }
-  return isHadron ? corrA : corrA*(corrB + log(energy));
+  return isHadron ? corrA : corrA * (corrB + log(energy));
 }
 
-void PFCluster::setLayer( PFLayer::Layer layer) {
+void PFCluster::setLayer(PFLayer::Layer layer) {
   // cout<<"calling PFCluster::setLayer "<<layer<<endl;
   layer_ = layer;
-  caloID_ = PFLayer::toCaloID( layer );
+  caloID_ = PFLayer::toCaloID(layer);
   // cout<<"done "<<caloID_<<endl;
 }
 
-
-PFLayer::Layer  PFCluster::layer() const {
-  
+PFLayer::Layer PFCluster::layer() const {
   // cout<<"calling PFCluster::layer "<<caloID()<<" "<<PFLayer::fromCaloID( caloID() )<<endl;
-  if( layer_ != PFLayer::NONE ) return layer_;
-  return PFLayer::fromCaloID( caloID() );
-}     
-
+  if (layer_ != PFLayer::NONE)
+    return layer_;
+  return PFLayer::fromCaloID(caloID());
+}
 
 PFCluster& PFCluster::operator=(const PFCluster& other) {
-
-  CaloCluster::operator=(other); 
+  CaloCluster::operator=(other);
   rechits_ = other.rechits_;
   energy_ = other.energy_;
   position_ = other.position_;
@@ -137,33 +115,26 @@ PFCluster& PFCluster::operator=(const PFCluster& other) {
   return *this;
 }
 
+std::ostream& reco::operator<<(std::ostream& out, const PFCluster& cluster) {
+  if (!out)
+    return out;
 
-std::ostream& reco::operator<<(std::ostream& out, 
-                               const PFCluster& cluster) {
-  
-  if(!out) return out;
-  
-  const math::XYZPoint&  pos = cluster.position();
-  const PFCluster::REPPoint&  posrep = cluster.positionREP();
-  const std::vector< reco::PFRecHitFraction >& fracs = 
-    cluster.recHitFractions();
-  
-  out<<"PFcluster "
-     <<", layer: "<<cluster.layer()
-     <<"\tE = "<<cluster.energy()
-     <<"\tXYZ: "
-     <<pos.X()<<","<<pos.Y()<<","<<pos.Z()<<" | "
-     <<"\tREP: "
-     <<posrep.Rho()<<","<<posrep.Eta()<<","<<posrep.Phi()<<" | "
-     <<fracs.size()<<" rechits";
-  
-  for(unsigned i=0; i<fracs.size(); i++) {
+  const math::XYZPoint& pos = cluster.position();
+  const PFCluster::REPPoint& posrep = cluster.positionREP();
+  const std::vector<reco::PFRecHitFraction>& fracs = cluster.recHitFractions();
+
+  out << "PFcluster "
+      << ", layer: " << cluster.layer() << "\tE = " << cluster.energy() << "\tXYZ: " << pos.X() << "," << pos.Y() << ","
+      << pos.Z() << " | "
+      << "\tREP: " << posrep.Rho() << "," << posrep.Eta() << "," << posrep.Phi() << " | " << fracs.size() << " rechits";
+
+  for (unsigned i = 0; i < fracs.size(); i++) {
     // PFRecHit is not available, print the detID
-    if( !fracs[i].recHitRef().isAvailable() )
-      out<<cluster.printHitAndFraction(i)<<", ";
-    else 
-      out<<fracs[i]<<", ";
+    if (!fracs[i].recHitRef().isAvailable())
+      out << cluster.printHitAndFraction(i) << ", ";
+    else
+      out << fracs[i] << ", ";
   }
-  
+
   return out;
 }

--- a/DataFormats/ParticleFlowReco/src/PFConversion.cc
+++ b/DataFormats/ParticleFlowReco/src/PFConversion.cc
@@ -2,12 +2,9 @@
 
 using namespace reco;
 
-PFConversion::PFConversion(  const reco::ConversionRef& cp, const std::vector<reco::PFRecTrackRef>& tr ) :
-  originalConversion_(cp), pfTracks_(tr) {  }
+PFConversion::PFConversion(const reco::ConversionRef& cp, const std::vector<reco::PFRecTrackRef>& tr)
+    : originalConversion_(cp), pfTracks_(tr) {}
 
-PFConversion::PFConversion(  const reco::ConversionRef cp ) :
-  originalConversion_(cp) {  }
+PFConversion::PFConversion(const reco::ConversionRef cp) : originalConversion_(cp) {}
 
-
-
-PFConversion::~PFConversion() { }
+PFConversion::~PFConversion() {}

--- a/DataFormats/ParticleFlowReco/src/PFDisplacedVertex.cc
+++ b/DataFormats/ParticleFlowReco/src/PFDisplacedVertex.cc
@@ -5,210 +5,190 @@
 using namespace std;
 using namespace reco;
 
+PFDisplacedVertex::PFDisplacedVertex() : Vertex(), vertexType_(ANY), primaryDirection_(0, 0, 0) {}
 
-PFDisplacedVertex::PFDisplacedVertex() : Vertex(),
-					 vertexType_(ANY),
-					 primaryDirection_(0,0,0)
-{}
+PFDisplacedVertex::PFDisplacedVertex(Vertex& v) : Vertex(v), vertexType_(ANY), primaryDirection_(0, 0, 0) {}
 
-PFDisplacedVertex::PFDisplacedVertex(Vertex& v) : Vertex(v),
-						  vertexType_(ANY),
-						  primaryDirection_(0,0,0)
-{}
-
-void 
-PFDisplacedVertex::addElement( const TrackBaseRef & r, const Track & refTrack, 
-			       const PFTrackHitFullInfo& hitInfo , 
-			       VertexTrackType trackType, float w ) {
-  add(r, refTrack, w );
+void PFDisplacedVertex::addElement(const TrackBaseRef& r,
+                                   const Track& refTrack,
+                                   const PFTrackHitFullInfo& hitInfo,
+                                   VertexTrackType trackType,
+                                   float w) {
+  add(r, refTrack, w);
   trackTypes_.push_back(trackType);
   trackHitFullInfos_.push_back(hitInfo);
 }
 
-void 
-PFDisplacedVertex::cleanTracks() {
-
+void PFDisplacedVertex::cleanTracks() {
   removeTracks();
   trackTypes_.clear();
   trackHitFullInfos_.clear();
-
 }
 
-    
-const bool 
-PFDisplacedVertex::isThereKindTracks(VertexTrackType T) const {
-
-  vector <VertexTrackType>::const_iterator iter = 
-    find (trackTypes_.begin(), trackTypes_.end(), T);
-  return (iter != trackTypes_.end()) ;      
-
+const bool PFDisplacedVertex::isThereKindTracks(VertexTrackType T) const {
+  vector<VertexTrackType>::const_iterator iter = find(trackTypes_.begin(), trackTypes_.end(), T);
+  return (iter != trackTypes_.end());
 }
 
-const int 
-PFDisplacedVertex::nKindTracks(VertexTrackType T) const {
-
-  return count ( trackTypes_.begin(), trackTypes_.end(), T);
-
+const int PFDisplacedVertex::nKindTracks(VertexTrackType T) const {
+  return count(trackTypes_.begin(), trackTypes_.end(), T);
 }
 
-
-const size_t 
-PFDisplacedVertex::trackPosition(const reco::TrackBaseRef& originalTrack) const {
-
+const size_t PFDisplacedVertex::trackPosition(const reco::TrackBaseRef& originalTrack) const {
   size_t pos = -1;
-  
+
   const Track refittedTrack = PFDisplacedVertex::refittedTrack(originalTrack);
 
   std::vector<Track> refitTrks = refittedTracks();
-  for (size_t i = 0; i < refitTrks.size(); i++){
-    if ( fabs(refitTrks[i].pt() - refittedTrack.pt()) < 1.e-5 ){
+  for (size_t i = 0; i < refitTrks.size(); i++) {
+    if (fabs(refitTrks[i].pt() - refittedTrack.pt()) < 1.e-5) {
       pos = i;
       continue;
     }
-    
   }
   //  cout << "pos = " << pos << endl;
 
   return pos;
-
 }
 
-
-void 
-PFDisplacedVertex::setPrimaryDirection(const math::XYZPoint& pvtx){
-  primaryDirection_ = math::XYZVector(position().x(), position().y(), position().z()); 
+void PFDisplacedVertex::setPrimaryDirection(const math::XYZPoint& pvtx) {
+  primaryDirection_ = math::XYZVector(position().x(), position().y(), position().z());
   math::XYZVector vtx(pvtx.x(), pvtx.y(), pvtx.z());
 
-  primaryDirection_  = primaryDirection_ - vtx;
-  primaryDirection_ /= (sqrt(primaryDirection_.Mag2())+1e-10);
+  primaryDirection_ = primaryDirection_ - vtx;
+  primaryDirection_ /= (sqrt(primaryDirection_.Mag2()) + 1e-10);
 }
 
-
-std::string 
-PFDisplacedVertex::nameVertexType() const {
-  switch (vertexType_){
-  case ANY:   return "ANY";
-  case FAKE:  return "FAKE";
-  case LOOPER: return "LOOPER";
-  case NUCL: return "NUCL";
-  case NUCL_LOOSE: return "NUCL_LOOSE";
-  case NUCL_KINK: return "NUCL_KINK";
-  case CONVERSION: return "CONVERSION";
-  case CONVERSION_LOOSE: return "CONVERSION_LOOSE";
-  case CONVERTED_BREMM: return "CONVERTED_BREMM";
-  case K0_DECAY: return "K0_DECAY";
-  case LAMBDA_DECAY: return "LAMBDA_DECAY";
-  case LAMBDABAR_DECAY: return "LAMBDABAR_DECAY";
-  case KPLUS_DECAY: return "KPLUS_DECAY";
-  case KMINUS_DECAY: return "KMINUS_DECAY";
-  case KPLUS_DECAY_LOOSE: return "KPLUS_DECAY_LOOSE";
-  case KMINUS_DECAY_LOOSE: return "KMINUS_DECAY_LOOSE";
-  case BSM_VERTEX: return "BSM_VERTEX";
-  default: return "?";
+std::string PFDisplacedVertex::nameVertexType() const {
+  switch (vertexType_) {
+    case ANY:
+      return "ANY";
+    case FAKE:
+      return "FAKE";
+    case LOOPER:
+      return "LOOPER";
+    case NUCL:
+      return "NUCL";
+    case NUCL_LOOSE:
+      return "NUCL_LOOSE";
+    case NUCL_KINK:
+      return "NUCL_KINK";
+    case CONVERSION:
+      return "CONVERSION";
+    case CONVERSION_LOOSE:
+      return "CONVERSION_LOOSE";
+    case CONVERTED_BREMM:
+      return "CONVERTED_BREMM";
+    case K0_DECAY:
+      return "K0_DECAY";
+    case LAMBDA_DECAY:
+      return "LAMBDA_DECAY";
+    case LAMBDABAR_DECAY:
+      return "LAMBDABAR_DECAY";
+    case KPLUS_DECAY:
+      return "KPLUS_DECAY";
+    case KMINUS_DECAY:
+      return "KMINUS_DECAY";
+    case KPLUS_DECAY_LOOSE:
+      return "KPLUS_DECAY_LOOSE";
+    case KMINUS_DECAY_LOOSE:
+      return "KMINUS_DECAY_LOOSE";
+    case BSM_VERTEX:
+      return "BSM_VERTEX";
+    default:
+      return "?";
   }
   return "?";
 }
 
-
-const math::XYZTLorentzVector 
-PFDisplacedVertex::momentum(string massHypo, VertexTrackType T, bool useRefitted, double mass) const {
-
+const math::XYZTLorentzVector PFDisplacedVertex::momentum(string massHypo,
+                                                          VertexTrackType T,
+                                                          bool useRefitted,
+                                                          double mass) const {
   M_Hypo mHypo = M_CUSTOM;
 
-  if (massHypo.find("PI")!=string::npos) mHypo = M_PION;
-  else if (massHypo.find("KAON")!=string::npos) mHypo = M_KAON;
-  else if (massHypo.find("LAMBDA")!=string::npos) mHypo = M_LAMBDA;
-  else if (massHypo.find("MASSLESS")!=string::npos) mHypo = M_MASSLESS; 
-  else if (massHypo.find("CUSTOM")!=string::npos) mHypo = M_CUSTOM;
+  if (massHypo.find("PI") != string::npos)
+    mHypo = M_PION;
+  else if (massHypo.find("KAON") != string::npos)
+    mHypo = M_KAON;
+  else if (massHypo.find("LAMBDA") != string::npos)
+    mHypo = M_LAMBDA;
+  else if (massHypo.find("MASSLESS") != string::npos)
+    mHypo = M_MASSLESS;
+  else if (massHypo.find("CUSTOM") != string::npos)
+    mHypo = M_CUSTOM;
 
   return momentum(mHypo, T, useRefitted, mass);
-
 }
 
-
-const math::XYZTLorentzVector 
-PFDisplacedVertex::momentum(M_Hypo massHypo, VertexTrackType T, bool useRefitted, double mass) const {
-
+const math::XYZTLorentzVector PFDisplacedVertex::momentum(M_Hypo massHypo,
+                                                          VertexTrackType T,
+                                                          bool useRefitted,
+                                                          double mass) const {
   const double m2 = getMass2(massHypo, mass);
-
-
 
   math::XYZTLorentzVector P;
 
-  for (size_t i = 0; i< tracksSize(); i++){
-    bool bType = (trackTypes_[i]== T);
+  for (size_t i = 0; i < tracksSize(); i++) {
+    bool bType = (trackTypes_[i] == T);
     if (T == T_TO_VERTEX || T == T_MERGED)
-      bType =  (trackTypes_[i] == T_TO_VERTEX || trackTypes_[i] == T_MERGED);
- 
-    if ( bType ) {
+      bType = (trackTypes_[i] == T_TO_VERTEX || trackTypes_[i] == T_MERGED);
 
+    if (bType) {
       if (!useRefitted) {
+        TrackBaseRef trackRef = originalTrack(refittedTracks()[i]);
 
-	TrackBaseRef trackRef = originalTrack(refittedTracks()[i]);
-
-	double p2 = trackRef->momentum().Mag2();
-	P += math::XYZTLorentzVector (trackRef->momentum().x(),
-				      trackRef->momentum().y(),
-				      trackRef->momentum().z(),
-				      sqrt(m2 + p2));
+        double p2 = trackRef->momentum().Mag2();
+        P += math::XYZTLorentzVector(
+            trackRef->momentum().x(), trackRef->momentum().y(), trackRef->momentum().z(), sqrt(m2 + p2));
       } else {
+        //	cout << "m2 " << m2 << endl;
 
-	//	cout << "m2 " << m2 << endl; 
-
-	double p2 = refittedTracks()[i].momentum().Mag2();
-	P += math::XYZTLorentzVector (refittedTracks()[i].momentum().x(),
-				      refittedTracks()[i].momentum().y(),
-				      refittedTracks()[i].momentum().z(),
-				      sqrt(m2 + p2));
-
-
+        double p2 = refittedTracks()[i].momentum().Mag2();
+        P += math::XYZTLorentzVector(refittedTracks()[i].momentum().x(),
+                                     refittedTracks()[i].momentum().y(),
+                                     refittedTracks()[i].momentum().z(),
+                                     sqrt(m2 + p2));
       }
     }
   }
 
-  return P;    
-
+  return P;
 }
 
-
-const int 
-PFDisplacedVertex::totalCharge() const {
-  
+const int PFDisplacedVertex::totalCharge() const {
   int charge = 0;
 
-  for (size_t i = 0; i< tracksSize(); i++){
-    if(trackTypes_[i] == T_TO_VERTEX) charge +=  refittedTracks()[i].charge();  
-    else if(trackTypes_[i] == T_FROM_VERTEX) charge -=  refittedTracks()[i].charge();  
+  for (size_t i = 0; i < tracksSize(); i++) {
+    if (trackTypes_[i] == T_TO_VERTEX)
+      charge += refittedTracks()[i].charge();
+    else if (trackTypes_[i] == T_FROM_VERTEX)
+      charge -= refittedTracks()[i].charge();
   }
 
   return charge;
 }
 
-
-const double
-PFDisplacedVertex::angle_io() const {
+const double PFDisplacedVertex::angle_io() const {
   math::XYZTLorentzVector momentumSec = secondaryMomentum((string) "PI", true);
 
   math::XYZVector p_out = momentumSec.Vect();
 
   math::XYZVector p_in = primaryDirection();
 
-  if (p_in.Mag2() < 1e-10) return -1;
-  return acos(p_in.Dot(p_out)/sqrt(p_in.Mag2()*p_out.Mag2()))/TMath::Pi()*180.0; 
-  
+  if (p_in.Mag2() < 1e-10)
+    return -1;
+  return acos(p_in.Dot(p_out) / sqrt(p_in.Mag2() * p_out.Mag2())) / TMath::Pi() * 180.0;
 }
 
-const math::XYZVector
-PFDisplacedVertex:: primaryDirection() const { 
-
+const math::XYZVector PFDisplacedVertex::primaryDirection() const {
   math::XYZTLorentzVector momentumPrim = primaryMomentum((string) "PI", true);
   math::XYZTLorentzVector momentumSec = secondaryMomentum((string) "PI", true);
 
   math::XYZVector p_in;
 
-  if (( isThereKindTracks(T_TO_VERTEX) || isThereKindTracks(T_MERGED) ) &&
-      momentumPrim.E() >  momentumSec.E()){
-    p_in = momentumPrim.Vect()/sqrt(momentumPrim.Vect().Mag2()+1e-10);
+  if ((isThereKindTracks(T_TO_VERTEX) || isThereKindTracks(T_MERGED)) && momentumPrim.E() > momentumSec.E()) {
+    p_in = momentumPrim.Vect() / sqrt(momentumPrim.Vect().Mag2() + 1e-10);
   } else {
     p_in = primaryDirection_;
   }
@@ -216,86 +196,66 @@ PFDisplacedVertex:: primaryDirection() const {
   return p_in;
 }
 
-
-const double 
-PFDisplacedVertex::getMass2(M_Hypo massHypo, double mass) const {
-
+const double PFDisplacedVertex::getMass2(M_Hypo massHypo, double mass) const {
   // pion_mass = 0.1396 GeV
   double pion_mass2 = 0.0194;
   // k0_mass = 0.4976 GeV
   double kaon_mass2 = 0.2476;
   // lambda0_mass = 1.116 GeV
   double lambda_mass2 = 1.267;
-	
-  if (massHypo == M_PION) return pion_mass2;
-  else if (massHypo == M_KAON) return kaon_mass2;
-  else if (massHypo == M_LAMBDA) return lambda_mass2;
-  else if (massHypo == M_MASSLESS) return 0;
-  else if (massHypo == M_CUSTOM) return mass*mass;
+
+  if (massHypo == M_PION)
+    return pion_mass2;
+  else if (massHypo == M_KAON)
+    return kaon_mass2;
+  else if (massHypo == M_LAMBDA)
+    return lambda_mass2;
+  else if (massHypo == M_MASSLESS)
+    return 0;
+  else if (massHypo == M_CUSTOM)
+    return mass * mass;
 
   cout << "Warning: undefined mass hypothesis" << endl;
   return 0;
-
 }
 
-void PFDisplacedVertex::Dump( ostream& out ) const {
-  if(! out ) return;
+void PFDisplacedVertex::Dump(ostream& out) const {
+  if (!out)
+    return;
 
   out << "" << endl;
-  out << "==================== This is a Displaced Vertex type " << 
-    nameVertexType() << " ===============" << endl;
+  out << "==================== This is a Displaced Vertex type " << nameVertexType() << " ===============" << endl;
 
-  out << " Vertex chi2 = " << chi2() << " ndf = " << ndof()<< " normalised chi2 = " << normalizedChi2()<< endl;
+  out << " Vertex chi2 = " << chi2() << " ndf = " << ndof() << " normalised chi2 = " << normalizedChi2() << endl;
 
-  out << " The vertex Fitted Position is: x = " << position().x()
-      << " y = " << position().y()
-      << " rho = " << position().rho() 
-      << " z = " << position().z() 
-      << endl;
+  out << " The vertex Fitted Position is: x = " << position().x() << " y = " << position().y()
+      << " rho = " << position().rho() << " z = " << position().z() << endl;
 
-  out<< "\t--- Structure ---  " << endl;
-  out<< "Number of tracks: "  << nTracks() 
-     << " nPrimary " << nPrimaryTracks()
-     << " nMerged " << nMergedTracks()
-     << " nSecondary " << nSecondaryTracks() << endl;
-              
-  vector <PFDisplacedVertex::PFTrackHitFullInfo> pattern = trackHitFullInfos();
-  vector <PFDisplacedVertex::VertexTrackType> trackType = trackTypes();
-  for (unsigned i = 0; i < pattern.size(); i++){
-    out << "track " << i 
-	<< " type = " << trackType[i]
-	<< " nHit BeforeVtx = " << pattern[i].first.first 
-	<< " AfterVtx = " << pattern[i].second.first
-	<< " MissHit BeforeVtx = " << pattern[i].first.second
-	<< " AfterVtx = " << pattern[i].second.second
-	<< endl;
+  out << "\t--- Structure ---  " << endl;
+  out << "Number of tracks: " << nTracks() << " nPrimary " << nPrimaryTracks() << " nMerged " << nMergedTracks()
+      << " nSecondary " << nSecondaryTracks() << endl;
+
+  vector<PFDisplacedVertex::PFTrackHitFullInfo> pattern = trackHitFullInfos();
+  vector<PFDisplacedVertex::VertexTrackType> trackType = trackTypes();
+  for (unsigned i = 0; i < pattern.size(); i++) {
+    out << "track " << i << " type = " << trackType[i] << " nHit BeforeVtx = " << pattern[i].first.first
+        << " AfterVtx = " << pattern[i].second.first << " MissHit BeforeVtx = " << pattern[i].first.second
+        << " AfterVtx = " << pattern[i].second.second << endl;
   }
 
   math::XYZTLorentzVector mom_prim = primaryMomentum((string) "PI", true);
   math::XYZTLorentzVector mom_sec = secondaryMomentum((string) "PI", true);
 
-  // out << "Primary P:\t E " << setprecision(3) << setw(5) << mom_prim.E() 
-  out << "Primary P:\t E " << mom_prim.E() 
-      << "\tPt = " << mom_prim.Pt()
-      << "\tPz = " << mom_prim.Pz()
-      << "\tM = "  << mom_prim.M() 
-      << "\tEta = " << mom_prim.Eta() 
-      << "\tPhi = " << mom_prim.Phi() << endl;
+  // out << "Primary P:\t E " << setprecision(3) << setw(5) << mom_prim.E()
+  out << "Primary P:\t E " << mom_prim.E() << "\tPt = " << mom_prim.Pt() << "\tPz = " << mom_prim.Pz()
+      << "\tM = " << mom_prim.M() << "\tEta = " << mom_prim.Eta() << "\tPhi = " << mom_prim.Phi() << endl;
 
-  out << "Secondary P:\t E " << mom_sec.E()
-      << "\tPt = " << mom_sec.Pt()
-      << "\tPz = " << mom_sec.Pz()
-      << "\tM = "  << mom_sec.M() 
-      << "\tEta = " << mom_sec.Eta()
-      << "\tPhi = " << mom_sec.Phi() << endl;
+  out << "Secondary P:\t E " << mom_sec.E() << "\tPt = " << mom_sec.Pt() << "\tPz = " << mom_sec.Pz()
+      << "\tM = " << mom_sec.M() << "\tEta = " << mom_sec.Eta() << "\tPhi = " << mom_sec.Phi() << endl;
 
-  out << " The vertex Direction is x = " << primaryDirection().x()
-      << " y = " << primaryDirection().y()
-      << " z = " << primaryDirection().z() 
-      << " eta = " << primaryDirection().eta() 
+  out << " The vertex Direction is x = " << primaryDirection().x() << " y = " << primaryDirection().y()
+      << " z = " << primaryDirection().z() << " eta = " << primaryDirection().eta()
       << " phi = " << primaryDirection().phi() << endl;
 
   out << " Angle_io = " << angle_io() << " deg" << endl << endl;
-  
 }
-

--- a/DataFormats/ParticleFlowReco/src/PFDisplacedVertexCandidate.cc
+++ b/DataFormats/ParticleFlowReco/src/PFDisplacedVertexCandidate.cc
@@ -6,265 +6,214 @@
 using namespace std;
 using namespace reco;
 
+PFDisplacedVertexCandidate::PFDisplacedVertexCandidate() {}
 
-PFDisplacedVertexCandidate::PFDisplacedVertexCandidate(){}
+void PFDisplacedVertexCandidate::addElement(const TrackBaseRef element) { elements_.push_back(element); }
 
-void PFDisplacedVertexCandidate::addElement(const TrackBaseRef element) {
-  elements_.push_back( element ); 
-}
+void PFDisplacedVertexCandidate::setLink(
+    const unsigned i1, const unsigned i2, const float dist, const GlobalPoint& dcaPoint, const VertexLinkTest test) {
+  assert(test < LINKTEST_ALL);
 
-
-void PFDisplacedVertexCandidate::setLink(const unsigned i1, 
-					 const unsigned i2, 
-					 const float dist,
-					 const GlobalPoint& dcaPoint,
-					 const VertexLinkTest test){
-
-  
-  assert( test<LINKTEST_ALL );
-  
   unsigned index = 0;
-  bool ok =  matrix2vector(i1,i2, index);
+  bool ok = matrix2vector(i1, i2, index);
 
-  if(ok) {
+  if (ok) {
     //ignore the  -1, -1 pair
-    if ( dist > -0.5 ) {
-      VertexLink & l = vertexLinkData_[index];
+    if (dist > -0.5) {
+      VertexLink& l = vertexLinkData_[index];
       l.distance_ = dist;
       l.dcaPoint_ = dcaPoint;
       l.test_ |= (1 << test);
-    }     else  //delete if existing
-      {
-	VertexLinkData::iterator it = vertexLinkData_.find(index);
-	if(it!=vertexLinkData_.end()) vertexLinkData_.erase(it);
-      }
+    } else  //delete if existing
+    {
+      VertexLinkData::iterator it = vertexLinkData_.find(index);
+      if (it != vertexLinkData_.end())
+        vertexLinkData_.erase(it);
+    }
 
   } else {
     assert(0);
   }
-  
 }
 
-
-void PFDisplacedVertexCandidate::associatedElements( const unsigned i, 
-						     const VertexLinkData& vertexLinkData, 
-						     multimap<float, unsigned>& sortedAssociates,
-						     const VertexLinkTest test ) const {
-
+void PFDisplacedVertexCandidate::associatedElements(const unsigned i,
+                                                    const VertexLinkData& vertexLinkData,
+                                                    multimap<float, unsigned>& sortedAssociates,
+                                                    const VertexLinkTest test) const {
   sortedAssociates.clear();
-  
+
   // i is too large
-  if( i > elements_.size() ) return;
+  if (i > elements_.size())
+    return;
   // assert(i>=0); // i >= 0, since i is unsigned
-  for(unsigned ie=0; ie<elements_.size(); ie++) {
-    
+  for (unsigned ie = 0; ie < elements_.size(); ie++) {
     // considered element itself
-    if( ie == i ) {
+    if (ie == i) {
       continue;
     }
 
     // Order the elements by increasing distance !
 
     unsigned index = 0;
-    if( !matrix2vector(i, ie, index) ) continue;
+    if (!matrix2vector(i, ie, index))
+      continue;
 
-    float c2=-1;
-    VertexLinkData::const_iterator it =  vertexLinkData.find(index);
-    if ( it!=vertexLinkData.end() && 
-	 ( ( (1 << test ) & it->second.test_) !=0 || (test == LINKTEST_ALL) ) ) 
-      c2= it->second.distance_;
+    float c2 = -1;
+    VertexLinkData::const_iterator it = vertexLinkData.find(index);
+    if (it != vertexLinkData.end() && (((1 << test) & it->second.test_) != 0 || (test == LINKTEST_ALL)))
+      c2 = it->second.distance_;
 
     // not associated
-    if( c2 < 0 ) { 
+    if (c2 < 0) {
       continue;
     }
 
-    sortedAssociates.insert( pair<float,unsigned>(c2, ie) );
+    sortedAssociates.insert(pair<float, unsigned>(c2, ie));
   }
-} 
-
-
-
-
-
-
+}
 
 // -------- Provide useful information -------- //
 
-
 PFDisplacedVertexCandidate::DistMap PFDisplacedVertexCandidate::r2Map() const {
-
   DistMap r2Map;
 
-  for (unsigned ie1 = 0; ie1<elements_.size(); ie1++)
-    for (unsigned ie2 = ie1+1; ie2<elements_.size(); ie2++){
-
+  for (unsigned ie1 = 0; ie1 < elements_.size(); ie1++)
+    for (unsigned ie2 = ie1 + 1; ie2 < elements_.size(); ie2++) {
       GlobalPoint P = dcaPoint(ie1, ie2);
-      if (P.x() > 1e9) continue;
+      if (P.x() > 1e9)
+        continue;
 
-      float r2 = P.x()*P.x()+P.y()*P.y()+P.z()*P.z();
+      float r2 = P.x() * P.x() + P.y() * P.y() + P.z() * P.z();
 
-      r2Map.insert(pair<float, pair<int,int> >(r2, pair <int, int>(ie1, ie2)));
+      r2Map.insert(pair<float, pair<int, int> >(r2, pair<int, int>(ie1, ie2)));
     }
 
   return r2Map;
-
 }
 
-
-
 PFDisplacedVertexCandidate::DistVector PFDisplacedVertexCandidate::r2Vector() const {
-
   DistVector r2Vector;
 
-  for (unsigned ie1 = 0; ie1<elements_.size(); ie1++)
-    for (unsigned ie2 = ie1+1; ie2<elements_.size(); ie2++){
-
+  for (unsigned ie1 = 0; ie1 < elements_.size(); ie1++)
+    for (unsigned ie2 = ie1 + 1; ie2 < elements_.size(); ie2++) {
       GlobalPoint P = dcaPoint(ie1, ie2);
-      if (P.x() > 1e9) continue;
+      if (P.x() > 1e9)
+        continue;
 
-      float r2 = P.x()*P.x()+P.y()*P.y()+P.z()*P.z();
+      float r2 = P.x() * P.x() + P.y() * P.y() + P.z() * P.z();
 
       r2Vector.push_back(r2);
     }
 
   return r2Vector;
-
 }
 
-
 PFDisplacedVertexCandidate::DistVector PFDisplacedVertexCandidate::distVector() const {
-
   DistVector distVector;
 
-
-  for (unsigned ie1 = 0; ie1<elements_.size(); ie1++)
-    for (unsigned ie2 = ie1+1; ie2<elements_.size(); ie2++){
-
+  for (unsigned ie1 = 0; ie1 < elements_.size(); ie1++)
+    for (unsigned ie2 = ie1 + 1; ie2 < elements_.size(); ie2++) {
       float d = dist(ie1, ie2);
-      if (d < -0.5) continue;
+      if (d < -0.5)
+        continue;
 
       distVector.push_back(d);
-
     }
 
   return distVector;
-
 }
 
-const GlobalPoint PFDisplacedVertexCandidate::dcaPoint( unsigned ie1, unsigned ie2) const {
-
-  GlobalPoint dcaPoint(1e10,1e10,1e10);
+const GlobalPoint PFDisplacedVertexCandidate::dcaPoint(unsigned ie1, unsigned ie2) const {
+  GlobalPoint dcaPoint(1e10, 1e10, 1e10);
 
   unsigned index = 0;
-  if( !matrix2vector(ie1, ie2, index) ) return dcaPoint;
-  VertexLinkData::const_iterator it =  vertexLinkData_.find(index);
-  if( it!=vertexLinkData_.end() ) dcaPoint = it->second.dcaPoint_;
+  if (!matrix2vector(ie1, ie2, index))
+    return dcaPoint;
+  VertexLinkData::const_iterator it = vertexLinkData_.find(index);
+  if (it != vertexLinkData_.end())
+    dcaPoint = it->second.dcaPoint_;
 
   return dcaPoint;
-
 }
-
 
 // -------- Internal tools -------- //
 
 bool PFDisplacedVertexCandidate::testLink(unsigned ie1, unsigned ie2) const {
-  float d = dist( ie1, ie2);
-  if (d < -0.5) return false;
+  float d = dist(ie1, ie2);
+  if (d < -0.5)
+    return false;
   return true;
 }
 
-
-const float PFDisplacedVertexCandidate::dist( unsigned ie1, unsigned ie2) const {
-
+const float PFDisplacedVertexCandidate::dist(unsigned ie1, unsigned ie2) const {
   float dist = -1;
 
   unsigned index = 0;
-  if( !matrix2vector(ie1, ie2, index) ) return dist;
-  VertexLinkData::const_iterator it =  vertexLinkData_.find(index);
-  if( it!=vertexLinkData_.end() ) dist= it->second.distance_;
+  if (!matrix2vector(ie1, ie2, index))
+    return dist;
+  VertexLinkData::const_iterator it = vertexLinkData_.find(index);
+  if (it != vertexLinkData_.end())
+    dist = it->second.distance_;
 
   return dist;
-
 }
-
-
-
-
-
-
-
-
 
 // -------- Storage of the information -------- //
 
-
 unsigned PFDisplacedVertexCandidate::vertexLinkDataSize() const {
   unsigned n = elements_.size();
-  
+
   // number of possible undirected links between n elements.
   // reflective links impossible.
- 
-  return n*(n-1)/2; 
+
+  return n * (n - 1) / 2;
 }
 
-
-bool PFDisplacedVertexCandidate::matrix2vector( unsigned iindex, 
-						unsigned jindex, 
-						unsigned& index ) const {
-
+bool PFDisplacedVertexCandidate::matrix2vector(unsigned iindex, unsigned jindex, unsigned& index) const {
   unsigned size = elements_.size();
-  if( iindex == jindex || 
-      iindex >=  size ||
-      jindex >=  size ) {
+  if (iindex == jindex || iindex >= size || jindex >= size) {
     return false;
   }
-  
-  if( iindex > jindex ) 
-    swap( iindex, jindex);
 
-  
-  index = jindex-iindex-1;
+  if (iindex > jindex)
+    swap(iindex, jindex);
 
-  if(iindex>0) {
-    index += iindex*size;
-    unsigned missing = iindex*(iindex+1)/2;
+  index = jindex - iindex - 1;
+
+  if (iindex > 0) {
+    index += iindex * size;
+    unsigned missing = iindex * (iindex + 1) / 2;
     index -= missing;
   }
-  
+
   return true;
 }
 
-void PFDisplacedVertexCandidate::Dump( ostream& out ) const {
-  if(! out ) return;
+void PFDisplacedVertexCandidate::Dump(ostream& out) const {
+  if (!out)
+    return;
 
-  const vector < TrackBaseRef >& elements = elements_;
-  out<<"\t--- DisplacedVertexCandidate ---  "<<endl;
-  out<<"\tnumber of elements: "<<elements.size()<<endl;
-  
+  const vector<TrackBaseRef>& elements = elements_;
+  out << "\t--- DisplacedVertexCandidate ---  " << endl;
+  out << "\tnumber of elements: " << elements.size() << endl;
+
   // Build element label (string) : elid from type, layer and occurence number
   // use stringstream instead of sprintf to concatenate string and integer into string
-  for(unsigned ie=0; ie<elements.size(); ie++) {
-
+  for (unsigned ie = 0; ie < elements.size(); ie++) {
     math::XYZPoint Pi(elements[ie].get()->innerPosition());
     math::XYZPoint Po(elements[ie].get()->outerPosition());
 
-    float innermost_radius = sqrt(Pi.x()*Pi.x() + Pi.y()*Pi.y() + Pi.z()*Pi.z());
-    float outermost_radius = sqrt(Po.x()*Po.x() + Po.y()*Po.y() + Po.z()*Po.z());
-    float innermost_rho = sqrt(Pi.x()*Pi.x() + Pi.y()*Pi.y());
-    float outermost_rho = sqrt(Po.x()*Po.x() + Po.y()*Po.y());
-    
+    float innermost_radius = sqrt(Pi.x() * Pi.x() + Pi.y() * Pi.y() + Pi.z() * Pi.z());
+    float outermost_radius = sqrt(Po.x() * Po.x() + Po.y() * Po.y() + Po.z() * Po.z());
+    float innermost_rho = sqrt(Pi.x() * Pi.x() + Pi.y() * Pi.y());
+    float outermost_rho = sqrt(Po.x() * Po.x() + Po.y() * Po.y());
+
     double pt = elements[ie]->pt();
 
-
-    out<<"ie = " << elements[ie].key() << " pt = " << pt
-       <<" innermost hit radius = " << innermost_radius << " rho = " << innermost_rho
-       <<" outermost hit radius = " << outermost_radius << " rho = " << outermost_rho
-       <<endl;
+    out << "ie = " << elements[ie].key() << " pt = " << pt << " innermost hit radius = " << innermost_radius
+        << " rho = " << innermost_rho << " outermost hit radius = " << outermost_radius << " rho = " << outermost_rho
+        << endl;
   }
-   
-  out<<endl;
 
-
+  out << endl;
 }
-  

--- a/DataFormats/ParticleFlowReco/src/PFDisplacedVertexSeed.cc
+++ b/DataFormats/ParticleFlowReco/src/PFDisplacedVertexSeed.cc
@@ -6,115 +6,92 @@
 using namespace std;
 using namespace reco;
 
-
-PFDisplacedVertexSeed::PFDisplacedVertexSeed() :
-  seedPoint_(GlobalPoint(0,0,0)),
-  totalWeight_(0)
-{}
-
+PFDisplacedVertexSeed::PFDisplacedVertexSeed() : seedPoint_(GlobalPoint(0, 0, 0)), totalWeight_(0) {}
 
 void PFDisplacedVertexSeed::addElement(TrackBaseRef element) {
-  if(std::find(elements_.begin(),elements_.end(), element) == elements_.end()) {
+  if (std::find(elements_.begin(), elements_.end(), element) == elements_.end()) {
     elements_.emplace_back(std::move(element));
   }
 }
 
-void PFDisplacedVertexSeed::reserveElements(size_t newSize) {
-  elements_.reserve(newSize);
-}
+void PFDisplacedVertexSeed::reserveElements(size_t newSize) { elements_.reserve(newSize); }
 
-    
-void PFDisplacedVertexSeed::updateSeedPoint(const GlobalPoint& dcaPoint, TrackBaseRef r1, TrackBaseRef r2, double weight){
-    
-  
-  if ( isEmpty() ) {
+void PFDisplacedVertexSeed::updateSeedPoint(const GlobalPoint& dcaPoint,
+                                            TrackBaseRef r1,
+                                            TrackBaseRef r2,
+                                            double weight) {
+  if (isEmpty()) {
     seedPoint_ = dcaPoint;
     totalWeight_ = weight;
-  }
-  else {
-    Basic3DVector<double>vertexSeedVector(seedPoint_);
-    Basic3DVector<double>dcaVector(dcaPoint);
+  } else {
+    Basic3DVector<double> vertexSeedVector(seedPoint_);
+    Basic3DVector<double> dcaVector(dcaPoint);
 
- 
-    dcaVector = (dcaVector*weight + vertexSeedVector*totalWeight_)/(totalWeight_+weight);
+    dcaVector = (dcaVector * weight + vertexSeedVector * totalWeight_) / (totalWeight_ + weight);
     GlobalPoint P(dcaVector.x(), dcaVector.y(), dcaVector.z());
     totalWeight_ += weight;
     seedPoint_ = P;
-
   }
 
-  reserveElements(elements_.size()+2);
-  addElement(r1); 
+  reserveElements(elements_.size() + 2);
+  addElement(r1);
   addElement(r2);
-
 }
 
-
-void PFDisplacedVertexSeed::mergeWith(const PFDisplacedVertexSeed& displacedVertex){
-
-  
+void PFDisplacedVertexSeed::mergeWith(const PFDisplacedVertexSeed& displacedVertex) {
   double weight = displacedVertex.totalWeight();
   const GlobalPoint& dcaPoint = displacedVertex.seedPoint();
 
-  Basic3DVector<double>vertexSeedVector(seedPoint_);
-  Basic3DVector<double>dcaVector(dcaPoint);
+  Basic3DVector<double> vertexSeedVector(seedPoint_);
+  Basic3DVector<double> dcaVector(dcaPoint);
 
-  dcaVector = (dcaVector*weight + vertexSeedVector*totalWeight_)/(totalWeight_+weight);
+  dcaVector = (dcaVector * weight + vertexSeedVector * totalWeight_) / (totalWeight_ + weight);
   GlobalPoint P(dcaVector.x(), dcaVector.y(), dcaVector.z());
   totalWeight_ += weight;
   seedPoint_ = P;
 
-  reserveElements(elements_.size()+displacedVertex.elements().size());
-  auto const oldSize=elements_.size();
+  reserveElements(elements_.size() + displacedVertex.elements().size());
+  auto const oldSize = elements_.size();
   //avoid checking elements we just added from displacedVertex.elements()
-  for(auto const& e: displacedVertex.elements()) {
-    if(std::find(elements_.begin(), elements_.begin()+oldSize,e) == elements_.begin()+oldSize) {
+  for (auto const& e : displacedVertex.elements()) {
+    if (std::find(elements_.begin(), elements_.begin() + oldSize, e) == elements_.begin() + oldSize) {
       elements_.emplace_back(e);
     }
   }
 }
 
+void PFDisplacedVertexSeed::Dump(ostream& out) const {
+  if (!out)
+    return;
 
-void PFDisplacedVertexSeed::Dump( ostream& out ) const {
-  if(! out ) return;
+  out << "\t--- DisplacedVertexSeed ---  " << endl;
+  out << "\tnumber of elements: " << elements_.size() << endl;
 
-  out<<"\t--- DisplacedVertexSeed ---  "<<endl;
-  out<<"\tnumber of elements: "<<elements_.size()<<endl;
-  
-  out<<"\t Seed Point x = " << seedPoint().x() 
-     <<"\t Seed Point y = " << seedPoint().y()
-     <<"\t Seed Point z = " << seedPoint().z() << endl;
+  out << "\t Seed Point x = " << seedPoint().x() << "\t Seed Point y = " << seedPoint().y()
+      << "\t Seed Point z = " << seedPoint().z() << endl;
 
   // Build element label (string) : elid from type, layer and occurence number
   // use stringstream instead of sprintf to concatenate string and integer into string
-  for(auto const& ie : elements_) {
-
+  for (auto const& ie : elements_) {
     math::XYZPoint Pi(ie.get()->innerPosition());
     math::XYZPoint Po(ie.get()->outerPosition());
 
-    float innermost_radius = sqrt(Pi.x()*Pi.x() + Pi.y()*Pi.y() + Pi.z()*Pi.z());
-    float outermost_radius = sqrt(Po.x()*Po.x() + Po.y()*Po.y() + Po.z()*Po.z());
-    float innermost_rho = sqrt(Pi.x()*Pi.x() + Pi.y()*Pi.y());
-    float outermost_rho = sqrt(Po.x()*Po.x() + Po.y()*Po.y());
-    
+    float innermost_radius = sqrt(Pi.x() * Pi.x() + Pi.y() * Pi.y() + Pi.z() * Pi.z());
+    float outermost_radius = sqrt(Po.x() * Po.x() + Po.y() * Po.y() + Po.z() * Po.z());
+    float innermost_rho = sqrt(Pi.x() * Pi.x() + Pi.y() * Pi.y());
+    float outermost_rho = sqrt(Po.x() * Po.x() + Po.y() * Po.y());
+
     double pt = ie->pt();
 
+    out << "ie = " << ie.key() << " pt = " << pt << " innermost hit radius = " << innermost_radius
+        << " rho = " << innermost_rho << " outermost hit radius = " << outermost_radius << " rho = " << outermost_rho
+        << endl;
 
-    out<<"ie = " << ie.key() << " pt = " << pt
-       <<" innermost hit radius = " << innermost_radius << " rho = " << innermost_rho
-       <<" outermost hit radius = " << outermost_radius << " rho = " << outermost_rho
-       <<endl;
-
-    out<<"ie = " << ie.key() << " pt = " << pt
-      //       <<" inn hit pos x = " << Pi.x() << " y = " << Pi.y() << " z = " << Pi.z() 
-       <<" out hit pos x = " << Po.x() << " y = " << Po.y() << " z = " << Po.z() 
-       <<endl;
-
+    out << "ie = " << ie.key() << " pt = "
+        << pt
+        //       <<" inn hit pos x = " << Pi.x() << " y = " << Pi.y() << " z = " << Pi.z()
+        << " out hit pos x = " << Po.x() << " y = " << Po.y() << " z = " << Po.z() << endl;
   }
-   
-  out<<endl;
 
-
+  out << endl;
 }
-  
-

--- a/DataFormats/ParticleFlowReco/src/PFLayer.cc
+++ b/DataFormats/ParticleFlowReco/src/PFLayer.cc
@@ -8,42 +8,62 @@
 using namespace reco;
 using namespace std;
 
-CaloID  PFLayer::toCaloID( Layer layer) {
-  
-  switch(layer) {
-  case PS2           : return  CaloID(CaloID::DET_PS2);      
-  case PS1           : return  CaloID(CaloID::DET_PS1); 
-  case ECAL_ENDCAP   : return  CaloID(CaloID::DET_ECAL_ENDCAP); 
-  case ECAL_BARREL   : return  CaloID(CaloID::DET_ECAL_BARREL);  
-  case HCAL_BARREL1  : return  CaloID(CaloID::DET_HCAL_BARREL); 
-  case HCAL_BARREL2  : return  CaloID(CaloID::DET_HO); 
-  case HCAL_ENDCAP   : return  CaloID(CaloID::DET_HCAL_ENDCAP); 
-  case HF_EM         : return  CaloID(CaloID::DET_HF_EM); 
-  case HF_HAD        : return  CaloID(CaloID::DET_HF_HAD); 
-  case HGCAL         : return  CaloID(CaloID::DET_HGCAL_ENDCAP);
-  default            : return  CaloID();
+CaloID PFLayer::toCaloID(Layer layer) {
+  switch (layer) {
+    case PS2:
+      return CaloID(CaloID::DET_PS2);
+    case PS1:
+      return CaloID(CaloID::DET_PS1);
+    case ECAL_ENDCAP:
+      return CaloID(CaloID::DET_ECAL_ENDCAP);
+    case ECAL_BARREL:
+      return CaloID(CaloID::DET_ECAL_BARREL);
+    case HCAL_BARREL1:
+      return CaloID(CaloID::DET_HCAL_BARREL);
+    case HCAL_BARREL2:
+      return CaloID(CaloID::DET_HO);
+    case HCAL_ENDCAP:
+      return CaloID(CaloID::DET_HCAL_ENDCAP);
+    case HF_EM:
+      return CaloID(CaloID::DET_HF_EM);
+    case HF_HAD:
+      return CaloID(CaloID::DET_HF_HAD);
+    case HGCAL:
+      return CaloID(CaloID::DET_HGCAL_ENDCAP);
+    default:
+      return CaloID();
   }
 }
 
-
-PFLayer::Layer   PFLayer::fromCaloID( const CaloID& id) {
-
+PFLayer::Layer PFLayer::fromCaloID(const CaloID& id) {
   //  cout<<"PFLayer::fromCaloID "<<id<<" "<<id.detector()<<endl;
-  if( !id.isSingleDetector() ) {
-    edm::LogError("PFLayer")<<"cannot convert "<<id<<" to a layer, as this CaloID does not correspond to a single detector"; 
+  if (!id.isSingleDetector()) {
+    edm::LogError("PFLayer") << "cannot convert " << id
+                             << " to a layer, as this CaloID does not correspond to a single detector";
   }
 
-  switch( id.detector() ) {
-  case CaloID::DET_ECAL_BARREL   : return  ECAL_BARREL;  
-  case CaloID::DET_ECAL_ENDCAP   : return  ECAL_ENDCAP; 
-  case CaloID::DET_PS1	         : return  PS1;
-  case CaloID::DET_PS2	         : return  PS2;
-  case CaloID::DET_HCAL_BARREL   : return  HCAL_BARREL1;
-  case CaloID::DET_HCAL_ENDCAP   : return  HCAL_ENDCAP;
-  case CaloID::DET_HF_EM         : return  HF_EM;
-  case CaloID::DET_HF_HAD        : return  HF_HAD;
-  case CaloID::DET_HO            : return  HCAL_BARREL2; 
-  case CaloID::DET_HGCAL_ENDCAP  : return  HGCAL;
-  default                        : return  NONE;
+  switch (id.detector()) {
+    case CaloID::DET_ECAL_BARREL:
+      return ECAL_BARREL;
+    case CaloID::DET_ECAL_ENDCAP:
+      return ECAL_ENDCAP;
+    case CaloID::DET_PS1:
+      return PS1;
+    case CaloID::DET_PS2:
+      return PS2;
+    case CaloID::DET_HCAL_BARREL:
+      return HCAL_BARREL1;
+    case CaloID::DET_HCAL_ENDCAP:
+      return HCAL_ENDCAP;
+    case CaloID::DET_HF_EM:
+      return HF_EM;
+    case CaloID::DET_HF_HAD:
+      return HF_HAD;
+    case CaloID::DET_HO:
+      return HCAL_BARREL2;
+    case CaloID::DET_HGCAL_ENDCAP:
+      return HGCAL;
+    default:
+      return NONE;
   }
 }

--- a/DataFormats/ParticleFlowReco/src/PFRecHit.cc
+++ b/DataFormats/ParticleFlowReco/src/PFRecHit.cc
@@ -1,88 +1,82 @@
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
-#include<limits>
+#include <limits>
 namespace reco {
 
-void PFRecHit::addNeighbour(short x,short y,short z, unsigned int ref) {
-  //bitmask interface  to accomodate more advanced naighbour finding [i.e in z as well]
-  //bit 0 side for eta [0 for <=0 , 1 for >0]
-  //bits 1,2,3 : abs(eta) wrt the center
-  //bit 4 side for phi 
-  //bits 5,6,7 : abs(phi) wrt the center
-  //bit 8 side for z 
-  //bits 9,10,11 : abs(z) wrt the center
+  void PFRecHit::addNeighbour(short x, short y, short z, unsigned int ref) {
+    //bitmask interface  to accomodate more advanced naighbour finding [i.e in z as well]
+    //bit 0 side for eta [0 for <=0 , 1 for >0]
+    //bits 1,2,3 : abs(eta) wrt the center
+    //bit 4 side for phi
+    //bits 5,6,7 : abs(phi) wrt the center
+    //bit 8 side for z
+    //bits 9,10,11 : abs(z) wrt the center
 
-  unsigned short absx = std::abs(x);
-  unsigned short absy = std::abs(y);
-  unsigned short absz = std::abs(z);
+    unsigned short absx = std::abs(x);
+    unsigned short absy = std::abs(y);
+    unsigned short absz = std::abs(z);
 
-  unsigned short bitmask=0;
+    unsigned short bitmask = 0;
 
+    if (x > 0)
+      bitmask = bitmask | 1;
+    bitmask = bitmask | (absx << 1);
+    if (y > 0)
+      bitmask = bitmask | (1 << 4);
+    bitmask = bitmask | (absy << 5);
+    if (z > 0)
+      bitmask = bitmask | (1 << 8);
+    bitmask = bitmask | (absz << 9);
 
-  if (x>0)
-    bitmask = bitmask | 1 ;
-  bitmask = bitmask | (absx << 1);
-  if (y>0)
-    bitmask = bitmask | (1<<4) ;
-  bitmask = bitmask | (absy << 5);
-  if (z>0)
-    bitmask = bitmask | (1<<8) ;
-  bitmask = bitmask | (absz << 9);
-  
-   auto pos = neighbours_.size();
-  if (z==0) {
-    pos = neighbours8_++;
-    //find only the 4 neighbours
-    if (absx+absy==1)
-      pos = neighbours4_++;
+    auto pos = neighbours_.size();
+    if (z == 0) {
+      pos = neighbours8_++;
+      //find only the 4 neighbours
+      if (absx + absy == 1)
+        pos = neighbours4_++;
+    }
+    neighbours_.insert(neighbours_.begin() + pos, ref);
+    neighbourInfos_.insert(neighbourInfos_.begin() + pos, bitmask);
+
+    assert(neighbours4_ < 5);
+    assert(neighbours8_ < 9);
+    assert(neighbours4_ <= neighbours8_);
+    assert(neighbours8_ <= neighbours_.size());
   }
-  neighbours_.insert(neighbours_.begin()+pos,ref);
-  neighbourInfos_.insert(neighbourInfos_.begin()+pos,bitmask);
 
-  assert( neighbours4_<5);
-  assert( neighbours8_<9);
-  assert( neighbours4_<=neighbours8_);
-  assert( neighbours8_<=neighbours_.size());
+  unsigned int PFRecHit::getNeighbour(short x, short y, short z) const {
+    unsigned short absx = abs(x);
+    unsigned short absy = abs(y);
+    unsigned short absz = abs(z);
 
-}
+    unsigned short bitmask = 0;
 
+    if (x > 0)
+      bitmask = bitmask | 1;
+    bitmask = bitmask | (absx << 1);
+    if (y > 0)
+      bitmask = bitmask | (1 << 4);
+    bitmask = bitmask | (absy << 5);
+    if (z > 0)
+      bitmask = bitmask | (1 << 8);
+    bitmask = bitmask | (absz << 9);
 
-unsigned int PFRecHit::getNeighbour(short x,short y,short z) const {
-  unsigned short absx = abs(x);
-  unsigned short absy = abs(y);
-  unsigned short absz = abs(z);
-
-  unsigned short bitmask=0;
-
-  if (x>0)
-    bitmask = bitmask | 1 ;
-  bitmask = bitmask | (absx << 1);
-  if (y>0)
-    bitmask = bitmask | (1<<4) ;
-  bitmask = bitmask | (absy << 5);
-  if (z>0)
-    bitmask = bitmask | (1<<8) ;
-  bitmask = bitmask | (absz << 9);
-
-  for (unsigned int i=0;i<neighbourInfos_.size();++i) {
-    if (neighbourInfos_[i] == bitmask)
-      return neighbours_[i];
+    for (unsigned int i = 0; i < neighbourInfos_.size(); ++i) {
+      if (neighbourInfos_[i] == bitmask)
+        return neighbours_[i];
+    }
+    return std::numeric_limits<unsigned int>::max();
   }
-  return std::numeric_limits<unsigned int>::max();
-}
 
-}
+}  // namespace reco
 
 std::ostream& operator<<(std::ostream& out, const reco::PFRecHit& hit) {
+  if (!out)
+    return out;
 
-  if(!out) return out;
-
-  out<<"hit id:"<<hit.detId()
-     <<" l:"<<hit.layer()
-     <<" E:"<<hit.energy()
-     <<" t:"<<hit.time();
+  out << "hit id:" << hit.detId() << " l:" << hit.layer() << " E:" << hit.energy() << " t:" << hit.time();
   if (hit.hasCaloCell()) {
-    auto const & pos = hit.positionREP();
-    out  <<" rep:"<<pos.rho()<<","<<pos.eta()<<","<<pos.phi()<<"|";
+    auto const& pos = hit.positionREP();
+    out << " rep:" << pos.rho() << "," << pos.eta() << "," << pos.phi() << "|";
   }
   return out;
 }

--- a/DataFormats/ParticleFlowReco/src/PFRecHitFraction.cc
+++ b/DataFormats/ParticleFlowReco/src/PFRecHitFraction.cc
@@ -1,20 +1,18 @@
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFraction.h"
-#include "DataFormats/Common/interface/Ref.h" 
+#include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
 // #include "FWCore/Utilities/interface/Exception.h"
 
 using namespace std;
 using namespace reco;
 
-
-ostream& reco::operator<<( std::ostream& out, 
-                           const PFRecHitFraction& hit) {
-
-  if(!out) return out;
+ostream& reco::operator<<(std::ostream& out, const PFRecHitFraction& hit) {
+  if (!out)
+    return out;
 
   //   const reco::PFRecHit* rechit = hit.getRecHit();
 
-  out<<hit.fraction()<<"x["<< hit.recHitRef()->detId()<<"]";
+  out << hit.fraction() << "x[" << hit.recHitRef()->detId() << "]";
 
   return out;
 }

--- a/DataFormats/ParticleFlowReco/src/PFRecTrack.cc
+++ b/DataFormats/ParticleFlowReco/src/PFRecTrack.cc
@@ -1,62 +1,32 @@
 #include "DataFormats/ParticleFlowReco/interface/PFRecTrack.h"
-#include "Math/GenVector/PositionVector3D.h" 
-#include "DataFormats/Math/interface/Point3D.h" 
+#include "Math/GenVector/PositionVector3D.h"
+#include "DataFormats/Math/interface/Point3D.h"
 // #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace reco;
 
+PFRecTrack::PFRecTrack() : PFTrack(), algoType_(PFRecTrack::Unknown), trackId_(-1), STIP_(-99.) {}
 
-PFRecTrack::PFRecTrack() :
-  PFTrack(),
-  algoType_(PFRecTrack::Unknown),
-  trackId_(-1),
-  STIP_(-99.)
-{}
+PFRecTrack::PFRecTrack(double charge, AlgoType_t algoType, int trackId, const reco::TrackRef& trackRef)
+    : PFTrack(charge), algoType_(algoType), trackId_(trackId), trackRef_(trackRef), STIP_(-99.) {}
 
+PFRecTrack::PFRecTrack(double charge, AlgoType_t algoType)
+    : PFTrack(charge), algoType_(algoType), trackId_(-1), STIP_(-99.) {}
 
+std::ostream& reco::operator<<(std::ostream& out, const PFRecTrack& track) {
+  if (!out)
+    return out;
 
-PFRecTrack::PFRecTrack(double charge, 
-                       AlgoType_t algoType, 
-                       int trackId, 
-                       const reco::TrackRef& trackRef ) : 
-  PFTrack(charge), 
-  algoType_(algoType),
-  trackId_(trackId), 
-  trackRef_(trackRef),
-  STIP_(-99.)
-{}
+  const reco::PFTrajectoryPoint& closestApproach = track.trajectoryPoint(reco::PFTrajectoryPoint::ClosestApproach);
 
+  out << "Reco track charge = " << track.charge() << ", type = " << track.algoType()
+      << ", Pt = " << closestApproach.momentum().Pt() << ", P = " << closestApproach.momentum().P() << std::endl
+      << "\tR0 = " << closestApproach.position().Rho() << " Z0 = " << closestApproach.position().Z() << std::endl
+      << "\tnumber of tracker measurements = " << track.nTrajectoryMeasurements() << std::endl
+      << "\tnumber of points total = " << track.trajectoryPoints().size() << std::endl;
 
-
-PFRecTrack::PFRecTrack(double charge, AlgoType_t algoType) : 
-  PFTrack(charge), 
-  algoType_(algoType),
-  trackId_(-1),
-  STIP_(-99.)
-{}
-  
-
-std::ostream& reco::operator<<(std::ostream& out, 
-                               const PFRecTrack& track) {  
-  if (!out) return out;  
-  
-  const reco::PFTrajectoryPoint& closestApproach = 
-    track.trajectoryPoint(reco::PFTrajectoryPoint::ClosestApproach);
-  
-  out << "Reco track charge = " << track.charge() 
-      << ", type = " << track.algoType()
-      << ", Pt = " << closestApproach.momentum().Pt() 
-      << ", P = " << closestApproach.momentum().P() << std::endl
-      << "\tR0 = " << closestApproach.position().Rho()
-      <<" Z0 = " << closestApproach.position().Z() << std::endl
-      << "\tnumber of tracker measurements = " 
-      << track.nTrajectoryMeasurements() << std::endl
-      <<"\tnumber of points total = "
-      << track.trajectoryPoints().size()<< std::endl;
-
-  for(unsigned i=0; i<track.trajectoryPoints().size(); i++) 
-    out<<track.trajectoryPoints()[i]<<std::endl;
-
+  for (unsigned i = 0; i < track.trajectoryPoints().size(); i++)
+    out << track.trajectoryPoints()[i] << std::endl;
 
   return out;
 }

--- a/DataFormats/ParticleFlowReco/src/PFSimParticle.cc
+++ b/DataFormats/ParticleFlowReco/src/PFSimParticle.cc
@@ -4,185 +4,464 @@
 using namespace reco;
 using namespace std;
 
+PFSimParticle::PFSimParticle() : PFTrack(), pdgCode_(0), id_(0), motherId_(0) {}
 
-PFSimParticle::PFSimParticle() :
-  PFTrack(),
-  pdgCode_(0), 
-  id_(0),
-  motherId_(0)
-{}
-
-
-PFSimParticle::PFSimParticle(double charge, int pdgCode,
-                             unsigned id, int motherId,
+PFSimParticle::PFSimParticle(double charge,
+                             int pdgCode,
+                             unsigned id,
+                             int motherId,
                              const vector<int>& daughterIds,
-			     unsigned rectrackId, 
-			     const std::vector<unsigned>& recHitContrib, 
-			     const std::vector<double>& recHitContribFrac ):
-  PFTrack(charge),
-  pdgCode_(pdgCode), 
-  id_(id), 
-  motherId_(motherId), 
-  daughterIds_(daughterIds),
-  rectrackId_(rectrackId), 
-  recHitContrib_(recHitContrib), 
-  recHitContribFrac_(recHitContribFrac)
-{}
+                             unsigned rectrackId,
+                             const std::vector<unsigned>& recHitContrib,
+                             const std::vector<double>& recHitContribFrac)
+    : PFTrack(charge),
+      pdgCode_(pdgCode),
+      id_(id),
+      motherId_(motherId),
+      daughterIds_(daughterIds),
+      rectrackId_(rectrackId),
+      recHitContrib_(recHitContrib),
+      recHitContribFrac_(recHitContribFrac) {}
 
+PFSimParticle::PFSimParticle(const PFSimParticle& other)
+    : PFTrack(other),
+      pdgCode_(other.pdgCode_),
+      id_(other.id_),
+      motherId_(other.motherId_),
+      daughterIds_(other.daughterIds_),
+      rectrackId_(other.rectrackId_),
+      recHitContrib_(other.recHitContrib_),
+      recHitContribFrac_(other.recHitContribFrac_) {}
 
-PFSimParticle::PFSimParticle(const PFSimParticle& other) :
-  PFTrack(other), 
-  pdgCode_(other.pdgCode_), 
-  id_(other.id_), 
-  motherId_(other.motherId_), 
-  daughterIds_(other.daughterIds_),
-  rectrackId_(other.rectrackId_),
-  recHitContrib_(other.recHitContrib_),
-  recHitContribFrac_(other.recHitContribFrac_)
-{}
+ostream& reco::operator<<(ostream& out, const PFSimParticle& particle) {
+  if (!out)
+    return out;
 
-ostream& reco::operator<<(ostream& out, 
-                          const PFSimParticle& particle) {  
-  if (!out) return out;  
+  const reco::PFTrajectoryPoint& closestApproach = particle.trajectoryPoint(reco::PFTrajectoryPoint::ClosestApproach);
 
-  const reco::PFTrajectoryPoint& closestApproach = 
-    particle.trajectoryPoint(reco::PFTrajectoryPoint::ClosestApproach);
-  
-  out<<setiosflags(ios::right);
-  out<<setiosflags(ios::fixed);
-  
-  out<<"Particle #"<<particle.id()
-     <<", mother = "<<setw(2)<<particle.motherId();
-  
-  out<<setprecision(1);
-  out<<", charge = "<<setw(5)<<particle.charge();
-  out<<setprecision(3);
-  
+  out << setiosflags(ios::right);
+  out << setiosflags(ios::fixed);
+
+  out << "Particle #" << particle.id() << ", mother = " << setw(2) << particle.motherId();
+
+  out << setprecision(1);
+  out << ", charge = " << setw(5) << particle.charge();
+  out << setprecision(3);
+
   //   modif to get "name" of particle from pdg code
   int partId = particle.pdgCode();
   std::string name;
-  
-  // We have here a subset of particles only. 
+
+  // We have here a subset of particles only.
   // To be filled according to the needs.
-  switch(partId) {
-	  case    1: { name = "d"; break; } 
-	  case    2: { name = "u"; break; } 
-	  case    3: { name = "s"; break; } 
-	  case    4: { name = "c"; break; } 
-	  case    5: { name = "b"; break; } 
-	  case    6: { name = "t"; break; } 
-	  case   -1: { name = "~d"; break; } 
-	  case   -2: { name = "~u"; break; } 
-	  case   -3: { name = "~s"; break; } 
-	  case   -4: { name = "~c"; break; } 
-	  case   -5: { name = "~b"; break; } 
-	  case   -6: { name = "~t"; break; } 
-	  case   11: { name = "e-"; break; }
-	  case  -11: { name = "e+"; break; }
-	  case   12: { name = "nu_e"; break; }
-	  case  -12: { name = "~nu_e"; break; }
-	  case   13: { name = "mu-"; break; }
-	  case  -13: { name = "mu+"; break; }
-	  case   14: { name = "nu_mu"; break; }
-	  case  -14: { name = "~nu_mu"; break; }
-	  case   15: { name = "tau-"; break; }
-	  case  -15: { name = "tau+"; break; }
-	  case   16: { name = "nu_tau"; break; }
-	  case  -16: { name = "~nu_tau"; break; }
-	  case   21: { name = "gluon"; break; }
-	  case   22: { name = "gamma"; break; }
-	  case   23: { name = "Z0"; break; }
-	  case   24: { name = "W+"; break; }
-	  case   25: { name = "H0"; break; }
-	  case  -24: { name = "W-"; break; }
-	  case  111: { name = "pi0"; break; }
-	  case  113: { name = "rho0"; break; }
-	  case  223: { name = "omega"; break; }
-	  case  333: { name = "phi"; break; }
-	  case  443: { name = "J/psi"; break; }
-	  case  553: { name = "Upsilon"; break; }
-	  case  130: { name = "K0L"; break; }
-	  case  211: { name = "pi+"; break; }
-	  case -211: { name = "pi-"; break; }
-	  case  213: { name = "rho+"; break; }
-	  case -213: { name = "rho-"; break; }
-	  case  221: { name = "eta"; break; }
-	  case  331: { name = "eta'"; break; }
-	  case  441: { name = "etac"; break; }
-	  case  551: { name = "etab"; break; }
-	  case  310: { name = "K0S"; break; }
-	  case  311: { name = "K0"; break; }
-	  case -311: { name = "Kbar0"; break; }
-	  case  321: { name = "K+"; break; }
-	  case -321: { name = "K-"; break; }
-	  case  411: { name = "D+"; break; }
-	  case -411: { name = "D-"; break; }
-	  case  421: { name = "D0"; break; }
-	  case  431: { name = "Ds_+"; break; }
-	  case -431: { name = "Ds_-"; break; }
-	  case  511: { name = "B0"; break; }
-	  case  521: { name = "B+"; break; }
-	  case -521: { name = "B-"; break; }
-	  case  531: { name = "Bs_0"; break; }
-	  case  541: { name = "Bc_+"; break; }
-	  case -541: { name = "Bc_+"; break; }
-	  case  313: { name = "K*0"; break; }
-	  case -313: { name = "K*bar0"; break; }
-	  case  323: { name = "K*+"; break; }
-	  case -323: { name = "K*-"; break; }
-	  case  413: { name = "D*+"; break; }
-	  case -413: { name = "D*-"; break; }
-	  case  423: { name = "D*0"; break; }
-	  case  513: { name = "B*0"; break; }
-	  case  523: { name = "B*+"; break; }
-	  case -523: { name = "B*-"; break; }
-	  case  533: { name = "B*_s0"; break; }
-	  case  543: { name = "B*_c+"; break; }
-	  case -543: { name = "B*_c-"; break; }
-	  case  1114: { name = "Delta-"; break; }
-	  case -1114: { name = "Deltabar+"; break; }
-	  case -2112: { name = "nbar0"; break; }
-	  case  2112: { name = "n"; break; }
-	  case  2114: { name = "Delta0"; break; }
-	  case -2114: { name = "Deltabar0"; break; }
-	  case  3122: { name = "Lambda0"; break; }
-	  case -3122: { name = "Lambdabar0"; break; }
-	  case  3112: { name = "Sigma-"; break; }
-	  case -3112: { name = "Sigmabar+"; break; }
-	  case  3212: { name = "Sigma0"; break; }
-	  case -3212: { name = "Sigmabar0"; break; }
-	  case  3214: { name = "Sigma*0"; break; }
-	  case -3214: { name = "Sigma*bar0"; break; }
-	  case  3222: { name = "Sigma+"; break; }
-	  case -3222: { name = "Sigmabar-"; break; }
-	  case  2212: { name = "p"; break; }
-	  case -2212: { name = "~p"; break; }
-	  case -2214: { name = "Delta-"; break; }
-	  case  2214: { name = "Delta+"; break; }
-	  case -2224: { name = "Deltabar--"; break; }
-	  case  2224: { name = "Delta++"; break; }
-	  default: { 
-    name = "unknown"; 
-    cout << "Unknown code : " << partId << endl;
-  }   
+  switch (partId) {
+    case 1: {
+      name = "d";
+      break;
+    }
+    case 2: {
+      name = "u";
+      break;
+    }
+    case 3: {
+      name = "s";
+      break;
+    }
+    case 4: {
+      name = "c";
+      break;
+    }
+    case 5: {
+      name = "b";
+      break;
+    }
+    case 6: {
+      name = "t";
+      break;
+    }
+    case -1: {
+      name = "~d";
+      break;
+    }
+    case -2: {
+      name = "~u";
+      break;
+    }
+    case -3: {
+      name = "~s";
+      break;
+    }
+    case -4: {
+      name = "~c";
+      break;
+    }
+    case -5: {
+      name = "~b";
+      break;
+    }
+    case -6: {
+      name = "~t";
+      break;
+    }
+    case 11: {
+      name = "e-";
+      break;
+    }
+    case -11: {
+      name = "e+";
+      break;
+    }
+    case 12: {
+      name = "nu_e";
+      break;
+    }
+    case -12: {
+      name = "~nu_e";
+      break;
+    }
+    case 13: {
+      name = "mu-";
+      break;
+    }
+    case -13: {
+      name = "mu+";
+      break;
+    }
+    case 14: {
+      name = "nu_mu";
+      break;
+    }
+    case -14: {
+      name = "~nu_mu";
+      break;
+    }
+    case 15: {
+      name = "tau-";
+      break;
+    }
+    case -15: {
+      name = "tau+";
+      break;
+    }
+    case 16: {
+      name = "nu_tau";
+      break;
+    }
+    case -16: {
+      name = "~nu_tau";
+      break;
+    }
+    case 21: {
+      name = "gluon";
+      break;
+    }
+    case 22: {
+      name = "gamma";
+      break;
+    }
+    case 23: {
+      name = "Z0";
+      break;
+    }
+    case 24: {
+      name = "W+";
+      break;
+    }
+    case 25: {
+      name = "H0";
+      break;
+    }
+    case -24: {
+      name = "W-";
+      break;
+    }
+    case 111: {
+      name = "pi0";
+      break;
+    }
+    case 113: {
+      name = "rho0";
+      break;
+    }
+    case 223: {
+      name = "omega";
+      break;
+    }
+    case 333: {
+      name = "phi";
+      break;
+    }
+    case 443: {
+      name = "J/psi";
+      break;
+    }
+    case 553: {
+      name = "Upsilon";
+      break;
+    }
+    case 130: {
+      name = "K0L";
+      break;
+    }
+    case 211: {
+      name = "pi+";
+      break;
+    }
+    case -211: {
+      name = "pi-";
+      break;
+    }
+    case 213: {
+      name = "rho+";
+      break;
+    }
+    case -213: {
+      name = "rho-";
+      break;
+    }
+    case 221: {
+      name = "eta";
+      break;
+    }
+    case 331: {
+      name = "eta'";
+      break;
+    }
+    case 441: {
+      name = "etac";
+      break;
+    }
+    case 551: {
+      name = "etab";
+      break;
+    }
+    case 310: {
+      name = "K0S";
+      break;
+    }
+    case 311: {
+      name = "K0";
+      break;
+    }
+    case -311: {
+      name = "Kbar0";
+      break;
+    }
+    case 321: {
+      name = "K+";
+      break;
+    }
+    case -321: {
+      name = "K-";
+      break;
+    }
+    case 411: {
+      name = "D+";
+      break;
+    }
+    case -411: {
+      name = "D-";
+      break;
+    }
+    case 421: {
+      name = "D0";
+      break;
+    }
+    case 431: {
+      name = "Ds_+";
+      break;
+    }
+    case -431: {
+      name = "Ds_-";
+      break;
+    }
+    case 511: {
+      name = "B0";
+      break;
+    }
+    case 521: {
+      name = "B+";
+      break;
+    }
+    case -521: {
+      name = "B-";
+      break;
+    }
+    case 531: {
+      name = "Bs_0";
+      break;
+    }
+    case 541: {
+      name = "Bc_+";
+      break;
+    }
+    case -541: {
+      name = "Bc_+";
+      break;
+    }
+    case 313: {
+      name = "K*0";
+      break;
+    }
+    case -313: {
+      name = "K*bar0";
+      break;
+    }
+    case 323: {
+      name = "K*+";
+      break;
+    }
+    case -323: {
+      name = "K*-";
+      break;
+    }
+    case 413: {
+      name = "D*+";
+      break;
+    }
+    case -413: {
+      name = "D*-";
+      break;
+    }
+    case 423: {
+      name = "D*0";
+      break;
+    }
+    case 513: {
+      name = "B*0";
+      break;
+    }
+    case 523: {
+      name = "B*+";
+      break;
+    }
+    case -523: {
+      name = "B*-";
+      break;
+    }
+    case 533: {
+      name = "B*_s0";
+      break;
+    }
+    case 543: {
+      name = "B*_c+";
+      break;
+    }
+    case -543: {
+      name = "B*_c-";
+      break;
+    }
+    case 1114: {
+      name = "Delta-";
+      break;
+    }
+    case -1114: {
+      name = "Deltabar+";
+      break;
+    }
+    case -2112: {
+      name = "nbar0";
+      break;
+    }
+    case 2112: {
+      name = "n";
+      break;
+    }
+    case 2114: {
+      name = "Delta0";
+      break;
+    }
+    case -2114: {
+      name = "Deltabar0";
+      break;
+    }
+    case 3122: {
+      name = "Lambda0";
+      break;
+    }
+    case -3122: {
+      name = "Lambdabar0";
+      break;
+    }
+    case 3112: {
+      name = "Sigma-";
+      break;
+    }
+    case -3112: {
+      name = "Sigmabar+";
+      break;
+    }
+    case 3212: {
+      name = "Sigma0";
+      break;
+    }
+    case -3212: {
+      name = "Sigmabar0";
+      break;
+    }
+    case 3214: {
+      name = "Sigma*0";
+      break;
+    }
+    case -3214: {
+      name = "Sigma*bar0";
+      break;
+    }
+    case 3222: {
+      name = "Sigma+";
+      break;
+    }
+    case -3222: {
+      name = "Sigmabar-";
+      break;
+    }
+    case 2212: {
+      name = "p";
+      break;
+    }
+    case -2212: {
+      name = "~p";
+      break;
+    }
+    case -2214: {
+      name = "Delta-";
+      break;
+    }
+    case 2214: {
+      name = "Delta+";
+      break;
+    }
+    case -2224: {
+      name = "Deltabar--";
+      break;
+    }
+    case 2224: {
+      name = "Delta++";
+      break;
+    }
+    default: {
+      name = "unknown";
+      cout << "Unknown code : " << partId << endl;
+    }
   }
-  
-  out<<", pdg="<<setw(6)<<particle.pdgCode() << setw(6)<< name
-    
-    // end of modif to get name from pdg code
-    
-     <<", pT ="<<setw(7)<<closestApproach.momentum().Pt() 
-     <<", E  ="<<setw(7)<<closestApproach.momentum().E();
-  
-  out<<resetiosflags(ios::right|ios::fixed);
-  
-  out<<"\tdaughters : ";
-  for(unsigned i=0; i<particle.daughterIds().size(); i++) 
-    out<<particle.daughterIds()[i]<<" ";
-  
+
+  out << ", pdg=" << setw(6) << particle.pdgCode() << setw(6)
+      << name
+
+      // end of modif to get name from pdg code
+
+      << ", pT =" << setw(7) << closestApproach.momentum().Pt() << ", E  =" << setw(7)
+      << closestApproach.momentum().E();
+
+  out << resetiosflags(ios::right | ios::fixed);
+
+  out << "\tdaughters : ";
+  for (unsigned i = 0; i < particle.daughterIds().size(); i++)
+    out << particle.daughterIds()[i] << " ";
+
   //   out<<endl;
-  //   for(unsigned i=0; i<particle.trajectoryPoints_.size(); i++) 
+  //   for(unsigned i=0; i<particle.trajectoryPoints_.size(); i++)
   //     out<<particle.trajectoryPoints_[i]<<endl;
-  
+
   return out;
 }

--- a/DataFormats/ParticleFlowReco/src/PFSuperCluster.cc
+++ b/DataFormats/ParticleFlowReco/src/PFSuperCluster.cc
@@ -2,59 +2,43 @@
 #include "DataFormats/GeometryVector/interface/Pi.h"
 #include "DataFormats/Common/interface/PtrVector.h"
 
-
 using namespace std;
 using namespace reco;
 
-PFSuperCluster::PFSuperCluster(const edm::PtrVector<reco::PFCluster>& clusters):
-clusters_(clusters)
-{  
-}
+PFSuperCluster::PFSuperCluster(const edm::PtrVector<reco::PFCluster>& clusters) : clusters_(clusters) {}
 
 void PFSuperCluster::reset() {
-  
   PFCluster::reset();
   clusters_.clear();
-
 }
 
 PFSuperCluster& PFSuperCluster::operator=(const PFSuperCluster& other) {
-
-  PFCluster::operator=((PFCluster)other); 
+  PFCluster::operator=((PFCluster)other);
   clusters_ = other.clusters_;
 
   return *this;
 }
 
+std::ostream& reco::operator<<(std::ostream& out, const PFSuperCluster& cluster) {
+  if (!out)
+    return out;
 
-std::ostream& reco::operator<<(std::ostream& out, 
-                               const PFSuperCluster& cluster) {
-  
-  if(!out) return out;
+  const math::XYZPoint& pos = cluster.position();
+  const PFCluster::REPPoint& posrep = cluster.positionREP();
+  const std::vector<reco::PFRecHitFraction>& fracs = cluster.recHitFractions();
 
-  const math::XYZPoint&  pos = cluster.position();
-  const PFCluster::REPPoint&  posrep = cluster.positionREP();
-  const std::vector< reco::PFRecHitFraction >& fracs =
-    cluster.recHitFractions();
+  out << "PFSuperCluster "
+      << ", clusters: " << cluster.clusters().size() << ", layer: " << cluster.layer() << "\tE = " << cluster.energy()
+      << "\tXYZ: " << pos.X() << "," << pos.Y() << "," << pos.Z() << " | "
+      << "\tREP: " << posrep.Rho() << "," << posrep.Eta() << "," << posrep.Phi() << " | " << fracs.size() << " rechits";
 
-  out<<"PFSuperCluster "
-     <<", clusters: "<<cluster.clusters().size()
-     <<", layer: "<<cluster.layer()
-     <<"\tE = "<<cluster.energy()
-     <<"\tXYZ: "
-     <<pos.X()<<","<<pos.Y()<<","<<pos.Z()<<" | "
-     <<"\tREP: "
-     <<posrep.Rho()<<","<<posrep.Eta()<<","<<posrep.Phi()<<" | "
-     <<fracs.size()<<" rechits";
-
-  for(unsigned i=0; i<fracs.size(); i++) {
+  for (unsigned i = 0; i < fracs.size(); i++) {
     // PFRecHit is not available, print the detID
-    if( !fracs[i].recHitRef().isAvailable() )
-      out<<cluster.printHitAndFraction(i)<<", ";
+    if (!fracs[i].recHitRef().isAvailable())
+      out << cluster.printHitAndFraction(i) << ", ";
     else
-      out<<fracs[i]<<", ";
+      out << fracs[i] << ", ";
   }
 
-  
   return out;
 }

--- a/DataFormats/ParticleFlowReco/src/PFTrack.cc
+++ b/DataFormats/ParticleFlowReco/src/PFTrack.cc
@@ -1,6 +1,6 @@
 #include "DataFormats/ParticleFlowReco/interface/PFTrack.h"
-#include "Math/GenVector/PositionVector3D.h" 
-#include "DataFormats/Math/interface/Point3D.h" 
+#include "Math/GenVector/PositionVector3D.h"
+#include "DataFormats/Math/interface/Point3D.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 using namespace reco;
@@ -8,54 +8,39 @@ using namespace std;
 
 const unsigned PFTrack::nMaxTrackingLayers_ = 17;
 
-PFTrack::PFTrack() :
-  charge_(0.),
-  indexInnermost_(0),
-  indexOutermost_(0),
-  color_(1) {
-
+PFTrack::PFTrack() : charge_(0.), indexInnermost_(0), indexOutermost_(0), color_(1) {
   // prepare vector of trajectory points for propagated positions
   trajectoryPoints_.reserve(PFTrajectoryPoint::NLayers + nMaxTrackingLayers_);
 }
 
-
-PFTrack::PFTrack(double charge) : 
-  charge_(charge), 
-  indexInnermost_(0),
-  indexOutermost_(0),
-  color_(1) {
-
+PFTrack::PFTrack(double charge) : charge_(charge), indexInnermost_(0), indexOutermost_(0), color_(1) {
   // prepare vector of trajectory points for propagated positions
   trajectoryPoints_.reserve(PFTrajectoryPoint::NLayers + nMaxTrackingLayers_);
 }
-  
 
-PFTrack::PFTrack(const PFTrack& other) :
-  charge_(other.charge_), 
-  trajectoryPoints_(other.trajectoryPoints_),
-  indexInnermost_(other.indexInnermost_),
-  indexOutermost_(other.indexOutermost_),
-  color_(other.color_)
-{}
-
+PFTrack::PFTrack(const PFTrack& other)
+    : charge_(other.charge_),
+      trajectoryPoints_(other.trajectoryPoints_),
+      indexInnermost_(other.indexInnermost_),
+      indexOutermost_(other.indexOutermost_),
+      color_(other.color_) {}
 
 void PFTrack::addPoint(const PFTrajectoryPoint& trajPt) {
-  
   //   cout<<"adding "<<trajPt<<endl;
 
   if (trajPt.isTrackerLayer()) {
-    if (!indexOutermost_) { // first time a measurement is added
+    if (!indexOutermost_) {  // first time a measurement is added
       if (trajectoryPoints_.size() < PFTrajectoryPoint::BeamPipeOrEndVertex + 1) {
         PFTrajectoryPoint dummyPt;
         for (unsigned iPt = trajectoryPoints_.size(); iPt < PFTrajectoryPoint::BeamPipeOrEndVertex + 1; iPt++)
           trajectoryPoints_.push_back(dummyPt);
       } else if (trajectoryPoints_.size() > PFTrajectoryPoint::BeamPipeOrEndVertex + 1) {
         // throw an exception here
-        //      edm::LogError("PFTrack")<<"trajectoryPoints_.size() is too large = " 
+        //      edm::LogError("PFTrack")<<"trajectoryPoints_.size() is too large = "
         //                              <<trajectoryPoints_.size()<<"\n";
       }
       indexOutermost_ = indexInnermost_ = PFTrajectoryPoint::BeamPipeOrEndVertex + 1;
-    } else 
+    } else
       indexOutermost_++;
   }
   // Use push_back instead of insert in order to gain time
@@ -64,55 +49,42 @@ void PFTrack::addPoint(const PFTrajectoryPoint& trajPt) {
   //   cout<<"adding point "<<*this<<endl;
 }
 
-
 void PFTrack::calculatePositionREP() {
-  
   //for(unsigned i=0; i<trajectoryPoints_.size(); i++) {
   //  trajectoryPoints_[i].calculatePositionREP();
   //}
 }
 
- 
 const reco::PFTrajectoryPoint& PFTrack::extrapolatedPoint(unsigned layerid) const {
   const unsigned offset_layerid = nTrajectoryMeasurements() + layerid;
-  if( layerid >= reco::PFTrajectoryPoint::NLayers ||
-      offset_layerid >= trajectoryPoints_.size() ) {
-
+  if (layerid >= reco::PFTrajectoryPoint::NLayers || offset_layerid >= trajectoryPoints_.size()) {
     // cout<<(*this)<<endl;
     // cout<<"lid "<<layerid<<" "<<nTrajectoryMeasurements()<<" "<<trajectoryPoints_.size()<<endl;
-    
-    throw cms::Exception("SizeError")<<"PFRecTrack::extrapolatedPoint: cannot access "
-				     <<layerid
-				     <<" #traj meas = "<<nTrajectoryMeasurements()
-				     <<" #traj points = "<<trajectoryPoints_.size()
-				     <<endl
-				     <<(*this);
+
+    throw cms::Exception("SizeError") << "PFRecTrack::extrapolatedPoint: cannot access " << layerid
+                                      << " #traj meas = " << nTrajectoryMeasurements()
+                                      << " #traj points = " << trajectoryPoints_.size() << endl
+                                      << (*this);
     // assert(0);
   }
   if (layerid < indexInnermost_)
-    return trajectoryPoints_[ layerid ];
+    return trajectoryPoints_[layerid];
   else
-    return trajectoryPoints_[ offset_layerid ];  
+    return trajectoryPoints_[offset_layerid];
 }
 
+ostream& reco::operator<<(ostream& out, const PFTrack& track) {
+  if (!out)
+    return out;
 
-ostream& reco::operator<<(ostream& out, 
-                          const PFTrack& track) {  
-  if (!out) return out;  
+  const reco::PFTrajectoryPoint& closestApproach = track.trajectoryPoint(reco::PFTrajectoryPoint::ClosestApproach);
 
-  const reco::PFTrajectoryPoint& closestApproach = 
-    track.trajectoryPoint(reco::PFTrajectoryPoint::ClosestApproach);
-
-  out<<"Track charge = "<<track.charge() 
-     <<", Pt = "<<closestApproach.momentum().Pt() 
-     <<", P = "<<closestApproach.momentum().P()<<endl
-     <<"\tR0 = "<<closestApproach.position().Rho()
-     <<" Z0 = "<<closestApproach.position().Z()<<endl
-     <<"\tnumber of tracker measurements = " 
-     <<track.nTrajectoryMeasurements()<<endl;
-  for(unsigned i=0; i<track.trajectoryPoints().size(); i++) 
-    out<<track.trajectoryPoints()[i]<<endl;
-  
+  out << "Track charge = " << track.charge() << ", Pt = " << closestApproach.momentum().Pt()
+      << ", P = " << closestApproach.momentum().P() << endl
+      << "\tR0 = " << closestApproach.position().Rho() << " Z0 = " << closestApproach.position().Z() << endl
+      << "\tnumber of tracker measurements = " << track.nTrajectoryMeasurements() << endl;
+  for (unsigned i = 0; i < track.trajectoryPoints().size(); i++)
+    out << track.trajectoryPoints()[i] << endl;
 
   return out;
 }

--- a/DataFormats/ParticleFlowReco/src/PFTrajectoryPoint.cc
+++ b/DataFormats/ParticleFlowReco/src/PFTrajectoryPoint.cc
@@ -3,58 +3,44 @@
 
 using namespace reco;
 
-PFTrajectoryPoint::PFTrajectoryPoint() : 
-  isTrackerLayer_(false),
-  detId_(-1),
-  layer_(-1) {}
-
+PFTrajectoryPoint::PFTrajectoryPoint() : isTrackerLayer_(false), detId_(-1), layer_(-1) {}
 
 PFTrajectoryPoint::PFTrajectoryPoint(int detId,
-                                     int layer, 
-                                     const math::XYZPoint& posxyz, 
-                                     const math::XYZTLorentzVector& momentum) :
-  isTrackerLayer_(false),
-  detId_(detId),
-  layer_(layer),
-  posxyz_(posxyz),
-  momentum_(momentum) 
-{ 
-  if (detId) isTrackerLayer_ = true;
-  posrep_.SetCoordinates(posxyz_.Rho(), posxyz_.Eta(), posxyz_.Phi()); 
+                                     int layer,
+                                     const math::XYZPoint& posxyz,
+                                     const math::XYZTLorentzVector& momentum)
+    : isTrackerLayer_(false), detId_(detId), layer_(layer), posxyz_(posxyz), momentum_(momentum) {
+  if (detId)
+    isTrackerLayer_ = true;
+  posrep_.SetCoordinates(posxyz_.Rho(), posxyz_.Eta(), posxyz_.Phi());
 }
 
+PFTrajectoryPoint::PFTrajectoryPoint(const PFTrajectoryPoint& other)
+    : isTrackerLayer_(other.isTrackerLayer_),
+      detId_(other.detId_),
+      layer_(other.layer_),
+      posxyz_(other.posxyz_),
+      posrep_(other.posrep_),
+      momentum_(other.momentum_) {}
 
-PFTrajectoryPoint::PFTrajectoryPoint(const PFTrajectoryPoint& other) :
-  isTrackerLayer_(other.isTrackerLayer_),
-  detId_(other.detId_), 
-  layer_(other.layer_), 
-  posxyz_(other.posxyz_), 
-  posrep_(other.posrep_),
-  momentum_(other.momentum_) { }
+PFTrajectoryPoint::~PFTrajectoryPoint() {}
 
-
-PFTrajectoryPoint::~PFTrajectoryPoint() 
-{}
-
-
-bool   PFTrajectoryPoint::operator==(const reco::PFTrajectoryPoint& other) const {
-  if( posxyz_ == other.posxyz_ && 
-      momentum_ == other.momentum_ ) return true;
-  else return false;
+bool PFTrajectoryPoint::operator==(const reco::PFTrajectoryPoint& other) const {
+  if (posxyz_ == other.posxyz_ && momentum_ == other.momentum_)
+    return true;
+  else
+    return false;
 }
 
-std::ostream& reco::operator<<(std::ostream& out, 
-                               const reco::PFTrajectoryPoint& trajPoint) {
-  if(!out) return out;
-  
+std::ostream& reco::operator<<(std::ostream& out, const reco::PFTrajectoryPoint& trajPoint) {
+  if (!out)
+    return out;
+
   const math::XYZPoint& posxyz = trajPoint.position();
-  
-  out<<"Traj point id = "<<trajPoint.detId()
-     <<", layer = "<<trajPoint.layer()
-     <<", Eta,Phi = "<<posxyz.Eta()<<","<<posxyz.Phi()
-     <<", X,Y = "<<posxyz.X()<<","<<posxyz.Y()
-     <<", R,Z = "<<posxyz.Rho()<<","<<posxyz.Z()
-     <<", E,Pt = "<<trajPoint.momentum().E()<<","<<trajPoint.momentum().Pt();
-  
+
+  out << "Traj point id = " << trajPoint.detId() << ", layer = " << trajPoint.layer() << ", Eta,Phi = " << posxyz.Eta()
+      << "," << posxyz.Phi() << ", X,Y = " << posxyz.X() << "," << posxyz.Y() << ", R,Z = " << posxyz.Rho() << ","
+      << posxyz.Z() << ", E,Pt = " << trajPoint.momentum().E() << "," << trajPoint.momentum().Pt();
+
   return out;
 }

--- a/DataFormats/ParticleFlowReco/src/PreId.cc
+++ b/DataFormats/ParticleFlowReco/src/PreId.cc
@@ -3,28 +3,20 @@
 
 using namespace reco;
 
-void PreId::setMatching(MatchingType type,bool result,unsigned n)
-{
-  if(n<matching_.size())
-    {
-      if(result)
-	{
-	  matching_[n] |= (1 << type);
-	}
-      else
-	{
-	  matching_[n] &= ~(1 <<type);
-	}
+void PreId::setMatching(MatchingType type, bool result, unsigned n) {
+  if (n < matching_.size()) {
+    if (result) {
+      matching_[n] |= (1 << type);
+    } else {
+      matching_[n] &= ~(1 << type);
     }
-  else
-    {
-      std::cout << " Out of range " << std::endl;
-    }
+  } else {
+    std::cout << " Out of range " << std::endl;
+  }
 }
 
-float PreId::mva(unsigned n) const
-{
-  if(n<mva_.size())
+float PreId::mva(unsigned n) const {
+  if (n < mva_.size())
     return mva_[n];
   return -999.;
 }

--- a/DataFormats/ParticleFlowReco/src/classes_1.h
+++ b/DataFormats/ParticleFlowReco/src/classes_1.h
@@ -26,9 +26,9 @@
 #include "DataFormats/ParticleFlowReco/interface/PFTrajectoryPoint.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElement.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h"
-#include "DataFormats/ParticleFlowReco/interface/PFBlockElementGsfTrack.h"  //Daniele
-#include "DataFormats/ParticleFlowReco/interface/PFBlockElementBrem.h"  //Daniele
-#include "DataFormats/ParticleFlowReco/interface/PFBlockElementSuperCluster.h" //Florian
+#include "DataFormats/ParticleFlowReco/interface/PFBlockElementGsfTrack.h"      //Daniele
+#include "DataFormats/ParticleFlowReco/interface/PFBlockElementBrem.h"          //Daniele
+#include "DataFormats/ParticleFlowReco/interface/PFBlockElementSuperCluster.h"  //Florian
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
 #include "DataFormats/ParticleFlowReco/interface/PFDisplacedTrackerVertex.h"
@@ -53,4 +53,3 @@
 #include "DataFormats/ParticleFlowReco/interface/RecoPFClusterRefCandidateFwd.h"
 
 #include <map>
-

--- a/DataFormats/ParticleFlowReco/src/classes_2.h
+++ b/DataFormats/ParticleFlowReco/src/classes_2.h
@@ -26,9 +26,9 @@
 #include "DataFormats/ParticleFlowReco/interface/PFTrajectoryPoint.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElement.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementTrack.h"
-#include "DataFormats/ParticleFlowReco/interface/PFBlockElementGsfTrack.h"  //Daniele
-#include "DataFormats/ParticleFlowReco/interface/PFBlockElementBrem.h"  //Daniele
-#include "DataFormats/ParticleFlowReco/interface/PFBlockElementSuperCluster.h" //Florian
+#include "DataFormats/ParticleFlowReco/interface/PFBlockElementGsfTrack.h"      //Daniele
+#include "DataFormats/ParticleFlowReco/interface/PFBlockElementBrem.h"          //Daniele
+#include "DataFormats/ParticleFlowReco/interface/PFBlockElementSuperCluster.h"  //Florian
 #include "DataFormats/ParticleFlowReco/interface/PFBlockElementCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
 #include "DataFormats/ParticleFlowReco/interface/PFDisplacedTrackerVertex.h"
@@ -55,4 +55,3 @@
 #include "DataFormats/ParticleFlowReco/interface/HGCalMultiCluster.h"
 
 #include <map>
-

--- a/DataFormats/ParticleFlowReco/test/test_catch2_PFDisplacedVertexSeed.cc
+++ b/DataFormats/ParticleFlowReco/test/test_catch2_PFDisplacedVertexSeed.cc
@@ -10,68 +10,64 @@ TEST_CASE("Check adding elements", s_tag) {
   REQUIRE(seed.elements().empty());
 
   SECTION("updateSeedPoint") {
-
     //empty tracks are fine
     std::vector<reco::Track> tracks(5);
-    
-    seed.updateSeedPoint(GlobalPoint(0.01,0.01,0.01),
-                         reco::TrackBaseRef(reco::TrackRef(&tracks,0)),
-                         reco::TrackBaseRef(reco::TrackRef(&tracks,1)) );
+
+    seed.updateSeedPoint(GlobalPoint(0.01, 0.01, 0.01),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks, 0)),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks, 1)));
     REQUIRE(seed.elements().size() == 2);
     REQUIRE(seed.nTracks() == 2);
 
-    seed.updateSeedPoint(GlobalPoint(0.01,0.01,0.01),
-                         reco::TrackBaseRef(reco::TrackRef(&tracks,0)),
-                         reco::TrackBaseRef(reco::TrackRef(&tracks,1)) );
+    seed.updateSeedPoint(GlobalPoint(0.01, 0.01, 0.01),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks, 0)),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks, 1)));
     REQUIRE(seed.elements().size() == 2);
     REQUIRE(seed.nTracks() == 2);
 
-    seed.updateSeedPoint(GlobalPoint(0.01,0.01,0.01),
-                         reco::TrackBaseRef(reco::TrackRef(&tracks,0)),
-                         reco::TrackBaseRef(reco::TrackRef(&tracks,2)) );
+    seed.updateSeedPoint(GlobalPoint(0.01, 0.01, 0.01),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks, 0)),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks, 2)));
     REQUIRE(seed.elements().size() == 3);
     REQUIRE(seed.nTracks() == 3);
 
-    seed.updateSeedPoint(GlobalPoint(0.01,0.01,0.01),
-                         reco::TrackBaseRef(reco::TrackRef(&tracks,3)),
-                         reco::TrackBaseRef(reco::TrackRef(&tracks,4)) );
+    seed.updateSeedPoint(GlobalPoint(0.01, 0.01, 0.01),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks, 3)),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks, 4)));
     REQUIRE(seed.elements().size() == 5);
     REQUIRE(seed.nTracks() == 5);
-
   }
-  
+
   SECTION("addElement") {
     //empty tracks are fine
     std::vector<reco::Track> tracks(3);
-    
-    seed.updateSeedPoint(GlobalPoint(0.01,0.01,0.01),
-                         reco::TrackBaseRef(reco::TrackRef(&tracks,0)),
-                         reco::TrackBaseRef(reco::TrackRef(&tracks,1)) );
+
+    seed.updateSeedPoint(GlobalPoint(0.01, 0.01, 0.01),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks, 0)),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks, 1)));
     REQUIRE(seed.elements().size() == 2);
     REQUIRE(seed.nTracks() == 2);
 
-    seed.addElement(reco::TrackBaseRef(reco::TrackRef(&tracks,0)));
+    seed.addElement(reco::TrackBaseRef(reco::TrackRef(&tracks, 0)));
     REQUIRE(seed.elements().size() == 2);
     REQUIRE(seed.nTracks() == 2);
 
-    seed.addElement(reco::TrackBaseRef(reco::TrackRef(&tracks,2)));
+    seed.addElement(reco::TrackBaseRef(reco::TrackRef(&tracks, 2)));
     REQUIRE(seed.elements().size() == 3);
     REQUIRE(seed.nTracks() == 3);
-
   }
   SECTION("mergeWith") {
     std::vector<reco::Track> tracks(5);
-    
-    seed.updateSeedPoint(GlobalPoint(0.01,0.01,0.01),
-                         reco::TrackBaseRef(reco::TrackRef(&tracks,0)),
-                         reco::TrackBaseRef(reco::TrackRef(&tracks,1)) );
 
+    seed.updateSeedPoint(GlobalPoint(0.01, 0.01, 0.01),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks, 0)),
+                         reco::TrackBaseRef(reco::TrackRef(&tracks, 1)));
 
     SECTION("completely overlapping seeds") {
       reco::PFDisplacedVertexSeed otherSeed;
-      otherSeed.updateSeedPoint(GlobalPoint(0.01,0.01,0.01),
-                                       reco::TrackBaseRef(reco::TrackRef(&tracks,0)),
-                                       reco::TrackBaseRef(reco::TrackRef(&tracks,1)) );
+      otherSeed.updateSeedPoint(GlobalPoint(0.01, 0.01, 0.01),
+                                reco::TrackBaseRef(reco::TrackRef(&tracks, 0)),
+                                reco::TrackBaseRef(reco::TrackRef(&tracks, 1)));
 
       seed.mergeWith(otherSeed);
       REQUIRE(seed.elements().size() == 2);
@@ -79,26 +75,24 @@ TEST_CASE("Check adding elements", s_tag) {
 
     SECTION("partially overlapping seeds") {
       reco::PFDisplacedVertexSeed otherSeed;
-      otherSeed.updateSeedPoint(GlobalPoint(0.01,0.01,0.01),
-                                       reco::TrackBaseRef(reco::TrackRef(&tracks,0)),
-                                       reco::TrackBaseRef(reco::TrackRef(&tracks,2)) );
+      otherSeed.updateSeedPoint(GlobalPoint(0.01, 0.01, 0.01),
+                                reco::TrackBaseRef(reco::TrackRef(&tracks, 0)),
+                                reco::TrackBaseRef(reco::TrackRef(&tracks, 2)));
 
       seed.mergeWith(otherSeed);
       REQUIRE(seed.elements().size() == 3);
     }
 
     SECTION("non overlapping seeds") {
-      REQUIRE(seed.elements().size()==2);
+      REQUIRE(seed.elements().size() == 2);
       reco::PFDisplacedVertexSeed otherSeed;
-      otherSeed.updateSeedPoint(GlobalPoint(0.01,0.01,0.01),
-                                       reco::TrackBaseRef(reco::TrackRef(&tracks,3)),
-                                       reco::TrackBaseRef(reco::TrackRef(&tracks,2)) );
+      otherSeed.updateSeedPoint(GlobalPoint(0.01, 0.01, 0.01),
+                                reco::TrackBaseRef(reco::TrackRef(&tracks, 3)),
+                                reco::TrackBaseRef(reco::TrackRef(&tracks, 2)));
       REQUIRE(otherSeed.elements().size() == 2);
 
       seed.mergeWith(otherSeed);
       REQUIRE(seed.elements().size() == 4);
     }
-
   }
 }
-

--- a/MagneticField/Interpolation/interface/MFGrid.h
+++ b/MagneticField/Interpolation/interface/MFGrid.h
@@ -12,15 +12,13 @@
 #include "DataFormats/GeometrySurface/interface/GloballyPositioned.h"
 #include "MagneticField/Interpolation/interface/MagProviderInterpol.h"
 
-struct Dimensions 
-{
+struct Dimensions {
   int w;
   int h;
   int d;
 };
 
-struct Indexes
-{
+struct Indexes {
   int i;
   int j;
   int k;
@@ -28,44 +26,41 @@ struct Indexes
 
 class MFGrid : public MagProviderInterpol {
 public:
+  typedef GloballyPositioned<float>::GlobalPoint GlobalPoint;
+  typedef GloballyPositioned<float>::GlobalVector GlobalVector;
+  typedef GloballyPositioned<float>::LocalPoint LocalPoint;
+  typedef GloballyPositioned<float>::LocalVector LocalVector;
 
-  typedef GloballyPositioned<float>::GlobalPoint     GlobalPoint;
-  typedef GloballyPositioned<float>::GlobalVector    GlobalVector;
-  typedef GloballyPositioned<float>::LocalPoint      LocalPoint;
-  typedef GloballyPositioned<float>::LocalVector     LocalVector;
-
-  explicit MFGrid( const GloballyPositioned<float>& vol) : frame_(vol) {}
+  explicit MFGrid(const GloballyPositioned<float>& vol) : frame_(vol) {}
 
   ~MFGrid() override {}
 
   /// Interpolated field value at given point.
-  LocalVector valueInTesla( const LocalPoint& p) const override = 0;
+  LocalVector valueInTesla(const LocalPoint& p) const override = 0;
 
   virtual void dump() const {}
 
   /// find grid coordinates for point. For debugging and validation only.
-  virtual void toGridFrame( const LocalPoint& p, double& a, double& b, double& c) const = 0;
+  virtual void toGridFrame(const LocalPoint& p, double& a, double& b, double& c) const = 0;
 
   /// find grid coordinates for point. For debugging and validation only.
-  virtual LocalPoint fromGridFrame( double a, double b, double c) const = 0;
+  virtual LocalPoint fromGridFrame(double a, double b, double c) const = 0;
 
   virtual Dimensions dimensions() const = 0;
 
   /// Position of node in local frame
-  virtual LocalPoint  nodePosition( int i, int j, int k) const = 0;
+  virtual LocalPoint nodePosition(int i, int j, int k) const = 0;
 
   /// Field value at node
-  virtual LocalVector nodeValue( int i, int j, int k) const = 0;
+  virtual LocalVector nodeValue(int i, int j, int k) const = 0;
 
-  virtual Indexes index( const LocalPoint& p) const {return Indexes();}
+  virtual Indexes index(const LocalPoint& p) const { return Indexes(); }
 
   /// Local reference frame
-  const GloballyPositioned<float>& frame() const { return frame_;}
+  const GloballyPositioned<float>& frame() const { return frame_; }
 
 private:
-
   GloballyPositioned<float> frame_;
-
 };
 
 #endif

--- a/MagneticField/Interpolation/interface/MFGridFactory.h
+++ b/MagneticField/Interpolation/interface/MFGridFactory.h
@@ -10,18 +10,16 @@
 
 #include <string>
 class MFGrid;
-template <class T> class GloballyPositioned;
+template <class T>
+class GloballyPositioned;
 
 class MFGridFactory {
 public:
-
   /// Build interpolator for a binary grid file
   static MFGrid* build(const std::string& name, const GloballyPositioned<float>& vol);
 
   /// Build a 2pi phi-symmetric interpolator for a binary grid file
-  static MFGrid* build(const std::string& name, const GloballyPositioned<float>& vol,
-		       double phiMin, double phiMax);
-
+  static MFGrid* build(const std::string& name, const GloballyPositioned<float>& vol, double phiMin, double phiMax);
 };
 
 #endif

--- a/MagneticField/Interpolation/interface/MagProviderInterpol.h
+++ b/MagneticField/Interpolation/interface/MagProviderInterpol.h
@@ -3,6 +3,6 @@
 
 #include "MagneticField/VolumeGeometry/interface/MagneticFieldProvider.h"
 
-typedef MagneticFieldProvider<float>    MagProviderInterpol;
+typedef MagneticFieldProvider<float> MagProviderInterpol;
 
 #endif

--- a/MagneticField/Interpolation/src/CylinderFromSectorMFGrid.cc
+++ b/MagneticField/Interpolation/src/CylinderFromSectorMFGrid.cc
@@ -2,67 +2,63 @@
 #include "MagneticField/VolumeGeometry/interface/MagExceptions.h"
 #include <iostream>
 
-CylinderFromSectorMFGrid::CylinderFromSectorMFGrid( const GloballyPositioned<float>& vol,
-						    double phiMin, double phiMax,
-						    MFGrid* sectorGrid) :
-  MFGrid(vol), thePhiMin(phiMin), thePhiMax(phiMax), theSectorGrid( sectorGrid)
+CylinderFromSectorMFGrid::CylinderFromSectorMFGrid(const GloballyPositioned<float>& vol,
+                                                   double phiMin,
+                                                   double phiMax,
+                                                   MFGrid* sectorGrid)
+    : MFGrid(vol),
+      thePhiMin(phiMin),
+      thePhiMax(phiMax),
+      theSectorGrid(sectorGrid)
 
 {
-   if (thePhiMax < thePhiMin) thePhiMax += 2.0*Geom::pi();
-   theDelta = thePhiMax - thePhiMin;
+  if (thePhiMax < thePhiMin)
+    thePhiMax += 2.0 * Geom::pi();
+  theDelta = thePhiMax - thePhiMin;
 }
 
-CylinderFromSectorMFGrid::~CylinderFromSectorMFGrid()
-{
-  delete theSectorGrid;
-}
+CylinderFromSectorMFGrid::~CylinderFromSectorMFGrid() { delete theSectorGrid; }
 
-MFGrid::LocalVector CylinderFromSectorMFGrid::valueInTesla( const LocalPoint& p) const
-{
+MFGrid::LocalVector CylinderFromSectorMFGrid::valueInTesla(const LocalPoint& p) const {
   double phi = p.phi();
-  if (phi < thePhiMax && phi > thePhiMin) return theSectorGrid->valueInTesla(p);
+  if (phi < thePhiMax && phi > thePhiMin)
+    return theSectorGrid->valueInTesla(p);
   else {
-    double phiRot = floor((phi-thePhiMin)/theDelta) * theDelta;
+    double phiRot = floor((phi - thePhiMin) / theDelta) * theDelta;
     double c = cos(phiRot);
     double s = sin(phiRot);
-    double xrot =  p.x()*c + p.y()*s;
-    double yrot = -p.x()*s + p.y()*c;
+    double xrot = p.x() * c + p.y() * s;
+    double yrot = -p.x() * s + p.y() * c;
 
-    // get field in interpolation sector 
-    MFGrid::LocalVector tmp = theSectorGrid->valueInTesla( LocalPoint(xrot,yrot,p.z()));
+    // get field in interpolation sector
+    MFGrid::LocalVector tmp = theSectorGrid->valueInTesla(LocalPoint(xrot, yrot, p.z()));
 
     // rotate field back to original sector
-    return MFGrid::LocalVector( tmp.x()*c - tmp.y()*s, tmp.x()*s + tmp.y()*c, tmp.z());
+    return MFGrid::LocalVector(tmp.x() * c - tmp.y() * s, tmp.x() * s + tmp.y() * c, tmp.z());
   }
 }
 
-void CylinderFromSectorMFGrid::throwUp( const char *message) const
-{
+void CylinderFromSectorMFGrid::throwUp(const char* message) const {
   std::cout << "Throwing exception " << message << std::endl;
   throw MagGeometryError(message);
 }
-void CylinderFromSectorMFGrid::toGridFrame( const LocalPoint& p, double& a, double& b, double& c) const 
-{
+void CylinderFromSectorMFGrid::toGridFrame(const LocalPoint& p, double& a, double& b, double& c) const {
   throwUp("Not implemented yet");
 }
 
-MFGrid::LocalPoint CylinderFromSectorMFGrid::fromGridFrame( double a, double b, double c) const
-{
+MFGrid::LocalPoint CylinderFromSectorMFGrid::fromGridFrame(double a, double b, double c) const {
   throwUp("Not implemented yet");
   return LocalPoint();
 }
 
-Dimensions CylinderFromSectorMFGrid::dimensions() const 
-{return theSectorGrid->dimensions();}
+Dimensions CylinderFromSectorMFGrid::dimensions() const { return theSectorGrid->dimensions(); }
 
-MFGrid::LocalPoint  CylinderFromSectorMFGrid::nodePosition( int i, int j, int k) const
-{
+MFGrid::LocalPoint CylinderFromSectorMFGrid::nodePosition(int i, int j, int k) const {
   throwUp("Not implemented yet");
   return LocalPoint();
 }
 
-MFGrid::LocalVector CylinderFromSectorMFGrid::nodeValue( int i, int j, int k) const
-{
+MFGrid::LocalVector CylinderFromSectorMFGrid::nodeValue(int i, int j, int k) const {
   throwUp("Not implemented yet");
   return LocalVector();
 }

--- a/MagneticField/Interpolation/src/CylinderFromSectorMFGrid.h
+++ b/MagneticField/Interpolation/src/CylinderFromSectorMFGrid.h
@@ -6,34 +6,29 @@
 
 class dso_internal CylinderFromSectorMFGrid : public MFGrid {
 public:
-
-  CylinderFromSectorMFGrid(const GloballyPositioned<float>& vol,
-			   double phiMin, double phiMax, MFGrid* sectorGrid);
+  CylinderFromSectorMFGrid(const GloballyPositioned<float>& vol, double phiMin, double phiMax, MFGrid* sectorGrid);
 
   ~CylinderFromSectorMFGrid() override;
 
-  LocalVector valueInTesla( const LocalPoint& p) const override;
+  LocalVector valueInTesla(const LocalPoint& p) const override;
 
-  void toGridFrame( const LocalPoint& p, double& a, double& b, double& c) const override ;
+  void toGridFrame(const LocalPoint& p, double& a, double& b, double& c) const override;
 
-  LocalPoint fromGridFrame( double a, double b, double c) const override ;
+  LocalPoint fromGridFrame(double a, double b, double c) const override;
 
   Dimensions dimensions() const override;
 
-  LocalPoint  nodePosition( int i, int j, int k) const override ;
+  LocalPoint nodePosition(int i, int j, int k) const override;
 
-  LocalVector nodeValue( int i, int j, int k) const override ;
-
+  LocalVector nodeValue(int i, int j, int k) const override;
 
 private:
-
-  double  thePhiMin;
-  double  thePhiMax;
+  double thePhiMin;
+  double thePhiMax;
   MFGrid* theSectorGrid;
-  double  theDelta;
+  double theDelta;
 
-  void throwUp( const char *message) const;
-
+  void throwUp(const char* message) const;
 };
 
 #endif

--- a/MagneticField/Interpolation/src/GlobalGridWrapper.cc
+++ b/MagneticField/Interpolation/src/GlobalGridWrapper.cc
@@ -4,65 +4,52 @@
 
 using namespace std;
 
-GlobalGridWrapper::GlobalGridWrapper( const GloballyPositioned<float>& vol,
-				      const string& fileName)
-  : MFGrid(vol)
-{
+GlobalGridWrapper::GlobalGridWrapper(const GloballyPositioned<float>& vol, const string& fileName) : MFGrid(vol) {
   theRealOne = new MagneticFieldGrid;
   theRealOne->load(fileName);
 }
 
-MFGrid::LocalVector GlobalGridWrapper::valueInTesla( const LocalPoint& p) const
-{
-
+MFGrid::LocalVector GlobalGridWrapper::valueInTesla(const LocalPoint& p) const {
   GlobalPoint gp = frame().toGlobal(p);
   float bx, by, bz;
 
   int gridType = theRealOne->gridType();
-  if ( gridType == 1 || gridType == 2) {
+  if (gridType == 1 || gridType == 2) {
     // x,y,z grid
-    theRealOne->interpolateAtPoint( gp.x(), gp.y(), gp.z(), bx, by, bz);      
-  }
-  else {
+    theRealOne->interpolateAtPoint(gp.x(), gp.y(), gp.z(), bx, by, bz);
+  } else {
     // r,phi,z grid
-//     cout << "calling interpolateAtPoint with args " 
-// 	 << gp.perp() << " " << gp.phi() << " " << gp.z() << endl;
-    theRealOne->interpolateAtPoint( gp.perp(), gp.phi(), gp.z(), bx, by, bz);      
-//     cout << "interpolateAtPoint returned " 
-// 	 << bx << " " << by << " " << bz << endl;
+    //     cout << "calling interpolateAtPoint with args "
+    // 	 << gp.perp() << " " << gp.phi() << " " << gp.z() << endl;
+    theRealOne->interpolateAtPoint(gp.perp(), gp.phi(), gp.z(), bx, by, bz);
+    //     cout << "interpolateAtPoint returned "
+    // 	 << bx << " " << by << " " << bz << endl;
   }
-  return LocalVector( bx, by, bz);
+  return LocalVector(bx, by, bz);
 }
 
 void GlobalGridWrapper::dump() const {}
 
-void GlobalGridWrapper::toGridFrame( const LocalPoint& p, 
-					      double& a, double& b, double& c) const
-{
-  throw MagLogicError ("GlobalGridWrapper::toGridFrame not implemented yet");
-}
- 
-MFGrid::LocalPoint GlobalGridWrapper::fromGridFrame( double a, double b, double c) const
-{
-  throw MagLogicError ("GlobalGridWrapper::fromGridFrame not implemented yet");
-  return LocalPoint( 0, 0, 0);
+void GlobalGridWrapper::toGridFrame(const LocalPoint& p, double& a, double& b, double& c) const {
+  throw MagLogicError("GlobalGridWrapper::toGridFrame not implemented yet");
 }
 
-Dimensions GlobalGridWrapper::dimensions() const
-{
-  throw MagLogicError ("GlobalGridWrapper::dimensions not implemented yet");
+MFGrid::LocalPoint GlobalGridWrapper::fromGridFrame(double a, double b, double c) const {
+  throw MagLogicError("GlobalGridWrapper::fromGridFrame not implemented yet");
+  return LocalPoint(0, 0, 0);
+}
+
+Dimensions GlobalGridWrapper::dimensions() const {
+  throw MagLogicError("GlobalGridWrapper::dimensions not implemented yet");
   return Dimensions();
 }
 
-MFGrid::LocalPoint GlobalGridWrapper::nodePosition( int i, int j, int k) const
-{
-  throw MagLogicError ("GlobalGridWrapper::nodePosition not implemented yet");
-  return LocalPoint( 0, 0, 0);
+MFGrid::LocalPoint GlobalGridWrapper::nodePosition(int i, int j, int k) const {
+  throw MagLogicError("GlobalGridWrapper::nodePosition not implemented yet");
+  return LocalPoint(0, 0, 0);
 }
 
-MFGrid::LocalVector GlobalGridWrapper::nodeValue( int i, int j, int k) const
-{
-  throw MagLogicError ("GlobalGridWrapper::nodeValue not implemented yet");
-  return LocalVector( 0, 0, 0);
+MFGrid::LocalVector GlobalGridWrapper::nodeValue(int i, int j, int k) const {
+  throw MagLogicError("GlobalGridWrapper::nodeValue not implemented yet");
+  return LocalVector(0, 0, 0);
 }
-

--- a/MagneticField/Interpolation/src/GlobalGridWrapper.h
+++ b/MagneticField/Interpolation/src/GlobalGridWrapper.h
@@ -9,7 +9,6 @@
  *  \author T. Todorov
  */
 
-
 #include "FWCore/Utilities/interface/Visibility.h"
 #include "MagneticField/Interpolation/interface/MFGrid.h"
 
@@ -20,28 +19,24 @@ class MagneticFieldGrid;
 
 class dso_internal GlobalGridWrapper : public MFGrid {
 public:
+  GlobalGridWrapper(const GloballyPositioned<float>& vol, const std::string& fileName);
 
-  GlobalGridWrapper(  const GloballyPositioned<float>& vol,
-		      const std::string& fileName);
-
-  LocalVector valueInTesla( const LocalPoint& p) const override;
+  LocalVector valueInTesla(const LocalPoint& p) const override;
 
   void dump() const override;
 
-  void toGridFrame( const LocalPoint& p, double& a, double& b, double& c) const override;
+  void toGridFrame(const LocalPoint& p, double& a, double& b, double& c) const override;
 
-  LocalPoint fromGridFrame( double a, double b, double c) const override;
+  LocalPoint fromGridFrame(double a, double b, double c) const override;
 
   Dimensions dimensions() const override;
 
-  LocalPoint  nodePosition( int i, int j, int k) const override;
+  LocalPoint nodePosition(int i, int j, int k) const override;
 
-  LocalVector nodeValue( int i, int j, int k) const override;
+  LocalVector nodeValue(int i, int j, int k) const override;
 
 private:
-
   MagneticFieldGrid* theRealOne;
-
 };
 
 #endif

--- a/MagneticField/Interpolation/src/Grid1D.h
+++ b/MagneticField/Interpolation/src/Grid1D.h
@@ -6,77 +6,67 @@
 
 class dso_internal Grid1D {
 public:
-
-  typedef float   Scalar;
+  typedef float Scalar;
   //  typedef double Scalar;
 
   Grid1D() {}
 
-  Grid1D( Scalar lower, Scalar upper, int nodes) : 
-    lower_(lower), upper_(upper), edges_(nodes-2) {
-    stepinv_ =  (nodes-1)/(upper - lower);
+  Grid1D(Scalar lower, Scalar upper, int nodes) : lower_(lower), upper_(upper), edges_(nodes - 2) {
+    stepinv_ = (nodes - 1) / (upper - lower);
   }
 
+  Scalar step() const { return 1. / stepinv_; }
+  Scalar lower() const { return lower_; }
+  Scalar upper() const { return upper_; }
+  int nodes() const { return edges_ + 2; }
+  int cells() const { return edges_ + 1; }
 
-  Scalar step() const {return 1./stepinv_;}
-  Scalar lower() const {return lower_;}
-  Scalar upper() const {return upper_;}
-  int nodes() const {return  edges_+2;}
-  int cells() const {return  edges_+1;}
+  Scalar node(int i) const { return i * step() + lower(); }
 
-  Scalar node( int i) const { return i*step() + lower();}
-
-  bool inRange(int i) const {
-    return i>=0 && i<=edges_;
-  }
+  bool inRange(int i) const { return i >= 0 && i <= edges_; }
 
   // return index and fractional part...
-  int index(Scalar a, Scalar & f) const {
+  int index(Scalar a, Scalar& f) const {
     Scalar b;
-    f = modff((a-lower())*stepinv_, &b);
+    f = modff((a - lower()) * stepinv_, &b);
     return b;
   }
 
   // move index and fraction in range..
-  void normalize(int & ind,  Scalar & f) const {
-    if (ind<0) {
+  void normalize(int& ind, Scalar& f) const {
+    if (ind < 0) {
       f -= ind;
       ind = 0;
-    }
-    else if (ind>edges_) {
-      f += ind-edges_;
+    } else if (ind > edges_) {
+      f += ind - edges_;
       ind = edges_;
     }
   }
 
-
-  Scalar closestNode( Scalar a) const {
-    Scalar b = (a-lower())/step();
+  Scalar closestNode(Scalar a) const {
+    Scalar b = (a - lower()) / step();
     Scalar c = floor(b);
-    Scalar tmp = (b-c < 0.5) ? std::max(c,0.f) : std::min(c+1.f,static_cast<Scalar>(nodes()-1));
-    return tmp*step()+lower();
+    Scalar tmp = (b - c < 0.5) ? std::max(c, 0.f) : std::min(c + 1.f, static_cast<Scalar>(nodes() - 1));
+    return tmp * step() + lower();
   }
 
   /// returns valid index, or -1 if the value is outside range +/- one cell.
-  int index( Scalar a) const {
-    int ind = static_cast<int>((a-lower())/step());
+  int index(Scalar a) const {
+    int ind = static_cast<int>((a - lower()) / step());
     // FIXME: this causes an exception to be thrown later. Should be tested
     // more carefully before release
     //  if (ind < -1 || ind > cells()) {
     //     std::cout << "**** ind = " << ind << " cells: " << cells() << std::endl;
     //    return -1;
     //  }
-    return std::max(0, std::min( cells()-1, ind));
+    return std::max(0, std::min(cells() - 1, ind));
   }
 
- 
 private:
-
   Scalar stepinv_;
   Scalar lower_;
   Scalar upper_;
-  int    edges_; // number of lower edges = nodes-2...
-
+  int edges_;  // number of lower edges = nodes-2...
 };
 
 #endif

--- a/MagneticField/Interpolation/src/Grid3D.cc
+++ b/MagneticField/Interpolation/src/Grid3D.cc
@@ -1,7 +1,6 @@
 #include "Grid3D.h"
 #include <iostream>
 
-
 /*
 Grid3D::Grid3D( const Grid1D& ga, const Grid1D& gb, const Grid1D& gc,
 		std::vector<ValueType> const & data) : 
@@ -15,16 +14,13 @@ Grid3D::Grid3D( const Grid1D& ga, const Grid1D& gb, const Grid1D& gc,
 }
 */
 
-void Grid3D::dump() const
-{
-  for (int j=0; j<gridb().nodes(); ++j) {
-    for (int k=0; k<gridc().nodes(); ++k) {
-      for (int i=0; i<grida().nodes(); ++i) {
-        std::cout << grida().node(i) << " " << gridb().node(j) << " " << gridc().node(k) << " " 
-		  << operator()(i,j,k) << std::endl;
+void Grid3D::dump() const {
+  for (int j = 0; j < gridb().nodes(); ++j) {
+    for (int k = 0; k < gridc().nodes(); ++k) {
+      for (int i = 0; i < grida().nodes(); ++i) {
+        std::cout << grida().node(i) << " " << gridb().node(j) << " " << gridc().node(k) << " " << operator()(i, j, k)
+                  << std::endl;
       }
     }
   }
 }
-
-

--- a/MagneticField/Interpolation/src/Grid3D.h
+++ b/MagneticField/Interpolation/src/Grid3D.h
@@ -17,63 +17,54 @@
 // the storage class
 // needed just because legacy software used () constructor
 struct BStorageArray {
-  BStorageArray(){}
-  BStorageArray(float x,float y, float z) : v{x,y,z}{}
+  BStorageArray() {}
+  BStorageArray(float x, float y, float z) : v{x, y, z} {}
 
-  float const & operator[](int i) const { return v[i];}
+  float const& operator[](int i) const { return v[i]; }
 
   float v[3];
 };
 
 class dso_internal Grid3D {
 public:
+  // typedef double   Scalar;
+  typedef float Scalar;
+  typedef Basic3DVector<Scalar> ValueType;
+  typedef ValueType ReturnType;
 
- // typedef double   Scalar;
-  typedef float   Scalar;
-  typedef Basic3DVector<Scalar>   ValueType;
-  typedef ValueType ReturnType; 
- 
   using BVector = BStorageArray;
   //using BVector =  ValueType;
   using Container = std::vector<BVector>;
 
   Grid3D() {}
 
-  Grid3D( const Grid1D& ga, const Grid1D& gb, const Grid1D& gc,
-	  std::vector<BVector>& data) : 
-    grida_(ga), gridb_(gb), gridc_(gc) {
-     data_.swap(data);
-     stride1_ = gridb_.nodes() * gridc_.nodes();
-     stride2_ = gridc_.nodes();
+  Grid3D(const Grid1D& ga, const Grid1D& gb, const Grid1D& gc, std::vector<BVector>& data)
+      : grida_(ga), gridb_(gb), gridc_(gc) {
+    data_.swap(data);
+    stride1_ = gridb_.nodes() * gridc_.nodes();
+    stride2_ = gridc_.nodes();
   }
-
 
   //  Grid3D( const Grid1D& ga, const Grid1D& gb, const Grid1D& gc,
   //	  std::vector<ValueType> const & data);
 
+  int index(int i, int j, int k) const { return i * stride1_ + j * stride2_ + k; }
+  int stride1() const { return stride1_; }
+  int stride2() const { return stride2_; }
+  int stride3() const { return 1; }
+  ValueType operator()(int i) const { return ValueType(data_[i][0], data_[i][1], data_[i][2]); }
 
-  int index(int i, int j, int k) const {return i*stride1_ + j*stride2_ + k;}
-  int stride1() const { return stride1_;}
-  int stride2() const { return stride2_;}
-  int stride3() const { return 1;}
-  ValueType operator()(int i) const {
-    return ValueType(data_[i][0],data_[i][1],data_[i][2]);
-  }
+  ValueType operator()(int i, int j, int k) const { return (*this)(index(i, j, k)); }
 
-  ValueType operator()(int i, int j, int k) const {
-    return (*this)(index(i,j,k));
-  }
+  const Grid1D& grida() const { return grida_; }
+  const Grid1D& gridb() const { return gridb_; }
+  const Grid1D& gridc() const { return gridc_; }
 
-  const Grid1D& grida() const {return grida_;}
-  const Grid1D& gridb() const {return gridb_;}
-  const Grid1D& gridc() const {return gridc_;}
-
-  const Container & data() const {return data_;}
+  const Container& data() const { return data_; }
 
   void dump() const;
 
 private:
-
   Grid1D grida_;
   Grid1D gridb_;
   Grid1D gridc_;
@@ -82,8 +73,6 @@ private:
 
   int stride1_;
   int stride2_;
-
-
 };
 
 #endif

--- a/MagneticField/Interpolation/src/InterpolationDebug.cc
+++ b/MagneticField/Interpolation/src/InterpolationDebug.cc
@@ -1,5 +1,5 @@
 #include "InterpolationDebug.h"
 
 #ifdef DEBUG_LinearGridInterpolator3D
-const bool InterpolationDebug::debug=false;
+const bool InterpolationDebug::debug = false;
 #endif

--- a/MagneticField/Interpolation/src/LinearGridInterpolator3D.cc
+++ b/MagneticField/Interpolation/src/LinearGridInterpolator3D.cc
@@ -3,16 +3,12 @@
 #include "Grid3D.h"
 #include "MagneticField/VolumeGeometry/interface/MagExceptions.h"
 
-void
-LinearGridInterpolator3D::throwGridInterpolator3DException(void)
-{
-  throw GridInterpolator3DException(grida.lower(),gridb.lower(),gridc.lower(),
-                                    grida.upper(),gridb.upper(),gridc.upper());
+void LinearGridInterpolator3D::throwGridInterpolator3DException(void) {
+  throw GridInterpolator3DException(
+      grida.lower(), gridb.lower(), gridc.lower(), grida.upper(), gridb.upper(), gridc.upper());
 }
 
-LinearGridInterpolator3D::ValueType 
-LinearGridInterpolator3D::interpolate( Scalar a, Scalar b, Scalar c) 
-{
+LinearGridInterpolator3D::ValueType LinearGridInterpolator3D::interpolate(Scalar a, Scalar b, Scalar c) {
   /*
   int i = grida.index(a);
   int j = gridb.index(b);
@@ -31,91 +27,91 @@ LinearGridInterpolator3D::interpolate( Scalar a, Scalar b, Scalar c)
   */
 
   Scalar s, t, u;
-  int i = grida.index(a,s);
-  int j = gridb.index(b,t);
-  int k = gridc.index(c,u);
-  
+  int i = grida.index(a, s);
+  int j = gridb.index(b, t);
+  int k = gridc.index(c, u);
+
   // test range??
 
-  grida.normalize(i,s);
-  gridb.normalize(j,t);
-  gridc.normalize(k,u);
+  grida.normalize(i, s);
+  gridb.normalize(j, t);
+  gridc.normalize(k, u);
 
 #ifdef DEBUG_LinearGridInterpolator3D
   if (InterpolationDebug::debug) {
     using std::cout;
     using std::endl;
     cout << "LinearGridInterpolator3D called with a,b,c " << a << "," << b << "," << c << endl;
-    cout <<" i,j,k = " << i << "," << j << "," << k
-         << " s,t,u = " << s << "," << t << "," << u << endl;
-    cout << "Node positions for " << i << "," << j << "," << k << " : "
-         << grida.node(i) << "," << gridb.node(j) << "," << gridc.node(k) << endl;
-    cout << "Node positions for " << i+1 << "," << j+1 << "," << k+1 << " : "
-         << grida.node(i+1) << "," << gridb.node(j+1) << "," << gridc.node(k+1) << endl;
-    cout << "Grid(" << i << "," << j << "," << k << ") = " << grid(i,  j,  k) << " ";
-    cout << "Grid(" << i << "," << j << "," << k+1 << ") = " << grid(i,j,k+1) << endl;
-    cout << "Grid(" << i << "," << j+1 << "," << k << ") = " << grid(i,j+1,k) << " ";
-    cout << "Grid(" << i << "," << j+1 << "," << k+1 << ") = " << grid(i,j+1,k+1) << endl;
-    cout << "Grid(" << i+1 << "," << j << "," << k << ") = " << grid(i+1,j,k) << " ";
-    cout << "Grid(" << i+1 << "," << j << "," << k+1 << ") = " << grid(i+1,j,k+1) << endl;
-    cout << "Grid(" << i+1 << "," << j+1 << "," << k << ") = " << grid(i+1,j+1,k) << " ";
-    cout << "Grid(" << i+1 << "," << j+1 << "," << k+1 << ") = " << grid(i+1,j+1,k+1) << endl;
+    cout << " i,j,k = " << i << "," << j << "," << k << " s,t,u = " << s << "," << t << "," << u << endl;
+    cout << "Node positions for " << i << "," << j << "," << k << " : " << grida.node(i) << "," << gridb.node(j) << ","
+         << gridc.node(k) << endl;
+    cout << "Node positions for " << i + 1 << "," << j + 1 << "," << k + 1 << " : " << grida.node(i + 1) << ","
+         << gridb.node(j + 1) << "," << gridc.node(k + 1) << endl;
+    cout << "Grid(" << i << "," << j << "," << k << ") = " << grid(i, j, k) << " ";
+    cout << "Grid(" << i << "," << j << "," << k + 1 << ") = " << grid(i, j, k + 1) << endl;
+    cout << "Grid(" << i << "," << j + 1 << "," << k << ") = " << grid(i, j + 1, k) << " ";
+    cout << "Grid(" << i << "," << j + 1 << "," << k + 1 << ") = " << grid(i, j + 1, k + 1) << endl;
+    cout << "Grid(" << i + 1 << "," << j << "," << k << ") = " << grid(i + 1, j, k) << " ";
+    cout << "Grid(" << i + 1 << "," << j << "," << k + 1 << ") = " << grid(i + 1, j, k + 1) << endl;
+    cout << "Grid(" << i + 1 << "," << j + 1 << "," << k << ") = " << grid(i + 1, j + 1, k) << " ";
+    cout << "Grid(" << i + 1 << "," << j + 1 << "," << k + 1 << ") = " << grid(i + 1, j + 1, k + 1) << endl;
     cout << "number of nodes: " << grida.nodes() << "," << gridb.nodes() << "," << gridc.nodes() << endl;
 
-//     cout << (1-s)*(1-t)*(1-u)*grid(i,  j,  k) << " " << (1-s)*(1-t)*u*grid(i,  j,  k+1) << endl 
-//       << (1-s)*   t *(1-u)*grid(i,  j+1,k) << " " << (1-s)*   t *u*grid(i,  j+1,k+1) << endl 
-//       << s    *(1-t)*(1-u)*grid(i+1,j,  k) << " " <<  s    *(1-t)*u*grid(i+1,j,  k+1) << endl 
-//       << s    *   t *(1-u)*grid(i+1,j+1,k) << " " << s    *   t *u*grid(i+1,j+1,k+1) << endl;
+    //     cout << (1-s)*(1-t)*(1-u)*grid(i,  j,  k) << " " << (1-s)*(1-t)*u*grid(i,  j,  k+1) << endl
+    //       << (1-s)*   t *(1-u)*grid(i,  j+1,k) << " " << (1-s)*   t *u*grid(i,  j+1,k+1) << endl
+    //       << s    *(1-t)*(1-u)*grid(i+1,j,  k) << " " <<  s    *(1-t)*u*grid(i+1,j,  k+1) << endl
+    //       << s    *   t *(1-u)*grid(i+1,j+1,k) << " " << s    *   t *u*grid(i+1,j+1,k+1) << endl;
   }
 
 #endif
 
-  int ind = grid.index(i,j,k);
-  int s1 = grid.stride1(); 
-  int s2 = grid.stride2(); 
-  int s3 = grid.stride3(); 
+  int ind = grid.index(i, j, k);
+  int s1 = grid.stride1();
+  int s2 = grid.stride2();
+  int s3 = grid.stride3();
   //chances are this is more numerically precise this way
-
-
 
   // this code for test to check  properly inline of wrapped math...
 #if defined(CMS_TEST_RAWSSE)
 
-  __m128 resultSIMD =                 _mm_mul_ps(_mm_set1_ps((1.f - s) * (1.f - t) * u), _mm_sub_ps(grid(ind           + s3).v.vec, grid(ind          ).v.vec));
-  resultSIMD = _mm_add_ps(resultSIMD, _mm_mul_ps(_mm_set1_ps((1.f - s) *         t * u), _mm_sub_ps(grid(ind      + s2 + s3).v.vec, grid(ind      + s2).v.vec)));
-  resultSIMD = _mm_add_ps(resultSIMD, _mm_mul_ps(_mm_set1_ps(        s * (1.f - t) * u), _mm_sub_ps(grid(ind + s1      + s3).v.vec, grid(ind + s1     ).v.vec)));
-  resultSIMD = _mm_add_ps(resultSIMD, _mm_mul_ps(_mm_set1_ps(        s *         t * u), _mm_sub_ps(grid(ind + s1 + s2 + s3).v.vec, grid(ind + s1 + s2).v.vec)));
-  resultSIMD = _mm_add_ps(resultSIMD, _mm_mul_ps(_mm_set1_ps((1.f - s) *         t    ), _mm_sub_ps(grid(ind      + s2     ).v.vec, grid(ind          ).v.vec)));
-  resultSIMD = _mm_add_ps(resultSIMD, _mm_mul_ps(_mm_set1_ps(        s *         t    ), _mm_sub_ps(grid(ind + s1 + s2     ).v.vec, grid(ind + s1     ).v.vec)));
-  resultSIMD = _mm_add_ps(resultSIMD, _mm_mul_ps(_mm_set1_ps(        s                ), _mm_sub_ps(grid(ind + s1          ).v.vec, grid(ind          ).v.vec)));
-  resultSIMD = _mm_add_ps(resultSIMD,                                                                                             grid(ind          ).v.vec);
-  
-  ValueType result; result.v=resultSIMD;
+  __m128 resultSIMD =
+      _mm_mul_ps(_mm_set1_ps((1.f - s) * (1.f - t) * u), _mm_sub_ps(grid(ind + s3).v.vec, grid(ind).v.vec));
+  resultSIMD = _mm_add_ps(
+      resultSIMD,
+      _mm_mul_ps(_mm_set1_ps((1.f - s) * t * u), _mm_sub_ps(grid(ind + s2 + s3).v.vec, grid(ind + s2).v.vec)));
+  resultSIMD = _mm_add_ps(
+      resultSIMD,
+      _mm_mul_ps(_mm_set1_ps(s * (1.f - t) * u), _mm_sub_ps(grid(ind + s1 + s3).v.vec, grid(ind + s1).v.vec)));
+  resultSIMD = _mm_add_ps(
+      resultSIMD,
+      _mm_mul_ps(_mm_set1_ps(s * t * u), _mm_sub_ps(grid(ind + s1 + s2 + s3).v.vec, grid(ind + s1 + s2).v.vec)));
+  resultSIMD =
+      _mm_add_ps(resultSIMD, _mm_mul_ps(_mm_set1_ps((1.f - s) * t), _mm_sub_ps(grid(ind + s2).v.vec, grid(ind).v.vec)));
+  resultSIMD = _mm_add_ps(resultSIMD,
+                          _mm_mul_ps(_mm_set1_ps(s * t), _mm_sub_ps(grid(ind + s1 + s2).v.vec, grid(ind + s1).v.vec)));
+  resultSIMD = _mm_add_ps(resultSIMD, _mm_mul_ps(_mm_set1_ps(s), _mm_sub_ps(grid(ind + s1).v.vec, grid(ind).v.vec)));
+  resultSIMD = _mm_add_ps(resultSIMD, grid(ind).v.vec);
 
+  ValueType result;
+  result.v = resultSIMD;
 
 #else
-  
-  ValueType result = ((1.f-s)*(1.f-t)*u)*(grid(ind      +s3) - grid(ind      ));
-  result =  result + ((1.f-s)*     t *u)*(grid(ind   +s2+s3) - grid(ind   +s2));
-  result =  result + (s      *(1.f-t)*u)*(grid(ind+s1   +s3) - grid(ind+s1   ));
-  result =  result + (s      *     t *u)*(grid(ind+s1+s2+s3) - grid(ind+s1+s2)); 
-  result =  result + (        (1.f-s)*t)*(grid(ind   +s2   ) - grid(ind      ));
-  result =  result + (      s        *t)*(grid(ind+s1+s2   ) - grid(ind+s1   ));
-  result =  result + (                s)*(grid(ind+s1      ) - grid(ind      ));
-  result =  result +                                           grid(ind      );
 
+  ValueType result = ((1.f - s) * (1.f - t) * u) * (grid(ind + s3) - grid(ind));
+  result = result + ((1.f - s) * t * u) * (grid(ind + s2 + s3) - grid(ind + s2));
+  result = result + (s * (1.f - t) * u) * (grid(ind + s1 + s3) - grid(ind + s1));
+  result = result + (s * t * u) * (grid(ind + s1 + s2 + s3) - grid(ind + s1 + s2));
+  result = result + ((1.f - s) * t) * (grid(ind + s2) - grid(ind));
+  result = result + (s * t) * (grid(ind + s1 + s2) - grid(ind + s1));
+  result = result + (s) * (grid(ind + s1) - grid(ind));
+  result = result + grid(ind);
 
 #endif
 
-
-
-  //      (1-s)*(1-t)*(1-u)*grid(i,  j,  k) + (1-s)*(1-t)*u*grid(i,  j,  k+1) + 
+  //      (1-s)*(1-t)*(1-u)*grid(i,  j,  k) + (1-s)*(1-t)*u*grid(i,  j,  k+1) +
   //      (1-s)*   t *(1-u)*grid(i,  j+1,k) + (1-s)*   t *u*grid(i,  j+1,k+1) +
-  //      s    *(1-t)*(1-u)*grid(i+1,j,  k) + s    *(1-t)*u*grid(i+1,j,  k+1) + 
+  //      s    *(1-t)*(1-u)*grid(i+1,j,  k) + s    *(1-t)*u*grid(i+1,j,  k+1) +
   //      s    *   t *(1-u)*grid(i+1,j+1,k) + s    *   t *u*grid(i+1,j+1,k+1);
 
-
   return result;
-
-
 }

--- a/MagneticField/Interpolation/src/LinearGridInterpolator3D.h
+++ b/MagneticField/Interpolation/src/LinearGridInterpolator3D.h
@@ -14,7 +14,6 @@
 #include "DataFormats/GeometryVector/interface/Basic3DVector.h"
 #include "FWCore/Utilities/interface/Visibility.h"
 
-
 #ifdef DEBUG_LinearGridInterpolator3D
 #include <iostream>
 #include "InterpolationDebug.h"
@@ -22,17 +21,15 @@
 
 class dso_internal LinearGridInterpolator3D {
 public:
-
   typedef Grid3D::ValueType ValueType;
   typedef Grid3D::Scalar Scalar;
-  typedef ValueType ReturnType; 
+  typedef ValueType ReturnType;
 
-  LinearGridInterpolator3D( const Grid3D& g) :
-    grid(g), grida(g.grida()), gridb(g.gridb()), gridc(g.gridc()) {}
+  LinearGridInterpolator3D(const Grid3D& g) : grid(g), grida(g.grida()), gridb(g.gridb()), gridc(g.gridc()) {}
 
   void throwGridInterpolator3DException(void);
-  
-  ReturnType interpolate( Scalar a, Scalar b, Scalar c); 
+
+  ReturnType interpolate(Scalar a, Scalar b, Scalar c);
   //  Value operator()( Scalar a, Scalar b, Scalar c) {return interpolate(a,b,c);}
 
 private:
@@ -40,7 +37,6 @@ private:
   const Grid1D& grida;
   const Grid1D& gridb;
   const Grid1D& gridc;
-
 };
 
 #endif

--- a/MagneticField/Interpolation/src/MFGrid3D.cc
+++ b/MagneticField/Interpolation/src/MFGrid3D.cc
@@ -2,16 +2,13 @@
 #include "MagneticField/VolumeGeometry/interface/MagVolumeOutsideValidity.h"
 #include "MagneticField/VolumeGeometry/interface/MagExceptions.h"
 
-MFGrid::LocalVector MFGrid3D::valueInTesla( const LocalPoint& p) const
-{
+MFGrid::LocalVector MFGrid3D::valueInTesla(const LocalPoint& p) const {
   try {
-    return uncheckedValueInTesla( p);
+    return uncheckedValueInTesla(p);
+  } catch (GridInterpolator3DException& outside) {
+    double* limits = outside.limits();
+    LocalPoint lower = fromGridFrame(limits[0], limits[1], limits[2]);
+    LocalPoint upper = fromGridFrame(limits[3], limits[4], limits[5]);
+    throw MagVolumeOutsideValidity(lower, upper);
   }
-  catch ( GridInterpolator3DException& outside) {
-    double *limits = outside.limits();
-    LocalPoint lower = fromGridFrame( limits[0], limits[1], limits[2]);
-    LocalPoint upper = fromGridFrame( limits[3], limits[4], limits[5]);
-    throw MagVolumeOutsideValidity( lower, upper);
-  }
-
 }

--- a/MagneticField/Interpolation/src/MFGrid3D.h
+++ b/MagneticField/Interpolation/src/MFGrid3D.h
@@ -16,9 +16,7 @@
 
 class dso_internal MFGrid3D : public MFGrid {
 public:
-
-  explicit MFGrid3D( const GloballyPositioned<float>& vol) : MFGrid(vol) {}
-
+  explicit MFGrid3D(const GloballyPositioned<float>& vol) : MFGrid(vol) {}
 
   Dimensions dimensions(void) const override {
     Dimensions tmp;
@@ -27,44 +25,40 @@ public:
     tmp.d = grid_.gridc().nodes();
     return tmp;
   }
-    
+
   /// Position of node in local frame
-  LocalPoint  nodePosition( int i, int j, int k) const override {
-    return fromGridFrame( grid_.grida().node(i), grid_.gridb().node(j), grid_.gridc().node(k));
+  LocalPoint nodePosition(int i, int j, int k) const override {
+    return fromGridFrame(grid_.grida().node(i), grid_.gridb().node(j), grid_.gridc().node(k));
   }
 
   /// Field value at node
-  LocalVector nodeValue( int i, int j, int k) const override {
+  LocalVector nodeValue(int i, int j, int k) const override {
     /// must check range here: FIX ME !!!!
-    return MFGrid::LocalVector(grid_( i, j, k));
+    return MFGrid::LocalVector(grid_(i, j, k));
   }
 
-  Indexes index( const LocalPoint& p) const override {
+  Indexes index(const LocalPoint& p) const override {
     Indexes result;
     double a, b, c;
-    toGridFrame( p, a, b, c);
+    toGridFrame(p, a, b, c);
     result.i = grid_.grida().index(a);
     result.j = grid_.gridb().index(b);
     result.k = grid_.gridc().index(c);
     return result;
   }
 
-  LocalVector valueInTesla( const LocalPoint& p) const override;
+  LocalVector valueInTesla(const LocalPoint& p) const override;
 
   /// Interpolated field value at given point; does not check for exceptions
-  virtual LocalVector uncheckedValueInTesla( const LocalPoint& p) const = 0;
+  virtual LocalVector uncheckedValueInTesla(const LocalPoint& p) const = 0;
 
 protected:
-
-  using GridType =  Grid3D;
+  using GridType = Grid3D;
   using BVector = Grid3D::BVector;
 
-  GridType       grid_; // should become private...
+  GridType grid_;  // should become private...
 
-  void setGrid( const GridType& grid) {
-    grid_ = grid;
-  }
-
+  void setGrid(const GridType& grid) { grid_ = grid; }
 };
 
 #endif

--- a/MagneticField/Interpolation/src/MFGridFactory.cc
+++ b/MagneticField/Interpolation/src/MFGridFactory.cc
@@ -19,39 +19,36 @@ MFGrid* MFGridFactory::build(const string& name, const GloballyPositioned<float>
   inFile >> gridType;
 
   MFGrid* result;
-  switch (gridType){
-  case 1:
-    result = new RectangularCartesianMFGrid(inFile, vol);
-    break;
-  case 2:
-    result = new TrapezoidalCartesianMFGrid(inFile, vol);
-    break;
-  case 3:
-    result = new RectangularCylindricalMFGrid(inFile, vol);
-    break;
-  case 4:
-    result = new TrapezoidalCylindricalMFGrid(inFile, vol);
-    break;
-  case 5:
-    result = new SpecialCylindricalMFGrid(inFile, vol, gridType);
-    break;
-  case 6:
-    result = new SpecialCylindricalMFGrid(inFile, vol, gridType);
-    break;
-  default:
-    cout << "ERROR Grid type unknown: " << gridType << endl;
-    //    result = new GlobalGridWrapper(vol, name);
-    result = nullptr;
-    break;
+  switch (gridType) {
+    case 1:
+      result = new RectangularCartesianMFGrid(inFile, vol);
+      break;
+    case 2:
+      result = new TrapezoidalCartesianMFGrid(inFile, vol);
+      break;
+    case 3:
+      result = new RectangularCylindricalMFGrid(inFile, vol);
+      break;
+    case 4:
+      result = new TrapezoidalCylindricalMFGrid(inFile, vol);
+      break;
+    case 5:
+      result = new SpecialCylindricalMFGrid(inFile, vol, gridType);
+      break;
+    case 6:
+      result = new SpecialCylindricalMFGrid(inFile, vol, gridType);
+      break;
+    default:
+      cout << "ERROR Grid type unknown: " << gridType << endl;
+      //    result = new GlobalGridWrapper(vol, name);
+      result = nullptr;
+      break;
   }
   inFile.close();
   return result;
 }
 
-MFGrid* MFGridFactory::build(const string& name, 
-			     const GloballyPositioned<float>& vol,
-			     double phiMin, double phiMax)
-{
-  MFGrid* sectorGrid = build(name,vol);
-  return new CylinderFromSectorMFGrid( vol, phiMin, phiMax, sectorGrid);
+MFGrid* MFGridFactory::build(const string& name, const GloballyPositioned<float>& vol, double phiMin, double phiMax) {
+  MFGrid* sectorGrid = build(name, vol);
+  return new CylinderFromSectorMFGrid(vol, phiMin, phiMax, sectorGrid);
 }

--- a/MagneticField/Interpolation/src/MagneticFieldGrid.cc
+++ b/MagneticField/Interpolation/src/MagneticFieldGrid.cc
@@ -4,137 +4,145 @@
 
 using namespace std;
 
-void MagneticFieldGrid::load(const string& name){
+void MagneticFieldGrid::load(const string &name) {
   binary_ifstream inFile(name);
   inFile >> GridType;
   // reading the header
-  switch (GridType){
-  case 1:
-    inFile >> NumberOfPoints[0]    >> NumberOfPoints[1]    >> NumberOfPoints[2];
-    inFile >> ReferencePoint[0]    >> ReferencePoint[1]    >> ReferencePoint[2];
-    inFile >> BasicDistance0[0]    >> BasicDistance0[1]    >> BasicDistance0[2];
-    break;
-  case 2:
-    inFile >> NumberOfPoints[0]    >> NumberOfPoints[1]    >> NumberOfPoints[2];
-    inFile >> ReferencePoint[0]    >> ReferencePoint[1]    >> ReferencePoint[2];
-    inFile >> BasicDistance0[0]    >> BasicDistance0[1]    >> BasicDistance0[2];
-    inFile >> BasicDistance1[0][0] >> BasicDistance1[1][0] >> BasicDistance1[2][0];
-    inFile >> BasicDistance1[0][1] >> BasicDistance1[1][1] >> BasicDistance1[2][1];
-    inFile >> BasicDistance1[0][2] >> BasicDistance1[1][2] >> BasicDistance1[2][2];
-    inFile >> BasicDistance2[0][0] >> BasicDistance2[1][0] >> BasicDistance2[2][0];
-    inFile >> BasicDistance2[0][1] >> BasicDistance2[1][1] >> BasicDistance2[2][1];
-    inFile >> BasicDistance2[0][2] >> BasicDistance2[1][2] >> BasicDistance2[2][2];
-    inFile >> EasyCoordinate[0]    >> EasyCoordinate[1]    >> EasyCoordinate[2];
-    break;
-  case 3:
-    inFile >> NumberOfPoints[0]    >> NumberOfPoints[1]    >> NumberOfPoints[2];
-    inFile >> ReferencePoint[0]    >> ReferencePoint[1]    >> ReferencePoint[2];
-    inFile >> BasicDistance0[0]    >> BasicDistance0[1]    >> BasicDistance0[2];
-    break;
-  case 4:
-    inFile >> NumberOfPoints[0]    >> NumberOfPoints[1]    >> NumberOfPoints[2];
-    inFile >> ReferencePoint[0]    >> ReferencePoint[1]    >> ReferencePoint[2];
-    inFile >> BasicDistance0[0]    >> BasicDistance0[1]    >> BasicDistance0[2];
-    inFile >> BasicDistance1[0][0] >> BasicDistance1[1][0] >> BasicDistance1[2][0];
-    inFile >> BasicDistance1[0][1] >> BasicDistance1[1][1] >> BasicDistance1[2][1];
-    inFile >> BasicDistance1[0][2] >> BasicDistance1[1][2] >> BasicDistance1[2][2];
-    inFile >> BasicDistance2[0][0] >> BasicDistance2[1][0] >> BasicDistance2[2][0];
-    inFile >> BasicDistance2[0][1] >> BasicDistance2[1][1] >> BasicDistance2[2][1];
-    inFile >> BasicDistance2[0][2] >> BasicDistance2[1][2] >> BasicDistance2[2][2];
-    inFile >> EasyCoordinate[0]    >> EasyCoordinate[1]    >> EasyCoordinate[2];
-    break;
-  case 5:
-    inFile >> NumberOfPoints[0]    >> NumberOfPoints[1]    >> NumberOfPoints[2];
-    inFile >> ReferencePoint[0]    >> ReferencePoint[1]    >> ReferencePoint[2];
-    inFile >> BasicDistance0[0]    >> BasicDistance0[1]    >> BasicDistance0[2];
-    inFile >> RParAsFunOfPhi[0]    >> RParAsFunOfPhi[1]    >> RParAsFunOfPhi[2]    >> RParAsFunOfPhi[3];
-    break;
-  default:
-    assert(0); //this is a bug
+  switch (GridType) {
+    case 1:
+      inFile >> NumberOfPoints[0] >> NumberOfPoints[1] >> NumberOfPoints[2];
+      inFile >> ReferencePoint[0] >> ReferencePoint[1] >> ReferencePoint[2];
+      inFile >> BasicDistance0[0] >> BasicDistance0[1] >> BasicDistance0[2];
+      break;
+    case 2:
+      inFile >> NumberOfPoints[0] >> NumberOfPoints[1] >> NumberOfPoints[2];
+      inFile >> ReferencePoint[0] >> ReferencePoint[1] >> ReferencePoint[2];
+      inFile >> BasicDistance0[0] >> BasicDistance0[1] >> BasicDistance0[2];
+      inFile >> BasicDistance1[0][0] >> BasicDistance1[1][0] >> BasicDistance1[2][0];
+      inFile >> BasicDistance1[0][1] >> BasicDistance1[1][1] >> BasicDistance1[2][1];
+      inFile >> BasicDistance1[0][2] >> BasicDistance1[1][2] >> BasicDistance1[2][2];
+      inFile >> BasicDistance2[0][0] >> BasicDistance2[1][0] >> BasicDistance2[2][0];
+      inFile >> BasicDistance2[0][1] >> BasicDistance2[1][1] >> BasicDistance2[2][1];
+      inFile >> BasicDistance2[0][2] >> BasicDistance2[1][2] >> BasicDistance2[2][2];
+      inFile >> EasyCoordinate[0] >> EasyCoordinate[1] >> EasyCoordinate[2];
+      break;
+    case 3:
+      inFile >> NumberOfPoints[0] >> NumberOfPoints[1] >> NumberOfPoints[2];
+      inFile >> ReferencePoint[0] >> ReferencePoint[1] >> ReferencePoint[2];
+      inFile >> BasicDistance0[0] >> BasicDistance0[1] >> BasicDistance0[2];
+      break;
+    case 4:
+      inFile >> NumberOfPoints[0] >> NumberOfPoints[1] >> NumberOfPoints[2];
+      inFile >> ReferencePoint[0] >> ReferencePoint[1] >> ReferencePoint[2];
+      inFile >> BasicDistance0[0] >> BasicDistance0[1] >> BasicDistance0[2];
+      inFile >> BasicDistance1[0][0] >> BasicDistance1[1][0] >> BasicDistance1[2][0];
+      inFile >> BasicDistance1[0][1] >> BasicDistance1[1][1] >> BasicDistance1[2][1];
+      inFile >> BasicDistance1[0][2] >> BasicDistance1[1][2] >> BasicDistance1[2][2];
+      inFile >> BasicDistance2[0][0] >> BasicDistance2[1][0] >> BasicDistance2[2][0];
+      inFile >> BasicDistance2[0][1] >> BasicDistance2[1][1] >> BasicDistance2[2][1];
+      inFile >> BasicDistance2[0][2] >> BasicDistance2[1][2] >> BasicDistance2[2][2];
+      inFile >> EasyCoordinate[0] >> EasyCoordinate[1] >> EasyCoordinate[2];
+      break;
+    case 5:
+      inFile >> NumberOfPoints[0] >> NumberOfPoints[1] >> NumberOfPoints[2];
+      inFile >> ReferencePoint[0] >> ReferencePoint[1] >> ReferencePoint[2];
+      inFile >> BasicDistance0[0] >> BasicDistance0[1] >> BasicDistance0[2];
+      inFile >> RParAsFunOfPhi[0] >> RParAsFunOfPhi[1] >> RParAsFunOfPhi[2] >> RParAsFunOfPhi[3];
+      break;
+    default:
+      assert(0);  //this is a bug
   }
   //reading the field
   float Bx, By, Bz;
   BVector FieldEntry;
-  int nLines = NumberOfPoints[0]*NumberOfPoints[1]*NumberOfPoints[2];
+  int nLines = NumberOfPoints[0] * NumberOfPoints[1] * NumberOfPoints[2];
   FieldValues.reserve(nLines);
 
-  for (int iLine=0; iLine<nLines; ++iLine){
+  for (int iLine = 0; iLine < nLines; ++iLine) {
     inFile >> Bx >> By >> Bz;
-    FieldEntry.putB3(Bx,By,Bz);
+    FieldEntry.putB3(Bx, By, Bz);
     FieldValues.push_back(FieldEntry);
   }
   // check completeness and close file
   string lastEntry;
   inFile >> lastEntry;
   inFile.close();
-  if (lastEntry != "complete"){
+  if (lastEntry != "complete") {
     GridType = 0;
     cout << "error during file reading: file is not complete" << endl;
   }
   return;
 }
 
-int MagneticFieldGrid::gridType(){
+int MagneticFieldGrid::gridType() {
   int type = GridType;
   bool text = false;
-  if (text){
-    if (type == 0) cout << "  grid type = " << type << "  -->  not determined" << endl;
-    if (type == 1) cout << "  grid type = " << type << "  -->  (x,y,z) cube" << endl;
-    if (type == 2) cout << "  grid type = " << type << "  -->  (x,y,z) trapezoid" << endl;
-    if (type == 3) cout << "  grid type = " << type << "  -->  (r,phi,z) cube" << endl;
-    if (type == 4) cout << "  grid type = " << type << "  -->  (r,phi,z) trapezoid" << endl;
-    if (type == 5) cout << "  grid type = " << type << "  -->  (r,phi,z) 1/sin(phi)" << endl;
+  if (text) {
+    if (type == 0)
+      cout << "  grid type = " << type << "  -->  not determined" << endl;
+    if (type == 1)
+      cout << "  grid type = " << type << "  -->  (x,y,z) cube" << endl;
+    if (type == 2)
+      cout << "  grid type = " << type << "  -->  (x,y,z) trapezoid" << endl;
+    if (type == 3)
+      cout << "  grid type = " << type << "  -->  (r,phi,z) cube" << endl;
+    if (type == 4)
+      cout << "  grid type = " << type << "  -->  (r,phi,z) trapezoid" << endl;
+    if (type == 5)
+      cout << "  grid type = " << type << "  -->  (r,phi,z) 1/sin(phi)" << endl;
   }
   return type;
 }
 
-void MagneticFieldGrid::interpolateAtPoint(double X1, double X2, double X3, float &Bx, float &By, float &Bz){
-  double dB[3] = {0.,0.,0.};
+void MagneticFieldGrid::interpolateAtPoint(double X1, double X2, double X3, float &Bx, float &By, float &Bz) {
+  double dB[3] = {0., 0., 0.};
   // define interpolation object
   VectorFieldInterpolation MagInterpol;
   // calculate indices for "CellPoint000"
   int index[3];
-  putCoordGetInd(X1,X2,X3,index[0],index[1],index[2]);
-  int index0[3] = {0,0,0};
-  int index1[3] = {0,0,0};
-  for (int i=0; i<3; ++i){
-    if (NumberOfPoints[i] > 1){
-      index0[i] = max(0,index[i]);
-      if (index0[i] > NumberOfPoints[i]-2) index0[i] = NumberOfPoints[i]-2;
-      index1[i] = max(1,index[i]+1);
-      if (index1[i] > NumberOfPoints[i]-1) index1[i] = NumberOfPoints[i]-1;
+  putCoordGetInd(X1, X2, X3, index[0], index[1], index[2]);
+  int index0[3] = {0, 0, 0};
+  int index1[3] = {0, 0, 0};
+  for (int i = 0; i < 3; ++i) {
+    if (NumberOfPoints[i] > 1) {
+      index0[i] = max(0, index[i]);
+      if (index0[i] > NumberOfPoints[i] - 2)
+        index0[i] = NumberOfPoints[i] - 2;
+      index1[i] = max(1, index[i] + 1);
+      if (index1[i] > NumberOfPoints[i] - 1)
+        index1[i] = NumberOfPoints[i] - 1;
     }
   }
   double tmpX[3];
-  float  tmpB[3];
+  float tmpB[3];
   // define the corners of interpolation volume
   // FIXME: should not unpack the arrays to then repack them as first thing.
-  putIndicesGetB(index0[0],index0[1],index0[2],tmpB[0],tmpB[1],tmpB[2]);
-  putIndGetCoord(index0[0],index0[1],index0[2],tmpX[0],tmpX[1],tmpX[2]);
-  MagInterpol.defineCellPoint000(tmpX[0],tmpX[1],tmpX[2],double(tmpB[0]),double(tmpB[1]),double(tmpB[2]));
-  putIndicesGetB(index1[0],index0[1],index0[2],tmpB[0],tmpB[1],tmpB[2]);
-  putIndGetCoord(index1[0],index0[1],index0[2],tmpX[0],tmpX[1],tmpX[2]);
-  MagInterpol.defineCellPoint100(tmpX[0],tmpX[1],tmpX[2],double(tmpB[0]),double(tmpB[1]),double(tmpB[2]));
-  putIndicesGetB(index0[0],index1[1],index0[2],tmpB[0],tmpB[1],tmpB[2]);
-  putIndGetCoord(index0[0],index1[1],index0[2],tmpX[0],tmpX[1],tmpX[2]);
-  MagInterpol.defineCellPoint010(tmpX[0],tmpX[1],tmpX[2],double(tmpB[0]),double(tmpB[1]),double(tmpB[2]));
-  putIndicesGetB(index1[0],index1[1],index0[2],tmpB[0],tmpB[1],tmpB[2]);
-  putIndGetCoord(index1[0],index1[1],index0[2],tmpX[0],tmpX[1],tmpX[2]);
-  MagInterpol.defineCellPoint110(tmpX[0],tmpX[1],tmpX[2],double(tmpB[0]),double(tmpB[1]),double(tmpB[2]));
-  putIndicesGetB(index0[0],index0[1],index1[2],tmpB[0],tmpB[1],tmpB[2]);
-  putIndGetCoord(index0[0],index0[1],index1[2],tmpX[0],tmpX[1],tmpX[2]);
-  MagInterpol.defineCellPoint001(tmpX[0],tmpX[1],tmpX[2],double(tmpB[0]),double(tmpB[1]),double(tmpB[2]));
-  putIndicesGetB(index1[0],index0[1],index1[2],tmpB[0],tmpB[1],tmpB[2]);
-  putIndGetCoord(index1[0],index0[1],index1[2],tmpX[0],tmpX[1],tmpX[2]);
-  MagInterpol.defineCellPoint101(tmpX[0],tmpX[1],tmpX[2],double(tmpB[0]),double(tmpB[1]),double(tmpB[2]));
-  putIndicesGetB(index0[0],index1[1],index1[2],tmpB[0],tmpB[1],tmpB[2]);
-  putIndGetCoord(index0[0],index1[1],index1[2],tmpX[0],tmpX[1],tmpX[2]);
-  MagInterpol.defineCellPoint011(tmpX[0],tmpX[1],tmpX[2],double(tmpB[0]),double(tmpB[1]),double(tmpB[2]));
-  putIndicesGetB(index1[0],index1[1],index1[2],tmpB[0],tmpB[1],tmpB[2]);
-  putIndGetCoord(index1[0],index1[1],index1[2],tmpX[0],tmpX[1],tmpX[2]);
-  MagInterpol.defineCellPoint111(tmpX[0],tmpX[1],tmpX[2],double(tmpB[0]),double(tmpB[1]),double(tmpB[2]));
+  putIndicesGetB(index0[0], index0[1], index0[2], tmpB[0], tmpB[1], tmpB[2]);
+  putIndGetCoord(index0[0], index0[1], index0[2], tmpX[0], tmpX[1], tmpX[2]);
+  MagInterpol.defineCellPoint000(tmpX[0], tmpX[1], tmpX[2], double(tmpB[0]), double(tmpB[1]), double(tmpB[2]));
+  putIndicesGetB(index1[0], index0[1], index0[2], tmpB[0], tmpB[1], tmpB[2]);
+  putIndGetCoord(index1[0], index0[1], index0[2], tmpX[0], tmpX[1], tmpX[2]);
+  MagInterpol.defineCellPoint100(tmpX[0], tmpX[1], tmpX[2], double(tmpB[0]), double(tmpB[1]), double(tmpB[2]));
+  putIndicesGetB(index0[0], index1[1], index0[2], tmpB[0], tmpB[1], tmpB[2]);
+  putIndGetCoord(index0[0], index1[1], index0[2], tmpX[0], tmpX[1], tmpX[2]);
+  MagInterpol.defineCellPoint010(tmpX[0], tmpX[1], tmpX[2], double(tmpB[0]), double(tmpB[1]), double(tmpB[2]));
+  putIndicesGetB(index1[0], index1[1], index0[2], tmpB[0], tmpB[1], tmpB[2]);
+  putIndGetCoord(index1[0], index1[1], index0[2], tmpX[0], tmpX[1], tmpX[2]);
+  MagInterpol.defineCellPoint110(tmpX[0], tmpX[1], tmpX[2], double(tmpB[0]), double(tmpB[1]), double(tmpB[2]));
+  putIndicesGetB(index0[0], index0[1], index1[2], tmpB[0], tmpB[1], tmpB[2]);
+  putIndGetCoord(index0[0], index0[1], index1[2], tmpX[0], tmpX[1], tmpX[2]);
+  MagInterpol.defineCellPoint001(tmpX[0], tmpX[1], tmpX[2], double(tmpB[0]), double(tmpB[1]), double(tmpB[2]));
+  putIndicesGetB(index1[0], index0[1], index1[2], tmpB[0], tmpB[1], tmpB[2]);
+  putIndGetCoord(index1[0], index0[1], index1[2], tmpX[0], tmpX[1], tmpX[2]);
+  MagInterpol.defineCellPoint101(tmpX[0], tmpX[1], tmpX[2], double(tmpB[0]), double(tmpB[1]), double(tmpB[2]));
+  putIndicesGetB(index0[0], index1[1], index1[2], tmpB[0], tmpB[1], tmpB[2]);
+  putIndGetCoord(index0[0], index1[1], index1[2], tmpX[0], tmpX[1], tmpX[2]);
+  MagInterpol.defineCellPoint011(tmpX[0], tmpX[1], tmpX[2], double(tmpB[0]), double(tmpB[1]), double(tmpB[2]));
+  putIndicesGetB(index1[0], index1[1], index1[2], tmpB[0], tmpB[1], tmpB[2]);
+  putIndGetCoord(index1[0], index1[1], index1[2], tmpX[0], tmpX[1], tmpX[2]);
+  MagInterpol.defineCellPoint111(tmpX[0], tmpX[1], tmpX[2], double(tmpB[0]), double(tmpB[1]), double(tmpB[2]));
   // interpolate
-  MagInterpol.putSCoordGetVField(X1,X2,X3,dB[0],dB[1],dB[2]);
+  MagInterpol.putSCoordGetVField(X1, X2, X3, dB[0], dB[1], dB[2]);
   Bx = float(dB[0]);
   By = float(dB[1]);
   Bz = float(dB[2]);
@@ -143,71 +151,78 @@ void MagneticFieldGrid::interpolateAtPoint(double X1, double X2, double X3, floa
 
 // FIXME: Signature should be:
 //
-//     void MagneticFieldGrid::putCoordGetInd(double *pos, int *index) 
+//     void MagneticFieldGrid::putCoordGetInd(double *pos, int *index)
 //
-void MagneticFieldGrid::putCoordGetInd(double X1, double X2, double X3, int &Index1, int &Index2, int &Index3){
-  double pnt[3] = {X1,X2,X3};
+void MagneticFieldGrid::putCoordGetInd(double X1, double X2, double X3, int &Index1, int &Index2, int &Index3) {
+  double pnt[3] = {X1, X2, X3};
   int index[3];
-  switch (GridType){
-  case 1:{
-    for (int i=0; i<3; ++i){
-      index[i] = int((pnt[i]-ReferencePoint[i])/BasicDistance0[i]);
-    }
-    break;}
-  case 2:{
-    // FIXME: Should use else!
-    for (int i=0; i<3; ++i){
-      if (EasyCoordinate[i]){
-	index[i] = int((pnt[i]-ReferencePoint[i])/BasicDistance0[i]);
-      } else index[i] = 0;//computed below
-    }
-    for (int i=0; i<3; ++i){
-      if (!EasyCoordinate[i]){
-	double stepSize = BasicDistance0[i];
-	double offset   = 0.0;
-	for (int j=0; j<3; ++j){
-	  stepSize += BasicDistance1[i][j]*index[j];
-	  offset   += BasicDistance2[i][j]*index[j];
-	}
-	index[i] = int((pnt[i]-(ReferencePoint[i] + offset))/stepSize);
+  switch (GridType) {
+    case 1: {
+      for (int i = 0; i < 3; ++i) {
+        index[i] = int((pnt[i] - ReferencePoint[i]) / BasicDistance0[i]);
       }
+      break;
     }
-    break;}
-  case 3:{
-    for (int i=0; i<3; ++i){
-      index[i] = int((pnt[i]-ReferencePoint[i])/BasicDistance0[i]);
-    }
-    break;}
-  case 4:{
-    // FIXME: should use else!
-    for (int i=0; i<3; ++i){
-      if (EasyCoordinate[i]){
-	index[i] = int((pnt[i]-ReferencePoint[i])/BasicDistance0[i]);
-      } else index[i] = 0;//computed below
-    }
-    for (int i=0; i<3; ++i){
-      if (!EasyCoordinate[i]){
-	double stepSize = BasicDistance0[i];
-	double offset   = 0.0;
-	for (int j=0; j<3; ++j){
-	  stepSize += BasicDistance1[i][j]*index[j];
-	  offset   += BasicDistance2[i][j]*index[j];
-	}
-	index[i] = int((pnt[i]-(ReferencePoint[i] + offset))/stepSize);
+    case 2: {
+      // FIXME: Should use else!
+      for (int i = 0; i < 3; ++i) {
+        if (EasyCoordinate[i]) {
+          index[i] = int((pnt[i] - ReferencePoint[i]) / BasicDistance0[i]);
+        } else
+          index[i] = 0;  //computed below
       }
+      for (int i = 0; i < 3; ++i) {
+        if (!EasyCoordinate[i]) {
+          double stepSize = BasicDistance0[i];
+          double offset = 0.0;
+          for (int j = 0; j < 3; ++j) {
+            stepSize += BasicDistance1[i][j] * index[j];
+            offset += BasicDistance2[i][j] * index[j];
+          }
+          index[i] = int((pnt[i] - (ReferencePoint[i] + offset)) / stepSize);
+        }
+      }
+      break;
     }
-    break;}
-  case 5:{
-    double sinPhi = sin(pnt[1]);
-    double stepSize = RParAsFunOfPhi[0] + RParAsFunOfPhi[1]/sinPhi - RParAsFunOfPhi[2] - RParAsFunOfPhi[3]/sinPhi;
-    stepSize =  stepSize/(NumberOfPoints[0]-1);
-    double startingPoint = RParAsFunOfPhi[2] + RParAsFunOfPhi[3]/sinPhi;
-    index[0] = int((pnt[0]-startingPoint)/stepSize);
-    index[1] = int((pnt[1]-ReferencePoint[1])/BasicDistance0[1]);
-    index[2] = int((pnt[2]-ReferencePoint[2])/BasicDistance0[2]);
-    break;}
-  default:
-    assert(0); //shouldn't be here
+    case 3: {
+      for (int i = 0; i < 3; ++i) {
+        index[i] = int((pnt[i] - ReferencePoint[i]) / BasicDistance0[i]);
+      }
+      break;
+    }
+    case 4: {
+      // FIXME: should use else!
+      for (int i = 0; i < 3; ++i) {
+        if (EasyCoordinate[i]) {
+          index[i] = int((pnt[i] - ReferencePoint[i]) / BasicDistance0[i]);
+        } else
+          index[i] = 0;  //computed below
+      }
+      for (int i = 0; i < 3; ++i) {
+        if (!EasyCoordinate[i]) {
+          double stepSize = BasicDistance0[i];
+          double offset = 0.0;
+          for (int j = 0; j < 3; ++j) {
+            stepSize += BasicDistance1[i][j] * index[j];
+            offset += BasicDistance2[i][j] * index[j];
+          }
+          index[i] = int((pnt[i] - (ReferencePoint[i] + offset)) / stepSize);
+        }
+      }
+      break;
+    }
+    case 5: {
+      double sinPhi = sin(pnt[1]);
+      double stepSize = RParAsFunOfPhi[0] + RParAsFunOfPhi[1] / sinPhi - RParAsFunOfPhi[2] - RParAsFunOfPhi[3] / sinPhi;
+      stepSize = stepSize / (NumberOfPoints[0] - 1);
+      double startingPoint = RParAsFunOfPhi[2] + RParAsFunOfPhi[3] / sinPhi;
+      index[0] = int((pnt[0] - startingPoint) / stepSize);
+      index[1] = int((pnt[1] - ReferencePoint[1]) / BasicDistance0[1]);
+      index[2] = int((pnt[2] - ReferencePoint[2]) / BasicDistance0[2]);
+      break;
+    }
+    default:
+      assert(0);  //shouldn't be here
   }
   Index1 = index[0];
   Index2 = index[1];
@@ -215,7 +230,7 @@ void MagneticFieldGrid::putCoordGetInd(double X1, double X2, double X3, int &Ind
   return;
 }
 
-void MagneticFieldGrid::putIndicesGetB(int Index1, int Index2, int Index3, float &Bx, float &By, float &Bz){
+void MagneticFieldGrid::putIndicesGetB(int Index1, int Index2, int Index3, float &Bx, float &By, float &Bz) {
   BVector FieldEntry;
   FieldEntry = FieldValues.operator[](lineNumber(Index1, Index2, Index3));
   Bx = FieldEntry.bx();
@@ -225,63 +240,66 @@ void MagneticFieldGrid::putIndicesGetB(int Index1, int Index2, int Index3, float
 }
 
 // FIXME: same as above.
-void MagneticFieldGrid::putIndGetCoord(int Index1, int Index2, int Index3, double &X1, double &X2, double &X3){
+void MagneticFieldGrid::putIndGetCoord(int Index1, int Index2, int Index3, double &X1, double &X2, double &X3) {
   int index[3] = {Index1, Index2, Index3};
   double pnt[3];
-  switch (GridType){
-  case 1:{
-    for (int i=0; i<3; ++i){
-      pnt[i] = ReferencePoint[i] + BasicDistance0[i]*index[i];
-    }
-    break;}
-  case 2:{
-    for (int i=0; i<3; ++i){
-      if (EasyCoordinate[i]){
-	pnt[i] = ReferencePoint[i] + BasicDistance0[i]*index[i];
+  switch (GridType) {
+    case 1: {
+      for (int i = 0; i < 3; ++i) {
+        pnt[i] = ReferencePoint[i] + BasicDistance0[i] * index[i];
       }
-      else {
-	double stepSize = BasicDistance0[i];
-	double offset   = 0.0;
-	for (int j=0; j<3; ++j){
-	  stepSize += BasicDistance1[i][j]*index[j];
-	  offset   += BasicDistance2[i][j]*index[j];
-	}
-	pnt[i] = ReferencePoint[i] + offset + stepSize*index[i];
-      }
+      break;
     }
-    break;}
-  case 3:{
-    for (int i=0; i<3; ++i){
-      pnt[i] = ReferencePoint[i] + BasicDistance0[i]*index[i];
-    }
-    break;}
-  case 4:{
-    for (int i=0; i<3; ++i){
-      if (EasyCoordinate[i]){
-	pnt[i] = ReferencePoint[i] + BasicDistance0[i]*index[i];
+    case 2: {
+      for (int i = 0; i < 3; ++i) {
+        if (EasyCoordinate[i]) {
+          pnt[i] = ReferencePoint[i] + BasicDistance0[i] * index[i];
+        } else {
+          double stepSize = BasicDistance0[i];
+          double offset = 0.0;
+          for (int j = 0; j < 3; ++j) {
+            stepSize += BasicDistance1[i][j] * index[j];
+            offset += BasicDistance2[i][j] * index[j];
+          }
+          pnt[i] = ReferencePoint[i] + offset + stepSize * index[i];
+        }
       }
-      else {
-	double stepSize = BasicDistance0[i];
-	double offset   = 0.0;
-	for (int j=0; j<3; ++j){
-	  stepSize += BasicDistance1[i][j]*index[j];
-	  offset   += BasicDistance2[i][j]*index[j];
-	}
-	pnt[i] = ReferencePoint[i] + offset + stepSize*index[i];
-      }
+      break;
     }
-    break;}
-  case 5:{
-    pnt[2] = ReferencePoint[2] + BasicDistance0[2]*index[2];
-    pnt[1] = ReferencePoint[1] + BasicDistance0[1]*index[1];
-    double sinPhi = sin(pnt[1]);
-    double stepSize = RParAsFunOfPhi[0] + RParAsFunOfPhi[1]/sinPhi - RParAsFunOfPhi[2] - RParAsFunOfPhi[3]/sinPhi;
-    stepSize =  stepSize/(NumberOfPoints[0]-1);
-    double startingPoint = RParAsFunOfPhi[2] + RParAsFunOfPhi[3]/sinPhi;
-    pnt[0] = startingPoint + stepSize*index[0];
-    break;}
-  default:
-    assert(0);//bug if make it here
+    case 3: {
+      for (int i = 0; i < 3; ++i) {
+        pnt[i] = ReferencePoint[i] + BasicDistance0[i] * index[i];
+      }
+      break;
+    }
+    case 4: {
+      for (int i = 0; i < 3; ++i) {
+        if (EasyCoordinate[i]) {
+          pnt[i] = ReferencePoint[i] + BasicDistance0[i] * index[i];
+        } else {
+          double stepSize = BasicDistance0[i];
+          double offset = 0.0;
+          for (int j = 0; j < 3; ++j) {
+            stepSize += BasicDistance1[i][j] * index[j];
+            offset += BasicDistance2[i][j] * index[j];
+          }
+          pnt[i] = ReferencePoint[i] + offset + stepSize * index[i];
+        }
+      }
+      break;
+    }
+    case 5: {
+      pnt[2] = ReferencePoint[2] + BasicDistance0[2] * index[2];
+      pnt[1] = ReferencePoint[1] + BasicDistance0[1] * index[1];
+      double sinPhi = sin(pnt[1]);
+      double stepSize = RParAsFunOfPhi[0] + RParAsFunOfPhi[1] / sinPhi - RParAsFunOfPhi[2] - RParAsFunOfPhi[3] / sinPhi;
+      stepSize = stepSize / (NumberOfPoints[0] - 1);
+      double startingPoint = RParAsFunOfPhi[2] + RParAsFunOfPhi[3] / sinPhi;
+      pnt[0] = startingPoint + stepSize * index[0];
+      break;
+    }
+    default:
+      assert(0);  //bug if make it here
   }
   X1 = pnt[0];
   X2 = pnt[1];
@@ -289,19 +307,19 @@ void MagneticFieldGrid::putIndGetCoord(int Index1, int Index2, int Index3, doubl
   return;
 }
 
-int MagneticFieldGrid::lineNumber(int Index1, int Index2, int Index3){
-  return Index1*NumberOfPoints[1]*NumberOfPoints[2] + Index2*NumberOfPoints[2] + Index3;
+int MagneticFieldGrid::lineNumber(int Index1, int Index2, int Index3) {
+  return Index1 * NumberOfPoints[1] * NumberOfPoints[2] + Index2 * NumberOfPoints[2] + Index3;
 }
 
-void MagneticFieldGrid::BVector::putB3(float Bx, float By, float Bz){
+void MagneticFieldGrid::BVector::putB3(float Bx, float By, float Bz) {
   B3[0] = Bx;
   B3[1] = By;
   B3[2] = Bz;
   return;
 }
 
-float MagneticFieldGrid::BVector::bx(){  return B3[0]; }
+float MagneticFieldGrid::BVector::bx() { return B3[0]; }
 
-float MagneticFieldGrid::BVector::by(){  return B3[1]; }
+float MagneticFieldGrid::BVector::by() { return B3[1]; }
 
-float MagneticFieldGrid::BVector::bz(){  return B3[2]; }
+float MagneticFieldGrid::BVector::bz() { return B3[2]; }

--- a/MagneticField/Interpolation/src/MagneticFieldGrid.h
+++ b/MagneticField/Interpolation/src/MagneticFieldGrid.h
@@ -29,44 +29,65 @@
 #include <iostream>
 #include <fstream>
 
-class dso_internal MagneticFieldGrid{
+class dso_internal MagneticFieldGrid {
 public:
   // constructor
-  MagneticFieldGrid(){
+  MagneticFieldGrid() {
     GridType = 0;
-    for (int i=0;i<3; ++i) {NumberOfPoints[i] = 0;};
-    for (int i=0;i<3; ++i) {ReferencePoint[i] = 0.;};
-    for (int i=0;i<3; ++i) {BasicDistance0[i] = 0.;};
-    for (int i=0;i<3; ++i) {for (int j=0;j<3; ++j) {BasicDistance1[i][j] = 0.;};};
-    for (int i=0;i<3; ++i) {for (int j=0;j<3; ++j) {BasicDistance2[i][j] = 0.;};};
-    for (int i=0;i<4; ++i) {RParAsFunOfPhi[i] = 0.;};
-    for (int i=0;i<3; ++i) {EasyCoordinate[i] = false;};
+    for (int i = 0; i < 3; ++i) {
+      NumberOfPoints[i] = 0;
+    };
+    for (int i = 0; i < 3; ++i) {
+      ReferencePoint[i] = 0.;
+    };
+    for (int i = 0; i < 3; ++i) {
+      BasicDistance0[i] = 0.;
+    };
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        BasicDistance1[i][j] = 0.;
+      };
+    };
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        BasicDistance2[i][j] = 0.;
+      };
+    };
+    for (int i = 0; i < 4; ++i) {
+      RParAsFunOfPhi[i] = 0.;
+    };
+    for (int i = 0; i < 3; ++i) {
+      EasyCoordinate[i] = false;
+    };
   }
   // destructor
-  ~MagneticFieldGrid(){}
+  ~MagneticFieldGrid() {}
 
 private:
   // header classes (5: one for each type)
-  class dso_internal HeaderType3{
+  class dso_internal HeaderType3 {
   public:
     // constructor
-    HeaderType3(){}
+    HeaderType3() {}
     // destructor
-    ~HeaderType3(){}
+    ~HeaderType3() {}
+
   private:
   public:
     void printInfo();
   };
   // b-field container
-  class dso_internal BVector{
+  class dso_internal BVector {
   public:
     // constructor
-    BVector(){}
+    BVector() {}
     // destructor
-    ~BVector(){}
+    ~BVector() {}
+
   private:
     // three component vector in float precision
     float B3[3];
+
   public:
     // Accessors
     void putB3(float Bx, float By, float Bz);
@@ -79,19 +100,19 @@ private:
   // type
   int GridType;
   // header
-  int    NumberOfPoints[3];
+  int NumberOfPoints[3];
   double ReferencePoint[3];
   double BasicDistance0[3];     // constant step
   double BasicDistance1[3][3];  // linear step
   double BasicDistance2[3][3];  // linear offset
   double RParAsFunOfPhi[4];     // R = f(phi) or const. (0,2: const. par. ; 1,3: const./sin(phi))
-  bool   EasyCoordinate[3];
+  bool EasyCoordinate[3];
   // field (Bx,By,Bz) container
   std::vector<BVector> FieldValues;
 
 public:
   /// load grid binary file
-  void load(const std::string& name);
+  void load(const std::string &name);
   /// returns value of GridType (and eventually prints the type + short description)
   int gridType();
 
@@ -100,13 +121,12 @@ public:
 
   // calculates indices from coordinates
   void putCoordGetInd(double X1, double X2, double X3, int &Index1, int &Index2, int &Index3);
-  // takes indices and returns magnetic field values 
+  // takes indices and returns magnetic field values
   void putIndicesGetB(int Index1, int Index2, int Index3, float &Bx, float &By, float &Bz);
   // takes indices, calculates coordinates, and returns coordinates
   void putIndGetCoord(int Index1, int Index2, int Index3, double &X1, double &X2, double &X3);
   // converts three indices into one number (for the vector FieldValues)
   int lineNumber(int Index1, int Index2, int Index3);
 };
-
 
 #endif

--- a/MagneticField/Interpolation/src/RectangularCartesianMFGrid.cc
+++ b/MagneticField/Interpolation/src/RectangularCartesianMFGrid.cc
@@ -6,25 +6,21 @@
 
 using namespace std;
 
-RectangularCartesianMFGrid::RectangularCartesianMFGrid( binary_ifstream& inFile,
-							const GloballyPositioned<float>& vol)
-  : MFGrid3D(vol)
-{
-
+RectangularCartesianMFGrid::RectangularCartesianMFGrid(binary_ifstream& inFile, const GloballyPositioned<float>& vol)
+    : MFGrid3D(vol) {
   // The parameters read from the data files are given in global coordinates.
   // In version 85l, local frame has the same orientation of global frame for the reference
   // volume, i.e. the r.f. transformation is only a translation.
   // There is therefore no need to convert the field values to local coordinates.
-  // Check this assumption: 
-  GlobalVector localXDir(frame().toGlobal(LocalVector(1,0,0)));
-  GlobalVector localYDir(frame().toGlobal(LocalVector(0,1,0)));
+  // Check this assumption:
+  GlobalVector localXDir(frame().toGlobal(LocalVector(1, 0, 0)));
+  GlobalVector localYDir(frame().toGlobal(LocalVector(0, 1, 0)));
 
-  if (localXDir.dot(GlobalVector(1,0,0)) > 0.999999 &&
-      localYDir.dot(GlobalVector(0,1,0)) > 0.999999) {
+  if (localXDir.dot(GlobalVector(1, 0, 0)) > 0.999999 && localYDir.dot(GlobalVector(0, 1, 0)) > 0.999999) {
     // "null" rotation - requires no conversion...
   } else {
-    cout << "ERROR: RectangularCartesianMFGrid: unexpected orientation: x: " 
-	 << localXDir << " y: " << localYDir << endl;
+    cout << "ERROR: RectangularCartesianMFGrid: unexpected orientation: x: " << localXDir << " y: " << localYDir
+         << endl;
   }
 
   int n1, n2, n3;
@@ -32,80 +28,72 @@ RectangularCartesianMFGrid::RectangularCartesianMFGrid( binary_ifstream& inFile,
   double xref, yref, zref;
   inFile >> xref >> yref >> zref;
   double stepx, stepy, stepz;
-  inFile >> stepx    >> stepy    >> stepz;
+  inFile >> stepx >> stepy >> stepz;
 
   vector<BVector> fieldValues;
   float Bx, By, Bz;
-  int nLines = n1*n2*n3;
+  int nLines = n1 * n2 * n3;
   fieldValues.reserve(nLines);
-  for (int iLine=0; iLine<nLines; ++iLine){
+  for (int iLine = 0; iLine < nLines; ++iLine) {
     inFile >> Bx >> By >> Bz;
-    fieldValues.push_back(BVector(Bx,By,Bz));
+    fieldValues.push_back(BVector(Bx, By, Bz));
   }
   // check completeness
   string lastEntry;
   inFile >> lastEntry;
-  if (lastEntry != "complete"){
+  if (lastEntry != "complete") {
     cout << "ERROR during file reading: file is not complete" << endl;
   }
 
-  GlobalPoint grefp( xref, yref, zref);
-  LocalPoint lrefp = frame().toLocal( grefp);
+  GlobalPoint grefp(xref, yref, zref);
+  LocalPoint lrefp = frame().toLocal(grefp);
 
-  Grid1D gridX( lrefp.x(), lrefp.x() + stepx*(n1-1), n1);
-  Grid1D gridY( lrefp.y(), lrefp.y() + stepy*(n2-1), n2);
-  Grid1D gridZ( lrefp.z(), lrefp.z() + stepz*(n3-1), n3);
-  grid_ = GridType( gridX, gridY, gridZ, fieldValues);
-  
+  Grid1D gridX(lrefp.x(), lrefp.x() + stepx * (n1 - 1), n1);
+  Grid1D gridY(lrefp.y(), lrefp.y() + stepy * (n2 - 1), n2);
+  Grid1D gridZ(lrefp.z(), lrefp.z() + stepz * (n3 - 1), n3);
+  grid_ = GridType(gridX, gridY, gridZ, fieldValues);
+
   // Activate/deactivate timers
-//   static SimpleConfigurable<bool> timerOn(false,"MFGrid:timing");
-//   (*TimingReport::current()).switchOn("MagneticFieldProvider::valueInTesla(RectangularCartesianMFGrid)",timerOn);
-
+  //   static SimpleConfigurable<bool> timerOn(false,"MFGrid:timing");
+  //   (*TimingReport::current()).switchOn("MagneticFieldProvider::valueInTesla(RectangularCartesianMFGrid)",timerOn);
 }
 
-void RectangularCartesianMFGrid::dump() const
-{
+void RectangularCartesianMFGrid::dump() const {
   cout << endl << "Dump of RectangularCartesianMFGrid" << endl;
-//   cout << "Number of points from file   " 
-//        << n1 << " " << n2 << " " << n3 << endl;
-  cout << "Number of points from Grid1D " 
-       << grid_.grida().nodes() << " " << grid_.gridb().nodes() << " " << grid_.gridc().nodes() << endl;
+  //   cout << "Number of points from file   "
+  //        << n1 << " " << n2 << " " << n3 << endl;
+  cout << "Number of points from Grid1D " << grid_.grida().nodes() << " " << grid_.gridb().nodes() << " "
+       << grid_.gridc().nodes() << endl;
 
-//   cout << "Reference Point from file   " 
-//        << xref << " " << yref << " " << zref << endl;
-  cout << "Reference Point from Grid1D " 
-       << grid_.grida().lower() << " " << grid_.gridb().lower() << " " << grid_.gridc().lower() << endl;
+  //   cout << "Reference Point from file   "
+  //        << xref << " " << yref << " " << zref << endl;
+  cout << "Reference Point from Grid1D " << grid_.grida().lower() << " " << grid_.gridb().lower() << " "
+       << grid_.gridc().lower() << endl;
 
-//   cout << "Basic Distance from file   " 
-//        <<  stepx << " " << stepy << " " << stepz << endl;
-  cout << "Basic Distance from Grid1D "
-       << grid_.grida().step() << " " << grid_.gridb().step() << " " << grid_.gridc().step() << endl;
-
+  //   cout << "Basic Distance from file   "
+  //        <<  stepx << " " << stepy << " " << stepz << endl;
+  cout << "Basic Distance from Grid1D " << grid_.grida().step() << " " << grid_.gridb().step() << " "
+       << grid_.gridc().step() << endl;
 
   cout << "Dumping " << grid_.data().size() << " field values " << endl;
   // grid_.dump();
 }
 
-MFGrid::LocalVector 
-RectangularCartesianMFGrid::uncheckedValueInTesla( const LocalPoint& p) const
-{
-//   static TimingReport::Item & timer= (*TimingReport::current())["MagneticFieldProvider::valueInTesla(RectangularCartesianMFGrid)"];
-//   TimeMe t(timer,false);
+MFGrid::LocalVector RectangularCartesianMFGrid::uncheckedValueInTesla(const LocalPoint& p) const {
+  //   static TimingReport::Item & timer= (*TimingReport::current())["MagneticFieldProvider::valueInTesla(RectangularCartesianMFGrid)"];
+  //   TimeMe t(timer,false);
 
-  LinearGridInterpolator3D interpol( grid_);
-  GridType::ReturnType value = interpol.interpolate( p.x(), p.y(), p.z());
+  LinearGridInterpolator3D interpol(grid_);
+  GridType::ReturnType value = interpol.interpolate(p.x(), p.y(), p.z());
   return LocalVector(value);
 }
 
-void RectangularCartesianMFGrid::toGridFrame( const LocalPoint& p, 
-					      double& a, double& b, double& c) const
-{
+void RectangularCartesianMFGrid::toGridFrame(const LocalPoint& p, double& a, double& b, double& c) const {
   a = p.x();
   b = p.y();
   c = p.z();
 }
- 
-MFGrid::LocalPoint RectangularCartesianMFGrid::fromGridFrame( double a, double b, double c) const
-{
-  return LocalPoint( a, b, c);
+
+MFGrid::LocalPoint RectangularCartesianMFGrid::fromGridFrame(double a, double b, double c) const {
+  return LocalPoint(a, b, c);
 }

--- a/MagneticField/Interpolation/src/RectangularCartesianMFGrid.h
+++ b/MagneticField/Interpolation/src/RectangularCartesianMFGrid.h
@@ -8,18 +8,15 @@ class binary_ifstream;
 
 class dso_internal RectangularCartesianMFGrid : public MFGrid3D {
 public:
+  RectangularCartesianMFGrid(binary_ifstream& istr, const GloballyPositioned<float>& vol);
 
-  RectangularCartesianMFGrid( binary_ifstream& istr, 
-			      const GloballyPositioned<float>& vol);
-
-  LocalVector uncheckedValueInTesla( const LocalPoint& p) const override;
+  LocalVector uncheckedValueInTesla(const LocalPoint& p) const override;
 
   void dump() const override;
 
-  void toGridFrame( const LocalPoint& p, double& a, double& b, double& c) const override;
+  void toGridFrame(const LocalPoint& p, double& a, double& b, double& c) const override;
 
-  LocalPoint fromGridFrame( double a, double b, double c) const override;
-
+  LocalPoint fromGridFrame(double a, double b, double c) const override;
 };
 
 #endif

--- a/MagneticField/Interpolation/src/RectangularCylindricalMFGrid.cc
+++ b/MagneticField/Interpolation/src/RectangularCylindricalMFGrid.cc
@@ -5,24 +5,22 @@
 
 using namespace std;
 
-RectangularCylindricalMFGrid::RectangularCylindricalMFGrid( binary_ifstream& inFile, 
-							    const GloballyPositioned<float>& vol)
-  : MFGrid3D(vol)
-{
+RectangularCylindricalMFGrid::RectangularCylindricalMFGrid(binary_ifstream& inFile,
+                                                           const GloballyPositioned<float>& vol)
+    : MFGrid3D(vol) {
   // The parameters read from the data files are given in global coordinates.
   // In version 85l, local frame has the same orientation of global frame for the reference
   // volume, i.e. the r.f. transformation is only a translation.
   // There is therefore no need to convert the field values to local coordinates.
-  // Check this assumption: 
-  GlobalVector localXDir(frame().toGlobal(LocalVector(1,0,0)));
-  GlobalVector localYDir(frame().toGlobal(LocalVector(0,1,0)));
+  // Check this assumption:
+  GlobalVector localXDir(frame().toGlobal(LocalVector(1, 0, 0)));
+  GlobalVector localYDir(frame().toGlobal(LocalVector(0, 1, 0)));
 
-  if (localXDir.dot(GlobalVector(1,0,0)) > 0.999999 &&
-      localYDir.dot(GlobalVector(0,1,0)) > 0.999999) {
+  if (localXDir.dot(GlobalVector(1, 0, 0)) > 0.999999 && localYDir.dot(GlobalVector(0, 1, 0)) > 0.999999) {
     // "null" rotation - requires no conversion...
   } else {
-    cout << "ERROR: RectangularCylindricalMFGrid: unexpected orientation: x: " 
-	 << localXDir << " y: " << localYDir << endl;
+    cout << "ERROR: RectangularCylindricalMFGrid: unexpected orientation: x: " << localXDir << " y: " << localYDir
+         << endl;
   }
 
   int n1, n2, n3;
@@ -30,93 +28,85 @@ RectangularCylindricalMFGrid::RectangularCylindricalMFGrid( binary_ifstream& inF
   double xref, yref, zref;
   inFile >> xref >> yref >> zref;
   double stepx, stepy, stepz;
-  inFile >> stepx    >> stepy    >> stepz;
+  inFile >> stepx >> stepy >> stepz;
 
   vector<BVector> fieldValues;
   float Bx, By, Bz;
-  int nLines = n1*n2*n3;
+  int nLines = n1 * n2 * n3;
   fieldValues.reserve(nLines);
-  for (int iLine=0; iLine<nLines; ++iLine){
+  for (int iLine = 0; iLine < nLines; ++iLine) {
     inFile >> Bx >> By >> Bz;
-    fieldValues.push_back(BVector(Bx,By,Bz));
+    fieldValues.push_back(BVector(Bx, By, Bz));
   }
   // check completeness
   string lastEntry;
   inFile >> lastEntry;
-  if (lastEntry != "complete"){
+  if (lastEntry != "complete") {
     cout << "ERROR during file reading: file is not complete" << endl;
   }
 
-  GlobalPoint grefp( GlobalPoint::Cylindrical( xref, yref, zref));
-  LocalPoint lrefp = frame().toLocal( grefp);
+  GlobalPoint grefp(GlobalPoint::Cylindrical(xref, yref, zref));
+  LocalPoint lrefp = frame().toLocal(grefp);
 
 #ifdef DEBUG_GRID
   cout << "Grid reference point in grid system: " << xref << "," << yref << "," << zref << endl;
   cout << "Grid reference point in global x,y,z: " << grefp << endl;
   cout << "Grid reference point in local x,y,z: " << lrefp << endl;
-  cout << "steps " << stepx << "," <<  stepy << "," << stepz << endl;
+  cout << "steps " << stepx << "," << stepy << "," << stepz << endl;
 #endif
 
-  Grid1D gridX( lrefp.perp(), lrefp.perp() + stepx*(n1-1), n1);
+  Grid1D gridX(lrefp.perp(), lrefp.perp() + stepx * (n1 - 1), n1);
   //Grid1D gridY( lrefp.phi(), lrefp.phi() + stepy*(n2-1), n2); // wrong: gives zero
-  Grid1D gridY( yref, yref + stepy*(n2-1), n2);
-  Grid1D gridZ( lrefp.z(), lrefp.z() + stepz*(n3-1), n3);
+  Grid1D gridY(yref, yref + stepy * (n2 - 1), n2);
+  Grid1D gridZ(lrefp.z(), lrefp.z() + stepz * (n3 - 1), n3);
 
-  grid_ = GridType( gridX, gridY, gridZ, fieldValues);
-  
+  grid_ = GridType(gridX, gridY, gridZ, fieldValues);
 }
 
-void RectangularCylindricalMFGrid::dump() const
-{
+void RectangularCylindricalMFGrid::dump() const {
   cout << endl << "Dump of RectangularCylindricalMFGrid" << endl;
-  cout << "Number of points from Grid1D " 
-       << grid_.grida().nodes() << " " << grid_.gridb().nodes() << " " << grid_.gridc().nodes() << endl;
+  cout << "Number of points from Grid1D " << grid_.grida().nodes() << " " << grid_.gridb().nodes() << " "
+       << grid_.gridc().nodes() << endl;
 
-  cout << "Reference Point from Grid1D " 
-       << grid_.grida().lower() << " " << grid_.gridb().lower() << " " << grid_.gridc().lower() << endl;
+  cout << "Reference Point from Grid1D " << grid_.grida().lower() << " " << grid_.gridb().lower() << " "
+       << grid_.gridc().lower() << endl;
 
-  cout << "Basic Distance from Grid1D "
-       << grid_.grida().step() << " " << grid_.gridb().step() << " " << grid_.gridc().step() << endl;
-
+  cout << "Basic Distance from Grid1D " << grid_.grida().step() << " " << grid_.gridb().step() << " "
+       << grid_.gridc().step() << endl;
 
   cout << "Dumping " << grid_.data().size() << " field values " << endl;
   // grid_.dump();
 }
 
-MFGrid::LocalVector RectangularCylindricalMFGrid::uncheckedValueInTesla( const LocalPoint& p) const
-{
-  const float minimalSignificantR = 1e-6; // [cm], points below this radius are treated as zero radius
+MFGrid::LocalVector RectangularCylindricalMFGrid::uncheckedValueInTesla(const LocalPoint& p) const {
+  const float minimalSignificantR = 1e-6;  // [cm], points below this radius are treated as zero radius
   float R = p.perp();
   if (R < minimalSignificantR) {
     if (grid_.grida().lower() < minimalSignificantR) {
       int k = grid_.gridc().index(p.z());
       double u = (p.z() - grid_.gridc().node(k)) / grid_.gridc().step();
-      LocalVector result((1-u)*grid_(0,  0,  k) + u*grid_(0,  0,  k+1)); 
+      LocalVector result((1 - u) * grid_(0, 0, k) + u * grid_(0, 0, k + 1));
       return result;
     }
   }
-  
-  LinearGridInterpolator3D interpol( grid_);
+
+  LinearGridInterpolator3D interpol(grid_);
   // FIXME: "OLD" convention of phi.
   // GridType::ValueType value = interpol( R, Geom::pi() - p.phi(), p.z());
-  GridType::ReturnType value = interpol.interpolate( R, p.phi(), p.z());
+  GridType::ReturnType value = interpol.interpolate(R, p.phi(), p.z());
   return LocalVector(value);
 }
 
-void RectangularCylindricalMFGrid::toGridFrame( const LocalPoint& p, 
-					      double& a, double& b, double& c) const
-{
+void RectangularCylindricalMFGrid::toGridFrame(const LocalPoint& p, double& a, double& b, double& c) const {
   a = p.perp();
   // FIXME: "OLD" convention of phi.
   //  b = Geom::pi() - p.phi();
   b = p.phi();
   c = p.z();
 }
- 
-MFGrid::LocalPoint RectangularCylindricalMFGrid::fromGridFrame( double a, double b, double c) const
-{
 
+MFGrid::LocalPoint RectangularCylindricalMFGrid::fromGridFrame(double a, double b, double c) const {
   // FIXME: "OLD" convention of phi.
   //  return LocalPoint( LocalPoint::Cylindrical(a, Geom::pi() - b, c));
-  return LocalPoint( LocalPoint::Cylindrical(a, b, c));
+  return LocalPoint(LocalPoint::Cylindrical(a, b, c));
 }

--- a/MagneticField/Interpolation/src/RectangularCylindricalMFGrid.h
+++ b/MagneticField/Interpolation/src/RectangularCylindricalMFGrid.h
@@ -8,18 +8,15 @@ class binary_ifstream;
 
 class dso_internal RectangularCylindricalMFGrid : public MFGrid3D {
 public:
+  RectangularCylindricalMFGrid(binary_ifstream& istr, const GloballyPositioned<float>& vol);
 
-  RectangularCylindricalMFGrid( binary_ifstream& istr, 
-				const GloballyPositioned<float>& vol );
-
-  LocalVector uncheckedValueInTesla( const LocalPoint& p) const override;
+  LocalVector uncheckedValueInTesla(const LocalPoint& p) const override;
 
   void dump() const override;
 
-  void toGridFrame( const LocalPoint& p, double& a, double& b, double& c) const override;
+  void toGridFrame(const LocalPoint& p, double& a, double& b, double& c) const override;
 
-  LocalPoint fromGridFrame( double a, double b, double c) const override;
-
+  LocalPoint fromGridFrame(double a, double b, double c) const override;
 };
 
 #endif

--- a/MagneticField/Interpolation/src/SpecialCylindricalMFGrid.cc
+++ b/MagneticField/Interpolation/src/SpecialCylindricalMFGrid.cc
@@ -2,18 +2,17 @@
 #include "binary_ifstream.h"
 #include "LinearGridInterpolator3D.h"
 
-
 #include <iostream>
 
 using namespace std;
 
-SpecialCylindricalMFGrid::SpecialCylindricalMFGrid( binary_ifstream& inFile, 
-						    const GloballyPositioned<float>& vol, int gridType)
-  : MFGrid3D(vol)
-{
-  if (gridType == 5 ) {
+SpecialCylindricalMFGrid::SpecialCylindricalMFGrid(binary_ifstream& inFile,
+                                                   const GloballyPositioned<float>& vol,
+                                                   int gridType)
+    : MFGrid3D(vol) {
+  if (gridType == 5) {
     sector1 = false;
-  } else if (gridType == 6 ) {
+  } else if (gridType == 6) {
     sector1 = true;
   } else {
     cout << "ERROR wrong SpecialCylindricalMFGrid type " << gridType << endl;
@@ -28,106 +27,102 @@ SpecialCylindricalMFGrid::SpecialCylindricalMFGrid( binary_ifstream& inFile,
   double xref, yref, zref;
   inFile >> xref >> yref >> zref;
   double stepx, stepy, stepz;
-  inFile >> stepx    >> stepy    >> stepz;
+  inFile >> stepx >> stepy >> stepz;
 
   double RParAsFunOfPhi[4];  // R = f(phi) or const. (0,2: const. par. ; 1,3: const./sin(phi));
   inFile >> RParAsFunOfPhi[0] >> RParAsFunOfPhi[1] >> RParAsFunOfPhi[2] >> RParAsFunOfPhi[3];
 
   vector<BVector> fieldValues;
   float Bx, By, Bz;
-  int nLines = n1*n2*n3;
+  int nLines = n1 * n2 * n3;
   fieldValues.reserve(nLines);
-  for (int iLine=0; iLine<nLines; ++iLine){
+  for (int iLine = 0; iLine < nLines; ++iLine) {
     inFile >> Bx >> By >> Bz;
     // This would be fine only if local r.f. has the axes oriented as the global r.f.
     // For this volume we know that the local and global r.f. have different axis
     // orientation, so we do not try to be clever.
     //    fieldValues.push_back(BVector(Bx,By,Bz));
-    
+
     // Preserve double precision!
-    Vector3DBase<double, LocalTag>  lB = frame().toLocal(Vector3DBase<double, GlobalTag>(Bx,By,Bz));
+    Vector3DBase<double, LocalTag> lB = frame().toLocal(Vector3DBase<double, GlobalTag>(Bx, By, Bz));
     fieldValues.push_back(BVector(lB.x(), lB.y(), lB.z()));
   }
   // check completeness
   string lastEntry;
   inFile >> lastEntry;
-  if (lastEntry != "complete"){
+  if (lastEntry != "complete") {
     cout << "ERROR during file reading: file is not complete" << endl;
   }
 
-  GlobalPoint grefp( GlobalPoint::Cylindrical( xref, yref, zref));
+  GlobalPoint grefp(GlobalPoint::Cylindrical(xref, yref, zref));
 
 #ifdef DEBUG_GRID
-  LocalPoint lrefp = frame().toLocal( grefp);
+  LocalPoint lrefp = frame().toLocal(grefp);
   cout << "Grid reference point in grid system: " << xref << "," << yref << "," << zref << endl;
   cout << "Grid reference point in global x,y,z: " << grefp << endl;
   cout << "Grid reference point in local x,y,z: " << lrefp << endl;
-  cout << "steps " << stepx << "," <<  stepy << "," << stepz << endl;
+  cout << "steps " << stepx << "," << stepy << "," << stepz << endl;
   cout << "RParAsFunOfPhi[0...4] = ";
-  for (int i=0; i<4; ++i) cout << RParAsFunOfPhi[i] << " "; cout << endl;
+  for (int i = 0; i < 4; ++i)
+    cout << RParAsFunOfPhi[i] << " ";
+  cout << endl;
 #endif
 
-  Grid1D gridX( 0, n1-1, n1); // offset and step size not constant
-  Grid1D gridY( yref, yref + stepy*(n2-1), n2);
-  Grid1D gridZ( grefp.z(), grefp.z() + stepz*(n3-1), n3);
+  Grid1D gridX(0, n1 - 1, n1);  // offset and step size not constant
+  Grid1D gridY(yref, yref + stepy * (n2 - 1), n2);
+  Grid1D gridZ(grefp.z(), grefp.z() + stepz * (n3 - 1), n3);
 
-  grid_ = GridType( gridX, gridY, gridZ, fieldValues);
+  grid_ = GridType(gridX, gridY, gridZ, fieldValues);
 
-  stepConstTerm_ = (RParAsFunOfPhi[0] - RParAsFunOfPhi[2]) / (n1-1);
-  stepPhiTerm_   = (RParAsFunOfPhi[1] - RParAsFunOfPhi[3]) / (n1-1);
+  stepConstTerm_ = (RParAsFunOfPhi[0] - RParAsFunOfPhi[2]) / (n1 - 1);
+  stepPhiTerm_ = (RParAsFunOfPhi[1] - RParAsFunOfPhi[3]) / (n1 - 1);
   startConstTerm_ = RParAsFunOfPhi[2];
-  startPhiTerm_   = RParAsFunOfPhi[3];
+  startPhiTerm_ = RParAsFunOfPhi[3];
 
   // Activate/deactivate timers
-//   static SimpleConfigurable<bool> timerOn(false,"MFGrid:timing");
-//   (*TimingReport::current()).switchOn("MagneticFieldProvider::valueInTesla(SpecialCylindricalMFGrid)",timerOn);
+  //   static SimpleConfigurable<bool> timerOn(false,"MFGrid:timing");
+  //   (*TimingReport::current()).switchOn("MagneticFieldProvider::valueInTesla(SpecialCylindricalMFGrid)",timerOn);
 }
- 
 
-MFGrid::LocalVector SpecialCylindricalMFGrid::uncheckedValueInTesla( const LocalPoint& p) const
-{
-//   static TimingReport::Item & timer= (*TimingReport::current())["MagneticFieldProvider::valueInTesla(SpecialCylindricalMFGrid)"];
-//   TimeMe t(timer,false);
+MFGrid::LocalVector SpecialCylindricalMFGrid::uncheckedValueInTesla(const LocalPoint& p) const {
+  //   static TimingReport::Item & timer= (*TimingReport::current())["MagneticFieldProvider::valueInTesla(SpecialCylindricalMFGrid)"];
+  //   TimeMe t(timer,false);
 
-  LinearGridInterpolator3D interpol( grid_);
+  LinearGridInterpolator3D interpol(grid_);
   double a, b, c;
-  toGridFrame( p, a, b, c);
+  toGridFrame(p, a, b, c);
   // the following holds if B values was not converted to local coords -- see ctor
-//   GlobalVector gv( interpol.interpolate( a, b, c)); // grid in global frame
-//   return frame().toLocal(gv);           // must return a local vector
-  return LocalVector(interpol.interpolate( a, b, c));
+  //   GlobalVector gv( interpol.interpolate( a, b, c)); // grid in global frame
+  //   return frame().toLocal(gv);           // must return a local vector
+  return LocalVector(interpol.interpolate(a, b, c));
 }
 
 void SpecialCylindricalMFGrid::dump() const {}
 
-
-MFGrid::LocalPoint SpecialCylindricalMFGrid::fromGridFrame( double a, double b, double c) const
-{
-  double sinPhi; // sin or cos depending on wether we are at phi=0 or phi=pi/2
+MFGrid::LocalPoint SpecialCylindricalMFGrid::fromGridFrame(double a, double b, double c) const {
+  double sinPhi;  // sin or cos depending on wether we are at phi=0 or phi=pi/2
   if (sector1) {
     sinPhi = cos(b);
   } else {
     sinPhi = sin(b);
   }
-  
-  double R = a*stepSize(sinPhi) + startingPoint(sinPhi);
+
+  double R = a * stepSize(sinPhi) + startingPoint(sinPhi);
   // "OLD" convention of phi.
   //  GlobalPoint gp( GlobalPoint::Cylindrical(R, Geom::pi() - b, c));
-  GlobalPoint gp( GlobalPoint::Cylindrical(R, b, c));
+  GlobalPoint gp(GlobalPoint::Cylindrical(R, b, c));
   return frame().toLocal(gp);
 }
 
-void SpecialCylindricalMFGrid::toGridFrame( const LocalPoint& p, 
-					    double& a, double& b, double& c) const
-{
+void SpecialCylindricalMFGrid::toGridFrame(const LocalPoint& p, double& a, double& b, double& c) const {
   GlobalPoint gp = frame().toGlobal(p);
-  double sinPhi; // sin or cos depending on wether we are at phi=0 or phi=pi/2
+  double sinPhi;  // sin or cos depending on wether we are at phi=0 or phi=pi/2
   if (sector1) {
     sinPhi = cos(gp.phi());
   } else {
     sinPhi = sin(gp.phi());
   }
-  a = (gp.perp()-startingPoint(sinPhi))/stepSize(sinPhi);
+  a = (gp.perp() - startingPoint(sinPhi)) / stepSize(sinPhi);
   // FIXME: "OLD" convention of phi.
   // b = Geom::pi() - gp.phi();
   b = gp.phi();
@@ -135,14 +130,12 @@ void SpecialCylindricalMFGrid::toGridFrame( const LocalPoint& p,
 
 #ifdef DEBUG_GRID
   if (sector1) {
-    cout << "toGridFrame: sinPhi " ;
+    cout << "toGridFrame: sinPhi ";
   } else {
-    cout << "toGridFrame: cosPhi " ;
+    cout << "toGridFrame: cosPhi ";
   }
-  cout << sinPhi << " LocalPoint " << p 
-       << " GlobalPoint " << gp << endl 
+  cout << sinPhi << " LocalPoint " << p << " GlobalPoint " << gp << endl
        << " a " << a << " b " << b << " c " << c << endl;
-    
+
 #endif
 }
-

--- a/MagneticField/Interpolation/src/SpecialCylindricalMFGrid.h
+++ b/MagneticField/Interpolation/src/SpecialCylindricalMFGrid.h
@@ -8,7 +8,6 @@
  *  \author T. Todorov - updated 08 N. Amapane
  */
 
-
 #include "FWCore/Utilities/interface/Visibility.h"
 #include "MFGrid3D.h"
 
@@ -16,24 +15,20 @@ class binary_ifstream;
 
 class dso_internal SpecialCylindricalMFGrid : public MFGrid3D {
 public:
+  /// Constructor.
+  /// gridType = 5 => 1/sin(phi); i.e. master sector is #4
+  /// gridType = 6 => 1/cos(phi); i.e. master sector is #1
+  SpecialCylindricalMFGrid(binary_ifstream& istr, const GloballyPositioned<float>& vol, int gridType);
 
-  /// Constructor. 
-  /// gridType = 5 => 1/sin(phi); i.e. master sector is #4 
-  /// gridType = 6 => 1/cos(phi); i.e. master sector is #1 
-  SpecialCylindricalMFGrid( binary_ifstream& istr, 
-			    const GloballyPositioned<float>& vol,
-			    int gridType);
-
-  LocalVector uncheckedValueInTesla( const LocalPoint& p) const override;
+  LocalVector uncheckedValueInTesla(const LocalPoint& p) const override;
 
   void dump() const override;
 
-  void toGridFrame( const LocalPoint& p, double& a, double& b, double& c) const override;
+  void toGridFrame(const LocalPoint& p, double& a, double& b, double& c) const override;
 
-  LocalPoint fromGridFrame( double a, double b, double c) const override;
+  LocalPoint fromGridFrame(double a, double b, double c) const override;
 
 private:
-
   //double RParAsFunOfPhi[4];     // R = f(phi) or const. (0,2: const. par. ; 1,3: const./sin(phi))
 
   double stepConstTerm_;
@@ -41,8 +36,8 @@ private:
   double startConstTerm_;
   double startPhiTerm_;
 
-  double stepSize( double sinPhi) const {return stepConstTerm_ + stepPhiTerm_ /sinPhi;}
-  double startingPoint( double sinPhi) const {return startConstTerm_ + startPhiTerm_/sinPhi;}
+  double stepSize(double sinPhi) const { return stepConstTerm_ + stepPhiTerm_ / sinPhi; }
+  double startingPoint(double sinPhi) const { return startConstTerm_ + startPhiTerm_ / sinPhi; }
   bool sector1;
 };
 

--- a/MagneticField/Interpolation/src/Trapezoid2RectangleMappingX.h
+++ b/MagneticField/Interpolation/src/Trapezoid2RectangleMappingX.h
@@ -10,7 +10,6 @@
  *  \author T. Todorov
  */
 
-
 //#define DEBUG_GRID_TRM
 
 #ifdef DEBUG_GRID_TRM
@@ -21,47 +20,42 @@
 
 class dso_internal Trapezoid2RectangleMappingX {
 public:
-
   Trapezoid2RectangleMappingX() {}
 
   /// normal trapezoid case, a != b
-  Trapezoid2RectangleMappingX( double x0, double y0, double bovera, double h) :
-    x0_(x0), y0_(y0), parallel_(false)
-  {
-    k_ = 2/h * (bovera-1.) / (bovera+1.);
+  Trapezoid2RectangleMappingX(double x0, double y0, double bovera, double h) : x0_(x0), y0_(y0), parallel_(false) {
+    k_ = 2 / h * (bovera - 1.) / (bovera + 1.);
 
 #ifdef DEBUG_GRID_TRM
-    std::cout << "Trapezoid2RectangleMappingX constructed with x0,y0 " << x0 << " " << y0 
- 	 << " b/a= " << bovera << " h= " << h << std::endl;
+    std::cout << "Trapezoid2RectangleMappingX constructed with x0,y0 " << x0 << " " << y0 << " b/a= " << bovera
+              << " h= " << h << std::endl;
 #endif
   }
 
   /// special parallelogram case, a == b. The meaning of k changes.
-  Trapezoid2RectangleMappingX( double x0, double y0, double k) :
-    x0_(x0), y0_(y0), k_(k), parallel_(true)
-  {
+  Trapezoid2RectangleMappingX(double x0, double y0, double k) : x0_(x0), y0_(y0), k_(k), parallel_(true) {
 #ifdef DEBUG_GRID_TRM
-    std::cout << "Trapezoid2RectangleMappingX constructed with x0,y0 " << x0 << " " << y0 
- 	 << " k= " << k << std::endl;
+    std::cout << "Trapezoid2RectangleMappingX constructed with x0,y0 " << x0 << " " << y0 << " k= " << k << std::endl;
 #endif
   }
 
-  void rectangle( double xtrap, double ytrap, 
-		  double& xrec, double& yrec) const {
-
+  void rectangle(double xtrap, double ytrap, double& xrec, double& yrec) const {
     yrec = ytrap - y0_;
-    if (!parallel_) xrec = (xtrap - x0_) / (1.+ yrec*k_);
-    else            xrec = xtrap - x0_ + k_*yrec;
+    if (!parallel_)
+      xrec = (xtrap - x0_) / (1. + yrec * k_);
+    else
+      xrec = xtrap - x0_ + k_ * yrec;
 
 #ifdef DEBUG_GRID
     std::cout << xtrap << " " << ytrap << " transformed to rectangle " << xrec << " " << yrec << std::endl;
 #endif
   }
 
-  void trapezoid( double xrec, double yrec, 
-		  double& xtrap, double& ytrap) const {
-    if (!parallel_) xtrap = x0_ + xrec * (1.+ yrec*k_);
-    else            xtrap = x0_ + xrec - k_*yrec;
+  void trapezoid(double xrec, double yrec, double& xtrap, double& ytrap) const {
+    if (!parallel_)
+      xtrap = x0_ + xrec * (1. + yrec * k_);
+    else
+      xtrap = x0_ + xrec - k_ * yrec;
     ytrap = y0_ + yrec;
 
 #ifdef DEBUG_GRID

--- a/MagneticField/Interpolation/src/TrapezoidalCartesianMFGrid.cc
+++ b/MagneticField/Interpolation/src/TrapezoidalCartesianMFGrid.cc
@@ -13,33 +13,28 @@
 
 using namespace std;
 
-TrapezoidalCartesianMFGrid::TrapezoidalCartesianMFGrid( binary_ifstream& inFile,
-							const GloballyPositioned<float>& vol)
-  : MFGrid3D(vol), increasingAlongX(false), convertToLocal(true)
-{
-  
+TrapezoidalCartesianMFGrid::TrapezoidalCartesianMFGrid(binary_ifstream& inFile, const GloballyPositioned<float>& vol)
+    : MFGrid3D(vol), increasingAlongX(false), convertToLocal(true) {
   // The parameters read from the data files are given in global coordinates.
   // In version 85l, local frame has the same orientation of global frame for the reference
   // volume, i.e. the r.f. transformation is only a translation.
   // There is therefore no need to convert the field values to local coordinates.
 
-  // Check orientation of local reference frame: 
-  GlobalVector localXDir(frame().toGlobal(LocalVector(1,0,0)));
-  GlobalVector localYDir(frame().toGlobal(LocalVector(0,1,0)));
+  // Check orientation of local reference frame:
+  GlobalVector localXDir(frame().toGlobal(LocalVector(1, 0, 0)));
+  GlobalVector localYDir(frame().toGlobal(LocalVector(0, 1, 0)));
 
-  if (localXDir.dot(GlobalVector(1,0,0)) > 0.999999 &&
-      localYDir.dot(GlobalVector(0,1,0)) > 0.999999) {
+  if (localXDir.dot(GlobalVector(1, 0, 0)) > 0.999999 && localYDir.dot(GlobalVector(0, 1, 0)) > 0.999999) {
     // "null" rotation - requires no conversion...
     convertToLocal = false;
-  } else if (localXDir.dot(GlobalVector(0,1,0)) > 0.999999 &&
-	     localYDir.dot(GlobalVector(1,0,0)) > 0.999999) {
-    // Typical orientation if master volume is in sector 1 
-    convertToLocal = true;    
+  } else if (localXDir.dot(GlobalVector(0, 1, 0)) > 0.999999 && localYDir.dot(GlobalVector(1, 0, 0)) > 0.999999) {
+    // Typical orientation if master volume is in sector 1
+    convertToLocal = true;
   } else {
-    convertToLocal = true;    
+    convertToLocal = true;
     // Nothing wrong in principle, but this is not expected
-    cout << "WARNING: TrapezoidalCartesianMFGrid: unexpected orientation: x: " 
-	 << localXDir << " y: " << localYDir << endl;
+    cout << "WARNING: TrapezoidalCartesianMFGrid: unexpected orientation: x: " << localXDir << " y: " << localYDir
+         << endl;
   }
 
   int n1, n2, n3;
@@ -47,11 +42,11 @@ TrapezoidalCartesianMFGrid::TrapezoidalCartesianMFGrid( binary_ifstream& inFile,
   double xref, yref, zref;
   inFile >> xref >> yref >> zref;
   double step1, step2, step3;
-  inFile >> step1    >> step2    >> step3;
+  inFile >> step1 >> step2 >> step3;
 
   double BasicDistance1[3][3];  // linear step
   double BasicDistance2[3][3];  // linear offset
-  bool   easya, easyb, easyc;
+  bool easya, easyb, easyc;
 
   inFile >> BasicDistance1[0][0] >> BasicDistance1[1][0] >> BasicDistance1[2][0];
   inFile >> BasicDistance1[0][1] >> BasicDistance1[1][1] >> BasicDistance1[2][1];
@@ -63,17 +58,17 @@ TrapezoidalCartesianMFGrid::TrapezoidalCartesianMFGrid( binary_ifstream& inFile,
 
   vector<BVector> fieldValues;
   float Bx, By, Bz;
-  int nLines = n1*n2*n3;
+  int nLines = n1 * n2 * n3;
   fieldValues.reserve(nLines);
-  for (int iLine=0; iLine<nLines; ++iLine){
+  for (int iLine = 0; iLine < nLines; ++iLine) {
     inFile >> Bx >> By >> Bz;
     if (convertToLocal) {
       // Preserve double precision!
-      Vector3DBase<double, LocalTag>  lB = frame().toLocal(Vector3DBase<double, GlobalTag>(Bx,By,Bz));
+      Vector3DBase<double, LocalTag> lB = frame().toLocal(Vector3DBase<double, GlobalTag>(Bx, By, Bz));
       fieldValues.push_back(BVector(lB.x(), lB.y(), lB.z()));
-      
+
     } else {
-      fieldValues.push_back(BVector(Bx,By,Bz));
+      fieldValues.push_back(BVector(Bx, By, Bz));
     }
   }
   // check completeness
@@ -96,7 +91,7 @@ TrapezoidalCartesianMFGrid::TrapezoidalCartesianMFGrid( binary_ifstream& inFile,
     increasingAlongX = true;
     nx = n1;
     ny = n2;
-    stepx = step1; 
+    stepx = step1;
     stepy = step2;
     stepz = step3;
     dstep = BasicDistance1[0][1];
@@ -106,29 +101,29 @@ TrapezoidalCartesianMFGrid::TrapezoidalCartesianMFGrid( binary_ifstream& inFile,
     increasingAlongX = false;
     nx = n2;
     ny = n1;
-    stepx = step2; 
+    stepx = step2;
     stepy = step1;
     stepz = -step3;
     dstep = BasicDistance1[1][0];
     offset = BasicDistance2[1][0];
 
-   } else {
+  } else {
     // Increasing spacing on z or on > 1 coordinate not supported
     throw MagGeometryError("TrapezoidalCartesianMFGrid only implemented for first or second coordinate");
   }
 
-  double a = stepx * (nx -1);             // first base
-  double b = a + dstep * (ny-1) * (nx-1); // second base
-  double h = stepy * (ny-1);              // height
-  double delta = -offset * (ny-1);        // offset between two bases
-  double baMinus1 = dstep*(ny-1) / stepx; // (b*a) - 1
+  double a = stepx * (nx - 1);                 // first base
+  double b = a + dstep * (ny - 1) * (nx - 1);  // second base
+  double h = stepy * (ny - 1);                 // height
+  double delta = -offset * (ny - 1);           // offset between two bases
+  double baMinus1 = dstep * (ny - 1) / stepx;  // (b*a) - 1
 
-  GlobalPoint grefp( xref, yref, zref);
-  LocalPoint lrefp = frame().toLocal( grefp);
+  GlobalPoint grefp(xref, yref, zref);
+  LocalPoint lrefp = frame().toLocal(grefp);
 
   if (fabs(baMinus1) > 0.000001) {
     double b_over_a = 1 + baMinus1;
-    double a1 = delta/baMinus1;
+    double a1 = delta / baMinus1;
 
 #ifdef DEBUG_GRID
     cout << "Trapeze size (a,b,h) = " << a << "," << b << "," << h << endl;
@@ -137,136 +132,122 @@ TrapezoidalCartesianMFGrid::TrapezoidalCartesianMFGrid( binary_ifstream& inFile,
     cout << "a1 = " << a1 << endl;
 #endif
 
-    // FIXME ASSUMPTION: here we assume that the local reference frame is oriented with X along 
+    // FIXME ASSUMPTION: here we assume that the local reference frame is oriented with X along
     // the direction of where the grid is not uniform. This is the case for all current geometries
     double x0 = lrefp.x() + a1;
-    double y0 = lrefp.y() + h/2.;
-    mapping_ = Trapezoid2RectangleMappingX( x0, y0, b_over_a, h);
-  }
-  else { // parallelogram
-    mapping_ = Trapezoid2RectangleMappingX( 0, 0, delta/h);
+    double y0 = lrefp.y() + h / 2.;
+    mapping_ = Trapezoid2RectangleMappingX(x0, y0, b_over_a, h);
+  } else {  // parallelogram
+    mapping_ = Trapezoid2RectangleMappingX(0, 0, delta / h);
   }
 
   // transform reference point to grid frame
   double xrec, yrec;
-  mapping_.rectangle( lrefp.x(), lrefp.y(), xrec, yrec);
+  mapping_.rectangle(lrefp.x(), lrefp.y(), xrec, yrec);
 
-  Grid1D gridX( xrec, xrec + (a+b)/2., nx);
-  Grid1D gridY( yrec, yrec + h, ny);
-  Grid1D gridZ( lrefp.z(), lrefp.z() + stepz*(n3-1), n3);  
+  Grid1D gridX(xrec, xrec + (a + b) / 2., nx);
+  Grid1D gridY(yrec, yrec + h, ny);
+  Grid1D gridZ(lrefp.z(), lrefp.z() + stepz * (n3 - 1), n3);
 
 #ifdef DEBUG_GRID
-  cout << " GRID X range: local " << gridX.lower() <<  " - " << gridX.upper()
-       <<" global: " << (frame().toGlobal(LocalPoint(gridX.lower(),0,0))).y() << " - " 
-       << (frame().toGlobal(LocalPoint(gridX.upper(),0,0))).y() << endl;
+  cout << " GRID X range: local " << gridX.lower() << " - " << gridX.upper()
+       << " global: " << (frame().toGlobal(LocalPoint(gridX.lower(), 0, 0))).y() << " - "
+       << (frame().toGlobal(LocalPoint(gridX.upper(), 0, 0))).y() << endl;
 
-  cout << " GRID Y range: local " << gridY.lower() <<  " - " << gridY.upper()
-       << " global: " << (frame().toGlobal(LocalPoint(0,gridY.lower(),0))).x() << " - " 
-       << (frame().toGlobal(LocalPoint(0,gridY.upper(),0))).x() << endl;
+  cout << " GRID Y range: local " << gridY.lower() << " - " << gridY.upper()
+       << " global: " << (frame().toGlobal(LocalPoint(0, gridY.lower(), 0))).x() << " - "
+       << (frame().toGlobal(LocalPoint(0, gridY.upper(), 0))).x() << endl;
 
-  cout << " GRID Z range: local " << gridZ.lower() <<  " - " << gridZ.upper()
-       << " global: " << (frame().toGlobal(LocalPoint(0,0,gridZ.lower()))).z() << " " 
-       << (frame().toGlobal(LocalPoint(0,0,gridZ.upper()))).z() << endl;
+  cout << " GRID Z range: local " << gridZ.lower() << " - " << gridZ.upper()
+       << " global: " << (frame().toGlobal(LocalPoint(0, 0, gridZ.lower()))).z() << " "
+       << (frame().toGlobal(LocalPoint(0, 0, gridZ.upper()))).z() << endl;
 #endif
 
   if (increasingAlongX) {
-    grid_ = GridType( gridX, gridY, gridZ, fieldValues);
+    grid_ = GridType(gridX, gridY, gridZ, fieldValues);
   } else {
     // The reason why gridY and gridX have to be exchanged is because Grid3D::index(i,j,k)
     // assumes a specific order for the fieldValues, and we cannot rearrange this vector.
     // Given that we exchange grids, we will have to exchange the outpouts of mapping_rectangle()
     // and the inputs of mapping_.trapezoid() in the following...
-    grid_ = GridType( gridY, gridX, gridZ, fieldValues);
+    grid_ = GridType(gridY, gridX, gridZ, fieldValues);
   }
-    
-  
+
 #ifdef DEBUG_GRID
   dump();
 #endif
 }
 
-void TrapezoidalCartesianMFGrid::dump() const
-{
-  
+void TrapezoidalCartesianMFGrid::dump() const {
   cout << endl << "Dump of TrapezoidalCartesianMFGrid" << endl;
-//   cout << "Number of points from file   " 
-//        << n1 << " " << n2 << " " << n3 << endl;
-  cout << "Number of points from Grid1D " 
-       << grid_.grida().nodes() << " " << grid_.gridb().nodes() << " " << grid_.gridc().nodes() << endl;
+  //   cout << "Number of points from file   "
+  //        << n1 << " " << n2 << " " << n3 << endl;
+  cout << "Number of points from Grid1D " << grid_.grida().nodes() << " " << grid_.gridb().nodes() << " "
+       << grid_.gridc().nodes() << endl;
 
-//   cout << "Reference Point from file   " 
-//        << xref << " " << yref << " " << zref << endl;
-  cout << "Reference Point from Grid1D " 
-       << grid_.grida().lower() << " " << grid_.gridb().lower() << " " << grid_.gridc().lower() << endl;
+  //   cout << "Reference Point from file   "
+  //        << xref << " " << yref << " " << zref << endl;
+  cout << "Reference Point from Grid1D " << grid_.grida().lower() << " " << grid_.gridb().lower() << " "
+       << grid_.gridc().lower() << endl;
 
-//   cout << "Basic Distance from file   " 
-//        <<  stepx << " " << stepy << " " << stepz << endl;
-  cout << "Basic Distance from Grid1D "
-       << grid_.grida().step() << " " << grid_.gridb().step() << " " << grid_.gridc().step() << endl;
-
+  //   cout << "Basic Distance from file   "
+  //        <<  stepx << " " << stepy << " " << stepz << endl;
+  cout << "Basic Distance from Grid1D " << grid_.grida().step() << " " << grid_.gridb().step() << " "
+       << grid_.gridc().step() << endl;
 
   cout << "Dumping " << grid_.data().size() << " field values " << endl;
   // grid_.dump();
-  
 
   // Dump ALL grid points and values
   // CAVEAT: if convertToLocal = true in the ctor, points have been converted to LOCAL
   // coordinates. To match those from .table files they have to be converted back to global
-//   for (int j=0; j < grid_.gridb().nodes(); j++) {
-//     for (int i=0; i < grid_.grida().nodes(); i++) {
-//       for (int k=0; k < grid_.gridc().nodes(); k++) {
-// 	cout << i << " " << j << " " << k << " "  
-// 	     << frame().toGlobal(LocalPoint(nodePosition(i,j,k))) << " "
-// 	     << nodeValue(i,j,k) << endl;
-//       }
-//     }
-//   }
-  
-
+  //   for (int j=0; j < grid_.gridb().nodes(); j++) {
+  //     for (int i=0; i < grid_.grida().nodes(); i++) {
+  //       for (int k=0; k < grid_.gridc().nodes(); k++) {
+  // 	cout << i << " " << j << " " << k << " "
+  // 	     << frame().toGlobal(LocalPoint(nodePosition(i,j,k))) << " "
+  // 	     << nodeValue(i,j,k) << endl;
+  //       }
+  //     }
+  //   }
 }
 
-MFGrid::LocalVector TrapezoidalCartesianMFGrid::uncheckedValueInTesla( const LocalPoint& p) const
-{
-
+MFGrid::LocalVector TrapezoidalCartesianMFGrid::uncheckedValueInTesla(const LocalPoint& p) const {
   double xrec, yrec;
-  mapping_.rectangle( p.x(), p.y(), xrec, yrec);
-  
+  mapping_.rectangle(p.x(), p.y(), xrec, yrec);
 
-// cout << "TrapezoidalCartesianMFGrid::valueInTesla at local point " << p << endl;
-//   cout << p.x() << " " << p.y()  
-//        << " transformed to grid frame: " << xrec << " " << yrec << endl;
+  // cout << "TrapezoidalCartesianMFGrid::valueInTesla at local point " << p << endl;
+  //   cout << p.x() << " " << p.y()
+  //        << " transformed to grid frame: " << xrec << " " << yrec << endl;
 
-  LinearGridInterpolator3D interpol( grid_);
+  LinearGridInterpolator3D interpol(grid_);
 
   if (!increasingAlongX) {
-    std::swap(xrec,yrec);
+    std::swap(xrec, yrec);
     // B values are already converted to local coord!!! otherwise we should:
     // GridType::ValueType value = interpol.interpolate( xrec, yrec, p.z());
     // return LocalVector(value.y(),value.x(),-value.z());
   }
 
-  return LocalVector(interpol.interpolate( xrec, yrec, p.z()));
+  return LocalVector(interpol.interpolate(xrec, yrec, p.z()));
 }
 
-void TrapezoidalCartesianMFGrid::toGridFrame( const LocalPoint& p, 
-					      double& a, double& b, double& c) const
-{
+void TrapezoidalCartesianMFGrid::toGridFrame(const LocalPoint& p, double& a, double& b, double& c) const {
   if (increasingAlongX) {
-    mapping_.rectangle( p.x(), p.y(), a, b);
+    mapping_.rectangle(p.x(), p.y(), a, b);
   } else {
-    mapping_.rectangle( p.x(), p.y(), b, a);
-  }  
-  
+    mapping_.rectangle(p.x(), p.y(), b, a);
+  }
+
   c = p.z();
 }
- 
-MFGrid::LocalPoint TrapezoidalCartesianMFGrid::fromGridFrame( double a, double b, double c) const
-{
+
+MFGrid::LocalPoint TrapezoidalCartesianMFGrid::fromGridFrame(double a, double b, double c) const {
   double xtrap, ytrap;
   if (increasingAlongX) {
-    mapping_.trapezoid( a, b, xtrap, ytrap);
-  } else {    
-    mapping_.trapezoid( b, a, xtrap, ytrap);
+    mapping_.trapezoid(a, b, xtrap, ytrap);
+  } else {
+    mapping_.trapezoid(b, a, xtrap, ytrap);
   }
-  return LocalPoint( xtrap, ytrap, c);
+  return LocalPoint(xtrap, ytrap, c);
 }

--- a/MagneticField/Interpolation/src/TrapezoidalCartesianMFGrid.h
+++ b/MagneticField/Interpolation/src/TrapezoidalCartesianMFGrid.h
@@ -18,24 +18,20 @@ class binary_ifstream;
 
 class dso_internal TrapezoidalCartesianMFGrid : public MFGrid3D {
 public:
+  TrapezoidalCartesianMFGrid(binary_ifstream& istr, const GloballyPositioned<float>& vol);
 
-  TrapezoidalCartesianMFGrid( binary_ifstream& istr, 
-			      const GloballyPositioned<float>& vol);
-
-  LocalVector uncheckedValueInTesla( const LocalPoint& p) const override;
+  LocalVector uncheckedValueInTesla(const LocalPoint& p) const override;
 
   void dump() const override;
 
-  void toGridFrame( const LocalPoint& p, double& a, double& b, double& c) const override;
+  void toGridFrame(const LocalPoint& p, double& a, double& b, double& c) const override;
 
-  LocalPoint fromGridFrame( double a, double b, double c) const override;
+  LocalPoint fromGridFrame(double a, double b, double c) const override;
 
 private:
-
   Trapezoid2RectangleMappingX mapping_;
   bool increasingAlongX;
   bool convertToLocal;
-  
 };
 
 #endif

--- a/MagneticField/Interpolation/src/TrapezoidalCylindricalMFGrid.cc
+++ b/MagneticField/Interpolation/src/TrapezoidalCylindricalMFGrid.cc
@@ -7,24 +7,22 @@
 
 using namespace std;
 
-TrapezoidalCylindricalMFGrid::TrapezoidalCylindricalMFGrid( binary_ifstream& inFile,
-							const GloballyPositioned<float>& vol)
-  : MFGrid3D(vol)
-{
+TrapezoidalCylindricalMFGrid::TrapezoidalCylindricalMFGrid(binary_ifstream& inFile,
+                                                           const GloballyPositioned<float>& vol)
+    : MFGrid3D(vol) {
   // The parameters read from the data files are given in global coordinates.
   // In version 85l, local frame has the same orientation of global frame for the reference
   // volume, i.e. the r.f. transformation is only a translation.
   // There is therefore no need to convert the field values to local coordinates.
-  // Check this assumption: 
-  GlobalVector localXDir(frame().toGlobal(LocalVector(1,0,0)));
-  GlobalVector localYDir(frame().toGlobal(LocalVector(0,1,0)));
+  // Check this assumption:
+  GlobalVector localXDir(frame().toGlobal(LocalVector(1, 0, 0)));
+  GlobalVector localYDir(frame().toGlobal(LocalVector(0, 1, 0)));
 
-  if (localXDir.dot(GlobalVector(1,0,0)) > 0.999999 &&
-      localYDir.dot(GlobalVector(0,1,0)) > 0.999999) {
+  if (localXDir.dot(GlobalVector(1, 0, 0)) > 0.999999 && localYDir.dot(GlobalVector(0, 1, 0)) > 0.999999) {
     // "null" rotation - requires no conversion...
   } else {
-    cout << "ERROR: TrapezoidalCylindricalMFGrid: unexpected orientation: x: " 
-	 << localXDir << " y: " << localYDir << endl;
+    cout << "ERROR: TrapezoidalCylindricalMFGrid: unexpected orientation: x: " << localXDir << " y: " << localYDir
+         << endl;
   }
 
   int n1, n2, n3;
@@ -32,11 +30,11 @@ TrapezoidalCylindricalMFGrid::TrapezoidalCylindricalMFGrid( binary_ifstream& inF
   double xref, yref, zref;
   inFile >> xref >> yref >> zref;
   double stepx, stepy, stepz;
-  inFile >> stepx    >> stepy    >> stepz;
+  inFile >> stepx >> stepy >> stepz;
 
   double BasicDistance1[3][3];  // linear step
   double BasicDistance2[3][3];  // linear offset
-  bool   easya, easyb, easyc;
+  bool easya, easyb, easyc;
 
   inFile >> BasicDistance1[0][0] >> BasicDistance1[1][0] >> BasicDistance1[2][0];
   inFile >> BasicDistance1[0][1] >> BasicDistance1[1][1] >> BasicDistance1[2][1];
@@ -48,11 +46,11 @@ TrapezoidalCylindricalMFGrid::TrapezoidalCylindricalMFGrid( binary_ifstream& inF
 
   vector<BVector> fieldValues;
   float Bx, By, Bz;
-  int nLines = n1*n2*n3;
+  int nLines = n1 * n2 * n3;
   fieldValues.reserve(nLines);
-  for (int iLine=0; iLine<nLines; ++iLine){
+  for (int iLine = 0; iLine < nLines; ++iLine) {
     inFile >> Bx >> By >> Bz;
-    fieldValues.push_back(BVector(Bx,By,Bz));
+    fieldValues.push_back(BVector(Bx, By, Bz));
   }
   // check completeness
   string lastEntry;
@@ -71,93 +69,86 @@ TrapezoidalCylindricalMFGrid::TrapezoidalCylindricalMFGrid( binary_ifstream& inF
 
 #ifdef DEBUG_GRID
   cout << "Grid reference point in grid system: " << xref << "," << yref << "," << zref << endl;
-  cout << "steps " << stepx << "," <<  stepy << "," << stepz << endl;
-  cout << "ns " << n1 << "," <<  n2 << "," << n3 << endl;
+  cout << "steps " << stepx << "," << stepy << "," << stepz << endl;
+  cout << "ns " << n1 << "," << n2 << "," << n3 << endl;
 
-  for (int i=0; i<3; ++i) for (int j=0; j<3; ++j) {
-    cout << "BasicDistance1[" << i << "][" << j << "] = " << BasicDistance1[i][j]
-	 << "BasicDistance2[" << i << "][" << j << "] = " << BasicDistance2[i][j] << endl;
-  }
+  for (int i = 0; i < 3; ++i)
+    for (int j = 0; j < 3; ++j) {
+      cout << "BasicDistance1[" << i << "][" << j << "] = " << BasicDistance1[i][j] << "BasicDistance2[" << i << "]["
+           << j << "] = " << BasicDistance2[i][j] << endl;
+    }
 #endif
 
   // the "not easy" coordinate is x
-  double a = stepx * (n1 -1);
-  double b = a + BasicDistance1[0][1] * (n2-1)*(n1-1) + BasicDistance1[0][2] * (n3-1)*(n1-1);
+  double a = stepx * (n1 - 1);
+  double b = a + BasicDistance1[0][1] * (n2 - 1) * (n1 - 1) + BasicDistance1[0][2] * (n3 - 1) * (n1 - 1);
   //  double h = stepy * (n2-1);
-  double h = stepz * (n3-1);
-  double delta = -BasicDistance2[0][1] * (n2-1) -BasicDistance2[0][2] * (n3-1);
+  double h = stepz * (n3 - 1);
+  double delta = -BasicDistance2[0][1] * (n2 - 1) - BasicDistance2[0][2] * (n3 - 1);
 
 #ifdef DEBUG_GRID
   cout << "Trapeze size (a,b,h) = " << a << "," << b << "," << h << endl;
 #endif
 
-  GlobalPoint grefp( GlobalPoint::Cylindrical( xref, Geom::pi() - yref, zref));
-  LocalPoint lrefp = frame().toLocal( grefp);
+  GlobalPoint grefp(GlobalPoint::Cylindrical(xref, Geom::pi() - yref, zref));
+  LocalPoint lrefp = frame().toLocal(grefp);
 
 #ifdef DEBUG_GRID
   cout << "Global origin " << grefp << endl;
   cout << "Local origin  " << lrefp << endl;
 #endif
 
-  double baMinus1 = BasicDistance1[0][2]*(n3-1) / stepx;
+  double baMinus1 = BasicDistance1[0][2] * (n3 - 1) / stepx;
   if (std::abs(baMinus1) > 0.000001) {
     double b_over_a = 1 + baMinus1;
-    double a1 = std::abs(baMinus1) > 0.000001 ? delta / baMinus1 : a/2;
+    double a1 = std::abs(baMinus1) > 0.000001 ? delta / baMinus1 : a / 2;
 #ifdef DEBUG_GRID
-   cout << "a1 = " << a1 << endl;
+    cout << "a1 = " << a1 << endl;
 #endif
 
     // transform reference point to grid frame
     double x0 = lrefp.perp() + a1;
-    double y0 = lrefp.z() + h/2.;
-    mapping_ = Trapezoid2RectangleMappingX( x0, y0, b_over_a, h);
-  }
-  else { // parallelogram
-    mapping_ = Trapezoid2RectangleMappingX( 0, 0, delta/h);
+    double y0 = lrefp.z() + h / 2.;
+    mapping_ = Trapezoid2RectangleMappingX(x0, y0, b_over_a, h);
+  } else {  // parallelogram
+    mapping_ = Trapezoid2RectangleMappingX(0, 0, delta / h);
   }
   double xrec, yrec;
-  mapping_.rectangle( lrefp.perp(), lrefp.z(), xrec, yrec);
+  mapping_.rectangle(lrefp.perp(), lrefp.z(), xrec, yrec);
 
-  Grid1D gridX( xrec, xrec + (a+b)/2., n1);
-  Grid1D gridY( yref, yref + stepy*(n2-1), n2);
-  Grid1D gridZ( yrec, yrec + h, n3);
-  grid_ = GridType( gridX, gridY, gridZ, fieldValues);
-    
+  Grid1D gridX(xrec, xrec + (a + b) / 2., n1);
+  Grid1D gridY(yref, yref + stepy * (n2 - 1), n2);
+  Grid1D gridZ(yrec, yrec + h, n3);
+  grid_ = GridType(gridX, gridY, gridZ, fieldValues);
+
   // Activate/deactivate timers
-//   static SimpleConfigurable<bool> timerOn(false,"MFGrid:timing");
-//   (*TimingReport::current()).switchOn("MagneticFieldProvider::valueInTesla(TrapezoidalCylindricalMFGrid)",timerOn);
+  //   static SimpleConfigurable<bool> timerOn(false,"MFGrid:timing");
+  //   (*TimingReport::current()).switchOn("MagneticFieldProvider::valueInTesla(TrapezoidalCylindricalMFGrid)",timerOn);
 }
 
-void TrapezoidalCylindricalMFGrid::dump() const
-{}
+void TrapezoidalCylindricalMFGrid::dump() const {}
 
-MFGrid::LocalVector 
-TrapezoidalCylindricalMFGrid::uncheckedValueInTesla( const LocalPoint& p) const
-{
-//   static TimingReport::Item & timer= (*TimingReport::current())["MagneticFieldProvider::valueInTesla(TrapezoidalCylindricalMFGrid)"];
-//   TimeMe t(timer,false);
+MFGrid::LocalVector TrapezoidalCylindricalMFGrid::uncheckedValueInTesla(const LocalPoint& p) const {
+  //   static TimingReport::Item & timer= (*TimingReport::current())["MagneticFieldProvider::valueInTesla(TrapezoidalCylindricalMFGrid)"];
+  //   TimeMe t(timer,false);
 
-  LinearGridInterpolator3D interpol( grid_);
+  LinearGridInterpolator3D interpol(grid_);
   double a, b, c;
-  toGridFrame( p, a, b, c);
-  GlobalVector gv( interpol.interpolate( a, b, c)); // grid in global frame
-  return frame().toLocal(gv);           // must return a local vector
+  toGridFrame(p, a, b, c);
+  GlobalVector gv(interpol.interpolate(a, b, c));  // grid in global frame
+  return frame().toLocal(gv);                      // must return a local vector
 }
 
-void TrapezoidalCylindricalMFGrid::toGridFrame( const LocalPoint& p, 
-					      double& a, double& b, double& c) const
-{
-  mapping_.rectangle( p.perp(), p.z(), a, c);
+void TrapezoidalCylindricalMFGrid::toGridFrame(const LocalPoint& p, double& a, double& b, double& c) const {
+  mapping_.rectangle(p.perp(), p.z(), a, c);
   // FIXME: "OLD" convention of phi.
   //  b = Geom::pi() - p.phi();
   b = p.phi();
 }
 
-MFGrid::LocalPoint 
-TrapezoidalCylindricalMFGrid::fromGridFrame( double a, double b, double c) const
-{
+MFGrid::LocalPoint TrapezoidalCylindricalMFGrid::fromGridFrame(double a, double b, double c) const {
   double rtrap, ztrap;
-  mapping_.trapezoid( a, c, rtrap, ztrap);
+  mapping_.trapezoid(a, c, rtrap, ztrap);
   // FIXME: "OLD" convention of phi.
   //  return LocalPoint(LocalPoint::Cylindrical(rtrap, Geom::pi() - b, ztrap));
   return LocalPoint(LocalPoint::Cylindrical(rtrap, b, ztrap));

--- a/MagneticField/Interpolation/src/TrapezoidalCylindricalMFGrid.h
+++ b/MagneticField/Interpolation/src/TrapezoidalCylindricalMFGrid.h
@@ -5,27 +5,22 @@
 #include "Trapezoid2RectangleMappingX.h"
 #include "FWCore/Utilities/interface/Visibility.h"
 
-
 class binary_ifstream;
 
 class dso_internal TrapezoidalCylindricalMFGrid : public MFGrid3D {
 public:
+  TrapezoidalCylindricalMFGrid(binary_ifstream& istr, const GloballyPositioned<float>& vol);
 
-  TrapezoidalCylindricalMFGrid( binary_ifstream& istr, 
-				const GloballyPositioned<float>& vol);
-
-  LocalVector uncheckedValueInTesla( const LocalPoint& p) const override;
+  LocalVector uncheckedValueInTesla(const LocalPoint& p) const override;
 
   void dump() const override;
 
-  void toGridFrame( const LocalPoint& p, double& a, double& b, double& c) const override;
+  void toGridFrame(const LocalPoint& p, double& a, double& b, double& c) const override;
 
-  LocalPoint fromGridFrame( double a, double b, double c) const override;
+  LocalPoint fromGridFrame(double a, double b, double c) const override;
 
 private:
-
   Trapezoid2RectangleMappingX mapping_;
-
 };
 
 #endif

--- a/MagneticField/Interpolation/src/VectorFieldInterpolation.cc
+++ b/MagneticField/Interpolation/src/VectorFieldInterpolation.cc
@@ -1,8 +1,7 @@
 // include header for VectorFieldInterpolation
 #include "VectorFieldInterpolation.h"
 
-
-void VectorFieldInterpolation::defineCellPoint000(double X1, double X2, double X3, double F1, double F2, double F3){
+void VectorFieldInterpolation::defineCellPoint000(double X1, double X2, double X3, double F1, double F2, double F3) {
   CellPoint000[0] = X1;
   CellPoint000[1] = X2;
   CellPoint000[2] = X3;
@@ -12,8 +11,7 @@ void VectorFieldInterpolation::defineCellPoint000(double X1, double X2, double X
   return;
 }
 
-
-void VectorFieldInterpolation::defineCellPoint100(double X1, double X2, double X3, double F1, double F2, double F3){
+void VectorFieldInterpolation::defineCellPoint100(double X1, double X2, double X3, double F1, double F2, double F3) {
   CellPoint100[0] = X1;
   CellPoint100[1] = X2;
   CellPoint100[2] = X3;
@@ -23,8 +21,7 @@ void VectorFieldInterpolation::defineCellPoint100(double X1, double X2, double X
   return;
 }
 
-
-void VectorFieldInterpolation::defineCellPoint010(double X1, double X2, double X3, double F1, double F2, double F3){
+void VectorFieldInterpolation::defineCellPoint010(double X1, double X2, double X3, double F1, double F2, double F3) {
   CellPoint010[0] = X1;
   CellPoint010[1] = X2;
   CellPoint010[2] = X3;
@@ -34,8 +31,7 @@ void VectorFieldInterpolation::defineCellPoint010(double X1, double X2, double X
   return;
 }
 
-
-void VectorFieldInterpolation::defineCellPoint110(double X1, double X2, double X3, double F1, double F2, double F3){
+void VectorFieldInterpolation::defineCellPoint110(double X1, double X2, double X3, double F1, double F2, double F3) {
   CellPoint110[0] = X1;
   CellPoint110[1] = X2;
   CellPoint110[2] = X3;
@@ -45,8 +41,7 @@ void VectorFieldInterpolation::defineCellPoint110(double X1, double X2, double X
   return;
 }
 
-
-void VectorFieldInterpolation::defineCellPoint001(double X1, double X2, double X3, double F1, double F2, double F3){
+void VectorFieldInterpolation::defineCellPoint001(double X1, double X2, double X3, double F1, double F2, double F3) {
   CellPoint001[0] = X1;
   CellPoint001[1] = X2;
   CellPoint001[2] = X3;
@@ -56,8 +51,7 @@ void VectorFieldInterpolation::defineCellPoint001(double X1, double X2, double X
   return;
 }
 
-
-void VectorFieldInterpolation::defineCellPoint101(double X1, double X2, double X3, double F1, double F2, double F3){
+void VectorFieldInterpolation::defineCellPoint101(double X1, double X2, double X3, double F1, double F2, double F3) {
   CellPoint101[0] = X1;
   CellPoint101[1] = X2;
   CellPoint101[2] = X3;
@@ -67,8 +61,7 @@ void VectorFieldInterpolation::defineCellPoint101(double X1, double X2, double X
   return;
 }
 
-
-void VectorFieldInterpolation::defineCellPoint011(double X1, double X2, double X3, double F1, double F2, double F3){
+void VectorFieldInterpolation::defineCellPoint011(double X1, double X2, double X3, double F1, double F2, double F3) {
   CellPoint011[0] = X1;
   CellPoint011[1] = X2;
   CellPoint011[2] = X3;
@@ -78,8 +71,7 @@ void VectorFieldInterpolation::defineCellPoint011(double X1, double X2, double X
   return;
 }
 
-
-void VectorFieldInterpolation::defineCellPoint111(double X1, double X2, double X3, double F1, double F2, double F3){
+void VectorFieldInterpolation::defineCellPoint111(double X1, double X2, double X3, double F1, double F2, double F3) {
   CellPoint111[0] = X1;
   CellPoint111[1] = X2;
   CellPoint111[2] = X3;
@@ -89,8 +81,7 @@ void VectorFieldInterpolation::defineCellPoint111(double X1, double X2, double X
   return;
 }
 
-
-void VectorFieldInterpolation::putSCoordGetVField(double X1, double X2, double X3, double &F1, double &F2, double &F3){
+void VectorFieldInterpolation::putSCoordGetVField(double X1, double X2, double X3, double &F1, double &F2, double &F3) {
   SC[0] = X1;
   SC[1] = X2;
   SC[2] = X3;
@@ -98,7 +89,7 @@ void VectorFieldInterpolation::putSCoordGetVField(double X1, double X2, double X
   // values describing 4 help points after interpolation step of variables X1
   // 5 dimensions: 2 space dimensions + 3 field dimensions
   //                        X2' , X3' , F1' , F2' , F3'
-  double HelpPoint00[5]; // {0.0 , 0.0 , 0.0 , 0.0 , 0.0};
+  double HelpPoint00[5];  // {0.0 , 0.0 , 0.0 , 0.0 , 0.0};
   double HelpPoint10[5];
   double HelpPoint01[5];
   double HelpPoint11[5];
@@ -106,33 +97,36 @@ void VectorFieldInterpolation::putSCoordGetVField(double X1, double X2, double X
   // values describing 2 help points after interpolation step of variables X2'
   // 4 dimensions: 1 space dimensions + 3 field dimensions
   //                       X3" , F1" , F2" , F3"
-  double HelpPoint0[4]; // {0.0 , 0.0 , 0.0 , 0.0};
+  double HelpPoint0[4];  // {0.0 , 0.0 , 0.0 , 0.0};
   double HelpPoint1[4];
-
 
   // 1. iteration *****
   // prepare interpolation between CellPoint000 and CellPoint100
   double DeltaX100X000 = CellPoint100[0] - CellPoint000[0];
   double DeltaSC0X000overDeltaX100X000 = 0.;
-  if (DeltaX100X000 != 0.) DeltaSC0X000overDeltaX100X000 = (SC[0] - CellPoint000[0]) / DeltaX100X000;
+  if (DeltaX100X000 != 0.)
+    DeltaSC0X000overDeltaX100X000 = (SC[0] - CellPoint000[0]) / DeltaX100X000;
 
   // prepare interpolation between CellPoint010 and CellPoint110
   double DeltaX110X010 = CellPoint110[0] - CellPoint010[0];
   double DeltaSC0X010overDeltaX110X010 = 0.;
-  if (DeltaX110X010 != 0.) DeltaSC0X010overDeltaX110X010 = (SC[0] - CellPoint010[0]) / DeltaX110X010;
+  if (DeltaX110X010 != 0.)
+    DeltaSC0X010overDeltaX110X010 = (SC[0] - CellPoint010[0]) / DeltaX110X010;
 
   // prepare interpolation between CellPoint001 and CellPoint101
   double DeltaX101X001 = CellPoint101[0] - CellPoint001[0];
   double DeltaSC0X001overDeltaX101X001 = 0.;
-  if (DeltaX101X001 != 0.) DeltaSC0X001overDeltaX101X001 = (SC[0] - CellPoint001[0]) / DeltaX101X001;
+  if (DeltaX101X001 != 0.)
+    DeltaSC0X001overDeltaX101X001 = (SC[0] - CellPoint001[0]) / DeltaX101X001;
 
   // prepare interpolation between CellPoint011 and CellPoint111
   double DeltaX111X011 = CellPoint111[0] - CellPoint011[0];
   double DeltaSC0X011overDeltaX111X011 = 0.;
-  if (DeltaX111X011 != 0.) DeltaSC0X011overDeltaX111X011 = (SC[0] - CellPoint011[0]) / DeltaX111X011;
+  if (DeltaX111X011 != 0.)
+    DeltaSC0X011overDeltaX111X011 = (SC[0] - CellPoint011[0]) / DeltaX111X011;
 
-  for (int i=0; i<5; ++i){
-    int ip = i+1; 
+  for (int i = 0; i < 5; ++i) {
+    int ip = i + 1;
 
     // interpolate between CellPoint000 and CellPoint100
     HelpPoint00[i] = CellPoint000[ip] + DeltaSC0X000overDeltaX100X000 * (CellPoint100[ip] - CellPoint000[ip]);
@@ -151,14 +145,16 @@ void VectorFieldInterpolation::putSCoordGetVField(double X1, double X2, double X
   // prepare interpolation between HelpPoint00 and HelpPoint10
   double DeltaX10X00 = HelpPoint10[0] - HelpPoint00[0];
   double DeltaSC1X00overDeltaX10X00 = 0.;
-  if (DeltaX10X00 != 0.) DeltaSC1X00overDeltaX10X00 = (SC[1] - HelpPoint00[0]) / DeltaX10X00;
+  if (DeltaX10X00 != 0.)
+    DeltaSC1X00overDeltaX10X00 = (SC[1] - HelpPoint00[0]) / DeltaX10X00;
   // prepare interpolation between HelpPoint01 and HelpPoint11
   double DeltaX11X01 = HelpPoint11[0] - HelpPoint01[0];
   double DeltaSC1X01overDeltaX11X01 = 0.;
-  if (DeltaX11X01 != 0.) DeltaSC1X01overDeltaX11X01 = (SC[1] - HelpPoint01[0]) / DeltaX11X01;
+  if (DeltaX11X01 != 0.)
+    DeltaSC1X01overDeltaX11X01 = (SC[1] - HelpPoint01[0]) / DeltaX11X01;
 
-  for (int i=0; i<4; ++i){
-    int ip = i+1; 
+  for (int i = 0; i < 4; ++i) {
+    int ip = i + 1;
 
     // interpolate between HelpPoint00 and HelpPoint10
     HelpPoint0[i] = HelpPoint00[ip] + DeltaSC1X00overDeltaX10X00 * (HelpPoint10[ip] - HelpPoint00[ip]);
@@ -171,10 +167,11 @@ void VectorFieldInterpolation::putSCoordGetVField(double X1, double X2, double X
   // prepare interpolation between HelpPoint0 and HelpPoint1
   double DeltaX1X0 = HelpPoint1[0] - HelpPoint0[0];
   double DeltaSC2X0overDeltaX1X0 = 0.;
-  if (DeltaX1X0 != 0.) DeltaSC2X0overDeltaX1X0 = (SC[2] - HelpPoint0[0]) / DeltaX1X0;
+  if (DeltaX1X0 != 0.)
+    DeltaSC2X0overDeltaX1X0 = (SC[2] - HelpPoint0[0]) / DeltaX1X0;
 
-  for (int i=0; i<3; ++i){
-    int ip = i+1; 
+  for (int i = 0; i < 3; ++i) {
+    int ip = i + 1;
 
     // interpolate between HelpPoint0 and HelpPoint1
     VF[i] = HelpPoint0[ip] + DeltaSC2X0overDeltaX1X0 * (HelpPoint1[ip] - HelpPoint0[ip]);

--- a/MagneticField/Interpolation/src/VectorFieldInterpolation.h
+++ b/MagneticField/Interpolation/src/VectorFieldInterpolation.h
@@ -51,22 +51,22 @@
 //
 // ***************************************************************
 
-class VectorFieldInterpolation{
+class VectorFieldInterpolation {
 public:
   // constructor
-  VectorFieldInterpolation(){}
+  VectorFieldInterpolation() {}
   // destructor
-  ~VectorFieldInterpolation(){}
+  ~VectorFieldInterpolation() {}
 
 private:
   // spatial coordinates, where the field has to be calculated
   //                X1 ,  X2 , X3
-  double SC[3]; // {0.0 ,0.0 ,0.0 };
-  
+  double SC[3];  // {0.0 ,0.0 ,0.0 };
+
   // values describing the 8 corners of an interpolation cell
   // 6 dimensions: 3 space dimensions + 3 field dimensions
   //                          X1 ,  X2 ,  X3 ,  F1 ,  F2 ,  F3
-  double CellPoint000[6]; // {0.0 , 0.0 , 0.0 , 0.0 , 0.0 , 0.0 };
+  double CellPoint000[6];  // {0.0 , 0.0 , 0.0 , 0.0 , 0.0 , 0.0 };
   double CellPoint100[6];
   double CellPoint010[6];
   double CellPoint110[6];
@@ -77,22 +77,21 @@ private:
 
   // 3 components of the interpolated vector field at spatial coordinates SC
   //                F1  , F2  , F3
-  double VF[3]; // {0.0 , 0.0 , 0.0 };
-
+  double VF[3];  // {0.0 , 0.0 , 0.0 };
 
 public:
-   // Accessors
-   /// provide the interpolation algorithm with 8 points, where the field is known (in)
-   void defineCellPoint000(double X1, double X2, double X3, double  F1, double  F2, double  F3);
-   void defineCellPoint100(double X1, double X2, double X3, double  F1, double  F2, double  F3);
-   void defineCellPoint010(double X1, double X2, double X3, double  F1, double  F2, double  F3);
-   void defineCellPoint110(double X1, double X2, double X3, double  F1, double  F2, double  F3);
-   void defineCellPoint001(double X1, double X2, double X3, double  F1, double  F2, double  F3);
-   void defineCellPoint101(double X1, double X2, double X3, double  F1, double  F2, double  F3);
-   void defineCellPoint011(double X1, double X2, double X3, double  F1, double  F2, double  F3);
-   void defineCellPoint111(double X1, double X2, double X3, double  F1, double  F2, double  F3);
-   /// receive the interpolated field (out) at any point in space (in)
-   void putSCoordGetVField(double X1, double X2, double X3, double &F1, double &F2, double &F3);
+  // Accessors
+  /// provide the interpolation algorithm with 8 points, where the field is known (in)
+  void defineCellPoint000(double X1, double X2, double X3, double F1, double F2, double F3);
+  void defineCellPoint100(double X1, double X2, double X3, double F1, double F2, double F3);
+  void defineCellPoint010(double X1, double X2, double X3, double F1, double F2, double F3);
+  void defineCellPoint110(double X1, double X2, double X3, double F1, double F2, double F3);
+  void defineCellPoint001(double X1, double X2, double X3, double F1, double F2, double F3);
+  void defineCellPoint101(double X1, double X2, double X3, double F1, double F2, double F3);
+  void defineCellPoint011(double X1, double X2, double X3, double F1, double F2, double F3);
+  void defineCellPoint111(double X1, double X2, double X3, double F1, double F2, double F3);
+  /// receive the interpolated field (out) at any point in space (in)
+  void putSCoordGetVField(double X1, double X2, double X3, double &F1, double &F2, double &F3);
 };
 
 #endif

--- a/MagneticField/Interpolation/src/ZReflectedMFGrid.cc
+++ b/MagneticField/Interpolation/src/ZReflectedMFGrid.cc
@@ -5,51 +5,42 @@
 
 using namespace std;
 
-ZReflectedMFGrid::ZReflectedMFGrid( const GloballyPositioned<float>& vol,
-				    MFGrid* sectorGrid) :
-  MFGrid(vol), theSectorGrid( sectorGrid)
+ZReflectedMFGrid::ZReflectedMFGrid(const GloballyPositioned<float>& vol, MFGrid* sectorGrid)
+    : MFGrid(vol),
+      theSectorGrid(sectorGrid)
 
 {}
 
-ZReflectedMFGrid::~ZReflectedMFGrid()
-{
-  delete theSectorGrid;
-}
+ZReflectedMFGrid::~ZReflectedMFGrid() { delete theSectorGrid; }
 
-MFGrid::LocalVector ZReflectedMFGrid::valueInTesla( const LocalPoint& p) const
-{
+MFGrid::LocalVector ZReflectedMFGrid::valueInTesla(const LocalPoint& p) const {
   // Z reflection of point
-  LocalPoint mirrorp( p.x(), p.y(), -p.z());
-  LocalVector mirrorB = theSectorGrid->valueInTesla( mirrorp);
-  return LocalVector( -mirrorB.x(), -mirrorB.y(), mirrorB.z());
+  LocalPoint mirrorp(p.x(), p.y(), -p.z());
+  LocalVector mirrorB = theSectorGrid->valueInTesla(mirrorp);
+  return LocalVector(-mirrorB.x(), -mirrorB.y(), mirrorB.z());
 }
 
-void ZReflectedMFGrid::throwUp( const char* message) const
-{
+void ZReflectedMFGrid::throwUp(const char* message) const {
   std::cout << "Throwing exception " << message << std::endl;
   throw MagGeometryError(message);
 }
-void ZReflectedMFGrid::toGridFrame( const LocalPoint& p, double& a, double& b, double& c) const 
-{
+void ZReflectedMFGrid::toGridFrame(const LocalPoint& p, double& a, double& b, double& c) const {
   throwUp("Not implemented yet");
 }
 
-MFGrid::LocalPoint ZReflectedMFGrid::fromGridFrame( double a, double b, double c) const
-{
+MFGrid::LocalPoint ZReflectedMFGrid::fromGridFrame(double a, double b, double c) const {
   throwUp("Not implemented yet");
   return LocalPoint();
 }
 
-Dimensions ZReflectedMFGrid::dimensions() const {return theSectorGrid->dimensions();}
+Dimensions ZReflectedMFGrid::dimensions() const { return theSectorGrid->dimensions(); }
 
-MFGrid::LocalPoint  ZReflectedMFGrid::nodePosition( int i, int j, int k) const
-{
+MFGrid::LocalPoint ZReflectedMFGrid::nodePosition(int i, int j, int k) const {
   throwUp("Not implemented yet");
   return LocalPoint();
 }
 
-MFGrid::LocalVector ZReflectedMFGrid::nodeValue( int i, int j, int k) const
-{
+MFGrid::LocalVector ZReflectedMFGrid::nodeValue(int i, int j, int k) const {
   throwUp("Not implemented yet");
   return LocalVector();
 }

--- a/MagneticField/Interpolation/src/ZReflectedMFGrid.h
+++ b/MagneticField/Interpolation/src/ZReflectedMFGrid.h
@@ -6,34 +6,29 @@
 
 class dso_internal ZReflectedMFGrid : public MFGrid {
 public:
-
-  ZReflectedMFGrid( const GloballyPositioned<float>& vol,
-		    MFGrid* sectorGrid);
+  ZReflectedMFGrid(const GloballyPositioned<float>& vol, MFGrid* sectorGrid);
 
   ~ZReflectedMFGrid() override;
 
-  LocalVector valueInTesla( const LocalPoint& p) const override;
+  LocalVector valueInTesla(const LocalPoint& p) const override;
 
-  void toGridFrame( const LocalPoint& p, double& a, double& b, double& c) const override ;
+  void toGridFrame(const LocalPoint& p, double& a, double& b, double& c) const override;
 
-  LocalPoint fromGridFrame( double a, double b, double c) const override ;
+  LocalPoint fromGridFrame(double a, double b, double c) const override;
 
-  Dimensions dimensions() const override ;
+  Dimensions dimensions() const override;
 
-  LocalPoint  nodePosition( int i, int j, int k) const override ;
+  LocalPoint nodePosition(int i, int j, int k) const override;
 
-  LocalVector nodeValue( int i, int j, int k) const override ;
-
+  LocalVector nodeValue(int i, int j, int k) const override;
 
 private:
-
-  double  thePhiMin;
-  double  thePhiMax;
+  double thePhiMin;
+  double thePhiMax;
   MFGrid* theSectorGrid;
-  double  theDelta;
+  double theDelta;
 
-  void throwUp( const char *message) const;
-
+  void throwUp(const char* message) const;
 };
 
 #endif

--- a/MagneticField/Interpolation/src/binary_ifstream.cc
+++ b/MagneticField/Interpolation/src/binary_ifstream.cc
@@ -5,103 +5,98 @@
 
 struct binary_ifstream_error {};
 
-binary_ifstream::binary_ifstream( const char* name) : file_(nullptr)
-{
-    init (name);
+binary_ifstream::binary_ifstream(const char* name) : file_(nullptr) { init(name); }
+
+binary_ifstream::binary_ifstream(const std::string& name) : file_(nullptr) { init(name.c_str()); }
+
+void binary_ifstream::init(const char* name) {
+  file_ = fopen(name, "rb");
+  if (file_ == nullptr) {
+    std::cout << "file " << name << " cannot be opened for reading" << std::endl;
+    throw binary_ifstream_error();
+  }
 }
 
-binary_ifstream::binary_ifstream( const std::string& name) : file_(nullptr)
-{
-    init (name.c_str());
+binary_ifstream::~binary_ifstream() { close(); }
+void binary_ifstream::close() {
+  if (file_ != nullptr)
+    fclose(file_);
+  file_ = nullptr;
 }
 
-void binary_ifstream::init( const char* name)
-{
-    file_ = fopen( name, "rb");
-    if (file_ == nullptr) {
-	std::cout << "file " << name << " cannot be opened for reading"
-		  << std::endl;
-	throw binary_ifstream_error();
-    }
+binary_ifstream& binary_ifstream::operator>>(char& n) {
+  n = static_cast<char>(fgetc(file_));
+  return *this;
 }
 
-binary_ifstream::~binary_ifstream()
-{
-    close();
-}
-void binary_ifstream::close()
-{
-    if (file_ != nullptr) fclose( file_);
-    file_ = nullptr;
+binary_ifstream& binary_ifstream::operator>>(unsigned char& n) {
+  n = static_cast<unsigned char>(fgetc(file_));
+  return *this;
 }
 
-binary_ifstream& binary_ifstream::operator>>( char& n) {
-    n = static_cast<char>(fgetc(file_));
-    return *this;
+binary_ifstream& binary_ifstream::operator>>(short& n) {
+  fread(&n, sizeof(n), 1, file_);
+  return *this;
+}
+binary_ifstream& binary_ifstream::operator>>(unsigned short& n) {
+  fread(&n, sizeof(n), 1, file_);
+  return *this;
+}
+binary_ifstream& binary_ifstream::operator>>(int& n) {
+  fread(&n, sizeof(n), 1, file_);
+  return *this;
+}
+binary_ifstream& binary_ifstream::operator>>(unsigned int& n) {
+  fread(&n, sizeof(n), 1, file_);
+  return *this;
 }
 
-binary_ifstream& binary_ifstream::operator>>( unsigned char& n) {
-    n = static_cast<unsigned char>(fgetc(file_));
-    return *this;
+binary_ifstream& binary_ifstream::operator>>(long& n) {
+  fread(&n, sizeof(n), 1, file_);
+  return *this;
+}
+binary_ifstream& binary_ifstream::operator>>(unsigned long& n) {
+  fread(&n, sizeof(n), 1, file_);
+  return *this;
 }
 
-binary_ifstream& binary_ifstream::operator>>( short& n) {
-    fread( &n, sizeof(n), 1, file_); return *this;}
-binary_ifstream& binary_ifstream::operator>>( unsigned short& n) {
-    fread( &n, sizeof(n), 1, file_); return *this;}
-binary_ifstream& binary_ifstream::operator>>( int& n) {
-    fread( &n, sizeof(n), 1, file_); return *this;}
-binary_ifstream& binary_ifstream::operator>>( unsigned int& n) {
-    fread( &n, sizeof(n), 1, file_); return *this;}
-
-binary_ifstream& binary_ifstream::operator>>( long& n) {
-    fread( &n, sizeof(n), 1, file_); return *this;}
-binary_ifstream& binary_ifstream::operator>>( unsigned long& n) {
-    fread( &n, sizeof(n), 1, file_); return *this;}
-
-binary_ifstream& binary_ifstream::operator>>( float& n) {
-    fread( &n, sizeof(n), 1, file_); return *this;}
-binary_ifstream& binary_ifstream::operator>>( double& n) {
-    fread( &n, sizeof(n), 1, file_); return *this;}
-
-binary_ifstream& binary_ifstream::operator>>( bool& n) {
-    n = static_cast<bool>(fgetc(file_));
-    return *this;
+binary_ifstream& binary_ifstream::operator>>(float& n) {
+  fread(&n, sizeof(n), 1, file_);
+  return *this;
+}
+binary_ifstream& binary_ifstream::operator>>(double& n) {
+  fread(&n, sizeof(n), 1, file_);
+  return *this;
 }
 
-binary_ifstream& binary_ifstream::operator>>( std::string& n) {
+binary_ifstream& binary_ifstream::operator>>(bool& n) {
+  n = static_cast<bool>(fgetc(file_));
+  return *this;
+}
+
+binary_ifstream& binary_ifstream::operator>>(std::string& n) {
   unsigned int nchar;
-  (*this) >> nchar;  
-  char* tmp = new char[nchar+1];
-  unsigned int nread = fread( tmp, 1, nchar, file_);
-  if (nread != nchar) std::cout << "binary_ifstream error: read less then expected " << std::endl;
-  n.assign( tmp, nread);
+  (*this) >> nchar;
+  char* tmp = new char[nchar + 1];
+  unsigned int nread = fread(tmp, 1, nchar, file_);
+  if (nread != nchar)
+    std::cout << "binary_ifstream error: read less then expected " << std::endl;
+  n.assign(tmp, nread);
   delete[] tmp;
   return *this;
 }
 
-bool binary_ifstream::good() const 
-{
-    return !bad() && !eof();
-}
+bool binary_ifstream::good() const { return !bad() && !eof(); }
 
-bool binary_ifstream::eof() const
-{
-    return feof( file_);
-}
+bool binary_ifstream::eof() const { return feof(file_); }
 
-bool binary_ifstream::fail() const
-{
-    return file_ == nullptr || ferror( file_) != 0;
-}
+bool binary_ifstream::fail() const { return file_ == nullptr || ferror(file_) != 0; }
 
 // don't know the difference between fail() and bad() (yet)
-bool binary_ifstream::bad() const {return fail();}
+bool binary_ifstream::bad() const { return fail(); }
 
-bool binary_ifstream::operator!() const {return fail() || bad() || eof();}
+bool binary_ifstream::operator!() const { return fail() || bad() || eof(); }
 
 //binary_ifstream::operator bool() const {return !fail() && !bad();}
 
-binary_ifstream::operator bool() const {
-    return good();
-}
+binary_ifstream::operator bool() const { return good(); }

--- a/MagneticField/Interpolation/src/binary_ifstream.h
+++ b/MagneticField/Interpolation/src/binary_ifstream.h
@@ -7,46 +7,43 @@
 
 class binary_ifstream {
 public:
+  explicit binary_ifstream(const char* name);
+  explicit binary_ifstream(const std::string& name);
 
-    explicit binary_ifstream( const char* name);
-    explicit binary_ifstream( const std::string& name);
+  ~binary_ifstream();
 
-    ~binary_ifstream();
+  binary_ifstream& operator>>(char& n);
+  binary_ifstream& operator>>(unsigned char& n);
 
-    binary_ifstream& operator>>( char& n);
-    binary_ifstream& operator>>( unsigned char& n);
+  binary_ifstream& operator>>(short& n);
+  binary_ifstream& operator>>(unsigned short& n);
 
-    binary_ifstream& operator>>( short& n);
-    binary_ifstream& operator>>( unsigned short& n);
+  binary_ifstream& operator>>(int& n);
+  binary_ifstream& operator>>(unsigned int& n);
 
-    binary_ifstream& operator>>( int& n);
-    binary_ifstream& operator>>( unsigned int& n);
+  binary_ifstream& operator>>(long& n);
+  binary_ifstream& operator>>(unsigned long& n);
 
-    binary_ifstream& operator>>( long& n);
-    binary_ifstream& operator>>( unsigned long& n);
+  binary_ifstream& operator>>(float& n);
+  binary_ifstream& operator>>(double& n);
 
-    binary_ifstream& operator>>( float& n);
-    binary_ifstream& operator>>( double& n);
+  binary_ifstream& operator>>(bool& n);
+  binary_ifstream& operator>>(std::string& n);
 
-    binary_ifstream& operator>>( bool& n);
-    binary_ifstream& operator>>( std::string& n);
-
-    void close();
+  void close();
 
   /// stream state checking
-    bool good() const;
-    bool eof() const;
-    bool fail() const;
-    bool bad() const;
-    bool operator!() const;
-    operator bool() const;
+  bool good() const;
+  bool eof() const;
+  bool fail() const;
+  bool bad() const;
+  bool operator!() const;
+  operator bool() const;
 
 private:
+  FILE* file_;
 
-    FILE* file_;
-
-    void init( const char* name);
-
+  void init(const char* name);
 };
 
 #endif

--- a/MagneticField/Interpolation/src/binary_ofstream.cc
+++ b/MagneticField/Interpolation/src/binary_ofstream.cc
@@ -5,66 +5,73 @@
 
 struct binary_ofstream_error {};
 
-binary_ofstream::binary_ofstream( const char* name) : file_(nullptr)
-{
-    init (name);
+binary_ofstream::binary_ofstream(const char* name) : file_(nullptr) { init(name); }
+
+binary_ofstream::binary_ofstream(const std::string& name) : file_(nullptr) { init(name.c_str()); }
+
+void binary_ofstream::init(const char* name) {
+  file_ = fopen(name, "wb");
+  if (file_ == nullptr) {
+    std::cout << "file " << name << " cannot be opened for writing" << std::endl;
+    throw binary_ofstream_error();
+  }
 }
 
-binary_ofstream::binary_ofstream( const std::string& name) : file_(nullptr)
-{
-    init (name.c_str());
+binary_ofstream::~binary_ofstream() { close(); }
+void binary_ofstream::close() {
+  if (file_ != nullptr)
+    fclose(file_);
+  file_ = nullptr;
 }
 
-void binary_ofstream::init( const char* name)
-{
-    file_ = fopen( name, "wb");
-    if (file_ == nullptr) {
-	std::cout << "file " << name << " cannot be opened for writing"
-		  << std::endl;
-	throw binary_ofstream_error();
-    }
+binary_ofstream& binary_ofstream::operator<<(char n) {
+  fputc(n, file_);
+  return *this;
+}
+binary_ofstream& binary_ofstream::operator<<(unsigned char n) {
+  fputc(n, file_);
+  return *this;
 }
 
-binary_ofstream::~binary_ofstream()
-{
-    close();
+binary_ofstream& binary_ofstream::operator<<(short n) {
+  fwrite(&n, sizeof(n), 1, file_);
+  return *this;
 }
-void binary_ofstream::close()
-{
-    if (file_ != nullptr) fclose( file_);
-    file_ = nullptr;
+binary_ofstream& binary_ofstream::operator<<(unsigned short n) {
+  fwrite(&n, sizeof(n), 1, file_);
+  return *this;
 }
-
-binary_ofstream& binary_ofstream::operator<<( char n) {
-    fputc( n, file_); return *this;
+binary_ofstream& binary_ofstream::operator<<(int n) {
+  fwrite(&n, sizeof(n), 1, file_);
+  return *this;
 }
-binary_ofstream& binary_ofstream::operator<<( unsigned char n) {
-    fputc( n, file_); return *this;
+binary_ofstream& binary_ofstream::operator<<(unsigned int n) {
+  fwrite(&n, sizeof(n), 1, file_);
+  return *this;
 }
-
-binary_ofstream& binary_ofstream::operator<<( short n) {
-    fwrite( &n, sizeof(n), 1, file_); return *this;}
-binary_ofstream& binary_ofstream::operator<<( unsigned short n) {
-    fwrite( &n, sizeof(n), 1, file_); return *this;}
-binary_ofstream& binary_ofstream::operator<<( int n) {
-    fwrite( &n, sizeof(n), 1, file_); return *this;}
-binary_ofstream& binary_ofstream::operator<<( unsigned int n) {
-    fwrite( &n, sizeof(n), 1, file_); return *this;}
-binary_ofstream& binary_ofstream::operator<<( long n) {
-    fwrite( &n, sizeof(n), 1, file_); return *this;}
-binary_ofstream& binary_ofstream::operator<<( unsigned long n) {
-    fwrite( &n, sizeof(n), 1, file_); return *this;}
-binary_ofstream& binary_ofstream::operator<<( float n) {
-    fwrite( &n, sizeof(n), 1, file_); return *this;}
-binary_ofstream& binary_ofstream::operator<<( double n) {
-    fwrite( &n, sizeof(n), 1, file_); return *this;}
-
-binary_ofstream& binary_ofstream::operator<<( bool n) {
-  return operator<<( static_cast<char>(n));
+binary_ofstream& binary_ofstream::operator<<(long n) {
+  fwrite(&n, sizeof(n), 1, file_);
+  return *this;
+}
+binary_ofstream& binary_ofstream::operator<<(unsigned long n) {
+  fwrite(&n, sizeof(n), 1, file_);
+  return *this;
+}
+binary_ofstream& binary_ofstream::operator<<(float n) {
+  fwrite(&n, sizeof(n), 1, file_);
+  return *this;
+}
+binary_ofstream& binary_ofstream::operator<<(double n) {
+  fwrite(&n, sizeof(n), 1, file_);
+  return *this;
 }
 
-binary_ofstream& binary_ofstream::operator<<( const std::string& s) {
-  (*this) << (uint32_t) s.size(); // Use uint32 for backward compatibilty of binary files that were generated on 32-bit machines.
-  fwrite( s.data(), 1, s.size(), file_);
+binary_ofstream& binary_ofstream::operator<<(bool n) { return operator<<(static_cast<char>(n)); }
+
+binary_ofstream& binary_ofstream::operator<<(const std::string& s) {
+  (*this)
+      << (uint32_t)
+             s.size();  // Use uint32 for backward compatibilty of binary files that were generated on 32-bit machines.
+  fwrite(s.data(), 1, s.size(), file_);
   return *this;
 }

--- a/MagneticField/Interpolation/src/binary_ofstream.h
+++ b/MagneticField/Interpolation/src/binary_ofstream.h
@@ -7,38 +7,35 @@
 #include "FWCore/Utilities/interface/Visibility.h"
 class binary_ofstream {
 public:
+  explicit binary_ofstream(const char* name);
+  explicit binary_ofstream(const std::string& name);
 
-    explicit binary_ofstream( const char* name);
-    explicit binary_ofstream( const std::string& name);
+  ~binary_ofstream();
 
-    ~binary_ofstream();
+  binary_ofstream& operator<<(char n);
+  binary_ofstream& operator<<(unsigned char n);
 
-    binary_ofstream& operator<<( char n);
-    binary_ofstream& operator<<( unsigned char n);
+  binary_ofstream& operator<<(short n);
+  binary_ofstream& operator<<(unsigned short n);
 
-    binary_ofstream& operator<<( short n);
-    binary_ofstream& operator<<( unsigned short n);
+  binary_ofstream& operator<<(int n);
+  binary_ofstream& operator<<(unsigned int n);
 
-    binary_ofstream& operator<<( int n);
-    binary_ofstream& operator<<( unsigned int n);
+  binary_ofstream& operator<<(long n);
+  binary_ofstream& operator<<(unsigned long n);
 
-    binary_ofstream& operator<<( long n);
-    binary_ofstream& operator<<( unsigned long n);
+  binary_ofstream& operator<<(float n);
+  binary_ofstream& operator<<(double n);
 
-    binary_ofstream& operator<<( float n);
-    binary_ofstream& operator<<( double n);
+  binary_ofstream& operator<<(bool n);
+  binary_ofstream& operator<<(const std::string& n);
 
-    binary_ofstream& operator<<( bool n);
-    binary_ofstream& operator<<( const std::string& n);
-
-    void close();
+  void close();
 
 private:
+  FILE* file_;
 
-    FILE* file_;
-
-    void init( const char* name);
-
+  void init(const char* name);
 };
 
 #endif

--- a/MagneticField/Interpolation/src/gridTesters.cc
+++ b/MagneticField/Interpolation/src/gridTesters.cc
@@ -3,40 +3,37 @@
 #include <cassert>
 
 namespace {
-  bool testGrid1D( Grid1D const & grid)  {
-    
-    bool ok=true;
-    
+  bool testGrid1D(Grid1D const& grid) {
+    bool ok = true;
+
     Grid1D::Scalar f;
-    int i = grid.index(7.2,f); 
+    int i = grid.index(7.2, f);
     ok &= grid.inRange(i);
-    
-    ok &=  (8==i);
-    ok &= (0.6==f);
-    
+
+    ok &= (8 == i);
+    ok &= (0.6 == f);
+
     return ok;
   }
-}
+}  // namespace
 
-
-#include<iostream>
-#include<cstdlib>
-#include<cstdio>
+#include <iostream>
+#include <cstdlib>
+#include <cstdio>
 
 namespace {
-  void print(Grid1D grid,  Grid1D::Scalar a) {
+  void print(Grid1D grid, Grid1D::Scalar a) {
     Grid1D::Scalar f;
-    int i = grid.index(a,f); 
-    ::printf("%i %f %a\n",i,f,f);
-    grid.normalize(i,f);
-    ::printf("%i %f %a\n",i,f,f);
+    int i = grid.index(a, f);
+    ::printf("%i %f %a\n", i, f, f);
+    grid.normalize(i, f);
+    ::printf("%i %f %a\n", i, f, f);
   }
-}
+}  // namespace
 
 int grid1d_t() {
-
-  bool ok=true;
-  Grid1D grid(-10.,10.,11);
+  bool ok = true;
+  Grid1D grid(-10., 10., 11);
 
   print(grid, 7.2);
   print(grid, 10.);
@@ -45,51 +42,41 @@ int grid1d_t() {
 
   ok &= testGrid1D(grid);
 
-  assert(ok? 0 : 1);
+  assert(ok ? 0 : 1);
   return ok ? 0 : 1;
-
 }
-
-
 
 namespace {
 
-  Grid3D const  * factory() {
+  Grid3D const* factory() {
+    Grid1D ga(0., 10., 5);
+    Grid1D gb(-10., 10., 11);
+    Grid1D gc(-10., 10., 11);
 
-    Grid1D ga(0.,10.,5);
-    Grid1D gb(-10.,10.,11);
-    Grid1D gc(-10.,10.,11);
+    std::vector<Grid3D::BVector> data;
+    data.reserve(ga.nodes() * gb.nodes() * gc.nodes());
+    for (int i = 0; i < ga.nodes(); ++i)
+      for (int j = 0; j < gb.nodes(); ++j)
+        for (int k = 0; k < gc.nodes(); ++k) {
+          data.push_back(Grid3D::BVector(10 * ga.node(i), 10 * gb.node(j), 10 * gc.node(k)));
+        }
 
-    std::vector< Grid3D::BVector>  data;
-    data.reserve(ga.nodes()*gb.nodes()*gc.nodes());
-    for (int i=0; i<ga.nodes(); ++i) 
-      for (int j=0; j<gb.nodes(); ++j) 
-	for (int k=0; k<gc.nodes(); ++k) {
-	  data.push_back(Grid3D::BVector(10*ga.node(i),10*gb.node(j),10*gc.node(k)));	  
-	}
-    
-    return new Grid3D(ga,gb,gc,data);
-
+    return new Grid3D(ga, gb, gc, data);
   }
 
-}
-
-
-
+}  // namespace
 
 #include "LinearGridInterpolator3D.h"
 #include <iostream>
 
 int grid3d_t() {
-  
-  Grid3D const  * grid = factory();
-  
+  Grid3D const* grid = factory();
+
   LinearGridInterpolator3D inter(*grid);
-  
-  std::cout << inter.interpolate(7.5,7.2,-3.4) << std::endl;
-  std::cout << inter.interpolate(-0.5,10.2,-3.4) << std::endl;
-  
-  
+
+  std::cout << inter.interpolate(7.5, 7.2, -3.4) << std::endl;
+  std::cout << inter.interpolate(-0.5, 10.2, -3.4) << std::endl;
+
   delete grid;
   return 0;
 }

--- a/MagneticField/Interpolation/test/BinaryTablesGeneration/GridFileReader.cpp
+++ b/MagneticField/Interpolation/test/BinaryTablesGeneration/GridFileReader.cpp
@@ -11,25 +11,23 @@
 #include <cmath>
 #include <stdlib.h>
 #include "DataFormats/Math/interface/approx_exp.h"
-inline
-int bits(int a) {
+inline int bits(int a) {
   unsigned int aa = abs(a);
-  int b=0; if (a==0) return 0;
-  while ( (aa/=2) > 0 )  ++b;
-  return (a>0) ? b : -b;
-
+  int b = 0;
+  if (a == 0)
+    return 0;
+  while ((aa /= 2) > 0)
+    ++b;
+  return (a > 0) ? b : -b;
 }
 
 using namespace std;
 using namespace approx_math;
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
   if (argc > 3) {
-    cout << "SYNOPSIS:" << endl
-	 << " GridFileReader input.bin [fullDump=true|false]" << endl;
-    cout << "Example:" << endl
-	 << " GridFileReader grid.217.bin false" << endl;
-      return 1;  
+    cout << "SYNOPSIS:" << endl << " GridFileReader input.bin [fullDump=true|false]" << endl;
+    cout << "Example:" << endl << " GridFileReader grid.217.bin false" << endl;
+    return 1;
   }
   const string filename = argv[1];
 
@@ -52,121 +50,121 @@ int main(int argc, char **argv)
   double dist1[3][3];
   double dist2[3][3];
   double rParm[4];
-  bool   easyC[3];
+  bool easyC[3];
   // float Bx, By, Bz;
   // reading the type
   inFile >> type;
   // reading the header
-  if (type == 1){
-    inFile >>  nPnt[0]    >>  nPnt[1]    >>  nPnt[2];
-    inFile >> ooPnt[0]    >> ooPnt[1]    >> ooPnt[2];
-    inFile >> dist0[0]    >> dist0[1]    >> dist0[2];
+  if (type == 1) {
+    inFile >> nPnt[0] >> nPnt[1] >> nPnt[2];
+    inFile >> ooPnt[0] >> ooPnt[1] >> ooPnt[2];
+    inFile >> dist0[0] >> dist0[1] >> dist0[2];
   }
-  if (type == 2){
-    inFile >> nPnt[0]     >> nPnt[1]     >> nPnt[2];
-    inFile >> ooPnt[0]    >> ooPnt[1]    >> ooPnt[2];
-    inFile >> dist0[0]    >> dist0[1]    >> dist0[2];
+  if (type == 2) {
+    inFile >> nPnt[0] >> nPnt[1] >> nPnt[2];
+    inFile >> ooPnt[0] >> ooPnt[1] >> ooPnt[2];
+    inFile >> dist0[0] >> dist0[1] >> dist0[2];
     inFile >> dist1[0][0] >> dist1[1][0] >> dist1[2][0];
     inFile >> dist1[0][1] >> dist1[1][1] >> dist1[2][1];
     inFile >> dist1[0][2] >> dist1[1][2] >> dist1[2][2];
     inFile >> dist2[0][0] >> dist2[1][0] >> dist2[2][0];
     inFile >> dist2[0][1] >> dist2[1][1] >> dist2[2][1];
     inFile >> dist2[0][2] >> dist2[1][2] >> dist2[2][2];
-    inFile >> easyC[0]    >> easyC[1]    >> easyC[2];
+    inFile >> easyC[0] >> easyC[1] >> easyC[2];
   }
-  if (type == 3){
-    inFile >>  nPnt[0]    >>  nPnt[1]    >>  nPnt[2];
-    inFile >> ooPnt[0]    >> ooPnt[1]    >> ooPnt[2];
-    inFile >> dist0[0]    >> dist0[1]    >> dist0[2];
+  if (type == 3) {
+    inFile >> nPnt[0] >> nPnt[1] >> nPnt[2];
+    inFile >> ooPnt[0] >> ooPnt[1] >> ooPnt[2];
+    inFile >> dist0[0] >> dist0[1] >> dist0[2];
   }
-  if (type == 4){
-    inFile >> nPnt[0]     >> nPnt[1]     >> nPnt[2];
-    inFile >> ooPnt[0]    >> ooPnt[1]    >> ooPnt[2];
-    inFile >> dist0[0]    >> dist0[1]    >> dist0[2];
+  if (type == 4) {
+    inFile >> nPnt[0] >> nPnt[1] >> nPnt[2];
+    inFile >> ooPnt[0] >> ooPnt[1] >> ooPnt[2];
+    inFile >> dist0[0] >> dist0[1] >> dist0[2];
     inFile >> dist1[0][0] >> dist1[1][0] >> dist1[2][0];
     inFile >> dist1[0][1] >> dist1[1][1] >> dist1[2][1];
     inFile >> dist1[0][2] >> dist1[1][2] >> dist1[2][2];
     inFile >> dist2[0][0] >> dist2[1][0] >> dist2[2][0];
     inFile >> dist2[0][1] >> dist2[1][1] >> dist2[2][1];
     inFile >> dist2[0][2] >> dist2[1][2] >> dist2[2][2];
-    inFile >> easyC[0]    >> easyC[1]    >> easyC[2];
+    inFile >> easyC[0] >> easyC[1] >> easyC[2];
   }
-  if (type == 5){
-    inFile >>  nPnt[0]    >>  nPnt[1]    >>  nPnt[2];
-    inFile >> ooPnt[0]    >> ooPnt[1]    >> ooPnt[2];
-    inFile >> dist0[0]    >> dist0[1]    >> dist0[2];
-    inFile >> rParm[0]    >> rParm[1]    >> rParm[2]    >> rParm[3];
+  if (type == 5) {
+    inFile >> nPnt[0] >> nPnt[1] >> nPnt[2];
+    inFile >> ooPnt[0] >> ooPnt[1] >> ooPnt[2];
+    inFile >> dist0[0] >> dist0[1] >> dist0[2];
+    inFile >> rParm[0] >> rParm[1] >> rParm[2] >> rParm[3];
   }
 
   //reading the field
-  int nLines = nPnt[0]*nPnt[1]*nPnt[2];
+  int nLines = nPnt[0] * nPnt[1] * nPnt[2];
 
   // print the stuff from above (onlt last line of field values)
   cout << "  content of " << filename << endl;
   cout << type << endl;
-  if (type == 1){
-    cout <<  nPnt[0] << " " <<  nPnt[1] << " " <<  nPnt[2] << endl;
+  if (type == 1) {
+    cout << nPnt[0] << " " << nPnt[1] << " " << nPnt[2] << endl;
     cout << ooPnt[0] << " " << ooPnt[1] << " " << ooPnt[2] << endl;
     cout << dist0[0] << " " << dist0[1] << " " << dist0[2] << endl;
   }
-  if (type == 2){
-    cout <<  nPnt[0]    << " " <<  nPnt[1]    << " " <<  nPnt[2]    << endl;
-    cout << ooPnt[0]    << " " << ooPnt[1]    << " " << ooPnt[2]    << endl;
-    cout << dist0[0]    << " " << dist0[1]    << " " << dist0[2]    << endl;
+  if (type == 2) {
+    cout << nPnt[0] << " " << nPnt[1] << " " << nPnt[2] << endl;
+    cout << ooPnt[0] << " " << ooPnt[1] << " " << ooPnt[2] << endl;
+    cout << dist0[0] << " " << dist0[1] << " " << dist0[2] << endl;
     cout << dist1[0][0] << " " << dist1[1][0] << " " << dist1[2][0] << endl;
     cout << dist1[0][1] << " " << dist1[1][1] << " " << dist1[2][1] << endl;
     cout << dist1[0][2] << " " << dist1[1][2] << " " << dist1[2][2] << endl;
     cout << dist2[0][0] << " " << dist2[1][0] << " " << dist2[2][0] << endl;
     cout << dist2[0][1] << " " << dist2[1][1] << " " << dist2[2][1] << endl;
     cout << dist2[0][2] << " " << dist2[1][2] << " " << dist2[2][2] << endl;
-    cout << easyC[0]    << " " << easyC[1]    << " " << easyC[2]    << endl;
+    cout << easyC[0] << " " << easyC[1] << " " << easyC[2] << endl;
   }
-  if (type == 3){
-    cout <<  nPnt[0] << " " <<  nPnt[1] << " " <<  nPnt[2] << endl;
+  if (type == 3) {
+    cout << nPnt[0] << " " << nPnt[1] << " " << nPnt[2] << endl;
     cout << ooPnt[0] << " " << ooPnt[1] << " " << ooPnt[2] << endl;
     cout << dist0[0] << " " << dist0[1] << " " << dist0[2] << endl;
   }
-  if (type == 4){
-    cout <<  nPnt[0]    << " " <<  nPnt[1]    << " " <<  nPnt[2]    << endl;
-    cout << ooPnt[0]    << " " << ooPnt[1]    << " " << ooPnt[2]    << endl;
-    cout << dist0[0]    << " " << dist0[1]    << " " << dist0[2]    << endl;
+  if (type == 4) {
+    cout << nPnt[0] << " " << nPnt[1] << " " << nPnt[2] << endl;
+    cout << ooPnt[0] << " " << ooPnt[1] << " " << ooPnt[2] << endl;
+    cout << dist0[0] << " " << dist0[1] << " " << dist0[2] << endl;
     cout << dist1[0][0] << " " << dist1[1][0] << " " << dist1[2][0] << endl;
     cout << dist1[0][1] << " " << dist1[1][1] << " " << dist1[2][1] << endl;
     cout << dist1[0][2] << " " << dist1[1][2] << " " << dist1[2][2] << endl;
     cout << dist2[0][0] << " " << dist2[1][0] << " " << dist2[2][0] << endl;
     cout << dist2[0][1] << " " << dist2[1][1] << " " << dist2[2][1] << endl;
     cout << dist2[0][2] << " " << dist2[1][2] << " " << dist2[2][2] << endl;
-    cout << easyC[0]    << " " << easyC[1]    << " " << easyC[2]    << endl;
+    cout << easyC[0] << " " << easyC[1] << " " << easyC[2] << endl;
   }
-  if (type == 5){
-    cout <<  nPnt[0] << " " <<  nPnt[1] << " " <<  nPnt[2] << endl;
+  if (type == 5) {
+    cout << nPnt[0] << " " << nPnt[1] << " " << nPnt[2] << endl;
     cout << ooPnt[0] << " " << ooPnt[1] << " " << ooPnt[2] << endl;
     cout << dist0[0] << " " << dist0[1] << " " << dist0[2] << endl;
     cout << rParm[0] << " " << rParm[1] << " " << rParm[2] << " " << rParm[3] << endl;
   }
 
-  float B[3]={0,0,0} , Bmin[3]={9999.,9999.,9999.}, Bmax[3]={0,0,0.};
-  for (int iLine=0; iLine<nLines; ++iLine){
+  float B[3] = {0, 0, 0}, Bmin[3] = {9999., 9999., 9999.}, Bmax[3] = {0, 0, 0.};
+  for (int iLine = 0; iLine < nLines; ++iLine) {
     inFile >> B[0] >> B[1] >> B[2];
-    for (int i=0;i!=3; ++i) {
-      Bmin[i] = std::min(Bmin[i],std::abs(B[i]));
-      Bmax[i] = std::max(Bmax[i],std::abs(B[i]));
+    for (int i = 0; i != 3; ++i) {
+      Bmin[i] = std::min(Bmin[i], std::abs(B[i]));
+      Bmax[i] = std::max(Bmax[i], std::abs(B[i]));
     }
     if (fullDump) {
-      cout  << setprecision(12);
-      cout  << "line: " << iLine  << " " << B[0] << " " << B[1] << " " << B[2] << endl;
+      cout << setprecision(12);
+      cout << "line: " << iLine << " " << B[0] << " " << B[1] << " " << B[2] << endl;
     }
   }
-  
+
   if (!fullDump) {
     cout << ". . ." << endl;
     cout << B[0] << " " << B[1] << " " << B[2] << " (last line of B-field only)" << endl;
     cout << Bmin[0] << " " << Bmin[1] << " " << Bmin[2] << " (min B-field abs)" << endl;
     cout << Bmax[0] << " " << Bmax[1] << " " << Bmax[2] << " (max B-field abs)" << endl;
-    for (int i=0;i!=3; ++i)  std::cout << bits(binary32(Bmax[i]).i32-binary32(Bmin[i]).i32) << " ";
+    for (int i = 0; i != 3; ++i)
+      std::cout << bits(binary32(Bmax[i]).i32 - binary32(Bmin[i]).i32) << " ";
     std::cout << "(max-min in bits)" << std::endl;
   }
-  
 
   // check completeness and close file
   string lastEntry;
@@ -174,9 +172,11 @@ int main(int argc, char **argv)
   inFile.close();
 
   cout << "  file is " << lastEntry;
-  if (lastEntry == "complete") cout << "  -->  reading done" << endl;
-  else                         cout << "  -->  reading ERROR" << endl;
+  if (lastEntry == "complete")
+    cout << "  -->  reading done" << endl;
+  else
+    cout << "  -->  reading ERROR" << endl;
   cout << endl;
 
-  return(0);
+  return (0);
 }

--- a/MagneticField/Interpolation/test/BinaryTablesGeneration/prepareFieldTable.cpp
+++ b/MagneticField/Interpolation/test/BinaryTablesGeneration/prepareFieldTable.cpp
@@ -1,6 +1,6 @@
 // Magnetic Field Interpolation Test Program (formerly prepareFieldInterpolation.cpp)
-// by droll (03/02/04) 
-// Updated N. Amapane 3/07 -former name 
+// by droll (03/02/04)
+// Updated N. Amapane 3/07 -former name
 
 #include <iostream>
 
@@ -10,52 +10,52 @@ using namespace std;
 
 int main(int argc, char **argv) {
   if (argc > 4) {
-    cout << "SYNOPSIS:" << endl
-	 << " prepareFieldTable input.table output.bin [sector]" << endl;
+    cout << "SYNOPSIS:" << endl << " prepareFieldTable input.table output.bin [sector]" << endl;
     cout << "Example:" << endl
-	 << " prepareFieldTable /afs/cern.ch/cms/OO/mag_field/version_85l_030919/v-xyz-217.table grid.217.bin" << endl;
-      return 1;  
+         << " prepareFieldTable /afs/cern.ch/cms/OO/mag_field/version_85l_030919/v-xyz-217.table grid.217.bin" << endl;
+    return 1;
   }
 
   string filename1 = argv[1];
   string filename2 = argv[2];
 
-  int sector=0;
-  if (argc==4) {  
+  int sector = 0;
+  if (argc == 4) {
     sector = atoi(argv[3]);
   }
-  
+
   cout << "Using Rotation from sector " << sector << endl;
 
-  prepareMagneticFieldGrid MFG001(sector);                                    // MFG001 for standard cases
-  MFG001.countTrueNumberOfPoints(filename1);   // check, if file contains some points twice
+  prepareMagneticFieldGrid MFG001(sector);    // MFG001 for standard cases
+  MFG001.countTrueNumberOfPoints(filename1);  // check, if file contains some points twice
 
-
-  
-  MFG001.fillFromFile(filename1);              // determine grid structure (standard cases)
-  int type           =   MFG001.gridType();                           // grid type
+  MFG001.fillFromFile(filename1);  // determine grid structure (standard cases)
+  int type = MFG001.gridType();    // grid type
   if (type == 0) {
     cout << "  standard grid sructure detection failed, retrying with special grid sructure" << endl;
   } else {
-    if (MFG001.isReady())  MFG001.validateAllPoints();                  // check position of every point
-    if (MFG001.isReady())  {
-      MFG001.saveGridToFile(filename2);            // write grid to disk
+    if (MFG001.isReady())
+      MFG001.validateAllPoints();  // check position of every point
+    if (MFG001.isReady()) {
+      MFG001.saveGridToFile(filename2);  // write grid to disk
       cout << " " << endl;
       return 0;
     }
   }
 
   // MFG001 anlysis was not successful. Different processing for special cases
-  prepareMagneticFieldGrid MFG002(sector);                                  // MFG002 for special cases
-  MFG002.fillFromFileSpecial(filename1);     // determine grid structure (special cases)
-  type = MFG002.gridType();                         // grid type
-  if (type == 0) cout << "  special grid sructure detection failed " << endl;
-  if (MFG002.isReady())  MFG002.validateAllPoints();                // check position of every point
-  if (MFG002.isReady())  {
-    MFG002.saveGridToFile(filename2);          // write grid to disk
+  prepareMagneticFieldGrid MFG002(sector);  // MFG002 for special cases
+  MFG002.fillFromFileSpecial(filename1);    // determine grid structure (special cases)
+  type = MFG002.gridType();                 // grid type
+  if (type == 0)
+    cout << "  special grid sructure detection failed " << endl;
+  if (MFG002.isReady())
+    MFG002.validateAllPoints();  // check position of every point
+  if (MFG002.isReady()) {
+    MFG002.saveGridToFile(filename2);  // write grid to disk
     cout << " " << endl;
     return 0;
-  } 
+  }
 
   return 1;
 }

--- a/MagneticField/Interpolation/test/BinaryTablesGeneration/prepareMagneticFieldGrid.cc
+++ b/MagneticField/Interpolation/test/BinaryTablesGeneration/prepareMagneticFieldGrid.cc
@@ -10,14 +10,12 @@
 
 using namespace std;
 
-void prepareMagneticFieldGrid::countTrueNumberOfPoints(const std::string& name) const {
-
+void prepareMagneticFieldGrid::countTrueNumberOfPoints(const std::string &name) const {
   int nLines = 0;
   int nPoints = 0;
 
-
   // define vectors of IndexedDoubleVectors
-  IndexedDoubleVector         XBVector;
+  IndexedDoubleVector XBVector;
   std::vector<IndexedDoubleVector> XBValues;
 
   // read file and copy to a vector
@@ -25,18 +23,19 @@ void prepareMagneticFieldGrid::countTrueNumberOfPoints(const std::string& name) 
   std::ifstream file(name.c_str());
   string line;
   if (file.good()) {
-    while (getline(file,line)) {
-      double x1,x2,x3,Bx,By,Bz,perm;//,poten;
+    while (getline(file, line)) {
+      double x1, x2, x3, Bx, By, Bz, perm;  //,poten;
       stringstream linestr;
-      linestr << line;      
-      linestr >> x1 >> x2 >> x3 >> Bx >> By >> Bz >> perm;;// >> poten;
-      if (file){
+      linestr << line;
+      linestr >> x1 >> x2 >> x3 >> Bx >> By >> Bz >> perm;
+      ;  // >> poten;
+      if (file) {
         XBVector.putV6(x1, x2, x3, Bx, By, Bz);
-// 	if (nLines<5) {
-// 	  double tx1, tx2, tx3, tBx, tBy, tBz;
-// 	  XBVector.getV6(tx1, tx2, tx3, tBx, tBy, tBz);
-// 	  cout << "Read: " <<  setprecision(12) << Bx << " " << tBx << endl;
-// 	}
+        // 	if (nLines<5) {
+        // 	  double tx1, tx2, tx3, tBx, tBy, tBz;
+        // 	  XBVector.getV6(tx1, tx2, tx3, tBx, tBy, tBz);
+        // 	  cout << "Read: " <<  setprecision(12) << Bx << " " << tBx << endl;
+        // 	}
         XBValues.push_back(XBVector);
         ++nLines;
       }
@@ -44,55 +43,59 @@ void prepareMagneticFieldGrid::countTrueNumberOfPoints(const std::string& name) 
   }
 
   // compare point by point
-  for (int iLine=0; iLine<nLines; ++iLine){
-    double x1,x2,x3,Bx,By,Bz;
+  for (int iLine = 0; iLine < nLines; ++iLine) {
+    double x1, x2, x3, Bx, By, Bz;
     XBVector = XBValues.operator[](iLine);
     XBVector.getV6(x1, x2, x3, Bx, By, Bz);
-    double pnt[3] = {x1,x2,x3};
+    double pnt[3] = {x1, x2, x3};
     double tmpBz = Bz;
     bool isSinglePoint = true;
-    for (int i=0; i<nLines; ++i){
-      if (i < iLine){
-	XBVector = XBValues.operator[](i);
-	XBVector.getV6(x1, x2, x3, Bx, By, Bz);
-	double distPP = sqrt((pnt[0]-x1)*(pnt[0]-x1)+(pnt[1]-x2)*(pnt[1]-x2)+(pnt[2]-x3)*(pnt[2]-x3));
-	if (distPP < epsilonRadius) {
-	  isSinglePoint = false;
+    for (int i = 0; i < nLines; ++i) {
+      if (i < iLine) {
+        XBVector = XBValues.operator[](i);
+        XBVector.getV6(x1, x2, x3, Bx, By, Bz);
+        double distPP =
+            sqrt((pnt[0] - x1) * (pnt[0] - x1) + (pnt[1] - x2) * (pnt[1] - x2) + (pnt[2] - x3) * (pnt[2] - x3));
+        if (distPP < epsilonRadius) {
+          isSinglePoint = false;
           cout << "same points(" << iLine << ") with dR = " << distPP << endl;
-	  cout << "             point 1: " << iLine << " " <<  pnt[0] << " " << pnt[1] << " " << pnt[2] << " Bz: " << tmpBz << endl;
-	  cout << "             point 2: " << i << " " << x1     << " " << x2     << " " << x3     << " Bz: " <<    Bz << endl;
-	}
+          cout << "             point 1: " << iLine << " " << pnt[0] << " " << pnt[1] << " " << pnt[2]
+               << " Bz: " << tmpBz << endl;
+          cout << "             point 2: " << i << " " << x1 << " " << x2 << " " << x3 << " Bz: " << Bz << endl;
+        }
       }
     }
-    if (isSinglePoint) ++nPoints;
+    if (isSinglePoint)
+      ++nPoints;
   }
 
-  if (PRINT) cout << "  file " << name << endl;
-  if (PRINT) cout << "  # lines = " << nLines << "  # points = " << nPoints;
+  if (PRINT)
+    cout << "  file " << name << endl;
+  if (PRINT)
+    cout << "  # lines = " << nLines << "  # points = " << nPoints;
   if (nLines == nPoints) {
-    if (PRINT) cout << "  -->  PASSED" << endl;
-  }
-  else {
-    if (PRINT) cout << "  -->  FAILED" << endl;
+    if (PRINT)
+      cout << "  -->  PASSED" << endl;
+  } else {
+    if (PRINT)
+      cout << "  -->  FAILED" << endl;
   }
 
   return;
 }
 
-
-void prepareMagneticFieldGrid::fillFromFile(const std::string& name){
-
-  double phi=(rotateSector-1)*Geom::pi()/6.;
+void prepareMagneticFieldGrid::fillFromFile(const std::string &name) {
+  double phi = (rotateSector - 1) * Geom::pi() / 6.;
   double sphi = sin(-phi);
   double cphi = cos(-phi);
 
   // check, whether coordinates are Cartesian or cylindrical
   std::string::size_type ibeg, iend;
-  ibeg = name.find('-');  // first occurance of "-"
-  iend = name.rfind('-'); // last  occurance of "-"
-  if  ((name.substr(ibeg+1, iend-ibeg-1)) == "xyz") {
+  ibeg = name.find('-');   // first occurance of "-"
+  iend = name.rfind('-');  // last  occurance of "-"
+  if ((name.substr(ibeg + 1, iend - ibeg - 1)) == "xyz") {
     XyzCoordinates = true;
-  } else if  ((name.substr(ibeg+1, iend-ibeg-1)) == "rpz") {
+  } else if ((name.substr(ibeg + 1, iend - ibeg - 1)) == "rpz") {
     RpzCoordinates = true;
   } else {
     cout << " Unrecognized input file name: valid formats are *-xyz-* or *-rpz-*" << endl;
@@ -101,95 +104,98 @@ void prepareMagneticFieldGrid::fillFromFile(const std::string& name){
 
   // define vectors of IndexedDoubleVectors
   IndexedDoubleVector XBVector;
-  std::vector<IndexedDoubleVector>  XBValues;
+  std::vector<IndexedDoubleVector> XBValues;
   std::vector<IndexedDoubleVector> IXBValues;
-  std::vector<IndexedDoubleVector>  XBArray;
+  std::vector<IndexedDoubleVector> XBArray;
 
   // vectors for pre analysis
   std::vector<double> valX[3];
-  std::vector<int>    numX[3];
+  std::vector<int> numX[3];
 
   // copy ASCII file to the vector
   int nLines = 0;
-  int     index[3] = {0,0,0};
-  int    nSteps[3] = {0,0,0};
-  double x1,x2,x3,Bx,By,Bz,perm,poten;
+  int index[3] = {0, 0, 0};
+  int nSteps[3] = {0, 0, 0};
+  double x1, x2, x3, Bx, By, Bz, perm, poten;
   std::ifstream file(name.c_str());
-  int n_air  = 0;
+  int n_air = 0;
   int n_iron = 0;
-  
-  if (file.good()) {
-    while (file.good()){
-      file >> x1 >> x2 >> x3 >> Bx >> By >> Bz >> perm >> poten;
-      if (file){
-	if (rotateSector>1) {
-	  if (RpzCoordinates) {
-	    x2 = x2-phi;
-	    if (fabs(x2)>0.78) {
-	      cout << "ERROR: Input coordinates do not belong to sector " << rotateSector 
-		   << " : " << fabs(x2) << endl;
-	      abort();
-	    }
-	  } else {
-	    double x=x1;
-	    double y=x2;	    
-	    x1 = x*cphi-y*sphi;
-	    x2 = x*sphi+y*cphi;
-	    if (fabs(atan2(x2,x1))>0.78) {
-	      cout << "ERROR: Input coordinates do not belong to sector " << rotateSector 
-		   << " : " << atan2(x2,x1) << endl;
-	      abort();
-	    }
-	  }
-	  double Bx0 = Bx;
-	  double By0 = By;	  
-	  Bx = Bx0*cphi-By0*sphi;
-	  By = Bx0*sphi+By0*cphi;
-	  
-	}
-	
-	//	cerr << fixed << x1 << " " <<  x2 << " " <<  x3 << " " <<  Bx << " " <<  By << " " <<  Bz << " " <<  perm << " " <<  poten << " " << endl;
 
-	// Check that the table is homogeneous (ie does not mix perm=1 with perm>>1)	
-	if (perm>1.) ++n_iron;
-	else ++n_air;
+  if (file.good()) {
+    while (file.good()) {
+      file >> x1 >> x2 >> x3 >> Bx >> By >> Bz >> perm >> poten;
+      if (file) {
+        if (rotateSector > 1) {
+          if (RpzCoordinates) {
+            x2 = x2 - phi;
+            if (fabs(x2) > 0.78) {
+              cout << "ERROR: Input coordinates do not belong to sector " << rotateSector << " : " << fabs(x2) << endl;
+              abort();
+            }
+          } else {
+            double x = x1;
+            double y = x2;
+            x1 = x * cphi - y * sphi;
+            x2 = x * sphi + y * cphi;
+            if (fabs(atan2(x2, x1)) > 0.78) {
+              cout << "ERROR: Input coordinates do not belong to sector " << rotateSector << " : " << atan2(x2, x1)
+                   << endl;
+              abort();
+            }
+          }
+          double Bx0 = Bx;
+          double By0 = By;
+          Bx = Bx0 * cphi - By0 * sphi;
+          By = Bx0 * sphi + By0 * cphi;
+        }
+
+        //	cerr << fixed << x1 << " " <<  x2 << " " <<  x3 << " " <<  Bx << " " <<  By << " " <<  Bz << " " <<  perm << " " <<  poten << " " << endl;
+
+        // Check that the table is homogeneous (ie does not mix perm=1 with perm>>1)
+        if (perm > 1.)
+          ++n_iron;
+        else
+          ++n_air;
 
         XBVector.putI3(index[0], index[1], index[2]);
         XBVector.putV6(x1, x2, x3, Bx, By, Bz);
         XBValues.push_back(XBVector);
         ++nLines;
         // pre analyze file content
-        double pnt[3] = {x1,x2,x3};
-        if (nLines == 1){
-	  for (int i=0; i<3; ++i){
-	    valX[i].push_back(pnt[i]);
-	    numX[i].push_back(1);
-	  }
-        }
-        else{
-	  for (int i=0; i<3; ++i){
+        double pnt[3] = {x1, x2, x3};
+        if (nLines == 1) {
+          for (int i = 0; i < 3; ++i) {
+            valX[i].push_back(pnt[i]);
+            numX[i].push_back(1);
+          }
+        } else {
+          for (int i = 0; i < 3; ++i) {
             bool knownValue = false;
-	    for (int j=0; j<(nSteps[i]+1); ++j){
-	      if (std::abs(valX[i].operator[](j) - pnt[i]) < EPSILON) knownValue = true;
-	      if (std::abs(valX[i].operator[](j) - pnt[i]) < EPSILON) numX[i].operator[](j)+=1;
-	    }
-	    if (!knownValue) {
-	      valX[i].push_back(pnt[i]);
-	      nSteps[i]++;
-	      numX[i].push_back(1);
-	    }
-	  }
+            for (int j = 0; j < (nSteps[i] + 1); ++j) {
+              if (std::abs(valX[i].operator[](j) - pnt[i]) < EPSILON)
+                knownValue = true;
+              if (std::abs(valX[i].operator[](j) - pnt[i]) < EPSILON)
+                numX[i].operator[](j) += 1;
+            }
+            if (!knownValue) {
+              valX[i].push_back(pnt[i]);
+              nSteps[i]++;
+              numX[i].push_back(1);
+            }
+          }
         }
       }
     }
-    if (n_air && n_iron)  cout << "WARNING: table " << name << " contains "<< n_air << " points with perm=1 and " << n_iron << " with perm>1" << endl;
-  }
-  else return;
+    if (n_air && n_iron)
+      cout << "WARNING: table " << name << " contains " << n_air << " points with perm=1 and " << n_iron
+           << " with perm>1" << endl;
+  } else
+    return;
 
   // PART I: FOR SIMPLE COORDINATES
 
   // begin simple grid (EasyCoordinate) analysis
-  for (int i=0; i<3; ++i){
+  for (int i = 0; i < 3; ++i) {
     // sort the different values per one coordinate
     sort(valX[i].begin(), valX[i].end());
     // calculate number of points and constant step size
@@ -198,245 +204,272 @@ void prepareMagneticFieldGrid::fillFromFile(const std::string& name){
     BasicDistance0[i] = 9e9;
     double newVal = 0.0;
     double oldVal = 0.0;
-    for (int j=0; j<NumberOfPoints[i]; ++j){
+    for (int j = 0; j < NumberOfPoints[i]; ++j) {
       newVal = valX[i].operator[](j);
-      if (j ==1) BasicDistance0[i] = newVal - oldVal;
-      else if (j > 1){
-	if (std::abs(newVal - oldVal - BasicDistance0[i]) > EPSILON) EasyCoordinate[i] = false;
+      if (j == 1)
+        BasicDistance0[i] = newVal - oldVal;
+      else if (j > 1) {
+        if (std::abs(newVal - oldVal - BasicDistance0[i]) > EPSILON)
+          EasyCoordinate[i] = false;
       }
       oldVal = newVal;
     }
   }
 
   // define indices for easy coordinates
-  for (int iLine=0; iLine<nLines; ++iLine){
+  for (int iLine = 0; iLine < nLines; ++iLine) {
     XBVector = XBValues.operator[](iLine);
     XBVector.getI3(index[0], index[1], index[2]);
     XBVector.getV6(x1, x2, x3, Bx, By, Bz);
-    double pnt[3] = {x1,x2,x3};
-    for (int i=0; i<3; ++i){
-      for (int j=0; j<NumberOfPoints[i]; ++j){
-	if (EasyCoordinate[i]){
-	  if (std::abs(valX[i].operator[](j) - pnt[i]) < EPSILON) index[i] = j;
-	}
+    double pnt[3] = {x1, x2, x3};
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < NumberOfPoints[i]; ++j) {
+        if (EasyCoordinate[i]) {
+          if (std::abs(valX[i].operator[](j) - pnt[i]) < EPSILON)
+            index[i] = j;
+        }
       }
     }
     XBVector.putI3(index[0], index[1], index[2]);
     IXBValues.push_back(XBVector);
   }
-  if (!XBValues.empty()) XBValues.clear();
+  if (!XBValues.empty())
+    XBValues.clear();
 
   // sort according to defined indices
   sort(IXBValues.begin(), IXBValues.end());
 
   // check, if structure is known at this point
-  bool systematicGrid[3] = {false,false,false};
+  bool systematicGrid[3] = {false, false, false};
   KnownStructure = true;
-  if (NumberOfPoints[0]*NumberOfPoints[1]*NumberOfPoints[2] != nLines) KnownStructure = false;
-  for (int i=0; i<3; ++i){
+  if (NumberOfPoints[0] * NumberOfPoints[1] * NumberOfPoints[2] != nLines)
+    KnownStructure = false;
+  for (int i = 0; i < 3; ++i) {
     systematicGrid[i] = EasyCoordinate[i];
-      if (!systematicGrid[i]) KnownStructure = false;
+    if (!systematicGrid[i])
+      KnownStructure = false;
   }
 
-  if (KnownStructure == true){
-    for (int iLine=0; iLine<nLines; ++iLine){
+  if (KnownStructure == true) {
+    for (int iLine = 0; iLine < nLines; ++iLine) {
       XBVector = IXBValues.operator[](iLine);
       XBArray.push_back(XBVector);
     }
   }
 
   // get first point = ReferencePoint (and last point for structure checking)
-  if (!XBArray.empty()) XBVector = XBArray.front();
+  if (!XBArray.empty())
+    XBVector = XBArray.front();
   XBVector.getV6(x1, x2, x3, Bx, By, Bz);
-  double firstListPoint[3] = {x1,x2,x3};
-  if (!XBArray.empty()) XBVector = XBArray.back();
+  double firstListPoint[3] = {x1, x2, x3};
+  if (!XBArray.empty())
+    XBVector = XBArray.back();
   XBVector.getV6(x1, x2, x3, Bx, By, Bz);
-  double secondRefPoint[3] = {x1,x2,x3};
+  double secondRefPoint[3] = {x1, x2, x3};
 
   // recheck all coordinates
   KnownStructure = true;
-  for (int i=0; i<3; ++i){
+  for (int i = 0; i < 3; ++i) {
     ReferencePoint[i] = firstListPoint[i];
     // calculate step size for maximal indices
     double stepSize = BasicDistance0[i];
-    for (int j=0; j<3; ++j){
-      stepSize += BasicDistance1[i][j]*nSteps[j];
+    for (int j = 0; j < 3; ++j) {
+      stepSize += BasicDistance1[i][j] * nSteps[j];
     }
     double offset = 0.0;
-    for (int j=0; j<3; ++j){
-      offset += BasicDistance2[i][j]*nSteps[j];
+    for (int j = 0; j < 3; ++j) {
+      offset += BasicDistance2[i][j] * nSteps[j];
     }
     // calculate difference between the two reference points minus the total difference (=0)
-    double totDiff = secondRefPoint[i] - (ReferencePoint[i] + offset + stepSize*nSteps[i]);
-    if (std::abs(totDiff) < EPSILON*10.) systematicGrid[i] = true;
-    else                         systematicGrid[i] = false;
-    if (!systematicGrid[i]) KnownStructure = false;
+    double totDiff = secondRefPoint[i] - (ReferencePoint[i] + offset + stepSize * nSteps[i]);
+    if (std::abs(totDiff) < EPSILON * 10.)
+      systematicGrid[i] = true;
+    else
+      systematicGrid[i] = false;
+    if (!systematicGrid[i])
+      KnownStructure = false;
   }
 
-  if (KnownStructure){
-    if (XyzCoordinates) GridType = 1;
-    if (RpzCoordinates) GridType = 3;
-    if (PRINT){
+  if (KnownStructure) {
+    if (XyzCoordinates)
+      GridType = 1;
+    if (RpzCoordinates)
+      GridType = 3;
+    if (PRINT) {
       // print result
       cout << "  read " << nLines << " lines -> grid structure:" << endl;
-      cout << "  # of points:   N1 = " << NumberOfPoints[0]
-                         << "   N2 = " << NumberOfPoints[1]
-                         << "   N3 = " << NumberOfPoints[2] << endl; 
-      cout << "  ref. point :   X1 = " << ReferencePoint[0]
-                         << "   X2 = " << ReferencePoint[1]
-                         << "   X3 = " << ReferencePoint[2] << endl; 
-      cout << "  step parm0 :   A1 = " << BasicDistance0[0]
-                         << "   A2 = " << BasicDistance0[1]
-                         << "   A3 = " << BasicDistance0[2] << endl; 
-      cout << "  easy grid  :   E1 = " << EasyCoordinate[0]
-                         << "   E2 = " << EasyCoordinate[1]
-                         << "   E3 = " << EasyCoordinate[2] << endl; 
-      cout << "  structure  :   S1 = " << systematicGrid[0]
-                         << "   S2 = " << systematicGrid[1]
-                         << "   S3 = " << systematicGrid[2]; 
-      if (KnownStructure) cout << "  -->  VALID   (step I)" << endl;
-      else                cout << "  -->  INVALID (step I)" << endl;
+      cout << "  # of points:   N1 = " << NumberOfPoints[0] << "   N2 = " << NumberOfPoints[1]
+           << "   N3 = " << NumberOfPoints[2] << endl;
+      cout << "  ref. point :   X1 = " << ReferencePoint[0] << "   X2 = " << ReferencePoint[1]
+           << "   X3 = " << ReferencePoint[2] << endl;
+      cout << "  step parm0 :   A1 = " << BasicDistance0[0] << "   A2 = " << BasicDistance0[1]
+           << "   A3 = " << BasicDistance0[2] << endl;
+      cout << "  easy grid  :   E1 = " << EasyCoordinate[0] << "   E2 = " << EasyCoordinate[1]
+           << "   E3 = " << EasyCoordinate[2] << endl;
+      cout << "  structure  :   S1 = " << systematicGrid[0] << "   S2 = " << systematicGrid[1]
+           << "   S3 = " << systematicGrid[2];
+      if (KnownStructure)
+        cout << "  -->  VALID   (step I)" << endl;
+      else
+        cout << "  -->  INVALID (step I)" << endl;
     }
   }
 
   // END OF PART I: FOR SIMPLE COORDINATES
   //
   // PART II: FOR MORE COMPLICATED COORDINATES
-  bool goodIndex[3] = {true,true,true};
+  bool goodIndex[3] = {true, true, true};
 
-  if (!KnownStructure){
+  if (!KnownStructure) {
     // analyze structure of missing coordinates
     int nEasy = 0;
-    for (int i=0; i<3; ++i){
-      if (EasyCoordinate[i]) ++nEasy;
+    for (int i = 0; i < 3; ++i) {
+      if (EasyCoordinate[i])
+        ++nEasy;
     }
     std::vector<double> misValX[3];
 
     // try to recover info of missing coordiates
-    if (nEasy > 0){
+    if (nEasy > 0) {
       bool lastLine = false;
       int lowerLineLimit = 0;
       int upperLineLimit = 0;
-      int oldIndex[3] = {0,0,0};
-      for (int iLine=0; iLine<nLines; ++iLine){
-	if (iLine == (nLines-1)) lastLine = true;
+      int oldIndex[3] = {0, 0, 0};
+      for (int iLine = 0; iLine < nLines; ++iLine) {
+        if (iLine == (nLines - 1))
+          lastLine = true;
         XBVector = IXBValues.operator[](iLine);
-	XBVector.getI3(index[0], index[1], index[2]);
-	bool newIndices = false;
-        for (int i=0; i<3; ++i){
-	  if (oldIndex[i] != index[i]){
-	    oldIndex[i] = index[i];
-	    newIndices = true;
-	  }
-	}
-	if (newIndices){
-	  for (int i=0; i<3; ++i){
-	    if (!EasyCoordinate[i]) sort(misValX[i].begin(), misValX[i].end());
-	  }
-	  lowerLineLimit = upperLineLimit;
-	  upperLineLimit = iLine;
-	  for (int jLine=lowerLineLimit; jLine<upperLineLimit; ++jLine){
-	    XBVector = IXBValues.operator[](jLine);
-	    XBVector.getI3(index[0], index[1], index[2]);
-	    XBVector.getV6(x1, x2, x3, Bx, By, Bz);
-	    double pnt[3] = {x1,x2,x3};
-	    for (int i=0; i<3; ++i){
-	      if (!EasyCoordinate[i]){
-		double thisVal = 0.; double lastVal = 0.; double deltVal = 0.;
-		for (int j=0; j<NumberOfPoints[i]; ++j){
+        XBVector.getI3(index[0], index[1], index[2]);
+        bool newIndices = false;
+        for (int i = 0; i < 3; ++i) {
+          if (oldIndex[i] != index[i]) {
+            oldIndex[i] = index[i];
+            newIndices = true;
+          }
+        }
+        if (newIndices) {
+          for (int i = 0; i < 3; ++i) {
+            if (!EasyCoordinate[i])
+              sort(misValX[i].begin(), misValX[i].end());
+          }
+          lowerLineLimit = upperLineLimit;
+          upperLineLimit = iLine;
+          for (int jLine = lowerLineLimit; jLine < upperLineLimit; ++jLine) {
+            XBVector = IXBValues.operator[](jLine);
+            XBVector.getI3(index[0], index[1], index[2]);
+            XBVector.getV6(x1, x2, x3, Bx, By, Bz);
+            double pnt[3] = {x1, x2, x3};
+            for (int i = 0; i < 3; ++i) {
+              if (!EasyCoordinate[i]) {
+                double thisVal = 0.;
+                double lastVal = 0.;
+                double deltVal = 0.;
+                for (int j = 0; j < NumberOfPoints[i]; ++j) {
                   thisVal = misValX[i].operator[](j);
-		  if (std::abs(thisVal - pnt[i]) < EPSILON) index[i] = j;
-		  if (j ==1) deltVal = thisVal - lastVal;
-		  else if (j > 1){
-		    if (std::abs(thisVal - lastVal - deltVal) > EPSILON) goodIndex[i] = false;
-		  }
-		  lastVal = thisVal;
-		}
-	      }
-	    }
-	    XBVector.putI3(index[0], index[1], index[2]);
-	    XBArray.push_back(XBVector);
-	    for (int i=0; i<3; ++i){
-	      if (!misValX[i].empty()) misValX[i].clear();
-	    }
-	  }
-	}
+                  if (std::abs(thisVal - pnt[i]) < EPSILON)
+                    index[i] = j;
+                  if (j == 1)
+                    deltVal = thisVal - lastVal;
+                  else if (j > 1) {
+                    if (std::abs(thisVal - lastVal - deltVal) > EPSILON)
+                      goodIndex[i] = false;
+                  }
+                  lastVal = thisVal;
+                }
+              }
+            }
+            XBVector.putI3(index[0], index[1], index[2]);
+            XBArray.push_back(XBVector);
+            for (int i = 0; i < 3; ++i) {
+              if (!misValX[i].empty())
+                misValX[i].clear();
+            }
+          }
+        }
         XBVector = IXBValues.operator[](iLine);
         XBVector.getV6(x1, x2, x3, Bx, By, Bz);
-        double pnt[3] = {x1,x2,x3};
-        for (int i=0; i<3; ++i){
-          if (!EasyCoordinate[i]){
-	    if (iLine == 0){
-	      NumberOfPoints[i] = 1;
-	      misValX[i].push_back(pnt[i]);
-	    }
-	    else if (newIndices){
-	      NumberOfPoints[i] = 1;
-	      misValX[i].push_back(pnt[i]);
-	    }
-	    else{
-	      bool knownValue = false;
-	      for (int j=0; j<NumberOfPoints[i]; ++j){
-		if (std::abs(misValX[i].operator[](j) - pnt[i]) < EPSILON) knownValue = true;
-	      }
-	      if (!knownValue){
-		++NumberOfPoints[i];
-		misValX[i].push_back(pnt[i]);
-	      }
-	    }
-	  }
-	}
-	if (lastLine){
-	  for (int i=0; i<3; ++i){
-	    if (!EasyCoordinate[i]) sort(misValX[i].begin(), misValX[i].end());
-	  }
-	  lowerLineLimit = upperLineLimit;
-	  upperLineLimit = nLines;
-	  for (int jLine=lowerLineLimit; jLine<upperLineLimit; ++jLine){
-	    XBVector = IXBValues.operator[](jLine);
-	    XBVector.getI3(index[0], index[1], index[2]);
-	    XBVector.getV6(x1, x2, x3, Bx, By, Bz);
-	    double pnt[3] = {x1,x2,x3};
-	    for (int i=0; i<3; ++i){
-	      if (!EasyCoordinate[i]){
-		double thisVal = 0.; double lastVal = 0.; double deltVal = 0.;
-		for (int j=0; j<NumberOfPoints[i]; ++j){
+        double pnt[3] = {x1, x2, x3};
+        for (int i = 0; i < 3; ++i) {
+          if (!EasyCoordinate[i]) {
+            if (iLine == 0) {
+              NumberOfPoints[i] = 1;
+              misValX[i].push_back(pnt[i]);
+            } else if (newIndices) {
+              NumberOfPoints[i] = 1;
+              misValX[i].push_back(pnt[i]);
+            } else {
+              bool knownValue = false;
+              for (int j = 0; j < NumberOfPoints[i]; ++j) {
+                if (std::abs(misValX[i].operator[](j) - pnt[i]) < EPSILON)
+                  knownValue = true;
+              }
+              if (!knownValue) {
+                ++NumberOfPoints[i];
+                misValX[i].push_back(pnt[i]);
+              }
+            }
+          }
+        }
+        if (lastLine) {
+          for (int i = 0; i < 3; ++i) {
+            if (!EasyCoordinate[i])
+              sort(misValX[i].begin(), misValX[i].end());
+          }
+          lowerLineLimit = upperLineLimit;
+          upperLineLimit = nLines;
+          for (int jLine = lowerLineLimit; jLine < upperLineLimit; ++jLine) {
+            XBVector = IXBValues.operator[](jLine);
+            XBVector.getI3(index[0], index[1], index[2]);
+            XBVector.getV6(x1, x2, x3, Bx, By, Bz);
+            double pnt[3] = {x1, x2, x3};
+            for (int i = 0; i < 3; ++i) {
+              if (!EasyCoordinate[i]) {
+                double thisVal = 0.;
+                double lastVal = 0.;
+                double deltVal = 0.;
+                for (int j = 0; j < NumberOfPoints[i]; ++j) {
                   thisVal = misValX[i].operator[](j);
-		  if (std::abs(thisVal - pnt[i]) < EPSILON) index[i] = j;
-		  if (j ==1) deltVal = thisVal - lastVal;
-		  else if (j > 1){
-		    if (std::abs(thisVal - lastVal - deltVal) > EPSILON) goodIndex[i] = false;
-		  }
-		  lastVal = thisVal;
-		}
-	      }
-	    }
-	    XBVector.putI3(index[0], index[1], index[2]);
-	    XBArray.push_back(XBVector);
-	    for (int i=0; i<3; ++i){
-	      if (!misValX[i].empty()) misValX[i].clear();
-	    }
-	  }
-	}
+                  if (std::abs(thisVal - pnt[i]) < EPSILON)
+                    index[i] = j;
+                  if (j == 1)
+                    deltVal = thisVal - lastVal;
+                  else if (j > 1) {
+                    if (std::abs(thisVal - lastVal - deltVal) > EPSILON)
+                      goodIndex[i] = false;
+                  }
+                  lastVal = thisVal;
+                }
+              }
+            }
+            XBVector.putI3(index[0], index[1], index[2]);
+            XBArray.push_back(XBVector);
+            for (int i = 0; i < 3; ++i) {
+              if (!misValX[i].empty())
+                misValX[i].clear();
+            }
+          }
+        }
       }
     }
     int nGoodInd = 0;
-    for (int i=0; i<3; ++i){
-      if (goodIndex[i]) ++nGoodInd;
+    for (int i = 0; i < 3; ++i) {
+      if (goodIndex[i])
+        ++nGoodInd;
     }
     // try to recover info of last missing coordiates
-    if (nGoodInd < 3){
+    if (nGoodInd < 3) {
       cout << endl;
       cout << "Neasy = 1: beginning of T E S T area!" << endl;
       cout << "# good indices = " << nGoodInd << " (" << goodIndex[0] << goodIndex[1] << goodIndex[2] << ") " << endl;
       // reset wrong indices and sort
-      for (int iLine=0; iLine<nLines; ++iLine){
-	XBVector = XBArray.operator[](iLine);
-	XBVector.getI3(index[0], index[1], index[2]);
-	for (int i=0; i<3; ++i){
-	  if (!goodIndex[i]) index[i] = 0;
-	}
-	XBVector.putI3(index[0], index[1], index[2]);
+      for (int iLine = 0; iLine < nLines; ++iLine) {
+        XBVector = XBArray.operator[](iLine);
+        XBVector.getI3(index[0], index[1], index[2]);
+        for (int i = 0; i < 3; ++i) {
+          if (!goodIndex[i])
+            index[i] = 0;
+        }
+        XBVector.putI3(index[0], index[1], index[2]);
       }
       sort(XBArray.begin(), XBArray.end());
 
@@ -444,23 +477,23 @@ void prepareMagneticFieldGrid::fillFromFile(const std::string& name){
       cout << endl;
     }
     // common part of missing coordiate(s) recovery (1 or 2 missing)
-    if (nEasy > 0){
+    if (nEasy > 0) {
       // sort without resetting of indices
       sort(XBArray.begin(), XBArray.end());
 
-      double miniGrid[3][2][2][2] = {{{{0.,0.},{0.,0.}},{{0.,0.},{0.,0.}}},
-                                     {{{0.,0.},{0.,0.}},{{0.,0.},{0.,0.}}},
-                                     {{{0.,0.},{0.,0.}},{{0.,0.},{0.,0.}}}};
-      for (int iLine=0; iLine<nLines; ++iLine){
-	XBVector = XBArray.operator[](iLine);
-	XBVector.getI3(index[0], index[1], index[2]);
-	XBVector.getV6(x1, x2, x3, Bx, By, Bz);
-	double pnt[3] = {x1,x2,x3};
-        if (index[0] < 2 && index[1] < 2 && index[2] < 2){
-       	for (int i=0; i<3; ++i){
+      double miniGrid[3][2][2][2] = {{{{0., 0.}, {0., 0.}}, {{0., 0.}, {0., 0.}}},
+                                     {{{0., 0.}, {0., 0.}}, {{0., 0.}, {0., 0.}}},
+                                     {{{0., 0.}, {0., 0.}}, {{0., 0.}, {0., 0.}}}};
+      for (int iLine = 0; iLine < nLines; ++iLine) {
+        XBVector = XBArray.operator[](iLine);
+        XBVector.getI3(index[0], index[1], index[2]);
+        XBVector.getV6(x1, x2, x3, Bx, By, Bz);
+        double pnt[3] = {x1, x2, x3};
+        if (index[0] < 2 && index[1] < 2 && index[2] < 2) {
+          for (int i = 0; i < 3; ++i) {
             miniGrid[i][index[0]][index[1]][index[2]] = pnt[i];
-	  }
-	}
+          }
+        }
       }
       // basic distances (sorry, I have found no smarter solution so far)
       // recalculate constant terms for step size from miniGrid[3][2][2][2]
@@ -497,18 +530,21 @@ void prepareMagneticFieldGrid::fillFromFile(const std::string& name){
       BasicDistance2[2][1] = miniGrid[2][0][1][0] - miniGrid[2][0][0][0];
       BasicDistance2[2][2] = 0.0;
       // set default values of BasicDistance0 in case of < 2 points
-      for (int i=0; i<3; ++i){
-        if (NumberOfPoints[i] < 2) BasicDistance0[i] = 9e9;
+      for (int i = 0; i < 3; ++i) {
+        if (NumberOfPoints[i] < 2)
+          BasicDistance0[i] = 9e9;
       }
     }
 
     // get first point = ReferencePoint (and last point for structure checking)
-    if (!XBArray.empty()) XBVector = XBArray.front();
+    if (!XBArray.empty())
+      XBVector = XBArray.front();
     XBVector.getV6(x1, x2, x3, Bx, By, Bz);
     firstListPoint[0] = x1;
     firstListPoint[1] = x2;
     firstListPoint[2] = x3;
-    if (!XBArray.empty()) XBVector = XBArray.back();
+    if (!XBArray.empty())
+      XBVector = XBArray.back();
     XBVector.getV6(x1, x2, x3, Bx, By, Bz);
     secondRefPoint[0] = x1;
     secondRefPoint[1] = x2;
@@ -516,77 +552,71 @@ void prepareMagneticFieldGrid::fillFromFile(const std::string& name){
 
     // recheck all coordinates
     KnownStructure = true;
-    for (int i=0; i<3; ++i){
+    for (int i = 0; i < 3; ++i) {
       ReferencePoint[i] = firstListPoint[i];
-      nSteps[i] = NumberOfPoints[i]-1;
+      nSteps[i] = NumberOfPoints[i] - 1;
       // calculate step size for maximal indices
       double stepSize = BasicDistance0[i];
-      for (int j=0; j<3; ++j){
-        stepSize += BasicDistance1[i][j]*nSteps[j];
+      for (int j = 0; j < 3; ++j) {
+        stepSize += BasicDistance1[i][j] * nSteps[j];
       }
       double offset = 0.0;
-      for (int j=0; j<3; ++j){
-        offset += BasicDistance2[i][j]*nSteps[j];
+      for (int j = 0; j < 3; ++j) {
+        offset += BasicDistance2[i][j] * nSteps[j];
       }
       // calculate difference between the two reference points minus the total difference (=0)
-      double totDiff = secondRefPoint[i] - (ReferencePoint[i] + offset + stepSize*nSteps[i]);
-      if (std::abs(totDiff) < EPSILON*10.) systematicGrid[i] = true;
-      else                         systematicGrid[i] = false;
-      if (!systematicGrid[i]) KnownStructure = false;
+      double totDiff = secondRefPoint[i] - (ReferencePoint[i] + offset + stepSize * nSteps[i]);
+      if (std::abs(totDiff) < EPSILON * 10.)
+        systematicGrid[i] = true;
+      else
+        systematicGrid[i] = false;
+      if (!systematicGrid[i])
+        KnownStructure = false;
     }
 
-    if (KnownStructure){
-      if (XyzCoordinates) GridType = 2;
-      if (RpzCoordinates) GridType = 4;
-      if (PRINT){
+    if (KnownStructure) {
+      if (XyzCoordinates)
+        GridType = 2;
+      if (RpzCoordinates)
+        GridType = 4;
+      if (PRINT) {
         // print result
         cout << "  read " << nLines << " lines -> grid structure:" << endl;
-        cout << "  # of points:   N1 = " << NumberOfPoints[0]
-                           << "   N2 = " << NumberOfPoints[1]
-                           << "   N3 = " << NumberOfPoints[2] << endl; 
-        cout << "  ref. point :   X1 = " << ReferencePoint[0]
-                           << "   X2 = " << ReferencePoint[1]
-                           << "   X3 = " << ReferencePoint[2] << endl; 
-        cout << "  step parm0 :   A1 = " << BasicDistance0[0]
-                           << "   A2 = " << BasicDistance0[1]
-                           << "   A3 = " << BasicDistance0[2] << endl; 
-        cout << "  step parm1 :  B11 = " << BasicDistance1[0][0]
-                           << "  B21 = " << BasicDistance1[1][0]
-                           << "  B31 = " << BasicDistance1[2][0] << endl; 
-        cout << "             :  B12 = " << BasicDistance1[0][1]
-                           << "  B22 = " << BasicDistance1[1][1]
-                           << "  B32 = " << BasicDistance1[2][1] << endl;
-        cout << "             :  B13 = " << BasicDistance1[0][2]
-                           << "  B23 = " << BasicDistance1[1][2]
-                           << "  B33 = " << BasicDistance1[2][2] << endl; 
-        cout << "  offset parm:  O11 = " << BasicDistance2[0][0]
-                           << "  O21 = " << BasicDistance2[1][0]
-                           << "  O31 = " << BasicDistance2[2][0] << endl; 
-        cout << "             :  O12 = " << BasicDistance2[0][1]
-                           << "  O22 = " << BasicDistance2[1][1]
-                           << "  O32 = " << BasicDistance2[2][1] << endl;
-        cout << "             :  O13 = " << BasicDistance2[0][2]
-                           << "  O23 = " << BasicDistance2[1][2]
-                           << "  O33 = " << BasicDistance2[2][2] << endl; 
-        cout << "  easy grid  :   E1 = " << EasyCoordinate[0]
-                           << "   E2 = " << EasyCoordinate[1]
-                           << "   E3 = " << EasyCoordinate[2] << endl; 
-        cout << "             :   I1 = " << goodIndex[0]
-                           << "   I2 = " << goodIndex[1]
-                           << "   I3 = " << goodIndex[2] << endl; 
-        cout << "  structure  :   S1 = " << systematicGrid[0]
-                           << "   S2 = " << systematicGrid[1]
-                           << "   S3 = " << systematicGrid[2]; 
-        if (KnownStructure) cout << "  -->  VALID   (step II)" << endl;
-        else{               cout << "  -->  INVALID (step II)" << endl;
+        cout << "  # of points:   N1 = " << NumberOfPoints[0] << "   N2 = " << NumberOfPoints[1]
+             << "   N3 = " << NumberOfPoints[2] << endl;
+        cout << "  ref. point :   X1 = " << ReferencePoint[0] << "   X2 = " << ReferencePoint[1]
+             << "   X3 = " << ReferencePoint[2] << endl;
+        cout << "  step parm0 :   A1 = " << BasicDistance0[0] << "   A2 = " << BasicDistance0[1]
+             << "   A3 = " << BasicDistance0[2] << endl;
+        cout << "  step parm1 :  B11 = " << BasicDistance1[0][0] << "  B21 = " << BasicDistance1[1][0]
+             << "  B31 = " << BasicDistance1[2][0] << endl;
+        cout << "             :  B12 = " << BasicDistance1[0][1] << "  B22 = " << BasicDistance1[1][1]
+             << "  B32 = " << BasicDistance1[2][1] << endl;
+        cout << "             :  B13 = " << BasicDistance1[0][2] << "  B23 = " << BasicDistance1[1][2]
+             << "  B33 = " << BasicDistance1[2][2] << endl;
+        cout << "  offset parm:  O11 = " << BasicDistance2[0][0] << "  O21 = " << BasicDistance2[1][0]
+             << "  O31 = " << BasicDistance2[2][0] << endl;
+        cout << "             :  O12 = " << BasicDistance2[0][1] << "  O22 = " << BasicDistance2[1][1]
+             << "  O32 = " << BasicDistance2[2][1] << endl;
+        cout << "             :  O13 = " << BasicDistance2[0][2] << "  O23 = " << BasicDistance2[1][2]
+             << "  O33 = " << BasicDistance2[2][2] << endl;
+        cout << "  easy grid  :   E1 = " << EasyCoordinate[0] << "   E2 = " << EasyCoordinate[1]
+             << "   E3 = " << EasyCoordinate[2] << endl;
+        cout << "             :   I1 = " << goodIndex[0] << "   I2 = " << goodIndex[1] << "   I3 = " << goodIndex[2]
+             << endl;
+        cout << "  structure  :   S1 = " << systematicGrid[0] << "   S2 = " << systematicGrid[1]
+             << "   S3 = " << systematicGrid[2];
+        if (KnownStructure)
+          cout << "  -->  VALID   (step II)" << endl;
+        else {
+          cout << "  -->  INVALID (step II)" << endl;
           cout << "  reason for error: ";
-          if (NumberOfPoints[0]*NumberOfPoints[1]*NumberOfPoints[2] != nLines) {
+          if (NumberOfPoints[0] * NumberOfPoints[1] * NumberOfPoints[2] != nLines) {
             cout << endl;
             cout << "  N1*N2*N3 =/= N.lines  -->  exiting now ..." << endl;
             return;
-          }
-          else {
-	    cout << "  no idea so far  -->  exiting now ..." << endl;
+          } else {
+            cout << "  no idea so far  -->  exiting now ..." << endl;
             return;
           }
         }
@@ -597,87 +627,82 @@ void prepareMagneticFieldGrid::fillFromFile(const std::string& name){
 
   // save coordinates and field values
   SixDPoint GridEntry;
-  for (unsigned int iLine=0; iLine<XBArray.size(); ++iLine){
+  for (unsigned int iLine = 0; iLine < XBArray.size(); ++iLine) {
     XBVector = XBArray.operator[](iLine);
     XBVector.getV6(x1, x2, x3, Bx, By, Bz);
     GridEntry.putP6(x1, x2, x3, Bx, By, Bz);
     GridData.push_back(GridEntry);
   }
-  if (!XBArray.empty()) XBArray.clear();
+  if (!XBArray.empty())
+    XBArray.clear();
 
   return;
 }
 
-
-void prepareMagneticFieldGrid::fillFromFileSpecial(const std::string& name){
-
+void prepareMagneticFieldGrid::fillFromFileSpecial(const std::string &name) {
   // GridType = 5; // 1/sin(phi) coordinates. Obsolete, not used anymore.
-  GridType = 6; // 1/cos(phi) coordinates.
+  GridType = 6;  // 1/cos(phi) coordinates.
 
-  double phi=(rotateSector-1)*Geom::pi()/6.;
+  double phi = (rotateSector - 1) * Geom::pi() / 6.;
   double sphi = sin(-phi);
   double cphi = cos(-phi);
 
   // check, whether coordinates are Cartesian or cylindrical
   std::string::size_type ibeg, iend;
-  ibeg = name.find('-');  // first occurance of "-"
-  iend = name.rfind('-'); // last  occurance of "-"
-  if  ((name.substr(ibeg+1, iend-ibeg-1)) == "xyz") {
+  ibeg = name.find('-');   // first occurance of "-"
+  iend = name.rfind('-');  // last  occurance of "-"
+  if ((name.substr(ibeg + 1, iend - ibeg - 1)) == "xyz") {
     XyzCoordinates = true;
-  } else if  ((name.substr(ibeg+1, iend-ibeg-1)) == "rpz") {
+  } else if ((name.substr(ibeg + 1, iend - ibeg - 1)) == "rpz") {
     RpzCoordinates = true;
   } else {
     cout << " Unrecognized input file name: valid formats are *-xyz-* or *-rpz-*" << endl;
     abort();
   }
 
-
-
   // define vectors of IndexedDoubleVectors
   IndexedDoubleVector XBVector;
-  std::vector<IndexedDoubleVector>  XBValues;
+  std::vector<IndexedDoubleVector> XBValues;
   std::vector<IndexedDoubleVector> IXBValues;
-  std::vector<IndexedDoubleVector>  XBArray;
+  std::vector<IndexedDoubleVector> XBArray;
 
   // vectors for pre analysis
   std::vector<double> valX[3];
-  std::vector<int>    numX[3];
+  std::vector<int> numX[3];
 
   // copy ASCII file to the vector
   int nLines = 0;
-  int     index[3] = {0,0,0};
-  int    nSteps[3] = {0,0,0};
-  double x1,x2,x3,Bx,By,Bz,perm,poten;
+  int index[3] = {0, 0, 0};
+  int nSteps[3] = {0, 0, 0};
+  double x1, x2, x3, Bx, By, Bz, perm, poten;
   std::ifstream file(name.c_str());
   if (file.good()) {
-    while (file.good()){
+    while (file.good()) {
       file >> x1 >> x2 >> x3 >> Bx >> By >> Bz >> perm >> poten;
-      if (file){
-	if (rotateSector>1) {
-	  if (RpzCoordinates) {
-	    x2 = x2-phi;
-	    if (fabs(x2)>0.78) {
-	      cout << "ERROR: Input coordinates do not belong to sector " << rotateSector 
-		   << " : " << x2 << endl;
-	      abort();
-	    }
-	  } else {
-	    double x=x1;
-	    double y=x2;	    
-	    x1 = x*cphi-y*sphi;
-	    x2 = x*sphi+y*cphi;
-	    if (fabs(atan2(x2,x1))>0.78) {
-	      cout << "ERROR: Input coordinates do not belong to sector " << rotateSector 
-		   << " : " << atan2(x2,x1) << endl;
-	      abort();
-	    }
-	  }
-	  double Bx0 = Bx;
-	  double By0 = By;	  
-	  Bx = Bx0*cphi-By0*sphi;
-	  By = Bx0*sphi+By0*cphi;
-	  
-	}
+      if (file) {
+        if (rotateSector > 1) {
+          if (RpzCoordinates) {
+            x2 = x2 - phi;
+            if (fabs(x2) > 0.78) {
+              cout << "ERROR: Input coordinates do not belong to sector " << rotateSector << " : " << x2 << endl;
+              abort();
+            }
+          } else {
+            double x = x1;
+            double y = x2;
+            x1 = x * cphi - y * sphi;
+            x2 = x * sphi + y * cphi;
+            if (fabs(atan2(x2, x1)) > 0.78) {
+              cout << "ERROR: Input coordinates do not belong to sector " << rotateSector << " : " << atan2(x2, x1)
+                   << endl;
+              abort();
+            }
+          }
+          double Bx0 = Bx;
+          double By0 = By;
+          Bx = Bx0 * cphi - By0 * sphi;
+          By = Bx0 * sphi + By0 * cphi;
+        }
 
         XBVector.putI3(index[0], index[1], index[2]);
         XBVector.putV6(x1, x2, x3, Bx, By, Bz);
@@ -685,34 +710,35 @@ void prepareMagneticFieldGrid::fillFromFileSpecial(const std::string& name){
         ++nLines;
 
         // pre analyze file content
-        double pnt[3] = {x1,x2,x3};
-        if (nLines == 1){
-	  for (int i=0; i<3; ++i){
-	    valX[i].push_back(pnt[i]);
-	    numX[i].push_back(1);
-	  }
-        }
-        else{
-	  for (int i=0; i<3; ++i){
+        double pnt[3] = {x1, x2, x3};
+        if (nLines == 1) {
+          for (int i = 0; i < 3; ++i) {
+            valX[i].push_back(pnt[i]);
+            numX[i].push_back(1);
+          }
+        } else {
+          for (int i = 0; i < 3; ++i) {
             bool knownValue = false;
-	    for (int j=0; j<(nSteps[i]+1); ++j){
-	      if (std::abs(valX[i].operator[](j) - pnt[i]) < EPSILON) knownValue = true;
-	      if (std::abs(valX[i].operator[](j) - pnt[i]) < EPSILON) numX[i].operator[](j)+=1;
-	    }
-	    if (!knownValue) {
-	      valX[i].push_back(pnt[i]);
-	      nSteps[i]++;
-	      numX[i].push_back(1);
-	    }
-	  }
+            for (int j = 0; j < (nSteps[i] + 1); ++j) {
+              if (std::abs(valX[i].operator[](j) - pnt[i]) < EPSILON)
+                knownValue = true;
+              if (std::abs(valX[i].operator[](j) - pnt[i]) < EPSILON)
+                numX[i].operator[](j) += 1;
+            }
+            if (!knownValue) {
+              valX[i].push_back(pnt[i]);
+              nSteps[i]++;
+              numX[i].push_back(1);
+            }
+          }
         }
       }
     }
-  }
-  else return;
+  } else
+    return;
 
   // begin simple grid (EasyCoordinate) analysis
-  for (int i=0; i<3; ++i){
+  for (int i = 0; i < 3; ++i) {
     // sort the different values per one coordinate
     sort(valX[i].begin(), valX[i].end());
     // calculate number of points and constant step size
@@ -721,11 +747,13 @@ void prepareMagneticFieldGrid::fillFromFileSpecial(const std::string& name){
     BasicDistance0[i] = 9e9;
     double newVal = 0.0;
     double oldVal = 0.0;
-    for (int j=0; j<NumberOfPoints[i]; ++j){
+    for (int j = 0; j < NumberOfPoints[i]; ++j) {
       newVal = valX[i].operator[](j);
-      if (j ==1) BasicDistance0[i] = newVal - oldVal;
-      else if (j > 1){
-	if (std::abs(newVal - oldVal - BasicDistance0[i]) > EPSILON) EasyCoordinate[i] = false;
+      if (j == 1)
+        BasicDistance0[i] = newVal - oldVal;
+      else if (j > 1) {
+        if (std::abs(newVal - oldVal - BasicDistance0[i]) > EPSILON)
+          EasyCoordinate[i] = false;
       }
       oldVal = newVal;
     }
@@ -734,250 +762,283 @@ void prepareMagneticFieldGrid::fillFromFileSpecial(const std::string& name){
   std::cout << std::endl;
 
   // define indices for easy coordinates
-  for (int iLine=0; iLine<nLines; ++iLine){
+  for (int iLine = 0; iLine < nLines; ++iLine) {
     XBVector = XBValues.operator[](iLine);
     XBVector.getI3(index[0], index[1], index[2]);
     XBVector.getV6(x1, x2, x3, Bx, By, Bz);
-    double pnt[3] = {x1,x2,x3};
-    for (int i=0; i<3; ++i){
-      for (int j=0; j<NumberOfPoints[i]; ++j){
-	if (EasyCoordinate[i]){
-	  if (std::abs(valX[i].operator[](j) - pnt[i]) < EPSILON) index[i] = j;
-	}
+    double pnt[3] = {x1, x2, x3};
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < NumberOfPoints[i]; ++j) {
+        if (EasyCoordinate[i]) {
+          if (std::abs(valX[i].operator[](j) - pnt[i]) < EPSILON)
+            index[i] = j;
+        }
       }
     }
     XBVector.putI3(index[0], index[1], index[2]);
     IXBValues.push_back(XBVector);
   }
-  if (!XBValues.empty()) XBValues.clear();
+  if (!XBValues.empty())
+    XBValues.clear();
 
   // sort according to defined indices
   sort(IXBValues.begin(), IXBValues.end());
 
   // check, if structure is known at this point
-  bool systematicGrid[3] = {false,false,false};
+  bool systematicGrid[3] = {false, false, false};
   KnownStructure = true;
-  if (NumberOfPoints[0]*NumberOfPoints[1]*NumberOfPoints[2] != nLines) KnownStructure = false;
-  for (int i=0; i<3; ++i){
+  if (NumberOfPoints[0] * NumberOfPoints[1] * NumberOfPoints[2] != nLines)
+    KnownStructure = false;
+  for (int i = 0; i < 3; ++i) {
     systematicGrid[i] = EasyCoordinate[i];
-      if (!systematicGrid[i]) KnownStructure = false;
+    if (!systematicGrid[i])
+      KnownStructure = false;
   }
 
-  if (KnownStructure == true){
-    for (int iLine=0; iLine<nLines; ++iLine){
+  if (KnownStructure == true) {
+    for (int iLine = 0; iLine < nLines; ++iLine) {
       XBVector = IXBValues.operator[](iLine);
       XBArray.push_back(XBVector);
     }
   }
 
   // get first point = ReferencePoint (and last point for structure checking)
-  if (!XBArray.empty()) XBVector = XBArray.front();
+  if (!XBArray.empty())
+    XBVector = XBArray.front();
   XBVector.getV6(x1, x2, x3, Bx, By, Bz);
-  double firstListPoint[3] = {x1,x2,x3};
-  if (!XBArray.empty()) XBVector = XBArray.back();
+  double firstListPoint[3] = {x1, x2, x3};
+  if (!XBArray.empty())
+    XBVector = XBArray.back();
   XBVector.getV6(x1, x2, x3, Bx, By, Bz);
-  double secondRefPoint[3] = {x1,x2,x3};
+  double secondRefPoint[3] = {x1, x2, x3};
 
   // recheck all coordinates
   KnownStructure = true;
-  for (int i=0; i<3; ++i){
+  for (int i = 0; i < 3; ++i) {
     ReferencePoint[i] = firstListPoint[i];
     // calculate step size for maximal indices
     double stepSize = BasicDistance0[i];
     // calculate difference between the two reference points minus the total difference (=0)
-    double totDiff = secondRefPoint[i] - (ReferencePoint[i] + stepSize*nSteps[i]);
-    if (std::abs(totDiff) < EPSILON*10.) systematicGrid[i] = true;
-    else                         systematicGrid[i] = false;
-    if (!systematicGrid[i]) KnownStructure = false;
+    double totDiff = secondRefPoint[i] - (ReferencePoint[i] + stepSize * nSteps[i]);
+    if (std::abs(totDiff) < EPSILON * 10.)
+      systematicGrid[i] = true;
+    else
+      systematicGrid[i] = false;
+    if (!systematicGrid[i])
+      KnownStructure = false;
   }
-  bool goodIndex[3] = {true,true,true};
+  bool goodIndex[3] = {true, true, true};
 
-  if (!KnownStructure){
+  if (!KnownStructure) {
     // analyze structure of missing coordinates
     int nEasy = 0;
-    for (int i=0; i<3; ++i){
-      if (EasyCoordinate[i]) ++nEasy;
+    for (int i = 0; i < 3; ++i) {
+      if (EasyCoordinate[i])
+        ++nEasy;
     }
     std::vector<double> misValX[3];
 
     // try to recover info of missing coordiates
-    if (nEasy > 0){
+    if (nEasy > 0) {
       bool lastLine = false;
       int lowerLineLimit = 0;
       int upperLineLimit = 0;
-      int oldIndex[3] = {0,0,0};
-      for (int iLine=0; iLine<nLines; ++iLine){
-	if (iLine == (nLines-1)) lastLine = true;
+      int oldIndex[3] = {0, 0, 0};
+      for (int iLine = 0; iLine < nLines; ++iLine) {
+        if (iLine == (nLines - 1))
+          lastLine = true;
         XBVector = IXBValues.operator[](iLine);
-	XBVector.getI3(index[0], index[1], index[2]);
-	bool newIndices = false;
-        for (int i=0; i<3; ++i){
-	  if (oldIndex[i] != index[i]){
-	    oldIndex[i] = index[i];
-	    newIndices = true;
-	  }
-	}
-	if (newIndices){
-	  for (int i=0; i<3; ++i){
-	    if (!EasyCoordinate[i]) sort(misValX[i].begin(), misValX[i].end());
-	  }
-	  lowerLineLimit = upperLineLimit;
-	  upperLineLimit = iLine;
-	  for (int jLine=lowerLineLimit; jLine<upperLineLimit; ++jLine){
-	    XBVector = IXBValues.operator[](jLine);
-	    XBVector.getI3(index[0], index[1], index[2]);
-	    XBVector.getV6(x1, x2, x3, Bx, By, Bz);
-	    double pnt[3] = {x1,x2,x3};
-	    for (int i=0; i<3; ++i){
-	      if (!EasyCoordinate[i]){
-		double thisVal = 0.; double lastVal = 0.; double deltVal = 0.;
-		for (int j=0; j<NumberOfPoints[i]; ++j){
+        XBVector.getI3(index[0], index[1], index[2]);
+        bool newIndices = false;
+        for (int i = 0; i < 3; ++i) {
+          if (oldIndex[i] != index[i]) {
+            oldIndex[i] = index[i];
+            newIndices = true;
+          }
+        }
+        if (newIndices) {
+          for (int i = 0; i < 3; ++i) {
+            if (!EasyCoordinate[i])
+              sort(misValX[i].begin(), misValX[i].end());
+          }
+          lowerLineLimit = upperLineLimit;
+          upperLineLimit = iLine;
+          for (int jLine = lowerLineLimit; jLine < upperLineLimit; ++jLine) {
+            XBVector = IXBValues.operator[](jLine);
+            XBVector.getI3(index[0], index[1], index[2]);
+            XBVector.getV6(x1, x2, x3, Bx, By, Bz);
+            double pnt[3] = {x1, x2, x3};
+            for (int i = 0; i < 3; ++i) {
+              if (!EasyCoordinate[i]) {
+                double thisVal = 0.;
+                double lastVal = 0.;
+                double deltVal = 0.;
+                for (int j = 0; j < NumberOfPoints[i]; ++j) {
                   thisVal = misValX[i].operator[](j);
-		  if (std::abs(thisVal - pnt[i]) < EPSILON) index[i] = j;
-		  if (j ==1) deltVal = thisVal - lastVal;
-		  else if (j > 1){
-		    if (std::abs(thisVal - lastVal - deltVal) > EPSILON) goodIndex[i] = false;
-		  }
-		  lastVal = thisVal;
-		}
-	      }
-	    }
-	    XBVector.putI3(index[0], index[1], index[2]);
-	    XBArray.push_back(XBVector);
-	    for (int i=0; i<3; ++i){
-	      if (!misValX[i].empty()) misValX[i].clear();
-	    }
-	  }
-	}
+                  if (std::abs(thisVal - pnt[i]) < EPSILON)
+                    index[i] = j;
+                  if (j == 1)
+                    deltVal = thisVal - lastVal;
+                  else if (j > 1) {
+                    if (std::abs(thisVal - lastVal - deltVal) > EPSILON)
+                      goodIndex[i] = false;
+                  }
+                  lastVal = thisVal;
+                }
+              }
+            }
+            XBVector.putI3(index[0], index[1], index[2]);
+            XBArray.push_back(XBVector);
+            for (int i = 0; i < 3; ++i) {
+              if (!misValX[i].empty())
+                misValX[i].clear();
+            }
+          }
+        }
         XBVector = IXBValues.operator[](iLine);
         XBVector.getV6(x1, x2, x3, Bx, By, Bz);
-        double pnt[3] = {x1,x2,x3};
-        for (int i=0; i<3; ++i){
-          if (!EasyCoordinate[i]){
-	    if (iLine == 0){
-	      NumberOfPoints[i] = 1;
-	      misValX[i].push_back(pnt[i]);
-	    }
-	    else if (newIndices){
-	      NumberOfPoints[i] = 1;
-	      misValX[i].push_back(pnt[i]);
-	    }
-	    else{
-	      bool knownValue = false;
-	      for (int j=0; j<NumberOfPoints[i]; ++j){
-		if (std::abs(misValX[i].operator[](j) - pnt[i]) < EPSILON) knownValue = true;
-	      }
-	      if (!knownValue){
-		++NumberOfPoints[i];
-		misValX[i].push_back(pnt[i]);
-	      }
-	    }
-	  }
-	}
-	if (lastLine){
-	  for (int i=0; i<3; ++i){
-	    if (!EasyCoordinate[i]) sort(misValX[i].begin(), misValX[i].end());
-	  }
-	  lowerLineLimit = upperLineLimit;
-	  upperLineLimit = nLines;
-	  for (int jLine=lowerLineLimit; jLine<upperLineLimit; ++jLine){
-	    XBVector = IXBValues.operator[](jLine);
-	    XBVector.getI3(index[0], index[1], index[2]);
-	    XBVector.getV6(x1, x2, x3, Bx, By, Bz);
-	    double pnt[3] = {x1,x2,x3};
-	    for (int i=0; i<3; ++i){
-	      if (!EasyCoordinate[i]){
-		double thisVal = 0.; double lastVal = 0.; double deltVal = 0.;
-		for (int j=0; j<NumberOfPoints[i]; ++j){
+        double pnt[3] = {x1, x2, x3};
+        for (int i = 0; i < 3; ++i) {
+          if (!EasyCoordinate[i]) {
+            if (iLine == 0) {
+              NumberOfPoints[i] = 1;
+              misValX[i].push_back(pnt[i]);
+            } else if (newIndices) {
+              NumberOfPoints[i] = 1;
+              misValX[i].push_back(pnt[i]);
+            } else {
+              bool knownValue = false;
+              for (int j = 0; j < NumberOfPoints[i]; ++j) {
+                if (std::abs(misValX[i].operator[](j) - pnt[i]) < EPSILON)
+                  knownValue = true;
+              }
+              if (!knownValue) {
+                ++NumberOfPoints[i];
+                misValX[i].push_back(pnt[i]);
+              }
+            }
+          }
+        }
+        if (lastLine) {
+          for (int i = 0; i < 3; ++i) {
+            if (!EasyCoordinate[i])
+              sort(misValX[i].begin(), misValX[i].end());
+          }
+          lowerLineLimit = upperLineLimit;
+          upperLineLimit = nLines;
+          for (int jLine = lowerLineLimit; jLine < upperLineLimit; ++jLine) {
+            XBVector = IXBValues.operator[](jLine);
+            XBVector.getI3(index[0], index[1], index[2]);
+            XBVector.getV6(x1, x2, x3, Bx, By, Bz);
+            double pnt[3] = {x1, x2, x3};
+            for (int i = 0; i < 3; ++i) {
+              if (!EasyCoordinate[i]) {
+                double thisVal = 0.;
+                double lastVal = 0.;
+                double deltVal = 0.;
+                for (int j = 0; j < NumberOfPoints[i]; ++j) {
                   thisVal = misValX[i].operator[](j);
-		  if (std::abs(thisVal - pnt[i]) < EPSILON) index[i] = j;
-		  if (j ==1) deltVal = thisVal - lastVal;
-		  else if (j > 1){
-		    if (std::abs(thisVal - lastVal - deltVal) > EPSILON) goodIndex[i] = false;
-		  }
-		  lastVal = thisVal;
-		}
-	      }
-	    }
-	    XBVector.putI3(index[0], index[1], index[2]);
-	    XBArray.push_back(XBVector);
-	    for (int i=0; i<3; ++i){
-	      if (!misValX[i].empty()) misValX[i].clear();
-	    }
-	  }
-	}
+                  if (std::abs(thisVal - pnt[i]) < EPSILON)
+                    index[i] = j;
+                  if (j == 1)
+                    deltVal = thisVal - lastVal;
+                  else if (j > 1) {
+                    if (std::abs(thisVal - lastVal - deltVal) > EPSILON)
+                      goodIndex[i] = false;
+                  }
+                  lastVal = thisVal;
+                }
+              }
+            }
+            XBVector.putI3(index[0], index[1], index[2]);
+            XBArray.push_back(XBVector);
+            for (int i = 0; i < 3; ++i) {
+              if (!misValX[i].empty())
+                misValX[i].clear();
+            }
+          }
+        }
       }
     }
     int nGoodInd = 0;
-    for (int i=0; i<3; ++i){
-      if (goodIndex[i]) ++nGoodInd;
+    for (int i = 0; i < 3; ++i) {
+      if (goodIndex[i])
+        ++nGoodInd;
     }
     // common part of missing coordiate(s) recovery (1 or 2 missing)
-    if (nEasy > 0){
+    if (nEasy > 0) {
       // sort without resetting of indices
       sort(XBArray.begin(), XBArray.end());
 
-      for (int i=0; i<3; ++i){
-	nSteps[i] = NumberOfPoints[i]-1;
+      for (int i = 0; i < 3; ++i) {
+        nSteps[i] = NumberOfPoints[i] - 1;
       }
       std::vector<double> rMinVec;
       std::vector<double> rMaxVec;
       std::vector<double> phiVec;
-      for (int iLine=0; iLine<nLines; ++iLine){
-	XBVector = XBArray.operator[](iLine);
-	XBVector.getI3(index[0], index[1], index[2]);
-	// in this case:r,phi,z       
-	XBVector.getV6(x1, x2, x3, Bx, By, Bz);
-	if (index[2] == 0){
-	  if (index[0] == 0        ) rMinVec.push_back(x1);
-	  if (index[0] == nSteps[0]) rMaxVec.push_back(x1);
-	  if (index[0] == nSteps[0])  phiVec.push_back(x2);
-	}
+      for (int iLine = 0; iLine < nLines; ++iLine) {
+        XBVector = XBArray.operator[](iLine);
+        XBVector.getI3(index[0], index[1], index[2]);
+        // in this case:r,phi,z
+        XBVector.getV6(x1, x2, x3, Bx, By, Bz);
+        if (index[2] == 0) {
+          if (index[0] == 0)
+            rMinVec.push_back(x1);
+          if (index[0] == nSteps[0])
+            rMaxVec.push_back(x1);
+          if (index[0] == nSteps[0])
+            phiVec.push_back(x2);
+        }
       }
-      for (int j=0; j<NumberOfPoints[1]; ++j){
-	double phi  =  phiVec.operator[](j);
-	double rMin = rMinVec.operator[](j);
-	double rMax = rMaxVec.operator[](j);
-	double rhoMin, rhoMax;
-	if (GridType==6) {
-	  rhoMin = rMin*cos(phi);
-	  rhoMax = rMax*cos(phi);
-	} else if (GridType==5) {
-	  rhoMin = rMin*sin(phi);
-	  rhoMax = rMax*sin(phi);
-	} else {
-	  cout << "unknown grid type!" << endl;
-	  abort();
-	}
-	
-	
-	if (j == 0){
-	  RParAsFunOfPhi[0] = rMax;
-	  RParAsFunOfPhi[1] = rhoMax;
-	  RParAsFunOfPhi[2] = rMin;
-	  RParAsFunOfPhi[3] = rhoMin;
-	}
-	else{
-	  if (std::abs(rMax   - RParAsFunOfPhi[0]) > EPSILON) RParAsFunOfPhi[0] = 0.;
-	  if (std::abs(rhoMax - RParAsFunOfPhi[1]) > EPSILON) RParAsFunOfPhi[1] = 0.;
-	  if (std::abs(rMin   - RParAsFunOfPhi[2]) > EPSILON) RParAsFunOfPhi[2] = 0.;
-	  if (std::abs(rhoMin - RParAsFunOfPhi[3]) > EPSILON) RParAsFunOfPhi[3] = 0.;
-	}
+      for (int j = 0; j < NumberOfPoints[1]; ++j) {
+        double phi = phiVec.operator[](j);
+        double rMin = rMinVec.operator[](j);
+        double rMax = rMaxVec.operator[](j);
+        double rhoMin, rhoMax;
+        if (GridType == 6) {
+          rhoMin = rMin * cos(phi);
+          rhoMax = rMax * cos(phi);
+        } else if (GridType == 5) {
+          rhoMin = rMin * sin(phi);
+          rhoMax = rMax * sin(phi);
+        } else {
+          cout << "unknown grid type!" << endl;
+          abort();
+        }
+
+        if (j == 0) {
+          RParAsFunOfPhi[0] = rMax;
+          RParAsFunOfPhi[1] = rhoMax;
+          RParAsFunOfPhi[2] = rMin;
+          RParAsFunOfPhi[3] = rhoMin;
+        } else {
+          if (std::abs(rMax - RParAsFunOfPhi[0]) > EPSILON)
+            RParAsFunOfPhi[0] = 0.;
+          if (std::abs(rhoMax - RParAsFunOfPhi[1]) > EPSILON)
+            RParAsFunOfPhi[1] = 0.;
+          if (std::abs(rMin - RParAsFunOfPhi[2]) > EPSILON)
+            RParAsFunOfPhi[2] = 0.;
+          if (std::abs(rhoMin - RParAsFunOfPhi[3]) > EPSILON)
+            RParAsFunOfPhi[3] = 0.;
+        }
       }
 
       // set default values of BasicDistance0 in case of < 2 points
-      for (int i=0; i<3; ++i){
-        if (NumberOfPoints[i] < 2) BasicDistance0[i] = 9e9;
+      for (int i = 0; i < 3; ++i) {
+        if (NumberOfPoints[i] < 2)
+          BasicDistance0[i] = 9e9;
       }
     }
 
     // get first point = ReferencePoint (and last point for structure checking)
-    if (!XBArray.empty()) XBVector = XBArray.front();
+    if (!XBArray.empty())
+      XBVector = XBArray.front();
     XBVector.getV6(x1, x2, x3, Bx, By, Bz);
     firstListPoint[0] = x1;
     firstListPoint[1] = x2;
     firstListPoint[2] = x3;
-    if (!XBArray.empty()) XBVector = XBArray.back();
+    if (!XBArray.empty())
+      XBVector = XBArray.back();
     XBVector.getV6(x1, x2, x3, Bx, By, Bz);
     secondRefPoint[0] = x1;
     secondRefPoint[1] = x2;
@@ -985,78 +1046,80 @@ void prepareMagneticFieldGrid::fillFromFileSpecial(const std::string& name){
 
     // recheck all coordinates
     KnownStructure = true;
-    for (int i=0; i<3; ++i){
+    for (int i = 0; i < 3; ++i) {
       ReferencePoint[i] = firstListPoint[i];
-      nSteps[i] = NumberOfPoints[i]-1;
+      nSteps[i] = NumberOfPoints[i] - 1;
     }
 
-    double sinPhi; // either sin or cos depending on grid type
-    if (GridType==6) {
+    double sinPhi;  // either sin or cos depending on grid type
+    if (GridType == 6) {
       sinPhi = cos(secondRefPoint[1]);
-    } else if (GridType==5) {
+    } else if (GridType == 5) {
       sinPhi = sin(secondRefPoint[1]);
     } else {
       cout << "unknown GridType!" << endl;
       abort();
     }
-	
-    
+
     if (std::abs(sinPhi) < EPSILON) {
       cout << " WARNING: unexpected sinPhi parameter = 0" << endl;
       sinPhi = EPSILON;
     }
-    
-    double totStepSize = RParAsFunOfPhi[0] + RParAsFunOfPhi[1]/sinPhi - RParAsFunOfPhi[2] - RParAsFunOfPhi[3]/sinPhi;
-    double startingPoint = RParAsFunOfPhi[2] + RParAsFunOfPhi[3]/sinPhi;
+
+    double totStepSize =
+        RParAsFunOfPhi[0] + RParAsFunOfPhi[1] / sinPhi - RParAsFunOfPhi[2] - RParAsFunOfPhi[3] / sinPhi;
+    double startingPoint = RParAsFunOfPhi[2] + RParAsFunOfPhi[3] / sinPhi;
     double totDiff = secondRefPoint[0] - (startingPoint + totStepSize);
-    if (std::abs(totDiff) < EPSILON*10.) systematicGrid[0] = true;
-    else                         systematicGrid[0] = false;
-    if (!systematicGrid[0]) KnownStructure = false;
-    totDiff = secondRefPoint[1] - (ReferencePoint[1] + BasicDistance0[1]*nSteps[1]);
-    if (std::abs(totDiff) < EPSILON*10.) systematicGrid[1] = true;
-    else                         systematicGrid[1] = false;
-    if (!systematicGrid[1]) KnownStructure = false;
-    totDiff = secondRefPoint[2] - (ReferencePoint[2] + BasicDistance0[2]*nSteps[2]);
-    if (std::abs(totDiff) < EPSILON*10.) systematicGrid[2] = true;
-    else                         systematicGrid[2] = false;
-    if (!systematicGrid[2]) KnownStructure = false;
-    
-    if (PRINT){
+    if (std::abs(totDiff) < EPSILON * 10.)
+      systematicGrid[0] = true;
+    else
+      systematicGrid[0] = false;
+    if (!systematicGrid[0])
+      KnownStructure = false;
+    totDiff = secondRefPoint[1] - (ReferencePoint[1] + BasicDistance0[1] * nSteps[1]);
+    if (std::abs(totDiff) < EPSILON * 10.)
+      systematicGrid[1] = true;
+    else
+      systematicGrid[1] = false;
+    if (!systematicGrid[1])
+      KnownStructure = false;
+    totDiff = secondRefPoint[2] - (ReferencePoint[2] + BasicDistance0[2] * nSteps[2]);
+    if (std::abs(totDiff) < EPSILON * 10.)
+      systematicGrid[2] = true;
+    else
+      systematicGrid[2] = false;
+    if (!systematicGrid[2])
+      KnownStructure = false;
+
+    if (PRINT) {
       // print result
       cout << "  read " << nLines << " lines -> grid structure:" << endl;
-      cout << "  # of points:   N1 = " << NumberOfPoints[0]
-	   << "   N2 = " << NumberOfPoints[1]
-	   << "   N3 = " << NumberOfPoints[2] << endl;
-      cout << "  ref. point :   X1 = " << ReferencePoint[0]
-	   << "   X2 = " << ReferencePoint[1]
-	   << "   X3 = " << ReferencePoint[2] << endl;
-      cout << "  step parm0 :   A1 = " << BasicDistance0[0]
-	   << "   A2 = " << BasicDistance0[1]
-	   << "   A3 = " << BasicDistance0[2] << endl;
-      cout << "  r param.s. :   R1 = " << RParAsFunOfPhi[0]
-	   << " RHO1 = " << RParAsFunOfPhi[1]
-	   << "   R2 = " << RParAsFunOfPhi[2]
-	   << " RHO2 = " << RParAsFunOfPhi[3] << endl;
-      cout << "  easy grid  :   E1 = " << EasyCoordinate[0]
-	   << "   E2 = " << EasyCoordinate[1]
-	   << "   E3 = " << EasyCoordinate[2] << endl;
-      cout << "             :   I1 = " << goodIndex[0]
-	   << "   I2 = " << goodIndex[1]
-	   << "   I3 = " << goodIndex[2] << endl;
-      cout << "  structure  :   S1 = " << systematicGrid[0]
-	   << "   S2 = " << systematicGrid[1]
-	   << "   S3 = " << systematicGrid[2]; 
-      if (KnownStructure) cout << "  -->  VALID   (step II)" << endl;
-      else{               cout << "  -->  INVALID (step II)" << endl;
-	cout << "  reason for error: ";
-	if (NumberOfPoints[0]*NumberOfPoints[1]*NumberOfPoints[2] != nLines) {
-	  cout << endl;
-	  cout << "  N1*N2*N3 =/= N.lines  -->  exiting now ..." << endl;
-	  return;
-	}
-	else {
-	  cout << "  no idea so far  -->  exiting now ..." << endl;
-	  return;
+      cout << "  # of points:   N1 = " << NumberOfPoints[0] << "   N2 = " << NumberOfPoints[1]
+           << "   N3 = " << NumberOfPoints[2] << endl;
+      cout << "  ref. point :   X1 = " << ReferencePoint[0] << "   X2 = " << ReferencePoint[1]
+           << "   X3 = " << ReferencePoint[2] << endl;
+      cout << "  step parm0 :   A1 = " << BasicDistance0[0] << "   A2 = " << BasicDistance0[1]
+           << "   A3 = " << BasicDistance0[2] << endl;
+      cout << "  r param.s. :   R1 = " << RParAsFunOfPhi[0] << " RHO1 = " << RParAsFunOfPhi[1]
+           << "   R2 = " << RParAsFunOfPhi[2] << " RHO2 = " << RParAsFunOfPhi[3] << endl;
+      cout << "  easy grid  :   E1 = " << EasyCoordinate[0] << "   E2 = " << EasyCoordinate[1]
+           << "   E3 = " << EasyCoordinate[2] << endl;
+      cout << "             :   I1 = " << goodIndex[0] << "   I2 = " << goodIndex[1] << "   I3 = " << goodIndex[2]
+           << endl;
+      cout << "  structure  :   S1 = " << systematicGrid[0] << "   S2 = " << systematicGrid[1]
+           << "   S3 = " << systematicGrid[2];
+      if (KnownStructure)
+        cout << "  -->  VALID   (step II)" << endl;
+      else {
+        cout << "  -->  INVALID (step II)" << endl;
+        cout << "  reason for error: ";
+        if (NumberOfPoints[0] * NumberOfPoints[1] * NumberOfPoints[2] != nLines) {
+          cout << endl;
+          cout << "  N1*N2*N3 =/= N.lines  -->  exiting now ..." << endl;
+          return;
+        } else {
+          cout << "  no idea so far  -->  exiting now ..." << endl;
+          return;
         }
       }
     }
@@ -1064,36 +1127,42 @@ void prepareMagneticFieldGrid::fillFromFileSpecial(const std::string& name){
 
   // save coordinates and field values
   SixDPoint GridEntry;
-  for (unsigned int iLine=0; iLine<XBArray.size(); ++iLine){
+  for (unsigned int iLine = 0; iLine < XBArray.size(); ++iLine) {
     XBVector = XBArray.operator[](iLine);
     XBVector.getV6(x1, x2, x3, Bx, By, Bz);
     GridEntry.putP6(x1, x2, x3, Bx, By, Bz);
     GridData.push_back(GridEntry);
   }
-  if (!XBArray.empty()) XBArray.clear();
+  if (!XBArray.empty())
+    XBArray.clear();
 
   return;
 }
 
-
-int prepareMagneticFieldGrid::gridType(){
+int prepareMagneticFieldGrid::gridType() {
   int type = GridType;
-  if (PRINT){
-    if (type == 0) cout << "  grid type = " << type << "  -->  not determined" << endl;
-    if (type == 1) cout << "  grid type = " << type << "  -->  (x,y,z) cube" << endl;
-    if (type == 2) cout << "  grid type = " << type << "  -->  (x,y,z) trapezoid" << endl;
-    if (type == 3) cout << "  grid type = " << type << "  -->  (r,phi,z) cube" << endl;
-    if (type == 4) cout << "  grid type = " << type << "  -->  (r,phi,z) trapezoid" << endl;
-    if (type == 5) cout << "  grid type = " << type << "  -->  (r,phi,z) 1/sin(phi)" << endl;
-    if (type == 6) cout << "  grid type = " << type << "  -->  (r,phi,z) 1/cos(phi)" << endl;
+  if (PRINT) {
+    if (type == 0)
+      cout << "  grid type = " << type << "  -->  not determined" << endl;
+    if (type == 1)
+      cout << "  grid type = " << type << "  -->  (x,y,z) cube" << endl;
+    if (type == 2)
+      cout << "  grid type = " << type << "  -->  (x,y,z) trapezoid" << endl;
+    if (type == 3)
+      cout << "  grid type = " << type << "  -->  (r,phi,z) cube" << endl;
+    if (type == 4)
+      cout << "  grid type = " << type << "  -->  (r,phi,z) trapezoid" << endl;
+    if (type == 5)
+      cout << "  grid type = " << type << "  -->  (r,phi,z) 1/sin(phi)" << endl;
+    if (type == 6)
+      cout << "  grid type = " << type << "  -->  (r,phi,z) 1/cos(phi)" << endl;
   }
   return type;
 }
 
-
-void prepareMagneticFieldGrid::validateAllPoints(){
-
-  if (!KnownStructure) return;
+void prepareMagneticFieldGrid::validateAllPoints() {
+  if (!KnownStructure)
+    return;
 
   double x1, x2, x3, Bx, By, Bz;
   int numberOfErrors = 0;
@@ -1101,126 +1170,130 @@ void prepareMagneticFieldGrid::validateAllPoints(){
   // loop over three dimensions
   int index[3];
 
-  if (GridType < 5){
-    for (index[0]=0; index[0]<NumberOfPoints[0]; ++index[0]){
-      for (index[1]=0; index[1]<NumberOfPoints[1]; ++index[1]){
-        for (index[2]=0; index[2]<NumberOfPoints[2]; ++index[2]){
-	  // get reference values
-	  putIndicesGetXAndB(index[0], index[1], index[2], x1, x2, x3, Bx, By, Bz);
+  if (GridType < 5) {
+    for (index[0] = 0; index[0] < NumberOfPoints[0]; ++index[0]) {
+      for (index[1] = 0; index[1] < NumberOfPoints[1]; ++index[1]) {
+        for (index[2] = 0; index[2] < NumberOfPoints[2]; ++index[2]) {
+          // get reference values
+          putIndicesGetXAndB(index[0], index[1], index[2], x1, x2, x3, Bx, By, Bz);
 
-	  // first check: calculate indices from coordinates and compare with original indices
-	  double pnt[3] = {x1,x2,x3};
-	  int tmpIdx[3] = {999,999,999};
-	  putCoordGetIndices((x1+EPSILON), (x2+EPSILON), (x3+EPSILON), tmpIdx[0], tmpIdx[1], tmpIdx[2]);
-	  for (int i=0; i<3; ++i){
-	    if (tmpIdx[i] != index[i]) ++numberOfErrors;
-	  }
+          // first check: calculate indices from coordinates and compare with original indices
+          double pnt[3] = {x1, x2, x3};
+          int tmpIdx[3] = {999, 999, 999};
+          putCoordGetIndices((x1 + EPSILON), (x2 + EPSILON), (x3 + EPSILON), tmpIdx[0], tmpIdx[1], tmpIdx[2]);
+          for (int i = 0; i < 3; ++i) {
+            if (tmpIdx[i] != index[i])
+              ++numberOfErrors;
+          }
 
-	  // second check: calculate coordinate from indices and compare with original values
-          double tmpPnt[3] = {0.0,0.0,0.0};
-	  putIndCalcXReturnB(index[0], index[1], index[2], tmpPnt[0], tmpPnt[1], tmpPnt[2], Bx, By, Bz);
-	  for (int i=0; i<3; ++i){
-	    if (std::abs(tmpPnt[i]-pnt[i]) > EPSILON) ++numberOfErrors;
-	  }
+          // second check: calculate coordinate from indices and compare with original values
+          double tmpPnt[3] = {0.0, 0.0, 0.0};
+          putIndCalcXReturnB(index[0], index[1], index[2], tmpPnt[0], tmpPnt[1], tmpPnt[2], Bx, By, Bz);
+          for (int i = 0; i < 3; ++i) {
+            if (std::abs(tmpPnt[i] - pnt[i]) > EPSILON)
+              ++numberOfErrors;
+          }
         }
       }
     }
   }
 
-  if (GridType == 5 || GridType == 6){
-    for (index[0]=0; index[0]<NumberOfPoints[0]; ++index[0]){
-      for (index[1]=0; index[1]<NumberOfPoints[1]; ++index[1]){
-	for (index[2]=0; index[2]<NumberOfPoints[2]; ++index[2]){
-	  // get reference values
-	  putIndicesGetXAndB(index[0], index[1], index[2], x1, x2, x3, Bx, By, Bz);
+  if (GridType == 5 || GridType == 6) {
+    for (index[0] = 0; index[0] < NumberOfPoints[0]; ++index[0]) {
+      for (index[1] = 0; index[1] < NumberOfPoints[1]; ++index[1]) {
+        for (index[2] = 0; index[2] < NumberOfPoints[2]; ++index[2]) {
+          // get reference values
+          putIndicesGetXAndB(index[0], index[1], index[2], x1, x2, x3, Bx, By, Bz);
 
-	  // first check: calculate indices from coordinates and compare with original indices
-	  double pnt[3] = {x1,x2,x3};
-	  int tmpIdx[3] = {999,999,999};
-	  putCoordGetIndices((x1+EPSILON), (x2+EPSILON), (x3+EPSILON), tmpIdx[0], tmpIdx[1], tmpIdx[2]);
-	  for (int i=0; i<3; ++i){
-	    if (tmpIdx[i] != index[i]){
-	      putCoordGetIndices((x1-EPSILON), (x2+EPSILON), (x3+EPSILON), tmpIdx[0], tmpIdx[1], tmpIdx[2]);
-	      if (tmpIdx[i] != index[i]){
-		putCoordGetIndices((x1+EPSILON), (x2-EPSILON), (x3+EPSILON), tmpIdx[0], tmpIdx[1], tmpIdx[2]);
-		if (tmpIdx[i] != index[i]){
-		  putCoordGetIndices((x1-EPSILON), (x2-EPSILON), (x3+EPSILON), tmpIdx[0], tmpIdx[1], tmpIdx[2]);
-		  if (tmpIdx[i] != index[i]) ++numberOfErrors;
-		}
-	      }
-	    }
-	  }
+          // first check: calculate indices from coordinates and compare with original indices
+          double pnt[3] = {x1, x2, x3};
+          int tmpIdx[3] = {999, 999, 999};
+          putCoordGetIndices((x1 + EPSILON), (x2 + EPSILON), (x3 + EPSILON), tmpIdx[0], tmpIdx[1], tmpIdx[2]);
+          for (int i = 0; i < 3; ++i) {
+            if (tmpIdx[i] != index[i]) {
+              putCoordGetIndices((x1 - EPSILON), (x2 + EPSILON), (x3 + EPSILON), tmpIdx[0], tmpIdx[1], tmpIdx[2]);
+              if (tmpIdx[i] != index[i]) {
+                putCoordGetIndices((x1 + EPSILON), (x2 - EPSILON), (x3 + EPSILON), tmpIdx[0], tmpIdx[1], tmpIdx[2]);
+                if (tmpIdx[i] != index[i]) {
+                  putCoordGetIndices((x1 - EPSILON), (x2 - EPSILON), (x3 + EPSILON), tmpIdx[0], tmpIdx[1], tmpIdx[2]);
+                  if (tmpIdx[i] != index[i])
+                    ++numberOfErrors;
+                }
+              }
+            }
+          }
 
-	  // second check: calculate coordinate from indices and compare with original values
-	  double tmpPnt[3] = {0.0,0.0,0.0};
-	  putIndCalcXReturnB(index[0], index[1], index[2], tmpPnt[0], tmpPnt[1], tmpPnt[2], Bx, By, Bz);
-	  for (int i=0; i<3; ++i){
-	    if (std::abs(tmpPnt[i]-pnt[i]) > EPSILON) ++numberOfErrors;
-	  }
-	}
+          // second check: calculate coordinate from indices and compare with original values
+          double tmpPnt[3] = {0.0, 0.0, 0.0};
+          putIndCalcXReturnB(index[0], index[1], index[2], tmpPnt[0], tmpPnt[1], tmpPnt[2], Bx, By, Bz);
+          for (int i = 0; i < 3; ++i) {
+            if (std::abs(tmpPnt[i] - pnt[i]) > EPSILON)
+              ++numberOfErrors;
+          }
+        }
       }
     }
   }
 
-  if (numberOfErrors > 0) KnownStructure = false;
-  if (PRINT) cout << "  grid validation of all points done  -->  # errors = " << numberOfErrors << endl;
+  if (numberOfErrors > 0)
+    KnownStructure = false;
+  if (PRINT)
+    cout << "  grid validation of all points done  -->  # errors = " << numberOfErrors << endl;
 
   return;
 }
 
-
-void prepareMagneticFieldGrid::saveGridToFile(const std::string& outName){
-
+void prepareMagneticFieldGrid::saveGridToFile(const std::string &outName) {
   // open output file
   binary_ofstream outFile(outName);
   // write grid type
   outFile << GridType;
   // write header (depending on grid type)
-  convertUnits(); // m->cm
+  convertUnits();  // m->cm
   if (GridType == 1) {
-    outFile << NumberOfPoints[0]    << NumberOfPoints[1]    << NumberOfPoints[2];
-    outFile << ReferencePoint[0]    << ReferencePoint[1]    << ReferencePoint[2];
-    outFile << BasicDistance0[0]    << BasicDistance0[1]    << BasicDistance0[2];
+    outFile << NumberOfPoints[0] << NumberOfPoints[1] << NumberOfPoints[2];
+    outFile << ReferencePoint[0] << ReferencePoint[1] << ReferencePoint[2];
+    outFile << BasicDistance0[0] << BasicDistance0[1] << BasicDistance0[2];
   }
   if (GridType == 2) {
-    outFile << NumberOfPoints[0]    << NumberOfPoints[1]    << NumberOfPoints[2];
-    outFile << ReferencePoint[0]    << ReferencePoint[1]    << ReferencePoint[2];
-    outFile << BasicDistance0[0]    << BasicDistance0[1]    << BasicDistance0[2];
+    outFile << NumberOfPoints[0] << NumberOfPoints[1] << NumberOfPoints[2];
+    outFile << ReferencePoint[0] << ReferencePoint[1] << ReferencePoint[2];
+    outFile << BasicDistance0[0] << BasicDistance0[1] << BasicDistance0[2];
     outFile << BasicDistance1[0][0] << BasicDistance1[1][0] << BasicDistance1[2][0];
     outFile << BasicDistance1[0][1] << BasicDistance1[1][1] << BasicDistance1[2][1];
     outFile << BasicDistance1[0][2] << BasicDistance1[1][2] << BasicDistance1[2][2];
     outFile << BasicDistance2[0][0] << BasicDistance2[1][0] << BasicDistance2[2][0];
     outFile << BasicDistance2[0][1] << BasicDistance2[1][1] << BasicDistance2[2][1];
     outFile << BasicDistance2[0][2] << BasicDistance2[1][2] << BasicDistance2[2][2];
-    outFile << EasyCoordinate[0]    << EasyCoordinate[1]    << EasyCoordinate[2];
+    outFile << EasyCoordinate[0] << EasyCoordinate[1] << EasyCoordinate[2];
   }
   if (GridType == 3) {
-    outFile << NumberOfPoints[0]    << NumberOfPoints[1]    << NumberOfPoints[2];
-    outFile << ReferencePoint[0]    << ReferencePoint[1]    << ReferencePoint[2];
-    outFile << BasicDistance0[0]    << BasicDistance0[1]    << BasicDistance0[2];
+    outFile << NumberOfPoints[0] << NumberOfPoints[1] << NumberOfPoints[2];
+    outFile << ReferencePoint[0] << ReferencePoint[1] << ReferencePoint[2];
+    outFile << BasicDistance0[0] << BasicDistance0[1] << BasicDistance0[2];
   }
   if (GridType == 4) {
-    outFile << NumberOfPoints[0]    << NumberOfPoints[1]    << NumberOfPoints[2];
-    outFile << ReferencePoint[0]    << ReferencePoint[1]    << ReferencePoint[2];
-    outFile << BasicDistance0[0]    << BasicDistance0[1]    << BasicDistance0[2];
+    outFile << NumberOfPoints[0] << NumberOfPoints[1] << NumberOfPoints[2];
+    outFile << ReferencePoint[0] << ReferencePoint[1] << ReferencePoint[2];
+    outFile << BasicDistance0[0] << BasicDistance0[1] << BasicDistance0[2];
     outFile << BasicDistance1[0][0] << BasicDistance1[1][0] << BasicDistance1[2][0];
     outFile << BasicDistance1[0][1] << BasicDistance1[1][1] << BasicDistance1[2][1];
     outFile << BasicDistance1[0][2] << BasicDistance1[1][2] << BasicDistance1[2][2];
     outFile << BasicDistance2[0][0] << BasicDistance2[1][0] << BasicDistance2[2][0];
     outFile << BasicDistance2[0][1] << BasicDistance2[1][1] << BasicDistance2[2][1];
     outFile << BasicDistance2[0][2] << BasicDistance2[1][2] << BasicDistance2[2][2];
-    outFile << EasyCoordinate[0]    << EasyCoordinate[1]    << EasyCoordinate[2];
+    outFile << EasyCoordinate[0] << EasyCoordinate[1] << EasyCoordinate[2];
   }
   if (GridType == 5 || GridType == 6) {
-    outFile << NumberOfPoints[0]    << NumberOfPoints[1]    << NumberOfPoints[2];
-    outFile << ReferencePoint[0]    << ReferencePoint[1]    << ReferencePoint[2];
-    outFile << BasicDistance0[0]    << BasicDistance0[1]    << BasicDistance0[2];
-    outFile << RParAsFunOfPhi[0]    << RParAsFunOfPhi[1]    << RParAsFunOfPhi[2]    << RParAsFunOfPhi[3];
+    outFile << NumberOfPoints[0] << NumberOfPoints[1] << NumberOfPoints[2];
+    outFile << ReferencePoint[0] << ReferencePoint[1] << ReferencePoint[2];
+    outFile << BasicDistance0[0] << BasicDistance0[1] << BasicDistance0[2];
+    outFile << RParAsFunOfPhi[0] << RParAsFunOfPhi[1] << RParAsFunOfPhi[2] << RParAsFunOfPhi[3];
   }
-  int nLines = NumberOfPoints[0]*NumberOfPoints[1]*NumberOfPoints[2];
+  int nLines = NumberOfPoints[0] * NumberOfPoints[1] * NumberOfPoints[2];
   SixDPoint GridPoint;
   // write magnetic field values (3*nPoints)
-  for (int iLine=0; iLine<nLines; ++iLine){
+  for (int iLine = 0; iLine < nLines; ++iLine) {
     GridPoint = GridData.operator[](iLine);
     float Bx = float(GridPoint.bx());
     float By = float(GridPoint.by());
@@ -1232,121 +1305,152 @@ void prepareMagneticFieldGrid::saveGridToFile(const std::string& outName){
   const std::string lastEntry = "complete";
   outFile << lastEntry;
   outFile.close();
-  if (PRINT) cout << "  output " << outName << endl;
+  if (PRINT)
+    cout << "  output " << outName << endl;
   return;
 }
 
-void  prepareMagneticFieldGrid::convertUnits(){
-  double cm = 100.; // m->cm (just multiply all lengths with 100)
-  if (XyzCoordinates){
-    for (int i=0;i<3; ++i) {ReferencePoint[i] *= cm;};
-    for (int i=0;i<3; ++i) {BasicDistance0[i] *= cm;};
-    for (int i=0;i<3; ++i) {for (int j=0;j<3; ++j) {BasicDistance1[i][j] *= cm;};};
-    for (int i=0;i<3; ++i) {for (int j=0;j<3; ++j) {BasicDistance2[i][j] *= cm;};};
-    for (int i=0;i<4; ++i) {RParAsFunOfPhi[i] *= cm;};
+void prepareMagneticFieldGrid::convertUnits() {
+  double cm = 100.;  // m->cm (just multiply all lengths with 100)
+  if (XyzCoordinates) {
+    for (int i = 0; i < 3; ++i) {
+      ReferencePoint[i] *= cm;
+    };
+    for (int i = 0; i < 3; ++i) {
+      BasicDistance0[i] *= cm;
+    };
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        BasicDistance1[i][j] *= cm;
+      };
+    };
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        BasicDistance2[i][j] *= cm;
+      };
+    };
+    for (int i = 0; i < 4; ++i) {
+      RParAsFunOfPhi[i] *= cm;
+    };
   }
-  double du[3] = {100.,1.,100.}; // m->cm ; rad->rad (unchanged)
-  if (RpzCoordinates){
-    for (int i=0;i<3; ++i) {ReferencePoint[i] *= du[i];};
-    for (int i=0;i<3; ++i) {BasicDistance0[i] *= du[i];};
-    for (int i=0;i<3; ++i) {for (int j=0;j<3; ++j) {BasicDistance1[i][j] *= du[i];};};
-    for (int i=0;i<3; ++i) {for (int j=0;j<3; ++j) {BasicDistance2[i][j] *= du[i];};};
-    for (int i=0;i<4; ++i) {RParAsFunOfPhi[i] *= cm;};
+  double du[3] = {100., 1., 100.};  // m->cm ; rad->rad (unchanged)
+  if (RpzCoordinates) {
+    for (int i = 0; i < 3; ++i) {
+      ReferencePoint[i] *= du[i];
+    };
+    for (int i = 0; i < 3; ++i) {
+      BasicDistance0[i] *= du[i];
+    };
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        BasicDistance1[i][j] *= du[i];
+      };
+    };
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        BasicDistance2[i][j] *= du[i];
+      };
+    };
+    for (int i = 0; i < 4; ++i) {
+      RParAsFunOfPhi[i] *= cm;
+    };
   }
   return;
 }
 
-bool prepareMagneticFieldGrid::isReady(){  return KnownStructure; }
+bool prepareMagneticFieldGrid::isReady() { return KnownStructure; }
 
-void prepareMagneticFieldGrid::interpolateAtPoint(double X1, double X2, double X3, double &Bx, double &By, double &Bz){
-
+void prepareMagneticFieldGrid::interpolateAtPoint(double X1, double X2, double X3, double &Bx, double &By, double &Bz) {
   Bx = By = Bz = 0.0;
-  if (KnownStructure){
+  if (KnownStructure) {
     // define interpolation object
     VectorFieldInterpolation MagInterpol;
     // calculate indices for "CellPoint000"
     int index[3];
-    putCoordGetIndices(X1,X2,X3,index[0],index[1],index[2]);
-    int index0[3] = {0,0,0};
-    int index1[3] = {0,0,0};
-    for (int i=0; i<3; ++i){
-      if (NumberOfPoints[i] > 1){
-	                                     index0[i] = std::max(0,index[i]);
-	if (index0[i] > NumberOfPoints[i]-2) index0[i] = NumberOfPoints[i]-2;;
-	                                     index1[i] = std::max(1,index[i]+1);;
-	if (index1[i] > NumberOfPoints[i]-1) index1[i] = NumberOfPoints[i]-1;
+    putCoordGetIndices(X1, X2, X3, index[0], index[1], index[2]);
+    int index0[3] = {0, 0, 0};
+    int index1[3] = {0, 0, 0};
+    for (int i = 0; i < 3; ++i) {
+      if (NumberOfPoints[i] > 1) {
+        index0[i] = std::max(0, index[i]);
+        if (index0[i] > NumberOfPoints[i] - 2)
+          index0[i] = NumberOfPoints[i] - 2;
+        ;
+        index1[i] = std::max(1, index[i] + 1);
+        ;
+        if (index1[i] > NumberOfPoints[i] - 1)
+          index1[i] = NumberOfPoints[i] - 1;
       }
     }
     double tmpX[3];
     double tmpB[3];
     // define the corners of interpolation volume
-    putIndicesGetXAndB(index0[0],index0[1],index0[2],tmpX[0],tmpX[1],tmpX[2],tmpB[0],tmpB[1],tmpB[2]);
-    MagInterpol.defineCellPoint000(tmpX[0],tmpX[1],tmpX[2],tmpB[0],tmpB[1],tmpB[2]);
-    putIndicesGetXAndB(index1[0],index0[1],index0[2],tmpX[0],tmpX[1],tmpX[2],tmpB[0],tmpB[1],tmpB[2]);
-    MagInterpol.defineCellPoint100(tmpX[0],tmpX[1],tmpX[2],tmpB[0],tmpB[1],tmpB[2]);
-    putIndicesGetXAndB(index0[0],index1[1],index0[2],tmpX[0],tmpX[1],tmpX[2],tmpB[0],tmpB[1],tmpB[2]);
-    MagInterpol.defineCellPoint010(tmpX[0],tmpX[1],tmpX[2],tmpB[0],tmpB[1],tmpB[2]);
-    putIndicesGetXAndB(index1[0],index1[1],index0[2],tmpX[0],tmpX[1],tmpX[2],tmpB[0],tmpB[1],tmpB[2]);
-    MagInterpol.defineCellPoint110(tmpX[0],tmpX[1],tmpX[2],tmpB[0],tmpB[1],tmpB[2]);
-    putIndicesGetXAndB(index0[0],index0[1],index1[2],tmpX[0],tmpX[1],tmpX[2],tmpB[0],tmpB[1],tmpB[2]);
-    MagInterpol.defineCellPoint001(tmpX[0],tmpX[1],tmpX[2],tmpB[0],tmpB[1],tmpB[2]);
-    putIndicesGetXAndB(index1[0],index0[1],index1[2],tmpX[0],tmpX[1],tmpX[2],tmpB[0],tmpB[1],tmpB[2]);
-    MagInterpol.defineCellPoint101(tmpX[0],tmpX[1],tmpX[2],tmpB[0],tmpB[1],tmpB[2]);
-    putIndicesGetXAndB(index0[0],index1[1],index1[2],tmpX[0],tmpX[1],tmpX[2],tmpB[0],tmpB[1],tmpB[2]);
-    MagInterpol.defineCellPoint011(tmpX[0],tmpX[1],tmpX[2],tmpB[0],tmpB[1],tmpB[2]);
-    putIndicesGetXAndB(index1[0],index1[1],index1[2],tmpX[0],tmpX[1],tmpX[2],tmpB[0],tmpB[1],tmpB[2]);
-    MagInterpol.defineCellPoint111(tmpX[0],tmpX[1],tmpX[2],tmpB[0],tmpB[1],tmpB[2]);
+    putIndicesGetXAndB(index0[0], index0[1], index0[2], tmpX[0], tmpX[1], tmpX[2], tmpB[0], tmpB[1], tmpB[2]);
+    MagInterpol.defineCellPoint000(tmpX[0], tmpX[1], tmpX[2], tmpB[0], tmpB[1], tmpB[2]);
+    putIndicesGetXAndB(index1[0], index0[1], index0[2], tmpX[0], tmpX[1], tmpX[2], tmpB[0], tmpB[1], tmpB[2]);
+    MagInterpol.defineCellPoint100(tmpX[0], tmpX[1], tmpX[2], tmpB[0], tmpB[1], tmpB[2]);
+    putIndicesGetXAndB(index0[0], index1[1], index0[2], tmpX[0], tmpX[1], tmpX[2], tmpB[0], tmpB[1], tmpB[2]);
+    MagInterpol.defineCellPoint010(tmpX[0], tmpX[1], tmpX[2], tmpB[0], tmpB[1], tmpB[2]);
+    putIndicesGetXAndB(index1[0], index1[1], index0[2], tmpX[0], tmpX[1], tmpX[2], tmpB[0], tmpB[1], tmpB[2]);
+    MagInterpol.defineCellPoint110(tmpX[0], tmpX[1], tmpX[2], tmpB[0], tmpB[1], tmpB[2]);
+    putIndicesGetXAndB(index0[0], index0[1], index1[2], tmpX[0], tmpX[1], tmpX[2], tmpB[0], tmpB[1], tmpB[2]);
+    MagInterpol.defineCellPoint001(tmpX[0], tmpX[1], tmpX[2], tmpB[0], tmpB[1], tmpB[2]);
+    putIndicesGetXAndB(index1[0], index0[1], index1[2], tmpX[0], tmpX[1], tmpX[2], tmpB[0], tmpB[1], tmpB[2]);
+    MagInterpol.defineCellPoint101(tmpX[0], tmpX[1], tmpX[2], tmpB[0], tmpB[1], tmpB[2]);
+    putIndicesGetXAndB(index0[0], index1[1], index1[2], tmpX[0], tmpX[1], tmpX[2], tmpB[0], tmpB[1], tmpB[2]);
+    MagInterpol.defineCellPoint011(tmpX[0], tmpX[1], tmpX[2], tmpB[0], tmpB[1], tmpB[2]);
+    putIndicesGetXAndB(index1[0], index1[1], index1[2], tmpX[0], tmpX[1], tmpX[2], tmpB[0], tmpB[1], tmpB[2]);
+    MagInterpol.defineCellPoint111(tmpX[0], tmpX[1], tmpX[2], tmpB[0], tmpB[1], tmpB[2]);
     // interpolate
-    MagInterpol.putSCoordGetVField(X1,X2,X3,Bx,By,Bz);
+    MagInterpol.putSCoordGetVField(X1, X2, X3, Bx, By, Bz);
   }
 
   return;
 }
 
-void prepareMagneticFieldGrid::putCoordGetIndices(double X1, double X2, double X3, int &Index1, int &Index2, int &Index3){
-
-  double pnt[3] = {X1,X2,X3};
+void prepareMagneticFieldGrid::putCoordGetIndices(
+    double X1, double X2, double X3, int &Index1, int &Index2, int &Index3) {
+  double pnt[3] = {X1, X2, X3};
   int index[3];
-	
-  if (GridType < 5){
-    for (int i=0; i<3; ++i){
-      if (EasyCoordinate[i]){
-	index[i] = int((pnt[i]-ReferencePoint[i])/BasicDistance0[i]);
+
+  if (GridType < 5) {
+    for (int i = 0; i < 3; ++i) {
+      if (EasyCoordinate[i]) {
+        index[i] = int((pnt[i] - ReferencePoint[i]) / BasicDistance0[i]);
       }
     }
-    for (int i=0; i<3; ++i){
-      if (!EasyCoordinate[i]){
-	double stepSize = BasicDistance0[i];
-	double offset   = 0.0;
-	for (int j=0; j<3; ++j){
-	  stepSize += BasicDistance1[i][j]*index[j];
-	  offset   += BasicDistance2[i][j]*index[j];
-	}
-	index[i] = int((pnt[i]-(ReferencePoint[i] + offset))/stepSize);
+    for (int i = 0; i < 3; ++i) {
+      if (!EasyCoordinate[i]) {
+        double stepSize = BasicDistance0[i];
+        double offset = 0.0;
+        for (int j = 0; j < 3; ++j) {
+          stepSize += BasicDistance1[i][j] * index[j];
+          offset += BasicDistance2[i][j] * index[j];
+        }
+        index[i] = int((pnt[i] - (ReferencePoint[i] + offset)) / stepSize);
       }
     }
   }
-  if (GridType == 5 || GridType == 6){
-
-    double sinPhi; // either sin or cos depending on grid type
-    if (GridType==6) {
+  if (GridType == 5 || GridType == 6) {
+    double sinPhi;  // either sin or cos depending on grid type
+    if (GridType == 6) {
       sinPhi = cos(pnt[1]);
-    } else if (GridType==5) {
+    } else if (GridType == 5) {
       sinPhi = sin(pnt[1]);
     } else {
       abort();
-    } 
-    
-    if (std::abs(sinPhi) < EPSILON){
+    }
+
+    if (std::abs(sinPhi) < EPSILON) {
       sinPhi = EPSILON;
       cout << "ERROR DIVISION BY ZERO" << endl;
     }
-    double stepSize = RParAsFunOfPhi[0] + RParAsFunOfPhi[1]/sinPhi - RParAsFunOfPhi[2] - RParAsFunOfPhi[3]/sinPhi;
-    stepSize =  stepSize/(NumberOfPoints[0]-1);
-    double startingPoint = RParAsFunOfPhi[2] + RParAsFunOfPhi[3]/sinPhi;
-    index[0] = int((pnt[0]-startingPoint)/stepSize);
-    index[1] = int((pnt[1]-ReferencePoint[1])/BasicDistance0[1]);
-    index[2] = int((pnt[2]-ReferencePoint[2])/BasicDistance0[2]);
+    double stepSize = RParAsFunOfPhi[0] + RParAsFunOfPhi[1] / sinPhi - RParAsFunOfPhi[2] - RParAsFunOfPhi[3] / sinPhi;
+    stepSize = stepSize / (NumberOfPoints[0] - 1);
+    double startingPoint = RParAsFunOfPhi[2] + RParAsFunOfPhi[3] / sinPhi;
+    index[0] = int((pnt[0] - startingPoint) / stepSize);
+    index[1] = int((pnt[1] - ReferencePoint[1]) / BasicDistance0[1]);
+    index[2] = int((pnt[2] - ReferencePoint[2]) / BasicDistance0[2]);
   }
 
   Index1 = index[0];
@@ -1356,8 +1460,8 @@ void prepareMagneticFieldGrid::putCoordGetIndices(double X1, double X2, double X
   return;
 }
 
-void prepareMagneticFieldGrid::putIndicesGetXAndB(int Index1, int Index2, int Index3, double &X1, double &X2, double &X3, double &Bx, double &By, double &Bz){
-
+void prepareMagneticFieldGrid::putIndicesGetXAndB(
+    int Index1, int Index2, int Index3, double &X1, double &X2, double &X3, double &Bx, double &By, double &Bz) {
   SixDPoint GridPoint;
   GridPoint = GridData.operator[](lineNumber(Index1, Index2, Index3));
   X1 = GridPoint.x1();
@@ -1370,49 +1474,48 @@ void prepareMagneticFieldGrid::putIndicesGetXAndB(int Index1, int Index2, int In
   return;
 }
 
-void prepareMagneticFieldGrid::putIndCalcXReturnB(int Index1, int Index2, int Index3, double &X1, double &X2, double &X3, double &Bx, double &By, double &Bz){
-
+void prepareMagneticFieldGrid::putIndCalcXReturnB(
+    int Index1, int Index2, int Index3, double &X1, double &X2, double &X3, double &Bx, double &By, double &Bz) {
   int index[3] = {Index1, Index2, Index3};
   double pnt[3];
 
-  if (GridType < 5){
-    for (int i=0; i<3; ++i){
-      if (EasyCoordinate[i]){
-	pnt[i] = ReferencePoint[i] + BasicDistance0[i]*index[i];
-      }
-      else {
-	double stepSize = BasicDistance0[i];
-	double offset   = 0.0;
-	for (int j=0; j<3; ++j){
-	  stepSize += BasicDistance1[i][j]*index[j];
-	  offset   += BasicDistance2[i][j]*index[j];
-	}
-	pnt[i] = ReferencePoint[i] + offset + stepSize*index[i];
+  if (GridType < 5) {
+    for (int i = 0; i < 3; ++i) {
+      if (EasyCoordinate[i]) {
+        pnt[i] = ReferencePoint[i] + BasicDistance0[i] * index[i];
+      } else {
+        double stepSize = BasicDistance0[i];
+        double offset = 0.0;
+        for (int j = 0; j < 3; ++j) {
+          stepSize += BasicDistance1[i][j] * index[j];
+          offset += BasicDistance2[i][j] * index[j];
+        }
+        pnt[i] = ReferencePoint[i] + offset + stepSize * index[i];
       }
     }
   }
-  if (GridType == 5 || GridType == 6){
-    pnt[2] = ReferencePoint[2] + BasicDistance0[2]*index[2];
-    pnt[1] = ReferencePoint[1] + BasicDistance0[1]*index[1];
+  if (GridType == 5 || GridType == 6) {
+    pnt[2] = ReferencePoint[2] + BasicDistance0[2] * index[2];
+    pnt[1] = ReferencePoint[1] + BasicDistance0[1] * index[1];
 
-    double sinPhi; // Set either cos or sin depending on grid type
-    if (GridType==6) {
+    double sinPhi;  // Set either cos or sin depending on grid type
+    if (GridType == 6) {
       sinPhi = cos(pnt[1]);
-    } else if (GridType ==5) {
+    } else if (GridType == 5) {
       sinPhi = sin(pnt[1]);
     } else {
       cout << "unknown GridType!" << endl;
       abort();
     }
-    
-    if (std::abs(sinPhi) < EPSILON){
+
+    if (std::abs(sinPhi) < EPSILON) {
       sinPhi = EPSILON;
       cout << "ERROR DIVISION BY ZERO" << endl;
     }
-    double stepSize = RParAsFunOfPhi[0] + RParAsFunOfPhi[1]/sinPhi - RParAsFunOfPhi[2] - RParAsFunOfPhi[3]/sinPhi;
-    stepSize =  stepSize/(NumberOfPoints[0]-1);
-    double startingPoint = RParAsFunOfPhi[2] + RParAsFunOfPhi[3]/sinPhi;
-    pnt[0] = startingPoint + stepSize*index[0];
+    double stepSize = RParAsFunOfPhi[0] + RParAsFunOfPhi[1] / sinPhi - RParAsFunOfPhi[2] - RParAsFunOfPhi[3] / sinPhi;
+    stepSize = stepSize / (NumberOfPoints[0] - 1);
+    double startingPoint = RParAsFunOfPhi[2] + RParAsFunOfPhi[3] / sinPhi;
+    pnt[0] = startingPoint + stepSize * index[0];
   }
 
   X1 = pnt[0];
@@ -1428,40 +1531,43 @@ void prepareMagneticFieldGrid::putIndCalcXReturnB(int Index1, int Index2, int In
   return;
 }
 
-int prepareMagneticFieldGrid::lineNumber(int Index1, int Index2, int Index3){
-  return Index1*NumberOfPoints[1]*NumberOfPoints[2] + Index2*NumberOfPoints[2] + Index3;
+int prepareMagneticFieldGrid::lineNumber(int Index1, int Index2, int Index3) {
+  return Index1 * NumberOfPoints[1] * NumberOfPoints[2] + Index2 * NumberOfPoints[2] + Index3;
 }
 
-
-bool prepareMagneticFieldGrid::IndexedDoubleVector::operator<(const IndexedDoubleVector& x) const{
-
-  if (I3[0] < x.I3[0]) return true;
-  else if (I3[0] == x.I3[0]){
-    if (I3[1] < x.I3[1]) return true;
-    else if (I3[1] == x.I3[1]){
-      if (I3[2] < x.I3[2]) return true;
-      else                 return false;
-    }
-    else                 return false;
-  }
-  else                 return false;
+bool prepareMagneticFieldGrid::IndexedDoubleVector::operator<(const IndexedDoubleVector &x) const {
+  if (I3[0] < x.I3[0])
+    return true;
+  else if (I3[0] == x.I3[0]) {
+    if (I3[1] < x.I3[1])
+      return true;
+    else if (I3[1] == x.I3[1]) {
+      if (I3[2] < x.I3[2])
+        return true;
+      else
+        return false;
+    } else
+      return false;
+  } else
+    return false;
 }
 
-void prepareMagneticFieldGrid::IndexedDoubleVector::putI3(int  index1, int  index2, int  index3){
+void prepareMagneticFieldGrid::IndexedDoubleVector::putI3(int index1, int index2, int index3) {
   I3[0] = index1;
   I3[1] = index2;
   I3[2] = index3;
   return;
 }
 
-void prepareMagneticFieldGrid::IndexedDoubleVector::getI3(int &index1, int &index2, int &index3){
+void prepareMagneticFieldGrid::IndexedDoubleVector::getI3(int &index1, int &index2, int &index3) {
   index1 = I3[0];
   index2 = I3[1];
   index3 = I3[2];
   return;
 }
 
-void prepareMagneticFieldGrid::IndexedDoubleVector::putV6(double  X1, double  X2, double  X3, double  Bx, double  By, double  Bz){
+void prepareMagneticFieldGrid::IndexedDoubleVector::putV6(
+    double X1, double X2, double X3, double Bx, double By, double Bz) {
   V6[0] = X1;
   V6[1] = X2;
   V6[2] = X3;
@@ -1471,7 +1577,8 @@ void prepareMagneticFieldGrid::IndexedDoubleVector::putV6(double  X1, double  X2
   return;
 }
 
-void prepareMagneticFieldGrid::IndexedDoubleVector::getV6(double &X1, double &X2, double &X3, double &Bx, double &By, double &Bz){
+void prepareMagneticFieldGrid::IndexedDoubleVector::getV6(
+    double &X1, double &X2, double &X3, double &Bx, double &By, double &Bz) {
   X1 = V6[0];
   X2 = V6[1];
   X3 = V6[2];
@@ -1481,8 +1588,7 @@ void prepareMagneticFieldGrid::IndexedDoubleVector::getV6(double &X1, double &X2
   return;
 }
 
-
-void prepareMagneticFieldGrid::SixDPoint::putP6(double  X1, double  X2, double  X3, double  Bx, double  By, double  Bz){
+void prepareMagneticFieldGrid::SixDPoint::putP6(double X1, double X2, double X3, double Bx, double By, double Bz) {
   P6[0] = X1;
   P6[1] = X2;
   P6[2] = X3;
@@ -1492,14 +1598,14 @@ void prepareMagneticFieldGrid::SixDPoint::putP6(double  X1, double  X2, double  
   return;
 }
 
-double prepareMagneticFieldGrid::SixDPoint::x1(){  return P6[0]; }
+double prepareMagneticFieldGrid::SixDPoint::x1() { return P6[0]; }
 
-double prepareMagneticFieldGrid::SixDPoint::x2(){  return P6[1]; }
+double prepareMagneticFieldGrid::SixDPoint::x2() { return P6[1]; }
 
-double prepareMagneticFieldGrid::SixDPoint::x3(){  return P6[2]; }
+double prepareMagneticFieldGrid::SixDPoint::x3() { return P6[2]; }
 
-double prepareMagneticFieldGrid::SixDPoint::bx(){  return P6[3]; }
+double prepareMagneticFieldGrid::SixDPoint::bx() { return P6[3]; }
 
-double prepareMagneticFieldGrid::SixDPoint::by(){  return P6[4]; }
+double prepareMagneticFieldGrid::SixDPoint::by() { return P6[4]; }
 
-double prepareMagneticFieldGrid::SixDPoint::bz(){  return P6[5]; }
+double prepareMagneticFieldGrid::SixDPoint::bz() { return P6[5]; }

--- a/MagneticField/Interpolation/test/BinaryTablesGeneration/prepareMagneticFieldGrid.h
+++ b/MagneticField/Interpolation/test/BinaryTablesGeneration/prepareMagneticFieldGrid.h
@@ -38,63 +38,82 @@
 #define PRINT true
 #define EPSILON 1e-4
 
-class prepareMagneticFieldGrid{
+class prepareMagneticFieldGrid {
 public:
   // constructor
-  prepareMagneticFieldGrid(int rotateFromSector=0) :
-    rotateSector(rotateFromSector)
-{
+  prepareMagneticFieldGrid(int rotateFromSector = 0) : rotateSector(rotateFromSector) {
     GridType = 0;
-    for (int i=0;i<3; ++i) {NumberOfPoints[i] = 0;};
-    for (int i=0;i<3; ++i) {ReferencePoint[i] = 0.;};
-    for (int i=0;i<3; ++i) {BasicDistance0[i] = 0.;};
-    for (int i=0;i<3; ++i) {for (int j=0;j<3; ++j) {BasicDistance1[i][j] = 0.;};};
-    for (int i=0;i<3; ++i) {for (int j=0;j<3; ++j) {BasicDistance2[i][j] = 0.;};};
-    for (int i=0;i<4; ++i) {RParAsFunOfPhi[i] = 0.;};
-    for (int i=0;i<3; ++i) {EasyCoordinate[i] = false;};
+    for (int i = 0; i < 3; ++i) {
+      NumberOfPoints[i] = 0;
+    };
+    for (int i = 0; i < 3; ++i) {
+      ReferencePoint[i] = 0.;
+    };
+    for (int i = 0; i < 3; ++i) {
+      BasicDistance0[i] = 0.;
+    };
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        BasicDistance1[i][j] = 0.;
+      };
+    };
+    for (int i = 0; i < 3; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        BasicDistance2[i][j] = 0.;
+      };
+    };
+    for (int i = 0; i < 4; ++i) {
+      RParAsFunOfPhi[i] = 0.;
+    };
+    for (int i = 0; i < 3; ++i) {
+      EasyCoordinate[i] = false;
+    };
     KnownStructure = false;
     XyzCoordinates = false;
     RpzCoordinates = false;
     sector = unknown;
-}
+  }
   // destructor
-  ~prepareMagneticFieldGrid(){}
+  ~prepareMagneticFieldGrid() {}
 
 private:
+  enum masterSector { unknown = 0, one = 1, four = 4 };
 
-  enum masterSector {unknown=0, one=1, four=4};
-
-  class IndexedDoubleVector{
+  class IndexedDoubleVector {
   public:
     // constructor
-    IndexedDoubleVector(){}
+    IndexedDoubleVector() {}
     // destructor
-    ~IndexedDoubleVector(){}
+    ~IndexedDoubleVector() {}
     // less operator (defined for indices: 1st index = highest priority, 2nd index = 2nd highest priority, ...)
-    bool operator<(const IndexedDoubleVector&) const;
+    bool operator<(const IndexedDoubleVector &) const;
+
   private:
     // six component vector in double precision
-    int    I3[3];
+    int I3[3];
     double V6[6];
+
   public:
     // Accessors
-    void putI3(int  index1, int  index2, int  index3);
+    void putI3(int index1, int index2, int index3);
     void getI3(int &index1, int &index2, int &index3);
-    void putV6(double  X1, double  X2, double  X3, double  Bx, double  By, double  Bz);
+    void putV6(double X1, double X2, double X3, double Bx, double By, double Bz);
     void getV6(double &X1, double &X2, double &X3, double &Bx, double &By, double &Bz);
   };
-  class SixDPoint{
+  class SixDPoint {
   public:
     // constructor
-    SixDPoint(){}
+    SixDPoint() {}
     // destructor
-    ~SixDPoint(){}
+    ~SixDPoint() {}
+
   private:
     // six component vector in double precision
     double P6[6];
+
   public:
     // Accessors
-    void putP6(double  X1, double  X2, double  X3, double  Bx, double  By, double  Bz);
+    void putP6(double X1, double X2, double X3, double Bx, double By, double Bz);
     double x1();
     double x2();
     double x3();
@@ -104,17 +123,17 @@ private:
   };
   // definition of grid
   // structure
-  int    GridType;
-  int    NumberOfPoints[3];
+  int GridType;
+  int NumberOfPoints[3];
   double ReferencePoint[3];
   double BasicDistance0[3];     // constant step
   double BasicDistance1[3][3];  // linear step
   double BasicDistance2[3][3];  // linear offset
   double RParAsFunOfPhi[4];     // R = f(phi) or const. (0,2: const. par. ; 1,3: const./sin(phi))
-  bool   EasyCoordinate[3];
-  bool   KnownStructure;
-  bool   XyzCoordinates;
-  bool   RpzCoordinates;
+  bool EasyCoordinate[3];
+  bool KnownStructure;
+  bool XyzCoordinates;
+  bool RpzCoordinates;
   int rotateSector;
   masterSector sector;
 
@@ -126,17 +145,17 @@ private:
 
 public:
   /// check, if number of lines corresponds to number of points in space (double counting test)
-  void countTrueNumberOfPoints(const std::string& name) const;
+  void countTrueNumberOfPoints(const std::string &name) const;
   /// reads the corresponding ASCII file, detects the logic of the points, and saves them on a grid
-  void fillFromFile(const std::string& name);
+  void fillFromFile(const std::string &name);
   /// sames as fillFromFile, but for special cases which are not covered by the standard algorithm
-  void fillFromFileSpecial(const std::string& name);
+  void fillFromFileSpecial(const std::string &name);
   /// returns value of GridType (and eventually prints the type + short description)
   int gridType();
   /// possibility to check existing MagneticFieldGrid point by point (all points)
   void validateAllPoints();
   /// sames as fillFromFile, but for special cases which are not covered by the standard algorithm
-  void saveGridToFile(const std::string& outName);
+  void saveGridToFile(const std::string &outName);
 
   /// indicates, that MagneticFieldGrid is fully operational (for interpolation)
   bool isReady();
@@ -146,14 +165,14 @@ public:
 
   // calculates indices from coordinates
   void putCoordGetIndices(double X1, double X2, double X3, int &Index1, int &Index2, int &Index3);
-  // takes indices and returns coordinates and magnetic field values 
-  void putIndicesGetXAndB(int Index1, int Index2, int Index3, double &X1, double &X2, double &X3, double &Bx, double &By, double &Bz);
+  // takes indices and returns coordinates and magnetic field values
+  void putIndicesGetXAndB(
+      int Index1, int Index2, int Index3, double &X1, double &X2, double &X3, double &Bx, double &By, double &Bz);
   // takes indices, calculates coordinates, and returns coordinates + magnetic fiels values (for testing purposes only)
-  void putIndCalcXReturnB(int Index1, int Index2, int Index3, double &X1, double &X2, double &X3, double &Bx, double &By, double &Bz);
+  void putIndCalcXReturnB(
+      int Index1, int Index2, int Index3, double &X1, double &X2, double &X3, double &Bx, double &By, double &Bz);
   // converts three indices into one number (for the vector GridData)
   int lineNumber(int Index1, int Index2, int Index3);
-
 };
-
 
 #endif

--- a/MagneticField/VolumeGeometry/interface/FourPointPlaneBounds.h
+++ b/MagneticField/VolumeGeometry/interface/FourPointPlaneBounds.h
@@ -5,46 +5,40 @@
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
 #include "DataFormats/GeometryVector/interface/Vector2DBase.h"
 
-typedef Vector2DBase< float, LocalTag>    Local2DVector;
+typedef Vector2DBase<float, LocalTag> Local2DVector;
 
 class FourPointPlaneBounds : public Bounds {
 public:
+  typedef LocalPoint::ScalarType Scalar;
 
-    typedef LocalPoint::ScalarType    Scalar;
-
-/** The corners are ASSUMED to come in cyclic order
+  /** The corners are ASSUMED to come in cyclic order
  */
-    FourPointPlaneBounds( const LocalPoint& a, const LocalPoint& b, 
-			  const LocalPoint& c, const LocalPoint& d); 
-    ~FourPointPlaneBounds() override {}
+  FourPointPlaneBounds(const LocalPoint& a, const LocalPoint& b, const LocalPoint& c, const LocalPoint& d);
+  ~FourPointPlaneBounds() override {}
 
   float length() const override;
   float width() const override;
   float thickness() const override;
 
-    // basic bounds function
-    bool inside( const Local3DPoint& lp) const override;
-    
-    bool inside( const Local3DPoint& lp , const LocalError& e, float scale) const override {
-      return inside( lp);
-    }
+  // basic bounds function
+  bool inside(const Local3DPoint& lp) const override;
 
-    Bounds* clone() const override {return new FourPointPlaneBounds(*this);}
+  bool inside(const Local3DPoint& lp, const LocalError& e, float scale) const override { return inside(lp); }
+
+  Bounds* clone() const override { return new FourPointPlaneBounds(*this); }
 
 private:
+  Local2DPoint corners_[4];
 
-    Local2DPoint corners_[4];
+  const Local2DPoint& corner(int i) const { return corners_[i % 4]; }
+  double checkSide(int i, const Local2DPoint& lp) const;
 
-    const Local2DPoint& corner(int i) const {return corners_[i%4];}
-    double checkSide( int i, const Local2DPoint& lp) const;
-
-    double checkSide( int i, Scalar x, Scalar y) const {
-	const Local2DPoint& cor( corner(i));
-	Local2DVector v( corner(i+1) - cor);
-	// Local2DVector normal( -v.y(), v.x());  //  90 deg rotated
-	return -v.y() * (x-cor.x()) + v.x() * (y-cor.y()); // == normal.dot(LP(x,y)-cor))
-    }
-
+  double checkSide(int i, Scalar x, Scalar y) const {
+    const Local2DPoint& cor(corner(i));
+    Local2DVector v(corner(i + 1) - cor);
+    // Local2DVector normal( -v.y(), v.x());  //  90 deg rotated
+    return -v.y() * (x - cor.x()) + v.x() * (y - cor.y());  // == normal.dot(LP(x,y)-cor))
+  }
 };
 
 #endif

--- a/MagneticField/VolumeGeometry/interface/MagCylinder.h
+++ b/MagneticField/VolumeGeometry/interface/MagCylinder.h
@@ -15,29 +15,27 @@ class MagneticFieldProvider;
 
 class MagCylinder : public MagVolume {
 public:
+  MagCylinder(const PositionType& pos,
+              const RotationType& rot,
+              const std::vector<VolumeSide>& faces,
+              const MagneticFieldProvider<float>* mfp);
 
-  MagCylinder( const PositionType& pos, const RotationType& rot, 
-	       const std::vector<VolumeSide>& faces,
-	       const MagneticFieldProvider<float> * mfp);
-
-  bool inside( const GlobalPoint& gp, double tolerance=0.) const override;
-  bool inside( const LocalPoint& lp, double tolerance=0.) const override;
+  bool inside(const GlobalPoint& gp, double tolerance = 0.) const override;
+  bool inside(const LocalPoint& lp, double tolerance = 0.) const override;
 
   /// Access to volume faces
-  const std::vector<VolumeSide>& faces() const override {return theFaces;}
+  const std::vector<VolumeSide>& faces() const override { return theFaces; }
 
   //-- FIXME
   std::string name;
   //--
 
 private:
-
   std::vector<VolumeSide> theFaces;
   Scalar theZmin;
   Scalar theZmax;
   Scalar theInnerR;
   Scalar theOuterR;
-
 };
 
 #endif

--- a/MagneticField/VolumeGeometry/interface/MagExceptions.h
+++ b/MagneticField/VolumeGeometry/interface/MagExceptions.h
@@ -7,9 +7,10 @@
 class MagException : public std::exception {
 public:
   MagException() throw() {}
-  MagException( const char *message);
+  MagException(const char *message);
   ~MagException() throw() override;
-  const char* what() const throw() override;
+  const char *what() const throw() override;
+
 private:
   std::string theMessage;
 };
@@ -30,12 +31,11 @@ public:
 
 class GridInterpolator3DException : public std::exception {
 public:
-
-  GridInterpolator3DException(double a1, double b1, double c1,
-			      double a2, double b2, double c2)  throw();
+  GridInterpolator3DException(double a1, double b1, double c1, double a2, double b2, double c2) throw();
   ~GridInterpolator3DException() throw() override;
-  const char* what() const throw() override;
-  double  *limits(void) {return limits_;}
+  const char *what() const throw() override;
+  double *limits(void) { return limits_; }
+
 protected:
   double limits_[6];
 };

--- a/MagneticField/VolumeGeometry/interface/MagVolume.h
+++ b/MagneticField/VolumeGeometry/interface/MagVolume.h
@@ -12,51 +12,46 @@ class MagneticFieldProvider;
 
 class MagVolume : public GloballyPositioned<float>, public MagneticField {
 public:
+  typedef GloballyPositioned<float> Base;
+  typedef GloballyPositioned<float>::LocalPoint LocalPoint;
+  typedef GloballyPositioned<float>::LocalVector LocalVector;
+  typedef GloballyPositioned<float>::GlobalPoint GlobalPoint;
+  typedef GloballyPositioned<float>::GlobalVector GlobalVector;
 
-  typedef GloballyPositioned<float>    Base;
-  typedef GloballyPositioned<float>::LocalPoint     LocalPoint;
-  typedef GloballyPositioned<float>::LocalVector    LocalVector;
-  typedef GloballyPositioned<float>::GlobalPoint    GlobalPoint;
-  typedef GloballyPositioned<float>::GlobalVector   GlobalVector;
-
-  MagVolume( const PositionType& pos, const RotationType& rot, 
-	     const MagneticFieldProvider<float> * mfp,
-	     double sf=1.) :
-    Base(pos,rot), MagneticField(), theProvider(mfp), 
-    theProviderOwned(false), theScalingFactor(sf), isIronFlag(false) {}
+  MagVolume(const PositionType& pos, const RotationType& rot, const MagneticFieldProvider<float>* mfp, double sf = 1.)
+      : Base(pos, rot),
+        MagneticField(),
+        theProvider(mfp),
+        theProviderOwned(false),
+        theScalingFactor(sf),
+        isIronFlag(false) {}
 
   ~MagVolume() override;
 
-  LocalVector fieldInTesla( const LocalPoint& lp) const;
-  GlobalVector fieldInTesla( const GlobalPoint& lp) const;
+  LocalVector fieldInTesla(const LocalPoint& lp) const;
+  GlobalVector fieldInTesla(const GlobalPoint& lp) const;
 
-  virtual bool inside( const GlobalPoint& gp, double tolerance=0.) const = 0;
-  virtual bool inside( const LocalPoint& lp, double tolerance=0.) const {
-    return inside( toGlobal(lp), tolerance);
-  }
+  virtual bool inside(const GlobalPoint& gp, double tolerance = 0.) const = 0;
+  virtual bool inside(const LocalPoint& lp, double tolerance = 0.) const { return inside(toGlobal(lp), tolerance); }
 
-  const MagneticFieldProvider<float>* provider() const {return theProvider;}
+  const MagneticFieldProvider<float>* provider() const { return theProvider; }
 
   /// Access to volume faces
   virtual const std::vector<VolumeSide>& faces() const = 0;
 
-  ::GlobalVector inTesla ( const ::GlobalPoint& gp) const override {
-    return fieldInTesla( gp);
-  }
+  ::GlobalVector inTesla(const ::GlobalPoint& gp) const override { return fieldInTesla(gp); }
 
   /// Temporary hack to pass information on material. Will eventually be replaced!
-  bool isIron() const {return isIronFlag;}
-  void setIsIron(bool iron) {isIronFlag = iron;}
-  void ownsFieldProvider(bool o) {theProviderOwned=o;}
+  bool isIron() const { return isIronFlag; }
+  void setIsIron(bool iron) { isIronFlag = iron; }
+  void ownsFieldProvider(bool o) { theProviderOwned = o; }
 
 private:
-
-  const MagneticFieldProvider<float> * theProvider;
+  const MagneticFieldProvider<float>* theProvider;
   bool theProviderOwned;
   double theScalingFactor;
   // Temporary hack to keep information on material. Will eventually be replaced!
   bool isIronFlag;
-
 };
 
 #endif

--- a/MagneticField/VolumeGeometry/interface/MagVolume6Faces.h
+++ b/MagneticField/VolumeGeometry/interface/MagVolume6Faces.h
@@ -22,17 +22,17 @@ class MagneticFieldProvider;
 
 class MagVolume6Faces : public MagVolume {
 public:
-
-  MagVolume6Faces( const PositionType& pos, const RotationType& rot, 
-		   const std::vector<VolumeSide>& faces,
-		   const MagneticFieldProvider<float> * mfp,
-		   double sf=1.);
+  MagVolume6Faces(const PositionType& pos,
+                  const RotationType& rot,
+                  const std::vector<VolumeSide>& faces,
+                  const MagneticFieldProvider<float>* mfp,
+                  double sf = 1.);
 
   using MagVolume::inside;
-  bool inside( const GlobalPoint& gp, double tolerance=0.) const override;
+  bool inside(const GlobalPoint& gp, double tolerance = 0.) const override;
 
   /// Access to volume faces
-  const std::vector<VolumeSide>& faces() const override {return theFaces;}
+  const std::vector<VolumeSide>& faces() const override { return theFaces; }
 
   //--> These are used for debugging purposes only
   short volumeNo;
@@ -40,9 +40,7 @@ public:
   //<--
 
 private:
-
   std::vector<VolumeSide> theFaces;
-
 };
 
 #endif

--- a/MagneticField/VolumeGeometry/interface/MagVolumeOutsideValidity.h
+++ b/MagneticField/VolumeGeometry/interface/MagVolumeOutsideValidity.h
@@ -2,23 +2,18 @@
 #define MagVolumeOutsideValidity_H
 
 #include "MagneticField/VolumeGeometry/interface/MagVolume.h"
-#include <exception> 
+#include <exception>
 
 class MagVolumeOutsideValidity : public std::exception {
 public:
+  MagVolumeOutsideValidity(MagVolume::LocalPoint l, MagVolume::LocalPoint u) throw();
 
-  MagVolumeOutsideValidity( MagVolume::LocalPoint l,
-			    MagVolume::LocalPoint u) throw();
-
-  MagVolume::LocalPoint lower() const  throw() {return lower_;} 
-  MagVolume::LocalPoint upper() const  throw() {return upper_;} 
+  MagVolume::LocalPoint lower() const throw() { return lower_; }
+  MagVolume::LocalPoint upper() const throw() { return upper_; }
 
   ~MagVolumeOutsideValidity() throw() override {}
 
-  const char* what() const throw() override { 
-    return m_message.c_str();
-  }
-
+  const char* what() const throw() override { return m_message.c_str(); }
 
 private:
   std::string m_message;

--- a/MagneticField/VolumeGeometry/interface/MagneticFieldProvider.h
+++ b/MagneticField/VolumeGeometry/interface/MagneticFieldProvider.h
@@ -16,18 +16,16 @@
 template <class T>
 class MagneticFieldProvider {
 public:
+  typedef Point3DBase<T, GlobalTag> GlobalPointType;
+  typedef Point3DBase<T, LocalTag> LocalPointType;
+  typedef Vector3DBase<T, GlobalTag> GlobalVectorType;
+  typedef Vector3DBase<T, LocalTag> LocalVectorType;
 
-  typedef Point3DBase<T,GlobalTag>      GlobalPointType;
-  typedef Point3DBase<T,LocalTag>       LocalPointType;
-  typedef Vector3DBase<T,GlobalTag>     GlobalVectorType;
-  typedef Vector3DBase<T,LocalTag>      LocalVectorType;
-
-
-  virtual ~MagneticFieldProvider(){}
+  virtual ~MagneticFieldProvider() {}
 
   /** Returns the field vector in the local frame, at local position p
    */
-  virtual LocalVectorType valueInTesla( const LocalPointType& p) const = 0;
+  virtual LocalVectorType valueInTesla(const LocalPointType& p) const = 0;
 
   /** Returns the field vector in the global frame, at global position p
    * Not needed, the MagVolume does the transformation to global!
@@ -37,15 +35,11 @@ public:
   /** Returns the maximal order of available derivatives.
    *  Returns 0 if derivatives are not available.
    */
-  virtual int hasDerivatives() const {return false;}
+  virtual int hasDerivatives() const { return false; }
 
   /** Returns the Nth spacial derivative of the field in the local frame.
    */
-  virtual LocalVectorType derivativeInTeslaPerMeter( const LocalPointType& p, 
-						     int N) const {
-    return LocalVectorType();
-  }
-
+  virtual LocalVectorType derivativeInTeslaPerMeter(const LocalPointType& p, int N) const { return LocalVectorType(); }
 };
 
 #endif

--- a/MagneticField/VolumeGeometry/interface/VolumeSide.h
+++ b/MagneticField/VolumeGeometry/interface/VolumeSide.h
@@ -16,30 +16,27 @@ class VolumeSide {
 public:
   typedef SurfaceOrientation::GlobalFace GlobalFace;
   typedef SurfaceOrientation::Side Side;
-  
-  typedef ReferenceCountingPointer<Surface>    SurfacePointer;
 
-  VolumeSide( Surface* surf, GlobalFace gSide, Side sSide) : 
-    theSurface( surf),  theGlobalFace( gSide), theSurfaceSide( sSide) {}
+  typedef ReferenceCountingPointer<Surface> SurfacePointer;
 
-  VolumeSide( SurfacePointer surf, GlobalFace gSide,
-	      Side sSide) : 
-    theSurface( surf),  theGlobalFace( gSide), theSurfaceSide( sSide) {}
+  VolumeSide(Surface* surf, GlobalFace gSide, Side sSide)
+      : theSurface(surf), theGlobalFace(gSide), theSurfaceSide(sSide) {}
 
-  Surface& mutableSurface() const {return *theSurface;}
+  VolumeSide(SurfacePointer surf, GlobalFace gSide, Side sSide)
+      : theSurface(surf), theGlobalFace(gSide), theSurfaceSide(sSide) {}
 
-  const Surface& surface() const {return *theSurface;}
+  Surface& mutableSurface() const { return *theSurface; }
 
-  GlobalFace globalFace() const { return theGlobalFace;}
+  const Surface& surface() const { return *theSurface; }
 
-  Side  surfaceSide() const {return theSurfaceSide;}
+  GlobalFace globalFace() const { return theGlobalFace; }
+
+  Side surfaceSide() const { return theSurfaceSide; }
 
 private:
-
   SurfacePointer theSurface;
-  GlobalFace     theGlobalFace;
-  Side           theSurfaceSide;
-
+  GlobalFace theGlobalFace;
+  Side theSurfaceSide;
 };
 
 #endif

--- a/MagneticField/VolumeGeometry/src/FourPointPlaneBounds.cc
+++ b/MagneticField/VolumeGeometry/src/FourPointPlaneBounds.cc
@@ -5,39 +5,39 @@
 #include <algorithm>
 #include <iostream>
 
-FourPointPlaneBounds::FourPointPlaneBounds( const LocalPoint& a, const LocalPoint& b, 
-					    const LocalPoint& c, const LocalPoint& d) {
-    corners_[0] = Local2DPoint( a.x(), a.y());
-    corners_[1] = Local2DPoint( b.x(), b.y());
-    corners_[2] = Local2DPoint( c.x(), c.y());
-    corners_[3] = Local2DPoint( d.x(), d.y());
+FourPointPlaneBounds::FourPointPlaneBounds(const LocalPoint& a,
+                                           const LocalPoint& b,
+                                           const LocalPoint& c,
+                                           const LocalPoint& d) {
+  corners_[0] = Local2DPoint(a.x(), a.y());
+  corners_[1] = Local2DPoint(b.x(), b.y());
+  corners_[2] = Local2DPoint(c.x(), c.y());
+  corners_[3] = Local2DPoint(d.x(), d.y());
 
-// check for convexity
-    for (int i=0; i<4; ++i) {
-	if (checkSide( i, corner(i+2)) *  checkSide( i, corner(i+3)) < 0) { // not on same side
-	    throw GeometryError("FourPointPlaneBounds: coners not in order or not convex");
-	}
+  // check for convexity
+  for (int i = 0; i < 4; ++i) {
+    if (checkSide(i, corner(i + 2)) * checkSide(i, corner(i + 3)) < 0) {  // not on same side
+      throw GeometryError("FourPointPlaneBounds: coners not in order or not convex");
     }
+  }
 
-    double side = checkSide( 0, corners_[2]); // - for clockwise corners, + for counterclockwise
-    if (side < 0) {
-	std::cout << "FourPointPlaneBounds: Changing order of corners to counterclockwise" << std::endl;
-	std::swap( corners_[1], corners_[3]);
-    }
+  double side = checkSide(0, corners_[2]);  // - for clockwise corners, + for counterclockwise
+  if (side < 0) {
+    std::cout << "FourPointPlaneBounds: Changing order of corners to counterclockwise" << std::endl;
+    std::swap(corners_[1], corners_[3]);
+  }
 }
 
-double FourPointPlaneBounds::checkSide( int i, const Local2DPoint& lp) const {
-    return checkSide(i, lp.x(), lp.y());
+double FourPointPlaneBounds::checkSide(int i, const Local2DPoint& lp) const { return checkSide(i, lp.x(), lp.y()); }
+
+bool FourPointPlaneBounds::inside(const Local3DPoint& lp) const {
+  for (int i = 0; i < 4; ++i) {
+    if (checkSide(i, lp.x(), lp.y()) < 0)
+      return false;
+  }
+  return true;
 }
 
-bool FourPointPlaneBounds::inside( const Local3DPoint& lp) const
-{
-    for (int i=0; i<4; ++i) {
-	if (checkSide(i,lp.x(),lp.y()) < 0) return false;
-    }
-    return true;
-}
-
-float FourPointPlaneBounds::length() const {return 0;}
-float FourPointPlaneBounds::width() const {return 0;}
-float FourPointPlaneBounds::thickness() const {return 0;}
+float FourPointPlaneBounds::length() const { return 0; }
+float FourPointPlaneBounds::width() const { return 0; }
+float FourPointPlaneBounds::thickness() const { return 0; }

--- a/MagneticField/VolumeGeometry/src/MagCylinder.cc
+++ b/MagneticField/VolumeGeometry/src/MagCylinder.cc
@@ -2,51 +2,42 @@
 #include "MagneticField/VolumeGeometry/interface/MagExceptions.h"
 #include "DataFormats/GeometrySurface/interface/Cylinder.h"
 
-MagCylinder::MagCylinder( const PositionType& pos,
-			  const RotationType& rot, 
-			  const std::vector<VolumeSide>& faces,
-			  const MagneticFieldProvider<float> * mfp)
-  : MagVolume(pos,rot,mfp), theFaces(faces), theZmin(0.), theZmax(0.), theInnerR(0.), theOuterR(0.)
-{
+MagCylinder::MagCylinder(const PositionType& pos,
+                         const RotationType& rot,
+                         const std::vector<VolumeSide>& faces,
+                         const MagneticFieldProvider<float>* mfp)
+    : MagVolume(pos, rot, mfp), theFaces(faces), theZmin(0.), theZmax(0.), theInnerR(0.), theOuterR(0.) {
   using SurfaceOrientation::GlobalFace;
 
   unsigned int def = 0;
-  for (std::vector<VolumeSide>::const_iterator i=faces.begin(); i!= faces.end(); ++i) {
+  for (std::vector<VolumeSide>::const_iterator i = faces.begin(); i != faces.end(); ++i) {
     if (i->globalFace() == SurfaceOrientation::zminus) {
-      theZmin = MagVolume::toLocal( i->surface().position()).z();
+      theZmin = MagVolume::toLocal(i->surface().position()).z();
       ++def;
-    }
-    else if (i->globalFace() == SurfaceOrientation::zplus) {
-      theZmax = MagVolume::toLocal( i->surface().position()).z();
+    } else if (i->globalFace() == SurfaceOrientation::zplus) {
+      theZmax = MagVolume::toLocal(i->surface().position()).z();
       ++def;
-    }
-    else if (i->globalFace() == SurfaceOrientation::outer || i->globalFace() == SurfaceOrientation::inner) {
+    } else if (i->globalFace() == SurfaceOrientation::outer || i->globalFace() == SurfaceOrientation::inner) {
       const Cylinder* cyl = dynamic_cast<const Cylinder*>(&(i->surface()));
       if (cyl == nullptr) {
-	throw MagGeometryError("MagCylinder inner/outer surface is not a cylinder");
+        throw MagGeometryError("MagCylinder inner/outer surface is not a cylinder");
       }
-      if (i->globalFace() == SurfaceOrientation::outer) theOuterR = cyl->radius();
-      else                                              theInnerR = cyl->radius();
+      if (i->globalFace() == SurfaceOrientation::outer)
+        theOuterR = cyl->radius();
+      else
+        theInnerR = cyl->radius();
       ++def;
     }
   }
   if (def != faces.size()) {
     throw MagGeometryError("MagCylinder constructed with wrong number/type of faces");
   }
-  
 }
 
-bool MagCylinder::inside( const GlobalPoint& gp, double tolerance) const 
-{
-  return inside( toLocal(gp), tolerance);
-}
+bool MagCylinder::inside(const GlobalPoint& gp, double tolerance) const { return inside(toLocal(gp), tolerance); }
 
-bool MagCylinder::inside( const LocalPoint& lp, double tolerance) const 
-{
-  Scalar r( lp.perp());
-  return 
-    lp.z() > theZmin - tolerance &&
-    lp.z() < theZmax + tolerance &&
-    r      > theInnerR - tolerance && 
-    r      < theOuterR + tolerance;
+bool MagCylinder::inside(const LocalPoint& lp, double tolerance) const {
+  Scalar r(lp.perp());
+  return lp.z() > theZmin - tolerance && lp.z() < theZmax + tolerance && r > theInnerR - tolerance &&
+         r < theOuterR + tolerance;
 }

--- a/MagneticField/VolumeGeometry/src/MagExceptions.cc
+++ b/MagneticField/VolumeGeometry/src/MagExceptions.cc
@@ -1,13 +1,11 @@
 #include "MagneticField/VolumeGeometry/interface/MagExceptions.h"
 
-MagException::MagException(const char *message) : theMessage(message) {}
+MagException::MagException(const char* message) : theMessage(message) {}
 MagException::~MagException() throw() {}
-const char* 
-MagException::what() const throw() { return theMessage.c_str();}
+const char* MagException::what() const throw() { return theMessage.c_str(); }
 
-GridInterpolator3DException::GridInterpolator3DException(double a1, double b1, double c1,
-                                                         double a2, double b2, double c2)  throw() 
-{
+GridInterpolator3DException::GridInterpolator3DException(
+    double a1, double b1, double c1, double a2, double b2, double c2) throw() {
   limits_[0] = a1;
   limits_[1] = b1;
   limits_[2] = c1;
@@ -18,5 +16,6 @@ GridInterpolator3DException::GridInterpolator3DException(double a1, double b1, d
 
 GridInterpolator3DException::~GridInterpolator3DException() throw() {}
 
-const char* 
-GridInterpolator3DException::what() const throw() { return "LinearGridInterpolator3D: field requested outside of grid validity";}
+const char* GridInterpolator3DException::what() const throw() {
+  return "LinearGridInterpolator3D: field requested outside of grid validity";
+}

--- a/MagneticField/VolumeGeometry/src/MagVolume.cc
+++ b/MagneticField/VolumeGeometry/src/MagVolume.cc
@@ -4,17 +4,14 @@
 #include "MagneticField/VolumeGeometry/interface/MagneticFieldProvider.h"
 
 MagVolume::~MagVolume() {
-  if (theProviderOwned) delete theProvider;
+  if (theProviderOwned)
+    delete theProvider;
 }
 
-
-MagVolume::LocalVector MagVolume::fieldInTesla( const LocalPoint& lp) const 
-{
-  return theProvider->valueInTesla(lp)*theScalingFactor;
+MagVolume::LocalVector MagVolume::fieldInTesla(const LocalPoint& lp) const {
+  return theProvider->valueInTesla(lp) * theScalingFactor;
 }
 
-MagVolume::GlobalVector MagVolume::fieldInTesla( const GlobalPoint& gp) const
-{
-  return toGlobal( theProvider->valueInTesla( toLocal(gp)))*theScalingFactor;
+MagVolume::GlobalVector MagVolume::fieldInTesla(const GlobalPoint& gp) const {
+  return toGlobal(theProvider->valueInTesla(toLocal(gp))) * theScalingFactor;
 }
-

--- a/MagneticField/VolumeGeometry/src/MagVolume6Faces.cc
+++ b/MagneticField/VolumeGeometry/src/MagVolume6Faces.cc
@@ -1,20 +1,18 @@
 #include "MagneticField/VolumeGeometry/interface/MagVolume6Faces.h"
 
-MagVolume6Faces::MagVolume6Faces( const PositionType& pos,
-				  const RotationType& rot, 
-				  const std::vector<VolumeSide>& faces,
-				  const MagneticFieldProvider<float> * mfp,
-				  double sf)
-  : MagVolume(pos,rot,mfp,sf),  volumeNo(0), copyno(0), theFaces(faces)
-{}
+MagVolume6Faces::MagVolume6Faces(const PositionType& pos,
+                                 const RotationType& rot,
+                                 const std::vector<VolumeSide>& faces,
+                                 const MagneticFieldProvider<float>* mfp,
+                                 double sf)
+    : MagVolume(pos, rot, mfp, sf), volumeNo(0), copyno(0), theFaces(faces) {}
 
-bool MagVolume6Faces::inside( const GlobalPoint& gp, double tolerance) const 
-{
-
+bool MagVolume6Faces::inside(const GlobalPoint& gp, double tolerance) const {
   // check if the point is on the correct side of all delimiting surfaces
-  for (std::vector<VolumeSide>::const_iterator i=theFaces.begin(); i!=theFaces.end(); ++i) {
-    Surface::Side side = i->surface().side( gp, tolerance);
-    if ( side != i->surfaceSide() && side != SurfaceOrientation::onSurface) return false;
+  for (std::vector<VolumeSide>::const_iterator i = theFaces.begin(); i != theFaces.end(); ++i) {
+    Surface::Side side = i->surface().side(gp, tolerance);
+    if (side != i->surfaceSide() && side != SurfaceOrientation::onSurface)
+      return false;
   }
   return true;
 }

--- a/MagneticField/VolumeGeometry/src/MagVolumeOutsideValidity.cc
+++ b/MagneticField/VolumeGeometry/src/MagVolumeOutsideValidity.cc
@@ -6,11 +6,10 @@
 #include "MagneticField/VolumeGeometry/interface/MagVolumeOutsideValidity.h"
 #include <sstream>
 
-MagVolumeOutsideValidity::MagVolumeOutsideValidity( MagVolume::LocalPoint l,
-						    MagVolume::LocalPoint u) throw() : lower_(l), upper_(u) {
+MagVolumeOutsideValidity::MagVolumeOutsideValidity(MagVolume::LocalPoint l, MagVolume::LocalPoint u) throw()
+    : lower_(l), upper_(u) {
   std::stringstream linestr;
-  linestr << "Magnetic field requested outside of validity of the MagVolume: "
-	  << lower() << " - " << upper() << std::endl;
-  m_message = linestr.str();  
+  linestr << "Magnetic field requested outside of validity of the MagVolume: " << lower() << " - " << upper()
+          << std::endl;
+  m_message = linestr.str();
 }
-

--- a/RecoLocalCalo/EcalRecAlgos/interface/ESRecHitAnalyticAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/ESRecHitAnalyticAlgo.h
@@ -10,14 +10,12 @@
 #include "CondFormats/ESObjects/interface/ESAngleCorrectionFactors.h"
 
 class ESRecHitAnalyticAlgo {
-
- public:
-
+public:
   ESRecHitAnalyticAlgo();
   ~ESRecHitAnalyticAlgo();
 
   void setESGain(const double& value) { gain_ = value; }
-  void setMIPGeV(const double& value) { MIPGeV_ = value; } 
+  void setMIPGeV(const double& value) { MIPGeV_ = value; }
   void setPedestals(const ESPedestals* peds) { peds_ = peds; }
   void setIntercalibConstants(const ESIntercalibConstants* mips) { mips_ = mips; }
   void setChannelStatus(const ESChannelStatus* status) { channelStatus_ = status; }
@@ -26,16 +24,14 @@ class ESRecHitAnalyticAlgo {
   double* EvalAmplitude(const ESDataFrame& digi, double ped) const;
   EcalRecHit reconstruct(const ESDataFrame& digi) const;
 
- private:
-
+private:
   double gain_;
-  const ESPedestals *peds_;
-  const ESIntercalibConstants *mips_;
-  const ESChannelStatus *channelStatus_;
-  const ESRecHitRatioCuts *ratioCuts_;
-  const ESAngleCorrectionFactors *ang_;
+  const ESPedestals* peds_;
+  const ESIntercalibConstants* mips_;
+  const ESChannelStatus* channelStatus_;
+  const ESRecHitRatioCuts* ratioCuts_;
+  const ESAngleCorrectionFactors* ang_;
   double MIPGeV_;
-
 };
 
 #endif

--- a/RecoLocalCalo/EcalRecAlgos/interface/ESRecHitFitAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/ESRecHitFitAlgo.h
@@ -12,14 +12,12 @@
 #include "TF1.h"
 
 class ESRecHitFitAlgo {
-
- public:
-
+public:
   ESRecHitFitAlgo();
   ~ESRecHitFitAlgo();
 
   void setESGain(const double& value) { gain_ = value; }
-  void setMIPGeV(const double& value) { MIPGeV_ = value; } 
+  void setMIPGeV(const double& value) { MIPGeV_ = value; }
   void setPedestals(const ESPedestals* peds) { peds_ = peds; }
   void setIntercalibConstants(const ESIntercalibConstants* mips) { mips_ = mips; }
   void setChannelStatus(const ESChannelStatus* status) { channelStatus_ = status; }
@@ -28,17 +26,15 @@ class ESRecHitFitAlgo {
   double* EvalAmplitude(const ESDataFrame& digi, double ped) const;
   EcalRecHit reconstruct(const ESDataFrame& digi) const;
 
- private:
-
-  TF1 *fit_;
+private:
+  TF1* fit_;
   double gain_;
-  const ESPedestals *peds_;
-  const ESIntercalibConstants *mips_;
-  const ESChannelStatus *channelStatus_;
-  const ESRecHitRatioCuts *ratioCuts_;
-  const ESAngleCorrectionFactors *ang_;
+  const ESPedestals* peds_;
+  const ESIntercalibConstants* mips_;
+  const ESChannelStatus* channelStatus_;
+  const ESRecHitRatioCuts* ratioCuts_;
+  const ESAngleCorrectionFactors* ang_;
   double MIPGeV_;
-
 };
 
 #endif

--- a/RecoLocalCalo/EcalRecAlgos/interface/ESRecHitSimAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/ESRecHitSimAlgo.h
@@ -10,9 +10,7 @@
 #include "CondFormats/ESObjects/interface/ESAngleCorrectionFactors.h"
 
 class ESRecHitSimAlgo {
-
- public:
-
+public:
   void setESGain(float value) { gain_ = value; }
   void setMIPGeV(float value) { MIPGeV_ = value; }
   void setPedestals(const ESPedestals* peds) { peds_ = peds; }
@@ -20,32 +18,29 @@ class ESRecHitSimAlgo {
   void setChannelStatus(const ESChannelStatus* status) { channelStatus_ = status; }
   void setRatioCuts(const ESRecHitRatioCuts* ratioCuts) { ratioCuts_ = ratioCuts; }
   void setAngleCorrectionFactors(const ESAngleCorrectionFactors* ang) { ang_ = ang; }
-  void setW0(float value) { w0_ = value; } 
-  void setW1(float value) { w1_ = value; } 
-  void setW2(float value) { w2_ = value; } 
+  void setW0(float value) { w0_ = value; }
+  void setW1(float value) { w1_ = value; }
+  void setW2(float value) { w2_ = value; }
 
   EcalRecHit reconstruct(const ESDataFrame& digi) const;
 
- private:
+private:
+  EcalRecHit::ESFlags evalAmplitude(float* result, const ESDataFrame& digi, float ped) const;
 
-  EcalRecHit::ESFlags evalAmplitude(float * result, const ESDataFrame& digi, float ped) const;
-
-  double* oldEvalAmplitude(const ESDataFrame& digi, const double& ped, const double& w0, const double& w1, const double& w2) const;
+  double* oldEvalAmplitude(
+      const ESDataFrame& digi, const double& ped, const double& w0, const double& w1, const double& w2) const;
   EcalRecHit oldreconstruct(const ESDataFrame& digi) const;
 
-
-
   int gain_;
-  const ESPedestals *peds_;
-  const ESIntercalibConstants *mips_;
-  const ESChannelStatus *channelStatus_;
-  const ESRecHitRatioCuts *ratioCuts_;
-  const ESAngleCorrectionFactors *ang_;
+  const ESPedestals* peds_;
+  const ESIntercalibConstants* mips_;
+  const ESChannelStatus* channelStatus_;
+  const ESRecHitRatioCuts* ratioCuts_;
+  const ESAngleCorrectionFactors* ang_;
   float w0_;
   float w1_;
   float w2_;
   float MIPGeV_;
-
 };
 
 #endif

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalCleaningAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalCleaningAlgo.h
@@ -9,33 +9,26 @@
 #ifndef __EcalCleaningAlgo_h_
 #define __EcalCleaningAlgo_h_
 
-
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h" 
-#include "DataFormats/EcalRecHit/interface/EcalRecHit.h" 
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
 #include <vector>
 
 class DetId;
 
-
-class EcalCleaningAlgo{
-
-
+class EcalCleaningAlgo {
 public:
-  
   EcalCleaningAlgo(const edm::ParameterSet& p);
-  
+
   /** check topology, return :
    *  kGood    : not anomalous
       kWeird   : spike
       kDiWeird : dispike */
-  EcalRecHit::Flags checkTopology(const DetId& id,
-				  const EcalRecHitCollection& rhs);
+  EcalRecHit::Flags checkTopology(const DetId& id, const EcalRecHitCollection& rhs);
 
   void setFlags(EcalRecHitCollection& rhs);
-  
+
 private:
-  
   /// yet another function to calculate swiss cross
   float e4e1(const DetId& id, const EcalRecHitCollection& rhs);
 
@@ -47,12 +40,10 @@ private:
            | |1|2| |
            +-+-+-+-+
              | | |               */
-  float e6e2 (const DetId& id, const EcalRecHitCollection& rhs);
+  float e6e2(const DetId& id, const EcalRecHitCollection& rhs);
 
-  float recHitE( const DetId id, 
-		 const EcalRecHitCollection &recHits,
-		 bool  useTimingInfo);
-  
+  float recHitE(const DetId id, const EcalRecHitCollection& recHits, bool useTimingInfo);
+
   /// in EB, check if we are near a crack
   bool isNearCrack(const DetId& detid);
 
@@ -62,10 +53,10 @@ private:
   ///ignore kOutOfTime above threshold when calculating e4e1
   float ignoreOutOfTimeThresh_;
 
-  // Parameters for tolopogical cut 
+  // Parameters for tolopogical cut
   // mark anomalous if e> cThreshold &&  e4e1> a*log10(e1e1)+b
   float cThreshold_barrel_;
-  float cThreshold_endcap_;         
+  float cThreshold_endcap_;
   float e4e1_a_barrel_;
   float e4e1_b_barrel_;
   float e4e1_a_endcap_;
@@ -79,10 +70,9 @@ private:
   float tightenCrack_e1_double_;
   float tightenCrack_e6e2_double_;
   float e6e2thresh_;
-
 };
 
-#endif // __EcalCleaningAlgo_h_
+#endif  // __EcalCleaningAlgo_h_
 
 // Configure (x)emacs for this file ...
 // Local Variables:

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalRecHitAbsAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalRecHitAbsAlgo.h
@@ -11,20 +11,20 @@
 #include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
 #include "DataFormats/EcalRecHit/interface/EcalUncalibratedRecHit.h"
 
-class EcalRecHitAbsAlgo
-{
- public:
-
+class EcalRecHitAbsAlgo {
+public:
   /// Constructor
   //EcalRecHitAbsAlgo() { };
 
   /// Destructor
-  virtual ~EcalRecHitAbsAlgo() { };
+  virtual ~EcalRecHitAbsAlgo(){};
 
   /// make rechits from dataframes
 
   virtual void setADCToGeVConstant(const float& value) = 0;
-  virtual EcalRecHit makeRecHit(const EcalUncalibratedRecHit& uncalibRH, const float& intercalib, const float& timecalib, const uint32_t &flags) const = 0;
-
+  virtual EcalRecHit makeRecHit(const EcalUncalibratedRecHit& uncalibRH,
+                                const float& intercalib,
+                                const float& timecalib,
+                                const uint32_t& flags) const = 0;
 };
 #endif

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalRecHitSimpleAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalRecHitSimpleAlgo.h
@@ -13,7 +13,7 @@
 #include <iostream>
 
 class EcalRecHitSimpleAlgo : public EcalRecHitAbsAlgo {
- public:
+public:
   // default ctor
   EcalRecHitSimpleAlgo() {
     adcToGeVConstant_ = -1;
@@ -25,72 +25,70 @@ class EcalRecHitSimpleAlgo : public EcalRecHitAbsAlgo {
     adcToGeVConstantIsSet_ = true;
   }
 
-
   // destructor
-  ~EcalRecHitSimpleAlgo() override { };
+  ~EcalRecHitSimpleAlgo() override{};
 
   /// Compute parameters
   EcalRecHit makeRecHit(const EcalUncalibratedRecHit& uncalibRH,
-                                const float& intercalibConstant,
-                                const float& timeIntercalib = 0,
-                                const uint32_t& flags = 0) const override {
-
-    if(!adcToGeVConstantIsSet_) {
-      std::cout << "EcalRecHitSimpleAlgo::makeRecHit: adcToGeVConstant_ not set before calling this method!" << 
-                   " will use -1 and produce bogus rechits!" << std::endl;
+                        const float& intercalibConstant,
+                        const float& timeIntercalib = 0,
+                        const uint32_t& flags = 0) const override {
+    if (!adcToGeVConstantIsSet_) {
+      std::cout << "EcalRecHitSimpleAlgo::makeRecHit: adcToGeVConstant_ not set before calling this method!"
+                << " will use -1 and produce bogus rechits!" << std::endl;
     }
 
     float clockToNsConstant = 25;
-    float energy = uncalibRH.amplitude()*adcToGeVConstant_*intercalibConstant;
-    float time   = uncalibRH.jitter() * clockToNsConstant + timeIntercalib;
+    float energy = uncalibRH.amplitude() * adcToGeVConstant_ * intercalibConstant;
+    float time = uncalibRH.jitter() * clockToNsConstant + timeIntercalib;
 
-    EcalRecHit rh( uncalibRH.id(), energy, time );
-    rh.setChi2( uncalibRH.chi2() );
-    rh.setEnergyError( uncalibRH.amplitudeError()*adcToGeVConstant_*intercalibConstant);
+    EcalRecHit rh(uncalibRH.id(), energy, time);
+    rh.setChi2(uncalibRH.chi2());
+    rh.setEnergyError(uncalibRH.amplitudeError() * adcToGeVConstant_ * intercalibConstant);
     /* rh.setOutOfTimeEnergy( uncalibRH.outOfTimeEnergy() * adcToGeVConstant_ * intercalibConstant ); */
     /* rh.setOutOfTimeChi2( uncalibRH.outOfTimeChi2() ); */
     rh.setTimeError(uncalibRH.jitterErrorBits());
 
     // Now fill flags
 
-    bool good=true;
-    
-    if ( uncalibRH.checkFlag(EcalUncalibratedRecHit::kLeadingEdgeRecovered) ){
-            rh.setFlag(EcalRecHit::kLeadingEdgeRecovered);
-            good=false; 
-    } 
-    if ( uncalibRH.checkFlag(EcalUncalibratedRecHit::kSaturated) ) { 
-            // leading edge recovery failed - still keep the information 
-            // about the saturation and do not flag as dead 
-            rh.setFlag(EcalRecHit::kSaturated); 
-            good=false;
-    } 
-    if( uncalibRH.isSaturated() ) {
-            rh.setFlag(EcalRecHit::kSaturated);
-            good=false;
-    } 
-    if ( uncalibRH.checkFlag(EcalUncalibratedRecHit::kOutOfTime) ) {
-            rh.setFlag(EcalRecHit::kOutOfTime) ;
-	    good=false;   
-    } 
-    if ( uncalibRH.checkFlag(EcalUncalibratedRecHit::kPoorReco) ) {
-            rh.setFlag(EcalRecHit::kPoorReco);
-            good=false;
+    bool good = true;
+
+    if (uncalibRH.checkFlag(EcalUncalibratedRecHit::kLeadingEdgeRecovered)) {
+      rh.setFlag(EcalRecHit::kLeadingEdgeRecovered);
+      good = false;
     }
-    if ( uncalibRH.checkFlag( EcalUncalibratedRecHit::kHasSwitchToGain6 ) ) {
-            rh.setFlag(EcalRecHit::kHasSwitchToGain6);
+    if (uncalibRH.checkFlag(EcalUncalibratedRecHit::kSaturated)) {
+      // leading edge recovery failed - still keep the information
+      // about the saturation and do not flag as dead
+      rh.setFlag(EcalRecHit::kSaturated);
+      good = false;
     }
-    if (uncalibRH.checkFlag( EcalUncalibratedRecHit::kHasSwitchToGain1 ) ) {
-            rh.setFlag(EcalRecHit::kHasSwitchToGain1);
+    if (uncalibRH.isSaturated()) {
+      rh.setFlag(EcalRecHit::kSaturated);
+      good = false;
     }
-    
-    if (good) rh.setFlag(EcalRecHit::kGood);
+    if (uncalibRH.checkFlag(EcalUncalibratedRecHit::kOutOfTime)) {
+      rh.setFlag(EcalRecHit::kOutOfTime);
+      good = false;
+    }
+    if (uncalibRH.checkFlag(EcalUncalibratedRecHit::kPoorReco)) {
+      rh.setFlag(EcalRecHit::kPoorReco);
+      good = false;
+    }
+    if (uncalibRH.checkFlag(EcalUncalibratedRecHit::kHasSwitchToGain6)) {
+      rh.setFlag(EcalRecHit::kHasSwitchToGain6);
+    }
+    if (uncalibRH.checkFlag(EcalUncalibratedRecHit::kHasSwitchToGain1)) {
+      rh.setFlag(EcalRecHit::kHasSwitchToGain1);
+    }
+
+    if (good)
+      rh.setFlag(EcalRecHit::kGood);
     return rh;
   }
 
 private:
   float adcToGeVConstant_;
-  bool  adcToGeVConstantIsSet_;
-
+  bool adcToGeVConstantIsSet_;
 };
 #endif

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h
@@ -14,7 +14,6 @@
 #include "DataFormats/EcalRecHit/interface/EcalSeverityLevel.h"
 #include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
 
-
 #include <vector>
 
 /**
@@ -31,43 +30,30 @@
 class EcalRecHit;
 class DetId;
 
-
-class  EcalSeverityLevelAlgo{
-
-
+class EcalSeverityLevelAlgo {
 public:
-
- 
   explicit EcalSeverityLevelAlgo(const edm::ParameterSet& p);
-
 
   /// Evaluate status from id use channelStatus from DB
   EcalSeverityLevel::SeverityLevel severityLevel(const DetId& id) const;
 
-
   /** If the id is in the collection, use the EcalRecHit::Flag
       else use the channelStatus from DB 
    */
-  EcalSeverityLevel::SeverityLevel severityLevel(const DetId& id, 
-				  const EcalRecHitCollection& rhs) const;
-
+  EcalSeverityLevel::SeverityLevel severityLevel(const DetId& id, const EcalRecHitCollection& rhs) const;
 
   /// Evaluate status from rechit, using its EcalRecHit::Flag
   EcalSeverityLevel::SeverityLevel severityLevel(const EcalRecHit& rh) const;
 
-
-  /// Set the ChannelStatus record. 
-  void setChannelStatus(const EcalChannelStatus& chs){chStatus_=&chs;}
+  /// Set the ChannelStatus record.
+  void setChannelStatus(const EcalChannelStatus& chs) { chStatus_ = &chs; }
 
 private:
-
- 
   /// Configure which EcalRecHit::Flag is mapped into which EcalSeverityLevel
   /** The position in the vector is the EcalSeverityLevel
       The content defines which EcalRecHit::Flag should be mapped into that EcalSeverityLevel
       in a bit-wise way */
   std::vector<uint32_t> flagMask_;
-  
 
   /// Configure which DBStatus::Flag is mapped into which EcalSeverityLevel
   /** The position in the vector is the EcalSeverityLevel
@@ -75,15 +61,13 @@ private:
       in a bit-wise way*/
   std::vector<uint32_t> dbstatusMask_;
 
-
   /// Return kTime only if the rechit is flagged kOutOfTime and E>timeThresh_
   float timeThresh_;
 
-  const EcalChannelStatus * chStatus_;
+  const EcalChannelStatus* chStatus_;
 };
 
-
-#endif // __EcalSeverityLevelAlgo_h_
+#endif  // __EcalSeverityLevelAlgo_h_
 
 // Configure (x)emacs for this file ...
 // Local Variables:

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h
@@ -1,7 +1,6 @@
 #ifndef EcalSeverityLevelAlgoRcd_h
 #define EcalSeverityLevelAlgoRcd_h
 
-
 #include "boost/mpl/vector.hpp"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
@@ -10,6 +9,8 @@
 // Registration of EcalSeverityLevelAlgo to the EventSetup mechanism
 //
 
-class EcalSeverityLevelAlgoRcd : public edm::eventsetup::DependentRecordImplementation<EcalSeverityLevelAlgoRcd, boost::mpl::vector<EcalChannelStatusRcd> > {};
+class EcalSeverityLevelAlgoRcd
+    : public edm::eventsetup::DependentRecordImplementation<EcalSeverityLevelAlgoRcd,
+                                                            boost::mpl::vector<EcalChannelStatusRcd> > {};
 
 #endif

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitFixedAlphaBetaAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitFixedAlphaBetaAlgo.h
@@ -29,26 +29,23 @@
 //#include "TMatrixD.h"
 //#include "TVectorD.h"
 
-template<class C> class EcalUncalibRecHitFixedAlphaBetaAlgo : public EcalUncalibRecHitRecAbsAlgo<C>
-{
-
-
- private:
+template <class C>
+class EcalUncalibRecHitFixedAlphaBetaAlgo : public EcalUncalibRecHitRecAbsAlgo<C> {
+private:
   double MinAmpl_;
   bool dyn_pedestal;
-  double fAlpha_;//parameter of the shape
-  double fBeta_;//parameter of the shape
-  double fAmp_max_;// peak amplitude 
-  double fTim_max_ ;// time of the peak (in 25ns units)
-  double fPed_max_;// pedestal value
-  double alfabeta_; 
+  double fAlpha_;    //parameter of the shape
+  double fBeta_;     //parameter of the shape
+  double fAmp_max_;  // peak amplitude
+  double fTim_max_;  // time of the peak (in 25ns units)
+  double fPed_max_;  // pedestal value
+  double alfabeta_;
 
-  
   int fNb_iter_;
-  int  fNum_samp_bef_max_ ;
+  int fNum_samp_bef_max_;
   int fNum_samp_after_max_;
-  
-  float fSigma_ped; 
+
+  float fSigma_ped;
   double un_sur_sigma;
   //temporary solution for different alpha and beta
   float alpha_table_[36][1701];
@@ -59,328 +56,363 @@ template<class C> class EcalUncalibRecHitFixedAlphaBetaAlgo : public EcalUncalib
   double pulseShapeFunction(double t);
   float PerformAnalyticFit(double* samples, int max_sample);
   void InitFitParameters(double* samples, int max_sample);
-  CLHEP::HepSymMatrix DM1_ ; CLHEP::HepVector temp_;
-   public:
+  CLHEP::HepSymMatrix DM1_;
+  CLHEP::HepVector temp_;
 
-  EcalUncalibRecHitFixedAlphaBetaAlgo<C>():fAlpha_(0.),fBeta_(0.),fAmp_max_(-1.),fTim_max_(-1),fPed_max_(0),alfabeta_(0),fNb_iter_(4),fNum_samp_bef_max_(1),fNum_samp_after_max_(3),fSigma_ped(1.1),DM1_(3),temp_(3){
-    un_sur_sigma = 1./double(fSigma_ped) ;
-    for (int i=0;i<36;i++){
-      for(int j=0;j<1701;j++){
-	alpha_table_[i][j] = 1.2 ;
-	beta_table_[i][j]  =  1.7 ;
+public:
+  EcalUncalibRecHitFixedAlphaBetaAlgo<C>()
+      : fAlpha_(0.),
+        fBeta_(0.),
+        fAmp_max_(-1.),
+        fTim_max_(-1),
+        fPed_max_(0),
+        alfabeta_(0),
+        fNb_iter_(4),
+        fNum_samp_bef_max_(1),
+        fNum_samp_after_max_(3),
+        fSigma_ped(1.1),
+        DM1_(3),
+        temp_(3) {
+    un_sur_sigma = 1. / double(fSigma_ped);
+    for (int i = 0; i < 36; i++) {
+      for (int j = 0; j < 1701; j++) {
+        alpha_table_[i][j] = 1.2;
+        beta_table_[i][j] = 1.7;
       }
     }
     doFit_ = false;
     MinAmpl_ = 16;
     dyn_pedestal = true;
   }
-  EcalUncalibRecHitFixedAlphaBetaAlgo<C>(int n_iter, int n_bef_max =1, int n_aft_max =3, float sigma_ped = 1.1):fAlpha_(0.),fBeta_(0.),fAmp_max_(-1.),fTim_max_(-1),fPed_max_(0),alfabeta_(0),DM1_(3),temp_(3){
-    
-   fNb_iter_ = n_iter ;
-   fNum_samp_bef_max_   = n_bef_max ;
-   fNum_samp_after_max_ = n_aft_max ;
-   fSigma_ped = sigma_ped;
-   un_sur_sigma = 1./double(fSigma_ped) ;
-   for (int i=0;i<36;i++){
-     for(int j=0;j<1701;j++){
-       alpha_table_[i][j] = 1.2 ;
-       beta_table_[i][j]  =  1.7 ;
-     }
-   }
-   doFit_ = false;
-   MinAmpl_ = 16;
-   dyn_pedestal = true;
+  EcalUncalibRecHitFixedAlphaBetaAlgo<C>(int n_iter, int n_bef_max = 1, int n_aft_max = 3, float sigma_ped = 1.1)
+      : fAlpha_(0.), fBeta_(0.), fAmp_max_(-1.), fTim_max_(-1), fPed_max_(0), alfabeta_(0), DM1_(3), temp_(3) {
+    fNb_iter_ = n_iter;
+    fNum_samp_bef_max_ = n_bef_max;
+    fNum_samp_after_max_ = n_aft_max;
+    fSigma_ped = sigma_ped;
+    un_sur_sigma = 1. / double(fSigma_ped);
+    for (int i = 0; i < 36; i++) {
+      for (int j = 0; j < 1701; j++) {
+        alpha_table_[i][j] = 1.2;
+        beta_table_[i][j] = 1.7;
+      }
+    }
+    doFit_ = false;
+    MinAmpl_ = 16;
+    dyn_pedestal = true;
   };
 
-  ~EcalUncalibRecHitFixedAlphaBetaAlgo<C>() override { };
-  EcalUncalibratedRecHit makeRecHit(const C& dataFrame, const double* pedestals,
-					    const double* gainRatios,
-					    const EcalWeightSet::EcalWeightMatrix** weights, 
-					    const EcalWeightSet::EcalChi2WeightMatrix** chi2Matrix) override; 
-  void SetAlphaBeta( double alpha, double beta);
+  ~EcalUncalibRecHitFixedAlphaBetaAlgo<C>() override{};
+  EcalUncalibratedRecHit makeRecHit(const C& dataFrame,
+                                    const double* pedestals,
+                                    const double* gainRatios,
+                                    const EcalWeightSet::EcalWeightMatrix** weights,
+                                    const EcalWeightSet::EcalChi2WeightMatrix** chi2Matrix) override;
+  void SetAlphaBeta(double alpha, double beta);
   void SetMinAmpl(double ampl);
   void SetDynamicPedestal(bool dyn_pede);
 };
 
-
-
-  /// Compute parameters
-template<class C> EcalUncalibratedRecHit  EcalUncalibRecHitFixedAlphaBetaAlgo<C>::makeRecHit(const C& dataFrame, const double* pedestals,
-											     const double* gainRatios,
-											     const EcalWeightSet::EcalWeightMatrix** weights, 
-											     const EcalWeightSet::EcalChi2WeightMatrix** chi2Matrix){
+/// Compute parameters
+template <class C>
+EcalUncalibratedRecHit EcalUncalibRecHitFixedAlphaBetaAlgo<C>::makeRecHit(
+    const C& dataFrame,
+    const double* pedestals,
+    const double* gainRatios,
+    const EcalWeightSet::EcalWeightMatrix** weights,
+    const EcalWeightSet::EcalChi2WeightMatrix** chi2Matrix) {
   double chi2_(-1.);
-  
+
   //  double Gain12Equivalent[4]={0,1,2,12};
-  double frame[C::MAXSAMPLES];// will contain the ADC values
-  double pedestal =0;     // carries pedestal for gain12 i.e. gainId==1
-  
-  int gainId0 = 1;        // expected gainId at the beginning of dataFrame 
-  int iGainSwitch = 0;    // flags whether there's any gainId other than gainId0
-  int GainId= 0;          // stores gainId at every sample
-  double maxsample(-1);   // ADC value of maximal ped-subtracted sample
-  int imax(-1);           // sample number of maximal ped-subtracted sample
+  double frame[C::MAXSAMPLES];  // will contain the ADC values
+  double pedestal = 0;          // carries pedestal for gain12 i.e. gainId==1
+
+  int gainId0 = 1;       // expected gainId at the beginning of dataFrame
+  int iGainSwitch = 0;   // flags whether there's any gainId other than gainId0
+  int GainId = 0;        // stores gainId at every sample
+  double maxsample(-1);  // ADC value of maximal ped-subtracted sample
+  int imax(-1);          // sample number of maximal ped-subtracted sample
   bool external_pede = false;
-  bool isSaturated = false;   // flag reporting whether gain0 has been found
+  bool isSaturated = false;  // flag reporting whether gain0 has been found
 
   // Get time samples checking for Gain Switch and pedestals
-  if(pedestals){
+  if (pedestals) {
     external_pede = true;
-    if(dyn_pedestal) { pedestal = (double(dataFrame.sample(0).adc()) + double(dataFrame.sample(1).adc()))/2.;}
-    else{ pedestal  = pedestals[0];}
-    for(int iSample = 0; iSample < C::MAXSAMPLES; iSample++) {
-	//create frame in adc gain 12 equivalent
-	GainId = dataFrame.sample(iSample).gainId();
+    if (dyn_pedestal) {
+      pedestal = (double(dataFrame.sample(0).adc()) + double(dataFrame.sample(1).adc())) / 2.;
+    } else {
+      pedestal = pedestals[0];
+    }
+    for (int iSample = 0; iSample < C::MAXSAMPLES; iSample++) {
+      //create frame in adc gain 12 equivalent
+      GainId = dataFrame.sample(iSample).gainId();
 
-	// FIX-ME: warning: the vector pedestal is supposed to have in the order G12, G6 and G1
-        // if GainId is zero treat it as 3 temporarily to protect against undefined
-	// frame will be set to ~max of gain1
-	if ( GainId == 0 )
-	  { 
-	    GainId = 3;
-	    isSaturated = true;
-	  }
-
-	if (GainId != gainId0) iGainSwitch = 1;
-
-	if(GainId==gainId0){frame[iSample] = double(dataFrame.sample(iSample).adc())-pedestal ;}
-	else {frame[iSample] = (double(dataFrame.sample(iSample).adc())-pedestals[GainId-1])*gainRatios[GainId-1];}
-
-	if( frame[iSample]>maxsample ) {
-          maxsample = frame[iSample];
-          imax = iSample;
-	}
+      // FIX-ME: warning: the vector pedestal is supposed to have in the order G12, G6 and G1
+      // if GainId is zero treat it as 3 temporarily to protect against undefined
+      // frame will be set to ~max of gain1
+      if (GainId == 0) {
+        GainId = 3;
+        isSaturated = true;
       }
-  }
-  else {// pedestal from pre-sample
-    external_pede = false;
-    pedestal = (double(dataFrame.sample(0).adc()) + double(dataFrame.sample(1).adc()))/2.;
 
-    for(int iSample = 0; iSample < C::MAXSAMPLES; iSample++) {
+      if (GainId != gainId0)
+        iGainSwitch = 1;
+
+      if (GainId == gainId0) {
+        frame[iSample] = double(dataFrame.sample(iSample).adc()) - pedestal;
+      } else {
+        frame[iSample] = (double(dataFrame.sample(iSample).adc()) - pedestals[GainId - 1]) * gainRatios[GainId - 1];
+      }
+
+      if (frame[iSample] > maxsample) {
+        maxsample = frame[iSample];
+        imax = iSample;
+      }
+    }
+  } else {  // pedestal from pre-sample
+    external_pede = false;
+    pedestal = (double(dataFrame.sample(0).adc()) + double(dataFrame.sample(1).adc())) / 2.;
+
+    for (int iSample = 0; iSample < C::MAXSAMPLES; iSample++) {
       //create frame in adc gain 12 equivalent
       GainId = dataFrame.sample(iSample).gainId();
       //no gain switch forseen if there is no external pedestal
-      if ( GainId == 0 ) 
-	{
-	  GainId = 3;
-	  isSaturated = true;
-	}
-
-      frame[iSample] = double(dataFrame.sample(iSample).adc())-pedestal ;
-      // if gain has switched but no pedestals are available, no much good you can do...
-      if (GainId > gainId0) iGainSwitch = 1;
-      if( frame[iSample]>maxsample ) {
-	maxsample = frame[iSample];
-	imax = iSample;
+      if (GainId == 0) {
+        GainId = 3;
+        isSaturated = true;
       }
-    } 
+
+      frame[iSample] = double(dataFrame.sample(iSample).adc()) - pedestal;
+      // if gain has switched but no pedestals are available, no much good you can do...
+      if (GainId > gainId0)
+        iGainSwitch = 1;
+      if (frame[iSample] > maxsample) {
+        maxsample = frame[iSample];
+        imax = iSample;
+      }
+    }
   }
 
-  if( (iGainSwitch==1 && external_pede==false) ||  // ... thus you return dummy rechit
-      imax ==-1 ){                                 // protect against all frames being <-1
-    return EcalUncalibratedRecHit( dataFrame.id(), -1., -100., -1. , -1.);
+  if ((iGainSwitch == 1 && external_pede == false) ||  // ... thus you return dummy rechit
+      imax == -1) {                                    // protect against all frames being <-1
+    return EcalUncalibratedRecHit(dataFrame.id(), -1., -100., -1., -1.);
   }
-  
+
   InitFitParameters(frame, imax);
-  chi2_ = PerformAnalyticFit(frame,imax);
+  chi2_ = PerformAnalyticFit(frame, imax);
   uint32_t flags = 0;
-  if (isSaturated) flags = EcalUncalibratedRecHit::kSaturated;
+  if (isSaturated)
+    flags = EcalUncalibratedRecHit::kSaturated;
 
   /*    std::cout << "separate fits\nA: " << fAmp_max_  << ", ResidualPed: " <<  fPed_max_
               <<", pedestal: "<<pedestal << ", tPeak " << fTim_max_ << std::endl;
   */
-  return EcalUncalibratedRecHit( dataFrame.id(),fAmp_max_, pedestal+fPed_max_, fTim_max_ - 5 , chi2_, flags );
+  return EcalUncalibratedRecHit(dataFrame.id(), fAmp_max_, pedestal + fPed_max_, fTim_max_ - 5, chi2_, flags);
 }
 
-template<class C> double EcalUncalibRecHitFixedAlphaBetaAlgo<C>::pulseShapeFunction(double t){
-  if( alfabeta_ <= 0 ) return((double)0.);
-  double dtsbeta,variable,puiss;
-  double dt = t-fTim_max_ ;
-  if(dt > -alfabeta_)  {
-    dtsbeta=dt/fBeta_ ;
-    variable=1.+dt/alfabeta_ ;
-    puiss=pow(variable,fAlpha_);
-    return fAmp_max_*puiss*exp(-dtsbeta)+fPed_max_ ;
+template <class C>
+double EcalUncalibRecHitFixedAlphaBetaAlgo<C>::pulseShapeFunction(double t) {
+  if (alfabeta_ <= 0)
+    return ((double)0.);
+  double dtsbeta, variable, puiss;
+  double dt = t - fTim_max_;
+  if (dt > -alfabeta_) {
+    dtsbeta = dt / fBeta_;
+    variable = 1. + dt / alfabeta_;
+    puiss = pow(variable, fAlpha_);
+    return fAmp_max_ * puiss * exp(-dtsbeta) + fPed_max_;
   }
-  return  fPed_max_ ;
+  return fPed_max_;
 }
 
-template<class C> void  EcalUncalibRecHitFixedAlphaBetaAlgo<C>::InitFitParameters(double* samples, int max_sample){
-
-  // in a first attempt just use the value of the maximum sample 
+template <class C>
+void EcalUncalibRecHitFixedAlphaBetaAlgo<C>::InitFitParameters(double* samples, int max_sample) {
+  // in a first attempt just use the value of the maximum sample
   fAmp_max_ = samples[max_sample];
   fTim_max_ = max_sample;
   fPed_max_ = 0;
 
   // amplitude too low for fit to converge
   // timing set correctly is assumed
-  if(fAmp_max_ <  MinAmpl_){
-    fAmp_max_      = samples[5];
-    double sumA    = samples[5]+samples[4]+samples[6];
-    if(sumA != 0) { fTim_max_ = 5+(samples[6]-samples[4])/sumA; }
-    else{ fTim_max_ = -993; }//-999+6
+  if (fAmp_max_ < MinAmpl_) {
+    fAmp_max_ = samples[5];
+    double sumA = samples[5] + samples[4] + samples[6];
+    if (sumA != 0) {
+      fTim_max_ = 5 + (samples[6] - samples[4]) / sumA;
+    } else {
+      fTim_max_ = -993;
+    }  //-999+6
     doFit_ = false;
   }
   // if timing very badly off, that just use max sample
-  else if(max_sample <1 || max_sample > 7)
-    {    doFit_ = false;}
-  else{
+  else if (max_sample < 1 || max_sample > 7) {
+    doFit_ = false;
+  } else {
     //y=a*(x-xM)^2+b*(x-xM)+c
     doFit_ = true;
-    float a = float(samples[max_sample-1]+samples[max_sample+1]-2*samples[max_sample])/2.;
-    if(a==0){doFit_ =false; return;}
-    float b = float(samples[max_sample+1]-samples[max_sample-1])/2.;
-  
-    fTim_max_ = max_sample - b/(2*a);
-    fAmp_max_ =  samples[max_sample] - b*b/(4*a); 
-  }  
-  
-} 
+    float a = float(samples[max_sample - 1] + samples[max_sample + 1] - 2 * samples[max_sample]) / 2.;
+    if (a == 0) {
+      doFit_ = false;
+      return;
+    }
+    float b = float(samples[max_sample + 1] - samples[max_sample - 1]) / 2.;
 
-template<class C> float EcalUncalibRecHitFixedAlphaBetaAlgo<C>::PerformAnalyticFit(double* samples, int max_sample){
-  
-  //int fValue_tim_max = max_sample;  
+    fTim_max_ = max_sample - b / (2 * a);
+    fAmp_max_ = samples[max_sample] - b * b / (4 * a);
+  }
+}
+
+template <class C>
+float EcalUncalibRecHitFixedAlphaBetaAlgo<C>::PerformAnalyticFit(double* samples, int max_sample) {
+  //int fValue_tim_max = max_sample;
   //! fit electronic function from simulation
   //! parameters fAlpha_ and fBeta_ are fixed and fit is providing the 3 following parameters
-  //! the maximum amplitude ( fAmp_max_ ) 
+  //! the maximum amplitude ( fAmp_max_ )
   //! the time of the maximum  ( fTim_max_)
-  //| the pedestal (fPed_max_) 	
-  
-  double chi2=-1 , db[3] ;
-  
+  //| the pedestal (fPed_max_)
+
+  double chi2 = -1, db[3];
 
   //HepSymMatrix DM1(3) ; CLHEP::HepVector temp(3) ;
 
-  int num_fit_min =(int)(max_sample - fNum_samp_bef_max_ ) ;
-  int num_fit_max =(int)(max_sample + fNum_samp_after_max_) ;
+  int num_fit_min = (int)(max_sample - fNum_samp_bef_max_);
+  int num_fit_max = (int)(max_sample + fNum_samp_after_max_);
 
-  if (num_fit_min<0) num_fit_min = 0 ; 
+  if (num_fit_min < 0)
+    num_fit_min = 0;
   //if (num_fit_max>=fNsamples-1) num_fit_max = fNsamples-2 ;
-  if (num_fit_max>= C::MAXSAMPLES ) {num_fit_max = C::MAXSAMPLES-1 ;}
+  if (num_fit_max >= C::MAXSAMPLES) {
+    num_fit_max = C::MAXSAMPLES - 1;
+  }
 
-  if(! doFit_ ) {
-    LogDebug("EcalUncalibRecHitFixedAlphaBetaAlgo")<<"No fit performed. The amplitude of sample 5 will be used";
+  if (!doFit_) {
+    LogDebug("EcalUncalibRecHitFixedAlphaBetaAlgo") << "No fit performed. The amplitude of sample 5 will be used";
     return -1;
   }
 
-  double func,delta ;
-  double variation_func_max = 0. ;double variation_tim_max = 0. ; double variation_ped_max = 0. ;
+  double func, delta;
+  double variation_func_max = 0.;
+  double variation_tim_max = 0.;
+  double variation_ped_max = 0.;
   //!          Loop on iterations
-  for (int iter=0 ; iter < fNb_iter_ ; iter ++) {
+  for (int iter = 0; iter < fNb_iter_; iter++) {
     //!          initialization inside iteration loop !
-    chi2 = 0. ; //PROD.Zero() ;  DM1.Zero() ;
+    chi2 = 0.;  //PROD.Zero() ;  DM1.Zero() ;
 
-     for(int i1=0 ; i1<3 ; i1++) {
-       temp_[i1]=0;
-	for(int j1=i1 ; j1<3 ; j1++) { 
-	  DM1_.fast(j1+1,i1+1) = 0; }
+    for (int i1 = 0; i1 < 3; i1++) {
+      temp_[i1] = 0;
+      for (int j1 = i1; j1 < 3; j1++) {
+        DM1_.fast(j1 + 1, i1 + 1) = 0;
       }
+    }
 
-    fAmp_max_ += variation_func_max ;
-    fTim_max_ += variation_tim_max ;
-    fPed_max_ += variation_ped_max ;
-    
+    fAmp_max_ += variation_func_max;
+    fTim_max_ += variation_tim_max;
+    fPed_max_ += variation_ped_max;
+
     //! Then we loop on samples to be fitted
-    for( int i = num_fit_min ; i <= num_fit_max ; i++) {
+    for (int i = num_fit_min; i <= num_fit_max; i++) {
       //if(i>fsamp_edge_fit && i<num_fit_min) continue ; // remove front edge samples
       //! calculate function to be fitted
-      func = pulseShapeFunction( (double)i  ) ;
+      func = pulseShapeFunction((double)i);
       //! then calculate derivatives of function to be fitted
-      double dt =(double)i - fTim_max_ ;
-      if(dt > -alfabeta_)  {      
-	double dt_sur_beta = dt/fBeta_ ;
-	double variable = (double)1. + dt/alfabeta_ ;
-	double expo = exp(-dt_sur_beta) ;	 
-	double puissance = pow(variable,fAlpha_) ;
-	
-	db[0]=un_sur_sigma*puissance*expo ;
-	db[1]=fAmp_max_*db[0]*dt_sur_beta/(alfabeta_*variable) ;
+      double dt = (double)i - fTim_max_;
+      if (dt > -alfabeta_) {
+        double dt_sur_beta = dt / fBeta_;
+        double variable = (double)1. + dt / alfabeta_;
+        double expo = exp(-dt_sur_beta);
+        double puissance = pow(variable, fAlpha_);
+
+        db[0] = un_sur_sigma * puissance * expo;
+        db[1] = fAmp_max_ * db[0] * dt_sur_beta / (alfabeta_ * variable);
+      } else {
+        db[0] = 0.;
+        db[1] = 0.;
       }
-      else {
-	db[0]=0. ; db[1]=0. ; 
-      }
-      db[2]=un_sur_sigma ;
+      db[2] = un_sur_sigma;
       //! compute matrix elements DM1
-      for(int i1=0 ; i1<3 ; i1++) {
-	for(int j1=i1 ; j1<3 ; j1++) { 
-	  //double & fast(int row, int col);
-	  DM1_.fast(j1+1,i1+1) += db[i1]*db[j1]; }
+      for (int i1 = 0; i1 < 3; i1++) {
+        for (int j1 = i1; j1 < 3; j1++) {
+          //double & fast(int row, int col);
+          DM1_.fast(j1 + 1, i1 + 1) += db[i1] * db[j1];
+        }
       }
       //! compute delta
-      delta = (samples[i]-func)*un_sur_sigma ;
+      delta = (samples[i] - func) * un_sur_sigma;
       //! compute vector elements PROD
-      for(int ii=0 ; ii<3 ;ii++) {temp_[ii] += delta*db[ii] ;}
-      chi2 += delta * delta ;
-    }//! end of loop on samples 
-    
-    int fail=0 ;
-    DM1_.invert(fail) ;
-      if(fail != 0.) {
+      for (int ii = 0; ii < 3; ii++) {
+        temp_[ii] += delta * db[ii];
+      }
+      chi2 += delta * delta;
+    }  //! end of loop on samples
+
+    int fail = 0;
+    DM1_.invert(fail);
+    if (fail != 0.) {
       //just a guess from the value of the parameters in the previous interaction;
       //printf("wH4PulseFitWithFunction =====> determinant error --> No Fit Provided !\n") ;
-      InitFitParameters(samples,max_sample);
-      return -101 ;
+      InitFitParameters(samples, max_sample);
+      return -101;
     }
-/*     for(int i1=0 ; i1<3 ; i1++) { */
-/*       for(int j1=0 ; j1<3 ; j1++) {  */
-/* 	//double & fast(int row, int col); */
-/* 	std::cout<<"inverted: "<<DM1[j1][i1]<<std::endl;;} */
-/*     } */
-/*     std::cout<<"vector temp: "<< temp[0]<<" "<<temp[1]<<" "<<temp[2]<<std::endl; */
-    //! compute variations of parameters fAmp_max and fTim_max 
-    CLHEP::HepVector PROD = DM1_*temp_ ;
+    /*     for(int i1=0 ; i1<3 ; i1++) { */
+    /*       for(int j1=0 ; j1<3 ; j1++) {  */
+    /* 	//double & fast(int row, int col); */
+    /* 	std::cout<<"inverted: "<<DM1[j1][i1]<<std::endl;;} */
+    /*     } */
+    /*     std::cout<<"vector temp: "<< temp[0]<<" "<<temp[1]<<" "<<temp[2]<<std::endl; */
+    //! compute variations of parameters fAmp_max and fTim_max
+    CLHEP::HepVector PROD = DM1_ * temp_;
     //    std::cout<<"vector PROD: "<< PROD[0]<<" "<<PROD[1]<<" "<<PROD[2]<<std::endl;
 
     // Probably the fastest way to protect against
     // +-inf value in the matrix DM1_ after inversion
     // (which is nevertheless flagged as successfull...)
-    if ( edm::isNotFinite( PROD[0] ) ) {
-            InitFitParameters(samples,max_sample);
-            return -103 ;
+    if (edm::isNotFinite(PROD[0])) {
+      InitFitParameters(samples, max_sample);
+      return -103;
     }
 
-    variation_func_max = PROD[0] ;
-    variation_tim_max = PROD[1] ;
-    variation_ped_max = PROD[2] ;
+    variation_func_max = PROD[0];
+    variation_tim_max = PROD[1];
+    variation_ped_max = PROD[2];
     //chi2 = chi2/((double)nsamp_used - 3.) ;
-  }//!end of loop on iterations       
-  
+  }  //!end of loop on iterations
 
-  //!   protection again diverging/unstable fit 
-  if( variation_func_max > 2000. || variation_func_max < -1000. ) {
-    InitFitParameters(samples,max_sample);
+  //!   protection again diverging/unstable fit
+  if (variation_func_max > 2000. || variation_func_max < -1000.) {
+    InitFitParameters(samples, max_sample);
     return -102;
   }
-  
 
   //!      results of the fit are calculated
-  fAmp_max_ += variation_func_max ;
-  fTim_max_ += variation_tim_max ;
-  fPed_max_ += variation_ped_max ;
-
+  fAmp_max_ += variation_func_max;
+  fTim_max_ += variation_tim_max;
+  fPed_max_ += variation_ped_max;
 
   // protection against unphysical results:
   // ampli mismatched to MaxSample, ampli largely negative, time off preselected range
-  if( fAmp_max_>2*samples[max_sample]  ||  fAmp_max_<-100 ||  fTim_max_<0  ||  9<fTim_max_ ) {
-    InitFitParameters(samples,max_sample);
+  if (fAmp_max_ > 2 * samples[max_sample] || fAmp_max_ < -100 || fTim_max_ < 0 || 9 < fTim_max_) {
+    InitFitParameters(samples, max_sample);
     return -104;
   }
-  
 
   //std::cout <<"chi2: "<<chi2<<" ampl: "<<fAmp_max_<<" time: "<<fTim_max_<<" pede: "<<fPed_max_<<std::endl;
   return chi2;
 }
 
-template<class C> void EcalUncalibRecHitFixedAlphaBetaAlgo<C>::SetAlphaBeta( double alpha, double beta){
+template <class C>
+void EcalUncalibRecHitFixedAlphaBetaAlgo<C>::SetAlphaBeta(double alpha, double beta) {
   fAlpha_ = alpha;
-  fBeta_=  beta;
-  alfabeta_ = fAlpha_*fBeta_;
+  fBeta_ = beta;
+  alfabeta_ = fAlpha_ * fBeta_;
 }
 
-template<class C> void EcalUncalibRecHitFixedAlphaBetaAlgo<C>::SetMinAmpl( double ampl){
+template <class C>
+void EcalUncalibRecHitFixedAlphaBetaAlgo<C>::SetMinAmpl(double ampl) {
   MinAmpl_ = ampl;
 }
-template<class C> void EcalUncalibRecHitFixedAlphaBetaAlgo<C>::SetDynamicPedestal (bool p){
+template <class C>
+void EcalUncalibRecHitFixedAlphaBetaAlgo<C>::SetDynamicPedestal(bool p) {
   dyn_pedestal = p;
 }
 #endif

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMaxSampleAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMaxSampleAlgo.h
@@ -11,72 +11,71 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecAbsAlgo.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+template <class C>
+class EcalUncalibRecHitMaxSampleAlgo : public EcalUncalibRecHitRecAbsAlgo<C> {
+public:
+  ~EcalUncalibRecHitMaxSampleAlgo<C>() override{};
+  EcalUncalibratedRecHit makeRecHit(const C& dataFrame,
+                                    const double* pedestals,
+                                    const double* gainRatios,
+                                    const EcalWeightSet::EcalWeightMatrix** weights,
+                                    const EcalWeightSet::EcalChi2WeightMatrix** chi2Matrix) override;
 
-template<class C> class EcalUncalibRecHitMaxSampleAlgo : public EcalUncalibRecHitRecAbsAlgo<C>
-{
-  
- public:
-  
-  ~EcalUncalibRecHitMaxSampleAlgo<C>() override { };
-  EcalUncalibratedRecHit makeRecHit(const C& dataFrame, const double* pedestals,
-					    const double* gainRatios,
-					    const EcalWeightSet::EcalWeightMatrix** weights,
-                                            const EcalWeightSet::EcalChi2WeightMatrix** chi2Matrix) override;
-
- private:
-  int16_t  amplitude_,  pedestal_, jitter_, sampleAdc_, gainId_;
-  double   chi2_;
-
+private:
+  int16_t amplitude_, pedestal_, jitter_, sampleAdc_, gainId_;
+  double chi2_;
 };
 
 /// compute rechits
-template<class C> EcalUncalibratedRecHit  
-EcalUncalibRecHitMaxSampleAlgo<C>::makeRecHit(const C& dataFrame, const double* pedestals,
-					      const double* gainRatios,
-					      const EcalWeightSet::EcalWeightMatrix** weights,
-					      const EcalWeightSet::EcalChi2WeightMatrix** chi2Matrix) {
-
+template <class C>
+EcalUncalibratedRecHit EcalUncalibRecHitMaxSampleAlgo<C>::makeRecHit(
+    const C& dataFrame,
+    const double* pedestals,
+    const double* gainRatios,
+    const EcalWeightSet::EcalWeightMatrix** weights,
+    const EcalWeightSet::EcalChi2WeightMatrix** chi2Matrix) {
   amplitude_ = std::numeric_limits<int16_t>::min();
-  pedestal_  = 4095;
-  jitter_    = -1;
-  chi2_      = -1;
+  pedestal_ = 4095;
+  jitter_ = -1;
+  chi2_ = -1;
   //bool isSaturated = 0;
   uint32_t flags = 0;
-  for(int16_t iSample = 0; iSample < C::MAXSAMPLES; iSample++) {
-    
-    gainId_ = dataFrame.sample(iSample).gainId(); 
+  for (int16_t iSample = 0; iSample < C::MAXSAMPLES; iSample++) {
+    gainId_ = dataFrame.sample(iSample).gainId();
 
-    if (gainId_ == 0 )
-      {
-        flags = EcalUncalibratedRecHit::kSaturated;
-      }
+    if (gainId_ == 0) {
+      flags = EcalUncalibratedRecHit::kSaturated;
+    }
 
     // ampli gain 12
-    if ( gainId_ == 1){
+    if (gainId_ == 1) {
       sampleAdc_ = dataFrame.sample(iSample).adc();
     }
-      
-    else
-      {
-	if ( gainId_ == 2){ 	  // ampli gain 6
-	  sampleAdc_ = 200 + (dataFrame.sample(iSample).adc() - 200) * 2 ;
-	}
-	else  {  // accounts for gainId_==3 or 0 - ampli gain 1 and gain0
-	  sampleAdc_ = 200 + (dataFrame.sample(iSample).adc() - 200) * 12 ;
-	}
-      }
-    
-    if( sampleAdc_ >amplitude_ )	  {
-      amplitude_ = sampleAdc_;
-      jitter_    = iSample;
-    }// if statement
-    
-    if (sampleAdc_<pedestal_) pedestal_ = sampleAdc_;
 
-  }// loop on samples
-      
-      
-  return EcalUncalibratedRecHit( dataFrame.id(), static_cast<double>(amplitude_-pedestal_) , static_cast<double>(pedestal_), static_cast<double>(jitter_ - 5), chi2_, flags );
+    else {
+      if (gainId_ == 2) {  // ampli gain 6
+        sampleAdc_ = 200 + (dataFrame.sample(iSample).adc() - 200) * 2;
+      } else {  // accounts for gainId_==3 or 0 - ampli gain 1 and gain0
+        sampleAdc_ = 200 + (dataFrame.sample(iSample).adc() - 200) * 12;
+      }
+    }
+
+    if (sampleAdc_ > amplitude_) {
+      amplitude_ = sampleAdc_;
+      jitter_ = iSample;
+    }  // if statement
+
+    if (sampleAdc_ < pedestal_)
+      pedestal_ = sampleAdc_;
+
+  }  // loop on samples
+
+  return EcalUncalibratedRecHit(dataFrame.id(),
+                                static_cast<double>(amplitude_ - pedestal_),
+                                static_cast<double>(pedestal_),
+                                static_cast<double>(jitter_ - 5),
+                                chi2_,
+                                flags);
 }
 
 #endif

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMultiFitAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMultiFitAlgo.h
@@ -14,18 +14,20 @@
 #include "CondFormats/EcalObjects/interface/EcalGainRatios.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/PulseChiSqSNNLS.h"
 
-
 #include "TMatrixDSym.h"
 #include "TVectorD.h"
 
-class EcalUncalibRecHitMultiFitAlgo
-{
-  
- public:
-  
+class EcalUncalibRecHitMultiFitAlgo {
+public:
   EcalUncalibRecHitMultiFitAlgo();
-  ~EcalUncalibRecHitMultiFitAlgo() { };
-  EcalUncalibratedRecHit makeRecHit(const EcalDataFrame& dataFrame, const EcalPedestals::Item * aped, const EcalMGPAGainRatio * aGain, const SampleMatrixGainArray &noisecors, const FullSampleVector &fullpulse, const FullSampleMatrix &fullpulsecov, const BXVector &activeBX);
+  ~EcalUncalibRecHitMultiFitAlgo(){};
+  EcalUncalibratedRecHit makeRecHit(const EcalDataFrame &dataFrame,
+                                    const EcalPedestals::Item *aped,
+                                    const EcalMGPAGainRatio *aGain,
+                                    const SampleMatrixGainArray &noisecors,
+                                    const FullSampleVector &fullpulse,
+                                    const FullSampleMatrix &fullpulsecov,
+                                    const BXVector &activeBX);
   void disableErrorCalculation() { _computeErrors = false; }
   void setDoPrefit(bool b) { _doPrefit = b; }
   void setPrefitMaxChiSq(double x) { _prefitMaxChiSq = x; }
@@ -35,21 +37,20 @@ class EcalUncalibRecHitMultiFitAlgo
   void setAddPedestalUncertainty(double x) { _addPedestalUncertainty = x; }
   void setSimplifiedNoiseModelForGainSwitch(bool b) { _simplifiedNoiseModelForGainSwitch = b; }
   void setGainSwitchUseMaxSample(bool b) { _gainSwitchUseMaxSample = b; }
-  
- private:
-   PulseChiSqSNNLS _pulsefunc;
-   PulseChiSqSNNLS _pulsefuncSingle;
-   bool _computeErrors;
-   bool _doPrefit;
-   double _prefitMaxChiSq;
-   bool _dynamicPedestals;
-   bool _mitigateBadSamples;
-   bool _selectiveBadSampleCriteria;
-   double _addPedestalUncertainty;
-   bool _simplifiedNoiseModelForGainSwitch;
-   bool _gainSwitchUseMaxSample;
-   BXVector _singlebx;
 
+private:
+  PulseChiSqSNNLS _pulsefunc;
+  PulseChiSqSNNLS _pulsefuncSingle;
+  bool _computeErrors;
+  bool _doPrefit;
+  double _prefitMaxChiSq;
+  bool _dynamicPedestals;
+  bool _mitigateBadSamples;
+  bool _selectiveBadSampleCriteria;
+  double _addPedestalUncertainty;
+  bool _simplifiedNoiseModelForGainSwitch;
+  bool _gainSwitchUseMaxSample;
+  BXVector _singlebx;
 };
 
 #endif

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecAbsAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecAbsAlgo.h
@@ -14,9 +14,9 @@
 #include "DataFormats/EcalRecHit/interface/EcalUncalibratedRecHit.h"
 #include "CondFormats/EcalObjects/interface/EcalWeightSet.h"
 
-template<class C> class EcalUncalibRecHitRecAbsAlgo
-{
- public:
+template <class C>
+class EcalUncalibRecHitRecAbsAlgo {
+public:
   enum { nWeightsRows = 3, iAmplitude = 0, iPedestal = 1, iTime = 2 };
 
   /// Constructor
@@ -27,11 +27,10 @@ template<class C> class EcalUncalibRecHitRecAbsAlgo
 
   /// make rechits from dataframes
 
-  virtual EcalUncalibratedRecHit makeRecHit(const C& dataFrame, 
-					    const double* pedestals,
-					    const double* gainRatios,
-					    const EcalWeightSet::EcalWeightMatrix** weights, 
-					    const EcalWeightSet::EcalChi2WeightMatrix** chi2Matrix) = 0;
-
+  virtual EcalUncalibratedRecHit makeRecHit(const C& dataFrame,
+                                            const double* pedestals,
+                                            const double* gainRatios,
+                                            const EcalWeightSet::EcalWeightMatrix** weights,
+                                            const EcalWeightSet::EcalChi2WeightMatrix** chi2Matrix) = 0;
 };
 #endif

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecAnalFitAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecAnalFitAlgo.h
@@ -19,40 +19,36 @@
 #include "TGraph.h"
 #include "TF1.h"
 
-template<class C> class EcalUncalibRecHitRecAnalFitAlgo : public EcalUncalibRecHitRecAbsAlgo<C>
-{
-
-
- private:
-
+template <class C>
+class EcalUncalibRecHitRecAnalFitAlgo : public EcalUncalibRecHitRecAbsAlgo<C> {
+private:
   double pulseShapeFunction(double* var, double* par) {
-    double  x     = var[0];
-    double  ampl  = par[0];
-    double  tp    = par[1];
-    double  alpha = par[2];
-    double  t0    = par[3];
+    double x = var[0];
+    double ampl = par[0];
+    double tp = par[1];
+    double alpha = par[2];
+    double t0 = par[3];
 
-    double f = pow( (x-t0)/tp , alpha ) * exp( -alpha*(x-tp-t0)/tp );
-    return   ampl*f;
+    double f = pow((x - t0) / tp, alpha) * exp(-alpha * (x - tp - t0) / tp);
+    return ampl * f;
   };
 
   double pedestalFunction(double* var, double* par) {
-    double ped    = par[0];
+    double ped = par[0];
     return ped;
   };
 
- public:
+public:
   // destructor
-  ~EcalUncalibRecHitRecAnalFitAlgo<C>() override { };
-
+  ~EcalUncalibRecHitRecAnalFitAlgo<C>() override{};
 
   /// Compute parameters
-  EcalUncalibratedRecHit makeRecHit(const C& dataFrame, const double* pedestals,
-					    const double* gainRatios,
-					    const EcalWeightSet::EcalWeightMatrix** weights, 
-					    const EcalWeightSet::EcalChi2WeightMatrix** chi2Matrix) override
-    { 
-    double amplitude_(-1.),  pedestal_(-1.), jitter_(-1.), chi2_(-1.);
+  EcalUncalibratedRecHit makeRecHit(const C& dataFrame,
+                                    const double* pedestals,
+                                    const double* gainRatios,
+                                    const EcalWeightSet::EcalWeightMatrix** weights,
+                                    const EcalWeightSet::EcalChi2WeightMatrix** chi2Matrix) override {
+    double amplitude_(-1.), pedestal_(-1.), jitter_(-1.), chi2_(-1.);
 
     // Get time samples
     //HepMatrix frame(C::MAXSAMPLES, 1);
@@ -64,23 +60,24 @@ template<class C> class EcalUncalibRecHitRecAnalFitAlgo : public EcalUncalibRecH
     int imax(-1);
     bool isSaturated = false;
     uint32_t flag = 0;
-    for(int iSample = 0; iSample < C::MAXSAMPLES; iSample++) {
-      int gainId = dataFrame.sample(iSample).gainId(); 
-      if ( dataFrame.isSaturated() ) 
-	{
-	  gainId = 3;
-	  isSaturated = true;
-	}
+    for (int iSample = 0; iSample < C::MAXSAMPLES; iSample++) {
+      int gainId = dataFrame.sample(iSample).gainId();
+      if (dataFrame.isSaturated()) {
+        gainId = 3;
+        isSaturated = true;
+      }
 
-      if (gainId != gainId0) ++iGainSwitch ;
+      if (gainId != gainId0)
+        ++iGainSwitch;
       if (!iGainSwitch)
-	frame[iSample] = double(dataFrame.sample(iSample).adc());
+        frame[iSample] = double(dataFrame.sample(iSample).adc());
       else
-	frame[iSample] = double(((double)(dataFrame.sample(iSample).adc()) - pedestals[gainId-1]) * gainRatios[gainId-1]);
+        frame[iSample] =
+            double(((double)(dataFrame.sample(iSample).adc()) - pedestals[gainId - 1]) * gainRatios[gainId - 1]);
 
-      if( frame[iSample]>maxsample ) {
-          maxsample= frame[iSample];
-          imax=iSample;
+      if (frame[iSample] > maxsample) {
+        maxsample = frame[iSample];
+        imax = iSample;
       }
     }
 
@@ -88,73 +85,69 @@ template<class C> class EcalUncalibRecHitRecAnalFitAlgo : public EcalUncalibRecH
     //std::cout << "EcalUncalibRecHitRecAnalFitAlgo::makeRecHit() not yey implemented. returning dummy rechit" << std::endl;
 
     // prepare TGraph for analytic fit
-    double  xarray[10]={0.,1.,2.,3.,4.,5.,6.,7.,8.,9.};
-    TGraph graph(10,xarray,frame);
+    double xarray[10] = {0., 1., 2., 3., 4., 5., 6., 7., 8., 9.};
+    TGraph graph(10, xarray, frame);
 
     // fit functions
-    TF1 pulseShape = TF1("pulseShape",
-                         "[0]*pow((x - [3])/[1],[2])*exp(-[2]*(x - [1] - [3])/[1])",
-                         imax-1.,imax+3.);
-    TF1 pedestal = TF1("pedestal","[0]",0.,2.);
+    TF1 pulseShape =
+        TF1("pulseShape", "[0]*pow((x - [3])/[1],[2])*exp(-[2]*(x - [1] - [3])/[1])", imax - 1., imax + 3.);
+    TF1 pedestal = TF1("pedestal", "[0]", 0., 2.);
 
     //TF1 pulseShape = TF1("pulseShape",pulseShapeFunction,imax-1.,imax+3.);
     //TF1 pedestal = TF1("pedestal",pedestalFunction,0.,2.);
-    TF1 pluseAndPed = TF1("pulseAndPed","pedestal+pulseShape");
+    TF1 pluseAndPed = TF1("pulseAndPed", "pedestal+pulseShape");
 
     //pulseShape parameters
     // Amplitude
-    double FIT_A=(double)maxsample;  //Amplitude
-    pulseShape.SetParameter(0,FIT_A);
-    pulseShape.SetParName(0,"Amplitude");
+    double FIT_A = (double)maxsample;  //Amplitude
+    pulseShape.SetParameter(0, FIT_A);
+    pulseShape.SetParName(0, "Amplitude");
     // T peak
-    double FIT_Tp=(double)imax;  //T peak
-    pulseShape.SetParameter(1,FIT_Tp);
-    pulseShape.SetParName(1,"t_{P}");
+    double FIT_Tp = (double)imax;  //T peak
+    pulseShape.SetParameter(1, FIT_Tp);
+    pulseShape.SetParName(1, "t_{P}");
     // Alpha
-    double FIT_ALFA=1.5;  //Alpha
-    pulseShape.SetParameter(2,FIT_ALFA);
-    pulseShape.SetParName(2,"\\alpha");
+    double FIT_ALFA = 1.5;  //Alpha
+    pulseShape.SetParameter(2, FIT_ALFA);
+    pulseShape.SetParName(2, "\\alpha");
     // T off
-    double FIT_To=3.;  //T off
-    pulseShape.SetParameter(3,FIT_To);
-    pulseShape.SetParName(3,"t_{0}");
+    double FIT_To = 3.;  //T off
+    pulseShape.SetParameter(3, FIT_To);
+    pulseShape.SetParName(3, "t_{0}");
 
     // pedestal
-    pedestal.SetParameter(0,frame[0]);
-    pedestal.SetParName(0,"Pedestal");
+    pedestal.SetParameter(0, frame[0]);
+    pedestal.SetParName(0, "Pedestal");
 
-
-
-    graph.Fit(&pulseShape,"QRM");
+    graph.Fit(&pulseShape, "QRM");
     //TF1 *pulseShape2=graph.GetFunction("pulseShape");
 
-    if ( std::string(gMinuit->fCstatu.Data()) == std::string("CONVERGED ") ) {
+    if (std::string(gMinuit->fCstatu.Data()) == std::string("CONVERGED ")) {
+      double amplitude_value = pulseShape.GetParameter(0);
 
-      double amplitude_value=pulseShape.GetParameter(0);
-
-      graph.Fit(&pedestal,"QRL");
+      graph.Fit(&pedestal, "QRL");
       //TF1 *pedestal2=graph.GetFunction("pedestal");
-      double pedestal_value=pedestal.GetParameter(0);
+      double pedestal_value = pedestal.GetParameter(0);
 
       if (!iGainSwitch)
-	amplitude_ = amplitude_value - pedestal_value;
+        amplitude_ = amplitude_value - pedestal_value;
       else
-	amplitude_ = amplitude_value;
+        amplitude_ = amplitude_value;
 
-      pedestal_  = pedestal_value;
-      jitter_    = pulseShape.GetParameter(3);
-      chi2_ = 1.; // successful fit
-      if (isSaturated) flag = EcalUncalibratedRecHit::kSaturated;
+      pedestal_ = pedestal_value;
+      jitter_ = pulseShape.GetParameter(3);
+      chi2_ = 1.;  // successful fit
+      if (isSaturated)
+        flag = EcalUncalibratedRecHit::kSaturated;
       /*
       std::cout << "separate fits\nA: " <<  amplitude_value << ", Ped: " << pedestal_value
                 << ", t0: " << jitter_ << ", tp: " << pulseShape.GetParameter(1)
                 << ", alpha: " << pulseShape.GetParameter(2)
                 << std::endl;
       */
-
     }
 
-    return EcalUncalibratedRecHit( dataFrame.id(), amplitude_, pedestal_, jitter_ - 6, chi2_, flag);
+    return EcalUncalibratedRecHit(dataFrame.id(), amplitude_, pedestal_, jitter_ - 6, chi2_, flag);
   }
 };
 #endif

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecChi2Algo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecChi2Algo.h
@@ -18,143 +18,130 @@
 #include "CondFormats/EcalObjects/interface/EcalTimeCalibConstants.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
 #include <vector>
 
-template<class C> class EcalUncalibRecHitRecChi2Algo 
-{
-  public:
-
+template <class C>
+class EcalUncalibRecHitRecChi2Algo {
+public:
   // destructor
-  virtual ~EcalUncalibRecHitRecChi2Algo<C>() { };
+  virtual ~EcalUncalibRecHitRecChi2Algo<C>(){};
 
-  EcalUncalibRecHitRecChi2Algo<C>() { };
-  EcalUncalibRecHitRecChi2Algo<C>(
-				  const C& dataFrame,
-				  const double amplitude,
-				  const EcalTimeCalibConstant& timeIC,
-				  const double amplitudeOutOfTime,
-				  const double jitter,
-				  const double* pedestals,
-				  const double* pedestalsRMS,
-				  const double* gainRatios,
-				  const EcalShapeBase & testbeamPulseShape,
-                                  const std::vector<double>& chi2Parameters
-  );
+  EcalUncalibRecHitRecChi2Algo<C>(){};
+  EcalUncalibRecHitRecChi2Algo<C>(const C& dataFrame,
+                                  const double amplitude,
+                                  const EcalTimeCalibConstant& timeIC,
+                                  const double amplitudeOutOfTime,
+                                  const double jitter,
+                                  const double* pedestals,
+                                  const double* pedestalsRMS,
+                                  const double* gainRatios,
+                                  const EcalShapeBase& testbeamPulseShape,
+                                  const std::vector<double>& chi2Parameters);
 
+  virtual double chi2() { return chi2_; }
+  virtual double chi2OutOfTime() { return chi2OutOfTime_; }
 
-  virtual double chi2(){return chi2_;}
-  virtual double chi2OutOfTime(){return chi2OutOfTime_;}
-
-
-  private:
-    double chi2_;
-    double chi2OutOfTime_;
+private:
+  double chi2_;
+  double chi2OutOfTime_;
 };
 
-
 template <class C>
-EcalUncalibRecHitRecChi2Algo<C>::EcalUncalibRecHitRecChi2Algo(
-			const C& dataFrame, 
-			const double amplitude, 
-			const EcalTimeCalibConstant& timeIC, 
-			const double amplitudeOutOfTime, 
-			const double jitter, 
-			const double* pedestals, 
-			const double* pedestalsRMS,
-			const double* gainRatios,
-			const EcalShapeBase & testbeamPulseShape,
-			const std::vector<double>& chi2Parameters
-) 
-{
+EcalUncalibRecHitRecChi2Algo<C>::EcalUncalibRecHitRecChi2Algo(const C& dataFrame,
+                                                              const double amplitude,
+                                                              const EcalTimeCalibConstant& timeIC,
+                                                              const double amplitudeOutOfTime,
+                                                              const double jitter,
+                                                              const double* pedestals,
+                                                              const double* pedestalsRMS,
+                                                              const double* gainRatios,
+                                                              const EcalShapeBase& testbeamPulseShape,
+                                                              const std::vector<double>& chi2Parameters) {
+  double noise_A = chi2Parameters[0];  // noise term for in-time chi2
+  double const_A = chi2Parameters[1];  // constant term for in-time chi2
+  double noise_B = chi2Parameters[2];  // noise term for out-of-time chi2
+  double const_B = chi2Parameters[3];  // constant term for out-of-time chi2
 
-    double noise_A = chi2Parameters[0]; // noise term for in-time chi2
-    double const_A = chi2Parameters[1]; // constant term for in-time chi2
-    double noise_B = chi2Parameters[2]; // noise term for out-of-time chi2
-    double const_B = chi2Parameters[3]; // constant term for out-of-time chi2
+  chi2_ = 0;
+  chi2OutOfTime_ = 0;
+  double S_0 = 0;      // will store the first mgpa sample
+  double ped_ave = 0;  // will store the average pedestal
 
-
-    chi2_=0;
-    chi2OutOfTime_=0;
-    double S_0=0;  // will store the first mgpa sample
-    double ped_ave=0;  // will store the average pedestal
-
-    int gainId0 = 1;
-    int iGainSwitch = 0;
-    bool isSaturated = false;
-    for(int iSample = 0; iSample < C::MAXSAMPLES; iSample++) // if gain switch use later the pedestal RMS, otherwise we use the pedestal from the DB
-    {
-      int gainId = dataFrame.sample(iSample).gainId();
-      if(gainId == 0)
-      {
-	gainId = 3; // if saturated, treat it as G1
-	isSaturated = true;
-      }
-      if(gainId != gainId0)iGainSwitch = 1;
-
-      if(gainId==1 && iSample==0)S_0 = dataFrame.sample(iSample).adc(); // take only first presample to estimate the pedestal
-      if(gainId==1 && iSample<3)ped_ave += (1/3.0)*dataFrame.sample(iSample).adc(); // take first 3 presamples to estimate the pedestal
+  int gainId0 = 1;
+  int iGainSwitch = 0;
+  bool isSaturated = false;
+  for (int iSample = 0; iSample < C::MAXSAMPLES;
+       iSample++)  // if gain switch use later the pedestal RMS, otherwise we use the pedestal from the DB
+  {
+    int gainId = dataFrame.sample(iSample).gainId();
+    if (gainId == 0) {
+      gainId = 3;  // if saturated, treat it as G1
+      isSaturated = true;
     }
+    if (gainId != gainId0)
+      iGainSwitch = 1;
 
+    if (gainId == 1 && iSample == 0)
+      S_0 = dataFrame.sample(iSample).adc();  // take only first presample to estimate the pedestal
+    if (gainId == 1 && iSample < 3)
+      ped_ave += (1 / 3.0) * dataFrame.sample(iSample).adc();  // take first 3 presamples to estimate the pedestal
+  }
 
-    // compute testbeamPulseShape shape parameters
-    double ADC_clock = 25; // 25 ns
-    double risingTime = testbeamPulseShape.timeToRise();
-    double tzero = risingTime  - 5*ADC_clock;  // 5 samples before the peak
+  // compute testbeamPulseShape shape parameters
+  double ADC_clock = 25;  // 25 ns
+  double risingTime = testbeamPulseShape.timeToRise();
+  double tzero = risingTime - 5 * ADC_clock;  // 5 samples before the peak
 
-    double shiftTime = + timeIC; // we put positive here
-    double shiftTimeOutOfTime = -jitter*ADC_clock; // we put negative here
-    
+  double shiftTime = +timeIC;                       // we put positive here
+  double shiftTimeOutOfTime = -jitter * ADC_clock;  // we put negative here
 
-    bool readoutError = false;
+  bool readoutError = false;
 
-    for(int iSample = 0; iSample < C::MAXSAMPLES; iSample++)
-    {
-        int gainId = dataFrame.sample(iSample).gainId();
-	if(dataFrame.sample(iSample).adc()==0)readoutError=true;
-        if(gainId==0)continue; // skip saturated samples
+  for (int iSample = 0; iSample < C::MAXSAMPLES; iSample++) {
+    int gainId = dataFrame.sample(iSample).gainId();
+    if (dataFrame.sample(iSample).adc() == 0)
+      readoutError = true;
+    if (gainId == 0)
+      continue;  // skip saturated samples
 
+    double ped =
+        !iGainSwitch ? ped_ave : pedestals[gainId - 1];  // use dynamic pedestal for G12 and average pedestal for G6,G1
+                                                         //double pedRMS = pedestalsRMS[gainId-1];
+    double S_i = double(dataFrame.sample(iSample).adc());
 
-        double ped = !iGainSwitch ? ped_ave:pedestals[gainId-1];  // use dynamic pedestal for G12 and average pedestal for G6,G1
-	//double pedRMS = pedestalsRMS[gainId-1];
-        double S_i = double(dataFrame.sample(iSample).adc());
+    // --- calculate in-time chi2
 
-	// --- calculate in-time chi2
+    double f_i = (testbeamPulseShape)(tzero + shiftTime + iSample * ADC_clock);
+    double R_i = (S_i - ped) * gainRatios[gainId - 1] - f_i * amplitude;
+    double R_iErrorSquare = noise_A * noise_A + const_A * const_A * amplitude * amplitude;
 
+    chi2_ += R_i * R_i / R_iErrorSquare;
 
-        double f_i = (testbeamPulseShape)(tzero + shiftTime + iSample*ADC_clock);
-	double R_i = (S_i- ped)*gainRatios[gainId-1] - f_i*amplitude;
-	double R_iErrorSquare = noise_A*noise_A + const_A*const_A*amplitude*amplitude;
+    // --- calculate out-of-time chi2
 
-	chi2_ += R_i*R_i/R_iErrorSquare;
+    double g_i = (testbeamPulseShape)(tzero + shiftTimeOutOfTime + iSample * ADC_clock);  // calculate out of time chi2
 
-	// --- calculate out-of-time chi2
+    double R_iOutOfTime = (S_i - S_0) * gainRatios[gainId - 1] - g_i * amplitudeOutOfTime;
+    double R_iOutOfTimeErrorSquare = noise_B * noise_B + const_B * const_B * amplitudeOutOfTime * amplitudeOutOfTime;
 
-        double g_i = (testbeamPulseShape)(tzero + shiftTimeOutOfTime + iSample*ADC_clock); // calculate out of time chi2
+    chi2OutOfTime_ += R_iOutOfTime * R_iOutOfTime / R_iOutOfTimeErrorSquare;
+  }
 
-        double R_iOutOfTime = (S_i- S_0)*gainRatios[gainId-1] - g_i*amplitudeOutOfTime;
-	double R_iOutOfTimeErrorSquare = noise_B*noise_B + const_B*const_B*amplitudeOutOfTime*amplitudeOutOfTime;
+  if (!isSaturated && !iGainSwitch && chi2_ > 0 && chi2OutOfTime_ > 0) {
+    chi2_ = 7 * (3 + log(chi2_));
+    chi2_ = chi2_ < 0 ? 0 : chi2_;  // this is just a convinient mapping for storing in the calibRecHit bit map
+    chi2OutOfTime_ = 7 * (3 + log(chi2OutOfTime_));
+    chi2OutOfTime_ = chi2OutOfTime_ < 0 ? 0 : chi2OutOfTime_;
+  } else {
+    chi2_ = 0;
+    chi2OutOfTime_ = 0;
+  }
 
- 
-        chi2OutOfTime_ += R_iOutOfTime*R_iOutOfTime/R_iOutOfTimeErrorSquare;
-    }
-
-
-    if(!isSaturated && !iGainSwitch && chi2_>0 && chi2OutOfTime_>0)	
-    {	
-	chi2_ = 7*(3+log(chi2_)); chi2_ = chi2_<0 ? 0:chi2_; // this is just a convinient mapping for storing in the calibRecHit bit map 
-	chi2OutOfTime_ = 7*(3+log(chi2OutOfTime_)); chi2OutOfTime_ = chi2OutOfTime_<0 ? 0:chi2OutOfTime_; 
-    }else
-    {
-    	chi2_=0;
-	chi2OutOfTime_=0;
-    }
-
-    if(readoutError) // rare situation
-    {
-	chi2_=99.0;  // chi2 is very large in these cases, put a code value to discriminate against normal noise
-	chi2OutOfTime_=99.0;
-    }
+  if (readoutError)  // rare situation
+  {
+    chi2_ = 99.0;  // chi2 is very large in these cases, put a code value to discriminate against normal noise
+    chi2OutOfTime_ = 99.0;
+  }
 }
 
 #endif

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecWeightsAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecWeightsAlgo.h
@@ -20,66 +20,66 @@
 
 #include <vector>
 
-template<class C> class EcalUncalibRecHitRecWeightsAlgo 
-{
- public:
+template <class C>
+class EcalUncalibRecHitRecWeightsAlgo {
+public:
   // destructor
-  virtual ~EcalUncalibRecHitRecWeightsAlgo<C>() { };
+  virtual ~EcalUncalibRecHitRecWeightsAlgo<C>(){};
 
   /// Compute parameters
-   virtual EcalUncalibratedRecHit makeRecHit(
-					      const C& dataFrame 
-					      , const double* pedestals
-					      , const double* pedestalsRMS
-					      , const double* gainRatios 
-					      , const EcalWeightSet::EcalWeightMatrix** weights
-					      , const EcalShapeBase & testbeamPulseShape
-    ) {
-    double amplitude_(-1.),  pedestal_(-1.), jitter_(-1.), chi2_(-1.);
+  virtual EcalUncalibratedRecHit makeRecHit(const C& dataFrame,
+                                            const double* pedestals,
+                                            const double* pedestalsRMS,
+                                            const double* gainRatios,
+                                            const EcalWeightSet::EcalWeightMatrix** weights,
+                                            const EcalShapeBase& testbeamPulseShape) {
+    double amplitude_(-1.), pedestal_(-1.), jitter_(-1.), chi2_(-1.);
     uint32_t flag = 0;
 
-
     // Get time samples
-    ROOT::Math::SVector<double,C::MAXSAMPLES> frame;
+    ROOT::Math::SVector<double, C::MAXSAMPLES> frame;
     int gainId0 = 1;
     int iGainSwitch = 0;
     bool isSaturated = false;
-    for(int iSample = 0; iSample < C::MAXSAMPLES; iSample++) {
+    for (int iSample = 0; iSample < C::MAXSAMPLES; iSample++) {
       int gainId = dataFrame.sample(iSample).gainId();
       //Handling saturation (treating saturated gainId as maximum gain)
-      if ( gainId == 0 ) 
-	{ 
-	  gainId = 3;
-	  //isSaturated = 1;
-	  // in pileup run May2012 samples 7,8,9,10 have gainid ==0
-          // fix it like this: it won't hurt for the future SA20120512
-	  if(iSample==4 || iSample ==5 || iSample==6) isSaturated = true;
-	}
+      if (gainId == 0) {
+        gainId = 3;
+        //isSaturated = 1;
+        // in pileup run May2012 samples 7,8,9,10 have gainid ==0
+        // fix it like this: it won't hurt for the future SA20120512
+        if (iSample == 4 || iSample == 5 || iSample == 6)
+          isSaturated = true;
+      }
 
       //      if (gainId != gainId0) iGainSwitch = 1;
       // same problem as above: mark saturation only when physically
       // expected to occur SA20120513
-      if ( (gainId != gainId0) && (iSample==4 || iSample ==5 || iSample==6) ) iGainSwitch = 1;
+      if ((gainId != gainId0) && (iSample == 4 || iSample == 5 || iSample == 6))
+        iGainSwitch = 1;
       if (!iGainSwitch)
-	frame(iSample) = double(dataFrame.sample(iSample).adc());
+        frame(iSample) = double(dataFrame.sample(iSample).adc());
       else
-	frame(iSample) = double(((double)(dataFrame.sample(iSample).adc()) - pedestals[gainId-1]) * gainRatios[gainId-1]);
+        frame(iSample) =
+            double(((double)(dataFrame.sample(iSample).adc()) - pedestals[gainId - 1]) * gainRatios[gainId - 1]);
     }
 
     // Compute parameters
-    ROOT::Math::SVector <double,3> param = (*(weights[iGainSwitch])) * frame;
+    ROOT::Math::SVector<double, 3> param = (*(weights[iGainSwitch])) * frame;
     amplitude_ = param(EcalUncalibRecHitRecAbsAlgo<C>::iAmplitude);
     pedestal_ = param(EcalUncalibRecHitRecAbsAlgo<C>::iPedestal);
-    if (amplitude_) jitter_ = -param(EcalUncalibRecHitRecAbsAlgo<C>::iTime) / amplitude_;
-    else jitter_ = 0.;
+    if (amplitude_)
+      jitter_ = -param(EcalUncalibRecHitRecAbsAlgo<C>::iTime) / amplitude_;
+    else
+      jitter_ = 0.;
 
     //When saturated gain flag i
-    if (isSaturated)
-      {
-        flag = EcalUncalibratedRecHit::kSaturated;
-	amplitude_ = double((4095. - pedestals[2]) * gainRatios[2]);
-      }
-    return EcalUncalibratedRecHit( dataFrame.id(), amplitude_, pedestal_, jitter_, chi2_, flag);
+    if (isSaturated) {
+      flag = EcalUncalibratedRecHit::kSaturated;
+      amplitude_ = double((4095. - pedestals[2]) * gainRatios[2]);
+    }
+    return EcalUncalibratedRecHit(dataFrame.id(), amplitude_, pedestal_, jitter_, chi2_, flag);
   }
 
   ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitTimeWeightsAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitTimeWeightsAlgo.h
@@ -23,89 +23,90 @@
 #include "TVectorD.h"
 #include <vector>
 
-template<class C> class EcalUncalibRecHitTimeWeightsAlgo 
-{
- public:
-
-  EcalUncalibRecHitTimeWeightsAlgo<C>() { };
-  virtual ~EcalUncalibRecHitTimeWeightsAlgo<C>() { };
+template <class C>
+class EcalUncalibRecHitTimeWeightsAlgo {
+public:
+  EcalUncalibRecHitTimeWeightsAlgo<C>(){};
+  virtual ~EcalUncalibRecHitTimeWeightsAlgo<C>(){};
 
   /// Compute time
-  double time(const C& dataFrame, const std::vector<double> &amplitudes, const EcalPedestals::Item * aped, const EcalMGPAGainRatio * aGain, const FullSampleVector &fullpulse, const EcalWeightSet::EcalWeightMatrix** weights) {
-  
+  double time(const C &dataFrame,
+              const std::vector<double> &amplitudes,
+              const EcalPedestals::Item *aped,
+              const EcalMGPAGainRatio *aGain,
+              const FullSampleVector &fullpulse,
+              const EcalWeightSet::EcalWeightMatrix **weights) {
     const unsigned int nsample = EcalDataFrame::MAXSAMPLES;
-  
+
     double maxamplitude = -std::numeric_limits<double>::max();
-  
+
     double pulsenorm = 0.;
     int iGainSwitch = 0;
 
-    ROOT::Math::SVector<double,nsample> pedSubSamples;
-    for(unsigned int iSample = 0; iSample < nsample; iSample++) {
-    
+    ROOT::Math::SVector<double, nsample> pedSubSamples;
+    for (unsigned int iSample = 0; iSample < nsample; iSample++) {
       const EcalMGPASample &sample = dataFrame.sample(iSample);
-    
+
       double amplitude = 0.;
       int gainId = sample.gainId();
-    
+
       double pedestal = 0.;
       double gainratio = 1.;
-        
-      if (gainId==0 || gainId==3) {
+
+      if (gainId == 0 || gainId == 3) {
         pedestal = aped->mean_x1;
-        gainratio = aGain->gain6Over1()*aGain->gain12Over6();
+        gainratio = aGain->gain6Over1() * aGain->gain12Over6();
         iGainSwitch = 1;
-      }
-      else if (gainId==1) {
+      } else if (gainId == 1) {
         pedestal = aped->mean_x12;
         gainratio = 1.;
         iGainSwitch = 0;
-      }
-      else if (gainId==2) {
+      } else if (gainId == 2) {
         pedestal = aped->mean_x6;
         gainratio = aGain->gain12Over6();
         iGainSwitch = 1;
       }
 
       amplitude = ((double)(sample.adc()) - pedestal) * gainratio;
-    
+
       if (gainId == 0) {
         //saturation
         amplitude = (4095. - pedestal) * gainratio;
       }
-        
+
       pedSubSamples(iSample) = amplitude;
 
-      if (amplitude>maxamplitude) {
+      if (amplitude > maxamplitude) {
         maxamplitude = amplitude;
-      }    
+      }
       pulsenorm += fullpulse(iSample);
     }
 
     std::vector<double>::const_iterator amplit;
-    for(amplit=amplitudes.begin(); amplit<amplitudes.end(); ++amplit) {
-      int ipulse = std::distance(amplitudes.begin(),amplit);
+    for (amplit = amplitudes.begin(); amplit < amplitudes.end(); ++amplit) {
+      int ipulse = std::distance(amplitudes.begin(), amplit);
       int bx = ipulse - 5;
-      int firstsamplet = std::max(0,bx + 3);
-      int offset = 7-3-bx;
+      int firstsamplet = std::max(0, bx + 3);
+      int offset = 7 - 3 - bx;
 
       TVectorD pulse;
       pulse.ResizeTo(nsample);
-      for (unsigned int isample = firstsamplet; isample<nsample; ++isample) {
-        pulse(isample) = fullpulse(isample+offset);
-        pedSubSamples(isample) = std::max(0., pedSubSamples(isample) - amplitudes[ipulse]*pulse(isample)/pulsenorm);
+      for (unsigned int isample = firstsamplet; isample < nsample; ++isample) {
+        pulse(isample) = fullpulse(isample + offset);
+        pedSubSamples(isample) = std::max(0., pedSubSamples(isample) - amplitudes[ipulse] * pulse(isample) / pulsenorm);
       }
     }
 
     // Compute parameters
     double amplitude_(-1.), jitter_(-1.);
-    ROOT::Math::SVector <double,3> param = (*(weights[iGainSwitch])) * pedSubSamples;
+    ROOT::Math::SVector<double, 3> param = (*(weights[iGainSwitch])) * pedSubSamples;
     amplitude_ = param(EcalUncalibRecHitRecAbsAlgo<C>::iAmplitude);
-    if (amplitude_) jitter_ = -param(EcalUncalibRecHitRecAbsAlgo<C>::iTime) / amplitude_;
-    else jitter_ = 0.;
-  
+    if (amplitude_)
+      jitter_ = -param(EcalUncalibRecHitRecAbsAlgo<C>::iTime) / amplitude_;
+    else
+      jitter_ = 0.;
+
     return jitter_;
   }
-
 };
 #endif

--- a/RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h
@@ -9,22 +9,22 @@ constexpr int FullSampleVectorSize = 19;
 constexpr int PulseVectorSize = 12;
 constexpr int NGains = 3;
 
-typedef Eigen::Matrix<double,SampleVectorSize,1> SampleVector;
-typedef Eigen::Matrix<double,FullSampleVectorSize,1> FullSampleVector;
-typedef Eigen::Matrix<double,Eigen::Dynamic,1,0,PulseVectorSize,1> PulseVector;
-typedef Eigen::Matrix<char,Eigen::Dynamic,1,0,PulseVectorSize,1> BXVector;
-typedef Eigen::Matrix<char,SampleVectorSize,1> SampleGainVector;
-typedef Eigen::Matrix<double,SampleVectorSize,SampleVectorSize> SampleMatrix;
-typedef Eigen::Matrix<double,FullSampleVectorSize,FullSampleVectorSize> FullSampleMatrix;
-typedef Eigen::Matrix<double,Eigen::Dynamic,Eigen::Dynamic,0,PulseVectorSize,PulseVectorSize> PulseMatrix;
-typedef Eigen::Matrix<double,SampleVectorSize,Eigen::Dynamic,0,SampleVectorSize,PulseVectorSize> SamplePulseMatrix;
+typedef Eigen::Matrix<double, SampleVectorSize, 1> SampleVector;
+typedef Eigen::Matrix<double, FullSampleVectorSize, 1> FullSampleVector;
+typedef Eigen::Matrix<double, Eigen::Dynamic, 1, 0, PulseVectorSize, 1> PulseVector;
+typedef Eigen::Matrix<char, Eigen::Dynamic, 1, 0, PulseVectorSize, 1> BXVector;
+typedef Eigen::Matrix<char, SampleVectorSize, 1> SampleGainVector;
+typedef Eigen::Matrix<double, SampleVectorSize, SampleVectorSize> SampleMatrix;
+typedef Eigen::Matrix<double, FullSampleVectorSize, FullSampleVectorSize> FullSampleMatrix;
+typedef Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, 0, PulseVectorSize, PulseVectorSize> PulseMatrix;
+typedef Eigen::Matrix<double, SampleVectorSize, Eigen::Dynamic, 0, SampleVectorSize, PulseVectorSize> SamplePulseMatrix;
 typedef Eigen::LLT<SampleMatrix> SampleDecompLLT;
 typedef Eigen::LLT<PulseMatrix> PulseDecompLLT;
 typedef Eigen::LDLT<PulseMatrix> PulseDecompLDLT;
 
-typedef Eigen::Matrix<double,1,1> SingleMatrix;
-typedef Eigen::Matrix<double,1,1> SingleVector;
+typedef Eigen::Matrix<double, 1, 1> SingleMatrix;
+typedef Eigen::Matrix<double, 1, 1> SingleVector;
 
-typedef std::array<SampleMatrix,NGains> SampleMatrixGainArray;
+typedef std::array<SampleMatrix, NGains> SampleMatrixGainArray;
 
 #endif

--- a/RecoLocalCalo/EcalRecAlgos/interface/PulseChiSqSNNLS.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/PulseChiSqSNNLS.h
@@ -1,75 +1,77 @@
 #ifndef PulseChiSqSNNLS_h
 #define PulseChiSqSNNLS_h
 
-#define EIGEN_NO_DEBUG // kill throws in eigen code
+#define EIGEN_NO_DEBUG  // kill throws in eigen code
 #include "RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h"
 
 #include <set>
 #include <array>
 
 class PulseChiSqSNNLS {
-  public:
-    
-    typedef BXVector::Index Index;
-    
-    PulseChiSqSNNLS();
-    ~PulseChiSqSNNLS();
-    
-    
-    bool DoFit(const SampleVector &samples, const SampleMatrix &samplecov, const BXVector &bxs, const FullSampleVector &fullpulse, const FullSampleMatrix &fullpulsecov, const SampleGainVector &gains = -1*SampleGainVector::Ones(), const SampleGainVector &badSamples = SampleGainVector::Zero());
-    
-    const SamplePulseMatrix &pulsemat() const { return _pulsemat; }
-    const SampleMatrix &invcov() const { return _invcov; }
-    
-    const PulseVector &X() const { return _ampvecmin; }
-    const PulseVector &Errors() const { return _errvec; }
-    const BXVector &BXs() const { return _bxsmin; }
-    
-    double ChiSq() const { return _chisq; }
-    void disableErrorCalculation() { _computeErrors = false; }
-    void setMaxIters(int n) { _maxiters = n;}
-    void setMaxIterWarnings(bool b) { _maxiterwarnings = b;}
+public:
+  typedef BXVector::Index Index;
 
-  protected:
-    
-    bool Minimize(const SampleMatrix &samplecov, const FullSampleMatrix &fullpulsecov);
-    bool NNLS();
-    void NNLSUnconstrainParameter(Index idxp);
-    void NNLSConstrainParameter(Index minratioidx);
-    bool OnePulseMinimize();
-    bool updateCov(const SampleMatrix &samplecov, const FullSampleMatrix &fullpulsecov);
-    double ComputeChiSq();
-    double ComputeApproxUncertainty(unsigned int ipulse);
-    
-    
-    SampleVector _sampvec;
-    SampleMatrix _invcov;
-    SamplePulseMatrix _pulsemat;
-    PulseVector _ampvec;
-    PulseVector _errvec;
-    PulseVector _ampvecmin;
-    
-    SampleDecompLLT _covdecomp;
-    SampleMatrix _covdecompLinv;
-    PulseMatrix _topleft_work;
-    PulseDecompLDLT _pulsedecomp;
+  PulseChiSqSNNLS();
+  ~PulseChiSqSNNLS();
 
-    BXVector _bxs;
-    BXVector _bxsmin;
-    unsigned int _npulsetot;
-    unsigned int _nP;
-    
-    SamplePulseMatrix invcovp;
-    PulseMatrix aTamat;
-    PulseVector aTbvec;
-    PulseVector updatework;
-    
-    PulseVector ampvecpermtest;
-    
-    double _chisq;
-    bool _computeErrors;
-    int _maxiters;
-    bool _maxiterwarnings;
+  bool DoFit(const SampleVector &samples,
+             const SampleMatrix &samplecov,
+             const BXVector &bxs,
+             const FullSampleVector &fullpulse,
+             const FullSampleMatrix &fullpulsecov,
+             const SampleGainVector &gains = -1 * SampleGainVector::Ones(),
+             const SampleGainVector &badSamples = SampleGainVector::Zero());
+
+  const SamplePulseMatrix &pulsemat() const { return _pulsemat; }
+  const SampleMatrix &invcov() const { return _invcov; }
+
+  const PulseVector &X() const { return _ampvecmin; }
+  const PulseVector &Errors() const { return _errvec; }
+  const BXVector &BXs() const { return _bxsmin; }
+
+  double ChiSq() const { return _chisq; }
+  void disableErrorCalculation() { _computeErrors = false; }
+  void setMaxIters(int n) { _maxiters = n; }
+  void setMaxIterWarnings(bool b) { _maxiterwarnings = b; }
+
+protected:
+  bool Minimize(const SampleMatrix &samplecov, const FullSampleMatrix &fullpulsecov);
+  bool NNLS();
+  void NNLSUnconstrainParameter(Index idxp);
+  void NNLSConstrainParameter(Index minratioidx);
+  bool OnePulseMinimize();
+  bool updateCov(const SampleMatrix &samplecov, const FullSampleMatrix &fullpulsecov);
+  double ComputeChiSq();
+  double ComputeApproxUncertainty(unsigned int ipulse);
+
+  SampleVector _sampvec;
+  SampleMatrix _invcov;
+  SamplePulseMatrix _pulsemat;
+  PulseVector _ampvec;
+  PulseVector _errvec;
+  PulseVector _ampvecmin;
+
+  SampleDecompLLT _covdecomp;
+  SampleMatrix _covdecompLinv;
+  PulseMatrix _topleft_work;
+  PulseDecompLDLT _pulsedecomp;
+
+  BXVector _bxs;
+  BXVector _bxsmin;
+  unsigned int _npulsetot;
+  unsigned int _nP;
+
+  SamplePulseMatrix invcovp;
+  PulseMatrix aTamat;
+  PulseVector aTbvec;
+  PulseVector updatework;
+
+  PulseVector ampvecpermtest;
+
+  double _chisq;
+  bool _computeErrors;
+  int _maxiters;
+  bool _maxiterwarnings;
 };
 
 #endif

--- a/RecoLocalCalo/EcalRecAlgos/plugins/EcalSeverityLevelESProducer.cc
+++ b/RecoLocalCalo/EcalRecAlgos/plugins/EcalSeverityLevelESProducer.cc
@@ -19,54 +19,40 @@
  */
 
 class EcalSeverityLevelESProducer : public edm::ESProducer {
-  
 public:
   EcalSeverityLevelESProducer(const edm::ParameterSet& iConfig);
-  
+
   typedef std::shared_ptr<EcalSeverityLevelAlgo> ReturnType;
-  
+
   ReturnType produce(const EcalSeverityLevelAlgoRcd& iRecord);
 
 private:
+  void setupChannelStatus(const EcalChannelStatusRcd&, EcalSeverityLevelAlgo*);
 
-  void setupChannelStatus(const EcalChannelStatusRcd&,
-                          EcalSeverityLevelAlgo*);
-
-  using HostType = edm::ESProductHost<EcalSeverityLevelAlgo,
-                                      EcalChannelStatusRcd>;
+  using HostType = edm::ESProductHost<EcalSeverityLevelAlgo, EcalChannelStatusRcd>;
 
   edm::ReusableObjectHolder<HostType> holder_;
   edm::ParameterSet pset_;
 };
 
-EcalSeverityLevelESProducer::EcalSeverityLevelESProducer(const edm::ParameterSet& iConfig) :
-  pset_(iConfig) {
-
+EcalSeverityLevelESProducer::EcalSeverityLevelESProducer(const edm::ParameterSet& iConfig) : pset_(iConfig) {
   //the following line is needed to tell the framework what
   // data is being produced
   setWhatProduced(this);
 }
 
-EcalSeverityLevelESProducer::ReturnType
-EcalSeverityLevelESProducer::produce(const EcalSeverityLevelAlgoRcd& iRecord){
-
-  auto host = holder_.makeOrGet([this]() {
-    return new HostType(pset_);
-  });
+EcalSeverityLevelESProducer::ReturnType EcalSeverityLevelESProducer::produce(const EcalSeverityLevelAlgoRcd& iRecord) {
+  auto host = holder_.makeOrGet([this]() { return new HostType(pset_); });
 
   host->ifRecordChanges<EcalChannelStatusRcd>(iRecord,
-                                              [this,h=host.get()](auto const& rec) {
-    setupChannelStatus(rec, h);
-  });
+                                              [this, h = host.get()](auto const& rec) { setupChannelStatus(rec, h); });
 
   return host;
 }
 
-void 
-EcalSeverityLevelESProducer::setupChannelStatus(const EcalChannelStatusRcd& chs,
-                                                EcalSeverityLevelAlgo* algo){
-  edm::ESHandle <EcalChannelStatus> h;
-  chs.get (h);
+void EcalSeverityLevelESProducer::setupChannelStatus(const EcalChannelStatusRcd& chs, EcalSeverityLevelAlgo* algo) {
+  edm::ESHandle<EcalChannelStatus> h;
+  chs.get(h);
   algo->setChannelStatus(*h.product());
 }
 

--- a/RecoLocalCalo/EcalRecAlgos/src/ESRecHitFitAlgo.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/ESRecHitFitAlgo.cc
@@ -8,66 +8,71 @@
 #include <cmath>
 
 // fit function
-Double_t fitf(Double_t *x, Double_t *par) {
-
+Double_t fitf(Double_t* x, Double_t* par) {
   Double_t wc = 0.07291;
-  Double_t n  = 1.798; // n-1 (in fact)
-  Double_t v1 = pow(wc/n*(x[0]-par[1]), n);
-  Double_t v2 = TMath::Exp(n-wc*(x[0]-par[1]));
-  Double_t v  = par[0]*v1*v2;
+  Double_t n = 1.798;  // n-1 (in fact)
+  Double_t v1 = pow(wc / n * (x[0] - par[1]), n);
+  Double_t v2 = TMath::Exp(n - wc * (x[0] - par[1]));
+  Double_t v = par[0] * v1 * v2;
 
-  if (x[0] < par[1]) v = 0;
+  if (x[0] < par[1])
+    v = 0;
 
   return v;
 }
 
 ESRecHitFitAlgo::ESRecHitFitAlgo() {
-
   fit_ = new TF1("fit", fitf, -200, 200, 2);
   fit_->SetParameters(50, 10);
-
 }
 
-ESRecHitFitAlgo::~ESRecHitFitAlgo() {
-  delete fit_;
-}
+ESRecHitFitAlgo::~ESRecHitFitAlgo() { delete fit_; }
 
 double* ESRecHitFitAlgo::EvalAmplitude(const ESDataFrame& digi, double ped) const {
-  
-  double *fitresults = new double[3] {};
-  double adc[3] {};  
-  double tx[3] {};
-  tx[0] = -5.; 
+  double* fitresults = new double[3]{};
+  double adc[3]{};
+  double tx[3]{};
+  tx[0] = -5.;
   tx[1] = 20.;
   tx[2] = 45.;
 
-  for (int i=0; i<digi.size(); i++) 
+  for (int i = 0; i < digi.size(); i++)
     adc[i] = digi.sample(i).adc() - ped;
 
   double status = 0;
-  if (adc[0] > 20) status = 14;
-  if (adc[1] < 0 || adc[2] < 0) status = 10;
-  if (adc[0] > adc[1] && adc[0] > adc[2]) status = 8;
-  if (adc[2] > adc[1] && adc[2] > adc[0]) status = 9;  
-  double r12 = (adc[1] != 0) ? adc[0]/adc[1] : 99999;
-  double r23 = (adc[2] != 0) ? adc[1]/adc[2] : 99999;
-  if (r12 > ratioCuts_->getR12High()) status = 5;
-  if (r23 > ratioCuts_->getR23High()) status = 6;
-  if (r23 < ratioCuts_->getR23Low()) status = 7;
+  if (adc[0] > 20)
+    status = 14;
+  if (adc[1] < 0 || adc[2] < 0)
+    status = 10;
+  if (adc[0] > adc[1] && adc[0] > adc[2])
+    status = 8;
+  if (adc[2] > adc[1] && adc[2] > adc[0])
+    status = 9;
+  double r12 = (adc[1] != 0) ? adc[0] / adc[1] : 99999;
+  double r23 = (adc[2] != 0) ? adc[1] / adc[2] : 99999;
+  if (r12 > ratioCuts_->getR12High())
+    status = 5;
+  if (r23 > ratioCuts_->getR23High())
+    status = 6;
+  if (r23 < ratioCuts_->getR23Low())
+    status = 7;
 
   if (int(status) == 0) {
-    double para[10] {};
-    TGraph *gr = new TGraph(3, tx, adc);
+    double para[10]{};
+    TGraph* gr = new TGraph(3, tx, adc);
     fit_->SetParameters(50, 10);
     gr->Fit(fit_, "MQ");
-    fit_->GetParameters(para); 
-    fitresults[0] = para[0]; 
-    fitresults[1] = para[1];  
+    fit_->GetParameters(para);
+    fitresults[0] = para[0];
+    fitresults[1] = para[1];
     delete gr;
 
-    if (adc[1] > 2800 && adc[2] > 2800) status = 11;
-    else if (adc[1] > 2800) status = 12;
-    else if (adc[2] > 2800) status = 13;
+    if (adc[1] > 2800 && adc[2] > 2800)
+      status = 11;
+    else if (adc[1] > 2800)
+      status = 12;
+    else if (adc[2] > 2800)
+      status = 13;
 
   } else {
     fitresults[0] = 0;
@@ -80,9 +85,8 @@ double* ESRecHitFitAlgo::EvalAmplitude(const ESDataFrame& digi, double ped) cons
 }
 
 EcalRecHit ESRecHitFitAlgo::reconstruct(const ESDataFrame& digi) const {
-  
   ESPedestals::const_iterator it_ped = peds_->find(digi.id());
-  
+
   ESIntercalibConstantMap::const_iterator it_mip = mips_->getMap().find(digi.id());
   ESAngleCorrectionFactors::const_iterator it_ang = ang_->getMap().find(digi.id());
 
@@ -94,43 +98,42 @@ EcalRecHit ESRecHitFitAlgo::reconstruct(const ESDataFrame& digi) const {
 
   double energy = results[0];
   double t0 = results[1];
-  int status = (int) results[2];
+  int status = (int)results[2];
   delete[] results;
 
-  double mipCalib = (std::fabs(cos(*it_ang)) != 0.) ? (*it_mip)/fabs(cos(*it_ang)) : 0.;
-  energy *= (mipCalib != 0.) ? MIPGeV_/mipCalib : 0.;
+  double mipCalib = (std::fabs(cos(*it_ang)) != 0.) ? (*it_mip) / fabs(cos(*it_ang)) : 0.;
+  energy *= (mipCalib != 0.) ? MIPGeV_ / mipCalib : 0.;
 
-  LogDebug("ESRecHitFitAlgo") << "ESRecHitFitAlgo : reconstructed energy "<<energy<<" T0 "<<t0;
+  LogDebug("ESRecHitFitAlgo") << "ESRecHitFitAlgo : reconstructed energy " << energy << " T0 " << t0;
 
   EcalRecHit rechit(digi.id(), energy, t0);
 
   if (it_status->getStatusCode() == 1) {
-      rechit.setFlag(EcalRecHit::kESDead);
+    rechit.setFlag(EcalRecHit::kESDead);
   } else {
-    if (status == 0) 
+    if (status == 0)
       rechit.setFlag(EcalRecHit::kESGood);
-    else if (status == 5) 
+    else if (status == 5)
       rechit.setFlag(EcalRecHit::kESBadRatioFor12);
-    else if (status == 6) 
+    else if (status == 6)
       rechit.setFlag(EcalRecHit::kESBadRatioFor23Upper);
-    else if (status == 7) 
+    else if (status == 7)
       rechit.setFlag(EcalRecHit::kESBadRatioFor23Lower);
-    else if (status == 8) 
+    else if (status == 8)
       rechit.setFlag(EcalRecHit::kESTS1Largest);
-    else if (status == 9) 
+    else if (status == 9)
       rechit.setFlag(EcalRecHit::kESTS3Largest);
-    else if (status == 10) 
+    else if (status == 10)
       rechit.setFlag(EcalRecHit::kESTS3Negative);
-    else if (status == 11) 
+    else if (status == 11)
       rechit.setFlag(EcalRecHit::kESSaturated);
-    else if (status == 12) 
+    else if (status == 12)
       rechit.setFlag(EcalRecHit::kESTS2Saturated);
-    else if (status == 13) 
+    else if (status == 13)
       rechit.setFlag(EcalRecHit::kESTS3Saturated);
-    else if (status == 14) 
+    else if (status == 14)
       rechit.setFlag(EcalRecHit::kESTS13Sigmas);
   }
 
   return rechit;
 }
-

--- a/RecoLocalCalo/EcalRecAlgos/src/ESRecHitSimAlgo.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/ESRecHitSimAlgo.cc
@@ -4,37 +4,44 @@
 #include <cmath>
 #include <vdt/vdtMath.h>
 
-#include<cstdlib>
-#include<cstring>
-#include<cassert>
+#include <cstdlib>
+#include <cstring>
+#include <cassert>
 #include <iostream>
 
-EcalRecHit::ESFlags ESRecHitSimAlgo::evalAmplitude(float * results, const ESDataFrame& digi, float ped) const {
-  
+EcalRecHit::ESFlags ESRecHitSimAlgo::evalAmplitude(float* results, const ESDataFrame& digi, float ped) const {
   float energy = 0;
-  float adc[3] {};
-  float pw[3] {};
+  float adc[3]{};
+  float pw[3]{};
   pw[0] = w0_;
   pw[1] = w1_;
   pw[2] = w2_;
 
-  for (int i=0; i<digi.size(); i++) {
-    energy += pw[i]*(digi.sample(i).adc()-ped);
-    LogDebug("ESRecHitSimAlgo") << "ESRecHitSimAlgo : Digi "<<i<<" ADC counts "<<digi.sample(i).adc()<<" Ped "<<ped;
+  for (int i = 0; i < digi.size(); i++) {
+    energy += pw[i] * (digi.sample(i).adc() - ped);
+    LogDebug("ESRecHitSimAlgo") << "ESRecHitSimAlgo : Digi " << i << " ADC counts " << digi.sample(i).adc() << " Ped "
+                                << ped;
     //std::cout<<i<<" "<<digi.sample(i).adc()<<" "<<ped<<" "<<pw[i]<<std::endl;
     adc[i] = digi.sample(i).adc() - ped;
   }
-  
+
   EcalRecHit::ESFlags status = EcalRecHit::kESGood;
-  if (adc[0] > 20.f) status = EcalRecHit::kESTS13Sigmas; // 14;
-  if (adc[1] <= 0 || adc[2] <= 0) status = EcalRecHit::kESTS3Negative; // 10;
-  if (adc[0] > adc[1] && adc[0] > adc[2]) status = EcalRecHit::kESTS1Largest; // 8;
-  if (adc[2] > adc[1] && adc[2] > adc[0]) status = EcalRecHit::kESTS3Largest; // 9;
-  auto r12 = (adc[1] != 0) ? adc[0]/adc[1] : 99.f;
-  auto r23 = (adc[2] != 0) ? adc[1]/adc[2] : 99.f;
-  if (r12 > ratioCuts_->getR12High()) status = EcalRecHit::kESBadRatioFor12;// 5;
-  if (r23 > ratioCuts_->getR23High()) status = EcalRecHit::kESBadRatioFor23Upper; // 6;
-  if (r23 < ratioCuts_->getR23Low()) status = EcalRecHit::kESBadRatioFor23Lower; // 7
+  if (adc[0] > 20.f)
+    status = EcalRecHit::kESTS13Sigmas;  // 14;
+  if (adc[1] <= 0 || adc[2] <= 0)
+    status = EcalRecHit::kESTS3Negative;  // 10;
+  if (adc[0] > adc[1] && adc[0] > adc[2])
+    status = EcalRecHit::kESTS1Largest;  // 8;
+  if (adc[2] > adc[1] && adc[2] > adc[0])
+    status = EcalRecHit::kESTS3Largest;  // 9;
+  auto r12 = (adc[1] != 0) ? adc[0] / adc[1] : 99.f;
+  auto r23 = (adc[2] != 0) ? adc[1] / adc[2] : 99.f;
+  if (r12 > ratioCuts_->getR12High())
+    status = EcalRecHit::kESBadRatioFor12;  // 5;
+  if (r23 > ratioCuts_->getR23High())
+    status = EcalRecHit::kESBadRatioFor23Upper;  // 6;
+  if (r23 < ratioCuts_->getR23Low())
+    status = EcalRecHit::kESBadRatioFor23Lower;  // 7
 
   auto A1 = adc[1];
   auto A2 = adc[2];
@@ -43,57 +50,56 @@ EcalRecHit::ESFlags ESRecHitSimAlgo::evalAmplitude(float * results, const ESData
   constexpr float n = 1.798;
   constexpr float w = 0.07291;
   constexpr float DeltaT = 25.;
-  auto aaa = (A2 > 0 && A1 > 0) ? std::log(A2/A1)/n : 20.f; // if A1=0, t0=20
-  constexpr float bbb = w/n*DeltaT;
-  auto ccc= std::exp(aaa+bbb);
+  auto aaa = (A2 > 0 && A1 > 0) ? std::log(A2 / A1) / n : 20.f;  // if A1=0, t0=20
+  constexpr float bbb = w / n * DeltaT;
+  auto ccc = std::exp(aaa + bbb);
 
-  auto t0 = (2.f-ccc)/(1.f-ccc) * DeltaT - 5.f;
+  auto t0 = (2.f - ccc) / (1.f - ccc) * DeltaT - 5.f;
 
   // A from analytical formula:
   constexpr float t1 = 20.;
-  #if defined(__clang__) || defined(__INTEL_COMPILER)
-  const float A_1 = 1./( std::pow(w/n*(t1),n) * std::exp(n-w*(t1)) );
-  #else
-  constexpr float A_1 = 1./( std::pow(w/n*(t1),n) * std::exp(n-w*(t1)) );
-  #endif
-  auto AA1 = A1 * A_1 ;
+#if defined(__clang__) || defined(__INTEL_COMPILER)
+  const float A_1 = 1. / (std::pow(w / n * (t1), n) * std::exp(n - w * (t1)));
+#else
+  constexpr float A_1 = 1. / (std::pow(w / n * (t1), n) * std::exp(n - w * (t1)));
+#endif
+  auto AA1 = A1 * A_1;
 
- if (adc[1] > 2800.f && adc[2] > 2800.f) status = EcalRecHit::kESSaturated;
-  else if (adc[1] > 2800.f) status = EcalRecHit::kESTS2Saturated;
-  else if (adc[2] > 2800.f) status = EcalRecHit::kESTS3Saturated;
+  if (adc[1] > 2800.f && adc[2] > 2800.f)
+    status = EcalRecHit::kESSaturated;
+  else if (adc[1] > 2800.f)
+    status = EcalRecHit::kESTS2Saturated;
+  else if (adc[2] > 2800.f)
+    status = EcalRecHit::kESTS3Saturated;
 
-  results[0] = energy; // energy with weight method
-  results[1] = t0;     // timing
-  results[2] = AA1;    // energy with analytic method
+  results[0] = energy;  // energy with weight method
+  results[1] = t0;      // timing
+  results[2] = AA1;     // energy with analytic method
 
   return status;
-
 }
 
 EcalRecHit ESRecHitSimAlgo::reconstruct(const ESDataFrame& digi) const {
-
-
   auto ind = digi.id().hashedIndex();
 
-  auto const & ped = peds_->preshower(ind);
-  auto const & mip = mips_->getMap().preshower(ind);
-  auto const & ang = ang_->getMap().preshower(ind);
-  auto const & statusCh = channelStatus_->getMap().preshower(ind);
+  auto const& ped = peds_->preshower(ind);
+  auto const& mip = mips_->getMap().preshower(ind);
+  auto const& ang = ang_->getMap().preshower(ind);
+  auto const& statusCh = channelStatus_->getMap().preshower(ind);
 
-  float results[3] {};
+  float results[3]{};
 
   auto status = evalAmplitude(results, digi, ped.getMean());
 
-  auto energy   = results[0];
-  auto t0       = results[1];
-  auto otenergy = results[2] * 1000000.f; // set out-of-time energy to keV
-  
+  auto energy = results[0];
+  auto t0 = results[1];
+  auto otenergy = results[2] * 1000000.f;  // set out-of-time energy to keV
 
-  auto mipCalib = (mip != 0.f) ? MIPGeV_*std::abs(vdt::fast_cosf(ang))/(mip) : 0.f;
+  auto mipCalib = (mip != 0.f) ? MIPGeV_ * std::abs(vdt::fast_cosf(ang)) / (mip) : 0.f;
   energy *= mipCalib;
   otenergy *= mipCalib;
 
-  LogDebug("ESRecHitSimAlgo") << "ESRecHitSimAlgo : reconstructed energy "<<energy;
+  LogDebug("ESRecHitSimAlgo") << "ESRecHitSimAlgo : reconstructed energy " << energy;
 
   EcalRecHit rechit(digi.id(), energy, t0);
   // edm: this is just a placeholder for alternative energy reconstruction,
@@ -104,7 +110,6 @@ EcalRecHit ESRecHitSimAlgo::reconstruct(const ESDataFrame& digi) const {
   rechit.setFlag(statusCh.getStatusCode() == 1 ? EcalRecHit::kESDead : status);
 
   return rechit;
-
 }
 
 /*
@@ -148,33 +153,41 @@ EcalRecHit ESRecHitSimAlgo::reconstruct(const ESDataFrame& digi) const {
 
 //
 
-double* ESRecHitSimAlgo::oldEvalAmplitude(const ESDataFrame& digi, const double& ped, const double& w0, const double& w1, const double& w2) const {
-  
-  double *results = new double[4] {};
+double* ESRecHitSimAlgo::oldEvalAmplitude(
+    const ESDataFrame& digi, const double& ped, const double& w0, const double& w1, const double& w2) const {
+  double* results = new double[4]{};
   float energy = 0;
-  double adc[3] {};
-  float pw[3] {};
+  double adc[3]{};
+  float pw[3]{};
   pw[0] = w0;
   pw[1] = w1;
   pw[2] = w2;
 
-  for (int i=0; i<digi.size(); i++) {
-    energy += pw[i]*(digi.sample(i).adc()-ped);
-    LogDebug("ESRecHitSimAlgo") << "ESRecHitSimAlgo : Digi "<<i<<" ADC counts "<<digi.sample(i).adc()<<" Ped "<<ped;
+  for (int i = 0; i < digi.size(); i++) {
+    energy += pw[i] * (digi.sample(i).adc() - ped);
+    LogDebug("ESRecHitSimAlgo") << "ESRecHitSimAlgo : Digi " << i << " ADC counts " << digi.sample(i).adc() << " Ped "
+                                << ped;
     //std::cout<<i<<" "<<digi.sample(i).adc()<<" "<<ped<<" "<<pw[i]<<std::endl;
     adc[i] = digi.sample(i).adc() - ped;
   }
-  
+
   double status = 0;
-  if (adc[0] > 20) status = 14;
-  if (adc[1] <= 0 || adc[2] <= 0) status = 10;
-  if (adc[0] > adc[1] && adc[0] > adc[2]) status = 8;
-  if (adc[2] > adc[1] && adc[2] > adc[0]) status = 9;
-  double r12 = (adc[1] != 0) ? adc[0]/adc[1] : 99;
-  double r23 = (adc[2] != 0) ? adc[1]/adc[2] : 99;
-  if (r12 > ratioCuts_->getR12High()) status = 5;
-  if (r23 > ratioCuts_->getR23High()) status = 6;
-  if (r23 < ratioCuts_->getR23Low()) status = 7;
+  if (adc[0] > 20)
+    status = 14;
+  if (adc[1] <= 0 || adc[2] <= 0)
+    status = 10;
+  if (adc[0] > adc[1] && adc[0] > adc[2])
+    status = 8;
+  if (adc[2] > adc[1] && adc[2] > adc[0])
+    status = 9;
+  double r12 = (adc[1] != 0) ? adc[0] / adc[1] : 99;
+  double r23 = (adc[2] != 0) ? adc[1] / adc[2] : 99;
+  if (r12 > ratioCuts_->getR12High())
+    status = 5;
+  if (r23 > ratioCuts_->getR23High())
+    status = 6;
+  if (r23 < ratioCuts_->getR23Low())
+    status = 7;
 
   double A1 = adc[1];
   double A2 = adc[2];
@@ -183,31 +196,33 @@ double* ESRecHitSimAlgo::oldEvalAmplitude(const ESDataFrame& digi, const double&
   double n = 1.798;
   double w = 0.07291;
   double DeltaT = 25.;
-  double aaa = (A2 > 0 && A1 > 0) ? log(A2/A1)/n : 20.; // if A1=0, t0=20
-  double bbb = w/n*DeltaT;
-  double ccc= exp(aaa+bbb);
+  double aaa = (A2 > 0 && A1 > 0) ? log(A2 / A1) / n : 20.;  // if A1=0, t0=20
+  double bbb = w / n * DeltaT;
+  double ccc = exp(aaa + bbb);
 
-  double t0 = (2.-ccc)/(1.-ccc) * DeltaT - 5;
+  double t0 = (2. - ccc) / (1. - ccc) * DeltaT - 5;
 
   // A from analytical formula:
   double t1 = 20.;
-  double A_1 =  pow(w/n*(t1),n) * exp(n-w*(t1));
+  double A_1 = pow(w / n * (t1), n) * exp(n - w * (t1));
   double AA1 = (A_1 != 0.) ? A1 / A_1 : 0.;
 
-  if (adc[1] > 2800 && adc[2] > 2800) status = 11;
-  else if (adc[1] > 2800) status = 12;
-  else if (adc[2] > 2800) status = 13;
+  if (adc[1] > 2800 && adc[2] > 2800)
+    status = 11;
+  else if (adc[1] > 2800)
+    status = 12;
+  else if (adc[2] > 2800)
+    status = 13;
 
-  results[0] = energy; // energy with weight method
-  results[1] = t0;     // timing
-  results[2] = status; // hit status
-  results[3] = AA1;    // energy with analytic method
+  results[0] = energy;  // energy with weight method
+  results[1] = t0;      // timing
+  results[2] = status;  // hit status
+  results[3] = AA1;     // energy with analytic method
 
   return results;
 }
 
 EcalRecHit ESRecHitSimAlgo::oldreconstruct(const ESDataFrame& digi) const {
-
   ESPedestals::const_iterator it_ped = peds_->find(digi.id());
 
   ESIntercalibConstantMap::const_iterator it_mip = mips_->getMap().find(digi.id());
@@ -219,17 +234,17 @@ EcalRecHit ESRecHitSimAlgo::oldreconstruct(const ESDataFrame& digi) const {
 
   results = oldEvalAmplitude(digi, it_ped->getMean(), w0_, w1_, w2_);
 
-  double energy   = results[0];
-  double t0       = results[1];
-  int status      = (int) results[2];
-  double otenergy = results[3] * 1000000.; // set out-of-time energy to keV
+  double energy = results[0];
+  double t0 = results[1];
+  int status = (int)results[2];
+  double otenergy = results[3] * 1000000.;  // set out-of-time energy to keV
   delete[] results;
 
-  double mipCalib = (fabs(cos(*it_ang)) != 0.) ? (*it_mip)/fabs(cos(*it_ang)) : 0.;
-  energy *= (mipCalib != 0.) ? MIPGeV_/mipCalib : 0.;
-  otenergy *= (mipCalib != 0.) ? MIPGeV_/mipCalib : 0.;
+  double mipCalib = (fabs(cos(*it_ang)) != 0.) ? (*it_mip) / fabs(cos(*it_ang)) : 0.;
+  energy *= (mipCalib != 0.) ? MIPGeV_ / mipCalib : 0.;
+  otenergy *= (mipCalib != 0.) ? MIPGeV_ / mipCalib : 0.;
 
-  LogDebug("ESRecHitSimAlgo") << "ESRecHitSimAlgo : reconstructed energy "<<energy;
+  LogDebug("ESRecHitSimAlgo") << "ESRecHitSimAlgo : reconstructed energy " << energy;
 
   EcalRecHit rechit(digi.id(), energy, t0);
   // edm: this is just a placeholder for alternative energy reconstruction,
@@ -266,4 +281,3 @@ EcalRecHit ESRecHitSimAlgo::oldreconstruct(const ESDataFrame& digi) const {
 
   return rechit;
 }
-

--- a/RecoLocalCalo/EcalRecAlgos/src/EcalCleaningAlgo.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/EcalCleaningAlgo.cc
@@ -1,42 +1,36 @@
 /* Implementation of class EcalCleaningAlgo
    \author Stefano Argiro
    \date 20 Dec 2010
-*/    
-
+*/
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
-#include "DataFormats/EcalRecHit/interface/EcalRecHit.h" 
+#include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
 
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalCleaningAlgo.h"
 
-EcalCleaningAlgo::EcalCleaningAlgo(const edm::ParameterSet&  p){
-  
-  cThreshold_barrel_   = p.getParameter<double>("cThreshold_barrel");;
-  cThreshold_endcap_   = p.getParameter<double>("cThreshold_endcap");;  
-  e4e1_a_barrel_       = p.getParameter<double>("e4e1_a_barrel");
-  e4e1_b_barrel_       = p.getParameter<double>("e4e1_b_barrel");
-  e4e1_a_endcap_       = p.getParameter<double>("e4e1_a_endcap");
-  e4e1_b_endcap_       = p.getParameter<double>("e4e1_b_endcap");
+EcalCleaningAlgo::EcalCleaningAlgo(const edm::ParameterSet& p) {
+  cThreshold_barrel_ = p.getParameter<double>("cThreshold_barrel");
+  ;
+  cThreshold_endcap_ = p.getParameter<double>("cThreshold_endcap");
+  ;
+  e4e1_a_barrel_ = p.getParameter<double>("e4e1_a_barrel");
+  e4e1_b_barrel_ = p.getParameter<double>("e4e1_b_barrel");
+  e4e1_a_endcap_ = p.getParameter<double>("e4e1_a_endcap");
+  e4e1_b_endcap_ = p.getParameter<double>("e4e1_b_endcap");
   e4e1Treshold_barrel_ = p.getParameter<double>("e4e1Threshold_barrel");
   e4e1Treshold_endcap_ = p.getParameter<double>("e4e1Threshold_endcap");
 
-  cThreshold_double_   = p.getParameter<double>("cThreshold_double"); 
+  cThreshold_double_ = p.getParameter<double>("cThreshold_double");
 
-  ignoreOutOfTimeThresh_   =p.getParameter<double>("ignoreOutOfTimeThresh");  
-  tightenCrack_e1_single_  =p.getParameter<double>("tightenCrack_e1_single");
-  tightenCrack_e4e1_single_=p.getParameter<double>("tightenCrack_e4e1_single");
-  tightenCrack_e1_double_  =p.getParameter<double>("tightenCrack_e1_double");
-  tightenCrack_e6e2_double_=p.getParameter<double>("tightenCrack_e6e2_double");
-  e6e2thresh_=              p.getParameter<double>("e6e2thresh");
-
-
-  
+  ignoreOutOfTimeThresh_ = p.getParameter<double>("ignoreOutOfTimeThresh");
+  tightenCrack_e1_single_ = p.getParameter<double>("tightenCrack_e1_single");
+  tightenCrack_e4e1_single_ = p.getParameter<double>("tightenCrack_e4e1_single");
+  tightenCrack_e1_double_ = p.getParameter<double>("tightenCrack_e1_double");
+  tightenCrack_e6e2_double_ = p.getParameter<double>("tightenCrack_e6e2_double");
+  e6e2thresh_ = p.getParameter<double>("e6e2thresh");
 }
-
-
-
 
 /**
    Flag spikey channels
@@ -65,159 +59,130 @@ EcalCleaningAlgo::EcalCleaningAlgo(const edm::ParameterSet&  p){
    ignored in topological quantities   
  */
 
-EcalRecHit::Flags 
-EcalCleaningAlgo::checkTopology(const DetId& id,
-				const EcalRecHitCollection& rhs){
+EcalRecHit::Flags EcalCleaningAlgo::checkTopology(const DetId& id, const EcalRecHitCollection& rhs) {
+  float a = 0, b = 0, e4e1thresh = 0, ethresh = 0;
 
+  if (id.subdetId() == EcalBarrel) {
+    a = e4e1_a_barrel_;
+    b = e4e1_b_barrel_;
+    ethresh = cThreshold_barrel_;
 
-  float a=0,b=0,e4e1thresh=0,ethresh=0;
-
-
-  if( id.subdetId() == EcalBarrel) {
-    a= e4e1_a_barrel_;
-    b= e4e1_b_barrel_; 
-    ethresh=cThreshold_barrel_;
-   
+  } else if (id.subdetId() == EcalEndcap) {
+    a = e4e1_a_endcap_;
+    b = e4e1_b_endcap_;
+    ethresh = cThreshold_endcap_;
   }
-  else if( id.subdetId() == EcalEndcap){
-    a= e4e1_a_endcap_;
-    b= e4e1_b_endcap_;
-    ethresh=cThreshold_endcap_;
-   }
-  
-  
 
   // for energies below threshold, we don't apply e4e1 cut
-  float energy = recHitE(id,rhs,false);
- 
-  if (energy< ethresh) return EcalRecHit::kGood;
-  if (isNearCrack(id) && energy < ethresh*tightenCrack_e1_single_) 
+  float energy = recHitE(id, rhs, false);
+
+  if (energy < ethresh)
+    return EcalRecHit::kGood;
+  if (isNearCrack(id) && energy < ethresh * tightenCrack_e1_single_)
     return EcalRecHit::kGood;
 
+  float e4e1value = e4e1(id, rhs);
+  e4e1thresh = a * log10(energy) + b;
 
-  float e4e1value = e4e1(id,rhs);
-  e4e1thresh = a* log10(energy) + b;
-
-  // near cracks the cut is tighter by a factor 
+  // near cracks the cut is tighter by a factor
   if (isNearCrack(id)) {
-    e4e1thresh/=tightenCrack_e4e1_single_;
+    e4e1thresh /= tightenCrack_e4e1_single_;
   }
 
   // identify spike
-  if (e4e1value < e4e1thresh) return EcalRecHit::kWeird; 
-  
-
+  if (e4e1value < e4e1thresh)
+    return EcalRecHit::kWeird;
 
   // now for double spikes
- 
-  // no checking for double spikes in EE
-  if( id.subdetId() == EcalEndcap) return EcalRecHit::kGood;
 
-  float e6e2value = e6e2(id,rhs);
-  float e6e2thresh = e6e2thresh_ ;
-  if (isNearCrack(id) && energy < cThreshold_double_ *tightenCrack_e1_double_ )
+  // no checking for double spikes in EE
+  if (id.subdetId() == EcalEndcap)
     return EcalRecHit::kGood;
 
-  if  (energy <  cThreshold_double_) return EcalRecHit::kGood;
-  
-  // near cracks the cut is tighter by a factor 
-  if (id.subdetId() == EcalBarrel && isNearCrack(id)) 
-    e6e2thresh/=tightenCrack_e6e2_double_;
+  float e6e2value = e6e2(id, rhs);
+  float e6e2thresh = e6e2thresh_;
+  if (isNearCrack(id) && energy < cThreshold_double_ * tightenCrack_e1_double_)
+    return EcalRecHit::kGood;
+
+  if (energy < cThreshold_double_)
+    return EcalRecHit::kGood;
+
+  // near cracks the cut is tighter by a factor
+  if (id.subdetId() == EcalBarrel && isNearCrack(id))
+    e6e2thresh /= tightenCrack_e6e2_double_;
 
   // identify double spike
-  if (e6e2value < e6e2thresh) return EcalRecHit::kDiWeird; 
+  if (e6e2value < e6e2thresh)
+    return EcalRecHit::kDiWeird;
 
   return EcalRecHit::kGood;
-
 }
 
-
-
-
-
-
-float EcalCleaningAlgo::e4e1(const DetId& id, 
-			     const EcalRecHitCollection& rhs){
-
- 
+float EcalCleaningAlgo::e4e1(const DetId& id, const EcalRecHitCollection& rhs) {
   float s4 = 0;
-  float e1 = recHitE( id, rhs, false );
-  
-  
-  if ( e1 == 0 ) return 0;
-  const std::vector<DetId>& neighs =  neighbours(id);
-  for (size_t i=0; i<neighs.size(); ++i)
+  float e1 = recHitE(id, rhs, false);
+
+  if (e1 == 0)
+    return 0;
+  const std::vector<DetId>& neighs = neighbours(id);
+  for (size_t i = 0; i < neighs.size(); ++i)
     // avoid hits out of time when making s4
-    s4+=recHitE(neighs[i],rhs, true);
-  
+    s4 += recHitE(neighs[i], rhs, true);
+
   return s4 / e1;
-  
- 
 }
 
+float EcalCleaningAlgo::e6e2(const DetId& id, const EcalRecHitCollection& rhs) {
+  float s4_1 = 0;
+  float s4_2 = 0;
+  float e1 = recHitE(id, rhs, false);
 
+  float maxene = 0;
+  DetId maxid;
 
+  if (e1 == 0)
+    return 0;
 
-float EcalCleaningAlgo::e6e2(const DetId& id, 
-			     const EcalRecHitCollection& rhs){
+  const std::vector<DetId>& neighs = neighbours(id);
 
-    float s4_1 = 0;
-    float s4_2 = 0;
-    float e1 = recHitE( id, rhs , false );
-
-
-    float maxene=0;
-    DetId maxid;
-
-    if ( e1 == 0 ) return 0;
-
-    const std::vector<DetId>& neighs =  neighbours(id);
-
-    // find the most energetic neighbour ignoring time info
-    for (size_t i=0; i<neighs.size(); ++i){
-      float ene = recHitE(neighs[i],rhs,false);
-      if (ene>maxene)  {
-	maxene=ene;
-	maxid = neighs[i];
-      }
+  // find the most energetic neighbour ignoring time info
+  for (size_t i = 0; i < neighs.size(); ++i) {
+    float ene = recHitE(neighs[i], rhs, false);
+    if (ene > maxene) {
+      maxene = ene;
+      maxid = neighs[i];
     }
+  }
 
-    float e2=maxene;
+  float e2 = maxene;
 
-    s4_1 = e4e1(id,rhs)* e1;
-    s4_2 = e4e1(maxid,rhs)* e2;
+  s4_1 = e4e1(id, rhs) * e1;
+  s4_2 = e4e1(maxid, rhs) * e2;
 
-    return (s4_1 + s4_2) / (e1+e2) -1. ;
-
+  return (s4_1 + s4_2) / (e1 + e2) - 1.;
 }
 
-
-
-
-float EcalCleaningAlgo::recHitE( const DetId id, 
-				 const EcalRecHitCollection &recHits,
-                                 bool useTimingInfo )
-{
-  if ( id.rawId() == 0 ) return 0;
-  
+float EcalCleaningAlgo::recHitE(const DetId id, const EcalRecHitCollection& recHits, bool useTimingInfo) {
+  if (id.rawId() == 0)
+    return 0;
 
   float threshold = e4e1Treshold_barrel_;
-  if ( id.subdetId() == EcalEndcap) threshold = e4e1Treshold_endcap_; 
+  if (id.subdetId() == EcalEndcap)
+    threshold = e4e1Treshold_endcap_;
 
-  EcalRecHitCollection::const_iterator it = recHits.find( id );
-  if ( it != recHits.end() ){
-    float ene= (*it).energy();
+  EcalRecHitCollection::const_iterator it = recHits.find(id);
+  if (it != recHits.end()) {
+    float ene = (*it).energy();
 
     // ignore out of time in EB when making e4e1 if so configured
-    if (useTimingInfo){
-
-      if (id.subdetId()==EcalBarrel &&
-	  it->checkFlag(EcalRecHit::kOutOfTime) 
-	  && ene>ignoreOutOfTimeThresh_) return 0;
+    if (useTimingInfo) {
+      if (id.subdetId() == EcalBarrel && it->checkFlag(EcalRecHit::kOutOfTime) && ene > ignoreOutOfTimeThresh_)
+        return 0;
     }
 
     // ignore hits below threshold
-    if (ene < threshold) return 0;
+    if (ene < threshold)
+      return 0;
 
     // else return the energy of this hit
     return ene;
@@ -226,52 +191,42 @@ float EcalCleaningAlgo::recHitE( const DetId id,
 }
 
 /// four neighbours in the swiss cross around id
-const std::vector<DetId> EcalCleaningAlgo::neighbours(const DetId& id){
- 
+const std::vector<DetId> EcalCleaningAlgo::neighbours(const DetId& id) {
   std::vector<DetId> ret;
 
-  if ( id.subdetId() == EcalBarrel) {
-
-    ret.push_back( EBDetId::offsetBy( id,  1, 0 ));
-    ret.push_back( EBDetId::offsetBy( id, -1, 0 ));
-    ret.push_back( EBDetId::offsetBy( id,  0, 1 ));
-    ret.push_back( EBDetId::offsetBy( id,  0,-1 ));
+  if (id.subdetId() == EcalBarrel) {
+    ret.push_back(EBDetId::offsetBy(id, 1, 0));
+    ret.push_back(EBDetId::offsetBy(id, -1, 0));
+    ret.push_back(EBDetId::offsetBy(id, 0, 1));
+    ret.push_back(EBDetId::offsetBy(id, 0, -1));
   }
   // nobody understands what polymorphism is for, sgrunt !
-  else  if (id.subdetId() == EcalEndcap) {
-    ret.push_back( EEDetId::offsetBy( id,  1, 0 ));
-    ret.push_back( EEDetId::offsetBy( id, -1, 0 ));
-    ret.push_back( EEDetId::offsetBy( id,  0, 1 ));
-    ret.push_back( EEDetId::offsetBy( id,  0,-1 ));
-
+  else if (id.subdetId() == EcalEndcap) {
+    ret.push_back(EEDetId::offsetBy(id, 1, 0));
+    ret.push_back(EEDetId::offsetBy(id, -1, 0));
+    ret.push_back(EEDetId::offsetBy(id, 0, 1));
+    ret.push_back(EEDetId::offsetBy(id, 0, -1));
   }
 
-
   return ret;
+}
 
-} 
-
-
-bool EcalCleaningAlgo::isNearCrack(const DetId& id){
-
-  if (id.subdetId() == EcalEndcap) { 
+bool EcalCleaningAlgo::isNearCrack(const DetId& id) {
+  if (id.subdetId() == EcalEndcap) {
     return EEDetId::isNextToRingBoundary(id);
   } else {
     return EBDetId::isNextToBoundary(id);
   }
 }
 
-
-
-void EcalCleaningAlgo::setFlags(EcalRecHitCollection& rhs){
+void EcalCleaningAlgo::setFlags(EcalRecHitCollection& rhs) {
   EcalRecHitCollection::iterator rh;
   //changing the collection on place
-  for (rh=rhs.begin(); rh!=rhs.end(); ++rh){
-    EcalRecHit::Flags state=checkTopology(rh->id(),rhs);
-    if (state!=EcalRecHit::kGood) { 
+  for (rh = rhs.begin(); rh != rhs.end(); ++rh) {
+    EcalRecHit::Flags state = checkTopology(rh->id(), rhs);
+    if (state != EcalRecHit::kGood) {
       rh->unsetFlag(EcalRecHit::kGood);
       rh->setFlag(state);
     }
   }
 }
-

--- a/RecoLocalCalo/EcalRecAlgos/src/EcalSeverityLevelAlgoRcd.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/EcalSeverityLevelAlgoRcd.cc
@@ -2,5 +2,5 @@
 
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h"
 #include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
- 
+
 EVENTSETUP_RECORD_REG(EcalSeverityLevelAlgoRcd);

--- a/RecoLocalCalo/EcalRecAlgos/src/EcalUncalibRecHitMultiFitAlgo.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/EcalUncalibRecHitMultiFitAlgo.cc
@@ -5,119 +5,117 @@
 #include "CondFormats/EcalObjects/interface/EcalPedestals.h"
 #include "CondFormats/EcalObjects/interface/EcalGainRatios.h"
 
-EcalUncalibRecHitMultiFitAlgo::EcalUncalibRecHitMultiFitAlgo() : 
-  _computeErrors(true),
-  _doPrefit(false),
-  _prefitMaxChiSq(1.0),
-  _dynamicPedestals(false),
-  _mitigateBadSamples(false),
-  _selectiveBadSampleCriteria(false),
-  _addPedestalUncertainty(0.),
-  _simplifiedNoiseModelForGainSwitch(true),
-  _gainSwitchUseMaxSample(false){
-    
+EcalUncalibRecHitMultiFitAlgo::EcalUncalibRecHitMultiFitAlgo()
+    : _computeErrors(true),
+      _doPrefit(false),
+      _prefitMaxChiSq(1.0),
+      _dynamicPedestals(false),
+      _mitigateBadSamples(false),
+      _selectiveBadSampleCriteria(false),
+      _addPedestalUncertainty(0.),
+      _simplifiedNoiseModelForGainSwitch(true),
+      _gainSwitchUseMaxSample(false) {
   _singlebx.resize(1);
   _singlebx << 0;
-  
+
   _pulsefuncSingle.disableErrorCalculation();
   _pulsefuncSingle.setMaxIters(1);
   _pulsefuncSingle.setMaxIterWarnings(false);
-    
 }
 
 /// compute rechits
-EcalUncalibratedRecHit EcalUncalibRecHitMultiFitAlgo::makeRecHit(const EcalDataFrame& dataFrame, const EcalPedestals::Item * aped, const EcalMGPAGainRatio * aGain, const SampleMatrixGainArray &noisecors, const FullSampleVector &fullpulse, const FullSampleMatrix &fullpulsecov, const BXVector &activeBX) {
-
+EcalUncalibratedRecHit EcalUncalibRecHitMultiFitAlgo::makeRecHit(const EcalDataFrame &dataFrame,
+                                                                 const EcalPedestals::Item *aped,
+                                                                 const EcalMGPAGainRatio *aGain,
+                                                                 const SampleMatrixGainArray &noisecors,
+                                                                 const FullSampleVector &fullpulse,
+                                                                 const FullSampleMatrix &fullpulsecov,
+                                                                 const BXVector &activeBX) {
   uint32_t flags = 0;
-  
+
   const unsigned int nsample = EcalDataFrame::MAXSAMPLES;
-  
+
   double maxamplitude = -std::numeric_limits<double>::max();
   const unsigned int iSampleMax = 5;
   const unsigned int iFullPulseMax = 9;
-  
+
   double pedval = 0.;
-    
+
   SampleVector amplitudes;
   SampleGainVector gainsNoise;
   SampleGainVector gainsPedestal;
   SampleGainVector badSamples = SampleGainVector::Zero();
   bool hasSaturation = dataFrame.isSaturated();
   bool hasGainSwitch = hasSaturation || dataFrame.hasSwitchToGain6() || dataFrame.hasSwitchToGain1();
-  
+
   //no dynamic pedestal in case of gain switch, since then the fit becomes too underconstrained
   bool dynamicPedestal = _dynamicPedestals && !hasGainSwitch;
-  
-  for(unsigned int iSample = 0; iSample < nsample; iSample++) {
-        
+
+  for (unsigned int iSample = 0; iSample < nsample; iSample++) {
     const EcalMGPASample &sample = dataFrame.sample(iSample);
-    
+
     double amplitude = 0.;
     int gainId = sample.gainId();
-    
+
     double pedestal = 0.;
     double gainratio = 1.;
-    
-    if (gainId==0 || gainId==3) {
+
+    if (gainId == 0 || gainId == 3) {
       pedestal = aped->mean_x1;
-      gainratio = aGain->gain6Over1()*aGain->gain12Over6();
+      gainratio = aGain->gain6Over1() * aGain->gain12Over6();
       gainsNoise[iSample] = 2;
       gainsPedestal[iSample] = dynamicPedestal ? 2 : -1;  //-1 for static pedestal
-    }
-    else if (gainId==1) {
+    } else if (gainId == 1) {
       pedestal = aped->mean_x12;
       gainratio = 1.;
       gainsNoise[iSample] = 0;
-      gainsPedestal[iSample] = dynamicPedestal ? 0 : -1; //-1 for static pedestal
-    }
-    else if (gainId==2) {
+      gainsPedestal[iSample] = dynamicPedestal ? 0 : -1;  //-1 for static pedestal
+    } else if (gainId == 2) {
       pedestal = aped->mean_x6;
       gainratio = aGain->gain12Over6();
       gainsNoise[iSample] = 1;
-      gainsPedestal[iSample] = dynamicPedestal ? 1 : -1; //-1 for static pedestals
+      gainsPedestal[iSample] = dynamicPedestal ? 1 : -1;  //-1 for static pedestals
     }
 
     if (dynamicPedestal) {
-      amplitude = (double)(sample.adc())*gainratio;
-    }
-    else {
+      amplitude = (double)(sample.adc()) * gainratio;
+    } else {
       amplitude = ((double)(sample.adc()) - pedestal) * gainratio;
     }
-    
+
     if (gainId == 0) {
-       edm::LogError("EcalUncalibRecHitMultiFitAlgo")<< "Saturation encountered.  Multifit is not intended to be used for saturated channels.";
+      edm::LogError("EcalUncalibRecHitMultiFitAlgo")
+          << "Saturation encountered.  Multifit is not intended to be used for saturated channels.";
       //saturation
       if (dynamicPedestal) {
-        amplitude = 4095.*gainratio;
-      }
-      else {
+        amplitude = 4095. * gainratio;
+      } else {
         amplitude = (4095. - pedestal) * gainratio;
       }
     }
-        
+
     amplitudes[iSample] = amplitude;
-    
-    if (iSample==iSampleMax) {
+
+    if (iSample == iSampleMax) {
       maxamplitude = amplitude;
       pedval = pedestal;
     }
-        
   }
 
   double amplitude, amperr, chisq;
   bool status = false;
-    
+
   //special handling for gain switch, where sample before maximum is potentially affected by slew rate limitation
   //optionally apply a stricter criteria, assuming slew rate limit is only reached in case where maximum sample has gain switched but previous sample has not
   //option 1: use simple max-sample algorithm
   if (hasGainSwitch && _gainSwitchUseMaxSample) {
     double maxpulseamplitude = maxamplitude / fullpulse[iFullPulseMax];
-    EcalUncalibratedRecHit rh( dataFrame.id(), maxpulseamplitude, pedval, 0., 0., flags );
+    EcalUncalibratedRecHit rh(dataFrame.id(), maxpulseamplitude, pedval, 0., 0., flags);
     rh.setAmplitudeError(0.);
-    for (unsigned int ipulse=0; ipulse<_pulsefunc.BXs().rows(); ++ipulse) {
+    for (unsigned int ipulse = 0; ipulse < _pulsefunc.BXs().rows(); ++ipulse) {
       int bx = _pulsefunc.BXs().coeff(ipulse);
-      if (bx!=0) {
-        rh.setOutOfTimeAmplitude(bx+5, 0.0);
+      if (bx != 0) {
+        rh.setOutOfTimeAmplitude(bx + 5, 0.0);
       }
     }
     return rh;
@@ -125,103 +123,103 @@ EcalUncalibratedRecHit EcalUncalibRecHitMultiFitAlgo::makeRecHit(const EcalDataF
 
   //option2: A floating negative single-sample offset is added to the fit
   //such that the affected sample is treated only as a lower limit for the true amplitude
-  bool mitigateBadSample = _mitigateBadSamples && hasGainSwitch && iSampleMax>0;
-  mitigateBadSample &= (!_selectiveBadSampleCriteria || (gainsNoise.coeff(iSampleMax-1)!=gainsNoise.coeff(iSampleMax)) );
+  bool mitigateBadSample = _mitigateBadSamples && hasGainSwitch && iSampleMax > 0;
+  mitigateBadSample &=
+      (!_selectiveBadSampleCriteria || (gainsNoise.coeff(iSampleMax - 1) != gainsNoise.coeff(iSampleMax)));
   if (mitigateBadSample) {
-    badSamples[iSampleMax-1] = 1;
+    badSamples[iSampleMax - 1] = 1;
   }
-  
+
   //compute noise covariance matrix, which depends on the sample gains
   SampleMatrix noisecov;
   if (hasGainSwitch) {
-    std::array<double,3> pedrmss = {{aped->rms_x12, aped->rms_x6, aped->rms_x1}};
-    std::array<double,3> gainratios = {{ 1., aGain->gain12Over6(), aGain->gain6Over1()*aGain->gain12Over6()}};
+    std::array<double, 3> pedrmss = {{aped->rms_x12, aped->rms_x6, aped->rms_x1}};
+    std::array<double, 3> gainratios = {{1., aGain->gain12Over6(), aGain->gain6Over1() * aGain->gain12Over6()}};
     if (_simplifiedNoiseModelForGainSwitch) {
       int gainidxmax = gainsNoise[iSampleMax];
-      noisecov = gainratios[gainidxmax]*gainratios[gainidxmax]*pedrmss[gainidxmax]*pedrmss[gainidxmax]*noisecors[gainidxmax];
-      if (!dynamicPedestal && _addPedestalUncertainty>0.) {
+      noisecov = gainratios[gainidxmax] * gainratios[gainidxmax] * pedrmss[gainidxmax] * pedrmss[gainidxmax] *
+                 noisecors[gainidxmax];
+      if (!dynamicPedestal && _addPedestalUncertainty > 0.) {
         //add fully correlated component to noise covariance to inflate pedestal uncertainty
-        noisecov += _addPedestalUncertainty*_addPedestalUncertainty*SampleMatrix::Ones();
+        noisecov += _addPedestalUncertainty * _addPedestalUncertainty * SampleMatrix::Ones();
       }
-    }
-    else {
+    } else {
       noisecov = SampleMatrix::Zero();
-      for (unsigned int gainidx=0; gainidx<noisecors.size(); ++gainidx) {
-        SampleGainVector mask = gainidx*SampleGainVector::Ones();
-        SampleVector pedestal = (gainsNoise.array()==mask.array()).cast<SampleVector::value_type>();
-        if (pedestal.maxCoeff()>0.) {
+      for (unsigned int gainidx = 0; gainidx < noisecors.size(); ++gainidx) {
+        SampleGainVector mask = gainidx * SampleGainVector::Ones();
+        SampleVector pedestal = (gainsNoise.array() == mask.array()).cast<SampleVector::value_type>();
+        if (pedestal.maxCoeff() > 0.) {
           //select out relevant components of each correlation matrix, and assume no correlation between samples with
           //different gain
-          noisecov += gainratios[gainidx]*gainratios[gainidx]*pedrmss[gainidx]*pedrmss[gainidx]*pedestal.asDiagonal()*noisecors[gainidx]*pedestal.asDiagonal();
-          if (!dynamicPedestal && _addPedestalUncertainty>0.) {
+          noisecov += gainratios[gainidx] * gainratios[gainidx] * pedrmss[gainidx] * pedrmss[gainidx] *
+                      pedestal.asDiagonal() * noisecors[gainidx] * pedestal.asDiagonal();
+          if (!dynamicPedestal && _addPedestalUncertainty > 0.) {
             //add fully correlated component to noise covariance to inflate pedestal uncertainty
-            noisecov += gainratios[gainidx]*gainratios[gainidx]*_addPedestalUncertainty*_addPedestalUncertainty*pedestal.asDiagonal()*SampleMatrix::Ones()*pedestal.asDiagonal();
+            noisecov += gainratios[gainidx] * gainratios[gainidx] * _addPedestalUncertainty * _addPedestalUncertainty *
+                        pedestal.asDiagonal() * SampleMatrix::Ones() * pedestal.asDiagonal();
           }
         }
       }
     }
-  }
-  else {
-    noisecov = aped->rms_x12*aped->rms_x12*noisecors[0];
-    if (!dynamicPedestal && _addPedestalUncertainty>0.) {
+  } else {
+    noisecov = aped->rms_x12 * aped->rms_x12 * noisecors[0];
+    if (!dynamicPedestal && _addPedestalUncertainty > 0.) {
       //add fully correlated component to noise covariance to inflate pedestal uncertainty
-      noisecov += _addPedestalUncertainty*_addPedestalUncertainty*SampleMatrix::Ones();
+      noisecov += _addPedestalUncertainty * _addPedestalUncertainty * SampleMatrix::Ones();
     }
   }
-  
+
   //optimized one-pulse fit for hlt
   bool usePrefit = false;
   if (_doPrefit) {
-    status = _pulsefuncSingle.DoFit(amplitudes,noisecov,_singlebx,fullpulse,fullpulsecov,gainsPedestal,badSamples);
+    status =
+        _pulsefuncSingle.DoFit(amplitudes, noisecov, _singlebx, fullpulse, fullpulsecov, gainsPedestal, badSamples);
     amplitude = status ? _pulsefuncSingle.X()[0] : 0.;
     amperr = status ? _pulsefuncSingle.Errors()[0] : 0.;
     chisq = _pulsefuncSingle.ChiSq();
-    
+
     if (chisq < _prefitMaxChiSq) {
       usePrefit = true;
     }
   }
-  
+
   if (!usePrefit) {
-  
-    if(!_computeErrors) _pulsefunc.disableErrorCalculation();
-    status = _pulsefunc.DoFit(amplitudes,noisecov,activeBX,fullpulse,fullpulsecov,gainsPedestal,badSamples);
+    if (!_computeErrors)
+      _pulsefunc.disableErrorCalculation();
+    status = _pulsefunc.DoFit(amplitudes, noisecov, activeBX, fullpulse, fullpulsecov, gainsPedestal, badSamples);
     chisq = _pulsefunc.ChiSq();
-    
+
     if (!status) {
       edm::LogWarning("EcalUncalibRecHitMultiFitAlgo::makeRecHit") << "Failed Fit" << std::endl;
     }
 
     unsigned int ipulseintime = 0;
-    for (unsigned int ipulse=0; ipulse<_pulsefunc.BXs().rows(); ++ipulse) {
-      if (_pulsefunc.BXs().coeff(ipulse)==0) {
+    for (unsigned int ipulse = 0; ipulse < _pulsefunc.BXs().rows(); ++ipulse) {
+      if (_pulsefunc.BXs().coeff(ipulse) == 0) {
         ipulseintime = ipulse;
         break;
       }
     }
-    
+
     amplitude = status ? _pulsefunc.X()[ipulseintime] : 0.;
     amperr = status ? _pulsefunc.Errors()[ipulseintime] : 0.;
-  
   }
-  
+
   double jitter = 0.;
-  
-  EcalUncalibratedRecHit rh( dataFrame.id(), amplitude , pedval, jitter, chisq, flags );
+
+  EcalUncalibratedRecHit rh(dataFrame.id(), amplitude, pedval, jitter, chisq, flags);
   rh.setAmplitudeError(amperr);
-  
+
   if (!usePrefit) {
-    for (unsigned int ipulse=0; ipulse<_pulsefunc.BXs().rows(); ++ipulse) {
+    for (unsigned int ipulse = 0; ipulse < _pulsefunc.BXs().rows(); ++ipulse) {
       int bx = _pulsefunc.BXs().coeff(ipulse);
-      if (bx!=0 && std::abs(bx)<100) {
-        rh.setOutOfTimeAmplitude(bx+5, status ? _pulsefunc.X().coeff(ipulse) : 0.);
-      }
-      else if (bx==(100+gainsPedestal[iSampleMax])) {
+      if (bx != 0 && std::abs(bx) < 100) {
+        rh.setOutOfTimeAmplitude(bx + 5, status ? _pulsefunc.X().coeff(ipulse) : 0.);
+      } else if (bx == (100 + gainsPedestal[iSampleMax])) {
         rh.setPedestal(status ? _pulsefunc.X().coeff(ipulse) : 0.);
       }
     }
   }
-  
+
   return rh;
 }
-

--- a/RecoLocalCalo/EcalRecAlgos/src/PulseChiSqSNNLS.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/PulseChiSqSNNLS.cc
@@ -3,377 +3,352 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 
-void eigen_solve_submatrix(PulseMatrix& mat, PulseVector& invec, PulseVector& outvec, unsigned NP) {
+void eigen_solve_submatrix(PulseMatrix &mat, PulseVector &invec, PulseVector &outvec, unsigned NP) {
   using namespace Eigen;
-  switch( NP ) { // pulse matrix is always square.
-  case 10:
-    {
-      Matrix<double,10,10> temp = mat.topLeftCorner<10,10>();
+  switch (NP) {  // pulse matrix is always square.
+    case 10: {
+      Matrix<double, 10, 10> temp = mat.topLeftCorner<10, 10>();
       outvec.head<10>() = temp.ldlt().solve(invec.head<10>());
-    }
-    break;
-  case 9:
-    {
-      Matrix<double,9,9> temp = mat.topLeftCorner<9,9>();
+    } break;
+    case 9: {
+      Matrix<double, 9, 9> temp = mat.topLeftCorner<9, 9>();
       outvec.head<9>() = temp.ldlt().solve(invec.head<9>());
-    }
-    break;
-  case 8:
-    {
-      Matrix<double,8,8> temp = mat.topLeftCorner<8,8>();
+    } break;
+    case 8: {
+      Matrix<double, 8, 8> temp = mat.topLeftCorner<8, 8>();
       outvec.head<8>() = temp.ldlt().solve(invec.head<8>());
-    }
-    break;
-  case 7:
-    {
-      Matrix<double,7,7> temp = mat.topLeftCorner<7,7>();
+    } break;
+    case 7: {
+      Matrix<double, 7, 7> temp = mat.topLeftCorner<7, 7>();
       outvec.head<7>() = temp.ldlt().solve(invec.head<7>());
-    }
-    break;
-  case 6:
-    {
-      Matrix<double,6,6> temp = mat.topLeftCorner<6,6>();
+    } break;
+    case 6: {
+      Matrix<double, 6, 6> temp = mat.topLeftCorner<6, 6>();
       outvec.head<6>() = temp.ldlt().solve(invec.head<6>());
-    }
-    break;
-  case 5:
-    {
-      Matrix<double,5,5> temp = mat.topLeftCorner<5,5>();
+    } break;
+    case 5: {
+      Matrix<double, 5, 5> temp = mat.topLeftCorner<5, 5>();
       outvec.head<5>() = temp.ldlt().solve(invec.head<5>());
-    }
-    break;
-  case 4:
-    {
-      Matrix<double,4,4> temp = mat.topLeftCorner<4,4>();
+    } break;
+    case 4: {
+      Matrix<double, 4, 4> temp = mat.topLeftCorner<4, 4>();
       outvec.head<4>() = temp.ldlt().solve(invec.head<4>());
-    }
-    break;
-  case 3: 
-    {
-      Matrix<double,3,3> temp = mat.topLeftCorner<3,3>();
+    } break;
+    case 3: {
+      Matrix<double, 3, 3> temp = mat.topLeftCorner<3, 3>();
       outvec.head<3>() = temp.ldlt().solve(invec.head<3>());
-    }
-    break;
-  case 2:
-    {
-      Matrix<double,2,2> temp = mat.topLeftCorner<2,2>();
+    } break;
+    case 2: {
+      Matrix<double, 2, 2> temp = mat.topLeftCorner<2, 2>();
       outvec.head<2>() = temp.ldlt().solve(invec.head<2>());
-    }
-    break;
-  case 1:
-    {
-      Matrix<double,1,1> temp = mat.topLeftCorner<1,1>();
+    } break;
+    case 1: {
+      Matrix<double, 1, 1> temp = mat.topLeftCorner<1, 1>();
       outvec.head<1>() = temp.ldlt().solve(invec.head<1>());
-    }
-    break;
-  default:
-    throw cms::Exception("MultFitWeirdState")
-      << "Weird number of pulses encountered in multifit, module is configured incorrectly!";
+    } break;
+    default:
+      throw cms::Exception("MultFitWeirdState")
+          << "Weird number of pulses encountered in multifit, module is configured incorrectly!";
   }
 }
 
-PulseChiSqSNNLS::PulseChiSqSNNLS() :
-  _chisq(0.),
-  _computeErrors(true),
-  _maxiters(50),
-  _maxiterwarnings(true)
-{
-  
-}  
+PulseChiSqSNNLS::PulseChiSqSNNLS() : _chisq(0.), _computeErrors(true), _maxiters(50), _maxiterwarnings(true) {}
 
-PulseChiSqSNNLS::~PulseChiSqSNNLS() {
-  
-}
+PulseChiSqSNNLS::~PulseChiSqSNNLS() {}
 
-bool PulseChiSqSNNLS::DoFit(const SampleVector &samples, const SampleMatrix &samplecov, const BXVector &bxs, const FullSampleVector &fullpulse, const FullSampleMatrix &fullpulsecov, const SampleGainVector &gains, const SampleGainVector &badSamples) {
- 
+bool PulseChiSqSNNLS::DoFit(const SampleVector &samples,
+                            const SampleMatrix &samplecov,
+                            const BXVector &bxs,
+                            const FullSampleVector &fullpulse,
+                            const FullSampleMatrix &fullpulsecov,
+                            const SampleGainVector &gains,
+                            const SampleGainVector &badSamples) {
   int npulse = bxs.rows();
-  
+
   _sampvec = samples;
   _bxs = bxs;
-  _pulsemat.resize(Eigen::NoChange,npulse);
+  _pulsemat.resize(Eigen::NoChange, npulse);
 
   //construct dynamic pedestals if applicable
-  int ngains = gains.maxCoeff()+1;
+  int ngains = gains.maxCoeff() + 1;
   int nPedestals = 0;
-  for (int gainidx=0; gainidx<ngains; ++gainidx) {
-    SampleGainVector mask = gainidx*SampleGainVector::Ones();
-    SampleVector pedestal = (gains.array()==mask.array()).cast<SampleVector::value_type>();
-    if (pedestal.maxCoeff()>0.) {
-      ++nPedestals;      
-      _bxs.resize(npulse+nPedestals);
-      _bxs[npulse+nPedestals-1] = 100 + gainidx; //bx values >=100 indicate dynamic pedestals
-      _pulsemat.resize(Eigen::NoChange, npulse+nPedestals);
-      _pulsemat.col(npulse+nPedestals-1) = pedestal;
+  for (int gainidx = 0; gainidx < ngains; ++gainidx) {
+    SampleGainVector mask = gainidx * SampleGainVector::Ones();
+    SampleVector pedestal = (gains.array() == mask.array()).cast<SampleVector::value_type>();
+    if (pedestal.maxCoeff() > 0.) {
+      ++nPedestals;
+      _bxs.resize(npulse + nPedestals);
+      _bxs[npulse + nPedestals - 1] = 100 + gainidx;  //bx values >=100 indicate dynamic pedestals
+      _pulsemat.resize(Eigen::NoChange, npulse + nPedestals);
+      _pulsemat.col(npulse + nPedestals - 1) = pedestal;
     }
   }
-  
+
   //construct negative step functions for saturated or potentially slew-rate-limited samples
-  for (int isample=0; isample<SampleVector::RowsAtCompileTime; ++isample) {
-    if (badSamples.coeff(isample)>0) {
+  for (int isample = 0; isample < SampleVector::RowsAtCompileTime; ++isample) {
+    if (badSamples.coeff(isample) > 0) {
       SampleVector step = SampleVector::Zero();
       //step correction has negative sign for saturated or slew-limited samples which have been forced to zero
       step[isample] = -1.;
-      
-      ++nPedestals;      
-      _bxs.resize(npulse+nPedestals);
-      _bxs[npulse+nPedestals-1] = -100 - isample; //bx values <=-100 indicate step corrections for saturated or slew-limited samples
-      _pulsemat.resize(Eigen::NoChange, npulse+nPedestals);
-      _pulsemat.col(npulse+nPedestals-1) = step;
+
+      ++nPedestals;
+      _bxs.resize(npulse + nPedestals);
+      _bxs[npulse + nPedestals - 1] =
+          -100 - isample;  //bx values <=-100 indicate step corrections for saturated or slew-limited samples
+      _pulsemat.resize(Eigen::NoChange, npulse + nPedestals);
+      _pulsemat.col(npulse + nPedestals - 1) = step;
     }
   }
-  
+
   _npulsetot = npulse + nPedestals;
-  
+
   _ampvec = PulseVector::Zero(_npulsetot);
-  _errvec = PulseVector::Zero(_npulsetot);  
+  _errvec = PulseVector::Zero(_npulsetot);
   _nP = 0;
   _chisq = 0.;
-  
-  if (_bxs.rows()==1 && std::abs(_bxs.coeff(0))<100) {
+
+  if (_bxs.rows() == 1 && std::abs(_bxs.coeff(0)) < 100) {
     _ampvec.coeffRef(0) = _sampvec.coeff(_bxs.coeff(0) + 5);
   }
-  
-  aTamat.resize(_npulsetot,_npulsetot);
+
+  aTamat.resize(_npulsetot, _npulsetot);
 
   //initialize pulse template matrix
-  for (int ipulse=0; ipulse<npulse; ++ipulse) {
+  for (int ipulse = 0; ipulse < npulse; ++ipulse) {
     int bx = _bxs.coeff(ipulse);
-    int offset = 7-3-bx;
+    int offset = 7 - 3 - bx;
     _pulsemat.col(ipulse) = fullpulse.segment<SampleVector::RowsAtCompileTime>(offset);
   }
-  
+
   //unconstrain pedestals already for first iteration since they should always be non-zero
-  if (nPedestals>0) {
-    for (int i=0; i<_bxs.rows(); ++i) {
+  if (nPedestals > 0) {
+    for (int i = 0; i < _bxs.rows(); ++i) {
       int bx = _bxs.coeff(i);
-      if (bx>=100) {
+      if (bx >= 100) {
         NNLSUnconstrainParameter(i);
       }
     }
   }
-  
+
   //do the actual fit
-  bool status = Minimize(samplecov,fullpulsecov);
+  bool status = Minimize(samplecov, fullpulsecov);
   _ampvecmin = _ampvec;
   _bxsmin = _bxs;
-  
-  if (!status) return status;
-  
-  if(!_computeErrors) return status;
+
+  if (!status)
+    return status;
+
+  if (!_computeErrors)
+    return status;
 
   //compute MINOS-like uncertainties for in-time amplitude
   bool foundintime = false;
   unsigned int ipulseintime = 0;
-  for (unsigned int ipulse=0; ipulse<_npulsetot; ++ipulse) {
-    if (_bxs.coeff(ipulse)==0) {
+  for (unsigned int ipulse = 0; ipulse < _npulsetot; ++ipulse) {
+    if (_bxs.coeff(ipulse) == 0) {
       ipulseintime = ipulse;
       foundintime = true;
       break;
     }
   }
-  if (!foundintime) return status;
-  
+  if (!foundintime)
+    return status;
+
   const unsigned int ipulseintimemin = ipulseintime;
-  
+
   double approxerr = ComputeApproxUncertainty(ipulseintime);
   double chisq0 = _chisq;
-  double x0 = _ampvecmin[ipulseintime];  
-  
+  double x0 = _ampvecmin[ipulseintime];
+
   //move in time pulse first to active set if necessary
-  if (ipulseintime<_nP) {
-    _pulsemat.col(_nP-1).swap(_pulsemat.col(ipulseintime));
-    std::swap(_ampvec.coeffRef(_nP-1),_ampvec.coeffRef(ipulseintime));
-    std::swap(_bxs.coeffRef(_nP-1),_bxs.coeffRef(ipulseintime));
+  if (ipulseintime < _nP) {
+    _pulsemat.col(_nP - 1).swap(_pulsemat.col(ipulseintime));
+    std::swap(_ampvec.coeffRef(_nP - 1), _ampvec.coeffRef(ipulseintime));
+    std::swap(_bxs.coeffRef(_nP - 1), _bxs.coeffRef(ipulseintime));
     ipulseintime = _nP - 1;
-    --_nP;    
+    --_nP;
   }
-  
-  
+
   SampleVector pulseintime = _pulsemat.col(ipulseintime);
   _pulsemat.col(ipulseintime).setZero();
-  
+
   //two point interpolation for upper uncertainty when amplitude is away from boundary
   double xplus100 = x0 + approxerr;
   _ampvec.coeffRef(ipulseintime) = xplus100;
-  _sampvec = samples - _ampvec.coeff(ipulseintime)*pulseintime;  
-  status &= Minimize(samplecov,fullpulsecov);
-  if (!status) return status;
+  _sampvec = samples - _ampvec.coeff(ipulseintime) * pulseintime;
+  status &= Minimize(samplecov, fullpulsecov);
+  if (!status)
+    return status;
   double chisqplus100 = ComputeChiSq();
-  
-  double sigmaplus = std::abs(xplus100-x0)/sqrt(chisqplus100-chisq0);
-  
+
+  double sigmaplus = std::abs(xplus100 - x0) / sqrt(chisqplus100 - chisq0);
+
   //if amplitude is sufficiently far from the boundary, compute also the lower uncertainty and average them
-  if ( (x0/sigmaplus) > 0.5 ) {
-    for (unsigned int ipulse=0; ipulse<_npulsetot; ++ipulse) {
-      if (_bxs.coeff(ipulse)==0) {
+  if ((x0 / sigmaplus) > 0.5) {
+    for (unsigned int ipulse = 0; ipulse < _npulsetot; ++ipulse) {
+      if (_bxs.coeff(ipulse) == 0) {
         ipulseintime = ipulse;
         break;
       }
-    }    
-    double xminus100 = std::max(0.,x0-approxerr);
+    }
+    double xminus100 = std::max(0., x0 - approxerr);
     _ampvec.coeffRef(ipulseintime) = xminus100;
-   _sampvec = samples - _ampvec.coeff(ipulseintime)*pulseintime;
-    status &= Minimize(samplecov,fullpulsecov);
-    if (!status) return status;
+    _sampvec = samples - _ampvec.coeff(ipulseintime) * pulseintime;
+    status &= Minimize(samplecov, fullpulsecov);
+    if (!status)
+      return status;
     double chisqminus100 = ComputeChiSq();
-    
-    double sigmaminus = std::abs(xminus100-x0)/sqrt(chisqminus100-chisq0);
-    _errvec[ipulseintimemin] = 0.5*(sigmaplus + sigmaminus);
-    
-  }
-  else {
+
+    double sigmaminus = std::abs(xminus100 - x0) / sqrt(chisqminus100 - chisq0);
+    _errvec[ipulseintimemin] = 0.5 * (sigmaplus + sigmaminus);
+
+  } else {
     _errvec[ipulseintimemin] = sigmaplus;
   }
-            
-  _chisq = chisq0;  
+
+  _chisq = chisq0;
 
   return status;
-  
 }
 
 bool PulseChiSqSNNLS::Minimize(const SampleMatrix &samplecov, const FullSampleMatrix &fullpulsecov) {
-
   const unsigned int npulse = _bxs.rows();
-  
+
   int iter = 0;
   bool status = false;
-  while (true) {    
-    
-    if (iter>=_maxiters) {
+  while (true) {
+    if (iter >= _maxiters) {
       if (_maxiterwarnings) {
         LogDebug("PulseChiSqSNNLS::Minimize") << "Max Iterations reached at iter " << iter;
       }
       break;
-    }    
-    
-    status = updateCov(samplecov,fullpulsecov);    
-    if (!status) break; 
-    if (npulse>1) {
-      status = NNLS();
     }
-    else {
+
+    status = updateCov(samplecov, fullpulsecov);
+    if (!status)
+      break;
+    if (npulse > 1) {
+      status = NNLS();
+    } else {
       //special case for one pulse fit (performance optimized)
       status = OnePulseMinimize();
     }
-    if (!status) break;
-        
+    if (!status)
+      break;
+
     double chisqnow = ComputeChiSq();
-    double deltachisq = chisqnow-_chisq;
-        
+    double deltachisq = chisqnow - _chisq;
+
     _chisq = chisqnow;
-    if (std::abs(deltachisq)<1e-3) {
+    if (std::abs(deltachisq) < 1e-3) {
       break;
     }
-    ++iter;    
-  }  
-  
-  return status;  
-  
+    ++iter;
+  }
+
+  return status;
 }
 
 bool PulseChiSqSNNLS::updateCov(const SampleMatrix &samplecov, const FullSampleMatrix &fullpulsecov) {
- 
   const unsigned int nsample = SampleVector::RowsAtCompileTime;
   const unsigned int npulse = _bxs.rows();
 
-  _invcov = samplecov; //
-  
-  for (unsigned int ipulse=0; ipulse<npulse; ++ipulse) {
-    if (_ampvec.coeff(ipulse)==0.) continue;
+  _invcov = samplecov;  //
+
+  for (unsigned int ipulse = 0; ipulse < npulse; ++ipulse) {
+    if (_ampvec.coeff(ipulse) == 0.)
+      continue;
     int bx = _bxs.coeff(ipulse);
-    if (std::abs(bx)>=100) continue; //no contribution to covariance from pedestal or saturation/slew step correction
-    
-    int firstsamplet = std::max(0,bx + 3);
-    int offset = 7-3-bx;
-    
+    if (std::abs(bx) >= 100)
+      continue;  //no contribution to covariance from pedestal or saturation/slew step correction
+
+    int firstsamplet = std::max(0, bx + 3);
+    int offset = 7 - 3 - bx;
+
     const double ampveccoef = _ampvec.coeff(ipulse);
-    const double ampsq = ampveccoef*ampveccoef;
-    
-    const unsigned int nsamplepulse = nsample-firstsamplet;    
-    _invcov.block(firstsamplet,firstsamplet,nsamplepulse,nsamplepulse) += 
-      ampsq*fullpulsecov.block(firstsamplet+offset,firstsamplet+offset,nsamplepulse,nsamplepulse);   
+    const double ampsq = ampveccoef * ampveccoef;
+
+    const unsigned int nsamplepulse = nsample - firstsamplet;
+    _invcov.block(firstsamplet, firstsamplet, nsamplepulse, nsamplepulse) +=
+        ampsq * fullpulsecov.block(firstsamplet + offset, firstsamplet + offset, nsamplepulse, nsamplepulse);
   }
-  
+
   _covdecomp.compute(_invcov);
-  
+
   bool status = true;
   return status;
-    
 }
 
 double PulseChiSqSNNLS::ComputeChiSq() {
-  
-//   SampleVector resvec = _pulsemat*_ampvec - _sampvec;
-//   return resvec.transpose()*_covdecomp.solve(resvec);
-  
-  return _covdecomp.matrixL().solve(_pulsemat*_ampvec - _sampvec).squaredNorm();
-  
+  //   SampleVector resvec = _pulsemat*_ampvec - _sampvec;
+  //   return resvec.transpose()*_covdecomp.solve(resvec);
+
+  return _covdecomp.matrixL().solve(_pulsemat * _ampvec - _sampvec).squaredNorm();
 }
 
 double PulseChiSqSNNLS::ComputeApproxUncertainty(unsigned int ipulse) {
   //compute approximate uncertainties
   //(using 1/second derivative since full Hessian is not meaningful in
   //presence of positive amplitude boundaries.)
-      
-  return 1./_covdecomp.matrixL().solve(_pulsemat.col(ipulse)).norm();
-  
+
+  return 1. / _covdecomp.matrixL().solve(_pulsemat.col(ipulse)).norm();
 }
 
 bool PulseChiSqSNNLS::NNLS() {
-  
   //Fast NNLS (fnnls) algorithm as per http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.157.9203&rep=rep1&type=pdf
-  
+
   const unsigned int npulse = _bxs.rows();
   constexpr unsigned int nsamples = SampleVector::RowsAtCompileTime;
 
   invcovp = _covdecomp.matrixL().solve(_pulsemat);
   aTamat.noalias() = invcovp.transpose().lazyProduct(invcovp);
   aTbvec.noalias() = invcovp.transpose().lazyProduct(_covdecomp.matrixL().solve(_sampvec));
-  
+
   int iter = 0;
   Index idxwmax = 0;
   double wmax = 0.0;
   double threshold = 1e-11;
   while (true) {
     //can only perform this step if solution is guaranteed viable
-    if (iter>0 || _nP==0) {
-      if ( _nP==std::min(npulse,nsamples) ) break;                  
-      
+    if (iter > 0 || _nP == 0) {
+      if (_nP == std::min(npulse, nsamples))
+        break;
+
       const unsigned int nActive = npulse - _nP;
-      
-      updatework = aTbvec - aTamat*_ampvec;      
+
+      updatework = aTbvec - aTamat * _ampvec;
       Index idxwmaxprev = idxwmax;
       double wmaxprev = wmax;
       wmax = updatework.tail(nActive).maxCoeff(&idxwmax);
-      
+
       //convergence
-      if (wmax<threshold || (idxwmax==idxwmaxprev && wmax==wmaxprev)) break;
-      
+      if (wmax < threshold || (idxwmax == idxwmaxprev && wmax == wmaxprev))
+        break;
+
       //worst case protection
-      if (iter>=500) {
+      if (iter >= 500) {
         LogDebug("PulseChiSqSNNLS::NNLS()") << "Max Iterations reached at iter " << iter;
         break;
       }
-      
+
       //unconstrain parameter
       Index idxp = _nP + idxwmax;
       NNLSUnconstrainParameter(idxp);
     }
 
-    
     while (true) {
       //printf("iter in, idxsP = %i\n",int(_idxsP.size()));
-      
-      if (_nP==0) break;     
-      
+
+      if (_nP == 0)
+        break;
+
       ampvecpermtest = _ampvec;
-      
-      //solve for unconstrained parameters 
+
+      //solve for unconstrained parameters
       //need to have specialized function to call optimized versions
       // of matrix solver... this is truly amazing...
-      eigen_solve_submatrix(aTamat,aTbvec,ampvecpermtest,_nP);
-      
+      eigen_solve_submatrix(aTamat, aTbvec, ampvecpermtest, _nP);
+
       //check solution
       bool positive = true;
       for (unsigned int i = 0; i < _nP; ++i)
@@ -381,82 +356,76 @@ bool PulseChiSqSNNLS::NNLS() {
       if (positive) {
         _ampvec.head(_nP) = ampvecpermtest.head(_nP);
         break;
-      }      
+      }
 
       //update parameter vector
-      Index minratioidx=0;
-      
+      Index minratioidx = 0;
+
       // no realizable optimization here (because it autovectorizes!)
       double minratio = std::numeric_limits<double>::max();
-      for (unsigned int ipulse=0; ipulse<_nP; ++ipulse) {
-        if (ampvecpermtest.coeff(ipulse)<=0.) {
-	  const double c_ampvec = _ampvec.coeff(ipulse);
-          const double ratio = c_ampvec/(c_ampvec-ampvecpermtest.coeff(ipulse));
-          if (ratio<minratio) {
+      for (unsigned int ipulse = 0; ipulse < _nP; ++ipulse) {
+        if (ampvecpermtest.coeff(ipulse) <= 0.) {
+          const double c_ampvec = _ampvec.coeff(ipulse);
+          const double ratio = c_ampvec / (c_ampvec - ampvecpermtest.coeff(ipulse));
+          if (ratio < minratio) {
             minratio = ratio;
             minratioidx = ipulse;
           }
         }
       }
 
-      _ampvec.head(_nP) += minratio*(ampvecpermtest.head(_nP)- _ampvec.head(_nP));
-      
+      _ampvec.head(_nP) += minratio * (ampvecpermtest.head(_nP) - _ampvec.head(_nP));
+
       //avoid numerical problems with later ==0. check
       _ampvec.coeffRef(minratioidx) = 0.;
-            
+
       //printf("removing index %i, orig idx %i\n",int(minratioidx),int(_bxs.coeff(minratioidx)));
-      NNLSConstrainParameter(minratioidx);    
+      NNLSConstrainParameter(minratioidx);
     }
     ++iter;
-    
+
     //adaptive convergence threshold to avoid infinite loops but still
     //ensure best value is used
     if (iter % 16 == 0) {
       threshold *= 2;
     }
   }
-  
+
   return true;
-  
-  
 }
 
 void PulseChiSqSNNLS::NNLSUnconstrainParameter(Index idxp) {
-  
   aTamat.col(_nP).swap(aTamat.col(idxp));
   aTamat.row(_nP).swap(aTamat.row(idxp));
   _pulsemat.col(_nP).swap(_pulsemat.col(idxp));
-  std::swap(aTbvec.coeffRef(_nP),aTbvec.coeffRef(idxp));
-  std::swap(_ampvec.coeffRef(_nP),_ampvec.coeffRef(idxp));
-  std::swap(_bxs.coeffRef(_nP),_bxs.coeffRef(idxp));
+  std::swap(aTbvec.coeffRef(_nP), aTbvec.coeffRef(idxp));
+  std::swap(_ampvec.coeffRef(_nP), _ampvec.coeffRef(idxp));
+  std::swap(_bxs.coeffRef(_nP), _bxs.coeffRef(idxp));
   ++_nP;
 }
 
 void PulseChiSqSNNLS::NNLSConstrainParameter(Index minratioidx) {
-  aTamat.col(_nP-1).swap(aTamat.col(minratioidx));
-  aTamat.row(_nP-1).swap(aTamat.row(minratioidx));
-  _pulsemat.col(_nP-1).swap(_pulsemat.col(minratioidx));
-  std::swap(aTbvec.coeffRef(_nP-1),aTbvec.coeffRef(minratioidx));
-  std::swap(_ampvec.coeffRef(_nP-1),_ampvec.coeffRef(minratioidx));
-  std::swap(_bxs.coeffRef(_nP-1),_bxs.coeffRef(minratioidx));
+  aTamat.col(_nP - 1).swap(aTamat.col(minratioidx));
+  aTamat.row(_nP - 1).swap(aTamat.row(minratioidx));
+  _pulsemat.col(_nP - 1).swap(_pulsemat.col(minratioidx));
+  std::swap(aTbvec.coeffRef(_nP - 1), aTbvec.coeffRef(minratioidx));
+  std::swap(_ampvec.coeffRef(_nP - 1), _ampvec.coeffRef(minratioidx));
+  std::swap(_bxs.coeffRef(_nP - 1), _bxs.coeffRef(minratioidx));
   --_nP;
-  
 }
 
 bool PulseChiSqSNNLS::OnePulseMinimize() {
-  
   //Fast NNLS (fnnls) algorithm as per http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.157.9203&rep=rep1&type=pdf
-  
-//   const unsigned int npulse = 1;
+
+  //   const unsigned int npulse = 1;
 
   invcovp = _covdecomp.matrixL().solve(_pulsemat);
-//   aTamat = invcovp.transpose()*invcovp;
-//   aTbvec = invcovp.transpose()*_covdecomp.matrixL().solve(_sampvec);
+  //   aTamat = invcovp.transpose()*invcovp;
+  //   aTbvec = invcovp.transpose()*_covdecomp.matrixL().solve(_sampvec);
 
-  SingleMatrix aTamatval = invcovp.transpose()*invcovp;
-  SingleVector aTbvecval = invcovp.transpose()*_covdecomp.matrixL().solve(_sampvec);
-  _ampvec.coeffRef(0) = std::max(0.,aTbvecval.coeff(0)/aTamatval.coeff(0));
-  
+  SingleMatrix aTamatval = invcovp.transpose() * invcovp;
+  SingleVector aTbvecval = invcovp.transpose() * _covdecomp.matrixL().solve(_sampvec);
+  _ampvec.coeffRef(0) = std::max(0., aTbvecval.coeff(0) / aTamatval.coeff(0));
+
   return true;
-  
 }

--- a/RecoLocalCalo/EcalRecAlgos/test/stubs/testEcalSeverityLevelAlgo.cc
+++ b/RecoLocalCalo/EcalRecAlgos/test/stubs/testEcalSeverityLevelAlgo.cc
@@ -11,52 +11,41 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include <FWCore/Framework/interface/Event.h>
 
-
-class EcalSeverityLevelAlgoAnalyzer: public edm::EDAnalyzer{
-  
+class EcalSeverityLevelAlgoAnalyzer : public edm::EDAnalyzer {
 public:
- EcalSeverityLevelAlgoAnalyzer(const edm::ParameterSet& ps);
-  
+  EcalSeverityLevelAlgoAnalyzer(const edm::ParameterSet& ps);
+
 protected:
-  
-  void analyze( edm::Event const & iEvent, const  edm::EventSetup& iSetup);
+  void analyze(edm::Event const& iEvent, const edm::EventSetup& iSetup);
 
 private:
-
   TH1F* shisto_;
   TH1F* fhisto_;
 };
 
 DEFINE_FWK_MODULE(EcalSeverityLevelAlgoAnalyzer);
- 
-EcalSeverityLevelAlgoAnalyzer::EcalSeverityLevelAlgoAnalyzer(const edm::ParameterSet& ps){
-  
+
+EcalSeverityLevelAlgoAnalyzer::EcalSeverityLevelAlgoAnalyzer(const edm::ParameterSet& ps) {
   edm::Service<TFileService> fs;
-  shisto_= fs->make<TH1F>("SeverityLevel", "SeverityLevel", 6, 0, 6);
-  fhisto_= fs->make<TH1F>("Flags", "Flags", 32, 0, 32);
+  shisto_ = fs->make<TH1F>("SeverityLevel", "SeverityLevel", 6, 0, 6);
+  fhisto_ = fs->make<TH1F>("Flags", "Flags", 32, 0, 32);
 }
 
+void EcalSeverityLevelAlgoAnalyzer::analyze(edm::Event const& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<EcalRecHitCollection> rechits;
+  iEvent.getByLabel("ecalRecHit", "EcalRecHitsEB", rechits);
 
-void EcalSeverityLevelAlgoAnalyzer::analyze(edm::Event const & iEvent, 
-					    const  edm::EventSetup& iSetup){
+  edm::ESHandle<EcalSeverityLevelAlgo> sevlv;
+  iSetup.get<EcalSeverityLevelAlgoRcd>().get(sevlv);
 
-  
-    edm::Handle<EcalRecHitCollection> rechits;
-    iEvent.getByLabel("ecalRecHit","EcalRecHitsEB",rechits);
-
-    edm::ESHandle<EcalSeverityLevelAlgo> sevlv;
-    iSetup.get<EcalSeverityLevelAlgoRcd>().get(sevlv);
-
-    EcalRecHitCollection::const_iterator rechit= rechits->begin();
-    for (; rechit!= rechits->end(); ++rechit){
-      
-      for (int flag=0;flag<32; ++flag ){
-	if (rechit->checkFlag(flag)) fhisto_->Fill(flag);
-      }
-      
-
-      int severity = sevlv->severityLevel(rechit->id(),*rechits);
-      shisto_->Fill(severity);
-      
+  EcalRecHitCollection::const_iterator rechit = rechits->begin();
+  for (; rechit != rechits->end(); ++rechit) {
+    for (int flag = 0; flag < 32; ++flag) {
+      if (rechit->checkFlag(flag))
+        fhisto_->Fill(flag);
     }
+
+    int severity = sevlv->severityLevel(rechit->id(), *rechits);
+    shisto_->Fill(severity);
+  }
 }

--- a/RecoLocalCalo/EcalRecAlgos/test/testEcalSeverityLevelAlgo.cppunit.cc
+++ b/RecoLocalCalo/EcalRecAlgos/test/testEcalSeverityLevelAlgo.cppunit.cc
@@ -9,15 +9,14 @@
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-class testEcalSeverityLevelAlgo: public CppUnit::TestFixture
-{
+class testEcalSeverityLevelAlgo : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(testEcalSeverityLevelAlgo);
   CPPUNIT_TEST(testSeverity);
   CPPUNIT_TEST_SUITE_END();
 
 public:
   void setUp();
-  void tearDown(){delete algo_;}
+  void tearDown() { delete algo_; }
 
   void testSeverity();
 
@@ -29,16 +28,13 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testEcalSeverityLevelAlgo);
 
 using std::string;
 
-void testEcalSeverityLevelAlgo::setUp(){
-
+void testEcalSeverityLevelAlgo::setUp() {
   edm::ParameterSet ps;
- 
 
-  ps.addParameter< double> ("timeThresh",2.0);
-  
+  ps.addParameter<double>("timeThresh", 2.0);
+
   edm::ParameterSet flagmaskps;
-  std::vector<std::string> kGoodv,kProblematicv,kRecoveredv,
-                           kTimev,kWeirdv,kBadv; 
+  std::vector<std::string> kGoodv, kProblematicv, kRecoveredv, kTimev, kWeirdv, kBadv;
   kGoodv.push_back("kGood");
   kProblematicv.push_back("kPoorReco");
   kProblematicv.push_back("kPoorCalib");
@@ -53,37 +49,36 @@ void testEcalSeverityLevelAlgo::setUp(){
   kBadv.push_back("kDead");
   kBadv.push_back("kKilled");
 
-  flagmaskps.addParameter<std::vector<string> > ("kGood",kGoodv);
-  flagmaskps.addParameter<std::vector<string> > ("kProblematic",kProblematicv);
-  flagmaskps.addParameter<std::vector<string> > ("kRecovered",kRecoveredv);
-  flagmaskps.addParameter<std::vector<string> > ("kTime",kTimev);
-  flagmaskps.addParameter<std::vector<string> > ("kWeird",kWeirdv);
-  flagmaskps.addParameter<std::vector<string> > ("kBad",kBadv);
+  flagmaskps.addParameter<std::vector<string> >("kGood", kGoodv);
+  flagmaskps.addParameter<std::vector<string> >("kProblematic", kProblematicv);
+  flagmaskps.addParameter<std::vector<string> >("kRecovered", kRecoveredv);
+  flagmaskps.addParameter<std::vector<string> >("kTime", kTimev);
+  flagmaskps.addParameter<std::vector<string> >("kWeird", kWeirdv);
+  flagmaskps.addParameter<std::vector<string> >("kBad", kBadv);
 
-  ps.addParameter<edm::ParameterSet>("flagMask",flagmaskps);
+  ps.addParameter<edm::ParameterSet>("flagMask", flagmaskps);
 
   edm::ParameterSet dbmaskps;
-  std::vector<uint32_t> kGoods,kProblematics,kRecovereds,
-                           kTimes,kWeirds,kBads;
+  std::vector<uint32_t> kGoods, kProblematics, kRecovereds, kTimes, kWeirds, kBads;
 
   kGoods.push_back(0);
-  for (int i =1;  i<=10; ++i) kProblematics.push_back(i);
-  for (int i =11; i<=16; ++i) kBads.push_back(i);
-  
-  ps.addParameter<edm::ParameterSet>("dbstatusMask",dbmaskps);
+  for (int i = 1; i <= 10; ++i)
+    kProblematics.push_back(i);
+  for (int i = 11; i <= 16; ++i)
+    kBads.push_back(i);
 
+  ps.addParameter<edm::ParameterSet>("dbstatusMask", dbmaskps);
 
-  algo_=new EcalSeverityLevelAlgo(ps);
+  algo_ = new EcalSeverityLevelAlgo(ps);
 }
-void testEcalSeverityLevelAlgo::testSeverity(){
-
-  EBDetId  id(1,1);
-  EcalRecHit rh1(id,0,0);
+void testEcalSeverityLevelAlgo::testSeverity() {
+  EBDetId id(1, 1);
+  EcalRecHit rh1(id, 0, 0);
   rh1.setFlag(EcalRecHit::kGood);
-   
+
   CPPUNIT_ASSERT(algo_->severityLevel(rh1) == EcalSeverityLevel::kGood);
-  
-  EcalRecHit rh2(id,0,0);
+
+  EcalRecHit rh2(id, 0, 0);
   rh2.setFlag(EcalRecHit::kPoorReco);
   rh2.setFlag(EcalRecHit::kPoorCalib);
   rh2.setFlag(EcalRecHit::kNoisy);
@@ -93,41 +88,38 @@ void testEcalSeverityLevelAlgo::testSeverity(){
   CPPUNIT_ASSERT(algo_->severityLevel(rh2) != EcalSeverityLevel::kGood);
   CPPUNIT_ASSERT(algo_->severityLevel(rh2) != EcalSeverityLevel::kWeird);
 
-  EcalRecHit rh3(id,0,0);
+  EcalRecHit rh3(id, 0, 0);
   rh3.setFlag(EcalRecHit::kLeadingEdgeRecovered);
   rh3.setFlag(EcalRecHit::kTowerRecovered);
 
   CPPUNIT_ASSERT(algo_->severityLevel(rh3) == EcalSeverityLevel::kRecovered);
 
-
-  EcalRecHit rh4(id,5.0,0);
+  EcalRecHit rh4(id, 5.0, 0);
   rh4.setFlag(EcalRecHit::kOutOfTime);
   rh4.setFlag(EcalRecHit::kTowerRecovered);
-  
+
   CPPUNIT_ASSERT(algo_->severityLevel(rh4) == EcalSeverityLevel::kTime);
 
-  EcalRecHit rh5(id,0,0);
+  EcalRecHit rh5(id, 0, 0);
   rh5.setFlag(EcalRecHit::kWeird);
   rh5.setFlag(EcalRecHit::kDiWeird);
-  
+
   CPPUNIT_ASSERT(algo_->severityLevel(rh5) == EcalSeverityLevel::kWeird);
-  
-  EcalRecHit rh6(id,0,0);
+
+  EcalRecHit rh6(id, 0, 0);
   rh6.setFlag(EcalRecHit::kFaultyHardware);
   rh6.setFlag(EcalRecHit::kDead);
   rh6.setFlag(EcalRecHit::kKilled);
 
   CPPUNIT_ASSERT(algo_->severityLevel(rh6) == EcalSeverityLevel::kBad);
 
-
-  EcalRecHit rh7(id,1.5,0);
+  EcalRecHit rh7(id, 1.5, 0);
   rh7.setFlag(EcalRecHit::kOutOfTime);
-  
+
   CPPUNIT_ASSERT(algo_->severityLevel(rh7) == EcalSeverityLevel::kGood);
 
-  EcalRecHit rh8(id,2.5,0);
+  EcalRecHit rh8(id, 2.5, 0);
   rh8.setFlag(EcalRecHit::kOutOfTime);
-  
-  CPPUNIT_ASSERT(algo_->severityLevel(rh8) == EcalSeverityLevel::kTime);
 
+  CPPUNIT_ASSERT(algo_->severityLevel(rh8) == EcalSeverityLevel::kTime);
 }

--- a/RecoTracker/MeasurementDet/interface/ClusterFilterPayload.h
+++ b/RecoTracker/MeasurementDet/interface/ClusterFilterPayload.h
@@ -1,19 +1,20 @@
 #ifndef RecoTrackerMeasurementDetClusterFilterPayload_H
-#define	RecoTrackerMeasurementDetClusterFilterPayload_H
+#define RecoTrackerMeasurementDetClusterFilterPayload_H
 
 #include "TrackingTools/DetLayers/interface/MeasurementEstimator.h"
 
 class SiStripCluster;
 struct ClusterFilterPayload final : public MeasurementEstimator::OpaquePayload {
-  ~ClusterFilterPayload() override{}
+  ~ClusterFilterPayload() override {}
 
-  ClusterFilterPayload(unsigned int id, SiStripCluster const	* mono, SiStripCluster const	* stereo=nullptr) : detId(id), cluster{mono,stereo}{ tag=myTag;}
-  unsigned int detId=0;
-  SiStripCluster const * cluster[2] = {nullptr,nullptr};
+  ClusterFilterPayload(unsigned int id, SiStripCluster const* mono, SiStripCluster const* stereo = nullptr)
+      : detId(id), cluster{mono, stereo} {
+    tag = myTag;
+  }
+  unsigned int detId = 0;
+  SiStripCluster const* cluster[2] = {nullptr, nullptr};
 
   static constexpr int myTag = 123;
 };
-
-
 
 #endif

--- a/RecoTracker/MeasurementDet/interface/LayerCollector.h
+++ b/RecoTracker/MeasurementDet/interface/LayerCollector.h
@@ -14,29 +14,21 @@
 #include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
 #include "TrackingTools/DetLayers/interface/ForwardDetLayer.h"
 
-
 class NavigationSchool;
 
 class LayerCollector {
-
 private:
-
   typedef FreeTrajectoryState FTS;
   typedef TrajectoryStateOnSurface TSOS;
   typedef std::pair<float, float> Range;
 
 public:
-
-  LayerCollector(NavigationSchool const * aSchool,
+  LayerCollector(NavigationSchool const* aSchool,
                  const Propagator* aPropagator,
-		 const StartingLayerFinder* aFinder,
-		 float dr, 
-		 float dz) : 
-    theSchool(aSchool),
-    thePropagator(aPropagator),
-    theStartingLayerFinder(aFinder),
-    theDeltaR(dr),
-    theDeltaZ(dz) { }
+                 const StartingLayerFinder* aFinder,
+                 float dr,
+                 float dz)
+      : theSchool(aSchool), thePropagator(aPropagator), theStartingLayerFinder(aFinder), theDeltaR(dr), theDeltaZ(dz) {}
 
   ~LayerCollector() {}
 
@@ -44,26 +36,24 @@ public:
   std::vector<const BarrelDetLayer*> barrelLayers(const FTS& aFts) const;
   std::vector<const ForwardDetLayer*> forwardLayers(const FTS& aFts) const;
 
-  const Propagator* propagator() const {return thePropagator;}
-  const StartingLayerFinder* finder() const {return theStartingLayerFinder;}
-  float deltaR() const {return theDeltaR;}
-  float deltaZ() const {return theDeltaZ;}
-  
+  const Propagator* propagator() const { return thePropagator; }
+  const StartingLayerFinder* finder() const { return theStartingLayerFinder; }
+  float deltaR() const { return theDeltaR; }
+  float deltaZ() const { return theDeltaZ; }
+
 private:
-  NavigationSchool const * theSchool;
+  NavigationSchool const* theSchool;
   const Propagator* thePropagator;
   const StartingLayerFinder* theStartingLayerFinder;
   float theDeltaR;
   float theDeltaZ;
 
-
-
-  inline bool rangesIntersect( const Range& a, const Range& b) const {
-    if ( a.first > b.second || b.first > a.second) return false;
-    else return true;
+  inline bool rangesIntersect(const Range& a, const Range& b) const {
+    if (a.first > b.second || b.first > a.second)
+      return false;
+    else
+      return true;
   }
-
-
 };
 
-#endif //TR_LayerCollector_H_
+#endif  //TR_LayerCollector_H_

--- a/RecoTracker/MeasurementDet/interface/MeasurementTracker.h
+++ b/RecoTracker/MeasurementDet/interface/MeasurementTracker.h
@@ -20,35 +20,34 @@ class Phase2OTMeasurementConditionSet;
 
 class MeasurementTracker : public MeasurementDetSystem {
 public:
-   enum QualityFlags { BadModules=1, // for everybody
-                       /* Strips: */ BadAPVFibers=2, BadStrips=4, MaskBad128StripBlocks=8, 
-                       /* Pixels: */ BadROCs=2 }; 
+  enum QualityFlags {
+    BadModules = 1,  // for everybody
+    /* Strips: */ BadAPVFibers = 2,
+    BadStrips = 4,
+    MaskBad128StripBlocks = 8,
+    /* Pixels: */ BadROCs = 2
+  };
 
-  MeasurementTracker(TrackerGeometry const *  trackerGeom,
-		     GeometricSearchTracker const * geometricSearchTracker) : 
-    theTrackerGeom(trackerGeom), theGeometricSearchTracker(geometricSearchTracker) {}
-
-
+  MeasurementTracker(TrackerGeometry const* trackerGeom, GeometricSearchTracker const* geometricSearchTracker)
+      : theTrackerGeom(trackerGeom), theGeometricSearchTracker(geometricSearchTracker) {}
 
   ~MeasurementTracker() override;
 
-  const TrackingGeometry* geomTracker() const { return theTrackerGeom;}
+  const TrackingGeometry* geomTracker() const { return theTrackerGeom; }
 
-  const GeometricSearchTracker* geometricSearchTracker() const {return theGeometricSearchTracker;}
+  const GeometricSearchTracker* geometricSearchTracker() const { return theGeometricSearchTracker; }
 
   /// MeasurementDetSystem interface
-  MeasurementDetWithData idToDet(const DetId& id, const MeasurementTrackerEvent &data) const override = 0;
+  MeasurementDetWithData idToDet(const DetId& id, const MeasurementTrackerEvent& data) const override = 0;
 
   /// Provide templates to be filled in
-  virtual const StMeasurementConditionSet & stripDetConditions() const = 0;
-  virtual const PxMeasurementConditionSet & pixelDetConditions() const = 0;
-  virtual const Phase2OTMeasurementConditionSet & phase2DetConditions() const = 0;
+  virtual const StMeasurementConditionSet& stripDetConditions() const = 0;
+  virtual const PxMeasurementConditionSet& pixelDetConditions() const = 0;
+  virtual const Phase2OTMeasurementConditionSet& phase2DetConditions() const = 0;
 
 protected:
-  const TrackerGeometry*                theTrackerGeom;
-  const GeometricSearchTracker*         theGeometricSearchTracker;
-
-
+  const TrackerGeometry* theTrackerGeom;
+  const GeometricSearchTracker* theGeometricSearchTracker;
 };
 
-#endif // MeasurementTracker_H
+#endif  // MeasurementTracker_H

--- a/RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h
+++ b/RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h
@@ -14,62 +14,70 @@ class Phase2OTMeasurementDetSet;
 
 class MeasurementTrackerEvent {
 public:
-   using QualityFlags =  MeasurementTracker::QualityFlags;
+  using QualityFlags = MeasurementTracker::QualityFlags;
 
-   /// Dummy constructor used for I/O (even if it's a transient object)
-   MeasurementTrackerEvent() {}
-   ~MeasurementTrackerEvent() ;
+  /// Dummy constructor used for I/O (even if it's a transient object)
+  MeasurementTrackerEvent() {}
+  ~MeasurementTrackerEvent();
 
-   /// Real constructor 1: with the full data (owned)
-   MeasurementTrackerEvent(const MeasurementTracker &tracker, const StMeasurementDetSet *strips, const PxMeasurementDetSet *pixels,
-                           const Phase2OTMeasurementDetSet *phase2OT,
-                           const std::vector<bool> & stripClustersToSkip,
-                           const std::vector<bool> & pixelClustersToSkip,
-                           const std::vector<bool> & phase2OTClustersToSkip):
-         theTracker(&tracker), theStripData(strips), thePixelData(pixels), thePhase2OTData(phase2OT), theOwner(true),
-         theStripClustersToSkip(stripClustersToSkip), thePixelClustersToSkip(pixelClustersToSkip), thePhase2OTClustersToSkip(phase2OTClustersToSkip) {}
+  /// Real constructor 1: with the full data (owned)
+  MeasurementTrackerEvent(const MeasurementTracker &tracker,
+                          const StMeasurementDetSet *strips,
+                          const PxMeasurementDetSet *pixels,
+                          const Phase2OTMeasurementDetSet *phase2OT,
+                          const std::vector<bool> &stripClustersToSkip,
+                          const std::vector<bool> &pixelClustersToSkip,
+                          const std::vector<bool> &phase2OTClustersToSkip)
+      : theTracker(&tracker),
+        theStripData(strips),
+        thePixelData(pixels),
+        thePhase2OTData(phase2OT),
+        theOwner(true),
+        theStripClustersToSkip(stripClustersToSkip),
+        thePixelClustersToSkip(pixelClustersToSkip),
+        thePhase2OTClustersToSkip(phase2OTClustersToSkip) {}
 
-   /// Real constructor 2: with new cluster skips (checked)
-   MeasurementTrackerEvent(const MeasurementTrackerEvent &trackerEvent,
-                           const edm::ContainerMask<edmNew::DetSetVector<SiStripCluster> > & stripClustersToSkip,
-                           const edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster> > & pixelClustersToSkip) ;
-
-  //FIXME:just temporary solution for phase2! 
+  /// Real constructor 2: with new cluster skips (checked)
   MeasurementTrackerEvent(const MeasurementTrackerEvent &trackerEvent,
-                          const edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster> > & phase2pixelClustersToSkip,
-                          const edm::ContainerMask<edmNew::DetSetVector<Phase2TrackerCluster1D> > & phase2OTClustersToSkip) ;
+                          const edm::ContainerMask<edmNew::DetSetVector<SiStripCluster> > &stripClustersToSkip,
+                          const edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster> > &pixelClustersToSkip);
 
-   MeasurementTrackerEvent(const MeasurementTrackerEvent & other) = delete;
-   MeasurementTrackerEvent & operator=(const MeasurementTrackerEvent & other) = delete;
-   MeasurementTrackerEvent(MeasurementTrackerEvent && other);
-   MeasurementTrackerEvent & operator=(MeasurementTrackerEvent && other);
+  //FIXME:just temporary solution for phase2!
+  MeasurementTrackerEvent(
+      const MeasurementTrackerEvent &trackerEvent,
+      const edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster> > &phase2pixelClustersToSkip,
+      const edm::ContainerMask<edmNew::DetSetVector<Phase2TrackerCluster1D> > &phase2OTClustersToSkip);
 
+  MeasurementTrackerEvent(const MeasurementTrackerEvent &other) = delete;
+  MeasurementTrackerEvent &operator=(const MeasurementTrackerEvent &other) = delete;
+  MeasurementTrackerEvent(MeasurementTrackerEvent &&other);
+  MeasurementTrackerEvent &operator=(MeasurementTrackerEvent &&other);
 
-   const MeasurementTracker & measurementTracker() const { return * theTracker; }
-   const StMeasurementDetSet & stripData() const { return * theStripData; }
-   const PxMeasurementDetSet & pixelData() const { return * thePixelData; }
-   const Phase2OTMeasurementDetSet & phase2OTData() const { return * thePhase2OTData; }
-   const std::vector<bool> & stripClustersToSkip() const { return theStripClustersToSkip; }
-   const std::vector<bool> & pixelClustersToSkip() const { return thePixelClustersToSkip; }
-   const std::vector<bool> & phase2OTClustersToSkip() const { return thePhase2OTClustersToSkip; }
+  const MeasurementTracker &measurementTracker() const { return *theTracker; }
+  const StMeasurementDetSet &stripData() const { return *theStripData; }
+  const PxMeasurementDetSet &pixelData() const { return *thePixelData; }
+  const Phase2OTMeasurementDetSet &phase2OTData() const { return *thePhase2OTData; }
+  const std::vector<bool> &stripClustersToSkip() const { return theStripClustersToSkip; }
+  const std::vector<bool> &pixelClustersToSkip() const { return thePixelClustersToSkip; }
+  const std::vector<bool> &phase2OTClustersToSkip() const { return thePhase2OTClustersToSkip; }
 
-   // forwarded calls
-   const TrackingGeometry* geomTracker() const { return measurementTracker().geomTracker(); }
-   const GeometricSearchTracker* geometricSearchTracker() const {return measurementTracker().geometricSearchTracker(); }
+  // forwarded calls
+  const TrackingGeometry *geomTracker() const { return measurementTracker().geomTracker(); }
+  const GeometricSearchTracker *geometricSearchTracker() const { return measurementTracker().geometricSearchTracker(); }
 
-   /// Previous MeasurementDetSystem interface
-   MeasurementDetWithData  idToDet(const DetId& id) const { return measurementTracker().idToDet(id, *this); }
+  /// Previous MeasurementDetSystem interface
+  MeasurementDetWithData idToDet(const DetId &id) const { return measurementTracker().idToDet(id, *this); }
 
 private:
-   const MeasurementTracker * theTracker=nullptr;
-   const StMeasurementDetSet *theStripData=nullptr;
-   const PxMeasurementDetSet *thePixelData=nullptr;
-   const Phase2OTMeasurementDetSet *thePhase2OTData=nullptr;
-   bool  theOwner=false; // do I own the tree above?
-   // these  could be const pointers as well, but ContainerMask doesn't expose the vector
-   std::vector<bool> theStripClustersToSkip;
-   std::vector<bool> thePixelClustersToSkip;
-   std::vector<bool> thePhase2OTClustersToSkip;
+  const MeasurementTracker *theTracker = nullptr;
+  const StMeasurementDetSet *theStripData = nullptr;
+  const PxMeasurementDetSet *thePixelData = nullptr;
+  const Phase2OTMeasurementDetSet *thePhase2OTData = nullptr;
+  bool theOwner = false;  // do I own the tree above?
+  // these  could be const pointers as well, but ContainerMask doesn't expose the vector
+  std::vector<bool> theStripClustersToSkip;
+  std::vector<bool> thePixelClustersToSkip;
+  std::vector<bool> thePhase2OTClustersToSkip;
 };
 
-#endif // MeasurementTrackerEvent_H
+#endif  // MeasurementTrackerEvent_H

--- a/RecoTracker/MeasurementDet/interface/StartingLayerFinder.h
+++ b/RecoTracker/MeasurementDet/interface/StartingLayerFinder.h
@@ -1,11 +1,9 @@
 #ifndef TkNavigation_StartingLayerFinder_H_
 #define TkNavigation_StartingLayerFinder_H_
 
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
-
 
 #include "TrackingTools/DetLayers/interface/DetLayer.h"
 #include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
@@ -27,28 +25,25 @@
 class PTrajectoryStateOnDet;
 
 class StartingLayerFinder {
-
 private:
-
   typedef FreeTrajectoryState FTS;
   typedef TrajectoryStateOnSurface TSOS;
   typedef std::pair<float, float> Range;
 
-public: 
+public:
+  StartingLayerFinder(const Propagator* aPropagator, const MeasurementTracker* tracker)
+      :
 
-  StartingLayerFinder(const Propagator* aPropagator, const MeasurementTracker*  tracker ) :
-
-    thePropagator(aPropagator),
-    theMeasurementTracker(tracker),
-    thePixelLayersValid(false),
-    theFirstPixelBarrelLayer(nullptr),
-    theFirstNegPixelFwdLayer(0),
-    theFirstPosPixelFwdLayer(0) { }
+        thePropagator(aPropagator),
+        theMeasurementTracker(tracker),
+        thePixelLayersValid(false),
+        theFirstPixelBarrelLayer(nullptr),
+        theFirstNegPixelFwdLayer(0),
+        theFirstPosPixelFwdLayer(0) {}
 
   ~StartingLayerFinder() {}
 
   std::vector<const DetLayer*> startingLayers(const FTS& aFts, float dr, float dz) const;
-  
 
   std::vector<const DetLayer*> startingLayers(const TrajectorySeed& aSeed) const;
 
@@ -56,31 +51,23 @@ public:
   const std::vector<const ForwardDetLayer*> firstNegPixelFwdLayer() const;
   const std::vector<const ForwardDetLayer*> firstPosPixelFwdLayer() const;
 
-  const Propagator* propagator() const {return thePropagator;}
-
-
+  const Propagator* propagator() const { return thePropagator; }
 
 private:
-
   const Propagator* thePropagator;
-  const MeasurementTracker*     theMeasurementTracker;
+  const MeasurementTracker* theMeasurementTracker;
   mutable bool thePixelLayersValid;
   mutable const BarrelDetLayer* theFirstPixelBarrelLayer;
   mutable std::vector<const ForwardDetLayer*> theFirstNegPixelFwdLayer;
   mutable std::vector<const ForwardDetLayer*> theFirstPosPixelFwdLayer;
 
-
   void checkPixelLayers() const;
-  
-  
-  
-  inline bool rangesIntersect( const Range& a, const Range& b) const {
-    if ( a.first > b.second || b.first > a.second) return false;
-    else return true;
+
+  inline bool rangesIntersect(const Range& a, const Range& b) const {
+    if (a.first > b.second || b.first > a.second)
+      return false;
+    else
+      return true;
   }
-
-
-
-
 };
-#endif //TR_StartingLayerFinder_H_
+#endif  //TR_StartingLayerFinder_H_

--- a/RecoTracker/MeasurementDet/plugins/Chi2ChargeMeasurementEstimatorESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/Chi2ChargeMeasurementEstimatorESProducer.cc
@@ -4,94 +4,81 @@
  *  \author speer
  */
 
-
-
 #include "DataFormats/SiStripCluster/interface/SiStripClusterTools.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
 #include "RecoTracker/MeasurementDet/interface/ClusterFilterPayload.h"
 
-#include<limits>
+#include <limits>
 
 #include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
 
 #include "RecoLocalTracker/SiStripClusterizer/interface/ClusterChargeCut.h"
 
-
 namespace {
 
-class Chi2ChargeMeasurementEstimator final : public Chi2MeasurementEstimator {
-public:
-
-  /** Construct with cuts on chi2 and nSigma.
+  class Chi2ChargeMeasurementEstimator final : public Chi2MeasurementEstimator {
+  public:
+    /** Construct with cuts on chi2 and nSigma.
    *  The cut on Chi2 is used to define the acceptance of RecHits.
    *  The errors of the trajectory state are multiplied by nSigma 
    *  to define acceptance of Plane and maximalLocalDisplacement.
    */
-  template<typename... Args>
-  Chi2ChargeMeasurementEstimator(
-	float minGoodPixelCharge, float minGoodStripCharge,
-	float pTChargeCutThreshold,
-        Args && ...args) : 
-    Chi2MeasurementEstimator(args...),
-    minGoodPixelCharge_(minGoodPixelCharge),
-    minGoodStripCharge_(minGoodStripCharge),
-    pTChargeCutThreshold2_( pTChargeCutThreshold>=0.? pTChargeCutThreshold*pTChargeCutThreshold :std::numeric_limits<float>::max())
-    {}
+    template <typename... Args>
+    Chi2ChargeMeasurementEstimator(float minGoodPixelCharge,
+                                   float minGoodStripCharge,
+                                   float pTChargeCutThreshold,
+                                   Args&&... args)
+        : Chi2MeasurementEstimator(args...),
+          minGoodPixelCharge_(minGoodPixelCharge),
+          minGoodStripCharge_(minGoodStripCharge),
+          pTChargeCutThreshold2_(pTChargeCutThreshold >= 0. ? pTChargeCutThreshold * pTChargeCutThreshold
+                                                            : std::numeric_limits<float>::max()) {}
 
+    bool preFilter(const TrajectoryStateOnSurface& ts, const MeasurementEstimator::OpaquePayload& opay) const override;
 
-  bool preFilter(const TrajectoryStateOnSurface& ts,
-                 const MeasurementEstimator::OpaquePayload  & opay) const override;
+    Chi2ChargeMeasurementEstimator* clone() const override { return new Chi2ChargeMeasurementEstimator(*this); }
 
+  private:
+    const float minGoodPixelCharge_;
+    const float minGoodStripCharge_;
+    const float pTChargeCutThreshold2_;
 
-  Chi2ChargeMeasurementEstimator* clone() const override {
-    return new Chi2ChargeMeasurementEstimator(*this);
-  }
-private:
+    bool checkClusterCharge(DetId id, SiStripCluster const& cluster, const TrajectoryStateOnSurface& ts) const {
+      return siStripClusterTools::chargePerCM(id, cluster, ts.localParameters()) > minGoodStripCharge_;
+    }
+  };
 
-  const float minGoodPixelCharge_; 
-  const float minGoodStripCharge_;
-  const float pTChargeCutThreshold2_;
+  bool Chi2ChargeMeasurementEstimator::preFilter(const TrajectoryStateOnSurface& ts,
+                                                 const MeasurementEstimator::OpaquePayload& opay) const {
+    // what we got?
+    if (opay.tag != ClusterFilterPayload::myTag)
+      return true;  // not mine...
 
-  bool checkClusterCharge(DetId id, SiStripCluster const & cluster, const TrajectoryStateOnSurface& ts) const {
-    return siStripClusterTools::chargePerCM(id, cluster, ts.localParameters() ) >  minGoodStripCharge_;
+    auto const& clf = reinterpret_cast<ClusterFilterPayload const&>(opay);
 
-  }
+    if (ts.globalMomentum().perp2() > pTChargeCutThreshold2_)
+      return true;
 
+    DetId detid = clf.detId;
+    uint32_t subdet = detid.subdetId();
 
-};
+    if (subdet > 2) {
+      return checkClusterCharge(detid, *clf.cluster[0], ts) &&
+             (nullptr == clf.cluster[1] || checkClusterCharge(detid, *clf.cluster[1], ts));
+    }
 
-bool Chi2ChargeMeasurementEstimator::preFilter(const TrajectoryStateOnSurface& ts,
-                                               const MeasurementEstimator::OpaquePayload  & opay) const {
-
-  // what we got?
-  if (opay.tag != ClusterFilterPayload::myTag) return true;  // not mine...
-  
-  auto const & clf = reinterpret_cast<ClusterFilterPayload const &>(opay);
-
-  if (ts.globalMomentum().perp2()>pTChargeCutThreshold2_) return true;
-
-  DetId detid = clf.detId;
-  uint32_t subdet = detid.subdetId();
-
-  if (subdet>2) {
-    return checkClusterCharge(detid, *clf.cluster[0],ts) && ( nullptr==clf.cluster[1] || checkClusterCharge(detid, *clf.cluster[1],ts) ) ; 
-
-  }
-
-  /*  pixel charge not implemented as not used...
+    /*  pixel charge not implemented as not used...
      auto const & thit = static_cast<const SiPixelRecHit &>(hit);
      thit.cluster()->charge() ...
 
   */
 
-  return true;
-}
+    return true;
+  }
 
-}
-
-
+}  // namespace
 
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -100,65 +87,53 @@ bool Chi2ChargeMeasurementEstimator::preFilter(const TrajectoryStateOnSurface& t
 
 #include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimatorParams.h"
 
-
 namespace {
 
+  class Chi2ChargeMeasurementEstimatorESProducer : public edm::ESProducer {
+  public:
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+    Chi2ChargeMeasurementEstimatorESProducer(const edm::ParameterSet& p);
+    ~Chi2ChargeMeasurementEstimatorESProducer() override;
+    std::unique_ptr<Chi2MeasurementEstimatorBase> produce(const TrackingComponentsRecord&);
 
-class  Chi2ChargeMeasurementEstimatorESProducer: public edm::ESProducer{
- public:
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  Chi2ChargeMeasurementEstimatorESProducer(const edm::ParameterSet & p);
-  ~Chi2ChargeMeasurementEstimatorESProducer() override; 
-  std::unique_ptr<Chi2MeasurementEstimatorBase> produce(const TrackingComponentsRecord &);
+  private:
+    const edm::ParameterSet m_pset;
+  };
 
- private:
-  const edm::ParameterSet m_pset;
-};
+  void Chi2ChargeMeasurementEstimatorESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    auto desc = chi2MeasurementEstimatorParams::getFilledConfigurationDescription();
+    desc.add<std::string>("ComponentName", "Chi2Charge");
+    desc.add<double>("pTChargeCutThreshold", -1.);
+    edm::ParameterSetDescription descCCC = getFilledConfigurationDescription4CCC();
+    desc.add<edm::ParameterSetDescription>("clusterChargeCut", descCCC);
+    descriptions.add("Chi2ChargeMeasurementEstimatorDefault", desc);
+  }
 
-void
-Chi2ChargeMeasurementEstimatorESProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  Chi2ChargeMeasurementEstimatorESProducer::Chi2ChargeMeasurementEstimatorESProducer(const edm::ParameterSet& pset)
+      : m_pset(pset) {
+    std::string const& myname = pset.getParameter<std::string>("ComponentName");
+    setWhatProduced(this, myname);
+  }
 
-  auto desc = chi2MeasurementEstimatorParams::getFilledConfigurationDescription();
-  desc.add<std::string>("ComponentName","Chi2Charge");
-  desc.add<double>("pTChargeCutThreshold",-1.);
-  edm::ParameterSetDescription descCCC = getFilledConfigurationDescription4CCC();
-  desc.add<edm::ParameterSetDescription>("clusterChargeCut", descCCC);
-  descriptions.add("Chi2ChargeMeasurementEstimatorDefault", desc);
-}
+  Chi2ChargeMeasurementEstimatorESProducer::~Chi2ChargeMeasurementEstimatorESProducer() {}
 
+  std::unique_ptr<Chi2MeasurementEstimatorBase> Chi2ChargeMeasurementEstimatorESProducer::produce(
+      const TrackingComponentsRecord& iRecord) {
+    auto maxChi2 = m_pset.getParameter<double>("MaxChi2");
+    auto nSigma = m_pset.getParameter<double>("nSigma");
+    auto maxDis = m_pset.getParameter<double>("MaxDisplacement");
+    auto maxSag = m_pset.getParameter<double>("MaxSagitta");
+    auto minTol = m_pset.getParameter<double>("MinimalTolerance");
+    auto minpt = m_pset.getParameter<double>("MinPtForHitRecoveryInGluedDet");
+    auto minGoodPixelCharge = 0;
+    auto minGoodStripCharge = clusterChargeCut(m_pset);
+    auto pTChargeCutThreshold = m_pset.getParameter<double>("pTChargeCutThreshold");
 
+    return std::make_unique<Chi2ChargeMeasurementEstimator>(
+        minGoodPixelCharge, minGoodStripCharge, pTChargeCutThreshold, maxChi2, nSigma, maxDis, maxSag, minTol, minpt);
+  }
 
-Chi2ChargeMeasurementEstimatorESProducer::Chi2ChargeMeasurementEstimatorESProducer(const edm::ParameterSet & pset) :
-  m_pset(pset)
-{
-  std::string const & myname = pset.getParameter<std::string>("ComponentName");
-  setWhatProduced(this,myname);
-}
-
-Chi2ChargeMeasurementEstimatorESProducer::~Chi2ChargeMeasurementEstimatorESProducer() {}
-
-std::unique_ptr<Chi2MeasurementEstimatorBase> 
-Chi2ChargeMeasurementEstimatorESProducer::produce(const TrackingComponentsRecord & iRecord){ 
-
-  auto maxChi2 = m_pset.getParameter<double>("MaxChi2");
-  auto nSigma  = m_pset.getParameter<double>("nSigma");
-  auto maxDis  = m_pset.getParameter<double>("MaxDisplacement");
-  auto maxSag  = m_pset.getParameter<double>("MaxSagitta");
-  auto minTol  = m_pset.getParameter<double>("MinimalTolerance");
-  auto minpt = m_pset.getParameter<double>("MinPtForHitRecoveryInGluedDet");
-  auto minGoodPixelCharge  = 0;
-  auto minGoodStripCharge  =  clusterChargeCut(m_pset);
-  auto pTChargeCutThreshold=   m_pset.getParameter<double>("pTChargeCutThreshold");
-
-  return std::make_unique<Chi2ChargeMeasurementEstimator>(
-                                            minGoodPixelCharge, minGoodStripCharge, pTChargeCutThreshold,
-                                            maxChi2,nSigma, maxDis, maxSag, minTol,minpt);
-
-}
-
-}
-
+}  // namespace
 
 #include "FWCore/Framework/interface/ModuleFactory.h"
 DEFINE_FWK_EVENTSETUP_MODULE(Chi2ChargeMeasurementEstimatorESProducer);
-

--- a/RecoTracker/MeasurementDet/plugins/MaskedMeasurementTrackerEventProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MaskedMeasurementTrackerEventProducer.cc
@@ -7,76 +7,72 @@
 
 class dso_hidden MaskedMeasurementTrackerEventProducer final : public edm::stream::EDProducer<> {
 public:
-      explicit MaskedMeasurementTrackerEventProducer(const edm::ParameterSet &iConfig) ;
-      ~MaskedMeasurementTrackerEventProducer() override {}
+  explicit MaskedMeasurementTrackerEventProducer(const edm::ParameterSet &iConfig);
+  ~MaskedMeasurementTrackerEventProducer() override {}
+
 private:
-      void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event &, const edm::EventSetup &) override;
 
-      typedef edm::ContainerMask<edmNew::DetSetVector<SiStripCluster> > StripMask;
-      typedef edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster> > PixelMask;
-      typedef edm::ContainerMask<edmNew::DetSetVector<Phase2TrackerCluster1D> > Phase2OTMask;
+  typedef edm::ContainerMask<edmNew::DetSetVector<SiStripCluster> > StripMask;
+  typedef edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster> > PixelMask;
+  typedef edm::ContainerMask<edmNew::DetSetVector<Phase2TrackerCluster1D> > Phase2OTMask;
 
-      edm::EDGetTokenT<MeasurementTrackerEvent> src_;
+  edm::EDGetTokenT<MeasurementTrackerEvent> src_;
 
-      bool skipClusters_;
-      bool phase2skipClusters_;
+  bool skipClusters_;
+  bool phase2skipClusters_;
 
-      edm::EDGetTokenT<StripMask> maskStrips_;
-      edm::EDGetTokenT<PixelMask> maskPixels_;
-      edm::EDGetTokenT<Phase2OTMask> maskPhase2OTs_;
+  edm::EDGetTokenT<StripMask> maskStrips_;
+  edm::EDGetTokenT<PixelMask> maskPixels_;
+  edm::EDGetTokenT<Phase2OTMask> maskPhase2OTs_;
 };
 
-
-MaskedMeasurementTrackerEventProducer::MaskedMeasurementTrackerEventProducer(const edm::ParameterSet &iConfig) :
-    src_(consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("src"))),
-    skipClusters_(false), phase2skipClusters_(false)
-{
-    //FIXME:temporary solution in order to use this class for both phase0/1 and phase2
-    if (iConfig.existsAs<edm::InputTag>("clustersToSkip")) {
-      skipClusters_ = true;
-      edm::InputTag clustersToSkip = iConfig.getParameter<edm::InputTag>("clustersToSkip");
-      maskPixels_ = consumes<PixelMask>(clustersToSkip);
-      maskStrips_ = consumes<StripMask>(clustersToSkip);
-    }
-    if (iConfig.existsAs<edm::InputTag>("phase2clustersToSkip")) {
-      phase2skipClusters_ = true;
-      edm::InputTag phase2clustersToSkip = iConfig.getParameter<edm::InputTag>("phase2clustersToSkip");
-      maskPixels_ = consumes<PixelMask>(phase2clustersToSkip);
-      maskPhase2OTs_ = consumes<Phase2OTMask>(phase2clustersToSkip);
-    }
-    produces<MeasurementTrackerEvent>();
+MaskedMeasurementTrackerEventProducer::MaskedMeasurementTrackerEventProducer(const edm::ParameterSet &iConfig)
+    : src_(consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("src"))),
+      skipClusters_(false),
+      phase2skipClusters_(false) {
+  //FIXME:temporary solution in order to use this class for both phase0/1 and phase2
+  if (iConfig.existsAs<edm::InputTag>("clustersToSkip")) {
+    skipClusters_ = true;
+    edm::InputTag clustersToSkip = iConfig.getParameter<edm::InputTag>("clustersToSkip");
+    maskPixels_ = consumes<PixelMask>(clustersToSkip);
+    maskStrips_ = consumes<StripMask>(clustersToSkip);
+  }
+  if (iConfig.existsAs<edm::InputTag>("phase2clustersToSkip")) {
+    phase2skipClusters_ = true;
+    edm::InputTag phase2clustersToSkip = iConfig.getParameter<edm::InputTag>("phase2clustersToSkip");
+    maskPixels_ = consumes<PixelMask>(phase2clustersToSkip);
+    maskPhase2OTs_ = consumes<Phase2OTMask>(phase2clustersToSkip);
+  }
+  produces<MeasurementTrackerEvent>();
 }
 
-void
-MaskedMeasurementTrackerEventProducer::produce(edm::Event &iEvent, const edm::EventSetup& iSetup)
-{
-    edm::Handle<MeasurementTrackerEvent> mte;
-    iEvent.getByToken(src_, mte);
+void MaskedMeasurementTrackerEventProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+  edm::Handle<MeasurementTrackerEvent> mte;
+  iEvent.getByToken(src_, mte);
 
-    // prepare output
-    std::unique_ptr<MeasurementTrackerEvent> out;
+  // prepare output
+  std::unique_ptr<MeasurementTrackerEvent> out;
 
-    if (skipClusters_) {
+  if (skipClusters_) {
+    edm::Handle<PixelMask> maskPixels;
+    iEvent.getByToken(maskPixels_, maskPixels);
+    edm::Handle<StripMask> maskStrips;
+    iEvent.getByToken(maskStrips_, maskStrips);
 
-      edm::Handle<PixelMask> maskPixels;
-      iEvent.getByToken(maskPixels_, maskPixels);
-      edm::Handle<StripMask> maskStrips;
-      iEvent.getByToken(maskStrips_, maskStrips);
+    out = std::make_unique<MeasurementTrackerEvent>(*mte, *maskStrips, *maskPixels);
 
-      out = std::make_unique<MeasurementTrackerEvent>(*mte, *maskStrips, *maskPixels);
+  } else if (phase2skipClusters_) {
+    edm::Handle<PixelMask> maskPixels;
+    iEvent.getByToken(maskPixels_, maskPixels);
+    edm::Handle<Phase2OTMask> maskPhase2OTs;
+    iEvent.getByToken(maskPhase2OTs_, maskPhase2OTs);
 
-    } else if (phase2skipClusters_) {
+    out = std::make_unique<MeasurementTrackerEvent>(*mte, *maskPixels, *maskPhase2OTs);
+  }
 
-      edm::Handle<PixelMask> maskPixels;
-      iEvent.getByToken(maskPixels_, maskPixels);
-      edm::Handle<Phase2OTMask> maskPhase2OTs;
-      iEvent.getByToken(maskPhase2OTs_, maskPhase2OTs);
-
-      out = std::make_unique<MeasurementTrackerEvent>(*mte, *maskPixels, *maskPhase2OTs);
-    }
-
-    // put into event
-    iEvent.put(std::move(out));
+  // put into event
+  iEvent.put(std::move(out));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
@@ -137,7 +137,7 @@ MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
   iRecord.getRecord<TrackerRecoGeometryRecord>().get(geometricSearchTracker);
 
 
-  if(phase2TrackerCPEName != ""){
+  if(!phase2TrackerCPEName.empty()){
       iRecord.getRecord<TkStripCPERecord>().get(phase2TrackerCPEName,phase2TrackerCPE);
       return             std::make_unique<MeasurementTrackerImpl>(pset_,
 							          pixelCPE.product(),

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.cc
@@ -35,12 +35,11 @@
 
 using namespace edm;
 
-MeasurementTrackerESProducer::MeasurementTrackerESProducer(const edm::ParameterSet & p) 
-{  
+MeasurementTrackerESProducer::MeasurementTrackerESProducer(const edm::ParameterSet &p) {
   std::string myname = p.getParameter<std::string>("ComponentName");
   pixelCPEName = p.getParameter<std::string>("PixelCPE");
   stripCPEName = p.getParameter<std::string>("StripCPE");
-  matcherName  = p.getParameter<std::string>("HitMatcher");
+  matcherName = p.getParameter<std::string>("HitMatcher");
 
   //FIXME:: just temporary solution for phase2!
   phase2TrackerCPEName = "";
@@ -49,36 +48,32 @@ MeasurementTrackerESProducer::MeasurementTrackerESProducer(const edm::ParameterS
   }
 
   pset_ = p;
-  setWhatProduced(this,myname);
+  setWhatProduced(this, myname);
 }
 
 MeasurementTrackerESProducer::~MeasurementTrackerESProducer() {}
 
-std::unique_ptr<MeasurementTracker> 
-MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
-{ 
-
+std::unique_ptr<MeasurementTracker> MeasurementTrackerESProducer::produce(const CkfComponentsRecord &iRecord) {
   // ========= SiPixelQuality related tasks =============
-  const SiPixelQuality    *ptr_pixelQuality = nullptr;
+  const SiPixelQuality *ptr_pixelQuality = nullptr;
   const SiPixelFedCabling *ptr_pixelCabling = nullptr;
-  int   pixelQualityFlags = 0;
-  int   pixelQualityDebugFlags = 0;
-  edm::ESHandle<SiPixelQuality>	      pixelQuality;
+  int pixelQualityFlags = 0;
+  int pixelQualityDebugFlags = 0;
+  edm::ESHandle<SiPixelQuality> pixelQuality;
   edm::ESHandle<SiPixelFedCablingMap> pixelCabling;
 
   if (pset_.getParameter<bool>("UsePixelModuleQualityDB")) {
     pixelQualityFlags += MeasurementTracker::BadModules;
     if (pset_.getUntrackedParameter<bool>("DebugPixelModuleQualityDB", false)) {
-        pixelQualityDebugFlags += MeasurementTracker::BadModules;
+      pixelQualityDebugFlags += MeasurementTracker::BadModules;
     }
   }
   if (pset_.getParameter<bool>("UsePixelROCQualityDB")) {
     pixelQualityFlags += MeasurementTracker::BadROCs;
     if (pset_.getUntrackedParameter<bool>("DebugPixelROCQualityDB", false)) {
-        pixelQualityDebugFlags += MeasurementTracker::BadROCs;
+      pixelQualityDebugFlags += MeasurementTracker::BadROCs;
     }
   }
-
 
   if (pixelQualityFlags != 0) {
     iRecord.getRecord<SiPixelQualityRcd>().get(pixelQuality);
@@ -86,32 +81,32 @@ MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
     iRecord.getRecord<SiPixelFedCablingMapRcd>().get(pixelCabling);
     ptr_pixelCabling = pixelCabling.product();
   }
-  
+
   // ========= SiStripQuality related tasks =============
   const SiStripQuality *ptr_stripQuality = nullptr;
-  int   stripQualityFlags = 0;
-  int   stripQualityDebugFlags = 0;
-  edm::ESHandle<SiStripQuality>	stripQuality;
+  int stripQualityFlags = 0;
+  int stripQualityDebugFlags = 0;
+  edm::ESHandle<SiStripQuality> stripQuality;
 
   if (pset_.getParameter<bool>("UseStripModuleQualityDB")) {
     stripQualityFlags += MeasurementTracker::BadModules;
     if (pset_.getUntrackedParameter<bool>("DebugStripModuleQualityDB", false)) {
-        stripQualityDebugFlags += MeasurementTracker::BadModules;
+      stripQualityDebugFlags += MeasurementTracker::BadModules;
     }
   }
   if (pset_.getParameter<bool>("UseStripAPVFiberQualityDB")) {
     stripQualityFlags += MeasurementTracker::BadAPVFibers;
     if (pset_.getUntrackedParameter<bool>("DebugStripAPVFiberQualityDB", false)) {
-        stripQualityDebugFlags += MeasurementTracker::BadAPVFibers;
+      stripQualityDebugFlags += MeasurementTracker::BadAPVFibers;
     }
     if (pset_.getParameter<bool>("MaskBadAPVFibers")) {
-        stripQualityFlags += MeasurementTracker::MaskBad128StripBlocks;
+      stripQualityFlags += MeasurementTracker::MaskBad128StripBlocks;
     }
   }
   if (pset_.getParameter<bool>("UseStripStripQualityDB")) {
     stripQualityFlags += MeasurementTracker::BadStrips;
     if (pset_.getUntrackedParameter<bool>("DebugStripStripQualityDB", false)) {
-        stripQualityDebugFlags += MeasurementTracker::BadStrips;
+      stripQualityDebugFlags += MeasurementTracker::BadStrips;
     }
   }
 
@@ -120,56 +115,53 @@ MeasurementTrackerESProducer::produce(const CkfComponentsRecord& iRecord)
     iRecord.getRecord<SiStripQualityRcd>().get(siStripQualityLabel, stripQuality);
     ptr_stripQuality = stripQuality.product();
   }
-  
+
   edm::ESHandle<PixelClusterParameterEstimator> pixelCPE;
   edm::ESHandle<StripClusterParameterEstimator> stripCPE;
-  edm::ESHandle<SiStripRecHitMatcher>           hitMatcher;
-  edm::ESHandle<TrackerTopology>                trackerTopology;
-  edm::ESHandle<TrackerGeometry>                trackerGeom;
-  edm::ESHandle<GeometricSearchTracker>         geometricSearchTracker;
+  edm::ESHandle<SiStripRecHitMatcher> hitMatcher;
+  edm::ESHandle<TrackerTopology> trackerTopology;
+  edm::ESHandle<TrackerGeometry> trackerGeom;
+  edm::ESHandle<GeometricSearchTracker> geometricSearchTracker;
   edm::ESHandle<ClusterParameterEstimator<Phase2TrackerCluster1D> > phase2TrackerCPE;
-  
-  iRecord.getRecord<TkPixelCPERecord>().get(pixelCPEName,pixelCPE);
-  iRecord.getRecord<TkStripCPERecord>().get(stripCPEName,stripCPE);
-  iRecord.getRecord<TkStripCPERecord>().get(matcherName,hitMatcher);
+
+  iRecord.getRecord<TkPixelCPERecord>().get(pixelCPEName, pixelCPE);
+  iRecord.getRecord<TkStripCPERecord>().get(stripCPEName, stripCPE);
+  iRecord.getRecord<TkStripCPERecord>().get(matcherName, hitMatcher);
   iRecord.getRecord<TrackerTopologyRcd>().get(trackerTopology);
   iRecord.getRecord<TrackerDigiGeometryRecord>().get(trackerGeom);
   iRecord.getRecord<TrackerRecoGeometryRecord>().get(geometricSearchTracker);
 
-
-  if(!phase2TrackerCPEName.empty()){
-      iRecord.getRecord<TkStripCPERecord>().get(phase2TrackerCPEName,phase2TrackerCPE);
-      return             std::make_unique<MeasurementTrackerImpl>(pset_,
-							          pixelCPE.product(),
-							          stripCPE.product(),
-							          hitMatcher.product(),
-							          trackerTopology.product(),
-							          trackerGeom.product(),
-							          geometricSearchTracker.product(),
-							          ptr_stripQuality,
-                                                                  stripQualityFlags,
-                                                                  stripQualityDebugFlags,
-							          ptr_pixelQuality,
-							          ptr_pixelCabling,
-                                                                  pixelQualityFlags,
-                                                                  pixelQualityDebugFlags,
-							          phase2TrackerCPE.product());
+  if (!phase2TrackerCPEName.empty()) {
+    iRecord.getRecord<TkStripCPERecord>().get(phase2TrackerCPEName, phase2TrackerCPE);
+    return std::make_unique<MeasurementTrackerImpl>(pset_,
+                                                    pixelCPE.product(),
+                                                    stripCPE.product(),
+                                                    hitMatcher.product(),
+                                                    trackerTopology.product(),
+                                                    trackerGeom.product(),
+                                                    geometricSearchTracker.product(),
+                                                    ptr_stripQuality,
+                                                    stripQualityFlags,
+                                                    stripQualityDebugFlags,
+                                                    ptr_pixelQuality,
+                                                    ptr_pixelCabling,
+                                                    pixelQualityFlags,
+                                                    pixelQualityDebugFlags,
+                                                    phase2TrackerCPE.product());
   } else {
-      return             std::make_unique<MeasurementTrackerImpl>(pset_,
-							          pixelCPE.product(),
-							          stripCPE.product(),
-							          hitMatcher.product(),
-							          trackerTopology.product(),
-							          trackerGeom.product(),
-							          geometricSearchTracker.product(),
-							          ptr_stripQuality,
-                                                                  stripQualityFlags,
-                                                                  stripQualityDebugFlags,
-							          ptr_pixelQuality,
-                                                                  ptr_pixelCabling,
-                                                                  pixelQualityFlags,
-                                                                  pixelQualityDebugFlags);
+    return std::make_unique<MeasurementTrackerImpl>(pset_,
+                                                    pixelCPE.product(),
+                                                    stripCPE.product(),
+                                                    hitMatcher.product(),
+                                                    trackerTopology.product(),
+                                                    trackerGeom.product(),
+                                                    geometricSearchTracker.product(),
+                                                    ptr_stripQuality,
+                                                    stripQualityFlags,
+                                                    stripQualityDebugFlags,
+                                                    ptr_pixelQuality,
+                                                    ptr_pixelCabling,
+                                                    pixelQualityFlags,
+                                                    pixelQualityDebugFlags);
   }
 }
-
-

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.h
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.h
@@ -7,12 +7,13 @@
 #include "RecoTracker/MeasurementDet/interface/MeasurementTracker.h"
 #include <memory>
 
-class  dso_hidden MeasurementTrackerESProducer: public edm::ESProducer{
- public:
-  MeasurementTrackerESProducer(const edm::ParameterSet & p);
-  ~MeasurementTrackerESProducer() override; 
+class dso_hidden MeasurementTrackerESProducer : public edm::ESProducer {
+public:
+  MeasurementTrackerESProducer(const edm::ParameterSet &p);
+  ~MeasurementTrackerESProducer() override;
   std::unique_ptr<MeasurementTracker> produce(const CkfComponentsRecord &);
- private:
+
+private:
   edm::ParameterSet pset_;
   std::string pixelCPEName;
   std::string stripCPEName;
@@ -20,9 +21,4 @@ class  dso_hidden MeasurementTrackerESProducer: public edm::ESProducer{
   std::string phase2TrackerCPEName;
 };
 
-
 #endif
-
-
-
-

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.cc
@@ -14,42 +14,54 @@
 
 #include <algorithm>
 
-MeasurementTrackerEventProducer::MeasurementTrackerEventProducer(const edm::ParameterSet &iConfig) :
-    measurementTrackerLabel_(iConfig.getParameter<std::string>("measurementTracker")),
-    switchOffPixelsIfEmpty_(iConfig.getParameter<bool>("switchOffPixelsIfEmpty"))
-{
-    std::vector<edm::InputTag> inactivePixelDetectorTags(iConfig.getParameter<std::vector<edm::InputTag> >("inactivePixelDetectorLabels"));
-    for (auto &t : inactivePixelDetectorTags) theInactivePixelDetectorLabels.push_back(consumes<DetIdCollection>(t));
+MeasurementTrackerEventProducer::MeasurementTrackerEventProducer(const edm::ParameterSet& iConfig)
+    : measurementTrackerLabel_(iConfig.getParameter<std::string>("measurementTracker")),
+      switchOffPixelsIfEmpty_(iConfig.getParameter<bool>("switchOffPixelsIfEmpty")) {
+  std::vector<edm::InputTag> inactivePixelDetectorTags(
+      iConfig.getParameter<std::vector<edm::InputTag>>("inactivePixelDetectorLabels"));
+  for (auto& t : inactivePixelDetectorTags)
+    theInactivePixelDetectorLabels.push_back(consumes<DetIdCollection>(t));
 
-    std::vector<edm::InputTag> badPixelFEDChannelCollectionTags = iConfig.getParameter<std::vector<edm::InputTag> >("badPixelFEDChannelCollectionLabels");
-    if (!badPixelFEDChannelCollectionTags.empty()) {
-      for (auto &t : badPixelFEDChannelCollectionTags) theBadPixelFEDChannelsLabels.push_back(consumes<PixelFEDChannelCollection>(t));
-      pixelCablingMapLabel_ = iConfig.getParameter<std::string> ("pixelCablingMapLabel");
-    }
+  std::vector<edm::InputTag> badPixelFEDChannelCollectionTags =
+      iConfig.getParameter<std::vector<edm::InputTag>>("badPixelFEDChannelCollectionLabels");
+  if (!badPixelFEDChannelCollectionTags.empty()) {
+    for (auto& t : badPixelFEDChannelCollectionTags)
+      theBadPixelFEDChannelsLabels.push_back(consumes<PixelFEDChannelCollection>(t));
+    pixelCablingMapLabel_ = iConfig.getParameter<std::string>("pixelCablingMapLabel");
+  }
 
-    std::vector<edm::InputTag> inactiveStripDetectorTags(iConfig.getParameter<std::vector<edm::InputTag> >("inactiveStripDetectorLabels"));
-    for (auto &t : inactiveStripDetectorTags) theInactiveStripDetectorLabels.push_back(consumes<DetIdCollection>(t));
+  std::vector<edm::InputTag> inactiveStripDetectorTags(
+      iConfig.getParameter<std::vector<edm::InputTag>>("inactiveStripDetectorLabels"));
+  for (auto& t : inactiveStripDetectorTags)
+    theInactiveStripDetectorLabels.push_back(consumes<DetIdCollection>(t));
 
-    //the measurement tracking is set to skip clusters, the other option is set from outside
-    edm::InputTag skip=iConfig.getParameter<edm::InputTag>("skipClusters");
-    selfUpdateSkipClusters_ = !( skip==edm::InputTag("") );
-    LogDebug("MeasurementTracker")<<"skipping clusters: "<<selfUpdateSkipClusters_;
-    isPhase2 = false;
+  //the measurement tracking is set to skip clusters, the other option is set from outside
+  edm::InputTag skip = iConfig.getParameter<edm::InputTag>("skipClusters");
+  selfUpdateSkipClusters_ = !(skip == edm::InputTag(""));
+  LogDebug("MeasurementTracker") << "skipping clusters: " << selfUpdateSkipClusters_;
+  isPhase2 = false;
 
-    if (!iConfig.getParameter<std::string>("stripClusterProducer").empty()) {
-        theStripClusterLabel = consumes<edmNew::DetSetVector<SiStripCluster> >(edm::InputTag(iConfig.getParameter<std::string>("stripClusterProducer")));
-        if (selfUpdateSkipClusters_) theStripClusterMask = consumes<edm::ContainerMask<edmNew::DetSetVector<SiStripCluster>>>(iConfig.getParameter<edm::InputTag>("skipClusters"));
-    }
-    if (!iConfig.getParameter<std::string>("pixelClusterProducer").empty()) {
-        thePixelClusterLabel = consumes<edmNew::DetSetVector<SiPixelCluster> >(edm::InputTag(iConfig.getParameter<std::string>("pixelClusterProducer")));
-        if (selfUpdateSkipClusters_) thePixelClusterMask = consumes<edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster>>>(iConfig.getParameter<edm::InputTag>("skipClusters"));
-    }
-    if (!iConfig.getParameter<std::string>("Phase2TrackerCluster1DProducer").empty()) {
-        thePh2OTClusterLabel = consumes<edmNew::DetSetVector<Phase2TrackerCluster1D> >(edm::InputTag(iConfig.getParameter<std::string>("Phase2TrackerCluster1DProducer")));
-        isPhase2 = true;
-    }
+  if (!iConfig.getParameter<std::string>("stripClusterProducer").empty()) {
+    theStripClusterLabel = consumes<edmNew::DetSetVector<SiStripCluster>>(
+        edm::InputTag(iConfig.getParameter<std::string>("stripClusterProducer")));
+    if (selfUpdateSkipClusters_)
+      theStripClusterMask = consumes<edm::ContainerMask<edmNew::DetSetVector<SiStripCluster>>>(
+          iConfig.getParameter<edm::InputTag>("skipClusters"));
+  }
+  if (!iConfig.getParameter<std::string>("pixelClusterProducer").empty()) {
+    thePixelClusterLabel = consumes<edmNew::DetSetVector<SiPixelCluster>>(
+        edm::InputTag(iConfig.getParameter<std::string>("pixelClusterProducer")));
+    if (selfUpdateSkipClusters_)
+      thePixelClusterMask = consumes<edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster>>>(
+          iConfig.getParameter<edm::InputTag>("skipClusters"));
+  }
+  if (!iConfig.getParameter<std::string>("Phase2TrackerCluster1DProducer").empty()) {
+    thePh2OTClusterLabel = consumes<edmNew::DetSetVector<Phase2TrackerCluster1D>>(
+        edm::InputTag(iConfig.getParameter<std::string>("Phase2TrackerCluster1DProducer")));
+    isPhase2 = true;
+  }
 
-    produces<MeasurementTrackerEvent>();
+  produces<MeasurementTrackerEvent>();
 }
 
 void MeasurementTrackerEventProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
@@ -61,77 +73,89 @@ void MeasurementTrackerEventProducer::fillDescriptions(edm::ConfigurationDescrip
   desc.add<std::string>("stripClusterProducer", "siStripClusters");
   desc.add<std::string>("Phase2TrackerCluster1DProducer", "");
 
-  desc.add<std::vector<edm::InputTag>>("inactivePixelDetectorLabels", std::vector<edm::InputTag>{{edm::InputTag("siPixelDigis")}})->setComment("One or more DetIdCollections of modules to mask on the fly for a given event");
-  desc.add<std::vector<edm::InputTag>>("badPixelFEDChannelCollectionLabels", std::vector<edm::InputTag>())->setComment("One or more PixelFEDChannelCollections of modules+ROCs to mask on the fly for a given event");
+  desc.add<std::vector<edm::InputTag>>("inactivePixelDetectorLabels",
+                                       std::vector<edm::InputTag>{{edm::InputTag("siPixelDigis")}})
+      ->setComment("One or more DetIdCollections of modules to mask on the fly for a given event");
+  desc.add<std::vector<edm::InputTag>>("badPixelFEDChannelCollectionLabels", std::vector<edm::InputTag>())
+      ->setComment("One or more PixelFEDChannelCollections of modules+ROCs to mask on the fly for a given event");
   desc.add<std::string>("pixelCablingMapLabel", "");
 
-  desc.add<std::vector<edm::InputTag>>("inactiveStripDetectorLabels", std::vector<edm::InputTag>{{edm::InputTag("siStripDigis")}})->setComment("One or more DetIdCollections of modules to mask on the fly for a given event");
+  desc.add<std::vector<edm::InputTag>>("inactiveStripDetectorLabels",
+                                       std::vector<edm::InputTag>{{edm::InputTag("siStripDigis")}})
+      ->setComment("One or more DetIdCollections of modules to mask on the fly for a given event");
 
   desc.add<bool>("switchOffPixelsIfEmpty", true)->setComment("let's keep it like this, for cosmics");
 
-  descriptions.add("measurementTrackerEventDefault",desc);
+  descriptions.add("measurementTrackerEventDefault", desc);
 }
 
+void MeasurementTrackerEventProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::ESHandle<MeasurementTracker> measurementTracker;
+  iSetup.get<CkfComponentsRecord>().get(measurementTrackerLabel_, measurementTracker);
 
-void
-MeasurementTrackerEventProducer::produce(edm::Event &iEvent, const edm::EventSetup& iSetup)
-{
-    edm::ESHandle<MeasurementTracker> measurementTracker;
-    iSetup.get<CkfComponentsRecord>().get(measurementTrackerLabel_, measurementTracker);
+  // create new data structures from templates
+  auto stripData = std::make_unique<StMeasurementDetSet>(measurementTracker->stripDetConditions());
+  auto pixelData = std::make_unique<PxMeasurementDetSet>(measurementTracker->pixelDetConditions());
+  auto phase2OTData = std::make_unique<Phase2OTMeasurementDetSet>(measurementTracker->phase2DetConditions());
+  std::vector<bool> stripClustersToSkip;
+  std::vector<bool> pixelClustersToSkip;
+  std::vector<bool> phase2ClustersToSkip;
+  // fill them
+  updateStrips(iEvent, *stripData, stripClustersToSkip);
+  updatePixels(iEvent,
+               *pixelData,
+               pixelClustersToSkip,
+               dynamic_cast<const TrackerGeometry&>(*(measurementTracker->geomTracker())),
+               iSetup);
+  updatePhase2OT(iEvent, *phase2OTData);
+  updateStacks(iEvent, *phase2OTData);
 
-    // create new data structures from templates
-    auto stripData = std::make_unique<StMeasurementDetSet>(measurementTracker->stripDetConditions());
-    auto pixelData=  std::make_unique<PxMeasurementDetSet>(measurementTracker->pixelDetConditions());
-    auto phase2OTData = std::make_unique<Phase2OTMeasurementDetSet>(measurementTracker->phase2DetConditions());
-    std::vector<bool> stripClustersToSkip;
-    std::vector<bool> pixelClustersToSkip;
-    std::vector<bool> phase2ClustersToSkip;
-    // fill them
-    updateStrips(iEvent, *stripData, stripClustersToSkip);
-    updatePixels(iEvent, *pixelData, pixelClustersToSkip, dynamic_cast<const TrackerGeometry&>(*(measurementTracker->geomTracker())), iSetup);
-    updatePhase2OT(iEvent, *phase2OTData);
-    updateStacks(iEvent, *phase2OTData);
-
-    // put into MTE
-    // put into event
-    iEvent.put(
-      std::make_unique<MeasurementTrackerEvent>(*measurementTracker, 
-                                                stripData.release(), pixelData.release(), phase2OTData.release(),
-	                                        stripClustersToSkip, pixelClustersToSkip, phase2ClustersToSkip)
-    );
+  // put into MTE
+  // put into event
+  iEvent.put(std::make_unique<MeasurementTrackerEvent>(*measurementTracker,
+                                                       stripData.release(),
+                                                       pixelData.release(),
+                                                       phase2OTData.release(),
+                                                       stripClustersToSkip,
+                                                       pixelClustersToSkip,
+                                                       phase2ClustersToSkip));
 }
 
-void 
-MeasurementTrackerEventProducer::updatePixels( const edm::Event& event, PxMeasurementDetSet & thePxDets, std::vector<bool> & pixelClustersToSkip, 
-					       const TrackerGeometry& trackerGeom, const edm::EventSetup& iSetup) const
-{
+void MeasurementTrackerEventProducer::updatePixels(const edm::Event& event,
+                                                   PxMeasurementDetSet& thePxDets,
+                                                   std::vector<bool>& pixelClustersToSkip,
+                                                   const TrackerGeometry& trackerGeom,
+                                                   const edm::EventSetup& iSetup) const {
   // start by clearinng everything
   thePxDets.setEmpty();
 
-  std::vector<uint32_t> rawInactiveDetIds; 
+  std::vector<uint32_t> rawInactiveDetIds;
   if (!theInactivePixelDetectorLabels.empty()) {
     edm::Handle<DetIdCollection> detIds;
-    for (const edm::EDGetTokenT<DetIdCollection> &tk : theInactivePixelDetectorLabels) {
-      if (event.getByToken(tk, detIds)){
+    for (const edm::EDGetTokenT<DetIdCollection>& tk : theInactivePixelDetectorLabels) {
+      if (event.getByToken(tk, detIds)) {
         rawInactiveDetIds.insert(rawInactiveDetIds.end(), detIds->begin(), detIds->end());
-      }else{
+      } else {
         static std::atomic<bool> iFailedAlready{false};
         bool expected = false;
-        if (iFailedAlready.compare_exchange_strong(expected,true,std::memory_order_acq_rel)){
-          edm::LogError("MissingProduct")<<"I fail to get the list of inactive pixel modules, because of 4.2/4.4 event content change.";
+        if (iFailedAlready.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+          edm::LogError("MissingProduct")
+              << "I fail to get the list of inactive pixel modules, because of 4.2/4.4 event content change.";
         }
       }
     }
-    if (!rawInactiveDetIds.empty()) std::sort(rawInactiveDetIds.begin(), rawInactiveDetIds.end());
+    if (!rawInactiveDetIds.empty())
+      std::sort(rawInactiveDetIds.begin(), rawInactiveDetIds.end());
     // mark as inactive if in rawInactiveDetIds
-    int i=0, endDet = thePxDets.size();
-    unsigned int idp=0;
-    for ( auto id : rawInactiveDetIds) {
-        if (id==idp) continue; // skip multiple id
-        idp=id;
-        i=thePxDets.find(id,i);
-        assert(i!=endDet && id == thePxDets.id(i));
-        thePxDets.setActiveThisEvent(i,false);
+    int i = 0, endDet = thePxDets.size();
+    unsigned int idp = 0;
+    for (auto id : rawInactiveDetIds) {
+      if (id == idp)
+        continue;  // skip multiple id
+      idp = id;
+      i = thePxDets.find(id, i);
+      assert(i != endDet && id == thePxDets.id(i));
+      thePxDets.setActiveThisEvent(i, false);
     }
   }
 
@@ -140,231 +164,241 @@ MeasurementTrackerEventProducer::updatePixels( const edm::Event& event, PxMeasur
     iSetup.get<SiPixelFedCablingMapRcd>().get(pixelCablingMapLabel_, cablingMap);
 
     edm::Handle<PixelFEDChannelCollection> pixelFEDChannelCollectionHandle;
-    for (const edm::EDGetTokenT<PixelFEDChannelCollection>& tk: theBadPixelFEDChannelsLabels) {
-      if (!event.getByToken(tk, pixelFEDChannelCollectionHandle)) continue;
-      int i=0;
-      for (const auto& disabledChannels: *pixelFEDChannelCollectionHandle) {	
-	PxMeasurementDetSet::BadFEDChannelPositions positions;
-	for(const auto& ch: disabledChannels) {
-	  const sipixelobjects::PixelROC *roc_first=nullptr, *roc_last=nullptr;
-	  sipixelobjects::CablingPathToDetUnit path = {ch.fed, ch.link, 0};
-	  // PixelFEDChannelCollection addresses the ROCs by their 'idInDetUnit' (from 0 to 15), ROCs also know their on 'idInDetUnit',
-	  // however the cabling map uses a numbering [1,numberOfROCs], see sipixelobjects::PixelFEDLink::roc(unsigned int id), not necessarily sorted in the same direction.
-	  // PixelFEDChannelCollection MUST be filled such that ch.roc_first (ch.roc_last) correspond to the lowest (highest) 'idInDetUnit' in the channel
-	  for (path.roc=1; path.roc<=(ch.roc_last-ch.roc_first)+1; path.roc++) {
-	    const sipixelobjects::PixelROC *roc = cablingMap->findItem(path);
-	    if (roc==nullptr) continue;
-	    assert(roc->rawId()==disabledChannels.detId());
-	    if (roc->idInDetUnit()==ch.roc_first) roc_first=roc;
-	    if (roc->idInDetUnit()==ch.roc_last) roc_last=roc;
-	  }
-	  if (roc_first==nullptr || roc_last==nullptr) { 
-	    edm::LogError("PixelFEDChannelCollection")<<"Do not find either roc_first or roc_last in the cabling map."; 
-	    continue; 
-	  }
-	  const PixelGeomDetUnit * theGeomDet = dynamic_cast<const PixelGeomDetUnit*> (trackerGeom.idToDet(roc_first->rawId()));
-	  PixelTopology const * topology = &(theGeomDet->specificTopology());
-	  sipixelobjects::LocalPixel::RocRowCol local = {topology->rowsperroc()/2, topology->colsperroc()/2};   //corresponding to center of ROC row, col
-	  sipixelobjects::GlobalPixel global = roc_first->toGlobal(sipixelobjects::LocalPixel(local));
-	  LocalPoint lp1 = topology->localPosition(MeasurementPoint(global.row, global.col));
-	  global = roc_last->toGlobal(sipixelobjects::LocalPixel(local));
-	  LocalPoint lp2 = topology->localPosition(MeasurementPoint(global.row, global.col));
-	  LocalPoint ll(std::min(lp1.x(), lp2.x()), std::min(lp1.y(), lp2.y()), std::min(lp1.z(), lp2.z()));
-	  LocalPoint ur(std::max(lp1.x(), lp2.x()), std::max(lp1.y(), lp2.y()), std::max(lp1.z(), lp2.z()));	  
-	  positions.push_back(std::make_pair(ll, ur));
-	} // loop on channels
-	if (!positions.empty()) {
-	  i=thePxDets.find(disabledChannels.detId(),i);
-	  assert(i!=thePxDets.size() && thePxDets.id(i)==disabledChannels.detId());
-	  thePxDets.addBadFEDChannelPositions(i, positions);
-	}
-      } // loop on DetId-s
-    } // loop on labels
-  } // if collection labels are populated
+    for (const edm::EDGetTokenT<PixelFEDChannelCollection>& tk : theBadPixelFEDChannelsLabels) {
+      if (!event.getByToken(tk, pixelFEDChannelCollectionHandle))
+        continue;
+      int i = 0;
+      for (const auto& disabledChannels : *pixelFEDChannelCollectionHandle) {
+        PxMeasurementDetSet::BadFEDChannelPositions positions;
+        for (const auto& ch : disabledChannels) {
+          const sipixelobjects::PixelROC *roc_first = nullptr, *roc_last = nullptr;
+          sipixelobjects::CablingPathToDetUnit path = {ch.fed, ch.link, 0};
+          // PixelFEDChannelCollection addresses the ROCs by their 'idInDetUnit' (from 0 to 15), ROCs also know their on 'idInDetUnit',
+          // however the cabling map uses a numbering [1,numberOfROCs], see sipixelobjects::PixelFEDLink::roc(unsigned int id), not necessarily sorted in the same direction.
+          // PixelFEDChannelCollection MUST be filled such that ch.roc_first (ch.roc_last) correspond to the lowest (highest) 'idInDetUnit' in the channel
+          for (path.roc = 1; path.roc <= (ch.roc_last - ch.roc_first) + 1; path.roc++) {
+            const sipixelobjects::PixelROC* roc = cablingMap->findItem(path);
+            if (roc == nullptr)
+              continue;
+            assert(roc->rawId() == disabledChannels.detId());
+            if (roc->idInDetUnit() == ch.roc_first)
+              roc_first = roc;
+            if (roc->idInDetUnit() == ch.roc_last)
+              roc_last = roc;
+          }
+          if (roc_first == nullptr || roc_last == nullptr) {
+            edm::LogError("PixelFEDChannelCollection")
+                << "Do not find either roc_first or roc_last in the cabling map.";
+            continue;
+          }
+          const PixelGeomDetUnit* theGeomDet =
+              dynamic_cast<const PixelGeomDetUnit*>(trackerGeom.idToDet(roc_first->rawId()));
+          PixelTopology const* topology = &(theGeomDet->specificTopology());
+          sipixelobjects::LocalPixel::RocRowCol local = {
+              topology->rowsperroc() / 2, topology->colsperroc() / 2};  //corresponding to center of ROC row, col
+          sipixelobjects::GlobalPixel global = roc_first->toGlobal(sipixelobjects::LocalPixel(local));
+          LocalPoint lp1 = topology->localPosition(MeasurementPoint(global.row, global.col));
+          global = roc_last->toGlobal(sipixelobjects::LocalPixel(local));
+          LocalPoint lp2 = topology->localPosition(MeasurementPoint(global.row, global.col));
+          LocalPoint ll(std::min(lp1.x(), lp2.x()), std::min(lp1.y(), lp2.y()), std::min(lp1.z(), lp2.z()));
+          LocalPoint ur(std::max(lp1.x(), lp2.x()), std::max(lp1.y(), lp2.y()), std::max(lp1.z(), lp2.z()));
+          positions.push_back(std::make_pair(ll, ur));
+        }  // loop on channels
+        if (!positions.empty()) {
+          i = thePxDets.find(disabledChannels.detId(), i);
+          assert(i != thePxDets.size() && thePxDets.id(i) == disabledChannels.detId());
+          thePxDets.addBadFEDChannelPositions(i, positions);
+        }
+      }  // loop on DetId-s
+    }    // loop on labels
+  }      // if collection labels are populated
 
   // Pixel Clusters
-  if( thePixelClusterLabel.isUninitialized() ) { //clusters have not been produced
+  if (thePixelClusterLabel.isUninitialized()) {  //clusters have not been produced
     if (switchOffPixelsIfEmpty_) {
       thePxDets.setActiveThisEvent(false);
     }
-  }else{  
+  } else {
+    edm::Handle<edmNew::DetSetVector<SiPixelCluster>>& pixelClusters = thePxDets.handle();
+    if (event.getByToken(thePixelClusterLabel, pixelClusters)) {
+      const edmNew::DetSetVector<SiPixelCluster>* pixelCollection = pixelClusters.product();
 
-    edm::Handle<edmNew::DetSetVector<SiPixelCluster> > & pixelClusters = thePxDets.handle();
-    if(event.getByToken(thePixelClusterLabel, pixelClusters)) {
-    
-      const  edmNew::DetSetVector<SiPixelCluster>* pixelCollection = pixelClusters.product();
-      
-   
       if (switchOffPixelsIfEmpty_ && pixelCollection->empty()) {
-	thePxDets.setActiveThisEvent(false);
-      } else { 
-	
-	//std::cout <<"updatePixels "<<pixelCollection->dataSize()<<std::endl;
-	pixelClustersToSkip.resize(pixelCollection->dataSize());
-	std::fill(pixelClustersToSkip.begin(),pixelClustersToSkip.end(),false);
-	
-	if(selfUpdateSkipClusters_) {
-          edm::Handle<edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster> > > pixelClusterMask;
-	  //and get the collection of pixel ref to skip
-	  event.getByToken(thePixelClusterMask,pixelClusterMask);
-	  LogDebug("MeasurementTracker")<<"getting pxl refs to skip";
-	  if (pixelClusterMask.failedToGet())edm::LogError("MeasurementTracker")<<"not getting the pixel clusters to skip";
-	  if (pixelClusterMask->refProd().id()!=pixelClusters.id()){
-	    edm::LogError("ProductIdMismatch")<<"The pixel masking does not point to the proper collection of clusters: "<<pixelClusterMask->refProd().id()<<"!="<<pixelClusters.id();
-	  }
-	  pixelClusterMask->copyMaskTo(pixelClustersToSkip);
-	}
-	
-	
-	// FIXME: should check if lower_bound is better
-	int i = 0, endDet = thePxDets.size();
-	for (edmNew::DetSetVector<SiPixelCluster>::const_iterator it = pixelCollection->begin(), ed = pixelCollection->end(); it != ed; ++it) {
-	  edmNew::DetSet<SiPixelCluster> set(*it);
-	  unsigned int id = set.id();
-	  while ( id != thePxDets.id(i)) { 
-	    ++i;
-	    if (endDet==i) throw "we have a problem!!!!";
-	  }
-	  // push cluster range in det
-	  if ( thePxDets.isActive(i) ) {
-	    thePxDets.update(i,set);         
-	  }
-	}
+        thePxDets.setActiveThisEvent(false);
+      } else {
+        //std::cout <<"updatePixels "<<pixelCollection->dataSize()<<std::endl;
+        pixelClustersToSkip.resize(pixelCollection->dataSize());
+        std::fill(pixelClustersToSkip.begin(), pixelClustersToSkip.end(), false);
+
+        if (selfUpdateSkipClusters_) {
+          edm::Handle<edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster>>> pixelClusterMask;
+          //and get the collection of pixel ref to skip
+          event.getByToken(thePixelClusterMask, pixelClusterMask);
+          LogDebug("MeasurementTracker") << "getting pxl refs to skip";
+          if (pixelClusterMask.failedToGet())
+            edm::LogError("MeasurementTracker") << "not getting the pixel clusters to skip";
+          if (pixelClusterMask->refProd().id() != pixelClusters.id()) {
+            edm::LogError("ProductIdMismatch")
+                << "The pixel masking does not point to the proper collection of clusters: "
+                << pixelClusterMask->refProd().id() << "!=" << pixelClusters.id();
+          }
+          pixelClusterMask->copyMaskTo(pixelClustersToSkip);
+        }
+
+        // FIXME: should check if lower_bound is better
+        int i = 0, endDet = thePxDets.size();
+        for (edmNew::DetSetVector<SiPixelCluster>::const_iterator it = pixelCollection->begin(),
+                                                                  ed = pixelCollection->end();
+             it != ed;
+             ++it) {
+          edmNew::DetSet<SiPixelCluster> set(*it);
+          unsigned int id = set.id();
+          while (id != thePxDets.id(i)) {
+            ++i;
+            if (endDet == i)
+              throw "we have a problem!!!!";
+          }
+          // push cluster range in det
+          if (thePxDets.isActive(i)) {
+            thePxDets.update(i, set);
+          }
+        }
       }
     } else {
       edm::EDConsumerBase::Labels labels;
       labelsForToken(thePixelClusterLabel, labels);
-      edm::LogWarning("MeasurementTrackerEventProducer") << "input pixel clusters collection " << labels.module << " is not valid";
+      edm::LogWarning("MeasurementTrackerEventProducer")
+          << "input pixel clusters collection " << labels.module << " is not valid";
     }
   }
 }
 
-void 
-MeasurementTrackerEventProducer::updateStrips( const edm::Event& event, StMeasurementDetSet & theStDets, std::vector<bool> & stripClustersToSkip ) const
-{
-  typedef edmNew::DetSet<SiStripCluster>   StripDetSet;
+void MeasurementTrackerEventProducer::updateStrips(const edm::Event& event,
+                                                   StMeasurementDetSet& theStDets,
+                                                   std::vector<bool>& stripClustersToSkip) const {
+  typedef edmNew::DetSet<SiStripCluster> StripDetSet;
 
   std::vector<uint32_t> rawInactiveDetIds;
-  getInactiveStrips(event,rawInactiveDetIds);
+  getInactiveStrips(event, rawInactiveDetIds);
 
   // Strip Clusters
   //first clear all of them
   theStDets.setEmpty();
 
-
-  if( theStripClusterLabel.isUninitialized() )  return;  //clusters have not been produced
+  if (theStripClusterLabel.isUninitialized())
+    return;  //clusters have not been produced
 
   const int endDet = theStDets.size();
- 
 
   // mark as inactive if in rawInactiveDetIds
-  int i=0;
-  unsigned int idp=0;
-  for ( auto id : rawInactiveDetIds) {
-    if (id==idp) continue; // skip multiple id
-    idp=id;
-    i=theStDets.find(id,i);
-    assert(i!=endDet && id == theStDets.id(i));
-    theStDets.setActiveThisEvent(i,false);
+  int i = 0;
+  unsigned int idp = 0;
+  for (auto id : rawInactiveDetIds) {
+    if (id == idp)
+      continue;  // skip multiple id
+    idp = id;
+    i = theStDets.find(id, i);
+    assert(i != endDet && id == theStDets.id(i));
+    theStDets.setActiveThisEvent(i, false);
   }
 
   //=========  actually load cluster =============
   {
-    edm::Handle<edmNew::DetSetVector<SiStripCluster> > clusterHandle;
+    edm::Handle<edmNew::DetSetVector<SiStripCluster>> clusterHandle;
     if (event.getByToken(theStripClusterLabel, clusterHandle)) {
       const edmNew::DetSetVector<SiStripCluster>* clusterCollection = clusterHandle.product();
-    
-    
-      if (selfUpdateSkipClusters_){
-	edm::Handle<edm::ContainerMask<edmNew::DetSetVector<SiStripCluster> > > stripClusterMask;
-	//and get the collection of pixel ref to skip
-	LogDebug("MeasurementTracker")<<"getting strp refs to skip";
-	event.getByToken(theStripClusterMask,stripClusterMask);
-	if (stripClusterMask.failedToGet())  edm::LogError("MeasurementTracker")<<"not getting the strip clusters to skip";
-	if (stripClusterMask->refProd().id()!=clusterHandle.id()){
-	  edm::LogError("ProductIdMismatch")<<"The strip masking does not point to the proper collection of clusters: "<<stripClusterMask->refProd().id()<<"!="<<clusterHandle.id();
-	}
-	stripClusterMask->copyMaskTo(stripClustersToSkip);
+
+      if (selfUpdateSkipClusters_) {
+        edm::Handle<edm::ContainerMask<edmNew::DetSetVector<SiStripCluster>>> stripClusterMask;
+        //and get the collection of pixel ref to skip
+        LogDebug("MeasurementTracker") << "getting strp refs to skip";
+        event.getByToken(theStripClusterMask, stripClusterMask);
+        if (stripClusterMask.failedToGet())
+          edm::LogError("MeasurementTracker") << "not getting the strip clusters to skip";
+        if (stripClusterMask->refProd().id() != clusterHandle.id()) {
+          edm::LogError("ProductIdMismatch")
+              << "The strip masking does not point to the proper collection of clusters: "
+              << stripClusterMask->refProd().id() << "!=" << clusterHandle.id();
+        }
+        stripClusterMask->copyMaskTo(stripClustersToSkip);
       }
-    
+
       theStDets.handle() = clusterHandle;
-      int i=0;
+      int i = 0;
       // cluster and det and in order (both) and unique so let's use set intersection
-      for ( auto j = 0U; j< (*clusterCollection).size(); ++j) {
-	unsigned int id = (*clusterCollection).id(j);
-	while ( id != theStDets.id(i)) { // eventually change to lower_bound
-	  ++i;
-	  if (endDet==i) throw "we have a problem in strips!!!!";
-	}
-      
-	// push cluster range in det
-	if ( theStDets.isActive(i) )
-	  theStDets.update(i,j);
+      for (auto j = 0U; j < (*clusterCollection).size(); ++j) {
+        unsigned int id = (*clusterCollection).id(j);
+        while (id != theStDets.id(i)) {  // eventually change to lower_bound
+          ++i;
+          if (endDet == i)
+            throw "we have a problem in strips!!!!";
+        }
+
+        // push cluster range in det
+        if (theStDets.isActive(i))
+          theStDets.update(i, j);
       }
     } else {
       edm::EDConsumerBase::Labels labels;
       labelsForToken(theStripClusterLabel, labels);
-      edm::LogWarning("MeasurementTrackerEventProducer") << "input strip cluster collection " << labels.module << " is not valid";
+      edm::LogWarning("MeasurementTrackerEventProducer")
+          << "input strip cluster collection " << labels.module << " is not valid";
     }
   }
 }
 
 //FIXME: just a temporary solution for phase2!
-void 
-MeasurementTrackerEventProducer::updatePhase2OT( const edm::Event& event, Phase2OTMeasurementDetSet & thePh2OTDets ) const {
-
-
+void MeasurementTrackerEventProducer::updatePhase2OT(const edm::Event& event,
+                                                     Phase2OTMeasurementDetSet& thePh2OTDets) const {
   // Phase2OT Clusters
-  if ( isPhase2 ) {
-
-    if( thePh2OTClusterLabel.isUninitialized() ) { //clusters have not been produced
+  if (isPhase2) {
+    if (thePh2OTClusterLabel.isUninitialized()) {  //clusters have not been produced
       thePh2OTDets.setActiveThisEvent(false);
     } else {
-  
-      edm::Handle<edmNew::DetSetVector<Phase2TrackerCluster1D> > & phase2OTClusters = thePh2OTDets.handle();
+      edm::Handle<edmNew::DetSetVector<Phase2TrackerCluster1D>>& phase2OTClusters = thePh2OTDets.handle();
       if (event.getByToken(thePh2OTClusterLabel, phase2OTClusters)) {
-	const edmNew::DetSetVector<Phase2TrackerCluster1D>* phase2OTCollection = phase2OTClusters.product();
-  
-	int i = 0, endDet = thePh2OTDets.size();
-	for (edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator it = phase2OTCollection->begin(), ed = phase2OTCollection->end(); it != ed; ++it) {
-	  
-	  edmNew::DetSet<Phase2TrackerCluster1D> set(*it);
-	  unsigned int id = set.id();
-	  while ( id != thePh2OTDets.id(i)) {
+        const edmNew::DetSetVector<Phase2TrackerCluster1D>* phase2OTCollection = phase2OTClusters.product();
+
+        int i = 0, endDet = thePh2OTDets.size();
+        for (edmNew::DetSetVector<Phase2TrackerCluster1D>::const_iterator it = phase2OTCollection->begin(),
+                                                                          ed = phase2OTCollection->end();
+             it != ed;
+             ++it) {
+          edmNew::DetSet<Phase2TrackerCluster1D> set(*it);
+          unsigned int id = set.id();
+          while (id != thePh2OTDets.id(i)) {
             ++i;
-            if (endDet==i) throw "we have a problem!!!!";
-	  }
-	  // push cluster range in det
-	  if ( thePh2OTDets.isActive(i) ) {
-            thePh2OTDets.update(i,set);
-	  }
-	}
+            if (endDet == i)
+              throw "we have a problem!!!!";
+          }
+          // push cluster range in det
+          if (thePh2OTDets.isActive(i)) {
+            thePh2OTDets.update(i, set);
+          }
+        }
       } else {
         edm::EDConsumerBase::Labels labels;
         labelsForToken(thePh2OTClusterLabel, labels);
-        edm::LogWarning("MeasurementTrackerEventProducer") << "input Phase2TrackerCluster1D collection " << labels.module << " is not valid";
+        edm::LogWarning("MeasurementTrackerEventProducer")
+            << "input Phase2TrackerCluster1D collection " << labels.module << " is not valid";
       }
     }
-
   }
   return;
 }
 
-void
-MeasurementTrackerEventProducer::getInactiveStrips(const edm::Event& event,std::vector<uint32_t> & rawInactiveDetIds) const
-{
+void MeasurementTrackerEventProducer::getInactiveStrips(const edm::Event& event,
+                                                        std::vector<uint32_t>& rawInactiveDetIds) const {
   if (!theInactiveStripDetectorLabels.empty()) {
     edm::Handle<DetIdCollection> detIds;
-    for (const edm::EDGetTokenT<DetIdCollection> &tk : theInactiveStripDetectorLabels) {
-        if (event.getByToken(tk, detIds)){
-            rawInactiveDetIds.insert(rawInactiveDetIds.end(), detIds->begin(), detIds->end());
-        }
+    for (const edm::EDGetTokenT<DetIdCollection>& tk : theInactiveStripDetectorLabels) {
+      if (event.getByToken(tk, detIds)) {
+        rawInactiveDetIds.insert(rawInactiveDetIds.end(), detIds->begin(), detIds->end());
+      }
     }
-    if (!rawInactiveDetIds.empty()) std::sort(rawInactiveDetIds.begin(), rawInactiveDetIds.end());
+    if (!rawInactiveDetIds.empty())
+      std::sort(rawInactiveDetIds.begin(), rawInactiveDetIds.end());
   }
-
 }
-
-
 
 DEFINE_FWK_MODULE(MeasurementTrackerEventProducer);

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.h
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerEventProducer.h
@@ -15,38 +15,42 @@
 
 class dso_hidden MeasurementTrackerEventProducer final : public edm::stream::EDProducer<> {
 public:
-      explicit MeasurementTrackerEventProducer(const edm::ParameterSet &iConfig) ;
-      ~MeasurementTrackerEventProducer() override {}
+  explicit MeasurementTrackerEventProducer(const edm::ParameterSet& iConfig);
+  ~MeasurementTrackerEventProducer() override {}
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
 private:
-      void produce(edm::Event&, const edm::EventSetup&) override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
 protected:
-      void updatePixels( const edm::Event&, PxMeasurementDetSet & thePxDets, std::vector<bool> & pixelClustersToSkip, 
-			 const TrackerGeometry& trackerGeom, const edm::EventSetup& iSetup) const;
-      void updateStrips( const edm::Event&, StMeasurementDetSet & theStDets, std::vector<bool> & stripClustersToSkip ) const;
-      void updatePhase2OT( const edm::Event&, Phase2OTMeasurementDetSet & thePh2OTDets ) const;
-      //FIXME:: going to be updated soon
-      void updateStacks( const edm::Event&, Phase2OTMeasurementDetSet & theStDets ) const {};
+  void updatePixels(const edm::Event&,
+                    PxMeasurementDetSet& thePxDets,
+                    std::vector<bool>& pixelClustersToSkip,
+                    const TrackerGeometry& trackerGeom,
+                    const edm::EventSetup& iSetup) const;
+  void updateStrips(const edm::Event&, StMeasurementDetSet& theStDets, std::vector<bool>& stripClustersToSkip) const;
+  void updatePhase2OT(const edm::Event&, Phase2OTMeasurementDetSet& thePh2OTDets) const;
+  //FIXME:: going to be updated soon
+  void updateStacks(const edm::Event&, Phase2OTMeasurementDetSet& theStDets) const {};
 
-      void getInactiveStrips(const edm::Event& event,std::vector<uint32_t> & rawInactiveDetIds) const;
+  void getInactiveStrips(const edm::Event& event, std::vector<uint32_t>& rawInactiveDetIds) const;
 
-      std::string measurementTrackerLabel_;
-      edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>> thePixelClusterLabel;
-      edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster>> theStripClusterLabel;
-      edm::EDGetTokenT<edmNew::DetSetVector<Phase2TrackerCluster1D>> thePh2OTClusterLabel;
-      edm::EDGetTokenT<edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster>>> thePixelClusterMask;
-      edm::EDGetTokenT<edm::ContainerMask<edmNew::DetSetVector<SiStripCluster>>> theStripClusterMask;
+  std::string measurementTrackerLabel_;
+  edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>> thePixelClusterLabel;
+  edm::EDGetTokenT<edmNew::DetSetVector<SiStripCluster>> theStripClusterLabel;
+  edm::EDGetTokenT<edmNew::DetSetVector<Phase2TrackerCluster1D>> thePh2OTClusterLabel;
+  edm::EDGetTokenT<edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster>>> thePixelClusterMask;
+  edm::EDGetTokenT<edm::ContainerMask<edmNew::DetSetVector<SiStripCluster>>> theStripClusterMask;
 
-      std::vector<edm::EDGetTokenT<DetIdCollection>>      theInactivePixelDetectorLabels;
-      std::vector<edm::EDGetTokenT<PixelFEDChannelCollection> > theBadPixelFEDChannelsLabels;
-      std::string pixelCablingMapLabel_;
-      std::vector<edm::EDGetTokenT<DetIdCollection>>      theInactiveStripDetectorLabels;
+  std::vector<edm::EDGetTokenT<DetIdCollection>> theInactivePixelDetectorLabels;
+  std::vector<edm::EDGetTokenT<PixelFEDChannelCollection>> theBadPixelFEDChannelsLabels;
+  std::string pixelCablingMapLabel_;
+  std::vector<edm::EDGetTokenT<DetIdCollection>> theInactiveStripDetectorLabels;
 
-      bool selfUpdateSkipClusters_;
-      bool switchOffPixelsIfEmpty_;
-      bool isPhase2;
+  bool selfUpdateSkipClusters_;
+  bool switchOffPixelsIfEmpty_;
+  bool isPhase2;
 };
 
 #endif

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.cc
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.cc
@@ -24,7 +24,7 @@
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
 #include "RecoLocalTracker/Records/interface/TrackerCPERecord.h"
 #include "RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h"
-#include "RecoLocalTracker/SiStripRecHitConverter/interface/StripCPE.h"  
+#include "RecoLocalTracker/SiStripRecHitConverter/interface/StripCPE.h"
 
 #include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
 #include "RecoTracker/Record/interface/TrackerRecoGeometryRecord.h"
@@ -42,200 +42,190 @@
 #include <map>
 #include <algorithm>
 
-
 //
 
 using namespace std;
 
 namespace {
 
-  class StrictWeakOrdering{
-    public:
-     bool operator() ( uint32_t p,const uint32_t& i) const {return p < i;}
+  class StrictWeakOrdering {
+  public:
+    bool operator()(uint32_t p, const uint32_t& i) const { return p < i; }
   };
 
-
   struct CmpTKD {
-    bool operator()(MeasurementDet const* rh, MeasurementDet const * lh) {
+    bool operator()(MeasurementDet const* rh, MeasurementDet const* lh) {
       return rh->fastGeomDet().geographicalId().rawId() < lh->fastGeomDet().geographicalId().rawId();
     }
-    bool operator()(MeasurementDet const & rh, MeasurementDet const &  lh) {
+    bool operator()(MeasurementDet const& rh, MeasurementDet const& lh) {
       return rh.fastGeomDet().geographicalId().rawId() < lh.fastGeomDet().geographicalId().rawId();
     }
   };
 
-  template<typename TKD>
-  void sortTKD( std::vector<TKD*> & det) {
-    std::sort(det.begin(),det.end(),CmpTKD());
+  template <typename TKD>
+  void sortTKD(std::vector<TKD*>& det) {
+    std::sort(det.begin(), det.end(), CmpTKD());
   }
-  template<typename TKD>
-  void sortTKD( std::vector<TKD> & det) {
-    std::sort(det.begin(),det.end(),CmpTKD());
+  template <typename TKD>
+  void sortTKD(std::vector<TKD>& det) {
+    std::sort(det.begin(), det.end(), CmpTKD());
   }
 
-}
+}  // namespace
 
-
-MeasurementTrackerImpl::MeasurementTrackerImpl(const edm::ParameterSet&              conf,
-				       const PixelClusterParameterEstimator* pixelCPE,
-				       const StripClusterParameterEstimator* stripCPE,
-				       const SiStripRecHitMatcher*  hitMatcher,
-				       const TrackerTopology*  trackerTopology,
-				       const TrackerGeometry*  trackerGeom,
-				       const GeometricSearchTracker* geometricSearchTracker,
-                                       const SiStripQuality *stripQuality,
-                                       int   stripQualityFlags,
-                                       int   stripQualityDebugFlags,
-                                       const SiPixelQuality *pixelQuality,
-                                       const SiPixelFedCabling *pixelCabling,
-                                       int   pixelQualityFlags,
-                                       int   pixelQualityDebugFlags,
-		                       const ClusterParameterEstimator<Phase2TrackerCluster1D>* phase2OTCPE):
-  MeasurementTracker(trackerGeom,geometricSearchTracker),
-  pset_(conf),
-  name_(conf.getParameter<std::string>("ComponentName")),
-  theStDetConditions(hitMatcher,stripCPE),
-  thePxDetConditions(pixelCPE),
-  thePhase2DetConditions(phase2OTCPE)
-{
+MeasurementTrackerImpl::MeasurementTrackerImpl(const edm::ParameterSet& conf,
+                                               const PixelClusterParameterEstimator* pixelCPE,
+                                               const StripClusterParameterEstimator* stripCPE,
+                                               const SiStripRecHitMatcher* hitMatcher,
+                                               const TrackerTopology* trackerTopology,
+                                               const TrackerGeometry* trackerGeom,
+                                               const GeometricSearchTracker* geometricSearchTracker,
+                                               const SiStripQuality* stripQuality,
+                                               int stripQualityFlags,
+                                               int stripQualityDebugFlags,
+                                               const SiPixelQuality* pixelQuality,
+                                               const SiPixelFedCabling* pixelCabling,
+                                               int pixelQualityFlags,
+                                               int pixelQualityDebugFlags,
+                                               const ClusterParameterEstimator<Phase2TrackerCluster1D>* phase2OTCPE)
+    : MeasurementTracker(trackerGeom, geometricSearchTracker),
+      pset_(conf),
+      name_(conf.getParameter<std::string>("ComponentName")),
+      theStDetConditions(hitMatcher, stripCPE),
+      thePxDetConditions(pixelCPE),
+      thePhase2DetConditions(phase2OTCPE) {
   this->initialize(trackerTopology);
   this->initializeStripStatus(stripQuality, stripQualityFlags, stripQualityDebugFlags);
   this->initializePixelStatus(pixelQuality, pixelCabling, pixelQualityFlags, pixelQualityDebugFlags);
 }
 
-MeasurementTrackerImpl::~MeasurementTrackerImpl()
-{
-}
+MeasurementTrackerImpl::~MeasurementTrackerImpl() {}
 
-
-void MeasurementTrackerImpl::initialize(const TrackerTopology* trackerTopology)
-{ 
-
+void MeasurementTrackerImpl::initialize(const TrackerTopology* trackerTopology) {
   bool subIsPixel = false;
   //FIXME:just temporary solution for phase2 :
   //the OT is defined as PixelSubDetector!
   bool subIsOT = false;
 
   //if the TkGeometry has the subDet vector filled, the theDetMap is filled, otherwise nothing should happen
-  if(!theTrackerGeom->detsPXB().empty()) {
-    subIsPixel = GeomDetEnumerators::isTrackerPixel(theTrackerGeom->geomDetSubDetector(theTrackerGeom->detsPXB().front()->geographicalId().subdetId()));
+  if (!theTrackerGeom->detsPXB().empty()) {
+    subIsPixel = GeomDetEnumerators::isTrackerPixel(
+        theTrackerGeom->geomDetSubDetector(theTrackerGeom->detsPXB().front()->geographicalId().subdetId()));
     addDets(theTrackerGeom->detsPXB(), subIsPixel, subIsOT);
   }
 
-  if(!theTrackerGeom->detsPXF().empty()) {
-    subIsPixel = GeomDetEnumerators::isTrackerPixel(theTrackerGeom->geomDetSubDetector(theTrackerGeom->detsPXF().front()->geographicalId().subdetId()));
+  if (!theTrackerGeom->detsPXF().empty()) {
+    subIsPixel = GeomDetEnumerators::isTrackerPixel(
+        theTrackerGeom->geomDetSubDetector(theTrackerGeom->detsPXF().front()->geographicalId().subdetId()));
     addDets(theTrackerGeom->detsPXF(), subIsPixel, subIsOT);
   }
 
   subIsOT = true;
 
-  if(!theTrackerGeom->detsTIB().empty()) {
-    subIsPixel = GeomDetEnumerators::isTrackerPixel(theTrackerGeom->geomDetSubDetector(theTrackerGeom->detsTIB().front()->geographicalId().subdetId()));
+  if (!theTrackerGeom->detsTIB().empty()) {
+    subIsPixel = GeomDetEnumerators::isTrackerPixel(
+        theTrackerGeom->geomDetSubDetector(theTrackerGeom->detsTIB().front()->geographicalId().subdetId()));
     addDets(theTrackerGeom->detsTIB(), subIsPixel, subIsOT);
   }
 
-  if(!theTrackerGeom->detsTID().empty()) {
-    subIsPixel = GeomDetEnumerators::isTrackerPixel(theTrackerGeom->geomDetSubDetector(theTrackerGeom->detsTID().front()->geographicalId().subdetId()));
+  if (!theTrackerGeom->detsTID().empty()) {
+    subIsPixel = GeomDetEnumerators::isTrackerPixel(
+        theTrackerGeom->geomDetSubDetector(theTrackerGeom->detsTID().front()->geographicalId().subdetId()));
     addDets(theTrackerGeom->detsTID(), subIsPixel, subIsOT);
   }
 
-  if(!theTrackerGeom->detsTOB().empty()) {
-    subIsPixel = GeomDetEnumerators::isTrackerPixel(theTrackerGeom->geomDetSubDetector(theTrackerGeom->detsTOB().front()->geographicalId().subdetId()));
+  if (!theTrackerGeom->detsTOB().empty()) {
+    subIsPixel = GeomDetEnumerators::isTrackerPixel(
+        theTrackerGeom->geomDetSubDetector(theTrackerGeom->detsTOB().front()->geographicalId().subdetId()));
     addDets(theTrackerGeom->detsTOB(), subIsPixel, subIsOT);
   }
 
-  if(!theTrackerGeom->detsTEC().empty()) { 
-    subIsPixel = GeomDetEnumerators::isTrackerPixel(theTrackerGeom->geomDetSubDetector(theTrackerGeom->detsTEC().front()->geographicalId().subdetId()));
+  if (!theTrackerGeom->detsTEC().empty()) {
+    subIsPixel = GeomDetEnumerators::isTrackerPixel(
+        theTrackerGeom->geomDetSubDetector(theTrackerGeom->detsTEC().front()->geographicalId().subdetId()));
     addDets(theTrackerGeom->detsTEC(), subIsPixel, subIsOT);
   }
 
   // fist all stripdets
   sortTKD(theStripDets);
   initStMeasurementConditionSet(theStripDets);
-  for (unsigned int i=0; i!=theStripDets.size(); ++i)
+  for (unsigned int i = 0; i != theStripDets.size(); ++i)
     theDetMap[theStDetConditions.id(i)] = &theStripDets[i];
-  
+
   // now the glued dets
   sortTKD(theGluedDets);
-  for (unsigned int i=0; i!=theGluedDets.size(); ++i)
+  for (unsigned int i = 0; i != theGluedDets.size(); ++i)
     initGluedDet(theGluedDets[i], trackerTopology);
 
   // then the pixels
   sortTKD(thePixelDets);
   initPxMeasurementConditionSet(thePixelDets);
-  for (unsigned int i=0; i!=thePixelDets.size(); ++i)
+  for (unsigned int i = 0; i != thePixelDets.size(); ++i)
     theDetMap[thePxDetConditions.id(i)] = &thePixelDets[i];
 
   // then the phase2 dets
   sortTKD(thePhase2Dets);
   initPhase2OTMeasurementConditionSet(thePhase2Dets);
-  for (unsigned int i=0; i!=thePhase2Dets.size(); ++i)
+  for (unsigned int i = 0; i != thePhase2Dets.size(); ++i)
     theDetMap[thePhase2DetConditions.id(i)] = &thePhase2Dets[i];
 
   // and then the stack dets, at last
   sortTKD(theStackDets);
-  for (unsigned int i=0; i!=theStackDets.size(); ++i)
+  for (unsigned int i = 0; i != theStackDets.size(); ++i)
     initStackDet(theStackDets[i]);
 
-  if(!checkDets())
+  if (!checkDets())
     throw MeasurementDetException("Number of dets in MeasurementTracker not consistent with TrackerGeometry!");
-
 }
 
-void MeasurementTrackerImpl::initStMeasurementConditionSet(std::vector<TkStripMeasurementDet> & stripDets)
-{
+void MeasurementTrackerImpl::initStMeasurementConditionSet(std::vector<TkStripMeasurementDet>& stripDets) {
   // assume vector is full and ordered!
   int size = stripDets.size();
   theStDetConditions.init(size);
-  for (int i=0; i!=size; ++i) {
-    auto & mdet =  stripDets[i]; 
+  for (int i = 0; i != size; ++i) {
+    auto& mdet = stripDets[i];
     mdet.setIndex(i);
     //intialize the detId !
     theStDetConditions.id_[i] = mdet.specificGeomDet().geographicalId().rawId();
-    theStDetConditions.subId_[i]=SiStripDetId(theStDetConditions.id_[i]).subdetId()-3;
+    theStDetConditions.subId_[i] = SiStripDetId(theStDetConditions.id_[i]).subdetId() - 3;
     //initalize the total number of strips
-    theStDetConditions.totalStrips_[i] =  mdet.specificGeomDet().specificTopology().nstrips();
+    theStDetConditions.totalStrips_[i] = mdet.specificGeomDet().specificTopology().nstrips();
   }
 }
 
-void MeasurementTrackerImpl::initPxMeasurementConditionSet(std::vector<TkPixelMeasurementDet> & pixelDets)
-{
+void MeasurementTrackerImpl::initPxMeasurementConditionSet(std::vector<TkPixelMeasurementDet>& pixelDets) {
   // assume vector is full and ordered!
   int size = pixelDets.size();
   thePxDetConditions.init(size);
 
-  for (int i=0; i!=size; ++i) {
-    auto & mdet =  pixelDets[i]; 
+  for (int i = 0; i != size; ++i) {
+    auto& mdet = pixelDets[i];
     mdet.setIndex(i);
     thePxDetConditions.id_[i] = mdet.specificGeomDet().geographicalId().rawId();
   }
 }
 
-void MeasurementTrackerImpl::initPhase2OTMeasurementConditionSet(std::vector<TkPhase2OTMeasurementDet> & phase2Dets)
-{
+void MeasurementTrackerImpl::initPhase2OTMeasurementConditionSet(std::vector<TkPhase2OTMeasurementDet>& phase2Dets) {
   // assume vector is full and ordered!
   int size = phase2Dets.size();
   thePhase2DetConditions.init(size);
 
-  for (int i=0; i!=size; ++i) {
-    auto & mdet =  phase2Dets[i]; 
+  for (int i = 0; i != size; ++i) {
+    auto& mdet = phase2Dets[i];
     mdet.setIndex(i);
     thePhase2DetConditions.id_[i] = mdet.specificGeomDet().geographicalId().rawId();
   }
 }
 
-void MeasurementTrackerImpl::addDets( const TrackingGeometry::DetContainer& dets, bool subIsPixel, bool subIsOT){
-
+void MeasurementTrackerImpl::addDets(const TrackingGeometry::DetContainer& dets, bool subIsPixel, bool subIsOT) {
   //in phase2, we can have composed subDetector made by Pixel or Strip
-  for (TrackerGeometry::DetContainer::const_iterator gd=dets.begin();
-       gd != dets.end(); gd++) {
-
+  for (TrackerGeometry::DetContainer::const_iterator gd = dets.begin(); gd != dets.end(); gd++) {
     const GeomDetUnit* gdu = dynamic_cast<const GeomDetUnit*>(*gd);
 
     //Pixel or Strip GeomDetUnit
     if (gdu->isLeaf()) {
-      if(subIsPixel) {
-        if(!subIsOT) {
+      if (subIsPixel) {
+        if (!subIsOT) {
           addPixelDet(*gd);
         } else {
           addPhase2Det(*gd);
@@ -244,7 +234,6 @@ void MeasurementTrackerImpl::addDets( const TrackingGeometry::DetContainer& dets
         addStripDet(*gd);
       }
     } else {
-
       //Glued or Stack GeomDet
       const GluedGeomDet* gluedDet = dynamic_cast<const GluedGeomDet*>(*gd);
       const StackGeomDet* stackDet = dynamic_cast<const StackGeomDet*>(*gd);
@@ -252,69 +241,58 @@ void MeasurementTrackerImpl::addDets( const TrackingGeometry::DetContainer& dets
       if ((gluedDet == nullptr && stackDet == nullptr) || (gluedDet != nullptr && stackDet != nullptr)) {
         throw MeasurementDetException("MeasurementTracker ERROR: GeomDet neither DetUnit nor GluedDet nor StackDet");
       }
-      if(gluedDet != nullptr)
+      if (gluedDet != nullptr)
         addGluedDet(gluedDet);
       else
         addStackDet(stackDet);
-
     }
   }
-
 }
 
-bool MeasurementTrackerImpl::checkDets(){
-  if(theTrackerGeom->dets().size() == theDetMap.size())
+bool MeasurementTrackerImpl::checkDets() {
+  if (theTrackerGeom->dets().size() == theDetMap.size())
     return true;
   return false;
 }
 
-void MeasurementTrackerImpl::addStripDet( const GeomDet* gd)
-{
+void MeasurementTrackerImpl::addStripDet(const GeomDet* gd) {
   try {
-    theStripDets.push_back(TkStripMeasurementDet( gd, theStDetConditions ));
-  }
-  catch(MeasurementDetException& err){
-    edm::LogError("MeasurementDet") << "Oops, got a MeasurementDetException: " << err.what() ;
+    theStripDets.push_back(TkStripMeasurementDet(gd, theStDetConditions));
+  } catch (MeasurementDetException& err) {
+    edm::LogError("MeasurementDet") << "Oops, got a MeasurementDetException: " << err.what();
   }
 }
 
-void MeasurementTrackerImpl::addPixelDet( const GeomDet* gd)
-{
+void MeasurementTrackerImpl::addPixelDet(const GeomDet* gd) {
   try {
-    thePixelDets.push_back(TkPixelMeasurementDet( gd, thePxDetConditions ));
-  }
-  catch(MeasurementDetException& err){
-    edm::LogError("MeasurementDet") << "Oops, got a MeasurementDetException: " << err.what() ;
+    thePixelDets.push_back(TkPixelMeasurementDet(gd, thePxDetConditions));
+  } catch (MeasurementDetException& err) {
+    edm::LogError("MeasurementDet") << "Oops, got a MeasurementDetException: " << err.what();
   }
 }
 
-void MeasurementTrackerImpl::addPhase2Det( const GeomDet* gd)
-{
+void MeasurementTrackerImpl::addPhase2Det(const GeomDet* gd) {
   try {
-    thePhase2Dets.push_back(TkPhase2OTMeasurementDet( gd, thePhase2DetConditions ));
-  }
-  catch(MeasurementDetException& err){
-    edm::LogError("MeasurementDet") << "Oops, got a MeasurementDetException: " << err.what() ;
+    thePhase2Dets.push_back(TkPhase2OTMeasurementDet(gd, thePhase2DetConditions));
+  } catch (MeasurementDetException& err) {
+    edm::LogError("MeasurementDet") << "Oops, got a MeasurementDetException: " << err.what();
   }
 }
 
-void MeasurementTrackerImpl::addGluedDet( const GluedGeomDet* gd)
-{
-  theGluedDets.push_back(TkGluedMeasurementDet( gd, theStDetConditions.matcher(), theStDetConditions.stripCPE() ));
+void MeasurementTrackerImpl::addGluedDet(const GluedGeomDet* gd) {
+  theGluedDets.push_back(TkGluedMeasurementDet(gd, theStDetConditions.matcher(), theStDetConditions.stripCPE()));
 }
 
-void MeasurementTrackerImpl::addStackDet( const StackGeomDet* gd)
-{
-  //since the Stack will be composed by PS or 2S, 
+void MeasurementTrackerImpl::addStackDet(const StackGeomDet* gd) {
+  //since the Stack will be composed by PS or 2S,
   //both cluster parameter estimators are needed? - right now just the thePixelCPE is used.
-  theStackDets.push_back(TkStackMeasurementDet( gd, thePxDetConditions.pixelCPE() ));
+  theStackDets.push_back(TkStackMeasurementDet(gd, thePxDetConditions.pixelCPE()));
 }
 
-void MeasurementTrackerImpl::initGluedDet( TkGluedMeasurementDet & det, const TrackerTopology* trackerTopology)
-{
+void MeasurementTrackerImpl::initGluedDet(TkGluedMeasurementDet& det, const TrackerTopology* trackerTopology) {
   const GluedGeomDet& gd = det.specificGeomDet();
-  const MeasurementDet* monoDet = findDet( gd.monoDet()->geographicalId());
-  const MeasurementDet* stereoDet = findDet( gd.stereoDet()->geographicalId());
+  const MeasurementDet* monoDet = findDet(gd.monoDet()->geographicalId());
+  const MeasurementDet* stereoDet = findDet(gd.stereoDet()->geographicalId());
   if (monoDet == nullptr || stereoDet == nullptr) {
     edm::LogError("MeasurementDet") << "MeasurementTracker ERROR: GluedDet components not found as MeasurementDets ";
     throw MeasurementDetException("MeasurementTracker ERROR: GluedDet components not found as MeasurementDets");
@@ -323,133 +301,140 @@ void MeasurementTrackerImpl::initGluedDet( TkGluedMeasurementDet & det, const Tr
   theDetMap[gd.geographicalId()] = &det;
 }
 
-void MeasurementTrackerImpl::initStackDet( TkStackMeasurementDet & det)
-{
+void MeasurementTrackerImpl::initStackDet(TkStackMeasurementDet& det) {
   const StackGeomDet& gd = det.specificGeomDet();
-  const MeasurementDet* lowerDet = findDet( gd.lowerDet()->geographicalId());
-  const MeasurementDet* upperDet = findDet( gd.upperDet()->geographicalId());
+  const MeasurementDet* lowerDet = findDet(gd.lowerDet()->geographicalId());
+  const MeasurementDet* upperDet = findDet(gd.upperDet()->geographicalId());
   if (lowerDet == nullptr || upperDet == nullptr) {
     edm::LogError("MeasurementDet") << "MeasurementTracker ERROR: StackDet components not found as MeasurementDets ";
     throw MeasurementDetException("MeasurementTracker ERROR: StackDet components not found as MeasurementDets");
   }
-  det.init(lowerDet,upperDet);
+  det.init(lowerDet, upperDet);
   theDetMap[gd.geographicalId()] = &det;
 }
 
-void MeasurementTrackerImpl::initializeStripStatus(const SiStripQuality *quality, int qualityFlags, int qualityDebugFlags) {
+void MeasurementTrackerImpl::initializeStripStatus(const SiStripQuality* quality,
+                                                   int qualityFlags,
+                                                   int qualityDebugFlags) {
   edm::ParameterSet cutPset = pset_.getParameter<edm::ParameterSet>("badStripCuts");
   if (qualityFlags & BadStrips) {
-     typedef StMeasurementConditionSet::BadStripCuts BadStripCuts;
-     theStDetConditions.badStripCuts_[SiStripDetId::TIB-3] = BadStripCuts(cutPset.getParameter<edm::ParameterSet>("TIB"));
-     theStDetConditions.badStripCuts_[SiStripDetId::TOB-3] = BadStripCuts(cutPset.getParameter<edm::ParameterSet>("TOB"));
-     theStDetConditions.badStripCuts_[SiStripDetId::TID-3] = BadStripCuts(cutPset.getParameter<edm::ParameterSet>("TID"));
-     theStDetConditions.badStripCuts_[SiStripDetId::TEC-3] = BadStripCuts(cutPset.getParameter<edm::ParameterSet>("TEC"));
+    typedef StMeasurementConditionSet::BadStripCuts BadStripCuts;
+    theStDetConditions.badStripCuts_[SiStripDetId::TIB - 3] =
+        BadStripCuts(cutPset.getParameter<edm::ParameterSet>("TIB"));
+    theStDetConditions.badStripCuts_[SiStripDetId::TOB - 3] =
+        BadStripCuts(cutPset.getParameter<edm::ParameterSet>("TOB"));
+    theStDetConditions.badStripCuts_[SiStripDetId::TID - 3] =
+        BadStripCuts(cutPset.getParameter<edm::ParameterSet>("TID"));
+    theStDetConditions.badStripCuts_[SiStripDetId::TEC - 3] =
+        BadStripCuts(cutPset.getParameter<edm::ParameterSet>("TEC"));
   }
   theStDetConditions.setMaskBad128StripBlocks((qualityFlags & MaskBad128StripBlocks) != 0);
-  
-  
-  if ((quality != nullptr) && (qualityFlags != 0))  {
+
+  if ((quality != nullptr) && (qualityFlags != 0)) {
     edm::LogInfo("MeasurementTracker") << "qualityFlags = " << qualityFlags;
-    unsigned int on = 0, tot = 0; 
-    unsigned int foff = 0, ftot = 0, aoff = 0, atot = 0; 
-    for (int i=0; i!= theStDetConditions.nDet(); i++) {
+    unsigned int on = 0, tot = 0;
+    unsigned int foff = 0, ftot = 0, aoff = 0, atot = 0;
+    for (int i = 0; i != theStDetConditions.nDet(); i++) {
       uint32_t detid = theStDetConditions.id(i);
       if (qualityFlags & BadModules) {
-	bool isOn = quality->IsModuleUsable(detid);
-	theStDetConditions.setActive(i,isOn);
-	tot++; on += (unsigned int) isOn;
-	if (qualityDebugFlags & BadModules) {
-	  edm::LogInfo("MeasurementTracker")<< "MeasurementTrackerImpl::initializeStripStatus : detid " << detid << " is " << (isOn ?  "on" : "off");
-	}
+        bool isOn = quality->IsModuleUsable(detid);
+        theStDetConditions.setActive(i, isOn);
+        tot++;
+        on += (unsigned int)isOn;
+        if (qualityDebugFlags & BadModules) {
+          edm::LogInfo("MeasurementTracker")
+              << "MeasurementTrackerImpl::initializeStripStatus : detid " << detid << " is " << (isOn ? "on" : "off");
+        }
       } else {
-	theStDetConditions.setActive(i,true);
+        theStDetConditions.setActive(i, true);
       }
       // first turn all APVs and fibers ON
-      theStDetConditions.set128StripStatus(i,true); 
+      theStDetConditions.set128StripStatus(i, true);
       if (qualityFlags & BadAPVFibers) {
-	short badApvs   = quality->getBadApvs(detid);
-	short badFibers = quality->getBadFibers(detid);
-	for (int j = 0; j < 6; j++) {
-	  atot++;
-	  if (badApvs & (1 << j)) {
-	    theStDetConditions.set128StripStatus(i,false, j);
-	    aoff++;
-	  }
-	}
-	for (int j = 0; j < 3; j++) {
-	  ftot++;
-             if (badFibers & (1 << j)) {
-	       theStDetConditions.set128StripStatus(i,false, 2*j);
-	       theStDetConditions.set128StripStatus(i,false, 2*j+1);
-	       foff++;
-             }
-	}
-      } 
-      auto & badStrips = theStDetConditions.getBadStripBlocks(i);
-       badStrips.clear();
-       if (qualityFlags & BadStrips) {
-	 SiStripBadStrip::Range range = quality->getRange(detid);
-	 for (SiStripBadStrip::ContainerIterator bit = range.first; bit != range.second; ++bit) {
-	   badStrips.push_back(quality->decode(*bit));
-	 }
-       }
+        short badApvs = quality->getBadApvs(detid);
+        short badFibers = quality->getBadFibers(detid);
+        for (int j = 0; j < 6; j++) {
+          atot++;
+          if (badApvs & (1 << j)) {
+            theStDetConditions.set128StripStatus(i, false, j);
+            aoff++;
+          }
+        }
+        for (int j = 0; j < 3; j++) {
+          ftot++;
+          if (badFibers & (1 << j)) {
+            theStDetConditions.set128StripStatus(i, false, 2 * j);
+            theStDetConditions.set128StripStatus(i, false, 2 * j + 1);
+            foff++;
+          }
+        }
+      }
+      auto& badStrips = theStDetConditions.getBadStripBlocks(i);
+      badStrips.clear();
+      if (qualityFlags & BadStrips) {
+        SiStripBadStrip::Range range = quality->getRange(detid);
+        for (SiStripBadStrip::ContainerIterator bit = range.first; bit != range.second; ++bit) {
+          badStrips.push_back(quality->decode(*bit));
+        }
+      }
     }
     if (qualityDebugFlags & BadModules) {
-      edm::LogInfo("MeasurementTracker StripModuleStatus") << 
-	" Total modules: " << tot << ", active " << on <<", inactive " << (tot - on);
+      edm::LogInfo("MeasurementTracker StripModuleStatus")
+          << " Total modules: " << tot << ", active " << on << ", inactive " << (tot - on);
     }
     if (qualityDebugFlags & BadAPVFibers) {
-      edm::LogInfo("MeasurementTracker StripAPVStatus") << 
-	" Total APVs: " << atot << ", active " << (atot-aoff) <<", inactive " << (aoff);
-        edm::LogInfo("MeasurementTracker StripFiberStatus") << 
-	  " Total Fibers: " << ftot << ", active " << (ftot-foff) <<", inactive " << (foff);
+      edm::LogInfo("MeasurementTracker StripAPVStatus")
+          << " Total APVs: " << atot << ", active " << (atot - aoff) << ", inactive " << (aoff);
+      edm::LogInfo("MeasurementTracker StripFiberStatus")
+          << " Total Fibers: " << ftot << ", active " << (ftot - foff) << ", inactive " << (foff);
     }
   } else {
-    for (int i=0; i!=theStDetConditions.nDet(); i++) {
-      theStDetConditions.setActive(i,true);          // module ON
-      theStDetConditions.set128StripStatus(i,true);  // all APVs and fibers ON
+    for (int i = 0; i != theStDetConditions.nDet(); i++) {
+      theStDetConditions.setActive(i, true);          // module ON
+      theStDetConditions.set128StripStatus(i, true);  // all APVs and fibers ON
     }
   }
-
 }
 
-void MeasurementTrackerImpl::initializePixelStatus(const SiPixelQuality *quality, const SiPixelFedCabling *pixelCabling, int qualityFlags, int qualityDebugFlags) {
-  if ((quality != nullptr) && (qualityFlags != 0))  {
+void MeasurementTrackerImpl::initializePixelStatus(const SiPixelQuality* quality,
+                                                   const SiPixelFedCabling* pixelCabling,
+                                                   int qualityFlags,
+                                                   int qualityDebugFlags) {
+  if ((quality != nullptr) && (qualityFlags != 0)) {
     edm::LogInfo("MeasurementTracker") << "qualityFlags = " << qualityFlags;
-    unsigned int on = 0, tot = 0, badrocs = 0; 
-    for (std::vector<TkPixelMeasurementDet>::iterator i=thePixelDets.begin();
-	 i!=thePixelDets.end(); i++) {
+    unsigned int on = 0, tot = 0, badrocs = 0;
+    for (std::vector<TkPixelMeasurementDet>::iterator i = thePixelDets.begin(); i != thePixelDets.end(); i++) {
       uint32_t detid = ((*i).geomDet().geographicalId()).rawId();
       if (qualityFlags & BadModules) {
-          bool isOn = quality->IsModuleUsable(detid);
-          (i)->setActive(isOn);
-          tot++; on += (unsigned int) isOn;
-          if (qualityDebugFlags & BadModules) {
-	    edm::LogInfo("MeasurementTracker")<< "MeasurementTrackerImpl::initializePixelStatus : detid " << detid << " is " << (isOn ?  "on" : "off");
-          }
-       } else {
-          (i)->setActive(true);
-       }
-       if ((qualityFlags & BadROCs) && (quality->getBadRocs(detid) != 0)) {
-          std::vector<LocalPoint> badROCs = quality->getBadRocPositions(detid, *theTrackerGeom, pixelCabling);
-          badrocs += badROCs.size();
-          (i)->setBadRocPositions(badROCs);
-       } else {
-          (i)->clearBadRocPositions();  
-       }
+        bool isOn = quality->IsModuleUsable(detid);
+        (i)->setActive(isOn);
+        tot++;
+        on += (unsigned int)isOn;
+        if (qualityDebugFlags & BadModules) {
+          edm::LogInfo("MeasurementTracker")
+              << "MeasurementTrackerImpl::initializePixelStatus : detid " << detid << " is " << (isOn ? "on" : "off");
+        }
+      } else {
+        (i)->setActive(true);
+      }
+      if ((qualityFlags & BadROCs) && (quality->getBadRocs(detid) != 0)) {
+        std::vector<LocalPoint> badROCs = quality->getBadRocPositions(detid, *theTrackerGeom, pixelCabling);
+        badrocs += badROCs.size();
+        (i)->setBadRocPositions(badROCs);
+      } else {
+        (i)->clearBadRocPositions();
+      }
     }
     if (qualityDebugFlags & BadModules) {
-        edm::LogInfo("MeasurementTracker PixelModuleStatus") << 
-            " Total modules: " << tot << ", active " << on <<", inactive " << (tot - on);
+      edm::LogInfo("MeasurementTracker PixelModuleStatus")
+          << " Total modules: " << tot << ", active " << on << ", inactive " << (tot - on);
     }
     if (qualityDebugFlags & BadROCs) {
-        edm::LogInfo("MeasurementTracker PixelROCStatus") << " Total of bad ROCs: " << badrocs ;
+      edm::LogInfo("MeasurementTracker PixelROCStatus") << " Total of bad ROCs: " << badrocs;
     }
   } else {
-    for (std::vector<TkPixelMeasurementDet>::iterator i=thePixelDets.begin();
-	 i!=thePixelDets.end(); i++) {
-      (i)->setActive(true);          // module ON
+    for (std::vector<TkPixelMeasurementDet>::iterator i = thePixelDets.begin(); i != thePixelDets.end(); i++) {
+      (i)->setActive(true);  // module ON
     }
   }
 }
-

--- a/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.h
+++ b/RecoTracker/MeasurementDet/plugins/MeasurementTrackerImpl.h
@@ -30,7 +30,6 @@
 #include <unordered_map>
 #include <vector>
 
-
 class TkStripMeasurementDet;
 class TkPixelMeasurementDet;
 class TkPhase2OTMeasurementDet;
@@ -44,72 +43,68 @@ class SiPixelFedCabling;
 
 class dso_hidden MeasurementTrackerImpl final : public MeasurementTracker {
 public:
-   enum QualityFlags { BadModules=1, // for everybody
-                       /* Strips: */ BadAPVFibers=2, BadStrips=4, MaskBad128StripBlocks=8, 
-                       /* Pixels: */ BadROCs=2 }; 
+  enum QualityFlags {
+    BadModules = 1,  // for everybody
+    /* Strips: */ BadAPVFibers = 2,
+    BadStrips = 4,
+    MaskBad128StripBlocks = 8,
+    /* Pixels: */ BadROCs = 2
+  };
 
-  MeasurementTrackerImpl(const edm::ParameterSet&              conf,
-		     const PixelClusterParameterEstimator* pixelCPE,
-		     const StripClusterParameterEstimator* stripCPE,
-		     const SiStripRecHitMatcher*  hitMatcher,
-		     const TrackerTopology*  trackerTopology,
-		     const TrackerGeometry*  trackerGeom,
-		     const GeometricSearchTracker* geometricSearchTracker,
-                     const SiStripQuality *stripQuality,
-                     int   stripQualityFlags,
-                     int   stripQualityDebugFlags,
-                     const SiPixelQuality *pixelQuality,
-                     const SiPixelFedCabling *pixelCabling,
-                     int   pixelQualityFlags,
-                     int   pixelQualityDebugFlags,
-		     const ClusterParameterEstimator<Phase2TrackerCluster1D>* phase2OTCPE = nullptr);
+  MeasurementTrackerImpl(const edm::ParameterSet& conf,
+                         const PixelClusterParameterEstimator* pixelCPE,
+                         const StripClusterParameterEstimator* stripCPE,
+                         const SiStripRecHitMatcher* hitMatcher,
+                         const TrackerTopology* trackerTopology,
+                         const TrackerGeometry* trackerGeom,
+                         const GeometricSearchTracker* geometricSearchTracker,
+                         const SiStripQuality* stripQuality,
+                         int stripQualityFlags,
+                         int stripQualityDebugFlags,
+                         const SiPixelQuality* pixelQuality,
+                         const SiPixelFedCabling* pixelCabling,
+                         int pixelQualityFlags,
+                         int pixelQualityDebugFlags,
+                         const ClusterParameterEstimator<Phase2TrackerCluster1D>* phase2OTCPE = nullptr);
 
   ~MeasurementTrackerImpl() override;
- 
-  const TrackingGeometry* geomTracker() const { return theTrackerGeom;}
 
-  const GeometricSearchTracker* geometricSearchTracker() const {return theGeometricSearchTracker;}
+  const TrackingGeometry* geomTracker() const { return theTrackerGeom; }
+
+  const GeometricSearchTracker* geometricSearchTracker() const { return theGeometricSearchTracker; }
 
   /// MeasurementDetSystem interface  (won't be overloaded anymore)
-  MeasurementDetWithData 
-  idToDet(const DetId& id, const MeasurementTrackerEvent &data) const override {
+  MeasurementDetWithData idToDet(const DetId& id, const MeasurementTrackerEvent& data) const override {
     return MeasurementDetWithData(*idToDetBare(id, data), data);
   }
 
-  const MeasurementDet * 
-  idToDetBare(const DetId& id, const MeasurementTrackerEvent &data) const {
-    return findDet(id);
-  }
+  const MeasurementDet* idToDetBare(const DetId& id, const MeasurementTrackerEvent& data) const { return findDet(id); }
 
-
-
-  const MeasurementDet* 
-  findDet(const DetId& id) const
-  {
+  const MeasurementDet* findDet(const DetId& id) const {
     auto it = theDetMap.find(id);
-    if(it !=theDetMap.end()) {
+    if (it != theDetMap.end()) {
       return it->second;
-    }else{
+    } else {
       //throw exception;
     }
-    
-    return nullptr; //to avoid compile warning
+
+    return nullptr;  //to avoid compile warning
   }
 
-  typedef std::unordered_map<unsigned int,MeasurementDet*>   DetContainer;
+  typedef std::unordered_map<unsigned int, MeasurementDet*> DetContainer;
 
-  /// For debug only 
-  const DetContainer& allDets() const {return theDetMap;}
-  const std::vector<TkStripMeasurementDet>& stripDets() const {return theStripDets;}
-  const std::vector<TkPixelMeasurementDet>& pixelDets() const {return thePixelDets;}
-  const std::vector<TkGluedMeasurementDet>& gluedDets() const {return theGluedDets;}
-  const std::vector<TkStackMeasurementDet>& stackDets() const {return theStackDets;}
+  /// For debug only
+  const DetContainer& allDets() const { return theDetMap; }
+  const std::vector<TkStripMeasurementDet>& stripDets() const { return theStripDets; }
+  const std::vector<TkPixelMeasurementDet>& pixelDets() const { return thePixelDets; }
+  const std::vector<TkGluedMeasurementDet>& gluedDets() const { return theGluedDets; }
+  const std::vector<TkStackMeasurementDet>& stackDets() const { return theStackDets; }
 
-  const StMeasurementConditionSet & stripDetConditions() const override { return theStDetConditions; }
-  const PxMeasurementConditionSet & pixelDetConditions() const override { return thePxDetConditions; }
-  const Phase2OTMeasurementConditionSet & phase2DetConditions() const override { return thePhase2DetConditions; }
+  const StMeasurementConditionSet& stripDetConditions() const override { return theStDetConditions; }
+  const PxMeasurementConditionSet& pixelDetConditions() const override { return thePxDetConditions; }
+  const Phase2OTMeasurementConditionSet& phase2DetConditions() const override { return thePhase2DetConditions; }
 
- protected:
+protected:
   const edm::ParameterSet& pset_;
   const std::string name_;
 
@@ -117,7 +112,7 @@ public:
   PxMeasurementConditionSet thePxDetConditions;
   Phase2OTMeasurementConditionSet thePhase2DetConditions;
 
-  DetContainer                        theDetMap;
+  DetContainer theDetMap;
 
   std::vector<TkPixelMeasurementDet> thePixelDets;
   std::vector<TkStripMeasurementDet> theStripDets;
@@ -125,31 +120,33 @@ public:
   std::vector<TkGluedMeasurementDet> theGluedDets;
   std::vector<TkStackMeasurementDet> theStackDets;
 
-  const SiPixelFedCabling*              thePixelCabling;
+  const SiPixelFedCabling* thePixelCabling;
 
   void initialize(const TrackerTopology* trackerTopology);
-  void initStMeasurementConditionSet(std::vector<TkStripMeasurementDet> & stripDets);
-  void initPxMeasurementConditionSet(std::vector<TkPixelMeasurementDet> & pixelDets);
-  void initPhase2OTMeasurementConditionSet(std::vector<TkPhase2OTMeasurementDet> & phase2Dets);
+  void initStMeasurementConditionSet(std::vector<TkStripMeasurementDet>& stripDets);
+  void initPxMeasurementConditionSet(std::vector<TkPixelMeasurementDet>& pixelDets);
+  void initPhase2OTMeasurementConditionSet(std::vector<TkPhase2OTMeasurementDet>& phase2Dets);
 
-  void addStripDet( const GeomDet* gd);
-  void addPixelDet( const GeomDet* gd);
-  void addPhase2Det( const GeomDet* gd);
+  void addStripDet(const GeomDet* gd);
+  void addPixelDet(const GeomDet* gd);
+  void addPhase2Det(const GeomDet* gd);
 
-  void addGluedDet( const GluedGeomDet* gd);
-  void addStackDet( const StackGeomDet* gd);
+  void addGluedDet(const GluedGeomDet* gd);
+  void addStackDet(const StackGeomDet* gd);
 
-  void initGluedDet( TkGluedMeasurementDet & det, const TrackerTopology* trackerTopology);
-  void initStackDet( TkStackMeasurementDet & det);
+  void initGluedDet(TkGluedMeasurementDet& det, const TrackerTopology* trackerTopology);
+  void initStackDet(TkStackMeasurementDet& det);
 
-  void addDets( const TrackingGeometry::DetContainer& dets, bool subIsPixel, bool subIsOT);
+  void addDets(const TrackingGeometry::DetContainer& dets, bool subIsPixel, bool subIsOT);
 
   bool checkDets();
 
+  void initializeStripStatus(const SiStripQuality* stripQuality, int qualityFlags, int qualityDebugFlags);
 
-  void initializeStripStatus (const SiStripQuality *stripQuality, int qualityFlags, int qualityDebugFlags);
-
-  void initializePixelStatus (const SiPixelQuality *stripQuality, const SiPixelFedCabling *pixelCabling, int qualityFlags, int qualityDebugFlags);
+  void initializePixelStatus(const SiPixelQuality* stripQuality,
+                             const SiPixelFedCabling* pixelCabling,
+                             int qualityFlags,
+                             int qualityDebugFlags);
 };
 
 #endif

--- a/RecoTracker/MeasurementDet/plugins/NonPropagatingDetMeasurements.cc
+++ b/RecoTracker/MeasurementDet/plugins/NonPropagatingDetMeasurements.cc
@@ -5,12 +5,10 @@
 #include "TrackingTools/MeasurementDet/interface/MeasurementDet.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/InvalidTransientRecHit.h"
 
-std::vector<TrajectoryMeasurement> 
-NonPropagatingDetMeasurements::get( const MeasurementDet& det,
-				    const TrajectoryStateOnSurface& stateOnThisDet,
-				    const MeasurementEstimator& est,
-                                    const MeasurementTrackerEvent &data) const
-{
+std::vector<TrajectoryMeasurement> NonPropagatingDetMeasurements::get(const MeasurementDet& det,
+                                                                      const TrajectoryStateOnSurface& stateOnThisDet,
+                                                                      const MeasurementEstimator& est,
+                                                                      const MeasurementTrackerEvent& data) const {
   throw cms::Exception("THIS SHOULD NOT BE CALLED");
   std::vector<TrajectoryMeasurement> result;
   /*

--- a/RecoTracker/MeasurementDet/plugins/NonPropagatingDetMeasurements.h
+++ b/RecoTracker/MeasurementDet/plugins/NonPropagatingDetMeasurements.h
@@ -12,11 +12,10 @@ class MeasurementEstimator;
 
 class dso_hidden NonPropagatingDetMeasurements {
 public:
-
-  std::vector<TrajectoryMeasurement> get( const MeasurementDet& det,
-					  const TrajectoryStateOnSurface& stateOnThisDet,
-					  const MeasurementEstimator& est,
-                                          const MeasurementTrackerEvent& data) const;
+  std::vector<TrajectoryMeasurement> get(const MeasurementDet& det,
+                                         const TrajectoryStateOnSurface& stateOnThisDet,
+                                         const MeasurementEstimator& est,
+                                         const MeasurementTrackerEvent& data) const;
 };
 
-#endif 
+#endif

--- a/RecoTracker/MeasurementDet/plugins/RecHitPropagator.cc
+++ b/RecoTracker/MeasurementDet/plugins/RecHitPropagator.cc
@@ -2,32 +2,30 @@
 #include "TrackingTools/GeomPropagators/interface/AnalyticalPropagator.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 
-TrajectoryStateOnSurface 
-RecHitPropagator::propagate( const TrackingRecHit& hit,
-			     const Plane& plane, 
-			     const TrajectoryStateOnSurface& ts) const
-{
+TrajectoryStateOnSurface RecHitPropagator::propagate(const TrackingRecHit& hit,
+                                                     const Plane& plane,
+                                                     const TrajectoryStateOnSurface& ts) const {
   const MagneticField& field = ts.globalParameters().magneticField();
-  AnalyticalPropagator prop( &field, anyDirection);
-  TrajectoryStateOnSurface tsNoErr = TrajectoryStateOnSurface( ts.globalParameters(), ts.surface());
-  TrajectoryStateOnSurface hitts = prop.propagate( tsNoErr, hit.det()->specificSurface());
+  AnalyticalPropagator prop(&field, anyDirection);
+  TrajectoryStateOnSurface tsNoErr = TrajectoryStateOnSurface(ts.globalParameters(), ts.surface());
+  TrajectoryStateOnSurface hitts = prop.propagate(tsNoErr, hit.det()->specificSurface());
 
   // LocalVector ldir = hit.det()->specificSurface().toLocal(ts.globalMomentum());
   LocalVector ldir = hitts.localMomentum();
-  LocalTrajectoryParameters ltp( hit.localPosition(), ldir, ts.charge());
+  LocalTrajectoryParameters ltp(hit.localPosition(), ldir, ts.charge());
   AlgebraicSymMatrix55 m;
   LocalError lhe = hit.localPositionError();
   m[3][3] = lhe.xx();
   m[3][4] = lhe.xy();
   m[4][4] = lhe.yy();
 
-  const double epsilon = 1.e-8; // very small errors on momentum and angle
+  const double epsilon = 1.e-8;  // very small errors on momentum and angle
   m[0][0] = epsilon;
   m[1][1] = epsilon;
   m[2][2] = epsilon;
-  LocalTrajectoryError lte( m);
+  LocalTrajectoryError lte(m);
 
-  TrajectoryStateOnSurface startingState( ltp, lte, hit.det()->specificSurface(), &field);
+  TrajectoryStateOnSurface startingState(ltp, lte, hit.det()->specificSurface(), &field);
 
-  return prop.propagate( startingState, plane);
+  return prop.propagate(startingState, plane);
 }

--- a/RecoTracker/MeasurementDet/plugins/RecHitPropagator.h
+++ b/RecoTracker/MeasurementDet/plugins/RecHitPropagator.h
@@ -9,32 +9,28 @@ class Plane;
 
 class dso_hidden RecHitPropagator {
 public:
-
-  TrajectoryStateOnSurface propagate( const TrackingRecHit& hit,
-				      const Plane& plane, 
-				      const TrajectoryStateOnSurface& ts) const;
-
+  TrajectoryStateOnSurface propagate(const TrackingRecHit& hit,
+                                     const Plane& plane,
+                                     const TrajectoryStateOnSurface& ts) const;
 };
 
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
 // propagate from glued to mono/stereo
-inline
-TrajectoryStateOnSurface fastProp(const TrajectoryStateOnSurface& ts, const Plane& oPlane, const Plane& tPlane) {
+inline TrajectoryStateOnSurface fastProp(const TrajectoryStateOnSurface& ts, const Plane& oPlane, const Plane& tPlane) {
   GlobalVector gdir = ts.globalMomentum();
-   
+
   double delta = tPlane.localZ(oPlane.position());
   LocalVector ldir = tPlane.toLocal(gdir);  // fast prop!
-  LocalPoint lPos = tPlane.toLocal( ts.globalPosition());
-  LocalPoint projectedPos = lPos - ldir * delta/ldir.z();
+  LocalPoint lPos = tPlane.toLocal(ts.globalPosition());
+  LocalPoint projectedPos = lPos - ldir * delta / ldir.z();
   // we can also patch it up as only the position-errors are used...
-  GlobalTrajectoryParameters gp(tPlane.toGlobal(projectedPos),gdir,ts.charge(), &ts.globalParameters().magneticField());
+  GlobalTrajectoryParameters gp(
+      tPlane.toGlobal(projectedPos), gdir, ts.charge(), &ts.globalParameters().magneticField());
   if (ts.hasError())
-    return TrajectoryStateOnSurface(gp,ts.curvilinearError(),tPlane);
+    return TrajectoryStateOnSurface(gp, ts.curvilinearError(), tPlane);
   else
-    return TrajectoryStateOnSurface(gp,tPlane);
-
-
+    return TrajectoryStateOnSurface(gp, tPlane);
 }
 
-#endif 
+#endif

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
@@ -17,18 +17,17 @@
 
 #include <typeinfo>
 
-
 namespace {
-  inline
-  std::pair<LocalPoint,LocalError> projectedPos(const TrackingRecHit& hit,
-                         const GeomDet& det,
-                         const GlobalVector & gdir, const StripClusterParameterEstimator* cpe) {
+  inline std::pair<LocalPoint, LocalError> projectedPos(const TrackingRecHit& hit,
+                                                        const GeomDet& det,
+                                                        const GlobalVector& gdir,
+                                                        const StripClusterParameterEstimator* cpe) {
     const BoundPlane& gluedPlane = det.surface();
     const BoundPlane& hitPlane = hit.det()->surface();
 
     // check if the planes are parallel
     //const float epsilon = 1.e-7; // corresponds to about 0.3 miliradian but cannot be reduced
-                                 // because of float precision
+    // because of float precision
 
     //if (fabs(gluedPlane.normalVector().dot( hitPlane.normalVector())) < 1-epsilon) {
     //       std::cout << "TkGluedMeasurementDet plane not parallel to DetUnit plane: dot product is "
@@ -37,508 +36,497 @@ namespace {
     //throw MeasurementDetException("TkGluedMeasurementDet plane not parallel to DetUnit plane");
     //}
 
-    double delta = gluedPlane.localZ( hitPlane.position());
+    double delta = gluedPlane.localZ(hitPlane.position());
     LocalVector ldir = gluedPlane.toLocal(gdir);
-    LocalPoint lhitPos = gluedPlane.toLocal( hit.globalPosition());
-    LocalPoint projectedHitPos = lhitPos - ldir * delta/ldir.z();                  
+    LocalPoint lhitPos = gluedPlane.toLocal(hit.globalPosition());
+    LocalPoint projectedHitPos = lhitPos - ldir * delta / ldir.z();
 
-    LocalVector hitXAxis = gluedPlane.toLocal( hitPlane.toGlobal( LocalVector(1,0,0)));
+    LocalVector hitXAxis = gluedPlane.toLocal(hitPlane.toGlobal(LocalVector(1, 0, 0)));
     LocalError hitErr = hit.localPositionError();
-    if (gluedPlane.normalVector().dot( hitPlane.normalVector()) < 0) {
+    if (gluedPlane.normalVector().dot(hitPlane.normalVector()) < 0) {
       // the two planes are inverted, and the correlation element must change sign
-      hitErr = LocalError( hitErr.xx(), -hitErr.xy(), hitErr.yy());
+      hitErr = LocalError(hitErr.xx(), -hitErr.xy(), hitErr.yy());
     }
-    LocalError rotatedError = hitErr.rotate( hitXAxis.x(), hitXAxis.y());
+    LocalError rotatedError = hitErr.rotate(hitXAxis.x(), hitXAxis.y());
 
     return std::make_pair(projectedHitPos, rotatedError);
   }
-}
+}  // namespace
 
 // #include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
 #include "TrackingTools/PatternTools/interface/TrajMeasLessEstim.h"
 
 using namespace std;
 
-TkGluedMeasurementDet::TkGluedMeasurementDet( const GluedGeomDet* gdet, 
-					      const SiStripRecHitMatcher* matcher,
-                                              const StripClusterParameterEstimator* cpe) :
-  MeasurementDet(gdet), 
-  theMatcher(matcher),  theCPE(cpe),
-  theMonoDet(nullptr), theStereoDet(nullptr),
-  theTopology(nullptr)
-{}
+TkGluedMeasurementDet::TkGluedMeasurementDet(const GluedGeomDet* gdet,
+                                             const SiStripRecHitMatcher* matcher,
+                                             const StripClusterParameterEstimator* cpe)
+    : MeasurementDet(gdet),
+      theMatcher(matcher),
+      theCPE(cpe),
+      theMonoDet(nullptr),
+      theStereoDet(nullptr),
+      theTopology(nullptr) {}
 
 void TkGluedMeasurementDet::init(const MeasurementDet* monoDet,
-				 const MeasurementDet* stereoDet,
+                                 const MeasurementDet* stereoDet,
                                  const TrackerTopology* tTopo) {
-  theMonoDet = dynamic_cast<const TkStripMeasurementDet *>(monoDet);
-  theStereoDet = dynamic_cast<const TkStripMeasurementDet *>(stereoDet);
+  theMonoDet = dynamic_cast<const TkStripMeasurementDet*>(monoDet);
+  theStereoDet = dynamic_cast<const TkStripMeasurementDet*>(stereoDet);
   theTopology = tTopo;
-  
+
   if ((theMonoDet == nullptr) || (theStereoDet == nullptr)) {
-    throw MeasurementDetException("TkGluedMeasurementDet ERROR: Trying to glue a det which is not a TkStripMeasurementDet");
+    throw MeasurementDetException(
+        "TkGluedMeasurementDet ERROR: Trying to glue a det which is not a TkStripMeasurementDet");
   }
 }
 
-TkGluedMeasurementDet::RecHitContainer 
-TkGluedMeasurementDet::recHits( const TrajectoryStateOnSurface& ts, const MeasurementTrackerEvent & data) const
-{
-  
+TkGluedMeasurementDet::RecHitContainer TkGluedMeasurementDet::recHits(const TrajectoryStateOnSurface& ts,
+                                                                      const MeasurementTrackerEvent& data) const {
   RecHitContainer result;
-  HitCollectorForRecHits collector( &fastGeomDet(), theMatcher, theCPE, result );
+  HitCollectorForRecHits collector(&fastGeomDet(), theMatcher, theCPE, result);
   collectRecHits(ts, data, collector);
   return result;
 }
 
-
 // simple hits
-bool TkGluedMeasurementDet::recHits(SimpleHitContainer & result,  
-				    const TrajectoryStateOnSurface& stateOnThisDet, 
-				    const MeasurementEstimator& est, const MeasurementTrackerEvent & data) const {
-  if UNLIKELY((!theMonoDet->isActive(data)) && (!theStereoDet->isActive(data))) return false;
+bool TkGluedMeasurementDet::recHits(SimpleHitContainer& result,
+                                    const TrajectoryStateOnSurface& stateOnThisDet,
+                                    const MeasurementEstimator& est,
+                                    const MeasurementTrackerEvent& data) const {
+  if
+    UNLIKELY((!theMonoDet->isActive(data)) && (!theStereoDet->isActive(data))) return false;
   auto oldSize = result.size();
-  HitCollectorForSimpleHits collector( &fastGeomDet(), theMatcher, theCPE, stateOnThisDet, est, result);
+  HitCollectorForSimpleHits collector(&fastGeomDet(), theMatcher, theCPE, stateOnThisDet, est, result);
   collectRecHits(stateOnThisDet, data, collector);
-  
-  return result.size()>oldSize;
-  
+
+  return result.size() > oldSize;
 }
 
-
-
-
-bool TkGluedMeasurementDet::measurements( const TrajectoryStateOnSurface& stateOnThisDet,
-					  const MeasurementEstimator& est,
-                                          const MeasurementTrackerEvent & data,
-					  TempMeasurements & result) const {
-  
-  if UNLIKELY((!theMonoDet->isActive(data)) && (!theStereoDet->isActive(data))) {
-       //     LogDebug("TkStripMeasurementDet") << " DetID " << geomDet().geographicalId().rawId() << " (glued) fully inactive";
-       result.add(theInactiveHit, 0.F);
-       return true;
+bool TkGluedMeasurementDet::measurements(const TrajectoryStateOnSurface& stateOnThisDet,
+                                         const MeasurementEstimator& est,
+                                         const MeasurementTrackerEvent& data,
+                                         TempMeasurements& result) const {
+  if
+    UNLIKELY((!theMonoDet->isActive(data)) && (!theStereoDet->isActive(data))) {
+      //     LogDebug("TkStripMeasurementDet") << " DetID " << geomDet().geographicalId().rawId() << " (glued) fully inactive";
+      result.add(theInactiveHit, 0.F);
+      return true;
     }
-  
-   auto oldSize = result.size();
 
-   HitCollectorForFastMeasurements collector( &fastGeomDet(), theMatcher, theCPE, stateOnThisDet, est, result);
-   collectRecHits(stateOnThisDet, data, collector);
-   
-   
-   if (result.size()>oldSize) return true;
-   
-   auto id = geomDet().geographicalId().subdetId()-3;
-   auto l = theTopology->tobLayer(geomDet().geographicalId());
-   bool killHIP = (1==l) && (2==id); //TOB1
-   killHIP &= stateOnThisDet.globalMomentum().perp2()>est.minPt2ForHitRecoveryInGluedDet();
-   if (killHIP) {
-        result.add(theInactiveHit, 0.F); 
-        return true;
-   }
+  auto oldSize = result.size();
 
+  HitCollectorForFastMeasurements collector(&fastGeomDet(), theMatcher, theCPE, stateOnThisDet, est, result);
+  collectRecHits(stateOnThisDet, data, collector);
 
-   //LogDebug("TkStripMeasurementDet") << "No hit found on TkGlued. Testing strips...  ";
-   const BoundPlane &gluedPlane = geomDet().surface();
-   if (  // sorry for the big IF, but I want to exploit short-circuiting of logic
-       stateOnThisDet.hasError() && ( /* do this only if the state has uncertainties, otherwise it will throw 
+  if (result.size() > oldSize)
+    return true;
+
+  auto id = geomDet().geographicalId().subdetId() - 3;
+  auto l = theTopology->tobLayer(geomDet().geographicalId());
+  bool killHIP = (1 == l) && (2 == id);  //TOB1
+  killHIP &= stateOnThisDet.globalMomentum().perp2() > est.minPt2ForHitRecoveryInGluedDet();
+  if (killHIP) {
+    result.add(theInactiveHit, 0.F);
+    return true;
+  }
+
+  //LogDebug("TkStripMeasurementDet") << "No hit found on TkGlued. Testing strips...  ";
+  const BoundPlane& gluedPlane = geomDet().surface();
+  if (  // sorry for the big IF, but I want to exploit short-circuiting of logic
+      stateOnThisDet.hasError() &&
+      (/* do this only if the state has uncertainties, otherwise it will throw 
 					 (states without uncertainties are passed to this code from seeding */
-				     (theMonoDet->isActive(data) && 
-				      (theMonoDet->hasAllGoodChannels() || 
-				       testStrips(stateOnThisDet,gluedPlane,*theMonoDet)
-				       )
-				      ) /*Mono OK*/ 
-                                     && // was || 
-				     (theStereoDet->isActive(data) && 
-				      (theStereoDet->hasAllGoodChannels() || 
-				       testStrips(stateOnThisDet,gluedPlane,*theStereoDet)
-				       )
-				      ) /*Stereo OK*/ 
-				      ) /* State has errors */
-	 ) {
-     result.add(theMissingHit, 0.F);
-     return false;
-   } 
-   result.add(theInactiveHit, 0.F);
-   return true;
-   
+       (theMonoDet->isActive(data) &&
+        (theMonoDet->hasAllGoodChannels() || testStrips(stateOnThisDet, gluedPlane, *theMonoDet))) /*Mono OK*/
+       &&                                                                                          // was ||
+       (theStereoDet->isActive(data) &&
+        (theStereoDet->hasAllGoodChannels() || testStrips(stateOnThisDet, gluedPlane, *theStereoDet))) /*Stereo OK*/
+       ) /* State has errors */
+  ) {
+    result.add(theMissingHit, 0.F);
+    return false;
+  }
+  result.add(theInactiveHit, 0.F);
+  return true;
 }
 
-
-struct take_address { template<typename T> const T * operator()(const T &val) const { return &val; } };
+struct take_address {
+  template <typename T>
+  const T* operator()(const T& val) const {
+    return &val;
+  }
+};
 
 #ifdef DOUBLE_MATCH
-template<typename Collector>
-void
-TkGluedMeasurementDet::collectRecHits( const TrajectoryStateOnSurface& ts, const MeasurementTrackerEvent & data, Collector & collector) const
-{
-  doubleMatch(ts,data,collector);
+template <typename Collector>
+void TkGluedMeasurementDet::collectRecHits(const TrajectoryStateOnSurface& ts,
+                                           const MeasurementTrackerEvent& data,
+                                           Collector& collector) const {
+  doubleMatch(ts, data, collector);
 }
 #else
-template<typename Collector>
-void
-TkGluedMeasurementDet::collectRecHits( const TrajectoryStateOnSurface& ts, const MeasurementTrackerEvent & data, Collector & collector) const
-{
+template <typename Collector>
+void TkGluedMeasurementDet::collectRecHits(const TrajectoryStateOnSurface& ts,
+                                           const MeasurementTrackerEvent& data,
+                                           Collector& collector) const {
   //------ WARNING: here ts is used as it is on the mono/stereo surface.
   //-----           A further propagation is necessary.
   //-----           To limit the problem, the SimpleCPE should be used
-  RecHitContainer monoHits = theMonoDet->recHits( ts, data );
-  GlobalVector glbDir = (ts.isValid() ? ts.globalParameters().momentum() : position()-GlobalPoint(0,0,0));
-  
+  RecHitContainer monoHits = theMonoDet->recHits(ts, data);
+  GlobalVector glbDir = (ts.isValid() ? ts.globalParameters().momentum() : position() - GlobalPoint(0, 0, 0));
+
   //edm::LogWarning("TkGluedMeasurementDet::recHits") << "Query-for-detid-" << theGeomDet->geographicalId().rawId();
-  
+
   //checkProjection(ts, monoHits, stereoHits);
-  
+
   if (monoHits.empty()) {
-      // make stereo TTRHs and project them
-      projectOnGluedDet( collector, theStereoDet->recHits(ts, data), glbDir);
+    // make stereo TTRHs and project them
+    projectOnGluedDet(collector, theStereoDet->recHits(ts, data), glbDir);
   } else {
     // collect simple stereo hits
     std::vector<SiStripRecHit2D> simpleSteroHitsByValue;
     theStereoDet->simpleRecHits(ts, data, simpleSteroHitsByValue);
-    
+
     if (simpleSteroHitsByValue.empty()) {
-      projectOnGluedDet( collector, monoHits, glbDir);
+      projectOnGluedDet(collector, monoHits, glbDir);
     } else {
-      
-      LocalVector tkDir = (ts.isValid() ? ts.localDirection() : surface().toLocal( position()-GlobalPoint(0,0,0)));
+      LocalVector tkDir = (ts.isValid() ? ts.localDirection() : surface().toLocal(position() - GlobalPoint(0, 0, 0)));
       SiStripRecHitMatcher::SimpleHitCollection vsStereoHits;
       vsStereoHits.resize(simpleSteroHitsByValue.size());
-      std::transform(simpleSteroHitsByValue.begin(), simpleSteroHitsByValue.end(), vsStereoHits.begin(), take_address()); 
-      
+      std::transform(
+          simpleSteroHitsByValue.begin(), simpleSteroHitsByValue.end(), vsStereoHits.begin(), take_address());
+
       // convert mono hits to type expected by matcher
-      for (RecHitContainer::const_iterator monoHit = monoHits.begin();
-	   monoHit != monoHits.end(); ++monoHit) {
-	const TrackingRecHit* tkhit = (**monoHit).hit();
-	const SiStripRecHit2D* verySpecificMonoHit = reinterpret_cast<const SiStripRecHit2D*>(tkhit);
-	theMatcher->match( verySpecificMonoHit, vsStereoHits.begin(), vsStereoHits.end(), 
-			   collector.collector(), &specificGeomDet(), tkDir);
-	
-	if (collector.hasNewMatchedHits()) {
-	  collector.clearNewMatchedHitsFlag();
-	} else {
-	  collector.addProjected( **monoHit, glbDir );
-	}
-      } // loop on mono hit
+      for (RecHitContainer::const_iterator monoHit = monoHits.begin(); monoHit != monoHits.end(); ++monoHit) {
+        const TrackingRecHit* tkhit = (**monoHit).hit();
+        const SiStripRecHit2D* verySpecificMonoHit = reinterpret_cast<const SiStripRecHit2D*>(tkhit);
+        theMatcher->match(verySpecificMonoHit,
+                          vsStereoHits.begin(),
+                          vsStereoHits.end(),
+                          collector.collector(),
+                          &specificGeomDet(),
+                          tkDir);
+
+        if (collector.hasNewMatchedHits()) {
+          collector.clearNewMatchedHitsFlag();
+        } else {
+          collector.addProjected(**monoHit, glbDir);
+        }
+      }  // loop on mono hit
     }
     //GIO// std::cerr << "TkGluedMeasurementDet hits " << monoHits.size() << "/" << stereoHits.size() << " => " << result.size() << std::endl;
   }
 }
 #endif
 
-#include<cstdint>
+#include <cstdint>
 #ifdef VI_STAT
-#include<cstdio>
+#include <cstdio>
 #endif
 namespace {
   struct Stat {
 #ifdef VI_STAT
-    double totCall=0;
-    double totMono=0;
-    double totStereo=0;
-    double totComb=0;
-    double totMatched=0;
-    double filtMono=0;
-    double filtStereo=0;
-    double filtComb=0;
-    double matchT=0;
-    double matchF=0;
-    double singleF=0;
-    double zeroM=0;
-    double zeroS=0;
+    double totCall = 0;
+    double totMono = 0;
+    double totStereo = 0;
+    double totComb = 0;
+    double totMatched = 0;
+    double filtMono = 0;
+    double filtStereo = 0;
+    double filtComb = 0;
+    double matchT = 0;
+    double matchF = 0;
+    double singleF = 0;
+    double zeroM = 0;
+    double zeroS = 0;
 
     void match(uint64_t t) {
-      if(t!=0) ++matchT;
-      totMatched+=t;
+      if (t != 0)
+        ++matchT;
+      totMatched += t;
     }
-    void operator()(uint64_t m,uint64_t s, uint64_t fm, uint64_t fs) {
-      ++totCall; 
-      totMono+=m;
-      totStereo+=s;
-      totComb += m*s;
-      filtMono+=fm;
-      filtStereo+=fs;
-      filtComb += fm*fs;
-      if(fm==0) ++zeroM;
-      if(fs==0) ++zeroS;
-      if(fm!=0&&fs!=0) ++matchF;
-      if(fm!=0||fs!=0) ++singleF;
+    void operator()(uint64_t m, uint64_t s, uint64_t fm, uint64_t fs) {
+      ++totCall;
+      totMono += m;
+      totStereo += s;
+      totComb += m * s;
+      filtMono += fm;
+      filtStereo += fs;
+      filtComb += fm * fs;
+      if (fm == 0)
+        ++zeroM;
+      if (fs == 0)
+        ++zeroS;
+      if (fm != 0 && fs != 0)
+        ++matchF;
+      if (fm != 0 || fs != 0)
+        ++singleF;
     }
     ~Stat() {
-      if ( totCall>0)
-	printf("Matches:%d/%d/%d/%d/%d/%d : %f/%f/%f/%f/%f/%f/%f\n",
-	       int(totCall),int(matchF),int(singleF-matchF),int(matchT),int(zeroM),int(zeroS),
-	       totMono/totCall,totStereo/totCall,totComb/totCall,totMatched/matchT,
-	       filtMono/totCall,filtStereo/totCall,filtComb/matchF);
+      if (totCall > 0)
+        printf("Matches:%d/%d/%d/%d/%d/%d : %f/%f/%f/%f/%f/%f/%f\n",
+               int(totCall),
+               int(matchF),
+               int(singleF - matchF),
+               int(matchT),
+               int(zeroM),
+               int(zeroS),
+               totMono / totCall,
+               totStereo / totCall,
+               totComb / totCall,
+               totMatched / matchT,
+               filtMono / totCall,
+               filtStereo / totCall,
+               filtComb / matchF);
     }
 #else
-   Stat(){}
-   void match(uint64_t) const{}
-   void operator()(uint64_t,uint64_t, uint64_t, uint64_t) const {}
+    Stat() {}
+    void match(uint64_t) const {}
+    void operator()(uint64_t, uint64_t, uint64_t, uint64_t) const {}
 #endif
   };
 #ifndef VI_STAT
   const
 #endif
-  Stat stat;
-}
+      Stat stat;
+}  // namespace
 
-
-
-
-TkGluedMeasurementDet::RecHitContainer 
-TkGluedMeasurementDet::projectOnGluedDet( const RecHitContainer& hits,
-					  const TrajectoryStateOnSurface& ts) const
-{
+TkGluedMeasurementDet::RecHitContainer TkGluedMeasurementDet::projectOnGluedDet(
+    const RecHitContainer& hits, const TrajectoryStateOnSurface& ts) const {
   RecHitContainer result;
-  for ( auto const & hit : hits) {
-    auto && vl = projectedPos(*hit, fastGeomDet(), ts.globalParameters().momentum(),  theCPE);
-    auto && phit = std::make_shared<ProjectedSiStripRecHit2D> (vl.first,vl.second, fastGeomDet(), static_cast<SiStripRecHit2D const &>(*hit));
+  for (auto const& hit : hits) {
+    auto&& vl = projectedPos(*hit, fastGeomDet(), ts.globalParameters().momentum(), theCPE);
+    auto&& phit = std::make_shared<ProjectedSiStripRecHit2D>(
+        vl.first, vl.second, fastGeomDet(), static_cast<SiStripRecHit2D const&>(*hit));
     result.push_back(std::move(phit));
   }
   return result;
 }
 
-template<typename Collector>
-void 
-TkGluedMeasurementDet::projectOnGluedDet( Collector& collector,
-                                          const RecHitContainer& hits,
-                                          const GlobalVector & gdir ) const 
-{
-  for ( RecHitContainer::const_iterator ihit = hits.begin(); ihit!=hits.end(); ihit++) {
-    collector.addProjected( **ihit, gdir );
+template <typename Collector>
+void TkGluedMeasurementDet::projectOnGluedDet(Collector& collector,
+                                              const RecHitContainer& hits,
+                                              const GlobalVector& gdir) const {
+  for (RecHitContainer::const_iterator ihit = hits.begin(); ihit != hits.end(); ihit++) {
+    collector.addProjected(**ihit, gdir);
   }
 }
 
-TkGluedMeasurementDet::RecHitContainer 
-TkGluedMeasurementDet::projectOnGluedDet( std::vector<SiStripRecHit2D> const & hits,
-					  const TrajectoryStateOnSurface& ts) const
-{
+TkGluedMeasurementDet::RecHitContainer TkGluedMeasurementDet::projectOnGluedDet(
+    std::vector<SiStripRecHit2D> const& hits, const TrajectoryStateOnSurface& ts) const {
   RecHitContainer result;
-  for ( auto const & hit : hits) {
-    auto && vl = projectedPos(hit, fastGeomDet(), ts.globalParameters().momentum(),  theCPE);
-    auto && phit = std::make_shared<ProjectedSiStripRecHit2D> (vl.first,vl.second,fastGeomDet(), static_cast<SiStripRecHit2D const &>(hit));
+  for (auto const& hit : hits) {
+    auto&& vl = projectedPos(hit, fastGeomDet(), ts.globalParameters().momentum(), theCPE);
+    auto&& phit = std::make_shared<ProjectedSiStripRecHit2D>(
+        vl.first, vl.second, fastGeomDet(), static_cast<SiStripRecHit2D const&>(hit));
     result.push_back(std::move(phit));
   }
   return result;
 }
 
-template<typename Collector>
-void 
-TkGluedMeasurementDet::projectOnGluedDet( Collector& collector,
-                                          std::vector<SiStripRecHit2D> const & hits,
-                                          const GlobalVector & gdir ) const 
-{
-  for ( auto const & hit : hits)
-    collector.addProjected(hit, gdir );
+template <typename Collector>
+void TkGluedMeasurementDet::projectOnGluedDet(Collector& collector,
+                                              std::vector<SiStripRecHit2D> const& hits,
+                                              const GlobalVector& gdir) const {
+  for (auto const& hit : hits)
+    collector.addProjected(hit, gdir);
 }
 
-
-
-
-
-void TkGluedMeasurementDet::checkProjection(const TrajectoryStateOnSurface& ts, 
-					    const RecHitContainer& monoHits, 
-					    const RecHitContainer& stereoHits) const
-{
-  for (RecHitContainer::const_iterator i=monoHits.begin(); i != monoHits.end(); ++i) {
-    checkHitProjection( **i, ts, fastGeomDet());
+void TkGluedMeasurementDet::checkProjection(const TrajectoryStateOnSurface& ts,
+                                            const RecHitContainer& monoHits,
+                                            const RecHitContainer& stereoHits) const {
+  for (RecHitContainer::const_iterator i = monoHits.begin(); i != monoHits.end(); ++i) {
+    checkHitProjection(**i, ts, fastGeomDet());
   }
-  for (RecHitContainer::const_iterator i=stereoHits.begin(); i != stereoHits.end(); ++i) {
-    checkHitProjection( **i, ts, fastGeomDet());
+  for (RecHitContainer::const_iterator i = stereoHits.begin(); i != stereoHits.end(); ++i) {
+    checkHitProjection(**i, ts, fastGeomDet());
   }
 }
 
 void TkGluedMeasurementDet::checkHitProjection(const TrackingRecHit& hit,
-					       const TrajectoryStateOnSurface& ts, 
-					       const GeomDet& det) const
-{
-  auto && vl = projectedPos(hit, det, ts.globalParameters().momentum(),  theCPE);
-  ProjectedSiStripRecHit2D projectedHit(vl.first,vl.second, det, static_cast<SiStripRecHit2D const &>(hit));
-  
+                                               const TrajectoryStateOnSurface& ts,
+                                               const GeomDet& det) const {
+  auto&& vl = projectedPos(hit, det, ts.globalParameters().momentum(), theCPE);
+  ProjectedSiStripRecHit2D projectedHit(vl.first, vl.second, det, static_cast<SiStripRecHit2D const&>(hit));
+
   RecHitPropagator prop;
-  TrajectoryStateOnSurface propState = prop.propagate( hit, det.surface(), ts);
-  
-  if ((projectedHit.localPosition()-propState.localPosition()).mag() > 0.0001f) {
-    std::cout << "PROBLEM: projected and propagated hit positions differ by " 
-	      << (projectedHit.localPosition()-propState.localPosition()).mag() << std::endl;
+  TrajectoryStateOnSurface propState = prop.propagate(hit, det.surface(), ts);
+
+  if ((projectedHit.localPosition() - propState.localPosition()).mag() > 0.0001f) {
+    std::cout << "PROBLEM: projected and propagated hit positions differ by "
+              << (projectedHit.localPosition() - propState.localPosition()).mag() << std::endl;
   }
-  
+
   LocalError le1 = projectedHit.localPositionError();
   LocalError le2 = propState.localError().positionError();
   double eps = 1.e-5;
-  double cutoff = 1.e-4; // if element below cutoff, use absolute instead of relative accuracy
-  double maxdiff = std::max( std::max( fabs(le1.xx() - le2.xx())/(cutoff+le1.xx()),
-				       fabs(le1.xy() - le2.xy())/(cutoff+fabs(le1.xy()))),
-			     fabs(le1.yy() - le2.yy())/(cutoff+le1.xx()));  
-  if (maxdiff > eps) { 
-    std::cout << "PROBLEM: projected and propagated hit errors differ by " 
-	      << maxdiff << std::endl;
+  double cutoff = 1.e-4;  // if element below cutoff, use absolute instead of relative accuracy
+  double maxdiff = std::max(
+      std::max(fabs(le1.xx() - le2.xx()) / (cutoff + le1.xx()), fabs(le1.xy() - le2.xy()) / (cutoff + fabs(le1.xy()))),
+      fabs(le1.yy() - le2.yy()) / (cutoff + le1.xx()));
+  if (maxdiff > eps) {
+    std::cout << "PROBLEM: projected and propagated hit errors differ by " << maxdiff << std::endl;
   }
-  
 }
 
-bool
-TkGluedMeasurementDet::testStrips(const TrajectoryStateOnSurface& tsos,
-                                  const BoundPlane &gluedPlane,
-                                  const TkStripMeasurementDet &mdet) const {
+bool TkGluedMeasurementDet::testStrips(const TrajectoryStateOnSurface& tsos,
+                                       const BoundPlane& gluedPlane,
+                                       const TkStripMeasurementDet& mdet) const {
   // from TrackingRecHitProjector
-  const GeomDet &det = mdet.fastGeomDet();
-  const BoundPlane &stripPlane = det.surface();
+  const GeomDet& det = mdet.fastGeomDet();
+  const BoundPlane& stripPlane = det.surface();
 
-   //LocalPoint glp = tsos.localPosition();
-  LocalError  err = tsos.localError().positionError();
+  //LocalPoint glp = tsos.localPosition();
+  LocalError err = tsos.localError().positionError();
   /*LogDebug("TkStripMeasurementDet") << 
     "Testing local pos glued: " << glp << 
     " local err glued: " << tsos.localError().positionError() << 
       " in? " << gluedPlane.bounds().inside(glp) <<
       " in(3s)? " << gluedPlane.bounds().inside(glp, err, 3.0f);*/
-  
+
   GlobalVector gdir = tsos.globalParameters().momentum();
-  
-  LocalPoint  slp = stripPlane.toLocal(tsos.globalPosition()); 
+
+  LocalPoint slp = stripPlane.toLocal(tsos.globalPosition());
   LocalVector sld = stripPlane.toLocal(gdir);
-  
-  double delta = stripPlane.localZ( tsos.globalPosition());
-  LocalPoint pos = slp - sld * delta/sld.z();
-  
-  
-   // now the error
-   LocalVector hitXAxis = stripPlane.toLocal( gluedPlane.toGlobal( LocalVector(1,0,0)));
-   if (stripPlane.normalVector().dot( gluedPlane.normalVector()) < 0) {
-     // the two planes are inverted, and the correlation element must change sign
-     err = LocalError( err.xx(), -err.xy(), err.yy());
-   }
-   LocalError rotatedError = err.rotate( hitXAxis.x(), hitXAxis.y());
-   
-   /* // This is probably meaningless 
+
+  double delta = stripPlane.localZ(tsos.globalPosition());
+  LocalPoint pos = slp - sld * delta / sld.z();
+
+  // now the error
+  LocalVector hitXAxis = stripPlane.toLocal(gluedPlane.toGlobal(LocalVector(1, 0, 0)));
+  if (stripPlane.normalVector().dot(gluedPlane.normalVector()) < 0) {
+    // the two planes are inverted, and the correlation element must change sign
+    err = LocalError(err.xx(), -err.xy(), err.yy());
+  }
+  LocalError rotatedError = err.rotate(hitXAxis.x(), hitXAxis.y());
+
+  /* // This is probably meaningless 
       LogDebug("TkStripMeasurementDet") << 
       "Testing local pos on strip (SLP): " << slp << 
       " in? :" << stripPlane.bounds().inside(slp) <<
       " in(3s)? :" << stripPlane.bounds().inside(slp, rotatedError, 3.0f);
       // but it helps to test bugs in the formula for POS */
-   /*LogDebug("TkStripMeasurementDet") << 
+  /*LogDebug("TkStripMeasurementDet") << 
      "Testing local pos strip: " << pos << 
      " in? " << stripPlane.bounds().inside(pos) <<
      " in(3s)? " << stripPlane.bounds().inside(pos, rotatedError, 3.0f);*/
-   
-   // now we need to convert to MeasurementFrame
-   const StripTopology &topo = mdet.specificGeomDet().specificTopology();
-   float utraj = topo.measurementPosition(pos).x();
-   float uerr  = std::sqrt(topo.measurementError(pos,rotatedError).uu());
-   return mdet.testStrips(utraj, uerr);
-} 
 
-#include<boost/bind.hpp>
-TkGluedMeasurementDet::HitCollectorForRecHits::HitCollectorForRecHits(const GeomDet * geomDet, 
-								      const SiStripRecHitMatcher * matcher, const StripClusterParameterEstimator* cpe,
-								      RecHitContainer & target) :
-  geomDet_(geomDet), matcher_(matcher), cpe_(cpe),target_(target),
-  collector_(boost::bind(&HitCollectorForRecHits::add,boost::ref(*this),_1)),
-  hasNewHits_(false)
-{
+  // now we need to convert to MeasurementFrame
+  const StripTopology& topo = mdet.specificGeomDet().specificTopology();
+  float utraj = topo.measurementPosition(pos).x();
+  float uerr = std::sqrt(topo.measurementError(pos, rotatedError).uu());
+  return mdet.testStrips(utraj, uerr);
 }
+
+#include <boost/bind.hpp>
+TkGluedMeasurementDet::HitCollectorForRecHits::HitCollectorForRecHits(const GeomDet* geomDet,
+                                                                      const SiStripRecHitMatcher* matcher,
+                                                                      const StripClusterParameterEstimator* cpe,
+                                                                      RecHitContainer& target)
+    : geomDet_(geomDet),
+      matcher_(matcher),
+      cpe_(cpe),
+      target_(target),
+      collector_(boost::bind(&HitCollectorForRecHits::add, boost::ref(*this), _1)),
+      hasNewHits_(false) {}
 
 TkGluedMeasurementDet::HitCollectorForSimpleHits::HitCollectorForSimpleHits(
-									    const GeomDet * geomDet, 
-									    const SiStripRecHitMatcher * matcher, 
-									    const StripClusterParameterEstimator* cpe,
-									    const TrajectoryStateOnSurface& stateOnThisDet,
-									    const MeasurementEstimator& est,
-									    SimpleHitContainer & target) :
-  geomDet_(geomDet), matcher_(matcher), cpe_(cpe),stateOnThisDet_(stateOnThisDet), est_(est), target_(target),
-  collector_(boost::bind(&HitCollectorForSimpleHits::add,boost::ref(*this),_1)),
-  hasNewHits_(false)
-{
-}
+    const GeomDet* geomDet,
+    const SiStripRecHitMatcher* matcher,
+    const StripClusterParameterEstimator* cpe,
+    const TrajectoryStateOnSurface& stateOnThisDet,
+    const MeasurementEstimator& est,
+    SimpleHitContainer& target)
+    : geomDet_(geomDet),
+      matcher_(matcher),
+      cpe_(cpe),
+      stateOnThisDet_(stateOnThisDet),
+      est_(est),
+      target_(target),
+      collector_(boost::bind(&HitCollectorForSimpleHits::add, boost::ref(*this), _1)),
+      hasNewHits_(false) {}
 
-
-void
-TkGluedMeasurementDet::HitCollectorForRecHits::addProjected(const TrackingRecHit& hit,
-                                                            const GlobalVector & gdir)
-{
-  auto && vl = projectedPos(hit,*geomDet_, gdir,  cpe_);
-  auto && phit = std::make_shared<ProjectedSiStripRecHit2D> (vl.first,vl.second,*geomDet_, static_cast<SiStripRecHit2D const &>(hit));
+void TkGluedMeasurementDet::HitCollectorForRecHits::addProjected(const TrackingRecHit& hit, const GlobalVector& gdir) {
+  auto&& vl = projectedPos(hit, *geomDet_, gdir, cpe_);
+  auto&& phit = std::make_shared<ProjectedSiStripRecHit2D>(
+      vl.first, vl.second, *geomDet_, static_cast<SiStripRecHit2D const&>(hit));
   target_.push_back(std::move(phit));
 }
 
+void TkGluedMeasurementDet::HitCollectorForSimpleHits::add(SiStripMatchedRecHit2D const& hit2d) {
+  hasNewHits_ = true;  //FIXME: see also what happens moving this within testAndPush   // consistent with previous code
+  if (!est_.preFilter(stateOnThisDet_,
+                      ClusterFilterPayload(hit2d.geographicalId(), &hit2d.monoCluster(), &hit2d.stereoCluster())))
+    return;
+  hasNewHits_ = true;  //FIXME: see also what happens moving this within testAndPush
 
-void
-TkGluedMeasurementDet::HitCollectorForSimpleHits::add(SiStripMatchedRecHit2D const & hit2d) 
-{
-  hasNewHits_ = true; //FIXME: see also what happens moving this within testAndPush   // consistent with previous code
-  if ( !est_.preFilter(stateOnThisDet_, ClusterFilterPayload(hit2d.geographicalId(), &hit2d.monoCluster(), &hit2d.stereoCluster()) ) ) return; 
-  hasNewHits_ = true; //FIXME: see also what happens moving this within testAndPush
-
-  std::pair<bool,double> diffEst = est_.estimate( stateOnThisDet_, hit2d);
+  std::pair<bool, double> diffEst = est_.estimate(stateOnThisDet_, hit2d);
   if (diffEst.first)
     target_.emplace_back(new SiStripMatchedRecHit2D(hit2d));  // fix to use move (really needed???)
 }
 
-
-
-void
-TkGluedMeasurementDet::HitCollectorForSimpleHits::addProjected(const TrackingRecHit& hit,
-							       const GlobalVector & gdir)
-{
- auto const & thit = reinterpret_cast<TrackerSingleRecHit const&>(hit);
- if ( !est_.preFilter(stateOnThisDet_, ClusterFilterPayload(hit.geographicalId(), &thit.stripCluster()) ) ) return;
+void TkGluedMeasurementDet::HitCollectorForSimpleHits::addProjected(const TrackingRecHit& hit,
+                                                                    const GlobalVector& gdir) {
+  auto const& thit = reinterpret_cast<TrackerSingleRecHit const&>(hit);
+  if (!est_.preFilter(stateOnThisDet_, ClusterFilterPayload(hit.geographicalId(), &thit.stripCluster())))
+    return;
 
   // here we're ok with some extra casual new's and delete's
-  auto && vl = projectedPos(hit,*geomDet_, gdir,  cpe_);
-  std::unique_ptr<ProjectedSiStripRecHit2D> phit(new ProjectedSiStripRecHit2D(vl.first,vl.second,*geomDet_, static_cast<SiStripRecHit2D const &>(hit)));
-  std::pair<bool,double> diffEst = est_.estimate( stateOnThisDet_, *phit);
-  if ( diffEst.first) {
+  auto&& vl = projectedPos(hit, *geomDet_, gdir, cpe_);
+  std::unique_ptr<ProjectedSiStripRecHit2D> phit(
+      new ProjectedSiStripRecHit2D(vl.first, vl.second, *geomDet_, static_cast<SiStripRecHit2D const&>(hit)));
+  std::pair<bool, double> diffEst = est_.estimate(stateOnThisDet_, *phit);
+  if (diffEst.first) {
     target_.emplace_back(phit.release());
   }
 }
 
+TkGluedMeasurementDet::HitCollectorForFastMeasurements::HitCollectorForFastMeasurements(
+    const GeomDet* geomDet,
+    const SiStripRecHitMatcher* matcher,
+    const StripClusterParameterEstimator* cpe,
+    const TrajectoryStateOnSurface& stateOnThisDet,
+    const MeasurementEstimator& est,
+    TempMeasurements& target)
+    : geomDet_(geomDet),
+      matcher_(matcher),
+      cpe_(cpe),
+      stateOnThisDet_(stateOnThisDet),
+      est_(est),
+      target_(target),
+      collector_(boost::bind(&HitCollectorForFastMeasurements::add, boost::ref(*this), _1)),
+      hasNewHits_(false) {}
 
+void TkGluedMeasurementDet::HitCollectorForFastMeasurements::add(SiStripMatchedRecHit2D const& hit2d) {
+  hasNewHits_ =
+      true;  //FIXME: see also what happens moving this within testAndPush  // consistent with previous code...
+  if (!est_.preFilter(stateOnThisDet_,
+                      ClusterFilterPayload(hit2d.geographicalId(), &hit2d.monoCluster(), &hit2d.stereoCluster())))
+    return;
+  hasNewHits_ = true;  //FIXME: see also what happens moving this within testAndPush
 
-
-TkGluedMeasurementDet::HitCollectorForFastMeasurements::HitCollectorForFastMeasurements
-(const GeomDet * geomDet, 
- const SiStripRecHitMatcher * matcher, const StripClusterParameterEstimator* cpe,
- const TrajectoryStateOnSurface& stateOnThisDet,
- const MeasurementEstimator& est,
- TempMeasurements & target) :
-  geomDet_(geomDet), matcher_(matcher), cpe_(cpe),stateOnThisDet_(stateOnThisDet), est_(est), target_(target),
-  collector_(boost::bind(&HitCollectorForFastMeasurements::add,boost::ref(*this),_1)),
-  hasNewHits_(false)
-{
-}
-
-
-void
-TkGluedMeasurementDet::HitCollectorForFastMeasurements::add(SiStripMatchedRecHit2D const& hit2d) 
-{
-  hasNewHits_ = true; //FIXME: see also what happens moving this within testAndPush  // consistent with previous code...
-  if ( !est_.preFilter(stateOnThisDet_, ClusterFilterPayload(hit2d.geographicalId(), &hit2d.monoCluster(), &hit2d.stereoCluster()) ) ) return;
-  hasNewHits_ = true; //FIXME: see also what happens moving this within testAndPush
-
-  std::pair<bool,double> diffEst = est_.estimate( stateOnThisDet_, hit2d);
+  std::pair<bool, double> diffEst = est_.estimate(stateOnThisDet_, hit2d);
   if (diffEst.first)
-    target_.add(hit2d.cloneSH(),diffEst.second);
+    target_.add(hit2d.cloneSH(), diffEst.second);
 }
 
-
-void
-TkGluedMeasurementDet::HitCollectorForFastMeasurements::addProjected(const TrackingRecHit& hit,
-								     const GlobalVector & gdir)
-{
-  auto const & thit = reinterpret_cast<TrackerSingleRecHit const&>(hit);
-  if ( !est_.preFilter(stateOnThisDet_, ClusterFilterPayload(hit.geographicalId(), &thit.stripCluster()) ) ) return;
-
+void TkGluedMeasurementDet::HitCollectorForFastMeasurements::addProjected(const TrackingRecHit& hit,
+                                                                          const GlobalVector& gdir) {
+  auto const& thit = reinterpret_cast<TrackerSingleRecHit const&>(hit);
+  if (!est_.preFilter(stateOnThisDet_, ClusterFilterPayload(hit.geographicalId(), &thit.stripCluster())))
+    return;
 
   // here we're ok with some extra casual new's and delete's
-  auto && vl = projectedPos(hit,*geomDet_, gdir,  cpe_);
-  auto && phit = std::make_shared<ProjectedSiStripRecHit2D> (vl.first,vl.second,*geomDet_, static_cast<SiStripRecHit2D const &>(hit));
+  auto&& vl = projectedPos(hit, *geomDet_, gdir, cpe_);
+  auto&& phit = std::make_shared<ProjectedSiStripRecHit2D>(
+      vl.first, vl.second, *geomDet_, static_cast<SiStripRecHit2D const&>(hit));
 
-  std::pair<bool,double> diffEst = est_.estimate( stateOnThisDet_, *phit);
-  if ( diffEst.first) {
+  std::pair<bool, double> diffEst = est_.estimate(stateOnThisDet_, *phit);
+  if (diffEst.first) {
     target_.add(phit, diffEst.second);
   }
 }
-
-
 
 #ifdef DOUBLE_MATCH
 #include "doubleMatch.icc"

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.h
@@ -12,188 +12,185 @@ class GluedGeomDet;
 #include <TrackingTools/DetLayers/interface/MeasurementEstimator.h>
 #include <TrackingTools/PatternTools/interface/TrajectoryMeasurement.h>
 
-
 #include "FWCore/Utilities/interface/Visibility.h"
-
 
 class dso_hidden TkGluedMeasurementDet final : public MeasurementDet {
 public:
+  TkGluedMeasurementDet(const GluedGeomDet* gdet,
+                        const SiStripRecHitMatcher* matcher,
+                        const StripClusterParameterEstimator* cpe);
+  void init(const MeasurementDet* monoDet, const MeasurementDet* stereoDet, const TrackerTopology* tTopo);
 
-  TkGluedMeasurementDet( const GluedGeomDet* gdet,const SiStripRecHitMatcher* matcher, const StripClusterParameterEstimator* cpe);
-  void init(const MeasurementDet* monoDet,
-	    const MeasurementDet* stereoDet,
-	    const TrackerTopology* tTopo);
+  RecHitContainer recHits(const TrajectoryStateOnSurface&, const MeasurementTrackerEvent& data) const override;
 
-  RecHitContainer recHits( const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & data) const override;
+  // simple hits
+  bool recHits(SimpleHitContainer& result,
+               const TrajectoryStateOnSurface& stateOnThisDet,
+               const MeasurementEstimator&,
+               const MeasurementTrackerEvent& data) const override;
 
- // simple hits
-  bool recHits(SimpleHitContainer & result,  
-		       const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator&, const MeasurementTrackerEvent & data) const override;
+  const GluedGeomDet& specificGeomDet() const { return static_cast<GluedGeomDet const&>(fastGeomDet()); }
 
-  
+  bool measurements(const TrajectoryStateOnSurface& stateOnThisDet,
+                    const MeasurementEstimator& est,
+                    const MeasurementTrackerEvent& data,
+                    TempMeasurements& result) const override;
 
- const GluedGeomDet& specificGeomDet() const {return static_cast<GluedGeomDet const&>(fastGeomDet());}
+  const TkStripMeasurementDet* monoDet() const { return theMonoDet; }
+  const TkStripMeasurementDet* stereoDet() const { return theStereoDet; }
 
- bool measurements( const TrajectoryStateOnSurface& stateOnThisDet,
-			     const MeasurementEstimator& est, const MeasurementTrackerEvent & data,
-			    TempMeasurements & result) const override;
-
-  const TkStripMeasurementDet* monoDet() const{ return theMonoDet;} 
-  const TkStripMeasurementDet* stereoDet() const{ return theStereoDet;} 
-
-  unsigned int rawId() const { return  fastGeomDet().geographicalId(); }
-
+  unsigned int rawId() const { return fastGeomDet().geographicalId(); }
 
   /// return TRUE if both mono and stereo components are active
-  bool isActive(const MeasurementTrackerEvent & data) const override {return monoDet()->isActive(data) && stereoDet()->isActive(data); }
- 	  	 
+  bool isActive(const MeasurementTrackerEvent& data) const override {
+    return monoDet()->isActive(data) && stereoDet()->isActive(data);
+  }
+
   /// return TRUE if at least one of the mono and stereo components has badChannels
-  bool hasBadComponents( const TrajectoryStateOnSurface &tsos, const MeasurementTrackerEvent & data ) const override {
-    return (monoDet()->hasBadComponents(tsos,data) || stereoDet()->hasBadComponents(tsos,data));}
+  bool hasBadComponents(const TrajectoryStateOnSurface& tsos, const MeasurementTrackerEvent& data) const override {
+    return (monoDet()->hasBadComponents(tsos, data) || stereoDet()->hasBadComponents(tsos, data));
+  }
 
 private:
-  const SiStripRecHitMatcher*       theMatcher;
+  const SiStripRecHitMatcher* theMatcher;
   const StripClusterParameterEstimator* theCPE;
-  const TkStripMeasurementDet*       theMonoDet;
-  const TkStripMeasurementDet*       theStereoDet;
-  const TrackerTopology*             theTopology;
+  const TkStripMeasurementDet* theMonoDet;
+  const TkStripMeasurementDet* theStereoDet;
+  const TrackerTopology* theTopology;
 
+  template <typename Collector>
+  void doubleMatch(const TrajectoryStateOnSurface& ts,
+                   const MeasurementTrackerEvent& data,
+                   Collector& collector) const dso_internal;
 
-  template<typename Collector>
-  void doubleMatch(const TrajectoryStateOnSurface& ts, const MeasurementTrackerEvent & data, Collector & collector) const  dso_internal;
-
-  template<typename Collector>
-  void collectRecHits(const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & data, Collector &coll) const dso_internal;
+  template <typename Collector>
+  void collectRecHits(const TrajectoryStateOnSurface&,
+                      const MeasurementTrackerEvent& data,
+                      Collector& coll) const dso_internal;
 
   // for TTRH
-  class dso_internal  HitCollectorForRecHits {
+  class dso_internal HitCollectorForRecHits {
   public:
     typedef SiStripRecHitMatcher::Collector Collector;
-    HitCollectorForRecHits(const GeomDet * geomDet, 
-			   const SiStripRecHitMatcher * matcher,
-			   const StripClusterParameterEstimator* cpe,
-			   RecHitContainer & target) ;
+    HitCollectorForRecHits(const GeomDet* geomDet,
+                           const SiStripRecHitMatcher* matcher,
+                           const StripClusterParameterEstimator* cpe,
+                           RecHitContainer& target);
     void add(SiStripMatchedRecHit2D const& hit) {
       target_.emplace_back(hit.cloneSH());
-      hasNewHits_ = true; 
+      hasNewHits_ = true;
     }
-    void addProjected(const TrackingRecHit& hit,
-		      const GlobalVector & gdir) ;
-    SiStripRecHitMatcher::Collector & collector() { return collector_; }
-    bool hasNewMatchedHits() const { return hasNewHits_;  }
+    void addProjected(const TrackingRecHit& hit, const GlobalVector& gdir);
+    SiStripRecHitMatcher::Collector& collector() { return collector_; }
+    bool hasNewMatchedHits() const { return hasNewHits_; }
     void clearNewMatchedHitsFlag() { hasNewHits_ = false; }
-    static bool filter() { return false;}   /// always fast as no estimator available here! 
-    size_t size() const { return target_.size();}
+    static bool filter() { return false; }  /// always fast as no estimator available here!
+    size_t size() const { return target_.size(); }
 
-    static const MeasurementEstimator  & estimator() { static const MeasurementEstimator * dummy=nullptr; return *dummy;}
+    static const MeasurementEstimator& estimator() {
+      static const MeasurementEstimator* dummy = nullptr;
+      return *dummy;
+    }
 
-  private: 
-    const GeomDet              * geomDet_;
-    const SiStripRecHitMatcher * matcher_;
+  private:
+    const GeomDet* geomDet_;
+    const SiStripRecHitMatcher* matcher_;
     const StripClusterParameterEstimator* cpe_;
-    RecHitContainer       & target_;
-    SiStripRecHitMatcher::Collector collector_;       
+    RecHitContainer& target_;
+    SiStripRecHitMatcher::Collector collector_;
     bool hasNewHits_;
   };
 
   // for TRH
-  class dso_internal  HitCollectorForSimpleHits {
+  class dso_internal HitCollectorForSimpleHits {
   public:
     typedef SiStripRecHitMatcher::Collector Collector;
-    HitCollectorForSimpleHits(const GeomDet * geomDet, 
-			      const SiStripRecHitMatcher * matcher,
-			      const StripClusterParameterEstimator* cpe,
-			      const TrajectoryStateOnSurface& stateOnThisDet,
-			      const MeasurementEstimator& est,
-			      SimpleHitContainer & target) ;
-    void add(SiStripMatchedRecHit2D const & hit);
-    void addProjected(const TrackingRecHit& hit,
-		      const GlobalVector & gdir) ;
-    SiStripRecHitMatcher::Collector & collector() { return collector_; }
-    bool hasNewMatchedHits() const { return hasNewHits_;  }
+    HitCollectorForSimpleHits(const GeomDet* geomDet,
+                              const SiStripRecHitMatcher* matcher,
+                              const StripClusterParameterEstimator* cpe,
+                              const TrajectoryStateOnSurface& stateOnThisDet,
+                              const MeasurementEstimator& est,
+                              SimpleHitContainer& target);
+    void add(SiStripMatchedRecHit2D const& hit);
+    void addProjected(const TrackingRecHit& hit, const GlobalVector& gdir);
+    SiStripRecHitMatcher::Collector& collector() { return collector_; }
+    bool hasNewMatchedHits() const { return hasNewHits_; }
     void clearNewMatchedHitsFlag() { hasNewHits_ = false; }
-    bool filter() const { return matcher_->preFilter();}   // if true mono-colection will been filter using the estimator before matching  
-    size_t size() const { return target_.size();}
-    const MeasurementEstimator  & estimator() { return est_;}
-  private: 
-    const GeomDet              * geomDet_;
-    const SiStripRecHitMatcher * matcher_;
+    bool filter() const {
+      return matcher_->preFilter();
+    }  // if true mono-colection will been filter using the estimator before matching
+    size_t size() const { return target_.size(); }
+    const MeasurementEstimator& estimator() { return est_; }
+
+  private:
+    const GeomDet* geomDet_;
+    const SiStripRecHitMatcher* matcher_;
     const StripClusterParameterEstimator* cpe_;
-    const TrajectoryStateOnSurface & stateOnThisDet_;
-    const MeasurementEstimator     & est_;
-    SimpleHitContainer & target_;
-    SiStripRecHitMatcher::Collector collector_;       
+    const TrajectoryStateOnSurface& stateOnThisDet_;
+    const MeasurementEstimator& est_;
+    SimpleHitContainer& target_;
+    SiStripRecHitMatcher::Collector collector_;
     bool hasNewHits_;
   };
-
-  
 
   class dso_internal HitCollectorForFastMeasurements {
   public:
     typedef TransientTrackingRecHit::RecHitPointer RecHitPointer;
     typedef SiStripRecHitMatcher::Collector Collector;
-    
-    HitCollectorForFastMeasurements(const GeomDet * geomDet, 
-				    const SiStripRecHitMatcher * matcher,
-				    const StripClusterParameterEstimator* cpe,
-				    const TrajectoryStateOnSurface& stateOnThisDet,
-				    const MeasurementEstimator& est,
-				    TempMeasurements & target) ;
-    void add(SiStripMatchedRecHit2D const& hit) ;
-    void addProjected(const TrackingRecHit& hit,
-		      const GlobalVector & gdir) ;
-    
-    SiStripRecHitMatcher::Collector & collector() { return collector_; }
-    bool hasNewMatchedHits() const { return hasNewHits_;  }
+
+    HitCollectorForFastMeasurements(const GeomDet* geomDet,
+                                    const SiStripRecHitMatcher* matcher,
+                                    const StripClusterParameterEstimator* cpe,
+                                    const TrajectoryStateOnSurface& stateOnThisDet,
+                                    const MeasurementEstimator& est,
+                                    TempMeasurements& target);
+    void add(SiStripMatchedRecHit2D const& hit);
+    void addProjected(const TrackingRecHit& hit, const GlobalVector& gdir);
+
+    SiStripRecHitMatcher::Collector& collector() { return collector_; }
+    bool hasNewMatchedHits() const { return hasNewHits_; }
     void clearNewMatchedHitsFlag() { hasNewHits_ = false; }
-    bool filter() const { return matcher_->preFilter();}   // if true mono-colection will been filter using the estimator before matching  
-    size_t size() const { return target_.size();}
-    const MeasurementEstimator  & estimator() { return est_;}
-  private: 
-    const GeomDet              * geomDet_;
-    const SiStripRecHitMatcher * matcher_;
+    bool filter() const {
+      return matcher_->preFilter();
+    }  // if true mono-colection will been filter using the estimator before matching
+    size_t size() const { return target_.size(); }
+    const MeasurementEstimator& estimator() { return est_; }
+
+  private:
+    const GeomDet* geomDet_;
+    const SiStripRecHitMatcher* matcher_;
     const StripClusterParameterEstimator* cpe_;
-    const TrajectoryStateOnSurface & stateOnThisDet_;
-    const MeasurementEstimator     & est_;
-    TempMeasurements & target_;
-    SiStripRecHitMatcher::Collector collector_;       
+    const TrajectoryStateOnSurface& stateOnThisDet_;
+    const MeasurementEstimator& est_;
+    TempMeasurements& target_;
+    SiStripRecHitMatcher::Collector collector_;
     bool hasNewHits_;
   };
-  
 
-  
-  RecHitContainer 
-  projectOnGluedDet( const std::vector<SiStripRecHit2D>& hits,
-		     const TrajectoryStateOnSurface& ts) const dso_internal;
-  template<typename HitCollector>
-  void
-  projectOnGluedDet( HitCollector & collector,
-                     const std::vector<SiStripRecHit2D>& hits,
-                     const GlobalVector & gdir ) const  dso_internal;
+  RecHitContainer projectOnGluedDet(const std::vector<SiStripRecHit2D>& hits,
+                                    const TrajectoryStateOnSurface& ts) const dso_internal;
+  template <typename HitCollector>
+  void projectOnGluedDet(HitCollector& collector,
+                         const std::vector<SiStripRecHit2D>& hits,
+                         const GlobalVector& gdir) const dso_internal;
 
+  RecHitContainer projectOnGluedDet(const RecHitContainer& hits, const TrajectoryStateOnSurface& ts) const dso_internal;
+  template <typename HitCollector>
+  void projectOnGluedDet(HitCollector& collector,
+                         const RecHitContainer& hits,
+                         const GlobalVector& gdir) const dso_internal;
 
-  RecHitContainer 
-    projectOnGluedDet( const RecHitContainer& hits,
-		       const TrajectoryStateOnSurface& ts) const dso_internal;
-  template<typename HitCollector>
-  void
-  projectOnGluedDet( HitCollector & collector,
-                     const RecHitContainer& hits,
-                     const GlobalVector & gdir ) const  dso_internal;
-
-
-  void checkProjection(const TrajectoryStateOnSurface& ts, 
-		       const RecHitContainer& monoHits, 
-		       const RecHitContainer& stereoHits) const;
+  void checkProjection(const TrajectoryStateOnSurface& ts,
+                       const RecHitContainer& monoHits,
+                       const RecHitContainer& stereoHits) const;
   void checkHitProjection(const TrackingRecHit& hit,
-			  const TrajectoryStateOnSurface& ts, 
-			  const GeomDet& det) const dso_internal;
+                          const TrajectoryStateOnSurface& ts,
+                          const GeomDet& det) const dso_internal;
 
   /** \brief Test the strips on one of the two dets with projection */
   bool testStrips(const TrajectoryStateOnSurface& tsos,
-                  const BoundPlane &gluedPlane,
-                  const TkStripMeasurementDet &mdet) const  dso_internal;
-
+                  const BoundPlane& gluedPlane,
+                  const TkStripMeasurementDet& mdet) const dso_internal;
 };
 
 #endif

--- a/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.cc
@@ -7,164 +7,164 @@
 #include "TrackingTools/DetLayers/interface/MeasurementEstimator.h"
 #include "TrackingTools/PatternTools/interface/TrajMeasLessEstim.h"
 
-TkPhase2OTMeasurementDet::TkPhase2OTMeasurementDet( const GeomDet* gdet,
-					      Phase2OTMeasurementConditionSet & conditions ) : 
-    MeasurementDet (gdet),
-    theDetConditions(&conditions)
-  {
-    if ( dynamic_cast<const PixelGeomDetUnit*>(gdet) == nullptr) {
-      throw MeasurementDetException( "TkPhase2OTMeasurementDet constructed with a GeomDet which is not a PixelGeomDetUnit");
-    }
+TkPhase2OTMeasurementDet::TkPhase2OTMeasurementDet(const GeomDet* gdet, Phase2OTMeasurementConditionSet& conditions)
+    : MeasurementDet(gdet), theDetConditions(&conditions) {
+  if (dynamic_cast<const PixelGeomDetUnit*>(gdet) == nullptr) {
+    throw MeasurementDetException(
+        "TkPhase2OTMeasurementDet constructed with a GeomDet which is not a PixelGeomDetUnit");
   }
+}
 
-bool TkPhase2OTMeasurementDet::measurements( const TrajectoryStateOnSurface& stateOnThisDet,
-					  const MeasurementEstimator& est, const MeasurementTrackerEvent & data,
-					  TempMeasurements & result) const {
-
-
+bool TkPhase2OTMeasurementDet::measurements(const TrajectoryStateOnSurface& stateOnThisDet,
+                                            const MeasurementEstimator& est,
+                                            const MeasurementTrackerEvent& data,
+                                            TempMeasurements& result) const {
   if (!isActive(data)) {
     result.add(theInactiveHit, 0.F);
     return true;
   }
-  
-  if (recHits(stateOnThisDet,est,data,result.hits,result.distances)) return true;
+
+  if (recHits(stateOnThisDet, est, data, result.hits, result.distances))
+    return true;
 
   // create a TrajectoryMeasurement with an invalid RecHit and zero estimate
   bool inac = hasBadComponents(stateOnThisDet, data);
   result.add(inac ? theInactiveHit : theMissingHit, 0.F);
   return inac;
-
 }
 
-bool TkPhase2OTMeasurementDet::recHits( const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator& est, const MeasurementTrackerEvent & data,
-                                        RecHitContainer & result, std::vector<float> & diffs) const {
-
-  if UNLIKELY( (!isActive(data)) || isEmpty(data.phase2OTData()) ) return false;
+bool TkPhase2OTMeasurementDet::recHits(const TrajectoryStateOnSurface& stateOnThisDet,
+                                       const MeasurementEstimator& est,
+                                       const MeasurementTrackerEvent& data,
+                                       RecHitContainer& result,
+                                       std::vector<float>& diffs) const {
+  if
+    UNLIKELY((!isActive(data)) || isEmpty(data.phase2OTData())) return false;
 
   auto oldSize = result.size();
 
-
-
-  const detset & detSet = data.phase2OTData().detSet(index()); 
+  const detset& detSet = data.phase2OTData().detSet(index());
   auto begin = &(data.phase2OTData().handle()->data().front());
-  auto reject = [&](auto ci)-> bool { return (!data.phase2OTClustersToSkip().empty()) && data.phase2OTClustersToSkip()[ci-begin];};
+  auto reject = [&](auto ci) -> bool {
+    return (!data.phase2OTClustersToSkip().empty()) && data.phase2OTClustersToSkip()[ci - begin];
+  };
 
-  /// use the usual 5 sigma cut from the Traj to identify the column.... 
+  /// use the usual 5 sigma cut from the Traj to identify the column....
   auto firstCluster = detSet.begin();
   auto lastCluster = detSet.end();
 
   // do not use this as it does not account for APE...
   // auto xyLimits = est.maximalLocalDisplacement(stateOnThisDet,fastGeomDet().specificSurface());
   auto le = stateOnThisDet.localError().positionError();
-  LocalError lape = static_cast<TrackerGeomDet const &>(fastGeomDet()).localAlignmentError();
+  LocalError lape = static_cast<TrackerGeomDet const&>(fastGeomDet()).localAlignmentError();
   auto ye = le.yy();
   if (lape.valid()) {
-    ye+=lape.yy();
+    ye += lape.yy();
   }
   // 5 sigma to be on the safe side
-  ye = 5.f*std::sqrt(ye);
-  LocalVector  maxD(0,ye,0);
-  // pixel topology is rectangular: x and y are independent 
-  auto ymin = specificGeomDet().specificTopology().measurementPosition( stateOnThisDet.localPosition()-maxD);
-  auto ymax = specificGeomDet().specificTopology().measurementPosition( stateOnThisDet.localPosition()+maxD);
+  ye = 5.f * std::sqrt(ye);
+  LocalVector maxD(0, ye, 0);
+  // pixel topology is rectangular: x and y are independent
+  auto ymin = specificGeomDet().specificTopology().measurementPosition(stateOnThisDet.localPosition() - maxD);
+  auto ymax = specificGeomDet().specificTopology().measurementPosition(stateOnThisDet.localPosition() + maxD);
   int utraj = ymin.x();
   // do not apply for iteration not cutting on propagation
-  if (est.maxSagitta() >=0 ) {
+  if (est.maxSagitta() >= 0) {
     int colMin = ymin.y();
     int colMax = ymax.y();
-    firstCluster = 
-         std::find_if(firstCluster, detSet.end(), [colMin](const Phase2TrackerCluster1D& hit) { return int(hit.column()) >= colMin; });
-    lastCluster =        	
-         std::find_if(firstCluster, detSet.end(), [colMax](const Phase2TrackerCluster1D& hit) { return int(hit.column()) > colMax; });
+    firstCluster = std::find_if(firstCluster, detSet.end(), [colMin](const Phase2TrackerCluster1D& hit) {
+      return int(hit.column()) >= colMin;
+    });
+    lastCluster = std::find_if(
+        firstCluster, detSet.end(), [colMax](const Phase2TrackerCluster1D& hit) { return int(hit.column()) > colMax; });
   }
 
-  while (firstCluster!=lastCluster) { // loop on each column
+  while (firstCluster != lastCluster) {  // loop on each column
     auto const col = firstCluster->column();
-    auto endCluster =
-    std::find_if(firstCluster, detSet.end(), [col](const Phase2TrackerCluster1D& hit) { return hit.column() != col; });
+    auto endCluster = std::find_if(
+        firstCluster, detSet.end(), [col](const Phase2TrackerCluster1D& hit) { return hit.column() != col; });
     // find trajectory position in this column
-    auto rightCluster = 
-      std::find_if(firstCluster, endCluster, [utraj](const Phase2TrackerCluster1D& hit) { return int(hit.firstStrip()) > utraj; });
+    auto rightCluster = std::find_if(
+        firstCluster, endCluster, [utraj](const Phase2TrackerCluster1D& hit) { return int(hit.firstStrip()) > utraj; });
     // search for compatible clusters...
-    if ( rightCluster != firstCluster) {
-     // there are hits on the left of the utraj
-     auto leftCluster = rightCluster;
-     while ( --leftCluster >=  firstCluster) {
-       if(reject(leftCluster)) continue;
-       Phase2TrackerCluster1DRef cluster = detSet.makeRefTo( data.phase2OTData().handle(), leftCluster);
-       auto hit = buildRecHit( cluster, stateOnThisDet.localParameters() );
-       auto diffEst = est.estimate( stateOnThisDet, *hit); 
-       if ( !diffEst.first ) break; // exit loop on first incompatible hit
-       result.push_back(hit);
-       diffs.push_back(diffEst.second);
-     }
+    if (rightCluster != firstCluster) {
+      // there are hits on the left of the utraj
+      auto leftCluster = rightCluster;
+      while (--leftCluster >= firstCluster) {
+        if (reject(leftCluster))
+          continue;
+        Phase2TrackerCluster1DRef cluster = detSet.makeRefTo(data.phase2OTData().handle(), leftCluster);
+        auto hit = buildRecHit(cluster, stateOnThisDet.localParameters());
+        auto diffEst = est.estimate(stateOnThisDet, *hit);
+        if (!diffEst.first)
+          break;  // exit loop on first incompatible hit
+        result.push_back(hit);
+        diffs.push_back(diffEst.second);
+      }
     }
-    for ( ; rightCluster != endCluster; rightCluster++) {
-       if(reject(rightCluster)) continue;
-       Phase2TrackerCluster1DRef cluster = detSet.makeRefTo( data.phase2OTData().handle(), rightCluster);
-       auto hit = buildRecHit( cluster, stateOnThisDet.localParameters() );
-       auto diffEst = est.estimate( stateOnThisDet, *hit);
-       if ( !diffEst.first ) break; // exit loop on first incompatible hit
-       result.push_back(hit);
-       diffs.push_back(diffEst.second);
-     }
-     firstCluster = endCluster;
-   } // loop over columns 
-   return result.size()>oldSize;
-} 
- 
-
-
-
-TrackingRecHit::RecHitPointer
-TkPhase2OTMeasurementDet::buildRecHit( const Phase2TrackerCluster1DRef & cluster,
-				    const LocalTrajectoryParameters & ltp) const
-{
-
-  const PixelGeomDetUnit& gdu( specificGeomDet() );
-  auto && params = cpe()->localParameters( *cluster, gdu );
-
-  return std::make_shared<Phase2TrackerRecHit1D>( params.first, params.second, fastGeomDet(), cluster);
-
+    for (; rightCluster != endCluster; rightCluster++) {
+      if (reject(rightCluster))
+        continue;
+      Phase2TrackerCluster1DRef cluster = detSet.makeRefTo(data.phase2OTData().handle(), rightCluster);
+      auto hit = buildRecHit(cluster, stateOnThisDet.localParameters());
+      auto diffEst = est.estimate(stateOnThisDet, *hit);
+      if (!diffEst.first)
+        break;  // exit loop on first incompatible hit
+      result.push_back(hit);
+      diffs.push_back(diffEst.second);
+    }
+    firstCluster = endCluster;
+  }  // loop over columns
+  return result.size() > oldSize;
 }
 
-TkPhase2OTMeasurementDet::RecHitContainer 
-TkPhase2OTMeasurementDet::recHits( const TrajectoryStateOnSurface& ts, const MeasurementTrackerEvent & data ) const
-{
+TrackingRecHit::RecHitPointer TkPhase2OTMeasurementDet::buildRecHit(const Phase2TrackerCluster1DRef& cluster,
+                                                                    const LocalTrajectoryParameters& ltp) const {
+  const PixelGeomDetUnit& gdu(specificGeomDet());
+  auto&& params = cpe()->localParameters(*cluster, gdu);
+
+  return std::make_shared<Phase2TrackerRecHit1D>(params.first, params.second, fastGeomDet(), cluster);
+}
+
+TkPhase2OTMeasurementDet::RecHitContainer TkPhase2OTMeasurementDet::recHits(const TrajectoryStateOnSurface& ts,
+                                                                            const MeasurementTrackerEvent& data) const {
   RecHitContainer result;
-  if (isEmpty(data.phase2OTData())) return result;
-  if (!isActive(data)) return result;
-  const Phase2TrackerCluster1D* begin=nullptr;
+  if (isEmpty(data.phase2OTData()))
+    return result;
+  if (!isActive(data))
+    return result;
+  const Phase2TrackerCluster1D* begin = nullptr;
   if (!data.phase2OTData().handle()->data().empty()) {
-     begin = &(data.phase2OTData().handle()->data().front());
+    begin = &(data.phase2OTData().handle()->data().front());
   }
-  const detset & detSet = data.phase2OTData().detSet(index());
+  const detset& detSet = data.phase2OTData().detSet(index());
   result.reserve(detSet.size());
-  for ( const_iterator ci = detSet.begin(); ci != detSet.end(); ++ ci ) {
-    
-    if (ci < begin){
-      edm::LogError("IndexMisMatch")<<"TkPhase2OTMeasurementDet cannot create hit because of index mismatch.";
+  for (const_iterator ci = detSet.begin(); ci != detSet.end(); ++ci) {
+    if (ci < begin) {
+      edm::LogError("IndexMisMatch") << "TkPhase2OTMeasurementDet cannot create hit because of index mismatch.";
       return result;
     }
-     unsigned int index = ci-begin;
-     if (!data.phase2OTClustersToSkip().empty() &&  index>=data.phase2OTClustersToSkip().size()){
-       edm::LogError("IndexMisMatch")<<"TkPhase2OTMeasurementDet cannot create hit because of index mismatch. i.e "<<index<<" >= "<<data.phase2OTClustersToSkip().size();
-       return result;
-     }
-     if(data.phase2OTClustersToSkip().empty() or (not data.phase2OTClustersToSkip()[index]) ) {
-       Phase2TrackerCluster1DRef cluster = detSet.makeRefTo( data.phase2OTData().handle(), ci );
-       result.push_back( buildRecHit( cluster, ts.localParameters() ) );
-     }else{   
-       LogDebug("TkPhase2OTMeasurementDet")<<"skipping this cluster from last iteration on "<<fastGeomDet().geographicalId().rawId()<<" key: "<<index;
-     }
+    unsigned int index = ci - begin;
+    if (!data.phase2OTClustersToSkip().empty() && index >= data.phase2OTClustersToSkip().size()) {
+      edm::LogError("IndexMisMatch") << "TkPhase2OTMeasurementDet cannot create hit because of index mismatch. i.e "
+                                     << index << " >= " << data.phase2OTClustersToSkip().size();
+      return result;
+    }
+    if (data.phase2OTClustersToSkip().empty() or (not data.phase2OTClustersToSkip()[index])) {
+      Phase2TrackerCluster1DRef cluster = detSet.makeRefTo(data.phase2OTData().handle(), ci);
+      result.push_back(buildRecHit(cluster, ts.localParameters()));
+    } else {
+      LogDebug("TkPhase2OTMeasurementDet") << "skipping this cluster from last iteration on "
+                                           << fastGeomDet().geographicalId().rawId() << " key: " << index;
+    }
   }
   return result;
 }
 
 //FIXME:just temporary solution for phase2!
-bool
-TkPhase2OTMeasurementDet::hasBadComponents( const TrajectoryStateOnSurface &tsos, const MeasurementTrackerEvent & data ) const {
-/*
+bool TkPhase2OTMeasurementDet::hasBadComponents(const TrajectoryStateOnSurface& tsos,
+                                                const MeasurementTrackerEvent& data) const {
+  /*
     if (badRocPositions_.empty()) return false;
     LocalPoint lp = tsos.localPosition();
     LocalError le = tsos.localError().positionError();
@@ -174,5 +174,5 @@ TkPhase2OTMeasurementDet::hasBadComponents( const TrajectoryStateOnSurface &tsos
              (std::abs(it->y() - lp.y()) < dy) ) return true;
     } 
 */
-    return false;
+  return false;
 }

--- a/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkPhase2OTMeasurementDet.h
@@ -15,60 +15,60 @@ class LocalTrajectoryParameters;
 
 class dso_hidden TkPhase2OTMeasurementDet final : public MeasurementDet {
 public:
-
   typedef edm::Ref<edmNew::DetSetVector<Phase2TrackerCluster1D>, Phase2TrackerCluster1D> Phase2TrackerCluster1DRef;
-  
+
   typedef edmNew::DetSet<Phase2TrackerCluster1D> detset;
   typedef detset::const_iterator const_iterator;
-  typedef ClusterParameterEstimator<Phase2TrackerCluster1D>::LocalValues    LocalValues;
+  typedef ClusterParameterEstimator<Phase2TrackerCluster1D>::LocalValues LocalValues;
 
-  TkPhase2OTMeasurementDet( const GeomDet* gdet,
-    			    Phase2OTMeasurementConditionSet & conditionSet );
+  TkPhase2OTMeasurementDet(const GeomDet* gdet, Phase2OTMeasurementConditionSet& conditionSet);
 
-  void update(Phase2OTMeasurementDetSet &data, const detset & detSet ) { 
+  void update(Phase2OTMeasurementDetSet& data, const detset& detSet) {
     data.update(index(), detSet);
     data.setActiveThisEvent(index(), true);
   }
 
-  void setEmpty(Phase2OTMeasurementDetSet & data) { data.setEmpty(index());  }
-  bool isEmpty(const Phase2OTMeasurementDetSet & data) const {return data.empty(index());}
+  void setEmpty(Phase2OTMeasurementDetSet& data) { data.setEmpty(index()); }
+  bool isEmpty(const Phase2OTMeasurementDetSet& data) const { return data.empty(index()); }
 
-  ~TkPhase2OTMeasurementDet() override { }
+  ~TkPhase2OTMeasurementDet() override {}
 
-  RecHitContainer recHits( const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & dat ) const override;
-  bool recHits( const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator&, const MeasurementTrackerEvent & data,
-			RecHitContainer & result, std::vector<float> &) const override;
- 
+  RecHitContainer recHits(const TrajectoryStateOnSurface&, const MeasurementTrackerEvent& dat) const override;
+  bool recHits(const TrajectoryStateOnSurface& stateOnThisDet,
+               const MeasurementEstimator&,
+               const MeasurementTrackerEvent& data,
+               RecHitContainer& result,
+               std::vector<float>&) const override;
 
-
- // simple hits
-  bool recHits(SimpleHitContainer & result,  
-		       const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator&, const MeasurementTrackerEvent & data) const override {
-    assert("not implemented for Pixel yet"==nullptr);
+  // simple hits
+  bool recHits(SimpleHitContainer& result,
+               const TrajectoryStateOnSurface& stateOnThisDet,
+               const MeasurementEstimator&,
+               const MeasurementTrackerEvent& data) const override {
+    assert("not implemented for Pixel yet" == nullptr);
   }
 
- 
+  bool measurements(const TrajectoryStateOnSurface& stateOnThisDet,
+                    const MeasurementEstimator& est,
+                    const MeasurementTrackerEvent& dat,
+                    TempMeasurements& result) const override;
 
-  bool measurements( const TrajectoryStateOnSurface& stateOnThisDet,
-			    const MeasurementEstimator& est, const MeasurementTrackerEvent & dat,
-			    TempMeasurements & result) const override;
+  const PixelGeomDetUnit& specificGeomDet() const { return static_cast<PixelGeomDetUnit const&>(fastGeomDet()); }
 
-
-  const PixelGeomDetUnit& specificGeomDet() const {return static_cast<PixelGeomDetUnit const &>(fastGeomDet());}
-
-  TrackingRecHit::RecHitPointer
-  buildRecHit( const Phase2TrackerCluster1DRef & cluster,
-  	       const LocalTrajectoryParameters & ltp) const;
+  TrackingRecHit::RecHitPointer buildRecHit(const Phase2TrackerCluster1DRef& cluster,
+                                            const LocalTrajectoryParameters& ltp) const;
 
   /** \brief Turn on/off the module for reconstruction, for the full run or lumi (using info from DB, usually). */
   void setActive(bool active) { conditionSet().setActive(index(), active); }
   /** \brief Turn on/off the module for reconstruction for one events.
              This per-event flag is cleared by any call to 'update' or 'setEmpty'  */
-  void setActiveThisEvent(Phase2OTMeasurementDetSet & data, bool active) const { data.setActiveThisEvent(index(), active); }
+  void setActiveThisEvent(Phase2OTMeasurementDetSet& data, bool active) const {
+    data.setActiveThisEvent(index(), active);
+  }
   /** \brief Is this module active in reconstruction? It must be both 'setActiveThisEvent' and 'setActive'. */
-  bool isActive(const MeasurementTrackerEvent & data) const override { return data.phase2OTData().isActive(index()); }
+  bool isActive(const MeasurementTrackerEvent& data) const override { return data.phase2OTData().isActive(index()); }
 
-  bool hasBadComponents( const TrajectoryStateOnSurface &tsos, const MeasurementTrackerEvent & dat ) const override ; 
+  bool hasBadComponents(const TrajectoryStateOnSurface& tsos, const MeasurementTrackerEvent& dat) const override;
 
   //FIXME:just temporary solution for phase2!
   /** \brief Sets the list of bad ROCs, identified by the positions of their centers in the local coordinate frame*/
@@ -84,12 +84,11 @@ private:
   //  std::vector< LocalPoint > badRocPositions_;
 
   int index_;
-  Phase2OTMeasurementConditionSet * theDetConditions;
-  Phase2OTMeasurementConditionSet & conditionSet() { return *theDetConditions; }
-  const Phase2OTMeasurementConditionSet & conditionSet() const { return *theDetConditions; }
+  Phase2OTMeasurementConditionSet* theDetConditions;
+  Phase2OTMeasurementConditionSet& conditionSet() { return *theDetConditions; }
+  const Phase2OTMeasurementConditionSet& conditionSet() const { return *theDetConditions; }
 
   const ClusterParameterEstimator<Phase2TrackerCluster1D>* cpe() const { return conditionSet().cpe(); }
-
 };
 
 #endif

--- a/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
@@ -8,171 +8,170 @@
 #include "TrackingTools/DetLayers/interface/MeasurementEstimator.h"
 #include "TrackingTools/PatternTools/interface/TrajMeasLessEstim.h"
 
-
 namespace {
   // in cms units are in cm
-  constexpr float theRocWidth  = 0.81/2;
-  constexpr float theRocHeight = 0.81/2;
+  constexpr float theRocWidth = 0.81 / 2;
+  constexpr float theRocHeight = 0.81 / 2;
+}  // namespace
+
+TkPixelMeasurementDet::TkPixelMeasurementDet(const GeomDet* gdet, PxMeasurementConditionSet& conditions)
+    : MeasurementDet(gdet), theDetConditions(&conditions) {
+  if (dynamic_cast<const PixelGeomDetUnit*>(gdet) == nullptr) {
+    throw MeasurementDetException("TkPixelMeasurementDet constructed with a GeomDet which is not a PixelGeomDetUnit");
+  }
 }
 
-TkPixelMeasurementDet::TkPixelMeasurementDet( const GeomDet* gdet,
-					      PxMeasurementConditionSet & conditions ) : 
-    MeasurementDet (gdet),
-    theDetConditions(&conditions)
-  {
-    if ( dynamic_cast<const PixelGeomDetUnit*>(gdet) == nullptr) {
-      throw MeasurementDetException( "TkPixelMeasurementDet constructed with a GeomDet which is not a PixelGeomDetUnit");
-    }
-  }
-
-bool TkPixelMeasurementDet::measurements( const TrajectoryStateOnSurface& stateOnThisDet,
-					  const MeasurementEstimator& est, const MeasurementTrackerEvent & data,
-					  TempMeasurements & result) const {
-
+bool TkPixelMeasurementDet::measurements(const TrajectoryStateOnSurface& stateOnThisDet,
+                                         const MeasurementEstimator& est,
+                                         const MeasurementTrackerEvent& data,
+                                         TempMeasurements& result) const {
   if (!isActive(data)) {
     result.add(theInactiveHit, 0.F);
     return true;
-   }
-  
+  }
+
   auto xl = 100.f;
   auto yl = 100.f;
-   // do not apply for iteration not cutting on propagation
-  if (est.maxSagitta() >=0 ) {
+  // do not apply for iteration not cutting on propagation
+  if (est.maxSagitta() >= 0) {
     // do not use this as it does not account for APE...
     // auto xyLimits = est.maximalLocalDisplacement(stateOnThisDet,fastGeomDet().specificSurface());
     auto le = stateOnThisDet.localError().positionError();
-    LocalError lape = static_cast<TrackerGeomDet const &>(fastGeomDet()).localAlignmentError();
+    LocalError lape = static_cast<TrackerGeomDet const&>(fastGeomDet()).localAlignmentError();
     xl = le.xx();
     yl = le.yy();
     if (lape.valid()) {
-      xl+=lape.xx();
-      yl+=lape.yy();
+      xl += lape.xx();
+      yl += lape.yy();
     }
     // 5 sigma to be on the safe side
-    xl = 5.f*std::sqrt(xl);
-    yl = 5.f*std::sqrt(yl);
+    xl = 5.f * std::sqrt(xl);
+    yl = 5.f * std::sqrt(yl);
   }
-  
+
   auto oldSize = result.size();
-  MeasurementDet::RecHitContainer && allHits = compHits(stateOnThisDet, data,xl,yl);
-  for (auto && hit : allHits) {
-    std::pair<bool,double> diffEst = est.estimate( stateOnThisDet, *hit);
-    if ( diffEst.first)
+  MeasurementDet::RecHitContainer&& allHits = compHits(stateOnThisDet, data, xl, yl);
+  for (auto&& hit : allHits) {
+    std::pair<bool, double> diffEst = est.estimate(stateOnThisDet, *hit);
+    if (diffEst.first)
       result.add(std::move(hit), diffEst.second);
   }
 
-  if (result.size()>oldSize) return true;
+  if (result.size() > oldSize)
+    return true;
 
   // create a TrajectoryMeasurement with an invalid RecHit and zero estimate
   bool inac = hasBadComponents(stateOnThisDet, data);
   result.add(inac ? theInactiveHit : theMissingHit, 0.F);
   return inac;
-
 }
 
-
-TrackingRecHit::RecHitPointer
-TkPixelMeasurementDet::buildRecHit( const SiPixelClusterRef & cluster,
-				    const LocalTrajectoryParameters & ltp) const
-{
+TrackingRecHit::RecHitPointer TkPixelMeasurementDet::buildRecHit(const SiPixelClusterRef& cluster,
+                                                                 const LocalTrajectoryParameters& ltp) const {
   const GeomDetUnit& gdu(specificGeomDet());
 
-  auto && params = cpe()->getParameters( * cluster, gdu, ltp );
-  return std::make_shared<SiPixelRecHit>( std::get<0>(params), std::get<1>(params), std::get<2>(params), fastGeomDet(), cluster);
+  auto&& params = cpe()->getParameters(*cluster, gdu, ltp);
+  return std::make_shared<SiPixelRecHit>(
+      std::get<0>(params), std::get<1>(params), std::get<2>(params), fastGeomDet(), cluster);
 }
 
-
-TkPixelMeasurementDet::RecHitContainer
-TkPixelMeasurementDet::recHits( const TrajectoryStateOnSurface& ts, const MeasurementTrackerEvent & data) const {
-  float xl = 100.f; // larger than any detector
+TkPixelMeasurementDet::RecHitContainer TkPixelMeasurementDet::recHits(const TrajectoryStateOnSurface& ts,
+                                                                      const MeasurementTrackerEvent& data) const {
+  float xl = 100.f;  // larger than any detector
   float yl = 100.f;
-  return compHits(ts,data,xl,yl);
+  return compHits(ts, data, xl, yl);
 }
 
-
-TkPixelMeasurementDet::RecHitContainer 
-TkPixelMeasurementDet::compHits( const TrajectoryStateOnSurface& ts, const MeasurementTrackerEvent & data, float xl, float yl  ) const
-{
+TkPixelMeasurementDet::RecHitContainer TkPixelMeasurementDet::compHits(const TrajectoryStateOnSurface& ts,
+                                                                       const MeasurementTrackerEvent& data,
+                                                                       float xl,
+                                                                       float yl) const {
   RecHitContainer result;
-  if (isEmpty(data.pixelData())== true ) return result;
-  if (isActive(data) == false) return result;
-  const SiPixelCluster* begin=nullptr;
+  if (isEmpty(data.pixelData()) == true)
+    return result;
+  if (isActive(data) == false)
+    return result;
+  const SiPixelCluster* begin = nullptr;
   if (!data.pixelData().handle()->data().empty()) {
-     begin = &(data.pixelData().handle()->data().front());
+    begin = &(data.pixelData().handle()->data().front());
   }
-  const detset & detSet = data.pixelData().detSet(index());
+  const detset& detSet = data.pixelData().detSet(index());
   result.reserve(detSet.size());
 
   // pixel topology is rectangular, all positions are independent
-  LocalVector  maxD(xl,yl,0);
-  auto PMinus = specificGeomDet().specificTopology().measurementPosition(ts.localPosition()-maxD);
-  auto PPlus =  specificGeomDet().specificTopology().measurementPosition(ts.localPosition()+maxD);
+  LocalVector maxD(xl, yl, 0);
+  auto PMinus = specificGeomDet().specificTopology().measurementPosition(ts.localPosition() - maxD);
+  auto PPlus = specificGeomDet().specificTopology().measurementPosition(ts.localPosition() + maxD);
 
   int xminus = PMinus.x();
   int yminus = PMinus.y();
-  int xplus = PPlus.x()+0.5f;
-  int yplus = PPlus.y()+0.5f;
-
+  int xplus = PPlus.x() + 0.5f;
+  int yplus = PPlus.y() + 0.5f;
 
   // rechits are sorted in x...
-  auto rightCluster = 
-    std::find_if( detSet.begin(), detSet.end(), [xplus](const SiPixelCluster& cl) { return cl.minPixelRow() > xplus; });
+  auto rightCluster = std::find_if(
+      detSet.begin(), detSet.end(), [xplus](const SiPixelCluster& cl) { return cl.minPixelRow() > xplus; });
 
   // std::cout << "px xlim " << xl << ' ' << xminus << '/' << xplus << ' ' << rightCluster-detSet.begin() << ',' << detSet.end()-rightCluster << std::endl;
-  
 
   // consider only compatible clusters
- for (auto ci = detSet.begin(); ci != rightCluster; ++ci ) {    
-
-    if (ci < begin){
-      edm::LogError("IndexMisMatch")<<"TkPixelMeasurementDet cannot create hit because of index mismatch.";
+  for (auto ci = detSet.begin(); ci != rightCluster; ++ci) {
+    if (ci < begin) {
+      edm::LogError("IndexMisMatch") << "TkPixelMeasurementDet cannot create hit because of index mismatch.";
       return result;
     }
-     unsigned int index = ci-begin;
-     if (!data.pixelClustersToSkip().empty() &&  index>=data.pixelClustersToSkip().size()){
-       edm::LogError("IndexMisMatch")<<"TkPixelMeasurementDet cannot create hit because of index mismatch. i.e "<<index<<" >= "<<data.pixelClustersToSkip().size();
-       return result;
-     }
+    unsigned int index = ci - begin;
+    if (!data.pixelClustersToSkip().empty() && index >= data.pixelClustersToSkip().size()) {
+      edm::LogError("IndexMisMatch") << "TkPixelMeasurementDet cannot create hit because of index mismatch. i.e "
+                                     << index << " >= " << data.pixelClustersToSkip().size();
+      return result;
+    }
 
-     if (ci->maxPixelRow()<xminus) continue;
-     // also check compatibility in y... (does not add much)
-     if (ci->minPixelCol()>yplus) continue;
-     if (ci->maxPixelCol()<yminus) continue;
+    if (ci->maxPixelRow() < xminus)
+      continue;
+    // also check compatibility in y... (does not add much)
+    if (ci->minPixelCol() > yplus)
+      continue;
+    if (ci->maxPixelCol() < yminus)
+      continue;
 
-     if(data.pixelClustersToSkip().empty() or (not data.pixelClustersToSkip()[index]) ) {
-       SiPixelClusterRef cluster = detSet.makeRefTo( data.pixelData().handle(), ci );
-       result.push_back( buildRecHit( cluster, ts.localParameters() ) );
-     }else{   
-       LogDebug("TkPixelMeasurementDet")<<"skipping this cluster from last iteration on "<<fastGeomDet().geographicalId().rawId()<<" key: "<<index;
-     }
+    if (data.pixelClustersToSkip().empty() or (not data.pixelClustersToSkip()[index])) {
+      SiPixelClusterRef cluster = detSet.makeRefTo(data.pixelData().handle(), ci);
+      result.push_back(buildRecHit(cluster, ts.localParameters()));
+    } else {
+      LogDebug("TkPixelMeasurementDet") << "skipping this cluster from last iteration on "
+                                        << fastGeomDet().geographicalId().rawId() << " key: " << index;
+    }
   }
   return result;
 }
 
-bool
-TkPixelMeasurementDet::hasBadComponents( const TrajectoryStateOnSurface &tsos, const MeasurementTrackerEvent & data ) const {
-  auto badFEDChannelPositions=getBadFEDChannelPositions(data);
-  if (badRocPositions_.empty() && badFEDChannelPositions==nullptr) return false;
+bool TkPixelMeasurementDet::hasBadComponents(const TrajectoryStateOnSurface& tsos,
+                                             const MeasurementTrackerEvent& data) const {
+  auto badFEDChannelPositions = getBadFEDChannelPositions(data);
+  if (badRocPositions_.empty() && badFEDChannelPositions == nullptr)
+    return false;
 
-    auto lp = tsos.localPosition();
-    auto le = tsos.localError().positionError();
-    for (auto const & broc : badRocPositions_) {
-      auto dx = std::abs(broc.x() - lp.x()) - theRocWidth;
-      auto dy = std::abs(broc.y() - lp.y()) - theRocHeight;
-      if ( (dx<=0.f) & (dy<=0.f) ) return true;
-      if ( (dx*dx < 9.f*le.xx()) && (dy*dy< 9.f*le.yy()) ) return true;
-    }
+  auto lp = tsos.localPosition();
+  auto le = tsos.localError().positionError();
+  for (auto const& broc : badRocPositions_) {
+    auto dx = std::abs(broc.x() - lp.x()) - theRocWidth;
+    auto dy = std::abs(broc.y() - lp.y()) - theRocHeight;
+    if ((dx <= 0.f) & (dy <= 0.f))
+      return true;
+    if ((dx * dx < 9.f * le.xx()) && (dy * dy < 9.f * le.yy()))
+      return true;
+  }
 
-  if (badFEDChannelPositions==nullptr) return false;
-  float dx = 3.f*std::sqrt(le.xx()) + theRocWidth, dy = 3.f*std::sqrt(le.yy()) + theRocHeight;
+  if (badFEDChannelPositions == nullptr)
+    return false;
+  float dx = 3.f * std::sqrt(le.xx()) + theRocWidth, dy = 3.f * std::sqrt(le.yy()) + theRocHeight;
   for (auto const& p : *badFEDChannelPositions) {
-    if ( lp.x() > (p.first.x()-dx) &&
-	 lp.x() < (p.second.x()+dx) &&
-	 lp.y() > (p.first.y()-dy) &&
-	 lp.y() < (p.second.y()+dy) ) {
+    if (lp.x() > (p.first.x() - dx) && lp.x() < (p.second.x() + dx) && lp.y() > (p.first.y() - dy) &&
+        lp.y() < (p.second.y() + dy)) {
       return true;
     }
   }
 
-    return false;
+  return false;
 }

--- a/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.h
@@ -16,69 +16,68 @@ class LocalTrajectoryParameters;
 
 class dso_hidden TkPixelMeasurementDet final : public MeasurementDet {
 public:
-
   typedef edm::Ref<edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster> SiPixelClusterRef;
-  
+
   typedef edmNew::DetSet<SiPixelCluster> detset;
   typedef detset::const_iterator const_iterator;
-  typedef PixelClusterParameterEstimator::LocalValues    LocalValues;
+  typedef PixelClusterParameterEstimator::LocalValues LocalValues;
 
-  TkPixelMeasurementDet( const GeomDet* gdet,
-			 PxMeasurementConditionSet & conditionSet );
+  TkPixelMeasurementDet(const GeomDet* gdet, PxMeasurementConditionSet& conditionSet);
 
-  void update(PxMeasurementDetSet &data, const detset & detSet ) { 
+  void update(PxMeasurementDetSet& data, const detset& detSet) {
     data.update(index(), detSet);
     data.setActiveThisEvent(index(), true);
   }
 
-  void setEmpty(PxMeasurementDetSet & data) { data.setEmpty(index());  }
-  bool isEmpty(const PxMeasurementDetSet & data) const {return data.empty(index());}
+  void setEmpty(PxMeasurementDetSet& data) { data.setEmpty(index()); }
+  bool isEmpty(const PxMeasurementDetSet& data) const { return data.empty(index()); }
 
-  ~TkPixelMeasurementDet() override { }
+  ~TkPixelMeasurementDet() override {}
 
   // all hits
-  RecHitContainer recHits( const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & dat) const override;
+  RecHitContainer recHits(const TrajectoryStateOnSurface&, const MeasurementTrackerEvent& dat) const override;
 
-  // only hits compatible with tsos 
-  RecHitContainer compHits( const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & dat, float xl, float yl ) const;
+  // only hits compatible with tsos
+  RecHitContainer compHits(const TrajectoryStateOnSurface&,
+                           const MeasurementTrackerEvent& dat,
+                           float xl,
+                           float yl) const;
 
-
-
- // simple hits
-  bool recHits(SimpleHitContainer & result,  
-		       const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator&, const MeasurementTrackerEvent & data) const override {
-    assert("not implemented for Pixel yet"==nullptr);
+  // simple hits
+  bool recHits(SimpleHitContainer& result,
+               const TrajectoryStateOnSurface& stateOnThisDet,
+               const MeasurementEstimator&,
+               const MeasurementTrackerEvent& data) const override {
+    assert("not implemented for Pixel yet" == nullptr);
   }
 
- 
+  bool measurements(const TrajectoryStateOnSurface& stateOnThisDet,
+                    const MeasurementEstimator& est,
+                    const MeasurementTrackerEvent& dat,
+                    TempMeasurements& result) const override;
 
-  bool measurements( const TrajectoryStateOnSurface& stateOnThisDet,
-			    const MeasurementEstimator& est, const MeasurementTrackerEvent & dat,
-			    TempMeasurements & result) const override;
+  const PixelGeomDetUnit& specificGeomDet() const { return static_cast<PixelGeomDetUnit const&>(fastGeomDet()); }
 
-
-  const PixelGeomDetUnit& specificGeomDet() const {return static_cast<PixelGeomDetUnit const &>(fastGeomDet());}
-
-  TrackingRecHit::RecHitPointer 
-  buildRecHit( const SiPixelClusterRef & cluster,
-	       const LocalTrajectoryParameters & ltp) const;
+  TrackingRecHit::RecHitPointer buildRecHit(const SiPixelClusterRef& cluster,
+                                            const LocalTrajectoryParameters& ltp) const;
 
   /** \brief Turn on/off the module for reconstruction, for the full run or lumi (using info from DB, usually). */
   void setActive(bool active) { conditionSet().setActive(index(), active); }
   /** \brief Turn on/off the module for reconstruction for one events.
              This per-event flag is cleared by any call to 'update' or 'setEmpty'  */
-  void setActiveThisEvent(PxMeasurementDetSet & data, bool active) const { data.setActiveThisEvent(index(), active); }
+  void setActiveThisEvent(PxMeasurementDetSet& data, bool active) const { data.setActiveThisEvent(index(), active); }
   /** \brief Is this module active in reconstruction? It must be both 'setActiveThisEvent' and 'setActive'. */
-  bool isActive(const MeasurementTrackerEvent & data) const override { return data.pixelData().isActive(index()); }
+  bool isActive(const MeasurementTrackerEvent& data) const override { return data.pixelData().isActive(index()); }
 
-  bool hasBadComponents( const TrajectoryStateOnSurface &tsos, const MeasurementTrackerEvent & dat ) const override ; 
+  bool hasBadComponents(const TrajectoryStateOnSurface& tsos, const MeasurementTrackerEvent& dat) const override;
 
   /** \brief Sets the list of bad ROCs, identified by the positions of their centers in the local coordinate frame*/
-  void setBadRocPositions(std::vector< LocalPoint > & positions) { badRocPositions_.swap(positions); }
+  void setBadRocPositions(std::vector<LocalPoint>& positions) { badRocPositions_.swap(positions); }
   /** \brief Clear the list of bad ROCs */
   void clearBadRocPositions() { badRocPositions_.clear(); }
 
-  const PxMeasurementDetSet::BadFEDChannelPositions* getBadFEDChannelPositions(const MeasurementTrackerEvent & data) const {
+  const PxMeasurementDetSet::BadFEDChannelPositions* getBadFEDChannelPositions(
+      const MeasurementTrackerEvent& data) const {
     return data.pixelData().getBadFEDChannelPositions(index());
   }
 
@@ -87,27 +86,25 @@ public:
 
 private:
   unsigned int id_;
-  std::vector< LocalPoint > badRocPositions_;
+  std::vector<LocalPoint> badRocPositions_;
 
   int index_;
-  PxMeasurementConditionSet * theDetConditions;
-  PxMeasurementConditionSet & conditionSet() { return *theDetConditions; }
-  const PxMeasurementConditionSet & conditionSet() const { return *theDetConditions; }
+  PxMeasurementConditionSet* theDetConditions;
+  PxMeasurementConditionSet& conditionSet() { return *theDetConditions; }
+  const PxMeasurementConditionSet& conditionSet() const { return *theDetConditions; }
 
-  const PixelClusterParameterEstimator * cpe() const { return conditionSet().pixelCPE(); }
+  const PixelClusterParameterEstimator* cpe() const { return conditionSet().pixelCPE(); }
 
- public:
-
-  inline bool accept(SiPixelClusterRefNew & r, const std::vector<bool> skipClusters) const {
-    
-    if(skipClusters.empty()) return true;
-    if (r.key()>=skipClusters.size()){
-      edm::LogError("IndexMisMatch")<<r.key()<<" is larger than: "<<skipClusters.size()<<" no skipping done";
+public:
+  inline bool accept(SiPixelClusterRefNew& r, const std::vector<bool> skipClusters) const {
+    if (skipClusters.empty())
+      return true;
+    if (r.key() >= skipClusters.size()) {
+      edm::LogError("IndexMisMatch") << r.key() << " is larger than: " << skipClusters.size() << " no skipping done";
       return true;
     }
     return not skipClusters[r.key()];
   }
-
 };
 
 #endif

--- a/RecoTracker/MeasurementDet/plugins/TkStackMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkStackMeasurementDet.cc
@@ -4,36 +4,32 @@
 
 using namespace std;
 
-TkStackMeasurementDet::TkStackMeasurementDet( const StackGeomDet* gdet,
-                                              const PixelClusterParameterEstimator* cpe) :
-  MeasurementDet(gdet),
-  thePixelCPE(cpe),
-  theInnerDet(nullptr), theOuterDet(nullptr)
-{}
+TkStackMeasurementDet::TkStackMeasurementDet(const StackGeomDet* gdet, const PixelClusterParameterEstimator* cpe)
+    : MeasurementDet(gdet), thePixelCPE(cpe), theInnerDet(nullptr), theOuterDet(nullptr) {}
 
-void TkStackMeasurementDet::init(const MeasurementDet* lowerDet,
-                                 const MeasurementDet* upperDet) {
-  theInnerDet = dynamic_cast<const TkPhase2OTMeasurementDet *>(lowerDet);
-  theOuterDet = dynamic_cast<const TkPhase2OTMeasurementDet *>(upperDet);
+void TkStackMeasurementDet::init(const MeasurementDet* lowerDet, const MeasurementDet* upperDet) {
+  theInnerDet = dynamic_cast<const TkPhase2OTMeasurementDet*>(lowerDet);
+  theOuterDet = dynamic_cast<const TkPhase2OTMeasurementDet*>(upperDet);
 
   if ((theInnerDet == nullptr) || (theOuterDet == nullptr)) {
-    throw MeasurementDetException("TkStackMeasurementDet ERROR: Trying to glue a det which is not a TkPhase2OTMeasurementDet");
+    throw MeasurementDetException(
+        "TkStackMeasurementDet ERROR: Trying to glue a det which is not a TkPhase2OTMeasurementDet");
   }
 }
 
-TkStackMeasurementDet::RecHitContainer
-TkStackMeasurementDet::recHits( const TrajectoryStateOnSurface& ts, const MeasurementTrackerEvent & data) const
-{
+TkStackMeasurementDet::RecHitContainer TkStackMeasurementDet::recHits(const TrajectoryStateOnSurface& ts,
+                                                                      const MeasurementTrackerEvent& data) const {
   RecHitContainer result;
-/*
+  /*
   HitCollectorForRecHits collector( &fastGeomDet(), theMatcher, theCPE, result );
   collectRecHits(ts, collector);
 */
   return result;
 }
 
-bool TkStackMeasurementDet::measurements( const TrajectoryStateOnSurface& stateOnThisDet,
-                                          const MeasurementEstimator& est, const MeasurementTrackerEvent & data,
-                                          TempMeasurements & result) const {
+bool TkStackMeasurementDet::measurements(const TrajectoryStateOnSurface& stateOnThisDet,
+                                         const MeasurementEstimator& est,
+                                         const MeasurementTrackerEvent& data,
+                                         TempMeasurements& result) const {
   return true;
 }

--- a/RecoTracker/MeasurementDet/plugins/TkStackMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkStackMeasurementDet.h
@@ -12,36 +12,36 @@
 // FIXME::TkStackMeasurementDet in this moment is just a prototype: to be fixed soon!
 
 class TkStackMeasurementDet GCC11_FINAL : public MeasurementDet {
+public:
+  TkStackMeasurementDet(const StackGeomDet* gdet, const PixelClusterParameterEstimator* cpe);
+  void init(const MeasurementDet* lowerDet, const MeasurementDet* upperDet);
 
- public:
+  RecHitContainer recHits(const TrajectoryStateOnSurface&, const MeasurementTrackerEvent& data) const override;
 
-  TkStackMeasurementDet( const StackGeomDet* gdet, const PixelClusterParameterEstimator* cpe);
-  void init(const MeasurementDet* lowerDet,
-	    const MeasurementDet* upperDet);
+  const StackGeomDet& specificGeomDet() const { return static_cast<StackGeomDet const&>(fastGeomDet()); }
 
-  RecHitContainer recHits( const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & data) const override;
+  bool measurements(const TrajectoryStateOnSurface& stateOnThisDet,
+                    const MeasurementEstimator& est,
+                    const MeasurementTrackerEvent& data,
+                    TempMeasurements& result) const override;
 
-  const StackGeomDet& specificGeomDet() const {return static_cast<StackGeomDet const&>(fastGeomDet());}
-
-  bool measurements( const TrajectoryStateOnSurface& stateOnThisDet,
-			     const MeasurementEstimator& est, const MeasurementTrackerEvent & data,
-			     TempMeasurements & result) const override;
-
-  const TkPhase2OTMeasurementDet* lowerDet() const{ return theInnerDet;}
-  const TkPhase2OTMeasurementDet* upperDet() const{ return theOuterDet;}
+  const TkPhase2OTMeasurementDet* lowerDet() const { return theInnerDet; }
+  const TkPhase2OTMeasurementDet* upperDet() const { return theOuterDet; }
 
   /// return TRUE if both lower and upper components are active
-  bool isActive(const MeasurementTrackerEvent & data) const override {return lowerDet()->isActive(data) && upperDet()->isActive(data); }
+  bool isActive(const MeasurementTrackerEvent& data) const override {
+    return lowerDet()->isActive(data) && upperDet()->isActive(data);
+  }
 
   /// return TRUE if at least one of the lower and upper components has badChannels
-  bool hasBadComponents( const TrajectoryStateOnSurface &tsos, const MeasurementTrackerEvent & data ) const override {
-    return (lowerDet()->hasBadComponents(tsos, data) || upperDet()->hasBadComponents(tsos, data));}
+  bool hasBadComponents(const TrajectoryStateOnSurface& tsos, const MeasurementTrackerEvent& data) const override {
+    return (lowerDet()->hasBadComponents(tsos, data) || upperDet()->hasBadComponents(tsos, data));
+  }
 
- private:
+private:
   const PixelClusterParameterEstimator* thePixelCPE;
-  const TkPhase2OTMeasurementDet*       theInnerDet;
-  const TkPhase2OTMeasurementDet*       theOuterDet;
-
+  const TkPhase2OTMeasurementDet* theInnerDet;
+  const TkPhase2OTMeasurementDet* theOuterDet;
 };
 
 #endif

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.h
@@ -23,289 +23,275 @@
 #include "TrackingTools/DetLayers/interface/MeasurementEstimator.h"
 #include "RecoTracker/MeasurementDet/interface/ClusterFilterPayload.h"
 
-#include<tuple>
+#include <tuple>
 
 class TrackingRecHit;
-
 
 class TkStripMeasurementDet;
 
 struct dso_hidden TkStripRecHitIter {
   using detset = edmNew::DetSet<SiStripCluster>;
-  using new_const_iterator =  detset::const_iterator;
-  
+  using new_const_iterator = detset::const_iterator;
 
-  TkStripRecHitIter(){}
-  TkStripRecHitIter(const TkStripMeasurementDet & imdet,
-		    const TrajectoryStateOnSurface & itsos,
-		    const MeasurementTrackerEvent & idata) : mdet(&imdet),tsos(&itsos),data(&idata){}
-  
-  TkStripRecHitIter(new_const_iterator ci, new_const_iterator ce, 
-		    const TkStripMeasurementDet & imdet,
-		    const TrajectoryStateOnSurface & itsos,
-		    const MeasurementTrackerEvent & idata) 
-    : mdet(&imdet),tsos(&itsos),data(&idata), clusterI(ci), clusterE(ce) {}
-  
-  
-  const TkStripMeasurementDet * mdet = nullptr;
-  const TrajectoryStateOnSurface * tsos=nullptr;
-  const MeasurementTrackerEvent * data=nullptr;
-  
+  TkStripRecHitIter() {}
+  TkStripRecHitIter(const TkStripMeasurementDet& imdet,
+                    const TrajectoryStateOnSurface& itsos,
+                    const MeasurementTrackerEvent& idata)
+      : mdet(&imdet), tsos(&itsos), data(&idata) {}
+
+  TkStripRecHitIter(new_const_iterator ci,
+                    new_const_iterator ce,
+                    const TkStripMeasurementDet& imdet,
+                    const TrajectoryStateOnSurface& itsos,
+                    const MeasurementTrackerEvent& idata)
+      : mdet(&imdet), tsos(&itsos), data(&idata), clusterI(ci), clusterE(ce) {}
+
+  const TkStripMeasurementDet* mdet = nullptr;
+  const TrajectoryStateOnSurface* tsos = nullptr;
+  const MeasurementTrackerEvent* data = nullptr;
+
   new_const_iterator clusterI;
   new_const_iterator clusterE;
-  
+
   inline SiStripRecHit2D buildHit() const;
   inline void advance();
-  
+
 public:
-  
-  bool empty() const { return clusterI==clusterE; }
-  
-  bool operator==(TkStripRecHitIter const & rh) {
-    return clusterI==rh.clusterI;
-  }
-  bool operator!=(TkStripRecHitIter const & rh) {
-    return clusterI!=rh.clusterI;
-  }
-  bool operator<(TkStripRecHitIter const & rh) {
-    return clusterI<rh.clusterI;
-  }
-  
-  TkStripRecHitIter & operator++() {
+  bool empty() const { return clusterI == clusterE; }
+
+  bool operator==(TkStripRecHitIter const& rh) { return clusterI == rh.clusterI; }
+  bool operator!=(TkStripRecHitIter const& rh) { return clusterI != rh.clusterI; }
+  bool operator<(TkStripRecHitIter const& rh) { return clusterI < rh.clusterI; }
+
+  TkStripRecHitIter& operator++() {
     advance();
     return *this;
   }
-  
-  SiStripRecHit2D operator*() const {
-    return buildHit();
-  } 
-  
-};
 
+  SiStripRecHit2D operator*() const { return buildHit(); }
+};
 
 class dso_hidden TkStripMeasurementDet final : public MeasurementDet {
 public:
-  
-  typedef StripClusterParameterEstimator::LocalValues    LocalValues;
-  typedef StripClusterParameterEstimator::VLocalValues    VLocalValues;
-  
+  typedef StripClusterParameterEstimator::LocalValues LocalValues;
+  typedef StripClusterParameterEstimator::VLocalValues VLocalValues;
+
   typedef SiStripRecHit2D::ClusterRef SiStripClusterRef;
-  
+
   typedef edmNew::DetSet<SiStripCluster> detset;
   typedef detset::const_iterator new_const_iterator;
-  
-  typedef std::vector<SiStripCluster>::const_iterator const_iterator;
-  
-  ~TkStripMeasurementDet() override{}
-  
-  TkStripMeasurementDet( const GeomDet* gdet, StMeasurementConditionSet & conditionSet );
 
-  void setIndex(int i) { index_=i;}
-  
-  void setEmpty(StMeasurementDetSet & theDets) const { theDets.setEmpty(index()); }
-  
-  bool  isEmpty(const StMeasurementDetSet & theDets) const {return theDets.empty(index());}
-  
-  int index() const { return index_;}
+  typedef std::vector<SiStripCluster>::const_iterator const_iterator;
+
+  ~TkStripMeasurementDet() override {}
+
+  TkStripMeasurementDet(const GeomDet* gdet, StMeasurementConditionSet& conditionSet);
+
+  void setIndex(int i) { index_ = i; }
+
+  void setEmpty(StMeasurementDetSet& theDets) const { theDets.setEmpty(index()); }
+
+  bool isEmpty(const StMeasurementDetSet& theDets) const { return theDets.empty(index()); }
+
+  int index() const { return index_; }
 
   unsigned int rawId() const { return conditionSet().id(index()); }
-  unsigned char subId() const { return conditionSet().subId(index());}
-  
-  
-  const detset & theSet(const StMeasurementDetSet & theDets) const {return theDets.detSet(index());}
-  const detset & detSet(const StMeasurementDetSet & theDets) const {return theDets.detSet(index());}
+  unsigned char subId() const { return conditionSet().subId(index()); }
 
-  
+  const detset& theSet(const StMeasurementDetSet& theDets) const { return theDets.detSet(index()); }
+  const detset& detSet(const StMeasurementDetSet& theDets) const { return theDets.detSet(index()); }
+
   /** \brief Is this module active in reconstruction? It must be both 'setActiveThisEvent' and 'setActive'. */
-  bool isActive(const MeasurementTrackerEvent & data) const override { return data.stripData().isActive(index()); }
-  
+  bool isActive(const MeasurementTrackerEvent& data) const override { return data.stripData().isActive(index()); }
+
   //TO BE IMPLEMENTED
-  bool hasBadComponents( const TrajectoryStateOnSurface &tsos, const MeasurementTrackerEvent & data ) const override {return false;}
-  
-  
-  std::tuple<TkStripRecHitIter,TkStripRecHitIter> hitRange(const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & data) const;
-  void advance(TkStripRecHitIter & hi ) const;
-  SiStripRecHit2D hit(TkStripRecHitIter const & hi ) const;
-  
-  RecHitContainer recHits( const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & data) const override;
+  bool hasBadComponents(const TrajectoryStateOnSurface& tsos, const MeasurementTrackerEvent& data) const override {
+    return false;
+  }
 
+  std::tuple<TkStripRecHitIter, TkStripRecHitIter> hitRange(const TrajectoryStateOnSurface&,
+                                                            const MeasurementTrackerEvent& data) const;
+  void advance(TkStripRecHitIter& hi) const;
+  SiStripRecHit2D hit(TkStripRecHitIter const& hi) const;
 
-  bool empty(const MeasurementTrackerEvent & data) const;
+  RecHitContainer recHits(const TrajectoryStateOnSurface&, const MeasurementTrackerEvent& data) const override;
 
-  void simpleRecHits( const TrajectoryStateOnSurface& ts, const MeasurementTrackerEvent & data, std::vector<SiStripRecHit2D> &result) const ;
-  bool simpleRecHits( const TrajectoryStateOnSurface& ts, const MeasurementEstimator& est, const MeasurementTrackerEvent & data, std::vector<SiStripRecHit2D> &result) const ;
-  
+  bool empty(const MeasurementTrackerEvent& data) const;
+
+  void simpleRecHits(const TrajectoryStateOnSurface& ts,
+                     const MeasurementTrackerEvent& data,
+                     std::vector<SiStripRecHit2D>& result) const;
+  bool simpleRecHits(const TrajectoryStateOnSurface& ts,
+                     const MeasurementEstimator& est,
+                     const MeasurementTrackerEvent& data,
+                     std::vector<SiStripRecHit2D>& result) const;
+
   // simple hits
-  bool recHits(SimpleHitContainer & result,  
-		       const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator&, const MeasurementTrackerEvent & data) const override;
+  bool recHits(SimpleHitContainer& result,
+               const TrajectoryStateOnSurface& stateOnThisDet,
+               const MeasurementEstimator&,
+               const MeasurementTrackerEvent& data) const override;
 
   // TTRH
-  bool recHits( const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator& est, const MeasurementTrackerEvent & data,
-			RecHitContainer & result, std::vector<float> & diffs) const override;
-  
-  
-  bool measurements( const TrajectoryStateOnSurface& stateOnThisDet,
-			     const MeasurementEstimator& est, const MeasurementTrackerEvent & data,
-			     TempMeasurements & result) const override;
-  
-  const StripGeomDetUnit& specificGeomDet() const {return static_cast<StripGeomDetUnit const &>(fastGeomDet());}
-  
+  bool recHits(const TrajectoryStateOnSurface& stateOnThisDet,
+               const MeasurementEstimator& est,
+               const MeasurementTrackerEvent& data,
+               RecHitContainer& result,
+               std::vector<float>& diffs) const override;
 
-  template<class ClusterRefT>
-  TrackingRecHit::RecHitPointer
-  buildRecHit( const ClusterRefT &cluster, const TrajectoryStateOnSurface& ltp) const {
-    const GeomDetUnit& gdu( specificGeomDet());
-    LocalValues lv = cpe()->localParameters( *cluster, gdu, ltp);
-    return std::make_shared<SiStripRecHit2D>( lv.first, lv.second, fastGeomDet(), cluster);
+  bool measurements(const TrajectoryStateOnSurface& stateOnThisDet,
+                    const MeasurementEstimator& est,
+                    const MeasurementTrackerEvent& data,
+                    TempMeasurements& result) const override;
+
+  const StripGeomDetUnit& specificGeomDet() const { return static_cast<StripGeomDetUnit const&>(fastGeomDet()); }
+
+  template <class ClusterRefT>
+  TrackingRecHit::RecHitPointer buildRecHit(const ClusterRefT& cluster, const TrajectoryStateOnSurface& ltp) const {
+    const GeomDetUnit& gdu(specificGeomDet());
+    LocalValues lv = cpe()->localParameters(*cluster, gdu, ltp);
+    return std::make_shared<SiStripRecHit2D>(lv.first, lv.second, fastGeomDet(), cluster);
   }
-  
-  
-  template<class ClusterRefT>
-    void
-    buildRecHits( const ClusterRefT& cluster, const TrajectoryStateOnSurface& ltp,  const RecHitContainer& _res) const {
+
+  template <class ClusterRefT>
+  void buildRecHits(const ClusterRefT& cluster,
+                    const TrajectoryStateOnSurface& ltp,
+                    const RecHitContainer& _res) const {
     RecHitContainer res = _res;
-    const GeomDetUnit& gdu( specificGeomDet());
-    VLocalValues vlv = cpe()->localParametersV( *cluster, gdu, ltp);
-    for(VLocalValues::const_iterator it=vlv.begin();it!=vlv.end();++it)
-      res.push_back(std::make_shared<SiStripRecHit2D>( it->first, it->second, fastGeomDet(), cluster));
+    const GeomDetUnit& gdu(specificGeomDet());
+    VLocalValues vlv = cpe()->localParametersV(*cluster, gdu, ltp);
+    for (VLocalValues::const_iterator it = vlv.begin(); it != vlv.end(); ++it)
+      res.push_back(std::make_shared<SiStripRecHit2D>(it->first, it->second, fastGeomDet(), cluster));
   }
-  
 
-  template<class ClusterRefT>
-  bool filteredRecHits( const ClusterRefT& cluster, StripCPE::AlgoParam const& cpepar,
-			const TrajectoryStateOnSurface& ltp,  const MeasurementEstimator& est, const std::vector<bool> & skipClusters,
-			RecHitContainer & result, std::vector<float> & diffs) const {
-    if (isMasked(*cluster)) return true;
-    if (!accept(cluster, skipClusters)) return true;
-    if (!est.preFilter(ltp, ClusterFilterPayload(rawId(),&*cluster) )) return true;  // avoids shadow; consistent with previous statement...
-    auto const & vl = cpe()->localParameters( *cluster, cpepar);
-    SiStripRecHit2D recHit(vl.first, vl.second, fastGeomDet(), cluster); // FIXME add cluster count in OmniRef (and move again to multiple sub-clusters..)
-    std::pair<bool,double> diffEst = est.estimate(ltp, recHit);
-    LogDebug("TkStripMeasurementDet")<<" chi2=" << diffEst.second;
-    if ( diffEst.first ) {
+  template <class ClusterRefT>
+  bool filteredRecHits(const ClusterRefT& cluster,
+                       StripCPE::AlgoParam const& cpepar,
+                       const TrajectoryStateOnSurface& ltp,
+                       const MeasurementEstimator& est,
+                       const std::vector<bool>& skipClusters,
+                       RecHitContainer& result,
+                       std::vector<float>& diffs) const {
+    if (isMasked(*cluster))
+      return true;
+    if (!accept(cluster, skipClusters))
+      return true;
+    if (!est.preFilter(ltp, ClusterFilterPayload(rawId(), &*cluster)))
+      return true;  // avoids shadow; consistent with previous statement...
+    auto const& vl = cpe()->localParameters(*cluster, cpepar);
+    SiStripRecHit2D recHit(vl.first,
+                           vl.second,
+                           fastGeomDet(),
+                           cluster);  // FIXME add cluster count in OmniRef (and move again to multiple sub-clusters..)
+    std::pair<bool, double> diffEst = est.estimate(ltp, recHit);
+    LogDebug("TkStripMeasurementDet") << " chi2=" << diffEst.second;
+    if (diffEst.first) {
       result.push_back(std::make_shared<SiStripRecHit2D>(recHit));
       diffs.push_back(diffEst.second);
     }
     return diffEst.first;
   }
 
-
-  template<class ClusterRefT>
-    bool filteredRecHits( const ClusterRefT& cluster, StripCPE::AlgoParam const& cpepar,
-			  const TrajectoryStateOnSurface& ltp,  const MeasurementEstimator& est, const std::vector<bool> & skipClusters,
-			  std::vector<SiStripRecHit2D> & result) const {
-    if (isMasked(*cluster)) return true;
-    if (!accept(cluster, skipClusters)) return true;
-    if (!est.preFilter(ltp, ClusterFilterPayload(rawId(),&*cluster) )) return true;   // avoids shadow; consistent with previous statement...
-    auto const & vl = cpe()->localParameters( *cluster, cpepar);
-    result.emplace_back( vl.first, vl.second, fastGeomDet(), cluster);   // FIXME add cluster count in OmniRef
-    std::pair<bool,double> diffEst = est.estimate(ltp, result.back());
-    LogDebug("TkStripMeasurementDet")<<" chi2=" << diffEst.second;
-    if ( !diffEst.first ) result.pop_back();
+  template <class ClusterRefT>
+  bool filteredRecHits(const ClusterRefT& cluster,
+                       StripCPE::AlgoParam const& cpepar,
+                       const TrajectoryStateOnSurface& ltp,
+                       const MeasurementEstimator& est,
+                       const std::vector<bool>& skipClusters,
+                       std::vector<SiStripRecHit2D>& result) const {
+    if (isMasked(*cluster))
+      return true;
+    if (!accept(cluster, skipClusters))
+      return true;
+    if (!est.preFilter(ltp, ClusterFilterPayload(rawId(), &*cluster)))
+      return true;  // avoids shadow; consistent with previous statement...
+    auto const& vl = cpe()->localParameters(*cluster, cpepar);
+    result.emplace_back(vl.first, vl.second, fastGeomDet(), cluster);  // FIXME add cluster count in OmniRef
+    std::pair<bool, double> diffEst = est.estimate(ltp, result.back());
+    LogDebug("TkStripMeasurementDet") << " chi2=" << diffEst.second;
+    if (!diffEst.first)
+      result.pop_back();
     return diffEst.first;
   }
 
-
-
-  
   /** \brief Turn on/off the module for reconstruction, for the full run or lumi (using info from DB, usually). */
-  void setActiveThisPeriod(StMeasurementDetSet & theDets, bool active) { conditionSet().setActive(index(),active);}
+  void setActiveThisPeriod(StMeasurementDetSet& theDets, bool active) { conditionSet().setActive(index(), active); }
 
   /** \brief Turn on/off the module for reconstruction for one events.
       This per-event flag is cleared by any call to 'update' or 'setEmpty'  */
-  void setActiveThisEvent(StMeasurementDetSet & theDets, bool active) const {  theDets.setActiveThisEvent(index(),active); }
-  
+  void setActiveThisEvent(StMeasurementDetSet& theDets, bool active) const {
+    theDets.setActiveThisEvent(index(), active);
+  }
+
   /** \brief does this module have at least one bad strip, APV or channel? */
   bool hasAllGoodChannels() const { return (!hasAny128StripBad()) && badStripBlocks().empty(); }
-  
+
   /** \brief Sets the status of a block of 128 strips (or all blocks if idx=-1) */
-  void set128StripStatus(bool good, int idx=-1) {
-    conditionSet().set128StripStatus(index(),good,idx);
-  }
-  
+  void set128StripStatus(bool good, int idx = -1) { conditionSet().set128StripStatus(index(), good, idx); }
+
   typedef StMeasurementConditionSet::BadStripCuts BadStripCuts;
-  
+
   /** \brief return true if there are 'enough' good strips in the utraj +/- 3 uerr range.*/
   bool testStrips(float utraj, float uerr) const;
-  
-  typedef StMeasurementConditionSet::BadStripBlock BadStripBlock;
-  
-  std::vector<BadStripBlock> & getBadStripBlocks() { return conditionSet().getBadStripBlocks(index()); }
-  std::vector<BadStripBlock> const & badStripBlocks() const { return conditionSet().badStripBlocks(index()); }
 
-  bool maskBad128StripBlocks() const { return conditionSet().maskBad128StripBlocks();}
-  
+  typedef StMeasurementConditionSet::BadStripBlock BadStripBlock;
+
+  std::vector<BadStripBlock>& getBadStripBlocks() { return conditionSet().getBadStripBlocks(index()); }
+  std::vector<BadStripBlock> const& badStripBlocks() const { return conditionSet().badStripBlocks(index()); }
+
+  bool maskBad128StripBlocks() const { return conditionSet().maskBad128StripBlocks(); }
+
 private:
   using AClusters = StripClusterParameterEstimator::AClusters;
-  using ALocalValues  = StripClusterParameterEstimator::ALocalValues;
+  using ALocalValues = StripClusterParameterEstimator::ALocalValues;
 
-  
   int index_;
-  StMeasurementConditionSet * theDetConditions;
-  StMeasurementConditionSet & conditionSet() { return *theDetConditions; }
-  const StMeasurementConditionSet & conditionSet() const { return *theDetConditions; }
-  
-  const StripCPE * cpe() const { return  static_cast<const StripCPE *>(conditionSet().stripCPE()); }
+  StMeasurementConditionSet* theDetConditions;
+  StMeasurementConditionSet& conditionSet() { return *theDetConditions; }
+  const StMeasurementConditionSet& conditionSet() const { return *theDetConditions; }
+
+  const StripCPE* cpe() const { return static_cast<const StripCPE*>(conditionSet().stripCPE()); }
 
   // --- regional unpacking
   int totalStrips() const { return conditionSet().totalStrips(index()); }
-  BadStripCuts const & badStripCuts() const { return conditionSet().badStripCuts(index());}
-  
-  bool hasAny128StripBad() const { return  conditionSet().hasAny128StripBad(index()); } 
-  
-  
-  inline bool isMasked(const SiStripCluster &cluster) const {
-    return conditionSet().isMasked(index(), cluster);
-  }
-  
+  BadStripCuts const& badStripCuts() const { return conditionSet().badStripCuts(index()); }
 
-  void buildSimpleRecHits(AClusters const & clusters, const MeasurementTrackerEvent & data,
-			  const detset & detSet,
-			  const TrajectoryStateOnSurface& ltp,
-			  std::vector<SiStripRecHit2D>& res) const {
-    const GeomDetUnit& gdu( specificGeomDet());
-    declareDynArray(LocalValues,clusters.size(),alv);
+  bool hasAny128StripBad() const { return conditionSet().hasAny128StripBad(index()); }
+
+  inline bool isMasked(const SiStripCluster& cluster) const { return conditionSet().isMasked(index(), cluster); }
+
+  void buildSimpleRecHits(AClusters const& clusters,
+                          const MeasurementTrackerEvent& data,
+                          const detset& detSet,
+                          const TrajectoryStateOnSurface& ltp,
+                          std::vector<SiStripRecHit2D>& res) const {
+    const GeomDetUnit& gdu(specificGeomDet());
+    declareDynArray(LocalValues, clusters.size(), alv);
     cpe()->localParameters(clusters, alv, gdu, ltp.localParameters());
     res.reserve(alv.size());
-    for (unsigned int i=0; i< clusters.size(); ++i)
-      res.emplace_back( alv[i].first, alv[i].second, gdu, detSet.makeRefTo( data.stripData().handle(), clusters[i]) );
-    
+    for (unsigned int i = 0; i < clusters.size(); ++i)
+      res.emplace_back(alv[i].first, alv[i].second, gdu, detSet.makeRefTo(data.stripData().handle(), clusters[i]));
   }
 
-
-
- 
-  
-  
-  
 public:
-  inline bool accept(SiStripClusterRef const & r, const std::vector<bool> & skipClusters) const {
-    return  accept(r.key(), skipClusters);
+  inline bool accept(SiStripClusterRef const& r, const std::vector<bool>& skipClusters) const {
+    return accept(r.key(), skipClusters);
   }
 
-  inline bool accept(unsigned int key, const std::vector<bool> & skipClusters) const {
-    if(skipClusters.empty()) return true;
-    if (key>=skipClusters.size()){
-      LogDebug("TkStripMeasurementDet")<<key<<" is larger than: "<<skipClusters.size()
-				       <<"\n This must be a new cluster, and therefore should not be skiped most likely.";
+  inline bool accept(unsigned int key, const std::vector<bool>& skipClusters) const {
+    if (skipClusters.empty())
+      return true;
+    if (key >= skipClusters.size()) {
+      LogDebug("TkStripMeasurementDet")
+          << key << " is larger than: " << skipClusters.size()
+          << "\n This must be a new cluster, and therefore should not be skiped most likely.";
       return true;
     }
-    return (not (skipClusters[key]));
+    return (not(skipClusters[key]));
   }
-
-  
 };
 
-
-inline
-SiStripRecHit2D TkStripRecHitIter::buildHit() const {
-  return mdet->hit(*this);
-}
-inline
-void TkStripRecHitIter::advance() {
-  mdet->advance(*this);
-}
-
-
+inline SiStripRecHit2D TkStripRecHitIter::buildHit() const { return mdet->hit(*this); }
+inline void TkStripRecHitIter::advance() { mdet->advance(*this); }
 
 #endif

--- a/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
+++ b/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
@@ -1,79 +1,69 @@
 
 
-namespace {  
+namespace {
 
-  template<typename Collector>
+  template <typename Collector>
   struct CollectorHelper {
+    Collector& m_collector;
+    GlobalVector const& glbDir;
 
-    Collector & m_collector;
-    GlobalVector const & glbDir;
+    CollectorHelper(Collector& i_collector, GlobalVector const& i_glbDir)
+        : m_collector(i_collector), glbDir(i_glbDir) {}
 
-    CollectorHelper(Collector & i_collector,  GlobalVector const & i_glbDir) : 
-      m_collector(i_collector), glbDir(i_glbDir) {}
-    
-    inline static SiStripRecHit2D const & monoHit(TkGluedMeasurementDet::RecHitContainer::const_iterator monoHit) {
+    inline static SiStripRecHit2D const& monoHit(TkGluedMeasurementDet::RecHitContainer::const_iterator monoHit) {
       return *reinterpret_cast<const SiStripRecHit2D*>((**monoHit).hit());
     }
-    
-    inline static SiStripRecHit2D const & monoHit(std::vector<SiStripRecHit2D>::const_iterator iter) {
-      return *iter;
-    }
-    
-    inline static SiStripRecHit2D const & stereoHit(std::vector<SiStripRecHit2D>::const_iterator iter) {
-      return *iter;
-    }
-    
-    inline static SiStripRecHit2D const & stereoHit(TkGluedMeasurementDet::RecHitContainer::const_iterator hit) {
+
+    inline static SiStripRecHit2D const& monoHit(std::vector<SiStripRecHit2D>::const_iterator iter) { return *iter; }
+
+    inline static SiStripRecHit2D const& stereoHit(std::vector<SiStripRecHit2D>::const_iterator iter) { return *iter; }
+
+    inline static SiStripRecHit2D const& stereoHit(TkGluedMeasurementDet::RecHitContainer::const_iterator hit) {
       return *reinterpret_cast<const SiStripRecHit2D*>((**hit).hit());
     }
 
-    typename Collector::Collector & collector() { return m_collector.collector();}
-    
-    inline void closure( TkGluedMeasurementDet::RecHitContainer::const_iterator monoHit) {
+    typename Collector::Collector& collector() { return m_collector.collector(); }
+
+    inline void closure(TkGluedMeasurementDet::RecHitContainer::const_iterator monoHit) {
       if (m_collector.hasNewMatchedHits()) {
-	m_collector.clearNewMatchedHitsFlag();
+        m_collector.clearNewMatchedHitsFlag();
       } else {
-	m_collector.addProjected( **monoHit, glbDir );
+        m_collector.addProjected(**monoHit, glbDir);
       }
     }
 
     inline void closure(std::vector<SiStripRecHit2D>::const_iterator monoHit) {
       if (m_collector.hasNewMatchedHits()) {
-	m_collector.clearNewMatchedHitsFlag();
+        m_collector.clearNewMatchedHitsFlag();
       } else {
-	m_collector.addProjected( *monoHit, glbDir );
+        m_collector.addProjected(*monoHit, glbDir);
       }
     }
-  
-    
   };
 
-}
+}  // namespace
 
 #include "RecHitPropagator.h"
 #include "DataFormats/GeometrySurface/interface/RectangularPlaneBounds.h"
-#include "DataFormats/GeometrySurface/interface/LocalError.h" 
+#include "DataFormats/GeometrySurface/interface/LocalError.h"
 
 namespace {
-  inline
-  void print(const char* where, const TrajectoryStateOnSurface& t1,const TrajectoryStateOnSurface& t2) {
-    std::cout << where<< std::endl;
-    std::cout <<  t1.localParameters().vector() << std::endl;
-    std::cout <<  t1.localError().positionError() << std::endl;
-    std::cout <<  t2.localParameters().vector() << std::endl;
-    std::cout <<  t2.localError().positionError() << std::endl;
-
+  inline void print(const char* where, const TrajectoryStateOnSurface& t1, const TrajectoryStateOnSurface& t2) {
+    std::cout << where << std::endl;
+    std::cout << t1.localParameters().vector() << std::endl;
+    std::cout << t1.localError().positionError() << std::endl;
+    std::cout << t2.localParameters().vector() << std::endl;
+    std::cout << t2.localError().positionError() << std::endl;
   }
-}
+}  // namespace
 
+template <typename Collector>
+void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts,
+                                        const MeasurementTrackerEvent& data,
+                                        Collector& collector) const {
+  GlobalVector glbDir = (ts.isValid() ? ts.globalMomentum() : position() - GlobalPoint(0, 0, 0));
 
-template<typename Collector>
-void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts, const MeasurementTrackerEvent &data, Collector & collector) const {
-
-
-  GlobalVector glbDir = (ts.isValid() ? ts.globalMomentum() : position()-GlobalPoint(0,0,0));
- 
- //  static SiStripRecHitMatcher::SimpleHitCollection vsStereoHits;
+  //  static SiStripRecHitMatcher::SimpleHitCollection vsStereoHits;
   // vsStereoHits.resize(simpleSteroHitsByValue.size());
   //std::transform(simpleSteroHitsByValue.begin(), simpleSteroHitsByValue.end(), vsStereoHits.begin(), take_address());
 
@@ -82,79 +72,79 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts, cons
 
   auto mf = monoHits.size();
   auto sf = stereoHits.size();
-  
+
   bool emptyMono = false;
   bool emptyStereo = false;
 
   // FIXME  clean this and optimize the rest of the code once understood and validated
-  if (true) { // collector.filter()) {
+  if (true) {  // collector.filter()) {
     emptyMono = theMonoDet->empty(data);
-    if LIKELY(!emptyMono) {
+    if
+      LIKELY(!emptyMono) {
         // mono does require "projection" for precise estimate
-	TrajectoryStateOnSurface mts = fastProp(ts,geomDet().surface(),theMonoDet->geomDet().surface());
-	theMonoDet->simpleRecHits(mts,collector.estimator(),data,monoHits);
+        TrajectoryStateOnSurface mts = fastProp(ts, geomDet().surface(), theMonoDet->geomDet().surface());
+        theMonoDet->simpleRecHits(mts, collector.estimator(), data, monoHits);
       }
     // print("mono", mts,ts);
     mf = monoHits.size();
-  }
-  else {
-    theMonoDet->simpleRecHits(ts, data,monoHits);
+  } else {
+    theMonoDet->simpleRecHits(ts, data, monoHits);
     emptyMono = monoHits.empty();
   }
 
   // stereo requires "projection" for precision and change in coordinates
   if (collector.filter()) {
     emptyStereo = theStereoDet->empty(data);
-    if LIKELY(!emptyStereo) {
-	TrajectoryStateOnSurface pts = fastProp(ts,geomDet().surface(),theStereoDet->geomDet().surface());
-	theStereoDet->simpleRecHits(pts,collector.estimator(),data,stereoHits);
-	// print("stereo", pts,ts);
+    if
+      LIKELY(!emptyStereo) {
+        TrajectoryStateOnSurface pts = fastProp(ts, geomDet().surface(), theStereoDet->geomDet().surface());
+        theStereoDet->simpleRecHits(pts, collector.estimator(), data, stereoHits);
+        // print("stereo", pts,ts);
       }
     sf = stereoHits.size();
-  }
-  else {
-    theStereoDet->simpleRecHits(ts,data,stereoHits);
+  } else {
+    theStereoDet->simpleRecHits(ts, data, stereoHits);
     emptyStereo = stereoHits.empty();
   }
 
   if (collector.filter()) {
     auto mh = monoHits.size();
     auto sh = stereoHits.size();
-    stat(mh,sh,mf,sf);
+    stat(mh, sh, mf, sf);
   }
 
-  if UNLIKELY( emptyMono &  emptyStereo) return;
+  if
+    UNLIKELY(emptyMono & emptyStereo) return;
 
-  if UNLIKELY(emptyStereo) {
+  if
+    UNLIKELY(emptyStereo) {
       // make mono TTRHs and project them
-      projectOnGluedDet( collector, monoHits, glbDir);
+      projectOnGluedDet(collector, monoHits, glbDir);
       return;
     }
-  
-  if UNLIKELY( emptyMono ) {
+
+  if
+    UNLIKELY(emptyMono) {
       // make stereo TTRHs and project them
-    projectOnGluedDet( collector, stereoHits, glbDir);
-    return;
+      projectOnGluedDet(collector, stereoHits, glbDir);
+      return;
     }
 
-
-  if ((!monoHits.empty()) &  (!stereoHits.empty()) ) {
-    
+  if ((!monoHits.empty()) & (!stereoHits.empty())) {
     const GluedGeomDet* gluedDet = &specificGeomDet();
-    LocalVector trdir = (ts.isValid() ? ts.localDirection() : surface().toLocal( position()-GlobalPoint(0,0,0)));
-    
+    LocalVector trdir = (ts.isValid() ? ts.localDirection() : surface().toLocal(position() - GlobalPoint(0, 0, 0)));
+
     CollectorHelper<Collector> chelper(collector, glbDir);
-    theMatcher->doubleMatch(monoHits.begin(), monoHits.end(),
-			    stereoHits.begin(), stereoHits.end(),
-			    gluedDet, trdir, chelper);
+    theMatcher->doubleMatch(
+        monoHits.begin(), monoHits.end(), stereoHits.begin(), stereoHits.end(), gluedDet, trdir, chelper);
   }
 
-  if (ts.globalMomentum().perp2()> collector.estimator().minPt2ForHitRecoveryInGluedDet()) {
+  if (ts.globalMomentum().perp2() > collector.estimator().minPt2ForHitRecoveryInGluedDet()) {
     // if no match found try add mon than try to add stereo...
-    if (0==collector.size()) 
-      projectOnGluedDet( collector, monoHits, glbDir);
-    if (0==collector.size())
-      projectOnGluedDet( collector, stereoHits, glbDir);
+    if (0 == collector.size())
+      projectOnGluedDet(collector, monoHits, glbDir);
+    if (0 == collector.size())
+      projectOnGluedDet(collector, stereoHits, glbDir);
   }
   /*
   // recover hits outside 
@@ -173,6 +163,4 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts, cons
   if (collector.filter()) {
     stat.match(collector.size());
   }
-   
 }
-   

--- a/RecoTracker/MeasurementDet/plugins/module.cc
+++ b/RecoTracker/MeasurementDet/plugins/module.cc
@@ -3,10 +3,8 @@
 
 #include "RecoTracker/MeasurementDet/plugins/MeasurementTrackerESProducer.h"
 
-
 #include "FWCore/Framework/interface/ModuleFactory.h"
 #include "FWCore/Framework/interface/ESProducer.h"
 #include "FWCore/Utilities/interface/typelookup.h"
-
 
 DEFINE_FWK_EVENTSETUP_MODULE(MeasurementTrackerESProducer);

--- a/RecoTracker/MeasurementDet/src/LayerCollector.cc
+++ b/RecoTracker/MeasurementDet/src/LayerCollector.cc
@@ -1,15 +1,11 @@
 #include "RecoTracker/MeasurementDet/interface/LayerCollector.h"
-#include "RecoTracker/MeasurementDet/interface/StartingLayerFinder.h" 
+#include "RecoTracker/MeasurementDet/interface/StartingLayerFinder.h"
 #include "TrackingTools/DetLayers/interface/NavigationSchool.h"
 
 using namespace std;
 
 vector<const DetLayer*> LayerCollector::allLayers(const FTS& aFts) const {
-
-
   vector<const DetLayer*> myLayers;
-
-
 
   FTS myFts(aFts.parameters());
 
@@ -17,114 +13,64 @@ vector<const DetLayer*> LayerCollector::allLayers(const FTS& aFts) const {
 
   vector<const DetLayer*> dummy;
 
-
-
-
   bool inside = true;
-  while(inside) {
-
+  while (inside) {
     inside = false;
-    for(vector<const DetLayer*>::iterator ilay = nextLayers.begin(); ilay != nextLayers.end(); ilay++) {
-
-      
+    for (vector<const DetLayer*>::iterator ilay = nextLayers.begin(); ilay != nextLayers.end(); ilay++) {
       TSOS pTsos = propagator()->propagate(myFts, (**ilay).surface());
 
+      if (pTsos.isValid()) {
+        inside = true;
 
-      if(pTsos.isValid()) {
+        if ((**ilay).location() == GeomDetEnumerators::barrel) {
+          Range barrZRange((**ilay).position().z() - 0.5 * ((**ilay).surface().bounds().length()),
+                           (**ilay).position().z() + 0.5 * ((**ilay).surface().bounds().length()));
+          Range trajZRange(pTsos.globalPosition().z() - deltaZ(), pTsos.globalPosition().z() + deltaZ());
 
-	inside = true;
+          if (rangesIntersect(trajZRange, barrZRange))
+            myLayers.push_back(*ilay);
 
-     
+        } else if ((**ilay).location() == GeomDetEnumerators::endcap) {
+          const ForwardDetLayer* fwd = dynamic_cast<const ForwardDetLayer*>(*ilay);
+          Range fwdRRange((*fwd).specificSurface().innerRadius(), (*fwd).specificSurface().outerRadius());
+          Range trajRRange(pTsos.globalPosition().perp() - deltaR(), pTsos.globalPosition().perp() + deltaR());
 
-	if((**ilay).location() == GeomDetEnumerators::barrel) {
+          if (rangesIntersect(trajRRange, fwdRRange))
+            myLayers.push_back(*ilay);
+        }
 
-	  Range barrZRange((**ilay).position().z() - 
-			   0.5*((**ilay).surface().bounds().length()),
-			   (**ilay).position().z() + 
-			   0.5*((**ilay).surface().bounds().length()));
-	  Range trajZRange(pTsos.globalPosition().z() - deltaZ(),
-			   pTsos.globalPosition().z() + deltaZ());
-	  
-	  if(rangesIntersect(trajZRange, barrZRange)) 
-	    myLayers.push_back(*ilay);
+        myFts = FTS(pTsos.globalParameters());
 
-	} else if((**ilay).location() == GeomDetEnumerators::endcap) {
+        nextLayers = theSchool->nextLayers(**ilay, *pTsos.freeState(), propagator()->propagationDirection());
 
-	  const ForwardDetLayer* fwd = 
-	    dynamic_cast<const ForwardDetLayer*>(*ilay);
-	  Range fwdRRange((*fwd).specificSurface().innerRadius(),
-			  (*fwd).specificSurface().outerRadius());
-	  Range trajRRange(pTsos.globalPosition().perp() - deltaR(),
-			   pTsos.globalPosition().perp() + deltaR());
-
-	  if(rangesIntersect(trajRRange, fwdRRange)) 
-	    myLayers.push_back(*ilay);
-	 
-	}
-
-	myFts = FTS(pTsos.globalParameters());
- 
-	
-	nextLayers = theSchool->nextLayers(**ilay, *pTsos.freeState(), 
-					 propagator()->propagationDirection());
-
-
-	break;
-
-
-      }     
-
-
-
+        break;
+      }
     }
   }
 
-
-
-  
   return myLayers;
 }
 
 vector<const BarrelDetLayer*> LayerCollector::barrelLayers(const FTS& aFts) const {
-
   vector<const DetLayer*> all = allLayers(aFts);
   vector<const BarrelDetLayer*> barrelLayers;
 
-
-  for(vector<const DetLayer*>::iterator ilay = all.begin();
-      ilay != all.end(); ilay++) {
-
-    if(const BarrelDetLayer* myBarrel = 
-       dynamic_cast<const BarrelDetLayer*>(*ilay))
+  for (vector<const DetLayer*>::iterator ilay = all.begin(); ilay != all.end(); ilay++) {
+    if (const BarrelDetLayer* myBarrel = dynamic_cast<const BarrelDetLayer*>(*ilay))
       barrelLayers.push_back(myBarrel);
   }
 
-
   return barrelLayers;
 }
-  
+
 vector<const ForwardDetLayer*> LayerCollector::forwardLayers(const FTS& aFts) const {
-  
   vector<const DetLayer*> all = allLayers(aFts);
   vector<const ForwardDetLayer*> fwdLayers;
 
-
-  for(vector<const DetLayer*>::iterator ilay = all.begin();
-      ilay != all.end(); ilay++) {
-    
-    if(const ForwardDetLayer* myFwd = 
-       dynamic_cast<const ForwardDetLayer*>(*ilay))
+  for (vector<const DetLayer*>::iterator ilay = all.begin(); ilay != all.end(); ilay++) {
+    if (const ForwardDetLayer* myFwd = dynamic_cast<const ForwardDetLayer*>(*ilay))
       fwdLayers.push_back(myFwd);
   }
 
-  
   return fwdLayers;
 }
-
-
-
-
-
-
-
-

--- a/RecoTracker/MeasurementDet/src/MeasurementTracker.cc
+++ b/RecoTracker/MeasurementDet/src/MeasurementTracker.cc
@@ -1,8 +1,7 @@
 #include "RecoTracker/MeasurementDet/interface/MeasurementTracker.h"
 
-MeasurementTracker::~MeasurementTracker(){}
+MeasurementTracker::~MeasurementTracker() {}
 
 #include "FWCore/Utilities/interface/typelookup.h"
-
 
 TYPELOOKUP_DATA_REG(MeasurementTracker);

--- a/RecoTracker/MeasurementDet/src/MeasurementTrackerEvent.cc
+++ b/RecoTracker/MeasurementDet/src/MeasurementTrackerEvent.cc
@@ -2,87 +2,101 @@
 #include "RecoTracker/MeasurementDet/src/TkMeasurementDetSet.h"
 
 MeasurementTrackerEvent::~MeasurementTrackerEvent() {
-    if (theOwner) {
-        //std::cout << "Deleting owned MT @" << this << " (strip data @ " << theStripData << ")" << std::endl;
-        delete theStripData; theStripData = nullptr; // also sets to zero since sometimes the FWK seems
-        delete thePixelData; thePixelData = nullptr; // to double-delete the same object (!!!)
-        delete thePhase2OTData; thePhase2OTData = nullptr; // to double-delete the same object (!!!)
-    }
+  if (theOwner) {
+    //std::cout << "Deleting owned MT @" << this << " (strip data @ " << theStripData << ")" << std::endl;
+    delete theStripData;
+    theStripData = nullptr;  // also sets to zero since sometimes the FWK seems
+    delete thePixelData;
+    thePixelData = nullptr;  // to double-delete the same object (!!!)
+    delete thePhase2OTData;
+    thePhase2OTData = nullptr;  // to double-delete the same object (!!!)
+  }
 }
 
-MeasurementTrackerEvent::MeasurementTrackerEvent(MeasurementTrackerEvent && other) {
+MeasurementTrackerEvent::MeasurementTrackerEvent(MeasurementTrackerEvent &&other) {
   theTracker = std::move(other.theTracker);
   theStripData = std::move(other.theStripData);
   thePixelData = std::move(other.thePixelData);
   thePhase2OTData = std::move(other.thePhase2OTData);
   theOwner = other.theOwner;
-  other.theOwner = false; // make sure to fully transfer the ownership
+  other.theOwner = false;  // make sure to fully transfer the ownership
   theStripClustersToSkip = std::move(other.theStripClustersToSkip);
   thePixelClustersToSkip = std::move(other.thePixelClustersToSkip);
 }
-MeasurementTrackerEvent& MeasurementTrackerEvent::operator=(MeasurementTrackerEvent && other) {
+MeasurementTrackerEvent &MeasurementTrackerEvent::operator=(MeasurementTrackerEvent &&other) {
   theTracker = std::move(other.theTracker);
   theStripData = std::move(other.theStripData);
   thePixelData = std::move(other.thePixelData);
   thePhase2OTData = std::move(other.thePhase2OTData);
   theOwner = other.theOwner;
-  other.theOwner = false; // make sure to fully transfer the ownership
+  other.theOwner = false;  // make sure to fully transfer the ownership
   theStripClustersToSkip = std::move(other.theStripClustersToSkip);
   thePixelClustersToSkip = std::move(other.thePixelClustersToSkip);
   return *this;
 }
 
-MeasurementTrackerEvent::MeasurementTrackerEvent(const MeasurementTrackerEvent &trackerEvent,
-                           const edm::ContainerMask<edmNew::DetSetVector<SiStripCluster> > & stripClustersToSkip,
-                           const edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster> > & pixelClustersToSkip) :
-     theTracker(trackerEvent.theTracker),
-     theStripData(trackerEvent.theStripData), 
-     thePixelData(trackerEvent.thePixelData),
-     thePhase2OTData(nullptr),
-     theOwner(false)
-{
-    //std::cout << "Creatign non-owned MT @ " << this << " from @ " << & trackerEvent << " (strip data @ " << trackerEvent.theStripData << ")" << std::endl;
-    if (stripClustersToSkip.refProd().id() != theStripData->handle().id() ){
-        edm::LogError("ProductIdMismatch")<<"The strip masking does not point to the strip collection of clusters: "<<stripClustersToSkip.refProd().id()<<"!="<<  theStripData->handle().id();
-        throw cms::Exception("Configuration")<<"The strip masking does not point to the strip collection of clusters: "<<stripClustersToSkip.refProd().id()<<"!="<< theStripData->handle().id()<< "\n";
-    }
+MeasurementTrackerEvent::MeasurementTrackerEvent(
+    const MeasurementTrackerEvent &trackerEvent,
+    const edm::ContainerMask<edmNew::DetSetVector<SiStripCluster> > &stripClustersToSkip,
+    const edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster> > &pixelClustersToSkip)
+    : theTracker(trackerEvent.theTracker),
+      theStripData(trackerEvent.theStripData),
+      thePixelData(trackerEvent.thePixelData),
+      thePhase2OTData(nullptr),
+      theOwner(false) {
+  //std::cout << "Creatign non-owned MT @ " << this << " from @ " << & trackerEvent << " (strip data @ " << trackerEvent.theStripData << ")" << std::endl;
+  if (stripClustersToSkip.refProd().id() != theStripData->handle().id()) {
+    edm::LogError("ProductIdMismatch") << "The strip masking does not point to the strip collection of clusters: "
+                                       << stripClustersToSkip.refProd().id() << "!=" << theStripData->handle().id();
+    throw cms::Exception("Configuration")
+        << "The strip masking does not point to the strip collection of clusters: "
+        << stripClustersToSkip.refProd().id() << "!=" << theStripData->handle().id() << "\n";
+  }
 
-    if (pixelClustersToSkip.refProd().id() != thePixelData->handle().id()){
-        edm::LogError("ProductIdMismatch")<<"The pixel masking does not point to the proper collection of clusters: "<<pixelClustersToSkip.refProd().id()<<"!="<<thePixelData->handle().id();
-        throw cms::Exception("Configuration")<<"The pixel masking does not point to the proper collection of clusters: "<<pixelClustersToSkip.refProd().id()<<"!="<<thePixelData->handle().id()<<"\n";
-    }
+  if (pixelClustersToSkip.refProd().id() != thePixelData->handle().id()) {
+    edm::LogError("ProductIdMismatch") << "The pixel masking does not point to the proper collection of clusters: "
+                                       << pixelClustersToSkip.refProd().id() << "!=" << thePixelData->handle().id();
+    throw cms::Exception("Configuration")
+        << "The pixel masking does not point to the proper collection of clusters: "
+        << pixelClustersToSkip.refProd().id() << "!=" << thePixelData->handle().id() << "\n";
+  }
 
-    theStripClustersToSkip.resize(stripClustersToSkip.size());
-    stripClustersToSkip.copyMaskTo(theStripClustersToSkip);
+  theStripClustersToSkip.resize(stripClustersToSkip.size());
+  stripClustersToSkip.copyMaskTo(theStripClustersToSkip);
 
-    thePixelClustersToSkip.resize(pixelClustersToSkip.size());
-    pixelClustersToSkip.copyMaskTo(thePixelClustersToSkip);
+  thePixelClustersToSkip.resize(pixelClustersToSkip.size());
+  pixelClustersToSkip.copyMaskTo(thePixelClustersToSkip);
 }
 
 //FIXME:just temporary solution for phase2!
-MeasurementTrackerEvent::MeasurementTrackerEvent(const MeasurementTrackerEvent &trackerEvent,
-                           const edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster> > & pixelClustersToSkip,
-                           const edm::ContainerMask<edmNew::DetSetVector<Phase2TrackerCluster1D> > & phase2OTClustersToSkip) :
-     theTracker(trackerEvent.theTracker),
-     theStripData(nullptr), 
-     thePixelData(trackerEvent.thePixelData),
-     thePhase2OTData(trackerEvent.thePhase2OTData),
-     theOwner(false)
-{
+MeasurementTrackerEvent::MeasurementTrackerEvent(
+    const MeasurementTrackerEvent &trackerEvent,
+    const edm::ContainerMask<edmNew::DetSetVector<SiPixelCluster> > &pixelClustersToSkip,
+    const edm::ContainerMask<edmNew::DetSetVector<Phase2TrackerCluster1D> > &phase2OTClustersToSkip)
+    : theTracker(trackerEvent.theTracker),
+      theStripData(nullptr),
+      thePixelData(trackerEvent.thePixelData),
+      thePhase2OTData(trackerEvent.thePhase2OTData),
+      theOwner(false) {
+  if (pixelClustersToSkip.refProd().id() != thePixelData->handle().id()) {
+    edm::LogError("ProductIdMismatch") << "The pixel masking does not point to the proper collection of clusters: "
+                                       << pixelClustersToSkip.refProd().id() << "!=" << thePixelData->handle().id();
+    throw cms::Exception("Configuration")
+        << "The pixel masking does not point to the proper collection of clusters: "
+        << pixelClustersToSkip.refProd().id() << "!=" << thePixelData->handle().id() << "\n";
+  }
 
-    if (pixelClustersToSkip.refProd().id() != thePixelData->handle().id()){
-        edm::LogError("ProductIdMismatch")<<"The pixel masking does not point to the proper collection of clusters: "<<pixelClustersToSkip.refProd().id()<<"!="<<thePixelData->handle().id();
-        throw cms::Exception("Configuration")<<"The pixel masking does not point to the proper collection of clusters: "<<pixelClustersToSkip.refProd().id()<<"!="<<thePixelData->handle().id()<<"\n";
-    }
+  if (phase2OTClustersToSkip.refProd().id() != thePhase2OTData->handle().id()) {
+    edm::LogError("ProductIdMismatch") << "The pixel masking does not point to the proper collection of clusters: "
+                                       << pixelClustersToSkip.refProd().id() << "!=" << thePixelData->handle().id();
+    throw cms::Exception("Configuration")
+        << "The pixel masking does not point to the proper collection of clusters: "
+        << pixelClustersToSkip.refProd().id() << "!=" << thePixelData->handle().id() << "\n";
+  }
 
-    if (phase2OTClustersToSkip.refProd().id() != thePhase2OTData->handle().id()){
-        edm::LogError("ProductIdMismatch")<<"The pixel masking does not point to the proper collection of clusters: "<<pixelClustersToSkip.refProd().id()<<"!="<<thePixelData->handle().id();
-        throw cms::Exception("Configuration")<<"The pixel masking does not point to the proper collection of clusters: "<<pixelClustersToSkip.refProd().id()<<"!="<<thePixelData->handle().id()<<"\n";
-    }
+  thePixelClustersToSkip.resize(pixelClustersToSkip.size());
+  pixelClustersToSkip.copyMaskTo(thePixelClustersToSkip);
 
-    thePixelClustersToSkip.resize(pixelClustersToSkip.size());
-    pixelClustersToSkip.copyMaskTo(thePixelClustersToSkip);
-
-    thePhase2OTClustersToSkip.resize(phase2OTClustersToSkip.size());
-    phase2OTClustersToSkip.copyMaskTo(thePhase2OTClustersToSkip);
+  thePhase2OTClustersToSkip.resize(phase2OTClustersToSkip.size());
+  phase2OTClustersToSkip.copyMaskTo(thePhase2OTClustersToSkip);
 }

--- a/RecoTracker/MeasurementDet/src/StartingLayerFinder.cc
+++ b/RecoTracker/MeasurementDet/src/StartingLayerFinder.cc
@@ -11,135 +11,102 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
-
 #include <utility>
 
 using namespace std;
 
-vector<const DetLayer*> 
-StartingLayerFinder::startingLayers(const FTS& aFts, float dr, float dz) const {
-
-
-
-  
-  vector<const DetLayer*> mylayers; 
+vector<const DetLayer*> StartingLayerFinder::startingLayers(const FTS& aFts, float dr, float dz) const {
+  vector<const DetLayer*> mylayers;
   mylayers.reserve(3);
 
   FTS fastFts(aFts.parameters());
-  
 
   //barrel pixel
-  TSOS pTsos = 
-    propagator()->propagate(fastFts, firstPixelBarrelLayer()->surface());
-  
-  if(pTsos.isValid()) {
+  TSOS pTsos = propagator()->propagate(fastFts, firstPixelBarrelLayer()->surface());
 
-    Range barrZRange(firstPixelBarrelLayer()->position().z() - 
-		    0.5*(firstPixelBarrelLayer()->surface().bounds().length()),
-		     firstPixelBarrelLayer()->position().z() + 
-		   0.5*(firstPixelBarrelLayer()->surface().bounds().length()));
-    Range trajZRange(pTsos.globalPosition().z() - dz,
-		     pTsos.globalPosition().z() + dz);
+  if (pTsos.isValid()) {
+    Range barrZRange(
+        firstPixelBarrelLayer()->position().z() - 0.5 * (firstPixelBarrelLayer()->surface().bounds().length()),
+        firstPixelBarrelLayer()->position().z() + 0.5 * (firstPixelBarrelLayer()->surface().bounds().length()));
+    Range trajZRange(pTsos.globalPosition().z() - dz, pTsos.globalPosition().z() + dz);
 
-    if(rangesIntersect(trajZRange, barrZRange)) {
+    if (rangesIntersect(trajZRange, barrZRange)) {
       mylayers.push_back(firstPixelBarrelLayer());
-
     }
   }
 
-
   //negative fwd pixel
 
-  for(auto infwd : firstPosPixelFwdLayer() ) {
-    pTsos = propagator()->propagate(fastFts, infwd->surface());  
-    if(pTsos.isValid()) {
-      Range nfwdRRange(infwd->specificSurface().innerRadius(),
-		       infwd->specificSurface().outerRadius());
-      Range trajRRange(pTsos.globalPosition().perp() - dr,
-		       pTsos.globalPosition().perp() + dr);
-      if(rangesIntersect(trajRRange, nfwdRRange)) {
-	mylayers.push_back(infwd);
-
+  for (auto infwd : firstPosPixelFwdLayer()) {
+    pTsos = propagator()->propagate(fastFts, infwd->surface());
+    if (pTsos.isValid()) {
+      Range nfwdRRange(infwd->specificSurface().innerRadius(), infwd->specificSurface().outerRadius());
+      Range trajRRange(pTsos.globalPosition().perp() - dr, pTsos.globalPosition().perp() + dr);
+      if (rangesIntersect(trajRRange, nfwdRRange)) {
+        mylayers.push_back(infwd);
       }
     }
   }
 
   //positive fwd pixel
-  for(auto ipfwd: firstPosPixelFwdLayer()) {
+  for (auto ipfwd : firstPosPixelFwdLayer()) {
     pTsos = propagator()->propagate(fastFts, ipfwd->surface());
-    if(pTsos.isValid()) {
-      Range pfwdRRange(ipfwd->specificSurface().innerRadius(),
-		       ipfwd->specificSurface().outerRadius());
-      Range trajRRange(pTsos.globalPosition().perp() - dr,
-		       pTsos.globalPosition().perp() + dr);
-      if(rangesIntersect(trajRRange, pfwdRRange)) {
-	mylayers.push_back(ipfwd);
-
+    if (pTsos.isValid()) {
+      Range pfwdRRange(ipfwd->specificSurface().innerRadius(), ipfwd->specificSurface().outerRadius());
+      Range trajRRange(pTsos.globalPosition().perp() - dr, pTsos.globalPosition().perp() + dr);
+      if (rangesIntersect(trajRRange, pfwdRRange)) {
+        mylayers.push_back(ipfwd);
       }
     }
   }
 
-
-
   return mylayers;
-
-
-
-
-
 }
 
-vector<const DetLayer*> 
-StartingLayerFinder::startingLayers(const TrajectorySeed& aSeed) const {
-
-
-
+vector<const DetLayer*> StartingLayerFinder::startingLayers(const TrajectorySeed& aSeed) const {
   float dr = 0., dz = 0.;
 
-
-  if(propagator()->propagationDirection() != aSeed.direction())
+  if (propagator()->propagationDirection() != aSeed.direction())
     return vector<const DetLayer*>();
 
-  if(aSeed.nHits() != 2) return vector<const DetLayer*>();
- 
+  if (aSeed.nHits() != 2)
+    return vector<const DetLayer*>();
 
-  TrackingRecHitCollection::const_iterator firstHit= aSeed.recHits().first;
-  const TrackingRecHit* recHit1=&(*firstHit);
+  TrackingRecHitCollection::const_iterator firstHit = aSeed.recHits().first;
+  const TrackingRecHit* recHit1 = &(*firstHit);
   const DetLayer* hit1Layer = theMeasurementTracker->geometricSearchTracker()->detLayer(recHit1->geographicalId());
 
-  TrackingRecHitCollection::const_iterator secondHit= aSeed.recHits().second;
-  const TrackingRecHit* recHit2=&(*secondHit);
+  TrackingRecHitCollection::const_iterator secondHit = aSeed.recHits().second;
+  const TrackingRecHit* recHit2 = &(*secondHit);
   const DetLayer* hit2Layer = theMeasurementTracker->geometricSearchTracker()->detLayer(recHit2->geographicalId());
 
-  
-  GeomDetEnumerators::Location p1 =  hit1Layer->location();
-  GeomDetEnumerators::Location p2 =  hit2Layer->location();
+  GeomDetEnumerators::Location p1 = hit1Layer->location();
+  GeomDetEnumerators::Location p2 = hit2Layer->location();
 
-  if(p1 == GeomDetEnumerators::barrel && p2 == GeomDetEnumerators::barrel) {
-    dr = 0.1; dz = 5.;
-  } else if(p1 == GeomDetEnumerators::endcap && p2 == GeomDetEnumerators::endcap) {
-    dr = 5.; dz = 0.1;
+  if (p1 == GeomDetEnumerators::barrel && p2 == GeomDetEnumerators::barrel) {
+    dr = 0.1;
+    dz = 5.;
+  } else if (p1 == GeomDetEnumerators::endcap && p2 == GeomDetEnumerators::endcap) {
+    dr = 5.;
+    dz = 0.1;
   } else {
-    dr = 0.1; dz = 0.1;
+    dr = 0.1;
+    dz = 0.1;
   }
 
+  const GeomDet* gdet = theMeasurementTracker->geomTracker()->idToDet(DetId(aSeed.startingState().detId()));
 
-  
-  const GeomDet* gdet = theMeasurementTracker->geomTracker()->idToDet( DetId( aSeed.startingState().detId()));
-  
-  
-  TrajectoryStateOnSurface tsos = trajectoryStateTransform::transientState( aSeed.startingState(), &(gdet->surface()), 
-							      thePropagator->magneticField());
+  TrajectoryStateOnSurface tsos = trajectoryStateTransform::transientState(
+      aSeed.startingState(), &(gdet->surface()), thePropagator->magneticField());
 
+  const FreeTrajectoryState* fts = tsos.freeTrajectoryState();
 
-  const FreeTrajectoryState* fts=tsos.freeTrajectoryState();
-  
   return startingLayers(*fts, dr, dz);
 }
-  
+
 const BarrelDetLayer* StartingLayerFinder::firstPixelBarrelLayer() const {
   checkPixelLayers();
-  return theFirstPixelBarrelLayer;  
+  return theFirstPixelBarrelLayer;
 }
 
 const vector<const ForwardDetLayer*> StartingLayerFinder::firstNegPixelFwdLayer() const {
@@ -147,30 +114,18 @@ const vector<const ForwardDetLayer*> StartingLayerFinder::firstNegPixelFwdLayer(
   return theFirstNegPixelFwdLayer;
 }
 
-const vector<const ForwardDetLayer*>  StartingLayerFinder::firstPosPixelFwdLayer() const {
+const vector<const ForwardDetLayer*> StartingLayerFinder::firstPosPixelFwdLayer() const {
   checkPixelLayers();
   return theFirstPosPixelFwdLayer;
 }
 
 void StartingLayerFinder::checkPixelLayers() const {
+  if (!thePixelLayersValid) {
+    const GeometricSearchTracker* theGeometricSearchTracker = theMeasurementTracker->geometricSearchTracker();
 
-
-  if(!thePixelLayersValid) {
-   
-    const GeometricSearchTracker* theGeometricSearchTracker=theMeasurementTracker->geometricSearchTracker();
-
-   
     theFirstPixelBarrelLayer = theGeometricSearchTracker->pixelBarrelLayers().front();
     theFirstNegPixelFwdLayer = theGeometricSearchTracker->negPixelForwardLayers();
     theFirstPosPixelFwdLayer = theGeometricSearchTracker->posPixelForwardLayers();
     thePixelLayersValid = true;
-
-
- 
   }
-
-
 }
-
-
-

--- a/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.cc
+++ b/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.cc
@@ -1,45 +1,45 @@
 #include "TkMeasurementDetSet.h"
 
 void StMeasurementConditionSet::init(int size) {
-  activeThisPeriod_.resize(size,true);
+  activeThisPeriod_.resize(size, true);
   id_.resize(size);
   subId_.resize(size);
   totalStrips_.resize(size);
-  
-  bad128Strip_.resize(size*6);
+
+  bad128Strip_.resize(size * 6);
   hasAny128StripBad_.resize(size);
   badStripBlocks_.resize(size);
 }
 
-
-void StMeasurementConditionSet::set128StripStatus(int i, bool good, int idx) { 
-    int offset =  nbad128*i;
-    if (idx == -1) {
-      std::fill(bad128Strip_.begin()+offset, bad128Strip_.begin()+offset+6, !good);
-      hasAny128StripBad_[i] = !good;
-    } else {
-      bad128Strip_[offset+idx] = !good;
-      if (good == false) {
-         hasAny128StripBad_[i] = false;
-      } else { // this should not happen, as usually you turn on all fibers
-       // and then turn off the bad ones, and not vice-versa,
-       // so I don't care if it's not optimized
-         hasAny128StripBad_[i] = true;
-         for (int j = 0; i < (totalStrips_[j] >> 7); j++) {
-           if (bad128Strip_[j+offset] == false) {hasAny128StripBad_[i] = false; break;}
-         }
-      }    
-    } 
+void StMeasurementConditionSet::set128StripStatus(int i, bool good, int idx) {
+  int offset = nbad128 * i;
+  if (idx == -1) {
+    std::fill(bad128Strip_.begin() + offset, bad128Strip_.begin() + offset + 6, !good);
+    hasAny128StripBad_[i] = !good;
+  } else {
+    bad128Strip_[offset + idx] = !good;
+    if (good == false) {
+      hasAny128StripBad_[i] = false;
+    } else {  // this should not happen, as usually you turn on all fibers
+              // and then turn off the bad ones, and not vice-versa,
+              // so I don't care if it's not optimized
+      hasAny128StripBad_[i] = true;
+      for (int j = 0; i < (totalStrips_[j] >> 7); j++) {
+        if (bad128Strip_[j + offset] == false) {
+          hasAny128StripBad_[i] = false;
+          break;
+        }
+      }
+    }
   }
-  
+}
 
 void PxMeasurementConditionSet::init(int size) {
-  activeThisPeriod_.resize(size,true);
+  activeThisPeriod_.resize(size, true);
   id_.resize(size);
 }
 
 void Phase2OTMeasurementConditionSet::init(int size) {
-  activeThisPeriod_.resize(size,true);
+  activeThisPeriod_.resize(size, true);
   id_.resize(size);
 }
-

--- a/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.h
+++ b/RecoTracker/MeasurementDet/src/TkMeasurementDetSet.h
@@ -1,7 +1,7 @@
 #ifndef StMeasurementDetSet_H
 #define StMeasurementDetSet_H
 
-#include<vector>
+#include <vector>
 class TkStripMeasurementDet;
 class TkStripMeasurementDet;
 class TkPixelMeasurementDet;
@@ -27,7 +27,7 @@ class Phase2StripCPE;
 // #define VISTAT
 
 #ifdef VISTAT
-#include<iostream>
+#include <iostream>
 #define COUT std::cout
 #else
 #define COUT LogDebug("")
@@ -39,289 +39,279 @@ class Phase2StripCPE;
  */
 class StMeasurementConditionSet {
 public:
-  enum QualityFlags { BadModules=1, // for everybody
-                       /* Strips: */ BadAPVFibers=2, BadStrips=4, MaskBad128StripBlocks=8, 
-                       /* Pixels: */ BadROCs=2 }; 
+  enum QualityFlags {
+    BadModules = 1,  // for everybody
+    /* Strips: */ BadAPVFibers = 2,
+    BadStrips = 4,
+    MaskBad128StripBlocks = 8,
+    /* Pixels: */ BadROCs = 2
+  };
 
   struct BadStripCuts {
     BadStripCuts() : maxBad(9999), maxConsecutiveBad(9999) {}
-    BadStripCuts(const edm::ParameterSet &pset) :
-      maxBad(pset.getParameter<uint32_t>("maxBad")),
-      maxConsecutiveBad(pset.getParameter<uint32_t>("maxConsecutiveBad")) {}
+    BadStripCuts(const edm::ParameterSet& pset)
+        : maxBad(pset.getParameter<uint32_t>("maxBad")),
+          maxConsecutiveBad(pset.getParameter<uint32_t>("maxConsecutiveBad")) {}
     uint16_t maxBad, maxConsecutiveBad;
   };
-  
+
   struct BadStripBlock {
     short first;
     short last;
-    BadStripBlock(const SiStripBadStrip::data &data) : first(data.firstStrip), last(data.firstStrip+data.range-1) { }
+    BadStripBlock(const SiStripBadStrip::data& data) : first(data.firstStrip), last(data.firstStrip + data.range - 1) {}
   };
-  
-  
-  StMeasurementConditionSet(const SiStripRecHitMatcher* matcher,
-		           const StripClusterParameterEstimator* cpe):
-    theMatcher(matcher), theCPE(cpe){}
-  
-  
+
+  StMeasurementConditionSet(const SiStripRecHitMatcher* matcher, const StripClusterParameterEstimator* cpe)
+      : theMatcher(matcher), theCPE(cpe) {}
+
   void init(int size);
- 
-  const SiStripRecHitMatcher*  matcher() const { return theMatcher;}
-  const StripClusterParameterEstimator*  stripCPE() const { return theCPE;}
 
+  const SiStripRecHitMatcher* matcher() const { return theMatcher; }
+  const StripClusterParameterEstimator* stripCPE() const { return theCPE; }
 
-  int nDet() const { return id_.size();}
+  int nDet() const { return id_.size(); }
   unsigned int id(int i) const { return id_[i]; }
-  unsigned char subId(int i) const { return subId_[i];}
+  unsigned char subId(int i) const { return subId_[i]; }
 
-  int find(unsigned int jd, int i=0) const {
-    return std::lower_bound(id_.begin()+i,id_.end(),jd)-id_.begin();
-  }
-  
+  int find(unsigned int jd, int i = 0) const { return std::lower_bound(id_.begin() + i, id_.end(), jd) - id_.begin(); }
+
   bool isActiveThisPeriod(int i) const { return activeThisPeriod_[i]; }
 
- 
   /** \brief Turn on/off the module for reconstruction, for the full run or lumi (using info from DB, usually) */
   void setActive(int i, bool active) { activeThisPeriod_[i] = active; }
-  
-  int totalStrips(int i) const { return totalStrips_[i];}
-  
+
+  int totalStrips(int i) const { return totalStrips_[i]; }
+
   void setMaskBad128StripBlocks(bool maskThem) { maskBad128StripBlocks_ = maskThem; }
-  const BadStripCuts & badStripCuts(int i) const { return  badStripCuts_[subId_[i]];}
-  
-  bool maskBad128StripBlocks() const { return maskBad128StripBlocks_;}
-  bool hasAny128StripBad(int i) const { return  hasAny128StripBad_[i];}
-  
+  const BadStripCuts& badStripCuts(int i) const { return badStripCuts_[subId_[i]]; }
+
+  bool maskBad128StripBlocks() const { return maskBad128StripBlocks_; }
+  bool hasAny128StripBad(int i) const { return hasAny128StripBad_[i]; }
+
   /// note: index is 6*detector index + offset!
-  bool bad128Strip(int offset) const { return  bad128Strip_[offset];}
-  bool bad128Strip(int index, int strip) const { return  bad128Strip_[nbad128*index+(strip>>7)];}
+  bool bad128Strip(int offset) const { return bad128Strip_[offset]; }
+  bool bad128Strip(int index, int strip) const { return bad128Strip_[nbad128 * index + (strip >> 7)]; }
 
-  std::vector<BadStripBlock> & getBadStripBlocks(int i) { return badStripBlocks_[i]; }
-  std::vector<BadStripBlock> const & badStripBlocks(int i) const {return badStripBlocks_[i]; }
+  std::vector<BadStripBlock>& getBadStripBlocks(int i) { return badStripBlocks_[i]; }
+  std::vector<BadStripBlock> const& badStripBlocks(int i) const { return badStripBlocks_[i]; }
 
-  bool isMasked(int i, const SiStripCluster &cluster) const {
-    int offset =  nbad128*i;
-    if ( bad128Strip_[offset+( cluster.firstStrip() >> 7)] ) {
-      if ( bad128Strip_[offset+( (cluster.firstStrip()+cluster.amplitudes().size())  >> 7)] ||
-	   bad128Strip_[offset+( static_cast<int32_t>(cluster.barycenter()-0.499999) >> 7)] ) {
-	return true;
+  bool isMasked(int i, const SiStripCluster& cluster) const {
+    int offset = nbad128 * i;
+    if (bad128Strip_[offset + (cluster.firstStrip() >> 7)]) {
+      if (bad128Strip_[offset + ((cluster.firstStrip() + cluster.amplitudes().size()) >> 7)] ||
+          bad128Strip_[offset + (static_cast<int32_t>(cluster.barycenter() - 0.499999) >> 7)]) {
+        return true;
       }
     } else {
-      if ( bad128Strip_[offset+( (cluster.firstStrip()+cluster.amplitudes().size())  >> 7)] &&
-	   bad128Strip_[offset+( static_cast<int32_t>(cluster.barycenter()-0.499999) >> 7)] ) {
-	return true;
+      if (bad128Strip_[offset + ((cluster.firstStrip() + cluster.amplitudes().size()) >> 7)] &&
+          bad128Strip_[offset + (static_cast<int32_t>(cluster.barycenter() - 0.499999) >> 7)]) {
+        return true;
       }
     }
     return false;
   }
-  
-  
-  void set128StripStatus(int i, bool good, int idx=-1);  
+
+  void set128StripStatus(int i, bool good, int idx = -1);
 
 private:
-  
-  friend class  MeasurementTrackerImpl;
-  
+  friend class MeasurementTrackerImpl;
+
   // globals
-  const SiStripRecHitMatcher*       theMatcher;
+  const SiStripRecHitMatcher* theMatcher;
   const StripClusterParameterEstimator* theCPE;
-  
+
   bool maskBad128StripBlocks_;
   BadStripCuts badStripCuts_[4];
-  
+
   // members of TkStripMeasurementDet
   std::vector<unsigned int> id_;
   std::vector<unsigned char> subId_;
-  
+
   std::vector<int> totalStrips_;
-  
+
   static const int nbad128 = 6;
   std::vector<bool> bad128Strip_;
   std::vector<bool> hasAny128StripBad_;
-  
-  std::vector<std::vector<BadStripBlock>> badStripBlocks_;  
+
+  std::vector<std::vector<BadStripBlock>> badStripBlocks_;
 
   std::vector<bool> activeThisPeriod_;
 };
 
 class StMeasurementDetSet {
 public:
-
   typedef edmNew::DetSet<SiStripCluster> StripDetset;
   typedef StripDetset::const_iterator new_const_iterator;
-  
 
-  StMeasurementDetSet(const StMeasurementConditionSet & cond) : 
-    conditionSet_(&cond),
-    empty_(cond.nDet(), true),
-    activeThisEvent_(cond.nDet(), true),
-    detSet_(cond.nDet()),
-    detIndex_(cond.nDet(),-1),
-    ready_(cond.nDet(),true),
-    theRawInactiveStripDetIds_(),
-    stripDefined_(0), 
-    stripUpdated_(0), 
-    stripRegions_(0) 
-  {
-  }
+  StMeasurementDetSet(const StMeasurementConditionSet& cond)
+      : conditionSet_(&cond),
+        empty_(cond.nDet(), true),
+        activeThisEvent_(cond.nDet(), true),
+        detSet_(cond.nDet()),
+        detIndex_(cond.nDet(), -1),
+        ready_(cond.nDet(), true),
+        theRawInactiveStripDetIds_(),
+        stripDefined_(0),
+        stripUpdated_(0),
+        stripRegions_(0) {}
 
-  ~StMeasurementDetSet() {
-    printStat();
-  }
+  ~StMeasurementDetSet() { printStat(); }
 
-  const StMeasurementConditionSet & conditions() const { return *conditionSet_; } 
- 
- 
-  void update(int i,const StripDetset & detSet ) { 
-    detSet_[i] = detSet;     
+  const StMeasurementConditionSet& conditions() const { return *conditionSet_; }
+
+  void update(int i, const StripDetset& detSet) {
+    detSet_[i] = detSet;
     empty_[i] = false;
   }
 
-  void update(int i, int j ) {
-    assert(j>=0); assert(empty_[i]); assert(ready_[i]); 
+  void update(int i, int j) {
+    assert(j >= 0);
+    assert(empty_[i]);
+    assert(ready_[i]);
     detIndex_[i] = j;
     empty_[i] = false;
     incReady();
   }
 
   int size() const { return conditions().nDet(); }
-  int nDet() const { return size();}
+  int nDet() const { return size(); }
   unsigned int id(int i) const { return conditions().id(i); }
-  int find(unsigned int jd, int i=0) const  {
-    return conditions().find(jd,i);
-  }
-  
-  bool empty(int i) const { return empty_[i];}  
+  int find(unsigned int jd, int i = 0) const { return conditions().find(jd, i); }
+
+  bool empty(int i) const { return empty_[i]; }
   bool isActive(int i) const { return activeThisEvent_[i] && conditions().isActiveThisPeriod(i); }
 
-  void setEmpty(int i) {empty_[i] = true; activeThisEvent_[i] = true; }
+  void setEmpty(int i) {
+    empty_[i] = true;
+    activeThisEvent_[i] = true;
+  }
   void setUpdated(int i) { stripUpdated_[i] = true; }
-  
+
   void setEmpty() {
     printStat();
-    std::fill(empty_.begin(),empty_.end(),true);
-    std::fill(ready_.begin(),ready_.end(),true);
-    std::fill(detIndex_.begin(),detIndex_.end(),-1);
-    std::fill(activeThisEvent_.begin(), activeThisEvent_.end(),true);
+    std::fill(empty_.begin(), empty_.end(), true);
+    std::fill(ready_.begin(), ready_.end(), true);
+    std::fill(detIndex_.begin(), detIndex_.end(), -1);
+    std::fill(activeThisEvent_.begin(), activeThisEvent_.end(), true);
     incTot(size());
   }
-  
+
   /** \brief Turn on/off the module for reconstruction for one events.
       This per-event flag is cleared by any call to 'update' or 'setEmpty'  */
-  void setActiveThisEvent(int i, bool active) { activeThisEvent_[i] = active;  if (!active) empty_[i] = true; }
-  
-  edm::Handle<edmNew::DetSetVector<SiStripCluster> > & handle() {  return handle_; }
-  const edm::Handle<edmNew::DetSetVector<SiStripCluster> > & handle() const {  return handle_; }
+  void setActiveThisEvent(int i, bool active) {
+    activeThisEvent_[i] = active;
+    if (!active)
+      empty_[i] = true;
+  }
+
+  edm::Handle<edmNew::DetSetVector<SiStripCluster>>& handle() { return handle_; }
+  const edm::Handle<edmNew::DetSetVector<SiStripCluster>>& handle() const { return handle_; }
   // StripDetset & detSet(int i) { return detSet_[i]; }
-  const StripDetset & detSet(int i) const { if (ready_[i]) const_cast<StMeasurementDetSet*>(this)->getDetSet(i);     return detSet_[i]; }
-  
+  const StripDetset& detSet(int i) const {
+    if (ready_[i])
+      const_cast<StMeasurementDetSet*>(this)->getDetSet(i);
+    return detSet_[i];
+  }
 
-  //// ------- pieces for on-demand unpacking -------- 
-  std::vector<uint32_t> & rawInactiveStripDetIds() { return theRawInactiveStripDetIds_; } 
-  const std::vector<uint32_t> & rawInactiveStripDetIds() const { return theRawInactiveStripDetIds_; } 
+  //// ------- pieces for on-demand unpacking --------
+  std::vector<uint32_t>& rawInactiveStripDetIds() { return theRawInactiveStripDetIds_; }
+  const std::vector<uint32_t>& rawInactiveStripDetIds() const { return theRawInactiveStripDetIds_; }
 
-  void resetOnDemandStrips() { std::fill(stripDefined_.begin(), stripDefined_.end(), false); std::fill(stripUpdated_.begin(), stripUpdated_.end(), false); }
+  void resetOnDemandStrips() {
+    std::fill(stripDefined_.begin(), stripDefined_.end(), false);
+    std::fill(stripUpdated_.begin(), stripUpdated_.end(), false);
+  }
   const bool stripDefined(int i) const { return stripDefined_[i]; }
   const bool stripUpdated(int i) const { return stripUpdated_[i]; }
   void defineStrip(int i, std::pair<unsigned int, unsigned int> range) {
     stripDefined_[i] = true;
     stripUpdated_[i] = false;
-    stripRegions_[i] = range; 
+    stripRegions_[i] = range;
   }
 
 private:
-
   void getDetSet(int i) {
-    if(detIndex_[i]>=0) {
-      detSet_[i].set(*handle_,handle_->item(detIndex_[i]));
-      empty_[i]=false; // better be false already
+    if (detIndex_[i] >= 0) {
+      detSet_[i].set(*handle_, handle_->item(detIndex_[i]));
+      empty_[i] = false;  // better be false already
       incAct();
-    }  else { // we should not be here
+    } else {  // we should not be here
       detSet_[i] = StripDetset();
-      empty_[i]=true;  
+      empty_[i] = true;
     }
-    ready_[i]=false;
+    ready_[i] = false;
     incSet();
   }
 
+  friend class MeasurementTrackerImpl;
 
-  friend class  MeasurementTrackerImpl;
-
-  const StMeasurementConditionSet *conditionSet_; 
-
+  const StMeasurementConditionSet* conditionSet_;
 
   // Globals, per-event
-  edm::Handle<edmNew::DetSetVector<SiStripCluster> > handle_;
+  edm::Handle<edmNew::DetSetVector<SiStripCluster>> handle_;
 
- 
   std::vector<bool> empty_;
   std::vector<bool> activeThisEvent_;
-  
+
   // full reco
   std::vector<StripDetset> detSet_;
   std::vector<int> detIndex_;
-  std::vector<bool> ready_; // to be cleaned
-  
- 
+  std::vector<bool> ready_;  // to be cleaned
+
   // note: not aligned to the index
   std::vector<uint32_t> theRawInactiveStripDetIds_;
   // keyed on si-strip index
   std::vector<bool> stripDefined_, stripUpdated_;
-  std::vector<std::pair<unsigned int, unsigned int> > stripRegions_;
+  std::vector<std::pair<unsigned int, unsigned int>> stripRegions_;
   // keyed on glued
   // std::vector<bool> gluedUpdated_;
 
-
-
 #ifdef VISTAT
   struct Stat {
-    int totDet=0; // all dets
-    int detReady=0; // dets "updated"
-    int detSet=0;  // det actually set not empty
-    int detAct=0;  // det actually set with content
+    int totDet = 0;    // all dets
+    int detReady = 0;  // dets "updated"
+    int detSet = 0;    // det actually set not empty
+    int detAct = 0;    // det actually set with content
   };
 
   mutable Stat stat;
   void zeroStat() const { stat = Stat(); }
-  void incTot(int n) const { stat.totDet=n;}
-  void incReady() const { stat.detReady++;}
-  void incSet() const { stat.detSet++;}
-  void incAct() const { stat.detAct++;}
+  void incTot(int n) const { stat.totDet = n; }
+  void incReady() const { stat.detReady++; }
+  void incSet() const { stat.detSet++; }
+  void incAct() const { stat.detAct++; }
   void printStat() const {
-    COUT << "VI detsets " << stat.totDet <<','<< stat.detReady <<','<< stat.detSet <<','<< stat.detAct << std::endl;
+    COUT << "VI detsets " << stat.totDet << ',' << stat.detReady << ',' << stat.detSet << ',' << stat.detAct
+         << std::endl;
   }
 
 #else
-  static void zeroStat(){}
-  static void incTot(int){}
+  static void zeroStat() {}
+  static void incTot(int) {}
   static void incReady() {}
   static void incSet() {}
   static void incAct() {}
-  static void printStat(){}
+  static void printStat() {}
 #endif
-   
 };
 
 class PxMeasurementConditionSet {
 public:
-  PxMeasurementConditionSet(const PixelClusterParameterEstimator *cpe) :
-    theCPE(cpe) {}
+  PxMeasurementConditionSet(const PixelClusterParameterEstimator* cpe) : theCPE(cpe) {}
 
   void init(int size);
 
-  int nDet() const { return id_.size();}
+  int nDet() const { return id_.size(); }
   unsigned int id(int i) const { return id_[i]; }
-  int find(unsigned int jd, int i=0) const {
-    return std::lower_bound(id_.begin()+i,id_.end(),jd)-id_.begin();
-  }
+  int find(unsigned int jd, int i = 0) const { return std::lower_bound(id_.begin() + i, id_.end(), jd) - id_.begin(); }
 
-  const PixelClusterParameterEstimator*  pixelCPE() const { return theCPE;}
+  const PixelClusterParameterEstimator* pixelCPE() const { return theCPE; }
   bool isActiveThisPeriod(int i) const { return activeThisPeriod_[i]; }
 
   /** \brief Turn on/off the module for reconstruction, for the full run or lumi (using info from DB, usually).
       This also resets the 'setActiveThisEvent' to true */
   void setActive(int i, bool active) { activeThisPeriod_[i] = active; }
 
- 
 private:
   friend class MeasurementTrackerImpl;
 
@@ -331,86 +321,81 @@ private:
   // Locals, per-event
   std::vector<unsigned int> id_;
   std::vector<bool> activeThisPeriod_;
-
 };
-
 
 class PxMeasurementDetSet {
 public:
   typedef edm::Ref<edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster> SiPixelClusterRef;
   typedef edmNew::DetSet<SiPixelCluster> PixelDetSet;
-  typedef std::vector<std::pair<LocalPoint,LocalPoint> > BadFEDChannelPositions;
+  typedef std::vector<std::pair<LocalPoint, LocalPoint>> BadFEDChannelPositions;
 
-  PxMeasurementDetSet(const PxMeasurementConditionSet &cond) : 
-    conditionSet_(&cond),
-    detSet_(cond.nDet()),
-    empty_(cond.nDet(), true),
-    activeThisEvent_(cond.nDet(), true) {}
+  PxMeasurementDetSet(const PxMeasurementConditionSet& cond)
+      : conditionSet_(&cond), detSet_(cond.nDet()), empty_(cond.nDet(), true), activeThisEvent_(cond.nDet(), true) {}
 
-  const PxMeasurementConditionSet & conditions() const { return *conditionSet_; } 
+  const PxMeasurementConditionSet& conditions() const { return *conditionSet_; }
 
   int size() const { return conditions().nDet(); }
-  int nDet() const { return size();}
+  int nDet() const { return size(); }
   unsigned int id(int i) const { return conditions().id(i); }
-  int find(unsigned int jd, int i=0) const {
-    return conditions().find(jd,i);
-  }
+  int find(unsigned int jd, int i = 0) const { return conditions().find(jd, i); }
 
-  void update(int i,const PixelDetSet & detSet ) { 
-    detSet_[i] = detSet;     
+  void update(int i, const PixelDetSet& detSet) {
+    detSet_[i] = detSet;
     empty_[i] = false;
   }
 
-  bool empty(int i) const { return empty_[i];}  
+  bool empty(int i) const { return empty_[i]; }
   bool isActive(int i) const { return activeThisEvent_[i] && conditions().isActiveThisPeriod(i); }
 
   void setEmpty(int i) {
     empty_[i] = true;
     activeThisEvent_[i] = true;
     auto found = badFEDChannelPositionsSet_.find(i);
-    if(found != badFEDChannelPositionsSet_.end()) {
+    if (found != badFEDChannelPositionsSet_.end()) {
       badFEDChannelPositionsSet_.erase(found);
     }
   }
-  
+
   void setEmpty() {
-    std::fill(empty_.begin(),empty_.end(),true);
-    std::fill(activeThisEvent_.begin(), activeThisEvent_.end(),true);
+    std::fill(empty_.begin(), empty_.end(), true);
+    std::fill(activeThisEvent_.begin(), activeThisEvent_.end(), true);
     badFEDChannelPositionsSet_.clear();
   }
-  void setActiveThisEvent(bool active) {
-    std::fill(activeThisEvent_.begin(), activeThisEvent_.end(),active);
-  }
-  
+  void setActiveThisEvent(bool active) { std::fill(activeThisEvent_.begin(), activeThisEvent_.end(), active); }
+
   const BadFEDChannelPositions* getBadFEDChannelPositions(int i) const {
     auto found = badFEDChannelPositionsSet_.find(i);
-    if(found == badFEDChannelPositionsSet_.end())
+    if (found == badFEDChannelPositionsSet_.end())
       return nullptr;
     return &(found->second);
   }
   void addBadFEDChannelPositions(int i, BadFEDChannelPositions& positions) {
     auto found = badFEDChannelPositionsSet_.find(i);
-    if(found == badFEDChannelPositionsSet_.end()) {
+    if (found == badFEDChannelPositionsSet_.end()) {
       badFEDChannelPositionsSet_.emplace(i, positions);
-    }
-    else {
+    } else {
       found->second.insert(found->second.end(), positions.begin(), positions.end());
     }
   }
 
   /** \brief Turn on/off the module for reconstruction for one events.
       This per-event flag is cleared by any call to 'update' or 'setEmpty'  */
-  void setActiveThisEvent(int i, bool active) { activeThisEvent_[i] = active;  if (!active) empty_[i] = true; }
-  const edm::Handle<edmNew::DetSetVector<SiPixelCluster> > & handle() const {  return handle_;}
-  edm::Handle<edmNew::DetSetVector<SiPixelCluster> > & handle() {  return handle_;}
-  const PixelDetSet & detSet(int i) const { return detSet_[i];}
+  void setActiveThisEvent(int i, bool active) {
+    activeThisEvent_[i] = active;
+    if (!active)
+      empty_[i] = true;
+  }
+  const edm::Handle<edmNew::DetSetVector<SiPixelCluster>>& handle() const { return handle_; }
+  edm::Handle<edmNew::DetSetVector<SiPixelCluster>>& handle() { return handle_; }
+  const PixelDetSet& detSet(int i) const { return detSet_[i]; }
+
 private:
   friend class MeasurementTrackerImpl;
 
-  const PxMeasurementConditionSet *conditionSet_;
+  const PxMeasurementConditionSet* conditionSet_;
 
   // Globals, per-event
-  edm::Handle<edmNew::DetSetVector<SiPixelCluster> > handle_;
+  edm::Handle<edmNew::DetSetVector<SiPixelCluster>> handle_;
 
   // Locals, per-event
   std::vector<PixelDetSet> detSet_;
@@ -422,35 +407,30 @@ private:
 //FIXME:just temporary solution for phase2 OT that works!
 class Phase2OTMeasurementConditionSet {
 public:
-  Phase2OTMeasurementConditionSet(const ClusterParameterEstimator<Phase2TrackerCluster1D> *cpe) :
-    theCPE(cpe) {}
+  Phase2OTMeasurementConditionSet(const ClusterParameterEstimator<Phase2TrackerCluster1D>* cpe) : theCPE(cpe) {}
 
   void init(int size);
 
-  int nDet() const { return id_.size();}
+  int nDet() const { return id_.size(); }
   unsigned int id(int i) const { return id_[i]; }
-  int find(unsigned int jd, int i=0) const {
-    return std::lower_bound(id_.begin()+i,id_.end(),jd)-id_.begin();
-  }
+  int find(unsigned int jd, int i = 0) const { return std::lower_bound(id_.begin() + i, id_.end(), jd) - id_.begin(); }
 
-  const ClusterParameterEstimator<Phase2TrackerCluster1D>*  cpe() const { return theCPE;}
+  const ClusterParameterEstimator<Phase2TrackerCluster1D>* cpe() const { return theCPE; }
   bool isActiveThisPeriod(int i) const { return activeThisPeriod_[i]; }
 
   /** \brief Turn on/off the module for reconstruction, for the full run or lumi (using info from DB, usually).
  *       This also resets the 'setActiveThisEvent' to true */
   void setActive(int i, bool active) { activeThisPeriod_[i] = active; }
 
-
 private:
   friend class MeasurementTrackerImpl;
 
   // Globals (not-per-event)
   const ClusterParameterEstimator<Phase2TrackerCluster1D>* theCPE;
-  
+
   // Locals, per-event
   std::vector<unsigned int> id_;
   std::vector<bool> activeThisPeriod_;
-  
 };
 
 class Phase2OTMeasurementDetSet {
@@ -458,54 +438,55 @@ public:
   typedef edm::Ref<edmNew::DetSetVector<Phase2TrackerCluster1D>, Phase2TrackerCluster1D> Phase2TrackerCluster1DRef;
   typedef edmNew::DetSet<Phase2TrackerCluster1D> Phase2DetSet;
 
-  Phase2OTMeasurementDetSet(const Phase2OTMeasurementConditionSet &cond) :
-    conditionSet_(&cond),
-    detSet_(cond.nDet()),
-    empty_(cond.nDet(), true),
-    activeThisEvent_(cond.nDet(), true)  {}
+  Phase2OTMeasurementDetSet(const Phase2OTMeasurementConditionSet& cond)
+      : conditionSet_(&cond), detSet_(cond.nDet()), empty_(cond.nDet(), true), activeThisEvent_(cond.nDet(), true) {}
 
-  const Phase2OTMeasurementConditionSet & conditions() const { return *conditionSet_; }
+  const Phase2OTMeasurementConditionSet& conditions() const { return *conditionSet_; }
 
   int size() const { return conditions().nDet(); }
-  int nDet() const { return size();}
+  int nDet() const { return size(); }
   unsigned int id(int i) const { return conditions().id(i); }
-  int find(unsigned int jd, int i=0) const {
-    return conditions().find(jd,i);
-  }
+  int find(unsigned int jd, int i = 0) const { return conditions().find(jd, i); }
 
-  void update(int i,const Phase2DetSet & detSet ) {
+  void update(int i, const Phase2DetSet& detSet) {
     detSet_[i] = detSet;
     empty_[i] = false;
   }
 
-  bool empty(int i) const { return empty_[i];}
+  bool empty(int i) const { return empty_[i]; }
   bool isActive(int i) const { return activeThisEvent_[i] && conditions().isActiveThisPeriod(i); }
 
-  void setEmpty(int i) {empty_[i] = true; activeThisEvent_[i] = true; }
+  void setEmpty(int i) {
+    empty_[i] = true;
+    activeThisEvent_[i] = true;
+  }
 
   void setEmpty() {
-    std::fill(empty_.begin(),empty_.end(),true);
-    std::fill(activeThisEvent_.begin(), activeThisEvent_.end(),true);
+    std::fill(empty_.begin(), empty_.end(), true);
+    std::fill(activeThisEvent_.begin(), activeThisEvent_.end(), true);
   }
-  void setActiveThisEvent(bool active) {
-    std::fill(activeThisEvent_.begin(), activeThisEvent_.end(),active);
+  void setActiveThisEvent(bool active) { std::fill(activeThisEvent_.begin(), activeThisEvent_.end(), active); }
+  void setActiveThisEvent(int i, bool active) {
+    activeThisEvent_[i] = active;
+    if (!active)
+      empty_[i] = true;
   }
-  void setActiveThisEvent(int i, bool active) { activeThisEvent_[i] = active;  if (!active) empty_[i] = true; }
-  const edm::Handle<edmNew::DetSetVector<Phase2TrackerCluster1D> > & handle() const {  return handle_;}
-  edm::Handle<edmNew::DetSetVector<Phase2TrackerCluster1D> > & handle() {  return handle_;}
-  const Phase2DetSet & detSet(int i) const { return detSet_[i];}
+  const edm::Handle<edmNew::DetSetVector<Phase2TrackerCluster1D>>& handle() const { return handle_; }
+  edm::Handle<edmNew::DetSetVector<Phase2TrackerCluster1D>>& handle() { return handle_; }
+  const Phase2DetSet& detSet(int i) const { return detSet_[i]; }
+
 private:
   friend class MeasurementTrackerImpl;
 
-  const Phase2OTMeasurementConditionSet *conditionSet_;
+  const Phase2OTMeasurementConditionSet* conditionSet_;
 
   //Globals, per-event
-  edm::Handle<edmNew::DetSetVector<Phase2TrackerCluster1D> > handle_;
- 
+  edm::Handle<edmNew::DetSetVector<Phase2TrackerCluster1D>> handle_;
+
   // Locals, per-event
   std::vector<Phase2DetSet> detSet_;
   std::vector<bool> empty_;
   std::vector<bool> activeThisEvent_;
 };
 
-#endif // StMeasurementDetSet_H
+#endif  // StMeasurementDetSet_H

--- a/RecoTracker/MeasurementDet/src/classes.h
+++ b/RecoTracker/MeasurementDet/src/classes.h
@@ -1,7 +1,9 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 
-namespace RecoTracker_MeasurementDet { struct dictionary {
-  MeasurementTrackerEvent dummy;
-  edm::Wrapper<MeasurementTrackerEvent> dummy1;
-};}
+namespace RecoTracker_MeasurementDet {
+  struct dictionary {
+    MeasurementTrackerEvent dummy;
+    edm::Wrapper<MeasurementTrackerEvent> dummy1;
+  };
+}  // namespace RecoTracker_MeasurementDet

--- a/RecoTracker/MeasurementDet/test/MeasurementTrackerTest.cc
+++ b/RecoTracker/MeasurementDet/test/MeasurementTrackerTest.cc
@@ -26,7 +26,6 @@
 #include "MagneticField/VolumeGeometry/interface/MagVolumeOutsideValidity.h"
 #include "DataFormats/GeometrySurface/interface/PlaneBuilder.h"
 
-
 #include "TrackingTools/GeomPropagators/interface/AnalyticalPropagator.h"
 #include "TrackPropagation/RungeKutta/interface/defaultRKPropagator.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
@@ -38,22 +37,19 @@
 
 namespace {
 
-Surface::RotationType rotation( const GlobalVector& zDir)
-{
-  GlobalVector zAxis = zDir.unit();
-  GlobalVector yAxis( zAxis.y(), -zAxis.x(), 0); 
-  GlobalVector xAxis = yAxis.cross( zAxis);
-  return Surface::RotationType( xAxis, yAxis, zAxis);
-}
+  Surface::RotationType rotation(const GlobalVector& zDir) {
+    GlobalVector zAxis = zDir.unit();
+    GlobalVector yAxis(zAxis.y(), -zAxis.x(), 0);
+    GlobalVector xAxis = yAxis.cross(zAxis);
+    return Surface::RotationType(xAxis, yAxis, zAxis);
+  }
 
-
-}
+}  // namespace
 
 class MeasurementTrackerTest : public edm::EDAnalyzer {
 public:
   explicit MeasurementTrackerTest(const edm::ParameterSet&);
   ~MeasurementTrackerTest();
-
 
 private:
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
@@ -62,40 +58,38 @@ private:
   std::string theNavigationSchoolName;
 };
 
-
-MeasurementTrackerTest::MeasurementTrackerTest(const edm::ParameterSet& iConfig): 
-   theMeasurementTrackerName(iConfig.getParameter<std::string>("measurementTracker"))
-  ,theNavigationSchoolName(iConfig.getParameter<std::string>("navigationSchool")){}
+MeasurementTrackerTest::MeasurementTrackerTest(const edm::ParameterSet& iConfig)
+    : theMeasurementTrackerName(iConfig.getParameter<std::string>("measurementTracker")),
+      theNavigationSchoolName(iConfig.getParameter<std::string>("navigationSchool")) {}
 
 MeasurementTrackerTest::~MeasurementTrackerTest() {}
 
-void MeasurementTrackerTest::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void MeasurementTrackerTest::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
-  
+
   //get the measurementtracker
   edm::ESHandle<MeasurementTracker> measurementTracker;
-  edm::ESHandle<NavigationSchool>   navSchool;
+  edm::ESHandle<NavigationSchool> navSchool;
 
   iSetup.get<CkfComponentsRecord>().get(theMeasurementTrackerName, measurementTracker);
   iSetup.get<NavigationSchoolRecord>().get(theNavigationSchoolName, navSchool);
 
-  auto const & geom = *(TrackerGeometry const *)(*measurementTracker).geomTracker();
-  auto const & searchGeom = *(*measurementTracker).geometricSearchTracker();
-  auto const & dus = geom.detUnits();
-  
+  auto const& geom = *(TrackerGeometry const*)(*measurementTracker).geomTracker();
+  auto const& searchGeom = *(*measurementTracker).geometricSearchTracker();
+  auto const& dus = geom.detUnits();
+
   auto firstBarrel = geom.offsetDU(GeomDetEnumerators::tkDetEnum[1]);
   auto firstForward = geom.offsetDU(GeomDetEnumerators::tkDetEnum[2]);
- 
+
   std::cout << "number of dets " << dus.size() << std::endl;
-  std::cout << "Bl/Fw loc " << firstBarrel<< '/' << firstForward << std::endl;
+  std::cout << "Bl/Fw loc " << firstBarrel << '/' << firstForward << std::endl;
 
   edm::ESHandle<MagneticField> magfield;
   iSetup.get<IdealMagneticFieldRecord>().get(magfield);
 
-  edm::ESHandle<Propagator>             propagatorHandle;
+  edm::ESHandle<Propagator> propagatorHandle;
   iSetup.get<TrackingComponentsRecord>().get("PropagatorWithMaterial", propagatorHandle);
-  auto const & ANprop = *propagatorHandle;  
+  auto const& ANprop = *propagatorHandle;
 
   // error (very very small)
   ROOT::Math::SMatrixIdentity id;
@@ -105,82 +99,89 @@ void MeasurementTrackerTest::analyze(const edm::Event& iEvent, const edm::EventS
   CurvilinearTrajectoryError err(C);
 
   //use negative sigma=-3.0 in order to use a more conservative definition of isInside() for Bounds classes.
-  Chi2MeasurementEstimator estimator(30.,-3.0,0.5,2.0,0.5,1.e12);  // same as defauts....
-  
+  Chi2MeasurementEstimator estimator(30., -3.0, 0.5, 2.0, 0.5, 1.e12);  // same as defauts....
+
   KFUpdator kfu;
-  LocalError he(0.01*0.01,0,0.02*0.02);
+  LocalError he(0.01 * 0.01, 0, 0.02 * 0.02);
 
-  for (float tl = 0.1f; tl<3.0f; tl+=0.5f) {
+  for (float tl = 0.1f; tl < 3.0f; tl += 0.5f) {
+    float p = 1.0f;
+    float phi = 0.1415f;
+    float tanlmd = tl;  // 0.1f;
+    auto sinth2 = 1.f / (1.f + tanlmd * tanlmd);
+    auto sinth = std::sqrt(sinth2);
+    auto costh = tanlmd * sinth;
 
-  float p = 1.0f;
-  float phi = 0.1415f;
-  float tanlmd = tl; // 0.1f;
-  auto sinth2 = 1.f/(1.f+tanlmd*tanlmd);
-  auto sinth = std::sqrt(sinth2);
-  auto costh = tanlmd*sinth;
+    std::cout << tanlmd << ' ' << sinth << ' ' << costh << std::endl;
 
-  std::cout << tanlmd << ' ' << sinth << ' ' << costh << std::endl;
+    GlobalVector startingMomentum(p * std::sin(phi) * sinth, p * std::cos(phi) * sinth, p * costh);
+    float z = 0.1f;
+    GlobalPoint startingPosition(0, 0, z);
 
-  GlobalVector startingMomentum(p*std::sin(phi)*sinth,p*std::cos(phi)*sinth,p*costh);
-  float z = 0.1f;
-  GlobalPoint startingPosition(0,0,z);
+    // make TSOS happy
+    //Define starting plane
+    PlaneBuilder pb;
+    auto rot = rotation(startingMomentum);
+    auto startingPlane = pb.plane(startingPosition, rot);
 
-  // make TSOS happy
-  //Define starting plane
-  PlaneBuilder pb;
-  auto rot = rotation(startingMomentum);
-  auto startingPlane = pb.plane( startingPosition, rot);
+    GlobalVector moms[3] = {0.5f * startingMomentum, startingMomentum, 10.f * startingMomentum};
 
-  GlobalVector moms[3] = { 0.5f*startingMomentum,startingMomentum,10.f*startingMomentum};
-  
-  for (auto mom : moms) {
+    for (auto mom : moms) {
+      TrajectoryStateOnSurface startingStateP(
+          GlobalTrajectoryParameters(startingPosition, mom, 1, magfield.product()), err, *startingPlane);
+      auto tsos = startingStateP;
 
-  TrajectoryStateOnSurface startingStateP( GlobalTrajectoryParameters(startingPosition, 
-	  				          mom, 1, magfield.product()), 
-				                  err, *startingPlane);
-  auto tsos = startingStateP;
+      // auto layer = searchGeom.idToLayer(dus[firstBarrel]->geographicalId());
+      const DetLayer* layer = searchGeom.pixelBarrelLayers().front();
+      {
+        auto it = layer;
+        std::cout << "first layer " << (it->isBarrel() ? " Barrel" : " Forward") << " layer " << it->seqNum()
+                  << " SubDet " << it->subDetector() << std::endl;
+      }
+      auto const& detWithState = layer->compatibleDets(tsos, ANprop, estimator);
+      if (!detWithState.size()) {
+        std::cout << "no det on first layer" << std::endl;
+        continue;
+      }
+      auto did = detWithState.front().first->geographicalId();
+      std::cout << "arrived at " << int(did) << std::endl;
+      tsos = detWithState.front().second;
+      std::cout << tsos.globalPosition() << ' ' << tsos.localError().positionError() << std::endl;
 
-  // auto layer = searchGeom.idToLayer(dus[firstBarrel]->geographicalId());
-  const DetLayer* layer = searchGeom.pixelBarrelLayers().front();
-  {
-    auto it = layer;
-   std::cout << "first layer " << (it->isBarrel() ? " Barrel" : " Forward") << " layer " << it->seqNum() << " SubDet " << it->subDetector()<< std::endl;
-  }
-  auto const & detWithState = layer->compatibleDets(tsos,ANprop,estimator);
-  if(!detWithState.size()) { std::cout << "no det on first layer" << std::endl; continue;}
-  auto did = detWithState.front().first->geographicalId();
-  std::cout << "arrived at " << int(did) << std::endl;
-  tsos = detWithState.front().second;
-  std::cout << tsos.globalPosition() << ' ' << tsos.localError().positionError() << std::endl;
+      SiPixelRecHit::ClusterRef pref;
+      SiPixelRecHit hitpx(tsos.localPosition(), he, 1., *detWithState.front().first, pref);
+      tsos = kfu.update(tsos, hitpx);
+      std::cout << tsos.globalPosition() << ' ' << tsos.localError().positionError() << std::endl;
 
-  SiPixelRecHit::ClusterRef pref;
-  SiPixelRecHit   hitpx(tsos.localPosition(),he,1.,*detWithState.front().first,pref);
-  tsos = kfu.update(tsos, hitpx);
-  std::cout << tsos.globalPosition() << ' ' << tsos.localError().positionError() << std::endl;
-
-
-  for (auto il=1; il<5;	++il) {
-  if (!layer) break;
-  auto const & compLayers = (*navSchool).nextLayers(*layer,*tsos.freeState(),alongMomentum);
-  layer = nullptr;
-  for(auto it : compLayers){
-    if (it->basicComponents().empty()) {
-	   //this should never happen. but better protect for it
-	   std::cout <<"a detlayer with no components: I cannot figure out a DetId from this layer. please investigate." << std::endl;
-	   continue;
+      for (auto il = 1; il < 5; ++il) {
+        if (!layer)
+          break;
+        auto const& compLayers = (*navSchool).nextLayers(*layer, *tsos.freeState(), alongMomentum);
+        layer = nullptr;
+        for (auto it : compLayers) {
+          if (it->basicComponents().empty()) {
+            //this should never happen. but better protect for it
+            std::cout
+                << "a detlayer with no components: I cannot figure out a DetId from this layer. please investigate."
+                << std::endl;
+            continue;
+          }
+          std::cout << il << (it->isBarrel() ? " Barrel" : " Forward") << " layer " << it->seqNum() << " SubDet "
+                    << it->subDetector() << std::endl;
+          auto const& detWithState = it->compatibleDets(tsos, ANprop, estimator);
+          if (!detWithState.size()) {
+            std::cout << "no det on this layer" << std::endl;
+            continue;
+          }
+          layer = it;
+          auto did = detWithState.front().first->geographicalId();
+          std::cout << "arrived at " << int(did) << std::endl;
+          tsos = detWithState.front().second;
+          std::cout << tsos.globalPosition() << ' ' << tsos.localError().positionError() << std::endl;
         }
-    std::cout << il << (it->isBarrel() ? " Barrel" : " Forward") << " layer " << it->seqNum() << " SubDet " << it->subDetector()<< std::endl;
-    auto const & detWithState = it->compatibleDets(tsos,ANprop,estimator);
-    if(!detWithState.size()) { std::cout << "no det on this layer" << std::endl; continue;}
-    layer = it;
-    auto did = detWithState.front().first->geographicalId();
-    std::cout << "arrived at " << int(did) << std::endl;
-    tsos = detWithState.front().second;
-    std::cout << tsos.globalPosition() << ' ' << tsos.localError().positionError() << std::endl; 
-  }
-  } // layer loop
-  }  // loop on moms
- } // loop  on tanLa
+      }  // layer loop
+    }    // loop on moms
+  }      // loop  on tanLa
 }
 
 //define this as a plug-in

--- a/RecoVertex/MultiVertexFit/interface/DefaultMVFAnnealing.h
+++ b/RecoVertex/MultiVertexFit/interface/DefaultMVFAnnealing.h
@@ -4,7 +4,6 @@
 #include "RecoVertex/VertexTools/interface/GeometricAnnealing.h"
 
 class DefaultMVFAnnealing : public GeometricAnnealing {
-
 public:
   /**
    *  Default annealing schedule from mvf
@@ -19,8 +18,7 @@ public:
    *  DefaultMVFAnnealing:Tini=1024
    *  DefaultMVFAnnealing:Ratio=0.2
    */
-  DefaultMVFAnnealing( const double cutoff=9., const double T=1024.,
-     const double annealing_ratio=0.2 );
+  DefaultMVFAnnealing(const double cutoff = 9., const double T = 1024., const double annealing_ratio = 0.2);
 };
 
 #endif

--- a/RecoVertex/MultiVertexFit/interface/LinTrackCache.h
+++ b/RecoVertex/MultiVertexFit/interface/LinTrackCache.h
@@ -7,36 +7,32 @@
 #include "DataFormats/GeometrySurface/interface/ReferenceCounted.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 
-class LinTrackCache
-{
+class LinTrackCache {
 private:
-  struct Comparer
-  {
-    bool operator() ( const GlobalPoint &, const GlobalPoint & ) const;
+  struct Comparer {
+    bool operator()(const GlobalPoint &, const GlobalPoint &) const;
   };
 
-  struct Vicinity
-  {
-    bool operator() ( const GlobalPoint &, const GlobalPoint & ) const;
+  struct Vicinity {
+    bool operator()(const GlobalPoint &, const GlobalPoint &) const;
   };
 
 public:
-
   typedef ReferenceCountingPointer<LinearizedTrackState<5> > RefCountedLinearizedTrackState;
 
   /**
    *  \class LinTrackCache
    *  caches LinearizedTrackStates
    */
-  RefCountedLinearizedTrackState linTrack ( const GlobalPoint &, const reco::TransientTrack & );
+  RefCountedLinearizedTrackState linTrack(const GlobalPoint &, const reco::TransientTrack &);
   ~LinTrackCache();
   void clear();
 
 private:
-  typedef std::map < reco::TransientTrack, RefCountedLinearizedTrackState > LinTrkMap;
-  typedef std::map < reco::TransientTrack, bool > HasLinTrkMap;
-  std::map < GlobalPoint, LinTrkMap, Vicinity > theLinTracks;
-  std::map < GlobalPoint, HasLinTrkMap, Vicinity > theHasLinTrack;
+  typedef std::map<reco::TransientTrack, RefCountedLinearizedTrackState> LinTrkMap;
+  typedef std::map<reco::TransientTrack, bool> HasLinTrkMap;
+  std::map<GlobalPoint, LinTrkMap, Vicinity> theLinTracks;
+  std::map<GlobalPoint, HasLinTrkMap, Vicinity> theHasLinTrack;
 };
 
 #endif

--- a/RecoVertex/MultiVertexFit/interface/MultiVertexBSeeder.h
+++ b/RecoVertex/MultiVertexFit/interface/MultiVertexBSeeder.h
@@ -9,21 +9,17 @@
  *  (i.e. high-multiplicity, collimated track "bundles" with
  *  at least one secondary vertex )
  */
-class MultiVertexBSeeder : public VertexReconstructor
-{
+class MultiVertexBSeeder : public VertexReconstructor {
 public:
-  MultiVertexBSeeder ( double nsigma=50. );
-  std::vector<TransientVertex> vertices(
-      const std::vector<reco::TransientTrack> &) const override; 
-  std::vector<TransientVertex> vertices(
-      const std::vector<reco::TransientTrack> &,
-      const reco::BeamSpot & ) const override; 
+  MultiVertexBSeeder(double nsigma = 50.);
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &) const override;
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &,
+                                        const reco::BeamSpot &) const override;
 
-  MultiVertexBSeeder * clone() const override;
+  MultiVertexBSeeder *clone() const override;
 
 private:
   double theNSigma;
-
 };
 
 #endif

--- a/RecoVertex/MultiVertexFit/interface/MultiVertexFitter.h
+++ b/RecoVertex/MultiVertexFit/interface/MultiVertexFitter.h
@@ -12,8 +12,7 @@
 #include "RecoVertex/LinearizationPointFinders/interface/DefaultLinearizationPointFinder.h"
 #include "RecoVertex/MultiVertexFit/interface/LinTrackCache.h"
 
-class MultiVertexFitter
-{
+class MultiVertexFitter {
 public:
   /**
    *  \class MultiVertexFitter
@@ -33,26 +32,24 @@ public:
    *
    */
 
-  MultiVertexFitter( const AnnealingSchedule & sched = DefaultMVFAnnealing(),
-                     const LinearizationPointFinder & seeder = 
-                        DefaultLinearizationPointFinder(),
-                     float revive_below = -1. );
-  MultiVertexFitter( const MultiVertexFitter & );
+  MultiVertexFitter(const AnnealingSchedule &sched = DefaultMVFAnnealing(),
+                    const LinearizationPointFinder &seeder = DefaultLinearizationPointFinder(),
+                    float revive_below = -1.);
+  MultiVertexFitter(const MultiVertexFitter &);
   ~MultiVertexFitter();
 
-  typedef std::pair < reco::TransientTrack, float > TrackAndWeight;
-  typedef std::map < int , double > SeedToWeightMap;
-  typedef std::map < reco::TransientTrack, SeedToWeightMap > TrackAndSeedToWeightMap;
+  typedef std::pair<reco::TransientTrack, float> TrackAndWeight;
+  typedef std::map<int, double> SeedToWeightMap;
+  typedef std::map<reco::TransientTrack, SeedToWeightMap> TrackAndSeedToWeightMap;
 
   /**
    * Supply simple clusters of reco::TransientTracks.
    * \paramname primaries: supply tracks which are hard coded
    * to the primary vertex.
    */
-  std::vector < CachingVertex<5> > vertices ( 
-      const std::vector < std::vector < reco::TransientTrack > > &,
-      const std::vector < reco::TransientTrack > & primaries =
-       std::vector < reco::TransientTrack > () );
+  std::vector<CachingVertex<5> > vertices(
+      const std::vector<std::vector<reco::TransientTrack> > &,
+      const std::vector<reco::TransientTrack> &primaries = std::vector<reco::TransientTrack>());
 
   /**
    *  Supply clusters of tracks with weights, association weights of the other
@@ -61,60 +58,57 @@ public:
    * \paramname primaries: supply tracks which are hard coded
    * to the primary vertex.
    */
-  std::vector < CachingVertex<5> > vertices (
-      const std::vector < std::vector < TrackAndWeight > > &,
-      const std::vector < reco::TransientTrack > & primaries =
-       std::vector < reco::TransientTrack > () );
+  std::vector<CachingVertex<5> > vertices(
+      const std::vector<std::vector<TrackAndWeight> > &,
+      const std::vector<reco::TransientTrack> &primaries = std::vector<reco::TransientTrack>());
 
   /**
    *  Supply full CachingVertices; CachingVertices are the first seeds.
    * \paramname primaries: supply tracks which are hard coded
    * to the primary vertex.
    */
-  std::vector < CachingVertex<5> > vertices (
-      const std::vector < CachingVertex<5> > &,
-      const std::vector < reco::TransientTrack > & primaries =
-       std::vector < reco::TransientTrack > () );
+  std::vector<CachingVertex<5> > vertices(
+      const std::vector<CachingVertex<5> > &,
+      const std::vector<reco::TransientTrack> &primaries = std::vector<reco::TransientTrack>());
 
   /**
    *  Same as above.
    */
-  std::vector < CachingVertex<5> > vertices ( const std::vector < TransientVertex > &,
-     const std::vector < reco::TransientTrack > & primaries =
-     std::vector < reco::TransientTrack > () );
+  std::vector<CachingVertex<5> > vertices(
+      const std::vector<TransientVertex> &,
+      const std::vector<reco::TransientTrack> &primaries = std::vector<reco::TransientTrack>());
 
 private:
-  std::vector < CachingVertex<5> > fit();
+  std::vector<CachingVertex<5> > fit();
   void lostVertexClaimer();
   void updateWeights();
   bool updateSeeds();
 
   void clear();
-  void createSeed ( const std::vector < reco::TransientTrack > & tracks );
-  void createSeed ( const std::vector < TrackAndWeight > & tracks );
-  void createPrimaries ( const std::vector < reco::TransientTrack > &tracks );
+  void createSeed(const std::vector<reco::TransientTrack> &tracks);
+  void createSeed(const std::vector<TrackAndWeight> &tracks);
+  void createPrimaries(const std::vector<reco::TransientTrack> &tracks);
   void printWeights() const;
-  void printWeights( const reco::TransientTrack & ) const;
+  void printWeights(const reco::TransientTrack &) const;
   void printSeeds() const;
 
   int seedNr();
   void resetSeedNr();
 
 private:
-
   typedef CachingVertex<5>::RefCountedVertexTrack RefCountedVertexTrack;
   typedef ReferenceCountingPointer<LinearizedTrackState<5> > RefCountedLinearizedTrackState;
 
   // vertex seeds. Come with a seed number
   // makes the weight table simpler, faster,
   // and more reliable (I hope)
-  std::vector < std::pair < int, CachingVertex<5> > > theVertexStates;
+  std::vector<std::pair<int, CachingVertex<5> > > theVertexStates;
   int theVertexStateNr;
   float theReviveBelow;
-  std::vector < reco::TransientTrack > theTracks;
-  std::set < reco::TransientTrack > thePrimaries;
-  AnnealingSchedule * theAssComp;
-  LinearizationPointFinder * theSeeder;
+  std::vector<reco::TransientTrack> theTracks;
+  std::set<reco::TransientTrack> thePrimaries;
+  AnnealingSchedule *theAssComp;
+  LinearizationPointFinder *theSeeder;
   TrackAndSeedToWeightMap theWeights;
   LinTrackCache theCache;
 };

--- a/RecoVertex/MultiVertexFit/interface/MultiVertexReconstructor.h
+++ b/RecoVertex/MultiVertexFit/interface/MultiVertexReconstructor.h
@@ -9,31 +9,30 @@
  *  Class that wraps the MultiVertexFitter, together with
  *  a user-supplied VertexReconstructor into a VertexReconstructor.
  */
-class MultiVertexReconstructor : public VertexReconstructor
-{
+class MultiVertexReconstructor : public VertexReconstructor {
 public:
-  MultiVertexReconstructor ( const VertexReconstructor &,
-                             const AnnealingSchedule & s = DefaultMVFAnnealing(),
-                             float revive=-1. );
-  MultiVertexReconstructor ( const MultiVertexReconstructor & );
+  MultiVertexReconstructor(const VertexReconstructor &,
+                           const AnnealingSchedule &s = DefaultMVFAnnealing(),
+                           float revive = -1.);
+  MultiVertexReconstructor(const MultiVertexReconstructor &);
   ~MultiVertexReconstructor() override;
 
   std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &,
-      const reco::BeamSpot & ) const override; 
-  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &) const override; 
+                                        const reco::BeamSpot &) const override;
+  std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &) const override;
   std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &,
-      const std::vector < reco::TransientTrack > & primaries ) const;
+                                        const std::vector<reco::TransientTrack> &primaries) const;
 
   std::vector<TransientVertex> vertices(const std::vector<reco::TransientTrack> &,
-      const std::vector < reco::TransientTrack > & primaries,
-      const reco::BeamSpot & spot ) const override;
+                                        const std::vector<reco::TransientTrack> &primaries,
+                                        const reco::BeamSpot &spot) const override;
 
-  VertexReconstructor * reconstructor() const;
+  VertexReconstructor *reconstructor() const;
 
-  MultiVertexReconstructor * clone() const override;
+  MultiVertexReconstructor *clone() const override;
 
 private:
-  VertexReconstructor * theOldReconstructor;
+  VertexReconstructor *theOldReconstructor;
   mutable MultiVertexFitter theFitter;
 };
 

--- a/RecoVertex/MultiVertexFit/src/DefaultMVFAnnealing.cc
+++ b/RecoVertex/MultiVertexFit/src/DefaultMVFAnnealing.cc
@@ -8,9 +8,5 @@
         (0.5,"DefaultMVFAnnealing:Ratio").value();
 */
 
-DefaultMVFAnnealing::DefaultMVFAnnealing (
-     const double cutoff, const double T, const double ratio ) :
-  GeometricAnnealing (cutoff, 
-                      T, 
-                      ratio)
-{}
+DefaultMVFAnnealing::DefaultMVFAnnealing(const double cutoff, const double T, const double ratio)
+    : GeometricAnnealing(cutoff, T, ratio) {}

--- a/RecoVertex/MultiVertexFit/src/LinTrackCache.cc
+++ b/RecoVertex/MultiVertexFit/src/LinTrackCache.cc
@@ -3,70 +3,55 @@
 
 using namespace std;
 
-namespace
-{
-  float maxRelinDistance()
-  {
+namespace {
+  float maxRelinDistance() {
     // maximum distance before relinearizing
     static const float ret = 1e-2; /*  SimpleConfigurable<float>
       (0.01, "LinTrackCache:RelinearizeAfter").value();
       */
     return ret;
   }
-}
+}  // namespace
 
-LinTrackCache::RefCountedLinearizedTrackState LinTrackCache::linTrack
-    ( const GlobalPoint & pos, const reco::TransientTrack & rt )
-{
-  if ( theHasLinTrack[pos][rt] )
-  {
+LinTrackCache::RefCountedLinearizedTrackState LinTrackCache::linTrack(const GlobalPoint& pos,
+                                                                      const reco::TransientTrack& rt) {
+  if (theHasLinTrack[pos][rt]) {
     return theLinTracks[pos][rt];
   };
 
   LinearizedTrackStateFactory lTrackFactory;
-  RefCountedLinearizedTrackState lTrData =
-    lTrackFactory.linearizedTrackState( pos, rt );
+  RefCountedLinearizedTrackState lTrData = lTrackFactory.linearizedTrackState(pos, rt);
 
-  theLinTracks[pos][rt]=lTrData;
-  theHasLinTrack[pos][rt]=true;
+  theLinTracks[pos][rt] = lTrData;
+  theHasLinTrack[pos][rt] = true;
   return lTrData;
 }
 
-bool LinTrackCache::Comparer::operator() ( const GlobalPoint & left,
-                                           const GlobalPoint & right ) const
-{
+bool LinTrackCache::Comparer::operator()(const GlobalPoint& left, const GlobalPoint& right) const {
   // if theyre closer than 1 micron, they're
   // indistinguishable, i.e. the same
   // static const double max = 1e-4 * 1e-4;
   // if ( ( left - right ).mag2() < max ) return false;
 
-  if ( left.x() != right.x() )
-  {
-    return ( left.x() < right.x() );
+  if (left.x() != right.x()) {
+    return (left.x() < right.x());
   } else if (left.y() != right.y()) {
-    return ( left.y() < right.y() );
+    return (left.y() < right.y());
   } else {
-    return ( left.z() < right.z() );
+    return (left.z() < right.z());
   }
 }
 
-bool LinTrackCache::Vicinity::operator() ( const GlobalPoint & p1,
-                                           const GlobalPoint & p2 ) const
-{
-  if ( (p1 - p2).mag() < maxRelinDistance() )
-  {
+bool LinTrackCache::Vicinity::operator()(const GlobalPoint& p1, const GlobalPoint& p2) const {
+  if ((p1 - p2).mag() < maxRelinDistance()) {
     return false;
   };
-  return Comparer()(p1,p2);
+  return Comparer()(p1, p2);
 }
 
-LinTrackCache::~LinTrackCache()
-{
-  clear();
-}
+LinTrackCache::~LinTrackCache() { clear(); }
 
-void LinTrackCache::clear()
-{
+void LinTrackCache::clear() {
   theLinTracks.clear();
   theHasLinTrack.clear();
 }

--- a/RecoVertex/MultiVertexFit/src/MultiVertexFitter.cc
+++ b/RecoVertex/MultiVertexFit/src/MultiVertexFitter.cc
@@ -20,22 +20,19 @@
 using namespace std;
 using namespace reco;
 
-namespace
-{
+namespace {
   typedef MultiVertexFitter::TrackAndWeight TrackAndWeight;
   typedef MultiVertexFitter::TrackAndSeedToWeightMap TrackAndSeedToWeightMap;
   typedef MultiVertexFitter::SeedToWeightMap SeedToWeightMap;
   typedef CachingVertex<5>::RefCountedVertexTrack RefCountedVertexTrack;
 
-  int verbose()
-  {
+  int verbose() {
     static const int ret = 0; /*SimpleConfigurable<int>
       (0, "MultiVertexFitter:Debug").value(); */
     return ret;
   }
 
-  double minWeightFraction()
-  {
+  double minWeightFraction() {
     // minimum weight that a track has to have
     // in order to be taken into account for the
     // vertex fit.
@@ -45,8 +42,7 @@ namespace
     return ret;
   }
 
-  bool discardLightWeights()
-  {
+  bool discardLightWeights() {
     static const bool ret = true; /* SimpleConfigurable<bool>
       (true, "MultiVertexFitter:DiscardLightWeights").value();*/
     return ret;
@@ -62,31 +58,25 @@ namespace
     };
   }*/
 
-  CachingVertex<5> createSeedFromLinPt ( const GlobalPoint & gp )
-  {
-    return CachingVertex<5> ( gp, GlobalError (),
-                           vector<RefCountedVertexTrack> (), 0.0 );
+  CachingVertex<5> createSeedFromLinPt(const GlobalPoint &gp) {
+    return CachingVertex<5>(gp, GlobalError(), vector<RefCountedVertexTrack>(), 0.0);
   }
 
-  double validWeight ( double weight )
-  {
-    if ( weight > 1.0 )
-    {
+  double validWeight(double weight) {
+    if (weight > 1.0) {
       cout << "[MultiVertexFitter] weight=" << weight << "??" << endl;
       return 1.0;
     };
 
-    if ( weight < 0.0 )
-    {
+    if (weight < 0.0) {
       cout << "[MultiVertexFitter] weight=" << weight << "??" << endl;
       return 0.0;
     };
     return weight;
   }
-}
+}  // namespace
 
-void MultiVertexFitter::clear()
-{
+void MultiVertexFitter::clear() {
   theAssComp->resetAnnealing();
   theTracks.clear();
   thePrimaries.clear();
@@ -98,458 +88,362 @@ void MultiVertexFitter::clear()
 // creates the seed, additionally it pushes all tracks
 // onto theTracks
 
-void MultiVertexFitter::createSeed( const vector < TransientTrack > & tracks )
-{
-  if ( tracks.size() > 1 )
-  {
-    CachingVertex<5> vtx = createSeedFromLinPt (
-        theSeeder->getLinearizationPoint ( tracks ) );
-    int snr= seedNr();
-    theVertexStates.push_back ( pair < int, CachingVertex<5> > ( snr, vtx ) );
-    for ( vector< TransientTrack >::const_iterator track=tracks.begin();
-          track!=tracks.end() ; ++track )
-    {
-      theWeights[*track][snr]=1.;
-      theTracks.push_back ( *track );
+void MultiVertexFitter::createSeed(const vector<TransientTrack> &tracks) {
+  if (tracks.size() > 1) {
+    CachingVertex<5> vtx = createSeedFromLinPt(theSeeder->getLinearizationPoint(tracks));
+    int snr = seedNr();
+    theVertexStates.push_back(pair<int, CachingVertex<5> >(snr, vtx));
+    for (vector<TransientTrack>::const_iterator track = tracks.begin(); track != tracks.end(); ++track) {
+      theWeights[*track][snr] = 1.;
+      theTracks.push_back(*track);
     };
   };
 }
 
-void MultiVertexFitter::createPrimaries ( const std::vector < reco::TransientTrack > &tracks )
-{
+void MultiVertexFitter::createPrimaries(const std::vector<reco::TransientTrack> &tracks) {
   // cout << "[MultiVertexFitter] creating primaries: ";
-  for ( vector< reco::TransientTrack >::const_iterator i=tracks.begin(); 
-        i!=tracks.end() ; ++i )
-  {
-    thePrimaries.insert ( *i );
+  for (vector<reco::TransientTrack>::const_iterator i = tracks.begin(); i != tracks.end(); ++i) {
+    thePrimaries.insert(*i);
     // cout << i->id() << "  ";
   }
   // cout << endl;
 }
 
-int MultiVertexFitter::seedNr()
-{
-  return theVertexStateNr++;
-}
+int MultiVertexFitter::seedNr() { return theVertexStateNr++; }
 
-void MultiVertexFitter::resetSeedNr()
-{
-  theVertexStateNr=0;
-}
+void MultiVertexFitter::resetSeedNr() { theVertexStateNr = 0; }
 
-void MultiVertexFitter::createSeed( const vector < TrackAndWeight > & tracks )
-{
+void MultiVertexFitter::createSeed(const vector<TrackAndWeight> &tracks) {
   // create initial seed for every bundle
-  vector < RefCountedVertexTrack> newTracks;
+  vector<RefCountedVertexTrack> newTracks;
 
-  for ( vector< TrackAndWeight >::const_iterator track=tracks.begin();
-        track!=tracks.end() ; ++track )
-  {
-    double weight = validWeight ( track->second );
-    const GlobalPoint & pos = track->first.impactPointState().globalPosition();
-    GlobalError err; // FIXME
-    VertexState realseed ( pos, err );
+  for (vector<TrackAndWeight>::const_iterator track = tracks.begin(); track != tracks.end(); ++track) {
+    double weight = validWeight(track->second);
+    const GlobalPoint &pos = track->first.impactPointState().globalPosition();
+    GlobalError err;  // FIXME
+    VertexState realseed(pos, err);
 
-    RefCountedLinearizedTrackState lTrData = 
-      theCache.linTrack ( pos, track->first );
+    RefCountedLinearizedTrackState lTrData = theCache.linTrack(pos, track->first);
 
     VertexTrackFactory<5> vTrackFactory;
-    RefCountedVertexTrack vTrData = vTrackFactory.vertexTrack(
-      lTrData, realseed, weight );
-    newTracks.push_back ( vTrData );
+    RefCountedVertexTrack vTrData = vTrackFactory.vertexTrack(lTrData, realseed, weight);
+    newTracks.push_back(vTrData);
   };
 
-  if ( newTracks.size() > 1 )
-  {
-    CachingVertex<5> vtx = KalmanVertexFitter().vertex ( newTracks );
+  if (newTracks.size() > 1) {
+    CachingVertex<5> vtx = KalmanVertexFitter().vertex(newTracks);
     int snr = seedNr();
-    theVertexStates.push_back ( pair < int, CachingVertex<5> > ( snr, vtx ) );
+    theVertexStates.push_back(pair<int, CachingVertex<5> >(snr, vtx));
 
     // We initialise the weights with the original
     // user supplied weights.
-    for ( vector< TrackAndWeight >::const_iterator track=tracks.begin();
-          track!=tracks.end() ; ++track )
-    {
-      if ( thePrimaries.count ( track->first ) )
-      {
+    for (vector<TrackAndWeight>::const_iterator track = tracks.begin(); track != tracks.end(); ++track) {
+      if (thePrimaries.count(track->first)) {
         /*
         cout << "[MultiVertexFitter] " << track->first.id() << " is a primary."
              << " setting weight for state " << theVertexStates[0].first
              << " to " << track->second
              << endl;
              */
-        theWeights[track->first][theVertexStates[0].first]=track->second;
+        theWeights[track->first][theVertexStates[0].first] = track->second;
         continue;
       };
       float weight = track->second;
-      if ( weight > 1.0 )
-      {
-        cout << "[MultiVertexFitter] error weight " << weight << " > 1.0 given."
-             << endl;
+      if (weight > 1.0) {
+        cout << "[MultiVertexFitter] error weight " << weight << " > 1.0 given." << endl;
         cout << "[MultiVertexFitter] will revert to 1.0" << endl;
-        weight=1.0;
+        weight = 1.0;
       };
-      if ( weight < 0.0 )
-      {
-        cout << "[MultiVertexFitter] error weight " << weight << " < 0.0 given."
-             << endl;
+      if (weight < 0.0) {
+        cout << "[MultiVertexFitter] error weight " << weight << " < 0.0 given." << endl;
         cout << "[MultiVertexFitter] will revert to 0.0" << endl;
-        weight=0.0;
+        weight = 0.0;
       };
-      theWeights[track->first][snr]=weight;
-      theTracks.push_back ( track->first );
+      theWeights[track->first][snr] = weight;
+      theTracks.push_back(track->first);
     };
   };
 
   // this thing will actually have to discard tracks
   // that have been submitted - attached to a different vertex - already.
   // sort ( theTracks.begin(), theTracks.end(), CompareRaveTracks() );
-  sort ( theTracks.begin(), theTracks.end() );
-  for ( vector< TransientTrack >::iterator i=theTracks.begin(); 
-        i<theTracks.end() ; ++i )
-  {
-    if ( i != theTracks.begin() )
-    {
-      if ( (*i) == ( *(i-1) ) )
-      {
-        theTracks.erase ( i );
+  sort(theTracks.begin(), theTracks.end());
+  for (vector<TransientTrack>::iterator i = theTracks.begin(); i < theTracks.end(); ++i) {
+    if (i != theTracks.begin()) {
+      if ((*i) == (*(i - 1))) {
+        theTracks.erase(i);
       };
     };
   };
 }
 
-vector < CachingVertex<5> > MultiVertexFitter::vertices (
-    const vector < TransientVertex > & vtces,
-    const vector < TransientTrack > & primaries )
-{
+vector<CachingVertex<5> > MultiVertexFitter::vertices(const vector<TransientVertex> &vtces,
+                                                      const vector<TransientTrack> &primaries) {
   // FIXME if vtces.size < 1 return sth that includes the primaries
-  if ( vtces.empty() )
-  {
-    return vector < CachingVertex<5> > ();
+  if (vtces.empty()) {
+    return vector<CachingVertex<5> >();
   };
-  vector < vector < TrackAndWeight > > bundles;
-  for ( vector< TransientVertex >::const_iterator vtx=vtces.begin();
-        vtx!=vtces.end() ; ++vtx )
-  {
-    vector < TransientTrack > trks = vtx->originalTracks();
-    vector < TrackAndWeight > tnws;
-    for ( vector< TransientTrack >::const_iterator trk=trks.begin(); 
-          trk!=trks.end() ; ++trk )
-    {
-      float w = vtx->trackWeight ( *trk ); 
-      if ( w > 1e-5 )
-      {
-        TrackAndWeight tmp ( *trk, w );
-        tnws.push_back ( tmp );
+  vector<vector<TrackAndWeight> > bundles;
+  for (vector<TransientVertex>::const_iterator vtx = vtces.begin(); vtx != vtces.end(); ++vtx) {
+    vector<TransientTrack> trks = vtx->originalTracks();
+    vector<TrackAndWeight> tnws;
+    for (vector<TransientTrack>::const_iterator trk = trks.begin(); trk != trks.end(); ++trk) {
+      float w = vtx->trackWeight(*trk);
+      if (w > 1e-5) {
+        TrackAndWeight tmp(*trk, w);
+        tnws.push_back(tmp);
       };
     };
-    bundles.push_back ( tnws );
+    bundles.push_back(tnws);
   };
-  return vertices ( bundles, primaries );
+  return vertices(bundles, primaries);
 }
 
-vector < CachingVertex<5> > MultiVertexFitter::vertices (
-    const vector < CachingVertex<5> > & initials,
-    const vector < TransientTrack > & primaries )
-{
+vector<CachingVertex<5> > MultiVertexFitter::vertices(const vector<CachingVertex<5> > &initials,
+                                                      const vector<TransientTrack> &primaries) {
   clear();
-  createPrimaries ( primaries );
+  createPrimaries(primaries);
   // FIXME if initials size < 1 return sth that includes the primaries
-  if (  initials.empty() ) return initials;
-  for ( vector< CachingVertex<5> >::const_iterator vtx=initials.begin();
-        vtx!=initials.end() ; ++vtx )
-  {
+  if (initials.empty())
+    return initials;
+  for (vector<CachingVertex<5> >::const_iterator vtx = initials.begin(); vtx != initials.end(); ++vtx) {
     int snr = seedNr();
-    theVertexStates.push_back ( pair < int, CachingVertex<5> >
-        ( snr, *vtx ) );
+    theVertexStates.push_back(pair<int, CachingVertex<5> >(snr, *vtx));
     TransientVertex rvtx = *vtx;
-    const vector < TransientTrack > & trks = rvtx.originalTracks();
-    for ( vector< TransientTrack >::const_iterator trk=trks.begin();
-          trk!=trks.end() ; ++trk )
-    {
-      if ( !(thePrimaries.count (*trk )) )
-      {
+    const vector<TransientTrack> &trks = rvtx.originalTracks();
+    for (vector<TransientTrack>::const_iterator trk = trks.begin(); trk != trks.end(); ++trk) {
+      if (!(thePrimaries.count(*trk))) {
         // cout << "[MultiVertexFitter] free track " << trk->id() << endl;
-        theTracks.push_back ( *trk );
+        theTracks.push_back(*trk);
       } else {
         // cout << "[MultiVertexFitter " << trk->id() << " is not free." << endl;
       }
       cout << "[MultiVertexFitter] error! track weight currently set to one"
            << " FIXME!!!" << endl;
-      theWeights[*trk][snr]=1.0;
+      theWeights[*trk][snr] = 1.0;
     };
   };
-  #ifdef MVFHarvestingDebug
-  for ( vector< CachingVertex<5> >::const_iterator i=theVertexStates.begin();
-        i!=theVertexStates.end() ; ++i )
+#ifdef MVFHarvestingDebug
+  for (vector<CachingVertex<5> >::const_iterator i = theVertexStates.begin(); i != theVertexStates.end(); ++i)
     PrimitivesHarvester::file()->save(*i);
-  #endif
+#endif
   return fit();
 }
 
-vector < CachingVertex<5> > MultiVertexFitter::vertices (
-    const vector < vector < TransientTrack > > & tracks,
-    const vector < TransientTrack > & primaries )
-{
+vector<CachingVertex<5> > MultiVertexFitter::vertices(const vector<vector<TransientTrack> > &tracks,
+                                                      const vector<TransientTrack> &primaries) {
   clear();
-  createPrimaries ( primaries );
+  createPrimaries(primaries);
 
-  for ( vector< vector < TransientTrack > >::const_iterator cluster=
-        tracks.begin(); cluster!=tracks.end() ; ++cluster )
-  {
-    createSeed ( *cluster );
+  for (vector<vector<TransientTrack> >::const_iterator cluster = tracks.begin(); cluster != tracks.end(); ++cluster) {
+    createSeed(*cluster);
   };
-  if ( verbose() )
-  {
+  if (verbose()) {
     printSeeds();
   };
-  #ifdef MVFHarvestingDebug
-  for ( vector< CachingVertex<5> >::const_iterator i=theVertexStates.begin();
-        i!=theVertexStates.end() ; ++i )
+#ifdef MVFHarvestingDebug
+  for (vector<CachingVertex<5> >::const_iterator i = theVertexStates.begin(); i != theVertexStates.end(); ++i)
     PrimitivesHarvester::file()->save(*i);
-  #endif
+#endif
   return fit();
 }
 
-vector < CachingVertex<5> > MultiVertexFitter::vertices (
-    const vector < vector < TrackAndWeight > > & tracks,
-    const vector < TransientTrack > & primaries )
-{
+vector<CachingVertex<5> > MultiVertexFitter::vertices(const vector<vector<TrackAndWeight> > &tracks,
+                                                      const vector<TransientTrack> &primaries) {
   clear();
-  createPrimaries ( primaries );
+  createPrimaries(primaries);
 
-  for ( vector< vector < TrackAndWeight > >::const_iterator cluster=
-        tracks.begin(); cluster!=tracks.end() ; ++cluster )
-  {
-    createSeed ( *cluster );
+  for (vector<vector<TrackAndWeight> >::const_iterator cluster = tracks.begin(); cluster != tracks.end(); ++cluster) {
+    createSeed(*cluster);
   };
-  if ( verbose() )
-  {
+  if (verbose()) {
     printSeeds();
   };
 
   return fit();
 }
 
-MultiVertexFitter::MultiVertexFitter( const AnnealingSchedule & ann,
-                                      const LinearizationPointFinder & seeder,
-                                      float revive_below ) :
-    theVertexStateNr ( 0 ), theReviveBelow ( revive_below ),
-    theAssComp ( ann.clone() ), theSeeder ( seeder.clone() )
-{}
+MultiVertexFitter::MultiVertexFitter(const AnnealingSchedule &ann,
+                                     const LinearizationPointFinder &seeder,
+                                     float revive_below)
+    : theVertexStateNr(0), theReviveBelow(revive_below), theAssComp(ann.clone()), theSeeder(seeder.clone()) {}
 
-MultiVertexFitter::MultiVertexFitter( const MultiVertexFitter & o ) :
-    theVertexStateNr ( o.theVertexStateNr ), theReviveBelow ( o.theReviveBelow ),
-    theAssComp ( o.theAssComp->clone() ), theSeeder ( o.theSeeder->clone() )
-{}
+MultiVertexFitter::MultiVertexFitter(const MultiVertexFitter &o)
+    : theVertexStateNr(o.theVertexStateNr),
+      theReviveBelow(o.theReviveBelow),
+      theAssComp(o.theAssComp->clone()),
+      theSeeder(o.theSeeder->clone()) {}
 
-MultiVertexFitter::~MultiVertexFitter()
-{
+MultiVertexFitter::~MultiVertexFitter() {
   delete theAssComp;
   delete theSeeder;
 }
 
-void MultiVertexFitter::updateWeights()
-{
+void MultiVertexFitter::updateWeights() {
   theWeights.clear();
-  if ( verbose() & 4 )
-  {
+  if (verbose() & 4) {
     cout << "[MultiVertexFitter] Start weight update." << endl;
   };
 
   KalmanVertexTrackCompatibilityEstimator<5> theComp;
-  
+
   /** 
    *  add the primary only tracks to primary vertex only.
    */
-  for ( set < TransientTrack >::const_iterator trk=thePrimaries.begin();
-        trk!=thePrimaries.end() ; ++trk )
-  {
+  for (set<TransientTrack>::const_iterator trk = thePrimaries.begin(); trk != thePrimaries.end(); ++trk) {
     int seednr = theVertexStates[0].first;
     CachingVertex<5> seed = theVertexStates[0].second;
-    pair<bool, double> result = theComp.estimate ( seed, theCache.linTrack ( seed.position(), *trk ) ); 
+    pair<bool, double> result = theComp.estimate(seed, theCache.linTrack(seed.position(), *trk));
     double weight = 0.;
-    if (result.first) weight = theAssComp->phi ( result.second );
-    theWeights[*trk][seednr]= weight; // FIXME maybe "hard" 1.0 or "soft" weight?
+    if (result.first)
+      weight = theAssComp->phi(result.second);
+    theWeights[*trk][seednr] = weight;  // FIXME maybe "hard" 1.0 or "soft" weight?
   }
 
   /**
    *  now add "free tracks" to all vertices
    */
-  for ( vector< TransientTrack >::const_iterator trk=theTracks.begin();
-        trk!=theTracks.end() ; ++trk )
-  {
-    double tot_weight=theAssComp->phi ( theAssComp->cutoff() * theAssComp->cutoff() );
+  for (vector<TransientTrack>::const_iterator trk = theTracks.begin(); trk != theTracks.end(); ++trk) {
+    double tot_weight = theAssComp->phi(theAssComp->cutoff() * theAssComp->cutoff());
 
-    for ( vector < pair < int, CachingVertex<5> > >::const_iterator 
-          seed=theVertexStates.begin(); seed!=theVertexStates.end(); ++seed )
-    {
-      
-      pair<bool, double> result = theComp.estimate ( seed->second, theCache.linTrack ( seed->second.position(),
-             *trk ) );
+    for (vector<pair<int, CachingVertex<5> > >::const_iterator seed = theVertexStates.begin();
+         seed != theVertexStates.end();
+         ++seed) {
+      pair<bool, double> result = theComp.estimate(seed->second, theCache.linTrack(seed->second.position(), *trk));
       double weight = 0.;
-      if (result.first) weight = theAssComp->phi ( result.second );
-      tot_weight+=weight;
-      theWeights[*trk][seed->first]=weight;
+      if (result.first)
+        weight = theAssComp->phi(result.second);
+      tot_weight += weight;
+      theWeights[*trk][seed->first] = weight;
       /* cout << "[MultiVertexFitter] w[" << TransientTrackNamer().name(*trk)
            << "," << seed->position() << "] = " << weight << endl;*/
     };
 
     // normalize to sum of all weights of one track equals 1.
     // (if we include the "cutoff", as well)
-    if ( tot_weight > 0.0 )
-    {
-      for ( vector < pair < int, CachingVertex<5> > >::const_iterator 
-            seed=theVertexStates.begin();
-            seed!=theVertexStates.end(); ++seed )
-      {
-        double normedweight=theWeights[*trk][seed->first]/tot_weight;
-        if ( normedweight > 1.0 )
-        {
-          cout << "[MultiVertexFitter] he? w[" // << TransientTrackNamer().name(*trk)
-               << "," << seed->second.position() << "] = " << normedweight
-               << " totw=" << tot_weight << endl;
-          normedweight=1.0;
+    if (tot_weight > 0.0) {
+      for (vector<pair<int, CachingVertex<5> > >::const_iterator seed = theVertexStates.begin();
+           seed != theVertexStates.end();
+           ++seed) {
+        double normedweight = theWeights[*trk][seed->first] / tot_weight;
+        if (normedweight > 1.0) {
+          cout << "[MultiVertexFitter] he? w["  // << TransientTrackNamer().name(*trk)
+               << "," << seed->second.position() << "] = " << normedweight << " totw=" << tot_weight << endl;
+          normedweight = 1.0;
         };
-        if ( normedweight < 0.0 )
-        {
-          cout << "[MultiVertexFitter] he? weight=" << normedweight
-               << " totw=" << tot_weight << endl;
-          normedweight=0.0;
+        if (normedweight < 0.0) {
+          cout << "[MultiVertexFitter] he? weight=" << normedweight << " totw=" << tot_weight << endl;
+          normedweight = 0.0;
         };
-        theWeights[*trk][seed->first]=normedweight;
+        theWeights[*trk][seed->first] = normedweight;
       };
     } else {
       // total weight equals zero? restart, with uniform distribution!
       cout << "[MultiVertexFitter] track found with no assignment - ";
       cout << "will assign uniformly." << endl;
-      float w = .5 / (float) theVertexStates.size();
-      for ( vector < pair < int, CachingVertex<5> > >::const_iterator seed=theVertexStates.begin();
-            seed!=theVertexStates.end(); ++seed )
-      {
-        theWeights[*trk][seed->first]=w;
+      float w = .5 / (float)theVertexStates.size();
+      for (vector<pair<int, CachingVertex<5> > >::const_iterator seed = theVertexStates.begin();
+           seed != theVertexStates.end();
+           ++seed) {
+        theWeights[*trk][seed->first] = w;
       };
     };
   };
-  if ( verbose() & 2 ) printWeights();
+  if (verbose() & 2)
+    printWeights();
 }
 
-bool MultiVertexFitter::updateSeeds()
-{
-  double max_disp=0.;
+bool MultiVertexFitter::updateSeeds() {
+  double max_disp = 0.;
   // need to fit with the right weights.
   // also trigger an updateWeights.
   // if the seeds dont move much we return true
 
-  vector < pair < int, CachingVertex<5> > > newSeeds;
+  vector<pair<int, CachingVertex<5> > > newSeeds;
 
-  for ( vector< pair < int, CachingVertex<5> > >::const_iterator seed=theVertexStates.begin();
-        seed!=theVertexStates.end() ; ++seed )
-  {
+  for (vector<pair<int, CachingVertex<5> > >::const_iterator seed = theVertexStates.begin();
+       seed != theVertexStates.end();
+       ++seed) {
     // for each seed get the tracks with the right weights.
     // TransientVertex rv = seed->second;
     // const GlobalPoint & seedpos = seed->second.position();
     int snr = seed->first;
-    VertexState realseed ( seed->second.position(), seed->second.error() );
+    VertexState realseed(seed->second.position(), seed->second.error());
 
-    double totweight=0.;
-    for ( vector< TransientTrack >::const_iterator track=theTracks.begin();
-          track!=theTracks.end() ; ++track )
-    {
-      totweight+=theWeights[*track][snr];
+    double totweight = 0.;
+    for (vector<TransientTrack>::const_iterator track = theTracks.begin(); track != theTracks.end(); ++track) {
+      totweight += theWeights[*track][snr];
     };
 
-
-    int nr_good_trks=0; // how many tracks above weight limit
+    int nr_good_trks = 0;  // how many tracks above weight limit
     // we count those tracks, because that way
     // we can discard lightweights if there are enough tracks
     // and not discard the lightweights if that would give us
     // fewer than two tracks ( we would loose a seed, then ).
-    if ( discardLightWeights() )
-    {
-      for ( vector< TransientTrack >::const_iterator track=theTracks.begin();
-            track!=theTracks.end() ; ++track )
-      {
-        if ( theWeights[*track][snr] > totweight * minWeightFraction() )
-        {
+    if (discardLightWeights()) {
+      for (vector<TransientTrack>::const_iterator track = theTracks.begin(); track != theTracks.end(); ++track) {
+        if (theWeights[*track][snr] > totweight * minWeightFraction()) {
           nr_good_trks++;
         };
       };
     };
 
     vector<RefCountedVertexTrack> newTracks;
-    for ( vector< TransientTrack >::const_iterator track=theTracks.begin();
-          track!=theTracks.end() ; ++track )
-    {
-      double weight = validWeight ( theWeights[*track][snr] );
+    for (vector<TransientTrack>::const_iterator track = theTracks.begin(); track != theTracks.end(); ++track) {
+      double weight = validWeight(theWeights[*track][snr]);
       // Now we add a track, if
       // a. we consider all tracks or
       // b. we discard the lightweights but the track's weight is high enough or
       // c. we discard the lightweights but there arent enough good tracks,
       //    so we add all lightweights again (too expensive to figure out
       //    which lightweights are the most important)
-      if ( !discardLightWeights() || weight > minWeightFraction() * totweight
-           || nr_good_trks < 2 )
-      {
+      if (!discardLightWeights() || weight > minWeightFraction() * totweight || nr_good_trks < 2) {
         // if the linearization point didnt move too much,
         // we take the old LinTrackState.
         // Otherwise we relinearize.
 
-        RefCountedLinearizedTrackState lTrData =
-          theCache.linTrack ( seed->second.position(), *track );
+        RefCountedLinearizedTrackState lTrData = theCache.linTrack(seed->second.position(), *track);
 
         VertexTrackFactory<5> vTrackFactory;
-        RefCountedVertexTrack vTrData = vTrackFactory.vertexTrack(
-          lTrData, realseed, weight );
-        newTracks.push_back ( vTrData );
+        RefCountedVertexTrack vTrData = vTrackFactory.vertexTrack(lTrData, realseed, weight);
+        newTracks.push_back(vTrData);
       };
     };
 
-    for ( set< TransientTrack >::const_iterator track=thePrimaries.begin();
-          track!=thePrimaries.end() ; ++track )
-    {
-      double weight = validWeight ( theWeights[*track][snr] );
+    for (set<TransientTrack>::const_iterator track = thePrimaries.begin(); track != thePrimaries.end(); ++track) {
+      double weight = validWeight(theWeights[*track][snr]);
 
-      RefCountedLinearizedTrackState lTrData =
-        theCache.linTrack ( seed->second.position(), *track );
+      RefCountedLinearizedTrackState lTrData = theCache.linTrack(seed->second.position(), *track);
 
       VertexTrackFactory<5> vTrackFactory;
-      RefCountedVertexTrack vTrData = vTrackFactory.vertexTrack(
-        lTrData, realseed, weight );
-      newTracks.push_back ( vTrData );
-
+      RefCountedVertexTrack vTrData = vTrackFactory.vertexTrack(lTrData, realseed, weight);
+      newTracks.push_back(vTrData);
     };
 
     try {
-      if ( newTracks.size() < 2 )
-      {
-        throw VertexException("less than two tracks in vector" );
+      if (newTracks.size() < 2) {
+        throw VertexException("less than two tracks in vector");
       };
 
-      if ( verbose() )
-      {
+      if (verbose()) {
         cout << "[MultiVertexFitter] now fitting with Kalman: ";
-        for ( vector< RefCountedVertexTrack >::const_iterator i=newTracks.begin(); 
-              i!=newTracks.end() ; ++i )
-        {
+        for (vector<RefCountedVertexTrack>::const_iterator i = newTracks.begin(); i != newTracks.end(); ++i) {
           cout << (**i).weight() << " ";
         };
         cout << endl;
       };
 
-      if ( newTracks.size() > 1 )
-      {
+      if (newTracks.size() > 1) {
         KalmanVertexFitter fitter;
         // warning! first track determines lin pt!
-        CachingVertex<5> newVertex = fitter.vertex ( newTracks );
+        CachingVertex<5> newVertex = fitter.vertex(newTracks);
         int snr = seedNr();
-        double disp = ( newVertex.position() - seed->second.position() ).mag();
-        if ( disp > max_disp ) max_disp = disp;
-        newSeeds.push_back ( 
-            pair < int, CachingVertex<5> > ( snr, newVertex ) );
+        double disp = (newVertex.position() - seed->second.position()).mag();
+        if (disp > max_disp)
+          max_disp = disp;
+        newSeeds.push_back(pair<int, CachingVertex<5> >(snr, newVertex));
       };
-    } catch ( exception & e )
-    {
+    } catch (exception &e) {
       cout << "[MultiVertexFitter] exception: " << e.what() << endl;
     }
   };
@@ -557,95 +451,83 @@ bool MultiVertexFitter::updateSeeds()
   // now discard all old seeds and weights, compute new ones.
   theVertexStates.clear();
   theWeights.clear();
-  theVertexStates=newSeeds;
-  #ifdef MVFHarvestingDebug
-  for ( vector< CachingVertex<5> >::const_iterator i=theVertexStates.begin();
-        i!=theVertexStates.end() ; ++i )
+  theVertexStates = newSeeds;
+#ifdef MVFHarvestingDebug
+  for (vector<CachingVertex<5> >::const_iterator i = theVertexStates.begin(); i != theVertexStates.end(); ++i)
     PrimitivesHarvester::file()->save(*i);
-  #endif
+#endif
   updateWeights();
 
   static const double disp_limit = 1e-4; /* SimpleConfigurable<double>
     (0.0001, "MultiVertexFitter:DisplacementLimit" ).value(); */
 
-  if ( verbose() & 2 )
-  {
+  if (verbose() & 2) {
     printSeeds();
-    cout << "[MultiVertexFitter] max displacement in this iteration: "
-         << max_disp << endl;
+    cout << "[MultiVertexFitter] max displacement in this iteration: " << max_disp << endl;
   };
-  if ( max_disp < disp_limit ) return false;
+  if (max_disp < disp_limit)
+    return false;
   return true;
 }
 
 // iterating over the fits
-vector < CachingVertex<5> > MultiVertexFitter::fit()
-{
-  if ( verbose() & 2 ) printWeights();
-  int ctr=1;
+vector<CachingVertex<5> > MultiVertexFitter::fit() {
+  if (verbose() & 2)
+    printWeights();
+  int ctr = 1;
   static const int ctr_max = 50; /* SimpleConfigurable<int>(100,
       "MultiVertexFitter:MaxIterations").value(); */
-  while ( updateSeeds() || !(theAssComp->isAnnealed()) )
-  {
-    if ( ++ctr >= ctr_max ) break;
+  while (updateSeeds() || !(theAssComp->isAnnealed())) {
+    if (++ctr >= ctr_max)
+      break;
     theAssComp->anneal();
     // lostVertexClaimer(); // was a silly(?) idea to "revive" vertex candidates.
     resetSeedNr();
   };
 
-  if ( verbose() )
-  {
+  if (verbose()) {
     cout << "[MultiVertexFitter] number of iterations: " << ctr << endl;
-    cout << "[MultiVertexFitter] remaining seeds: "
-         << theVertexStates.size() << endl;
+    cout << "[MultiVertexFitter] remaining seeds: " << theVertexStates.size() << endl;
     printWeights();
   };
 
-  vector < CachingVertex<5> > ret;
-  for ( vector< pair < int, CachingVertex<5> > >::const_iterator 
-        i=theVertexStates.begin(); i!=theVertexStates.end() ; ++i )
-  {
-    ret.push_back ( i->second );
+  vector<CachingVertex<5> > ret;
+  for (vector<pair<int, CachingVertex<5> > >::const_iterator i = theVertexStates.begin(); i != theVertexStates.end();
+       ++i) {
+    ret.push_back(i->second);
   };
 
   return ret;
 }
 
-void MultiVertexFitter::printWeights ( const reco::TransientTrack & t ) const
-{
-    // cout << "Trk " << t.id();
-    for ( vector < pair < int, CachingVertex<5> > >::const_iterator seed=theVertexStates.begin();
-          seed!=theVertexStates.end(); ++seed )
-    {
-      double val = 0;
-      auto a = theWeights.find(t);
-      if ( a != theWeights.end()){
-        auto b = a->second.find(seed->first);
-        if (b != a->second.end()) val = b->second;
-      }
-      cout << "  -- Vertex[" << seed->first << "] with " << setw(12)
-           << setprecision(3) << val;
-    };
-    cout << endl;
+void MultiVertexFitter::printWeights(const reco::TransientTrack &t) const {
+  // cout << "Trk " << t.id();
+  for (vector<pair<int, CachingVertex<5> > >::const_iterator seed = theVertexStates.begin();
+       seed != theVertexStates.end();
+       ++seed) {
+    double val = 0;
+    auto a = theWeights.find(t);
+    if (a != theWeights.end()) {
+      auto b = a->second.find(seed->first);
+      if (b != a->second.end())
+        val = b->second;
+    }
+    cout << "  -- Vertex[" << seed->first << "] with " << setw(12) << setprecision(3) << val;
+  };
+  cout << endl;
 }
 
-void MultiVertexFitter::printWeights() const
-{
+void MultiVertexFitter::printWeights() const {
   cout << endl << "Weight table: " << endl << "=================" << endl;
-  for ( set < TransientTrack >::const_iterator trk=thePrimaries.begin();
-        trk!=thePrimaries.end() ; ++trk )
-  {
-    printWeights ( *trk );
+  for (set<TransientTrack>::const_iterator trk = thePrimaries.begin(); trk != thePrimaries.end(); ++trk) {
+    printWeights(*trk);
   };
-  for ( vector< TransientTrack >::const_iterator trk=theTracks.begin();
-        trk!=theTracks.end() ; ++trk )
-  {
-    printWeights ( *trk );
+  for (vector<TransientTrack>::const_iterator trk = theTracks.begin(); trk != theTracks.end(); ++trk) {
+    printWeights(*trk);
   };
 }
 
-void MultiVertexFitter::printSeeds() const
-{
+void MultiVertexFitter::printSeeds() const {
   cout << endl << "Seed table: " << endl << "=====================" << endl;
   /*
   for ( vector < pair < int, CachingVertex<5> > >::const_iterator seed=theVertexStates.begin();
@@ -656,39 +538,34 @@ void MultiVertexFitter::printSeeds() const
   };*/
 }
 
-void MultiVertexFitter::lostVertexClaimer()
-{
-  if ( !(theReviveBelow < 0.) ) return;
+void MultiVertexFitter::lostVertexClaimer() {
+  if (!(theReviveBelow < 0.))
+    return;
   // this experimental method is used to get almost lost vertices
   // back into the play by upweighting vertices with very low total weights
 
   bool has_revived = false;
   // find out about total weight
-  for ( vector< pair < int, CachingVertex<5> > >::const_iterator i=theVertexStates.begin();
-        i!=theVertexStates.end() ; ++i )
-  {
-    double totweight=0.;
-    for ( vector< TransientTrack >::const_iterator trk=theTracks.begin();
-          trk!=theTracks.end() ; ++trk )
-    {
-      totweight+=theWeights[*trk][i->first];
+  for (vector<pair<int, CachingVertex<5> > >::const_iterator i = theVertexStates.begin(); i != theVertexStates.end();
+       ++i) {
+    double totweight = 0.;
+    for (vector<TransientTrack>::const_iterator trk = theTracks.begin(); trk != theTracks.end(); ++trk) {
+      totweight += theWeights[*trk][i->first];
     };
 
     /*
     cout << "[MultiVertexFitter] vertex seed " << TransientVertexNamer().name(*i)
          << " total weight=" << totweight << endl;*/
 
-    if ( totweight < theReviveBelow && totweight > 0.0 )
-    {
+    if (totweight < theReviveBelow && totweight > 0.0) {
       cout << "[MultiVertexFitter] now trying to revive vertex"
            << " revive_below=" << theReviveBelow << endl;
-      has_revived=true;
-      for ( vector< TransientTrack >::const_iterator trk=theTracks.begin();
-            trk!=theTracks.end() ; ++trk )
-      {
-        theWeights[*trk][i->first]/=totweight;
+      has_revived = true;
+      for (vector<TransientTrack>::const_iterator trk = theTracks.begin(); trk != theTracks.end(); ++trk) {
+        theWeights[*trk][i->first] /= totweight;
       };
     };
   };
-  if ( has_revived && verbose() ) printWeights();
+  if (has_revived && verbose())
+    printWeights();
 }

--- a/RecoVertex/MultiVertexFit/src/MultiVertexReconstructor.cc
+++ b/RecoVertex/MultiVertexFit/src/MultiVertexReconstructor.cc
@@ -5,110 +5,77 @@ using namespace std;
 namespace {
   typedef MultiVertexFitter::TrackAndWeight TrackAndWeight;
 
-  int verbose()
-  {
-    return 0;
-  }
+  int verbose() { return 0; }
 
 #ifndef __clang__
-  inline void remove ( vector < TransientVertex > & vtces,
-                const vector < reco::TransientTrack > & trks )
-  {
+  inline void remove(vector<TransientVertex>& vtces, const vector<reco::TransientTrack>& trks) {
     cout << "[MultiVertexReconstructor] fixme remove not yet implemented" << endl;
     // remove trks from vtces
   }
 #endif
 
-  vector < vector < TrackAndWeight > > recover (
-      const vector < TransientVertex > & vtces, const vector < reco::TransientTrack > & trks )
-  {
-    set < reco::TransientTrack > st;
-    for ( vector< reco::TransientTrack >::const_iterator i=trks.begin(); 
-          i!=trks.end() ; ++i )
-    {
-      st.insert ( *i );
+  vector<vector<TrackAndWeight> > recover(const vector<TransientVertex>& vtces,
+                                          const vector<reco::TransientTrack>& trks) {
+    set<reco::TransientTrack> st;
+    for (vector<reco::TransientTrack>::const_iterator i = trks.begin(); i != trks.end(); ++i) {
+      st.insert(*i);
     }
-    
-    vector < vector < TrackAndWeight > > bundles;
-    for ( vector< TransientVertex >::const_iterator vtx=vtces.begin();
-          vtx!=vtces.end() ; ++vtx )
-    {
-      vector < reco::TransientTrack > trks = vtx->originalTracks();
-      vector < TrackAndWeight > tnws;
-      for ( vector< reco::TransientTrack >::const_iterator trk=trks.begin(); 
-            trk!=trks.end() ; ++trk )
-      {
-        float w = vtx->trackWeight ( *trk ); 
-        if ( w > 1e-5 )
-        {
-          TrackAndWeight tmp ( *trk, w );
-          set < reco::TransientTrack >::iterator pos = st.find( *trk );
-          if ( pos != st.end() )
-          {
-            st.erase ( pos  );
+
+    vector<vector<TrackAndWeight> > bundles;
+    for (vector<TransientVertex>::const_iterator vtx = vtces.begin(); vtx != vtces.end(); ++vtx) {
+      vector<reco::TransientTrack> trks = vtx->originalTracks();
+      vector<TrackAndWeight> tnws;
+      for (vector<reco::TransientTrack>::const_iterator trk = trks.begin(); trk != trks.end(); ++trk) {
+        float w = vtx->trackWeight(*trk);
+        if (w > 1e-5) {
+          TrackAndWeight tmp(*trk, w);
+          set<reco::TransientTrack>::iterator pos = st.find(*trk);
+          if (pos != st.end()) {
+            st.erase(pos);
           }
-          tnws.push_back ( tmp );
+          tnws.push_back(tmp);
         };
       };
-      bundles.push_back ( tnws );
+      bundles.push_back(tnws);
     };
 
-    if ( bundles.empty() ) return bundles;
+    if (bundles.empty())
+      return bundles;
 
     // now add not-yet assigned tracks
-    for ( set < reco::TransientTrack >::const_iterator i=st.begin(); 
-          i!=st.end() ; ++i )
-    {
+    for (set<reco::TransientTrack>::const_iterator i = st.begin(); i != st.end(); ++i) {
       // cout << "[MultiVertexReconstructor] recovering " << i->id() << endl;
-      TrackAndWeight tmp ( *i, 0. );
-      bundles[0].push_back ( tmp );
+      TrackAndWeight tmp(*i, 0.);
+      bundles[0].push_back(tmp);
     }
     return bundles;
   }
+}  // namespace
+
+MultiVertexReconstructor::MultiVertexReconstructor(const VertexReconstructor& o,
+                                                   const AnnealingSchedule& s,
+                                                   float revive)
+    : theOldReconstructor(o.clone()), theFitter(MultiVertexFitter(s, DefaultLinearizationPointFinder(), revive)) {}
+
+MultiVertexReconstructor::~MultiVertexReconstructor() { delete theOldReconstructor; }
+
+MultiVertexReconstructor* MultiVertexReconstructor::clone() const { return new MultiVertexReconstructor(*this); }
+
+MultiVertexReconstructor::MultiVertexReconstructor(const MultiVertexReconstructor& o)
+    : theOldReconstructor(o.theOldReconstructor->clone()), theFitter(o.theFitter) {}
+
+vector<TransientVertex> MultiVertexReconstructor::vertices(const vector<reco::TransientTrack>& trks,
+                                                           const reco::BeamSpot& s) const {
+  return vertices(trks);
 }
 
-MultiVertexReconstructor::MultiVertexReconstructor ( 
-    const VertexReconstructor & o, const AnnealingSchedule & s, float revive  ) : 
-    theOldReconstructor ( o.clone() ), theFitter ( 
-        MultiVertexFitter ( s, DefaultLinearizationPointFinder(), revive ) )
-{
+vector<TransientVertex> MultiVertexReconstructor::vertices(const vector<reco::TransientTrack>& trks,
+                                                           const vector<reco::TransientTrack>& primaries,
+                                                           const reco::BeamSpot& s) const {
+  return vertices(trks, primaries);
 }
 
-MultiVertexReconstructor::~MultiVertexReconstructor()
-{
-  delete theOldReconstructor;
-}
-
-MultiVertexReconstructor * MultiVertexReconstructor::clone() const
-{
-  return new MultiVertexReconstructor ( * this );
-}
-
-MultiVertexReconstructor::MultiVertexReconstructor ( 
-    const MultiVertexReconstructor & o ) :
-  theOldReconstructor ( o.theOldReconstructor->clone() ),
-  theFitter ( o.theFitter )
-{}
-
-vector < TransientVertex > MultiVertexReconstructor::vertices ( 
-    const vector < reco::TransientTrack > & trks,
-    const reco::BeamSpot & s ) const
-{
-  return vertices ( trks );
-}
-
-vector < TransientVertex > MultiVertexReconstructor::vertices ( 
-    const vector < reco::TransientTrack > & trks,
-    const vector < reco::TransientTrack > & primaries,
-    const reco::BeamSpot & s ) const
-{
-  return vertices ( trks, primaries );
-}
-
-
-vector < TransientVertex > MultiVertexReconstructor::vertices ( 
-    const vector < reco::TransientTrack > & trks ) const
-{
+vector<TransientVertex> MultiVertexReconstructor::vertices(const vector<reco::TransientTrack>& trks) const {
   /*
   cout << "[MultiVertexReconstructor] input trks: ";
   for ( vector< reco::TransientTrack >::const_iterator i=trks.begin(); 
@@ -117,84 +84,64 @@ vector < TransientVertex > MultiVertexReconstructor::vertices (
     cout << i->id() << "  ";
   }
   cout << endl;*/
-  vector < TransientVertex > tmp = theOldReconstructor->vertices ( trks );
-  if ( verbose() )
-  {
-    cout << "[MultiVertexReconstructor] non-freezing seeder found " << tmp.size()
-         << " vertices from " << trks.size() << " tracks." << endl;
+  vector<TransientVertex> tmp = theOldReconstructor->vertices(trks);
+  if (verbose()) {
+    cout << "[MultiVertexReconstructor] non-freezing seeder found " << tmp.size() << " vertices from " << trks.size()
+         << " tracks." << endl;
   }
-  vector < vector < TrackAndWeight > > rc = recover ( tmp, trks );
-  vector < CachingVertex<5> > cvts = theFitter.vertices ( rc );
-  vector < TransientVertex > ret;
-  for ( vector< CachingVertex<5> >::const_iterator i=cvts.begin(); 
-        i!=cvts.end() ; ++i )
-  {
-    ret.push_back ( *i );
+  vector<vector<TrackAndWeight> > rc = recover(tmp, trks);
+  vector<CachingVertex<5> > cvts = theFitter.vertices(rc);
+  vector<TransientVertex> ret;
+  for (vector<CachingVertex<5> >::const_iterator i = cvts.begin(); i != cvts.end(); ++i) {
+    ret.push_back(*i);
   };
 
-  if ( verbose() )
-  {
-    cout << "[MultiVertexReconstructor] input " << tmp.size()
-         << " vertices, output " << ret.size() << " vertices."
+  if (verbose()) {
+    cout << "[MultiVertexReconstructor] input " << tmp.size() << " vertices, output " << ret.size() << " vertices."
          << endl;
   };
   return ret;
 }
 
-vector < TransientVertex > MultiVertexReconstructor::vertices ( 
-    const vector < reco::TransientTrack > & trks,
-    const vector < reco::TransientTrack > & primaries ) const
-{
+vector<TransientVertex> MultiVertexReconstructor::vertices(const vector<reco::TransientTrack>& trks,
+                                                           const vector<reco::TransientTrack>& primaries) const {
   /*
   cout << "[MultiVertexReconstructor] with " << primaries.size()
        << " primaries!" << endl;
        */
-  
-  map < reco::TransientTrack, bool > st;
-  
-  vector < reco::TransientTrack > total = trks;
-  for ( vector< reco::TransientTrack >::const_iterator i=trks.begin(); 
-        i!=trks.end() ; ++i )
-  {
-    st[(*i)]=true;
+
+  map<reco::TransientTrack, bool> st;
+
+  vector<reco::TransientTrack> total = trks;
+  for (vector<reco::TransientTrack>::const_iterator i = trks.begin(); i != trks.end(); ++i) {
+    st[(*i)] = true;
   }
 
   // cout << "[MultiVertexReconstructor] FIXME dont just add up tracks. superpose" << endl;
-  for ( vector< reco::TransientTrack >::const_iterator i=primaries.begin(); 
-        i!=primaries.end() ; ++i )
-  {
-    if (!(st[(*i)]))
-    {
-      total.push_back ( *i );
+  for (vector<reco::TransientTrack>::const_iterator i = primaries.begin(); i != primaries.end(); ++i) {
+    if (!(st[(*i)])) {
+      total.push_back(*i);
     }
   }
 
-  vector < TransientVertex > tmp = theOldReconstructor->vertices ( total );
+  vector<TransientVertex> tmp = theOldReconstructor->vertices(total);
 
-  if ( verbose() )
-  {
-    cout << "[MultiVertexReconstructor] freezing seeder found " << tmp.size()
-         << " vertices from " << total.size() << " tracks." << endl;
+  if (verbose()) {
+    cout << "[MultiVertexReconstructor] freezing seeder found " << tmp.size() << " vertices from " << total.size()
+         << " tracks." << endl;
   }
-  vector < vector < TrackAndWeight > > rc = recover ( tmp, trks );
-  vector < CachingVertex<5> > cvts = theFitter.vertices ( rc, primaries );
-   
-  vector < TransientVertex > ret;
-  for ( vector< CachingVertex<5> >::const_iterator i=cvts.begin(); 
-        i!=cvts.end() ; ++i )
-  {
-    ret.push_back ( *i );
+  vector<vector<TrackAndWeight> > rc = recover(tmp, trks);
+  vector<CachingVertex<5> > cvts = theFitter.vertices(rc, primaries);
+
+  vector<TransientVertex> ret;
+  for (vector<CachingVertex<5> >::const_iterator i = cvts.begin(); i != cvts.end(); ++i) {
+    ret.push_back(*i);
   };
-  if ( verbose() )
-  {
-    cout << "[MultiVertexReconstructor] input " << tmp.size()
-         << " vertices, output " << ret.size() << " vertices."
+  if (verbose()) {
+    cout << "[MultiVertexReconstructor] input " << tmp.size() << " vertices, output " << ret.size() << " vertices."
          << endl;
   };
   return ret;
 }
 
-VertexReconstructor * MultiVertexReconstructor::reconstructor() const
-{
-  return theOldReconstructor;
-}
+VertexReconstructor* MultiVertexReconstructor::reconstructor() const { return theOldReconstructor; }


### PR DESCRIPTION

Applying code-format for CMSSW category reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/343//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


