### PR TITLE
Running code-format for reconstruction

### DIFF
--- a/DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h
+++ b/DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h
@@ -24,7 +24,7 @@
 
 class LocalTrajectoryParameters {
 public:
-// construct
+  // construct
 
   LocalTrajectoryParameters() {}
 
@@ -36,18 +36,17 @@ public:
    *  in which case the charge of the first element will be neglected.
    */
   LocalTrajectoryParameters(const AlgebraicVector5& v, float aPzSign, bool charged = true) {
-    theQbp  = v[0];
+    theQbp = v[0];
     theDxdz = v[1];
     theDydz = v[2];
-    theX    = v[3];
-    theY    = v[4];
+    theX = v[3];
+    theY = v[4];
     thePzSign = aPzSign;
-    if ( charged )
-      theCharge = theQbp>0 ? 1 : -1;
+    if (charged)
+      theCharge = theQbp > 0 ? 1 : -1;
     else
       theCharge = 0;
   }
-
 
   /** Constructor from individual parameters.
    *
@@ -56,66 +55,62 @@ public:
    *  the first argument. For neutral particles the last argument should be false, 
    *  in which case the charge of the first argument will be neglected.
    */
-  LocalTrajectoryParameters(float aQbp, float aDxdz, float aDydz,
-                            float aX, float aY, float aPzSign, bool charged = true) :
-    theDxdz(aDxdz), theDydz(aDydz),
-    theX(aX), theY(aY), thePzSign(aPzSign>0 ? 1 : -1) {
-    if ( charged ) {
+  LocalTrajectoryParameters(float aQbp, float aDxdz, float aDydz, float aX, float aY, float aPzSign, bool charged = true)
+      : theDxdz(aDxdz), theDydz(aDydz), theX(aX), theY(aY), thePzSign(aPzSign > 0 ? 1 : -1) {
+    if (charged) {
       theQbp = aQbp;
-      theCharge = theQbp>0 ? 1 : -1;
-    }
-    else {
+      theCharge = theQbp > 0 ? 1 : -1;
+    } else {
       theQbp = aQbp;
       theCharge = 0;
     }
   }
 
   /// Constructor from local position, momentum and charge.
-  LocalTrajectoryParameters( const LocalPoint& pos, const LocalVector& p,
-			     TrackCharge charge) :
-    theQbp( charge/p.mag()), theDxdz( p.x()/p.z()), theDydz( p.y()/p.z()), 
-    theX( pos.x()), theY(pos.y()), thePzSign( p.z()>0. ? 1:-1), theCharge(charge) {
-    if ( charge==0 )  theQbp = 1.f/p.mag();
+  LocalTrajectoryParameters(const LocalPoint& pos, const LocalVector& p, TrackCharge charge)
+      : theQbp(charge / p.mag()),
+        theDxdz(p.x() / p.z()),
+        theDydz(p.y() / p.z()),
+        theX(pos.x()),
+        theY(pos.y()),
+        thePzSign(p.z() > 0. ? 1 : -1),
+        theCharge(charge) {
+    if (charge == 0)
+      theQbp = 1.f / p.mag();
   }
 
-// access
+  // access
 
   /// Local x and y position coordinates.
-  LocalPoint position() const {
-    return LocalPoint(theX, theY);
-  }
+  LocalPoint position() const { return LocalPoint(theX, theY); }
 
-  /// Momentum vector in the local frame. 
+  /// Momentum vector in the local frame.
   LocalVector momentum() const {
     float op = std::abs(theQbp);
-    if ( op<1.e-9f )  op = 1.e-9f;
-    float pz = float(thePzSign)/(op*std::sqrt(1.f + theDxdz*theDxdz + theDydz*theDydz));
-    float px = pz*theDxdz;
-    float py = pz*theDydz;
+    if (op < 1.e-9f)
+      op = 1.e-9f;
+    float pz = float(thePzSign) / (op * std::sqrt(1.f + theDxdz * theDxdz + theDydz * theDydz));
+    float px = pz * theDxdz;
+    float py = pz * theDydz;
     return LocalVector(px, py, pz);
   }
 
-  /// Momentum vector unit in the local frame. 
+  /// Momentum vector unit in the local frame.
   LocalVector direction() const {
-    float dz = float(thePzSign)/std::sqrt(1.f + theDxdz*theDxdz + theDydz*theDydz);
-    float dx = dz*theDxdz;
-    float dy = dz*theDydz;
+    float dz = float(thePzSign) / std::sqrt(1.f + theDxdz * theDxdz + theDydz * theDydz);
+    float dx = dz * theDxdz;
+    float dy = dz * theDydz;
     return LocalVector(dx, dy, dz);
   }
 
   /// Momentum vector unit in the local frame.
-  LocalVector directionNotNormalized() const {
-    return LocalVector(theDxdz, theDydz, 1.f);
-  }
-
+  LocalVector directionNotNormalized() const { return LocalVector(theDxdz, theDydz, 1.f); }
 
   /// Charge (-1, 0 or 1)
-  TrackCharge charge() const {return theCharge;}
+  TrackCharge charge() const { return theCharge; }
 
   /// Signed inverse momentum q/p (zero for neutrals).
-  float signedInverseMomentum() const {
-    return charge()==0 ? 0.f : theQbp;
-  }
+  float signedInverseMomentum() const { return charge() == 0 ? 0.f : theQbp; }
 
   /** Vector of parameters with signed inverse momentum.
    *
@@ -139,7 +134,7 @@ public:
    */
   AlgebraicVector5 mixedFormatVector() const {
     AlgebraicVector5 v;
-    v[0] = theQbp;    // signed in case of charged particles, 1/p for neutrals
+    v[0] = theQbp;  // signed in case of charged particles, 1/p for neutrals
     v[1] = theDxdz;
     v[2] = theDydz;
     v[3] = theX;
@@ -148,37 +143,33 @@ public:
   }
 
   /// Sign of the z-component of the momentum in the local frame.
-  float pzSign() const {
-    return thePzSign;
-  }
+  float pzSign() const { return thePzSign; }
 
   /// Update of momentum by a scalar dP.
   bool updateP(float dP) {
-    float p = 1.f/std::abs(theQbp);
-    if ((p += dP) <= 0.f) return false;
-    float newQbp = theQbp > 0. ? 1.f/p : -1.f/p;
+    float p = 1.f / std::abs(theQbp);
+    if ((p += dP) <= 0.f)
+      return false;
+    float newQbp = theQbp > 0. ? 1.f / p : -1.f / p;
     theQbp = newQbp;
     return true;
   }
 
-
-  float qbp() const { return theQbp;}
-  float dxdz() const { return theDxdz;}
-  float dydz() const { return theDydz;}
-  float absdz() const { return 1.f/std::sqrt(1.f + theDxdz*theDxdz + theDydz*theDydz); }
-
+  float qbp() const { return theQbp; }
+  float dxdz() const { return theDxdz; }
+  float dydz() const { return theDydz; }
+  float absdz() const { return 1.f / std::sqrt(1.f + theDxdz * theDxdz + theDydz * theDydz); }
 
 private:
-  float theQbp;    ///< q/p (charged) or 1/p (neutral)
-  float theDxdz;   ///< tangent of direction in local x vs. z
-  float theDydz;   ///< tangent of direction in local y vs. z
-  float theX;      ///< local x position
-  float theY;      ///< local y position
+  float theQbp;   ///< q/p (charged) or 1/p (neutral)
+  float theDxdz;  ///< tangent of direction in local x vs. z
+  float theDydz;  ///< tangent of direction in local y vs. z
+  float theX;     ///< local x position
+  float theY;     ///< local y position
 
-  short thePzSign; ///< sign of local pz
+  short thePzSign;  ///< sign of local pz
 
-  short theCharge; ///< charge
-
+  short theCharge;  ///< charge
 };
 
 #endif

--- a/DataFormats/TrajectoryState/interface/PTrajectoryStateOnDet.h
+++ b/DataFormats/TrajectoryState/interface/PTrajectoryStateOnDet.h
@@ -2,7 +2,7 @@
 #define PTrajectoryStateOnDet_H
 
 #include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
-#include<cassert>
+#include <cassert>
 /** Persistent version of a TrajectoryStateOnSurface.
  *  Stores local trajectory parameters and errors and
  *  the id of the Det defining the surface.
@@ -15,74 +15,64 @@ public:
     unsigned char ss : 2;
   };
   struct DetPack {
-    unsigned int  loc : 25;
+    unsigned int loc : 25;
     unsigned char sub : 3;
     unsigned char det : 4;
   };
+
 private:
   // we assume that id cannot be calo! (i.e. det<4)
   static const unsigned int idMask = 0x3fffffff;
   union Pack {
-    Pack(){}
-    Pack(unsigned int pack) : packed(pack){}
+    Pack() {}
+    Pack(unsigned int pack) : packed(pack) {}
     Pack(unsigned int id, int surfaceSide) : packed(id) {
-      bytes.ss=surfaceSide;
-      assert(surfaceSide<3);
-      assert((id>>28)<4);
+      bytes.ss = surfaceSide;
+      assert(surfaceSide < 3);
+      assert((id >> 28) < 4);
     }
-    int side() const { return bytes.ss;}
-    unsigned int id() const { return packed&idMask;}
+    int side() const { return bytes.ss; }
+    unsigned int id() const { return packed & idMask; }
     unsigned int packed;
     Packing bytes;
     DetPack det;
   };
 
-
 public:
-
   PTrajectoryStateOnDet() {}
 
-  PTrajectoryStateOnDet( const LocalTrajectoryParameters& param, float ipt,
-			 unsigned int id,
-			 int surfaceSide) :   
-    theLocalParameters(param) ,	thePt(ipt)
-  {
+  PTrajectoryStateOnDet(const LocalTrajectoryParameters& param, float ipt, unsigned int id, int surfaceSide)
+      : theLocalParameters(param), thePt(ipt) {
     Pack p(id, surfaceSide);
     thePack = p.packed;
-    theLocalErrors[0]=-99999.e10; 
+    theLocalErrors[0] = -99999.e10;
   }
-  
-  PTrajectoryStateOnDet( const LocalTrajectoryParameters& param, float ipt,
-			 float errmatrix[15], unsigned int id,
-			 int surfaceSide) :   
-    theLocalParameters( param), thePt(ipt)
-  {
+
+  PTrajectoryStateOnDet(
+      const LocalTrajectoryParameters& param, float ipt, float errmatrix[15], unsigned int id, int surfaceSide)
+      : theLocalParameters(param), thePt(ipt) {
     Pack p(id, surfaceSide);
     thePack = p.packed;
-    for (int i=0; i<15; i++) theLocalErrors[i] = errmatrix[i];
+    for (int i = 0; i < 15; i++)
+      theLocalErrors[i] = errmatrix[i];
   }
 
-
-  const LocalTrajectoryParameters& parameters() const {return theLocalParameters;}
+  const LocalTrajectoryParameters& parameters() const { return theLocalParameters; }
   float pt() const { return thePt; }
   bool hasError() const { return theLocalErrors[0] > -1.e10; }
-  float & error(int i)  {return theLocalErrors[i];}
-  float   error(int i) const {return theLocalErrors[i];}
-  unsigned int detId() const {
-    return thePack&idMask;
-  }
-  int surfaceSide() const    {
+  float& error(int i) { return theLocalErrors[i]; }
+  float error(int i) const { return theLocalErrors[i]; }
+  unsigned int detId() const { return thePack & idMask; }
+  int surfaceSide() const {
     Pack p(thePack);
     return p.side();
   }
 
 private:
-
   LocalTrajectoryParameters theLocalParameters;
   float theLocalErrors[15] = {};
   float thePt = 0;
   unsigned int thePack = 0;
-
 };
 
 #endif

--- a/DataFormats/TrajectoryState/interface/TrackCharge.h
+++ b/DataFormats/TrajectoryState/interface/TrackCharge.h
@@ -1,6 +1,6 @@
 #ifndef TrackCharge_H
 #define TrackCharge_H
 
-typedef int   TrackCharge;
+typedef int TrackCharge;
 
-#endif // TrackCharge_H
+#endif  // TrackCharge_H

--- a/DataFormats/TrajectoryState/src/classes.h
+++ b/DataFormats/TrajectoryState/src/classes.h
@@ -1,2 +1,1 @@
 #include "DataFormats/TrajectoryState/interface/PTrajectoryStateOnDet.h"
-

--- a/DataFormats/TrajectoryState/test/PTraj_t.cpp
+++ b/DataFormats/TrajectoryState/test/PTraj_t.cpp
@@ -1,41 +1,35 @@
 #include "DataFormats/TrajectoryState/interface/PTrajectoryStateOnDet.h"
 #include "DataFormats/DetId/interface/DetId.h"
 
-
 // from Surface
-namespace{
-  namespace sn{
-    enum Side {positiveSide, negativeSide, onSurface};
-    enum GlobalFace {outer,inner,zplus,zminus,phiplus,phiminus};
-  }
-}
-#include<cassert>
+namespace {
+  namespace sn {
+    enum Side { positiveSide, negativeSide, onSurface };
+    enum GlobalFace { outer, inner, zplus, zminus, phiplus, phiminus };
+  }  // namespace sn
+}  // namespace
+#include <cassert>
 
 namespace {
-  void verify(DetId id,
-	      sn::Side ss) {
+  void verify(DetId id, sn::Side ss) {
     LocalTrajectoryParameters tp;
     PTrajectoryStateOnDet p(tp, 0., id, ss);
-    assert(p.detId()==id);
-    assert(p.surfaceSide()==ss);
+    assert(p.detId() == id);
+    assert(p.surfaceSide() == ss);
   }
-}
-
-
+}  // namespace
 
 int main() {
+  DetId tracker(DetId::Tracker, 2);
+  DetId muon(DetId::Muon, 3);
 
-  DetId tracker(DetId::Tracker,2);
-  DetId muon(DetId::Muon,3);
+  verify(tracker, sn::positiveSide);
+  verify(tracker, sn::negativeSide);
+  verify(tracker, sn::onSurface);
 
-  verify(tracker,sn::positiveSide);
-  verify(tracker,sn::negativeSide);
-  verify(tracker,sn::onSurface);
-
-  verify(muon,sn::positiveSide);
-  verify(muon,sn::negativeSide);
-  verify(muon,sn::onSurface);
+  verify(muon, sn::positiveSide);
+  verify(muon, sn::negativeSide);
+  verify(muon, sn::onSurface);
 
   return 0;
 }
-

--- a/RecoBTag/CTagging/interface/CharmTagger.h
+++ b/RecoBTag/CTagging/interface/CharmTagger.h
@@ -19,31 +19,31 @@
 
 class CharmTagger : public JetTagComputer {
 public:
-  /// explicit ctor 
-	CharmTagger(const edm::ParameterSet & );
-	~CharmTagger() override;//{}
-  float discriminator(const TagInfoHelper & tagInfo) const override;
-	void initialize(const JetTagComputerRecord & record) override;
-	
-	typedef std::vector<edm::ParameterSet> vpset;
-	
-	struct MVAVar {
-		std::string name;
-		reco::btau::TaggingVariableName id;
-		size_t index;
-		bool has_index;
-		float default_value;
-	};
+  /// explicit ctor
+  CharmTagger(const edm::ParameterSet&);
+  ~CharmTagger() override;  //{}
+  float discriminator(const TagInfoHelper& tagInfo) const override;
+  void initialize(const JetTagComputerRecord& record) override;
+
+  typedef std::vector<edm::ParameterSet> vpset;
+
+  struct MVAVar {
+    std::string name;
+    reco::btau::TaggingVariableName id;
+    size_t index;
+    bool has_index;
+    float default_value;
+  };
 
 private:
-	std::unique_ptr<TMVAEvaluator> mvaID_;
-	CombinedSVSoftLeptonComputer sl_computer_;
-	std::vector<MVAVar> variables_;
+  std::unique_ptr<TMVAEvaluator> mvaID_;
+  CombinedSVSoftLeptonComputer sl_computer_;
+  std::vector<MVAVar> variables_;
 
-	std::string mva_name_;
+  std::string mva_name_;
   bool use_condDB_;
-	std::string gbrForest_label_;
-	edm::FileInPath weight_file_;
+  std::string gbrForest_label_;
+  edm::FileInPath weight_file_;
   bool use_GBRForest_;
   bool use_adaBoost_;
   bool defaultValueNoTracks_;

--- a/RecoBTag/CTagging/plugins/CTaggerESProducer.cc
+++ b/RecoBTag/CTagging/plugins/CTaggerESProducer.cc
@@ -4,5 +4,5 @@
 #include "RecoBTau/JetTagComputer/interface/JetTagComputerESProducer.h"
 #include "RecoBTag/CTagging/interface/CharmTagger.h"
 
-typedef JetTagComputerESProducer<CharmTagger>        CharmTaggerESProducer;
+typedef JetTagComputerESProducer<CharmTagger> CharmTaggerESProducer;
 DEFINE_FWK_EVENTSETUP_MODULE(CharmTaggerESProducer);

--- a/RecoBTag/CTagging/src/CharmTagger.cc
+++ b/RecoBTag/CTagging/src/CharmTagger.cc
@@ -12,98 +12,92 @@
 #include <map>
 #include <iostream>
 
-CharmTagger::CharmTagger(const edm::ParameterSet & configuration):
-	sl_computer_(configuration.getParameter<edm::ParameterSet>("slComputerCfg")),
-  mva_name_( configuration.getParameter<std::string >("mvaName") ),
-  use_condDB_(configuration.getParameter<bool>("useCondDB")),
-  gbrForest_label_(configuration.getParameter<std::string>("gbrForestLabel")),
-  weight_file_(configuration.getParameter<edm::FileInPath>("weightFile")),
-  use_GBRForest_(configuration.getParameter<bool>("useGBRForest")),
-  use_adaBoost_(configuration.getParameter<bool>("useAdaBoost")),
-  defaultValueNoTracks_(configuration.getParameter<bool>("defaultValueNoTracks"))
-{
-	vpset vars_definition = configuration.getParameter<vpset>("variables");
-	for(auto &var : vars_definition) {
-		MVAVar mva_var;
-		mva_var.name = var.getParameter<std::string>("name");
-		mva_var.id = reco::getTaggingVariableName(
-			var.getParameter<std::string>("taggingVarName")
-			);
-		mva_var.has_index = var.existsAs<int>("idx") ;
-		mva_var.index = mva_var.has_index ? var.getParameter<int>("idx") : 0;
-		mva_var.default_value = var.getParameter<double>("default");
+CharmTagger::CharmTagger(const edm::ParameterSet &configuration)
+    : sl_computer_(configuration.getParameter<edm::ParameterSet>("slComputerCfg")),
+      mva_name_(configuration.getParameter<std::string>("mvaName")),
+      use_condDB_(configuration.getParameter<bool>("useCondDB")),
+      gbrForest_label_(configuration.getParameter<std::string>("gbrForestLabel")),
+      weight_file_(configuration.getParameter<edm::FileInPath>("weightFile")),
+      use_GBRForest_(configuration.getParameter<bool>("useGBRForest")),
+      use_adaBoost_(configuration.getParameter<bool>("useAdaBoost")),
+      defaultValueNoTracks_(configuration.getParameter<bool>("defaultValueNoTracks")) {
+  vpset vars_definition = configuration.getParameter<vpset>("variables");
+  for (auto &var : vars_definition) {
+    MVAVar mva_var;
+    mva_var.name = var.getParameter<std::string>("name");
+    mva_var.id = reco::getTaggingVariableName(var.getParameter<std::string>("taggingVarName"));
+    mva_var.has_index = var.existsAs<int>("idx");
+    mva_var.index = mva_var.has_index ? var.getParameter<int>("idx") : 0;
+    mva_var.default_value = var.getParameter<double>("default");
 
-		variables_.push_back(mva_var);
-	}
+    variables_.push_back(mva_var);
+  }
 
-	uses(0, "pfImpactParameterTagInfos");
-	uses(1, "pfInclusiveSecondaryVertexFinderCvsLTagInfos");
-	uses(2, "softPFMuonsTagInfos");
-	uses(3, "softPFElectronsTagInfos");
+  uses(0, "pfImpactParameterTagInfos");
+  uses(1, "pfInclusiveSecondaryVertexFinderCvsLTagInfos");
+  uses(2, "softPFMuonsTagInfos");
+  uses(3, "softPFElectronsTagInfos");
 }
 
-void CharmTagger::initialize(const JetTagComputerRecord & record)
-{
-	mvaID_.reset(new TMVAEvaluator());
+void CharmTagger::initialize(const JetTagComputerRecord &record) {
+  mvaID_.reset(new TMVAEvaluator());
 
-	std::vector<std::string> variable_names;
-	variable_names.reserve(variables_.size());
+  std::vector<std::string> variable_names;
+  variable_names.reserve(variables_.size());
 
-	for(auto &var : variables_) {
-		variable_names.push_back(var.name);
-	}
-	std::vector<std::string> spectators;
-
-  if(use_condDB_) {
-		const GBRWrapperRcd & gbrWrapperRecord = record.getRecord<GBRWrapperRcd>();
-
-		edm::ESHandle<GBRForest> gbrForestHandle;
-		gbrWrapperRecord.get(gbrForest_label_.c_str(), gbrForestHandle);
-
-		mvaID_->initializeGBRForest(
-			gbrForestHandle.product(), variable_names, 
-			spectators, use_adaBoost_
-			);
+  for (auto &var : variables_) {
+    variable_names.push_back(var.name);
   }
-  else {
-    mvaID_->initialize(
-			"Color:Silent:Error", mva_name_,
-			weight_file_.fullPath(), variable_names, 
-			spectators, use_GBRForest_, use_adaBoost_
-			);
+  std::vector<std::string> spectators;
+
+  if (use_condDB_) {
+    const GBRWrapperRcd &gbrWrapperRecord = record.getRecord<GBRWrapperRcd>();
+
+    edm::ESHandle<GBRForest> gbrForestHandle;
+    gbrWrapperRecord.get(gbrForest_label_.c_str(), gbrForestHandle);
+
+    mvaID_->initializeGBRForest(gbrForestHandle.product(), variable_names, spectators, use_adaBoost_);
+  } else {
+    mvaID_->initialize("Color:Silent:Error",
+                       mva_name_,
+                       weight_file_.fullPath(),
+                       variable_names,
+                       spectators,
+                       use_GBRForest_,
+                       use_adaBoost_);
   }
 }
 
-CharmTagger::~CharmTagger()
-{
-}
+CharmTagger::~CharmTagger() {}
 
 /// b-tag a jet based on track-to-jet parameters in the extened info collection
-float CharmTagger::discriminator(const TagInfoHelper & tagInfo) const {
+float CharmTagger::discriminator(const TagInfoHelper &tagInfo) const {
   // default value, used if there are no leptons associated to this jet
-  const reco::CandIPTagInfo & ip_info = tagInfo.get<reco::CandIPTagInfo>(0);
-	const reco::CandSecondaryVertexTagInfo & sv_info = tagInfo.get<reco::CandSecondaryVertexTagInfo>(1);
-	const reco::CandSoftLeptonTagInfo& softmu_info = tagInfo.get<reco::CandSoftLeptonTagInfo>(2);
-	const reco::CandSoftLeptonTagInfo& softel_info = tagInfo.get<reco::CandSoftLeptonTagInfo>(3);
-	reco::TaggingVariableList vars = sl_computer_(ip_info, sv_info, softmu_info, softel_info);
+  const reco::CandIPTagInfo &ip_info = tagInfo.get<reco::CandIPTagInfo>(0);
+  const reco::CandSecondaryVertexTagInfo &sv_info = tagInfo.get<reco::CandSecondaryVertexTagInfo>(1);
+  const reco::CandSoftLeptonTagInfo &softmu_info = tagInfo.get<reco::CandSoftLeptonTagInfo>(2);
+  const reco::CandSoftLeptonTagInfo &softel_info = tagInfo.get<reco::CandSoftLeptonTagInfo>(3);
+  reco::TaggingVariableList vars = sl_computer_(ip_info, sv_info, softmu_info, softel_info);
 
-	// Loop over input variables
-	std::map<std::string, float> inputs;
-	for(auto &mva_var : variables_){
-		//vectorial tagging variable
-		if(mva_var.has_index){
-			std::vector<float> vals = vars.getList(mva_var.id, false);
-			inputs[mva_var.name] = (vals.size() > mva_var.index) ? vals[mva_var.index] : mva_var.default_value;
-		}
-		//single value tagging var
-		else {
-			inputs[mva_var.name] = vars.get(mva_var.id, mva_var.default_value);
-		}
-	}
+  // Loop over input variables
+  std::map<std::string, float> inputs;
+  for (auto &mva_var : variables_) {
+    //vectorial tagging variable
+    if (mva_var.has_index) {
+      std::vector<float> vals = vars.getList(mva_var.id, false);
+      inputs[mva_var.name] = (vals.size() > mva_var.index) ? vals[mva_var.index] : mva_var.default_value;
+    }
+    //single value tagging var
+    else {
+      inputs[mva_var.name] = vars.get(mva_var.id, mva_var.default_value);
+    }
+  }
 
-	//get the MVA output
-	bool notracks = (vars.get(reco::btau::jetNTracks,0) == 0);
-	float tag = mvaID_->evaluate(inputs);
-	if (defaultValueNoTracks_ && notracks){tag = -2;} // if no tracks available, put value at -2 (only for Phase I)
-	return tag;
+  //get the MVA output
+  bool notracks = (vars.get(reco::btau::jetNTracks, 0) == 0);
+  float tag = mvaID_->evaluate(inputs);
+  if (defaultValueNoTracks_ && notracks) {
+    tag = -2;
+  }  // if no tracks available, put value at -2 (only for Phase I)
+  return tag;
 }

--- a/RecoCTPPS/ProtonReconstruction/interface/ProtonReconstructionAlgorithm.h
+++ b/RecoCTPPS/ProtonReconstruction/interface/ProtonReconstructionAlgorithm.h
@@ -23,65 +23,63 @@
 
 //----------------------------------------------------------------------------------------------------
 
-class ProtonReconstructionAlgorithm
-{
+class ProtonReconstructionAlgorithm {
+public:
+  ProtonReconstructionAlgorithm(bool fit_vtx_y, bool improved_estimate, unsigned int verbosity);
+  ~ProtonReconstructionAlgorithm() = default;
+
+  void init(const LHCInterpolatedOpticalFunctionsSetCollection &opticalFunctions);
+  void release();
+
+  /// run proton reconstruction using single-RP strategy
+  reco::ForwardProton reconstructFromSingleRP(const CTPPSLocalTrackLiteRef &track,
+                                              const LHCInfo &lhcInfo,
+                                              std::ostream &os) const;
+
+  /// run proton reconstruction using multiple-RP strategy
+  reco::ForwardProton reconstructFromMultiRP(const CTPPSLocalTrackLiteRefVector &tracks,
+                                             const LHCInfo &lhcInfo,
+                                             std::ostream &os) const;
+
+private:
+  unsigned int verbosity_;
+  bool fitVtxY_;
+  bool useImprovedInitialEstimate_;
+  bool initialized_;
+
+  /// optics data associated with 1 RP
+  struct RPOpticsData {
+    const LHCInterpolatedOpticalFunctionsSet *optics;
+    std::shared_ptr<const TSpline3> s_xi_vs_x_d, s_y_d_vs_xi, s_v_y_vs_xi, s_L_y_vs_xi;
+    double x0;   ///< beam horizontal position, cm
+    double y0;   ///< beam vertical position, cm
+    double ch0;  ///< intercept for linear approximation of \f$x(\xi)\f$
+    double ch1;  ///< slope for linear approximation of \f$x(\xi)\f$
+    double la0;  ///< intercept for linear approximation of \f$L_x(\xi)\f$
+    double la1;  ///< slope for linear approximation of \f$L_x(\xi)\f$
+  };
+
+  /// map: RP id --> optics data
+  std::map<unsigned int, RPOpticsData> m_rp_optics_;
+
+  /// class for calculation of chi^2
+  class ChiSquareCalculator {
   public:
-    ProtonReconstructionAlgorithm(bool fit_vtx_y, bool improved_estimate, unsigned int verbosity);
-    ~ProtonReconstructionAlgorithm() = default;
+    ChiSquareCalculator() = default;
 
-    void init(const LHCInterpolatedOpticalFunctionsSetCollection &opticalFunctions);
-    void release();
+    double operator()(const double *parameters) const;
 
-    /// run proton reconstruction using single-RP strategy
-    reco::ForwardProton reconstructFromSingleRP(const CTPPSLocalTrackLiteRef &track,
-      const LHCInfo& lhcInfo, std::ostream& os) const;
+    const CTPPSLocalTrackLiteRefVector *tracks;
+    const std::map<unsigned int, RPOpticsData> *m_rp_optics;
+  };
 
-    /// run proton reconstruction using multiple-RP strategy
-    reco::ForwardProton reconstructFromMultiRP(const CTPPSLocalTrackLiteRefVector &tracks,
-      const LHCInfo& lhcInfo, std::ostream& os) const;
+  /// fitter object
+  std::unique_ptr<ROOT::Fit::Fitter> fitter_;
 
-  private:
-    unsigned int verbosity_;
-    bool fitVtxY_;
-    bool useImprovedInitialEstimate_;
-    bool initialized_;
+  /// object to calculate chi^2
+  std::unique_ptr<ChiSquareCalculator> chiSquareCalculator_;
 
-    /// optics data associated with 1 RP
-    struct RPOpticsData
-    {
-      const LHCInterpolatedOpticalFunctionsSet *optics;
-      std::shared_ptr<const TSpline3> s_xi_vs_x_d, s_y_d_vs_xi, s_v_y_vs_xi, s_L_y_vs_xi;
-      double x0; ///< beam horizontal position, cm
-      double y0; ///< beam vertical position, cm
-      double ch0; ///< intercept for linear approximation of \f$x(\xi)\f$
-      double ch1; ///< slope for linear approximation of \f$x(\xi)\f$
-      double la0; ///< intercept for linear approximation of \f$L_x(\xi)\f$
-      double la1; ///< slope for linear approximation of \f$L_x(\xi)\f$
-    };
-
-    /// map: RP id --> optics data
-    std::map<unsigned int, RPOpticsData> m_rp_optics_;
-
-    /// class for calculation of chi^2
-    class ChiSquareCalculator
-    {
-      public:
-        ChiSquareCalculator() = default;
-
-        double operator() (const double *parameters) const;
-
-        const CTPPSLocalTrackLiteRefVector* tracks;
-        const std::map<unsigned int, RPOpticsData>* m_rp_optics;
-    };
-
-    /// fitter object
-    std::unique_ptr<ROOT::Fit::Fitter> fitter_;
-
-    /// object to calculate chi^2
-    std::unique_ptr<ChiSquareCalculator> chiSquareCalculator_;
-
-    static void doLinearFit(const std::vector<double> &vx, const std::vector<double> &vy, double &b, double &a);
+  static void doLinearFit(const std::vector<double> &vx, const std::vector<double> &vy, double &b, double &a);
 };
 
 #endif
-

--- a/RecoCTPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
+++ b/RecoCTPPS/ProtonReconstruction/plugins/CTPPSProtonProducer.cc
@@ -32,104 +32,99 @@
 
 //----------------------------------------------------------------------------------------------------
 
-class CTPPSProtonProducer : public edm::stream::EDProducer<>
-{
-  public:
-    explicit CTPPSProtonProducer(const edm::ParameterSet&);
-    ~CTPPSProtonProducer() override = default;
+class CTPPSProtonProducer : public edm::stream::EDProducer<> {
+public:
+  explicit CTPPSProtonProducer(const edm::ParameterSet &);
+  ~CTPPSProtonProducer() override = default;
 
-    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
 
-  private:
-    void produce(edm::Event&, const edm::EventSetup&) override;
+private:
+  void produce(edm::Event &, const edm::EventSetup &) override;
 
-    edm::EDGetTokenT<CTPPSLocalTrackLiteCollection> tracksToken_;
+  edm::EDGetTokenT<CTPPSLocalTrackLiteCollection> tracksToken_;
 
-    std::string lhcInfoLabel_;
+  std::string lhcInfoLabel_;
 
-    unsigned int verbosity_;
+  unsigned int verbosity_;
 
-    bool doSingleRPReconstruction_;
-    bool doMultiRPReconstruction_;
+  bool doSingleRPReconstruction_;
+  bool doMultiRPReconstruction_;
 
-    std::string singleRPReconstructionLabel_;
-    std::string multiRPReconstructionLabel_;
+  std::string singleRPReconstructionLabel_;
+  std::string multiRPReconstructionLabel_;
 
-    double localAngleXMin_, localAngleXMax_, localAngleYMin_, localAngleYMax_;
+  double localAngleXMin_, localAngleXMax_, localAngleYMin_, localAngleYMax_;
 
-    struct AssociationCuts
-    {
-      bool x_cut_apply;
-      double x_cut_value;
-      bool y_cut_apply;
-      double y_cut_value;
-      bool xi_cut_apply;
-      double xi_cut_value;
-      bool th_y_cut_apply;
-      double th_y_cut_value;
+  struct AssociationCuts {
+    bool x_cut_apply;
+    double x_cut_value;
+    bool y_cut_apply;
+    double y_cut_value;
+    bool xi_cut_apply;
+    double xi_cut_value;
+    bool th_y_cut_apply;
+    double th_y_cut_value;
 
-      void load(const edm::ParameterSet &ps)
-      {
-        x_cut_apply    = ps.getParameter<bool>  ("x_cut_apply");
-        x_cut_value    = ps.getParameter<double>("x_cut_value");
-        y_cut_apply    = ps.getParameter<bool>  ("y_cut_apply");
-        y_cut_value    = ps.getParameter<double>("y_cut_value");
-        xi_cut_apply   = ps.getParameter<bool>  ("xi_cut_apply");
-        xi_cut_value   = ps.getParameter<double>("xi_cut_value");
-        th_y_cut_apply = ps.getParameter<bool>  ("th_y_cut_apply");
-        th_y_cut_value = ps.getParameter<double>("th_y_cut_value");
-      }
+    void load(const edm::ParameterSet &ps) {
+      x_cut_apply = ps.getParameter<bool>("x_cut_apply");
+      x_cut_value = ps.getParameter<double>("x_cut_value");
+      y_cut_apply = ps.getParameter<bool>("y_cut_apply");
+      y_cut_value = ps.getParameter<double>("y_cut_value");
+      xi_cut_apply = ps.getParameter<bool>("xi_cut_apply");
+      xi_cut_value = ps.getParameter<double>("xi_cut_value");
+      th_y_cut_apply = ps.getParameter<bool>("th_y_cut_apply");
+      th_y_cut_value = ps.getParameter<double>("th_y_cut_value");
+    }
 
-      static edm::ParameterSetDescription getDefaultParameters()
-      {
-        edm::ParameterSetDescription desc;
+    static edm::ParameterSetDescription getDefaultParameters() {
+      edm::ParameterSetDescription desc;
 
-        desc.add<bool>("x_cut_apply", false)->setComment("whether to apply track-association cut in x");
-        desc.add<double>("x_cut_value", 800E-6)->setComment("threshold of track-association cut in x, mm");
-        desc.add<bool>("y_cut_apply", false)->setComment("whether to apply track-association cut in y");
-        desc.add<double>("y_cut_value", 600E-6)->setComment("threshold of track-association cut in y, mm");
-        desc.add<bool>("xi_cut_apply", true)->setComment("whether to apply track-association cut in xi");
-        desc.add<double>("xi_cut_value", 0.013)->setComment("threshold of track-association cut in xi");
-        desc.add<bool>("th_y_cut_apply", true)->setComment("whether to apply track-association cut in th_y");
-        desc.add<double>("th_y_cut_value", 20E-6)->setComment("threshold of track-association cut in th_y, rad");
+      desc.add<bool>("x_cut_apply", false)->setComment("whether to apply track-association cut in x");
+      desc.add<double>("x_cut_value", 800E-6)->setComment("threshold of track-association cut in x, mm");
+      desc.add<bool>("y_cut_apply", false)->setComment("whether to apply track-association cut in y");
+      desc.add<double>("y_cut_value", 600E-6)->setComment("threshold of track-association cut in y, mm");
+      desc.add<bool>("xi_cut_apply", true)->setComment("whether to apply track-association cut in xi");
+      desc.add<double>("xi_cut_value", 0.013)->setComment("threshold of track-association cut in xi");
+      desc.add<bool>("th_y_cut_apply", true)->setComment("whether to apply track-association cut in th_y");
+      desc.add<double>("th_y_cut_value", 20E-6)->setComment("threshold of track-association cut in th_y, rad");
 
-        return desc;
-      }
-    };
+      return desc;
+    }
+  };
 
-    std::map<unsigned int, AssociationCuts> association_cuts_;  // map: arm -> AssociationCuts
+  std::map<unsigned int, AssociationCuts> association_cuts_;  // map: arm -> AssociationCuts
 
-    unsigned int max_n_timing_tracks_;
+  unsigned int max_n_timing_tracks_;
 
-    ProtonReconstructionAlgorithm algorithm_;
+  ProtonReconstructionAlgorithm algorithm_;
 
-    bool opticsValid_;
-    edm::ESWatcher<CTPPSInterpolatedOpticsRcd> opticsWatcher_;
+  bool opticsValid_;
+  edm::ESWatcher<CTPPSInterpolatedOpticsRcd> opticsWatcher_;
 };
 
 //----------------------------------------------------------------------------------------------------
 
-CTPPSProtonProducer::CTPPSProtonProducer(const edm::ParameterSet& iConfig) :
-  tracksToken_                (consumes<CTPPSLocalTrackLiteCollection>(iConfig.getParameter<edm::InputTag>("tagLocalTrackLite"))),
-  lhcInfoLabel_               (iConfig.getParameter<std::string>("lhcInfoLabel")),
-  verbosity_                  (iConfig.getUntrackedParameter<unsigned int>("verbosity", 0)),
-  doSingleRPReconstruction_   (iConfig.getParameter<bool>("doSingleRPReconstruction")),
-  doMultiRPReconstruction_    (iConfig.getParameter<bool>("doMultiRPReconstruction")),
-  singleRPReconstructionLabel_(iConfig.getParameter<std::string>("singleRPReconstructionLabel")),
-  multiRPReconstructionLabel_ (iConfig.getParameter<std::string>("multiRPReconstructionLabel")),
+CTPPSProtonProducer::CTPPSProtonProducer(const edm::ParameterSet &iConfig)
+    : tracksToken_(consumes<CTPPSLocalTrackLiteCollection>(iConfig.getParameter<edm::InputTag>("tagLocalTrackLite"))),
+      lhcInfoLabel_(iConfig.getParameter<std::string>("lhcInfoLabel")),
+      verbosity_(iConfig.getUntrackedParameter<unsigned int>("verbosity", 0)),
+      doSingleRPReconstruction_(iConfig.getParameter<bool>("doSingleRPReconstruction")),
+      doMultiRPReconstruction_(iConfig.getParameter<bool>("doMultiRPReconstruction")),
+      singleRPReconstructionLabel_(iConfig.getParameter<std::string>("singleRPReconstructionLabel")),
+      multiRPReconstructionLabel_(iConfig.getParameter<std::string>("multiRPReconstructionLabel")),
 
-  localAngleXMin_             (iConfig.getParameter<double>("localAngleXMin")),
-  localAngleXMax_             (iConfig.getParameter<double>("localAngleXMax")),
-  localAngleYMin_             (iConfig.getParameter<double>("localAngleYMin")),
-  localAngleYMax_             (iConfig.getParameter<double>("localAngleYMax")),
+      localAngleXMin_(iConfig.getParameter<double>("localAngleXMin")),
+      localAngleXMax_(iConfig.getParameter<double>("localAngleXMax")),
+      localAngleYMin_(iConfig.getParameter<double>("localAngleYMin")),
+      localAngleYMax_(iConfig.getParameter<double>("localAngleYMax")),
 
-  max_n_timing_tracks_        (iConfig.getParameter<unsigned int>("max_n_timing_tracks")),
+      max_n_timing_tracks_(iConfig.getParameter<unsigned int>("max_n_timing_tracks")),
 
-  algorithm_                  (iConfig.getParameter<bool>("fitVtxY"), iConfig.getParameter<bool>("useImprovedInitialEstimate"), verbosity_),
-  opticsValid_(false)
-{
-  for (const std::string &sector : { "45", "56" })
-  {
+      algorithm_(
+          iConfig.getParameter<bool>("fitVtxY"), iConfig.getParameter<bool>("useImprovedInitialEstimate"), verbosity_),
+      opticsValid_(false) {
+  for (const std::string &sector : {"45", "56"}) {
     const unsigned int arm = (sector == "45") ? 0 : 1;
     association_cuts_[arm].load(iConfig.getParameterSet("association_cuts_" + sector));
   }
@@ -143,39 +138,35 @@ CTPPSProtonProducer::CTPPSProtonProducer(const edm::ParameterSet& iConfig) :
 
 //----------------------------------------------------------------------------------------------------
 
-void CTPPSProtonProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
-{
+void CTPPSProtonProducer::fillDescriptions(edm::ConfigurationDescriptions &descriptions) {
   edm::ParameterSetDescription desc;
 
   desc.add<edm::InputTag>("tagLocalTrackLite", edm::InputTag("ctppsLocalTrackLiteProducer"))
-    ->setComment("specification of the input lite-track collection");
+      ->setComment("specification of the input lite-track collection");
 
-  desc.add<std::string>("lhcInfoLabel", "")
-    ->setComment("label of the LHCInfo record");
+  desc.add<std::string>("lhcInfoLabel", "")->setComment("label of the LHCInfo record");
 
   desc.addUntracked<unsigned int>("verbosity", 0)->setComment("verbosity level");
 
   desc.add<bool>("doSingleRPReconstruction", true)
-    ->setComment("flag whether to apply single-RP reconstruction strategy");
+      ->setComment("flag whether to apply single-RP reconstruction strategy");
 
-  desc.add<bool>("doMultiRPReconstruction", true)
-    ->setComment("flag whether to apply multi-RP reconstruction strategy");
+  desc.add<bool>("doMultiRPReconstruction", true)->setComment("flag whether to apply multi-RP reconstruction strategy");
 
   desc.add<std::string>("singleRPReconstructionLabel", "singleRP")
-    ->setComment("output label for single-RP reconstruction products");
+      ->setComment("output label for single-RP reconstruction products");
 
   desc.add<std::string>("multiRPReconstructionLabel", "multiRP")
-    ->setComment("output label for multi-RP reconstruction products");
+      ->setComment("output label for multi-RP reconstruction products");
 
   desc.add<double>("localAngleXMin", -0.03)->setComment("minimal accepted value of local horizontal angle (rad)");
   desc.add<double>("localAngleXMax", +0.03)->setComment("maximal accepted value of local horizontal angle (rad)");
   desc.add<double>("localAngleYMin", -0.04)->setComment("minimal accepted value of local vertical angle (rad)");
   desc.add<double>("localAngleYMax", +0.04)->setComment("maximal accepted value of local vertical angle (rad)");
 
-  for (const std::string &sector : { "45", "56" })
-  {
+  for (const std::string &sector : {"45", "56"}) {
     desc.add<edm::ParameterSetDescription>("association_cuts_" + sector, AssociationCuts::getDefaultParameters())
-      ->setComment("track-association cuts for sector " + sector);
+        ->setComment("track-association cuts for sector " + sector);
   }
 
   std::vector<edm::ParameterSet> config;
@@ -183,18 +174,18 @@ void CTPPSProtonProducer::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<unsigned int>("max_n_timing_tracks", 5)->setComment("maximum number of timing tracks per RP");
 
   desc.add<bool>("fitVtxY", true)
-    ->setComment("for multi-RP reconstruction, flag whether y* should be free fit parameter");
+      ->setComment("for multi-RP reconstruction, flag whether y* should be free fit parameter");
 
   desc.add<bool>("useImprovedInitialEstimate", true)
-    ->setComment("for multi-RP reconstruction, flag whether a quadratic estimate of the initial point should be used");
+      ->setComment(
+          "for multi-RP reconstruction, flag whether a quadratic estimate of the initial point should be used");
 
   descriptions.add("ctppsProtons", desc);
 }
 
 //----------------------------------------------------------------------------------------------------
 
-void CTPPSProtonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void CTPPSProtonProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
   // get input
   edm::Handle<CTPPSLocalTrackLiteCollection> hTracks;
   iEvent.getByToken(tracksToken_, hTracks);
@@ -205,8 +196,7 @@ void CTPPSProtonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
   // continue only if there is something to process
   // NB: this avoids loading (possibly non-existing) conditions in workflows without proton data
-  if (!hTracks->empty())
-  {
+  if (!hTracks->empty()) {
     // get conditions
     edm::ESHandle<LHCInfo> hLHCInfo;
     iSetup.get<LHCInfoRcd>().get(lhcInfoLabel_, hLHCInfo);
@@ -218,22 +208,19 @@ void CTPPSProtonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     iSetup.get<VeryForwardRealGeometryRecord>().get(hGeometry);
 
     // re-initialise algorithm upon crossing-angle change
-    if (opticsWatcher_.check(iSetup))
-    {
+    if (opticsWatcher_.check(iSetup)) {
       if (hOpticalFunctions->empty()) {
         edm::LogInfo("CTPPSProtonProducer") << "No optical functions available, reconstruction disabled.";
         algorithm_.release();
         opticsValid_ = false;
-      }
-      else {
+      } else {
         algorithm_.init(*hOpticalFunctions);
         opticsValid_ = true;
       }
     }
 
     // do reconstruction only if optics is valid
-    if (opticsValid_)
-    {
+    if (opticsValid_) {
       // prepare log
       std::ostringstream ssLog;
       if (verbosity_)
@@ -242,24 +229,24 @@ void CTPPSProtonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
       // select tracks with small local angles, split them by LHC sector and tracker/timing RPs
       std::map<unsigned int, std::vector<unsigned int>> trackingSelection, timingSelection;
 
-      for (unsigned int idx = 0; idx < hTracks->size(); ++idx)
-      {
-        const auto& tr = hTracks->at(idx);
+      for (unsigned int idx = 0; idx < hTracks->size(); ++idx) {
+        const auto &tr = hTracks->at(idx);
 
-        if (tr.getTx() < localAngleXMin_ || tr.getTx() > localAngleXMax_
-            || tr.getTy() < localAngleYMin_ || tr.getTy() > localAngleYMax_)
+        if (tr.getTx() < localAngleXMin_ || tr.getTx() > localAngleXMax_ || tr.getTy() < localAngleYMin_ ||
+            tr.getTy() > localAngleYMax_)
           continue;
 
         const CTPPSDetId rpId(tr.getRPId());
 
         if (verbosity_)
           ssLog << "\t"
-            << "[" << idx << "] "
-            << tr.getRPId() << " (" << (rpId.arm()*100 + rpId.station()*10 + rpId.rp()) << "): "
-            << "x=" << tr.getX() << " +- " << tr.getXUnc() << " mm, "
-            << "y=" << tr.getY() << " +- " << tr.getYUnc() << " mm" << std::endl;
+                << "[" << idx << "] " << tr.getRPId() << " (" << (rpId.arm() * 100 + rpId.station() * 10 + rpId.rp())
+                << "): "
+                << "x=" << tr.getX() << " +- " << tr.getXUnc() << " mm, "
+                << "y=" << tr.getY() << " +- " << tr.getYUnc() << " mm" << std::endl;
 
-        const bool trackerRP = (rpId.subdetId() == CTPPSDetId::sdTrackingStrip || rpId.subdetId() == CTPPSDetId::sdTrackingPixel);
+        const bool trackerRP =
+            (rpId.subdetId() == CTPPSDetId::sdTrackingStrip || rpId.subdetId() == CTPPSDetId::sdTrackingPixel);
 
         if (trackerRP)
           trackingSelection[rpId.arm()].push_back(idx);
@@ -268,22 +255,20 @@ void CTPPSProtonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
       }
 
       // process each arm
-      for (const auto &arm_it : trackingSelection)
-      {
+      for (const auto &arm_it : trackingSelection) {
         const auto &indices = arm_it.second;
 
         const auto &ac = association_cuts_[arm_it.first];
 
         // do single-RP reco if needed
         std::map<unsigned int, reco::ForwardProton> singleRPResultsIndexed;
-        if (doSingleRPReconstruction_ || ac.xi_cut_apply || ac.th_y_cut_apply)
-        {
-          for (const auto &idx : indices)
-          {
+        if (doSingleRPReconstruction_ || ac.xi_cut_apply || ac.th_y_cut_apply) {
+          for (const auto &idx : indices) {
             if (verbosity_)
               ssLog << std::endl << "* reconstruction from track " << idx << std::endl;
 
-            singleRPResultsIndexed[idx] = algorithm_.reconstructFromSingleRP(CTPPSLocalTrackLiteRef(hTracks, idx), *hLHCInfo, ssLog);
+            singleRPResultsIndexed[idx] =
+                algorithm_.reconstructFromSingleRP(CTPPSLocalTrackLiteRef(hTracks, idx), *hLHCInfo, ssLog);
           }
         }
 
@@ -295,15 +280,12 @@ void CTPPSProtonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
           rpIds.insert(hTracks->at(idx).getRPId());
 
         // do multi-RP reco if chosen
-        if (doMultiRPReconstruction_ && rpIds.size() == 2)
-        {
+        if (doMultiRPReconstruction_ && rpIds.size() == 2) {
           // find matching track pairs from different tracking RPs
           std::vector<std::pair<unsigned int, unsigned int>> idx_pairs;
           std::map<unsigned int, unsigned int> idx_pair_multiplicity;
-          for (const auto &i : indices)
-          {
-            for (const auto &j : indices)
-            {
+          for (const auto &i : indices) {
+            for (const auto &j : indices) {
               if (j <= i)
                 continue;
 
@@ -338,8 +320,7 @@ void CTPPSProtonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
           // evaluate track multiplicity in each timing RP
           std::map<unsigned int, unsigned int> timing_RP_track_multiplicity;
-          for (const auto &ti : timingSelection[arm_it.first])
-          {
+          for (const auto &ti : timingSelection[arm_it.first]) {
             const auto &tr = hTracks->at(ti);
             timing_RP_track_multiplicity[tr.getRPId()]++;
           }
@@ -347,8 +328,7 @@ void CTPPSProtonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
           // associate tracking-RP pairs with timing-RP tracks
           std::map<unsigned int, std::vector<unsigned int>> matched_timing_track_indices;
           std::map<unsigned int, unsigned int> matched_timing_track_multiplicity;
-          for (unsigned int pr_idx = 0; pr_idx < idx_pairs.size(); ++pr_idx)
-          {
+          for (unsigned int pr_idx = 0; pr_idx < idx_pairs.size(); ++pr_idx) {
             const auto &i = idx_pairs[pr_idx].first;
             const auto &j = idx_pairs[pr_idx].second;
 
@@ -362,8 +342,7 @@ void CTPPSProtonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
             const double z_i = hGeometry->getRPTranslation(tr_i.getRPId()).z();
             const double z_j = hGeometry->getRPTranslation(tr_j.getRPId()).z();
 
-            for (const auto &ti : timingSelection[arm_it.first])
-            {
+            for (const auto &ti : timingSelection[arm_it.first]) {
               const auto &tr_ti = hTracks->at(ti);
 
               // skip if timing RP saturated (high track multiplicity)
@@ -371,21 +350,22 @@ void CTPPSProtonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
                 continue;
 
               // interpolation from tracking RPs
-              const double z_ti = - hGeometry->getRPTranslation(tr_ti.getRPId()).z(); // the minus sign fixes a bug in the diamond geometry
+              const double z_ti = -hGeometry->getRPTranslation(tr_ti.getRPId())
+                                       .z();  // the minus sign fixes a bug in the diamond geometry
               const double f_i = (z_ti - z_j) / (z_i - z_j), f_j = (z_i - z_ti) / (z_i - z_j);
               const double x_inter = f_i * tr_i.getX() + f_j * tr_j.getX();
-              const double x_inter_unc_sq = f_i*f_i * tr_i.getXUnc()*tr_i.getXUnc() + f_j*f_j * tr_j.getXUnc()*tr_j.getXUnc();
+              const double x_inter_unc_sq =
+                  f_i * f_i * tr_i.getXUnc() * tr_i.getXUnc() + f_j * f_j * tr_j.getXUnc() * tr_j.getXUnc();
 
               const double de_x = tr_ti.getX() - x_inter;
-              const double de_x_unc = sqrt(tr_ti.getXUnc()*tr_ti.getXUnc() + x_inter_unc_sq);
+              const double de_x_unc = sqrt(tr_ti.getXUnc() * tr_ti.getXUnc() + x_inter_unc_sq);
 
               const bool matching = (std::abs(de_x) <= de_x_unc);
 
               if (verbosity_)
-                ssLog << "ti=" << ti << ", i=" << i << ", j=" << j
-                  << " | z_ti=" << z_ti << ", z_i=" << z_i << ", z_j=" << z_j
-                  << " | x_ti=" << tr_ti.getX() << ", x_inter=" << x_inter << ", de_x=" << de_x << ", de_x_unc=" << de_x_unc
-                  << ", matching=" << matching << std::endl;
+                ssLog << "ti=" << ti << ", i=" << i << ", j=" << j << " | z_ti=" << z_ti << ", z_i=" << z_i
+                      << ", z_j=" << z_j << " | x_ti=" << tr_ti.getX() << ", x_inter=" << x_inter << ", de_x=" << de_x
+                      << ", de_x_unc=" << de_x_unc << ", matching=" << matching << std::endl;
 
               if (!matching)
                 continue;
@@ -396,8 +376,7 @@ void CTPPSProtonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
           }
 
           // process associated tracks
-          for (unsigned int pr_idx = 0; pr_idx < idx_pairs.size(); ++pr_idx)
-          {
+          for (unsigned int pr_idx = 0; pr_idx < idx_pairs.size(); ++pr_idx) {
             const auto &i = idx_pairs[pr_idx].first;
             const auto &j = idx_pairs[pr_idx].second;
 
@@ -406,7 +385,8 @@ void CTPPSProtonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
               continue;
 
             if (verbosity_)
-              ssLog << std::endl << "* reconstruction from tracking-RP tracks: " << i << ", " << j << " and timing-RP tracks: ";
+              ssLog << std::endl
+                    << "* reconstruction from tracking-RP tracks: " << i << ", " << j << " and timing-RP tracks: ";
 
             // process tracking-RP data
             CTPPSLocalTrackLiteRefVector sel_tracks;
@@ -415,9 +395,8 @@ void CTPPSProtonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
             reco::ForwardProton proton = algorithm_.reconstructFromMultiRP(sel_tracks, *hLHCInfo, ssLog);
 
             // process timing-RP data
-            double sw=0., swt=0.;
-            for (const auto &ti : matched_timing_track_indices[pr_idx])
-            {
+            double sw = 0., swt = 0.;
+            for (const auto &ti : matched_timing_track_indices[pr_idx]) {
               // skip non-unique associations of timing-RP tracks
               if (matched_timing_track_multiplicity[ti] > 1)
                 continue;
@@ -429,14 +408,13 @@ void CTPPSProtonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
               const auto &tr = hTracks->at(ti);
               const double t_unc = tr.getTimeUnc();
-              const double w = (t_unc > 0.) ? 1./t_unc/t_unc : 1.;
+              const double w = (t_unc > 0.) ? 1. / t_unc / t_unc : 1.;
               sw += w;
               swt += w * tr.getTime();
             }
 
             float time = 0., time_unc = 0.;
-            if (sw > 0.)
-            {
+            if (sw > 0.) {
               time = swt / sw;
               time_unc = 1. / sqrt(sw);
             }
@@ -475,4 +453,3 @@ void CTPPSProtonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 //----------------------------------------------------------------------------------------------------
 
 DEFINE_FWK_MODULE(CTPPSProtonProducer);
-

--- a/RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondRecHitProducerAlgorithm.h
+++ b/RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondRecHitProducerAlgorithm.h
@@ -23,21 +23,19 @@
 
 #include "CondFormats/CTPPSReadoutObjects/interface/PPSTimingCalibration.h"
 
-class CTPPSDiamondRecHitProducerAlgorithm
-{
-  public:
-    CTPPSDiamondRecHitProducerAlgorithm( const edm::ParameterSet& conf );
+class CTPPSDiamondRecHitProducerAlgorithm {
+public:
+  CTPPSDiamondRecHitProducerAlgorithm(const edm::ParameterSet& conf);
 
-    void setCalibration( const PPSTimingCalibration& );
-    void build( const CTPPSGeometry&, const edm::DetSetVector<CTPPSDiamondDigi>&, edm::DetSetVector<CTPPSDiamondRecHit>& );
+  void setCalibration(const PPSTimingCalibration&);
+  void build(const CTPPSGeometry&, const edm::DetSetVector<CTPPSDiamondDigi>&, edm::DetSetVector<CTPPSDiamondRecHit>&);
 
-  private:
-    static constexpr unsigned short MAX_CHANNEL = 20;
-    /// Conversion constant between HPTDC time slice and absolute time (in ns)
-    double ts_to_ns_;
-    PPSTimingCalibration calib_;
-    std::unique_ptr<reco::FormulaEvaluator> calib_fct_;
+private:
+  static constexpr unsigned short MAX_CHANNEL = 20;
+  /// Conversion constant between HPTDC time slice and absolute time (in ns)
+  double ts_to_ns_;
+  PPSTimingCalibration calib_;
+  std::unique_ptr<reco::FormulaEvaluator> calib_fct_;
 };
 
 #endif
-

--- a/RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondTrackRecognition.h
+++ b/RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondTrackRecognition.h
@@ -23,21 +23,19 @@
  * \brief Class performing smart reconstruction for PPS Diamond Detectors.
  * \date Jan 2017
 **/
-class CTPPSDiamondTrackRecognition : public CTPPSTimingTrackRecognition<CTPPSDiamondLocalTrack, CTPPSDiamondRecHit>
-{
-  public:
-    CTPPSDiamondTrackRecognition( const edm::ParameterSet& iConfig );
+class CTPPSDiamondTrackRecognition : public CTPPSTimingTrackRecognition<CTPPSDiamondLocalTrack, CTPPSDiamondRecHit> {
+public:
+  CTPPSDiamondTrackRecognition(const edm::ParameterSet& iConfig);
 
-    void clear() override;
-    /// Feed a new hit to the tracks recognition algorithm
-    void addHit( const CTPPSDiamondRecHit& recHit ) override;
-    /// Produce a collection of tracks for the current station, given its hits collection
-    int produceTracks( edm::DetSet<CTPPSDiamondLocalTrack>& tracks ) override;
+  void clear() override;
+  /// Feed a new hit to the tracks recognition algorithm
+  void addHit(const CTPPSDiamondRecHit& recHit) override;
+  /// Produce a collection of tracks for the current station, given its hits collection
+  int produceTracks(edm::DetSet<CTPPSDiamondLocalTrack>& tracks) override;
 
-  private:
-    std::unordered_map<int,int> mhMap_;
-    bool excludeSingleEdgeHits_;
+private:
+  std::unordered_map<int, int> mhMap_;
+  bool excludeSingleEdgeHits_;
 };
 
 #endif
-

--- a/RecoCTPPS/TotemRPLocal/interface/FastLineRecognition.h
+++ b/RecoCTPPS/TotemRPLocal/interface/FastLineRecognition.h
@@ -17,89 +17,81 @@
 #include "DataFormats/CTPPSReco/interface/TotemRPRecHit.h"
 #include "DataFormats/CTPPSReco/interface/TotemRPUVPattern.h"
 
-
 /**
  * \brief Class performing optimized hough transform to recognize lines.
 **/
 
-class FastLineRecognition
-{
-  public:
-    FastLineRecognition(double cw_a = 0., double cw_b = 0.);
+class FastLineRecognition {
+public:
+  FastLineRecognition(double cw_a = 0., double cw_b = 0.);
 
-    ~FastLineRecognition();
+  ~FastLineRecognition();
 
-    void resetGeometry(const CTPPSGeometry *_g)
-    {
-      geometry = _g;
-      geometryMap.clear();
-    }
+  void resetGeometry(const CTPPSGeometry *_g) {
+    geometry = _g;
+    geometryMap.clear();
+  }
 
-    void getPatterns(const edm::DetSetVector<TotemRPRecHit> &input, double _z0, double threshold,
-      edm::DetSet<TotemRPUVPattern> &patterns);
+  void getPatterns(const edm::DetSetVector<TotemRPRecHit> &input,
+                   double _z0,
+                   double threshold,
+                   edm::DetSet<TotemRPUVPattern> &patterns);
 
-  private:
-    /// the uncertainty of 1-hit cluster, in mm
-    static const double sigma0;
+private:
+  /// the uncertainty of 1-hit cluster, in mm
+  static const double sigma0;
 
-    /// "typical" z
-    double z0;
+  /// "typical" z
+  double z0;
 
-    /// cluster half widths in a and b
-    double chw_a, chw_b;
+  /// cluster half widths in a and b
+  double chw_a, chw_b;
 
-    /// weight threshold for accepting pattern candidates (clusters)
-    double threshold;
+  /// weight threshold for accepting pattern candidates (clusters)
+  double threshold;
 
-    /// pointer to the geometry
-    const CTPPSGeometry* geometry;
+  /// pointer to the geometry
+  const CTPPSGeometry *geometry;
 
-    struct GeomData
-    {
-      double z;   ///< z position of a sensor (wrt. IP)
-      double s;   ///< sensor's centre projected to its read-out direction
-    };
+  struct GeomData {
+    double z;  ///< z position of a sensor (wrt. IP)
+    double s;  ///< sensor's centre projected to its read-out direction
+  };
 
-    /// map: raw detector id --> GeomData
-    std::map<unsigned int, GeomData> geometryMap;
+  /// map: raw detector id --> GeomData
+  std::map<unsigned int, GeomData> geometryMap;
 
-    /// expects raw detector id
-    GeomData getGeomData(unsigned int id);
+  /// expects raw detector id
+  GeomData getGeomData(unsigned int id);
 
-    struct Point
-    {
-      unsigned int detId;       ///< raw detector id
-      const TotemRPRecHit* hit; ///< pointer to original reco hit
-      double h;                 ///< hit position in global coordinate system
-      double z;                 ///< z position with respect to z0
-      double w;                 ///< weight
-      bool usable;              ///< whether the point can still be used
-      Point(unsigned int _d=0, const TotemRPRecHit* _hit=nullptr, double _h=0., double _z=0., double _w=0.) :
-        detId(_d), hit(_hit), h(_h), z(_z), w(_w), usable(true) {}
-    };
-    
-    /// cluster of intersection points
-    struct Cluster
-    {
-      double Saw, Sbw, Sw, S1;
-      double weight;
+  struct Point {
+    unsigned int detId;        ///< raw detector id
+    const TotemRPRecHit *hit;  ///< pointer to original reco hit
+    double h;                  ///< hit position in global coordinate system
+    double z;                  ///< z position with respect to z0
+    double w;                  ///< weight
+    bool usable;               ///< whether the point can still be used
+    Point(unsigned int _d = 0, const TotemRPRecHit *_hit = nullptr, double _h = 0., double _z = 0., double _w = 0.)
+        : detId(_d), hit(_hit), h(_h), z(_z), w(_w), usable(true) {}
+  };
 
-      std::vector<const Point *> contents;
+  /// cluster of intersection points
+  struct Cluster {
+    double Saw, Sbw, Sw, S1;
+    double weight;
 
-      Cluster() : Saw(0.), Sbw(0.), Sw(0.), S1(0.), weight(0.) {}
+    std::vector<const Point *> contents;
 
-      void add(const Point *p1, const Point *p2, double a, double b, double w);
+    Cluster() : Saw(0.), Sbw(0.), Sw(0.), S1(0.), weight(0.) {}
 
-      bool operator<(const Cluster &c) const
-      {
-        return (this->Sw > c.Sw) ? true : false;
-      }
-    };
+    void add(const Point *p1, const Point *p2, double a, double b, double w);
 
-    /// gets the most significant pattern in the (remaining) points
-    /// returns true when a pattern was found
-    bool getOneLine(const std::vector<Point> &points, double threshold, Cluster &result);
+    bool operator<(const Cluster &c) const { return (this->Sw > c.Sw) ? true : false; }
+  };
+
+  /// gets the most significant pattern in the (remaining) points
+  /// returns true when a pattern was found
+  bool getOneLine(const std::vector<Point> &points, double threshold, Cluster &result);
 };
 
 #endif
-

--- a/RecoCTPPS/TotemRPLocal/interface/TotemRPClusterProducerAlgorithm.h
+++ b/RecoCTPPS/TotemRPLocal/interface/TotemRPClusterProducerAlgorithm.h
@@ -19,23 +19,22 @@
 #include <vector>
 #include <set>
 
-class TotemRPClusterProducerAlgorithm
-{
-  public:
-    TotemRPClusterProducerAlgorithm(const edm::ParameterSet& param);
+class TotemRPClusterProducerAlgorithm {
+public:
+  TotemRPClusterProducerAlgorithm(const edm::ParameterSet &param);
 
-    ~TotemRPClusterProducerAlgorithm();
-    
-    int buildClusters(unsigned int detId, const std::vector<TotemRPDigi> &digi, std::vector<TotemRPCluster> &clusters);
-    
-  private:
-    typedef std::set<TotemRPDigi> TotemRPDigiSet;
+  ~TotemRPClusterProducerAlgorithm();
 
-    TotemRPDigiSet strip_digi_set_;  ///< input digi set, strip by strip
+  int buildClusters(unsigned int detId, const std::vector<TotemRPDigi> &digi, std::vector<TotemRPCluster> &clusters);
 
-    const edm::ParameterSet &param_;
+private:
+  typedef std::set<TotemRPDigi> TotemRPDigiSet;
 
-    int verbosity_;
+  TotemRPDigiSet strip_digi_set_;  ///< input digi set, strip by strip
+
+  const edm::ParameterSet &param_;
+
+  int verbosity_;
 };
 
 #endif

--- a/RecoCTPPS/TotemRPLocal/interface/TotemRPLocalTrackFitterAlgorithm.h
+++ b/RecoCTPPS/TotemRPLocal/interface/TotemRPLocalTrackFitterAlgorithm.h
@@ -29,45 +29,43 @@
 /**
  *\brief Algorithm for fitting tracks through a single RP.
  **/
-class TotemRPLocalTrackFitterAlgorithm
-{
-  public:
-    TotemRPLocalTrackFitterAlgorithm(const edm::ParameterSet &conf);
+class TotemRPLocalTrackFitterAlgorithm {
+public:
+  TotemRPLocalTrackFitterAlgorithm(const edm::ParameterSet &conf);
 
-    /// performs the track fit, returns true if successful
-    bool fitTrack(const edm::DetSetVector<TotemRPRecHit> &hits, double z_0, const CTPPSGeometry &tot_geom, TotemRPLocalTrack &fitted_track);
+  /// performs the track fit, returns true if successful
+  bool fitTrack(const edm::DetSetVector<TotemRPRecHit> &hits,
+                double z_0,
+                const CTPPSGeometry &tot_geom,
+                TotemRPLocalTrack &fitted_track);
 
-    /// Resets the reconstruction-data cache.
-    void reset();
+  /// Resets the reconstruction-data cache.
+  void reset();
 
-  private:
-    struct RPDetCoordinateAlgebraObjs
-    {
-      TVector3 centre_of_det_global_position_;
-      double rec_u_0_;              ///< in mm, position of det. centre projected on readout direction
-      TVector2 readout_direction_;  ///< non paralell projection and rot_cor included
-      bool available_;              ///< if det should be included in the reconstruction
-    };
+private:
+  struct RPDetCoordinateAlgebraObjs {
+    TVector3 centre_of_det_global_position_;
+    double rec_u_0_;              ///< in mm, position of det. centre projected on readout direction
+    TVector2 readout_direction_;  ///< non paralell projection and rot_cor included
+    bool available_;              ///< if det should be included in the reconstruction
+  };
 
-    /// A cache of reconstruction data. Must be reset every time the geometry chagnges.
-    std::unordered_map<unsigned int, RPDetCoordinateAlgebraObjs> det_data_map_;
+  /// A cache of reconstruction data. Must be reset every time the geometry chagnges.
+  std::unordered_map<unsigned int, RPDetCoordinateAlgebraObjs> det_data_map_;
 
-    RPTopology rp_topology_;
+  RPTopology rp_topology_;
 
-    /// Returns the reconstruction data for the chosen detector from the cache DetReconstructionDataMap.
-    /// If it is not yet in the cache, calls PrepareReconstAlgebraData to make it.
-    RPDetCoordinateAlgebraObjs *getDetAlgebraData(unsigned int det_id, const CTPPSGeometry &tot_rp_geom);
+  /// Returns the reconstruction data for the chosen detector from the cache DetReconstructionDataMap.
+  /// If it is not yet in the cache, calls PrepareReconstAlgebraData to make it.
+  RPDetCoordinateAlgebraObjs *getDetAlgebraData(unsigned int det_id, const CTPPSGeometry &tot_rp_geom);
 
-    /// Build the reconstruction data.
-    RPDetCoordinateAlgebraObjs prepareReconstAlgebraData(unsigned int det_id, const CTPPSGeometry &tot_rp_geom);
+  /// Build the reconstruction data.
+  RPDetCoordinateAlgebraObjs prepareReconstAlgebraData(unsigned int det_id, const CTPPSGeometry &tot_rp_geom);
 
-    /// A matrix multiplication shorthand.
-    void multiplyByDiagonalInPlace(TMatrixD &mt, const TVectorD &diag);
-    
-    static TVector3 convert3vector(const CLHEP::Hep3Vector & v)
-    {
-      return TVector3(v.x(),v.y(),v.z()) ;
-    }
+  /// A matrix multiplication shorthand.
+  void multiplyByDiagonalInPlace(TMatrixD &mt, const TVectorD &diag);
+
+  static TVector3 convert3vector(const CLHEP::Hep3Vector &v) { return TVector3(v.x(), v.y(), v.z()); }
 };
 
 #endif

--- a/RecoCTPPS/TotemRPLocal/interface/TotemRPRecHitProducerAlgorithm.h
+++ b/RecoCTPPS/TotemRPLocal/interface/TotemRPRecHitProducerAlgorithm.h
@@ -18,17 +18,14 @@
 
 #include "Geometry/VeryForwardRPTopology/interface/RPTopology.h"
 
-class TotemRPRecHitProducerAlgorithm
-{
-  public:
-    TotemRPRecHitProducerAlgorithm(const edm::ParameterSet& conf)
-    {
-    }
+class TotemRPRecHitProducerAlgorithm {
+public:
+  TotemRPRecHitProducerAlgorithm(const edm::ParameterSet& conf) {}
 
-    void buildRecoHits(const edm::DetSet<TotemRPCluster>& input, edm::DetSet<TotemRPRecHit>& output);
+  void buildRecoHits(const edm::DetSet<TotemRPCluster>& input, edm::DetSet<TotemRPRecHit>& output);
 
-  private:
-    RPTopology rp_topology_;
+private:
+  RPTopology rp_topology_;
 };
 
 #endif

--- a/RecoCTPPS/TotemRPLocal/interface/TotemTimingConversions.h
+++ b/RecoCTPPS/TotemRPLocal/interface/TotemTimingConversions.h
@@ -19,29 +19,27 @@
 #include <string>
 #include <vector>
 
-class TotemTimingConversions
-{
-  public:
-    TotemTimingConversions(bool mergeTimePeaks, const PPSTimingCalibration& calibration);
+class TotemTimingConversions {
+public:
+  TotemTimingConversions(bool mergeTimePeaks, const PPSTimingCalibration& calibration);
 
-    float timeOfFirstSample(const TotemTimingDigi& digi) const;
-    float triggerTime(const TotemTimingDigi& digi) const;
-    float timePrecision(const TotemTimingDigi& digi) const;
-    std::vector<float> timeSamples(const TotemTimingDigi& digi) const;
-    std::vector<float> voltSamples(const TotemTimingDigi& digi) const;
+  float timeOfFirstSample(const TotemTimingDigi& digi) const;
+  float triggerTime(const TotemTimingDigi& digi) const;
+  float timePrecision(const TotemTimingDigi& digi) const;
+  std::vector<float> timeSamples(const TotemTimingDigi& digi) const;
+  std::vector<float> voltSamples(const TotemTimingDigi& digi) const;
 
-  private:
-    static constexpr float SAMPIC_SAMPLING_PERIOD_NS = 1. / 7.695;
-    static constexpr float SAMPIC_ADC_V = 1. / 256;
-    static constexpr int SAMPIC_MAX_NUMBER_OF_SAMPLES = 64;
-    static constexpr int SAMPIC_DEFAULT_OFFSET = 30;
-    static constexpr int ACCEPTED_TIME_RADIUS = 4;
-    static constexpr unsigned long CELL0_MASK = 0xfffffff000;
+private:
+  static constexpr float SAMPIC_SAMPLING_PERIOD_NS = 1. / 7.695;
+  static constexpr float SAMPIC_ADC_V = 1. / 256;
+  static constexpr int SAMPIC_MAX_NUMBER_OF_SAMPLES = 64;
+  static constexpr int SAMPIC_DEFAULT_OFFSET = 30;
+  static constexpr int ACCEPTED_TIME_RADIUS = 4;
+  static constexpr unsigned long CELL0_MASK = 0xfffffff000;
 
-    PPSTimingCalibration calibration_;
-    bool mergeTimePeaks_;
-    reco::FormulaEvaluator calibrationFunction_;
+  PPSTimingCalibration calibration_;
+  bool mergeTimePeaks_;
+  reco::FormulaEvaluator calibrationFunction_;
 };
 
 #endif
-

--- a/RecoCTPPS/TotemRPLocal/interface/TotemTimingRecHitProducerAlgorithm.h
+++ b/RecoCTPPS/TotemRPLocal/interface/TotemTimingRecHitProducerAlgorithm.h
@@ -25,46 +25,40 @@
 
 #include <memory>
 
-class TotemTimingRecHitProducerAlgorithm
-{
-  public:
-    TotemTimingRecHitProducerAlgorithm(const edm::ParameterSet &conf);
+class TotemTimingRecHitProducerAlgorithm {
+public:
+  TotemTimingRecHitProducerAlgorithm(const edm::ParameterSet& conf);
 
-    void setCalibration(const PPSTimingCalibration&);
-    void build(const CTPPSGeometry&,
-               const edm::DetSetVector<TotemTimingDigi>&,
-               edm::DetSetVector<TotemTimingRecHit>&);
+  void setCalibration(const PPSTimingCalibration&);
+  void build(const CTPPSGeometry&, const edm::DetSetVector<TotemTimingDigi>&, edm::DetSetVector<TotemTimingRecHit>&);
 
-  private:
-    struct RegressionResults
-    {
-      float m, q, rms;
-      RegressionResults() : m(0.), q(0.), rms(0.) {}
-    };
+private:
+  struct RegressionResults {
+    float m, q, rms;
+    RegressionResults() : m(0.), q(0.), rms(0.) {}
+  };
 
-    RegressionResults simplifiedLinearRegression(const std::vector<float>& time,
-                                                 const std::vector<float>& data,
-                                                 const unsigned int start_at,
-                                                 const unsigned int points) const;
+  RegressionResults simplifiedLinearRegression(const std::vector<float>& time,
+                                               const std::vector<float>& data,
+                                               const unsigned int start_at,
+                                               const unsigned int points) const;
 
-    int fastDiscriminator(const std::vector<float>& data, float threshold) const;
+  int fastDiscriminator(const std::vector<float>& data, float threshold) const;
 
-    float constantFractionDiscriminator(const std::vector<float>& time,
-                                        const std::vector<float>& data);
+  float constantFractionDiscriminator(const std::vector<float>& time, const std::vector<float>& data);
 
-    static constexpr float SINC_COEFFICIENT = M_PI*2 / 7.8;
+  static constexpr float SINC_COEFFICIENT = M_PI * 2 / 7.8;
 
-    std::unique_ptr<TotemTimingConversions> sampicConversions_;
+  std::unique_ptr<TotemTimingConversions> sampicConversions_;
 
-    bool mergeTimePeaks_;
-    int baselinePoints_;
-    double saturationLimit_;
-    double cfdFraction_;
-    int smoothingPoints_;
-    double lowPassFrequency_;
-    double hysteresis_;
-    TotemTimingRecHit::TimingAlgorithm mode_;
+  bool mergeTimePeaks_;
+  int baselinePoints_;
+  double saturationLimit_;
+  double cfdFraction_;
+  int smoothingPoints_;
+  double lowPassFrequency_;
+  double hysteresis_;
+  TotemTimingRecHit::TimingAlgorithm mode_;
 };
 
 #endif
-

--- a/RecoCTPPS/TotemRPLocal/interface/TotemTimingTrackRecognition.h
+++ b/RecoCTPPS/TotemRPLocal/interface/TotemTimingTrackRecognition.h
@@ -21,17 +21,15 @@
  * Class intended to perform general CTPPS timing detectors track recognition,
  * as well as construction of specialized classes (for now CTPPSDiamond and TotemTiming local tracks).
 **/
-class TotemTimingTrackRecognition : public CTPPSTimingTrackRecognition<TotemTimingLocalTrack, TotemTimingRecHit>
-{
-  public:
-    TotemTimingTrackRecognition( const edm::ParameterSet& iConfig );
+class TotemTimingTrackRecognition : public CTPPSTimingTrackRecognition<TotemTimingLocalTrack, TotemTimingRecHit> {
+public:
+  TotemTimingTrackRecognition(const edm::ParameterSet& iConfig);
 
-    // Adds new hit to the set from which the tracks are reconstructed.
-    void addHit( const TotemTimingRecHit& recHit ) override;
+  // Adds new hit to the set from which the tracks are reconstructed.
+  void addHit(const TotemTimingRecHit& recHit) override;
 
-    /// Produces a collection of tracks for the current station, given its hits collection
-    int produceTracks( edm::DetSet<TotemTimingLocalTrack>& tracks ) override;
+  /// Produces a collection of tracks for the current station, given its hits collection
+  int produceTracks(edm::DetSet<TotemTimingLocalTrack>& tracks) override;
 };
 
 #endif
-

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondLocalTrackFitter.cc
@@ -25,59 +25,60 @@
 
 #include "RecoCTPPS/TotemRPLocal/interface/CTPPSDiamondTrackRecognition.h"
 
-class CTPPSDiamondLocalTrackFitter : public edm::stream::EDProducer<>
-{
-  public:
-    explicit CTPPSDiamondLocalTrackFitter( const edm::ParameterSet& );
-    ~CTPPSDiamondLocalTrackFitter() override;
+class CTPPSDiamondLocalTrackFitter : public edm::stream::EDProducer<> {
+public:
+  explicit CTPPSDiamondLocalTrackFitter(const edm::ParameterSet&);
+  ~CTPPSDiamondLocalTrackFitter() override;
 
-    static void fillDescriptions( edm::ConfigurationDescriptions& );
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
 
-  private:
-    void produce( edm::Event&, const edm::EventSetup& ) override;
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-    edm::EDGetTokenT<edm::DetSetVector<CTPPSDiamondRecHit> > recHitsToken_;
-    CTPPSDiamondTrackRecognition trk_algo_45_;
-    CTPPSDiamondTrackRecognition trk_algo_56_;
+  edm::EDGetTokenT<edm::DetSetVector<CTPPSDiamondRecHit> > recHitsToken_;
+  CTPPSDiamondTrackRecognition trk_algo_45_;
+  CTPPSDiamondTrackRecognition trk_algo_56_;
 };
 
-CTPPSDiamondLocalTrackFitter::CTPPSDiamondLocalTrackFitter( const edm::ParameterSet& iConfig ) :
-  recHitsToken_( consumes<edm::DetSetVector<CTPPSDiamondRecHit> >( iConfig.getParameter<edm::InputTag>( "recHitsTag" ) ) ),
-  trk_algo_45_ ( iConfig.getParameter<edm::ParameterSet>( "trackingAlgorithmParams" ) ),
-  trk_algo_56_ ( iConfig.getParameter<edm::ParameterSet>( "trackingAlgorithmParams" ) )
-{
+CTPPSDiamondLocalTrackFitter::CTPPSDiamondLocalTrackFitter(const edm::ParameterSet& iConfig)
+    : recHitsToken_(
+          consumes<edm::DetSetVector<CTPPSDiamondRecHit> >(iConfig.getParameter<edm::InputTag>("recHitsTag"))),
+      trk_algo_45_(iConfig.getParameter<edm::ParameterSet>("trackingAlgorithmParams")),
+      trk_algo_56_(iConfig.getParameter<edm::ParameterSet>("trackingAlgorithmParams")) {
   produces<edm::DetSetVector<CTPPSDiamondLocalTrack> >();
 }
 
-CTPPSDiamondLocalTrackFitter::~CTPPSDiamondLocalTrackFitter()
-{}
+CTPPSDiamondLocalTrackFitter::~CTPPSDiamondLocalTrackFitter() {}
 
-void
-CTPPSDiamondLocalTrackFitter::produce( edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
+void CTPPSDiamondLocalTrackFitter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   auto pOut = std::make_unique<edm::DetSetVector<CTPPSDiamondLocalTrack> >();
 
   edm::Handle<edm::DetSetVector<CTPPSDiamondRecHit> > recHits;
-  iEvent.getByToken( recHitsToken_, recHits );
+  iEvent.getByToken(recHitsToken_, recHits);
 
-  const CTPPSDiamondDetId id_45( 0, 1, 6, 0, 0 ), id_56( 1, 1, 6, 0, 0 );
+  const CTPPSDiamondDetId id_45(0, 1, 6, 0, 0), id_56(1, 1, 6, 0, 0);
 
-  pOut->find_or_insert( id_45 ); // tracks in 4-5
-  edm::DetSet<CTPPSDiamondLocalTrack>& tracks56 = pOut->find_or_insert( id_56 ); // tracks in 5-6
+  pOut->find_or_insert(id_45);                                                  // tracks in 4-5
+  edm::DetSet<CTPPSDiamondLocalTrack>& tracks56 = pOut->find_or_insert(id_56);  // tracks in 5-6
 
   // workaround to retrieve the detset for 4-5 without losing the reference
-  edm::DetSet<CTPPSDiamondLocalTrack>& tracks45 = pOut->operator[]( id_45 );
+  edm::DetSet<CTPPSDiamondLocalTrack>& tracks45 = pOut->operator[](id_45);
 
   // feed hits to the track producers
-  for ( const auto& vec : *recHits ) {
-    const CTPPSDiamondDetId detid( vec.detId() );
-    for ( const auto& hit : vec ) {
+  for (const auto& vec : *recHits) {
+    const CTPPSDiamondDetId detid(vec.detId());
+    for (const auto& hit : vec) {
       // skip hits without a leading edge
-      if ( hit.getOOTIndex() == CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING ) continue;
+      if (hit.getOOTIndex() == CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING)
+        continue;
 
-      switch ( detid.arm() ) {
-        case 0: { trk_algo_45_.addHit( hit ); } break;
-        case 1: { trk_algo_56_.addHit( hit ); } break;
+      switch (detid.arm()) {
+        case 0: {
+          trk_algo_45_.addHit(hit);
+        } break;
+        case 1: {
+          trk_algo_56_.addHit(hit);
+        } break;
         default:
           edm::LogWarning("CTPPSDiamondLocalTrackFitter") << "Invalid arm for rechit: " << detid.arm();
           break;
@@ -86,60 +87,59 @@ CTPPSDiamondLocalTrackFitter::produce( edm::Event& iEvent, const edm::EventSetup
   }
 
   // retrieve the tracks for both arms
-  trk_algo_45_.produceTracks( tracks45 );
-  trk_algo_56_.produceTracks( tracks56 );
+  trk_algo_45_.produceTracks(tracks45);
+  trk_algo_56_.produceTracks(tracks56);
 
-  iEvent.put( std::move( pOut ) );
+  iEvent.put(std::move(pOut));
 
   // remove all hits from the track producers to prepare for the next event
   trk_algo_45_.clear();
   trk_algo_56_.clear();
 }
 
-void
-CTPPSDiamondLocalTrackFitter::fillDescriptions( edm::ConfigurationDescriptions& descr )
-{
+void CTPPSDiamondLocalTrackFitter::fillDescriptions(edm::ConfigurationDescriptions& descr) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>( "recHitsTag", edm::InputTag( "ctppsDiamondRecHits" ) )
-    ->setComment( "input rechits collection to retrieve" );
+  desc.add<edm::InputTag>("recHitsTag", edm::InputTag("ctppsDiamondRecHits"))
+      ->setComment("input rechits collection to retrieve");
 
   edm::ParameterSetDescription trackingAlgoParams;
-  trackingAlgoParams.add<double>( "threshold", 1.5 )
-    ->setComment( "minimal number of rechits to be observed before launching the track recognition algorithm" );
-  trackingAlgoParams.add<double>( "thresholdFromMaximum", 0.5 );
-  trackingAlgoParams.add<double>( "resolution", 0.01 /* mm */ )
-    ->setComment( "spatial resolution on the horizontal coordinate (in mm)" );
-  trackingAlgoParams.add<double>( "sigma", 0.1 );
-  trackingAlgoParams.add<double>( "startFromX", -0.5 /* mm */ )
-    ->setComment( "starting horizontal coordinate of rechits for the track recognition" );
-  trackingAlgoParams.add<double>( "stopAtX", 19.5 /* mm */ )
-    ->setComment( "ending horizontal coordinate of rechits for the track recognition" );
-  trackingAlgoParams.add<double>( "tolerance", 0.1 /* mm */)
-    ->setComment( "tolerance used for checking if the track contains certain hit" );
+  trackingAlgoParams.add<double>("threshold", 1.5)
+      ->setComment("minimal number of rechits to be observed before launching the track recognition algorithm");
+  trackingAlgoParams.add<double>("thresholdFromMaximum", 0.5);
+  trackingAlgoParams.add<double>("resolution", 0.01 /* mm */)
+      ->setComment("spatial resolution on the horizontal coordinate (in mm)");
+  trackingAlgoParams.add<double>("sigma", 0.1);
+  trackingAlgoParams.add<double>("startFromX", -0.5 /* mm */)
+      ->setComment("starting horizontal coordinate of rechits for the track recognition");
+  trackingAlgoParams.add<double>("stopAtX", 19.5 /* mm */)
+      ->setComment("ending horizontal coordinate of rechits for the track recognition");
+  trackingAlgoParams.add<double>("tolerance", 0.1 /* mm */)
+      ->setComment("tolerance used for checking if the track contains certain hit");
 
-  trackingAlgoParams.add<std::string>( "pixelEfficiencyFunction", "(x>[0]-0.5*[1])*(x<[0]+0.5*[1])+0*[2]" )
-    ->setComment( "efficiency function for single pixel\n"
-                  "can be defined as:\n"
-                  " * Precise: (TMath::Erf((x-[0]+0.5*[1])/([2]/4)+2)+1)*TMath::Erfc((x-[0]-0.5*[1])/([2]/4)-2)/4\n"
-                  " * Fast: (x>[0]-0.5*[1])*(x<[0]+0.5*[1])+((x-[0]+0.5*[1]+[2])/[2])*(x>[0]-0.5*[1]-[2])*(x<[0]-0.5*[1])+(2-(x-[0]-0.5*[1]+[2])/[2])*(x>[0]+0.5*[1])*(x<[0]+0.5*[1]+[2])\n"
-                  " * Legacy: (1/(1+exp(-(x-[0]+0.5*[1])/[2])))*(1/(1+exp((x-[0]-0.5*[1])/[2])))\n"
-                  " * Default (sigma ignored): (x>[0]-0.5*[1])*(x<[0]+0.5*[1])+0*[2]\n"
-                  "with:\n"
-                  "  [0]: centre of pad\n"
-                  "  [1]: width of pad\n"
-                  "  [2]: sigma: distance between efficiency ~100 -> 0 outside width" );
+  trackingAlgoParams.add<std::string>("pixelEfficiencyFunction", "(x>[0]-0.5*[1])*(x<[0]+0.5*[1])+0*[2]")
+      ->setComment(
+          "efficiency function for single pixel\n"
+          "can be defined as:\n"
+          " * Precise: (TMath::Erf((x-[0]+0.5*[1])/([2]/4)+2)+1)*TMath::Erfc((x-[0]-0.5*[1])/([2]/4)-2)/4\n"
+          " * Fast: "
+          "(x>[0]-0.5*[1])*(x<[0]+0.5*[1])+((x-[0]+0.5*[1]+[2])/"
+          "[2])*(x>[0]-0.5*[1]-[2])*(x<[0]-0.5*[1])+(2-(x-[0]-0.5*[1]+[2])/[2])*(x>[0]+0.5*[1])*(x<[0]+0.5*[1]+[2])\n"
+          " * Legacy: (1/(1+exp(-(x-[0]+0.5*[1])/[2])))*(1/(1+exp((x-[0]-0.5*[1])/[2])))\n"
+          " * Default (sigma ignored): (x>[0]-0.5*[1])*(x<[0]+0.5*[1])+0*[2]\n"
+          "with:\n"
+          "  [0]: centre of pad\n"
+          "  [1]: width of pad\n"
+          "  [2]: sigma: distance between efficiency ~100 -> 0 outside width");
 
-  trackingAlgoParams.add<double>( "yPosition", 0.0 )
-    ->setComment( "vertical offset of the outcoming track centre" );
-  trackingAlgoParams.add<double>( "yWidth", 0.0 )
-    ->setComment( "vertical track width" );
-  trackingAlgoParams.add<bool>( "excludeSingleEdgeHits", true )
-    ->setComment( "exclude rechits with missing leading/trailing edge" );
+  trackingAlgoParams.add<double>("yPosition", 0.0)->setComment("vertical offset of the outcoming track centre");
+  trackingAlgoParams.add<double>("yWidth", 0.0)->setComment("vertical track width");
+  trackingAlgoParams.add<bool>("excludeSingleEdgeHits", true)
+      ->setComment("exclude rechits with missing leading/trailing edge");
 
-  desc.add<edm::ParameterSetDescription>( "trackingAlgorithmParams", trackingAlgoParams )
-    ->setComment( "list of parameters associated to the track recognition algorithm" );
+  desc.add<edm::ParameterSetDescription>("trackingAlgorithmParams", trackingAlgoParams)
+      ->setComment("list of parameters associated to the track recognition algorithm");
 
-  descr.add( "ctppsDiamondLocalTracks", desc );
+  descr.add("ctppsDiamondLocalTracks", desc);
 }
 
-DEFINE_FWK_MODULE( CTPPSDiamondLocalTrackFitter );
+DEFINE_FWK_MODULE(CTPPSDiamondLocalTrackFitter);

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondRecHitProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSDiamondRecHitProducer.cc
@@ -31,75 +31,70 @@
 #include "Geometry/Records/interface/VeryForwardRealGeometryRecord.h"
 #include "CondFormats/DataRecord/interface/PPSTimingCalibrationRcd.h"
 
-class CTPPSDiamondRecHitProducer : public edm::stream::EDProducer<>
-{
-  public:
-    explicit CTPPSDiamondRecHitProducer( const edm::ParameterSet& );
+class CTPPSDiamondRecHitProducer : public edm::stream::EDProducer<> {
+public:
+  explicit CTPPSDiamondRecHitProducer(const edm::ParameterSet&);
 
-    static void fillDescriptions( edm::ConfigurationDescriptions& );
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
 
-  private:
-    void produce( edm::Event&, const edm::EventSetup& ) override;
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-    edm::EDGetTokenT<edm::DetSetVector<CTPPSDiamondDigi> > digiToken_;
+  edm::EDGetTokenT<edm::DetSetVector<CTPPSDiamondDigi> > digiToken_;
 
-    /// Label to timing calibration tag
-    edm::ESInputTag timingCalibrationTag_;
-    /// A watcher to detect timing calibration changes.
-    edm::ESWatcher<PPSTimingCalibrationRcd> calibWatcher_;
+  /// Label to timing calibration tag
+  edm::ESInputTag timingCalibrationTag_;
+  /// A watcher to detect timing calibration changes.
+  edm::ESWatcher<PPSTimingCalibrationRcd> calibWatcher_;
 
-    CTPPSDiamondRecHitProducerAlgorithm algo_;
+  CTPPSDiamondRecHitProducerAlgorithm algo_;
 };
 
-CTPPSDiamondRecHitProducer::CTPPSDiamondRecHitProducer( const edm::ParameterSet& iConfig ) :
-  digiToken_( consumes<edm::DetSetVector<CTPPSDiamondDigi> >( iConfig.getParameter<edm::InputTag>( "digiTag" ) ) ),
-  timingCalibrationTag_( iConfig.getParameter<std::string>( "timingCalibrationTag" ) ),
-  algo_( iConfig )
-{
+CTPPSDiamondRecHitProducer::CTPPSDiamondRecHitProducer(const edm::ParameterSet& iConfig)
+    : digiToken_(consumes<edm::DetSetVector<CTPPSDiamondDigi> >(iConfig.getParameter<edm::InputTag>("digiTag"))),
+      timingCalibrationTag_(iConfig.getParameter<std::string>("timingCalibrationTag")),
+      algo_(iConfig) {
   produces<edm::DetSetVector<CTPPSDiamondRecHit> >();
 }
 
-void
-CTPPSDiamondRecHitProducer::produce( edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
+void CTPPSDiamondRecHitProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   auto pOut = std::make_unique<edm::DetSetVector<CTPPSDiamondRecHit> >();
 
   // get the digi collection
   edm::Handle<edm::DetSetVector<CTPPSDiamondDigi> > digis;
-  iEvent.getByToken( digiToken_, digis );
+  iEvent.getByToken(digiToken_, digis);
 
-  if ( !digis->empty() ) {
-    if ( calibWatcher_.check( iSetup ) ) {
+  if (!digis->empty()) {
+    if (calibWatcher_.check(iSetup)) {
       edm::ESHandle<PPSTimingCalibration> hTimingCalib;
-      iSetup.get<PPSTimingCalibrationRcd>().get( timingCalibrationTag_, hTimingCalib );
-      algo_.setCalibration( *hTimingCalib );
+      iSetup.get<PPSTimingCalibrationRcd>().get(timingCalibrationTag_, hTimingCalib);
+      algo_.setCalibration(*hTimingCalib);
     }
     // get the geometry
     edm::ESHandle<CTPPSGeometry> geometry;
-    iSetup.get<VeryForwardRealGeometryRecord>().get( geometry );
+    iSetup.get<VeryForwardRealGeometryRecord>().get(geometry);
 
     // produce the rechits collection
-    algo_.build( *geometry, *digis, *pOut );
+    algo_.build(*geometry, *digis, *pOut);
   }
 
-  iEvent.put( std::move( pOut ) );
+  iEvent.put(std::move(pOut));
 }
 
-void
-CTPPSDiamondRecHitProducer::fillDescriptions( edm::ConfigurationDescriptions& descr )
-{
+void CTPPSDiamondRecHitProducer::fillDescriptions(edm::ConfigurationDescriptions& descr) {
   edm::ParameterSetDescription desc;
 
-  desc.add<edm::InputTag>( "digiTag", edm::InputTag( "ctppsDiamondRawToDigi", "TimingDiamond" ) )
-    ->setComment( "input digis collection to retrieve" );
-  desc.add<std::string>( "timingCalibrationTag", "GlobalTag:PPSDiamondTimingCalibration" )
-    ->setComment( "input tag for timing calibrations retrieval" );
-  desc.add<double>( "timeSliceNs", 25.0/1024.0 )
-    ->setComment( "conversion constant between HPTDC timing bin size and nanoseconds" );
-  desc.add<int>( "timeShift", 0 ) // to be determined at calibration level, will be replaced by a map channel id -> time shift
-    ->setComment( "overall time offset to apply on all hits in all channels" );
+  desc.add<edm::InputTag>("digiTag", edm::InputTag("ctppsDiamondRawToDigi", "TimingDiamond"))
+      ->setComment("input digis collection to retrieve");
+  desc.add<std::string>("timingCalibrationTag", "GlobalTag:PPSDiamondTimingCalibration")
+      ->setComment("input tag for timing calibrations retrieval");
+  desc.add<double>("timeSliceNs", 25.0 / 1024.0)
+      ->setComment("conversion constant between HPTDC timing bin size and nanoseconds");
+  desc.add<int>("timeShift",
+                0)  // to be determined at calibration level, will be replaced by a map channel id -> time shift
+      ->setComment("overall time offset to apply on all hits in all channels");
 
-  descr.add( "ctppsDiamondRecHits", desc );
+  descr.add("ctppsDiamondRecHits", desc);
 }
 
-DEFINE_FWK_MODULE( CTPPSDiamondRecHitProducer );
+DEFINE_FWK_MODULE(CTPPSDiamondRecHitProducer);

--- a/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/CTPPSLocalTrackLiteProducer.cc
@@ -43,8 +43,7 @@ private:
   edm::EDGetTokenT<edm::DetSetVector<TotemRPLocalTrack>> siStripTrackToken_;
 
   bool includeDiamonds_;
-  edm::EDGetTokenT<edm::DetSetVector<CTPPSDiamondLocalTrack>>
-      diamondTrackToken_;
+  edm::EDGetTokenT<edm::DetSetVector<CTPPSDiamondLocalTrack>> diamondTrackToken_;
 
   bool includePixels_;
   edm::EDGetTokenT<edm::DetSetVector<CTPPSPixelLocalTrack>> pixelTrackToken_;
@@ -55,8 +54,7 @@ private:
 
 //----------------------------------------------------------------------------------------------------
 
-CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer(
-    const edm::ParameterSet &iConfig)
+CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer(const edm::ParameterSet &iConfig)
     : includeStrips_(iConfig.getParameter<bool>("includeStrips")),
       includeDiamonds_(iConfig.getParameter<bool>("includeDiamonds")),
       includePixels_(iConfig.getParameter<bool>("includePixels")),
@@ -68,26 +66,22 @@ CTPPSLocalTrackLiteProducer::CTPPSLocalTrackLiteProducer(
       timingTrackTMax_(iConfig.getParameter<double>("timingTrackTMax")) {
   auto tagSiStripTrack = iConfig.getParameter<edm::InputTag>("tagSiStripTrack");
   if (!tagSiStripTrack.label().empty())
-    siStripTrackToken_ =
-        consumes<edm::DetSetVector<TotemRPLocalTrack>>(tagSiStripTrack);
+    siStripTrackToken_ = consumes<edm::DetSetVector<TotemRPLocalTrack>>(tagSiStripTrack);
 
   auto tagDiamondTrack = iConfig.getParameter<edm::InputTag>("tagDiamondTrack");
   if (!tagDiamondTrack.label().empty())
-    diamondTrackToken_ =
-        consumes<edm::DetSetVector<CTPPSDiamondLocalTrack>>(tagDiamondTrack);
+    diamondTrackToken_ = consumes<edm::DetSetVector<CTPPSDiamondLocalTrack>>(tagDiamondTrack);
 
   auto tagPixelTrack = iConfig.getParameter<edm::InputTag>("tagPixelTrack");
   if (!tagPixelTrack.label().empty())
-    pixelTrackToken_ =
-        consumes<edm::DetSetVector<CTPPSPixelLocalTrack>>(tagPixelTrack);
+    pixelTrackToken_ = consumes<edm::DetSetVector<CTPPSPixelLocalTrack>>(tagPixelTrack);
 
   produces<CTPPSLocalTrackLiteCollection>();
 }
 
 //----------------------------------------------------------------------------------------------------
 
-void CTPPSLocalTrackLiteProducer::produce(edm::Event &iEvent,
-                                          const edm::EventSetup &) {
+void CTPPSLocalTrackLiteProducer::produce(edm::Event &iEvent, const edm::EventSetup &) {
   // prepare output
   auto pOut = std::make_unique<CTPPSLocalTrackLiteCollection>();
 
@@ -105,41 +99,35 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event &iEvent,
         if (!trk.isValid())
           continue;
 
-        float roundedX0 =
-            MiniFloatConverter::reduceMantissaToNbitsRounding<14>(trk.getX0());
-        float roundedX0Sigma =
-            MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
-                trk.getX0Sigma());
-        float roundedY0 =
-            MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.getY0());
-        float roundedY0Sigma =
-            MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
-                trk.getY0Sigma());
-        float roundedTx =
-            MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.getTx());
-        float roundedTxSigma =
-            MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
-                trk.getTxSigma());
-        float roundedTy =
-            MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.getTy());
-        float roundedTySigma =
-            MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
-                trk.getTySigma());
+        float roundedX0 = MiniFloatConverter::reduceMantissaToNbitsRounding<14>(trk.getX0());
+        float roundedX0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getX0Sigma());
+        float roundedY0 = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.getY0());
+        float roundedY0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getY0Sigma());
+        float roundedTx = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.getTx());
+        float roundedTxSigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTxSigma());
+        float roundedTy = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.getTy());
+        float roundedTySigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTySigma());
         float roundedChiSquaredOverNDF =
-            MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
-                trk.getChiSquaredOverNDF());
+            MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getChiSquaredOverNDF());
 
-        pOut->emplace_back(rpId, // detector info
-                                 // spatial info
-                           roundedX0, roundedX0Sigma, roundedY0, roundedY0Sigma,
+        pOut->emplace_back(rpId,  // detector info
+                                  // spatial info
+                           roundedX0,
+                           roundedX0Sigma,
+                           roundedY0,
+                           roundedY0Sigma,
                            // angular info
-                           roundedTx, roundedTxSigma, roundedTy, roundedTySigma,
+                           roundedTx,
+                           roundedTxSigma,
+                           roundedTy,
+                           roundedTySigma,
                            // reconstruction info
                            roundedChiSquaredOverNDF,
                            CTPPSpixelLocalTrackReconstructionInfo::invalid,
                            trk.getNumberOfPointsUsedForFit(),
                            // timing info
-                           0., 0.);
+                           0.,
+                           0.);
       }
     }
   }
@@ -158,37 +146,35 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event &iEvent,
         if (!trk.isValid())
           continue;
 
-        const float abs_time =
-            trk.getT() + trk.getOOTIndex() * HPTDC_TIME_SLICE_WIDTH;
+        const float abs_time = trk.getT() + trk.getOOTIndex() * HPTDC_TIME_SLICE_WIDTH;
         if (abs_time < timingTrackTMin_ || abs_time > timingTrackTMax_)
           continue;
 
-        float roundedX0 =
-            MiniFloatConverter::reduceMantissaToNbitsRounding<16>(trk.getX0());
-        float roundedX0Sigma =
-            MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
-                trk.getX0Sigma());
-        float roundedY0 =
-            MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.getY0());
-        float roundedY0Sigma =
-            MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
-                trk.getY0Sigma());
-        float roundedT =
-            MiniFloatConverter::reduceMantissaToNbitsRounding<16>(abs_time);
-        float roundedTSigma =
-            MiniFloatConverter::reduceMantissaToNbitsRounding<13>(
-                trk.getTSigma());
+        float roundedX0 = MiniFloatConverter::reduceMantissaToNbitsRounding<16>(trk.getX0());
+        float roundedX0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getX0Sigma());
+        float roundedY0 = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.getY0());
+        float roundedY0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getY0Sigma());
+        float roundedT = MiniFloatConverter::reduceMantissaToNbitsRounding<16>(abs_time);
+        float roundedTSigma = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.getTSigma());
 
-        pOut->emplace_back(rpId, // detector info
-                                 // spatial info
-                           roundedX0, roundedX0Sigma, roundedY0, roundedY0Sigma,
+        pOut->emplace_back(rpId,  // detector info
+                                  // spatial info
+                           roundedX0,
+                           roundedX0Sigma,
+                           roundedY0,
+                           roundedY0Sigma,
                            // angular info
-                           0., 0., 0., 0.,
+                           0.,
+                           0.,
+                           0.,
+                           0.,
                            // reconstruction info
-                           0., CTPPSpixelLocalTrackReconstructionInfo::invalid,
+                           0.,
+                           CTPPSpixelLocalTrackReconstructionInfo::invalid,
                            trk.getNumOfPlanes(),
                            // timing info
-                           roundedT, roundedTSigma);
+                           roundedT,
+                           roundedTSigma);
       }
     }
   }
@@ -206,49 +192,37 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event &iEvent,
         for (const auto &trk : rpv) {
           if (!trk.isValid())
             continue;
-          if (trk.getTx() > pixelTrackTxMin_ &&
-              trk.getTx() < pixelTrackTxMax_ &&
-              trk.getTy() > pixelTrackTyMin_ &&
+          if (trk.getTx() > pixelTrackTxMin_ && trk.getTx() < pixelTrackTxMax_ && trk.getTy() > pixelTrackTyMin_ &&
               trk.getTy() < pixelTrackTyMax_) {
-            float roundedX0 =
-                MiniFloatConverter::reduceMantissaToNbitsRounding<16>(
-                    trk.getX0());
-            float roundedX0Sigma =
-                MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
-                    trk.getX0Sigma());
-            float roundedY0 =
-                MiniFloatConverter::reduceMantissaToNbitsRounding<13>(
-                    trk.getY0());
-            float roundedY0Sigma =
-                MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
-                    trk.getY0Sigma());
-            float roundedTx =
-                MiniFloatConverter::reduceMantissaToNbitsRounding<11>(
-                    trk.getTx());
-            float roundedTxSigma =
-                MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
-                    trk.getTxSigma());
-            float roundedTy =
-                MiniFloatConverter::reduceMantissaToNbitsRounding<11>(
-                    trk.getTy());
-            float roundedTySigma =
-                MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
-                    trk.getTySigma());
+            float roundedX0 = MiniFloatConverter::reduceMantissaToNbitsRounding<16>(trk.getX0());
+            float roundedX0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getX0Sigma());
+            float roundedY0 = MiniFloatConverter::reduceMantissaToNbitsRounding<13>(trk.getY0());
+            float roundedY0Sigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getY0Sigma());
+            float roundedTx = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.getTx());
+            float roundedTxSigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTxSigma());
+            float roundedTy = MiniFloatConverter::reduceMantissaToNbitsRounding<11>(trk.getTy());
+            float roundedTySigma = MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getTySigma());
             float roundedChiSquaredOverNDF =
-                MiniFloatConverter::reduceMantissaToNbitsRounding<8>(
-                    trk.getChiSquaredOverNDF());
+                MiniFloatConverter::reduceMantissaToNbitsRounding<8>(trk.getChiSquaredOverNDF());
 
-            pOut->emplace_back(
-                rpId, // detector info
-                      // spatial info
-                roundedX0, roundedX0Sigma, roundedY0, roundedY0Sigma,
-                // angular info
-                roundedTx, roundedTxSigma, roundedTy, roundedTySigma,
-                // reconstruction info
-                roundedChiSquaredOverNDF, trk.getRecoInfo(),
-                trk.getNumberOfPointsUsedForFit(),
-                // timing info
-                0., 0.);
+            pOut->emplace_back(rpId,  // detector info
+                                      // spatial info
+                               roundedX0,
+                               roundedX0Sigma,
+                               roundedY0,
+                               roundedY0Sigma,
+                               // angular info
+                               roundedTx,
+                               roundedTxSigma,
+                               roundedTy,
+                               roundedTySigma,
+                               // reconstruction info
+                               roundedChiSquaredOverNDF,
+                               trk.getRecoInfo(),
+                               trk.getNumberOfPointsUsedForFit(),
+                               // timing info
+                               0.,
+                               0.);
           }
         }
       }
@@ -261,8 +235,7 @@ void CTPPSLocalTrackLiteProducer::produce(edm::Event &iEvent,
 
 //----------------------------------------------------------------------------------------------------
 
-void CTPPSLocalTrackLiteProducer::fillDescriptions(
-    edm::ConfigurationDescriptions &descr) {
+void CTPPSLocalTrackLiteProducer::fillDescriptions(edm::ConfigurationDescriptions &descr) {
   edm::ParameterSetDescription desc;
 
   // By default: all includeXYZ flags set to false.
@@ -270,29 +243,19 @@ void CTPPSLocalTrackLiteProducer::fillDescriptions(
   // python config, see:
   // RecoCTPPS/TotemRPLocal/python/ctppsLocalTrackLiteProducer_cff.py
 
-  desc.add<bool>("includeStrips", false)
-      ->setComment("whether tracks from Si strips should be included");
-  desc.add<edm::InputTag>("tagSiStripTrack",
-                          edm::InputTag("totemRPLocalTrackFitter"))
+  desc.add<bool>("includeStrips", false)->setComment("whether tracks from Si strips should be included");
+  desc.add<edm::InputTag>("tagSiStripTrack", edm::InputTag("totemRPLocalTrackFitter"))
       ->setComment("input TOTEM strips' local tracks collection to retrieve");
 
-  desc.add<bool>("includeDiamonds", false)
-      ->setComment("whether tracks from diamonds strips should be included");
-  desc.add<edm::InputTag>("tagDiamondTrack",
-                          edm::InputTag("ctppsDiamondLocalTracks"))
-      ->setComment(
-          "input diamond detectors' local tracks collection to retrieve");
+  desc.add<bool>("includeDiamonds", false)->setComment("whether tracks from diamonds strips should be included");
+  desc.add<edm::InputTag>("tagDiamondTrack", edm::InputTag("ctppsDiamondLocalTracks"))
+      ->setComment("input diamond detectors' local tracks collection to retrieve");
 
-  desc.add<bool>("includePixels", false)
-      ->setComment("whether tracks from pixels should be included");
-  desc.add<edm::InputTag>("tagPixelTrack",
-                          edm::InputTag("ctppsPixelLocalTracks"))
-      ->setComment(
-          "input pixel detectors' local tracks collection to retrieve");
-  desc.add<double>("timingTrackTMin", -12.5)
-      ->setComment("minimal track time selection for timing detectors, in ns");
-  desc.add<double>("timingTrackTMax", +12.5)
-      ->setComment("maximal track time selection for timing detectors, in ns");
+  desc.add<bool>("includePixels", false)->setComment("whether tracks from pixels should be included");
+  desc.add<edm::InputTag>("tagPixelTrack", edm::InputTag("ctppsPixelLocalTracks"))
+      ->setComment("input pixel detectors' local tracks collection to retrieve");
+  desc.add<double>("timingTrackTMin", -12.5)->setComment("minimal track time selection for timing detectors, in ns");
+  desc.add<double>("timingTrackTMax", +12.5)->setComment("maximal track time selection for timing detectors, in ns");
 
   desc.add<double>("pixelTrackTxMin", -10.0);
   desc.add<double>("pixelTrackTxMax", 10.0);

--- a/RecoCTPPS/TotemRPLocal/plugins/TotemRPClusterProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/TotemRPClusterProducer.cc
@@ -19,32 +19,30 @@
 #include "DataFormats/CTPPSDigi/interface/TotemRPDigi.h"
 
 #include "RecoCTPPS/TotemRPLocal/interface/TotemRPClusterProducerAlgorithm.h"
- 
+
 //----------------------------------------------------------------------------------------------------
 
 /**
  * Merges neighbouring active TOTEM RP strips into clusters.
  **/
-class TotemRPClusterProducer : public edm::stream::EDProducer<>
-{
-  public:
-  
-    explicit TotemRPClusterProducer(const edm::ParameterSet& conf);
-  
-    ~TotemRPClusterProducer() override {}
-  
-    void produce(edm::Event& e, const edm::EventSetup& c) override;
-    static void fillDescriptions( edm::ConfigurationDescriptions& );
-  
-  private:
-    edm::ParameterSet conf_;
-    int verbosity_;
-    edm::InputTag digiInputTag_;
-    edm::EDGetTokenT<edm::DetSetVector<TotemRPDigi>> digiInputTagToken_;
+class TotemRPClusterProducer : public edm::stream::EDProducer<> {
+public:
+  explicit TotemRPClusterProducer(const edm::ParameterSet& conf);
 
-    TotemRPClusterProducerAlgorithm algorithm_;
+  ~TotemRPClusterProducer() override {}
 
-    void run(const edm::DetSetVector<TotemRPDigi> &input, edm::DetSetVector<TotemRPCluster> &output);
+  void produce(edm::Event& e, const edm::EventSetup& c) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+private:
+  edm::ParameterSet conf_;
+  int verbosity_;
+  edm::InputTag digiInputTag_;
+  edm::EDGetTokenT<edm::DetSetVector<TotemRPDigi>> digiInputTagToken_;
+
+  TotemRPClusterProducerAlgorithm algorithm_;
+
+  void run(const edm::DetSetVector<TotemRPDigi>& input, edm::DetSetVector<TotemRPCluster>& output);
 };
 
 //----------------------------------------------------------------------------------------------------
@@ -55,28 +53,25 @@ using namespace edm;
 
 //----------------------------------------------------------------------------------------------------
 
-TotemRPClusterProducer::TotemRPClusterProducer(edm::ParameterSet const& conf) :
-  conf_(conf), algorithm_(conf)
-{
+TotemRPClusterProducer::TotemRPClusterProducer(edm::ParameterSet const& conf) : conf_(conf), algorithm_(conf) {
   verbosity_ = conf.getParameter<int>("verbosity");
 
   digiInputTag_ = conf.getParameter<edm::InputTag>("tagDigi");
-  digiInputTagToken_ = consumes<edm::DetSetVector<TotemRPDigi> >(digiInputTag_);
+  digiInputTagToken_ = consumes<edm::DetSetVector<TotemRPDigi>>(digiInputTag_);
 
-  produces< edm::DetSetVector<TotemRPCluster> > ();
+  produces<edm::DetSetVector<TotemRPCluster>>();
 }
 
 //----------------------------------------------------------------------------------------------------
- 
-void TotemRPClusterProducer::produce(edm::Event& e, const edm::EventSetup& es)
-{
+
+void TotemRPClusterProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   // get input
-  edm::Handle< edm::DetSetVector<TotemRPDigi> > input;
+  edm::Handle<edm::DetSetVector<TotemRPDigi>> input;
   e.getByToken(digiInputTagToken_, input);
 
   // prepare output
   DetSetVector<TotemRPCluster> output;
-  
+
   // run clusterisation
   if (!input->empty())
     run(*input, output);
@@ -87,11 +82,10 @@ void TotemRPClusterProducer::produce(edm::Event& e, const edm::EventSetup& es)
 
 //----------------------------------------------------------------------------------------------------
 
-void TotemRPClusterProducer::run(const edm::DetSetVector<TotemRPDigi>& input, edm::DetSetVector<TotemRPCluster> &output)
-{
-  for (const auto &ds_digi : input)
-  {
-    edm::DetSet<TotemRPCluster> &ds_cluster = output.find_or_insert(ds_digi.id);
+void TotemRPClusterProducer::run(const edm::DetSetVector<TotemRPDigi>& input,
+                                 edm::DetSetVector<TotemRPCluster>& output) {
+  for (const auto& ds_digi : input) {
+    edm::DetSet<TotemRPCluster>& ds_cluster = output.find_or_insert(ds_digi.id);
 
     algorithm_.buildClusters(ds_digi.id, ds_digi.data, ds_cluster.data);
   }
@@ -99,16 +93,14 @@ void TotemRPClusterProducer::run(const edm::DetSetVector<TotemRPDigi>& input, ed
 
 //----------------------------------------------------------------------------------------------------
 
-void
-TotemRPClusterProducer::fillDescriptions( edm::ConfigurationDescriptions& descr )
-{
+void TotemRPClusterProducer::fillDescriptions(edm::ConfigurationDescriptions& descr) {
   edm::ParameterSetDescription desc;
 
-  desc.add<edm::InputTag>( "tagDigi", edm::InputTag( "totemRPRawToDigi", "TrackingStrip" ) )
-    ->setComment( "input digis collection to retrieve" );
-  desc.add<int>( "verbosity", 0 );
+  desc.add<edm::InputTag>("tagDigi", edm::InputTag("totemRPRawToDigi", "TrackingStrip"))
+      ->setComment("input digis collection to retrieve");
+  desc.add<int>("verbosity", 0);
 
-  descr.add( "totemRPClusterProducer", desc );
+  descr.add("totemRPClusterProducer", desc);
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/RecoCTPPS/TotemRPLocal/plugins/TotemRPRecHitProducer.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/TotemRPRecHitProducer.cc
@@ -20,28 +20,26 @@
 #include "DataFormats/CTPPSReco/interface/TotemRPRecHit.h"
 
 #include "RecoCTPPS/TotemRPLocal/interface/TotemRPRecHitProducerAlgorithm.h"
- 
+
 //----------------------------------------------------------------------------------------------------
 
-class TotemRPRecHitProducer : public edm::stream::EDProducer<>
-{
-  public:
-  
-    explicit TotemRPRecHitProducer(const edm::ParameterSet& conf);
-  
-    ~TotemRPRecHitProducer() override {}
-  
-    void produce(edm::Event& e, const edm::EventSetup& c) override;
-    static void fillDescriptions( edm::ConfigurationDescriptions& );
-  
-  private:
-    const edm::ParameterSet conf_;
-    int verbosity_;
+class TotemRPRecHitProducer : public edm::stream::EDProducer<> {
+public:
+  explicit TotemRPRecHitProducer(const edm::ParameterSet& conf);
 
-    TotemRPRecHitProducerAlgorithm algorithm_;
+  ~TotemRPRecHitProducer() override {}
 
-    edm::InputTag tagCluster_;
-    edm::EDGetTokenT<edm::DetSetVector<TotemRPCluster>> tokenCluster_;
+  void produce(edm::Event& e, const edm::EventSetup& c) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
+
+private:
+  const edm::ParameterSet conf_;
+  int verbosity_;
+
+  TotemRPRecHitProducerAlgorithm algorithm_;
+
+  edm::InputTag tagCluster_;
+  edm::EDGetTokenT<edm::DetSetVector<TotemRPCluster>> tokenCluster_;
 };
 
 //----------------------------------------------------------------------------------------------------
@@ -52,51 +50,45 @@ using namespace edm;
 
 //----------------------------------------------------------------------------------------------------
 
-TotemRPRecHitProducer::TotemRPRecHitProducer(const edm::ParameterSet& conf) :
-  conf_(conf), algorithm_(conf)
-{
+TotemRPRecHitProducer::TotemRPRecHitProducer(const edm::ParameterSet& conf) : conf_(conf), algorithm_(conf) {
   verbosity_ = conf.getParameter<int>("verbosity");
 
   tagCluster_ = conf.getParameter<edm::InputTag>("tagCluster");
-  tokenCluster_ = consumes<edm::DetSetVector<TotemRPCluster> >(tagCluster_);
+  tokenCluster_ = consumes<edm::DetSetVector<TotemRPCluster>>(tagCluster_);
 
   produces<edm::DetSetVector<TotemRPRecHit>>();
 }
 
 //----------------------------------------------------------------------------------------------------
- 
-void TotemRPRecHitProducer::produce(edm::Event& e, const edm::EventSetup& es)
-{
+
+void TotemRPRecHitProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   // get input
-  edm::Handle< edm::DetSetVector<TotemRPCluster> > input;
+  edm::Handle<edm::DetSetVector<TotemRPCluster>> input;
   e.getByToken(tokenCluster_, input);
- 
+
   // prepare output
   DetSetVector<TotemRPRecHit> output;
 
   // build reco hits
-  for (auto &ids : *input)
-  {
-    DetSet<TotemRPRecHit> &ods = output.find_or_insert(ids.detId());
+  for (auto& ids : *input) {
+    DetSet<TotemRPRecHit>& ods = output.find_or_insert(ids.detId());
     algorithm_.buildRecoHits(ids, ods);
   }
-   
+
   // save output
   e.put(make_unique<DetSetVector<TotemRPRecHit>>(output));
 }
 
 //----------------------------------------------------------------------------------------------------
 
-void
-TotemRPRecHitProducer::fillDescriptions( edm::ConfigurationDescriptions& descr )
-{
+void TotemRPRecHitProducer::fillDescriptions(edm::ConfigurationDescriptions& descr) {
   edm::ParameterSetDescription desc;
 
-  desc.add<edm::InputTag>( "tagCluster", edm::InputTag( "totemRPClusterProducer" ) )
-    ->setComment( "input clusters collection to retrieve" );
-  desc.add<int>( "verbosity", 0 );
+  desc.add<edm::InputTag>("tagCluster", edm::InputTag("totemRPClusterProducer"))
+      ->setComment("input clusters collection to retrieve");
+  desc.add<int>("verbosity", 0);
 
-  descr.add( "totemRPRecHitProducer", desc );
+  descr.add("totemRPRecHitProducer", desc);
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/RecoCTPPS/TotemRPLocal/plugins/TotemRPUVPatternFinder.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/TotemRPUVPatternFinder.cc
@@ -33,56 +33,57 @@
  * The search is perfomed in global U,V coordinates (wrt. beam). In this way (some of)
  * the alignment corrections can be taken into account.
 **/
-class TotemRPUVPatternFinder : public edm::stream::EDProducer<>
-{
-  public:
-    TotemRPUVPatternFinder(const edm::ParameterSet& conf);
+class TotemRPUVPatternFinder : public edm::stream::EDProducer<> {
+public:
+  TotemRPUVPatternFinder(const edm::ParameterSet &conf);
 
-    ~TotemRPUVPatternFinder() override;
+  ~TotemRPUVPatternFinder() override;
 
-    void produce(edm::Event& e, const edm::EventSetup& c) override;
-    static void fillDescriptions( edm::ConfigurationDescriptions& );
-  
-  private:
-    edm::InputTag tagRecHit;
-    edm::EDGetTokenT<edm::DetSetVector<TotemRPRecHit> > detSetVectorTotemRPRecHitToken;
+  void produce(edm::Event &e, const edm::EventSetup &c) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions &);
 
-    unsigned int verbosity;
+private:
+  edm::InputTag tagRecHit;
+  edm::EDGetTokenT<edm::DetSetVector<TotemRPRecHit>> detSetVectorTotemRPRecHitToken;
 
-    /// minimal required number of active planes per projection to even start track recognition
-    unsigned char minPlanesPerProjectionToSearch;
+  unsigned int verbosity;
 
-    /// minimal required number of active planes per projection to mark track candidate as fittable
-    unsigned char minPlanesPerProjectionToFit;
+  /// minimal required number of active planes per projection to even start track recognition
+  unsigned char minPlanesPerProjectionToSearch;
 
-    /// above this limit, planes are considered noisy
-    unsigned int maxHitsPerPlaneToSearch;
+  /// minimal required number of active planes per projection to mark track candidate as fittable
+  unsigned char minPlanesPerProjectionToFit;
 
-    /// the line recognition algorithm
-    FastLineRecognition *lrcgn;
+  /// above this limit, planes are considered noisy
+  unsigned int maxHitsPerPlaneToSearch;
 
-    /// minimal weight of (Hough) cluster to accept it as candidate
-    double threshold;
+  /// the line recognition algorithm
+  FastLineRecognition *lrcgn;
 
-    /// maximal angle (in any projection) to mark candidate as fittable - controls track parallelity
-    double max_a_toFit;
+  /// minimal weight of (Hough) cluster to accept it as candidate
+  double threshold;
 
-    /// block of (exceptional) settings for 1 RP
-    struct RPSettings
-    {
-      unsigned char minPlanesPerProjectionToFit_U, minPlanesPerProjectionToFit_V;
-      double threshold_U, threshold_V;
-    };
+  /// maximal angle (in any projection) to mark candidate as fittable - controls track parallelity
+  double max_a_toFit;
 
-    /// exceptional settings: RP Id --> settings
-    std::map<unsigned int, RPSettings> exceptionalSettings;
+  /// block of (exceptional) settings for 1 RP
+  struct RPSettings {
+    unsigned char minPlanesPerProjectionToFit_U, minPlanesPerProjectionToFit_V;
+    double threshold_U, threshold_V;
+  };
 
-    edm::ESWatcher<VeryForwardRealGeometryRecord> geometryWatcher;
+  /// exceptional settings: RP Id --> settings
+  std::map<unsigned int, RPSettings> exceptionalSettings;
 
-    /// executes line recognition in a projection
-    void recognizeAndSelect(TotemRPUVPattern::ProjectionType proj, double z0, double threshold,
-      unsigned int planes_required,
-      const edm::DetSetVector<TotemRPRecHit> &hits, edm::DetSet<TotemRPUVPattern> &patterns);
+  edm::ESWatcher<VeryForwardRealGeometryRecord> geometryWatcher;
+
+  /// executes line recognition in a projection
+  void recognizeAndSelect(TotemRPUVPattern::ProjectionType proj,
+                          double z0,
+                          double threshold,
+                          unsigned int planes_required,
+                          const edm::DetSetVector<TotemRPRecHit> &hits,
+                          edm::DetSet<TotemRPUVPattern> &patterns);
 };
 
 //----------------------------------------------------------------------------------------------------
@@ -92,18 +93,17 @@ using namespace edm;
 
 //----------------------------------------------------------------------------------------------------
 
-TotemRPUVPatternFinder::TotemRPUVPatternFinder(const edm::ParameterSet& conf) :
-  tagRecHit(conf.getParameter<edm::InputTag>("tagRecHit")),
-  verbosity(conf.getUntrackedParameter<unsigned int>("verbosity", 0)),
-  minPlanesPerProjectionToSearch(conf.getParameter<unsigned int>("minPlanesPerProjectionToSearch")),
-  minPlanesPerProjectionToFit(conf.getParameter<unsigned int>("minPlanesPerProjectionToFit")),
-  maxHitsPerPlaneToSearch(conf.getParameter<unsigned int>("maxHitsPerPlaneToSearch")),
-  lrcgn(new FastLineRecognition(conf.getParameter<double>("clusterSize_a"), conf.getParameter<double>("clusterSize_b"))),
-  threshold(conf.getParameter<double>("threshold")),
-  max_a_toFit(conf.getParameter<double>("max_a_toFit"))
-{
-  for (const auto &ps : conf.getParameter< vector<ParameterSet> >("exceptionalSettings"))
-  {
+TotemRPUVPatternFinder::TotemRPUVPatternFinder(const edm::ParameterSet &conf)
+    : tagRecHit(conf.getParameter<edm::InputTag>("tagRecHit")),
+      verbosity(conf.getUntrackedParameter<unsigned int>("verbosity", 0)),
+      minPlanesPerProjectionToSearch(conf.getParameter<unsigned int>("minPlanesPerProjectionToSearch")),
+      minPlanesPerProjectionToFit(conf.getParameter<unsigned int>("minPlanesPerProjectionToFit")),
+      maxHitsPerPlaneToSearch(conf.getParameter<unsigned int>("maxHitsPerPlaneToSearch")),
+      lrcgn(new FastLineRecognition(conf.getParameter<double>("clusterSize_a"),
+                                    conf.getParameter<double>("clusterSize_b"))),
+      threshold(conf.getParameter<double>("threshold")),
+      max_a_toFit(conf.getParameter<double>("max_a_toFit")) {
+  for (const auto &ps : conf.getParameter<vector<ParameterSet>>("exceptionalSettings")) {
     unsigned int rpId = ps.getParameter<unsigned int>("rpId");
 
     RPSettings settings;
@@ -115,42 +115,40 @@ TotemRPUVPatternFinder::TotemRPUVPatternFinder(const edm::ParameterSet& conf) :
     exceptionalSettings[rpId] = settings;
   }
 
-  detSetVectorTotemRPRecHitToken = consumes<edm::DetSetVector<TotemRPRecHit> >(tagRecHit);
+  detSetVectorTotemRPRecHitToken = consumes<edm::DetSetVector<TotemRPRecHit>>(tagRecHit);
 
   produces<DetSetVector<TotemRPUVPattern>>();
 }
 
 //----------------------------------------------------------------------------------------------------
 
-TotemRPUVPatternFinder::~TotemRPUVPatternFinder()
-{
-  delete lrcgn;
-}
+TotemRPUVPatternFinder::~TotemRPUVPatternFinder() { delete lrcgn; }
 
 //----------------------------------------------------------------------------------------------------
 
 void TotemRPUVPatternFinder::recognizeAndSelect(TotemRPUVPattern::ProjectionType proj,
-    double z0, double threshold_loc, unsigned int planes_required,
-    const DetSetVector<TotemRPRecHit> &hits, DetSet<TotemRPUVPattern> &patterns)
-{
+                                                double z0,
+                                                double threshold_loc,
+                                                unsigned int planes_required,
+                                                const DetSetVector<TotemRPRecHit> &hits,
+                                                DetSet<TotemRPUVPattern> &patterns) {
   // run recognition
   DetSet<TotemRPUVPattern> newPatterns;
   lrcgn->getPatterns(hits, z0, threshold_loc, newPatterns);
-  
+
   // set pattern properties and copy to the global pattern collection
-  for (auto &p : newPatterns)
-  {
+  for (auto &p : newPatterns) {
     p.setProjection(proj);
 
     p.setFittable(true);
 
     set<unsigned int> planes;
     for (const auto &ds : p.getHits())
-        planes.insert(TotemRPDetId(ds.detId()).plane());
+      planes.insert(TotemRPDetId(ds.detId()).plane());
 
     if (planes.size() < planes_required)
       p.setFittable(false);
-    
+
     if (fabs(p.getA()) > max_a_toFit)
       p.setFittable(false);
 
@@ -160,35 +158,32 @@ void TotemRPUVPatternFinder::recognizeAndSelect(TotemRPUVPattern::ProjectionType
 
 //----------------------------------------------------------------------------------------------------
 
-void TotemRPUVPatternFinder::produce(edm::Event& event, const edm::EventSetup& es)
-{
+void TotemRPUVPatternFinder::produce(edm::Event &event, const edm::EventSetup &es) {
   if (verbosity > 5)
     LogVerbatim("TotemRPUVPatternFinder")
-      << ">> TotemRPUVPatternFinder::produce " << event.id().run() << ":" << event.id().event();
+        << ">> TotemRPUVPatternFinder::produce " << event.id().run() << ":" << event.id().event();
 
   // geometry
   ESHandle<CTPPSGeometry> geometry;
   es.get<VeryForwardRealGeometryRecord>().get(geometry);
   if (geometryWatcher.check(es))
     lrcgn->resetGeometry(geometry.product());
-  
+
   // get input
-  edm::Handle< edm::DetSetVector<TotemRPRecHit> > input;
+  edm::Handle<edm::DetSetVector<TotemRPRecHit>> input;
   event.getByToken(detSetVectorTotemRPRecHitToken, input);
 
   // prepare output
   DetSetVector<TotemRPUVPattern> patternsVector;
-  
+
   // split input per RP and per U/V projection
-  struct RPData
-  {
+  struct RPData {
     DetSetVector<TotemRPRecHit> hits_U, hits_V;
     map<uint8_t, uint16_t> planeOccupancy_U, planeOccupancy_V;
   };
   map<unsigned int, RPData> rpData;
 
-  for (auto &ids : *input)
-  {
+  for (auto &ids : *input) {
     TotemRPDetId detId(ids.detId());
     unsigned int plane = detId.plane();
     bool uDir = detId.isStripsCoordinateUDirection();
@@ -197,10 +192,8 @@ void TotemRPUVPatternFinder::produce(edm::Event& event, const edm::EventSetup& e
 
     RPData &data = rpData[rpId];
 
-    for (auto &h : ids)
-    {
-      if (uDir)
-      {
+    for (auto &h : ids) {
+      if (uDir) {
         auto &ods = data.hits_U.find_or_insert(ids.detId());
         ods.push_back(h);
         data.planeOccupancy_U[plane]++;
@@ -213,8 +206,7 @@ void TotemRPUVPatternFinder::produce(edm::Event& event, const edm::EventSetup& e
   }
 
   // track recognition pot by pot
-  for (auto it : rpData)
-  {
+  for (auto it : rpData) {
     CTPPSDetId rpId(it.first);
     RPData &data = it.second;
 
@@ -223,10 +215,9 @@ void TotemRPUVPatternFinder::produce(edm::Event& event, const edm::EventSetup& e
     unsigned int minPlanesPerProjectionToFit_V = minPlanesPerProjectionToFit;
     double threshold_U = threshold;
     double threshold_V = threshold;
-    
+
     auto setIt = exceptionalSettings.find(rpId);
-    if (setIt != exceptionalSettings.end())
-    {
+    if (setIt != exceptionalSettings.end()) {
       minPlanesPerProjectionToFit_U = setIt->second.minPlanesPerProjectionToFit_U;
       minPlanesPerProjectionToFit_V = setIt->second.minPlanesPerProjectionToFit_V;
       threshold_U = setIt->second.threshold_U;
@@ -236,11 +227,9 @@ void TotemRPUVPatternFinder::produce(edm::Event& event, const edm::EventSetup& e
     auto &uColl = data.planeOccupancy_U;
     auto &vColl = data.planeOccupancy_V;
 
-    if (verbosity > 5)
-    {
+    if (verbosity > 5) {
       LogVerbatim("TotemRPUVPatternFinder")
-        << "\tRP " << rpId
-        << "\n\t\tall planes: u = " << uColl.size() << ", v = " << vColl.size();
+          << "\tRP " << rpId << "\n\t\tall planes: u = " << uColl.size() << ", v = " << vColl.size();
     }
 
     // count planes with clean data (no showers, noise, ...)
@@ -271,77 +260,77 @@ void TotemRPUVPatternFinder::produce(edm::Event& event, const edm::EventSetup& e
 
     recognizeAndSelect(TotemRPUVPattern::projV, z0, threshold_V, minPlanesPerProjectionToFit_V, data.hits_V, patterns);
 
-    if (verbosity > 5)
-    {
+    if (verbosity > 5) {
       LogVerbatim("TotemRPUVPatternFinder") << "\t\tpatterns:";
-      for (const auto &p : patterns)
-      {
+      for (const auto &p : patterns) {
         unsigned int n_hits = 0;
         for (auto &hds : p.getHits())
           n_hits += hds.size();
-      
+
         LogVerbatim("TotemRPUVPatternFinder")
-          << "\t\t\tproj = " << ((p.getProjection() == TotemRPUVPattern::projU) ? "U" : "V")
-          << ", a = " << p.getA()
-          << ", b = " << p.getB()
-          << ", w = " << p.getW()
-          << ", fittable = " << p.getFittable()
-          << ", hits = " << n_hits;
+            << "\t\t\tproj = " << ((p.getProjection() == TotemRPUVPattern::projU) ? "U" : "V") << ", a = " << p.getA()
+            << ", b = " << p.getB() << ", w = " << p.getW() << ", fittable = " << p.getFittable()
+            << ", hits = " << n_hits;
       }
     }
   }
- 
+
   // save output
   event.put(make_unique<DetSetVector<TotemRPUVPattern>>(patternsVector));
 }
- 
+
 //----------------------------------------------------------------------------------------------------
 
-void
-TotemRPUVPatternFinder::fillDescriptions( edm::ConfigurationDescriptions& descr )
-{
+void TotemRPUVPatternFinder::fillDescriptions(edm::ConfigurationDescriptions &descr) {
   edm::ParameterSetDescription desc;
 
-  desc.add<edm::InputTag>( "tagRecHit", edm::InputTag( "totemRPRecHitProducer" ) )
-    ->setComment( "input rechits collection to retrieve" );
-  desc.addUntracked<unsigned int>( "verbosity", 0 );
-  desc.add<unsigned int>( "maxHitsPerPlaneToSearch", 5 )
-    ->setComment( "minimum threshold of hits multiplicity to flag the pattern as dirty" );
-  desc.add<unsigned int>( "minPlanesPerProjectionToSearch", 3 )
-    ->setComment( "minimal number of reasonable (= not empty and not dirty) planes per projection and per RP, to start the pattern search" );
-  desc.add<double>( "clusterSize_a", 0.02 /* rad */ )
-    ->setComment( "(full) cluster size (in rad) in slope-intercept space" );
-  desc.add<double>( "clusterSize_b", 0.3 /* mm */ );
+  desc.add<edm::InputTag>("tagRecHit", edm::InputTag("totemRPRecHitProducer"))
+      ->setComment("input rechits collection to retrieve");
+  desc.addUntracked<unsigned int>("verbosity", 0);
+  desc.add<unsigned int>("maxHitsPerPlaneToSearch", 5)
+      ->setComment("minimum threshold of hits multiplicity to flag the pattern as dirty");
+  desc.add<unsigned int>("minPlanesPerProjectionToSearch", 3)
+      ->setComment(
+          "minimal number of reasonable (= not empty and not dirty) planes per projection and per RP, to start the "
+          "pattern search");
+  desc.add<double>("clusterSize_a", 0.02 /* rad */)
+      ->setComment("(full) cluster size (in rad) in slope-intercept space");
+  desc.add<double>("clusterSize_b", 0.3 /* mm */);
 
-  desc.add<double>( "threshold", 2.99 )
-    ->setComment( "minimal weight of (Hough) cluster to accept it as candidate\n"
-                  "  weight of cluster = sum of weights of contributing points\n"
-                  "  weight of point = sigma0 / sigma_of_point\n"
-                  "most often: weight of point ~ 1, thus cluster weight is roughly number of contributing points" );
+  desc.add<double>("threshold", 2.99)
+      ->setComment(
+          "minimal weight of (Hough) cluster to accept it as candidate\n"
+          "  weight of cluster = sum of weights of contributing points\n"
+          "  weight of point = sigma0 / sigma_of_point\n"
+          "most often: weight of point ~ 1, thus cluster weight is roughly number of contributing points");
 
-  desc.add<unsigned int>( "minPlanesPerProjectionToFit", 3 )
-    ->setComment( "minimal number of planes (in the recognised patterns) per projection and per RP, to tag the candidate as fittable" );
+  desc.add<unsigned int>("minPlanesPerProjectionToFit", 3)
+      ->setComment(
+          "minimal number of planes (in the recognised patterns) per projection and per RP, to tag the candidate as "
+          "fittable");
 
-  desc.add<bool>( "allowAmbiguousCombination", false )
-    ->setComment( "whether to allow combination of most significant U and V pattern, in case there several of them.\n"
-                  "don't set it to True, unless you have reason" );
+  desc.add<bool>("allowAmbiguousCombination", false)
+      ->setComment(
+          "whether to allow combination of most significant U and V pattern, in case there several of them.\n"
+          "don't set it to True, unless you have reason");
 
-  desc.add<double>( "max_a_toFit", 10.0 )
-    ->setComment( "maximal angle (in any projection) to mark the candidate as fittable -> controls track parallelity with beam\n"
-                  "huge value -> no constraint" );
+  desc.add<double>("max_a_toFit", 10.0)
+      ->setComment(
+          "maximal angle (in any projection) to mark the candidate as fittable -> controls track parallelity with "
+          "beam\n"
+          "huge value -> no constraint");
 
   edm::ParameterSetDescription exceptions_validator;
-  exceptions_validator.add<unsigned int>( "rpId" )
-    ->setComment( "RP id according to CTPPSDetId" );
-  exceptions_validator.add<unsigned int>( "minPlanesPerProjectionToFit_U" );
-  exceptions_validator.add<unsigned int>( "minPlanesPerProjectionToFit_V" );
-  exceptions_validator.add<double>( "threshold_U" );
-  exceptions_validator.add<double>( "threshold_V" );
+  exceptions_validator.add<unsigned int>("rpId")->setComment("RP id according to CTPPSDetId");
+  exceptions_validator.add<unsigned int>("minPlanesPerProjectionToFit_U");
+  exceptions_validator.add<unsigned int>("minPlanesPerProjectionToFit_V");
+  exceptions_validator.add<double>("threshold_U");
+  exceptions_validator.add<double>("threshold_V");
 
   std::vector<edm::ParameterSet> exceptions_default;
-  desc.addVPSet( "exceptionalSettings", exceptions_validator, exceptions_default );
+  desc.addVPSet("exceptionalSettings", exceptions_validator, exceptions_default);
 
-  descr.add( "totemRPUVPatternFinder", desc );
+  descr.add("totemRPUVPatternFinder", desc);
 }
 
 //----------------------------------------------------------------------------------------------------

--- a/RecoCTPPS/TotemRPLocal/plugins/TotemTimingLocalTrackFitter.cc
+++ b/RecoCTPPS/TotemRPLocal/plugins/TotemTimingLocalTrackFitter.cc
@@ -27,126 +27,121 @@
 
 #include "RecoCTPPS/TotemRPLocal/interface/TotemTimingTrackRecognition.h"
 
-class TotemTimingLocalTrackFitter : public edm::stream::EDProducer<>
-{
-  public:
-    explicit TotemTimingLocalTrackFitter( const edm::ParameterSet& );
+class TotemTimingLocalTrackFitter : public edm::stream::EDProducer<> {
+public:
+  explicit TotemTimingLocalTrackFitter(const edm::ParameterSet&);
 
-    static void fillDescriptions( edm::ConfigurationDescriptions& );
+  static void fillDescriptions(edm::ConfigurationDescriptions&);
 
-  private:
-    void produce( edm::Event&, const edm::EventSetup& ) override;
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-    const edm::EDGetTokenT<edm::DetSetVector<TotemTimingRecHit> > recHitsToken_;
-    const int maxPlaneActiveChannels_;
-    std::map<TotemTimingDetId,TotemTimingTrackRecognition> trk_algo_map_;
+  const edm::EDGetTokenT<edm::DetSetVector<TotemTimingRecHit> > recHitsToken_;
+  const int maxPlaneActiveChannels_;
+  std::map<TotemTimingDetId, TotemTimingTrackRecognition> trk_algo_map_;
 };
 
-TotemTimingLocalTrackFitter::TotemTimingLocalTrackFitter( const edm::ParameterSet& iConfig ) :
-  recHitsToken_( consumes<edm::DetSetVector<TotemTimingRecHit> >( iConfig.getParameter<edm::InputTag>( "recHitsTag" ) ) ),
-  maxPlaneActiveChannels_( iConfig.getParameter<int>( "maxPlaneActiveChannels" ) )
-{
+TotemTimingLocalTrackFitter::TotemTimingLocalTrackFitter(const edm::ParameterSet& iConfig)
+    : recHitsToken_(consumes<edm::DetSetVector<TotemTimingRecHit> >(iConfig.getParameter<edm::InputTag>("recHitsTag"))),
+      maxPlaneActiveChannels_(iConfig.getParameter<int>("maxPlaneActiveChannels")) {
   produces<edm::DetSetVector<TotemTimingLocalTrack> >();
 
-  for ( unsigned short armNo = 0; armNo < 2; armNo++ )
-    for ( unsigned short rpNo = 0; rpNo < 2; rpNo++ ) {
-      TotemTimingDetId id( armNo, 1, rpNo, 0, 0 );
-      TotemTimingTrackRecognition trk_algo( iConfig.getParameter<edm::ParameterSet>( "trackingAlgorithmParams" ) );
-      trk_algo_map_.insert( std::make_pair( id, trk_algo ) );
+  for (unsigned short armNo = 0; armNo < 2; armNo++)
+    for (unsigned short rpNo = 0; rpNo < 2; rpNo++) {
+      TotemTimingDetId id(armNo, 1, rpNo, 0, 0);
+      TotemTimingTrackRecognition trk_algo(iConfig.getParameter<edm::ParameterSet>("trackingAlgorithmParams"));
+      trk_algo_map_.insert(std::make_pair(id, trk_algo));
     }
 }
 
-void
-TotemTimingLocalTrackFitter::produce( edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
+void TotemTimingLocalTrackFitter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   auto pOut = std::make_unique<edm::DetSetVector<TotemTimingLocalTrack> >();
 
   edm::Handle<edm::DetSetVector<TotemTimingRecHit> > recHits;
-  iEvent.getByToken( recHitsToken_, recHits );
+  iEvent.getByToken(recHitsToken_, recHits);
 
-  for ( const auto& trk_algo_entry : trk_algo_map_ )
-    pOut->find_or_insert( trk_algo_entry.first );
+  for (const auto& trk_algo_entry : trk_algo_map_)
+    pOut->find_or_insert(trk_algo_entry.first);
 
-  std::map<TotemTimingDetId,int> planeActivityMap;
+  std::map<TotemTimingDetId, int> planeActivityMap;
 
-  auto motherId = []( const edm::det_id_type& detid ) {
-    TotemTimingDetId out( detid );
-    out.setStation( 1 );
-    out.setChannel( 0 );
+  auto motherId = [](const edm::det_id_type& detid) {
+    TotemTimingDetId out(detid);
+    out.setStation(1);
+    out.setChannel(0);
     return out;
   };
 
-  for ( const auto& vec: *recHits )
+  for (const auto& vec : *recHits)
     planeActivityMap[motherId(vec.detId())] += vec.size();
 
   // feed hits to the track producers
-  for ( const auto& vec : *recHits ) {
-    auto detId = motherId( vec.detId() );
-    if ( planeActivityMap[detId] > maxPlaneActiveChannels_ )
+  for (const auto& vec : *recHits) {
+    auto detId = motherId(vec.detId());
+    if (planeActivityMap[detId] > maxPlaneActiveChannels_)
       continue;
 
-    detId.setPlane( 0 );
-    for ( const auto& hit : vec ) {
-      if ( trk_algo_map_.find( detId ) == trk_algo_map_.end() )
+    detId.setPlane(0);
+    for (const auto& hit : vec) {
+      if (trk_algo_map_.find(detId) == trk_algo_map_.end())
         throw cms::Exception("TotemTimingLocalTrackFitter")
-          << "Invalid detId for rechit: arm=" << detId.arm() << ", rp=" << detId.rp();
-      trk_algo_map_.find( detId )->second.addHit( hit );
+            << "Invalid detId for rechit: arm=" << detId.arm() << ", rp=" << detId.rp();
+      trk_algo_map_.find(detId)->second.addHit(hit);
     }
   }
 
   // retrieves tracks for all hit sets
-  for ( auto& trk_algo_entry : trk_algo_map_ )
-    trk_algo_entry.second.produceTracks( pOut->operator[]( trk_algo_entry.first ) );
+  for (auto& trk_algo_entry : trk_algo_map_)
+    trk_algo_entry.second.produceTracks(pOut->operator[](trk_algo_entry.first));
 
-  iEvent.put( std::move( pOut ) );
+  iEvent.put(std::move(pOut));
 
   // remove all hits from the track producers to prepare for the next event
-  for ( auto& trk_algo_entry : trk_algo_map_ )
+  for (auto& trk_algo_entry : trk_algo_map_)
     trk_algo_entry.second.clear();
 }
 
-void
-TotemTimingLocalTrackFitter::fillDescriptions( edm::ConfigurationDescriptions& descr )
-{
+void TotemTimingLocalTrackFitter::fillDescriptions(edm::ConfigurationDescriptions& descr) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>( "recHitsTag", edm::InputTag( "totemTimingRecHits" ) )
-    ->setComment( "input rechits collection to retrieve" );
-  desc.add<int>( "maxPlaneActiveChannels", 2 )
-    ->setComment( "threshold for discriminating noisy planes" );
+  desc.add<edm::InputTag>("recHitsTag", edm::InputTag("totemTimingRecHits"))
+      ->setComment("input rechits collection to retrieve");
+  desc.add<int>("maxPlaneActiveChannels", 2)->setComment("threshold for discriminating noisy planes");
 
   edm::ParameterSetDescription trackingAlgoParams;
-  trackingAlgoParams.add<double>( "threshold", 1.5 )
-    ->setComment( "minimal number of rechits to be observed before launching the track recognition algorithm" );
-  trackingAlgoParams.add<double>( "thresholdFromMaximum", 0.5 )
-    ->setComment( "threshold relative to hit profile function local maximum for determining the width of the track" );
-  trackingAlgoParams.add<double>( "resolution", 0.01 /* mm */ )
-    ->setComment( "spatial resolution on the horizontal coordinate (in mm)" );
-  trackingAlgoParams.add<double>( "sigma", 0. )
-    ->setComment( "pixel efficiency function parameter determining the smoothness of the step" );
-  trackingAlgoParams.add<double>( "tolerance", 0.1 /* mm */)
-    ->setComment( "tolerance used for checking if the track contains certain hit" );
+  trackingAlgoParams.add<double>("threshold", 1.5)
+      ->setComment("minimal number of rechits to be observed before launching the track recognition algorithm");
+  trackingAlgoParams.add<double>("thresholdFromMaximum", 0.5)
+      ->setComment("threshold relative to hit profile function local maximum for determining the width of the track");
+  trackingAlgoParams.add<double>("resolution", 0.01 /* mm */)
+      ->setComment("spatial resolution on the horizontal coordinate (in mm)");
+  trackingAlgoParams.add<double>("sigma", 0.)
+      ->setComment("pixel efficiency function parameter determining the smoothness of the step");
+  trackingAlgoParams.add<double>("tolerance", 0.1 /* mm */)
+      ->setComment("tolerance used for checking if the track contains certain hit");
 
-  trackingAlgoParams.add<std::string>( "pixelEfficiencyFunction", "(x>[0]-0.5*[1]-0.05)*(x<[0]+0.5*[1]-0.05)+0*[2]" )
-    ->setComment( "efficiency function for single pixel\n"
-                  "can be defined as:\n"
-                  " * Precise: (TMath::Erf((x-[0]+0.5*([1]-0.05))/([2]/4)+2)+1)*TMath::Erfc((x-[0]-0.5*([1]-0.05))/([2]/4)-2)/4\n"
-                  " * Fast: (x>[0]-0.5*([1]-0.05))*(x<[0]+0.5*([1]-0.05))+((x-[0]+0.5*([1]-0.05)+[2])/[2])*(x>[0]-0.5*([1]-0.05)-[2])*(x<[0]-0.5*([1]-0.05))+(2-(x-[0]-0.5*([1]-0.05)+[2])/[2])*(x>[0]+0.5*([1]-0.05))*(x<[0]+0.5*([1]-0.05)+[2])\n"
-                  " * Legacy: (1/(1+exp(-(x-[0]+0.5*([1]-0.05))/[2])))*(1/(1+exp((x-[0]-0.5*([1]-0.05))/[2])))\n"
-                  " * Default (sigma ignored): (x>[0]-0.5*[1]-0.05)*(x<[0]+0.5*[1]-0.05)+0*[2]\n"
-                  "with:\n"
-                  "  [0]: centre of pad\n"
-                  "  [1]: width of pad\n"
-                  "  [2]: sigma: distance between efficiency ~100 -> 0 outside width" );
+  trackingAlgoParams.add<std::string>("pixelEfficiencyFunction", "(x>[0]-0.5*[1]-0.05)*(x<[0]+0.5*[1]-0.05)+0*[2]")
+      ->setComment(
+          "efficiency function for single pixel\n"
+          "can be defined as:\n"
+          " * Precise: "
+          "(TMath::Erf((x-[0]+0.5*([1]-0.05))/([2]/4)+2)+1)*TMath::Erfc((x-[0]-0.5*([1]-0.05))/([2]/4)-2)/4\n"
+          " * Fast: "
+          "(x>[0]-0.5*([1]-0.05))*(x<[0]+0.5*([1]-0.05))+((x-[0]+0.5*([1]-0.05)+[2])/"
+          "[2])*(x>[0]-0.5*([1]-0.05)-[2])*(x<[0]-0.5*([1]-0.05))+(2-(x-[0]-0.5*([1]-0.05)+[2])/"
+          "[2])*(x>[0]+0.5*([1]-0.05))*(x<[0]+0.5*([1]-0.05)+[2])\n"
+          " * Legacy: (1/(1+exp(-(x-[0]+0.5*([1]-0.05))/[2])))*(1/(1+exp((x-[0]-0.5*([1]-0.05))/[2])))\n"
+          " * Default (sigma ignored): (x>[0]-0.5*[1]-0.05)*(x<[0]+0.5*[1]-0.05)+0*[2]\n"
+          "with:\n"
+          "  [0]: centre of pad\n"
+          "  [1]: width of pad\n"
+          "  [2]: sigma: distance between efficiency ~100 -> 0 outside width");
 
-  trackingAlgoParams.add<double>( "yPosition", 0.0 )
-    ->setComment( "vertical offset of the outcoming track centre" );
-  trackingAlgoParams.add<double>( "yWidth", 0.0 )
-    ->setComment( "vertical track width" );
-  desc.add<edm::ParameterSetDescription>( "trackingAlgorithmParams", trackingAlgoParams )
-      ->setComment( "list of parameters associated to the track recognition algorithm" );
+  trackingAlgoParams.add<double>("yPosition", 0.0)->setComment("vertical offset of the outcoming track centre");
+  trackingAlgoParams.add<double>("yWidth", 0.0)->setComment("vertical track width");
+  desc.add<edm::ParameterSetDescription>("trackingAlgorithmParams", trackingAlgoParams)
+      ->setComment("list of parameters associated to the track recognition algorithm");
 
-  descr.add( "totemTimingLocalTracks", desc );
+  descr.add("totemTimingLocalTracks", desc);
 }
 
-DEFINE_FWK_MODULE( TotemTimingLocalTrackFitter );
-
+DEFINE_FWK_MODULE(TotemTimingLocalTrackFitter);

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondRecHitProducerAlgorithm.cc
@@ -11,83 +11,81 @@
 
 //----------------------------------------------------------------------------------------------------
 
-CTPPSDiamondRecHitProducerAlgorithm::CTPPSDiamondRecHitProducerAlgorithm( const edm::ParameterSet& iConfig ) :
-  ts_to_ns_( iConfig.getParameter<double>( "timeSliceNs" ) )
-{}
+CTPPSDiamondRecHitProducerAlgorithm::CTPPSDiamondRecHitProducerAlgorithm(const edm::ParameterSet& iConfig)
+    : ts_to_ns_(iConfig.getParameter<double>("timeSliceNs")) {}
 
-void
-CTPPSDiamondRecHitProducerAlgorithm::setCalibration( const PPSTimingCalibration& calib )
-{
+void CTPPSDiamondRecHitProducerAlgorithm::setCalibration(const PPSTimingCalibration& calib) {
   calib_ = calib;
-  calib_fct_.reset( new reco::FormulaEvaluator( calib_.formula() ) );
+  calib_fct_.reset(new reco::FormulaEvaluator(calib_.formula()));
 }
 
-void
-CTPPSDiamondRecHitProducerAlgorithm::build( const CTPPSGeometry& geom,
-                                            const edm::DetSetVector<CTPPSDiamondDigi>& input,
-                                            edm::DetSetVector<CTPPSDiamondRecHit>& output )
-{
-  for ( const auto& vec : input ) {
-    const CTPPSDiamondDetId detid( vec.detId() );
+void CTPPSDiamondRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
+                                                const edm::DetSetVector<CTPPSDiamondDigi>& input,
+                                                edm::DetSetVector<CTPPSDiamondRecHit>& output) {
+  for (const auto& vec : input) {
+    const CTPPSDiamondDetId detid(vec.detId());
 
-    if ( detid.channel() > MAX_CHANNEL ) // VFAT-like information, to be ignored
+    if (detid.channel() > MAX_CHANNEL)  // VFAT-like information, to be ignored
       continue;
 
     // retrieve the geometry element associated to this DetID
-    const DetGeomDesc* det = geom.getSensor( detid );
+    const DetGeomDesc* det = geom.getSensor(detid);
 
-    const float x_pos = det->translation().x(),
-                y_pos = det->translation().y();
+    const float x_pos = det->translation().x(), y_pos = det->translation().y();
     float z_pos = 0.;
-    z_pos = det->parentZPosition(); // retrieve the plane position;
+    z_pos = det->parentZPosition();  // retrieve the plane position;
 
-    const float x_width = 2.0 * det->params().at( 0 ), // parameters stand for half the size
-                y_width = 2.0 * det->params().at( 1 ),
-                z_width = 2.0 * det->params().at( 2 );
+    const float x_width = 2.0 * det->params().at(0),  // parameters stand for half the size
+        y_width = 2.0 * det->params().at(1), z_width = 2.0 * det->params().at(2);
 
     // retrieve the timing calibration part for this channel
     const int sector = detid.arm(), station = detid.station(), plane = detid.plane(), channel = detid.channel();
-    const auto& ch_params = calib_.parameters( sector, station, plane, channel );
+    const auto& ch_params = calib_.parameters(sector, station, plane, channel);
     // offset + time precision set to 0 if not found
-    const double ch_t_offset = calib_.timeOffset( sector, station, plane, channel );
-    const double ch_t_precis = calib_.timePrecision( sector, station, plane, channel );
+    const double ch_t_offset = calib_.timeOffset(sector, station, plane, channel);
+    const double ch_t_precis = calib_.timePrecision(sector, station, plane, channel);
 
-    edm::DetSet<CTPPSDiamondRecHit>& rec_hits = output.find_or_insert( detid );
+    edm::DetSet<CTPPSDiamondRecHit>& rec_hits = output.find_or_insert(detid);
 
-    for ( const auto& digi : vec ) {
+    for (const auto& digi : vec) {
       const int t_lead = digi.getLeadingEdge(), t_trail = digi.getTrailingEdge();
       // skip invalid digis
-      if ( t_lead == 0 && t_trail == 0 )
+      if (t_lead == 0 && t_trail == 0)
         continue;
 
       double tot = -1., ch_t_twc = 0.;
-      if ( t_lead != 0 && t_trail != 0 ) {
-        tot = ( t_trail-t_lead )*ts_to_ns_; // in ns
-        if ( calib_fct_ ) {
+      if (t_lead != 0 && t_trail != 0) {
+        tot = (t_trail - t_lead) * ts_to_ns_;  // in ns
+        if (calib_fct_) {
           // compute the time-walk correction
-          ch_t_twc = calib_fct_->evaluate( std::vector<double>{ tot }, ch_params );
-          if ( edm::isNotFinite( ch_t_twc ) )
+          ch_t_twc = calib_fct_->evaluate(std::vector<double>{tot}, ch_params);
+          if (edm::isNotFinite(ch_t_twc))
             ch_t_twc = 0.;
         }
       }
 
-      const int time_slice = ( t_lead != 0 )
-        ? ( t_lead-ch_t_offset/ts_to_ns_ ) / 1024
-        : CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING;
+      const int time_slice =
+          (t_lead != 0) ? (t_lead - ch_t_offset / ts_to_ns_) / 1024 : CTPPSDiamondRecHit::TIMESLICE_WITHOUT_LEADING;
 
       // calibrated time of arrival
-      const double t0 = ( t_lead % 1024 )*ts_to_ns_-ch_t_twc;
+      const double t0 = (t_lead % 1024) * ts_to_ns_ - ch_t_twc;
 
       rec_hits.emplace_back(
-        // spatial information
-        x_pos, x_width, y_pos, y_width, z_pos, z_width,
-        // timing information
-        t0, tot, ch_t_precis, time_slice,
-        // readout information
-        digi.getHPTDCErrorFlags(),
-        digi.getMultipleHit()
-      );
+          // spatial information
+          x_pos,
+          x_width,
+          y_pos,
+          y_width,
+          z_pos,
+          z_width,
+          // timing information
+          t0,
+          tot,
+          ch_t_precis,
+          time_slice,
+          // readout information
+          digi.getHPTDCErrorFlags(),
+          digi.getMultipleHit());
     }
   }
 }
-

--- a/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
+++ b/RecoCTPPS/TotemRPLocal/src/CTPPSDiamondTrackRecognition.cc
@@ -12,91 +12,83 @@
 
 //----------------------------------------------------------------------------------------------------
 
-CTPPSDiamondTrackRecognition::CTPPSDiamondTrackRecognition( const edm::ParameterSet& iConfig ) :
-  CTPPSTimingTrackRecognition<CTPPSDiamondLocalTrack, CTPPSDiamondRecHit>( iConfig ),
-  excludeSingleEdgeHits_( iConfig.getParameter<bool>( "excludeSingleEdgeHits" ) )
-{}
+CTPPSDiamondTrackRecognition::CTPPSDiamondTrackRecognition(const edm::ParameterSet& iConfig)
+    : CTPPSTimingTrackRecognition<CTPPSDiamondLocalTrack, CTPPSDiamondRecHit>(iConfig),
+      excludeSingleEdgeHits_(iConfig.getParameter<bool>("excludeSingleEdgeHits")) {}
 
 //----------------------------------------------------------------------------------------------------
 
-void
-CTPPSDiamondTrackRecognition::clear()
-{
+void CTPPSDiamondTrackRecognition::clear() {
   CTPPSTimingTrackRecognition<CTPPSDiamondLocalTrack, CTPPSDiamondRecHit>::clear();
   mhMap_.clear();
 }
 
 //----------------------------------------------------------------------------------------------------
 
-void
-CTPPSDiamondTrackRecognition::addHit( const CTPPSDiamondRecHit& recHit )
-{
-  if ( excludeSingleEdgeHits_ && recHit.getToT() <= 0. )
+void CTPPSDiamondTrackRecognition::addHit(const CTPPSDiamondRecHit& recHit) {
+  if (excludeSingleEdgeHits_ && recHit.getToT() <= 0.)
     return;
   // store hit parameters
-  hitVectorMap_[recHit.getOOTIndex()].emplace_back( recHit );
+  hitVectorMap_[recHit.getOOTIndex()].emplace_back(recHit);
 }
 
 //----------------------------------------------------------------------------------------------------
 
-int
-CTPPSDiamondTrackRecognition::produceTracks( edm::DetSet<CTPPSDiamondLocalTrack>& tracks )
-{
+int CTPPSDiamondTrackRecognition::produceTracks(edm::DetSet<CTPPSDiamondLocalTrack>& tracks) {
   int numberOfTracks = 0;
   DimensionParameters param;
 
-  auto getX = []( const CTPPSDiamondRecHit& hit ){ return hit.getX(); };
-  auto getXWidth = []( const CTPPSDiamondRecHit& hit ){ return hit.getXWidth(); };
-  auto setX = []( CTPPSDiamondLocalTrack& track, float x ){ track.setPosition( math::XYZPoint( x, 0., 0. ) ); };
-  auto setXSigma = []( CTPPSDiamondLocalTrack& track, float sigma ){ track.setPositionSigma( math::XYZPoint( sigma, 0., 0. ) ); };
+  auto getX = [](const CTPPSDiamondRecHit& hit) { return hit.getX(); };
+  auto getXWidth = [](const CTPPSDiamondRecHit& hit) { return hit.getXWidth(); };
+  auto setX = [](CTPPSDiamondLocalTrack& track, float x) { track.setPosition(math::XYZPoint(x, 0., 0.)); };
+  auto setXSigma = [](CTPPSDiamondLocalTrack& track, float sigma) {
+    track.setPositionSigma(math::XYZPoint(sigma, 0., 0.));
+  };
 
-  for ( const auto& hitBatch: hitVectorMap_ ) {
+  for (const auto& hitBatch : hitVectorMap_) {
     // separate the tracking for each bunch crossing
     const auto& oot = hitBatch.first;
     const auto& hits = hitBatch.second;
 
-    auto hitRange = getHitSpatialRange( hits );
+    auto hitRange = getHitSpatialRange(hits);
 
     TrackVector xPartTracks;
 
     // produce tracks in x dimension
     param.rangeBegin = hitRange.xBegin;
     param.rangeEnd = hitRange.xEnd;
-    producePartialTracks( hits, param, getX, getXWidth, setX, setXSigma, xPartTracks );
+    producePartialTracks(hits, param, getX, getXWidth, setX, setXSigma, xPartTracks);
 
-    if ( xPartTracks.empty() )
+    if (xPartTracks.empty())
       continue;
 
-    const float yRangeCenter = 0.5f*( hitRange.yBegin + hitRange.yEnd );
-    const float zRangeCenter = 0.5f*( hitRange.zBegin + hitRange.zEnd );
-    const float ySigma = 0.5f*( hitRange.yEnd - hitRange.yBegin );
-    const float zSigma = 0.5f*( hitRange.zEnd - hitRange.zBegin );
+    const float yRangeCenter = 0.5f * (hitRange.yBegin + hitRange.yEnd);
+    const float zRangeCenter = 0.5f * (hitRange.zBegin + hitRange.zEnd);
+    const float ySigma = 0.5f * (hitRange.yEnd - hitRange.yBegin);
+    const float zSigma = 0.5f * (hitRange.zEnd - hitRange.zBegin);
 
-    for ( const auto& xTrack: xPartTracks ) {
-      math::XYZPoint position( xTrack.getX0(), yRangeCenter, zRangeCenter );
-      math::XYZPoint positionSigma( xTrack.getX0Sigma(), ySigma, zSigma );
+    for (const auto& xTrack : xPartTracks) {
+      math::XYZPoint position(xTrack.getX0(), yRangeCenter, zRangeCenter);
+      math::XYZPoint positionSigma(xTrack.getX0Sigma(), ySigma, zSigma);
 
-      const int multipleHits = ( mhMap_.find(oot) != mhMap_.end() )
-        ? mhMap_[oot]
-        : 0;
-      CTPPSDiamondLocalTrack newTrack( position, positionSigma, 0.f, 0.f, oot, multipleHits );
+      const int multipleHits = (mhMap_.find(oot) != mhMap_.end()) ? mhMap_[oot] : 0;
+      CTPPSDiamondLocalTrack newTrack(position, positionSigma, 0.f, 0.f, oot, multipleHits);
 
       // find contributing hits
       HitVector componentHits;
-      for ( const auto& hit : hits )
-        if ( newTrack.containsHit( hit, tolerance_ ) && ( !excludeSingleEdgeHits_ || hit.getToT() > 0. ) )
-          componentHits.emplace_back( hit );
+      for (const auto& hit : hits)
+        if (newTrack.containsHit(hit, tolerance_) && (!excludeSingleEdgeHits_ || hit.getToT() > 0.))
+          componentHits.emplace_back(hit);
       // compute timing information
       float mean_time = 0.f, time_sigma = 0.f;
-      bool valid_hits = timeEval( componentHits, mean_time, time_sigma );
-      newTrack.setValid( valid_hits );
-      newTrack.setT( mean_time );
-      newTrack.setTSigma( time_sigma );
+      bool valid_hits = timeEval(componentHits, mean_time, time_sigma);
+      newTrack.setValid(valid_hits);
+      newTrack.setT(mean_time);
+      newTrack.setTSigma(time_sigma);
 
-      tracks.push_back( newTrack );
+      tracks.push_back(newTrack);
     }
   }
 
   return numberOfTracks;
 }
-

--- a/RecoCTPPS/TotemRPLocal/src/FastLineRecognition.cc
+++ b/RecoCTPPS/TotemRPLocal/src/FastLineRecognition.cc
@@ -24,23 +24,21 @@ using namespace edm;
 
 //----------------------------------------------------------------------------------------------------
 
-const double FastLineRecognition::sigma0 = 66E-3/sqrt(12.);
+const double FastLineRecognition::sigma0 = 66E-3 / sqrt(12.);
 
 //----------------------------------------------------------------------------------------------------
 
-void FastLineRecognition::Cluster::add(const Point *p1, const Point *p2, double a, double b, double w)
-{
+void FastLineRecognition::Cluster::add(const Point *p1, const Point *p2, double a, double b, double w) {
   // which points to be added to contents?
   bool add1 = true, add2 = true;
-  for (vector<const Point *>::const_iterator it = contents.begin(); it != contents.end() && (add1 || add2); ++it)
-  {
+  for (vector<const Point *>::const_iterator it = contents.begin(); it != contents.end() && (add1 || add2); ++it) {
     if ((*it)->hit == p1->hit)
       add1 = false;
 
     if ((*it)->hit == p2->hit)
       add2 = false;
   }
-  
+
   // add the points
   if (add1)
     contents.push_back(p1);
@@ -48,8 +46,8 @@ void FastLineRecognition::Cluster::add(const Point *p1, const Point *p2, double 
     contents.push_back(p2);
 
   // update sums
-  Saw += a*w;
-  Sbw += b*w;
+  Saw += a * w;
+  Sbw += b * w;
   Sw += w;
   S1 += 1.;
 }
@@ -57,21 +55,16 @@ void FastLineRecognition::Cluster::add(const Point *p1, const Point *p2, double 
 //----------------------------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------------------------
 
-FastLineRecognition::FastLineRecognition(double cw_a, double cw_b) :
-  chw_a(cw_a/2.), chw_b(cw_b/2.), geometry(nullptr)
-{
-}
+FastLineRecognition::FastLineRecognition(double cw_a, double cw_b)
+    : chw_a(cw_a / 2.), chw_b(cw_b / 2.), geometry(nullptr) {}
 
 //----------------------------------------------------------------------------------------------------
 
-FastLineRecognition::~FastLineRecognition()
-{
-}
+FastLineRecognition::~FastLineRecognition() {}
 
 //----------------------------------------------------------------------------------------------------
 
-FastLineRecognition::GeomData FastLineRecognition::getGeomData(unsigned int id)
-{
+FastLineRecognition::GeomData FastLineRecognition::getGeomData(unsigned int id) {
   // result already buffered?
   map<unsigned int, GeomData>::iterator it = geometryMap.find(id);
   if (it != geometryMap.end())
@@ -82,7 +75,7 @@ FastLineRecognition::GeomData FastLineRecognition::getGeomData(unsigned int id)
   DetGeomDesc::Translation c = geometry->getSensor(TotemRPDetId(id))->translation();
   GeomData gd;
   gd.z = c.z();
-  gd.s = d.x()*c.x() + d.y()*c.y();
+  gd.s = d.x() * c.x() + d.y() * c.y();
 
   geometryMap[id] = gd;
 
@@ -91,24 +84,23 @@ FastLineRecognition::GeomData FastLineRecognition::getGeomData(unsigned int id)
 
 //----------------------------------------------------------------------------------------------------
 
-void FastLineRecognition::getPatterns(const DetSetVector<TotemRPRecHit> &input, double z0,
-  double threshold, DetSet<TotemRPUVPattern> &patterns)
-{
+void FastLineRecognition::getPatterns(const DetSetVector<TotemRPRecHit> &input,
+                                      double z0,
+                                      double threshold,
+                                      DetSet<TotemRPUVPattern> &patterns) {
   // build collection of points in the global coordinate system
   std::vector<Point> points;
-  for (auto &ds : input)
-  {
+  for (auto &ds : input) {
     unsigned int detId = ds.detId();
 
-    for (auto &h : ds)
-    {
+    for (auto &h : ds) {
       const TotemRPRecHit *hit = &h;
       const GeomData &gd = getGeomData(detId);
-  
+
       double p = hit->getPosition() + gd.s;
       double z = gd.z - z0;
       double w = sigma0 / hit->getSigma();
-  
+
       points.push_back(Point(detId, hit, p, z, w));
     }
   }
@@ -122,20 +114,18 @@ void FastLineRecognition::getPatterns(const DetSetVector<TotemRPRecHit> &input, 
   patterns.clear();
 
   Cluster c;
-  while (getOneLine(points, threshold, c))
-  {
+  while (getOneLine(points, threshold, c)) {
     // convert cluster to pattern and save it
     TotemRPUVPattern pattern;
-    pattern.setA(c.Saw/c.Sw);
-    pattern.setB(c.Sbw/c.Sw);
+    pattern.setA(c.Saw / c.Sw);
+    pattern.setB(c.Sbw / c.Sw);
     pattern.setW(c.weight);
 
 #if CTPPS_DEBUG > 0
     printf("\tpoints of the selected cluster: %lu\n", c.contents.size());
 #endif
 
-    for (auto &pit : c.contents)
-    { 
+    for (auto &pit : c.contents) {
 #if CTPPS_DEBUG > 0
       printf("\t\t%.1f\n", pit->z);
 #endif
@@ -153,13 +143,10 @@ void FastLineRecognition::getPatterns(const DetSetVector<TotemRPRecHit> &input, 
 #endif
 
     // remove points belonging to the recognized line
-    for (vector<const Point *>::iterator hit = c.contents.begin(); hit != c.contents.end(); ++hit)
-    {
-      for (vector<Point>::iterator dit = points.begin(); dit != points.end(); ++dit)
-      {
+    for (vector<const Point *>::iterator hit = c.contents.begin(); hit != c.contents.end(); ++hit) {
+      for (vector<Point>::iterator dit = points.begin(); dit != points.end(); ++dit) {
         //printf("\t\t1: %.2f, %p vs. 2: %.2f, %p\n", (*hit)->z, (*hit)->hit, dit->z, dit->hit);
-        if ((*hit)->hit == dit->hit)
-        {
+        if ((*hit)->hit == dit->hit) {
           dit->usable = false;
           //points.erase(dit);
           break;
@@ -185,25 +172,23 @@ void FastLineRecognition::getPatterns(const DetSetVector<TotemRPRecHit> &input, 
 //----------------------------------------------------------------------------------------------------
 
 bool FastLineRecognition::getOneLine(const vector<FastLineRecognition::Point> &points,
-  double threshold, FastLineRecognition::Cluster &result)
-{
+                                     double threshold,
+                                     FastLineRecognition::Cluster &result) {
 #if CTPPS_DEBUG > 0
   printf("\tFastLineRecognition::getOneLine\n");
 #endif
 
   if (points.size() < 2)
-        return false;
-  
+    return false;
+
   vector<Cluster> clusters;
 
   // go through all the combinations of measured points
-  for (vector<Point>::const_iterator it1 = points.begin(); it1 != points.end(); ++it1)
-  {
+  for (vector<Point>::const_iterator it1 = points.begin(); it1 != points.end(); ++it1) {
     if (!it1->usable)
       continue;
 
-    for (vector<Point>::const_iterator it2 = it1; it2 != points.end(); ++it2)
-    {
+    for (vector<Point>::const_iterator it2 = it1; it2 != points.end(); ++it2) {
       if (!it2->usable)
         continue;
 
@@ -215,7 +200,7 @@ bool FastLineRecognition::getOneLine(const vector<FastLineRecognition::Point> &p
 
       const double &p1 = it1->h;
       const double &p2 = it2->h;
-      
+
       const double &w1 = it1->w;
       const double &w2 = it2->w;
 
@@ -225,28 +210,38 @@ bool FastLineRecognition::getOneLine(const vector<FastLineRecognition::Point> &p
       double w = w1 + w2;
 
 #if CTPPS_DEBUG > 0
-      printf("\t\t\tz: 1=%+5.1f, 2=%+5.1f | U/V: 1=%+6.3f, 2=%+6.3f | a=%+6.3f rad, b=%+6.3f mm, w=%.1f\n", z1, z2, p1, p2, a, b, w);
+      printf("\t\t\tz: 1=%+5.1f, 2=%+5.1f | U/V: 1=%+6.3f, 2=%+6.3f | a=%+6.3f rad, b=%+6.3f mm, w=%.1f\n",
+             z1,
+             z2,
+             p1,
+             p2,
+             a,
+             b,
+             w);
 #endif
 
       // add it to the appropriate cluster
       bool newCluster = true;
-      for (unsigned int k = 0; k < clusters.size(); k++)
-      {
+      for (unsigned int k = 0; k < clusters.size(); k++) {
         Cluster &c = clusters[k];
         if (c.S1 < 1. || c.Sw <= 0.)
           continue;
 
 #if CTPPS_DEBUG > 0
         if (k < 10)
-          printf("\t\t\t\ttest cluster %u at a=%+6.3f, b=%+6.3f : %+6.3f, %+6.3f : %i, %i\n", k, c.Saw/c.Sw, c.Sbw/c.Sw, 
-            chw_a, chw_b,
-            (std::abs(a - c.Saw/c.Sw) < chw_a), (std::abs(b - c.Sbw/c.Sw) < chw_b));
+          printf("\t\t\t\ttest cluster %u at a=%+6.3f, b=%+6.3f : %+6.3f, %+6.3f : %i, %i\n",
+                 k,
+                 c.Saw / c.Sw,
+                 c.Sbw / c.Sw,
+                 chw_a,
+                 chw_b,
+                 (std::abs(a - c.Saw / c.Sw) < chw_a),
+                 (std::abs(b - c.Sbw / c.Sw) < chw_b));
 #endif
 
-        if ((std::abs(a - c.Saw/c.Sw) < chw_a) && (std::abs(b - c.Sbw/c.Sw) < chw_b))
-        {
+        if ((std::abs(a - c.Saw / c.Sw) < chw_a) && (std::abs(b - c.Sbw / c.Sw) < chw_b)) {
           newCluster = false;
-          clusters[k].add(& (*it1), & (*it2), a, b, w);
+          clusters[k].add(&(*it1), &(*it2), a, b, w);
 #if CTPPS_DEBUG > 0
           printf("\t\t\t\t--> cluster %u\n", k);
 #endif
@@ -255,13 +250,12 @@ bool FastLineRecognition::getOneLine(const vector<FastLineRecognition::Point> &p
       }
 
       // make new cluster
-      if (newCluster)
-      {
+      if (newCluster) {
 #if CTPPS_DEBUG > 0
         printf("\t\t\t\t--> new cluster %lu\n", clusters.size());
 #endif
         clusters.push_back(Cluster());
-        clusters.back().add(& (*it1), & (*it2), a, b, w);
+        clusters.back().add(&(*it1), &(*it2), a, b, w);
       }
     }
   }
@@ -273,15 +267,13 @@ bool FastLineRecognition::getOneLine(const vector<FastLineRecognition::Point> &p
   // find the cluster with highest weight
   unsigned int mk = 0;
   double mw = -1.;
-  for (unsigned int k = 0; k < clusters.size(); k++)
-  {
+  for (unsigned int k = 0; k < clusters.size(); k++) {
     double w = 0;
     for (vector<const Point *>::iterator it = clusters[k].contents.begin(); it != clusters[k].contents.end(); ++it)
       w += (*it)->w;
     clusters[k].weight = w;
 
-    if (w > mw)
-    {
+    if (w > mw) {
       mw = w;
       mk = k;
     }
@@ -292,12 +284,10 @@ bool FastLineRecognition::getOneLine(const vector<FastLineRecognition::Point> &p
 #endif
 
   // rerturn result
-  if (mw >= threshold)
-  {
+  if (mw >= threshold) {
     result = clusters[mk];
 
     return true;
   } else
     return false;
 }
-

--- a/RecoCTPPS/TotemRPLocal/src/TotemRPClusterProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemRPClusterProducerAlgorithm.cc
@@ -13,22 +13,19 @@
 
 //----------------------------------------------------------------------------------------------------
 
-TotemRPClusterProducerAlgorithm::TotemRPClusterProducerAlgorithm(const edm::ParameterSet &param)
- :param_(param)
-{
+TotemRPClusterProducerAlgorithm::TotemRPClusterProducerAlgorithm(const edm::ParameterSet &param) : param_(param) {
   verbosity_ = param_.getParameter<int>("verbosity");
 }
 
 //----------------------------------------------------------------------------------------------------
 
-TotemRPClusterProducerAlgorithm::~TotemRPClusterProducerAlgorithm()
-{
-}
+TotemRPClusterProducerAlgorithm::~TotemRPClusterProducerAlgorithm() {}
 
 //----------------------------------------------------------------------------------------------------
 
-int TotemRPClusterProducerAlgorithm::buildClusters(unsigned int detId, const std::vector<TotemRPDigi> &digi, std::vector<TotemRPCluster> &clusters)
-{
+int TotemRPClusterProducerAlgorithm::buildClusters(unsigned int detId,
+                                                   const std::vector<TotemRPDigi> &digi,
+                                                   std::vector<TotemRPCluster> &clusters) {
   clusters.clear();
 
   strip_digi_set_.clear();
@@ -36,39 +33,34 @@ int TotemRPClusterProducerAlgorithm::buildClusters(unsigned int detId, const std
 
   if (strip_digi_set_.empty())
     return 0;
-    
-  bool iter_beg=true;
-  int cluster_beg=-16;
+
+  bool iter_beg = true;
+  int cluster_beg = -16;
   int cluster_end;
-  int prev_strip=-16;
+  int prev_strip = -16;
   int cur_strip;
-  
-  for (TotemRPDigiSet::const_iterator i=strip_digi_set_.begin(); i!=strip_digi_set_.end(); ++i)
-  {
+
+  for (TotemRPDigiSet::const_iterator i = strip_digi_set_.begin(); i != strip_digi_set_.end(); ++i) {
     cur_strip = i->getStripNumber();
-    bool non_continuity = (cur_strip!=prev_strip+1);
-    
-    if (iter_beg)
-    {
-      cluster_beg=cur_strip;
-      iter_beg=false;
+    bool non_continuity = (cur_strip != prev_strip + 1);
+
+    if (iter_beg) {
+      cluster_beg = cur_strip;
+      iter_beg = false;
+    } else if (non_continuity) {
+      cluster_end = prev_strip;
+      clusters.push_back(TotemRPCluster((uint16_t)cluster_beg, (uint16_t)cluster_end));
+
+      cluster_beg = cur_strip;
     }
-    else if (non_continuity)
-    {
-      cluster_end=prev_strip;
-      clusters.push_back(TotemRPCluster((uint16_t)cluster_beg, (uint16_t) cluster_end));
-      
-      cluster_beg=cur_strip;
-    }
-    
-    prev_strip=cur_strip;
+
+    prev_strip = cur_strip;
   }
-  
-  if (!iter_beg)
-  {
-    cluster_end=prev_strip;
-    clusters.push_back(TotemRPCluster((uint16_t)cluster_beg, (uint16_t) cluster_end));
+
+  if (!iter_beg) {
+    cluster_end = prev_strip;
+    clusters.push_back(TotemRPCluster((uint16_t)cluster_beg, (uint16_t)cluster_end));
   }
-    
+
   return clusters.size();
 }

--- a/RecoCTPPS/TotemRPLocal/src/TotemRPLocalTrackFitterAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemRPLocalTrackFitterAlgorithm.cc
@@ -20,53 +20,45 @@ using namespace edm;
 
 //----------------------------------------------------------------------------------------------------
 
-TotemRPLocalTrackFitterAlgorithm::TotemRPLocalTrackFitterAlgorithm(const edm::ParameterSet &)
-{
-}
+TotemRPLocalTrackFitterAlgorithm::TotemRPLocalTrackFitterAlgorithm(const edm::ParameterSet &) {}
 
 //----------------------------------------------------------------------------------------------------
 
-
-void TotemRPLocalTrackFitterAlgorithm::reset()
-{
-  det_data_map_.clear();
-}
+void TotemRPLocalTrackFitterAlgorithm::reset() { det_data_map_.clear(); }
 
 //----------------------------------------------------------------------------------------------------
 
 TotemRPLocalTrackFitterAlgorithm::RPDetCoordinateAlgebraObjs
-TotemRPLocalTrackFitterAlgorithm::prepareReconstAlgebraData(unsigned int det_id, const CTPPSGeometry& tot_rp_geom)
-{
+TotemRPLocalTrackFitterAlgorithm::prepareReconstAlgebraData(unsigned int det_id, const CTPPSGeometry &tot_rp_geom) {
   RPDetCoordinateAlgebraObjs det_algebra_obj;
 
   det_algebra_obj.centre_of_det_global_position_ = convert3vector(tot_rp_geom.getSensorTranslation(det_id));
- 
+
   HepMC::ThreeVector rp_topology_stripaxis = rp_topology_.GetStripReadoutAxisDir();
   CLHEP::Hep3Vector rp_topology_stripaxis_clhep;
-  
+
   rp_topology_stripaxis_clhep.setX(rp_topology_stripaxis.x());
   rp_topology_stripaxis_clhep.setY(rp_topology_stripaxis.y());
   rp_topology_stripaxis_clhep.setZ(rp_topology_stripaxis.z());
- 
-  TVector3 rd_dir = convert3vector( tot_rp_geom.localToGlobalDirection(det_id, rp_topology_stripaxis_clhep ) );
-  
+
+  TVector3 rd_dir = convert3vector(tot_rp_geom.localToGlobalDirection(det_id, rp_topology_stripaxis_clhep));
+
   TVector2 v(rd_dir.X(), rd_dir.Y());
   det_algebra_obj.readout_direction_ = v.Unit();
   det_algebra_obj.rec_u_0_ = 0.0;
   det_algebra_obj.available_ = true;
-  det_algebra_obj.rec_u_0_ = - (det_algebra_obj.readout_direction_ * det_algebra_obj.centre_of_det_global_position_.XYvector());
-  
+  det_algebra_obj.rec_u_0_ =
+      -(det_algebra_obj.readout_direction_ * det_algebra_obj.centre_of_det_global_position_.XYvector());
+
   return det_algebra_obj;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-TotemRPLocalTrackFitterAlgorithm::RPDetCoordinateAlgebraObjs*
-TotemRPLocalTrackFitterAlgorithm::getDetAlgebraData(unsigned int det_id, const CTPPSGeometry& tot_rp_geom)
-{
+TotemRPLocalTrackFitterAlgorithm::RPDetCoordinateAlgebraObjs *TotemRPLocalTrackFitterAlgorithm::getDetAlgebraData(
+    unsigned int det_id, const CTPPSGeometry &tot_rp_geom) {
   auto it = det_data_map_.find(det_id);
-  if (it != det_data_map_.end())
-  {
+  if (it != det_data_map_.end()) {
     return &(it->second);
   } else {
     det_data_map_[det_id] = prepareReconstAlgebraData(det_id, tot_rp_geom);
@@ -76,54 +68,51 @@ TotemRPLocalTrackFitterAlgorithm::getDetAlgebraData(unsigned int det_id, const C
 
 //----------------------------------------------------------------------------------------------------
 
-bool TotemRPLocalTrackFitterAlgorithm::fitTrack(const edm::DetSetVector<TotemRPRecHit> &hits, double z_0,
-    const CTPPSGeometry &tot_geom, TotemRPLocalTrack &fitted_track)
-{
+bool TotemRPLocalTrackFitterAlgorithm::fitTrack(const edm::DetSetVector<TotemRPRecHit> &hits,
+                                                double z_0,
+                                                const CTPPSGeometry &tot_geom,
+                                                TotemRPLocalTrack &fitted_track) {
   fitted_track.setValid(false);
 
   // bind hits with their algebra objects
-  struct HitWithAlg
-  {
+  struct HitWithAlg {
     unsigned int detId;
     const TotemRPRecHit *hit;
     RPDetCoordinateAlgebraObjs *alg;
   };
-  
+
   vector<HitWithAlg> applicable_hits;
 
-  for (auto &ds : hits)
-  {
+  for (auto &ds : hits) {
     unsigned int detId = ds.detId();
 
-    for (auto &h : ds)
-    {
-      RPDetCoordinateAlgebraObjs * alg = getDetAlgebraData(detId, tot_geom);
+    for (auto &h : ds) {
+      RPDetCoordinateAlgebraObjs *alg = getDetAlgebraData(detId, tot_geom);
       if (alg->available_)
-        applicable_hits.push_back({ detId, &h, alg});
+        applicable_hits.push_back({detId, &h, alg});
     }
   }
-  
+
   if (applicable_hits.size() < 5)
     return false;
-  
+
   TMatrixD H(applicable_hits.size(), 4);
   TVectorD V(applicable_hits.size());
   TVectorD V_inv(applicable_hits.size());
   TVectorD U(applicable_hits.size());
-  
-  for(unsigned int i = 0;  i < applicable_hits.size(); ++i)
-  {
+
+  for (unsigned int i = 0; i < applicable_hits.size(); ++i) {
     RPDetCoordinateAlgebraObjs *alg_obj = applicable_hits[i].alg;
 
-    H(i,0) = alg_obj->readout_direction_.X();
-    H(i,1) = alg_obj->readout_direction_.Y();
-    double delta_z = alg_obj->centre_of_det_global_position_.Z()-z_0;
-    H(i,2) = alg_obj->readout_direction_.X()*delta_z;
-    H(i,3) = alg_obj->readout_direction_.Y()*delta_z;
+    H(i, 0) = alg_obj->readout_direction_.X();
+    H(i, 1) = alg_obj->readout_direction_.Y();
+    double delta_z = alg_obj->centre_of_det_global_position_.Z() - z_0;
+    H(i, 2) = alg_obj->readout_direction_.X() * delta_z;
+    H(i, 3) = alg_obj->readout_direction_.Y() * delta_z;
     double var = applicable_hits[i].hit->getSigma();
-    var*=var;
+    var *= var;
     V[i] = var;
-    V_inv[i] = 1.0/var;
+    V_inv[i] = 1.0 / var;
     U[i] = applicable_hits[i].hit->getPosition() - alg_obj->rec_u_0_;
   }
 
@@ -131,52 +120,48 @@ bool TotemRPLocalTrackFitterAlgorithm::fitTrack(const edm::DetSetVector<TotemRPR
   multiplyByDiagonalInPlace(H_T_V_inv, V_inv);
   TMatrixD V_a(H_T_V_inv);
   TMatrixD V_a_mult(V_a, TMatrixD::kMult, H);
-  try
-  {
+  try {
     V_a_mult.Invert();
-  }
-  catch (cms::Exception &e)
-  {
+  } catch (cms::Exception &e) {
     LogError("TotemRPLocalTrackFitterAlgorithm") << "Error in TotemRPLocalTrackFitterAlgorithm::fitTrack > "
-      << "Fit matrix is singular. Skipping.";
+                                                 << "Fit matrix is singular. Skipping.";
     return false;
   }
 
   TMatrixD u_to_a(V_a_mult, TMatrixD::kMult, H_T_V_inv);
   TVectorD a(U);
   a *= u_to_a;
-  
+
   fitted_track.setZ0(z_0);
   fitted_track.setParameterVector(a);
   fitted_track.setCovarianceMatrix(V_a_mult);
-  
+
   double Chi_2 = 0;
-  for(unsigned int i=0; i<applicable_hits.size(); ++i)
-  {
+  for (unsigned int i = 0; i < applicable_hits.size(); ++i) {
     RPDetCoordinateAlgebraObjs *alg_obj = applicable_hits[i].alg;
     TVector2 readout_dir = alg_obj->readout_direction_;
     double det_z = alg_obj->centre_of_det_global_position_.Z();
     double sigma_str = applicable_hits[i].hit->getSigma();
-    double sigma_str_2 = sigma_str*sigma_str;
+    double sigma_str_2 = sigma_str * sigma_str;
     TVector2 fited_det_xy_point = fitted_track.getTrackPoint(det_z);
     double U_readout = applicable_hits[i].hit->getPosition() - alg_obj->rec_u_0_;
-    double U_fited = (readout_dir*=fited_det_xy_point);
+    double U_fited = (readout_dir *= fited_det_xy_point);
     double residual = U_fited - U_readout;
-    TMatrixD V_T_Cov_X_Y(1,2);
-    V_T_Cov_X_Y(0,0) = readout_dir.X();
-    V_T_Cov_X_Y(0,1) = readout_dir.Y();
+    TMatrixD V_T_Cov_X_Y(1, 2);
+    V_T_Cov_X_Y(0, 0) = readout_dir.X();
+    V_T_Cov_X_Y(0, 1) = readout_dir.Y();
     TMatrixD V_T_Cov_X_Y_mult(V_T_Cov_X_Y, TMatrixD::kMult, fitted_track.trackPointInterpolationCovariance(det_z));
-    double fit_strip_var = V_T_Cov_X_Y_mult(0,0)*readout_dir.X() + V_T_Cov_X_Y_mult(0,1)*readout_dir.Y();
+    double fit_strip_var = V_T_Cov_X_Y_mult(0, 0) * readout_dir.X() + V_T_Cov_X_Y_mult(0, 1) * readout_dir.Y();
     double pull_normalization = sqrt(sigma_str_2 - fit_strip_var);
-    double pull = residual/pull_normalization;
-    
-    Chi_2 += residual*residual / sigma_str_2;
+    double pull = residual / pull_normalization;
 
-    TotemRPLocalTrack::FittedRecHit hit_point(*(applicable_hits[i].hit), TVector3(fited_det_xy_point.X(),
-      fited_det_xy_point.Y(), det_z), residual, pull);
+    Chi_2 += residual * residual / sigma_str_2;
+
+    TotemRPLocalTrack::FittedRecHit hit_point(
+        *(applicable_hits[i].hit), TVector3(fited_det_xy_point.X(), fited_det_xy_point.Y(), det_z), residual, pull);
     fitted_track.addHit(applicable_hits[i].detId, hit_point);
   }
-  
+
   fitted_track.setChiSquared(Chi_2);
   fitted_track.setValid(true);
   return true;
@@ -184,12 +169,9 @@ bool TotemRPLocalTrackFitterAlgorithm::fitTrack(const edm::DetSetVector<TotemRPR
 
 //----------------------------------------------------------------------------------------------------
 
-void TotemRPLocalTrackFitterAlgorithm::multiplyByDiagonalInPlace(TMatrixD &mt, const TVectorD &diag)
-{
-  for(int i=0; i<mt.GetNrows(); ++i)
-  {
-    for(int j=0; j<mt.GetNcols(); ++j)
-    {
+void TotemRPLocalTrackFitterAlgorithm::multiplyByDiagonalInPlace(TMatrixD &mt, const TVectorD &diag) {
+  for (int i = 0; i < mt.GetNrows(); ++i) {
+    for (int j = 0; j < mt.GetNcols(); ++j) {
       mt[i][j] *= diag[j];
     }
   }

--- a/RecoCTPPS/TotemRPLocal/src/TotemRPRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemRPRecHitProducerAlgorithm.cc
@@ -11,12 +11,11 @@
 
 //----------------------------------------------------------------------------------------------------
 
-void TotemRPRecHitProducerAlgorithm::buildRecoHits(const edm::DetSet<TotemRPCluster>& input, 
-    edm::DetSet<TotemRPRecHit>& output)
-{
-  for (edm::DetSet<TotemRPCluster>::const_iterator it = input.begin(); it!=input.end(); ++it)
-  {
+void TotemRPRecHitProducerAlgorithm::buildRecoHits(const edm::DetSet<TotemRPCluster>& input,
+                                                   edm::DetSet<TotemRPRecHit>& output) {
+  for (edm::DetSet<TotemRPCluster>::const_iterator it = input.begin(); it != input.end(); ++it) {
     constexpr double nominal_sigma = 0.0191;
-    output.push_back(TotemRPRecHit(rp_topology_.GetHitPositionInReadoutDirection(it->getCenterStripPosition()), nominal_sigma));
-  }  
+    output.push_back(
+        TotemRPRecHit(rp_topology_.GetHitPositionInReadoutDirection(it->getCenterStripPosition()), nominal_sigma));
+  }
 }

--- a/RecoCTPPS/TotemRPLocal/src/TotemTimingConversions.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemTimingConversions.cc
@@ -13,36 +13,30 @@
 
 //----------------------------------------------------------------------------------------------------
 
-TotemTimingConversions::TotemTimingConversions(bool mergeTimePeaks, const PPSTimingCalibration& calibration) :
-  calibration_(calibration), mergeTimePeaks_(mergeTimePeaks),
-  calibrationFunction_(calibration_.formula())
-{}
+TotemTimingConversions::TotemTimingConversions(bool mergeTimePeaks, const PPSTimingCalibration& calibration)
+    : calibration_(calibration), mergeTimePeaks_(mergeTimePeaks), calibrationFunction_(calibration_.formula()) {}
 
 //----------------------------------------------------------------------------------------------------
 
-float
-TotemTimingConversions::timeOfFirstSample(const TotemTimingDigi& digi) const
-{
+float TotemTimingConversions::timeOfFirstSample(const TotemTimingDigi& digi) const {
   unsigned int offsetOfSamples = digi.getEventInfo().getOffsetOfSamples();
   if (offsetOfSamples == 0)
-    offsetOfSamples = SAMPIC_DEFAULT_OFFSET; // FW 0 is not sending this, FW > 0 yes
+    offsetOfSamples = SAMPIC_DEFAULT_OFFSET;  // FW 0 is not sending this, FW > 0 yes
 
-  unsigned int timestamp = (digi.getCellInfo() <= SAMPIC_MAX_NUMBER_OF_SAMPLES/2)
-    ? digi.getTimestampA()
-    : digi.getTimestampB();
+  unsigned int timestamp =
+      (digi.getCellInfo() <= SAMPIC_MAX_NUMBER_OF_SAMPLES / 2) ? digi.getTimestampA() : digi.getTimestampB();
 
-  int cell0TimeClock = timestamp +
-    ((digi.getFPGATimestamp()-timestamp) & CELL0_MASK)
-    - digi.getEventInfo().getL1ATimestamp()
-    + digi.getEventInfo().getL1ALatency();
+  int cell0TimeClock = timestamp + ((digi.getFPGATimestamp() - timestamp) & CELL0_MASK) -
+                       digi.getEventInfo().getL1ATimestamp() + digi.getEventInfo().getL1ALatency();
 
   // time of first cell
   float cell0TimeInstant = SAMPIC_MAX_NUMBER_OF_SAMPLES * SAMPIC_SAMPLING_PERIOD_NS * cell0TimeClock;
 
   // time of triggered cell
-  float firstCellTimeInstant = (digi.getCellInfo() < offsetOfSamples)
-    ? cell0TimeInstant + digi.getCellInfo() * SAMPIC_SAMPLING_PERIOD_NS
-    : cell0TimeInstant - (SAMPIC_MAX_NUMBER_OF_SAMPLES - digi.getCellInfo())*SAMPIC_SAMPLING_PERIOD_NS;
+  float firstCellTimeInstant =
+      (digi.getCellInfo() < offsetOfSamples)
+          ? cell0TimeInstant + digi.getCellInfo() * SAMPIC_SAMPLING_PERIOD_NS
+          : cell0TimeInstant - (SAMPIC_MAX_NUMBER_OF_SAMPLES - digi.getCellInfo()) * SAMPIC_SAMPLING_PERIOD_NS;
 
   int db = digi.getHardwareBoardId();
   int sampic = digi.getHardwareSampicId();
@@ -61,21 +55,17 @@ TotemTimingConversions::timeOfFirstSample(const TotemTimingDigi& digi) const
 
 //----------------------------------------------------------------------------------------------------
 
-float
-TotemTimingConversions::triggerTime(const TotemTimingDigi& digi) const
-{
+float TotemTimingConversions::triggerTime(const TotemTimingDigi& digi) const {
   unsigned int offsetOfSamples = digi.getEventInfo().getOffsetOfSamples();
   if (offsetOfSamples == 0)
-    offsetOfSamples = 30; // FW 0 is not sending this, FW > 0 yes
+    offsetOfSamples = 30;  // FW 0 is not sending this, FW > 0 yes
 
   return timeOfFirstSample(digi) + (SAMPIC_MAX_NUMBER_OF_SAMPLES - offsetOfSamples) * SAMPIC_SAMPLING_PERIOD_NS;
 }
 
 //----------------------------------------------------------------------------------------------------
 
-float
-TotemTimingConversions::timePrecision(const TotemTimingDigi& digi) const
-{
+float TotemTimingConversions::timePrecision(const TotemTimingDigi& digi) const {
   int db = digi.getHardwareBoardId();
   int sampic = digi.getHardwareSampicId();
   int channel = digi.getHardwareChannelId();
@@ -84,9 +74,7 @@ TotemTimingConversions::timePrecision(const TotemTimingDigi& digi) const
 
 //----------------------------------------------------------------------------------------------------
 
-std::vector<float>
-TotemTimingConversions::timeSamples(const TotemTimingDigi& digi) const
-{
+std::vector<float> TotemTimingConversions::timeSamples(const TotemTimingDigi& digi) const {
   std::vector<float> time(digi.getNumberOfSamples());
   for (unsigned int i = 0; i < time.size(); ++i)
     time.at(i) = timeOfFirstSample(digi) + i * SAMPIC_SAMPLING_PERIOD_NS;
@@ -96,9 +84,7 @@ TotemTimingConversions::timeSamples(const TotemTimingDigi& digi) const
 //----------------------------------------------------------------------------------------------------
 // NOTE: If no proper file is specified, calibration is not applied
 
-std::vector<float>
-TotemTimingConversions::voltSamples(const TotemTimingDigi& digi) const
-{
+std::vector<float> TotemTimingConversions::voltSamples(const TotemTimingDigi& digi) const {
   std::vector<float> data;
   if (calibrationFunction_.numberOfVariables() != 1)
     for (const auto& sample : digi.getSamples())
@@ -114,11 +100,10 @@ TotemTimingConversions::voltSamples(const TotemTimingDigi& digi) const
       auto parameters = calibration_.parameters(db, sampic, channel, sample_cell);
       if (parameters.empty() || parameters.size() != calibrationFunction_.numberOfParameters())
         throw cms::Exception("TotemTimingConversions:voltSamples")
-          << "Invalid calibrations retrieved for Sampic digi"
-          << " (" << db << ", " << sampic << ", " << channel << ", " << sample_cell << ")!";
+            << "Invalid calibrations retrieved for Sampic digi"
+            << " (" << db << ", " << sampic << ", " << channel << ", " << sample_cell << ")!";
       data.emplace_back(calibrationFunction_.evaluate(std::vector<double>{(double)sample}, parameters));
     }
   }
   return data;
 }
-

--- a/RecoCTPPS/TotemRPLocal/src/TotemTimingRecHitProducerAlgorithm.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemTimingRecHitProducerAlgorithm.cc
@@ -15,31 +15,26 @@
 
 //----------------------------------------------------------------------------------------------------
 
-TotemTimingRecHitProducerAlgorithm::TotemTimingRecHitProducerAlgorithm(const edm::ParameterSet& iConfig) :
-  mergeTimePeaks_  (iConfig.getParameter<bool>  ("mergeTimePeaks")),
-  baselinePoints_  (iConfig.getParameter<int>   ("baselinePoints")),
-  saturationLimit_ (iConfig.getParameter<double>("saturationLimit")),
-  cfdFraction_     (iConfig.getParameter<double>("cfdFraction")),
-  smoothingPoints_ (iConfig.getParameter<int>   ("smoothingPoints")),
-  lowPassFrequency_(iConfig.getParameter<double>("lowPassFrequency")),
-  hysteresis_      (iConfig.getParameter<double>("hysteresis"))
-{}
+TotemTimingRecHitProducerAlgorithm::TotemTimingRecHitProducerAlgorithm(const edm::ParameterSet& iConfig)
+    : mergeTimePeaks_(iConfig.getParameter<bool>("mergeTimePeaks")),
+      baselinePoints_(iConfig.getParameter<int>("baselinePoints")),
+      saturationLimit_(iConfig.getParameter<double>("saturationLimit")),
+      cfdFraction_(iConfig.getParameter<double>("cfdFraction")),
+      smoothingPoints_(iConfig.getParameter<int>("smoothingPoints")),
+      lowPassFrequency_(iConfig.getParameter<double>("lowPassFrequency")),
+      hysteresis_(iConfig.getParameter<double>("hysteresis")) {}
 
 //----------------------------------------------------------------------------------------------------
 
-void
-TotemTimingRecHitProducerAlgorithm::setCalibration(const PPSTimingCalibration& calib)
-{
+void TotemTimingRecHitProducerAlgorithm::setCalibration(const PPSTimingCalibration& calib) {
   sampicConversions_.reset(new TotemTimingConversions(mergeTimePeaks_, calib));
 }
 
 //----------------------------------------------------------------------------------------------------
 
-void
-TotemTimingRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
-                                          const edm::DetSetVector<TotemTimingDigi>& input,
-                                          edm::DetSetVector<TotemTimingRecHit>& output)
-{
+void TotemTimingRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
+                                               const edm::DetSetVector<TotemTimingDigi>& input,
+                                               edm::DetSetVector<TotemTimingRecHit>& output) {
   for (const auto& vec : input) {
     const TotemTimingDetId detid(vec.detId());
 
@@ -52,13 +47,11 @@ TotemTimingRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
     if (det) {
       x_pos = det->translation().x();
       y_pos = det->translation().y();
-      z_pos = det->parentZPosition(); // retrieve the plane position;
+      z_pos = det->parentZPosition();  // retrieve the plane position;
 
-      x_width = 2.0 * det->params()[0], // parameters stand for half the size
-      y_width = 2.0 * det->params()[1],
-      z_width = 2.0 * det->params()[2];
-    }
-    else
+      x_width = 2.0 * det->params()[0],  // parameters stand for half the size
+          y_width = 2.0 * det->params()[1], z_width = 2.0 * det->params()[2];
+    } else
       throw cms::Exception("TotemTimingRecHitProducerAlgorithm") << "Failed to retrieve a sensor for " << detid;
 
     if (!sampicConversions_)
@@ -74,15 +67,13 @@ TotemTimingRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
 
       auto max_it = std::max_element(data.begin(), data.end());
 
-      RegressionResults baselineRegression =
-        simplifiedLinearRegression(time, data, 0, baselinePoints_);
+      RegressionResults baselineRegression = simplifiedLinearRegression(time, data, 0, baselinePoints_);
 
       // remove baseline
       std::vector<float> dataCorrected(data.size());
       for (unsigned int i = 0; i < data.size(); ++i)
         dataCorrected[i] = data[i] - (baselineRegression.q + baselineRegression.m * time[i]);
-      auto max_corrected_it =
-        std::max_element(dataCorrected.begin(), dataCorrected.end());
+      auto max_corrected_it = std::max_element(dataCorrected.begin(), dataCorrected.end());
 
       float t = TotemTimingRecHit::NO_T_AVAILABLE;
       if (*max_it < saturationLimit_)
@@ -90,20 +81,29 @@ TotemTimingRecHitProducerAlgorithm::build(const CTPPSGeometry& geom,
 
       mode_ = TotemTimingRecHit::CFD;
 
-      rec_hits.push_back(TotemTimingRecHit(
-        x_pos, x_width, y_pos, y_width, z_pos, z_width, // spatial information
-        t, triggerCellTimeInstant, timePrecision, *max_corrected_it,
-        baselineRegression.rms, mode_));
+      rec_hits.push_back(TotemTimingRecHit(x_pos,
+                                           x_width,
+                                           y_pos,
+                                           y_width,
+                                           z_pos,
+                                           z_width,  // spatial information
+                                           t,
+                                           triggerCellTimeInstant,
+                                           timePrecision,
+                                           *max_corrected_it,
+                                           baselineRegression.rms,
+                                           mode_));
     }
   }
 }
 
 //----------------------------------------------------------------------------------------------------
 
-TotemTimingRecHitProducerAlgorithm::RegressionResults
-TotemTimingRecHitProducerAlgorithm::simplifiedLinearRegression(const std::vector<float>& time, const std::vector<float>& data,
-                                                               const unsigned int start_at, const unsigned int points) const
-{
+TotemTimingRecHitProducerAlgorithm::RegressionResults TotemTimingRecHitProducerAlgorithm::simplifiedLinearRegression(
+    const std::vector<float>& time,
+    const std::vector<float>& data,
+    const unsigned int start_at,
+    const unsigned int points) const {
   RegressionResults results;
   if (time.size() != data.size())
     return results;
@@ -117,12 +117,12 @@ TotemTimingRecHitProducerAlgorithm::simplifiedLinearRegression(const std::vector
   auto d_end = std::next(data.begin(), stop_at);
 
   const float sx = std::accumulate(t_begin, t_end, 0.);
-  const float sxx = std::inner_product(t_begin, t_end, t_begin, 0.); // sum(t**2)
+  const float sxx = std::inner_product(t_begin, t_end, t_begin, 0.);  // sum(t**2)
   const float sy = std::accumulate(d_begin, d_end, 0.);
 
   float sxy = 0.;
   for (unsigned int i = 0; i < realPoints; ++i)
-    sxy += time[i]*data[i];
+    sxy += time[i] * data[i];
 
   // y = mx + q
   results.m = (sxy * realPoints - sx * sy) / (sxx * realPoints - sx * sx);
@@ -138,9 +138,7 @@ TotemTimingRecHitProducerAlgorithm::simplifiedLinearRegression(const std::vector
 
 //----------------------------------------------------------------------------------------------------
 
-int
-TotemTimingRecHitProducerAlgorithm::fastDiscriminator(const std::vector<float>& data, float threshold) const
-{
+int TotemTimingRecHitProducerAlgorithm::fastDiscriminator(const std::vector<float>& data, float threshold) const {
   int threholdCrossingIndex = -1;
   bool above = false;
   bool lockForHysteresis = false;
@@ -152,8 +150,8 @@ TotemTimingRecHitProducerAlgorithm::fastDiscriminator(const std::vector<float>& 
       above = true;
       lockForHysteresis = true;
     }
-    if (above && lockForHysteresis) // NOTE: not else if!, "above" can be set in
-                                    // the previous if
+    if (above && lockForHysteresis)  // NOTE: not else if!, "above" can be set in
+                                     // the previous if
     {
       // Lock until above threshold_+hysteresis
       if (lockForHysteresis && data[i] > threshold + hysteresis_)
@@ -162,7 +160,7 @@ TotemTimingRecHitProducerAlgorithm::fastDiscriminator(const std::vector<float>& 
       if (lockForHysteresis && data[i] < threshold) {
         above = false;
         lockForHysteresis = false;
-        threholdCrossingIndex = -1; // assigned because of noise
+        threholdCrossingIndex = -1;  // assigned because of noise
       }
     }
   }
@@ -170,14 +168,13 @@ TotemTimingRecHitProducerAlgorithm::fastDiscriminator(const std::vector<float>& 
   return threholdCrossingIndex;
 }
 
-float
-TotemTimingRecHitProducerAlgorithm::constantFractionDiscriminator(const std::vector<float>& time, const std::vector<float>& data)
-{
+float TotemTimingRecHitProducerAlgorithm::constantFractionDiscriminator(const std::vector<float>& time,
+                                                                        const std::vector<float>& data) {
   std::vector<float> dataProcessed(data);
-  if (lowPassFrequency_ != 0) // Smoothing
+  if (lowPassFrequency_ != 0)  // Smoothing
     for (unsigned short i = 0; i < data.size(); ++i)
-      for (unsigned short j = -smoothingPoints_/2; j <= +smoothingPoints_/2; ++j)
-        if ((i+j) >= 0 && (i+j) < data.size() && j != 0) {
+      for (unsigned short j = -smoothingPoints_ / 2; j <= +smoothingPoints_ / 2; ++j)
+        if ((i + j) >= 0 && (i + j) < data.size() && j != 0) {
           float x = SINC_COEFFICIENT * lowPassFrequency_ * j;
           dataProcessed[i] += data[i + j] * std::sin(x) / x;
         }
@@ -188,12 +185,11 @@ TotemTimingRecHitProducerAlgorithm::constantFractionDiscriminator(const std::vec
   int indexOfThresholdCrossing = fastDiscriminator(dataProcessed, threshold);
 
   //--- necessary sanity checks before proceeding with the extrapolation
-  return (indexOfThresholdCrossing >= 1
-       && indexOfThresholdCrossing >= baselinePoints_
-       && indexOfThresholdCrossing < (int)time.size())
-    ? (time[indexOfThresholdCrossing-1]-time[indexOfThresholdCrossing])
-      / (dataProcessed[indexOfThresholdCrossing-1] -dataProcessed[indexOfThresholdCrossing]) * (threshold-dataProcessed[indexOfThresholdCrossing])
-      + time[indexOfThresholdCrossing]
-    : TotemTimingRecHit::NO_T_AVAILABLE;
+  return (indexOfThresholdCrossing >= 1 && indexOfThresholdCrossing >= baselinePoints_ &&
+          indexOfThresholdCrossing < (int)time.size())
+             ? (time[indexOfThresholdCrossing - 1] - time[indexOfThresholdCrossing]) /
+                       (dataProcessed[indexOfThresholdCrossing - 1] - dataProcessed[indexOfThresholdCrossing]) *
+                       (threshold - dataProcessed[indexOfThresholdCrossing]) +
+                   time[indexOfThresholdCrossing]
+             : TotemTimingRecHit::NO_T_AVAILABLE;
 }
-

--- a/RecoCTPPS/TotemRPLocal/src/TotemTimingTrackRecognition.cc
+++ b/RecoCTPPS/TotemRPLocal/src/TotemTimingTrackRecognition.cc
@@ -12,80 +12,79 @@
 
 //----------------------------------------------------------------------------------------------------
 
-TotemTimingTrackRecognition::TotemTimingTrackRecognition( const edm::ParameterSet& iConfig ) :
-  CTPPSTimingTrackRecognition<TotemTimingLocalTrack, TotemTimingRecHit>( iConfig )
-{}
+TotemTimingTrackRecognition::TotemTimingTrackRecognition(const edm::ParameterSet& iConfig)
+    : CTPPSTimingTrackRecognition<TotemTimingLocalTrack, TotemTimingRecHit>(iConfig) {}
 
 //----------------------------------------------------------------------------------------------------
 
-void
-TotemTimingTrackRecognition::addHit( const TotemTimingRecHit& recHit )
-{
-  if ( recHit.getT() != TotemTimingRecHit::NO_T_AVAILABLE )
-    hitVectorMap_[0].emplace_back( recHit );
+void TotemTimingTrackRecognition::addHit(const TotemTimingRecHit& recHit) {
+  if (recHit.getT() != TotemTimingRecHit::NO_T_AVAILABLE)
+    hitVectorMap_[0].emplace_back(recHit);
 }
 
 //----------------------------------------------------------------------------------------------------
 
-int
-TotemTimingTrackRecognition::produceTracks( edm::DetSet<TotemTimingLocalTrack>& tracks )
-{
+int TotemTimingTrackRecognition::produceTracks(edm::DetSet<TotemTimingLocalTrack>& tracks) {
   int numberOfTracks = 0;
   DimensionParameters param;
 
-  auto getX = []( const TotemTimingRecHit& hit ){ return hit.getX(); };
-  auto getXWidth = []( const TotemTimingRecHit& hit ){ return hit.getXWidth(); };
-  auto setX = []( TotemTimingLocalTrack& track, float x ){ track.setPosition( math::XYZPoint( x, 0., 0. ) ); };
-  auto setXSigma = []( TotemTimingLocalTrack& track, float sigma ){ track.setPositionSigma( math::XYZPoint( sigma, 0., 0. ) ); };
-  auto getY = []( const TotemTimingRecHit& hit ){ return hit.getY(); };
-  auto getYWidth = []( const TotemTimingRecHit& hit ){ return hit.getYWidth(); };
-  auto setY = []( TotemTimingLocalTrack& track, float y ){ track.setPosition( math::XYZPoint( 0., y, 0. ) ); };
-  auto setYSigma = []( TotemTimingLocalTrack& track, float sigma ){ track.setPositionSigma( math::XYZPoint( 0., sigma, 0. ) ); };
+  auto getX = [](const TotemTimingRecHit& hit) { return hit.getX(); };
+  auto getXWidth = [](const TotemTimingRecHit& hit) { return hit.getXWidth(); };
+  auto setX = [](TotemTimingLocalTrack& track, float x) { track.setPosition(math::XYZPoint(x, 0., 0.)); };
+  auto setXSigma = [](TotemTimingLocalTrack& track, float sigma) {
+    track.setPositionSigma(math::XYZPoint(sigma, 0., 0.));
+  };
+  auto getY = [](const TotemTimingRecHit& hit) { return hit.getY(); };
+  auto getYWidth = [](const TotemTimingRecHit& hit) { return hit.getYWidth(); };
+  auto setY = [](TotemTimingLocalTrack& track, float y) { track.setPosition(math::XYZPoint(0., y, 0.)); };
+  auto setYSigma = [](TotemTimingLocalTrack& track, float sigma) {
+    track.setPositionSigma(math::XYZPoint(0., sigma, 0.));
+  };
 
-  for ( const auto& hitBatch : hitVectorMap_ ) {
+  for (const auto& hitBatch : hitVectorMap_) {
     const auto& hits = hitBatch.second;
-    const auto& hitRange = getHitSpatialRange( hits );
+    const auto& hitRange = getHitSpatialRange(hits);
 
     TrackVector xPartTracks, yPartTracks;
 
     param.rangeBegin = hitRange.xBegin;
     param.rangeEnd = hitRange.xEnd;
-    producePartialTracks( hits, param, getX, getXWidth, setX, setXSigma, xPartTracks );
+    producePartialTracks(hits, param, getX, getXWidth, setX, setXSigma, xPartTracks);
 
     param.rangeBegin = hitRange.yBegin;
     param.rangeEnd = hitRange.yEnd;
-    producePartialTracks( hits, param, getY, getYWidth, setY, setYSigma, yPartTracks );
+    producePartialTracks(hits, param, getY, getYWidth, setY, setYSigma, yPartTracks);
 
-    if ( xPartTracks.empty() && yPartTracks.empty() )
-     continue;
+    if (xPartTracks.empty() && yPartTracks.empty())
+      continue;
 
-    unsigned int validHitsNumber = (unsigned int)threshold_+1;
+    unsigned int validHitsNumber = (unsigned int)threshold_ + 1;
 
-    for ( const auto& xTrack : xPartTracks ) {
-      for ( const auto& yTrack : yPartTracks ) {
-        math::XYZPoint position( xTrack.getX0(), yTrack.getY0(), 0.5f*( hitRange.zBegin + hitRange.zEnd ) );
-        math::XYZPoint positionSigma( xTrack.getX0Sigma(), yTrack.getY0Sigma(), 0.5f*( hitRange.zEnd - hitRange.zBegin ) );
+    for (const auto& xTrack : xPartTracks) {
+      for (const auto& yTrack : yPartTracks) {
+        math::XYZPoint position(xTrack.getX0(), yTrack.getY0(), 0.5f * (hitRange.zBegin + hitRange.zEnd));
+        math::XYZPoint positionSigma(
+            xTrack.getX0Sigma(), yTrack.getY0Sigma(), 0.5f * (hitRange.zEnd - hitRange.zBegin));
 
-        TotemTimingLocalTrack newTrack( position, positionSigma, 0., 0. );
+        TotemTimingLocalTrack newTrack(position, positionSigma, 0., 0.);
 
         HitVector componentHits;
-        for ( const auto& hit : hits )
-          if ( newTrack.containsHit( hit, tolerance_ ) )
-            componentHits.emplace_back( hit );
-        if ( componentHits.size() < validHitsNumber )
+        for (const auto& hit : hits)
+          if (newTrack.containsHit(hit, tolerance_))
+            componentHits.emplace_back(hit);
+        if (componentHits.size() < validHitsNumber)
           continue;
 
         float mean_time = 0.f, time_sigma = 0.f;
-        bool valid_hits = timeEval( componentHits, mean_time, time_sigma );
-        newTrack.setValid( valid_hits );
-        newTrack.setT( mean_time );
-        newTrack.setTSigma( time_sigma );
+        bool valid_hits = timeEval(componentHits, mean_time, time_sigma);
+        newTrack.setValid(valid_hits);
+        newTrack.setT(mean_time);
+        newTrack.setTSigma(time_sigma);
         // in a next iteration, we will be setting validity / numHits / numPlanes
-        tracks.push_back( newTrack );
+        tracks.push_back(newTrack);
       }
     }
   }
 
   return numberOfTracks;
 }
-

--- a/RecoEcal/EgammaClusterProducers/interface/CleanAndMergeProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/CleanAndMergeProducer.h
@@ -14,33 +14,22 @@
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "RecoEcal/EgammaCoreTools/interface/ClusterShapeAlgo.h"
 
+class CleanAndMergeProducer : public edm::stream::EDProducer<> {
+public:
+  CleanAndMergeProducer(const edm::ParameterSet& ps);
 
-class CleanAndMergeProducer : public edm::stream::EDProducer<>
-{
-  
-  public:
+  ~CleanAndMergeProducer() override;
 
-      CleanAndMergeProducer(const edm::ParameterSet& ps);
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-      ~CleanAndMergeProducer() override;
+private:
+  edm::EDGetTokenT<reco::SuperClusterCollection> cleanScToken_;
+  edm::EDGetTokenT<reco::SuperClusterCollection> uncleanScToken_;
 
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      
-  private:
-      
-
-      edm::EDGetTokenT<reco::SuperClusterCollection> cleanScToken_;
-      edm::EDGetTokenT<reco::SuperClusterCollection> uncleanScToken_;
-     
-      // the names of the products to be produced:
-      std::string  bcCollection_;     
-      std::string  scCollection_;     
-      std::string  refScCollection_;  
-
-
+  // the names of the products to be produced:
+  std::string bcCollection_;
+  std::string scCollection_;
+  std::string refScCollection_;
 };
 
-
 #endif
-
-

--- a/RecoEcal/EgammaClusterProducers/interface/CosmicClusterProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/CosmicClusterProducer.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 #include <ctime>
-#include <vector> //TEMP JHAUPT 4-27
+#include <vector>  //TEMP JHAUPT 4-27
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
@@ -23,58 +23,51 @@
 
 //
 
+class CosmicClusterProducer : public edm::stream::EDProducer<> {
+public:
+  CosmicClusterProducer(const edm::ParameterSet& ps);
 
-class CosmicClusterProducer : public edm::stream::EDProducer<>
-{
-  public:
+  ~CosmicClusterProducer() override;
 
-      CosmicClusterProducer(const edm::ParameterSet& ps);
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-      ~CosmicClusterProducer() override;
+private:
+  int nMaxPrintout_;  // max # of printouts
+  int nEvt_;          // internal counter of events
 
-      void produce(edm::Event&, const edm::EventSetup&) override;
+  CosmicClusterAlgo::VerbosityLevel verbosity;
 
-   private:
+  edm::EDGetTokenT<EcalRecHitCollection> ebHitsToken_;
+  edm::EDGetTokenT<EcalRecHitCollection> eeHitsToken_;
 
-      int nMaxPrintout_; // max # of printouts
-      int nEvt_;         // internal counter of events
+  edm::EDGetTokenT<EcalUncalibratedRecHitCollection> ebUHitsToken_;
+  edm::EDGetTokenT<EcalUncalibratedRecHitCollection> eeUHitsToken_;
 
-      CosmicClusterAlgo::VerbosityLevel verbosity;
+  std::string barrelClusterCollection_;
+  std::string endcapClusterCollection_;
 
-      edm::EDGetTokenT<EcalRecHitCollection> ebHitsToken_;
-      edm::EDGetTokenT<EcalRecHitCollection> eeHitsToken_;
+  std::string clustershapecollectionEB_;
+  std::string clustershapecollectionEE_;
 
-      edm::EDGetTokenT<EcalUncalibratedRecHitCollection> ebUHitsToken_;
-      edm::EDGetTokenT<EcalUncalibratedRecHitCollection> eeUHitsToken_;
-	  
-      std::string barrelClusterCollection_;
-      std::string endcapClusterCollection_;
+  //BasicClusterShape AssociationMap
+  std::string barrelClusterShapeAssociation_;
+  std::string endcapClusterShapeAssociation_;
 
-      std::string clustershapecollectionEB_;
-      std::string clustershapecollectionEE_;
+  PositionCalc posCalculator_;  // position calculation algorithm
+  ClusterShapeAlgo shapeAlgo_;  // cluster shape algorithm
+  CosmicClusterAlgo* island_p;
 
-      //BasicClusterShape AssociationMap
-      std::string barrelClusterShapeAssociation_;
-      std::string endcapClusterShapeAssociation_; 
+  bool counterExceeded() const { return ((nEvt_ > nMaxPrintout_) || (nMaxPrintout_ < 0)); }
 
-      PositionCalc posCalculator_; // position calculation algorithm
-      ClusterShapeAlgo shapeAlgo_; // cluster shape algorithm
-      CosmicClusterAlgo * island_p;
+  void clusterizeECALPart(edm::Event& evt,
+                          const edm::EventSetup& es,
+                          const edm::EDGetTokenT<EcalRecHitCollection>& hitsToken,
+                          const edm::EDGetTokenT<EcalUncalibratedRecHitCollection>& uhitsToken,
+                          const std::string& clusterCollection,
+                          const std::string& clusterShapeAssociation,
+                          const CosmicClusterAlgo::EcalPart& ecalPart);
 
-      bool counterExceeded() const { return ((nEvt_ > nMaxPrintout_) || (nMaxPrintout_ < 0)); }
-
-      											 
-      void clusterizeECALPart(edm::Event &evt, const edm::EventSetup &es,
-			      const edm::EDGetTokenT<EcalRecHitCollection>& hitsToken,
-			      const edm::EDGetTokenT<EcalUncalibratedRecHitCollection>& uhitsToken,       
-                              const std::string& clusterCollection,
-			      const std::string& clusterShapeAssociation,
-                              const CosmicClusterAlgo::EcalPart& ecalPart);
-
-      void outputValidationInfo(reco::CaloClusterPtrVector &clusterPtrVector);
-	  
-	 
+  void outputValidationInfo(reco::CaloClusterPtrVector& clusterPtrVector);
 };
-
 
 #endif

--- a/RecoEcal/EgammaClusterProducers/interface/EcalDigiSelector.h
+++ b/RecoEcal/EgammaClusterProducers/interface/EcalDigiSelector.h
@@ -12,23 +12,17 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
-#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h" 
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 
 //
 
-
-class EcalDigiSelector : public edm::stream::EDProducer<> 
-{
-  
- public:
-  
+class EcalDigiSelector : public edm::stream::EDProducer<> {
+public:
   EcalDigiSelector(const edm::ParameterSet& ps);
-   
-  void produce(edm::Event&, const edm::EventSetup&) override;
-  
 
- private:
- 
+  void produce(edm::Event&, const edm::EventSetup&) override;
+
+private:
   std::string selectedEcalEBDigiCollection_;
   std::string selectedEcalEEDigiCollection_;
 
@@ -41,14 +35,9 @@ class EcalDigiSelector : public edm::stream::EDProducer<>
   edm::EDGetTokenT<EBDigiCollection> EcalEBDigiToken_;
   edm::EDGetTokenT<EEDigiCollection> EcalEEDigiToken_;
 
-
- 
-
   double cluster_pt_thresh_;
   double single_cluster_thresh_;
   int nclus_sel_;
-
 };
-
 
 #endif

--- a/RecoEcal/EgammaClusterProducers/interface/EgammaSCCorrectionMaker.h
+++ b/RecoEcal/EgammaClusterProducers/interface/EgammaSCCorrectionMaker.h
@@ -5,7 +5,7 @@
 //
 // Package:    EgammaSCCorrectionMaker
 // Class:      EgammaSCCorrectionMaker
-// 
+//
 /**\class EgammaSCCorrectionMaker EgammaSCCorrectionMaker.cc EgammaSCCorrectionMaker/EgammaSCCorrectionMaker/src/EgammaSCCorrectionMaker.cc
 
  Description: Producer of corrected SuperClusters
@@ -28,55 +28,48 @@
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 
 #include "RecoEcal/EgammaClusterAlgos/interface/EgammaSCEnergyCorrectionAlgo.h"
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h" 
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h" 
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
 
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 
-
 class EgammaSCCorrectionMaker : public edm::stream::EDProducer<> {
-	
-   public:
-     explicit EgammaSCCorrectionMaker(const edm::ParameterSet&);
-     ~EgammaSCCorrectionMaker() override;
-     void produce(edm::Event&, const edm::EventSetup&) override;
+public:
+  explicit EgammaSCCorrectionMaker(const edm::ParameterSet&);
+  ~EgammaSCCorrectionMaker() override;
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-   private:
+private:
+  std::unique_ptr<EcalClusterFunctionBaseClass> energyCorrectionFunction_;
+  std::unique_ptr<EcalClusterFunctionBaseClass> crackCorrectionFunction_;
+  std::unique_ptr<EcalClusterFunctionBaseClass> localContCorrectionFunction_;
 
-     std::unique_ptr<EcalClusterFunctionBaseClass> energyCorrectionFunction_;
-     std::unique_ptr<EcalClusterFunctionBaseClass> crackCorrectionFunction_;
-     std::unique_ptr<EcalClusterFunctionBaseClass> localContCorrectionFunction_;
+  // pointer to the correction algo object
+  std::unique_ptr<EgammaSCEnergyCorrectionAlgo> energyCorrector_;
 
+  // vars for the correction algo
+  bool applyEnergyCorrection_;
+  bool applyCrackCorrection_;
+  bool applyLocalContCorrection_;
 
-     // pointer to the correction algo object
-     std::unique_ptr<EgammaSCEnergyCorrectionAlgo> energyCorrector_;
-    
-     
+  std::string energyCorrectorName_;
+  std::string crackCorrectorName_;
+  std::string localContCorrectorName_;
 
-     // vars for the correction algo
-     bool applyEnergyCorrection_;
-     bool applyCrackCorrection_;
-     bool applyLocalContCorrection_;
+  int modeEB_;
+  int modeEE_;
 
-     std::string energyCorrectorName_;
-     std::string crackCorrectorName_;
-     std::string localContCorrectorName_;
+  //     bool oldEnergyScaleCorrection_;
+  double sigmaElectronicNoise_;
+  double etThresh_;
 
-     int modeEB_;
-     int modeEE_;
+  // vars to get products
+  edm::EDGetTokenT<EcalRecHitCollection> rHInputProducer_;
+  edm::EDGetTokenT<reco::SuperClusterCollection> sCInputProducer_;
+  edm::InputTag rHTag_;
 
-     //     bool oldEnergyScaleCorrection_;
-     double sigmaElectronicNoise_;
-     double etThresh_;
-     
-     // vars to get products
-     edm::EDGetTokenT<EcalRecHitCollection>          rHInputProducer_;
-     edm::EDGetTokenT<reco::SuperClusterCollection>  sCInputProducer_;
-	 edm::InputTag rHTag_;
-
-     reco::CaloCluster::AlgoId sCAlgo_;
-     std::string outputCollection_;
-
+  reco::CaloCluster::AlgoId sCAlgo_;
+  std::string outputCollection_;
 };
 #endif

--- a/RecoEcal/EgammaClusterProducers/interface/HybridClusterProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/HybridClusterProducer.h
@@ -15,34 +15,24 @@
 
 //
 
+class HybridClusterProducer : public edm::stream::EDProducer<> {
+public:
+  HybridClusterProducer(const edm::ParameterSet& ps);
 
-class HybridClusterProducer : public edm::stream::EDProducer<>
-{
-  
-  public:
+  ~HybridClusterProducer() override;
 
-      HybridClusterProducer(const edm::ParameterSet& ps);
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-      ~HybridClusterProducer() override;
+private:
+  int nEvt_;  // internal counter of events
 
-      void produce(edm::Event&, const edm::EventSetup&) override;
+  std::string basicclusterCollection_;
+  std::string superclusterCollection_;
 
-   private:
-      int nEvt_;         // internal counter of events
- 
-      std::string basicclusterCollection_;
-      std::string superclusterCollection_;
-      
-      edm::EDGetTokenT<EcalRecHitCollection> hitsToken_;
- 
+  edm::EDGetTokenT<EcalRecHitCollection> hitsToken_;
 
-      HybridClusterAlgo * hybrid_p; // clustering algorithm
-      PositionCalc posCalculator_; // position calculation algorithm
-
-
+  HybridClusterAlgo* hybrid_p;  // clustering algorithm
+  PositionCalc posCalculator_;  // position calculation algorithm
 };
 
-
 #endif
-
-

--- a/RecoEcal/EgammaClusterProducers/interface/InterestingDetIdCollectionProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/InterestingDetIdCollectionProducer.h
@@ -5,7 +5,7 @@
 //
 // Package:    InterestingDetIdCollectionProducer
 // Class:      InterestingDetIdCollectionProducer
-// 
+//
 /**\class InterestingDetIdCollectionProducer 
 Original author: Paolo Meridiani PH/CMG
  
@@ -23,8 +23,6 @@ The following classes of "interesting id" are considered
     3. Channels next to dead ones,  keepNextToDead_ is true
     4. Channels next to the EB/EE transition if keepNextToBoundary_ is true
 */
-
-
 
 // system include files
 #include <memory>
@@ -45,27 +43,26 @@ class CaloTopology;
 class EcalSeverityLevelAlgo;
 
 class InterestingDetIdCollectionProducer : public edm::stream::EDProducer<> {
-   public:
-      //! ctor
-      explicit InterestingDetIdCollectionProducer(const edm::ParameterSet&);
-      void beginRun (edm::Run const&, const edm::EventSetup&) final;
-      //! producer
-      void produce(edm::Event &, const edm::EventSetup&) override;
+public:
+  //! ctor
+  explicit InterestingDetIdCollectionProducer(const edm::ParameterSet&);
+  void beginRun(edm::Run const&, const edm::EventSetup&) final;
+  //! producer
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-   private:
-      // ----------member data ---------------------------
-      edm::EDGetTokenT<EcalRecHitCollection>         recHitsToken_;
-      edm::EDGetTokenT<reco::BasicClusterCollection> basicClustersToken_;
-      std::string interestingDetIdCollection_;
-      int minimalEtaSize_;
-      int minimalPhiSize_;
-      const CaloTopology* caloTopology_;
+private:
+  // ----------member data ---------------------------
+  edm::EDGetTokenT<EcalRecHitCollection> recHitsToken_;
+  edm::EDGetTokenT<reco::BasicClusterCollection> basicClustersToken_;
+  std::string interestingDetIdCollection_;
+  int minimalEtaSize_;
+  int minimalPhiSize_;
+  const CaloTopology* caloTopology_;
 
-      int severityLevel_;
-      const EcalSeverityLevelAlgo * severity_;
-      bool  keepNextToDead_;
-      bool  keepNextToBoundary_;
-
+  int severityLevel_;
+  const EcalSeverityLevelAlgo* severity_;
+  bool keepNextToDead_;
+  bool keepNextToBoundary_;
 };
 
 #endif

--- a/RecoEcal/EgammaClusterProducers/interface/InterestingDetIdFromSuperClusterProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/InterestingDetIdFromSuperClusterProducer.h
@@ -5,7 +5,7 @@
 //
 // Package:    InterestingDetIdFromSuperClusterProducer
 // Class:      InterestingDetIdFromSuperClusterProducer
-// 
+//
 /**\class InterestingDetIdFromSuperClusterProducer 
 Adapted from InterestingDetIdCollectionProducer by J.Bendavid
  
@@ -23,8 +23,6 @@ The following classes of "interesting id" are considered
     3. Channels next to dead ones,  keepNextToDead_ is true
     4. Channels next to the EB/EE transition if keepNextToBoundary_ is true
 */
-
-
 
 // system include files
 #include <memory>
@@ -45,27 +43,26 @@ class CaloTopology;
 class EcalSeverityLevelAlgo;
 
 class InterestingDetIdFromSuperClusterProducer : public edm::stream::EDProducer<> {
-   public:
-      //! ctor
-      explicit InterestingDetIdFromSuperClusterProducer(const edm::ParameterSet&);
-      void beginRun (edm::Run const&, const edm::EventSetup&) final;
-      //! producer
-      void produce(edm::Event &, const edm::EventSetup&) override;
+public:
+  //! ctor
+  explicit InterestingDetIdFromSuperClusterProducer(const edm::ParameterSet&);
+  void beginRun(edm::Run const&, const edm::EventSetup&) final;
+  //! producer
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-   private:
-      // ----------member data ---------------------------
-      edm::EDGetTokenT<EcalRecHitCollection>         recHitsToken_;
-      edm::EDGetTokenT<reco::SuperClusterCollection> superClustersToken_;
-      std::string interestingDetIdCollection_;
-      int minimalEtaSize_;
-      int minimalPhiSize_;
-      const CaloTopology* caloTopology_;
+private:
+  // ----------member data ---------------------------
+  edm::EDGetTokenT<EcalRecHitCollection> recHitsToken_;
+  edm::EDGetTokenT<reco::SuperClusterCollection> superClustersToken_;
+  std::string interestingDetIdCollection_;
+  int minimalEtaSize_;
+  int minimalPhiSize_;
+  const CaloTopology* caloTopology_;
 
-      int severityLevel_;
-      const EcalSeverityLevelAlgo * severity_;
-      bool  keepNextToDead_;
-      bool  keepNextToBoundary_;
-
+  int severityLevel_;
+  const EcalSeverityLevelAlgo* severity_;
+  bool keepNextToDead_;
+  bool keepNextToBoundary_;
 };
 
 #endif

--- a/RecoEcal/EgammaClusterProducers/interface/IslandClusterProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/IslandClusterProducer.h
@@ -23,56 +23,49 @@
 
 //
 
+class IslandClusterProducer : public edm::stream::EDProducer<> {
+public:
+  IslandClusterProducer(const edm::ParameterSet& ps);
 
-class IslandClusterProducer : public edm::stream::EDProducer<> 
-{
-  public:
+  ~IslandClusterProducer() override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-      IslandClusterProducer(const edm::ParameterSet& ps);
+private:
+  int nMaxPrintout_;  // max # of printouts
+  int nEvt_;          // internal counter of events
 
-      ~IslandClusterProducer() override;
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-      void produce(edm::Event&, const edm::EventSetup&) override;
+  IslandClusterAlgo::VerbosityLevel verbosity;
 
-   private:
+  edm::EDGetTokenT<EcalRecHitCollection> barrelRecHits_;
+  edm::EDGetTokenT<EcalRecHitCollection> endcapRecHits_;
 
-      int nMaxPrintout_; // max # of printouts
-      int nEvt_;         // internal counter of events
+  std::string barrelClusterCollection_;
+  std::string endcapClusterCollection_;
 
-      IslandClusterAlgo::VerbosityLevel verbosity;
+  std::string clustershapecollectionEB_;
+  std::string clustershapecollectionEE_;
 
+  //BasicClusterShape AssociationMap
+  std::string barrelClusterShapeAssociation_;
+  std::string endcapClusterShapeAssociation_;
 
- 	  edm::EDGetTokenT<EcalRecHitCollection> barrelRecHits_;
-	  edm::EDGetTokenT<EcalRecHitCollection> endcapRecHits_;
+  PositionCalc posCalculator_;  // position calculation algorithm
+  ClusterShapeAlgo shapeAlgo_;  // cluster shape algorithm
+  IslandClusterAlgo* island_p;
 
-      std::string barrelClusterCollection_;
-      std::string endcapClusterCollection_;
+  bool counterExceeded() const { return ((nEvt_ > nMaxPrintout_) || (nMaxPrintout_ < 0)); }
 
-      std::string clustershapecollectionEB_;
-      std::string clustershapecollectionEE_;
+  const EcalRecHitCollection* getCollection(edm::Event& evt, const edm::EDGetTokenT<EcalRecHitCollection>& token);
 
-      //BasicClusterShape AssociationMap
-      std::string barrelClusterShapeAssociation_;
-      std::string endcapClusterShapeAssociation_; 
+  void clusterizeECALPart(edm::Event& evt,
+                          const edm::EventSetup& es,
+                          const edm::EDGetTokenT<EcalRecHitCollection>& token,
+                          const std::string& clusterCollection,
+                          const std::string& clusterShapeAssociation,
+                          const IslandClusterAlgo::EcalPart& ecalPart);
 
-      PositionCalc posCalculator_; // position calculation algorithm
-      ClusterShapeAlgo shapeAlgo_; // cluster shape algorithm
-      IslandClusterAlgo * island_p;
-
-      bool counterExceeded() const { return ((nEvt_ > nMaxPrintout_) || (nMaxPrintout_ < 0)); }
-
-      const EcalRecHitCollection * getCollection(edm::Event& evt,
-                                   const edm::EDGetTokenT<EcalRecHitCollection>& token);
-
-
-      void clusterizeECALPart(edm::Event &evt, const edm::EventSetup &es,
-							  const edm::EDGetTokenT<EcalRecHitCollection>& token,
-                              const std::string& clusterCollection,
-			      const std::string& clusterShapeAssociation,
-                              const IslandClusterAlgo::EcalPart& ecalPart);
-
-      void outputValidationInfo(reco::CaloClusterPtrVector &clusterPtrVector);
+  void outputValidationInfo(reco::CaloClusterPtrVector& clusterPtrVector);
 };
-
 
 #endif

--- a/RecoEcal/EgammaClusterProducers/interface/Multi5x5ClusterProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/Multi5x5ClusterProducer.h
@@ -21,48 +21,42 @@
 
 //
 
+class Multi5x5ClusterProducer : public edm::stream::EDProducer<> {
+public:
+  Multi5x5ClusterProducer(const edm::ParameterSet& ps);
 
-class Multi5x5ClusterProducer : public edm::stream::EDProducer<> 
-{
-  public:
+  ~Multi5x5ClusterProducer() override;
 
-      Multi5x5ClusterProducer(const edm::ParameterSet& ps);
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-      ~Multi5x5ClusterProducer() override;
+private:
+  int nMaxPrintout_;  // max # of printouts
+  int nEvt_;          // internal counter of events
 
-      void produce(edm::Event&, const edm::EventSetup&) override;
+  // cluster which regions
+  bool doBarrel_;
+  bool doEndcap_;
 
-   private:
+  edm::EDGetTokenT<EcalRecHitCollection> barrelHitToken_;
+  edm::EDGetTokenT<EcalRecHitCollection> endcapHitToken_;
 
-      int nMaxPrintout_; // max # of printouts
-      int nEvt_;         // internal counter of events
+  std::string barrelClusterCollection_;
+  std::string endcapClusterCollection_;
 
-      // cluster which regions
-      bool doBarrel_;
-      bool doEndcap_;
+  PositionCalc posCalculator_;  // position calculation algorithm
+  Multi5x5ClusterAlgo* island_p;
 
-      edm::EDGetTokenT<EcalRecHitCollection> barrelHitToken_;
-	  edm::EDGetTokenT<EcalRecHitCollection> endcapHitToken_;
+  bool counterExceeded() const { return ((nEvt_ > nMaxPrintout_) || (nMaxPrintout_ < 0)); }
 
-      std::string barrelClusterCollection_;
-      std::string endcapClusterCollection_;
+  const EcalRecHitCollection* getCollection(edm::Event& evt, const edm::EDGetTokenT<EcalRecHitCollection>& token);
 
-      PositionCalc posCalculator_; // position calculation algorithm
-      Multi5x5ClusterAlgo * island_p;
+  void clusterizeECALPart(edm::Event& evt,
+                          const edm::EventSetup& es,
+                          const edm::EDGetTokenT<EcalRecHitCollection>& token,
+                          const std::string& clusterCollection,
+                          const reco::CaloID::Detectors detector);
 
-      bool counterExceeded() const { return ((nEvt_ > nMaxPrintout_) || (nMaxPrintout_ < 0)); }
-
-      const EcalRecHitCollection * getCollection(edm::Event& evt,
-                                                 const edm::EDGetTokenT<EcalRecHitCollection>& token );
-
-
-      void clusterizeECALPart(edm::Event &evt, const edm::EventSetup &es,
-                              const edm::EDGetTokenT<EcalRecHitCollection>& token, 
-                              const std::string& clusterCollection,
-                              const reco::CaloID::Detectors detector);
-
-      void outputValidationInfo(reco::CaloClusterPtrVector &clusterPtrVector);
+  void outputValidationInfo(reco::CaloClusterPtrVector& clusterPtrVector);
 };
-
 
 #endif

--- a/RecoEcal/EgammaClusterProducers/interface/Multi5x5SuperClusterProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/Multi5x5SuperClusterProducer.h
@@ -15,49 +15,41 @@
 #include "DataFormats/EgammaReco/interface/BasicClusterFwd.h"
 //
 
+class Multi5x5SuperClusterProducer : public edm::stream::EDProducer<> {
+public:
+  Multi5x5SuperClusterProducer(const edm::ParameterSet& ps);
 
-class Multi5x5SuperClusterProducer : public edm::stream::EDProducer<>
-{
-  
-  public:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void endStream() override;
 
-      Multi5x5SuperClusterProducer(const edm::ParameterSet& ps);
+private:
+  edm::EDGetTokenT<reco::BasicClusterCollection> eeClustersToken_;
+  edm::EDGetTokenT<reco::BasicClusterCollection> ebClustersToken_;
+  edm::EDPutTokenT<reco::SuperClusterCollection> endcapPutToken_;
+  edm::EDPutTokenT<reco::SuperClusterCollection> barrelPutToken_;
 
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      void endStream() override;
+  const float barrelEtaSearchRoad_;
+  const float barrelPhiSearchRoad_;
+  const float endcapEtaSearchRoad_;
+  const float endcapPhiSearchRoad_;
+  const float seedTransverseEnergyThreshold_;
 
-   private:
+  const bool doBarrel_;
+  const bool doEndcaps_;
 
-      edm::EDGetTokenT<reco::BasicClusterCollection> eeClustersToken_; 
-      edm::EDGetTokenT<reco::BasicClusterCollection> ebClustersToken_; 
-      edm::EDPutTokenT<reco::SuperClusterCollection> endcapPutToken_;
-      edm::EDPutTokenT<reco::SuperClusterCollection> barrelPutToken_;
+  std::unique_ptr<Multi5x5BremRecoveryClusterAlgo> bremAlgo_p;
 
-      const float barrelEtaSearchRoad_;
-      const float barrelPhiSearchRoad_;
-      const float endcapEtaSearchRoad_; 
-      const float endcapPhiSearchRoad_;
-      const float seedTransverseEnergyThreshold_;
+  double totalE;
+  int noSuperClusters;
 
-      const bool doBarrel_;
-      const bool doEndcaps_;
+  reco::CaloClusterPtrVector getClusterPtrVector(
+      edm::Event& evt, const edm::EDGetTokenT<reco::BasicClusterCollection>& clustersToken) const;
 
-      std::unique_ptr<Multi5x5BremRecoveryClusterAlgo>  bremAlgo_p;
+  void produceSuperclustersForECALPart(edm::Event& evt,
+                                       const edm::EDGetTokenT<reco::BasicClusterCollection>& clustersToken,
+                                       const edm::EDPutTokenT<reco::SuperClusterCollection>& putToken);
 
-      double totalE;
-      int noSuperClusters;
-
-      reco::CaloClusterPtrVector
-      getClusterPtrVector(edm::Event& evt, 
-                          const edm::EDGetTokenT<reco::BasicClusterCollection>& clustersToken) const;
-  
-      void produceSuperclustersForECALPart(edm::Event& evt, 
-                                           const edm::EDGetTokenT<reco::BasicClusterCollection>& clustersToken,
-                                           const edm::EDPutTokenT<reco::SuperClusterCollection>& putToken);
-
-      void outputValidationInfo(reco::SuperClusterCollection &superclusterCollection);
-    
+  void outputValidationInfo(reco::SuperClusterCollection& superclusterCollection);
 };
 
 #endif
-

--- a/RecoEcal/EgammaClusterProducers/interface/PFECALSuperClusterProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/PFECALSuperClusterProducer.h
@@ -22,7 +22,7 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 #include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"
-#include "Geometry/CaloTopology/interface/CaloTopology.h" 
+#include "Geometry/CaloTopology/interface/CaloTopology.h"
 
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
@@ -41,27 +41,27 @@ class GBRForest;
 class GBRWrapperRcd;
 
 class PFECALSuperClusterProducer : public edm::stream::EDProducer<> {
- public:  
+public:
   explicit PFECALSuperClusterProducer(const edm::ParameterSet&);
   ~PFECALSuperClusterProducer() override;
 
   void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  
-  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions); 
 
- private:  
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
   // ----------member data ---------------------------
 
-  /// clustering algorithm 
-  PFECALSuperClusterAlgo                  superClusterAlgo_;
+  /// clustering algorithm
+  PFECALSuperClusterAlgo superClusterAlgo_;
   PFECALSuperClusterAlgo::clustering_type _theclusteringtype;
-  PFECALSuperClusterAlgo::energy_weight   _theenergyweight;
+  PFECALSuperClusterAlgo::energy_weight _theenergyweight;
 
   std::shared_ptr<PFEnergyCalibration> thePFEnergyCalibration_;
 
   /// verbose ?
-  bool   verbose_;
+  bool verbose_;
 
   std::string PFBasicClusterCollectionBarrel_;
   std::string PFSuperClusterCollectionBarrel_;

--- a/RecoEcal/EgammaClusterProducers/interface/PreshowerClusterProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/PreshowerClusterProducer.h
@@ -22,36 +22,33 @@
 #include "CondFormats/ESObjects/interface/ESChannelStatus.h"
 
 class PreshowerClusterProducer : public edm::stream::EDProducer<> {
-
- public:
-
+public:
   typedef math::XYZPoint Point;
 
-  explicit PreshowerClusterProducer (const edm::ParameterSet& ps);
+  explicit PreshowerClusterProducer(const edm::ParameterSet& ps);
 
   ~PreshowerClusterProducer() override;
 
-  void produce( edm::Event& evt, const edm::EventSetup& es) override;
+  void produce(edm::Event& evt, const edm::EventSetup& es) override;
   void set(const edm::EventSetup& es);
 
- private:
-
-  int nEvt_;         // internal counter of events
+private:
+  int nEvt_;  // internal counter of events
 
   //clustering parameters:
-  edm::EDGetTokenT<EcalRecHitCollection> preshHitsToken_;         // name of module/plugin/producer producing hits
-  edm::EDGetTokenT<reco::SuperClusterCollection> endcapSClusterToken_;   // ditto SuperClusters
+  edm::EDGetTokenT<EcalRecHitCollection> preshHitsToken_;               // name of module/plugin/producer producing hits
+  edm::EDGetTokenT<reco::SuperClusterCollection> endcapSClusterToken_;  // ditto SuperClusters
 
   // name out output collections
-  std::string preshClusterCollectionX_;  
-  std::string preshClusterCollectionY_;  
+  std::string preshClusterCollectionX_;
+  std::string preshClusterCollectionY_;
 
   int preshNclust_;
   float preshClustECut;
   double etThresh_;
 
   // association parameters:
-  std::string assocSClusterCollection_;    // name of super cluster output collection
+  std::string assocSClusterCollection_;  // name of super cluster output collection
 
   edm::ESHandle<ESGain> esgain_;
   edm::ESHandle<ESMIPToGeVConstant> esMIPToGeV_;
@@ -70,11 +67,8 @@ class PreshowerClusterProducer : public edm::stream::EDProducer<> {
   double aEta_[4];
   double bEta_[4];
 
-  PreshowerClusterAlgo * presh_algo; // algorithm doing the real work
-   // The set of used DetID's
+  PreshowerClusterAlgo* presh_algo;  // algorithm doing the real work
+                                     // The set of used DetID's
   //std::set<DetId> used_strips;
-
-
 };
 #endif
-

--- a/RecoEcal/EgammaClusterProducers/interface/PreshowerClusterShapeProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/PreshowerClusterShapeProducer.h
@@ -1,7 +1,6 @@
 #ifndef RecoEcal_EgammaClusterProducers_PreshowerClusterShapeProducer_h
 #define RecoEcal_EgammaClusterProducers_PreshowerClusterShapeProducer_h
 
-
 #include <memory>
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
@@ -20,33 +19,28 @@
 // authors A. Kyriakis, D. Maletic
 
 class PreshowerClusterShapeProducer : public edm::stream::EDProducer<> {
-
- public:
-
+public:
   typedef math::XYZPoint Point;
 
-  explicit PreshowerClusterShapeProducer (const edm::ParameterSet& ps);
+  explicit PreshowerClusterShapeProducer(const edm::ParameterSet& ps);
 
   ~PreshowerClusterShapeProducer() override;
 
-  void produce( edm::Event& evt, const edm::EventSetup& es) override;
+  void produce(edm::Event& evt, const edm::EventSetup& es) override;
 
- private:
-
-  int nEvt_;         // internal counter of events
+private:
+  int nEvt_;  // internal counter of events
 
   //clustering parameters:
 
-  edm::EDGetTokenT<EcalRecHitCollection> preshHitToken_; // name of module/plugin/producer 
-                                                         // producing hits
-  edm::EDGetTokenT<reco::SuperClusterCollection> endcapSClusterToken_; // likewise for producer 
-                                                                       // of endcap superclusters
+  edm::EDGetTokenT<EcalRecHitCollection> preshHitToken_;                // name of module/plugin/producer
+                                                                        // producing hits
+  edm::EDGetTokenT<reco::SuperClusterCollection> endcapSClusterToken_;  // likewise for producer
+                                                                        // of endcap superclusters
 
   std::string PreshowerClusterShapeCollectionX_;
   std::string PreshowerClusterShapeCollectionY_;
-  
-  EndcapPiZeroDiscriminatorAlgo * presh_pi0_algo; // algorithm doing the real work
 
+  EndcapPiZeroDiscriminatorAlgo* presh_pi0_algo;  // algorithm doing the real work
 };
 #endif
-

--- a/RecoEcal/EgammaClusterProducers/interface/PreshowerPhiClusterProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/PreshowerPhiClusterProducer.h
@@ -21,33 +21,30 @@
 #include "CondFormats/ESObjects/interface/ESChannelStatus.h"
 
 class PreshowerPhiClusterProducer : public edm::stream::EDProducer<> {
-
- public:
-
+public:
   typedef math::XYZPoint Point;
 
-  explicit PreshowerPhiClusterProducer (const edm::ParameterSet& ps);
+  explicit PreshowerPhiClusterProducer(const edm::ParameterSet& ps);
 
   ~PreshowerPhiClusterProducer() override;
 
-  void produce( edm::Event& evt, const edm::EventSetup& es) override;
+  void produce(edm::Event& evt, const edm::EventSetup& es) override;
   void set(const edm::EventSetup& es);
 
- private:
-
-  int nEvt_;         // internal counter of events
+private:
+  int nEvt_;  // internal counter of events
 
   //clustering parameters:
-  edm::EDGetTokenT<EcalRecHitCollection> preshHitToken_; // name of module/plugin/producer 
-                                                         // producing hits
-  edm::EDGetTokenT<reco::SuperClusterCollection> endcapSClusterToken_;   // ditto SuperClusters
+  edm::EDGetTokenT<EcalRecHitCollection> preshHitToken_;                // name of module/plugin/producer
+                                                                        // producing hits
+  edm::EDGetTokenT<reco::SuperClusterCollection> endcapSClusterToken_;  // ditto SuperClusters
 
   // name out output collections
-  std::string preshClusterCollectionX_;  
-  std::string preshClusterCollectionY_;  
+  std::string preshClusterCollectionX_;
+  std::string preshClusterCollectionY_;
 
   // association parameters:
-  std::string assocSClusterCollection_;    // name of super cluster output collection
+  std::string assocSClusterCollection_;  // name of super cluster output collection
 
   edm::ESHandle<ESGain> esgain_;
   edm::ESHandle<ESMIPToGeVConstant> esMIPToGeV_;
@@ -68,12 +65,11 @@ class PreshowerPhiClusterProducer : public edm::stream::EDProducer<> {
 
   double etThresh_;
 
-  PreshowerPhiClusterAlgo * presh_algo; // algorithm doing the real work
-   // The set of used DetID's
+  PreshowerPhiClusterAlgo* presh_algo;  // algorithm doing the real work
+                                        // The set of used DetID's
   //std::set<DetId> used_strips;
 
   float esPhiClusterDeltaEta_;
   float esPhiClusterDeltaPhi_;
 };
 #endif
-

--- a/RecoEcal/EgammaClusterProducers/interface/RecHitFilter.h
+++ b/RecoEcal/EgammaClusterProducers/interface/RecHitFilter.h
@@ -18,24 +18,18 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-
 class RecHitFilter : public edm::global::EDProducer<> {
+public:
+  RecHitFilter(const edm::ParameterSet& ps);
 
-  public:
+  ~RecHitFilter() override;
 
-      RecHitFilter(const edm::ParameterSet& ps);
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
-      ~RecHitFilter() override;
-
-      void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-
-   private:
-
-      const double        noiseEnergyThreshold_;
-      const double        noiseChi2Threshold_;
-      const std::string   reducedHitCollection_;
-      const edm::EDGetTokenT<EcalRecHitCollection> hitCollection_;
-
-
+private:
+  const double noiseEnergyThreshold_;
+  const double noiseChi2Threshold_;
+  const std::string reducedHitCollection_;
+  const edm::EDGetTokenT<EcalRecHitCollection> hitCollection_;
 };
 #endif

--- a/RecoEcal/EgammaClusterProducers/interface/ReducedESRecHitCollectionProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/ReducedESRecHitCollectionProducer.h
@@ -22,32 +22,27 @@
 class EcalPreshowerGeometry;
 class CaloSubdetectorTopology;
 class ReducedESRecHitCollectionProducer : public edm::stream::EDProducer<> {
-
- public :
-
+public:
   ReducedESRecHitCollectionProducer(const edm::ParameterSet& pset);
   ~ReducedESRecHitCollectionProducer() override;
-  void beginRun (edm::Run const&, const edm::EventSetup&) final;
-  void produce(edm::Event & e, const edm::EventSetup& c) override;
-  void collectIds(const ESDetId strip1, const ESDetId strip2, const int & row=0);
-  
- private :
+  void beginRun(edm::Run const&, const edm::EventSetup&) final;
+  void produce(edm::Event& e, const edm::EventSetup& c) override;
+  void collectIds(const ESDetId strip1, const ESDetId strip2, const int& row = 0);
 
-  const EcalPreshowerGeometry *geometry_p;
+private:
+  const EcalPreshowerGeometry* geometry_p;
   std::unique_ptr<CaloSubdetectorTopology> topology_p;
 
   double scEtThresh_;
 
-  edm::EDGetTokenT<ESRecHitCollection>           InputRecHitES_;  
+  edm::EDGetTokenT<ESRecHitCollection> InputRecHitES_;
   edm::EDGetTokenT<reco::SuperClusterCollection> InputSuperClusterEE_;
   std::string OutputLabelES_;
   std::vector<edm::EDGetTokenT<DetIdCollection>> interestingDetIdCollections_;
-  std::vector<edm::EDGetTokenT<DetIdCollection>> interestingDetIdCollectionsNotToClean_; //theres a hard coded cut on rec-hit quality which some collections would prefer not to have...
+  std::vector<edm::EDGetTokenT<DetIdCollection>>
+      interestingDetIdCollectionsNotToClean_;  //theres a hard coded cut on rec-hit quality which some collections would prefer not to have...
 
   std::set<DetId> collectedIds_;
-  
 };
 
 #endif
-
-

--- a/RecoEcal/EgammaClusterProducers/interface/ReducedRecHitCollectionProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/ReducedRecHitCollectionProducer.h
@@ -5,7 +5,7 @@
 //
 // Package:    ReducedRecHitCollectionProducer
 // Class:      ReducedRecHitCollectionProducer
-// 
+//
 /**\class ReducedRecHitCollectionProducer ReducedRecHitCollectionProducer.cc Calibration/EcalAlCaRecoProducers/src/ReducedRecHitCollectionProducer.cc
 
 Original author: Paolo Meridiani PH/CMG
@@ -13,8 +13,6 @@ Original author: Paolo Meridiani PH/CMG
 Implementation:
  <Notes on implementation>
 */
-
-
 
 // system include files
 #include <memory>
@@ -33,19 +31,18 @@ Implementation:
 class CaloTopology;
 
 class ReducedRecHitCollectionProducer : public edm::stream::EDProducer<> {
-   public:
-      //! ctor
-      explicit ReducedRecHitCollectionProducer(const edm::ParameterSet&);
-      ~ReducedRecHitCollectionProducer() override;
-      //! producer
-      void produce(edm::Event &, const edm::EventSetup&) override;
+public:
+  //! ctor
+  explicit ReducedRecHitCollectionProducer(const edm::ParameterSet &);
+  ~ReducedRecHitCollectionProducer() override;
+  //! producer
+  void produce(edm::Event &, const edm::EventSetup &) override;
 
-   private:
-      // ----------member data ---------------------------
-      edm::EDGetTokenT<EcalRecHitCollection>     recHitsToken_;
-      std::vector<edm::EDGetTokenT<DetIdCollection> > interestingDetIdCollections_;
-      std::string reducedHitsCollection_;
-  
+private:
+  // ----------member data ---------------------------
+  edm::EDGetTokenT<EcalRecHitCollection> recHitsToken_;
+  std::vector<edm::EDGetTokenT<DetIdCollection> > interestingDetIdCollections_;
+  std::string reducedHitsCollection_;
 };
 
 #endif

--- a/RecoEcal/EgammaClusterProducers/interface/UncleanSCRecoveryProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/UncleanSCRecoveryProducer.h
@@ -12,32 +12,22 @@
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 #include "DataFormats/EgammaReco/interface/BasicClusterFwd.h"
 
+class UncleanSCRecoveryProducer : public edm::global::EDProducer<> {
+public:
+  UncleanSCRecoveryProducer(const edm::ParameterSet& ps);
 
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
-class UncleanSCRecoveryProducer : public edm::global::EDProducer<> 
-{
-  
-  public:
-
-      UncleanSCRecoveryProducer(const edm::ParameterSet& ps);
-
-      void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-      
-  private:
-      // the clean collection      
-      const edm::EDGetTokenT<reco::BasicClusterCollection>  cleanBcCollection_; 
-      const edm::EDGetTokenT<reco::SuperClusterCollection>  cleanScCollection_; 
-      // the uncleaned collection
-      const edm::EDGetTokenT<reco::BasicClusterCollection>  uncleanBcCollection_;
-      const edm::EDGetTokenT<reco::SuperClusterCollection>  uncleanScCollection_;
-      // the names of the products to be produced:
-      const std::string  bcCollection_;     
-      const std::string  scCollection_;     
-
-
+private:
+  // the clean collection
+  const edm::EDGetTokenT<reco::BasicClusterCollection> cleanBcCollection_;
+  const edm::EDGetTokenT<reco::SuperClusterCollection> cleanScCollection_;
+  // the uncleaned collection
+  const edm::EDGetTokenT<reco::BasicClusterCollection> uncleanBcCollection_;
+  const edm::EDGetTokenT<reco::SuperClusterCollection> uncleanScCollection_;
+  // the names of the products to be produced:
+  const std::string bcCollection_;
+  const std::string scCollection_;
 };
 
-
 #endif
-
-

--- a/RecoEcal/EgammaClusterProducers/interface/UnifiedSCCollectionProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/UnifiedSCCollectionProducer.h
@@ -15,34 +15,25 @@
 
 #include "FWCore/Utilities/interface/InputTag.h"
 
-class UnifiedSCCollectionProducer : public edm::stream::EDProducer<> 
-{
-  
-  public:
+class UnifiedSCCollectionProducer : public edm::stream::EDProducer<> {
+public:
+  UnifiedSCCollectionProducer(const edm::ParameterSet& ps);
 
-      UnifiedSCCollectionProducer(const edm::ParameterSet& ps);
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      
-  private:
-	  // the clean collection      
-      edm::EDGetTokenT<reco::BasicClusterCollection>  cleanBcCollection_; 
-      edm::EDGetTokenT<reco::SuperClusterCollection>  cleanScCollection_; 
-      // the uncleaned collection
-      edm::EDGetTokenT<reco::BasicClusterCollection>  uncleanBcCollection_;
-      edm::EDGetTokenT<reco::SuperClusterCollection>  uncleanScCollection_;
-      
-      // the names of the products to be produced:
-      std::string  bcCollection_;     
-      std::string  scCollection_;     
-      std::string  bcCollectionUncleanOnly_;
-      std::string  scCollectionUncleanOnly_;
+private:
+  // the clean collection
+  edm::EDGetTokenT<reco::BasicClusterCollection> cleanBcCollection_;
+  edm::EDGetTokenT<reco::SuperClusterCollection> cleanScCollection_;
+  // the uncleaned collection
+  edm::EDGetTokenT<reco::BasicClusterCollection> uncleanBcCollection_;
+  edm::EDGetTokenT<reco::SuperClusterCollection> uncleanScCollection_;
 
-
-
+  // the names of the products to be produced:
+  std::string bcCollection_;
+  std::string scCollection_;
+  std::string bcCollectionUncleanOnly_;
+  std::string scCollectionUncleanOnly_;
 };
 
-
 #endif
-
-

--- a/RecoEcal/EgammaClusterProducers/src/CleanAndMergeProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/CleanAndMergeProducer.cc
@@ -33,7 +33,6 @@
 #include "RecoEcal/EgammaCoreTools/interface/PositionCalc.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 
-
 /*
 CleanAndMergeProducer:
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -49,165 +48,156 @@ many thanks to Shahram Rahatlou and Federico Ferri
 
 */
 
+CleanAndMergeProducer::CleanAndMergeProducer(const edm::ParameterSet& ps) {
+  // get the parameters
+  // the cleaned collection:
+  cleanScToken_ = consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("cleanScInputTag"));
+  uncleanScToken_ = consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("uncleanScInputTag"));
 
-CleanAndMergeProducer::CleanAndMergeProducer(const edm::ParameterSet& ps)
-{
+  // the names of the products to be produced:
+  bcCollection_ = ps.getParameter<std::string>("bcCollection");
+  scCollection_ = ps.getParameter<std::string>("scCollection");
+  refScCollection_ = ps.getParameter<std::string>("refScCollection");
 
-        // get the parameters
-        // the cleaned collection:
-        cleanScToken_   = 
-            consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("cleanScInputTag"));
-	uncleanScToken_ = 
-	    consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("uncleanScInputTag"));          
+  std::map<std::string, double> providedParameters;
+  providedParameters.insert(std::make_pair("LogWeighted", ps.getParameter<bool>("posCalc_logweight")));
+  providedParameters.insert(std::make_pair("T0_barl", ps.getParameter<double>("posCalc_t0")));
+  providedParameters.insert(std::make_pair("W0", ps.getParameter<double>("posCalc_w0")));
+  providedParameters.insert(std::make_pair("X0", ps.getParameter<double>("posCalc_x0")));
 
-        // the names of the products to be produced:
-        bcCollection_ = ps.getParameter<std::string>("bcCollection");
-        scCollection_ = ps.getParameter<std::string>("scCollection");
-        refScCollection_ = ps.getParameter<std::string>("refScCollection");
-
-        std::map<std::string,double> providedParameters;  
-        providedParameters.insert(std::make_pair("LogWeighted",ps.getParameter<bool>("posCalc_logweight")));
-        providedParameters.insert(std::make_pair("T0_barl",ps.getParameter<double>("posCalc_t0")));
-        providedParameters.insert(std::make_pair("W0",ps.getParameter<double>("posCalc_w0")));
-        providedParameters.insert(std::make_pair("X0",ps.getParameter<double>("posCalc_x0")));
-
-
-        // the products:
-        produces< reco::BasicClusterCollection >(bcCollection_);
-        produces< reco::SuperClusterCollection >(scCollection_);
-        produces< reco::SuperClusterRefVector >(refScCollection_);
-
+  // the products:
+  produces<reco::BasicClusterCollection>(bcCollection_);
+  produces<reco::SuperClusterCollection>(scCollection_);
+  produces<reco::SuperClusterRefVector>(refScCollection_);
 }
 
-CleanAndMergeProducer::~CleanAndMergeProducer() {;}
+CleanAndMergeProducer::~CleanAndMergeProducer() { ; }
 
-void CleanAndMergeProducer::produce(edm::Event& evt, 
-                                    const edm::EventSetup& es)
-{
-        // get the input collections
-        // ______________________________________________________________________________________
-        //
-        // cluster collections:
+void CleanAndMergeProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
+  // get the input collections
+  // ______________________________________________________________________________________
+  //
+  // cluster collections:
 
-        edm::Handle<reco::SuperClusterCollection> pCleanSC;
-        edm::Handle<reco::SuperClusterCollection> pUncleanSC;
+  edm::Handle<reco::SuperClusterCollection> pCleanSC;
+  edm::Handle<reco::SuperClusterCollection> pUncleanSC;
 
-        evt.getByToken(cleanScToken_, pCleanSC);
-        evt.getByToken(uncleanScToken_, pUncleanSC);
-    
-        //
-        // collections are all taken now _____________________________________________________
-        //
-        //
-        // the collections to be produced:
-        reco::BasicClusterCollection basicClusters;
-        reco::SuperClusterCollection superClusters;
-        reco::SuperClusterRefVector * scRefs = new reco::SuperClusterRefVector;
+  evt.getByToken(cleanScToken_, pCleanSC);
+  evt.getByToken(uncleanScToken_, pUncleanSC);
 
-        //
-        // run over the uncleaned SC and check how many of them are matched to the cleaned ones
-        // if you find a matched one, create a reference to the cleaned collection and store it
-        // if you find an unmatched one, then keep all its basic clusters in the basic Clusters 
-        // vector
-        int uncleanSize =  pUncleanSC->size();
-        int cleanSize =    pCleanSC->size();
+  //
+  // collections are all taken now _____________________________________________________
+  //
+  //
+  // the collections to be produced:
+  reco::BasicClusterCollection basicClusters;
+  reco::SuperClusterCollection superClusters;
+  reco::SuperClusterRefVector* scRefs = new reco::SuperClusterRefVector;
 
-        LogTrace("EcalCleaning") << "Size of Clean Collection: " << cleanSize 
-                << ", uncleanSize: " << uncleanSize  << std::endl;
-        //
-        // keep whether the SC in unique in the uncleaned collection
-        std::vector<int> isUncleanOnly;     // 1 if unique in the uncleaned
-        std::vector<int> basicClusterOwner; // contains the index of the SC that owns that BS
-        std::vector<int> isSeed; // if this basic cluster is a seed it is 1
-        for (int isc =0; isc< uncleanSize; ++isc) {
-	  reco::SuperClusterRef unscRef( pUncleanSC, isc );    
-	  const std::vector< std::pair<DetId, float> > & uhits = unscRef->hitsAndFractions();
-	  int uhitsSize = uhits.size();
-	  bool foundTheSame = false;
-	  for (int jsc=0; jsc < cleanSize; ++jsc) { // loop over the cleaned SC
-	    reco::SuperClusterRef cscRef( pCleanSC, jsc );
-	    const std::vector< std::pair<DetId, float> > & chits = cscRef->hitsAndFractions();
-	    int chitsSize =  chits.size();
-	    foundTheSame = true;
-	    if (unscRef->seed()->seed() == cscRef->seed()->seed() && chitsSize == uhitsSize) { 
-	      // if the clusters are exactly the same then because the clustering
-	      // algorithm works in a deterministic way, the order of the rechits
-	      // will be the same
-	      for (int i=0; i< chitsSize; ++i) {
-		if (uhits[i].first != chits[i].first ) { foundTheSame=false;  break;}
-	      }
-	      if (foundTheSame) { // ok you have found it!
-		// make the reference
-		//scRefs->push_back( edm::Ref<reco::SuperClusterCollection>(pCleanSC, jsc) );
-		scRefs->push_back( cscRef );
-		isUncleanOnly.push_back(0);
-		break;
-	      }
-	    }
-	  }
-	  if (not foundTheSame) {
-	    // mark it as unique in the uncleaned
-	    isUncleanOnly.push_back(1);
-	    // keep all its basic clusters
-	    for (reco::CaloCluster_iterator bciter = unscRef->clustersBegin(); bciter != unscRef->clustersEnd(); ++bciter) {
-	      // the basic clusters
-	      basicClusters.push_back(**bciter);
-	      basicClusterOwner.push_back(isc);
-	    }
-	  }
+  //
+  // run over the uncleaned SC and check how many of them are matched to the cleaned ones
+  // if you find a matched one, create a reference to the cleaned collection and store it
+  // if you find an unmatched one, then keep all its basic clusters in the basic Clusters
+  // vector
+  int uncleanSize = pUncleanSC->size();
+  int cleanSize = pCleanSC->size();
+
+  LogTrace("EcalCleaning") << "Size of Clean Collection: " << cleanSize << ", uncleanSize: " << uncleanSize
+                           << std::endl;
+  //
+  // keep whether the SC in unique in the uncleaned collection
+  std::vector<int> isUncleanOnly;      // 1 if unique in the uncleaned
+  std::vector<int> basicClusterOwner;  // contains the index of the SC that owns that BS
+  std::vector<int> isSeed;             // if this basic cluster is a seed it is 1
+  for (int isc = 0; isc < uncleanSize; ++isc) {
+    reco::SuperClusterRef unscRef(pUncleanSC, isc);
+    const std::vector<std::pair<DetId, float> >& uhits = unscRef->hitsAndFractions();
+    int uhitsSize = uhits.size();
+    bool foundTheSame = false;
+    for (int jsc = 0; jsc < cleanSize; ++jsc) {  // loop over the cleaned SC
+      reco::SuperClusterRef cscRef(pCleanSC, jsc);
+      const std::vector<std::pair<DetId, float> >& chits = cscRef->hitsAndFractions();
+      int chitsSize = chits.size();
+      foundTheSame = true;
+      if (unscRef->seed()->seed() == cscRef->seed()->seed() && chitsSize == uhitsSize) {
+        // if the clusters are exactly the same then because the clustering
+        // algorithm works in a deterministic way, the order of the rechits
+        // will be the same
+        for (int i = 0; i < chitsSize; ++i) {
+          if (uhits[i].first != chits[i].first) {
+            foundTheSame = false;
+            break;
+          }
         }
-        int bcSize =  basicClusters.size();
-	
-        LogDebug("EcalCleaning") << "Found cleaned SC: " << cleanSize <<  " uncleaned SC: " 
-                << uncleanSize << " from which " << scRefs->size() 
-                << " will become refs to the cleaned collection" ;
-     
-
-        // now you have the collection of basic clusters of the SC to be remain in the
-        // in the clean collection, export them to the event
-        // you will need to reread them later in order to make correctly the refs to the SC
-        auto basicClusters_p = std::make_unique<reco::BasicClusterCollection>();
-        basicClusters_p->assign(basicClusters.begin(), basicClusters.end());
-        edm::OrphanHandle<reco::BasicClusterCollection> bccHandle =  
-                evt.put(std::move(basicClusters_p), bcCollection_);
-        if (!(bccHandle.isValid())) {
-	  edm::LogWarning("MissingInput")<<"could not get a handle on the BasicClusterCollection!" << std::endl;
-	  return;
+        if (foundTheSame) {  // ok you have found it!
+          // make the reference
+          //scRefs->push_back( edm::Ref<reco::SuperClusterCollection>(pCleanSC, jsc) );
+          scRefs->push_back(cscRef);
+          isUncleanOnly.push_back(0);
+          break;
         }
+      }
+    }
+    if (not foundTheSame) {
+      // mark it as unique in the uncleaned
+      isUncleanOnly.push_back(1);
+      // keep all its basic clusters
+      for (reco::CaloCluster_iterator bciter = unscRef->clustersBegin(); bciter != unscRef->clustersEnd(); ++bciter) {
+        // the basic clusters
+        basicClusters.push_back(**bciter);
+        basicClusterOwner.push_back(isc);
+      }
+    }
+  }
+  int bcSize = basicClusters.size();
 
-        LogDebug("EcalCleaning")<< "Got the BasicClusters from the event again";
-        // now you have to create again your superclusters
-        // you run over the uncleaned SC, but now you know which of them are
-        // the ones that are needed and which are their basic clusters
-        for (int isc=0; isc< uncleanSize; ++isc) {
-	  if (isUncleanOnly[isc]==1) { // look for sc that are unique in the unclean collection
-	    // make the basic cluster collection
-	    reco::CaloClusterPtrVector clusterPtrVector;
-	    reco::CaloClusterPtr seed; // the seed is the basic cluster with the highest energy
-	    double energy = -1;
-	    for (int jbc=0; jbc< bcSize; ++jbc) {
-	      if (basicClusterOwner[jbc]==isc) {
-		reco::CaloClusterPtr currentClu = reco::CaloClusterPtr(bccHandle, jbc);
-		clusterPtrVector.push_back(currentClu);
-		if (energy< currentClu->energy()) {
-		  energy = currentClu->energy(); seed = currentClu;
-		}
-	      }
-	    }
-	    reco::SuperClusterRef unscRef( pUncleanSC, isc ); 
-	    reco::SuperCluster newSC(unscRef->energy(), unscRef->position(), seed, clusterPtrVector );
-	    superClusters.push_back(newSC);
-	  }
-	  
+  LogDebug("EcalCleaning") << "Found cleaned SC: " << cleanSize << " uncleaned SC: " << uncleanSize << " from which "
+                           << scRefs->size() << " will become refs to the cleaned collection";
+
+  // now you have the collection of basic clusters of the SC to be remain in the
+  // in the clean collection, export them to the event
+  // you will need to reread them later in order to make correctly the refs to the SC
+  auto basicClusters_p = std::make_unique<reco::BasicClusterCollection>();
+  basicClusters_p->assign(basicClusters.begin(), basicClusters.end());
+  edm::OrphanHandle<reco::BasicClusterCollection> bccHandle = evt.put(std::move(basicClusters_p), bcCollection_);
+  if (!(bccHandle.isValid())) {
+    edm::LogWarning("MissingInput") << "could not get a handle on the BasicClusterCollection!" << std::endl;
+    return;
+  }
+
+  LogDebug("EcalCleaning") << "Got the BasicClusters from the event again";
+  // now you have to create again your superclusters
+  // you run over the uncleaned SC, but now you know which of them are
+  // the ones that are needed and which are their basic clusters
+  for (int isc = 0; isc < uncleanSize; ++isc) {
+    if (isUncleanOnly[isc] == 1) {  // look for sc that are unique in the unclean collection
+      // make the basic cluster collection
+      reco::CaloClusterPtrVector clusterPtrVector;
+      reco::CaloClusterPtr seed;  // the seed is the basic cluster with the highest energy
+      double energy = -1;
+      for (int jbc = 0; jbc < bcSize; ++jbc) {
+        if (basicClusterOwner[jbc] == isc) {
+          reco::CaloClusterPtr currentClu = reco::CaloClusterPtr(bccHandle, jbc);
+          clusterPtrVector.push_back(currentClu);
+          if (energy < currentClu->energy()) {
+            energy = currentClu->energy();
+            seed = currentClu;
+          }
         }
-        // export the collection of references to the clean collection
-        std::unique_ptr<reco::SuperClusterRefVector> scRefs_p(scRefs);
-        evt.put(std::move(scRefs_p), refScCollection_);
+      }
+      reco::SuperClusterRef unscRef(pUncleanSC, isc);
+      reco::SuperCluster newSC(unscRef->energy(), unscRef->position(), seed, clusterPtrVector);
+      superClusters.push_back(newSC);
+    }
+  }
+  // export the collection of references to the clean collection
+  std::unique_ptr<reco::SuperClusterRefVector> scRefs_p(scRefs);
+  evt.put(std::move(scRefs_p), refScCollection_);
 
-        // the collection of basic clusters is already in the event
-        // the collection of uncleaned SC
-        auto superClusters_p = std::make_unique<reco::SuperClusterCollection>();
-        superClusters_p->assign(superClusters.begin(), superClusters.end());
-        evt.put(std::move(superClusters_p), scCollection_);
-        LogDebug("EcalCleaning")<< "Hybrid Clusters (Basic/Super) added to the Event! :-)";
+  // the collection of basic clusters is already in the event
+  // the collection of uncleaned SC
+  auto superClusters_p = std::make_unique<reco::SuperClusterCollection>();
+  superClusters_p->assign(superClusters.begin(), superClusters.end());
+  evt.put(std::move(superClusters_p), scCollection_);
+  LogDebug("EcalCleaning") << "Hybrid Clusters (Basic/Super) added to the Event! :-)";
 }

--- a/RecoEcal/EgammaClusterProducers/src/CosmicClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/CosmicClusterProducer.cc
@@ -36,41 +36,41 @@
 // Class header file
 #include "RecoEcal/EgammaClusterProducers/interface/CosmicClusterProducer.h"
 
-CosmicClusterProducer::CosmicClusterProducer(const edm::ParameterSet& ps)
-{
+CosmicClusterProducer::CosmicClusterProducer(const edm::ParameterSet& ps) {
   // The verbosity level
   std::string verbosityString = ps.getParameter<std::string>("VerbosityLevel");
-  if      (verbosityString == "DEBUG")   verbosity = CosmicClusterAlgo::pDEBUG;
-  else if (verbosityString == "WARNING") verbosity = CosmicClusterAlgo::pWARNING;
-  else if (verbosityString == "INFO")    verbosity = CosmicClusterAlgo::pINFO;
-  else                                   verbosity = CosmicClusterAlgo::pERROR;
+  if (verbosityString == "DEBUG")
+    verbosity = CosmicClusterAlgo::pDEBUG;
+  else if (verbosityString == "WARNING")
+    verbosity = CosmicClusterAlgo::pWARNING;
+  else if (verbosityString == "INFO")
+    verbosity = CosmicClusterAlgo::pINFO;
+  else
+    verbosity = CosmicClusterAlgo::pERROR;
 
-  
   // Parameters to identify the hit collections
-  ebHitsToken_    = consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("barrelHits"));
-  eeHitsToken_    = consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("endcapHits"));
-  
-  ebUHitsToken_    = consumes<EcalUncalibratedRecHitCollection>(ps.getParameter<edm::InputTag>("barrelUncalibHits"));
-  eeUHitsToken_    = consumes<EcalUncalibratedRecHitCollection>(ps.getParameter<edm::InputTag>("endcapUncalibHits"));
-  
+  ebHitsToken_ = consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("barrelHits"));
+  eeHitsToken_ = consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("endcapHits"));
+
+  ebUHitsToken_ = consumes<EcalUncalibratedRecHitCollection>(ps.getParameter<edm::InputTag>("barrelUncalibHits"));
+  eeUHitsToken_ = consumes<EcalUncalibratedRecHitCollection>(ps.getParameter<edm::InputTag>("endcapUncalibHits"));
 
   // The names of the produced cluster collections
-  barrelClusterCollection_  = ps.getParameter<std::string>("barrelClusterCollection");
-  endcapClusterCollection_  = ps.getParameter<std::string>("endcapClusterCollection");
+  barrelClusterCollection_ = ps.getParameter<std::string>("barrelClusterCollection");
+  endcapClusterCollection_ = ps.getParameter<std::string>("endcapClusterCollection");
 
   // Island algorithm parameters
-  double barrelSeedThreshold        = ps.getParameter<double>("BarrelSeedThr");
-  double barrelSingleThreshold      = ps.getParameter<double>("BarrelSingleThr");
-  double barrelSecondThreshold      = ps.getParameter<double>("BarrelSecondThr");
-  double barrelSupThreshold         = ps.getParameter<double>("BarrelSupThr");
-  double endcapSeedThreshold        = ps.getParameter<double>("EndcapSeedThr");
-  double endcapSingleThreshold      = ps.getParameter<double>("EndcapSingleThr");
-  double endcapSecondThreshold      = ps.getParameter<double>("EndcapSecondThr");
-  double endcapSupThreshold         = ps.getParameter<double>("EndcapSupThr");
+  double barrelSeedThreshold = ps.getParameter<double>("BarrelSeedThr");
+  double barrelSingleThreshold = ps.getParameter<double>("BarrelSingleThr");
+  double barrelSecondThreshold = ps.getParameter<double>("BarrelSecondThr");
+  double barrelSupThreshold = ps.getParameter<double>("BarrelSupThr");
+  double endcapSeedThreshold = ps.getParameter<double>("EndcapSeedThr");
+  double endcapSingleThreshold = ps.getParameter<double>("EndcapSingleThr");
+  double endcapSecondThreshold = ps.getParameter<double>("EndcapSecondThr");
+  double endcapSupThreshold = ps.getParameter<double>("EndcapSupThr");
 
   // Parameters for the position calculation:
-  edm::ParameterSet posCalcParameters = 
-    ps.getParameter<edm::ParameterSet>("posCalcParameters");
+  edm::ParameterSet posCalcParameters = ps.getParameter<edm::ParameterSet>("posCalcParameters");
 
   posCalculator_ = PositionCalc(posCalcParameters);
   shapeAlgo_ = ClusterShapeAlgo(posCalcParameters);
@@ -84,112 +84,122 @@ CosmicClusterProducer::CosmicClusterProducer(const edm::ParameterSet& ps)
 
   // Produces a collection of barrel and a collection of endcap clusters
 
-  produces< reco::ClusterShapeCollection>(clustershapecollectionEE_);
-  produces< reco::BasicClusterCollection >(endcapClusterCollection_);
-  produces< reco::ClusterShapeCollection>(clustershapecollectionEB_);
-  produces< reco::BasicClusterCollection >(barrelClusterCollection_);
-  produces< reco::BasicClusterShapeAssociationCollection >(barrelClusterShapeAssociation_);
-  produces< reco::BasicClusterShapeAssociationCollection >(endcapClusterShapeAssociation_);
+  produces<reco::ClusterShapeCollection>(clustershapecollectionEE_);
+  produces<reco::BasicClusterCollection>(endcapClusterCollection_);
+  produces<reco::ClusterShapeCollection>(clustershapecollectionEB_);
+  produces<reco::BasicClusterCollection>(barrelClusterCollection_);
+  produces<reco::BasicClusterShapeAssociationCollection>(barrelClusterShapeAssociation_);
+  produces<reco::BasicClusterShapeAssociationCollection>(endcapClusterShapeAssociation_);
 
-  island_p = new CosmicClusterAlgo(barrelSeedThreshold, barrelSingleThreshold, barrelSecondThreshold, barrelSupThreshold, endcapSeedThreshold, endcapSingleThreshold, endcapSecondThreshold, endcapSupThreshold, posCalculator_,verbosity);
+  island_p = new CosmicClusterAlgo(barrelSeedThreshold,
+                                   barrelSingleThreshold,
+                                   barrelSecondThreshold,
+                                   barrelSupThreshold,
+                                   endcapSeedThreshold,
+                                   endcapSingleThreshold,
+                                   endcapSecondThreshold,
+                                   endcapSupThreshold,
+                                   posCalculator_,
+                                   verbosity);
 
   nEvt_ = 0;
 }
 
+CosmicClusterProducer::~CosmicClusterProducer() { delete island_p; }
 
-CosmicClusterProducer::~CosmicClusterProducer()
-{
-  delete island_p;
-}
- 
-
-void CosmicClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
-  clusterizeECALPart(evt, es, eeHitsToken_,eeUHitsToken_, endcapClusterCollection_, endcapClusterShapeAssociation_, CosmicClusterAlgo::endcap); 
-  clusterizeECALPart(evt, es, eeHitsToken_,eeUHitsToken_, barrelClusterCollection_, barrelClusterShapeAssociation_, CosmicClusterAlgo::barrel);
+void CosmicClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
+  clusterizeECALPart(evt,
+                     es,
+                     eeHitsToken_,
+                     eeUHitsToken_,
+                     endcapClusterCollection_,
+                     endcapClusterShapeAssociation_,
+                     CosmicClusterAlgo::endcap);
+  clusterizeECALPart(evt,
+                     es,
+                     eeHitsToken_,
+                     eeUHitsToken_,
+                     barrelClusterCollection_,
+                     barrelClusterShapeAssociation_,
+                     CosmicClusterAlgo::barrel);
   nEvt_++;
 }
 
-
-
-
-void CosmicClusterProducer::clusterizeECALPart(edm::Event &evt, const edm::EventSetup &es,
+void CosmicClusterProducer::clusterizeECALPart(edm::Event& evt,
+                                               const edm::EventSetup& es,
                                                const edm::EDGetTokenT<EcalRecHitCollection>& hitsToken,
-                                               const edm::EDGetTokenT<EcalUncalibratedRecHitCollection>& uhitsToken,             
+                                               const edm::EDGetTokenT<EcalUncalibratedRecHitCollection>& uhitsToken,
                                                const std::string& clusterCollection,
-					       const std::string& clusterShapeAssociation,
-                                               const CosmicClusterAlgo::EcalPart& ecalPart)
-{
+                                               const std::string& clusterShapeAssociation,
+                                               const CosmicClusterAlgo::EcalPart& ecalPart) {
   // get the hit collection from the event:
 
   edm::Handle<EcalRecHitCollection> hits_h;
   edm::Handle<EcalUncalibratedRecHitCollection> uhits_h;
-  
-  evt.getByToken(hitsToken,hits_h);
-  evt.getByToken(uhitsToken,uhits_h);
 
-  const EcalRecHitCollection *hitCollection_p = hits_h.product();
-  const EcalUncalibratedRecHitCollection *uhitCollection_p = uhits_h.product();
+  evt.getByToken(hitsToken, hits_h);
+  evt.getByToken(uhitsToken, uhits_h);
+
+  const EcalRecHitCollection* hitCollection_p = hits_h.product();
+  const EcalUncalibratedRecHitCollection* uhitCollection_p = uhits_h.product();
 
   // get the geometry and topology from the event setup:
   edm::ESHandle<CaloGeometry> geoHandle;
   es.get<CaloGeometryRecord>().get(geoHandle);
 
-  const CaloSubdetectorGeometry *geometry_p;
+  const CaloSubdetectorGeometry* geometry_p;
   std::unique_ptr<CaloSubdetectorTopology> topology_p;
 
   std::string clustershapetag;
-  if (ecalPart == CosmicClusterAlgo::barrel) 
-    {
-      geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-      topology_p = std::make_unique<EcalBarrelTopology>(*geoHandle);
-    }
-  else
-    {
-      geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-      topology_p = std::make_unique<EcalEndcapTopology>(*geoHandle);
-   }
+  if (ecalPart == CosmicClusterAlgo::barrel) {
+    geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
+    topology_p = std::make_unique<EcalBarrelTopology>(*geoHandle);
+  } else {
+    geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
+    topology_p = std::make_unique<EcalEndcapTopology>(*geoHandle);
+  }
 
-  const CaloSubdetectorGeometry *geometryES_p;
-  geometryES_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower); 
-  
+  const CaloSubdetectorGeometry* geometryES_p;
+  geometryES_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
+
   // Run the clusterization algorithm:
   reco::BasicClusterCollection clusters;
-  clusters = island_p->makeClusters(hitCollection_p, uhitCollection_p, geometry_p, topology_p.get(), geometryES_p,  ecalPart);
-  
+  clusters =
+      island_p->makeClusters(hitCollection_p, uhitCollection_p, geometry_p, topology_p.get(), geometryES_p, ecalPart);
+
   //Create associated ClusterShape objects.
-  std::vector <reco::ClusterShape> ClusVec;
- 
-  for (int erg=0;erg<int(clusters.size());++erg){
-    reco::ClusterShape TestShape = shapeAlgo_.Calculate(clusters[erg],hitCollection_p,geometry_p,topology_p.get());
+  std::vector<reco::ClusterShape> ClusVec;
+
+  for (int erg = 0; erg < int(clusters.size()); ++erg) {
+    reco::ClusterShape TestShape = shapeAlgo_.Calculate(clusters[erg], hitCollection_p, geometry_p, topology_p.get());
     ClusVec.push_back(TestShape);
   }
-  
+
   //Put clustershapes in event, but retain a Handle on them.
   auto clustersshapes_p = std::make_unique<reco::ClusterShapeCollection>();
   clustersshapes_p->assign(ClusVec.begin(), ClusVec.end());
-  edm::OrphanHandle<reco::ClusterShapeCollection> clusHandle; 
-  if (ecalPart == CosmicClusterAlgo::barrel) 
-    clusHandle= evt.put(std::move(clustersshapes_p), clustershapecollectionEB_);
+  edm::OrphanHandle<reco::ClusterShapeCollection> clusHandle;
+  if (ecalPart == CosmicClusterAlgo::barrel)
+    clusHandle = evt.put(std::move(clustersshapes_p), clustershapecollectionEB_);
   else
-    clusHandle= evt.put(std::move(clustersshapes_p), clustershapecollectionEE_);
-  
+    clusHandle = evt.put(std::move(clustersshapes_p), clustershapecollectionEE_);
+
   // create a unique_ptr to a BasicClusterCollection, copy the barrel clusters into it and put in the Event:
   auto clusters_p = std::make_unique<reco::BasicClusterCollection>();
   clusters_p->assign(clusters.begin(), clusters.end());
   edm::OrphanHandle<reco::BasicClusterCollection> bccHandle;
-  
-  if (ecalPart == CosmicClusterAlgo::barrel) 
+
+  if (ecalPart == CosmicClusterAlgo::barrel)
     bccHandle = evt.put(std::move(clusters_p), barrelClusterCollection_);
   else
     bccHandle = evt.put(std::move(clusters_p), endcapClusterCollection_);
 
-  
-  // BasicClusterShapeAssociationMap 
+  // BasicClusterShapeAssociationMap
   auto shapeAssocs_p = std::make_unique<reco::BasicClusterShapeAssociationCollection>(bccHandle, clusHandle);
 
-  for (unsigned int i = 0; i < clusHandle->size(); i++){
-    shapeAssocs_p->insert(edm::Ref<reco::BasicClusterCollection>(bccHandle,i),edm::Ref<reco::ClusterShapeCollection>(clusHandle,i));
-  }  
-  evt.put(std::move(shapeAssocs_p),clusterShapeAssociation);
+  for (unsigned int i = 0; i < clusHandle->size(); i++) {
+    shapeAssocs_p->insert(edm::Ref<reco::BasicClusterCollection>(bccHandle, i),
+                          edm::Ref<reco::ClusterShapeCollection>(clusHandle, i));
+  }
+  evt.put(std::move(shapeAssocs_p), clusterShapeAssociation);
 }

--- a/RecoEcal/EgammaClusterProducers/src/EcalDigiSelector.cc
+++ b/RecoEcal/EgammaClusterProducers/src/EcalDigiSelector.cc
@@ -18,215 +18,193 @@
 #include <iostream>
 #include <set>
 
-
 using namespace reco;
-EcalDigiSelector::EcalDigiSelector(const edm::ParameterSet& ps)
-{
+EcalDigiSelector::EcalDigiSelector(const edm::ParameterSet& ps) {
   selectedEcalEBDigiCollection_ = ps.getParameter<std::string>("selectedEcalEBDigiCollection");
   selectedEcalEEDigiCollection_ = ps.getParameter<std::string>("selectedEcalEEDigiCollection");
 
-  barrelSuperClusterProducer_ = 
-	  consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("barrelSuperClusterProducer"));
-  endcapSuperClusterProducer_ = 
-	  consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("endcapSuperClusterProducer"));
+  barrelSuperClusterProducer_ =
+      consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("barrelSuperClusterProducer"));
+  endcapSuperClusterProducer_ =
+      consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("endcapSuperClusterProducer"));
 
-  
-  EcalEBRecHitToken_ = 
-	  consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("EcalEBRecHitTag"));
-  EcalEERecHitToken_ = 
-	  consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("EcalEERecHitTag"));
+  EcalEBRecHitToken_ = consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("EcalEBRecHitTag"));
+  EcalEERecHitToken_ = consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("EcalEERecHitTag"));
 
-  EcalEBDigiToken_ = 
-	  consumes<EBDigiCollection>(ps.getParameter<edm::InputTag>("EcalEBDigiTag"));
-  EcalEEDigiToken_ = 
-	  consumes<EEDigiCollection>(ps.getParameter<edm::InputTag>("EcalEEDigiTag"));
-  
+  EcalEBDigiToken_ = consumes<EBDigiCollection>(ps.getParameter<edm::InputTag>("EcalEBDigiTag"));
+  EcalEEDigiToken_ = consumes<EEDigiCollection>(ps.getParameter<edm::InputTag>("EcalEEDigiTag"));
+
   cluster_pt_thresh_ = ps.getParameter<double>("cluster_pt_thresh");
   single_cluster_thresh_ = ps.getParameter<double>("single_cluster_thresh");
 
   nclus_sel_ = ps.getParameter<int>("nclus_sel");
   produces<EBDigiCollection>(selectedEcalEBDigiCollection_);
   produces<EEDigiCollection>(selectedEcalEEDigiCollection_);
-
 }
-  
-void EcalDigiSelector::produce(edm::Event& evt, const edm::EventSetup& es)
-{
-  
+
+void EcalDigiSelector::produce(edm::Event& evt, const edm::EventSetup& es) {
   //Get BarrelSuperClusters to start.
   edm::Handle<reco::SuperClusterCollection> pBarrelSuperClusters;
-  
+
   evt.getByToken(barrelSuperClusterProducer_, pBarrelSuperClusters);
 
-  const reco::SuperClusterCollection & BarrelSuperClusters = *pBarrelSuperClusters;
+  const reco::SuperClusterCollection& BarrelSuperClusters = *pBarrelSuperClusters;
   //Got BarrelSuperClusters
 
   //Get BarrelSuperClusters to start.
   edm::Handle<reco::SuperClusterCollection> pEndcapSuperClusters;
-  
+
   evt.getByToken(endcapSuperClusterProducer_, pEndcapSuperClusters);
 
-  const reco::SuperClusterCollection & EndcapSuperClusters = *pEndcapSuperClusters;
+  const reco::SuperClusterCollection& EndcapSuperClusters = *pEndcapSuperClusters;
   //Got EndcapSuperClusters
 
   reco::SuperClusterCollection saveBarrelSuperClusters;
   reco::SuperClusterCollection saveEndcapSuperClusters;
   bool meet_single_thresh = false;
   //Loop over barrel superclusters, and apply threshold
-  for (int loop=0;loop<int(BarrelSuperClusters.size());loop++){
+  for (int loop = 0; loop < int(BarrelSuperClusters.size()); loop++) {
     SuperCluster clus1 = BarrelSuperClusters[loop];
     float eta1 = clus1.eta();
     float energy1 = clus1.energy();
-    float theta1 = 2*atan(exp(-1.*eta1));
+    float theta1 = 2 * atan(exp(-1. * eta1));
     float cluspt1 = energy1 * sin(theta1);
-    if (cluspt1 > cluster_pt_thresh_){
+    if (cluspt1 > cluster_pt_thresh_) {
       saveBarrelSuperClusters.push_back(clus1);
       if (cluspt1 > single_cluster_thresh_)
-	meet_single_thresh = true;
-      
+        meet_single_thresh = true;
     }
   }
 
   //Loop over endcap superclusters, and apply threshold
-  for (int loop=0;loop<int(EndcapSuperClusters.size());loop++){
+  for (int loop = 0; loop < int(EndcapSuperClusters.size()); loop++) {
     SuperCluster clus1 = EndcapSuperClusters[loop];
     float eta1 = clus1.eta();
     float energy1 = clus1.energy();
-    float theta1 = 2*atan(exp(-1.*eta1));
+    float theta1 = 2 * atan(exp(-1. * eta1));
     float cluspt1 = energy1 * sin(theta1);
-    if (cluspt1 > cluster_pt_thresh_){
+    if (cluspt1 > cluster_pt_thresh_) {
       saveEndcapSuperClusters.push_back(clus1);
       if (cluspt1 > single_cluster_thresh_)
-	meet_single_thresh = true;
+        meet_single_thresh = true;
     }
   }
-  
+
   auto SEBDigiCol = std::make_unique<EBDigiCollection>();
   auto SEEDigiCol = std::make_unique<EEDigiCollection>();
   int TotClus = saveBarrelSuperClusters.size() + saveEndcapSuperClusters.size();
 
-  if (TotClus >= nclus_sel_ || meet_single_thresh){
-	
-    if (!saveBarrelSuperClusters.empty()){
-      
-		
-	  edm::ESHandle<CaloTopology> pTopology;
+  if (TotClus >= nclus_sel_ || meet_single_thresh) {
+    if (!saveBarrelSuperClusters.empty()) {
+      edm::ESHandle<CaloTopology> pTopology;
       es.get<CaloTopologyRecord>().get(pTopology);
-      const CaloTopology *topology = pTopology.product();	
+      const CaloTopology* topology = pTopology.product();
 
       //get barrel digi collection
       edm::Handle<EBDigiCollection> pdigis;
-      const EBDigiCollection* digis=nullptr;
-      evt.getByToken(EcalEBDigiToken_,pdigis);
-      digis = pdigis.product(); // get a ptr to the product
+      const EBDigiCollection* digis = nullptr;
+      evt.getByToken(EcalEBDigiToken_, pdigis);
+      digis = pdigis.product();  // get a ptr to the product
 
-	  edm::Handle<EcalRecHitCollection> prechits;
-      const EcalRecHitCollection* rechits=nullptr;
-      evt.getByToken(EcalEBRecHitToken_,prechits);
-      rechits = prechits.product(); // get a ptr to the product
+      edm::Handle<EcalRecHitCollection> prechits;
+      const EcalRecHitCollection* rechits = nullptr;
+      evt.getByToken(EcalEBRecHitToken_, prechits);
+      rechits = prechits.product();  // get a ptr to the product
 
+      if (digis) {
+        std::vector<DetId> saveTheseDetIds;
+        //pick out the detids for the 3x3 in each of the selected superclusters
+        for (int loop = 0; loop < int(saveBarrelSuperClusters.size()); loop++) {
+          SuperCluster clus1 = saveBarrelSuperClusters[loop];
+          const CaloClusterPtr& bcref = clus1.seed();
+          const BasicCluster* bc = bcref.get();
+          //Get the maximum detid
+          DetId maxDetId = EcalClusterTools::getMaximum(*bc, rechits).first;
+          // Loop over the 3x3 array centered on maximum detid
+          for (DetId detId : CaloRectangleRange(1, maxDetId, *topology))
+            saveTheseDetIds.push_back(detId);
+        }
+        for (int detloop = 0; detloop < int(saveTheseDetIds.size()); ++detloop) {
+          EBDetId detL = EBDetId(saveTheseDetIds[detloop]);
 
-      if ( digis ) {
-         std::vector<DetId> saveTheseDetIds;
-         //pick out the detids for the 3x3 in each of the selected superclusters
-         for (int loop = 0;loop < int(saveBarrelSuperClusters.size());loop++){
-           SuperCluster clus1 = saveBarrelSuperClusters[loop];
-           const CaloClusterPtr& bcref = clus1.seed();
-           const BasicCluster *bc = bcref.get();
-           //Get the maximum detid
-           DetId maxDetId = EcalClusterTools::getMaximum(*bc,rechits).first;
-           // Loop over the 3x3 array centered on maximum detid
-           for(DetId detId : CaloRectangleRange(1, maxDetId, *topology)) saveTheseDetIds.push_back(detId);
-           
-         }
-         for (int detloop=0; detloop < int(saveTheseDetIds.size());++detloop){
-         	EBDetId detL = EBDetId(saveTheseDetIds[detloop]);
-           
-           for (EBDigiCollection::const_iterator blah = digis->begin();
-                blah!=digis->end();blah++){
-             
-             if (detL == blah->id()){
-               EBDataFrame myDigi = (*blah);
-               SEBDigiCol->push_back(detL);
-           
-               EBDataFrame df( SEBDigiCol->back());
-               for (int iq =0;iq<myDigi.size();++iq){
-                 df.setSample(iq, myDigi.sample(iq).raw());
-               }
-               //ebcounter++;
-             } 
-           }
-           //if (ebcounter >= int(saveTheseDetIds.size())) break;
-         }//loop over dets
-    
+          for (EBDigiCollection::const_iterator blah = digis->begin(); blah != digis->end(); blah++) {
+            if (detL == blah->id()) {
+              EBDataFrame myDigi = (*blah);
+              SEBDigiCol->push_back(detL);
+
+              EBDataFrame df(SEBDigiCol->back());
+              for (int iq = 0; iq < myDigi.size(); ++iq) {
+                df.setSample(iq, myDigi.sample(iq).raw());
+              }
+              //ebcounter++;
+            }
+          }
+          //if (ebcounter >= int(saveTheseDetIds.size())) break;
+        }  //loop over dets
       }
 
-    }//If barrel superclusters need saving.
-    
-    
-    if (!saveEndcapSuperClusters.empty()){
- 
+    }  //If barrel superclusters need saving.
+
+    if (!saveEndcapSuperClusters.empty()) {
       edm::ESHandle<CaloTopology> pTopology;
       es.get<CaloTopologyRecord>().get(pTopology);
-      const CaloTopology *topology = pTopology.product();	
+      const CaloTopology* topology = pTopology.product();
 
       //Get endcap rec hit collection
       //get endcap digi collection
       edm::Handle<EEDigiCollection> pdigis;
-      const EEDigiCollection* digis=nullptr;
-      evt.getByToken(EcalEEDigiToken_,pdigis);
-      digis = pdigis.product(); // get a ptr to the product
-  
+      const EEDigiCollection* digis = nullptr;
+      evt.getByToken(EcalEEDigiToken_, pdigis);
+      digis = pdigis.product();  // get a ptr to the product
+
       edm::Handle<EcalRecHitCollection> prechits;
-      const EcalRecHitCollection* rechits=nullptr;
-      evt.getByToken(EcalEERecHitToken_,prechits);
-      rechits = prechits.product(); // get a ptr to the product
+      const EcalRecHitCollection* rechits = nullptr;
+      evt.getByToken(EcalEERecHitToken_, prechits);
+      rechits = prechits.product();  // get a ptr to the product
 
-      if ( digis ) {
-         //std::vector<DetId> saveTheseDetIds;
-         std::set<DetId> saveTheseDetIds;
-         //pick out the digis for the 3x3 in each of the selected superclusters
-         for (int loop = 0;loop < int(saveEndcapSuperClusters.size());loop++){
-           SuperCluster clus1 = saveEndcapSuperClusters[loop];
-           const CaloClusterPtr& bcref = clus1.seed();
-           const BasicCluster *bc = bcref.get();
-           //Get the maximum detid
-           DetId maxDetId = EcalClusterTools::getMaximum(*bc,rechits).first;
-           // Loop over the 3x3 array centered on maximum detid
-           for(DetId detId : CaloRectangleRange(1, maxDetId, *topology)) saveTheseDetIds.insert(detId);
-         }
-         int eecounter=0;
-         for (EEDigiCollection::const_iterator blah = digis->begin();
-              blah!=digis->end();blah++){
-           std::set<DetId>::const_iterator finder = saveTheseDetIds.find(blah->id());
-           if (finder!=saveTheseDetIds.end()){
-             EEDetId detL = EEDetId(*finder);
+      if (digis) {
+        //std::vector<DetId> saveTheseDetIds;
+        std::set<DetId> saveTheseDetIds;
+        //pick out the digis for the 3x3 in each of the selected superclusters
+        for (int loop = 0; loop < int(saveEndcapSuperClusters.size()); loop++) {
+          SuperCluster clus1 = saveEndcapSuperClusters[loop];
+          const CaloClusterPtr& bcref = clus1.seed();
+          const BasicCluster* bc = bcref.get();
+          //Get the maximum detid
+          DetId maxDetId = EcalClusterTools::getMaximum(*bc, rechits).first;
+          // Loop over the 3x3 array centered on maximum detid
+          for (DetId detId : CaloRectangleRange(1, maxDetId, *topology))
+            saveTheseDetIds.insert(detId);
+        }
+        int eecounter = 0;
+        for (EEDigiCollection::const_iterator blah = digis->begin(); blah != digis->end(); blah++) {
+          std::set<DetId>::const_iterator finder = saveTheseDetIds.find(blah->id());
+          if (finder != saveTheseDetIds.end()) {
+            EEDetId detL = EEDetId(*finder);
 
-             if (detL == blah->id()){
-               EEDataFrame myDigi = (*blah);
-               SEEDigiCol->push_back(detL);
-               EEDataFrame df( SEEDigiCol->back());
-               for (int iq =0;iq<myDigi.size();++iq){
-                 df.setSample(iq, myDigi.sample(iq).raw());	      
-               }
-               eecounter++;
-               
-             }
-           }
-           if (eecounter >= int(saveTheseDetIds.size())) break;
-         }//loop over digis
+            if (detL == blah->id()) {
+              EEDataFrame myDigi = (*blah);
+              SEEDigiCol->push_back(detL);
+              EEDataFrame df(SEEDigiCol->back());
+              for (int iq = 0; iq < myDigi.size(); ++iq) {
+                df.setSample(iq, myDigi.sample(iq).raw());
+              }
+              eecounter++;
+            }
+          }
+          if (eecounter >= int(saveTheseDetIds.size()))
+            break;
+        }  //loop over digis
       }
-    }//If endcap superclusters need saving.
-    
-  }//If we're actually saving stuff
-  
+    }  //If endcap superclusters need saving.
+
+  }  //If we're actually saving stuff
+
   //Okay, either my collections have been filled with the requisite Digis, or they haven't.
-  
 
   //Empty collection, or full, still put in event.
   SEBDigiCol->sort();
   SEEDigiCol->sort();
   evt.put(std::move(SEBDigiCol), selectedEcalEBDigiCollection_);
   evt.put(std::move(SEEDigiCol), selectedEcalEEDigiCollection_);
-  
 }

--- a/RecoEcal/EgammaClusterProducers/src/EgammaSCCorrectionMaker.cc
+++ b/RecoEcal/EgammaClusterProducers/src/EgammaSCCorrectionMaker.cc
@@ -14,17 +14,14 @@
 #include "Geometry/CaloTopology/interface/EcalEndcapTopology.h"
 #include "Geometry/CaloTopology/interface/EcalPreshowerTopology.h"
 
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h" 
-#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h" 
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
 
 #include <string>
 
-EgammaSCCorrectionMaker::EgammaSCCorrectionMaker(const edm::ParameterSet& ps)
-{
- 
-
+EgammaSCCorrectionMaker::EgammaSCCorrectionMaker(const edm::ParameterSet& ps) {
   // the input producers
-  rHTag_ = 	 ps.getParameter<edm::InputTag>("recHitProducer");
+  rHTag_ = ps.getParameter<edm::InputTag>("recHitProducer");
   rHInputProducer_ = consumes<EcalRecHitCollection>(rHTag_);
   sCInputProducer_ = consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("rawSuperClusterProducer"));
   std::string sCAlgo_str = ps.getParameter<std::string>("superClusterAlgo");
@@ -32,45 +29,45 @@ EgammaSCCorrectionMaker::EgammaSCCorrectionMaker(const edm::ParameterSet& ps)
   // determine which BasicCluster algo we are correcting for
   //And obtain forrection parameters form cfg file
   edm::ParameterSet fCorrPset;
-  if (sCAlgo_str=="Hybrid") {
-    sCAlgo_= reco::CaloCluster::hybrid;
-    fCorrPset = ps.getParameter<edm::ParameterSet>("hyb_fCorrPset"); 
-  } else if (sCAlgo_str=="Island") {
-    sCAlgo_= reco::CaloCluster::island;
+  if (sCAlgo_str == "Hybrid") {
+    sCAlgo_ = reco::CaloCluster::hybrid;
+    fCorrPset = ps.getParameter<edm::ParameterSet>("hyb_fCorrPset");
+  } else if (sCAlgo_str == "Island") {
+    sCAlgo_ = reco::CaloCluster::island;
     fCorrPset = ps.getParameter<edm::ParameterSet>("isl_fCorrPset");
-  } else if (sCAlgo_str=="DynamicHybrid") {
+  } else if (sCAlgo_str == "DynamicHybrid") {
     sCAlgo_ = reco::CaloCluster::dynamicHybrid;
-    fCorrPset = ps.getParameter<edm::ParameterSet>("dyn_fCorrPset"); 
-  } else if (sCAlgo_str=="Multi5x5") {
+    fCorrPset = ps.getParameter<edm::ParameterSet>("dyn_fCorrPset");
+  } else if (sCAlgo_str == "Multi5x5") {
     sCAlgo_ = reco::CaloCluster::multi5x5;
     fCorrPset = ps.getParameter<edm::ParameterSet>("fix_fCorrPset");
   } else {
-    edm::LogError("EgammaSCCorrectionMakerError") 
-      << "Error! SuperClusterAlgo in config file must be Hybrid or Island: " 
-      << sCAlgo_str << "  Using Hybrid by default";
-    sCAlgo_=reco::CaloCluster::hybrid;
+    edm::LogError("EgammaSCCorrectionMakerError")
+        << "Error! SuperClusterAlgo in config file must be Hybrid or Island: " << sCAlgo_str
+        << "  Using Hybrid by default";
+    sCAlgo_ = reco::CaloCluster::hybrid;
   }
-  
+
   // set correction algo parameters
   applyEnergyCorrection_ = ps.getParameter<bool>("applyEnergyCorrection");
-  applyCrackCorrection_  = ps.getParameter<bool>("applyCrackCorrection");
-  applyLocalContCorrection_= ps.existsAs<bool>("applyLocalContCorrection") ?  
-    ps.getParameter<bool>("applyLocalContCorrection") : false;
+  applyCrackCorrection_ = ps.getParameter<bool>("applyCrackCorrection");
+  applyLocalContCorrection_ =
+      ps.existsAs<bool>("applyLocalContCorrection") ? ps.getParameter<bool>("applyLocalContCorrection") : false;
 
   energyCorrectorName_ = ps.getParameter<std::string>("energyCorrectorName");
-  crackCorrectorName_  = ps.existsAs<std::string>("crackCorrectorName") ?  
-    ps.getParameter<std::string>("crackCorrectorName") : std::string("EcalClusterCrackCorrection");
-  localContCorrectorName_= ps.existsAs<std::string>("localContCorrectorName") ? 
-    ps.getParameter<std::string>("localContCorrectorName") : std::string("EcalBasicClusterLocalContCorrection") ;
+  crackCorrectorName_ = ps.existsAs<std::string>("crackCorrectorName")
+                            ? ps.getParameter<std::string>("crackCorrectorName")
+                            : std::string("EcalClusterCrackCorrection");
+  localContCorrectorName_ = ps.existsAs<std::string>("localContCorrectorName")
+                                ? ps.getParameter<std::string>("localContCorrectorName")
+                                : std::string("EcalBasicClusterLocalContCorrection");
 
-  modeEB_ =  ps.getParameter<int>("modeEB");
-  modeEE_ =  ps.getParameter<int>("modeEE");
+  modeEB_ = ps.getParameter<int>("modeEB");
+  modeEE_ = ps.getParameter<int>("modeEE");
 
-  sigmaElectronicNoise_ =  ps.getParameter<double>("sigmaElectronicNoise");
+  sigmaElectronicNoise_ = ps.getParameter<double>("sigmaElectronicNoise");
 
-  etThresh_ =  ps.getParameter<double>("etThresh");
-
-
+  etThresh_ = ps.getParameter<double>("etThresh");
 
   // set the producer parameters
   outputCollection_ = ps.getParameter<std::string>("corectedSuperClusterCollection");
@@ -78,109 +75,108 @@ EgammaSCCorrectionMaker::EgammaSCCorrectionMaker(const edm::ParameterSet& ps)
 
   // instanciate the correction algo object
   energyCorrector_ = std::make_unique<EgammaSCEnergyCorrectionAlgo>(sigmaElectronicNoise_, sCAlgo_, fCorrPset);
-  
+
   // energy correction class
-  if (applyEnergyCorrection_ )
-    energyCorrectionFunction_ = std::unique_ptr<EcalClusterFunctionBaseClass>(EcalClusterFunctionFactory::get()->create(energyCorrectorName_, ps));
-    //energyCorrectionFunction_ = EcalClusterFunctionFactory::get()->create("EcalClusterEnergyCorrection", ps);
+  if (applyEnergyCorrection_)
+    energyCorrectionFunction_ = std::unique_ptr<EcalClusterFunctionBaseClass>(
+        EcalClusterFunctionFactory::get()->create(energyCorrectorName_, ps));
+  //energyCorrectionFunction_ = EcalClusterFunctionFactory::get()->create("EcalClusterEnergyCorrection", ps);
 
-  if (applyCrackCorrection_ )
-    crackCorrectionFunction_ = std::unique_ptr<EcalClusterFunctionBaseClass>(EcalClusterFunctionFactory::get()->create(crackCorrectorName_, ps));
+  if (applyCrackCorrection_)
+    crackCorrectionFunction_ = std::unique_ptr<EcalClusterFunctionBaseClass>(
+        EcalClusterFunctionFactory::get()->create(crackCorrectorName_, ps));
 
-
-  if (applyLocalContCorrection_ )
-    localContCorrectionFunction_ = std::unique_ptr<EcalClusterFunctionBaseClass>(EcalClusterFunctionFactory::get()->create(localContCorrectorName_, ps));
-
+  if (applyLocalContCorrection_)
+    localContCorrectionFunction_ = std::unique_ptr<EcalClusterFunctionBaseClass>(
+        EcalClusterFunctionFactory::get()->create(localContCorrectorName_, ps));
 }
 
 EgammaSCCorrectionMaker::~EgammaSCCorrectionMaker() = default;
 
-void
-EgammaSCCorrectionMaker::produce(edm::Event& evt, const edm::EventSetup& es)
-{
+void EgammaSCCorrectionMaker::produce(edm::Event& evt, const edm::EventSetup& es) {
   using namespace edm;
 
   // initialize energy correction class
-  if(applyEnergyCorrection_) 
+  if (applyEnergyCorrection_)
     energyCorrectionFunction_->init(es);
 
   // initialize energy correction class
-  if(applyCrackCorrection_) 
+  if (applyCrackCorrection_)
     crackCorrectionFunction_->init(es);
-  
 
   // initialize containemnt correction class
-  if(applyLocalContCorrection_) 
+  if (applyLocalContCorrection_)
     localContCorrectionFunction_->init(es);
 
   // get the collection geometry:
   edm::ESHandle<CaloGeometry> geoHandle;
   es.get<CaloGeometryRecord>().get(geoHandle);
   const CaloGeometry& geometry = *geoHandle;
-  const CaloSubdetectorGeometry *geometry_p;
+  const CaloSubdetectorGeometry* geometry_p;
 
   std::string rHInputCollection = rHTag_.instance();
-  if(rHInputCollection == "EcalRecHitsEB") {
+  if (rHInputCollection == "EcalRecHitsEB") {
     geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-  } else if(rHInputCollection == "EcalRecHitsEE") {
+  } else if (rHInputCollection == "EcalRecHitsEE") {
     geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-  } else if(rHInputCollection == "EcalRecHitsPS") {
+  } else if (rHInputCollection == "EcalRecHitsPS") {
     geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
   } else {
-          std::string str = "\n\nSCCorrectionMaker encountered invalied ecalhitcollection type: " + rHInputCollection + ".\n\n";
-          throw(std::runtime_error( str.c_str() ));
+    std::string str =
+        "\n\nSCCorrectionMaker encountered invalied ecalhitcollection type: " + rHInputCollection + ".\n\n";
+    throw(std::runtime_error(str.c_str()));
   }
-  
-  // Get raw SuperClusters from the event    
+
+  // Get raw SuperClusters from the event
   Handle<reco::SuperClusterCollection> pRawSuperClusters;
   evt.getByToken(sCInputProducer_, pRawSuperClusters);
-  
+
   // Get the RecHits from the event
   Handle<EcalRecHitCollection> pRecHits;
   evt.getByToken(rHInputProducer_, pRecHits);
-  
+
   // Create a pointer to the RecHits and raw SuperClusters
-  const EcalRecHitCollection *hitCollection = pRecHits.product();
-  const reco::SuperClusterCollection *rawClusters = pRawSuperClusters.product();
-   
+  const EcalRecHitCollection* hitCollection = pRecHits.product();
+  const reco::SuperClusterCollection* rawClusters = pRawSuperClusters.product();
+
   // Define a collection of corrected SuperClusters to put back into the event
   auto corrClusters = std::make_unique<reco::SuperClusterCollection>();
-  
+
   //  Loop over raw clusters and make corrected ones
   reco::SuperClusterCollection::const_iterator aClus;
-  int i=0;
-  for(aClus = rawClusters->begin(); aClus != rawClusters->end(); aClus++)
-    {
-      reco::SuperCluster enecorrClus,crackcorrClus,localContCorrClus;
- 
-      i++;
+  int i = 0;
+  for (aClus = rawClusters->begin(); aClus != rawClusters->end(); aClus++) {
+    reco::SuperCluster enecorrClus, crackcorrClus, localContCorrClus;
 
-      if(applyEnergyCorrection_) 
-        enecorrClus = energyCorrector_->applyCorrection(*aClus, *hitCollection, sCAlgo_, geometry_p, energyCorrectionFunction_.get(), energyCorrectorName_, modeEB_, modeEE_);
-      else
-	enecorrClus=*aClus;
+    i++;
 
+    if (applyEnergyCorrection_)
+      enecorrClus = energyCorrector_->applyCorrection(*aClus,
+                                                      *hitCollection,
+                                                      sCAlgo_,
+                                                      geometry_p,
+                                                      energyCorrectionFunction_.get(),
+                                                      energyCorrectorName_,
+                                                      modeEB_,
+                                                      modeEE_);
+    else
+      enecorrClus = *aClus;
 
-      if(applyCrackCorrection_)
-	crackcorrClus=energyCorrector_->applyCrackCorrection(enecorrClus,crackCorrectionFunction_.get());
-      else 
-	crackcorrClus=enecorrClus;
+    if (applyCrackCorrection_)
+      crackcorrClus = energyCorrector_->applyCrackCorrection(enecorrClus, crackCorrectionFunction_.get());
+    else
+      crackcorrClus = enecorrClus;
 
-      if (applyLocalContCorrection_)
-	localContCorrClus = 
-	  energyCorrector_->applyLocalContCorrection(crackcorrClus,localContCorrectionFunction_.get());
-      else
-	localContCorrClus = crackcorrClus;
-      
+    if (applyLocalContCorrection_)
+      localContCorrClus = energyCorrector_->applyLocalContCorrection(crackcorrClus, localContCorrectionFunction_.get());
+    else
+      localContCorrClus = crackcorrClus;
 
-      if(localContCorrClus.energy()*sin(localContCorrClus.position().theta())>etThresh_) {
-	
-	corrClusters->push_back(localContCorrClus);
-      }
+    if (localContCorrClus.energy() * sin(localContCorrClus.position().theta()) > etThresh_) {
+      corrClusters->push_back(localContCorrClus);
     }
+  }
 
   // Put collection of corrected SuperClusters into the event
-  evt.put(std::move(corrClusters), outputCollection_);   
-  
+  evt.put(std::move(corrClusters), outputCollection_);
 }
-

--- a/RecoEcal/EgammaClusterProducers/src/HybridClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/HybridClusterProducer.cc
@@ -35,140 +35,120 @@
 #include "RecoEcal/EgammaClusterProducers/interface/HybridClusterProducer.h"
 #include "RecoEcal/EgammaCoreTools/interface/PositionCalc.h"
 
- 
-
-HybridClusterProducer::HybridClusterProducer(const edm::ParameterSet& ps)
-{
-
-
+HybridClusterProducer::HybridClusterProducer(const edm::ParameterSet& ps) {
   basicclusterCollection_ = ps.getParameter<std::string>("basicclusterCollection");
   superclusterCollection_ = ps.getParameter<std::string>("superclusterCollection");
-  hitsToken_              = 
-    consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("recHitsCollection"));
-   
-  //Setup for core tools objects. 
-  edm::ParameterSet posCalcParameters = 
-    ps.getParameter<edm::ParameterSet>("posCalcParameters");
+  hitsToken_ = consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("recHitsCollection"));
+
+  //Setup for core tools objects.
+  edm::ParameterSet posCalcParameters = ps.getParameter<edm::ParameterSet>("posCalcParameters");
 
   posCalculator_ = PositionCalc(posCalcParameters);
 
-  const std::vector<std::string> flagnames = 
-    ps.getParameter<std::vector<std::string> >("RecHitFlagToBeExcluded");
+  const std::vector<std::string> flagnames = ps.getParameter<std::vector<std::string> >("RecHitFlagToBeExcluded");
 
-  const std::vector<int> flagsexcl= 
-    StringToEnumValue<EcalRecHit::Flags>(flagnames);
+  const std::vector<int> flagsexcl = StringToEnumValue<EcalRecHit::Flags>(flagnames);
 
-  const std::vector<std::string> severitynames = 
-    ps.getParameter<std::vector<std::string> >("RecHitSeverityToBeExcluded");
+  const std::vector<std::string> severitynames =
+      ps.getParameter<std::vector<std::string> >("RecHitSeverityToBeExcluded");
 
-  const std::vector<int> severitiesexcl= 
-    StringToEnumValue<EcalSeverityLevel::SeverityLevel>(severitynames);
+  const std::vector<int> severitiesexcl = StringToEnumValue<EcalSeverityLevel::SeverityLevel>(severitynames);
 
-  hybrid_p = new HybridClusterAlgo(ps.getParameter<double>("HybridBarrelSeedThr"), 
+  hybrid_p = new HybridClusterAlgo(ps.getParameter<double>("HybridBarrelSeedThr"),
                                    ps.getParameter<int>("step"),
                                    ps.getParameter<double>("ethresh"),
                                    ps.getParameter<double>("eseed"),
                                    ps.getParameter<double>("xi"),
                                    ps.getParameter<bool>("useEtForXi"),
                                    ps.getParameter<double>("ewing"),
-				   flagsexcl,
+                                   flagsexcl,
                                    posCalculator_,
-			           ps.getParameter<bool>("dynamicEThresh"),
+                                   ps.getParameter<bool>("dynamicEThresh"),
                                    ps.getParameter<double>("eThreshA"),
                                    ps.getParameter<double>("eThreshB"),
-				   severitiesexcl,
-				   ps.getParameter<bool>("excludeFlagged")
-                                   );
-                                   //bremRecoveryPset,
+                                   severitiesexcl,
+                                   ps.getParameter<bool>("excludeFlagged"));
+  //bremRecoveryPset,
 
   // get brem recovery parameters
   bool dynamicPhiRoad = ps.getParameter<bool>("dynamicPhiRoad");
   if (dynamicPhiRoad) {
-     edm::ParameterSet bremRecoveryPset = ps.getParameter<edm::ParameterSet>("bremRecoveryPset");
-     hybrid_p->setDynamicPhiRoad(bremRecoveryPset);
+    edm::ParameterSet bremRecoveryPset = ps.getParameter<edm::ParameterSet>("bremRecoveryPset");
+    hybrid_p->setDynamicPhiRoad(bremRecoveryPset);
   }
 
-  produces< reco::BasicClusterCollection >(basicclusterCollection_);
-  produces< reco::SuperClusterCollection >(superclusterCollection_);
+  produces<reco::BasicClusterCollection>(basicclusterCollection_);
+  produces<reco::SuperClusterCollection>(superclusterCollection_);
   nEvt_ = 0;
 }
 
+HybridClusterProducer::~HybridClusterProducer() { delete hybrid_p; }
 
-HybridClusterProducer::~HybridClusterProducer()
-{
-  delete hybrid_p;
-}
-
-
-void HybridClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
+void HybridClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   // get the hit collection from the event:
   edm::Handle<EcalRecHitCollection> rhcHandle;
- 
+
   evt.getByToken(hitsToken_, rhcHandle);
-  if (!(rhcHandle.isValid())){
+  if (!(rhcHandle.isValid())) {
     edm::LogError("MissingProduct") << "could not get a handle on the EcalRecHitCollection!";
     return;
-
   }
-  const EcalRecHitCollection *hit_collection = rhcHandle.product();
+  const EcalRecHitCollection* hit_collection = rhcHandle.product();
 
   // get the collection geometry:
   edm::ESHandle<CaloGeometry> geoHandle;
   es.get<CaloGeometryRecord>().get(geoHandle);
   const CaloGeometry& geometry = *geoHandle;
-  const CaloSubdetectorGeometry *geometry_p;
+  const CaloSubdetectorGeometry* geometry_p;
   std::unique_ptr<const CaloSubdetectorTopology> topology;
 
   edm::ESHandle<EcalSeverityLevelAlgo> sevLv;
   es.get<EcalSeverityLevelAlgoRcd>().get(sevLv);
- 
+
   geometry_p = geometry.getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
   topology = std::make_unique<EcalBarrelTopology>(*geoHandle);
 
   // make the Basic clusters!
   reco::BasicClusterCollection basicClusters;
-  hybrid_p->makeClusters(hit_collection, geometry_p, basicClusters, sevLv.product(),false,
-			 std::vector<RectangularEtaPhiRegion>());
+  hybrid_p->makeClusters(
+      hit_collection, geometry_p, basicClusters, sevLv.product(), false, std::vector<RectangularEtaPhiRegion>());
 
-  LogTrace("EcalClusters") << "Finished clustering - BasicClusterCollection returned to producer..." ;
+  LogTrace("EcalClusters") << "Finished clustering - BasicClusterCollection returned to producer...";
 
   // create a unique_ptr to a BasicClusterCollection, copy the clusters into it and put in the Event:
   auto basicclusters_p = std::make_unique<reco::BasicClusterCollection>();
   basicclusters_p->assign(basicClusters.begin(), basicClusters.end());
-  edm::OrphanHandle<reco::BasicClusterCollection> bccHandle =  evt.put(std::move(basicclusters_p),basicclusterCollection_);
-								       
+  edm::OrphanHandle<reco::BasicClusterCollection> bccHandle =
+      evt.put(std::move(basicclusters_p), basicclusterCollection_);
+
   //Basic clusters now in the event.
-  LogTrace("EcalClusters") << "Basic Clusters now put into event." ;
-  
-  
+  LogTrace("EcalClusters") << "Basic Clusters now put into event.";
+
   //Weird though it is, get the BasicClusters back out of the event.  We need the
   //edm::Ref to these guys to make our superclusters for Hybrid.
 
   if (!(bccHandle.isValid())) {
-    edm::LogError("Missing Product") << "could not get a handle on the BasicClusterCollection!" ;
+    edm::LogError("Missing Product") << "could not get a handle on the BasicClusterCollection!";
     return;
   }
- 
+
   reco::BasicClusterCollection clusterCollection = *bccHandle;
-  
-  LogTrace("EcalClusters")<< "Got the BasicClusterCollection" << std::endl;
+
+  LogTrace("EcalClusters") << "Got the BasicClusterCollection" << std::endl;
 
   reco::CaloClusterPtrVector clusterPtrVector;
-  for (unsigned int i = 0; i < clusterCollection.size(); i++){
+  for (unsigned int i = 0; i < clusterCollection.size(); i++) {
     clusterPtrVector.push_back(reco::CaloClusterPtr(bccHandle, i));
   }
 
   reco::SuperClusterCollection superClusters = hybrid_p->makeSuperClusters(clusterPtrVector);
-  LogTrace("EcalClusters") << "Found: " << superClusters.size() << " superclusters." ;
+  LogTrace("EcalClusters") << "Found: " << superClusters.size() << " superclusters.";
 
   auto superclusters_p = std::make_unique<reco::SuperClusterCollection>();
   superclusters_p->assign(superClusters.begin(), superClusters.end());
-  
-  evt.put(std::move(superclusters_p), superclusterCollection_);
-  LogTrace("EcalClusters") << "Hybrid Clusters (Basic/Super) added to the Event! :-)" ;
 
-  
+  evt.put(std::move(superclusters_p), superclusterCollection_);
+  LogTrace("EcalClusters") << "Hybrid Clusters (Basic/Super) added to the Event! :-)";
+
   nEvt_++;
 }
-

--- a/RecoEcal/EgammaClusterProducers/src/InterestingDetIdCollectionProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/InterestingDetIdCollectionProducer.cc
@@ -4,7 +4,6 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 
@@ -19,36 +18,30 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalTools.h"
 
-
-InterestingDetIdCollectionProducer::InterestingDetIdCollectionProducer(const edm::ParameterSet& iConfig) 
-{
-
-  recHitsToken_ = 
-	  consumes<EcalRecHitCollection>(iConfig.getParameter< edm::InputTag > ("recHitsLabel"));
-  basicClustersToken_ = 
-	  consumes<reco::BasicClusterCollection>(iConfig.getParameter< edm::InputTag >("basicClustersLabel"));
+InterestingDetIdCollectionProducer::InterestingDetIdCollectionProducer(const edm::ParameterSet& iConfig) {
+  recHitsToken_ = consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitsLabel"));
+  basicClustersToken_ =
+      consumes<reco::BasicClusterCollection>(iConfig.getParameter<edm::InputTag>("basicClustersLabel"));
 
   interestingDetIdCollection_ = iConfig.getParameter<std::string>("interestingDetIdCollection");
-  
-  minimalEtaSize_ = iConfig.getParameter<int> ("etaSize");
-  minimalPhiSize_ = iConfig.getParameter<int> ("phiSize");
-  if ( minimalPhiSize_ % 2 == 0 ||  minimalEtaSize_ % 2 == 0)
-    edm::LogError("InterestingDetIdCollectionProducerError") << "Size of eta/phi should be odd numbers";
- 
-   //register your products
-  produces< DetIdCollection > (interestingDetIdCollection_) ;
 
-  severityLevel_  = iConfig.getParameter<int>("severityLevel");
+  minimalEtaSize_ = iConfig.getParameter<int>("etaSize");
+  minimalPhiSize_ = iConfig.getParameter<int>("phiSize");
+  if (minimalPhiSize_ % 2 == 0 || minimalEtaSize_ % 2 == 0)
+    edm::LogError("InterestingDetIdCollectionProducerError") << "Size of eta/phi should be odd numbers";
+
+  //register your products
+  produces<DetIdCollection>(interestingDetIdCollection_);
+
+  severityLevel_ = iConfig.getParameter<int>("severityLevel");
   keepNextToDead_ = iConfig.getParameter<bool>("keepNextToDead");
   keepNextToBoundary_ = iConfig.getParameter<bool>("keepNextToBoundary");
 }
 
-
-void InterestingDetIdCollectionProducer::beginRun (edm::Run const& run, const edm::EventSetup & iSetup)  
-{
+void InterestingDetIdCollectionProducer::beginRun(edm::Run const& run, const edm::EventSetup& iSetup) {
   edm::ESHandle<CaloTopology> theCaloTopology;
   iSetup.get<CaloTopologyRecord>().get(theCaloTopology);
-  caloTopology_ = &(*theCaloTopology); 
+  caloTopology_ = &(*theCaloTopology);
 
   edm::ESHandle<EcalSeverityLevelAlgo> sevLv;
   iSetup.get<EcalSeverityLevelAlgoRcd>().get(sevLv);
@@ -56,20 +49,17 @@ void InterestingDetIdCollectionProducer::beginRun (edm::Run const& run, const ed
 }
 
 // ------------ method called to produce the data  ------------
-void
-InterestingDetIdCollectionProducer::produce (edm::Event& iEvent, 
-                                const edm::EventSetup& iSetup)
-{
-   using namespace edm;
-   using namespace std;
+void InterestingDetIdCollectionProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  using namespace std;
 
-   // take BasicClusters
+  // take BasicClusters
   Handle<reco::BasicClusterCollection> pClusters;
   iEvent.getByToken(basicClustersToken_, pClusters);
-  
+
   // take EcalRecHits
   Handle<EcalRecHitCollection> recHitsHandle;
-  iEvent.getByToken(recHitsToken_,recHitsHandle);
+  iEvent.getByToken(recHitsToken_, recHitsHandle);
 
   //Create empty output collections
   std::vector<DetId> indexToStore;
@@ -79,87 +69,76 @@ InterestingDetIdCollectionProducer::produce (edm::Event& iEvent,
 
   std::vector<DetId> xtalsToStore;
   xtalsToStore.reserve(50);
-  for (clusIt=pClusters->begin(); clusIt!=pClusters->end(); clusIt++) {
-    const std::vector<std::pair<DetId,float> > &clusterDetIds = clusIt->hitsAndFractions();
-    for (const auto &detidpair : clusterDetIds) {
+  for (clusIt = pClusters->begin(); clusIt != pClusters->end(); clusIt++) {
+    const std::vector<std::pair<DetId, float> >& clusterDetIds = clusIt->hitsAndFractions();
+    for (const auto& detidpair : clusterDetIds) {
       indexToStore.push_back(detidpair.first);
     }
-    
+
     //below checks and additional code are only relevant for EB/EE, not for ES
-    if (clusterDetIds.front().first.subdetId()==EcalBarrel || clusterDetIds.front().first.subdetId()==EcalEndcap) {
-      std::vector<std::pair<DetId,float> >::const_iterator posCurrent;
-      
-      float eMax=0.;
-      DetId eMaxId(0);        
+    if (clusterDetIds.front().first.subdetId() == EcalBarrel || clusterDetIds.front().first.subdetId() == EcalEndcap) {
+      std::vector<std::pair<DetId, float> >::const_iterator posCurrent;
+
+      float eMax = 0.;
+      DetId eMaxId(0);
 
       EcalRecHit testEcalRecHit;
-      
-      for(posCurrent = clusterDetIds.begin(); posCurrent != clusterDetIds.end(); posCurrent++)
-        {
-          EcalRecHitCollection::const_iterator itt = recHitsHandle->find((*posCurrent).first);
-          if ((!((*posCurrent).first.null())) && (itt != recHitsHandle->end()) && ((*itt).energy() > eMax) )
-            {
-              eMax = (*itt).energy();
-              eMaxId = (*itt).id();
-            }
-        }
-      
-      if (eMaxId.null())
-      continue;
-      
-      const CaloSubdetectorTopology* topology  = caloTopology_->getSubdetectorTopology(eMaxId.det(),eMaxId.subdetId());
 
-      xtalsToStore=topology->getWindow(eMaxId,minimalEtaSize_,minimalPhiSize_);
-      
-      for (const auto &detid : xtalsToStore) {
+      for (posCurrent = clusterDetIds.begin(); posCurrent != clusterDetIds.end(); posCurrent++) {
+        EcalRecHitCollection::const_iterator itt = recHitsHandle->find((*posCurrent).first);
+        if ((!((*posCurrent).first.null())) && (itt != recHitsHandle->end()) && ((*itt).energy() > eMax)) {
+          eMax = (*itt).energy();
+          eMaxId = (*itt).id();
+        }
+      }
+
+      if (eMaxId.null())
+        continue;
+
+      const CaloSubdetectorTopology* topology = caloTopology_->getSubdetectorTopology(eMaxId.det(), eMaxId.subdetId());
+
+      xtalsToStore = topology->getWindow(eMaxId, minimalEtaSize_, minimalPhiSize_);
+
+      for (const auto& detid : xtalsToStore) {
         indexToStore.push_back(detid);
       }
-      
     }
   }
 
-
-  if (severityLevel_>=0 || keepNextToDead_ || keepNextToBoundary_) {
+  if (severityLevel_ >= 0 || keepNextToDead_ || keepNextToBoundary_) {
     for (EcalRecHitCollection::const_iterator it = recHitsHandle->begin(); it != recHitsHandle->end(); ++it) {
       // also add recHits of dead TT if the corresponding TP is saturated
-      if ( it->checkFlag(EcalRecHit::kTPSaturated) ) {
+      if (it->checkFlag(EcalRecHit::kTPSaturated)) {
         indexToStore.push_back(it->id());
       }
       // add hits for severities above a threshold
-      if ( severityLevel_>=0 && 
-          severity_->severityLevel(*it) >=severityLevel_){
-        
+      if (severityLevel_ >= 0 && severity_->severityLevel(*it) >= severityLevel_) {
         indexToStore.push_back(it->id());
-      } 
+      }
       if (keepNextToDead_) {
         // also keep channels next to dead ones
         if (EcalTools::isNextToDead(it->id(), iSetup)) {
           indexToStore.push_back(it->id());
         }
-      } 
+      }
 
-      if (keepNextToBoundary_){
+      if (keepNextToBoundary_) {
         // keep channels around EB/EE boundary
-        if (it->id().subdetId() == EcalBarrel){
+        if (it->id().subdetId() == EcalBarrel) {
           EBDetId ebid(it->id());
-          if (abs(ebid.ieta())== 85)
+          if (abs(ebid.ieta()) == 85)
             indexToStore.push_back(it->id());
         } else {
-      
           if (EEDetId::isNextToRingBoundary(it->id()))
             indexToStore.push_back(it->id());
         }
-
       }
-      
     }
   }
 
   //unify the vector
-  std::sort(indexToStore.begin(),indexToStore.end());
-  std::unique(indexToStore.begin(),indexToStore.end());
-  
- 
-  iEvent.put(std::make_unique<DetIdCollection>(indexToStore), interestingDetIdCollection_);
+  std::sort(indexToStore.begin(), indexToStore.end());
+  std::unique(indexToStore.begin(), indexToStore.end());
 
+  iEvent.put(std::make_unique<DetIdCollection>(indexToStore), interestingDetIdCollection_);
 }

--- a/RecoEcal/EgammaClusterProducers/src/InterestingDetIdFromSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/InterestingDetIdFromSuperClusterProducer.cc
@@ -4,7 +4,6 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 
@@ -19,36 +18,30 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalTools.h"
 
-
-InterestingDetIdFromSuperClusterProducer::InterestingDetIdFromSuperClusterProducer(const edm::ParameterSet& iConfig) 
-{
-
-  recHitsToken_ = 
-	  consumes<EcalRecHitCollection>(iConfig.getParameter< edm::InputTag > ("recHitsLabel"));
-  superClustersToken_ = 
-	  consumes<reco::SuperClusterCollection>(iConfig.getParameter< edm::InputTag >("superClustersLabel"));
+InterestingDetIdFromSuperClusterProducer::InterestingDetIdFromSuperClusterProducer(const edm::ParameterSet& iConfig) {
+  recHitsToken_ = consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitsLabel"));
+  superClustersToken_ =
+      consumes<reco::SuperClusterCollection>(iConfig.getParameter<edm::InputTag>("superClustersLabel"));
 
   interestingDetIdCollection_ = iConfig.getParameter<std::string>("interestingDetIdCollection");
-  
-  minimalEtaSize_ = iConfig.getParameter<int> ("etaSize");
-  minimalPhiSize_ = iConfig.getParameter<int> ("phiSize");
-  if ( minimalPhiSize_ % 2 == 0 ||  minimalEtaSize_ % 2 == 0)
-    edm::LogError("InterestingDetIdFromSuperClusterProducerError") << "Size of eta/phi should be odd numbers";
- 
-   //register your products
-  produces< DetIdCollection > (interestingDetIdCollection_) ;
 
-  severityLevel_  = iConfig.getParameter<int>("severityLevel");
+  minimalEtaSize_ = iConfig.getParameter<int>("etaSize");
+  minimalPhiSize_ = iConfig.getParameter<int>("phiSize");
+  if (minimalPhiSize_ % 2 == 0 || minimalEtaSize_ % 2 == 0)
+    edm::LogError("InterestingDetIdFromSuperClusterProducerError") << "Size of eta/phi should be odd numbers";
+
+  //register your products
+  produces<DetIdCollection>(interestingDetIdCollection_);
+
+  severityLevel_ = iConfig.getParameter<int>("severityLevel");
   keepNextToDead_ = iConfig.getParameter<bool>("keepNextToDead");
   keepNextToBoundary_ = iConfig.getParameter<bool>("keepNextToBoundary");
 }
 
-
-void InterestingDetIdFromSuperClusterProducer::beginRun (edm::Run const& run, const edm::EventSetup & iSetup)  
-{
+void InterestingDetIdFromSuperClusterProducer::beginRun(edm::Run const& run, const edm::EventSetup& iSetup) {
   edm::ESHandle<CaloTopology> theCaloTopology;
   iSetup.get<CaloTopologyRecord>().get(theCaloTopology);
-  caloTopology_ = &(*theCaloTopology); 
+  caloTopology_ = &(*theCaloTopology);
 
   edm::ESHandle<EcalSeverityLevelAlgo> sevLv;
   iSetup.get<EcalSeverityLevelAlgoRcd>().get(sevLv);
@@ -56,20 +49,17 @@ void InterestingDetIdFromSuperClusterProducer::beginRun (edm::Run const& run, co
 }
 
 // ------------ method called to produce the data  ------------
-void
-InterestingDetIdFromSuperClusterProducer::produce (edm::Event& iEvent, 
-                                const edm::EventSetup& iSetup)
-{
-   using namespace edm;
-   using namespace std;
+void InterestingDetIdFromSuperClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  using namespace std;
 
-   // take BasicClusters
+  // take BasicClusters
   Handle<reco::SuperClusterCollection> pClusters;
   iEvent.getByToken(superClustersToken_, pClusters);
-  
+
   // take EcalRecHits
   Handle<EcalRecHitCollection> recHitsHandle;
-  iEvent.getByToken(recHitsToken_,recHitsHandle);
+  iEvent.getByToken(recHitsToken_, recHitsHandle);
 
   //Create empty output collections
   std::vector<DetId> indexToStore;
@@ -79,91 +69,79 @@ InterestingDetIdFromSuperClusterProducer::produce (edm::Event& iEvent,
 
   std::vector<DetId> xtalsToStore;
   xtalsToStore.reserve(50);
-  
+
   //loop over superclusters
-  for (sclusIt=pClusters->begin(); sclusIt!=pClusters->end(); sclusIt++) {
+  for (sclusIt = pClusters->begin(); sclusIt != pClusters->end(); sclusIt++) {
     //loop over subclusters
-    for (reco::CaloCluster_iterator clusIt = sclusIt->clustersBegin(); clusIt!=sclusIt->clustersEnd(); ++clusIt) {   
+    for (reco::CaloCluster_iterator clusIt = sclusIt->clustersBegin(); clusIt != sclusIt->clustersEnd(); ++clusIt) {
       //PG barrel
-      
-      float eMax=0.;
+
+      float eMax = 0.;
       DetId eMaxId(0);
 
-      std::vector<std::pair<DetId,float> > clusterDetIds = (*clusIt)->hitsAndFractions();
-      std::vector<std::pair<DetId,float> >::iterator posCurrent;
+      std::vector<std::pair<DetId, float> > clusterDetIds = (*clusIt)->hitsAndFractions();
+      std::vector<std::pair<DetId, float> >::iterator posCurrent;
 
       EcalRecHit testEcalRecHit;
-      
-      for(posCurrent = clusterDetIds.begin(); posCurrent != clusterDetIds.end(); posCurrent++)
-        {
-          EcalRecHitCollection::const_iterator itt = recHitsHandle->find((*posCurrent).first);
-          if ((!((*posCurrent).first.null())) && (itt != recHitsHandle->end()) && ((*itt).energy() > eMax) )
-            {
-              eMax = (*itt).energy();
-              eMaxId = (*itt).id();
-            }
-        }
-      
-      if (eMaxId.null())
-      continue;
-      
-      const CaloSubdetectorTopology* topology  = caloTopology_->getSubdetectorTopology(eMaxId.det(),eMaxId.subdetId());
 
-      xtalsToStore=topology->getWindow(eMaxId,minimalEtaSize_,minimalPhiSize_);
-      std::vector<std::pair<DetId,float > > xtalsInClus=(*clusIt)->hitsAndFractions();
-      
-      for (unsigned int ii=0;ii<xtalsInClus.size();ii++)
-        {
-            xtalsToStore.push_back(xtalsInClus[ii].first);
+      for (posCurrent = clusterDetIds.begin(); posCurrent != clusterDetIds.end(); posCurrent++) {
+        EcalRecHitCollection::const_iterator itt = recHitsHandle->find((*posCurrent).first);
+        if ((!((*posCurrent).first.null())) && (itt != recHitsHandle->end()) && ((*itt).energy() > eMax)) {
+          eMax = (*itt).energy();
+          eMaxId = (*itt).id();
         }
-      
-      indexToStore.insert(indexToStore.end(),xtalsToStore.begin(),xtalsToStore.end());
+      }
+
+      if (eMaxId.null())
+        continue;
+
+      const CaloSubdetectorTopology* topology = caloTopology_->getSubdetectorTopology(eMaxId.det(), eMaxId.subdetId());
+
+      xtalsToStore = topology->getWindow(eMaxId, minimalEtaSize_, minimalPhiSize_);
+      std::vector<std::pair<DetId, float> > xtalsInClus = (*clusIt)->hitsAndFractions();
+
+      for (unsigned int ii = 0; ii < xtalsInClus.size(); ii++) {
+        xtalsToStore.push_back(xtalsInClus[ii].first);
+      }
+
+      indexToStore.insert(indexToStore.end(), xtalsToStore.begin(), xtalsToStore.end());
     }
   }
 
-
- 
   for (EcalRecHitCollection::const_iterator it = recHitsHandle->begin(); it != recHitsHandle->end(); ++it) {
     // also add recHits of dead TT if the corresponding TP is saturated
-    if ( it->checkFlag(EcalRecHit::kTPSaturated) ) {
+    if (it->checkFlag(EcalRecHit::kTPSaturated)) {
       indexToStore.push_back(it->id());
     }
     // add hits for severities above a threshold
-    if ( severityLevel_>=0 && 
-	 severity_->severityLevel(*it) >=severityLevel_){
-      
+    if (severityLevel_ >= 0 && severity_->severityLevel(*it) >= severityLevel_) {
       indexToStore.push_back(it->id());
-    } 
+    }
     if (keepNextToDead_) {
       // also keep channels next to dead ones
       if (EcalTools::isNextToDead(it->id(), iSetup)) {
-	indexToStore.push_back(it->id());
+        indexToStore.push_back(it->id());
       }
-    } 
-
-    if (keepNextToBoundary_){
-      // keep channels around EB/EE boundary
-      if (it->id().subdetId() == EcalBarrel){
-	EBDetId ebid(it->id());
-	if (abs(ebid.ieta())== 85)
-	  indexToStore.push_back(it->id());
-      } else {
-     
-	if (EEDetId::isNextToRingBoundary(it->id()))
-	  indexToStore.push_back(it->id());
-      }
-
     }
-    
+
+    if (keepNextToBoundary_) {
+      // keep channels around EB/EE boundary
+      if (it->id().subdetId() == EcalBarrel) {
+        EBDetId ebid(it->id());
+        if (abs(ebid.ieta()) == 85)
+          indexToStore.push_back(it->id());
+      } else {
+        if (EEDetId::isNextToRingBoundary(it->id()))
+          indexToStore.push_back(it->id());
+      }
+    }
   }
 
   //unify the vector
-  std::sort(indexToStore.begin(),indexToStore.end());
-  std::unique(indexToStore.begin(),indexToStore.end());
-  
+  std::sort(indexToStore.begin(), indexToStore.end());
+  std::unique(indexToStore.begin(), indexToStore.end());
+
   auto detIdCollection = std::make_unique<DetIdCollection>(indexToStore);
 
- 
-  iEvent.put(std::move(detIdCollection), interestingDetIdCollection_ );
-
+  iEvent.put(std::move(detIdCollection), interestingDetIdCollection_);
 }

--- a/RecoEcal/EgammaClusterProducers/src/IslandClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/IslandClusterProducer.cc
@@ -37,33 +37,32 @@
 // Class header file
 #include "RecoEcal/EgammaClusterProducers/interface/IslandClusterProducer.h"
 
-
-IslandClusterProducer::IslandClusterProducer(const edm::ParameterSet& ps)
-{
+IslandClusterProducer::IslandClusterProducer(const edm::ParameterSet& ps) {
   // The verbosity level
   std::string verbosityString = ps.getParameter<std::string>("VerbosityLevel");
-  if      (verbosityString == "DEBUG")   verbosity = IslandClusterAlgo::pDEBUG;
-  else if (verbosityString == "WARNING") verbosity = IslandClusterAlgo::pWARNING;
-  else if (verbosityString == "INFO")    verbosity = IslandClusterAlgo::pINFO;
-  else                                   verbosity = IslandClusterAlgo::pERROR;
+  if (verbosityString == "DEBUG")
+    verbosity = IslandClusterAlgo::pDEBUG;
+  else if (verbosityString == "WARNING")
+    verbosity = IslandClusterAlgo::pWARNING;
+  else if (verbosityString == "INFO")
+    verbosity = IslandClusterAlgo::pINFO;
+  else
+    verbosity = IslandClusterAlgo::pERROR;
 
   // Parameters to identify the hit collections
-  barrelRecHits_   = 
-	  consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("barrelHits"));
-  endcapRecHits_   = 
-	  consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("endcapHits"));
+  barrelRecHits_ = consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("barrelHits"));
+  endcapRecHits_ = consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("endcapHits"));
 
   // The names of the produced cluster collections
-  barrelClusterCollection_  = ps.getParameter<std::string>("barrelClusterCollection");
-  endcapClusterCollection_  = ps.getParameter<std::string>("endcapClusterCollection");
+  barrelClusterCollection_ = ps.getParameter<std::string>("barrelClusterCollection");
+  endcapClusterCollection_ = ps.getParameter<std::string>("endcapClusterCollection");
 
   // Island algorithm parameters
   double barrelSeedThreshold = ps.getParameter<double>("IslandBarrelSeedThr");
   double endcapSeedThreshold = ps.getParameter<double>("IslandEndcapSeedThr");
 
   // Parameters for the position calculation:
-   edm::ParameterSet posCalcParameters = 
-    ps.getParameter<edm::ParameterSet>("posCalcParameters");
+  edm::ParameterSet posCalcParameters = ps.getParameter<edm::ParameterSet>("posCalcParameters");
   posCalculator_ = PositionCalc(posCalcParameters);
   shapeAlgo_ = ClusterShapeAlgo(posCalcParameters);
 
@@ -74,40 +73,44 @@ IslandClusterProducer::IslandClusterProducer(const edm::ParameterSet& ps)
   barrelClusterShapeAssociation_ = ps.getParameter<std::string>("barrelShapeAssociation");
   endcapClusterShapeAssociation_ = ps.getParameter<std::string>("endcapShapeAssociation");
 
-  const std::vector<std::string> seedflagnamesEB = ps.getParameter<std::vector<std::string> >("SeedRecHitFlagToBeExcludedEB");
+  const std::vector<std::string> seedflagnamesEB =
+      ps.getParameter<std::vector<std::string>>("SeedRecHitFlagToBeExcludedEB");
   const std::vector<int> seedflagsexclEB = StringToEnumValue<EcalRecHit::Flags>(seedflagnamesEB);
 
-  const std::vector<std::string> seedflagnamesEE = ps.getParameter<std::vector<std::string> >("SeedRecHitFlagToBeExcludedEE");
+  const std::vector<std::string> seedflagnamesEE =
+      ps.getParameter<std::vector<std::string>>("SeedRecHitFlagToBeExcludedEE");
   const std::vector<int> seedflagsexclEE = StringToEnumValue<EcalRecHit::Flags>(seedflagnamesEE);
 
-  const std::vector<std::string> flagnamesEB = ps.getParameter<std::vector<std::string> >("RecHitFlagToBeExcludedEB");
+  const std::vector<std::string> flagnamesEB = ps.getParameter<std::vector<std::string>>("RecHitFlagToBeExcludedEB");
   const std::vector<int> flagsexclEB = StringToEnumValue<EcalRecHit::Flags>(flagnamesEB);
 
-  const std::vector<std::string> flagnamesEE = ps.getParameter<std::vector<std::string> >("RecHitFlagToBeExcludedEE");
+  const std::vector<std::string> flagnamesEE = ps.getParameter<std::vector<std::string>>("RecHitFlagToBeExcludedEE");
   const std::vector<int> flagsexclEE = StringToEnumValue<EcalRecHit::Flags>(flagnamesEE);
 
   // Produces a collection of barrel and a collection of endcap clusters
 
-  produces< reco::ClusterShapeCollection>(clustershapecollectionEE_);
-  produces< reco::BasicClusterCollection >(endcapClusterCollection_);
-  produces< reco::ClusterShapeCollection>(clustershapecollectionEB_);
-  produces< reco::BasicClusterCollection >(barrelClusterCollection_);
-  produces< reco::BasicClusterShapeAssociationCollection >(barrelClusterShapeAssociation_);
-  produces< reco::BasicClusterShapeAssociationCollection >(endcapClusterShapeAssociation_);
+  produces<reco::ClusterShapeCollection>(clustershapecollectionEE_);
+  produces<reco::BasicClusterCollection>(endcapClusterCollection_);
+  produces<reco::ClusterShapeCollection>(clustershapecollectionEB_);
+  produces<reco::BasicClusterCollection>(barrelClusterCollection_);
+  produces<reco::BasicClusterShapeAssociationCollection>(barrelClusterShapeAssociation_);
+  produces<reco::BasicClusterShapeAssociationCollection>(endcapClusterShapeAssociation_);
 
-  island_p = new IslandClusterAlgo(barrelSeedThreshold, endcapSeedThreshold, posCalculator_, seedflagsexclEB, seedflagsexclEE, flagsexclEB, flagsexclEE, verbosity);
+  island_p = new IslandClusterAlgo(barrelSeedThreshold,
+                                   endcapSeedThreshold,
+                                   posCalculator_,
+                                   seedflagsexclEB,
+                                   seedflagsexclEE,
+                                   flagsexclEB,
+                                   flagsexclEE,
+                                   verbosity);
 
   nEvt_ = 0;
 }
 
-
-IslandClusterProducer::~IslandClusterProducer()
-{
-  delete island_p;
-}
+IslandClusterProducer::~IslandClusterProducer() { delete island_p; }
 
 void IslandClusterProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-
   edm::ParameterSetDescription desc;
   desc.add<std::string>("VerbosityLevel", "ERROR");
   desc.add<edm::InputTag>("barrelHits", edm::InputTag("ecalRecHit", "EcalRecHitsEB"));
@@ -137,49 +140,47 @@ void IslandClusterProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   descriptions.add("IslandClusterProducer", desc);
 }
 
-void IslandClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
-  clusterizeECALPart(evt, es, endcapRecHits_, endcapClusterCollection_, endcapClusterShapeAssociation_, IslandClusterAlgo::endcap); 
-  clusterizeECALPart(evt, es, barrelRecHits_, barrelClusterCollection_, barrelClusterShapeAssociation_, IslandClusterAlgo::barrel);
+void IslandClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
+  clusterizeECALPart(
+      evt, es, endcapRecHits_, endcapClusterCollection_, endcapClusterShapeAssociation_, IslandClusterAlgo::endcap);
+  clusterizeECALPart(
+      evt, es, barrelRecHits_, barrelClusterCollection_, barrelClusterShapeAssociation_, IslandClusterAlgo::barrel);
   nEvt_++;
 }
 
-
-const EcalRecHitCollection * IslandClusterProducer::getCollection(edm::Event& evt,const edm::EDGetTokenT<EcalRecHitCollection>& token)
-{
+const EcalRecHitCollection* IslandClusterProducer::getCollection(edm::Event& evt,
+                                                                 const edm::EDGetTokenT<EcalRecHitCollection>& token) {
   edm::Handle<EcalRecHitCollection> rhcHandle;
   evt.getByToken(token, rhcHandle);
   return rhcHandle.product();
-  
 }
 
-void IslandClusterProducer::clusterizeECALPart(edm::Event &evt, const edm::EventSetup &es,const edm::EDGetTokenT<EcalRecHitCollection>& token,                                              const std::string& clusterCollection,
-					       const std::string& clusterShapeAssociation,
-                                               const IslandClusterAlgo::EcalPart& ecalPart)
-{
+void IslandClusterProducer::clusterizeECALPart(edm::Event& evt,
+                                               const edm::EventSetup& es,
+                                               const edm::EDGetTokenT<EcalRecHitCollection>& token,
+                                               const std::string& clusterCollection,
+                                               const std::string& clusterShapeAssociation,
+                                               const IslandClusterAlgo::EcalPart& ecalPart) {
   // get the hit collection from the event:
-  const EcalRecHitCollection *hitCollection_p = getCollection(evt,token);
+  const EcalRecHitCollection* hitCollection_p = getCollection(evt, token);
 
   // get the geometry and topology from the event setup:
   edm::ESHandle<CaloGeometry> geoHandle;
   es.get<CaloGeometryRecord>().get(geoHandle);
 
-  const CaloSubdetectorGeometry *geometry_p;
+  const CaloSubdetectorGeometry* geometry_p;
   std::unique_ptr<CaloSubdetectorTopology> topology_p;
 
   std::string clustershapetag;
-  if (ecalPart == IslandClusterAlgo::barrel) 
-    {
-      geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-      topology_p = std::make_unique<EcalBarrelTopology>(*geoHandle);
-    }
-  else
-    {
-      geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-      topology_p = std::make_unique<EcalEndcapTopology>(*geoHandle);
-   }
+  if (ecalPart == IslandClusterAlgo::barrel) {
+    geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
+    topology_p = std::make_unique<EcalBarrelTopology>(*geoHandle);
+  } else {
+    geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
+    topology_p = std::make_unique<EcalEndcapTopology>(*geoHandle);
+  }
 
-  const CaloSubdetectorGeometry *geometryES_p;
+  const CaloSubdetectorGeometry* geometryES_p;
   geometryES_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
 
   // Run the clusterization algorithm:
@@ -187,35 +188,35 @@ void IslandClusterProducer::clusterizeECALPart(edm::Event &evt, const edm::Event
   clusters = island_p->makeClusters(hitCollection_p, geometry_p, topology_p.get(), geometryES_p, ecalPart);
 
   //Create associated ClusterShape objects.
-  std::vector <reco::ClusterShape> ClusVec;
-  for (int erg=0;erg<int(clusters.size());++erg){
-    reco::ClusterShape TestShape = shapeAlgo_.Calculate(clusters[erg],hitCollection_p,geometry_p,topology_p.get());
+  std::vector<reco::ClusterShape> ClusVec;
+  for (int erg = 0; erg < int(clusters.size()); ++erg) {
+    reco::ClusterShape TestShape = shapeAlgo_.Calculate(clusters[erg], hitCollection_p, geometry_p, topology_p.get());
     ClusVec.push_back(TestShape);
   }
 
   //Put clustershapes in event, but retain a Handle on them.
   auto clustersshapes_p = std::make_unique<reco::ClusterShapeCollection>();
   clustersshapes_p->assign(ClusVec.begin(), ClusVec.end());
-  edm::OrphanHandle<reco::ClusterShapeCollection> clusHandle; 
-  if (ecalPart == IslandClusterAlgo::barrel) 
-    clusHandle= evt.put(std::move(clustersshapes_p), clustershapecollectionEB_);
+  edm::OrphanHandle<reco::ClusterShapeCollection> clusHandle;
+  if (ecalPart == IslandClusterAlgo::barrel)
+    clusHandle = evt.put(std::move(clustersshapes_p), clustershapecollectionEB_);
   else
-    clusHandle= evt.put(std::move(clustersshapes_p), clustershapecollectionEE_);
+    clusHandle = evt.put(std::move(clustersshapes_p), clustershapecollectionEE_);
 
   // create a unique_ptr to a BasicClusterCollection, copy the barrel clusters into it and put in the Event:
   auto clusters_p = std::make_unique<reco::BasicClusterCollection>();
   clusters_p->assign(clusters.begin(), clusters.end());
   edm::OrphanHandle<reco::BasicClusterCollection> bccHandle;
-  if (ecalPart == IslandClusterAlgo::barrel) 
+  if (ecalPart == IslandClusterAlgo::barrel)
     bccHandle = evt.put(std::move(clusters_p), barrelClusterCollection_);
   else
     bccHandle = evt.put(std::move(clusters_p), endcapClusterCollection_);
 
-
   // BasicClusterShapeAssociationMap
   auto shapeAssocs_p = std::make_unique<reco::BasicClusterShapeAssociationCollection>(bccHandle, clusHandle);
-  for (unsigned int i = 0; i < clusHandle->size(); i++){
-    shapeAssocs_p->insert(edm::Ref<reco::BasicClusterCollection>(bccHandle,i),edm::Ref<reco::ClusterShapeCollection>(clusHandle,i));
-  }  
-  evt.put(std::move(shapeAssocs_p),clusterShapeAssociation);
+  for (unsigned int i = 0; i < clusHandle->size(); i++) {
+    shapeAssocs_p->insert(edm::Ref<reco::BasicClusterCollection>(bccHandle, i),
+                          edm::Ref<reco::ClusterShapeCollection>(clusHandle, i));
+  }
+  evt.put(std::move(shapeAssocs_p), clusterShapeAssociation);
 }

--- a/RecoEcal/EgammaClusterProducers/src/Multi5x5ClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/Multi5x5ClusterProducer.cc
@@ -34,67 +34,51 @@
 // Class header file
 #include "RecoEcal/EgammaClusterProducers/interface/Multi5x5ClusterProducer.h"
 
-
-Multi5x5ClusterProducer::Multi5x5ClusterProducer(const edm::ParameterSet& ps)
-{
-
+Multi5x5ClusterProducer::Multi5x5ClusterProducer(const edm::ParameterSet& ps) {
   // Parameters to identify the hit collections
-  barrelHitToken_   = 
-	  consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("barrelHitTag"));
-  
-  endcapHitToken_   = 
-	  consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("endcapHitTag"));
+  barrelHitToken_ = consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("barrelHitTag"));
 
+  endcapHitToken_ = consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("endcapHitTag"));
 
   // should cluster algo be run in barrel and endcap?
   doEndcap_ = ps.getParameter<bool>("doEndcap");
   doBarrel_ = ps.getParameter<bool>("doBarrel");
 
   // The names of the produced cluster collections
-  barrelClusterCollection_  = ps.getParameter<std::string>("barrelClusterCollection");
-  endcapClusterCollection_  = ps.getParameter<std::string>("endcapClusterCollection");
+  barrelClusterCollection_ = ps.getParameter<std::string>("barrelClusterCollection");
+  endcapClusterCollection_ = ps.getParameter<std::string>("endcapClusterCollection");
 
   // Island algorithm parameters
   double barrelSeedThreshold = ps.getParameter<double>("IslandBarrelSeedThr");
   double endcapSeedThreshold = ps.getParameter<double>("IslandEndcapSeedThr");
 
-  const std::vector<std::string> flagnames = 
-    ps.getParameter<std::vector<std::string> >("RecHitFlagToBeExcluded");
-  
-  const std::vector<int> v_chstatus= 
-    StringToEnumValue<EcalRecHit::Flags>(flagnames);
+  const std::vector<std::string> flagnames = ps.getParameter<std::vector<std::string> >("RecHitFlagToBeExcluded");
+
+  const std::vector<int> v_chstatus = StringToEnumValue<EcalRecHit::Flags>(flagnames);
 
   // Parameters for the position calculation:
-  edm::ParameterSet posCalcParameters = 
-    ps.getParameter<edm::ParameterSet>("posCalcParameters");
+  edm::ParameterSet posCalcParameters = ps.getParameter<edm::ParameterSet>("posCalcParameters");
   posCalculator_ = PositionCalc(posCalcParameters);
 
   // Produces a collection of barrel and a collection of endcap clusters
-  produces< reco::BasicClusterCollection >(endcapClusterCollection_);
-  produces< reco::BasicClusterCollection >(barrelClusterCollection_);
-  
-  bool reassignSeedCrysToClusterItSeeds=false;
-  if(ps.exists("reassignSeedCrysToClusterItSeeds")) reassignSeedCrysToClusterItSeeds = ps.getParameter<bool>("reassignSeedCrysToClusterItSeeds");
+  produces<reco::BasicClusterCollection>(endcapClusterCollection_);
+  produces<reco::BasicClusterCollection>(barrelClusterCollection_);
 
-    
+  bool reassignSeedCrysToClusterItSeeds = false;
+  if (ps.exists("reassignSeedCrysToClusterItSeeds"))
+    reassignSeedCrysToClusterItSeeds = ps.getParameter<bool>("reassignSeedCrysToClusterItSeeds");
 
-  island_p = new Multi5x5ClusterAlgo(barrelSeedThreshold, endcapSeedThreshold,  v_chstatus, posCalculator_,reassignSeedCrysToClusterItSeeds);
+  island_p = new Multi5x5ClusterAlgo(
+      barrelSeedThreshold, endcapSeedThreshold, v_chstatus, posCalculator_, reassignSeedCrysToClusterItSeeds);
 
   nEvt_ = 0;
 }
 
+Multi5x5ClusterProducer::~Multi5x5ClusterProducer() { delete island_p; }
 
-Multi5x5ClusterProducer::~Multi5x5ClusterProducer()
-{
-  delete island_p;
-}
-
-
-void Multi5x5ClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
-
+void Multi5x5ClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
   if (doEndcap_) {
-    clusterizeECALPart(evt, es, endcapHitToken_, endcapClusterCollection_, reco::CaloID::DET_ECAL_ENDCAP); 
+    clusterizeECALPart(evt, es, endcapHitToken_, endcapClusterCollection_, reco::CaloID::DET_ECAL_ENDCAP);
   }
   if (doBarrel_) {
     clusterizeECALPart(evt, es, barrelHitToken_, barrelClusterCollection_, reco::CaloID::DET_ECAL_BARREL);
@@ -103,42 +87,37 @@ void Multi5x5ClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es
   nEvt_++;
 }
 
-
-const EcalRecHitCollection * Multi5x5ClusterProducer::getCollection(edm::Event& evt, const edm::EDGetTokenT<EcalRecHitCollection>& token)
-{
+const EcalRecHitCollection* Multi5x5ClusterProducer::getCollection(
+    edm::Event& evt, const edm::EDGetTokenT<EcalRecHitCollection>& token) {
   edm::Handle<EcalRecHitCollection> rhcHandle;
   evt.getByToken(token, rhcHandle);
   return rhcHandle.product();
 }
 
-
-void Multi5x5ClusterProducer::clusterizeECALPart(edm::Event &evt, const edm::EventSetup &es,
-											   const edm::EDGetTokenT<EcalRecHitCollection>& token,
-                                               const std::string& clusterCollection,
-                                               const reco::CaloID::Detectors detector)
-{
+void Multi5x5ClusterProducer::clusterizeECALPart(edm::Event& evt,
+                                                 const edm::EventSetup& es,
+                                                 const edm::EDGetTokenT<EcalRecHitCollection>& token,
+                                                 const std::string& clusterCollection,
+                                                 const reco::CaloID::Detectors detector) {
   // get the hit collection from the event:
-  const EcalRecHitCollection *hitCollection_p = getCollection(evt, token);
+  const EcalRecHitCollection* hitCollection_p = getCollection(evt, token);
 
   // get the geometry and topology from the event setup:
   edm::ESHandle<CaloGeometry> geoHandle;
   es.get<CaloGeometryRecord>().get(geoHandle);
 
-  const CaloSubdetectorGeometry *geometry_p;
+  const CaloSubdetectorGeometry* geometry_p;
   std::unique_ptr<CaloSubdetectorTopology> topology_p;
 
-  if (detector == reco::CaloID::DET_ECAL_BARREL) 
-    {
-      geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-      topology_p = std::make_unique<EcalBarrelTopology>(*geoHandle);
-    }
-  else
-    {
-      geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-      topology_p = std::make_unique<EcalEndcapTopology>(*geoHandle);
-   }
+  if (detector == reco::CaloID::DET_ECAL_BARREL) {
+    geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
+    topology_p = std::make_unique<EcalBarrelTopology>(*geoHandle);
+  } else {
+    geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
+    topology_p = std::make_unique<EcalEndcapTopology>(*geoHandle);
+  }
 
-  const CaloSubdetectorGeometry *geometryES_p;
+  const CaloSubdetectorGeometry* geometryES_p;
   geometryES_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
 
   // Run the clusterization algorithm:
@@ -149,7 +128,7 @@ void Multi5x5ClusterProducer::clusterizeECALPart(edm::Event &evt, const edm::Eve
   auto clusters_p = std::make_unique<reco::BasicClusterCollection>();
   clusters_p->assign(clusters.begin(), clusters.end());
   edm::OrphanHandle<reco::BasicClusterCollection> bccHandle;
-  if (detector == reco::CaloID::DET_ECAL_BARREL) 
+  if (detector == reco::CaloID::DET_ECAL_BARREL)
     bccHandle = evt.put(std::move(clusters_p), barrelClusterCollection_);
   else
     bccHandle = evt.put(std::move(clusters_p), endcapClusterCollection_);

--- a/RecoEcal/EgammaClusterProducers/src/Multi5x5SuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/Multi5x5SuperClusterProducer.cc
@@ -20,106 +20,95 @@
 // Class header file
 #include "RecoEcal/EgammaClusterProducers/interface/Multi5x5SuperClusterProducer.h"
 
-
-Multi5x5SuperClusterProducer::Multi5x5SuperClusterProducer(const edm::ParameterSet& ps):
-  barrelEtaSearchRoad_{static_cast<float>(ps.getParameter<double>("barrelEtaSearchRoad"))},
-  barrelPhiSearchRoad_{static_cast<float>(ps.getParameter<double>("barrelPhiSearchRoad"))},
-  endcapEtaSearchRoad_{static_cast<float>(ps.getParameter<double>("endcapEtaSearchRoad"))},
-  endcapPhiSearchRoad_{static_cast<float>(ps.getParameter<double>("endcapPhiSearchRoad"))},
-  seedTransverseEnergyThreshold_{static_cast<float>(ps.getParameter<double>("seedTransverseEnergyThreshold"))},
-  doBarrel_{ps.getParameter<bool>("doBarrel")},
-  doEndcaps_{ps.getParameter<bool>("doEndcaps")},
-  totalE{0.},
-  noSuperClusters{0}
-{
-
-  if(doEndcaps_) {
-    eeClustersToken_ = 
-      consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("endcapClusterTag"));
+Multi5x5SuperClusterProducer::Multi5x5SuperClusterProducer(const edm::ParameterSet& ps)
+    : barrelEtaSearchRoad_{static_cast<float>(ps.getParameter<double>("barrelEtaSearchRoad"))},
+      barrelPhiSearchRoad_{static_cast<float>(ps.getParameter<double>("barrelPhiSearchRoad"))},
+      endcapEtaSearchRoad_{static_cast<float>(ps.getParameter<double>("endcapEtaSearchRoad"))},
+      endcapPhiSearchRoad_{static_cast<float>(ps.getParameter<double>("endcapPhiSearchRoad"))},
+      seedTransverseEnergyThreshold_{static_cast<float>(ps.getParameter<double>("seedTransverseEnergyThreshold"))},
+      doBarrel_{ps.getParameter<bool>("doBarrel")},
+      doEndcaps_{ps.getParameter<bool>("doEndcaps")},
+      totalE{0.},
+      noSuperClusters{0} {
+  if (doEndcaps_) {
+    eeClustersToken_ = consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("endcapClusterTag"));
   }
-  if(doBarrel_) {
-    ebClustersToken_ = 
-      consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("barrelClusterTag"));
+  if (doBarrel_) {
+    ebClustersToken_ = consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("barrelClusterTag"));
   }
 
   const edm::ParameterSet bremRecoveryPset = ps.getParameter<edm::ParameterSet>("bremRecoveryPset");
   bool dynamicPhiRoad = ps.getParameter<bool>("dynamicPhiRoad");
 
-  bremAlgo_p = std::make_unique<Multi5x5BremRecoveryClusterAlgo>(bremRecoveryPset, barrelEtaSearchRoad_, barrelPhiSearchRoad_, 
-                                                                 endcapEtaSearchRoad_, endcapPhiSearchRoad_, 
-                                                                 dynamicPhiRoad, seedTransverseEnergyThreshold_);
+  bremAlgo_p = std::make_unique<Multi5x5BremRecoveryClusterAlgo>(bremRecoveryPset,
+                                                                 barrelEtaSearchRoad_,
+                                                                 barrelPhiSearchRoad_,
+                                                                 endcapEtaSearchRoad_,
+                                                                 endcapPhiSearchRoad_,
+                                                                 dynamicPhiRoad,
+                                                                 seedTransverseEnergyThreshold_);
 
-  if(doEndcaps_) {
-   endcapPutToken_ =  produces< reco::SuperClusterCollection >(ps.getParameter<std::string>("endcapSuperclusterCollection"));
+  if (doEndcaps_) {
+    endcapPutToken_ =
+        produces<reco::SuperClusterCollection>(ps.getParameter<std::string>("endcapSuperclusterCollection"));
   }
-  if(doBarrel_) {
-    barrelPutToken_ = produces< reco::SuperClusterCollection >(ps.getParameter<std::string>("barrelSuperclusterCollection"));
+  if (doBarrel_) {
+    barrelPutToken_ =
+        produces<reco::SuperClusterCollection>(ps.getParameter<std::string>("barrelSuperclusterCollection"));
   }
 }
 
-
-void
-Multi5x5SuperClusterProducer::endStream() {
+void Multi5x5SuperClusterProducer::endStream() {
   double averEnergy = 0.;
   std::ostringstream str;
   str << "Multi5x5SuperClusterProducer::endJob()\n"
       << "  total # reconstructed super clusters: " << noSuperClusters << "\n"
       << "  total energy of all clusters: " << totalE << "\n";
-  if(noSuperClusters>0) { 
+  if (noSuperClusters > 0) {
     averEnergy = totalE / noSuperClusters;
     str << "  average SuperCluster energy = " << averEnergy << "\n";
   }
   edm::LogInfo("Multi5x5SuperClusterProducerInfo") << str.str() << "\n";
-
 }
 
-
-void Multi5x5SuperClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es)
-{
-  if(doEndcaps_)
+void Multi5x5SuperClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
+  if (doEndcaps_)
     produceSuperclustersForECALPart(evt, eeClustersToken_, endcapPutToken_);
 
-  if(doBarrel_)
+  if (doBarrel_)
     produceSuperclustersForECALPart(evt, ebClustersToken_, barrelPutToken_);
 }
 
-
-void Multi5x5SuperClusterProducer::
-produceSuperclustersForECALPart(edm::Event& evt, 
-                                const edm::EDGetTokenT<reco::BasicClusterCollection>& clustersToken,
-                                const edm::EDPutTokenT<reco::SuperClusterCollection>& putToken)
-{
+void Multi5x5SuperClusterProducer::produceSuperclustersForECALPart(
+    edm::Event& evt,
+    const edm::EDGetTokenT<reco::BasicClusterCollection>& clustersToken,
+    const edm::EDPutTokenT<reco::SuperClusterCollection>& putToken) {
   // get the cluster collection out and turn it to a BasicClusterRefVector:
-  reco::CaloClusterPtrVector clusterPtrVector_p=getClusterPtrVector(evt, clustersToken);
+  reco::CaloClusterPtrVector clusterPtrVector_p = getClusterPtrVector(evt, clustersToken);
 
   // run the brem recovery and get the SC collection
   reco::SuperClusterCollection superclusters_ap(bremAlgo_p->makeSuperClusters(clusterPtrVector_p));
 
   // count the total energy and the number of superclusters
-  for (auto const& sc: superclusters_ap)
-    {
-      totalE += sc.energy();
-      noSuperClusters++;
-    }
+  for (auto const& sc : superclusters_ap) {
+    totalE += sc.energy();
+    noSuperClusters++;
+  }
 
   // put the SC collection in the event
-  evt.emplace(putToken,std::move(superclusters_ap));
-
+  evt.emplace(putToken, std::move(superclusters_ap));
 }
 
-reco::CaloClusterPtrVector
-Multi5x5SuperClusterProducer::getClusterPtrVector(edm::Event& evt, 
-                                                  const edm::EDGetTokenT<reco::BasicClusterCollection>& clustersToken) const
-{  
+reco::CaloClusterPtrVector Multi5x5SuperClusterProducer::getClusterPtrVector(
+    edm::Event& evt, const edm::EDGetTokenT<reco::BasicClusterCollection>& clustersToken) const {
   reco::CaloClusterPtrVector clusterPtrVector_p;
   edm::Handle<reco::BasicClusterCollection> bccHandle;
   evt.getByToken(clustersToken, bccHandle);
-  
-  const reco::BasicClusterCollection *clusterCollection_p = bccHandle.product();
+
+  const reco::BasicClusterCollection* clusterCollection_p = bccHandle.product();
   clusterPtrVector_p.reserve(clusterCollection_p->size());
-  for (unsigned int i = 0; i < clusterCollection_p->size(); i++)
-    {
-      clusterPtrVector_p.push_back(reco::CaloClusterPtr(bccHandle, i));
-    }
+  for (unsigned int i = 0; i < clusterCollection_p->size(); i++) {
+    clusterPtrVector_p.push_back(reco::CaloClusterPtr(bccHandle, i));
+  }
   return clusterPtrVector_p;
-}                               
+}

--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -41,46 +41,40 @@ namespace {
   const std::string EnergyWeight__Raw("Raw");
   const std::string EnergyWeight__CalibratedNoPS("CalibratedNoPS");
   const std::string EnergyWeight__CalibratedTotal("CalibratedTotal");
-}
+}  // namespace
 
-PFECALSuperClusterProducer::PFECALSuperClusterProducer(const edm::ParameterSet& iConfig)
-{
-    
-  verbose_ = 
-    iConfig.getUntrackedParameter<bool>("verbose",false);
+PFECALSuperClusterProducer::PFECALSuperClusterProducer(const edm::ParameterSet& iConfig) {
+  verbose_ = iConfig.getUntrackedParameter<bool>("verbose", false);
 
-  superClusterAlgo_.setUseRegression(iConfig.getParameter<bool>("useRegression")); 
+  superClusterAlgo_.setUseRegression(iConfig.getParameter<bool>("useRegression"));
 
   isOOTCollection_ = iConfig.getParameter<bool>("isOOTCollection");
   superClusterAlgo_.setIsOOTCollection(isOOTCollection_);
 
-  superClusterAlgo_.setTokens(iConfig,consumesCollector());
+  superClusterAlgo_.setTokens(iConfig, consumesCollector());
 
   std::string _typename = iConfig.getParameter<std::string>("ClusteringType");
-  if( _typename == ClusterType__BOX ) {
+  if (_typename == ClusterType__BOX) {
     _theclusteringtype = PFECALSuperClusterAlgo::kBOX;
-  } else if ( _typename == ClusterType__Mustache ) {
+  } else if (_typename == ClusterType__Mustache) {
     _theclusteringtype = PFECALSuperClusterAlgo::kMustache;
   } else {
-    throw cms::Exception("InvalidClusteringType") 
-      << "You have not chosen a valid clustering type," 
-      << " please choose from \"Box\" or \"Mustache\"!";
+    throw cms::Exception("InvalidClusteringType") << "You have not chosen a valid clustering type,"
+                                                  << " please choose from \"Box\" or \"Mustache\"!";
   }
 
   std::string _weightname = iConfig.getParameter<std::string>("EnergyWeight");
-  if( _weightname == EnergyWeight__Raw ) {
+  if (_weightname == EnergyWeight__Raw) {
     _theenergyweight = PFECALSuperClusterAlgo::kRaw;
-  } else if ( _weightname == EnergyWeight__CalibratedNoPS ) {
+  } else if (_weightname == EnergyWeight__CalibratedNoPS) {
     _theenergyweight = PFECALSuperClusterAlgo::kCalibratedNoPS;
-  } else if ( _weightname == EnergyWeight__CalibratedTotal) {
+  } else if (_weightname == EnergyWeight__CalibratedTotal) {
     _theenergyweight = PFECALSuperClusterAlgo::kCalibratedTotal;
   } else {
-    throw cms::Exception("InvalidClusteringType") 
-      << "You have not chosen a valid energy weighting scheme," 
-      << " please choose from \"Raw\", \"CalibratedNoPS\", or"
-      << " \"CalibratedTotal\"!";
+    throw cms::Exception("InvalidClusteringType") << "You have not chosen a valid energy weighting scheme,"
+                                                  << " please choose from \"Raw\", \"CalibratedNoPS\", or"
+                                                  << " \"CalibratedTotal\"!";
   }
-  
 
   // parameters for clustering
   bool seedThresholdIsET = iConfig.getParameter<bool>("seedThresholdIsET");
@@ -92,7 +86,7 @@ PFECALSuperClusterProducer::PFECALSuperClusterProducer(const edm::ParameterSet& 
 
   double threshPFClusterSeedEndcap = iConfig.getParameter<double>("thresh_PFClusterSeedEndcap");
   double threshPFClusterEndcap = iConfig.getParameter<double>("thresh_PFClusterEndcap");
-  
+
   double phiwidthSuperClusterBarrel = iConfig.getParameter<double>("phiwidth_SuperClusterBarrel");
   double etawidthSuperClusterBarrel = iConfig.getParameter<double>("etawidth_SuperClusterBarrel");
 
@@ -102,12 +96,9 @@ PFECALSuperClusterProducer::PFECALSuperClusterProducer(const edm::ParameterSet& 
   //double threshPFClusterMustacheOutBarrel = iConfig.getParameter<double>("thresh_PFClusterMustacheOutBarrel");
   //double threshPFClusterMustacheOutEndcap = iConfig.getParameter<double>("thresh_PFClusterMustacheOutEndcap");
 
-  double doSatelliteClusterMerge = 
-    iConfig.getParameter<bool>("doSatelliteClusterMerge");
-  double satelliteClusterSeedThreshold = 
-    iConfig.getParameter<double>("satelliteClusterSeedThreshold");
-  double satelliteMajorityFraction = 
-    iConfig.getParameter<double>("satelliteMajorityFraction");
+  double doSatelliteClusterMerge = iConfig.getParameter<bool>("doSatelliteClusterMerge");
+  double satelliteClusterSeedThreshold = iConfig.getParameter<double>("satelliteClusterSeedThreshold");
+  double satelliteMajorityFraction = iConfig.getParameter<double>("satelliteMajorityFraction");
   bool dropUnseedable = iConfig.getParameter<bool>("dropUnseedable");
 
   superClusterAlgo_.setVerbosityLevel(verbose_);
@@ -116,35 +107,34 @@ PFECALSuperClusterProducer::PFECALSuperClusterProducer(const edm::ParameterSet& 
   superClusterAlgo_.setUseETForSeeding(seedThresholdIsET);
   superClusterAlgo_.setUseDynamicDPhi(useDynamicDPhi);
 
-  superClusterAlgo_.setThreshSuperClusterEt( iConfig.getParameter<double>("thresh_SCEt") );
-  
-  superClusterAlgo_.setThreshPFClusterSeedBarrel( threshPFClusterSeedBarrel );
-  superClusterAlgo_.setThreshPFClusterBarrel( threshPFClusterBarrel );
+  superClusterAlgo_.setThreshSuperClusterEt(iConfig.getParameter<double>("thresh_SCEt"));
 
-  superClusterAlgo_.setThreshPFClusterSeedEndcap( threshPFClusterSeedEndcap );
-  superClusterAlgo_.setThreshPFClusterEndcap( threshPFClusterEndcap );
+  superClusterAlgo_.setThreshPFClusterSeedBarrel(threshPFClusterSeedBarrel);
+  superClusterAlgo_.setThreshPFClusterBarrel(threshPFClusterBarrel);
 
-  superClusterAlgo_.setPhiwidthSuperClusterBarrel( phiwidthSuperClusterBarrel );
-  superClusterAlgo_.setEtawidthSuperClusterBarrel( etawidthSuperClusterBarrel );
+  superClusterAlgo_.setThreshPFClusterSeedEndcap(threshPFClusterSeedEndcap);
+  superClusterAlgo_.setThreshPFClusterEndcap(threshPFClusterEndcap);
 
-  superClusterAlgo_.setPhiwidthSuperClusterEndcap( phiwidthSuperClusterEndcap );
-  superClusterAlgo_.setEtawidthSuperClusterEndcap( etawidthSuperClusterEndcap );
+  superClusterAlgo_.setPhiwidthSuperClusterBarrel(phiwidthSuperClusterBarrel);
+  superClusterAlgo_.setEtawidthSuperClusterBarrel(etawidthSuperClusterBarrel);
 
-  superClusterAlgo_.setSatelliteMerging( doSatelliteClusterMerge );
-  superClusterAlgo_.setSatelliteThreshold( satelliteClusterSeedThreshold );
-  superClusterAlgo_.setMajorityFraction( satelliteMajorityFraction );
-  superClusterAlgo_.setDropUnseedable( dropUnseedable );
+  superClusterAlgo_.setPhiwidthSuperClusterEndcap(phiwidthSuperClusterEndcap);
+  superClusterAlgo_.setEtawidthSuperClusterEndcap(etawidthSuperClusterEndcap);
+
+  superClusterAlgo_.setSatelliteMerging(doSatelliteClusterMerge);
+  superClusterAlgo_.setSatelliteThreshold(satelliteClusterSeedThreshold);
+  superClusterAlgo_.setMajorityFraction(satelliteMajorityFraction);
+  superClusterAlgo_.setDropUnseedable(dropUnseedable);
   //superClusterAlgo_.setThreshPFClusterMustacheOutBarrel( threshPFClusterMustacheOutBarrel );
   //superClusterAlgo_.setThreshPFClusterMustacheOutEndcap( threshPFClusterMustacheOutEndcap );
 
   //Load the ECAL energy calibration
-  thePFEnergyCalibration_ = 
-    std::make_shared<PFEnergyCalibration>();
+  thePFEnergyCalibration_ = std::make_shared<PFEnergyCalibration>();
   superClusterAlgo_.setPFClusterCalibration(thePFEnergyCalibration_);
 
   bool applyCrackCorrections_ = iConfig.getParameter<bool>("applyCrackCorrections");
   superClusterAlgo_.setCrackCorrections(applyCrackCorrections_);
-  
+
   PFBasicClusterCollectionBarrel_ = iConfig.getParameter<string>("PFBasicClusterCollectionBarrel");
   PFSuperClusterCollectionBarrel_ = iConfig.getParameter<string>("PFSuperClusterCollectionBarrel");
 
@@ -152,207 +142,200 @@ PFECALSuperClusterProducer::PFECALSuperClusterProducer(const edm::ParameterSet& 
   PFSuperClusterCollectionEndcap_ = iConfig.getParameter<string>("PFSuperClusterCollectionEndcap");
 
   PFBasicClusterCollectionPreshower_ = iConfig.getParameter<string>("PFBasicClusterCollectionPreshower");
-  PFSuperClusterCollectionEndcapWithPreshower_ = iConfig.getParameter<string>("PFSuperClusterCollectionEndcapWithPreshower");
+  PFSuperClusterCollectionEndcapWithPreshower_ =
+      iConfig.getParameter<string>("PFSuperClusterCollectionEndcapWithPreshower");
 
   PFClusterAssociationEBEE_ = "PFClusterAssociationEBEE";
   PFClusterAssociationES_ = "PFClusterAssociationES";
-  
-  produces<reco::SuperClusterCollection>(PFSuperClusterCollectionBarrel_);  
+
+  produces<reco::SuperClusterCollection>(PFSuperClusterCollectionBarrel_);
   produces<reco::SuperClusterCollection>(PFSuperClusterCollectionEndcapWithPreshower_);
   produces<reco::CaloClusterCollection>(PFBasicClusterCollectionBarrel_);
   produces<reco::CaloClusterCollection>(PFBasicClusterCollectionEndcap_);
   produces<reco::CaloClusterCollection>(PFBasicClusterCollectionPreshower_);
-  produces<edm::ValueMap<reco::CaloClusterPtr> >(PFClusterAssociationEBEE_);
-  produces<edm::ValueMap<reco::CaloClusterPtr> >(PFClusterAssociationES_);
+  produces<edm::ValueMap<reco::CaloClusterPtr>>(PFClusterAssociationEBEE_);
+  produces<edm::ValueMap<reco::CaloClusterPtr>>(PFClusterAssociationES_);
 }
-
-
 
 PFECALSuperClusterProducer::~PFECALSuperClusterProducer() {}
 
-void PFECALSuperClusterProducer::
-beginLuminosityBlock(LuminosityBlock const& iL, EventSetup const& iE) {
-  superClusterAlgo_.update(iE); 
+void PFECALSuperClusterProducer::beginLuminosityBlock(LuminosityBlock const& iL, EventSetup const& iE) {
+  superClusterAlgo_.update(iE);
 }
 
-
-void PFECALSuperClusterProducer::produce(edm::Event& iEvent, 
-				const edm::EventSetup& iSetup) {
-  
+void PFECALSuperClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // do clustering
   superClusterAlgo_.loadAndSortPFClusters(iEvent);
   superClusterAlgo_.run();
-  
+
   //build collections of output CaloClusters from the used PFClusters
   auto caloClustersEB = std::make_unique<reco::CaloClusterCollection>();
   auto caloClustersEE = std::make_unique<reco::CaloClusterCollection>();
   auto caloClustersES = std::make_unique<reco::CaloClusterCollection>();
-  
-  std::map<reco::CaloClusterPtr, unsigned int> pfClusterMapEB; //maps of pfclusters to caloclusters 
+
+  std::map<reco::CaloClusterPtr, unsigned int> pfClusterMapEB;  //maps of pfclusters to caloclusters
   std::map<reco::CaloClusterPtr, unsigned int> pfClusterMapEE;
   std::map<reco::CaloClusterPtr, unsigned int> pfClusterMapES;
-  
+
   //fill calocluster collections and maps
-  for( const auto& ebsc : *(superClusterAlgo_.getEBOutputSCCollection()) ) {
-    for (reco::CaloCluster_iterator pfclus = ebsc.clustersBegin(); pfclus!=ebsc.clustersEnd(); ++pfclus) {
+  for (const auto& ebsc : *(superClusterAlgo_.getEBOutputSCCollection())) {
+    for (reco::CaloCluster_iterator pfclus = ebsc.clustersBegin(); pfclus != ebsc.clustersEnd(); ++pfclus) {
       if (!pfClusterMapEB.count(*pfclus)) {
         reco::CaloCluster caloclus(**pfclus);
         caloClustersEB->push_back(caloclus);
         pfClusterMapEB[*pfclus] = caloClustersEB->size() - 1;
-      }
-      else {
+      } else {
         throw cms::Exception("PFECALSuperClusterProducer::produce")
-            << "Found an EB pfcluster matched to more than one EB supercluster!" 
-            << std::dec << std::endl;
+            << "Found an EB pfcluster matched to more than one EB supercluster!" << std::dec << std::endl;
       }
     }
   }
-  for( const auto& eesc : *(superClusterAlgo_.getEEOutputSCCollection()) ) {
-    for (reco::CaloCluster_iterator pfclus = eesc.clustersBegin(); pfclus!=eesc.clustersEnd(); ++pfclus) {
+  for (const auto& eesc : *(superClusterAlgo_.getEEOutputSCCollection())) {
+    for (reco::CaloCluster_iterator pfclus = eesc.clustersBegin(); pfclus != eesc.clustersEnd(); ++pfclus) {
       if (!pfClusterMapEE.count(*pfclus)) {
         reco::CaloCluster caloclus(**pfclus);
         caloClustersEE->push_back(caloclus);
         pfClusterMapEE[*pfclus] = caloClustersEE->size() - 1;
-      }
-      else {
+      } else {
         throw cms::Exception("PFECALSuperClusterProducer::produce")
-            << "Found an EE pfcluster matched to more than one EE supercluster!" 
-            << std::dec << std::endl;
+            << "Found an EE pfcluster matched to more than one EE supercluster!" << std::dec << std::endl;
       }
     }
-    for (reco::CaloCluster_iterator pfclus = eesc.preshowerClustersBegin(); pfclus!=eesc.preshowerClustersEnd(); ++pfclus) {
+    for (reco::CaloCluster_iterator pfclus = eesc.preshowerClustersBegin(); pfclus != eesc.preshowerClustersEnd();
+         ++pfclus) {
       if (!pfClusterMapES.count(*pfclus)) {
         reco::CaloCluster caloclus(**pfclus);
         caloClustersES->push_back(caloclus);
         pfClusterMapES[*pfclus] = caloClustersES->size() - 1;
-      }
-      else {
+      } else {
         throw cms::Exception("PFECALSuperClusterProducer::produce")
-            << "Found an ES pfcluster matched to more than one EE supercluster!" 
-            << std::dec << std::endl;
+            << "Found an ES pfcluster matched to more than one EE supercluster!" << std::dec << std::endl;
       }
     }
   }
-  
+
   //create ValueMaps from output CaloClusters back to original PFClusters
   auto pfClusterAssociationEBEE = std::make_unique<edm::ValueMap<reco::CaloClusterPtr>>();
-  auto pfClusterAssociationES = std::make_unique<edm::ValueMap<reco::CaloClusterPtr>>();    
-  
+  auto pfClusterAssociationES = std::make_unique<edm::ValueMap<reco::CaloClusterPtr>>();
+
   //vectors to fill ValueMaps
   std::vector<reco::CaloClusterPtr> clusptrsEB(caloClustersEB->size());
   std::vector<reco::CaloClusterPtr> clusptrsEE(caloClustersEE->size());
-  std::vector<reco::CaloClusterPtr> clusptrsES(caloClustersES->size());  
-  
+  std::vector<reco::CaloClusterPtr> clusptrsES(caloClustersES->size());
+
   //put calocluster output collections in event and get orphan handles to create ptrs
-  const edm::OrphanHandle<reco::CaloClusterCollection> &caloClusHandleEB = iEvent.put(std::move(caloClustersEB),PFBasicClusterCollectionBarrel_);
-  const edm::OrphanHandle<reco::CaloClusterCollection> &caloClusHandleEE = iEvent.put(std::move(caloClustersEE),PFBasicClusterCollectionEndcap_);
-  const edm::OrphanHandle<reco::CaloClusterCollection> &caloClusHandleES = iEvent.put(std::move(caloClustersES),PFBasicClusterCollectionPreshower_);
-    
+  const edm::OrphanHandle<reco::CaloClusterCollection>& caloClusHandleEB =
+      iEvent.put(std::move(caloClustersEB), PFBasicClusterCollectionBarrel_);
+  const edm::OrphanHandle<reco::CaloClusterCollection>& caloClusHandleEE =
+      iEvent.put(std::move(caloClustersEE), PFBasicClusterCollectionEndcap_);
+  const edm::OrphanHandle<reco::CaloClusterCollection>& caloClusHandleES =
+      iEvent.put(std::move(caloClustersES), PFBasicClusterCollectionPreshower_);
+
   //relink superclusters to output caloclusters and fill vectors for ValueMaps
-  for( auto& ebsc : *(superClusterAlgo_.getEBOutputSCCollection()) ) {
-    reco::CaloClusterPtr seedptr(caloClusHandleEB,pfClusterMapEB[ebsc.seed()]);
+  for (auto& ebsc : *(superClusterAlgo_.getEBOutputSCCollection())) {
+    reco::CaloClusterPtr seedptr(caloClusHandleEB, pfClusterMapEB[ebsc.seed()]);
     ebsc.setSeed(seedptr);
-    
+
     reco::CaloClusterPtrVector clusters;
-    for (reco::CaloCluster_iterator pfclus = ebsc.clustersBegin(); pfclus!=ebsc.clustersEnd(); ++pfclus) {
+    for (reco::CaloCluster_iterator pfclus = ebsc.clustersBegin(); pfclus != ebsc.clustersEnd(); ++pfclus) {
       int caloclusidx = pfClusterMapEB[*pfclus];
-      reco::CaloClusterPtr clusptr(caloClusHandleEB,caloclusidx);
+      reco::CaloClusterPtr clusptr(caloClusHandleEB, caloclusidx);
       clusters.push_back(clusptr);
       clusptrsEB[caloclusidx] = *pfclus;
     }
     ebsc.setClusters(clusters);
   }
-  for( auto& eesc : *(superClusterAlgo_.getEEOutputSCCollection()) ) {
-    reco::CaloClusterPtr seedptr(caloClusHandleEE,pfClusterMapEE[eesc.seed()]);
+  for (auto& eesc : *(superClusterAlgo_.getEEOutputSCCollection())) {
+    reco::CaloClusterPtr seedptr(caloClusHandleEE, pfClusterMapEE[eesc.seed()]);
     eesc.setSeed(seedptr);
-    
+
     reco::CaloClusterPtrVector clusters;
-    for (reco::CaloCluster_iterator pfclus = eesc.clustersBegin(); pfclus!=eesc.clustersEnd(); ++pfclus) {
+    for (reco::CaloCluster_iterator pfclus = eesc.clustersBegin(); pfclus != eesc.clustersEnd(); ++pfclus) {
       int caloclusidx = pfClusterMapEE[*pfclus];
-      reco::CaloClusterPtr clusptr(caloClusHandleEE,caloclusidx);
+      reco::CaloClusterPtr clusptr(caloClusHandleEE, caloclusidx);
       clusters.push_back(clusptr);
       clusptrsEE[caloclusidx] = *pfclus;
     }
     eesc.setClusters(clusters);
-    
+
     reco::CaloClusterPtrVector psclusters;
-    for (reco::CaloCluster_iterator pfclus = eesc.preshowerClustersBegin(); pfclus!=eesc.preshowerClustersEnd(); ++pfclus) {
+    for (reco::CaloCluster_iterator pfclus = eesc.preshowerClustersBegin(); pfclus != eesc.preshowerClustersEnd();
+         ++pfclus) {
       int caloclusidx = pfClusterMapES[*pfclus];
-      reco::CaloClusterPtr clusptr(caloClusHandleES,caloclusidx);
+      reco::CaloClusterPtr clusptr(caloClusHandleES, caloclusidx);
       psclusters.push_back(clusptr);
       clusptrsES[caloclusidx] = *pfclus;
     }
-    eesc.setPreshowerClusters(psclusters);  
+    eesc.setPreshowerClusters(psclusters);
   }
-    
+
   //fill association maps from output CaloClusters back to original PFClusters
   edm::ValueMap<reco::CaloClusterPtr>::Filler fillerEBEE(*pfClusterAssociationEBEE);
   fillerEBEE.insert(caloClusHandleEB, clusptrsEB.begin(), clusptrsEB.end());
   fillerEBEE.insert(caloClusHandleEE, clusptrsEE.begin(), clusptrsEE.end());
   fillerEBEE.fill();
-  
+
   edm::ValueMap<reco::CaloClusterPtr>::Filler fillerES(*pfClusterAssociationES);
-  fillerES.insert(caloClusHandleES, clusptrsES.begin(), clusptrsES.end());  
-  fillerES.fill();  
+  fillerES.insert(caloClusHandleES, clusptrsES.begin(), clusptrsES.end());
+  fillerES.fill();
 
   //store in the event
-  iEvent.put(std::move(pfClusterAssociationEBEE),PFClusterAssociationEBEE_);
-  iEvent.put(std::move(pfClusterAssociationES),PFClusterAssociationES_);
-  iEvent.put(std::move(superClusterAlgo_.getEBOutputSCCollection()),
-	     PFSuperClusterCollectionBarrel_);
-  iEvent.put(std::move(superClusterAlgo_.getEEOutputSCCollection()), 
-	     PFSuperClusterCollectionEndcapWithPreshower_);
+  iEvent.put(std::move(pfClusterAssociationEBEE), PFClusterAssociationEBEE_);
+  iEvent.put(std::move(pfClusterAssociationES), PFClusterAssociationES_);
+  iEvent.put(std::move(superClusterAlgo_.getEBOutputSCCollection()), PFSuperClusterCollectionBarrel_);
+  iEvent.put(std::move(superClusterAlgo_.getEEOutputSCCollection()), PFSuperClusterCollectionEndcapWithPreshower_);
 }
 
 void PFECALSuperClusterProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<std::string>("PFSuperClusterCollectionEndcap","particleFlowSuperClusterECALEndcap");
-  desc.add<bool>("doSatelliteClusterMerge",false);
-  desc.add<double>("thresh_PFClusterBarrel",0.0);
-  desc.add<std::string>("PFBasicClusterCollectionBarrel","particleFlowBasicClusterECALBarrel");
-  desc.add<bool>("useRegression",true);
-  desc.add<double>("satelliteMajorityFraction",0.5);
-  desc.add<double>("thresh_PFClusterEndcap",0.0);
-  desc.add<edm::InputTag>("ESAssociation",edm::InputTag("particleFlowClusterECAL"));
-  desc.add<std::string>("PFBasicClusterCollectionPreshower","particleFlowBasicClusterECALPreshower");
-  desc.add<bool>("use_preshower",true);
-  desc.addUntracked<bool>("verbose",false);
-  desc.add<double>("thresh_SCEt",4.0);
-  desc.add<double>("etawidth_SuperClusterEndcap",0.04);
-  desc.add<double>("phiwidth_SuperClusterEndcap",0.6);
-  desc.add<bool>("useDynamicDPhiWindow",true);
-  desc.add<std::string>("PFSuperClusterCollectionBarrel","particleFlowSuperClusterECALBarrel");
+  desc.add<std::string>("PFSuperClusterCollectionEndcap", "particleFlowSuperClusterECALEndcap");
+  desc.add<bool>("doSatelliteClusterMerge", false);
+  desc.add<double>("thresh_PFClusterBarrel", 0.0);
+  desc.add<std::string>("PFBasicClusterCollectionBarrel", "particleFlowBasicClusterECALBarrel");
+  desc.add<bool>("useRegression", true);
+  desc.add<double>("satelliteMajorityFraction", 0.5);
+  desc.add<double>("thresh_PFClusterEndcap", 0.0);
+  desc.add<edm::InputTag>("ESAssociation", edm::InputTag("particleFlowClusterECAL"));
+  desc.add<std::string>("PFBasicClusterCollectionPreshower", "particleFlowBasicClusterECALPreshower");
+  desc.add<bool>("use_preshower", true);
+  desc.addUntracked<bool>("verbose", false);
+  desc.add<double>("thresh_SCEt", 4.0);
+  desc.add<double>("etawidth_SuperClusterEndcap", 0.04);
+  desc.add<double>("phiwidth_SuperClusterEndcap", 0.6);
+  desc.add<bool>("useDynamicDPhiWindow", true);
+  desc.add<std::string>("PFSuperClusterCollectionBarrel", "particleFlowSuperClusterECALBarrel");
   {
     edm::ParameterSetDescription psd0;
     psd0.add<bool>("isHLT", false);
     psd0.add<bool>("applySigmaIetaIphiBug", false);
-    psd0.add<edm::InputTag>("ecalRecHitsEE",edm::InputTag("ecalRecHit","EcalRecHitsEE"));
-    psd0.add<edm::InputTag>("ecalRecHitsEB",edm::InputTag("ecalRecHit","EcalRecHitsEB"));
-    psd0.add<std::string>("regressionKeyEB","pfscecal_EBCorrection_offline_v1");
-    psd0.add<std::string>("regressionKeyEE","pfscecal_EECorrection_offline_v1");
-    psd0.add<std::string>("uncertaintyKeyEB","pfscecal_EBUncertainty_offline_v1");
-    psd0.add<std::string>("uncertaintyKeyEE","pfscecal_EEUncertainty_offline_v1");
-    psd0.add<edm::InputTag>("vertexCollection",edm::InputTag("offlinePrimaryVertices")); 
+    psd0.add<edm::InputTag>("ecalRecHitsEE", edm::InputTag("ecalRecHit", "EcalRecHitsEE"));
+    psd0.add<edm::InputTag>("ecalRecHitsEB", edm::InputTag("ecalRecHit", "EcalRecHitsEB"));
+    psd0.add<std::string>("regressionKeyEB", "pfscecal_EBCorrection_offline_v1");
+    psd0.add<std::string>("regressionKeyEE", "pfscecal_EECorrection_offline_v1");
+    psd0.add<std::string>("uncertaintyKeyEB", "pfscecal_EBUncertainty_offline_v1");
+    psd0.add<std::string>("uncertaintyKeyEE", "pfscecal_EEUncertainty_offline_v1");
+    psd0.add<edm::InputTag>("vertexCollection", edm::InputTag("offlinePrimaryVertices"));
     psd0.add<double>("eRecHitThreshold", 1.);
-    desc.add<edm::ParameterSetDescription>("regressionConfig",psd0);
+    desc.add<edm::ParameterSetDescription>("regressionConfig", psd0);
   }
-  desc.add<bool>("applyCrackCorrections",false);
-  desc.add<double>("satelliteClusterSeedThreshold",50.0);
-  desc.add<double>("etawidth_SuperClusterBarrel",0.04);
-  desc.add<std::string>("PFBasicClusterCollectionEndcap","particleFlowBasicClusterECALEndcap");
-  desc.add<edm::InputTag>("PFClusters",edm::InputTag("particleFlowClusterECAL"));
-  desc.add<double>("thresh_PFClusterSeedBarrel",1.0);
-  desc.add<std::string>("ClusteringType","Mustache");
-  desc.add<std::string>("EnergyWeight","Raw");
-  desc.add<edm::InputTag>("BeamSpot",edm::InputTag("offlineBeamSpot"));
-  desc.add<double>("thresh_PFClusterSeedEndcap",1.0);
-  desc.add<double>("phiwidth_SuperClusterBarrel",0.6);
-  desc.add<double>("thresh_PFClusterES",0.0);
-  desc.add<bool>("seedThresholdIsET",true);
-  desc.add<bool>("isOOTCollection",false);
-  desc.add<edm::InputTag>("barrelRecHits",edm::InputTag("ecalRecHit","EcalRecHitsEE"));
-  desc.add<edm::InputTag>("endcapRecHits",edm::InputTag("ecalRecHit","EcalRecHitsEB"));
-  desc.add<std::string>("PFSuperClusterCollectionEndcapWithPreshower","particleFlowSuperClusterECALEndcapWithPreshower");
-  desc.add<bool>("dropUnseedable",false);
-  descriptions.add("particleFlowSuperClusterECALMustache",desc);
+  desc.add<bool>("applyCrackCorrections", false);
+  desc.add<double>("satelliteClusterSeedThreshold", 50.0);
+  desc.add<double>("etawidth_SuperClusterBarrel", 0.04);
+  desc.add<std::string>("PFBasicClusterCollectionEndcap", "particleFlowBasicClusterECALEndcap");
+  desc.add<edm::InputTag>("PFClusters", edm::InputTag("particleFlowClusterECAL"));
+  desc.add<double>("thresh_PFClusterSeedBarrel", 1.0);
+  desc.add<std::string>("ClusteringType", "Mustache");
+  desc.add<std::string>("EnergyWeight", "Raw");
+  desc.add<edm::InputTag>("BeamSpot", edm::InputTag("offlineBeamSpot"));
+  desc.add<double>("thresh_PFClusterSeedEndcap", 1.0);
+  desc.add<double>("phiwidth_SuperClusterBarrel", 0.6);
+  desc.add<double>("thresh_PFClusterES", 0.0);
+  desc.add<bool>("seedThresholdIsET", true);
+  desc.add<bool>("isOOTCollection", false);
+  desc.add<edm::InputTag>("barrelRecHits", edm::InputTag("ecalRecHit", "EcalRecHitsEE"));
+  desc.add<edm::InputTag>("endcapRecHits", edm::InputTag("ecalRecHit", "EcalRecHitsEB"));
+  desc.add<std::string>("PFSuperClusterCollectionEndcapWithPreshower",
+                        "particleFlowSuperClusterECALEndcapWithPreshower");
+  desc.add<bool>("dropUnseedable", false);
+  descriptions.add("particleFlowSuperClusterECALMustache", desc);
 }

--- a/RecoEcal/EgammaClusterProducers/src/PreshowerClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PreshowerClusterProducer.cc
@@ -46,241 +46,239 @@ using namespace edm;
 using namespace std;
 
 PreshowerClusterProducer::PreshowerClusterProducer(const edm::ParameterSet& ps) {
+  // use configuration file to setup input/output collection names
+  preshHitsToken_ = consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("preshRecHitProducer"));
 
-  // use configuration file to setup input/output collection names 
-  preshHitsToken_   = 
-	  consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("preshRecHitProducer"));
-  
   // Name of a SuperClusterCollection to make associations:
-  endcapSClusterToken_   = 
-	  consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("endcapSClusterProducer"));
-  
+  endcapSClusterToken_ =
+      consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("endcapSClusterProducer"));
+
   // Output collections:
   preshClusterCollectionX_ = ps.getParameter<std::string>("preshClusterCollectionX");
   preshClusterCollectionY_ = ps.getParameter<std::string>("preshClusterCollectionY");
-  preshNclust_             = ps.getParameter<int>("preshNclust");
-  
-  etThresh_ =  ps.getParameter<double>("etThresh");
-  
+  preshNclust_ = ps.getParameter<int>("preshNclust");
+
+  etThresh_ = ps.getParameter<double>("etThresh");
+
   assocSClusterCollection_ = ps.getParameter<std::string>("assocSClusterCollection");
-  
-  produces< reco::PreshowerClusterCollection >(preshClusterCollectionX_);
-  produces< reco::PreshowerClusterCollection >(preshClusterCollectionY_);
-  produces< reco::SuperClusterCollection >(assocSClusterCollection_);
-  
+
+  produces<reco::PreshowerClusterCollection>(preshClusterCollectionX_);
+  produces<reco::PreshowerClusterCollection>(preshClusterCollectionY_);
+  produces<reco::SuperClusterCollection>(assocSClusterCollection_);
+
   float preshStripECut = ps.getParameter<double>("preshStripEnergyCut");
-  int preshSeededNst   = ps.getParameter<int>("preshSeededNstrip");
+  int preshSeededNst = ps.getParameter<int>("preshSeededNstrip");
   preshClustECut = ps.getParameter<double>("preshClusterEnergyCut");
 
-  presh_algo = new PreshowerClusterAlgo(preshStripECut,preshClustECut,preshSeededNst);
+  presh_algo = new PreshowerClusterAlgo(preshStripECut, preshClustECut, preshSeededNst);
 
-  nEvt_ = 0;  
+  nEvt_ = 0;
 }
 
-
-PreshowerClusterProducer::~PreshowerClusterProducer() {
-  delete presh_algo;
-}
+PreshowerClusterProducer::~PreshowerClusterProducer() { delete presh_algo; }
 
 void PreshowerClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
-  
-  edm::Handle< EcalRecHitCollection >   pRecHits;
-  edm::Handle< reco::SuperClusterCollection > pSuperClusters;
-  
+  edm::Handle<EcalRecHitCollection> pRecHits;
+  edm::Handle<reco::SuperClusterCollection> pSuperClusters;
+
   // get the ECAL geometry:
   edm::ESHandle<CaloGeometry> geoHandle;
   es.get<CaloGeometryRecord>().get(geoHandle);
-  
+
   // retrieve ES-EE intercalibration constants and channel status
   set(es);
-  const ESChannelStatus *channelStatus = esChannelStatus_.product();
-  
-  const CaloSubdetectorGeometry *geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
-  
+  const ESChannelStatus* channelStatus = esChannelStatus_.product();
+
+  const CaloSubdetectorGeometry* geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
+
   // create unique_ptr to a PreshowerClusterCollection
   auto clusters_p1 = std::make_unique<reco::PreshowerClusterCollection>();
   auto clusters_p2 = std::make_unique<reco::PreshowerClusterCollection>();
   // create new collection of corrected super clusters
   auto superclusters_p = std::make_unique<reco::SuperClusterCollection>();
-  
+
   std::unique_ptr<CaloSubdetectorTopology> topology_p;
   if (geometry_p)
-    topology_p  = std::make_unique<EcalPreshowerTopology>();
-  
+    topology_p = std::make_unique<EcalPreshowerTopology>();
+
   // fetch the product (pSuperClusters)
-  evt.getByToken(endcapSClusterToken_, pSuperClusters);   
+  evt.getByToken(endcapSClusterToken_, pSuperClusters);
   const reco::SuperClusterCollection* SClusts = pSuperClusters.product();
-  
+
   // fetch the product (RecHits)
-  evt.getByToken( preshHitsToken_, pRecHits);
+  evt.getByToken(preshHitsToken_, pRecHits);
   // pointer to the object in the product
-  const EcalRecHitCollection* rechits = pRecHits.product(); // EcalRecHitCollection hit_collection = *rhcHandle;
-  
-  LogTrace("EcalClusters") << "PreshowerClusterProducerInfo: ### Total # of preshower RecHits: "<< rechits->size();
-  
+  const EcalRecHitCollection* rechits = pRecHits.product();  // EcalRecHitCollection hit_collection = *rhcHandle;
+
+  LogTrace("EcalClusters") << "PreshowerClusterProducerInfo: ### Total # of preshower RecHits: " << rechits->size();
+
   // make the map of rechits:
   std::map<DetId, EcalRecHit> rechits_map;
   EcalRecHitCollection::const_iterator it;
   for (it = rechits->begin(); it != rechits->end(); it++) {
     // remove bad ES rechits
-    if (it->recoFlag()==1 || it->recoFlag()==14 || (it->recoFlag()<=10 && it->recoFlag()>=5)) continue;
+    if (it->recoFlag() == 1 || it->recoFlag() == 14 || (it->recoFlag() <= 10 && it->recoFlag() >= 5))
+      continue;
     //Make the map of DetID, EcalRecHit pairs
-    rechits_map.insert(std::make_pair(it->id(), *it));   
+    rechits_map.insert(std::make_pair(it->id(), *it));
   }
   // The set of used DetID's for a given event:
   std::set<DetId> used_strips;
   used_strips.clear();
-  LogTrace("EcalClusters") << "PreshowerClusterProducerInfo: ### rechits_map of size " << rechits_map.size() <<" was created!";
-  
-  
-  reco::PreshowerClusterCollection clusters1, clusters2;   // output collection of corrected PCs
-  reco::SuperClusterCollection new_SC; // output collection of corrected SCs
-  
+  LogTrace("EcalClusters") << "PreshowerClusterProducerInfo: ### rechits_map of size " << rechits_map.size()
+                           << " was created!";
+
+  reco::PreshowerClusterCollection clusters1, clusters2;  // output collection of corrected PCs
+  reco::SuperClusterCollection new_SC;                    // output collection of corrected SCs
+
   //make cycle over super clusters
   reco::SuperClusterCollection::const_iterator it_super;
-  int isc  = 0;
-  for (it_super=SClusts->begin();  it_super!=SClusts->end(); ++it_super) {     
-
-    float e1     = 0;
-    float e2     = 0;
+  int isc = 0;
+  for (it_super = SClusts->begin(); it_super != SClusts->end(); ++it_super) {
+    float e1 = 0;
+    float e2 = 0;
     float deltaE = 0;
 
-    reco::CaloClusterPtrVector new_BC; 
+    reco::CaloClusterPtrVector new_BC;
     ++isc;
-    LogTrace("EcalClusters")<< " superE = " << it_super->energy() << " superETA = " << it_super->eta() << " superPHI = " << it_super->phi() ;
-    
+    LogTrace("EcalClusters") << " superE = " << it_super->energy() << " superETA = " << it_super->eta()
+                             << " superPHI = " << it_super->phi();
+
     int nBC = 0;
-    int condP1 = 1; // 0: dead channel; 1: active channel
+    int condP1 = 1;  // 0: dead channel; 1: active channel
     int condP2 = 1;
     reco::CaloCluster_iterator bc_iter = it_super->clustersBegin();
-    for ( ; bc_iter !=it_super->clustersEnd(); ++bc_iter ) {  
+    for (; bc_iter != it_super->clustersEnd(); ++bc_iter) {
       if (geometry_p) {
-	
-	// Get strip position at intersection point of the line EE - Vertex:
-	double X = (*bc_iter)->x();
-	double Y = (*bc_iter)->y();
-	double Z = (*bc_iter)->z();        
-	const GlobalPoint point(X,Y,Z);    
-	
-	DetId tmp1 = (dynamic_cast<const EcalPreshowerGeometry*>(geometry_p))->getClosestCellInPlane(point, 1);
-	DetId tmp2 = (dynamic_cast<const EcalPreshowerGeometry*>(geometry_p))->getClosestCellInPlane(point, 2);
-	ESDetId strip1 = (tmp1 == DetId(0)) ? ESDetId(0) : ESDetId(tmp1);
-	ESDetId strip2 = (tmp2 == DetId(0)) ? ESDetId(0) : ESDetId(tmp2);     
-	
-	if (nBC == 0) {
-	  if (strip1 != ESDetId(0) && strip2 != ESDetId(0)) {
-	    ESChannelStatusMap::const_iterator status_p1 = channelStatus->getMap().find(strip1);
-	    ESChannelStatusMap::const_iterator status_p2 = channelStatus->getMap().find(strip2);
-	    if (status_p1->getStatusCode() == 1) condP1 = 0;
-	    if (status_p2->getStatusCode() == 1) condP2 = 0;
-	  } else if (strip1 == ESDetId(0))
-	    condP1 = 0;
-	  else if (strip2 == ESDetId(0))
-	    condP2 = 0;
-	}
-	
-	// Get a vector of ES clusters (found by the PreshSeeded algorithm) associated with a given EE basic cluster.           
-	for (int i=0; i<preshNclust_; i++) {
-	  reco::PreshowerCluster cl1 = presh_algo->makeOneCluster(strip1,&used_strips,&rechits_map,geometry_p,topology_p.get());
-	  cl1.setBCRef(*bc_iter);
-	  if (cl1.energy() > preshClustECut) {
-	    clusters1.push_back(cl1);
-	    e1 += cl1.energy();       
-	  }
-	  reco::PreshowerCluster cl2 = presh_algo->makeOneCluster(strip2,&used_strips,&rechits_map,geometry_p,topology_p.get());
-	  cl2.setBCRef(*bc_iter);
-	  
-	  if ( cl2.energy() > preshClustECut) {
-	    clusters2.push_back(cl2);
-	    e2 += cl2.energy();
-	  }	                               
-	} // end of cycle over ES clusters
+        // Get strip position at intersection point of the line EE - Vertex:
+        double X = (*bc_iter)->x();
+        double Y = (*bc_iter)->y();
+        double Z = (*bc_iter)->z();
+        const GlobalPoint point(X, Y, Z);
+
+        DetId tmp1 = (dynamic_cast<const EcalPreshowerGeometry*>(geometry_p))->getClosestCellInPlane(point, 1);
+        DetId tmp2 = (dynamic_cast<const EcalPreshowerGeometry*>(geometry_p))->getClosestCellInPlane(point, 2);
+        ESDetId strip1 = (tmp1 == DetId(0)) ? ESDetId(0) : ESDetId(tmp1);
+        ESDetId strip2 = (tmp2 == DetId(0)) ? ESDetId(0) : ESDetId(tmp2);
+
+        if (nBC == 0) {
+          if (strip1 != ESDetId(0) && strip2 != ESDetId(0)) {
+            ESChannelStatusMap::const_iterator status_p1 = channelStatus->getMap().find(strip1);
+            ESChannelStatusMap::const_iterator status_p2 = channelStatus->getMap().find(strip2);
+            if (status_p1->getStatusCode() == 1)
+              condP1 = 0;
+            if (status_p2->getStatusCode() == 1)
+              condP2 = 0;
+          } else if (strip1 == ESDetId(0))
+            condP1 = 0;
+          else if (strip2 == ESDetId(0))
+            condP2 = 0;
+        }
+
+        // Get a vector of ES clusters (found by the PreshSeeded algorithm) associated with a given EE basic cluster.
+        for (int i = 0; i < preshNclust_; i++) {
+          reco::PreshowerCluster cl1 =
+              presh_algo->makeOneCluster(strip1, &used_strips, &rechits_map, geometry_p, topology_p.get());
+          cl1.setBCRef(*bc_iter);
+          if (cl1.energy() > preshClustECut) {
+            clusters1.push_back(cl1);
+            e1 += cl1.energy();
+          }
+          reco::PreshowerCluster cl2 =
+              presh_algo->makeOneCluster(strip2, &used_strips, &rechits_map, geometry_p, topology_p.get());
+          cl2.setBCRef(*bc_iter);
+
+          if (cl2.energy() > preshClustECut) {
+            clusters2.push_back(cl2);
+            e2 += cl2.energy();
+          }
+        }  // end of cycle over ES clusters
       }
-      
+
       new_BC.push_back(*bc_iter);
       nBC++;
     }  // end of cycle over BCs
-    
-    LogTrace("EcalClusters") << " For SC #" << isc-1 << ", containing " 
-			     << it_super->clustersSize() 			      
-			     << " basic clusters, PreshowerClusterAlgo made " 
-			     << clusters1.size() << " in X plane and " 
-			     << clusters2.size()       
-			     << " in Y plane " << " preshower clusters " ;
-    
-    // update energy of the SuperCluster    
-    if(e1+e2 > 1.0e-10) {
 
-      e1 = e1 / mip_; // GeV to #MIPs
+    LogTrace("EcalClusters") << " For SC #" << isc - 1 << ", containing " << it_super->clustersSize()
+                             << " basic clusters, PreshowerClusterAlgo made " << clusters1.size() << " in X plane and "
+                             << clusters2.size() << " in Y plane "
+                             << " preshower clusters ";
+
+    // update energy of the SuperCluster
+    if (e1 + e2 > 1.0e-10) {
+      e1 = e1 / mip_;  // GeV to #MIPs
       e2 = e2 / mip_;
-      
+
       if (condP1 == 1 && condP2 == 1) {
-	deltaE = gamma0_*(e1 + alpha0_*e2);       
+        deltaE = gamma0_ * (e1 + alpha0_ * e2);
       } else if (condP1 == 1 && condP2 == 0) {
-	deltaE = gamma1_*(e1 + alpha1_*e2);       
+        deltaE = gamma1_ * (e1 + alpha1_ * e2);
       } else if (condP1 == 0 && condP2 == 1) {
-	deltaE = gamma2_*(e1 + alpha2_*e2);       
+        deltaE = gamma2_ * (e1 + alpha2_ * e2);
       } else if (condP1 == 0 && condP2 == 0) {
-	deltaE = gamma3_*(e1 + alpha3_*e2);       
+        deltaE = gamma3_ * (e1 + alpha3_ * e2);
       }
     }
-    
+
     //corrected Energy
     float E = it_super->energy() + deltaE;
-    
+
     LogTrace("EcalClusters") << " Creating corrected SC ";
-    
+
     reco::SuperCluster sc(E, it_super->position(), it_super->seed(), new_BC, deltaE);
-    if (condP1 == 1 && condP2 == 1) sc.setPreshowerPlanesStatus(0);
-    else if (condP1 == 1 && condP2 == 0) sc.setPreshowerPlanesStatus(1);
-    else if (condP1 == 0 && condP2 == 1) sc.setPreshowerPlanesStatus(2);
-    else if (condP1 == 0 && condP2 == 0) sc.setPreshowerPlanesStatus(3);
-    
-    if (sc.energy()*sin(sc.position().theta())>etThresh_)
+    if (condP1 == 1 && condP2 == 1)
+      sc.setPreshowerPlanesStatus(0);
+    else if (condP1 == 1 && condP2 == 0)
+      sc.setPreshowerPlanesStatus(1);
+    else if (condP1 == 0 && condP2 == 1)
+      sc.setPreshowerPlanesStatus(2);
+    else if (condP1 == 0 && condP2 == 0)
+      sc.setPreshowerPlanesStatus(3);
+
+    if (sc.energy() * sin(sc.position().theta()) > etThresh_)
       new_SC.push_back(sc);
-    LogTrace("EcalClusters") << " SuperClusters energies: new E = " << sc.energy() << " vs. old E =" << it_super->energy();
-    
-  } // end of cycle over SCs
-  
+    LogTrace("EcalClusters") << " SuperClusters energies: new E = " << sc.energy()
+                             << " vs. old E =" << it_super->energy();
+
+  }  // end of cycle over SCs
+
   // copy the preshower clusters into collections and put in the Event:
   clusters_p1->assign(clusters1.begin(), clusters1.end());
   clusters_p2->assign(clusters2.begin(), clusters2.end());
   // put collection of preshower clusters to the event
   evt.put(std::move(clusters_p1), preshClusterCollectionX_);
   evt.put(std::move(clusters_p2), preshClusterCollectionY_);
-  LogTrace("EcalClusters") << "Preshower clusters added to the event" ;
-  
+  LogTrace("EcalClusters") << "Preshower clusters added to the event";
+
   // put collection of corrected super clusters to the event
   superclusters_p->assign(new_SC.begin(), new_SC.end());
   evt.put(std::move(superclusters_p), assocSClusterCollection_);
-  LogTrace("EcalClusters") << "Corrected SClusters added to the event" ;
-  
+  LogTrace("EcalClusters") << "Corrected SClusters added to the event";
+
   nEvt_++;
-  
 }
 
 void PreshowerClusterProducer::set(const edm::EventSetup& es) {
-  
   es.get<ESGainRcd>().get(esgain_);
-  const ESGain *gain = esgain_.product();
-  
+  const ESGain* gain = esgain_.product();
+
   double ESGain = gain->getESGain();
 
   es.get<ESMIPToGeVConstantRcd>().get(esMIPToGeV_);
-  const ESMIPToGeVConstant *mipToGeV = esMIPToGeV_.product();
+  const ESMIPToGeVConstant* mipToGeV = esMIPToGeV_.product();
 
-  mip_ = (ESGain == 1) ? mipToGeV->getESValueLow() : mipToGeV->getESValueHigh(); 
+  mip_ = (ESGain == 1) ? mipToGeV->getESValueLow() : mipToGeV->getESValueHigh();
 
   es.get<ESChannelStatusRcd>().get(esChannelStatus_);
 
   es.get<ESEEIntercalibConstantsRcd>().get(esEEInterCalib_);
-  const ESEEIntercalibConstants *esEEInterCalib = esEEInterCalib_.product();
+  const ESEEIntercalibConstants* esEEInterCalib = esEEInterCalib_.product();
 
   // both planes work
   gamma0_ = (ESGain == 1) ? 0.02 : esEEInterCalib->getGammaHigh0();
   alpha0_ = (ESGain == 1) ? esEEInterCalib->getAlphaLow0() : esEEInterCalib->getAlphaHigh0();
 
-  // only first plane works 
+  // only first plane works
   gamma1_ = (ESGain == 1) ? (0.02 * esEEInterCalib->getGammaLow1()) : esEEInterCalib->getGammaHigh1();
   alpha1_ = (ESGain == 1) ? esEEInterCalib->getAlphaLow1() : esEEInterCalib->getAlphaHigh1();
 
@@ -293,7 +291,7 @@ void PreshowerClusterProducer::set(const edm::EventSetup& es) {
   alpha3_ = (ESGain == 1) ? esEEInterCalib->getAlphaLow3() : esEEInterCalib->getAlphaHigh3();
 
   es.get<ESMissingEnergyCalibrationRcd>().get(esMissingECalib_);
-  const ESMissingEnergyCalibration * esMissingECalib = esMissingECalib_.product();
+  const ESMissingEnergyCalibration* esMissingECalib = esMissingECalib_.product();
 
   // |eta| < 1.9
   aEta_[0] = esMissingECalib->getConstAEta0();
@@ -310,5 +308,4 @@ void PreshowerClusterProducer::set(const edm::EventSetup& es) {
   // 2.3 < |eta| < 2.5
   aEta_[3] = esMissingECalib->getConstAEta3();
   bEta_[3] = esMissingECalib->getConstBEta3();
-
 }

--- a/RecoEcal/EgammaClusterProducers/src/PreshowerClusterShapeProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PreshowerClusterShapeProducer.cc
@@ -40,153 +40,139 @@ using namespace edm;
 PreshowerClusterShapeProducer::PreshowerClusterShapeProducer(const ParameterSet& ps) {
   // use configuration file to setup input/output collection names
   // Parameters to identify the hit collections
-  preshHitToken_   = 
-	  consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("preshRecHitProducer"));
-  endcapSClusterToken_   = 
-	  consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("endcapSClusterProducer"));
+  preshHitToken_ = consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("preshRecHitProducer"));
+  endcapSClusterToken_ =
+      consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("endcapSClusterProducer"));
 
   PreshowerClusterShapeCollectionX_ = ps.getParameter<string>("PreshowerClusterShapeCollectionX");
   PreshowerClusterShapeCollectionY_ = ps.getParameter<string>("PreshowerClusterShapeCollectionY");
 
-  produces< reco::PreshowerClusterShapeCollection >(PreshowerClusterShapeCollectionX_);
-  produces< reco::PreshowerClusterShapeCollection >(PreshowerClusterShapeCollectionY_);
-  
+  produces<reco::PreshowerClusterShapeCollection>(PreshowerClusterShapeCollectionX_);
+  produces<reco::PreshowerClusterShapeCollection>(PreshowerClusterShapeCollectionY_);
+
   float preshStripECut = ps.getParameter<double>("preshStripEnergyCut");
   int preshNst = ps.getParameter<int>("preshPi0Nstrip");
-  
+
   string debugString = ps.getParameter<string>("debugLevel");
 
+  string tmpPath = ps.getUntrackedParameter<string>("pathToWeightFiles", "RecoEcal/EgammaClusterProducers/data/");
 
-  string tmpPath = ps.getUntrackedParameter<string>("pathToWeightFiles","RecoEcal/EgammaClusterProducers/data/");
-  
-  presh_pi0_algo = new EndcapPiZeroDiscriminatorAlgo(preshStripECut, preshNst, tmpPath); 
+  presh_pi0_algo = new EndcapPiZeroDiscriminatorAlgo(preshStripECut, preshNst, tmpPath);
 
-  LogTrace("EcalClusters") << "PreshowerClusterShapeProducer:presh_pi0_algo class instantiated " ;
-  
-  
+  LogTrace("EcalClusters") << "PreshowerClusterShapeProducer:presh_pi0_algo class instantiated ";
+
   nEvt_ = 0;
-
 }
 
-
-PreshowerClusterShapeProducer::~PreshowerClusterShapeProducer() {
-   delete presh_pi0_algo;
-}
-
+PreshowerClusterShapeProducer::~PreshowerClusterShapeProducer() { delete presh_pi0_algo; }
 
 void PreshowerClusterShapeProducer::produce(Event& evt, const EventSetup& es) {
+  ostringstream ostr;  // use this stream for all messages in produce
 
-  ostringstream ostr; // use this stream for all messages in produce
+  LogTrace("EcalClusters") << "\n .......  Event " << evt.id() << " with Number = " << nEvt_ + 1
+                           << " is analyzing ....... ";
 
-  LogTrace("EcalClusters") << "\n .......  Event " << evt.id() << " with Number = " <<  nEvt_+1 << " is analyzing ....... " ;
-
-
-  Handle< EcalRecHitCollection >   pRecHits;
-  Handle< SuperClusterCollection > pSuperClusters;
+  Handle<EcalRecHitCollection> pRecHits;
+  Handle<SuperClusterCollection> pSuperClusters;
 
   // get the ECAL -> Preshower geometry and topology:
   ESHandle<CaloGeometry> geoHandle;
   es.get<CaloGeometryRecord>().get(geoHandle);
-  const CaloSubdetectorGeometry *geometry = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
-  const CaloSubdetectorGeometry *& geometry_p = geometry;
-
+  const CaloSubdetectorGeometry* geometry = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
+  const CaloSubdetectorGeometry*& geometry_p = geometry;
 
   // create a unique_ptr to a PreshowerClusterShapeCollection
   auto ps_cl_for_pi0_disc_x = std::make_unique<reco::PreshowerClusterShapeCollection>();
   auto ps_cl_for_pi0_disc_y = std::make_unique<reco::PreshowerClusterShapeCollection>();
 
-
   std::unique_ptr<CaloSubdetectorTopology> topology_p;
   if (geometry)
     topology_p = std::make_unique<EcalPreshowerTopology>();
 
-  
   // fetch the Preshower product (RecHits)
-  evt.getByToken( preshHitToken_, pRecHits);
+  evt.getByToken(preshHitToken_, pRecHits);
   // pointer to the object in the product
-  const EcalRecHitCollection* rechits = pRecHits.product(); 
-  
-  LogTrace("EcalClusters") << "PreshowerClusterShapeProducer: ### Total # of preshower RecHits: " << rechits->size() ;
-  
+  const EcalRecHitCollection* rechits = pRecHits.product();
+
+  LogTrace("EcalClusters") << "PreshowerClusterShapeProducer: ### Total # of preshower RecHits: " << rechits->size();
+
   //  if ( rechits->size() <= 0 ) return;
-  
+
   // make the map of Preshower rechits:
   map<DetId, EcalRecHit> rechits_map;
   EcalRecHitCollection::const_iterator it;
   for (it = rechits->begin(); it != rechits->end(); it++) {
-     rechits_map.insert(make_pair(it->id(), *it));
+    rechits_map.insert(make_pair(it->id(), *it));
   }
-  
-  LogTrace("EcalClusters") << "PreshowerClusterShapeProducer: ### Preshower RecHits_map of size " << rechits_map.size() <<" was created!" ;
-  
+
+  LogTrace("EcalClusters") << "PreshowerClusterShapeProducer: ### Preshower RecHits_map of size " << rechits_map.size()
+                           << " was created!";
+
   reco::PreshowerClusterShapeCollection ps_cl_x, ps_cl_y;
 
   //make cycle over Photon Collection
-  int SC_index  = 0;
-//  Handle<PhotonCollection> correctedPhotonHandle; 
-//  evt.getByLabel(photonCorrCollectionProducer_, correctedPhotonCollection_ , correctedPhotonHandle);
-//  const PhotonCollection corrPhoCollection = *(correctedPhotonHandle.product());
-//  cout << " Photon Collection size : " << corrPhoCollection.size() << endl;
+  int SC_index = 0;
+  //  Handle<PhotonCollection> correctedPhotonHandle;
+  //  evt.getByLabel(photonCorrCollectionProducer_, correctedPhotonCollection_ , correctedPhotonHandle);
+  //  const PhotonCollection corrPhoCollection = *(correctedPhotonHandle.product());
+  //  cout << " Photon Collection size : " << corrPhoCollection.size() << endl;
 
   evt.getByToken(endcapSClusterToken_, pSuperClusters);
   const reco::SuperClusterCollection* SClusts = pSuperClusters.product();
-  LogTrace("EcalClusters") << "### Total # Endcap Superclusters: " << SClusts->size() ;
+  LogTrace("EcalClusters") << "### Total # Endcap Superclusters: " << SClusts->size();
 
   SuperClusterCollection::const_iterator it_s;
-  for ( it_s=SClusts->begin();  it_s!=SClusts->end(); it_s++ ) {
+  for (it_s = SClusts->begin(); it_s != SClusts->end(); it_s++) {
+    SuperClusterRef it_super(reco::SuperClusterRef(pSuperClusters, SC_index));
 
-      SuperClusterRef it_super(reco::SuperClusterRef(pSuperClusters,SC_index));
-      
-      float SC_eta  = it_super->eta();
+    float SC_eta = it_super->eta();
 
-      LogTrace("EcalClusters") << "PreshowerClusterShapeProducer: superCl_E = " << it_super->energy() << " superCl_Et = " << it_super->energy()*sin(2*atan(exp(-it_super->eta()))) << " superCl_Eta = " << SC_eta << " superCl_Phi = " << it_super->phi() ;
+    LogTrace("EcalClusters") << "PreshowerClusterShapeProducer: superCl_E = " << it_super->energy()
+                             << " superCl_Et = " << it_super->energy() * sin(2 * atan(exp(-it_super->eta())))
+                             << " superCl_Eta = " << SC_eta << " superCl_Phi = " << it_super->phi();
 
-      
-      if(fabs(SC_eta) >= 1.65 && fabs(SC_eta) <= 2.5) 
-	{  //  Use Preshower region only
-	  if (geometry)
-	    {
-	      const GlobalPoint pointSC(it_super->x(),it_super->y(),it_super->z()); // get the centroid of the SC
-	      LogTrace("EcalClusters") << "SC centroind = " << pointSC ;
-	      
-	      // Get the Preshower 2-planes RecHit vectors associated with the given SC
-	      
-	      DetId tmp_stripX = (dynamic_cast<const EcalPreshowerGeometry*>(geometry_p))->getClosestCellInPlane(pointSC, 1);
-	      DetId tmp_stripY = (dynamic_cast<const EcalPreshowerGeometry*>(geometry_p))->getClosestCellInPlane(pointSC, 2);
-	      ESDetId stripX = (tmp_stripX == DetId(0)) ? ESDetId(0) : ESDetId(tmp_stripX);
-	      ESDetId stripY = (tmp_stripY == DetId(0)) ? ESDetId(0) : ESDetId(tmp_stripY);
-	      
-	      vector<float> vout_stripE1 = presh_pi0_algo->findPreshVector(stripX, &rechits_map, topology_p.get());
-	      vector<float> vout_stripE2 = presh_pi0_algo->findPreshVector(stripY, &rechits_map, topology_p.get());
-	      
-	      LogTrace("EcalClusters") << "PreshowerClusterShapeProducer : ES Energy vector associated to the given SC = " ;
-	      for(int k1=0;k1<11;k1++) {
-		LogTrace("EcalClusters") << vout_stripE1[k1] << " " ;
-	      }
-	      
-	      for(int k1=0;k1<11;k1++) {
-		LogTrace("EcalClusters")  << vout_stripE2[k1] << " " ;
-	      } 
-	      
-	      reco::PreshowerClusterShape ps1 = reco::PreshowerClusterShape(vout_stripE1,1);
-	      ps1.setSCRef(it_super);
-	      ps_cl_x.push_back(ps1);
-	      
-	      reco::PreshowerClusterShape ps2 = reco::PreshowerClusterShape(vout_stripE2,2);
-	      ps2.setSCRef(it_super);
-	      ps_cl_y.push_back(ps2);
-	      
-	    }
-	  SC_index++;
-	} // end of cycle over Endcap SC       
-  } 
+    if (fabs(SC_eta) >= 1.65 && fabs(SC_eta) <= 2.5) {  //  Use Preshower region only
+      if (geometry) {
+        const GlobalPoint pointSC(it_super->x(), it_super->y(), it_super->z());  // get the centroid of the SC
+        LogTrace("EcalClusters") << "SC centroind = " << pointSC;
+
+        // Get the Preshower 2-planes RecHit vectors associated with the given SC
+
+        DetId tmp_stripX = (dynamic_cast<const EcalPreshowerGeometry*>(geometry_p))->getClosestCellInPlane(pointSC, 1);
+        DetId tmp_stripY = (dynamic_cast<const EcalPreshowerGeometry*>(geometry_p))->getClosestCellInPlane(pointSC, 2);
+        ESDetId stripX = (tmp_stripX == DetId(0)) ? ESDetId(0) : ESDetId(tmp_stripX);
+        ESDetId stripY = (tmp_stripY == DetId(0)) ? ESDetId(0) : ESDetId(tmp_stripY);
+
+        vector<float> vout_stripE1 = presh_pi0_algo->findPreshVector(stripX, &rechits_map, topology_p.get());
+        vector<float> vout_stripE2 = presh_pi0_algo->findPreshVector(stripY, &rechits_map, topology_p.get());
+
+        LogTrace("EcalClusters") << "PreshowerClusterShapeProducer : ES Energy vector associated to the given SC = ";
+        for (int k1 = 0; k1 < 11; k1++) {
+          LogTrace("EcalClusters") << vout_stripE1[k1] << " ";
+        }
+
+        for (int k1 = 0; k1 < 11; k1++) {
+          LogTrace("EcalClusters") << vout_stripE2[k1] << " ";
+        }
+
+        reco::PreshowerClusterShape ps1 = reco::PreshowerClusterShape(vout_stripE1, 1);
+        ps1.setSCRef(it_super);
+        ps_cl_x.push_back(ps1);
+
+        reco::PreshowerClusterShape ps2 = reco::PreshowerClusterShape(vout_stripE2, 2);
+        ps2.setSCRef(it_super);
+        ps_cl_y.push_back(ps2);
+      }
+      SC_index++;
+    }  // end of cycle over Endcap SC
+  }
   // put collection of PreshowerClusterShape in the Event:
   ps_cl_for_pi0_disc_x->assign(ps_cl_x.begin(), ps_cl_x.end());
   ps_cl_for_pi0_disc_y->assign(ps_cl_y.begin(), ps_cl_y.end());
-  
+
   evt.put(std::move(ps_cl_for_pi0_disc_x), PreshowerClusterShapeCollectionX_);
-  evt.put(std::move(ps_cl_for_pi0_disc_y), PreshowerClusterShapeCollectionY_);  
-  LogTrace("EcalClusters") << "PreshowerClusterShapeCollection added to the event" ;
+  evt.put(std::move(ps_cl_for_pi0_disc_y), PreshowerClusterShapeCollectionY_);
+  LogTrace("EcalClusters") << "PreshowerClusterShapeCollection added to the event";
 
   nEvt_++;
 

--- a/RecoEcal/EgammaClusterProducers/src/PreshowerPhiClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PreshowerPhiClusterProducer.cc
@@ -42,256 +42,256 @@ using namespace edm;
 using namespace std;
 
 PreshowerPhiClusterProducer::PreshowerPhiClusterProducer(const edm::ParameterSet& ps) {
+  // use configuration file to setup input/output collection names
+  preshHitToken_ = consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("preshRecHitProducer"));
 
-  // use configuration file to setup input/output collection names 
-  preshHitToken_   =  
-	  consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("preshRecHitProducer"));
-  
   // Name of a SuperClusterCollection to make associations:
-  endcapSClusterToken_   = 
+  endcapSClusterToken_ =
       consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("endcapSClusterProducer"));
-  
+
   // Output collections:
   preshClusterCollectionX_ = ps.getParameter<std::string>("preshClusterCollectionX");
   preshClusterCollectionY_ = ps.getParameter<std::string>("preshClusterCollectionY");
-  
-  assocSClusterCollection_ = ps.getParameter<std::string>("assocSClusterCollection");
-  
-  produces< reco::PreshowerClusterCollection >(preshClusterCollectionX_);
-  produces< reco::PreshowerClusterCollection >(preshClusterCollectionY_);
-  produces< reco::SuperClusterCollection >(assocSClusterCollection_);
-  
-  float esStripECut          = ps.getParameter<double>("esStripEnergyCut");
-  esPhiClusterDeltaEta_      = ps.getParameter<double>("esPhiClusterDeltaEta");
-  esPhiClusterDeltaPhi_      = ps.getParameter<double>("esPhiClusterDeltaPhi");
 
-  etThresh_                  = ps.getParameter<double>("etThresh");
+  assocSClusterCollection_ = ps.getParameter<std::string>("assocSClusterCollection");
+
+  produces<reco::PreshowerClusterCollection>(preshClusterCollectionX_);
+  produces<reco::PreshowerClusterCollection>(preshClusterCollectionY_);
+  produces<reco::SuperClusterCollection>(assocSClusterCollection_);
+
+  float esStripECut = ps.getParameter<double>("esStripEnergyCut");
+  esPhiClusterDeltaEta_ = ps.getParameter<double>("esPhiClusterDeltaEta");
+  esPhiClusterDeltaPhi_ = ps.getParameter<double>("esPhiClusterDeltaPhi");
+
+  etThresh_ = ps.getParameter<double>("etThresh");
 
   presh_algo = new PreshowerPhiClusterAlgo(esStripECut);
 }
 
-PreshowerPhiClusterProducer::~PreshowerPhiClusterProducer() {
-  delete presh_algo;
-}
+PreshowerPhiClusterProducer::~PreshowerPhiClusterProducer() { delete presh_algo; }
 
 void PreshowerPhiClusterProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
-  
-  edm::Handle< EcalRecHitCollection >   pRecHits;
-  edm::Handle< reco::SuperClusterCollection > pSuperClusters;
-  
+  edm::Handle<EcalRecHitCollection> pRecHits;
+  edm::Handle<reco::SuperClusterCollection> pSuperClusters;
+
   // get the ECAL geometry:
   edm::ESHandle<CaloGeometry> geoHandle;
   es.get<CaloGeometryRecord>().get(geoHandle);
-  
+
   // retrieve ES-EE intercalibration constants and channel status
   set(es);
-  const ESChannelStatus *channelStatus = esChannelStatus_.product();
-  
-  const CaloSubdetectorGeometry *geometry_p = (geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower));
-  
+  const ESChannelStatus* channelStatus = esChannelStatus_.product();
+
+  const CaloSubdetectorGeometry* geometry_p = (geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower));
+
   // create unique_ptr to a PreshowerClusterCollection
   auto clusters_p1 = std::make_unique<reco::PreshowerClusterCollection>();
   auto clusters_p2 = std::make_unique<reco::PreshowerClusterCollection>();
   // create new collection of corrected super clusters
   auto superclusters_p = std::make_unique<reco::SuperClusterCollection>();
-  
+
   // fetch the product (pSuperClusters)
-  evt.getByToken(endcapSClusterToken_, pSuperClusters);   
+  evt.getByToken(endcapSClusterToken_, pSuperClusters);
   const reco::SuperClusterCollection* SClusts = pSuperClusters.product();
-  
+
   // fetch the product (RecHits)
-  evt.getByToken( preshHitToken_, pRecHits);
+  evt.getByToken(preshHitToken_, pRecHits);
   // pointer to the object in the product
-  const EcalRecHitCollection* rechits = pRecHits.product(); // EcalRecHitCollection hit_collection = *rhcHandle;
-  
-  LogTrace("EcalClusters") << "PreshowerPhiClusterProducerInfo: ### Total # of preshower RecHits: "<< rechits->size();
-  
+  const EcalRecHitCollection* rechits = pRecHits.product();  // EcalRecHitCollection hit_collection = *rhcHandle;
+
+  LogTrace("EcalClusters") << "PreshowerPhiClusterProducerInfo: ### Total # of preshower RecHits: " << rechits->size();
+
   // make the map of rechits:
   std::map<DetId, EcalRecHit> rechits_map;
   EcalRecHitCollection::const_iterator it;
   for (it = rechits->begin(); it != rechits->end(); it++) {
     // remove bad ES rechits
-    if (it->recoFlag()==1 || it->recoFlag()==14 || (it->recoFlag()<=10 && it->recoFlag()>=5)) continue;
+    if (it->recoFlag() == 1 || it->recoFlag() == 14 || (it->recoFlag() <= 10 && it->recoFlag() >= 5))
+      continue;
     //Make the map of DetID, EcalRecHit pairs
-    rechits_map.insert(std::make_pair(it->id(), *it));   
+    rechits_map.insert(std::make_pair(it->id(), *it));
   }
   // The set of used DetID's for a given event:
   std::set<DetId> used_strips;
   used_strips.clear();
-  LogTrace("EcalClusters") << "PreshowerPhiClusterProducerInfo: ### rechits_map of size " << rechits_map.size() <<" was created!";
-  
-  reco::PreshowerClusterCollection clusters1, clusters2;   // output collection of corrected PCs
-  reco::SuperClusterCollection new_SC; // output collection of corrected SCs
-  
+  LogTrace("EcalClusters") << "PreshowerPhiClusterProducerInfo: ### rechits_map of size " << rechits_map.size()
+                           << " was created!";
+
+  reco::PreshowerClusterCollection clusters1, clusters2;  // output collection of corrected PCs
+  reco::SuperClusterCollection new_SC;                    // output collection of corrected SCs
+
   //make cycle over super clusters
   reco::SuperClusterCollection::const_iterator it_super;
-  int isc  = 0;
-  for (it_super=SClusts->begin();  it_super!=SClusts->end(); ++it_super) {     
-
-    float e1     = 0;
-    float e2     = 0;
+  int isc = 0;
+  for (it_super = SClusts->begin(); it_super != SClusts->end(); ++it_super) {
+    float e1 = 0;
+    float e2 = 0;
     float deltaE = 0;
 
-    reco::CaloClusterPtrVector new_BC; 
+    reco::CaloClusterPtrVector new_BC;
     ++isc;
-    LogTrace("EcalClusters")<< " superE = " << it_super->energy() << " superETA = " << it_super->eta() << " superPHI = " << it_super->phi() ;
-    
+    LogTrace("EcalClusters") << " superE = " << it_super->energy() << " superETA = " << it_super->eta()
+                             << " superPHI = " << it_super->phi();
+
     //cout<<"=== new SC ==="<<endl;
     //cout<<"superE = "<<it_super->energy()<<" superETA = "<<it_super->eta()<<" superPHI = "<<it_super->phi()<<endl;
 
     int nBC = 0;
-    int condP1 = 1; // 0: dead channel; 1: active channel
+    int condP1 = 1;  // 0: dead channel; 1: active channel
     int condP2 = 1;
     float maxDeltaPhi = 0;
     float minDeltaPhi = 0;
-    float refPhi = 0; 
+    float refPhi = 0;
 
     reco::CaloCluster_iterator bc_iter = it_super->clustersBegin();
-    for ( ; bc_iter !=it_super->clustersEnd(); ++bc_iter) {
+    for (; bc_iter != it_super->clustersEnd(); ++bc_iter) {
       if (nBC == 0) {
-	refPhi = (*bc_iter)->phi();
+        refPhi = (*bc_iter)->phi();
       } else {
-	if (reco::deltaPhi((*bc_iter)->phi(), refPhi) > 0 && reco::deltaPhi((*bc_iter)->phi(), refPhi) > maxDeltaPhi)
-	  maxDeltaPhi = reco::deltaPhi((*bc_iter)->phi(), refPhi);
-	if (reco::deltaPhi((*bc_iter)->phi(), refPhi) < 0 && reco::deltaPhi((*bc_iter)->phi(), refPhi) < minDeltaPhi)
-	  minDeltaPhi = reco::deltaPhi((*bc_iter)->phi(), refPhi);
-	//cout<<"delta phi : "<<reco::deltaPhi((*bc_iter)->phi(), refPhi)<<endl;
+        if (reco::deltaPhi((*bc_iter)->phi(), refPhi) > 0 && reco::deltaPhi((*bc_iter)->phi(), refPhi) > maxDeltaPhi)
+          maxDeltaPhi = reco::deltaPhi((*bc_iter)->phi(), refPhi);
+        if (reco::deltaPhi((*bc_iter)->phi(), refPhi) < 0 && reco::deltaPhi((*bc_iter)->phi(), refPhi) < minDeltaPhi)
+          minDeltaPhi = reco::deltaPhi((*bc_iter)->phi(), refPhi);
+        //cout<<"delta phi : "<<reco::deltaPhi((*bc_iter)->phi(), refPhi)<<endl;
       }
-      //cout<<"BC : "<<nBC<<" "<<(*bc_iter)->energy()<<" "<<(*bc_iter)->eta()<<" "<<(*bc_iter)->phi()<<endl; 
+      //cout<<"BC : "<<nBC<<" "<<(*bc_iter)->energy()<<" "<<(*bc_iter)->eta()<<" "<<(*bc_iter)->phi()<<endl;
       nBC++;
     }
     maxDeltaPhi += esPhiClusterDeltaPhi_;
     minDeltaPhi -= esPhiClusterDeltaPhi_;
 
     nBC = 0;
-    for (bc_iter = it_super->clustersBegin() ; bc_iter !=it_super->clustersEnd(); ++bc_iter) {  
+    for (bc_iter = it_super->clustersBegin(); bc_iter != it_super->clustersEnd(); ++bc_iter) {
       if (geometry_p) {
-	
-	// Get strip position at intersection point of the line EE - Vertex:
-	double X = (*bc_iter)->x();
-	double Y = (*bc_iter)->y();
-	double Z = (*bc_iter)->z();        
-	const GlobalPoint point(X,Y,Z);    
-	
-	DetId tmp1 = (dynamic_cast<const EcalPreshowerGeometry*>(geometry_p))->getClosestCellInPlane(point, 1);
-	DetId tmp2 = (dynamic_cast<const EcalPreshowerGeometry*>(geometry_p))->getClosestCellInPlane(point, 2);
-	ESDetId strip1 = (tmp1 == DetId(0)) ? ESDetId(0) : ESDetId(tmp1);
-	ESDetId strip2 = (tmp2 == DetId(0)) ? ESDetId(0) : ESDetId(tmp2);     
+        // Get strip position at intersection point of the line EE - Vertex:
+        double X = (*bc_iter)->x();
+        double Y = (*bc_iter)->y();
+        double Z = (*bc_iter)->z();
+        const GlobalPoint point(X, Y, Z);
 
-	if (nBC == 0) {
-	  if (strip1 != ESDetId(0) && strip2 != ESDetId(0)) {
-	    ESChannelStatusMap::const_iterator status_p1 = channelStatus->getMap().find(strip1);
-	    ESChannelStatusMap::const_iterator status_p2 = channelStatus->getMap().find(strip2);
-	    if (status_p1->getStatusCode() == 1) condP1 = 0;
-	    if (status_p2->getStatusCode() == 1) condP2 = 0;
-	  } else if (strip1 == ESDetId(0)) {
-	    condP1 = 0;
-	  } else if (strip2 == ESDetId(0)) {
-	    condP2 = 0;
-	  }
-	  
-	  //cout<<"starting cluster : "<<maxDeltaPhi<<" "<<minDeltaPhi<<" "<<esPhiClusterDeltaEta_<<endl;
-	  //cout<<"do plane 1 === "<<strip1.zside()<<" "<<strip1.plane()<<" "<<strip1.six()<<" "<<strip1.siy()<<" "<<strip1.strip()<<endl;
-	  // Get a vector of ES clusters (found by the PreshSeeded algorithm) associated with a given EE basic cluster.           
-	  reco::PreshowerCluster cl1 = presh_algo->makeOneCluster(strip1,&used_strips,&rechits_map,geometry_p,esPhiClusterDeltaEta_,minDeltaPhi,maxDeltaPhi);
-	  cl1.setBCRef(*bc_iter);
-	  clusters1.push_back(cl1);
-	  e1 += cl1.energy();       
-	  
-	  //cout<<"do plane 2 === "<<strip2.zside()<<" "<<strip2.plane()<<" "<<strip2.six()<<" "<<strip2.siy()<<" "<<strip2.strip()<<endl;
-	  reco::PreshowerCluster cl2 = presh_algo->makeOneCluster(strip2,&used_strips,&rechits_map,geometry_p,esPhiClusterDeltaEta_,minDeltaPhi,maxDeltaPhi);
-	  cl2.setBCRef(*bc_iter);
-	  clusters2.push_back(cl2);
-	  e2 += cl2.energy();
-	}
+        DetId tmp1 = (dynamic_cast<const EcalPreshowerGeometry*>(geometry_p))->getClosestCellInPlane(point, 1);
+        DetId tmp2 = (dynamic_cast<const EcalPreshowerGeometry*>(geometry_p))->getClosestCellInPlane(point, 2);
+        ESDetId strip1 = (tmp1 == DetId(0)) ? ESDetId(0) : ESDetId(tmp1);
+        ESDetId strip2 = (tmp2 == DetId(0)) ? ESDetId(0) : ESDetId(tmp2);
+
+        if (nBC == 0) {
+          if (strip1 != ESDetId(0) && strip2 != ESDetId(0)) {
+            ESChannelStatusMap::const_iterator status_p1 = channelStatus->getMap().find(strip1);
+            ESChannelStatusMap::const_iterator status_p2 = channelStatus->getMap().find(strip2);
+            if (status_p1->getStatusCode() == 1)
+              condP1 = 0;
+            if (status_p2->getStatusCode() == 1)
+              condP2 = 0;
+          } else if (strip1 == ESDetId(0)) {
+            condP1 = 0;
+          } else if (strip2 == ESDetId(0)) {
+            condP2 = 0;
+          }
+
+          //cout<<"starting cluster : "<<maxDeltaPhi<<" "<<minDeltaPhi<<" "<<esPhiClusterDeltaEta_<<endl;
+          //cout<<"do plane 1 === "<<strip1.zside()<<" "<<strip1.plane()<<" "<<strip1.six()<<" "<<strip1.siy()<<" "<<strip1.strip()<<endl;
+          // Get a vector of ES clusters (found by the PreshSeeded algorithm) associated with a given EE basic cluster.
+          reco::PreshowerCluster cl1 = presh_algo->makeOneCluster(
+              strip1, &used_strips, &rechits_map, geometry_p, esPhiClusterDeltaEta_, minDeltaPhi, maxDeltaPhi);
+          cl1.setBCRef(*bc_iter);
+          clusters1.push_back(cl1);
+          e1 += cl1.energy();
+
+          //cout<<"do plane 2 === "<<strip2.zside()<<" "<<strip2.plane()<<" "<<strip2.six()<<" "<<strip2.siy()<<" "<<strip2.strip()<<endl;
+          reco::PreshowerCluster cl2 = presh_algo->makeOneCluster(
+              strip2, &used_strips, &rechits_map, geometry_p, esPhiClusterDeltaEta_, minDeltaPhi, maxDeltaPhi);
+          cl2.setBCRef(*bc_iter);
+          clusters2.push_back(cl2);
+          e2 += cl2.energy();
+        }
       }
 
       new_BC.push_back(*bc_iter);
       nBC++;
     }  // end of cycle over BCs
 
-    LogTrace("EcalClusters") << " For SC #" << isc-1 << ", containing " 
-			     << it_super->clustersSize() 			      
-			     << " basic clusters, PreshowerPhiClusterAlgo made " 
-			     << clusters1.size() << " in X plane and " 
-			     << clusters2.size()       
-			     << " in Y plane " << " preshower clusters " ;
-    
-    // update energy of the SuperCluster    
-    if(e1+e2 > 1.0e-10) {
+    LogTrace("EcalClusters") << " For SC #" << isc - 1 << ", containing " << it_super->clustersSize()
+                             << " basic clusters, PreshowerPhiClusterAlgo made " << clusters1.size()
+                             << " in X plane and " << clusters2.size() << " in Y plane "
+                             << " preshower clusters ";
 
-      e1 = e1 / mip_; // GeV to #MIPs
+    // update energy of the SuperCluster
+    if (e1 + e2 > 1.0e-10) {
+      e1 = e1 / mip_;  // GeV to #MIPs
       e2 = e2 / mip_;
-      
+
       if (condP1 == 1 && condP2 == 1) {
-	deltaE = gamma0_*(e1 + alpha0_*e2);       
+        deltaE = gamma0_ * (e1 + alpha0_ * e2);
       } else if (condP1 == 1 && condP2 == 0) {
-	deltaE = gamma1_*(e1 + alpha1_*e2);       
+        deltaE = gamma1_ * (e1 + alpha1_ * e2);
       } else if (condP1 == 0 && condP2 == 1) {
-	deltaE = gamma2_*(e1 + alpha2_*e2);       
+        deltaE = gamma2_ * (e1 + alpha2_ * e2);
       } else if (condP1 == 0 && condP2 == 0) {
-	deltaE = gamma3_*(e1 + alpha3_*e2);       
+        deltaE = gamma3_ * (e1 + alpha3_ * e2);
       }
     }
-    
+
     //corrected Energy
     float E = it_super->energy() + deltaE;
-    
-    LogTrace("EcalClusters") << " Creating corrected SC ";
-    
-    reco::SuperCluster sc(E, it_super->position(), it_super->seed(), new_BC, deltaE);
-    sc.setPreshowerEnergyPlane1(e1*mip_);
-    sc.setPreshowerEnergyPlane2(e2*mip_);
-    if (condP1 == 1 && condP2 == 1) sc.setPreshowerPlanesStatus(0);
-    else if (condP1 == 1 && condP2 == 0) sc.setPreshowerPlanesStatus(1);
-    else if (condP1 == 0 && condP2 == 1) sc.setPreshowerPlanesStatus(2);
-    else if (condP1 == 0 && condP2 == 0) sc.setPreshowerPlanesStatus(3);
 
-    if (etThresh_>0){ // calling postion().theta can be expensive
-        if (sc.energy()*sin(sc.position().theta())>etThresh_ ) 
-            new_SC.push_back(sc);
-    } else {
+    LogTrace("EcalClusters") << " Creating corrected SC ";
+
+    reco::SuperCluster sc(E, it_super->position(), it_super->seed(), new_BC, deltaE);
+    sc.setPreshowerEnergyPlane1(e1 * mip_);
+    sc.setPreshowerEnergyPlane2(e2 * mip_);
+    if (condP1 == 1 && condP2 == 1)
+      sc.setPreshowerPlanesStatus(0);
+    else if (condP1 == 1 && condP2 == 0)
+      sc.setPreshowerPlanesStatus(1);
+    else if (condP1 == 0 && condP2 == 1)
+      sc.setPreshowerPlanesStatus(2);
+    else if (condP1 == 0 && condP2 == 0)
+      sc.setPreshowerPlanesStatus(3);
+
+    if (etThresh_ > 0) {  // calling postion().theta can be expensive
+      if (sc.energy() * sin(sc.position().theta()) > etThresh_)
         new_SC.push_back(sc);
+    } else {
+      new_SC.push_back(sc);
     }
-    
-  } // end of cycle over SCs
-  
+
+  }  // end of cycle over SCs
+
   // copy the preshower clusters into collections and put in the Event:
   clusters_p1->assign(clusters1.begin(), clusters1.end());
   clusters_p2->assign(clusters2.begin(), clusters2.end());
   // put collection of preshower clusters to the event
-  evt.put(std::move(clusters_p1), preshClusterCollectionX_ );
-  evt.put(std::move(clusters_p2), preshClusterCollectionY_ );
-  LogTrace("EcalClusters") << "Preshower clusters added to the event" ;
-  
+  evt.put(std::move(clusters_p1), preshClusterCollectionX_);
+  evt.put(std::move(clusters_p2), preshClusterCollectionY_);
+  LogTrace("EcalClusters") << "Preshower clusters added to the event";
+
   // put collection of corrected super clusters to the event
   superclusters_p->assign(new_SC.begin(), new_SC.end());
   evt.put(std::move(superclusters_p), assocSClusterCollection_);
-  LogTrace("EcalClusters") << "Corrected SClusters added to the event" ;
+  LogTrace("EcalClusters") << "Corrected SClusters added to the event";
 }
 
 void PreshowerPhiClusterProducer::set(const edm::EventSetup& es) {
-  
   es.get<ESGainRcd>().get(esgain_);
-  const ESGain *gain = esgain_.product();
-  
+  const ESGain* gain = esgain_.product();
+
   double ESGain = gain->getESGain();
 
   es.get<ESMIPToGeVConstantRcd>().get(esMIPToGeV_);
-  const ESMIPToGeVConstant *mipToGeV = esMIPToGeV_.product();
+  const ESMIPToGeVConstant* mipToGeV = esMIPToGeV_.product();
 
-  mip_ = (ESGain == 1) ? mipToGeV->getESValueLow() : mipToGeV->getESValueHigh(); 
+  mip_ = (ESGain == 1) ? mipToGeV->getESValueLow() : mipToGeV->getESValueHigh();
 
   es.get<ESChannelStatusRcd>().get(esChannelStatus_);
 
   es.get<ESEEIntercalibConstantsRcd>().get(esEEInterCalib_);
-  const ESEEIntercalibConstants *esEEInterCalib = esEEInterCalib_.product();
+  const ESEEIntercalibConstants* esEEInterCalib = esEEInterCalib_.product();
 
   // both planes work
   gamma0_ = (ESGain == 1) ? 0.02 : esEEInterCalib->getGammaHigh0();
   alpha0_ = (ESGain == 1) ? esEEInterCalib->getAlphaLow0() : esEEInterCalib->getAlphaHigh0();
 
-  // only first plane works 
+  // only first plane works
   gamma1_ = (ESGain == 1) ? (0.02 * esEEInterCalib->getGammaLow1()) : esEEInterCalib->getGammaHigh1();
   alpha1_ = (ESGain == 1) ? esEEInterCalib->getAlphaLow1() : esEEInterCalib->getAlphaHigh1();
 
@@ -304,7 +304,7 @@ void PreshowerPhiClusterProducer::set(const edm::EventSetup& es) {
   alpha3_ = (ESGain == 1) ? esEEInterCalib->getAlphaLow3() : esEEInterCalib->getAlphaHigh3();
 
   es.get<ESMissingEnergyCalibrationRcd>().get(esMissingECalib_);
-  const ESMissingEnergyCalibration * esMissingECalib = esMissingECalib_.product();
+  const ESMissingEnergyCalibration* esMissingECalib = esMissingECalib_.product();
 
   // |eta| < 1.9
   aEta_[0] = esMissingECalib->getConstAEta0();
@@ -321,5 +321,4 @@ void PreshowerPhiClusterProducer::set(const edm::EventSetup& es) {
   // 2.3 < |eta| < 2.5
   aEta_[3] = esMissingECalib->getConstAEta3();
   bEta_[3] = esMissingECalib->getConstBEta3();
-
 }

--- a/RecoEcal/EgammaClusterProducers/src/RecHitFilter.cc
+++ b/RecoEcal/EgammaClusterProducers/src/RecHitFilter.cc
@@ -24,24 +24,17 @@
 // Class header file
 #include "RecoEcal/EgammaClusterProducers/interface/RecHitFilter.h"
 
-
-RecHitFilter::RecHitFilter(const edm::ParameterSet& ps):
-  noiseEnergyThreshold_(ps.getParameter<double>("noiseEnergyThreshold")),
-  noiseChi2Threshold_(ps.getParameter<double>("noiseChi2Threshold")),
-  reducedHitCollection_(ps.getParameter<std::string>("reducedHitCollection")),
-  hitCollection_(consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("hitCollection")))  
-{
-  produces< EcalRecHitCollection >(reducedHitCollection_);
+RecHitFilter::RecHitFilter(const edm::ParameterSet& ps)
+    : noiseEnergyThreshold_(ps.getParameter<double>("noiseEnergyThreshold")),
+      noiseChi2Threshold_(ps.getParameter<double>("noiseChi2Threshold")),
+      reducedHitCollection_(ps.getParameter<std::string>("reducedHitCollection")),
+      hitCollection_(consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("hitCollection"))) {
+  produces<EcalRecHitCollection>(reducedHitCollection_);
 }
 
+RecHitFilter::~RecHitFilter() {}
 
-RecHitFilter::~RecHitFilter()
-{
-}
-
-
-void RecHitFilter::produce(edm::StreamID, edm::Event& evt, const edm::EventSetup& es) const
-{
+void RecHitFilter::produce(edm::StreamID, edm::Event& evt, const edm::EventSetup& es) const {
   // get the hit collection from the event:
   edm::Handle<EcalRecHitCollection> rhcHandle;
   evt.getByToken(hitCollection_, rhcHandle);
@@ -53,17 +46,16 @@ void RecHitFilter::produce(edm::StreamID, edm::Event& evt, const edm::EventSetup
   // create a unique_ptr to a BasicClusterCollection, copy the clusters into it and put in the Event:
   auto redCollection = std::make_unique<EcalRecHitCollection>();
 
-  for(EcalRecHitCollection::const_iterator it = hit_collection->begin(); it != hit_collection->end(); ++it) {
+  for (EcalRecHitCollection::const_iterator it = hit_collection->begin(); it != hit_collection->end(); ++it) {
     //std::cout << *it << std::endl;
-    if(it->energy() > noiseEnergyThreshold_ && it->chi2() < noiseChi2Threshold_) { 
-        nRed++;
-        redCollection->push_back( EcalRecHit(*it) );
+    if (it->energy() > noiseEnergyThreshold_ && it->chi2() < noiseChi2Threshold_) {
+      nRed++;
+      redCollection->push_back(EcalRecHit(*it));
     }
-   
   }
 
-  edm::LogInfo("")<< "total # hits: " << nTot << "  #hits with E > " << noiseEnergyThreshold_ << " GeV  and  chi2 < " <<  noiseChi2Threshold_ << " : " << nRed << std::endl;
+  edm::LogInfo("") << "total # hits: " << nTot << "  #hits with E > " << noiseEnergyThreshold_ << " GeV  and  chi2 < "
+                   << noiseChi2Threshold_ << " : " << nRed << std::endl;
 
   evt.put(std::move(redCollection), reducedHitCollection_);
-
 }

--- a/RecoEcal/EgammaClusterProducers/src/ReducedESRecHitCollectionProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/ReducedESRecHitCollectionProducer.cc
@@ -17,156 +17,135 @@ using namespace edm;
 using namespace std;
 using namespace reco;
 
-ReducedESRecHitCollectionProducer::ReducedESRecHitCollectionProducer(const edm::ParameterSet& ps):
-  geometry_p(nullptr)
-{
+ReducedESRecHitCollectionProducer::ReducedESRecHitCollectionProducer(const edm::ParameterSet& ps)
+    : geometry_p(nullptr) {
+  scEtThresh_ = ps.getParameter<double>("scEtThreshold");
 
- scEtThresh_          = ps.getParameter<double>("scEtThreshold");
+  InputRecHitES_ = consumes<ESRecHitCollection>(ps.getParameter<edm::InputTag>("EcalRecHitCollectionES"));
+  InputSuperClusterEE_ =
+      consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("EndcapSuperClusterCollection"));
 
- InputRecHitES_       = 
-	 consumes<ESRecHitCollection>(ps.getParameter<edm::InputTag>("EcalRecHitCollectionES"));
- InputSuperClusterEE_ = 
-	 consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("EndcapSuperClusterCollection")); 
+  OutputLabelES_ = ps.getParameter<std::string>("OutputLabel_ES");
 
- OutputLabelES_       = ps.getParameter<std::string>("OutputLabel_ES");
- 
- interestingDetIdCollections_  = 
-	 edm::vector_transform(
-		   ps.getParameter<std::vector<edm::InputTag>>("interestingDetIds"),
-           [this](edm::InputTag const & tag) { 
-			   return consumes<DetIdCollection>(tag); 
-		   }
-		   );
+  interestingDetIdCollections_ =
+      edm::vector_transform(ps.getParameter<std::vector<edm::InputTag>>("interestingDetIds"),
+                            [this](edm::InputTag const& tag) { return consumes<DetIdCollection>(tag); });
 
- interestingDetIdCollectionsNotToClean_ = edm::vector_transform(ps.getParameter<std::vector<edm::InputTag>>("interestingDetIdsNotToClean"),
-								[this](edm::InputTag const & tag) 
-								{ return consumes<DetIdCollection>(tag); }
-								);
+  interestingDetIdCollectionsNotToClean_ =
+      edm::vector_transform(ps.getParameter<std::vector<edm::InputTag>>("interestingDetIdsNotToClean"),
+                            [this](edm::InputTag const& tag) { return consumes<DetIdCollection>(tag); });
 
- produces< EcalRecHitCollection > (OutputLabelES_);
- 
+  produces<EcalRecHitCollection>(OutputLabelES_);
 }
 
 ReducedESRecHitCollectionProducer::~ReducedESRecHitCollectionProducer() = default;
 
-void ReducedESRecHitCollectionProducer::beginRun (edm::Run const&, const edm::EventSetup&iSetup){
+void ReducedESRecHitCollectionProducer::beginRun(edm::Run const&, const edm::EventSetup& iSetup) {
   ESHandle<CaloGeometry> geoHandle;
   iSetup.get<CaloGeometryRecord>().get(geoHandle);
-  geometry_p = dynamic_cast<const EcalPreshowerGeometry*>(geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower));
-  if (!geometry_p){
-    edm::LogError("WrongGeometry")<<
-      "could not cast the subdet geometry to preshower geometry";
+  geometry_p =
+      dynamic_cast<const EcalPreshowerGeometry*>(geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower));
+  if (!geometry_p) {
+    edm::LogError("WrongGeometry") << "could not cast the subdet geometry to preshower geometry";
   }
-  
-  if (geometry_p) topology_p = std::make_unique<EcalPreshowerTopology>();
-  
+
+  if (geometry_p)
+    topology_p = std::make_unique<EcalPreshowerTopology>();
 }
 
-void ReducedESRecHitCollectionProducer::produce(edm::Event & e, const edm::EventSetup& iSetup){
-
-
+void ReducedESRecHitCollectionProducer::produce(edm::Event& e, const edm::EventSetup& iSetup) {
   edm::Handle<ESRecHitCollection> ESRecHits_;
   e.getByToken(InputRecHitES_, ESRecHits_);
-  
+
   auto output = std::make_unique<EcalRecHitCollection>();
 
   edm::Handle<reco::SuperClusterCollection> pEndcapSuperClusters;
   e.getByToken(InputSuperClusterEE_, pEndcapSuperClusters);
   {
     const reco::SuperClusterCollection* eeSuperClusters = pEndcapSuperClusters.product();
-    
-    for (reco::SuperClusterCollection::const_iterator isc = eeSuperClusters->begin(); isc != eeSuperClusters->end(); ++isc) {
 
-      if (isc->energy() < scEtThresh_) continue;
-      if (fabs(isc->eta()) < 1.65 || fabs(isc->eta()) > 2.6) continue;
+    for (reco::SuperClusterCollection::const_iterator isc = eeSuperClusters->begin(); isc != eeSuperClusters->end();
+         ++isc) {
+      if (isc->energy() < scEtThresh_)
+        continue;
+      if (fabs(isc->eta()) < 1.65 || fabs(isc->eta()) > 2.6)
+        continue;
       //cout<<"SC energy : "<<isc->energy()<<" "<<isc->eta()<<endl;
 
       //Int_t nBC = 0;
       reco::CaloCluster_iterator ibc = isc->clustersBegin();
-      for ( ; ibc != isc->clustersEnd(); ++ibc ) {  
+      for (; ibc != isc->clustersEnd(); ++ibc) {
+        //cout<<"BC : "<<nBC<<endl;
 
-	//cout<<"BC : "<<nBC<<endl;
+        const GlobalPoint point((*ibc)->x(), (*ibc)->y(), (*ibc)->z());
 
-	const GlobalPoint point((*ibc)->x(),(*ibc)->y(),(*ibc)->z());
+        ESDetId esId1 = geometry_p->getClosestCellInPlane(point, 1);
+        ESDetId esId2 = geometry_p->getClosestCellInPlane(point, 2);
 
-	ESDetId esId1 = geometry_p->getClosestCellInPlane(point, 1);
-	ESDetId esId2 = geometry_p->getClosestCellInPlane(point, 2);
-	
-	collectIds(esId1, esId2, 0);
-	collectIds(esId1, esId2, 1);
-	collectIds(esId1, esId2, -1);
+        collectIds(esId1, esId2, 0);
+        collectIds(esId1, esId2, 1);
+        collectIds(esId1, esId2, -1);
 
-	//nBC++;
+        //nBC++;
       }
-      
     }
-    
   }
 
-
-  edm::Handle<DetIdCollection > detId;
-  for( unsigned int t = 0; t < interestingDetIdCollections_.size(); ++t )
-    {
-      e.getByToken(interestingDetIdCollections_[t],detId);    
-      if(!detId.isValid())
-      {
-          Labels labels;
-          labelsForToken(interestingDetIdCollections_[t], labels);
-          edm::LogError("MissingInput")<<"no reason to skip detid from : (" << labels.module << ", "
-                                                                            << labels.productInstance << ", "
-                                                                            << labels.process << ")" << std::endl;
-          continue;
-      }
-      collectedIds_.insert(detId->begin(),detId->end());
+  edm::Handle<DetIdCollection> detId;
+  for (unsigned int t = 0; t < interestingDetIdCollections_.size(); ++t) {
+    e.getByToken(interestingDetIdCollections_[t], detId);
+    if (!detId.isValid()) {
+      Labels labels;
+      labelsForToken(interestingDetIdCollections_[t], labels);
+      edm::LogError("MissingInput") << "no reason to skip detid from : (" << labels.module << ", "
+                                    << labels.productInstance << ", " << labels.process << ")" << std::endl;
+      continue;
     }
-
+    collectedIds_.insert(detId->begin(), detId->end());
+  }
 
   //screw it, cant think of a better solution, not the best but lets run over all the rec hits, remove the ones failing cleaning
   //and then merge in the collection not to be cleaned
   //mainly as I suspect its more efficient to find an object in the DetIdSet rather than the rec-hit in the rec-hit collecition
   //with only a det id
   //if its a CPU issues then revisit
-  for(const auto& hit : *ESRecHits_) {
-    if(hit.recoFlag()==1 || hit.recoFlag()==14 || (hit.recoFlag()<=10 && hit.recoFlag()>=5)){ //right we might need to erase it from the collection
+  for (const auto& hit : *ESRecHits_) {
+    if (hit.recoFlag() == 1 || hit.recoFlag() == 14 ||
+        (hit.recoFlag() <= 10 && hit.recoFlag() >= 5)) {  //right we might need to erase it from the collection
       auto idIt = collectedIds_.find(hit.id());
-      if(idIt!=collectedIds_.end()) collectedIds_.erase(idIt);
+      if (idIt != collectedIds_.end())
+        collectedIds_.erase(idIt);
     }
   }
-   
-  
-  for(const auto& token : interestingDetIdCollectionsNotToClean_) {
-    e.getByToken(token,detId);    
-    if(!detId.isValid()){ //meh might as well keep the warning
+
+  for (const auto& token : interestingDetIdCollectionsNotToClean_) {
+    e.getByToken(token, detId);
+    if (!detId.isValid()) {  //meh might as well keep the warning
       Labels labels;
       labelsForToken(token, labels);
-      edm::LogError("MissingInput")<<"no reason to skip detid from : (" << labels.module << ", "
-				   << labels.productInstance << ", "
-				   << labels.process << ")" << std::endl;
+      edm::LogError("MissingInput") << "no reason to skip detid from : (" << labels.module << ", "
+                                    << labels.productInstance << ", " << labels.process << ")" << std::endl;
       continue;
     }
-    collectedIds_.insert(detId->begin(),detId->end());
+    collectedIds_.insert(detId->begin(), detId->end());
   }
-  
 
-  output->reserve( collectedIds_.size());
+  output->reserve(collectedIds_.size());
   EcalRecHitCollection::const_iterator it;
   for (it = ESRecHits_->begin(); it != ESRecHits_->end(); ++it) {
-    if (collectedIds_.find(it->id())!=collectedIds_.end()){
+    if (collectedIds_.find(it->id()) != collectedIds_.end()) {
       output->push_back(*it);
     }
   }
   collectedIds_.clear();
 
   e.put(std::move(output), OutputLabelES_);
-
 }
 
-
-void ReducedESRecHitCollectionProducer::collectIds(const ESDetId esDetId1, const ESDetId esDetId2, const int & row) {
-
+void ReducedESRecHitCollectionProducer::collectIds(const ESDetId esDetId1, const ESDetId esDetId2, const int& row) {
   //cout<<row<<endl;
-  
-  map<DetId,const EcalRecHit*>::iterator it;
+
+  map<DetId, const EcalRecHit*>::iterator it;
   map<DetId, int>::iterator itu;
   ESDetId next;
   ESDetId strip1;
@@ -177,77 +156,78 @@ void ReducedESRecHitCollectionProducer::collectIds(const ESDetId esDetId1, const
 
   EcalPreshowerNavigator theESNav1(strip1, topology_p.get());
   theESNav1.setHome(strip1);
-  
+
   EcalPreshowerNavigator theESNav2(strip2, topology_p.get());
   theESNav2.setHome(strip2);
 
   if (row == 1) {
-    if (strip1 != ESDetId(0)) strip1 = theESNav1.north();
-    if (strip2 != ESDetId(0)) strip2 = theESNav2.east();
+    if (strip1 != ESDetId(0))
+      strip1 = theESNav1.north();
+    if (strip2 != ESDetId(0))
+      strip2 = theESNav2.east();
   } else if (row == -1) {
-    if (strip1 != ESDetId(0)) strip1 = theESNav1.south();
-    if (strip2 != ESDetId(0)) strip2 = theESNav2.west();
+    if (strip1 != ESDetId(0))
+      strip1 = theESNav1.south();
+    if (strip2 != ESDetId(0))
+      strip2 = theESNav2.west();
   }
 
-  // Plane 1 
+  // Plane 1
   if (strip1 == ESDetId(0)) {
   } else {
     collectedIds_.insert(strip1);
     //cout<<"center : "<<strip1<<endl;
-    // east road 
-    for (int i=0; i<15; ++i) {
+    // east road
+    for (int i = 0; i < 15; ++i) {
       next = theESNav1.east();
       //cout<<"east : "<<i<<" "<<next<<endl;
       if (next != ESDetId(0)) {
-	collectedIds_.insert(next);
+        collectedIds_.insert(next);
       } else {
-	break;
+        break;
       }
     }
 
-    // west road 
+    // west road
     theESNav1.setHome(strip1);
     theESNav1.home();
-    for (int i=0; i<15; ++i) {
+    for (int i = 0; i < 15; ++i) {
       next = theESNav1.west();
       //cout<<"west : "<<i<<" "<<next<<endl;
       if (next != ESDetId(0)) {
-	collectedIds_.insert(next);
+        collectedIds_.insert(next);
       } else {
-	break;
+        break;
       }
     }
-
   }
 
   if (strip2 == ESDetId(0)) {
   } else {
     collectedIds_.insert(strip2);
     //cout<<"center : "<<strip2<<endl;
-    // north road 
-    for (int i=0; i<15; ++i) {
+    // north road
+    for (int i = 0; i < 15; ++i) {
       next = theESNav2.north();
       //cout<<"north : "<<i<<" "<<next<<endl;
       if (next != ESDetId(0)) {
-	collectedIds_.insert(next);
+        collectedIds_.insert(next);
       } else {
-	break;
-      } 
+        break;
+      }
     }
 
-    // south road 
+    // south road
     theESNav2.setHome(strip2);
     theESNav2.home();
-    for (int i=0; i<15; ++i) {
+    for (int i = 0; i < 15; ++i) {
       next = theESNav2.south();
       //cout<<"south : "<<i<<" "<<next<<endl;
       if (next != ESDetId(0)) {
-	collectedIds_.insert(next);
+        collectedIds_.insert(next);
       } else {
-	break;
+        break;
       }
     }
   }
 }
-
-

--- a/RecoEcal/EgammaClusterProducers/src/ReducedRecHitCollectionProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/ReducedRecHitCollectionProducer.cc
@@ -4,12 +4,8 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-
-
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
-
-
 
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 #include "DataFormats/EgammaReco/interface/BasicClusterFwd.h"
@@ -22,96 +18,74 @@
 
 #include <iostream>
 
-ReducedRecHitCollectionProducer::ReducedRecHitCollectionProducer(const edm::ParameterSet& iConfig) 
-{
+ReducedRecHitCollectionProducer::ReducedRecHitCollectionProducer(const edm::ParameterSet& iConfig) {
+  recHitsToken_ = consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("recHitsLabel"));
 
-  recHitsToken_ = 
-	  consumes<EcalRecHitCollection>(iConfig.getParameter< edm::InputTag > ("recHitsLabel"));
+  interestingDetIdCollections_ =
+      edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag>>("interestingDetIdCollections"),
+                            [this](edm::InputTag const& tag) { return consumes<DetIdCollection>(tag); });
 
-  interestingDetIdCollections_ = 
-	  edm::vector_transform(
-		   iConfig.getParameter<std::vector<edm::InputTag>>("interestingDetIdCollections"),
-           [this](edm::InputTag const & tag) { 
-			   return consumes<DetIdCollection>(tag); 
-		   }
-		   );
-	  
   reducedHitsCollection_ = iConfig.getParameter<std::string>("reducedHitsCollection");
-  
-   //register your products
-  produces< EcalRecHitCollection > (reducedHitsCollection_) ;
-  
+
+  //register your products
+  produces<EcalRecHitCollection>(reducedHitsCollection_);
 }
 
-
-ReducedRecHitCollectionProducer::~ReducedRecHitCollectionProducer()
-{}
-
+ReducedRecHitCollectionProducer::~ReducedRecHitCollectionProducer() {}
 
 // ------------ method called to produce the data  ------------
-void
-ReducedRecHitCollectionProducer::produce (edm::Event& iEvent, 
-                                const edm::EventSetup& iSetup)
-{
-   using namespace edm;
-   using namespace std;
+void ReducedRecHitCollectionProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  using namespace std;
 
-   if (interestingDetIdCollections_.empty())
-     {
-       edm::LogError("ReducedRecHitCollectionProducer") << "VInputTag collections empty" ;
-       return;
-     }
-   
+  if (interestingDetIdCollections_.empty()) {
+    edm::LogError("ReducedRecHitCollectionProducer") << "VInputTag collections empty";
+    return;
+  }
 
-   Handle< DetIdCollection > detIds;
-   iEvent.getByToken(interestingDetIdCollections_[0],detIds);
-   std::vector<DetId> xtalsToStore((*detIds).size());
-   std::copy( (*detIds).begin() , (*detIds).end() , xtalsToStore.begin() );   
-   
-   //Merging DetIds from different collections 
-   for( unsigned int t = 1; t < interestingDetIdCollections_.size(); ++t )
-     {
-       Handle< DetIdCollection > detId;
-       iEvent.getByToken(interestingDetIdCollections_[t],detId);
-       if(!detId.isValid())
-       {
-           Labels labels;
-           labelsForToken(interestingDetIdCollections_[t], labels);
-           edm::LogError("MissingInput")<<"no reason to skip detid from : (" << labels.module << ", "
-                                                                             << labels.productInstance << ", "
-                                                                             << labels.process << ")" << std::endl;
-           continue;
-       }
-     
-       
-       for (unsigned int ii=0;ii<(*detId).size();ii++)
-	 {
-	   if (std::find(xtalsToStore.begin(),xtalsToStore.end(),(*detId)[ii]) == xtalsToStore.end())
-	     xtalsToStore.push_back((*detId)[ii]);
-	 }
-     }
-   
-   Handle<EcalRecHitCollection> recHitsHandle;
-   iEvent.getByToken(recHitsToken_,recHitsHandle);
-   if( !recHitsHandle.isValid() ) 
-     {
-       edm::LogError("ReducedRecHitCollectionProducer") << "RecHit collection not found";
-       return;
-     }
-   
-   //Create empty output collections
-   auto miniRecHitCollection  = std::make_unique<EcalRecHitCollection>();
-   
-   for (unsigned int iCry=0;iCry<xtalsToStore.size();iCry++)
-     {
-       EcalRecHitCollection::const_iterator iRecHit = recHitsHandle->find(xtalsToStore[iCry]);
-       if ( (iRecHit != recHitsHandle->end()) && (miniRecHitCollection->find(xtalsToStore[iCry]) == miniRecHitCollection->end()) )
-	 miniRecHitCollection->push_back(*iRecHit);
-     }  
+  Handle<DetIdCollection> detIds;
+  iEvent.getByToken(interestingDetIdCollections_[0], detIds);
+  std::vector<DetId> xtalsToStore((*detIds).size());
+  std::copy((*detIds).begin(), (*detIds).end(), xtalsToStore.begin());
 
-	std::sort(xtalsToStore.begin(), xtalsToStore.end());   
-	std::unique(xtalsToStore.begin(), xtalsToStore.end());   
-   
-   //   std::cout << "New Collection " << reducedHitsCollection_ << " size is " << miniRecHitCollection->size() << " original is " << recHitsHandle->size() << std::endl;
-   iEvent.put(std::move(miniRecHitCollection),reducedHitsCollection_ );
+  //Merging DetIds from different collections
+  for (unsigned int t = 1; t < interestingDetIdCollections_.size(); ++t) {
+    Handle<DetIdCollection> detId;
+    iEvent.getByToken(interestingDetIdCollections_[t], detId);
+    if (!detId.isValid()) {
+      Labels labels;
+      labelsForToken(interestingDetIdCollections_[t], labels);
+      edm::LogError("MissingInput") << "no reason to skip detid from : (" << labels.module << ", "
+                                    << labels.productInstance << ", " << labels.process << ")" << std::endl;
+      continue;
+    }
+
+    for (unsigned int ii = 0; ii < (*detId).size(); ii++) {
+      if (std::find(xtalsToStore.begin(), xtalsToStore.end(), (*detId)[ii]) == xtalsToStore.end())
+        xtalsToStore.push_back((*detId)[ii]);
+    }
+  }
+
+  Handle<EcalRecHitCollection> recHitsHandle;
+  iEvent.getByToken(recHitsToken_, recHitsHandle);
+  if (!recHitsHandle.isValid()) {
+    edm::LogError("ReducedRecHitCollectionProducer") << "RecHit collection not found";
+    return;
+  }
+
+  //Create empty output collections
+  auto miniRecHitCollection = std::make_unique<EcalRecHitCollection>();
+
+  for (unsigned int iCry = 0; iCry < xtalsToStore.size(); iCry++) {
+    EcalRecHitCollection::const_iterator iRecHit = recHitsHandle->find(xtalsToStore[iCry]);
+    if ((iRecHit != recHitsHandle->end()) &&
+        (miniRecHitCollection->find(xtalsToStore[iCry]) == miniRecHitCollection->end()))
+      miniRecHitCollection->push_back(*iRecHit);
+  }
+
+  std::sort(xtalsToStore.begin(), xtalsToStore.end());
+  std::unique(xtalsToStore.begin(), xtalsToStore.end());
+
+  //   std::cout << "New Collection " << reducedHitsCollection_ << " size is " << miniRecHitCollection->size() << " original is " << recHitsHandle->size() << std::endl;
+  iEvent.put(std::move(miniRecHitCollection), reducedHitsCollection_);
 }

--- a/RecoEcal/EgammaClusterProducers/src/SealModule.cc
+++ b/RecoEcal/EgammaClusterProducers/src/SealModule.cc
@@ -20,7 +20,6 @@
 #include "RecoEcal/EgammaClusterProducers/interface/PFECALSuperClusterProducer.h"
 #include "RecoEcal/EgammaClusterProducers/interface/PreshowerPhiClusterProducer.h"
 
-
 DEFINE_FWK_MODULE(IslandClusterProducer);
 DEFINE_FWK_MODULE(HybridClusterProducer);
 DEFINE_FWK_MODULE(EgammaSCCorrectionMaker);
@@ -40,4 +39,3 @@ DEFINE_FWK_MODULE(UnifiedSCCollectionProducer);
 DEFINE_FWK_MODULE(CleanAndMergeProducer);
 DEFINE_FWK_MODULE(PFECALSuperClusterProducer);
 DEFINE_FWK_MODULE(PreshowerPhiClusterProducer);
-

--- a/RecoEcal/EgammaClusterProducers/src/UncleanSCRecoveryProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/UncleanSCRecoveryProducer.cc
@@ -20,7 +20,6 @@
 #include "RecoEcal/EgammaClusterProducers/interface/UncleanSCRecoveryProducer.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 
-
 /*
 UncleanSCRecoveryProducer:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,185 +33,178 @@ Nikolaos Rompotis and Chris Seez  - Imperial College London
 many thanks to David Wardrope, Shahram Rahatlou and Federico Ferri
 */
 
-
-UncleanSCRecoveryProducer::UncleanSCRecoveryProducer(const edm::ParameterSet& ps):
-  cleanBcCollection_(consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("cleanBcCollection"))),
-  cleanScCollection_(consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("cleanScCollection"))),
-  uncleanBcCollection_(consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("uncleanBcCollection"))),
-  uncleanScCollection_(consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("uncleanScCollection"))),
-  bcCollection_(ps.getParameter<std::string>("bcCollection")),
-  scCollection_(ps.getParameter<std::string>("scCollection"))
-{
-        // the products:
-        produces< reco::BasicClusterCollection >(bcCollection_);
-        produces< reco::SuperClusterCollection >(scCollection_);
+UncleanSCRecoveryProducer::UncleanSCRecoveryProducer(const edm::ParameterSet& ps)
+    : cleanBcCollection_(consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("cleanBcCollection"))),
+      cleanScCollection_(consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("cleanScCollection"))),
+      uncleanBcCollection_(
+          consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("uncleanBcCollection"))),
+      uncleanScCollection_(
+          consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("uncleanScCollection"))),
+      bcCollection_(ps.getParameter<std::string>("bcCollection")),
+      scCollection_(ps.getParameter<std::string>("scCollection")) {
+  // the products:
+  produces<reco::BasicClusterCollection>(bcCollection_);
+  produces<reco::SuperClusterCollection>(scCollection_);
 }
 
+void UncleanSCRecoveryProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetup& es) const {
+  // __________________________________________________________________________
+  //
+  // cluster collections:
+  edm::Handle<reco::BasicClusterCollection> pCleanBC;
+  edm::Handle<reco::SuperClusterCollection> pCleanSC;
+  //
+  edm::Handle<reco::BasicClusterCollection> pUncleanBC;
+  edm::Handle<reco::SuperClusterCollection> pUncleanSC;
+  // clean collections ________________________________________________________
+  evt.getByToken(cleanScCollection_, pCleanSC);
+  const reco::SuperClusterCollection cleanSC = *(pCleanSC.product());
 
-void UncleanSCRecoveryProducer::produce(edm::StreamID, edm::Event& evt, 
-                                        const edm::EventSetup& es) const
-{
-        // __________________________________________________________________________
-        //
-        // cluster collections:
-        edm::Handle<reco::BasicClusterCollection> pCleanBC;
-        edm::Handle<reco::SuperClusterCollection> pCleanSC;
-        //
-        edm::Handle<reco::BasicClusterCollection> pUncleanBC;
-        edm::Handle<reco::SuperClusterCollection> pUncleanSC;
-        // clean collections ________________________________________________________
-        evt.getByToken(cleanScCollection_, pCleanSC);      
-        const  reco::SuperClusterCollection cleanSC = *(pCleanSC.product());
+  // unclean collections ______________________________________________________
+  evt.getByToken(uncleanBcCollection_, pUncleanBC);
+  const reco::BasicClusterCollection uncleanBC = *(pUncleanBC.product());
+  //
+  evt.getByToken(uncleanScCollection_, pUncleanSC);
+  const reco::SuperClusterCollection uncleanSC = *(pUncleanSC.product());
+  int uncleanSize = pUncleanSC->size();
+  int cleanSize = pCleanSC->size();
 
-        // unclean collections ______________________________________________________
-        evt.getByToken(uncleanBcCollection_, pUncleanBC);
-        const  reco::BasicClusterCollection uncleanBC = *(pUncleanBC.product());
-        //
-        evt.getByToken(uncleanScCollection_, pUncleanSC);
-        const  reco::SuperClusterCollection uncleanSC = *(pUncleanSC.product());
-        int uncleanSize = pUncleanSC->size();
-        int cleanSize =   pCleanSC->size();
+  LogTrace("EcalCleaning") << "Size of Clean Collection: " << cleanSize << ", uncleanSize: " << uncleanSize;
 
-        LogTrace("EcalCleaning")  << "Size of Clean Collection: " << cleanSize 
-                << ", uncleanSize: " << uncleanSize;
+  // collections are all taken now ____________________________________________
+  //
+  // the collections to be produced ___________________________________________
+  reco::BasicClusterCollection basicClusters;
+  reco::SuperClusterCollection superClusters;
+  //
+  //
+  // collect all the basic clusters of the SC that belong to the unclean
+  // collection and put them into the basicClusters vector
+  // keep the information of which SC they belong to
+  //
+  // loop over the unclean sc: all SC will join the new collection
+  std::vector<std::pair<int, int> > basicClusterOwner;  // counting all
 
-        // collections are all taken now ____________________________________________
-        //
-        // the collections to be produced ___________________________________________
-        reco::BasicClusterCollection basicClusters;
-        reco::SuperClusterCollection superClusters;
-        //
-        //
-        // collect all the basic clusters of the SC that belong to the unclean
-        // collection and put them into the basicClusters vector
-        // keep the information of which SC they belong to
-        //
-        // loop over the unclean sc: all SC will join the new collection
-        std::vector< std::pair<int, int> > basicClusterOwner; // counting all
+  std::vector<DetId> scUncleanSeedDetId;  // counting the unclean
+  for (int isc = 0; isc < uncleanSize; ++isc) {
+    const reco::SuperCluster unsc = uncleanSC[isc];
+    scUncleanSeedDetId.push_back(unsc.seed()->seed());
+    reco::CaloCluster_iterator bciter = unsc.clustersBegin();
+    for (; bciter != unsc.clustersEnd(); ++bciter) {
+      // the basic clusters
+      basicClusters.push_back(**bciter);
+      // index of the unclean SC
+      basicClusterOwner.push_back(std::make_pair(isc, 0));
+    }
+  }
+  // loop over the clean: only the ones which are in common with the unclean
+  // are taken into account
 
-        std::vector<DetId> scUncleanSeedDetId;  // counting the unclean
-        for (int isc =0; isc< uncleanSize; ++isc) {
-                const reco::SuperCluster unsc = uncleanSC[isc];    
-                scUncleanSeedDetId.push_back(unsc.seed()->seed());
-                reco::CaloCluster_iterator bciter = unsc.clustersBegin();
-                for (; bciter != unsc.clustersEnd(); ++bciter) {
-                        // the basic clusters
-                        basicClusters.push_back(**bciter);
-                        // index of the unclean SC
-                        basicClusterOwner.push_back( std::make_pair(isc,0) ); 
-                }
+  std::vector<DetId> scCleanSeedDetId;  // counting the clean
+  std::vector<int> isToBeKept;
+  for (int isc = 0; isc < cleanSize; ++isc) {
+    reco::SuperClusterRef cscRef(pCleanSC, isc);
+    scCleanSeedDetId.push_back(cscRef->seed()->seed());
+    for (reco::CaloCluster_iterator bciter = cscRef->clustersBegin(); bciter != cscRef->clustersEnd(); ++bciter) {
+      // the basic clusters
+      basicClusters.push_back(**bciter);
+      // index of the clean SC
+      basicClusterOwner.push_back(std::make_pair(isc, 1));
+    }
+    if (cscRef->isInUnclean())
+      isToBeKept.push_back(1);
+    else
+      isToBeKept.push_back(0);
+  }
+  //
+  // now export the basic clusters into the event and get them back
+  auto basicClusters_p = std::make_unique<reco::BasicClusterCollection>();
+  basicClusters_p->assign(basicClusters.begin(), basicClusters.end());
+  edm::OrphanHandle<reco::BasicClusterCollection> bccHandle = evt.put(std::move(basicClusters_p), bcCollection_);
+  if (!(bccHandle.isValid())) {
+    edm::LogWarning("MissingInput") << "could not handle the new BasicClusters!";
+    return;
+  }
+  reco::BasicClusterCollection basicClustersProd = *bccHandle;
+
+  LogTrace("EcalCleaning") << "Got the BasicClusters from the event again";
+  int bcSize = bccHandle->size();
+  //
+  // now we can create the SC collection
+  //
+  // run over the unclean SC: all to be kept here
+  for (int isc = 0; isc < uncleanSize; ++isc) {
+    reco::CaloClusterPtrVector clusterPtrVector;
+    // the seed is the basic cluster with the highest energy
+    reco::CaloClusterPtr seed;
+    for (int jbc = 0; jbc < bcSize; ++jbc) {
+      std::pair<int, int> theBcOwner = basicClusterOwner[jbc];
+      if (theBcOwner.first == isc && theBcOwner.second == 0) {
+        reco::CaloClusterPtr currentClu = reco::CaloClusterPtr(bccHandle, jbc);
+        clusterPtrVector.push_back(currentClu);
+        if (scUncleanSeedDetId[isc] == currentClu->seed()) {
+          seed = currentClu;
         }
-        // loop over the clean: only the ones which are in common with the unclean
-        // are taken into account
-
-        std::vector<DetId> scCleanSeedDetId;  // counting the clean
-        std::vector<int> isToBeKept;
-        for (int isc =0; isc< cleanSize; ++isc) {
-                reco::SuperClusterRef cscRef( pCleanSC, isc );    
-                scCleanSeedDetId.push_back(cscRef->seed()->seed());
-                for (reco::CaloCluster_iterator bciter = cscRef->clustersBegin(); bciter != cscRef->clustersEnd(); ++bciter) {
-                        // the basic clusters
-                        basicClusters.push_back(**bciter);
-                        // index of the clean SC
-                        basicClusterOwner.push_back( std::make_pair(isc,1) ); 
-                }
-                if (cscRef->isInUnclean()) isToBeKept.push_back(1);
-                else isToBeKept.push_back(0);
+      }
+    }
+    const reco::SuperCluster unsc = uncleanSC[isc];
+    reco::SuperCluster newSC(unsc.energy(), unsc.position(), seed, clusterPtrVector);
+    newSC.setFlags(reco::CaloCluster::uncleanOnly);
+    superClusters.push_back(newSC);
+  }
+  // run over the clean SC: only those who are in common between the
+  // clean and unclean collection are kept
+  for (int isc = 0; isc < cleanSize; ++isc) {
+    reco::SuperClusterRef cscRef(pCleanSC, isc);
+    if (not cscRef->isInUnclean())
+      continue;
+    reco::CaloClusterPtrVector clusterPtrVector;
+    // the seed is the basic cluster with the highest energy
+    reco::CaloClusterPtr seed;
+    for (int jbc = 0; jbc < bcSize; ++jbc) {
+      std::pair<int, int> theBcOwner = basicClusterOwner[jbc];
+      if (theBcOwner.first == isc && theBcOwner.second == 1) {
+        reco::CaloClusterPtr currentClu = reco::CaloClusterPtr(bccHandle, jbc);
+        clusterPtrVector.push_back(currentClu);
+        if (scCleanSeedDetId[isc] == currentClu->seed()) {
+          seed = currentClu;
         }
-        //
-        // now export the basic clusters into the event and get them back
-        auto basicClusters_p = std::make_unique<reco::BasicClusterCollection>();
-        basicClusters_p->assign(basicClusters.begin(), basicClusters.end());
-        edm::OrphanHandle<reco::BasicClusterCollection> bccHandle =  
-                evt.put(std::move(basicClusters_p), bcCollection_);
-        if (!(bccHandle.isValid())) {
+      }
+    }
+    reco::SuperCluster newSC(cscRef->energy(), cscRef->position(), seed, clusterPtrVector);
+    newSC.setFlags(reco::CaloCluster::common);
+    superClusters.push_back(newSC);
+  }
 
-                edm::LogWarning("MissingInput") << "could not handle the new BasicClusters!";
-                return;
-        }
-        reco::BasicClusterCollection basicClustersProd = *bccHandle;
+  auto superClusters_p = std::make_unique<reco::SuperClusterCollection>();
+  superClusters_p->assign(superClusters.begin(), superClusters.end());
 
-        LogTrace("EcalCleaning") <<"Got the BasicClusters from the event again";
-        int bcSize = bccHandle->size();
-        //
-        // now we can create the SC collection
-        //
-        // run over the unclean SC: all to be kept here
-        for (int isc=0; isc< uncleanSize; ++isc) {
-                reco::CaloClusterPtrVector clusterPtrVector;
-                // the seed is the basic cluster with the highest energy
-                reco::CaloClusterPtr seed; 
-                for (int jbc=0; jbc< bcSize; ++jbc) {
-                        std::pair<int,int> theBcOwner = basicClusterOwner[jbc];
-                        if (theBcOwner.first == isc && theBcOwner.second == 0) {
-                                reco::CaloClusterPtr currentClu=reco::CaloClusterPtr(bccHandle,jbc);
-                                clusterPtrVector.push_back(currentClu);
-                                if (scUncleanSeedDetId[isc] == currentClu->seed()) {
-                                        seed = currentClu;
-                                }
-                        }
-                }
-                const reco::SuperCluster unsc = uncleanSC[isc]; 
-                reco::SuperCluster newSC(unsc.energy(), unsc.position(), seed, clusterPtrVector );
-                newSC.setFlags(reco::CaloCluster::uncleanOnly);
-                superClusters.push_back(newSC);
-        }
-        // run over the clean SC: only those who are in common between the
-        // clean and unclean collection are kept
-        for (int isc=0; isc< cleanSize; ++isc) {
-                reco::SuperClusterRef cscRef( pCleanSC, isc); 
-                if (not cscRef->isInUnclean()) continue;
-                reco::CaloClusterPtrVector clusterPtrVector;
-                // the seed is the basic cluster with the highest energy
-                reco::CaloClusterPtr seed; 
-                for (int jbc=0; jbc< bcSize; ++jbc) {
-                        std::pair<int,int> theBcOwner = basicClusterOwner[jbc];
-                        if (theBcOwner.first == isc && theBcOwner.second == 1) {
-                                reco::CaloClusterPtr currentClu=reco::CaloClusterPtr(bccHandle,jbc);
-                                clusterPtrVector.push_back(currentClu);
-                                if (scCleanSeedDetId[isc] == currentClu->seed()) {
-                                        seed = currentClu;
-                                }
-                        }
-                }
-                reco::SuperCluster newSC(cscRef->energy(), cscRef->position(), 
-                                         seed, clusterPtrVector );
-                newSC.setFlags(reco::CaloCluster::common);
-                superClusters.push_back(newSC);
-        }
+  evt.put(std::move(superClusters_p), scCollection_);
 
-        auto superClusters_p = std::make_unique<reco::SuperClusterCollection>();
-        superClusters_p->assign(superClusters.begin(), superClusters.end());
+  LogTrace("EcalCleaning") << "Clusters (Basic/Super) added to the Event! :-)";
 
-        evt.put(std::move(superClusters_p), scCollection_);
-
-        LogTrace("EcalCleaning")<<"Clusters (Basic/Super) added to the Event! :-)";
-
-        // ----- debugging ----------
-        // print the new collection SC quantities
-        // print out the clean collection SC
-        LogTrace("EcalCleaning") << "Clean Collection SC ";
-        for (int i=0; i < cleanSize; ++i) {
-                const reco::SuperCluster csc = cleanSC[i];
-                LogTrace("EcalCleaning") << " >>> clean    #" << i << "; Energy: " << csc.energy()
-                        << " eta: " << csc.eta() 
-                        << " sc seed detid: " << csc.seed()->seed().rawId();
-        }
-        // the unclean SC
-        LogTrace("EcalCleaning") << "Unclean Collection SC ";
-        for (int i=0; i < uncleanSize; ++i) {
-                const reco::SuperCluster usc = uncleanSC[i];
-                LogTrace("EcalCleaning") << " >>> unclean  #" << i << "; Energy: " << usc.energy()
-                        << " eta: " << usc.eta() 
-                        << " sc seed detid: " << usc.seed()->seed().rawId();
-        }
-        // the new collection
-        LogTrace("EcalCleaning")<<"The new SC clean collection with size "<< superClusters.size();
-        for (unsigned int i=0; i <  superClusters.size(); ++i) {
-                const reco::SuperCluster nsc = superClusters[i];
-                LogTrace("EcalCleaning")<< " >>> newSC    #" << i << "; Energy: " << nsc.energy()
-                        << " eta: " << nsc.eta()  << " isClean=" 
-                        << nsc.isInClean() << " isUnclean=" << nsc.isInUnclean()
-                        << " sc seed detid: " << nsc.seed()->seed().rawId();
-        }
+  // ----- debugging ----------
+  // print the new collection SC quantities
+  // print out the clean collection SC
+  LogTrace("EcalCleaning") << "Clean Collection SC ";
+  for (int i = 0; i < cleanSize; ++i) {
+    const reco::SuperCluster csc = cleanSC[i];
+    LogTrace("EcalCleaning") << " >>> clean    #" << i << "; Energy: " << csc.energy() << " eta: " << csc.eta()
+                             << " sc seed detid: " << csc.seed()->seed().rawId();
+  }
+  // the unclean SC
+  LogTrace("EcalCleaning") << "Unclean Collection SC ";
+  for (int i = 0; i < uncleanSize; ++i) {
+    const reco::SuperCluster usc = uncleanSC[i];
+    LogTrace("EcalCleaning") << " >>> unclean  #" << i << "; Energy: " << usc.energy() << " eta: " << usc.eta()
+                             << " sc seed detid: " << usc.seed()->seed().rawId();
+  }
+  // the new collection
+  LogTrace("EcalCleaning") << "The new SC clean collection with size " << superClusters.size();
+  for (unsigned int i = 0; i < superClusters.size(); ++i) {
+    const reco::SuperCluster nsc = superClusters[i];
+    LogTrace("EcalCleaning") << " >>> newSC    #" << i << "; Energy: " << nsc.energy() << " eta: " << nsc.eta()
+                             << " isClean=" << nsc.isInClean() << " isUnclean=" << nsc.isInUnclean()
+                             << " sc seed detid: " << nsc.seed()->seed().rawId();
+  }
 }

--- a/RecoEcal/EgammaClusterProducers/src/UnifiedSCCollectionProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/UnifiedSCCollectionProducer.cc
@@ -25,7 +25,6 @@
 #include "RecoEcal/EgammaCoreTools/interface/PositionCalc.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 
-
 /*
 UnifiedSCCollectionProducer:
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -49,47 +48,35 @@ Nikolaos Rompotis and Chris Seez  - Imperial College London
 many thanks to David Wardrope, Shahram Rahatlou and Federico Ferri
 */
 
+UnifiedSCCollectionProducer::UnifiedSCCollectionProducer(const edm::ParameterSet& ps) {
+  using reco::BasicClusterCollection;
+  using reco::SuperClusterCollection;
+  // get the parameters
+  // the cleaned collection:
+  cleanBcCollection_ = consumes<BasicClusterCollection>(ps.getParameter<edm::InputTag>("cleanBcCollection"));
+  cleanScCollection_ = consumes<SuperClusterCollection>(ps.getParameter<edm::InputTag>("cleanScCollection"));
 
-UnifiedSCCollectionProducer::UnifiedSCCollectionProducer(const edm::ParameterSet& ps)
-{
-	    using  reco::BasicClusterCollection;
-	    using  reco::SuperClusterCollection;
-	    // get the parameters
-        // the cleaned collection:
-	    cleanBcCollection_ = 
-			consumes<BasicClusterCollection>(ps.getParameter<edm::InputTag>("cleanBcCollection"));
-        cleanScCollection_ = 
-			consumes<SuperClusterCollection>(ps.getParameter<edm::InputTag>("cleanScCollection"));
- 
-        // the uncleaned collection
-        uncleanBcCollection_ = 
-			consumes<BasicClusterCollection>(ps.getParameter<edm::InputTag>("uncleanBcCollection"));
-        uncleanScCollection_ = 
-			consumes<SuperClusterCollection>(ps.getParameter<edm::InputTag>("uncleanScCollection"));
-       
-        // the names of the products to be produced:
-        //
-        // the clean collection: this is as it was before, but labeled
-        bcCollection_ = ps.getParameter<std::string>("bcCollection");
-        scCollection_ = ps.getParameter<std::string>("scCollection");
-        // the unclean only collection: SC unique to the unclean collection
-        bcCollectionUncleanOnly_ = ps.getParameter<std::string>("bcCollectionUncleanOnly");
-        scCollectionUncleanOnly_ = ps.getParameter<std::string>("scCollectionUncleanOnly");
-        // the products:
-        produces< reco::BasicClusterCollection >(bcCollection_);
-        produces< reco::SuperClusterCollection >(scCollection_);
-        produces< reco::BasicClusterCollection >(bcCollectionUncleanOnly_);
-        produces< reco::SuperClusterCollection >(scCollectionUncleanOnly_);
+  // the uncleaned collection
+  uncleanBcCollection_ = consumes<BasicClusterCollection>(ps.getParameter<edm::InputTag>("uncleanBcCollection"));
+  uncleanScCollection_ = consumes<SuperClusterCollection>(ps.getParameter<edm::InputTag>("uncleanScCollection"));
 
+  // the names of the products to be produced:
+  //
+  // the clean collection: this is as it was before, but labeled
+  bcCollection_ = ps.getParameter<std::string>("bcCollection");
+  scCollection_ = ps.getParameter<std::string>("scCollection");
+  // the unclean only collection: SC unique to the unclean collection
+  bcCollectionUncleanOnly_ = ps.getParameter<std::string>("bcCollectionUncleanOnly");
+  scCollectionUncleanOnly_ = ps.getParameter<std::string>("scCollectionUncleanOnly");
+  // the products:
+  produces<reco::BasicClusterCollection>(bcCollection_);
+  produces<reco::SuperClusterCollection>(scCollection_);
+  produces<reco::BasicClusterCollection>(bcCollectionUncleanOnly_);
+  produces<reco::SuperClusterCollection>(scCollectionUncleanOnly_);
 }
 
-
-
-void UnifiedSCCollectionProducer::produce(edm::Event& evt, 
-                                          const edm::EventSetup& es)
-{
-
-  edm::LogInfo("UnifiedSC")<< ">>>>> Entering UnifiedSCCollectionProducer <<<<<";
+void UnifiedSCCollectionProducer::produce(edm::Event& evt, const edm::EventSetup& es) {
+  edm::LogInfo("UnifiedSC") << ">>>>> Entering UnifiedSCCollectionProducer <<<<<";
   // get the input collections
   // __________________________________________________________________________
   //
@@ -99,12 +86,12 @@ void UnifiedSCCollectionProducer::produce(edm::Event& evt,
   //
   edm::Handle<reco::BasicClusterCollection> pUncleanBC;
   edm::Handle<reco::SuperClusterCollection> pUncleanSC;
-  
+
   evt.getByToken(cleanScCollection_, pCleanSC);
   evt.getByToken(cleanBcCollection_, pCleanBC);
   evt.getByToken(uncleanBcCollection_, pUncleanBC);
   evt.getByToken(uncleanScCollection_, pUncleanSC);
-       
+
   // the collections to be produced ___________________________________________
   reco::BasicClusterCollection basicClusters;
   reco::SuperClusterCollection superClusters;
@@ -112,356 +99,331 @@ void UnifiedSCCollectionProducer::produce(edm::Event& evt,
   reco::BasicClusterCollection basicClustersUncleanOnly;
   reco::SuperClusterCollection superClustersUncleanOnly;
   //
-  // run over the uncleaned SC and check how many of them are matched to 
+  // run over the uncleaned SC and check how many of them are matched to
   // the cleaned ones
-  // if you find a matched one, then keep the info that it is matched 
+  // if you find a matched one, then keep the info that it is matched
   //    along with which clean SC was matched + its basic clusters
   // if you find an unmatched one, keep the info and store its basic clusters
   //
-  // 
+  //
   int uncleanSize = pUncleanSC->size();
-  int cleanSize =   pCleanSC->size();
-	
-	LogTrace("UnifiedSC") << "Size of Clean Collection: " << cleanSize 
-                        << ", uncleanSize: " << uncleanSize;
+  int cleanSize = pCleanSC->size();
 
+  LogTrace("UnifiedSC") << "Size of Clean Collection: " << cleanSize << ", uncleanSize: " << uncleanSize;
 
-        // keep the indices
-        std::vector<int> inUncleanOnlyInd;      // counting the unclean
-        std::vector<int> inCleanInd;            // counting the unclean
-        std::vector<int> inCleanOnlyInd;        // counting the clean
-        std::vector<DetId> scUncleanSeedDetId;  // counting the unclean
-        std::vector<DetId> scCleanSeedDetId;    // counting the clean
-        // ontains the index of the SC that owns that BS
-        // first basic cluster index, second: 0 for unclean and 1 for clean
-        std::vector< std::pair<int, int> > basicClusterOwner; 
-        std::vector< std::pair<int, int> > basicClusterOwnerUncleanOnly; 
-        // if this basic cluster is a seed it is 1
-        std::vector<int> uncleanBasicClusterIsSeed;
+  // keep the indices
+  std::vector<int> inUncleanOnlyInd;      // counting the unclean
+  std::vector<int> inCleanInd;            // counting the unclean
+  std::vector<int> inCleanOnlyInd;        // counting the clean
+  std::vector<DetId> scUncleanSeedDetId;  // counting the unclean
+  std::vector<DetId> scCleanSeedDetId;    // counting the clean
+  // ontains the index of the SC that owns that BS
+  // first basic cluster index, second: 0 for unclean and 1 for clean
+  std::vector<std::pair<int, int> > basicClusterOwner;
+  std::vector<std::pair<int, int> > basicClusterOwnerUncleanOnly;
+  // if this basic cluster is a seed it is 1
+  std::vector<int> uncleanBasicClusterIsSeed;
 
-        // loop over unclean SC _____________________________________________________
-        for (int isc =0; isc< uncleanSize; ++isc) {
-                reco::SuperClusterRef unscRef( pUncleanSC, isc);    
-                const std::vector< std::pair<DetId, float> > & uhits = unscRef->hitsAndFractions();
-                int uhitsSize = uhits.size();
-                bool foundTheSame = false;
-                for (int jsc=0; jsc < cleanSize; ++jsc) { // loop over the cleaned SC
-                        reco::SuperClusterRef cscRef( pCleanSC, jsc );
-                        const std::vector<std::pair<DetId,float> > & chits = cscRef->hitsAndFractions();
-                        int chitsSize =  chits.size();
-                        foundTheSame = false;
-                        if (unscRef->seed()->seed()==cscRef->seed()->seed() && chitsSize == uhitsSize) { 
-                                // if the clusters are exactly the same then because the clustering
-                                // algorithm works in a deterministic way, the order of the rechits
-                                // will be the same
-			        foundTheSame = true;
-                                for (int i=0; i< chitsSize; ++i) {
-                                        if (uhits[i].first != chits[i].first ) { 
-					  foundTheSame=false;    
-					  break;
-					}
-                                }
-                                
-                        }
-                        if (foundTheSame) { // ok you have found it:
-                                // this supercluster belongs to both collections
-                                inUncleanOnlyInd.push_back(0);
-                                inCleanInd.push_back(jsc); // keeps the index of the clean SC
-                                scUncleanSeedDetId.push_back(unscRef->seed()->seed());
-                                //
-                                // keep its basic clusters:
-                                for (reco::CaloCluster_iterator bciter = unscRef->clustersBegin(); bciter != unscRef->clustersEnd(); ++bciter) {
-                                        // the basic clusters
-                                        basicClusters.push_back(**bciter);
-                                        // index of the unclean SC
-                                        basicClusterOwner.push_back( std::make_pair(isc,0) ); 
-                                } 
-                                break; // break the loop over unclean sc
-                        }
-                }
-                if (not foundTheSame) { // this SC is only in the unclean collection
-                        // mark it as unique in the uncleaned
-                        inUncleanOnlyInd.push_back(1);
-                        scUncleanSeedDetId.push_back(unscRef->seed()->seed());
-                        // keep all its basic clusters
-                        for (reco::CaloCluster_iterator bciter = unscRef->clustersBegin(); bciter != unscRef->clustersEnd(); ++bciter) {
-                                // the basic clusters
-                                basicClustersUncleanOnly.push_back(**bciter);
-                                basicClusterOwnerUncleanOnly.push_back( std::make_pair(isc,0) );
-                        }
-                }
-        } // loop over the unclean SC _______________________________________________
-        //
-        int inCleanSize = inCleanInd.size();
-        //
-        // loop over the clean SC, check that are not in common with the unclean
-        // ones and then store their SC as before ___________________________________
-        for (int jsc =0; jsc< cleanSize; ++jsc) {
-                // check whether this index is already in the common collection
-                bool takenAlready = false;
-                for (int j=0; j< inCleanSize; ++j) {
-                        if (jsc == inCleanInd[j]) { takenAlready = true ;break;}
-                }
-                if (takenAlready) {
-                        inCleanOnlyInd.push_back(0);
-                        scCleanSeedDetId.push_back(DetId(0));
-                        continue;
-                }
-                inCleanOnlyInd.push_back(1);
-                reco::SuperClusterRef cscRef( pCleanSC, jsc );
-                scCleanSeedDetId.push_back(cscRef->seed()->seed());
-                for (reco::CaloCluster_iterator bciter = cscRef->clustersBegin(); bciter != cscRef->clustersEnd(); ++bciter) {
-                        // the basic clusters
-                        basicClusters.push_back(**bciter);
-                        basicClusterOwner.push_back( std::make_pair(jsc,1) );
-                }
-        } // end loop over clean SC _________________________________________________
-        //
-        //
-
-	// Final check: in the endcap BC may exist that are not associated to SC,
-	// we need to recover them as well (e.g. multi5x5 algo)
-	// This is should be optimized (SA, 20110621)
-
-
-	// loop on original clean BC collection and see if the BC is missing from the new one
-	for (reco::BasicClusterCollection::const_iterator bc = pCleanBC->begin();
-	     bc!=pCleanBC->end();
-	     ++bc){
-	  
-	  bool foundTheSame = false;
-	  for (reco::BasicClusterCollection::const_iterator cleanonly_bc = basicClusters.begin();
-	       cleanonly_bc!=basicClusters.end();
-	       ++cleanonly_bc){	    
-	    
-	    const std::vector<std::pair<DetId,float> > & chits = bc->hitsAndFractions();
-	    int chitsSize =  chits.size();
-	    
-	    const std::vector<std::pair<DetId,float> > & uhits = cleanonly_bc->hitsAndFractions();
-	    int uhitsSize =  uhits.size();
-	    
-	    
-	    if (cleanonly_bc->seed()==bc->seed() && chitsSize == uhitsSize) {
-	        foundTheSame = true;
-		for (int i=0; i< chitsSize; ++i) {
-		  if (uhits[i].first != chits[i].first ) { 
-		    foundTheSame=false;    
-		    break;
-		  }
-		}
-	    }
-	    	    
-	  } // loop on new clean BC collection
-	  
-	  // clean basic cluster is not associated to SC and does not belong to the 
-	  // new collection, add it
-	  if (!foundTheSame){	      
-	    basicClusters.push_back(*bc);
-	    LogTrace("UnifiedSC")<<"found BC to add that was not associated to any SC";
-	  }
-	  
-	} // loop on original clean BC collection
-
-
-        // at this point we have the basic cluster collection ready
-        // Up to index   basicClusterOwner.size() we have the BC owned by a SC
-        // The remaining are BCs not owned by a SC
-
-        int bcSize = (int) basicClusterOwner.size();
-        int bcSizeUncleanOnly = (int) basicClustersUncleanOnly.size();
-
-	LogTrace("UnifiedSC") << "Found cleaned SC: " << cleanSize 
-			      <<  " uncleaned SC: "   << uncleanSize ;
-        //
-        // export the clusters to the event from the clean clusters
-        auto basicClusters_p = std::make_unique<reco::BasicClusterCollection>();
-        basicClusters_p->assign(basicClusters.begin(), basicClusters.end());
-        edm::OrphanHandle<reco::BasicClusterCollection> bccHandle =  
-                evt.put(std::move(basicClusters_p), bcCollection_);
-        if (!(bccHandle.isValid())) {
-              
-	  edm::LogWarning("MissingInput")<< "could not handle the new BasicClusters!";
-	  return;
+  // loop over unclean SC _____________________________________________________
+  for (int isc = 0; isc < uncleanSize; ++isc) {
+    reco::SuperClusterRef unscRef(pUncleanSC, isc);
+    const std::vector<std::pair<DetId, float> >& uhits = unscRef->hitsAndFractions();
+    int uhitsSize = uhits.size();
+    bool foundTheSame = false;
+    for (int jsc = 0; jsc < cleanSize; ++jsc) {  // loop over the cleaned SC
+      reco::SuperClusterRef cscRef(pCleanSC, jsc);
+      const std::vector<std::pair<DetId, float> >& chits = cscRef->hitsAndFractions();
+      int chitsSize = chits.size();
+      foundTheSame = false;
+      if (unscRef->seed()->seed() == cscRef->seed()->seed() && chitsSize == uhitsSize) {
+        // if the clusters are exactly the same then because the clustering
+        // algorithm works in a deterministic way, the order of the rechits
+        // will be the same
+        foundTheSame = true;
+        for (int i = 0; i < chitsSize; ++i) {
+          if (uhits[i].first != chits[i].first) {
+            foundTheSame = false;
+            break;
+          }
         }
-        reco::BasicClusterCollection basicClustersProd = *bccHandle;
-
-	LogTrace("UnifiedSC")<< "Got the BasicClusters from the event again" ;
+      }
+      if (foundTheSame) {  // ok you have found it:
+        // this supercluster belongs to both collections
+        inUncleanOnlyInd.push_back(0);
+        inCleanInd.push_back(jsc);  // keeps the index of the clean SC
+        scUncleanSeedDetId.push_back(unscRef->seed()->seed());
         //
-        // export the clusters to the event: from the unclean only clusters
-        auto basicClustersUncleanOnly_p = std::make_unique<reco::BasicClusterCollection>();
-        basicClustersUncleanOnly_p->assign(basicClustersUncleanOnly.begin(), 
-                                           basicClustersUncleanOnly.end());
-        edm::OrphanHandle<reco::BasicClusterCollection> bccHandleUncleanOnly =  
-                evt.put(std::move(basicClustersUncleanOnly_p), bcCollectionUncleanOnly_);
-        if (!(bccHandleUncleanOnly.isValid())) {
-
-	  edm::LogWarning("MissingInput")<< "could not handle the new BasicClusters (Unclean Only)!" ;
-	  return;
+        // keep its basic clusters:
+        for (reco::CaloCluster_iterator bciter = unscRef->clustersBegin(); bciter != unscRef->clustersEnd(); ++bciter) {
+          // the basic clusters
+          basicClusters.push_back(**bciter);
+          // index of the unclean SC
+          basicClusterOwner.push_back(std::make_pair(isc, 0));
         }
-        reco::BasicClusterCollection basicClustersUncleanOnlyProd = *bccHandleUncleanOnly;
-	LogTrace("UnifiedSC")<< "Got the BasicClusters from the event again  (Unclean Only)" ;
-        //
+        break;  // break the loop over unclean sc
+      }
+    }
+    if (not foundTheSame) {  // this SC is only in the unclean collection
+      // mark it as unique in the uncleaned
+      inUncleanOnlyInd.push_back(1);
+      scUncleanSeedDetId.push_back(unscRef->seed()->seed());
+      // keep all its basic clusters
+      for (reco::CaloCluster_iterator bciter = unscRef->clustersBegin(); bciter != unscRef->clustersEnd(); ++bciter) {
+        // the basic clusters
+        basicClustersUncleanOnly.push_back(**bciter);
+        basicClusterOwnerUncleanOnly.push_back(std::make_pair(isc, 0));
+      }
+    }
+  }  // loop over the unclean SC _______________________________________________
+  //
+  int inCleanSize = inCleanInd.size();
+  //
+  // loop over the clean SC, check that are not in common with the unclean
+  // ones and then store their SC as before ___________________________________
+  for (int jsc = 0; jsc < cleanSize; ++jsc) {
+    // check whether this index is already in the common collection
+    bool takenAlready = false;
+    for (int j = 0; j < inCleanSize; ++j) {
+      if (jsc == inCleanInd[j]) {
+        takenAlready = true;
+        break;
+      }
+    }
+    if (takenAlready) {
+      inCleanOnlyInd.push_back(0);
+      scCleanSeedDetId.push_back(DetId(0));
+      continue;
+    }
+    inCleanOnlyInd.push_back(1);
+    reco::SuperClusterRef cscRef(pCleanSC, jsc);
+    scCleanSeedDetId.push_back(cscRef->seed()->seed());
+    for (reco::CaloCluster_iterator bciter = cscRef->clustersBegin(); bciter != cscRef->clustersEnd(); ++bciter) {
+      // the basic clusters
+      basicClusters.push_back(**bciter);
+      basicClusterOwner.push_back(std::make_pair(jsc, 1));
+    }
+  }  // end loop over clean SC _________________________________________________
+     //
+     //
 
-        // now we can build the SC collection
-        //
-        // start again from the unclean collection
-        // all the unclean SC will become members of the new collection
-        // with different algoIDs ___________________________________________________
-        for (int isc=0; isc< uncleanSize; ++isc) {
-                reco::CaloClusterPtrVector clusterPtrVector;
-                // the seed is the basic cluster with the highest energy
-                reco::CaloClusterPtr seed; 
-                if (inUncleanOnlyInd[isc] == 1) { // unclean SC Unique in Unclean
-                        for (int jbc=0; jbc< bcSizeUncleanOnly; ++jbc) {
-                                std::pair<int, int> theBcOwner = basicClusterOwnerUncleanOnly[jbc];
-                                if (theBcOwner.first == isc && theBcOwner.second == 0) {
-                                        reco::CaloClusterPtr currentClu=reco::CaloClusterPtr(bccHandleUncleanOnly,jbc);
-                                        clusterPtrVector.push_back(currentClu);
-                                        if (scUncleanSeedDetId[isc] == currentClu->seed()) {
-                                                seed = currentClu;
-                                        }
-                                }
-                        }
+  // Final check: in the endcap BC may exist that are not associated to SC,
+  // we need to recover them as well (e.g. multi5x5 algo)
+  // This is should be optimized (SA, 20110621)
 
-                }
-                else { // unclean SC common in clean and unclean
-                        for (int jbc=0; jbc< bcSize; ++jbc) {
-                                std::pair<int, int> theBcOwner = basicClusterOwner[jbc];
-                                if (theBcOwner.first == isc && theBcOwner.second == 0) {
-                                        reco::CaloClusterPtr currentClu=reco::CaloClusterPtr(bccHandle,jbc);
-                                        clusterPtrVector.push_back(currentClu);
-                                        if (scUncleanSeedDetId[isc] == currentClu->seed()) {
-                                                seed = currentClu;
-                                        }
-                                }
-                        }
-                }
-                //std::cout << "before getting the uncl" << std::endl;
-                reco::SuperClusterRef unscRef( pUncleanSC, isc ); 
-                reco::SuperCluster newSC(unscRef->energy(), unscRef->position(), 
-                                         seed, clusterPtrVector );
-                // now set the algoID for this SC again
-                if (inUncleanOnlyInd[isc] == 1) {
-                        // set up the quality to unclean only .............
-                        newSC.setFlags(reco::CaloCluster::uncleanOnly);
-                        superClustersUncleanOnly.push_back(newSC);
-                }
-                else {
-                        // set up the quality to common  .............
-                        newSC.setFlags(reco::CaloCluster::common);
-                        superClusters.push_back(newSC);
-                }
-                // now you can store your SC
+  // loop on original clean BC collection and see if the BC is missing from the new one
+  for (reco::BasicClusterCollection::const_iterator bc = pCleanBC->begin(); bc != pCleanBC->end(); ++bc) {
+    bool foundTheSame = false;
+    for (reco::BasicClusterCollection::const_iterator cleanonly_bc = basicClusters.begin();
+         cleanonly_bc != basicClusters.end();
+         ++cleanonly_bc) {
+      const std::vector<std::pair<DetId, float> >& chits = bc->hitsAndFractions();
+      int chitsSize = chits.size();
 
-        } // end loop over unclean SC _______________________________________________
-        //  flags numbering scheme
-        //  flags =   0 = cleanedOnly     cluster is only in the cleaned collection
-        //  flags = 100 = common          cluster is common in both collections
-        //  flags = 200 = uncleanedOnly   cluster is only in the uncleaned collection
+      const std::vector<std::pair<DetId, float> >& uhits = cleanonly_bc->hitsAndFractions();
+      int uhitsSize = uhits.size();
 
-        // now loop over the clean SC and do the same but now you have to avoid the
-        // the duplicated ones ______________________________________________________
-        for (int jsc=0; jsc< cleanSize; ++jsc) {
-                //std::cout << "working in cl #" << jsc << std::endl;
-                // check that the SC is not in the unclean collection
-                if (inCleanOnlyInd[jsc] == 0) continue;
-                reco::CaloClusterPtrVector clusterPtrVector;
-                // the seed is the basic cluster with the highest energy
-                reco::CaloClusterPtr seed; 
-                for (int jbc=0; jbc< bcSize; ++jbc) {
-                        std::pair<int, int> theBcOwner = basicClusterOwner[jbc];
-                        if (theBcOwner.first == jsc && theBcOwner.second == 1) {
-                                reco::CaloClusterPtr currentClu=reco::CaloClusterPtr(bccHandle,jbc);
-                                clusterPtrVector.push_back(currentClu);
-                                if (scCleanSeedDetId[jsc] == currentClu->seed()) {
-                                        seed = currentClu;
-                                }
-                        }
-                }
-                reco::SuperClusterRef cscRef( pCleanSC, jsc ); 
-                reco::SuperCluster newSC(cscRef->energy(), cscRef->position(),
-                                         seed, clusterPtrVector );
-                newSC.setFlags(reco::CaloCluster::cleanOnly);
+      if (cleanonly_bc->seed() == bc->seed() && chitsSize == uhitsSize) {
+        foundTheSame = true;
+        for (int i = 0; i < chitsSize; ++i) {
+          if (uhits[i].first != chits[i].first) {
+            foundTheSame = false;
+            break;
+          }
+        }
+      }
 
-                // add it to the collection:
-                superClusters.push_back(newSC);
+    }  // loop on new clean BC collection
 
-        } // end loop over clean SC _________________________________________________
+    // clean basic cluster is not associated to SC and does not belong to the
+    // new collection, add it
+    if (!foundTheSame) {
+      basicClusters.push_back(*bc);
+      LogTrace("UnifiedSC") << "found BC to add that was not associated to any SC";
+    }
 
+  }  // loop on original clean BC collection
 
+  // at this point we have the basic cluster collection ready
+  // Up to index   basicClusterOwner.size() we have the BC owned by a SC
+  // The remaining are BCs not owned by a SC
 
+  int bcSize = (int)basicClusterOwner.size();
+  int bcSizeUncleanOnly = (int)basicClustersUncleanOnly.size();
 
+  LogTrace("UnifiedSC") << "Found cleaned SC: " << cleanSize << " uncleaned SC: " << uncleanSize;
+  //
+  // export the clusters to the event from the clean clusters
+  auto basicClusters_p = std::make_unique<reco::BasicClusterCollection>();
+  basicClusters_p->assign(basicClusters.begin(), basicClusters.end());
+  edm::OrphanHandle<reco::BasicClusterCollection> bccHandle = evt.put(std::move(basicClusters_p), bcCollection_);
+  if (!(bccHandle.isValid())) {
+    edm::LogWarning("MissingInput") << "could not handle the new BasicClusters!";
+    return;
+  }
+  reco::BasicClusterCollection basicClustersProd = *bccHandle;
 
+  LogTrace("UnifiedSC") << "Got the BasicClusters from the event again";
+  //
+  // export the clusters to the event: from the unclean only clusters
+  auto basicClustersUncleanOnly_p = std::make_unique<reco::BasicClusterCollection>();
+  basicClustersUncleanOnly_p->assign(basicClustersUncleanOnly.begin(), basicClustersUncleanOnly.end());
+  edm::OrphanHandle<reco::BasicClusterCollection> bccHandleUncleanOnly =
+      evt.put(std::move(basicClustersUncleanOnly_p), bcCollectionUncleanOnly_);
+  if (!(bccHandleUncleanOnly.isValid())) {
+    edm::LogWarning("MissingInput") << "could not handle the new BasicClusters (Unclean Only)!";
+    return;
+  }
+  reco::BasicClusterCollection basicClustersUncleanOnlyProd = *bccHandleUncleanOnly;
+  LogTrace("UnifiedSC") << "Got the BasicClusters from the event again  (Unclean Only)";
+  //
 
+  // now we can build the SC collection
+  //
+  // start again from the unclean collection
+  // all the unclean SC will become members of the new collection
+  // with different algoIDs ___________________________________________________
+  for (int isc = 0; isc < uncleanSize; ++isc) {
+    reco::CaloClusterPtrVector clusterPtrVector;
+    // the seed is the basic cluster with the highest energy
+    reco::CaloClusterPtr seed;
+    if (inUncleanOnlyInd[isc] == 1) {  // unclean SC Unique in Unclean
+      for (int jbc = 0; jbc < bcSizeUncleanOnly; ++jbc) {
+        std::pair<int, int> theBcOwner = basicClusterOwnerUncleanOnly[jbc];
+        if (theBcOwner.first == isc && theBcOwner.second == 0) {
+          reco::CaloClusterPtr currentClu = reco::CaloClusterPtr(bccHandleUncleanOnly, jbc);
+          clusterPtrVector.push_back(currentClu);
+          if (scUncleanSeedDetId[isc] == currentClu->seed()) {
+            seed = currentClu;
+          }
+        }
+      }
 
-	LogTrace("UnifiedSC")<< "New SC collection was created";
+    } else {  // unclean SC common in clean and unclean
+      for (int jbc = 0; jbc < bcSize; ++jbc) {
+        std::pair<int, int> theBcOwner = basicClusterOwner[jbc];
+        if (theBcOwner.first == isc && theBcOwner.second == 0) {
+          reco::CaloClusterPtr currentClu = reco::CaloClusterPtr(bccHandle, jbc);
+          clusterPtrVector.push_back(currentClu);
+          if (scUncleanSeedDetId[isc] == currentClu->seed()) {
+            seed = currentClu;
+          }
+        }
+      }
+    }
+    //std::cout << "before getting the uncl" << std::endl;
+    reco::SuperClusterRef unscRef(pUncleanSC, isc);
+    reco::SuperCluster newSC(unscRef->energy(), unscRef->position(), seed, clusterPtrVector);
+    // now set the algoID for this SC again
+    if (inUncleanOnlyInd[isc] == 1) {
+      // set up the quality to unclean only .............
+      newSC.setFlags(reco::CaloCluster::uncleanOnly);
+      superClustersUncleanOnly.push_back(newSC);
+    } else {
+      // set up the quality to common  .............
+      newSC.setFlags(reco::CaloCluster::common);
+      superClusters.push_back(newSC);
+    }
+    // now you can store your SC
 
-        auto superClusters_p = std::make_unique<reco::SuperClusterCollection>();
-        superClusters_p->assign(superClusters.begin(), superClusters.end());
+  }  // end loop over unclean SC _______________________________________________
+  //  flags numbering scheme
+  //  flags =   0 = cleanedOnly     cluster is only in the cleaned collection
+  //  flags = 100 = common          cluster is common in both collections
+  //  flags = 200 = uncleanedOnly   cluster is only in the uncleaned collection
 
-        evt.put(std::move(superClusters_p), scCollection_);
-	
-	LogTrace("UnifiedSC") << "Clusters (Basic/Super) added to the Event! :-)";
+  // now loop over the clean SC and do the same but now you have to avoid the
+  // the duplicated ones ______________________________________________________
+  for (int jsc = 0; jsc < cleanSize; ++jsc) {
+    //std::cout << "working in cl #" << jsc << std::endl;
+    // check that the SC is not in the unclean collection
+    if (inCleanOnlyInd[jsc] == 0)
+      continue;
+    reco::CaloClusterPtrVector clusterPtrVector;
+    // the seed is the basic cluster with the highest energy
+    reco::CaloClusterPtr seed;
+    for (int jbc = 0; jbc < bcSize; ++jbc) {
+      std::pair<int, int> theBcOwner = basicClusterOwner[jbc];
+      if (theBcOwner.first == jsc && theBcOwner.second == 1) {
+        reco::CaloClusterPtr currentClu = reco::CaloClusterPtr(bccHandle, jbc);
+        clusterPtrVector.push_back(currentClu);
+        if (scCleanSeedDetId[jsc] == currentClu->seed()) {
+          seed = currentClu;
+        }
+      }
+    }
+    reco::SuperClusterRef cscRef(pCleanSC, jsc);
+    reco::SuperCluster newSC(cscRef->energy(), cscRef->position(), seed, clusterPtrVector);
+    newSC.setFlags(reco::CaloCluster::cleanOnly);
 
-        auto superClustersUncleanOnly_p = std::make_unique<reco::SuperClusterCollection>();
-        superClustersUncleanOnly_p->assign(superClustersUncleanOnly.begin(), 
-                                           superClustersUncleanOnly.end());
+    // add it to the collection:
+    superClusters.push_back(newSC);
 
-        evt.put(std::move(superClustersUncleanOnly_p), scCollectionUncleanOnly_);
+  }  // end loop over clean SC _________________________________________________
 
-        // ----- debugging ----------
-        // print the new collection SC quantities
+  LogTrace("UnifiedSC") << "New SC collection was created";
 
-	// print out the clean collection SC
-	LogTrace("UnifiedSC") << "Clean Collection SC ";
-	for (int i=0; i < cleanSize; ++i) {
-	  reco::SuperClusterRef cscRef( pCleanSC, i );
-	  LogTrace("UnifiedSC") << " >>> clean    #" << i << "; Energy: " << cscRef->energy()
-                                << " eta: " << cscRef->eta() 
-                                << " sc seed detid: " << cscRef->seed()->seed().rawId()
-                                << std::endl;
-                }
-                // the unclean SC
-                LogTrace("UnifiedSC") << "Unclean Collection SC ";
-                for (int i=0; i < uncleanSize; ++i) {
-                        reco::SuperClusterRef uscRef( pUncleanSC, i );
-                        LogTrace("UnifiedSC") << " >>> unclean  #" << i << "; Energy: " << uscRef->energy()
-                                << " eta: " << uscRef->eta() 
-                                << " sc seed detid: " << uscRef->seed()->seed().rawId();
-                }
-                // the new collection
-                LogTrace("UnifiedSC")<< "The new SC clean collection with size "<< superClusters.size()  << std::endl;
+  auto superClusters_p = std::make_unique<reco::SuperClusterCollection>();
+  superClusters_p->assign(superClusters.begin(), superClusters.end());
 
-                int new_unclean = 0, new_clean=0;
-                for (int i=0; i < (int) superClusters.size(); ++i) {
-                        const reco::SuperCluster & nsc = superClusters[i];
-                        LogTrace("UnifiedSC") << "SC was got" << std::endl
-                                << " ---> energy: " << nsc.energy() << std::endl
-                                << " ---> eta: " << nsc.eta() << std::endl
-                                << " ---> inClean: " << nsc.isInClean() << std::endl
-                                << " ---> id: " << nsc.seed()->seed().rawId() << std::endl
-                                << " >>> newSC    #" << i << "; Energy: " << nsc.energy()
-                                << " eta: " << nsc.eta()  << " isClean=" 
-                                << nsc.isInClean() << " isUnclean=" << nsc.isInUnclean()
-                                << " sc seed detid: " << nsc.seed()->seed().rawId();
+  evt.put(std::move(superClusters_p), scCollection_);
 
-                        if (nsc.isInUnclean()) ++new_unclean;
-                        if (nsc.isInClean()) ++new_clean;
-                }
-                LogTrace("UnifiedSC")<< "The new SC unclean only collection with size "<< superClustersUncleanOnly.size();
-                for (int i=0; i < (int) superClustersUncleanOnly.size(); ++i) {
-                        const reco::SuperCluster nsc = superClustersUncleanOnly[i];
-                        LogTrace ("UnifiedSC") << " >>> newSC    #" << i << "; Energy: " << nsc.energy()
-                                << " eta: " << nsc.eta()  << " isClean=" 
-                                << nsc.isInClean() << " isUnclean=" << nsc.isInUnclean()
-                                << " sc seed detid: " << nsc.seed()->seed().rawId();
-                        if (nsc.isInUnclean()) ++new_unclean;
-                        if (nsc.isInClean()) ++new_clean;      
-                }
-                if ( (new_unclean != uncleanSize) || (new_clean != cleanSize) ) {
-                        LogTrace("UnifiedSC") << ">>>>!!!!!! MISMATCH: new unclean/ old unclean= " 
-                                << new_unclean << " / " << uncleanSize 
-                                << ", new clean/ old clean" << new_clean << " / " << cleanSize;
-                }
-        
+  LogTrace("UnifiedSC") << "Clusters (Basic/Super) added to the Event! :-)";
+
+  auto superClustersUncleanOnly_p = std::make_unique<reco::SuperClusterCollection>();
+  superClustersUncleanOnly_p->assign(superClustersUncleanOnly.begin(), superClustersUncleanOnly.end());
+
+  evt.put(std::move(superClustersUncleanOnly_p), scCollectionUncleanOnly_);
+
+  // ----- debugging ----------
+  // print the new collection SC quantities
+
+  // print out the clean collection SC
+  LogTrace("UnifiedSC") << "Clean Collection SC ";
+  for (int i = 0; i < cleanSize; ++i) {
+    reco::SuperClusterRef cscRef(pCleanSC, i);
+    LogTrace("UnifiedSC") << " >>> clean    #" << i << "; Energy: " << cscRef->energy() << " eta: " << cscRef->eta()
+                          << " sc seed detid: " << cscRef->seed()->seed().rawId() << std::endl;
+  }
+  // the unclean SC
+  LogTrace("UnifiedSC") << "Unclean Collection SC ";
+  for (int i = 0; i < uncleanSize; ++i) {
+    reco::SuperClusterRef uscRef(pUncleanSC, i);
+    LogTrace("UnifiedSC") << " >>> unclean  #" << i << "; Energy: " << uscRef->energy() << " eta: " << uscRef->eta()
+                          << " sc seed detid: " << uscRef->seed()->seed().rawId();
+  }
+  // the new collection
+  LogTrace("UnifiedSC") << "The new SC clean collection with size " << superClusters.size() << std::endl;
+
+  int new_unclean = 0, new_clean = 0;
+  for (int i = 0; i < (int)superClusters.size(); ++i) {
+    const reco::SuperCluster& nsc = superClusters[i];
+    LogTrace("UnifiedSC") << "SC was got" << std::endl
+                          << " ---> energy: " << nsc.energy() << std::endl
+                          << " ---> eta: " << nsc.eta() << std::endl
+                          << " ---> inClean: " << nsc.isInClean() << std::endl
+                          << " ---> id: " << nsc.seed()->seed().rawId() << std::endl
+                          << " >>> newSC    #" << i << "; Energy: " << nsc.energy() << " eta: " << nsc.eta()
+                          << " isClean=" << nsc.isInClean() << " isUnclean=" << nsc.isInUnclean()
+                          << " sc seed detid: " << nsc.seed()->seed().rawId();
+
+    if (nsc.isInUnclean())
+      ++new_unclean;
+    if (nsc.isInClean())
+      ++new_clean;
+  }
+  LogTrace("UnifiedSC") << "The new SC unclean only collection with size " << superClustersUncleanOnly.size();
+  for (int i = 0; i < (int)superClustersUncleanOnly.size(); ++i) {
+    const reco::SuperCluster nsc = superClustersUncleanOnly[i];
+    LogTrace("UnifiedSC") << " >>> newSC    #" << i << "; Energy: " << nsc.energy() << " eta: " << nsc.eta()
+                          << " isClean=" << nsc.isInClean() << " isUnclean=" << nsc.isInUnclean()
+                          << " sc seed detid: " << nsc.seed()->seed().rawId();
+    if (nsc.isInUnclean())
+      ++new_unclean;
+    if (nsc.isInClean())
+      ++new_clean;
+  }
+  if ((new_unclean != uncleanSize) || (new_clean != cleanSize)) {
+    LogTrace("UnifiedSC") << ">>>>!!!!!! MISMATCH: new unclean/ old unclean= " << new_unclean << " / " << uncleanSize
+                          << ", new clean/ old clean" << new_clean << " / " << cleanSize;
+  }
 }

--- a/RecoEcal/EgammaClusterProducers/test/PFSuperClusterTreeMaker.cc
+++ b/RecoEcal/EgammaClusterProducers/test/PFSuperClusterTreeMaker.cc
@@ -43,197 +43,192 @@ namespace MK = reco::MustacheKernel;
 
 typedef edm::ParameterSet PSet;
 
-namespace {  
-  template<typename T>
-  void array_deleter (T* arr) { delete [] arr; }
+namespace {
+  template <typename T>
+  void array_deleter(T* arr) {
+    delete[] arr;
+  }
 
   struct GetSharedRecHitFraction {
-    const edm::Ptr<reco::CaloCluster> the_seed;    
+    const edm::Ptr<reco::CaloCluster> the_seed;
     double x_rechits_tot, x_rechits_match;
-    GetSharedRecHitFraction(const edm::Ptr<reco::CaloCluster>& s) : 
-      the_seed(s) {}
-    double operator()(const edm::Ptr<reco::CaloCluster>& x) {      
+    GetSharedRecHitFraction(const edm::Ptr<reco::CaloCluster>& s) : the_seed(s) {}
+    double operator()(const edm::Ptr<reco::CaloCluster>& x) {
       // now see if the clusters overlap in rechits
-      const auto& seedHitsAndFractions = 
-	the_seed->hitsAndFractions();
-      const auto& xHitsAndFractions = 
-	x->hitsAndFractions();      
-      x_rechits_tot   = xHitsAndFractions.size();
-      x_rechits_match = 0.0;      
-      for( const std::pair<DetId, float>& seedHit : seedHitsAndFractions ) {
-	for( const std::pair<DetId, float>& xHit : xHitsAndFractions ) {
-	  if( seedHit.first == xHit.first ) {	    
-	    x_rechits_match += 1.0;
-	  }
-	}	
-      }      
-      return x_rechits_match/x_rechits_tot;
+      const auto& seedHitsAndFractions = the_seed->hitsAndFractions();
+      const auto& xHitsAndFractions = x->hitsAndFractions();
+      x_rechits_tot = xHitsAndFractions.size();
+      x_rechits_match = 0.0;
+      for (const std::pair<DetId, float>& seedHit : seedHitsAndFractions) {
+        for (const std::pair<DetId, float>& xHit : xHitsAndFractions) {
+          if (seedHit.first == xHit.first) {
+            x_rechits_match += 1.0;
+          }
+        }
+      }
+      return x_rechits_match / x_rechits_tot;
     }
   };
-}
+}  // namespace
 
 class PFSuperClusterTreeMaker : public edm::EDAnalyzer {
-  typedef TTree* treeptr;  
+  typedef TTree* treeptr;
+
 public:
   PFSuperClusterTreeMaker(const PSet&);
   ~PFSuperClusterTreeMaker() {}
 
   void analyze(const edm::Event&, const edm::EventSetup&);
-private:    
+
+private:
   edm::Service<TFileService> _fs;
   bool _dogen;
   edm::InputTag _geninput;
   edm::InputTag _vtxsrc;
   bool _readEB, _readEE;
-  edm::InputTag _scInputEB,_scInputEE;
+  edm::InputTag _scInputEB, _scInputEE;
   std::shared_ptr<PFEnergyCalibration> _calib;
-  std::map<reco::SuperClusterRef,reco::GenParticleRef> _genmatched;
-  void findBestGenMatches(const edm::Event& e, 
-			  const edm::Handle<reco::SuperClusterCollection>& scs);
-  void processSuperClusterFillTree(const edm::Event&,
-				   const reco::SuperClusterRef&);
-  // the tree  
-  void setTreeArraysForSize(const size_t N_ECAL,const size_t N_PS);
+  std::map<reco::SuperClusterRef, reco::GenParticleRef> _genmatched;
+  void findBestGenMatches(const edm::Event& e, const edm::Handle<reco::SuperClusterCollection>& scs);
+  void processSuperClusterFillTree(const edm::Event&, const reco::SuperClusterRef&);
+  // the tree
+  void setTreeArraysForSize(const size_t N_ECAL, const size_t N_PS);
   treeptr _tree;
   Int_t nVtx;
-  Float_t scRawEnergy, scCalibratedEnergy, scPreshowerEnergy,
-    scEta, scPhi, scR, scPhiWidth, scEtaWidth, scSeedRawEnergy, 
-    scSeedCalibratedEnergy, scSeedEta, scSeedPhi;
+  Float_t scRawEnergy, scCalibratedEnergy, scPreshowerEnergy, scEta, scPhi, scR, scPhiWidth, scEtaWidth,
+      scSeedRawEnergy, scSeedCalibratedEnergy, scSeedEta, scSeedPhi;
   Float_t genEnergy, genEta, genPhi, genDRToCentroid, genDRToSeed;
   Int_t N_ECALClusters;
-  std::shared_ptr<Float_t> clusterRawEnergy, clusterCalibEnergy, 
-    clusterEta, clusterPhi, clusterDPhiToSeed, clusterDEtaToSeed, 
-    clusterDPhiToCentroid, clusterDEtaToCentroid, 
-    clusterDPhiToGen, clusterDEtaToGen, clusterHitFractionSharedWithSeed;
+  std::shared_ptr<Float_t> clusterRawEnergy, clusterCalibEnergy, clusterEta, clusterPhi, clusterDPhiToSeed,
+      clusterDEtaToSeed, clusterDPhiToCentroid, clusterDEtaToCentroid, clusterDPhiToGen, clusterDEtaToGen,
+      clusterHitFractionSharedWithSeed;
   std::shared_ptr<Int_t> clusterInMustache, clusterInDynDPhi;
   Int_t N_PSClusters;
   std::shared_ptr<Float_t> psClusterRawEnergy, psClusterEta, psClusterPhi;
 };
 
-void PFSuperClusterTreeMaker::analyze(const edm::Event& e, 
-				      const edm::EventSetup& es) {
+void PFSuperClusterTreeMaker::analyze(const edm::Event& e, const edm::EventSetup& es) {
   edm::Handle<reco::VertexCollection> vtcs;
-  e.getByLabel(_vtxsrc,vtcs);
-  if( vtcs.isValid() ) nVtx = vtcs->size();
-  else nVtx = -1;
+  e.getByLabel(_vtxsrc, vtcs);
+  if (vtcs.isValid())
+    nVtx = vtcs->size();
+  else
+    nVtx = -1;
 
   edm::Handle<reco::SuperClusterCollection> ebSCs, eeSCs;
-  if( _readEB )
-    e.getByLabel(_scInputEB, ebSCs);  
-  if( _readEE )
-    e.getByLabel(_scInputEE, eeSCs);  
- 
-  if( ebSCs.isValid() ) {   
-    findBestGenMatches(e, ebSCs);
-    for( size_t i = 0; i < ebSCs->size(); ++i ) {
-      processSuperClusterFillTree(e,reco::SuperClusterRef(ebSCs,i));
-    }
-  } 
+  if (_readEB)
+    e.getByLabel(_scInputEB, ebSCs);
+  if (_readEE)
+    e.getByLabel(_scInputEE, eeSCs);
 
-  if( eeSCs.isValid() ) {
+  if (ebSCs.isValid()) {
+    findBestGenMatches(e, ebSCs);
+    for (size_t i = 0; i < ebSCs->size(); ++i) {
+      processSuperClusterFillTree(e, reco::SuperClusterRef(ebSCs, i));
+    }
+  }
+
+  if (eeSCs.isValid()) {
     findBestGenMatches(e, eeSCs);
-    for( size_t i = 0; i < eeSCs->size(); ++i ) {       
-      processSuperClusterFillTree(e,reco::SuperClusterRef(eeSCs,i));
+    for (size_t i = 0; i < eeSCs->size(); ++i) {
+      processSuperClusterFillTree(e, reco::SuperClusterRef(eeSCs, i));
     }
   }
 }
 
-void PFSuperClusterTreeMaker::
-findBestGenMatches(const edm::Event& e, 
-		   const edm::Handle<reco::SuperClusterCollection>& scs) {
+void PFSuperClusterTreeMaker::findBestGenMatches(const edm::Event& e,
+                                                 const edm::Handle<reco::SuperClusterCollection>& scs) {
   _genmatched.clear();
   reco::GenParticleRef genmatch;
   // gen information (if needed)
-  if( _dogen ) {
+  if (_dogen) {
     edm::Handle<reco::GenParticleCollection> genp;
     std::vector<reco::GenParticleRef> elesandphos;
-    e.getByLabel(_geninput,genp);
-    if( genp.isValid() ) {     
+    e.getByLabel(_geninput, genp);
+    if (genp.isValid()) {
       reco::GenParticleRef bestmatch;
-      for(size_t i = 0; i < genp->size(); ++i) {	
-	const int pdgid = std::abs(genp->at(i).pdgId());
-	if( pdgid == 22 || pdgid == 11 ) {	     
-	  elesandphos.push_back(reco::GenParticleRef(genp,i));
-	}
+      for (size_t i = 0; i < genp->size(); ++i) {
+        const int pdgid = std::abs(genp->at(i).pdgId());
+        if (pdgid == 22 || pdgid == 11) {
+          elesandphos.push_back(reco::GenParticleRef(genp, i));
+        }
       }
-      for( size_t i = 0; i < elesandphos.size(); ++i ) {
-	double dE_min = -1;
-	reco::SuperClusterRef bestmatch;
-	for( size_t k = 0; k < scs->size(); ++k ) {
-	  if( reco::deltaR(scs->at(k),*elesandphos[i]) < 0.3 ) {
-	    double dE = std::abs(scs->at(k).energy()-elesandphos[i]->energy());
-	    if( dE_min == -1 || dE < dE_min ) {
-	      dE_min = dE;
-	      bestmatch = reco::SuperClusterRef(scs,k);
-	    }
-	  }
-	}
-	_genmatched[bestmatch] = elesandphos[i];
+      for (size_t i = 0; i < elesandphos.size(); ++i) {
+        double dE_min = -1;
+        reco::SuperClusterRef bestmatch;
+        for (size_t k = 0; k < scs->size(); ++k) {
+          if (reco::deltaR(scs->at(k), *elesandphos[i]) < 0.3) {
+            double dE = std::abs(scs->at(k).energy() - elesandphos[i]->energy());
+            if (dE_min == -1 || dE < dE_min) {
+              dE_min = dE;
+              bestmatch = reco::SuperClusterRef(scs, k);
+            }
+          }
+        }
+        _genmatched[bestmatch] = elesandphos[i];
       }
     } else {
       throw cms::Exception("PFSuperClusterTreeMaker")
-      << "Requested generator level information was not available!"
-      << std::endl;
+          << "Requested generator level information was not available!" << std::endl;
     }
   }
 }
 
-void PFSuperClusterTreeMaker::
-processSuperClusterFillTree(const edm::Event& e, 
-			    const reco::SuperClusterRef& sc) {
+void PFSuperClusterTreeMaker::processSuperClusterFillTree(const edm::Event& e, const reco::SuperClusterRef& sc) {
   const int N_ECAL = sc->clustersSize();
-  const int N_PS   = sc->preshowerClustersSize();
+  const int N_PS = sc->preshowerClustersSize();
   const double sc_eta = std::abs(sc->position().Eta());
   const double sc_cosheta = std::cosh(sc_eta);
-  const double sc_pt = sc->rawEnergy()/sc_cosheta;
-  if( !std::distance(sc->clustersBegin(),sc->clustersEnd()) ) return;
-  if( (sc_pt < 3.0 && sc_eta < 2.0) || 
-      (sc_pt < 4.0 && sc_eta < 2.5 && sc_eta > 2.0) ||
-      (sc_pt < 6.0 && sc_eta > 2.5) ) return;
-  N_ECALClusters = std::max(0,N_ECAL - 1); // minus 1 because of seed
-  N_PSClusters = N_PS;  
+  const double sc_pt = sc->rawEnergy() / sc_cosheta;
+  if (!std::distance(sc->clustersBegin(), sc->clustersEnd()))
+    return;
+  if ((sc_pt < 3.0 && sc_eta < 2.0) || (sc_pt < 4.0 && sc_eta < 2.5 && sc_eta > 2.0) || (sc_pt < 6.0 && sc_eta > 2.5))
+    return;
+  N_ECALClusters = std::max(0, N_ECAL - 1);  // minus 1 because of seed
+  N_PSClusters = N_PS;
   // gen information (if needed)
   reco::GenParticleRef genmatch;
-  if( _dogen ) {    
-    std::map<reco::SuperClusterRef,reco::GenParticleRef>::iterator itrmatch;
-      if(  (itrmatch = _genmatched.find(sc)) != _genmatched.end() ) {
-      genmatch  = itrmatch->second;           
+  if (_dogen) {
+    std::map<reco::SuperClusterRef, reco::GenParticleRef>::iterator itrmatch;
+    if ((itrmatch = _genmatched.find(sc)) != _genmatched.end()) {
+      genmatch = itrmatch->second;
       genEnergy = genmatch->energy();
-      genEta    = genmatch->eta();
-      genPhi    = genmatch->phi();
-      genDRToCentroid = reco::deltaR(*sc,*genmatch);
-      genDRToSeed = reco::deltaR(*genmatch,**(sc->clustersBegin()));
+      genEta = genmatch->eta();
+      genPhi = genmatch->phi();
+      genDRToCentroid = reco::deltaR(*sc, *genmatch);
+      genDRToSeed = reco::deltaR(*genmatch, **(sc->clustersBegin()));
     } else {
       genEnergy = -1.0;
-      genEta    = 999.0;
-      genPhi    = 999.0;
+      genEta = 999.0;
+      genPhi = 999.0;
       genDRToCentroid = 999.0;
       genDRToSeed = 999.0;
-    }    
+    }
   }
   // supercluster information
-  setTreeArraysForSize(N_ECALClusters,N_PSClusters);
+  setTreeArraysForSize(N_ECALClusters, N_PSClusters);
   scRawEnergy = sc->rawEnergy();
   scCalibratedEnergy = sc->energy();
   scPreshowerEnergy = sc->preshowerEnergy();
   scEta = sc->position().Eta();
   scPhi = sc->position().Phi();
-  scR   = sc->position().R();
+  scR = sc->position().R();
   scPhiWidth = sc->phiWidth();
   scEtaWidth = sc->etaWidth();
   // sc seed information
   bool sc_is_pf = false;
-  edm::Ptr<reco::CaloCluster> theseed = sc->seed();  
+  edm::Ptr<reco::CaloCluster> theseed = sc->seed();
   reco::CaloCluster_iterator startCluster = sc->clustersBegin();
-  if( theseed.isNull() || !theseed.isAvailable() ) {
-    edm::Ptr<reco::CaloCluster> theseed = *(startCluster++);  
+  if (theseed.isNull() || !theseed.isAvailable()) {
+    edm::Ptr<reco::CaloCluster> theseed = *(startCluster++);
   }
   edm::Ptr<reco::PFCluster> seedasPF = edm::Ptr<reco::PFCluster>(theseed);
-  if( seedasPF.isNonnull() && seedasPF.isAvailable() ) sc_is_pf = true;
+  if (seedasPF.isNonnull() && seedasPF.isAvailable())
+    sc_is_pf = true;
   GetSharedRecHitFraction fractionOfSeed(theseed);
   scSeedRawEnergy = theseed->energy();
-  if( sc_is_pf ) {
-    scSeedCalibratedEnergy = _calib->energyEm(*seedasPF,0.0,0.0,false);
+  if (sc_is_pf) {
+    scSeedCalibratedEnergy = _calib->energyEm(*seedasPF, 0.0, 0.0, false);
   } else {
     scSeedCalibratedEnergy = theseed->energy();
   }
@@ -243,55 +238,44 @@ processSuperClusterFillTree(const edm::Event& e,
   auto clusend = sc->clustersEnd();
   size_t iclus = 0;
   edm::Ptr<reco::PFCluster> pclus;
-  for( auto clus = startCluster; clus != clusend; ++clus ) {    
-    if( theseed == *clus ) continue;
+  for (auto clus = startCluster; clus != clusend; ++clus) {
+    if (theseed == *clus)
+      continue;
     clusterRawEnergy.get()[iclus] = (*clus)->energy();
-    if( sc_is_pf ) {
+    if (sc_is_pf) {
       pclus = edm::Ptr<reco::PFCluster>(*clus);
-      clusterCalibEnergy.get()[iclus] = _calib->energyEm(*pclus,0.0,0.0,false);
+      clusterCalibEnergy.get()[iclus] = _calib->energyEm(*pclus, 0.0, 0.0, false);
     } else {
       clusterCalibEnergy.get()[iclus] = (*clus)->energy();
     }
     clusterEta.get()[iclus] = (*clus)->eta();
     clusterPhi.get()[iclus] = (*clus)->phi();
-    clusterDPhiToSeed.get()[iclus] = 
-      TVector2::Phi_mpi_pi((*clus)->phi() - theseed->phi());
+    clusterDPhiToSeed.get()[iclus] = TVector2::Phi_mpi_pi((*clus)->phi() - theseed->phi());
     clusterDEtaToSeed.get()[iclus] = (*clus)->eta() - theseed->eta();
-    clusterDPhiToCentroid.get()[iclus] = 
-      TVector2::Phi_mpi_pi((*clus)->phi() - sc->phi());
+    clusterDPhiToCentroid.get()[iclus] = TVector2::Phi_mpi_pi((*clus)->phi() - sc->phi());
     clusterDEtaToCentroid.get()[iclus] = (*clus)->eta() - sc->eta();
-    clusterDPhiToCentroid.get()[iclus] = 
-      TVector2::Phi_mpi_pi((*clus)->phi() - sc->phi());
-    clusterDEtaToCentroid.get()[iclus] = (*clus)->eta() - sc->eta();    
+    clusterDPhiToCentroid.get()[iclus] = TVector2::Phi_mpi_pi((*clus)->phi() - sc->phi());
+    clusterDEtaToCentroid.get()[iclus] = (*clus)->eta() - sc->eta();
     clusterHitFractionSharedWithSeed.get()[iclus] = fractionOfSeed(*clus);
-    if( _dogen && genmatch.isNonnull() ) {
-      clusterDPhiToGen.get()[iclus] = 
-	TVector2::Phi_mpi_pi((*clus)->phi() - genmatch->phi());
+    if (_dogen && genmatch.isNonnull()) {
+      clusterDPhiToGen.get()[iclus] = TVector2::Phi_mpi_pi((*clus)->phi() - genmatch->phi());
       clusterDEtaToGen.get()[iclus] = (*clus)->eta() - genmatch->eta();
     }
-    clusterInMustache.get()[iclus] = (Int_t) MK::inMustache(theseed->eta(),
-							    theseed->phi(),
-							    (*clus)->energy(),
-							    (*clus)->eta(),
-							    (*clus)->phi());
+    clusterInMustache.get()[iclus] =
+        (Int_t)MK::inMustache(theseed->eta(), theseed->phi(), (*clus)->energy(), (*clus)->eta(), (*clus)->phi());
 
-    clusterInDynDPhi.get()[iclus] = (Int_t)
-      MK::inDynamicDPhiWindow(theseed->eta(),
-			      theseed->phi(),
-			      (*clus)->energy(),
-			      (*clus)->eta(),
-			      (*clus)->phi());   
+    clusterInDynDPhi.get()[iclus] = (Int_t)MK::inDynamicDPhiWindow(
+        theseed->eta(), theseed->phi(), (*clus)->energy(), (*clus)->eta(), (*clus)->phi());
     ++iclus;
   }
-  // loop over all preshower clusters 
+  // loop over all preshower clusters
   auto psclusend = sc->preshowerClustersEnd();
   size_t ipsclus = 0;
   edm::Ptr<reco::CaloCluster> ppsclus;
-  for( auto psclus = sc->preshowerClustersBegin(); psclus != psclusend; 
-       ++psclus ) {
+  for (auto psclus = sc->preshowerClustersBegin(); psclus != psclusend; ++psclus) {
     ppsclus = edm::Ptr<reco::CaloCluster>(*psclus);
-    psClusterRawEnergy.get()[ipsclus] = ppsclus->energy();    
-    psClusterEta.get()[ipsclus] = ppsclus->eta();    
+    psClusterRawEnergy.get()[ipsclus] = ppsclus->energy();
+    psClusterEta.get()[ipsclus] = ppsclus->eta();
     psClusterPhi.get()[ipsclus] = ppsclus->phi();
     ++ipsclus;
   }
@@ -301,155 +285,133 @@ processSuperClusterFillTree(const edm::Event& e,
 PFSuperClusterTreeMaker::PFSuperClusterTreeMaker(const PSet& p) {
   _calib.reset(new PFEnergyCalibration());
   N_ECALClusters = 1;
-  N_PSClusters   = 1;
-  _tree = _fs->make<TTree>("SuperClusterTree","Dump of all available SC info");
-  _tree->Branch("N_ECALClusters",&N_ECALClusters,"N_ECALClusters/I");
-  _tree->Branch("N_PSClusters",&N_PSClusters,"N_PSClusters/I");
-  _tree->Branch("nVtx",&nVtx,"nVtx/I");
-  _tree->Branch("scRawEnergy",&scRawEnergy,"scRawEnergy/F");
-  _tree->Branch("scCalibratedEnergy",&scCalibratedEnergy,
-		"scCalibratedEnergy/F");
-  _tree->Branch("scPreshowerEnergy",&scPreshowerEnergy,"scPreshowerEnergy/F");
-  _tree->Branch("scEta",&scEta,"scEta/F");
-  _tree->Branch("scPhi",&scPhi,"scPhi/F");
-  _tree->Branch("scR",&scR,"scR/F");
-  _tree->Branch("scPhiWidth",&scPhiWidth,"scPhiWidth/F");
-  _tree->Branch("scEtaWidth",&scEtaWidth,"scEtaWidth/F");
-  _tree->Branch("scSeedRawEnergy",&scSeedRawEnergy,"scSeedRawEnergy/F");
-  _tree->Branch("scSeedCalibratedEnergy",&scSeedCalibratedEnergy,
-		"scSeedCalibratedEnergy/F");
-  _tree->Branch("scSeedEta",&scSeedEta,"scSeedEta/F");
-  _tree->Branch("scSeedPhi",&scSeedPhi,"scSeedPhi/F");
+  N_PSClusters = 1;
+  _tree = _fs->make<TTree>("SuperClusterTree", "Dump of all available SC info");
+  _tree->Branch("N_ECALClusters", &N_ECALClusters, "N_ECALClusters/I");
+  _tree->Branch("N_PSClusters", &N_PSClusters, "N_PSClusters/I");
+  _tree->Branch("nVtx", &nVtx, "nVtx/I");
+  _tree->Branch("scRawEnergy", &scRawEnergy, "scRawEnergy/F");
+  _tree->Branch("scCalibratedEnergy", &scCalibratedEnergy, "scCalibratedEnergy/F");
+  _tree->Branch("scPreshowerEnergy", &scPreshowerEnergy, "scPreshowerEnergy/F");
+  _tree->Branch("scEta", &scEta, "scEta/F");
+  _tree->Branch("scPhi", &scPhi, "scPhi/F");
+  _tree->Branch("scR", &scR, "scR/F");
+  _tree->Branch("scPhiWidth", &scPhiWidth, "scPhiWidth/F");
+  _tree->Branch("scEtaWidth", &scEtaWidth, "scEtaWidth/F");
+  _tree->Branch("scSeedRawEnergy", &scSeedRawEnergy, "scSeedRawEnergy/F");
+  _tree->Branch("scSeedCalibratedEnergy", &scSeedCalibratedEnergy, "scSeedCalibratedEnergy/F");
+  _tree->Branch("scSeedEta", &scSeedEta, "scSeedEta/F");
+  _tree->Branch("scSeedPhi", &scSeedPhi, "scSeedPhi/F");
   // ecal cluster information
-  clusterRawEnergy.reset(new Float_t[1],array_deleter<Float_t>);
-  _tree->Branch("clusterRawEnergy",clusterRawEnergy.get(),
-		"clusterRawEnergy[N_ECALClusters]/F");
-  clusterCalibEnergy.reset(new Float_t[1],array_deleter<Float_t>);
-  _tree->Branch("clusterCalibEnergy",clusterCalibEnergy.get(),
-		"clusterCalibEnergy[N_ECALClusters]/F");
-  clusterEta.reset(new Float_t[1],array_deleter<Float_t>);
-  _tree->Branch("clusterEta",clusterEta.get(),
-		"clusterEta[N_ECALClusters]/F");
-  clusterPhi.reset(new Float_t[1],array_deleter<Float_t>);
-  _tree->Branch("clusterPhi",clusterPhi.get(),
-		"clusterPhi[N_ECALClusters]/F");
-  clusterDPhiToSeed.reset(new Float_t[1],array_deleter<Float_t>);
-  _tree->Branch("clusterDPhiToSeed",clusterDPhiToSeed.get(),
-		"clusterDPhiToSeed[N_ECALClusters]/F");
-  clusterDEtaToSeed.reset(new Float_t[1],array_deleter<Float_t>);  
-  _tree->Branch("clusterDEtaToSeed",clusterDEtaToSeed.get(),
-		"clusterDEtaToSeed[N_ECALClusters]/F");  
-  clusterDPhiToCentroid.reset(new Float_t[1],array_deleter<Float_t>);
-  _tree->Branch("clusterDPhiToCentroid",clusterDPhiToCentroid.get(),
-		"clusterDPhiToCentroid[N_ECALClusters]/F");
-  clusterDEtaToCentroid.reset(new Float_t[1],array_deleter<Float_t>);
-  _tree->Branch("clusterDEtaToCentroid",clusterDEtaToCentroid.get(),
-		"clusterDEtaToCentroid[N_ECALClusters]/F");
-  clusterHitFractionSharedWithSeed.reset(new Float_t[1],
-					 array_deleter<Float_t>);
+  clusterRawEnergy.reset(new Float_t[1], array_deleter<Float_t>);
+  _tree->Branch("clusterRawEnergy", clusterRawEnergy.get(), "clusterRawEnergy[N_ECALClusters]/F");
+  clusterCalibEnergy.reset(new Float_t[1], array_deleter<Float_t>);
+  _tree->Branch("clusterCalibEnergy", clusterCalibEnergy.get(), "clusterCalibEnergy[N_ECALClusters]/F");
+  clusterEta.reset(new Float_t[1], array_deleter<Float_t>);
+  _tree->Branch("clusterEta", clusterEta.get(), "clusterEta[N_ECALClusters]/F");
+  clusterPhi.reset(new Float_t[1], array_deleter<Float_t>);
+  _tree->Branch("clusterPhi", clusterPhi.get(), "clusterPhi[N_ECALClusters]/F");
+  clusterDPhiToSeed.reset(new Float_t[1], array_deleter<Float_t>);
+  _tree->Branch("clusterDPhiToSeed", clusterDPhiToSeed.get(), "clusterDPhiToSeed[N_ECALClusters]/F");
+  clusterDEtaToSeed.reset(new Float_t[1], array_deleter<Float_t>);
+  _tree->Branch("clusterDEtaToSeed", clusterDEtaToSeed.get(), "clusterDEtaToSeed[N_ECALClusters]/F");
+  clusterDPhiToCentroid.reset(new Float_t[1], array_deleter<Float_t>);
+  _tree->Branch("clusterDPhiToCentroid", clusterDPhiToCentroid.get(), "clusterDPhiToCentroid[N_ECALClusters]/F");
+  clusterDEtaToCentroid.reset(new Float_t[1], array_deleter<Float_t>);
+  _tree->Branch("clusterDEtaToCentroid", clusterDEtaToCentroid.get(), "clusterDEtaToCentroid[N_ECALClusters]/F");
+  clusterHitFractionSharedWithSeed.reset(new Float_t[1], array_deleter<Float_t>);
   _tree->Branch("clusterHitFractionSharedWithSeed",
-		clusterHitFractionSharedWithSeed.get(),
-		"clusterHitFractionSharedWithSeed[N_ECALClusters]/F");
-  clusterInMustache.reset(new Int_t[1],array_deleter<Int_t>);
-  _tree->Branch("clusterInMustache",clusterInMustache.get(),
-		"clusterInMustache[N_ECALClusters]/I");
-  clusterInDynDPhi.reset(new Int_t[1],array_deleter<Int_t>);
-  _tree->Branch("clusterInDynDPhi",clusterInDynDPhi.get(),
-		"clusterInDynDPhi[N_ECALClusters]/I");
+                clusterHitFractionSharedWithSeed.get(),
+                "clusterHitFractionSharedWithSeed[N_ECALClusters]/F");
+  clusterInMustache.reset(new Int_t[1], array_deleter<Int_t>);
+  _tree->Branch("clusterInMustache", clusterInMustache.get(), "clusterInMustache[N_ECALClusters]/I");
+  clusterInDynDPhi.reset(new Int_t[1], array_deleter<Int_t>);
+  _tree->Branch("clusterInDynDPhi", clusterInDynDPhi.get(), "clusterInDynDPhi[N_ECALClusters]/I");
   // preshower information
-  psClusterRawEnergy.reset(new Float_t[1],array_deleter<Float_t>);
-  _tree->Branch("psClusterRawEnergy",psClusterRawEnergy.get(),
-		   "psClusterRawEnergy[N_PSClusters]/F");
-  psClusterEta.reset(new Float_t[1],array_deleter<Float_t>);
-  _tree->Branch("psClusterEta",psClusterEta.get(),
-		"psClusterEta[N_PSClusters]/F");
-  psClusterPhi.reset(new Float_t[1],array_deleter<Float_t>);
-  _tree->Branch("psClusterPhi",psClusterPhi.get(),
-		"psClusterPhi[N_PSClusters]/F");
+  psClusterRawEnergy.reset(new Float_t[1], array_deleter<Float_t>);
+  _tree->Branch("psClusterRawEnergy", psClusterRawEnergy.get(), "psClusterRawEnergy[N_PSClusters]/F");
+  psClusterEta.reset(new Float_t[1], array_deleter<Float_t>);
+  _tree->Branch("psClusterEta", psClusterEta.get(), "psClusterEta[N_PSClusters]/F");
+  psClusterPhi.reset(new Float_t[1], array_deleter<Float_t>);
+  _tree->Branch("psClusterPhi", psClusterPhi.get(), "psClusterPhi[N_PSClusters]/F");
 
+  if ((_dogen = p.getUntrackedParameter<bool>("doGen", false))) {
+    _geninput = p.getParameter<edm::InputTag>("genSrc");
+    _tree->Branch("genEta", &genEta, "genEta/F");
+    _tree->Branch("genPhi", &genPhi, "genPhi/F");
+    _tree->Branch("genEnergy", &genEnergy, "genEnergy/F");
+    _tree->Branch("genDRToCentroid", &genDRToCentroid, "genDRToCentroid/F");
+    _tree->Branch("genDRToSeed", &genDRToSeed, "genDRToSeed/F");
 
-  if( (_dogen = p.getUntrackedParameter<bool>("doGen",false)) ) {
-    _geninput = p.getParameter<edm::InputTag>("genSrc");    
-    _tree->Branch("genEta",&genEta,"genEta/F");
-    _tree->Branch("genPhi",&genPhi,"genPhi/F");
-    _tree->Branch("genEnergy",&genEnergy,"genEnergy/F");
-    _tree->Branch("genDRToCentroid",&genDRToCentroid,"genDRToCentroid/F");
-    _tree->Branch("genDRToSeed",&genDRToSeed,"genDRToSeed/F");
-    
-    clusterDPhiToGen.reset(new Float_t[1],array_deleter<Float_t>);
-    _tree->Branch("clusterDPhiToGen",clusterDPhiToGen.get(),
-		  "clusterDPhiToGen[N_ECALClusters]/F");
-    clusterDEtaToGen.reset(new Float_t[1],array_deleter<Float_t>);
-    _tree->Branch("clusterDEtaToGen",clusterDEtaToGen.get(),
-		  "clusterDPhiToGen[N_ECALClusters]/F");
+    clusterDPhiToGen.reset(new Float_t[1], array_deleter<Float_t>);
+    _tree->Branch("clusterDPhiToGen", clusterDPhiToGen.get(), "clusterDPhiToGen[N_ECALClusters]/F");
+    clusterDEtaToGen.reset(new Float_t[1], array_deleter<Float_t>);
+    _tree->Branch("clusterDEtaToGen", clusterDEtaToGen.get(), "clusterDPhiToGen[N_ECALClusters]/F");
   }
-  _vtxsrc    = p.getParameter<edm::InputTag>("primaryVertices");
+  _vtxsrc = p.getParameter<edm::InputTag>("primaryVertices");
 
   _readEB = _readEE = false;
-  if( p.existsAs<edm::InputTag>("superClusterSrcEB") ) {
+  if (p.existsAs<edm::InputTag>("superClusterSrcEB")) {
     _readEB = true;
     _scInputEB = p.getParameter<edm::InputTag>("superClusterSrcEB");
-  } 
-  if( p.existsAs<edm::InputTag>("superClusterSrcEE") ) {
+  }
+  if (p.existsAs<edm::InputTag>("superClusterSrcEE")) {
     _readEE = true;
-    _scInputEE = p.getParameter<edm::InputTag>("superClusterSrcEE"); 
+    _scInputEE = p.getParameter<edm::InputTag>("superClusterSrcEE");
   }
 }
 
-
-void PFSuperClusterTreeMaker::setTreeArraysForSize(const size_t N_ECAL,
-						   const size_t N_PS) {
+void PFSuperClusterTreeMaker::setTreeArraysForSize(const size_t N_ECAL, const size_t N_PS) {
   Float_t* cRE_new = new Float_t[N_ECAL];
-  clusterRawEnergy.reset(cRE_new,array_deleter<Float_t>);
+  clusterRawEnergy.reset(cRE_new, array_deleter<Float_t>);
   _tree->GetBranch("clusterRawEnergy")->SetAddress(clusterRawEnergy.get());
   Float_t* cCE_new = new Float_t[N_ECAL];
-  clusterCalibEnergy.reset(cCE_new,array_deleter<Float_t>);
+  clusterCalibEnergy.reset(cCE_new, array_deleter<Float_t>);
   _tree->GetBranch("clusterCalibEnergy")->SetAddress(clusterCalibEnergy.get());
   Float_t* cEta_new = new Float_t[N_ECAL];
-  clusterEta.reset(cEta_new,array_deleter<Float_t>);
+  clusterEta.reset(cEta_new, array_deleter<Float_t>);
   _tree->GetBranch("clusterEta")->SetAddress(clusterEta.get());
   Float_t* cPhi_new = new Float_t[N_ECAL];
-  clusterPhi.reset(cPhi_new,array_deleter<Float_t>);
+  clusterPhi.reset(cPhi_new, array_deleter<Float_t>);
   _tree->GetBranch("clusterPhi")->SetAddress(clusterPhi.get());
   Float_t* cDPhiSeed_new = new Float_t[N_ECAL];
-  clusterDPhiToSeed.reset(cDPhiSeed_new,array_deleter<Float_t>);
+  clusterDPhiToSeed.reset(cDPhiSeed_new, array_deleter<Float_t>);
   _tree->GetBranch("clusterDPhiToSeed")->SetAddress(clusterDPhiToSeed.get());
   Float_t* cDEtaSeed_new = new Float_t[N_ECAL];
-  clusterDEtaToSeed.reset(cDEtaSeed_new,array_deleter<Float_t>);  
+  clusterDEtaToSeed.reset(cDEtaSeed_new, array_deleter<Float_t>);
   _tree->GetBranch("clusterDEtaToSeed")->SetAddress(clusterDEtaToSeed.get());
   Float_t* cDPhiCntr_new = new Float_t[N_ECAL];
-  clusterDPhiToCentroid.reset(cDPhiCntr_new,array_deleter<Float_t>);
+  clusterDPhiToCentroid.reset(cDPhiCntr_new, array_deleter<Float_t>);
   _tree->GetBranch("clusterDPhiToCentroid")->SetAddress(clusterDPhiToCentroid.get());
   Float_t* cDEtaCntr_new = new Float_t[N_ECAL];
-  clusterDEtaToCentroid.reset(cDEtaCntr_new,array_deleter<Float_t>);
+  clusterDEtaToCentroid.reset(cDEtaCntr_new, array_deleter<Float_t>);
   _tree->GetBranch("clusterDEtaToCentroid")->SetAddress(clusterDEtaToCentroid.get());
   Float_t* cHitFracShared_new = new Float_t[N_ECAL];
-  clusterHitFractionSharedWithSeed.reset(cHitFracShared_new,
-					 array_deleter<Float_t>);
+  clusterHitFractionSharedWithSeed.reset(cHitFracShared_new, array_deleter<Float_t>);
   _tree->GetBranch("clusterHitFractionSharedWithSeed")->SetAddress(clusterHitFractionSharedWithSeed.get());
-  
-  if( _dogen ) {
+
+  if (_dogen) {
     Float_t* cDPhiGen_new = new Float_t[N_ECAL];
-    clusterDPhiToGen.reset(cDPhiGen_new,array_deleter<Float_t>);
+    clusterDPhiToGen.reset(cDPhiGen_new, array_deleter<Float_t>);
     _tree->GetBranch("clusterDPhiToGen")->SetAddress(clusterDPhiToGen.get());
     Float_t* cDEtaGen_new = new Float_t[N_ECAL];
-    clusterDEtaToGen.reset(cDEtaGen_new,array_deleter<Float_t>);
+    clusterDEtaToGen.reset(cDEtaGen_new, array_deleter<Float_t>);
     _tree->GetBranch("clusterDEtaToGen")->SetAddress(clusterDEtaToGen.get());
   }
   Int_t* cInMust_new = new Int_t[N_ECAL];
-  clusterInMustache.reset(cInMust_new,array_deleter<Int_t>);
+  clusterInMustache.reset(cInMust_new, array_deleter<Int_t>);
   _tree->GetBranch("clusterInMustache")->SetAddress(clusterInMustache.get());
   Int_t* cInDynDPhi_new = new Int_t[N_ECAL];
-  clusterInDynDPhi.reset(cInDynDPhi_new,array_deleter<Int_t>);
+  clusterInDynDPhi.reset(cInDynDPhi_new, array_deleter<Int_t>);
   _tree->GetBranch("clusterInDynDPhi")->SetAddress(clusterInDynDPhi.get());
   Float_t* psRE_new = new Float_t[N_PS];
-  psClusterRawEnergy.reset(psRE_new,array_deleter<Float_t>);
+  psClusterRawEnergy.reset(psRE_new, array_deleter<Float_t>);
   _tree->GetBranch("psClusterRawEnergy")->SetAddress(psClusterRawEnergy.get());
   Float_t* psEta_new = new Float_t[N_PS];
-  psClusterEta.reset(psEta_new,array_deleter<Float_t>);
+  psClusterEta.reset(psEta_new, array_deleter<Float_t>);
   _tree->GetBranch("psClusterEta")->SetAddress(psClusterEta.get());
   Float_t* psPhi_new = new Float_t[N_PS];
-  psClusterPhi.reset(psPhi_new,array_deleter<Float_t>);
+  psClusterPhi.reset(psPhi_new, array_deleter<Float_t>);
   _tree->GetBranch("psClusterPhi")->SetAddress(psClusterPhi.get());
 }
 

--- a/RecoMuon/GlobalTrackingTools/interface/ChamberSegmentUtility.h
+++ b/RecoMuon/GlobalTrackingTools/interface/ChamberSegmentUtility.h
@@ -30,11 +30,8 @@
 #include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
-
 class ChamberSegmentUtility {
-
- public:
-
+public:
   ChamberSegmentUtility();
 
   void initCSU(const edm::Handle<DTRecSegment4DCollection>&, const edm::Handle<CSCSegmentCollection>&);
@@ -44,9 +41,8 @@ class ChamberSegmentUtility {
 
   // Get the 4D segments in a DT chamber
   std::vector<DTRecSegment4D> getDTSegmentsInChamber(DTChamberId);
-  
- private:
 
+private:
   edm::ESHandle<CSCGeometry> cscGeometry;
   edm::Handle<CSCSegmentCollection> CSCSegments;
   edm::ESHandle<DTGeometry> dtGeom;
@@ -56,5 +52,3 @@ class ChamberSegmentUtility {
 };
 
 #endif
-
-

--- a/RecoMuon/GlobalTrackingTools/interface/DirectTrackerNavigation.h
+++ b/RecoMuon/GlobalTrackingTools/interface/DirectTrackerNavigation.h
@@ -24,55 +24,46 @@ class FreeTrajectoryState;
 //              ---------------------
 
 class DirectTrackerNavigation {
+public:
+  /// constructor
+  DirectTrackerNavigation(const edm::ESHandle<GeometricSearchTracker>&, bool outOnly = true);
 
-  public:
+  /// find compatible layers for a given trajectory state
+  std::vector<const DetLayer*> compatibleLayers(const FreeTrajectoryState& fts,
+                                                PropagationDirection timeDirection) const;
 
-    /// constructor
-    DirectTrackerNavigation(const edm::ESHandle<GeometricSearchTracker>&, 
-                            bool outOnly = true);
+private:
+  void inOutTOB(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
 
+  void inOutTIB(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
 
+  void inOutPx(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
 
-    /// find compatible layers for a given trajectory state
-    std::vector<const DetLayer*> 
-      compatibleLayers(const FreeTrajectoryState& fts, 
-                       PropagationDirection timeDirection) const;
+  void inOutFTEC(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
 
-  private:
+  void inOutFTID(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
 
-    void inOutTOB(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
+  void inOutFPx(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
 
-    void inOutTIB(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
+  void inOutBTEC(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
 
-    void inOutPx(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
+  void inOutBTID(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
 
-    void inOutFTEC(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
+  void inOutBPx(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
 
-    void inOutFTID(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
+  bool checkCompatible(const FreeTrajectoryState&, const BarrelDetLayer*) const;
 
-    void inOutFPx(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
+  bool checkCompatible(const FreeTrajectoryState&, const ForwardDetLayer*) const;
 
-    void inOutBTEC(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
+  bool outward(const FreeTrajectoryState&) const;
 
-    void inOutBTID(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
+  float calculateEta(float r, float z) const;
 
-    void inOutBPx(const FreeTrajectoryState&, std::vector<const DetLayer*>&) const;
+private:
+  edm::ESHandle<GeometricSearchTracker> theGeometricSearchTracker;
 
-    bool checkCompatible(const FreeTrajectoryState&, const BarrelDetLayer*) const;
+  bool theOutLayerOnlyFlag;
 
-    bool checkCompatible(const FreeTrajectoryState&, const ForwardDetLayer*) const;
-
-    bool outward(const FreeTrajectoryState&) const;
-
-    float calculateEta(float r, float z) const;
-
-  private:
-
-    edm::ESHandle<GeometricSearchTracker> theGeometricSearchTracker;
-
-    bool theOutLayerOnlyFlag;
-
-    float theEpsilon;
-
+  float theEpsilon;
 };
 #endif

--- a/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
+++ b/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
@@ -41,33 +41,31 @@
 #include "RecoMuon/GlobalTrackingTools/interface/ThrParameters.h"
 #include "RecoMuon/GlobalTrackingTools/interface/ChamberSegmentUtility.h"
 
-namespace dyt_utils{
-  enum class etaRegion {eta0p8, eta1p2, eta2p0, eta2p2, eta2p4};
+namespace dyt_utils {
+  enum class etaRegion { eta0p8, eta1p2, eta2p0, eta2p2, eta2p4 };
 };
 
 class DynamicTruncation {
-  
- public:
-
+public:
   typedef TransientTrackingRecHit::ConstRecHitPointer ConstRecHitPointer;
   typedef TransientTrackingRecHit::ConstRecHitContainer ConstRecHitContainer;
 
-  DynamicTruncation(const edm::Event&, const MuonServiceProxy&);
+  DynamicTruncation(const edm::Event &, const MuonServiceProxy &);
 
   ~DynamicTruncation();
 
-  void setProd(const edm::Handle<DTRecSegment4DCollection>& DTSegProd, 
-	       const edm::Handle<CSCSegmentCollection>& CSCSegProd) {
+  void setProd(const edm::Handle<DTRecSegment4DCollection> &DTSegProd,
+               const edm::Handle<CSCSegmentCollection> &CSCSegProd) {
     getSegs->initCSU(DTSegProd, CSCSegProd);
   }
 
   void setSelector(int);
-  void setThr(const std::vector<int>&);
+  void setThr(const std::vector<int> &);
   void setUpdateState(bool);
   void setUseAPE(bool);
   /*---- DyT v2-----*/
-  void setThrsMap(const edm::ParameterSet&);
-  void setParThrsMode(bool dytParThrsMode) { useParametrizedThr = dytParThrsMode;}
+  void setThrsMap(const edm::ParameterSet &);
+  void setParThrsMode(bool dytParThrsMode) { useParametrizedThr = dytParThrsMode; }
   void setRecoP(double p) { p_reco = p; }
   void setRecoEta(double eta) {
     eta_reco = eta;
@@ -75,9 +73,9 @@ class DynamicTruncation {
   }
 
   // Return the vector with the tracker plus the selected muon hits
-  TransientTrackingRecHit::ConstRecHitContainer filter(const Trajectory&);
+  TransientTrackingRecHit::ConstRecHitContainer filter(const Trajectory &);
 
-  // Return the DYTInfo object 
+  // Return the DYTInfo object
   reco::DYTInfo getDYTInfo() {
     dytInfo.setNStUsed(nStationsUsed);
     dytInfo.setDYTEstimators(estimatorMap);
@@ -86,27 +84,42 @@ class DynamicTruncation {
     return dytInfo;
   }
 
- private:
-
-  void                 compatibleDets(TrajectoryStateOnSurface&, std::map<int, std::vector<DetId> >&);
-  void                 filteringAlgo();
-  void                 fillSegmentMaps(std::map<int, std::vector<DetId> >&, std::map<int, std::vector<DTRecSegment4D> >&, std::map<int, std::vector<CSCSegment> >&);
-  void                 preliminaryFit(std::map<int, std::vector<DetId> >, std::map<int, std::vector<DTRecSegment4D> >, std::map<int, std::vector<CSCSegment> >);
-  bool                 chooseLayers(int&, double const &, DTRecSegment4D const &, TrajectoryStateOnSurface const &, double const &, CSCSegment const &, TrajectoryStateOnSurface const &);
-  void                 fillDYTInfos(int const&, bool const&, int&, double const&, double const&, DTRecSegment4D const&, CSCSegment const&);
-  int                  stationfromDet(DetId const&);
-  void                 update(TrajectoryStateOnSurface&, ConstRecHitPointer);
-  void                 updateWithDThits(TrajectoryStateOnSurface&, DTRecSegment4D const &);
-  void                 updateWithCSChits(TrajectoryStateOnSurface&, CSCSegment const &);
-  void                 getThresholdFromDB(double&, DetId const&);
-  void                 correctThrByPAndEta(double&);
-  void                 getThresholdFromCFG(double&, DetId const&);
-  void                 testDTstation(TrajectoryStateOnSurface&, std::vector<DTRecSegment4D> const &, double&, DTRecSegment4D&, TrajectoryStateOnSurface&);
-  void                 testCSCstation(TrajectoryStateOnSurface&, std::vector<CSCSegment> const &, double&, CSCSegment&, TrajectoryStateOnSurface&);
-  void                 useSegment(DTRecSegment4D const &, TrajectoryStateOnSurface const &);
-  void                 useSegment(CSCSegment const &, TrajectoryStateOnSurface const &);
-  void                 sort(ConstRecHitContainer&);
-  void                 setEtaRegion();
+private:
+  void compatibleDets(TrajectoryStateOnSurface &, std::map<int, std::vector<DetId>> &);
+  void filteringAlgo();
+  void fillSegmentMaps(std::map<int, std::vector<DetId>> &,
+                       std::map<int, std::vector<DTRecSegment4D>> &,
+                       std::map<int, std::vector<CSCSegment>> &);
+  void preliminaryFit(std::map<int, std::vector<DetId>>,
+                      std::map<int, std::vector<DTRecSegment4D>>,
+                      std::map<int, std::vector<CSCSegment>>);
+  bool chooseLayers(int &,
+                    double const &,
+                    DTRecSegment4D const &,
+                    TrajectoryStateOnSurface const &,
+                    double const &,
+                    CSCSegment const &,
+                    TrajectoryStateOnSurface const &);
+  void fillDYTInfos(
+      int const &, bool const &, int &, double const &, double const &, DTRecSegment4D const &, CSCSegment const &);
+  int stationfromDet(DetId const &);
+  void update(TrajectoryStateOnSurface &, ConstRecHitPointer);
+  void updateWithDThits(TrajectoryStateOnSurface &, DTRecSegment4D const &);
+  void updateWithCSChits(TrajectoryStateOnSurface &, CSCSegment const &);
+  void getThresholdFromDB(double &, DetId const &);
+  void correctThrByPAndEta(double &);
+  void getThresholdFromCFG(double &, DetId const &);
+  void testDTstation(TrajectoryStateOnSurface &,
+                     std::vector<DTRecSegment4D> const &,
+                     double &,
+                     DTRecSegment4D &,
+                     TrajectoryStateOnSurface &);
+  void testCSCstation(
+      TrajectoryStateOnSurface &, std::vector<CSCSegment> const &, double &, CSCSegment &, TrajectoryStateOnSurface &);
+  void useSegment(DTRecSegment4D const &, TrajectoryStateOnSurface const &);
+  void useSegment(CSCSegment const &, TrajectoryStateOnSurface const &);
+  void sort(ConstRecHitContainer &);
+  void setEtaRegion();
 
   ConstRecHitContainer result, prelFitMeas;
   bool useAPE;
@@ -132,9 +145,9 @@ class DynamicTruncation {
   std::map<DTChamberId, GlobalError> dtApeMap;
   std::map<CSCDetId, GlobalError> cscApeMap;
   double muonPTest, muonETAest;
-  const DYTThrObject* dytThresholds;
-  ChamberSegmentUtility* getSegs;
-  ThrParameters* thrManager;
+  const DYTThrObject *dytThresholds;
+  ChamberSegmentUtility *getSegs;
+  ThrParameters *thrManager;
   bool useDBforThr;
   bool doUpdateOfKFStates;
   /* Variables for v2 */

--- a/RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h
+++ b/RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h
@@ -33,8 +33,12 @@
 #include "DataFormats/MuonReco/interface/DYTInfo.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
 
-namespace edm {class Event;}
-namespace reco {class TransientTrack;}
+namespace edm {
+  class Event;
+}
+namespace reco {
+  class TransientTrack;
+}
 
 class TrajectoryStateOnSurface;
 class TrackerTopology;
@@ -46,152 +50,144 @@ class Trajectory;
 class TrajectoryFitter;
 
 class GlobalMuonRefitter {
+public:
+  typedef TransientTrackingRecHit::RecHitContainer RecHitContainer;
+  typedef TransientTrackingRecHit::ConstRecHitContainer ConstRecHitContainer;
+  typedef TransientTrackingRecHit::RecHitPointer RecHitPointer;
+  typedef TransientTrackingRecHit::ConstRecHitPointer ConstRecHitPointer;
 
-  public:
+  typedef MuonTransientTrackingRecHit::MuonRecHitPointer MuonRecHitPointer;
+  typedef MuonTransientTrackingRecHit::ConstMuonRecHitPointer ConstMuonRecHitPointer;
+  typedef MuonTransientTrackingRecHit::MuonRecHitContainer MuonRecHitContainer;
+  typedef MuonTransientTrackingRecHit::ConstMuonRecHitContainer ConstMuonRecHitContainer;
 
-    typedef TransientTrackingRecHit::RecHitContainer RecHitContainer;
-    typedef TransientTrackingRecHit::ConstRecHitContainer ConstRecHitContainer;
-    typedef TransientTrackingRecHit::RecHitPointer RecHitPointer;
-    typedef TransientTrackingRecHit::ConstRecHitPointer ConstRecHitPointer;
+  typedef std::vector<Trajectory> TC;
+  typedef TC::const_iterator TI;
 
-    typedef MuonTransientTrackingRecHit::MuonRecHitPointer MuonRecHitPointer;
-    typedef MuonTransientTrackingRecHit::ConstMuonRecHitPointer ConstMuonRecHitPointer;
-    typedef MuonTransientTrackingRecHit::MuonRecHitContainer MuonRecHitContainer;
-    typedef MuonTransientTrackingRecHit::ConstMuonRecHitContainer ConstMuonRecHitContainer;
+  enum subDetector { PXB = 1, PXF = 2, TIB = 3, TID = 4, TOB = 5, TEC = 6 };
 
-    typedef std::vector<Trajectory> TC;
-    typedef TC::const_iterator TI;
+public:
+  /// constructor with Parameter Set and MuonServiceProxy
+  GlobalMuonRefitter(const edm::ParameterSet&, const MuonServiceProxy*, edm::ConsumesCollector&);
 
-    enum subDetector { PXB = 1, PXF = 2, TIB = 3, TID = 4, TOB = 5, TEC = 6 };
+  /// destructor
+  virtual ~GlobalMuonRefitter();
 
-  public:
+  /// pass the Event to the algo at each event
+  virtual void setEvent(const edm::Event&);
 
-    /// constructor with Parameter Set and MuonServiceProxy
-    GlobalMuonRefitter(const edm::ParameterSet&, const MuonServiceProxy*, edm::ConsumesCollector&);
-          
-    /// destructor
-    virtual ~GlobalMuonRefitter();
+  /// set the services needed by the TrackTransformer
+  void setServices(const edm::EventSetup&);
 
-    /// pass the Event to the algo at each event
-    virtual void setEvent(const edm::Event&);
+  /// build combined trajectory from sta Track and tracker RecHits
+  std::vector<Trajectory> refit(const reco::Track& globalTrack,
+                                const int theMuonHitsOption,
+                                const TrackerTopology* tTopo) const;
 
-    /// set the services needed by the TrackTransformer
-    void setServices(const edm::EventSetup&);
+  /// build combined trajectory from subset of sta Track and tracker RecHits
+  std::vector<Trajectory> refit(const reco::Track& globalTrack,
+                                const reco::TransientTrack track,
+                                const TransientTrackingRecHit::ConstRecHitContainer& allRecHitsTemp,
+                                const int theMuonHitsOption,
+                                const TrackerTopology* tTopo) const;
 
-    /// build combined trajectory from sta Track and tracker RecHits
-    std::vector<Trajectory> refit(const reco::Track& globalTrack, const int theMuonHitsOption,
-				  const TrackerTopology *tTopo) const;
+  /// refit the track with a new set of RecHits
+  std::vector<Trajectory> transform(const reco::Track& newTrack,
+                                    const reco::TransientTrack track,
+                                    const TransientTrackingRecHit::ConstRecHitContainer& recHitsForReFit) const;
 
-    /// build combined trajectory from subset of sta Track and tracker RecHits
-    std::vector<Trajectory> refit(const reco::Track& globalTrack,
-				  const reco::TransientTrack track,
-				  const TransientTrackingRecHit::ConstRecHitContainer& allRecHitsTemp,
-				  const int theMuonHitsOption,
-				  const TrackerTopology *tTopo) const;
+  // get rid of selected station RecHits
+  ConstRecHitContainer getRidOfSelectStationHits(const ConstRecHitContainer& hits, const TrackerTopology* tTopo) const;
 
-    /// refit the track with a new set of RecHits
-    std::vector<Trajectory> transform(const reco::Track& newTrack,
-                                      const reco::TransientTrack track,
-                                      const TransientTrackingRecHit::ConstRecHitContainer& recHitsForReFit) const;
+  // return DYT-related informations
+  const reco::DYTInfo* getDYTInfo() { return dytInfo; }
 
-    // get rid of selected station RecHits
-    ConstRecHitContainer getRidOfSelectStationHits(const ConstRecHitContainer& hits,
-						   const TrackerTopology *tTopo) const;
+protected:
+  enum RefitDirection { insideOut, outsideIn, undetermined };
 
-    // return DYT-related informations
-    const reco::DYTInfo* getDYTInfo() {return dytInfo;}
+  /// check muon RecHits, calculate chamber occupancy and select hits to be used in the final fit
+  void checkMuonHits(const reco::Track&, ConstRecHitContainer&, std::map<DetId, int>&) const;
 
-  protected:
+  /// get the RecHits in the tracker and the first muon chamber with hits
+  void getFirstHits(const reco::Track&, ConstRecHitContainer&, ConstRecHitContainer&) const;
 
-    enum RefitDirection{insideOut,outsideIn,undetermined};
+  /// select muon hits compatible with trajectory; check hits in chambers with showers
+  ConstRecHitContainer selectMuonHits(const Trajectory&, const std::map<DetId, int>&) const;
 
-    /// check muon RecHits, calculate chamber occupancy and select hits to be used in the final fit
-    void checkMuonHits(const reco::Track&, ConstRecHitContainer&, 
-                       std::map<DetId, int> &) const;
+  /// print all RecHits of a trajectory
+  void printHits(const ConstRecHitContainer&) const;
 
-    /// get the RecHits in the tracker and the first muon chamber with hits
-    void getFirstHits(const reco::Track&, ConstRecHitContainer&, 
-                       ConstRecHitContainer&) const;
+  RefitDirection checkRecHitsOrdering(const ConstRecHitContainer&) const;
 
-    /// select muon hits compatible with trajectory; check hits in chambers with showers
-    ConstRecHitContainer selectMuonHits(const Trajectory&, 
-                                        const std::map<DetId, int> &) const;
+  const MuonServiceProxy* service() const { return theService; }
 
-    /// print all RecHits of a trajectory
-    void printHits(const ConstRecHitContainer&) const;
+protected:
+  std::string theCategory;
+  bool theTkTrajsAvailableFlag;
+  float thePtCut;
 
-    RefitDirection checkRecHitsOrdering(const ConstRecHitContainer&) const;
+private:
+  int theMuonHitsOption;
+  float theProbCut;
+  int theHitThreshold;
+  float theDTChi2Cut;
+  float theCSCChi2Cut;
+  float theRPCChi2Cut;
+  float theGEMChi2Cut;
+  float theME0Chi2Cut;
+  bool theCosmicFlag;
 
-    const MuonServiceProxy* service() const { return theService; }
+  edm::InputTag theDTRecHitLabel;
+  edm::InputTag theCSCRecHitLabel;
+  edm::InputTag theGEMRecHitLabel;
+  edm::InputTag theME0RecHitLabel;
+  edm::Handle<DTRecHitCollection> theDTRecHits;
+  edm::Handle<CSCRecHit2DCollection> theCSCRecHits;
+  edm::Handle<GEMRecHitCollection> theGEMRecHits;
+  edm::Handle<ME0SegmentCollection> theME0RecHits;
+  edm::EDGetTokenT<DTRecHitCollection> theDTRecHitToken;
+  edm::EDGetTokenT<CSCRecHit2DCollection> theCSCRecHitToken;
+  edm::EDGetTokenT<GEMRecHitCollection> theGEMRecHitToken;
+  edm::EDGetTokenT<ME0SegmentCollection> theME0RecHitToken;
 
-  protected:
-    std::string theCategory;
-    bool theTkTrajsAvailableFlag;
-    float thePtCut;
+  int theSkipStation;
+  int theTrackerSkipSystem;
+  int theTrackerSkipSection;
 
-  private:
-  
-    int   theMuonHitsOption;
-    float theProbCut;
-    int   theHitThreshold;
-    float theDTChi2Cut;
-    float theCSCChi2Cut;
-    float theRPCChi2Cut;
-    float theGEMChi2Cut;
-    float theME0Chi2Cut;
-    bool  theCosmicFlag;
+  unsigned long long theCacheId_TRH;
 
-    edm::InputTag theDTRecHitLabel;
-    edm::InputTag theCSCRecHitLabel;
-    edm::InputTag theGEMRecHitLabel;
-    edm::InputTag theME0RecHitLabel;
-    edm::Handle<DTRecHitCollection>    theDTRecHits;
-    edm::Handle<CSCRecHit2DCollection> theCSCRecHits;
-    edm::Handle<GEMRecHitCollection> theGEMRecHits;
-    edm::Handle<ME0SegmentCollection> theME0RecHits;
-    edm::EDGetTokenT<DTRecHitCollection> theDTRecHitToken;
-    edm::EDGetTokenT<CSCRecHit2DCollection> theCSCRecHitToken;
-    edm::EDGetTokenT<GEMRecHitCollection> theGEMRecHitToken;
-    edm::EDGetTokenT<ME0SegmentCollection> theME0RecHitToken;
+  std::string thePropagatorName;
 
-    int	  theSkipStation;
-    int   theTrackerSkipSystem;
-    int   theTrackerSkipSection;
+  bool theRPCInTheFit;
 
-    unsigned long long theCacheId_TRH;
+  double theRescaleErrorFactor;
 
-    std::string thePropagatorName;
+  RefitDirection theRefitDirection;
 
-    bool theRPCInTheFit;
+  std::vector<int> theDYTthrs;
+  int theDYTselector;
+  bool theDYTupdator;
+  bool theDYTuseAPE;
+  bool theDYTParThrsMode;
+  edm::ParameterSet theDYTthrsParameters;
+  reco::DYTInfo* dytInfo;
 
-    double theRescaleErrorFactor;
+  std::string theFitterName;
+  std::unique_ptr<TrajectoryFitter> theFitter;
 
-    RefitDirection theRefitDirection;
+  std::string theTrackerRecHitBuilderName;
+  edm::ESHandle<TransientTrackingRecHitBuilder> theTrackerRecHitBuilder;
+  TkClonerImpl hitCloner;
 
-    std::vector<int> theDYTthrs;
-    int theDYTselector;
-    bool theDYTupdator;
-    bool theDYTuseAPE;
-    bool theDYTParThrsMode;
-    edm::ParameterSet theDYTthrsParameters;
-    reco::DYTInfo *dytInfo;
+  std::string theMuonRecHitBuilderName;
+  edm::ESHandle<TransientTrackingRecHitBuilder> theMuonRecHitBuilder;
 
-    std::string theFitterName;
-    std::unique_ptr<TrajectoryFitter> theFitter;
+  const MuonServiceProxy* theService;
+  const edm::Event* theEvent;
 
-    std::string theTrackerRecHitBuilderName;
-    edm::ESHandle<TransientTrackingRecHitBuilder> theTrackerRecHitBuilder;
-    TkClonerImpl hitCloner;
-
-    std::string theMuonRecHitBuilderName;
-    edm::ESHandle<TransientTrackingRecHitBuilder> theMuonRecHitBuilder;
-
-    const MuonServiceProxy* theService;
-    const edm::Event* theEvent;
-
-    edm::EDGetTokenT<CSCSegmentCollection> CSCSegmentsToken;
-    edm::EDGetTokenT<DTRecSegment4DCollection> all4DSegmentsToken;
-    edm::Handle<CSCSegmentCollection> CSCSegments;
-    edm::Handle<DTRecSegment4DCollection> all4DSegments;
+  edm::EDGetTokenT<CSCSegmentCollection> CSCSegmentsToken;
+  edm::EDGetTokenT<DTRecSegment4DCollection> all4DSegmentsToken;
+  edm::Handle<CSCSegmentCollection> CSCSegments;
+  edm::Handle<DTRecSegment4DCollection> all4DSegments;
 };
 #endif

--- a/RecoMuon/GlobalTrackingTools/interface/GlobalMuonTrackMatcher.h
+++ b/RecoMuon/GlobalTrackingTools/interface/GlobalMuonTrackMatcher.h
@@ -28,82 +28,76 @@ class TrajectoryStateOnSurface;
 class MuonServiceProxy;
 class Trajectory;
 
-namespace edm {class ParameterSet;}
+namespace edm {
+  class ParameterSet;
+}
 
 //              ---------------------
 //              -- Class Interface --
 //              ---------------------
 
 class GlobalMuonTrackMatcher {
+public:
+  typedef std::pair<const Trajectory*, reco::TrackRef> TrackCand;
 
-  public:
+  /// constructor
+  GlobalMuonTrackMatcher(const edm::ParameterSet&, const MuonServiceProxy*);
 
-    typedef std::pair<const Trajectory*,reco::TrackRef> TrackCand;
+  /// destructor
+  virtual ~GlobalMuonTrackMatcher();
 
-    /// constructor
-    GlobalMuonTrackMatcher(const edm::ParameterSet&,
-                           const MuonServiceProxy*);
+  /// check if two tracks are compatible (less than Chi2Cut, DeltaDCut, DeltaRCut)
+  bool matchTight(const TrackCand& sta, const TrackCand& track) const;
 
-    /// destructor
-    virtual ~GlobalMuonTrackMatcher();
-    
-    /// check if two tracks are compatible (less than Chi2Cut, DeltaDCut, DeltaRCut)
-    bool matchTight(const TrackCand& sta, 
-               const TrackCand& track) const;
-    
-    /// check if two tracks are compatible
-    /// matchOption: 0 = chi2, 1 = distance, 2 = deltaR
-    /// surfaceOption: 0 = outermost tracker surface, 1 = innermost muon system surface 
-    double match(const TrackCand& sta, 
-                 const TrackCand& track,
-                 int matchOption = 0,
-                 int surfaceOption = 1) const;
+  /// check if two tracks are compatible
+  /// matchOption: 0 = chi2, 1 = distance, 2 = deltaR
+  /// surfaceOption: 0 = outermost tracker surface, 1 = innermost muon system surface
+  double match(const TrackCand& sta, const TrackCand& track, int matchOption = 0, int surfaceOption = 1) const;
 
-    /// choose all tracks with a matching-chi2 less than Chi2Cut
-    std::vector<TrackCand> match(const TrackCand& sta, 
-                                 const std::vector<TrackCand>& tracks) const;
-  
-    /// choose the one tracker track which best matches a muon track
-    std::vector<TrackCand>::const_iterator matchOne(const TrackCand& sta,
-                                                    const std::vector<TrackCand>& tracks) const;
+  /// choose all tracks with a matching-chi2 less than Chi2Cut
+  std::vector<TrackCand> match(const TrackCand& sta, const std::vector<TrackCand>& tracks) const;
 
-    double match_R_IP(const TrackCand&, const TrackCand&) const;
-    double match_D(const TrajectoryStateOnSurface&, const TrajectoryStateOnSurface&) const;
-    double match_d(const TrajectoryStateOnSurface&, const TrajectoryStateOnSurface&) const;
-    double match_Rmom(const TrajectoryStateOnSurface&, const TrajectoryStateOnSurface&) const;
-    double match_Rpos(const TrajectoryStateOnSurface&, const TrajectoryStateOnSurface&) const;
-    double match_Chi2(const TrajectoryStateOnSurface&, const TrajectoryStateOnSurface&) const;
-    double match_dist(const TrajectoryStateOnSurface&, const TrajectoryStateOnSurface&) const;
+  /// choose the one tracker track which best matches a muon track
+  std::vector<TrackCand>::const_iterator matchOne(const TrackCand& sta, const std::vector<TrackCand>& tracks) const;
 
-    std::pair<TrajectoryStateOnSurface,TrajectoryStateOnSurface> convertToTSOSTk(const TrackCand&, const TrackCand&) const;
-    std::pair<TrajectoryStateOnSurface,TrajectoryStateOnSurface> convertToTSOSMuHit(const TrackCand&, const TrackCand&) const;
-    std::pair<TrajectoryStateOnSurface,TrajectoryStateOnSurface> convertToTSOSTkHit(const TrackCand&, const TrackCand&) const;
-    bool samePlane(const TrajectoryStateOnSurface&, const TrajectoryStateOnSurface&) const;
+  double match_R_IP(const TrackCand&, const TrackCand&) const;
+  double match_D(const TrajectoryStateOnSurface&, const TrajectoryStateOnSurface&) const;
+  double match_d(const TrajectoryStateOnSurface&, const TrajectoryStateOnSurface&) const;
+  double match_Rmom(const TrajectoryStateOnSurface&, const TrajectoryStateOnSurface&) const;
+  double match_Rpos(const TrajectoryStateOnSurface&, const TrajectoryStateOnSurface&) const;
+  double match_Chi2(const TrajectoryStateOnSurface&, const TrajectoryStateOnSurface&) const;
+  double match_dist(const TrajectoryStateOnSurface&, const TrajectoryStateOnSurface&) const;
 
-  private:
+  std::pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface> convertToTSOSTk(const TrackCand&,
+                                                                                const TrackCand&) const;
+  std::pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface> convertToTSOSMuHit(const TrackCand&,
+                                                                                   const TrackCand&) const;
+  std::pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface> convertToTSOSTkHit(const TrackCand&,
+                                                                                   const TrackCand&) const;
+  bool samePlane(const TrajectoryStateOnSurface&, const TrajectoryStateOnSurface&) const;
 
-    double theMinP;
-    double theMinPt;
-    double thePt_threshold1;
-    double thePt_threshold2;
-    double theEta_threshold;
-    double theChi2_1;
-    double theChi2_2;
-    double theChi2_3;
-    double theLocChi2;
-    double theDeltaD_1;
-    double theDeltaD_2;
-    double theDeltaD_3;
-    double theDeltaR_1;
-    double theDeltaR_2;
-    double theDeltaR_3;
-    double theQual_1;
-    double theQual_2;
-    double theQual_3;
+private:
+  double theMinP;
+  double theMinPt;
+  double thePt_threshold1;
+  double thePt_threshold2;
+  double theEta_threshold;
+  double theChi2_1;
+  double theChi2_2;
+  double theChi2_3;
+  double theLocChi2;
+  double theDeltaD_1;
+  double theDeltaD_2;
+  double theDeltaD_3;
+  double theDeltaR_1;
+  double theDeltaR_2;
+  double theDeltaR_3;
+  double theQual_1;
+  double theQual_2;
+  double theQual_3;
 
-    const MuonServiceProxy* theService;
-    std::string theOutPropagatorName;
-
+  const MuonServiceProxy* theService;
+  std::string theOutPropagatorName;
 };
 
 #endif

--- a/RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h
+++ b/RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h
@@ -35,71 +35,71 @@
 class MuonServiceProxy;
 class MeasurementTrackerEvent;
 
-namespace edm {class ParameterSet; class Event;}
+namespace edm {
+  class ParameterSet;
+  class Event;
+}  // namespace edm
 
 class MuonTrackingRegionBuilder : public TrackingRegionProducer {
-  
-  public:
- 
-    /// Constructor
-    explicit MuonTrackingRegionBuilder(const edm::ParameterSet& par, edm::ConsumesCollector& iC) { build(par, iC); }
-    explicit MuonTrackingRegionBuilder(const edm::ParameterSet& par, edm::ConsumesCollector&& iC) { build(par, iC); }
+public:
+  /// Constructor
+  explicit MuonTrackingRegionBuilder(const edm::ParameterSet& par, edm::ConsumesCollector& iC) { build(par, iC); }
+  explicit MuonTrackingRegionBuilder(const edm::ParameterSet& par, edm::ConsumesCollector&& iC) { build(par, iC); }
 
-    /// Destructor
-    ~MuonTrackingRegionBuilder() override {}
+  /// Destructor
+  ~MuonTrackingRegionBuilder() override {}
 
-    /// Create Region of Interest
-    std::vector<std::unique_ptr<TrackingRegion> > regions(const edm::Event&, const edm::EventSetup&) const override;
-  
-    /// Define tracking region
-    std::unique_ptr<RectangularEtaPhiTrackingRegion> region(const reco::TrackRef&) const;
-    std::unique_ptr<RectangularEtaPhiTrackingRegion> region(const reco::Track& t) const { return region(t,*theEvent); }
-    std::unique_ptr<RectangularEtaPhiTrackingRegion> region(const reco::Track&, const edm::Event&) const;
+  /// Create Region of Interest
+  std::vector<std::unique_ptr<TrackingRegion> > regions(const edm::Event&, const edm::EventSetup&) const override;
 
-    /// Pass the Event to the algo at each event
-    virtual void setEvent(const edm::Event&);
+  /// Define tracking region
+  std::unique_ptr<RectangularEtaPhiTrackingRegion> region(const reco::TrackRef&) const;
+  std::unique_ptr<RectangularEtaPhiTrackingRegion> region(const reco::Track& t) const { return region(t, *theEvent); }
+  std::unique_ptr<RectangularEtaPhiTrackingRegion> region(const reco::Track&, const edm::Event&) const;
 
-    /// Add Fill Descriptions
-    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-    static void fillDescriptionsHLT(edm::ParameterSetDescription& descriptions);
-    static void fillDescriptionsOffline(edm::ParameterSetDescription& descriptions);
+  /// Pass the Event to the algo at each event
+  virtual void setEvent(const edm::Event&);
 
-  private:
-    
-    void build(const edm::ParameterSet&, edm::ConsumesCollector&);
+  /// Add Fill Descriptions
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptionsHLT(edm::ParameterSetDescription& descriptions);
+  static void fillDescriptionsOffline(edm::ParameterSetDescription& descriptions);
 
-    const edm::Event* theEvent;
+private:
+  void build(const edm::ParameterSet&, edm::ConsumesCollector&);
 
-    bool useVertex;
-    bool useFixedZ;
-    bool useFixedPt;
-    bool useFixedPhi;
-    bool useFixedEta;
-    bool thePrecise;
+  const edm::Event* theEvent;
 
-    int theMaxRegions;
+  bool useVertex;
+  bool useFixedZ;
+  bool useFixedPt;
+  bool useFixedPhi;
+  bool useFixedEta;
+  bool thePrecise;
 
-    double theNsigmaEta;
-    double theNsigmaPhi;
-    double theNsigmaDz;
-  
-    double theEtaRegionPar1; 
-    double theEtaRegionPar2;
-    double thePhiRegionPar1;
-    double thePhiRegionPar2;
+  int theMaxRegions;
 
-    double thePtMin;
-    double thePhiMin;
-    double theEtaMin;
-    double theDeltaR;
-    double theHalfZ;
-    double theDeltaPhi;
-    double theDeltaEta;
+  double theNsigmaEta;
+  double theNsigmaPhi;
+  double theNsigmaDz;
 
-    RectangularEtaPhiTrackingRegion::UseMeasurementTracker theOnDemand;
-    edm::EDGetTokenT<MeasurementTrackerEvent> theMeasurementTrackerToken;
-    edm::EDGetTokenT<reco::BeamSpot> beamSpotToken;
-    edm::EDGetTokenT<reco::VertexCollection> vertexCollectionToken;
-    edm::EDGetTokenT<reco::TrackCollection> inputCollectionToken;
+  double theEtaRegionPar1;
+  double theEtaRegionPar2;
+  double thePhiRegionPar1;
+  double thePhiRegionPar2;
+
+  double thePtMin;
+  double thePhiMin;
+  double theEtaMin;
+  double theDeltaR;
+  double theHalfZ;
+  double theDeltaPhi;
+  double theDeltaEta;
+
+  RectangularEtaPhiTrackingRegion::UseMeasurementTracker theOnDemand;
+  edm::EDGetTokenT<MeasurementTrackerEvent> theMeasurementTrackerToken;
+  edm::EDGetTokenT<reco::BeamSpot> beamSpotToken;
+  edm::EDGetTokenT<reco::VertexCollection> vertexCollectionToken;
+  edm::EDGetTokenT<reco::TrackCollection> inputCollectionToken;
 };
 #endif

--- a/RecoMuon/GlobalTrackingTools/interface/StateSegmentMatcher.h
+++ b/RecoMuon/GlobalTrackingTools/interface/StateSegmentMatcher.h
@@ -19,10 +19,8 @@
 #include "DataFormats/GeometrySurface/interface/LocalError.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 
-
 class Tsos4D {
- public:
-
+public:
   Tsos4D(TrajectoryStateOnSurface const &);
 
   // Returns the 4d vector
@@ -31,16 +29,13 @@ class Tsos4D {
   // Returns the 4x4 covariance matrix
   AlgebraicSymMatrix44 errorMatrix() const;
 
- private:
+private:
   AlgebraicVector4 tsos_4d;
   AlgebraicSymMatrix44 tsosErr_44;
-
 };
 
-
-
 class Tsos2DPhi {
- public:
+public:
   // Constructor of the class
   Tsos2DPhi(TrajectoryStateOnSurface const &);
 
@@ -50,16 +45,13 @@ class Tsos2DPhi {
   // Returns the 2x2 covariance matrix
   AlgebraicSymMatrix22 errorMatrix() const;
 
- private:
+private:
   AlgebraicVector2 tsos_2d_phi;
   AlgebraicSymMatrix22 tsosErr_22_phi;
 };
 
-
-
 class Tsos2DZed {
- public:
-
+public:
   Tsos2DZed(TrajectoryStateOnSurface const &);
 
   // Returns the 2d vector
@@ -68,28 +60,23 @@ class Tsos2DZed {
   // Returns the 2x2 covariance matrix
   AlgebraicSymMatrix22 errorMatrix() const;
 
- private:
+private:
   AlgebraicVector2 tsos_2d_zed;
   AlgebraicSymMatrix22 tsosErr_22_zed;
 };
 
-
-
 class StateSegmentMatcher {
-
- public:
-  
+public:
   // Perform the matching between a track state and a CSC segment
   StateSegmentMatcher(TrajectoryStateOnSurface const &, CSCSegment const &, LocalError const &);
 
   // Perform the matching between a track state and a DT segment
-  StateSegmentMatcher(TrajectoryStateOnSurface const &, DTRecSegment4D  const &, LocalError const &);
+  StateSegmentMatcher(TrajectoryStateOnSurface const &, DTRecSegment4D const &, LocalError const &);
 
-  // Returns the estimator value 
+  // Returns the estimator value
   double value();
 
- private:
-  
+private:
   AlgebraicVector4 v1, v2;
   AlgebraicSymMatrix44 m1, m2, ape;
   AlgebraicVector2 v1_2d, v2_2d;
@@ -98,22 +85,19 @@ class StateSegmentMatcher {
   double estValue;
 
   void setAPE4d(LocalError const &apeLoc) {
-    ape[0][0] = 0; //sigma (dx/dz) 
-    ape[1][1] = 0; //sigma (dy/dz)
-    ape[2][2] = apeLoc.xx(); //sigma (x)  
-    ape[3][3] = apeLoc.yy(); //sigma (y)
-    ape[0][2] = 0; //cov(dx/dz,x) 
-    ape[1][3] = 0; //cov(dy/dz,y)
+    ape[0][0] = 0;            //sigma (dx/dz)
+    ape[1][1] = 0;            //sigma (dy/dz)
+    ape[2][2] = apeLoc.xx();  //sigma (x)
+    ape[3][3] = apeLoc.yy();  //sigma (y)
+    ape[0][2] = 0;            //cov(dx/dz,x)
+    ape[1][3] = 0;            //cov(dy/dz,y)
   };
 
   void setAPE2d(LocalError const &apeLoc) {
-    ape_2d[0][0] = 0; //sigma (dx/dz)
-    ape_2d[1][1] = apeLoc.xx(); //sigma (x)
-    ape_2d[0][1] = 0; //cov(dx/dz,x) 
+    ape_2d[0][0] = 0;            //sigma (dx/dz)
+    ape_2d[1][1] = apeLoc.xx();  //sigma (x)
+    ape_2d[0][1] = 0;            //cov(dx/dz,x)
   };
 };
 
-
 #endif
-
-

--- a/RecoMuon/GlobalTrackingTools/interface/ThrParameters.h
+++ b/RecoMuon/GlobalTrackingTools/interface/ThrParameters.h
@@ -19,18 +19,17 @@
 #include "CondFormats/AlignmentRecord/interface/CSCAlignmentErrorExtendedRcd.h"
 
 class ThrParameters {
-
- public:
+public:
   ThrParameters(const edm::EventSetup*);
   ~ThrParameters();
 
-  void setInitialThr(double thr0) {x0 = thr0;};
-  const bool isValidThdDB() {return isValidThdDB_;};
-  const std::map<DTChamberId, GlobalError>& GetDTApeMap() {return dtApeMap;};
-  const std::map<CSCDetId, GlobalError>& GetCSCApeMap() {return cscApeMap;};
-  const DYTThrObject* getInitialThresholds() {return dytThresholds;}
+  void setInitialThr(double thr0) { x0 = thr0; };
+  const bool isValidThdDB() { return isValidThdDB_; };
+  const std::map<DTChamberId, GlobalError>& GetDTApeMap() { return dtApeMap; };
+  const std::map<CSCDetId, GlobalError>& GetCSCApeMap() { return cscApeMap; };
+  const DYTThrObject* getInitialThresholds() { return dytThresholds; }
 
- private:
+private:
   double x0;
   bool isValidThdDB_;
   const DYTThrObject* dytThresholds;
@@ -38,4 +37,4 @@ class ThrParameters {
   std::map<CSCDetId, GlobalError> cscApeMap;
 };
 
-#endif // RecoMuon_GlobalTrackingTools_ThrParameters_h
+#endif  // RecoMuon_GlobalTrackingTools_ThrParameters_h

--- a/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
+++ b/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
@@ -24,41 +24,46 @@
 #include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
-GlobalTrackQualityProducer::GlobalTrackQualityProducer(const edm::ParameterSet& iConfig):
-  inputCollection_(iConfig.getParameter<edm::InputTag>("InputCollection")),inputLinksCollection_(iConfig.getParameter<edm::InputTag>("InputLinksCollection")),theService(nullptr),theGlbRefitter(nullptr),theGlbMatcher(nullptr)
-{
+GlobalTrackQualityProducer::GlobalTrackQualityProducer(const edm::ParameterSet& iConfig)
+    : inputCollection_(iConfig.getParameter<edm::InputTag>("InputCollection")),
+      inputLinksCollection_(iConfig.getParameter<edm::InputTag>("InputLinksCollection")),
+      theService(nullptr),
+      theGlbRefitter(nullptr),
+      theGlbMatcher(nullptr) {
   // service parameters
   edm::ParameterSet serviceParameters = iConfig.getParameter<edm::ParameterSet>("ServiceParameters");
   theService = new MuonServiceProxy(serviceParameters);
 
   // TrackRefitter parameters
-  edm::ConsumesCollector iC  = consumesCollector();
+  edm::ConsumesCollector iC = consumesCollector();
   edm::ParameterSet refitterParameters = iConfig.getParameter<edm::ParameterSet>("RefitterParameters");
   theGlbRefitter = new GlobalMuonRefitter(refitterParameters, theService, iC);
 
   edm::ParameterSet trackMatcherPSet = iConfig.getParameter<edm::ParameterSet>("GlobalMuonTrackMatcher");
-  theGlbMatcher = new GlobalMuonTrackMatcher(trackMatcherPSet,theService);
+  theGlbMatcher = new GlobalMuonTrackMatcher(trackMatcherPSet, theService);
 
   double maxChi2 = iConfig.getParameter<double>("MaxChi2");
   double nSigma = iConfig.getParameter<double>("nSigma");
-  theEstimator = new Chi2MeasurementEstimator(maxChi2,nSigma);
+  theEstimator = new Chi2MeasurementEstimator(maxChi2, nSigma);
 
-  glbMuonsToken=consumes<reco::TrackCollection>(inputCollection_);
-  linkCollectionToken=consumes<reco::MuonTrackLinksCollection>(inputLinksCollection_);
+  glbMuonsToken = consumes<reco::TrackCollection>(inputCollection_);
+  linkCollectionToken = consumes<reco::MuonTrackLinksCollection>(inputLinksCollection_);
 
-  produces<edm::ValueMap<reco::MuonQuality> >();
+  produces<edm::ValueMap<reco::MuonQuality>>();
 }
 
 GlobalTrackQualityProducer::~GlobalTrackQualityProducer() {
-  if (theService) delete theService;
-  if (theGlbRefitter) delete theGlbRefitter;
-  if (theGlbMatcher) delete theGlbMatcher;
-  if (theEstimator) delete theEstimator;
+  if (theService)
+    delete theService;
+  if (theGlbRefitter)
+    delete theGlbRefitter;
+  if (theGlbMatcher)
+    delete theGlbMatcher;
+  if (theEstimator)
+    delete theEstimator;
 }
 
-void
-GlobalTrackQualityProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void GlobalTrackQualityProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   const std::string theCategory = "Muon|RecoMuon|GlobalTrackQualityProducer";
 
   theService->update(iSetup);
@@ -69,82 +74,85 @@ GlobalTrackQualityProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 
   // Take the GLB muon container(s)
   edm::Handle<reco::TrackCollection> glbMuons;
-  iEvent.getByToken(glbMuonsToken,glbMuons);
+  iEvent.getByToken(glbMuonsToken, glbMuons);
 
-  edm::Handle<reco::MuonTrackLinksCollection>    linkCollectionHandle;
-  iEvent.getByToken(linkCollectionToken,linkCollectionHandle);
+  edm::Handle<reco::MuonTrackLinksCollection> linkCollectionHandle;
+  iEvent.getByToken(linkCollectionToken, linkCollectionHandle);
 
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHand;
   iSetup.get<TrackerTopologyRcd>().get(tTopoHand);
-  const TrackerTopology *tTopo=tTopoHand.product();
-
+  const TrackerTopology* tTopo = tTopoHand.product();
 
   // reserve some space
   std::vector<reco::MuonQuality> valuesQual;
   valuesQual.reserve(glbMuons->size());
 
   int trackIndex = 0;
-  for (reco::TrackCollection::const_iterator track = glbMuons->begin(); track!=glbMuons->end(); ++track , ++trackIndex) {
-    reco::TrackRef glbRef(glbMuons,trackIndex);
+  for (reco::TrackCollection::const_iterator track = glbMuons->begin(); track != glbMuons->end();
+       ++track, ++trackIndex) {
+    reco::TrackRef glbRef(glbMuons, trackIndex);
     reco::TrackRef staTrack = reco::TrackRef();
 
-    std::vector<Trajectory> refitted=theGlbRefitter->refit(*track,1,tTopo);
+    std::vector<Trajectory> refitted = theGlbRefitter->refit(*track, 1, tTopo);
 
-    LogTrace(theCategory)<<"GLBQual N refitted " << refitted.size();
+    LogTrace(theCategory) << "GLBQual N refitted " << refitted.size();
 
-    std::pair<double,double> thisKink;
+    std::pair<double, double> thisKink;
     double relative_muon_chi2 = 0.0;
     double relative_tracker_chi2 = 0.0;
     double glbTrackProbability = 0.0;
-    if(!refitted.empty()) {
-      thisKink = kink(refitted.front()) ;
-      std::pair<double,double> chi = newChi2(refitted.front());
-      relative_muon_chi2 = chi.second; //normalized inside to /sum(muHits.dimension)
-      relative_tracker_chi2 = chi.first; //normalized inside to /sum(tkHits.dimension)
+    if (!refitted.empty()) {
+      thisKink = kink(refitted.front());
+      std::pair<double, double> chi = newChi2(refitted.front());
+      relative_muon_chi2 = chi.second;    //normalized inside to /sum(muHits.dimension)
+      relative_tracker_chi2 = chi.first;  //normalized inside to /sum(tkHits.dimension)
       glbTrackProbability = trackProbability(refitted.front());
     }
 
-    LogTrace(theCategory)<<"GLBQual: Kink " << thisKink.first << " " << thisKink.second;
-    LogTrace(theCategory)<<"GLBQual: Rel Chi2 " << relative_tracker_chi2 << " " << relative_muon_chi2;
-    LogTrace(theCategory)<<"GLBQual: trackProbability " << glbTrackProbability;
+    LogTrace(theCategory) << "GLBQual: Kink " << thisKink.first << " " << thisKink.second;
+    LogTrace(theCategory) << "GLBQual: Rel Chi2 " << relative_tracker_chi2 << " " << relative_muon_chi2;
+    LogTrace(theCategory) << "GLBQual: trackProbability " << glbTrackProbability;
 
     // Fill the STA-TK match information
     float chi2, d, dist, Rpos;
     chi2 = d = dist = Rpos = -1.0;
     bool passTight = false;
     typedef MuonTrajectoryBuilder::TrackCand TrackCand;
-    if ( linkCollectionHandle.isValid() ) {
-      for ( reco::MuonTrackLinksCollection::const_iterator links = linkCollectionHandle->begin();
-	    links != linkCollectionHandle->end(); ++links )
-	{
-	  if ( links->trackerTrack().isNull() ||
-	       links->standAloneTrack().isNull() ||
-	       links->globalTrack().isNull() )
-	    {
-	      edm::LogWarning(theCategory) << "Global muon links to constituent tracks are invalid. There should be no such object. Muon is skipped.";
-	      continue;
-	    }
-	  if (links->globalTrack() == glbRef) {
-	    staTrack = !links->standAloneTrack().isNull() ? links->standAloneTrack() : reco::TrackRef();
-	    TrackCand staCand = TrackCand((Trajectory*)nullptr,links->standAloneTrack());
-	    TrackCand tkCand = TrackCand((Trajectory*)nullptr,links->trackerTrack());
-	    chi2 = theGlbMatcher->match(staCand,tkCand,0,0);
-	    d    = theGlbMatcher->match(staCand,tkCand,1,0);
-	    Rpos = theGlbMatcher->match(staCand,tkCand,2,0);
-	    dist = theGlbMatcher->match(staCand,tkCand,3,0);
-	    passTight = theGlbMatcher->matchTight(staCand,tkCand);
-	  }
-	}
+    if (linkCollectionHandle.isValid()) {
+      for (reco::MuonTrackLinksCollection::const_iterator links = linkCollectionHandle->begin();
+           links != linkCollectionHandle->end();
+           ++links) {
+        if (links->trackerTrack().isNull() || links->standAloneTrack().isNull() || links->globalTrack().isNull()) {
+          edm::LogWarning(theCategory) << "Global muon links to constituent tracks are invalid. There should be no "
+                                          "such object. Muon is skipped.";
+          continue;
+        }
+        if (links->globalTrack() == glbRef) {
+          staTrack = !links->standAloneTrack().isNull() ? links->standAloneTrack() : reco::TrackRef();
+          TrackCand staCand = TrackCand((Trajectory*)nullptr, links->standAloneTrack());
+          TrackCand tkCand = TrackCand((Trajectory*)nullptr, links->trackerTrack());
+          chi2 = theGlbMatcher->match(staCand, tkCand, 0, 0);
+          d = theGlbMatcher->match(staCand, tkCand, 1, 0);
+          Rpos = theGlbMatcher->match(staCand, tkCand, 2, 0);
+          dist = theGlbMatcher->match(staCand, tkCand, 3, 0);
+          passTight = theGlbMatcher->matchTight(staCand, tkCand);
+        }
+      }
     }
 
-    if(!staTrack.isNull()) LogTrace(theCategory)<<"GLBQual: Used UpdatedAtVtx : " <<  (iEvent.getProvenance(staTrack.id()).productInstanceName() == std::string("UpdatedAtVtx"));
+    if (!staTrack.isNull())
+      LogTrace(theCategory) << "GLBQual: Used UpdatedAtVtx : "
+                            << (iEvent.getProvenance(staTrack.id()).productInstanceName() ==
+                                std::string("UpdatedAtVtx"));
 
-    float maxFloat01 = std::numeric_limits<float>::max()*0.1; // a better solution would be to use float above .. m/be not
+    float maxFloat01 =
+        std::numeric_limits<float>::max() * 0.1;  // a better solution would be to use float above .. m/be not
     reco::MuonQuality muQual;
-    if(!staTrack.isNull()) muQual.updatedSta = iEvent.getProvenance(staTrack.id()).productInstanceName() == std::string("UpdatedAtVtx");
-    muQual.trkKink    = thisKink.first > maxFloat01 ? maxFloat01 : thisKink.first;
-    muQual.glbKink    = thisKink.second > maxFloat01 ? maxFloat01 : thisKink.second;
+    if (!staTrack.isNull())
+      muQual.updatedSta = iEvent.getProvenance(staTrack.id()).productInstanceName() == std::string("UpdatedAtVtx");
+    muQual.trkKink = thisKink.first > maxFloat01 ? maxFloat01 : thisKink.first;
+    muQual.glbKink = thisKink.second > maxFloat01 ? maxFloat01 : thisKink.second;
     muQual.trkRelChi2 = relative_tracker_chi2 > maxFloat01 ? maxFloat01 : relative_tracker_chi2;
     muQual.staRelChi2 = relative_muon_chi2 > maxFloat01 ? maxFloat01 : relative_muon_chi2;
     muQual.tightMatch = passTight;
@@ -172,8 +180,7 @@ GlobalTrackQualityProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   iEvent.put(std::move(outQual));
 }
 
-std::pair<double,double> GlobalTrackQualityProducer::kink(Trajectory& muon) const {
-
+std::pair<double, double> GlobalTrackQualityProducer::kink(Trajectory& muon) const {
   const std::string theCategory = "Muon|RecoMuon|GlobalTrackQualityProducer";
 
   using namespace std;
@@ -183,44 +190,43 @@ std::pair<double,double> GlobalTrackQualityProducer::kink(Trajectory& muon) cons
   double result = 0.0;
   double resultGlb = 0.0;
 
-
-  typedef TransientTrackingRecHit::ConstRecHitPointer 	ConstRecHitPointer;
+  typedef TransientTrackingRecHit::ConstRecHitPointer ConstRecHitPointer;
   typedef ConstRecHitPointer RecHit;
   typedef std::vector<TrajectoryMeasurement>::const_iterator TMI;
 
-
   vector<TrajectoryMeasurement> meas = muon.measurements();
 
-  for ( TMI m = meas.begin(); m != meas.end(); m++ ) {
+  for (TMI m = meas.begin(); m != meas.end(); m++) {
     TransientTrackingRecHit::ConstRecHitPointer hit = m->recHit();
 
     //not used    double estimate = 0.0;
 
     RecHit rhit = (*m).recHit();
     bool ok = false;
-    if ( rhit->isValid() ) {
-      if(DetId::Tracker == rhit->geographicalId().det()) ok = true;
+    if (rhit->isValid()) {
+      if (DetId::Tracker == rhit->geographicalId().det())
+        ok = true;
     }
 
     //if ( !ok ) continue;
 
     const TrajectoryStateOnSurface& tsos = (*m).predictedState();
 
-
-    if ( tsos.isValid() && rhit->isValid() && rhit->hit()->isValid()
-	 && !edm::isNotFinite(rhit->localPositionError().xx()) //this is paranoia induced by reported case
-	 && !edm::isNotFinite(rhit->localPositionError().xy()) //it's better to track down the origin of bad numbers
-	 && !edm::isNotFinite(rhit->localPositionError().yy())
-	 ) {
-
+    if (tsos.isValid() && rhit->isValid() && rhit->hit()->isValid() &&
+        !edm::isNotFinite(rhit->localPositionError().xx())     //this is paranoia induced by reported case
+        && !edm::isNotFinite(rhit->localPositionError().xy())  //it's better to track down the origin of bad numbers
+        && !edm::isNotFinite(rhit->localPositionError().yy())) {
       double phi1 = tsos.globalPosition().phi();
-      if ( phi1 < 0 ) phi1 = 2*M_PI + phi1;
+      if (phi1 < 0)
+        phi1 = 2 * M_PI + phi1;
 
       double phi2 = rhit->globalPosition().phi();
-      if ( phi2 < 0 ) phi2 = 2*M_PI + phi2;
+      if (phi2 < 0)
+        phi2 = 2 * M_PI + phi2;
 
       double diff = fabs(phi1 - phi2);
-      if ( diff > M_PI ) diff = 2*M_PI - diff;
+      if (diff > M_PI)
+        diff = 2 * M_PI - diff;
 
       GlobalPoint hitPos = rhit->globalPosition();
 
@@ -228,20 +234,18 @@ std::pair<double,double> GlobalTrackQualityProducer::kink(Trajectory& muon) cons
       //LogDebug(theCategory)<<"hitPos " << hitPos;
       double error = hitErr.phierr(hitPos);  // error squared
 
-      double s = ( error > 0.0 ) ? (diff*diff)/error : (diff*diff);
+      double s = (error > 0.0) ? (diff * diff) / error : (diff * diff);
 
-      if(ok) result += s;
+      if (ok)
+        result += s;
       resultGlb += s;
     }
-
   }
 
-
-  return std::pair<double,double>(result,resultGlb);
-
+  return std::pair<double, double>(result, resultGlb);
 }
 
-std::pair<double,double> GlobalTrackQualityProducer::newChi2(Trajectory& muon) const {
+std::pair<double, double> GlobalTrackQualityProducer::newChi2(Trajectory& muon) const {
   const std::string theCategory = "Muon|RecoMuon|GlobalTrackQualityProducer";
 
   using namespace std;
@@ -253,13 +257,13 @@ std::pair<double,double> GlobalTrackQualityProducer::newChi2(Trajectory& muon) c
   unsigned int muNdof = 0;
   unsigned int tkNdof = 0;
 
-  typedef TransientTrackingRecHit::ConstRecHitPointer 	ConstRecHitPointer;
+  typedef TransientTrackingRecHit::ConstRecHitPointer ConstRecHitPointer;
   typedef ConstRecHitPointer RecHit;
   typedef vector<TrajectoryMeasurement>::const_iterator TMI;
 
   vector<TrajectoryMeasurement> meas = muon.measurements();
 
-  for ( TMI m = meas.begin(); m != meas.end(); m++ ) {
+  for (TMI m = meas.begin(); m != meas.end(); m++) {
     TransientTrackingRecHit::ConstRecHitPointer hit = m->recHit();
     const TrajectoryStateOnSurface& uptsos = (*m).updatedState();
     // FIXME FIXME CLONE!!!
@@ -267,18 +271,18 @@ std::pair<double,double> GlobalTrackQualityProducer::newChi2(Trajectory& muon) c
     const auto& preciseHit = hit;
     double estimate = 0.0;
     if (preciseHit->isValid() && uptsos.isValid()) {
-      estimate = theEstimator->estimate(uptsos, *preciseHit ).second;
+      estimate = theEstimator->estimate(uptsos, *preciseHit).second;
     }
 
     //LogTrace(theCategory) << "estimate " << estimate << " TM.est " << m->estimate();
     //UNUSED:    double tkDiff = 0.0;
     //UNUSED:    double staDiff = 0.0;
-    if ( hit->isValid() &&  (hit->geographicalId().det()) == DetId::Tracker ) {
+    if (hit->isValid() && (hit->geographicalId().det()) == DetId::Tracker) {
       tkChi2 += estimate;
       //UNUSED:      tkDiff = estimate - m->estimate();
       tkNdof += hit->dimension();
     }
-    if ( hit->isValid() &&  (hit->geographicalId().det()) == DetId::Muon ) {
+    if (hit->isValid() && (hit->geographicalId().det()) == DetId::Muon) {
       muChi2 += estimate;
       //UNUSED      staDiff = estimate - m->estimate();
       muNdof += hit->dimension();
@@ -287,31 +291,31 @@ std::pair<double,double> GlobalTrackQualityProducer::newChi2(Trajectory& muon) c
 
   //For tkNdof < 6, should a large number or something else
   // be used instead of just tkChi2 directly?
-  if (tkNdof > 5 ) {tkChi2 /= (tkNdof-5.); }
+  if (tkNdof > 5) {
+    tkChi2 /= (tkNdof - 5.);
+  }
 
   //For muNdof < 6, should a large number or something else
   // be used instead of just muChi2 directly?
-  if (muNdof > 5 ) {muChi2 /= (muNdof-5.); }
+  if (muNdof > 5) {
+    muChi2 /= (muNdof - 5.);
+  }
 
-  return std::pair<double,double>(tkChi2,muChi2);
-
+  return std::pair<double, double>(tkChi2, muChi2);
 }
 
 //
 // calculate the tail probability (-ln(P)) of a fit
 //
-double
-GlobalTrackQualityProducer::trackProbability(Trajectory& track) const {
-
-  if ( track.ndof() > 0 && track.chiSquared() > 0 ) {
+double GlobalTrackQualityProducer::trackProbability(Trajectory& track) const {
+  if (track.ndof() > 0 && track.chiSquared() > 0) {
     return -LnChiSquaredProbability(track.chiSquared(), track.ndof());
   } else {
     return 0.0;
   }
-
 }
 
-void GlobalTrackQualityProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions){
+void GlobalTrackQualityProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   {
     edm::ParameterSetDescription psd1;
@@ -323,17 +327,17 @@ void GlobalTrackQualityProducer::fillDescriptions(edm::ConfigurationDescriptions
     psd1.setAllowAnything();
     desc.add<edm::ParameterSetDescription>("GlobalMuonTrackMatcher", psd1);
   }
-  desc.add<edm::InputTag>("InputCollection",edm::InputTag("globalMuons"));
-  desc.add<edm::InputTag>("InputLinksCollection",edm::InputTag("globalMuons"));
-  desc.add<std::string>("BaseLabel","GLB");
+  desc.add<edm::InputTag>("InputCollection", edm::InputTag("globalMuons"));
+  desc.add<edm::InputTag>("InputLinksCollection", edm::InputTag("globalMuons"));
+  desc.add<std::string>("BaseLabel", "GLB");
   {
     edm::ParameterSetDescription descGlbMuonRefitter;
     descGlbMuonRefitter.setAllowAnything();
-    descGlbMuonRefitter.add<edm::InputTag>("DTRecSegmentLabel" , edm::InputTag("dt1DRecHits"));
-    descGlbMuonRefitter.add<edm::InputTag>("CSCRecSegmentLabel" , edm::InputTag("csc2DRecHits"));
-    descGlbMuonRefitter.add<edm::InputTag>("GEMRecHitLabel" , edm::InputTag("gemRecHits"));
-    descGlbMuonRefitter.add<edm::InputTag>("ME0RecHitLabel" , edm::InputTag("me0Segments"));
-    descGlbMuonRefitter.add<edm::InputTag>("RPCRecSegmentLabel" , edm::InputTag("rpcRecHits"));
+    descGlbMuonRefitter.add<edm::InputTag>("DTRecSegmentLabel", edm::InputTag("dt1DRecHits"));
+    descGlbMuonRefitter.add<edm::InputTag>("CSCRecSegmentLabel", edm::InputTag("csc2DRecHits"));
+    descGlbMuonRefitter.add<edm::InputTag>("GEMRecHitLabel", edm::InputTag("gemRecHits"));
+    descGlbMuonRefitter.add<edm::InputTag>("ME0RecHitLabel", edm::InputTag("me0Segments"));
+    descGlbMuonRefitter.add<edm::InputTag>("RPCRecSegmentLabel", edm::InputTag("rpcRecHits"));
 
     descGlbMuonRefitter.add<std::string>("Fitter", "KFFitterForRefitInsideOut");
     descGlbMuonRefitter.add<std::string>("Smoother", "KFSmootherForRefitInsideOut");
@@ -345,25 +349,25 @@ void GlobalTrackQualityProducer::fillDescriptions(edm::ConfigurationDescriptions
     descGlbMuonRefitter.add<bool>("PropDirForCosmics", false);
     descGlbMuonRefitter.add<bool>("RefitRPCHits", true);
 
-    descGlbMuonRefitter.add<std::vector<int>>("DYTthrs",{10, 10});
-    descGlbMuonRefitter.add<int>("DYTselector",1);
+    descGlbMuonRefitter.add<std::vector<int>>("DYTthrs", {10, 10});
+    descGlbMuonRefitter.add<int>("DYTselector", 1);
     descGlbMuonRefitter.add<bool>("DYTupdator", false);
-    descGlbMuonRefitter.add<bool>("DYTuseAPE", false );
+    descGlbMuonRefitter.add<bool>("DYTuseAPE", false);
     descGlbMuonRefitter.add<bool>("DYTuseThrsParametrization", true);
     {
       edm::ParameterSetDescription descDYTthrs;
-      descDYTthrs.add<std::vector<double>>("eta0p8", {1,-0.919853, 0.990742});
-      descDYTthrs.add<std::vector<double>>("eta1p2", {1,-0.897354, 0.987738});
-      descDYTthrs.add<std::vector<double>>("eta2p0", {4,-0.986855, 0.998516});
-      descDYTthrs.add<std::vector<double>>("eta2p2", {1,-0.940342, 0.992955});
-      descDYTthrs.add<std::vector<double>>("eta2p4", {1,-0.947633, 0.993762});
+      descDYTthrs.add<std::vector<double>>("eta0p8", {1, -0.919853, 0.990742});
+      descDYTthrs.add<std::vector<double>>("eta1p2", {1, -0.897354, 0.987738});
+      descDYTthrs.add<std::vector<double>>("eta2p0", {4, -0.986855, 0.998516});
+      descDYTthrs.add<std::vector<double>>("eta2p2", {1, -0.940342, 0.992955});
+      descDYTthrs.add<std::vector<double>>("eta2p4", {1, -0.947633, 0.993762});
       descGlbMuonRefitter.add<edm::ParameterSetDescription>("DYTthrsParameters", descDYTthrs);
     }
 
     descGlbMuonRefitter.add<int>("SkipStation", -1);
-    descGlbMuonRefitter.add<int>("TrackerSkipSystem",-1);
+    descGlbMuonRefitter.add<int>("TrackerSkipSystem", -1);
     descGlbMuonRefitter.add<int>("TrackerSkipSection", -1);
-    descGlbMuonRefitter.add<bool>("RefitFlag", true );
+    descGlbMuonRefitter.add<bool>("RefitFlag", true);
 
     desc.add<edm::ParameterSetDescription>("RefitterParameters", descGlbMuonRefitter);
   }

--- a/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.h
+++ b/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.h
@@ -26,19 +26,20 @@
 class GlobalMuonRefitter;
 
 class GlobalTrackQualityProducer : public edm::stream::EDProducer<> {
- public:
+public:
   explicit GlobalTrackQualityProducer(const edm::ParameterSet& iConfig);
 
-  ~GlobalTrackQualityProducer() override; // {}
-  
+  ~GlobalTrackQualityProducer() override;  // {}
+
   // describe the parameters it allows or requires to be in its configuration
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
- private:
+
+private:
   void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual std::pair<double,double> kink(Trajectory& muon) const ;
-  virtual std::pair<double,double> newChi2(Trajectory& muon) const;
+  virtual std::pair<double, double> kink(Trajectory& muon) const;
+  virtual std::pair<double, double> newChi2(Trajectory& muon) const;
   virtual double trackProbability(Trajectory& track) const;
- 
+
   edm::InputTag inputCollection_;
   edm::InputTag inputLinksCollection_;
   edm::EDGetTokenT<reco::TrackCollection> glbMuonsToken;
@@ -46,7 +47,7 @@ class GlobalTrackQualityProducer : public edm::stream::EDProducer<> {
   MuonServiceProxy* theService;
   GlobalMuonRefitter* theGlbRefitter;
   GlobalMuonTrackMatcher* theGlbMatcher;
-  MeasurementEstimator *theEstimator;
+  MeasurementEstimator* theEstimator;
   //muon::SelectionType selectionType_;
 };
 #endif

--- a/RecoMuon/GlobalTrackingTools/plugins/Module.cc
+++ b/RecoMuon/GlobalTrackingTools/plugins/Module.cc
@@ -4,7 +4,6 @@
 
 #include "RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.h"
 
-
 DEFINE_FWK_MODULE(GlobalTrackQualityProducer);
 
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducerFactory.h"
@@ -15,5 +14,3 @@ DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, MuonTrackingRegionBuilder, "Muo
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionEDProducerT.h"
 using MuonTrackingRegionEDProducer = TrackingRegionEDProducerT<MuonTrackingRegionBuilder>;
 DEFINE_FWK_MODULE(MuonTrackingRegionEDProducer);
-
-

--- a/RecoMuon/GlobalTrackingTools/src/ChamberSegmentUtility.cc
+++ b/RecoMuon/GlobalTrackingTools/src/ChamberSegmentUtility.cc
@@ -33,38 +33,28 @@ using namespace edm;
 using namespace std;
 using namespace reco;
 
-ChamberSegmentUtility::ChamberSegmentUtility()
-{}
+ChamberSegmentUtility::ChamberSegmentUtility() {}
 
 void ChamberSegmentUtility::initCSU(const edm::Handle<DTRecSegment4DCollection>& DTSegProd,
-				    const edm::Handle<CSCSegmentCollection>& CSCSegProd) {
+                                    const edm::Handle<CSCSegmentCollection>& CSCSegProd) {
   all4DSegments = DTSegProd;
-  CSCSegments   = CSCSegProd;
+  CSCSegments = CSCSegProd;
 }
 
-
-vector<CSCSegment> ChamberSegmentUtility::getCSCSegmentsInChamber(CSCDetId sel)
-{
+vector<CSCSegment> ChamberSegmentUtility::getCSCSegmentsInChamber(CSCDetId sel) {
   cscseg.clear();
-  CSCSegmentCollection::range  range = CSCSegments->get(sel);
-  for (CSCSegmentCollection::const_iterator segment = range.first;
-       segment!=range.second; ++segment) {
+  CSCSegmentCollection::range range = CSCSegments->get(sel);
+  for (CSCSegmentCollection::const_iterator segment = range.first; segment != range.second; ++segment) {
     cscseg.push_back(*segment);
   }
   return cscseg;
 }
 
-
-vector<DTRecSegment4D> ChamberSegmentUtility::getDTSegmentsInChamber(DTChamberId sel)
-{
+vector<DTRecSegment4D> ChamberSegmentUtility::getDTSegmentsInChamber(DTChamberId sel) {
   dtseg.clear();
-  DTRecSegment4DCollection::range  range = all4DSegments->get(sel);
-  for (DTRecSegment4DCollection::const_iterator segment = range.first;
-       segment!=range.second; ++segment){
+  DTRecSegment4DCollection::range range = all4DSegments->get(sel);
+  for (DTRecSegment4DCollection::const_iterator segment = range.first; segment != range.second; ++segment) {
     dtseg.push_back(*segment);
   }
   return dtseg;
 }
-
-
-

--- a/RecoMuon/GlobalTrackingTools/src/DirectTrackerNavigation.cc
+++ b/RecoMuon/GlobalTrackingTools/src/DirectTrackerNavigation.cc
@@ -29,20 +29,14 @@ using namespace std;
 //
 // constructor
 //
-DirectTrackerNavigation::DirectTrackerNavigation(const edm::ESHandle<GeometricSearchTracker>& tkLayout, 
-                                                 bool outOnly) : 
- theGeometricSearchTracker(tkLayout), theOutLayerOnlyFlag(outOnly), theEpsilon(-0.01) {
-
-}
-
+DirectTrackerNavigation::DirectTrackerNavigation(const edm::ESHandle<GeometricSearchTracker>& tkLayout, bool outOnly)
+    : theGeometricSearchTracker(tkLayout), theOutLayerOnlyFlag(outOnly), theEpsilon(-0.01) {}
 
 //
-// return compatible layers for a given trajectory state 
+// return compatible layers for a given trajectory state
 //
-vector<const DetLayer*> 
-DirectTrackerNavigation::compatibleLayers(const FreeTrajectoryState& fts,
-                                          PropagationDirection dir) const {
-
+vector<const DetLayer*> DirectTrackerNavigation::compatibleLayers(const FreeTrajectoryState& fts,
+                                                                  PropagationDirection dir) const {
   bool inOut = outward(fts);
   double eta0 = fts.position().eta();
 
@@ -50,167 +44,151 @@ DirectTrackerNavigation::compatibleLayers(const FreeTrajectoryState& fts,
 
   // check eta of DetLayers for compatibility
 
-  if (inOut) { 
+  if (inOut) {
+    if (!theOutLayerOnlyFlag) {
+      inOutPx(fts, output);
 
-      if ( !theOutLayerOnlyFlag ) {
-         inOutPx(fts,output);
+      if (eta0 > 1.55)
+        inOutFPx(fts, output);
+      else if (eta0 < -1.55)
+        inOutBPx(fts, output);
 
-         if ( eta0 > 1.55) inOutFPx(fts,output);
-         else if ( eta0 < -1.55 ) inOutBPx(fts,output);
+      if (fabs(eta0) < 1.67)
+        inOutTIB(fts, output);
 
-         if ( fabs(eta0) < 1.67 ) inOutTIB(fts,output); 
+      if (eta0 > 1.17)
+        inOutFTID(fts, output);
+      else if (eta0 < -1.17)
+        inOutBTID(fts, output);
+    }
 
-         if ( eta0 > 1.17 ) inOutFTID(fts,output);
-         else if ( eta0 < -1.17 ) inOutBTID(fts,output);
-      }
+    if (fabs(eta0) < 1.35)
+      inOutTOB(fts, output);
 
-      if ( fabs(eta0) < 1.35 ) inOutTOB(fts,output);
+    if (eta0 > 0.97)
+      inOutFTEC(fts, output);
+    else if (eta0 < -0.97)
+      inOutBTEC(fts, output);
 
-      if ( eta0 > 0.97 ) inOutFTEC(fts,output);
-      else if ( eta0 < -0.97 )  inOutBTEC(fts,output);
+  } else {
+    LogTrace("Muon|RecoMuon|DirectionTrackerNavigation") << "No implementation for inward state at this moment. ";
+  }
 
-   } else {
-      LogTrace("Muon|RecoMuon|DirectionTrackerNavigation")<<"No implementation for inward state at this moment. ";
-   }
-
-  if ( dir == oppositeToMomentum ) std::reverse(output.begin(),output.end());
+  if (dir == oppositeToMomentum)
+    std::reverse(output.begin(), output.end());
 
   return output;
-
 }
-
 
 //
 //
 //
 void DirectTrackerNavigation::inOutPx(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
-
   for (const auto i : theGeometricSearchTracker->pixelBarrelLayers()) {
-    if ( checkCompatible(fts,i) ) output.push_back(i);
+    if (checkCompatible(fts, i))
+      output.push_back(i);
   }
-
 }
-
 
 //
 //
 //
 void DirectTrackerNavigation::inOutTIB(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
-
-  for(const auto i : theGeometricSearchTracker->tibLayers() ) {
-    if ( checkCompatible(fts,i) ) output.push_back(i);
+  for (const auto i : theGeometricSearchTracker->tibLayers()) {
+    if (checkCompatible(fts, i))
+      output.push_back(i);
   }
-
 }
-
 
 //
 //
 //
 void DirectTrackerNavigation::inOutTOB(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
-
-  for( const auto i : theGeometricSearchTracker->tobLayers()) {
-    if ( checkCompatible(fts,i) ) output.push_back(i);
+  for (const auto i : theGeometricSearchTracker->tobLayers()) {
+    if (checkCompatible(fts, i))
+      output.push_back(i);
   }
-
 }
-
 
 //
 //
 //
 void DirectTrackerNavigation::inOutFPx(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
-
-  for(const auto i : theGeometricSearchTracker->posPixelForwardLayers()) {
-    if ( checkCompatible(fts,i) ) output.push_back(i);
+  for (const auto i : theGeometricSearchTracker->posPixelForwardLayers()) {
+    if (checkCompatible(fts, i))
+      output.push_back(i);
   }
-
 }
-
 
 //
 //
 //
 void DirectTrackerNavigation::inOutFTID(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
-
-  for(const auto i: theGeometricSearchTracker->posTidLayers()) {
-    if ( checkCompatible(fts,i) ) output.push_back(i);
+  for (const auto i : theGeometricSearchTracker->posTidLayers()) {
+    if (checkCompatible(fts, i))
+      output.push_back(i);
   }
-
 }
-
 
 //
 //
 //
 void DirectTrackerNavigation::inOutFTEC(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
-
-  for(const auto i : theGeometricSearchTracker->posTecLayers()) {
-    if ( checkCompatible(fts,i) ) output.push_back(i);
+  for (const auto i : theGeometricSearchTracker->posTecLayers()) {
+    if (checkCompatible(fts, i))
+      output.push_back(i);
   }
-
 }
-
 
 //
 //
 //
 void DirectTrackerNavigation::inOutBPx(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
-
-  for(const auto i: theGeometricSearchTracker->negPixelForwardLayers()) {
-    if ( checkCompatible(fts,i) ) output.push_back(i);
+  for (const auto i : theGeometricSearchTracker->negPixelForwardLayers()) {
+    if (checkCompatible(fts, i))
+      output.push_back(i);
   }
-
 }
-
 
 //
 //
 //
 void DirectTrackerNavigation::inOutBTID(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
-
-  for(const auto i: theGeometricSearchTracker->negTidLayers()) {
-      if ( checkCompatible(fts,i) ) output.push_back(i);
+  for (const auto i : theGeometricSearchTracker->negTidLayers()) {
+    if (checkCompatible(fts, i))
+      output.push_back(i);
   }
-
 }
-
 
 //
 //
 //
 void DirectTrackerNavigation::inOutBTEC(const FreeTrajectoryState& fts, vector<const DetLayer*>& output) const {
-
-  for(const auto i: theGeometricSearchTracker->negTecLayers()) {
-    if ( checkCompatible(fts,i) ) output.push_back(i);
+  for (const auto i : theGeometricSearchTracker->negTecLayers()) {
+    if (checkCompatible(fts, i))
+      output.push_back(i);
   }
-
 }
 
-
 //
 //
 //
-bool DirectTrackerNavigation::checkCompatible(const FreeTrajectoryState& fts,const BarrelDetLayer* dl) const {
-
+bool DirectTrackerNavigation::checkCompatible(const FreeTrajectoryState& fts, const BarrelDetLayer* dl) const {
   float eta0 = fts.position().eta();
 
   const BoundCylinder& bc = dl->specificSurface();
   float radius = bc.radius();
-  float length = bc.bounds().length()/2.;
+  float length = bc.bounds().length() / 2.;
 
   float eta = calculateEta(radius, length);
 
-  return ( fabs(eta0) <= (fabs(eta) + theEpsilon) );
-
+  return (fabs(eta0) <= (fabs(eta) + theEpsilon));
 }
 
-
 //
 //
 //
-bool DirectTrackerNavigation::checkCompatible(const FreeTrajectoryState& fts,const ForwardDetLayer* dl) const {
-
+bool DirectTrackerNavigation::checkCompatible(const FreeTrajectoryState& fts, const ForwardDetLayer* dl) const {
   float eta0 = fts.position().eta();
 
   const BoundDisk& bd = dl->specificSurface();
@@ -221,29 +199,25 @@ bool DirectTrackerNavigation::checkCompatible(const FreeTrajectoryState& fts,con
 
   float etaOut = calculateEta(outRadius, z);
   float etaIn = calculateEta(inRadius, z);
- 
-  if ( eta0 > 0 ) return ( eta0 > ( etaOut - theEpsilon) && eta0 < (etaIn + theEpsilon) );
-  else return ( eta0 < (etaOut + theEpsilon ) && eta0 > ( etaIn - theEpsilon ) );
 
+  if (eta0 > 0)
+    return (eta0 > (etaOut - theEpsilon) && eta0 < (etaIn + theEpsilon));
+  else
+    return (eta0 < (etaOut + theEpsilon) && eta0 > (etaIn - theEpsilon));
 }
-
 
 //
 //
 //
 bool DirectTrackerNavigation::outward(const FreeTrajectoryState& fts) const {
- 
   return (fts.position().basicVector().dot(fts.momentum().basicVector()) > 0);
-
 }
-
 
 //
 // calculate pseudorapidity from r and z
 //
 float DirectTrackerNavigation::calculateEta(float r, float z) const {
-
-  if ( z > 0 ) return -log((tan(atan(r/z)/2.)));
-  return log(-(tan(atan(r/z)/2.)));
-
+  if (z > 0)
+    return -log((tan(atan(r / z) / 2.)));
+  return log(-(tan(atan(r / z) / 2.)));
 }

--- a/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
+++ b/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
@@ -34,23 +34,21 @@ using namespace edm;
 using namespace std;
 using namespace reco;
 
-namespace dyt_utils{
-  static const std::map<etaRegion, std::string> etaRegionStr { {etaRegion::eta0p8, "eta0p8"},
-                                                  {etaRegion::eta1p2, "eta1p2"},
-                                                  {etaRegion::eta2p0, "eta2p0"},
-                                                  {etaRegion::eta2p2, "eta2p2"},
-                                                  {etaRegion::eta2p4, "eta2p4"}};
+namespace dyt_utils {
+  static const std::map<etaRegion, std::string> etaRegionStr{{etaRegion::eta0p8, "eta0p8"},
+                                                             {etaRegion::eta1p2, "eta1p2"},
+                                                             {etaRegion::eta2p0, "eta2p0"},
+                                                             {etaRegion::eta2p2, "eta2p2"},
+                                                             {etaRegion::eta2p4, "eta2p4"}};
 };
 
-
-
-DynamicTruncation::DynamicTruncation(const edm::Event& event, const MuonServiceProxy& theService) {
+DynamicTruncation::DynamicTruncation(const edm::Event &event, const MuonServiceProxy &theService) {
   propagator = theService.propagator("SmartPropagatorAny");
   propagatorPF = theService.propagator("SmartPropagatorAny");
   propagatorCompatibleDet = theService.propagator("SmartPropagatorAny");
   theG = theService.trackingGeometry();
-  theService.eventSetup().get<TransientRecHitRecord>().get("MuonRecHitBuilder",theMuonRecHitBuilder);
-  theService.eventSetup().get<TrackingComponentsRecord>().get("KFUpdator",updatorHandle);
+  theService.eventSetup().get<TransientRecHitRecord>().get("MuonRecHitBuilder", theMuonRecHitBuilder);
+  theService.eventSetup().get<TrackingComponentsRecord>().get("KFUpdator", updatorHandle);
   theService.eventSetup().get<MuonGeometryRecord>().get(cscGeom);
   theService.eventSetup().get<MuonRecoGeometryRecord>().get(navMuon);
   theService.eventSetup().get<IdealMagneticFieldRecord>().get(magfield);
@@ -58,7 +56,8 @@ DynamicTruncation::DynamicTruncation(const edm::Event& event, const MuonServiceP
   getSegs = new ChamberSegmentUtility();
   thrManager = new ThrParameters(&theService.eventSetup());
   useDBforThr = thrManager->isValidThdDB();
-  if (useDBforThr) dytThresholds = thrManager->getInitialThresholds();
+  if (useDBforThr)
+    dytThresholds = thrManager->getInitialThresholds();
 
   doUpdateOfKFStates = true;
   useParametrizedThr = false;
@@ -70,15 +69,16 @@ DynamicTruncation::~DynamicTruncation() {
   delete getSegs;
 }
 
-void DynamicTruncation::update(TrajectoryStateOnSurface& tsos, ConstRecHitPointer rechit) {
+void DynamicTruncation::update(TrajectoryStateOnSurface &tsos, ConstRecHitPointer rechit) {
   TrajectoryStateOnSurface temp = updatorHandle->update(tsos, *rechit);
-  if (temp.isValid()) tsos = updatorHandle->update(tsos, *rechit);
+  if (temp.isValid())
+    tsos = updatorHandle->update(tsos, *rechit);
 }
 
-void DynamicTruncation::updateWithDThits(TrajectoryStateOnSurface& tsos, DTRecSegment4D const &bestDTSeg) {
+void DynamicTruncation::updateWithDThits(TrajectoryStateOnSurface &tsos, DTRecSegment4D const &bestDTSeg) {
   ConstRecHitContainer tmprecHits;
-  vector<const TrackingRecHit*> DTrh = bestDTSeg.recHits();
-  for (vector<const TrackingRecHit*>::iterator it = DTrh.begin(); it != DTrh.end(); it++) {
+  vector<const TrackingRecHit *> DTrh = bestDTSeg.recHits();
+  for (vector<const TrackingRecHit *>::iterator it = DTrh.begin(); it != DTrh.end(); it++) {
     tmprecHits.push_back(theMuonRecHitBuilder->build(*it));
   }
   sort(tmprecHits);
@@ -86,13 +86,14 @@ void DynamicTruncation::updateWithDThits(TrajectoryStateOnSurface& tsos, DTRecSe
     DTLayerId layid((*it)->det()->geographicalId());
     TrajectoryStateOnSurface temp = propagator->propagate(tsos, theG->idToDet(layid)->surface());
     if (temp.isValid()) {
-        TrajectoryStateOnSurface tempTsos = updatorHandle->update(temp, **it);
-        if (tempTsos.isValid() ) tsos = tempTsos;
+      TrajectoryStateOnSurface tempTsos = updatorHandle->update(temp, **it);
+      if (tempTsos.isValid())
+        tsos = tempTsos;
     }
   }
 }
 
-void DynamicTruncation::updateWithCSChits(TrajectoryStateOnSurface& tsos, CSCSegment const &bestCSCSeg) {
+void DynamicTruncation::updateWithCSChits(TrajectoryStateOnSurface &tsos, CSCSegment const &bestCSCSeg) {
   ConstRecHitContainer tmprecHits;
   vector<CSCRecHit2D> CSCrh = bestCSCSeg.specificRecHits();
   for (vector<CSCRecHit2D>::iterator it = CSCrh.begin(); it != CSCrh.end(); ++it) {
@@ -100,59 +101,56 @@ void DynamicTruncation::updateWithCSChits(TrajectoryStateOnSurface& tsos, CSCSeg
   }
   sort(tmprecHits);
   for (ConstRecHitContainer::const_iterator it = tmprecHits.begin(); it != tmprecHits.end(); ++it) {
-    const CSCLayer* cscLayer = cscGeom->layer((*it)->det()->geographicalId());
+    const CSCLayer *cscLayer = cscGeom->layer((*it)->det()->geographicalId());
     TrajectoryStateOnSurface temp = propagator->propagate(tsos, cscLayer->surface());
     if (temp.isValid()) {
       TrajectoryStateOnSurface tempTsos = updatorHandle->update(temp, **it);
-      if (tempTsos.isValid() ) tsos = tempTsos;
+      if (tempTsos.isValid())
+        tsos = tempTsos;
     }
   }
 }
-
 
 /////////////////////////////////
 ///// Configuration methods /////
 /////////////////////////////////
 void DynamicTruncation::setSelector(int selector) {
-  if (selector < 0 || selector > 2) throw cms::Exception("NotAvailable") << "DYT selector: wrong option!" << endl;
+  if (selector < 0 || selector > 2)
+    throw cms::Exception("NotAvailable") << "DYT selector: wrong option!" << endl;
   //if (selector == 0) cout << "[DYT disabled]\n";
   //if (selector == 1) cout << "[use all compatible stations]\n";
   //if (selector == 2) cout << "[stop at second consecutive incompatible station]\n";
   DYTselector = selector;
-
 }
 
-void DynamicTruncation::setUseAPE(bool useAPE_) {
-  useAPE = useAPE_;
-}
+void DynamicTruncation::setUseAPE(bool useAPE_) { useAPE = useAPE_; }
 
-void DynamicTruncation::setUpdateState(bool upState) {
-  doUpdateOfKFStates = upState;
-}
+void DynamicTruncation::setUpdateState(bool upState) { doUpdateOfKFStates = upState; }
 
-void DynamicTruncation::setThr(const vector<int>& thr) {
+void DynamicTruncation::setThr(const vector<int> &thr) {
   if (thr.size() == 2) {
     for (unsigned int i = 0; i < thr.size(); i++)
-      if (thr[i] >= 0) Thrs.push_back(thr[i]);
-      else Thrs.push_back(MAX_THR);
+      if (thr[i] >= 0)
+        Thrs.push_back(thr[i]);
+      else
+        Thrs.push_back(MAX_THR);
     return;
   }
-  throw cms::Exception("NotAvailable") << "WARNING: wrong size for the threshold vector!\nExpected size: 2\n   Found size: " << thr.size();
+  throw cms::Exception("NotAvailable")
+      << "WARNING: wrong size for the threshold vector!\nExpected size: 2\n   Found size: " << thr.size();
 }
 
-void DynamicTruncation::setThrsMap(const edm::ParameterSet& par) {
-  for (auto const& region : dyt_utils::etaRegionStr ){
-      parameters[region.first] = par.getParameter< std::vector<double> >(region.second);
+void DynamicTruncation::setThrsMap(const edm::ParameterSet &par) {
+  for (auto const &region : dyt_utils::etaRegionStr) {
+    parameters[region.first] = par.getParameter<std::vector<double> >(region.second);
   }
 }
 /////////////////////////////////
 /////////////////////////////////
 /////////////////////////////////
 
-
-
 //===> filter
-TransientTrackingRecHit::ConstRecHitContainer DynamicTruncation::filter(const Trajectory& traj) {
+TransientTrackingRecHit::ConstRecHitContainer DynamicTruncation::filter(const Trajectory &traj) {
   result.clear();
   prelFitMeas.clear();
 
@@ -163,14 +161,18 @@ TransientTrackingRecHit::ConstRecHitContainer DynamicTruncation::filter(const Tr
   // Get Last tracker TSOS (updated)
   vector<TrajectoryMeasurement> muonMeasurements = traj.measurements();
   TrajectoryMeasurement lastTKm = muonMeasurements.front();
-  for (vector<TrajectoryMeasurement>::const_iterator imT = muonMeasurements.begin(); imT != muonMeasurements.end(); imT++ ) {
-    if ( !(*imT).recHit()->isValid() ) continue;
-    const TransientTrackingRecHit* hit = &(*(*imT).recHit());
+  for (vector<TrajectoryMeasurement>::const_iterator imT = muonMeasurements.begin(); imT != muonMeasurements.end();
+       imT++) {
+    if (!(*imT).recHit()->isValid())
+      continue;
+    const TransientTrackingRecHit *hit = &(*(*imT).recHit());
     if (hit->geographicalId().det() == DetId::Tracker) {
       result.push_back((*imT).recHit());
-      if (!(*imT).forwardPredictedState().isValid()) continue;
+      if (!(*imT).forwardPredictedState().isValid())
+        continue;
       if ((*imT).forwardPredictedState().globalPosition().mag() >
-	  lastTKm.forwardPredictedState().globalPosition().mag()) lastTKm = *imT;
+          lastTKm.forwardPredictedState().globalPosition().mag())
+        lastTKm = *imT;
     }
   }
   currentState = lastTKm.forwardPredictedState();
@@ -185,7 +187,6 @@ TransientTrackingRecHit::ConstRecHitContainer DynamicTruncation::filter(const Tr
 
   return result;
 }
-
 
 //===> filteringAlgo
 void DynamicTruncation::filteringAlgo() {
@@ -202,17 +203,18 @@ void DynamicTruncation::filteringAlgo() {
   fillSegmentMaps(compatibleIds, dtSegMap, cscSegMap);
 
   // Do a preliminary fit
-  if (useDBforThr) preliminaryFit(compatibleIds, dtSegMap, cscSegMap);
+  if (useDBforThr)
+    preliminaryFit(compatibleIds, dtSegMap, cscSegMap);
 
   // Loop on compatible layers
-  for (map<int, vector<DetId> >::iterator it=compatibleIds.begin(); it!=compatibleIds.end(); ++it) {
+  for (map<int, vector<DetId> >::iterator it = compatibleIds.begin(); it != compatibleIds.end(); ++it) {
     int stLayer = stationfromDet(it->second.front());
     DTRecSegment4D bestDTSeg;
     CSCSegment bestCSCSeg;
-    double bestDTEstimator  = MAX_THR;
+    double bestDTEstimator = MAX_THR;
     double bestCSCEstimator = MAX_THR;
-    vector<DTRecSegment4D> dtSegs   = dtSegMap[it->first];
-    vector<CSCSegment> cscSegs      = cscSegMap[it->first];
+    vector<DTRecSegment4D> dtSegs = dtSegMap[it->first];
+    vector<CSCSegment> cscSegs = cscSegMap[it->first];
 
     // DT case: find the most compatible segment
     TrajectoryStateOnSurface tsosDTlayer;
@@ -223,15 +225,15 @@ void DynamicTruncation::filteringAlgo() {
     testCSCstation(currentState, cscSegs, bestCSCEstimator, bestCSCSeg, tsosCSClayer);
 
     // Decide whether to keep the layer or not
-    bool chosenLayer = chooseLayers(incompConLay, bestDTEstimator, bestDTSeg, tsosDTlayer, bestCSCEstimator, bestCSCSeg, tsosCSClayer);
+    bool chosenLayer =
+        chooseLayers(incompConLay, bestDTEstimator, bestDTSeg, tsosDTlayer, bestCSCEstimator, bestCSCSeg, tsosCSClayer);
     fillDYTInfos(stLayer, chosenLayer, incompConLay, bestDTEstimator, bestCSCEstimator, bestDTSeg, bestCSCSeg);
   }
   //cout << "Number of used stations = " << nStationsUsed << endl;
 }
 
-
 //===> stationfromDet
-int DynamicTruncation::stationfromDet(DetId const& det) {
+int DynamicTruncation::stationfromDet(DetId const &det) {
   if (det.subdetId() == MuonSubdetId::CSC) {
     CSCDetId ch(det);
     return ch.station();
@@ -243,11 +245,14 @@ int DynamicTruncation::stationfromDet(DetId const& det) {
   return 0;
 }
 
-
 //===> fillDYTInfos
-void DynamicTruncation::fillDYTInfos(int const &st, bool const &chosenLayer, int &incompConLay,
-				     double const &bestDTEstimator, double const &bestCSCEstimator,
-				     DTRecSegment4D const &bestDTSeg, CSCSegment const &bestCSCSeg) {
+void DynamicTruncation::fillDYTInfos(int const &st,
+                                     bool const &chosenLayer,
+                                     int &incompConLay,
+                                     double const &bestDTEstimator,
+                                     double const &bestCSCEstimator,
+                                     DTRecSegment4D const &bestDTSeg,
+                                     CSCSegment const &bestCSCSeg) {
   if (chosenLayer) {
     nStationsUsed++;
     incompConLay = 0;
@@ -268,7 +273,6 @@ void DynamicTruncation::fillDYTInfos(int const &st, bool const &chosenLayer, int
   }
 }
 
-
 //===> compatibleDets
 void DynamicTruncation::compatibleDets(TrajectoryStateOnSurface &tsos, map<int, vector<DetId> > &detMap) {
   MuonPatternRecoDumper dumper;
@@ -276,116 +280,134 @@ void DynamicTruncation::compatibleDets(TrajectoryStateOnSurface &tsos, map<int, 
   vector<const DetLayer *> navLayers;
   navLayers = navigation->compatibleLayers(*(currentState.freeState()), alongMomentum);
   unsigned int ilayerCorrected = 0;
-  for ( unsigned int ilayer=0; ilayer<navLayers.size(); ilayer++ ) {
+  for (unsigned int ilayer = 0; ilayer < navLayers.size(); ilayer++) {
     // Skip RPC layers
     if (navLayers[ilayer]->subDetector() != GeomDetEnumerators::DT &&
-	navLayers[ilayer]->subDetector() != GeomDetEnumerators::CSC) continue;
+        navLayers[ilayer]->subDetector() != GeomDetEnumerators::CSC)
+      continue;
     ilayerCorrected++;
-    vector<DetLayer::DetWithState> comps = navLayers[ilayer]->compatibleDets(currentState, *propagatorCompatibleDet, *theEstimator);
+    vector<DetLayer::DetWithState> comps =
+        navLayers[ilayer]->compatibleDets(currentState, *propagatorCompatibleDet, *theEstimator);
     //cout << comps.size() << " compatible Dets with " << navLayers[ilayer]->subDetector() << " Layer " << ilayer << " "
     //<< dumper.dumpLayer(navLayers[ilayer]);
     if (!comps.empty()) {
-      for ( unsigned int icomp=0; icomp<comps.size(); icomp++ ) {
-		DetId id(comps[icomp].first->geographicalId().rawId());
-		detMap[ilayerCorrected].push_back(id);
+      for (unsigned int icomp = 0; icomp < comps.size(); icomp++) {
+        DetId id(comps[icomp].first->geographicalId().rawId());
+        detMap[ilayerCorrected].push_back(id);
       }
     }
   }
-  if (theEstimator) delete theEstimator;
+  if (theEstimator)
+    delete theEstimator;
 }
 
-
 //===> fillSegmentMaps
-void DynamicTruncation::fillSegmentMaps( map<int, vector<DetId> > &compatibleIds,
-                                         map<int, vector<DTRecSegment4D> > &dtSegMap,
-                                         map<int, vector<CSCSegment> > &cscSegMap) {
-  for (map<int, vector<DetId> >::iterator it=compatibleIds.begin(); it!=compatibleIds.end(); ++it) {
+void DynamicTruncation::fillSegmentMaps(map<int, vector<DetId> > &compatibleIds,
+                                        map<int, vector<DTRecSegment4D> > &dtSegMap,
+                                        map<int, vector<CSCSegment> > &cscSegMap) {
+  for (map<int, vector<DetId> >::iterator it = compatibleIds.begin(); it != compatibleIds.end(); ++it) {
     vector<DetId> ids = compatibleIds[it->first];
     for (unsigned j = 0; j < ids.size(); j++) {
       if (ids[j].subdetId() == MuonSubdetId::CSC) {
         CSCDetId ch(ids[j]);
         vector<CSCSegment> tmp = getSegs->getCSCSegmentsInChamber(ch);
-        for (unsigned int k = 0; k < tmp.size(); k++) cscSegMap[it->first].push_back(tmp[k]);
+        for (unsigned int k = 0; k < tmp.size(); k++)
+          cscSegMap[it->first].push_back(tmp[k]);
       }
       if (ids[j].subdetId() == MuonSubdetId::DT) {
         DTChamberId ch(ids[j]);
         vector<DTRecSegment4D> tmp = getSegs->getDTSegmentsInChamber(ch);
-        for (unsigned int k = 0; k < tmp.size(); k++) dtSegMap[it->first].push_back(tmp[k]);
+        for (unsigned int k = 0; k < tmp.size(); k++)
+          dtSegMap[it->first].push_back(tmp[k]);
       }
     }
   }
 }
 
-
 //===> testDTstation
-void DynamicTruncation::testDTstation(TrajectoryStateOnSurface &startingState, vector<DTRecSegment4D> const &segments,
-				      double &bestEstimator, DTRecSegment4D &bestSeg, TrajectoryStateOnSurface &tsosdt) {
-  if (segments.empty()) return;
+void DynamicTruncation::testDTstation(TrajectoryStateOnSurface &startingState,
+                                      vector<DTRecSegment4D> const &segments,
+                                      double &bestEstimator,
+                                      DTRecSegment4D &bestSeg,
+                                      TrajectoryStateOnSurface &tsosdt) {
+  if (segments.empty())
+    return;
   for (unsigned int iSeg = 0; iSeg < segments.size(); iSeg++) {
     DTChamberId chamber(segments[iSeg].chamberId());
-    if (!propagator->propagate(startingState, theG->idToDet(chamber)->surface()).isValid()) continue;
+    if (!propagator->propagate(startingState, theG->idToDet(chamber)->surface()).isValid())
+      continue;
     tsosdt = propagator->propagate(startingState, theG->idToDet(chamber)->surface());
     //if (!tsosdt.isValid()) continue;
     LocalError apeLoc;
-    if (useAPE) apeLoc = ErrorFrameTransformer().transform(dtApeMap.find(chamber)->second, theG->idToDet(chamber)->surface());
+    if (useAPE)
+      apeLoc = ErrorFrameTransformer().transform(dtApeMap.find(chamber)->second, theG->idToDet(chamber)->surface());
     StateSegmentMatcher estim(tsosdt, segments[iSeg], apeLoc);
     double estimator = estim.value();
     //cout << "estimator DT = " << estimator << endl;
-    if (estimator >= bestEstimator) continue;
+    if (estimator >= bestEstimator)
+      continue;
     bestEstimator = estimator;
     bestSeg = segments[iSeg];
   }
 }
 
-
 //===> testCSCstation
-void DynamicTruncation::testCSCstation(TrajectoryStateOnSurface &startingState, vector<CSCSegment> const &segments,
-				       double &bestEstimator, CSCSegment &bestSeg, TrajectoryStateOnSurface &tsoscsc) {
-  if (segments.empty()) return;
+void DynamicTruncation::testCSCstation(TrajectoryStateOnSurface &startingState,
+                                       vector<CSCSegment> const &segments,
+                                       double &bestEstimator,
+                                       CSCSegment &bestSeg,
+                                       TrajectoryStateOnSurface &tsoscsc) {
+  if (segments.empty())
+    return;
   for (unsigned int iSeg = 0; iSeg < segments.size(); iSeg++) {
     CSCDetId chamber(segments[iSeg].cscDetId());
-    if (!propagator->propagate(startingState, theG->idToDet(chamber)->surface()).isValid()) continue;
+    if (!propagator->propagate(startingState, theG->idToDet(chamber)->surface()).isValid())
+      continue;
     tsoscsc = propagator->propagate(startingState, theG->idToDet(chamber)->surface());
     //if (!tsoscsc.isValid()) continue;
     LocalError apeLoc;
-    if (useAPE) apeLoc = ErrorFrameTransformer().transform(cscApeMap.find(chamber)->second, theG->idToDet(chamber)->surface());
+    if (useAPE)
+      apeLoc = ErrorFrameTransformer().transform(cscApeMap.find(chamber)->second, theG->idToDet(chamber)->surface());
     StateSegmentMatcher estim(tsoscsc, segments[iSeg], apeLoc);
     double estimator = estim.value();
     //cout << "estimator CSC = " << estimator << endl;
-    if (estimator >= bestEstimator) continue;
+    if (estimator >= bestEstimator)
+      continue;
     bestEstimator = estimator;
     bestSeg = segments[iSeg];
   }
 }
-
 
 //===> useSegment
 void DynamicTruncation::useSegment(DTRecSegment4D const &bestDTSeg, TrajectoryStateOnSurface const &tsosDT) {
   result.push_back(theMuonRecHitBuilder->build(&bestDTSeg));
-  if (doUpdateOfKFStates) updateWithDThits(currentState, bestDTSeg);
-  else currentState = tsosDT;
+  if (doUpdateOfKFStates)
+    updateWithDThits(currentState, bestDTSeg);
+  else
+    currentState = tsosDT;
 }
-
 
 //===> useSegment
 void DynamicTruncation::useSegment(CSCSegment const &bestCSCSeg, TrajectoryStateOnSurface const &tsosCSC) {
   result.push_back(theMuonRecHitBuilder->build(&bestCSCSeg));
-  if (doUpdateOfKFStates) updateWithCSChits(currentState, bestCSCSeg);
-  else currentState = tsosCSC;
+  if (doUpdateOfKFStates)
+    updateWithCSChits(currentState, bestCSCSeg);
+  else
+    currentState = tsosCSC;
 }
 
-
 //===> preliminaryFit
-void DynamicTruncation::preliminaryFit(map<int, vector<DetId> > compatibleIds, map<int, vector<DTRecSegment4D> > dtSegMap,
-				       map<int, vector<CSCSegment> > cscSegMap) {
-  for (map<int, vector<DetId> >::iterator it=compatibleIds.begin(); it!=compatibleIds.end(); ++it) {
+void DynamicTruncation::preliminaryFit(map<int, vector<DetId> > compatibleIds,
+                                       map<int, vector<DTRecSegment4D> > dtSegMap,
+                                       map<int, vector<CSCSegment> > cscSegMap) {
+  for (map<int, vector<DetId> >::iterator it = compatibleIds.begin(); it != compatibleIds.end(); ++it) {
     DTRecSegment4D bestDTSeg;
     CSCSegment bestCSCSeg;
-    double bestDTEstimator  = MAX_THR;
+    double bestDTEstimator = MAX_THR;
     double bestCSCEstimator = MAX_THR;
     double initThr = MAX_THR;
     vector<DTRecSegment4D> dtSegs = dtSegMap[it->first];
-    vector<CSCSegment> cscSegs    = cscSegMap[it->first];
+    vector<CSCSegment> cscSegs = cscSegMap[it->first];
 
     // DT case: find the most compatible segment
     TrajectoryStateOnSurface tsosDTlayer;
@@ -396,62 +418,76 @@ void DynamicTruncation::preliminaryFit(map<int, vector<DetId> > compatibleIds, m
     testCSCstation(prelFitState, cscSegs, bestCSCEstimator, bestCSCSeg, tsosCSClayer);
 
     // Decide whether to keep the layer or not
-    if (bestDTEstimator == MAX_THR && bestCSCEstimator == MAX_THR) continue;
+    if (bestDTEstimator == MAX_THR && bestCSCEstimator == MAX_THR)
+      continue;
     if (bestDTEstimator <= bestCSCEstimator) {
       getThresholdFromCFG(initThr, DetId(bestDTSeg.chamberId()));
-      if (bestDTEstimator >= initThr) continue;
+      if (bestDTEstimator >= initThr)
+        continue;
       prelFitMeas.push_back(theMuonRecHitBuilder->build(&bestDTSeg));
       auto aSegRH = prelFitMeas.back();
       auto uRes = updatorHandle->update(tsosDTlayer, *aSegRH);
-      if (uRes.isValid()){
-	prelFitState = uRes;
+      if (uRes.isValid()) {
+        prelFitState = uRes;
       } else {
-	prelFitMeas.pop_back();
+        prelFitMeas.pop_back();
       }
     } else {
       getThresholdFromCFG(initThr, DetId(bestCSCSeg.cscDetId()));
-      if (bestCSCEstimator >= initThr) continue;
+      if (bestCSCEstimator >= initThr)
+        continue;
       prelFitMeas.push_back(theMuonRecHitBuilder->build(&bestCSCSeg));
       auto aSegRH = prelFitMeas.back();
       auto uRes = updatorHandle->update(tsosCSClayer, *aSegRH);
-      if (uRes.isValid()){
-	prelFitState = uRes;
+      if (uRes.isValid()) {
+        prelFitState = uRes;
       } else {
-	prelFitMeas.pop_back();
+        prelFitMeas.pop_back();
       }
     }
   }
-  if (!prelFitMeas.empty()) prelFitMeas.pop_back();
+  if (!prelFitMeas.empty())
+    prelFitMeas.pop_back();
   for (auto imrh = prelFitMeas.rbegin(); imrh != prelFitMeas.rend(); ++imrh) {
     DetId id = (*imrh)->geographicalId();
     TrajectoryStateOnSurface tmp = propagatorPF->propagate(prelFitState, theG->idToDet(id)->surface());
-    if (tmp.isValid()) prelFitState = tmp;
+    if (tmp.isValid())
+      prelFitState = tmp;
   }
-  muonPTest  = prelFitState.globalMomentum().perp();
+  muonPTest = prelFitState.globalMomentum().perp();
   muonETAest = prelFitState.globalMomentum().eta();
 }
 
-
 //===> chooseLayers
-bool DynamicTruncation::chooseLayers(int &incompLayers, double const &bestDTEstimator, DTRecSegment4D const &bestDTSeg, TrajectoryStateOnSurface const &tsosDT,
-				     double const &bestCSCEstimator, CSCSegment const &bestCSCSeg, TrajectoryStateOnSurface const &tsosCSC) {
+bool DynamicTruncation::chooseLayers(int &incompLayers,
+                                     double const &bestDTEstimator,
+                                     DTRecSegment4D const &bestDTSeg,
+                                     TrajectoryStateOnSurface const &tsosDT,
+                                     double const &bestCSCEstimator,
+                                     CSCSegment const &bestCSCSeg,
+                                     TrajectoryStateOnSurface const &tsosCSC) {
   double initThr = MAX_THR;
-  if (bestDTEstimator == MAX_THR && bestCSCEstimator == MAX_THR) return false;
+  if (bestDTEstimator == MAX_THR && bestCSCEstimator == MAX_THR)
+    return false;
   if (bestDTEstimator <= bestCSCEstimator) {
     // Get threshold for the chamber
-    if (useDBforThr) getThresholdFromDB(initThr, DetId(bestDTSeg.chamberId()));
-    else getThresholdFromCFG(initThr, DetId(bestDTSeg.chamberId()));
+    if (useDBforThr)
+      getThresholdFromDB(initThr, DetId(bestDTSeg.chamberId()));
+    else
+      getThresholdFromCFG(initThr, DetId(bestDTSeg.chamberId()));
     if (DYTselector == 0 || (DYTselector == 1 && bestDTEstimator < initThr) ||
-	(DYTselector == 2 && incompLayers < 2 && bestDTEstimator < initThr)) {
+        (DYTselector == 2 && incompLayers < 2 && bestDTEstimator < initThr)) {
       useSegment(bestDTSeg, tsosDT);
       return true;
     }
   } else {
     // Get threshold for the chamber
-    if (useDBforThr) getThresholdFromDB(initThr, DetId(bestCSCSeg.cscDetId()));
-    else getThresholdFromCFG(initThr, DetId(bestCSCSeg.cscDetId()));
+    if (useDBforThr)
+      getThresholdFromDB(initThr, DetId(bestCSCSeg.cscDetId()));
+    else
+      getThresholdFromCFG(initThr, DetId(bestCSCSeg.cscDetId()));
     if (DYTselector == 0 || (DYTselector == 1 && bestCSCEstimator < initThr) ||
-	(DYTselector == 2 && incompLayers < 2 && bestCSCEstimator < initThr)) {
+        (DYTselector == 2 && incompLayers < 2 && bestCSCEstimator < initThr)) {
       useSegment(bestCSCSeg, tsosCSC);
       return true;
     }
@@ -459,9 +495,8 @@ bool DynamicTruncation::chooseLayers(int &incompLayers, double const &bestDTEsti
   return false;
 }
 
-
 //===> getThresholdFromDB
-void DynamicTruncation::getThresholdFromDB(double& thr, DetId const& id) {
+void DynamicTruncation::getThresholdFromDB(double &thr, DetId const &id) {
   vector<DYTThrObject::DytThrStruct> thrvector = dytThresholds->thrsVec;
   for (vector<DYTThrObject::DytThrStruct>::const_iterator it = thrvector.begin(); it != thrvector.end(); it++) {
     DYTThrObject::DytThrStruct obj = (*it);
@@ -470,42 +505,45 @@ void DynamicTruncation::getThresholdFromDB(double& thr, DetId const& id) {
       break;
     }
   }
-  if (useParametrizedThr) correctThrByPAndEta(thr);
+  if (useParametrizedThr)
+    correctThrByPAndEta(thr);
 }
-
 
 //===> correctThrByPAndEta
-void DynamicTruncation::correctThrByPAndEta(double& thr) {
+void DynamicTruncation::correctThrByPAndEta(double &thr) {
+  auto parametricThreshold = [this] {
+    double thr50 = this->parameters[this->region].at(0);
+    double p0 = this->parameters[this->region].at(1);
+    double p1 = this->parameters[this->region].at(2);
+    return thr50 * (1 + p0 * p_reco + std::pow(this->p_reco, p1));
+  };
 
-    auto parametricThreshold = [this]{
-      double thr50 = this->parameters[this->region].at(0);
-      double p0    = this->parameters[this->region].at(1);
-      double p1    = this->parameters[this->region].at(2);
-      return thr50 * ( 1 + p0*p_reco + std::pow( this->p_reco, p1));
-    };
+  std::set<dyt_utils::etaRegion> regionsToExclude = {
+      dyt_utils::etaRegion::eta2p0, dyt_utils::etaRegion::eta2p2, dyt_utils::etaRegion::eta2p4};
 
-    std::set<dyt_utils::etaRegion> regionsToExclude = {dyt_utils::etaRegion::eta2p0,dyt_utils::etaRegion::eta2p2, dyt_utils::etaRegion::eta2p4 };
-
-    if ( ! regionsToExclude.count(this->region) ) thr = parametricThreshold();
+  if (!regionsToExclude.count(this->region))
+    thr = parametricThreshold();
 }
 
-void DynamicTruncation::setEtaRegion(){
-
+void DynamicTruncation::setEtaRegion() {
   float absEta = std::abs(eta_reco);
   // Defaul value for muons with abs(eta) > 2.4
   region = dyt_utils::etaRegion::eta2p4;
 
-  if( absEta <= 0.8 ) region = dyt_utils::etaRegion::eta0p8;
-  else if( absEta <= 1.2 ) region = dyt_utils::etaRegion::eta1p2;
-  else if( absEta <= 2.0 ) region = dyt_utils::etaRegion::eta2p0;
-  else if( absEta <= 2.2 ) region = dyt_utils::etaRegion::eta2p2;
-  else if( absEta <= 2.4 ) region = dyt_utils::etaRegion::eta2p4;
-
+  if (absEta <= 0.8)
+    region = dyt_utils::etaRegion::eta0p8;
+  else if (absEta <= 1.2)
+    region = dyt_utils::etaRegion::eta1p2;
+  else if (absEta <= 2.0)
+    region = dyt_utils::etaRegion::eta2p0;
+  else if (absEta <= 2.2)
+    region = dyt_utils::etaRegion::eta2p2;
+  else if (absEta <= 2.4)
+    region = dyt_utils::etaRegion::eta2p4;
 }
 
-
 //===> getThresholdFromCFG
-void DynamicTruncation::getThresholdFromCFG(double& thr, DetId const& id) {
+void DynamicTruncation::getThresholdFromCFG(double &thr, DetId const &id) {
   if (id.subdetId() == MuonSubdetId::DT) {
     thr = Thrs[0];
   }
@@ -513,17 +551,17 @@ void DynamicTruncation::getThresholdFromCFG(double& thr, DetId const& id) {
     thr = Thrs[1];
   }
 
-  if (useParametrizedThr) correctThrByPAndEta(thr);
-
+  if (useParametrizedThr)
+    correctThrByPAndEta(thr);
 }
 
-
 //===> sort
-void DynamicTruncation::sort(ConstRecHitContainer& recHits) {
-  unsigned int i=0;
-  unsigned int j=0;
+void DynamicTruncation::sort(ConstRecHitContainer &recHits) {
+  unsigned int i = 0;
+  unsigned int j = 0;
   ConstRecHitContainer::size_type n = recHits.size();
-  for(i=1; i<n; ++i)
-    for(j=n-1; j>=i; --j)
-      if(recHits[j-1]->globalPosition().mag() > recHits[j]->globalPosition().mag()) swap (recHits[j-1],recHits[j]);
+  for (i = 1; i < n; ++i)
+    for (j = n - 1; j >= i; --j)
+      if (recHits[j - 1]->globalPosition().mag() > recHits[j]->globalPosition().mag())
+        swap(recHits[j - 1], recHits[j]);
 }

--- a/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
@@ -40,7 +40,6 @@
 #include "TrackingTools/TrackFitters/interface/TrajectoryFitter.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 
-
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
@@ -74,19 +73,18 @@ using namespace edm;
 //----------------
 
 GlobalMuonRefitter::GlobalMuonRefitter(const edm::ParameterSet& par,
-				       const MuonServiceProxy* service,
-				       edm::ConsumesCollector& iC) : 
-  theCosmicFlag(par.getParameter<bool>("PropDirForCosmics")),
-  theDTRecHitLabel(par.getParameter<InputTag>("DTRecSegmentLabel")),
-  theCSCRecHitLabel(par.getParameter<InputTag>("CSCRecSegmentLabel")),
-  theGEMRecHitLabel(par.getParameter<InputTag>("GEMRecHitLabel")),
-  theME0RecHitLabel(par.getParameter<InputTag>("ME0RecHitLabel")),
-  theService(service) {
-
+                                       const MuonServiceProxy* service,
+                                       edm::ConsumesCollector& iC)
+    : theCosmicFlag(par.getParameter<bool>("PropDirForCosmics")),
+      theDTRecHitLabel(par.getParameter<InputTag>("DTRecSegmentLabel")),
+      theCSCRecHitLabel(par.getParameter<InputTag>("CSCRecSegmentLabel")),
+      theGEMRecHitLabel(par.getParameter<InputTag>("GEMRecHitLabel")),
+      theME0RecHitLabel(par.getParameter<InputTag>("ME0RecHitLabel")),
+      theService(service) {
   theCategory = par.getUntrackedParameter<string>("Category", "Muon|RecoMuon|GlobalMuon|GlobalMuonRefitter");
 
   theHitThreshold = par.getParameter<int>("HitThreshold");
-  theDTChi2Cut  = par.getParameter<double>("Chi2CutDT");
+  theDTChi2Cut = par.getParameter<double>("Chi2CutDT");
   theCSCChi2Cut = par.getParameter<double>("Chi2CutCSC");
   theRPCChi2Cut = par.getParameter<double>("Chi2CutRPC");
   theGEMChi2Cut = par.getParameter<double>("Chi2CutGEM");
@@ -95,123 +93,116 @@ GlobalMuonRefitter::GlobalMuonRefitter(const edm::ParameterSet& par,
   // Refit direction
   string refitDirectionName = par.getParameter<string>("RefitDirection");
 
-  if (refitDirectionName == "insideOut" ) theRefitDirection = insideOut;
-  else if (refitDirectionName == "outsideIn" ) theRefitDirection = outsideIn;
-  else 
-    throw cms::Exception("TrackTransformer constructor") 
-      <<"Wrong refit direction chosen in TrackTransformer ParameterSet"
-      << "\n"
-      << "Possible choices are:"
-      << "\n"
-      << "RefitDirection = insideOut or RefitDirection = outsideIn";
+  if (refitDirectionName == "insideOut")
+    theRefitDirection = insideOut;
+  else if (refitDirectionName == "outsideIn")
+    theRefitDirection = outsideIn;
+  else
+    throw cms::Exception("TrackTransformer constructor")
+        << "Wrong refit direction chosen in TrackTransformer ParameterSet"
+        << "\n"
+        << "Possible choices are:"
+        << "\n"
+        << "RefitDirection = insideOut or RefitDirection = outsideIn";
 
-  theFitterName = par.getParameter<string>("Fitter");  
+  theFitterName = par.getParameter<string>("Fitter");
   thePropagatorName = par.getParameter<string>("Propagator");
 
-  theSkipStation        = par.getParameter<int>("SkipStation");
-  theTrackerSkipSystem	= par.getParameter<int>("TrackerSkipSystem");
-  theTrackerSkipSection	= par.getParameter<int>("TrackerSkipSection");//layer, wheel, or disk depending on the system
+  theSkipStation = par.getParameter<int>("SkipStation");
+  theTrackerSkipSystem = par.getParameter<int>("TrackerSkipSystem");
+  theTrackerSkipSection = par.getParameter<int>("TrackerSkipSection");  //layer, wheel, or disk depending on the system
 
   theTrackerRecHitBuilderName = par.getParameter<string>("TrackerRecHitBuilder");
   theMuonRecHitBuilderName = par.getParameter<string>("MuonRecHitBuilder");
 
   theRPCInTheFit = par.getParameter<bool>("RefitRPCHits");
 
-  theDYTthrs     = par.getParameter< std::vector<int> >("DYTthrs");
+  theDYTthrs = par.getParameter<std::vector<int> >("DYTthrs");
   theDYTselector = par.getParameter<int>("DYTselector");
-  theDYTupdator  = par.getParameter<bool>("DYTupdator");
-  theDYTuseAPE   = par.getParameter<bool>("DYTuseAPE");
+  theDYTupdator = par.getParameter<bool>("DYTupdator");
+  theDYTuseAPE = par.getParameter<bool>("DYTuseAPE");
   theDYTParThrsMode = par.getParameter<bool>("DYTuseThrsParametrization");
-  if (theDYTParThrsMode) theDYTthrsParameters = par.getParameter< edm::ParameterSet >("DYTthrsParameters");
-  dytInfo        = new reco::DYTInfo();
+  if (theDYTParThrsMode)
+    theDYTthrsParameters = par.getParameter<edm::ParameterSet>("DYTthrsParameters");
+  dytInfo = new reco::DYTInfo();
 
   if (par.existsAs<double>("RescaleErrorFactor")) {
     theRescaleErrorFactor = par.getParameter<double>("RescaleErrorFactor");
     edm::LogWarning("GlobalMuonRefitter") << "using error rescale factor " << theRescaleErrorFactor;
-  }
-  else
+  } else
     theRescaleErrorFactor = 1000.;
 
   theCacheId_TRH = 0;
-  theDTRecHitToken=iC.consumes<DTRecHitCollection>(theDTRecHitLabel);
-  theCSCRecHitToken=iC.consumes<CSCRecHit2DCollection>(theCSCRecHitLabel);
-  theGEMRecHitToken=iC.consumes<GEMRecHitCollection>(theGEMRecHitLabel); 
-  theME0RecHitToken=iC.consumes<ME0SegmentCollection>(theME0RecHitLabel);
+  theDTRecHitToken = iC.consumes<DTRecHitCollection>(theDTRecHitLabel);
+  theCSCRecHitToken = iC.consumes<CSCRecHit2DCollection>(theCSCRecHitLabel);
+  theGEMRecHitToken = iC.consumes<GEMRecHitCollection>(theGEMRecHitLabel);
+  theME0RecHitToken = iC.consumes<ME0SegmentCollection>(theME0RecHitLabel);
   CSCSegmentsToken = iC.consumes<CSCSegmentCollection>(InputTag("cscSegments"));
-  all4DSegmentsToken=iC.consumes<DTRecSegment4DCollection>(InputTag("dt4DSegments"));
+  all4DSegmentsToken = iC.consumes<DTRecSegment4DCollection>(InputTag("dt4DSegments"));
 }
 
 //--------------
 // Destructor --
 //--------------
 
-GlobalMuonRefitter::~GlobalMuonRefitter() {
-  delete dytInfo;
-}
-
+GlobalMuonRefitter::~GlobalMuonRefitter() { delete dytInfo; }
 
 //
 // set Event
 //
 void GlobalMuonRefitter::setEvent(const edm::Event& event) {
-
   theEvent = &event;
   event.getByToken(theDTRecHitToken, theDTRecHits);
   event.getByToken(theCSCRecHitToken, theCSCRecHits);
-  event.getByToken(theGEMRecHitToken, theGEMRecHits);   
-  event.getByToken(theME0RecHitToken, theME0RecHits);   
+  event.getByToken(theGEMRecHitToken, theGEMRecHits);
+  event.getByToken(theME0RecHitToken, theME0RecHits);
   event.getByToken(CSCSegmentsToken, CSCSegments);
   event.getByToken(all4DSegmentsToken, all4DSegments);
 }
 
-
 void GlobalMuonRefitter::setServices(const EventSetup& setup) {
-
   edm::ESHandle<TrajectoryFitter> aFitter;
-  theService->eventSetup().get<TrajectoryFitter::Record>().get(theFitterName,aFitter);
+  theService->eventSetup().get<TrajectoryFitter::Record>().get(theFitterName, aFitter);
   theFitter = aFitter->clone();
-
 
   // Transient Rechit Builders
   unsigned long long newCacheId_TRH = setup.get<TransientRecHitRecord>().cacheIdentifier();
-  if ( newCacheId_TRH != theCacheId_TRH ) {
+  if (newCacheId_TRH != theCacheId_TRH) {
     LogDebug(theCategory) << "TransientRecHitRecord changed!";
-    setup.get<TransientRecHitRecord>().get(theTrackerRecHitBuilderName,theTrackerRecHitBuilder);
-    setup.get<TransientRecHitRecord>().get(theMuonRecHitBuilderName,theMuonRecHitBuilder);
-    hitCloner = static_cast<TkTransientTrackingRecHitBuilder const *>(theTrackerRecHitBuilder.product())->cloner();
+    setup.get<TransientRecHitRecord>().get(theTrackerRecHitBuilderName, theTrackerRecHitBuilder);
+    setup.get<TransientRecHitRecord>().get(theMuonRecHitBuilderName, theMuonRecHitBuilder);
+    hitCloner = static_cast<TkTransientTrackingRecHitBuilder const*>(theTrackerRecHitBuilder.product())->cloner();
   }
   theFitter->setHitCloner(&hitCloner);
-
 }
-
 
 //
 // build a combined tracker-muon trajectory
 //
 vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
-					     const int theMuonHitsOption,
-					     const TrackerTopology *tTopo) const {
+                                             const int theMuonHitsOption,
+                                             const TrackerTopology* tTopo) const {
   LogTrace(theCategory) << " *** GlobalMuonRefitter *** option " << theMuonHitsOption << endl;
 
-  ConstRecHitContainer allRecHitsTemp; // all muon rechits temp
+  ConstRecHitContainer allRecHitsTemp;  // all muon rechits temp
 
-  reco::TransientTrack track(globalTrack,&*(theService->magneticField()),theService->trackingGeometry());
+  reco::TransientTrack track(globalTrack, &*(theService->magneticField()), theService->trackingGeometry());
 
-  auto tkbuilder = static_cast<TkTransientTrackingRecHitBuilder const *>(theTrackerRecHitBuilder.product());
+  auto tkbuilder = static_cast<TkTransientTrackingRecHitBuilder const*>(theTrackerRecHitBuilder.product());
 
   for (trackingRecHit_iterator hit = track.recHitsBegin(); hit != track.recHitsEnd(); ++hit)
     if ((*hit)->isValid()) {
       if ((*hit)->geographicalId().det() == DetId::Tracker)
-	allRecHitsTemp.push_back((**hit).cloneForFit(*tkbuilder->geometry()->idToDet( (**hit).geographicalId() ) ) );
+        allRecHitsTemp.push_back((**hit).cloneForFit(*tkbuilder->geometry()->idToDet((**hit).geographicalId())));
       else if ((*hit)->geographicalId().det() == DetId::Muon) {
-	if ((*hit)->geographicalId().subdetId() == 3 && !theRPCInTheFit) {
-	  LogTrace(theCategory) << "RPC Rec Hit discarged"; 
-	  continue;
-	}
-	allRecHitsTemp.push_back(theMuonRecHitBuilder->build(&**hit));
+        if ((*hit)->geographicalId().subdetId() == 3 && !theRPCInTheFit) {
+          LogTrace(theCategory) << "RPC Rec Hit discarged";
+          continue;
+        }
+        allRecHitsTemp.push_back(theMuonRecHitBuilder->build(&**hit));
       }
     }
-  vector<Trajectory> refitted = refit(globalTrack,track,allRecHitsTemp,theMuonHitsOption, tTopo);
+  vector<Trajectory> refitted = refit(globalTrack, track, allRecHitsTemp, theMuonHitsOption, tTopo);
   return refitted;
 }
 
@@ -219,68 +210,67 @@ vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
 // build a combined tracker-muon trajectory
 //
 vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
-					     const reco::TransientTrack track,
-					     const TransientTrackingRecHit::ConstRecHitContainer& allRecHitsTemp,
-					     const int theMuonHitsOption,
-					     const TrackerTopology *tTopo) const {
-
+                                             const reco::TransientTrack track,
+                                             const TransientTrackingRecHit::ConstRecHitContainer& allRecHitsTemp,
+                                             const int theMuonHitsOption,
+                                             const TrackerTopology* tTopo) const {
   // MuonHitsOption: 0 - tracker only
   //                 1 - include all muon hits
   //                 2 - include only first muon hit(s)
   //                 3 - include only selected muon hits
   //                 4 - redo pattern recognition with dynamic truncation
 
-  vector<int> stationHits(4,0);
+  vector<int> stationHits(4, 0);
   map<DetId, int> hitMap;
 
-  ConstRecHitContainer allRecHits; // all muon rechits
-  ConstRecHitContainer fmsRecHits; // only first muon rechits
-  ConstRecHitContainer selectedRecHits; // selected muon rechits
-  ConstRecHitContainer DYTRecHits; // rec hits from dynamic truncation algorithm
+  ConstRecHitContainer allRecHits;       // all muon rechits
+  ConstRecHitContainer fmsRecHits;       // only first muon rechits
+  ConstRecHitContainer selectedRecHits;  // selected muon rechits
+  ConstRecHitContainer DYTRecHits;       // rec hits from dynamic truncation algorithm
 
   LogTrace(theCategory) << " *** GlobalMuonRefitter *** option " << theMuonHitsOption << endl;
   LogTrace(theCategory) << " Track momentum before refit: " << globalTrack.pt() << endl;
   LogTrace(theCategory) << " Hits size before : " << allRecHitsTemp.size() << endl;
 
-  allRecHits = getRidOfSelectStationHits(allRecHitsTemp, tTopo);  
+  allRecHits = getRidOfSelectStationHits(allRecHitsTemp, tTopo);
   //    printHits(allRecHits);
   LogTrace(theCategory) << " Hits size: " << allRecHits.size() << endl;
 
-  vector <Trajectory> outputTraj;
+  vector<Trajectory> outputTraj;
 
-  if ((theMuonHitsOption == 1) || (theMuonHitsOption == 3) || (theMuonHitsOption == 4) ) {
+  if ((theMuonHitsOption == 1) || (theMuonHitsOption == 3) || (theMuonHitsOption == 4)) {
     // refit the full track with all muon hits
-    vector <Trajectory> globalTraj = transform(globalTrack, track, allRecHits);
+    vector<Trajectory> globalTraj = transform(globalTrack, track, allRecHits);
 
     if (globalTraj.empty()) {
       LogTrace(theCategory) << "No trajectory from the TrackTransformer!" << endl;
       return vector<Trajectory>();
     }
 
-    LogTrace(theCategory) << " Initial trajectory state: " 
+    LogTrace(theCategory) << " Initial trajectory state: "
                           << globalTraj.front().lastMeasurement().updatedState().freeState()->parameters() << endl;
 
-    if (theMuonHitsOption == 1 )
+    if (theMuonHitsOption == 1)
       outputTraj.push_back(globalTraj.front());
 
-    if (theMuonHitsOption == 3 ) {
+    if (theMuonHitsOption == 3) {
       checkMuonHits(globalTrack, allRecHits, hitMap);
-      selectedRecHits = selectMuonHits(globalTraj.front(),hitMap);
+      selectedRecHits = selectMuonHits(globalTraj.front(), hitMap);
       LogTrace(theCategory) << " Selected hits size: " << selectedRecHits.size() << endl;
       outputTraj = transform(globalTrack, track, selectedRecHits);
     }
 
-    if (theMuonHitsOption == 4 ) {
+    if (theMuonHitsOption == 4) {
       //
       // DYT 2.0
       //
-      DynamicTruncation dytRefit(*theEvent,*theService);
+      DynamicTruncation dytRefit(*theEvent, *theService);
       dytRefit.setProd(all4DSegments, CSCSegments);
       dytRefit.setSelector(theDYTselector);
       dytRefit.setThr(theDYTthrs);
       dytRefit.setUpdateState(theDYTupdator);
       dytRefit.setUseAPE(theDYTuseAPE);
-      if(theDYTParThrsMode) {
+      if (theDYTParThrsMode) {
         dytRefit.setParThrsMode(theDYTParThrsMode);
         dytRefit.setThrsMap(theDYTthrsParameters);
         dytRefit.setRecoP(globalTrack.p());
@@ -288,43 +278,42 @@ vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
       }
       DYTRecHits = dytRefit.filter(globalTraj.front());
       dytInfo->CopyFrom(dytRefit.getDYTInfo());
-      if ((DYTRecHits.size() > 1) && (DYTRecHits.front()->globalPosition().mag() > DYTRecHits.back()->globalPosition().mag()))
-        stable_sort(DYTRecHits.begin(),DYTRecHits.end(),RecHitLessByDet(alongMomentum));
+      if ((DYTRecHits.size() > 1) &&
+          (DYTRecHits.front()->globalPosition().mag() > DYTRecHits.back()->globalPosition().mag()))
+        stable_sort(DYTRecHits.begin(), DYTRecHits.end(), RecHitLessByDet(alongMomentum));
       outputTraj = transform(globalTrack, track, DYTRecHits);
     }
 
-  } else if (theMuonHitsOption == 2 )  {
-      getFirstHits(globalTrack, allRecHits, fmsRecHits);
-      outputTraj = transform(globalTrack, track, fmsRecHits);
-    }
-
+  } else if (theMuonHitsOption == 2) {
+    getFirstHits(globalTrack, allRecHits, fmsRecHits);
+    outputTraj = transform(globalTrack, track, fmsRecHits);
+  }
 
   if (!outputTraj.empty()) {
-    LogTrace(theCategory) << "Refitted pt: " << outputTraj.front().firstMeasurement().updatedState().globalParameters().momentum().perp() << endl;
+    LogTrace(theCategory) << "Refitted pt: "
+                          << outputTraj.front().firstMeasurement().updatedState().globalParameters().momentum().perp()
+                          << endl;
     return outputTraj;
   } else {
     LogTrace(theCategory) << "No refitted Tracks... " << endl;
     return vector<Trajectory>();
   }
-
 }
 
-
 //
 //
 //
-void GlobalMuonRefitter::checkMuonHits(const reco::Track& muon, 
-				       ConstRecHitContainer& all,
-				       map<DetId, int> &hitMap) const {
-
+void GlobalMuonRefitter::checkMuonHits(const reco::Track& muon,
+                                       ConstRecHitContainer& all,
+                                       map<DetId, int>& hitMap) const {
   LogTrace(theCategory) << " GlobalMuonRefitter::checkMuonHits " << endl;
 
   float coneSize = 20.0;
 
   // loop through all muon hits and calculate the maximum # of hits in each chamber
-  for (ConstRecHitContainer::const_iterator imrh = all.begin(); imrh != all.end(); imrh++ ) {
-
-    if ( (*imrh != nullptr ) && !(*imrh)->isValid() ) continue;
+  for (ConstRecHitContainer::const_iterator imrh = all.begin(); imrh != all.end(); imrh++) {
+    if ((*imrh != nullptr) && !(*imrh)->isValid())
+      continue;
 
     int detRecHits = 0;
     MuonRecHitContainer dRecHits;
@@ -333,42 +322,49 @@ void GlobalMuonRefitter::checkMuonHits(const reco::Track& muon,
     DetId chamberId;
 
     // Skip tracker hits
-    if (id.det()!=DetId::Muon) continue;
+    if (id.det() != DetId::Muon)
+      continue;
 
-    if ( id.subdetId() == MuonSubdetId::DT ) {
+    if (id.subdetId() == MuonSubdetId::DT) {
       DTChamberId did(id.rawId());
-      chamberId=did;
+      chamberId = did;
 
-      if ((*imrh)->dimension()>1) {
-        std::vector <const TrackingRecHit*> hits2d = (*imrh)->recHits();
-        for (std::vector <const TrackingRecHit*>::const_iterator hit2d = hits2d.begin(); hit2d!= hits2d.end(); hit2d++) {
-          if ((*hit2d)->dimension()>1) {
-            std::vector <const TrackingRecHit*> hits1d = (*hit2d)->recHits();
-            for (std::vector <const TrackingRecHit*>::const_iterator hit1d = hits1d.begin(); hit1d!= hits1d.end(); hit1d++) {
+      if ((*imrh)->dimension() > 1) {
+        std::vector<const TrackingRecHit*> hits2d = (*imrh)->recHits();
+        for (std::vector<const TrackingRecHit*>::const_iterator hit2d = hits2d.begin(); hit2d != hits2d.end();
+             hit2d++) {
+          if ((*hit2d)->dimension() > 1) {
+            std::vector<const TrackingRecHit*> hits1d = (*hit2d)->recHits();
+            for (std::vector<const TrackingRecHit*>::const_iterator hit1d = hits1d.begin(); hit1d != hits1d.end();
+                 hit1d++) {
               DetId id1 = (*hit1d)->geographicalId();
               DTLayerId lid(id1.rawId());
               // Get the 1d DT RechHits from this layer
               DTRecHitCollection::range dRecHits = theDTRecHits->get(lid);
-              int layerHits=0;
-              for (DTRecHitCollection::const_iterator ir = dRecHits.first; ir != dRecHits.second; ir++ ) {
-          	double rhitDistance = fabs(ir->localPosition().x()-(**hit1d).localPosition().x());
-        	if ( rhitDistance < coneSize ) layerHits++;
+              int layerHits = 0;
+              for (DTRecHitCollection::const_iterator ir = dRecHits.first; ir != dRecHits.second; ir++) {
+                double rhitDistance = fabs(ir->localPosition().x() - (**hit1d).localPosition().x());
+                if (rhitDistance < coneSize)
+                  layerHits++;
                 LogTrace(theCategory) << "       " << (ir)->localPosition() << "  " << (**hit1d).localPosition()
-                     << " Distance: " << rhitDistance << " recHits: " << layerHits << "  SL: " << lid.superLayer() << endl;
+                                      << " Distance: " << rhitDistance << " recHits: " << layerHits
+                                      << "  SL: " << lid.superLayer() << endl;
               }
-              if (layerHits>detRecHits) detRecHits=layerHits;
+              if (layerHits > detRecHits)
+                detRecHits = layerHits;
             }
           } else {
-	    DTLayerId lid(id.rawId());
-	    // Get the 1d DT RechHits from this layer
-	    DTRecHitCollection::range dRecHits = theDTRecHits->get(lid);
-	    for (DTRecHitCollection::const_iterator ir = dRecHits.first; ir != dRecHits.second; ir++ ) {
-	      double rhitDistance = fabs(ir->localPosition().x()-(**imrh).localPosition().x());
-	      if ( rhitDistance < coneSize ) detRecHits++;
-	      LogTrace(theCategory)<< "       " << (ir)->localPosition() << "  " << (**imrh).localPosition()
-				   << " Distance: " << rhitDistance << " recHits: " << detRecHits << endl;
-	    }
-	  }
+            DTLayerId lid(id.rawId());
+            // Get the 1d DT RechHits from this layer
+            DTRecHitCollection::range dRecHits = theDTRecHits->get(lid);
+            for (DTRecHitCollection::const_iterator ir = dRecHits.first; ir != dRecHits.second; ir++) {
+              double rhitDistance = fabs(ir->localPosition().x() - (**imrh).localPosition().x());
+              if (rhitDistance < coneSize)
+                detRecHits++;
+              LogTrace(theCategory) << "       " << (ir)->localPosition() << "  " << (**imrh).localPosition()
+                                    << " Distance: " << rhitDistance << " recHits: " << detRecHits << endl;
+            }
+          }
         }
 
       } else {
@@ -377,209 +373,232 @@ void GlobalMuonRefitter::checkMuonHits(const reco::Track& muon,
         // Get the 1d DT RechHits from this layer
         DTRecHitCollection::range dRecHits = theDTRecHits->get(lid);
 
-        for (DTRecHitCollection::const_iterator ir = dRecHits.first; ir != dRecHits.second; ir++ ) {
-  	  double rhitDistance = fabs(ir->localPosition().x()-(**imrh).localPosition().x());
-  	  if ( rhitDistance < coneSize ) detRecHits++;
-          LogTrace(theCategory)	<< "       " << (ir)->localPosition() << "  " << (**imrh).localPosition()
-               << " Distance: " << rhitDistance << " recHits: " << detRecHits << endl;
+        for (DTRecHitCollection::const_iterator ir = dRecHits.first; ir != dRecHits.second; ir++) {
+          double rhitDistance = fabs(ir->localPosition().x() - (**imrh).localPosition().x());
+          if (rhitDistance < coneSize)
+            detRecHits++;
+          LogTrace(theCategory) << "       " << (ir)->localPosition() << "  " << (**imrh).localPosition()
+                                << " Distance: " << rhitDistance << " recHits: " << detRecHits << endl;
         }
       }
-    }// end of if DT
-    else if ( id.subdetId() == MuonSubdetId::CSC ) {
+    }  // end of if DT
+    else if (id.subdetId() == MuonSubdetId::CSC) {
       CSCDetId did(id.rawId());
-      chamberId=did.chamberId();
+      chamberId = did.chamberId();
 
-      if ((*imrh)->recHits().size()>1) {
-        std::vector <const TrackingRecHit*> hits2d = (*imrh)->recHits();
-        for (std::vector <const TrackingRecHit*>::const_iterator hit2d = hits2d.begin(); hit2d!= hits2d.end(); hit2d++) {
+      if ((*imrh)->recHits().size() > 1) {
+        std::vector<const TrackingRecHit*> hits2d = (*imrh)->recHits();
+        for (std::vector<const TrackingRecHit*>::const_iterator hit2d = hits2d.begin(); hit2d != hits2d.end();
+             hit2d++) {
           DetId id1 = (*hit2d)->geographicalId();
           CSCDetId lid(id1.rawId());
 
           // Get the CSC Rechits from this layer
           CSCRecHit2DCollection::range dRecHits = theCSCRecHits->get(lid);
-          int layerHits=0;
+          int layerHits = 0;
 
-          for (CSCRecHit2DCollection::const_iterator ir = dRecHits.first; ir != dRecHits.second; ir++ ) {
-    	    double rhitDistance = (ir->localPosition()-(**hit2d).localPosition()).mag();
-  	    if ( rhitDistance < coneSize ) layerHits++;
+          for (CSCRecHit2DCollection::const_iterator ir = dRecHits.first; ir != dRecHits.second; ir++) {
+            double rhitDistance = (ir->localPosition() - (**hit2d).localPosition()).mag();
+            if (rhitDistance < coneSize)
+              layerHits++;
             LogTrace(theCategory) << ir->localPosition() << "  " << (**hit2d).localPosition()
-  	           << " Distance: " << rhitDistance << " recHits: " << layerHits << endl;
+                                  << " Distance: " << rhitDistance << " recHits: " << layerHits << endl;
           }
-          if (layerHits>detRecHits) detRecHits=layerHits;
+          if (layerHits > detRecHits)
+            detRecHits = layerHits;
         }
       } else {
         // Get the CSC Rechits from this layer
         CSCRecHit2DCollection::range dRecHits = theCSCRecHits->get(did);
 
-        for (CSCRecHit2DCollection::const_iterator ir = dRecHits.first; ir != dRecHits.second; ir++ ) {
-  	  double rhitDistance = (ir->localPosition()-(**imrh).localPosition()).mag();
-	  if ( rhitDistance < coneSize ) detRecHits++;
+        for (CSCRecHit2DCollection::const_iterator ir = dRecHits.first; ir != dRecHits.second; ir++) {
+          double rhitDistance = (ir->localPosition() - (**imrh).localPosition()).mag();
+          if (rhitDistance < coneSize)
+            detRecHits++;
           LogTrace(theCategory) << ir->localPosition() << "  " << (**imrh).localPosition()
-	         << " Distance: " << rhitDistance << " recHits: " << detRecHits << endl;
+                                << " Distance: " << rhitDistance << " recHits: " << detRecHits << endl;
         }
       }
-    } //end of CSC if
-    else if ( id.subdetId() == MuonSubdetId::GEM ) {
+    }  //end of CSC if
+    else if (id.subdetId() == MuonSubdetId::GEM) {
       GEMDetId did(id.rawId());
-      chamberId=did.chamberId();
+      chamberId = did.chamberId();
 
-      if ((*imrh)->recHits().size()>1) {
-        std::vector <const TrackingRecHit*> hits2d = (*imrh)->recHits();
-        for (std::vector <const TrackingRecHit*>::const_iterator hit2d = hits2d.begin(); hit2d!= hits2d.end(); hit2d++) {
+      if ((*imrh)->recHits().size() > 1) {
+        std::vector<const TrackingRecHit*> hits2d = (*imrh)->recHits();
+        for (std::vector<const TrackingRecHit*>::const_iterator hit2d = hits2d.begin(); hit2d != hits2d.end();
+             hit2d++) {
           DetId id1 = (*hit2d)->geographicalId();
           GEMDetId lid(id1.rawId());
 
           // Get the GEM Rechits from this layer
           GEMRecHitCollection::range dRecHits = theGEMRecHits->get(lid);
-          int layerHits=0;
+          int layerHits = 0;
 
-          for (GEMRecHitCollection::const_iterator ir = dRecHits.first; ir != dRecHits.second; ir++ ) {
-            double rhitDistance = (ir->localPosition()-(**hit2d).localPosition()).mag();
-            if ( rhitDistance < coneSize ) layerHits++;
+          for (GEMRecHitCollection::const_iterator ir = dRecHits.first; ir != dRecHits.second; ir++) {
+            double rhitDistance = (ir->localPosition() - (**hit2d).localPosition()).mag();
+            if (rhitDistance < coneSize)
+              layerHits++;
             LogTrace(theCategory) << ir->localPosition() << "  " << (**hit2d).localPosition()
-                   << " Distance: " << rhitDistance << " recHits: " << layerHits << endl;
+                                  << " Distance: " << rhitDistance << " recHits: " << layerHits << endl;
           }
-          if (layerHits>detRecHits) detRecHits=layerHits;
+          if (layerHits > detRecHits)
+            detRecHits = layerHits;
         }
       } else {
         // Get the GEM Rechits from this layer
         GEMRecHitCollection::range dRecHits = theGEMRecHits->get(did);
 
-        for (GEMRecHitCollection::const_iterator ir = dRecHits.first; ir != dRecHits.second; ir++ ) {
-          double rhitDistance = (ir->localPosition()-(**imrh).localPosition()).mag();
-          if ( rhitDistance < coneSize ) detRecHits++;
+        for (GEMRecHitCollection::const_iterator ir = dRecHits.first; ir != dRecHits.second; ir++) {
+          double rhitDistance = (ir->localPosition() - (**imrh).localPosition()).mag();
+          if (rhitDistance < coneSize)
+            detRecHits++;
           LogTrace(theCategory) << ir->localPosition() << "  " << (**imrh).localPosition()
-                 << " Distance: " << rhitDistance << " recHits: " << detRecHits << endl;
+                                << " Distance: " << rhitDistance << " recHits: " << detRecHits << endl;
         }
       }
-    } //end of GEM if
-    else if ( id.subdetId() == MuonSubdetId::ME0 ) {
+    }  //end of GEM if
+    else if (id.subdetId() == MuonSubdetId::ME0) {
       ME0DetId did(id.rawId());
-      chamberId=did.chamberId();
+      chamberId = did.chamberId();
 
-      if ((*imrh)->recHits().size()>1) {
-        std::vector <const TrackingRecHit*> hits2d = (*imrh)->recHits();
-        for (std::vector <const TrackingRecHit*>::const_iterator hit2d = hits2d.begin(); hit2d!= hits2d.end(); hit2d++) {
+      if ((*imrh)->recHits().size() > 1) {
+        std::vector<const TrackingRecHit*> hits2d = (*imrh)->recHits();
+        for (std::vector<const TrackingRecHit*>::const_iterator hit2d = hits2d.begin(); hit2d != hits2d.end();
+             hit2d++) {
           DetId id1 = (*hit2d)->geographicalId();
           ME0DetId lid(id1.rawId());
 
           // Get the ME0 Rechits from this layer
           ME0SegmentCollection::range dRecHits = theME0RecHits->get(lid);
-          int layerHits=0;
+          int layerHits = 0;
 
-          for (ME0SegmentCollection::const_iterator ir = dRecHits.first; ir != dRecHits.second; ir++ ) {
-            double rhitDistance = (ir->localPosition()-(**hit2d).localPosition()).mag();
-            if ( rhitDistance < coneSize ) layerHits++;
+          for (ME0SegmentCollection::const_iterator ir = dRecHits.first; ir != dRecHits.second; ir++) {
+            double rhitDistance = (ir->localPosition() - (**hit2d).localPosition()).mag();
+            if (rhitDistance < coneSize)
+              layerHits++;
             LogTrace(theCategory) << ir->localPosition() << "  " << (**hit2d).localPosition()
-                   << " Distance: " << rhitDistance << " recHits: " << layerHits << endl;
+                                  << " Distance: " << rhitDistance << " recHits: " << layerHits << endl;
           }
-          if (layerHits>detRecHits) detRecHits=layerHits;
+          if (layerHits > detRecHits)
+            detRecHits = layerHits;
         }
       } else {
         // Get the ME0 Rechits from this layer
         ME0SegmentCollection::range dRecHits = theME0RecHits->get(did);
 
-        for (ME0SegmentCollection::const_iterator ir = dRecHits.first; ir != dRecHits.second; ir++ ) {
-          double rhitDistance = (ir->localPosition()-(**imrh).localPosition()).mag();
-          if ( rhitDistance < coneSize ) detRecHits++;
+        for (ME0SegmentCollection::const_iterator ir = dRecHits.first; ir != dRecHits.second; ir++) {
+          double rhitDistance = (ir->localPosition() - (**imrh).localPosition()).mag();
+          if (rhitDistance < coneSize)
+            detRecHits++;
           LogTrace(theCategory) << ir->localPosition() << "  " << (**imrh).localPosition()
-                 << " Distance: " << rhitDistance << " recHits: " << detRecHits << endl;
+                                << " Distance: " << rhitDistance << " recHits: " << detRecHits << endl;
         }
       }
-    } //end of ME0 if
+    }  //end of ME0 if
     else {
-      if ( id.subdetId() != MuonSubdetId::RPC ) LogError(theCategory)<<" Wrong Hit Type ";
+      if (id.subdetId() != MuonSubdetId::RPC)
+        LogError(theCategory) << " Wrong Hit Type ";
       continue;
     }
 
-    map<DetId,int>::iterator imap=hitMap.find(chamberId);
-    if (imap!=hitMap.end()) {
-      if (detRecHits>imap->second) imap->second=detRecHits;
-    } else hitMap[chamberId]=detRecHits;
+    map<DetId, int>::iterator imap = hitMap.find(chamberId);
+    if (imap != hitMap.end()) {
+      if (detRecHits > imap->second)
+        imap->second = detRecHits;
+    } else
+      hitMap[chamberId] = detRecHits;
 
-  } // end of loop over muon rechits
+  }  // end of loop over muon rechits
 
-  for (map<DetId,int>::iterator imap=hitMap.begin(); imap!=hitMap.end(); imap++ ) 
-    LogTrace(theCategory) << " Station " << imap->first.rawId() << ": " << imap->second <<endl; 
+  for (map<DetId, int>::iterator imap = hitMap.begin(); imap != hitMap.end(); imap++)
+    LogTrace(theCategory) << " Station " << imap->first.rawId() << ": " << imap->second << endl;
 
-  LogTrace(theCategory) << "CheckMuonHits: "<<all.size();
+  LogTrace(theCategory) << "CheckMuonHits: " << all.size();
 
   // check order of muon measurements
-  if ( (all.size() > 1) &&
-       ( all.front()->globalPosition().mag() >
-	 all.back()->globalPosition().mag() ) ) {
-    LogTrace(theCategory)<< "reverse order: ";
-    stable_sort(all.begin(),all.end(),RecHitLessByDet(alongMomentum));
+  if ((all.size() > 1) && (all.front()->globalPosition().mag() > all.back()->globalPosition().mag())) {
+    LogTrace(theCategory) << "reverse order: ";
+    stable_sort(all.begin(), all.end(), RecHitLessByDet(alongMomentum));
   }
 }
-
 
 //
 // Get the hits from the first muon station (containing hits)
 //
-void GlobalMuonRefitter::getFirstHits(const reco::Track& muon, 
-				       ConstRecHitContainer& all,
-				       ConstRecHitContainer& first) const {
-
+void GlobalMuonRefitter::getFirstHits(const reco::Track& muon,
+                                      ConstRecHitContainer& all,
+                                      ConstRecHitContainer& first) const {
   LogTrace(theCategory) << " GlobalMuonRefitter::getFirstHits\nall rechits length:" << all.size() << endl;
   first.clear();
 
   int station_to_keep = 999;
   vector<int> stations;
   for (ConstRecHitContainer::const_iterator ihit = all.begin(); ihit != all.end(); ++ihit) {
-
     int station = 0;
     bool use_it = true;
     DetId id = (*ihit)->geographicalId();
     unsigned raw_id = id.rawId();
-    if (!(*ihit)->isValid()) station = -1;
-          else {
-	if (id.det() == DetId::Muon) {
-	  switch (id.subdetId()) {
-	  case MuonSubdetId::DT:  station = DTChamberId(raw_id).station(); break;
-	  case MuonSubdetId::CSC: station = CSCDetId(raw_id).station(); break;
-          case MuonSubdetId::GEM: station = GEMDetId(raw_id).station(); break;
-	  case MuonSubdetId::ME0: station = ME0DetId(raw_id).station(); break;
-	  case MuonSubdetId::RPC: station = RPCDetId(raw_id).station(); use_it = false; break;
-	  }
-	}
+    if (!(*ihit)->isValid())
+      station = -1;
+    else {
+      if (id.det() == DetId::Muon) {
+        switch (id.subdetId()) {
+          case MuonSubdetId::DT:
+            station = DTChamberId(raw_id).station();
+            break;
+          case MuonSubdetId::CSC:
+            station = CSCDetId(raw_id).station();
+            break;
+          case MuonSubdetId::GEM:
+            station = GEMDetId(raw_id).station();
+            break;
+          case MuonSubdetId::ME0:
+            station = ME0DetId(raw_id).station();
+            break;
+          case MuonSubdetId::RPC:
+            station = RPCDetId(raw_id).station();
+            use_it = false;
+            break;
+        }
       }
+    }
 
-
-    if (use_it && station > 0 && station < station_to_keep) station_to_keep = station;
+    if (use_it && station > 0 && station < station_to_keep)
+      station_to_keep = station;
     stations.push_back(station);
-    LogTrace(theCategory) << "rawId: " << raw_id << " station = " << station << " station_to_keep is now " << station_to_keep;
+    LogTrace(theCategory) << "rawId: " << raw_id << " station = " << station << " station_to_keep is now "
+                          << station_to_keep;
   }
 
   if (station_to_keep <= 0 || station_to_keep > 4 || stations.size() != all.size())
-    LogInfo(theCategory) << "failed to getFirstHits (all muon hits are outliers/bad ?)! station_to_keep = " 
-			    << station_to_keep << " stations.size " << stations.size() << " all.size " << all.size();
+    LogInfo(theCategory) << "failed to getFirstHits (all muon hits are outliers/bad ?)! station_to_keep = "
+                         << station_to_keep << " stations.size " << stations.size() << " all.size " << all.size();
 
   for (unsigned i = 0; i < stations.size(); ++i)
-    if (stations[i] >= 0 && stations[i] <= station_to_keep) first.push_back(all[i]);
+    if (stations[i] >= 0 && stations[i] <= station_to_keep)
+      first.push_back(all[i]);
 
   return;
 }
 
-
 //
-// select muon hits compatible with trajectory; 
+// select muon hits compatible with trajectory;
 // check hits in chambers with showers
 //
-GlobalMuonRefitter::ConstRecHitContainer 
-GlobalMuonRefitter::selectMuonHits(const Trajectory& traj, 
-                                   const map<DetId, int> &hitMap) const {
-
+GlobalMuonRefitter::ConstRecHitContainer GlobalMuonRefitter::selectMuonHits(const Trajectory& traj,
+                                                                            const map<DetId, int>& hitMap) const {
   ConstRecHitContainer muonRecHits;
   const double globalChi2Cut = 200.0;
 
-  vector<TrajectoryMeasurement> muonMeasurements = traj.measurements(); 
+  vector<TrajectoryMeasurement> muonMeasurements = traj.measurements();
 
   // loop through all muon hits and skip hits with bad chi2 in chambers with high occupancy
-  for (std::vector<TrajectoryMeasurement>::const_iterator im = muonMeasurements.begin(); im != muonMeasurements.end(); im++ ) {
-
-    if ( !(*im).recHit()->isValid() ) continue;
-    if ( (*im).recHit()->det()->geographicalId().det() != DetId::Muon ) {
+  for (std::vector<TrajectoryMeasurement>::const_iterator im = muonMeasurements.begin(); im != muonMeasurements.end();
+       im++) {
+    if (!(*im).recHit()->isValid())
+      continue;
+    if ((*im).recHit()->det()->geographicalId().det() != DetId::Muon) {
       //      if ( ( chi2ndf < globalChi2Cut ) )
       muonRecHits.push_back((*im).recHit());
       continue;
@@ -592,35 +611,35 @@ GlobalMuonRefitter::selectMuonHits(const Trajectory& traj,
     double chi2Cut = 0.0;
 
     // get station of hit if it is in DT
-    if ( (*immrh).isDT() ) {
+    if ((*immrh).isDT()) {
       DTChamberId did(id.rawId());
       chamberId = did;
       threshold = theHitThreshold;
       chi2Cut = theDTChi2Cut;
     }
     // get station of hit if it is in CSC
-    else if ( (*immrh).isCSC() ) {
+    else if ((*immrh).isCSC()) {
       CSCDetId did(id.rawId());
       chamberId = did.chamberId();
       threshold = theHitThreshold;
       chi2Cut = theCSCChi2Cut;
     }
     // get station of hit if it is in GEM
-    else if ( (*immrh).isGEM() ) {
+    else if ((*immrh).isGEM()) {
       GEMDetId did(id.rawId());
       chamberId = did.chamberId();
       threshold = theHitThreshold;
       chi2Cut = theGEMChi2Cut;
     }
     // get station of hit if it is in ME0
-    else if ( (*immrh).isME0() ) {
+    else if ((*immrh).isME0()) {
       ME0DetId did(id.rawId());
       chamberId = did.chamberId();
       threshold = theHitThreshold;
       chi2Cut = theME0Chi2Cut;
     }
     // get station of hit if it is in RPC
-    else if ( (*immrh).isRPC() ) {
+    else if ((*immrh).isRPC()) {
       RPCDetId rpcid(id.rawId());
       chamberId = rpcid;
       threshold = theHitThreshold;
@@ -628,137 +647,134 @@ GlobalMuonRefitter::selectMuonHits(const Trajectory& traj,
     } else
       continue;
 
-    double chi2ndf = (*im).estimate()/(*im).recHit()->dimension();  
+    double chi2ndf = (*im).estimate() / (*im).recHit()->dimension();
 
     bool keep = true;
-    map<DetId,int>::const_iterator imap=hitMap.find(chamberId);
-    if ( imap!=hitMap.end() ) 
-      if (imap->second>threshold) keep = false;
+    map<DetId, int>::const_iterator imap = hitMap.find(chamberId);
+    if (imap != hitMap.end())
+      if (imap->second > threshold)
+        keep = false;
 
-    if ( (keep || (chi2ndf<chi2Cut)) && (chi2ndf<globalChi2Cut) ) {
+    if ((keep || (chi2ndf < chi2Cut)) && (chi2ndf < globalChi2Cut)) {
       muonRecHits.push_back((*im).recHit());
     } else {
-      LogTrace(theCategory)
-	<< "Skip hit: " << id.rawId() << " chi2=" 
-	<< chi2ndf << " ( threshold: " << chi2Cut << ") Det: " 
-	<< imap->second << endl;
+      LogTrace(theCategory) << "Skip hit: " << id.rawId() << " chi2=" << chi2ndf << " ( threshold: " << chi2Cut
+                            << ") Det: " << imap->second << endl;
     }
   }
 
   // check order of rechits
-  reverse(muonRecHits.begin(),muonRecHits.end());
+  reverse(muonRecHits.begin(), muonRecHits.end());
   return muonRecHits;
 }
-
 
 //
 // print RecHits
 //
 void GlobalMuonRefitter::printHits(const ConstRecHitContainer& hits) const {
-
   LogTrace(theCategory) << "Used RecHits: " << hits.size();
-  for (ConstRecHitContainer::const_iterator ir = hits.begin(); ir != hits.end(); ir++ ) {
-    if ( !(*ir)->isValid() ) {
+  for (ConstRecHitContainer::const_iterator ir = hits.begin(); ir != hits.end(); ir++) {
+    if (!(*ir)->isValid()) {
       LogTrace(theCategory) << "invalid RecHit";
-      continue; 
+      continue;
     }
 
     const GlobalPoint& pos = (*ir)->globalPosition();
 
-    LogTrace(theCategory) 
-      << "r = " << sqrt(pos.x() * pos.x() + pos.y() * pos.y())
-      << "  z = " << pos.z()
-      << "  dimension = " << (*ir)->dimension()
-      << "  det = " << (*ir)->det()->geographicalId().det()
-      << "  subdet = " << (*ir)->det()->subDetector()
-      << "  raw id = " << (*ir)->det()->geographicalId().rawId();
+    LogTrace(theCategory) << "r = " << sqrt(pos.x() * pos.x() + pos.y() * pos.y()) << "  z = " << pos.z()
+                          << "  dimension = " << (*ir)->dimension()
+                          << "  det = " << (*ir)->det()->geographicalId().det()
+                          << "  subdet = " << (*ir)->det()->subDetector()
+                          << "  raw id = " << (*ir)->det()->geographicalId().rawId();
   }
-
 }
-
 
 //
 // add Trajectory* to TrackCand if not already present
 //
-GlobalMuonRefitter::RefitDirection
-GlobalMuonRefitter::checkRecHitsOrdering(const TransientTrackingRecHit::ConstRecHitContainer& recHits) const {
-
-  if (!recHits.empty()){
+GlobalMuonRefitter::RefitDirection GlobalMuonRefitter::checkRecHitsOrdering(
+    const TransientTrackingRecHit::ConstRecHitContainer& recHits) const {
+  if (!recHits.empty()) {
     ConstRecHitContainer::const_iterator frontHit = recHits.begin();
-    ConstRecHitContainer::const_iterator backHit  = recHits.end() - 1;
-    while( !(*frontHit)->isValid() && frontHit != backHit) {frontHit++;}
-    while( !(*backHit)->isValid() && backHit != frontHit)  {backHit--;}
+    ConstRecHitContainer::const_iterator backHit = recHits.end() - 1;
+    while (!(*frontHit)->isValid() && frontHit != backHit) {
+      frontHit++;
+    }
+    while (!(*backHit)->isValid() && backHit != frontHit) {
+      backHit--;
+    }
 
     double rFirst = (*frontHit)->globalPosition().mag();
-    double rLast  = (*backHit) ->globalPosition().mag();
+    double rLast = (*backHit)->globalPosition().mag();
 
-    if(rFirst < rLast) return insideOut;
-    else if(rFirst > rLast) return outsideIn;
+    if (rFirst < rLast)
+      return insideOut;
+    else if (rFirst > rLast)
+      return outsideIn;
     else {
-      LogError(theCategory) << "Impossible determine the rechits order" <<endl;
+      LogError(theCategory) << "Impossible determine the rechits order" << endl;
       return undetermined;
     }
   } else {
-    LogError(theCategory) << "Impossible determine the rechits order" <<endl;
+    LogError(theCategory) << "Impossible determine the rechits order" << endl;
     return undetermined;
   }
 }
 
-
 //
 // Convert Tracks into Trajectories with a given set of hits
 //
-vector<Trajectory> GlobalMuonRefitter::transform(const reco::Track& newTrack,
-						 const reco::TransientTrack track,
-						 const TransientTrackingRecHit::ConstRecHitContainer& urecHitsForReFit) const {
-
+vector<Trajectory> GlobalMuonRefitter::transform(
+    const reco::Track& newTrack,
+    const reco::TransientTrack track,
+    const TransientTrackingRecHit::ConstRecHitContainer& urecHitsForReFit) const {
   TransientTrackingRecHit::ConstRecHitContainer recHitsForReFit = urecHitsForReFit;
   LogTrace(theCategory) << "GlobalMuonRefitter::transform: " << recHitsForReFit.size() << " hits:";
   printHits(recHitsForReFit);
 
-  if(recHitsForReFit.size() < 2) return vector<Trajectory>();
+  if (recHitsForReFit.size() < 2)
+    return vector<Trajectory>();
 
   // Check the order of the rechits
   RefitDirection recHitsOrder = checkRecHitsOrdering(recHitsForReFit);
 
-  LogTrace(theCategory) << "checkRecHitsOrdering() returned " << recHitsOrder
-			<< ", theRefitDirection is " << theRefitDirection
-			<< " (insideOut == " << insideOut << ", outsideIn == " << outsideIn << ")";
+  LogTrace(theCategory) << "checkRecHitsOrdering() returned " << recHitsOrder << ", theRefitDirection is "
+                        << theRefitDirection << " (insideOut == " << insideOut << ", outsideIn == " << outsideIn << ")";
 
   // Reverse the order in the case of inconsistency between the fit direction and the rechit order
-  if(theRefitDirection != recHitsOrder) reverse(recHitsForReFit.begin(),recHitsForReFit.end());
+  if (theRefitDirection != recHitsOrder)
+    reverse(recHitsForReFit.begin(), recHitsForReFit.end());
 
   // Even though we checked the rechits' ordering above, we may have
   // already flipped them elsewhere (getFirstHits() is such a
   // culprit). Use the global positions of the states and the desired
   // refit direction to find the starting TSOS.
   TrajectoryStateOnSurface firstTSOS, lastTSOS;
-  unsigned int innerId; //UNUSED: outerId;
-  bool order_swapped = track.outermostMeasurementState().globalPosition().mag() < track.innermostMeasurementState().globalPosition().mag();
+  unsigned int innerId;  //UNUSED: outerId;
+  bool order_swapped = track.outermostMeasurementState().globalPosition().mag() <
+                       track.innermostMeasurementState().globalPosition().mag();
   bool inner_is_first;
   LogTrace(theCategory) << "order swapped? " << order_swapped;
 
   // Fill the starting state, depending on the ordering above.
   if ((theRefitDirection == insideOut && !order_swapped) || (theRefitDirection == outsideIn && order_swapped)) {
-    innerId   = newTrack.innerDetId();
+    innerId = newTrack.innerDetId();
     //UNUSED:    outerId   = newTrack.outerDetId();
     firstTSOS = track.innermostMeasurementState();
-    lastTSOS  = track.outermostMeasurementState();
+    lastTSOS = track.outermostMeasurementState();
     inner_is_first = true;
-  }
-  else {
-    innerId   = newTrack.outerDetId();
+  } else {
+    innerId = newTrack.outerDetId();
     //UNUSED:    outerId   = newTrack.innerDetId();
     firstTSOS = track.outermostMeasurementState();
-    lastTSOS  = track.innermostMeasurementState();
+    lastTSOS = track.innermostMeasurementState();
     inner_is_first = false;
   }
 
-  LogTrace(theCategory) << "firstTSOS: inner_is_first? " << inner_is_first
-			<< " globalPosition is " << firstTSOS.globalPosition()
-			<< " innerId is " << innerId;
+  LogTrace(theCategory) << "firstTSOS: inner_is_first? " << inner_is_first << " globalPosition is "
+                        << firstTSOS.globalPosition() << " innerId is " << innerId;
 
-  if(!firstTSOS.isValid()){
+  if (!firstTSOS.isValid()) {
     LogWarning(theCategory) << "Error wrong initial state!" << endl;
     return vector<Trajectory>();
   }
@@ -771,41 +787,55 @@ vector<Trajectory> GlobalMuonRefitter::transform(const reco::Track& newTrack,
 
   // These lines cause the code to ignore completely what was set
   // above, and force propDir for tracks from collisions!
-//  if(propDir == alongMomentum && theRefitDirection == outsideIn)  propDir=oppositeToMomentum;
-//  if(propDir == oppositeToMomentum && theRefitDirection == insideOut) propDir=alongMomentum;
+  //  if(propDir == alongMomentum && theRefitDirection == outsideIn)  propDir=oppositeToMomentum;
+  //  if(propDir == oppositeToMomentum && theRefitDirection == insideOut) propDir=alongMomentum;
 
   const TrajectoryStateOnSurface& tsosForDir = inner_is_first ? lastTSOS : firstTSOS;
-  PropagationDirection propDir = (tsosForDir.globalPosition().basicVector().dot(tsosForDir.globalMomentum().basicVector())>0) ? alongMomentum : oppositeToMomentum;
-  LogTrace(theCategory) << "propDir based on firstTSOS x dot p is " << propDir
-			<< " (alongMomentum == " << alongMomentum << ", oppositeToMomentum == " << oppositeToMomentum << ")";
+  PropagationDirection propDir =
+      (tsosForDir.globalPosition().basicVector().dot(tsosForDir.globalMomentum().basicVector()) > 0)
+          ? alongMomentum
+          : oppositeToMomentum;
+  LogTrace(theCategory) << "propDir based on firstTSOS x dot p is " << propDir << " (alongMomentum == " << alongMomentum
+                        << ", oppositeToMomentum == " << oppositeToMomentum << ")";
 
   // Additional propagation diretcion determination logic for cosmic muons
   if (theCosmicFlag) {
-    PropagationDirection propDir_first = (firstTSOS.globalPosition().basicVector().dot(firstTSOS.globalMomentum().basicVector()) > 0) ? alongMomentum : oppositeToMomentum;
-    PropagationDirection propDir_last  = (lastTSOS .globalPosition().basicVector().dot(lastTSOS .globalMomentum().basicVector()) > 0) ? alongMomentum : oppositeToMomentum;
-    LogTrace(theCategory) << "propDir_first " << propDir_first << ", propdir_last " << propDir_last
-			  << " : they " << (propDir_first == propDir_last ? "agree" : "disagree");
+    PropagationDirection propDir_first =
+        (firstTSOS.globalPosition().basicVector().dot(firstTSOS.globalMomentum().basicVector()) > 0)
+            ? alongMomentum
+            : oppositeToMomentum;
+    PropagationDirection propDir_last =
+        (lastTSOS.globalPosition().basicVector().dot(lastTSOS.globalMomentum().basicVector()) > 0) ? alongMomentum
+                                                                                                   : oppositeToMomentum;
+    LogTrace(theCategory) << "propDir_first " << propDir_first << ", propdir_last " << propDir_last << " : they "
+                          << (propDir_first == propDir_last ? "agree" : "disagree");
 
     int y_count = 0;
-    for (TransientTrackingRecHit::ConstRecHitContainer::const_iterator it = recHitsForReFit.begin(); it != recHitsForReFit.end(); ++it) {
-      if ((*it)->globalPosition().y() > 0) ++y_count;
-      else --y_count;
+    for (TransientTrackingRecHit::ConstRecHitContainer::const_iterator it = recHitsForReFit.begin();
+         it != recHitsForReFit.end();
+         ++it) {
+      if ((*it)->globalPosition().y() > 0)
+        ++y_count;
+      else
+        --y_count;
     }
 
     PropagationDirection propDir_ycount = alongMomentum;
     if (y_count > 0) {
-      if      (theRefitDirection == insideOut) propDir_ycount = oppositeToMomentum;
-      else if (theRefitDirection == outsideIn) propDir_ycount = alongMomentum;
-    }
-    else {
-      if      (theRefitDirection == insideOut) propDir_ycount = alongMomentum;
-      else if (theRefitDirection == outsideIn) propDir_ycount = oppositeToMomentum;
+      if (theRefitDirection == insideOut)
+        propDir_ycount = oppositeToMomentum;
+      else if (theRefitDirection == outsideIn)
+        propDir_ycount = alongMomentum;
+    } else {
+      if (theRefitDirection == insideOut)
+        propDir_ycount = alongMomentum;
+      else if (theRefitDirection == outsideIn)
+        propDir_ycount = oppositeToMomentum;
     }
 
-    LogTrace(theCategory) << "y_count = " << y_count
-			  << "; based on geometrically-outermost TSOS, propDir is " << propDir << ": "
-			  << (propDir == propDir_ycount ? "agrees" : "disagrees")
-			  << " with ycount determination";
+    LogTrace(theCategory) << "y_count = " << y_count << "; based on geometrically-outermost TSOS, propDir is "
+                          << propDir << ": " << (propDir == propDir_ycount ? "agrees" : "disagrees")
+                          << " with ycount determination";
 
     if (propDir_first != propDir_last) {
       LogTrace(theCategory) << "since first/last disagreed, using y_count propDir";
@@ -813,118 +843,109 @@ vector<Trajectory> GlobalMuonRefitter::transform(const reco::Track& newTrack,
     }
   }
 
-  TrajectorySeed seed(garbage1,garbage2,propDir);
+  TrajectorySeed seed(garbage1, garbage2, propDir);
 
-  if(recHitsForReFit.front()->geographicalId() != DetId(innerId)){
-    LogDebug(theCategory)<<"Propagation occured"<<endl;
+  if (recHitsForReFit.front()->geographicalId() != DetId(innerId)) {
+    LogDebug(theCategory) << "Propagation occured" << endl;
     LogTrace(theCategory) << "propagating firstTSOS at " << firstTSOS.globalPosition()
-			  << " to first rechit with surface pos " << recHitsForReFit.front()->det()->surface().toGlobal(LocalPoint(0,0,0));
-    firstTSOS = theService->propagator(thePropagatorName)->propagate(firstTSOS, recHitsForReFit.front()->det()->surface());
-    if(!firstTSOS.isValid()){
-      LogDebug(theCategory)<<"Propagation error!"<<endl;
+                          << " to first rechit with surface pos "
+                          << recHitsForReFit.front()->det()->surface().toGlobal(LocalPoint(0, 0, 0));
+    firstTSOS =
+        theService->propagator(thePropagatorName)->propagate(firstTSOS, recHitsForReFit.front()->det()->surface());
+    if (!firstTSOS.isValid()) {
+      LogDebug(theCategory) << "Propagation error!" << endl;
       return vector<Trajectory>();
     }
   }
 
-
   LogDebug(theCategory) << " GlobalMuonRefitter : theFitter " << propDir << endl;
-  LogDebug(theCategory) << "                      First TSOS: "
-       << firstTSOS.globalPosition() << "  p="
-       << firstTSOS.globalMomentum() << " = "
-       << firstTSOS.globalMomentum().mag() << endl;
+  LogDebug(theCategory) << "                      First TSOS: " << firstTSOS.globalPosition()
+                        << "  p=" << firstTSOS.globalMomentum() << " = " << firstTSOS.globalMomentum().mag() << endl;
 
   LogDebug(theCategory) << "                      Starting seed: "
-       << " nHits= " << seed.nHits()
-       << " tsos: "
-       << seed.startingState().parameters().position() << "  p="
-       << seed.startingState().parameters().momentum() << endl;
+                        << " nHits= " << seed.nHits() << " tsos: " << seed.startingState().parameters().position()
+                        << "  p=" << seed.startingState().parameters().momentum() << endl;
 
-  LogDebug(theCategory) << "                      RecHits: "
-       << recHitsForReFit.size() << endl;
+  LogDebug(theCategory) << "                      RecHits: " << recHitsForReFit.size() << endl;
 
-  vector<Trajectory> trajectories = theFitter->fit(seed,recHitsForReFit,firstTSOS);
+  vector<Trajectory> trajectories = theFitter->fit(seed, recHitsForReFit, firstTSOS);
 
-  if(trajectories.empty()){
+  if (trajectories.empty()) {
     LogDebug(theCategory) << "No Track refitted!" << endl;
     return vector<Trajectory>();
   }
   return trajectories;
 }
 
-
 //
 // Remove Selected Station Rec Hits
 //
-GlobalMuonRefitter::ConstRecHitContainer GlobalMuonRefitter::getRidOfSelectStationHits(const ConstRecHitContainer& hits,
-										       const TrackerTopology *tTopo) const
-{
+GlobalMuonRefitter::ConstRecHitContainer GlobalMuonRefitter::getRidOfSelectStationHits(
+    const ConstRecHitContainer& hits, const TrackerTopology* tTopo) const {
   ConstRecHitContainer results;
   ConstRecHitContainer::const_iterator it = hits.begin();
-  for (; it!=hits.end(); it++) {
-
+  for (; it != hits.end(); it++) {
     DetId id = (*it)->geographicalId();
 
     //Check that this is a Muon hit that we're toying with -- else pass on this because the hacker is a moron / not careful
 
     if (id.det() == DetId::Tracker && theTrackerSkipSystem > 0) {
       int layer = -999;
-      int disk  = -999;
+      int disk = -999;
       int wheel = -999;
-      if ( id.subdetId() == theTrackerSkipSystem){
-	//                              continue;  //caveat that just removes the whole system from refitting
+      if (id.subdetId() == theTrackerSkipSystem) {
+        //                              continue;  //caveat that just removes the whole system from refitting
 
-	if (theTrackerSkipSystem == PXB) {
+        if (theTrackerSkipSystem == PXB) {
+          layer = tTopo->pxbLayer(id);
+        }
+        if (theTrackerSkipSystem == TIB) {
+          layer = tTopo->tibLayer(id);
+        }
 
-	  layer = tTopo->pxbLayer(id);
-	}
-	if (theTrackerSkipSystem == TIB) {
-
-	  layer = tTopo->tibLayer(id);
-	}
-
-	if (theTrackerSkipSystem == TOB) {
-
-	  layer = tTopo->tobLayer(id);
-	}
-	if (theTrackerSkipSystem == PXF) {
-
-	  disk = tTopo->pxfDisk(id);
-	}
-	if (theTrackerSkipSystem == TID) {
-
-	  wheel = tTopo->tidWheel(id);
-	}
-	if (theTrackerSkipSystem == TEC) {
-
-	  wheel = tTopo->tecWheel(id);
-	}
-	if (theTrackerSkipSection >= 0 && layer == theTrackerSkipSection) continue;
-	if (theTrackerSkipSection >= 0 && disk == theTrackerSkipSection) continue;
-	if (theTrackerSkipSection >= 0 && wheel == theTrackerSkipSection) continue;
+        if (theTrackerSkipSystem == TOB) {
+          layer = tTopo->tobLayer(id);
+        }
+        if (theTrackerSkipSystem == PXF) {
+          disk = tTopo->pxfDisk(id);
+        }
+        if (theTrackerSkipSystem == TID) {
+          wheel = tTopo->tidWheel(id);
+        }
+        if (theTrackerSkipSystem == TEC) {
+          wheel = tTopo->tecWheel(id);
+        }
+        if (theTrackerSkipSection >= 0 && layer == theTrackerSkipSection)
+          continue;
+        if (theTrackerSkipSection >= 0 && disk == theTrackerSkipSection)
+          continue;
+        if (theTrackerSkipSection >= 0 && wheel == theTrackerSkipSection)
+          continue;
       }
     }
 
     if (id.det() == DetId::Muon && theSkipStation) {
       int station = -999;
       //UNUSED:      int wheel = -999;
-      if ( id.subdetId() == MuonSubdetId::DT ) {
-	DTChamberId did(id.rawId());
-	station = did.station();
-	//UNUSED:	wheel = did.wheel();
-      } else if ( id.subdetId() == MuonSubdetId::CSC ) {
-	CSCDetId did(id.rawId());
-	station = did.station();
-      } else if ( id.subdetId() == MuonSubdetId::GEM ) {
+      if (id.subdetId() == MuonSubdetId::DT) {
+        DTChamberId did(id.rawId());
+        station = did.station();
+        //UNUSED:	wheel = did.wheel();
+      } else if (id.subdetId() == MuonSubdetId::CSC) {
+        CSCDetId did(id.rawId());
+        station = did.station();
+      } else if (id.subdetId() == MuonSubdetId::GEM) {
         GEMDetId did(id.rawId());
         station = did.station();
-      } else if ( id.subdetId() == MuonSubdetId::ME0 ) {
+      } else if (id.subdetId() == MuonSubdetId::ME0) {
         ME0DetId did(id.rawId());
         station = did.station();
-      } else if ( id.subdetId() == MuonSubdetId::RPC ) {
-	RPCDetId rpcid(id.rawId());
-	station = rpcid.station();
+      } else if (id.subdetId() == MuonSubdetId::RPC) {
+        RPCDetId rpcid(id.rawId());
+        station = rpcid.station();
       }
-      if(station == theSkipStation) continue;
+      if (station == theSkipStation)
+        continue;
     }
     results.push_back(*it);
   }

--- a/RecoMuon/GlobalTrackingTools/src/GlobalMuonTrackMatcher.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalMuonTrackMatcher.cc
@@ -16,7 +16,6 @@
 // C++ Headers --
 //---------------
 
-
 //-------------------------------
 // Collaborating Class Headers --
 //-------------------------------
@@ -47,621 +46,592 @@ using namespace reco;
 //
 // constructor
 //
-GlobalMuonTrackMatcher::GlobalMuonTrackMatcher(const edm::ParameterSet& par, 
-                                               const MuonServiceProxy* service) : 
-  theService(service) {
+GlobalMuonTrackMatcher::GlobalMuonTrackMatcher(const edm::ParameterSet& par, const MuonServiceProxy* service)
+    : theService(service) {
   theMinP = par.getParameter<double>("MinP");
   theMinPt = par.getParameter<double>("MinPt");
   thePt_threshold1 = par.getParameter<double>("Pt_threshold1");
   thePt_threshold2 = par.getParameter<double>("Pt_threshold2");
-  theEta_threshold= par.getParameter<double>("Eta_threshold");
-  theChi2_1= par.getParameter<double>("Chi2Cut_1");
-  theChi2_2= par.getParameter<double>("Chi2Cut_2");
-  theChi2_3= par.getParameter<double>("Chi2Cut_3");
-  theLocChi2= par.getParameter<double>("LocChi2Cut");
-  theDeltaD_1= par.getParameter<double>("DeltaDCut_1");
-  theDeltaD_2= par.getParameter<double>("DeltaDCut_2");
-  theDeltaD_3= par.getParameter<double>("DeltaDCut_3");
-  theDeltaR_1= par.getParameter<double>("DeltaRCut_1");
-  theDeltaR_2= par.getParameter<double>("DeltaRCut_2");
-  theDeltaR_3= par.getParameter<double>("DeltaRCut_3");
-  theQual_1= par.getParameter<double>("Quality_1");
-  theQual_2= par.getParameter<double>("Quality_2");
-  theQual_3= par.getParameter<double>("Quality_3");
+  theEta_threshold = par.getParameter<double>("Eta_threshold");
+  theChi2_1 = par.getParameter<double>("Chi2Cut_1");
+  theChi2_2 = par.getParameter<double>("Chi2Cut_2");
+  theChi2_3 = par.getParameter<double>("Chi2Cut_3");
+  theLocChi2 = par.getParameter<double>("LocChi2Cut");
+  theDeltaD_1 = par.getParameter<double>("DeltaDCut_1");
+  theDeltaD_2 = par.getParameter<double>("DeltaDCut_2");
+  theDeltaD_3 = par.getParameter<double>("DeltaDCut_3");
+  theDeltaR_1 = par.getParameter<double>("DeltaRCut_1");
+  theDeltaR_2 = par.getParameter<double>("DeltaRCut_2");
+  theDeltaR_3 = par.getParameter<double>("DeltaRCut_3");
+  theQual_1 = par.getParameter<double>("Quality_1");
+  theQual_2 = par.getParameter<double>("Quality_2");
+  theQual_3 = par.getParameter<double>("Quality_3");
   theOutPropagatorName = par.getParameter<string>("Propagator");
-
 }
-
 
 //
 // destructor
 //
-GlobalMuonTrackMatcher::~GlobalMuonTrackMatcher() {
-
-}
-
+GlobalMuonTrackMatcher::~GlobalMuonTrackMatcher() {}
 
 //
 // check if two tracks are compatible with the *tight* criteria
 //
-bool 
-GlobalMuonTrackMatcher::matchTight(const TrackCand& sta,
-                              const TrackCand& track) const {
+bool GlobalMuonTrackMatcher::matchTight(const TrackCand& sta, const TrackCand& track) const {
+  std::pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface> tsosPair = convertToTSOSMuHit(sta, track);
 
-  std::pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface> tsosPair
-      = convertToTSOSMuHit(sta,track);
+  double chi2 = match_Chi2(tsosPair.first, tsosPair.second);
+  if (chi2 > 0. && chi2 < theChi2_2)
+    return true;
 
-  double chi2 = match_Chi2(tsosPair.first,tsosPair.second);
-  if ( chi2 > 0. && chi2 < theChi2_2 ) return true;
-
-  double distance = match_d(tsosPair.first,tsosPair.second);
-  if ( distance > 0. && distance < theDeltaD_2 ) return true;
+  double distance = match_d(tsosPair.first, tsosPair.second);
+  if (distance > 0. && distance < theDeltaD_2)
+    return true;
 
   //double deltaR = match_Rpos(tsosPair.first,tsosPair.second);
   //if ( deltaR > 0. && deltaR < theDeltaR_3 ) return true;
 
   return false;
-
 }
-
 
 //
 // check if two tracks are compatible
 //
-double
-GlobalMuonTrackMatcher::match(const TrackCand& sta,
-                              const TrackCand& track,
-                              int matchOption,
-                              int surfaceOption) const {
-
+double GlobalMuonTrackMatcher::match(const TrackCand& sta,
+                                     const TrackCand& track,
+                                     int matchOption,
+                                     int surfaceOption) const {
   std::pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface> tsosPair;
-  if ( surfaceOption == 0 ) tsosPair = convertToTSOSMuHit(sta,track);
-  if ( surfaceOption == 1 ) tsosPair = convertToTSOSTkHit(sta,track);
-  if ( surfaceOption != 0 && surfaceOption != 1 ) return -1.0;
+  if (surfaceOption == 0)
+    tsosPair = convertToTSOSMuHit(sta, track);
+  if (surfaceOption == 1)
+    tsosPair = convertToTSOSTkHit(sta, track);
+  if (surfaceOption != 0 && surfaceOption != 1)
+    return -1.0;
 
-  if ( matchOption == 0 ) {
+  if (matchOption == 0) {
     // chi^2
-    return  match_Chi2(tsosPair.first,tsosPair.second);
-  }
-  else if ( matchOption == 1 ) {
+    return match_Chi2(tsosPair.first, tsosPair.second);
+  } else if (matchOption == 1) {
     // distance
-    return match_d(tsosPair.first,tsosPair.second);
-  }
-  else if ( matchOption == 2 ) {
+    return match_d(tsosPair.first, tsosPair.second);
+  } else if (matchOption == 2) {
     // deltaR
-    return match_Rpos(tsosPair.first,tsosPair.second);
-  }
-  else if ( matchOption == 3 ) {
-    return match_dist(tsosPair.first,tsosPair.second);
-  }
-  else {
+    return match_Rpos(tsosPair.first, tsosPair.second);
+  } else if (matchOption == 3) {
+    return match_dist(tsosPair.first, tsosPair.second);
+  } else {
     return -1.0;
   }
 }
-
 
 //
 // choose the track from a TrackCollection which best
 // matches a given standalone muon track
 //
-std::vector<GlobalMuonTrackMatcher::TrackCand>::const_iterator 
-GlobalMuonTrackMatcher::matchOne(const TrackCand& sta,
-                                 const std::vector<TrackCand>& tracks) const {
-
-  if ( tracks.empty() ) return tracks.end();
+std::vector<GlobalMuonTrackMatcher::TrackCand>::const_iterator GlobalMuonTrackMatcher::matchOne(
+    const TrackCand& sta, const std::vector<TrackCand>& tracks) const {
+  if (tracks.empty())
+    return tracks.end();
 
   double minChi2 = 1000.0;
   vector<TrackCand>::const_iterator result = tracks.end();
   for (vector<TrackCand>::const_iterator is = tracks.begin(); is != tracks.end(); ++is) {
     // propagate to common surface
-    std::pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface> tsosPair
-      = convertToTSOSMuHit(sta,*is);
+    std::pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface> tsosPair = convertToTSOSMuHit(sta, *is);
 
     // calculate chi^2 of local track parameters
-    double chi2 = match_Chi2(tsosPair.first,tsosPair.second);
-    if ( chi2 > 0. && chi2 <= minChi2 ) {
+    double chi2 = match_Chi2(tsosPair.first, tsosPair.second);
+    if (chi2 > 0. && chi2 <= minChi2) {
       minChi2 = chi2;
       result = is;
     }
-    
   }
-  
-  return result;
-  
-}
 
+  return result;
+}
 
 //
 // choose a vector of tracks from a TrackCollection that are compatible
-// with a given standalone track. The order of checks for compatability 
-// * for low momentum: use chi2 selection 
-// * high momentum: use direction or local position 
+// with a given standalone track. The order of checks for compatability
+// * for low momentum: use chi2 selection
+// * high momentum: use direction or local position
 //
-vector<GlobalMuonTrackMatcher::TrackCand>
-GlobalMuonTrackMatcher::match(const TrackCand& sta, 
-                              const vector<TrackCand>& tracks) const {
+vector<GlobalMuonTrackMatcher::TrackCand> GlobalMuonTrackMatcher::match(const TrackCand& sta,
+                                                                        const vector<TrackCand>& tracks) const {
   const string category = "GlobalMuonTrackMatcher";
-  
+
   vector<TrackCand> result;
-  
-  if ( tracks.empty() ) return result;
-  
+
+  if (tracks.empty())
+    return result;
+
   typedef std::pair<TrackCand, TrajectoryStateOnSurface> TrackCandWithTSOS;
   vector<TrackCandWithTSOS> cands;
   int iiTk = 1;
   TrajectoryStateOnSurface muonTSOS;
 
-  LogTrace(category) << "   ***" << endl << "STA Muon pT "<< sta.second->pt(); 
+  LogTrace(category) << "   ***" << endl << "STA Muon pT " << sta.second->pt();
   LogTrace(category) << "   Tk in Region " << tracks.size() << endl;
 
-  for (vector<TrackCand>::const_iterator is = tracks.begin(); is != tracks.end(); ++is,iiTk++) {
-    // propagate to a common surface 
-    std::pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface> tsosPair = convertToTSOSMuHit(sta,*is);
-    LogTrace(category) << "    Tk " << iiTk << " of " << tracks.size() << "  ConvertToMuHitSurface muon isValid " << tsosPair.first.isValid() << " tk isValid " << tsosPair.second.isValid() << endl;
-    if(tsosPair.first.isValid()) muonTSOS = tsosPair.first;
-    cands.push_back(TrackCandWithTSOS(*is,tsosPair.second));
+  for (vector<TrackCand>::const_iterator is = tracks.begin(); is != tracks.end(); ++is, iiTk++) {
+    // propagate to a common surface
+    std::pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface> tsosPair = convertToTSOSMuHit(sta, *is);
+    LogTrace(category) << "    Tk " << iiTk << " of " << tracks.size() << "  ConvertToMuHitSurface muon isValid "
+                       << tsosPair.first.isValid() << " tk isValid " << tsosPair.second.isValid() << endl;
+    if (tsosPair.first.isValid())
+      muonTSOS = tsosPair.first;
+    cands.push_back(TrackCandWithTSOS(*is, tsosPair.second));
   }
-  
+
   // initialize variables
   double min_chisq = 999999;
   double min_d = 999999;
-  double min_de= 999999;
+  double min_de = 999999;
   double min_r_pos = 999999;
-  std::vector<bool> passes(cands.size(),false);
-  int jj=0;
+  std::vector<bool> passes(cands.size(), false);
+  int jj = 0;
 
   int iTkCand = 1;
-  for (vector<TrackCandWithTSOS>::const_iterator ii = cands.begin(); ii != cands.end(); ++ii,jj++,iTkCand++) {
-    
+  for (vector<TrackCandWithTSOS>::const_iterator ii = cands.begin(); ii != cands.end(); ++ii, jj++, iTkCand++) {
     // tracks that are able not able propagate to a common surface
-    if(!muonTSOS.isValid() || !(*ii).second.isValid()) continue;
-    
-    // calculate matching variables
-    double distance = match_d(muonTSOS,(*ii).second);
-    double chi2 = match_Chi2(muonTSOS,(*ii).second);
-    double loc_chi2 = match_dist(muonTSOS,(*ii).second);
-    double deltaR = match_Rpos(muonTSOS,(*ii).second);
+    if (!muonTSOS.isValid() || !(*ii).second.isValid())
+      continue;
 
-    LogTrace(category) << "   iTk " << iTkCand << " of " << cands.size() << " eta " << (*ii).second.globalPosition().eta() << " phi " << (*ii).second.globalPosition().phi() << endl; 
-    LogTrace(category) << "    distance " << distance << " distance cut " << " " << endl;
-    LogTrace(category) << "    chi2 " << chi2 << " chi2 cut " << " " << endl;
-    LogTrace(category) << "    loc_chi2 " << loc_chi2 << " locChi2 cut " << " " << endl;
-    LogTrace(category) << "    deltaR " << deltaR << " deltaR cut " << " " << endl;   
-    
-    if( (*ii).second.globalMomentum().perp()<thePt_threshold1){
+    // calculate matching variables
+    double distance = match_d(muonTSOS, (*ii).second);
+    double chi2 = match_Chi2(muonTSOS, (*ii).second);
+    double loc_chi2 = match_dist(muonTSOS, (*ii).second);
+    double deltaR = match_Rpos(muonTSOS, (*ii).second);
+
+    LogTrace(category) << "   iTk " << iTkCand << " of " << cands.size() << " eta "
+                       << (*ii).second.globalPosition().eta() << " phi " << (*ii).second.globalPosition().phi() << endl;
+    LogTrace(category) << "    distance " << distance << " distance cut "
+                       << " " << endl;
+    LogTrace(category) << "    chi2 " << chi2 << " chi2 cut "
+                       << " " << endl;
+    LogTrace(category) << "    loc_chi2 " << loc_chi2 << " locChi2 cut "
+                       << " " << endl;
+    LogTrace(category) << "    deltaR " << deltaR << " deltaR cut "
+                       << " " << endl;
+
+    if ((*ii).second.globalMomentum().perp() < thePt_threshold1) {
       LogTrace(category) << "    Enters  a1" << endl;
 
-      if( ( chi2>0 && fabs((*ii).second.globalMomentum().eta())<theEta_threshold && chi2<theChi2_1 ) || (distance>0 && distance/(*ii).first.second->pt()<theDeltaD_1 && loc_chi2>0 && loc_chi2<theLocChi2) ){
-	LogTrace(category) << "    Passes a1" << endl;
+      if ((chi2 > 0 && fabs((*ii).second.globalMomentum().eta()) < theEta_threshold && chi2 < theChi2_1) ||
+          (distance > 0 && distance / (*ii).first.second->pt() < theDeltaD_1 && loc_chi2 > 0 &&
+           loc_chi2 < theLocChi2)) {
+        LogTrace(category) << "    Passes a1" << endl;
         result.push_back((*ii).first);
-        passes[jj]=true;
+        passes[jj] = true;
       }
     }
-    if( (passes[jj]==false) && (*ii).second.globalMomentum().perp()<thePt_threshold2){
+    if ((passes[jj] == false) && (*ii).second.globalMomentum().perp() < thePt_threshold2) {
       LogTrace(category) << "    Enters a2" << endl;
-      if( ( chi2>0 && chi2< theChi2_2 ) || (distance>0 && distance<theDeltaD_2) ){
-	LogTrace(category) << "    Passes a2" << endl;
-	result.push_back((*ii).first);
-	passes[jj] = true;
+      if ((chi2 > 0 && chi2 < theChi2_2) || (distance > 0 && distance < theDeltaD_2)) {
+        LogTrace(category) << "    Passes a2" << endl;
+        result.push_back((*ii).first);
+        passes[jj] = true;
       }
-    }else{
+    } else {
       LogTrace(category) << "    Enters a3" << endl;
-      if( distance>0 && distance<theDeltaD_3 && deltaR>0 && deltaR<theDeltaR_1){
-	LogTrace(category) << "    Passes a3" << endl;
-	result.push_back((*ii).first);
-        passes[jj]=true;
+      if (distance > 0 && distance < theDeltaD_3 && deltaR > 0 && deltaR < theDeltaR_1) {
+        LogTrace(category) << "    Passes a3" << endl;
+        result.push_back((*ii).first);
+        passes[jj] = true;
       }
-    }
-    
-    if(passes[jj]){
-      if(distance<min_d) min_d = distance;
-      if(loc_chi2<min_de) min_de = loc_chi2;
-      if(deltaR<min_r_pos) min_r_pos = deltaR;
-      if(chi2<min_chisq) min_chisq = chi2;
     }
 
+    if (passes[jj]) {
+      if (distance < min_d)
+        min_d = distance;
+      if (loc_chi2 < min_de)
+        min_de = loc_chi2;
+      if (deltaR < min_r_pos)
+        min_r_pos = deltaR;
+      if (chi2 < min_chisq)
+        min_chisq = chi2;
+    }
   }
-  
+
   // re-initialize mask counter
-  jj=0;
-  
-  if ( result.empty() ) {
+  jj = 0;
+
+  if (result.empty()) {
     LogTrace(category) << "   Stage 1 returned 0 results";
-    for (vector<TrackCandWithTSOS>::const_iterator is = cands.begin(); is != cands.end(); ++is,jj++) {
-      double deltaR = match_Rpos(muonTSOS,(*is).second);
+    for (vector<TrackCandWithTSOS>::const_iterator is = cands.begin(); is != cands.end(); ++is, jj++) {
+      double deltaR = match_Rpos(muonTSOS, (*is).second);
 
       if (muonTSOS.isValid() && (*is).second.isValid()) {
-	// check matching between tracker and muon tracks using dEta cut looser then dPhi cut 
-	LogTrace(category) << "    Stage 2 deltaR " << deltaR << " deltaEta " << fabs((*is).second.globalPosition().eta()-muonTSOS.globalPosition().eta()<1.5*theDeltaR_2) << " deltaPhi " << (fabs(deltaPhi((*is).second.globalPosition().barePhi(),muonTSOS.globalPosition().barePhi()))<theDeltaR_2) << endl;
-        
-	if(fabs((*is).second.globalPosition().eta()-muonTSOS.globalPosition().eta())<1.5*theDeltaR_2
-	   &&fabs(deltaPhi((*is).second.globalPosition().barePhi(),muonTSOS.globalPosition().barePhi()))<theDeltaR_2){
-	  result.push_back((*is).first);
-	  passes[jj]=true;
-	}
-      }
-      
-      if(passes[jj]){
-        double distance = match_d(muonTSOS,(*is).second);
-        double chi2 = match_Chi2(muonTSOS,(*is).second);
-        double loc_chi2 = match_dist(muonTSOS,(*is).second);
-        if(distance<min_d) min_d = distance;
-        if(loc_chi2<min_de) min_de = loc_chi2;
-        if(deltaR<min_r_pos) min_r_pos = deltaR;
-        if(chi2<min_chisq) min_chisq = chi2;
-	
-      }
-      
-    }
-    
-  }  
+        // check matching between tracker and muon tracks using dEta cut looser then dPhi cut
+        LogTrace(category) << "    Stage 2 deltaR " << deltaR << " deltaEta "
+                           << fabs((*is).second.globalPosition().eta() - muonTSOS.globalPosition().eta() <
+                                   1.5 * theDeltaR_2)
+                           << " deltaPhi "
+                           << (fabs(deltaPhi((*is).second.globalPosition().barePhi(),
+                                             muonTSOS.globalPosition().barePhi())) < theDeltaR_2)
+                           << endl;
 
-  for(vector<TrackCand>::const_iterator iTk=result.begin();
-      iTk != result.end(); ++iTk) {
-    LogTrace(category) << "   -----" << endl 
-			      << "selected pt " << iTk->second->pt() 
-			      << " eta " << iTk->second->eta() 
-			      << " phi " << iTk->second->phi() << endl; 
+        if (fabs((*is).second.globalPosition().eta() - muonTSOS.globalPosition().eta()) < 1.5 * theDeltaR_2 &&
+            fabs(deltaPhi((*is).second.globalPosition().barePhi(), muonTSOS.globalPosition().barePhi())) <
+                theDeltaR_2) {
+          result.push_back((*is).first);
+          passes[jj] = true;
+        }
+      }
+
+      if (passes[jj]) {
+        double distance = match_d(muonTSOS, (*is).second);
+        double chi2 = match_Chi2(muonTSOS, (*is).second);
+        double loc_chi2 = match_dist(muonTSOS, (*is).second);
+        if (distance < min_d)
+          min_d = distance;
+        if (loc_chi2 < min_de)
+          min_de = loc_chi2;
+        if (deltaR < min_r_pos)
+          min_r_pos = deltaR;
+        if (chi2 < min_chisq)
+          min_chisq = chi2;
+      }
+    }
   }
 
-  if(result.size()<2)
+  for (vector<TrackCand>::const_iterator iTk = result.begin(); iTk != result.end(); ++iTk) {
+    LogTrace(category) << "   -----" << endl
+                       << "selected pt " << iTk->second->pt() << " eta " << iTk->second->eta() << " phi "
+                       << iTk->second->phi() << endl;
+  }
+
+  if (result.size() < 2)
     return result;
   else
     result.clear();
-  
+
   LogTrace(category) << "   Cleaning matched candiates" << endl;
 
   // re-initialize mask counter
-  jj=0;
-  
-  
-  for (vector<TrackCandWithTSOS>::const_iterator is = cands.begin(); is != cands.end(); ++is,jj++) {
-    
-    if(!passes[jj]) continue;
-    
-    double distance = match_d(muonTSOS,(*is).second);
-    double chi2 = match_Chi2(muonTSOS,(*is).second);
+  jj = 0;
+
+  for (vector<TrackCandWithTSOS>::const_iterator is = cands.begin(); is != cands.end(); ++is, jj++) {
+    if (!passes[jj])
+      continue;
+
+    double distance = match_d(muonTSOS, (*is).second);
+    double chi2 = match_Chi2(muonTSOS, (*is).second);
     //unused    double loc_chi2 = match_dist(muonTSOS,(*is).second);
-    double deltaR = match_Rpos(muonTSOS,(*is).second);
-    
+    double deltaR = match_Rpos(muonTSOS, (*is).second);
+
     // compute quality as the relative ratio to the minimum found for each variable
-    
-    int qual = (int)(chi2/min_chisq + distance/min_d + deltaR/min_r_pos);
-    int n_min = ((chi2/min_chisq==1)?1:0) + ((distance/min_d==1)?1:0) + ((deltaR/min_r_pos==1)?1:0);
-    
-    if(n_min == 3){
+
+    int qual = (int)(chi2 / min_chisq + distance / min_d + deltaR / min_r_pos);
+    int n_min =
+        ((chi2 / min_chisq == 1) ? 1 : 0) + ((distance / min_d == 1) ? 1 : 0) + ((deltaR / min_r_pos == 1) ? 1 : 0);
+
+    if (n_min == 3) {
       result.push_back((*is).first);
     }
-    
-    if(n_min == 2 && qual < theQual_1 ){
+
+    if (n_min == 2 && qual < theQual_1) {
       result.push_back((*is).first);
     }
-    
-    if(n_min == 1 && qual < theQual_2 ){
+
+    if (n_min == 1 && qual < theQual_2) {
       result.push_back((*is).first);
     }
-    
-    if(n_min == 0 && qual < theQual_3 ){
+
+    if (n_min == 0 && qual < theQual_3) {
       result.push_back((*is).first);
     }
-    
   }
 
-  for(vector<TrackCand>::const_iterator iTk=result.begin();
-      iTk != result.end(); ++iTk) {
-    LogTrace(category) << "   -----" << endl 
-			      << "selected pt " << iTk->second->pt() 
-			      << " eta " << iTk->second->eta() 
-			      << " phi " << iTk->second->phi() << endl; 
+  for (vector<TrackCand>::const_iterator iTk = result.begin(); iTk != result.end(); ++iTk) {
+    LogTrace(category) << "   -----" << endl
+                       << "selected pt " << iTk->second->pt() << " eta " << iTk->second->eta() << " phi "
+                       << iTk->second->phi() << endl;
   }
- 
+
   return result;
 }
-
 
 //
 // propagate the two track candidates to the tracker bound surface
 //
-std::pair<TrajectoryStateOnSurface,TrajectoryStateOnSurface>
-GlobalMuonTrackMatcher::convertToTSOSTk(const TrackCand& staCand,
-                                        const TrackCand& tkCand) const {
-  
+std::pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface> GlobalMuonTrackMatcher::convertToTSOSTk(
+    const TrackCand& staCand, const TrackCand& tkCand) const {
   const string category = "GlobalMuonTrackMatcher";
 
-  TrajectoryStateOnSurface empty; 
-  
-  TransientTrack muTT(*staCand.second,&*theService->magneticField(),theService->trackingGeometry());
+  TrajectoryStateOnSurface empty;
+
+  TransientTrack muTT(*staCand.second, &*theService->magneticField(), theService->trackingGeometry());
   TrajectoryStateOnSurface impactMuTSOS = muTT.impactPointState();
 
   TrajectoryStateOnSurface outerTkTsos;
   if (tkCand.second.isNonnull()) {
     // make sure the tracker track has enough momentum to reach the muon chambers
-    if ( !(tkCand.second->p() < theMinP || tkCand.second->pt() < theMinPt )) {
-      
-      outerTkTsos = trajectoryStateTransform::outerStateOnSurface(*tkCand.second,*theService->trackingGeometry(),&*theService->magneticField());
+    if (!(tkCand.second->p() < theMinP || tkCand.second->pt() < theMinPt)) {
+      outerTkTsos = trajectoryStateTransform::outerStateOnSurface(
+          *tkCand.second, *theService->trackingGeometry(), &*theService->magneticField());
     }
   }
-  
-  if ( !impactMuTSOS.isValid() || !outerTkTsos.isValid() ) return pair<TrajectoryStateOnSurface,TrajectoryStateOnSurface>(empty,empty);
-  
+
+  if (!impactMuTSOS.isValid() || !outerTkTsos.isValid())
+    return pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface>(empty, empty);
+
   // define StateOnTrackerBound object
   StateOnTrackerBound fromInside(&*theService->propagator(theOutPropagatorName));
-  
+
   // extrapolate to outer tracker surface
   TrajectoryStateOnSurface tkTsosFromMu = fromInside(impactMuTSOS);
   TrajectoryStateOnSurface tkTsosFromTk = fromInside(outerTkTsos);
 
-  if ( !samePlane(tkTsosFromMu,tkTsosFromTk) ) {
+  if (!samePlane(tkTsosFromMu, tkTsosFromTk)) {
     // propagate tracker track to same surface as muon
     bool same1, same2;
     TrajectoryStateOnSurface newTkTsosFromTk, newTkTsosFromMu;
-    if ( tkTsosFromMu.isValid() ) newTkTsosFromTk = theService->propagator(theOutPropagatorName)->propagate(outerTkTsos,tkTsosFromMu.surface());
-    same1 = samePlane(newTkTsosFromTk,tkTsosFromMu);
+    if (tkTsosFromMu.isValid())
+      newTkTsosFromTk = theService->propagator(theOutPropagatorName)->propagate(outerTkTsos, tkTsosFromMu.surface());
+    same1 = samePlane(newTkTsosFromTk, tkTsosFromMu);
     LogTrace(category) << "Propagating to same tracker surface (Mu):" << same1;
-    if ( !same1 ) {
-      if ( tkTsosFromTk.isValid() ) newTkTsosFromMu = theService->propagator(theOutPropagatorName)->propagate(impactMuTSOS,tkTsosFromTk.surface());
-      same2 = samePlane(newTkTsosFromMu,tkTsosFromTk);
+    if (!same1) {
+      if (tkTsosFromTk.isValid())
+        newTkTsosFromMu = theService->propagator(theOutPropagatorName)->propagate(impactMuTSOS, tkTsosFromTk.surface());
+      same2 = samePlane(newTkTsosFromMu, tkTsosFromTk);
       LogTrace(category) << "Propagating to same tracker surface (Tk):" << same2;
     }
-    if (same1) tkTsosFromTk = newTkTsosFromTk;
-    else if (same2) tkTsosFromMu = newTkTsosFromMu;
-    else  {
+    if (same1)
+      tkTsosFromTk = newTkTsosFromTk;
+    else if (same2)
+      tkTsosFromMu = newTkTsosFromMu;
+    else {
       LogTrace(category) << "Could not propagate Muon and Tracker track to the same tracker bound!";
-      return pair<TrajectoryStateOnSurface,TrajectoryStateOnSurface>(empty, empty);
+      return pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface>(empty, empty);
     }
   }
- 
-  return pair<TrajectoryStateOnSurface,TrajectoryStateOnSurface>(tkTsosFromMu, tkTsosFromTk);
 
+  return pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface>(tkTsosFromMu, tkTsosFromTk);
 }
-
 
 //
 // propagate the two track candidates to the surface of the innermost muon hit
 //
-std::pair<TrajectoryStateOnSurface,TrajectoryStateOnSurface>
-GlobalMuonTrackMatcher::convertToTSOSMuHit(const TrackCand& staCand,
-                                           const TrackCand& tkCand) const {
-  
+std::pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface> GlobalMuonTrackMatcher::convertToTSOSMuHit(
+    const TrackCand& staCand, const TrackCand& tkCand) const {
   const string category = "GlobalMuonTrackMatcher";
-  TrajectoryStateOnSurface empty; 
-  TransientTrack muTT(*staCand.second,&*theService->magneticField(),theService->trackingGeometry());
+  TrajectoryStateOnSurface empty;
+  TransientTrack muTT(*staCand.second, &*theService->magneticField(), theService->trackingGeometry());
   TrajectoryStateOnSurface innerMuTSOS = muTT.innermostMeasurementState();
-  TrajectoryStateOnSurface outerTkTsos,innerTkTsos;
-  if ( tkCand.second.isNonnull() ) {
+  TrajectoryStateOnSurface outerTkTsos, innerTkTsos;
+  if (tkCand.second.isNonnull()) {
     // make sure the tracker track has enough momentum to reach the muon chambers
-    if ( !(tkCand.second->p() < theMinP || tkCand.second->pt() < theMinPt ) ) {
+    if (!(tkCand.second->p() < theMinP || tkCand.second->pt() < theMinPt)) {
       TrajectoryStateOnSurface innerTkTsos;
-      
-      outerTkTsos = trajectoryStateTransform::outerStateOnSurface(*tkCand.second,*theService->trackingGeometry(),&*theService->magneticField());
-      innerTkTsos = trajectoryStateTransform::innerStateOnSurface(*tkCand.second,*theService->trackingGeometry(),&*theService->magneticField());
+
+      outerTkTsos = trajectoryStateTransform::outerStateOnSurface(
+          *tkCand.second, *theService->trackingGeometry(), &*theService->magneticField());
+      innerTkTsos = trajectoryStateTransform::innerStateOnSurface(
+          *tkCand.second, *theService->trackingGeometry(), &*theService->magneticField());
       // for cosmics, outer-most referst to last traversed layer
-      if ( (innerMuTSOS.globalPosition() -  outerTkTsos.globalPosition()).mag() > (innerMuTSOS.globalPosition() -  innerTkTsos.globalPosition()).mag() )
-	outerTkTsos = innerTkTsos;
-      
+      if ((innerMuTSOS.globalPosition() - outerTkTsos.globalPosition()).mag() >
+          (innerMuTSOS.globalPosition() - innerTkTsos.globalPosition()).mag())
+        outerTkTsos = innerTkTsos;
     }
   }
-    
-  if ( !innerMuTSOS.isValid() || !outerTkTsos.isValid() ) {
-    LogTrace(category) << "A TSOS validity problem! MuTSOS " << innerMuTSOS.isValid() << " TkTSOS " << outerTkTsos.isValid();
-    return pair<TrajectoryStateOnSurface,TrajectoryStateOnSurface>(empty,empty);
+
+  if (!innerMuTSOS.isValid() || !outerTkTsos.isValid()) {
+    LogTrace(category) << "A TSOS validity problem! MuTSOS " << innerMuTSOS.isValid() << " TkTSOS "
+                       << outerTkTsos.isValid();
+    return pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface>(empty, empty);
   }
-  
+
   const Surface& refSurface = innerMuTSOS.surface();
-  TrajectoryStateOnSurface tkAtMu = theService->propagator(theOutPropagatorName)->propagate(*outerTkTsos.freeState(),refSurface);
-  
-  if ( !tkAtMu.isValid() ) {
+  TrajectoryStateOnSurface tkAtMu =
+      theService->propagator(theOutPropagatorName)->propagate(*outerTkTsos.freeState(), refSurface);
+
+  if (!tkAtMu.isValid()) {
     LogTrace(category) << "Could not propagate Muon and Tracker track to the same muon hit surface!";
-    return pair<TrajectoryStateOnSurface,TrajectoryStateOnSurface>(empty,empty);    
+    return pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface>(empty, empty);
   }
-  
-  return pair<TrajectoryStateOnSurface,TrajectoryStateOnSurface>(innerMuTSOS, tkAtMu);
 
+  return pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface>(innerMuTSOS, tkAtMu);
 }
-
 
 //
 // propagate the two track candidates to the surface of the outermost tracker hit
 //
-std::pair<TrajectoryStateOnSurface,TrajectoryStateOnSurface>
-GlobalMuonTrackMatcher::convertToTSOSTkHit(const TrackCand& staCand,
-                                           const TrackCand& tkCand) const {
-  
+std::pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface> GlobalMuonTrackMatcher::convertToTSOSTkHit(
+    const TrackCand& staCand, const TrackCand& tkCand) const {
   const string category = "GlobalMuonTrackMatcher";
 
-  TrajectoryStateOnSurface empty; 
+  TrajectoryStateOnSurface empty;
 
-  TransientTrack muTT(*staCand.second,&*theService->magneticField(),theService->trackingGeometry());
+  TransientTrack muTT(*staCand.second, &*theService->magneticField(), theService->trackingGeometry());
   TrajectoryStateOnSurface impactMuTSOS = muTT.impactPointState();
   TrajectoryStateOnSurface innerMuTSOS = muTT.innermostMeasurementState();
-  
-  TrajectoryStateOnSurface outerTkTsos,innerTkTsos;
-  if ( tkCand.second.isNonnull() ) {
+
+  TrajectoryStateOnSurface outerTkTsos, innerTkTsos;
+  if (tkCand.second.isNonnull()) {
     // make sure the tracker track has enough momentum to reach the muon chambers
-    if ( !(tkCand.second->p() < theMinP || tkCand.second->pt() < theMinPt )) {
-      
-      outerTkTsos = trajectoryStateTransform::outerStateOnSurface(*tkCand.second,*theService->trackingGeometry(),&*theService->magneticField());
-      innerTkTsos = trajectoryStateTransform::innerStateOnSurface(*tkCand.second,*theService->trackingGeometry(),&*theService->magneticField());
-      
+    if (!(tkCand.second->p() < theMinP || tkCand.second->pt() < theMinPt)) {
+      outerTkTsos = trajectoryStateTransform::outerStateOnSurface(
+          *tkCand.second, *theService->trackingGeometry(), &*theService->magneticField());
+      innerTkTsos = trajectoryStateTransform::innerStateOnSurface(
+          *tkCand.second, *theService->trackingGeometry(), &*theService->magneticField());
+
       // for cosmics, outer-most referst to last traversed layer
-      if ( (innerMuTSOS.globalPosition() -  outerTkTsos.globalPosition()).mag() > (innerMuTSOS.globalPosition() -  innerTkTsos.globalPosition()).mag() )
-	outerTkTsos = innerTkTsos;
-      
+      if ((innerMuTSOS.globalPosition() - outerTkTsos.globalPosition()).mag() >
+          (innerMuTSOS.globalPosition() - innerTkTsos.globalPosition()).mag())
+        outerTkTsos = innerTkTsos;
     }
   }
 
-  if ( !impactMuTSOS.isValid() || !outerTkTsos.isValid() ) {
-    LogTrace(category) << "A TSOS validity problem! MuTSOS " << impactMuTSOS.isValid() << " TkTSOS " << outerTkTsos.isValid();
-    return pair<TrajectoryStateOnSurface,TrajectoryStateOnSurface>(empty,empty);
+  if (!impactMuTSOS.isValid() || !outerTkTsos.isValid()) {
+    LogTrace(category) << "A TSOS validity problem! MuTSOS " << impactMuTSOS.isValid() << " TkTSOS "
+                       << outerTkTsos.isValid();
+    return pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface>(empty, empty);
   }
 
   const Surface& refSurface = outerTkTsos.surface();
-  TrajectoryStateOnSurface muAtTk = theService->propagator(theOutPropagatorName)->propagate(*impactMuTSOS.freeState(),refSurface);
-  
-  if ( !muAtTk.isValid() ) {
+  TrajectoryStateOnSurface muAtTk =
+      theService->propagator(theOutPropagatorName)->propagate(*impactMuTSOS.freeState(), refSurface);
+
+  if (!muAtTk.isValid()) {
     LogTrace(category) << "Could not propagate Muon and Tracker track to the same tracker hit surface!";
-    return pair<TrajectoryStateOnSurface,TrajectoryStateOnSurface>(empty,empty);    
+    return pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface>(empty, empty);
   }
 
-  return pair<TrajectoryStateOnSurface,TrajectoryStateOnSurface>(muAtTk, outerTkTsos);
-
+  return pair<TrajectoryStateOnSurface, TrajectoryStateOnSurface>(muAtTk, outerTkTsos);
 }
 
-
 //
 //
 //
-bool
-GlobalMuonTrackMatcher::samePlane(const TrajectoryStateOnSurface& tsos1,
-				  const TrajectoryStateOnSurface& tsos2) const {
+bool GlobalMuonTrackMatcher::samePlane(const TrajectoryStateOnSurface& tsos1,
+                                       const TrajectoryStateOnSurface& tsos2) const {
+  if (!tsos1.isValid() || !tsos2.isValid())
+    return false;
 
-  if ( !tsos1.isValid() || !tsos2.isValid() ) return false;
-
-  if ( fabs(match_D(tsos1,tsos2) - match_d(tsos1,tsos2)) > 0.1 ) return false;
+  if (fabs(match_D(tsos1, tsos2) - match_d(tsos1, tsos2)) > 0.1)
+    return false;
 
   const float maxtilt = 0.999;
-  const float maxdist = 0.01; // in cm
+  const float maxdist = 0.01;  // in cm
 
   auto p1(tsos1.surface().tangentPlane(tsos1.localPosition()));
   auto p2(tsos2.surface().tangentPlane(tsos2.localPosition()));
 
-  bool returnValue = ( (fabs(p1->normalVector().dot(p2->normalVector())) > maxtilt) || (fabs((p1->toLocal(p2->position())).z()) < maxdist) ) ? true : false;
+  bool returnValue = ((fabs(p1->normalVector().dot(p2->normalVector())) > maxtilt) ||
+                      (fabs((p1->toLocal(p2->position())).z()) < maxdist))
+                         ? true
+                         : false;
 
-  return returnValue; 
- 
+  return returnValue;
 }
-
 
 //
 // calculate Chi^2 of two trajectory states
 //
-double 
-GlobalMuonTrackMatcher::match_Chi2(const TrajectoryStateOnSurface& tsos1, 
-                                   const TrajectoryStateOnSurface& tsos2) const {
-  
+double GlobalMuonTrackMatcher::match_Chi2(const TrajectoryStateOnSurface& tsos1,
+                                          const TrajectoryStateOnSurface& tsos2) const {
   const string category = "GlobalMuonTrackMatcher";
   //LogTrace(category) << "match_Chi2 sanity check: " << tsos1.isValid() << " " << tsos2.isValid();
-  if ( !tsos1.isValid() || !tsos2.isValid() ) return -1.;
-  
+  if (!tsos1.isValid() || !tsos2.isValid())
+    return -1.;
+
   AlgebraicVector5 v(tsos1.localParameters().vector() - tsos2.localParameters().vector());
   AlgebraicSymMatrix55 m(tsos1.localError().matrix() + tsos2.localError().matrix());
-  
+
   //LogTrace(category) << "match_Chi2 vector v " << v;
 
   bool ierr = !m.Invert();
- 
-  if ( ierr ) { 
+
+  if (ierr) {
     edm::LogInfo(category) << "Error inverting covariance matrix";
     return -1;
   }
- 
-  double est = ROOT::Math::Similarity(v,m);
- 
+
+  double est = ROOT::Math::Similarity(v, m);
+
   //LogTrace(category) << "Chi2 " << est;
 
   return est;
-
 }
-
 
 //
 // calculate Delta_R of two track candidates at the IP
 //
-double
-GlobalMuonTrackMatcher::match_R_IP(const TrackCand& staCand, 
-                                   const TrackCand& tkCand) const {
-
+double GlobalMuonTrackMatcher::match_R_IP(const TrackCand& staCand, const TrackCand& tkCand) const {
   double dR = 99.0;
   if (tkCand.second.isNonnull()) {
-    dR = (deltaR<double>(staCand.second->eta(),staCand.second->phi(),
-			 tkCand.second->eta(),tkCand.second->phi()));
+    dR = (deltaR<double>(staCand.second->eta(), staCand.second->phi(), tkCand.second->eta(), tkCand.second->phi()));
   }
 
   return dR;
-
 }
-
 
 //
 // calculate Delta_R of two trajectory states
 //
-double
-GlobalMuonTrackMatcher::match_Rmom(const TrajectoryStateOnSurface& sta, 
-                                   const TrajectoryStateOnSurface& tk) const {
-
-  if( !sta.isValid() || !tk.isValid() ) return -1;
-  return (deltaR<double>(sta.globalMomentum().eta(),sta.globalMomentum().phi(),
-			 tk.globalMomentum().eta(),tk.globalMomentum().phi()));
-
+double GlobalMuonTrackMatcher::match_Rmom(const TrajectoryStateOnSurface& sta,
+                                          const TrajectoryStateOnSurface& tk) const {
+  if (!sta.isValid() || !tk.isValid())
+    return -1;
+  return (deltaR<double>(
+      sta.globalMomentum().eta(), sta.globalMomentum().phi(), tk.globalMomentum().eta(), tk.globalMomentum().phi()));
 }
-
 
 //
 // calculate Delta_R of two trajectory states
 //
-double
-GlobalMuonTrackMatcher::match_Rpos(const TrajectoryStateOnSurface& sta, 
-                                   const TrajectoryStateOnSurface& tk) const {
-
-  if ( !sta.isValid() || !tk.isValid() ) return -1;
-  return (deltaR<double>(sta.globalPosition().eta(),sta.globalPosition().phi(),
-			 tk.globalPosition().eta(),tk.globalPosition().phi()));
-
+double GlobalMuonTrackMatcher::match_Rpos(const TrajectoryStateOnSurface& sta,
+                                          const TrajectoryStateOnSurface& tk) const {
+  if (!sta.isValid() || !tk.isValid())
+    return -1;
+  return (deltaR<double>(
+      sta.globalPosition().eta(), sta.globalPosition().phi(), tk.globalPosition().eta(), tk.globalPosition().phi()));
 }
-
 
 //
 // calculate the distance in global position of two trajectory states
 //
-double
-GlobalMuonTrackMatcher::match_D(const TrajectoryStateOnSurface& sta, 
-                                const TrajectoryStateOnSurface& tk) const {
-
-  if ( !sta.isValid() || !tk.isValid() ) return -1;
+double GlobalMuonTrackMatcher::match_D(const TrajectoryStateOnSurface& sta, const TrajectoryStateOnSurface& tk) const {
+  if (!sta.isValid() || !tk.isValid())
+    return -1;
   return (sta.globalPosition() - tk.globalPosition()).mag();
-
 }
-
 
 //
 // calculate the distance in local position of two trajectory states
 //
-double
-GlobalMuonTrackMatcher::match_d(const TrajectoryStateOnSurface& sta, 
-                                const TrajectoryStateOnSurface& tk) const {
-
-  if ( !sta.isValid() || !tk.isValid() ) return -1;
+double GlobalMuonTrackMatcher::match_d(const TrajectoryStateOnSurface& sta, const TrajectoryStateOnSurface& tk) const {
+  if (!sta.isValid() || !tk.isValid())
+    return -1;
   return (sta.localPosition() - tk.localPosition()).mag();
-
 }
 
-
 //
-// calculate the chi2 of the distance in local position of two 
+// calculate the chi2 of the distance in local position of two
 // trajectory states including local errors
 //
-double
-GlobalMuonTrackMatcher::match_dist(const TrajectoryStateOnSurface& sta, 
-				   const TrajectoryStateOnSurface& tk) const {
- 
-   const string category = "GlobalMuonTrackMatcher";
-   
-   if ( !sta.isValid() || !tk.isValid() ) return -1;
- 
-   AlgebraicMatrix22 m;
-   m(0,0) = tk.localError().positionError().xx() + sta.localError().positionError().xx();
-   m(1,0) = m(0,1) = tk.localError().positionError().xy() + sta.localError().positionError().xy();
-   m(1,1) = tk.localError().positionError().yy() + sta.localError().positionError().yy();
- 
-   AlgebraicVector2 v;
-   v[0] = tk.localPosition().x() - sta.localPosition().x();
-   v[1] = tk.localPosition().y() - sta.localPosition().y();
- 
-   if ( !m.Invert() ) {
-     LogTrace(category) << "Error inverting local matrix ";
-     return -1;
-   }
- 
-   return ROOT::Math::Similarity(v,m);
+double GlobalMuonTrackMatcher::match_dist(const TrajectoryStateOnSurface& sta,
+                                          const TrajectoryStateOnSurface& tk) const {
+  const string category = "GlobalMuonTrackMatcher";
 
+  if (!sta.isValid() || !tk.isValid())
+    return -1;
+
+  AlgebraicMatrix22 m;
+  m(0, 0) = tk.localError().positionError().xx() + sta.localError().positionError().xx();
+  m(1, 0) = m(0, 1) = tk.localError().positionError().xy() + sta.localError().positionError().xy();
+  m(1, 1) = tk.localError().positionError().yy() + sta.localError().positionError().yy();
+
+  AlgebraicVector2 v;
+  v[0] = tk.localPosition().x() - sta.localPosition().x();
+  v[1] = tk.localPosition().y() - sta.localPosition().y();
+
+  if (!m.Invert()) {
+    LogTrace(category) << "Error inverting local matrix ";
+    return -1;
+  }
+
+  return ROOT::Math::Similarity(v, m);
 }

--- a/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
@@ -75,15 +75,18 @@
 //----------------
 GlobalTrajectoryBuilderBase::GlobalTrajectoryBuilderBase(const edm::ParameterSet& par,
                                                          const MuonServiceProxy* service,
-							 edm::ConsumesCollector& iC) : 
-  theLayerMeasurements(nullptr),theTrackTransformer(nullptr),theRegionBuilder(nullptr), theService(service),theGlbRefitter(nullptr) {
+                                                         edm::ConsumesCollector& iC)
+    : theLayerMeasurements(nullptr),
+      theTrackTransformer(nullptr),
+      theRegionBuilder(nullptr),
+      theService(service),
+      theGlbRefitter(nullptr) {
+  theCategory =
+      par.getUntrackedParameter<std::string>("Category", "Muon|RecoMuon|GlobalMuon|GlobalTrajectoryBuilderBase");
 
-  theCategory = par.getUntrackedParameter<std::string>("Category", "Muon|RecoMuon|GlobalMuon|GlobalTrajectoryBuilderBase");
-
-  
   edm::ParameterSet trackMatcherPSet = par.getParameter<edm::ParameterSet>("GlobalMuonTrackMatcher");
-  theTrackMatcher = new GlobalMuonTrackMatcher(trackMatcherPSet,theService);
-  
+  theTrackMatcher = new GlobalMuonTrackMatcher(trackMatcherPSet, theService);
+
   theTrackerPropagatorName = par.getParameter<std::string>("TrackerPropagator");
 
   edm::ParameterSet trackTransformerPSet = par.getParameter<edm::ParameterSet>("TrackTransformer");
@@ -91,7 +94,7 @@ GlobalTrajectoryBuilderBase::GlobalTrajectoryBuilderBase(const edm::ParameterSet
 
   edm::ParameterSet regionBuilderPSet = par.getParameter<edm::ParameterSet>("MuonTrackingRegionBuilder");
 
-  theRegionBuilder = new MuonTrackingRegionBuilder(regionBuilderPSet,iC);
+  theRegionBuilder = new MuonTrackingRegionBuilder(regionBuilderPSet, iC);
 
   // TrackRefitter parameters
   edm::ParameterSet refitterParameters = par.getParameter<edm::ParameterSet>("GlbRefitterParameters");
@@ -111,27 +114,26 @@ GlobalTrajectoryBuilderBase::GlobalTrajectoryBuilderBase(const edm::ParameterSet
   thePCut = par.getParameter<double>("PCut");
 
   theCacheId_TRH = 0;
-
 }
-
 
 //--------------
 // Destructor --
 //--------------
 GlobalTrajectoryBuilderBase::~GlobalTrajectoryBuilderBase() {
-
-  if (theTrackMatcher) delete theTrackMatcher;
-  if (theRegionBuilder) delete theRegionBuilder;
-  if (theTrackTransformer) delete theTrackTransformer;
-  if (theGlbRefitter) delete theGlbRefitter;
+  if (theTrackMatcher)
+    delete theTrackMatcher;
+  if (theRegionBuilder)
+    delete theRegionBuilder;
+  if (theTrackTransformer)
+    delete theTrackTransformer;
+  if (theGlbRefitter)
+    delete theGlbRefitter;
 }
-
 
 //
 // set Event
 //
 void GlobalTrajectoryBuilderBase::setEvent(const edm::Event& event) {
-  
   theEvent = &event;
 
   theTrackTransformer->setServices(theService->eventSetup());
@@ -141,145 +143,163 @@ void GlobalTrajectoryBuilderBase::setEvent(const edm::Event& event) {
   theGlbRefitter->setServices(theService->eventSetup());
 
   unsigned long long newCacheId_TRH = theService->eventSetup().get<TransientRecHitRecord>().cacheIdentifier();
-  if ( newCacheId_TRH != theCacheId_TRH ) {
+  if (newCacheId_TRH != theCacheId_TRH) {
     LogDebug(theCategory) << "TransientRecHitRecord changed!";
     theCacheId_TRH = newCacheId_TRH;
-    theService->eventSetup().get<TransientRecHitRecord>().get(theTrackerRecHitBuilderName,theTrackerRecHitBuilder);
-    theService->eventSetup().get<TransientRecHitRecord>().get(theMuonRecHitBuilderName,theMuonRecHitBuilder);
+    theService->eventSetup().get<TransientRecHitRecord>().get(theTrackerRecHitBuilderName, theTrackerRecHitBuilder);
+    theService->eventSetup().get<TransientRecHitRecord>().get(theMuonRecHitBuilderName, theMuonRecHitBuilder);
   }
 
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHand;
   theService->eventSetup().get<TrackerTopologyRcd>().get(tTopoHand);
-  theTopo=tTopoHand.product();
-
+  theTopo = tTopoHand.product();
 }
-
 
 //
 // build a combined tracker-muon trajectory
 //
-MuonCandidate::CandidateContainer 
-GlobalTrajectoryBuilderBase::build(const TrackCand& staCand,
-                                   MuonCandidate::CandidateContainer& tkTrajs ) const {
-
+MuonCandidate::CandidateContainer GlobalTrajectoryBuilderBase::build(const TrackCand& staCand,
+                                                                     MuonCandidate::CandidateContainer& tkTrajs) const {
   LogTrace(theCategory) << " Begin Build" << std::endl;
 
   // tracker trajectory should be built and refit before this point
-  if ( tkTrajs.empty() ) return CandidateContainer();
+  if (tkTrajs.empty())
+    return CandidateContainer();
 
   // add muon hits and refit/smooth trajectories
   CandidateContainer refittedResult;
   ConstRecHitContainer muonRecHits = getTransientRecHits(*(staCand.second));
 
   // check order of muon measurements
-  if ( (muonRecHits.size() > 1) &&
-       ( muonRecHits.front()->globalPosition().mag() >
-	 muonRecHits.back()->globalPosition().mag() ) ) {
-    LogTrace(theCategory)<< "   reverse order: ";
+  if ((muonRecHits.size() > 1) &&
+      (muonRecHits.front()->globalPosition().mag() > muonRecHits.back()->globalPosition().mag())) {
+    LogTrace(theCategory) << "   reverse order: ";
   }
 
-  for (auto&& it: tkTrajs){
-	// cut on tracks with low momenta
-    LogTrace(theCategory)<< "   Track p and pT " << it->trackerTrack()->p() << " " << it->trackerTrack()->pt();
-    if(  it->trackerTrack()->p() < thePCut || it->trackerTrack()->pt() < thePtCut  ) continue;
+  for (auto&& it : tkTrajs) {
+    // cut on tracks with low momenta
+    LogTrace(theCategory) << "   Track p and pT " << it->trackerTrack()->p() << " " << it->trackerTrack()->pt();
+    if (it->trackerTrack()->p() < thePCut || it->trackerTrack()->pt() < thePtCut)
+      continue;
 
-	// If true we will run theGlbRefitter->refit from all hits
-	if (theRefitFlag){
-	    ConstRecHitContainer trackerRecHits;
-	    if (it->trackerTrack().isNonnull()) {
-	      trackerRecHits = getTransientRecHits(*it->trackerTrack());
-	    } else {
-	      LogDebug(theCategory)<<"     NEED HITS FROM TRAJ";
-	    }
-	
-	    // ToDo: Do we need the following ?:
-	    // check for single TEC RecHits in trajectories in the overalp region
-	    if ( std::abs(it->trackerTrack()->eta()) > 0.95 && std::abs(it->trackerTrack()->eta()) < 1.15 && it->trackerTrack()->pt() < 60 ) {
-	      if ( theTECxScale < 0 || theTECyScale < 0 )
-	        trackerRecHits = selectTrackerHits(trackerRecHits);
-	      else
-	        fixTEC(trackerRecHits,theTECxScale,theTECyScale);
-	    }
-			  
-	    RefitDirection recHitDir = checkRecHitsOrdering(trackerRecHits);
-	    if ( recHitDir == outToIn ) reverse(trackerRecHits.begin(),trackerRecHits.end());
-	
-	    reco::TransientTrack tTT(it->trackerTrack(),&*theService->magneticField(),theService->trackingGeometry());
-	    TrajectoryStateOnSurface innerTsos = tTT.innermostMeasurementState();
-	
-	    edm::RefToBase<TrajectorySeed> tmpSeed;
-	    if(it->trackerTrack()->seedRef().isAvailable()) tmpSeed = it->trackerTrack()->seedRef();
-	
-	    if ( !innerTsos.isValid() ) {
-	      LogTrace(theCategory) << "     inner Trajectory State is invalid. ";
-	      continue;
-	    }
-	  
-	    innerTsos.rescaleError(100.);
-	                  
-	    TC refitted0,refitted1;
-	    MuonCandidate* finalTrajectory = nullptr;
-	    Trajectory *tkTrajectory = nullptr;
-	
-	    // tracker only track
-	    if ( ! (it->trackerTrajectory() && it->trackerTrajectory()->isValid()) ) {
-	      refitted0 = theTrackTransformer->transform(it->trackerTrack()) ;
-	      if (!refitted0.empty()) tkTrajectory = new Trajectory(*(refitted0.begin())); 
-	      else edm::LogWarning(theCategory)<< "     Failed to load tracker track trajectory";
-	    } else tkTrajectory = it->trackerTrajectory();
-	    if (tkTrajectory) tkTrajectory->setSeedRef(tmpSeed);
-	
-	    // full track with all muon hits using theGlbRefitter    
-	    ConstRecHitContainer allRecHits = trackerRecHits;
-	    allRecHits.insert(allRecHits.end(), muonRecHits.begin(),muonRecHits.end());
-	    refitted1 = theGlbRefitter->refit( *it->trackerTrack(), tTT, allRecHits,theMuonHitsOption, theTopo);
-	    LogTrace(theCategory)<<"     This track-sta refitted to " << refitted1.size() << " trajectories";
-	
-	    Trajectory *glbTrajectory1 = nullptr;
-	    if (!refitted1.empty()) glbTrajectory1 = new Trajectory(*(refitted1.begin()));
-	    else LogDebug(theCategory)<< "     Failed to load global track trajectory 1"; 
-	    if (glbTrajectory1) glbTrajectory1->setSeedRef(tmpSeed);
-	    
-	    finalTrajectory = nullptr;
-	    if(glbTrajectory1 && tkTrajectory) finalTrajectory = new MuonCandidate(glbTrajectory1, it->muonTrack(), it->trackerTrack(),
-						tkTrajectory? new Trajectory(*tkTrajectory) : nullptr);
-	
-	    if ( finalTrajectory ) refittedResult.push_back(finalTrajectory);
-	    if(tkTrajectory) delete tkTrajectory;
-	  }
-	  else{
-		MuonCandidate* finalTrajectory = nullptr;
-		edm::RefToBase<TrajectorySeed> tmpSeed;
-		if(it->trackerTrack()->seedRef().isAvailable()) tmpSeed = it->trackerTrack()->seedRef();
-	
-		TC refitted0;
-		Trajectory *tkTrajectory = nullptr;
-		if ( ! (it->trackerTrajectory() && it->trackerTrajectory()->isValid()) ) {
-		  refitted0 = theTrackTransformer->transform(it->trackerTrack());
-		  if (!refitted0.empty()){
-			  tkTrajectory = new Trajectory(*(refitted0.begin()));
-		  }
-		  else edm::LogWarning(theCategory)<< "     Failed to load tracker track trajectory";
-		}
-		else tkTrajectory = it->trackerTrajectory();
-		if (tkTrajectory) tkTrajectory->setSeedRef(tmpSeed);
-		// Creating MuonCandidate using only the tracker trajectory:
-		finalTrajectory = new MuonCandidate(new Trajectory(*tkTrajectory), it->muonTrack(), it->trackerTrack(),new Trajectory(*tkTrajectory));
-		if (finalTrajectory) refittedResult.push_back(finalTrajectory);
-		if(tkTrajectory) delete tkTrajectory;
-	  }
+    // If true we will run theGlbRefitter->refit from all hits
+    if (theRefitFlag) {
+      ConstRecHitContainer trackerRecHits;
+      if (it->trackerTrack().isNonnull()) {
+        trackerRecHits = getTransientRecHits(*it->trackerTrack());
+      } else {
+        LogDebug(theCategory) << "     NEED HITS FROM TRAJ";
+      }
+
+      // ToDo: Do we need the following ?:
+      // check for single TEC RecHits in trajectories in the overalp region
+      if (std::abs(it->trackerTrack()->eta()) > 0.95 && std::abs(it->trackerTrack()->eta()) < 1.15 &&
+          it->trackerTrack()->pt() < 60) {
+        if (theTECxScale < 0 || theTECyScale < 0)
+          trackerRecHits = selectTrackerHits(trackerRecHits);
+        else
+          fixTEC(trackerRecHits, theTECxScale, theTECyScale);
+      }
+
+      RefitDirection recHitDir = checkRecHitsOrdering(trackerRecHits);
+      if (recHitDir == outToIn)
+        reverse(trackerRecHits.begin(), trackerRecHits.end());
+
+      reco::TransientTrack tTT(it->trackerTrack(), &*theService->magneticField(), theService->trackingGeometry());
+      TrajectoryStateOnSurface innerTsos = tTT.innermostMeasurementState();
+
+      edm::RefToBase<TrajectorySeed> tmpSeed;
+      if (it->trackerTrack()->seedRef().isAvailable())
+        tmpSeed = it->trackerTrack()->seedRef();
+
+      if (!innerTsos.isValid()) {
+        LogTrace(theCategory) << "     inner Trajectory State is invalid. ";
+        continue;
+      }
+
+      innerTsos.rescaleError(100.);
+
+      TC refitted0, refitted1;
+      MuonCandidate* finalTrajectory = nullptr;
+      Trajectory* tkTrajectory = nullptr;
+
+      // tracker only track
+      if (!(it->trackerTrajectory() && it->trackerTrajectory()->isValid())) {
+        refitted0 = theTrackTransformer->transform(it->trackerTrack());
+        if (!refitted0.empty())
+          tkTrajectory = new Trajectory(*(refitted0.begin()));
+        else
+          edm::LogWarning(theCategory) << "     Failed to load tracker track trajectory";
+      } else
+        tkTrajectory = it->trackerTrajectory();
+      if (tkTrajectory)
+        tkTrajectory->setSeedRef(tmpSeed);
+
+      // full track with all muon hits using theGlbRefitter
+      ConstRecHitContainer allRecHits = trackerRecHits;
+      allRecHits.insert(allRecHits.end(), muonRecHits.begin(), muonRecHits.end());
+      refitted1 = theGlbRefitter->refit(*it->trackerTrack(), tTT, allRecHits, theMuonHitsOption, theTopo);
+      LogTrace(theCategory) << "     This track-sta refitted to " << refitted1.size() << " trajectories";
+
+      Trajectory* glbTrajectory1 = nullptr;
+      if (!refitted1.empty())
+        glbTrajectory1 = new Trajectory(*(refitted1.begin()));
+      else
+        LogDebug(theCategory) << "     Failed to load global track trajectory 1";
+      if (glbTrajectory1)
+        glbTrajectory1->setSeedRef(tmpSeed);
+
+      finalTrajectory = nullptr;
+      if (glbTrajectory1 && tkTrajectory)
+        finalTrajectory = new MuonCandidate(glbTrajectory1,
+                                            it->muonTrack(),
+                                            it->trackerTrack(),
+                                            tkTrajectory ? new Trajectory(*tkTrajectory) : nullptr);
+
+      if (finalTrajectory)
+        refittedResult.push_back(finalTrajectory);
+      if (tkTrajectory)
+        delete tkTrajectory;
+    } else {
+      MuonCandidate* finalTrajectory = nullptr;
+      edm::RefToBase<TrajectorySeed> tmpSeed;
+      if (it->trackerTrack()->seedRef().isAvailable())
+        tmpSeed = it->trackerTrack()->seedRef();
+
+      TC refitted0;
+      Trajectory* tkTrajectory = nullptr;
+      if (!(it->trackerTrajectory() && it->trackerTrajectory()->isValid())) {
+        refitted0 = theTrackTransformer->transform(it->trackerTrack());
+        if (!refitted0.empty()) {
+          tkTrajectory = new Trajectory(*(refitted0.begin()));
+        } else
+          edm::LogWarning(theCategory) << "     Failed to load tracker track trajectory";
+      } else
+        tkTrajectory = it->trackerTrajectory();
+      if (tkTrajectory)
+        tkTrajectory->setSeedRef(tmpSeed);
+      // Creating MuonCandidate using only the tracker trajectory:
+      finalTrajectory = new MuonCandidate(
+          new Trajectory(*tkTrajectory), it->muonTrack(), it->trackerTrack(), new Trajectory(*tkTrajectory));
+      if (finalTrajectory)
+        refittedResult.push_back(finalTrajectory);
+      if (tkTrajectory)
+        delete tkTrajectory;
+    }
   }
 
   // choose the best global fit for this Standalone Muon based on the track probability
   CandidateContainer selectedResult;
   MuonCandidate* tmpCand = nullptr;
-  if ( !refittedResult.empty() ) tmpCand = *(refittedResult.begin());
+  if (!refittedResult.empty())
+    tmpCand = *(refittedResult.begin());
   double minProb = std::numeric_limits<double>::max();
 
-  for (auto&& iter: refittedResult){
+  for (auto&& iter : refittedResult) {
     double prob = trackProbability(*iter->trajectory());
-    LogTrace(theCategory)<<"   refitted-track-sta with pT " << iter->trackerTrack()->pt() << " has probability " << prob;
+    LogTrace(theCategory) << "   refitted-track-sta with pT " << iter->trackerTrack()->pt() << " has probability "
+                          << prob;
 
     if (prob < minProb) {
       minProb = prob;
@@ -287,31 +307,34 @@ GlobalTrajectoryBuilderBase::build(const TrackCand& staCand,
     }
   }
 
-  if ( tmpCand )  selectedResult.push_back(new MuonCandidate(new Trajectory(*(tmpCand->trajectory())), tmpCand->muonTrack(), tmpCand->trackerTrack(), 
-							     (tmpCand->trackerTrajectory())? new Trajectory( *(tmpCand->trackerTrajectory()) ):nullptr ) );
+  if (tmpCand)
+    selectedResult.push_back(
+        new MuonCandidate(new Trajectory(*(tmpCand->trajectory())),
+                          tmpCand->muonTrack(),
+                          tmpCand->trackerTrack(),
+                          (tmpCand->trackerTrajectory()) ? new Trajectory(*(tmpCand->trackerTrajectory())) : nullptr));
 
-  for (auto&& it: refittedResult){
-    if ( it->trajectory() ) delete it->trajectory();
-    if ( it->trackerTrajectory() ) delete it->trackerTrajectory();
-    if ( it ) delete it;
+  for (auto&& it : refittedResult) {
+    if (it->trajectory())
+      delete it->trajectory();
+    if (it->trackerTrajectory())
+      delete it->trackerTrajectory();
+    if (it)
+      delete it;
   }
   refittedResult.clear();
 
   return selectedResult;
-
 }
-
 
 //
 // select tracker tracks within a region of interest
 //
-std::vector<GlobalTrajectoryBuilderBase::TrackCand>
-GlobalTrajectoryBuilderBase::chooseRegionalTrackerTracks(const TrackCand& staCand, 
-                                                         const std::vector<TrackCand>& tkTs) {
-  
+std::vector<GlobalTrajectoryBuilderBase::TrackCand> GlobalTrajectoryBuilderBase::chooseRegionalTrackerTracks(
+    const TrackCand& staCand, const std::vector<TrackCand>& tkTs) {
   // define eta-phi region
   RectangularEtaPhiTrackingRegion regionOfInterest = defineRegionOfInterest(staCand.second);
-  
+
   // get region's etaRange and phiMargin
   //UNUSED:  PixelRecoRange<float> etaRange = regionOfInterest.etaRange();
   //UNUSED:  TkTrackingRegionsMargin<float> phiMargin = regionOfInterest.phiMargin();
@@ -320,10 +343,11 @@ GlobalTrajectoryBuilderBase::chooseRegionalTrackerTracks(const TrackCand& staCan
 
   double deltaR_max = 1.0;
 
-  for (auto&& is: tkTs){
+  for (auto&& is : tkTs) {
     double deltaR_tmp = deltaR(static_cast<double>(regionOfInterest.direction().eta()),
-							   static_cast<double>(regionOfInterest.direction().phi()),
-							   is.second->eta(), is.second->phi());
+                               static_cast<double>(regionOfInterest.direction().phi()),
+                               is.second->eta(),
+                               is.second->phi());
 
     // for each trackCand in region, add trajectory and add to result
     //if ( inEtaRange && inPhiRange ) {
@@ -333,166 +357,150 @@ GlobalTrajectoryBuilderBase::chooseRegionalTrackerTracks(const TrackCand& staCan
     }
   }
 
-  return result; 
-
+  return result;
 }
-
 
 //
 // define a region of interest within the tracker
 //
-RectangularEtaPhiTrackingRegion 
-GlobalTrajectoryBuilderBase::defineRegionOfInterest(const reco::TrackRef& staTrack) const {
-
+RectangularEtaPhiTrackingRegion GlobalTrajectoryBuilderBase::defineRegionOfInterest(
+    const reco::TrackRef& staTrack) const {
   std::unique_ptr<RectangularEtaPhiTrackingRegion> region1 = theRegionBuilder->region(staTrack);
-  
-  TkTrackingRegionsMargin<float> etaMargin(std::abs(region1->etaRange().min() - region1->etaRange().mean()),
-					   std::abs(region1->etaRange().max() - region1->etaRange().mean()));
-  
-  RectangularEtaPhiTrackingRegion region2(region1->direction(),
-					  region1->origin(),
-					  region1->ptMin(),
-					  region1->originRBound(),
-					  region1->originZBound(),
-					  etaMargin,
-					  region1->phiMargin());
-  
-  return region2;
-  
-}
 
+  TkTrackingRegionsMargin<float> etaMargin(std::abs(region1->etaRange().min() - region1->etaRange().mean()),
+                                           std::abs(region1->etaRange().max() - region1->etaRange().mean()));
+
+  RectangularEtaPhiTrackingRegion region2(region1->direction(),
+                                          region1->origin(),
+                                          region1->ptMin(),
+                                          region1->originRBound(),
+                                          region1->originZBound(),
+                                          etaMargin,
+                                          region1->phiMargin());
+
+  return region2;
+}
 
 //
 // calculate the tail probability (-ln(P)) of a fit
 //
-double 
-GlobalTrajectoryBuilderBase::trackProbability(const Trajectory& track) const {
-
-  if ( track.ndof() > 0 && track.chiSquared() > 0 ) { 
+double GlobalTrajectoryBuilderBase::trackProbability(const Trajectory& track) const {
+  if (track.ndof() > 0 && track.chiSquared() > 0) {
     return -LnChiSquaredProbability(track.chiSquared(), track.ndof());
   } else {
     return 0.0;
   }
-
 }
-
 
 //
 // print RecHits
 //
 void GlobalTrajectoryBuilderBase::printHits(const ConstRecHitContainer& hits) const {
-
   LogTrace(theCategory) << "Used RecHits: " << hits.size();
-  for (auto&& ir: hits){
-    if ( !ir->isValid() ) {
+  for (auto&& ir : hits) {
+    if (!ir->isValid()) {
       LogTrace(theCategory) << "invalid RecHit";
-      continue; 
+      continue;
     }
-    
+
     const GlobalPoint& pos = ir->globalPosition();
-    
-    LogTrace(theCategory) 
-      << "r = " << sqrt(pos.x() * pos.x() + pos.y() * pos.y())
-      << "  z = " << pos.z()
-      << "  dimension = " << ir->dimension()
-      << "  " << ir->det()->geographicalId().det()
-      << "  " << ir->det()->subDetector();
 
+    LogTrace(theCategory) << "r = " << sqrt(pos.x() * pos.x() + pos.y() * pos.y()) << "  z = " << pos.z()
+                          << "  dimension = " << ir->dimension() << "  " << ir->det()->geographicalId().det() << "  "
+                          << ir->det()->subDetector();
   }
-
 }
 
 //
 // check order of RechIts on a trajectory
 //
-GlobalTrajectoryBuilderBase::RefitDirection
-GlobalTrajectoryBuilderBase::checkRecHitsOrdering(const TransientTrackingRecHit::ConstRecHitContainer& recHits) const {
-
-  if ( !recHits.empty() ) {
+GlobalTrajectoryBuilderBase::RefitDirection GlobalTrajectoryBuilderBase::checkRecHitsOrdering(
+    const TransientTrackingRecHit::ConstRecHitContainer& recHits) const {
+  if (!recHits.empty()) {
     ConstRecHitContainer::const_iterator frontHit = recHits.begin();
-    ConstRecHitContainer::const_iterator backHit  = recHits.end() - 1;
-    while ( !(*frontHit)->isValid() && frontHit != backHit ) {frontHit++;}
-    while ( !(*backHit)->isValid() && backHit != frontHit )  {backHit--;}
+    ConstRecHitContainer::const_iterator backHit = recHits.end() - 1;
+    while (!(*frontHit)->isValid() && frontHit != backHit) {
+      frontHit++;
+    }
+    while (!(*backHit)->isValid() && backHit != frontHit) {
+      backHit--;
+    }
 
     double rFirst = (*frontHit)->globalPosition().mag();
-    double rLast  = (*backHit) ->globalPosition().mag();
+    double rLast = (*backHit)->globalPosition().mag();
 
-    if ( rFirst < rLast ) return inToOut;
-    else if (rFirst > rLast) return outToIn;
+    if (rFirst < rLast)
+      return inToOut;
+    else if (rFirst > rLast)
+      return outToIn;
     else {
       edm::LogError(theCategory) << "Impossible to determine the rechits order" << std::endl;
       return undetermined;
     }
-  }
-  else {
+  } else {
     edm::LogError(theCategory) << "Impossible to determine the rechits order" << std::endl;
     return undetermined;
   }
 }
 
-
 //
 // select trajectories with only a single TEC hit
 //
-GlobalTrajectoryBuilderBase::ConstRecHitContainer 
-GlobalTrajectoryBuilderBase::selectTrackerHits(const ConstRecHitContainer& all) const {
- 
+GlobalTrajectoryBuilderBase::ConstRecHitContainer GlobalTrajectoryBuilderBase::selectTrackerHits(
+    const ConstRecHitContainer& all) const {
   int nTEC(0);
 
   ConstRecHitContainer hits;
-  for (auto&& i: all){
-    if ( !i->isValid() ) continue;
-    if ( i->det()->geographicalId().det() == DetId::Tracker &&
-         i->det()->geographicalId().subdetId() == StripSubdetector::TEC) {
+  for (auto&& i : all) {
+    if (!i->isValid())
+      continue;
+    if (i->det()->geographicalId().det() == DetId::Tracker &&
+        i->det()->geographicalId().subdetId() == StripSubdetector::TEC) {
       nTEC++;
     } else {
       hits.push_back(i);
     }
-    if ( nTEC > 1 ) return all;
+    if (nTEC > 1)
+      return all;
   }
 
   return hits;
-
 }
-
 
 //
 // rescale errors of outermost TEC RecHit
 //
-void GlobalTrajectoryBuilderBase::fixTEC(ConstRecHitContainer& all,
-                                         double scl_x,
-                                         double scl_y) const {
-
+void GlobalTrajectoryBuilderBase::fixTEC(ConstRecHitContainer& all, double scl_x, double scl_y) const {
   int nTEC(0);
   ConstRecHitContainer::iterator lone_tec;
 
-  for ( ConstRecHitContainer::iterator i = all.begin(); i != all.end(); i++) {
-    if ( !(*i)->isValid() ) continue;
-    
-    if ( (*i)->det()->geographicalId().det() == DetId::Tracker &&
-         (*i)->det()->geographicalId().subdetId() == StripSubdetector::TEC) {
+  for (ConstRecHitContainer::iterator i = all.begin(); i != all.end(); i++) {
+    if (!(*i)->isValid())
+      continue;
+
+    if ((*i)->det()->geographicalId().det() == DetId::Tracker &&
+        (*i)->det()->geographicalId().subdetId() == StripSubdetector::TEC) {
       lone_tec = i;
       nTEC++;
-      
-      if ( (i+1) != all.end() && (*(i+1))->isValid() &&
-          (*(i+1))->det()->geographicalId().det() == DetId::Tracker &&
-          (*(i+1))->det()->geographicalId().subdetId() == StripSubdetector::TEC) {
+
+      if ((i + 1) != all.end() && (*(i + 1))->isValid() &&
+          (*(i + 1))->det()->geographicalId().det() == DetId::Tracker &&
+          (*(i + 1))->det()->geographicalId().subdetId() == StripSubdetector::TEC) {
         nTEC++;
         break;
       }
     }
-    
-    if (nTEC > 1) break;
+
+    if (nTEC > 1)
+      break;
   }
-  
+
   int hitDet = (*lone_tec)->hit()->geographicalId().det();
   int hitSubDet = (*lone_tec)->hit()->geographicalId().subdetId();
-  if ( nTEC == 1 && (*lone_tec)->hit()->isValid() &&
-       hitDet == DetId::Tracker && hitSubDet == StripSubdetector::TEC) {
-    
+  if (nTEC == 1 && (*lone_tec)->hit()->isValid() && hitDet == DetId::Tracker && hitSubDet == StripSubdetector::TEC) {
     // rescale the TEC rechit error matrix in its rotated frame
     const SiStripRecHit2D* strip = dynamic_cast<const SiStripRecHit2D*>((*lone_tec)->hit());
-    if (strip && strip->det() ) {
+    if (strip && strip->det()) {
       LocalPoint pos = strip->localPosition();
       if ((*lone_tec)->detUnit()) {
         const StripTopology* topology = dynamic_cast<const StripTopology*>(&(*lone_tec)->detUnit()->topology());
@@ -503,65 +511,60 @@ void GlobalTrajectoryBuilderBase::fixTEC(ConstRecHitContainer& all,
           LocalError rotError = error.rotate(angle);
           LocalError scaledError(rotError.xx() * scl_x * scl_x, 0, rotError.yy() * scl_y * scl_y);
           error = scaledError.rotate(-angle);
-             /// freeze this hit, make sure it will not be recomputed during fitting
-            //// the implemetantion below works with cloning
-            //// to get a RecHitPointer to SiStripRecHit2D, the only  method that works is
-            //// RecHitPointer MuonTransientTrackingRecHit::build(const GeomDet*,const TrackingRecHit*)
-            SiStripRecHit2D* st = new SiStripRecHit2D(pos,error,
-                                                      *strip->det(),
-                                                      strip->cluster());
-            *lone_tec = MuonTransientTrackingRecHit::build((*lone_tec)->det(),st);
- 
+          /// freeze this hit, make sure it will not be recomputed during fitting
+          //// the implemetantion below works with cloning
+          //// to get a RecHitPointer to SiStripRecHit2D, the only  method that works is
+          //// RecHitPointer MuonTransientTrackingRecHit::build(const GeomDet*,const TrackingRecHit*)
+          SiStripRecHit2D* st = new SiStripRecHit2D(pos, error, *strip->det(), strip->cluster());
+          *lone_tec = MuonTransientTrackingRecHit::build((*lone_tec)->det(), st);
         }
       }
     }
   }
-
 }
-
 
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
 //
 // get transient RecHits
 //
-TransientTrackingRecHit::ConstRecHitContainer
-GlobalTrajectoryBuilderBase::getTransientRecHits(const reco::Track& track) const {
-
+TransientTrackingRecHit::ConstRecHitContainer GlobalTrajectoryBuilderBase::getTransientRecHits(
+    const reco::Track& track) const {
   TransientTrackingRecHit::ConstRecHitContainer result;
-  
-  
 
-  TrajectoryStateOnSurface currTsos = trajectoryStateTransform::innerStateOnSurface(track, *theService->trackingGeometry(), &*theService->magneticField());
+  TrajectoryStateOnSurface currTsos = trajectoryStateTransform::innerStateOnSurface(
+      track, *theService->trackingGeometry(), &*theService->magneticField());
 
-  auto tkbuilder = static_cast<TkTransientTrackingRecHitBuilder const *>(theTrackerRecHitBuilder.product());
-  auto hitCloner = tkbuilder->cloner(); 
+  auto tkbuilder = static_cast<TkTransientTrackingRecHitBuilder const*>(theTrackerRecHitBuilder.product());
+  auto hitCloner = tkbuilder->cloner();
   for (trackingRecHit_iterator hit = track.recHitsBegin(); hit != track.recHitsEnd(); ++hit) {
-    if((*hit)->isValid()) {
+    if ((*hit)->isValid()) {
       DetId recoid = (*hit)->geographicalId();
-      if ( recoid.det() == DetId::Tracker ) {
-	if (!(*hit)->hasPositionAndError()){
-	  TrajectoryStateOnSurface predTsos =  theService->propagator(theTrackerPropagatorName)->propagate(currTsos, theService->trackingGeometry()->idToDet(recoid)->surface());
-	  
-	  if ( !predTsos.isValid() ) {
-	    edm::LogError("MissingTransientHit")
-	      <<"Could not get a tsos on the hit surface. We will miss a tracking hit.";
-	    continue; 
-	  }
-	  currTsos = predTsos;
-          auto h = (**hit).cloneForFit(*tkbuilder->geometry()->idToDet( (**hit).geographicalId() ) );
-	  result.emplace_back(hitCloner.makeShared(h,predTsos));
-	}else{
-	  result.push_back((*hit)->cloneSH());
-	}
-      } else if ( recoid.det() == DetId::Muon ) {
-	if ( (*hit)->geographicalId().subdetId() == 3 && !theRPCInTheFit) {
-	  LogDebug(theCategory) << "RPC Rec Hit discarded"; 
-	  continue;
-	}
-	result.push_back(theMuonRecHitBuilder->build(&**hit));
+      if (recoid.det() == DetId::Tracker) {
+        if (!(*hit)->hasPositionAndError()) {
+          TrajectoryStateOnSurface predTsos =
+              theService->propagator(theTrackerPropagatorName)
+                  ->propagate(currTsos, theService->trackingGeometry()->idToDet(recoid)->surface());
+
+          if (!predTsos.isValid()) {
+            edm::LogError("MissingTransientHit")
+                << "Could not get a tsos on the hit surface. We will miss a tracking hit.";
+            continue;
+          }
+          currTsos = predTsos;
+          auto h = (**hit).cloneForFit(*tkbuilder->geometry()->idToDet((**hit).geographicalId()));
+          result.emplace_back(hitCloner.makeShared(h, predTsos));
+        } else {
+          result.push_back((*hit)->cloneSH());
+        }
+      } else if (recoid.det() == DetId::Muon) {
+        if ((*hit)->geographicalId().subdetId() == 3 && !theRPCInTheFit) {
+          LogDebug(theCategory) << "RPC Rec Hit discarded";
+          continue;
+        }
+        result.push_back(theMuonRecHitBuilder->build(&**hit));
       }
     }
   }
-  
+
   return result;
 }

--- a/RecoMuon/GlobalTrackingTools/src/MuonTrackingRegionBuilder.cc
+++ b/RecoMuon/GlobalTrackingTools/src/MuonTrackingRegionBuilder.cc
@@ -30,14 +30,13 @@
 // constructor
 //
 void MuonTrackingRegionBuilder::build(const edm::ParameterSet& par, edm::ConsumesCollector& iC) {
-
   // Adjust errors on Eta, Phi, Z
-  theNsigmaEta  = par.getParameter<double>("Rescale_eta");
-  theNsigmaPhi  = par.getParameter<double>("Rescale_phi");
-  theNsigmaDz   = par.getParameter<double>("Rescale_Dz");
+  theNsigmaEta = par.getParameter<double>("Rescale_eta");
+  theNsigmaPhi = par.getParameter<double>("Rescale_phi");
+  theNsigmaDz = par.getParameter<double>("Rescale_Dz");
 
   // Upper limits parameters
-  theEtaRegionPar1 = par.getParameter<double>("EtaR_UpperLimit_Par1"); 
+  theEtaRegionPar1 = par.getParameter<double>("EtaR_UpperLimit_Par1");
   theEtaRegionPar2 = par.getParameter<double>("EtaR_UpperLimit_Par2");
   thePhiRegionPar1 = par.getParameter<double>("PhiR_UpperLimit_Par1");
   thePhiRegionPar2 = par.getParameter<double>("PhiR_UpperLimit_Par2");
@@ -61,7 +60,7 @@ void MuonTrackingRegionBuilder::build(const edm::ParameterSet& par, edm::Consume
   theEtaMin = par.getParameter<double>("Eta_min");
 
   // The static region size along the Z direction
-  theHalfZ  = par.getParameter<double>("DeltaZ");
+  theHalfZ = par.getParameter<double>("DeltaZ");
 
   // The transverse distance of the region from the BS/PV
   theDeltaR = par.getParameter<double>("DeltaR");
@@ -76,12 +75,13 @@ void MuonTrackingRegionBuilder::build(const edm::ParameterSet& par, edm::Consume
   theMaxRegions = par.getParameter<int>("maxRegions");
 
   // Flag to use precise??
-  thePrecise = par.getParameter<bool>("precise"); 
+  thePrecise = par.getParameter<bool>("precise");
 
   // perigee reference point ToDo: Check this
   theOnDemand = RectangularEtaPhiTrackingRegion::intToUseMeasurementTracker(par.getParameter<int>("OnDemand"));
   if (theOnDemand != RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever) {
-    theMeasurementTrackerToken = iC.consumes<MeasurementTrackerEvent>(par.getParameter<edm::InputTag>("MeasurementTrackerName"));
+    theMeasurementTrackerToken =
+        iC.consumes<MeasurementTrackerEvent>(par.getParameter<edm::InputTag>("MeasurementTrackerName"));
   }
 
   // Vertex collection and Beam Spot
@@ -92,12 +92,11 @@ void MuonTrackingRegionBuilder::build(const edm::ParameterSet& par, edm::Consume
   inputCollectionToken = iC.consumes<reco::TrackCollection>(par.getParameter<edm::InputTag>("input"));
 }
 
-
 //
 // Member function to be compatible with TrackingRegionProducerFactory: create many ROI for many tracks
 //
-std::vector<std::unique_ptr<TrackingRegion>> MuonTrackingRegionBuilder::regions(const edm::Event& ev, const edm::EventSetup& es) const {
-	
+std::vector<std::unique_ptr<TrackingRegion>> MuonTrackingRegionBuilder::regions(const edm::Event& ev,
+                                                                                const edm::EventSetup& es) const {
   std::vector<std::unique_ptr<TrackingRegion>> result;
 
   edm::Handle<reco::TrackCollection> tracks;
@@ -105,14 +104,12 @@ std::vector<std::unique_ptr<TrackingRegion>> MuonTrackingRegionBuilder::regions(
 
   int nRegions = 0;
   for (auto it = tracks->cbegin(), ed = tracks->cend(); it != ed && nRegions < theMaxRegions; ++it) {
-    result.push_back(region(*it,ev));
-    nRegions++; 
+    result.push_back(region(*it, ev));
+    nRegions++;
   }
 
   return result;
-
 }
-
 
 //
 // Call region on Track from TrackRef
@@ -121,34 +118,30 @@ std::unique_ptr<RectangularEtaPhiTrackingRegion> MuonTrackingRegionBuilder::regi
   return region(*track);
 }
 
-
 //
 // ToDo: Not sure if this is needed?
 //
-void MuonTrackingRegionBuilder::setEvent(const edm::Event& event) {
-  theEvent = &event;
-}
-
+void MuonTrackingRegionBuilder::setEvent(const edm::Event& event) { theEvent = &event; }
 
 //
 //	Main member function called to create the ROI
 //
-std::unique_ptr<RectangularEtaPhiTrackingRegion> MuonTrackingRegionBuilder::region(const reco::Track& staTrack, const edm::Event& ev) const {
-
+std::unique_ptr<RectangularEtaPhiTrackingRegion> MuonTrackingRegionBuilder::region(const reco::Track& staTrack,
+                                                                                   const edm::Event& ev) const {
   // get track momentum/direction at vertex
   const math::XYZVector& mom = staTrack.momentum();
-  GlobalVector dirVector(mom.x(),mom.y(),mom.z());
+  GlobalVector dirVector(mom.x(), mom.y(), mom.z());
   double pt = staTrack.pt();
 
   // Fix for StandAlone tracks with low momentum
   const math::XYZVector& innerMomentum = staTrack.innerMomentum();
-  GlobalVector forSmallMomentum(innerMomentum.x(),innerMomentum.y(),innerMomentum.z());
-  if ( staTrack.p() <= 1.5 ) {
+  GlobalVector forSmallMomentum(innerMomentum.x(), innerMomentum.y(), innerMomentum.z());
+  if (staTrack.p() <= 1.5) {
     pt = std::abs(forSmallMomentum.perp());
   }
 
   // initial vertex position - in the following it is replaced with beamspot/vertexing
-  GlobalPoint vertexPos(0.0,0.0,0.0);
+  GlobalPoint vertexPos(0.0, 0.0, 0.0);
   // standard 15.9, if useVertex than use error from  vertex
   double deltaZ = theHalfZ;
 
@@ -157,7 +150,7 @@ std::unique_ptr<RectangularEtaPhiTrackingRegion> MuonTrackingRegionBuilder::regi
   bool bsHandleFlag = ev.getByToken(beamSpotToken, bs);
 
   // check the validity, otherwise vertexing
-  if ( bsHandleFlag && bs.isValid() && !useVertex ) {
+  if (bsHandleFlag && bs.isValid() && !useVertex) {
     vertexPos = GlobalPoint(bs->x0(), bs->y0(), bs->z0());
     deltaZ = useFixedZ ? theHalfZ : bs->sigmaZ() * theNsigmaDz;
   } else {
@@ -165,11 +158,11 @@ std::unique_ptr<RectangularEtaPhiTrackingRegion> MuonTrackingRegionBuilder::regi
     edm::Handle<reco::VertexCollection> vertexCollection;
     bool vtxHandleFlag = ev.getByToken(vertexCollectionToken, vertexCollection);
     // check if there exists at least one reconstructed vertex
-    if ( vtxHandleFlag && !vertexCollection->empty() ) {
-      // use the first vertex in the collection and assume it is the primary event vertex 
+    if (vtxHandleFlag && !vertexCollection->empty()) {
+      // use the first vertex in the collection and assume it is the primary event vertex
       reco::VertexCollection::const_iterator vtx = vertexCollection->begin();
-      if (!vtx->isFake() && vtx->isValid() ) {
-        vertexPos = GlobalPoint(vtx->x(),vtx->y(),vtx->z());
+      if (!vtx->isFake() && vtx->isValid()) {
+        vertexPos = GlobalPoint(vtx->x(), vtx->y(), vtx->z());
         deltaZ = useFixedZ ? theHalfZ : vtx->zError() * theNsigmaDz;
       }
     }
@@ -180,8 +173,8 @@ std::unique_ptr<RectangularEtaPhiTrackingRegion> MuonTrackingRegionBuilder::regi
   double dphi = 0.6;
 
   // evaluate the dynamical region if possible
-  deta = theNsigmaEta*(staTrack.etaError());
-  dphi = theNsigmaPhi*(staTrack.phiError());
+  deta = theNsigmaEta * (staTrack.etaError());
+  dphi = theNsigmaPhi * (staTrack.phiError());
 
   // Region_Parametrizations to take into account possible L2 error matrix inconsistencies
   double region_dEta = 0;
@@ -190,39 +183,38 @@ std::unique_ptr<RectangularEtaPhiTrackingRegion> MuonTrackingRegionBuilder::regi
   double phi = 0;
 
   // eta, pt parametrization from MC study (circa 2009?)
-  if ( pt <= 10. ) {
-     // angular coefficients
-     float acoeff_Phi = (thePhiRegionPar2 - thePhiRegionPar1)/5;
-     float acoeff_Eta = (theEtaRegionPar2 - theEtaRegionPar1)/5;
+  if (pt <= 10.) {
+    // angular coefficients
+    float acoeff_Phi = (thePhiRegionPar2 - thePhiRegionPar1) / 5;
+    float acoeff_Eta = (theEtaRegionPar2 - theEtaRegionPar1) / 5;
 
-     eta = theEtaRegionPar1 + (acoeff_Eta)*(pt-5.);
-     phi = thePhiRegionPar1 + (acoeff_Phi)*(pt-5.) ;
+    eta = theEtaRegionPar1 + (acoeff_Eta) * (pt - 5.);
+    phi = thePhiRegionPar1 + (acoeff_Phi) * (pt - 5.);
   }
-  // parametrization 2nd bin in pt from MC study  
-  if ( pt > 10. && pt < 100. ) {
-     eta = theEtaRegionPar2;
-     phi = thePhiRegionPar2;
+  // parametrization 2nd bin in pt from MC study
+  if (pt > 10. && pt < 100.) {
+    eta = theEtaRegionPar2;
+    phi = thePhiRegionPar2;
   }
   // parametrization 3rd bin in pt from MC study
-  if ( pt >= 100. ) {
-     // angular coefficients
-     float acoeff_Phi = (thePhiRegionPar1 - thePhiRegionPar2)/900;
-     float acoeff_Eta = (theEtaRegionPar1 - theEtaRegionPar2)/900;
+  if (pt >= 100.) {
+    // angular coefficients
+    float acoeff_Phi = (thePhiRegionPar1 - thePhiRegionPar2) / 900;
+    float acoeff_Eta = (theEtaRegionPar1 - theEtaRegionPar2) / 900;
 
-     eta = theEtaRegionPar2 + (acoeff_Eta)*(pt-100.);
-     phi = thePhiRegionPar2 + (acoeff_Phi)*(pt-100.);
+    eta = theEtaRegionPar2 + (acoeff_Eta) * (pt - 100.);
+    phi = thePhiRegionPar2 + (acoeff_Phi) * (pt - 100.);
   }
 
-  double region_dPhi1 = std::min(phi,dphi);
-  double region_dEta1 = std::min(eta,deta);
+  double region_dPhi1 = std::min(phi, dphi);
+  double region_dEta1 = std::min(eta, deta);
 
   // decide to use either a parametrization or a dynamical region
-  region_dPhi = useFixedPhi ? theDeltaPhi : std::max(thePhiMin,region_dPhi1);
-  region_dEta = useFixedEta ? theDeltaEta : std::max(theEtaMin,region_dEta1);
+  region_dPhi = useFixedPhi ? theDeltaPhi : std::max(thePhiMin, region_dPhi1);
+  region_dEta = useFixedEta ? theDeltaEta : std::max(theEtaMin, region_dEta1);
 
   float deltaR = theDeltaR;
-  double minPt = useFixedPt ? thePtMin : std::max(thePtMin,pt*0.6);
-
+  double minPt = useFixedPt ? thePtMin : std::max(thePtMin, pt * 0.6);
 
   const MeasurementTrackerEvent* measurementTracker = nullptr;
   if (!theMeasurementTrackerToken.isUninitialized()) {
@@ -231,95 +223,87 @@ std::unique_ptr<RectangularEtaPhiTrackingRegion> MuonTrackingRegionBuilder::regi
     measurementTracker = hmte.product();
   }
 
-  auto region = std::make_unique<RectangularEtaPhiTrackingRegion>(dirVector, vertexPos,
-                                               minPt, deltaR,
-                                               deltaZ, region_dEta, region_dPhi,
-                                               theOnDemand,
-                                               thePrecise,
-                                               measurementTracker);
+  auto region = std::make_unique<RectangularEtaPhiTrackingRegion>(
+      dirVector, vertexPos, minPt, deltaR, deltaZ, region_dEta, region_dPhi, theOnDemand, thePrecise, measurementTracker);
 
-  LogDebug("MuonTrackingRegionBuilder")<<"the region parameters are:\n"
-				       <<"\n dirVector: "<<dirVector
-				       <<"\n vertexPos: "<<vertexPos
-				       <<"\n minPt: "<<minPt
-				       <<"\n deltaR:"<<deltaR
-				       <<"\n deltaZ:"<<deltaZ
-				       <<"\n region_dEta:"<<region_dEta
-				       <<"\n region_dPhi:"<<region_dPhi
-				       <<"\n on demand parameter: "<<static_cast<int>(theOnDemand);
-  
+  LogDebug("MuonTrackingRegionBuilder") << "the region parameters are:\n"
+                                        << "\n dirVector: " << dirVector << "\n vertexPos: " << vertexPos
+                                        << "\n minPt: " << minPt << "\n deltaR:" << deltaR << "\n deltaZ:" << deltaZ
+                                        << "\n region_dEta:" << region_dEta << "\n region_dPhi:" << region_dPhi
+                                        << "\n on demand parameter: " << static_cast<int>(theOnDemand);
+
   return region;
-
 }
 
 void MuonTrackingRegionBuilder::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   {
     edm::ParameterSetDescription desc;
     fillDescriptionsOffline(desc);
-    descriptions.add("MuonTrackingRegionBuilder",desc);
+    descriptions.add("MuonTrackingRegionBuilder", desc);
   }
   {
     edm::ParameterSetDescription desc;
     fillDescriptionsHLT(desc);
-    descriptions.add("MuonTrackingRegionBuilderHLT",desc);
+    descriptions.add("MuonTrackingRegionBuilderHLT", desc);
   }
-  descriptions.setComment("Build a TrackingRegion around a standalone muon. Options to define region around beamspot or primary vertex and dynamic regions are included.");
+  descriptions.setComment(
+      "Build a TrackingRegion around a standalone muon. Options to define region around beamspot or primary vertex and "
+      "dynamic regions are included.");
 }
 void MuonTrackingRegionBuilder::fillDescriptionsHLT(edm::ParameterSetDescription& desc) {
-  desc.add<double>("EtaR_UpperLimit_Par1",0.25);
-  desc.add<double>("DeltaR",0.2);
-  desc.add<edm::InputTag>("beamSpot",edm::InputTag("hltOnlineBeamSpot"));
-  desc.add<int>("OnDemand",-1);
-  desc.add<edm::InputTag>("vertexCollection",edm::InputTag("pixelVertices"));
-  desc.add<double>("Rescale_phi",3.0);
-  desc.add<bool>("Eta_fixed",false);
-  desc.add<double>("Rescale_eta",3.0);
-  desc.add<double>("PhiR_UpperLimit_Par2",0.2);
-  desc.add<double>("Eta_min",0.05);
-  desc.add<bool>("Phi_fixed",false);
-  desc.add<double>("Phi_min",0.05);
-  desc.add<double>("PhiR_UpperLimit_Par1",0.6);
-  desc.add<double>("EtaR_UpperLimit_Par2",0.15);
-  desc.add<edm::InputTag>("MeasurementTrackerName",edm::InputTag("hltESPMeasurementTracker"));
-  desc.add<bool>("UseVertex",false);
-  desc.add<double>("Rescale_Dz",3.0);
-  desc.add<bool>("Pt_fixed",false);
-  desc.add<bool>("Z_fixed",true);
-  desc.add<double>("Pt_min",1.5);
-  desc.add<double>("DeltaZ",15.9);
-  desc.add<double>("DeltaEta",0.2);
-  desc.add<double>("DeltaPhi",0.2);
-  desc.add<int>("maxRegions",1);
-  desc.add<bool>("precise",true);
-  desc.add<edm::InputTag>("input",edm::InputTag("hltL2Muons","UpdatedAtVtx"));
+  desc.add<double>("EtaR_UpperLimit_Par1", 0.25);
+  desc.add<double>("DeltaR", 0.2);
+  desc.add<edm::InputTag>("beamSpot", edm::InputTag("hltOnlineBeamSpot"));
+  desc.add<int>("OnDemand", -1);
+  desc.add<edm::InputTag>("vertexCollection", edm::InputTag("pixelVertices"));
+  desc.add<double>("Rescale_phi", 3.0);
+  desc.add<bool>("Eta_fixed", false);
+  desc.add<double>("Rescale_eta", 3.0);
+  desc.add<double>("PhiR_UpperLimit_Par2", 0.2);
+  desc.add<double>("Eta_min", 0.05);
+  desc.add<bool>("Phi_fixed", false);
+  desc.add<double>("Phi_min", 0.05);
+  desc.add<double>("PhiR_UpperLimit_Par1", 0.6);
+  desc.add<double>("EtaR_UpperLimit_Par2", 0.15);
+  desc.add<edm::InputTag>("MeasurementTrackerName", edm::InputTag("hltESPMeasurementTracker"));
+  desc.add<bool>("UseVertex", false);
+  desc.add<double>("Rescale_Dz", 3.0);
+  desc.add<bool>("Pt_fixed", false);
+  desc.add<bool>("Z_fixed", true);
+  desc.add<double>("Pt_min", 1.5);
+  desc.add<double>("DeltaZ", 15.9);
+  desc.add<double>("DeltaEta", 0.2);
+  desc.add<double>("DeltaPhi", 0.2);
+  desc.add<int>("maxRegions", 1);
+  desc.add<bool>("precise", true);
+  desc.add<edm::InputTag>("input", edm::InputTag("hltL2Muons", "UpdatedAtVtx"));
 }
 
 void MuonTrackingRegionBuilder::fillDescriptionsOffline(edm::ParameterSetDescription& desc) {
-  desc.add<double>("EtaR_UpperLimit_Par1",0.25);
-  desc.add<double>("DeltaR",0.2);
-  desc.add<edm::InputTag>("beamSpot",edm::InputTag(""));
-  desc.add<int>("OnDemand",-1);
-  desc.add<edm::InputTag>("vertexCollection",edm::InputTag(""));
-  desc.add<double>("Rescale_phi",3.0);
-  desc.add<bool>("Eta_fixed",false);
-  desc.add<double>("Rescale_eta",3.0);
-  desc.add<double>("PhiR_UpperLimit_Par2",0.2);
-  desc.add<double>("Eta_min",0.05);
-  desc.add<bool>("Phi_fixed",false);
-  desc.add<double>("Phi_min",0.05);
-  desc.add<double>("PhiR_UpperLimit_Par1",0.6);
-  desc.add<double>("EtaR_UpperLimit_Par2",0.15);
-  desc.add<edm::InputTag>("MeasurementTrackerName",edm::InputTag(""));
-  desc.add<bool>("UseVertex",false);
-  desc.add<double>("Rescale_Dz",3.0);
-  desc.add<bool>("Pt_fixed",false);
-  desc.add<bool>("Z_fixed",true);
-  desc.add<double>("Pt_min",1.5);
-  desc.add<double>("DeltaZ",15.9);
-  desc.add<double>("DeltaEta",0.2);
-  desc.add<double>("DeltaPhi",0.2);
-  desc.add<int>("maxRegions",1);
-  desc.add<bool>("precise",true);
-  desc.add<edm::InputTag>("input",edm::InputTag(""));
-
+  desc.add<double>("EtaR_UpperLimit_Par1", 0.25);
+  desc.add<double>("DeltaR", 0.2);
+  desc.add<edm::InputTag>("beamSpot", edm::InputTag(""));
+  desc.add<int>("OnDemand", -1);
+  desc.add<edm::InputTag>("vertexCollection", edm::InputTag(""));
+  desc.add<double>("Rescale_phi", 3.0);
+  desc.add<bool>("Eta_fixed", false);
+  desc.add<double>("Rescale_eta", 3.0);
+  desc.add<double>("PhiR_UpperLimit_Par2", 0.2);
+  desc.add<double>("Eta_min", 0.05);
+  desc.add<bool>("Phi_fixed", false);
+  desc.add<double>("Phi_min", 0.05);
+  desc.add<double>("PhiR_UpperLimit_Par1", 0.6);
+  desc.add<double>("EtaR_UpperLimit_Par2", 0.15);
+  desc.add<edm::InputTag>("MeasurementTrackerName", edm::InputTag(""));
+  desc.add<bool>("UseVertex", false);
+  desc.add<double>("Rescale_Dz", 3.0);
+  desc.add<bool>("Pt_fixed", false);
+  desc.add<bool>("Z_fixed", true);
+  desc.add<double>("Pt_min", 1.5);
+  desc.add<double>("DeltaZ", 15.9);
+  desc.add<double>("DeltaEta", 0.2);
+  desc.add<double>("DeltaPhi", 0.2);
+  desc.add<int>("maxRegions", 1);
+  desc.add<bool>("precise", true);
+  desc.add<edm::InputTag>("input", edm::InputTag(""));
 }

--- a/RecoMuon/GlobalTrackingTools/src/StateSegmentMatcher.cc
+++ b/RecoMuon/GlobalTrackingTools/src/StateSegmentMatcher.cc
@@ -13,28 +13,39 @@
 
 using namespace std;
 
-
-
-StateSegmentMatcher::StateSegmentMatcher(TrajectoryStateOnSurface const &tsos, DTRecSegment4D const &dtseg4d, LocalError const &apeLoc)
-{
+StateSegmentMatcher::StateSegmentMatcher(TrajectoryStateOnSurface const &tsos,
+                                         DTRecSegment4D const &dtseg4d,
+                                         LocalError const &apeLoc) {
   if (dtseg4d.hasPhi() && dtseg4d.hasZed()) {
     setAPE4d(apeLoc);
     match2D = false;
-    AlgebraicVector dtseg = dtseg4d.parameters();                                                         
-    v1[0] = dtseg[0]; 
-    v1[1] = dtseg[1]; 
-    v1[2] = dtseg[2]; 
-    v1[3] = dtseg[3]; 
+    AlgebraicVector dtseg = dtseg4d.parameters();
+    v1[0] = dtseg[0];
+    v1[1] = dtseg[1];
+    v1[2] = dtseg[2];
+    v1[3] = dtseg[3];
 
-    AlgebraicSymMatrix rhErr_vect       = dtseg4d.parametersError(); 
-    m1(0,0) = rhErr_vect(1,1); m1(0,1) = rhErr_vect(1,2); m1(0,2) = rhErr_vect(1,3);m1(0,3) = rhErr_vect(1,4); 
-    m1(1,0) = rhErr_vect(2,1); m1(1,1) = rhErr_vect(2,2); m1(1,2) = rhErr_vect(2,3);m1(1,3) = rhErr_vect(2,4); 
-    m1(2,0) = rhErr_vect(3,1); m1(2,1) = rhErr_vect(3,2); m1(2,2) = rhErr_vect(3,3);m1(2,3) = rhErr_vect(3,4); 
-    m1(3,0) = rhErr_vect(4,1); m1(3,1) = rhErr_vect(4,2); m1(3,2) = rhErr_vect(4,3);m1(3,3) = rhErr_vect(4,4);
-    
-    Tsos4D tsos4d = Tsos4D(tsos);                                                                                                                                             
-    v2 = tsos4d.paramVector();                                                            
-    m2 = tsos4d.errorMatrix();  
+    AlgebraicSymMatrix rhErr_vect = dtseg4d.parametersError();
+    m1(0, 0) = rhErr_vect(1, 1);
+    m1(0, 1) = rhErr_vect(1, 2);
+    m1(0, 2) = rhErr_vect(1, 3);
+    m1(0, 3) = rhErr_vect(1, 4);
+    m1(1, 0) = rhErr_vect(2, 1);
+    m1(1, 1) = rhErr_vect(2, 2);
+    m1(1, 2) = rhErr_vect(2, 3);
+    m1(1, 3) = rhErr_vect(2, 4);
+    m1(2, 0) = rhErr_vect(3, 1);
+    m1(2, 1) = rhErr_vect(3, 2);
+    m1(2, 2) = rhErr_vect(3, 3);
+    m1(2, 3) = rhErr_vect(3, 4);
+    m1(3, 0) = rhErr_vect(4, 1);
+    m1(3, 1) = rhErr_vect(4, 2);
+    m1(3, 2) = rhErr_vect(4, 3);
+    m1(3, 3) = rhErr_vect(4, 4);
+
+    Tsos4D tsos4d = Tsos4D(tsos);
+    v2 = tsos4d.paramVector();
+    m2 = tsos4d.errorMatrix();
   } else {
     setAPE2d(apeLoc);
     match2D = true;
@@ -43,27 +54,28 @@ StateSegmentMatcher::StateSegmentMatcher(TrajectoryStateOnSurface const &tsos, D
     v1_2d[1] = dtseg[1];
 
     AlgebraicSymMatrix rhErr_vect = dtseg4d.parametersError();
-    m1_2d(0,0) = rhErr_vect(1,1); m1_2d(0,1) = rhErr_vect(1,2); 
-    m1_2d(1,0) = rhErr_vect(2,1); m1_2d(1,1) = rhErr_vect(2,2); 
-            
+    m1_2d(0, 0) = rhErr_vect(1, 1);
+    m1_2d(0, 1) = rhErr_vect(1, 2);
+    m1_2d(1, 0) = rhErr_vect(2, 1);
+    m1_2d(1, 1) = rhErr_vect(2, 2);
+
     if (dtseg4d.hasPhi()) {
-      Tsos2DPhi  tsos2d = Tsos2DPhi(tsos);
+      Tsos2DPhi tsos2d = Tsos2DPhi(tsos);
       v2_2d = tsos2d.paramVector();
       m2_2d = tsos2d.errorMatrix();
     }
 
     if (dtseg4d.hasZed()) {
-      Tsos2DZed  tsos2d = Tsos2DZed(tsos);
+      Tsos2DZed tsos2d = Tsos2DZed(tsos);
       v2_2d = tsos2d.paramVector();
       m2_2d = tsos2d.errorMatrix();
     }
   }
 }
 
-
-
-StateSegmentMatcher::StateSegmentMatcher(TrajectoryStateOnSurface const &tsos, CSCSegment const &cscseg4d, LocalError const &apeLoc)
-{
+StateSegmentMatcher::StateSegmentMatcher(TrajectoryStateOnSurface const &tsos,
+                                         CSCSegment const &cscseg4d,
+                                         LocalError const &apeLoc) {
   setAPE4d(apeLoc);
   match2D = false;
   AlgebraicVector cscseg = cscseg4d.parameters();
@@ -73,46 +85,53 @@ StateSegmentMatcher::StateSegmentMatcher(TrajectoryStateOnSurface const &tsos, C
   v1[3] = cscseg[3];
 
   AlgebraicSymMatrix rhErr_vect = cscseg4d.parametersError();
-  m1(0,0) = rhErr_vect(1,1);m1(0,1) = rhErr_vect(1,2);m1(0,2) = rhErr_vect(1,3);m1(0,3) = rhErr_vect(1,4);
-  m1(1,0) = rhErr_vect(2,1);m1(1,1) = rhErr_vect(2,2);m1(1,2) = rhErr_vect(2,3);m1(1,3) = rhErr_vect(2,4);
-  m1(2,0) = rhErr_vect(3,1);m1(2,1) = rhErr_vect(3,2);m1(2,2) = rhErr_vect(3,3);m1(2,3) = rhErr_vect(3,4);
-  m1(3,0) = rhErr_vect(4,1);m1(3,1) = rhErr_vect(4,2);m1(3,2) = rhErr_vect(4,3);m1(3,3) = rhErr_vect(4,4);
+  m1(0, 0) = rhErr_vect(1, 1);
+  m1(0, 1) = rhErr_vect(1, 2);
+  m1(0, 2) = rhErr_vect(1, 3);
+  m1(0, 3) = rhErr_vect(1, 4);
+  m1(1, 0) = rhErr_vect(2, 1);
+  m1(1, 1) = rhErr_vect(2, 2);
+  m1(1, 2) = rhErr_vect(2, 3);
+  m1(1, 3) = rhErr_vect(2, 4);
+  m1(2, 0) = rhErr_vect(3, 1);
+  m1(2, 1) = rhErr_vect(3, 2);
+  m1(2, 2) = rhErr_vect(3, 3);
+  m1(2, 3) = rhErr_vect(3, 4);
+  m1(3, 0) = rhErr_vect(4, 1);
+  m1(3, 1) = rhErr_vect(4, 2);
+  m1(3, 2) = rhErr_vect(4, 3);
+  m1(3, 3) = rhErr_vect(4, 4);
 
   Tsos4D tsos4d = Tsos4D(tsos);
   v2 = tsos4d.paramVector();
   m2 = tsos4d.errorMatrix();
 }
 
-
-
-double StateSegmentMatcher::value() 
-{
+double StateSegmentMatcher::value() {
   if (match2D) {
     AlgebraicVector2 v3(v1_2d - v2_2d);
     AlgebraicSymMatrix22 m3(m1_2d + m2_2d + ape_2d);
     bool m3i = !m3.Invert();
-    if ( m3i ) {
+    if (m3i) {
       return 1e7;
     } else {
-      estValue = ROOT::Math::Similarity(v3,m3);
+      estValue = ROOT::Math::Similarity(v3, m3);
     }
-    
+
   } else {
     AlgebraicVector4 v3(v1 - v2);
     AlgebraicSymMatrix44 m3(m1 + m2 + ape);
     bool m3i = !m3.Invert();
-    if ( m3i ) {
+    if (m3i) {
       return 1e7;
     } else {
-      estValue = ROOT::Math::Similarity(v3,m3);
+      estValue = ROOT::Math::Similarity(v3, m3);
     }
   }
   return estValue;
 }
 
-
-Tsos4D::Tsos4D(TrajectoryStateOnSurface const &tsos)
-{
+Tsos4D::Tsos4D(TrajectoryStateOnSurface const &tsos) {
   AlgebraicVector5 tsos_v = tsos.localParameters().vector();
   tsos_4d[0] = tsos_v[1];
   tsos_4d[1] = tsos_v[2];
@@ -120,52 +139,56 @@ Tsos4D::Tsos4D(TrajectoryStateOnSurface const &tsos)
   tsos_4d[3] = tsos_v[4];
 
   AlgebraicSymMatrix55 E = tsos.localError().matrix();
-  tsosErr_44(0,0) = E(1,1);tsosErr_44(0,1) = E(1,2);tsosErr_44(0,2) = E(1,3);tsosErr_44(0,3) = E(1,4);
-  tsosErr_44(1,0) = E(2,1);tsosErr_44(1,1) = E(2,2);tsosErr_44(1,2) = E(2,3);tsosErr_44(1,3) = E(2,4);
-  tsosErr_44(2,0) = E(3,1);tsosErr_44(2,1) = E(3,2);tsosErr_44(2,2) = E(3,3);tsosErr_44(2,3) = E(3,4);
-  tsosErr_44(3,0) = E(4,1);tsosErr_44(3,1) = E(4,2);tsosErr_44(3,2) = E(4,3);tsosErr_44(3,3) = E(4,4);
+  tsosErr_44(0, 0) = E(1, 1);
+  tsosErr_44(0, 1) = E(1, 2);
+  tsosErr_44(0, 2) = E(1, 3);
+  tsosErr_44(0, 3) = E(1, 4);
+  tsosErr_44(1, 0) = E(2, 1);
+  tsosErr_44(1, 1) = E(2, 2);
+  tsosErr_44(1, 2) = E(2, 3);
+  tsosErr_44(1, 3) = E(2, 4);
+  tsosErr_44(2, 0) = E(3, 1);
+  tsosErr_44(2, 1) = E(3, 2);
+  tsosErr_44(2, 2) = E(3, 3);
+  tsosErr_44(2, 3) = E(3, 4);
+  tsosErr_44(3, 0) = E(4, 1);
+  tsosErr_44(3, 1) = E(4, 2);
+  tsosErr_44(3, 2) = E(4, 3);
+  tsosErr_44(3, 3) = E(4, 4);
 }
 
+AlgebraicVector4 Tsos4D::paramVector() const { return tsos_4d; }
 
-AlgebraicVector4 Tsos4D::paramVector() const {return tsos_4d;}
+AlgebraicSymMatrix44 Tsos4D::errorMatrix() const { return tsosErr_44; }
 
-
-AlgebraicSymMatrix44 Tsos4D::errorMatrix() const {return tsosErr_44;}
-
-
-
-Tsos2DPhi::Tsos2DPhi(TrajectoryStateOnSurface const &tsos)
-{
+Tsos2DPhi::Tsos2DPhi(TrajectoryStateOnSurface const &tsos) {
   AlgebraicVector5 tsos_v = tsos.localParameters().vector();
   tsos_2d_phi[0] = tsos_v[1];
   tsos_2d_phi[1] = tsos_v[3];
-  
+
   AlgebraicSymMatrix55 E = tsos.localError().matrix();
-  tsosErr_22_phi(0,0) = E(1,1);tsosErr_22_phi(0,1) = E(1,3);
-  tsosErr_22_phi(1,0) = E(3,1);tsosErr_22_phi(1,1) = E(3,3);
+  tsosErr_22_phi(0, 0) = E(1, 1);
+  tsosErr_22_phi(0, 1) = E(1, 3);
+  tsosErr_22_phi(1, 0) = E(3, 1);
+  tsosErr_22_phi(1, 1) = E(3, 3);
 }
 
+AlgebraicVector2 Tsos2DPhi::paramVector() const { return tsos_2d_phi; }
 
-AlgebraicVector2 Tsos2DPhi::paramVector() const {return tsos_2d_phi;}
+AlgebraicSymMatrix22 Tsos2DPhi::errorMatrix() const { return tsosErr_22_phi; }
 
-
-AlgebraicSymMatrix22 Tsos2DPhi::errorMatrix() const {return tsosErr_22_phi;}
-
-
-
-Tsos2DZed::Tsos2DZed(TrajectoryStateOnSurface const &tsos)
-{
+Tsos2DZed::Tsos2DZed(TrajectoryStateOnSurface const &tsos) {
   AlgebraicVector5 tsos_v = tsos.localParameters().vector();
   tsos_2d_zed[0] = tsos_v[2];
   tsos_2d_zed[1] = tsos_v[4];
 
   AlgebraicSymMatrix55 E = tsos.localError().matrix();
-  tsosErr_22_zed(0,0) = E(2,2);tsosErr_22_zed(0,1) = E(2,4);
-  tsosErr_22_zed(1,0) = E(4,2);tsosErr_22_zed(1,1) = E(4,4);
+  tsosErr_22_zed(0, 0) = E(2, 2);
+  tsosErr_22_zed(0, 1) = E(2, 4);
+  tsosErr_22_zed(1, 0) = E(4, 2);
+  tsosErr_22_zed(1, 1) = E(4, 4);
 }
 
+AlgebraicVector2 Tsos2DZed::paramVector() const { return tsos_2d_zed; }
 
-AlgebraicVector2 Tsos2DZed::paramVector() const {return tsos_2d_zed;}
-
-
-AlgebraicSymMatrix22 Tsos2DZed::errorMatrix() const {return tsosErr_22_zed;}
+AlgebraicSymMatrix22 Tsos2DZed::errorMatrix() const { return tsosErr_22_zed; }

--- a/RecoMuon/GlobalTrackingTools/src/ThrParameters.cc
+++ b/RecoMuon/GlobalTrackingTools/src/ThrParameters.cc
@@ -4,42 +4,43 @@
 using namespace edm;
 using namespace std;
 
-ThrParameters::ThrParameters(const EventSetup* eSetup)
-{
+ThrParameters::ThrParameters(const EventSetup* eSetup) {
   // Read the threshold DB
   ESHandle<DYTThrObject> dytThresholdsH;
-  
+
   // This try catch is just temporary and
   // will be removed as soon as the DYTThrObject
   // record is included in a GT.
   // It is necessary here for testing
-  try {eSetup->get<DYTThrObjectRcd>().get(dytThresholdsH);
+  try {
+    eSetup->get<DYTThrObjectRcd>().get(dytThresholdsH);
     dytThresholds = dytThresholdsH.product();
     isValidThdDB_ = true;
-  } catch(...) {
+  } catch (...) {
     isValidThdDB_ = false;
   }
 
   // Ape are always filled even they're null
   ESHandle<AlignmentErrorsExtended> dtAlignmentErrorsExtended;
-  eSetup->get<DTAlignmentErrorExtendedRcd>().get( dtAlignmentErrorsExtended );
-  for ( std::vector<AlignTransformErrorExtended>::const_iterator it = dtAlignmentErrorsExtended->m_alignError.begin();
-	it != dtAlignmentErrorsExtended->m_alignError.end(); it++ ) {
+  eSetup->get<DTAlignmentErrorExtendedRcd>().get(dtAlignmentErrorsExtended);
+  for (std::vector<AlignTransformErrorExtended>::const_iterator it = dtAlignmentErrorsExtended->m_alignError.begin();
+       it != dtAlignmentErrorsExtended->m_alignError.end();
+       it++) {
     CLHEP::HepSymMatrix error = (*it).matrix();
     GlobalError glbErr(error[0][0], error[1][0], error[1][1], error[2][0], error[2][1], error[2][2]);
     DTChamberId DTid((*it).rawId());
-    dtApeMap.insert( pair<DTChamberId, GlobalError> (DTid, glbErr) );
+    dtApeMap.insert(pair<DTChamberId, GlobalError>(DTid, glbErr));
   }
   ESHandle<AlignmentErrorsExtended> cscAlignmentErrorsExtended;
-  eSetup->get<CSCAlignmentErrorExtendedRcd>().get( cscAlignmentErrorsExtended );
-  for ( std::vector<AlignTransformErrorExtended>::const_iterator it = cscAlignmentErrorsExtended->m_alignError.begin();
-	it != cscAlignmentErrorsExtended->m_alignError.end(); it++ ) {
+  eSetup->get<CSCAlignmentErrorExtendedRcd>().get(cscAlignmentErrorsExtended);
+  for (std::vector<AlignTransformErrorExtended>::const_iterator it = cscAlignmentErrorsExtended->m_alignError.begin();
+       it != cscAlignmentErrorsExtended->m_alignError.end();
+       it++) {
     CLHEP::HepSymMatrix error = (*it).matrix();
     GlobalError glbErr(error[0][0], error[1][0], error[1][1], error[2][0], error[2][1], error[2][2]);
     CSCDetId CSCid((*it).rawId());
-    cscApeMap.insert( pair<CSCDetId, GlobalError> (CSCid, glbErr) );
+    cscApeMap.insert(pair<CSCDetId, GlobalError>(CSCid, glbErr));
   }
 }
 
 ThrParameters::~ThrParameters() {}
-

--- a/RecoMuon/GlobalTrackingTools/test/DYTTuner.cc
+++ b/RecoMuon/GlobalTrackingTools/test/DYTTuner.cc
@@ -7,7 +7,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CondFormats/RecoMuonObjects/interface/DYTThrObject.h"
-#include "CondFormats/DataRecord/interface/DYTThrObjectRcd.h" 
+#include "CondFormats/DataRecord/interface/DYTThrObjectRcd.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
@@ -30,19 +30,19 @@ class DYTTuner : public edm::EDAnalyzer {
 public:
   explicit DYTTuner(const edm::ParameterSet&);
   ~DYTTuner();
-  
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-  
+
 private:
-  virtual void   beginJob() ;
-  virtual void   analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void   endJob() ;
+  virtual void beginJob();
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void endJob();
   virtual double doIntegral(std::vector<double>&, DetId&);
-  virtual void   writePlots();
-  virtual void   beginRun(edm::Run const&, edm::EventSetup const&);
-  virtual void   endRun(edm::Run const&, edm::EventSetup const&);
-  virtual void   beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
-  virtual void   endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  virtual void writePlots();
+  virtual void beginRun(edm::Run const&, edm::EventSetup const&);
+  virtual void endRun(edm::Run const&, edm::EventSetup const&);
+  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
 
   typedef edm::ValueMap<reco::DYTInfo> DYTestimators;
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
@@ -56,116 +56,110 @@ private:
   edm::EDGetTokenT<reco::MuonCollection> muonsToken;
 };
 
-
-DYTTuner::DYTTuner(const edm::ParameterSet& iConfig)
-{
-  MinEnVal     = iConfig.getParameter<double>("MinEnergyVal");
-  MaxEnVal     = iConfig.getParameter<double>("MaxEnergyVal");
-  IntegralCut  = iConfig.getParameter<double>("IntegralCut");
-  MaxEstVal    = iConfig.getParameter<double>("MaxEstVal");
+DYTTuner::DYTTuner(const edm::ParameterSet& iConfig) {
+  MinEnVal = iConfig.getParameter<double>("MinEnergyVal");
+  MaxEnVal = iConfig.getParameter<double>("MaxEnergyVal");
+  IntegralCut = iConfig.getParameter<double>("IntegralCut");
+  MaxEstVal = iConfig.getParameter<double>("MaxEstVal");
   MinNumValues = iConfig.getParameter<unsigned int>("MinNumValues");
-  saveROOTfile = iConfig.getParameter<bool>("writePlots");  
-  MaxValPlots  = iConfig.getParameter<unsigned int>("MaxValPlots");
-  NBinsPlots   = iConfig.getParameter<unsigned int>("NBinsPlots");
+  saveROOTfile = iConfig.getParameter<bool>("writePlots");
+  MaxValPlots = iConfig.getParameter<unsigned int>("MaxValPlots");
+  NBinsPlots = iConfig.getParameter<unsigned int>("NBinsPlots");
 
-  edm::ConsumesCollector iC  = consumesCollector();
-  dytInfoToken=iC.consumes<DYTestimators>(edm::InputTag("tevMuons", "dytInfo"));
-  muonsToken=iC.consumes<reco::MuonCollection>(edm::InputTag("muons"));
+  edm::ConsumesCollector iC = consumesCollector();
+  dytInfoToken = iC.consumes<DYTestimators>(edm::InputTag("tevMuons", "dytInfo"));
+  muonsToken = iC.consumes<reco::MuonCollection>(edm::InputTag("muons"));
 
-  if (MaxEstVal == -1) MaxEstVal = MAX_THR;
+  if (MaxEstVal == -1)
+    MaxEstVal = MAX_THR;
 
-  if (!poolDbService->isNewTagRequest("DYTThrObjectRcd")) 
-    throw cms::Exception("NotAvailable") << "The output file already contains a valid \"DYTThrObjectRcd\" record.\nPlease provide a different file name or tag.";
+  if (!poolDbService->isNewTagRequest("DYTThrObjectRcd"))
+    throw cms::Exception("NotAvailable") << "The output file already contains a valid \"DYTThrObjectRcd\" "
+                                            "record.\nPlease provide a different file name or tag.";
 }
 
+DYTTuner::~DYTTuner() {}
 
-DYTTuner::~DYTTuner()
-{
-}
-
-
-void DYTTuner::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void DYTTuner::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace std;
   using namespace edm;
   using namespace reco;
 
   Handle<DYTestimators> dytInfoH;
   iEvent.getByToken(dytInfoToken, dytInfoH);
-  const DYTestimators &dytInfoC = *dytInfoH;
+  const DYTestimators& dytInfoC = *dytInfoH;
   Handle<MuonCollection> muons;
   iEvent.getByToken(muonsToken, muons);
-  for(size_t i = 0; i != muons->size(); ++i) {
-    
+  for (size_t i = 0; i != muons->size(); ++i) {
     // Energy range cut
-    if (muons->at(i).pt() < MinEnVal || muons->at(i).pt() > MaxEnVal) continue;
+    if (muons->at(i).pt() < MinEnVal || muons->at(i).pt() > MaxEnVal)
+      continue;
 
     const TrackRef& tkRef = muons->at(i).globalTrack();
-    if(dytInfoC.contains(tkRef.id())){
+    if (dytInfoC.contains(tkRef.id())) {
       DYTInfo dytInfo = dytInfoC[muons->at(i).globalTrack()];
       vector<double> estimators = dytInfo.DYTEstimators();
-      vector<DetId> ids         = dytInfo.IdChambers();
-      
+      vector<DetId> ids = dytInfo.IdChambers();
+
       for (int j = 0; j < 4; j++) {
-	if (ids[j].null()) continue;
-	DetId chamberId = ids[j];
-	double estValue = estimators[j];
-	if (estValue >= 0 && estValue <= MaxEstVal)
-	  mapId[chamberId].push_back(estValue);
+        if (ids[j].null())
+          continue;
+        DetId chamberId = ids[j];
+        double estValue = estimators[j];
+        if (estValue >= 0 && estValue <= MaxEstVal)
+          mapId[chamberId].push_back(estValue);
       }
-    } else {continue;}
+    } else {
+      continue;
+    }
   }
 }
 
+void DYTTuner::beginJob() {}
 
-void DYTTuner::beginJob()
-{
-}
-
-
-void DYTTuner::endJob() 
-{
-  if (saveROOTfile) writePlots();
+void DYTTuner::endJob() {
+  if (saveROOTfile)
+    writePlots();
   thresholds = new DYTThrObject();
 
   // Full barrel/endcap computation
   std::map<DetId, std::vector<double> >::iterator it;
   std::map<int, std::vector<double> > estBarrel, estEndcap;
-  for ( it = mapId.begin() ; it != mapId.end(); it++ ) {
+  for (it = mapId.begin(); it != mapId.end(); it++) {
     DetId id = (*it).first;
     std::vector<double> estValCh = (*it).second;
-    if ((*it).first.subdetId() == MuonSubdetId::DT) 
+    if ((*it).first.subdetId() == MuonSubdetId::DT)
       for (unsigned int b = 0; b < estValCh.size(); b++) {
-	int station = DTChamberId(id).station();
-	estBarrel[station].push_back(estValCh[b]);
+        int station = DTChamberId(id).station();
+        estBarrel[station].push_back(estValCh[b]);
       }
-    if ((*it).first.subdetId() == MuonSubdetId::CSC) 
+    if ((*it).first.subdetId() == MuonSubdetId::CSC)
       for (unsigned int e = 0; e < estValCh.size(); e++) {
-	int station = CSCDetId(id).station();
-	estEndcap[station].push_back(estValCh[e]);
+        int station = CSCDetId(id).station();
+        estEndcap[station].push_back(estValCh[e]);
       }
   }
   DetId empty = DetId();
   double barrelCut[4], endcapCut[4];
   for (unsigned st = 1; st <= 4; st++) {
-    barrelCut[st-1] = doIntegral(estBarrel[st], empty);
-    endcapCut[st-1] = doIntegral(estEndcap[st], empty);
-  }  
+    barrelCut[st - 1] = doIntegral(estBarrel[st], empty);
+    endcapCut[st - 1] = doIntegral(estEndcap[st], empty);
+  }
 
   // Chamber by chamber computation
-  for ( it = mapId.begin() ; it != mapId.end(); it++ ) {
+  for (it = mapId.begin(); it != mapId.end(); it++) {
     DetId id = (*it).first;
     std::vector<double> estValCh = (*it).second;
     DYTThrObject::DytThrStruct obj;
     obj.id = id;
     if (estValCh.size() < MinNumValues) {
       if (id.subdetId() == MuonSubdetId::DT) {
-	int station = DTChamberId(id).station();
-	obj.thr = barrelCut[station-1];
+        int station = DTChamberId(id).station();
+        obj.thr = barrelCut[station - 1];
       }
       if (id.subdetId() == MuonSubdetId::CSC) {
-	int station = CSCDetId(id).station();
-	obj.thr = endcapCut[station-1];
+        int station = CSCDetId(id).station();
+        obj.thr = endcapCut[station - 1];
       }
       thresholds->thrsVec.push_back(obj);
       continue;
@@ -176,27 +170,27 @@ void DYTTuner::endJob()
 
   // Writing to DB
   edm::Service<cond::service::PoolDBOutputService> poolDbService;
-  if( poolDbService.isAvailable() )
-  {
-    poolDbService->writeOne( thresholds, poolDbService->beginOfTime(), "DYTThrObjectRcd"  ); 
-  }
-  else throw cms::Exception("NotAvailable") << "PoolDBOutputService is not available.";
+  if (poolDbService.isAvailable()) {
+    poolDbService->writeOne(thresholds, poolDbService->beginOfTime(), "DYTThrObjectRcd");
+  } else
+    throw cms::Exception("NotAvailable") << "PoolDBOutputService is not available.";
 }
-
 
 double DYTTuner::doIntegral(std::vector<double>& estValues, DetId& id) {
   double cutOnE = -1;
   int nPosVal = 0;
-  sort( estValues.begin(), estValues.end() );
-  for (unsigned int j = 0; j < estValues.size(); j++) 
-    if (estValues[j] > 0 && estValues[j] < MaxEstVal) nPosVal++;
+  sort(estValues.begin(), estValues.end());
+  for (unsigned int j = 0; j < estValues.size(); j++)
+    if (estValues[j] > 0 && estValues[j] < MaxEstVal)
+      nPosVal++;
   double limit = nPosVal * IntegralCut;
-  int nVal = 0; 
+  int nVal = 0;
   for (unsigned int j = 0; j < estValues.size(); j++) {
-    if (estValues[j] < 0) continue;
+    if (estValues[j] < 0)
+      continue;
     nVal++;
     if (nVal >= limit) {
-      cutOnE = estValues[j-1];
+      cutOnE = estValues[j - 1];
       break;
     }
   }
@@ -204,42 +198,29 @@ double DYTTuner::doIntegral(std::vector<double>& estValues, DetId& id) {
   return cutOnE;
 }
 
-
 void DYTTuner::writePlots() {
   edm::Service<TFileService> fs;
   std::map<DetId, std::vector<double> >::iterator it;
-  for ( it = mapId.begin() ; it != mapId.end(); it++ ) {
+  for (it = mapId.begin(); it != mapId.end(); it++) {
     DetId id = (*it).first;
     std::vector<double> estValCh = (*it).second;
     char plotName[200];
     sprintf(plotName, "%i", id.rawId());
     TH1F* tmpPlot = new TH1F(plotName, plotName, NBinsPlots, 0., MaxValPlots);
-    for (unsigned int i = 0; i < estValCh.size(); i++) 
+    for (unsigned int i = 0; i < estValCh.size(); i++)
       tmpPlot->Fill(estValCh[i]);
     EstPlots[id] = fs->make<TH1F>(*tmpPlot);
     delete tmpPlot;
   }
 }
 
+void DYTTuner::beginRun(edm::Run const&, edm::EventSetup const&) {}
 
-void DYTTuner::beginRun(edm::Run const&, edm::EventSetup const&)
-{
-}
+void DYTTuner::endRun(edm::Run const&, edm::EventSetup const&) {}
 
-void DYTTuner::endRun(edm::Run const&, edm::EventSetup const&)
-{
-}
+void DYTTuner::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
 
-
-void DYTTuner::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-
-
-void DYTTuner::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-
+void DYTTuner::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
 
 void DYTTuner::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation

--- a/RecoMuon/MuonIdentification/interface/CSCTimingExtractor.h
+++ b/RecoMuon/MuonIdentification/interface/CSCTimingExtractor.h
@@ -47,36 +47,36 @@ namespace edm {
   class ParameterSet;
   class EventSetup;
   class InputTag;
-}
+}  // namespace edm
 
 class MuonServiceProxy;
 
 class CSCTimingExtractor {
-
 public:
-  
   /// Constructor
-  CSCTimingExtractor(const edm::ParameterSet&, MuonSegmentMatcher *segMatcher);
-  
+  CSCTimingExtractor(const edm::ParameterSet &, MuonSegmentMatcher *segMatcher);
+
   /// Destructor
   ~CSCTimingExtractor();
 
- class TimeMeasurement
-  {
-   public:
-     float distIP;
-     float timeCorr;
-     int station;
-     float weightTimeVtx;
-     float weightInvbeta;
+  class TimeMeasurement {
+  public:
+    float distIP;
+    float timeCorr;
+    int station;
+    float weightTimeVtx;
+    float weightInvbeta;
   };
 
   void fillTiming(TimeMeasurementSequence &tmSequence,
-		 const std::vector<const CSCSegment*> &segments,
-		 reco::TrackRef muonTrack,
-                  const edm::Event& iEvent, const edm::EventSetup& iSetup);
-  void fillTiming(TimeMeasurementSequence &tmSequence, reco::TrackRef muonTrack,
-                  const edm::Event& iEvent, const edm::EventSetup& iSetup);
+                  const std::vector<const CSCSegment *> &segments,
+                  reco::TrackRef muonTrack,
+                  const edm::Event &iEvent,
+                  const edm::EventSetup &iSetup);
+  void fillTiming(TimeMeasurementSequence &tmSequence,
+                  reco::TrackRef muonTrack,
+                  const edm::Event &iEvent,
+                  const edm::EventSetup &iSetup);
 
 private:
   edm::InputTag CSCSegmentTags_;
@@ -89,9 +89,9 @@ private:
   bool UseWireTime;
   bool UseStripTime;
   bool debug;
-  
+
   std::unique_ptr<MuonServiceProxy> theService;
-  MuonSegmentMatcher *theMatcher;  
+  MuonSegmentMatcher *theMatcher;
 };
 
 #endif

--- a/RecoMuon/MuonIdentification/interface/DTTimingExtractor.h
+++ b/RecoMuon/MuonIdentification/interface/DTTimingExtractor.h
@@ -47,44 +47,49 @@ namespace edm {
   class ParameterSet;
   class EventSetup;
   class InputTag;
-}
+}  // namespace edm
 
 class MuonServiceProxy;
 
 class DTTimingExtractor {
-
 public:
-  
   /// Constructor
-  DTTimingExtractor(const edm::ParameterSet&, MuonSegmentMatcher *segMatcher);
-  
+  DTTimingExtractor(const edm::ParameterSet&, MuonSegmentMatcher* segMatcher);
+
   /// Destructor
   ~DTTimingExtractor();
 
- class TimeMeasurement
-  {
-   public:
-     bool isLeft;
-     bool isPhi;
-     float posInLayer;
-     float distIP;
-     float timeCorr;
-     int station;
-     DetId driftCell;
+  class TimeMeasurement {
+  public:
+    bool isLeft;
+    bool isPhi;
+    float posInLayer;
+    float distIP;
+    float timeCorr;
+    int station;
+    DetId driftCell;
   };
 
- void fillTiming(TimeMeasurementSequence &tmSequence, 
-		 const std::vector<const DTRecSegment4D*> &segments,
-		 reco::TrackRef muonTrack,
-		 const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  void fillTiming(TimeMeasurementSequence& tmSequence,
+                  const std::vector<const DTRecSegment4D*>& segments,
+                  reco::TrackRef muonTrack,
+                  const edm::Event& iEvent,
+                  const edm::EventSetup& iSetup);
 
- void fillTiming(TimeMeasurementSequence &tmSequence, reco::TrackRef muonTrack,
-		 const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  void fillTiming(TimeMeasurementSequence& tmSequence,
+                  reco::TrackRef muonTrack,
+                  const edm::Event& iEvent,
+                  const edm::EventSetup& iSetup);
 
 private:
-  double fitT0(double &a, double &b, const std::vector<double>& xl, const std::vector<double>& yl, const std::vector<double>& xr, const std::vector<double>& yr );
+  double fitT0(double& a,
+               double& b,
+               const std::vector<double>& xl,
+               const std::vector<double>& yl,
+               const std::vector<double>& xr,
+               const std::vector<double>& yr);
 
-  edm::InputTag DTSegmentTags_; 
+  edm::InputTag DTSegmentTags_;
   unsigned int theHitsMin_;
   double thePruneCut_;
   double theTimeOffset_;
@@ -94,10 +99,9 @@ private:
   bool dropTheta_;
   bool requireBothProjections_;
   bool debug;
-  
-  std::unique_ptr<MuonServiceProxy> theService;
-  MuonSegmentMatcher *theMatcher;
 
+  std::unique_ptr<MuonServiceProxy> theService;
+  MuonSegmentMatcher* theMatcher;
 };
 
 #endif

--- a/RecoMuon/MuonIdentification/interface/ME0MuonSelector.h
+++ b/RecoMuon/MuonIdentification/interface/ME0MuonSelector.h
@@ -8,30 +8,33 @@
 
 #include <string>
 
-
-
-
 namespace muon {
-   /// Selector type
-   enum SelectionType {
-      All = 0,                      // dummy options - always true
-      VeryLoose = 1,           //
-      Loose = 2,           //
-      Tight = 3,           //
-   };
+  /// Selector type
+  enum SelectionType {
+    All = 0,        // dummy options - always true
+    VeryLoose = 1,  //
+    Loose = 2,      //
+    Tight = 3,      //
+  };
 
-   /// a lightweight "map" for selection type string label and enum value
-   struct SelectionTypeStringToEnum { const char *label; SelectionType value; };
-   SelectionType selectionTypeFromString( const std::string &label );
-     
-   /// main GoodMuon wrapper call
-   bool isGoodMuon(const reco::ME0Muon& me0muon, SelectionType type );
+  /// a lightweight "map" for selection type string label and enum value
+  struct SelectionTypeStringToEnum {
+    const char* label;
+    SelectionType value;
+  };
+  SelectionType selectionTypeFromString(const std::string& label);
 
+  /// main GoodMuon wrapper call
+  bool isGoodMuon(const reco::ME0Muon& me0muon, SelectionType type);
 
-   /// Specialized isGoodMuon function called from main wrapper
+  /// Specialized isGoodMuon function called from main wrapper
 
-   bool isGoodMuon(const reco::ME0Muon& me0muon, double MaxPullX, double MaxDiffX, double MaxPullY, double MaxDiffY, double MaxDiffPhiDir  );
+  bool isGoodMuon(const reco::ME0Muon& me0muon,
+                  double MaxPullX,
+                  double MaxDiffX,
+                  double MaxPullY,
+                  double MaxDiffY,
+                  double MaxDiffPhiDir);
 
-
-}
+}  // namespace muon
 #endif

--- a/RecoMuon/MuonIdentification/interface/MuonArbitrationMethods.h
+++ b/RecoMuon/MuonIdentification/interface/MuonArbitrationMethods.h
@@ -10,50 +10,43 @@
 
 /// functor predicate for standard library sort algorithm
 struct SortMuonSegmentMatches {
-   /// constructor takes arbitration type
-   SortMuonSegmentMatches( unsigned int flag ) {
-      flag_ = flag;
-   }
-   /// sorts vector of pairs of chamber and segment pointers
-   bool operator() ( std::pair<reco::MuonChamberMatch*,reco::MuonSegmentMatch*> p1,
-         std::pair<reco::MuonChamberMatch*,reco::MuonSegmentMatch*> p2 )
-   {
-      reco::MuonChamberMatch* cm1 = p1.first;
-      reco::MuonSegmentMatch* sm1 = p1.second;
-      reco::MuonChamberMatch* cm2 = p2.first;
-      reco::MuonSegmentMatch* sm2 = p2.second;
+  /// constructor takes arbitration type
+  SortMuonSegmentMatches(unsigned int flag) { flag_ = flag; }
+  /// sorts vector of pairs of chamber and segment pointers
+  bool operator()(std::pair<reco::MuonChamberMatch*, reco::MuonSegmentMatch*> p1,
+                  std::pair<reco::MuonChamberMatch*, reco::MuonSegmentMatch*> p2) {
+    reco::MuonChamberMatch* cm1 = p1.first;
+    reco::MuonSegmentMatch* sm1 = p1.second;
+    reco::MuonChamberMatch* cm2 = p2.first;
+    reco::MuonSegmentMatch* sm2 = p2.second;
 
-      if(flag_ == reco::MuonSegmentMatch::BestInChamberByDX ||
-         flag_ == reco::MuonSegmentMatch::BestInStationByDX ||
-         flag_ == reco::MuonSegmentMatch::BelongsToTrackByDX)
-         return fabs(sm1->x-cm1->x) < fabs(sm2->x-cm2->x);
-      if(flag_ == reco::MuonSegmentMatch::BestInChamberByDR ||
-         flag_ == reco::MuonSegmentMatch::BestInStationByDR || 
-         flag_ == reco::MuonSegmentMatch::BelongsToTrackByDR)
-      {
-         if((! sm1->hasZed()) || (! sm2->hasZed())) // no y information so return dx
-            return fabs(sm1->x-cm1->x) < fabs(sm2->x-cm2->x);
-         return sqrt(pow(sm1->x-cm1->x,2)+pow(sm1->y-cm1->y,2)) <
-            sqrt(pow(sm2->x-cm2->x,2)+pow(sm2->y-cm2->y,2)); 
-      }
-      if(flag_ == reco::MuonSegmentMatch::BestInChamberByDXSlope ||
-         flag_ == reco::MuonSegmentMatch::BestInStationByDXSlope ||
-         flag_ == reco::MuonSegmentMatch::BelongsToTrackByDXSlope)
-         return fabs(sm1->dXdZ-cm1->dXdZ) < fabs(sm2->dXdZ-cm2->dXdZ);
-      if(flag_ == reco::MuonSegmentMatch::BestInChamberByDRSlope ||
-         flag_ == reco::MuonSegmentMatch::BestInStationByDRSlope ||
-         flag_ == reco::MuonSegmentMatch::BelongsToTrackByDRSlope)
-      {
-         if((! sm1->hasZed()) || (! sm2->hasZed())) // no y information so return dx
-            return fabs(sm1->dXdZ-cm1->dXdZ) < fabs(sm2->dXdZ-cm2->dXdZ);
-         return sqrt(pow(sm1->dXdZ-cm1->dXdZ,2)+pow(sm1->dYdZ-cm1->dYdZ,2)) <
-            sqrt(pow(sm2->dXdZ-cm2->dXdZ,2)+pow(sm2->dYdZ-cm2->dYdZ,2)); 
-      }
+    if (flag_ == reco::MuonSegmentMatch::BestInChamberByDX || flag_ == reco::MuonSegmentMatch::BestInStationByDX ||
+        flag_ == reco::MuonSegmentMatch::BelongsToTrackByDX)
+      return fabs(sm1->x - cm1->x) < fabs(sm2->x - cm2->x);
+    if (flag_ == reco::MuonSegmentMatch::BestInChamberByDR || flag_ == reco::MuonSegmentMatch::BestInStationByDR ||
+        flag_ == reco::MuonSegmentMatch::BelongsToTrackByDR) {
+      if ((!sm1->hasZed()) || (!sm2->hasZed()))  // no y information so return dx
+        return fabs(sm1->x - cm1->x) < fabs(sm2->x - cm2->x);
+      return sqrt(pow(sm1->x - cm1->x, 2) + pow(sm1->y - cm1->y, 2)) <
+             sqrt(pow(sm2->x - cm2->x, 2) + pow(sm2->y - cm2->y, 2));
+    }
+    if (flag_ == reco::MuonSegmentMatch::BestInChamberByDXSlope ||
+        flag_ == reco::MuonSegmentMatch::BestInStationByDXSlope ||
+        flag_ == reco::MuonSegmentMatch::BelongsToTrackByDXSlope)
+      return fabs(sm1->dXdZ - cm1->dXdZ) < fabs(sm2->dXdZ - cm2->dXdZ);
+    if (flag_ == reco::MuonSegmentMatch::BestInChamberByDRSlope ||
+        flag_ == reco::MuonSegmentMatch::BestInStationByDRSlope ||
+        flag_ == reco::MuonSegmentMatch::BelongsToTrackByDRSlope) {
+      if ((!sm1->hasZed()) || (!sm2->hasZed()))  // no y information so return dx
+        return fabs(sm1->dXdZ - cm1->dXdZ) < fabs(sm2->dXdZ - cm2->dXdZ);
+      return sqrt(pow(sm1->dXdZ - cm1->dXdZ, 2) + pow(sm1->dYdZ - cm1->dYdZ, 2)) <
+             sqrt(pow(sm2->dXdZ - cm2->dXdZ, 2) + pow(sm2->dYdZ - cm2->dYdZ, 2));
+    }
 
-      return false; // is this appropriate? fix this
-   }
+    return false;  // is this appropriate? fix this
+  }
 
-   unsigned int flag_;
+  unsigned int flag_;
 };
 
 #endif

--- a/RecoMuon/MuonIdentification/interface/MuonCaloCompatibility.h
+++ b/RecoMuon/MuonIdentification/interface/MuonCaloCompatibility.h
@@ -5,7 +5,7 @@
 //
 // Package:    MuonIdentification
 // Class:      MuonCaloCompatibility
-// 
+//
 /*
 
  Description: test track muon hypothesis using energy deposition in ECAL,HCAL,HO
@@ -24,57 +24,58 @@
 #include <string>
 
 class MuonCaloCompatibility {
- public:
-   MuonCaloCompatibility():isConfigured_(false){}
-   void configure(const edm::ParameterSet&);
-   double evaluate( const reco::Muon& );
- private:
-   bool accessing_overflow( const TH2D& histo, double x, double y );
-   bool isConfigured_;
-   
-   // used input templates for given eta
-   std::shared_ptr<TH2D> pion_template_em ;
-   std::shared_ptr<TH2D> pion_template_had;
-   std::shared_ptr<TH2D> pion_template_ho ;
-   std::shared_ptr<TH2D> muon_template_em ;
-   std::shared_ptr<TH2D> muon_template_had;
-   std::shared_ptr<TH2D> muon_template_ho ;
-   // input template functions by eta
-   std::shared_ptr<TH2D> pion_had_etaEpl ;
-   std::shared_ptr<TH2D> pion_em_etaEpl  ;
-   std::shared_ptr<TH2D> pion_had_etaTpl ;
-   std::shared_ptr<TH2D> pion_em_etaTpl  ;
-   std::shared_ptr<TH2D> pion_ho_etaB    ;
-   std::shared_ptr<TH2D> pion_had_etaB   ;
-   std::shared_ptr<TH2D> pion_em_etaB    ;
-   std::shared_ptr<TH2D> pion_had_etaTmi ;
-   std::shared_ptr<TH2D> pion_em_etaTmi  ;
-   std::shared_ptr<TH2D> pion_had_etaEmi ;
-   std::shared_ptr<TH2D> pion_em_etaEmi  ;
+public:
+  MuonCaloCompatibility() : isConfigured_(false) {}
+  void configure(const edm::ParameterSet&);
+  double evaluate(const reco::Muon&);
 
-   std::shared_ptr<TH2D> muon_had_etaEpl ;
-   std::shared_ptr<TH2D> muon_em_etaEpl  ;
-   std::shared_ptr<TH2D> muon_had_etaTpl ;
-   std::shared_ptr<TH2D> muon_em_etaTpl  ;
-   std::shared_ptr<TH2D> muon_ho_etaB    ;
-   std::shared_ptr<TH2D> muon_had_etaB   ;
-   std::shared_ptr<TH2D> muon_em_etaB    ;
-   std::shared_ptr<TH2D> muon_had_etaTmi ;
-   std::shared_ptr<TH2D> muon_em_etaTmi  ;
-   std::shared_ptr<TH2D> muon_had_etaEmi ;
-   std::shared_ptr<TH2D> muon_em_etaEmi  ;
+private:
+  bool accessing_overflow(const TH2D& histo, double x, double y);
+  bool isConfigured_;
 
-   double  pbx;
-   double  pby;
-   double  pbz;
-   
-   double  psx;
-   double  psy;
-   double  psz;
+  // used input templates for given eta
+  std::shared_ptr<TH2D> pion_template_em;
+  std::shared_ptr<TH2D> pion_template_had;
+  std::shared_ptr<TH2D> pion_template_ho;
+  std::shared_ptr<TH2D> muon_template_em;
+  std::shared_ptr<TH2D> muon_template_had;
+  std::shared_ptr<TH2D> muon_template_ho;
+  // input template functions by eta
+  std::shared_ptr<TH2D> pion_had_etaEpl;
+  std::shared_ptr<TH2D> pion_em_etaEpl;
+  std::shared_ptr<TH2D> pion_had_etaTpl;
+  std::shared_ptr<TH2D> pion_em_etaTpl;
+  std::shared_ptr<TH2D> pion_ho_etaB;
+  std::shared_ptr<TH2D> pion_had_etaB;
+  std::shared_ptr<TH2D> pion_em_etaB;
+  std::shared_ptr<TH2D> pion_had_etaTmi;
+  std::shared_ptr<TH2D> pion_em_etaTmi;
+  std::shared_ptr<TH2D> pion_had_etaEmi;
+  std::shared_ptr<TH2D> pion_em_etaEmi;
 
-   double  muon_compatibility;
+  std::shared_ptr<TH2D> muon_had_etaEpl;
+  std::shared_ptr<TH2D> muon_em_etaEpl;
+  std::shared_ptr<TH2D> muon_had_etaTpl;
+  std::shared_ptr<TH2D> muon_em_etaTpl;
+  std::shared_ptr<TH2D> muon_ho_etaB;
+  std::shared_ptr<TH2D> muon_had_etaB;
+  std::shared_ptr<TH2D> muon_em_etaB;
+  std::shared_ptr<TH2D> muon_had_etaTmi;
+  std::shared_ptr<TH2D> muon_em_etaTmi;
+  std::shared_ptr<TH2D> muon_had_etaEmi;
+  std::shared_ptr<TH2D> muon_em_etaEmi;
 
-   bool use_corrected_hcal;
-   bool use_em_special;
+  double pbx;
+  double pby;
+  double pbz;
+
+  double psx;
+  double psy;
+  double psz;
+
+  double muon_compatibility;
+
+  bool use_corrected_hcal;
+  bool use_em_special;
 };
 #endif

--- a/RecoMuon/MuonIdentification/interface/MuonCosmicCompatibilityFiller.h
+++ b/RecoMuon/MuonIdentification/interface/MuonCosmicCompatibilityFiller.h
@@ -30,25 +30,24 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-
-namespace edm {class ParameterSet; class Event; class EventSetup;}
+namespace edm {
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
 class GlobalMuonRefitter;
 class MuonServiceProxy;
 
-
 class MuonCosmicCompatibilityFiller {
-	
-  public:
-   
-  MuonCosmicCompatibilityFiller(const edm::ParameterSet&,edm::ConsumesCollector&);
+public:
+  MuonCosmicCompatibilityFiller(const edm::ParameterSet&, edm::ConsumesCollector&);
   ~MuonCosmicCompatibilityFiller();
-  
-  /// fill cosmic compatibility variables  
-  reco::MuonCosmicCompatibility fillCompatibility( const reco::Muon& muon,edm::Event&, const edm::EventSetup&);
 
- private:
+  /// fill cosmic compatibility variables
+  reco::MuonCosmicCompatibility fillCompatibility(const reco::Muon& muon, edm::Event&, const edm::EventSetup&);
 
-  /// check muon time (DT and CSC) information: 0 == prompt-like 
+private:
+  /// check muon time (DT and CSC) information: 0 == prompt-like
   float muonTiming(const edm::Event& iEvent, const reco::Muon& muon, bool isLoose) const;
 
   ///return cosmic-likeness based on presence of a track in opp side: 0 == no matching opp tracks
@@ -59,7 +58,7 @@ class MuonCosmicCompatibilityFiller {
 
   /// returns cosmic-likeness based on overlap with traversing cosmic muon (only muon/STA hits are used)
   bool isOverlappingMuon(const edm::Event&, const edm::EventSetup& iSetup, const reco::Muon&) const;
-  
+
   /// get number of muons in the vent
   unsigned int nMuons(const edm::Event&) const;
 
@@ -67,16 +66,16 @@ class MuonCosmicCompatibilityFiller {
   unsigned int eventActivity(const edm::Event&, const reco::Muon&) const;
 
   /// combined cosmic-likeness: 0 == not cosmic-like
-  float combinedCosmicID(const edm::Event&, const edm::EventSetup& iSetup, const reco::Muon&, bool CheckMuonID, bool checkVertex) const;
+  float combinedCosmicID(
+      const edm::Event&, const edm::EventSetup& iSetup, const reco::Muon&, bool CheckMuonID, bool checkVertex) const;
 
   /// tag a muon as cosmic based on the muonID information
-  bool checkMuonID( const reco::Muon& ) const;
+  bool checkMuonID(const reco::Muon&) const;
 
   /// tag a muon as cosmic based on segment compatibility and the number of segment matches
   bool checkMuonSegments(const reco::Muon& muon) const;
 
- private:
- 
+private:
   std::vector<edm::InputTag> inputMuonCollections_;
   std::vector<edm::InputTag> inputTrackCollections_;
   edm::InputTag inputCosmicMuonCollection_;
@@ -87,10 +86,8 @@ class MuonCosmicCompatibilityFiller {
   edm::EDGetTokenT<reco::MuonCollection> cosmicToken_;
   edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
 
-
-
   MuonServiceProxy* service_;
-  
+
   double maxdxyLoose_;
   double maxdzLoose_;
   double maxdxyTight_;
@@ -119,11 +116,10 @@ class MuonCosmicCompatibilityFiller {
   double corrTimeNeg_;
   double deltaPt_;
   double angleThreshold_;
-  int sharedHits_;  
+  int sharedHits_;
   double sharedFrac_;
   double ipThreshold_;
   int nChamberMatches_;
   double segmentComp_;
-  
 };
 #endif

--- a/RecoMuon/MuonIdentification/interface/MuonCosmicsId.h
+++ b/RecoMuon/MuonIdentification/interface/MuonCosmicsId.h
@@ -2,22 +2,20 @@
 #define MuonIdentification_MuonCosmicsId_h 1
 // -*- C++ -*-
 //
-// Description: 
+// Description:
 //     Tools to identify cosmics muons in collisions
-//  
+//
 // Original Author:  Dmytro Kovalskyi
 //
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/Common/interface/Handle.h"
-namespace muonid
-{
+namespace muonid {
   // returns angle and dPt/Pt
-  std::pair<double, double> matchTracks(const reco::Track& ref,
-					const reco::Track& probe);
+  std::pair<double, double> matchTracks(const reco::Track& ref, const reco::Track& probe);
 
-  reco::TrackRef findOppositeTrack(const edm::Handle<reco::TrackCollection>& collection, 
-				   const reco::Track& muon,
-				   double angleMatch = 0.01,
-				   double momentumMatch = 0.05);
-}
+  reco::TrackRef findOppositeTrack(const edm::Handle<reco::TrackCollection>& collection,
+                                   const reco::Track& muon,
+                                   double angleMatch = 0.01,
+                                   double momentumMatch = 0.05);
+}  // namespace muonid
 #endif

--- a/RecoMuon/MuonIdentification/interface/MuonIdTruthInfo.h
+++ b/RecoMuon/MuonIdentification/interface/MuonIdTruthInfo.h
@@ -18,24 +18,19 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
-class MuonIdTruthInfo
-{
- public:
+class MuonIdTruthInfo {
+public:
+  void registerConsumes(edm::ConsumesCollector& iC);
 
-   void registerConsumes(edm::ConsumesCollector& iC);
+  static void truthMatchMuon(const edm::Event& iEvent, const edm::EventSetup& iSetup, reco::Muon& aMuon);
 
+private:
+  static void checkSimHitForBestMatch(reco::MuonSegmentMatch& segmentMatch,
+                                      double& distance,
+                                      const PSimHit& hit,
+                                      const DetId& chamberId,
+                                      const edm::ESHandle<GlobalTrackingGeometry>& geometry);
 
-   static void truthMatchMuon( const edm::Event& iEvent,
-			       const edm::EventSetup& iSetup,
-			       reco::Muon& aMuon);
- private:
-   static void checkSimHitForBestMatch(reco::MuonSegmentMatch& segmentMatch,
-				       double& distance,
-				       const PSimHit& hit, 
-				       const DetId& chamberId,
-				       const edm::ESHandle<GlobalTrackingGeometry>& geometry);
-   
-   static double matchChi2(    const reco::Track& recoTrk,
-			       const SimTrack& simTrk);
+  static double matchChi2(const reco::Track& recoTrk, const SimTrack& simTrk);
 };
 #endif

--- a/RecoMuon/MuonIdentification/interface/MuonKinkFinder.h
+++ b/RecoMuon/MuonIdentification/interface/MuonKinkFinder.h
@@ -5,32 +5,32 @@
 #include "TrackingTools/TrackRefitter/interface/TrackTransformer.h"
 
 class MuonKinkFinder {
-    public:
-        MuonKinkFinder(const edm::ParameterSet &iConfig);
-        ~MuonKinkFinder() ;
+public:
+  MuonKinkFinder(const edm::ParameterSet &iConfig);
+  ~MuonKinkFinder();
 
-        // set event setup
-        void init(const edm::EventSetup &iSetup) ;
+  // set event setup
+  void init(const edm::EventSetup &iSetup);
 
-        // fill data, return false if refit failed or too few hits
-        bool fillTrkKink(reco::MuonQuality & quality, const Trajectory &trajectory) const ;
+  // fill data, return false if refit failed or too few hits
+  bool fillTrkKink(reco::MuonQuality &quality, const Trajectory &trajectory) const;
 
-        // fill data, return false if refit failed or too few hits
-        bool fillTrkKink(reco::MuonQuality & quality, const reco::Track &track) const ;
+  // fill data, return false if refit failed or too few hits
+  bool fillTrkKink(reco::MuonQuality &quality, const reco::Track &track) const;
 
-    private:
-        /// use only on-diagonal terms of the covariance matrices
-        bool diagonalOnly_;
-        /// if true, use full 5x5 track state; if false, use only the track direction
-        bool usePosition_;
+private:
+  /// use only on-diagonal terms of the covariance matrices
+  bool diagonalOnly_;
+  /// if true, use full 5x5 track state; if false, use only the track direction
+  bool usePosition_;
 
-        /// Track Transformer
-        TrackTransformer refitter_;
+  /// Track Transformer
+  TrackTransformer refitter_;
 
-        // compute chi2 between track states
-        double getChi2(const TrajectoryStateOnSurface &start, const TrajectoryStateOnSurface &other) const ;
+  // compute chi2 between track states
+  double getChi2(const TrajectoryStateOnSurface &start, const TrajectoryStateOnSurface &other) const;
 
-        // possibly crop matrix or set to zero off-diagonal elements, then invert
-        void cropAndInvert(AlgebraicSymMatrix55 &cov) const ;
+  // possibly crop matrix or set to zero off-diagonal elements, then invert
+  void cropAndInvert(AlgebraicSymMatrix55 &cov) const;
 };
 #endif

--- a/RecoMuon/MuonIdentification/interface/MuonMesh.h
+++ b/RecoMuon/MuonIdentification/interface/MuonMesh.h
@@ -15,64 +15,52 @@
 class CSCGeometry;
 
 class MuonMesh {
-
   typedef std::map<reco::Muon*,
-                   std::vector<std::pair<reco::Muon*,
-                                         std::pair<reco::MuonChamberMatch*,
-                                                   reco::MuonSegmentMatch*
-                                                  >
-                                        >
-                              >
-                  > MeshType;
+                   std::vector<std::pair<reco::Muon*, std::pair<reco::MuonChamberMatch*, reco::MuonSegmentMatch*> > > >
+      MeshType;
 
-  typedef std::vector<std::pair<reco::Muon*,
-                                std::pair<reco::MuonChamberMatch*,
-                                          reco::MuonSegmentMatch*
-                                         >
-                               >
-                     > AssociationType;
+  typedef std::vector<std::pair<reco::Muon*, std::pair<reco::MuonChamberMatch*, reco::MuonSegmentMatch*> > >
+      AssociationType;
 
- public:
-  
+public:
   MuonMesh(const edm::ParameterSet&);
-  
-  void runMesh(std::vector<reco::Muon>* p) {fillMesh(p); pruneMesh();}
+
+  void runMesh(std::vector<reco::Muon>* p) {
+    fillMesh(p);
+    pruneMesh();
+  }
 
   void clearMesh() { mesh_.clear(); }
 
-  void setCSCGeometry(const CSCGeometry* pg) { geometry_ = pg; } 
+  void setCSCGeometry(const CSCGeometry* pg) { geometry_ = pg; }
 
   bool isDuplicateOf(const CSCSegmentRef& lhs, const CSCSegmentRef& rhs) const;
-  bool isDuplicateOf(const std::pair<CSCDetId,CSCSegmentRef>& rhs, 
-		     const std::pair<CSCDetId,CSCSegmentRef>& lhs) const;
-  bool isClusteredWith(const std::pair<CSCDetId,CSCSegmentRef>& lhs, 
-		       const std::pair<CSCDetId,CSCSegmentRef>& rhs) const;
+  bool isDuplicateOf(const std::pair<CSCDetId, CSCSegmentRef>& rhs,
+                     const std::pair<CSCDetId, CSCSegmentRef>& lhs) const;
+  bool isClusteredWith(const std::pair<CSCDetId, CSCSegmentRef>& lhs,
+                       const std::pair<CSCDetId, CSCSegmentRef>& rhs) const;
 
- private:
-
+private:
   void fillMesh(std::vector<reco::Muon>*);
 
   void pruneMesh();
 
-  
   // implement to remove cases where two segments in the same
   // chamber overlap within 2 sigma of ALL of their errors
-  bool withinTwoSigma(const std::pair<CSCDetId,CSCSegmentRef>& rhs, 
-		      const std::pair<CSCDetId,CSCSegmentRef>& lhs) const { return false; }
-  
-  
-  
-  
+  bool withinTwoSigma(const std::pair<CSCDetId, CSCSegmentRef>& rhs,
+                      const std::pair<CSCDetId, CSCSegmentRef>& lhs) const {
+    return false;
+  }
 
   MeshType mesh_;
 
   // geometry cache for segment arbitration
-   const CSCGeometry* geometry_;
-   
-   // do various cleanings?
-   const bool doME1a, doOverlaps, doClustering;
-   // overlap and clustering parameters
-   const double OverlapDPhi, OverlapDTheta, ClusterDPhi, ClusterDTheta;
+  const CSCGeometry* geometry_;
+
+  // do various cleanings?
+  const bool doME1a, doOverlaps, doClustering;
+  // overlap and clustering parameters
+  const double OverlapDPhi, OverlapDTheta, ClusterDPhi, ClusterDTheta;
 };
 
 #endif

--- a/RecoMuon/MuonIdentification/interface/MuonShowerDigiFiller.h
+++ b/RecoMuon/MuonIdentification/interface/MuonShowerDigiFiller.h
@@ -5,7 +5,7 @@
 //
 // Package:    MuonShowerDigiFiller
 // Class:      MuonShowerDigiFiller
-// 
+//
 /**\class MuonShowerDigiFiller MuonShowerDigiFiller.h RecoMuon/MuonIdentification/interface/MuonShowerDigiFiller.h
 
  Description: Class filling shower information using DT and CSC digis
@@ -44,32 +44,27 @@
 // class decleration
 //
 
-class MuonShowerDigiFiller 
-{
-
- public:
-
+class MuonShowerDigiFiller {
+public:
   MuonShowerDigiFiller(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
 
-  void getES( const edm::EventSetup& iSetup );
-  void getDigis( edm::Event& iEvent );   
+  void getES(const edm::EventSetup& iSetup);
+  void getDigis(edm::Event& iEvent);
 
-  void fill( reco::MuonChamberMatch & muChMatch ) const;
-  void fillDefault( reco::MuonChamberMatch & muChMatch ) const;
+  void fill(reco::MuonChamberMatch& muChMatch) const;
+  void fillDefault(reco::MuonChamberMatch& muChMatch) const;
 
- private:
-  
+private:
   double m_digiMaxDistanceX;
 
   edm::EDGetTokenT<DTDigiCollection> m_dtDigisToken;
   edm::EDGetTokenT<CSCStripDigiCollection> m_cscDigisToken;
 
-  edm::ESHandle<DTGeometry>  m_dtGeometry;
+  edm::ESHandle<DTGeometry> m_dtGeometry;
   edm::ESHandle<CSCGeometry> m_cscGeometry;
 
   edm::Handle<DTDigiCollection> m_dtDigis;
   edm::Handle<CSCStripDigiCollection> m_cscDigis;
-
 };
 
 #endif

--- a/RecoMuon/MuonIdentification/interface/MuonShowerInformationFiller.h
+++ b/RecoMuon/MuonIdentification/interface/MuonShowerInformationFiller.h
@@ -39,8 +39,15 @@
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
-namespace edm {class ParameterSet; class Event; class EventSetup;}
-namespace reco {class TransientTrack; struct MuonShower;}
+namespace edm {
+  class ParameterSet;
+  class Event;
+  class EventSetup;
+}  // namespace edm
+namespace reco {
+  class TransientTrack;
+  struct MuonShower;
+}  // namespace reco
 
 class MuonServiceProxy;
 class Trajectory;
@@ -53,162 +60,157 @@ class GeometricSearchTracker;
 class GlobalTrackingGeometry;
 class MuonDetLayerGeometry;
 
-
 class MuonShowerInformationFiller {
+public:
+  typedef TransientTrackingRecHit::ConstRecHitContainer ConstRecHitContainer;
+  typedef MuonTransientTrackingRecHit::MuonRecHitContainer MuonRecHitContainer;
+  typedef MuonTransientTrackingRecHit::ConstMuonRecHitPointer ConstMuonRecHitPointer;
 
-  public:
+public:
+  ///constructors
+  MuonShowerInformationFiller(){};
+  MuonShowerInformationFiller(const edm::ParameterSet&, edm::ConsumesCollector&);
 
-    typedef TransientTrackingRecHit::ConstRecHitContainer ConstRecHitContainer;
-    typedef MuonTransientTrackingRecHit::MuonRecHitContainer MuonRecHitContainer;
-    typedef MuonTransientTrackingRecHit::ConstMuonRecHitPointer ConstMuonRecHitPointer;
-	
-  public:
+  ///destructor
+  virtual ~MuonShowerInformationFiller();
 
-    ///constructors
-    MuonShowerInformationFiller() {};
-    MuonShowerInformationFiller(const edm::ParameterSet&,edm::ConsumesCollector&);
+  /// fill muon shower variables
+  reco::MuonShower fillShowerInformation(const reco::Muon& muon, const edm::Event&, const edm::EventSetup&);
 
-    ///destructor
-    virtual ~MuonShowerInformationFiller();
-   
-    /// fill muon shower variables  
-    reco::MuonShower fillShowerInformation( const reco::Muon& muon, const edm::Event&, const edm::EventSetup&);
+  /// pass the Event to the algorithm at each event
+  virtual void setEvent(const edm::Event&);
 
-    /// pass the Event to the algorithm at each event
-    virtual void setEvent(const edm::Event&);
+  /// set the services needed
+  void setServices(const edm::EventSetup&);
 
-    /// set the services needed
-    void setServices(const edm::EventSetup&);
+  //set the data members
+  void fillHitsByStation(const reco::Muon&);
 
-    //set the data members
-    void fillHitsByStation(const reco::Muon&);
+protected:
+  const MuonServiceProxy* getService() const { return theService; }
 
-  protected:
+private:
+  std::vector<float> theStationShowerDeltaR;
+  std::vector<float> theStationShowerTSize;
+  std::vector<int> theAllStationHits;
+  std::vector<int> theCorrelatedStationHits;
 
-    const MuonServiceProxy* getService() const { return theService; }
+  MuonServiceProxy* theService;
 
-  private:
+  GlobalPoint crossingPoint(const GlobalPoint&, const GlobalPoint&, const BarrelDetLayer*) const;
+  GlobalPoint crossingPoint(const GlobalPoint&, const GlobalPoint&, const Cylinder&) const;
+  GlobalPoint crossingPoint(const GlobalPoint&, const GlobalPoint&, const ForwardDetLayer*) const;
+  GlobalPoint crossingPoint(const GlobalPoint&, const GlobalPoint&, const Disk&) const;
+  std::vector<const GeomDet*> dtPositionToDets(const GlobalPoint&) const;
+  std::vector<const GeomDet*> cscPositionToDets(const GlobalPoint&) const;
+  MuonRecHitContainer findPerpCluster(MuonRecHitContainer& muonRecHits) const;
+  TransientTrackingRecHit::ConstRecHitContainer findThetaCluster(TransientTrackingRecHit::ConstRecHitContainer&,
+                                                                 const GlobalPoint&) const;
+  TransientTrackingRecHit::ConstRecHitContainer hitsFromSegments(const GeomDet*,
+                                                                 edm::Handle<DTRecSegment4DCollection>,
+                                                                 edm::Handle<CSCSegmentCollection>) const;
+  std::vector<const GeomDet*> getCompatibleDets(const reco::Track&) const;
 
-    std::vector<float> theStationShowerDeltaR;
-    std::vector<float> theStationShowerTSize;
-    std::vector<int>   theAllStationHits;
-    std::vector<int>   theCorrelatedStationHits;
+  struct LessMag {
+    LessMag(const GlobalPoint& point) : thePoint(point) {}
+    bool operator()(const GlobalPoint& lhs, const GlobalPoint& rhs) const {
+      return (lhs - thePoint).mag() < (rhs - thePoint).mag();
+    }
+    bool operator()(const MuonTransientTrackingRecHit::MuonRecHitPointer& lhs,
+                    const MuonTransientTrackingRecHit::MuonRecHitPointer& rhs) const {
+      return (lhs->globalPosition() - thePoint).mag() < (rhs->globalPosition() - thePoint).mag();
+    }
+    GlobalPoint thePoint;
+  };
 
-    MuonServiceProxy* theService;
+  struct LessDPhi {
+    LessDPhi(const GlobalPoint& point) : thePoint(point) {}
+    bool operator()(const MuonTransientTrackingRecHit::MuonRecHitPointer& lhs,
+                    const MuonTransientTrackingRecHit::MuonRecHitPointer& rhs) const {
+      return deltaPhi(lhs->globalPosition().barePhi(), thePoint.barePhi()) <
+             deltaPhi(rhs->globalPosition().barePhi(), thePoint.barePhi());
+    }
+    GlobalPoint thePoint;
+  };
 
-    GlobalPoint crossingPoint(const GlobalPoint&, const GlobalPoint&, const BarrelDetLayer* ) const;
-    GlobalPoint crossingPoint(const GlobalPoint&, const GlobalPoint&, const Cylinder& ) const;
-    GlobalPoint crossingPoint(const GlobalPoint&, const GlobalPoint&, const ForwardDetLayer* ) const;
-    GlobalPoint crossingPoint(const GlobalPoint&, const GlobalPoint&, const Disk& ) const;
-    std::vector<const GeomDet*> dtPositionToDets(const GlobalPoint&) const;
-    std::vector<const GeomDet*> cscPositionToDets(const GlobalPoint&) const;
-    MuonRecHitContainer findPerpCluster(MuonRecHitContainer& muonRecHits) const;
-    TransientTrackingRecHit::ConstRecHitContainer findThetaCluster(TransientTrackingRecHit::ConstRecHitContainer&, const GlobalPoint&) const;
-    TransientTrackingRecHit::ConstRecHitContainer hitsFromSegments(const GeomDet*,edm::Handle<DTRecSegment4DCollection>, edm::Handle<CSCSegmentCollection>) const;
-    std::vector<const GeomDet*> getCompatibleDets(const reco::Track&) const;
+  struct AbsLessDPhi {
+    AbsLessDPhi(const GlobalPoint& point) : thePoint(point) {}
+    bool operator()(const MuonTransientTrackingRecHit::MuonRecHitPointer& lhs,
+                    const MuonTransientTrackingRecHit::MuonRecHitPointer& rhs) const {
+      return (fabs(deltaPhi(lhs->globalPosition().barePhi(), thePoint.barePhi())) <
+              fabs(deltaPhi(rhs->globalPosition().barePhi(), thePoint.barePhi())));
+    }
+    GlobalPoint thePoint;
+  };
 
-   struct LessMag {
-       LessMag(const GlobalPoint& point) : thePoint(point) {}
-       bool operator()(const GlobalPoint& lhs,
-                       const GlobalPoint& rhs) const{ 
-            return (lhs - thePoint).mag() < (rhs -thePoint).mag();
-        }
-        bool operator()(const MuonTransientTrackingRecHit::MuonRecHitPointer& lhs,
-                       const MuonTransientTrackingRecHit::MuonRecHitPointer& rhs) const{
-           return (lhs->globalPosition() - thePoint).mag() < (rhs->globalPosition() -thePoint).mag();
-        }
-      GlobalPoint thePoint;
-   };
+  struct AbsLessDTheta {
+    AbsLessDTheta(const GlobalPoint& point) : thePoint(point) {}
+    bool operator()(const TransientTrackingRecHit::ConstRecHitPointer& lhs,
+                    const TransientTrackingRecHit::ConstRecHitPointer& rhs) const {
+      return (fabs(lhs->globalPosition().bareTheta() - thePoint.bareTheta()) <
+              fabs(rhs->globalPosition().bareTheta() - thePoint.bareTheta()));
+    }
+    GlobalPoint thePoint;
+  };
 
-   struct LessDPhi {
-        LessDPhi(const GlobalPoint& point) : thePoint(point) {}
-        bool operator()(const MuonTransientTrackingRecHit::MuonRecHitPointer& lhs,
-                       const MuonTransientTrackingRecHit::MuonRecHitPointer& rhs) const{
-           return deltaPhi(lhs->globalPosition().barePhi(), thePoint.barePhi()) < deltaPhi(rhs->globalPosition().barePhi(), thePoint.barePhi());
-        }
-      GlobalPoint thePoint;
-    };
+  struct LessPhi {
+    LessPhi() : thePoint(0, 0, 0) {}
+    bool operator()(const MuonTransientTrackingRecHit::MuonRecHitPointer& lhs,
+                    const MuonTransientTrackingRecHit::MuonRecHitPointer& rhs) const {
+      return (lhs->globalPosition().barePhi() < rhs->globalPosition().barePhi());
+    }
+    GlobalPoint thePoint;
+  };
 
-    struct AbsLessDPhi {
-        AbsLessDPhi(const GlobalPoint& point) : thePoint(point) {}
-        bool operator()(const MuonTransientTrackingRecHit::MuonRecHitPointer& lhs,
-                       const MuonTransientTrackingRecHit::MuonRecHitPointer& rhs) const{
-           return ( fabs(deltaPhi(lhs->globalPosition().barePhi(), thePoint.barePhi())) < fabs(deltaPhi(rhs->globalPosition().barePhi(), thePoint.barePhi())) );
-        }
-      GlobalPoint thePoint;
-    };
+  struct LessPerp {
+    LessPerp() : thePoint(0, 0, 0) {}
+    bool operator()(const MuonTransientTrackingRecHit::MuonRecHitPointer& lhs,
+                    const MuonTransientTrackingRecHit::MuonRecHitPointer& rhs) const {
+      return (lhs->globalPosition().perp() < rhs->globalPosition().perp());
+    }
+    GlobalPoint thePoint;
+  };
 
-    struct AbsLessDTheta {
-        AbsLessDTheta(const GlobalPoint& point) : thePoint(point) {}
-        bool operator()(const TransientTrackingRecHit::ConstRecHitPointer& lhs,
-                       const TransientTrackingRecHit::ConstRecHitPointer& rhs) const{
-           return ( fabs(lhs->globalPosition().bareTheta() - thePoint.bareTheta()) < fabs(rhs->globalPosition().bareTheta() - thePoint.bareTheta()) );
-        }
-      GlobalPoint thePoint;
-    };
+  struct LessAbsMag {
+    LessAbsMag() : thePoint(0, 0, 0) {}
+    bool operator()(const MuonTransientTrackingRecHit::MuonRecHitPointer& lhs,
+                    const MuonTransientTrackingRecHit::MuonRecHitPointer& rhs) const {
+      return (lhs->globalPosition().mag() < rhs->globalPosition().mag());
+    }
+    GlobalPoint thePoint;
+  };
 
-    struct LessPhi {
-        LessPhi() : thePoint(0,0,0) {}
-        bool operator()(const MuonTransientTrackingRecHit::MuonRecHitPointer& lhs,
-                       const MuonTransientTrackingRecHit::MuonRecHitPointer& rhs) const{
-           return (lhs->globalPosition().barePhi() < rhs->globalPosition().barePhi());
-        }
-        GlobalPoint thePoint;
-    };
+  std::string category_;
 
-    struct LessPerp {
-        LessPerp() : thePoint(0,0,0) {}
-        bool operator()(const MuonTransientTrackingRecHit::MuonRecHitPointer& lhs,
-                       const MuonTransientTrackingRecHit::MuonRecHitPointer& rhs) const{
-           return (lhs->globalPosition().perp() < rhs->globalPosition().perp());
-        }
-      GlobalPoint thePoint;
-    };
+  unsigned long long theCacheId_TRH;
+  unsigned long long theCacheId_MT;
 
-    struct LessAbsMag {
-        LessAbsMag() : thePoint(0,0,0) {}
-        bool operator()(const MuonTransientTrackingRecHit::MuonRecHitPointer& lhs,
-                       const MuonTransientTrackingRecHit::MuonRecHitPointer& rhs) const{
-           return (lhs->globalPosition().mag() < rhs->globalPosition().mag());
-        }
-      GlobalPoint thePoint;
-    };
+  std::string theTrackerRecHitBuilderName;
+  edm::ESHandle<TransientTrackingRecHitBuilder> theTrackerRecHitBuilder;
 
-    std::string category_;
+  std::string theMuonRecHitBuilderName;
+  edm::ESHandle<TransientTrackingRecHitBuilder> theMuonRecHitBuilder;
 
-    unsigned long long theCacheId_TRH;
-    unsigned long long theCacheId_MT;
+  edm::InputTag theDTRecHitLabel;
+  edm::InputTag theCSCRecHitLabel;
+  edm::InputTag theCSCSegmentsLabel;
+  edm::InputTag theDT4DRecSegmentLabel;
 
-    std::string theTrackerRecHitBuilderName;
-    edm::ESHandle<TransientTrackingRecHitBuilder> theTrackerRecHitBuilder;
+  edm::Handle<DTRecHitCollection> theDTRecHits;
+  edm::Handle<CSCRecHit2DCollection> theCSCRecHits;
+  edm::Handle<CSCSegmentCollection> theCSCSegments;
+  edm::Handle<DTRecSegment4DCollection> theDT4DRecSegments;
 
-    std::string theMuonRecHitBuilderName;
-    edm::ESHandle<TransientTrackingRecHitBuilder> theMuonRecHitBuilder;
+  edm::EDGetTokenT<DTRecHitCollection> theDTRecHitToken;
+  edm::EDGetTokenT<CSCRecHit2DCollection> theCSCRecHitToken;
+  edm::EDGetTokenT<CSCSegmentCollection> theCSCSegmentsToken;
+  edm::EDGetTokenT<DTRecSegment4DCollection> theDT4DRecSegmentToken;
 
-    edm::InputTag theDTRecHitLabel;
-    edm::InputTag theCSCRecHitLabel;
-    edm::InputTag theCSCSegmentsLabel;
-    edm::InputTag theDT4DRecSegmentLabel;
-
-    edm::Handle<DTRecHitCollection> theDTRecHits;
-    edm::Handle<CSCRecHit2DCollection> theCSCRecHits;
-    edm::Handle<CSCSegmentCollection> theCSCSegments;
-    edm::Handle<DTRecSegment4DCollection> theDT4DRecSegments;
-
-    edm::EDGetTokenT<DTRecHitCollection> theDTRecHitToken;
-    edm::EDGetTokenT<CSCRecHit2DCollection> theCSCRecHitToken;
-    edm::EDGetTokenT<CSCSegmentCollection> theCSCSegmentsToken;
-    edm::EDGetTokenT<DTRecSegment4DCollection> theDT4DRecSegmentToken;
-
-
-
-
-    // geometry
-    edm::ESHandle<GeometricSearchTracker> theTracker;
-    edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
-    edm::ESHandle<MagneticField> theField;
-    edm::ESHandle<CSCGeometry> theCSCGeometry;
-    edm::ESHandle<DTGeometry> theDTGeometry;
-
+  // geometry
+  edm::ESHandle<GeometricSearchTracker> theTracker;
+  edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
+  edm::ESHandle<MagneticField> theField;
+  edm::ESHandle<CSCGeometry> theCSCGeometry;
+  edm::ESHandle<DTGeometry> theDTGeometry;
 };
 #endif

--- a/RecoMuon/MuonIdentification/interface/MuonTimingFiller.h
+++ b/RecoMuon/MuonIdentification/interface/MuonTimingFiller.h
@@ -5,7 +5,7 @@
 //
 // Package:    MuonTimingFiller
 // Class:      MuonTimingFiller
-// 
+//
 /**\class MuonTimingFiller MuonTimingFiller.h RecoMuon/MuonIdentification/interface/MuonTimingFiller.h
 
  Description: Class filling the DT, CSC and Combined MuonTimeExtra objects
@@ -40,29 +40,33 @@
 //
 
 class MuonTimingFiller {
-   public:
+public:
   MuonTimingFiller(const edm::ParameterSet&, edm::ConsumesCollector&& iC);
-      ~MuonTimingFiller();
-      void fillTiming( const reco::Muon& muon, reco::MuonTimeExtra& dtTime, 
-                    reco::MuonTimeExtra& cscTime, reco::MuonTime& rpcTime, 
-                    reco::MuonTimeExtra& combinedTime, 
-                    edm::Event& iEvent, const edm::EventSetup& iSetup );
+  ~MuonTimingFiller();
+  void fillTiming(const reco::Muon& muon,
+                  reco::MuonTimeExtra& dtTime,
+                  reco::MuonTimeExtra& cscTime,
+                  reco::MuonTime& rpcTime,
+                  reco::MuonTimeExtra& combinedTime,
+                  edm::Event& iEvent,
+                  const edm::EventSetup& iSetup);
 
-   private:
-      void fillTimeFromMeasurements( const TimeMeasurementSequence& tmSeq, reco::MuonTimeExtra &muTime );
-      void fillRPCTime( const reco::Muon& muon, reco::MuonTime &muTime, edm::Event& iEvent );
-      void rawFit(double &a, double &da, double &b, double &db, 
-                  const std::vector<double>& hitsx, const std::vector<double>& hitsy);
-      void addEcalTime( const reco::Muon& muon, TimeMeasurementSequence &cmbSeq );
-      void combineTMSequences( const reco::Muon& muon, const TimeMeasurementSequence& dtSeq, 
-                               const TimeMeasurementSequence& cscSeq, TimeMeasurementSequence &cmbSeq );
-      
-      std::unique_ptr<MuonSegmentMatcher> theMatcher_;
-      std::unique_ptr<DTTimingExtractor> theDTTimingExtractor_;
-      std::unique_ptr<CSCTimingExtractor> theCSCTimingExtractor_;
-      double errorEB_,errorEE_,ecalEcut_;
-      bool useDT_, useCSC_, useECAL_;
+private:
+  void fillTimeFromMeasurements(const TimeMeasurementSequence& tmSeq, reco::MuonTimeExtra& muTime);
+  void fillRPCTime(const reco::Muon& muon, reco::MuonTime& muTime, edm::Event& iEvent);
+  void rawFit(
+      double& a, double& da, double& b, double& db, const std::vector<double>& hitsx, const std::vector<double>& hitsy);
+  void addEcalTime(const reco::Muon& muon, TimeMeasurementSequence& cmbSeq);
+  void combineTMSequences(const reco::Muon& muon,
+                          const TimeMeasurementSequence& dtSeq,
+                          const TimeMeasurementSequence& cscSeq,
+                          TimeMeasurementSequence& cmbSeq);
 
+  std::unique_ptr<MuonSegmentMatcher> theMatcher_;
+  std::unique_ptr<DTTimingExtractor> theDTTimingExtractor_;
+  std::unique_ptr<CSCTimingExtractor> theCSCTimingExtractor_;
+  double errorEB_, errorEE_, ecalEcut_;
+  bool useDT_, useCSC_, useECAL_;
 };
 
 #endif

--- a/RecoMuon/MuonIdentification/interface/TimeMeasurementSequence.h
+++ b/RecoMuon/MuonIdentification/interface/TimeMeasurementSequence.h
@@ -13,23 +13,16 @@
 #include <vector>
 
 class TimeMeasurementSequence {
+public:
+  std::vector<double> dstnc;
+  std::vector<double> local_t0;
+  std::vector<double> weightTimeVtx;
+  std::vector<double> weightInvbeta;
 
-    public:
+  double totalWeightInvbeta;
+  double totalWeightTimeVtx;
 
-      std::vector <double> dstnc;
-      std::vector <double> local_t0;
-      std::vector <double> weightTimeVtx;
-      std::vector <double> weightInvbeta;
-      
-      double totalWeightInvbeta;
-      double totalWeightTimeVtx;
-      
-      TimeMeasurementSequence():
-	totalWeightInvbeta(0),
-	totalWeightTimeVtx(0)
-	 {}
-
+  TimeMeasurementSequence() : totalWeightInvbeta(0), totalWeightTimeVtx(0) {}
 };
-
 
 #endif

--- a/RecoMuon/MuonIdentification/plugins/CaloMuonMerger.cc
+++ b/RecoMuon/MuonIdentification/plugins/CaloMuonMerger.cc
@@ -8,7 +8,6 @@
   \author   Giovanni Petrucciani
 */
 
-
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -22,10 +21,10 @@
 
 class CaloMuonMerger : public edm::stream::EDProducer<> {
 public:
-  explicit CaloMuonMerger(const edm::ParameterSet & iConfig);
-  ~CaloMuonMerger() override { }
+  explicit CaloMuonMerger(const edm::ParameterSet& iConfig);
+  ~CaloMuonMerger() override {}
 
-  void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
 private:
   edm::InputTag muons_;
@@ -38,112 +37,116 @@ private:
   edm::InputTag tracks_;
   StringCutObjectSelector<reco::TrackRef, false> tracksCut_;
 
-    edm::EDGetTokenT<std::vector<reco::Muon> > muonToken_;
-    edm::EDGetTokenT<std::vector<reco::CaloMuon> > caloMuonToken_;
-    edm::EDGetTokenT<std::vector<reco::Track> > trackToken_;
-
-
-
+  edm::EDGetTokenT<std::vector<reco::Muon>> muonToken_;
+  edm::EDGetTokenT<std::vector<reco::CaloMuon>> caloMuonToken_;
+  edm::EDGetTokenT<std::vector<reco::Track>> trackToken_;
 };
 
-
-CaloMuonMerger::CaloMuonMerger(const edm::ParameterSet & iConfig) :
-    muons_(iConfig.getParameter<edm::InputTag>("muons")),
-    muonsCut_(iConfig.existsAs<std::string>("muonsCut") ? iConfig.getParameter<std::string>("muonsCut") : ""),
-    mergeCaloMuons_(iConfig.existsAs<bool>("mergeCaloMuons") ? iConfig.getParameter<bool>("mergeCaloMuons") : true),
-    caloMuons_(iConfig.getParameter<edm::InputTag>("caloMuons")),
-    caloMuonsCut_(iConfig.existsAs<std::string>("caloMuonsCut") ? iConfig.getParameter<std::string>("caloMuonsCut") : ""),
-    minCaloCompatibility_(mergeCaloMuons_ ? iConfig.getParameter<double>("minCaloCompatibility") : 0),
-    mergeTracks_(iConfig.existsAs<bool>("mergeTracks") ? iConfig.getParameter<bool>("mergeTracks") : false),
-    tracks_(mergeTracks_ ? iConfig.getParameter<edm::InputTag>("tracks") : edm::InputTag()),
-    tracksCut_(iConfig.existsAs<std::string>("tracksCut") ? iConfig.getParameter<std::string>("tracksCut") : "")
-{
-  muonToken_ = consumes<std::vector<reco::Muon> >(muons_);
-  caloMuonToken_=consumes<std::vector<reco::CaloMuon> >(caloMuons_);
-  trackToken_ = consumes<std::vector<reco::Track> > (tracks_);
-  produces<std::vector<reco::Muon> >();
+CaloMuonMerger::CaloMuonMerger(const edm::ParameterSet& iConfig)
+    : muons_(iConfig.getParameter<edm::InputTag>("muons")),
+      muonsCut_(iConfig.existsAs<std::string>("muonsCut") ? iConfig.getParameter<std::string>("muonsCut") : ""),
+      mergeCaloMuons_(iConfig.existsAs<bool>("mergeCaloMuons") ? iConfig.getParameter<bool>("mergeCaloMuons") : true),
+      caloMuons_(iConfig.getParameter<edm::InputTag>("caloMuons")),
+      caloMuonsCut_(iConfig.existsAs<std::string>("caloMuonsCut") ? iConfig.getParameter<std::string>("caloMuonsCut")
+                                                                  : ""),
+      minCaloCompatibility_(mergeCaloMuons_ ? iConfig.getParameter<double>("minCaloCompatibility") : 0),
+      mergeTracks_(iConfig.existsAs<bool>("mergeTracks") ? iConfig.getParameter<bool>("mergeTracks") : false),
+      tracks_(mergeTracks_ ? iConfig.getParameter<edm::InputTag>("tracks") : edm::InputTag()),
+      tracksCut_(iConfig.existsAs<std::string>("tracksCut") ? iConfig.getParameter<std::string>("tracksCut") : "") {
+  muonToken_ = consumes<std::vector<reco::Muon>>(muons_);
+  caloMuonToken_ = consumes<std::vector<reco::CaloMuon>>(caloMuons_);
+  trackToken_ = consumes<std::vector<reco::Track>>(tracks_);
+  produces<std::vector<reco::Muon>>();
 }
 
-void 
-CaloMuonMerger::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
-    edm::Handle<std::vector<reco::Muon> > muons;
-    edm::Handle<std::vector<reco::CaloMuon> > caloMuons;
-    edm::Handle<std::vector<reco::Track> > tracks;
+void CaloMuonMerger::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<std::vector<reco::Muon>> muons;
+  edm::Handle<std::vector<reco::CaloMuon>> caloMuons;
+  edm::Handle<std::vector<reco::Track>> tracks;
 
-    iEvent.getByToken(muonToken_,muons);
-    if(mergeCaloMuons_) iEvent.getByToken(caloMuonToken_,caloMuons);
-      if(mergeTracks_) iEvent.getByToken(trackToken_,tracks);
+  iEvent.getByToken(muonToken_, muons);
+  if (mergeCaloMuons_)
+    iEvent.getByToken(caloMuonToken_, caloMuons);
+  if (mergeTracks_)
+    iEvent.getByToken(trackToken_, tracks);
 
-    auto out = std::make_unique<std::vector<reco::Muon>>();
-    out->reserve(muons->size() + (mergeTracks_?tracks->size():0));
+  auto out = std::make_unique<std::vector<reco::Muon>>();
+  out->reserve(muons->size() + (mergeTracks_ ? tracks->size() : 0));
 
-    // copy reco::Muons, turning on the CaloCompatibility flag if enabled and possible
-    for (std::vector<reco::Muon>::const_iterator it = muons->begin(), ed = muons->end(); it != ed; ++it) {
-        if(!muonsCut_(*it)) continue;
-        out->push_back(*it);
-        reco::Muon & mu = out->back();
-        if (mergeCaloMuons_ && mu.track().isNonnull()) {
-            if (mu.isCaloCompatibilityValid()) {
-                if (mu.caloCompatibility() >= minCaloCompatibility_) {
-                    mu.setType(mu.type() | reco::Muon::CaloMuon);
-                }
-            } else throw cms::Exception("Boh") << "Muon with track and no CaloCompatibility; pt = " << mu.pt() << ", eta = " << mu.eta() << ", type = " << mu.type() << "\n";
+  // copy reco::Muons, turning on the CaloCompatibility flag if enabled and possible
+  for (std::vector<reco::Muon>::const_iterator it = muons->begin(), ed = muons->end(); it != ed; ++it) {
+    if (!muonsCut_(*it))
+      continue;
+    out->push_back(*it);
+    reco::Muon& mu = out->back();
+    if (mergeCaloMuons_ && mu.track().isNonnull()) {
+      if (mu.isCaloCompatibilityValid()) {
+        if (mu.caloCompatibility() >= minCaloCompatibility_) {
+          mu.setType(mu.type() | reco::Muon::CaloMuon);
         }
+      } else
+        throw cms::Exception("Boh") << "Muon with track and no CaloCompatibility; pt = " << mu.pt()
+                                    << ", eta = " << mu.eta() << ", type = " << mu.type() << "\n";
     }
+  }
 
-    if (mergeCaloMuons_) {
-        // copy reco::CaloMuon 
-        for (std::vector<reco::CaloMuon>::const_iterator it = caloMuons->begin(), ed = caloMuons->end(); it != ed; ++it) {
-            if(!caloMuonsCut_(*it)) continue;
-            // make a reco::Muon
-            reco::TrackRef track = it->track();
-            double energy = sqrt(track->p() * track->p() + 0.011163691);
-            math::XYZTLorentzVector p4(track->px(), track->py(), track->pz(), energy);
-            out->push_back(reco::Muon(track->charge(), p4, track->vertex()));
-            reco::Muon & mu = out->back();
-            // fill info 
-            mu.setCalEnergy( it->calEnergy() );
-            mu.setCaloCompatibility( it->caloCompatibility() );
-            mu.setInnerTrack( track );
-            mu.setType( reco::Muon::CaloMuon );
+  if (mergeCaloMuons_) {
+    // copy reco::CaloMuon
+    for (std::vector<reco::CaloMuon>::const_iterator it = caloMuons->begin(), ed = caloMuons->end(); it != ed; ++it) {
+      if (!caloMuonsCut_(*it))
+        continue;
+      // make a reco::Muon
+      reco::TrackRef track = it->track();
+      double energy = sqrt(track->p() * track->p() + 0.011163691);
+      math::XYZTLorentzVector p4(track->px(), track->py(), track->pz(), energy);
+      out->push_back(reco::Muon(track->charge(), p4, track->vertex()));
+      reco::Muon& mu = out->back();
+      // fill info
+      mu.setCalEnergy(it->calEnergy());
+      mu.setCaloCompatibility(it->caloCompatibility());
+      mu.setInnerTrack(track);
+      mu.setType(reco::Muon::CaloMuon);
+    }
+  }
+
+  // merge reco::Track avoiding duplication of innerTracks
+  if (mergeTracks_) {
+    for (size_t i = 0; i < tracks->size(); i++) {
+      reco::TrackRef track(tracks, i);
+      if (!tracksCut_(track))
+        continue;
+      // check if it is a muon or calomuon
+      bool isMuon = false;
+      for (std::vector<reco::Muon>::const_iterator muon = muons->begin(); muon < muons->end(); muon++) {
+        if (muon->innerTrack() == track) {
+          isMuon = true;
+          break;
         }
-    }
-
-    // merge reco::Track avoiding duplication of innerTracks
-    if(mergeTracks_){
-        for (size_t i = 0; i < tracks->size(); i++) {
-            reco::TrackRef track(tracks, i);
-            if(!tracksCut_(track)) continue;
-            // check if it is a muon or calomuon
-            bool isMuon = false;
-            for(std::vector<reco::Muon>::const_iterator muon = muons->begin(); muon < muons->end(); muon++){
-                if(muon->innerTrack() == track){
-                    isMuon = true;
-                    break;
-                }
-            }
-            if(isMuon) continue;
-            if (mergeCaloMuons_) {
-                bool isCaloMuon = false;
-                for(std::vector<reco::CaloMuon>::const_iterator muon = caloMuons->begin(); muon < caloMuons->end(); muon++){
-                    if(muon->innerTrack() == track){
-                        isCaloMuon = true;
-                        break;
-                    }
-                }
-                if(isCaloMuon) continue;
-            }
-            // make a reco::Muon
-            double energy = sqrt(track->p() * track->p() + 0.011163691);
-            math::XYZTLorentzVector p4(track->px(), track->py(), track->pz(), energy);
-            out->push_back(reco::Muon(track->charge(), p4, track->vertex()));
-            reco::Muon & mu = out->back();
-            // fill info 
-            mu.setInnerTrack( track );
+      }
+      if (isMuon)
+        continue;
+      if (mergeCaloMuons_) {
+        bool isCaloMuon = false;
+        for (std::vector<reco::CaloMuon>::const_iterator muon = caloMuons->begin(); muon < caloMuons->end(); muon++) {
+          if (muon->innerTrack() == track) {
+            isCaloMuon = true;
+            break;
+          }
         }
+        if (isCaloMuon)
+          continue;
+      }
+      // make a reco::Muon
+      double energy = sqrt(track->p() * track->p() + 0.011163691);
+      math::XYZTLorentzVector p4(track->px(), track->py(), track->pz(), energy);
+      out->push_back(reco::Muon(track->charge(), p4, track->vertex()));
+      reco::Muon& mu = out->back();
+      // fill info
+      mu.setInnerTrack(track);
     }
+  }
 
-    iEvent.put(std::move(out));
+  iEvent.put(std::move(out));
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoMuon/MuonIdentification/plugins/CaloMuonProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/CaloMuonProducer.cc
@@ -8,7 +8,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 
@@ -22,26 +21,21 @@
 
 #include "RecoMuon/MuonIdentification/plugins/CaloMuonProducer.h"
 
-CaloMuonProducer::CaloMuonProducer(const edm::ParameterSet& iConfig)
-{
-   produces<reco::CaloMuonCollection>();
-   inputCollection = iConfig.getParameter<edm::InputTag>("inputCollection");
-   muonToken_ = consumes<reco::CaloMuonCollection>(inputCollection);
+CaloMuonProducer::CaloMuonProducer(const edm::ParameterSet& iConfig) {
+  produces<reco::CaloMuonCollection>();
+  inputCollection = iConfig.getParameter<edm::InputTag>("inputCollection");
+  muonToken_ = consumes<reco::CaloMuonCollection>(inputCollection);
 }
 
-CaloMuonProducer::~CaloMuonProducer()
-{
-}
+CaloMuonProducer::~CaloMuonProducer() {}
 
-void CaloMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   edm::Handle<reco::CaloMuonCollection> iMuons;
-   iEvent.getByToken(muonToken_,iMuons);
-   auto oMuons = std::make_unique<reco::CaloMuonCollection>();
-   for ( reco::CaloMuonCollection::const_iterator muon = iMuons->begin();
-	 muon != iMuons->end(); ++muon )
-     oMuons->push_back( *muon );
-   iEvent.put(std::move(oMuons));
+void CaloMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<reco::CaloMuonCollection> iMuons;
+  iEvent.getByToken(muonToken_, iMuons);
+  auto oMuons = std::make_unique<reco::CaloMuonCollection>();
+  for (reco::CaloMuonCollection::const_iterator muon = iMuons->begin(); muon != iMuons->end(); ++muon)
+    oMuons->push_back(*muon);
+  iEvent.put(std::move(oMuons));
 }
 
 //define this as a plug-in

--- a/RecoMuon/MuonIdentification/plugins/CaloMuonProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/CaloMuonProducer.h
@@ -8,7 +8,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 
@@ -19,14 +18,13 @@
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/CaloMuon.h"
 
-
 class CaloMuonProducer : public edm::stream::EDProducer<> {
- public:
-   explicit CaloMuonProducer(const edm::ParameterSet&);
-   ~CaloMuonProducer() override;
-   
- private:
-   void     produce( edm::Event&, const edm::EventSetup& ) override;
-   edm::InputTag inputCollection;
-  edm::EDGetTokenT<reco::CaloMuonCollection > muonToken_;
+public:
+  explicit CaloMuonProducer(const edm::ParameterSet&);
+  ~CaloMuonProducer() override;
+
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  edm::InputTag inputCollection;
+  edm::EDGetTokenT<reco::CaloMuonCollection> muonToken_;
 };

--- a/RecoMuon/MuonIdentification/plugins/CosmicsMuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/CosmicsMuonIdProducer.cc
@@ -18,20 +18,19 @@
 
 class CosmicsMuonIdProducer : public edm::stream::EDProducer<> {
 public:
-  CosmicsMuonIdProducer(const edm::ParameterSet& iConfig) :
-    inputMuonCollection_(iConfig.getParameter<edm::InputTag>("muonCollection")),
-    inputTrackCollections_(iConfig.getParameter<std::vector<edm::InputTag> >("trackCollections"))
-  {
+  CosmicsMuonIdProducer(const edm::ParameterSet& iConfig)
+      : inputMuonCollection_(iConfig.getParameter<edm::InputTag>("muonCollection")),
+        inputTrackCollections_(iConfig.getParameter<std::vector<edm::InputTag>>("trackCollections")) {
     edm::ConsumesCollector iC = consumesCollector();
-    compatibilityFiller_ = new MuonCosmicCompatibilityFiller(iConfig.getParameter<edm::ParameterSet>("CosmicCompFillerParameters"),iC);
+    compatibilityFiller_ =
+        new MuonCosmicCompatibilityFiller(iConfig.getParameter<edm::ParameterSet>("CosmicCompFillerParameters"), iC);
 
-    produces<edm::ValueMap<unsigned int> >().setBranchAlias("cosmicsVeto");
-    produces<edm::ValueMap<reco::MuonCosmicCompatibility> >().setBranchAlias("cosmicCompatibility");
+    produces<edm::ValueMap<unsigned int>>().setBranchAlias("cosmicsVeto");
+    produces<edm::ValueMap<reco::MuonCosmicCompatibility>>().setBranchAlias("cosmicCompatibility");
 
-    muonToken_   = consumes<reco::MuonCollection>(inputMuonCollection_);
-    for(unsigned int i=0;i<inputTrackCollections_.size();++i) 
+    muonToken_ = consumes<reco::MuonCollection>(inputMuonCollection_);
+    for (unsigned int i = 0; i < inputTrackCollections_.size(); ++i)
       trackTokens_.push_back(consumes<reco::TrackCollection>(inputTrackCollections_.at(i)));
-
   }
   ~CosmicsMuonIdProducer() override {
     if (compatibilityFiller_)
@@ -43,15 +42,12 @@ private:
   edm::InputTag inputMuonCollection_;
   std::vector<edm::InputTag> inputTrackCollections_;
   edm::EDGetTokenT<reco::MuonCollection> muonToken_;
-  std::vector<edm::EDGetTokenT<reco::TrackCollection> > trackTokens_;
- 
+  std::vector<edm::EDGetTokenT<reco::TrackCollection>> trackTokens_;
 
-  MuonCosmicCompatibilityFiller *compatibilityFiller_;
+  MuonCosmicCompatibilityFiller* compatibilityFiller_;
 };
 
-void
-CosmicsMuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void CosmicsMuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<reco::MuonCollection> muons;
   iEvent.getByToken(muonToken_, muons);
   // reserve some space
@@ -60,33 +56,29 @@ CosmicsMuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
 
   std::vector<reco::MuonCosmicCompatibility> compValues;
   compValues.reserve(muons->size());
-  
-  for(reco::MuonCollection::const_iterator muon = muons->begin(); 
-      muon != muons->end(); ++muon)
-    {
-      unsigned int foundPartner(0);
-      if ( muon->innerTrack().isNonnull() ){
-	for ( unsigned int i=0; i<inputTrackCollections_.size(); ++i )
-	  {
-	    edm::Handle<reco::TrackCollection> tracks;
-	    iEvent.getByToken(trackTokens_.at(i), tracks);
-	    if ( muonid::findOppositeTrack(tracks,*muon->innerTrack()).isNonnull() ){
-	      foundPartner = i+1;
-	      break;
-	    }
-	  }
-      }
-      values.push_back(foundPartner);
 
-      compValues.push_back(compatibilityFiller_->fillCompatibility(*muon, iEvent, iSetup));
+  for (reco::MuonCollection::const_iterator muon = muons->begin(); muon != muons->end(); ++muon) {
+    unsigned int foundPartner(0);
+    if (muon->innerTrack().isNonnull()) {
+      for (unsigned int i = 0; i < inputTrackCollections_.size(); ++i) {
+        edm::Handle<reco::TrackCollection> tracks;
+        iEvent.getByToken(trackTokens_.at(i), tracks);
+        if (muonid::findOppositeTrack(tracks, *muon->innerTrack()).isNonnull()) {
+          foundPartner = i + 1;
+          break;
+        }
+      }
     }
+    values.push_back(foundPartner);
+
+    compValues.push_back(compatibilityFiller_->fillCompatibility(*muon, iEvent, iSetup));
+  }
 
   // create and fill value map
   auto out = std::make_unique<edm::ValueMap<unsigned int>>();
   edm::ValueMap<unsigned int>::Filler filler(*out);
   filler.insert(muons, values.begin(), values.end());
   filler.fill();
-
 
   auto outC = std::make_unique<edm::ValueMap<reco::MuonCosmicCompatibility>>();
   edm::ValueMap<reco::MuonCosmicCompatibility>::Filler fillerC(*outC);

--- a/RecoMuon/MuonIdentification/plugins/GlobalMuonToMuonProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/GlobalMuonToMuonProducer.cc
@@ -11,7 +11,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
 // tmp
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
@@ -19,98 +18,83 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 
-
 /// Constructor
-GlobalMuonToMuonProducer::GlobalMuonToMuonProducer(const edm::ParameterSet& pSet){
-
+GlobalMuonToMuonProducer::GlobalMuonToMuonProducer(const edm::ParameterSet& pSet) {
   theLinksCollectionLabel = pSet.getParameter<edm::InputTag>("InputObjects");
 
   setAlias(pSet.getParameter<std::string>("@module_label"));
   produces<reco::MuonCollection>().setBranchAlias(theAlias + "s");
   trackLinkToken_ = consumes<reco::MuonTrackLinksCollection>(theLinksCollectionLabel);
-  
 }
 
 /// Destructor
-GlobalMuonToMuonProducer::~GlobalMuonToMuonProducer(){
+GlobalMuonToMuonProducer::~GlobalMuonToMuonProducer() {}
 
-}
-
-void GlobalMuonToMuonProducer::printTrackRecHits(const reco::Track &track, 
-				     edm::ESHandle<GlobalTrackingGeometry> trackingGeometry) const{
-
+void GlobalMuonToMuonProducer::printTrackRecHits(const reco::Track& track,
+                                                 edm::ESHandle<GlobalTrackingGeometry> trackingGeometry) const {
   const std::string metname = "Muon|RecoMuon|MuonIdentification|GlobalMuonToMuonProducer";
 
-  LogTrace(metname) << "Valid RecHits: "<<track.found() << " invalid RecHits: " << track.lost();
-  
+  LogTrace(metname) << "Valid RecHits: " << track.found() << " invalid RecHits: " << track.lost();
+
   int i = 0;
-  for(trackingRecHit_iterator recHit = track.recHitsBegin(); recHit != track.recHitsEnd(); ++recHit)
-    if((*recHit)->isValid()){
+  for (trackingRecHit_iterator recHit = track.recHitsBegin(); recHit != track.recHitsEnd(); ++recHit)
+    if ((*recHit)->isValid()) {
       const GeomDet* geomDet = trackingGeometry->idToDet((*recHit)->geographicalId());
       double r = geomDet->surface().position().perp();
       double z = geomDet->toGlobal((*recHit)->localPosition()).z();
-      LogTrace(metname) << i++ <<" r: "<< r <<" z: "<<z <<" "<<geomDet->toGlobal((*recHit)->localPosition())
-			<<std::endl;
+      LogTrace(metname) << i++ << " r: " << r << " z: " << z << " " << geomDet->toGlobal((*recHit)->localPosition())
+                        << std::endl;
     }
 }
 
-
-
 /// reconstruct muons
 void GlobalMuonToMuonProducer::produce(edm::StreamID, edm::Event& event, const edm::EventSetup& eventSetup) const {
+  const std::string metname = "Muon|RecoMuon|MuonIdentification|GlobalMuonToMuonProducer";
 
-   const std::string metname = "Muon|RecoMuon|MuonIdentification|GlobalMuonToMuonProducer";
+  // the muon collection, it will be loaded in the event
+  auto muonCollection = std::make_unique<reco::MuonCollection>();
 
-   // the muon collection, it will be loaded in the event
-   auto muonCollection = std::make_unique<reco::MuonCollection>();
-   
+  edm::Handle<reco::MuonTrackLinksCollection> linksCollection;
+  event.getByToken(trackLinkToken_, linksCollection);
 
-   edm::Handle<reco::MuonTrackLinksCollection> linksCollection; 
-   event.getByToken(trackLinkToken_,linksCollection);
+  if (linksCollection->empty()) {
+    event.put(std::move(muonCollection));
+    return;
+  }
 
-   if(linksCollection->empty()) {
-     event.put(std::move(muonCollection));
-     return;
-   }
-   
+  // Global Tracking Geometry
+  edm::ESHandle<GlobalTrackingGeometry> trackingGeometry;
+  eventSetup.get<GlobalTrackingGeometryRecord>().get(trackingGeometry);
 
-   // Global Tracking Geometry
-   edm::ESHandle<GlobalTrackingGeometry> trackingGeometry; 
-   eventSetup.get<GlobalTrackingGeometryRecord>().get(trackingGeometry); 
-   
-   for(reco::MuonTrackLinksCollection::const_iterator links = linksCollection->begin();
-       links != linksCollection->end(); ++links){
+  for (reco::MuonTrackLinksCollection::const_iterator links = linksCollection->begin(); links != linksCollection->end();
+       ++links) {
+    // some temporary print-out
+    LogTrace(metname) << "trackerTrack";
+    printTrackRecHits(*(links->trackerTrack()), trackingGeometry);
+    LogTrace(metname) << "standAloneTrack";
+    printTrackRecHits(*(links->standAloneTrack()), trackingGeometry);
+    LogTrace(metname) << "globalTrack";
+    printTrackRecHits(*(links->globalTrack()), trackingGeometry);
 
-     // some temporary print-out
-     LogTrace(metname) << "trackerTrack";
-     printTrackRecHits(*(links->trackerTrack()),trackingGeometry);
-     LogTrace(metname) << "standAloneTrack";
-     printTrackRecHits(*(links->standAloneTrack()),trackingGeometry);
-     LogTrace(metname) << "globalTrack";
-     printTrackRecHits(*(links->globalTrack()),trackingGeometry);
-    
-     // Fill the muon 
-     reco::Muon muon;
-     muon.setStandAlone(links->standAloneTrack());
-     muon.setTrack(links->trackerTrack());
-     muon.setCombined(links->globalTrack());
-     
-     // FIXME: can this break in case combined info cannot be added to some tracks?
-     muon.setCharge(links->globalTrack()->charge());
+    // Fill the muon
+    reco::Muon muon;
+    muon.setStandAlone(links->standAloneTrack());
+    muon.setTrack(links->trackerTrack());
+    muon.setCombined(links->globalTrack());
 
-     //FIXME: E = sqrt(p^2 + m^2), where m == 0.105658369(9)GeV 
-     double energy = sqrt(links->globalTrack()->p() * links->globalTrack()->p() + 0.011163691);
-     math::XYZTLorentzVector p4(links->globalTrack()->px(),
-				links->globalTrack()->py(),
-				links->globalTrack()->pz(),
-				energy);
+    // FIXME: can this break in case combined info cannot be added to some tracks?
+    muon.setCharge(links->globalTrack()->charge());
 
-     muon.setP4(p4);
-     muon.setVertex(links->globalTrack()->vertex());
-       
+    //FIXME: E = sqrt(p^2 + m^2), where m == 0.105658369(9)GeV
+    double energy = sqrt(links->globalTrack()->p() * links->globalTrack()->p() + 0.011163691);
+    math::XYZTLorentzVector p4(
+        links->globalTrack()->px(), links->globalTrack()->py(), links->globalTrack()->pz(), energy);
+
+    muon.setP4(p4);
+    muon.setVertex(links->globalTrack()->vertex());
+
     muonCollection->push_back(muon);
-     
-   }
+  }
 
-   event.put(std::move(muonCollection));
+  event.put(std::move(muonCollection));
 }

--- a/RecoMuon/MuonIdentification/plugins/GlobalMuonToMuonProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/GlobalMuonToMuonProducer.h
@@ -11,47 +11,40 @@
 //#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-
-namespace reco {class Track;}
+namespace reco {
+  class Track;
+}
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonTrackLinks.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 
-
 class GlobalMuonToMuonProducer : public edm::global::EDProducer<> {
 public:
-
   /// Constructor
-  GlobalMuonToMuonProducer(const edm::ParameterSet&);
+  GlobalMuonToMuonProducer(const edm::ParameterSet &);
 
   /// Destructor
   ~GlobalMuonToMuonProducer() override;
 
   /// reconstruct muons
-  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  void produce(edm::StreamID, edm::Event &, const edm::EventSetup &) const override;
 
 protected:
-
 private:
-
   std::string theAlias;
 
-  void setAlias( std::string alias ){
-    alias.erase( alias.size() - 1, alias.size() );
-    theAlias=alias;
+  void setAlias(std::string alias) {
+    alias.erase(alias.size() - 1, alias.size());
+    theAlias = alias;
   }
 
   // tmp
-  void printTrackRecHits(const reco::Track &track, 
-			 edm::ESHandle<GlobalTrackingGeometry> trackingGeometry) const;
-
+  void printTrackRecHits(const reco::Track &track, edm::ESHandle<GlobalTrackingGeometry> trackingGeometry) const;
 
 private:
-
   edm::InputTag theLinksCollectionLabel;
   edm::EDGetTokenT<reco::MuonTrackLinksCollection> trackLinkToken_;
 };
 #endif
-

--- a/RecoMuon/MuonIdentification/plugins/InterestingEcalDetIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/InterestingEcalDetIdProducer.cc
@@ -19,43 +19,38 @@
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
 #include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
 
-
-InterestingEcalDetIdProducer::InterestingEcalDetIdProducer(const edm::ParameterSet& iConfig) 
-{
-  inputCollection_ = iConfig.getParameter< edm::InputTag >("inputCollection");
-  produces< DetIdCollection >() ;
+InterestingEcalDetIdProducer::InterestingEcalDetIdProducer(const edm::ParameterSet& iConfig) {
+  inputCollection_ = iConfig.getParameter<edm::InputTag>("inputCollection");
+  produces<DetIdCollection>();
   muonToken_ = consumes<reco::MuonCollection>(inputCollection_);
 }
 
+InterestingEcalDetIdProducer::~InterestingEcalDetIdProducer() {}
 
-InterestingEcalDetIdProducer::~InterestingEcalDetIdProducer()
-{}
-
-void InterestingEcalDetIdProducer::beginRun (const edm::Run & run, const edm::EventSetup & iSetup)  
-{
-   edm::ESHandle<CaloTopology> theCaloTopology;
-   iSetup.get<CaloTopologyRecord>().get(theCaloTopology);
-   caloTopology_ = &(*theCaloTopology); 
+void InterestingEcalDetIdProducer::beginRun(const edm::Run& run, const edm::EventSetup& iSetup) {
+  edm::ESHandle<CaloTopology> theCaloTopology;
+  iSetup.get<CaloTopologyRecord>().get(theCaloTopology);
+  caloTopology_ = &(*theCaloTopology);
 }
 
-void
-InterestingEcalDetIdProducer::produce (edm::Event& iEvent, 
-				       const edm::EventSetup& iSetup)
-{
+void InterestingEcalDetIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<reco::MuonCollection> muons;
-  iEvent.getByToken(muonToken_,muons);
-  
+  iEvent.getByToken(muonToken_, muons);
+
   auto interestingDetIdCollection = std::make_unique<DetIdCollection>();
 
-  for(reco::MuonCollection::const_iterator muon = muons->begin(); muon != muons->end(); ++muon){
-    if (! muon->isEnergyValid() ) continue;
-    if ( muon->calEnergy().ecal_id.rawId()==0 ) continue;
-    const CaloSubdetectorTopology* topology = caloTopology_->getSubdetectorTopology(DetId::Ecal,muon->calEnergy().ecal_id.subdetId());
-    const std::vector<DetId>& ids = topology->getWindow(muon->calEnergy().ecal_id, 5, 5); 
-    for ( std::vector<DetId>::const_iterator id = ids.begin(); id != ids.end(); ++id )
-      if(std::find(interestingDetIdCollection->begin(), interestingDetIdCollection->end(), *id) 
-	 == interestingDetIdCollection->end()) 
-	interestingDetIdCollection->push_back(*id);
+  for (reco::MuonCollection::const_iterator muon = muons->begin(); muon != muons->end(); ++muon) {
+    if (!muon->isEnergyValid())
+      continue;
+    if (muon->calEnergy().ecal_id.rawId() == 0)
+      continue;
+    const CaloSubdetectorTopology* topology =
+        caloTopology_->getSubdetectorTopology(DetId::Ecal, muon->calEnergy().ecal_id.subdetId());
+    const std::vector<DetId>& ids = topology->getWindow(muon->calEnergy().ecal_id, 5, 5);
+    for (std::vector<DetId>::const_iterator id = ids.begin(); id != ids.end(); ++id)
+      if (std::find(interestingDetIdCollection->begin(), interestingDetIdCollection->end(), *id) ==
+          interestingDetIdCollection->end())
+        interestingDetIdCollection->push_back(*id);
   }
   iEvent.put(std::move(interestingDetIdCollection));
 }

--- a/RecoMuon/MuonIdentification/plugins/InterestingEcalDetIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/InterestingEcalDetIdProducer.h
@@ -11,13 +11,13 @@
 
 class CaloTopology;
 class InterestingEcalDetIdProducer : public edm::stream::EDProducer<> {
- public:
+public:
   explicit InterestingEcalDetIdProducer(const edm::ParameterSet&);
   ~InterestingEcalDetIdProducer() override;
   void produce(edm::Event&, const edm::EventSetup&) override;
   void beginRun(const edm::Run&, const edm::EventSetup&) override;
 
- private:
+private:
   edm::InputTag inputCollection_;
   edm::EDGetTokenT<reco::MuonCollection> muonToken_;
   const CaloTopology* caloTopology_;

--- a/RecoMuon/MuonIdentification/plugins/ME0MuonConverter.cc
+++ b/RecoMuon/MuonIdentification/plugins/ME0MuonConverter.cc
@@ -3,17 +3,14 @@
  * \author David Nash
  */
 
-
 #include <FWCore/PluginManager/interface/ModuleDef.h>
 #include <FWCore/Framework/interface/MakerMacros.h>
 
 #include <DataFormats/Common/interface/Handle.h>
 #include <FWCore/Framework/interface/ESHandle.h>
-#include <FWCore/MessageLogger/interface/MessageLogger.h> 
+#include <FWCore/MessageLogger/interface/MessageLogger.h>
 
 #include <Geometry/Records/interface/MuonGeometryRecord.h>
-
-
 
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
@@ -27,7 +24,6 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
-
 
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
@@ -46,22 +42,16 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
-
 
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include <DataFormats/GEMRecHit/interface/ME0SegmentCollection.h>
 
-
-
 #include <DataFormats/MuonReco/interface/ME0Muon.h>
 #include <DataFormats/MuonReco/interface/ME0MuonCollection.h>
-
-
 
 class ME0MuonConverter : public edm::stream::EDProducer<> {
 public:
@@ -72,27 +62,20 @@ public:
   /// Produce the converted collection
   void produce(edm::Event&, const edm::EventSetup&) override;
 
-    
-
 private:
-
   //edm::EDGetTokenT<std::vector<reco::ME0Muon>> OurMuonsToken_;
   edm::EDGetTokenT<ME0MuonCollection> OurMuonsToken_;
 };
 
-
 ME0MuonConverter::ME0MuonConverter(const edm::ParameterSet& pas) {
-	
-  produces<std::vector<reco::RecoChargedCandidate> >();  
-  edm::InputTag OurMuonsTag ("me0SegmentMatching");
+  produces<std::vector<reco::RecoChargedCandidate> >();
+  edm::InputTag OurMuonsTag("me0SegmentMatching");
   OurMuonsToken_ = consumes<ME0MuonCollection>(OurMuonsTag);
-
 }
 
 ME0MuonConverter::~ME0MuonConverter() {}
 
 void ME0MuonConverter::produce(edm::Event& ev, const edm::EventSetup& setup) {
-
   using namespace edm;
 
   using namespace reco;
@@ -100,29 +83,27 @@ void ME0MuonConverter::produce(edm::Event& ev, const edm::EventSetup& setup) {
   // Handle <std::vector<ME0Muon> > OurMuons;
   // ev.getByToken <std::vector<ME0Muon> > (OurMuonsToken_, OurMuons);
 
-
-  Handle <ME0MuonCollection> OurMuons;
+  Handle<ME0MuonCollection> OurMuons;
   ev.getByToken(OurMuonsToken_, OurMuons);
 
   auto oc = std::make_unique<RecoChargedCandidateCollection>();
 
-  for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
-       thisMuon != OurMuons->end(); ++thisMuon){
+  for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin(); thisMuon != OurMuons->end(); ++thisMuon) {
     TrackRef tkRef = thisMuon->innerTrack();
-    
+
     Particle::Charge q = tkRef->charge();
     Particle::LorentzVector p4(tkRef->px(), tkRef->py(), tkRef->pz(), tkRef->p());
-    Particle::Point vtx(tkRef->vx(),tkRef->vy(), tkRef->vz());
+    Particle::Point vtx(tkRef->vx(), tkRef->vy(), tkRef->vz());
 
     int pid = 0;
-    if(abs(q)==1) pid = q < 0 ? 13 : -13;
+    if (abs(q) == 1)
+      pid = q < 0 ? 13 : -13;
     reco::RecoChargedCandidate cand(q, p4, vtx, pid);
     cand.setTrack(thisMuon->innerTrack());
     oc->push_back(cand);
   }
-    
+
   ev.put(std::move(oc));
 }
 
-
- DEFINE_FWK_MODULE(ME0MuonConverter);
+DEFINE_FWK_MODULE(ME0MuonConverter);

--- a/RecoMuon/MuonIdentification/plugins/ME0MuonSelector.cc
+++ b/RecoMuon/MuonIdentification/plugins/ME0MuonSelector.cc
@@ -11,81 +11,74 @@
 #include "TrackingTools/AnalyticalJacobians/interface/JacobianLocalToCartesian.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 
-
 namespace muon {
-SelectionType selectionTypeFromString( const std::string &label )
-{
-  const static SelectionTypeStringToEnum selectionTypeStringToEnumMap[] = {
-      { "All", All },
-      { "VeryLoose", VeryLoose },
-      { "Loose", Loose },
-      { "Tight", Tight },
-      { nullptr, (SelectionType)-1 }
-   };
+  SelectionType selectionTypeFromString(const std::string& label) {
+    const static SelectionTypeStringToEnum selectionTypeStringToEnumMap[] = {
+        {"All", All}, {"VeryLoose", VeryLoose}, {"Loose", Loose}, {"Tight", Tight}, {nullptr, (SelectionType)-1}};
 
-   SelectionType value = (SelectionType)-1;
-   bool found = false;
-   for(int i = 0; selectionTypeStringToEnumMap[i].label && (! found); ++i)
-      if (! strcmp(label.c_str(), selectionTypeStringToEnumMap[i].label)) {
-         found = true;
-         value = selectionTypeStringToEnumMap[i].value;
+    SelectionType value = (SelectionType)-1;
+    bool found = false;
+    for (int i = 0; selectionTypeStringToEnumMap[i].label && (!found); ++i)
+      if (!strcmp(label.c_str(), selectionTypeStringToEnumMap[i].label)) {
+        found = true;
+        value = selectionTypeStringToEnumMap[i].value;
       }
 
-   // in case of unrecognized selection type
-   if (! found) throw cms::Exception("MuonSelectorError") << label << " is not a recognized SelectionType";
-   return value;
-}
-}
+    // in case of unrecognized selection type
+    if (!found)
+      throw cms::Exception("MuonSelectorError") << label << " is not a recognized SelectionType";
+    return value;
+  }
+}  // namespace muon
 
-
-bool muon::isGoodMuon(const reco::ME0Muon& me0muon, SelectionType type)
-{
-  switch (type)
-    {
+bool muon::isGoodMuon(const reco::ME0Muon& me0muon, SelectionType type) {
+  switch (type) {
     case muon::All:
       return true;
       break;
     case muon::VeryLoose:
-      return isGoodMuon(me0muon,3,4,20,20,3.14); 
+      return isGoodMuon(me0muon, 3, 4, 20, 20, 3.14);
       break;
     case muon::Loose:
-      return isGoodMuon(me0muon,3,2,3,2,0.5);
+      return isGoodMuon(me0muon, 3, 2, 3, 2, 0.5);
       break;
     case muon::Tight:
-      return isGoodMuon(me0muon,3,2,3,2,0.15);
+      return isGoodMuon(me0muon, 3, 2, 3, 2, 0.15);
       break;
     default:
       return false;
-    }
+  }
 }
 
-
-
-
-bool muon::isGoodMuon(const reco::ME0Muon& me0muon, double MaxPullX, double MaxDiffX, double MaxPullY, double MaxDiffY, double MaxDiffPhiDir )
-{
+bool muon::isGoodMuon(const reco::ME0Muon& me0muon,
+                      double MaxPullX,
+                      double MaxDiffX,
+                      double MaxPullY,
+                      double MaxDiffY,
+                      double MaxDiffPhiDir) {
   using namespace reco;
 
   const ME0Segment& thisSegment = me0muon.me0segment();
-
 
   const LocalPoint& r3FinalReco = me0muon.localTrackPosAtSurface();
 
   AlgebraicSymMatrix55 C = me0muon.localTrackCov();
   LocalPoint thisPosition(thisSegment.localPosition());
 
-  
-  double sigmax = sqrt(C[3][3]+thisSegment.localPositionError().xx() );      
-  double sigmay = sqrt(C[4][4]+thisSegment.localPositionError().yy() );
+  double sigmax = sqrt(C[3][3] + thisSegment.localPositionError().xx());
+  double sigmay = sqrt(C[4][4] + thisSegment.localPositionError().yy());
 
   bool X_MatchFound = false, Y_MatchFound = false, Dir_MatchFound = false;
-  
-  
-  if ( ( (std::abs(thisPosition.x()-r3FinalReco.x())/sigmax ) < MaxPullX ) || (std::abs(thisPosition.x()-r3FinalReco.x()) < MaxDiffX ) ) X_MatchFound = true;
-  if ( ( (std::abs(thisPosition.y()-r3FinalReco.y())/sigmay ) < MaxPullY ) || (std::abs(thisPosition.y()-r3FinalReco.y()) < MaxDiffY ) ) Y_MatchFound = true;
-  if ( std::abs(reco::deltaPhi(me0muon.localTrackMomAtSurface().barePhi(),thisSegment.localDirection().barePhi())) < MaxDiffPhiDir) Dir_MatchFound = true;
+
+  if (((std::abs(thisPosition.x() - r3FinalReco.x()) / sigmax) < MaxPullX) ||
+      (std::abs(thisPosition.x() - r3FinalReco.x()) < MaxDiffX))
+    X_MatchFound = true;
+  if (((std::abs(thisPosition.y() - r3FinalReco.y()) / sigmay) < MaxPullY) ||
+      (std::abs(thisPosition.y() - r3FinalReco.y()) < MaxDiffY))
+    Y_MatchFound = true;
+  if (std::abs(reco::deltaPhi(me0muon.localTrackMomAtSurface().barePhi(), thisSegment.localDirection().barePhi())) <
+      MaxDiffPhiDir)
+    Dir_MatchFound = true;
 
   return (X_MatchFound && Y_MatchFound && Dir_MatchFound);
-
 }
-

--- a/RecoMuon/MuonIdentification/plugins/ME0SegmentMatcher.cc
+++ b/RecoMuon/MuonIdentification/plugins/ME0SegmentMatcher.cc
@@ -9,7 +9,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h" 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
@@ -40,46 +40,38 @@ public:
 
   void beginRun(edm::Run const&, edm::EventSetup const&) override;
 
-  FreeTrajectoryState getFTS(const GlobalVector& , const GlobalVector& , 
-			     int , const AlgebraicSymMatrix66& ,
-			     const MagneticField* );
+  FreeTrajectoryState getFTS(
+      const GlobalVector&, const GlobalVector&, int, const AlgebraicSymMatrix66&, const MagneticField*);
 
-  FreeTrajectoryState getFTS(const GlobalVector& , const GlobalVector& , 
-			     int , const AlgebraicSymMatrix55& ,
-			     const MagneticField* );
+  FreeTrajectoryState getFTS(
+      const GlobalVector&, const GlobalVector&, int, const AlgebraicSymMatrix55&, const MagneticField*);
 
-  void getFromFTS(const FreeTrajectoryState& ,
-		  GlobalVector& , GlobalVector& , 
-		  int& , AlgebraicSymMatrix66& );
+  void getFromFTS(const FreeTrajectoryState&, GlobalVector&, GlobalVector&, int&, AlgebraicSymMatrix66&);
 
 private:
-
   double theX_RESIDUAL_CUT, theX_PULL_CUT, theY_RESIDUAL_CUT, theY_PULL_CUT, thePHIDIR_RESIDUAL_CUT;
   edm::InputTag OurSegmentsTag, generalTracksTag;
   edm::EDGetTokenT<ME0SegmentCollection> OurSegmentsToken_;
   edm::EDGetTokenT<reco::TrackCollection> generalTracksToken_;
-  
 };
 
 ME0SegmentMatcher::ME0SegmentMatcher(const edm::ParameterSet& pas) {
-  produces<std::vector<reco::ME0Muon> >();  
-  theX_PULL_CUT   = pas.getParameter<double>("maxPullX");
-  theX_RESIDUAL_CUT   = pas.getParameter<double>("maxDiffX");
-  theY_PULL_CUT   = pas.getParameter<double>("maxPullY");
-  theY_RESIDUAL_CUT   = pas.getParameter<double>("maxDiffY");
-  thePHIDIR_RESIDUAL_CUT   = pas.getParameter<double>("maxDiffPhiDirection");
+  produces<std::vector<reco::ME0Muon>>();
+  theX_PULL_CUT = pas.getParameter<double>("maxPullX");
+  theX_RESIDUAL_CUT = pas.getParameter<double>("maxDiffX");
+  theY_PULL_CUT = pas.getParameter<double>("maxPullY");
+  theY_RESIDUAL_CUT = pas.getParameter<double>("maxDiffY");
+  thePHIDIR_RESIDUAL_CUT = pas.getParameter<double>("maxDiffPhiDirection");
   //Might need to replace "OurSegments" with an edm::InputTag of "OurSegments"
   OurSegmentsTag = pas.getParameter<edm::InputTag>("me0SegmentTag");
   generalTracksTag = pas.getParameter<edm::InputTag>("tracksTag");
   OurSegmentsToken_ = consumes<ME0SegmentCollection>(OurSegmentsTag);
   generalTracksToken_ = consumes<reco::TrackCollection>(generalTracksTag);
-
 }
 
 ME0SegmentMatcher::~ME0SegmentMatcher() {}
 
 void ME0SegmentMatcher::produce(edm::Event& ev, const edm::EventSetup& setup) {
-
   //Getting the objects we'll need
   using namespace edm;
 
@@ -93,29 +85,31 @@ void ME0SegmentMatcher::produce(edm::Event& ev, const edm::EventSetup& setup) {
   using namespace reco;
 
   Handle<ME0SegmentCollection> OurSegments;
-  ev.getByToken(OurSegmentsToken_,OurSegments);
+  ev.getByToken(OurSegmentsToken_, OurSegments);
 
-  auto oc = std::make_unique<std::vector<ME0Muon>>(); 
-  std::vector<ME0Muon> TempStore; 
+  auto oc = std::make_unique<std::vector<ME0Muon>>();
+  std::vector<ME0Muon> TempStore;
 
-  Handle <TrackCollection > generalTracks;
-  ev.getByToken(generalTracksToken_,generalTracks);
+  Handle<TrackCollection> generalTracks;
+  ev.getByToken(generalTracksToken_, generalTracks);
 
   int TrackNumber = 0;
-    
-  for (std::vector<Track>::const_iterator thisTrack = generalTracks->begin();
-       thisTrack != generalTracks->end(); ++thisTrack,++TrackNumber){
+
+  for (std::vector<Track>::const_iterator thisTrack = generalTracks->begin(); thisTrack != generalTracks->end();
+       ++thisTrack, ++TrackNumber) {
     //Initializing our plane
 
     //Remove later
-    if (std::abs(thisTrack->eta()) < 1.8) continue;
+    if (std::abs(thisTrack->eta()) < 1.8)
+      continue;
 
     //Getting the initial variables for propagation
     float zSign = thisTrack->pz() > 0 ? 1.0f : -1.0f;
 
-    ReferenceCountingPointer<Plane> plane = Plane::build(Surface::PositionType(0,0,zSign*526.75),Surface::RotationType());
+    ReferenceCountingPointer<Plane> plane =
+        Plane::build(Surface::PositionType(0, 0, zSign * 526.75), Surface::RotationType());
 
-    int chargeReco = thisTrack->charge(); 
+    int chargeReco = thisTrack->charge();
     GlobalVector p3reco, r3reco;
 
     p3reco = GlobalVector(thisTrack->outerPx(), thisTrack->outerPy(), thisTrack->outerPz());
@@ -123,14 +117,15 @@ void ME0SegmentMatcher::produce(edm::Event& ev, const edm::EventSetup& setup) {
 
     AlgebraicSymMatrix66 covReco;
     //This is to fill the cov matrix correctly
-    const AlgebraicSymMatrix55 & covReco_curv = thisTrack->outerStateCovariance();
+    const AlgebraicSymMatrix55& covReco_curv = thisTrack->outerStateCovariance();
     FreeTrajectoryState initrecostate = getFTS(p3reco, r3reco, chargeReco, covReco_curv, &*bField);
     getFromFTS(initrecostate, p3reco, r3reco, chargeReco, covReco);
 
     //Now we propagate and get the propagated variables from the propagated state
-    TrajectoryStateOnSurface lastrecostate = ThisshProp->propagate(initrecostate,*plane);
-    if (!lastrecostate.isValid()) continue;
-	
+    TrajectoryStateOnSurface lastrecostate = ThisshProp->propagate(initrecostate, *plane);
+    if (!lastrecostate.isValid())
+      continue;
+
     FreeTrajectoryState finalrecostate(*lastrecostate.freeTrajectoryState());
 
     AlgebraicSymMatrix66 covFinalReco;
@@ -143,75 +138,81 @@ void ME0SegmentMatcher::produce(edm::Event& ev, const edm::EventSetup& setup) {
     reco::ME0Muon MuonCandidate;
     double ClosestDelR2 = 999.;
 
-    for (auto thisSegment = OurSegments->begin(); thisSegment != OurSegments->end(); 
-	 ++thisSegment,++SegmentNumber){
+    for (auto thisSegment = OurSegments->begin(); thisSegment != OurSegments->end(); ++thisSegment, ++SegmentNumber) {
       ME0DetId id = thisSegment->me0DetId();
 
       auto chamber = me0Geom->chamber(id);
 
-      if ( zSign * chamber->toGlobal(thisSegment->localPosition()).z() < 0 ) continue;
+      if (zSign * chamber->toGlobal(thisSegment->localPosition()).z() < 0)
+        continue;
 
-      GlobalPoint r3FinalReco_glob(r3FinalReco_globv.x(),r3FinalReco_globv.y(),r3FinalReco_globv.z());
+      GlobalPoint r3FinalReco_glob(r3FinalReco_globv.x(), r3FinalReco_globv.y(), r3FinalReco_globv.z());
 
       LocalPoint r3FinalReco = chamber->toLocal(r3FinalReco_glob);
-      LocalVector p3FinalReco=chamber->toLocal(p3FinalReco_glob);
+      LocalVector p3FinalReco = chamber->toLocal(p3FinalReco_glob);
 
       LocalPoint thisPosition(thisSegment->localPosition());
-      LocalVector thisDirection(thisSegment->localDirection().x(),thisSegment->localDirection().y(),thisSegment->localDirection().z());  //FIXME
+      LocalVector thisDirection(thisSegment->localDirection().x(),
+                                thisSegment->localDirection().y(),
+                                thisSegment->localDirection().z());  //FIXME
 
       //The same goes for the error
-      AlgebraicMatrix thisCov(4,4,0);   
-      for (int i = 1; i <=4; i++){
-	for (int j = 1; j <=4; j++){
-	  thisCov(i,j) = thisSegment->parametersError()(i,j);
-	}
+      AlgebraicMatrix thisCov(4, 4, 0);
+      for (int i = 1; i <= 4; i++) {
+        for (int j = 1; j <= 4; j++) {
+          thisCov(i, j) = thisSegment->parametersError()(i, j);
+        }
       }
 
-      LocalTrajectoryParameters ltp(r3FinalReco,p3FinalReco,chargeReco);
-      JacobianCartesianToLocal jctl(chamber->surface(),ltp);
-      const AlgebraicMatrix56& jacobGlbToLoc = jctl.jacobian(); 
+      LocalTrajectoryParameters ltp(r3FinalReco, p3FinalReco, chargeReco);
+      JacobianCartesianToLocal jctl(chamber->surface(), ltp);
+      const AlgebraicMatrix56& jacobGlbToLoc = jctl.jacobian();
 
-      AlgebraicMatrix55 Ctmp =  (jacobGlbToLoc * covFinalReco) * ROOT::Math::Transpose(jacobGlbToLoc); 
+      AlgebraicMatrix55 Ctmp = (jacobGlbToLoc * covFinalReco) * ROOT::Math::Transpose(jacobGlbToLoc);
       AlgebraicSymMatrix55 C;  // I couldn't find any other way, so I resort to the brute force
-      for(int i=0; i<5; ++i) {
-	for(int j=0; j<5; ++j) {
-	  C[i][j] = Ctmp[i][j]; 
+      for (int i = 0; i < 5; ++i) {
+        for (int j = 0; j < 5; ++j) {
+          C[i][j] = Ctmp[i][j];
+        }
+      }
 
-	}
-      }  
-
-      Double_t sigmax = sqrt(C[3][3]+thisSegment->localPositionError().xx() );      
-      Double_t sigmay = sqrt(C[4][4]+thisSegment->localPositionError().yy() );
+      Double_t sigmax = sqrt(C[3][3] + thisSegment->localPositionError().xx());
+      Double_t sigmay = sqrt(C[4][4] + thisSegment->localPositionError().yy());
 
       bool X_MatchFound = false, Y_MatchFound = false, Dir_MatchFound = false;
-	
-      if ( (std::abs(thisPosition.x()-r3FinalReco.x()) < (theX_PULL_CUT * sigmax)) || (std::abs(thisPosition.x()-r3FinalReco.x()) < theX_RESIDUAL_CUT ) ) X_MatchFound = true;
-      if ( (std::abs(thisPosition.y()-r3FinalReco.y()) < (theY_PULL_CUT * sigmay)) || (std::abs(thisPosition.y()-r3FinalReco.y()) < theY_RESIDUAL_CUT ) ) Y_MatchFound = true;
 
-      if ( std::abs(reco::deltaPhi(p3FinalReco_glob.barePhi(),chamber->toGlobal(thisSegment->localDirection()).barePhi())) < thePHIDIR_RESIDUAL_CUT) Dir_MatchFound = true;
+      if ((std::abs(thisPosition.x() - r3FinalReco.x()) < (theX_PULL_CUT * sigmax)) ||
+          (std::abs(thisPosition.x() - r3FinalReco.x()) < theX_RESIDUAL_CUT))
+        X_MatchFound = true;
+      if ((std::abs(thisPosition.y() - r3FinalReco.y()) < (theY_PULL_CUT * sigmay)) ||
+          (std::abs(thisPosition.y() - r3FinalReco.y()) < theY_RESIDUAL_CUT))
+        Y_MatchFound = true;
+
+      if (std::abs(reco::deltaPhi(p3FinalReco_glob.barePhi(),
+                                  chamber->toGlobal(thisSegment->localDirection()).barePhi())) < thePHIDIR_RESIDUAL_CUT)
+        Dir_MatchFound = true;
 
       //Check for a Match, and if there is a match, check the delR from the segment, keeping only the closest in MuonCandidate
       if (X_MatchFound && Y_MatchFound && Dir_MatchFound) {
-	   
-	TrackRef thisTrackRef(generalTracks,TrackNumber);
-	   
-	GlobalPoint SegPos(chamber->toGlobal(thisSegment->localPosition()));
-	GlobalPoint TkPos(r3FinalReco_globv.x(),r3FinalReco_globv.y(),r3FinalReco_globv.z());
-	   
-	double thisDelR2 = reco::deltaR2(SegPos,TkPos);
-	if (thisDelR2 < ClosestDelR2){
-	  ClosestDelR2 = thisDelR2;
-	  MuonCandidate = reco::ME0Muon(thisTrackRef,(*thisSegment),SegmentNumber,chargeReco);
+        TrackRef thisTrackRef(generalTracks, TrackNumber);
 
-	  MuonCandidate.setGlobalTrackPosAtSurface(r3FinalReco_glob);
-	  MuonCandidate.setGlobalTrackMomAtSurface(p3FinalReco_glob);
-	  MuonCandidate.setLocalTrackPosAtSurface(r3FinalReco);
-	  MuonCandidate.setLocalTrackMomAtSurface(p3FinalReco);
-	  MuonCandidate.setGlobalTrackCov(covFinalReco);
-	  MuonCandidate.setLocalTrackCov(C);
-	}
+        GlobalPoint SegPos(chamber->toGlobal(thisSegment->localPosition()));
+        GlobalPoint TkPos(r3FinalReco_globv.x(), r3FinalReco_globv.y(), r3FinalReco_globv.z());
+
+        double thisDelR2 = reco::deltaR2(SegPos, TkPos);
+        if (thisDelR2 < ClosestDelR2) {
+          ClosestDelR2 = thisDelR2;
+          MuonCandidate = reco::ME0Muon(thisTrackRef, (*thisSegment), SegmentNumber, chargeReco);
+
+          MuonCandidate.setGlobalTrackPosAtSurface(r3FinalReco_glob);
+          MuonCandidate.setGlobalTrackMomAtSurface(p3FinalReco_glob);
+          MuonCandidate.setLocalTrackPosAtSurface(r3FinalReco);
+          MuonCandidate.setLocalTrackMomAtSurface(p3FinalReco);
+          MuonCandidate.setGlobalTrackCov(covFinalReco);
+          MuonCandidate.setLocalTrackCov(C);
+        }
       }
-    }//End loop for (auto thisSegment = OurSegments->begin(); thisSegment != OurSegments->end(); ++thisSegment,++SegmentNumber)
+    }  //End loop for (auto thisSegment = OurSegments->begin(); thisSegment != OurSegments->end(); ++thisSegment,++SegmentNumber)
 
     //As long as the delR of the MuonCandidate is sensible, store the track-segment pair
     if (ClosestDelR2 < 500.) {
@@ -220,54 +221,53 @@ void ME0SegmentMatcher::produce(edm::Event& ev, const edm::EventSetup& setup) {
   }
 
   // put collection in event
-  ev.put(std::move(oc));        
+  ev.put(std::move(oc));
 }
 
-FreeTrajectoryState
-ME0SegmentMatcher::getFTS(const GlobalVector& p3, const GlobalVector& r3, 
-			  int charge, const AlgebraicSymMatrix55& cov,
-			  const MagneticField* field){
-
+FreeTrajectoryState ME0SegmentMatcher::getFTS(const GlobalVector& p3,
+                                              const GlobalVector& r3,
+                                              int charge,
+                                              const AlgebraicSymMatrix55& cov,
+                                              const MagneticField* field) {
   GlobalVector p3GV(p3.x(), p3.y(), p3.z());
   GlobalPoint r3GP(r3.x(), r3.y(), r3.z());
   GlobalTrajectoryParameters tPars(r3GP, p3GV, charge, field);
 
   CurvilinearTrajectoryError tCov(cov);
-  
-  return cov.kRows == 5 ? FreeTrajectoryState(tPars, tCov) : FreeTrajectoryState(tPars) ;
+
+  return cov.kRows == 5 ? FreeTrajectoryState(tPars, tCov) : FreeTrajectoryState(tPars);
 }
 
-FreeTrajectoryState
-ME0SegmentMatcher::getFTS(const GlobalVector& p3, const GlobalVector& r3, 
-			  int charge, const AlgebraicSymMatrix66& cov,
-			  const MagneticField* field){
-
+FreeTrajectoryState ME0SegmentMatcher::getFTS(const GlobalVector& p3,
+                                              const GlobalVector& r3,
+                                              int charge,
+                                              const AlgebraicSymMatrix66& cov,
+                                              const MagneticField* field) {
   GlobalVector p3GV(p3.x(), p3.y(), p3.z());
   GlobalPoint r3GP(r3.x(), r3.y(), r3.z());
   GlobalTrajectoryParameters tPars(r3GP, p3GV, charge, field);
 
   CartesianTrajectoryError tCov(cov);
-  
-  return cov.kRows == 6 ? FreeTrajectoryState(tPars, tCov) : FreeTrajectoryState(tPars) ;
+
+  return cov.kRows == 6 ? FreeTrajectoryState(tPars, tCov) : FreeTrajectoryState(tPars);
 }
 
-void ME0SegmentMatcher::getFromFTS(const FreeTrajectoryState& fts,
-				   GlobalVector& p3, GlobalVector& r3, 
-				   int& charge, AlgebraicSymMatrix66& cov){
+void ME0SegmentMatcher::getFromFTS(
+    const FreeTrajectoryState& fts, GlobalVector& p3, GlobalVector& r3, int& charge, AlgebraicSymMatrix66& cov) {
   GlobalVector p3GV = fts.momentum();
   GlobalPoint r3GP = fts.position();
 
   GlobalVector p3T(p3GV.x(), p3GV.y(), p3GV.z());
   GlobalVector r3T(r3GP.x(), r3GP.y(), r3GP.z());
   p3 = p3T;
-  r3 = r3T;  
+  r3 = r3T;
   // p3.set(p3GV.x(), p3GV.y(), p3GV.z());
   // r3.set(r3GP.x(), r3GP.y(), r3GP.z());
-  
+
   charge = fts.charge();
   cov = fts.hasError() ? fts.cartesianError().matrix() : AlgebraicSymMatrix66();
 }
 
-void ME0SegmentMatcher::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup){}
+void ME0SegmentMatcher::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup) {}
 
 DEFINE_FWK_MODULE(ME0SegmentMatcher);

--- a/RecoMuon/MuonIdentification/plugins/Module.cc
+++ b/RecoMuon/MuonIdentification/plugins/Module.cc
@@ -12,7 +12,6 @@
 #include "RecoMuon/MuonIdentification/plugins/InterestingEcalDetIdProducer.h"
 #include "RecoMuon/MuonIdentification/plugins/MuonIDFilterProducerForHLT.h"
 
-
 DEFINE_FWK_MODULE(MuonIdProducer);
 DEFINE_FWK_MODULE(MuonLinksProducer);
 DEFINE_FWK_MODULE(MuonLinksProducerForHLT);

--- a/RecoMuon/MuonIdentification/plugins/MuonIDFilterProducerForHLT.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIDFilterProducerForHLT.cc
@@ -3,7 +3,6 @@
  *  \author S. Folgueras <santiago.folgueras@cern.ch>
  */
 
-
 // system include files
 #include <memory>
 
@@ -23,79 +22,85 @@
 
 //#include <algorithm>
 
-MuonIDFilterProducerForHLT::MuonIDFilterProducerForHLT(const edm::ParameterSet& iConfig):
-  muonTag_             ( iConfig.getParameter<edm::InputTag>("inputMuonCollection") ),
-  muonToken_           ( consumes<reco::MuonCollection>(muonTag_)),
-  applyTriggerIdLoose_ ( iConfig.getParameter<bool>("applyTriggerIdLoose") ),  
-  type_                ( muon::SelectionType(iConfig.getParameter<unsigned int>("typeMuon")) ),
-  allowedTypeMask_     ( iConfig.getParameter<unsigned int>("allowedTypeMask") ),
-  requiredTypeMask_    ( iConfig.getParameter<unsigned int>("requiredTypeMask") ),
-  min_NMuonHits_       ( iConfig.getParameter<int>("minNMuonHits") ),    
-  min_NMuonStations_   ( iConfig.getParameter<int>("minNMuonStations") ),
-  min_NTrkLayers_      ( iConfig.getParameter<int>("minNTrkLayers") ), 
-  min_NTrkHits_        ( iConfig.getParameter<int>("minTrkHits") ), 
-  min_PixLayers_       ( iConfig.getParameter<int>("minPixLayer") ),
-  min_PixHits_         ( iConfig.getParameter<int>("minPixHits") ),
-  min_Pt_              ( iConfig.getParameter<double>("minPt") ),           
-  max_NormalizedChi2_  ( iConfig.getParameter<double>("maxNormalizedChi2") )
-{
-   produces<reco::MuonCollection>();
+MuonIDFilterProducerForHLT::MuonIDFilterProducerForHLT(const edm::ParameterSet& iConfig)
+    : muonTag_(iConfig.getParameter<edm::InputTag>("inputMuonCollection")),
+      muonToken_(consumes<reco::MuonCollection>(muonTag_)),
+      applyTriggerIdLoose_(iConfig.getParameter<bool>("applyTriggerIdLoose")),
+      type_(muon::SelectionType(iConfig.getParameter<unsigned int>("typeMuon"))),
+      allowedTypeMask_(iConfig.getParameter<unsigned int>("allowedTypeMask")),
+      requiredTypeMask_(iConfig.getParameter<unsigned int>("requiredTypeMask")),
+      min_NMuonHits_(iConfig.getParameter<int>("minNMuonHits")),
+      min_NMuonStations_(iConfig.getParameter<int>("minNMuonStations")),
+      min_NTrkLayers_(iConfig.getParameter<int>("minNTrkLayers")),
+      min_NTrkHits_(iConfig.getParameter<int>("minTrkHits")),
+      min_PixLayers_(iConfig.getParameter<int>("minPixLayer")),
+      min_PixHits_(iConfig.getParameter<int>("minPixHits")),
+      min_Pt_(iConfig.getParameter<double>("minPt")),
+      max_NormalizedChi2_(iConfig.getParameter<double>("maxNormalizedChi2")) {
+  produces<reco::MuonCollection>();
 }
 
-MuonIDFilterProducerForHLT::~MuonIDFilterProducerForHLT()
-{
-}
-void MuonIDFilterProducerForHLT::fillDescriptions(edm::ConfigurationDescriptions & descriptions){
+MuonIDFilterProducerForHLT::~MuonIDFilterProducerForHLT() {}
+void MuonIDFilterProducerForHLT::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<edm::InputTag>("inputMuonCollection",edm::InputTag("hltIterL3MuonsNoID"));
-  desc.add<bool>("applyTriggerIdLoose",true);
-  desc.add<unsigned int>("typeMuon",0);
-  desc.add<unsigned int>("allowedTypeMask",0);
-  desc.add<unsigned int>("requiredTypeMask",0);
-  desc.add<int>("minNMuonHits",0);    
-  desc.add<int>("minNMuonStations",0);
-  desc.add<int>("minNTrkLayers",0); 
-  desc.add<int>("minTrkHits",0); 
-  desc.add<int>("minPixLayer",0);
-  desc.add<int>("minPixHits",0);
-  desc.add<double>("minPt",0.);           
-  desc.add<double>("maxNormalizedChi2",9999.); 
+  desc.add<edm::InputTag>("inputMuonCollection", edm::InputTag("hltIterL3MuonsNoID"));
+  desc.add<bool>("applyTriggerIdLoose", true);
+  desc.add<unsigned int>("typeMuon", 0);
+  desc.add<unsigned int>("allowedTypeMask", 0);
+  desc.add<unsigned int>("requiredTypeMask", 0);
+  desc.add<int>("minNMuonHits", 0);
+  desc.add<int>("minNMuonStations", 0);
+  desc.add<int>("minNTrkLayers", 0);
+  desc.add<int>("minTrkHits", 0);
+  desc.add<int>("minPixLayer", 0);
+  desc.add<int>("minPixHits", 0);
+  desc.add<double>("minPt", 0.);
+  desc.add<double>("maxNormalizedChi2", 9999.);
   descriptions.addWithDefaultLabel(desc);
 }
-void MuonIDFilterProducerForHLT::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
-{
+void MuonIDFilterProducerForHLT::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
   auto output = std::make_unique<reco::MuonCollection>();
-  
-  edm::Handle<reco::MuonCollection> muons; 
+
+  edm::Handle<reco::MuonCollection> muons;
   iEvent.getByToken(muonToken_, muons);
-  
-  for ( unsigned int i=0; i<muons->size(); ++i ){
+
+  for (unsigned int i = 0; i < muons->size(); ++i) {
     const reco::Muon& muon(muons->at(i));
-    if (applyTriggerIdLoose_ && muon::isLooseTriggerMuon(muon)) { 
+    if (applyTriggerIdLoose_ && muon::isLooseTriggerMuon(muon)) {
       output->push_back(muon);
-    }
-    else {  // Implement here manually all the required/desired cuts 
-      if ( (muon.type() & allowedTypeMask_) == 0 )                  continue;
-      if ( (muon.type() & requiredTypeMask_) != requiredTypeMask_ ) continue;
+    } else {  // Implement here manually all the required/desired cuts
+      if ((muon.type() & allowedTypeMask_) == 0)
+        continue;
+      if ((muon.type() & requiredTypeMask_) != requiredTypeMask_)
+        continue;
       // tracker cuts
-      if ( !muon.innerTrack().isNull() ){
-	if (muon.innerTrack()->hitPattern().trackerLayersWithMeasurement() < min_NTrkLayers_) continue;
-	if (muon.innerTrack()->numberOfValidHits()<  min_NTrkHits_) continue;
-	if (muon.innerTrack()->hitPattern().pixelLayersWithMeasurement() < min_PixLayers_) continue;
-	if (muon.innerTrack()->hitPattern().numberOfValidPixelHits()<  min_PixHits_) continue;
+      if (!muon.innerTrack().isNull()) {
+        if (muon.innerTrack()->hitPattern().trackerLayersWithMeasurement() < min_NTrkLayers_)
+          continue;
+        if (muon.innerTrack()->numberOfValidHits() < min_NTrkHits_)
+          continue;
+        if (muon.innerTrack()->hitPattern().pixelLayersWithMeasurement() < min_PixLayers_)
+          continue;
+        if (muon.innerTrack()->hitPattern().numberOfValidPixelHits() < min_PixHits_)
+          continue;
       }
       // muon cuts
-      if ( muon.numberOfMatchedStations()< min_NMuonStations_ )     continue;
-      if ( !muon.globalTrack().isNull() ){
-	if (muon.globalTrack()->normalizedChi2() > max_NormalizedChi2_) continue;
-	if (muon.globalTrack()->hitPattern().numberOfValidMuonHits() < min_NMuonHits_) continue;
+      if (muon.numberOfMatchedStations() < min_NMuonStations_)
+        continue;
+      if (!muon.globalTrack().isNull()) {
+        if (muon.globalTrack()->normalizedChi2() > max_NormalizedChi2_)
+          continue;
+        if (muon.globalTrack()->hitPattern().numberOfValidMuonHits() < min_NMuonHits_)
+          continue;
       }
-      if ( !muon::isGoodMuon(muon,type_) ) continue;
-      if ( muon.pt() < min_Pt_ ) continue;
-      
+      if (!muon::isGoodMuon(muon, type_))
+        continue;
+      if (muon.pt() < min_Pt_)
+        continue;
+
       output->push_back(muon);
     }
   }
-  
+
   iEvent.put(std::move(output));
 }

--- a/RecoMuon/MuonIdentification/plugins/MuonIDFilterProducerForHLT.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIDFilterProducerForHLT.h
@@ -9,7 +9,6 @@
  *  \author S. Folgueras <santiago.folgueras@cern.ch>
  */
 
-
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
@@ -20,29 +19,29 @@
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
 class MuonIDFilterProducerForHLT : public edm::global::EDProducer<> {
- public:
-   explicit MuonIDFilterProducerForHLT(const edm::ParameterSet&);
-   
-   ~MuonIDFilterProducerForHLT() override;
-   
-   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+public:
+  explicit MuonIDFilterProducerForHLT(const edm::ParameterSet&);
 
- private:
-   const edm::InputTag muonTag_;
-   const edm::EDGetTokenT<reco::MuonCollection> muonToken_;
-    
-   const bool applyTriggerIdLoose_;
-   const muon::SelectionType  type_;
-   const unsigned int allowedTypeMask_;
-   const unsigned int requiredTypeMask_;
-   const int    min_NMuonHits_;    // threshold on number of hits on muon
-   const int    min_NMuonStations_;    // threshold on number of hits on muon
-   const int    min_NTrkLayers_; 
-   const int    min_NTrkHits_; 
-   const int    min_PixLayers_;
-   const int    min_PixHits_;
-   const double min_Pt_;           // pt threshold in GeV
-   const double max_NormalizedChi2_; // cutoff in normalized chi2
+  ~MuonIDFilterProducerForHLT() override;
+
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+private:
+  const edm::InputTag muonTag_;
+  const edm::EDGetTokenT<reco::MuonCollection> muonToken_;
+
+  const bool applyTriggerIdLoose_;
+  const muon::SelectionType type_;
+  const unsigned int allowedTypeMask_;
+  const unsigned int requiredTypeMask_;
+  const int min_NMuonHits_;      // threshold on number of hits on muon
+  const int min_NMuonStations_;  // threshold on number of hits on muon
+  const int min_NTrkLayers_;
+  const int min_NTrkHits_;
+  const int min_PixLayers_;
+  const int min_PixHits_;
+  const double min_Pt_;              // pt threshold in GeV
+  const double max_NormalizedChi2_;  // cutoff in normalized chi2
 };
 #endif

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -8,7 +8,6 @@
 //
 //
 
-
 // user include files
 #include "RecoMuon/MuonIdentification/plugins/MuonIdProducer.h"
 
@@ -33,343 +32,334 @@
 
 #include "RecoMuon/MuonIdentification/interface/MuonKinkFinder.h"
 
-MuonIdProducer::MuonIdProducer(const edm::ParameterSet& iConfig)
-{
-  
+MuonIdProducer::MuonIdProducer(const edm::ParameterSet& iConfig) {
   LogTrace("MuonIdentification") << "RecoMuon/MuonIdProducer :: Constructor called";
 
-   produces<reco::MuonCollection>();
-   produces<reco::CaloMuonCollection>();
-   produces<reco::MuonTimeExtraMap>("combined");
-   produces<reco::MuonTimeExtraMap>("dt");
-   produces<reco::MuonTimeExtraMap>("csc");
+  produces<reco::MuonCollection>();
+  produces<reco::CaloMuonCollection>();
+  produces<reco::MuonTimeExtraMap>("combined");
+  produces<reco::MuonTimeExtraMap>("dt");
+  produces<reco::MuonTimeExtraMap>("csc");
 
-   minPt_                   = iConfig.getParameter<double>("minPt");
-   minP_                    = iConfig.getParameter<double>("minP");
-   minPCaloMuon_            = iConfig.getParameter<double>("minPCaloMuon");
-   minNumberOfMatches_      = iConfig.getParameter<int>("minNumberOfMatches");
-   addExtraSoftMuons_       = iConfig.getParameter<bool>("addExtraSoftMuons");
-   maxAbsEta_               = iConfig.getParameter<double>("maxAbsEta");
-   maxAbsDx_                = iConfig.getParameter<double>("maxAbsDx");
-   maxAbsPullX_             = iConfig.getParameter<double>("maxAbsPullX");
-   maxAbsDy_                = iConfig.getParameter<double>("maxAbsDy");
-   maxAbsPullY_             = iConfig.getParameter<double>("maxAbsPullY");
-   fillCaloCompatibility_   = iConfig.getParameter<bool>("fillCaloCompatibility");
-   fillEnergy_              = iConfig.getParameter<bool>("fillEnergy");
-   storeCrossedHcalRecHits_ = iConfig.getParameter<bool>("storeCrossedHcalRecHits");
-   fillMatching_            = iConfig.getParameter<bool>("fillMatching");
-   fillIsolation_           = iConfig.getParameter<bool>("fillIsolation");
-   fillShowerDigis_         = iConfig.getParameter<bool>("fillShowerDigis");
-   writeIsoDeposits_        = iConfig.getParameter<bool>("writeIsoDeposits");
-   fillGlobalTrackQuality_  = iConfig.getParameter<bool>("fillGlobalTrackQuality");
-   fillGlobalTrackRefits_   = iConfig.getParameter<bool>("fillGlobalTrackRefits");
-   arbitrateTrackerMuons_   = iConfig.getParameter<bool>("arbitrateTrackerMuons");
-   //SK: (maybe temporary) run it only if the global is also run
-   fillTrackerKink_         = false;
-   if (fillGlobalTrackQuality_)  fillTrackerKink_ =  iConfig.getParameter<bool>("fillTrackerKink");
+  minPt_ = iConfig.getParameter<double>("minPt");
+  minP_ = iConfig.getParameter<double>("minP");
+  minPCaloMuon_ = iConfig.getParameter<double>("minPCaloMuon");
+  minNumberOfMatches_ = iConfig.getParameter<int>("minNumberOfMatches");
+  addExtraSoftMuons_ = iConfig.getParameter<bool>("addExtraSoftMuons");
+  maxAbsEta_ = iConfig.getParameter<double>("maxAbsEta");
+  maxAbsDx_ = iConfig.getParameter<double>("maxAbsDx");
+  maxAbsPullX_ = iConfig.getParameter<double>("maxAbsPullX");
+  maxAbsDy_ = iConfig.getParameter<double>("maxAbsDy");
+  maxAbsPullY_ = iConfig.getParameter<double>("maxAbsPullY");
+  fillCaloCompatibility_ = iConfig.getParameter<bool>("fillCaloCompatibility");
+  fillEnergy_ = iConfig.getParameter<bool>("fillEnergy");
+  storeCrossedHcalRecHits_ = iConfig.getParameter<bool>("storeCrossedHcalRecHits");
+  fillMatching_ = iConfig.getParameter<bool>("fillMatching");
+  fillIsolation_ = iConfig.getParameter<bool>("fillIsolation");
+  fillShowerDigis_ = iConfig.getParameter<bool>("fillShowerDigis");
+  writeIsoDeposits_ = iConfig.getParameter<bool>("writeIsoDeposits");
+  fillGlobalTrackQuality_ = iConfig.getParameter<bool>("fillGlobalTrackQuality");
+  fillGlobalTrackRefits_ = iConfig.getParameter<bool>("fillGlobalTrackRefits");
+  arbitrateTrackerMuons_ = iConfig.getParameter<bool>("arbitrateTrackerMuons");
+  //SK: (maybe temporary) run it only if the global is also run
+  fillTrackerKink_ = false;
+  if (fillGlobalTrackQuality_)
+    fillTrackerKink_ = iConfig.getParameter<bool>("fillTrackerKink");
 
-   ptThresholdToFillCandidateP4WithGlobalFit_    = iConfig.getParameter<double>("ptThresholdToFillCandidateP4WithGlobalFit");
-   sigmaThresholdToFillCandidateP4WithGlobalFit_ = iConfig.getParameter<double>("sigmaThresholdToFillCandidateP4WithGlobalFit");
-   caloCut_ = iConfig.getParameter<double>("minCaloCompatibility"); //CaloMuons
-   arbClean_ = iConfig.getParameter<bool>("runArbitrationCleaner"); // muon mesh
+  ptThresholdToFillCandidateP4WithGlobalFit_ =
+      iConfig.getParameter<double>("ptThresholdToFillCandidateP4WithGlobalFit");
+  sigmaThresholdToFillCandidateP4WithGlobalFit_ =
+      iConfig.getParameter<double>("sigmaThresholdToFillCandidateP4WithGlobalFit");
+  caloCut_ = iConfig.getParameter<double>("minCaloCompatibility");  //CaloMuons
+  arbClean_ = iConfig.getParameter<bool>("runArbitrationCleaner");  // muon mesh
 
-   // Load TrackDetectorAssociator parameters
-   const edm::ParameterSet parameters = iConfig.getParameter<edm::ParameterSet>("TrackAssociatorParameters");
-   edm::ConsumesCollector iC = consumesCollector();
-   parameters_.loadParameters( parameters, iC );
+  // Load TrackDetectorAssociator parameters
+  const edm::ParameterSet parameters = iConfig.getParameter<edm::ParameterSet>("TrackAssociatorParameters");
+  edm::ConsumesCollector iC = consumesCollector();
+  parameters_.loadParameters(parameters, iC);
 
-   // Load parameters for the TimingFiller
-   edm::ParameterSet timingParameters = iConfig.getParameter<edm::ParameterSet>("TimingFillerParameters");
-   theTimingFiller_ = std::make_unique<MuonTimingFiller>(timingParameters,consumesCollector());
+  // Load parameters for the TimingFiller
+  edm::ParameterSet timingParameters = iConfig.getParameter<edm::ParameterSet>("TimingFillerParameters");
+  theTimingFiller_ = std::make_unique<MuonTimingFiller>(timingParameters, consumesCollector());
 
-   // Load parameters for the ShowerDigiFiller
-   if (fillShowerDigis_ && fillMatching_)
-     {
-       edm::ParameterSet showerDigiParameters = iConfig.getParameter<edm::ParameterSet>("ShowerDigiFillerParameters");
-       theShowerDigiFiller_ = std::make_unique<MuonShowerDigiFiller>(showerDigiParameters,consumesCollector());
-     }
+  // Load parameters for the ShowerDigiFiller
+  if (fillShowerDigis_ && fillMatching_) {
+    edm::ParameterSet showerDigiParameters = iConfig.getParameter<edm::ParameterSet>("ShowerDigiFillerParameters");
+    theShowerDigiFiller_ = std::make_unique<MuonShowerDigiFiller>(showerDigiParameters, consumesCollector());
+  }
 
-   if (fillCaloCompatibility_){
-      // Load MuonCaloCompatibility parameters
-      const auto caloParams = iConfig.getParameter<edm::ParameterSet>("MuonCaloCompatibility");
-      muonCaloCompatibility_.configure( caloParams );
-   }
+  if (fillCaloCompatibility_) {
+    // Load MuonCaloCompatibility parameters
+    const auto caloParams = iConfig.getParameter<edm::ParameterSet>("MuonCaloCompatibility");
+    muonCaloCompatibility_.configure(caloParams);
+  }
 
-   if (fillIsolation_){
-      // Load MuIsoExtractor parameters
-      edm::ParameterSet caloExtractorPSet = iConfig.getParameter<edm::ParameterSet>("CaloExtractorPSet");
-      std::string caloExtractorName = caloExtractorPSet.getParameter<std::string>("ComponentName");
-      muIsoExtractorCalo_ = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{IsoDepositExtractorFactory::get()->create( caloExtractorName, caloExtractorPSet,consumesCollector())};
+  if (fillIsolation_) {
+    // Load MuIsoExtractor parameters
+    edm::ParameterSet caloExtractorPSet = iConfig.getParameter<edm::ParameterSet>("CaloExtractorPSet");
+    std::string caloExtractorName = caloExtractorPSet.getParameter<std::string>("ComponentName");
+    muIsoExtractorCalo_ = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{
+        IsoDepositExtractorFactory::get()->create(caloExtractorName, caloExtractorPSet, consumesCollector())};
 
-      edm::ParameterSet trackExtractorPSet = iConfig.getParameter<edm::ParameterSet>("TrackExtractorPSet");
-      std::string trackExtractorName = trackExtractorPSet.getParameter<std::string>("ComponentName");
-      muIsoExtractorTrack_ = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{IsoDepositExtractorFactory::get()->create( trackExtractorName, trackExtractorPSet,consumesCollector())};
+    edm::ParameterSet trackExtractorPSet = iConfig.getParameter<edm::ParameterSet>("TrackExtractorPSet");
+    std::string trackExtractorName = trackExtractorPSet.getParameter<std::string>("ComponentName");
+    muIsoExtractorTrack_ = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{
+        IsoDepositExtractorFactory::get()->create(trackExtractorName, trackExtractorPSet, consumesCollector())};
 
-      edm::ParameterSet jetExtractorPSet = iConfig.getParameter<edm::ParameterSet>("JetExtractorPSet");
-      std::string jetExtractorName = jetExtractorPSet.getParameter<std::string>("ComponentName");
-      muIsoExtractorJet_ = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{IsoDepositExtractorFactory::get()->create( jetExtractorName, jetExtractorPSet,consumesCollector())};
-   }
-   if (fillIsolation_ && writeIsoDeposits_){
-     trackDepositName_ = iConfig.getParameter<std::string>("trackDepositName");
-     produces<reco::IsoDepositMap>(trackDepositName_);
-     ecalDepositName_ = iConfig.getParameter<std::string>("ecalDepositName");
-     produces<reco::IsoDepositMap>(ecalDepositName_);
-     hcalDepositName_ = iConfig.getParameter<std::string>("hcalDepositName");
-     produces<reco::IsoDepositMap>(hcalDepositName_);
-     hoDepositName_ = iConfig.getParameter<std::string>("hoDepositName");
-     produces<reco::IsoDepositMap>(hoDepositName_);
-     jetDepositName_ = iConfig.getParameter<std::string>("jetDepositName");
-     produces<reco::IsoDepositMap>(jetDepositName_);
-   }
+    edm::ParameterSet jetExtractorPSet = iConfig.getParameter<edm::ParameterSet>("JetExtractorPSet");
+    std::string jetExtractorName = jetExtractorPSet.getParameter<std::string>("ComponentName");
+    muIsoExtractorJet_ = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>{
+        IsoDepositExtractorFactory::get()->create(jetExtractorName, jetExtractorPSet, consumesCollector())};
+  }
+  if (fillIsolation_ && writeIsoDeposits_) {
+    trackDepositName_ = iConfig.getParameter<std::string>("trackDepositName");
+    produces<reco::IsoDepositMap>(trackDepositName_);
+    ecalDepositName_ = iConfig.getParameter<std::string>("ecalDepositName");
+    produces<reco::IsoDepositMap>(ecalDepositName_);
+    hcalDepositName_ = iConfig.getParameter<std::string>("hcalDepositName");
+    produces<reco::IsoDepositMap>(hcalDepositName_);
+    hoDepositName_ = iConfig.getParameter<std::string>("hoDepositName");
+    produces<reco::IsoDepositMap>(hoDepositName_);
+    jetDepositName_ = iConfig.getParameter<std::string>("jetDepositName");
+    produces<reco::IsoDepositMap>(jetDepositName_);
+  }
 
-   inputCollectionLabels_ = iConfig.getParameter<std::vector<edm::InputTag> >("inputCollectionLabels");
-   const auto inputCollectionTypes = iConfig.getParameter<std::vector<std::string> >("inputCollectionTypes");
-   if (inputCollectionLabels_.size() != inputCollectionTypes.size())
-     throw cms::Exception("ConfigurationError") << "Number of input collection labels is different from number of types. " <<
-     "For each collection label there should be exactly one collection type specified.";
-   if (inputCollectionLabels_.size()>7 ||inputCollectionLabels_.empty())
-     throw cms::Exception("ConfigurationError") << "Number of input collections should be from 1 to 7.";
+  inputCollectionLabels_ = iConfig.getParameter<std::vector<edm::InputTag> >("inputCollectionLabels");
+  const auto inputCollectionTypes = iConfig.getParameter<std::vector<std::string> >("inputCollectionTypes");
+  if (inputCollectionLabels_.size() != inputCollectionTypes.size())
+    throw cms::Exception("ConfigurationError")
+        << "Number of input collection labels is different from number of types. "
+        << "For each collection label there should be exactly one collection type specified.";
+  if (inputCollectionLabels_.size() > 7 || inputCollectionLabels_.empty())
+    throw cms::Exception("ConfigurationError") << "Number of input collections should be from 1 to 7.";
 
-   debugWithTruthMatching_    = iConfig.getParameter<bool>("debugWithTruthMatching");
-   if (debugWithTruthMatching_) edm::LogWarning("MuonIdentification")
-     << "========================================================================\n"
-     << "Debugging mode with truth matching is turned on!!! Make sure you understand what you are doing!\n"
-     << "========================================================================\n";
-   if (fillGlobalTrackQuality_){
-     const auto& glbQualTag = iConfig.getParameter<edm::InputTag>("globalTrackQualityInputTag");
-     glbQualToken_ = consumes<edm::ValueMap<reco::MuonQuality> >(glbQualTag);
-   }
+  debugWithTruthMatching_ = iConfig.getParameter<bool>("debugWithTruthMatching");
+  if (debugWithTruthMatching_)
+    edm::LogWarning("MuonIdentification")
+        << "========================================================================\n"
+        << "Debugging mode with truth matching is turned on!!! Make sure you understand what you are doing!\n"
+        << "========================================================================\n";
+  if (fillGlobalTrackQuality_) {
+    const auto& glbQualTag = iConfig.getParameter<edm::InputTag>("globalTrackQualityInputTag");
+    glbQualToken_ = consumes<edm::ValueMap<reco::MuonQuality> >(glbQualTag);
+  }
 
-   if (fillTrackerKink_) {
-     trackerKinkFinder_ = std::make_unique<MuonKinkFinder>(iConfig.getParameter<edm::ParameterSet>("TrackerKinkFinderParameters"));
-   }
+  if (fillTrackerKink_) {
+    trackerKinkFinder_ =
+        std::make_unique<MuonKinkFinder>(iConfig.getParameter<edm::ParameterSet>("TrackerKinkFinderParameters"));
+  }
 
-   //create mesh holder
-   meshAlgo_ = std::make_unique<MuonMesh>(iConfig.getParameter<edm::ParameterSet>("arbitrationCleanerOptions"));
+  //create mesh holder
+  meshAlgo_ = std::make_unique<MuonMesh>(iConfig.getParameter<edm::ParameterSet>("arbitrationCleanerOptions"));
 
+  edm::InputTag rpcHitTag("rpcRecHits");
+  rpcHitToken_ = consumes<RPCRecHitCollection>(rpcHitTag);
 
-   edm::InputTag rpcHitTag("rpcRecHits");
-   rpcHitToken_ = consumes<RPCRecHitCollection>(rpcHitTag);
-   
+  //Consumes... UGH
+  inputCollectionTypes_.resize(inputCollectionLabels_.size());
+  for (unsigned int i = 0; i < inputCollectionLabels_.size(); ++i) {
+    const auto inputLabel = inputCollectionLabels_[i];
+    const auto inputType = ICTypes::toKey(inputCollectionTypes[i]);  // Note: thorws exception if type is undefined.
 
-   //Consumes... UGH
-   inputCollectionTypes_.resize(inputCollectionLabels_.size());
-   for ( unsigned int i = 0; i < inputCollectionLabels_.size(); ++i ) {
-     const auto inputLabel = inputCollectionLabels_[i];
-     const auto inputType = ICTypes::toKey(inputCollectionTypes[i]); // Note: thorws exception if type is undefined.
+    if (inputType == ICTypes::INNER_TRACKS) {
+      innerTrackCollectionToken_ = consumes<reco::TrackCollection>(inputLabel);
+    } else if (inputType == ICTypes::OUTER_TRACKS) {
+      outerTrackCollectionToken_ = consumes<reco::TrackCollection>(inputLabel);
+    } else if (inputType == ICTypes::LINKS) {
+      linkCollectionToken_ = consumes<reco::MuonTrackLinksCollection>(inputLabel);
+    } else if (inputType == ICTypes::MUONS) {
+      muonCollectionToken_ = consumes<reco::MuonCollection>(inputLabel);
+    } else if (inputType == ICTypes::TEV_FIRSTHIT) {
+      tpfmsCollectionToken_ = consumes<reco::TrackToTrackMap>(inputLabel);
+    } else if (fillGlobalTrackRefits_ && inputType == ICTypes::TEV_PICKY) {
+      pickyCollectionToken_ = consumes<reco::TrackToTrackMap>(inputLabel);
+    } else if (fillGlobalTrackRefits_ && inputType == ICTypes::TEV_DYT) {
+      dytCollectionToken_ = consumes<reco::TrackToTrackMap>(inputCollectionLabels_.at(i));
+    }
 
-     if ( inputType == ICTypes::INNER_TRACKS ) {
-       innerTrackCollectionToken_ = consumes<reco::TrackCollection>(inputLabel);
-     }
-     else if ( inputType == ICTypes::OUTER_TRACKS ) {
-       outerTrackCollectionToken_ = consumes<reco::TrackCollection>(inputLabel);
-     }
-     else if ( inputType == ICTypes::LINKS ) {
-       linkCollectionToken_ = consumes<reco::MuonTrackLinksCollection>(inputLabel);
-     }
-     else if ( inputType == ICTypes::MUONS ) {
-       muonCollectionToken_ = consumes<reco::MuonCollection>(inputLabel);
-     }
-     else if ( inputType == ICTypes::TEV_FIRSTHIT ) {
-       tpfmsCollectionToken_ = consumes<reco::TrackToTrackMap>(inputLabel);
-     }
-     else if ( fillGlobalTrackRefits_  && inputType == ICTypes::TEV_PICKY ) {
-       pickyCollectionToken_ = consumes<reco::TrackToTrackMap>(inputLabel);
-     }
-     else if ( fillGlobalTrackRefits_  && inputType == ICTypes::TEV_DYT ) {
-       dytCollectionToken_ = consumes<reco::TrackToTrackMap>(inputCollectionLabels_.at(i));
-     }
-
-     inputCollectionTypes_[i] = inputType;
-   }
+    inputCollectionTypes_[i] = inputType;
+  }
 }
 
-
-
-MuonIdProducer::~MuonIdProducer()
-{
-   // TimingReport::current()->dump(std::cout);
+MuonIdProducer::~MuonIdProducer() {
+  // TimingReport::current()->dump(std::cout);
 }
 
-void MuonIdProducer::init(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   innerTrackCollectionHandle_.clear();
-   outerTrackCollectionHandle_.clear();
-   linkCollectionHandle_.clear();
-   muonCollectionHandle_.clear();
+void MuonIdProducer::init(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  innerTrackCollectionHandle_.clear();
+  outerTrackCollectionHandle_.clear();
+  linkCollectionHandle_.clear();
+  muonCollectionHandle_.clear();
 
-   tpfmsCollectionHandle_.clear();
-   pickyCollectionHandle_.clear();
-   dytCollectionHandle_.clear();
+  tpfmsCollectionHandle_.clear();
+  pickyCollectionHandle_.clear();
+  dytCollectionHandle_.clear();
 
+  edm::ESHandle<Propagator> propagator;
+  iSetup.get<TrackingComponentsRecord>().get("SteppingHelixPropagatorAny", propagator);
+  trackAssociator_.setPropagator(propagator.product());
 
-   edm::ESHandle<Propagator> propagator;
-   iSetup.get<TrackingComponentsRecord>().get("SteppingHelixPropagatorAny", propagator);
-   trackAssociator_.setPropagator(propagator.product());
+  if (fillTrackerKink_)
+    trackerKinkFinder_->init(iSetup);
 
-   if (fillTrackerKink_) trackerKinkFinder_->init(iSetup);
+  for (unsigned int i = 0; i < inputCollectionLabels_.size(); ++i) {
+    const auto& inputLabel = inputCollectionLabels_[i];
+    const auto inputType = inputCollectionTypes_[i];
+    if (inputType == ICTypes::INNER_TRACKS) {
+      iEvent.getByToken(innerTrackCollectionToken_, innerTrackCollectionHandle_);
+      if (!innerTrackCollectionHandle_.isValid())
+        throw cms::Exception("FatalError") << "Failed to get input track collection with label: " << inputLabel;
+      LogTrace("MuonIdentification") << "Number of input inner tracks: " << innerTrackCollectionHandle_->size();
+    } else if (inputType == ICTypes::OUTER_TRACKS) {
+      iEvent.getByToken(outerTrackCollectionToken_, outerTrackCollectionHandle_);
+      if (!outerTrackCollectionHandle_.isValid())
+        throw cms::Exception("FatalError") << "Failed to get input track collection with label: " << inputLabel;
+      LogTrace("MuonIdentification") << "Number of input outer tracks: " << outerTrackCollectionHandle_->size();
+    } else if (inputType == ICTypes::LINKS) {
+      iEvent.getByToken(linkCollectionToken_, linkCollectionHandle_);
+      if (!linkCollectionHandle_.isValid())
+        throw cms::Exception("FatalError") << "Failed to get input link collection with label: " << inputLabel;
+      LogTrace("MuonIdentification") << "Number of input links: " << linkCollectionHandle_->size();
+    } else if (inputType == ICTypes::MUONS) {
+      iEvent.getByToken(muonCollectionToken_, muonCollectionHandle_);
+      if (!muonCollectionHandle_.isValid())
+        throw cms::Exception("FatalError") << "Failed to get input muon collection with label: " << inputLabel;
+      LogTrace("MuonIdentification") << "Number of input muons: " << muonCollectionHandle_->size();
+    } else if (fillGlobalTrackRefits_ && inputType == ICTypes::TEV_FIRSTHIT) {
+      iEvent.getByToken(tpfmsCollectionToken_, tpfmsCollectionHandle_);
+      if (!tpfmsCollectionHandle_.isValid())
+        throw cms::Exception("FatalError") << "Failed to get input muon collection with label: " << inputLabel;
+      LogTrace("MuonIdentification") << "Number of input muons: " << tpfmsCollectionHandle_->size();
+    } else if (fillGlobalTrackRefits_ && inputType == ICTypes::TEV_PICKY) {
+      iEvent.getByToken(pickyCollectionToken_, pickyCollectionHandle_);
+      if (!pickyCollectionHandle_.isValid())
+        throw cms::Exception("FatalError") << "Failed to get input muon collection with label: " << inputLabel;
+      LogTrace("MuonIdentification") << "Number of input muons: " << pickyCollectionHandle_->size();
+    } else if (fillGlobalTrackRefits_ && inputType == ICTypes::TEV_DYT) {
+      iEvent.getByToken(dytCollectionToken_, dytCollectionHandle_);
+      if (!dytCollectionHandle_.isValid())
+        throw cms::Exception("FatalError") << "Failed to get input muon collection with label: " << inputLabel;
+      LogTrace("MuonIdentification") << "Number of input muons: " << dytCollectionHandle_->size();
+    } else
+      throw cms::Exception("FatalError") << "Unknown input collection type: #" << ICTypes::toStr(inputType);
+  }
 
-   for ( unsigned int i = 0; i < inputCollectionLabels_.size(); ++i ) {
-      const auto& inputLabel = inputCollectionLabels_[i];
-      const auto inputType = inputCollectionTypes_[i];
-      if ( inputType == ICTypes::INNER_TRACKS ) {
-         iEvent.getByToken(innerTrackCollectionToken_, innerTrackCollectionHandle_);
-         if (! innerTrackCollectionHandle_.isValid()) 
-            throw cms::Exception("FatalError") << "Failed to get input track collection with label: " << inputLabel;
-         LogTrace("MuonIdentification") << "Number of input inner tracks: " << innerTrackCollectionHandle_->size();
-      }
-      else if ( inputType == ICTypes::OUTER_TRACKS ) {
-         iEvent.getByToken(outerTrackCollectionToken_, outerTrackCollectionHandle_);
-         if (! outerTrackCollectionHandle_.isValid()) 
-            throw cms::Exception("FatalError") << "Failed to get input track collection with label: " << inputLabel;
-         LogTrace("MuonIdentification") << "Number of input outer tracks: " << outerTrackCollectionHandle_->size();
-      }
-      else if ( inputType == ICTypes::LINKS ) {
-         iEvent.getByToken(linkCollectionToken_, linkCollectionHandle_);
-         if (! linkCollectionHandle_.isValid()) 
-            throw cms::Exception("FatalError") << "Failed to get input link collection with label: " << inputLabel;
-         LogTrace("MuonIdentification") << "Number of input links: " << linkCollectionHandle_->size();
-      }
-      else if ( inputType == ICTypes::MUONS ) {
-         iEvent.getByToken(muonCollectionToken_, muonCollectionHandle_);
-         if (! muonCollectionHandle_.isValid()) 
-            throw cms::Exception("FatalError") << "Failed to get input muon collection with label: " << inputLabel;
-         LogTrace("MuonIdentification") << "Number of input muons: " << muonCollectionHandle_->size();
-      }
-      else if ( fillGlobalTrackRefits_  && inputType == ICTypes::TEV_FIRSTHIT ) {
-         iEvent.getByToken(tpfmsCollectionToken_, tpfmsCollectionHandle_);
-         if (! tpfmsCollectionHandle_.isValid()) 
-            throw cms::Exception("FatalError") << "Failed to get input muon collection with label: " << inputLabel;
-         LogTrace("MuonIdentification") << "Number of input muons: " << tpfmsCollectionHandle_->size();
-      }
-      else if ( fillGlobalTrackRefits_  && inputType == ICTypes::TEV_PICKY ) {
-         iEvent.getByToken(pickyCollectionToken_, pickyCollectionHandle_);
-         if (! pickyCollectionHandle_.isValid()) 
-            throw cms::Exception("FatalError") << "Failed to get input muon collection with label: " << inputLabel;
-         LogTrace("MuonIdentification") << "Number of input muons: " << pickyCollectionHandle_->size();
-      }
-      else if ( fillGlobalTrackRefits_  && inputType == ICTypes::TEV_DYT ) {
-         iEvent.getByToken(dytCollectionToken_, dytCollectionHandle_);
-         if (! dytCollectionHandle_.isValid()) 
-            throw cms::Exception("FatalError") << "Failed to get input muon collection with label: " << inputLabel;
-         LogTrace("MuonIdentification") << "Number of input muons: " << dytCollectionHandle_->size();
-      }
-      else throw cms::Exception("FatalError") << "Unknown input collection type: #" << ICTypes::toStr(inputType);
-   }
-
-   iEvent.getByToken(rpcHitToken_, rpcHitHandle_);
-   if (fillGlobalTrackQuality_) iEvent.getByToken(glbQualToken_, glbQualHandle_);
-
+  iEvent.getByToken(rpcHitToken_, rpcHitHandle_);
+  if (fillGlobalTrackQuality_)
+    iEvent.getByToken(glbQualToken_, glbQualHandle_);
 }
 
-reco::Muon MuonIdProducer::makeMuon(edm::Event& iEvent, const edm::EventSetup& iSetup,
-				     const reco::TrackRef& track, MuonIdProducer::TrackType type)
-{
-   LogTrace("MuonIdentification") << "Creating a muon from a track " << track.get()->pt() <<
-     " Pt (GeV), eta: " << track.get()->eta();
-   reco::Muon aMuon( makeMuon( *(track.get()) ) );
+reco::Muon MuonIdProducer::makeMuon(edm::Event& iEvent,
+                                    const edm::EventSetup& iSetup,
+                                    const reco::TrackRef& track,
+                                    MuonIdProducer::TrackType type) {
+  LogTrace("MuonIdentification") << "Creating a muon from a track " << track.get()->pt()
+                                 << " Pt (GeV), eta: " << track.get()->eta();
+  reco::Muon aMuon(makeMuon(*(track.get())));
 
-   LogTrace("MuonIdentification") << "Muon created from a track ";
+  LogTrace("MuonIdentification") << "Muon created from a track ";
 
-   aMuon.setMuonTrack(type,track);
-   aMuon.setBestTrack(type);
-   aMuon.setTunePBestTrack(type);
+  aMuon.setMuonTrack(type, track);
+  aMuon.setBestTrack(type);
+  aMuon.setTunePBestTrack(type);
 
-   LogTrace("MuonIdentification") << "Muon created from a track and setMuonBestTrack, setBestTrack and setTunePBestTrack called";
+  LogTrace("MuonIdentification")
+      << "Muon created from a track and setMuonBestTrack, setBestTrack and setTunePBestTrack called";
 
-   return aMuon;
+  return aMuon;
 }
 
-reco::CaloMuon MuonIdProducer::makeCaloMuon( const reco::Muon& muon )
-{
+reco::CaloMuon MuonIdProducer::makeCaloMuon(const reco::Muon& muon) {
+  LogTrace("MuonIdentification") << "Creating a CaloMuon from a Muon";
 
-   LogTrace("MuonIdentification") << "Creating a CaloMuon from a Muon";
+  reco::CaloMuon aMuon;
+  aMuon.setInnerTrack(muon.innerTrack());
 
-   reco::CaloMuon aMuon;
-   aMuon.setInnerTrack( muon.innerTrack() );
-
-   if (muon.isEnergyValid()) aMuon.setCalEnergy( muon.calEnergy() );
-   // get calo compatibility
-   if (fillCaloCompatibility_) aMuon.setCaloCompatibility( muonCaloCompatibility_.evaluate(muon) );
-   return aMuon;
+  if (muon.isEnergyValid())
+    aMuon.setCalEnergy(muon.calEnergy());
+  // get calo compatibility
+  if (fillCaloCompatibility_)
+    aMuon.setCaloCompatibility(muonCaloCompatibility_.evaluate(muon));
+  return aMuon;
 }
 
+reco::Muon MuonIdProducer::makeMuon(const reco::MuonTrackLinks& links) {
+  LogTrace("MuonIdentification") << "Creating a muon from a link to tracks object";
 
-reco::Muon MuonIdProducer::makeMuon( const reco::MuonTrackLinks& links )
-{
-   LogTrace("MuonIdentification") << "Creating a muon from a link to tracks object";
+  reco::Muon aMuon;
+  reco::Muon::MuonTrackTypePair chosenTrack;
+  reco::TrackRef tpfmsRef;
+  reco::TrackRef pickyRef;
+  reco::TrackRef dytRef;
+  bool useSigmaSwitch = false;
 
-   reco::Muon aMuon;
-   reco::Muon::MuonTrackTypePair chosenTrack;
-   reco::TrackRef tpfmsRef;
-   reco::TrackRef pickyRef;
-   reco::TrackRef dytRef;
-   bool useSigmaSwitch = false;
+  if (tpfmsCollectionHandle_.isValid() && !tpfmsCollectionHandle_.failedToGet() && pickyCollectionHandle_.isValid() &&
+      !pickyCollectionHandle_.failedToGet()) {
+    tpfmsRef = muon::getTevRefitTrack(links.globalTrack(), *tpfmsCollectionHandle_);
+    pickyRef = muon::getTevRefitTrack(links.globalTrack(), *pickyCollectionHandle_);
+    dytRef = muon::getTevRefitTrack(links.globalTrack(), *dytCollectionHandle_);
 
-   if (tpfmsCollectionHandle_.isValid() && !tpfmsCollectionHandle_.failedToGet() &&
-       pickyCollectionHandle_.isValid() && !pickyCollectionHandle_.failedToGet()) {
+    if (tpfmsRef.isNull() && pickyRef.isNull() && dytRef.isNull()) {
+      edm::LogWarning("MakeMuonWithTEV") << "Failed to get  TEV refits, fall back to sigma switch.";
+      useSigmaSwitch = true;
+    }
+  } else {
+    useSigmaSwitch = true;
+  }
 
-     tpfmsRef = muon::getTevRefitTrack(links.globalTrack(), *tpfmsCollectionHandle_);
-     pickyRef = muon::getTevRefitTrack(links.globalTrack(), *pickyCollectionHandle_);
-     dytRef = muon::getTevRefitTrack(links.globalTrack(), *dytCollectionHandle_);
+  if (useSigmaSwitch) {
+    chosenTrack = muon::sigmaSwitch(links.globalTrack(),
+                                    links.trackerTrack(),
+                                    sigmaThresholdToFillCandidateP4WithGlobalFit_,
+                                    ptThresholdToFillCandidateP4WithGlobalFit_);
+  } else {
+    chosenTrack = muon::tevOptimized(links.globalTrack(),
+                                     links.trackerTrack(),
+                                     tpfmsRef,
+                                     pickyRef,
+                                     dytRef,
+                                     ptThresholdToFillCandidateP4WithGlobalFit_);
+  }
+  aMuon = makeMuon(*chosenTrack.first);
+  aMuon.setInnerTrack(links.trackerTrack());
+  aMuon.setOuterTrack(links.standAloneTrack());
+  aMuon.setGlobalTrack(links.globalTrack());
+  aMuon.setBestTrack(chosenTrack.second);
+  aMuon.setTunePBestTrack(chosenTrack.second);
 
-     if (tpfmsRef.isNull() && pickyRef.isNull() && dytRef.isNull()){
-       edm::LogWarning("MakeMuonWithTEV")<<"Failed to get  TEV refits, fall back to sigma switch.";
-       useSigmaSwitch = true;
-     }
-   } else {
-     useSigmaSwitch = true;
-   }
-
-   if (useSigmaSwitch){
-     chosenTrack = muon::sigmaSwitch( links.globalTrack(), links.trackerTrack(),
-				      sigmaThresholdToFillCandidateP4WithGlobalFit_,
-				      ptThresholdToFillCandidateP4WithGlobalFit_);
-   } else {
-     chosenTrack = muon::tevOptimized( links.globalTrack(), links.trackerTrack(),
-				       tpfmsRef, pickyRef, dytRef,
-				       ptThresholdToFillCandidateP4WithGlobalFit_);
-   }
-   aMuon = makeMuon(*chosenTrack.first);
-   aMuon.setInnerTrack( links.trackerTrack() );
-   aMuon.setOuterTrack( links.standAloneTrack() );
-   aMuon.setGlobalTrack( links.globalTrack() );
-   aMuon.setBestTrack(chosenTrack.second);
-   aMuon.setTunePBestTrack(chosenTrack.second);
-
-   if(fillGlobalTrackRefits_){
-     if (tpfmsCollectionHandle_.isValid() && !tpfmsCollectionHandle_.failedToGet()) {
-       reco::TrackToTrackMap::const_iterator it = tpfmsCollectionHandle_->find(links.globalTrack());
-       if (it != tpfmsCollectionHandle_->end()) aMuon.setMuonTrack(reco::Muon::TPFMS, (it->val));
-     }
-     if (pickyCollectionHandle_.isValid() && !pickyCollectionHandle_.failedToGet()) {
-       reco::TrackToTrackMap::const_iterator it = pickyCollectionHandle_->find(links.globalTrack());
-       if (it != pickyCollectionHandle_->end()) aMuon.setMuonTrack(reco::Muon::Picky, (it->val));
-     }
-     if (dytCollectionHandle_.isValid() && !dytCollectionHandle_.failedToGet()) {
-       reco::TrackToTrackMap::const_iterator it = dytCollectionHandle_->find(links.globalTrack());
-       if (it != dytCollectionHandle_->end()) aMuon.setMuonTrack(reco::Muon::DYT, (it->val));
-     }
-   }
-   return aMuon;
+  if (fillGlobalTrackRefits_) {
+    if (tpfmsCollectionHandle_.isValid() && !tpfmsCollectionHandle_.failedToGet()) {
+      reco::TrackToTrackMap::const_iterator it = tpfmsCollectionHandle_->find(links.globalTrack());
+      if (it != tpfmsCollectionHandle_->end())
+        aMuon.setMuonTrack(reco::Muon::TPFMS, (it->val));
+    }
+    if (pickyCollectionHandle_.isValid() && !pickyCollectionHandle_.failedToGet()) {
+      reco::TrackToTrackMap::const_iterator it = pickyCollectionHandle_->find(links.globalTrack());
+      if (it != pickyCollectionHandle_->end())
+        aMuon.setMuonTrack(reco::Muon::Picky, (it->val));
+    }
+    if (dytCollectionHandle_.isValid() && !dytCollectionHandle_.failedToGet()) {
+      reco::TrackToTrackMap::const_iterator it = dytCollectionHandle_->find(links.globalTrack());
+      if (it != dytCollectionHandle_->end())
+        aMuon.setMuonTrack(reco::Muon::DYT, (it->val));
+    }
+  }
+  return aMuon;
 }
 
-
-bool MuonIdProducer::isGoodTrack( const reco::Track& track )
-{
+bool MuonIdProducer::isGoodTrack(const reco::Track& track) {
   // Pt and absolute momentum requirement
   const double p = track.p();
   const double pt = track.pt();
-  if (pt < minPt_ || (p < minP_ && p < minPCaloMuon_)){
-    LogTrace("MuonIdentification") << "Skipped low momentum track (Pt,P): " << pt
-                                   << ", " << track.p() << " GeV";
+  if (pt < minPt_ || (p < minP_ && p < minPCaloMuon_)) {
+    LogTrace("MuonIdentification") << "Skipped low momentum track (Pt,P): " << pt << ", " << track.p() << " GeV";
     return false;
   }
 
   // Eta requirement
   const double eta = track.eta();
   const double absEta = std::abs(eta);
-  if ( absEta > maxAbsEta_ ){
+  if (absEta > maxAbsEta_) {
     LogTrace("MuonIdentification") << "Skipped track with large pseudo rapidity (Eta: " << track.eta() << " )";
     return false;
   }
@@ -377,57 +367,50 @@ bool MuonIdProducer::isGoodTrack( const reco::Track& track )
   return true;
 }
 
-unsigned int MuonIdProducer::chamberId( const DetId& id )
-{
-  if ( id.det() != DetId::Muon ) return 0;
+unsigned int MuonIdProducer::chamberId(const DetId& id) {
+  if (id.det() != DetId::Muon)
+    return 0;
 
   const auto subdetId = id.subdetId();
-  if ( subdetId == MuonSubdetId::DT ) {
+  if (subdetId == MuonSubdetId::DT) {
     return DTChamberId(id.rawId()).rawId();
-  }
-  else if ( subdetId == MuonSubdetId::CSC ) {
+  } else if (subdetId == MuonSubdetId::CSC) {
     return CSCDetId(id.rawId()).chamberId().rawId();
   }
 
   return 0;
 }
 
+int MuonIdProducer::overlap(const reco::Muon& muon, const reco::Track& track) {
+  if (!muon.isMatchesValid() || track.extra().isNull() || track.extra()->recHitsSize() == 0)
+    return 0;
 
-int MuonIdProducer::overlap(const reco::Muon& muon, const reco::Track& track)
-{
-   if ( ! muon.isMatchesValid() ||
-          track.extra().isNull() ||
-          track.extra()->recHitsSize()==0 ) return 0;
+  int numberOfCommonDetIds = 0;
+  const std::vector<reco::MuonChamberMatch>& matches(muon.matches());
+  for (const auto& match : matches) {
+    if (match.segmentMatches.empty())
+      continue;
 
-   int numberOfCommonDetIds = 0;
-   const std::vector<reco::MuonChamberMatch>& matches( muon.matches() );
-   for ( const auto& match : matches )
-   {
-     if ( match.segmentMatches.empty() ) continue;
+    bool foundCommonDetId = false;
+    for (auto hit = track.extra()->recHitsBegin(); hit != track.extra()->recHitsEnd(); ++hit) {
+      // LogTrace("MuonIdentification") << "hit DetId: " << std::hex << hit->get()->geographicalId().rawId() <<
+      //  "\t hit chamber DetId: " << getChamberId(hit->get()->geographicalId()) <<
+      //  "\t segment DetId: " << match->id.rawId() << std::dec;
 
-     bool foundCommonDetId = false;
-     for ( auto hit = track.extra()->recHitsBegin();
-           hit != track.extra()->recHitsEnd(); ++hit )
-     {
-       // LogTrace("MuonIdentification") << "hit DetId: " << std::hex << hit->get()->geographicalId().rawId() <<
-       //  "\t hit chamber DetId: " << getChamberId(hit->get()->geographicalId()) <<
-       //  "\t segment DetId: " << match->id.rawId() << std::dec;
-
-       if ( chamberId((*hit)->geographicalId()) == match.id.rawId() ) {
-         foundCommonDetId = true;
-         break;
-       }
-     }
-     if ( foundCommonDetId ) {
-       ++numberOfCommonDetIds;
-       break;
-     }
-   }
-   return numberOfCommonDetIds;
+      if (chamberId((*hit)->geographicalId()) == match.id.rawId()) {
+        foundCommonDetId = true;
+        break;
+      }
+    }
+    if (foundCommonDetId) {
+      ++numberOfCommonDetIds;
+      break;
+    }
+  }
+  return numberOfCommonDetIds;
 }
 
-void MuonIdProducer::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup)
-{
+void MuonIdProducer::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
   edm::ESHandle<CSCGeometry> geomHandle;
   iSetup.get<MuonGeometryRecord>().get(geomHandle);
 
@@ -437,920 +420,969 @@ void MuonIdProducer::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetu
     theShowerDigiFiller_->getES(iSetup);
 }
 
-bool validateGlobalMuonPair( const reco::MuonTrackLinks& goodMuon,
-                             const reco::MuonTrackLinks& badMuon )
-{
+bool validateGlobalMuonPair(const reco::MuonTrackLinks& goodMuon, const reco::MuonTrackLinks& badMuon) {
   const int nHitsGood = goodMuon.globalTrack()->hitPattern().numberOfValidMuonHits();
-  const int nHitsBad  = badMuon.globalTrack()->hitPattern().numberOfValidMuonHits();
-  if ( std::min(nHitsGood, nHitsBad) > 10 ) {
+  const int nHitsBad = badMuon.globalTrack()->hitPattern().numberOfValidMuonHits();
+  if (std::min(nHitsGood, nHitsBad) > 10) {
     const double chi2Good = goodMuon.globalTrack()->normalizedChi2();
-	  const double chi2Bad  = badMuon.globalTrack()->normalizedChi2();
-    return ( chi2Good <= chi2Bad );
+    const double chi2Bad = badMuon.globalTrack()->normalizedChi2();
+    return (chi2Good <= chi2Bad);
   }
 
   return (nHitsGood >= nHitsBad);
 }
 
-void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  auto outputMuons = std::make_unique<reco::MuonCollection>();
+  auto caloMuons = std::make_unique<reco::CaloMuonCollection>();
 
-   auto outputMuons = std::make_unique<reco::MuonCollection>();
-   auto caloMuons = std::make_unique<reco::CaloMuonCollection>();
-
-   init(iEvent, iSetup);
+  init(iEvent, iSetup);
 
   if (fillShowerDigis_ && fillMatching_)
-      theShowerDigiFiller_->getDigis(iEvent);
+    theShowerDigiFiller_->getDigis(iEvent);
 
-   // loop over input collections
+  // loop over input collections
 
-   // muons first - no cleaning, take as is.
-   if ( muonCollectionHandle_.isValid() ) {
-     for ( const auto muon : *muonCollectionHandle_ ) {
-       outputMuons->push_back(muon);
-     }
-   }
+  // muons first - no cleaning, take as is.
+  if (muonCollectionHandle_.isValid()) {
+    for (const auto muon : *muonCollectionHandle_) {
+      outputMuons->push_back(muon);
+    }
+  }
 
-   // links second ( assume global muon type )
-   if ( linkCollectionHandle_.isValid() ) {
-     const auto nLink = linkCollectionHandle_->size();
-     std::vector<bool> goodmuons(nLink, true);
-     if ( nLink > 1 ) {
-       // check for shared tracker tracks
-       for ( unsigned int i=0; i<nLink-1; ++i ) {
-         const auto& iLink = linkCollectionHandle_->at(i);
-         if ( iLink.trackerTrack().isNull() || !checkLinks(&iLink) ) continue;
-         for ( unsigned int j=i+1; j<nLink; ++j ){
-           const auto& jLink = linkCollectionHandle_->at(j);
-           if (!checkLinks(&jLink)) continue;
-           if ( iLink.trackerTrack() == jLink.trackerTrack() ) {
-             // Tracker track is the essential part that dominates muon resolution
-             // so taking either muon is fine. All that is important is to preserve
-             // the muon identification information. If number of hits is small,
-             // keep the one with large number of hits, otherwise take the smalest chi2/ndof
-             if ( validateGlobalMuonPair(iLink, jLink) ) goodmuons[j] = false;
-             else goodmuons[i] = false;
-           }
-         }
-       }
-       // check for shared stand-alone muons.
-       for ( unsigned int i=0; i<nLink-1; ++i ) {
-         if ( !goodmuons[i] ) continue;
-         const auto& iLink = linkCollectionHandle_->at(i);
-         if ( iLink.standAloneTrack().isNull() || !checkLinks(&iLink)) continue;
-         for ( unsigned int j=i+1; j<nLink; ++j ) {
-           if ( !goodmuons[j] ) continue;
-           const auto& jLink = linkCollectionHandle_->at(j);
-           if (!checkLinks(&jLink)) continue;
-           if ( iLink.standAloneTrack() == jLink.standAloneTrack() ) {
-             if ( validateGlobalMuonPair(iLink, jLink) ) goodmuons[j] = false;
-             else goodmuons[i] = false;
-           }
-         }
-       }
-     }
-     for ( unsigned int i=0; i<nLink; ++i ) {
-       if ( !goodmuons[i] ) continue;
-       const auto& iLink = linkCollectionHandle_->at(i);
-       if ( ! checkLinks(&iLink) ) continue;
-       // check if this muon is already in the list
-       bool newMuon = true;
-       for ( auto muon : *outputMuons ) {
-         if ( muon.track() == iLink.trackerTrack() &&
-             muon.standAloneMuon() == iLink.standAloneTrack() &&
-             muon.combinedMuon() == iLink.globalTrack() ) {
-           newMuon = false;
-           break;
-         }
-       }
-       if ( newMuon ) {
-         outputMuons->push_back( makeMuon(iLink) );
-         outputMuons->back().setType(reco::Muon::GlobalMuon | reco::Muon::StandAloneMuon);
-       }
-     }
-   }
+  // links second ( assume global muon type )
+  if (linkCollectionHandle_.isValid()) {
+    const auto nLink = linkCollectionHandle_->size();
+    std::vector<bool> goodmuons(nLink, true);
+    if (nLink > 1) {
+      // check for shared tracker tracks
+      for (unsigned int i = 0; i < nLink - 1; ++i) {
+        const auto& iLink = linkCollectionHandle_->at(i);
+        if (iLink.trackerTrack().isNull() || !checkLinks(&iLink))
+          continue;
+        for (unsigned int j = i + 1; j < nLink; ++j) {
+          const auto& jLink = linkCollectionHandle_->at(j);
+          if (!checkLinks(&jLink))
+            continue;
+          if (iLink.trackerTrack() == jLink.trackerTrack()) {
+            // Tracker track is the essential part that dominates muon resolution
+            // so taking either muon is fine. All that is important is to preserve
+            // the muon identification information. If number of hits is small,
+            // keep the one with large number of hits, otherwise take the smalest chi2/ndof
+            if (validateGlobalMuonPair(iLink, jLink))
+              goodmuons[j] = false;
+            else
+              goodmuons[i] = false;
+          }
+        }
+      }
+      // check for shared stand-alone muons.
+      for (unsigned int i = 0; i < nLink - 1; ++i) {
+        if (!goodmuons[i])
+          continue;
+        const auto& iLink = linkCollectionHandle_->at(i);
+        if (iLink.standAloneTrack().isNull() || !checkLinks(&iLink))
+          continue;
+        for (unsigned int j = i + 1; j < nLink; ++j) {
+          if (!goodmuons[j])
+            continue;
+          const auto& jLink = linkCollectionHandle_->at(j);
+          if (!checkLinks(&jLink))
+            continue;
+          if (iLink.standAloneTrack() == jLink.standAloneTrack()) {
+            if (validateGlobalMuonPair(iLink, jLink))
+              goodmuons[j] = false;
+            else
+              goodmuons[i] = false;
+          }
+        }
+      }
+    }
+    for (unsigned int i = 0; i < nLink; ++i) {
+      if (!goodmuons[i])
+        continue;
+      const auto& iLink = linkCollectionHandle_->at(i);
+      if (!checkLinks(&iLink))
+        continue;
+      // check if this muon is already in the list
+      bool newMuon = true;
+      for (auto muon : *outputMuons) {
+        if (muon.track() == iLink.trackerTrack() && muon.standAloneMuon() == iLink.standAloneTrack() &&
+            muon.combinedMuon() == iLink.globalTrack()) {
+          newMuon = false;
+          break;
+        }
+      }
+      if (newMuon) {
+        outputMuons->push_back(makeMuon(iLink));
+        outputMuons->back().setType(reco::Muon::GlobalMuon | reco::Muon::StandAloneMuon);
+      }
+    }
+  }
 
-   // tracker and calo muons are next
-   if ( innerTrackCollectionHandle_.isValid() ) {
-     LogTrace("MuonIdentification") << "Creating tracker muons";
-     std::vector<TrackDetectorAssociator::Direction> directions1, directions2;
-     directions1.push_back(TrackDetectorAssociator::InsideOut);
-     directions1.push_back(TrackDetectorAssociator::OutsideIn);
-     directions2.push_back(TrackDetectorAssociator::Any);
+  // tracker and calo muons are next
+  if (innerTrackCollectionHandle_.isValid()) {
+    LogTrace("MuonIdentification") << "Creating tracker muons";
+    std::vector<TrackDetectorAssociator::Direction> directions1, directions2;
+    directions1.push_back(TrackDetectorAssociator::InsideOut);
+    directions1.push_back(TrackDetectorAssociator::OutsideIn);
+    directions2.push_back(TrackDetectorAssociator::Any);
 
-     for ( unsigned int i = 0; i < innerTrackCollectionHandle_->size(); ++i )
-     {
-       const reco::Track& track = innerTrackCollectionHandle_->at(i);
-       if ( ! isGoodTrack( track ) ) continue;
-       const auto& trackRef = reco::TrackRef(innerTrackCollectionHandle_, i);
-       bool splitTrack = false;
-       if ( track.extra().isAvailable() &&
-            TrackDetectorAssociator::crossedIP( track ) ) splitTrack = true;
-       const auto& directions = splitTrack ? directions1 : directions2;
-       for ( const auto direction : directions ) {
-         // make muon
-         reco::Muon trackerMuon( makeMuon(iEvent, iSetup, trackRef, reco::Muon::InnerTrack) );
-         fillMuonId(iEvent, iSetup, trackerMuon, direction);
+    for (unsigned int i = 0; i < innerTrackCollectionHandle_->size(); ++i) {
+      const reco::Track& track = innerTrackCollectionHandle_->at(i);
+      if (!isGoodTrack(track))
+        continue;
+      const auto& trackRef = reco::TrackRef(innerTrackCollectionHandle_, i);
+      bool splitTrack = false;
+      if (track.extra().isAvailable() && TrackDetectorAssociator::crossedIP(track))
+        splitTrack = true;
+      const auto& directions = splitTrack ? directions1 : directions2;
+      for (const auto direction : directions) {
+        // make muon
+        reco::Muon trackerMuon(makeMuon(iEvent, iSetup, trackRef, reco::Muon::InnerTrack));
+        fillMuonId(iEvent, iSetup, trackerMuon, direction);
 
-         if ( debugWithTruthMatching_ ) {
-           // add MC hits to a list of matched segments.
-           // Since it's debugging mode - code is slow
-           MuonIdTruthInfo::truthMatchMuon(iEvent, iSetup, trackerMuon);
-         }
+        if (debugWithTruthMatching_) {
+          // add MC hits to a list of matched segments.
+          // Since it's debugging mode - code is slow
+          MuonIdTruthInfo::truthMatchMuon(iEvent, iSetup, trackerMuon);
+        }
 
-         // check if this muon is already in the list
-         // have to check where muon hits are really located
-         // to match properly
-         bool newMuon = true;
-         const bool goodTrackerMuon = isGoodTrackerMuon( trackerMuon );
-         const bool goodRPCMuon = isGoodRPCMuon( trackerMuon );
-         const bool goodGEMMuon = isGoodGEMMuon( trackerMuon );
-         const bool goodME0Muon = isGoodME0Muon( trackerMuon );
-         if ( goodTrackerMuon ) trackerMuon.setType( trackerMuon.type() | reco::Muon::TrackerMuon );
-         if ( goodRPCMuon ) trackerMuon.setType( trackerMuon.type() | reco::Muon::RPCMuon );
-         if ( goodGEMMuon ) trackerMuon.setType( trackerMuon.type() | reco::Muon::GEMMuon );
-         if ( goodME0Muon ) trackerMuon.setType( trackerMuon.type() | reco::Muon::ME0Muon );
-         
-         for ( auto& muon : *outputMuons ) 
-         {
-           if ( muon.innerTrack().get() == trackerMuon.innerTrack().get() &&
-                cos(phiOfMuonIneteractionRegion(muon) - phiOfMuonIneteractionRegion(trackerMuon)) > 0 )
-           {
-             newMuon = false;
-             muon.setMatches( trackerMuon.matches() );
-             if (trackerMuon.isTimeValid()) muon.setTime( trackerMuon.time() );
-             if (trackerMuon.isEnergyValid()) muon.setCalEnergy( trackerMuon.calEnergy() );
-             if (goodTrackerMuon) muon.setType( muon.type() | reco::Muon::TrackerMuon );
-             if (goodRPCMuon) muon.setType( muon.type() | reco::Muon::RPCMuon );
-             if (goodGEMMuon) muon.setType( muon.type() | reco::Muon::GEMMuon );
-             if (goodME0Muon) muon.setType( muon.type() | reco::Muon::ME0Muon );
-             LogTrace("MuonIdentification") << "Found a corresponding global muon. Set energy, matches and move on";
-             break;
-           }
-         }
-         if ( newMuon ) {
-           if ( goodTrackerMuon || goodRPCMuon || goodGEMMuon || goodME0Muon){
-             outputMuons->push_back( trackerMuon );
-           } else {
-             LogTrace("MuonIdentification") << "track failed minimal number of muon matches requirement";
-             const reco::CaloMuon& caloMuon = makeCaloMuon(trackerMuon);
-	     if (isGoodCaloMuon(caloMuon)) caloMuons->push_back( caloMuon );
-           }
-         }
-       }
-     }
-   }
+        // check if this muon is already in the list
+        // have to check where muon hits are really located
+        // to match properly
+        bool newMuon = true;
+        const bool goodTrackerMuon = isGoodTrackerMuon(trackerMuon);
+        const bool goodRPCMuon = isGoodRPCMuon(trackerMuon);
+        const bool goodGEMMuon = isGoodGEMMuon(trackerMuon);
+        const bool goodME0Muon = isGoodME0Muon(trackerMuon);
+        if (goodTrackerMuon)
+          trackerMuon.setType(trackerMuon.type() | reco::Muon::TrackerMuon);
+        if (goodRPCMuon)
+          trackerMuon.setType(trackerMuon.type() | reco::Muon::RPCMuon);
+        if (goodGEMMuon)
+          trackerMuon.setType(trackerMuon.type() | reco::Muon::GEMMuon);
+        if (goodME0Muon)
+          trackerMuon.setType(trackerMuon.type() | reco::Muon::ME0Muon);
 
-   // and at last the stand alone muons
-   if ( outerTrackCollectionHandle_.isValid() ) {
-     LogTrace("MuonIdentification") << "Looking for new muons among stand alone muon tracks";
-     for ( unsigned int i = 0; i < outerTrackCollectionHandle_->size(); ++i )
-     {
-       const auto& outerTrack = outerTrackCollectionHandle_->at(i);
+        for (auto& muon : *outputMuons) {
+          if (muon.innerTrack().get() == trackerMuon.innerTrack().get() &&
+              cos(phiOfMuonIneteractionRegion(muon) - phiOfMuonIneteractionRegion(trackerMuon)) > 0) {
+            newMuon = false;
+            muon.setMatches(trackerMuon.matches());
+            if (trackerMuon.isTimeValid())
+              muon.setTime(trackerMuon.time());
+            if (trackerMuon.isEnergyValid())
+              muon.setCalEnergy(trackerMuon.calEnergy());
+            if (goodTrackerMuon)
+              muon.setType(muon.type() | reco::Muon::TrackerMuon);
+            if (goodRPCMuon)
+              muon.setType(muon.type() | reco::Muon::RPCMuon);
+            if (goodGEMMuon)
+              muon.setType(muon.type() | reco::Muon::GEMMuon);
+            if (goodME0Muon)
+              muon.setType(muon.type() | reco::Muon::ME0Muon);
+            LogTrace("MuonIdentification") << "Found a corresponding global muon. Set energy, matches and move on";
+            break;
+          }
+        }
+        if (newMuon) {
+          if (goodTrackerMuon || goodRPCMuon || goodGEMMuon || goodME0Muon) {
+            outputMuons->push_back(trackerMuon);
+          } else {
+            LogTrace("MuonIdentification") << "track failed minimal number of muon matches requirement";
+            const reco::CaloMuon& caloMuon = makeCaloMuon(trackerMuon);
+            if (isGoodCaloMuon(caloMuon))
+              caloMuons->push_back(caloMuon);
+          }
+        }
+      }
+    }
+  }
 
-       // check if this muon is already in the list of global muons
-       bool newMuon = true;
-       for ( auto& muon : *outputMuons )
-       {
-         if ( ! muon.standAloneMuon().isNull() ) {
-           // global muon
-           if ( muon.standAloneMuon().get() ==  &outerTrack ) {
-             newMuon = false;
-             break;
-           }
-         } else {
-           // tracker muon - no direct links to the standalone muon
-           // since we have only a few real muons in an event, matching
-           // the stand alone muon to the tracker muon by DetIds should
-           // be good enough for association. At the end it's up to a
-           // user to redefine the association and what it means. Here
-           // we would like to avoid obvious double counting and we
-           // tolerate a potential miss association
-           if ( overlap(muon, outerTrack) > 0 ) {
-             LogTrace("MuonIdentification") << "Found associated tracker muon. Set a reference and move on";
-             newMuon = false;
-             muon.setOuterTrack( reco::TrackRef( outerTrackCollectionHandle_, i ) );
-             muon.setType( muon.type() | reco::Muon::StandAloneMuon );
-             break;
-           }
-         }
-       }
-       if ( newMuon ) {
-         LogTrace("MuonIdentification") << "No associated stand alone track is found. Making a muon";
-         outputMuons->push_back( makeMuon(iEvent, iSetup,
-                                          reco::TrackRef( outerTrackCollectionHandle_, i ), reco::Muon::OuterTrack ) );
-         outputMuons->back().setType( reco::Muon::StandAloneMuon );
-       }
-     }
-   }
+  // and at last the stand alone muons
+  if (outerTrackCollectionHandle_.isValid()) {
+    LogTrace("MuonIdentification") << "Looking for new muons among stand alone muon tracks";
+    for (unsigned int i = 0; i < outerTrackCollectionHandle_->size(); ++i) {
+      const auto& outerTrack = outerTrackCollectionHandle_->at(i);
 
-   if (arbitrateTrackerMuons_){
-     fillArbitrationInfo( outputMuons.get() );
-     arbitrateMuons( outputMuons.get(), caloMuons.get() );
-   }
+      // check if this muon is already in the list of global muons
+      bool newMuon = true;
+      for (auto& muon : *outputMuons) {
+        if (!muon.standAloneMuon().isNull()) {
+          // global muon
+          if (muon.standAloneMuon().get() == &outerTrack) {
+            newMuon = false;
+            break;
+          }
+        } else {
+          // tracker muon - no direct links to the standalone muon
+          // since we have only a few real muons in an event, matching
+          // the stand alone muon to the tracker muon by DetIds should
+          // be good enough for association. At the end it's up to a
+          // user to redefine the association and what it means. Here
+          // we would like to avoid obvious double counting and we
+          // tolerate a potential miss association
+          if (overlap(muon, outerTrack) > 0) {
+            LogTrace("MuonIdentification") << "Found associated tracker muon. Set a reference and move on";
+            newMuon = false;
+            muon.setOuterTrack(reco::TrackRef(outerTrackCollectionHandle_, i));
+            muon.setType(muon.type() | reco::Muon::StandAloneMuon);
+            break;
+          }
+        }
+      }
+      if (newMuon) {
+        LogTrace("MuonIdentification") << "No associated stand alone track is found. Making a muon";
+        outputMuons->push_back(
+            makeMuon(iEvent, iSetup, reco::TrackRef(outerTrackCollectionHandle_, i), reco::Muon::OuterTrack));
+        outputMuons->back().setType(reco::Muon::StandAloneMuon);
+      }
+    }
+  }
 
-   LogTrace("MuonIdentification") << "Dress up muons if it's necessary";
+  if (arbitrateTrackerMuons_) {
+    fillArbitrationInfo(outputMuons.get());
+    arbitrateMuons(outputMuons.get(), caloMuons.get());
+  }
 
-   const int nMuons=outputMuons->size();
+  LogTrace("MuonIdentification") << "Dress up muons if it's necessary";
 
-   std::vector<reco::MuonTimeExtra> dtTimeColl(nMuons);
-   std::vector<reco::MuonTimeExtra> cscTimeColl(nMuons);
-   std::vector<reco::MuonTimeExtra> combinedTimeColl(nMuons);
-   std::vector<reco::IsoDeposit> trackDepColl(nMuons);
-   std::vector<reco::IsoDeposit> ecalDepColl(nMuons);
-   std::vector<reco::IsoDeposit> hcalDepColl(nMuons);
-   std::vector<reco::IsoDeposit> hoDepColl(nMuons);
-   std::vector<reco::IsoDeposit> jetDepColl(nMuons);
+  const int nMuons = outputMuons->size();
 
-   // Fill various information
-   for ( unsigned int i=0; i<outputMuons->size(); ++i )
-   {
-     auto& muon = outputMuons->at(i);
+  std::vector<reco::MuonTimeExtra> dtTimeColl(nMuons);
+  std::vector<reco::MuonTimeExtra> cscTimeColl(nMuons);
+  std::vector<reco::MuonTimeExtra> combinedTimeColl(nMuons);
+  std::vector<reco::IsoDeposit> trackDepColl(nMuons);
+  std::vector<reco::IsoDeposit> ecalDepColl(nMuons);
+  std::vector<reco::IsoDeposit> hcalDepColl(nMuons);
+  std::vector<reco::IsoDeposit> hoDepColl(nMuons);
+  std::vector<reco::IsoDeposit> jetDepColl(nMuons);
 
-     // Fill muonID
-     if ( ( fillMatching_ && ! muon.isMatchesValid() ) ||
-          ( fillEnergy_ && !muon.isEnergyValid() ) )
-     {
-       // predict direction based on the muon interaction region location
-       // if it's available
-       if ( muon.isStandAloneMuon() ) {
-         if ( cos(phiOfMuonIneteractionRegion(muon) - muon.phi()) > 0 ) {
-           fillMuonId(iEvent, iSetup, muon, TrackDetectorAssociator::InsideOut);
-         } else {
-           fillMuonId(iEvent, iSetup, muon, TrackDetectorAssociator::OutsideIn);
-         }
-       } else {
-         LogTrace("MuonIdentification") << "THIS SHOULD NEVER HAPPEN";
-         fillMuonId(iEvent, iSetup, muon);
-       }
-     }
+  // Fill various information
+  for (unsigned int i = 0; i < outputMuons->size(); ++i) {
+    auto& muon = outputMuons->at(i);
 
-     if (fillGlobalTrackQuality_){
-       // Fill global quality information
-       fillGlbQuality(iEvent, iSetup, muon);
-     }
-     LogDebug("MuonIdentification");
+    // Fill muonID
+    if ((fillMatching_ && !muon.isMatchesValid()) || (fillEnergy_ && !muon.isEnergyValid())) {
+      // predict direction based on the muon interaction region location
+      // if it's available
+      if (muon.isStandAloneMuon()) {
+        if (cos(phiOfMuonIneteractionRegion(muon) - muon.phi()) > 0) {
+          fillMuonId(iEvent, iSetup, muon, TrackDetectorAssociator::InsideOut);
+        } else {
+          fillMuonId(iEvent, iSetup, muon, TrackDetectorAssociator::OutsideIn);
+        }
+      } else {
+        LogTrace("MuonIdentification") << "THIS SHOULD NEVER HAPPEN";
+        fillMuonId(iEvent, iSetup, muon);
+      }
+    }
 
-     if (fillTrackerKink_) {
-       fillTrackerKink(muon);
-     }
+    if (fillGlobalTrackQuality_) {
+      // Fill global quality information
+      fillGlbQuality(iEvent, iSetup, muon);
+    }
+    LogDebug("MuonIdentification");
 
-     if ( fillCaloCompatibility_ ) muon.setCaloCompatibility( muonCaloCompatibility_.evaluate(muon) );
+    if (fillTrackerKink_) {
+      fillTrackerKink(muon);
+    }
 
-     if ( fillIsolation_ ) {
-       fillMuonIsolation(iEvent, iSetup, muon,
-                         trackDepColl[i], ecalDepColl[i], hcalDepColl[i], hoDepColl[i], jetDepColl[i]);
-     }
+    if (fillCaloCompatibility_)
+      muon.setCaloCompatibility(muonCaloCompatibility_.evaluate(muon));
 
-     // fill timing information
-     reco::MuonTime muonTime;
-     reco::MuonTimeExtra dtTime;
-     reco::MuonTimeExtra cscTime;
-     reco::MuonTime rpcTime;
-     reco::MuonTimeExtra combinedTime;
+    if (fillIsolation_) {
+      fillMuonIsolation(
+          iEvent, iSetup, muon, trackDepColl[i], ecalDepColl[i], hcalDepColl[i], hoDepColl[i], jetDepColl[i]);
+    }
 
-     theTimingFiller_->fillTiming(muon, dtTime, cscTime, rpcTime, combinedTime, iEvent, iSetup);
+    // fill timing information
+    reco::MuonTime muonTime;
+    reco::MuonTimeExtra dtTime;
+    reco::MuonTimeExtra cscTime;
+    reco::MuonTime rpcTime;
+    reco::MuonTimeExtra combinedTime;
 
-     muonTime.nDof=combinedTime.nDof();
-     muonTime.timeAtIpInOut=combinedTime.timeAtIpInOut();
-     muonTime.timeAtIpInOutErr=combinedTime.timeAtIpInOutErr();
-     muonTime.timeAtIpOutIn=combinedTime.timeAtIpOutIn();
-     muonTime.timeAtIpOutInErr=combinedTime.timeAtIpOutInErr();
+    theTimingFiller_->fillTiming(muon, dtTime, cscTime, rpcTime, combinedTime, iEvent, iSetup);
 
-     muon.setTime(muonTime);
-     muon.setRPCTime(rpcTime);
-     dtTimeColl[i] = dtTime;
-     cscTimeColl[i] = cscTime;
-     combinedTimeColl[i] = combinedTime;
-   }
+    muonTime.nDof = combinedTime.nDof();
+    muonTime.timeAtIpInOut = combinedTime.timeAtIpInOut();
+    muonTime.timeAtIpInOutErr = combinedTime.timeAtIpInOutErr();
+    muonTime.timeAtIpOutIn = combinedTime.timeAtIpOutIn();
+    muonTime.timeAtIpOutInErr = combinedTime.timeAtIpOutInErr();
 
-   LogTrace("MuonIdentification") << "number of muons produced: " << outputMuons->size();
-   if ( fillMatching_ ) {
-       fillArbitrationInfo( outputMuons.get(), reco::Muon::TrackerMuon );
-       fillArbitrationInfo( outputMuons.get(), reco::Muon::ME0Muon );
-       fillArbitrationInfo( outputMuons.get(), reco::Muon::GEMMuon );
-   }
-   edm::OrphanHandle<reco::MuonCollection> muonHandle = iEvent.put(std::move(outputMuons));
+    muon.setTime(muonTime);
+    muon.setRPCTime(rpcTime);
+    dtTimeColl[i] = dtTime;
+    cscTimeColl[i] = cscTime;
+    combinedTimeColl[i] = combinedTime;
+  }
 
-   auto fillMap = [](auto refH, auto& vec, edm::Event& ev, const std::string& cAl = ""){
-     typedef  edm::ValueMap<typename std::decay<decltype(vec)>::type::value_type> MapType;
-     auto oMap = std::make_unique<MapType>();
-     {
-       typename MapType::Filler filler(*oMap);
-       filler.insert(refH, vec.begin(), vec.end());
-       vec.clear();
-       filler.fill();
-     }
-     ev.put(std::move(oMap), cAl);
-   };
-   fillMap(muonHandle, combinedTimeColl, iEvent, "combined");
-   fillMap(muonHandle, dtTimeColl, iEvent, "dt");
-   fillMap(muonHandle, cscTimeColl, iEvent, "csc");
+  LogTrace("MuonIdentification") << "number of muons produced: " << outputMuons->size();
+  if (fillMatching_) {
+    fillArbitrationInfo(outputMuons.get(), reco::Muon::TrackerMuon);
+    fillArbitrationInfo(outputMuons.get(), reco::Muon::ME0Muon);
+    fillArbitrationInfo(outputMuons.get(), reco::Muon::GEMMuon);
+  }
+  edm::OrphanHandle<reco::MuonCollection> muonHandle = iEvent.put(std::move(outputMuons));
 
-   if (writeIsoDeposits_ && fillIsolation_){
-     fillMap(muonHandle, trackDepColl, iEvent, trackDepositName_);
-     fillMap(muonHandle, ecalDepColl, iEvent, ecalDepositName_);
-     fillMap(muonHandle, hcalDepColl, iEvent, hcalDepositName_);
-     fillMap(muonHandle, hoDepColl, iEvent, hoDepositName_);
-     fillMap(muonHandle, jetDepColl, iEvent, jetDepositName_);
-   }
+  auto fillMap = [](auto refH, auto& vec, edm::Event& ev, const std::string& cAl = "") {
+    typedef edm::ValueMap<typename std::decay<decltype(vec)>::type::value_type> MapType;
+    auto oMap = std::make_unique<MapType>();
+    {
+      typename MapType::Filler filler(*oMap);
+      filler.insert(refH, vec.begin(), vec.end());
+      vec.clear();
+      filler.fill();
+    }
+    ev.put(std::move(oMap), cAl);
+  };
+  fillMap(muonHandle, combinedTimeColl, iEvent, "combined");
+  fillMap(muonHandle, dtTimeColl, iEvent, "dt");
+  fillMap(muonHandle, cscTimeColl, iEvent, "csc");
 
-   iEvent.put(std::move(caloMuons));
+  if (writeIsoDeposits_ && fillIsolation_) {
+    fillMap(muonHandle, trackDepColl, iEvent, trackDepositName_);
+    fillMap(muonHandle, ecalDepColl, iEvent, ecalDepositName_);
+    fillMap(muonHandle, hcalDepColl, iEvent, hcalDepositName_);
+    fillMap(muonHandle, hoDepColl, iEvent, hoDepositName_);
+    fillMap(muonHandle, jetDepColl, iEvent, jetDepositName_);
+  }
+
+  iEvent.put(std::move(caloMuons));
 }
 
-
-bool MuonIdProducer::isGoodTrackerMuon( const reco::Muon& muon )
-{
-  if(muon.track()->pt() < minPt_ || muon.track()->p() < minP_) return false;
-  if ( addExtraSoftMuons_ &&
-       muon.pt()<5 && std::abs(muon.eta())<1.5 &&
-       muon.numberOfMatches( reco::Muon::NoArbitration ) >= 1 ) return true;
-  return ( muon.numberOfMatches( reco::Muon::NoArbitration ) >= minNumberOfMatches_ );
+bool MuonIdProducer::isGoodTrackerMuon(const reco::Muon& muon) {
+  if (muon.track()->pt() < minPt_ || muon.track()->p() < minP_)
+    return false;
+  if (addExtraSoftMuons_ && muon.pt() < 5 && std::abs(muon.eta()) < 1.5 &&
+      muon.numberOfMatches(reco::Muon::NoArbitration) >= 1)
+    return true;
+  return (muon.numberOfMatches(reco::Muon::NoArbitration) >= minNumberOfMatches_);
 }
 
-bool MuonIdProducer::isGoodCaloMuon( const reco::CaloMuon& caloMuon )
-{
-  if ( ! caloMuon.isCaloCompatibilityValid() || caloMuon.caloCompatibility() < caloCut_ || caloMuon.p() < minPCaloMuon_) return false;
+bool MuonIdProducer::isGoodCaloMuon(const reco::CaloMuon& caloMuon) {
+  if (!caloMuon.isCaloCompatibilityValid() || caloMuon.caloCompatibility() < caloCut_ || caloMuon.p() < minPCaloMuon_)
+    return false;
   return true;
 }
 
-bool MuonIdProducer::isGoodRPCMuon( const reco::Muon& muon )
-{
-  if(muon.track()->pt() < minPt_ || muon.track()->p() < minP_) return false;
-  if ( addExtraSoftMuons_ &&
-	     muon.pt()<5 && std::abs(muon.eta())<1.5 &&
-       muon.numberOfMatchedRPCLayers( reco::Muon::RPCHitAndTrackArbitration ) > 1 ) return true;
-  return ( muon.numberOfMatchedRPCLayers( reco::Muon::RPCHitAndTrackArbitration ) > minNumberOfMatches_ );
+bool MuonIdProducer::isGoodRPCMuon(const reco::Muon& muon) {
+  if (muon.track()->pt() < minPt_ || muon.track()->p() < minP_)
+    return false;
+  if (addExtraSoftMuons_ && muon.pt() < 5 && std::abs(muon.eta()) < 1.5 &&
+      muon.numberOfMatchedRPCLayers(reco::Muon::RPCHitAndTrackArbitration) > 1)
+    return true;
+  return (muon.numberOfMatchedRPCLayers(reco::Muon::RPCHitAndTrackArbitration) > minNumberOfMatches_);
 }
 
-bool MuonIdProducer::isGoodGEMMuon( const reco::Muon& muon )
-{
-  if(muon.track()->pt() < minPt_ || muon.track()->p() < minP_) return false;
-  return ( muon.numberOfMatches( reco::Muon::GEMSegmentAndTrackArbitration ) >= 1 );    
+bool MuonIdProducer::isGoodGEMMuon(const reco::Muon& muon) {
+  if (muon.track()->pt() < minPt_ || muon.track()->p() < minP_)
+    return false;
+  return (muon.numberOfMatches(reco::Muon::GEMSegmentAndTrackArbitration) >= 1);
 }
 
-bool MuonIdProducer::isGoodME0Muon( const reco::Muon& muon )
-{
+bool MuonIdProducer::isGoodME0Muon(const reco::Muon& muon) {
   // need to update min cuts on pt
-  if(muon.track()->p() < minP_) return false;
-  return ( muon.numberOfMatches( reco::Muon::ME0SegmentAndTrackArbitration ) >= 1 );
+  if (muon.track()->p() < minP_)
+    return false;
+  return (muon.numberOfMatches(reco::Muon::ME0SegmentAndTrackArbitration) >= 1);
 }
 
-void MuonIdProducer::fillMuonId(edm::Event& iEvent, const edm::EventSetup& iSetup,
-				reco::Muon& aMuon,
-				TrackDetectorAssociator::Direction direction)
-{
+void MuonIdProducer::fillMuonId(edm::Event& iEvent,
+                                const edm::EventSetup& iSetup,
+                                reco::Muon& aMuon,
+                                TrackDetectorAssociator::Direction direction) {
+  LogTrace("MuonIdentification") << "RecoMuon/MuonIdProducer :: fillMuonId";
 
-   LogTrace("MuonIdentification") << "RecoMuon/MuonIdProducer :: fillMuonId";
+  // perform track - detector association
+  const reco::Track* track = nullptr;
+  if (aMuon.track().isNonnull())
+    track = aMuon.track().get();
+  else if (aMuon.standAloneMuon().isNonnull())
+    track = aMuon.standAloneMuon().get();
+  else
+    throw cms::Exception("FatalError")
+        << "Failed to fill muon id information for a muon with undefined references to tracks";
 
-   // perform track - detector association
-   const reco::Track* track = nullptr;
-   if      ( aMuon.track().isNonnull() ) track = aMuon.track().get();
-   else if ( aMuon.standAloneMuon().isNonnull() ) track = aMuon.standAloneMuon().get();
-   else throw cms::Exception("FatalError") << "Failed to fill muon id information for a muon with undefined references to tracks";
+  TrackDetMatchInfo info = trackAssociator_.associate(iEvent, iSetup, *track, parameters_, direction);
 
+  LogTrace("MuonIdentification") << "RecoMuon/MuonIdProducer :: fillMuonId :: fillEnergy = " << fillEnergy_;
 
-   TrackDetMatchInfo info = trackAssociator_.associate(iEvent, iSetup, *track, parameters_, direction);
-
-   LogTrace("MuonIdentification") << "RecoMuon/MuonIdProducer :: fillMuonId :: fillEnergy = "<<fillEnergy_;
-
-   if ( fillEnergy_ ) {
-
-      reco::MuonEnergy muonEnergy;
-      muonEnergy.em      = info.crossedEnergy(TrackDetMatchInfo::EcalRecHits);
-      muonEnergy.had     = info.crossedEnergy(TrackDetMatchInfo::HcalRecHits);
-      muonEnergy.ho      = info.crossedEnergy(TrackDetMatchInfo::HORecHits);
-      muonEnergy.tower   = info.crossedEnergy(TrackDetMatchInfo::TowerTotal);
-      muonEnergy.emS9    = info.nXnEnergy(TrackDetMatchInfo::EcalRecHits,1); // 3x3 energy
-      muonEnergy.emS25   = info.nXnEnergy(TrackDetMatchInfo::EcalRecHits,2); // 5x5 energy
-      muonEnergy.hadS9   = info.nXnEnergy(TrackDetMatchInfo::HcalRecHits,1); // 3x3 energy
-      muonEnergy.hoS9    = info.nXnEnergy(TrackDetMatchInfo::HORecHits,1);   // 3x3 energy
-      muonEnergy.towerS9 = info.nXnEnergy(TrackDetMatchInfo::TowerTotal,1);  // 3x3 energy
-      if (storeCrossedHcalRecHits_) {
-	muonEnergy.crossedHadRecHits.clear();
-	for (auto hit: info.crossedHcalRecHits){
-	  reco::HcalMuonRecHit mhit;
-	  mhit.energy = hit->energy();
-	  mhit.chi2   = hit->chi2();
-	  mhit.time   = hit->time();
-	  mhit.detId  = hit->id();
-	  muonEnergy.crossedHadRecHits.push_back(mhit);
-	}
+  if (fillEnergy_) {
+    reco::MuonEnergy muonEnergy;
+    muonEnergy.em = info.crossedEnergy(TrackDetMatchInfo::EcalRecHits);
+    muonEnergy.had = info.crossedEnergy(TrackDetMatchInfo::HcalRecHits);
+    muonEnergy.ho = info.crossedEnergy(TrackDetMatchInfo::HORecHits);
+    muonEnergy.tower = info.crossedEnergy(TrackDetMatchInfo::TowerTotal);
+    muonEnergy.emS9 = info.nXnEnergy(TrackDetMatchInfo::EcalRecHits, 1);    // 3x3 energy
+    muonEnergy.emS25 = info.nXnEnergy(TrackDetMatchInfo::EcalRecHits, 2);   // 5x5 energy
+    muonEnergy.hadS9 = info.nXnEnergy(TrackDetMatchInfo::HcalRecHits, 1);   // 3x3 energy
+    muonEnergy.hoS9 = info.nXnEnergy(TrackDetMatchInfo::HORecHits, 1);      // 3x3 energy
+    muonEnergy.towerS9 = info.nXnEnergy(TrackDetMatchInfo::TowerTotal, 1);  // 3x3 energy
+    if (storeCrossedHcalRecHits_) {
+      muonEnergy.crossedHadRecHits.clear();
+      for (auto hit : info.crossedHcalRecHits) {
+        reco::HcalMuonRecHit mhit;
+        mhit.energy = hit->energy();
+        mhit.chi2 = hit->chi2();
+        mhit.time = hit->time();
+        mhit.detId = hit->id();
+        muonEnergy.crossedHadRecHits.push_back(mhit);
       }
-      muonEnergy.ecal_position = info.trkGlobPosAtEcal;
-      muonEnergy.hcal_position = info.trkGlobPosAtHcal;
-      if (! info.crossedEcalIds.empty() ) muonEnergy.ecal_id = info.crossedEcalIds.front();
-      if (! info.crossedHcalIds.empty() ) muonEnergy.hcal_id = info.crossedHcalIds.front();
-      // find maximal energy depositions and their time
-      DetId emMaxId      = info.findMaxDeposition(TrackDetMatchInfo::EcalRecHits,2); // max energy deposit in 5x5 shape
-      for ( const auto& hit : info.ecalRecHits ) {
-        if (hit->id() != emMaxId) continue;
-        muonEnergy.emMax   = hit->energy();
-        muonEnergy.ecal_time = hit->time();
+    }
+    muonEnergy.ecal_position = info.trkGlobPosAtEcal;
+    muonEnergy.hcal_position = info.trkGlobPosAtHcal;
+    if (!info.crossedEcalIds.empty())
+      muonEnergy.ecal_id = info.crossedEcalIds.front();
+    if (!info.crossedHcalIds.empty())
+      muonEnergy.hcal_id = info.crossedHcalIds.front();
+    // find maximal energy depositions and their time
+    DetId emMaxId = info.findMaxDeposition(TrackDetMatchInfo::EcalRecHits, 2);  // max energy deposit in 5x5 shape
+    for (const auto& hit : info.ecalRecHits) {
+      if (hit->id() != emMaxId)
+        continue;
+      muonEnergy.emMax = hit->energy();
+      muonEnergy.ecal_time = hit->time();
+    }
+    DetId hadMaxId = info.findMaxDeposition(TrackDetMatchInfo::HcalRecHits, 1);  // max energy deposit in 3x3 shape
+    for (const auto& hit : info.hcalRecHits) {
+      if (hit->id() != hadMaxId)
+        continue;
+      muonEnergy.hadMax = hit->energy();
+      muonEnergy.hcal_time = hit->time();
+    }
+    aMuon.setCalEnergy(muonEnergy);
+  }
+  if (!fillMatching_ && !aMuon.isTrackerMuon() && !aMuon.isRPCMuon())
+    return;
+
+  // fill muon match info
+  LogTrace("MuonIdentification") << "RecoMuon/MuonIdProducer :: fillMuonId :: fill muon match info ";
+  std::vector<reco::MuonChamberMatch> muonChamberMatches;
+  unsigned int nubmerOfMatchesAccordingToTrackAssociator = 0;
+  for (const auto& chamber : info.chambers) {
+    if (chamber.id.subdetId() == 3 && rpcHitHandle_.isValid())
+      continue;  // Skip RPC chambers, they are taken care of below)
+    reco::MuonChamberMatch matchedChamber;
+
+    const auto& lErr = chamber.tState.localError();
+    const auto& lPos = chamber.tState.localPosition();
+    const auto& lDir = chamber.tState.localDirection();
+
+    const auto& localError = lErr.positionError();
+    matchedChamber.x = lPos.x();
+    matchedChamber.y = lPos.y();
+    matchedChamber.xErr = sqrt(localError.xx());
+    matchedChamber.yErr = sqrt(localError.yy());
+
+    matchedChamber.dXdZ = lDir.z() != 0 ? lDir.x() / lDir.z() : 9999;
+    matchedChamber.dYdZ = lDir.z() != 0 ? lDir.y() / lDir.z() : 9999;
+    // DANGEROUS - compiler cannot guaranty parameters ordering
+    AlgebraicSymMatrix55 trajectoryCovMatrix = lErr.matrix();
+    matchedChamber.dXdZErr = trajectoryCovMatrix(1, 1) > 0 ? sqrt(trajectoryCovMatrix(1, 1)) : 0;
+    matchedChamber.dYdZErr = trajectoryCovMatrix(2, 2) > 0 ? sqrt(trajectoryCovMatrix(2, 2)) : 0;
+
+    matchedChamber.edgeX = chamber.localDistanceX;
+    matchedChamber.edgeY = chamber.localDistanceY;
+
+    matchedChamber.id = chamber.id;
+
+    if (fillShowerDigis_) {
+      theShowerDigiFiller_->fill(matchedChamber);
+    } else {
+      theShowerDigiFiller_->fillDefault(matchedChamber);
+    }
+
+    if (!chamber.segments.empty())
+      ++nubmerOfMatchesAccordingToTrackAssociator;
+
+    // fill segments
+    for (const auto& segment : chamber.segments) {
+      reco::MuonSegmentMatch matchedSegment;
+      matchedSegment.x = segment.segmentLocalPosition.x();
+      matchedSegment.y = segment.segmentLocalPosition.y();
+      matchedSegment.dXdZ =
+          segment.segmentLocalDirection.z() ? segment.segmentLocalDirection.x() / segment.segmentLocalDirection.z() : 0;
+      matchedSegment.dYdZ =
+          segment.segmentLocalDirection.z() ? segment.segmentLocalDirection.y() / segment.segmentLocalDirection.z() : 0;
+      matchedSegment.xErr = segment.segmentLocalErrorXX > 0 ? sqrt(segment.segmentLocalErrorXX) : 0;
+      matchedSegment.yErr = segment.segmentLocalErrorYY > 0 ? sqrt(segment.segmentLocalErrorYY) : 0;
+      matchedSegment.dXdZErr = segment.segmentLocalErrorDxDz > 0 ? sqrt(segment.segmentLocalErrorDxDz) : 0;
+      matchedSegment.dYdZErr = segment.segmentLocalErrorDyDz > 0 ? sqrt(segment.segmentLocalErrorDyDz) : 0;
+      matchedSegment.t0 = segment.t0;
+      matchedSegment.mask = 0;
+      matchedSegment.dtSegmentRef = segment.dtSegmentRef;
+      matchedSegment.cscSegmentRef = segment.cscSegmentRef;
+      matchedSegment.gemSegmentRef = segment.gemSegmentRef;
+      matchedSegment.me0SegmentRef = segment.me0SegmentRef;
+      matchedSegment.hasZed_ = segment.hasZed;
+      matchedSegment.hasPhi_ = segment.hasPhi;
+      // test segment
+      bool matchedX = false;
+      bool matchedY = false;
+      LogTrace("MuonIdentification") << " matching local x, segment x: " << matchedSegment.x
+                                     << ", chamber x: " << matchedChamber.x << ", max: " << maxAbsDx_;
+      LogTrace("MuonIdentification") << " matching local y, segment y: " << matchedSegment.y
+                                     << ", chamber y: " << matchedChamber.y << ", max: " << maxAbsDy_;
+      const double matchedSegChDx = std::abs(matchedSegment.x - matchedChamber.x);
+      const double matchedSegChDy = std::abs(matchedSegment.y - matchedChamber.y);
+      const double matchedSegChPullX = matchedSegChDx / std::hypot(matchedSegment.xErr, matchedChamber.xErr);
+      const double matchedSegChPullY = matchedSegChDy / std::hypot(matchedSegment.yErr, matchedChamber.yErr);
+      if (matchedSegment.xErr > 0 && matchedChamber.xErr > 0)
+        LogTrace("MuonIdentification") << " xpull: " << matchedSegChPullX;
+      if (matchedSegment.yErr > 0 && matchedChamber.yErr > 0)
+        LogTrace("MuonIdentification") << " ypull: " << matchedSegChPullY;
+
+      if (matchedSegChDx < maxAbsDx_)
+        matchedX = true;
+      if (matchedSegChDy < maxAbsDy_)
+        matchedY = true;
+      if (matchedSegment.xErr > 0 && matchedChamber.xErr > 0 && matchedSegChPullX < maxAbsPullX_)
+        matchedX = true;
+      if (matchedSegment.yErr > 0 && matchedChamber.yErr > 0 && matchedSegChPullY < maxAbsPullY_)
+        matchedY = true;
+      if (matchedX && matchedY) {
+        if (matchedChamber.id.subdetId() == MuonSubdetId::ME0)
+          matchedChamber.me0Matches.push_back(matchedSegment);
+        else if (matchedChamber.id.subdetId() == MuonSubdetId::GEM)
+          matchedChamber.gemMatches.push_back(matchedSegment);
+        else
+          matchedChamber.segmentMatches.push_back(matchedSegment);
       }
-      DetId hadMaxId     = info.findMaxDeposition(TrackDetMatchInfo::HcalRecHits,1); // max energy deposit in 3x3 shape
-      for ( const auto& hit : info.hcalRecHits ) {
-        if (hit->id() != hadMaxId) continue;
-        muonEnergy.hadMax   = hit->energy();
-        muonEnergy.hcal_time = hit->time();
+    }
+    muonChamberMatches.push_back(matchedChamber);
+  }
+
+  // Fill RPC info
+  LogTrace("MuonIdentification") << "RecoMuon/MuonIdProducer :: fillMuonId :: fill RPC info";
+  if (rpcHitHandle_.isValid()) {
+    for (const auto& chamber : info.chambers) {
+      if (chamber.id.subdetId() != 3)
+        continue;  // Consider RPC chambers only
+      const auto& lErr = chamber.tState.localError();
+      const auto& lPos = chamber.tState.localPosition();
+      const auto& lDir = chamber.tState.localDirection();
+
+      reco::MuonChamberMatch matchedChamber;
+
+      LocalError localError = lErr.positionError();
+      matchedChamber.x = lPos.x();
+      matchedChamber.y = lPos.y();
+      matchedChamber.xErr = sqrt(localError.xx());
+      matchedChamber.yErr = sqrt(localError.yy());
+
+      matchedChamber.dXdZ = lDir.z() != 0 ? lDir.x() / lDir.z() : 9999;
+      matchedChamber.dYdZ = lDir.z() != 0 ? lDir.y() / lDir.z() : 9999;
+      // DANGEROUS - compiler cannot guaranty parameters ordering
+      AlgebraicSymMatrix55 trajectoryCovMatrix = lErr.matrix();
+      matchedChamber.dXdZErr = trajectoryCovMatrix(1, 1) > 0 ? sqrt(trajectoryCovMatrix(1, 1)) : 0;
+      matchedChamber.dYdZErr = trajectoryCovMatrix(2, 2) > 0 ? sqrt(trajectoryCovMatrix(2, 2)) : 0;
+
+      matchedChamber.edgeX = chamber.localDistanceX;
+      matchedChamber.edgeY = chamber.localDistanceY;
+
+      theShowerDigiFiller_->fillDefault(matchedChamber);
+
+      matchedChamber.id = chamber.id;
+
+      for (const auto& rpcRecHit : *rpcHitHandle_) {
+        reco::MuonRPCHitMatch rpcHitMatch;
+
+        if (rpcRecHit.rawId() != chamber.id.rawId())
+          continue;
+
+        rpcHitMatch.x = rpcRecHit.localPosition().x();
+        rpcHitMatch.mask = 0;
+        rpcHitMatch.bx = rpcRecHit.BunchX();
+
+        const double absDx = std::abs(rpcRecHit.localPosition().x() - chamber.tState.localPosition().x());
+        if (absDx <= 20 or absDx / sqrt(localError.xx()) <= 4)
+          matchedChamber.rpcMatches.push_back(rpcHitMatch);
       }
-      aMuon.setCalEnergy( muonEnergy );
-   }
-   if ( ! fillMatching_ && ! aMuon.isTrackerMuon() && ! aMuon.isRPCMuon() ) return;
 
-   // fill muon match info
-   LogTrace("MuonIdentification") << "RecoMuon/MuonIdProducer :: fillMuonId :: fill muon match info ";
-   std::vector<reco::MuonChamberMatch> muonChamberMatches;
-   unsigned int nubmerOfMatchesAccordingToTrackAssociator = 0;
-   for ( const auto& chamber : info.chambers )
-   {
-     if (chamber.id.subdetId() == 3 && rpcHitHandle_.isValid()  ) continue; // Skip RPC chambers, they are taken care of below)
-     reco::MuonChamberMatch matchedChamber;
+      muonChamberMatches.push_back(matchedChamber);
+    }
+  }
 
-     const auto& lErr = chamber.tState.localError();
-     const auto& lPos = chamber.tState.localPosition();
-     const auto& lDir = chamber.tState.localDirection();
+  aMuon.setMatches(muonChamberMatches);
 
-     const auto& localError = lErr.positionError();
-     matchedChamber.x = lPos.x();
-     matchedChamber.y = lPos.y();
-     matchedChamber.xErr = sqrt( localError.xx() );
-     matchedChamber.yErr = sqrt( localError.yy() );
+  LogTrace("MuonIdentification") << "number of muon chambers: " << aMuon.matches().size() << "\n"
+                                 << "number of chambers with segments according to the associator requirements: "
+                                 << nubmerOfMatchesAccordingToTrackAssociator;
+  LogTrace("MuonIdentification") << "number of segment matches with the producer requirements: "
+                                 << aMuon.numberOfMatches(reco::Muon::NoArbitration);
 
-     matchedChamber.dXdZ = lDir.z()!=0?lDir.x()/lDir.z():9999;
-     matchedChamber.dYdZ = lDir.z()!=0?lDir.y()/lDir.z():9999;
-     // DANGEROUS - compiler cannot guaranty parameters ordering
-     AlgebraicSymMatrix55 trajectoryCovMatrix = lErr.matrix();
-     matchedChamber.dXdZErr = trajectoryCovMatrix(1,1)>0?sqrt(trajectoryCovMatrix(1,1)):0;
-     matchedChamber.dYdZErr = trajectoryCovMatrix(2,2)>0?sqrt(trajectoryCovMatrix(2,2)):0;
-
-     matchedChamber.edgeX = chamber.localDistanceX;
-     matchedChamber.edgeY = chamber.localDistanceY;
-
-     matchedChamber.id = chamber.id;
-
-     if (fillShowerDigis_) {
-       theShowerDigiFiller_->fill(matchedChamber);
-     }
-     else {
-       theShowerDigiFiller_->fillDefault(matchedChamber);
-     }
-
-     if ( ! chamber.segments.empty() ) ++nubmerOfMatchesAccordingToTrackAssociator;
-
-     // fill segments
-     for ( const auto& segment : chamber.segments )
-     {
-       reco::MuonSegmentMatch matchedSegment;
-       matchedSegment.x = segment.segmentLocalPosition.x();
-       matchedSegment.y = segment.segmentLocalPosition.y();
-       matchedSegment.dXdZ = segment.segmentLocalDirection.z()?segment.segmentLocalDirection.x()/segment.segmentLocalDirection.z():0;
-       matchedSegment.dYdZ = segment.segmentLocalDirection.z()?segment.segmentLocalDirection.y()/segment.segmentLocalDirection.z():0;
-       matchedSegment.xErr = segment.segmentLocalErrorXX>0?sqrt(segment.segmentLocalErrorXX):0;
-       matchedSegment.yErr = segment.segmentLocalErrorYY>0?sqrt(segment.segmentLocalErrorYY):0;
-       matchedSegment.dXdZErr = segment.segmentLocalErrorDxDz>0?sqrt(segment.segmentLocalErrorDxDz):0;
-       matchedSegment.dYdZErr = segment.segmentLocalErrorDyDz>0?sqrt(segment.segmentLocalErrorDyDz):0;
-       matchedSegment.t0 = segment.t0;
-       matchedSegment.mask = 0;
-       matchedSegment.dtSegmentRef  = segment.dtSegmentRef;
-       matchedSegment.cscSegmentRef = segment.cscSegmentRef;
-       matchedSegment.gemSegmentRef = segment.gemSegmentRef;
-       matchedSegment.me0SegmentRef = segment.me0SegmentRef;
-       matchedSegment.hasZed_ = segment.hasZed;
-       matchedSegment.hasPhi_ = segment.hasPhi;
-       // test segment
-       bool matchedX = false;
-       bool matchedY = false;
-       LogTrace("MuonIdentification") << " matching local x, segment x: " << matchedSegment.x <<
-         ", chamber x: " << matchedChamber.x << ", max: " << maxAbsDx_;
-       LogTrace("MuonIdentification") << " matching local y, segment y: " << matchedSegment.y <<
-         ", chamber y: " << matchedChamber.y << ", max: " << maxAbsDy_;
-       const double matchedSegChDx = std::abs(matchedSegment.x - matchedChamber.x);
-       const double matchedSegChDy = std::abs(matchedSegment.y - matchedChamber.y);
-       const double matchedSegChPullX = matchedSegChDx/std::hypot(matchedSegment.xErr, matchedChamber.xErr);
-       const double matchedSegChPullY = matchedSegChDy/std::hypot(matchedSegment.yErr, matchedChamber.yErr);
-       if (matchedSegment.xErr>0 && matchedChamber.xErr>0 )
-         LogTrace("MuonIdentification") << " xpull: " << matchedSegChPullX;
-       if (matchedSegment.yErr>0 && matchedChamber.yErr>0 )
-         LogTrace("MuonIdentification") << " ypull: " << matchedSegChPullY;
-
-       if (matchedSegChDx < maxAbsDx_) matchedX = true;
-       if (matchedSegChDy < maxAbsDy_) matchedY = true;
-       if (matchedSegment.xErr>0 && matchedChamber.xErr>0 && matchedSegChPullX < maxAbsPullX_) matchedX = true;
-       if (matchedSegment.yErr>0 && matchedChamber.yErr>0 && matchedSegChPullY < maxAbsPullY_) matchedY = true;
-       if (matchedX && matchedY){
-	 if (matchedChamber.id.subdetId() == MuonSubdetId::ME0)
-	   matchedChamber.me0Matches.push_back(matchedSegment);
-	 else if (matchedChamber.id.subdetId() == MuonSubdetId::GEM)
-	   matchedChamber.gemMatches.push_back(matchedSegment);
-	 else matchedChamber.segmentMatches.push_back(matchedSegment);
-       }
-     }	 
-     muonChamberMatches.push_back(matchedChamber);
-   }
-
-   // Fill RPC info
-   LogTrace("MuonIdentification") << "RecoMuon/MuonIdProducer :: fillMuonId :: fill RPC info";
-   if ( rpcHitHandle_.isValid() )
-   {
-     for ( const auto& chamber : info.chambers )
-     {
-       if ( chamber.id.subdetId() != 3 ) continue; // Consider RPC chambers only
-       const auto& lErr = chamber.tState.localError();
-       const auto& lPos = chamber.tState.localPosition();
-       const auto& lDir = chamber.tState.localDirection();
-
-       reco::MuonChamberMatch matchedChamber;
-
-       LocalError localError = lErr.positionError();
-       matchedChamber.x = lPos.x();
-       matchedChamber.y = lPos.y();
-       matchedChamber.xErr = sqrt( localError.xx() );
-       matchedChamber.yErr = sqrt( localError.yy() );
-
-       matchedChamber.dXdZ = lDir.z()!=0?lDir.x()/lDir.z():9999;
-       matchedChamber.dYdZ = lDir.z()!=0?lDir.y()/lDir.z():9999;
-       // DANGEROUS - compiler cannot guaranty parameters ordering
-       AlgebraicSymMatrix55 trajectoryCovMatrix = lErr.matrix();
-       matchedChamber.dXdZErr = trajectoryCovMatrix(1,1)>0?sqrt(trajectoryCovMatrix(1,1)):0;
-       matchedChamber.dYdZErr = trajectoryCovMatrix(2,2)>0?sqrt(trajectoryCovMatrix(2,2)):0;
-
-       matchedChamber.edgeX = chamber.localDistanceX;
-       matchedChamber.edgeY = chamber.localDistanceY;
-
-       theShowerDigiFiller_->fillDefault(matchedChamber);
-
-       matchedChamber.id = chamber.id;
-
-       for ( const auto& rpcRecHit : *rpcHitHandle_ )
-       {
-         reco::MuonRPCHitMatch rpcHitMatch;
-
-         if ( rpcRecHit.rawId() != chamber.id.rawId() ) continue;
-
-         rpcHitMatch.x = rpcRecHit.localPosition().x();
-         rpcHitMatch.mask = 0;
-         rpcHitMatch.bx = rpcRecHit.BunchX();
-
-         const double absDx = std::abs(rpcRecHit.localPosition().x()-chamber.tState.localPosition().x());
-         if( absDx <= 20 or absDx/sqrt(localError.xx()) <= 4 ) matchedChamber.rpcMatches.push_back(rpcHitMatch);
-       }
-
-       muonChamberMatches.push_back(matchedChamber);
-     }
-   }
-
-   aMuon.setMatches(muonChamberMatches);
-
-   LogTrace("MuonIdentification") << "number of muon chambers: " << aMuon.matches().size() << "\n"
-     << "number of chambers with segments according to the associator requirements: " <<
-     nubmerOfMatchesAccordingToTrackAssociator;
-   LogTrace("MuonIdentification") << "number of segment matches with the producer requirements: " <<
-     aMuon.numberOfMatches( reco::Muon::NoArbitration );
-
-   // fillTime( iEvent, iSetup, aMuon );
+  // fillTime( iEvent, iSetup, aMuon );
 }
 
-void MuonIdProducer::arbitrateMuons( reco::MuonCollection* muons, reco::CaloMuonCollection* caloMuons )
-{
+void MuonIdProducer::arbitrateMuons(reco::MuonCollection* muons, reco::CaloMuonCollection* caloMuons) {
   reco::Muon::ArbitrationType arbitration = reco::Muon::SegmentAndTrackArbitration;
   // arbitrate TrackerMuons
   // if a muon was exclusively TrackerMuon check if it can be a calo muon
-  for (reco::MuonCollection::iterator muon=muons->begin(); muon!=muons->end();){
-    if (muon->isTrackerMuon()){
-      if (muon->numberOfMatches(arbitration)<minNumberOfMatches_){
-	// TrackerMuon failed arbitration
-	// If not any other base type - erase the element
-	// (PFMuon is not a base type)
-	unsigned int mask = reco::Muon::TrackerMuon|reco::Muon::PFMuon;
-	if ((muon->type() & (~mask))==0){
-	  const reco::CaloMuon& caloMuon = makeCaloMuon(*muon);
-	  if (isGoodCaloMuon(caloMuon)) caloMuons->push_back( caloMuon );
-	  muon = muons->erase(muon);
-	  continue;
-	} else {
-	  muon->setType(muon->type()&(~reco::Muon::TrackerMuon));
-	}
-      } 
+  for (reco::MuonCollection::iterator muon = muons->begin(); muon != muons->end();) {
+    if (muon->isTrackerMuon()) {
+      if (muon->numberOfMatches(arbitration) < minNumberOfMatches_) {
+        // TrackerMuon failed arbitration
+        // If not any other base type - erase the element
+        // (PFMuon is not a base type)
+        unsigned int mask = reco::Muon::TrackerMuon | reco::Muon::PFMuon;
+        if ((muon->type() & (~mask)) == 0) {
+          const reco::CaloMuon& caloMuon = makeCaloMuon(*muon);
+          if (isGoodCaloMuon(caloMuon))
+            caloMuons->push_back(caloMuon);
+          muon = muons->erase(muon);
+          continue;
+        } else {
+          muon->setType(muon->type() & (~reco::Muon::TrackerMuon));
+        }
+      }
     }
     muon++;
   }
 }
 
-void MuonIdProducer::fillArbitrationInfo( reco::MuonCollection* pOutputMuons, unsigned int muonType )
-{
-   //
-   // apply segment flags
-   //
-   std::vector<std::pair<reco::MuonChamberMatch*,reco::MuonSegmentMatch*> > chamberPairs;     // for chamber segment sorting
-   std::vector<std::pair<reco::MuonChamberMatch*,reco::MuonSegmentMatch*> > stationPairs;     // for station segment sorting
-   std::vector<std::pair<reco::MuonChamberMatch*,reco::MuonSegmentMatch*> > arbitrationPairs; // for muon segment arbitration
+void MuonIdProducer::fillArbitrationInfo(reco::MuonCollection* pOutputMuons, unsigned int muonType) {
+  //
+  // apply segment flags
+  //
+  std::vector<std::pair<reco::MuonChamberMatch*, reco::MuonSegmentMatch*> > chamberPairs;  // for chamber segment sorting
+  std::vector<std::pair<reco::MuonChamberMatch*, reco::MuonSegmentMatch*> > stationPairs;  // for station segment sorting
+  std::vector<std::pair<reco::MuonChamberMatch*, reco::MuonSegmentMatch*> >
+      arbitrationPairs;  // for muon segment arbitration
 
-   // muonIndex1
-   for( unsigned int muonIndex1 = 0; muonIndex1 < pOutputMuons->size(); ++muonIndex1 )
-   {
-     auto& muon1 = pOutputMuons->at(muonIndex1);
-     // chamberIter1
-     for ( auto& chamber1 : muon1.matches() )
-     {
-       // segmentIter1
-       std::vector<reco::MuonSegmentMatch> * segmentMatches1 = getSegmentMatches(chamber1, muonType);
+  // muonIndex1
+  for (unsigned int muonIndex1 = 0; muonIndex1 < pOutputMuons->size(); ++muonIndex1) {
+    auto& muon1 = pOutputMuons->at(muonIndex1);
+    // chamberIter1
+    for (auto& chamber1 : muon1.matches()) {
+      // segmentIter1
+      std::vector<reco::MuonSegmentMatch>* segmentMatches1 = getSegmentMatches(chamber1, muonType);
 
-       if(segmentMatches1->empty()) continue;
-       chamberPairs.clear();
+      if (segmentMatches1->empty())
+        continue;
+      chamberPairs.clear();
 
-       for ( auto& segment1 : *segmentMatches1 )
-       {
-         chamberPairs.push_back(std::make_pair(&chamber1, &segment1));
-         if(!segment1.isMask()) // has not yet been arbitrated
-         {
-           arbitrationPairs.clear();
-           arbitrationPairs.push_back(std::make_pair(&chamber1, &segment1));
+      for (auto& segment1 : *segmentMatches1) {
+        chamberPairs.push_back(std::make_pair(&chamber1, &segment1));
+        if (!segment1.isMask())  // has not yet been arbitrated
+        {
+          arbitrationPairs.clear();
+          arbitrationPairs.push_back(std::make_pair(&chamber1, &segment1));
 
-           // find identical segments with which to arbitrate
-           // tracker muons only
-           if (muon1.type() & muonType) {
-             // muonIndex2
-             for( unsigned int muonIndex2 = muonIndex1+1; muonIndex2 < pOutputMuons->size(); ++muonIndex2 )
-             {
-               auto& muon2 = pOutputMuons->at(muonIndex2);
-               // tracker muons only
-               if ( !(muon2.type() & muonType) ) continue;
-               // chamberIter2
-               for ( auto& chamber2 : muon2.matches() )
-               {
-                 // segmentIter2
-                 std::vector<reco::MuonSegmentMatch> * segmentMatches2 = getSegmentMatches(chamber2, muonType);
-                 for ( auto& segment2 : *segmentMatches2 )
-                 {
-                   if(segment2.isMask()) continue; // has already been arbitrated
-                   if(approxEqual(segment2.x      , segment1.x      ) &&
-                      approxEqual(segment2.y      , segment1.y      ) &&
-                      approxEqual(segment2.dXdZ   , segment1.dXdZ   ) &&
-                      approxEqual(segment2.dYdZ   , segment1.dYdZ   ) &&
-                      approxEqual(segment2.xErr   , segment1.xErr   ) &&
-                      approxEqual(segment2.yErr   , segment1.yErr   ) &&
+          // find identical segments with which to arbitrate
+          // tracker muons only
+          if (muon1.type() & muonType) {
+            // muonIndex2
+            for (unsigned int muonIndex2 = muonIndex1 + 1; muonIndex2 < pOutputMuons->size(); ++muonIndex2) {
+              auto& muon2 = pOutputMuons->at(muonIndex2);
+              // tracker muons only
+              if (!(muon2.type() & muonType))
+                continue;
+              // chamberIter2
+              for (auto& chamber2 : muon2.matches()) {
+                // segmentIter2
+                std::vector<reco::MuonSegmentMatch>* segmentMatches2 = getSegmentMatches(chamber2, muonType);
+                for (auto& segment2 : *segmentMatches2) {
+                  if (segment2.isMask())
+                    continue;  // has already been arbitrated
+                  if (approxEqual(segment2.x, segment1.x) && approxEqual(segment2.y, segment1.y) &&
+                      approxEqual(segment2.dXdZ, segment1.dXdZ) && approxEqual(segment2.dYdZ, segment1.dYdZ) &&
+                      approxEqual(segment2.xErr, segment1.xErr) && approxEqual(segment2.yErr, segment1.yErr) &&
                       approxEqual(segment2.dXdZErr, segment1.dXdZErr) &&
-                      approxEqual(segment2.dYdZErr, segment1.dYdZErr))
-                   {
-                     arbitrationPairs.push_back(std::make_pair(&chamber2, &segment2));
-                   }
-                 } // segmentIter2
-               } // chamberIter2
-             } // muonIndex2
-           }
+                      approxEqual(segment2.dYdZErr, segment1.dYdZErr)) {
+                    arbitrationPairs.push_back(std::make_pair(&chamber2, &segment2));
+                  }
+                }  // segmentIter2
+              }    // chamberIter2
+            }      // muonIndex2
+          }
 
-           // arbitration segment sort
-           if(arbitrationPairs.empty()) continue; // this should never happen
-           if(arbitrationPairs.size()==1) {
-             arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::BelongsToTrackByDRSlope);
-             arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::BelongsToTrackByDXSlope);
-             arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::BelongsToTrackByDR);
-             arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::BelongsToTrackByDX);
-             arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::Arbitrated);
-           } else {
-             sort(arbitrationPairs.begin(), arbitrationPairs.end(), SortMuonSegmentMatches(reco::MuonSegmentMatch::BelongsToTrackByDRSlope));
-             arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::BelongsToTrackByDRSlope);
-             sort(arbitrationPairs.begin(), arbitrationPairs.end(), SortMuonSegmentMatches(reco::MuonSegmentMatch::BelongsToTrackByDXSlope));
-             arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::BelongsToTrackByDXSlope);
-             sort(arbitrationPairs.begin(), arbitrationPairs.end(), SortMuonSegmentMatches(reco::MuonSegmentMatch::BelongsToTrackByDR));
-             arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::BelongsToTrackByDR);
-             sort(arbitrationPairs.begin(), arbitrationPairs.end(), SortMuonSegmentMatches(reco::MuonSegmentMatch::BelongsToTrackByDX));
-             arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::BelongsToTrackByDX);
-             for ( auto& ap : arbitrationPairs ) {
-               ap.second->setMask(reco::MuonSegmentMatch::Arbitrated);
-             }
-           }
-         }
+          // arbitration segment sort
+          if (arbitrationPairs.empty())
+            continue;  // this should never happen
+          if (arbitrationPairs.size() == 1) {
+            arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::BelongsToTrackByDRSlope);
+            arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::BelongsToTrackByDXSlope);
+            arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::BelongsToTrackByDR);
+            arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::BelongsToTrackByDX);
+            arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::Arbitrated);
+          } else {
+            sort(arbitrationPairs.begin(),
+                 arbitrationPairs.end(),
+                 SortMuonSegmentMatches(reco::MuonSegmentMatch::BelongsToTrackByDRSlope));
+            arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::BelongsToTrackByDRSlope);
+            sort(arbitrationPairs.begin(),
+                 arbitrationPairs.end(),
+                 SortMuonSegmentMatches(reco::MuonSegmentMatch::BelongsToTrackByDXSlope));
+            arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::BelongsToTrackByDXSlope);
+            sort(arbitrationPairs.begin(),
+                 arbitrationPairs.end(),
+                 SortMuonSegmentMatches(reco::MuonSegmentMatch::BelongsToTrackByDR));
+            arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::BelongsToTrackByDR);
+            sort(arbitrationPairs.begin(),
+                 arbitrationPairs.end(),
+                 SortMuonSegmentMatches(reco::MuonSegmentMatch::BelongsToTrackByDX));
+            arbitrationPairs.front().second->setMask(reco::MuonSegmentMatch::BelongsToTrackByDX);
+            for (auto& ap : arbitrationPairs) {
+              ap.second->setMask(reco::MuonSegmentMatch::Arbitrated);
+            }
+          }
+        }
 
-         // setup me1a cleaning for later
-         if( muonType == reco::Muon::TrackerMuon && chamber1.id.subdetId() == MuonSubdetId::CSC && arbClean_ &&
-             CSCDetId(chamber1.id).ring() == 4) {
-           for ( auto& segment2 : chamber1.segmentMatches ) {
-             if( segment1.cscSegmentRef.isNull() || segment2.cscSegmentRef.isNull() ) continue;
-             if( meshAlgo_->isDuplicateOf(segment1.cscSegmentRef,segment2.cscSegmentRef) &&
-                 (segment2.mask & 0x1e0000) &&
-                 (segment1.mask & 0x1e0000) ) {
-               segment2.setMask(reco::MuonSegmentMatch::BelongsToTrackByME1aClean);
-               //if the track has lost the segment already through normal arbitration no need to do it again.
-             }
-           }
-         }// mark all ME1/a duplicates that this track owns
+        // setup me1a cleaning for later
+        if (muonType == reco::Muon::TrackerMuon && chamber1.id.subdetId() == MuonSubdetId::CSC && arbClean_ &&
+            CSCDetId(chamber1.id).ring() == 4) {
+          for (auto& segment2 : chamber1.segmentMatches) {
+            if (segment1.cscSegmentRef.isNull() || segment2.cscSegmentRef.isNull())
+              continue;
+            if (meshAlgo_->isDuplicateOf(segment1.cscSegmentRef, segment2.cscSegmentRef) &&
+                (segment2.mask & 0x1e0000) && (segment1.mask & 0x1e0000)) {
+              segment2.setMask(reco::MuonSegmentMatch::BelongsToTrackByME1aClean);
+              //if the track has lost the segment already through normal arbitration no need to do it again.
+            }
+          }
+        }  // mark all ME1/a duplicates that this track owns
 
-       } // segmentIter1
+      }  // segmentIter1
 
-       // chamber segment sort
-       if(chamberPairs.empty()) continue; // this should never happen
-       if(chamberPairs.size()==1) {
-         chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDRSlope);
-         chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDXSlope);
-         chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDR);
-         chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDX);
-       } else {
-         sort(chamberPairs.begin(), chamberPairs.end(), SortMuonSegmentMatches(reco::MuonSegmentMatch::BestInChamberByDRSlope));
-         chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDRSlope);
-         sort(chamberPairs.begin(), chamberPairs.end(), SortMuonSegmentMatches(reco::MuonSegmentMatch::BestInChamberByDXSlope));
-         chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDXSlope);
-         sort(chamberPairs.begin(), chamberPairs.end(), SortMuonSegmentMatches(reco::MuonSegmentMatch::BestInChamberByDR));
-         chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDR);
-         sort(chamberPairs.begin(), chamberPairs.end(), SortMuonSegmentMatches(reco::MuonSegmentMatch::BestInChamberByDX));
-         chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDX);
-       }
-     } // chamberIter1
+      // chamber segment sort
+      if (chamberPairs.empty())
+        continue;  // this should never happen
+      if (chamberPairs.size() == 1) {
+        chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDRSlope);
+        chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDXSlope);
+        chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDR);
+        chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDX);
+      } else {
+        sort(chamberPairs.begin(),
+             chamberPairs.end(),
+             SortMuonSegmentMatches(reco::MuonSegmentMatch::BestInChamberByDRSlope));
+        chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDRSlope);
+        sort(chamberPairs.begin(),
+             chamberPairs.end(),
+             SortMuonSegmentMatches(reco::MuonSegmentMatch::BestInChamberByDXSlope));
+        chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDXSlope);
+        sort(chamberPairs.begin(),
+             chamberPairs.end(),
+             SortMuonSegmentMatches(reco::MuonSegmentMatch::BestInChamberByDR));
+        chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDR);
+        sort(chamberPairs.begin(),
+             chamberPairs.end(),
+             SortMuonSegmentMatches(reco::MuonSegmentMatch::BestInChamberByDX));
+        chamberPairs.front().second->setMask(reco::MuonSegmentMatch::BestInChamberByDX);
+      }
+    }  // chamberIter1
 
-     // station segment sort
-     for( int stationIndex = 1; stationIndex < 5; ++stationIndex ) 
-     {
-       for( int detectorIndex = 1; detectorIndex <= 5; ++detectorIndex ) // 1-5, as in DataFormats/MuonDetId/interface/MuonSubdetId.h
-       {
-         stationPairs.clear();
+    // station segment sort
+    for (int stationIndex = 1; stationIndex < 5; ++stationIndex) {
+      for (int detectorIndex = 1; detectorIndex <= 5;
+           ++detectorIndex)  // 1-5, as in DataFormats/MuonDetId/interface/MuonSubdetId.h
+      {
+        stationPairs.clear();
 
-         // chamberIter
-         for ( auto& chamber : muon1.matches() )
-         {
-           if(!(chamber.station()==stationIndex && chamber.detector()==detectorIndex)) continue;
-           std::vector<reco::MuonSegmentMatch> * segmentMatches = getSegmentMatches(chamber, muonType);
-           if (segmentMatches->empty()) continue;
+        // chamberIter
+        for (auto& chamber : muon1.matches()) {
+          if (!(chamber.station() == stationIndex && chamber.detector() == detectorIndex))
+            continue;
+          std::vector<reco::MuonSegmentMatch>* segmentMatches = getSegmentMatches(chamber, muonType);
+          if (segmentMatches->empty())
+            continue;
 
-           for ( auto& segment : *segmentMatches ) {
-             stationPairs.push_back(std::make_pair(&chamber, &segment));
-           }
-         } // chamberIter
+          for (auto& segment : *segmentMatches) {
+            stationPairs.push_back(std::make_pair(&chamber, &segment));
+          }
+        }  // chamberIter
 
-         if(stationPairs.empty()) continue; // this may very well happen
-         if(stationPairs.size()==1) {
-           stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDRSlope);
-           stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDXSlope);
-           stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDR);
-           stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDX);
-         } else {
-           sort(stationPairs.begin(), stationPairs.end(), SortMuonSegmentMatches(reco::MuonSegmentMatch::BestInStationByDRSlope));
-           stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDRSlope);
-           sort(stationPairs.begin(), stationPairs.end(), SortMuonSegmentMatches(reco::MuonSegmentMatch::BestInStationByDXSlope));
-           stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDXSlope);
-           sort(stationPairs.begin(), stationPairs.end(), SortMuonSegmentMatches(reco::MuonSegmentMatch::BestInStationByDR));
-           stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDR);
-           sort(stationPairs.begin(), stationPairs.end(), SortMuonSegmentMatches(reco::MuonSegmentMatch::BestInStationByDX));
-           stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDX);
-         }
-       }
-     }
+        if (stationPairs.empty())
+          continue;  // this may very well happen
+        if (stationPairs.size() == 1) {
+          stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDRSlope);
+          stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDXSlope);
+          stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDR);
+          stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDX);
+        } else {
+          sort(stationPairs.begin(),
+               stationPairs.end(),
+               SortMuonSegmentMatches(reco::MuonSegmentMatch::BestInStationByDRSlope));
+          stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDRSlope);
+          sort(stationPairs.begin(),
+               stationPairs.end(),
+               SortMuonSegmentMatches(reco::MuonSegmentMatch::BestInStationByDXSlope));
+          stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDXSlope);
+          sort(stationPairs.begin(),
+               stationPairs.end(),
+               SortMuonSegmentMatches(reco::MuonSegmentMatch::BestInStationByDR));
+          stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDR);
+          sort(stationPairs.begin(),
+               stationPairs.end(),
+               SortMuonSegmentMatches(reco::MuonSegmentMatch::BestInStationByDX));
+          stationPairs.front().second->setMask(reco::MuonSegmentMatch::BestInStationByDX);
+        }
+      }
+    }
 
-   } // muonIndex1
+  }  // muonIndex1
 
-   if(arbClean_) {
-     // clear old mesh, create and prune new mesh!
-     meshAlgo_->clearMesh();
-     meshAlgo_->runMesh(pOutputMuons);
-   }
+  if (arbClean_) {
+    // clear old mesh, create and prune new mesh!
+    meshAlgo_->clearMesh();
+    meshAlgo_->runMesh(pOutputMuons);
+  }
 }
 
-void MuonIdProducer::fillMuonIsolation(edm::Event& iEvent, const edm::EventSetup& iSetup, reco::Muon& aMuon,
-				       reco::IsoDeposit& trackDep, reco::IsoDeposit& ecalDep, reco::IsoDeposit& hcalDep, reco::IsoDeposit& hoDep,
-				       reco::IsoDeposit& jetDep)
-{
-   const reco::Track* track = nullptr;
-   if ( aMuon.track().isNonnull() ) track = aMuon.track().get();
-   else if ( aMuon.standAloneMuon().isNonnull() ) track = aMuon.standAloneMuon().get();
-   else throw cms::Exception("FatalError") << "Failed to compute muon isolation information for a muon with undefined references to tracks";
+void MuonIdProducer::fillMuonIsolation(edm::Event& iEvent,
+                                       const edm::EventSetup& iSetup,
+                                       reco::Muon& aMuon,
+                                       reco::IsoDeposit& trackDep,
+                                       reco::IsoDeposit& ecalDep,
+                                       reco::IsoDeposit& hcalDep,
+                                       reco::IsoDeposit& hoDep,
+                                       reco::IsoDeposit& jetDep) {
+  const reco::Track* track = nullptr;
+  if (aMuon.track().isNonnull())
+    track = aMuon.track().get();
+  else if (aMuon.standAloneMuon().isNonnull())
+    track = aMuon.standAloneMuon().get();
+  else
+    throw cms::Exception("FatalError")
+        << "Failed to compute muon isolation information for a muon with undefined references to tracks";
 
-   reco::MuonIsolation isoR03, isoR05;
+  reco::MuonIsolation isoR03, isoR05;
 
-   // get deposits
-   reco::IsoDeposit depTrk = muIsoExtractorTrack_->deposit(iEvent, iSetup, *track );
-   std::vector<reco::IsoDeposit> caloDeps = muIsoExtractorCalo_->deposits(iEvent, iSetup, *track);
-   reco::IsoDeposit depJet = muIsoExtractorJet_->deposit(iEvent, iSetup, *track );
+  // get deposits
+  reco::IsoDeposit depTrk = muIsoExtractorTrack_->deposit(iEvent, iSetup, *track);
+  std::vector<reco::IsoDeposit> caloDeps = muIsoExtractorCalo_->deposits(iEvent, iSetup, *track);
+  reco::IsoDeposit depJet = muIsoExtractorJet_->deposit(iEvent, iSetup, *track);
 
-   if(caloDeps.size()!=3) {
-      LogTrace("MuonIdentification") << "Failed to fill vector of calorimeter isolation deposits!";
-      return;
-   }
+  if (caloDeps.size() != 3) {
+    LogTrace("MuonIdentification") << "Failed to fill vector of calorimeter isolation deposits!";
+    return;
+  }
 
-   reco::IsoDeposit depEcal = caloDeps.at(0);
-   reco::IsoDeposit depHcal = caloDeps.at(1);
-   reco::IsoDeposit depHo   = caloDeps.at(2);
+  reco::IsoDeposit depEcal = caloDeps.at(0);
+  reco::IsoDeposit depHcal = caloDeps.at(1);
+  reco::IsoDeposit depHo = caloDeps.at(2);
 
-   //no need to copy outside if we don't write them
-   if (writeIsoDeposits_){
-     trackDep = depTrk;
-     ecalDep = depEcal;
-     hcalDep = depHcal;
-     hoDep = depHo;
-     jetDep = depJet;
-   }
+  //no need to copy outside if we don't write them
+  if (writeIsoDeposits_) {
+    trackDep = depTrk;
+    ecalDep = depEcal;
+    hcalDep = depHcal;
+    hoDep = depHo;
+    jetDep = depJet;
+  }
 
-   isoR03.sumPt     = depTrk.depositWithin(0.3);
-   isoR03.emEt      = depEcal.depositWithin(0.3);
-   isoR03.hadEt     = depHcal.depositWithin(0.3);
-   isoR03.hoEt      = depHo.depositWithin(0.3);
-   isoR03.nTracks   = depTrk.depositAndCountWithin(0.3).second;
-   isoR03.nJets     = depJet.depositAndCountWithin(0.3).second;
-   isoR03.trackerVetoPt  = depTrk.candEnergy();
-   isoR03.emVetoEt       = depEcal.candEnergy();
-   isoR03.hadVetoEt      = depHcal.candEnergy();
-   isoR03.hoVetoEt       = depHo.candEnergy();
+  isoR03.sumPt = depTrk.depositWithin(0.3);
+  isoR03.emEt = depEcal.depositWithin(0.3);
+  isoR03.hadEt = depHcal.depositWithin(0.3);
+  isoR03.hoEt = depHo.depositWithin(0.3);
+  isoR03.nTracks = depTrk.depositAndCountWithin(0.3).second;
+  isoR03.nJets = depJet.depositAndCountWithin(0.3).second;
+  isoR03.trackerVetoPt = depTrk.candEnergy();
+  isoR03.emVetoEt = depEcal.candEnergy();
+  isoR03.hadVetoEt = depHcal.candEnergy();
+  isoR03.hoVetoEt = depHo.candEnergy();
 
-   isoR05.sumPt     = depTrk.depositWithin(0.5);
-   isoR05.emEt      = depEcal.depositWithin(0.5);
-   isoR05.hadEt     = depHcal.depositWithin(0.5);
-   isoR05.hoEt      = depHo.depositWithin(0.5);
-   isoR05.nTracks   = depTrk.depositAndCountWithin(0.5).second;
-   isoR05.nJets     = depJet.depositAndCountWithin(0.5).second;
-   isoR05.trackerVetoPt  = depTrk.candEnergy();
-   isoR05.emVetoEt       = depEcal.candEnergy();
-   isoR05.hadVetoEt      = depHcal.candEnergy();
-   isoR05.hoVetoEt       = depHo.candEnergy();
+  isoR05.sumPt = depTrk.depositWithin(0.5);
+  isoR05.emEt = depEcal.depositWithin(0.5);
+  isoR05.hadEt = depHcal.depositWithin(0.5);
+  isoR05.hoEt = depHo.depositWithin(0.5);
+  isoR05.nTracks = depTrk.depositAndCountWithin(0.5).second;
+  isoR05.nJets = depJet.depositAndCountWithin(0.5).second;
+  isoR05.trackerVetoPt = depTrk.candEnergy();
+  isoR05.emVetoEt = depEcal.candEnergy();
+  isoR05.hadVetoEt = depHcal.candEnergy();
+  isoR05.hoVetoEt = depHo.candEnergy();
 
-
-   aMuon.setIsolation(isoR03, isoR05);
-
+  aMuon.setIsolation(isoR03, isoR05);
 }
 
-reco::Muon MuonIdProducer::makeMuon( const reco::Track& track )
-{
+reco::Muon MuonIdProducer::makeMuon(const reco::Track& track) {
   const double energy = hypot(track.p(), 0.105658369);
   const math::XYZTLorentzVector p4(track.px(), track.py(), track.pz(), energy);
-  return reco::Muon( track.charge(), p4, track.vertex() );
+  return reco::Muon(track.charge(), p4, track.vertex());
 }
 
-double MuonIdProducer::sectorPhi( const DetId& id )
-{
+double MuonIdProducer::sectorPhi(const DetId& id) {
   double phi = 0;
-  if( id.subdetId() ==  MuonSubdetId::DT ) {    // DT
+  if (id.subdetId() == MuonSubdetId::DT) {  // DT
     DTChamberId muonId(id.rawId());
-    if ( muonId.sector() <= 12 )
-      phi = (muonId.sector()-1)/6.*M_PI;
-    if ( muonId.sector() == 13 ) phi = 3/6.*M_PI;
-    if ( muonId.sector() == 14 ) phi = 9/6.*M_PI;
+    if (muonId.sector() <= 12)
+      phi = (muonId.sector() - 1) / 6. * M_PI;
+    if (muonId.sector() == 13)
+      phi = 3 / 6. * M_PI;
+    if (muonId.sector() == 14)
+      phi = 9 / 6. * M_PI;
   }
-  if( id.subdetId() == MuonSubdetId::CSC ) {    // CSC
+  if (id.subdetId() == MuonSubdetId::CSC) {  // CSC
     CSCDetId muonId(id.rawId());
-    phi = M_PI/4+(muonId.triggerSector()-1)/3.*M_PI;
+    phi = M_PI / 4 + (muonId.triggerSector() - 1) / 3. * M_PI;
   }
-  if ( phi > M_PI ) phi -= 2*M_PI;
+  if (phi > M_PI)
+    phi -= 2 * M_PI;
   return phi;
 }
 
-double MuonIdProducer::phiOfMuonIneteractionRegion( const reco::Muon& muon ) const
-{
-  if ( muon.isStandAloneMuon() ) return muon.standAloneMuon()->innerPosition().phi();
+double MuonIdProducer::phiOfMuonIneteractionRegion(const reco::Muon& muon) const {
+  if (muon.isStandAloneMuon())
+    return muon.standAloneMuon()->innerPosition().phi();
   // the rest is tracker muon only
-  if ( muon.matches().empty() ) {
-    if ( muon.innerTrack().isAvailable() &&
-         muon.innerTrack()->extra().isAvailable() )
+  if (muon.matches().empty()) {
+    if (muon.innerTrack().isAvailable() && muon.innerTrack()->extra().isAvailable())
       return muon.innerTrack()->outerPosition().phi();
     else
-      return muon.phi(); // makes little sense, but what else can I use
+      return muon.phi();  // makes little sense, but what else can I use
   }
   return sectorPhi(muon.matches().at(0).id);
 }
 
-void MuonIdProducer::fillGlbQuality(edm::Event& iEvent, const edm::EventSetup& iSetup, reco::Muon& aMuon)
-{
-  if(aMuon.isGlobalMuon() && glbQualHandle_.isValid() && !glbQualHandle_.failedToGet()) {
+void MuonIdProducer::fillGlbQuality(edm::Event& iEvent, const edm::EventSetup& iSetup, reco::Muon& aMuon) {
+  if (aMuon.isGlobalMuon() && glbQualHandle_.isValid() && !glbQualHandle_.failedToGet()) {
     aMuon.setCombinedQuality((*glbQualHandle_)[aMuon.combinedMuon()]);
   }
 
   LogDebug("MuonIdentification") << "tkChiVal " << aMuon.combinedQuality().trkRelChi2;
-
 }
 
-void MuonIdProducer::fillTrackerKink( reco::Muon& aMuon ) {
-    // skip muons with no tracks
-    if (aMuon.innerTrack().isNull()) return;
-    // get quality from muon if already there, otherwise make empty one
-    reco::MuonQuality quality = (aMuon.isQualityValid() ? aMuon.combinedQuality() : reco::MuonQuality());
-    // fill it
-    const bool filled = trackerKinkFinder_->fillTrkKink(quality, *aMuon.innerTrack());
-    // if quality was there, or if we filled it, commit to the muon
-    if (filled || aMuon.isQualityValid()) aMuon.setCombinedQuality(quality);
+void MuonIdProducer::fillTrackerKink(reco::Muon& aMuon) {
+  // skip muons with no tracks
+  if (aMuon.innerTrack().isNull())
+    return;
+  // get quality from muon if already there, otherwise make empty one
+  reco::MuonQuality quality = (aMuon.isQualityValid() ? aMuon.combinedQuality() : reco::MuonQuality());
+  // fill it
+  const bool filled = trackerKinkFinder_->fillTrkKink(quality, *aMuon.innerTrack());
+  // if quality was there, or if we filled it, commit to the muon
+  if (filled || aMuon.isQualityValid())
+    aMuon.setCombinedQuality(quality);
 }
 
 bool MuonIdProducer::checkLinks(const reco::MuonTrackLinks* links) const {
   const bool trackBAD = links->trackerTrack().isNull();
   const bool staBAD = links->standAloneTrack().isNull();
   const bool glbBAD = links->globalTrack().isNull();
-  if (trackBAD || staBAD || glbBAD )
-    {
-      edm::LogWarning("muonIDbadLinks") << "Global muon links to constituent tracks are invalid: trkBad "
-					<<trackBAD <<" standaloneBad "<<staBAD<<" globalBad "<<glbBAD
-					<<". There should be no such object. Muon is skipped.";
-      return false;
-    }
+  if (trackBAD || staBAD || glbBAD) {
+    edm::LogWarning("muonIDbadLinks") << "Global muon links to constituent tracks are invalid: trkBad " << trackBAD
+                                      << " standaloneBad " << staBAD << " globalBad " << glbBAD
+                                      << ". There should be no such object. Muon is skipped.";
+    return false;
+  }
   return true;
 }
 
-void MuonIdProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {  
-  edm::ParameterSetDescription desc;  
+void MuonIdProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
   desc.setAllowAnything();
-  
-  desc.add<bool>("arbitrateTrackerMuons",false);
-  desc.add<bool>("storeCrossedHcalRecHits",false);
-  desc.add<bool>("fillShowerDigis",false);
+
+  desc.add<bool>("arbitrateTrackerMuons", false);
+  desc.add<bool>("storeCrossedHcalRecHits", false);
+  desc.add<bool>("fillShowerDigis", false);
 
   edm::ParameterSetDescription descTrkAsoPar;
-  descTrkAsoPar.add<edm::InputTag>("GEMSegmentCollectionLabel",edm::InputTag("gemSegments"));
-  descTrkAsoPar.add<edm::InputTag>("ME0SegmentCollectionLabel",edm::InputTag("me0Segments"));
+  descTrkAsoPar.add<edm::InputTag>("GEMSegmentCollectionLabel", edm::InputTag("gemSegments"));
+  descTrkAsoPar.add<edm::InputTag>("ME0SegmentCollectionLabel", edm::InputTag("me0Segments"));
   descTrkAsoPar.add<bool>("useGEM", false);
   descTrkAsoPar.add<bool>("useME0", false);
   descTrkAsoPar.setAllowAnything();
@@ -1360,11 +1392,11 @@ void MuonIdProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   descJet.setAllowAnything();
   descJet.add<edm::ParameterSetDescription>("TrackAssociatorParameters", descTrkAsoPar);
   desc.add<edm::ParameterSetDescription>("JetExtractorPSet", descJet);
-  
+
   edm::ParameterSetDescription descCalo;
   descCalo.setAllowAnything();
   descCalo.add<edm::ParameterSetDescription>("TrackAssociatorParameters", descTrkAsoPar);
   desc.add<edm::ParameterSetDescription>("CaloExtractorPSet", descCalo);
-  
+
   descriptions.addDefault(desc);
 }

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -5,7 +5,7 @@
 //
 // Package:    MuonIdentification
 // Class:      MuonIdProducer
-// 
+//
 /*
 
  Description: reco::Muon producer that can fill various information:
@@ -22,7 +22,6 @@
 // Original Author:  Dmytro Kovalskyi
 //
 //
-
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -61,197 +60,212 @@
 #include "RecoMuon/MuonIdentification/interface/MuonArbitrationMethods.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 
-
 class MuonMesh;
 class MuonKinkFinder;
 
 class MuonIdProducer : public edm::stream::EDProducer<> {
- public:
-   typedef reco::Muon::MuonTrackType TrackType;
-  
-   explicit MuonIdProducer(const edm::ParameterSet&);
-   
-   ~MuonIdProducer() override;
-   
-   void produce(edm::Event&, const edm::EventSetup&) override;
-   void beginRun(const edm::Run&, const edm::EventSetup&) override;
-   
-   static double sectorPhi( const DetId& id );
+public:
+  typedef reco::Muon::MuonTrackType TrackType;
 
-   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-   
- private:
-   void          fillMuonId( edm::Event&, const edm::EventSetup&, reco::Muon&, 
-			     TrackDetectorAssociator::Direction direction = TrackDetectorAssociator::InsideOut );
-   void          fillArbitrationInfo( reco::MuonCollection*, unsigned int muonType = reco::Muon::TrackerMuon );
-   void          arbitrateMuons( reco::MuonCollection*, reco::CaloMuonCollection* );
-   void          fillMuonIsolation( edm::Event&, const edm::EventSetup&, reco::Muon& aMuon,
-				    reco::IsoDeposit& trackDep, reco::IsoDeposit& ecalDep, reco::IsoDeposit& hcalDep, reco::IsoDeposit& hoDep,
-				    reco::IsoDeposit& jetDep);
-   void          fillGlbQuality( edm::Event&, const edm::EventSetup&, reco::Muon& aMuon );
-   void          fillTrackerKink( reco::Muon& aMuon ); 
-   void          init( edm::Event&, const edm::EventSetup& );
-   
-   // make a muon based on a track ref
-   reco::Muon    makeMuon( edm::Event& iEvent, const edm::EventSetup& iSetup, 
-			   const reco::TrackRef& track, TrackType type);
-   // make a global muon based on the links object
-   reco::Muon    makeMuon( const reco::MuonTrackLinks& links );
-   
-   // make a muon based on track (p4)
-   reco::Muon    makeMuon( const reco::Track& track );
-   
-   reco::CaloMuon makeCaloMuon( const reco::Muon& );
+  explicit MuonIdProducer(const edm::ParameterSet&);
 
-   // check if a silicon track satisfies the trackerMuon requirements
-   bool          isGoodTrack( const reco::Track& track );
-   
-   bool          isGoodTrackerMuon( const reco::Muon& muon );
-   bool          isGoodCaloMuon( const reco::CaloMuon& muon );
-   bool          isGoodRPCMuon( const reco::Muon& muon );
-   bool          isGoodGEMMuon( const reco::Muon& muon );
-   bool          isGoodME0Muon( const reco::Muon& muon );
-   
-   // check number of common DetIds for a given trackerMuon and a stand alone
-   // muon track
-   int           overlap(const reco::Muon& muon, const reco::Track& track);
+  ~MuonIdProducer() override;
 
-   unsigned int  chamberId(const DetId&);
-   
-   double phiOfMuonIneteractionRegion( const reco::Muon& muon ) const;
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void beginRun(const edm::Run&, const edm::EventSetup&) override;
 
-   bool checkLinks(const reco::MuonTrackLinks*) const ;
-   inline bool approxEqual(const double a, const double b, const double tol=1E-3) const
-   {
-     return std::abs(a-b) < tol;
-   }
+  static double sectorPhi(const DetId& id);
 
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-   /// get the segment matches of the appropriate type
-   std::vector<reco::MuonSegmentMatch> * getSegmentMatches(reco::MuonChamberMatch & chamber, unsigned int muonType) const {
-       if      (muonType == reco::Muon::TrackerMuon) return & chamber.segmentMatches;
-       else if (muonType == reco::Muon::ME0Muon)     return & chamber.me0Matches;
-       else if (muonType == reco::Muon::GEMMuon)     return & chamber.gemMatches;
-       else throw cms::Exception("getSegmentMatches called with unsupported muonType");
-   }
-     
-   TrackDetectorAssociator trackAssociator_;
-   TrackAssociatorParameters parameters_;
+private:
+  void fillMuonId(edm::Event&,
+                  const edm::EventSetup&,
+                  reco::Muon&,
+                  TrackDetectorAssociator::Direction direction = TrackDetectorAssociator::InsideOut);
+  void fillArbitrationInfo(reco::MuonCollection*, unsigned int muonType = reco::Muon::TrackerMuon);
+  void arbitrateMuons(reco::MuonCollection*, reco::CaloMuonCollection*);
+  void fillMuonIsolation(edm::Event&,
+                         const edm::EventSetup&,
+                         reco::Muon& aMuon,
+                         reco::IsoDeposit& trackDep,
+                         reco::IsoDeposit& ecalDep,
+                         reco::IsoDeposit& hcalDep,
+                         reco::IsoDeposit& hoDep,
+                         reco::IsoDeposit& jetDep);
+  void fillGlbQuality(edm::Event&, const edm::EventSetup&, reco::Muon& aMuon);
+  void fillTrackerKink(reco::Muon& aMuon);
+  void init(edm::Event&, const edm::EventSetup&);
 
-   struct ICTypes
-   {
-     enum ICTypeKey {
-       INNER_TRACKS, OUTER_TRACKS,
-       LINKS, MUONS,
-       TEV_FIRSTHIT, TEV_PICKY, TEV_DYT,
-       NONE
-     };
+  // make a muon based on a track ref
+  reco::Muon makeMuon(edm::Event& iEvent, const edm::EventSetup& iSetup, const reco::TrackRef& track, TrackType type);
+  // make a global muon based on the links object
+  reco::Muon makeMuon(const reco::MuonTrackLinks& links);
 
-     static ICTypeKey toKey(const std::string& s) {
-       if      ( s == "inner tracks" ) return INNER_TRACKS;
-       else if ( s == "outer tracks" ) return OUTER_TRACKS;
-       else if ( s == "links" ) return LINKS;
-       else if ( s == "muons" ) return MUONS;
-       else if ( s == "tev firstHit" ) return TEV_FIRSTHIT;
-       else if ( s == "tev picky"    ) return TEV_PICKY   ;
-       else if ( s == "tev dyt"      ) return TEV_DYT     ;
+  // make a muon based on track (p4)
+  reco::Muon makeMuon(const reco::Track& track);
 
-       throw cms::Exception("FatalError") << "Unknown input collection type: " << s;
-     }
+  reco::CaloMuon makeCaloMuon(const reco::Muon&);
 
-     static std::string toStr(const ICTypeKey k) {
-       switch ( k ) {
-         case INNER_TRACKS: return "inner tracks";
-         case OUTER_TRACKS: return "outer tracks";
-         case LINKS       : return "links"       ;
-         case MUONS       : return "muons"       ;
-         case TEV_FIRSTHIT: return "tev firstHit";
-         case TEV_PICKY   : return "tev picky"   ;
-         case TEV_DYT     : return "tev dyt"     ;
-         default: throw cms::Exception("FatalError") << "Unknown input collection type";
-       }
-       return "";
-     }
-   };
-   std::vector<edm::InputTag> inputCollectionLabels_;
-   std::vector<ICTypes::ICTypeKey> inputCollectionTypes_;
+  // check if a silicon track satisfies the trackerMuon requirements
+  bool isGoodTrack(const reco::Track& track);
+
+  bool isGoodTrackerMuon(const reco::Muon& muon);
+  bool isGoodCaloMuon(const reco::CaloMuon& muon);
+  bool isGoodRPCMuon(const reco::Muon& muon);
+  bool isGoodGEMMuon(const reco::Muon& muon);
+  bool isGoodME0Muon(const reco::Muon& muon);
+
+  // check number of common DetIds for a given trackerMuon and a stand alone
+  // muon track
+  int overlap(const reco::Muon& muon, const reco::Track& track);
+
+  unsigned int chamberId(const DetId&);
+
+  double phiOfMuonIneteractionRegion(const reco::Muon& muon) const;
+
+  bool checkLinks(const reco::MuonTrackLinks*) const;
+  inline bool approxEqual(const double a, const double b, const double tol = 1E-3) const {
+    return std::abs(a - b) < tol;
+  }
+
+  /// get the segment matches of the appropriate type
+  std::vector<reco::MuonSegmentMatch>* getSegmentMatches(reco::MuonChamberMatch& chamber, unsigned int muonType) const {
+    if (muonType == reco::Muon::TrackerMuon)
+      return &chamber.segmentMatches;
+    else if (muonType == reco::Muon::ME0Muon)
+      return &chamber.me0Matches;
+    else if (muonType == reco::Muon::GEMMuon)
+      return &chamber.gemMatches;
+    else
+      throw cms::Exception("getSegmentMatches called with unsupported muonType");
+  }
+
+  TrackDetectorAssociator trackAssociator_;
+  TrackAssociatorParameters parameters_;
+
+  struct ICTypes {
+    enum ICTypeKey { INNER_TRACKS, OUTER_TRACKS, LINKS, MUONS, TEV_FIRSTHIT, TEV_PICKY, TEV_DYT, NONE };
+
+    static ICTypeKey toKey(const std::string& s) {
+      if (s == "inner tracks")
+        return INNER_TRACKS;
+      else if (s == "outer tracks")
+        return OUTER_TRACKS;
+      else if (s == "links")
+        return LINKS;
+      else if (s == "muons")
+        return MUONS;
+      else if (s == "tev firstHit")
+        return TEV_FIRSTHIT;
+      else if (s == "tev picky")
+        return TEV_PICKY;
+      else if (s == "tev dyt")
+        return TEV_DYT;
+
+      throw cms::Exception("FatalError") << "Unknown input collection type: " << s;
+    }
+
+    static std::string toStr(const ICTypeKey k) {
+      switch (k) {
+        case INNER_TRACKS:
+          return "inner tracks";
+        case OUTER_TRACKS:
+          return "outer tracks";
+        case LINKS:
+          return "links";
+        case MUONS:
+          return "muons";
+        case TEV_FIRSTHIT:
+          return "tev firstHit";
+        case TEV_PICKY:
+          return "tev picky";
+        case TEV_DYT:
+          return "tev dyt";
+        default:
+          throw cms::Exception("FatalError") << "Unknown input collection type";
+      }
+      return "";
+    }
+  };
+  std::vector<edm::InputTag> inputCollectionLabels_;
+  std::vector<ICTypes::ICTypeKey> inputCollectionTypes_;
 
   std::unique_ptr<MuonTimingFiller> theTimingFiller_;
 
   std::unique_ptr<MuonShowerDigiFiller> theShowerDigiFiller_;
 
-   // selections
-   double minPt_;
-   double minP_;
-   double minPCaloMuon_;
-   int    minNumberOfMatches_;
-   double maxAbsEta_;
-   bool   addExtraSoftMuons_;
-   
-   // matching
-   double maxAbsDx_;
-   double maxAbsPullX_;
-   double maxAbsDy_;
-   double maxAbsPullY_;
-   
-   // what information to fill
-   bool fillCaloCompatibility_;
-   bool fillEnergy_;
-   bool storeCrossedHcalRecHits_;
-   bool fillMatching_;
-   bool fillShowerDigis_;
-   bool fillIsolation_;
-   bool writeIsoDeposits_;
-   double ptThresholdToFillCandidateP4WithGlobalFit_;
-   double sigmaThresholdToFillCandidateP4WithGlobalFit_;
-   
-   bool arbitrateTrackerMuons_;
+  // selections
+  double minPt_;
+  double minP_;
+  double minPCaloMuon_;
+  int minNumberOfMatches_;
+  double maxAbsEta_;
+  bool addExtraSoftMuons_;
 
-   bool debugWithTruthMatching_;
+  // matching
+  double maxAbsDx_;
+  double maxAbsPullX_;
+  double maxAbsDy_;
+  double maxAbsPullY_;
 
-   edm::Handle<reco::TrackCollection>             innerTrackCollectionHandle_;
-   edm::Handle<reco::TrackCollection>             outerTrackCollectionHandle_;
-   edm::Handle<reco::MuonCollection>              muonCollectionHandle_;
-   edm::Handle<reco::MuonTrackLinksCollection>    linkCollectionHandle_;
-   edm::Handle<reco::TrackToTrackMap>             tpfmsCollectionHandle_;
-   edm::Handle<reco::TrackToTrackMap>             pickyCollectionHandle_;
-   edm::Handle<reco::TrackToTrackMap>             dytCollectionHandle_;
+  // what information to fill
+  bool fillCaloCompatibility_;
+  bool fillEnergy_;
+  bool storeCrossedHcalRecHits_;
+  bool fillMatching_;
+  bool fillShowerDigis_;
+  bool fillIsolation_;
+  bool writeIsoDeposits_;
+  double ptThresholdToFillCandidateP4WithGlobalFit_;
+  double sigmaThresholdToFillCandidateP4WithGlobalFit_;
 
-   edm::EDGetTokenT<reco::TrackCollection>             innerTrackCollectionToken_;
-   edm::EDGetTokenT<reco::TrackCollection>             outerTrackCollectionToken_;
-   edm::EDGetTokenT<reco::MuonCollection>              muonCollectionToken_;
-   edm::EDGetTokenT<reco::MuonTrackLinksCollection>    linkCollectionToken_;
-   edm::EDGetTokenT<reco::TrackToTrackMap>             tpfmsCollectionToken_;
-   edm::EDGetTokenT<reco::TrackToTrackMap>             pickyCollectionToken_;
-   edm::EDGetTokenT<reco::TrackToTrackMap>             dytCollectionToken_;
+  bool arbitrateTrackerMuons_;
 
-   edm::EDGetTokenT<RPCRecHitCollection> rpcHitToken_;
-   edm::EDGetTokenT<edm::ValueMap<reco::MuonQuality> > glbQualToken_;
+  bool debugWithTruthMatching_;
 
-   edm::Handle<RPCRecHitCollection> rpcHitHandle_;
-   edm::Handle<edm::ValueMap<reco::MuonQuality> > glbQualHandle_;
-   
-   MuonCaloCompatibility muonCaloCompatibility_;
-   std::unique_ptr<reco::isodeposit::IsoDepositExtractor> muIsoExtractorCalo_;
-   std::unique_ptr<reco::isodeposit::IsoDepositExtractor> muIsoExtractorTrack_;
-   std::unique_ptr<reco::isodeposit::IsoDepositExtractor> muIsoExtractorJet_;
-   std::string trackDepositName_;
-   std::string ecalDepositName_;
-   std::string hcalDepositName_;
-   std::string hoDepositName_;
-   std::string jetDepositName_;
+  edm::Handle<reco::TrackCollection> innerTrackCollectionHandle_;
+  edm::Handle<reco::TrackCollection> outerTrackCollectionHandle_;
+  edm::Handle<reco::MuonCollection> muonCollectionHandle_;
+  edm::Handle<reco::MuonTrackLinksCollection> linkCollectionHandle_;
+  edm::Handle<reco::TrackToTrackMap> tpfmsCollectionHandle_;
+  edm::Handle<reco::TrackToTrackMap> pickyCollectionHandle_;
+  edm::Handle<reco::TrackToTrackMap> dytCollectionHandle_;
 
-   bool          fillGlobalTrackQuality_;
-   bool          fillGlobalTrackRefits_ ;
-   edm::InputTag globalTrackQualityInputTag_;
+  edm::EDGetTokenT<reco::TrackCollection> innerTrackCollectionToken_;
+  edm::EDGetTokenT<reco::TrackCollection> outerTrackCollectionToken_;
+  edm::EDGetTokenT<reco::MuonCollection> muonCollectionToken_;
+  edm::EDGetTokenT<reco::MuonTrackLinksCollection> linkCollectionToken_;
+  edm::EDGetTokenT<reco::TrackToTrackMap> tpfmsCollectionToken_;
+  edm::EDGetTokenT<reco::TrackToTrackMap> pickyCollectionToken_;
+  edm::EDGetTokenT<reco::TrackToTrackMap> dytCollectionToken_;
 
-   bool fillTrackerKink_;
-   std::unique_ptr<MuonKinkFinder> trackerKinkFinder_;
+  edm::EDGetTokenT<RPCRecHitCollection> rpcHitToken_;
+  edm::EDGetTokenT<edm::ValueMap<reco::MuonQuality> > glbQualToken_;
 
-   double caloCut_;
-   
-   bool arbClean_;
-   std::unique_ptr<MuonMesh> meshAlgo_;
+  edm::Handle<RPCRecHitCollection> rpcHitHandle_;
+  edm::Handle<edm::ValueMap<reco::MuonQuality> > glbQualHandle_;
 
+  MuonCaloCompatibility muonCaloCompatibility_;
+  std::unique_ptr<reco::isodeposit::IsoDepositExtractor> muIsoExtractorCalo_;
+  std::unique_ptr<reco::isodeposit::IsoDepositExtractor> muIsoExtractorTrack_;
+  std::unique_ptr<reco::isodeposit::IsoDepositExtractor> muIsoExtractorJet_;
+  std::string trackDepositName_;
+  std::string ecalDepositName_;
+  std::string hcalDepositName_;
+  std::string hoDepositName_;
+  std::string jetDepositName_;
+
+  bool fillGlobalTrackQuality_;
+  bool fillGlobalTrackRefits_;
+  edm::InputTag globalTrackQualityInputTag_;
+
+  bool fillTrackerKink_;
+  std::unique_ptr<MuonKinkFinder> trackerKinkFinder_;
+
+  double caloCut_;
+
+  bool arbClean_;
+  std::unique_ptr<MuonMesh> meshAlgo_;
 };
 #endif

--- a/RecoMuon/MuonIdentification/plugins/MuonLinksProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonLinksProducer.cc
@@ -2,12 +2,11 @@
 //
 // Package:    MuonIdentification
 // Class:      MuonLinksProducer
-// 
+//
 //
 // Original Author:  Dmytro Kovalskyi
 //
 //
-
 
 // system include files
 #include <memory>
@@ -28,28 +27,23 @@
 
 #include <algorithm>
 
-MuonLinksProducer::MuonLinksProducer(const edm::ParameterSet& iConfig)
-{
-   produces<reco::MuonTrackLinksCollection>();
-   m_inputCollection = iConfig.getParameter<edm::InputTag>("inputCollection");
-   muonToken_ = consumes<reco::MuonCollection>(m_inputCollection);
+MuonLinksProducer::MuonLinksProducer(const edm::ParameterSet& iConfig) {
+  produces<reco::MuonTrackLinksCollection>();
+  m_inputCollection = iConfig.getParameter<edm::InputTag>("inputCollection");
+  muonToken_ = consumes<reco::MuonCollection>(m_inputCollection);
 }
 
-MuonLinksProducer::~MuonLinksProducer()
-{
-}
+MuonLinksProducer::~MuonLinksProducer() {}
 
-void MuonLinksProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
-{
-   auto output = std::make_unique<reco::MuonTrackLinksCollection>();
-   edm::Handle<reco::MuonCollection> muons; 
-   iEvent.getByToken(muonToken_,muons);
-   
-   for ( reco::MuonCollection::const_iterator muon = muons->begin(); 
-	 muon != muons->end(); ++muon )
-     {
-	if ( ! muon->isGlobalMuon() ) continue;
-	output->push_back( reco::MuonTrackLinks( muon->track(), muon->standAloneMuon(), muon->combinedMuon() ) );
-     }
-   iEvent.put(std::move(output));
+void MuonLinksProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  auto output = std::make_unique<reco::MuonTrackLinksCollection>();
+  edm::Handle<reco::MuonCollection> muons;
+  iEvent.getByToken(muonToken_, muons);
+
+  for (reco::MuonCollection::const_iterator muon = muons->begin(); muon != muons->end(); ++muon) {
+    if (!muon->isGlobalMuon())
+      continue;
+    output->push_back(reco::MuonTrackLinks(muon->track(), muon->standAloneMuon(), muon->combinedMuon()));
+  }
+  iEvent.put(std::move(output));
 }

--- a/RecoMuon/MuonIdentification/plugins/MuonLinksProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonLinksProducer.h
@@ -5,7 +5,7 @@
 //
 // Package:    MuonIdentification
 // Class:      MuonLinksProducer
-// 
+//
 /*
  Simple producer to make reco::MuonTrackLinks collection 
  out of the global muons from "muons" collection to restore
@@ -16,7 +16,6 @@
 //
 //
 
-
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
@@ -26,16 +25,15 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 
 class MuonLinksProducer : public edm::global::EDProducer<> {
- public:
-   explicit MuonLinksProducer(const edm::ParameterSet&);
-   
-   ~MuonLinksProducer() override;
-   
-   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
-   
- private:
-   edm::InputTag m_inputCollection;
-   edm::EDGetTokenT<reco::MuonCollection> muonToken_; 
+public:
+  explicit MuonLinksProducer(const edm::ParameterSet&);
 
+  ~MuonLinksProducer() override;
+
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
+private:
+  edm::InputTag m_inputCollection;
+  edm::EDGetTokenT<reco::MuonCollection> muonToken_;
 };
 #endif

--- a/RecoMuon/MuonIdentification/plugins/MuonLinksProducerForHLT.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonLinksProducerForHLT.cc
@@ -3,7 +3,6 @@
  *  \author R. Bellan - UCSB <riccardo.bellan@cern.ch>
  */
 
-
 // system include files
 #include <memory>
 
@@ -20,73 +19,66 @@
 
 //#include <algorithm>
 
-MuonLinksProducerForHLT::MuonLinksProducerForHLT(const edm::ParameterSet& iConfig)
-{
-   produces<reco::MuonTrackLinksCollection>();
-   theLinkCollectionInInput = iConfig.getParameter<edm::InputTag>("LinkCollection");
-   theInclusiveTrackCollectionInInput = iConfig.getParameter<edm::InputTag>("InclusiveTrackerTrackCollection");
-   ptMin = iConfig.getParameter<double>("ptMin");
-   pMin = iConfig.getParameter<double>("pMin");
-   shareHitFraction = iConfig.getParameter<double>("shareHitFraction");
+MuonLinksProducerForHLT::MuonLinksProducerForHLT(const edm::ParameterSet& iConfig) {
+  produces<reco::MuonTrackLinksCollection>();
+  theLinkCollectionInInput = iConfig.getParameter<edm::InputTag>("LinkCollection");
+  theInclusiveTrackCollectionInInput = iConfig.getParameter<edm::InputTag>("InclusiveTrackerTrackCollection");
+  ptMin = iConfig.getParameter<double>("ptMin");
+  pMin = iConfig.getParameter<double>("pMin");
+  shareHitFraction = iConfig.getParameter<double>("shareHitFraction");
 
-   linkToken_ = consumes<reco::MuonTrackLinksCollection>(theLinkCollectionInInput);
-   trackToken_ = consumes<reco::TrackCollection>(theInclusiveTrackCollectionInInput);
-   
+  linkToken_ = consumes<reco::MuonTrackLinksCollection>(theLinkCollectionInInput);
+  trackToken_ = consumes<reco::TrackCollection>(theInclusiveTrackCollectionInInput);
 }
 
-MuonLinksProducerForHLT::~MuonLinksProducerForHLT()
-{
-}
+MuonLinksProducerForHLT::~MuonLinksProducerForHLT() {}
 
-void MuonLinksProducerForHLT::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
-{
-   auto output = std::make_unique<reco::MuonTrackLinksCollection>();
+void MuonLinksProducerForHLT::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  auto output = std::make_unique<reco::MuonTrackLinksCollection>();
 
-   edm::Handle<reco::MuonTrackLinksCollection> links; 
-   iEvent.getByToken(linkToken_, links);
+  edm::Handle<reco::MuonTrackLinksCollection> links;
+  iEvent.getByToken(linkToken_, links);
 
-   edm::Handle<reco::TrackCollection> incTracks; 
-   iEvent.getByToken(trackToken_, incTracks);
+  edm::Handle<reco::TrackCollection> incTracks;
+  iEvent.getByToken(trackToken_, incTracks);
 
-   for(reco::MuonTrackLinksCollection::const_iterator link = links->begin(); 
-       link != links->end(); ++link){
-     bool found = false;
-     unsigned int trackIndex = 0;
-     unsigned int muonTrackHits = link->trackerTrack()->extra()->recHitsSize();
-     for(reco::TrackCollection::const_iterator track = incTracks->begin();
-	 track != incTracks->end(); ++track, ++trackIndex){      
-       if ( track->pt() < ptMin ) continue;
-       if ( track->p() < pMin ) continue;
-       //std::cout << "pt (muon/track) " << link->trackerTrack()->pt() << " " << track->pt() << std::endl;
-       unsigned trackHits = track->extra()->recHitsSize();
-       //std::cout << "hits (muon/track) " << muonTrackHits  << " " << trackHits() << std::endl;
-       unsigned int smallestNumberOfHits = trackHits < muonTrackHits ? trackHits : muonTrackHits;
-       int numberOfCommonDetIds = 0;
-       for ( auto hit = track->extra()->recHitsBegin();
-	     hit != track->extra()->recHitsEnd(); ++hit ) {
-	 for ( auto mit = link->trackerTrack()->extra()->recHitsBegin();
-	     mit != link->trackerTrack()->extra()->recHitsEnd(); ++mit ) {
-	   if ( (*hit)->geographicalId() == (*mit)->geographicalId() && 
-		(*hit)->sharesInput((*mit),TrackingRecHit::some) ) { 
-	     numberOfCommonDetIds++;
-	     break;
-	   }
-	 }
-       }
-       double fraction = (double)numberOfCommonDetIds/smallestNumberOfHits;
-       // std::cout << "Overlap/Smallest/fraction = " << numberOfCommonDetIds << " " << smallestNumberOfHits << " " << fraction << std::endl;
-       if( fraction > shareHitFraction ) { 
-	 output->push_back(reco::MuonTrackLinks(reco::TrackRef(incTracks,trackIndex), 
-						link->standAloneTrack(), 
-						link->globalTrack() ) );
-	 found = true;
-	 break;
-       }
-     }
-     if (!found) 
-       output->push_back(reco::MuonTrackLinks(link->trackerTrack(), 
-					      link->standAloneTrack(), 
-					      link->globalTrack() ) );
-   }  
-   iEvent.put(std::move(output));
+  for (reco::MuonTrackLinksCollection::const_iterator link = links->begin(); link != links->end(); ++link) {
+    bool found = false;
+    unsigned int trackIndex = 0;
+    unsigned int muonTrackHits = link->trackerTrack()->extra()->recHitsSize();
+    for (reco::TrackCollection::const_iterator track = incTracks->begin(); track != incTracks->end();
+         ++track, ++trackIndex) {
+      if (track->pt() < ptMin)
+        continue;
+      if (track->p() < pMin)
+        continue;
+      //std::cout << "pt (muon/track) " << link->trackerTrack()->pt() << " " << track->pt() << std::endl;
+      unsigned trackHits = track->extra()->recHitsSize();
+      //std::cout << "hits (muon/track) " << muonTrackHits  << " " << trackHits() << std::endl;
+      unsigned int smallestNumberOfHits = trackHits < muonTrackHits ? trackHits : muonTrackHits;
+      int numberOfCommonDetIds = 0;
+      for (auto hit = track->extra()->recHitsBegin(); hit != track->extra()->recHitsEnd(); ++hit) {
+        for (auto mit = link->trackerTrack()->extra()->recHitsBegin();
+             mit != link->trackerTrack()->extra()->recHitsEnd();
+             ++mit) {
+          if ((*hit)->geographicalId() == (*mit)->geographicalId() &&
+              (*hit)->sharesInput((*mit), TrackingRecHit::some)) {
+            numberOfCommonDetIds++;
+            break;
+          }
+        }
+      }
+      double fraction = (double)numberOfCommonDetIds / smallestNumberOfHits;
+      // std::cout << "Overlap/Smallest/fraction = " << numberOfCommonDetIds << " " << smallestNumberOfHits << " " << fraction << std::endl;
+      if (fraction > shareHitFraction) {
+        output->push_back(
+            reco::MuonTrackLinks(reco::TrackRef(incTracks, trackIndex), link->standAloneTrack(), link->globalTrack()));
+        found = true;
+        break;
+      }
+    }
+    if (!found)
+      output->push_back(reco::MuonTrackLinks(link->trackerTrack(), link->standAloneTrack(), link->globalTrack()));
+  }
+  iEvent.put(std::move(output));
 }

--- a/RecoMuon/MuonIdentification/plugins/MuonLinksProducerForHLT.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonLinksProducerForHLT.h
@@ -10,7 +10,6 @@
  *  \author R. Bellan - UCSB <riccardo.bellan@cern.ch>
  */
 
-
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/global/EDProducer.h"
@@ -23,20 +22,20 @@
 #include "DataFormats/MuonReco/interface/MuonTrackLinks.h"
 
 class MuonLinksProducerForHLT : public edm::global::EDProducer<> {
- public:
-   explicit MuonLinksProducerForHLT(const edm::ParameterSet&);
-   
-   ~MuonLinksProducerForHLT() override;
-   
-   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+public:
+  explicit MuonLinksProducerForHLT(const edm::ParameterSet&);
 
- private:
-   edm::InputTag theLinkCollectionInInput;
-   edm::InputTag theInclusiveTrackCollectionInInput;
-   edm::EDGetTokenT<reco::MuonTrackLinksCollection> linkToken_;
-   edm::EDGetTokenT<reco::TrackCollection> trackToken_;
-   double ptMin;
-   double pMin;
-   double shareHitFraction;
+  ~MuonLinksProducerForHLT() override;
+
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
+private:
+  edm::InputTag theLinkCollectionInInput;
+  edm::InputTag theInclusiveTrackCollectionInInput;
+  edm::EDGetTokenT<reco::MuonTrackLinksCollection> linkToken_;
+  edm::EDGetTokenT<reco::TrackCollection> trackToken_;
+  double ptMin;
+  double pMin;
+  double shareHitFraction;
 };
 #endif

--- a/RecoMuon/MuonIdentification/plugins/MuonProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonProducer.cc
@@ -11,59 +11,56 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
-
 #ifndef dout
-#define dout if(debug_) std::cout
+#define dout  \
+  if (debug_) \
+  std::cout
 #endif
 
 using std::endl;
 
 typedef std::map<reco::MuonRef, unsigned int> MuToPFMap;
 
-
 namespace reco {
   typedef edm::ValueMap<reco::MuonShower> MuonShowerMap;
 }
 
-
 /// Constructor
-MuonProducer::MuonProducer(const edm::ParameterSet& pSet):debug_(pSet.getUntrackedParameter<bool>("ActivateDebug",false)){
-  
+MuonProducer::MuonProducer(const edm::ParameterSet& pSet)
+    : debug_(pSet.getUntrackedParameter<bool>("ActivateDebug", false)) {
   setAlias(pSet.getParameter<std::string>("@module_label"));
-  
-  fastLabelling_ = pSet.getUntrackedParameter<bool>("FastLabelling",true);
 
-  
+  fastLabelling_ = pSet.getUntrackedParameter<bool>("FastLabelling", true);
+
   theMuonsCollectionLabel = pSet.getParameter<edm::InputTag>("InputMuons");
   theMuonsCollectionToken_ = consumes<reco::MuonCollection>(theMuonsCollectionLabel);
 
   thePFCandLabel = pSet.getParameter<edm::InputTag>("PFCandidates");
   thePFCandToken_ = consumes<reco::PFCandidateCollection>(thePFCandLabel);
-  
+
   // Variables to switch on-off the differnt parts
-  fillSelectors_              = pSet.getParameter<bool>("FillSelectorMaps");
-  fillCosmicsIdMap_           = pSet.getParameter<bool>("FillCosmicsIdMap");
-  fillPFMomentum_             = pSet.getParameter<bool>("FillPFMomentumAndAssociation");
-  fillPFIsolation_            = pSet.getParameter<bool>("FillPFIsolation");
-  fillDetectorBasedIsolation_ = pSet.getParameter<bool>("FillDetectorBasedIsolation"); 
-  fillShoweringInfo_          = pSet.getParameter<bool>("FillShoweringInfo");
-  fillTimingInfo_             = pSet.getParameter<bool>("FillTimingInfo");
-  computeStandardSelectors_   = pSet.getParameter<bool>("ComputeStandardSelectors");
+  fillSelectors_ = pSet.getParameter<bool>("FillSelectorMaps");
+  fillCosmicsIdMap_ = pSet.getParameter<bool>("FillCosmicsIdMap");
+  fillPFMomentum_ = pSet.getParameter<bool>("FillPFMomentumAndAssociation");
+  fillPFIsolation_ = pSet.getParameter<bool>("FillPFIsolation");
+  fillDetectorBasedIsolation_ = pSet.getParameter<bool>("FillDetectorBasedIsolation");
+  fillShoweringInfo_ = pSet.getParameter<bool>("FillShoweringInfo");
+  fillTimingInfo_ = pSet.getParameter<bool>("FillTimingInfo");
+  computeStandardSelectors_ = pSet.getParameter<bool>("ComputeStandardSelectors");
 
   produces<reco::MuonCollection>();
 
-  if(fillTimingInfo_){
-
-    timeMapCmbToken_= consumes<reco::MuonTimeExtraMap>(edm::InputTag(theMuonsCollectionLabel.label(),"combined")) ;
-    timeMapDTToken_ = consumes<reco::MuonTimeExtraMap>(edm::InputTag(theMuonsCollectionLabel.label(),"dt")) ;
-    timeMapCSCToken_= consumes<reco::MuonTimeExtraMap>(edm::InputTag(theMuonsCollectionLabel.label(),"csc")) ;
+  if (fillTimingInfo_) {
+    timeMapCmbToken_ = consumes<reco::MuonTimeExtraMap>(edm::InputTag(theMuonsCollectionLabel.label(), "combined"));
+    timeMapDTToken_ = consumes<reco::MuonTimeExtraMap>(edm::InputTag(theMuonsCollectionLabel.label(), "dt"));
+    timeMapCSCToken_ = consumes<reco::MuonTimeExtraMap>(edm::InputTag(theMuonsCollectionLabel.label(), "csc"));
 
     produces<reco::MuonTimeExtraMap>("combined");
     produces<reco::MuonTimeExtraMap>("dt");
     produces<reco::MuonTimeExtraMap>("csc");
   }
-  
-  if (fillDetectorBasedIsolation_){
+
+  if (fillDetectorBasedIsolation_) {
     theTrackDepositName = pSet.getParameter<edm::InputTag>("TrackIsoDeposits");
     theTrackDepositToken_ = consumes<reco::IsoDepositMap>(theTrackDepositName);
     produces<reco::IsoDepositMap>(labelOrInstance(theTrackDepositName));
@@ -85,44 +82,39 @@ MuonProducer::MuonProducer(const edm::ParameterSet& pSet):debug_(pSet.getUntrack
 
     produces<reco::IsoDepositMap>(theHoDepositName.instance());
   }
-  
-  if(fillSelectors_){
+
+  if (fillSelectors_) {
     theSelectorMapNames = pSet.getParameter<InputTags>("SelectorMaps");
-    
-    for(InputTags::const_iterator tag = theSelectorMapNames.begin(); tag != theSelectorMapNames.end(); ++tag) {
-      theSelectorMapTokens_.push_back(consumes<edm::ValueMap<bool> >(*tag));
-      produces<edm::ValueMap<bool> >(labelOrInstance(*tag));
+
+    for (InputTags::const_iterator tag = theSelectorMapNames.begin(); tag != theSelectorMapNames.end(); ++tag) {
+      theSelectorMapTokens_.push_back(consumes<edm::ValueMap<bool>>(*tag));
+      produces<edm::ValueMap<bool>>(labelOrInstance(*tag));
     }
-  
   }
 
-  if(fillShoweringInfo_){
+  if (fillShoweringInfo_) {
     theShowerMapName = pSet.getParameter<edm::InputTag>("ShowerInfoMap");
     theShowerMapToken_ = consumes<reco::MuonShowerMap>(theShowerMapName);
-    produces<edm::ValueMap<reco::MuonShower> >(labelOrInstance(theShowerMapName));
+    produces<edm::ValueMap<reco::MuonShower>>(labelOrInstance(theShowerMapName));
   }
-  
-  if(fillCosmicsIdMap_){
+
+  if (fillCosmicsIdMap_) {
     theCosmicCompMapName = pSet.getParameter<edm::InputTag>("CosmicIdMap");
-    theCosmicIdMapToken_ = consumes<edm::ValueMap<unsigned int> >(theCosmicCompMapName);
-    theCosmicCompMapToken_ = consumes<edm::ValueMap<reco::MuonCosmicCompatibility> >(theCosmicCompMapName);
+    theCosmicIdMapToken_ = consumes<edm::ValueMap<unsigned int>>(theCosmicCompMapName);
+    theCosmicCompMapToken_ = consumes<edm::ValueMap<reco::MuonCosmicCompatibility>>(theCosmicCompMapName);
 
-    produces<edm::ValueMap<reco::MuonCosmicCompatibility> >(labelOrInstance(theCosmicCompMapName));
-    produces<edm::ValueMap<unsigned int> >(labelOrInstance(theCosmicCompMapName));
+    produces<edm::ValueMap<reco::MuonCosmicCompatibility>>(labelOrInstance(theCosmicCompMapName));
+    produces<edm::ValueMap<unsigned int>>(labelOrInstance(theCosmicCompMapName));
   }
-  
-  theMuToMuMapName = theMuonsCollectionLabel.label()+"2"+theAlias+"sMap";
-  produces<edm::ValueMap<reco::MuonRef> >(theMuToMuMapName);
 
+  theMuToMuMapName = theMuonsCollectionLabel.label() + "2" + theAlias + "sMap";
+  produces<edm::ValueMap<reco::MuonRef>>(theMuToMuMapName);
 
-
-  
-  if(fillPFIsolation_){
-    
-    edm::ParameterSet pfIsoPSet = pSet.getParameter<edm::ParameterSet >("PFIsolation");
+  if (fillPFIsolation_) {
+    edm::ParameterSet pfIsoPSet = pSet.getParameter<edm::ParameterSet>("PFIsolation");
 
     //Define a map between the isolation and the PSet for the PFHelper
-    std::map<std::string,edm::ParameterSet> psetMap;
+    std::map<std::string, edm::ParameterSet> psetMap;
 
     //First declare what isolation you are going to read
     std::vector<std::string> isolationLabels;
@@ -134,389 +126,378 @@ MuonProducer::MuonProducer(const edm::ParameterSet& pSet):debug_(pSet.getUntrack
     isolationLabels.push_back("pfIsoSumDRProfileR04");
 
     //Fill the label,pet map and initialize MuPFIsoHelper
-    for( std::vector<std::string>::const_iterator label = isolationLabels.begin();label != isolationLabels.end();++label)
-      psetMap[*label] =pfIsoPSet.getParameter<edm::ParameterSet >(*label); 
+    for (std::vector<std::string>::const_iterator label = isolationLabels.begin(); label != isolationLabels.end();
+         ++label)
+      psetMap[*label] = pfIsoPSet.getParameter<edm::ParameterSet>(*label);
 
-    thePFIsoHelper = new MuPFIsoHelper(psetMap,consumesCollector());
+    thePFIsoHelper = new MuPFIsoHelper(psetMap, consumesCollector());
 
     //Now loop on the mass read for each PSet the parameters and save them to the mapNames for later
 
-    for(std::map<std::string,edm::ParameterSet>::const_iterator map = psetMap.begin();map!= psetMap.end();++map) {
-      std::map<std::string,edm::InputTag> isoMap;
-      isoMap["chargedParticle"]              = map->second.getParameter<edm::InputTag>("chargedParticle");
-      isoMap["chargedHadron"]                = map->second.getParameter<edm::InputTag>("chargedHadron");
-      isoMap["neutralHadron"]                = map->second.getParameter<edm::InputTag>("neutralHadron");
-      isoMap["neutralHadronHighThreshold"]   = map->second.getParameter<edm::InputTag>("neutralHadronHighThreshold");
-      isoMap["photon"]                       = map->second.getParameter<edm::InputTag>("photon");
-      isoMap["photonHighThreshold"]          = map->second.getParameter<edm::InputTag>("photonHighThreshold");
-      isoMap["pu"]                           = map->second.getParameter<edm::InputTag>("pu");
+    for (std::map<std::string, edm::ParameterSet>::const_iterator map = psetMap.begin(); map != psetMap.end(); ++map) {
+      std::map<std::string, edm::InputTag> isoMap;
+      isoMap["chargedParticle"] = map->second.getParameter<edm::InputTag>("chargedParticle");
+      isoMap["chargedHadron"] = map->second.getParameter<edm::InputTag>("chargedHadron");
+      isoMap["neutralHadron"] = map->second.getParameter<edm::InputTag>("neutralHadron");
+      isoMap["neutralHadronHighThreshold"] = map->second.getParameter<edm::InputTag>("neutralHadronHighThreshold");
+      isoMap["photon"] = map->second.getParameter<edm::InputTag>("photon");
+      isoMap["photonHighThreshold"] = map->second.getParameter<edm::InputTag>("photonHighThreshold");
+      isoMap["pu"] = map->second.getParameter<edm::InputTag>("pu");
 
-      std::map<std::string,edm::EDGetTokenT<edm::ValueMap<double> > > isoMapToken;
-      isoMapToken["chargedParticle"]             = consumes<edm::ValueMap<double> >(isoMap["chargedParticle"]); 
-      isoMapToken["chargedHadron"]               = consumes<edm::ValueMap<double> >(isoMap["chargedHadron"]);  
-      isoMapToken["neutralHadron"]               = consumes<edm::ValueMap<double> >(isoMap["neutralHadron"]);  
-      isoMapToken["neutralHadronHighThreshold"]  = consumes<edm::ValueMap<double> >(isoMap["neutralHadronHighThreshold"]);  
-      isoMapToken["photon"]                      = consumes<edm::ValueMap<double> >(isoMap["photon"]);  
-      isoMapToken["photonHighThreshold"]         = consumes<edm::ValueMap<double> >(isoMap["photonHighThreshold"]);  
-      isoMapToken["pu"]                          = consumes<edm::ValueMap<double> >(isoMap["pu"]);  
-      
+      std::map<std::string, edm::EDGetTokenT<edm::ValueMap<double>>> isoMapToken;
+      isoMapToken["chargedParticle"] = consumes<edm::ValueMap<double>>(isoMap["chargedParticle"]);
+      isoMapToken["chargedHadron"] = consumes<edm::ValueMap<double>>(isoMap["chargedHadron"]);
+      isoMapToken["neutralHadron"] = consumes<edm::ValueMap<double>>(isoMap["neutralHadron"]);
+      isoMapToken["neutralHadronHighThreshold"] = consumes<edm::ValueMap<double>>(isoMap["neutralHadronHighThreshold"]);
+      isoMapToken["photon"] = consumes<edm::ValueMap<double>>(isoMap["photon"]);
+      isoMapToken["photonHighThreshold"] = consumes<edm::ValueMap<double>>(isoMap["photonHighThreshold"]);
+      isoMapToken["pu"] = consumes<edm::ValueMap<double>>(isoMap["pu"]);
 
       pfIsoMapNames.push_back(isoMap);
       pfIsoMapTokens_.push_back(isoMapToken);
     }
 
-
-    for(unsigned int j=0;j<pfIsoMapNames.size();++j) {
-      for(std::map<std::string,edm::InputTag>::const_iterator map = pfIsoMapNames.at(j).begin(); map != pfIsoMapNames.at(j).end(); ++map)
-	produces<edm::ValueMap<double> >(labelOrInstance(map->second));
-
+    for (unsigned int j = 0; j < pfIsoMapNames.size(); ++j) {
+      for (std::map<std::string, edm::InputTag>::const_iterator map = pfIsoMapNames.at(j).begin();
+           map != pfIsoMapNames.at(j).end();
+           ++map)
+        produces<edm::ValueMap<double>>(labelOrInstance(map->second));
     }
-    
   }
-  
-  if (computeStandardSelectors_){
+
+  if (computeStandardSelectors_) {
     vertexes_ = consumes<reco::VertexCollection>(pSet.getParameter<edm::InputTag>("vertices"));
   }
-
 }
 
 /// Destructor
-MuonProducer::~MuonProducer(){ 
-  if (fillPFIsolation_ && thePFIsoHelper) delete thePFIsoHelper;
+MuonProducer::~MuonProducer() {
+  if (fillPFIsolation_ && thePFIsoHelper)
+    delete thePFIsoHelper;
 }
-
 
 /// reconstruct muons
-void MuonProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup){
+void MuonProducer::produce(edm::Event& event, const edm::EventSetup& eventSetup) {
+  const std::string metname = "Muon|RecoMuon|MuonIdentification|MuonProducer";
 
-   const std::string metname = "Muon|RecoMuon|MuonIdentification|MuonProducer";
+  // the muon collection, it will be loaded in the event
+  auto outputMuons = std::make_unique<reco::MuonCollection>();
+  reco::MuonRefProd outputMuonsRefProd = event.getRefBeforePut<reco::MuonCollection>();
 
-   // the muon collection, it will be loaded in the event
-   auto outputMuons = std::make_unique<reco::MuonCollection>();
-   reco::MuonRefProd outputMuonsRefProd = event.getRefBeforePut<reco::MuonCollection>();
+  edm::Handle<reco::MuonCollection> inputMuons;
+  event.getByToken(theMuonsCollectionToken_, inputMuons);
+  edm::OrphanHandle<reco::MuonCollection> inputMuonsOH(inputMuons.product(), inputMuons.id());
 
-   edm::Handle<reco::MuonCollection> inputMuons; 
-   event.getByToken(theMuonsCollectionToken_, inputMuons);
-   edm::OrphanHandle<reco::MuonCollection> inputMuonsOH(inputMuons.product(), inputMuons.id());
-   
-   edm::Handle<reco::PFCandidateCollection> pfCandidates; 
-   event.getByToken(thePFCandToken_, pfCandidates);
+  edm::Handle<reco::PFCandidateCollection> pfCandidates;
+  event.getByToken(thePFCandToken_, pfCandidates);
 
-   edm::Handle<reco::VertexCollection> primaryVertices;
-   const reco::Vertex* vertex(nullptr);
-   if (computeStandardSelectors_){
-     event.getByToken(vertexes_, primaryVertices);
-     if (!primaryVertices->empty())
-       vertex = &(primaryVertices->front());
-   }
+  edm::Handle<reco::VertexCollection> primaryVertices;
+  const reco::Vertex* vertex(nullptr);
+  if (computeStandardSelectors_) {
+    event.getByToken(vertexes_, primaryVertices);
+    if (!primaryVertices->empty())
+      vertex = &(primaryVertices->front());
+  }
 
-   // fetch collections for PFIso
-   if(fillPFIsolation_) thePFIsoHelper->beginEvent(event);
+  // fetch collections for PFIso
+  if (fillPFIsolation_)
+    thePFIsoHelper->beginEvent(event);
 
-   
-   // Fill timing information
-   edm::Handle<reco::MuonTimeExtraMap> timeMapCmb;
-   edm::Handle<reco::MuonTimeExtraMap> timeMapDT;
-   edm::Handle<reco::MuonTimeExtraMap> timeMapCSC;
-   
-   int nMuons=inputMuons->size();
+  // Fill timing information
+  edm::Handle<reco::MuonTimeExtraMap> timeMapCmb;
+  edm::Handle<reco::MuonTimeExtraMap> timeMapDT;
+  edm::Handle<reco::MuonTimeExtraMap> timeMapCSC;
 
-   std::vector<reco::MuonTimeExtra> dtTimeColl(nMuons);
-   std::vector<reco::MuonTimeExtra> cscTimeColl(nMuons);
-   std::vector<reco::MuonTimeExtra> combinedTimeColl(nMuons);
+  int nMuons = inputMuons->size();
 
-   if(fillTimingInfo_){
-     event.getByToken(timeMapCmbToken_,timeMapCmb);
-     event.getByToken(timeMapDTToken_,timeMapDT);
-     event.getByToken(timeMapCSCToken_,timeMapCSC);
-   }
+  std::vector<reco::MuonTimeExtra> dtTimeColl(nMuons);
+  std::vector<reco::MuonTimeExtra> cscTimeColl(nMuons);
+  std::vector<reco::MuonTimeExtra> combinedTimeColl(nMuons);
 
-   std::vector<reco::IsoDeposit> trackDepColl(nMuons);
-   std::vector<reco::IsoDeposit> ecalDepColl(nMuons);
-   std::vector<reco::IsoDeposit> hcalDepColl(nMuons);
-   std::vector<reco::IsoDeposit> hoDepColl(nMuons);
-   std::vector<reco::IsoDeposit> jetDepColl(nMuons);
+  if (fillTimingInfo_) {
+    event.getByToken(timeMapCmbToken_, timeMapCmb);
+    event.getByToken(timeMapDTToken_, timeMapDT);
+    event.getByToken(timeMapCSCToken_, timeMapCSC);
+  }
 
+  std::vector<reco::IsoDeposit> trackDepColl(nMuons);
+  std::vector<reco::IsoDeposit> ecalDepColl(nMuons);
+  std::vector<reco::IsoDeposit> hcalDepColl(nMuons);
+  std::vector<reco::IsoDeposit> hoDepColl(nMuons);
+  std::vector<reco::IsoDeposit> jetDepColl(nMuons);
 
-   edm::Handle<reco::IsoDepositMap> trackIsoDepMap;
-   edm::Handle<reco::IsoDepositMap> ecalIsoDepMap;
-   edm::Handle<reco::IsoDepositMap> hcalIsoDepMap;
-   edm::Handle<reco::IsoDepositMap> hoIsoDepMap;
-   edm::Handle<reco::IsoDepositMap> jetIsoDepMap;
+  edm::Handle<reco::IsoDepositMap> trackIsoDepMap;
+  edm::Handle<reco::IsoDepositMap> ecalIsoDepMap;
+  edm::Handle<reco::IsoDepositMap> hcalIsoDepMap;
+  edm::Handle<reco::IsoDepositMap> hoIsoDepMap;
+  edm::Handle<reco::IsoDepositMap> jetIsoDepMap;
 
+  if (fillDetectorBasedIsolation_) {
+    event.getByToken(theTrackDepositToken_, trackIsoDepMap);
+    event.getByToken(theEcalDepositToken_, ecalIsoDepMap);
+    event.getByToken(theHcalDepositToken_, hcalIsoDepMap);
+    event.getByToken(theHoDepositToken_, hoIsoDepMap);
+    event.getByToken(theJetDepositToken_, jetIsoDepMap);
+  }
 
-   if(fillDetectorBasedIsolation_){
-     event.getByToken(theTrackDepositToken_,trackIsoDepMap);
-     event.getByToken(theEcalDepositToken_,ecalIsoDepMap);
-     event.getByToken(theHcalDepositToken_,hcalIsoDepMap);
-     event.getByToken(theHoDepositToken_,hoIsoDepMap);
-     event.getByToken(theJetDepositToken_,jetIsoDepMap);
-   }
+  std::vector<std::map<std::string, edm::Handle<edm::ValueMap<double>>>> pfIsoMaps;
+  std::vector<std::map<std::string, std::vector<double>>> pfIsoMapVals;
 
-   
-
-   std::vector<std::map<std::string,edm::Handle<edm::ValueMap<double> > > > pfIsoMaps;
-   std::vector<std::map<std::string,std::vector<double> > > pfIsoMapVals;
-
-   if(fillPFIsolation_){
-    for(unsigned int j=0;j<pfIsoMapNames.size();++j) {
-	std::map<std::string,std::vector<double> > mapVals;
-	std::map<std::string,edm::Handle<edm::ValueMap<double> > > maps;
-	for(std::map<std::string,edm::InputTag>::const_iterator map = pfIsoMapNames.at(j).begin(); map != pfIsoMapNames.at(j).end(); ++map) {
-	  edm::Handle<edm::ValueMap<double> > handleTmp;
-	  event.getByToken(pfIsoMapTokens_.at(j)[map->first],handleTmp);
-	  maps[map->first]=handleTmp;
-	  mapVals[map->first].resize(nMuons);
-	}
-	pfIsoMapVals.push_back(mapVals);
-	pfIsoMaps.push_back(maps);
-
+  if (fillPFIsolation_) {
+    for (unsigned int j = 0; j < pfIsoMapNames.size(); ++j) {
+      std::map<std::string, std::vector<double>> mapVals;
+      std::map<std::string, edm::Handle<edm::ValueMap<double>>> maps;
+      for (std::map<std::string, edm::InputTag>::const_iterator map = pfIsoMapNames.at(j).begin();
+           map != pfIsoMapNames.at(j).end();
+           ++map) {
+        edm::Handle<edm::ValueMap<double>> handleTmp;
+        event.getByToken(pfIsoMapTokens_.at(j)[map->first], handleTmp);
+        maps[map->first] = handleTmp;
+        mapVals[map->first].resize(nMuons);
+      }
+      pfIsoMapVals.push_back(mapVals);
+      pfIsoMaps.push_back(maps);
     }
-   }
+  }
 
+  std::vector<edm::Handle<edm::ValueMap<bool>>> selectorMaps(fillSelectors_ ? theSelectorMapNames.size() : 0);
+  std::vector<std::vector<bool>> selectorMapResults(fillSelectors_ ? theSelectorMapNames.size() : 0);
+  if (fillSelectors_) {
+    unsigned int s = 0;
+    for (InputTags::const_iterator tag = theSelectorMapNames.begin(); tag != theSelectorMapNames.end(); ++tag, ++s) {
+      event.getByToken(theSelectorMapTokens_.at(s), selectorMaps[s]);
+      selectorMapResults[s].resize(nMuons);
+    }
+  }
 
-   
-   std::vector<edm::Handle<edm::ValueMap<bool> > >  selectorMaps(fillSelectors_ ? theSelectorMapNames.size() : 0); 
-   std::vector<std::vector<bool> > selectorMapResults(fillSelectors_ ? theSelectorMapNames.size() : 0);
-   if(fillSelectors_){
-     unsigned int s=0;
-     for(InputTags::const_iterator tag = theSelectorMapNames.begin(); tag != theSelectorMapNames.end(); ++tag, ++s){
-       event.getByToken(theSelectorMapTokens_.at(s),selectorMaps[s]);
-       selectorMapResults[s].resize(nMuons);
-     }
-   }
+  edm::Handle<reco::MuonShowerMap> showerInfoMap;
+  if (fillShoweringInfo_)
+    event.getByToken(theShowerMapToken_, showerInfoMap);
 
-   edm::Handle<reco::MuonShowerMap> showerInfoMap;
-   if(fillShoweringInfo_) event.getByToken(theShowerMapToken_,showerInfoMap);
+  std::vector<reco::MuonShower> showerInfoColl(nMuons);
 
-   std::vector<reco::MuonShower> showerInfoColl(nMuons);
+  edm::Handle<edm::ValueMap<unsigned int>> cosmicIdMap;
+  if (fillCosmicsIdMap_)
+    event.getByToken(theCosmicIdMapToken_, cosmicIdMap);
+  std::vector<unsigned int> cosmicIdColl(fillCosmicsIdMap_ ? nMuons : 0);
 
-   edm::Handle<edm::ValueMap<unsigned int> > cosmicIdMap;
-   if(fillCosmicsIdMap_) event.getByToken(theCosmicIdMapToken_,cosmicIdMap);
-   std::vector<unsigned int> cosmicIdColl(fillCosmicsIdMap_ ? nMuons : 0);
-   
-   edm::Handle<edm::ValueMap<reco::MuonCosmicCompatibility> > cosmicCompMap;
-   if(fillCosmicsIdMap_) event.getByToken(theCosmicCompMapToken_,cosmicCompMap);
-   std::vector<reco::MuonCosmicCompatibility> cosmicCompColl(fillCosmicsIdMap_ ? nMuons : 0);
+  edm::Handle<edm::ValueMap<reco::MuonCosmicCompatibility>> cosmicCompMap;
+  if (fillCosmicsIdMap_)
+    event.getByToken(theCosmicCompMapToken_, cosmicCompMap);
+  std::vector<reco::MuonCosmicCompatibility> cosmicCompColl(fillCosmicsIdMap_ ? nMuons : 0);
 
+  std::vector<reco::MuonRef> muonRefColl(nMuons);
 
-   std::vector<reco::MuonRef> muonRefColl(nMuons);
+  if (inputMuons->empty()) {
+    edm::OrphanHandle<reco::MuonCollection> muonHandle = event.put(std::move(outputMuons));
 
+    if (fillTimingInfo_) {
+      fillMuonMap<reco::MuonTimeExtra>(event, muonHandle, combinedTimeColl, "combined");
+      fillMuonMap<reco::MuonTimeExtra>(event, muonHandle, dtTimeColl, "dt");
+      fillMuonMap<reco::MuonTimeExtra>(event, muonHandle, cscTimeColl, "csc");
+    }
 
+    if (fillDetectorBasedIsolation_) {
+      fillMuonMap<reco::IsoDeposit>(event, muonHandle, trackDepColl, labelOrInstance(theTrackDepositName));
+      fillMuonMap<reco::IsoDeposit>(event, muonHandle, jetDepColl, labelOrInstance(theJetDepositName));
+      fillMuonMap<reco::IsoDeposit>(event, muonHandle, ecalDepColl, theEcalDepositName.instance());
+      fillMuonMap<reco::IsoDeposit>(event, muonHandle, hcalDepColl, theHcalDepositName.instance());
+      fillMuonMap<reco::IsoDeposit>(event, muonHandle, hoDepColl, theHoDepositName.instance());
+    }
 
-   if(inputMuons->empty()) {
-     edm::OrphanHandle<reco::MuonCollection> muonHandle = event.put(std::move(outputMuons));
-     
-     if(fillTimingInfo_){
-       fillMuonMap<reco::MuonTimeExtra>(event, muonHandle, combinedTimeColl,"combined");
-       fillMuonMap<reco::MuonTimeExtra>(event, muonHandle, dtTimeColl,"dt");
-       fillMuonMap<reco::MuonTimeExtra>(event, muonHandle, cscTimeColl,"csc");
-     }
-     
-     if(fillDetectorBasedIsolation_){
-       fillMuonMap<reco::IsoDeposit>(event, muonHandle, trackDepColl, labelOrInstance(theTrackDepositName));
-       fillMuonMap<reco::IsoDeposit>(event, muonHandle, jetDepColl,   labelOrInstance(theJetDepositName));
-       fillMuonMap<reco::IsoDeposit>(event, muonHandle, ecalDepColl,  theEcalDepositName.instance());
-       fillMuonMap<reco::IsoDeposit>(event, muonHandle, hcalDepColl,  theHcalDepositName.instance());
-       fillMuonMap<reco::IsoDeposit>(event, muonHandle, hoDepColl,    theHoDepositName.instance());
-     }
+    if (fillSelectors_) {
+      unsigned int s = 0;
+      for (InputTags::const_iterator tag = theSelectorMapNames.begin(); tag != theSelectorMapNames.end(); ++tag, ++s) {
+        fillMuonMap<bool>(event, muonHandle, selectorMapResults[s], labelOrInstance(*tag));
+      }
+    }
 
-     if(fillSelectors_){
-       unsigned int s = 0;
-       for(InputTags::const_iterator tag = theSelectorMapNames.begin(); 
-	   tag != theSelectorMapNames.end(); ++tag, ++s){
-	 fillMuonMap<bool>(event, muonHandle, selectorMapResults[s], labelOrInstance(*tag));
-       }
-     }
+    if (fillShoweringInfo_)
+      fillMuonMap<reco::MuonShower>(event, muonHandle, showerInfoColl, labelOrInstance(theShowerMapName));
 
-     if(fillShoweringInfo_) fillMuonMap<reco::MuonShower>(event, muonHandle, showerInfoColl, labelOrInstance(theShowerMapName));
+    if (fillCosmicsIdMap_) {
+      fillMuonMap<unsigned int>(event, muonHandle, cosmicIdColl, labelOrInstance(theCosmicCompMapName));
+      fillMuonMap<reco::MuonCosmicCompatibility>(
+          event, muonHandle, cosmicCompColl, labelOrInstance(theCosmicCompMapName));
+    }
 
-     if(fillCosmicsIdMap_){
-       fillMuonMap<unsigned int>(event, muonHandle, cosmicIdColl, labelOrInstance(theCosmicCompMapName));
-       fillMuonMap<reco::MuonCosmicCompatibility>(event, muonHandle, cosmicCompColl, labelOrInstance(theCosmicCompMapName));
-     }
+    fillMuonMap<reco::MuonRef>(event, inputMuonsOH, muonRefColl, theMuToMuMapName);
 
-     fillMuonMap<reco::MuonRef>(event,inputMuonsOH, muonRefColl, theMuToMuMapName);
+    if (fillPFIsolation_) {
+      for (unsigned int j = 0; j < pfIsoMapNames.size(); ++j)
+        for (std::map<std::string, edm::InputTag>::const_iterator map = pfIsoMapNames.at(j).begin();
+             map != pfIsoMapNames.at(j).end();
+             ++map) {
+          fillMuonMap<double>(event, muonHandle, pfIsoMapVals.at(j)[map->first], labelOrInstance(map->second));
+        }
+    }
+    return;
+  }
 
-     if(fillPFIsolation_){
-       for(unsigned int j=0;j<pfIsoMapNames.size();++j) 
-	 for(std::map<std::string,edm::InputTag>::const_iterator map = pfIsoMapNames.at(j).begin(); map != pfIsoMapNames.at(j).end(); ++map) {
-	   fillMuonMap<double>(event, muonHandle, pfIsoMapVals.at(j)[map->first], labelOrInstance(map->second));
-	}
-     }
-     return;
-   }
-   
-   // FIXME: add the option to swith off the Muon-PF "info association".
-   
+  // FIXME: add the option to swith off the Muon-PF "info association".
 
-   MuToPFMap muToPFMap;
+  MuToPFMap muToPFMap;
 
-   if(fillPFMomentum_){
-     dout << "Number of PFCandidates: " << pfCandidates->size() << endl;
-     for(unsigned int i=0;i< pfCandidates->size();++i)
-       if(abs(pfCandidates->at(i).pdgId()) == 13){
-	 muToPFMap[pfCandidates->at(i).muonRef()] = i;
-	 dout << "MuonRef: " << pfCandidates->at(i).muonRef().id() << " " << pfCandidates->at(i).muonRef().key() << " PF p4: " << pfCandidates->at(i).p4() << endl;
-       }
-     dout << "Number of PFMuons: " << muToPFMap.size() << endl;
-     dout << "Number of Muons in the original collection: " << inputMuons->size() << endl;
-   }
+  if (fillPFMomentum_) {
+    dout << "Number of PFCandidates: " << pfCandidates->size() << endl;
+    for (unsigned int i = 0; i < pfCandidates->size(); ++i)
+      if (abs(pfCandidates->at(i).pdgId()) == 13) {
+        muToPFMap[pfCandidates->at(i).muonRef()] = i;
+        dout << "MuonRef: " << pfCandidates->at(i).muonRef().id() << " " << pfCandidates->at(i).muonRef().key()
+             << " PF p4: " << pfCandidates->at(i).p4() << endl;
+      }
+    dout << "Number of PFMuons: " << muToPFMap.size() << endl;
+    dout << "Number of Muons in the original collection: " << inputMuons->size() << endl;
+  }
 
-   reco::MuonRef::key_type muIndex = 0;
-   unsigned int i = 0;
-   for(auto const& inMuon : *inputMuons){
-     
-     reco::MuonRef muRef(inputMuons, muIndex);
-     muonRefColl[i] = reco::MuonRef(outputMuonsRefProd, muIndex++);
+  reco::MuonRef::key_type muIndex = 0;
+  unsigned int i = 0;
+  for (auto const& inMuon : *inputMuons) {
+    reco::MuonRef muRef(inputMuons, muIndex);
+    muonRefColl[i] = reco::MuonRef(outputMuonsRefProd, muIndex++);
 
-     // Copy the muon 
-     reco::Muon outMuon = inMuon;
-    
-     if(fillPFMomentum_){ 
-     // search for the corresponding pf candidate
-       MuToPFMap::iterator iter =  muToPFMap.find(muRef);
-       if(iter != muToPFMap.end()){
-	 const auto& pfMu = pfCandidates->at(iter->second);
-	 outMuon.setPFP4(pfMu.p4());
-	 outMuon.setP4(pfMu.p4());//PF is the default
-	 outMuon.setCharge(pfMu.charge());//PF is the default
-	 outMuon.setPdgId(-13*pfMu.charge());
-	 outMuon.setBestTrack(pfMu.bestMuonTrackType());
-	 muToPFMap.erase(iter);
-	 dout << "MuonRef: " << muRef.id() << " " << muRef.key() 
-	      << " Is it PF? " << outMuon.isPFMuon() 
-	      << " PF p4: " << outMuon.pfP4() << endl;
-       }
-       
-       
-       dout << "MuonRef: " << muRef.id() << " " << muRef.key() 
-	    << " Is it PF? " << outMuon.isPFMuon() << endl;
-       
-       dout << "GLB "  << outMuon.isGlobalMuon()
-	    << " TM "  << outMuon.isTrackerMuon()
-	    << " STA " << outMuon.isStandAloneMuon() 
-	    << " p4 "  << outMuon.p4() << endl;
-     }
+    // Copy the muon
+    reco::Muon outMuon = inMuon;
 
-     // Add PF isolation info
-     if(fillPFIsolation_){
-       thePFIsoHelper->embedPFIsolation(outMuon,muRef);
+    if (fillPFMomentum_) {
+      // search for the corresponding pf candidate
+      MuToPFMap::iterator iter = muToPFMap.find(muRef);
+      if (iter != muToPFMap.end()) {
+        const auto& pfMu = pfCandidates->at(iter->second);
+        outMuon.setPFP4(pfMu.p4());
+        outMuon.setP4(pfMu.p4());          //PF is the default
+        outMuon.setCharge(pfMu.charge());  //PF is the default
+        outMuon.setPdgId(-13 * pfMu.charge());
+        outMuon.setBestTrack(pfMu.bestMuonTrackType());
+        muToPFMap.erase(iter);
+        dout << "MuonRef: " << muRef.id() << " " << muRef.key() << " Is it PF? " << outMuon.isPFMuon()
+             << " PF p4: " << outMuon.pfP4() << endl;
+      }
 
-       for(unsigned int j=0;j<pfIsoMapNames.size();++j) {
-	 for(std::map<std::string,edm::InputTag>::const_iterator map = pfIsoMapNames[j].begin(); map != pfIsoMapNames[j].end(); ++map){
-	   (pfIsoMapVals[j])[map->first][i] = (*pfIsoMaps[j][map->first])[muRef];
-	 }
-       }
-     }
-     
-     // Fill timing information   
-     if(fillTimingInfo_){
-       combinedTimeColl[i] = (*timeMapCmb)[muRef];
-       dtTimeColl[i] = (*timeMapDT)[muRef];
-       cscTimeColl[i] = (*timeMapCSC)[muRef];
-     }
-     
-     if(fillDetectorBasedIsolation_){
-       trackDepColl[i] = (*trackIsoDepMap)[muRef];
-       ecalDepColl[i]  = (*ecalIsoDepMap)[muRef];
-       hcalDepColl[i]  = (*hcalIsoDepMap)[muRef];
-       hoDepColl[i]    = (*hoIsoDepMap)[muRef];
-       jetDepColl[i]   = (*jetIsoDepMap)[muRef];;
-     }
-     
-     if(fillSelectors_){
-       unsigned int s = 0;
-       for(InputTags::const_iterator tag = theSelectorMapNames.begin(); 
-	   tag != theSelectorMapNames.end(); ++tag, ++s)
-	 selectorMapResults[s][i] = (*selectorMaps[s])[muRef];
-     }
+      dout << "MuonRef: " << muRef.id() << " " << muRef.key() << " Is it PF? " << outMuon.isPFMuon() << endl;
 
-     // Fill the Showering Info
-     if(fillShoweringInfo_) showerInfoColl[i] = (*showerInfoMap)[muRef];
+      dout << "GLB " << outMuon.isGlobalMuon() << " TM " << outMuon.isTrackerMuon() << " STA "
+           << outMuon.isStandAloneMuon() << " p4 " << outMuon.p4() << endl;
+    }
 
-     if(fillCosmicsIdMap_){
-       cosmicIdColl[i] = (*cosmicIdMap)[muRef];
-       cosmicCompColl[i] = (*cosmicCompMap)[muRef];
-     }
-     
-     // Standard Selectors - keep it at the end so that all inputs are available
-     if (computeStandardSelectors_){
-       outMuon.setSelectors(0); // reset flags
-       bool isRun2016BCDEF = (272728 <= event.run() && event.run() <= 278808);
-       outMuon.setSelectors(muon::makeSelectorBitset(outMuon, vertex, isRun2016BCDEF));
-     }
+    // Add PF isolation info
+    if (fillPFIsolation_) {
+      thePFIsoHelper->embedPFIsolation(outMuon, muRef);
 
-     outputMuons->push_back(outMuon); 
-     ++i;
-   }
-   
-   dout << "Number of Muons in the new muon collection: " << outputMuons->size() << endl;
-   edm::OrphanHandle<reco::MuonCollection> muonHandle = event.put(std::move(outputMuons));
+      for (unsigned int j = 0; j < pfIsoMapNames.size(); ++j) {
+        for (std::map<std::string, edm::InputTag>::const_iterator map = pfIsoMapNames[j].begin();
+             map != pfIsoMapNames[j].end();
+             ++map) {
+          (pfIsoMapVals[j])[map->first][i] = (*pfIsoMaps[j][map->first])[muRef];
+        }
+      }
+    }
 
-   if(fillTimingInfo_){
-     fillMuonMap<reco::MuonTimeExtra>(event, muonHandle, combinedTimeColl,"combined");
-     fillMuonMap<reco::MuonTimeExtra>(event, muonHandle, dtTimeColl,"dt");
-     fillMuonMap<reco::MuonTimeExtra>(event, muonHandle, cscTimeColl,"csc");
-   }
+    // Fill timing information
+    if (fillTimingInfo_) {
+      combinedTimeColl[i] = (*timeMapCmb)[muRef];
+      dtTimeColl[i] = (*timeMapDT)[muRef];
+      cscTimeColl[i] = (*timeMapCSC)[muRef];
+    }
 
-   if(fillDetectorBasedIsolation_){
-     fillMuonMap<reco::IsoDeposit>(event, muonHandle, trackDepColl, labelOrInstance(theTrackDepositName));
-     fillMuonMap<reco::IsoDeposit>(event, muonHandle, jetDepColl,   labelOrInstance(theJetDepositName));
-     fillMuonMap<reco::IsoDeposit>(event, muonHandle, ecalDepColl,  theEcalDepositName.instance());
-     fillMuonMap<reco::IsoDeposit>(event, muonHandle, hcalDepColl,  theHcalDepositName.instance());
-     fillMuonMap<reco::IsoDeposit>(event, muonHandle, hoDepColl,    theHoDepositName.instance());
-   }
-   
-   if(fillPFIsolation_){
+    if (fillDetectorBasedIsolation_) {
+      trackDepColl[i] = (*trackIsoDepMap)[muRef];
+      ecalDepColl[i] = (*ecalIsoDepMap)[muRef];
+      hcalDepColl[i] = (*hcalIsoDepMap)[muRef];
+      hoDepColl[i] = (*hoIsoDepMap)[muRef];
+      jetDepColl[i] = (*jetIsoDepMap)[muRef];
+      ;
+    }
 
-     for(unsigned int j=0;j<pfIsoMapNames.size();++j) {
-       for(std::map<std::string,edm::InputTag>::const_iterator map = pfIsoMapNames[j].begin(); map != pfIsoMapNames[j].end(); ++map) 
-	 fillMuonMap<double>(event, muonHandle, pfIsoMapVals[j][map->first], labelOrInstance(map->second));
-     }
-   }   
+    if (fillSelectors_) {
+      unsigned int s = 0;
+      for (InputTags::const_iterator tag = theSelectorMapNames.begin(); tag != theSelectorMapNames.end(); ++tag, ++s)
+        selectorMapResults[s][i] = (*selectorMaps[s])[muRef];
+    }
 
-   if(fillSelectors_){
-     unsigned int s = 0;
-     for(InputTags::const_iterator tag = theSelectorMapNames.begin(); 
-	 tag != theSelectorMapNames.end(); ++tag, ++s)
-       fillMuonMap<bool>(event, muonHandle, selectorMapResults[s], labelOrInstance(*tag));
-   }
+    // Fill the Showering Info
+    if (fillShoweringInfo_)
+      showerInfoColl[i] = (*showerInfoMap)[muRef];
 
-   if(fillShoweringInfo_) fillMuonMap<reco::MuonShower>(event, muonHandle, showerInfoColl, labelOrInstance(theShowerMapName));
+    if (fillCosmicsIdMap_) {
+      cosmicIdColl[i] = (*cosmicIdMap)[muRef];
+      cosmicCompColl[i] = (*cosmicCompMap)[muRef];
+    }
 
-   if(fillCosmicsIdMap_){
-     fillMuonMap<unsigned int>(event, muonHandle, cosmicIdColl, labelOrInstance(theCosmicCompMapName));
-     fillMuonMap<reco::MuonCosmicCompatibility>(event, muonHandle, cosmicCompColl, labelOrInstance(theCosmicCompMapName));
-   }
+    // Standard Selectors - keep it at the end so that all inputs are available
+    if (computeStandardSelectors_) {
+      outMuon.setSelectors(0);  // reset flags
+      bool isRun2016BCDEF = (272728 <= event.run() && event.run() <= 278808);
+      outMuon.setSelectors(muon::makeSelectorBitset(outMuon, vertex, isRun2016BCDEF));
+    }
 
-   fillMuonMap<reco::MuonRef>(event,inputMuonsOH, muonRefColl, theMuToMuMapName);
-   
- 
+    outputMuons->push_back(outMuon);
+    ++i;
+  }
+
+  dout << "Number of Muons in the new muon collection: " << outputMuons->size() << endl;
+  edm::OrphanHandle<reco::MuonCollection> muonHandle = event.put(std::move(outputMuons));
+
+  if (fillTimingInfo_) {
+    fillMuonMap<reco::MuonTimeExtra>(event, muonHandle, combinedTimeColl, "combined");
+    fillMuonMap<reco::MuonTimeExtra>(event, muonHandle, dtTimeColl, "dt");
+    fillMuonMap<reco::MuonTimeExtra>(event, muonHandle, cscTimeColl, "csc");
+  }
+
+  if (fillDetectorBasedIsolation_) {
+    fillMuonMap<reco::IsoDeposit>(event, muonHandle, trackDepColl, labelOrInstance(theTrackDepositName));
+    fillMuonMap<reco::IsoDeposit>(event, muonHandle, jetDepColl, labelOrInstance(theJetDepositName));
+    fillMuonMap<reco::IsoDeposit>(event, muonHandle, ecalDepColl, theEcalDepositName.instance());
+    fillMuonMap<reco::IsoDeposit>(event, muonHandle, hcalDepColl, theHcalDepositName.instance());
+    fillMuonMap<reco::IsoDeposit>(event, muonHandle, hoDepColl, theHoDepositName.instance());
+  }
+
+  if (fillPFIsolation_) {
+    for (unsigned int j = 0; j < pfIsoMapNames.size(); ++j) {
+      for (std::map<std::string, edm::InputTag>::const_iterator map = pfIsoMapNames[j].begin();
+           map != pfIsoMapNames[j].end();
+           ++map)
+        fillMuonMap<double>(event, muonHandle, pfIsoMapVals[j][map->first], labelOrInstance(map->second));
+    }
+  }
+
+  if (fillSelectors_) {
+    unsigned int s = 0;
+    for (InputTags::const_iterator tag = theSelectorMapNames.begin(); tag != theSelectorMapNames.end(); ++tag, ++s)
+      fillMuonMap<bool>(event, muonHandle, selectorMapResults[s], labelOrInstance(*tag));
+  }
+
+  if (fillShoweringInfo_)
+    fillMuonMap<reco::MuonShower>(event, muonHandle, showerInfoColl, labelOrInstance(theShowerMapName));
+
+  if (fillCosmicsIdMap_) {
+    fillMuonMap<unsigned int>(event, muonHandle, cosmicIdColl, labelOrInstance(theCosmicCompMapName));
+    fillMuonMap<reco::MuonCosmicCompatibility>(
+        event, muonHandle, cosmicCompColl, labelOrInstance(theCosmicCompMapName));
+  }
+
+  fillMuonMap<reco::MuonRef>(event, inputMuonsOH, muonRefColl, theMuToMuMapName);
 }
 
-
-
-template<typename TYPE>
+template <typename TYPE>
 void MuonProducer::fillMuonMap(edm::Event& event,
-			       const edm::OrphanHandle<reco::MuonCollection>& muonHandle,
-			       const std::vector<TYPE>& muonExtra,
-			       const std::string& label){
- 
-  typedef typename edm::ValueMap<TYPE>::Filler FILLER; 
+                               const edm::OrphanHandle<reco::MuonCollection>& muonHandle,
+                               const std::vector<TYPE>& muonExtra,
+                               const std::string& label) {
+  typedef typename edm::ValueMap<TYPE>::Filler FILLER;
 
   auto muonMap = std::make_unique<edm::ValueMap<TYPE>>();
-  if(!muonExtra.empty()){
+  if (!muonExtra.empty()) {
     FILLER filler(*muonMap);
     filler.insert(muonHandle, muonExtra.begin(), muonExtra.end());
     filler.fill();
   }
-  event.put(std::move(muonMap),label);
+  event.put(std::move(muonMap), label);
 }
 
-
-std::string MuonProducer::labelOrInstance(const edm::InputTag &input) const{
-  if(fastLabelling_) return input.label();
+std::string MuonProducer::labelOrInstance(const edm::InputTag& input) const {
+  if (fastLabelling_)
+    return input.label();
 
   return input.label() != theMuonsCollectionLabel.label() ? input.label() : input.instance();
 }

--- a/RecoMuon/MuonIdentification/plugins/MuonProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonProducer.h
@@ -17,7 +17,9 @@
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/MuonTimeExtra.h"
 
-namespace reco {class Track;}
+namespace reco {
+  class Track;
+}
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 
@@ -41,13 +43,10 @@ namespace reco {class Track;}
 #include "DataFormats/RecoCandidate/interface/IsoDeposit.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
-
 class MuPFIsoHelper;
-
 
 class MuonProducer : public edm::stream::EDProducer<> {
 public:
-
   /// Constructor
   MuonProducer(const edm::ParameterSet&);
 
@@ -57,38 +56,34 @@ public:
   /// reconstruct muons
   void produce(edm::Event&, const edm::EventSetup&) override;
 
-
   typedef std::vector<edm::InputTag> InputTags;
 
 protected:
-
 private:
-  template<typename TYPE>
-    void fillMuonMap(edm::Event& event,
-		     const edm::OrphanHandle<reco::MuonCollection>& muonHandle,
-		     const std::vector<TYPE>& muonExtra,
-		     const std::string& label);
-  
+  template <typename TYPE>
+  void fillMuonMap(edm::Event& event,
+                   const edm::OrphanHandle<reco::MuonCollection>& muonHandle,
+                   const std::vector<TYPE>& muonExtra,
+                   const std::string& label);
+
   std::string theAlias;
 
-  void setAlias( std::string alias ){
-    alias.erase( alias.size() - 1, alias.size() );
-    theAlias=alias;
+  void setAlias(std::string alias) {
+    alias.erase(alias.size() - 1, alias.size());
+    theAlias = alias;
   }
 
-  std::string labelOrInstance(const edm::InputTag &) const;
+  std::string labelOrInstance(const edm::InputTag&) const;
 
 private:
   bool debug_;
   bool fastLabelling_;
-  
+
   edm::InputTag theMuonsCollectionLabel;
   edm::EDGetTokenT<reco::MuonCollection> theMuonsCollectionToken_;
- 
+
   edm::InputTag thePFCandLabel;
   edm::EDGetTokenT<reco::PFCandidateCollection> thePFCandToken_;
- 
-
 
   bool fillIsolation_;
   bool writeIsoDeposits_;
@@ -113,10 +108,8 @@ private:
   edm::EDGetTokenT<reco::IsoDepositMap> theHoDepositToken_;
   edm::EDGetTokenT<reco::IsoDepositMap> theJetDepositToken_;
 
-
   InputTags theSelectorMapNames;
-  std::vector<edm::EDGetTokenT<edm::ValueMap<bool> > >  theSelectorMapTokens_;
-
+  std::vector<edm::EDGetTokenT<edm::ValueMap<bool> > > theSelectorMapTokens_;
 
   edm::InputTag theShowerMapName;
   edm::EDGetTokenT<edm::ValueMap<reco::MuonShower> > theShowerMapToken_;
@@ -126,22 +119,15 @@ private:
   edm::EDGetTokenT<edm::ValueMap<reco::MuonCosmicCompatibility> > theCosmicCompMapToken_;
   std::string theMuToMuMapName;
 
-  MuPFIsoHelper *thePFIsoHelper;
+  MuPFIsoHelper* thePFIsoHelper;
 
   edm::EDGetTokenT<reco::MuonTimeExtraMap> timeMapCmbToken_;
   edm::EDGetTokenT<reco::MuonTimeExtraMap> timeMapDTToken_;
   edm::EDGetTokenT<reco::MuonTimeExtraMap> timeMapCSCToken_;
 
-
-
-
-  std::vector<std::map<std::string,edm::InputTag> > pfIsoMapNames;
-  std::vector<std::map<std::string,edm::EDGetTokenT<edm::ValueMap<double> > > > pfIsoMapTokens_;
+  std::vector<std::map<std::string, edm::InputTag> > pfIsoMapNames;
+  std::vector<std::map<std::string, edm::EDGetTokenT<edm::ValueMap<double> > > > pfIsoMapTokens_;
 
   edm::EDGetTokenT<reco::VertexCollection> vertexes_;
-  
 };
 #endif
-
-
- 

--- a/RecoMuon/MuonIdentification/plugins/MuonRefProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonRefProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    MuonIdentification
 // Class:      MuonRefProducer
-// 
+//
 //
 // Original Author:  Dmytro Kovalskyi
 //
@@ -26,52 +26,59 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
-MuonRefProducer::MuonRefProducer(const edm::ParameterSet& iConfig)
-{
-   theReferenceCollection_ = iConfig.getParameter<edm::InputTag>("ReferenceCollection");
-   muonToken_ = consumes<reco::MuonCollection> (theReferenceCollection_);
+MuonRefProducer::MuonRefProducer(const edm::ParameterSet& iConfig) {
+  theReferenceCollection_ = iConfig.getParameter<edm::InputTag>("ReferenceCollection");
+  muonToken_ = consumes<reco::MuonCollection>(theReferenceCollection_);
 
-   type_ = muon::TMLastStation; // default type
-   std::string type = iConfig.getParameter<std::string>("algorithmType");
-   if ( type != "TMLastStation" )
-     edm::LogWarning("MuonIdentification") << "Unknown algorithm type is requested: " << type << "\nUsing the default one.";
-   
-   minNumberOfMatches_      = iConfig.getParameter<int>("minNumberOfMatchedStations");
-   maxAbsDx_                = iConfig.getParameter<double>("maxAbsDx");
-   maxAbsPullX_             = iConfig.getParameter<double>("maxAbsPullX");
-   maxAbsDy_                = iConfig.getParameter<double>("maxAbsDy");
-   maxAbsPullY_             = iConfig.getParameter<double>("maxAbsPullY");
-   maxChamberDist_          = iConfig.getParameter<double>("maxChamberDistance");
-   maxChamberDistPull_      = iConfig.getParameter<double>("maxChamberDistancePull");
-   
-   std::string arbitrationType = iConfig.getParameter<std::string>("arbitrationType");
-   if (arbitrationType=="NoArbitration")
-     arbitrationType_ = reco::Muon::NoArbitration;
-   else if (arbitrationType=="SegmentArbitration")
-     arbitrationType_ = reco::Muon::SegmentArbitration;
-   else if (arbitrationType=="SegmentAndTrackArbitration")
-     arbitrationType_ = reco::Muon::SegmentAndTrackArbitration;
-   else {
-      edm::LogWarning("MuonIdentification") << "Unknown arbitration type is requested: " << arbitrationType << "\nUsing the default one";
-      arbitrationType_ = reco::Muon::SegmentAndTrackArbitration;
-   }
-   produces<edm::RefVector<std::vector<reco::Muon> > >();
+  type_ = muon::TMLastStation;  // default type
+  std::string type = iConfig.getParameter<std::string>("algorithmType");
+  if (type != "TMLastStation")
+    edm::LogWarning("MuonIdentification")
+        << "Unknown algorithm type is requested: " << type << "\nUsing the default one.";
+
+  minNumberOfMatches_ = iConfig.getParameter<int>("minNumberOfMatchedStations");
+  maxAbsDx_ = iConfig.getParameter<double>("maxAbsDx");
+  maxAbsPullX_ = iConfig.getParameter<double>("maxAbsPullX");
+  maxAbsDy_ = iConfig.getParameter<double>("maxAbsDy");
+  maxAbsPullY_ = iConfig.getParameter<double>("maxAbsPullY");
+  maxChamberDist_ = iConfig.getParameter<double>("maxChamberDistance");
+  maxChamberDistPull_ = iConfig.getParameter<double>("maxChamberDistancePull");
+
+  std::string arbitrationType = iConfig.getParameter<std::string>("arbitrationType");
+  if (arbitrationType == "NoArbitration")
+    arbitrationType_ = reco::Muon::NoArbitration;
+  else if (arbitrationType == "SegmentArbitration")
+    arbitrationType_ = reco::Muon::SegmentArbitration;
+  else if (arbitrationType == "SegmentAndTrackArbitration")
+    arbitrationType_ = reco::Muon::SegmentAndTrackArbitration;
+  else {
+    edm::LogWarning("MuonIdentification")
+        << "Unknown arbitration type is requested: " << arbitrationType << "\nUsing the default one";
+    arbitrationType_ = reco::Muon::SegmentAndTrackArbitration;
+  }
+  produces<edm::RefVector<std::vector<reco::Muon>>>();
 }
 
+MuonRefProducer::~MuonRefProducer() {}
 
-MuonRefProducer::~MuonRefProducer(){}
+void MuonRefProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  auto outputCollection = std::make_unique<edm::RefVector<std::vector<reco::Muon>>>();
 
-void MuonRefProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
-{
-   auto outputCollection = std::make_unique<edm::RefVector<std::vector<reco::Muon>>>();
+  edm::Handle<reco::MuonCollection> muons;
+  iEvent.getByToken(muonToken_, muons);
 
-   edm::Handle<reco::MuonCollection> muons;
-   iEvent.getByToken(muonToken_, muons);
-   
-   // loop over input collection
-   for ( unsigned int i=0; i<muons->size(); ++i ) 
-     if ( muon::isGoodMuon( (*muons)[i], type_, minNumberOfMatches_,
-	  maxAbsDx_, maxAbsPullX_, maxAbsDy_, maxAbsPullY_, maxChamberDist_, maxChamberDistPull_, arbitrationType_) )
-       outputCollection->push_back( edm::RefVector<std::vector<reco::Muon> >::value_type(muons,i) );
-   iEvent.put(std::move(outputCollection));
+  // loop over input collection
+  for (unsigned int i = 0; i < muons->size(); ++i)
+    if (muon::isGoodMuon((*muons)[i],
+                         type_,
+                         minNumberOfMatches_,
+                         maxAbsDx_,
+                         maxAbsPullX_,
+                         maxAbsDy_,
+                         maxAbsPullY_,
+                         maxChamberDist_,
+                         maxChamberDistPull_,
+                         arbitrationType_))
+      outputCollection->push_back(edm::RefVector<std::vector<reco::Muon>>::value_type(muons, i));
+  iEvent.put(std::move(outputCollection));
 }

--- a/RecoMuon/MuonIdentification/plugins/MuonRefProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonRefProducer.h
@@ -5,7 +5,7 @@
 //
 // Package:    MuonIdentification
 // Class:      MuonRefProducer
-// 
+//
 /*
 
  Description: create a reduced collection of muons based on a reference
@@ -14,7 +14,6 @@
 //
 // Original Author:  Dmytro Kovalskyi
 //
-
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -25,23 +24,23 @@
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
 class MuonRefProducer : public edm::global::EDProducer<> {
- public:
-   explicit MuonRefProducer(const edm::ParameterSet&);
-   ~MuonRefProducer() override;
-   void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+public:
+  explicit MuonRefProducer(const edm::ParameterSet&);
+  ~MuonRefProducer() override;
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
- private:
-   edm::InputTag theReferenceCollection_;
-   edm::EDGetTokenT<reco::MuonCollection> muonToken_;
+private:
+  edm::InputTag theReferenceCollection_;
+  edm::EDGetTokenT<reco::MuonCollection> muonToken_;
 
-   muon::AlgorithmType type_;
-   int    minNumberOfMatches_;
-   double maxAbsDx_;
-   double maxAbsPullX_;
-   double maxAbsDy_;
-   double maxAbsPullY_;
-   double maxChamberDist_;
-   double maxChamberDistPull_;
-   reco::Muon::ArbitrationType arbitrationType_;
+  muon::AlgorithmType type_;
+  int minNumberOfMatches_;
+  double maxAbsDx_;
+  double maxAbsPullX_;
+  double maxAbsDy_;
+  double maxAbsPullY_;
+  double maxChamberDist_;
+  double maxChamberDistPull_;
+  reco::Muon::ArbitrationType arbitrationType_;
 };
 #endif

--- a/RecoMuon/MuonIdentification/plugins/MuonSelectionTypeValueMapProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonSelectionTypeValueMapProducer.h
@@ -16,50 +16,47 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class MuonSelectionTypeValueMapProducer : public edm::stream::EDProducer<> {
-    public:
-        explicit MuonSelectionTypeValueMapProducer(const edm::ParameterSet& iConfig) :
-            inputMuonCollection_(iConfig.getParameter<edm::InputTag>("inputMuonCollection")),
-            selectionTypeLabel_(iConfig.getParameter<std::string>("selectionType"))
-        {
-            selectionType_ = muon::selectionTypeFromString(selectionTypeLabel_);
-            produces<edm::ValueMap<bool> >().setBranchAlias("muid"+selectionTypeLabel_);
-	    muonToken_ = consumes<reco::MuonCollection>(inputMuonCollection_);
-        }
-        ~MuonSelectionTypeValueMapProducer() override {}
+public:
+  explicit MuonSelectionTypeValueMapProducer(const edm::ParameterSet& iConfig)
+      : inputMuonCollection_(iConfig.getParameter<edm::InputTag>("inputMuonCollection")),
+        selectionTypeLabel_(iConfig.getParameter<std::string>("selectionType")) {
+    selectionType_ = muon::selectionTypeFromString(selectionTypeLabel_);
+    produces<edm::ValueMap<bool>>().setBranchAlias("muid" + selectionTypeLabel_);
+    muonToken_ = consumes<reco::MuonCollection>(inputMuonCollection_);
+  }
+  ~MuonSelectionTypeValueMapProducer() override {}
 
-    private:
-        void produce(edm::Event&, const edm::EventSetup&) override;
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-        edm::InputTag inputMuonCollection_;
-	edm::EDGetTokenT<reco::MuonCollection> muonToken_;
+  edm::InputTag inputMuonCollection_;
+  edm::EDGetTokenT<reco::MuonCollection> muonToken_;
 
-        std::string selectionTypeLabel_;
-        muon::SelectionType selectionType_;
+  std::string selectionTypeLabel_;
+  muon::SelectionType selectionType_;
 };
 
-void
-MuonSelectionTypeValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-    // input muon collection
-    edm::Handle<reco::MuonCollection> muonsH;
-    iEvent.getByToken(muonToken_, muonsH);
+void MuonSelectionTypeValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  // input muon collection
+  edm::Handle<reco::MuonCollection> muonsH;
+  iEvent.getByToken(muonToken_, muonsH);
 
-    // reserve some space
-    std::vector<bool> values;
-    values.reserve(muonsH->size());
+  // reserve some space
+  std::vector<bool> values;
+  values.reserve(muonsH->size());
 
-    // isGoodMuon
-    for(reco::MuonCollection::const_iterator it = muonsH->begin(); it != muonsH->end(); ++it)
-        values.push_back(muon::isGoodMuon(*it, selectionType_));
+  // isGoodMuon
+  for (reco::MuonCollection::const_iterator it = muonsH->begin(); it != muonsH->end(); ++it)
+    values.push_back(muon::isGoodMuon(*it, selectionType_));
 
-    // create and fill value map
-    auto out = std::make_unique<edm::ValueMap<bool>>();
-    edm::ValueMap<bool>::Filler filler(*out);
-    filler.insert(muonsH, values.begin(), values.end());
-    filler.fill();
+  // create and fill value map
+  auto out = std::make_unique<edm::ValueMap<bool>>();
+  edm::ValueMap<bool>::Filler filler(*out);
+  filler.insert(muonsH, values.begin(), values.end());
+  filler.fill();
 
-    // put value map into event
-    iEvent.put(std::move(out));
+  // put value map into event
+  iEvent.put(std::move(out));
 }
 
 #endif

--- a/RecoMuon/MuonIdentification/plugins/MuonShowerInformationProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonShowerInformationProducer.cc
@@ -18,19 +18,19 @@
 
 class MuonShowerInformationProducer : public edm::stream::EDProducer<> {
 public:
-  MuonShowerInformationProducer(const edm::ParameterSet& iConfig) :
-    inputMuonCollection_(iConfig.getParameter<edm::InputTag>("muonCollection")),
-    inputTrackCollection_(iConfig.getParameter<edm::InputTag>("trackCollection"))
-  {
+  MuonShowerInformationProducer(const edm::ParameterSet& iConfig)
+      : inputMuonCollection_(iConfig.getParameter<edm::InputTag>("muonCollection")),
+        inputTrackCollection_(iConfig.getParameter<edm::InputTag>("trackCollection")) {
     edm::ConsumesCollector iC = consumesCollector();
-    showerFiller_ =  new MuonShowerInformationFiller(iConfig.getParameter<edm::ParameterSet>("ShowerInformationFillerParameters"),iC);
+    showerFiller_ = new MuonShowerInformationFiller(
+        iConfig.getParameter<edm::ParameterSet>("ShowerInformationFillerParameters"), iC);
 
     muonToken_ = consumes<reco::MuonCollection>(inputMuonCollection_);
- 
-    produces<edm::ValueMap<reco::MuonShower> >().setBranchAlias("muonShowerInformation");
+
+    produces<edm::ValueMap<reco::MuonShower>>().setBranchAlias("muonShowerInformation");
   }
-   ~MuonShowerInformationProducer() override {
-    if( showerFiller_)
+  ~MuonShowerInformationProducer() override {
+    if (showerFiller_)
       delete showerFiller_;
   }
 
@@ -40,27 +40,21 @@ private:
   edm::InputTag inputTrackCollection_;
   edm::EDGetTokenT<reco::MuonCollection> muonToken_;
 
-
-
-  MuonShowerInformationFiller *showerFiller_;
+  MuonShowerInformationFiller* showerFiller_;
 };
 
-void
-MuonShowerInformationProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void MuonShowerInformationProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<reco::MuonCollection> muons;
   iEvent.getByToken(muonToken_, muons);
 
   // reserve some space for output
   std::vector<reco::MuonShower> showerInfoValues;
   showerInfoValues.reserve(muons->size());
-  
-  for(reco::MuonCollection::const_iterator muon = muons->begin(); 
-      muon != muons->end(); ++muon)
-    {
-     // if (!muon->isGlobalMuon() && !muon->isStandAloneMuon()) continue;
-      showerInfoValues.push_back(showerFiller_->fillShowerInformation(*muon,iEvent,iSetup));
-    }
+
+  for (reco::MuonCollection::const_iterator muon = muons->begin(); muon != muons->end(); ++muon) {
+    // if (!muon->isGlobalMuon() && !muon->isStandAloneMuon()) continue;
+    showerInfoValues.push_back(showerFiller_->fillShowerInformation(*muon, iEvent, iSetup));
+  }
 
   // create and fill value map
   auto outC = std::make_unique<edm::ValueMap<reco::MuonShower>>();

--- a/RecoMuon/MuonIdentification/plugins/MuonTimingProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonTimingProducer.cc
@@ -1,7 +1,7 @@
 //
 // Package:    MuonTimingProducer
 // Class:      MuonTimingProducer
-// 
+//
 /**\class MuonTimingProducer MuonTimingProducer.cc RecoMuon/MuonIdentification/src/MuonTimingProducer.cc
 
  Description: <one line class summary>
@@ -15,7 +15,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 
@@ -28,79 +27,71 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "DataFormats/MuonReco/interface/Muon.h" 
-#include "DataFormats/MuonReco/interface/MuonFwd.h" 
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/MuonTimeExtra.h"
 #include "DataFormats/MuonReco/interface/MuonTimeExtraMap.h"
 
 #include "RecoMuon/MuonIdentification/plugins/MuonTimingProducer.h"
 #include "RecoMuon/MuonIdentification/interface/TimeMeasurementSequence.h"
 
-
 //
 // constructors and destructor
 //
-MuonTimingProducer::MuonTimingProducer(const edm::ParameterSet& iConfig)
-{
-   produces<reco::MuonTimeExtraMap>("combined");
-   produces<reco::MuonTimeExtraMap>("dt");
-   produces<reco::MuonTimeExtraMap>("csc");
+MuonTimingProducer::MuonTimingProducer(const edm::ParameterSet& iConfig) {
+  produces<reco::MuonTimeExtraMap>("combined");
+  produces<reco::MuonTimeExtraMap>("dt");
+  produces<reco::MuonTimeExtraMap>("csc");
 
-   m_muonCollection = iConfig.getParameter<edm::InputTag>("MuonCollection");
-   muonToken_ = consumes<reco::MuonCollection>(m_muonCollection);
-   // Load parameters for the TimingFiller
-   edm::ParameterSet fillerParameters = iConfig.getParameter<edm::ParameterSet>("TimingFillerParameters");
-   theTimingFiller_ = new MuonTimingFiller(fillerParameters,consumesCollector());
+  m_muonCollection = iConfig.getParameter<edm::InputTag>("MuonCollection");
+  muonToken_ = consumes<reco::MuonCollection>(m_muonCollection);
+  // Load parameters for the TimingFiller
+  edm::ParameterSet fillerParameters = iConfig.getParameter<edm::ParameterSet>("TimingFillerParameters");
+  theTimingFiller_ = new MuonTimingFiller(fillerParameters, consumesCollector());
 }
 
-
-MuonTimingProducer::~MuonTimingProducer()
-{
-   if (theTimingFiller_) delete theTimingFiller_;
+MuonTimingProducer::~MuonTimingProducer() {
+  if (theTimingFiller_)
+    delete theTimingFiller_;
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to produce the data  ------------
-void
-MuonTimingProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-
+void MuonTimingProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   auto muonTimeMap = std::make_unique<reco::MuonTimeExtraMap>();
   reco::MuonTimeExtraMap::Filler filler(*muonTimeMap);
   auto muonTimeMapDT = std::make_unique<reco::MuonTimeExtraMap>();
   reco::MuonTimeExtraMap::Filler fillerDT(*muonTimeMapDT);
   auto muonTimeMapCSC = std::make_unique<reco::MuonTimeExtraMap>();
   reco::MuonTimeExtraMap::Filler fillerCSC(*muonTimeMapCSC);
-  
-  edm::Handle<reco::MuonCollection> muons; 
+
+  edm::Handle<reco::MuonCollection> muons;
   iEvent.getByToken(muonToken_, muons);
 
   unsigned int nMuons = muons->size();
-  
+
   std::vector<reco::MuonTimeExtra> dtTimeColl(nMuons);
   std::vector<reco::MuonTimeExtra> cscTimeColl(nMuons);
   std::vector<reco::MuonTimeExtra> combinedTimeColl(nMuons);
 
-  for ( unsigned int i=0; i<nMuons; ++i ) {
-
+  for (unsigned int i = 0; i < nMuons; ++i) {
     reco::MuonTimeExtra dtTime;
     reco::MuonTimeExtra cscTime;
     reco::MuonTime rpcTime;
     reco::MuonTimeExtra combinedTime;
 
-    reco::MuonRef muonr(muons,i);
-    
+    reco::MuonRef muonr(muons, i);
+
     theTimingFiller_->fillTiming(*muonr, dtTime, cscTime, rpcTime, combinedTime, iEvent, iSetup);
-    
+
     dtTimeColl[i] = dtTime;
     cscTimeColl[i] = cscTime;
     combinedTimeColl[i] = combinedTime;
-     
   }
-  
+
   filler.insert(muons, combinedTimeColl.begin(), combinedTimeColl.end());
   filler.fill();
   fillerDT.insert(muons, dtTimeColl.begin(), dtTimeColl.end());
@@ -108,12 +99,10 @@ MuonTimingProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   fillerCSC.insert(muons, cscTimeColl.begin(), cscTimeColl.end());
   fillerCSC.fill();
 
-  iEvent.put(std::move(muonTimeMap),"combined");
-  iEvent.put(std::move(muonTimeMapDT),"dt");
-  iEvent.put(std::move(muonTimeMapCSC),"csc");
-
+  iEvent.put(std::move(muonTimeMap), "combined");
+  iEvent.put(std::move(muonTimeMapDT), "dt");
+  iEvent.put(std::move(muonTimeMapCSC), "csc");
 }
-
 
 //define this as a plug-in
 //DEFINE_FWK_MODULE(MuonTimingProducer);

--- a/RecoMuon/MuonIdentification/plugins/MuonTimingProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonTimingProducer.h
@@ -5,7 +5,7 @@
 //
 // Package:    MuonTimingProducer
 // Class:      MuonTimingProducer
-// 
+//
 /**\class MuonTimingProducer MuonTimingProducer.h RecoMuon/MuonIdentification/interface/MuonTimingProducer.h
 
  Description: <one line class summary>
@@ -18,7 +18,6 @@
 //         Created:  Mon Mar 16 12:27:22 CET 2009
 //
 //
-
 
 // system include files
 #include <memory>
@@ -35,25 +34,23 @@
 #include "DataFormats/MuonReco/interface/MuonTimeExtra.h"
 #include "RecoMuon/MuonIdentification/interface/MuonTimingFiller.h"
 
-
 //
 // class decleration
 //
 
 class MuonTimingProducer : public edm::stream::EDProducer<> {
-   public:
-      explicit MuonTimingProducer(const edm::ParameterSet&);
-      ~MuonTimingProducer() override;
+public:
+  explicit MuonTimingProducer(const edm::ParameterSet&);
+  ~MuonTimingProducer() override;
 
-   private:
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      
-      // ----------member data ---------------------------
-      edm::InputTag m_muonCollection;
-      edm::EDGetTokenT<reco::MuonCollection> muonToken_;
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-      MuonTimingFiller* theTimingFiller_;
+  // ----------member data ---------------------------
+  edm::InputTag m_muonCollection;
+  edm::EDGetTokenT<reco::MuonCollection> muonToken_;
 
+  MuonTimingFiller* theTimingFiller_;
 };
 
 #endif

--- a/RecoMuon/MuonIdentification/plugins/MuonsFromRefitTracksProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonsFromRefitTracksProducer.cc
@@ -18,14 +18,15 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/TrackToTrackMap.h"
 
-reco::Muon::MuonTrackTypePair tevOptimizedTMR(const reco::Muon& muon, const reco::TrackToTrackMap& fmsMap,
-				const double cut) {
+reco::Muon::MuonTrackTypePair tevOptimizedTMR(const reco::Muon& muon,
+                                              const reco::TrackToTrackMap& fmsMap,
+                                              const double cut) {
   const reco::TrackRef& combinedTrack = muon.globalTrack();
-  const reco::TrackRef& trackerTrack  = muon.innerTrack();
+  const reco::TrackRef& trackerTrack = muon.innerTrack();
 
   reco::TrackToTrackMap::const_iterator fmsTrack = fmsMap.find(combinedTrack);
 
-  double probTK  = 0;
+  double probTK = 0;
   double probFMS = 0;
 
   if (trackerTrack.isAvailable() && trackerTrack->numberOfValidHits())
@@ -33,34 +34,34 @@ reco::Muon::MuonTrackTypePair tevOptimizedTMR(const reco::Muon& muon, const reco
   if (fmsTrack != fmsMap.end() && fmsTrack->val->numberOfValidHits())
     probFMS = muon::trackProbability(fmsTrack->val);
 
-  bool TKok  = probTK > 0;
+  bool TKok = probTK > 0;
   bool FMSok = probFMS > 0;
 
   if (TKok && FMSok) {
     if (probFMS - probTK > cut)
-      return make_pair(trackerTrack,reco::Muon::InnerTrack);
+      return make_pair(trackerTrack, reco::Muon::InnerTrack);
     else
-      return make_pair(fmsTrack->val,reco::Muon::TPFMS);
-  }
-  else if (FMSok)
-    return make_pair(fmsTrack->val,reco::Muon::TPFMS);
+      return make_pair(fmsTrack->val, reco::Muon::TPFMS);
+  } else if (FMSok)
+    return make_pair(fmsTrack->val, reco::Muon::TPFMS);
   else if (TKok)
-    return make_pair(trackerTrack,reco::Muon::InnerTrack);
+    return make_pair(trackerTrack, reco::Muon::InnerTrack);
 
-  return make_pair(combinedTrack,reco::Muon::CombinedTrack);
+  return make_pair(combinedTrack, reco::Muon::CombinedTrack);
 }
 
- reco::Muon::MuonTrackTypePair sigmaSwitch(const reco::Muon& muon, const double nSigma, const double ptThreshold) {
+reco::Muon::MuonTrackTypePair sigmaSwitch(const reco::Muon& muon, const double nSigma, const double ptThreshold) {
   const reco::TrackRef& combinedTrack = muon.globalTrack();
-  const reco::TrackRef& trackerTrack  = muon.innerTrack();
+  const reco::TrackRef& trackerTrack = muon.innerTrack();
 
   if (combinedTrack->pt() < ptThreshold || trackerTrack->pt() < ptThreshold)
-    return make_pair(trackerTrack,reco::Muon::InnerTrack);
+    return make_pair(trackerTrack, reco::Muon::InnerTrack);
 
   double delta = fabs(trackerTrack->qoverp() - combinedTrack->qoverp());
   double threshold = nSigma * trackerTrack->qoverpError();
 
-  return delta > threshold ? make_pair(trackerTrack,reco::Muon::InnerTrack) : make_pair(combinedTrack,reco::Muon::CombinedTrack);
+  return delta > threshold ? make_pair(trackerTrack, reco::Muon::InnerTrack)
+                           : make_pair(combinedTrack, reco::Muon::CombinedTrack);
 }
 
 class MuonsFromRefitTracksProducer : public edm::stream::EDProducer<> {
@@ -77,12 +78,11 @@ private:
   // Take the muon passed in, clone it (so that we save all the muon
   // id information such as isolation, calo energy, etc.) and replace
   // its combined muon track with the passed in track.
-  reco::Muon* cloneAndSwitchTrack(const reco::Muon& muon,
-				  const reco::Muon::MuonTrackTypePair& newTrack) const;
+  reco::Muon* cloneAndSwitchTrack(const reco::Muon& muon, const reco::Muon::MuonTrackTypePair& newTrack) const;
 
   // The input muons -- i.e. the merged collection of reco::Muons.
   edm::InputTag src;
- 
+
   // Allow building the muon from just the tracker track. This
   // functionality should go away after understanding the difference
   // between the output of option 1 of GlobalMuonProducer and just
@@ -119,10 +119,10 @@ private:
   // Whether to use Adam Everett's sigma-switch method, choosing
   // between the global track and the tracker track.
   bool fromSigmaSwitch;
-  
+
   // The number of sigma to switch on in the above method.
   double nSigmaSwitch;
-  
+
   // The pT threshold to switch at in the above method.
   double ptThreshold;
 
@@ -136,74 +136,61 @@ private:
   edm::Handle<reco::TrackToTrackMap> trackMapFirstHit;
   edm::Handle<reco::TrackToTrackMap> trackMapPicky;
 
-
-
   // All the tokens
   edm::EDGetTokenT<edm::View<reco::Muon> > srcToken_;
   edm::EDGetTokenT<reco::TrackToTrackMap> trackMapToken_;
   edm::EDGetTokenT<reco::TrackToTrackMap> trackMapDefaultToken_;
   edm::EDGetTokenT<reco::TrackToTrackMap> trackMapFirstHitToken_;
   edm::EDGetTokenT<reco::TrackToTrackMap> trackMapPickyToken_;
-
-
-
 };
 
 MuonsFromRefitTracksProducer::MuonsFromRefitTracksProducer(const edm::ParameterSet& cfg)
-  : src(cfg.getParameter<edm::InputTag>("src")),
-    fromTrackerTrack(cfg.getParameter<bool>("fromTrackerTrack")),
-    fromGlobalTrack(cfg.getParameter<bool>("fromGlobalTrack")),
-    tevMuonTracks(cfg.getParameter<std::string>("tevMuonTracks")),
-    fromCocktail(cfg.getParameter<bool>("fromCocktail")),
-    fromTMR(cfg.getParameter<bool>("fromTMR")),
-    TMRcut(cfg.getParameter<double>("TMRcut")),
-    fromSigmaSwitch(cfg.getParameter<bool>("fromSigmaSwitch")),
-    nSigmaSwitch(cfg.getParameter<double>("nSigmaSwitch")),
-    ptThreshold(cfg.getParameter<double>("ptThreshold"))
-{
+    : src(cfg.getParameter<edm::InputTag>("src")),
+      fromTrackerTrack(cfg.getParameter<bool>("fromTrackerTrack")),
+      fromGlobalTrack(cfg.getParameter<bool>("fromGlobalTrack")),
+      tevMuonTracks(cfg.getParameter<std::string>("tevMuonTracks")),
+      fromCocktail(cfg.getParameter<bool>("fromCocktail")),
+      fromTMR(cfg.getParameter<bool>("fromTMR")),
+      TMRcut(cfg.getParameter<double>("TMRcut")),
+      fromSigmaSwitch(cfg.getParameter<bool>("fromSigmaSwitch")),
+      nSigmaSwitch(cfg.getParameter<double>("nSigmaSwitch")),
+      ptThreshold(cfg.getParameter<double>("ptThreshold")) {
   fromTeVRefit = tevMuonTracks != "none";
 
-
-  srcToken_ = consumes<edm::View<reco::Muon> >(src) ;
-  trackMapToken_ = consumes<reco::TrackToTrackMap> (edm::InputTag(tevMuonTracks, "default"));
-  trackMapDefaultToken_ = consumes<reco::TrackToTrackMap>(edm::InputTag(tevMuonTracks)) ;
+  srcToken_ = consumes<edm::View<reco::Muon> >(src);
+  trackMapToken_ = consumes<reco::TrackToTrackMap>(edm::InputTag(tevMuonTracks, "default"));
+  trackMapDefaultToken_ = consumes<reco::TrackToTrackMap>(edm::InputTag(tevMuonTracks));
   trackMapFirstHitToken_ = consumes<reco::TrackToTrackMap>(edm::InputTag(tevMuonTracks, "firstHit"));
-  trackMapPickyToken_ = consumes<reco::TrackToTrackMap> (edm::InputTag(tevMuonTracks, "picky"));
-
-
-
+  trackMapPickyToken_ = consumes<reco::TrackToTrackMap>(edm::InputTag(tevMuonTracks, "picky"));
 
   produces<reco::MuonCollection>();
 }
 
 bool MuonsFromRefitTracksProducer::storeMatchMaps(const edm::Event& event) {
   if (fromCocktail || fromTMR) {
-    event.getByToken(trackMapDefaultToken_,trackMapDefault);
+    event.getByToken(trackMapDefaultToken_, trackMapDefault);
     event.getByToken(trackMapFirstHitToken_, trackMapFirstHit);
-    event.getByToken(trackMapPickyToken_,    trackMapPicky);
-    return !trackMapDefault.failedToGet() && 
-      !trackMapFirstHit.failedToGet() && !trackMapPicky.failedToGet();
-  }
-  else {
+    event.getByToken(trackMapPickyToken_, trackMapPicky);
+    return !trackMapDefault.failedToGet() && !trackMapFirstHit.failedToGet() && !trackMapPicky.failedToGet();
+  } else {
     event.getByToken(trackMapToken_, trackMap);
     return !trackMap.failedToGet();
   }
 }
 
 reco::Muon* MuonsFromRefitTracksProducer::cloneAndSwitchTrack(const reco::Muon& muon,
-							      const  reco::Muon::MuonTrackTypePair& newTrack) const {
+                                                              const reco::Muon::MuonTrackTypePair& newTrack) const {
   // Muon mass to make a four-vector out of the new track.
   static const double muMass = 0.10566;
 
-  reco::TrackRef tkTrack  = muon.innerTrack();
-  reco::TrackRef muTrack  = muon.outerTrack();
-	  
+  reco::TrackRef tkTrack = muon.innerTrack();
+  reco::TrackRef muTrack = muon.outerTrack();
+
   // Make up a real Muon from the tracker track.
   reco::Particle::Point vtx(newTrack.first->vx(), newTrack.first->vy(), newTrack.first->vz());
   reco::Particle::LorentzVector p4;
   double p = newTrack.first->p();
-  p4.SetXYZT(newTrack.first->px(), newTrack.first->py(), newTrack.first->pz(),
-	     sqrt(p*p + muMass*muMass));
+  p4.SetXYZT(newTrack.first->px(), newTrack.first->py(), newTrack.first->pz(), sqrt(p * p + muMass * muMass));
 
   reco::Muon* mu = muon.clone();
   mu->setCharge(newTrack.first->charge());
@@ -243,59 +230,56 @@ void MuonsFromRefitTracksProducer::produce(edm::Event& event, const edm::EventSe
       // Filter out the so-called trackerMuons and stand-alone muons
       // (and caloMuons, if they were ever to get into the input muons
       // collection).
-      if (!muon->isGlobalMuon()) continue;
+      if (!muon->isGlobalMuon())
+        continue;
 
       if (fromTeVRefit || fromSigmaSwitch) {
-	// Start out with a null TrackRef.
-	reco::Muon::MuonTrackTypePair tevTk;
-      
-	// If making a cocktail muon, use tevOptimized() to get the track
-	// desired. Otherwise, get the refit track from the desired track
-	// map.
-	if (fromTMR)
-	  tevTk = tevOptimizedTMR(*muon, *trackMapFirstHit, TMRcut);
-	else if (fromCocktail)
-          tevTk = muon::tevOptimized(*muon);	  
-	else if (fromSigmaSwitch)
-	  tevTk = sigmaSwitch(*muon, nSigmaSwitch, ptThreshold);
-	else {
-        reco::TrackToTrackMap::const_iterator tevTkRef =
-	    trackMap->find(muon->combinedMuon());
-	  if (tevTkRef != trackMap->end())
-	    tevTk = make_pair(tevTkRef->val,reco::Muon::CombinedTrack);
-	}
-	
-	// If the TrackRef is valid, make a new Muon that has the same
-	// tracker and stand-alone tracks, but has the refit track as
-	// its global track.
-	if (tevTk.first.isNonnull())
-	  cands->push_back(*cloneAndSwitchTrack(*muon, tevTk));
-      }
-      else if (fromTrackerTrack)
-	cands->push_back(*cloneAndSwitchTrack(*muon, make_pair(muon->innerTrack(),reco::Muon::InnerTrack)));
-      else if (fromGlobalTrack)
-	cands->push_back(*cloneAndSwitchTrack(*muon, make_pair(muon->globalTrack(),reco::Muon::CombinedTrack)));
-      else {
-	cands->push_back(*muon->clone());
+        // Start out with a null TrackRef.
+        reco::Muon::MuonTrackTypePair tevTk;
 
-	// Just cloning does not work in the case of the source being
-	// a pat::Muon with embedded track references -- these do not
-	// get copied. Explicitly set them.
-    reco::Muon& last = cands->at(cands->size()-1);
-	if (muon->globalTrack().isTransient())
-	  last.setGlobalTrack(muon->globalTrack());
-	if (muon->innerTrack().isTransient())
-	  last.setInnerTrack(muon->innerTrack());
-	if (muon->outerTrack().isTransient())
-	  last.setOuterTrack(muon->outerTrack());
+        // If making a cocktail muon, use tevOptimized() to get the track
+        // desired. Otherwise, get the refit track from the desired track
+        // map.
+        if (fromTMR)
+          tevTk = tevOptimizedTMR(*muon, *trackMapFirstHit, TMRcut);
+        else if (fromCocktail)
+          tevTk = muon::tevOptimized(*muon);
+        else if (fromSigmaSwitch)
+          tevTk = sigmaSwitch(*muon, nSigmaSwitch, ptThreshold);
+        else {
+          reco::TrackToTrackMap::const_iterator tevTkRef = trackMap->find(muon->combinedMuon());
+          if (tevTkRef != trackMap->end())
+            tevTk = make_pair(tevTkRef->val, reco::Muon::CombinedTrack);
+        }
+
+        // If the TrackRef is valid, make a new Muon that has the same
+        // tracker and stand-alone tracks, but has the refit track as
+        // its global track.
+        if (tevTk.first.isNonnull())
+          cands->push_back(*cloneAndSwitchTrack(*muon, tevTk));
+      } else if (fromTrackerTrack)
+        cands->push_back(*cloneAndSwitchTrack(*muon, make_pair(muon->innerTrack(), reco::Muon::InnerTrack)));
+      else if (fromGlobalTrack)
+        cands->push_back(*cloneAndSwitchTrack(*muon, make_pair(muon->globalTrack(), reco::Muon::CombinedTrack)));
+      else {
+        cands->push_back(*muon->clone());
+
+        // Just cloning does not work in the case of the source being
+        // a pat::Muon with embedded track references -- these do not
+        // get copied. Explicitly set them.
+        reco::Muon& last = cands->at(cands->size() - 1);
+        if (muon->globalTrack().isTransient())
+          last.setGlobalTrack(muon->globalTrack());
+        if (muon->innerTrack().isTransient())
+          last.setInnerTrack(muon->innerTrack());
+        if (muon->outerTrack().isTransient())
+          last.setOuterTrack(muon->outerTrack());
       }
     }
-  }
-  else
-    edm::LogWarning("MuonsFromRefitTracksProducer")
-      << "either " << src << " or the track map(s) " << tevMuonTracks
-      << " not present in the event; producing empty collection";
-  
+  } else
+    edm::LogWarning("MuonsFromRefitTracksProducer") << "either " << src << " or the track map(s) " << tevMuonTracks
+                                                    << " not present in the event; producing empty collection";
+
   event.put(std::move(cands));
 }
 

--- a/RecoMuon/MuonIdentification/plugins/TrajectorySeedFromMuonProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/TrajectorySeedFromMuonProducer.cc
@@ -44,67 +44,62 @@
 
 #include "RecoMuon/MuonIdentification/interface/MuonCosmicsId.h"
 
-class TrajectorySeedFromMuonProducer : public edm::stream::EDProducer<>
-{
-
+class TrajectorySeedFromMuonProducer : public edm::stream::EDProducer<> {
 public:
-    explicit TrajectorySeedFromMuonProducer( const edm::ParameterSet & );   
-    void produce(edm::Event&, const edm::EventSetup&) override;
+  explicit TrajectorySeedFromMuonProducer(const edm::ParameterSet&);
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
-  edm::InputTag  muonCollectionTag_;
-  edm::InputTag  trackCollectionTag_;
+  edm::InputTag muonCollectionTag_;
+  edm::InputTag trackCollectionTag_;
   edm::EDGetTokenT<edm::View<reco::Muon> > muonCollectionToken_;
   edm::EDGetTokenT<reco::TrackCollection> trackCollectionToken_;
   bool skipMatchedMuons_;
-
 };
 
-TrajectorySeedFromMuonProducer::TrajectorySeedFromMuonProducer(const edm::ParameterSet & iConfig)
-{
-  muonCollectionTag_  = iConfig.getParameter<edm::InputTag>("muonCollectionTag");
+TrajectorySeedFromMuonProducer::TrajectorySeedFromMuonProducer(const edm::ParameterSet& iConfig) {
+  muonCollectionTag_ = iConfig.getParameter<edm::InputTag>("muonCollectionTag");
   trackCollectionTag_ = iConfig.getParameter<edm::InputTag>("trackCollectionTag");
-  skipMatchedMuons_   = iConfig.getParameter<bool>("skipMatchedMuons");
-  
+  skipMatchedMuons_ = iConfig.getParameter<bool>("skipMatchedMuons");
+
   muonCollectionToken_ = consumes<edm::View<reco::Muon> >(muonCollectionTag_);
-  trackCollectionToken_ = consumes<reco::TrackCollection> (trackCollectionTag_);
+  trackCollectionToken_ = consumes<reco::TrackCollection>(trackCollectionTag_);
 
   produces<TrajectorySeedCollection>();
 }
 
-
-void TrajectorySeedFromMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void TrajectorySeedFromMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
   using namespace reco;
   using namespace std;
 
   // Product
   auto result = std::make_unique<TrajectorySeedCollection>();
-  
+
   edm::ESHandle<MagneticField> magneticField;
   iSetup.get<IdealMagneticFieldRecord>().get(magneticField);
-  
+
   edm::ESHandle<TrackerGeometry> trackerGeometry;
   iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeometry);
-  
-  
-  
+
   edm::Handle<edm::View<Muon> > muonCollectionHandle;
   iEvent.getByToken(muonCollectionToken_, muonCollectionHandle);
-  
+
   edm::Handle<reco::TrackCollection> trackCollectionHandle;
   iEvent.getByToken(trackCollectionToken_, trackCollectionHandle);
 
   // Loop over the muon track
-  for (edm::View<Muon>::const_iterator muon = muonCollectionHandle->begin();  muon != muonCollectionHandle->end(); ++muon) {
+  for (edm::View<Muon>::const_iterator muon = muonCollectionHandle->begin(); muon != muonCollectionHandle->end();
+       ++muon) {
     // muon must have a tracker track
-    if( muon->innerTrack().isNull() ) continue;
+    if (muon->innerTrack().isNull())
+      continue;
     edm::RefToBase<reco::Track> track(muon->innerTrack());
     // check if there is a back-to-back track
-    if( skipMatchedMuons_ &&
-	muonid::findOppositeTrack(trackCollectionHandle, *track).isNonnull() ) continue;
-    if( (!track->innerOk()) || (!track->recHit(0)->isValid())) continue;
+    if (skipMatchedMuons_ && muonid::findOppositeTrack(trackCollectionHandle, *track).isNonnull())
+      continue;
+    if ((!track->innerOk()) || (!track->recHit(0)->isValid()))
+      continue;
     GlobalPoint innerPosition(track->innerPosition().x(), track->innerPosition().y(), track->innerPosition().z());
     GlobalVector innerMomentum(track->innerMomentum().x(), track->innerMomentum().y(), track->innerMomentum().z());
     int charge = track->charge();
@@ -114,23 +109,23 @@ void TrajectorySeedFromMuonProducer::produce(edm::Event& iEvent, const edm::Even
     GlobalTrajectoryParameters globalTrajParams(innerPosition, innerMomentum, charge, &(*magneticField));
     CurvilinearTrajectoryError curviError(innerStateCovariance);
     FreeTrajectoryState tracker_state(globalTrajParams, curviError);
-    LogTrace("MuonIdentification") << "Track Inner FTS: "<<tracker_state;
-    
-    TrajectoryStateOnSurface tracker_tsos  = TrajectoryStateOnSurface(globalTrajParams, curviError, trackerGeometry->idToDet(innerDetId)->surface());
-    
+    LogTrace("MuonIdentification") << "Track Inner FTS: " << tracker_state;
+
+    TrajectoryStateOnSurface tracker_tsos =
+        TrajectoryStateOnSurface(globalTrajParams, curviError, trackerGeometry->idToDet(innerDetId)->surface());
+
     // Make Hits, push back the innermost Hit
     edm::OwnVector<TrackingRecHit> trackHits;
-    trackHits.push_back(track->recHit(0)->clone() );
-    
+    trackHits.push_back(track->recHit(0)->clone());
+
     // Make TrajectorySeed
-    PTrajectoryStateOnDet const & PTraj = trajectoryStateTransform::persistentState(tracker_tsos, innerDetId.rawId());
+    PTrajectoryStateOnDet const& PTraj = trajectoryStateTransform::persistentState(tracker_tsos, innerDetId.rawId());
     TrajectorySeed trajectorySeed(PTraj, trackHits, oppositeToMomentum);
-    LogTrace("MuonIdentification")<<"Trajectory Seed Direction: "<< trajectorySeed.direction()<<endl;
+    LogTrace("MuonIdentification") << "Trajectory Seed Direction: " << trajectorySeed.direction() << endl;
     result->push_back(trajectorySeed);
   }
-  
-  iEvent.put(std::move(result));
 
+  iEvent.put(std::move(result));
 }
 
 DEFINE_FWK_MODULE(TrajectorySeedFromMuonProducer);

--- a/RecoMuon/MuonIdentification/plugins/cuts/GlobalMuonPromptTightCut.cc
+++ b/RecoMuon/MuonIdentification/plugins/cuts/GlobalMuonPromptTightCut.cc
@@ -2,6 +2,4 @@
 
 typedef MuonSelectorVIDWrapper<muon::GlobalMuonPromptTight> GlobalMuonPromptTightCut;
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  GlobalMuonPromptTightCut,
-		  "GlobalMuonPromptTightCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, GlobalMuonPromptTightCut, "GlobalMuonPromptTightCut");

--- a/RecoMuon/MuonIdentification/plugins/cuts/MuonDxyCut.cc
+++ b/RecoMuon/MuonIdentification/plugins/cuts/MuonDxyCut.cc
@@ -3,8 +3,7 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
-class MuonDxyCut : public CutApplicatorWithEventContentBase
-{
+class MuonDxyCut : public CutApplicatorWithEventContentBase {
 public:
   MuonDxyCut(const edm::ParameterSet& c);
 
@@ -20,22 +19,20 @@ private:
   const double maxDxy_;
   enum BestTrackType { INNERTRACK, MUONBESTTRACK, NONE } trackType_;
 };
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-                  MuonDxyCut, "MuonDxyCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, MuonDxyCut, "MuonDxyCut");
 
 // Define constructors and initialization routines
-MuonDxyCut::MuonDxyCut(const edm::ParameterSet& c):
-  CutApplicatorWithEventContentBase(c),
-  maxDxy_(c.getParameter<double>("maxDxy"))
-{
+MuonDxyCut::MuonDxyCut(const edm::ParameterSet& c)
+    : CutApplicatorWithEventContentBase(c), maxDxy_(c.getParameter<double>("maxDxy")) {
   const std::string trackTypeName = c.getParameter<std::string>("trackType");
   trackType_ = NONE;
-  if      ( trackTypeName == "muonBestTrack" ) trackType_ = MUONBESTTRACK;
-  else if ( trackTypeName == "innerTrack" ) trackType_ = INNERTRACK;
-  else
-  {
+  if (trackTypeName == "muonBestTrack")
+    trackType_ = MUONBESTTRACK;
+  else if (trackTypeName == "innerTrack")
+    trackType_ = INNERTRACK;
+  else {
     edm::LogError("MuonDxyCut") << "Wrong cut id name, " << trackTypeName
-                                        << "Choose among \"muonBestTrack\", \"innerTrack\"";
+                                << "Choose among \"muonBestTrack\", \"innerTrack\"";
     trackType_ = NONE;
   }
 
@@ -43,37 +40,39 @@ MuonDxyCut::MuonDxyCut(const edm::ParameterSet& c):
   contentTags_.emplace("verticesMiniAOD", c.getParameter<edm::InputTag>("vertexSrcMiniAOD"));
 }
 
-void MuonDxyCut::setConsumes(edm::ConsumesCollector& cc)
-{
+void MuonDxyCut::setConsumes(edm::ConsumesCollector& cc) {
   contentTokens_.emplace("vertices", cc.consumes<reco::VertexCollection>(contentTags_["vertices"]));
   contentTokens_.emplace("verticesMiniAOD", cc.consumes<reco::VertexCollection>(contentTags_["verticesMiniAOD"]));
 }
 
-void MuonDxyCut::getEventContent(const edm::EventBase& ev)
-{
+void MuonDxyCut::getEventContent(const edm::EventBase& ev) {
   ev.getByLabel(contentTags_["vertices"], vtxs_);
-  if ( !vtxs_.isValid() ) ev.getByLabel(contentTags_["verticesMiniAOD"], vtxs_);
+  if (!vtxs_.isValid())
+    ev.getByLabel(contentTags_["verticesMiniAOD"], vtxs_);
 }
 
 // Functors for evaluation
-CutApplicatorBase::result_type MuonDxyCut::operator()(const reco::MuonPtr& cand) const
-{
+CutApplicatorBase::result_type MuonDxyCut::operator()(const reco::MuonPtr& cand) const {
   const auto& vtxPos = vtxs_->at(0).position();
 
   reco::TrackRef trackRef;
-  if      ( trackType_ == INNERTRACK    ) trackRef = cand->innerTrack();
-  else if ( trackType_ == MUONBESTTRACK ) trackRef = cand->muonBestTrack();
+  if (trackType_ == INNERTRACK)
+    trackRef = cand->innerTrack();
+  else if (trackType_ == MUONBESTTRACK)
+    trackRef = cand->muonBestTrack();
 
   return trackRef.isNonnull() and std::abs(trackRef->dxy(vtxPos)) <= maxDxy_;
 }
 
-double MuonDxyCut::value(const reco::CandidatePtr& cand) const
-{
+double MuonDxyCut::value(const reco::CandidatePtr& cand) const {
   const reco::MuonPtr muon(cand);
   reco::TrackRef trackRef;
-  if      ( trackType_ == INNERTRACK    ) trackRef = muon->innerTrack();
-  else if ( trackType_ == MUONBESTTRACK ) trackRef = muon->muonBestTrack();
-  if ( trackRef.isNull() ) return -1;
+  if (trackType_ == INNERTRACK)
+    trackRef = muon->innerTrack();
+  else if (trackType_ == MUONBESTTRACK)
+    trackRef = muon->muonBestTrack();
+  if (trackRef.isNull())
+    return -1;
 
   const auto& vtxPos = vtxs_->at(0).position();
   return std::abs(trackRef->dxy(vtxPos));

--- a/RecoMuon/MuonIdentification/plugins/cuts/MuonDzCut.cc
+++ b/RecoMuon/MuonIdentification/plugins/cuts/MuonDzCut.cc
@@ -3,8 +3,7 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
-class MuonDzCut : public CutApplicatorWithEventContentBase
-{
+class MuonDzCut : public CutApplicatorWithEventContentBase {
 public:
   MuonDzCut(const edm::ParameterSet& c);
 
@@ -20,22 +19,20 @@ private:
   const double maxDz_;
   enum BestTrackType { INNERTRACK, MUONBESTTRACK, NONE } trackType_;
 };
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-                  MuonDzCut, "MuonDzCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, MuonDzCut, "MuonDzCut");
 
 // Define constructors and initialization routines
-MuonDzCut::MuonDzCut(const edm::ParameterSet& c):
-  CutApplicatorWithEventContentBase(c),
-  maxDz_(c.getParameter<double>("maxDz"))
-{
+MuonDzCut::MuonDzCut(const edm::ParameterSet& c)
+    : CutApplicatorWithEventContentBase(c), maxDz_(c.getParameter<double>("maxDz")) {
   const std::string trackTypeName = c.getParameter<std::string>("trackType");
   trackType_ = NONE;
-  if      ( trackTypeName == "muonBestTrack" ) trackType_ = MUONBESTTRACK;
-  else if ( trackTypeName == "innerTrack" ) trackType_ = INNERTRACK;
-  else
-  {
+  if (trackTypeName == "muonBestTrack")
+    trackType_ = MUONBESTTRACK;
+  else if (trackTypeName == "innerTrack")
+    trackType_ = INNERTRACK;
+  else {
     edm::LogError("MuonDzCut") << "Wrong cut id name, " << trackTypeName
-                                        << "Choose among \"muonBestTrack\", \"innerTrack\"";
+                               << "Choose among \"muonBestTrack\", \"innerTrack\"";
     trackType_ = NONE;
   }
 
@@ -43,37 +40,39 @@ MuonDzCut::MuonDzCut(const edm::ParameterSet& c):
   contentTags_.emplace("verticesMiniAOD", c.getParameter<edm::InputTag>("vertexSrcMiniAOD"));
 }
 
-void MuonDzCut::setConsumes(edm::ConsumesCollector& cc)
-{
+void MuonDzCut::setConsumes(edm::ConsumesCollector& cc) {
   contentTokens_.emplace("vertices", cc.consumes<reco::VertexCollection>(contentTags_["vertices"]));
   contentTokens_.emplace("verticesMiniAOD", cc.consumes<reco::VertexCollection>(contentTags_["verticesMiniAOD"]));
 }
 
-void MuonDzCut::getEventContent(const edm::EventBase& ev)
-{
+void MuonDzCut::getEventContent(const edm::EventBase& ev) {
   ev.getByLabel(contentTags_["vertices"], vtxs_);
-  if ( !vtxs_.isValid() ) ev.getByLabel(contentTags_["verticesMiniAOD"], vtxs_);
+  if (!vtxs_.isValid())
+    ev.getByLabel(contentTags_["verticesMiniAOD"], vtxs_);
 }
 
 // Functors for evaluation
-CutApplicatorBase::result_type MuonDzCut::operator()(const reco::MuonPtr& cand) const
-{
+CutApplicatorBase::result_type MuonDzCut::operator()(const reco::MuonPtr& cand) const {
   const auto& vtxPos = vtxs_->at(0).position();
 
   reco::TrackRef trackRef;
-  if      ( trackType_ == INNERTRACK    ) trackRef = cand->innerTrack();
-  else if ( trackType_ == MUONBESTTRACK ) trackRef = cand->muonBestTrack();
+  if (trackType_ == INNERTRACK)
+    trackRef = cand->innerTrack();
+  else if (trackType_ == MUONBESTTRACK)
+    trackRef = cand->muonBestTrack();
 
   return trackRef.isNonnull() and std::abs(trackRef->dz(vtxPos)) <= maxDz_;
 }
 
-double MuonDzCut::value(const reco::CandidatePtr& cand) const
-{
+double MuonDzCut::value(const reco::CandidatePtr& cand) const {
   const reco::MuonPtr muon(cand);
   reco::TrackRef trackRef;
-  if      ( trackType_ == INNERTRACK    ) trackRef = muon->innerTrack();
-  else if ( trackType_ == MUONBESTTRACK ) trackRef = muon->muonBestTrack();
-  if ( trackRef.isNull() ) return -1;
+  if (trackType_ == INNERTRACK)
+    trackRef = muon->innerTrack();
+  else if (trackType_ == MUONBESTTRACK)
+    trackRef = muon->muonBestTrack();
+  if (trackRef.isNull())
+    return -1;
 
   const auto& vtxPos = vtxs_->at(0).position();
   return std::abs(trackRef->dz(vtxPos));

--- a/RecoMuon/MuonIdentification/plugins/cuts/MuonMatchCut.cc
+++ b/RecoMuon/MuonIdentification/plugins/cuts/MuonMatchCut.cc
@@ -2,8 +2,7 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
-class MuonMatchCut : public CutApplicatorBase
-{
+class MuonMatchCut : public CutApplicatorBase {
 public:
   MuonMatchCut(const edm::ParameterSet& c);
 
@@ -13,25 +12,19 @@ public:
 
 private:
   const int minNumberOfMatchedStations_;
-
 };
 DEFINE_EDM_PLUGIN(CutApplicatorFactory, MuonMatchCut, "MuonMatchCut");
 
 // Define constructors and initialization routines
-MuonMatchCut::MuonMatchCut(const edm::ParameterSet& c):
-  CutApplicatorBase(c),
-  minNumberOfMatchedStations_(c.getParameter<int>("minNumberOfMatchedStations"))
-{
-}
+MuonMatchCut::MuonMatchCut(const edm::ParameterSet& c)
+    : CutApplicatorBase(c), minNumberOfMatchedStations_(c.getParameter<int>("minNumberOfMatchedStations")) {}
 
 // Functors for evaluation
-CutApplicatorBase::result_type MuonMatchCut::operator()(const reco::MuonPtr& muon) const
-{
+CutApplicatorBase::result_type MuonMatchCut::operator()(const reco::MuonPtr& muon) const {
   return muon->numberOfMatchedStations() >= minNumberOfMatchedStations_;
 }
 
-double MuonMatchCut::value(const reco::CandidatePtr& cand) const
-{
+double MuonMatchCut::value(const reco::CandidatePtr& cand) const {
   const reco::MuonPtr muon(cand);
   return muon->numberOfMatchedStations();
 }

--- a/RecoMuon/MuonIdentification/plugins/cuts/MuonMomQualityCut.cc
+++ b/RecoMuon/MuonIdentification/plugins/cuts/MuonMomQualityCut.cc
@@ -2,8 +2,7 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
-class MuonMomQualityCut : public CutApplicatorBase
-{
+class MuonMomQualityCut : public CutApplicatorBase {
 public:
   MuonMomQualityCut(const edm::ParameterSet& c);
 
@@ -17,26 +16,22 @@ private:
 DEFINE_EDM_PLUGIN(CutApplicatorFactory, MuonMomQualityCut, "MuonMomQualityCut");
 
 // Define constructors and initialization routines
-MuonMomQualityCut::MuonMomQualityCut(const edm::ParameterSet& c):
-  CutApplicatorBase(c),
-  maxRelPtErr_(c.getParameter<double>("maxRelPtErr"))
-{
-}
+MuonMomQualityCut::MuonMomQualityCut(const edm::ParameterSet& c)
+    : CutApplicatorBase(c), maxRelPtErr_(c.getParameter<double>("maxRelPtErr")) {}
 
 // Functors for evaluation
-CutApplicatorBase::result_type MuonMomQualityCut::operator()(const reco::MuonPtr& cand) const
-{
+CutApplicatorBase::result_type MuonMomQualityCut::operator()(const reco::MuonPtr& cand) const {
   const auto trackRef = cand->muonBestTrack();
-  return trackRef.isNonnull() and trackRef->ptError() <= maxRelPtErr_*trackRef->pt();
+  return trackRef.isNonnull() and trackRef->ptError() <= maxRelPtErr_ * trackRef->pt();
 
   return true;
 }
 
-double MuonMomQualityCut::value(const reco::CandidatePtr& cand) const
-{
+double MuonMomQualityCut::value(const reco::CandidatePtr& cand) const {
   const reco::MuonPtr muon(cand);
   const auto trackRef = muon->muonBestTrack();
-  if ( trackRef.isNull() or trackRef->pt() <= 0 ) return -1;
+  if (trackRef.isNull() or trackRef->pt() <= 0)
+    return -1;
 
-  return trackRef->ptError()/trackRef->pt();
+  return trackRef->ptError() / trackRef->pt();
 }

--- a/RecoMuon/MuonIdentification/plugins/cuts/MuonPOGStandardCut.cc
+++ b/RecoMuon/MuonIdentification/plugins/cuts/MuonPOGStandardCut.cc
@@ -3,8 +3,7 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
-class MuonPOGStandardCut : public CutApplicatorWithEventContentBase
-{
+class MuonPOGStandardCut : public CutApplicatorWithEventContentBase {
 public:
   MuonPOGStandardCut(const edm::ParameterSet& c);
 
@@ -17,27 +16,25 @@ public:
   double value(const reco::CandidatePtr& cand) const final;
 
 private:
-  enum CutType {
-    LOOSE, MEDIUM, TIGHT, SOFT, HIGHPT,
-    NONE
-  } cutType_;
+  enum CutType { LOOSE, MEDIUM, TIGHT, SOFT, HIGHPT, NONE } cutType_;
   edm::Handle<reco::VertexCollection> vtxs_;
 };
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-                  MuonPOGStandardCut, "MuonPOGStandardCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, MuonPOGStandardCut, "MuonPOGStandardCut");
 
 // Define constructors and initialization routines
-MuonPOGStandardCut::MuonPOGStandardCut(const edm::ParameterSet& c):
-  CutApplicatorWithEventContentBase(c)
-{
+MuonPOGStandardCut::MuonPOGStandardCut(const edm::ParameterSet& c) : CutApplicatorWithEventContentBase(c) {
   const auto cutTypeName = c.getParameter<std::string>("idName");
-  if ( cutTypeName == "loose") cutType_ = LOOSE;
-  else if ( cutTypeName == "tight") cutType_ = TIGHT;
-  else if ( cutTypeName == "medium") cutType_ = MEDIUM;
-  else if ( cutTypeName == "soft" ) cutType_ = SOFT;
-  else if ( cutTypeName == "highpt" ) cutType_ = HIGHPT;
-  else
-  {
+  if (cutTypeName == "loose")
+    cutType_ = LOOSE;
+  else if (cutTypeName == "tight")
+    cutType_ = TIGHT;
+  else if (cutTypeName == "medium")
+    cutType_ = MEDIUM;
+  else if (cutTypeName == "soft")
+    cutType_ = SOFT;
+  else if (cutTypeName == "highpt")
+    cutType_ = HIGHPT;
+  else {
     edm::LogError("MuonPOGStandardCut") << "Wrong cut id name, " << cutTypeName;
     cutType_ = NONE;
   }
@@ -45,65 +42,60 @@ MuonPOGStandardCut::MuonPOGStandardCut(const edm::ParameterSet& c):
   contentTags_.emplace("vertices", c.getParameter<edm::InputTag>("vertexSrc"));
 }
 
-void MuonPOGStandardCut::setConsumes(edm::ConsumesCollector& cc)
-{
+void MuonPOGStandardCut::setConsumes(edm::ConsumesCollector& cc) {
   auto vtcs = cc.consumes<reco::VertexCollection>(contentTags_["vertices"]);
   contentTokens_.emplace("vertices", vtcs);
 }
 
-void MuonPOGStandardCut::getEventContent(const edm::EventBase& ev)
-{
-  ev.getByLabel(contentTags_["vertices"], vtxs_);
-}
+void MuonPOGStandardCut::getEventContent(const edm::EventBase& ev) { ev.getByLabel(contentTags_["vertices"], vtxs_); }
 
 // Functors for evaluation
-CutApplicatorBase::result_type MuonPOGStandardCut::operator()(const reco::MuonPtr& cand) const
-{
-  switch( cutType_ ){
-  case LOOSE:
-    return muon::isLooseMuon(*cand);
-    break;
-  case TIGHT:
-    return muon::isTightMuon(*cand, vtxs_->at(0));
-    break;
-  case MEDIUM:
-    return muon::isMediumMuon(*cand);
-    break;
-  case SOFT:
-    return muon::isSoftMuon(*cand, vtxs_->at(0));
-    break;
-  case HIGHPT:
-    return muon::isHighPtMuon(*cand, vtxs_->at(0));
-    break;
-  case NONE:
-    return false;
-    break;
+CutApplicatorBase::result_type MuonPOGStandardCut::operator()(const reco::MuonPtr& cand) const {
+  switch (cutType_) {
+    case LOOSE:
+      return muon::isLooseMuon(*cand);
+      break;
+    case TIGHT:
+      return muon::isTightMuon(*cand, vtxs_->at(0));
+      break;
+    case MEDIUM:
+      return muon::isMediumMuon(*cand);
+      break;
+    case SOFT:
+      return muon::isSoftMuon(*cand, vtxs_->at(0));
+      break;
+    case HIGHPT:
+      return muon::isHighPtMuon(*cand, vtxs_->at(0));
+      break;
+    case NONE:
+      return false;
+      break;
   }
-  
+
   return true;
 }
 
 double MuonPOGStandardCut::value(const reco::CandidatePtr& cand) const {
   edm::Ptr<reco::Muon> mu(cand);
-  switch( cutType_ ){
-  case LOOSE:
-    return muon::isLooseMuon(*mu);
-    break;
-  case TIGHT:
-    return muon::isTightMuon(*mu, vtxs_->at(0));
-    break;
-  case MEDIUM:
-    return muon::isMediumMuon(*mu);
-    break;
-  case SOFT:
-    return muon::isSoftMuon(*mu, vtxs_->at(0));
-    break;
-  case HIGHPT:
-    return muon::isHighPtMuon(*mu, vtxs_->at(0));
-    break;
-  case NONE:
-    return 0.0;
-    break;
+  switch (cutType_) {
+    case LOOSE:
+      return muon::isLooseMuon(*mu);
+      break;
+    case TIGHT:
+      return muon::isTightMuon(*mu, vtxs_->at(0));
+      break;
+    case MEDIUM:
+      return muon::isMediumMuon(*mu);
+      break;
+    case SOFT:
+      return muon::isSoftMuon(*mu, vtxs_->at(0));
+      break;
+    case HIGHPT:
+      return muon::isHighPtMuon(*mu, vtxs_->at(0));
+      break;
+    case NONE:
+      return 0.0;
+      break;
   }
   return 1.0;
- }
+}

--- a/RecoMuon/MuonIdentification/plugins/cuts/MuonSegmentCompatibilityCut.cc
+++ b/RecoMuon/MuonIdentification/plugins/cuts/MuonSegmentCompatibilityCut.cc
@@ -2,8 +2,7 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
-class MuonSegmentCompatibilityCut : public CutApplicatorBase
-{
+class MuonSegmentCompatibilityCut : public CutApplicatorBase {
 public:
   MuonSegmentCompatibilityCut(const edm::ParameterSet& c);
 
@@ -14,17 +13,14 @@ public:
 private:
   double maxGlbNormChi2_, maxChi2LocalPos_, maxTrkKink_;
   const double minCompatGlb_, minCompatNonGlb_;
-
 };
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-                  MuonSegmentCompatibilityCut, "MuonSegmentCompatibilityCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, MuonSegmentCompatibilityCut, "MuonSegmentCompatibilityCut");
 
 // Define constructors and initialization routines
-MuonSegmentCompatibilityCut::MuonSegmentCompatibilityCut(const edm::ParameterSet& c):
-  CutApplicatorBase(c),
-  minCompatGlb_(c.getParameter<double>("minCompatGlb")),
-  minCompatNonGlb_(c.getParameter<double>("minCompatNonGlb"))
-{
+MuonSegmentCompatibilityCut::MuonSegmentCompatibilityCut(const edm::ParameterSet& c)
+    : CutApplicatorBase(c),
+      minCompatGlb_(c.getParameter<double>("minCompatGlb")),
+      minCompatNonGlb_(c.getParameter<double>("minCompatNonGlb")) {
   const edm::ParameterSet cc = c.getParameter<edm::ParameterSet>("goodGLB");
   maxGlbNormChi2_ = cc.getParameter<double>("maxGlbNormChi2");
   maxChi2LocalPos_ = cc.getParameter<double>("maxChi2LocalPos");
@@ -32,23 +28,17 @@ MuonSegmentCompatibilityCut::MuonSegmentCompatibilityCut(const edm::ParameterSet
 }
 
 // Functors for evaluation
-CutApplicatorBase::result_type MuonSegmentCompatibilityCut::operator()(const reco::MuonPtr& muon) const
-{
-  const bool isGoodGlb = (
-    muon->isGlobalMuon() and
-    muon->globalTrack()->normalizedChi2() < maxGlbNormChi2_ and
-    muon->combinedQuality().chi2LocalPosition < maxChi2LocalPos_ and
-    muon->combinedQuality().trkKink < maxTrkKink_
-  );
+CutApplicatorBase::result_type MuonSegmentCompatibilityCut::operator()(const reco::MuonPtr& muon) const {
+  const bool isGoodGlb =
+      (muon->isGlobalMuon() and muon->globalTrack()->normalizedChi2() < maxGlbNormChi2_ and
+       muon->combinedQuality().chi2LocalPosition < maxChi2LocalPos_ and muon->combinedQuality().trkKink < maxTrkKink_);
 
   const double compat = muon::segmentCompatibility(*muon);
 
   return compat > (isGoodGlb ? minCompatGlb_ : minCompatNonGlb_);
-
 }
 
-double MuonSegmentCompatibilityCut::value(const reco::CandidatePtr& cand) const
-{
+double MuonSegmentCompatibilityCut::value(const reco::CandidatePtr& cand) const {
   const reco::MuonPtr muon(cand);
   return muon::segmentCompatibility(*muon);
 }

--- a/RecoMuon/MuonIdentification/plugins/cuts/MuonSelectorVIDWrapper.h
+++ b/RecoMuon/MuonIdentification/plugins/cuts/MuonSelectorVIDWrapper.h
@@ -6,24 +6,22 @@
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 
-template<muon::SelectionType selectionType,reco::Muon::ArbitrationType arbitrationType = reco::Muon::SegmentAndTrackArbitration>
-  class MuonSelectorVIDWrapper : public CutApplicatorBase {
- public:
- MuonSelectorVIDWrapper(const edm::ParameterSet& c) :
- CutApplicatorBase(c) { }
+template <muon::SelectionType selectionType,
+          reco::Muon::ArbitrationType arbitrationType = reco::Muon::SegmentAndTrackArbitration>
+class MuonSelectorVIDWrapper : public CutApplicatorBase {
+public:
+  MuonSelectorVIDWrapper(const edm::ParameterSet& c) : CutApplicatorBase(c) {}
 
- double value(const reco::CandidatePtr& cand) const final {
-   edm::Ptr<reco::Muon> mu(cand);
-   return muon::isGoodMuon(*mu,selectionType,arbitrationType);
- }
+  double value(const reco::CandidatePtr& cand) const final {
+    edm::Ptr<reco::Muon> mu(cand);
+    return muon::isGoodMuon(*mu, selectionType, arbitrationType);
+  }
 
- result_type operator()(const edm::Ptr<reco::Muon> & muon) const final {
-   return muon::isGoodMuon(*muon,selectionType,arbitrationType);
- }
+  result_type operator()(const edm::Ptr<reco::Muon>& muon) const final {
+    return muon::isGoodMuon(*muon, selectionType, arbitrationType);
+  }
 
- CandidateType candidateType() const final {
-   return MUON;
- }
+  CandidateType candidateType() const final { return MUON; }
 };
 
 #endif

--- a/RecoMuon/MuonIdentification/plugins/cuts/MuonTrackCut.cc
+++ b/RecoMuon/MuonIdentification/plugins/cuts/MuonTrackCut.cc
@@ -2,8 +2,7 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
-class MuonTrackCut : public CutApplicatorBase
-{
+class MuonTrackCut : public CutApplicatorBase {
 public:
   MuonTrackCut(const edm::ParameterSet& c);
 
@@ -19,95 +18,104 @@ private:
   int minNumberOfValidMuonHits_;
 
   bool doInnerTrack_, doGlobalTrack_;
-
 };
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-                  MuonTrackCut, "MuonTrackCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, MuonTrackCut, "MuonTrackCut");
 
 // Define constructors and initialization routines
-MuonTrackCut::MuonTrackCut(const edm::ParameterSet& c):
-  CutApplicatorBase(c),
-  minTrackerLayersWithMeasurement_(-1),
-  minPixelLayersWithMeasurement_(-1),
-  minNumberOfValidPixelHits_(-1),
-  minValidFraction_(-1),
-  trackQuality_(reco::Track::undefQuality),
-  minNumberOfValidMuonHits_(-1),
-  doInnerTrack_(false), doGlobalTrack_(false)
-{
-  
-  if ( c.existsAs<edm::ParameterSet>("innerTrack") )
-  {
+MuonTrackCut::MuonTrackCut(const edm::ParameterSet& c)
+    : CutApplicatorBase(c),
+      minTrackerLayersWithMeasurement_(-1),
+      minPixelLayersWithMeasurement_(-1),
+      minNumberOfValidPixelHits_(-1),
+      minValidFraction_(-1),
+      trackQuality_(reco::Track::undefQuality),
+      minNumberOfValidMuonHits_(-1),
+      doInnerTrack_(false),
+      doGlobalTrack_(false) {
+  if (c.existsAs<edm::ParameterSet>("innerTrack")) {
     doInnerTrack_ = true;
 
     const edm::ParameterSet cc = c.getParameter<edm::ParameterSet>("innerTrack");
-    if ( cc.exists("minTrackerLayersWithMeasurement") ) minTrackerLayersWithMeasurement_ = cc.getParameter<int>("minTrackerLayersWithMeasurement");
-    if ( cc.exists("minPixelLayersWithMeasurement") ) minPixelLayersWithMeasurement_ = cc.getParameter<int>("minPixelLayersWithMeasurement");
-    if ( cc.exists("minNumberOfValidPixelHits") ) minNumberOfValidPixelHits_ = cc.getParameter<int>("minNumberOfValidPixelHits");
-    if ( cc.exists("minValidFraction") ) minValidFraction_ = cc.getParameter<double>("minValidFraction");
+    if (cc.exists("minTrackerLayersWithMeasurement"))
+      minTrackerLayersWithMeasurement_ = cc.getParameter<int>("minTrackerLayersWithMeasurement");
+    if (cc.exists("minPixelLayersWithMeasurement"))
+      minPixelLayersWithMeasurement_ = cc.getParameter<int>("minPixelLayersWithMeasurement");
+    if (cc.exists("minNumberOfValidPixelHits"))
+      minNumberOfValidPixelHits_ = cc.getParameter<int>("minNumberOfValidPixelHits");
+    if (cc.exists("minValidFraction"))
+      minValidFraction_ = cc.getParameter<double>("minValidFraction");
     const std::string trackQualityStr = cc.exists("trackQuality") ? cc.getParameter<std::string>("trackQuality") : "";
     trackQuality_ = reco::Track::qualityByName(trackQualityStr);
   }
-  if ( c.existsAs<edm::ParameterSet>("globalTrack") )
-  {
+  if (c.existsAs<edm::ParameterSet>("globalTrack")) {
     doGlobalTrack_ = true;
 
     const edm::ParameterSet cc = c.getParameter<edm::ParameterSet>("globalTrack");
     //if ( cc.exists("maxNormalizedChi2") ) maxNormalizedChi2_ = cc.getParameter<double>("maxNormalizedChi2");
-    if ( cc.exists("minNumberOfValidMuonHits") ) minNumberOfValidMuonHits_ = cc.getParameter<int>("minNumberOfValidMuonHits");
+    if (cc.exists("minNumberOfValidMuonHits"))
+      minNumberOfValidMuonHits_ = cc.getParameter<int>("minNumberOfValidMuonHits");
   }
-
 }
 
 // Functors for evaluation
-CutApplicatorBase::result_type MuonTrackCut::operator()(const reco::MuonPtr& muon) const
-{
-  if ( doInnerTrack_ )
-  {
+CutApplicatorBase::result_type MuonTrackCut::operator()(const reco::MuonPtr& muon) const {
+  if (doInnerTrack_) {
     const reco::TrackRef t = muon->innerTrack();
-    if ( t.isNull() ) return false;
+    if (t.isNull())
+      return false;
     const auto& h = t->hitPattern();
-    if ( trackQuality_ != reco::Track::undefQuality and !t->quality(trackQuality_) ) return false;
-    if ( h.trackerLayersWithMeasurement() < minTrackerLayersWithMeasurement_ ) return false;
-    if ( h.pixelLayersWithMeasurement() < minPixelLayersWithMeasurement_ ) return false;
-    if ( h.numberOfValidPixelHits() < minNumberOfValidPixelHits_ ) return false;
-    if ( t->validFraction() <= minValidFraction_ ) return false;
+    if (trackQuality_ != reco::Track::undefQuality and !t->quality(trackQuality_))
+      return false;
+    if (h.trackerLayersWithMeasurement() < minTrackerLayersWithMeasurement_)
+      return false;
+    if (h.pixelLayersWithMeasurement() < minPixelLayersWithMeasurement_)
+      return false;
+    if (h.numberOfValidPixelHits() < minNumberOfValidPixelHits_)
+      return false;
+    if (t->validFraction() <= minValidFraction_)
+      return false;
   }
-  if ( doGlobalTrack_ )
-  {
+  if (doGlobalTrack_) {
     const reco::TrackRef t = muon->globalTrack();
-    if ( t.isNull() ) return false;
+    if (t.isNull())
+      return false;
     const auto& h = t->hitPattern();
-    if ( h.numberOfValidMuonHits() < minNumberOfValidMuonHits_ ) return false;
-    // if ( t->normalizedChi2() > maxNormalizedChi2_ ) return false; Not used for 
+    if (h.numberOfValidMuonHits() < minNumberOfValidMuonHits_)
+      return false;
+    // if ( t->normalizedChi2() > maxNormalizedChi2_ ) return false; Not used for
   }
 
   return true;
 }
 
-double MuonTrackCut::value(const reco::CandidatePtr& cand) const
-{
+double MuonTrackCut::value(const reco::CandidatePtr& cand) const {
   const reco::MuonPtr muon(cand);
-  if ( doInnerTrack_ )
-  {
+  if (doInnerTrack_) {
     const reco::TrackRef t = muon->innerTrack();
-    if ( t.isNull() ) return 0;
+    if (t.isNull())
+      return 0;
     const auto& h = t->hitPattern();
-    if ( trackQuality_ != reco::Track::undefQuality and !t->quality(trackQuality_) ) return t->quality(trackQuality_);
-    if ( h.trackerLayersWithMeasurement() < minTrackerLayersWithMeasurement_ ) return h.trackerLayersWithMeasurement();
-    if ( h.pixelLayersWithMeasurement() < minPixelLayersWithMeasurement_ ) return h.pixelLayersWithMeasurement();
-    if ( h.numberOfValidPixelHits() < minNumberOfValidPixelHits_ ) return h.numberOfValidPixelHits();
-    if ( t->validFraction() <= minValidFraction_ ) return t->validFraction();
+    if (trackQuality_ != reco::Track::undefQuality and !t->quality(trackQuality_))
+      return t->quality(trackQuality_);
+    if (h.trackerLayersWithMeasurement() < minTrackerLayersWithMeasurement_)
+      return h.trackerLayersWithMeasurement();
+    if (h.pixelLayersWithMeasurement() < minPixelLayersWithMeasurement_)
+      return h.pixelLayersWithMeasurement();
+    if (h.numberOfValidPixelHits() < minNumberOfValidPixelHits_)
+      return h.numberOfValidPixelHits();
+    if (t->validFraction() <= minValidFraction_)
+      return t->validFraction();
 
     return t->validFraction();
   }
-  if ( doGlobalTrack_ )
-  {
+  if (doGlobalTrack_) {
     const reco::TrackRef t = muon->globalTrack();
-    if ( t.isNull() ) return 0;
+    if (t.isNull())
+      return 0;
     const auto& h = t->hitPattern();
-    if ( h.numberOfValidMuonHits() < minNumberOfValidMuonHits_ ) return h.numberOfValidMuonHits();
-    // if ( t->normalizedChi2() > maxNormalizedChi2_ ) return false; Not used for 
+    if (h.numberOfValidMuonHits() < minNumberOfValidMuonHits_)
+      return h.numberOfValidMuonHits();
+    // if ( t->normalizedChi2() > maxNormalizedChi2_ ) return false; Not used for
 
     return h.numberOfValidMuonHits();
   }

--- a/RecoMuon/MuonIdentification/plugins/cuts/MuonTypeByOrCut.cc
+++ b/RecoMuon/MuonIdentification/plugins/cuts/MuonTypeByOrCut.cc
@@ -2,8 +2,7 @@
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 
-class MuonTypeByOrCut : public CutApplicatorBase
-{
+class MuonTypeByOrCut : public CutApplicatorBase {
 public:
   MuonTypeByOrCut(const edm::ParameterSet& c);
 
@@ -17,31 +16,31 @@ private:
 DEFINE_EDM_PLUGIN(CutApplicatorFactory, MuonTypeByOrCut, "MuonTypeByOrCut");
 
 // Define constructors and initialization routines
-MuonTypeByOrCut::MuonTypeByOrCut(const edm::ParameterSet& c):
-  CutApplicatorBase(c),
-  type_(0)
-{
+MuonTypeByOrCut::MuonTypeByOrCut(const edm::ParameterSet& c) : CutApplicatorBase(c), type_(0) {
   const auto muonTypes = c.getParameter<std::vector<std::string> >("types");
-  for ( auto x : muonTypes )
-  {
+  for (auto x : muonTypes) {
     std::transform(x.begin(), x.end(), x.begin(), ::tolower);
-    if      ( x == "globalmuon"     ) type_ |= reco::Muon::GlobalMuon;
-    else if ( x == "trackermuon"    ) type_ |= reco::Muon::TrackerMuon;
-    else if ( x == "standalonemuon" ) type_ |= reco::Muon::StandAloneMuon;
-    else if ( x == "calomuon"       ) type_ |= reco::Muon::CaloMuon;
-    else if ( x == "pfmuon"         ) type_ |= reco::Muon::PFMuon;
-    else if ( x == "rpcmuon"        ) type_ |= reco::Muon::RPCMuon;
+    if (x == "globalmuon")
+      type_ |= reco::Muon::GlobalMuon;
+    else if (x == "trackermuon")
+      type_ |= reco::Muon::TrackerMuon;
+    else if (x == "standalonemuon")
+      type_ |= reco::Muon::StandAloneMuon;
+    else if (x == "calomuon")
+      type_ |= reco::Muon::CaloMuon;
+    else if (x == "pfmuon")
+      type_ |= reco::Muon::PFMuon;
+    else if (x == "rpcmuon")
+      type_ |= reco::Muon::RPCMuon;
   }
 }
 
 // Functors for evaluation
-CutApplicatorBase::result_type MuonTypeByOrCut::operator()(const reco::MuonPtr& muon) const
-{
+CutApplicatorBase::result_type MuonTypeByOrCut::operator()(const reco::MuonPtr& muon) const {
   return (muon->type() & type_) != 0;
 }
 
-double MuonTypeByOrCut::value(const reco::CandidatePtr& cand) const
-{
+double MuonTypeByOrCut::value(const reco::CandidatePtr& cand) const {
   const reco::MuonPtr muon(cand);
   return muon->type() & type_;
 }

--- a/RecoMuon/MuonIdentification/plugins/cuts/TMOneStationTightCut.cc
+++ b/RecoMuon/MuonIdentification/plugins/cuts/TMOneStationTightCut.cc
@@ -2,6 +2,4 @@
 
 typedef MuonSelectorVIDWrapper<muon::TMOneStationTight> TMOneStationTightCut;
 
-DEFINE_EDM_PLUGIN(CutApplicatorFactory,
-		  TMOneStationTightCut,
-		  "TMOneStationTightCut");
+DEFINE_EDM_PLUGIN(CutApplicatorFactory, TMOneStationTightCut, "TMOneStationTightCut");

--- a/RecoMuon/MuonIdentification/src/CSCTimingExtractor.cc
+++ b/RecoMuon/MuonIdentification/src/CSCTimingExtractor.cc
@@ -2,7 +2,7 @@
 //
 // Package:    MuonIdentification
 // Class:      CSCTimingExtractor
-// 
+//
 /**\class CSCTimingExtractor CSCTimingExtractor.cc RecoMuon/MuonIdentification/src/CSCTimingExtractor.cc
  *
  * Description: Produce timing information for a muon track using CSC hits from segments used to build the track
@@ -15,7 +15,6 @@
 //
 
 #include "RecoMuon/MuonIdentification/interface/CSCTimingExtractor.h"
-
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -48,7 +47,6 @@
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
 #include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
 
-
 // system include files
 #include <memory>
 #include <vector>
@@ -59,211 +57,204 @@ namespace edm {
   class ParameterSet;
   class EventSetup;
   class InputTag;
-}
+}  // namespace edm
 
 class MuonServiceProxy;
 
 //
 // constructors and destructor
 //
-CSCTimingExtractor::CSCTimingExtractor(const edm::ParameterSet& iConfig, MuonSegmentMatcher *segMatcher)
-  :
-  thePruneCut_(iConfig.getParameter<double>("PruneCut")),
-  theStripTimeOffset_(iConfig.getParameter<double>("CSCStripTimeOffset")),
-  theWireTimeOffset_(iConfig.getParameter<double>("CSCWireTimeOffset")),
-  theStripError_(iConfig.getParameter<double>("CSCStripError")),
-  theWireError_(iConfig.getParameter<double>("CSCWireError")),
-  UseWireTime(iConfig.getParameter<bool>("UseWireTime")),
-  UseStripTime(iConfig.getParameter<bool>("UseStripTime")),
-  debug(iConfig.getParameter<bool>("debug"))
-{
+CSCTimingExtractor::CSCTimingExtractor(const edm::ParameterSet& iConfig, MuonSegmentMatcher* segMatcher)
+    : thePruneCut_(iConfig.getParameter<double>("PruneCut")),
+      theStripTimeOffset_(iConfig.getParameter<double>("CSCStripTimeOffset")),
+      theWireTimeOffset_(iConfig.getParameter<double>("CSCWireTimeOffset")),
+      theStripError_(iConfig.getParameter<double>("CSCStripError")),
+      theWireError_(iConfig.getParameter<double>("CSCWireError")),
+      UseWireTime(iConfig.getParameter<bool>("UseWireTime")),
+      UseStripTime(iConfig.getParameter<bool>("UseStripTime")),
+      debug(iConfig.getParameter<bool>("debug")) {
   edm::ParameterSet serviceParameters = iConfig.getParameter<edm::ParameterSet>("ServiceParameters");
   theService = std::make_unique<MuonServiceProxy>(serviceParameters);
   theMatcher = segMatcher;
 }
 
-
-CSCTimingExtractor::~CSCTimingExtractor()
-{
-}
-
+CSCTimingExtractor::~CSCTimingExtractor() {}
 
 //
 // member functions
 //
 
-void CSCTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence,
-				    const std::vector<const CSCSegment*> &segments,
-				    reco::TrackRef muonTrack,
-				    const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void CSCTimingExtractor::fillTiming(TimeMeasurementSequence& tmSequence,
+                                    const std::vector<const CSCSegment*>& segments,
+                                    reco::TrackRef muonTrack,
+                                    const edm::Event& iEvent,
+                                    const edm::EventSetup& iSetup) {
   theService->update(iSetup);
 
-  const GlobalTrackingGeometry *theTrackingGeometry = &*theService->trackingGeometry();
+  const GlobalTrackingGeometry* theTrackingGeometry = &*theService->trackingGeometry();
 
-  // get the propagator  
+  // get the propagator
   edm::ESHandle<Propagator> propagator;
   iSetup.get<TrackingComponentsRecord>().get("SteppingHelixPropagatorAny", propagator);
-  const Propagator *propag = propagator.product();
+  const Propagator* propag = propagator.product();
 
-  math::XYZPoint  pos=muonTrack->innerPosition();
-  math::XYZVector mom=muonTrack->innerMomentum();
-  if (sqrt(muonTrack->innerPosition().mag2()) > sqrt(muonTrack->outerPosition().mag2())){
-     pos=muonTrack->outerPosition();
-     mom=-1*muonTrack->outerMomentum();
+  math::XYZPoint pos = muonTrack->innerPosition();
+  math::XYZVector mom = muonTrack->innerMomentum();
+  if (sqrt(muonTrack->innerPosition().mag2()) > sqrt(muonTrack->outerPosition().mag2())) {
+    pos = muonTrack->outerPosition();
+    mom = -1 * muonTrack->outerMomentum();
   }
-  GlobalPoint  posp(pos.x(), pos.y(), pos.z());
+  GlobalPoint posp(pos.x(), pos.y(), pos.z());
   GlobalVector momv(mom.x(), mom.y(), mom.z());
   FreeTrajectoryState muonFTS(posp, momv, (TrackCharge)muonTrack->charge(), theService->magneticField().product());
 
-  // create a collection on TimeMeasurements for the track        
+  // create a collection on TimeMeasurements for the track
   std::vector<TimeMeasurement> tms;
   for (const auto& rechit : segments) {
-
     // Create the ChamberId
     DetId id = rechit->geographicalId();
     CSCDetId chamberId(id.rawId());
     //    int station = chamberId.station();
 
-    if (rechit->specificRecHits().empty()) continue;
+    if (rechit->specificRecHits().empty())
+      continue;
 
     const std::vector<CSCRecHit2D>& hits2d(rechit->specificRecHits());
 
     // store all the hits from the segment
     for (const auto& hiti : hits2d) {
-
       const GeomDet* cscDet = theTrackingGeometry->idToDet(hiti.geographicalId());
       TimeMeasurement thisHit;
 
-      std::pair< TrajectoryStateOnSurface, double> tsos;
-      tsos=propag->propagateWithPath(muonFTS,cscDet->surface());
+      std::pair<TrajectoryStateOnSurface, double> tsos;
+      tsos = propag->propagateWithPath(muonFTS, cscDet->surface());
 
-      double dist;            
-      if (tsos.first.isValid()) dist = tsos.second+posp.mag(); 
-        else dist = cscDet->toGlobal(hiti.localPosition()).mag();
+      double dist;
+      if (tsos.first.isValid())
+        dist = tsos.second + posp.mag();
+      else
+        dist = cscDet->toGlobal(hiti.localPosition()).mag();
 
       thisHit.distIP = dist;
       if (UseStripTime) {
-        thisHit.weightInvbeta = dist*dist/(theStripError_*theStripError_*30.*30.);
-        thisHit.weightTimeVtx = 1./(theStripError_*theStripError_);
-        thisHit.timeCorr = hiti.tpeak()-theStripTimeOffset_;
+        thisHit.weightInvbeta = dist * dist / (theStripError_ * theStripError_ * 30. * 30.);
+        thisHit.weightTimeVtx = 1. / (theStripError_ * theStripError_);
+        thisHit.timeCorr = hiti.tpeak() - theStripTimeOffset_;
         tms.push_back(thisHit);
       }
 
       if (UseWireTime) {
-	thisHit.weightInvbeta = dist*dist/(theWireError_*theWireError_*30.*30.);
-        thisHit.weightTimeVtx = 1./(theWireError_*theWireError_);
-        thisHit.timeCorr = hiti.wireTime()-theWireTimeOffset_;
+        thisHit.weightInvbeta = dist * dist / (theWireError_ * theWireError_ * 30. * 30.);
+        thisHit.weightTimeVtx = 1. / (theWireError_ * theWireError_);
+        thisHit.timeCorr = hiti.wireTime() - theWireTimeOffset_;
         tms.push_back(thisHit);
       }
-      
-//      std::cout << " CSC Hit. Dist= " << dist << "    Time= " << thisHit.timeCorr 
-//           << "   invBeta= " << (1.+thisHit.timeCorr/dist*30.) << std::endl;
+
+      //      std::cout << " CSC Hit. Dist= " << dist << "    Time= " << thisHit.timeCorr
+      //           << "   invBeta= " << (1.+thisHit.timeCorr/dist*30.) << std::endl;
     }
 
-  } // rechit
+  }  // rechit
 
   bool modified = false;
-  std::vector <double> dstnc, local_t0, hitWeightInvbeta, hitWeightTimeVtx;
-  double totalWeightInvbeta=0;
-  double totalWeightTimeVtx=0;
+  std::vector<double> dstnc, local_t0, hitWeightInvbeta, hitWeightTimeVtx;
+  double totalWeightInvbeta = 0;
+  double totalWeightTimeVtx = 0;
 
   // Now loop over the measurements, calculate 1/beta and cut away outliers
-  do {    
-
+  do {
     modified = false;
     dstnc.clear();
     local_t0.clear();
     hitWeightInvbeta.clear();
     hitWeightTimeVtx.clear();
 
-    totalWeightInvbeta=0;
-    totalWeightTimeVtx=0;
-      
+    totalWeightInvbeta = 0;
+    totalWeightTimeVtx = 0;
+
     for (auto& tm : tms) {
       dstnc.push_back(tm.distIP);
       local_t0.push_back(tm.timeCorr);
       hitWeightInvbeta.push_back(tm.weightInvbeta);
       hitWeightTimeVtx.push_back(tm.weightTimeVtx);
-      totalWeightInvbeta+=tm.weightInvbeta;
-      totalWeightTimeVtx+=tm.weightTimeVtx;
+      totalWeightInvbeta += tm.weightInvbeta;
+      totalWeightTimeVtx += tm.weightTimeVtx;
     }
-          
-    if (totalWeightInvbeta==0) break;        
+
+    if (totalWeightInvbeta == 0)
+      break;
 
     // calculate the value and error of 1/beta and timeVtx from the complete set of 1D hits
     if (debug)
       std::cout << " Points for global fit: " << dstnc.size() << std::endl;
 
-    double invbeta=0,invbetaErr=0;
-    double timeVtx=0,timeVtxErr=0;
+    double invbeta = 0, invbetaErr = 0;
+    double timeVtx = 0, timeVtxErr = 0;
 
-    for (unsigned int i=0;i<dstnc.size();i++) {
-      invbeta+=(1.+local_t0.at(i)/dstnc.at(i)*30.)*hitWeightInvbeta.at(i)/totalWeightInvbeta;
-      timeVtx+=local_t0.at(i)*hitWeightTimeVtx.at(i)/totalWeightTimeVtx;
+    for (unsigned int i = 0; i < dstnc.size(); i++) {
+      invbeta += (1. + local_t0.at(i) / dstnc.at(i) * 30.) * hitWeightInvbeta.at(i) / totalWeightInvbeta;
+      timeVtx += local_t0.at(i) * hitWeightTimeVtx.at(i) / totalWeightTimeVtx;
     }
-    
-    double chimax=0.;
+
+    double chimax = 0.;
     std::vector<TimeMeasurement>::iterator tmmax;
-    
+
     // Calculate the inv beta and time at vertex dispersion
-    double diff_ibeta,diff_tvtx;
-    for (unsigned int i=0;i<dstnc.size();i++) {
-      diff_ibeta=(1.+local_t0.at(i)/dstnc.at(i)*30.)-invbeta;
-      diff_ibeta=diff_ibeta*diff_ibeta*hitWeightInvbeta.at(i);
-      diff_tvtx=local_t0.at(i)-timeVtx;
-      diff_tvtx=diff_tvtx*diff_tvtx*hitWeightTimeVtx.at(i);
-      invbetaErr+=diff_ibeta;
-      timeVtxErr+=diff_tvtx;
-      
+    double diff_ibeta, diff_tvtx;
+    for (unsigned int i = 0; i < dstnc.size(); i++) {
+      diff_ibeta = (1. + local_t0.at(i) / dstnc.at(i) * 30.) - invbeta;
+      diff_ibeta = diff_ibeta * diff_ibeta * hitWeightInvbeta.at(i);
+      diff_tvtx = local_t0.at(i) - timeVtx;
+      diff_tvtx = diff_tvtx * diff_tvtx * hitWeightTimeVtx.at(i);
+      invbetaErr += diff_ibeta;
+      timeVtxErr += diff_tvtx;
+
       // decide if we cut away time at vertex outliers or inverse beta outliers
       // currently not configurable.
-      if (diff_tvtx>chimax) { 
-	tmmax=tms.begin()+i;
-	chimax=diff_tvtx;
+      if (diff_tvtx > chimax) {
+        tmmax = tms.begin() + i;
+        chimax = diff_tvtx;
       }
     }
-    
+
     // cut away the outliers
-    if (chimax>thePruneCut_) {
+    if (chimax > thePruneCut_) {
       tms.erase(tmmax);
-      modified=true;
-    }    
+      modified = true;
+    }
 
     if (debug) {
-      double cf = 1./(dstnc.size()-1);
-      invbetaErr=sqrt(invbetaErr/totalWeightInvbeta*cf); 
-      timeVtxErr=sqrt(timeVtxErr/totalWeightTimeVtx*cf); 
+      double cf = 1. / (dstnc.size() - 1);
+      invbetaErr = sqrt(invbetaErr / totalWeightInvbeta * cf);
+      timeVtxErr = sqrt(timeVtxErr / totalWeightTimeVtx * cf);
       std::cout << " Measured 1/beta: " << invbeta << " +/- " << invbetaErr << std::endl;
       std::cout << " Measured time: " << timeVtx << " +/- " << timeVtxErr << std::endl;
-    }  
+    }
 
   } while (modified);
 
-  for (unsigned int i=0;i<dstnc.size();i++) {
+  for (unsigned int i = 0; i < dstnc.size(); i++) {
     tmSequence.dstnc.push_back(dstnc.at(i));
     tmSequence.local_t0.push_back(local_t0.at(i));
     tmSequence.weightInvbeta.push_back(hitWeightInvbeta.at(i));
     tmSequence.weightTimeVtx.push_back(hitWeightTimeVtx.at(i));
   }
 
-  tmSequence.totalWeightInvbeta=totalWeightInvbeta;
-  tmSequence.totalWeightTimeVtx=totalWeightTimeVtx;
+  tmSequence.totalWeightInvbeta = totalWeightInvbeta;
+  tmSequence.totalWeightTimeVtx = totalWeightTimeVtx;
 }
 
-
 // ------------ method called to produce the data  ------------
-void
-CSCTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence, reco::TrackRef muonTrack, 
-                               const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-
-  if (debug) 
+void CSCTimingExtractor::fillTiming(TimeMeasurementSequence& tmSequence,
+                                    reco::TrackRef muonTrack,
+                                    const edm::Event& iEvent,
+                                    const edm::EventSetup& iSetup) {
+  if (debug)
     std::cout << " *** CSC Timimng Extractor ***" << std::endl;
 
   // get the CSC segments that were used to construct the muon
-  std::vector<const CSCSegment*> range = theMatcher->matchCSC(*muonTrack,iEvent);
-  
+  std::vector<const CSCSegment*> range = theMatcher->matchCSC(*muonTrack, iEvent);
+
   fillTiming(tmSequence, range, muonTrack, iEvent, iSetup);
 }
 

--- a/RecoMuon/MuonIdentification/src/DTTimingExtractor.cc
+++ b/RecoMuon/MuonIdentification/src/DTTimingExtractor.cc
@@ -2,7 +2,7 @@
 //
 // Package:    MuonIdentification
 // Class:      DTTimingExtractor
-// 
+//
 /**\class DTTimingExtractor DTTimingExtractor.cc RecoMuon/MuonIdentification/src/DTTimingExtractor.cc
  *
  * Description: Produce timing information for a muon track using 1D DT hits from segments used to build the track
@@ -15,7 +15,6 @@
 //
 
 #include "RecoMuon/MuonIdentification/interface/DTTimingExtractor.h"
-
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -54,7 +53,6 @@
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
 #include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
 
-
 // system include files
 #include <memory>
 #include <vector>
@@ -65,365 +63,376 @@ namespace edm {
   class ParameterSet;
   class EventSetup;
   class InputTag;
-}
+}  // namespace edm
 
 class MuonServiceProxy;
 
 //
 // constructors and destructor
 //
-DTTimingExtractor::DTTimingExtractor(const edm::ParameterSet& iConfig, MuonSegmentMatcher *segMatcher)
-  :
-  theHitsMin_(iConfig.getParameter<int>("HitsMin")),
-  thePruneCut_(iConfig.getParameter<double>("PruneCut")),
-  theTimeOffset_(iConfig.getParameter<double>("DTTimeOffset")),
-  theError_(iConfig.getParameter<double>("HitError")),
-  useSegmentT0_(iConfig.getParameter<bool>("UseSegmentT0")),
-  doWireCorr_(iConfig.getParameter<bool>("DoWireCorr")),
-  dropTheta_(iConfig.getParameter<bool>("DropTheta")),
-  requireBothProjections_(iConfig.getParameter<bool>("RequireBothProjections")),
-  debug(iConfig.getParameter<bool>("debug"))
-{
+DTTimingExtractor::DTTimingExtractor(const edm::ParameterSet& iConfig, MuonSegmentMatcher* segMatcher)
+    : theHitsMin_(iConfig.getParameter<int>("HitsMin")),
+      thePruneCut_(iConfig.getParameter<double>("PruneCut")),
+      theTimeOffset_(iConfig.getParameter<double>("DTTimeOffset")),
+      theError_(iConfig.getParameter<double>("HitError")),
+      useSegmentT0_(iConfig.getParameter<bool>("UseSegmentT0")),
+      doWireCorr_(iConfig.getParameter<bool>("DoWireCorr")),
+      dropTheta_(iConfig.getParameter<bool>("DropTheta")),
+      requireBothProjections_(iConfig.getParameter<bool>("RequireBothProjections")),
+      debug(iConfig.getParameter<bool>("debug")) {
   edm::ParameterSet serviceParameters = iConfig.getParameter<edm::ParameterSet>("ServiceParameters");
   theService = std::make_unique<MuonServiceProxy>(serviceParameters);
   theMatcher = segMatcher;
 }
 
-
-DTTimingExtractor::~DTTimingExtractor()
-{
-}
-
+DTTimingExtractor::~DTTimingExtractor() {}
 
 //
 // member functions
 //
-void DTTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence, 
-				   const std::vector<const DTRecSegment4D*> &segments,
-				   reco::TrackRef muonTrack,
-				   const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-  if (debug) 
+void DTTimingExtractor::fillTiming(TimeMeasurementSequence& tmSequence,
+                                   const std::vector<const DTRecSegment4D*>& segments,
+                                   reco::TrackRef muonTrack,
+                                   const edm::Event& iEvent,
+                                   const edm::EventSetup& iSetup) {
+  if (debug)
     std::cout << " *** DT Timimng Extractor ***" << std::endl;
 
   theService->update(iSetup);
 
-  const GlobalTrackingGeometry *theTrackingGeometry = &*theService->trackingGeometry();
+  const GlobalTrackingGeometry* theTrackingGeometry = &*theService->trackingGeometry();
 
   // get the DT geometry
   edm::ESHandle<DTGeometry> theDTGeom;
   iSetup.get<MuonGeometryRecord>().get(theDTGeom);
 
-  // get the propagator  
+  // get the propagator
   edm::ESHandle<Propagator> propagator;
   iSetup.get<TrackingComponentsRecord>().get("SteppingHelixPropagatorAny", propagator);
-  const Propagator *propag = propagator.product();
+  const Propagator* propag = propagator.product();
 
-  math::XYZPoint  pos=muonTrack->innerPosition();
-  math::XYZVector mom=muonTrack->innerMomentum();
-  GlobalPoint  posp(pos.x(), pos.y(), pos.z());
+  math::XYZPoint pos = muonTrack->innerPosition();
+  math::XYZVector mom = muonTrack->innerMomentum();
+  GlobalPoint posp(pos.x(), pos.y(), pos.z());
   GlobalVector momv(mom.x(), mom.y(), mom.z());
   FreeTrajectoryState muonFTS(posp, momv, (TrackCharge)muonTrack->charge(), theService->magneticField().product());
 
-  // create a collection on TimeMeasurements for the track        
+  // create a collection on TimeMeasurements for the track
   std::vector<TimeMeasurement> tms;
-  for (const auto& rechit : segments ) {
-
+  for (const auto& rechit : segments) {
     // Create the ChamberId
     DetId id = rechit->geographicalId();
     DTChamberId chamberId(id.rawId());
     int station = chamberId.station();
-    if (debug) std::cout << "Matched DT segment in station " << station << std::endl;
+    if (debug)
+      std::cout << "Matched DT segment in station " << station << std::endl;
 
     // use only segments with both phi and theta projections present (optional)
-    bool bothProjections = ( (rechit->hasPhi()) && (rechit->hasZed()) );
-    if (requireBothProjections_ && !bothProjections) continue;
+    bool bothProjections = ((rechit->hasPhi()) && (rechit->hasZed()));
+    if (requireBothProjections_ && !bothProjections)
+      continue;
 
     // loop over (theta, phi) segments
-    for (int phi=0; phi<2; phi++) {
-
-      if (dropTheta_ && !phi) continue;
+    for (int phi = 0; phi < 2; phi++) {
+      if (dropTheta_ && !phi)
+        continue;
 
       const DTRecSegment2D* segm;
-      if (phi) { 
-        segm = dynamic_cast<const DTRecSegment2D*>(rechit->phiSegment()); 
-        if (debug) std::cout << " *** Segment t0: " << segm->t0() << std::endl;
-      }    
-        else segm = dynamic_cast<const DTRecSegment2D*>(rechit->zSegment());
+      if (phi) {
+        segm = dynamic_cast<const DTRecSegment2D*>(rechit->phiSegment());
+        if (debug)
+          std::cout << " *** Segment t0: " << segm->t0() << std::endl;
+      } else
+        segm = dynamic_cast<const DTRecSegment2D*>(rechit->zSegment());
 
-      if(segm == nullptr) continue;
-      if (segm->specificRecHits().empty()) continue;
+      if (segm == nullptr)
+        continue;
+      if (segm->specificRecHits().empty())
+        continue;
 
       const GeomDet* geomDet = theTrackingGeometry->idToDet(segm->geographicalId());
       const std::vector<DTRecHit1D>& hits1d(segm->specificRecHits());
 
       // store all the hits from the segment
       for (const auto& hiti : hits1d) {
+        const GeomDet* dtcell = theTrackingGeometry->idToDet(hiti.geographicalId());
+        TimeMeasurement thisHit;
 
-	const GeomDet* dtcell = theTrackingGeometry->idToDet(hiti.geographicalId());
-	TimeMeasurement thisHit;
+        std::pair<TrajectoryStateOnSurface, double> tsos;
+        tsos = propag->propagateWithPath(muonFTS, dtcell->surface());
 
-	std::pair< TrajectoryStateOnSurface, double> tsos;
-	tsos=propag->propagateWithPath(muonFTS,dtcell->surface());
+        double dist;
+        double dist_straight = dtcell->toGlobal(hiti.localPosition()).mag();
+        if (tsos.first.isValid()) {
+          dist = tsos.second + posp.mag();
+          //	  std::cout << "Propagate distance: " << dist << " ( innermost: " << posp.mag() << ")" << std::endl;
+        } else {
+          dist = dist_straight;
+          //	  std::cout << "Geom distance: " << dist << std::endl;
+        }
 
-        double dist;            
-        double dist_straight = dtcell->toGlobal(hiti.localPosition()).mag(); 
-	if (tsos.first.isValid()) { 
-	  dist = tsos.second+posp.mag(); 
-//	  std::cout << "Propagate distance: " << dist << " ( innermost: " << posp.mag() << ")" << std::endl; 
-	} else { 
-	  dist = dist_straight;
-//	  std::cout << "Geom distance: " << dist << std::endl; 
-	}
+        thisHit.driftCell = hiti.geographicalId();
+        if (hiti.lrSide() == DTEnums::Left)
+          thisHit.isLeft = true;
+        else
+          thisHit.isLeft = false;
+        thisHit.isPhi = phi;
+        thisHit.posInLayer = geomDet->toLocal(dtcell->toGlobal(hiti.localPosition())).x();
+        thisHit.distIP = dist;
+        thisHit.station = station;
+        if (useSegmentT0_ && segm->ist0Valid())
+          thisHit.timeCorr = segm->t0();
+        else
+          thisHit.timeCorr = 0.;
+        thisHit.timeCorr += theTimeOffset_;
 
-	thisHit.driftCell = hiti.geographicalId();
-	if (hiti.lrSide()==DTEnums::Left) thisHit.isLeft=true; else thisHit.isLeft=false;
-	thisHit.isPhi = phi;
-	thisHit.posInLayer = geomDet->toLocal(dtcell->toGlobal(hiti.localPosition())).x();
-	thisHit.distIP = dist;
-	thisHit.station = station;
-	if (useSegmentT0_ && segm->ist0Valid()) thisHit.timeCorr=segm->t0();
-	else thisHit.timeCorr=0.;
-	thisHit.timeCorr += theTimeOffset_;
-	  
-	// signal propagation along the wire correction for unmached theta or phi segment hits
-	if (doWireCorr_ && !bothProjections && tsos.first.isValid()) {
-	  const DTLayer* layer = theDTGeom->layer(hiti.wireId());
-	  float propgL = layer->toLocal( tsos.first.globalPosition() ).y();
-	  float wirePropCorr = propgL/24.4*0.00543; // signal propagation speed along the wire
-	  if (thisHit.isLeft) wirePropCorr=-wirePropCorr;
-	  thisHit.posInLayer += wirePropCorr;
-	  const DTSuperLayer *sl = layer->superLayer();
-	  float tofCorr = sl->surface().position().mag()-tsos.first.globalPosition().mag();
-	  tofCorr = (tofCorr/29.979)*0.00543;
-	  if (thisHit.isLeft) tofCorr=-tofCorr;
-	  thisHit.posInLayer += tofCorr;
-	} else {
+        // signal propagation along the wire correction for unmached theta or phi segment hits
+        if (doWireCorr_ && !bothProjections && tsos.first.isValid()) {
+          const DTLayer* layer = theDTGeom->layer(hiti.wireId());
+          float propgL = layer->toLocal(tsos.first.globalPosition()).y();
+          float wirePropCorr = propgL / 24.4 * 0.00543;  // signal propagation speed along the wire
+          if (thisHit.isLeft)
+            wirePropCorr = -wirePropCorr;
+          thisHit.posInLayer += wirePropCorr;
+          const DTSuperLayer* sl = layer->superLayer();
+          float tofCorr = sl->surface().position().mag() - tsos.first.globalPosition().mag();
+          tofCorr = (tofCorr / 29.979) * 0.00543;
+          if (thisHit.isLeft)
+            tofCorr = -tofCorr;
+          thisHit.posInLayer += tofCorr;
+        } else {
           // non straight-line path correction
-          float slCorr = (dist_straight-dist)/29.979*0.00543;
-  	  if (thisHit.isLeft) slCorr=-slCorr;
-  	  thisHit.posInLayer += slCorr;
-	}
+          float slCorr = (dist_straight - dist) / 29.979 * 0.00543;
+          if (thisHit.isLeft)
+            slCorr = -slCorr;
+          thisHit.posInLayer += slCorr;
+        }
 
-        if (debug) std::cout << " dist: " << dist << "  t0: " << thisHit.posInLayer << std::endl;
- 
-	tms.push_back(thisHit);
+        if (debug)
+          std::cout << " dist: " << dist << "  t0: " << thisHit.posInLayer << std::endl;
+
+        tms.push_back(thisHit);
       }
-    } // phi = (0,1) 	        
-  } // rechit
-      
-  bool modified = false;
-  std::vector <double> dstnc, local_t0, hitWeightTimeVtx, hitWeightInvbeta, left;
-  double totalWeightInvbeta=0;
-  double totalWeightTimeVtx=0;
-    
-  // Now loop over the measurements, calculate 1/beta and time at vertex and cut away outliers
-  do {    
+    }  // phi = (0,1)
+  }    // rechit
 
+  bool modified = false;
+  std::vector<double> dstnc, local_t0, hitWeightTimeVtx, hitWeightInvbeta, left;
+  double totalWeightInvbeta = 0;
+  double totalWeightTimeVtx = 0;
+
+  // Now loop over the measurements, calculate 1/beta and time at vertex and cut away outliers
+  do {
     modified = false;
     dstnc.clear();
     local_t0.clear();
     hitWeightTimeVtx.clear();
     hitWeightInvbeta.clear();
     left.clear();
-      
-    std::vector <int> hit_idx;
-    totalWeightInvbeta=0;
-    totalWeightTimeVtx=0;
-      
+
+    std::vector<int> hit_idx;
+    totalWeightInvbeta = 0;
+    totalWeightTimeVtx = 0;
+
     // Rebuild segments
-    for (int sta=1;sta<5;sta++)
-      for (int phi=0;phi<2;phi++) {
-        std::vector <TimeMeasurement> seg;
-        std::vector <int> seg_idx;
-	int tmpos=0;
-	for (auto& tm : tms) {
-	  if ((tm.station==sta) && (tm.isPhi==phi)) {
-	    seg.push_back(tm);
-	    seg_idx.push_back(tmpos);
-	  }
-	  tmpos++;  
-	}
+    for (int sta = 1; sta < 5; sta++)
+      for (int phi = 0; phi < 2; phi++) {
+        std::vector<TimeMeasurement> seg;
+        std::vector<int> seg_idx;
+        int tmpos = 0;
+        for (auto& tm : tms) {
+          if ((tm.station == sta) && (tm.isPhi == phi)) {
+            seg.push_back(tm);
+            seg_idx.push_back(tmpos);
+          }
+          tmpos++;
+        }
 
-	unsigned int segsize = seg.size();
-	if (segsize<theHitsMin_) continue;
+        unsigned int segsize = seg.size();
+        if (segsize < theHitsMin_)
+          continue;
 
-	double a=0, b=0;
-        std::vector <double> hitxl,hitxr,hityl,hityr;
+        double a = 0, b = 0;
+        std::vector<double> hitxl, hitxr, hityl, hityr;
 
-	for (auto& tm : seg) {
- 
-	  DetId id = tm.driftCell;
-	  const GeomDet* dtcell = theTrackingGeometry->idToDet(id);
-	  DTChamberId chamberId(id.rawId());
-	  const GeomDet* dtcham = theTrackingGeometry->idToDet(chamberId);
+        for (auto& tm : seg) {
+          DetId id = tm.driftCell;
+          const GeomDet* dtcell = theTrackingGeometry->idToDet(id);
+          DTChamberId chamberId(id.rawId());
+          const GeomDet* dtcham = theTrackingGeometry->idToDet(chamberId);
 
-	  double celly=dtcham->toLocal(dtcell->position()).z();
-            
-	  if (tm.isLeft) {
-	    hitxl.push_back(celly);
-	    hityl.push_back(tm.posInLayer);
-	  } else {
-	    hitxr.push_back(celly);
-	    hityr.push_back(tm.posInLayer);
-	  }    
-	}
+          double celly = dtcham->toLocal(dtcell->position()).z();
 
-	if (!fitT0(a,b,hitxl,hityl,hitxr,hityr)) {
-	  if (debug)
-	    std::cout << "     t0 = zero, Left hits: " << hitxl.size() << " Right hits: " << hitxr.size() << std::endl;
-	  continue;
-	}
+          if (tm.isLeft) {
+            hitxl.push_back(celly);
+            hityl.push_back(tm.posInLayer);
+          } else {
+            hitxr.push_back(celly);
+            hityr.push_back(tm.posInLayer);
+          }
+        }
 
-	// a segment must have at least one left and one right hit
-	if ((hitxl.empty()) || (hityl.empty())) continue;
+        if (!fitT0(a, b, hitxl, hityl, hitxr, hityr)) {
+          if (debug)
+            std::cout << "     t0 = zero, Left hits: " << hitxl.size() << " Right hits: " << hitxr.size() << std::endl;
+          continue;
+        }
 
-	int segidx=0;
-	for (const auto& tm : seg) {
+        // a segment must have at least one left and one right hit
+        if ((hitxl.empty()) || (hityl.empty()))
+          continue;
 
-	  DetId id = tm.driftCell;
-	  const GeomDet* dtcell = theTrackingGeometry->idToDet(id);
-	  DTChamberId chamberId(id.rawId());
-	  const GeomDet* dtcham = theTrackingGeometry->idToDet(chamberId);
+        int segidx = 0;
+        for (const auto& tm : seg) {
+          DetId id = tm.driftCell;
+          const GeomDet* dtcell = theTrackingGeometry->idToDet(id);
+          DTChamberId chamberId(id.rawId());
+          const GeomDet* dtcham = theTrackingGeometry->idToDet(chamberId);
 
-	  double layerZ  = dtcham->toLocal(dtcell->position()).z();
-	  double segmLocalPos = b+layerZ*a;
-	  double hitLocalPos = tm.posInLayer;
-	  int hitSide = -tm.isLeft*2+1;
-	  double t0_segm = (-(hitSide*segmLocalPos)+(hitSide*hitLocalPos))/0.00543+tm.timeCorr;
-	  
-	  if (debug) std::cout << "   Segm hit.  dstnc: " << tm.distIP << "   t0: " << t0_segm << std::endl;
-            
-	  dstnc.push_back(tm.distIP);
-	  local_t0.push_back(t0_segm);
-	  left.push_back(hitSide);
-	  hitWeightInvbeta.push_back(((double)seg.size()-2.)*tm.distIP*tm.distIP/((double)seg.size()*30.*30.*theError_*theError_));
-          hitWeightTimeVtx.push_back(((double)seg.size()-2.)/((double)seg.size()*theError_*theError_));
-	  hit_idx.push_back(seg_idx.at(segidx));
-	  segidx++;
-	  totalWeightInvbeta+=((double)seg.size()-2.)*tm.distIP*tm.distIP/((double)seg.size()*30.*30.*theError_*theError_);
-	  totalWeightTimeVtx+=((double)seg.size()-2.)/((double)seg.size()*theError_*theError_);
-	}
+          double layerZ = dtcham->toLocal(dtcell->position()).z();
+          double segmLocalPos = b + layerZ * a;
+          double hitLocalPos = tm.posInLayer;
+          int hitSide = -tm.isLeft * 2 + 1;
+          double t0_segm = (-(hitSide * segmLocalPos) + (hitSide * hitLocalPos)) / 0.00543 + tm.timeCorr;
+
+          if (debug)
+            std::cout << "   Segm hit.  dstnc: " << tm.distIP << "   t0: " << t0_segm << std::endl;
+
+          dstnc.push_back(tm.distIP);
+          local_t0.push_back(t0_segm);
+          left.push_back(hitSide);
+          hitWeightInvbeta.push_back(((double)seg.size() - 2.) * tm.distIP * tm.distIP /
+                                     ((double)seg.size() * 30. * 30. * theError_ * theError_));
+          hitWeightTimeVtx.push_back(((double)seg.size() - 2.) / ((double)seg.size() * theError_ * theError_));
+          hit_idx.push_back(seg_idx.at(segidx));
+          segidx++;
+          totalWeightInvbeta += ((double)seg.size() - 2.) * tm.distIP * tm.distIP /
+                                ((double)seg.size() * 30. * 30. * theError_ * theError_);
+          totalWeightTimeVtx += ((double)seg.size() - 2.) / ((double)seg.size() * theError_ * theError_);
+        }
       }
 
-    if (totalWeightInvbeta==0) break;        
+    if (totalWeightInvbeta == 0)
+      break;
 
     // calculate the value and error of 1/beta and timeVtx from the complete set of 1D hits
     if (debug)
       std::cout << " Points for global fit: " << dstnc.size() << std::endl;
 
-    double invbeta=0,invbetaErr=0;
-    double timeVtx=0,timeVtxErr=0;
+    double invbeta = 0, invbetaErr = 0;
+    double timeVtx = 0, timeVtxErr = 0;
 
-    for (unsigned int i=0;i<dstnc.size();i++) {
-      invbeta+=(1.+local_t0.at(i)/dstnc.at(i)*30.)*hitWeightInvbeta.at(i)/totalWeightInvbeta;
-      timeVtx+=local_t0.at(i)*hitWeightTimeVtx.at(i)/totalWeightTimeVtx;
+    for (unsigned int i = 0; i < dstnc.size(); i++) {
+      invbeta += (1. + local_t0.at(i) / dstnc.at(i) * 30.) * hitWeightInvbeta.at(i) / totalWeightInvbeta;
+      timeVtx += local_t0.at(i) * hitWeightTimeVtx.at(i) / totalWeightTimeVtx;
     }
-    
-    double chimax=0.;
+
+    double chimax = 0.;
     std::vector<TimeMeasurement>::iterator tmmax;
-    
+
     // Calculate the inv beta and time at vertex dispersion
-    double diff_ibeta,diff_tvtx;
-    for (unsigned int i=0;i<dstnc.size();i++) {
-      diff_ibeta=(1.+local_t0.at(i)/dstnc.at(i)*30.)-invbeta;
-      diff_ibeta=diff_ibeta*diff_ibeta*hitWeightInvbeta.at(i);
-      diff_tvtx=local_t0.at(i)-timeVtx;
-      diff_tvtx=diff_tvtx*diff_tvtx*hitWeightTimeVtx.at(i);
-      invbetaErr+=diff_ibeta;
-      timeVtxErr+=diff_tvtx;
-      
+    double diff_ibeta, diff_tvtx;
+    for (unsigned int i = 0; i < dstnc.size(); i++) {
+      diff_ibeta = (1. + local_t0.at(i) / dstnc.at(i) * 30.) - invbeta;
+      diff_ibeta = diff_ibeta * diff_ibeta * hitWeightInvbeta.at(i);
+      diff_tvtx = local_t0.at(i) - timeVtx;
+      diff_tvtx = diff_tvtx * diff_tvtx * hitWeightTimeVtx.at(i);
+      invbetaErr += diff_ibeta;
+      timeVtxErr += diff_tvtx;
+
       // decide if we cut away time at vertex outliers or inverse beta outliers
       // currently not configurable.
-      if (diff_tvtx>chimax) { 
-	tmmax=tms.begin()+hit_idx.at(i);
-	chimax=diff_tvtx;
+      if (diff_tvtx > chimax) {
+        tmmax = tms.begin() + hit_idx.at(i);
+        chimax = diff_tvtx;
       }
     }
-    
+
     // cut away the outliers
-    if (chimax>thePruneCut_) {
+    if (chimax > thePruneCut_) {
       tms.erase(tmmax);
-      modified=true;
-    }    
+      modified = true;
+    }
 
     if (debug) {
-      double cf = 1./(dstnc.size()-1);
-      invbetaErr=sqrt(invbetaErr/totalWeightInvbeta*cf); 
-      timeVtxErr=sqrt(timeVtxErr/totalWeightTimeVtx*cf); 
+      double cf = 1. / (dstnc.size() - 1);
+      invbetaErr = sqrt(invbetaErr / totalWeightInvbeta * cf);
+      timeVtxErr = sqrt(timeVtxErr / totalWeightTimeVtx * cf);
       std::cout << " Measured 1/beta: " << invbeta << " +/- " << invbetaErr << std::endl;
       std::cout << " Measured time: " << timeVtx << " +/- " << timeVtxErr << std::endl;
-    }  
+    }
 
   } while (modified);
 
-  for (unsigned int i=0;i<dstnc.size();i++) {
+  for (unsigned int i = 0; i < dstnc.size(); i++) {
     tmSequence.dstnc.push_back(dstnc.at(i));
     tmSequence.local_t0.push_back(local_t0.at(i));
     tmSequence.weightInvbeta.push_back(hitWeightInvbeta.at(i));
     tmSequence.weightTimeVtx.push_back(hitWeightTimeVtx.at(i));
   }
 
-  tmSequence.totalWeightInvbeta=totalWeightInvbeta;
-  tmSequence.totalWeightTimeVtx=totalWeightTimeVtx;
+  tmSequence.totalWeightInvbeta = totalWeightInvbeta;
+  tmSequence.totalWeightTimeVtx = totalWeightTimeVtx;
 }
 
 // ------------ method called to produce the data  ------------
-void
-DTTimingExtractor::fillTiming(TimeMeasurementSequence &tmSequence, reco::TrackRef muonTrack,
-                              const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void DTTimingExtractor::fillTiming(TimeMeasurementSequence& tmSequence,
+                                   reco::TrackRef muonTrack,
+                                   const edm::Event& iEvent,
+                                   const edm::EventSetup& iSetup) {
   // get the DT segments that were used to construct the muon
-  std::vector<const DTRecSegment4D*> range = theMatcher->matchDT(*muonTrack,iEvent);
-  
-  if (debug) 
+  std::vector<const DTRecSegment4D*> range = theMatcher->matchDT(*muonTrack, iEvent);
+
+  if (debug)
     std::cout << " The muon track matches " << range.size() << " segments." << std::endl;
-  fillTiming(tmSequence,range,muonTrack,iEvent,iSetup);
+  fillTiming(tmSequence, range, muonTrack, iEvent, iSetup);
 }
 
-double
-DTTimingExtractor::fitT0(double &a, double &b, const std::vector<double>& xl, const std::vector<double>& yl, const std::vector<double>& xr, const std::vector<double>& yr ) {
+double DTTimingExtractor::fitT0(double& a,
+                                double& b,
+                                const std::vector<double>& xl,
+                                const std::vector<double>& yl,
+                                const std::vector<double>& xr,
+                                const std::vector<double>& yr) {
+  double sx = 0, sy = 0, sxy = 0, sxx = 0, ssx = 0, ssy = 0, s = 0, ss = 0;
 
-  double sx=0,sy=0,sxy=0,sxx=0,ssx=0,ssy=0,s=0,ss=0;
-
-  for (unsigned int i=0; i<xl.size(); i++) {
-    sx+=xl[i];
-    sy+=yl[i];
-    sxy+=xl[i]*yl[i];
-    sxx+=xl[i]*xl[i];
+  for (unsigned int i = 0; i < xl.size(); i++) {
+    sx += xl[i];
+    sy += yl[i];
+    sxy += xl[i] * yl[i];
+    sxx += xl[i] * xl[i];
     s++;
-    ssx+=xl[i];
-    ssy+=yl[i];
+    ssx += xl[i];
+    ssy += yl[i];
     ss++;
-  } 
+  }
 
-  for (unsigned int i=0; i<xr.size(); i++) {
-    sx+=xr[i];
-    sy+=yr[i];
-    sxy+=xr[i]*yr[i];
-    sxx+=xr[i]*xr[i];
+  for (unsigned int i = 0; i < xr.size(); i++) {
+    sx += xr[i];
+    sy += yr[i];
+    sxy += xr[i] * yr[i];
+    sxx += xr[i] * xr[i];
     s++;
-    ssx-=xr[i];
-    ssy-=yr[i];
+    ssx -= xr[i];
+    ssy -= yr[i];
     ss--;
-  } 
+  }
 
-  double delta = ss*ss*sxx+s*sx*sx+s*ssx*ssx-s*s*sxx-2*ss*sx*ssx;
-  
-  double t0_corr=0.;
+  double delta = ss * ss * sxx + s * sx * sx + s * ssx * ssx - s * s * sxx - 2 * ss * sx * ssx;
+
+  double t0_corr = 0.;
 
   if (delta) {
-    a=(ssy*s*ssx+sxy*ss*ss+sy*sx*s-sy*ss*ssx-ssy*sx*ss-sxy*s*s)/delta;
-    b=(ssx*sy*ssx+sxx*ssy*ss+sx*sxy*s-sxx*sy*s-ssx*sxy*ss-sx*ssy*ssx)/delta;
-    t0_corr=(ssx*s*sxy+sxx*ss*sy+sx*sx*ssy-sxx*s*ssy-sx*ss*sxy-ssx*sx*sy)/delta;
+    a = (ssy * s * ssx + sxy * ss * ss + sy * sx * s - sy * ss * ssx - ssy * sx * ss - sxy * s * s) / delta;
+    b = (ssx * sy * ssx + sxx * ssy * ss + sx * sxy * s - sxx * sy * s - ssx * sxy * ss - sx * ssy * ssx) / delta;
+    t0_corr = (ssx * s * sxy + sxx * ss * sy + sx * sx * ssy - sxx * s * ssy - sx * ss * sxy - ssx * sx * sy) / delta;
   }
 
   // convert drift distance to time
-  t0_corr/=-0.00543;
+  t0_corr /= -0.00543;
 
   return t0_corr;
 }
-
 
 //define this as a plug-in
 //DEFINE_FWK_MODULE(DTTimingExtractor);

--- a/RecoMuon/MuonIdentification/src/MuonCaloCompatibility.cc
+++ b/RecoMuon/MuonIdentification/src/MuonCaloCompatibility.cc
@@ -2,7 +2,7 @@
 //
 // Package:    MuonIdentification
 // Class:      MuonCaloCompatibility
-// 
+//
 /*
 
  Description: test track muon hypothesis using energy deposition in ECAL,HCAL,HO
@@ -18,153 +18,150 @@
 
 #include "TFile.h"
 
-void MuonCaloCompatibility::configure(const edm::ParameterSet& iConfig)
-{
-   const std::string muonfileName = (iConfig.getParameter<edm::FileInPath>("MuonTemplateFileName")).fullPath();
-   const std::string pionfileName = (iConfig.getParameter<edm::FileInPath>("PionTemplateFileName")).fullPath();
-   TFile muon_templates(muonfileName.c_str(),"READ");
-   TFile pion_templates(pionfileName.c_str(),"READ");
+void MuonCaloCompatibility::configure(const edm::ParameterSet& iConfig) {
+  const std::string muonfileName = (iConfig.getParameter<edm::FileInPath>("MuonTemplateFileName")).fullPath();
+  const std::string pionfileName = (iConfig.getParameter<edm::FileInPath>("PionTemplateFileName")).fullPath();
+  TFile muon_templates(muonfileName.c_str(), "READ");
+  TFile pion_templates(pionfileName.c_str(), "READ");
 
-   pion_em_etaEmi.reset((TH2D*) pion_templates.Get("em_etaEmi"));
-   pion_had_etaEmi.reset((TH2D*) pion_templates.Get("had_etaEmi"));
+  pion_em_etaEmi.reset((TH2D*)pion_templates.Get("em_etaEmi"));
+  pion_had_etaEmi.reset((TH2D*)pion_templates.Get("had_etaEmi"));
 
-   pion_em_etaTmi.reset((TH2D*) pion_templates.Get("em_etaTmi"));
-   pion_had_etaTmi.reset((TH2D*) pion_templates.Get("had_etaTmi"));
+  pion_em_etaTmi.reset((TH2D*)pion_templates.Get("em_etaTmi"));
+  pion_had_etaTmi.reset((TH2D*)pion_templates.Get("had_etaTmi"));
 
-   pion_em_etaB.reset((TH2D*) pion_templates.Get("em_etaB"));
-   pion_had_etaB.reset((TH2D*) pion_templates.Get("had_etaB"));
-   pion_ho_etaB.reset((TH2D*) pion_templates.Get("ho_etaB"));
+  pion_em_etaB.reset((TH2D*)pion_templates.Get("em_etaB"));
+  pion_had_etaB.reset((TH2D*)pion_templates.Get("had_etaB"));
+  pion_ho_etaB.reset((TH2D*)pion_templates.Get("ho_etaB"));
 
-   pion_em_etaTpl.reset((TH2D*) pion_templates.Get("em_etaTpl"));
-   pion_had_etaTpl.reset((TH2D*) pion_templates.Get("had_etaTpl"));
+  pion_em_etaTpl.reset((TH2D*)pion_templates.Get("em_etaTpl"));
+  pion_had_etaTpl.reset((TH2D*)pion_templates.Get("had_etaTpl"));
 
-   pion_em_etaEpl.reset((TH2D*) pion_templates.Get("em_etaEpl"));
-   pion_had_etaEpl.reset((TH2D*) pion_templates.Get("had_etaEpl"));
+  pion_em_etaEpl.reset((TH2D*)pion_templates.Get("em_etaEpl"));
+  pion_had_etaEpl.reset((TH2D*)pion_templates.Get("had_etaEpl"));
 
-   muon_em_etaEmi.reset((TH2D*) muon_templates.Get("em_etaEmi"));
-   muon_had_etaEmi.reset((TH2D*) muon_templates.Get("had_etaEmi"));
+  muon_em_etaEmi.reset((TH2D*)muon_templates.Get("em_etaEmi"));
+  muon_had_etaEmi.reset((TH2D*)muon_templates.Get("had_etaEmi"));
 
-   muon_em_etaTmi.reset((TH2D*) muon_templates.Get("em_etaTmi"));
-   muon_had_etaTmi.reset((TH2D*) muon_templates.Get("had_etaTmi"));
+  muon_em_etaTmi.reset((TH2D*)muon_templates.Get("em_etaTmi"));
+  muon_had_etaTmi.reset((TH2D*)muon_templates.Get("had_etaTmi"));
 
-   muon_em_etaB.reset((TH2D*) muon_templates.Get("em_etaB"));
-   muon_had_etaB.reset((TH2D*) muon_templates.Get("had_etaB"));
-   muon_ho_etaB.reset((TH2D*) muon_templates.Get("ho_etaB"));
+  muon_em_etaB.reset((TH2D*)muon_templates.Get("em_etaB"));
+  muon_had_etaB.reset((TH2D*)muon_templates.Get("had_etaB"));
+  muon_ho_etaB.reset((TH2D*)muon_templates.Get("ho_etaB"));
 
-   muon_em_etaTpl.reset((TH2D*) muon_templates.Get("em_etaTpl"));
-   muon_had_etaTpl.reset((TH2D*) muon_templates.Get("had_etaTpl"));
+  muon_em_etaTpl.reset((TH2D*)muon_templates.Get("em_etaTpl"));
+  muon_had_etaTpl.reset((TH2D*)muon_templates.Get("had_etaTpl"));
 
-   muon_em_etaEpl.reset((TH2D*) muon_templates.Get("em_etaEpl"));
-   muon_had_etaEpl.reset((TH2D*) muon_templates.Get("had_etaEpl"));
+  muon_em_etaEpl.reset((TH2D*)muon_templates.Get("em_etaEpl"));
+  muon_had_etaEpl.reset((TH2D*)muon_templates.Get("had_etaEpl"));
 
-   // Release from the opened file
-   pion_em_etaEmi->SetDirectory(nullptr);
-   pion_had_etaEmi->SetDirectory(nullptr);
+  // Release from the opened file
+  pion_em_etaEmi->SetDirectory(nullptr);
+  pion_had_etaEmi->SetDirectory(nullptr);
 
-   pion_em_etaTmi->SetDirectory(nullptr);
-   pion_had_etaTmi->SetDirectory(nullptr);
+  pion_em_etaTmi->SetDirectory(nullptr);
+  pion_had_etaTmi->SetDirectory(nullptr);
 
-   pion_em_etaB->SetDirectory(nullptr);
-   pion_had_etaB->SetDirectory(nullptr);
-   pion_ho_etaB->SetDirectory(nullptr);
+  pion_em_etaB->SetDirectory(nullptr);
+  pion_had_etaB->SetDirectory(nullptr);
+  pion_ho_etaB->SetDirectory(nullptr);
 
-   pion_em_etaTpl->SetDirectory(nullptr);
-   pion_had_etaTpl->SetDirectory(nullptr);
+  pion_em_etaTpl->SetDirectory(nullptr);
+  pion_had_etaTpl->SetDirectory(nullptr);
 
-   pion_em_etaEpl->SetDirectory(nullptr);
-   pion_had_etaEpl->SetDirectory(nullptr);
+  pion_em_etaEpl->SetDirectory(nullptr);
+  pion_had_etaEpl->SetDirectory(nullptr);
 
-   muon_em_etaEmi->SetDirectory(nullptr);
-   muon_had_etaEmi->SetDirectory(nullptr);
+  muon_em_etaEmi->SetDirectory(nullptr);
+  muon_had_etaEmi->SetDirectory(nullptr);
 
-   muon_em_etaTmi->SetDirectory(nullptr);
-   muon_had_etaTmi->SetDirectory(nullptr);
+  muon_em_etaTmi->SetDirectory(nullptr);
+  muon_had_etaTmi->SetDirectory(nullptr);
 
-   muon_em_etaB->SetDirectory(nullptr);
-   muon_had_etaB->SetDirectory(nullptr);
-   muon_ho_etaB->SetDirectory(nullptr);
+  muon_em_etaB->SetDirectory(nullptr);
+  muon_had_etaB->SetDirectory(nullptr);
+  muon_ho_etaB->SetDirectory(nullptr);
 
-   muon_em_etaTpl->SetDirectory(nullptr);
-   muon_had_etaTpl->SetDirectory(nullptr);
+  muon_em_etaTpl->SetDirectory(nullptr);
+  muon_had_etaTpl->SetDirectory(nullptr);
 
-   muon_em_etaEpl->SetDirectory(nullptr);
-   muon_had_etaEpl->SetDirectory(nullptr);
+  muon_em_etaEpl->SetDirectory(nullptr);
+  muon_had_etaEpl->SetDirectory(nullptr);
 
-   // change names
-   const std::string prefixPion = "MuonCaloCompatibility_pion_";
-   pion_em_etaEmi->SetName((prefixPion+pion_em_etaEmi->GetName()).c_str());
-   pion_had_etaEmi->SetName((prefixPion+pion_had_etaEmi->GetName()).c_str());
+  // change names
+  const std::string prefixPion = "MuonCaloCompatibility_pion_";
+  pion_em_etaEmi->SetName((prefixPion + pion_em_etaEmi->GetName()).c_str());
+  pion_had_etaEmi->SetName((prefixPion + pion_had_etaEmi->GetName()).c_str());
 
-   pion_em_etaTmi->SetName((prefixPion+pion_em_etaTmi->GetName()).c_str());
-   pion_had_etaTmi->SetName((prefixPion+pion_had_etaTmi->GetName()).c_str());
+  pion_em_etaTmi->SetName((prefixPion + pion_em_etaTmi->GetName()).c_str());
+  pion_had_etaTmi->SetName((prefixPion + pion_had_etaTmi->GetName()).c_str());
 
-   pion_em_etaB->SetName((prefixPion+pion_em_etaB->GetName()).c_str());
-   pion_had_etaB->SetName((prefixPion+pion_had_etaB->GetName()).c_str());
-   pion_ho_etaB->SetName((prefixPion+pion_ho_etaB->GetName()).c_str());
+  pion_em_etaB->SetName((prefixPion + pion_em_etaB->GetName()).c_str());
+  pion_had_etaB->SetName((prefixPion + pion_had_etaB->GetName()).c_str());
+  pion_ho_etaB->SetName((prefixPion + pion_ho_etaB->GetName()).c_str());
 
-   pion_em_etaTpl->SetName((prefixPion+pion_em_etaTpl->GetName()).c_str());
-   pion_had_etaTpl->SetName((prefixPion+pion_had_etaTpl->GetName()).c_str());
+  pion_em_etaTpl->SetName((prefixPion + pion_em_etaTpl->GetName()).c_str());
+  pion_had_etaTpl->SetName((prefixPion + pion_had_etaTpl->GetName()).c_str());
 
-   pion_em_etaEpl->SetName((prefixPion+pion_em_etaEpl->GetName()).c_str());
-   pion_had_etaEpl->SetName((prefixPion+pion_had_etaEpl->GetName()).c_str());
+  pion_em_etaEpl->SetName((prefixPion + pion_em_etaEpl->GetName()).c_str());
+  pion_had_etaEpl->SetName((prefixPion + pion_had_etaEpl->GetName()).c_str());
 
-   const std::string prefixMuon = "MuonCaloCompatibility_muon_";
-   muon_em_etaEmi->SetName((prefixMuon+muon_em_etaEmi->GetName()).c_str());
-   muon_had_etaEmi->SetName((prefixMuon+muon_had_etaEmi->GetName()).c_str());
+  const std::string prefixMuon = "MuonCaloCompatibility_muon_";
+  muon_em_etaEmi->SetName((prefixMuon + muon_em_etaEmi->GetName()).c_str());
+  muon_had_etaEmi->SetName((prefixMuon + muon_had_etaEmi->GetName()).c_str());
 
-   muon_em_etaTmi->SetName((prefixMuon+muon_em_etaTmi->GetName()).c_str());
-   muon_had_etaTmi->SetName((prefixMuon+muon_had_etaTmi->GetName()).c_str());
+  muon_em_etaTmi->SetName((prefixMuon + muon_em_etaTmi->GetName()).c_str());
+  muon_had_etaTmi->SetName((prefixMuon + muon_had_etaTmi->GetName()).c_str());
 
-   muon_em_etaB->SetName((prefixMuon+muon_em_etaB->GetName()).c_str());
-   muon_had_etaB->SetName((prefixMuon+muon_had_etaB->GetName()).c_str());
-   muon_ho_etaB->SetName((prefixMuon+muon_ho_etaB->GetName()).c_str());
+  muon_em_etaB->SetName((prefixMuon + muon_em_etaB->GetName()).c_str());
+  muon_had_etaB->SetName((prefixMuon + muon_had_etaB->GetName()).c_str());
+  muon_ho_etaB->SetName((prefixMuon + muon_ho_etaB->GetName()).c_str());
 
-   muon_em_etaTpl->SetName((prefixMuon+muon_em_etaTpl->GetName()).c_str());
-   muon_had_etaTpl->SetName((prefixMuon+muon_had_etaTpl->GetName()).c_str());
+  muon_em_etaTpl->SetName((prefixMuon + muon_em_etaTpl->GetName()).c_str());
+  muon_had_etaTpl->SetName((prefixMuon + muon_had_etaTpl->GetName()).c_str());
 
-   muon_em_etaEpl->SetName((prefixMuon+muon_em_etaEpl->GetName()).c_str());
-   muon_had_etaEpl->SetName((prefixMuon+muon_had_etaEpl->GetName()).c_str());
+  muon_em_etaEpl->SetName((prefixMuon + muon_em_etaEpl->GetName()).c_str());
+  muon_had_etaEpl->SetName((prefixMuon + muon_had_etaEpl->GetName()).c_str());
 
-   pbx = -1;
-   pby = -1;
-   pbz = -1;
+  pbx = -1;
+  pby = -1;
+  pbz = -1;
 
-   psx = -1;
-   psy = -1;
-   psz = -1;
+  psx = -1;
+  psy = -1;
+  psz = -1;
 
-   muon_compatibility = -1;
+  muon_compatibility = -1;
 
-   use_corrected_hcal = true;
-   use_em_special = true;
-   isConfigured_ = true;
+  use_corrected_hcal = true;
+  use_em_special = true;
+  isConfigured_ = true;
 }
 
-bool MuonCaloCompatibility::accessing_overflow( const TH2D& histo, double x, double y ) {
+bool MuonCaloCompatibility::accessing_overflow(const TH2D& histo, double x, double y) {
   bool access = false;
 
-  if( histo.GetXaxis()->FindBin(x) == 0 || 
-      histo.GetXaxis()->FindBin(x) > histo.GetXaxis()->GetNbins() ) {
+  if (histo.GetXaxis()->FindBin(x) == 0 || histo.GetXaxis()->FindBin(x) > histo.GetXaxis()->GetNbins()) {
     access = true;
   }
-  if( histo.GetYaxis()->FindBin(y) == 0 || 
-      histo.GetYaxis()->FindBin(y) > histo.GetYaxis()->GetNbins() ) {
+  if (histo.GetYaxis()->FindBin(y) == 0 || histo.GetYaxis()->FindBin(y) > histo.GetYaxis()->GetNbins()) {
     access = true;
   }
   return access;
 }
 
-double MuonCaloCompatibility::evaluate( const reco::Muon& amuon ) {
-  if (! isConfigured_) {
-     edm::LogWarning("MuonIdentification") << "MuonCaloCompatibility is not configured! Nothing is calculated.";
-     return -9999;
+double MuonCaloCompatibility::evaluate(const reco::Muon& amuon) {
+  if (!isConfigured_) {
+    edm::LogWarning("MuonIdentification") << "MuonCaloCompatibility is not configured! Nothing is calculated.";
+    return -9999;
   }
 
   double eta = 0.;
-  double p   = 0.;
-  double em  = 0.;
+  double p = 0.;
+  double em = 0.;
   double had = 0.;
-  double ho  = 0.;
+  double ho = 0.;
 
   // had forgotten this reset in previous versions 070409
   pbx = 1.;
@@ -177,166 +174,175 @@ double MuonCaloCompatibility::evaluate( const reco::Muon& amuon ) {
 
   muon_compatibility = -1.;
 
-  pion_template_em   = nullptr;
-  muon_template_em   = nullptr;
+  pion_template_em = nullptr;
+  muon_template_em = nullptr;
 
-  pion_template_had  = nullptr;
-  muon_template_had  = nullptr;
+  pion_template_had = nullptr;
+  muon_template_had = nullptr;
 
-  pion_template_ho   = nullptr;
-  muon_template_ho   = nullptr;
+  pion_template_ho = nullptr;
+  muon_template_ho = nullptr;
 
   // 071002: Get either tracker track, or SAmuon track.
-  // CaloCompatibility templates may have to be specialized for 
+  // CaloCompatibility templates may have to be specialized for
   // the use with SAmuons, currently just using the ones produced
-  // using tracker tracks. 
+  // using tracker tracks.
   const reco::Track* track = nullptr;
-  if ( ! amuon.track().isNull() ) {
+  if (!amuon.track().isNull()) {
     track = amuon.track().get();
-  }
-  else {
-    if ( ! amuon.standAloneMuon().isNull() ) {
+  } else {
+    if (!amuon.standAloneMuon().isNull()) {
       track = amuon.standAloneMuon().get();
-    }
-    else {
-      throw cms::Exception("FatalError") << "Failed to fill muon id calo_compatibility information for a muon with undefined references to tracks"; 
+    } else {
+      throw cms::Exception("FatalError")
+          << "Failed to fill muon id calo_compatibility information for a muon with undefined references to tracks";
     }
   }
 
-  if( !use_corrected_hcal ) { // old eta regions, uncorrected energy
+  if (!use_corrected_hcal) {  // old eta regions, uncorrected energy
     eta = track->eta();
-    p   = track->p(); 
+    p = track->p();
 
-    // new 070904: Set lookup momentum to 1999.9 if larger than 2 TeV. 
+    // new 070904: Set lookup momentum to 1999.9 if larger than 2 TeV.
     // Though the templates were produced with p<2TeV, we believe that
     // this approximation should be roughly valid. A special treatment
     // for >1 TeV muons is advisable anyway :)
-    if( p>=2000. ) p = 1999.9;
+    if (p >= 2000.)
+      p = 1999.9;
 
     //    p   = 10./sin(track->theta()); // use this for templates < 1_5
-    if( use_em_special ) {
-      if( amuon.calEnergy().em == 0. )    em  = -5.;
-      else em  = amuon.calEnergy().em;
-    }
-    else {
-      em  = amuon.calEnergy().em;
+    if (use_em_special) {
+      if (amuon.calEnergy().em == 0.)
+        em = -5.;
+      else
+        em = amuon.calEnergy().em;
+    } else {
+      em = amuon.calEnergy().em;
     }
     had = amuon.calEnergy().had;
-    ho  = amuon.calEnergy().ho;
-  }
-  else {
+    ho = amuon.calEnergy().ho;
+  } else {
     eta = track->eta();
-    p   = track->p();
+    p = track->p();
 
-    // new 070904: Set lookup momentum to 1999.9 if larger than 2 TeV. 
+    // new 070904: Set lookup momentum to 1999.9 if larger than 2 TeV.
     // Though the templates were produced with p<2TeV, we believe that
     // this approximation should be roughly valid. A special treatment
     // for >1 TeV muons is advisable anyway :)
-    if( p>=2000. ) p = 1999.9;
+    if (p >= 2000.)
+      p = 1999.9;
 
     //    p   = 10./sin(track->theta());  // use this for templates < 1_5
     // hcal energy is now done where we get the template histograms (to use corrected cal energy)!
     //     had = amuon.calEnergy().had;
-    if( use_em_special ) {
-      if( amuon.calEnergy().em == 0. )    em  = -5.;
-      else em  = amuon.calEnergy().em;
+    if (use_em_special) {
+      if (amuon.calEnergy().em == 0.)
+        em = -5.;
+      else
+        em = amuon.calEnergy().em;
+    } else {
+      em = amuon.calEnergy().em;
     }
-    else {
-      em  = amuon.calEnergy().em;
-    }
-    ho  = amuon.calEnergy().ho;
+    ho = amuon.calEnergy().ho;
   }
-
 
   // Skip everyting and return "I don't know" (i.e. 0.5) for uncovered regions:
   //  if( p < 0. || p > 500.) return 0.5; // removed 500 GeV cutoff 070817 after updating the tempates (v2_0) to have valid entried beyond 500 GeV
-  if( p < 0. ) return 0.5; // return "unknown" for unphysical momentum input.
-  if( fabs(eta) >  2.5 ) return 0.5; 
+  if (p < 0.)
+    return 0.5;  // return "unknown" for unphysical momentum input.
+  if (fabs(eta) > 2.5)
+    return 0.5;
   // temporary fix for low association efficiency:
   // set caloCompatibility to 0.12345 for tracks
   // which have 0 energy in BOTH ecal and hcal
-  if( amuon.calEnergy().had == 0.0 && amuon.calEnergy().em == 0.0 ) return 0.12345; 
+  if (amuon.calEnergy().had == 0.0 && amuon.calEnergy().em == 0.0)
+    return 0.12345;
 
   //  std::cout<<std::endl<<"Input values are: "<<eta <<" "<< p <<" "<< em <<" "<< had <<" "<< ho;
 
   //  depending on the eta, choose correct histogram: (now all for barrel):
   // bad! eta range has to be syncronised with choice for histogram... should be read out from the histo file somehow... 070322
-  if(42 != 42) { // old eta ranges and uncorrected hcal energy
-    if(eta <= -1.4) {
+  if (42 != 42) {  // old eta ranges and uncorrected hcal energy
+    if (eta <= -1.4) {
       //    std::cout<<"Emi"<<std::endl;
-      pion_template_em  = pion_em_etaEmi;
+      pion_template_em = pion_em_etaEmi;
       pion_template_had = pion_had_etaEmi;
-      muon_template_em  = muon_em_etaEmi;
+      muon_template_em = muon_em_etaEmi;
       muon_template_had = muon_had_etaEmi;
-    }
-    else if(eta > -1.4 && eta <= -1.31) {
+    } else if (eta > -1.4 && eta <= -1.31) {
       //    std::cout<<"Tmi"<<std::endl;
-      pion_template_em  = pion_em_etaTmi;
+      pion_template_em = pion_em_etaTmi;
       pion_template_had = pion_had_etaTmi;
-      muon_template_em  = muon_em_etaTmi;
+      muon_template_em = muon_em_etaTmi;
       muon_template_had = muon_had_etaTmi;
-    }
-    else if(eta > -1.31 && eta <= 1.31) {
+    } else if (eta > -1.31 && eta <= 1.31) {
       //    std::cout<<"B"<<std::endl;
-      pion_template_em  = pion_em_etaB;
+      pion_template_em = pion_em_etaB;
       pion_template_had = pion_had_etaB;
-      pion_template_ho  = pion_ho_etaB;
-      muon_template_em  = muon_em_etaB;
+      pion_template_ho = pion_ho_etaB;
+      muon_template_em = muon_em_etaB;
       muon_template_had = muon_had_etaB;
-      muon_template_ho  = muon_ho_etaB;
-    }
-    else if(eta > 1.31 && eta <= 1.4) {
+      muon_template_ho = muon_ho_etaB;
+    } else if (eta > 1.31 && eta <= 1.4) {
       //    std::cout<<"Tpl"<<std::endl;
-      pion_template_em  = pion_em_etaTpl;
+      pion_template_em = pion_em_etaTpl;
       pion_template_had = pion_had_etaTpl;
-      muon_template_em  = muon_em_etaTpl;
+      muon_template_em = muon_em_etaTpl;
       muon_template_had = muon_had_etaTpl;
-    }
-    else if(eta > 1.4) {
+    } else if (eta > 1.4) {
       //    std::cout<<"Epl"<<std::endl;
-      pion_template_em  = pion_em_etaEpl;
+      pion_template_em = pion_em_etaEpl;
       pion_template_had = pion_had_etaEpl;
-      muon_template_em  = muon_em_etaEpl;
+      muon_template_em = muon_em_etaEpl;
       muon_template_had = muon_had_etaEpl;
-    }
-    else {
-      LogTrace("MuonIdentification")<<"Some very weird thing happened in MuonCaloCompatibility::evaluate - go figure ;) ";
+    } else {
+      LogTrace("MuonIdentification")
+          << "Some very weird thing happened in MuonCaloCompatibility::evaluate - go figure ;) ";
       return -999;
     }
-  }
-  else if( 42 == 42 ) { // new eta bins, corrected hcal energy
-    if(  track->eta() >  1.27  ) {
+  } else if (42 == 42) {  // new eta bins, corrected hcal energy
+    if (track->eta() > 1.27) {
       // 	had_etaEpl ->Fill(muon->track().get()->p(),1.8/2.2*muon->calEnergy().had );
-      if(use_corrected_hcal)	had = 1.8/2.2*amuon.calEnergy().had;
-      else	had = amuon.calEnergy().had;
+      if (use_corrected_hcal)
+        had = 1.8 / 2.2 * amuon.calEnergy().had;
+      else
+        had = amuon.calEnergy().had;
       pion_template_had = pion_had_etaEpl;
       muon_template_had = muon_had_etaEpl;
     }
-    if( track->eta() <=  1.27  && track->eta() >  1.1 ) {
+    if (track->eta() <= 1.27 && track->eta() > 1.1) {
       // 	had_etaTpl ->Fill(muon->track().get()->p(),(1.8/(-2.2*muon->track().get()->eta()+5.5))*muon->calEnergy().had );
-      if(use_corrected_hcal)	had = (1.8/(-2.2*track->eta()+5.5))*amuon.calEnergy().had;
-      else 	had = amuon.calEnergy().had;
-      pion_template_had  = pion_had_etaTpl;
-      muon_template_had  = muon_had_etaTpl;
+      if (use_corrected_hcal)
+        had = (1.8 / (-2.2 * track->eta() + 5.5)) * amuon.calEnergy().had;
+      else
+        had = amuon.calEnergy().had;
+      pion_template_had = pion_had_etaTpl;
+      muon_template_had = muon_had_etaTpl;
     }
-    if( track->eta() <=  1.1 && track->eta() > -1.1 ) {
+    if (track->eta() <= 1.1 && track->eta() > -1.1) {
       // 	had_etaB   ->Fill(muon->track().get()->p(),sin(muon->track().get()->theta())*muon->calEnergy().had );
-      if(use_corrected_hcal)	had = sin(track->theta())*amuon.calEnergy().had;
-      else 	had = amuon.calEnergy().had;
-      pion_template_had  = pion_had_etaB;
-      muon_template_had  = muon_had_etaB;
+      if (use_corrected_hcal)
+        had = sin(track->theta()) * amuon.calEnergy().had;
+      else
+        had = amuon.calEnergy().had;
+      pion_template_had = pion_had_etaB;
+      muon_template_had = muon_had_etaB;
     }
-    if( track->eta() <= -1.1 && track->eta() > -1.27 ) {
+    if (track->eta() <= -1.1 && track->eta() > -1.27) {
       // 	had_etaTmi ->Fill(muon->track().get()->p(),(1.8/(-2.2*muon->track().get()->eta()+5.5))*muon->calEnergy().had );
-      if(use_corrected_hcal)	had = (1.8/(2.2*track->eta()+5.5))*amuon.calEnergy().had;
-      else 	had = amuon.calEnergy().had;
+      if (use_corrected_hcal)
+        had = (1.8 / (2.2 * track->eta() + 5.5)) * amuon.calEnergy().had;
+      else
+        had = amuon.calEnergy().had;
       pion_template_had = pion_had_etaTmi;
       muon_template_had = muon_had_etaTmi;
     }
-    if( track->eta() <= -1.27 ) {
+    if (track->eta() <= -1.27) {
       // 	had_etaEmi ->Fill(muon->track().get()->p(),1.8/2.2*muon->calEnergy().had );
-      if(use_corrected_hcal)	had = 1.8/2.2*amuon.calEnergy().had;
-      else 	had = amuon.calEnergy().had;
+      if (use_corrected_hcal)
+        had = 1.8 / 2.2 * amuon.calEnergy().had;
+      else
+        had = amuon.calEnergy().had;
       pion_template_had = pion_had_etaEmi;
       muon_template_had = muon_had_etaEmi;
     }
@@ -345,131 +351,152 @@ double MuonCaloCompatibility::evaluate( const reco::Muon& amuon ) {
 
     //    std::cout<<"We have a muon with an eta of: "<<track->eta()<<std::endl;
 
-    if(  track->eta() >  1.479  ) {
+    if (track->eta() > 1.479) {
       // 	em_etaEpl  ->Fill(muon->track().get()->p(),muon->calEnergy().em   );
       // 	//	em_etaTpl  ->Fill(muon->track().get()->p(),muon->calEnergy().em   );
       ////      em  = amuon.calEnergy().em;
-      pion_template_em  = pion_em_etaEpl;
-      muon_template_em  = muon_em_etaEpl;
+      pion_template_em = pion_em_etaEpl;
+      muon_template_em = muon_em_etaEpl;
     }
-    if( track->eta() <=  1.479 && track->eta() > -1.479 ) {
+    if (track->eta() <= 1.479 && track->eta() > -1.479) {
       // 	em_etaB    ->Fill(muon->track().get()->p(),muon->calEnergy().em   );
       ////      em  = amuon.calEnergy().em;
-      pion_template_em  = pion_em_etaB;
-      muon_template_em  = muon_em_etaB;
+      pion_template_em = pion_em_etaB;
+      muon_template_em = muon_em_etaB;
     }
-    if( track->eta() <= -1.479 ) {
+    if (track->eta() <= -1.479) {
       // 	//	em_etaTmi  ->Fill(muon->track().get()->p(),muon->calEnergy().em   );
       // 	em_etaEmi  ->Fill(muon->track().get()->p(),muon->calEnergy().em   );
       ////      em  = amuon.calEnergy().em;
-      pion_template_em  = pion_em_etaEmi;
-      muon_template_em  = muon_em_etaEmi;
+      pion_template_em = pion_em_etaEmi;
+      muon_template_em = muon_em_etaEmi;
     }
 
     // just one barrel eta region for the HO, no correction
     //    if( track->eta() < 1.4 && track->eta() > -1.4 ) { // experimenting now...
-    if( track->eta() < 1.28 && track->eta() > -1.28 ) {
+    if (track->eta() < 1.28 && track->eta() > -1.28) {
       // 	ho_etaB    ->Fill(muon->track().get()->p(),muon->calEnergy().ho   );
       ////      ho  = amuon.calEnergy().ho;
-      pion_template_ho  = pion_ho_etaB;
-      muon_template_ho  = muon_ho_etaB;
+      pion_template_ho = pion_ho_etaB;
+      muon_template_ho = muon_ho_etaB;
     }
-
-
   }
 
-
-  if( 42 != 42 ) { // check validity of input template histos and input variables"
-    pion_template_em ->ls();
+  if (42 != 42) {  // check validity of input template histos and input variables"
+    pion_template_em->ls();
     pion_template_had->ls();
-    if(pion_template_ho)   pion_template_ho ->ls();
-    muon_template_em ->ls();
+    if (pion_template_ho)
+      pion_template_ho->ls();
+    muon_template_em->ls();
     muon_template_had->ls();
-    if(muon_template_ho)   muon_template_ho ->ls();
+    if (muon_template_ho)
+      muon_template_ho->ls();
 
-    LogTrace("MuonIdentification")<<"Input variables: eta    p     em     had    ho "<<"\n"
-	     <<eta<<" "<<p<<" "<<em<<" "<<had<<" "<<ho<<" "<<"\n"
-	     <<"cal uncorr:    em     had    ho "<<"\n"
-	     <<eta<<" "<<p<<" "<<amuon.calEnergy().em<<" "<<amuon.calEnergy().had<<" "<<amuon.calEnergy().ho;
+    LogTrace("MuonIdentification") << "Input variables: eta    p     em     had    ho "
+                                   << "\n"
+                                   << eta << " " << p << " " << em << " " << had << " " << ho << " "
+                                   << "\n"
+                                   << "cal uncorr:    em     had    ho "
+                                   << "\n"
+                                   << eta << " " << p << " " << amuon.calEnergy().em << " " << amuon.calEnergy().had
+                                   << " " << amuon.calEnergy().ho;
   }
 
-
-  //  Look up Compatibility by, where x is p and y the energy. 
+  //  Look up Compatibility by, where x is p and y the energy.
   //  We have a set of different histograms for different regions of eta.
 
   // need error meassage in case the template histos are missing / the template file is not present!!! 070412
 
-  if( pion_template_em )  { // access ecal background template
-    if( accessing_overflow( *pion_template_em, p, em ) ) {
+  if (pion_template_em) {  // access ecal background template
+    if (accessing_overflow(*pion_template_em, p, em)) {
       pbx = 1.;
       psx = 1.;
-      LogTrace("MuonIdentification")<<"            // Message: trying to access overflow bin in MuonCompatibility template for ecal - defaulting signal and background  ";
-      LogTrace("MuonIdentification")<<"            // template value to 1. "<<pion_template_em->GetName()<<" e: "<<em<<" p: "<<p;
-    }
-    else pbx =  pion_template_em->GetBinContent(  pion_template_em->GetXaxis()->FindBin(p), pion_template_em->GetYaxis()->FindBin(em) );
+      LogTrace("MuonIdentification") << "            // Message: trying to access overflow bin in MuonCompatibility "
+                                        "template for ecal - defaulting signal and background  ";
+      LogTrace("MuonIdentification") << "            // template value to 1. " << pion_template_em->GetName()
+                                     << " e: " << em << " p: " << p;
+    } else
+      pbx = pion_template_em->GetBinContent(pion_template_em->GetXaxis()->FindBin(p),
+                                            pion_template_em->GetYaxis()->FindBin(em));
   }
-  if( pion_template_had ) { // access hcal background template
-    if( accessing_overflow( *pion_template_had, p, had ) ) {
+  if (pion_template_had) {  // access hcal background template
+    if (accessing_overflow(*pion_template_had, p, had)) {
       pby = 1.;
       psy = 1.;
-      LogTrace("MuonIdentification")<<"            // Message: trying to access overflow bin in MuonCompatibility template for hcal - defaulting signal and background  ";
-      LogTrace("MuonIdentification")<<"            // template value to 1. "<<pion_template_had->GetName()<<" e: "<<had<<" p: "<<p;
-    }
-    else pby =  pion_template_had->GetBinContent(  pion_template_had->GetXaxis()->FindBin(p), pion_template_had->GetYaxis()->FindBin(had) );
+      LogTrace("MuonIdentification") << "            // Message: trying to access overflow bin in MuonCompatibility "
+                                        "template for hcal - defaulting signal and background  ";
+      LogTrace("MuonIdentification") << "            // template value to 1. " << pion_template_had->GetName()
+                                     << " e: " << had << " p: " << p;
+    } else
+      pby = pion_template_had->GetBinContent(pion_template_had->GetXaxis()->FindBin(p),
+                                             pion_template_had->GetYaxis()->FindBin(had));
   }
-  if(pion_template_ho) { // access ho background template
-    if( accessing_overflow( *pion_template_ho, p, ho ) ) {
+  if (pion_template_ho) {  // access ho background template
+    if (accessing_overflow(*pion_template_ho, p, ho)) {
       pbz = 1.;
       psz = 1.;
-      LogTrace("MuonIdentification")<<"            // Message: trying to access overflow bin in MuonCompatibility template for ho   - defaulting signal and background  ";
-      LogTrace("MuonIdentification")<<"            // template value to 1. "<<pion_template_ho->GetName()<<" e: "<<em<<" p: "<<p; 
-    }
-    else pbz =  pion_template_ho->GetBinContent(  pion_template_ho->GetXaxis()->FindBin(p), pion_template_ho->GetYaxis()->FindBin(ho) );
+      LogTrace("MuonIdentification") << "            // Message: trying to access overflow bin in MuonCompatibility "
+                                        "template for ho   - defaulting signal and background  ";
+      LogTrace("MuonIdentification") << "            // template value to 1. " << pion_template_ho->GetName()
+                                     << " e: " << em << " p: " << p;
+    } else
+      pbz = pion_template_ho->GetBinContent(pion_template_ho->GetXaxis()->FindBin(p),
+                                            pion_template_ho->GetYaxis()->FindBin(ho));
   }
 
-
-  if( muon_template_em )  { // access ecal background template
-    if( accessing_overflow( *muon_template_em, p, em ) ) {
+  if (muon_template_em) {  // access ecal background template
+    if (accessing_overflow(*muon_template_em, p, em)) {
       psx = 1.;
       pbx = 1.;
-      LogTrace("MuonIdentification")<<"            // Message: trying to access overflow bin in MuonCompatibility template for ecal - defaulting signal and background  ";
-      LogTrace("MuonIdentification")<<"            // template value to 1. "<<muon_template_em->GetName()<<" e: "<<em<<" p: "<<p;
-    }
-    else psx =  muon_template_em->GetBinContent(  muon_template_em->GetXaxis()->FindBin(p), muon_template_em->GetYaxis()->FindBin(em) );
+      LogTrace("MuonIdentification") << "            // Message: trying to access overflow bin in MuonCompatibility "
+                                        "template for ecal - defaulting signal and background  ";
+      LogTrace("MuonIdentification") << "            // template value to 1. " << muon_template_em->GetName()
+                                     << " e: " << em << " p: " << p;
+    } else
+      psx = muon_template_em->GetBinContent(muon_template_em->GetXaxis()->FindBin(p),
+                                            muon_template_em->GetYaxis()->FindBin(em));
   }
-  if( muon_template_had ) { // access hcal background template
-    if( accessing_overflow( *muon_template_had, p, had ) ) {
+  if (muon_template_had) {  // access hcal background template
+    if (accessing_overflow(*muon_template_had, p, had)) {
       psy = 1.;
       pby = 1.;
-      LogTrace("MuonIdentification")<<"            // Message: trying to access overflow bin in MuonCompatibility template for hcal - defaulting signal and background  ";
-      LogTrace("MuonIdentification")<<"            // template value to 1. "<<muon_template_had->GetName()<<" e: "<<had<<" p: "<<p;
-    }
-    else psy =  muon_template_had->GetBinContent(  muon_template_had->GetXaxis()->FindBin(p), muon_template_had->GetYaxis()->FindBin(had) );
+      LogTrace("MuonIdentification") << "            // Message: trying to access overflow bin in MuonCompatibility "
+                                        "template for hcal - defaulting signal and background  ";
+      LogTrace("MuonIdentification") << "            // template value to 1. " << muon_template_had->GetName()
+                                     << " e: " << had << " p: " << p;
+    } else
+      psy = muon_template_had->GetBinContent(muon_template_had->GetXaxis()->FindBin(p),
+                                             muon_template_had->GetYaxis()->FindBin(had));
   }
-  if(muon_template_ho) { // access ho background template
-    if( accessing_overflow( *muon_template_ho, p, ho ) ) {
+  if (muon_template_ho) {  // access ho background template
+    if (accessing_overflow(*muon_template_ho, p, ho)) {
       psz = 1.;
       pbz = 1.;
-       LogTrace("MuonIdentification")<<"            // Message: trying to access overflow bin in MuonCompatibility template for ho   - defaulting signal and background  ";
-       LogTrace("MuonIdentification")<<"            // template value to 1. "<<muon_template_ho->GetName()<<" e: "<<ho<<" p: "<<p;
-    }
-    else psz =  muon_template_ho->GetBinContent(  muon_template_ho->GetXaxis()->FindBin(p), muon_template_ho->GetYaxis()->FindBin(ho) );
+      LogTrace("MuonIdentification") << "            // Message: trying to access overflow bin in MuonCompatibility "
+                                        "template for ho   - defaulting signal and background  ";
+      LogTrace("MuonIdentification") << "            // template value to 1. " << muon_template_ho->GetName()
+                                     << " e: " << ho << " p: " << p;
+    } else
+      psz = muon_template_ho->GetBinContent(muon_template_ho->GetXaxis()->FindBin(p),
+                                            muon_template_ho->GetYaxis()->FindBin(ho));
   }
 
   // erm - what is this?!?! How could the HO probability be less than 0????? Do we want this line!?!?
-  if(psz <= 0.) psz = 1.;
-  if(pbz <= 0.) pbz = 1.;
+  if (psz <= 0.)
+    psz = 1.;
+  if (pbz <= 0.)
+    pbz = 1.;
 
-  // Protection agains empty bins - set cal part to neutral if the bin of the template is empty 
+  // Protection agains empty bins - set cal part to neutral if the bin of the template is empty
   // (temporary fix, a proper extrapolation would be better)
   if (psx == 0. || pbx == 0.) {
     psx = 1.;
     pbx = 1.;
-  } 
+  }
   if (psy == 0. || pby == 0.) {
     psy = 1.;
     pby = 1.;
-  } 
+  }
   if (psz == 0. || pbz == 0.) {
     psz = 1.;
     pbz = 1.;
@@ -478,35 +505,39 @@ double MuonCaloCompatibility::evaluate( const reco::Muon& amuon ) {
   // There are two classes of events that deliver 0 for the hcal or ho energy:
   // 1) the track momentum is so low that the extrapolation tells us it should not have reached the cal
   // 2) the crossed cell had an reading below the readout cuts.
-  // The 2nd case discriminates between muons and hadrons, the 1st not. Thus for the time being, 
+  // The 2nd case discriminates between muons and hadrons, the 1st not. Thus for the time being,
   // we set the returned ps and pb to 0 for these cases.
   // We need to have a return value different from 0 for the 1st case in the long run.
-  if ( had == 0.0 ) {
+  if (had == 0.0) {
     psy = 1.;
     pby = 1.;
-  } 
-  if ( ho == 0.0 ) {
+  }
+  if (ho == 0.0) {
     psz = 1.;
     pbz = 1.;
   }
 
-
-  // Set em to neutral if no energy in em or negative energy measured. 
-  // (These cases might indicate problems in the ecal association or readout?! The only 
+  // Set em to neutral if no energy in em or negative energy measured.
+  // (These cases might indicate problems in the ecal association or readout?! The only
   // hint so far: for critical eta region (eta in [1.52, 1.64]) have negative em values.)
-  if( em <= 0. && !use_em_special ) {
+  if (em <= 0. && !use_em_special) {
     pbx = 1.;
     psx = 1.;
   }
 
-  if( (psx*psy*psz+pbx*pby*pbz) > 0. ) muon_compatibility = psx*psy*psz / (psx*psy*psz+pbx*pby*pbz);
+  if ((psx * psy * psz + pbx * pby * pbz) > 0.)
+    muon_compatibility = psx * psy * psz / (psx * psy * psz + pbx * pby * pbz);
   else {
-    LogTrace("MuonIdentification")<<"Divide by 0 - defaulting consistency to 0.5 (neutral)!!";
+    LogTrace("MuonIdentification") << "Divide by 0 - defaulting consistency to 0.5 (neutral)!!";
     muon_compatibility = 0.5;
-    LogTrace("MuonIdentification")<<"Input variables: eta    p     em     had    ho "<<"\n"
-	     <<eta<<" "<<p<<" "<<em<<" "<<had<<" "<<ho<<" "<<"\n"
-	     <<"cal uncorr:    em     had    ho "<<"\n"
-	     <<eta<<" "<<p<<" "<<amuon.calEnergy().em<<" "<<amuon.calEnergy().had<<" "<<amuon.calEnergy().ho;
+    LogTrace("MuonIdentification") << "Input variables: eta    p     em     had    ho "
+                                   << "\n"
+                                   << eta << " " << p << " " << em << " " << had << " " << ho << " "
+                                   << "\n"
+                                   << "cal uncorr:    em     had    ho "
+                                   << "\n"
+                                   << eta << " " << p << " " << amuon.calEnergy().em << " " << amuon.calEnergy().had
+                                   << " " << amuon.calEnergy().ho;
   }
   return muon_compatibility;
 }

--- a/RecoMuon/MuonIdentification/src/MuonCosmicCompatibilityFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonCosmicCompatibilityFiller.cc
@@ -40,21 +40,20 @@
 
 #include "TMath.h"
 
-
 using namespace edm;
 using namespace std;
 
-MuonCosmicCompatibilityFiller::MuonCosmicCompatibilityFiller(const edm::ParameterSet& iConfig,edm::ConsumesCollector& iC):
-  inputMuonCollections_(iConfig.getParameter<std::vector<edm::InputTag> >("InputMuonCollections")),
-  inputTrackCollections_(iConfig.getParameter<std::vector<edm::InputTag> >("InputTrackCollections")),
-  inputCosmicMuonCollection_(iConfig.getParameter<edm::InputTag>("InputCosmicMuonCollection")),
-  inputVertexCollection_(iConfig.getParameter<edm::InputTag>("InputVertexCollection")),
-  service_(nullptr)
-{
+MuonCosmicCompatibilityFiller::MuonCosmicCompatibilityFiller(const edm::ParameterSet& iConfig,
+                                                             edm::ConsumesCollector& iC)
+    : inputMuonCollections_(iConfig.getParameter<std::vector<edm::InputTag> >("InputMuonCollections")),
+      inputTrackCollections_(iConfig.getParameter<std::vector<edm::InputTag> >("InputTrackCollections")),
+      inputCosmicMuonCollection_(iConfig.getParameter<edm::InputTag>("InputCosmicMuonCollection")),
+      inputVertexCollection_(iConfig.getParameter<edm::InputTag>("InputVertexCollection")),
+      service_(nullptr) {
   // service parameters
   edm::ParameterSet serviceParameters = iConfig.getParameter<edm::ParameterSet>("ServiceParameters");
-  service_ = new MuonServiceProxy(serviceParameters);     
-  
+  service_ = new MuonServiceProxy(serviceParameters);
+
   //kinematic vars
   angleThreshold_ = iConfig.getParameter<double>("angleCut");
   deltaPt_ = iConfig.getParameter<double>("deltaPt");
@@ -92,153 +91,153 @@ MuonCosmicCompatibilityFiller::MuonCosmicCompatibilityFiller(const edm::Paramete
   minvProb_ = iConfig.getParameter<double>("minvProb");
   maxvertZ_ = iConfig.getParameter<double>("maxvertZ");
   maxvertRho_ = iConfig.getParameter<double>("maxvertRho");
-//  nTrackThreshold_ = iConfig.getParameter<unsigned int>("nTrackThreshold");
+  //  nTrackThreshold_ = iConfig.getParameter<unsigned int>("nTrackThreshold");
 
-  for(unsigned int i=0;i<inputMuonCollections_.size();++i)
+  for (unsigned int i = 0; i < inputMuonCollections_.size(); ++i)
     muonTokens_.push_back(iC.consumes<reco::MuonCollection>(inputMuonCollections_.at(i)));
-  for(unsigned int i=0;i<inputTrackCollections_.size();++i)
+  for (unsigned int i = 0; i < inputTrackCollections_.size(); ++i)
     trackTokens_.push_back(iC.consumes<reco::TrackCollection>(inputTrackCollections_.at(i)));
 
   cosmicToken_ = iC.consumes<reco::MuonCollection>(inputCosmicMuonCollection_);
   vertexToken_ = iC.consumes<reco::VertexCollection>(inputVertexCollection_);
-
-    
-
-
 }
 
 MuonCosmicCompatibilityFiller::~MuonCosmicCompatibilityFiller() {
-  if (service_) delete service_;
+  if (service_)
+    delete service_;
 }
 
-reco::MuonCosmicCompatibility
-MuonCosmicCompatibilityFiller::fillCompatibility( const reco::Muon& muon, edm::Event& iEvent, const edm::EventSetup& iSetup )
-{
+reco::MuonCosmicCompatibility MuonCosmicCompatibilityFiller::fillCompatibility(const reco::Muon& muon,
+                                                                               edm::Event& iEvent,
+                                                                               const edm::EventSetup& iSetup) {
   const std::string theCategory = "MuonCosmicCompatibilityFiller";
 
   reco::MuonCosmicCompatibility returnComp;
-  
+
   service_->update(iSetup);
-  
+
   float timeCompatibility = muonTiming(iEvent, muon, false);
-  float backToBackCompatibility = backToBack2LegCosmic(iEvent,muon);    
-  float overlapCompatibility = isOverlappingMuon(iEvent,iSetup,muon);
-  float ipCompatibility = pvMatches(iEvent,muon,false);
-  float vertexCompatibility = eventActivity(iEvent,muon);
-  float combinedCompatibility = combinedCosmicID(iEvent,iSetup,muon,false,false);
-  
+  float backToBackCompatibility = backToBack2LegCosmic(iEvent, muon);
+  float overlapCompatibility = isOverlappingMuon(iEvent, iSetup, muon);
+  float ipCompatibility = pvMatches(iEvent, muon, false);
+  float vertexCompatibility = eventActivity(iEvent, muon);
+  float combinedCompatibility = combinedCosmicID(iEvent, iSetup, muon, false, false);
+
   returnComp.timeCompatibility = timeCompatibility;
   returnComp.backToBackCompatibility = backToBackCompatibility;
   returnComp.overlapCompatibility = overlapCompatibility;
   returnComp.cosmicCompatibility = combinedCompatibility;
   returnComp.ipCompatibility = ipCompatibility;
   returnComp.vertexCompatibility = vertexCompatibility;
-  
+
   return returnComp;
-  
 }
 
 //
 //Timing: 0 - not cosmic-like
 //
-float
-MuonCosmicCompatibilityFiller::muonTiming(const edm::Event& iEvent, const reco::Muon& muon, bool isLoose) const {
+float MuonCosmicCompatibilityFiller::muonTiming(const edm::Event& iEvent, const reco::Muon& muon, bool isLoose) const {
+  float offTimeNegMult, offTimePosMult, offTimeNeg, offTimePos;
 
-   float offTimeNegMult, offTimePosMult, offTimeNeg, offTimePos;
-
-   if (isLoose) {
-     //use "loose" parameter set
-     offTimeNegMult = offTimeNegLooseMult_; 
-     offTimePosMult = offTimePosLooseMult_;
-     offTimeNeg     = offTimeNegLoose_;
-     offTimePos     = offTimePosLoose_;
+  if (isLoose) {
+    //use "loose" parameter set
+    offTimeNegMult = offTimeNegLooseMult_;
+    offTimePosMult = offTimePosLooseMult_;
+    offTimeNeg = offTimeNegLoose_;
+    offTimePos = offTimePosLoose_;
   } else {
-     offTimeNegMult = offTimeNegTightMult_;
-     offTimePosMult = offTimePosTightMult_;
-     offTimeNeg     = offTimeNegTight_;
-     offTimePos     = offTimePosTight_;
+    offTimeNegMult = offTimeNegTightMult_;
+    offTimePosMult = offTimePosTightMult_;
+    offTimeNeg = offTimeNegTight_;
+    offTimePos = offTimePosTight_;
   }
 
   float result = 0.0;
 
-  if( muon.isTimeValid() ) {
+  if (muon.isTimeValid()) {
     //case of multiple muon event
     if (nMuons(iEvent) > 1) {
-
       float positiveTime = 0;
-      if ( muon.time().timeAtIpInOut < offTimeNegMult || muon.time().timeAtIpInOut > offTimePosMult) result = 1.;
-      if ( muon.time().timeAtIpInOut > 0.) positiveTime = muon.time().timeAtIpInOut;
+      if (muon.time().timeAtIpInOut < offTimeNegMult || muon.time().timeAtIpInOut > offTimePosMult)
+        result = 1.;
+      if (muon.time().timeAtIpInOut > 0.)
+        positiveTime = muon.time().timeAtIpInOut;
 
-      //special case, looking for time-correlation 
-      // between muons in opposite hemispheres 
-      if (!isLoose && result == 0 && positiveTime > corrTimePos_) { 
+      //special case, looking for time-correlation
+      // between muons in opposite hemispheres
+      if (!isLoose && result == 0 && positiveTime > corrTimePos_) {
+        //check hemi of this muon
+        bool isUp = false;
+        reco::TrackRef outertrack = muon.outerTrack();
+        if (outertrack.isNonnull()) {
+          if (outertrack->phi() > 0)
+            isUp = true;
 
-          //check hemi of this muon
-          bool isUp = false;
-          reco::TrackRef outertrack = muon.outerTrack();
-          if( outertrack.isNonnull() ) {
-              if( outertrack->phi() > 0 ) isUp = true;
+          //loop over muons in that event and find if there are any in the opposite hemi
+          edm::Handle<reco::MuonCollection> muonHandle;
+          iEvent.getByToken(muonTokens_[1], muonHandle);
 
-              //loop over muons in that event and find if there are any in the opposite hemi 
-              edm::Handle<reco::MuonCollection> muonHandle;
-              iEvent.getByToken(muonTokens_[1], muonHandle);
+          if (!muonHandle.failedToGet()) {
+            for (reco::MuonCollection::const_iterator iMuon = muonHandle->begin(); iMuon != muonHandle->end();
+                 ++iMuon) {
+              if (!iMuon->isGlobalMuon())
+                continue;
 
-              if( !muonHandle.failedToGet() ) {
-                  for ( reco::MuonCollection::const_iterator iMuon = muonHandle->begin(); iMuon !=  muonHandle->end(); ++iMuon ) {
-                      if (!iMuon->isGlobalMuon()) continue;
+              reco::TrackRef checkedTrack = iMuon->outerTrack();
+              if (muon.isTimeValid()) {
+                // from bottom up
+                if (checkedTrack->phi() < 0 && isUp) {
+                  if (iMuon->time().timeAtIpInOut < corrTimeNeg_)
+                    result = 1.0;
+                  break;
+                } else if (checkedTrack->phi() > 0 && !isUp) {
+                  // from top down
+                  if (iMuon->time().timeAtIpInOut < corrTimeNeg_)
+                    result = 1.0;
+                  break;
+                }
+              }  //muon is time valid
+            }
+          }
+        }  //track is nonnull
+      }    //double check timing
+    } else {
+      //case of a single muon event
+      if (muon.time().timeAtIpInOut < offTimeNeg || muon.time().timeAtIpInOut > offTimePos)
+        result = 1.;
+    }
+  }  //is time valid
 
-                      reco::TrackRef checkedTrack = iMuon->outerTrack();
-                      if( muon.isTimeValid() ) {
+  if (!isLoose && result > 0) {
+    //check loose ip
+    if (pvMatches(iEvent, muon, true) == 0)
+      result *= 2.;
+  }
 
-                          // from bottom up
-                          if (checkedTrack->phi() < 0 && isUp) {
-                              if (iMuon->time().timeAtIpInOut < corrTimeNeg_) result = 1.0;
-                              break;
-                          } else if (checkedTrack->phi() > 0 && !isUp) {
-                               // from top down 
-                               if (iMuon->time().timeAtIpInOut < corrTimeNeg_) result = 1.0; 
-                               break;
-                             }
-                         } //muon is time valid
-                     } 
-                 }
-             } //track is nonnull
-         } //double check timing
-     } else {
-        //case of a single muon event
-        if ( muon.time().timeAtIpInOut < offTimeNeg || muon.time().timeAtIpInOut > offTimePos) result = 1.;
-      }
-    } //is time valid
-
-  
-   if (!isLoose && result > 0) {
-     //check loose ip
-     if (pvMatches(iEvent, muon, true) == 0) result *= 2.;
-   } 
-
-   return result;
+  return result;
 }
 
 //
-//Back-to-back selector 
+//Back-to-back selector
 //
-unsigned int 
-MuonCosmicCompatibilityFiller::backToBack2LegCosmic(const edm::Event& iEvent, const reco::Muon& muon) const {
-
-  unsigned int result = 0; //no partners - collision
+unsigned int MuonCosmicCompatibilityFiller::backToBack2LegCosmic(const edm::Event& iEvent,
+                                                                 const reco::Muon& muon) const {
+  unsigned int result = 0;  //no partners - collision
   reco::TrackRef track;
-  if ( muon.isGlobalMuon()  )            track = muon.innerTrack();
-  else if ( muon.isTrackerMuon() )       track = muon.track();
-  else if ( muon.isStandAloneMuon() || muon.isRPCMuon() || muon.isGEMMuon() || muon.isME0Muon() )
+  if (muon.isGlobalMuon())
+    track = muon.innerTrack();
+  else if (muon.isTrackerMuon())
+    track = muon.track();
+  else if (muon.isStandAloneMuon() || muon.isRPCMuon() || muon.isGEMMuon() || muon.isME0Muon())
     return false;
 
-  for (unsigned int iColl = 0; iColl<trackTokens_.size(); ++iColl){
+  for (unsigned int iColl = 0; iColl < trackTokens_.size(); ++iColl) {
     edm::Handle<reco::TrackCollection> trackHandle;
-    iEvent.getByToken(trackTokens_[iColl],trackHandle);
-    if (muonid::findOppositeTrack(trackHandle, *track, angleThreshold_, deltaPt_).isNonnull()) { 
+    iEvent.getByToken(trackTokens_[iColl], trackHandle);
+    if (muonid::findOppositeTrack(trackHandle, *track, angleThreshold_, deltaPt_).isNonnull()) {
       result++;
-     }
-   } //loop over track collections
+    }
+  }  //loop over track collections
 
   return result;
 }
@@ -246,31 +245,29 @@ MuonCosmicCompatibilityFiller::backToBack2LegCosmic(const edm::Event& iEvent, co
 //
 //Check the number of global muons in an event, return true if there are more than 1 muon
 //
-unsigned int
-MuonCosmicCompatibilityFiller::nMuons(const edm::Event& iEvent) const {
+unsigned int MuonCosmicCompatibilityFiller::nMuons(const edm::Event& iEvent) const {
+  unsigned int nGlb = 0;
 
-    unsigned int nGlb = 0;
+  edm::Handle<reco::MuonCollection> muonHandle;
+  iEvent.getByToken(muonTokens_[1], muonHandle);
 
-    edm::Handle<reco::MuonCollection> muonHandle;
-    iEvent.getByToken(muonTokens_[1], muonHandle);
+  if (!muonHandle.failedToGet()) {
+    for (reco::MuonCollection::const_iterator iMuon = muonHandle->begin(); iMuon != muonHandle->end(); ++iMuon) {
+      if (!iMuon->isGlobalMuon())
+        continue;
+      nGlb++;
+    }
+  }
 
-    if( !muonHandle.failedToGet() ) {
-      for ( reco::MuonCollection::const_iterator iMuon = muonHandle->begin(); iMuon !=  muonHandle->end(); ++iMuon ) {
-         if (!iMuon->isGlobalMuon()) continue;
-           nGlb++;
-        }
-      } 
- 
-    return nGlb;
+  return nGlb;
 }
-
 
 //
 //Check overlap between collections, use shared hits info
 //
-bool 
-MuonCosmicCompatibilityFiller::isOverlappingMuon(const edm::Event& iEvent, const edm::EventSetup& iSetup, const reco::Muon& muon) const {
-
+bool MuonCosmicCompatibilityFiller::isOverlappingMuon(const edm::Event& iEvent,
+                                                      const edm::EventSetup& iSetup,
+                                                      const reco::Muon& muon) const {
   // 4 steps in this module
   // step1 : check whether it's 1leg cosmic muon or not
   // step2 : both muons (muons and muonsFromCosmics1Leg) should have close IP
@@ -278,231 +275,251 @@ MuonCosmicCompatibilityFiller::isOverlappingMuon(const edm::Event& iEvent, const
   // step4 : check shared hits in both muon tracks
 
   // check if this muon is available in muonsFromCosmics collection
-  bool overlappingMuon = false; //false - not cosmic-like
-  if( !muon.isGlobalMuon() ) return false;
-  
+  bool overlappingMuon = false;  //false - not cosmic-like
+  if (!muon.isGlobalMuon())
+    return false;
+
   // reco muons for cosmics
   edm::Handle<reco::MuonCollection> muonHandle;
   iEvent.getByToken(cosmicToken_, muonHandle);
-  
+
   // Global Tracking Geometry
   ESHandle<GlobalTrackingGeometry> trackingGeometry;
   iSetup.get<GlobalTrackingGeometryRecord>().get(trackingGeometry);
-  
+
   // PV
   math::XYZPoint RefVtx;
   RefVtx.SetXYZ(0, 0, 0);
-  
+
   edm::Handle<reco::VertexCollection> pvHandle;
-  iEvent.getByToken(vertexToken_,pvHandle);
-  const reco::VertexCollection & vertices = *pvHandle.product();
-  for(reco::VertexCollection::const_iterator it=vertices.begin() ; it!=vertices.end() ; ++it) {
-      RefVtx = it->position();
+  iEvent.getByToken(vertexToken_, pvHandle);
+  const reco::VertexCollection& vertices = *pvHandle.product();
+  for (reco::VertexCollection::const_iterator it = vertices.begin(); it != vertices.end(); ++it) {
+    RefVtx = it->position();
   }
-  
-  
-  if( !muonHandle.failedToGet() ) {
-    for ( reco::MuonCollection::const_iterator cosmicMuon = muonHandle->begin();cosmicMuon !=  muonHandle->end(); ++cosmicMuon ) {
-      if ( cosmicMuon->innerTrack() == muon.innerTrack() || cosmicMuon->outerTrack() == muon.outerTrack()) return true;
-      
+
+  if (!muonHandle.failedToGet()) {
+    for (reco::MuonCollection::const_iterator cosmicMuon = muonHandle->begin(); cosmicMuon != muonHandle->end();
+         ++cosmicMuon) {
+      if (cosmicMuon->innerTrack() == muon.innerTrack() || cosmicMuon->outerTrack() == muon.outerTrack())
+        return true;
+
       reco::TrackRef outertrack = muon.outerTrack();
       reco::TrackRef costrack = cosmicMuon->outerTrack();
-      
+
       bool isUp = false;
-      if( outertrack->phi() > 0 ) isUp = true; 
-      
-      // shared hits 
+      if (outertrack->phi() > 0)
+        isUp = true;
+
+      // shared hits
       int RecHitsMuon = outertrack->numberOfValidHits();
       int RecHitsCosmicMuon = 0;
       int shared = 0;
       // count hits for same hemisphere
-      if( costrack.isNonnull() ) {
-	int nhitsUp = 0;
-	int nhitsDown = 0;
-	// unused
-	//	bool isCosmic1Leg = false;
-	//	bool isCloseIP = false;
-	//	bool isCloseRef = false;
+      if (costrack.isNonnull()) {
+        int nhitsUp = 0;
+        int nhitsDown = 0;
+        // unused
+        //	bool isCosmic1Leg = false;
+        //	bool isCloseIP = false;
+        //	bool isCloseRef = false;
 
-	for( trackingRecHit_iterator coshit = costrack->recHitsBegin(); coshit != costrack->recHitsEnd(); coshit++ ) {
-	  if( (*coshit)->isValid() ) {
-	    DetId id((*coshit)->geographicalId());
-	    double hity = trackingGeometry->idToDet(id)->position().y();
-	    if( hity > 0 ) nhitsUp++;
-	    if( hity < 0 ) nhitsDown++;
+        for (trackingRecHit_iterator coshit = costrack->recHitsBegin(); coshit != costrack->recHitsEnd(); coshit++) {
+          if ((*coshit)->isValid()) {
+            DetId id((*coshit)->geographicalId());
+            double hity = trackingGeometry->idToDet(id)->position().y();
+            if (hity > 0)
+              nhitsUp++;
+            if (hity < 0)
+              nhitsDown++;
 
-	    if( isUp && hity > 0 ) RecHitsCosmicMuon++;
-	    if( !isUp && hity < 0 ) RecHitsCosmicMuon++;
-	  }
-	}
-	// step1
-	//UNUSED:	if( nhitsUp > 0 && nhitsDown > 0 ) isCosmic1Leg = true;
-	//if( !isCosmic1Leg ) continue;
-	
-	if( outertrack.isNonnull() ) {
-	  // step2
-	  //UNUSED:          const double ipErr = (double)outertrack->d0Error();
-	  //UNUSED:          double ipThreshold  = max(ipThreshold_, ipErr);
-	  //UNUSED:	  if( fabs(outertrack->dxy(RefVtx) + costrack->dxy(RefVtx)) < ipThreshold ) isCloseIP = true;
-	  //if( !isCloseIP ) continue;
+            if (isUp && hity > 0)
+              RecHitsCosmicMuon++;
+            if (!isUp && hity < 0)
+              RecHitsCosmicMuon++;
+          }
+        }
+        // step1
+        //UNUSED:	if( nhitsUp > 0 && nhitsDown > 0 ) isCosmic1Leg = true;
+        //if( !isCosmic1Leg ) continue;
 
-	  // step3
-	  GlobalPoint muonRefVtx( outertrack->vx(), outertrack->vy(), outertrack->vz() );
-	  GlobalPoint cosmicRefVtx( costrack->vx(), costrack->vy(), costrack->vz() );
-	  //UNUSED:	  float dist = (muonRefVtx - cosmicRefVtx).mag();
-	  //UNUSED:	  if( dist < 0.1 ) isCloseRef = true;
-	  //if( !isCloseRef ) continue;
+        if (outertrack.isNonnull()) {
+          // step2
+          //UNUSED:          const double ipErr = (double)outertrack->d0Error();
+          //UNUSED:          double ipThreshold  = max(ipThreshold_, ipErr);
+          //UNUSED:	  if( fabs(outertrack->dxy(RefVtx) + costrack->dxy(RefVtx)) < ipThreshold ) isCloseIP = true;
+          //if( !isCloseIP ) continue;
 
-	  for( trackingRecHit_iterator trkhit = outertrack->recHitsBegin(); trkhit != outertrack->recHitsEnd(); trkhit++ ) {
-	    if( (*trkhit)->isValid() ) {
-	      for( trackingRecHit_iterator coshit = costrack->recHitsBegin(); coshit != costrack->recHitsEnd(); coshit++ ) {
-		if( (*coshit)->isValid() ) {
-		  if( (*trkhit)->geographicalId() == (*coshit)->geographicalId() ) {
-		    if( ((*trkhit)->localPosition() - (*coshit)->localPosition()).mag()< 10e-5 ) shared++;
-		  }
-		  
-		}
-	      }
-	    }
-	  }
-	}
+          // step3
+          GlobalPoint muonRefVtx(outertrack->vx(), outertrack->vy(), outertrack->vz());
+          GlobalPoint cosmicRefVtx(costrack->vx(), costrack->vy(), costrack->vz());
+          //UNUSED:	  float dist = (muonRefVtx - cosmicRefVtx).mag();
+          //UNUSED:	  if( dist < 0.1 ) isCloseRef = true;
+          //if( !isCloseRef ) continue;
+
+          for (trackingRecHit_iterator trkhit = outertrack->recHitsBegin(); trkhit != outertrack->recHitsEnd();
+               trkhit++) {
+            if ((*trkhit)->isValid()) {
+              for (trackingRecHit_iterator coshit = costrack->recHitsBegin(); coshit != costrack->recHitsEnd();
+                   coshit++) {
+                if ((*coshit)->isValid()) {
+                  if ((*trkhit)->geographicalId() == (*coshit)->geographicalId()) {
+                    if (((*trkhit)->localPosition() - (*coshit)->localPosition()).mag() < 10e-5)
+                      shared++;
+                  }
+                }
+              }
+            }
+          }
+        }
       }
       // step4
       double fraction = -1;
-      if( RecHitsMuon != 0 ) fraction = shared/(double)RecHitsMuon;
-    // 	     std::cout << "shared = " << shared << " " << fraction << " " << RecHitsMuon << " " << RecHitsCosmicMuon << std::endl;
-      if( shared > sharedHits_ && fraction > sharedFrac_ ) {
-	overlappingMuon = true;
-	break;
+      if (RecHitsMuon != 0)
+        fraction = shared / (double)RecHitsMuon;
+      // 	     std::cout << "shared = " << shared << " " << fraction << " " << RecHitsMuon << " " << RecHitsCosmicMuon << std::endl;
+      if (shared > sharedHits_ && fraction > sharedFrac_) {
+        overlappingMuon = true;
+        break;
       }
     }
   }
-  
+
   return overlappingMuon;
 }
 
 //
 //pv matches
 //
-unsigned int 
-MuonCosmicCompatibilityFiller::pvMatches(const edm::Event& iEvent, const reco::Muon& muon, bool isLoose) const {
+unsigned int MuonCosmicCompatibilityFiller::pvMatches(const edm::Event& iEvent,
+                                                      const reco::Muon& muon,
+                                                      bool isLoose) const {
+  float maxdxyMult, maxdzMult, maxdxy, maxdz;
 
-   float maxdxyMult, maxdzMult, maxdxy, maxdz;
-
-   if (isLoose) {
-     //use "loose" parameter set
-     maxdxyMult = maxdxyLooseMult_;
-     maxdzMult  = maxdzLooseMult_;
-     maxdxy     = maxdxyLoose_;
-     maxdz      = maxdzLoose_;
+  if (isLoose) {
+    //use "loose" parameter set
+    maxdxyMult = maxdxyLooseMult_;
+    maxdzMult = maxdzLooseMult_;
+    maxdxy = maxdxyLoose_;
+    maxdz = maxdzLoose_;
   } else {
-     maxdxyMult = maxdxyTightMult_;
-     maxdzMult  = maxdzTightMult_;
-     maxdxy     = maxdxyTight_;
-     maxdz      = maxdzTight_;
+    maxdxyMult = maxdxyTightMult_;
+    maxdzMult = maxdzTightMult_;
+    maxdxy = maxdxyTight_;
+    maxdz = maxdzTight_;
   }
 
   unsigned int result = 0;
 
   reco::TrackRef track;
-  if ( muon.isGlobalMuon() )          track = muon.innerTrack();
-  else if ( muon.isTrackerMuon() || muon.isRPCMuon() )    track = muon.track();
-  else if ( muon.isStandAloneMuon())  track = muon.standAloneMuon();
-  
+  if (muon.isGlobalMuon())
+    track = muon.innerTrack();
+  else if (muon.isTrackerMuon() || muon.isRPCMuon())
+    track = muon.track();
+  else if (muon.isStandAloneMuon())
+    track = muon.standAloneMuon();
+
   bool multipleMu = false;
-  if (nMuons(iEvent) > 1) multipleMu = true;
+  if (nMuons(iEvent) > 1)
+    multipleMu = true;
 
   math::XYZPoint RefVtx;
   RefVtx.SetXYZ(0, 0, 0);
 
   edm::Handle<reco::VertexCollection> pvHandle;
-  iEvent.getByToken(vertexToken_,pvHandle);
-  const reco::VertexCollection & vertices = *pvHandle.product();
-  for(reco::VertexCollection::const_iterator it=vertices.begin() ; it!=vertices.end() ; ++it){
+  iEvent.getByToken(vertexToken_, pvHandle);
+  const reco::VertexCollection& vertices = *pvHandle.product();
+  for (reco::VertexCollection::const_iterator it = vertices.begin(); it != vertices.end(); ++it) {
     RefVtx = it->position();
 
-    if ( track.isNonnull() ) {
-       if (multipleMu) {
-         //multiple muon event
+    if (track.isNonnull()) {
+      if (multipleMu) {
+        //multiple muon event
 
-         if ( fabs( (*track).dxy(RefVtx) ) < maxdxyMult || fabs( (*track).dz(RefVtx) ) < maxdzMult) {
-           result++;
-
-           //case of extra large dxy
-           if (!isLoose && fabs( (*track).dxy(RefVtx) ) > largedxyMult_) result -= 1;  
-
-          }
-     } else {
-        //single muon event
-
-        if (fabs( (*track).dxy(RefVtx) ) < maxdxy || fabs( (*track).dz(RefVtx) ) < maxdz) {
+        if (fabs((*track).dxy(RefVtx)) < maxdxyMult || fabs((*track).dz(RefVtx)) < maxdzMult) {
           result++;
 
           //case of extra large dxy
-          if (!isLoose && fabs( (*track).dxy(RefVtx) ) > largedxy_) result -= 1; 
+          if (!isLoose && fabs((*track).dxy(RefVtx)) > largedxyMult_)
+            result -= 1;
+        }
+      } else {
+        //single muon event
 
-         }
+        if (fabs((*track).dxy(RefVtx)) < maxdxy || fabs((*track).dz(RefVtx)) < maxdz) {
+          result++;
+
+          //case of extra large dxy
+          if (!isLoose && fabs((*track).dxy(RefVtx)) > largedxy_)
+            result -= 1;
+        }
       }
-   }//track is nonnull
-}//loop over vertices
+    }  //track is nonnull
+  }    //loop over vertices
 
-   //special case for non-cosmic large ip muons
-   if (result == 0 && multipleMu) {
-      // consider all reco muons in an event
-      edm::Handle<reco::MuonCollection> muonHandle;
-      iEvent.getByToken(muonTokens_[1], muonHandle);
+  //special case for non-cosmic large ip muons
+  if (result == 0 && multipleMu) {
+    // consider all reco muons in an event
+    edm::Handle<reco::MuonCollection> muonHandle;
+    iEvent.getByToken(muonTokens_[1], muonHandle);
 
-      //cosmic event should have zero good vertices
-      edm::Handle<reco::VertexCollection> pvHandle;
-      iEvent.getByToken(vertexToken_,pvHandle);
-      const reco::VertexCollection & vertices = *pvHandle.product();
+    //cosmic event should have zero good vertices
+    edm::Handle<reco::VertexCollection> pvHandle;
+    iEvent.getByToken(vertexToken_, pvHandle);
+    const reco::VertexCollection& vertices = *pvHandle.product();
 
-      //find the "other" one
-      if( !muonHandle.failedToGet() ) {
-         for ( reco::MuonCollection::const_iterator muons = muonHandle->begin(); muons !=  muonHandle->end(); ++muons ) {
-            if (!muons->isGlobalMuon()) continue;
-            //skip this track  
-            if ( muons->innerTrack() == muon.innerTrack() && muons->outerTrack() == muon.outerTrack()) continue;
-                //check ip and vertex of the "other" muon
-                reco::TrackRef tracks;
-                if (muons->isGlobalMuon()) tracks = muons->innerTrack();
-                if (fabs((*tracks).dxy(RefVtx)) > hIpTrdxy_) continue; 
-                //check if vertex collection is empty
-                if (vertices.begin() == vertices.end()) continue;
-                //for(reco::VertexCollection::const_iterator it=vertices.begin() ; it!=vertices.end() ; ++it) {
-                    //find matching vertex by position
-                    //if (fabs(it->z() - tracks->vz()) > 0.01) continue; //means will not be untagged from cosmics 
-                    if (TMath::Prob(vertices.front().chi2(),(int)(vertices.front().ndof())) > hIpTrvProb_) result = 1; 
-               //}
-           }
+    //find the "other" one
+    if (!muonHandle.failedToGet()) {
+      for (reco::MuonCollection::const_iterator muons = muonHandle->begin(); muons != muonHandle->end(); ++muons) {
+        if (!muons->isGlobalMuon())
+          continue;
+        //skip this track
+        if (muons->innerTrack() == muon.innerTrack() && muons->outerTrack() == muon.outerTrack())
+          continue;
+        //check ip and vertex of the "other" muon
+        reco::TrackRef tracks;
+        if (muons->isGlobalMuon())
+          tracks = muons->innerTrack();
+        if (fabs((*tracks).dxy(RefVtx)) > hIpTrdxy_)
+          continue;
+        //check if vertex collection is empty
+        if (vertices.begin() == vertices.end())
+          continue;
+        //for(reco::VertexCollection::const_iterator it=vertices.begin() ; it!=vertices.end() ; ++it) {
+        //find matching vertex by position
+        //if (fabs(it->z() - tracks->vz()) > 0.01) continue; //means will not be untagged from cosmics
+        if (TMath::Prob(vertices.front().chi2(), (int)(vertices.front().ndof())) > hIpTrvProb_)
+          result = 1;
+        //}
       }
- }
+    }
+  }
 
-    return result;
-
+  return result;
 }
 
-float
-MuonCosmicCompatibilityFiller::combinedCosmicID(const edm::Event& iEvent,
-                                   const edm::EventSetup& iSetup, const reco::Muon& muon, bool CheckMuonID, bool checkVertex) const {
-
+float MuonCosmicCompatibilityFiller::combinedCosmicID(const edm::Event& iEvent,
+                                                      const edm::EventSetup& iSetup,
+                                                      const reco::Muon& muon,
+                                                      bool CheckMuonID,
+                                                      bool checkVertex) const {
   float result = 0.0;
 
-  // return >=1 = identify as cosmic muon (the more like cosmics, the higher is the number) 
+  // return >=1 = identify as cosmic muon (the more like cosmics, the higher is the number)
   // return 0.0 = identify as collision muon
-  if( muon.isGlobalMuon() ) {
-
+  if (muon.isGlobalMuon()) {
     unsigned int cosmicVertex = eventActivity(iEvent, muon);
     bool isOverlapping = isOverlappingMuon(iEvent, iSetup, muon);
     unsigned int looseIp = pvMatches(iEvent, muon, true);
     unsigned int tightIp = pvMatches(iEvent, muon, false);
     float looseTime = muonTiming(iEvent, muon, true);
     float tightTime = muonTiming(iEvent, muon, false);
-    unsigned int backToback = backToBack2LegCosmic(iEvent,muon);
+    unsigned int backToback = backToBack2LegCosmic(iEvent, muon);
     //bool cosmicSegment = checkMuonSegments(muon);
 
     //short cut to reject cosmic event
-    if (checkVertex && cosmicVertex == 0) return 10.0;
+    if (checkVertex && cosmicVertex == 0)
+      return 10.0;
 
     // compatibility (0 - 10)
     // weight is assigned by the performance of individual module
@@ -518,108 +535,112 @@ MuonCosmicCompatibilityFiller::combinedCosmicID(const edm::Event& iEvent,
     // cosmic muon should have compatibility >= 4 (4 - 10)
 
     // b-to-b (max comp.: 4.0)
-    if( backToback >= 1 ) {
-       //in this case it is cosmic for sure
-       result += weight_btob*2.;
-       if( tightIp == 1 ) {
-           // check with other observables to reduce mis-id (subtract compatibilities)
-           if( looseIp == 1 ) {
-             if( backToback < 2 ) result -= weight_btob*0.5;
-           }
-       }
+    if (backToback >= 1) {
+      //in this case it is cosmic for sure
+      result += weight_btob * 2.;
+      if (tightIp == 1) {
+        // check with other observables to reduce mis-id (subtract compatibilities)
+        if (looseIp == 1) {
+          if (backToback < 2)
+            result -= weight_btob * 0.5;
+        }
+      }
     }
 
     // ip (max comp.: 4.0)
-    if( tightIp == 0 ) {
-        //in this case it is cosmic for sure
-        result += weight_ip*2.0;
-	if( backToback == 0 ) {
-           // check with other observables to reduce mis-id (subtract compatibilities)
-	   if( tightTime == 0 ) {
-	     if( looseTime == 0 && !isOverlapping ) result -= weight_ip*1.0;
-	   }
-	}
-    }
-    else if( tightIp >= 2 ) {
-        // in this case it is almost collision-like (reduce compatibility)
-        // if multi pvs: comp = -2.0 
-        if( backToback >= 1 ) result -= weight_ip*1.0;
+    if (tightIp == 0) {
+      //in this case it is cosmic for sure
+      result += weight_ip * 2.0;
+      if (backToback == 0) {
+        // check with other observables to reduce mis-id (subtract compatibilities)
+        if (tightTime == 0) {
+          if (looseTime == 0 && !isOverlapping)
+            result -= weight_ip * 1.0;
+        }
+      }
+    } else if (tightIp >= 2) {
+      // in this case it is almost collision-like (reduce compatibility)
+      // if multi pvs: comp = -2.0
+      if (backToback >= 1)
+        result -= weight_ip * 1.0;
     }
 
     // timing (max comp.: 2.0)
-    if( tightTime > 0 ) {
-        // bonus track
-        if( looseTime > 0 ) {
-	  if( backToback >= 1 ) {
-	    if( tightIp == 0 ) result += weight_time*tightTime;
-	    else if( looseIp == 0 ) result += weight_time*0.25;
-	  }
-	}
-	else {
-	  if( backToback >= 1 && tightIp == 0 ) result += weight_time*0.25;
-	}
+    if (tightTime > 0) {
+      // bonus track
+      if (looseTime > 0) {
+        if (backToback >= 1) {
+          if (tightIp == 0)
+            result += weight_time * tightTime;
+          else if (looseIp == 0)
+            result += weight_time * 0.25;
+        }
+      } else {
+        if (backToback >= 1 && tightIp == 0)
+          result += weight_time * 0.25;
+      }
     }
 
     // overlapping
-    if( backToback == 0 && isOverlapping ) {
-        // bonus track
-        if( tightIp == 0 && tightTime >= 1 ) {
-            result += weight_overlap*1.0;
-        }
+    if (backToback == 0 && isOverlapping) {
+      // bonus track
+      if (tightIp == 0 && tightTime >= 1) {
+        result += weight_overlap * 1.0;
+      }
     }
- }//is global muon
+  }  //is global muon
 
-
-//  if (CheckMuonID && cosmicSegment) result += 4;  
+  //  if (CheckMuonID && cosmicSegment) result += 4;
 
   return result;
 }
 
-
-
 //
 //Track activity/vertex quality, count good vertices
 //
-unsigned int 
-MuonCosmicCompatibilityFiller::eventActivity(const edm::Event& iEvent, const reco::Muon& muon) const
-{
-
-  unsigned int result = 0; //no good vertices - cosmic-like
+unsigned int MuonCosmicCompatibilityFiller::eventActivity(const edm::Event& iEvent, const reco::Muon& muon) const {
+  unsigned int result = 0;  //no good vertices - cosmic-like
 
   //check track activity
   edm::Handle<reco::TrackCollection> tracks;
-  iEvent.getByToken(trackTokens_[0],tracks);
-  if (!tracks.failedToGet() && tracks->size() < 3) return 0; 
+  iEvent.getByToken(trackTokens_[0], tracks);
+  if (!tracks.failedToGet() && tracks->size() < 3)
+    return 0;
 
   //cosmic event should have zero good vertices
   edm::Handle<reco::VertexCollection> pvHandle;
-  if (!iEvent.getByToken(vertexToken_,pvHandle)) {return 0;} else {
-      const reco::VertexCollection & vertices = *pvHandle.product();
-      //check if vertex collection is empty
-      if (vertices.begin() == vertices.end()) return 0;
-      for(reco::VertexCollection::const_iterator it=vertices.begin() ; it!=vertices.end() ; ++it){
-          if ((TMath::Prob(it->chi2(),(int)it->ndof()) > minvProb_) && (fabs(it->z()) <= maxvertZ_) && (fabs(it->position().rho()) <= maxvertRho_)) result++;
-          }
-       }
+  if (!iEvent.getByToken(vertexToken_, pvHandle)) {
+    return 0;
+  } else {
+    const reco::VertexCollection& vertices = *pvHandle.product();
+    //check if vertex collection is empty
+    if (vertices.begin() == vertices.end())
+      return 0;
+    for (reco::VertexCollection::const_iterator it = vertices.begin(); it != vertices.end(); ++it) {
+      if ((TMath::Prob(it->chi2(), (int)it->ndof()) > minvProb_) && (fabs(it->z()) <= maxvertZ_) &&
+          (fabs(it->position().rho()) <= maxvertRho_))
+        result++;
+    }
+  }
   return result;
 }
 
 //
 //Muon iD variables
 //
-bool MuonCosmicCompatibilityFiller::checkMuonID( const reco::Muon& imuon ) const
-{
+bool MuonCosmicCompatibilityFiller::checkMuonID(const reco::Muon& imuon) const {
   bool result = false;
   // initial set up using Jordan's study: GlobalMuonPromptTight + TMOneStationLoose
-  if( muon::isGoodMuon(imuon, muon::GlobalMuonPromptTight) && muon::isGoodMuon(imuon, muon::TMOneStationLoose) ) result = true;
-  
+  if (muon::isGoodMuon(imuon, muon::GlobalMuonPromptTight) && muon::isGoodMuon(imuon, muon::TMOneStationLoose))
+    result = true;
+
   return result;
 }
 
 bool MuonCosmicCompatibilityFiller::checkMuonSegments(const reco::Muon& imuon) const {
+  bool result = false;
+  if (imuon.numberOfMatches() < nChamberMatches_ && muon::segmentCompatibility(imuon) < segmentComp_)
+    result = true;
 
-   bool result = false;
-   if (imuon.numberOfMatches() < nChamberMatches_ &&  muon::segmentCompatibility(imuon) < segmentComp_) result = true;
-
-   return result;
+  return result;
 }

--- a/RecoMuon/MuonIdentification/src/MuonCosmicsId.cc
+++ b/RecoMuon/MuonIdentification/src/MuonCosmicsId.cc
@@ -1,44 +1,41 @@
 #include "RecoMuon/MuonIdentification/interface/MuonCosmicsId.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
-bool directionAlongMomentum(const reco::Track& track){
+bool directionAlongMomentum(const reco::Track& track) {
   // check is done in 2D
-  return (track.innerPosition().x()-track.vx())*track.px() +
-    (track.innerPosition().y()-track.vy())*track.py() > 0;
+  return (track.innerPosition().x() - track.vx()) * track.px() + (track.innerPosition().y() - track.vy()) * track.py() >
+         0;
 }
 
 // returns angle and dPt/Pt
-std::pair<double, double> 
-muonid::matchTracks(const reco::Track& ref, const reco::Track& probe)
-{
-  std::pair<double,double> result(0,0);
+std::pair<double, double> muonid::matchTracks(const reco::Track& ref, const reco::Track& probe) {
+  std::pair<double, double> result(0, 0);
   // When both tracks are reconstructed as outside going, sign is -1
   // otherwise it's +1. There is also a crazy case of both are outside
   // going, then sign is -1 as well.
-  int match_sign = directionAlongMomentum(ref)==directionAlongMomentum(probe) ? -1 : +1; 
-  double sprod = ref.px()*probe.px() + ref.py()*probe.py() + ref.pz()*probe.pz();
-  double argCos = match_sign*(sprod/ref.p()/probe.p());
-  if (argCos < -1.0) argCos = -1.0;
-  if (argCos > 1.0) argCos = 1.0;
-  result.first = acos( argCos );
-  result.second = fabs(probe.pt()-ref.pt())/sqrt(ref.pt()*probe.pt()); //SK: take a geom-mean pt
+  int match_sign = directionAlongMomentum(ref) == directionAlongMomentum(probe) ? -1 : +1;
+  double sprod = ref.px() * probe.px() + ref.py() * probe.py() + ref.pz() * probe.pz();
+  double argCos = match_sign * (sprod / ref.p() / probe.p());
+  if (argCos < -1.0)
+    argCos = -1.0;
+  if (argCos > 1.0)
+    argCos = 1.0;
+  result.first = acos(argCos);
+  result.second = fabs(probe.pt() - ref.pt()) / sqrt(ref.pt() * probe.pt());  //SK: take a geom-mean pt
   return result;
 }
 
-reco::TrackRef 
-muonid::findOppositeTrack(const edm::Handle<reco::TrackCollection>& tracks, 
-			const reco::Track& muonTrack,
-			double angleMatch,
-			double momentumMatch)
-{
-  for (unsigned int i=0; i<tracks->size(); ++i){
+reco::TrackRef muonid::findOppositeTrack(const edm::Handle<reco::TrackCollection>& tracks,
+                                         const reco::Track& muonTrack,
+                                         double angleMatch,
+                                         double momentumMatch) {
+  for (unsigned int i = 0; i < tracks->size(); ++i) {
     // When both tracks are reconstructed as outside going, sign is -1
     // otherwise it's +1. There is also a crazy case of both are outside
     // going, then sign is -1 as well.
-    const std::pair<double,double>& match = matchTracks(muonTrack,tracks->at(i));
-    if ( match.first < angleMatch && match.second < momentumMatch )
-      return reco::TrackRef(tracks,i);
+    const std::pair<double, double>& match = matchTracks(muonTrack, tracks->at(i));
+    if (match.first < angleMatch && match.second < momentumMatch)
+      return reco::TrackRef(tracks, i);
   }
   return reco::TrackRef();
-
 }

--- a/RecoMuon/MuonIdentification/src/MuonIdTruthInfo.cc
+++ b/RecoMuon/MuonIdentification/src/MuonIdTruthInfo.cc
@@ -9,161 +9,160 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 void MuonIdTruthInfo::registerConsumes(edm::ConsumesCollector& iC) {
-  iC.mayConsume<edm::SimTrackContainer>(edm::InputTag("g4SimHits",""));
-  iC.mayConsume<edm::PSimHitContainer>(edm::InputTag("g4SimHits","MuonDTHits"));
-  iC.mayConsume<edm::PSimHitContainer>(edm::InputTag("g4SimHits","MuonCSCHits"));
-
+  iC.mayConsume<edm::SimTrackContainer>(edm::InputTag("g4SimHits", ""));
+  iC.mayConsume<edm::PSimHitContainer>(edm::InputTag("g4SimHits", "MuonDTHits"));
+  iC.mayConsume<edm::PSimHitContainer>(edm::InputTag("g4SimHits", "MuonCSCHits"));
 }
 
+void MuonIdTruthInfo::truthMatchMuon(const edm::Event& iEvent, const edm::EventSetup& iSetup, reco::Muon& aMuon) {
+  // get a list of simulated track and find a track with the best match to
+  // the muon.track(). Use its id and chamber id to localize hits
+  // If a hit has non-zero local z coordinate, it's position wrt
+  // to the center of a chamber is extrapolated by a straight line
 
+  edm::Handle<edm::SimTrackContainer> simTracks;
+  iEvent.getByLabel<edm::SimTrackContainer>("g4SimHits", "", simTracks);
+  if (!simTracks.isValid()) {
+    LogTrace("MuonIdentification") << "No tracks found";
+    return;
+  }
 
-void MuonIdTruthInfo::truthMatchMuon(const edm::Event& iEvent, 
-				     const edm::EventSetup& iSetup,
-				     reco::Muon& aMuon)
-{
-   // get a list of simulated track and find a track with the best match to
-   // the muon.track(). Use its id and chamber id to localize hits
-   // If a hit has non-zero local z coordinate, it's position wrt
-   // to the center of a chamber is extrapolated by a straight line
-   
-   edm::Handle<edm::SimTrackContainer> simTracks;
-   iEvent.getByLabel<edm::SimTrackContainer>("g4SimHits", "", simTracks);
-   if (! simTracks.isValid() ) {
-      LogTrace("MuonIdentification") <<"No tracks found";
-      return;
-   }
-   
-   // get the tracking Geometry
-   edm::ESHandle<GlobalTrackingGeometry> geometry;
-   iSetup.get<GlobalTrackingGeometryRecord>().get(geometry);
-   if ( ! geometry.isValid() )
-     throw cms::Exception("FatalError") << "Unable to find GlobalTrackingGeometryRecord in event!\n";
-   
-   float bestMatchChi2 = 9999; //minimization creteria
-   unsigned int bestMatch = 0;
-   const unsigned int offset = 0; // kludge to fix a problem in trackId matching between tracks and hits.
-   
-   for( edm::SimTrackContainer::const_iterator simTrk = simTracks->begin();
-	simTrk != simTracks->end(); simTrk++ )
-     {
-	float chi2 = matchChi2(*aMuon.track().get(),*simTrk);
-	if (chi2>bestMatchChi2) continue;
-	bestMatchChi2 = chi2;
-	bestMatch = simTrk->trackId();
-     }
-   
-   bestMatch -= offset;
-   
-   std::vector<reco::MuonChamberMatch>& matches = aMuon.matches();
-   int numberOfTruthMatchedChambers = 0;
+  // get the tracking Geometry
+  edm::ESHandle<GlobalTrackingGeometry> geometry;
+  iSetup.get<GlobalTrackingGeometryRecord>().get(geometry);
+  if (!geometry.isValid())
+    throw cms::Exception("FatalError") << "Unable to find GlobalTrackingGeometryRecord in event!\n";
 
-   // loop over chambers
-   for(std::vector<reco::MuonChamberMatch>::iterator chamberMatch = matches.begin();
-       chamberMatch != matches.end(); chamberMatch ++)
-     {
-	if (chamberMatch->id.det() != DetId::Muon ) {
-	   edm::LogWarning("MuonIdentification") << "Detector id of a muon chamber corresponds to not a muon detector";
-	   continue;
-	}
-	reco::MuonSegmentMatch bestSegmentMatch;
-	double distance = 99999;
-	
-	if ( chamberMatch->id.subdetId() == MuonSubdetId::DT) {
-	   DTChamberId detId(chamberMatch->id.rawId());
+  float bestMatchChi2 = 9999;  //minimization creteria
+  unsigned int bestMatch = 0;
+  const unsigned int offset = 0;  // kludge to fix a problem in trackId matching between tracks and hits.
 
-	   edm::Handle<edm::PSimHitContainer> simHits;
-	   iEvent.getByLabel("g4SimHits", "MuonDTHits", simHits);
-	   if ( simHits.isValid() ) {
-	      for( edm::PSimHitContainer::const_iterator hit = simHits->begin(); hit != simHits->end(); hit++)
-		if ( hit->trackId() == bestMatch ) checkSimHitForBestMatch(bestSegmentMatch, distance, *hit, detId, geometry );
-	   }else LogTrace("MuonIdentification") <<"No DT simulated hits are found";
-	}
+  for (edm::SimTrackContainer::const_iterator simTrk = simTracks->begin(); simTrk != simTracks->end(); simTrk++) {
+    float chi2 = matchChi2(*aMuon.track().get(), *simTrk);
+    if (chi2 > bestMatchChi2)
+      continue;
+    bestMatchChi2 = chi2;
+    bestMatch = simTrk->trackId();
+  }
 
-	if ( chamberMatch->id.subdetId() == MuonSubdetId::CSC) {
-	   CSCDetId detId(chamberMatch->id.rawId());
+  bestMatch -= offset;
 
-	   edm::Handle<edm::PSimHitContainer> simHits;
-	   iEvent.getByLabel("g4SimHits", "MuonCSCHits", simHits);
-	   if ( simHits.isValid() ) {
-	      for( edm::PSimHitContainer::const_iterator hit = simHits->begin(); hit != simHits->end(); hit++)
-		if ( hit->trackId() == bestMatch ) checkSimHitForBestMatch(bestSegmentMatch, distance, *hit, detId, geometry );
-	   }else LogTrace("MuonIdentification") <<"No CSC simulated hits are found";
-	}
-	if (distance < 9999) {
-	   chamberMatch->truthMatches.push_back( bestSegmentMatch );
-	   numberOfTruthMatchedChambers++;
-	   LogTrace("MuonIdentification") << "Best truth matched hit:" <<
-	      "\tDetId: " << chamberMatch->id.rawId() << "\n" <<
-	      "\tprojection: ( " << bestSegmentMatch.x << ", " << bestSegmentMatch.y << " )\n";
-	}
-     }
-   LogTrace("MuonIdentification") << "Truth matching summary:\n\tnumber of chambers: " << matches.size() <<
-     "\n\tnumber of truth matched chambers: " << numberOfTruthMatchedChambers << "\n";
+  std::vector<reco::MuonChamberMatch>& matches = aMuon.matches();
+  int numberOfTruthMatchedChambers = 0;
+
+  // loop over chambers
+  for (std::vector<reco::MuonChamberMatch>::iterator chamberMatch = matches.begin(); chamberMatch != matches.end();
+       chamberMatch++) {
+    if (chamberMatch->id.det() != DetId::Muon) {
+      edm::LogWarning("MuonIdentification") << "Detector id of a muon chamber corresponds to not a muon detector";
+      continue;
+    }
+    reco::MuonSegmentMatch bestSegmentMatch;
+    double distance = 99999;
+
+    if (chamberMatch->id.subdetId() == MuonSubdetId::DT) {
+      DTChamberId detId(chamberMatch->id.rawId());
+
+      edm::Handle<edm::PSimHitContainer> simHits;
+      iEvent.getByLabel("g4SimHits", "MuonDTHits", simHits);
+      if (simHits.isValid()) {
+        for (edm::PSimHitContainer::const_iterator hit = simHits->begin(); hit != simHits->end(); hit++)
+          if (hit->trackId() == bestMatch)
+            checkSimHitForBestMatch(bestSegmentMatch, distance, *hit, detId, geometry);
+      } else
+        LogTrace("MuonIdentification") << "No DT simulated hits are found";
+    }
+
+    if (chamberMatch->id.subdetId() == MuonSubdetId::CSC) {
+      CSCDetId detId(chamberMatch->id.rawId());
+
+      edm::Handle<edm::PSimHitContainer> simHits;
+      iEvent.getByLabel("g4SimHits", "MuonCSCHits", simHits);
+      if (simHits.isValid()) {
+        for (edm::PSimHitContainer::const_iterator hit = simHits->begin(); hit != simHits->end(); hit++)
+          if (hit->trackId() == bestMatch)
+            checkSimHitForBestMatch(bestSegmentMatch, distance, *hit, detId, geometry);
+      } else
+        LogTrace("MuonIdentification") << "No CSC simulated hits are found";
+    }
+    if (distance < 9999) {
+      chamberMatch->truthMatches.push_back(bestSegmentMatch);
+      numberOfTruthMatchedChambers++;
+      LogTrace("MuonIdentification") << "Best truth matched hit:"
+                                     << "\tDetId: " << chamberMatch->id.rawId() << "\n"
+                                     << "\tprojection: ( " << bestSegmentMatch.x << ", " << bestSegmentMatch.y
+                                     << " )\n";
+    }
+  }
+  LogTrace("MuonIdentification") << "Truth matching summary:\n\tnumber of chambers: " << matches.size()
+                                 << "\n\tnumber of truth matched chambers: " << numberOfTruthMatchedChambers << "\n";
 }
 
 void MuonIdTruthInfo::checkSimHitForBestMatch(reco::MuonSegmentMatch& segmentMatch,
-					      double& distance,
-					      const PSimHit& hit, 
-					      const DetId& chamberId,
-					      const edm::ESHandle<GlobalTrackingGeometry>& geometry)
-{
+                                              double& distance,
+                                              const PSimHit& hit,
+                                              const DetId& chamberId,
+                                              const edm::ESHandle<GlobalTrackingGeometry>& geometry) {
   printf("DONT FORGET TO CALL REGISTERCONSUMES()\n");
 
-   // find the hit position projection at the reference surface of the chamber:
-   // first get entry and exit point of the hit in the global coordinates, then
-   // get local coordinates of these points wrt the chamber and then find the
-   // projected X-Y coordinates
-   
-   const GeomDet* chamberGeometry = geometry->idToDet( chamberId );
-   const GeomDet* simUnitGeometry = geometry->idToDet( DetId(hit.detUnitId()) );
-   
-   if (chamberGeometry && simUnitGeometry ) {
-      LocalPoint entryPoint = chamberGeometry->toLocal( simUnitGeometry->toGlobal( hit.entryPoint() ) );
-      LocalPoint exitPoint =  chamberGeometry->toLocal( simUnitGeometry->toGlobal( hit.exitPoint()  ) );
-      LocalVector direction = exitPoint - entryPoint;
-      if ( fabs(direction.z()) > 0.001) {
-	 LocalPoint projection = entryPoint - direction*(entryPoint.z()/direction.z());
-	 if ( fabs(projection.z()) > 0.001 ) 
-	   edm::LogWarning("MuonIdentification") << "z coordinate of the hit projection must be zero and it's not!\n";
-	 
-	 double new_distance = 99999;
-	 if( entryPoint.z()*exitPoint.z() < -1 ) // changed sign, so the reference point is inside
-	   new_distance = 0;
-	 else {
-	    if ( fabs(entryPoint.z()) < fabs(exitPoint.z()) )
-	      new_distance = fabs(entryPoint.z());
-	    else
-	      new_distance = fabs(exitPoint.z());
-	 }
-	 
-	 if (new_distance < distance) { 
-	    // find a SimHit closer to the reference surface, update segmentMatch
-	    segmentMatch.x = projection.x();
-	    segmentMatch.y = projection.y();
-	    segmentMatch.xErr = 0;
-	    segmentMatch.yErr = 0;
-	    segmentMatch.dXdZ = direction.x()/direction.z();
-	    segmentMatch.dYdZ = direction.y()/direction.z();
-	    segmentMatch.dXdZErr = 0;
-	    segmentMatch.dYdZErr = 0;
-	    distance = new_distance;
-	    LogTrace("MuonIdentificationVerbose") << "Better truth matched segment found:\n" <<
-	      "\tDetId: " << chamberId.rawId() << "\n" <<
-	      "\tentry point: ( " << entryPoint.x() << ", " << entryPoint.y() << ", " << entryPoint.z() << " )\n" <<
-	      "\texit point: ( " << exitPoint.x() << ", " << exitPoint.y() << ", " << exitPoint.z() << " )\n" <<
-	      "\tprojection: ( " << projection.x() << ", " << projection.y() << ", " << projection.z() << " )\n";
-	 }
+  // find the hit position projection at the reference surface of the chamber:
+  // first get entry and exit point of the hit in the global coordinates, then
+  // get local coordinates of these points wrt the chamber and then find the
+  // projected X-Y coordinates
+
+  const GeomDet* chamberGeometry = geometry->idToDet(chamberId);
+  const GeomDet* simUnitGeometry = geometry->idToDet(DetId(hit.detUnitId()));
+
+  if (chamberGeometry && simUnitGeometry) {
+    LocalPoint entryPoint = chamberGeometry->toLocal(simUnitGeometry->toGlobal(hit.entryPoint()));
+    LocalPoint exitPoint = chamberGeometry->toLocal(simUnitGeometry->toGlobal(hit.exitPoint()));
+    LocalVector direction = exitPoint - entryPoint;
+    if (fabs(direction.z()) > 0.001) {
+      LocalPoint projection = entryPoint - direction * (entryPoint.z() / direction.z());
+      if (fabs(projection.z()) > 0.001)
+        edm::LogWarning("MuonIdentification") << "z coordinate of the hit projection must be zero and it's not!\n";
+
+      double new_distance = 99999;
+      if (entryPoint.z() * exitPoint.z() < -1)  // changed sign, so the reference point is inside
+        new_distance = 0;
+      else {
+        if (fabs(entryPoint.z()) < fabs(exitPoint.z()))
+          new_distance = fabs(entryPoint.z());
+        else
+          new_distance = fabs(exitPoint.z());
       }
-   }else{
-      if ( ! chamberGeometry ) edm::LogWarning("MuonIdentification") << "Cannot get chamber geomtry for DetId: " << chamberId.rawId();
-      if ( ! simUnitGeometry ) edm::LogWarning("MuonIdentification") << "Cannot get detector unit geomtry for DetId: " << hit.detUnitId();
-   }
+
+      if (new_distance < distance) {
+        // find a SimHit closer to the reference surface, update segmentMatch
+        segmentMatch.x = projection.x();
+        segmentMatch.y = projection.y();
+        segmentMatch.xErr = 0;
+        segmentMatch.yErr = 0;
+        segmentMatch.dXdZ = direction.x() / direction.z();
+        segmentMatch.dYdZ = direction.y() / direction.z();
+        segmentMatch.dXdZErr = 0;
+        segmentMatch.dYdZErr = 0;
+        distance = new_distance;
+        LogTrace("MuonIdentificationVerbose")
+            << "Better truth matched segment found:\n"
+            << "\tDetId: " << chamberId.rawId() << "\n"
+            << "\tentry point: ( " << entryPoint.x() << ", " << entryPoint.y() << ", " << entryPoint.z() << " )\n"
+            << "\texit point: ( " << exitPoint.x() << ", " << exitPoint.y() << ", " << exitPoint.z() << " )\n"
+            << "\tprojection: ( " << projection.x() << ", " << projection.y() << ", " << projection.z() << " )\n";
+      }
+    }
+  } else {
+    if (!chamberGeometry)
+      edm::LogWarning("MuonIdentification") << "Cannot get chamber geomtry for DetId: " << chamberId.rawId();
+    if (!simUnitGeometry)
+      edm::LogWarning("MuonIdentification") << "Cannot get detector unit geomtry for DetId: " << hit.detUnitId();
+  }
 }
 
-double MuonIdTruthInfo::matchChi2( const reco::Track& recoTrk, const SimTrack& simTrk)
-{
-   double deltaPhi = fabs(recoTrk.phi()-simTrk.momentum().phi());
-   if (deltaPhi>1.8*3.1416) deltaPhi = 2*3.1416-deltaPhi; // take care of phi discontinuity
-   return pow((recoTrk.p()-simTrk.momentum().rho())/simTrk.momentum().rho(),2)+
-     pow(deltaPhi/(2*3.1416),2)+pow((recoTrk.theta()-simTrk.momentum().theta())/3.1416,2);
+double MuonIdTruthInfo::matchChi2(const reco::Track& recoTrk, const SimTrack& simTrk) {
+  double deltaPhi = fabs(recoTrk.phi() - simTrk.momentum().phi());
+  if (deltaPhi > 1.8 * 3.1416)
+    deltaPhi = 2 * 3.1416 - deltaPhi;  // take care of phi discontinuity
+  return pow((recoTrk.p() - simTrk.momentum().rho()) / simTrk.momentum().rho(), 2) + pow(deltaPhi / (2 * 3.1416), 2) +
+         pow((recoTrk.theta() - simTrk.momentum().theta()) / 3.1416, 2);
 }

--- a/RecoMuon/MuonIdentification/src/MuonKinkFinder.cc
+++ b/RecoMuon/MuonIdentification/src/MuonKinkFinder.cc
@@ -2,80 +2,88 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 
-MuonKinkFinder::MuonKinkFinder(const edm::ParameterSet &iConfig) :
-    diagonalOnly_(iConfig.getParameter<bool>("diagonalOnly")),
-    usePosition_(iConfig.getParameter<bool>("usePosition")),
-    refitter_(iConfig)
-{ 
+MuonKinkFinder::MuonKinkFinder(const edm::ParameterSet &iConfig)
+    : diagonalOnly_(iConfig.getParameter<bool>("diagonalOnly")),
+      usePosition_(iConfig.getParameter<bool>("usePosition")),
+      refitter_(iConfig) {}
+
+MuonKinkFinder::~MuonKinkFinder() {}
+
+void MuonKinkFinder::init(const edm::EventSetup &iSetup) { refitter_.setServices(iSetup); }
+
+bool MuonKinkFinder::fillTrkKink(reco::MuonQuality &quality, const reco::Track &track) const {
+  std::vector<Trajectory> traj = refitter_.transform(track);
+  if (traj.size() != 1) {
+    quality.trkKink = 999;
+    quality.tkKink_position = math::XYZPoint(0, 0, 0);
+    return false;
+  }
+  return fillTrkKink(quality, traj.front());
 }
 
-MuonKinkFinder::~MuonKinkFinder() { }
-
-void MuonKinkFinder::init(const edm::EventSetup &iSetup) { 
-    refitter_.setServices(iSetup);
-}
-
-bool MuonKinkFinder::fillTrkKink(reco::MuonQuality & quality, const reco::Track &track) const {
-    std::vector<Trajectory> traj  = refitter_.transform(track);
-    if (traj.size() != 1) {
-        quality.trkKink = 999;
-        quality.tkKink_position = math::XYZPoint(0,0,0);
-        return false;
+bool MuonKinkFinder::fillTrkKink(reco::MuonQuality &quality, const Trajectory &trajectory) const {
+  const std::vector<TrajectoryMeasurement> &tms = trajectory.measurements();
+  quality.trkKink = -1.0;
+  quality.tkKink_position = math::XYZPoint(0, 0, 0);
+  bool found = false;
+  for (int itm = 3, nm = tms.size() - 3; itm < nm; ++itm) {
+    TrajectoryStateOnSurface pre = tms[itm].forwardPredictedState();
+    TrajectoryStateOnSurface post = tms[itm].backwardPredictedState();
+    if (!pre.isValid() || !post.isValid())
+      continue;
+    found = true;
+    double c2f = getChi2(pre, post);
+    if (c2f > quality.trkKink) {
+      quality.trkKink = c2f;
+      GlobalPoint pos = (tms[itm].updatedState().isValid() ? tms[itm].updatedState() : pre).globalPosition();
+      quality.tkKink_position = math::XYZPoint(pos.x(), pos.y(), pos.z());
     }
-    return fillTrkKink(quality, traj.front());
-}
-
-bool MuonKinkFinder::fillTrkKink(reco::MuonQuality & quality, const Trajectory &trajectory) const {
-    const std::vector<TrajectoryMeasurement> &tms = trajectory.measurements();
-    quality.trkKink = -1.0;
-    quality.tkKink_position = math::XYZPoint(0,0,0);
-    bool found = false; 
-    for (int itm = 3, nm = tms.size() - 3;  itm < nm; ++itm) {
-        TrajectoryStateOnSurface pre  = tms[itm].forwardPredictedState();
-        TrajectoryStateOnSurface post = tms[itm].backwardPredictedState();
-        if (!pre.isValid() || !post.isValid()) continue;
-        found = true;
-        double c2f = getChi2(pre,post);
-        if (c2f > quality.trkKink) { 
-            quality.trkKink = c2f; 
-            GlobalPoint pos = (tms[itm].updatedState().isValid() ? tms[itm].updatedState() : pre).globalPosition();
-            quality.tkKink_position = math::XYZPoint(pos.x(), pos.y(), pos.z());
-        }
-    }
-    if (!found) quality.trkKink = 999;
-    return found;
+  }
+  if (!found)
+    quality.trkKink = 999;
+  return found;
 }
 
 double MuonKinkFinder::getChi2(const TrajectoryStateOnSurface &start, const TrajectoryStateOnSurface &other) const {
-    if (!start.hasError() && !other.hasError()) throw cms::Exception("LogicError") << "At least one of the two states must have errors to make chi2s.\n";
-    AlgebraicSymMatrix55 cov;
-    if (start.hasError()) cov += start.localError().matrix();
-    if (other.hasError()) cov += other.localError().matrix();
-    cropAndInvert(cov);
-    AlgebraicVector5 diff(start.localParameters().mixedFormatVector() - other.localParameters().mixedFormatVector());
-    return ROOT::Math::Similarity(diff, cov);
+  if (!start.hasError() && !other.hasError())
+    throw cms::Exception("LogicError") << "At least one of the two states must have errors to make chi2s.\n";
+  AlgebraicSymMatrix55 cov;
+  if (start.hasError())
+    cov += start.localError().matrix();
+  if (other.hasError())
+    cov += other.localError().matrix();
+  cropAndInvert(cov);
+  AlgebraicVector5 diff(start.localParameters().mixedFormatVector() - other.localParameters().mixedFormatVector());
+  return ROOT::Math::Similarity(diff, cov);
 }
 
 void MuonKinkFinder::cropAndInvert(AlgebraicSymMatrix55 &cov) const {
-    if (usePosition_) {
-        if (diagonalOnly_) {
-            for (size_t i = 0; i < 5; ++i) { for (size_t j = i+1; j < 5; ++j) {
-                cov(i,j) = 0;
-            } }
+  if (usePosition_) {
+    if (diagonalOnly_) {
+      for (size_t i = 0; i < 5; ++i) {
+        for (size_t j = i + 1; j < 5; ++j) {
+          cov(i, j) = 0;
         }
-        cov.Invert();
-    } else {
-        // get 3x3 covariance
-        AlgebraicSymMatrix33 momCov = cov.Sub<AlgebraicSymMatrix33>(0,0); // get 3x3 matrix
-        if (diagonalOnly_) { momCov(0,1) = 0; momCov(0,2) = 0; momCov(1,2) = 0; }
-        // invert        
-        momCov.Invert();
-        // place it
-        cov.Place_at(momCov,0,0);
-        // zero the rest
-        for (size_t i = 3; i < 5; ++i) { for (size_t j = i; j < 5; ++j) { 
-            cov(i,j) = 0;
-        } }
+      }
     }
+    cov.Invert();
+  } else {
+    // get 3x3 covariance
+    AlgebraicSymMatrix33 momCov = cov.Sub<AlgebraicSymMatrix33>(0, 0);  // get 3x3 matrix
+    if (diagonalOnly_) {
+      momCov(0, 1) = 0;
+      momCov(0, 2) = 0;
+      momCov(1, 2) = 0;
+    }
+    // invert
+    momCov.Invert();
+    // place it
+    cov.Place_at(momCov, 0, 0);
+    // zero the rest
+    for (size_t i = 3; i < 5; ++i) {
+      for (size_t j = i; j < 5; ++j) {
+        cov(i, j) = 0;
+      }
+    }
+  }
 }
-

--- a/RecoMuon/MuonIdentification/src/MuonMesh.cc
+++ b/RecoMuon/MuonIdentification/src/MuonMesh.cc
@@ -6,370 +6,329 @@
 #include <utility>
 #include <algorithm>
 
-MuonMesh::MuonMesh(const edm::ParameterSet& parm) : doME1a(parm.getParameter<bool>("ME1a")),
-						    doOverlaps(parm.getParameter<bool>("Overlap")),
-						    doClustering(parm.getParameter<bool>("Clustering")),
-						    OverlapDPhi(parm.getParameter<double>("OverlapDPhi")), 
-						    OverlapDTheta(parm.getParameter<double>("OverlapDTheta")), 
-						    ClusterDPhi(parm.getParameter<double>("ClusterDPhi")), 
-						    ClusterDTheta(parm.getParameter<double>("ClusterDTheta")) {
-}
+MuonMesh::MuonMesh(const edm::ParameterSet& parm)
+    : doME1a(parm.getParameter<bool>("ME1a")),
+      doOverlaps(parm.getParameter<bool>("Overlap")),
+      doClustering(parm.getParameter<bool>("Clustering")),
+      OverlapDPhi(parm.getParameter<double>("OverlapDPhi")),
+      OverlapDTheta(parm.getParameter<double>("OverlapDTheta")),
+      ClusterDPhi(parm.getParameter<double>("ClusterDPhi")),
+      ClusterDTheta(parm.getParameter<double>("ClusterDTheta")) {}
 
 void MuonMesh::fillMesh(std::vector<reco::Muon>* inputMuons) {
+  for (std::vector<reco::Muon>::iterator muonIter1 = inputMuons->begin(); muonIter1 != inputMuons->end(); ++muonIter1) {
+    if (muonIter1->isTrackerMuon()) {
+      mesh_[&*muonIter1];  // create this entry if it's a tracker muon
+      for (std::vector<reco::Muon>::iterator muonIter2 = inputMuons->begin(); muonIter2 != inputMuons->end();
+           ++muonIter2) {
+        if (muonIter2->isTrackerMuon()) {
+          if (muonIter2 != muonIter1) {
+            // now fill all the edges for muon1 based on overlaps with muon2
+            for (std::vector<reco::MuonChamberMatch>::iterator chamberIter1 = muonIter1->matches().begin();
+                 chamberIter1 != muonIter1->matches().end();
+                 ++chamberIter1) {
+              for (std::vector<reco::MuonSegmentMatch>::iterator segmentIter1 = chamberIter1->segmentMatches.begin();
+                   segmentIter1 != chamberIter1->segmentMatches.end();
+                   ++segmentIter1) {
+                for (std::vector<reco::MuonChamberMatch>::iterator chamberIter2 = muonIter2->matches().begin();
+                     chamberIter2 != muonIter2->matches().end();
+                     ++chamberIter2) {
+                  for (std::vector<reco::MuonSegmentMatch>::iterator segmentIter2 =
+                           chamberIter2->segmentMatches.begin();
+                       segmentIter2 != chamberIter2->segmentMatches.end();
+                       ++segmentIter2) {
+                    //if(segmentIter1->mask & 0x1e0000 && segmentIter2->mask &0x1e0000) {
 
-  for(std::vector<reco::Muon>::iterator muonIter1 = inputMuons->begin();
-      muonIter1 != inputMuons->end();
-      ++muonIter1) {
-    if(muonIter1->isTrackerMuon()){
+                    bool addsegment(false);
 
-      mesh_[&*muonIter1]; // create this entry if it's a tracker muon
-      for(std::vector<reco::Muon>::iterator muonIter2 = inputMuons->begin();
-	  muonIter2 != inputMuons->end();
-	  ++muonIter2) {
-	if(muonIter2->isTrackerMuon()) {
-	  if(muonIter2 != muonIter1) {
-	    
-	    // now fill all the edges for muon1 based on overlaps with muon2
-	    for(std::vector<reco::MuonChamberMatch>::iterator chamberIter1 = muonIter1->matches().begin();
-		chamberIter1 != muonIter1->matches().end();
-		++chamberIter1) {	      
-	      for(std::vector<reco::MuonSegmentMatch>::iterator segmentIter1 = chamberIter1->segmentMatches.begin();
-		  segmentIter1 != chamberIter1->segmentMatches.end();
-		  ++segmentIter1) {
-		for(std::vector<reco::MuonChamberMatch>::iterator chamberIter2 = muonIter2->matches().begin();
-		    chamberIter2 != muonIter2->matches().end();
-		    ++chamberIter2) {		  
-		  for(std::vector<reco::MuonSegmentMatch>::iterator segmentIter2 = chamberIter2->segmentMatches.begin();
-		      segmentIter2 != chamberIter2->segmentMatches.end();
-		      ++segmentIter2) {
-		    		      
+                    if (segmentIter1->cscSegmentRef.isNonnull() && segmentIter2->cscSegmentRef.isNonnull()) {
+                      if (doME1a && isDuplicateOf(segmentIter1->cscSegmentRef, segmentIter2->cscSegmentRef) &&
+                          CSCDetId(chamberIter1->id).ring() == 4 && CSCDetId(chamberIter2->id).ring() == 4 &&
+                          chamberIter1->id == chamberIter2->id) {
+                        addsegment = true;
+                        //std::cout << "\tME1/a sharing detected." << std::endl;
+                      }
 
-		    //if(segmentIter1->mask & 0x1e0000 && segmentIter2->mask &0x1e0000) {
+                      if (doOverlaps &&
+                          isDuplicateOf(std::make_pair(CSCDetId(chamberIter1->id), segmentIter1->cscSegmentRef),
+                                        std::make_pair(CSCDetId(chamberIter2->id), segmentIter2->cscSegmentRef))) {
+                        addsegment = true;
+                        //std::cout << "\tChamber Overlap sharing detected." << std::endl;
+                      }
 
-		      bool addsegment(false);
-		      
-		      if( segmentIter1->cscSegmentRef.isNonnull() && segmentIter2->cscSegmentRef.isNonnull() ) {
-						
-			if( doME1a && 
-			    isDuplicateOf(segmentIter1->cscSegmentRef,segmentIter2->cscSegmentRef) &&
-			    CSCDetId(chamberIter1->id).ring() == 4 && CSCDetId(chamberIter2->id).ring() == 4 &&
-			    chamberIter1->id == chamberIter2->id ) {
-			  addsegment = true;
-			  //std::cout << "\tME1/a sharing detected." << std::endl;
-			}
-			
-			if( doOverlaps &&
-			    isDuplicateOf(std::make_pair(CSCDetId(chamberIter1->id),segmentIter1->cscSegmentRef),
-					 std::make_pair(CSCDetId(chamberIter2->id),segmentIter2->cscSegmentRef)) ) {
-			  addsegment = true;
-			  //std::cout << "\tChamber Overlap sharing detected." << std::endl;
-			}
-			
-			if( doClustering &&
-			    isClusteredWith(std::make_pair(CSCDetId(chamberIter1->id),segmentIter1->cscSegmentRef),
-					   std::make_pair(CSCDetId(chamberIter2->id),segmentIter2->cscSegmentRef)) ) {
-			  addsegment = true;
-			  //std::cout << "\tCluster sharing detected." << std::endl;
-			}
-			//std::cout << std::endl;
-		      } // has valid csc segment ref
-		      
-		      if(addsegment) { // add segment if clusters/overlaps/replicant and doesn't already exist
-			
-			if(find(mesh_[&*muonIter1].begin(),
-				mesh_[&*muonIter1].end(),
-				std::make_pair(&*muonIter2,
-					       std::make_pair(&*chamberIter2,
-							      &*segmentIter2)
-					       )
-				) == mesh_[&*muonIter1].end()) {
-			  mesh_[&*muonIter1].push_back(std::make_pair(&*muonIter2,
-								      std::make_pair(&*chamberIter2,
-										     &*segmentIter2)
-								      )
-						       );
-			} // find
-		      } // add segment?
-		      //} // both segments won arbitration
-		  } // segmentIter 2				  		  
-		} // chamberIter2
-	      } //segmentIter1
-	    } // chamberIter1	
-	    
-	  } // if different muon	
-	} // is tracker muon  
-      } // muonIter2
-      
-    } // is tracker muon
-  } // muonIter1
+                      if (doClustering &&
+                          isClusteredWith(std::make_pair(CSCDetId(chamberIter1->id), segmentIter1->cscSegmentRef),
+                                          std::make_pair(CSCDetId(chamberIter2->id), segmentIter2->cscSegmentRef))) {
+                        addsegment = true;
+                        //std::cout << "\tCluster sharing detected." << std::endl;
+                      }
+                      //std::cout << std::endl;
+                    }  // has valid csc segment ref
+
+                    if (addsegment) {  // add segment if clusters/overlaps/replicant and doesn't already exist
+
+                      if (find(mesh_[&*muonIter1].begin(),
+                               mesh_[&*muonIter1].end(),
+                               std::make_pair(&*muonIter2, std::make_pair(&*chamberIter2, &*segmentIter2))) ==
+                          mesh_[&*muonIter1].end()) {
+                        mesh_[&*muonIter1].push_back(
+                            std::make_pair(&*muonIter2, std::make_pair(&*chamberIter2, &*segmentIter2)));
+                      }  // find
+                    }    // add segment?
+                         //} // both segments won arbitration
+                  }      // segmentIter 2
+                }        // chamberIter2
+              }          //segmentIter1
+            }            // chamberIter1
+
+          }  // if different muon
+        }    // is tracker muon
+      }      // muonIter2
+
+    }  // is tracker muon
+  }    // muonIter1
 
   // special cases
 
   // one muon: mark all segments belonging to a muon as cleaned as there are no other muons to fight with
-  if(mesh_.size() == 1) {
-    for(std::vector<reco::MuonChamberMatch>::iterator chamberIter1 = mesh_.begin()->first->matches().begin();
-	chamberIter1 != mesh_.begin()->first->matches().end();
-	++chamberIter1) {	      
-      for(std::vector<reco::MuonSegmentMatch>::iterator segmentIter1 = chamberIter1->segmentMatches.begin();
-	  segmentIter1 != chamberIter1->segmentMatches.end();
-	  ++segmentIter1) {
-	segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByCleaning);	
-      } // segmentIter1
-    } // chamberIter1
-  } // if only one tracker muon set winner bit boosted arbitration
+  if (mesh_.size() == 1) {
+    for (std::vector<reco::MuonChamberMatch>::iterator chamberIter1 = mesh_.begin()->first->matches().begin();
+         chamberIter1 != mesh_.begin()->first->matches().end();
+         ++chamberIter1) {
+      for (std::vector<reco::MuonSegmentMatch>::iterator segmentIter1 = chamberIter1->segmentMatches.begin();
+           segmentIter1 != chamberIter1->segmentMatches.end();
+           ++segmentIter1) {
+        segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByCleaning);
+      }  // segmentIter1
+    }    // chamberIter1
+  }      // if only one tracker muon set winner bit boosted arbitration
 
   // segments that are not shared amongst muons and the have won all segment arbitration flags need to be promoted
   // also promote DT segments
-  if(mesh_.size() > 1) {
-    for( MeshType::iterator i = mesh_.begin(); i != mesh_.end(); ++i ) {
-      for( std::vector<reco::MuonChamberMatch>::iterator chamberIter1 = i->first->matches().begin();
-	   chamberIter1 != i->first->matches().end();
-	   ++chamberIter1 ) {	
-	for(std::vector<reco::MuonSegmentMatch>::iterator segmentIter1 = chamberIter1->segmentMatches.begin();
-	    segmentIter1 != chamberIter1->segmentMatches.end();
-	    ++segmentIter1) {
+  if (mesh_.size() > 1) {
+    for (MeshType::iterator i = mesh_.begin(); i != mesh_.end(); ++i) {
+      for (std::vector<reco::MuonChamberMatch>::iterator chamberIter1 = i->first->matches().begin();
+           chamberIter1 != i->first->matches().end();
+           ++chamberIter1) {
+        for (std::vector<reco::MuonSegmentMatch>::iterator segmentIter1 = chamberIter1->segmentMatches.begin();
+             segmentIter1 != chamberIter1->segmentMatches.end();
+             ++segmentIter1) {
+          bool shared(false);
 
-	  bool shared(false);
-	  
-	  for( AssociationType::iterator j = i->second.begin();
-	       j != i->second.end();
-	       ++j ) {
+          for (AssociationType::iterator j = i->second.begin(); j != i->second.end(); ++j) {
+            if (segmentIter1->cscSegmentRef.isNonnull() && j->second.second->cscSegmentRef.isNonnull()) {
+              if (chamberIter1->id.subdetId() == MuonSubdetId::CSC &&
+                  j->second.first->id.subdetId() == MuonSubdetId::CSC) {
+                CSCDetId segIterId(chamberIter1->id), shareId(j->second.first->id);
 
-	    if( segmentIter1->cscSegmentRef.isNonnull() && 
-		j->second.second->cscSegmentRef.isNonnull() ) {	       	      
-	      if(chamberIter1->id.subdetId() == MuonSubdetId::CSC &&
-		 j->second.first->id.subdetId() == MuonSubdetId::CSC ) {
-		CSCDetId segIterId(chamberIter1->id), shareId(j->second.first->id);
+                if (doOverlaps && isDuplicateOf(std::make_pair(segIterId, segmentIter1->cscSegmentRef),
+                                                std::make_pair(shareId, j->second.second->cscSegmentRef)))
+                  shared = true;
 
-		if( doOverlaps &&
-		    isDuplicateOf(std::make_pair(segIterId,segmentIter1->cscSegmentRef),
-				  std::make_pair(shareId,j->second.second->cscSegmentRef)) )
-		  shared = true;
-		
-		if( doME1a && 
-		    isDuplicateOf(segmentIter1->cscSegmentRef,j->second.second->cscSegmentRef) &&
-		    segIterId.ring() == 4 && shareId.ring() == 4 &&
-		    segIterId == segIterId)
-		  shared = true;
+                if (doME1a && isDuplicateOf(segmentIter1->cscSegmentRef, j->second.second->cscSegmentRef) &&
+                    segIterId.ring() == 4 && shareId.ring() == 4 && segIterId == segIterId)
+                  shared = true;
 
-		if( doClustering && 
-		    isClusteredWith(std::make_pair(CSCDetId(chamberIter1->id),segmentIter1->cscSegmentRef),
-				    std::make_pair(CSCDetId(j->second.first->id),j->second.second->cscSegmentRef)) )
-		  shared = true;
-	      } // in CSCs?
-	    } // cscSegmentRef non null?
-	  } // j
-	  
-	  // Promote segments which have won all arbitration and are not shared or are DT segments
-	  if( ((segmentIter1->mask&0x1e0000) == 0x1e0000 && !shared) ||
-	      (chamberIter1->id.subdetId() == MuonSubdetId::DT && (segmentIter1->mask&0x1e0000)) ) 
-	      segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByCleaning);
+                if (doClustering &&
+                    isClusteredWith(std::make_pair(CSCDetId(chamberIter1->id), segmentIter1->cscSegmentRef),
+                                    std::make_pair(CSCDetId(j->second.first->id), j->second.second->cscSegmentRef)))
+                  shared = true;
+              }  // in CSCs?
+            }    // cscSegmentRef non null?
+          }      // j
 
-	} // segmentIter1
-      } // chamberIter1
-    }// i
-  } // if non-trivial case
+          // Promote segments which have won all arbitration and are not shared or are DT segments
+          if (((segmentIter1->mask & 0x1e0000) == 0x1e0000 && !shared) ||
+              (chamberIter1->id.subdetId() == MuonSubdetId::DT && (segmentIter1->mask & 0x1e0000)))
+            segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByCleaning);
 
+        }  // segmentIter1
+      }    // chamberIter1
+    }      // i
+  }        // if non-trivial case
 }
 
 void MuonMesh::pruneMesh() {
-  
-  for( MeshType::iterator i = mesh_.begin(); i != mesh_.end(); ++i ) {
+  for (MeshType::iterator i = mesh_.begin(); i != mesh_.end(); ++i) {
+    for (AssociationType::iterator j = i->second.begin(); j != i->second.end(); ++j) {
+      for (std::vector<reco::MuonChamberMatch>::iterator chamberIter1 = i->first->matches().begin();
+           chamberIter1 != i->first->matches().end();
+           ++chamberIter1) {
+        for (std::vector<reco::MuonSegmentMatch>::iterator segmentIter1 = chamberIter1->segmentMatches.begin();
+             segmentIter1 != chamberIter1->segmentMatches.end();
+             ++segmentIter1) {
+          if (j->second.second->cscSegmentRef.isNonnull() && segmentIter1->cscSegmentRef.isNonnull()) {
+            //UNUSED:	    bool me1a(false), overlap(false), cluster(false);
 
-        for( AssociationType::iterator j = i->second.begin();
-	 j != i->second.end();
-	 ++j ) {
+            // remove physical overlap duplicates first
+            if (doOverlaps &&
+                isDuplicateOf(std::make_pair(CSCDetId(chamberIter1->id), segmentIter1->cscSegmentRef),
+                              std::make_pair(CSCDetId(j->second.first->id), j->second.second->cscSegmentRef))) {
+              if (i->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000) >
+                  j->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000)) {
+                segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByOvlClean);
+                segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByCleaning);
 
-      for( std::vector<reco::MuonChamberMatch>::iterator chamberIter1 = i->first->matches().begin();
-	   chamberIter1 != i->first->matches().end();
-	   ++chamberIter1 ) {	
-	for(std::vector<reco::MuonSegmentMatch>::iterator segmentIter1 = chamberIter1->segmentMatches.begin();
-	    segmentIter1 != chamberIter1->segmentMatches.end();
-	    ++segmentIter1) {
+                //UNUSED:		overlap = true;
+              } else if (i->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000) ==
+                         j->first->numberOfMatches(
+                             (reco::Muon::ArbitrationType)0x1e0000)) {  // muon with more matched stations wins
 
-	  if(j->second.second->cscSegmentRef.isNonnull() && segmentIter1->cscSegmentRef.isNonnull()) {
-	    
-	    //UNUSED:	    bool me1a(false), overlap(false), cluster(false);
+                if ((segmentIter1->mask & 0x1e0000) >
+                    (j->second.second->mask & 0x1e0000)) {  // segment with better match wins
 
-	    // remove physical overlap duplicates first
-	    if( doOverlaps &&
-		isDuplicateOf(std::make_pair(CSCDetId(chamberIter1->id),segmentIter1->cscSegmentRef),
-			      std::make_pair(CSCDetId(j->second.first->id),j->second.second->cscSegmentRef)) ) {
+                  segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByOvlClean);
+                  segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByCleaning);
 
-	      if ( i->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000) >
-		   j->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000) ) {
-		
-		segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByOvlClean);
-		segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByCleaning);
-		
-		//UNUSED:		overlap = true;
-	      } else if ( i->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000) ==
-			  j->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000) ) { // muon with more matched stations wins
-		
-		if((segmentIter1->mask & 0x1e0000) > (j->second.second->mask & 0x1e0000)) { // segment with better match wins 
-		  
-		  segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByOvlClean);
-		  segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByCleaning);
-		  
-		  //UNUSED:		  overlap = true;				   
-		} else { // ??
-		  // leave this available for later
-		}		 
-	      } // overlap duplicate resolution
-	    } // is overlap duplicate
-	    
-	    // do ME1/a arbitration second since the tie breaker depends on other stations
-	    // Unlike the other cleanings this one removes the bits from segments associated to tracks which
-	    // fail cleaning. (Instead of setting bits for the segments which win.)
-	    if( doME1a && 
-		isDuplicateOf(segmentIter1->cscSegmentRef,j->second.second->cscSegmentRef) &&
-		CSCDetId(chamberIter1->id).ring() == 4 && CSCDetId(j->second.first->id).ring() == 4 &&
-		chamberIter1->id ==  j->second.first->id ) {	      
+                  //UNUSED:		  overlap = true;
+                } else {  // ??
+                  // leave this available for later
+                }
+              }  // overlap duplicate resolution
+            }    // is overlap duplicate
 
-	      if( j->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000) < 
-		  i->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000) ) {
-				
-		for(AssociationType::iterator AsscIter1 = i->second.begin();
-		    AsscIter1 != i->second.end();
-		    ++AsscIter1) {
-		  if(AsscIter1->second.second->cscSegmentRef.isNonnull())
-		    if(j->first == AsscIter1->first &&
-		       j->second.first == AsscIter1->second.first &&
-		       isDuplicateOf(segmentIter1->cscSegmentRef,AsscIter1->second.second->cscSegmentRef)) {
-		      AsscIter1->second.second->mask &= ~reco::MuonSegmentMatch::BelongsToTrackByME1aClean;
-		    }		
-		}  
+            // do ME1/a arbitration second since the tie breaker depends on other stations
+            // Unlike the other cleanings this one removes the bits from segments associated to tracks which
+            // fail cleaning. (Instead of setting bits for the segments which win.)
+            if (doME1a && isDuplicateOf(segmentIter1->cscSegmentRef, j->second.second->cscSegmentRef) &&
+                CSCDetId(chamberIter1->id).ring() == 4 && CSCDetId(j->second.first->id).ring() == 4 &&
+                chamberIter1->id == j->second.first->id) {
+              if (j->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000) <
+                  i->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000)) {
+                for (AssociationType::iterator AsscIter1 = i->second.begin(); AsscIter1 != i->second.end();
+                     ++AsscIter1) {
+                  if (AsscIter1->second.second->cscSegmentRef.isNonnull())
+                    if (j->first == AsscIter1->first && j->second.first == AsscIter1->second.first &&
+                        isDuplicateOf(segmentIter1->cscSegmentRef, AsscIter1->second.second->cscSegmentRef)) {
+                      AsscIter1->second.second->mask &= ~reco::MuonSegmentMatch::BelongsToTrackByME1aClean;
+                    }
+                }
 
-		//UNUSED:		me1a = true;
-	      } else if ( j->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000) == 
-			  i->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000) ) { // muon with best arbitration wins
-						
-		bool bestArb(true);
-		
-		for(AssociationType::iterator AsscIter1 = i->second.begin();
-		    AsscIter1 != i->second.end();
-		    ++AsscIter1) {
-		  if(AsscIter1->second.second->cscSegmentRef.isNonnull())
-		    if(j->first == AsscIter1->first &&
-		       j->second.first == AsscIter1->second.first &&
-		       isDuplicateOf(segmentIter1->cscSegmentRef,AsscIter1->second.second->cscSegmentRef) && 
-		       (segmentIter1->mask & 0x1e0000) < (AsscIter1->second.second->mask & 0x1e0000))
-		      bestArb = false;
-		}
-		
-		if(bestArb) {
-		  
-		  for(AssociationType::iterator AsscIter1 = i->second.begin();
-		      AsscIter1 != i->second.end();
-		      ++AsscIter1) {
-		    if(AsscIter1->second.second->cscSegmentRef.isNonnull())
-		      if(j->first == AsscIter1->first &&
-			 j->second.first == AsscIter1->second.first &&
-			 isDuplicateOf(segmentIter1->cscSegmentRef,AsscIter1->second.second->cscSegmentRef)) {
-			AsscIter1->second.second->mask &= ~reco::MuonSegmentMatch::BelongsToTrackByME1aClean;
-		      }
-		  }
-		  
-		}	 
-		//UNUSED		me1a = true;				
+                //UNUSED:		me1a = true;
+              } else if (j->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000) ==
+                         i->first->numberOfMatches(
+                             (reco::Muon::ArbitrationType)0x1e0000)) {  // muon with best arbitration wins
 
-	      } // ME1/a duplicate resolution	      	      
-	    } // is ME1/aduplicate?
-	    
-	    if(doClustering && 
-	       isClusteredWith(std::make_pair(CSCDetId(chamberIter1->id),segmentIter1->cscSegmentRef),
-			       std::make_pair(CSCDetId(j->second.first->id),j->second.second->cscSegmentRef))) {
+                bool bestArb(true);
 
-	      if (i->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000) >
-		  j->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000) ) {
+                for (AssociationType::iterator AsscIter1 = i->second.begin(); AsscIter1 != i->second.end();
+                     ++AsscIter1) {
+                  if (AsscIter1->second.second->cscSegmentRef.isNonnull())
+                    if (j->first == AsscIter1->first && j->second.first == AsscIter1->second.first &&
+                        isDuplicateOf(segmentIter1->cscSegmentRef, AsscIter1->second.second->cscSegmentRef) &&
+                        (segmentIter1->mask & 0x1e0000) < (AsscIter1->second.second->mask & 0x1e0000))
+                      bestArb = false;
+                }
 
-		 segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByClusClean);
-		 segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByCleaning);
+                if (bestArb) {
+                  for (AssociationType::iterator AsscIter1 = i->second.begin(); AsscIter1 != i->second.end();
+                       ++AsscIter1) {
+                    if (AsscIter1->second.second->cscSegmentRef.isNonnull())
+                      if (j->first == AsscIter1->first && j->second.first == AsscIter1->second.first &&
+                          isDuplicateOf(segmentIter1->cscSegmentRef, AsscIter1->second.second->cscSegmentRef)) {
+                        AsscIter1->second.second->mask &= ~reco::MuonSegmentMatch::BelongsToTrackByME1aClean;
+                      }
+                  }
+                }
+                //UNUSED		me1a = true;
 
-		 //UNUSED:		 cluster = true;
-	      } else if (i->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000) <
-			 j->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000)) {
+              }  // ME1/a duplicate resolution
+            }    // is ME1/aduplicate?
 
-		j->second.second->setMask(reco::MuonSegmentMatch::BelongsToTrackByClusClean);
-		j->second.second->setMask(reco::MuonSegmentMatch::BelongsToTrackByCleaning);
-		
-		//UNUSED:		cluster = true;
-	      } else { // muon with more matched stations wins
-		 
-		 if((segmentIter1->mask & 0x1e0000) > (j->second.second->mask & 0x1e0000)) { // segment with better match wins 
-		   
-		   segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByClusClean);
-		   segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByCleaning);
-		   
-		   //UNUSED:		   cluster = true;				   
-		 } else if ((segmentIter1->mask & 0x1e0000) < (j->second.second->mask & 0x1e0000)){ //
-		   
-		   j->second.second->setMask(reco::MuonSegmentMatch::BelongsToTrackByClusClean);
-		   j->second.second->setMask(reco::MuonSegmentMatch::BelongsToTrackByCleaning);
-		   
-		   //UNUSED:		   cluster = true;				   
-		 } else {
-		 }
-	       } // cluster sharing resolution
-	      
-	    } // is clustered with?
-	    
-	  } // csc ref nonnull	  
-	} // segmentIter1
-      } // chamberIter1       
-    } // j, associated segments iterator
-  } // i, map iterator
+            if (doClustering &&
+                isClusteredWith(std::make_pair(CSCDetId(chamberIter1->id), segmentIter1->cscSegmentRef),
+                                std::make_pair(CSCDetId(j->second.first->id), j->second.second->cscSegmentRef))) {
+              if (i->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000) >
+                  j->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000)) {
+                segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByClusClean);
+                segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByCleaning);
+
+                //UNUSED:		 cluster = true;
+              } else if (i->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000) <
+                         j->first->numberOfMatches((reco::Muon::ArbitrationType)0x1e0000)) {
+                j->second.second->setMask(reco::MuonSegmentMatch::BelongsToTrackByClusClean);
+                j->second.second->setMask(reco::MuonSegmentMatch::BelongsToTrackByCleaning);
+
+                //UNUSED:		cluster = true;
+              } else {  // muon with more matched stations wins
+
+                if ((segmentIter1->mask & 0x1e0000) >
+                    (j->second.second->mask & 0x1e0000)) {  // segment with better match wins
+
+                  segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByClusClean);
+                  segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByCleaning);
+
+                  //UNUSED:		   cluster = true;
+                } else if ((segmentIter1->mask & 0x1e0000) < (j->second.second->mask & 0x1e0000)) {  //
+
+                  j->second.second->setMask(reco::MuonSegmentMatch::BelongsToTrackByClusClean);
+                  j->second.second->setMask(reco::MuonSegmentMatch::BelongsToTrackByCleaning);
+
+                  //UNUSED:		   cluster = true;
+                } else {
+                }
+              }  // cluster sharing resolution
+
+            }  // is clustered with?
+
+          }  // csc ref nonnull
+        }    // segmentIter1
+      }      // chamberIter1
+    }        // j, associated segments iterator
+  }          // i, map iterator
 
   // final step: make sure everything that's won a cleaning flag has the "BelongsToTrackByCleaning" flag
 
-   for( MeshType::iterator i = mesh_.begin(); i != mesh_.end(); ++i ) {
-     for( std::vector<reco::MuonChamberMatch>::iterator chamberIter1 = i->first->matches().begin();
-	  chamberIter1 != i->first->matches().end();
-	  ++chamberIter1 ) {	
-       for(std::vector<reco::MuonSegmentMatch>::iterator segmentIter1 = chamberIter1->segmentMatches.begin();
-	   segmentIter1 != chamberIter1->segmentMatches.end();
-	   ++segmentIter1) {
-	 // set cleaning bit if initial no cleaning bit but there are cleaning algorithm bits set.
-	 if( !segmentIter1->isMask(reco::MuonSegmentMatch::BelongsToTrackByCleaning) &&
-	     segmentIter1->isMask(0xe00000) )
-	   segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByCleaning);	 
-       }// segmentIter1
-     } // chamberIter1
-   } // i
-  
+  for (MeshType::iterator i = mesh_.begin(); i != mesh_.end(); ++i) {
+    for (std::vector<reco::MuonChamberMatch>::iterator chamberIter1 = i->first->matches().begin();
+         chamberIter1 != i->first->matches().end();
+         ++chamberIter1) {
+      for (std::vector<reco::MuonSegmentMatch>::iterator segmentIter1 = chamberIter1->segmentMatches.begin();
+           segmentIter1 != chamberIter1->segmentMatches.end();
+           ++segmentIter1) {
+        // set cleaning bit if initial no cleaning bit but there are cleaning algorithm bits set.
+        if (!segmentIter1->isMask(reco::MuonSegmentMatch::BelongsToTrackByCleaning) && segmentIter1->isMask(0xe00000))
+          segmentIter1->setMask(reco::MuonSegmentMatch::BelongsToTrackByCleaning);
+      }  // segmentIter1
+    }    // chamberIter1
+  }      // i
 }
 
-bool MuonMesh::isDuplicateOf(const CSCSegmentRef& lhs, const CSCSegmentRef& rhs) const // this isDuplicateOf() deals with duplicate segments in ME1/a
+bool MuonMesh::isDuplicateOf(const CSCSegmentRef& lhs, const CSCSegmentRef& rhs)
+    const  // this isDuplicateOf() deals with duplicate segments in ME1/a
 {
   bool result(false);
- 
-  if(!lhs->isME11a_duplicate())
+
+  if (!lhs->isME11a_duplicate())
     return result;
 
   std::vector<CSCSegment> lhs_duplicates = lhs->duplicateSegments();
-      
-  if(fabs(lhs->localPosition().x()        - rhs->localPosition().x()      ) < 1E-3 &&
-     fabs(lhs->localPosition().y()        - rhs->localPosition().y()      ) < 1E-3 &&
-     fabs(lhs->localDirection().x()/lhs->localDirection().z()    - rhs->localDirection().x()/rhs->localDirection().z()   ) < 1E-3 &&
-     fabs(lhs->localDirection().y()/lhs->localDirection().z()    - rhs->localDirection().y()/rhs->localDirection().z()   ) < 1E-3 &&
-     fabs(lhs->localPositionError().xx()  - rhs->localPositionError().xx()   ) < 1E-3 &&
-     fabs(lhs->localPositionError().yy()  - rhs->localPositionError().yy()   ) < 1E-3 &&
-     fabs(lhs->localDirectionError().xx() - rhs->localDirectionError().xx()) < 1E-3 &&
-     fabs(lhs->localDirectionError().yy() - rhs->localDirectionError().yy()) < 1E-3)
+
+  if (fabs(lhs->localPosition().x() - rhs->localPosition().x()) < 1E-3 &&
+      fabs(lhs->localPosition().y() - rhs->localPosition().y()) < 1E-3 &&
+      fabs(lhs->localDirection().x() / lhs->localDirection().z() -
+           rhs->localDirection().x() / rhs->localDirection().z()) < 1E-3 &&
+      fabs(lhs->localDirection().y() / lhs->localDirection().z() -
+           rhs->localDirection().y() / rhs->localDirection().z()) < 1E-3 &&
+      fabs(lhs->localPositionError().xx() - rhs->localPositionError().xx()) < 1E-3 &&
+      fabs(lhs->localPositionError().yy() - rhs->localPositionError().yy()) < 1E-3 &&
+      fabs(lhs->localDirectionError().xx() - rhs->localDirectionError().xx()) < 1E-3 &&
+      fabs(lhs->localDirectionError().yy() - rhs->localDirectionError().yy()) < 1E-3)
     result = true;
 
-  for( std::vector<CSCSegment>::const_iterator segIter1 = lhs_duplicates.begin();
-       segIter1 != lhs_duplicates.end();
-       ++segIter1 ) { // loop over lhs duplicates
+  for (std::vector<CSCSegment>::const_iterator segIter1 = lhs_duplicates.begin(); segIter1 != lhs_duplicates.end();
+       ++segIter1) {  // loop over lhs duplicates
 
-    if(fabs(segIter1->localPosition().x()        - rhs->localPosition().x()      ) < 1E-3 &&
-       fabs(segIter1->localPosition().y()        - rhs->localPosition().y()      ) < 1E-3 &&
-       fabs(segIter1->localDirection().x()/segIter1->localDirection().z()    - rhs->localDirection().x()/rhs->localDirection().z()   ) < 1E-3 &&
-       fabs(segIter1->localDirection().y()/segIter1->localDirection().z()    - rhs->localDirection().y()/rhs->localDirection().z()   ) < 1E-3 &&
-       fabs(segIter1->localPositionError().xx()  - rhs->localPositionError().xx()   ) < 1E-3 &&
-       fabs(segIter1->localPositionError().yy()  - rhs->localPositionError().yy()   ) < 1E-3 &&
-       fabs(segIter1->localDirectionError().xx() - rhs->localDirectionError().xx()) < 1E-3 &&
-       fabs(segIter1->localDirectionError().yy() - rhs->localDirectionError().yy()) < 1E-3)
+    if (fabs(segIter1->localPosition().x() - rhs->localPosition().x()) < 1E-3 &&
+        fabs(segIter1->localPosition().y() - rhs->localPosition().y()) < 1E-3 &&
+        fabs(segIter1->localDirection().x() / segIter1->localDirection().z() -
+             rhs->localDirection().x() / rhs->localDirection().z()) < 1E-3 &&
+        fabs(segIter1->localDirection().y() / segIter1->localDirection().z() -
+             rhs->localDirection().y() / rhs->localDirection().z()) < 1E-3 &&
+        fabs(segIter1->localPositionError().xx() - rhs->localPositionError().xx()) < 1E-3 &&
+        fabs(segIter1->localPositionError().yy() - rhs->localPositionError().yy()) < 1E-3 &&
+        fabs(segIter1->localDirectionError().xx() - rhs->localDirectionError().xx()) < 1E-3 &&
+        fabs(segIter1->localDirectionError().yy() - rhs->localDirectionError().yy()) < 1E-3)
       result = true;
     /*
     if(fabs(segIter1->localPosition().x()        - rhs->localPosition().x()      ) < 2*sqrt(segIter1->localPositionError().xx()) &&
@@ -381,22 +340,22 @@ bool MuonMesh::isDuplicateOf(const CSCSegmentRef& lhs, const CSCSegmentRef& rhs)
       result = true;
     */
 
-  } // loop over duplicates
+  }  // loop over duplicates
 
   return result;
 }
 
-bool MuonMesh::isDuplicateOf(const std::pair<CSCDetId,CSCSegmentRef>& rhs, 
-			     const std::pair<CSCDetId,CSCSegmentRef>& lhs) const // this isDuplicateOf() deals with "overlapping chambers" duplicates
+bool MuonMesh::isDuplicateOf(const std::pair<CSCDetId, CSCSegmentRef>& rhs,
+                             const std::pair<CSCDetId, CSCSegmentRef>& lhs)
+    const  // this isDuplicateOf() deals with "overlapping chambers" duplicates
 {
   bool result(false);
-  
+
   // try to implement the simple case first just back-to-back segments without treatment of ME1/a ganging
   // ME1a should be a simple extension of this
 
-  if(rhs.first.endcap() == lhs.first.endcap() &&
-     rhs.first.station() == lhs.first.station() &&
-     rhs.first.ring() == lhs.first.ring()) { // if same endcap,station,ring (minimal requirement for ovl candidate)
+  if (rhs.first.endcap() == lhs.first.endcap() && rhs.first.station() == lhs.first.station() &&
+      rhs.first.ring() == lhs.first.ring()) {  // if same endcap,station,ring (minimal requirement for ovl candidate)
     /*
     std::cout << "Chamber 1: " << rhs.first << std::endl 
 	      << "Chamber 2: " << lhs.first << std::endl;
@@ -405,12 +364,14 @@ bool MuonMesh::isDuplicateOf(const std::pair<CSCDetId,CSCSegmentRef>& rhs,
     */
     //create neighboring chamber labels, treat ring as (Z mod 36 or 18) + 1 number line: left, right defined accordingly.
     unsigned modulus = ((rhs.first.ring() != 1 || rhs.first.station() == 1) ? 36 : 18);
-    int left_neighbor = (((rhs.first.chamber() - 1 + modulus)%modulus == 0 ) ? modulus : (rhs.first.chamber() - 1 + modulus)%modulus ); // + modulus to ensure positivity
-    int right_neighbor = (((rhs.first.chamber() + 1)%modulus == 0 ) ? modulus : (rhs.first.chamber() + 1)%modulus );
+    int left_neighbor = (((rhs.first.chamber() - 1 + modulus) % modulus == 0)
+                             ? modulus
+                             : (rhs.first.chamber() - 1 + modulus) % modulus);  // + modulus to ensure positivity
+    int right_neighbor = (((rhs.first.chamber() + 1) % modulus == 0) ? modulus : (rhs.first.chamber() + 1) % modulus);
 
-    if(lhs.first.chamber() == left_neighbor || 
-       lhs.first.chamber() == right_neighbor) { // if this is a neighboring chamber then it can be an overlap
-      
+    if (lhs.first.chamber() == left_neighbor ||
+        lhs.first.chamber() == right_neighbor) {  // if this is a neighboring chamber then it can be an overlap
+
       std::vector<CSCSegment> thesegments;
       thesegments.push_back(*(lhs.second));
       /*
@@ -431,16 +392,15 @@ bool MuonMesh::isDuplicateOf(const std::pair<CSCDetId,CSCSegmentRef>& rhs,
       double rhs_dydz_err = rhs.second->localDirectionError().yy();
       double rhs_dxdz_err = rhs.second->localDirectionError().xx();
       */
-      
+
       //rhs global position info
       double rhs_phi = geometry_->chamber(rhs.first)->toGlobal(rhs.second->localPosition()).phi();
       double rhs_theta = geometry_->chamber(rhs.first)->toGlobal(rhs.second->localPosition()).theta();
       double rhs_z = geometry_->chamber(rhs.first)->toGlobal(rhs.second->localPosition()).z();
 
-      for(std::vector<CSCSegment>::const_iterator ilhs = thesegments.begin(); ilhs != thesegments.end(); ++ilhs) {
-	
-	// lhs local direction info
-	/*
+      for (std::vector<CSCSegment>::const_iterator ilhs = thesegments.begin(); ilhs != thesegments.end(); ++ilhs) {
+        // lhs local direction info
+        /*
 	double lhs_dydz = geometry_->chamber(lhs.first)->toGlobal(ilhs->localDirection()).y()/
 	                  geometry_->chamber(lhs.first)->toGlobal(ilhs->localDirection()).z();
 	double lhs_dxdz = geometry_->chamber(lhs.first)->toGlobal(ilhs->localDirection()).x()/
@@ -448,12 +408,12 @@ bool MuonMesh::isDuplicateOf(const std::pair<CSCDetId,CSCSegmentRef>& rhs,
 	double lhs_dydz_err = ilhs->localDirectionError().yy();
 	double lhs_dxdz_err = ilhs->localDirectionError().xx();
 	*/
-	
-	//lhs global position info
-	double lhs_phi = geometry_->chamber(lhs.first)->toGlobal(ilhs->localPosition()).phi();
-	double lhs_theta = geometry_->chamber(lhs.first)->toGlobal(ilhs->localPosition()).theta();
-	double lhs_z = geometry_->chamber(lhs.first)->toGlobal(ilhs->localPosition()).z();
-	/*
+
+        //lhs global position info
+        double lhs_phi = geometry_->chamber(lhs.first)->toGlobal(ilhs->localPosition()).phi();
+        double lhs_theta = geometry_->chamber(lhs.first)->toGlobal(ilhs->localPosition()).theta();
+        double lhs_z = geometry_->chamber(lhs.first)->toGlobal(ilhs->localPosition()).z();
+        /*
 	  std::cout << "RHS Segment Parameters:" << std::endl
 	  << "\t RHS Phi   : " << rhs_phi << std::endl
 	  << "\t RHS Theta : " << rhs_theta << std::endl
@@ -466,43 +426,42 @@ bool MuonMesh::isDuplicateOf(const std::pair<CSCDetId,CSCSegmentRef>& rhs,
 	  << "\t LHS dx/dz : " << lhs_dxdz << " +- " << lhs_dxdz_err << std::endl
 	  << "\t LHS dy/dz : " << lhs_dydz << " +- " << lhs_dydz_err << std::endl; 
 	*/
-	
-	double phidiff = (fabs(rhs_phi - lhs_phi) > 2*M_PI ? fabs(rhs_phi - lhs_phi) - 2*M_PI : fabs(rhs_phi - lhs_phi));
 
-	if(phidiff < OverlapDPhi && fabs(rhs_theta - lhs_theta) < OverlapDTheta && 
-	   fabs(rhs_z) < fabs(lhs_z) && rhs_z*lhs_z > 0) // phi overlap region is 3.5 degrees and rhs is infront of lhs
-	  result = true;
-      } // loop over duplicate segments
-    }// neighboring chamber
-  } // same endcap,station,ring
+        double phidiff =
+            (fabs(rhs_phi - lhs_phi) > 2 * M_PI ? fabs(rhs_phi - lhs_phi) - 2 * M_PI : fabs(rhs_phi - lhs_phi));
+
+        if (phidiff < OverlapDPhi && fabs(rhs_theta - lhs_theta) < OverlapDTheta && fabs(rhs_z) < fabs(lhs_z) &&
+            rhs_z * lhs_z > 0)  // phi overlap region is 3.5 degrees and rhs is infront of lhs
+          result = true;
+      }  // loop over duplicate segments
+    }    // neighboring chamber
+  }      // same endcap,station,ring
 
   return result;
 }
 
-bool MuonMesh::isClusteredWith(const std::pair<CSCDetId,CSCSegmentRef>& lhs, 
-			       const std::pair<CSCDetId,CSCSegmentRef>& rhs) const
-{
+bool MuonMesh::isClusteredWith(const std::pair<CSCDetId, CSCSegmentRef>& lhs,
+                               const std::pair<CSCDetId, CSCSegmentRef>& rhs) const {
   bool result(false);
-  
+
   // try to implement the simple case first just back-to-back segments without treatment of ME1/a ganging
   // ME1a should be a simple extension of this
 
   //std::cout << lhs.first << ' ' << rhs.first << std::endl;
 
-  if(rhs.first.endcap() == lhs.first.endcap() && lhs.first.station() < rhs.first.station()) {
-          
-      std::vector<CSCSegment> thesegments;
-      thesegments.push_back(*(lhs.second));
-      /*
+  if (rhs.first.endcap() == lhs.first.endcap() && lhs.first.station() < rhs.first.station()) {
+    std::vector<CSCSegment> thesegments;
+    thesegments.push_back(*(lhs.second));
+    /*
       if(lhs.second->isME11a_duplicate())
 	thesegments.insert(thesegments.begin(),
 			   lhs.second->duplicateSegments().begin(),
 			   lhs.second->duplicateSegments().end());
       */
-      //std::cout << "lhs is in neighoring chamber of rhs." << std::endl;
+    //std::cout << "lhs is in neighoring chamber of rhs." << std::endl;
 
-      // rhs local direction info
-      /*
+    // rhs local direction info
+    /*
       double rhs_dydz = geometry_->chamber(rhs.first)->toGlobal(rhs.second->localDirection()).y()/
 	                geometry_->chamber(rhs.first)->toGlobal(rhs.second->localDirection()).z();
       double rhs_dxdz = geometry_->chamber(rhs.first)->toGlobal(rhs.second->localDirection()).x()/
@@ -510,15 +469,14 @@ bool MuonMesh::isClusteredWith(const std::pair<CSCDetId,CSCSegmentRef>& lhs,
       double rhs_dydz_err = rhs.second->localDirectionError().yy();
       double rhs_dxdz_err = rhs.second->localDirectionError().xx();
       */
-      
-      //rhs global position info
-      double rhs_phi = geometry_->chamber(rhs.first)->toGlobal(rhs.second->localPosition()).phi();
-      double rhs_theta = geometry_->chamber(rhs.first)->toGlobal(rhs.second->localPosition()).theta();
 
-      for(std::vector<CSCSegment>::const_iterator ilhs = thesegments.begin(); ilhs != thesegments.end(); ++ilhs) {
- 	
-	// lhs local direction info
-	/*
+    //rhs global position info
+    double rhs_phi = geometry_->chamber(rhs.first)->toGlobal(rhs.second->localPosition()).phi();
+    double rhs_theta = geometry_->chamber(rhs.first)->toGlobal(rhs.second->localPosition()).theta();
+
+    for (std::vector<CSCSegment>::const_iterator ilhs = thesegments.begin(); ilhs != thesegments.end(); ++ilhs) {
+      // lhs local direction info
+      /*
 	double lhs_dydz = geometry_->chamber(lhs.first)->toGlobal(ilhs->localDirection()).y()/
 	                  geometry_->chamber(lhs.first)->toGlobal(ilhs->localDirection()).z();
 	double lhs_dxdz = geometry_->chamber(lhs.first)->toGlobal(ilhs->localDirection()).x()/
@@ -527,10 +485,10 @@ bool MuonMesh::isClusteredWith(const std::pair<CSCDetId,CSCSegmentRef>& lhs,
 	double lhs_dxdz_err = ilhs->localDirectionError().xx();
 	*/
 
-	//lhs global position info
-	double lhs_phi = geometry_->chamber(lhs.first)->toGlobal(ilhs->localPosition()).phi();
-	double lhs_theta = geometry_->chamber(lhs.first)->toGlobal(ilhs->localPosition()).theta();
-	/*
+      //lhs global position info
+      double lhs_phi = geometry_->chamber(lhs.first)->toGlobal(ilhs->localPosition()).phi();
+      double lhs_theta = geometry_->chamber(lhs.first)->toGlobal(ilhs->localPosition()).theta();
+      /*
 	  std::cout << "RHS Segment Parameters:" << std::endl
 	  << "\t RHS Phi   : " << rhs_phi << std::endl
 	  << "\t RHS Theta : " << rhs_theta << std::endl
@@ -544,12 +502,13 @@ bool MuonMesh::isClusteredWith(const std::pair<CSCDetId,CSCSegmentRef>& lhs,
 	  << "\t LHS dy/dz : " << lhs_dydz << " +- " << lhs_dydz_err << std::endl; 
 	*/
 
-	double phidiff = (fabs(rhs_phi - lhs_phi) > 2*M_PI ? fabs(rhs_phi - lhs_phi) - 2*M_PI : fabs(rhs_phi - lhs_phi));
-	
-	if(phidiff < ClusterDPhi && fabs(rhs_theta - lhs_theta) < ClusterDTheta) // phi overlap region is 37 degrees
-	  result = true;
-      } // loop over duplicate segments    
-  } // same endcap,station,ring
+      double phidiff =
+          (fabs(rhs_phi - lhs_phi) > 2 * M_PI ? fabs(rhs_phi - lhs_phi) - 2 * M_PI : fabs(rhs_phi - lhs_phi));
+
+      if (phidiff < ClusterDPhi && fabs(rhs_theta - lhs_theta) < ClusterDTheta)  // phi overlap region is 37 degrees
+        result = true;
+    }  // loop over duplicate segments
+  }    // same endcap,station,ring
 
   return result;
 }

--- a/RecoMuon/MuonIdentification/src/MuonShowerDigiFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonShowerDigiFiller.cc
@@ -1,7 +1,7 @@
 //
 // Package:    MuonShowerDigiFiller
 // Class:      MuonShowerDigiFiller
-// 
+//
 /**\class MuonShowerDigiFiller MuonShowerDigiFiller.cc RecoMuon/MuonIdentification/src/MuonShowerDigiFiller.cc
 
  Description: Class filling shower information using DT and CSC digis 
@@ -10,11 +10,10 @@
      <Notes on implementation>
 */
 //
-// Original Author:  Carlo Battilana, INFN BO 
+// Original Author:  Carlo Battilana, INFN BO
 //         Created:  Sat Mar 23 14:36:22 CET 2019
 //
 //
-
 
 // system include files
 
@@ -27,124 +26,91 @@
 // constructors and destructor
 //
 
-MuonShowerDigiFiller::MuonShowerDigiFiller(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC) : 
-  m_digiMaxDistanceX(iConfig.getParameter<double>("digiMaxDistanceX")),
-  m_dtDigisToken(iC.consumes<DTDigiCollection>(iConfig.getParameter<edm::InputTag>("dtDigiCollectionLabel"))),
-  m_cscDigisToken(iC.consumes<CSCStripDigiCollection>(iConfig.getParameter<edm::InputTag>("cscDigiCollectionLabel")))
-{
-   
-}
-
+MuonShowerDigiFiller::MuonShowerDigiFiller(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC)
+    : m_digiMaxDistanceX(iConfig.getParameter<double>("digiMaxDistanceX")),
+      m_dtDigisToken(iC.consumes<DTDigiCollection>(iConfig.getParameter<edm::InputTag>("dtDigiCollectionLabel"))),
+      m_cscDigisToken(
+          iC.consumes<CSCStripDigiCollection>(iConfig.getParameter<edm::InputTag>("cscDigiCollectionLabel"))) {}
 
 //
 // member functions
 //
 
-void 
-MuonShowerDigiFiller::getES( const edm::EventSetup& iSetup )
-{
-
+void MuonShowerDigiFiller::getES(const edm::EventSetup& iSetup) {
   iSetup.get<MuonGeometryRecord>().get(m_dtGeometry);
   iSetup.get<MuonGeometryRecord>().get(m_cscGeometry);
-
 }
 
-void 
-MuonShowerDigiFiller::getDigis( edm::Event& iEvent )
-{
-  
-  iEvent.getByToken(m_dtDigisToken,  m_dtDigis);
+void MuonShowerDigiFiller::getDigis(edm::Event& iEvent) {
+  iEvent.getByToken(m_dtDigisToken, m_dtDigis);
   iEvent.getByToken(m_cscDigisToken, m_cscDigis);
-
 }
 
-void 
-MuonShowerDigiFiller::fill( reco::MuonChamberMatch & muChMatch ) const 
-{
-
+void MuonShowerDigiFiller::fill(reco::MuonChamberMatch& muChMatch) const {
   int nDigisInRange = 0;
 
   // DT chamber
-  if( muChMatch.detector() == MuonSubdetId::DT ) 
-    {
-      double xTrack = muChMatch.x;
-      
-      for (int sl = 1; sl <= DTChamberId::maxSuperLayerId; sl += 2) 
-	{
-	  for (int layer = 1; layer <= DTChamberId::maxLayerId; ++layer) 
-	    {
-	      const DTLayerId layerId(DTChamberId(muChMatch.id.rawId()),sl,layer);
-	      
-	      auto range =  m_dtDigis->get(layerId);
-	      
-	      for (auto digiIt = range.first ;digiIt!=range.second; ++digiIt) 
-		{
-		  const auto topo = m_dtGeometry->layer(layerId)->specificTopology();
-		  
-		  double xWire = topo.wirePosition((*digiIt).wire());
-		  double dX = std::abs(xWire - xTrack);
-		  
-		  if (dX < m_digiMaxDistanceX)
-		    nDigisInRange++;
-		}
-	    }
-	}
+  if (muChMatch.detector() == MuonSubdetId::DT) {
+    double xTrack = muChMatch.x;
+
+    for (int sl = 1; sl <= DTChamberId::maxSuperLayerId; sl += 2) {
+      for (int layer = 1; layer <= DTChamberId::maxLayerId; ++layer) {
+        const DTLayerId layerId(DTChamberId(muChMatch.id.rawId()), sl, layer);
+
+        auto range = m_dtDigis->get(layerId);
+
+        for (auto digiIt = range.first; digiIt != range.second; ++digiIt) {
+          const auto topo = m_dtGeometry->layer(layerId)->specificTopology();
+
+          double xWire = topo.wirePosition((*digiIt).wire());
+          double dX = std::abs(xWire - xTrack);
+
+          if (dX < m_digiMaxDistanceX)
+            nDigisInRange++;
+        }
+      }
     }
+  }
 
-  else if(muChMatch.detector() == MuonSubdetId::CSC) 
-    {
+  else if (muChMatch.detector() == MuonSubdetId::CSC) {
+    double xTrack = muChMatch.x;
+    double yTrack = muChMatch.y;
 
-      double xTrack = muChMatch.x;
-      double yTrack = muChMatch.y;
+    for (int iLayer = 1; iLayer <= CSCDetId::maxLayerId(); ++iLayer) {
+      const CSCDetId chId(muChMatch.id.rawId());
+      const CSCDetId layerId(chId.endcap(), chId.station(), chId.ring(), chId.chamber(), iLayer);
 
-      for (int iLayer = 1; iLayer <= CSCDetId::maxLayerId(); ++iLayer) 
-	{
-	  const CSCDetId chId(muChMatch.id.rawId());
-	  const CSCDetId layerId(chId.endcap(), chId.station(),
-				 chId.ring(),   chId.chamber(),
-				 iLayer);
-	  
-	  auto range =  m_cscDigis->get(layerId);
-	  
-	  for (auto digiIt = range.first ;digiIt!=range.second; ++digiIt) 
-	    {
-	    
-	      std::vector<int> adcVals = digiIt->getADCCounts();
-	      bool hasFired = false;
-	      float pedestal = 0.5*(float)(adcVals[0]+adcVals[1]);
-	      float threshold = 13.3 ;
-	      float diff = 0.;
-	      for (const auto & adcVal : adcVals) 
-		{
-		  diff = (float)adcVal - pedestal;
-		  if (diff > threshold) 
-		    { 
-		      hasFired = true; 
-		      break;
-		    }
-		} 
+      auto range = m_cscDigis->get(layerId);
 
-	      if (!hasFired) continue;
+      for (auto digiIt = range.first; digiIt != range.second; ++digiIt) {
+        std::vector<int> adcVals = digiIt->getADCCounts();
+        bool hasFired = false;
+        float pedestal = 0.5 * (float)(adcVals[0] + adcVals[1]);
+        float threshold = 13.3;
+        float diff = 0.;
+        for (const auto& adcVal : adcVals) {
+          diff = (float)adcVal - pedestal;
+          if (diff > threshold) {
+            hasFired = true;
+            break;
+          }
+        }
 
-	      const CSCLayerGeometry* layerGeom = m_cscGeometry->layer(layerId)->geometry();      
-	      
-	      Float_t xStrip = layerGeom->xOfStrip(digiIt->getStrip(), yTrack);
-	      float dX = std::abs(xStrip - xTrack);
-	      
-	      if (dX < m_digiMaxDistanceX)
-		nDigisInRange++;
-	    }
-	}
+        if (!hasFired)
+          continue;
+
+        const CSCLayerGeometry* layerGeom = m_cscGeometry->layer(layerId)->geometry();
+
+        Float_t xStrip = layerGeom->xOfStrip(digiIt->getStrip(), yTrack);
+        float dX = std::abs(xStrip - xTrack);
+
+        if (dX < m_digiMaxDistanceX)
+          nDigisInRange++;
+      }
     }
+  }
 
   muChMatch.nDigisInRange = nDigisInRange;
-  
 }
 
-void 
-MuonShowerDigiFiller::fillDefault( reco::MuonChamberMatch & muChMatch ) const 
-{
-
-  muChMatch.nDigisInRange = 0;
-
-}
+void MuonShowerDigiFiller::fillDefault(reco::MuonChamberMatch& muChMatch) const { muChMatch.nDigisInRange = 0; }

--- a/RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonShowerInformationFiller.cc
@@ -65,19 +65,16 @@ using namespace edm;
 //
 // Constructor
 //
-MuonShowerInformationFiller::MuonShowerInformationFiller(const edm::ParameterSet& par,edm::ConsumesCollector& iC) :
-  theService(nullptr),
-  theDTRecHitLabel(par.getParameter<InputTag>("DTRecSegmentLabel")),
-  theCSCRecHitLabel(par.getParameter<InputTag>("CSCRecSegmentLabel")),
-  theCSCSegmentsLabel(par.getParameter<InputTag>("CSCSegmentLabel")),
-  theDT4DRecSegmentLabel(par.getParameter<InputTag>("DT4DRecSegmentLabel"))
-{
-
-  theDTRecHitToken =iC.consumes<DTRecHitCollection>(theDTRecHitLabel) ;
-  theCSCRecHitToken =iC.consumes<CSCRecHit2DCollection>(theCSCRecHitLabel);
-  theCSCSegmentsToken=iC.consumes<CSCSegmentCollection>(theCSCSegmentsLabel);
-  theDT4DRecSegmentToken=iC.consumes<DTRecSegment4DCollection>(theDT4DRecSegmentLabel);
-
+MuonShowerInformationFiller::MuonShowerInformationFiller(const edm::ParameterSet& par, edm::ConsumesCollector& iC)
+    : theService(nullptr),
+      theDTRecHitLabel(par.getParameter<InputTag>("DTRecSegmentLabel")),
+      theCSCRecHitLabel(par.getParameter<InputTag>("CSCRecSegmentLabel")),
+      theCSCSegmentsLabel(par.getParameter<InputTag>("CSCSegmentLabel")),
+      theDT4DRecSegmentLabel(par.getParameter<InputTag>("DT4DRecSegmentLabel")) {
+  theDTRecHitToken = iC.consumes<DTRecHitCollection>(theDTRecHitLabel);
+  theCSCRecHitToken = iC.consumes<CSCRecHit2DCollection>(theCSCRecHitLabel);
+  theCSCSegmentsToken = iC.consumes<CSCSegmentCollection>(theCSCSegmentsLabel);
+  theDT4DRecSegmentToken = iC.consumes<DTRecSegment4DCollection>(theDT4DRecSegmentLabel);
 
   edm::ParameterSet serviceParameters = par.getParameter<edm::ParameterSet>("ServiceParameters");
   theService = new MuonServiceProxy(serviceParameters);
@@ -91,26 +88,27 @@ MuonShowerInformationFiller::MuonShowerInformationFiller(const edm::ParameterSet
   category_ = "MuonShowerInformationFiller";
 
   for (int istat = 0; istat < 4; istat++) {
-      theStationShowerDeltaR.push_back(0.);
-      theStationShowerTSize.push_back(0.);
-      theAllStationHits.push_back(0);
-      theCorrelatedStationHits.push_back(0);
+    theStationShowerDeltaR.push_back(0.);
+    theStationShowerTSize.push_back(0.);
+    theAllStationHits.push_back(0);
+    theCorrelatedStationHits.push_back(0);
   }
-
 }
 
 //
 // Destructor
 //
 MuonShowerInformationFiller::~MuonShowerInformationFiller() {
-  if (theService) delete theService;
+  if (theService)
+    delete theService;
 }
 
 //
 //Fill the MuonShower struct
 //
-reco::MuonShower MuonShowerInformationFiller::fillShowerInformation( const reco::Muon& muon, const edm::Event& iEvent, const edm::EventSetup& iSetup) {
-
+reco::MuonShower MuonShowerInformationFiller::fillShowerInformation(const reco::Muon& muon,
+                                                                    const edm::Event& iEvent,
+                                                                    const edm::EventSetup& iSetup) {
   reco::MuonShower returnShower;
 
   // Update the services
@@ -130,14 +128,12 @@ reco::MuonShower MuonShowerInformationFiller::fillShowerInformation( const reco:
   returnShower.stationShowerDeltaR = stationShowerDeltaR;
 
   return returnShower;
-
 }
 
 //
 // Set Event
 //
 void MuonShowerInformationFiller::setEvent(const edm::Event& event) {
-
   // get all the necesary products
   event.getByToken(theDTRecHitToken, theDTRecHits);
   event.getByToken(theCSCRecHitToken, theCSCRecHits);
@@ -145,19 +141,17 @@ void MuonShowerInformationFiller::setEvent(const edm::Event& event) {
   event.getByToken(theDT4DRecSegmentToken, theDT4DRecSegments);
 
   for (int istat = 0; istat < 4; istat++) {
-      theStationShowerDeltaR.at(istat) = 0.;
-      theStationShowerTSize.at(istat) = 0.;
-      theAllStationHits.at(istat) = 0;
-      theCorrelatedStationHits.at(istat) = 0;
+    theStationShowerDeltaR.at(istat) = 0.;
+    theStationShowerTSize.at(istat) = 0.;
+    theAllStationHits.at(istat) = 0;
+    theCorrelatedStationHits.at(istat) = 0;
   }
 }
-
 
 //
 // Set services
 //
 void MuonShowerInformationFiller::setServices(const EventSetup& setup) {
-
   // DetLayer Geometry
   setup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry);
   setup.get<IdealMagneticFieldRecord>().get(theField);
@@ -167,121 +161,113 @@ void MuonShowerInformationFiller::setServices(const EventSetup& setup) {
 
   // Transient Rechit Builders
   unsigned long long newCacheId_TRH = setup.get<TransientRecHitRecord>().cacheIdentifier();
-  if ( newCacheId_TRH != theCacheId_TRH ) {
-    setup.get<TransientRecHitRecord>().get(theTrackerRecHitBuilderName,theTrackerRecHitBuilder);
-    setup.get<TransientRecHitRecord>().get(theMuonRecHitBuilderName,theMuonRecHitBuilder);
+  if (newCacheId_TRH != theCacheId_TRH) {
+    setup.get<TransientRecHitRecord>().get(theTrackerRecHitBuilderName, theTrackerRecHitBuilder);
+    setup.get<TransientRecHitRecord>().get(theMuonRecHitBuilderName, theMuonRecHitBuilder);
   }
-
 }
 
 //
 // Get hits owned by segments
 //
-TransientTrackingRecHit::ConstRecHitContainer
-MuonShowerInformationFiller::hitsFromSegments(const GeomDet* geomDet,
-                            edm::Handle<DTRecSegment4DCollection> dtSegments,
-                            edm::Handle<CSCSegmentCollection> cscSegments) const {
-
+TransientTrackingRecHit::ConstRecHitContainer MuonShowerInformationFiller::hitsFromSegments(
+    const GeomDet* geomDet,
+    edm::Handle<DTRecSegment4DCollection> dtSegments,
+    edm::Handle<CSCSegmentCollection> cscSegments) const {
   MuonTransientTrackingRecHit::MuonRecHitContainer segments;
 
   DetId geoId = geomDet->geographicalId();
 
   if (geoId.subdetId() == MuonSubdetId::DT) {
-
     DTChamberId chamberId(geoId.rawId());
 
     // loop on segments 4D
     DTRecSegment4DCollection::id_iterator chamberIdIt;
-    for (chamberIdIt = dtSegments->id_begin();
-         chamberIdIt != dtSegments->id_end();
-         ++chamberIdIt){
-
-      if (*chamberIdIt != chamberId) continue;
+    for (chamberIdIt = dtSegments->id_begin(); chamberIdIt != dtSegments->id_end(); ++chamberIdIt) {
+      if (*chamberIdIt != chamberId)
+        continue;
 
       // Get the range for the corresponding ChamberId
-      DTRecSegment4DCollection::range  range = dtSegments->get((*chamberIdIt));
+      DTRecSegment4DCollection::range range = dtSegments->get((*chamberIdIt));
 
-      for (DTRecSegment4DCollection::const_iterator iseg = range.first;
-        iseg!=range.second;++iseg) {
-        if (iseg->dimension() != 4) continue;
-        segments.push_back(MuonTransientTrackingRecHit::specificBuild(geomDet,&*iseg));
+      for (DTRecSegment4DCollection::const_iterator iseg = range.first; iseg != range.second; ++iseg) {
+        if (iseg->dimension() != 4)
+          continue;
+        segments.push_back(MuonTransientTrackingRecHit::specificBuild(geomDet, &*iseg));
       }
     }
-  }
-  else if (geoId.subdetId() == MuonSubdetId::CSC) {
+  } else if (geoId.subdetId() == MuonSubdetId::CSC) {
+    CSCDetId did(geoId.rawId());
 
-      CSCDetId did(geoId.rawId());
-
-      for (  CSCSegmentCollection::id_iterator chamberId = cscSegments->id_begin();
-         chamberId != cscSegments->id_end(); ++chamberId) {
-
-      if ((*chamberId).chamber() != did.chamber()) continue;
+    for (CSCSegmentCollection::id_iterator chamberId = cscSegments->id_begin(); chamberId != cscSegments->id_end();
+         ++chamberId) {
+      if ((*chamberId).chamber() != did.chamber())
+        continue;
 
       // Get the range for the corresponding ChamberId
-      CSCSegmentCollection::range  range = cscSegments->get((*chamberId));
+      CSCSegmentCollection::range range = cscSegments->get((*chamberId));
 
-      for (CSCSegmentCollection::const_iterator iseg = range.first;
-        iseg!=range.second;++iseg) {
-        if (iseg->dimension() != 3) continue;
-        segments.push_back(MuonTransientTrackingRecHit::specificBuild(geomDet,&*iseg));
-       }
+      for (CSCSegmentCollection::const_iterator iseg = range.first; iseg != range.second; ++iseg) {
+        if (iseg->dimension() != 3)
+          continue;
+        segments.push_back(MuonTransientTrackingRecHit::specificBuild(geomDet, &*iseg));
+      }
     }
-  }
-  else {
+  } else {
     LogTrace(category_) << "Segments are not built in RPCs" << endl;
   }
 
   TransientTrackingRecHit::ConstRecHitContainer allhitscorrelated;
 
-  if (segments.empty()) return allhitscorrelated;
+  if (segments.empty())
+    return allhitscorrelated;
 
   TransientTrackingRecHit::ConstRecHitPointer muonRecHit(segments.front());
-  allhitscorrelated = MuonTransientTrackingRecHitBreaker::breakInSubRecHits(muonRecHit,2);
+  allhitscorrelated = MuonTransientTrackingRecHitBreaker::breakInSubRecHits(muonRecHit, 2);
 
-  if (segments.size() == 1) return allhitscorrelated;
+  if (segments.size() == 1)
+    return allhitscorrelated;
 
   for (MuonTransientTrackingRecHit::MuonRecHitContainer::const_iterator iseg = segments.begin() + 1;
-       iseg != segments.end(); ++iseg) {
-
+       iseg != segments.end();
+       ++iseg) {
     TransientTrackingRecHit::ConstRecHitPointer muonRecHit((*iseg));
-    TransientTrackingRecHit::ConstRecHitContainer hits1 = MuonTransientTrackingRecHitBreaker::breakInSubRecHits(muonRecHit,2);
+    TransientTrackingRecHit::ConstRecHitContainer hits1 =
+        MuonTransientTrackingRecHitBreaker::breakInSubRecHits(muonRecHit, 2);
 
-    for (TransientTrackingRecHit::ConstRecHitContainer::const_iterator ihit1 = hits1.begin();
-         ihit1 != hits1.end(); ++ihit1 ) {
-
+    for (TransientTrackingRecHit::ConstRecHitContainer::const_iterator ihit1 = hits1.begin(); ihit1 != hits1.end();
+         ++ihit1) {
       bool usedbefore = false;
       //unused      DetId thisID = (*ihit1)->geographicalId();
       //LocalPoint lp1dinsegHit = (*ihit1)->localPosition();
       GlobalPoint gp1dinsegHit = (*ihit1)->globalPosition();
 
       for (TransientTrackingRecHit::ConstRecHitContainer::const_iterator ihit2 = allhitscorrelated.begin();
-           ihit2 != allhitscorrelated.end(); ++ihit2 ) {
-
-	//unused        DetId thisID2 = (*ihit2)->geographicalId();
+           ihit2 != allhitscorrelated.end();
+           ++ihit2) {
+        //unused        DetId thisID2 = (*ihit2)->geographicalId();
         //LocalPoint lp1dinsegHit2 = (*ihit2)->localPosition();
         GlobalPoint gp1dinsegHit2 = (*ihit2)->globalPosition();
 
-        if ( (gp1dinsegHit2 - gp1dinsegHit).mag() < 1.0 ) usedbefore = true;
-
+        if ((gp1dinsegHit2 - gp1dinsegHit).mag() < 1.0)
+          usedbefore = true;
       }
-      if ( !usedbefore ) allhitscorrelated.push_back(*ihit1);
+      if (!usedbefore)
+        allhitscorrelated.push_back(*ihit1);
     }
   }
 
   return allhitscorrelated;
-
 }
-
 
 //
 // Find cluster
 //
 
-TransientTrackingRecHit::ConstRecHitContainer
-MuonShowerInformationFiller::findThetaCluster(TransientTrackingRecHit::ConstRecHitContainer& muonRecHits,
-                              const GlobalPoint& refpoint) const {
-
-  if ( muonRecHits.empty() ) return muonRecHits;
+TransientTrackingRecHit::ConstRecHitContainer MuonShowerInformationFiller::findThetaCluster(
+    TransientTrackingRecHit::ConstRecHitContainer& muonRecHits, const GlobalPoint& refpoint) const {
+  if (muonRecHits.empty())
+    return muonRecHits;
 
   //clustering step by theta
   float step = 0.05;
@@ -289,61 +275,63 @@ MuonShowerInformationFiller::findThetaCluster(TransientTrackingRecHit::ConstRecH
 
   stable_sort(muonRecHits.begin(), muonRecHits.end(), AbsLessDTheta(refpoint));
 
-  for (TransientTrackingRecHit::ConstRecHitContainer::const_iterator ihit = muonRecHits.begin(); ihit != muonRecHits.end() - 1; ++ihit) {
-      if (fabs((*(ihit+1))->globalPosition().theta() - (*ihit)->globalPosition().theta() ) < step) {
-          result.push_back(*ihit);
-        } else {
-           break;
-       }
+  for (TransientTrackingRecHit::ConstRecHitContainer::const_iterator ihit = muonRecHits.begin();
+       ihit != muonRecHits.end() - 1;
+       ++ihit) {
+    if (fabs((*(ihit + 1))->globalPosition().theta() - (*ihit)->globalPosition().theta()) < step) {
+      result.push_back(*ihit);
+    } else {
+      break;
+    }
   }
 
   return result;
-
 }
 
 //
 //Used to treat overlap region
 //
-MuonTransientTrackingRecHit::MuonRecHitContainer
-MuonShowerInformationFiller::findPerpCluster(MuonTransientTrackingRecHit::MuonRecHitContainer& muonRecHits) const {
-
-  if ( muonRecHits.empty() ) return muonRecHits;
+MuonTransientTrackingRecHit::MuonRecHitContainer MuonShowerInformationFiller::findPerpCluster(
+    MuonTransientTrackingRecHit::MuonRecHitContainer& muonRecHits) const {
+  if (muonRecHits.empty())
+    return muonRecHits;
 
   stable_sort(muonRecHits.begin(), muonRecHits.end(), LessPerp());
 
-  MuonTransientTrackingRecHit::MuonRecHitContainer::const_iterator
-  seedhit = min_element(muonRecHits.begin(), muonRecHits.end(), LessPerp());
+  MuonTransientTrackingRecHit::MuonRecHitContainer::const_iterator seedhit =
+      min_element(muonRecHits.begin(), muonRecHits.end(), LessPerp());
 
   MuonTransientTrackingRecHit::MuonRecHitContainer::const_iterator ihigh = seedhit;
   MuonTransientTrackingRecHit::MuonRecHitContainer::const_iterator ilow = seedhit;
 
   float step = 0.1;
-  while (ihigh != muonRecHits.end()-1 && ( fabs((*(ihigh+1))->globalPosition().perp() - (*ihigh)->globalPosition().perp() ) < step)  ) {
+  while (ihigh != muonRecHits.end() - 1 &&
+         (fabs((*(ihigh + 1))->globalPosition().perp() - (*ihigh)->globalPosition().perp()) < step)) {
     ihigh++;
   }
-  while (ilow != muonRecHits.begin() && ( fabs((*ilow)->globalPosition().perp() - (*(ilow -1))->globalPosition().perp()) < step ) ) {
+  while (ilow != muonRecHits.begin() &&
+         (fabs((*ilow)->globalPosition().perp() - (*(ilow - 1))->globalPosition().perp()) < step)) {
     ilow--;
   }
 
   MuonTransientTrackingRecHit::MuonRecHitContainer result(ilow, ihigh);
 
   return result;
-
 }
 
 //
 // Get compatible dets
 //
 vector<const GeomDet*> MuonShowerInformationFiller::getCompatibleDets(const reco::Track& track) const {
-
   vector<const GeomDet*> total;
   total.reserve(1000);
 
-  LogTrace(category_)  << "Consider a track " << track.p() << " eta: " << track.eta() << " phi " << track.phi() << endl;
+  LogTrace(category_) << "Consider a track " << track.p() << " eta: " << track.eta() << " phi " << track.phi() << endl;
 
-
-  TrajectoryStateOnSurface innerTsos = trajectoryStateTransform::innerStateOnSurface(track, *theService->trackingGeometry(), &*theService->magneticField());
-  TrajectoryStateOnSurface outerTsos = trajectoryStateTransform::outerStateOnSurface(track, *theService->trackingGeometry(), &*theService->magneticField());
+  TrajectoryStateOnSurface innerTsos = trajectoryStateTransform::innerStateOnSurface(
+      track, *theService->trackingGeometry(), &*theService->magneticField());
+  TrajectoryStateOnSurface outerTsos = trajectoryStateTransform::outerStateOnSurface(
+      track, *theService->trackingGeometry(), &*theService->magneticField());
 
   GlobalPoint innerPos = innerTsos.globalPosition();
   GlobalPoint outerPos = outerTsos.globalPosition();
@@ -353,334 +341,354 @@ vector<const GeomDet*> MuonShowerInformationFiller::getCompatibleDets(const reco
   const vector<const DetLayer*>& dtlayers = theService->detLayerGeometry()->allDTLayers();
 
   for (auto iLayer = dtlayers.begin(); iLayer != dtlayers.end(); ++iLayer) {
-
     // crossing points of track with cylinder
     GlobalPoint xPoint = crossingPoint(innerPos, outerPos, dynamic_cast<const BarrelDetLayer*>(*iLayer));
 
     // check if point is inside the detector
-    if ((fabs(xPoint.y()) < 1000.0) && (fabs(xPoint.z()) < 1500 ) &&
-             (!(xPoint.y() == 0 && xPoint.x() == 0 && xPoint.z() == 0))) allCrossingPoints.push_back(xPoint);
+    if ((fabs(xPoint.y()) < 1000.0) && (fabs(xPoint.z()) < 1500) &&
+        (!(xPoint.y() == 0 && xPoint.x() == 0 && xPoint.z() == 0)))
+      allCrossingPoints.push_back(xPoint);
   }
 
-  stable_sort(allCrossingPoints.begin(), allCrossingPoints.end(), LessMag(innerPos) );
+  stable_sort(allCrossingPoints.begin(), allCrossingPoints.end(), LessMag(innerPos));
 
   vector<const GeomDet*> tempDT;
 
   for (vector<GlobalPoint>::const_iterator ipos = allCrossingPoints.begin(); ipos != allCrossingPoints.end(); ++ipos) {
-
     tempDT = dtPositionToDets(*ipos);
     vector<const GeomDet*>::const_iterator begin = tempDT.begin();
     vector<const GeomDet*>::const_iterator end = tempDT.end();
 
-    for (; begin!=end;++begin) {
+    for (; begin != end; ++begin) {
       total.push_back(*begin);
     }
-
   }
   allCrossingPoints.clear();
 
   const vector<const DetLayer*>& csclayers = theService->detLayerGeometry()->allCSCLayers();
   for (auto iLayer = csclayers.begin(); iLayer != csclayers.end(); ++iLayer) {
-
     GlobalPoint xPoint = crossingPoint(innerPos, outerPos, dynamic_cast<const ForwardDetLayer*>(*iLayer));
 
     // check if point is inside the detector
-    if ((fabs(xPoint.y()) < 1000.0) && (fabs(xPoint.z()) < 1500.0)
-           && (!(xPoint.y() == 0 && xPoint.x() == 0 && xPoint.z() == 0))) allCrossingPoints.push_back(xPoint);
-   }
-   stable_sort(allCrossingPoints.begin(), allCrossingPoints.end(), LessMag(innerPos) );
+    if ((fabs(xPoint.y()) < 1000.0) && (fabs(xPoint.z()) < 1500.0) &&
+        (!(xPoint.y() == 0 && xPoint.x() == 0 && xPoint.z() == 0)))
+      allCrossingPoints.push_back(xPoint);
+  }
+  stable_sort(allCrossingPoints.begin(), allCrossingPoints.end(), LessMag(innerPos));
 
-   vector<const GeomDet*> tempCSC;
-   for (vector<GlobalPoint>::const_iterator ipos = allCrossingPoints.begin(); ipos != allCrossingPoints.end(); ++ipos) {
+  vector<const GeomDet*> tempCSC;
+  for (vector<GlobalPoint>::const_iterator ipos = allCrossingPoints.begin(); ipos != allCrossingPoints.end(); ++ipos) {
+    tempCSC = cscPositionToDets(*ipos);
+    vector<const GeomDet*>::const_iterator begin = tempCSC.begin();
+    vector<const GeomDet*>::const_iterator end = tempCSC.end();
 
-     tempCSC = cscPositionToDets(*ipos);
-     vector<const GeomDet*>::const_iterator begin = tempCSC.begin();
-     vector<const GeomDet*>::const_iterator end = tempCSC.end();
-
-     for (; begin!=end;++begin) {
-       total.push_back(*begin);
-     }
-
+    for (; begin != end; ++begin) {
+      total.push_back(*begin);
+    }
   }
 
   return total;
-
 }
-
 
 //
 // Intersection point of track with barrel layer
 //
 GlobalPoint MuonShowerInformationFiller::crossingPoint(const GlobalPoint& p1,
-                                            const GlobalPoint& p2,
-                                            const BarrelDetLayer* dl) const {
-
+                                                       const GlobalPoint& p2,
+                                                       const BarrelDetLayer* dl) const {
   const BoundCylinder& bc = dl->specificSurface();
   return crossingPoint(p1, p2, bc);
-
 }
 
 GlobalPoint MuonShowerInformationFiller::crossingPoint(const GlobalPoint& p1,
-                                            const GlobalPoint& p2,
-                                            const Cylinder& cyl) const {
-
+                                                       const GlobalPoint& p2,
+                                                       const Cylinder& cyl) const {
   float radius = cyl.radius();
 
   GlobalVector dp = p1 - p2;
-  float slope = dp.x()/dp.y();
+  float slope = dp.x() / dp.y();
   float a = p1.x() - slope * p1.y();
 
   float n2 = (1 + slope * slope);
-  float n1 = 2*a*slope;
-  float n0 = a*a - radius*radius;
+  float n1 = 2 * a * slope;
+  float n0 = a * a - radius * radius;
 
   float y1 = 9999;
   float y2 = 9999;
-  if ( n1*n1 - 4*n2*n0 > 0 ) {
-    y1 = (-n1 + sqrt(n1*n1 - 4*n2*n0) ) / (2 * n2);
-    y2 = (-n1 - sqrt(n1*n1 - 4*n2*n0) ) / (2 * n2);
+  if (n1 * n1 - 4 * n2 * n0 > 0) {
+    y1 = (-n1 + sqrt(n1 * n1 - 4 * n2 * n0)) / (2 * n2);
+    y2 = (-n1 - sqrt(n1 * n1 - 4 * n2 * n0)) / (2 * n2);
   }
 
   float x1 = p1.x() + slope * (y1 - p1.y());
   float x2 = p1.x() + slope * (y2 - p1.y());
 
-  float slopeZ = dp.z()/dp.y();
+  float slopeZ = dp.z() / dp.y();
 
   float z1 = p1.z() + slopeZ * (y1 - p1.y());
   float z2 = p1.z() + slopeZ * (y2 - p1.y());
 
   // there are two crossing points, return the one that is in the same quadrant as point of extrapolation
-  if ((p2.x()*x1 > 0) && (y1*p2.y() > 0) && (z1*p2.z() > 0)) {
+  if ((p2.x() * x1 > 0) && (y1 * p2.y() > 0) && (z1 * p2.z() > 0)) {
     return GlobalPoint(x1, y1, z1);
   } else {
     return GlobalPoint(x2, y2, z2);
   }
-
 }
-
 
 //
 // Intersection point of track with a forward layer
 //
 GlobalPoint MuonShowerInformationFiller::crossingPoint(const GlobalPoint& p1,
-                                            const GlobalPoint& p2,
-                                            const ForwardDetLayer* dl) const {
-
+                                                       const GlobalPoint& p2,
+                                                       const ForwardDetLayer* dl) const {
   const BoundDisk& bc = dl->specificSurface();
   return crossingPoint(p1, p2, bc);
-
 }
 
 GlobalPoint MuonShowerInformationFiller::crossingPoint(const GlobalPoint& p1,
-                                            const GlobalPoint& p2,
-                                            const BoundDisk& disk) const {
-
+                                                       const GlobalPoint& p2,
+                                                       const BoundDisk& disk) const {
   float diskZ = disk.position().z();
-  int endcap =  diskZ > 0 ? 1 : (diskZ < 0 ? -1 : 0);
-  diskZ = diskZ + endcap*dynamic_cast<const SimpleDiskBounds&>(disk.bounds()).thickness()/2.;
+  int endcap = diskZ > 0 ? 1 : (diskZ < 0 ? -1 : 0);
+  diskZ = diskZ + endcap * dynamic_cast<const SimpleDiskBounds&>(disk.bounds()).thickness() / 2.;
 
   GlobalVector dp = p1 - p2;
 
-  float slopeZ = dp.z()/dp.y();
+  float slopeZ = dp.z() / dp.y();
   float y1 = diskZ / slopeZ;
 
-  float slopeX = dp.z()/dp.x();
+  float slopeX = dp.z() / dp.x();
   float x1 = diskZ / slopeX;
 
   float z1 = diskZ;
 
-  if (p2.z()*z1 > 0) {
+  if (p2.z() * z1 > 0) {
     return GlobalPoint(x1, y1, z1);
   } else {
     return GlobalPoint(0, 0, 0);
   }
-
 }
-
 
 //
 // GeomDets along the track in DT
 //
 vector<const GeomDet*> MuonShowerInformationFiller::dtPositionToDets(const GlobalPoint& gp) const {
+  int minwheel = -3;
+  int maxwheel = -3;
+  if (gp.z() < -680.0) {
+    minwheel = -3;
+    maxwheel = -3;
+  } else if (gp.z() < -396.0) {
+    minwheel = -2;
+    maxwheel = -1;
+  } else if (gp.z() < -126.8) {
+    minwheel = -2;
+    maxwheel = 0;
+  } else if (gp.z() < 126.8) {
+    minwheel = -1;
+    maxwheel = 1;
+  } else if (gp.z() < 396.0) {
+    minwheel = 0;
+    maxwheel = 2;
+  } else if (gp.z() < 680.0) {
+    minwheel = 1;
+    maxwheel = 2;
+  } else {
+    minwheel = 3;
+    maxwheel = 3;
+  }
 
-   int minwheel = -3;
-   int maxwheel = -3;
-   if ( gp.z() < -680.0 ) { minwheel = -3; maxwheel = -3;}
-   else if ( gp.z() < -396.0 ) { minwheel = -2; maxwheel = -1;}
-   else if (gp.z() < -126.8) { minwheel = -2; maxwheel = 0; }
-   else if (gp.z() < 126.8) { minwheel = -1; maxwheel = 1; }
-   else if (gp.z() < 396.0) { minwheel = 0; maxwheel = 2; }
-   else if (gp.z() < 680.0) { minwheel = 1; maxwheel = 2; }
-   else { minwheel = 3; maxwheel = 3; }
+  int station = 5;
+  if (gp.perp() > 680.0 && gp.perp() < 755.0)
+    station = 4;
+  else if (gp.perp() > 580.0)
+    station = 3;
+  else if (gp.perp() > 480.0)
+    station = 2;
+  else if (gp.perp() > 380.0)
+    station = 1;
+  else
+    station = 0;
 
-   int station = 5;
-   if ( gp.perp() > 680.0 && gp.perp() < 755.0 ) station = 4;
-   else if ( gp.perp() > 580.0 ) station = 3;
-   else if ( gp.perp() > 480.0 ) station = 2;
-   else if ( gp.perp() > 380.0 ) station = 1;
-   else station = 0;
+  vector<int> sectors;
 
-   vector<int> sectors;
+  float phistep = M_PI / 6;
 
-   float phistep = M_PI/6;
+  float phigp = (float)gp.barePhi();
 
-   float phigp = (float)gp.barePhi();
+  if (fabs(deltaPhi(phigp, 0 * phistep)) < phistep)
+    sectors.push_back(1);
+  if (fabs(deltaPhi(phigp, phistep)) < phistep)
+    sectors.push_back(2);
+  if (fabs(deltaPhi(phigp, 2 * phistep)) < phistep)
+    sectors.push_back(3);
+  if (fabs(deltaPhi(phigp, 3 * phistep)) < phistep) {
+    sectors.push_back(4);
+    if (station == 4)
+      sectors.push_back(13);
+  }
+  if (fabs(deltaPhi(phigp, 4 * phistep)) < phistep)
+    sectors.push_back(5);
+  if (fabs(deltaPhi(phigp, 5 * phistep)) < phistep)
+    sectors.push_back(6);
+  if (fabs(deltaPhi(phigp, 6 * phistep)) < phistep)
+    sectors.push_back(7);
+  if (fabs(deltaPhi(phigp, 7 * phistep)) < phistep)
+    sectors.push_back(8);
+  if (fabs(deltaPhi(phigp, 8 * phistep)) < phistep)
+    sectors.push_back(9);
+  if (fabs(deltaPhi(phigp, 9 * phistep)) < phistep) {
+    sectors.push_back(10);
+    if (station == 4)
+      sectors.push_back(14);
+  }
+  if (fabs(deltaPhi(phigp, 10 * phistep)) < phistep)
+    sectors.push_back(11);
+  if (fabs(deltaPhi(phigp, 11 * phistep)) < phistep)
+    sectors.push_back(12);
 
-   if ( fabs(deltaPhi(phigp, 0*phistep)) < phistep ) sectors.push_back(1);
-   if ( fabs(deltaPhi(phigp, phistep))   < phistep ) sectors.push_back(2);
-   if ( fabs(deltaPhi(phigp, 2*phistep)) < phistep ) sectors.push_back(3);
-   if ( fabs(deltaPhi(phigp, 3*phistep)) < phistep ) {
-       sectors.push_back(4);
-       if (station == 4) sectors.push_back(13);
-   }
-   if ( fabs(deltaPhi(phigp, 4*phistep)) < phistep ) sectors.push_back(5);
-   if ( fabs(deltaPhi(phigp, 5*phistep)) < phistep ) sectors.push_back(6);
-   if ( fabs(deltaPhi(phigp, 6*phistep)) < phistep ) sectors.push_back(7);
-   if ( fabs(deltaPhi(phigp, 7*phistep)) < phistep ) sectors.push_back(8);
-   if ( fabs(deltaPhi(phigp, 8*phistep)) < phistep ) sectors.push_back(9);
-   if ( fabs(deltaPhi(phigp, 9*phistep)) < phistep ) {
-       sectors.push_back(10);
-       if (station == 4) sectors.push_back(14);
-   }
-   if ( fabs(deltaPhi(phigp, 10*phistep)) < phistep ) sectors.push_back(11);
-   if ( fabs(deltaPhi(phigp, 11*phistep)) < phistep ) sectors.push_back(12);
+  LogTrace(category_) << "DT position to dets" << endl;
+  LogTrace(category_) << "number of sectors to consider: " << sectors.size() << endl;
+  LogTrace(category_) << "station: " << station << " wheels: " << minwheel << " " << maxwheel << endl;
 
-   LogTrace(category_) << "DT position to dets" << endl;
-   LogTrace(category_) << "number of sectors to consider: " << sectors.size() << endl;
-   LogTrace(category_) << "station: " << station << " wheels: " << minwheel << " " << maxwheel << endl;
+  vector<const GeomDet*> result;
+  if (station > 4 || station < 1)
+    return result;
+  if (minwheel > 2 || maxwheel < -2)
+    return result;
 
-   vector<const GeomDet*> result;
-   if (station > 4 || station < 1) return result;
-   if (minwheel > 2 || maxwheel < -2) return result;
+  for (vector<int>::const_iterator isector = sectors.begin(); isector != sectors.end(); ++isector) {
+    for (int iwheel = minwheel; iwheel != maxwheel + 1; ++iwheel) {
+      DTChamberId chamberid(iwheel, station, (*isector));
+      result.push_back(theService->trackingGeometry()->idToDet(chamberid));
+    }
+  }
 
-   for (vector<int>::const_iterator isector = sectors.begin(); isector != sectors.end(); ++isector ) {
-     for (int iwheel = minwheel; iwheel != maxwheel + 1; ++iwheel) {
-       DTChamberId chamberid(iwheel, station, (*isector));
-       result.push_back(theService->trackingGeometry()->idToDet(chamberid));
-     }
-   }
+  LogTrace(category_) << "number of GeomDets for this track: " << result.size() << endl;
 
-   LogTrace(category_) << "number of GeomDets for this track: " << result.size() << endl;
-
-   return result;
-
+  return result;
 }
-
 
 //
 // GeomDets along the track in CSC
 //
 vector<const GeomDet*> MuonShowerInformationFiller::cscPositionToDets(const GlobalPoint& gp) const {
-
   // determine the endcap side
   int endcap = 0;
-  if (gp.z() > 0) {endcap = 1;} else {endcap = 2;}
+  if (gp.z() > 0) {
+    endcap = 1;
+  } else {
+    endcap = 2;
+  }
 
   // determine the csc station and range of rings
   int station = 5;
 
   // check all rings in a station
-  if ( fabs(gp.z()) > 1000. && fabs(gp.z()) < 1055.0 ) {
+  if (fabs(gp.z()) > 1000. && fabs(gp.z()) < 1055.0) {
     station = 4;
-  }
-  else if ( fabs(gp.z()) > 910.0 && fabs(gp.z()) < 965.0) {
+  } else if (fabs(gp.z()) > 910.0 && fabs(gp.z()) < 965.0) {
     station = 3;
-  }
-  else if ( fabs(gp.z()) > 800.0 && fabs(gp.z()) < 860.0) {
+  } else if (fabs(gp.z()) > 800.0 && fabs(gp.z()) < 860.0) {
     station = 2;
-  }
-  else if ( fabs(gp.z()) > 570.0 && fabs(gp.z()) < 730.0) {
+  } else if (fabs(gp.z()) > 570.0 && fabs(gp.z()) < 730.0) {
     station = 1;
   }
 
   vector<int> sectors;
 
-  float phistep1 = M_PI/18.; //for all the rings except first rings for stations > 1
-  float phistep2 = M_PI/9.;
+  float phistep1 = M_PI / 18.;  //for all the rings except first rings for stations > 1
+  float phistep2 = M_PI / 9.;
   float phigp = (float)gp.barePhi();
 
   int ring = -1;
 
   // determine the ring
   if (station == 1) {
+    //FIX ME!!!
+    if (gp.perp() > 100 && gp.perp() < 270)
+      ring = 1;
+    else if (gp.perp() > 270 && gp.perp() < 450)
+      ring = 2;
+    else if (gp.perp() > 450 && gp.perp() < 695)
+      ring = 3;
+    else if (gp.perp() > 100 && gp.perp() < 270)
+      ring = 4;
 
-//FIX ME!!!
-      if (gp.perp() >  100 && gp.perp() < 270) ring = 1;
-      else if (gp.perp() > 270 && gp.perp() < 450) ring = 2;
-      else if (gp.perp() > 450 && gp.perp() < 695) ring = 3;
-      else if (gp.perp() > 100 && gp.perp() < 270) ring = 4;
+  } else if (station == 2) {
+    if (gp.perp() > 140 && gp.perp() < 350)
+      ring = 1;
+    else if (gp.perp() > 350 && gp.perp() < 700)
+      ring = 2;
 
-  }
-  else if (station == 2) {
+  } else if (station == 3) {
+    if (gp.perp() > 160 && gp.perp() < 350)
+      ring = 1;
+    else if (gp.perp() > 350 && gp.perp() < 700)
+      ring = 2;
 
-      if (gp.perp() > 140 && gp.perp() < 350) ring = 1;
-      else if (gp.perp() > 350 && gp.perp() < 700) ring = 2;
-
-  }
-  else if (station == 3) {
-
-      if (gp.perp() > 160 && gp.perp() < 350) ring = 1;
-      else if (gp.perp() > 350 && gp.perp() < 700) ring = 2;
-
-  }
-  else if (station == 4) {
-
-      if (gp.perp() > 175 && gp.perp() < 350) ring = 1;
-      else if (gp.perp() > 350 && gp.perp() < 700) ring = 2;
-
+  } else if (station == 4) {
+    if (gp.perp() > 175 && gp.perp() < 350)
+      ring = 1;
+    else if (gp.perp() > 350 && gp.perp() < 700)
+      ring = 2;
   }
 
   if (station > 1 && ring == 1) {
-
-   // we have 18 sectors in that case
-   for (int i = 0; i < 18; i++) {
-      if ( fabs(deltaPhi(phigp, i*phistep2)) < phistep2 ) sectors.push_back(i+1);
+    // we have 18 sectors in that case
+    for (int i = 0; i < 18; i++) {
+      if (fabs(deltaPhi(phigp, i * phistep2)) < phistep2)
+        sectors.push_back(i + 1);
     }
 
   } else {
+    // we have 36 sectors in that case
+    for (int i = 0; i < 36; i++) {
+      if (fabs(deltaPhi(phigp, i * phistep1)) < phistep1)
+        sectors.push_back(i + 1);
+    }
+  }
 
-   // we have 36 sectors in that case
-   for (int i = 0; i < 36; i++) {
-     if ( fabs(deltaPhi(phigp, i*phistep1)) < phistep1 ) sectors.push_back(i+1);
-   }
-}
+  LogTrace(category_) << "CSC position to dets" << endl;
+  LogTrace(category_) << "ring: " << ring << endl;
+  LogTrace(category_) << "endcap: " << endcap << endl;
+  LogTrace(category_) << "station: " << station << endl;
+  LogTrace(category_) << "CSC number of sectors to consider: " << sectors.size() << endl;
 
-   LogTrace(category_) << "CSC position to dets" << endl;
-   LogTrace(category_) << "ring: " << ring << endl;
-   LogTrace(category_) << "endcap: " << endcap << endl;
-   LogTrace(category_) << "station: " << station << endl;
-   LogTrace(category_) << "CSC number of sectors to consider: " << sectors.size() << endl;
+  // check exceptional cases
+  vector<const GeomDet*> result;
+  if (station > 4 || station < 1)
+    return result;
+  if (endcap == 0)
+    return result;
+  if (ring == -1)
+    return result;
 
+  int minlayer = 1;
+  int maxlayer = 6;
 
- // check exceptional cases
-   vector<const GeomDet*> result;
-   if (station > 4 || station < 1) return result;
-   if (endcap == 0) return result;
-   if (ring == -1) return result;
-
-   int minlayer = 1;
-   int maxlayer = 6;
-
-   for (vector<int>::const_iterator isector = sectors.begin(); isector != sectors.end(); ++isector) {
-     for (int ilayer = minlayer; ilayer != maxlayer + 1; ++ ilayer) {
-       CSCDetId cscid(endcap, station, ring, (*isector), ilayer);
-       result.push_back(theService->trackingGeometry()->idToDet(cscid));
-     }
-   }
+  for (vector<int>::const_iterator isector = sectors.begin(); isector != sectors.end(); ++isector) {
+    for (int ilayer = minlayer; ilayer != maxlayer + 1; ++ilayer) {
+      CSCDetId cscid(endcap, station, ring, (*isector), ilayer);
+      result.push_back(theService->trackingGeometry()->idToDet(cscid));
+    }
+  }
 
   return result;
-
 }
 
 //
 //Set class members
 //
 void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon& muon) {
-
   reco::TrackRef track;
-  if ( muon.isGlobalMuon() )            track = muon.globalTrack();
-  else if ( muon.isStandAloneMuon() )    track = muon.outerTrack();
-  else return;
+  if (muon.isGlobalMuon())
+    track = muon.globalTrack();
+  else if (muon.isStandAloneMuon())
+    track = muon.outerTrack();
+  else
+    return;
 
   // split 1D rechits by station
   vector<MuonRecHitContainer> muonRecHits(4);
@@ -696,125 +704,125 @@ void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon& muon) {
   bool dtOverlapToCheck = false;
   bool cscOverlapToCheck = false;
 
-  for (vector<const GeomDet*>::const_iterator igd = compatibleLayers.begin(); igd != compatibleLayers.end(); igd++ )  {
-
+  for (vector<const GeomDet*>::const_iterator igd = compatibleLayers.begin(); igd != compatibleLayers.end(); igd++) {
     // get det id
     DetId geoId = (*igd)->geographicalId();
 
     // skip tracker hits
-    if (geoId.det()!= DetId::Muon) continue;
+    if (geoId.det() != DetId::Muon)
+      continue;
 
     // DT
-    if ( geoId.subdetId() == MuonSubdetId::DT ) {
-
+    if (geoId.subdetId() == MuonSubdetId::DT) {
       // get station
       DTChamberId detid(geoId.rawId());
       int station = detid.station();
       int wheel = detid.wheel();
 
       // get rechits from segments per station
-      TransientTrackingRecHit::ConstRecHitContainer muonCorrelatedHitsTmp = hitsFromSegments(*igd, theDT4DRecSegments, theCSCSegments);
+      TransientTrackingRecHit::ConstRecHitContainer muonCorrelatedHitsTmp =
+          hitsFromSegments(*igd, theDT4DRecSegments, theCSCSegments);
       TransientTrackingRecHit::ConstRecHitContainer::const_iterator hits_begin = muonCorrelatedHitsTmp.begin();
       TransientTrackingRecHit::ConstRecHitContainer::const_iterator hits_end = muonCorrelatedHitsTmp.end();
 
-      for (; hits_begin!= hits_end;++hits_begin) {
-        muonCorrelatedHits.at(station-1).push_back(*hits_begin);
+      for (; hits_begin != hits_end; ++hits_begin) {
+        muonCorrelatedHits.at(station - 1).push_back(*hits_begin);
       }
 
       //check overlap certain wheels and stations
-      if (abs(wheel) == 2 && station != 4 &&  station != 1) dtOverlapToCheck = true;
+      if (abs(wheel) == 2 && station != 4 && station != 1)
+        dtOverlapToCheck = true;
 
       // loop over all superlayers of a DT chamber
-      for (int isuperlayer = DTChamberId::minSuperLayerId; isuperlayer != DTChamberId::maxSuperLayerId + 1; ++isuperlayer) {
+      for (int isuperlayer = DTChamberId::minSuperLayerId; isuperlayer != DTChamberId::maxSuperLayerId + 1;
+           ++isuperlayer) {
         // loop over all layers inside the superlayer
-        for (int ilayer = DTChamberId::minLayerId; ilayer != DTChamberId::maxLayerId+1; ++ilayer) {
+        for (int ilayer = DTChamberId::minLayerId; ilayer != DTChamberId::maxLayerId + 1; ++ilayer) {
           DTLayerId lid(detid, isuperlayer, ilayer);
           DTRecHitCollection::range dRecHits = theDTRecHits->get(lid);
-          for (DTRecHitCollection::const_iterator rechit = dRecHits.first; rechit != dRecHits.second;++rechit) {
+          for (DTRecHitCollection::const_iterator rechit = dRecHits.first; rechit != dRecHits.second; ++rechit) {
             vector<const TrackingRecHit*> subrechits = (*rechit).recHits();
-            for (vector<const TrackingRecHit*>::iterator irechit = subrechits.begin(); irechit != subrechits.end(); ++irechit) {
-                     muonRecHits.at(station-1).push_back(MuonTransientTrackingRecHit::specificBuild((&**igd),&**irechit));
-                }
-             }
+            for (vector<const TrackingRecHit*>::iterator irechit = subrechits.begin(); irechit != subrechits.end();
+                 ++irechit) {
+              muonRecHits.at(station - 1).push_back(MuonTransientTrackingRecHit::specificBuild((&**igd), &**irechit));
+            }
           }
-       }
-    }
-    else if (geoId.subdetId() == MuonSubdetId::CSC) {
-
+        }
+      }
+    } else if (geoId.subdetId() == MuonSubdetId::CSC) {
       // get station
       CSCDetId did(geoId.rawId());
       int station = did.station();
       int ring = did.ring();
 
       //get rechits from segments by station
-      TransientTrackingRecHit::ConstRecHitContainer muonCorrelatedHitsTmp = hitsFromSegments(*igd, theDT4DRecSegments, theCSCSegments);
+      TransientTrackingRecHit::ConstRecHitContainer muonCorrelatedHitsTmp =
+          hitsFromSegments(*igd, theDT4DRecSegments, theCSCSegments);
       TransientTrackingRecHit::ConstRecHitContainer::const_iterator hits_begin = muonCorrelatedHitsTmp.begin();
       TransientTrackingRecHit::ConstRecHitContainer::const_iterator hits_end = muonCorrelatedHitsTmp.end();
 
-      for (; hits_begin!= hits_end;++hits_begin) {
-        muonCorrelatedHits.at(station-1).push_back(*hits_begin);
+      for (; hits_begin != hits_end; ++hits_begin) {
+        muonCorrelatedHits.at(station - 1).push_back(*hits_begin);
       }
 
-      if ((station == 1 && ring == 3) && dtOverlapToCheck) cscOverlapToCheck = true;
+      if ((station == 1 && ring == 3) && dtOverlapToCheck)
+        cscOverlapToCheck = true;
 
       // split 1D rechits by station
       CSCRecHit2DCollection::range dRecHits = theCSCRecHits->get(did);
       for (CSCRecHit2DCollection::const_iterator rechit = dRecHits.first; rechit != dRecHits.second; ++rechit) {
-
         if (!cscOverlapToCheck) {
-           muonRecHits.at(station-1).push_back(MuonTransientTrackingRecHit::specificBuild((&**igd),&*rechit));
-           } else {
-             tmpCSC1.push_back(MuonTransientTrackingRecHit::specificBuild((&**igd),&*rechit));
+          muonRecHits.at(station - 1).push_back(MuonTransientTrackingRecHit::specificBuild((&**igd), &*rechit));
+        } else {
+          tmpCSC1.push_back(MuonTransientTrackingRecHit::specificBuild((&**igd), &*rechit));
 
-             //sort by perp, then insert to appropriate container
-             MuonRecHitContainer temp = findPerpCluster(tmpCSC1);
-             if (temp.empty()) continue;
+          //sort by perp, then insert to appropriate container
+          MuonRecHitContainer temp = findPerpCluster(tmpCSC1);
+          if (temp.empty())
+            continue;
 
-             float center;
-             if (temp.size() > 1) {
-               center = (temp.front()->globalPosition().perp() + temp.back()->globalPosition().perp())/2.;
-             } else {
-               center = temp.front()->globalPosition().perp();
-             }
-             temp.clear();
+          float center;
+          if (temp.size() > 1) {
+            center = (temp.front()->globalPosition().perp() + temp.back()->globalPosition().perp()) / 2.;
+          } else {
+            center = temp.front()->globalPosition().perp();
+          }
+          temp.clear();
 
-             if (center > 550.) {
-                muonRecHits.at(2).insert(muonRecHits.at(2).end(),tmpCSC1.begin(),tmpCSC1.end());
-              } else {
-              muonRecHits.at(1).insert(muonRecHits.at(1).end(),tmpCSC1.begin(),tmpCSC1.end());
-           }
-           tmpCSC1.clear();
-         }
-       }
-     } else if (geoId.subdetId() == MuonSubdetId::RPC) {
-       LogTrace(category_) << "Wrong subdet id" << endl;
-     }
-  }//loop over GeomDets compatible with a track
+          if (center > 550.) {
+            muonRecHits.at(2).insert(muonRecHits.at(2).end(), tmpCSC1.begin(), tmpCSC1.end());
+          } else {
+            muonRecHits.at(1).insert(muonRecHits.at(1).end(), tmpCSC1.begin(), tmpCSC1.end());
+          }
+          tmpCSC1.clear();
+        }
+      }
+    } else if (geoId.subdetId() == MuonSubdetId::RPC) {
+      LogTrace(category_) << "Wrong subdet id" << endl;
+    }
+  }  //loop over GeomDets compatible with a track
 
   // calculate number of all and correlated hits
   for (int stat = 0; stat < 4; stat++) {
     theCorrelatedStationHits[stat] = muonCorrelatedHits.at(stat).size();
     theAllStationHits[stat] = muonRecHits[stat].size();
   }
-  LogTrace(category_) << "Hits used by the segments, by station "
-       << theCorrelatedStationHits.at(0) << " "
-       << theCorrelatedStationHits.at(1) << " "
-       << theCorrelatedStationHits.at(2) << " "
-       << theCorrelatedStationHits.at(3) << endl;
+  LogTrace(category_) << "Hits used by the segments, by station " << theCorrelatedStationHits.at(0) << " "
+                      << theCorrelatedStationHits.at(1) << " " << theCorrelatedStationHits.at(2) << " "
+                      << theCorrelatedStationHits.at(3) << endl;
 
-  LogTrace(category_) << "All DT 1D/CSC 2D  hits, by station "
-       << theAllStationHits.at(0) << " "
-       << theAllStationHits.at(1) << " "
-       << theAllStationHits.at(2) << " "
-       << theAllStationHits.at(3) << endl;
+  LogTrace(category_) << "All DT 1D/CSC 2D  hits, by station " << theAllStationHits.at(0) << " "
+                      << theAllStationHits.at(1) << " " << theAllStationHits.at(2) << " " << theAllStationHits.at(3)
+                      << endl;
 
   //station shower sizes
   MuonTransientTrackingRecHit::MuonRecHitContainer muonRecHitsPhiBest;
   TransientTrackingRecHit::ConstRecHitContainer muonRecHitsThetaTemp, muonRecHitsThetaBest;
   // send station hits to the clustering algorithm
-  for ( int stat = 0; stat != 4; stat++ ) {
+  for (int stat = 0; stat != 4; stat++) {
     const size_t nhit = muonRecHits[stat].size();
-    if (nhit < 2) continue; // Require at least 2 hits
+    if (nhit < 2)
+      continue;  // Require at least 2 hits
     muonRecHitsPhiBest.clear();
     muonRecHitsPhiBest.reserve(nhit);
 
@@ -824,117 +832,119 @@ void MuonShowerInformationFiller::fillHitsByStation(const reco::Muon& muon) {
 
     // Search for gaps (complexity = N)
     std::vector<size_t> clUppers;
-    for ( size_t ihit = 0; ihit < nhit; ++ihit ) {
-      const size_t jhit = (ihit+1)%nhit;
+    for (size_t ihit = 0; ihit < nhit; ++ihit) {
+      const size_t jhit = (ihit + 1) % nhit;
       const double phi1 = muonRecHits[stat].at(ihit)->globalPosition().barePhi();
       const double phi2 = muonRecHits[stat].at(jhit)->globalPosition().barePhi();
 
       const double dphi = std::abs(deltaPhi(phi1, phi2));
-      if ( dphi >= 0.05 ) clUppers.push_back(ihit);
+      if (dphi >= 0.05)
+        clUppers.push_back(ihit);
     }
 
     //station shower sizes
     double dphimax = 0;
-    if ( clUppers.empty() ) {
+    if (clUppers.empty()) {
       // No gaps - there is only one cluster. Take all of them
       const double refPhi = muonRecHits[stat].at(0)->globalPosition().barePhi();
       double dphilo = 0, dphihi = 0;
-      for ( auto& hit : muonRecHits[stat] ) {
+      for (auto& hit : muonRecHits[stat]) {
         muonRecHitsPhiBest.push_back(hit);
         const double phi = hit->globalPosition().barePhi();
         dphilo = std::min(dphilo, deltaPhi(refPhi, phi));
         dphihi = std::max(dphihi, deltaPhi(refPhi, phi));
       }
-      dphimax = std::abs(dphihi+dphilo);
+      dphimax = std::abs(dphihi + dphilo);
     } else {
       // Loop over gaps to find the one with maximum dphi(begin, end)
       // By construction, number of gap must be greater than 1.
       size_t bestUpper = 0, bestLower = 0;
-      for ( auto icl = clUppers.begin(); icl != clUppers.end(); ++icl ) {
+      for (auto icl = clUppers.begin(); icl != clUppers.end(); ++icl) {
         // upper bound of this cluster
         const size_t upper = *icl;
         // lower bound is +1 of preceeding upper bound
         const auto prevCl = (icl == clUppers.begin()) ? clUppers.end() : icl;
-        const size_t lower = (*(prevCl-1)+1)%nhit;
+        const size_t lower = (*(prevCl - 1) + 1) % nhit;
 
         // At least two hit for a cluster
-        if ( upper == lower ) continue;
+        if (upper == lower)
+          continue;
 
         const double phi1 = muonRecHits[stat].at(upper)->globalPosition().barePhi();
         const double phi2 = muonRecHits[stat].at(lower)->globalPosition().barePhi();
 
         const double dphi = std::abs(deltaPhi(phi1, phi2));
-        if ( dphimax < dphi ) {
+        if (dphimax < dphi) {
           dphimax = dphi;
           bestUpper = upper;
           bestLower = lower;
         }
       }
 
-      if ( bestUpper > bestLower ) {
-        muonRecHitsPhiBest.reserve(bestUpper-bestLower+1);
-        std::copy(muonRecHits[stat].begin()+bestLower,
-                  muonRecHits[stat].begin()+bestUpper+1,
+      if (bestUpper > bestLower) {
+        muonRecHitsPhiBest.reserve(bestUpper - bestLower + 1);
+        std::copy(muonRecHits[stat].begin() + bestLower,
+                  muonRecHits[stat].begin() + bestUpper + 1,
                   std::back_inserter(muonRecHitsPhiBest));
-      } else if ( bestUpper < bestLower ) {
-        muonRecHitsPhiBest.reserve(bestUpper+(nhit-bestLower)+1);
+      } else if (bestUpper < bestLower) {
+        muonRecHitsPhiBest.reserve(bestUpper + (nhit - bestLower) + 1);
         std::copy(muonRecHits[stat].begin(),
-                  muonRecHits[stat].begin()+bestUpper+1,
+                  muonRecHits[stat].begin() + bestUpper + 1,
                   std::back_inserter(muonRecHitsPhiBest));
-        std::copy(muonRecHits[stat].begin()+bestLower,
-                  muonRecHits[stat].end(),
-                  std::back_inserter(muonRecHitsPhiBest));
+        std::copy(
+            muonRecHits[stat].begin() + bestLower, muonRecHits[stat].end(), std::back_inserter(muonRecHitsPhiBest));
       }
     }
 
-     //fill showerTs
-      if (!muonRecHitsPhiBest.empty()) {
-        muonRecHits[stat] = muonRecHitsPhiBest;
-        stable_sort(muonRecHits[stat].begin(), muonRecHits[stat].end(), LessAbsMag());
-        muonRecHits[stat].front();
-        GlobalPoint refpoint = muonRecHits[stat].front()->globalPosition();
-        theStationShowerTSize.at(stat) = refpoint.mag() * dphimax;
-      }
+    //fill showerTs
+    if (!muonRecHitsPhiBest.empty()) {
+      muonRecHits[stat] = muonRecHitsPhiBest;
+      stable_sort(muonRecHits[stat].begin(), muonRecHits[stat].end(), LessAbsMag());
+      muonRecHits[stat].front();
+      GlobalPoint refpoint = muonRecHits[stat].front()->globalPosition();
+      theStationShowerTSize.at(stat) = refpoint.mag() * dphimax;
+    }
 
-     //for theta
-     if (!muonCorrelatedHits.at(stat).empty()) {
+    //for theta
+    if (!muonCorrelatedHits.at(stat).empty()) {
+      float dthetamax = 0;
+      for (TransientTrackingRecHit::ConstRecHitContainer::const_iterator iseed = muonCorrelatedHits.at(stat).begin();
+           iseed != muonCorrelatedHits.at(stat).end();
+           ++iseed) {
+        if (!(*iseed)->isValid())
+          continue;
+        GlobalPoint refpoint = (*iseed)->globalPosition();  //starting from the one with smallest value of phi
+        muonRecHitsThetaTemp.clear();
+        muonRecHitsThetaTemp = findThetaCluster(muonCorrelatedHits.at(stat), refpoint);
+        if (muonRecHitsThetaTemp.size() > 1) {
+          float dtheta = fabs((float)muonRecHitsThetaTemp.back()->globalPosition().theta() -
+                              (float)muonRecHitsThetaTemp.front()->globalPosition().theta());
+          if (dtheta > dthetamax) {
+            dthetamax = dtheta;
+            muonRecHitsThetaBest = muonRecHitsThetaTemp;
+          }
+        }  //at least two hits
+      }    //loop over seeds
+    }      //not empty container2
 
-       float dthetamax = 0;
-       for (TransientTrackingRecHit::ConstRecHitContainer::const_iterator iseed = muonCorrelatedHits.at(stat).begin(); iseed != muonCorrelatedHits.at(stat).end(); ++iseed) {
-           if (!(*iseed)->isValid()) continue;
-           GlobalPoint refpoint = (*iseed)->globalPosition(); //starting from the one with smallest value of phi
-           muonRecHitsThetaTemp.clear();
-           muonRecHitsThetaTemp = findThetaCluster(muonCorrelatedHits.at(stat), refpoint);
-	   if (muonRecHitsThetaTemp.size() > 1) {
-	     float dtheta = fabs((float)muonRecHitsThetaTemp.back()->globalPosition().theta() - (float)muonRecHitsThetaTemp.front()->globalPosition().theta());
-	     if (dtheta > dthetamax) {
-	       dthetamax = dtheta;
-	       muonRecHitsThetaBest = muonRecHitsThetaTemp;
-	     }
-	   } //at least two hits
-       }//loop over seeds
-     }//not empty container2
+    //fill deltaRs
+    if (muonRecHitsThetaBest.size() > 1 && muonRecHitsPhiBest.size() > 1)
+      theStationShowerDeltaR.at(stat) = sqrt(pow(deltaPhi(muonRecHitsPhiBest.front()->globalPosition().barePhi(),
+                                                          muonRecHitsPhiBest.back()->globalPosition().barePhi()),
+                                                 2) +
+                                             pow(muonRecHitsThetaBest.front()->globalPosition().theta() -
+                                                     muonRecHitsThetaBest.back()->globalPosition().theta(),
+                                                 2));
 
-     //fill deltaRs
-     if (muonRecHitsThetaBest.size() > 1 && muonRecHitsPhiBest.size() > 1)
-       theStationShowerDeltaR.at(stat) = sqrt(pow(deltaPhi(muonRecHitsPhiBest.front()->globalPosition().barePhi(),muonRecHitsPhiBest.back()->globalPosition().barePhi()),2)+pow(muonRecHitsThetaBest.front()->globalPosition().theta()-muonRecHitsThetaBest.back()->globalPosition().theta(),2));
+  }  //loop over station
 
-      }//loop over station
+  LogTrace(category_) << "deltaR around a track containing all the station hits, by station "
+                      << theStationShowerDeltaR.at(0) << " " << theStationShowerDeltaR.at(1) << " "
+                      << theStationShowerDeltaR.at(2) << " " << theStationShowerDeltaR.at(3) << endl;
 
-       LogTrace(category_) << "deltaR around a track containing all the station hits, by station "
-       << theStationShowerDeltaR.at(0) << " "
-       << theStationShowerDeltaR.at(1) << " "
-       << theStationShowerDeltaR.at(2) << " "
-       << theStationShowerDeltaR.at(3) << endl;
-
-
-       LogTrace(category_) << "Transverse cluster size, by station "
-       << theStationShowerTSize.at(0) << " "
-       << theStationShowerTSize.at(1) << " "
-       << theStationShowerTSize.at(2) << " "
-       << theStationShowerTSize.at(3) << endl;
+  LogTrace(category_) << "Transverse cluster size, by station " << theStationShowerTSize.at(0) << " "
+                      << theStationShowerTSize.at(1) << " " << theStationShowerTSize.at(2) << " "
+                      << theStationShowerTSize.at(3) << endl;
 
   return;
-
 }
-

--- a/RecoMuon/MuonIdentification/src/MuonTimingFiller.cc
+++ b/RecoMuon/MuonIdentification/src/MuonTimingFiller.cc
@@ -1,7 +1,7 @@
 //
 // Package:    MuonTimingFiller
 // Class:      MuonTimingFiller
-// 
+//
 /**\class MuonTimingFiller MuonTimingFiller.cc RecoMuon/MuonIdentification/src/MuonTimingFiller.cc
 
  Description: <one line class summary>
@@ -15,7 +15,6 @@
 //
 //
 
-
 // system include files
 #include <memory>
 
@@ -28,8 +27,8 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "DataFormats/MuonReco/interface/Muon.h" 
-#include "DataFormats/MuonReco/interface/MuonFwd.h" 
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/MuonTimeExtra.h"
 #include "DataFormats/MuonReco/interface/MuonTimeExtraMap.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
@@ -41,146 +40,142 @@
 //
 // constructors and destructor
 //
-MuonTimingFiller::MuonTimingFiller(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC)
-{
-   // Load parameters for the DTTimingExtractor
-   edm::ParameterSet dtTimingParameters = iConfig.getParameter<edm::ParameterSet>("DTTimingParameters");
+MuonTimingFiller::MuonTimingFiller(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC) {
+  // Load parameters for the DTTimingExtractor
+  edm::ParameterSet dtTimingParameters = iConfig.getParameter<edm::ParameterSet>("DTTimingParameters");
 
-   // Load parameters for the CSCTimingExtractor
-   edm::ParameterSet cscTimingParameters = iConfig.getParameter<edm::ParameterSet>("CSCTimingParameters");
+  // Load parameters for the CSCTimingExtractor
+  edm::ParameterSet cscTimingParameters = iConfig.getParameter<edm::ParameterSet>("CSCTimingParameters");
 
-   // Fallback mechanism for old configs (there the segment matcher was built inside the timing extractors)
-   edm::ParameterSet matchParameters;
-   if (iConfig.existsAs<edm::ParameterSet>("MatchParameters")) 
-       matchParameters = iConfig.getParameter<edm::ParameterSet>("MatchParameters");
-     else 
-       matchParameters = dtTimingParameters.getParameter<edm::ParameterSet>("MatchParameters");
-   
-   theMatcher_ = std::make_unique<MuonSegmentMatcher>(matchParameters, iC);
-   theDTTimingExtractor_ = std::make_unique<DTTimingExtractor>(dtTimingParameters,theMatcher_.get());
-   theCSCTimingExtractor_ = std::make_unique<CSCTimingExtractor>(cscTimingParameters,theMatcher_.get());
-   
-   errorEB_ = iConfig.getParameter<double>("ErrorEB");
-   errorEE_ = iConfig.getParameter<double>("ErrorEE");
-   ecalEcut_ = iConfig.getParameter<double>("EcalEnergyCut");
-   
-   useDT_ = iConfig.getParameter<bool>("UseDT");
-   useCSC_ = iConfig.getParameter<bool>("UseCSC");
-   useECAL_ = iConfig.getParameter<bool>("UseECAL");
-   
+  // Fallback mechanism for old configs (there the segment matcher was built inside the timing extractors)
+  edm::ParameterSet matchParameters;
+  if (iConfig.existsAs<edm::ParameterSet>("MatchParameters"))
+    matchParameters = iConfig.getParameter<edm::ParameterSet>("MatchParameters");
+  else
+    matchParameters = dtTimingParameters.getParameter<edm::ParameterSet>("MatchParameters");
+
+  theMatcher_ = std::make_unique<MuonSegmentMatcher>(matchParameters, iC);
+  theDTTimingExtractor_ = std::make_unique<DTTimingExtractor>(dtTimingParameters, theMatcher_.get());
+  theCSCTimingExtractor_ = std::make_unique<CSCTimingExtractor>(cscTimingParameters, theMatcher_.get());
+
+  errorEB_ = iConfig.getParameter<double>("ErrorEB");
+  errorEE_ = iConfig.getParameter<double>("ErrorEE");
+  ecalEcut_ = iConfig.getParameter<double>("EcalEnergyCut");
+
+  useDT_ = iConfig.getParameter<bool>("UseDT");
+  useCSC_ = iConfig.getParameter<bool>("UseCSC");
+  useECAL_ = iConfig.getParameter<bool>("UseECAL");
 }
 
-
-MuonTimingFiller::~MuonTimingFiller()
-{
-}
-
+MuonTimingFiller::~MuonTimingFiller() {}
 
 //
 // member functions
 //
 
-void 
-MuonTimingFiller::fillTiming( const reco::Muon& muon, 
-                              reco::MuonTimeExtra& dtTime, 
-                              reco::MuonTimeExtra& cscTime, 
-                              reco::MuonTime& rpcTime, 
-                              reco::MuonTimeExtra& combinedTime, 
-                              edm::Event& iEvent, 
-                              const edm::EventSetup& iSetup )
-{
-  TimeMeasurementSequence dtTmSeq,cscTmSeq;
-     
-  if ( !(muon.combinedMuon().isNull()) ) {
+void MuonTimingFiller::fillTiming(const reco::Muon& muon,
+                                  reco::MuonTimeExtra& dtTime,
+                                  reco::MuonTimeExtra& cscTime,
+                                  reco::MuonTime& rpcTime,
+                                  reco::MuonTimeExtra& combinedTime,
+                                  edm::Event& iEvent,
+                                  const edm::EventSetup& iSetup) {
+  TimeMeasurementSequence dtTmSeq, cscTmSeq;
+
+  if (!(muon.combinedMuon().isNull())) {
     theDTTimingExtractor_->fillTiming(dtTmSeq, muon.combinedMuon(), iEvent, iSetup);
     theCSCTimingExtractor_->fillTiming(cscTmSeq, muon.combinedMuon(), iEvent, iSetup);
   } else {
-    if ( !(muon.standAloneMuon().isNull()) ) {
+    if (!(muon.standAloneMuon().isNull())) {
       theDTTimingExtractor_->fillTiming(dtTmSeq, muon.standAloneMuon(), iEvent, iSetup);
       theCSCTimingExtractor_->fillTiming(cscTmSeq, muon.standAloneMuon(), iEvent, iSetup);
     } else {
-      if ( muon.isTrackerMuon() ) {
-	std::vector<const DTRecSegment4D*> dtSegments;
-	std::vector<const CSCSegment*> cscSegments;
-	for( auto& chamber: muon.matches() ){
-	  for ( auto& segment : chamber.segmentMatches ){
-	    // Use only the segments that passed arbitration to avoid mixing
-	    // segments from in-time and out-of-time muons that may bias the result
-	    // SegmentAndTrackArbitration
-            if(segment.isMask(reco::MuonSegmentMatch::BestInStationByDR) &&
-	       segment.isMask(reco::MuonSegmentMatch::BelongsToTrackByDR)){
-	      if ( !(segment.dtSegmentRef.isNull()))
-		dtSegments.push_back(segment.dtSegmentRef.get());
-	      if ( !(segment.cscSegmentRef.isNull()))
-		cscSegments.push_back(segment.cscSegmentRef.get());
-	    }
-	  }
-	}
-	theDTTimingExtractor_->fillTiming(dtTmSeq, dtSegments, muon.innerTrack(), iEvent, iSetup);
-	theCSCTimingExtractor_->fillTiming(cscTmSeq, cscSegments, muon.innerTrack(), iEvent, iSetup);
+      if (muon.isTrackerMuon()) {
+        std::vector<const DTRecSegment4D*> dtSegments;
+        std::vector<const CSCSegment*> cscSegments;
+        for (auto& chamber : muon.matches()) {
+          for (auto& segment : chamber.segmentMatches) {
+            // Use only the segments that passed arbitration to avoid mixing
+            // segments from in-time and out-of-time muons that may bias the result
+            // SegmentAndTrackArbitration
+            if (segment.isMask(reco::MuonSegmentMatch::BestInStationByDR) &&
+                segment.isMask(reco::MuonSegmentMatch::BelongsToTrackByDR)) {
+              if (!(segment.dtSegmentRef.isNull()))
+                dtSegments.push_back(segment.dtSegmentRef.get());
+              if (!(segment.cscSegmentRef.isNull()))
+                cscSegments.push_back(segment.cscSegmentRef.get());
+            }
+          }
+        }
+        theDTTimingExtractor_->fillTiming(dtTmSeq, dtSegments, muon.innerTrack(), iEvent, iSetup);
+        theCSCTimingExtractor_->fillTiming(cscTmSeq, cscSegments, muon.innerTrack(), iEvent, iSetup);
       }
     }
   }
-  
-  // Fill DT-specific timing information block     
+
+  // Fill DT-specific timing information block
   fillTimeFromMeasurements(dtTmSeq, dtTime);
 
-  // Fill CSC-specific timing information block     
+  // Fill CSC-specific timing information block
   fillTimeFromMeasurements(cscTmSeq, cscTime);
 
-  // Fill RPC-specific timing information block     
+  // Fill RPC-specific timing information block
   fillRPCTime(muon, rpcTime, iEvent);
-       
+
   // Combine the TimeMeasurementSequences from DT/CSC subdetectors
   TimeMeasurementSequence combinedTmSeq;
-  combineTMSequences(muon,dtTmSeq,cscTmSeq,combinedTmSeq);
+  combineTMSequences(muon, dtTmSeq, cscTmSeq, combinedTmSeq);
   // add ECAL info
-  if (useECAL_) addEcalTime(muon,combinedTmSeq);
+  if (useECAL_)
+    addEcalTime(muon, combinedTmSeq);
 
   // Fill the master timing block
   fillTimeFromMeasurements(combinedTmSeq, combinedTime);
-    
-  LogTrace("MuonTime") << "Global 1/beta: " << combinedTime.inverseBeta() << " +/- " << combinedTime.inverseBetaErr()<<std::endl;
-  LogTrace("MuonTime") << "  Free 1/beta: " << combinedTime.freeInverseBeta() << " +/- " << combinedTime.freeInverseBetaErr()<<std::endl;
-  LogTrace("MuonTime") << "  Vertex time (in-out): " << combinedTime.timeAtIpInOut() << " +/- " << combinedTime.timeAtIpInOutErr()
-                       << "  # of points: " << combinedTime.nDof() <<std::endl;
-  LogTrace("MuonTime") << "  Vertex time (out-in): " << combinedTime.timeAtIpOutIn() << " +/- " << combinedTime.timeAtIpOutInErr()<<std::endl;
-  LogTrace("MuonTime") << "  direction: "   << combinedTime.direction() << std::endl;
-     
+
+  LogTrace("MuonTime") << "Global 1/beta: " << combinedTime.inverseBeta() << " +/- " << combinedTime.inverseBetaErr()
+                       << std::endl;
+  LogTrace("MuonTime") << "  Free 1/beta: " << combinedTime.freeInverseBeta() << " +/- "
+                       << combinedTime.freeInverseBetaErr() << std::endl;
+  LogTrace("MuonTime") << "  Vertex time (in-out): " << combinedTime.timeAtIpInOut() << " +/- "
+                       << combinedTime.timeAtIpInOutErr() << "  # of points: " << combinedTime.nDof() << std::endl;
+  LogTrace("MuonTime") << "  Vertex time (out-in): " << combinedTime.timeAtIpOutIn() << " +/- "
+                       << combinedTime.timeAtIpOutInErr() << std::endl;
+  LogTrace("MuonTime") << "  direction: " << combinedTime.direction() << std::endl;
 }
 
-
-void 
-MuonTimingFiller::fillTimeFromMeasurements( const TimeMeasurementSequence& tmSeq, reco::MuonTimeExtra &muTime ) {
-  std::vector <double> x,y;
+void MuonTimingFiller::fillTimeFromMeasurements(const TimeMeasurementSequence& tmSeq, reco::MuonTimeExtra& muTime) {
+  std::vector<double> x, y;
   double invbeta(0), invbetaerr(0);
-  double vertexTime(0), vertexTimeErr(0), vertexTimeR(0), vertexTimeRErr(0);    
+  double vertexTime(0), vertexTimeErr(0), vertexTimeR(0), vertexTimeRErr(0);
   double freeBeta(0), freeBetaErr(0), freeTime(0), freeTimeErr(0);
 
-  if (tmSeq.dstnc.size()<=1) return;
+  if (tmSeq.dstnc.size() <= 1)
+    return;
 
-  for (unsigned int i=0;i<tmSeq.dstnc.size();i++) {
-    invbeta+=(1.+tmSeq.local_t0.at(i)/tmSeq.dstnc.at(i)*30.)*tmSeq.weightInvbeta.at(i)/tmSeq.totalWeightInvbeta;
-    x.push_back(tmSeq.dstnc.at(i)/30.);
-    y.push_back(tmSeq.local_t0.at(i)+tmSeq.dstnc.at(i)/30.);
-    vertexTime+=tmSeq.local_t0.at(i)*tmSeq.weightTimeVtx.at(i)/tmSeq.totalWeightTimeVtx;
-    vertexTimeR+=(tmSeq.local_t0.at(i)+2*tmSeq.dstnc.at(i)/30.)*tmSeq.weightTimeVtx.at(i)/tmSeq.totalWeightTimeVtx;
+  for (unsigned int i = 0; i < tmSeq.dstnc.size(); i++) {
+    invbeta +=
+        (1. + tmSeq.local_t0.at(i) / tmSeq.dstnc.at(i) * 30.) * tmSeq.weightInvbeta.at(i) / tmSeq.totalWeightInvbeta;
+    x.push_back(tmSeq.dstnc.at(i) / 30.);
+    y.push_back(tmSeq.local_t0.at(i) + tmSeq.dstnc.at(i) / 30.);
+    vertexTime += tmSeq.local_t0.at(i) * tmSeq.weightTimeVtx.at(i) / tmSeq.totalWeightTimeVtx;
+    vertexTimeR +=
+        (tmSeq.local_t0.at(i) + 2 * tmSeq.dstnc.at(i) / 30.) * tmSeq.weightTimeVtx.at(i) / tmSeq.totalWeightTimeVtx;
   }
 
   double diff;
-  for (unsigned int i=0;i<tmSeq.dstnc.size();i++) {
-    diff=(1.+tmSeq.local_t0.at(i)/tmSeq.dstnc.at(i)*30.)-invbeta;
-    invbetaerr+=diff*diff*tmSeq.weightInvbeta.at(i);
-    diff=tmSeq.local_t0.at(i)-vertexTime;
-    vertexTimeErr+=diff*diff*tmSeq.weightTimeVtx.at(i);
-    diff=tmSeq.local_t0.at(i)+2*tmSeq.dstnc.at(i)/30.-vertexTimeR;
-    vertexTimeRErr+=diff*diff*tmSeq.weightTimeVtx.at(i);
+  for (unsigned int i = 0; i < tmSeq.dstnc.size(); i++) {
+    diff = (1. + tmSeq.local_t0.at(i) / tmSeq.dstnc.at(i) * 30.) - invbeta;
+    invbetaerr += diff * diff * tmSeq.weightInvbeta.at(i);
+    diff = tmSeq.local_t0.at(i) - vertexTime;
+    vertexTimeErr += diff * diff * tmSeq.weightTimeVtx.at(i);
+    diff = tmSeq.local_t0.at(i) + 2 * tmSeq.dstnc.at(i) / 30. - vertexTimeR;
+    vertexTimeRErr += diff * diff * tmSeq.weightTimeVtx.at(i);
   }
-  
-  double cf = 1./(tmSeq.dstnc.size()-1);
-  invbetaerr=sqrt(invbetaerr/tmSeq.totalWeightInvbeta*cf);
-  vertexTimeErr=sqrt(vertexTimeErr/tmSeq.totalWeightTimeVtx*cf);
-  vertexTimeRErr=sqrt(vertexTimeRErr/tmSeq.totalWeightTimeVtx*cf);
+
+  double cf = 1. / (tmSeq.dstnc.size() - 1);
+  invbetaerr = sqrt(invbetaerr / tmSeq.totalWeightInvbeta * cf);
+  vertexTimeErr = sqrt(vertexTimeErr / tmSeq.totalWeightTimeVtx * cf);
+  vertexTimeRErr = sqrt(vertexTimeRErr / tmSeq.totalWeightTimeVtx * cf);
 
   muTime.setInverseBeta(invbeta);
   muTime.setInverseBetaErr(invbetaerr);
@@ -188,139 +183,135 @@ MuonTimingFiller::fillTimeFromMeasurements( const TimeMeasurementSequence& tmSeq
   muTime.setTimeAtIpInOutErr(vertexTimeErr);
   muTime.setTimeAtIpOutIn(vertexTimeR);
   muTime.setTimeAtIpOutInErr(vertexTimeRErr);
-      
+
   rawFit(freeBeta, freeBetaErr, freeTime, freeTimeErr, x, y);
 
   muTime.setFreeInverseBeta(freeBeta);
   muTime.setFreeInverseBetaErr(freeBetaErr);
-    
+
   muTime.setNDof(tmSeq.dstnc.size());
 }
 
-
-void 
-MuonTimingFiller::fillRPCTime( const reco::Muon& muon, reco::MuonTime &rpcTime, edm::Event& iEvent ) {
-
-  double trpc=0,trpc2=0;
+void MuonTimingFiller::fillRPCTime(const reco::Muon& muon, reco::MuonTime& rpcTime, edm::Event& iEvent) {
+  double trpc = 0, trpc2 = 0;
 
   reco::TrackRef staTrack = muon.standAloneMuon();
-  if (staTrack.isNull()) return;
+  if (staTrack.isNull())
+    return;
 
-  const std::vector<const RPCRecHit*> rpcHits = theMatcher_->matchRPC(*staTrack,iEvent);
+  const std::vector<const RPCRecHit*> rpcHits = theMatcher_->matchRPC(*staTrack, iEvent);
   const int nrpc = rpcHits.size();
-  for ( const auto& hitRPC : rpcHits ) {
-    const double time = hitRPC->timeError() < 0 ? hitRPC->BunchX()*25. : hitRPC->time();
+  for (const auto& hitRPC : rpcHits) {
+    const double time = hitRPC->timeError() < 0 ? hitRPC->BunchX() * 25. : hitRPC->time();
     trpc += time;
-    trpc2 += time*time;
+    trpc2 += time * time;
   }
 
-  if (nrpc==0) return;
-  
-  trpc2 = trpc2/nrpc;
-  trpc = trpc/nrpc;
-  const double trpcerr = sqrt(std::max(0., trpc2-trpc*trpc));
+  if (nrpc == 0)
+    return;
 
-  rpcTime.timeAtIpInOut=trpc;
-  rpcTime.timeAtIpInOutErr=trpcerr;
-  rpcTime.nDof=nrpc;
+  trpc2 = trpc2 / nrpc;
+  trpc = trpc / nrpc;
+  const double trpcerr = sqrt(std::max(0., trpc2 - trpc * trpc));
+
+  rpcTime.timeAtIpInOut = trpc;
+  rpcTime.timeAtIpInOutErr = trpcerr;
+  rpcTime.nDof = nrpc;
 
   // currently unused
-  rpcTime.timeAtIpOutIn=0.;
-  rpcTime.timeAtIpOutInErr=0.;
+  rpcTime.timeAtIpOutIn = 0.;
+  rpcTime.timeAtIpOutInErr = 0.;
 }
 
+void MuonTimingFiller::combineTMSequences(const reco::Muon& muon,
+                                          const TimeMeasurementSequence& dtSeq,
+                                          const TimeMeasurementSequence& cscSeq,
+                                          TimeMeasurementSequence& cmbSeq) {
+  if (useDT_)
+    for (unsigned int i = 0; i < dtSeq.dstnc.size(); i++) {
+      cmbSeq.dstnc.push_back(dtSeq.dstnc.at(i));
+      cmbSeq.local_t0.push_back(dtSeq.local_t0.at(i));
+      cmbSeq.weightTimeVtx.push_back(dtSeq.weightTimeVtx.at(i));
+      cmbSeq.weightInvbeta.push_back(dtSeq.weightInvbeta.at(i));
 
-void 
-MuonTimingFiller::combineTMSequences( const reco::Muon& muon, 
-                                      const TimeMeasurementSequence& dtSeq, 
-                                      const TimeMeasurementSequence& cscSeq, 
-                                      TimeMeasurementSequence &cmbSeq ) {
-                                        
-  if (useDT_) for (unsigned int i=0;i<dtSeq.dstnc.size();i++) {
-    cmbSeq.dstnc.push_back(dtSeq.dstnc.at(i));
-    cmbSeq.local_t0.push_back(dtSeq.local_t0.at(i));
-    cmbSeq.weightTimeVtx.push_back(dtSeq.weightTimeVtx.at(i));
-    cmbSeq.weightInvbeta.push_back(dtSeq.weightInvbeta.at(i));
+      cmbSeq.totalWeightTimeVtx += dtSeq.weightTimeVtx.at(i);
+      cmbSeq.totalWeightInvbeta += dtSeq.weightInvbeta.at(i);
+    }
 
-    cmbSeq.totalWeightTimeVtx+=dtSeq.weightTimeVtx.at(i);
-    cmbSeq.totalWeightInvbeta+=dtSeq.weightInvbeta.at(i);
-  }
+  if (useCSC_)
+    for (unsigned int i = 0; i < cscSeq.dstnc.size(); i++) {
+      cmbSeq.dstnc.push_back(cscSeq.dstnc.at(i));
+      cmbSeq.local_t0.push_back(cscSeq.local_t0.at(i));
+      cmbSeq.weightTimeVtx.push_back(cscSeq.weightTimeVtx.at(i));
+      cmbSeq.weightInvbeta.push_back(cscSeq.weightInvbeta.at(i));
 
-  if (useCSC_) for (unsigned int i=0;i<cscSeq.dstnc.size();i++) {
-    cmbSeq.dstnc.push_back(cscSeq.dstnc.at(i));
-    cmbSeq.local_t0.push_back(cscSeq.local_t0.at(i));
-    cmbSeq.weightTimeVtx.push_back(cscSeq.weightTimeVtx.at(i));
-    cmbSeq.weightInvbeta.push_back(cscSeq.weightInvbeta.at(i));
-
-    cmbSeq.totalWeightTimeVtx+=cscSeq.weightTimeVtx.at(i);
-    cmbSeq.totalWeightInvbeta+=cscSeq.weightInvbeta.at(i);
-  }
+      cmbSeq.totalWeightTimeVtx += cscSeq.weightTimeVtx.at(i);
+      cmbSeq.totalWeightInvbeta += cscSeq.weightInvbeta.at(i);
+    }
 }
 
-
-void 
-MuonTimingFiller::addEcalTime( const reco::Muon& muon, 
-                               TimeMeasurementSequence &cmbSeq ) {
-
+void MuonTimingFiller::addEcalTime(const reco::Muon& muon, TimeMeasurementSequence& cmbSeq) {
   reco::MuonEnergy muonE;
-  if (muon.isEnergyValid())  
+  if (muon.isEnergyValid())
     muonE = muon.calEnergy();
-  
+
   // Cut on the crystal energy and restrict to the ECAL barrel for now
-//  if (muonE.emMax<ecalEcut_ || fabs(muon.eta())>1.5) return;    
-  if (muonE.emMax<ecalEcut_) return;    
-  
+  //  if (muonE.emMax<ecalEcut_ || fabs(muon.eta())>1.5) return;
+  if (muonE.emMax < ecalEcut_)
+    return;
+
   // A simple parametrization of the error on the ECAL time measurement
   double emErr;
-  if (muonE.ecal_id.subdetId()==EcalBarrel) emErr= errorEB_/muonE.emMax; else
-    emErr=errorEE_/muonE.emMax;
-  double hitWeight = 1/(emErr*emErr);
-  double hitDist=muonE.ecal_position.r();
-        
+  if (muonE.ecal_id.subdetId() == EcalBarrel)
+    emErr = errorEB_ / muonE.emMax;
+  else
+    emErr = errorEE_ / muonE.emMax;
+  double hitWeight = 1 / (emErr * emErr);
+  double hitDist = muonE.ecal_position.r();
+
   cmbSeq.local_t0.push_back(muonE.ecal_time);
   cmbSeq.weightTimeVtx.push_back(hitWeight);
-  cmbSeq.weightInvbeta.push_back(hitDist*hitDist*hitWeight/(30.*30.));
+  cmbSeq.weightInvbeta.push_back(hitDist * hitDist * hitWeight / (30. * 30.));
 
   cmbSeq.dstnc.push_back(hitDist);
-  
-  cmbSeq.totalWeightTimeVtx+=hitWeight;
-  cmbSeq.totalWeightInvbeta+=hitDist*hitDist*hitWeight/(30.*30.);
-                                      
+
+  cmbSeq.totalWeightTimeVtx += hitWeight;
+  cmbSeq.totalWeightInvbeta += hitDist * hitDist * hitWeight / (30. * 30.);
 }
 
-
-
-void 
-MuonTimingFiller::rawFit(double &freeBeta, double &freeBetaErr, double &freeTime, double &freeTimeErr, 
-			 const std::vector<double>& hitsx, const std::vector<double>& hitsy) {
-
-  double s=0,sx=0,sy=0,x,y;
-  double sxx=0,sxy=0;
+void MuonTimingFiller::rawFit(double& freeBeta,
+                              double& freeBetaErr,
+                              double& freeTime,
+                              double& freeTimeErr,
+                              const std::vector<double>& hitsx,
+                              const std::vector<double>& hitsy) {
+  double s = 0, sx = 0, sy = 0, x, y;
+  double sxx = 0, sxy = 0;
 
   freeBeta = 0;
   freeBetaErr = 0;
   freeTime = 0;
   freeTimeErr = 0;
 
-  if (hitsx.empty()) return;
-  if (hitsx.size()==1) {
-    freeTime=hitsy[0];
+  if (hitsx.empty())
+    return;
+  if (hitsx.size() == 1) {
+    freeTime = hitsy[0];
   } else {
     for (unsigned int i = 0; i != hitsx.size(); i++) {
-      x=hitsx[i];
-      y=hitsy[i];
+      x = hitsx[i];
+      y = hitsy[i];
       sy += y;
-      sxy+= x*y;
+      sxy += x * y;
       s += 1.;
       sx += x;
-      sxx += x*x;
+      sxx += x * x;
     }
 
-    double d = s*sxx - sx*sx;
-    freeTime = (sxx*sy- sx*sxy)/ d;
-    freeBeta = (s*sxy - sx*sy) / d;
-    freeBetaErr = sqrt(sxx/d);
-    freeTimeErr = sqrt(s/d);
+    double d = s * sxx - sx * sx;
+    freeTime = (sxx * sy - sx * sxy) / d;
+    freeBeta = (s * sxy - sx * sy) / d;
+    freeBetaErr = sqrt(sxx / d);
+    freeTimeErr = sqrt(s / d);
   }
 }
-

--- a/RecoMuon/MuonIdentification/src/classes.h
+++ b/RecoMuon/MuonIdentification/src/classes.h
@@ -11,13 +11,13 @@
 #include "PhysicsTools/SelectorUtils/interface/PrintVIDToString.h"
 
 namespace RecoMuon_MuonIdentification {
-  struct dictionary {    
+  struct dictionary {
     //for using the selectors in python
-    VersionedMuonSelector vMuonSelector; 
-    
+    VersionedMuonSelector vMuonSelector;
+
     MakeVersionedSelector<reco::Muon> vMakeMuonVersionedSelector;
     MakePtrFromCollection<reco::MuonCollection> vMakeMuonPtrFromCollection;
-    MakePtrFromCollection<std::vector<pat::Muon>,pat::Muon,reco::Muon> vMakePatToRecoMuonPtrFromCollection;
+    MakePtrFromCollection<std::vector<pat::Muon>, pat::Muon, reco::Muon> vMakePatToRecoMuonPtrFromCollection;
     PrintVIDToString<reco::Muon> vPrintMuonVIDToString;
   };
-}
+}  // namespace RecoMuon_MuonIdentification

--- a/RecoMuon/MuonIdentification/test/ME0MuonAnalyzer.cc
+++ b/RecoMuon/MuonIdentification/test/ME0MuonAnalyzer.cc
@@ -7,7 +7,7 @@
 
 #include <DataFormats/Common/interface/Handle.h>
 #include <FWCore/Framework/interface/ESHandle.h>
-#include <FWCore/MessageLogger/interface/MessageLogger.h> 
+#include <FWCore/MessageLogger/interface/MessageLogger.h>
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include <Geometry/Records/interface/MuonGeometryRecord.h>
@@ -55,13 +55,12 @@
 #include "RecoMuon/MuonIdentification/plugins/ME0MuonSelector.cc"
 
 #include "Fit/FitResult.h"
-#include "TF1.h" 
-
+#include "TF1.h"
 
 #include "TMath.h"
 #include "TLorentzVector.h"
 
-#include "TH1.h" 
+#include "TH1.h"
 #include <TH2.h>
 #include "TFile.h"
 #include <TProfile.h>
@@ -75,12 +74,11 @@
 #include <Geometry/Records/interface/MuonGeometryRecord.h>
 #include <DataFormats/MuonDetId/interface/ME0DetId.h>
 
-
 #include "TrackingTools/AnalyticalJacobians/interface/JacobianCartesianToLocal.h"
 #include "TrackingTools/AnalyticalJacobians/interface/JacobianLocalToCartesian.h"
 #include "TGraph.h"
 
-#include <sstream>    
+#include <sstream>
 #include <string>
 
 #include <iostream>
@@ -89,94 +87,178 @@
 
 class ME0MuonAnalyzer : public edm::EDAnalyzer {
 public:
-  explicit ME0MuonAnalyzer(const edm::ParameterSet&);
+  explicit ME0MuonAnalyzer(const edm::ParameterSet &);
   ~ME0MuonAnalyzer();
-  FreeTrajectoryState getFTS(const GlobalVector& , const GlobalVector& , 
-			     int , const AlgebraicSymMatrix66& ,
-			     const MagneticField* );
+  FreeTrajectoryState getFTS(
+      const GlobalVector &, const GlobalVector &, int, const AlgebraicSymMatrix66 &, const MagneticField *);
 
-  FreeTrajectoryState getFTS(const GlobalVector& , const GlobalVector& , 
-			     int , const AlgebraicSymMatrix55& ,
-			     const MagneticField* );
-    void getFromFTS(const FreeTrajectoryState& ,
-		  GlobalVector& , GlobalVector& , 
-		  int& , AlgebraicSymMatrix66& );
+  FreeTrajectoryState getFTS(
+      const GlobalVector &, const GlobalVector &, int, const AlgebraicSymMatrix55 &, const MagneticField *);
+  void getFromFTS(const FreeTrajectoryState &, GlobalVector &, GlobalVector &, int &, AlgebraicSymMatrix66 &);
 
-
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  void beginRun(edm::Run const&, edm::EventSetup const&);
-  void endRun(edm::Run const&, edm::EventSetup const&);
+  virtual void analyze(const edm::Event &, const edm::EventSetup &);
+  void beginRun(edm::Run const &, edm::EventSetup const &);
+  void endRun(edm::Run const &, edm::EventSetup const &);
 
   //protected:
-  
-  private:
 
+private:
   edm::EDGetTokenT<reco::GenParticleCollection> genParticlesToken_;
   edm::EDGetTokenT<TrackingParticleCollection> trackingParticlesToken_;
-  edm::EDGetTokenT <reco::TrackCollection > generalTracksToken_;
-  edm::EDGetTokenT <ME0MuonCollection > OurMuonsToken_;
+  edm::EDGetTokenT<reco::TrackCollection> generalTracksToken_;
+  edm::EDGetTokenT<ME0MuonCollection> OurMuonsToken_;
   edm::EDGetTokenT<ME0SegmentCollection> OurSegmentsToken_;
   std::vector<edm::EDGetTokenT<edm::View<reco::Track> > > track_Collection_Token;
 
-
   bool UseAssociators;
   bool RejectEndcapMuons;
-  const TrackAssociatorByChi2Impl* associatorByChi2;
-
-
+  const TrackAssociatorByChi2Impl *associatorByChi2;
 
   std::vector<std::string> associators;
   std::vector<edm::InputTag> label;
-  std::vector<const reco::TrackToTrackingParticleAssociator*> associator;
+  std::vector<const reco::TrackToTrackingParticleAssociator *> associator;
 
   //Histos for plotting
   TString histoFolder;
   TString me0MuonSelector;
-  TFile* histoFile; 
-  TH1F *Candidate_Eta;  TH1F *Mass_h; 
-  TH1F *Segment_Eta;    TH1F *Segment_Phi;    TH1F *Segment_R;  TH2F *Segment_Pos;  
-  TH1F *Rechit_Eta;    TH1F *Rechit_Phi;    TH1F *Rechit_R;  TH2F *Rechit_Pos;  
-  TH1F *GenMuon_Phi;    TH1F *GenMuon_R;  TH2F *GenMuon_Pos;  
-  TH1F *Track_Eta; TH1F *Track_Pt;  TH1F *ME0Muon_Eta; TH1F *ME0Muon_Pt;  TH1F *CheckME0Muon_Eta; 
-  TH1F *ME0Muon_SmallBins_Pt;   TH1F *ME0Muon_VariableBins_Pt;
-  TH1F *ME0Muon_Cuts_Eta_5_10;   TH1F *ME0Muon_Cuts_Eta_9_11; TH1F *ME0Muon_Cuts_Eta_10_50; TH1F *ME0Muon_Cuts_Eta_50_100; TH1F *ME0Muon_Cuts_Eta_100; 
-  TH1F *UnmatchedME0Muon_Eta; TH1F *UnmatchedME0Muon_Pt;    TH1F *UnmatchedME0Muon_Window_Pt;    TH1F *Chi2UnmatchedME0Muon_Eta; 
-  TH1F *Chi2UnmatchedME0Muon_Pt; TH1F *Chi2UnmatchedME0Muon_SmallBins_Pt;   TH1F *Chi2UnmatchedME0Muon_VariableBins_Pt; 
-  TH1F *UnmatchedME0Muon_SmallBins_Pt;      TH1F *UnmatchedME0Muon_VariableBins_Pt;   
-  TH1F *UnmatchedME0Muon_Cuts_Eta_5_10;    TH1F *UnmatchedME0Muon_Cuts_Eta_9_11;  TH1F *UnmatchedME0Muon_Cuts_Eta_10_50;  TH1F *UnmatchedME0Muon_Cuts_Eta_50_100;  TH1F *UnmatchedME0Muon_Cuts_Eta_100;
-  TH1F *TracksPerSegment_h;  TH2F *TracksPerSegment_s;  TProfile *TracksPerSegment_p;
-  TH2F *ClosestDelR_s; TProfile *ClosestDelR_p;
-  TH2F *PtDiff_s; TProfile *PtDiff_p; TH1F *PtDiff_h; TH1F *QOverPtDiff_h; TH1F *PtDiff_rms; TH1F *PtDiff_gaus_narrow; TH1F *PtDiff_gaus_wide;
-  TH2F *StandalonePtDiff_s; TProfile *StandalonePtDiff_p; TH1F *StandalonePtDiff_h; TH1F *StandaloneQOverPtDiff_h; TH1F *StandalonePtDiff_rms; TH1F *StandalonePtDiff_gaus_narrow; TH1F *StandalonePtDiff_gaus_wide;
-  TH1F *PtDiff_gaus_5_10;  TH1F *PtDiff_gaus_10_50;  TH1F *PtDiff_gaus_50_100; TH1F *PtDiff_gaus_100;
+  TFile *histoFile;
+  TH1F *Candidate_Eta;
+  TH1F *Mass_h;
+  TH1F *Segment_Eta;
+  TH1F *Segment_Phi;
+  TH1F *Segment_R;
+  TH2F *Segment_Pos;
+  TH1F *Rechit_Eta;
+  TH1F *Rechit_Phi;
+  TH1F *Rechit_R;
+  TH2F *Rechit_Pos;
+  TH1F *GenMuon_Phi;
+  TH1F *GenMuon_R;
+  TH2F *GenMuon_Pos;
+  TH1F *Track_Eta;
+  TH1F *Track_Pt;
+  TH1F *ME0Muon_Eta;
+  TH1F *ME0Muon_Pt;
+  TH1F *CheckME0Muon_Eta;
+  TH1F *ME0Muon_SmallBins_Pt;
+  TH1F *ME0Muon_VariableBins_Pt;
+  TH1F *ME0Muon_Cuts_Eta_5_10;
+  TH1F *ME0Muon_Cuts_Eta_9_11;
+  TH1F *ME0Muon_Cuts_Eta_10_50;
+  TH1F *ME0Muon_Cuts_Eta_50_100;
+  TH1F *ME0Muon_Cuts_Eta_100;
+  TH1F *UnmatchedME0Muon_Eta;
+  TH1F *UnmatchedME0Muon_Pt;
+  TH1F *UnmatchedME0Muon_Window_Pt;
+  TH1F *Chi2UnmatchedME0Muon_Eta;
+  TH1F *Chi2UnmatchedME0Muon_Pt;
+  TH1F *Chi2UnmatchedME0Muon_SmallBins_Pt;
+  TH1F *Chi2UnmatchedME0Muon_VariableBins_Pt;
+  TH1F *UnmatchedME0Muon_SmallBins_Pt;
+  TH1F *UnmatchedME0Muon_VariableBins_Pt;
+  TH1F *UnmatchedME0Muon_Cuts_Eta_5_10;
+  TH1F *UnmatchedME0Muon_Cuts_Eta_9_11;
+  TH1F *UnmatchedME0Muon_Cuts_Eta_10_50;
+  TH1F *UnmatchedME0Muon_Cuts_Eta_50_100;
+  TH1F *UnmatchedME0Muon_Cuts_Eta_100;
+  TH1F *TracksPerSegment_h;
+  TH2F *TracksPerSegment_s;
+  TProfile *TracksPerSegment_p;
+  TH2F *ClosestDelR_s;
+  TProfile *ClosestDelR_p;
+  TH2F *PtDiff_s;
+  TProfile *PtDiff_p;
+  TH1F *PtDiff_h;
+  TH1F *QOverPtDiff_h;
+  TH1F *PtDiff_rms;
+  TH1F *PtDiff_gaus_narrow;
+  TH1F *PtDiff_gaus_wide;
+  TH2F *StandalonePtDiff_s;
+  TProfile *StandalonePtDiff_p;
+  TH1F *StandalonePtDiff_h;
+  TH1F *StandaloneQOverPtDiff_h;
+  TH1F *StandalonePtDiff_rms;
+  TH1F *StandalonePtDiff_gaus_narrow;
+  TH1F *StandalonePtDiff_gaus_wide;
+  TH1F *PtDiff_gaus_5_10;
+  TH1F *PtDiff_gaus_10_50;
+  TH1F *PtDiff_gaus_50_100;
+  TH1F *PtDiff_gaus_100;
   TH1F *StandalonePtDiff_gaus;
   TH1F *VertexDiff_h;
-  TH2F *PDiff_s; TProfile *PDiff_p; TH1F *PDiff_h;
-  TH2F *PtDiff_s_5_10;    TH2F *PtDiff_s_10_50;    TH2F *PtDiff_s_50_100;    TH2F *PtDiff_s_100;
-  TH1F *FakeTracksPerSegment_h;  TH2F *FakeTracksPerSegment_s;  TProfile *FakeTracksPerSegment_p;
-  TH1F *FakeTracksPerAssociatedSegment_h;  TH2F *FakeTracksPerAssociatedSegment_s;  TProfile *FakeTracksPerAssociatedSegment_p;
-  TH1F *GenMuon_Eta; TH1F *GenMuon_Pt;   TH1F *MatchedME0Muon_Eta; TH1F *MatchedME0Muon_Pt; TH1F *Chi2MatchedME0Muon_Eta; TH1F *Chi2MatchedME0Muon_Pt; 
-  TH1F *GenMuon_SmallBins_Pt;  TH1F *MatchedME0Muon_SmallBins_Pt; TH1F *Chi2MatchedME0Muons_Pt; TH1F *Chi2MatchedME0Muon_SmallBins_Pt; 
-  TH1F *GenMuon_VariableBins_Pt;  TH1F *MatchedME0Muon_VariableBins_Pt; TH1F *Chi2MatchedME0Muon_VariableBins_Pt; 
-  TH1F *TPMuon_Eta;   TH1F *TPMuon_SmallBins_Pt;    TH1F *TPMuon_Pt; TH1F *TPMuon_VariableBins_Pt;  
-  TH1F *MatchedME0Muon_Eta_5_10;    TH1F *MatchedME0Muon_Eta_9_11;  TH1F *MatchedME0Muon_Eta_10_50;  TH1F *MatchedME0Muon_Eta_50_100;  TH1F *MatchedME0Muon_Eta_100;
-  TH1F *Chi2MatchedME0Muon_Eta_5_10;   TH1F *Chi2MatchedME0Muon_Eta_9_11; TH1F *Chi2MatchedME0Muon_Eta_10_50;  TH1F *Chi2MatchedME0Muon_Eta_50_100;  TH1F *Chi2MatchedME0Muon_Eta_100;
-  TH1F *GenMuon_Eta_5_10;   TH1F *GenMuon_Eta_9_11;  TH1F *GenMuon_Eta_10_50;  TH1F *GenMuon_Eta_50_100;  TH1F *GenMuon_Eta_100;
-  TH1F *MuonRecoEff_Eta;  TH1F *MuonRecoEff_Pt;   TH1F *Chi2MuonRecoEff_Eta;  
-  TH1F *MuonRecoEff_Eta_5_10;   TH1F *MuonRecoEff_Eta_9_11;  TH1F *MuonRecoEff_Eta_10_50;  TH1F *MuonRecoEff_Eta_50_100;  TH1F *MuonRecoEff_Eta_100;
-  TH1F *Chi2MuonRecoEff_Eta_5_10;    TH1F *Chi2MuonRecoEff_Eta_9_11;  TH1F *Chi2MuonRecoEff_Eta_10_50;  TH1F *Chi2MuonRecoEff_Eta_50_100;  TH1F *Chi2MuonRecoEff_Eta_100;
-  TH1F *FakeRate_Eta;  TH1F *FakeRate_Pt;  TH1F *FakeRate_Eta_PerEvent;    TH1F *Chi2FakeRate_Eta;  
+  TH2F *PDiff_s;
+  TProfile *PDiff_p;
+  TH1F *PDiff_h;
+  TH2F *PtDiff_s_5_10;
+  TH2F *PtDiff_s_10_50;
+  TH2F *PtDiff_s_50_100;
+  TH2F *PtDiff_s_100;
+  TH1F *FakeTracksPerSegment_h;
+  TH2F *FakeTracksPerSegment_s;
+  TProfile *FakeTracksPerSegment_p;
+  TH1F *FakeTracksPerAssociatedSegment_h;
+  TH2F *FakeTracksPerAssociatedSegment_s;
+  TProfile *FakeTracksPerAssociatedSegment_p;
+  TH1F *GenMuon_Eta;
+  TH1F *GenMuon_Pt;
+  TH1F *MatchedME0Muon_Eta;
+  TH1F *MatchedME0Muon_Pt;
+  TH1F *Chi2MatchedME0Muon_Eta;
+  TH1F *Chi2MatchedME0Muon_Pt;
+  TH1F *GenMuon_SmallBins_Pt;
+  TH1F *MatchedME0Muon_SmallBins_Pt;
+  TH1F *Chi2MatchedME0Muons_Pt;
+  TH1F *Chi2MatchedME0Muon_SmallBins_Pt;
+  TH1F *GenMuon_VariableBins_Pt;
+  TH1F *MatchedME0Muon_VariableBins_Pt;
+  TH1F *Chi2MatchedME0Muon_VariableBins_Pt;
+  TH1F *TPMuon_Eta;
+  TH1F *TPMuon_SmallBins_Pt;
+  TH1F *TPMuon_Pt;
+  TH1F *TPMuon_VariableBins_Pt;
+  TH1F *MatchedME0Muon_Eta_5_10;
+  TH1F *MatchedME0Muon_Eta_9_11;
+  TH1F *MatchedME0Muon_Eta_10_50;
+  TH1F *MatchedME0Muon_Eta_50_100;
+  TH1F *MatchedME0Muon_Eta_100;
+  TH1F *Chi2MatchedME0Muon_Eta_5_10;
+  TH1F *Chi2MatchedME0Muon_Eta_9_11;
+  TH1F *Chi2MatchedME0Muon_Eta_10_50;
+  TH1F *Chi2MatchedME0Muon_Eta_50_100;
+  TH1F *Chi2MatchedME0Muon_Eta_100;
+  TH1F *GenMuon_Eta_5_10;
+  TH1F *GenMuon_Eta_9_11;
+  TH1F *GenMuon_Eta_10_50;
+  TH1F *GenMuon_Eta_50_100;
+  TH1F *GenMuon_Eta_100;
+  TH1F *MuonRecoEff_Eta;
+  TH1F *MuonRecoEff_Pt;
+  TH1F *Chi2MuonRecoEff_Eta;
+  TH1F *MuonRecoEff_Eta_5_10;
+  TH1F *MuonRecoEff_Eta_9_11;
+  TH1F *MuonRecoEff_Eta_10_50;
+  TH1F *MuonRecoEff_Eta_50_100;
+  TH1F *MuonRecoEff_Eta_100;
+  TH1F *Chi2MuonRecoEff_Eta_5_10;
+  TH1F *Chi2MuonRecoEff_Eta_9_11;
+  TH1F *Chi2MuonRecoEff_Eta_10_50;
+  TH1F *Chi2MuonRecoEff_Eta_50_100;
+  TH1F *Chi2MuonRecoEff_Eta_100;
+  TH1F *FakeRate_Eta;
+  TH1F *FakeRate_Pt;
+  TH1F *FakeRate_Eta_PerEvent;
+  TH1F *Chi2FakeRate_Eta;
 
-  TH1F *Chi2FakeRate_WideBinning_Eta;  
-  TH1F *Chi2FakeRate_WidestBinning_Eta;  
+  TH1F *Chi2FakeRate_WideBinning_Eta;
+  TH1F *Chi2FakeRate_WidestBinning_Eta;
   TH1F *FakeRate_WideBinning_Eta;
   TH1F *FakeRate_WidestBinning_Eta;
   TH1F *UnmatchedME0Muon_Cuts_WideBinning_Eta;
   TH1F *UnmatchedME0Muon_Cuts_WidestBinning_Eta;
-  TH1F *ME0Muon_Cuts_WideBinning_Eta; 
+  TH1F *ME0Muon_Cuts_WideBinning_Eta;
   TH1F *ME0Muon_Cuts_WidestBinning_Eta;
-  TH1F *Chi2UnmatchedME0Muon_WideBinning_Eta; 
-  TH1F *Chi2UnmatchedME0Muon_WidestBinning_Eta; 
+  TH1F *Chi2UnmatchedME0Muon_WideBinning_Eta;
+  TH1F *Chi2UnmatchedME0Muon_WidestBinning_Eta;
   TH1F *TPMuon_WideBinning_Eta;
   TH1F *TPMuon_WidestBinning_Eta;
   TH1F *GenMuon_WideBinning_Eta;
@@ -187,445 +269,489 @@ public:
   TH1F *Chi2MatchedME0Muon_WidestBinning_Eta;
   TH1F *MuonRecoEff_WideBinning_Eta;
   TH1F *MuonRecoEff_WidestBinning_Eta;
-  TH1F *Chi2MuonRecoEff_WideBinning_Eta;  
-  TH1F *Chi2MuonRecoEff_WidestBinning_Eta;  
+  TH1F *Chi2MuonRecoEff_WideBinning_Eta;
+  TH1F *Chi2MuonRecoEff_WidestBinning_Eta;
 
+  TH1F *FakeRate_Eta_5_10;
+  TH1F *FakeRate_Eta_9_11;
+  TH1F *FakeRate_Eta_10_50;
+  TH1F *FakeRate_Eta_50_100;
+  TH1F *FakeRate_Eta_100;
+  TH1F *MuonAllTracksEff_Eta;
+  TH1F *MuonAllTracksEff_Pt;
+  TH1F *MuonUnmatchedTracksEff_Eta;
+  TH1F *MuonUnmatchedTracksEff_Pt;
+  TH1F *FractionMatched_Eta;
 
-  TH1F *FakeRate_Eta_5_10;    TH1F *FakeRate_Eta_9_11;  TH1F *FakeRate_Eta_10_50;  TH1F *FakeRate_Eta_50_100;  TH1F *FakeRate_Eta_100;
-  TH1F *MuonAllTracksEff_Eta;  TH1F *MuonAllTracksEff_Pt;
-  TH1F *MuonUnmatchedTracksEff_Eta;  TH1F *MuonUnmatchedTracksEff_Pt; TH1F *FractionMatched_Eta;
-
-  TH1F *StandaloneMuonRecoEff_Eta;   TH1F *StandaloneMuonRecoEff_WideBinning_Eta;   TH1F *StandaloneMuonRecoEff_WidestBinning_Eta;
-  TH1F *UnmatchedME0Muon_Cuts_Eta;TH1F *ME0Muon_Cuts_Eta;
-  TH1F *StandaloneMatchedME0Muon_Eta;    TH1F *StandaloneMatchedME0Muon_WideBinning_Eta;    TH1F *StandaloneMatchedME0Muon_WidestBinning_Eta;
+  TH1F *StandaloneMuonRecoEff_Eta;
+  TH1F *StandaloneMuonRecoEff_WideBinning_Eta;
+  TH1F *StandaloneMuonRecoEff_WidestBinning_Eta;
+  TH1F *UnmatchedME0Muon_Cuts_Eta;
+  TH1F *ME0Muon_Cuts_Eta;
+  TH1F *StandaloneMatchedME0Muon_Eta;
+  TH1F *StandaloneMatchedME0Muon_WideBinning_Eta;
+  TH1F *StandaloneMatchedME0Muon_WidestBinning_Eta;
   TH1F *DelR_Segment_GenMuon;
 
-  TH1F *SegPosDirPhiDiff_True_h;    TH1F *SegPosDirEtaDiff_True_h;     TH1F *SegPosDirPhiDiff_All_h;    TH1F *SegPosDirEtaDiff_All_h;   
-  TH1F *SegTrackDirPhiDiff_True_h;    TH1F *SegTrackDirEtaDiff_True_h;     TH1F *SegTrackDirPhiDiff_All_h;    TH1F *SegTrackDirEtaDiff_All_h;   TH1F *SegTrackDirPhiPull_True_h;   TH1F *SegTrackDirPhiPull_All_h;   
+  TH1F *SegPosDirPhiDiff_True_h;
+  TH1F *SegPosDirEtaDiff_True_h;
+  TH1F *SegPosDirPhiDiff_All_h;
+  TH1F *SegPosDirEtaDiff_All_h;
+  TH1F *SegTrackDirPhiDiff_True_h;
+  TH1F *SegTrackDirEtaDiff_True_h;
+  TH1F *SegTrackDirPhiDiff_All_h;
+  TH1F *SegTrackDirEtaDiff_All_h;
+  TH1F *SegTrackDirPhiPull_True_h;
+  TH1F *SegTrackDirPhiPull_All_h;
 
-  TH1F *SegGenDirPhiDiff_True_h;    TH1F *SegGenDirEtaDiff_True_h;     TH1F *SegGenDirPhiDiff_All_h;    TH1F *SegGenDirEtaDiff_All_h;   TH1F *SegGenDirPhiPull_True_h;   TH1F *SegGenDirPhiPull_All_h;   
+  TH1F *SegGenDirPhiDiff_True_h;
+  TH1F *SegGenDirEtaDiff_True_h;
+  TH1F *SegGenDirPhiDiff_All_h;
+  TH1F *SegGenDirEtaDiff_All_h;
+  TH1F *SegGenDirPhiPull_True_h;
+  TH1F *SegGenDirPhiPull_All_h;
 
-  TH1F *XDiff_h;   TH1F *YDiff_h;   TH1F *XPull_h;   TH1F *YPull_h;
+  TH1F *XDiff_h;
+  TH1F *YDiff_h;
+  TH1F *XPull_h;
+  TH1F *YPull_h;
 
+  TH1F *DelR_Window_Under5;
+  TH1F *Pt_Window_Under5;
+  TH1F *DelR_Track_Window_Under5;
+  TH1F *Pt_Track_Window_Under5;
+  TH1F *Pt_Track_Window;
+  TH1F *DelR_Track_Window_Failed_Under5;
+  TH1F *Pt_Track_Window_Failed_Under5;
+  TH1F *Pt_Track_Window_Failed;
 
-  TH1F *DelR_Window_Under5; TH1F  *Pt_Window_Under5;
-  TH1F *DelR_Track_Window_Under5; TH1F  *Pt_Track_Window_Under5;  TH1F  *Pt_Track_Window;
-  TH1F *DelR_Track_Window_Failed_Under5; TH1F  *Pt_Track_Window_Failed_Under5;  TH1F  *Pt_Track_Window_Failed;
+  TH1F *FailedTrack_Window_XPull;
+  TH1F *FailedTrack_Window_YPull;
+  TH1F *FailedTrack_Window_PhiDiff;
+  TH1F *FailedTrack_Window_XDiff;
+  TH1F *FailedTrack_Window_YDiff;
 
-  TH1F *FailedTrack_Window_XPull;    TH1F *FailedTrack_Window_YPull;    TH1F *FailedTrack_Window_PhiDiff;
-  TH1F *FailedTrack_Window_XDiff;    TH1F *FailedTrack_Window_YDiff;    
+  TH1F *NormChi2_h;
+  TH1F *NormChi2Prob_h;
+  TH2F *NormChi2VsHits_h;
+  TH2F *chi2_vs_eta_h;
+  TH1F *AssociatedChi2_h;
+  TH1F *AssociatedChi2_Prob_h;
 
-  TH1F *NormChi2_h;    TH1F *NormChi2Prob_h; TH2F *NormChi2VsHits_h;	TH2F *chi2_vs_eta_h;  TH1F *AssociatedChi2_h;  TH1F *AssociatedChi2_Prob_h;
-
-  TH1F *PreMatch_TP_R;   TH1F *PostMatch_TP_R;  TH1F *PostMatch_BX0_TP_R;
+  TH1F *PreMatch_TP_R;
+  TH1F *PostMatch_TP_R;
+  TH1F *PostMatch_BX0_TP_R;
 
   TH2F *UnmatchedME0Muon_ScatterPlot;
 
-
-  double  FakeRatePtCut, MatchingWindowDelR;
+  double FakeRatePtCut, MatchingWindowDelR;
 
   double Nevents;
 
   TH1F *Nevents_h;
-
 };
 
-ME0MuonAnalyzer::ME0MuonAnalyzer(const edm::ParameterSet& iConfig) 
-{
+ME0MuonAnalyzer::ME0MuonAnalyzer(const edm::ParameterSet &iConfig) {
   histoFile = new TFile(iConfig.getParameter<std::string>("HistoFile").c_str(), "recreate");
   histoFolder = iConfig.getParameter<std::string>("HistoFolder").c_str();
   me0MuonSelector = iConfig.getParameter<std::string>("ME0MuonSelectionType").c_str();
-  RejectEndcapMuons = iConfig.getParameter< bool >("RejectEndcapMuons");
-  UseAssociators = iConfig.getParameter< bool >("UseAssociators");
+  RejectEndcapMuons = iConfig.getParameter<bool>("RejectEndcapMuons");
+  UseAssociators = iConfig.getParameter<bool>("UseAssociators");
 
-  FakeRatePtCut   = iConfig.getParameter<double>("FakeRatePtCut");
-  MatchingWindowDelR   = iConfig.getParameter<double>("MatchingWindowDelR");
+  FakeRatePtCut = iConfig.getParameter<double>("FakeRatePtCut");
+  MatchingWindowDelR = iConfig.getParameter<double>("MatchingWindowDelR");
 
   //Associator for chi2: getting parameters
-  UseAssociators = iConfig.getParameter< bool >("UseAssociators");
-  associators = iConfig.getParameter< std::vector<std::string> >("associators");
+  UseAssociators = iConfig.getParameter<bool>("UseAssociators");
+  associators = iConfig.getParameter<std::vector<std::string> >("associators");
 
-  label = iConfig.getParameter< std::vector<edm::InputTag> >("label");
-  edm::InputTag genParticlesTag ("genParticles");
+  label = iConfig.getParameter<std::vector<edm::InputTag> >("label");
+  edm::InputTag genParticlesTag("genParticles");
   genParticlesToken_ = consumes<reco::GenParticleCollection>(genParticlesTag);
-  edm::InputTag trackingParticlesTag ("mix","MergedTrackTruth");
+  edm::InputTag trackingParticlesTag("mix", "MergedTrackTruth");
   trackingParticlesToken_ = consumes<TrackingParticleCollection>(trackingParticlesTag);
-  edm::InputTag generalTracksTag ("generalTracks");
+  edm::InputTag generalTracksTag("generalTracks");
   generalTracksToken_ = consumes<reco::TrackCollection>(generalTracksTag);
-  edm::InputTag OurMuonsTag ("me0SegmentMatching");
+  edm::InputTag OurMuonsTag("me0SegmentMatching");
   OurMuonsToken_ = consumes<ME0MuonCollection>(OurMuonsTag);
-  edm::InputTag OurSegmentsTag ("me0Segments");
+  edm::InputTag OurSegmentsTag("me0Segments");
   OurSegmentsToken_ = consumes<ME0SegmentCollection>(OurSegmentsTag);
 
   //Getting tokens and doing consumers for track associators
-  for (unsigned int www=0;www<label.size();www++){
+  for (unsigned int www = 0; www < label.size(); www++) {
     track_Collection_Token.push_back(consumes<edm::View<reco::Track> >(label[www]));
   }
 
   if (UseAssociators) {
-    for (auto const& thisassociator :associators) {
+    for (auto const &thisassociator : associators) {
       consumes<reco::TrackToTrackingParticleAssociator>(edm::InputTag(thisassociator));
     }
   }
 
-
-  std::cout<<"Contructor end"<<std::endl;
+  std::cout << "Contructor end" << std::endl;
 }
 
-
-
-void ME0MuonAnalyzer::beginRun(edm::Run const&, edm::EventSetup const& iSetup) {
-
+void ME0MuonAnalyzer::beginRun(edm::Run const &, edm::EventSetup const &iSetup) {
   //Making the directory to write plot pngs to
   mkdir(histoFolder, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
 
   //Histos for plotting
-  Candidate_Eta = new TH1F("Candidate_Eta"      , "Candidate #eta"   , 4, 2.0, 2.8 );
+  Candidate_Eta = new TH1F("Candidate_Eta", "Candidate #eta", 4, 2.0, 2.8);
 
-  Nevents_h = new TH1F("Nevents_h"      , "Nevents"   , 2, 0, 2 );
+  Nevents_h = new TH1F("Nevents_h", "Nevents", 2, 0, 2);
 
-  Track_Eta = new TH1F("Track_Eta"      , "Track #eta"   , 4, 2.0, 2.8 );
-  Track_Pt = new TH1F("Track_Pt"      , "Muon p_{T}"   , 120,0 , 120. );
+  Track_Eta = new TH1F("Track_Eta", "Track #eta", 4, 2.0, 2.8);
+  Track_Pt = new TH1F("Track_Pt", "Muon p_{T}", 120, 0, 120.);
 
-  Segment_Eta = new TH1F("Segment_Eta"      , "Segment #eta"   , 4, 2.0, 2.8 );
-  Segment_Phi = new TH1F("Segment_Phi"      , "Segment #phi"   , 60, -3, 3. );
-  Segment_R = new TH1F("Segment_R"      , "Segment r"   , 30, 0, 150 );
-  Segment_Pos = new TH2F("Segment_Pos"      , "Segment x,y"   ,100,-100.,100., 100,-100.,100. );
+  Segment_Eta = new TH1F("Segment_Eta", "Segment #eta", 4, 2.0, 2.8);
+  Segment_Phi = new TH1F("Segment_Phi", "Segment #phi", 60, -3, 3.);
+  Segment_R = new TH1F("Segment_R", "Segment r", 30, 0, 150);
+  Segment_Pos = new TH2F("Segment_Pos", "Segment x,y", 100, -100., 100., 100, -100., 100.);
 
-  Rechit_Eta = new TH1F("Rechit_Eta"      , "Rechit #eta"   , 4, 2.0, 2.8 );
-  Rechit_Phi = new TH1F("Rechit_Phi"      , "Rechit #phi"   , 60, -3, 3. );
-  Rechit_R = new TH1F("Rechit_R"      , "Rechit r"   , 30, 0, 150 );
-  Rechit_Pos = new TH2F("Rechit_Pos"      , "Rechit x,y"   ,100,-100.,100., 100,-100.,100. );
+  Rechit_Eta = new TH1F("Rechit_Eta", "Rechit #eta", 4, 2.0, 2.8);
+  Rechit_Phi = new TH1F("Rechit_Phi", "Rechit #phi", 60, -3, 3.);
+  Rechit_R = new TH1F("Rechit_R", "Rechit r", 30, 0, 150);
+  Rechit_Pos = new TH2F("Rechit_Pos", "Rechit x,y", 100, -100., 100., 100, -100., 100.);
 
-  GenMuon_Phi = new TH1F("GenMuon_Phi"      , "GenMuon #phi"   , 60, -3, 3. );
-  GenMuon_R = new TH1F("GenMuon_R"      , "GenMuon r"   , 30, 0, 150 );
-  GenMuon_Pos = new TH2F("GenMuon_Pos"      , "GenMuon x,y"   ,100,-100.,100., 100,-100.,100. );
+  GenMuon_Phi = new TH1F("GenMuon_Phi", "GenMuon #phi", 60, -3, 3.);
+  GenMuon_R = new TH1F("GenMuon_R", "GenMuon r", 30, 0, 150);
+  GenMuon_Pos = new TH2F("GenMuon_Pos", "GenMuon x,y", 100, -100., 100., 100, -100., 100.);
 
-  ME0Muon_Eta = new TH1F("ME0Muon_Eta"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  ME0Muon_Cuts_Eta_5_10 = new TH1F("ME0Muon_Cuts_Eta_5_10"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  ME0Muon_Cuts_Eta_9_11 = new TH1F("ME0Muon_Cuts_Eta_9_11"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  ME0Muon_Cuts_Eta_10_50 = new TH1F("ME0Muon_Cuts_Eta_10_50"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  ME0Muon_Cuts_Eta_50_100 = new TH1F("ME0Muon_Cuts_Eta_50_100"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  ME0Muon_Cuts_Eta_100 = new TH1F("ME0Muon_Cuts_Eta_100"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  ME0Muon_Eta = new TH1F("ME0Muon_Eta", "Muon #eta", 4, 2.0, 2.8);
+  ME0Muon_Cuts_Eta_5_10 = new TH1F("ME0Muon_Cuts_Eta_5_10", "Muon #eta", 4, 2.0, 2.8);
+  ME0Muon_Cuts_Eta_9_11 = new TH1F("ME0Muon_Cuts_Eta_9_11", "Muon #eta", 4, 2.0, 2.8);
+  ME0Muon_Cuts_Eta_10_50 = new TH1F("ME0Muon_Cuts_Eta_10_50", "Muon #eta", 4, 2.0, 2.8);
+  ME0Muon_Cuts_Eta_50_100 = new TH1F("ME0Muon_Cuts_Eta_50_100", "Muon #eta", 4, 2.0, 2.8);
+  ME0Muon_Cuts_Eta_100 = new TH1F("ME0Muon_Cuts_Eta_100", "Muon #eta", 4, 2.0, 2.8);
 
-  CheckME0Muon_Eta = new TH1F("CheckME0Muon_Eta"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  ME0Muon_Pt = new TH1F("ME0Muon_Pt"      , "Muon p_{T}"   , 120,0 , 120. );
+  CheckME0Muon_Eta = new TH1F("CheckME0Muon_Eta", "Muon #eta", 4, 2.0, 2.8);
+  ME0Muon_Pt = new TH1F("ME0Muon_Pt", "Muon p_{T}", 120, 0, 120.);
 
-  GenMuon_Eta = new TH1F("GenMuon_Eta"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  GenMuon_Eta_5_10 = new TH1F("GenMuon_Eta_5_10"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  GenMuon_Eta_9_11 = new TH1F("GenMuon_Eta_9_11"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  GenMuon_Eta_10_50 = new TH1F("GenMuon_Eta_10_50"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  GenMuon_Eta_50_100 = new TH1F("GenMuon_Eta_50_100"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  GenMuon_Eta_100 = new TH1F("GenMuon_Eta_100"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  GenMuon_Eta = new TH1F("GenMuon_Eta", "Muon #eta", 4, 2.0, 2.8);
+  GenMuon_Eta_5_10 = new TH1F("GenMuon_Eta_5_10", "Muon #eta", 4, 2.0, 2.8);
+  GenMuon_Eta_9_11 = new TH1F("GenMuon_Eta_9_11", "Muon #eta", 4, 2.0, 2.8);
+  GenMuon_Eta_10_50 = new TH1F("GenMuon_Eta_10_50", "Muon #eta", 4, 2.0, 2.8);
+  GenMuon_Eta_50_100 = new TH1F("GenMuon_Eta_50_100", "Muon #eta", 4, 2.0, 2.8);
+  GenMuon_Eta_100 = new TH1F("GenMuon_Eta_100", "Muon #eta", 4, 2.0, 2.8);
 
-  TPMuon_Eta = new TH1F("TPMuon_Eta"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  TPMuon_Eta = new TH1F("TPMuon_Eta", "Muon #eta", 4, 2.0, 2.8);
 
-  GenMuon_Pt = new TH1F("GenMuon_Pt"      , "Muon p_{T}"   , 100,0 , 100. );
+  GenMuon_Pt = new TH1F("GenMuon_Pt", "Muon p_{T}", 100, 0, 100.);
 
   //Default variable binning scheme
-  double varbins[]={0.,5.,10.,15.,20.,25.,30.,40.,50.,70.,100.};
-  GenMuon_SmallBins_Pt = new TH1F("GenMuon_SmallBins_Pt"      , "Muon p_{T}"   ,10,varbins);
+  double varbins[] = {0., 5., 10., 15., 20., 25., 30., 40., 50., 70., 100.};
+  GenMuon_SmallBins_Pt = new TH1F("GenMuon_SmallBins_Pt", "Muon p_{T}", 10, varbins);
 
-  GenMuon_VariableBins_Pt = new TH1F("GenMuon_VariableBins_Pt"      , "Muon p_{T}"   ,10,varbins);
+  GenMuon_VariableBins_Pt = new TH1F("GenMuon_VariableBins_Pt", "Muon p_{T}", 10, varbins);
 
-  TPMuon_Pt = new TH1F("TPMuon_Pt"      , "Muon p_{T}"   , 100,0 , 100. );
-  TPMuon_SmallBins_Pt = new TH1F("TPMuon_SmallBins_Pt"      , "Muon p_{T}"   ,10,varbins);
-  TPMuon_VariableBins_Pt = new TH1F("TPMuon_VariableBins_Pt"      , "Muon p_{T}"   ,10,varbins);
+  TPMuon_Pt = new TH1F("TPMuon_Pt", "Muon p_{T}", 100, 0, 100.);
+  TPMuon_SmallBins_Pt = new TH1F("TPMuon_SmallBins_Pt", "Muon p_{T}", 10, varbins);
+  TPMuon_VariableBins_Pt = new TH1F("TPMuon_VariableBins_Pt", "Muon p_{T}", 10, varbins);
 
-  MatchedME0Muon_Eta = new TH1F("MatchedME0Muon_Eta"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  StandaloneMatchedME0Muon_Eta = new TH1F("StandaloneMatchedME0Muon_Eta"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  StandaloneMatchedME0Muon_WideBinning_Eta = new TH1F("StandaloneMatchedME0Muon_WideBinning_Eta"      , "Muon #eta"   , 8, 2.0, 2.8 );
-  StandaloneMatchedME0Muon_WidestBinning_Eta = new TH1F("StandaloneMatchedME0Muon_WidestBinning_Eta"      , "Muon #eta"   , 16, 2.0, 2.8 );
-  MatchedME0Muon_Eta_5_10 = new TH1F("MatchedME0Muon_Eta_5_10"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  MatchedME0Muon_Eta_9_11 = new TH1F("MatchedME0Muon_Eta_9_11"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  MatchedME0Muon_Eta_10_50 = new TH1F("MatchedME0Muon_Eta_10_50"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  MatchedME0Muon_Eta_50_100 = new TH1F("MatchedME0Muon_Eta_50_100"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  MatchedME0Muon_Eta_100 = new TH1F("MatchedME0Muon_Eta_100"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  MatchedME0Muon_Eta = new TH1F("MatchedME0Muon_Eta", "Muon #eta", 4, 2.0, 2.8);
+  StandaloneMatchedME0Muon_Eta = new TH1F("StandaloneMatchedME0Muon_Eta", "Muon #eta", 4, 2.0, 2.8);
+  StandaloneMatchedME0Muon_WideBinning_Eta =
+      new TH1F("StandaloneMatchedME0Muon_WideBinning_Eta", "Muon #eta", 8, 2.0, 2.8);
+  StandaloneMatchedME0Muon_WidestBinning_Eta =
+      new TH1F("StandaloneMatchedME0Muon_WidestBinning_Eta", "Muon #eta", 16, 2.0, 2.8);
+  MatchedME0Muon_Eta_5_10 = new TH1F("MatchedME0Muon_Eta_5_10", "Muon #eta", 4, 2.0, 2.8);
+  MatchedME0Muon_Eta_9_11 = new TH1F("MatchedME0Muon_Eta_9_11", "Muon #eta", 4, 2.0, 2.8);
+  MatchedME0Muon_Eta_10_50 = new TH1F("MatchedME0Muon_Eta_10_50", "Muon #eta", 4, 2.0, 2.8);
+  MatchedME0Muon_Eta_50_100 = new TH1F("MatchedME0Muon_Eta_50_100", "Muon #eta", 4, 2.0, 2.8);
+  MatchedME0Muon_Eta_100 = new TH1F("MatchedME0Muon_Eta_100", "Muon #eta", 4, 2.0, 2.8);
 
+  Chi2MatchedME0Muon_Eta_5_10 = new TH1F("Chi2MatchedME0Muon_Eta_5_10", "Muon #eta", 4, 2.0, 2.8);
+  Chi2MatchedME0Muon_Eta_9_11 = new TH1F("Chi2MatchedME0Muon_Eta_9_11", "Muon #eta", 4, 2.0, 2.8);
+  Chi2MatchedME0Muon_Eta_10_50 = new TH1F("Chi2MatchedME0Muon_Eta_10_50", "Muon #eta", 4, 2.0, 2.8);
+  Chi2MatchedME0Muon_Eta_50_100 = new TH1F("Chi2MatchedME0Muon_Eta_50_100", "Muon #eta", 4, 2.0, 2.8);
+  Chi2MatchedME0Muon_Eta_100 = new TH1F("Chi2MatchedME0Muon_Eta_100", "Muon #eta", 4, 2.0, 2.8);
 
-  Chi2MatchedME0Muon_Eta_5_10 = new TH1F("Chi2MatchedME0Muon_Eta_5_10"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  Chi2MatchedME0Muon_Eta_9_11 = new TH1F("Chi2MatchedME0Muon_Eta_9_11"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  Chi2MatchedME0Muon_Eta_10_50 = new TH1F("Chi2MatchedME0Muon_Eta_10_50"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  Chi2MatchedME0Muon_Eta_50_100 = new TH1F("Chi2MatchedME0Muon_Eta_50_100"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  Chi2MatchedME0Muon_Eta_100 = new TH1F("Chi2MatchedME0Muon_Eta_100"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  MatchedME0Muon_Pt = new TH1F("MatchedME0Muon_Pt", "Muon p_{T}", 100, 0, 100.);
+  MatchedME0Muon_SmallBins_Pt = new TH1F("MatchedME0Muon_SmallBins_Pt", "Muon p_{T}", 10, varbins);
+  MatchedME0Muon_VariableBins_Pt = new TH1F("MatchedME0Muon_VariableBins_Pt", "Muon p_{T}", 10, varbins);
 
-  MatchedME0Muon_Pt = new TH1F("MatchedME0Muon_Pt"      , "Muon p_{T}"   , 100,0 , 100. );
-  MatchedME0Muon_SmallBins_Pt = new TH1F("MatchedME0Muon_SmallBins_Pt"      , "Muon p_{T}"   ,10,varbins);
-  MatchedME0Muon_VariableBins_Pt = new TH1F("MatchedME0Muon_VariableBins_Pt"      , "Muon p_{T}"   ,10,varbins);
+  ME0Muon_SmallBins_Pt = new TH1F("ME0Muon_SmallBins_Pt", "Muon p_{T}", 10, varbins);
+  ME0Muon_VariableBins_Pt = new TH1F("ME0Muon_VariableBins_Pt", "Muon p_{T}", 10, varbins);
 
-  ME0Muon_SmallBins_Pt = new TH1F("ME0Muon_SmallBins_Pt"      , "Muon p_{T}"   ,10,varbins);
-  ME0Muon_VariableBins_Pt = new TH1F("ME0Muon_VariableBins_Pt"      , "Muon p_{T}"   ,10,varbins);
+  Chi2MatchedME0Muon_Eta = new TH1F("Chi2MatchedME0Muon_Eta", "Muon #eta", 4, 2.0, 2.8);
+  Chi2MatchedME0Muon_Pt = new TH1F("Chi2MatchedME0Muon_Pt", "Muon p_{T}", 100, 0, 100.);
+  Chi2MatchedME0Muon_SmallBins_Pt = new TH1F("Chi2MatchedME0Muon_SmallBins_Pt", "Muon p_{T}", 10, varbins);
+  Chi2MatchedME0Muon_VariableBins_Pt = new TH1F("Chi2MatchedME0Muon_VariableBins_Pt", "Muon p_{T}", 10, varbins);
 
-  Chi2MatchedME0Muon_Eta = new TH1F("Chi2MatchedME0Muon_Eta"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  Chi2MatchedME0Muon_Pt = new TH1F("Chi2MatchedME0Muon_Pt"      , "Muon p_{T}"   , 100,0 , 100. );
-  Chi2MatchedME0Muon_SmallBins_Pt = new TH1F("Chi2MatchedME0Muon_SmallBins_Pt"      , "Muon p_{T}"   ,10,varbins);
-  Chi2MatchedME0Muon_VariableBins_Pt = new TH1F("Chi2MatchedME0Muon_VariableBins_Pt"      , "Muon p_{T}"   ,10,varbins);
+  Chi2UnmatchedME0Muon_Eta = new TH1F("Chi2UnmatchedME0Muon_Eta", "Muon #eta", 4, 2.0, 2.8);
 
-  Chi2UnmatchedME0Muon_Eta = new TH1F("Chi2UnmatchedME0Muon_Eta"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  UnmatchedME0Muon_Eta = new TH1F("UnmatchedME0Muon_Eta", "Muon #eta", 4, 2.0, 2.8);
+  UnmatchedME0Muon_Cuts_Eta_5_10 = new TH1F("UnmatchedME0Muon_Cuts_Eta_5_10", "Muon #eta", 4, 2.0, 2.8);
+  UnmatchedME0Muon_Cuts_Eta_9_11 = new TH1F("UnmatchedME0Muon_Cuts_Eta_9_11", "Muon #eta", 4, 2.0, 2.8);
+  UnmatchedME0Muon_Cuts_Eta_10_50 = new TH1F("UnmatchedME0Muon_Cuts_Eta_10_50", "Muon #eta", 4, 2.0, 2.8);
+  UnmatchedME0Muon_Cuts_Eta_50_100 = new TH1F("UnmatchedME0Muon_Cuts_Eta_50_100", "Muon #eta", 4, 2.0, 2.8);
+  UnmatchedME0Muon_Cuts_Eta_100 = new TH1F("UnmatchedME0Muon_Cuts_Eta_100", "Muon #eta", 4, 2.0, 2.8);
 
-  UnmatchedME0Muon_Eta = new TH1F("UnmatchedME0Muon_Eta"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  UnmatchedME0Muon_Cuts_Eta_5_10 = new TH1F("UnmatchedME0Muon_Cuts_Eta_5_10"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  UnmatchedME0Muon_Cuts_Eta_9_11 = new TH1F("UnmatchedME0Muon_Cuts_Eta_9_11"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  UnmatchedME0Muon_Cuts_Eta_10_50 = new TH1F("UnmatchedME0Muon_Cuts_Eta_10_50"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  UnmatchedME0Muon_Cuts_Eta_50_100 = new TH1F("UnmatchedME0Muon_Cuts_Eta_50_100"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  UnmatchedME0Muon_Cuts_Eta_100 = new TH1F("UnmatchedME0Muon_Cuts_Eta_100"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  UnmatchedME0Muon_Pt = new TH1F("UnmatchedME0Muon_Pt", "Muon p_{T}", 100, 0, 100.);
+  UnmatchedME0Muon_SmallBins_Pt = new TH1F("UnmatchedME0Muon_SmallBins_Pt", "Muon p_{T}", 10, varbins);
+  UnmatchedME0Muon_VariableBins_Pt = new TH1F("UnmatchedME0Muon_VariableBins_Pt", "Muon p_{T}", 10, varbins);
 
-  UnmatchedME0Muon_Pt = new TH1F("UnmatchedME0Muon_Pt"      , "Muon p_{T}"   , 100,0 , 100. );
-  UnmatchedME0Muon_SmallBins_Pt = new TH1F("UnmatchedME0Muon_SmallBins_Pt"      , "Muon p_{T}"   ,10,varbins);
-  UnmatchedME0Muon_VariableBins_Pt = new TH1F("UnmatchedME0Muon_VariableBins_Pt"      , "Muon p_{T}"   ,10,varbins);
+  Chi2UnmatchedME0Muon_Pt = new TH1F("Chi2UnmatchedME0Muon_Pt", "Muon p_{T}", 100, 0, 100.);
+  Chi2UnmatchedME0Muon_SmallBins_Pt = new TH1F("Chi2UnmatchedME0Muon_SmallBins_Pt", "Muon p_{T}", 10, varbins);
+  Chi2UnmatchedME0Muon_VariableBins_Pt = new TH1F("Chi2UnmatchedME0Muon_VariableBins_Pt", "Muon p_{T}", 10, varbins);
 
-  Chi2UnmatchedME0Muon_Pt = new TH1F("Chi2UnmatchedME0Muon_Pt"      , "Muon p_{T}"   , 100,0 , 100. );
-  Chi2UnmatchedME0Muon_SmallBins_Pt = new TH1F("Chi2UnmatchedME0Muon_SmallBins_Pt"      , "Muon p_{T}"   ,10,varbins);
-  Chi2UnmatchedME0Muon_VariableBins_Pt = new TH1F("Chi2UnmatchedME0Muon_VariableBins_Pt"      , "Muon p_{T}"   ,10,varbins);
+  UnmatchedME0Muon_Window_Pt = new TH1F("UnmatchedME0Muon_Window_Pt", "Muon p_{T}", 500, 0, 50);
 
-  UnmatchedME0Muon_Window_Pt = new TH1F("UnmatchedME0Muon_Window_Pt"      , "Muon p_{T}"   , 500,0 , 50 );
+  UnmatchedME0Muon_Cuts_Eta = new TH1F("UnmatchedME0Muon_Cuts_Eta", "Muon #eta", 4, 2.0, 2.8);
+  ME0Muon_Cuts_Eta = new TH1F("ME0Muon_Cuts_Eta", "Muon #eta", 4, 2.0, 2.8);
 
-  UnmatchedME0Muon_Cuts_Eta = new TH1F("UnmatchedME0Muon_Cuts_Eta"      , "Muon #eta"   , 4, 2.0, 2.8 );
-  ME0Muon_Cuts_Eta = new TH1F("ME0Muon_Cuts_Eta"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  Mass_h = new TH1F("Mass_h", "Mass", 100, 0., 200);
 
-  Mass_h = new TH1F("Mass_h"      , "Mass"   , 100, 0., 200 );
+  MuonRecoEff_Eta = new TH1F("MuonRecoEff_Eta", "Fraction of ME0Muons matched to gen muons", 4, 2.0, 2.8);
 
-  MuonRecoEff_Eta = new TH1F("MuonRecoEff_Eta"      , "Fraction of ME0Muons matched to gen muons"   ,4, 2.0, 2.8  );
+  MuonRecoEff_Eta_5_10 = new TH1F("MuonRecoEff_Eta_5_10", "Fraction of ME0Muons matched to gen muons", 4, 2.0, 2.8);
+  MuonRecoEff_Eta_9_11 = new TH1F("MuonRecoEff_Eta_9_11", "Fraction of ME0Muons matched to gen muons", 4, 2.0, 2.8);
+  MuonRecoEff_Eta_10_50 = new TH1F("MuonRecoEff_Eta_10_50", "Fraction of ME0Muons matched to gen muons", 4, 2.0, 2.8);
+  MuonRecoEff_Eta_50_100 = new TH1F("MuonRecoEff_Eta_50_100", "Fraction of ME0Muons matched to gen muons", 4, 2.0, 2.8);
+  MuonRecoEff_Eta_100 = new TH1F("MuonRecoEff_Eta_100", "Fraction of ME0Muons matched to gen muons", 4, 2.0, 2.8);
+  Chi2MuonRecoEff_Eta = new TH1F("Chi2MuonRecoEff_Eta", "Fraction of ME0Muons matched to gen muons", 4, 2.0, 2.8);
+  Chi2MuonRecoEff_Eta_5_10 =
+      new TH1F("Chi2MuonRecoEff_Eta_5_10", "Fraction of ME0Muons matched to gen muons", 4, 2.0, 2.8);
+  Chi2MuonRecoEff_Eta_9_11 =
+      new TH1F("Chi2MuonRecoEff_Eta_9_11", "Fraction of ME0Muons matched to gen muons", 4, 2.0, 2.8);
+  Chi2MuonRecoEff_Eta_10_50 =
+      new TH1F("Chi2MuonRecoEff_Eta_10_50", "Fraction of ME0Muons matched to gen muons", 4, 2.0, 2.8);
+  Chi2MuonRecoEff_Eta_50_100 =
+      new TH1F("Chi2MuonRecoEff_Eta_50_100", "Fraction of ME0Muons matched to gen muons", 4, 2.0, 2.8);
+  Chi2MuonRecoEff_Eta_100 =
+      new TH1F("Chi2MuonRecoEff_Eta_100", "Fraction of ME0Muons matched to gen muons", 4, 2.0, 2.8);
 
-  MuonRecoEff_Eta_5_10 = new TH1F("MuonRecoEff_Eta_5_10"      , "Fraction of ME0Muons matched to gen muons"   ,4, 2.0, 2.8  );
-  MuonRecoEff_Eta_9_11 = new TH1F("MuonRecoEff_Eta_9_11"      , "Fraction of ME0Muons matched to gen muons"   ,4, 2.0, 2.8  );
-  MuonRecoEff_Eta_10_50 = new TH1F("MuonRecoEff_Eta_10_50"      , "Fraction of ME0Muons matched to gen muons"   ,4, 2.0, 2.8  );
-  MuonRecoEff_Eta_50_100 = new TH1F("MuonRecoEff_Eta_50_100"      , "Fraction of ME0Muons matched to gen muons"   ,4, 2.0, 2.8  );
-  MuonRecoEff_Eta_100 = new TH1F("MuonRecoEff_Eta_100"      , "Fraction of ME0Muons matched to gen muons"   ,4, 2.0, 2.8  );
-  Chi2MuonRecoEff_Eta = new TH1F("Chi2MuonRecoEff_Eta"      , "Fraction of ME0Muons matched to gen muons"   ,4, 2.0, 2.8  );
-  Chi2MuonRecoEff_Eta_5_10 = new TH1F("Chi2MuonRecoEff_Eta_5_10"      , "Fraction of ME0Muons matched to gen muons"   ,4, 2.0, 2.8  );
-  Chi2MuonRecoEff_Eta_9_11 = new TH1F("Chi2MuonRecoEff_Eta_9_11"      , "Fraction of ME0Muons matched to gen muons"   ,4, 2.0, 2.8  );
-  Chi2MuonRecoEff_Eta_10_50 = new TH1F("Chi2MuonRecoEff_Eta_10_50"      , "Fraction of ME0Muons matched to gen muons"   ,4, 2.0, 2.8  );
-  Chi2MuonRecoEff_Eta_50_100 = new TH1F("Chi2MuonRecoEff_Eta_50_100"      , "Fraction of ME0Muons matched to gen muons"   ,4, 2.0, 2.8  );
-  Chi2MuonRecoEff_Eta_100 = new TH1F("Chi2MuonRecoEff_Eta_100"      , "Fraction of ME0Muons matched to gen muons"   ,4, 2.0, 2.8  );
+  MuonRecoEff_Pt = new TH1F("MuonRecoEff_Pt", "Fraction of ME0Muons matched to gen muons", 8, 0, 40);
 
-  MuonRecoEff_Pt = new TH1F("MuonRecoEff_Pt"      , "Fraction of ME0Muons matched to gen muons"   ,8, 0,40  );
+  StandaloneMuonRecoEff_Eta =
+      new TH1F("StandaloneMuonRecoEff_Eta", "Fraction of Standalone Muons matched to gen muons", 4, 2.0, 2.8);
+  StandaloneMuonRecoEff_WideBinning_Eta = new TH1F(
+      "StandaloneMuonRecoEff_WideBinning_Eta", "Fraction of Standalone Muons matched to gen muons", 8, 2.0, 2.8);
+  StandaloneMuonRecoEff_WidestBinning_Eta = new TH1F(
+      "StandaloneMuonRecoEff_WidestBinning_Eta", "Fraction of Standalone Muons matched to gen muons", 16, 2.0, 2.8);
 
-  StandaloneMuonRecoEff_Eta = new TH1F("StandaloneMuonRecoEff_Eta"      , "Fraction of Standalone Muons matched to gen muons"   ,4, 2.0, 2.8  );
-  StandaloneMuonRecoEff_WideBinning_Eta = new TH1F("StandaloneMuonRecoEff_WideBinning_Eta"      , "Fraction of Standalone Muons matched to gen muons"   ,8, 2.0, 2.8  );
-  StandaloneMuonRecoEff_WidestBinning_Eta = new TH1F("StandaloneMuonRecoEff_WidestBinning_Eta"      , "Fraction of Standalone Muons matched to gen muons"   ,16, 2.0, 2.8  );
+  FakeRate_Eta = new TH1F("FakeRate_Eta", "PU140, unmatched ME0Muons/all ME0Muons", 4, 2.0, 2.8);
+  FakeRate_Eta_5_10 = new TH1F("FakeRate_Eta_5_10", "PU140, unmatched ME0Muons/all ME0Muons", 4, 2.0, 2.8);
+  FakeRate_Eta_9_11 = new TH1F("FakeRate_Eta_9_11", "PU140, unmatched ME0Muons/all ME0Muons", 4, 2.0, 2.8);
+  FakeRate_Eta_10_50 = new TH1F("FakeRate_Eta_10_50", "PU140, unmatched ME0Muons/all ME0Muons", 4, 2.0, 2.8);
+  FakeRate_Eta_50_100 = new TH1F("FakeRate_Eta_50_100", "PU140, unmatched ME0Muons/all ME0Muons", 4, 2.0, 2.8);
+  FakeRate_Eta_100 = new TH1F("FakeRate_Eta_100", "PU140, unmatched ME0Muons/all ME0Muons", 4, 2.0, 2.8);
 
-  FakeRate_Eta = new TH1F("FakeRate_Eta"      , "PU140, unmatched ME0Muons/all ME0Muons"   ,4, 2.0, 2.8  );
-  FakeRate_Eta_5_10 = new TH1F("FakeRate_Eta_5_10"      , "PU140, unmatched ME0Muons/all ME0Muons"   ,4, 2.0, 2.8  );
-  FakeRate_Eta_9_11 = new TH1F("FakeRate_Eta_9_11"      , "PU140, unmatched ME0Muons/all ME0Muons"   ,4, 2.0, 2.8  );
-  FakeRate_Eta_10_50 = new TH1F("FakeRate_Eta_10_50"      , "PU140, unmatched ME0Muons/all ME0Muons"   ,4, 2.0, 2.8  );
-  FakeRate_Eta_50_100 = new TH1F("FakeRate_Eta_50_100"      , "PU140, unmatched ME0Muons/all ME0Muons"   ,4, 2.0, 2.8  );
-  FakeRate_Eta_100 = new TH1F("FakeRate_Eta_100"      , "PU140, unmatched ME0Muons/all ME0Muons"   ,4, 2.0, 2.8  );
+  Chi2FakeRate_Eta = new TH1F("Chi2FakeRate_Eta", "PU140, unmatched ME0Muons/all ME0Muons", 4, 2.0, 2.8);
 
-  Chi2FakeRate_Eta = new TH1F("Chi2FakeRate_Eta"      , "PU140, unmatched ME0Muons/all ME0Muons"   ,4, 2.0, 2.8  );
+  FakeRate_Eta_PerEvent =
+      new TH1F("FakeRate_Eta_PerEvent", "PU140, unmatched ME0Muons/all ME0Muons normalized by N_{events}", 4, 2.0, 2.8);
+  FakeRate_Pt = new TH1F("FakeRate_Pt", "PU140, unmatched ME0Muons/all ME0Muons", 8, 0, 40);
 
-  FakeRate_Eta_PerEvent = new TH1F("FakeRate_Eta_PerEvent"      , "PU140, unmatched ME0Muons/all ME0Muons normalized by N_{events}"   ,4, 2.0, 2.8  );
-  FakeRate_Pt = new TH1F("FakeRate_Pt"      , "PU140, unmatched ME0Muons/all ME0Muons"   ,8, 0,40  );
+  MuonAllTracksEff_Eta = new TH1F("MuonAllTracksEff_Eta", "All ME0Muons over all tracks", 4, 2.0, 2.8);
+  MuonAllTracksEff_Pt = new TH1F("MuonAllTracksEff_Pt", "All ME0Muons over all tracks", 8, 0, 40);
 
-  MuonAllTracksEff_Eta = new TH1F("MuonAllTracksEff_Eta"      , "All ME0Muons over all tracks"   ,4, 2.0, 2.8  );
-  MuonAllTracksEff_Pt = new TH1F("MuonAllTracksEff_Pt"      , "All ME0Muons over all tracks"   ,8, 0,40  );
+  MuonUnmatchedTracksEff_Eta =
+      new TH1F("MuonUnmatchedTracksEff_Eta", "Unmatched ME0Muons over all ME0Muons", 4, 2.0, 2.8);
+  MuonUnmatchedTracksEff_Pt = new TH1F("MuonUnmatchedTracksEff_Pt", "Unmatched ME0Muons over all ME0Muons", 8, 0, 40);
 
-  MuonUnmatchedTracksEff_Eta = new TH1F("MuonUnmatchedTracksEff_Eta"      , "Unmatched ME0Muons over all ME0Muons"   ,4, 2.0, 2.8  );
-  MuonUnmatchedTracksEff_Pt = new TH1F("MuonUnmatchedTracksEff_Pt"      , "Unmatched ME0Muons over all ME0Muons"   ,8, 0,40  );
+  TracksPerSegment_h = new TH1F("TracksPerSegment_h", "Number of tracks", 60, 0., 60.);
+  TracksPerSegment_s = new TH2F("TracksPerSegment_s", "Tracks per segment vs |#eta|", 4, 2.0, 2.8, 60, 0., 60.);
+  TracksPerSegment_p = new TProfile("TracksPerSegment_p", "Tracks per segment vs |#eta|", 4, 2.0, 2.8, 0., 60.);
 
-  TracksPerSegment_h = new TH1F("TracksPerSegment_h", "Number of tracks", 60,0.,60.);
-  TracksPerSegment_s = new TH2F("TracksPerSegment_s" , "Tracks per segment vs |#eta|", 4, 2.0, 2.8, 60,0.,60.);
-  TracksPerSegment_p = new TProfile("TracksPerSegment_p" , "Tracks per segment vs |#eta|", 4, 2.0, 2.8, 0.,60.);
+  FakeTracksPerSegment_h = new TH1F("FakeTracksPerSegment_h", "Number of fake tracks", 60, 0., 60.);
+  FakeTracksPerSegment_s = new TH2F("FakeTracksPerSegment_s", "Fake tracks per segment", 10, 2.4, 4.0, 100, 0., 60.);
+  FakeTracksPerSegment_p = new TProfile(
+      "FakeTracksPerSegment_p", "Average N_{tracks}/segment not matched to genmuons", 10, 2.4, 4.0, 0., 60.);
 
-  FakeTracksPerSegment_h = new TH1F("FakeTracksPerSegment_h", "Number of fake tracks", 60,0.,60.);
-  FakeTracksPerSegment_s = new TH2F("FakeTracksPerSegment_s" , "Fake tracks per segment", 10, 2.4, 4.0, 100,0.,60.);
-  FakeTracksPerSegment_p = new TProfile("FakeTracksPerSegment_p" , "Average N_{tracks}/segment not matched to genmuons", 10, 2.4, 4.0, 0.,60.);
+  FakeTracksPerAssociatedSegment_h = new TH1F("FakeTracksPerAssociatedSegment_h", "Number of fake tracks", 60, 0., 60.);
+  FakeTracksPerAssociatedSegment_s =
+      new TH2F("FakeTracksPerAssociatedSegment_s", "Fake tracks per segment", 10, 2.4, 4.0, 100, 0., 60.);
+  FakeTracksPerAssociatedSegment_p = new TProfile(
+      "FakeTracksPerAssociatedSegment_p", "Average N_{tracks}/segment not matched to genmuons", 10, 2.4, 4.0, 0., 60.);
 
-  FakeTracksPerAssociatedSegment_h = new TH1F("FakeTracksPerAssociatedSegment_h", "Number of fake tracks", 60,0.,60.);
-  FakeTracksPerAssociatedSegment_s = new TH2F("FakeTracksPerAssociatedSegment_s" , "Fake tracks per segment", 10, 2.4, 4.0, 100,0.,60.);
-  FakeTracksPerAssociatedSegment_p = new TProfile("FakeTracksPerAssociatedSegment_p" , "Average N_{tracks}/segment not matched to genmuons", 10, 2.4, 4.0, 0.,60.);
+  ClosestDelR_s = new TH2F("ClosestDelR_s", "#Delta R", 4, 2.0, 2.8, 15, 0., 0.15);
+  ClosestDelR_p = new TProfile("ClosestDelR_p", "#Delta R", 4, 2.0, 2.8, 0., 0.15);
 
-  ClosestDelR_s = new TH2F("ClosestDelR_s" , "#Delta R", 4, 2.0, 2.8, 15,0.,0.15);
-  ClosestDelR_p = new TProfile("ClosestDelR_p" , "#Delta R", 4, 2.0, 2.8, 0.,0.15);
+  DelR_Window_Under5 = new TH1F("DelR_Window_Under5", "#Delta R", 15, 0, 0.15);
+  Pt_Window_Under5 = new TH1F("Pt_Window_Under5", "pt", 500, 0, 50);
 
-  DelR_Window_Under5 = new TH1F("DelR_Window_Under5","#Delta R", 15, 0,0.15  );
-  Pt_Window_Under5 = new TH1F("Pt_Window_Under5","pt",500, 0,50  );
+  DelR_Track_Window_Under5 = new TH1F("DelR_Track_Window_Under5", "#Delta R", 15, 0, 0.15);
+  Pt_Track_Window_Under5 = new TH1F("Pt_Track_Window_Under5", "pt", 20, 0, 5);
+  Pt_Track_Window = new TH1F("Pt_Track_Window", "pt", 500, 0, 50);
 
-  DelR_Track_Window_Under5 = new TH1F("DelR_Track_Window_Under5","#Delta R", 15, 0,0.15  );
-  Pt_Track_Window_Under5 = new TH1F("Pt_Track_Window_Under5","pt",20, 0,5  );
-  Pt_Track_Window = new TH1F("Pt_Track_Window","pt",500, 0,  50);
+  DelR_Track_Window_Failed_Under5 = new TH1F("DelR_Track_Window_Failed_Under5", "#Delta R", 15, 0, 0.15);
+  Pt_Track_Window_Failed_Under5 = new TH1F("Pt_Track_Window_Failed_Under5", "pt", 20, 0, 5);
+  Pt_Track_Window_Failed = new TH1F("Pt_Track_Window_Failed", "pt", 500, 0, 50);
 
-  DelR_Track_Window_Failed_Under5 = new TH1F("DelR_Track_Window_Failed_Under5","#Delta R", 15, 0,0.15  );
-  Pt_Track_Window_Failed_Under5 = new TH1F("Pt_Track_Window_Failed_Under5","pt",20, 0,5  );
-  Pt_Track_Window_Failed = new TH1F("Pt_Track_Window_Failed","pt",500, 0,  50);
+  FailedTrack_Window_XPull = new TH1F("FailedTrack_Window_XPull", "X Pull failed tracks", 100, 0, 20);
+  FailedTrack_Window_YPull = new TH1F("FailedTrack_Window_YPull", "Y  Pull failed tracks", 100, 0, 20);
+  FailedTrack_Window_XDiff = new TH1F("FailedTrack_Window_XDiff", "X Diff failed tracks", 100, 0, 20);
+  FailedTrack_Window_YDiff = new TH1F("FailedTrack_Window_YDiff", "Y  Diff failed tracks", 100, 0, 20);
 
-  FailedTrack_Window_XPull = new TH1F("FailedTrack_Window_XPull", "X Pull failed tracks", 100, 0,20);
-  FailedTrack_Window_YPull = new TH1F("FailedTrack_Window_YPull", "Y  Pull failed tracks", 100, 0,20);
-  FailedTrack_Window_XDiff = new TH1F("FailedTrack_Window_XDiff", "X Diff failed tracks", 100, 0,20);
-  FailedTrack_Window_YDiff = new TH1F("FailedTrack_Window_YDiff", "Y  Diff failed tracks", 100, 0,20);
+  FailedTrack_Window_PhiDiff = new TH1F("FailedTrack_Window_PhiDiff", "Phi Dir Diff failed tracks", 100, 0, 2.0);
 
-  FailedTrack_Window_PhiDiff = new TH1F("FailedTrack_Window_PhiDiff", "Phi Dir Diff failed tracks", 100,0 ,2.0);
+  DelR_Segment_GenMuon = new TH1F("DelR_Segment_GenMuon", "#Delta R between me0segment and gen muon", 200, 0, 2);
+  FractionMatched_Eta = new TH1F(
+      "FractionMatched_Eta", "Fraction of ME0Muons that end up successfully matched (matched/all)", 4, 2.0, 2.8);
 
-  DelR_Segment_GenMuon = new TH1F("DelR_Segment_GenMuon", "#Delta R between me0segment and gen muon",200,0,2);
-  FractionMatched_Eta = new TH1F("FractionMatched_Eta"      , "Fraction of ME0Muons that end up successfully matched (matched/all)"   ,4, 2.0, 2.8  );
+  PtDiff_s = new TH2F("PtDiff_s", "Relative pt difference", 4, 2.0, 2.8, 200, -1, 1.0);
 
-  PtDiff_s = new TH2F("PtDiff_s" , "Relative pt difference", 4, 2.0, 2.8, 200,-1,1.0);
+  PtDiff_s_5_10 = new TH2F("PtDiff_s_5_10", "Relative pt difference", 4, 2.0, 2.8, 200, -1, 1.0);
+  PtDiff_s_10_50 = new TH2F("PtDiff_s_10_50", "Relative pt difference", 4, 2.0, 2.8, 200, -1, 1.0);
+  PtDiff_s_50_100 = new TH2F("PtDiff_s_50_100", "Relative pt difference", 4, 2.0, 2.8, 200, -1, 1.0);
+  PtDiff_s_100 = new TH2F("PtDiff_s_100", "Relative pt difference", 4, 2.0, 2.8, 200, -1, 1.0);
 
-  PtDiff_s_5_10 = new TH2F("PtDiff_s_5_10" , "Relative pt difference", 4, 2.0, 2.8, 200,-1,1.0);
-  PtDiff_s_10_50 = new TH2F("PtDiff_s_10_50" , "Relative pt difference", 4, 2.0, 2.8, 200,-1,1.0);
-  PtDiff_s_50_100 = new TH2F("PtDiff_s_50_100" , "Relative pt difference", 4, 2.0, 2.8, 200,-1,1.0);
-  PtDiff_s_100 = new TH2F("PtDiff_s_100" , "Relative pt difference", 4, 2.0, 2.8, 200,-1,1.0);
+  PtDiff_h = new TH1F("PtDiff_h", "pt resolution", 100, -0.5, 0.5);
+  QOverPtDiff_h = new TH1F("QOverPtDiff_h", "q/pt resolution", 100, -0.5, 0.5);
+  PtDiff_p = new TProfile("PtDiff_p", "pt resolution vs. #eta", 4, 2.0, 2.8, -1.0, 1.0, "s");
 
-  PtDiff_h = new TH1F("PtDiff_h" , "pt resolution", 100,-0.5,0.5);
-  QOverPtDiff_h = new TH1F("QOverPtDiff_h" , "q/pt resolution", 100,-0.5,0.5);
-  PtDiff_p = new TProfile("PtDiff_p" , "pt resolution vs. #eta", 4, 2.0, 2.8, -1.0,1.0,"s");
+  StandalonePtDiff_s = new TH2F("StandalonePtDiff_s", "Relative pt difference", 4, 2.0, 2.8, 200, -1, 1.0);
+  StandalonePtDiff_h = new TH1F("StandalonePtDiff_h", "pt resolution", 100, -0.5, 0.5);
+  StandaloneQOverPtDiff_h = new TH1F("StandaloneQOverPtDiff_h", "q/pt resolution", 100, -0.5, 0.5);
+  StandalonePtDiff_p = new TProfile("StandalonePtDiff_p", "pt resolution vs. #eta", 4, 2.0, 2.8, -1.0, 1.0, "s");
 
-  StandalonePtDiff_s = new TH2F("StandalonePtDiff_s" , "Relative pt difference", 4, 2.0, 2.8, 200,-1,1.0);
-  StandalonePtDiff_h = new TH1F("StandalonePtDiff_h" , "pt resolution", 100,-0.5,0.5);
-  StandaloneQOverPtDiff_h = new TH1F("StandaloneQOverPtDiff_h" , "q/pt resolution", 100,-0.5,0.5);
-  StandalonePtDiff_p = new TProfile("StandalonePtDiff_p" , "pt resolution vs. #eta", 4, 2.0, 2.8, -1.0,1.0,"s");
+  PtDiff_rms = new TH1F("PtDiff_rms", "RMS", 4, 2.0, 2.8);
+  PtDiff_gaus_wide = new TH1F("PtDiff_gaus_wide", "GAUS_WIDE", 4, 2.0, 2.8);
+  PtDiff_gaus_narrow = new TH1F("PtDiff_gaus_narrow", "GAUS_NARROW", 4, 2.0, 2.8);
 
-  PtDiff_rms    = new TH1F( "PtDiff_rms",    "RMS", 4, 2.0, 2.8 ); 
-  PtDiff_gaus_wide    = new TH1F( "PtDiff_gaus_wide",    "GAUS_WIDE", 4, 2.0, 2.8 ); 
-  PtDiff_gaus_narrow    = new TH1F( "PtDiff_gaus_narrow",    "GAUS_NARROW", 4, 2.0, 2.8 ); 
+  PtDiff_gaus_5_10 = new TH1F("PtDiff_gaus_5_10", "GAUS_WIDE", 4, 2.0, 2.8);
+  PtDiff_gaus_10_50 = new TH1F("PtDiff_gaus_10_50", "GAUS_WIDE", 4, 2.0, 2.8);
+  PtDiff_gaus_50_100 = new TH1F("PtDiff_gaus_50_100", "GAUS_WIDE", 4, 2.0, 2.8);
+  PtDiff_gaus_100 = new TH1F("PtDiff_gaus_100", "GAUS_WIDE", 4, 2.0, 2.8);
 
-  PtDiff_gaus_5_10    = new TH1F( "PtDiff_gaus_5_10",    "GAUS_WIDE", 4, 2.0, 2.8 ); 
-  PtDiff_gaus_10_50    = new TH1F( "PtDiff_gaus_10_50",    "GAUS_WIDE", 4, 2.0, 2.8 ); 
-  PtDiff_gaus_50_100    = new TH1F( "PtDiff_gaus_50_100",    "GAUS_WIDE", 4, 2.0, 2.8 ); 
-  PtDiff_gaus_100    = new TH1F( "PtDiff_gaus_100",    "GAUS_WIDE", 4, 2.0, 2.8 ); 
+  StandalonePtDiff_gaus = new TH1F("StandalonePtDiff_gaus", "GAUS_WIDE", 4, 2.0, 2.8);
 
-  StandalonePtDiff_gaus    = new TH1F( "StandalonePtDiff_gaus",    "GAUS_WIDE", 4, 2.0, 2.8 ); 
-
-  PDiff_s = new TH2F("PDiff_s" , "Relative p difference", 4, 2.0, 2.8, 50,0.,0.5);
-  PDiff_h = new TH1F("PDiff_s" , "Relative p difference", 50,0.,0.5);
-  PDiff_p = new TProfile("PDiff_p" , "Relative p difference", 4, 2.0, 2.8, 0.,1.0,"s");
+  PDiff_s = new TH2F("PDiff_s", "Relative p difference", 4, 2.0, 2.8, 50, 0., 0.5);
+  PDiff_h = new TH1F("PDiff_s", "Relative p difference", 50, 0., 0.5);
+  PDiff_p = new TProfile("PDiff_p", "Relative p difference", 4, 2.0, 2.8, 0., 1.0, "s");
 
   VertexDiff_h = new TH1F("VertexDiff_h", "Difference in vertex Z", 50, 0, 0.2);
 
-  SegPosDirPhiDiff_True_h = new TH1F("SegPosDirPhiDiff_True_h", "#phi Dir. Diff. Real Muons", 50, -2,2);
-  SegPosDirEtaDiff_True_h = new TH1F("SegPosDirEtaDiff_True_h", "#eta Dir. Diff. Real Muons", 50, -2,2);
+  SegPosDirPhiDiff_True_h = new TH1F("SegPosDirPhiDiff_True_h", "#phi Dir. Diff. Real Muons", 50, -2, 2);
+  SegPosDirEtaDiff_True_h = new TH1F("SegPosDirEtaDiff_True_h", "#eta Dir. Diff. Real Muons", 50, -2, 2);
 
-  SegPosDirPhiDiff_All_h = new TH1F("SegPosDirPhiDiff_All_h", "#phi Dir. Diff. All Muons", 50, -3,3);
-  SegPosDirEtaDiff_All_h = new TH1F("SegPosDirEtaDiff_All_h", "#eta Dir. Diff. All Muons", 50, -3,3);
+  SegPosDirPhiDiff_All_h = new TH1F("SegPosDirPhiDiff_All_h", "#phi Dir. Diff. All Muons", 50, -3, 3);
+  SegPosDirEtaDiff_All_h = new TH1F("SegPosDirEtaDiff_All_h", "#eta Dir. Diff. All Muons", 50, -3, 3);
 
-  SegTrackDirPhiDiff_True_h = new TH1F("SegTrackDirPhiDiff_True_h", "#phi Dir. Diff. Real Muons", 50, -2,2);
-  SegTrackDirEtaDiff_True_h = new TH1F("SegTrackDirEtaDiff_True_h", "#eta Dir. Diff. Real Muons", 50, -2,2);
+  SegTrackDirPhiDiff_True_h = new TH1F("SegTrackDirPhiDiff_True_h", "#phi Dir. Diff. Real Muons", 50, -2, 2);
+  SegTrackDirEtaDiff_True_h = new TH1F("SegTrackDirEtaDiff_True_h", "#eta Dir. Diff. Real Muons", 50, -2, 2);
 
-  SegTrackDirPhiPull_True_h = new TH1F("SegTrackDirPhiPull_True_h", "#phi Dir. Pull. Real Muons", 50, -3,3);
-  SegTrackDirPhiPull_All_h = new TH1F("SegTrackDirPhiPull_True_h", "#phi Dir. Pull. All Muons", 50, -3,3);
+  SegTrackDirPhiPull_True_h = new TH1F("SegTrackDirPhiPull_True_h", "#phi Dir. Pull. Real Muons", 50, -3, 3);
+  SegTrackDirPhiPull_All_h = new TH1F("SegTrackDirPhiPull_True_h", "#phi Dir. Pull. All Muons", 50, -3, 3);
 
-  SegTrackDirPhiDiff_All_h = new TH1F("SegTrackDirPhiDiff_All_h", "#phi Dir. Diff. All Muons", 50, -3,3);
-  SegTrackDirEtaDiff_All_h = new TH1F("SegTrackDirEtaDiff_All_h", "#eta Dir. Diff. All Muons", 50, -3,3);
+  SegTrackDirPhiDiff_All_h = new TH1F("SegTrackDirPhiDiff_All_h", "#phi Dir. Diff. All Muons", 50, -3, 3);
+  SegTrackDirEtaDiff_All_h = new TH1F("SegTrackDirEtaDiff_All_h", "#eta Dir. Diff. All Muons", 50, -3, 3);
 
-  SegGenDirPhiDiff_True_h = new TH1F("SegGenDirPhiDiff_True_h", "#phi Dir. Diff. Real Muons", 50, -2,2);
-  SegGenDirEtaDiff_True_h = new TH1F("SegGenDirEtaDiff_True_h", "#eta Dir. Diff. Real Muons", 50, -2,2);
+  SegGenDirPhiDiff_True_h = new TH1F("SegGenDirPhiDiff_True_h", "#phi Dir. Diff. Real Muons", 50, -2, 2);
+  SegGenDirEtaDiff_True_h = new TH1F("SegGenDirEtaDiff_True_h", "#eta Dir. Diff. Real Muons", 50, -2, 2);
 
-  SegGenDirPhiPull_True_h = new TH1F("SegGenDirPhiPull_True_h", "#phi Dir. Pull. Real Muons", 50, -3,3);
-  SegGenDirPhiPull_All_h = new TH1F("SegGenDirPhiPull_True_h", "#phi Dir. Pull. All Muons", 50, -3,3);
+  SegGenDirPhiPull_True_h = new TH1F("SegGenDirPhiPull_True_h", "#phi Dir. Pull. Real Muons", 50, -3, 3);
+  SegGenDirPhiPull_All_h = new TH1F("SegGenDirPhiPull_True_h", "#phi Dir. Pull. All Muons", 50, -3, 3);
 
-  SegGenDirPhiDiff_All_h = new TH1F("SegGenDirPhiDiff_All_h", "#phi Dir. Diff. All Muons", 50, -3,3);
-  SegGenDirEtaDiff_All_h = new TH1F("SegGenDirEtaDiff_All_h", "#eta Dir. Diff. All Muons", 50, -3,3);
-
+  SegGenDirPhiDiff_All_h = new TH1F("SegGenDirPhiDiff_All_h", "#phi Dir. Diff. All Muons", 50, -3, 3);
+  SegGenDirEtaDiff_All_h = new TH1F("SegGenDirEtaDiff_All_h", "#eta Dir. Diff. All Muons", 50, -3, 3);
 
   PreMatch_TP_R = new TH1F("PreMatch_TP_R", "r distance from TP pre match to beamline", 100, 0, 10);
   PostMatch_TP_R = new TH1F("PostMatch_TP_R", "r distance from TP post match to beamline", 200, 0, 20);
   PostMatch_BX0_TP_R = new TH1F("PostMatch_BX0_TP_R", "r distance from TP post match to beamline", 200, 0, 20);
 
+  XDiff_h = new TH1F("XDiff_h", "X Diff", 100, -10.0, 10.0);
+  YDiff_h = new TH1F("YDiff_h", "Y Diff", 100, -50.0, 50.0);
+  XPull_h = new TH1F("XPull_h", "X Pull", 100, -5.0, 5.0);
+  YPull_h = new TH1F("YPull_h", "Y Pull", 40, -50.0, 50.0);
 
-  XDiff_h = new TH1F("XDiff_h", "X Diff", 100, -10.0, 10.0 );
-  YDiff_h = new TH1F("YDiff_h", "Y Diff", 100, -50.0, 50.0 ); 
-  XPull_h = new TH1F("XPull_h", "X Pull", 100, -5.0, 5.0 );
-  YPull_h = new TH1F("YPull_h", "Y Pull", 40, -50.0, 50.0 );
+  MuonRecoEff_WideBinning_Eta =
+      new TH1F("MuonRecoEff_WideBinning_Eta", "Fraction of ME0Muons matched to gen muons", 8, 2.0, 2.8);
+  MuonRecoEff_WidestBinning_Eta =
+      new TH1F("MuonRecoEff_WidestBinning_Eta", "Fraction of ME0Muons matched to gen muons", 16, 2.0, 2.8);
+  Chi2MuonRecoEff_WideBinning_Eta =
+      new TH1F("Chi2MuonRecoEff_WideBinning_Eta", "Fraction of ME0Muons matched to gen muons", 8, 2.0, 2.8);
+  Chi2MuonRecoEff_WidestBinning_Eta =
+      new TH1F("Chi2MuonRecoEff_WidestBinning_Eta", "Fraction of ME0Muons matched to gen muons", 16, 2.0, 2.8);
+  Chi2FakeRate_WideBinning_Eta =
+      new TH1F("Chi2FakeRate_WideBinning_Eta", "PU140, unmatched ME0Muons/all ME0Muons", 8, 2.0, 2.8);
+  Chi2FakeRate_WidestBinning_Eta =
+      new TH1F("Chi2FakeRate_WidestBinning_Eta", "PU140, unmatched ME0Muons/all ME0Muons", 16, 2.0, 2.8);
+  FakeRate_WideBinning_Eta =
+      new TH1F("FakeRate_WideBinning_Eta", "PU140, unmatched ME0Muons/all ME0Muons", 8, 2.0, 2.8);
+  FakeRate_WidestBinning_Eta =
+      new TH1F("FakeRate_WidestBinning_Eta", "PU140, unmatched ME0Muons/all ME0Muons", 16, 2.0, 2.8);
 
-  MuonRecoEff_WideBinning_Eta = new TH1F("MuonRecoEff_WideBinning_Eta"      , "Fraction of ME0Muons matched to gen muons"   ,8, 2.0, 2.8  );
-  MuonRecoEff_WidestBinning_Eta = new TH1F("MuonRecoEff_WidestBinning_Eta"      , "Fraction of ME0Muons matched to gen muons"   ,16, 2.0, 2.8  );
-  Chi2MuonRecoEff_WideBinning_Eta = new TH1F("Chi2MuonRecoEff_WideBinning_Eta"      , "Fraction of ME0Muons matched to gen muons"   ,8, 2.0, 2.8  );
-  Chi2MuonRecoEff_WidestBinning_Eta = new TH1F("Chi2MuonRecoEff_WidestBinning_Eta"      , "Fraction of ME0Muons matched to gen muons"   ,16, 2.0, 2.8  );
-  Chi2FakeRate_WideBinning_Eta = new TH1F("Chi2FakeRate_WideBinning_Eta"      , "PU140, unmatched ME0Muons/all ME0Muons"   ,8, 2.0, 2.8  );
-  Chi2FakeRate_WidestBinning_Eta = new TH1F("Chi2FakeRate_WidestBinning_Eta"      , "PU140, unmatched ME0Muons/all ME0Muons"   ,16, 2.0, 2.8  );
-  FakeRate_WideBinning_Eta = new TH1F("FakeRate_WideBinning_Eta"      , "PU140, unmatched ME0Muons/all ME0Muons"   ,8, 2.0, 2.8  );
-  FakeRate_WidestBinning_Eta = new TH1F("FakeRate_WidestBinning_Eta"      , "PU140, unmatched ME0Muons/all ME0Muons"   ,16, 2.0, 2.8  );
+  UnmatchedME0Muon_Cuts_WideBinning_Eta = new TH1F("UnmatchedME0Muon_Cuts_WideBinning_Eta", "Muon #eta", 8, 2.0, 2.8);
+  UnmatchedME0Muon_Cuts_WidestBinning_Eta =
+      new TH1F("UnmatchedME0Muon_Cuts_WidestBinning_Eta", "Muon #eta", 16, 2.0, 2.8);
+  ME0Muon_Cuts_WideBinning_Eta = new TH1F("ME0Muon_Cuts_WideBinning_Eta", "Muon #eta", 8, 2.0, 2.8);
+  ME0Muon_Cuts_WidestBinning_Eta = new TH1F("ME0Muon_Cuts_WidestBinning_Eta", "Muon #eta", 16, 2.0, 2.8);
+  Chi2UnmatchedME0Muon_WideBinning_Eta = new TH1F("Chi2UnmatchedME0Muon_WideBinning_Eta", "Muon #eta", 8, 2.0, 2.8);
+  Chi2UnmatchedME0Muon_WidestBinning_Eta =
+      new TH1F("Chi2UnmatchedME0Muon_WidestBinning_Eta", "Muon #eta", 16, 2.0, 2.8);
+  TPMuon_WideBinning_Eta = new TH1F("TPMuon_WideBinning_Eta", "Muon #eta", 8, 2.0, 2.8);
+  TPMuon_WidestBinning_Eta = new TH1F("TPMuon_WidestBinning_Eta", "Muon #eta", 16, 2.0, 2.8);
+  GenMuon_WideBinning_Eta = new TH1F("GenMuon_WideBinning_Eta", "Muon #eta", 8, 2.0, 2.8);
+  GenMuon_WidestBinning_Eta = new TH1F("GenMuon_WidestBinning_Eta", "Muon #eta", 16, 2.0, 2.8);
+  MatchedME0Muon_WideBinning_Eta = new TH1F("MatchedME0Muon_WideBinning_Eta", "Muon #eta", 8, 2.0, 2.8);
+  MatchedME0Muon_WidestBinning_Eta = new TH1F("MatchedME0Muon_WidestBinning_Eta", "Muon #eta", 16, 2.0, 2.8);
+  Chi2MatchedME0Muon_WideBinning_Eta = new TH1F("Chi2MatchedME0Muon_WideBinning_Eta", "Muon #eta", 8, 2.0, 2.8);
+  Chi2MatchedME0Muon_WidestBinning_Eta = new TH1F("Chi2MatchedME0Muon_WidestBinning_Eta", "Muon #eta", 16, 2.0, 2.8);
 
-  UnmatchedME0Muon_Cuts_WideBinning_Eta = new TH1F("UnmatchedME0Muon_Cuts_WideBinning_Eta"      , "Muon #eta"   , 8, 2.0, 2.8 );
-  UnmatchedME0Muon_Cuts_WidestBinning_Eta = new TH1F("UnmatchedME0Muon_Cuts_WidestBinning_Eta"      , "Muon #eta"   , 16, 2.0, 2.8 );
-  ME0Muon_Cuts_WideBinning_Eta = new TH1F("ME0Muon_Cuts_WideBinning_Eta"      , "Muon #eta"   , 8, 2.0, 2.8 );
-  ME0Muon_Cuts_WidestBinning_Eta = new TH1F("ME0Muon_Cuts_WidestBinning_Eta"      , "Muon #eta"   , 16, 2.0, 2.8 );
-  Chi2UnmatchedME0Muon_WideBinning_Eta = new TH1F("Chi2UnmatchedME0Muon_WideBinning_Eta"      , "Muon #eta"   , 8, 2.0, 2.8 );
-  Chi2UnmatchedME0Muon_WidestBinning_Eta = new TH1F("Chi2UnmatchedME0Muon_WidestBinning_Eta"      , "Muon #eta"   , 16, 2.0, 2.8 );
-  TPMuon_WideBinning_Eta = new TH1F("TPMuon_WideBinning_Eta"      , "Muon #eta"   , 8, 2.0, 2.8 );
-  TPMuon_WidestBinning_Eta = new TH1F("TPMuon_WidestBinning_Eta"      , "Muon #eta"   , 16, 2.0, 2.8 );
-  GenMuon_WideBinning_Eta = new TH1F("GenMuon_WideBinning_Eta"      , "Muon #eta"   , 8, 2.0, 2.8 );
-  GenMuon_WidestBinning_Eta = new TH1F("GenMuon_WidestBinning_Eta"      , "Muon #eta"   , 16, 2.0, 2.8 );
-  MatchedME0Muon_WideBinning_Eta = new TH1F("MatchedME0Muon_WideBinning_Eta"      , "Muon #eta"   , 8, 2.0, 2.8 );
-  MatchedME0Muon_WidestBinning_Eta = new TH1F("MatchedME0Muon_WidestBinning_Eta"      , "Muon #eta"   , 16, 2.0, 2.8 );
-  Chi2MatchedME0Muon_WideBinning_Eta = new TH1F("Chi2MatchedME0Muon_WideBinning_Eta"      , "Muon #eta"   , 8, 2.0, 2.8 );
-  Chi2MatchedME0Muon_WidestBinning_Eta = new TH1F("Chi2MatchedME0Muon_WidestBinning_Eta"      , "Muon #eta"   , 16, 2.0, 2.8 );
+  UnmatchedME0Muon_ScatterPlot =
+      new TH2F("UnmatchedME0Muon_ScatterPlot", "Muon #eta vs. #phi", 16, 2.0, 2.8, 8, 0., 3.14);
 
-  UnmatchedME0Muon_ScatterPlot = new TH2F("UnmatchedME0Muon_ScatterPlot"      , "Muon #eta vs. #phi"   , 16, 2.0, 2.8, 8, 0., 3.14 );
+  AssociatedChi2_h = new TH1F("AssociatedChi2_h", "Associated #chi^{2}", 50, 0, 50);
+  AssociatedChi2_Prob_h = new TH1F("AssociatedChi2_h", "Associated #chi^{2}", 50, 0, 1);
+  NormChi2_h = new TH1F("NormChi2_h", "normalized #chi^{2}", 200, 0, 20);
+  NormChi2Prob_h = new TH1F("NormChi2Prob_h", "normalized #chi^{2} probability", 100, 0, 1);
+  NormChi2VsHits_h = new TH2F("NormChi2VsHits_h", "#chi^{2} vs nhits", 25, 0, 25, 100, 0, 10);
+  chi2_vs_eta_h = new TH2F("chi2_vs_eta_h", "#chi^{2} vs #eta", 4, 2.0, 2.8, 200, 0, 20);
 
- 
-  AssociatedChi2_h = new TH1F("AssociatedChi2_h","Associated #chi^{2}",50,0,50);
-  AssociatedChi2_Prob_h = new TH1F("AssociatedChi2_h","Associated #chi^{2}",50,0,1);
-  NormChi2_h = new TH1F("NormChi2_h","normalized #chi^{2}", 200, 0, 20);
-  NormChi2Prob_h = new TH1F("NormChi2Prob_h","normalized #chi^{2} probability", 100, 0, 1);
-  NormChi2VsHits_h = new TH2F("NormChi2VsHits_h","#chi^{2} vs nhits",25,0,25,100,0,10);
-  chi2_vs_eta_h = new TH2F("chi2_vs_eta_h","#chi^{2} vs #eta",4, 2.0, 2.8 , 200, 0, 20);
-
-  Nevents=0;
-
-
-
+  Nevents = 0;
 }
 
+ME0MuonAnalyzer::~ME0MuonAnalyzer() {}
 
-ME0MuonAnalyzer::~ME0MuonAnalyzer(){}
-
-void
-ME0MuonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+void ME0MuonAnalyzer::analyze(const edm::Event &iEvent, const edm::EventSetup &iSetup)
 
 {
-
   Nevents_h->Fill(1);
   using namespace edm;
 
-
   if (UseAssociators) {
     edm::Handle<reco::TrackToTrackingParticleAssociator> theAssociator;
-    for (unsigned int w=0;w<associators.size();w++) {
-      iEvent.getByLabel(associators[w],theAssociator);
-      associator.push_back( theAssociator.product() );
+    for (unsigned int w = 0; w < associators.size(); w++) {
+      iEvent.getByLabel(associators[w], theAssociator);
+      associator.push_back(theAssociator.product());
     }
   }
-
 
   using namespace reco;
   Handle<GenParticleCollection> genParticles;
   iEvent.getByToken(genParticlesToken_, genParticles);
   const GenParticleCollection genParticlesForChi2 = *(genParticles.product());
 
-  unsigned int gensize=genParticles->size();
+  unsigned int gensize = genParticles->size();
 
   Handle<TrackingParticleCollection> trackingParticles;
   iEvent.getByToken(trackingParticlesToken_, trackingParticles);
 
-
-  if (RejectEndcapMuons){
+  if (RejectEndcapMuons) {
     //Section to turn off signal muons in the endcaps, to approximate a nu gun
-    for(unsigned int i=0; i<gensize; ++i) {
-      const reco::GenParticle& CurrentParticle=(*genParticles)[i];
-      if ( (CurrentParticle.status()==1) && ( (CurrentParticle.pdgId()==13)  || (CurrentParticle.pdgId()==-13) ) ){  
-	if (fabs(CurrentParticle.eta()) > 1.9 ) {
-	  //std::cout<<"Found a signal muon outside the barrel, exiting the function"<<std::endl;
-	  return;
-	}
+    for (unsigned int i = 0; i < gensize; ++i) {
+      const reco::GenParticle &CurrentParticle = (*genParticles)[i];
+      if ((CurrentParticle.status() == 1) && ((CurrentParticle.pdgId() == 13) || (CurrentParticle.pdgId() == -13))) {
+        if (fabs(CurrentParticle.eta()) > 1.9) {
+          //std::cout<<"Found a signal muon outside the barrel, exiting the function"<<std::endl;
+          return;
+        }
       }
-    }      
+    }
   }
-
-
 
   Nevents++;
 
+  Handle<TrackCollection> generalTracks;
+  iEvent.getByToken(generalTracksToken_, generalTracks);
 
-  Handle <TrackCollection > generalTracks;
-  iEvent.getByToken (generalTracksToken_, generalTracks);
-
-  Handle <std::vector<ME0Muon> > OurMuons;
-  iEvent.getByToken (OurMuonsToken_, OurMuons);
+  Handle<std::vector<ME0Muon> > OurMuons;
+  iEvent.getByToken(OurMuonsToken_, OurMuons);
 
   Handle<ME0SegmentCollection> OurSegments;
-  iEvent.getByToken(OurSegmentsToken_,OurSegments);
-
+  iEvent.getByToken(OurSegmentsToken_, OurSegments);
 
   edm::ESHandle<ME0Geometry> me0Geom;
   iSetup.get<MuonGeometryRecord>().get(me0Geom);
@@ -634,183 +760,184 @@ ME0MuonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   iSetup.get<IdealMagneticFieldRecord>().get(bField);
   ESHandle<Propagator> shProp;
   iSetup.get<TrackingComponentsRecord>().get("SteppingHelixPropagatorAlong", shProp);
-  
+
   //    -----First, make a vector of bools for each ME0Muon
 
   std::vector<bool> IsMatched;
   std::vector<int> SegIdForMatch;
-  for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
-       thisMuon != OurMuons->end(); ++thisMuon){
-    if (!muon::isGoodMuon(*thisMuon, muon::Tight)) continue;
+  for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin(); thisMuon != OurMuons->end(); ++thisMuon) {
+    if (!muon::isGoodMuon(*thisMuon, muon::Tight))
+      continue;
     IsMatched.push_back(false);
     SegIdForMatch.push_back(-1);
   }
- 
 
   //=====Finding ME0Muons that match gen muons, plotting the closest of those
   std::vector<int> MatchedSegIds;
 
-  for(unsigned int i=0; i<gensize; ++i) {
-    const reco::GenParticle& CurrentParticle=(*genParticles)[i];
-    if ( (CurrentParticle.status()==1) && ( (CurrentParticle.pdgId()==13)  || (CurrentParticle.pdgId()==-13) ) ){  
-     
+  for (unsigned int i = 0; i < gensize; ++i) {
+    const reco::GenParticle &CurrentParticle = (*genParticles)[i];
+    if ((CurrentParticle.status() == 1) && ((CurrentParticle.pdgId() == 13) || (CurrentParticle.pdgId() == -13))) {
       double LowestDelR = 9999;
       double thisDelR = 9999;
       int MatchedID = -1;
       int ME0MuonID = 0;
 
-
       std::vector<double> ReferenceTrackPt;
 
-      double VertexDiff=-1,PtDiff=-1,QOverPtDiff=-1,PDiff=-1;
+      double VertexDiff = -1, PtDiff = -1, QOverPtDiff = -1, PDiff = -1;
 
-      for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
-	   thisMuon != OurMuons->end(); ++thisMuon){
-	if (!muon::isGoodMuon(*thisMuon, muon::Tight)) continue;
-	TrackRef tkRef = thisMuon->innerTrack();
-	SegIdForMatch.push_back(thisMuon->me0segid());
-	thisDelR = reco::deltaR(CurrentParticle,*tkRef);
-	ReferenceTrackPt.push_back(tkRef->pt());
+      for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin(); thisMuon != OurMuons->end(); ++thisMuon) {
+        if (!muon::isGoodMuon(*thisMuon, muon::Tight))
+          continue;
+        TrackRef tkRef = thisMuon->innerTrack();
+        SegIdForMatch.push_back(thisMuon->me0segid());
+        thisDelR = reco::deltaR(CurrentParticle, *tkRef);
+        ReferenceTrackPt.push_back(tkRef->pt());
 
+        if ((tkRef->pt() > FakeRatePtCut)) {
+          if (thisDelR < MatchingWindowDelR) {
+            if (tkRef->pt() < 5.0) {
+              DelR_Window_Under5->Fill(thisDelR);
+              Pt_Window_Under5->Fill(tkRef->pt());
+            }
+            if (thisDelR < LowestDelR) {
+              LowestDelR = thisDelR;
+              //if (fabs(tkRef->pt() - CurrentParticle.pt())/CurrentParticle.pt() < 0.50) MatchedID = ME0MuonID;
+              MatchedID = ME0MuonID;
+              VertexDiff = fabs(tkRef->vz() - CurrentParticle.vz());
+              QOverPtDiff = ((tkRef->charge() / tkRef->pt()) - (CurrentParticle.charge() / CurrentParticle.pt())) /
+                            (CurrentParticle.charge() / CurrentParticle.pt());
+              PtDiff = (tkRef->pt() - CurrentParticle.pt()) / CurrentParticle.pt();
+              PDiff = (tkRef->p() - CurrentParticle.p()) / CurrentParticle.p();
+            }
+          }
+        }
 
-	if (( tkRef->pt() > FakeRatePtCut )  ){
-	  if (thisDelR < MatchingWindowDelR ){
-	    if (tkRef->pt() < 5.0){
-	      DelR_Window_Under5->Fill(thisDelR);
-	      Pt_Window_Under5->Fill(tkRef->pt());
-	    }
-	    if (thisDelR < LowestDelR){
-	      LowestDelR = thisDelR;
-	      //if (fabs(tkRef->pt() - CurrentParticle.pt())/CurrentParticle.pt() < 0.50) MatchedID = ME0MuonID;
-	      MatchedID = ME0MuonID;
-	      VertexDiff = fabs(tkRef->vz()-CurrentParticle.vz());
-	      QOverPtDiff = ( (tkRef->charge() /tkRef->pt()) - (CurrentParticle.charge()/CurrentParticle.pt() ) )/  (CurrentParticle.charge()/CurrentParticle.pt() );
-	      PtDiff = (tkRef->pt() - CurrentParticle.pt())/CurrentParticle.pt();
-	      PDiff = (tkRef->p() - CurrentParticle.p())/CurrentParticle.p();
-	    }
-	  }
-	}
-	
-	ME0MuonID++;
-
+        ME0MuonID++;
       }
 
-      for (std::vector<Track>::const_iterator thisTrack = generalTracks->begin();
-	   thisTrack != generalTracks->end();++thisTrack){
-	//TrackRef tkRef = thisTrack->innerTrack();
-	thisDelR = reco::deltaR(CurrentParticle,*thisTrack);
+      for (std::vector<Track>::const_iterator thisTrack = generalTracks->begin(); thisTrack != generalTracks->end();
+           ++thisTrack) {
+        //TrackRef tkRef = thisTrack->innerTrack();
+        thisDelR = reco::deltaR(CurrentParticle, *thisTrack);
 
-	if ((thisTrack->pt() > FakeRatePtCut ) ){
-	  if (thisDelR < MatchingWindowDelR ){
-	    if (thisTrack->pt() < 5.0){
-	      DelR_Track_Window_Under5->Fill(thisDelR);
-	      Pt_Track_Window_Under5->Fill(thisTrack->pt());
-	    }
-	    Pt_Track_Window->Fill(thisTrack->pt());
-	  }
-	}
+        if ((thisTrack->pt() > FakeRatePtCut)) {
+          if (thisDelR < MatchingWindowDelR) {
+            if (thisTrack->pt() < 5.0) {
+              DelR_Track_Window_Under5->Fill(thisDelR);
+              Pt_Track_Window_Under5->Fill(thisTrack->pt());
+            }
+            Pt_Track_Window->Fill(thisTrack->pt());
+          }
+        }
       }
-      if (MatchedID == -1){
-	
-	for (std::vector<Track>::const_iterator thisTrack = generalTracks->begin();
-	     thisTrack != generalTracks->end();++thisTrack){
-	  //TrackRef tkRef = thisTrack->innerTrack();
-	  thisDelR = reco::deltaR(CurrentParticle,*thisTrack);
+      if (MatchedID == -1) {
+        for (std::vector<Track>::const_iterator thisTrack = generalTracks->begin(); thisTrack != generalTracks->end();
+             ++thisTrack) {
+          //TrackRef tkRef = thisTrack->innerTrack();
+          thisDelR = reco::deltaR(CurrentParticle, *thisTrack);
 
-
-	  if ( (thisTrack->pt() > FakeRatePtCut ) && (TMath::Abs(thisTrack->eta()) < 2.8) && (TMath::Abs(thisTrack->eta()) > 2.0) )  {
-	    if (thisDelR < MatchingWindowDelR ){
-	      if (thisTrack->pt() < 5.0){
-		DelR_Track_Window_Failed_Under5->Fill(thisDelR);
-		Pt_Track_Window_Failed_Under5->Fill(thisTrack->pt());
-	      }
-	      Pt_Track_Window_Failed->Fill(thisTrack->pt());
-
-	    }
-	  }
-	}
+          if ((thisTrack->pt() > FakeRatePtCut) && (TMath::Abs(thisTrack->eta()) < 2.8) &&
+              (TMath::Abs(thisTrack->eta()) > 2.0)) {
+            if (thisDelR < MatchingWindowDelR) {
+              if (thisTrack->pt() < 5.0) {
+                DelR_Track_Window_Failed_Under5->Fill(thisDelR);
+                Pt_Track_Window_Failed_Under5->Fill(thisTrack->pt());
+              }
+              Pt_Track_Window_Failed->Fill(thisTrack->pt());
+            }
+          }
+        }
       }
 
-      if (MatchedID != -1){
-	IsMatched[MatchedID] = true;
+      if (MatchedID != -1) {
+        IsMatched[MatchedID] = true;
 
-	if ((CurrentParticle.pt() >FakeRatePtCut) ){
-	  MatchedME0Muon_Eta->Fill(fabs(CurrentParticle.eta()));
-	  if ( (TMath::Abs(CurrentParticle.eta()) > 2.0) && (TMath::Abs(CurrentParticle.eta()) < 2.8) )  {
-	    MatchedME0Muon_Pt->Fill(CurrentParticle.pt());
-	    MatchedME0Muon_SmallBins_Pt->Fill(CurrentParticle.pt());
-	    MatchedME0Muon_VariableBins_Pt->Fill(CurrentParticle.pt());
-	  }
+        if ((CurrentParticle.pt() > FakeRatePtCut)) {
+          MatchedME0Muon_Eta->Fill(fabs(CurrentParticle.eta()));
+          if ((TMath::Abs(CurrentParticle.eta()) > 2.0) && (TMath::Abs(CurrentParticle.eta()) < 2.8)) {
+            MatchedME0Muon_Pt->Fill(CurrentParticle.pt());
+            MatchedME0Muon_SmallBins_Pt->Fill(CurrentParticle.pt());
+            MatchedME0Muon_VariableBins_Pt->Fill(CurrentParticle.pt());
+          }
 
+          MatchedME0Muon_WideBinning_Eta->Fill(fabs(CurrentParticle.eta()));
+          MatchedME0Muon_WidestBinning_Eta->Fill(fabs(CurrentParticle.eta()));
+          if ((CurrentParticle.pt() > 5.0) && (CurrentParticle.pt() <= 10.0))
+            MatchedME0Muon_Eta_5_10->Fill(fabs(CurrentParticle.eta()));
+          if ((CurrentParticle.pt() > 9.0) && (CurrentParticle.pt() <= 11.0))
+            MatchedME0Muon_Eta_9_11->Fill(fabs(CurrentParticle.eta()));
+          if ((CurrentParticle.pt() > 10.0) && (CurrentParticle.pt() <= 50.0))
+            MatchedME0Muon_Eta_10_50->Fill(fabs(CurrentParticle.eta()));
+          if ((CurrentParticle.pt() > 50.0) && (CurrentParticle.pt() <= 100.0))
+            MatchedME0Muon_Eta_50_100->Fill(fabs(CurrentParticle.eta()));
+          if (CurrentParticle.pt() > 100.0)
+            MatchedME0Muon_Eta_100->Fill(fabs(CurrentParticle.eta()));
 
-	  MatchedME0Muon_WideBinning_Eta->Fill(fabs(CurrentParticle.eta()));
-	  MatchedME0Muon_WidestBinning_Eta->Fill(fabs(CurrentParticle.eta()));
-	  if ( (CurrentParticle.pt() > 5.0) && (CurrentParticle.pt() <= 10.0) )  	MatchedME0Muon_Eta_5_10->Fill(fabs(CurrentParticle.eta()));
-	  if ( (CurrentParticle.pt() > 9.0) && (CurrentParticle.pt() <= 11.0) )  	MatchedME0Muon_Eta_9_11->Fill(fabs(CurrentParticle.eta()));
-	  if ( (CurrentParticle.pt() > 10.0) && (CurrentParticle.pt() <= 50.0) )	MatchedME0Muon_Eta_10_50->Fill(fabs(CurrentParticle.eta()));
-	  if ( (CurrentParticle.pt() > 50.0) && (CurrentParticle.pt() <= 100.0) )	MatchedME0Muon_Eta_50_100->Fill(fabs(CurrentParticle.eta()));
-	  if ( CurrentParticle.pt() > 100.0) 		MatchedME0Muon_Eta_100->Fill(fabs(CurrentParticle.eta()));
-	
+          VertexDiff_h->Fill(VertexDiff);
+          PtDiff_h->Fill(PtDiff);
+          QOverPtDiff_h->Fill(QOverPtDiff);
+          PtDiff_s->Fill(CurrentParticle.eta(), PtDiff);
+          if ((CurrentParticle.pt() > 5.0) && (CurrentParticle.pt() <= 10.0))
+            PtDiff_s_5_10->Fill(CurrentParticle.eta(), PtDiff);
+          if ((CurrentParticle.pt() > 10.0) && (CurrentParticle.pt() <= 50.0))
+            PtDiff_s_10_50->Fill(CurrentParticle.eta(), PtDiff);
+          if ((CurrentParticle.pt() > 50.0) && (CurrentParticle.pt() <= 100.0))
+            PtDiff_s_50_100->Fill(CurrentParticle.eta(), PtDiff);
+          if (CurrentParticle.pt() > 100.0)
+            PtDiff_s_100->Fill(CurrentParticle.eta(), PtDiff);
+          PtDiff_p->Fill(CurrentParticle.eta(), PtDiff);
 
-
-	  VertexDiff_h->Fill(VertexDiff);
-	  PtDiff_h->Fill(PtDiff);	
-	  QOverPtDiff_h->Fill(QOverPtDiff);
-	  PtDiff_s->Fill(CurrentParticle.eta(),PtDiff);
-	  if ( (CurrentParticle.pt() > 5.0) && (CurrentParticle.pt() <= 10.0) ) 	PtDiff_s_5_10->Fill(CurrentParticle.eta(),PtDiff);
-	  if ( (CurrentParticle.pt() > 10.0) && (CurrentParticle.pt() <= 50.0) )	PtDiff_s_10_50->Fill(CurrentParticle.eta(),PtDiff);
-	  if ( (CurrentParticle.pt() > 50.0) && (CurrentParticle.pt() <= 100.0) )	PtDiff_s_50_100->Fill(CurrentParticle.eta(),PtDiff);
-	  if ( CurrentParticle.pt() > 100.0) 	PtDiff_s_100->Fill(CurrentParticle.eta(),PtDiff);
-	  PtDiff_p->Fill(CurrentParticle.eta(),PtDiff);
-	
-	  PDiff_h->Fill(PDiff);
-	  PDiff_s->Fill(CurrentParticle.eta(),PDiff);
-	  PDiff_p->Fill(CurrentParticle.eta(),PDiff);
-	}
-	MatchedSegIds.push_back(SegIdForMatch[MatchedID]);
+          PDiff_h->Fill(PDiff);
+          PDiff_s->Fill(CurrentParticle.eta(), PDiff);
+          PDiff_p->Fill(CurrentParticle.eta(), PDiff);
+        }
+        MatchedSegIds.push_back(SegIdForMatch[MatchedID]);
       }
 
-
-	if ( (CurrentParticle.pt() >FakeRatePtCut) ){
-	  GenMuon_Eta->Fill(fabs(CurrentParticle.eta()));
-	  GenMuon_WideBinning_Eta->Fill(fabs(CurrentParticle.eta()));
-	  GenMuon_WidestBinning_Eta->Fill(fabs(CurrentParticle.eta()));
-	  if ( (CurrentParticle.pt() > 5.0) && (CurrentParticle.pt() <= 10.0) )  	GenMuon_Eta_5_10->Fill(fabs(CurrentParticle.eta()));
-	  if ( (CurrentParticle.pt() > 9.0) && (CurrentParticle.pt() <= 11.0) )  	GenMuon_Eta_9_11->Fill(fabs(CurrentParticle.eta()));
-	  if ( (CurrentParticle.pt() > 10.0) && (CurrentParticle.pt() <= 50.0) )	GenMuon_Eta_10_50->Fill(fabs(CurrentParticle.eta()));
-	  if ( (CurrentParticle.pt() > 50.0) && (CurrentParticle.pt() <= 100.0) )	GenMuon_Eta_50_100->Fill(fabs(CurrentParticle.eta()));
-	  if ( CurrentParticle.pt() > 100.0) 		GenMuon_Eta_100->Fill(fabs(CurrentParticle.eta()));
-	  GenMuon_Phi->Fill(CurrentParticle.phi());
-	  if ( (fabs(CurrentParticle.eta()) > 2.0) && (fabs(CurrentParticle.eta()) < 2.8) ) {
-	    GenMuon_SmallBins_Pt->Fill(CurrentParticle.pt());
-	    GenMuon_VariableBins_Pt->Fill(CurrentParticle.pt());
-	    GenMuon_Pt->Fill(CurrentParticle.pt());
-	  }
-	}
-
+      if ((CurrentParticle.pt() > FakeRatePtCut)) {
+        GenMuon_Eta->Fill(fabs(CurrentParticle.eta()));
+        GenMuon_WideBinning_Eta->Fill(fabs(CurrentParticle.eta()));
+        GenMuon_WidestBinning_Eta->Fill(fabs(CurrentParticle.eta()));
+        if ((CurrentParticle.pt() > 5.0) && (CurrentParticle.pt() <= 10.0))
+          GenMuon_Eta_5_10->Fill(fabs(CurrentParticle.eta()));
+        if ((CurrentParticle.pt() > 9.0) && (CurrentParticle.pt() <= 11.0))
+          GenMuon_Eta_9_11->Fill(fabs(CurrentParticle.eta()));
+        if ((CurrentParticle.pt() > 10.0) && (CurrentParticle.pt() <= 50.0))
+          GenMuon_Eta_10_50->Fill(fabs(CurrentParticle.eta()));
+        if ((CurrentParticle.pt() > 50.0) && (CurrentParticle.pt() <= 100.0))
+          GenMuon_Eta_50_100->Fill(fabs(CurrentParticle.eta()));
+        if (CurrentParticle.pt() > 100.0)
+          GenMuon_Eta_100->Fill(fabs(CurrentParticle.eta()));
+        GenMuon_Phi->Fill(CurrentParticle.phi());
+        if ((fabs(CurrentParticle.eta()) > 2.0) && (fabs(CurrentParticle.eta()) < 2.8)) {
+          GenMuon_SmallBins_Pt->Fill(CurrentParticle.pt());
+          GenMuon_VariableBins_Pt->Fill(CurrentParticle.pt());
+          GenMuon_Pt->Fill(CurrentParticle.pt());
+        }
+      }
     }
   }
 
-
-
   //Del R study ===========================
-  for(unsigned int i=0; i<gensize; ++i) {
-    const reco::GenParticle& CurrentParticle=(*genParticles)[i];
-    if ( (CurrentParticle.status()==1) && ( (CurrentParticle.pdgId()==13)  || (CurrentParticle.pdgId()==-13) ) ){  
-
+  for (unsigned int i = 0; i < gensize; ++i) {
+    const reco::GenParticle &CurrentParticle = (*genParticles)[i];
+    if ((CurrentParticle.status() == 1) && ((CurrentParticle.pdgId() == 13) || (CurrentParticle.pdgId() == -13))) {
       double LowestDelR = 9999;
       double thisDelR = 9999;
 
-      for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
-	   thisMuon != OurMuons->end(); ++thisMuon){
-	if (!muon::isGoodMuon(*thisMuon, muon::Tight)) continue;
-	TrackRef tkRef = thisMuon->innerTrack();
-	thisDelR = reco::deltaR(CurrentParticle,*tkRef);
-	if (thisDelR < LowestDelR) LowestDelR = thisDelR;
+      for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin(); thisMuon != OurMuons->end(); ++thisMuon) {
+        if (!muon::isGoodMuon(*thisMuon, muon::Tight))
+          continue;
+        TrackRef tkRef = thisMuon->innerTrack();
+        thisDelR = reco::deltaR(CurrentParticle, *tkRef);
+        if (thisDelR < LowestDelR)
+          LowestDelR = thisDelR;
       }
-    
-    ClosestDelR_s->Fill(CurrentParticle.eta(), LowestDelR);
-    ClosestDelR_p->Fill(CurrentParticle.eta(), LowestDelR);
+
+      ClosestDelR_s->Fill(CurrentParticle.eta(), LowestDelR);
+      ClosestDelR_p->Fill(CurrentParticle.eta(), LowestDelR);
     }
   }
 
@@ -820,346 +947,332 @@ ME0MuonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   //   -----Before, we plotted the gen muon pt and eta for the efficiency plot of matches
   //   -----Now, each time a match failed, we plot the ME0Muon pt and eta
   int ME0MuonID = 0;
-  for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
-       thisMuon != OurMuons->end(); ++thisMuon){
-    if (!muon::isGoodMuon(*thisMuon, muon::Tight)) continue;
+  for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin(); thisMuon != OurMuons->end(); ++thisMuon) {
+    if (!muon::isGoodMuon(*thisMuon, muon::Tight))
+      continue;
     TrackRef tkRef = thisMuon->innerTrack();
     //Moved resolution stuff here, only calculate resolutions for matched muons!
-    if (!IsMatched[ME0MuonID]){
-
+    if (!IsMatched[ME0MuonID]) {
       UnmatchedME0Muon_Eta->Fill(fabs(tkRef->eta()));
 
-      if ((tkRef->pt() > FakeRatePtCut) && (TMath::Abs(tkRef->eta()) < 2.8) )  {
-	if ( (tkRef->pt() > 5.0) && (tkRef->pt() <= 10.0) )  	UnmatchedME0Muon_Cuts_Eta_5_10->Fill(fabs(tkRef->eta()));
-	if ( (tkRef->pt() > 9.0) && (tkRef->pt() <= 11.0) )  	UnmatchedME0Muon_Cuts_Eta_9_11->Fill(fabs(tkRef->eta()));
-	if ( (tkRef->pt() > 10.0) && (tkRef->pt() <= 20.0) )	UnmatchedME0Muon_Cuts_Eta_10_50->Fill(fabs(tkRef->eta()));
-	if ( (tkRef->pt() > 20.0) && (tkRef->pt() <= 40.0) )	UnmatchedME0Muon_Cuts_Eta_50_100->Fill(fabs(tkRef->eta()));
-	if ( tkRef->pt() > 40.0) 		UnmatchedME0Muon_Cuts_Eta_100->Fill(fabs(tkRef->eta()));
+      if ((tkRef->pt() > FakeRatePtCut) && (TMath::Abs(tkRef->eta()) < 2.8)) {
+        if ((tkRef->pt() > 5.0) && (tkRef->pt() <= 10.0))
+          UnmatchedME0Muon_Cuts_Eta_5_10->Fill(fabs(tkRef->eta()));
+        if ((tkRef->pt() > 9.0) && (tkRef->pt() <= 11.0))
+          UnmatchedME0Muon_Cuts_Eta_9_11->Fill(fabs(tkRef->eta()));
+        if ((tkRef->pt() > 10.0) && (tkRef->pt() <= 20.0))
+          UnmatchedME0Muon_Cuts_Eta_10_50->Fill(fabs(tkRef->eta()));
+        if ((tkRef->pt() > 20.0) && (tkRef->pt() <= 40.0))
+          UnmatchedME0Muon_Cuts_Eta_50_100->Fill(fabs(tkRef->eta()));
+        if (tkRef->pt() > 40.0)
+          UnmatchedME0Muon_Cuts_Eta_100->Fill(fabs(tkRef->eta()));
 
-	UnmatchedME0Muon_Cuts_Eta->Fill(fabs(tkRef->eta()));
-	UnmatchedME0Muon_Cuts_WideBinning_Eta->Fill(fabs(tkRef->eta()));
-	UnmatchedME0Muon_Cuts_WidestBinning_Eta->Fill(fabs(tkRef->eta()));
+        UnmatchedME0Muon_Cuts_Eta->Fill(fabs(tkRef->eta()));
+        UnmatchedME0Muon_Cuts_WideBinning_Eta->Fill(fabs(tkRef->eta()));
+        UnmatchedME0Muon_Cuts_WidestBinning_Eta->Fill(fabs(tkRef->eta()));
 
-	UnmatchedME0Muon_ScatterPlot->Fill(fabs(tkRef->eta()), fabs(tkRef->phi()) );
+        UnmatchedME0Muon_ScatterPlot->Fill(fabs(tkRef->eta()), fabs(tkRef->phi()));
 
-	for(unsigned int i=0; i<gensize; ++i) {
-	  const reco::GenParticle& CurrentParticle=(*genParticles)[i];
-	  double thisDelR = reco::deltaR(CurrentParticle,*tkRef);
-	  if (thisDelR < MatchingWindowDelR){
-	    if ( (TMath::Abs(tkRef->eta()) < 2.8) ) UnmatchedME0Muon_Window_Pt->Fill(tkRef->pt());
-	  }
-	}
-	if ( (TMath::Abs(tkRef->eta()) > 2.0) && (TMath::Abs(tkRef->eta()) < 2.8) ) {
-	  UnmatchedME0Muon_Pt->Fill(tkRef->pt());
-	  UnmatchedME0Muon_SmallBins_Pt->Fill(tkRef->pt());
-	  UnmatchedME0Muon_VariableBins_Pt->Fill(tkRef->pt());
-	}
-    
+        for (unsigned int i = 0; i < gensize; ++i) {
+          const reco::GenParticle &CurrentParticle = (*genParticles)[i];
+          double thisDelR = reco::deltaR(CurrentParticle, *tkRef);
+          if (thisDelR < MatchingWindowDelR) {
+            if ((TMath::Abs(tkRef->eta()) < 2.8))
+              UnmatchedME0Muon_Window_Pt->Fill(tkRef->pt());
+          }
+        }
+        if ((TMath::Abs(tkRef->eta()) > 2.0) && (TMath::Abs(tkRef->eta()) < 2.8)) {
+          UnmatchedME0Muon_Pt->Fill(tkRef->pt());
+          UnmatchedME0Muon_SmallBins_Pt->Fill(tkRef->pt());
+          UnmatchedME0Muon_VariableBins_Pt->Fill(tkRef->pt());
+        }
       }
     }
     ME0MuonID++;
   }
-  
 
-
- //Track Association by Chi2 or hits:
-
+  //Track Association by Chi2 or hits:
 
   //Map the list of all me0muons that failed or passed delR matching to a list of only Tight me0Muons that failed or passed delR matching
   std::vector<bool> SkimmedIsMatched;
-  int i_me0muon=0;
-  for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
-       thisMuon != OurMuons->end(); ++thisMuon, ++i_me0muon){
-    if (!muon::isGoodMuon(*thisMuon, muon::Tight)) continue;
+  int i_me0muon = 0;
+  for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin(); thisMuon != OurMuons->end();
+       ++thisMuon, ++i_me0muon) {
+    if (!muon::isGoodMuon(*thisMuon, muon::Tight))
+      continue;
     SkimmedIsMatched.push_back(IsMatched[i_me0muon]);
   }
 
   //int w=0;
   //std::cout<<"associators size = "<<associators.size()<<std::endl;
   if (UseAssociators) {
-    for (unsigned int ww=0;ww<associators.size();ww++){
+    for (unsigned int ww = 0; ww < associators.size(); ww++) {
+      for (unsigned int www = 0; www < label.size(); www++) {
+        reco::RecoToSimCollection recSimColl;
+        reco::SimToRecoCollection simRecColl;
+        edm::Handle<View<Track> > trackCollection;
 
-      for (unsigned int www=0;www<label.size();www++){
+        unsigned int trackCollectionSize = 0;
 
-	reco::RecoToSimCollection recSimColl;
-	reco::SimToRecoCollection simRecColl;
-	edm::Handle<View<Track> >  trackCollection;
-	
-	
-	
-	unsigned int trackCollectionSize = 0;
-      
-	if(!iEvent.getByToken(track_Collection_Token[www], trackCollection)){
-	  recSimColl.post_insert();
-	  simRecColl.post_insert();
-	  
-	}
-	
-	else {
-	  trackCollectionSize = trackCollection->size();
-	  recSimColl=associator[ww]->associateRecoToSim(trackCollection,
-							trackingParticles);
-	  
-	  
-	  simRecColl=associator[ww]->associateSimToReco(trackCollection,
-						      trackingParticles);
-	  
-	  
-	}
-	
-	for (TrackingParticleCollection::size_type i=0; i<trackingParticles->size(); i++){
-	  
-	  const TrackingParticle& TPCheck=(*trackingParticles)[i];
-	  if (abs(TPCheck.pdgId()) != 13) continue;
-	  
-	  TrackingParticleRef tpr(trackingParticles, i);
-	  TrackingParticle* tp=const_cast<TrackingParticle*>(tpr.get());
-	  TrackingParticle::Vector momentumTP; 
-	  TrackingParticle::Point vertexTP;
-	  
-	  if (abs(tp->pdgId()) != 13) continue;
-	  
-	  momentumTP = tp->momentum();
-	  vertexTP = tp->vertex();
-	  
-	  //This section fills the denominator for the chi2 efficiency...
-	  
-	  
-	  if ((tp->pt() >FakeRatePtCut) ){
-	    bool SignalMuon=false;
-	    if (tp->status() !=-99){
-	      int motherid=-1;
-	      if ((*tp->genParticle_begin())->numberOfMothers()>0)  {
-		if ((*tp->genParticle_begin())->mother()->numberOfMothers()>0){
-		  motherid=(*tp->genParticle_begin())->mother()->mother()->pdgId();
-		}
-	      }
-	      
-  	    std::cout<<"Mother ID = "<<motherid<<std::endl;
-	    
-  	    if ( 
-  		( (tp->status()==1) && ( (*tp->genParticle_begin())->numberOfMothers()==0 ) )  ||
-  		( (tp->status()==1) ) ) SignalMuon=true;
-	    
-  	    //if (SignalMuon) PreMatch_TP_R->Fill( sqrt(pow(tp->vertex().x(),2) + pow(tp->vertex().y(),2)) );
-	    }
-	    if (SignalMuon){
-	      TPMuon_Eta->Fill(fabs(tp->eta()));
-	      TPMuon_WideBinning_Eta->Fill(fabs(tp->eta()));
-	      TPMuon_WidestBinning_Eta->Fill(fabs(tp->eta()));
-	      if ( (fabs(tp->eta()) > 2.0) && (fabs(tp->eta()) < 2.8) ) {
-		TPMuon_SmallBins_Pt->Fill(tp->pt());
-		TPMuon_VariableBins_Pt->Fill(tp->pt());
-		TPMuon_Pt->Fill(tp->pt());
-	      }
-	      
-	    }
-	    
-	  }
-	  if ( (fabs(tp->eta()) > 2.0) && (fabs(tp->eta()) < 2.8) )  PreMatch_TP_R->Fill( sqrt(pow(tp->vertex().x(),2) + pow(tp->vertex().y(),2)) );
-  	}// END for (TrackingParticleCollection::size_type i=0; i<trackingParticles->size(); i++){
-      
-      for(View<Track>::size_type i=0; i<trackCollectionSize; ++i){
-  	RefToBase<Track> track(trackCollection, i);
+        if (!iEvent.getByToken(track_Collection_Token[www], trackCollection)) {
+          recSimColl.post_insert();
+          simRecColl.post_insert();
 
-  	std::vector<std::pair<TrackingParticleRef, double> > tp;
-  	std::vector<std::pair<TrackingParticleRef, double> > tpforfake;
-  	TrackingParticleRef tpr;
-  	TrackingParticleRef tprforfake;
+        }
 
-  	//Check if the track is associated to any gen particle
-  	bool TrackIsEfficient = false;
-  	//std::cout<<"About to check first collection"<<std::endl;
-  	if(recSimColl.find(track) != recSimColl.end()){
-  	  tp = recSimColl[track];
+        else {
+          trackCollectionSize = trackCollection->size();
+          recSimColl = associator[ww]->associateRecoToSim(trackCollection, trackingParticles);
 
-  	  if (tp.size()!=0) {
-  	    tpr = tp.begin()->first;
+          simRecColl = associator[ww]->associateSimToReco(trackCollection, trackingParticles);
+        }
 
-  	    double assocChi2 = -(tp.begin()->second);
-	   
-  	    //So this track is matched to a gen particle, lets get that gen particle now
+        for (TrackingParticleCollection::size_type i = 0; i < trackingParticles->size(); i++) {
+          const TrackingParticle &TPCheck = (*trackingParticles)[i];
+          if (abs(TPCheck.pdgId()) != 13)
+            continue;
 
-  	    if (  (simRecColl.find(tpr) != simRecColl.end())    ){
-  	      std::vector<std::pair<RefToBase<Track>, double> > rt;
-  	      if  (simRecColl[tpr].size() > 0){
-  		rt=simRecColl[tpr];
-  		RefToBase<Track> bestrecotrackforeff = rt.begin()->first;
-  		//Only fill the efficiency histo if the track found matches up to a gen particle's best choice
-  		if ( (bestrecotrackforeff == track ) && (abs(tpr->pdgId()) == 13) ) {
-  		  TrackIsEfficient=true;
-  		  //This section fills the numerator of the efficiency calculation...
-  		  //if ( (track->pt() > FakeRatePtCut) && (TMath::Abs(track->eta()) < 2.8) )
-  		  PostMatch_TP_R->Fill( sqrt(pow(tpr->vertex().x(),2) + pow(tpr->vertex().y(),2)) );
-  		  if (tpr->eventId().bunchCrossing()) PostMatch_BX0_TP_R->Fill( sqrt(pow(tpr->vertex().x(),2) + pow(tpr->vertex().y(),2)) );
+          TrackingParticleRef tpr(trackingParticles, i);
+          TrackingParticle *tp = const_cast<TrackingParticle *>(tpr.get());
+          TrackingParticle::Vector momentumTP;
+          TrackingParticle::Point vertexTP;
 
+          if (abs(tp->pdgId()) != 13)
+            continue;
 
-  		  if ( (tpr->pt() > FakeRatePtCut) )
-  		    {
+          momentumTP = tp->momentum();
+          vertexTP = tp->vertex();
 
-		      
-  		      bool SignalMuon=false;
+          //This section fills the denominator for the chi2 efficiency...
 
-  		      if (tpr->status() !=-99){
-  			int motherid=-1;
-  			if ((*tpr->genParticle_begin())->numberOfMothers()>0)  {
-  			  if ((*tpr->genParticle_begin())->mother()->numberOfMothers()>0){
-  			    motherid=(*tpr->genParticle_begin())->mother()->mother()->pdgId();
-  			  }
-  			}		
-  			std::cout<<"Mother ID = "<<motherid<<std::endl;
-  			if ( 
-  			    ( (tpr->status()==1) && ( (*tpr->genParticle_begin())->numberOfMothers()==0 ) )  ||
-  			    ( (tpr->status()==1)  ) )SignalMuon=true;
+          if ((tp->pt() > FakeRatePtCut)) {
+            bool SignalMuon = false;
+            if (tp->status() != -99) {
+              int motherid = -1;
+              if ((*tp->genParticle_begin())->numberOfMothers() > 0) {
+                if ((*tp->genParticle_begin())->mother()->numberOfMothers() > 0) {
+                  motherid = (*tp->genParticle_begin())->mother()->mother()->pdgId();
+                }
+              }
 
-  		      }
-		      if (SignalMuon){
-  			Chi2MatchedME0Muon_Eta->Fill(fabs(tpr->eta()));
-  			Chi2MatchedME0Muon_WideBinning_Eta->Fill(fabs(tpr->eta()));
-  			Chi2MatchedME0Muon_WidestBinning_Eta->Fill(fabs(tpr->eta()));
-  			if ( (TMath::Abs(tpr->eta()) > 2.0) && (TMath::Abs(tpr->eta()) < 2.8) ) {
-  			  Chi2MatchedME0Muon_Pt->Fill(tpr->pt());
-  			  Chi2MatchedME0Muon_SmallBins_Pt->Fill(tpr->pt());
-  			  Chi2MatchedME0Muon_VariableBins_Pt->Fill(tpr->pt());
-  			}
-			
-  			if ( (track->pt() > 5.0) && (track->pt() <= 10.0) )  	Chi2MatchedME0Muon_Eta_5_10->Fill(fabs(tpr->eta()));
-  			if ( (track->pt() > 9.0) && (track->pt() <= 11.0) )  	Chi2MatchedME0Muon_Eta_9_11->Fill(fabs(tpr->eta()));
-  			if ( (track->pt() > 10.0) && (track->pt() <= 50.0) )	Chi2MatchedME0Muon_Eta_10_50->Fill(fabs(tpr->eta()));
-  			if ( (track->pt() > 50.0) && (track->pt() <= 100.0) )	Chi2MatchedME0Muon_Eta_50_100->Fill(fabs(tpr->eta()));
-  			if ( track->pt() > 100.0) 		Chi2MatchedME0Muon_Eta_100->Fill(fabs(tpr->eta()));
-  		      }
+              std::cout << "Mother ID = " << motherid << std::endl;
 
-  		    }
-  		  //...end section
+              if (((tp->status() == 1) && ((*tp->genParticle_begin())->numberOfMothers() == 0)) ||
+                  ((tp->status() == 1)))
+                SignalMuon = true;
 
-  		  if ( (track->pt() > FakeRatePtCut) && (TMath::Abs(track->eta()) < 2.8) )AssociatedChi2_h->Fill(assocChi2);
-  		  if ( (track->pt() > FakeRatePtCut) && (TMath::Abs(track->eta()) < 2.8) )AssociatedChi2_Prob_h->Fill(TMath::Prob((assocChi2)*5,5));
-  		}
-  	      }
-  	    }
-	
-	    
-	    
-  	  }
-  	}
-  	//A simple way of measuring fake rate:
-  	if (!TrackIsEfficient) {
+              //if (SignalMuon) PreMatch_TP_R->Fill( sqrt(pow(tp->vertex().x(),2) + pow(tp->vertex().y(),2)) );
+            }
+            if (SignalMuon) {
+              TPMuon_Eta->Fill(fabs(tp->eta()));
+              TPMuon_WideBinning_Eta->Fill(fabs(tp->eta()));
+              TPMuon_WidestBinning_Eta->Fill(fabs(tp->eta()));
+              if ((fabs(tp->eta()) > 2.0) && (fabs(tp->eta()) < 2.8)) {
+                TPMuon_SmallBins_Pt->Fill(tp->pt());
+                TPMuon_VariableBins_Pt->Fill(tp->pt());
+                TPMuon_Pt->Fill(tp->pt());
+              }
+            }
+          }
+          if ((fabs(tp->eta()) > 2.0) && (fabs(tp->eta()) < 2.8))
+            PreMatch_TP_R->Fill(sqrt(pow(tp->vertex().x(), 2) + pow(tp->vertex().y(), 2)));
+        }  // END for (TrackingParticleCollection::size_type i=0; i<trackingParticles->size(); i++){
 
-  	  if ((track->pt() > FakeRatePtCut) && (TMath::Abs(track->eta()) < 2.8) ) {
-  	    Chi2UnmatchedME0Muon_Eta->Fill(fabs(track->eta()));
-  	    Chi2UnmatchedME0Muon_WideBinning_Eta->Fill(fabs(track->eta()));
-  	    Chi2UnmatchedME0Muon_WidestBinning_Eta->Fill(fabs(track->eta()));
-  	    if ( (TMath::Abs(track->eta()) > 2.0) && (TMath::Abs(track->eta()) < 2.8) ) {
-  	      Chi2UnmatchedME0Muon_Pt->Fill(track->pt());
-  	      Chi2UnmatchedME0Muon_SmallBins_Pt->Fill(track->pt());
-  	      Chi2UnmatchedME0Muon_VariableBins_Pt->Fill(track->pt());
-  	    }
-  	  }
+        for (View<Track>::size_type i = 0; i < trackCollectionSize; ++i) {
+          RefToBase<Track> track(trackCollection, i);
 
-  	}
-  	//End checking of Efficient muons
-	
-	//Deprecated F.R. method, only used for debugging offline.  Commented out now:
+          std::vector<std::pair<TrackingParticleRef, double> > tp;
+          std::vector<std::pair<TrackingParticleRef, double> > tpforfake;
+          TrackingParticleRef tpr;
+          TrackingParticleRef tprforfake;
 
-  	// //For Fakes --------------------------------------------  here we fill the numerator for the F.R., Chi2UnmatchedME0Muon_Eta
-  	// //The denominator is filled elsewhere, just a histo of all the ME0Muon eta values
-  	// //It is ME0Muon_Cuts_Eta, so named because it is all ME0Muons passing the selection (also the pT cut)
+          //Check if the track is associated to any gen particle
+          bool TrackIsEfficient = false;
+          //std::cout<<"About to check first collection"<<std::endl;
+          if (recSimColl.find(track) != recSimColl.end()) {
+            tp = recSimColl[track];
 
-	
-  	// //Check if finding a track associated to a gen particle fails, or if there is no track in the collection at all
+            if (tp.size() != 0) {
+              tpr = tp.begin()->first;
 
-  	// if( (recSimColl.find(track) == recSimColl.end() ) || ( recSimColl[track].size() == 0  ) ){
-  	//   if (SkimmedIsMatched[i]){
-  	//     if ((track->pt() >FakeRatePtCut) ){
-  	//       if (tp.size()!=0) std::cout<<"Found an me0muontrack failing chi2 matching: "<<track->pt()<<", "<<track->eta()<<", "<<tp.begin()->second<<std::endl;
-  	//     }
-  	//   }
-  	// }
-	
-  	// //Its possible that the track is associated to a gen particle, but isn't the best match and would still fail
-  	// //In that case, we go to the gen particle...
-  	// else if (recSimColl[track].size() > 0){
-  	//   tpforfake = recSimColl[track];
-  	//   tprforfake=tpforfake.begin()->first;
-  	//   //We now have the gen particle, to check
+              double assocChi2 = -(tp.begin()->second);
 
+              //So this track is matched to a gen particle, lets get that gen particle now
 
-  	//   //If for some crazy reason we can't find the gen particle, that means its a fake
-  	//   if (  (simRecColl.find(tprforfake) == simRecColl.end())  ||  (simRecColl[tprforfake].size() == 0)  ) {
-  	//     //Check if this muon matched via Del-R matching
-  	//     if (SkimmedIsMatched[i]){
-  	//       if ((track->pt() >FakeRatePtCut) ) {
-  	// 	if (tp.size()!=0) std::cout<<"Found an me0muontrack failing chi2 matching: "<<track->pt()<<", "<<track->eta()<<", "<<tp.begin()->second<<std::endl;
-  	//       }
-  	//     }
-  	//   }
-  	//   //We can probably find the gen particle
-  	//   else if(simRecColl[tprforfake].size() > 0)  {
-  	//     //We can now access the best possible track for the gen particle that this track was matched to
-  	//     std::vector<std::pair<RefToBase<Track>, double> > rtforfake;
-  	//     rtforfake=simRecColl[tprforfake];
-	   
-  	//     RefToBase<Track> bestrecotrack = rtforfake.begin()->first;
-  	//     //if the best reco track is NOT the track that we're looking at, we know we have a fake, that was within the cut, but not the closest
-  	//     if (bestrecotrack != track) {
-  	//       //Check if this muon matched via Del-R matching
-  	//       if (IsMatched[i]){
-  	// 	if (tp.size()!=0) std::cout<<"Found an me0muontrack failing chi2 matching: "<<track->pt()<<", "<<track->eta()<<", "<<tp.begin()->second<<std::endl;
-  	//       }
-  	//     }
+              if ((simRecColl.find(tpr) != simRecColl.end())) {
+                std::vector<std::pair<RefToBase<Track>, double> > rt;
+                if (simRecColl[tpr].size() > 0) {
+                  rt = simRecColl[tpr];
+                  RefToBase<Track> bestrecotrackforeff = rt.begin()->first;
+                  //Only fill the efficiency histo if the track found matches up to a gen particle's best choice
+                  if ((bestrecotrackforeff == track) && (abs(tpr->pdgId()) == 13)) {
+                    TrackIsEfficient = true;
+                    //This section fills the numerator of the efficiency calculation...
+                    //if ( (track->pt() > FakeRatePtCut) && (TMath::Abs(track->eta()) < 2.8) )
+                    PostMatch_TP_R->Fill(sqrt(pow(tpr->vertex().x(), 2) + pow(tpr->vertex().y(), 2)));
+                    if (tpr->eventId().bunchCrossing())
+                      PostMatch_BX0_TP_R->Fill(sqrt(pow(tpr->vertex().x(), 2) + pow(tpr->vertex().y(), 2)));
 
-  	//   }
-  	// }
+                    if ((tpr->pt() > FakeRatePtCut)) {
+                      bool SignalMuon = false;
 
-  	//End For Fakes --------------------------------------------
+                      if (tpr->status() != -99) {
+                        int motherid = -1;
+                        if ((*tpr->genParticle_begin())->numberOfMothers() > 0) {
+                          if ((*tpr->genParticle_begin())->mother()->numberOfMothers() > 0) {
+                            motherid = (*tpr->genParticle_begin())->mother()->mother()->pdgId();
+                          }
+                        }
+                        std::cout << "Mother ID = " << motherid << std::endl;
+                        if (((tpr->status() == 1) && ((*tpr->genParticle_begin())->numberOfMothers() == 0)) ||
+                            ((tpr->status() == 1)))
+                          SignalMuon = true;
+                      }
+                      if (SignalMuon) {
+                        Chi2MatchedME0Muon_Eta->Fill(fabs(tpr->eta()));
+                        Chi2MatchedME0Muon_WideBinning_Eta->Fill(fabs(tpr->eta()));
+                        Chi2MatchedME0Muon_WidestBinning_Eta->Fill(fabs(tpr->eta()));
+                        if ((TMath::Abs(tpr->eta()) > 2.0) && (TMath::Abs(tpr->eta()) < 2.8)) {
+                          Chi2MatchedME0Muon_Pt->Fill(tpr->pt());
+                          Chi2MatchedME0Muon_SmallBins_Pt->Fill(tpr->pt());
+                          Chi2MatchedME0Muon_VariableBins_Pt->Fill(tpr->pt());
+                        }
 
-	
-  	if (TMath::Abs(track->eta()) < 2.8) CheckME0Muon_Eta->Fill(fabs(track->eta()));	
+                        if ((track->pt() > 5.0) && (track->pt() <= 10.0))
+                          Chi2MatchedME0Muon_Eta_5_10->Fill(fabs(tpr->eta()));
+                        if ((track->pt() > 9.0) && (track->pt() <= 11.0))
+                          Chi2MatchedME0Muon_Eta_9_11->Fill(fabs(tpr->eta()));
+                        if ((track->pt() > 10.0) && (track->pt() <= 50.0))
+                          Chi2MatchedME0Muon_Eta_10_50->Fill(fabs(tpr->eta()));
+                        if ((track->pt() > 50.0) && (track->pt() <= 100.0))
+                          Chi2MatchedME0Muon_Eta_50_100->Fill(fabs(tpr->eta()));
+                        if (track->pt() > 100.0)
+                          Chi2MatchedME0Muon_Eta_100->Fill(fabs(tpr->eta()));
+                      }
+                    }
+                    //...end section
 
-  	NormChi2_h->Fill(track->normalizedChi2());
-  	NormChi2Prob_h->Fill(TMath::Prob(track->chi2(),(int)track->ndof()));
-  	NormChi2VsHits_h->Fill(track->numberOfValidHits(),track->normalizedChi2());
+                    if ((track->pt() > FakeRatePtCut) && (TMath::Abs(track->eta()) < 2.8))
+                      AssociatedChi2_h->Fill(assocChi2);
+                    if ((track->pt() > FakeRatePtCut) && (TMath::Abs(track->eta()) < 2.8))
+                      AssociatedChi2_Prob_h->Fill(TMath::Prob((assocChi2)*5, 5));
+                  }
+                }
+              }
+            }
+          }
+          //A simple way of measuring fake rate:
+          if (!TrackIsEfficient) {
+            if ((track->pt() > FakeRatePtCut) && (TMath::Abs(track->eta()) < 2.8)) {
+              Chi2UnmatchedME0Muon_Eta->Fill(fabs(track->eta()));
+              Chi2UnmatchedME0Muon_WideBinning_Eta->Fill(fabs(track->eta()));
+              Chi2UnmatchedME0Muon_WidestBinning_Eta->Fill(fabs(track->eta()));
+              if ((TMath::Abs(track->eta()) > 2.0) && (TMath::Abs(track->eta()) < 2.8)) {
+                Chi2UnmatchedME0Muon_Pt->Fill(track->pt());
+                Chi2UnmatchedME0Muon_SmallBins_Pt->Fill(track->pt());
+                Chi2UnmatchedME0Muon_VariableBins_Pt->Fill(track->pt());
+              }
+            }
+          }
+          //End checking of Efficient muons
 
+          //Deprecated F.R. method, only used for debugging offline.  Commented out now:
 
-  	chi2_vs_eta_h->Fill((track->eta()),track->normalizedChi2());
+          // //For Fakes --------------------------------------------  here we fill the numerator for the F.R., Chi2UnmatchedME0Muon_Eta
+          // //The denominator is filled elsewhere, just a histo of all the ME0Muon eta values
+          // //It is ME0Muon_Cuts_Eta, so named because it is all ME0Muons passing the selection (also the pT cut)
 
+          // //Check if finding a track associated to a gen particle fails, or if there is no track in the collection at all
 
-      }//END for(View<Track>::size_type i=0; i<trackCollectionSize; ++i){
-      }// END for (unsigned int www=0;www<label.size();www++)
-    }//END     for (unsigned int ww=0;ww<associators.size();ww++){
-  }//END if UseAssociators
-  
-  for (std::vector<Track>::const_iterator thisTrack = generalTracks->begin();
-       thisTrack != generalTracks->end();++thisTrack){
+          // if( (recSimColl.find(track) == recSimColl.end() ) || ( recSimColl[track].size() == 0  ) ){
+          //   if (SkimmedIsMatched[i]){
+          //     if ((track->pt() >FakeRatePtCut) ){
+          //       if (tp.size()!=0) std::cout<<"Found an me0muontrack failing chi2 matching: "<<track->pt()<<", "<<track->eta()<<", "<<tp.begin()->second<<std::endl;
+          //     }
+          //   }
+          // }
+
+          // //Its possible that the track is associated to a gen particle, but isn't the best match and would still fail
+          // //In that case, we go to the gen particle...
+          // else if (recSimColl[track].size() > 0){
+          //   tpforfake = recSimColl[track];
+          //   tprforfake=tpforfake.begin()->first;
+          //   //We now have the gen particle, to check
+
+          //   //If for some crazy reason we can't find the gen particle, that means its a fake
+          //   if (  (simRecColl.find(tprforfake) == simRecColl.end())  ||  (simRecColl[tprforfake].size() == 0)  ) {
+          //     //Check if this muon matched via Del-R matching
+          //     if (SkimmedIsMatched[i]){
+          //       if ((track->pt() >FakeRatePtCut) ) {
+          // 	if (tp.size()!=0) std::cout<<"Found an me0muontrack failing chi2 matching: "<<track->pt()<<", "<<track->eta()<<", "<<tp.begin()->second<<std::endl;
+          //       }
+          //     }
+          //   }
+          //   //We can probably find the gen particle
+          //   else if(simRecColl[tprforfake].size() > 0)  {
+          //     //We can now access the best possible track for the gen particle that this track was matched to
+          //     std::vector<std::pair<RefToBase<Track>, double> > rtforfake;
+          //     rtforfake=simRecColl[tprforfake];
+
+          //     RefToBase<Track> bestrecotrack = rtforfake.begin()->first;
+          //     //if the best reco track is NOT the track that we're looking at, we know we have a fake, that was within the cut, but not the closest
+          //     if (bestrecotrack != track) {
+          //       //Check if this muon matched via Del-R matching
+          //       if (IsMatched[i]){
+          // 	if (tp.size()!=0) std::cout<<"Found an me0muontrack failing chi2 matching: "<<track->pt()<<", "<<track->eta()<<", "<<tp.begin()->second<<std::endl;
+          //       }
+          //     }
+
+          //   }
+          // }
+
+          //End For Fakes --------------------------------------------
+
+          if (TMath::Abs(track->eta()) < 2.8)
+            CheckME0Muon_Eta->Fill(fabs(track->eta()));
+
+          NormChi2_h->Fill(track->normalizedChi2());
+          NormChi2Prob_h->Fill(TMath::Prob(track->chi2(), (int)track->ndof()));
+          NormChi2VsHits_h->Fill(track->numberOfValidHits(), track->normalizedChi2());
+
+          chi2_vs_eta_h->Fill((track->eta()), track->normalizedChi2());
+
+        }  //END for(View<Track>::size_type i=0; i<trackCollectionSize; ++i){
+      }    // END for (unsigned int www=0;www<label.size();www++)
+    }      //END     for (unsigned int ww=0;ww<associators.size();ww++){
+  }        //END if UseAssociators
+
+  for (std::vector<Track>::const_iterator thisTrack = generalTracks->begin(); thisTrack != generalTracks->end();
+       ++thisTrack) {
     Track_Eta->Fill(fabs(thisTrack->eta()));
-    if ( (TMath::Abs(thisTrack->eta()) > 2.0) && (TMath::Abs(thisTrack->eta()) < 2.8) ) Track_Pt->Fill(thisTrack->pt());
+    if ((TMath::Abs(thisTrack->eta()) > 2.0) && (TMath::Abs(thisTrack->eta()) < 2.8))
+      Track_Pt->Fill(thisTrack->pt());
   }
 
-  
   std::vector<double> SegmentEta, SegmentPhi, SegmentR, SegmentX, SegmentY;
   std::vector<int> Ids;
   std::vector<int> Ids_NonGenMuons;
   std::vector<int> UniqueIdList;
-  int TrackID=0;
+  int TrackID = 0;
 
   int MuID = 0;
 
-  for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
-       thisMuon != OurMuons->end(); ++thisMuon){
-    if (!muon::isGoodMuon(*thisMuon, muon::Tight)) continue;
+  for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin(); thisMuon != OurMuons->end(); ++thisMuon) {
+    if (!muon::isGoodMuon(*thisMuon, muon::Tight))
+      continue;
     TrackRef tkRef = thisMuon->innerTrack();
 
     ME0Segment Seg = thisMuon->me0segment();
-    ME0DetId id =Seg.me0DetId();
-    auto roll = me0Geom->etaPartition(id); 
+    ME0DetId id = Seg.me0DetId();
+    auto roll = me0Geom->etaPartition(id);
     auto GlobVect(roll->toGlobal(Seg.localPosition()));
 
-    int SegId=thisMuon->me0segid();
+    int SegId = thisMuon->me0segid();
 
     bool IsNew = true;
-    for (unsigned int i =0; i < Ids.size(); i++){
-      if (SegId == Ids[i]) IsNew=false;
+    for (unsigned int i = 0; i < Ids.size(); i++) {
+      if (SegId == Ids[i])
+        IsNew = false;
     }
 
     if (IsNew) {
@@ -1171,46 +1284,54 @@ ME0MuonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
       SegmentY.push_back(GlobVect.y());
     }
     Ids.push_back(SegId);
-    if (!IsMatched[TrackID]) Ids_NonGenMuons.push_back(SegId);
+    if (!IsMatched[TrackID])
+      Ids_NonGenMuons.push_back(SegId);
 
     ME0Muon_Eta->Fill(fabs(tkRef->eta()));
 
-    if ((tkRef->pt() > FakeRatePtCut) && (TMath::Abs(tkRef->eta()) < 2.8)){
+    if ((tkRef->pt() > FakeRatePtCut) && (TMath::Abs(tkRef->eta()) < 2.8)) {
       ME0Muon_Cuts_Eta->Fill(fabs(tkRef->eta()));
       ME0Muon_Cuts_WideBinning_Eta->Fill(fabs(tkRef->eta()));
       ME0Muon_Cuts_WidestBinning_Eta->Fill(fabs(tkRef->eta()));
-      if ( (tkRef->pt() > 5.0) && (tkRef->pt() <= 10.0) )  	ME0Muon_Cuts_Eta_5_10->Fill(fabs(tkRef->eta()));
-      if ( (tkRef->pt() > 9.0) && (tkRef->pt() <= 11.0) )  	ME0Muon_Cuts_Eta_9_11->Fill(fabs(tkRef->eta()));
-      if ( (tkRef->pt() > 10.0) && (tkRef->pt() <= 20.0) )	ME0Muon_Cuts_Eta_10_50->Fill(fabs(tkRef->eta()));
-      if ( (tkRef->pt() > 20.0) && (tkRef->pt() <= 40.0) )	ME0Muon_Cuts_Eta_50_100->Fill(fabs(tkRef->eta()));
-      if ( tkRef->pt() > 40.0) 		ME0Muon_Cuts_Eta_100->Fill(fabs(tkRef->eta()));
+      if ((tkRef->pt() > 5.0) && (tkRef->pt() <= 10.0))
+        ME0Muon_Cuts_Eta_5_10->Fill(fabs(tkRef->eta()));
+      if ((tkRef->pt() > 9.0) && (tkRef->pt() <= 11.0))
+        ME0Muon_Cuts_Eta_9_11->Fill(fabs(tkRef->eta()));
+      if ((tkRef->pt() > 10.0) && (tkRef->pt() <= 20.0))
+        ME0Muon_Cuts_Eta_10_50->Fill(fabs(tkRef->eta()));
+      if ((tkRef->pt() > 20.0) && (tkRef->pt() <= 40.0))
+        ME0Muon_Cuts_Eta_50_100->Fill(fabs(tkRef->eta()));
+      if (tkRef->pt() > 40.0)
+        ME0Muon_Cuts_Eta_100->Fill(fabs(tkRef->eta()));
 
-
-      if ( (TMath::Abs(tkRef->eta()) > 2.0) && (TMath::Abs(tkRef->eta()) < 2.8) ) {
-	ME0Muon_Pt->Fill(tkRef->pt());
-	ME0Muon_SmallBins_Pt->Fill(tkRef->pt());
-	ME0Muon_VariableBins_Pt->Fill(tkRef->pt());
+      if ((TMath::Abs(tkRef->eta()) > 2.0) && (TMath::Abs(tkRef->eta()) < 2.8)) {
+        ME0Muon_Pt->Fill(tkRef->pt());
+        ME0Muon_SmallBins_Pt->Fill(tkRef->pt());
+        ME0Muon_VariableBins_Pt->Fill(tkRef->pt());
       }
     }
     TrackID++;
     MuID++;
 
-  } //END   for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
-  
+  }  //END   for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
 
-  for (unsigned int i = 0; i < UniqueIdList.size(); i++){
-    int Num_Total=0, Num_Fake = 0, Num_Fake_Associated = 0;
-    for (unsigned int j = 0; j < Ids.size(); j++){
-      if (Ids[j] == UniqueIdList[i]) Num_Total++;
+  for (unsigned int i = 0; i < UniqueIdList.size(); i++) {
+    int Num_Total = 0, Num_Fake = 0, Num_Fake_Associated = 0;
+    for (unsigned int j = 0; j < Ids.size(); j++) {
+      if (Ids[j] == UniqueIdList[i])
+        Num_Total++;
     }
 
-    for (unsigned int j = 0; j < Ids_NonGenMuons.size(); j++){
-      if (Ids_NonGenMuons[j] == UniqueIdList[i]) Num_Fake++;
+    for (unsigned int j = 0; j < Ids_NonGenMuons.size(); j++) {
+      if (Ids_NonGenMuons[j] == UniqueIdList[i])
+        Num_Fake++;
       bool AssociatedWithMatchedSegment = false;
-      for (unsigned int isegid=0;isegid < MatchedSegIds.size();isegid++){
-	if (MatchedSegIds[isegid]==Ids_NonGenMuons[j]) AssociatedWithMatchedSegment=true;
+      for (unsigned int isegid = 0; isegid < MatchedSegIds.size(); isegid++) {
+        if (MatchedSegIds[isegid] == Ids_NonGenMuons[j])
+          AssociatedWithMatchedSegment = true;
       }
-      if (AssociatedWithMatchedSegment) Num_Fake_Associated++;
+      if (AssociatedWithMatchedSegment)
+        Num_Fake_Associated++;
     }
 
     TracksPerSegment_h->Fill((double)Num_Total);
@@ -1224,75 +1345,67 @@ ME0MuonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     FakeTracksPerAssociatedSegment_h->Fill((double)Num_Fake_Associated);
     FakeTracksPerAssociatedSegment_s->Fill(SegmentEta[i], (double)Num_Fake_Associated);
     FakeTracksPerAssociatedSegment_p->Fill(SegmentEta[i], (double)Num_Fake_Associated);
-
   }
 
   //================  For Segment Plotting
-  for (auto thisSegment = OurSegments->begin(); thisSegment != OurSegments->end(); 
-       ++thisSegment){
+  for (auto thisSegment = OurSegments->begin(); thisSegment != OurSegments->end(); ++thisSegment) {
     ME0DetId id = thisSegment->me0DetId();
-    auto roll = me0Geom->etaPartition(id); 
+    auto roll = me0Geom->etaPartition(id);
     auto GlobVect(roll->toGlobal(thisSegment->localPosition()));
     Segment_Eta->Fill(fabs(GlobVect.eta()));
     Segment_Phi->Fill(GlobVect.phi());
     Segment_R->Fill(GlobVect.perp());
-    Segment_Pos->Fill(GlobVect.x(),GlobVect.y());
-
-
+    Segment_Pos->Fill(GlobVect.x(), GlobVect.y());
 
     auto theseRecHits = thisSegment->specificRecHits();
-    
-    for (auto thisRecHit = theseRecHits.begin(); thisRecHit!= theseRecHits.end(); thisRecHit++){
+
+    for (auto thisRecHit = theseRecHits.begin(); thisRecHit != theseRecHits.end(); thisRecHit++) {
       auto me0id = thisRecHit->me0Id();
       auto rollForRechit = me0Geom->etaPartition(me0id);
-      
-      auto thisRecHitGlobalPoint = rollForRechit->toGlobal(thisRecHit->localPosition()); 
-      
+
+      auto thisRecHitGlobalPoint = rollForRechit->toGlobal(thisRecHit->localPosition());
+
       Rechit_Eta->Fill(fabs(thisRecHitGlobalPoint.eta()));
       Rechit_Phi->Fill(thisRecHitGlobalPoint.phi());
       Rechit_R->Fill(thisRecHitGlobalPoint.perp());
-      Rechit_Pos->Fill(thisRecHitGlobalPoint.x(),thisRecHitGlobalPoint.y());
-      
+      Rechit_Pos->Fill(thisRecHitGlobalPoint.x(), thisRecHitGlobalPoint.y());
     }
   }
   //==================
 
-  for(unsigned int i=0; i<gensize; ++i) {
-    const reco::GenParticle& CurrentParticle=(*genParticles)[i];
-    if ( (CurrentParticle.status()==1) && ( (CurrentParticle.pdgId()==13)  || (CurrentParticle.pdgId()==-13) ) ){  
+  for (unsigned int i = 0; i < gensize; ++i) {
+    const reco::GenParticle &CurrentParticle = (*genParticles)[i];
+    if ((CurrentParticle.status() == 1) && ((CurrentParticle.pdgId() == 13) || (CurrentParticle.pdgId() == -13))) {
       double SmallestDelR = 999.;
-      for (auto thisSegment = OurSegments->begin(); thisSegment != OurSegments->end(); 
-	   ++thisSegment){
-	ME0DetId id = thisSegment->me0DetId();
-	auto roll = me0Geom->etaPartition(id); 
-	  auto GlobVect(roll->toGlobal(thisSegment->localPosition()));
-	  if (reco::deltaR(CurrentParticle,GlobVect) < SmallestDelR) SmallestDelR = reco::deltaR(CurrentParticle,GlobVect);
-	  
+      for (auto thisSegment = OurSegments->begin(); thisSegment != OurSegments->end(); ++thisSegment) {
+        ME0DetId id = thisSegment->me0DetId();
+        auto roll = me0Geom->etaPartition(id);
+        auto GlobVect(roll->toGlobal(thisSegment->localPosition()));
+        if (reco::deltaR(CurrentParticle, GlobVect) < SmallestDelR)
+          SmallestDelR = reco::deltaR(CurrentParticle, GlobVect);
       }
-      if ((fabs(CurrentParticle.eta()) < 2.0 ) ||(fabs(CurrentParticle.eta()) > 2.8 )) continue;
+      if ((fabs(CurrentParticle.eta()) < 2.0) || (fabs(CurrentParticle.eta()) > 2.8))
+        continue;
       DelR_Segment_GenMuon->Fill(SmallestDelR);
     }
   }
 }
 
-
-void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&) 
+void ME0MuonAnalyzer::endRun(edm::Run const &, edm::EventSetup const &)
 
 {
-  
   //Write plots to histo root file and folder
 
-  TString cmsText     = "CMS PhaseII Simulation Prelim.";
+  TString cmsText = "CMS PhaseII Simulation Prelim.";
 
   TString lumiText = "PU 140, 14 TeV";
-  float cmsTextFont   = 61;  // default is helvetic-bold
+  float cmsTextFont = 61;  // default is helvetic-bold
 
- 
   //float extraTextFont = 52;  // default is helvetica-italics
-  float lumiTextSize     = 0.05;
+  float lumiTextSize = 0.05;
 
-  float lumiTextOffset   = 0.2;
-  float cmsTextSize      = 0.05;
+  float lumiTextOffset = 0.2;
+  float cmsTextSize = 0.05;
   //float cmsTextOffset    = 0.1;  // only used in outOfFrame version
 
   // float relPosX    = 0.045;
@@ -1302,41 +1415,37 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   // //ratio of "CMS" and extra text size
   // float extraOverCmsTextSize  = 0.76;
 
-
-
   histoFile->cd();
 
-
-  TCanvas *c1 = new TCanvas("c1", "canvas" );
-
+  TCanvas *c1 = new TCanvas("c1", "canvas");
 
   gStyle->SetOptStat(0);
   gStyle->SetOptTitle(0);
 
   //setTDRStyle();
 
-  gStyle->SetOptStat(1);     
+  gStyle->SetOptStat(1);
   //XPull_h->Fit("gaus","","",-1.,1.);
-  XPull_h->Draw(); 
+  XPull_h->Draw();
   XPull_h->GetXaxis()->SetTitle("Local pulls: X");
   XPull_h->GetXaxis()->SetTitleSize(0.05);
   c1->Print("PullX.png");
 
   //YPull_h->Fit("gaus");
-  YPull_h->Draw(); 
+  YPull_h->Draw();
   YPull_h->GetXaxis()->SetTitle("Local pulls: Y");
   YPull_h->GetXaxis()->SetTitleSize(0.05);
   c1->Print("PullY.png");
 
   gStyle->SetOptStat(1);
   //  XDiff_h->Fit("gaus","","",-1.,1.);
-  XDiff_h->Draw(); 
+  XDiff_h->Draw();
   XDiff_h->GetXaxis()->SetTitle("Local residuals : X");
   XDiff_h->GetXaxis()->SetTitleSize(0.05);
   c1->Print("DiffX.png");
 
   //  YDiff_h->Fit("gaus");
-  YDiff_h->Draw(); 
+  YDiff_h->Draw();
   YDiff_h->GetXaxis()->SetTitle("Local residuals : Y");
   YDiff_h->GetXaxis()->SetTitleSize(0.05);
   c1->Print("DiffY.png");
@@ -1344,299 +1453,535 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   gStyle->SetOptStat(0);
   Nevents_h->Write();
 
-  SegPosDirPhiDiff_True_h->Write();   SegPosDirPhiDiff_True_h->Draw();  c1->Print(histoFolder+"/SegPosDirPhiDiff_True_h.png");
-  SegPosDirEtaDiff_True_h->Write();   SegPosDirEtaDiff_True_h->Draw();  c1->Print(histoFolder+"/SegPosDirEtaDiff_True_h.png");
+  SegPosDirPhiDiff_True_h->Write();
+  SegPosDirPhiDiff_True_h->Draw();
+  c1->Print(histoFolder + "/SegPosDirPhiDiff_True_h.png");
+  SegPosDirEtaDiff_True_h->Write();
+  SegPosDirEtaDiff_True_h->Draw();
+  c1->Print(histoFolder + "/SegPosDirEtaDiff_True_h.png");
 
   c1->SetLogy();
-  SegPosDirPhiDiff_All_h->Write();   SegPosDirPhiDiff_All_h->Draw();  c1->Print(histoFolder+"/SegPosDirPhiDiff_All_h.png");
+  SegPosDirPhiDiff_All_h->Write();
+  SegPosDirPhiDiff_All_h->Draw();
+  c1->Print(histoFolder + "/SegPosDirPhiDiff_All_h.png");
   c1->SetLogy();
-  SegPosDirEtaDiff_All_h->Write();   SegPosDirEtaDiff_All_h->Draw();  c1->Print(histoFolder+"/SegPosDirEtaDiff_All_h.png");
+  SegPosDirEtaDiff_All_h->Write();
+  SegPosDirEtaDiff_All_h->Draw();
+  c1->Print(histoFolder + "/SegPosDirEtaDiff_All_h.png");
 
-  SegTrackDirPhiDiff_True_h->Write();   SegTrackDirPhiDiff_True_h->Draw();  c1->Print(histoFolder+"/SegTrackDirPhiDiff_True_h.png");
-  SegTrackDirEtaDiff_True_h->Write();   SegTrackDirEtaDiff_True_h->Draw();  c1->Print(histoFolder+"/SegTrackDirEtaDiff_True_h.png");
+  SegTrackDirPhiDiff_True_h->Write();
+  SegTrackDirPhiDiff_True_h->Draw();
+  c1->Print(histoFolder + "/SegTrackDirPhiDiff_True_h.png");
+  SegTrackDirEtaDiff_True_h->Write();
+  SegTrackDirEtaDiff_True_h->Draw();
+  c1->Print(histoFolder + "/SegTrackDirEtaDiff_True_h.png");
 
-  SegTrackDirPhiPull_True_h->Write();   SegTrackDirPhiPull_True_h->Draw();  c1->Print(histoFolder+"/SegTrackDirPhiPull_True_h.png");
-  SegTrackDirPhiPull_All_h->Write();   SegTrackDirPhiPull_All_h->Draw();  c1->Print(histoFolder+"/SegTrackDirPhiPull_All_h.png");
-
-  c1->SetLogy();
-  SegTrackDirPhiDiff_All_h->Write();   SegTrackDirPhiDiff_All_h->Draw();  c1->Print(histoFolder+"/SegTrackDirPhiDiff_All_h.png");
-  c1->SetLogy();
-  SegTrackDirEtaDiff_All_h->Write();   SegTrackDirEtaDiff_All_h->Draw();  c1->Print(histoFolder+"/SegTrackDirEtaDiff_All_h.png");
-
-
-  SegGenDirPhiDiff_True_h->Write();   SegGenDirPhiDiff_True_h->Draw();  c1->Print(histoFolder+"/SegGenDirPhiDiff_True_h.png");
-  SegGenDirEtaDiff_True_h->Write();   SegGenDirEtaDiff_True_h->Draw();  c1->Print(histoFolder+"/SegGenDirEtaDiff_True_h.png");
-
-  SegGenDirPhiPull_True_h->Write();   SegGenDirPhiPull_True_h->Draw();  c1->Print(histoFolder+"/SegGenDirPhiPull_True_h.png");
-  SegGenDirPhiPull_All_h->Write();   SegGenDirPhiPull_All_h->Draw();  c1->Print(histoFolder+"/SegGenDirPhiPull_All_h.png");
+  SegTrackDirPhiPull_True_h->Write();
+  SegTrackDirPhiPull_True_h->Draw();
+  c1->Print(histoFolder + "/SegTrackDirPhiPull_True_h.png");
+  SegTrackDirPhiPull_All_h->Write();
+  SegTrackDirPhiPull_All_h->Draw();
+  c1->Print(histoFolder + "/SegTrackDirPhiPull_All_h.png");
 
   c1->SetLogy();
-  SegGenDirPhiDiff_All_h->Write();   SegGenDirPhiDiff_All_h->Draw();  c1->Print(histoFolder+"/SegGenDirPhiDiff_All_h.png");
+  SegTrackDirPhiDiff_All_h->Write();
+  SegTrackDirPhiDiff_All_h->Draw();
+  c1->Print(histoFolder + "/SegTrackDirPhiDiff_All_h.png");
   c1->SetLogy();
-  SegGenDirEtaDiff_All_h->Write();   SegGenDirEtaDiff_All_h->Draw();  c1->Print(histoFolder+"/SegGenDirEtaDiff_All_h.png");
+  SegTrackDirEtaDiff_All_h->Write();
+  SegTrackDirEtaDiff_All_h->Draw();
+  c1->Print(histoFolder + "/SegTrackDirEtaDiff_All_h.png");
 
-  Candidate_Eta->Write();   Candidate_Eta->Draw();  c1->Print(histoFolder+"/Candidate_Eta.png");
-  Track_Eta->Write();   Track_Eta->Draw();  c1->Print(histoFolder+"/Track_Eta.png");
-  Track_Pt->Write();   Track_Pt->Draw();  c1->Print(histoFolder+"/Track_Pt.png");
+  SegGenDirPhiDiff_True_h->Write();
+  SegGenDirPhiDiff_True_h->Draw();
+  c1->Print(histoFolder + "/SegGenDirPhiDiff_True_h.png");
+  SegGenDirEtaDiff_True_h->Write();
+  SegGenDirEtaDiff_True_h->Draw();
+  c1->Print(histoFolder + "/SegGenDirEtaDiff_True_h.png");
+
+  SegGenDirPhiPull_True_h->Write();
+  SegGenDirPhiPull_True_h->Draw();
+  c1->Print(histoFolder + "/SegGenDirPhiPull_True_h.png");
+  SegGenDirPhiPull_All_h->Write();
+  SegGenDirPhiPull_All_h->Draw();
+  c1->Print(histoFolder + "/SegGenDirPhiPull_All_h.png");
+
+  c1->SetLogy();
+  SegGenDirPhiDiff_All_h->Write();
+  SegGenDirPhiDiff_All_h->Draw();
+  c1->Print(histoFolder + "/SegGenDirPhiDiff_All_h.png");
+  c1->SetLogy();
+  SegGenDirEtaDiff_All_h->Write();
+  SegGenDirEtaDiff_All_h->Draw();
+  c1->Print(histoFolder + "/SegGenDirEtaDiff_All_h.png");
+
+  Candidate_Eta->Write();
+  Candidate_Eta->Draw();
+  c1->Print(histoFolder + "/Candidate_Eta.png");
+  Track_Eta->Write();
+  Track_Eta->Draw();
+  c1->Print(histoFolder + "/Track_Eta.png");
+  Track_Pt->Write();
+  Track_Pt->Draw();
+  c1->Print(histoFolder + "/Track_Pt.png");
 
   Segment_Eta->GetXaxis()->SetTitle("me0segment |#eta|");
   Segment_Eta->GetYaxis()->SetTitle(" Num. Segments");
-  Segment_Eta->Write();   Segment_Eta->Draw();  
-  //GenMuon_Eta->SetLineColor(2);GenMuon_Eta->Draw("SAME"); 
-  c1->Print(histoFolder+"/Segment_Eta.png");
+  Segment_Eta->Write();
+  Segment_Eta->Draw();
+  //GenMuon_Eta->SetLineColor(2);GenMuon_Eta->Draw("SAME");
+  c1->Print(histoFolder + "/Segment_Eta.png");
 
-  Segment_Phi->Write();   Segment_Phi->Draw();  c1->Print(histoFolder+"/Segment_Phi.png");
-  Segment_R->Write();   Segment_R->Draw();  c1->Print(histoFolder+"/Segment_R.png");
-  Segment_Pos->Write();   Segment_Pos->Draw();  c1->Print(histoFolder+"/Segment_Pos.png");
+  Segment_Phi->Write();
+  Segment_Phi->Draw();
+  c1->Print(histoFolder + "/Segment_Phi.png");
+  Segment_R->Write();
+  Segment_R->Draw();
+  c1->Print(histoFolder + "/Segment_R.png");
+  Segment_Pos->Write();
+  Segment_Pos->Draw();
+  c1->Print(histoFolder + "/Segment_Pos.png");
 
-  Rechit_Eta->Write();   Rechit_Eta->Draw();   c1->Print(histoFolder+"/Rechit_Eta.png");
-  Rechit_Phi->Write();   Rechit_Phi->Draw();  c1->Print(histoFolder+"/Rechit_Phi.png");
-  Rechit_R->Write();   Rechit_R->Draw();  c1->Print(histoFolder+"/Rechit_R.png");
-  Rechit_Pos->Write();   Rechit_Pos->Draw();  c1->Print(histoFolder+"/Rechit_Pos.png");
+  Rechit_Eta->Write();
+  Rechit_Eta->Draw();
+  c1->Print(histoFolder + "/Rechit_Eta.png");
+  Rechit_Phi->Write();
+  Rechit_Phi->Draw();
+  c1->Print(histoFolder + "/Rechit_Phi.png");
+  Rechit_R->Write();
+  Rechit_R->Draw();
+  c1->Print(histoFolder + "/Rechit_R.png");
+  Rechit_Pos->Write();
+  Rechit_Pos->Draw();
+  c1->Print(histoFolder + "/Rechit_Pos.png");
 
-  ME0Muon_Eta->Write();   ME0Muon_Eta->Draw();  
+  ME0Muon_Eta->Write();
+  ME0Muon_Eta->Draw();
   ME0Muon_Eta->GetXaxis()->SetTitle("ME0Muon |#eta|");
   ME0Muon_Eta->GetXaxis()->SetTitleSize(0.05);
-  c1->Print(histoFolder+"/ME0Muon_Eta.png");
+  c1->Print(histoFolder + "/ME0Muon_Eta.png");
 
-  CheckME0Muon_Eta->Write();   CheckME0Muon_Eta->Draw();  
+  CheckME0Muon_Eta->Write();
+  CheckME0Muon_Eta->Draw();
   CheckME0Muon_Eta->GetXaxis()->SetTitle("CheckME0Muon |#eta|");
   CheckME0Muon_Eta->GetXaxis()->SetTitleSize(0.05);
-  c1->Print(histoFolder+"/CheckME0Muon_Eta.png");
+  c1->Print(histoFolder + "/CheckME0Muon_Eta.png");
 
-  ME0Muon_Cuts_Eta->Write();   ME0Muon_Cuts_Eta->Draw();  c1->Print(histoFolder+"/ME0Muon_Cuts_Eta.png");
-  ME0Muon_Cuts_WidestBinning_Eta->Write();   ME0Muon_Cuts_WidestBinning_Eta->Draw();  c1->Print(histoFolder+"/ME0Muon_Cuts_WidestBinning_Eta.png");
-  ME0Muon_Cuts_WideBinning_Eta->Write();   ME0Muon_Cuts_WideBinning_Eta->Draw();  c1->Print(histoFolder+"/ME0Muon_Cuts_WideBinning_Eta.png");
+  ME0Muon_Cuts_Eta->Write();
+  ME0Muon_Cuts_Eta->Draw();
+  c1->Print(histoFolder + "/ME0Muon_Cuts_Eta.png");
+  ME0Muon_Cuts_WidestBinning_Eta->Write();
+  ME0Muon_Cuts_WidestBinning_Eta->Draw();
+  c1->Print(histoFolder + "/ME0Muon_Cuts_WidestBinning_Eta.png");
+  ME0Muon_Cuts_WideBinning_Eta->Write();
+  ME0Muon_Cuts_WideBinning_Eta->Draw();
+  c1->Print(histoFolder + "/ME0Muon_Cuts_WideBinning_Eta.png");
   //c1->SetLogy();
-  ME0Muon_Pt->Write();   ME0Muon_Pt->Draw();  
+  ME0Muon_Pt->Write();
+  ME0Muon_Pt->Draw();
   ME0Muon_Pt->GetXaxis()->SetTitle("ME0Muon p_{T}");
   ME0Muon_Pt->GetXaxis()->SetTitleSize(0.05);
-  c1->Print(histoFolder+"/ME0Muon_Pt.png");
+  c1->Print(histoFolder + "/ME0Muon_Pt.png");
 
-  ME0Muon_SmallBins_Pt->Write();   ME0Muon_SmallBins_Pt->Draw();  
+  ME0Muon_SmallBins_Pt->Write();
+  ME0Muon_SmallBins_Pt->Draw();
   ME0Muon_SmallBins_Pt->GetXaxis()->SetTitle("ME0Muon p_{T}");
   ME0Muon_SmallBins_Pt->GetXaxis()->SetTitleSize(0.05);
-  c1->Print(histoFolder+"/ME0Muon_SmallBins_Pt.png");
+  c1->Print(histoFolder + "/ME0Muon_SmallBins_Pt.png");
 
-  ME0Muon_VariableBins_Pt->Write();   ME0Muon_VariableBins_Pt->Draw();  
+  ME0Muon_VariableBins_Pt->Write();
+  ME0Muon_VariableBins_Pt->Draw();
   ME0Muon_VariableBins_Pt->GetXaxis()->SetTitle("ME0Muon p_{T}");
   ME0Muon_VariableBins_Pt->GetXaxis()->SetTitleSize(0.05);
-  c1->Print(histoFolder+"/ME0Muon_VariableBins_Pt.png");
+  c1->Print(histoFolder + "/ME0Muon_VariableBins_Pt.png");
 
-  GenMuon_Eta->Write();   GenMuon_Eta->Draw();  c1->Print(histoFolder+"/GenMuon_Eta.png");
-  GenMuon_WideBinning_Eta->Write();   GenMuon_WideBinning_Eta->Draw();  c1->Print(histoFolder+"/GenMuon_WideBinning_Eta.png");
-  GenMuon_WidestBinning_Eta->Write();   GenMuon_WidestBinning_Eta->Draw();  c1->Print(histoFolder+"/GenMuon_WidestBinning_Eta.png");
+  GenMuon_Eta->Write();
+  GenMuon_Eta->Draw();
+  c1->Print(histoFolder + "/GenMuon_Eta.png");
+  GenMuon_WideBinning_Eta->Write();
+  GenMuon_WideBinning_Eta->Draw();
+  c1->Print(histoFolder + "/GenMuon_WideBinning_Eta.png");
+  GenMuon_WidestBinning_Eta->Write();
+  GenMuon_WidestBinning_Eta->Draw();
+  c1->Print(histoFolder + "/GenMuon_WidestBinning_Eta.png");
 
-  TPMuon_Eta->Write();   TPMuon_Eta->Draw();  c1->Print(histoFolder+"/TPMuon_Eta.png");
-  TPMuon_WideBinning_Eta->Write();   TPMuon_WideBinning_Eta->Draw();  c1->Print(histoFolder+"/TPMuon_WideBinning_Eta.png");
-  TPMuon_WidestBinning_Eta->Write();   TPMuon_WidestBinning_Eta->Draw();  c1->Print(histoFolder+"/TPMuon_WidestBinning_Eta.png");
+  TPMuon_Eta->Write();
+  TPMuon_Eta->Draw();
+  c1->Print(histoFolder + "/TPMuon_Eta.png");
+  TPMuon_WideBinning_Eta->Write();
+  TPMuon_WideBinning_Eta->Draw();
+  c1->Print(histoFolder + "/TPMuon_WideBinning_Eta.png");
+  TPMuon_WidestBinning_Eta->Write();
+  TPMuon_WidestBinning_Eta->Draw();
+  c1->Print(histoFolder + "/TPMuon_WidestBinning_Eta.png");
 
+  TPMuon_Pt->Write();
+  TPMuon_Pt->Draw();
+  c1->Print(histoFolder + "/TPMuon_Pt.png");
+  TPMuon_SmallBins_Pt->Write();
+  TPMuon_SmallBins_Pt->Draw();
+  c1->Print(histoFolder + "/TPMuon_SmallBins_Pt.png");
+  TPMuon_VariableBins_Pt->Write();
+  TPMuon_VariableBins_Pt->Draw();
+  c1->Print(histoFolder + "/TPMuon_VariableBins_Pt.png");
 
-  TPMuon_Pt->Write();   TPMuon_Pt->Draw();  c1->Print(histoFolder+"/TPMuon_Pt.png");
-  TPMuon_SmallBins_Pt->Write();   TPMuon_SmallBins_Pt->Draw();  c1->Print(histoFolder+"/TPMuon_SmallBins_Pt.png");
-  TPMuon_VariableBins_Pt->Write();   TPMuon_VariableBins_Pt->Draw();  c1->Print(histoFolder+"/TPMuon_VariableBins_Pt.png");
+  GenMuon_Pt->Write();
+  GenMuon_Pt->Draw();
+  c1->Print(histoFolder + "/GenMuon_Pt.png");
+  GenMuon_SmallBins_Pt->Write();
+  GenMuon_SmallBins_Pt->Draw();
+  c1->Print(histoFolder + "/GenMuon_SmallBins_Pt.png");
+  GenMuon_VariableBins_Pt->Write();
+  GenMuon_VariableBins_Pt->Draw();
+  c1->Print(histoFolder + "/GenMuon_VariableBins_Pt.png");
 
-  GenMuon_Pt->Write();   GenMuon_Pt->Draw();  c1->Print(histoFolder+"/GenMuon_Pt.png");
-  GenMuon_SmallBins_Pt->Write();   GenMuon_SmallBins_Pt->Draw();  c1->Print(histoFolder+"/GenMuon_SmallBins_Pt.png");
-  GenMuon_VariableBins_Pt->Write();   GenMuon_VariableBins_Pt->Draw();  c1->Print(histoFolder+"/GenMuon_VariableBins_Pt.png");
+  MatchedME0Muon_Eta->Write();
+  MatchedME0Muon_Eta->Draw();
+  c1->Print(histoFolder + "/MatchedME0Muon_Eta.png");
+  MatchedME0Muon_WideBinning_Eta->Write();
+  MatchedME0Muon_WideBinning_Eta->Draw();
+  c1->Print(histoFolder + "/MatchedME0Muon_WideBinning_Eta.png");
+  MatchedME0Muon_WidestBinning_Eta->Write();
+  MatchedME0Muon_WidestBinning_Eta->Draw();
+  c1->Print(histoFolder + "/MatchedME0Muon_WidestBinning_Eta.png");
 
-  MatchedME0Muon_Eta->Write();   MatchedME0Muon_Eta->Draw();  c1->Print(histoFolder+"/MatchedME0Muon_Eta.png");
-  MatchedME0Muon_WideBinning_Eta->Write();   MatchedME0Muon_WideBinning_Eta->Draw();  c1->Print(histoFolder+"/MatchedME0Muon_WideBinning_Eta.png");
-  MatchedME0Muon_WidestBinning_Eta->Write();   MatchedME0Muon_WidestBinning_Eta->Draw();  c1->Print(histoFolder+"/MatchedME0Muon_WidestBinning_Eta.png");
+  StandaloneMatchedME0Muon_Eta->Write();
+  StandaloneMatchedME0Muon_Eta->Draw();
+  c1->Print(histoFolder + "/StandaloneMatchedME0Muon_Eta.png");
+  StandaloneMatchedME0Muon_WideBinning_Eta->Write();
+  StandaloneMatchedME0Muon_WideBinning_Eta->Draw();
+  c1->Print(histoFolder + "/StandaloneMatchedME0Muon_WideBinning_Eta.png");
+  StandaloneMatchedME0Muon_WidestBinning_Eta->Write();
+  StandaloneMatchedME0Muon_WidestBinning_Eta->Draw();
+  c1->Print(histoFolder + "/StandaloneMatchedME0Muon_WidestBinning_Eta.png");
 
-  StandaloneMatchedME0Muon_Eta->Write();   StandaloneMatchedME0Muon_Eta->Draw();  c1->Print(histoFolder+"/StandaloneMatchedME0Muon_Eta.png");
-  StandaloneMatchedME0Muon_WideBinning_Eta->Write();   StandaloneMatchedME0Muon_WideBinning_Eta->Draw();  c1->Print(histoFolder+"/StandaloneMatchedME0Muon_WideBinning_Eta.png");
-  StandaloneMatchedME0Muon_WidestBinning_Eta->Write();   StandaloneMatchedME0Muon_WidestBinning_Eta->Draw();  c1->Print(histoFolder+"/StandaloneMatchedME0Muon_WidestBinning_Eta.png");
-
-  Chi2MatchedME0Muon_Eta->Write();   Chi2MatchedME0Muon_Eta->Draw();  c1->Print(histoFolder+"/Chi2MatchedME0Muon_Eta.png");
-  Chi2MatchedME0Muon_WideBinning_Eta->Write();   Chi2MatchedME0Muon_WideBinning_Eta->Draw();  c1->Print(histoFolder+"/Chi2MatchedME0Muon_WideBinning_Eta.png");
-  Chi2MatchedME0Muon_WidestBinning_Eta->Write();   Chi2MatchedME0Muon_WidestBinning_Eta->Draw();  c1->Print(histoFolder+"/Chi2MatchedME0Muon_WidestBinning_Eta.png");
-  Chi2UnmatchedME0Muon_Eta->Write();   Chi2UnmatchedME0Muon_Eta->Draw();  c1->Print(histoFolder+"/Chi2UnmatchedME0Muon_Eta.png");
-  Chi2UnmatchedME0Muon_WideBinning_Eta->Write();   Chi2UnmatchedME0Muon_WideBinning_Eta->Draw();  c1->Print(histoFolder+"/Chi2UnmatchedME0Muon_WideBinning_Eta.png");
-  Chi2UnmatchedME0Muon_WidestBinning_Eta->Write();   Chi2UnmatchedME0Muon_WidestBinning_Eta->Draw();  c1->Print(histoFolder+"/Chi2UnmatchedME0Muon_WidestBinning_Eta.png");
+  Chi2MatchedME0Muon_Eta->Write();
+  Chi2MatchedME0Muon_Eta->Draw();
+  c1->Print(histoFolder + "/Chi2MatchedME0Muon_Eta.png");
+  Chi2MatchedME0Muon_WideBinning_Eta->Write();
+  Chi2MatchedME0Muon_WideBinning_Eta->Draw();
+  c1->Print(histoFolder + "/Chi2MatchedME0Muon_WideBinning_Eta.png");
+  Chi2MatchedME0Muon_WidestBinning_Eta->Write();
+  Chi2MatchedME0Muon_WidestBinning_Eta->Draw();
+  c1->Print(histoFolder + "/Chi2MatchedME0Muon_WidestBinning_Eta.png");
+  Chi2UnmatchedME0Muon_Eta->Write();
+  Chi2UnmatchedME0Muon_Eta->Draw();
+  c1->Print(histoFolder + "/Chi2UnmatchedME0Muon_Eta.png");
+  Chi2UnmatchedME0Muon_WideBinning_Eta->Write();
+  Chi2UnmatchedME0Muon_WideBinning_Eta->Draw();
+  c1->Print(histoFolder + "/Chi2UnmatchedME0Muon_WideBinning_Eta.png");
+  Chi2UnmatchedME0Muon_WidestBinning_Eta->Write();
+  Chi2UnmatchedME0Muon_WidestBinning_Eta->Draw();
+  c1->Print(histoFolder + "/Chi2UnmatchedME0Muon_WidestBinning_Eta.png");
 
   gStyle->SetOptStat(1);
   MatchedME0Muon_Pt->GetXaxis()->SetTitle("ME0Muon p_{T}");
   //MatchedME0Muon_Pt->GetYaxis()->SetTitle(" \# of Se");
 
-  MatchedME0Muon_Pt->Write();   MatchedME0Muon_Pt->Draw();  c1->Print(histoFolder+"/MatchedME0Muon_Pt.png");
+  MatchedME0Muon_Pt->Write();
+  MatchedME0Muon_Pt->Draw();
+  c1->Print(histoFolder + "/MatchedME0Muon_Pt.png");
 
   MatchedME0Muon_SmallBins_Pt->GetXaxis()->SetTitle("ME0Muon p_{T}");
   //MatchedME0Muon_SmallBins_Pt->GetYaxis()->SetTitle(" \# of Se");
 
-  MatchedME0Muon_SmallBins_Pt->Write();   MatchedME0Muon_SmallBins_Pt->Draw();  c1->Print(histoFolder+"/MatchedME0Muon_SmallBins_Pt.png");
+  MatchedME0Muon_SmallBins_Pt->Write();
+  MatchedME0Muon_SmallBins_Pt->Draw();
+  c1->Print(histoFolder + "/MatchedME0Muon_SmallBins_Pt.png");
 
   MatchedME0Muon_VariableBins_Pt->GetXaxis()->SetTitle("ME0Muon p_{T}");
   //MatchedME0Muon_VariableBins_Pt->GetYaxis()->SetTitle(" \# of Se");
 
-  MatchedME0Muon_VariableBins_Pt->Write();   MatchedME0Muon_VariableBins_Pt->Draw();  c1->Print(histoFolder+"/MatchedME0Muon_VariableBins_Pt.png");
+  MatchedME0Muon_VariableBins_Pt->Write();
+  MatchedME0Muon_VariableBins_Pt->Draw();
+  c1->Print(histoFolder + "/MatchedME0Muon_VariableBins_Pt.png");
   gStyle->SetOptStat(0);
 
-  UnmatchedME0Muon_Eta->Write();   UnmatchedME0Muon_Eta->Draw();  c1->Print(histoFolder+"/UnmatchedME0Muon_Eta.png");
-  UnmatchedME0Muon_Cuts_Eta->Write();   UnmatchedME0Muon_Cuts_Eta->Draw();  c1->Print(histoFolder+"/UnmatchedME0Muon_Cuts_Eta.png");
-  UnmatchedME0Muon_Cuts_WideBinning_Eta->Write();   UnmatchedME0Muon_Cuts_WideBinning_Eta->Draw();  c1->Print(histoFolder+"/UnmatchedME0Muon_Cuts_WideBinning_Eta.png");
-  UnmatchedME0Muon_Cuts_WidestBinning_Eta->Write();   UnmatchedME0Muon_Cuts_WidestBinning_Eta->Draw();  c1->Print(histoFolder+"/UnmatchedME0Muon_Cuts_WidestBinning_Eta.png");
+  UnmatchedME0Muon_Eta->Write();
+  UnmatchedME0Muon_Eta->Draw();
+  c1->Print(histoFolder + "/UnmatchedME0Muon_Eta.png");
+  UnmatchedME0Muon_Cuts_Eta->Write();
+  UnmatchedME0Muon_Cuts_Eta->Draw();
+  c1->Print(histoFolder + "/UnmatchedME0Muon_Cuts_Eta.png");
+  UnmatchedME0Muon_Cuts_WideBinning_Eta->Write();
+  UnmatchedME0Muon_Cuts_WideBinning_Eta->Draw();
+  c1->Print(histoFolder + "/UnmatchedME0Muon_Cuts_WideBinning_Eta.png");
+  UnmatchedME0Muon_Cuts_WidestBinning_Eta->Write();
+  UnmatchedME0Muon_Cuts_WidestBinning_Eta->Draw();
+  c1->Print(histoFolder + "/UnmatchedME0Muon_Cuts_WidestBinning_Eta.png");
 
-  UnmatchedME0Muon_ScatterPlot->Write();  UnmatchedME0Muon_ScatterPlot->Draw(); UnmatchedME0Muon_ScatterPlot->Print(histoFolder+"/UnmatchedME0Muon_ScatterPlot.png");
-
+  UnmatchedME0Muon_ScatterPlot->Write();
+  UnmatchedME0Muon_ScatterPlot->Draw();
+  UnmatchedME0Muon_ScatterPlot->Print(histoFolder + "/UnmatchedME0Muon_ScatterPlot.png");
 
   //gStyle->SetOptStat('oue');
   c1->SetLogy();
-  UnmatchedME0Muon_Pt->Write();   UnmatchedME0Muon_Pt->Draw();  c1->Print(histoFolder+"/UnmatchedME0Muon_Pt.png");
-  UnmatchedME0Muon_SmallBins_Pt->Write();   UnmatchedME0Muon_SmallBins_Pt->Draw();  c1->Print(histoFolder+"/UnmatchedME0Muon_SmallBins_Pt.png");
-  UnmatchedME0Muon_VariableBins_Pt->Write();   UnmatchedME0Muon_VariableBins_Pt->Draw();  c1->Print(histoFolder+"/UnmatchedME0Muon_VariableBins_Pt.png");
+  UnmatchedME0Muon_Pt->Write();
+  UnmatchedME0Muon_Pt->Draw();
+  c1->Print(histoFolder + "/UnmatchedME0Muon_Pt.png");
+  UnmatchedME0Muon_SmallBins_Pt->Write();
+  UnmatchedME0Muon_SmallBins_Pt->Draw();
+  c1->Print(histoFolder + "/UnmatchedME0Muon_SmallBins_Pt.png");
+  UnmatchedME0Muon_VariableBins_Pt->Write();
+  UnmatchedME0Muon_VariableBins_Pt->Draw();
+  c1->Print(histoFolder + "/UnmatchedME0Muon_VariableBins_Pt.png");
 
-  Chi2UnmatchedME0Muon_Pt->Write();   Chi2UnmatchedME0Muon_Pt->Draw();  c1->Print(histoFolder+"/Chi2UnmatchedME0Muon_Pt.png");
-  Chi2UnmatchedME0Muon_SmallBins_Pt->Write();   Chi2UnmatchedME0Muon_SmallBins_Pt->Draw();  c1->Print(histoFolder+"/Chi2UnmatchedME0Muon_SmallBins_Pt.png");
-  Chi2UnmatchedME0Muon_VariableBins_Pt->Write();   Chi2UnmatchedME0Muon_VariableBins_Pt->Draw();  c1->Print(histoFolder+"/Chi2UnmatchedME0Muon_VariableBins_Pt.png");
+  Chi2UnmatchedME0Muon_Pt->Write();
+  Chi2UnmatchedME0Muon_Pt->Draw();
+  c1->Print(histoFolder + "/Chi2UnmatchedME0Muon_Pt.png");
+  Chi2UnmatchedME0Muon_SmallBins_Pt->Write();
+  Chi2UnmatchedME0Muon_SmallBins_Pt->Draw();
+  c1->Print(histoFolder + "/Chi2UnmatchedME0Muon_SmallBins_Pt.png");
+  Chi2UnmatchedME0Muon_VariableBins_Pt->Write();
+  Chi2UnmatchedME0Muon_VariableBins_Pt->Draw();
+  c1->Print(histoFolder + "/Chi2UnmatchedME0Muon_VariableBins_Pt.png");
 
+  Chi2MatchedME0Muon_Pt->Write();
+  Chi2MatchedME0Muon_Pt->Draw();
+  c1->Print(histoFolder + "/Chi2MatchedME0Muon_Pt.png");
+  Chi2MatchedME0Muon_SmallBins_Pt->Write();
+  Chi2MatchedME0Muon_SmallBins_Pt->Draw();
+  c1->Print(histoFolder + "/Chi2MatchedME0Muon_SmallBins_Pt.png");
+  Chi2MatchedME0Muon_VariableBins_Pt->Write();
+  Chi2MatchedME0Muon_VariableBins_Pt->Draw();
+  c1->Print(histoFolder + "/Chi2MatchedME0Muon_VariableBins_Pt.png");
 
-  Chi2MatchedME0Muon_Pt->Write();   Chi2MatchedME0Muon_Pt->Draw();  c1->Print(histoFolder+"/Chi2MatchedME0Muon_Pt.png");
-  Chi2MatchedME0Muon_SmallBins_Pt->Write();   Chi2MatchedME0Muon_SmallBins_Pt->Draw();  c1->Print(histoFolder+"/Chi2MatchedME0Muon_SmallBins_Pt.png");
-  Chi2MatchedME0Muon_VariableBins_Pt->Write();   Chi2MatchedME0Muon_VariableBins_Pt->Draw();  c1->Print(histoFolder+"/Chi2MatchedME0Muon_VariableBins_Pt.png");
-
-  UnmatchedME0Muon_Window_Pt->Write();   UnmatchedME0Muon_Window_Pt->Draw();  c1->Print(histoFolder+"/UnmatchedME0Muon_Window_Pt.png");
+  UnmatchedME0Muon_Window_Pt->Write();
+  UnmatchedME0Muon_Window_Pt->Draw();
+  c1->Print(histoFolder + "/UnmatchedME0Muon_Window_Pt.png");
   gStyle->SetOptStat(0);
 
-  FailedTrack_Window_XPull->Write();   FailedTrack_Window_XPull->Draw();  c1->Print(histoFolder+"/FailedTrack_Window_XPull.png");
-  FailedTrack_Window_YPull->Write();   FailedTrack_Window_YPull->Draw();  c1->Print(histoFolder+"/FailedTrack_Window_YPull.png");
-  FailedTrack_Window_XDiff->Write();   FailedTrack_Window_XDiff->Draw();  c1->Print(histoFolder+"/FailedTrack_Window_XDiff.png");
-  FailedTrack_Window_YDiff->Write();   FailedTrack_Window_YDiff->Draw();  c1->Print(histoFolder+"/FailedTrack_Window_YDiff.png");
-  FailedTrack_Window_PhiDiff->Write();   FailedTrack_Window_PhiDiff->Draw();  c1->Print(histoFolder+"/FailedTrack_Window_PhiDiff.png");
+  FailedTrack_Window_XPull->Write();
+  FailedTrack_Window_XPull->Draw();
+  c1->Print(histoFolder + "/FailedTrack_Window_XPull.png");
+  FailedTrack_Window_YPull->Write();
+  FailedTrack_Window_YPull->Draw();
+  c1->Print(histoFolder + "/FailedTrack_Window_YPull.png");
+  FailedTrack_Window_XDiff->Write();
+  FailedTrack_Window_XDiff->Draw();
+  c1->Print(histoFolder + "/FailedTrack_Window_XDiff.png");
+  FailedTrack_Window_YDiff->Write();
+  FailedTrack_Window_YDiff->Draw();
+  c1->Print(histoFolder + "/FailedTrack_Window_YDiff.png");
+  FailedTrack_Window_PhiDiff->Write();
+  FailedTrack_Window_PhiDiff->Draw();
+  c1->Print(histoFolder + "/FailedTrack_Window_PhiDiff.png");
 
   c1->SetLogy(0);
   TH1F *UnmatchedME0Muon_Cuts_Eta_PerEvent;
-  UnmatchedME0Muon_Cuts_Eta_PerEvent = new TH1F("UnmatchedME0Muon_Cuts_Eta_PerEvent"      , "Muon |#eta|"   , 4, 2.0, 2.8 );
+  UnmatchedME0Muon_Cuts_Eta_PerEvent = new TH1F("UnmatchedME0Muon_Cuts_Eta_PerEvent", "Muon |#eta|", 4, 2.0, 2.8);
   //UnmatchedME0Muon_Cuts_Eta_PerEvent->Sumw2();
-  for (int i=1; i<=UnmatchedME0Muon_Cuts_Eta_PerEvent->GetNbinsX(); ++i){
-    UnmatchedME0Muon_Cuts_Eta_PerEvent->SetBinContent(i,(UnmatchedME0Muon_Cuts_Eta->GetBinContent(i)));
+  for (int i = 1; i <= UnmatchedME0Muon_Cuts_Eta_PerEvent->GetNbinsX(); ++i) {
+    UnmatchedME0Muon_Cuts_Eta_PerEvent->SetBinContent(i, (UnmatchedME0Muon_Cuts_Eta->GetBinContent(i)));
   }
-  UnmatchedME0Muon_Cuts_Eta_PerEvent->Scale(1/Nevents);
+  UnmatchedME0Muon_Cuts_Eta_PerEvent->Scale(1 / Nevents);
 
   UnmatchedME0Muon_Cuts_Eta_PerEvent->GetXaxis()->SetTitle("ME0Muon |#eta|");
   UnmatchedME0Muon_Cuts_Eta_PerEvent->GetXaxis()->SetTitleSize(0.05);
-  
+
   UnmatchedME0Muon_Cuts_Eta_PerEvent->GetYaxis()->SetTitle("Average Num. ME0Muons per event");
   UnmatchedME0Muon_Cuts_Eta_PerEvent->GetYaxis()->SetTitleSize(0.05);
 
-  UnmatchedME0Muon_Cuts_Eta_PerEvent->Write();   UnmatchedME0Muon_Cuts_Eta_PerEvent->Draw();  c1->Print(histoFolder+"/UnmatchedME0Muon_Cuts_Eta_PerEvent.png");
-
+  UnmatchedME0Muon_Cuts_Eta_PerEvent->Write();
+  UnmatchedME0Muon_Cuts_Eta_PerEvent->Draw();
+  c1->Print(histoFolder + "/UnmatchedME0Muon_Cuts_Eta_PerEvent.png");
 
   TH1F *Chi2UnmatchedME0Muon_Eta_PerEvent;
-  Chi2UnmatchedME0Muon_Eta_PerEvent = new TH1F("Chi2UnmatchedME0Muon_Eta_PerEvent"      , "Muon |#eta|"   , 4, 2.0, 2.8 );
+  Chi2UnmatchedME0Muon_Eta_PerEvent = new TH1F("Chi2UnmatchedME0Muon_Eta_PerEvent", "Muon |#eta|", 4, 2.0, 2.8);
   //Chi2UnmatchedME0Muon_Eta_PerEvent->Sumw2();
-  for (int i=1; i<=Chi2UnmatchedME0Muon_Eta_PerEvent->GetNbinsX(); ++i){
-    Chi2UnmatchedME0Muon_Eta_PerEvent->SetBinContent(i,(Chi2UnmatchedME0Muon_Eta->GetBinContent(i)));
+  for (int i = 1; i <= Chi2UnmatchedME0Muon_Eta_PerEvent->GetNbinsX(); ++i) {
+    Chi2UnmatchedME0Muon_Eta_PerEvent->SetBinContent(i, (Chi2UnmatchedME0Muon_Eta->GetBinContent(i)));
   }
-  Chi2UnmatchedME0Muon_Eta_PerEvent->Scale(1/Nevents);
+  Chi2UnmatchedME0Muon_Eta_PerEvent->Scale(1 / Nevents);
 
   Chi2UnmatchedME0Muon_Eta_PerEvent->GetXaxis()->SetTitle("ME0Muon |#eta|");
   Chi2UnmatchedME0Muon_Eta_PerEvent->GetXaxis()->SetTitleSize(0.05);
-  
+
   Chi2UnmatchedME0Muon_Eta_PerEvent->GetYaxis()->SetTitle("Average Num. ME0Muons per event");
   Chi2UnmatchedME0Muon_Eta_PerEvent->GetYaxis()->SetTitleSize(0.05);
 
-  Chi2UnmatchedME0Muon_Eta_PerEvent->Write();   Chi2UnmatchedME0Muon_Eta_PerEvent->Draw();  c1->Print(histoFolder+"/Chi2UnmatchedME0Muon_Eta_PerEvent.png");
-
+  Chi2UnmatchedME0Muon_Eta_PerEvent->Write();
+  Chi2UnmatchedME0Muon_Eta_PerEvent->Draw();
+  c1->Print(histoFolder + "/Chi2UnmatchedME0Muon_Eta_PerEvent.png");
 
   TH1F *ME0Muon_Cuts_Eta_PerEvent;
-  ME0Muon_Cuts_Eta_PerEvent = new TH1F("ME0Muon_Cuts_Eta_PerEvent"      , "Muon |#eta|"   , 4, 2.0, 2.8 );
+  ME0Muon_Cuts_Eta_PerEvent = new TH1F("ME0Muon_Cuts_Eta_PerEvent", "Muon |#eta|", 4, 2.0, 2.8);
 
-  for (int i=1; i<=ME0Muon_Cuts_Eta_PerEvent->GetNbinsX(); ++i){
-    ME0Muon_Cuts_Eta_PerEvent->SetBinContent(i,(ME0Muon_Cuts_Eta->GetBinContent(i)));
+  for (int i = 1; i <= ME0Muon_Cuts_Eta_PerEvent->GetNbinsX(); ++i) {
+    ME0Muon_Cuts_Eta_PerEvent->SetBinContent(i, (ME0Muon_Cuts_Eta->GetBinContent(i)));
   }
-  ME0Muon_Cuts_Eta_PerEvent->Scale(1/Nevents);
+  ME0Muon_Cuts_Eta_PerEvent->Scale(1 / Nevents);
 
-  ME0Muon_Cuts_Eta_PerEvent->Write();   ME0Muon_Cuts_Eta_PerEvent->Draw();  c1->Print(histoFolder+"/ME0Muon_Cuts_Eta_PerEvent.png");
+  ME0Muon_Cuts_Eta_PerEvent->Write();
+  ME0Muon_Cuts_Eta_PerEvent->Draw();
+  c1->Print(histoFolder + "/ME0Muon_Cuts_Eta_PerEvent.png");
 
-  
-
-  Mass_h->Write();   Mass_h->Draw();  c1->Print(histoFolder+"/Mass_h.png");
+  Mass_h->Write();
+  Mass_h->Draw();
+  c1->Print(histoFolder + "/Mass_h.png");
   TracksPerSegment_s->SetMarkerStyle(1);
   TracksPerSegment_s->SetMarkerSize(3.0);
-  TracksPerSegment_s->Write();     TracksPerSegment_s->Draw();  c1->Print(histoFolder+"/TracksPerSegment_s.png");
+  TracksPerSegment_s->Write();
+  TracksPerSegment_s->Draw();
+  c1->Print(histoFolder + "/TracksPerSegment_s.png");
 
-  TracksPerSegment_h->Write();     TracksPerSegment_h->Draw();  c1->Print(histoFolder+"/TracksPerSegment_h.png");
+  TracksPerSegment_h->Write();
+  TracksPerSegment_h->Draw();
+  c1->Print(histoFolder + "/TracksPerSegment_h.png");
 
   TracksPerSegment_p->GetXaxis()->SetTitle("Gen Muon #eta");
   TracksPerSegment_p->GetYaxis()->SetTitle("Average N_{Tracks} per segment");
-  TracksPerSegment_p->Write();     TracksPerSegment_p->Draw();  c1->Print(histoFolder+"/TracksPerSegment_p.png");
+  TracksPerSegment_p->Write();
+  TracksPerSegment_p->Draw();
+  c1->Print(histoFolder + "/TracksPerSegment_p.png");
 
   ClosestDelR_s->SetMarkerStyle(1);
   ClosestDelR_s->SetMarkerSize(3.0);
-  ClosestDelR_s->Write();     ClosestDelR_s->Draw();  c1->Print(histoFolder+"/ClosestDelR_s.png");
+  ClosestDelR_s->Write();
+  ClosestDelR_s->Draw();
+  c1->Print(histoFolder + "/ClosestDelR_s.png");
 
-  DelR_Window_Under5->Write();     DelR_Window_Under5->Draw();     c1->Print(histoFolder+"/DelR_Window_Under5.png");
-  Pt_Window_Under5->Write();    Pt_Window_Under5->Draw();    c1->Print(histoFolder+"/Pt_Window_Under5.png");
+  DelR_Window_Under5->Write();
+  DelR_Window_Under5->Draw();
+  c1->Print(histoFolder + "/DelR_Window_Under5.png");
+  Pt_Window_Under5->Write();
+  Pt_Window_Under5->Draw();
+  c1->Print(histoFolder + "/Pt_Window_Under5.png");
 
-  DelR_Track_Window_Under5->Write();     DelR_Track_Window_Under5->Draw();     c1->Print(histoFolder+"/DelR_Track_Window_Under5.png");
-  Pt_Track_Window_Under5->Write();    Pt_Track_Window_Under5->Draw();    c1->Print(histoFolder+"/Pt_Track_Window_Under5.png");
+  DelR_Track_Window_Under5->Write();
+  DelR_Track_Window_Under5->Draw();
+  c1->Print(histoFolder + "/DelR_Track_Window_Under5.png");
+  Pt_Track_Window_Under5->Write();
+  Pt_Track_Window_Under5->Draw();
+  c1->Print(histoFolder + "/Pt_Track_Window_Under5.png");
   c1->SetLogy(1);
-  Pt_Track_Window->Write();    Pt_Track_Window->Draw();    c1->Print(histoFolder+"/Pt_Track_Window.png");
+  Pt_Track_Window->Write();
+  Pt_Track_Window->Draw();
+  c1->Print(histoFolder + "/Pt_Track_Window.png");
   c1->SetLogy(0);
 
-  DelR_Track_Window_Failed_Under5->Write();     DelR_Track_Window_Failed_Under5->Draw();     c1->Print(histoFolder+"/DelR_Track_Window_Failed_Under5.png");
-  Pt_Track_Window_Failed_Under5->Write();    Pt_Track_Window_Failed_Under5->Draw();    c1->Print(histoFolder+"/Pt_Track_Window_Failed_Under5.png");
+  DelR_Track_Window_Failed_Under5->Write();
+  DelR_Track_Window_Failed_Under5->Draw();
+  c1->Print(histoFolder + "/DelR_Track_Window_Failed_Under5.png");
+  Pt_Track_Window_Failed_Under5->Write();
+  Pt_Track_Window_Failed_Under5->Draw();
+  c1->Print(histoFolder + "/Pt_Track_Window_Failed_Under5.png");
   c1->SetLogy(1);
-  Pt_Track_Window_Failed->Write();    Pt_Track_Window_Failed->Draw();    c1->Print(histoFolder+"/Pt_Track_Window_Failed.png");
+  Pt_Track_Window_Failed->Write();
+  Pt_Track_Window_Failed->Draw();
+  c1->Print(histoFolder + "/Pt_Track_Window_Failed.png");
   c1->SetLogy(0);
 
-  DelR_Segment_GenMuon->Write();   DelR_Segment_GenMuon->Draw();  c1->Print(histoFolder+"/DelR_Segment_GenMuon.png");
+  DelR_Segment_GenMuon->Write();
+  DelR_Segment_GenMuon->Draw();
+  c1->Print(histoFolder + "/DelR_Segment_GenMuon.png");
 
   ClosestDelR_p->GetXaxis()->SetTitle("Gen Muon #eta");
   ClosestDelR_p->GetYaxis()->SetTitle("Average closest #Delta R track");
-  std::cout<<"  ClosestDelR_p values:"<<std::endl;
-  for (int i=1; i<=ClosestDelR_p->GetNbinsX(); ++i){
-    std::cout<<2.4+(double)i*((4.0-2.4)/40.)<<","<<ClosestDelR_p->GetBinContent(i)<<std::endl;
+  std::cout << "  ClosestDelR_p values:" << std::endl;
+  for (int i = 1; i <= ClosestDelR_p->GetNbinsX(); ++i) {
+    std::cout << 2.4 + (double)i * ((4.0 - 2.4) / 40.) << "," << ClosestDelR_p->GetBinContent(i) << std::endl;
   }
-  ClosestDelR_p->Write();     ClosestDelR_p->Draw();  c1->Print(histoFolder+"/ClosestDelR_p.png");
+  ClosestDelR_p->Write();
+  ClosestDelR_p->Draw();
+  c1->Print(histoFolder + "/ClosestDelR_p.png");
 
   FakeTracksPerSegment_s->SetMarkerStyle(1);
   FakeTracksPerSegment_s->SetMarkerSize(3.0);
-  FakeTracksPerSegment_s->Write();     FakeTracksPerSegment_s->Draw();  c1->Print(histoFolder+"/FakeTracksPerSegment_s.png");
+  FakeTracksPerSegment_s->Write();
+  FakeTracksPerSegment_s->Draw();
+  c1->Print(histoFolder + "/FakeTracksPerSegment_s.png");
 
-  FakeTracksPerSegment_h->Write();     FakeTracksPerSegment_h->Draw();  c1->Print(histoFolder+"/FakeTracksPerSegment_h.png");
+  FakeTracksPerSegment_h->Write();
+  FakeTracksPerSegment_h->Draw();
+  c1->Print(histoFolder + "/FakeTracksPerSegment_h.png");
 
   FakeTracksPerSegment_p->GetXaxis()->SetTitle("Gen Muon #eta");
   FakeTracksPerSegment_p->GetYaxis()->SetTitle("Average N_{Tracks} per segment");
-  FakeTracksPerSegment_p->Write();     FakeTracksPerSegment_p->Draw();  c1->Print(histoFolder+"/FakeTracksPerSegment_p.png");
+  FakeTracksPerSegment_p->Write();
+  FakeTracksPerSegment_p->Draw();
+  c1->Print(histoFolder + "/FakeTracksPerSegment_p.png");
 
   FakeTracksPerAssociatedSegment_s->SetMarkerStyle(1);
   FakeTracksPerAssociatedSegment_s->SetMarkerSize(3.0);
-  FakeTracksPerAssociatedSegment_s->Write();     FakeTracksPerAssociatedSegment_s->Draw();  c1->Print(histoFolder+"/FakeTracksPerAssociatedSegment_s.png");
+  FakeTracksPerAssociatedSegment_s->Write();
+  FakeTracksPerAssociatedSegment_s->Draw();
+  c1->Print(histoFolder + "/FakeTracksPerAssociatedSegment_s.png");
 
-  FakeTracksPerAssociatedSegment_h->Write();     FakeTracksPerAssociatedSegment_h->Draw();  c1->Print(histoFolder+"/FakeTracksPerAssociatedSegment_h.png");
+  FakeTracksPerAssociatedSegment_h->Write();
+  FakeTracksPerAssociatedSegment_h->Draw();
+  c1->Print(histoFolder + "/FakeTracksPerAssociatedSegment_h.png");
 
   FakeTracksPerAssociatedSegment_p->GetXaxis()->SetTitle("Gen Muon #eta");
   FakeTracksPerAssociatedSegment_p->GetYaxis()->SetTitle("Average N_{Tracks} per segment");
-  FakeTracksPerAssociatedSegment_p->Write();     FakeTracksPerAssociatedSegment_p->Draw();  c1->Print(histoFolder+"/FakeTracksPerAssociatedSegment_p.png");
+  FakeTracksPerAssociatedSegment_p->Write();
+  FakeTracksPerAssociatedSegment_p->Draw();
+  c1->Print(histoFolder + "/FakeTracksPerAssociatedSegment_p.png");
 
-  PreMatch_TP_R->Write(); PreMatch_TP_R->Draw();  c1->Print(histoFolder+"/PreMatch_TP_R.png");
-  PostMatch_TP_R->Write(); PostMatch_TP_R->Draw();  c1->Print(histoFolder+"/PostMatch_TP_R.png");
-  PostMatch_BX0_TP_R->Write(); PostMatch_BX0_TP_R->Draw();  c1->Print(histoFolder+"/PostMatch_BX0_TP_R.png");
+  PreMatch_TP_R->Write();
+  PreMatch_TP_R->Draw();
+  c1->Print(histoFolder + "/PreMatch_TP_R.png");
+  PostMatch_TP_R->Write();
+  PostMatch_TP_R->Draw();
+  c1->Print(histoFolder + "/PostMatch_TP_R.png");
+  PostMatch_BX0_TP_R->Write();
+  PostMatch_BX0_TP_R->Draw();
+  c1->Print(histoFolder + "/PostMatch_BX0_TP_R.png");
 
-  GenMuon_Eta->Sumw2();  MatchedME0Muon_Eta->Sumw2();  Chi2MatchedME0Muon_Eta->Sumw2();   Chi2UnmatchedME0Muon_Eta->Sumw2();TPMuon_Eta->Sumw2();
-  GenMuon_Pt->Sumw2();  MatchedME0Muon_Pt->Sumw2(); MatchedME0Muon_SmallBins_Pt->Sumw2(); MatchedME0Muon_VariableBins_Pt->Sumw2();
+  GenMuon_Eta->Sumw2();
+  MatchedME0Muon_Eta->Sumw2();
+  Chi2MatchedME0Muon_Eta->Sumw2();
+  Chi2UnmatchedME0Muon_Eta->Sumw2();
+  TPMuon_Eta->Sumw2();
+  GenMuon_Pt->Sumw2();
+  MatchedME0Muon_Pt->Sumw2();
+  MatchedME0Muon_SmallBins_Pt->Sumw2();
+  MatchedME0Muon_VariableBins_Pt->Sumw2();
   StandaloneMatchedME0Muon_Eta->Sumw2();
   StandaloneMatchedME0Muon_WideBinning_Eta->Sumw2();
   StandaloneMatchedME0Muon_WidestBinning_Eta->Sumw2();
-  
 
-  Track_Eta->Sumw2();  ME0Muon_Eta->Sumw2();
-  Track_Pt->Sumw2();  ME0Muon_Pt->Sumw2();  ME0Muon_SmallBins_Pt->Sumw2(); ME0Muon_VariableBins_Pt->Sumw2();
+  Track_Eta->Sumw2();
+  ME0Muon_Eta->Sumw2();
+  Track_Pt->Sumw2();
+  ME0Muon_Pt->Sumw2();
+  ME0Muon_SmallBins_Pt->Sumw2();
+  ME0Muon_VariableBins_Pt->Sumw2();
 
   UnmatchedME0Muon_Eta->Sumw2();
   UnmatchedME0Muon_Pt->Sumw2();
-  UnmatchedME0Muon_SmallBins_Pt->Sumw2();   UnmatchedME0Muon_VariableBins_Pt->Sumw2();
-  
-  UnmatchedME0Muon_Cuts_Eta->Sumw2();    ME0Muon_Cuts_Eta->Sumw2();
+  UnmatchedME0Muon_SmallBins_Pt->Sumw2();
+  UnmatchedME0Muon_VariableBins_Pt->Sumw2();
 
-  ME0Muon_Cuts_Eta_5_10->Sumw2();  ME0Muon_Cuts_Eta_9_11->Sumw2();  ME0Muon_Cuts_Eta_10_50->Sumw2();  ME0Muon_Cuts_Eta_50_100->Sumw2();  ME0Muon_Cuts_Eta_100->Sumw2();
-  UnmatchedME0Muon_Cuts_Eta_5_10->Sumw2();    UnmatchedME0Muon_Cuts_Eta_9_11->Sumw2();  UnmatchedME0Muon_Cuts_Eta_10_50->Sumw2();  UnmatchedME0Muon_Cuts_Eta_50_100->Sumw2();  UnmatchedME0Muon_Cuts_Eta_100->Sumw2();
-  GenMuon_Eta_5_10->Sumw2();    GenMuon_Eta_9_11->Sumw2();  GenMuon_Eta_10_50->Sumw2();  GenMuon_Eta_50_100->Sumw2();  GenMuon_Eta_100->Sumw2();
-  MatchedME0Muon_Eta_5_10->Sumw2();   MatchedME0Muon_Eta_9_11->Sumw2();  MatchedME0Muon_Eta_10_50->Sumw2();  MatchedME0Muon_Eta_50_100->Sumw2();  MatchedME0Muon_Eta_100->Sumw2();
+  UnmatchedME0Muon_Cuts_Eta->Sumw2();
+  ME0Muon_Cuts_Eta->Sumw2();
 
-  Chi2MatchedME0Muon_Eta_5_10->Sumw2();   Chi2MatchedME0Muon_Eta_9_11->Sumw2();  Chi2MatchedME0Muon_Eta_10_50->Sumw2();  Chi2MatchedME0Muon_Eta_50_100->Sumw2();  Chi2MatchedME0Muon_Eta_100->Sumw2();
+  ME0Muon_Cuts_Eta_5_10->Sumw2();
+  ME0Muon_Cuts_Eta_9_11->Sumw2();
+  ME0Muon_Cuts_Eta_10_50->Sumw2();
+  ME0Muon_Cuts_Eta_50_100->Sumw2();
+  ME0Muon_Cuts_Eta_100->Sumw2();
+  UnmatchedME0Muon_Cuts_Eta_5_10->Sumw2();
+  UnmatchedME0Muon_Cuts_Eta_9_11->Sumw2();
+  UnmatchedME0Muon_Cuts_Eta_10_50->Sumw2();
+  UnmatchedME0Muon_Cuts_Eta_50_100->Sumw2();
+  UnmatchedME0Muon_Cuts_Eta_100->Sumw2();
+  GenMuon_Eta_5_10->Sumw2();
+  GenMuon_Eta_9_11->Sumw2();
+  GenMuon_Eta_10_50->Sumw2();
+  GenMuon_Eta_50_100->Sumw2();
+  GenMuon_Eta_100->Sumw2();
+  MatchedME0Muon_Eta_5_10->Sumw2();
+  MatchedME0Muon_Eta_9_11->Sumw2();
+  MatchedME0Muon_Eta_10_50->Sumw2();
+  MatchedME0Muon_Eta_50_100->Sumw2();
+  MatchedME0Muon_Eta_100->Sumw2();
+
+  Chi2MatchedME0Muon_Eta_5_10->Sumw2();
+  Chi2MatchedME0Muon_Eta_9_11->Sumw2();
+  Chi2MatchedME0Muon_Eta_10_50->Sumw2();
+  Chi2MatchedME0Muon_Eta_50_100->Sumw2();
+  Chi2MatchedME0Muon_Eta_100->Sumw2();
 
   UnmatchedME0Muon_Cuts_WideBinning_Eta->Sumw2();
   UnmatchedME0Muon_Cuts_WidestBinning_Eta->Sumw2();
@@ -1653,16 +1998,14 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   Chi2UnmatchedME0Muon_WideBinning_Eta->Sumw2();
   Chi2UnmatchedME0Muon_WidestBinning_Eta->Sumw2();
 
-
   //Captions/labels
   std::stringstream PtCutString;
 
-  PtCutString<<"#splitline{DY }{Reco Track p_{T} > "<<FakeRatePtCut<<" GeV}";
-  const std::string& ptmp = PtCutString.str();
-  const char* pcstr = ptmp.c_str();
+  PtCutString << "#splitline{DY }{Reco Track p_{T} > " << FakeRatePtCut << " GeV}";
+  const std::string &ptmp = PtCutString.str();
+  const char *pcstr = ptmp.c_str();
 
-
-  TLatex* txt =new TLatex;
+  TLatex *txt = new TLatex;
   //txt->SetTextAlign(12);
   //txt->SetTextFont(42);
   txt->SetNDC();
@@ -1670,31 +2013,29 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   txt->SetTextFont(132);
   txt->SetTextSize(0.05);
 
-
   float t = c1->GetTopMargin();
   float r = c1->GetRightMargin();
 
-  TLatex* latex1 = new TLatex;
+  TLatex *latex1 = new TLatex;
   latex1->SetNDC();
   latex1->SetTextAngle(0);
-  latex1->SetTextColor(kBlack);    
-
+  latex1->SetTextColor(kBlack);
 
   latex1->SetTextFont(42);
-  latex1->SetTextAlign(31); 
-  //latex1->SetTextSize(lumiTextSize*t);    
-  latex1->SetTextSize(lumiTextSize);    
-  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+  latex1->SetTextAlign(31);
+  //latex1->SetTextSize(lumiTextSize*t);
+  latex1->SetTextSize(lumiTextSize);
+  latex1->DrawLatex(1 - r, 1 - t + lumiTextOffset * t, lumiText);
 
-  TLatex* latex = new TLatex;
+  TLatex *latex = new TLatex;
   latex->SetTextFont(cmsTextFont);
   latex->SetNDC();
   latex->SetTextSize(cmsTextSize);
   //latex->SetTextAlign(align_);
 
   //End captions/labels
-  std::cout<<"GenMuon_Eta =  "<<GenMuon_Eta->Integral()<<std::endl;
-  std::cout<<"MatchedME0Muon_Eta =  "<<MatchedME0Muon_Eta->Integral()<<std::endl;
+  std::cout << "GenMuon_Eta =  " << GenMuon_Eta->Integral() << std::endl;
+  std::cout << "MatchedME0Muon_Eta =  " << MatchedME0Muon_Eta->Integral() << std::endl;
 
   MuonRecoEff_Eta->Divide(MatchedME0Muon_Eta, GenMuon_Eta, 1, 1, "B");
   MuonRecoEff_Eta->GetXaxis()->SetTitle("Gen Muon |#eta|");
@@ -1706,13 +2047,13 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   //MuonRecoEff_Eta->SetMaximum(MuonRecoEff_Eta->GetMaximum()+0.1);
   MuonRecoEff_Eta->SetMaximum(1.2);
   //CMS_lumi( c1, 7, 11 );
-  MuonRecoEff_Eta->Write();   MuonRecoEff_Eta->Draw();  
-  txt->DrawLatex(0.15,0.2,pcstr);
+  MuonRecoEff_Eta->Write();
+  MuonRecoEff_Eta->Draw();
+  txt->DrawLatex(0.15, 0.2, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
 
   //c1->SaveAs("TestMuonRecoEff_Eta.png");
-  c1->Print(histoFolder+"/MuonRecoEff_Eta.png");
-
+  c1->Print(histoFolder + "/MuonRecoEff_Eta.png");
 
   MuonRecoEff_WideBinning_Eta->Divide(MatchedME0Muon_WideBinning_Eta, GenMuon_WideBinning_Eta, 1, 1, "B");
   MuonRecoEff_WideBinning_Eta->GetXaxis()->SetTitle("Gen Muon |#eta|");
@@ -1724,13 +2065,13 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   //MuonRecoEff_WideBinning_Eta->SetMaximum(MuonRecoEff_WideBinning_Eta->GetMaximum()+0.1);
   MuonRecoEff_WideBinning_Eta->SetMaximum(1.2);
   //CMS_lumi( c1, 7, 11 );
-  MuonRecoEff_WideBinning_Eta->Write();   MuonRecoEff_WideBinning_Eta->Draw();  
-  txt->DrawLatex(0.15,0.2,pcstr);
+  MuonRecoEff_WideBinning_Eta->Write();
+  MuonRecoEff_WideBinning_Eta->Draw();
+  txt->DrawLatex(0.15, 0.2, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
 
   //c1->SaveAs("TestMuonRecoEff_WideBinning_Eta.png");
-  c1->Print(histoFolder+"/MuonRecoEff_WideBinning_Eta.png");
-
+  c1->Print(histoFolder + "/MuonRecoEff_WideBinning_Eta.png");
 
   MuonRecoEff_WidestBinning_Eta->Divide(MatchedME0Muon_WidestBinning_Eta, GenMuon_WidestBinning_Eta, 1, 1, "B");
   MuonRecoEff_WidestBinning_Eta->GetXaxis()->SetTitle("Gen Muon |#eta|");
@@ -1742,13 +2083,13 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   //MuonRecoEff_WidestBinning_Eta->SetMaximum(MuonRecoEff_WidestBinning_Eta->GetMaximum()+0.1);
   MuonRecoEff_WidestBinning_Eta->SetMaximum(1.2);
   //CMS_lumi( c1, 7, 11 );
-  MuonRecoEff_WidestBinning_Eta->Write();   MuonRecoEff_WidestBinning_Eta->Draw();  
-  txt->DrawLatex(0.15,0.2,pcstr);
+  MuonRecoEff_WidestBinning_Eta->Write();
+  MuonRecoEff_WidestBinning_Eta->Draw();
+  txt->DrawLatex(0.15, 0.2, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
 
   //c1->SaveAs("TestMuonRecoEff_WidestBinning_Eta.png");
-  c1->Print(histoFolder+"/MuonRecoEff_WidestBinning_Eta.png");
-
+  c1->Print(histoFolder + "/MuonRecoEff_WidestBinning_Eta.png");
 
   StandaloneMuonRecoEff_Eta->Divide(StandaloneMatchedME0Muon_Eta, GenMuon_Eta, 1, 1, "B");
   StandaloneMuonRecoEff_Eta->GetXaxis()->SetTitle("Gen Muon |#eta|");
@@ -1760,15 +2101,16 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   //StandaloneMuonRecoEff_Eta->SetMaximum(StandaloneMuonRecoEff_Eta->GetMaximum()+0.1);
   StandaloneMuonRecoEff_Eta->SetMaximum(1.2);
   //CMS_lumi( c1, 7, 11 );
-  StandaloneMuonRecoEff_Eta->Write();   StandaloneMuonRecoEff_Eta->Draw();  
-  txt->DrawLatex(0.15,0.2,pcstr);
+  StandaloneMuonRecoEff_Eta->Write();
+  StandaloneMuonRecoEff_Eta->Draw();
+  txt->DrawLatex(0.15, 0.2, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
 
   //c1->SaveAs("TestStandaloneMuonRecoEff_Eta.png");
-  c1->Print(histoFolder+"/StandaloneMuonRecoEff_Eta.png");
+  c1->Print(histoFolder + "/StandaloneMuonRecoEff_Eta.png");
 
-
-  StandaloneMuonRecoEff_WideBinning_Eta->Divide(StandaloneMatchedME0Muon_WideBinning_Eta, GenMuon_WideBinning_Eta, 1, 1, "B");
+  StandaloneMuonRecoEff_WideBinning_Eta->Divide(
+      StandaloneMatchedME0Muon_WideBinning_Eta, GenMuon_WideBinning_Eta, 1, 1, "B");
   StandaloneMuonRecoEff_WideBinning_Eta->GetXaxis()->SetTitle("Gen Muon |#eta|");
   StandaloneMuonRecoEff_WideBinning_Eta->GetXaxis()->SetTitleSize(0.05);
   StandaloneMuonRecoEff_WideBinning_Eta->GetYaxis()->SetTitle("Standalone Muon Efficiency");
@@ -1778,15 +2120,16 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   //StandaloneMuonRecoEff_WideBinning_Eta->SetMaximum(StandaloneMuonRecoEff_WideBinning_Eta->GetMaximum()+0.1);
   StandaloneMuonRecoEff_WideBinning_Eta->SetMaximum(1.2);
   //CMS_lumi( c1, 7, 11 );
-  StandaloneMuonRecoEff_WideBinning_Eta->Write();   StandaloneMuonRecoEff_WideBinning_Eta->Draw();  
-  txt->DrawLatex(0.15,0.2,pcstr);
+  StandaloneMuonRecoEff_WideBinning_Eta->Write();
+  StandaloneMuonRecoEff_WideBinning_Eta->Draw();
+  txt->DrawLatex(0.15, 0.2, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
 
   //c1->SaveAs("TestStandaloneMuonRecoEff_WideBinning_Eta.png");
-  c1->Print(histoFolder+"/StandaloneMuonRecoEff_WideBinning_Eta.png");
+  c1->Print(histoFolder + "/StandaloneMuonRecoEff_WideBinning_Eta.png");
 
-
-  StandaloneMuonRecoEff_WidestBinning_Eta->Divide(StandaloneMatchedME0Muon_WidestBinning_Eta, GenMuon_WidestBinning_Eta, 1, 1, "B");
+  StandaloneMuonRecoEff_WidestBinning_Eta->Divide(
+      StandaloneMatchedME0Muon_WidestBinning_Eta, GenMuon_WidestBinning_Eta, 1, 1, "B");
   StandaloneMuonRecoEff_WidestBinning_Eta->GetXaxis()->SetTitle("Gen Muon |#eta|");
   StandaloneMuonRecoEff_WidestBinning_Eta->GetXaxis()->SetTitleSize(0.05);
   StandaloneMuonRecoEff_WidestBinning_Eta->GetYaxis()->SetTitle("Standalone Muon Efficiency");
@@ -1796,13 +2139,13 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   //StandaloneMuonRecoEff_WidestBinning_Eta->SetMaximum(StandaloneMuonRecoEff_WidestBinning_Eta->GetMaximum()+0.1);
   StandaloneMuonRecoEff_WidestBinning_Eta->SetMaximum(1.2);
   //CMS_lumi( c1, 7, 11 );
-  StandaloneMuonRecoEff_WidestBinning_Eta->Write();   StandaloneMuonRecoEff_WidestBinning_Eta->Draw();  
-  txt->DrawLatex(0.15,0.2,pcstr);
+  StandaloneMuonRecoEff_WidestBinning_Eta->Write();
+  StandaloneMuonRecoEff_WidestBinning_Eta->Draw();
+  txt->DrawLatex(0.15, 0.2, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
 
   //c1->SaveAs("TestStandaloneMuonRecoEff_WidestBinning_Eta.png");
-  c1->Print(histoFolder+"/StandaloneMuonRecoEff_WidestBinning_Eta.png");
-
+  c1->Print(histoFolder + "/StandaloneMuonRecoEff_WidestBinning_Eta.png");
 
   MuonRecoEff_Eta_5_10->Divide(MatchedME0Muon_Eta_5_10, GenMuon_Eta_5_10, 1, 1, "B");
   MuonRecoEff_Eta_5_10->GetXaxis()->SetTitle("Gen Muon |#eta|");
@@ -1814,12 +2157,13 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   //MuonRecoEff_Eta_5_10->SetMaximum(MuonRecoEff_Eta_5_10->GetMaximum()+0.1);
   MuonRecoEff_Eta_5_10->SetMaximum(1.2);
   //CMS_lumi( c1, 7, 11 );
-  MuonRecoEff_Eta_5_10->Write();   MuonRecoEff_Eta_5_10->Draw();  
-  txt->DrawLatex(0.15,0.2,pcstr);
+  MuonRecoEff_Eta_5_10->Write();
+  MuonRecoEff_Eta_5_10->Draw();
+  txt->DrawLatex(0.15, 0.2, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
 
   //c1->SaveAs("TestMuonRecoEff_Eta_5_10.png");
-  c1->Print(histoFolder+"/MuonRecoEff_Eta_5_10.png");
+  c1->Print(histoFolder + "/MuonRecoEff_Eta_5_10.png");
 
   MuonRecoEff_Eta_9_11->Divide(MatchedME0Muon_Eta_9_11, GenMuon_Eta_9_11, 1, 1, "B");
   MuonRecoEff_Eta_9_11->GetXaxis()->SetTitle("Gen Muon |#eta|");
@@ -1831,12 +2175,13 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   //MuonRecoEff_Eta_9_11->SetMaximum(MuonRecoEff_Eta_9_11->GetMaximum()+0.1);
   MuonRecoEff_Eta_9_11->SetMaximum(1.2);
   //CMS_lumi( c1, 7, 11 );
-  MuonRecoEff_Eta_9_11->Write();   MuonRecoEff_Eta_9_11->Draw();  
-  txt->DrawLatex(0.15,0.2,pcstr);
+  MuonRecoEff_Eta_9_11->Write();
+  MuonRecoEff_Eta_9_11->Draw();
+  txt->DrawLatex(0.15, 0.2, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
 
   //c1->SaveAs("TestMuonRecoEff_Eta_9_11.png");
-  c1->Print(histoFolder+"/MuonRecoEff_Eta_9_11.png");
+  c1->Print(histoFolder + "/MuonRecoEff_Eta_9_11.png");
 
   MuonRecoEff_Eta_10_50->Divide(MatchedME0Muon_Eta_10_50, GenMuon_Eta_10_50, 1, 1, "B");
   MuonRecoEff_Eta_10_50->GetXaxis()->SetTitle("Gen Muon |#eta|");
@@ -1848,13 +2193,13 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   //MuonRecoEff_Eta_10_50->SetMaximum(MuonRecoEff_Eta_10_50->GetMaximum()+0.1);
   MuonRecoEff_Eta_10_50->SetMaximum(1.2);
   //CMS_lumi( c1, 7, 11 );
-  MuonRecoEff_Eta_10_50->Write();   MuonRecoEff_Eta_10_50->Draw();  
-  txt->DrawLatex(0.15,0.2,pcstr);
+  MuonRecoEff_Eta_10_50->Write();
+  MuonRecoEff_Eta_10_50->Draw();
+  txt->DrawLatex(0.15, 0.2, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
 
   //c1->SaveAs("TestMuonRecoEff_Eta_10_50.png");
-  c1->Print(histoFolder+"/MuonRecoEff_Eta_10_50.png");
-
+  c1->Print(histoFolder + "/MuonRecoEff_Eta_10_50.png");
 
   MuonRecoEff_Eta_50_100->Divide(MatchedME0Muon_Eta_50_100, GenMuon_Eta_50_100, 1, 1, "B");
   MuonRecoEff_Eta_50_100->GetXaxis()->SetTitle("Gen Muon |#eta|");
@@ -1866,13 +2211,13 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   //MuonRecoEff_Eta_50_100->SetMaximum(MuonRecoEff_Eta_50_100->GetMaximum()+0.1);
   MuonRecoEff_Eta_50_100->SetMaximum(1.2);
   //CMS_lumi( c1, 7, 11 );
-  MuonRecoEff_Eta_50_100->Write();   MuonRecoEff_Eta_50_100->Draw();  
-  txt->DrawLatex(0.15,0.2,pcstr);
+  MuonRecoEff_Eta_50_100->Write();
+  MuonRecoEff_Eta_50_100->Draw();
+  txt->DrawLatex(0.15, 0.2, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
 
   //c1->SaveAs("TestMuonRecoEff_Eta_50_100.png");
-  c1->Print(histoFolder+"/MuonRecoEff_Eta_50_100.png");
-
+  c1->Print(histoFolder + "/MuonRecoEff_Eta_50_100.png");
 
   MuonRecoEff_Eta_100->Divide(MatchedME0Muon_Eta_100, GenMuon_Eta_100, 1, 1, "B");
   MuonRecoEff_Eta_100->GetXaxis()->SetTitle("Gen Muon |#eta|");
@@ -1884,90 +2229,88 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   //MuonRecoEff_Eta_100->SetMaximum(MuonRecoEff_Eta_100->GetMaximum()+0.1);
   MuonRecoEff_Eta_100->SetMaximum(1.2);
   //CMS_lumi( c1, 7, 11 );
-  MuonRecoEff_Eta_100->Write();   MuonRecoEff_Eta_100->Draw();  
-  txt->DrawLatex(0.15,0.2,pcstr);
+  MuonRecoEff_Eta_100->Write();
+  MuonRecoEff_Eta_100->Draw();
+  txt->DrawLatex(0.15, 0.2, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
 
   //c1->SaveAs("TestMuonRecoEff_Eta_100.png");
-  c1->Print(histoFolder+"/MuonRecoEff_Eta_100.png");
-
-
-
-
+  c1->Print(histoFolder + "/MuonRecoEff_Eta_100.png");
 
   Chi2MuonRecoEff_Eta->Divide(Chi2MatchedME0Muon_Eta, TPMuon_Eta, 1, 1, "B");
-  std::cout<<"TPMuon_Eta =  "<<TPMuon_Eta->Integral()<<std::endl;
-  std::cout<<"Chi2MatchedME0Muon_Eta =  "<<Chi2MatchedME0Muon_Eta->Integral()<<std::endl;
+  std::cout << "TPMuon_Eta =  " << TPMuon_Eta->Integral() << std::endl;
+  std::cout << "Chi2MatchedME0Muon_Eta =  " << Chi2MatchedME0Muon_Eta->Integral() << std::endl;
   Chi2MuonRecoEff_Eta->GetXaxis()->SetTitle("Gen Muon |#eta|");
   Chi2MuonRecoEff_Eta->GetXaxis()->SetTitleSize(0.05);
-  
+
   Chi2MuonRecoEff_Eta->GetYaxis()->SetTitle("ME0Muon Efficiency");
   Chi2MuonRecoEff_Eta->GetYaxis()->SetTitleSize(0.05);
   Chi2MuonRecoEff_Eta->SetMinimum(0);
   Chi2MuonRecoEff_Eta->SetMaximum(1.2);
 
-  Chi2MuonRecoEff_Eta->Write();   Chi2MuonRecoEff_Eta->Draw();  
+  Chi2MuonRecoEff_Eta->Write();
+  Chi2MuonRecoEff_Eta->Draw();
 
-  txt->DrawLatex(0.15,0.2,pcstr);
+  txt->DrawLatex(0.15, 0.2, pcstr);
 
-   
-  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+  latex1->DrawLatex(1 - r, 1 - t + lumiTextOffset * t, lumiText);
 
   //latex->SetTextAlign(align_);
   latex->DrawLatex(0.4, 0.85, cmsText);
 
-  c1->Print(histoFolder+"/Chi2MuonRecoEff_Eta.png");
+  c1->Print(histoFolder + "/Chi2MuonRecoEff_Eta.png");
 
   Chi2MuonRecoEff_WideBinning_Eta->Divide(Chi2MatchedME0Muon_WideBinning_Eta, TPMuon_WideBinning_Eta, 1, 1, "B");
-  std::cout<<"TPMuon_WideBinning_Eta =  "<<TPMuon_WideBinning_Eta->Integral()<<std::endl;
-  std::cout<<"Chi2MatchedME0Muon_WideBinning_Eta =  "<<Chi2MatchedME0Muon_WideBinning_Eta->Integral()<<std::endl;
+  std::cout << "TPMuon_WideBinning_Eta =  " << TPMuon_WideBinning_Eta->Integral() << std::endl;
+  std::cout << "Chi2MatchedME0Muon_WideBinning_Eta =  " << Chi2MatchedME0Muon_WideBinning_Eta->Integral() << std::endl;
   Chi2MuonRecoEff_WideBinning_Eta->GetXaxis()->SetTitle("Gen Muon |#eta|");
   Chi2MuonRecoEff_WideBinning_Eta->GetXaxis()->SetTitleSize(0.05);
-  
+
   Chi2MuonRecoEff_WideBinning_Eta->GetYaxis()->SetTitle("ME0Muon Efficiency");
   Chi2MuonRecoEff_WideBinning_Eta->GetYaxis()->SetTitleSize(0.05);
   Chi2MuonRecoEff_WideBinning_Eta->SetMinimum(0);
   Chi2MuonRecoEff_WideBinning_Eta->SetMaximum(1.2);
 
-  Chi2MuonRecoEff_WideBinning_Eta->Write();   Chi2MuonRecoEff_WideBinning_Eta->Draw();  
+  Chi2MuonRecoEff_WideBinning_Eta->Write();
+  Chi2MuonRecoEff_WideBinning_Eta->Draw();
 
-  txt->DrawLatex(0.15,0.2,pcstr);
+  txt->DrawLatex(0.15, 0.2, pcstr);
 
-   
-  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+  latex1->DrawLatex(1 - r, 1 - t + lumiTextOffset * t, lumiText);
 
   //latex->SetTextAlign(align_);
   latex->DrawLatex(0.4, 0.85, cmsText);
 
-  c1->Print(histoFolder+"/Chi2MuonRecoEff_WideBinning_Eta.png");
+  c1->Print(histoFolder + "/Chi2MuonRecoEff_WideBinning_Eta.png");
 
   Chi2MuonRecoEff_WidestBinning_Eta->Divide(Chi2MatchedME0Muon_WidestBinning_Eta, TPMuon_WidestBinning_Eta, 1, 1, "B");
-  std::cout<<"TPMuon_WidestBinning_Eta =  "<<TPMuon_WidestBinning_Eta->Integral()<<std::endl;
-  std::cout<<"Chi2MatchedME0Muon_WidestBinning_Eta =  "<<Chi2MatchedME0Muon_WidestBinning_Eta->Integral()<<std::endl;
+  std::cout << "TPMuon_WidestBinning_Eta =  " << TPMuon_WidestBinning_Eta->Integral() << std::endl;
+  std::cout << "Chi2MatchedME0Muon_WidestBinning_Eta =  " << Chi2MatchedME0Muon_WidestBinning_Eta->Integral()
+            << std::endl;
   Chi2MuonRecoEff_WidestBinning_Eta->GetXaxis()->SetTitle("Gen Muon |#eta|");
   Chi2MuonRecoEff_WidestBinning_Eta->GetXaxis()->SetTitleSize(0.05);
-  
+
   Chi2MuonRecoEff_WidestBinning_Eta->GetYaxis()->SetTitle("ME0Muon Efficiency");
   Chi2MuonRecoEff_WidestBinning_Eta->GetYaxis()->SetTitleSize(0.05);
   Chi2MuonRecoEff_WidestBinning_Eta->SetMinimum(0);
   Chi2MuonRecoEff_WidestBinning_Eta->SetMaximum(1.2);
 
-  Chi2MuonRecoEff_WidestBinning_Eta->Write();   Chi2MuonRecoEff_WidestBinning_Eta->Draw();  
+  Chi2MuonRecoEff_WidestBinning_Eta->Write();
+  Chi2MuonRecoEff_WidestBinning_Eta->Draw();
 
-  txt->DrawLatex(0.15,0.2,pcstr);
+  txt->DrawLatex(0.15, 0.2, pcstr);
 
-   
-  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+  latex1->DrawLatex(1 - r, 1 - t + lumiTextOffset * t, lumiText);
 
   //latex->SetTextAlign(align_);
   latex->DrawLatex(0.4, 0.85, cmsText);
 
-  c1->Print(histoFolder+"/Chi2MuonRecoEff_WidestBinning_Eta.png");
+  c1->Print(histoFolder + "/Chi2MuonRecoEff_WidestBinning_Eta.png");
 
-  std::cout<<"Here0"<<std::endl;
+  std::cout << "Here0" << std::endl;
 
   Chi2MuonRecoEff_Eta_5_10->Divide(Chi2MatchedME0Muon_Eta_5_10, GenMuon_Eta_5_10, 1, 1, "B");
-  std::cout<<"Here0"<<std::endl;
+  std::cout << "Here0" << std::endl;
   Chi2MuonRecoEff_Eta_5_10->GetXaxis()->SetTitle("Gen Muon |#eta|");
   Chi2MuonRecoEff_Eta_5_10->GetXaxis()->SetTitleSize(0.05);
   Chi2MuonRecoEff_Eta_5_10->GetYaxis()->SetTitle("ME0Muon Efficiency");
@@ -1977,16 +2320,16 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   //Chi2MuonRecoEff_Eta_5_10->SetMaximum(Chi2MuonRecoEff_Eta_5_10->GetMaximum()+0.1);
   Chi2MuonRecoEff_Eta_5_10->SetMaximum(1.2);
   //CMS_lumi( c1, 7, 11 );
-  Chi2MuonRecoEff_Eta_5_10->Write();   Chi2MuonRecoEff_Eta_5_10->Draw();  
-  txt->DrawLatex(0.15,0.2,pcstr);
+  Chi2MuonRecoEff_Eta_5_10->Write();
+  Chi2MuonRecoEff_Eta_5_10->Draw();
+  txt->DrawLatex(0.15, 0.2, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
 
   //c1->SaveAs("TestChi2MuonRecoEff_Eta_5_10.png");
-  c1->Print(histoFolder+"/Chi2MuonRecoEff_Eta_5_10.png");
-
+  c1->Print(histoFolder + "/Chi2MuonRecoEff_Eta_5_10.png");
 
   Chi2MuonRecoEff_Eta_9_11->Divide(Chi2MatchedME0Muon_Eta_9_11, GenMuon_Eta_9_11, 1, 1, "B");
-  std::cout<<"Here0"<<std::endl;
+  std::cout << "Here0" << std::endl;
   Chi2MuonRecoEff_Eta_9_11->GetXaxis()->SetTitle("Gen Muon |#eta|");
   Chi2MuonRecoEff_Eta_9_11->GetXaxis()->SetTitleSize(0.05);
   Chi2MuonRecoEff_Eta_9_11->GetYaxis()->SetTitle("ME0Muon Efficiency");
@@ -1996,14 +2339,15 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   //Chi2MuonRecoEff_Eta_9_11->SetMaximum(Chi2MuonRecoEff_Eta_9_11->GetMaximum()+0.1);
   Chi2MuonRecoEff_Eta_9_11->SetMaximum(1.2);
   //CMS_lumi( c1, 7, 11 );
-  Chi2MuonRecoEff_Eta_9_11->Write();   Chi2MuonRecoEff_Eta_9_11->Draw();  
-  txt->DrawLatex(0.15,0.2,pcstr);
+  Chi2MuonRecoEff_Eta_9_11->Write();
+  Chi2MuonRecoEff_Eta_9_11->Draw();
+  txt->DrawLatex(0.15, 0.2, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
 
   //c1->SaveAs("TestChi2MuonRecoEff_Eta_9_11.png");
-  c1->Print(histoFolder+"/Chi2MuonRecoEff_Eta_9_11.png");
+  c1->Print(histoFolder + "/Chi2MuonRecoEff_Eta_9_11.png");
 
-  std::cout<<"Here"<<std::endl;
+  std::cout << "Here" << std::endl;
 
   Chi2MuonRecoEff_Eta_10_50->Divide(Chi2MatchedME0Muon_Eta_10_50, GenMuon_Eta_10_50, 1, 1, "B");
   Chi2MuonRecoEff_Eta_10_50->GetXaxis()->SetTitle("Gen Muon |#eta|");
@@ -2015,13 +2359,13 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   //Chi2MuonRecoEff_Eta_10_50->SetMaximum(Chi2MuonRecoEff_Eta_10_50->GetMaximum()+0.1);
   Chi2MuonRecoEff_Eta_10_50->SetMaximum(1.2);
   //CMS_lumi( c1, 7, 11 );
-  Chi2MuonRecoEff_Eta_10_50->Write();   Chi2MuonRecoEff_Eta_10_50->Draw();  
-  txt->DrawLatex(0.15,0.2,pcstr);
+  Chi2MuonRecoEff_Eta_10_50->Write();
+  Chi2MuonRecoEff_Eta_10_50->Draw();
+  txt->DrawLatex(0.15, 0.2, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
 
   //c1->SaveAs("TestChi2MuonRecoEff_Eta_10_50.png");
-  c1->Print(histoFolder+"/Chi2MuonRecoEff_Eta_10_50.png");
-
+  c1->Print(histoFolder + "/Chi2MuonRecoEff_Eta_10_50.png");
 
   Chi2MuonRecoEff_Eta_50_100->Divide(Chi2MatchedME0Muon_Eta_50_100, GenMuon_Eta_50_100, 1, 1, "B");
   Chi2MuonRecoEff_Eta_50_100->GetXaxis()->SetTitle("Gen Muon |#eta|");
@@ -2033,13 +2377,13 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   //Chi2MuonRecoEff_Eta_50_100->SetMaximum(Chi2MuonRecoEff_Eta_50_100->GetMaximum()+0.1);
   Chi2MuonRecoEff_Eta_50_100->SetMaximum(1.2);
   //CMS_lumi( c1, 7, 11 );
-  Chi2MuonRecoEff_Eta_50_100->Write();   Chi2MuonRecoEff_Eta_50_100->Draw();  
-  txt->DrawLatex(0.15,0.2,pcstr);
+  Chi2MuonRecoEff_Eta_50_100->Write();
+  Chi2MuonRecoEff_Eta_50_100->Draw();
+  txt->DrawLatex(0.15, 0.2, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
 
   //c1->SaveAs("TestChi2MuonRecoEff_Eta_50_100.png");
-  c1->Print(histoFolder+"/Chi2MuonRecoEff_Eta_50_100.png");
-
+  c1->Print(histoFolder + "/Chi2MuonRecoEff_Eta_50_100.png");
 
   Chi2MuonRecoEff_Eta_100->Divide(Chi2MatchedME0Muon_Eta_100, GenMuon_Eta_100, 1, 1, "B");
   Chi2MuonRecoEff_Eta_100->GetXaxis()->SetTitle("Gen Muon |#eta|");
@@ -2051,20 +2395,20 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   //Chi2MuonRecoEff_Eta_100->SetMaximum(Chi2MuonRecoEff_Eta_100->GetMaximum()+0.1);
   Chi2MuonRecoEff_Eta_100->SetMaximum(1.2);
   //CMS_lumi( c1, 7, 11 );
-  Chi2MuonRecoEff_Eta_100->Write();   Chi2MuonRecoEff_Eta_100->Draw();  
-  txt->DrawLatex(0.15,0.2,pcstr);
+  Chi2MuonRecoEff_Eta_100->Write();
+  Chi2MuonRecoEff_Eta_100->Draw();
+  txt->DrawLatex(0.15, 0.2, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
 
   //c1->SaveAs("TestChi2MuonRecoEff_Eta_100.png");
-  c1->Print(histoFolder+"/Chi2MuonRecoEff_Eta_100.png");
+  c1->Print(histoFolder + "/Chi2MuonRecoEff_Eta_100.png");
 
-  std::cout<<"  MuonRecoEff_Eta values:"<<std::endl;
+  std::cout << "  MuonRecoEff_Eta values:" << std::endl;
   //MuonRecoEff_Eta->Sumw2();
-  for (int i=1; i<=MuonRecoEff_Eta->GetNbinsX(); ++i){
-    std::cout<<2.4+(double)i*((4.0-2.4)/40.)<<","<<MuonRecoEff_Eta->GetBinContent(i)<<","<<MuonRecoEff_Eta->GetBinError(i)<<std::endl;
-    
+  for (int i = 1; i <= MuonRecoEff_Eta->GetNbinsX(); ++i) {
+    std::cout << 2.4 + (double)i * ((4.0 - 2.4) / 40.) << "," << MuonRecoEff_Eta->GetBinContent(i) << ","
+              << MuonRecoEff_Eta->GetBinError(i) << std::endl;
   }
-  
 
   // MuonRecoEff_Pt->Divide(MatchedME0Muon_Pt, GenMuon_Pt, 1, 1, "B");
   // MuonRecoEff_Pt->GetXaxis()->SetTitle("Gen Muon p_{T}");
@@ -2072,9 +2416,8 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   // MuonRecoEff_Pt->SetMinimum(.85);
   // MuonRecoEff_Pt->Write();   MuonRecoEff_Pt->Draw();  c1->Print(histoFolder+"/MuonRecoEff_Pt.png");
 
-  std::cout<<"UnmatchedME0Muon_Eta =  "<<UnmatchedME0Muon_Cuts_Eta->Integral()<<std::endl;
-  std::cout<<"ME0Muon_Eta =  "<<ME0Muon_Cuts_Eta->Integral()<<std::endl;
-
+  std::cout << "UnmatchedME0Muon_Eta =  " << UnmatchedME0Muon_Cuts_Eta->Integral() << std::endl;
+  std::cout << "ME0Muon_Eta =  " << ME0Muon_Cuts_Eta->Integral() << std::endl;
 
   FakeRate_Eta->Divide(UnmatchedME0Muon_Cuts_Eta, ME0Muon_Cuts_Eta, 1, 1, "B");
   FakeRate_Eta->GetXaxis()->SetTitle("Reconstructed track |#eta|");
@@ -2085,14 +2428,15 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   FakeRate_Eta->SetMinimum(0);
   //FakeRate_Eta->SetMaximum(FakeRate_Eta->GetMaximum()+0.1);
   FakeRate_Eta->SetMaximum(1.2);
-  FakeRate_Eta->Write();   FakeRate_Eta->Draw();  
+  FakeRate_Eta->Write();
+  FakeRate_Eta->Draw();
 
-  txt->DrawLatex(0.15,0.4,pcstr);
+  txt->DrawLatex(0.15, 0.4, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
-  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+  latex1->DrawLatex(1 - r, 1 - t + lumiTextOffset * t, lumiText);
 
   //c1->SaveAs('TestFakeRate_Eta.png');
-  c1->Print(histoFolder+"/FakeRate_Eta.png");
+  c1->Print(histoFolder + "/FakeRate_Eta.png");
 
   FakeRate_WideBinning_Eta->Divide(UnmatchedME0Muon_Cuts_WideBinning_Eta, ME0Muon_Cuts_WideBinning_Eta, 1, 1, "B");
   FakeRate_WideBinning_Eta->GetXaxis()->SetTitle("Reconstructed track |#eta|");
@@ -2103,17 +2447,18 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   FakeRate_WideBinning_Eta->SetMinimum(0);
   //FakeRate_WideBinning_Eta->SetMaximum(FakeRate_WideBinning_Eta->GetMaximum()+0.1);
   FakeRate_WideBinning_Eta->SetMaximum(1.2);
-  FakeRate_WideBinning_Eta->Write();   FakeRate_WideBinning_Eta->Draw();  
+  FakeRate_WideBinning_Eta->Write();
+  FakeRate_WideBinning_Eta->Draw();
 
-  txt->DrawLatex(0.15,0.4,pcstr);
+  txt->DrawLatex(0.15, 0.4, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
-  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+  latex1->DrawLatex(1 - r, 1 - t + lumiTextOffset * t, lumiText);
 
   //c1->SaveAs('TestFakeRate_WideBinning_Eta.png');
-  c1->Print(histoFolder+"/FakeRate_WideBinning_Eta.png");
+  c1->Print(histoFolder + "/FakeRate_WideBinning_Eta.png");
 
-
-  FakeRate_WidestBinning_Eta->Divide(UnmatchedME0Muon_Cuts_WidestBinning_Eta, ME0Muon_Cuts_WidestBinning_Eta, 1, 1, "B");
+  FakeRate_WidestBinning_Eta->Divide(
+      UnmatchedME0Muon_Cuts_WidestBinning_Eta, ME0Muon_Cuts_WidestBinning_Eta, 1, 1, "B");
   FakeRate_WidestBinning_Eta->GetXaxis()->SetTitle("Reconstructed track |#eta|");
   FakeRate_WidestBinning_Eta->GetXaxis()->SetTitleSize(0.05);
   FakeRate_WidestBinning_Eta->GetYaxis()->SetTitle("ME0 Muon Fake Rate");
@@ -2122,15 +2467,15 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   FakeRate_WidestBinning_Eta->SetMinimum(0);
   //FakeRate_WidestBinning_Eta->SetMaximum(FakeRate_WidestBinning_Eta->GetMaximum()+0.1);
   FakeRate_WidestBinning_Eta->SetMaximum(1.2);
-  FakeRate_WidestBinning_Eta->Write();   FakeRate_WidestBinning_Eta->Draw();  
+  FakeRate_WidestBinning_Eta->Write();
+  FakeRate_WidestBinning_Eta->Draw();
 
-  txt->DrawLatex(0.15,0.4,pcstr);
+  txt->DrawLatex(0.15, 0.4, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
-  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+  latex1->DrawLatex(1 - r, 1 - t + lumiTextOffset * t, lumiText);
 
   //c1->SaveAs('TestFakeRate_WidestBinning_Eta.png');
-  c1->Print(histoFolder+"/FakeRate_WidestBinning_Eta.png");
-
+  c1->Print(histoFolder + "/FakeRate_WidestBinning_Eta.png");
 
   FakeRate_Eta_5_10->Divide(UnmatchedME0Muon_Cuts_Eta_5_10, ME0Muon_Cuts_Eta_5_10, 1, 1, "B");
   FakeRate_Eta_5_10->GetXaxis()->SetTitle("Reconstructed track |#eta|");
@@ -2141,15 +2486,15 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   FakeRate_Eta_5_10->SetMinimum(0);
   //FakeRate_Eta_5_10->SetMaximum(FakeRate_Eta_5_10->GetMaximum()+0.1);
   FakeRate_Eta_5_10->SetMaximum(1.2);
-  FakeRate_Eta_5_10->Write();   FakeRate_Eta_5_10->Draw();  
+  FakeRate_Eta_5_10->Write();
+  FakeRate_Eta_5_10->Draw();
 
-  txt->DrawLatex(0.15,0.4,pcstr);
+  txt->DrawLatex(0.15, 0.4, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
-  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+  latex1->DrawLatex(1 - r, 1 - t + lumiTextOffset * t, lumiText);
 
   //c1->SaveAs('TestFakeRate_Eta_5_10.png');
-  c1->Print(histoFolder+"/FakeRate_Eta_5_10.png");
-
+  c1->Print(histoFolder + "/FakeRate_Eta_5_10.png");
 
   FakeRate_Eta_9_11->Divide(UnmatchedME0Muon_Cuts_Eta_9_11, ME0Muon_Cuts_Eta_9_11, 1, 1, "B");
   FakeRate_Eta_9_11->GetXaxis()->SetTitle("Reconstructed track |#eta|");
@@ -2160,16 +2505,15 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   FakeRate_Eta_9_11->SetMinimum(0);
   //FakeRate_Eta_9_11->SetMaximum(FakeRate_Eta_9_11->GetMaximum()+0.1);
   FakeRate_Eta_9_11->SetMaximum(1.2);
-  FakeRate_Eta_9_11->Write();   FakeRate_Eta_9_11->Draw();  
+  FakeRate_Eta_9_11->Write();
+  FakeRate_Eta_9_11->Draw();
 
-  txt->DrawLatex(0.15,0.4,pcstr);
+  txt->DrawLatex(0.15, 0.4, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
-  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+  latex1->DrawLatex(1 - r, 1 - t + lumiTextOffset * t, lumiText);
 
   //c1->SaveAs('TestFakeRate_Eta_9_11.png');
-  c1->Print(histoFolder+"/FakeRate_Eta_9_11.png");
-
-
+  c1->Print(histoFolder + "/FakeRate_Eta_9_11.png");
 
   FakeRate_Eta_10_50->Divide(UnmatchedME0Muon_Cuts_Eta_10_50, ME0Muon_Cuts_Eta_10_50, 1, 1, "B");
   FakeRate_Eta_10_50->GetXaxis()->SetTitle("Reconstructed track |#eta|");
@@ -2180,16 +2524,15 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   FakeRate_Eta_10_50->SetMinimum(0);
   //FakeRate_Eta_10_50->SetMaximum(FakeRate_Eta_10_50->GetMaximum()+0.1);
   FakeRate_Eta_10_50->SetMaximum(1.2);
-  FakeRate_Eta_10_50->Write();   FakeRate_Eta_10_50->Draw();  
+  FakeRate_Eta_10_50->Write();
+  FakeRate_Eta_10_50->Draw();
 
-  txt->DrawLatex(0.15,0.4,pcstr);
+  txt->DrawLatex(0.15, 0.4, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
-  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+  latex1->DrawLatex(1 - r, 1 - t + lumiTextOffset * t, lumiText);
 
   //c1->SaveAs('TestFakeRate_Eta_10_50.png');
-  c1->Print(histoFolder+"/FakeRate_Eta_10_50.png");
-
-
+  c1->Print(histoFolder + "/FakeRate_Eta_10_50.png");
 
   FakeRate_Eta_50_100->Divide(UnmatchedME0Muon_Cuts_Eta_50_100, ME0Muon_Cuts_Eta_50_100, 1, 1, "B");
   FakeRate_Eta_50_100->GetXaxis()->SetTitle("Reconstructed track |#eta|");
@@ -2200,16 +2543,15 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   FakeRate_Eta_50_100->SetMinimum(0);
   //FakeRate_Eta_50_100->SetMaximum(FakeRate_Eta_50_100->GetMaximum()+0.1);
   FakeRate_Eta_50_100->SetMaximum(1.2);
-  FakeRate_Eta_50_100->Write();   FakeRate_Eta_50_100->Draw();  
+  FakeRate_Eta_50_100->Write();
+  FakeRate_Eta_50_100->Draw();
 
-  txt->DrawLatex(0.15,0.4,pcstr);
+  txt->DrawLatex(0.15, 0.4, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
-  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+  latex1->DrawLatex(1 - r, 1 - t + lumiTextOffset * t, lumiText);
 
   //c1->SaveAs('TestFakeRate_Eta_50_100.png');
-  c1->Print(histoFolder+"/FakeRate_Eta_50_100.png");
-
-
+  c1->Print(histoFolder + "/FakeRate_Eta_50_100.png");
 
   FakeRate_Eta_100->Divide(UnmatchedME0Muon_Cuts_Eta_100, ME0Muon_Cuts_Eta_100, 1, 1, "B");
   FakeRate_Eta_100->GetXaxis()->SetTitle("Reconstructed track |#eta|");
@@ -2220,22 +2562,21 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   FakeRate_Eta_100->SetMinimum(0);
   //FakeRate_Eta_100->SetMaximum(FakeRate_Eta_100->GetMaximum()+0.1);
   FakeRate_Eta_100->SetMaximum(1.2);
-  FakeRate_Eta_100->Write();   FakeRate_Eta_100->Draw();  
+  FakeRate_Eta_100->Write();
+  FakeRate_Eta_100->Draw();
 
-  txt->DrawLatex(0.15,0.4,pcstr);
+  txt->DrawLatex(0.15, 0.4, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
-  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+  latex1->DrawLatex(1 - r, 1 - t + lumiTextOffset * t, lumiText);
 
   //c1->SaveAs('TestFakeRate_Eta_100.png');
-  c1->Print(histoFolder+"/FakeRate_Eta_100.png");
-
-
+  c1->Print(histoFolder + "/FakeRate_Eta_100.png");
 
   Chi2FakeRate_Eta->Divide(Chi2UnmatchedME0Muon_Eta, ME0Muon_Cuts_Eta, 1, 1, "B");
-  std::cout<<"Chi2UnmatchedME0Muon_Eta =  "<<Chi2UnmatchedME0Muon_Eta->Integral()<<std::endl;
-  std::cout<<"UnmatchedME0Muon_Eta =  "<<UnmatchedME0Muon_Eta->Integral()<<std::endl;
-  std::cout<<"ME0Muon_Eta =  "<<ME0Muon_Cuts_Eta->Integral()<<std::endl;
-  std::cout<<"ME0Muon_Eta without cuts =  "<<ME0Muon_Eta->Integral()<<std::endl;
+  std::cout << "Chi2UnmatchedME0Muon_Eta =  " << Chi2UnmatchedME0Muon_Eta->Integral() << std::endl;
+  std::cout << "UnmatchedME0Muon_Eta =  " << UnmatchedME0Muon_Eta->Integral() << std::endl;
+  std::cout << "ME0Muon_Eta =  " << ME0Muon_Cuts_Eta->Integral() << std::endl;
+  std::cout << "ME0Muon_Eta without cuts =  " << ME0Muon_Eta->Integral() << std::endl;
 
   Chi2FakeRate_Eta->GetXaxis()->SetTitle("Reconstructed track |#eta|");
   Chi2FakeRate_Eta->GetXaxis()->SetTitleSize(0.05);
@@ -2243,15 +2584,14 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   Chi2FakeRate_Eta->GetYaxis()->SetTitleSize(0.05);
   Chi2FakeRate_Eta->SetMinimum(0);
   Chi2FakeRate_Eta->SetMaximum(1.2);
-  Chi2FakeRate_Eta->Write();   Chi2FakeRate_Eta->Draw();  
-  txt->DrawLatex(0.15,0.2,pcstr);
+  Chi2FakeRate_Eta->Write();
+  Chi2FakeRate_Eta->Draw();
+  txt->DrawLatex(0.15, 0.2, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
-  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+  latex1->DrawLatex(1 - r, 1 - t + lumiTextOffset * t, lumiText);
 
   //c1->SaveAs('TestChi2FakeRate_Eta.png');
-  c1->Print(histoFolder+"/Chi2FakeRate_Eta.png");
-
-
+  c1->Print(histoFolder + "/Chi2FakeRate_Eta.png");
 
   Chi2FakeRate_WideBinning_Eta->Divide(Chi2UnmatchedME0Muon_WideBinning_Eta, ME0Muon_Cuts_WideBinning_Eta, 1, 1, "B");
   //std::cout<<"Chi2UnmatchedME0Muon_WideBinning_Eta =  "<<Chi2UnmatchedME0Muon_WideBinning_Eta->Integral()<<std::endl;
@@ -2265,16 +2605,17 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   Chi2FakeRate_WideBinning_Eta->GetYaxis()->SetTitleSize(0.05);
   Chi2FakeRate_WideBinning_Eta->SetMinimum(0);
   Chi2FakeRate_WideBinning_Eta->SetMaximum(1.2);
-  Chi2FakeRate_WideBinning_Eta->Write();   Chi2FakeRate_WideBinning_Eta->Draw();  
-  txt->DrawLatex(0.15,0.2,pcstr);
+  Chi2FakeRate_WideBinning_Eta->Write();
+  Chi2FakeRate_WideBinning_Eta->Draw();
+  txt->DrawLatex(0.15, 0.2, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
-  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+  latex1->DrawLatex(1 - r, 1 - t + lumiTextOffset * t, lumiText);
 
   //c1->SaveAs('TestChi2FakeRate_WideBinning_Eta.png');
-  c1->Print(histoFolder+"/Chi2FakeRate_WideBinning_Eta.png");
+  c1->Print(histoFolder + "/Chi2FakeRate_WideBinning_Eta.png");
 
-
-  Chi2FakeRate_WidestBinning_Eta->Divide(Chi2UnmatchedME0Muon_WidestBinning_Eta, ME0Muon_Cuts_WidestBinning_Eta, 1, 1, "B");
+  Chi2FakeRate_WidestBinning_Eta->Divide(
+      Chi2UnmatchedME0Muon_WidestBinning_Eta, ME0Muon_Cuts_WidestBinning_Eta, 1, 1, "B");
   //std::cout<<"Chi2UnmatchedME0Muon_WidestBinning_Eta =  "<<Chi2UnmatchedME0Muon_WidestBinning_Eta->Integral()<<std::endl;
   //std::cout<<"UnmatchedME0Muon_WidestBinning_Eta =  "<<UnmatchedME0Muon_WidestBinning_Eta->Integral()<<std::endl;
   //std::cout<<"ME0Muon_WidestBinning_Eta =  "<<ME0Muon_Cuts_WidestBinning_Eta->Integral()<<std::endl;
@@ -2286,20 +2627,20 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   Chi2FakeRate_WidestBinning_Eta->GetYaxis()->SetTitleSize(0.05);
   Chi2FakeRate_WidestBinning_Eta->SetMinimum(0);
   Chi2FakeRate_WidestBinning_Eta->SetMaximum(1.2);
-  Chi2FakeRate_WidestBinning_Eta->Write();   Chi2FakeRate_WidestBinning_Eta->Draw();  
-  txt->DrawLatex(0.15,0.2,pcstr);
+  Chi2FakeRate_WidestBinning_Eta->Write();
+  Chi2FakeRate_WidestBinning_Eta->Draw();
+  txt->DrawLatex(0.15, 0.2, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
-  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+  latex1->DrawLatex(1 - r, 1 - t + lumiTextOffset * t, lumiText);
 
   //c1->SaveAs('TestChi2FakeRate_WidestBinning_Eta.png');
-  c1->Print(histoFolder+"/Chi2FakeRate_WidestBinning_Eta.png");
-
+  c1->Print(histoFolder + "/Chi2FakeRate_WidestBinning_Eta.png");
 
   //Fake Rate per Event:
 
   FakeRate_Eta_PerEvent->Divide(UnmatchedME0Muon_Cuts_Eta_PerEvent, ME0Muon_Cuts_Eta_PerEvent, 1, 1, "B");
-  std::cout<<"UnmatchedME0Muon_Eta_PerEvent =  "<<UnmatchedME0Muon_Cuts_Eta_PerEvent->Integral()<<std::endl;
-  std::cout<<"ME0Muon_Eta_PerEvent =  "<<ME0Muon_Cuts_Eta_PerEvent->Integral()<<std::endl;
+  std::cout << "UnmatchedME0Muon_Eta_PerEvent =  " << UnmatchedME0Muon_Cuts_Eta_PerEvent->Integral() << std::endl;
+  std::cout << "ME0Muon_Eta_PerEvent =  " << ME0Muon_Cuts_Eta_PerEvent->Integral() << std::endl;
 
   FakeRate_Eta_PerEvent->GetXaxis()->SetTitle("Reconstructed track |#eta|");
   FakeRate_Eta_PerEvent->GetXaxis()->SetTitleSize(0.05);
@@ -2307,19 +2648,19 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   FakeRate_Eta_PerEvent->GetYaxis()->SetTitleSize(0.05);
   FakeRate_Eta_PerEvent->SetMinimum(0);
   FakeRate_Eta_PerEvent->SetMaximum(1.2);
-  FakeRate_Eta_PerEvent->Write();   FakeRate_Eta_PerEvent->Draw();  
-  txt->DrawLatex(0.15,0.2,pcstr);
+  FakeRate_Eta_PerEvent->Write();
+  FakeRate_Eta_PerEvent->Draw();
+  txt->DrawLatex(0.15, 0.2, pcstr);
   latex->DrawLatex(0.4, 0.85, cmsText);
-  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+  latex1->DrawLatex(1 - r, 1 - t + lumiTextOffset * t, lumiText);
 
   //c1->SaveAs('TestFakeRate_Eta_PerEvent.png');
-  c1->Print(histoFolder+"/FakeRate_Eta_PerEvent.png");
+  c1->Print(histoFolder + "/FakeRate_Eta_PerEvent.png");
 
-  std::cout<<"  FakeRate_Eta values:"<<std::endl;
-  for (int i=1; i<=FakeRate_Eta->GetNbinsX(); ++i){
-    std::cout<<2.4+(double)i*((4.0-2.4)/40.)<<","<<FakeRate_Eta->GetBinContent(i)<<std::endl;
+  std::cout << "  FakeRate_Eta values:" << std::endl;
+  for (int i = 1; i <= FakeRate_Eta->GetNbinsX(); ++i) {
+    std::cout << 2.4 + (double)i * ((4.0 - 2.4) / 40.) << "," << FakeRate_Eta->GetBinContent(i) << std::endl;
   }
-  
 
   // FakeRate_Pt->Divide(MatchedME0Muon_Pt, GenMuon_Pt, 1, 1, "B");
   // FakeRate_Pt->GetXaxis()->SetTitle("Gen Muon p_{T}");
@@ -2328,7 +2669,9 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   // FakeRate_Pt->Write();   FakeRate_Pt->Draw();  c1->Print(histoFolder+"/FakeRate_Pt.png");
 
   MuonAllTracksEff_Eta->Divide(ME0Muon_Eta, Track_Eta, 1, 1, "B");
-  MuonAllTracksEff_Eta->Write();   MuonAllTracksEff_Eta->Draw();  c1->Print(histoFolder+"/MuonAllTracksEff_Eta.png");
+  MuonAllTracksEff_Eta->Write();
+  MuonAllTracksEff_Eta->Draw();
+  c1->Print(histoFolder + "/MuonAllTracksEff_Eta.png");
 
   // MuonAllTracksEff_Pt->Divide(ME0Muon_Pt, Track_Pt, 1, 1, "B");
   // MuonAllTracksEff_Pt->Write();   MuonAllTracksEff_Pt->Draw();  c1->Print(histoFolder+"/MuonAllTracksEff_Pt.png");
@@ -2341,45 +2684,50 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
   FractionMatched_Eta->Divide(MatchedME0Muon_Eta, ME0Muon_Eta, 1, 1, "B");
   FractionMatched_Eta->GetXaxis()->SetTitle("Gen Muon |#eta|");
   FractionMatched_Eta->GetYaxis()->SetTitle("Matched/All ME0Muons");
-  FractionMatched_Eta->Write();   FractionMatched_Eta->Draw();  c1->Print(histoFolder+"/FractionMatched_Eta.png");
+  FractionMatched_Eta->Write();
+  FractionMatched_Eta->Draw();
+  c1->Print(histoFolder + "/FractionMatched_Eta.png");
 
   gStyle->SetOptStat(1);
   PtDiff_h->GetXaxis()->SetTitle("(pt track-ptgen)/ptgen");
-  PtDiff_h->Write();     PtDiff_h->Draw();  c1->Print(histoFolder+"/PtDiff_h.png");
+  PtDiff_h->Write();
+  PtDiff_h->Draw();
+  c1->Print(histoFolder + "/PtDiff_h.png");
 
   QOverPtDiff_h->GetXaxis()->SetTitle("(q/pt track-q/ptgen)/(q/ptgen)");
-  QOverPtDiff_h->Write();     QOverPtDiff_h->Draw();  c1->Print(histoFolder+"/QOverPtDiff_h.png");
+  QOverPtDiff_h->Write();
+  QOverPtDiff_h->Draw();
+  c1->Print(histoFolder + "/QOverPtDiff_h.png");
 
   gStyle->SetOptStat(0);
   PtDiff_s->SetMarkerStyle(1);
   PtDiff_s->SetMarkerSize(3.0);
   PtDiff_s->GetXaxis()->SetTitle("Gen Muon #eta");
   PtDiff_s->GetYaxis()->SetTitle("|(pt track-ptgen)/ptgen|");
-  PtDiff_s->Write();     PtDiff_s->Draw();  c1->Print(histoFolder+"/PtDiff_s.png");
-  
-  for(int i=1; i<=PtDiff_p->GetNbinsX(); ++i) {
-    PtDiff_rms->SetBinContent(i, PtDiff_p->GetBinError(i)); 
-    std::cout<<"Pt_rms = "<<PtDiff_p->GetBinError(i)<<std::endl;
+  PtDiff_s->Write();
+  PtDiff_s->Draw();
+  c1->Print(histoFolder + "/PtDiff_s.png");
+
+  for (int i = 1; i <= PtDiff_p->GetNbinsX(); ++i) {
+    PtDiff_rms->SetBinContent(i, PtDiff_p->GetBinError(i));
+    std::cout << "Pt_rms = " << PtDiff_p->GetBinError(i) << std::endl;
   }
 
-
   TH1D *test;
-  std::cout<<"Total integral is "<<PtDiff_s->Integral()<<std::endl;
-    test= new TH1D("test"   , "pt resolution"   , 200, -1.0, 1.0 );      
-  for(Int_t i=1; i<=PtDiff_s->GetNbinsX(); ++i) {
-
-
+  std::cout << "Total integral is " << PtDiff_s->Integral() << std::endl;
+  test = new TH1D("test", "pt resolution", 200, -1.0, 1.0);
+  for (Int_t i = 1; i <= PtDiff_s->GetNbinsX(); ++i) {
     std::stringstream tempstore;
-    tempstore<<i;
-    const std::string& thistemp = tempstore.str();
+    tempstore << i;
+    const std::string &thistemp = tempstore.str();
     test->Draw();
 
-
-    PtDiff_s->ProjectionY("test",i,i,"");
-    std::cout<<"Bin = "<<PtDiff_s->GetBinContent(i)<<std::endl;
-    std::cout<<"Integral = "<<test->Integral()<<std::endl;
-    if (test->Integral() < 1.0) continue;
-    std::cout<<"Running some gaussian fits"<<std::endl;
+    PtDiff_s->ProjectionY("test", i, i, "");
+    std::cout << "Bin = " << PtDiff_s->GetBinContent(i) << std::endl;
+    std::cout << "Integral = " << test->Integral() << std::endl;
+    if (test->Integral() < 1.0)
+      continue;
+    std::cout << "Running some gaussian fits" << std::endl;
 
     // TF1 *gaus_narrow = new TF1("gaus_narrow","gaus",-.1,.1);
     // test->Fit(gaus_narrow,"R");
@@ -2395,433 +2743,458 @@ void ME0MuonAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
     // std::cout<<n0<<", "<<n1<<", "<<n2<<std::endl;
 
     //TF1 *gaus_wide = new TF1("gaus_wide","gaus",-.2,.2);
-    TF1 *gaus_wide = new TF1("gaus_wide","gaus",-1.,1.);
-    std::cout<<"About to fit"<<std::endl;
-    test->Fit(gaus_wide,"R");
+    TF1 *gaus_wide = new TF1("gaus_wide", "gaus", -1., 1.);
+    std::cout << "About to fit" << std::endl;
+    test->Fit(gaus_wide, "R");
 
-    std::cout<<"Getting values"<<std::endl;
-    Double_t w2  = gaus_wide->GetParameter(2);
+    std::cout << "Getting values" << std::endl;
+    Double_t w2 = gaus_wide->GetParameter(2);
 
-    Double_t e_w2  = gaus_wide->GetParError(2);
+    Double_t e_w2 = gaus_wide->GetParError(2);
 
-    std::cout<<"Got values"<<std::endl;
-    // PtDiff_gaus_narrow->SetBinContent(i, n2); 
-    // PtDiff_gaus_narrow->SetBinError(i, e_n2); 
-    PtDiff_gaus_wide->SetBinContent(i, w2); 
-    PtDiff_gaus_wide->SetBinError(i, e_w2); 
-    
+    std::cout << "Got values" << std::endl;
+    // PtDiff_gaus_narrow->SetBinContent(i, n2);
+    // PtDiff_gaus_narrow->SetBinError(i, e_n2);
+    PtDiff_gaus_wide->SetBinContent(i, w2);
+    PtDiff_gaus_wide->SetBinError(i, e_w2);
+
     test->Write();
-    TString FileName = "Bin"+thistemp+"Fit.png";
-    c1->Print(histoFolder+"/"+FileName);
+    TString FileName = "Bin" + thistemp + "Fit.png";
+    c1->Print(histoFolder + "/" + FileName);
 
     //test->Draw();
     //delete test;
-    
+
     //continue;
 
-
     delete test;
-    test= new TH1D("test"   , "pt resolution"   , 200, -1.0, 1.0 );  
+    test = new TH1D("test", "pt resolution", 200, -1.0, 1.0);
     test->Draw();
     // Redoing for pt 5 to 10
-    std::cout<<"About to project"<<std::endl;
-    PtDiff_s_5_10->ProjectionY("test",i,i,"");
-    std::cout<<"About to check, "<<std::endl;
-    std::cout<<test->Integral()<<std::endl;
-    if (test->Integral() < 1.0) continue;
+    std::cout << "About to project" << std::endl;
+    PtDiff_s_5_10->ProjectionY("test", i, i, "");
+    std::cout << "About to check, " << std::endl;
+    std::cout << test->Integral() << std::endl;
+    if (test->Integral() < 1.0)
+      continue;
 
-    std::cout<<"Running the 5-10 fit"<<std::endl;
-    TF1 *gaus_5_10 = new TF1("gaus_5_10","gaus",-.2,.2);
-    test->Fit(gaus_5_10,"R");
+    std::cout << "Running the 5-10 fit" << std::endl;
+    TF1 *gaus_5_10 = new TF1("gaus_5_10", "gaus", -.2, .2);
+    test->Fit(gaus_5_10, "R");
 
-     w2  = gaus_5_10->GetParameter(2);
-     e_w2  = gaus_5_10->GetParError(2);
+    w2 = gaus_5_10->GetParameter(2);
+    e_w2 = gaus_5_10->GetParError(2);
 
-    PtDiff_gaus_5_10->SetBinContent(i, w2); 
-    PtDiff_gaus_5_10->SetBinError(i, e_w2); 
+    PtDiff_gaus_5_10->SetBinContent(i, w2);
+    PtDiff_gaus_5_10->SetBinError(i, e_w2);
 
     test->Draw();
-    FileName = "Bin"+thistemp+"Fit_5_10.png";
-    c1->Print(histoFolder+"/"+FileName);
+    FileName = "Bin" + thistemp + "Fit_5_10.png";
+    c1->Print(histoFolder + "/" + FileName);
 
     delete test;
-    test= new TH1D("test"   , "pt resolution"   , 200, -1.0, 1.0 );  
+    test = new TH1D("test", "pt resolution", 200, -1.0, 1.0);
     test->Draw();
     // Redoing for pt 10 to 20
-    PtDiff_s_10_50->ProjectionY("test",i,i,"");
-    if (test->Integral() < 1.0) continue;
+    PtDiff_s_10_50->ProjectionY("test", i, i, "");
+    if (test->Integral() < 1.0)
+      continue;
 
-    TF1 *gaus_10_50 = new TF1("gaus_10_50","gaus",-.2,.2);
-    test->Fit(gaus_10_50,"R");
+    TF1 *gaus_10_50 = new TF1("gaus_10_50", "gaus", -.2, .2);
+    test->Fit(gaus_10_50, "R");
 
-     w2  = gaus_10_50->GetParameter(2);
-     e_w2  = gaus_10_50->GetParError(2);
+    w2 = gaus_10_50->GetParameter(2);
+    e_w2 = gaus_10_50->GetParError(2);
 
-    PtDiff_gaus_10_50->SetBinContent(i, w2); 
-    PtDiff_gaus_10_50->SetBinError(i, e_w2); 
+    PtDiff_gaus_10_50->SetBinContent(i, w2);
+    PtDiff_gaus_10_50->SetBinError(i, e_w2);
 
     test->Draw();
-    FileName = "Bin"+thistemp+"Fit_10_50.png";
-    c1->Print(histoFolder+"/"+FileName);
+    FileName = "Bin" + thistemp + "Fit_10_50.png";
+    c1->Print(histoFolder + "/" + FileName);
 
     delete test;
 
-    test= new TH1D("test"   , "pt resolution"   , 200, -1.0, 1.0 );  
+    test = new TH1D("test", "pt resolution", 200, -1.0, 1.0);
     test->Draw();
     // Redoing for pt 20 to 40
-    PtDiff_s_50_100->ProjectionY("test",i,i,"");
-    if (test->Integral() < 1.0) continue;
+    PtDiff_s_50_100->ProjectionY("test", i, i, "");
+    if (test->Integral() < 1.0)
+      continue;
 
-    TF1 *gaus_50_100 = new TF1("gaus_50_100","gaus",-.2,.2);
-    test->Fit(gaus_50_100,"R");
+    TF1 *gaus_50_100 = new TF1("gaus_50_100", "gaus", -.2, .2);
+    test->Fit(gaus_50_100, "R");
 
-     w2  = gaus_50_100->GetParameter(2);
-     e_w2  = gaus_50_100->GetParError(2);
+    w2 = gaus_50_100->GetParameter(2);
+    e_w2 = gaus_50_100->GetParError(2);
 
-    PtDiff_gaus_50_100->SetBinContent(i, w2); 
-    PtDiff_gaus_50_100->SetBinError(i, e_w2); 
+    PtDiff_gaus_50_100->SetBinContent(i, w2);
+    PtDiff_gaus_50_100->SetBinError(i, e_w2);
 
     test->Draw();
-    FileName = "Bin"+thistemp+"Fit_50_100.png";
-    c1->Print(histoFolder+"/"+FileName);
+    FileName = "Bin" + thistemp + "Fit_50_100.png";
+    c1->Print(histoFolder + "/" + FileName);
 
     delete test;
 
-    test= new TH1D("test"   , "pt resolution"   , 200, -1.0, 1.0 );  
+    test = new TH1D("test", "pt resolution", 200, -1.0, 1.0);
     test->Draw();
     // Redoing for pt 40+
-    PtDiff_s_100->ProjectionY("test",i,i,"");
-    if (test->Integral() < 1.0) continue;
+    PtDiff_s_100->ProjectionY("test", i, i, "");
+    if (test->Integral() < 1.0)
+      continue;
 
-    TF1 *gaus_100 = new TF1("gaus_100","gaus",-.2,.2);
-    test->Fit(gaus_100,"R");
+    TF1 *gaus_100 = new TF1("gaus_100", "gaus", -.2, .2);
+    test->Fit(gaus_100, "R");
 
-     w2  = gaus_100->GetParameter(2);
-     e_w2  = gaus_100->GetParError(2);
+    w2 = gaus_100->GetParameter(2);
+    e_w2 = gaus_100->GetParError(2);
 
-    PtDiff_gaus_100->SetBinContent(i, w2); 
-    PtDiff_gaus_100->SetBinError(i, e_w2); 
+    PtDiff_gaus_100->SetBinContent(i, w2);
+    PtDiff_gaus_100->SetBinError(i, e_w2);
 
     test->Draw();
-    FileName = "Bin"+thistemp+"Fit_100.png";
-    c1->Print(histoFolder+"/"+FileName);
+    FileName = "Bin" + thistemp + "Fit_100.png";
+    c1->Print(histoFolder + "/" + FileName);
 
     delete test;
 
-    test= new TH1D("test"   , "pt resolution"   , 200, -1.0, 1.0 );  
+    test = new TH1D("test", "pt resolution", 200, -1.0, 1.0);
     test->Draw();
     // Redoing for pt 40+
-    StandalonePtDiff_s->ProjectionY("test",i,i,"");
-    if (test->Integral() < 1.0) continue;
+    StandalonePtDiff_s->ProjectionY("test", i, i, "");
+    if (test->Integral() < 1.0)
+      continue;
 
-    TF1 *Standalonegaus = new TF1("Standalonegaus","gaus",-.2,.2);
-    test->Fit(Standalonegaus,"R");
+    TF1 *Standalonegaus = new TF1("Standalonegaus", "gaus", -.2, .2);
+    test->Fit(Standalonegaus, "R");
 
-     w2  = gaus_100->GetParameter(2);
-     e_w2  = gaus_100->GetParError(2);
+    w2 = gaus_100->GetParameter(2);
+    e_w2 = gaus_100->GetParError(2);
 
-     StandalonePtDiff_gaus->SetBinContent(i, w2); 
-     StandalonePtDiff_gaus->SetBinError(i, e_w2); 
+    StandalonePtDiff_gaus->SetBinContent(i, w2);
+    StandalonePtDiff_gaus->SetBinError(i, e_w2);
 
-     test->Draw();
-     FileName = "Bin"+thistemp+"StandaloneFit.png";
-     c1->Print(histoFolder+"/"+FileName);
-     
-     delete test;
-     //test->Clear();
+    test->Draw();
+    FileName = "Bin" + thistemp + "StandaloneFit.png";
+    c1->Print(histoFolder + "/" + FileName);
+
+    delete test;
+    //test->Clear();
   }
-  // PtDiff_gaus_narrow->SetMarkerStyle(22); 
-  // PtDiff_gaus_narrow->SetMarkerSize(1.2); 
-  // PtDiff_gaus_narrow->SetMarkerColor(kRed); 
-  // //PtDiff_gaus_narrow->SetLineColor(kRed); 
-  
-  // //PtDiff_gaus_narrow->Draw("PL"); 
+  // PtDiff_gaus_narrow->SetMarkerStyle(22);
+  // PtDiff_gaus_narrow->SetMarkerSize(1.2);
+  // PtDiff_gaus_narrow->SetMarkerColor(kRed);
+  // //PtDiff_gaus_narrow->SetLineColor(kRed);
+
+  // //PtDiff_gaus_narrow->Draw("PL");
 
   // PtDiff_gaus_narrow->GetXaxis()->SetTitle("Gen Muon #eta");
   // PtDiff_gaus_narrow->GetYaxis()->SetTitle("Gaussian width of (pt track-ptgen)/ptgen");
   // PtDiff_gaus_narrow->Write();     PtDiff_gaus_narrow->Draw("PE");
 
-  PtDiff_gaus_wide->SetMarkerStyle(22); 
-  PtDiff_gaus_wide->SetMarkerSize(1.2); 
-  PtDiff_gaus_wide->SetMarkerColor(kBlue); 
-  //PtDiff_gaus_wide->SetLineColor(kRed); 
-  
-  //PtDiff_gaus_wide->Draw("PL"); 
+  PtDiff_gaus_wide->SetMarkerStyle(22);
+  PtDiff_gaus_wide->SetMarkerSize(1.2);
+  PtDiff_gaus_wide->SetMarkerColor(kBlue);
+  //PtDiff_gaus_wide->SetLineColor(kRed);
+
+  //PtDiff_gaus_wide->Draw("PL");
 
   PtDiff_gaus_wide->GetXaxis()->SetTitle("Gen Muon |#eta|");
   PtDiff_gaus_wide->GetYaxis()->SetTitle("Gaussian width of (pt track-ptgen)/ptgen");
   PtDiff_gaus_wide->GetYaxis()->SetTitleSize(.04);
-  PtDiff_gaus_wide->Write();     PtDiff_gaus_wide->Draw("PE");  c1->Print(histoFolder+"/PtDiff_gaus.png");
+  PtDiff_gaus_wide->Write();
+  PtDiff_gaus_wide->Draw("PE");
+  c1->Print(histoFolder + "/PtDiff_gaus.png");
 
-  PtDiff_gaus_5_10->SetMarkerStyle(22); 
-  PtDiff_gaus_5_10->SetMarkerSize(1.2); 
-  PtDiff_gaus_5_10->SetMarkerColor(kBlue); 
-  //PtDiff_gaus_5_10->SetLineColor(kRed); 
-  
-  //PtDiff_gaus_5_10->Draw("PL"); 
+  PtDiff_gaus_5_10->SetMarkerStyle(22);
+  PtDiff_gaus_5_10->SetMarkerSize(1.2);
+  PtDiff_gaus_5_10->SetMarkerColor(kBlue);
+  //PtDiff_gaus_5_10->SetLineColor(kRed);
+
+  //PtDiff_gaus_5_10->Draw("PL");
 
   PtDiff_gaus_5_10->GetXaxis()->SetTitle("Gen Muon |#eta|");
   PtDiff_gaus_5_10->GetYaxis()->SetTitle("Gaussian width of (pt track-ptgen)/ptgen");
-  PtDiff_gaus_5_10->Write();     PtDiff_gaus_5_10->Draw("PE");  c1->Print(histoFolder+"/PtDiff_gaus_5_10.png");
+  PtDiff_gaus_5_10->Write();
+  PtDiff_gaus_5_10->Draw("PE");
+  c1->Print(histoFolder + "/PtDiff_gaus_5_10.png");
 
-  PtDiff_gaus_10_50->SetMarkerStyle(22); 
-  PtDiff_gaus_10_50->SetMarkerSize(1.2); 
-  PtDiff_gaus_10_50->SetMarkerColor(kBlue); 
-  //PtDiff_gaus_10_50->SetLineColor(kRed); 
-  
-  //PtDiff_gaus_10_50->Draw("PL"); 
+  PtDiff_gaus_10_50->SetMarkerStyle(22);
+  PtDiff_gaus_10_50->SetMarkerSize(1.2);
+  PtDiff_gaus_10_50->SetMarkerColor(kBlue);
+  //PtDiff_gaus_10_50->SetLineColor(kRed);
+
+  //PtDiff_gaus_10_50->Draw("PL");
 
   PtDiff_gaus_10_50->GetXaxis()->SetTitle("Gen Muon |#eta|");
   PtDiff_gaus_10_50->GetYaxis()->SetTitle("Gaussian width of (pt track-ptgen)/ptgen");
-  PtDiff_gaus_10_50->Write();     PtDiff_gaus_10_50->Draw("PE");  c1->Print(histoFolder+"/PtDiff_gaus_10_50.png");
+  PtDiff_gaus_10_50->Write();
+  PtDiff_gaus_10_50->Draw("PE");
+  c1->Print(histoFolder + "/PtDiff_gaus_10_50.png");
 
-  PtDiff_gaus_50_100->SetMarkerStyle(22); 
-  PtDiff_gaus_50_100->SetMarkerSize(1.2); 
-  PtDiff_gaus_50_100->SetMarkerColor(kBlue); 
-  //PtDiff_gaus_50_100->SetLineColor(kRed); 
-  
-  //PtDiff_gaus_50_100->Draw("PL"); 
+  PtDiff_gaus_50_100->SetMarkerStyle(22);
+  PtDiff_gaus_50_100->SetMarkerSize(1.2);
+  PtDiff_gaus_50_100->SetMarkerColor(kBlue);
+  //PtDiff_gaus_50_100->SetLineColor(kRed);
+
+  //PtDiff_gaus_50_100->Draw("PL");
 
   PtDiff_gaus_50_100->GetXaxis()->SetTitle("Gen Muon |#eta|");
   PtDiff_gaus_50_100->GetYaxis()->SetTitle("Gaussian width of (pt track-ptgen)/ptgen");
-  PtDiff_gaus_50_100->Write();     PtDiff_gaus_50_100->Draw("PE");  c1->Print(histoFolder+"/PtDiff_gaus_50_100.png");
+  PtDiff_gaus_50_100->Write();
+  PtDiff_gaus_50_100->Draw("PE");
+  c1->Print(histoFolder + "/PtDiff_gaus_50_100.png");
 
-  PtDiff_gaus_100->SetMarkerStyle(22); 
-  PtDiff_gaus_100->SetMarkerSize(1.2); 
-  PtDiff_gaus_100->SetMarkerColor(kBlue); 
-  //PtDiff_gaus_100->SetLineColor(kRed); 
-  
-  //PtDiff_gaus_100->Draw("PL"); 
+  PtDiff_gaus_100->SetMarkerStyle(22);
+  PtDiff_gaus_100->SetMarkerSize(1.2);
+  PtDiff_gaus_100->SetMarkerColor(kBlue);
+  //PtDiff_gaus_100->SetLineColor(kRed);
+
+  //PtDiff_gaus_100->Draw("PL");
 
   PtDiff_gaus_100->GetXaxis()->SetTitle("Gen Muon |#eta|");
   PtDiff_gaus_100->GetYaxis()->SetTitle("Gaussian width of (pt track-ptgen)/ptgen");
-  PtDiff_gaus_100->Write();     PtDiff_gaus_100->Draw("PE");  c1->Print(histoFolder+"/PtDiff_gaus_100.png");
+  PtDiff_gaus_100->Write();
+  PtDiff_gaus_100->Draw("PE");
+  c1->Print(histoFolder + "/PtDiff_gaus_100.png");
 
-  StandalonePtDiff_gaus->SetMarkerStyle(22); 
-  StandalonePtDiff_gaus->SetMarkerSize(1.2); 
-  StandalonePtDiff_gaus->SetMarkerColor(kBlue); 
-  //StandalonePtDiff_gaus->SetLineColor(kRed); 
-  
-  //StandalonePtDiff_gaus->Draw("PL"); 
+  StandalonePtDiff_gaus->SetMarkerStyle(22);
+  StandalonePtDiff_gaus->SetMarkerSize(1.2);
+  StandalonePtDiff_gaus->SetMarkerColor(kBlue);
+  //StandalonePtDiff_gaus->SetLineColor(kRed);
+
+  //StandalonePtDiff_gaus->Draw("PL");
 
   StandalonePtDiff_gaus->GetXaxis()->SetTitle("Gen Muon |#eta|");
   StandalonePtDiff_gaus->GetYaxis()->SetTitle("Gaussian width of (pt track-ptgen)/ptgen");
-  StandalonePtDiff_gaus->Write();     StandalonePtDiff_gaus->Draw("PE");  c1->Print(histoFolder+"/StandalonePtDiff_gaus.png");
-
+  StandalonePtDiff_gaus->Write();
+  StandalonePtDiff_gaus->Draw("PE");
+  c1->Print(histoFolder + "/StandalonePtDiff_gaus.png");
 
   PtDiff_p->SetMarkerStyle(1);
   PtDiff_p->SetMarkerSize(3.0);
   PtDiff_p->GetXaxis()->SetTitle("Gen Muon |#eta|");
   PtDiff_p->GetYaxis()->SetTitle("Average (pt track-ptgen)/ptgen");
-  PtDiff_p->Write();     PtDiff_p->Draw();  c1->Print(histoFolder+"/PtDiff_p.png");
+  PtDiff_p->Write();
+  PtDiff_p->Draw();
+  c1->Print(histoFolder + "/PtDiff_p.png");
 
   //PtDiff_rms->SetMarkerStyle(1);
   //PtDiff_rms->SetMarkerSize(3.0);
 
-  PtDiff_rms->SetMarkerStyle(22); 
-  PtDiff_rms->SetMarkerSize(1.2); 
-  PtDiff_rms->SetMarkerColor(kBlue); 
-  //PtDiff_rms->SetLineColor(kRed); 
-  
-  //PtDiff_rms->Draw("PL"); 
+  PtDiff_rms->SetMarkerStyle(22);
+  PtDiff_rms->SetMarkerSize(1.2);
+  PtDiff_rms->SetMarkerColor(kBlue);
+  //PtDiff_rms->SetLineColor(kRed);
+
+  //PtDiff_rms->Draw("PL");
 
   PtDiff_rms->GetXaxis()->SetTitle("Gen Muon |#eta|");
   PtDiff_rms->GetYaxis()->SetTitle("RMS of (pt track-ptgen)/ptgen");
-  PtDiff_rms->Write();     PtDiff_rms->Draw("P");  c1->Print(histoFolder+"/PtDiff_rms.png");
+  PtDiff_rms->Write();
+  PtDiff_rms->Draw("P");
+  c1->Print(histoFolder + "/PtDiff_rms.png");
 
   PDiff_h->GetXaxis()->SetTitle("|(p track-pgen)/pgen|");
-  PDiff_h->Write();     PDiff_h->Draw();  c1->Print(histoFolder+"/PDiff_h.png");
+  PDiff_h->Write();
+  PDiff_h->Draw();
+  c1->Print(histoFolder + "/PDiff_h.png");
 
   PDiff_s->SetMarkerStyle(1);
   PDiff_s->SetMarkerSize(3.0);
   PDiff_s->GetXaxis()->SetTitle("Gen Muon |#eta|");
   PDiff_s->GetYaxis()->SetTitle("|(p track-pgen)/pgen|");
-  PDiff_s->Write();     PDiff_s->Draw();  c1->Print(histoFolder+"/PDiff_s.png");
-  
+  PDiff_s->Write();
+  PDiff_s->Draw();
+  c1->Print(histoFolder + "/PDiff_s.png");
+
   PDiff_p->SetMarkerStyle(1);
   PDiff_p->SetMarkerSize(3.0);
   PDiff_p->GetXaxis()->SetTitle("Gen Muon #eta");
   PDiff_p->GetYaxis()->SetTitle("Average |(p track-pgen)/pgen|");
-  PDiff_p->Write();     PDiff_p->Draw();  c1->Print(histoFolder+"/PDiff_p.png");
+  PDiff_p->Write();
+  PDiff_p->Draw();
+  c1->Print(histoFolder + "/PDiff_p.png");
 
-  VertexDiff_h->Write();     VertexDiff_h->Draw();  c1->Print(histoFolder+"/VertexDiff_h.png");
+  VertexDiff_h->Write();
+  VertexDiff_h->Draw();
+  c1->Print(histoFolder + "/VertexDiff_h.png");
 
-
-
-  NormChi2_h->Write();       NormChi2_h->Draw();          c1->Print(histoFolder+"/NormChi2_h.png");
-  NormChi2Prob_h->Write();    NormChi2Prob_h->Draw();      c1->Print(histoFolder+"/NormChi2Prob_h.png");
-  NormChi2VsHits_h->Write();    NormChi2VsHits_h->Draw(); c1->Print(histoFolder+"/NormChi2VsHits_h.png");
-  chi2_vs_eta_h->Write();      chi2_vs_eta_h->Draw();     c1->Print(histoFolder+"/chi2_vs_eta_h.png");
+  NormChi2_h->Write();
+  NormChi2_h->Draw();
+  c1->Print(histoFolder + "/NormChi2_h.png");
+  NormChi2Prob_h->Write();
+  NormChi2Prob_h->Draw();
+  c1->Print(histoFolder + "/NormChi2Prob_h.png");
+  NormChi2VsHits_h->Write();
+  NormChi2VsHits_h->Draw();
+  c1->Print(histoFolder + "/NormChi2VsHits_h.png");
+  chi2_vs_eta_h->Write();
+  chi2_vs_eta_h->Draw();
+  c1->Print(histoFolder + "/chi2_vs_eta_h.png");
 
   c1->SetLogy(0);
-  AssociatedChi2_h->Write();    AssociatedChi2_h->Draw();   c1->Print(histoFolder+"/AssociatedChi2_h.png");
-  AssociatedChi2_Prob_h->Write();    AssociatedChi2_Prob_h->Draw();   c1->Print(histoFolder+"/AssociatedChi2_Prob_h.png");
+  AssociatedChi2_h->Write();
+  AssociatedChi2_h->Draw();
+  c1->Print(histoFolder + "/AssociatedChi2_h.png");
+  AssociatedChi2_Prob_h->Write();
+  AssociatedChi2_Prob_h->Draw();
+  c1->Print(histoFolder + "/AssociatedChi2_Prob_h.png");
 
   //Printing needing values to an output log file
   using namespace std;
   ofstream logout;
-  logout.open (histoFolder+"/Log.txt");
+  logout.open(histoFolder + "/Log.txt");
 
-  logout<<"Chi 2 Efficiencies and errors:\n";
-  for (int i=1; i<=Chi2MuonRecoEff_Eta->GetNbinsX(); ++i){
-    logout<<Chi2MuonRecoEff_Eta->GetBinContent(i)<<","<<Chi2MuonRecoEff_Eta->GetBinError(i)<<"\n";
-  }    
+  logout << "Chi 2 Efficiencies and errors:\n";
+  for (int i = 1; i <= Chi2MuonRecoEff_Eta->GetNbinsX(); ++i) {
+    logout << Chi2MuonRecoEff_Eta->GetBinContent(i) << "," << Chi2MuonRecoEff_Eta->GetBinError(i) << "\n";
+  }
 
-  logout<<"Efficiencies and errors:\n";
-  for (int i=1; i<=MuonRecoEff_Eta->GetNbinsX(); ++i){
-    logout<<MuonRecoEff_Eta->GetBinContent(i)<<","<<MuonRecoEff_Eta->GetBinError(i)<<"\n";
-  }    
+  logout << "Efficiencies and errors:\n";
+  for (int i = 1; i <= MuonRecoEff_Eta->GetNbinsX(); ++i) {
+    logout << MuonRecoEff_Eta->GetBinContent(i) << "," << MuonRecoEff_Eta->GetBinError(i) << "\n";
+  }
 
-  logout<<"Fake Rate:\n";
-  for (int i=1; i<=FakeRate_Eta->GetNbinsX(); ++i){
-    logout<<FakeRate_Eta->GetBinContent(i)<<","<<FakeRate_Eta->GetBinError(i)<<"\n";
-  }    
+  logout << "Fake Rate:\n";
+  for (int i = 1; i <= FakeRate_Eta->GetNbinsX(); ++i) {
+    logout << FakeRate_Eta->GetBinContent(i) << "," << FakeRate_Eta->GetBinError(i) << "\n";
+  }
 
-  logout<<"Resolution vs eta:\n";
-  for (int i=1; i<=PtDiff_gaus_wide->GetNbinsX(); ++i){
-    logout<<PtDiff_gaus_wide->GetBinContent(i)<<","<<PtDiff_gaus_wide->GetBinError(i)<<"\n";
-  }    
+  logout << "Resolution vs eta:\n";
+  for (int i = 1; i <= PtDiff_gaus_wide->GetNbinsX(); ++i) {
+    logout << PtDiff_gaus_wide->GetBinContent(i) << "," << PtDiff_gaus_wide->GetBinError(i) << "\n";
+  }
 
+  logout << "Efficiencies and errors 5_10:\n";
+  for (int i = 1; i <= MuonRecoEff_Eta_5_10->GetNbinsX(); ++i) {
+    logout << MuonRecoEff_Eta_5_10->GetBinContent(i) << "," << MuonRecoEff_Eta_5_10->GetBinError(i) << "\n";
+  }
 
-  logout<<"Efficiencies and errors 5_10:\n";
-  for (int i=1; i<=MuonRecoEff_Eta_5_10->GetNbinsX(); ++i){
-    logout<<MuonRecoEff_Eta_5_10->GetBinContent(i)<<","<<MuonRecoEff_Eta_5_10->GetBinError(i)<<"\n";
-  }    
+  logout << "Efficiencies and errors 9_11:\n";
+  for (int i = 1; i <= MuonRecoEff_Eta_9_11->GetNbinsX(); ++i) {
+    logout << MuonRecoEff_Eta_9_11->GetBinContent(i) << "," << MuonRecoEff_Eta_9_11->GetBinError(i) << "\n";
+  }
 
+  logout << "Chi 2 Efficiencies and errors 5_10:\n";
+  for (int i = 1; i <= Chi2MuonRecoEff_Eta_5_10->GetNbinsX(); ++i) {
+    logout << Chi2MuonRecoEff_Eta_5_10->GetBinContent(i) << "," << Chi2MuonRecoEff_Eta_5_10->GetBinError(i) << "\n";
+  }
 
-  logout<<"Efficiencies and errors 9_11:\n";
-  for (int i=1; i<=MuonRecoEff_Eta_9_11->GetNbinsX(); ++i){
-    logout<<MuonRecoEff_Eta_9_11->GetBinContent(i)<<","<<MuonRecoEff_Eta_9_11->GetBinError(i)<<"\n";
-  }    
+  logout << "Fake Rate 5_10:\n";
+  for (int i = 1; i <= FakeRate_Eta_5_10->GetNbinsX(); ++i) {
+    logout << FakeRate_Eta_5_10->GetBinContent(i) << "," << FakeRate_Eta_5_10->GetBinError(i) << "\n";
+  }
 
+  logout << "Resolution vs eta 5_10:\n";
+  for (int i = 1; i <= PtDiff_gaus_5_10->GetNbinsX(); ++i) {
+    logout << PtDiff_gaus_5_10->GetBinContent(i) << "," << PtDiff_gaus_5_10->GetBinError(i) << "\n";
+  }
 
-  logout<<"Chi 2 Efficiencies and errors 5_10:\n";
-  for (int i=1; i<=Chi2MuonRecoEff_Eta_5_10->GetNbinsX(); ++i){
-    logout<<Chi2MuonRecoEff_Eta_5_10->GetBinContent(i)<<","<<Chi2MuonRecoEff_Eta_5_10->GetBinError(i)<<"\n";
-  }    
+  logout << "Efficiencies and errors 10_50:\n";
+  for (int i = 1; i <= MuonRecoEff_Eta_10_50->GetNbinsX(); ++i) {
+    logout << MuonRecoEff_Eta_10_50->GetBinContent(i) << "," << MuonRecoEff_Eta_10_50->GetBinError(i) << "\n";
+  }
 
-  logout<<"Fake Rate 5_10:\n";
-  for (int i=1; i<=FakeRate_Eta_5_10->GetNbinsX(); ++i){
-    logout<<FakeRate_Eta_5_10->GetBinContent(i)<<","<<FakeRate_Eta_5_10->GetBinError(i)<<"\n";
-  }    
+  logout << "Chi 2 Efficiencies and errors 10_50:\n";
+  for (int i = 1; i <= Chi2MuonRecoEff_Eta_10_50->GetNbinsX(); ++i) {
+    logout << Chi2MuonRecoEff_Eta_10_50->GetBinContent(i) << "," << Chi2MuonRecoEff_Eta_10_50->GetBinError(i) << "\n";
+  }
 
-  logout<<"Resolution vs eta 5_10:\n";
-  for (int i=1; i<=PtDiff_gaus_5_10->GetNbinsX(); ++i){
-    logout<<PtDiff_gaus_5_10->GetBinContent(i)<<","<<PtDiff_gaus_5_10->GetBinError(i)<<"\n";
-  }    
+  logout << "Fake Rate 10_50:\n";
+  for (int i = 1; i <= FakeRate_Eta_10_50->GetNbinsX(); ++i) {
+    logout << FakeRate_Eta_10_50->GetBinContent(i) << "," << FakeRate_Eta_10_50->GetBinError(i) << "\n";
+  }
 
+  logout << "Resolution vs eta 10_50:\n";
+  for (int i = 1; i <= PtDiff_gaus_10_50->GetNbinsX(); ++i) {
+    logout << PtDiff_gaus_10_50->GetBinContent(i) << "," << PtDiff_gaus_10_50->GetBinError(i) << "\n";
+  }
 
-  logout<<"Efficiencies and errors 10_50:\n";
-  for (int i=1; i<=MuonRecoEff_Eta_10_50->GetNbinsX(); ++i){
-    logout<<MuonRecoEff_Eta_10_50->GetBinContent(i)<<","<<MuonRecoEff_Eta_10_50->GetBinError(i)<<"\n";
-  }    
+  logout << "Efficiencies and errors 50_100:\n";
+  for (int i = 1; i <= MuonRecoEff_Eta_50_100->GetNbinsX(); ++i) {
+    logout << MuonRecoEff_Eta_50_100->GetBinContent(i) << "," << MuonRecoEff_Eta_50_100->GetBinError(i) << "\n";
+  }
 
-  logout<<"Chi 2 Efficiencies and errors 10_50:\n";
-  for (int i=1; i<=Chi2MuonRecoEff_Eta_10_50->GetNbinsX(); ++i){
-    logout<<Chi2MuonRecoEff_Eta_10_50->GetBinContent(i)<<","<<Chi2MuonRecoEff_Eta_10_50->GetBinError(i)<<"\n";
-  }    
+  logout << "Chi 2 Efficiencies and errors 50_100:\n";
+  for (int i = 1; i <= Chi2MuonRecoEff_Eta_50_100->GetNbinsX(); ++i) {
+    logout << Chi2MuonRecoEff_Eta_50_100->GetBinContent(i) << "," << Chi2MuonRecoEff_Eta_50_100->GetBinError(i) << "\n";
+  }
 
+  logout << "Fake Rate 50_100:\n";
+  for (int i = 1; i <= FakeRate_Eta_50_100->GetNbinsX(); ++i) {
+    logout << FakeRate_Eta_50_100->GetBinContent(i) << "," << FakeRate_Eta_50_100->GetBinError(i) << "\n";
+  }
 
-  logout<<"Fake Rate 10_50:\n";
-  for (int i=1; i<=FakeRate_Eta_10_50->GetNbinsX(); ++i){
-    logout<<FakeRate_Eta_10_50->GetBinContent(i)<<","<<FakeRate_Eta_10_50->GetBinError(i)<<"\n";
-  }    
+  logout << "Resolution vs eta 50_100:\n";
+  for (int i = 1; i <= PtDiff_gaus_50_100->GetNbinsX(); ++i) {
+    logout << PtDiff_gaus_50_100->GetBinContent(i) << "," << PtDiff_gaus_50_100->GetBinError(i) << "\n";
+  }
 
-  logout<<"Resolution vs eta 10_50:\n";
-  for (int i=1; i<=PtDiff_gaus_10_50->GetNbinsX(); ++i){
-    logout<<PtDiff_gaus_10_50->GetBinContent(i)<<","<<PtDiff_gaus_10_50->GetBinError(i)<<"\n";
-  }    
+  logout << "Efficiencies and errors 40:\n";
+  for (int i = 1; i <= MuonRecoEff_Eta_100->GetNbinsX(); ++i) {
+    logout << MuonRecoEff_Eta_100->GetBinContent(i) << "," << MuonRecoEff_Eta_100->GetBinError(i) << "\n";
+  }
 
+  logout << "Chi 2 Efficiencies and errors 40:\n";
+  for (int i = 1; i <= Chi2MuonRecoEff_Eta_100->GetNbinsX(); ++i) {
+    logout << Chi2MuonRecoEff_Eta_100->GetBinContent(i) << "," << Chi2MuonRecoEff_Eta_100->GetBinError(i) << "\n";
+  }
 
-  logout<<"Efficiencies and errors 50_100:\n";
-  for (int i=1; i<=MuonRecoEff_Eta_50_100->GetNbinsX(); ++i){
-    logout<<MuonRecoEff_Eta_50_100->GetBinContent(i)<<","<<MuonRecoEff_Eta_50_100->GetBinError(i)<<"\n";
-  }    
+  logout << "Fake Rate 40:\n";
+  for (int i = 1; i <= FakeRate_Eta_100->GetNbinsX(); ++i) {
+    logout << FakeRate_Eta_100->GetBinContent(i) << "," << FakeRate_Eta_100->GetBinError(i) << "\n";
+  }
 
+  logout << "Resolution vs eta 40:\n";
+  for (int i = 1; i <= PtDiff_gaus_100->GetNbinsX(); ++i) {
+    logout << PtDiff_gaus_100->GetBinContent(i) << "," << PtDiff_gaus_100->GetBinError(i) << "\n";
+  }
 
-  logout<<"Chi 2 Efficiencies and errors 50_100:\n";
-  for (int i=1; i<=Chi2MuonRecoEff_Eta_50_100->GetNbinsX(); ++i){
-    logout<<Chi2MuonRecoEff_Eta_50_100->GetBinContent(i)<<","<<Chi2MuonRecoEff_Eta_50_100->GetBinError(i)<<"\n";
-  }    
+  logout << "Background yield:\n";
+  for (int i = 1; i <= UnmatchedME0Muon_Cuts_Eta_PerEvent->GetNbinsX(); ++i) {
+    logout << UnmatchedME0Muon_Cuts_Eta_PerEvent->GetBinContent(i) << ","
+           << UnmatchedME0Muon_Cuts_Eta_PerEvent->GetBinError(i) << "\n";
+  }
 
-  logout<<"Fake Rate 50_100:\n";
-  for (int i=1; i<=FakeRate_Eta_50_100->GetNbinsX(); ++i){
-    logout<<FakeRate_Eta_50_100->GetBinContent(i)<<","<<FakeRate_Eta_50_100->GetBinError(i)<<"\n";
-  }    
-
-  logout<<"Resolution vs eta 50_100:\n";
-  for (int i=1; i<=PtDiff_gaus_50_100->GetNbinsX(); ++i){
-    logout<<PtDiff_gaus_50_100->GetBinContent(i)<<","<<PtDiff_gaus_50_100->GetBinError(i)<<"\n";
-  }    
-
-
-  logout<<"Efficiencies and errors 40:\n";
-  for (int i=1; i<=MuonRecoEff_Eta_100->GetNbinsX(); ++i){
-    logout<<MuonRecoEff_Eta_100->GetBinContent(i)<<","<<MuonRecoEff_Eta_100->GetBinError(i)<<"\n";
-  }    
-
-
-  logout<<"Chi 2 Efficiencies and errors 40:\n";
-  for (int i=1; i<=Chi2MuonRecoEff_Eta_100->GetNbinsX(); ++i){
-    logout<<Chi2MuonRecoEff_Eta_100->GetBinContent(i)<<","<<Chi2MuonRecoEff_Eta_100->GetBinError(i)<<"\n";
-  }    
-
-  logout<<"Fake Rate 40:\n";
-  for (int i=1; i<=FakeRate_Eta_100->GetNbinsX(); ++i){
-    logout<<FakeRate_Eta_100->GetBinContent(i)<<","<<FakeRate_Eta_100->GetBinError(i)<<"\n";
-  }    
-
-  logout<<"Resolution vs eta 40:\n";
-  for (int i=1; i<=PtDiff_gaus_100->GetNbinsX(); ++i){
-    logout<<PtDiff_gaus_100->GetBinContent(i)<<","<<PtDiff_gaus_100->GetBinError(i)<<"\n";
-  }    
-
-
-  logout<<"Background yield:\n";
-  for (int i=1; i<=UnmatchedME0Muon_Cuts_Eta_PerEvent->GetNbinsX(); ++i){
-    logout<<UnmatchedME0Muon_Cuts_Eta_PerEvent->GetBinContent(i)<<","<<UnmatchedME0Muon_Cuts_Eta_PerEvent->GetBinError(i)<<"\n";
-  }    
-
-  
   //logout << "Writing this to a file.\n";
   logout.close();
 
-  delete histoFile; histoFile = 0;
+  delete histoFile;
+  histoFile = 0;
 }
 
-
-
-FreeTrajectoryState
-ME0MuonAnalyzer::getFTS(const GlobalVector& p3, const GlobalVector& r3, 
-			   int charge, const AlgebraicSymMatrix55& cov,
-			   const MagneticField* field){
-
+FreeTrajectoryState ME0MuonAnalyzer::getFTS(const GlobalVector &p3,
+                                            const GlobalVector &r3,
+                                            int charge,
+                                            const AlgebraicSymMatrix55 &cov,
+                                            const MagneticField *field) {
   GlobalVector p3GV(p3.x(), p3.y(), p3.z());
   GlobalPoint r3GP(r3.x(), r3.y(), r3.z());
   GlobalTrajectoryParameters tPars(r3GP, p3GV, charge, field);
 
   CurvilinearTrajectoryError tCov(cov);
-  
-  return cov.kRows == 5 ? FreeTrajectoryState(tPars, tCov) : FreeTrajectoryState(tPars) ;
+
+  return cov.kRows == 5 ? FreeTrajectoryState(tPars, tCov) : FreeTrajectoryState(tPars);
 }
 
-FreeTrajectoryState
-ME0MuonAnalyzer::getFTS(const GlobalVector& p3, const GlobalVector& r3, 
-			   int charge, const AlgebraicSymMatrix66& cov,
-			   const MagneticField* field){
-
+FreeTrajectoryState ME0MuonAnalyzer::getFTS(const GlobalVector &p3,
+                                            const GlobalVector &r3,
+                                            int charge,
+                                            const AlgebraicSymMatrix66 &cov,
+                                            const MagneticField *field) {
   GlobalVector p3GV(p3.x(), p3.y(), p3.z());
   GlobalPoint r3GP(r3.x(), r3.y(), r3.z());
   GlobalTrajectoryParameters tPars(r3GP, p3GV, charge, field);
 
   CartesianTrajectoryError tCov(cov);
-  
-  return cov.kRows == 6 ? FreeTrajectoryState(tPars, tCov) : FreeTrajectoryState(tPars) ;
+
+  return cov.kRows == 6 ? FreeTrajectoryState(tPars, tCov) : FreeTrajectoryState(tPars);
 }
 
-void ME0MuonAnalyzer::getFromFTS(const FreeTrajectoryState& fts,
-				    GlobalVector& p3, GlobalVector& r3, 
-				    int& charge, AlgebraicSymMatrix66& cov){
+void ME0MuonAnalyzer::getFromFTS(
+    const FreeTrajectoryState &fts, GlobalVector &p3, GlobalVector &r3, int &charge, AlgebraicSymMatrix66 &cov) {
   GlobalVector p3GV = fts.momentum();
   GlobalPoint r3GP = fts.position();
 
@@ -2831,10 +3204,9 @@ void ME0MuonAnalyzer::getFromFTS(const FreeTrajectoryState& fts,
   r3 = r3T;  //Yikes, was setting this to p3T instead of r3T!?!
   // p3.set(p3GV.x(), p3GV.y(), p3GV.z());
   // r3.set(r3GP.x(), r3GP.y(), r3GP.z());
-  
+
   charge = fts.charge();
   cov = fts.hasError() ? fts.cartesianError().matrix() : AlgebraicSymMatrix66();
-
 }
 
 DEFINE_FWK_MODULE(ME0MuonAnalyzer);

--- a/RecoMuon/MuonIdentification/test/MuonTimingValidator.cc
+++ b/RecoMuon/MuonIdentification/test/MuonTimingValidator.cc
@@ -2,7 +2,7 @@
 //
 // Package:    MuonTimingValidator
 // Class:      MuonTimingValidator
-// 
+//
 /**\class MuonTimingValidator MuonTimingValidator.cc 
 
  Description: An example analyzer that fills muon timing information histograms 
@@ -82,91 +82,84 @@
 //
 // constructors and destructor
 //
-MuonTimingValidator::MuonTimingValidator(const edm::ParameterSet& iConfig) 
-  :
-  TKtrackTags_(iConfig.getUntrackedParameter<edm::InputTag>("TKtracks")),
-  TKtrackTokens_(consumes<reco::TrackCollection>(TKtrackTags_)),
-  MuonTags_(iConfig.getUntrackedParameter<edm::InputTag>("Muons")),
-  MuonTokens_(consumes<reco::MuonCollection>(MuonTags_)),
-  CombinedTimeTags_(iConfig.getUntrackedParameter<edm::InputTag>("CombinedTiming")),
-  CombinedTimeTokens_(consumes<reco::MuonTimeExtraMap>(CombinedTimeTags_)),
-  DtTimeTags_(iConfig.getUntrackedParameter<edm::InputTag>("DtTiming")),
-  DtTimeTokens_(consumes<reco::MuonTimeExtraMap>(DtTimeTags_)),
-  CscTimeTags_(iConfig.getUntrackedParameter<edm::InputTag>("CscTiming")),
-  CscTimeTokens_(consumes<reco::MuonTimeExtraMap>(CscTimeTags_)),
-  out(iConfig.getParameter<std::string>("out")),
-  open(iConfig.getParameter<std::string>("open")),
-  theMinEta(iConfig.getParameter<double>("etaMin")),
-  theMaxEta(iConfig.getParameter<double>("etaMax")),
-  theMinPt(iConfig.getParameter<double>("simPtMin")),
-  thePtCut(iConfig.getParameter<double>("PtCut")),
-  theMinPtres(iConfig.getParameter<double>("PtresMin")),
-  theMaxPtres(iConfig.getParameter<double>("PtresMax")),
-  theScale(iConfig.getParameter<double>("PlotScale")),
-  theDtCut(iConfig.getParameter<int>("DTcut")),
-  theCscCut(iConfig.getParameter<int>("CSCcut")),
-  theNBins(iConfig.getParameter<int>("nbins"))
-{
+MuonTimingValidator::MuonTimingValidator(const edm::ParameterSet& iConfig)
+    : TKtrackTags_(iConfig.getUntrackedParameter<edm::InputTag>("TKtracks")),
+      TKtrackTokens_(consumes<reco::TrackCollection>(TKtrackTags_)),
+      MuonTags_(iConfig.getUntrackedParameter<edm::InputTag>("Muons")),
+      MuonTokens_(consumes<reco::MuonCollection>(MuonTags_)),
+      CombinedTimeTags_(iConfig.getUntrackedParameter<edm::InputTag>("CombinedTiming")),
+      CombinedTimeTokens_(consumes<reco::MuonTimeExtraMap>(CombinedTimeTags_)),
+      DtTimeTags_(iConfig.getUntrackedParameter<edm::InputTag>("DtTiming")),
+      DtTimeTokens_(consumes<reco::MuonTimeExtraMap>(DtTimeTags_)),
+      CscTimeTags_(iConfig.getUntrackedParameter<edm::InputTag>("CscTiming")),
+      CscTimeTokens_(consumes<reco::MuonTimeExtraMap>(CscTimeTags_)),
+      out(iConfig.getParameter<std::string>("out")),
+      open(iConfig.getParameter<std::string>("open")),
+      theMinEta(iConfig.getParameter<double>("etaMin")),
+      theMaxEta(iConfig.getParameter<double>("etaMax")),
+      theMinPt(iConfig.getParameter<double>("simPtMin")),
+      thePtCut(iConfig.getParameter<double>("PtCut")),
+      theMinPtres(iConfig.getParameter<double>("PtresMin")),
+      theMaxPtres(iConfig.getParameter<double>("PtresMax")),
+      theScale(iConfig.getParameter<double>("PlotScale")),
+      theDtCut(iConfig.getParameter<int>("DTcut")),
+      theCscCut(iConfig.getParameter<int>("CSCcut")),
+      theNBins(iConfig.getParameter<int>("nbins")) {
   //now do what ever initialization is needed
 }
 
-
-MuonTimingValidator::~MuonTimingValidator()
-{
- 
-   // do anything here that needs to be done at desctruction time
-   // (e.g. close files, deallocate resources etc.)
-  if (hFile!=0) {
+MuonTimingValidator::~MuonTimingValidator() {
+  // do anything here that needs to be done at desctruction time
+  // (e.g. close files, deallocate resources etc.)
+  if (hFile != 0) {
     hFile->Close();
     delete hFile;
   }
 }
-
 
 //
 // member functions
 //
 
 // ------------ method called to for each event  ------------
-void
-MuonTimingValidator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-//  std::cout << "*** Begin Muon Timing Validatior " << std::endl;
-//  std::cout << " Event: " << iEvent.id() << "  Orbit: " << iEvent.orbitNumber() << "  BX: " << iEvent.bunchCrossing() << std::endl;
+void MuonTimingValidator::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  //  std::cout << "*** Begin Muon Timing Validatior " << std::endl;
+  //  std::cout << " Event: " << iEvent.id() << "  Orbit: " << iEvent.orbitNumber() << "  BX: " << iEvent.bunchCrossing() << std::endl;
 
-  iEvent.getByToken( TKtrackTokens_, TKTrackCollection);
+  iEvent.getByToken(TKtrackTokens_, TKTrackCollection);
   reco::TrackCollection tkTC;
   const reco::TrackCollection tkTC1 = *(TKTrackCollection.product());
 
-  iEvent.getByToken(MuonTokens_,MuCollection);
+  iEvent.getByToken(MuonTokens_, MuCollection);
   const reco::MuonCollection muonC = *(MuCollection.product());
-  if (!muonC.size()) return;
+  if (!muonC.size())
+    return;
 
-  iEvent.getByToken(CombinedTimeTokens_,timeMap1);
-  const reco::MuonTimeExtraMap & timeMapCmb = *timeMap1;
-  iEvent.getByToken(DtTimeTokens_,timeMap2);
-  const reco::MuonTimeExtraMap & timeMapDT = *timeMap2;
-  iEvent.getByToken(CscTimeTokens_,timeMap3);
-  const reco::MuonTimeExtraMap & timeMapCSC = *timeMap3;
+  iEvent.getByToken(CombinedTimeTokens_, timeMap1);
+  const reco::MuonTimeExtraMap& timeMapCmb = *timeMap1;
+  iEvent.getByToken(DtTimeTokens_, timeMap2);
+  const reco::MuonTimeExtraMap& timeMapDT = *timeMap2;
+  iEvent.getByToken(CscTimeTokens_, timeMap3);
+  const reco::MuonTimeExtraMap& timeMapCSC = *timeMap3;
 
   edm::ESHandle<GlobalTrackingGeometry> theTrackingGeometry;
   iSetup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry);
 
   reco::MuonCollection::const_iterator imuon;
-  
-  int imucount=0;
-  for(imuon = muonC.begin(); imuon != muonC.end(); ++imuon){
-        
+
+  int imucount = 0;
+  for (imuon = muonC.begin(); imuon != muonC.end(); ++imuon) {
     LogDebug("RecoMuonIdentification") << " Event: " << iEvent.id() << " Found muon. Pt: " << imuon->p();
-    
-    if ((fabs(imuon->eta())<theMinEta) || (fabs(imuon->eta())>theMaxEta)) continue;
-    
+
+    if ((fabs(imuon->eta()) < theMinEta) || (fabs(imuon->eta()) > theMaxEta))
+      continue;
+
     reco::TrackRef trkTrack = imuon->track();
-    if (trkTrack.isNonnull()) { 
+    if (trkTrack.isNonnull()) {
       hi_tk_pt->Fill(((*trkTrack).pt()));
       hi_tk_phi->Fill(((*trkTrack).phi()));
       hi_tk_eta->Fill(((*trkTrack).eta()));
-    }  
+    }
 
     reco::TrackRef staTrack = imuon->standAloneMuon();
     if (staTrack.isNonnull()) {
@@ -179,57 +172,60 @@ MuonTimingValidator::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
     if (glbTrack.isNonnull()) {
       hi_glb_pt->Fill((*glbTrack).pt());
       hi_glb_phi->Fill((*glbTrack).phi());
-      hi_glb_eta->Fill((*glbTrack).eta()); 
-      
-       LogDebug("RecoMuonIdentification") << " Global Pt: " << (*glbTrack).pt();
+      hi_glb_eta->Fill((*glbTrack).eta());
+
+      LogDebug("RecoMuonIdentification") << " Global Pt: " << (*glbTrack).pt();
     }
 
     // Analyze the short info stored directly in reco::Muon
-    
+
     reco::MuonTime muonTime;
-    if (imuon->isTimeValid()) { 
+    if (imuon->isTimeValid()) {
       muonTime = imuon->time();
-//      std::cout << "    Time points: " << muonTime.nDof << "  time: " << muonTime.timeAtIpInOut << std::endl;
+      //      std::cout << "    Time points: " << muonTime.nDof << "  time: " << muonTime.timeAtIpInOut << std::endl;
       if (muonTime.nDof) {
         hi_mutime_vtx->Fill(muonTime.timeAtIpInOut);
         hi_mutime_vtx_err->Fill(muonTime.timeAtIpInOutErr);
       }
     }
-    
+
     reco::MuonEnergy muonE;
-//    if (imuon->isEnergyValid() && fabs(imuon->eta())<1.5) { 
-    if (imuon->isEnergyValid()) { 
+    //    if (imuon->isEnergyValid() && fabs(imuon->eta())<1.5) {
+    if (imuon->isEnergyValid()) {
       muonE = imuon->calEnergy();
-      if (muonE.emMax>0.25) {
+      if (muonE.emMax > 0.25) {
         hi_ecal_time->Fill(muonE.ecal_time);
-        if (muonE.emMax>1.) hi_ecal_time_ecut->Fill(muonE.ecal_time);
+        if (muonE.emMax > 1.)
+          hi_ecal_time_ecut->Fill(muonE.ecal_time);
         hi_ecal_energy->Fill(muonE.emMax);
-        if (muonE.hadMax>0.25) hi_hcalecal_vtx->Fill(muonE.hcal_time-muonE.ecal_time);
-        
-        double emErr = 1.5/muonE.emMax;
-        
-        if (emErr>0.) {
+        if (muonE.hadMax > 0.25)
+          hi_hcalecal_vtx->Fill(muonE.hcal_time - muonE.ecal_time);
+
+        double emErr = 1.5 / muonE.emMax;
+
+        if (emErr > 0.) {
           hi_ecal_time_err->Fill(emErr);
-          hi_ecal_time_pull->Fill((muonE.ecal_time-1.)/emErr);
-	  LogDebug("RecoMuonIdentification") << "     ECAL time: " << muonE.ecal_time << " +/- " << emErr;
+          hi_ecal_time_pull->Fill((muonE.ecal_time - 1.) / emErr);
+          LogDebug("RecoMuonIdentification") << "     ECAL time: " << muonE.ecal_time << " +/- " << emErr;
         }
       }
 
-      if (muonE.hadMax>0.25) {
+      if (muonE.hadMax > 0.25) {
         hi_hcal_time->Fill(muonE.hcal_time);
-        if (muonE.hadMax>1.) hi_hcal_time_ecut->Fill(muonE.hcal_time);
+        if (muonE.hadMax > 1.)
+          hi_hcal_time_ecut->Fill(muonE.hcal_time);
         hi_hcal_energy->Fill(muonE.hadMax);
-        
-        double hadErr = 1.; // DUMMY!!!
-        
+
+        double hadErr = 1.;  // DUMMY!!!
+
         hi_hcal_time_err->Fill(hadErr);
-        hi_hcal_time_pull->Fill((muonE.hcal_time-1.)/hadErr);
+        hi_hcal_time_pull->Fill((muonE.hcal_time - 1.) / hadErr);
         LogDebug("RecoMuonIdentification") << "     HCAL time: " << muonE.hcal_time << " +/- " << hadErr;
       }
     }
-    
+
     // Analyze the MuonTimeExtra information
-    reco::MuonRef muonR(MuCollection,imucount);
+    reco::MuonRef muonR(MuCollection, imucount);
     reco::MuonTimeExtra timec = timeMapCmb[muonR];
     reco::MuonTimeExtra timedt = timeMapDT[muonR];
     reco::MuonTimeExtra timecsc = timeMapCSC[muonR];
@@ -238,13 +234,15 @@ MuonTimingValidator::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
     hi_dttime_ndof->Fill(timedt.nDof());
     hi_csctime_ndof->Fill(timecsc.nDof());
 
-    if (timedt.nDof()>theDtCut) {
+    if (timedt.nDof() > theDtCut) {
       LogDebug("RecoMuonIdentification") << "          DT nDof: " << timedt.nDof();
-      LogDebug("RecoMuonIdentification") << "          DT Time: " << timedt.timeAtIpInOut() << " +/- " << timedt.inverseBetaErr();
-      LogDebug("RecoMuonIdentification") << "         DT FreeB: " << timedt.freeInverseBeta() << " +/- " << timedt.freeInverseBetaErr();
-      
+      LogDebug("RecoMuonIdentification") << "          DT Time: " << timedt.timeAtIpInOut() << " +/- "
+                                         << timedt.inverseBetaErr();
+      LogDebug("RecoMuonIdentification") << "         DT FreeB: " << timedt.freeInverseBeta() << " +/- "
+                                         << timedt.freeInverseBetaErr();
+
       hi_dttime_ibt->Fill(timedt.inverseBeta());
-      hi_dttime_ibt_pt->Fill(imuon->pt(),timedt.inverseBeta());
+      hi_dttime_ibt_pt->Fill(imuon->pt(), timedt.inverseBeta());
       hi_dttime_ibt_err->Fill(timedt.inverseBetaErr());
       hi_dttime_fib->Fill(timedt.freeInverseBeta());
       hi_dttime_fib_err->Fill(timedt.freeInverseBetaErr());
@@ -252,33 +250,36 @@ MuonTimingValidator::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
       hi_dttime_vtx_err->Fill(timedt.timeAtIpInOutErr());
       hi_dttime_vtxr->Fill(timedt.timeAtIpOutIn());
       hi_dttime_vtxr_err->Fill(timedt.timeAtIpOutInErr());
-      hi_dttime_errdiff->Fill(timedt.timeAtIpInOutErr()-timedt.timeAtIpOutInErr());
+      hi_dttime_errdiff->Fill(timedt.timeAtIpInOutErr() - timedt.timeAtIpOutInErr());
 
-      if (timedt.inverseBetaErr()>0.)
-        hi_dttime_ibt_pull->Fill((timedt.inverseBeta()-1.)/timedt.inverseBetaErr());
-      if (timedt.freeInverseBetaErr()>0.)    
-        hi_dttime_fib_pull->Fill((timedt.freeInverseBeta()-1.)/timedt.freeInverseBetaErr());
-      if (timedt.timeAtIpInOutErr()>0.)
-        hi_dttime_vtx_pull->Fill(timedt.timeAtIpInOut()/timedt.timeAtIpInOutErr());
-      if (timedt.timeAtIpOutInErr()>0.)
-        hi_dttime_vtxr_pull->Fill(timedt.timeAtIpOutIn()/timedt.timeAtIpOutInErr());
+      if (timedt.inverseBetaErr() > 0.)
+        hi_dttime_ibt_pull->Fill((timedt.inverseBeta() - 1.) / timedt.inverseBetaErr());
+      if (timedt.freeInverseBetaErr() > 0.)
+        hi_dttime_fib_pull->Fill((timedt.freeInverseBeta() - 1.) / timedt.freeInverseBetaErr());
+      if (timedt.timeAtIpInOutErr() > 0.)
+        hi_dttime_vtx_pull->Fill(timedt.timeAtIpInOut() / timedt.timeAtIpInOutErr());
+      if (timedt.timeAtIpOutInErr() > 0.)
+        hi_dttime_vtxr_pull->Fill(timedt.timeAtIpOutIn() / timedt.timeAtIpOutInErr());
 
-      if (timecsc.nDof()>theCscCut)
-        hi_dtcsc_vtx->Fill(timedt.timeAtIpInOut()-timecsc.timeAtIpInOut());
+      if (timecsc.nDof() > theCscCut)
+        hi_dtcsc_vtx->Fill(timedt.timeAtIpInOut() - timecsc.timeAtIpInOut());
       if (imuon->isEnergyValid()) {
-        if (muonE.emMax>0.25) hi_dtecal_vtx->Fill(timedt.timeAtIpInOut()-muonE.ecal_time);
-        if (muonE.hadMax>0.25) hi_dthcal_vtx->Fill(timedt.timeAtIpInOut()-muonE.hcal_time);
-      }    
-
+        if (muonE.emMax > 0.25)
+          hi_dtecal_vtx->Fill(timedt.timeAtIpInOut() - muonE.ecal_time);
+        if (muonE.hadMax > 0.25)
+          hi_dthcal_vtx->Fill(timedt.timeAtIpInOut() - muonE.hcal_time);
+      }
     }
 
-    if (timecsc.nDof()>theCscCut) {
+    if (timecsc.nDof() > theCscCut) {
       LogDebug("RecoMuonIdentification") << "         CSC nDof: " << timecsc.nDof();
-      LogDebug("RecoMuonIdentification") << "         CSC Time: " << timecsc.timeAtIpInOut() << " +/- " << timecsc.inverseBetaErr();
-      LogDebug("RecoMuonIdentification") << "        CSC FreeB: " << timecsc.freeInverseBeta() << " +/- " << timecsc.freeInverseBetaErr();
-      
+      LogDebug("RecoMuonIdentification") << "         CSC Time: " << timecsc.timeAtIpInOut() << " +/- "
+                                         << timecsc.inverseBetaErr();
+      LogDebug("RecoMuonIdentification") << "        CSC FreeB: " << timecsc.freeInverseBeta() << " +/- "
+                                         << timecsc.freeInverseBetaErr();
+
       hi_csctime_ibt->Fill(timecsc.inverseBeta());
-      hi_csctime_ibt_pt->Fill(imuon->pt(),timecsc.inverseBeta());
+      hi_csctime_ibt_pt->Fill(imuon->pt(), timecsc.inverseBeta());
       hi_csctime_ibt_err->Fill(timecsc.inverseBetaErr());
       hi_csctime_fib->Fill(timecsc.freeInverseBeta());
       hi_csctime_fib_err->Fill(timecsc.freeInverseBetaErr());
@@ -287,28 +288,32 @@ MuonTimingValidator::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
       hi_csctime_vtxr->Fill(timecsc.timeAtIpOutIn());
       hi_csctime_vtxr_err->Fill(timecsc.timeAtIpOutInErr());
 
-      if (timec.inverseBetaErr()>0.)
-        hi_csctime_ibt_pull->Fill((timecsc.inverseBeta()-1.)/timecsc.inverseBetaErr());
-      if (timecsc.freeInverseBetaErr()>0.)    
-        hi_csctime_fib_pull->Fill((timecsc.freeInverseBeta()-1.)/timecsc.freeInverseBetaErr());
-      if (timecsc.timeAtIpInOutErr()>0.)
-        hi_csctime_vtx_pull->Fill(timecsc.timeAtIpInOut()/timecsc.timeAtIpInOutErr());
-      if (timecsc.timeAtIpOutInErr()>0.)
-        hi_csctime_vtxr_pull->Fill(timecsc.timeAtIpOutIn()/timecsc.timeAtIpOutInErr());
+      if (timec.inverseBetaErr() > 0.)
+        hi_csctime_ibt_pull->Fill((timecsc.inverseBeta() - 1.) / timecsc.inverseBetaErr());
+      if (timecsc.freeInverseBetaErr() > 0.)
+        hi_csctime_fib_pull->Fill((timecsc.freeInverseBeta() - 1.) / timecsc.freeInverseBetaErr());
+      if (timecsc.timeAtIpInOutErr() > 0.)
+        hi_csctime_vtx_pull->Fill(timecsc.timeAtIpInOut() / timecsc.timeAtIpInOutErr());
+      if (timecsc.timeAtIpOutInErr() > 0.)
+        hi_csctime_vtxr_pull->Fill(timecsc.timeAtIpOutIn() / timecsc.timeAtIpOutInErr());
 
       if (imuon->isEnergyValid()) {
-        if (muonE.emMax>0.25) hi_ecalcsc_vtx->Fill(muonE.ecal_time-timecsc.timeAtIpInOut());
-        if (muonE.hadMax>0.25) hi_hcalcsc_vtx->Fill(muonE.hcal_time-timecsc.timeAtIpInOut());
+        if (muonE.emMax > 0.25)
+          hi_ecalcsc_vtx->Fill(muonE.ecal_time - timecsc.timeAtIpInOut());
+        if (muonE.hadMax > 0.25)
+          hi_hcalcsc_vtx->Fill(muonE.hcal_time - timecsc.timeAtIpInOut());
       }
     }
-    
-    if (timec.nDof()>0) {
+
+    if (timec.nDof() > 0) {
       LogDebug("RecoMuonIdentification") << "    Combined nDof: " << timec.nDof();
-      LogDebug("RecoMuonIdentification") << "    Combined Time: " << timec.timeAtIpInOut() << " +/- " << timec.inverseBetaErr();
-      LogDebug("RecoMuonIdentification") << "   Combined FreeB: " << timec.freeInverseBeta() << " +/- " << timec.freeInverseBetaErr();
+      LogDebug("RecoMuonIdentification") << "    Combined Time: " << timec.timeAtIpInOut() << " +/- "
+                                         << timec.inverseBetaErr();
+      LogDebug("RecoMuonIdentification") << "   Combined FreeB: " << timec.freeInverseBeta() << " +/- "
+                                         << timec.freeInverseBetaErr();
 
       hi_cmbtime_ibt->Fill(timec.inverseBeta());
-      hi_cmbtime_ibt_pt->Fill(imuon->pt(),timec.inverseBeta());
+      hi_cmbtime_ibt_pt->Fill(imuon->pt(), timec.inverseBeta());
       hi_cmbtime_ibt_err->Fill(timec.inverseBetaErr());
       hi_cmbtime_fib->Fill(timec.freeInverseBeta());
       hi_cmbtime_fib_err->Fill(timec.freeInverseBetaErr());
@@ -317,133 +322,134 @@ MuonTimingValidator::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
       hi_cmbtime_vtxr->Fill(timec.timeAtIpOutIn());
       hi_cmbtime_vtxr_err->Fill(timec.timeAtIpOutInErr());
 
-      if (timec.inverseBetaErr()>0.)
-        hi_cmbtime_ibt_pull->Fill((timec.inverseBeta()-1.)/timec.inverseBetaErr());
-      if (timec.freeInverseBetaErr()>0.)    
-        hi_cmbtime_fib_pull->Fill((timec.freeInverseBeta()-1.)/timec.freeInverseBetaErr());
-      if (timec.timeAtIpInOutErr()>0.)
-        hi_cmbtime_vtx_pull->Fill(timec.timeAtIpInOut()/timec.timeAtIpInOutErr());
-      if (timec.timeAtIpOutInErr()>0.)
-        hi_cmbtime_vtxr_pull->Fill(timec.timeAtIpOutIn()/timec.timeAtIpOutInErr());
+      if (timec.inverseBetaErr() > 0.)
+        hi_cmbtime_ibt_pull->Fill((timec.inverseBeta() - 1.) / timec.inverseBetaErr());
+      if (timec.freeInverseBetaErr() > 0.)
+        hi_cmbtime_fib_pull->Fill((timec.freeInverseBeta() - 1.) / timec.freeInverseBetaErr());
+      if (timec.timeAtIpInOutErr() > 0.)
+        hi_cmbtime_vtx_pull->Fill(timec.timeAtIpInOut() / timec.timeAtIpInOutErr());
+      if (timec.timeAtIpOutInErr() > 0.)
+        hi_cmbtime_vtxr_pull->Fill(timec.timeAtIpOutIn() / timec.timeAtIpOutInErr());
     }
 
-    imucount++;    
-  }  
+    imucount++;
+  }
 }
 
-
 // ------------ method called once each job just before starting event loop  ------------
-void 
-MuonTimingValidator::beginJob()
-{
-   hFile = new TFile( out.c_str(), open.c_str() );
-   hFile->cd();
+void MuonTimingValidator::beginJob() {
+  hFile = new TFile(out.c_str(), open.c_str());
+  hFile->cd();
 
-   effStyle = new TStyle("effStyle","Efficiency Study Style");   
-   effStyle->SetCanvasBorderMode(0);
-   effStyle->SetPadBorderMode(1);
-   effStyle->SetOptTitle(0);
-   effStyle->SetStatFont(42);
-   effStyle->SetTitleFont(22);
-   effStyle->SetCanvasColor(10);
-   effStyle->SetPadColor(0);
-   effStyle->SetLabelFont(42,"x");
-   effStyle->SetLabelFont(42,"y");
-   effStyle->SetHistFillStyle(1001);
-   effStyle->SetHistFillColor(0);
-   effStyle->SetOptStat(0);
-   effStyle->SetOptFit(0111);
-   effStyle->SetStatH(0.05);
+  effStyle = new TStyle("effStyle", "Efficiency Study Style");
+  effStyle->SetCanvasBorderMode(0);
+  effStyle->SetPadBorderMode(1);
+  effStyle->SetOptTitle(0);
+  effStyle->SetStatFont(42);
+  effStyle->SetTitleFont(22);
+  effStyle->SetCanvasColor(10);
+  effStyle->SetPadColor(0);
+  effStyle->SetLabelFont(42, "x");
+  effStyle->SetLabelFont(42, "y");
+  effStyle->SetHistFillStyle(1001);
+  effStyle->SetHistFillColor(0);
+  effStyle->SetOptStat(0);
+  effStyle->SetOptFit(0111);
+  effStyle->SetStatH(0.05);
 
-   hi_sta_pt   = new TH1F("hi_sta_pt","P_{T}^{STA}",theNBins,0.0,theMaxPtres);
-   hi_tk_pt   = new TH1F("hi_tk_pt","P_{T}^{TK}",theNBins,0.0,theMaxPtres);
-   hi_glb_pt   = new TH1F("hi_glb_pt","P_{T}^{GLB}",theNBins,0.0,theMaxPtres);
+  hi_sta_pt = new TH1F("hi_sta_pt", "P_{T}^{STA}", theNBins, 0.0, theMaxPtres);
+  hi_tk_pt = new TH1F("hi_tk_pt", "P_{T}^{TK}", theNBins, 0.0, theMaxPtres);
+  hi_glb_pt = new TH1F("hi_glb_pt", "P_{T}^{GLB}", theNBins, 0.0, theMaxPtres);
 
-   hi_sta_phi = new TH1F("hi_sta_phi","#phi^{STA}",theNBins,-3.0,3.);
-   hi_tk_phi  = new TH1F("hi_tk_phi","#phi^{TK}",theNBins,-3.0,3.);
-   hi_glb_phi = new TH1F("hi_glb_phi","#phi^{GLB}",theNBins,-3.0,3.);
+  hi_sta_phi = new TH1F("hi_sta_phi", "#phi^{STA}", theNBins, -3.0, 3.);
+  hi_tk_phi = new TH1F("hi_tk_phi", "#phi^{TK}", theNBins, -3.0, 3.);
+  hi_glb_phi = new TH1F("hi_glb_phi", "#phi^{GLB}", theNBins, -3.0, 3.);
 
-   hi_mutime_vtx = new TH1F("hi_mutime_vtx","Time at Vertex (inout)",theNBins,-25.*theScale,25.*theScale);
-   hi_mutime_vtx_err = new TH1F("hi_mutime_vtx_err","Time at Vertex Error (inout)",theNBins,0.,25.0);
+  hi_mutime_vtx = new TH1F("hi_mutime_vtx", "Time at Vertex (inout)", theNBins, -25. * theScale, 25. * theScale);
+  hi_mutime_vtx_err = new TH1F("hi_mutime_vtx_err", "Time at Vertex Error (inout)", theNBins, 0., 25.0);
 
-   hi_dtcsc_vtx = new TH1F("hi_dtcsc_vtx","Time at Vertex (DT-CSC)",theNBins,-25.*theScale,25.*theScale);
-   hi_dtecal_vtx = new TH1F("hi_dtecal_vtx","Time at Vertex (DT-ECAL)",theNBins,-25.*theScale,25.*theScale);
-   hi_ecalcsc_vtx = new TH1F("hi_ecalcsc_vtx","Time at Vertex (ECAL-CSC)",theNBins,-25.*theScale,25.*theScale);
-   hi_dthcal_vtx = new TH1F("hi_dthcal_vtx","Time at Vertex (DT-HCAL)",theNBins,-25.*theScale,25.*theScale);
-   hi_hcalcsc_vtx = new TH1F("hi_hcalcsc_vtx","Time at Vertex (HCAL-CSC)",theNBins,-25.*theScale,25.*theScale);
-   hi_hcalecal_vtx = new TH1F("hi_hcalecal_vtx","Time at Vertex (HCAL-ECAL)",theNBins,-25.*theScale,25.*theScale);
+  hi_dtcsc_vtx = new TH1F("hi_dtcsc_vtx", "Time at Vertex (DT-CSC)", theNBins, -25. * theScale, 25. * theScale);
+  hi_dtecal_vtx = new TH1F("hi_dtecal_vtx", "Time at Vertex (DT-ECAL)", theNBins, -25. * theScale, 25. * theScale);
+  hi_ecalcsc_vtx = new TH1F("hi_ecalcsc_vtx", "Time at Vertex (ECAL-CSC)", theNBins, -25. * theScale, 25. * theScale);
+  hi_dthcal_vtx = new TH1F("hi_dthcal_vtx", "Time at Vertex (DT-HCAL)", theNBins, -25. * theScale, 25. * theScale);
+  hi_hcalcsc_vtx = new TH1F("hi_hcalcsc_vtx", "Time at Vertex (HCAL-CSC)", theNBins, -25. * theScale, 25. * theScale);
+  hi_hcalecal_vtx =
+      new TH1F("hi_hcalecal_vtx", "Time at Vertex (HCAL-ECAL)", theNBins, -25. * theScale, 25. * theScale);
 
-   hi_cmbtime_ibt = new TH1F("hi_cmbtime_ibt","Inverse Beta",theNBins,0.,1.6);
-   hi_cmbtime_ibt_pt = new TH2F("hi_cmbtime_ibt_pt","P{T} vs Inverse Beta",theNBins,0.0,theMaxPtres,theNBins,0.7,2.0);
-   hi_cmbtime_ibt_err = new TH1F("hi_cmbtime_ibt_err","Inverse Beta Error",theNBins,0.,1.0);
-   hi_cmbtime_fib = new TH1F("hi_cmbtime_fib","Free Inverse Beta",theNBins,-5.*theScale,7.*theScale);
-   hi_cmbtime_fib_err = new TH1F("hi_cmbtime_fib_err","Free Inverse Beta Error",theNBins,0,5.);
-   hi_cmbtime_vtx = new TH1F("hi_cmbtime_vtx","Time at Vertex (inout)",theNBins,-25.*theScale,25.*theScale);
-   hi_cmbtime_vtx_err = new TH1F("hi_cmbtime_vtx_err","Time at Vertex Error (inout)",theNBins,0.,25.0);
-   hi_cmbtime_vtxr = new TH1F("hi_cmbtime_vtxR","Time at Vertex (inout)",theNBins,0.,75.*theScale);
-   hi_cmbtime_vtxr_err = new TH1F("hi_cmbtime_vtxR_err","Time at Vertex Error (inout)",theNBins,0.,25.0);
-   hi_cmbtime_ibt_pull = new TH1F("hi_cmbtime_ibt_pull","Inverse Beta Pull",theNBins,-5.,5.0);
-   hi_cmbtime_fib_pull = new TH1F("hi_cmbtime_fib_pull","Free Inverse Beta Pull",theNBins,-5.,5.0);
-   hi_cmbtime_vtx_pull = new TH1F("hi_cmbtime_vtx_pull","Time at Vertex Pull (inout)",theNBins,-5.,5.0);
-   hi_cmbtime_vtxr_pull = new TH1F("hi_cmbtime_vtxR_pull","Time at Vertex Pull (inout)",theNBins,-5.,5.0);
+  hi_cmbtime_ibt = new TH1F("hi_cmbtime_ibt", "Inverse Beta", theNBins, 0., 1.6);
+  hi_cmbtime_ibt_pt =
+      new TH2F("hi_cmbtime_ibt_pt", "P{T} vs Inverse Beta", theNBins, 0.0, theMaxPtres, theNBins, 0.7, 2.0);
+  hi_cmbtime_ibt_err = new TH1F("hi_cmbtime_ibt_err", "Inverse Beta Error", theNBins, 0., 1.0);
+  hi_cmbtime_fib = new TH1F("hi_cmbtime_fib", "Free Inverse Beta", theNBins, -5. * theScale, 7. * theScale);
+  hi_cmbtime_fib_err = new TH1F("hi_cmbtime_fib_err", "Free Inverse Beta Error", theNBins, 0, 5.);
+  hi_cmbtime_vtx = new TH1F("hi_cmbtime_vtx", "Time at Vertex (inout)", theNBins, -25. * theScale, 25. * theScale);
+  hi_cmbtime_vtx_err = new TH1F("hi_cmbtime_vtx_err", "Time at Vertex Error (inout)", theNBins, 0., 25.0);
+  hi_cmbtime_vtxr = new TH1F("hi_cmbtime_vtxR", "Time at Vertex (inout)", theNBins, 0., 75. * theScale);
+  hi_cmbtime_vtxr_err = new TH1F("hi_cmbtime_vtxR_err", "Time at Vertex Error (inout)", theNBins, 0., 25.0);
+  hi_cmbtime_ibt_pull = new TH1F("hi_cmbtime_ibt_pull", "Inverse Beta Pull", theNBins, -5., 5.0);
+  hi_cmbtime_fib_pull = new TH1F("hi_cmbtime_fib_pull", "Free Inverse Beta Pull", theNBins, -5., 5.0);
+  hi_cmbtime_vtx_pull = new TH1F("hi_cmbtime_vtx_pull", "Time at Vertex Pull (inout)", theNBins, -5., 5.0);
+  hi_cmbtime_vtxr_pull = new TH1F("hi_cmbtime_vtxR_pull", "Time at Vertex Pull (inout)", theNBins, -5., 5.0);
 
-   hi_cmbtime_ndof = new TH1F("hi_cmbtime_ndof","Number of timing measurements",48,0.,48.0);
+  hi_cmbtime_ndof = new TH1F("hi_cmbtime_ndof", "Number of timing measurements", 48, 0., 48.0);
 
-   hi_dttime_ibt = new TH1F("hi_dttime_ibt","DT Inverse Beta",theNBins,0.,1.6);
-   hi_dttime_ibt_pt = new TH2F("hi_dttime_ibt_pt","P{T} vs DT Inverse Beta",theNBins,0.0,theMaxPtres,theNBins,0.7,2.0);
-   hi_dttime_ibt_err = new TH1F("hi_dttime_ibt_err","DT Inverse Beta Error",theNBins,0.,0.3);
-   hi_dttime_fib = new TH1F("hi_dttime_fib","DT Free Inverse Beta",theNBins,-5.*theScale,7.*theScale);
-   hi_dttime_fib_err = new TH1F("hi_dttime_fib_err","DT Free Inverse Beta Error",theNBins,0,5.);
-   hi_dttime_vtx = new TH1F("hi_dttime_vtx","DT Time at Vertex (inout)",theNBins,-25.*theScale,25.*theScale);
-   hi_dttime_vtx_err = new TH1F("hi_dttime_vtx_err","DT Time at Vertex Error (inout)",theNBins,0.,10.0);
-   hi_dttime_vtxr = new TH1F("hi_dttime_vtxR","DT Time at Vertex (inout)",theNBins,0.,75.*theScale);
-   hi_dttime_vtxr_err = new TH1F("hi_dttime_vtxR_err","DT Time at Vertex Error (inout)",theNBins,0.,10.0);
-   hi_dttime_ibt_pull = new TH1F("hi_dttime_ibt_pull","DT Inverse Beta Pull",theNBins,-5.,5.0);
-   hi_dttime_fib_pull = new TH1F("hi_dttime_fib_pull","DT Free Inverse Beta Pull",theNBins,-5.,5.0);
-   hi_dttime_vtx_pull = new TH1F("hi_dttime_vtx_pull","DT Time at Vertex Pull (inout)",theNBins,-5.,5.0);
-   hi_dttime_vtxr_pull = new TH1F("hi_dttime_vtxR_pull","DT Time at Vertex Pull (inout)",theNBins,-5.,5.0);
-   hi_dttime_errdiff = new TH1F("hi_dttime_errdiff","DT Time at Vertex inout-outin error difference",theNBins,-2.*theScale,2.*theScale);
+  hi_dttime_ibt = new TH1F("hi_dttime_ibt", "DT Inverse Beta", theNBins, 0., 1.6);
+  hi_dttime_ibt_pt =
+      new TH2F("hi_dttime_ibt_pt", "P{T} vs DT Inverse Beta", theNBins, 0.0, theMaxPtres, theNBins, 0.7, 2.0);
+  hi_dttime_ibt_err = new TH1F("hi_dttime_ibt_err", "DT Inverse Beta Error", theNBins, 0., 0.3);
+  hi_dttime_fib = new TH1F("hi_dttime_fib", "DT Free Inverse Beta", theNBins, -5. * theScale, 7. * theScale);
+  hi_dttime_fib_err = new TH1F("hi_dttime_fib_err", "DT Free Inverse Beta Error", theNBins, 0, 5.);
+  hi_dttime_vtx = new TH1F("hi_dttime_vtx", "DT Time at Vertex (inout)", theNBins, -25. * theScale, 25. * theScale);
+  hi_dttime_vtx_err = new TH1F("hi_dttime_vtx_err", "DT Time at Vertex Error (inout)", theNBins, 0., 10.0);
+  hi_dttime_vtxr = new TH1F("hi_dttime_vtxR", "DT Time at Vertex (inout)", theNBins, 0., 75. * theScale);
+  hi_dttime_vtxr_err = new TH1F("hi_dttime_vtxR_err", "DT Time at Vertex Error (inout)", theNBins, 0., 10.0);
+  hi_dttime_ibt_pull = new TH1F("hi_dttime_ibt_pull", "DT Inverse Beta Pull", theNBins, -5., 5.0);
+  hi_dttime_fib_pull = new TH1F("hi_dttime_fib_pull", "DT Free Inverse Beta Pull", theNBins, -5., 5.0);
+  hi_dttime_vtx_pull = new TH1F("hi_dttime_vtx_pull", "DT Time at Vertex Pull (inout)", theNBins, -5., 5.0);
+  hi_dttime_vtxr_pull = new TH1F("hi_dttime_vtxR_pull", "DT Time at Vertex Pull (inout)", theNBins, -5., 5.0);
+  hi_dttime_errdiff = new TH1F(
+      "hi_dttime_errdiff", "DT Time at Vertex inout-outin error difference", theNBins, -2. * theScale, 2. * theScale);
 
-   hi_dttime_ndof = new TH1F("hi_dttime_ndof","Number of DT timing measurements",48,0.,48.0);
+  hi_dttime_ndof = new TH1F("hi_dttime_ndof", "Number of DT timing measurements", 48, 0., 48.0);
 
-   hi_csctime_ibt = new TH1F("hi_csctime_ibt","CSC Inverse Beta",theNBins,0.,1.6);
-   hi_csctime_ibt_pt = new TH2F("hi_csctime_ibt_pt","P{T} vs CSC Inverse Beta",theNBins,0.0,theMaxPtres,theNBins,0.7,2.0);
-   hi_csctime_ibt_err = new TH1F("hi_csctime_ibt_err","CSC Inverse Beta Error",theNBins,0.,1.0);
-   hi_csctime_fib = new TH1F("hi_csctime_fib","CSC Free Inverse Beta",theNBins,-5.*theScale,7.*theScale);
-   hi_csctime_fib_err = new TH1F("hi_csctime_fib_err","CSC Free Inverse Beta Error",theNBins,0,5.);
-   hi_csctime_vtx = new TH1F("hi_csctime_vtx","CSC Time at Vertex (inout)",theNBins,-25.*theScale,25.*theScale);
-   hi_csctime_vtx_err = new TH1F("hi_csctime_vtx_err","CSC Time at Vertex Error (inout)",theNBins,0.,25.0);
-   hi_csctime_vtxr = new TH1F("hi_csctime_vtxR","CSC Time at Vertex (inout)",theNBins,0.,75.*theScale);
-   hi_csctime_vtxr_err = new TH1F("hi_csctime_vtxR_err","CSC Time at Vertex Error (inout)",theNBins,0.,25.0);
-   hi_csctime_ibt_pull = new TH1F("hi_csctime_ibt_pull","CSC Inverse Beta Pull",theNBins,-5.,5.0);
-   hi_csctime_fib_pull = new TH1F("hi_csctime_fib_pull","CSC Free Inverse Beta Pull",theNBins,-5.,5.0);
-   hi_csctime_vtx_pull = new TH1F("hi_csctime_vtx_pull","CSC Time at Vertex Pull (inout)",theNBins,-5.,5.0);
-   hi_csctime_vtxr_pull = new TH1F("hi_csctime_vtxR_pull","CSC Time at Vertex Pull (inout)",theNBins,-5.,5.0);
+  hi_csctime_ibt = new TH1F("hi_csctime_ibt", "CSC Inverse Beta", theNBins, 0., 1.6);
+  hi_csctime_ibt_pt =
+      new TH2F("hi_csctime_ibt_pt", "P{T} vs CSC Inverse Beta", theNBins, 0.0, theMaxPtres, theNBins, 0.7, 2.0);
+  hi_csctime_ibt_err = new TH1F("hi_csctime_ibt_err", "CSC Inverse Beta Error", theNBins, 0., 1.0);
+  hi_csctime_fib = new TH1F("hi_csctime_fib", "CSC Free Inverse Beta", theNBins, -5. * theScale, 7. * theScale);
+  hi_csctime_fib_err = new TH1F("hi_csctime_fib_err", "CSC Free Inverse Beta Error", theNBins, 0, 5.);
+  hi_csctime_vtx = new TH1F("hi_csctime_vtx", "CSC Time at Vertex (inout)", theNBins, -25. * theScale, 25. * theScale);
+  hi_csctime_vtx_err = new TH1F("hi_csctime_vtx_err", "CSC Time at Vertex Error (inout)", theNBins, 0., 25.0);
+  hi_csctime_vtxr = new TH1F("hi_csctime_vtxR", "CSC Time at Vertex (inout)", theNBins, 0., 75. * theScale);
+  hi_csctime_vtxr_err = new TH1F("hi_csctime_vtxR_err", "CSC Time at Vertex Error (inout)", theNBins, 0., 25.0);
+  hi_csctime_ibt_pull = new TH1F("hi_csctime_ibt_pull", "CSC Inverse Beta Pull", theNBins, -5., 5.0);
+  hi_csctime_fib_pull = new TH1F("hi_csctime_fib_pull", "CSC Free Inverse Beta Pull", theNBins, -5., 5.0);
+  hi_csctime_vtx_pull = new TH1F("hi_csctime_vtx_pull", "CSC Time at Vertex Pull (inout)", theNBins, -5., 5.0);
+  hi_csctime_vtxr_pull = new TH1F("hi_csctime_vtxR_pull", "CSC Time at Vertex Pull (inout)", theNBins, -5., 5.0);
 
-   hi_csctime_ndof = new TH1F("hi_csctime_ndof","Number of CSC timing measurements",48,0.,48.0);
+  hi_csctime_ndof = new TH1F("hi_csctime_ndof", "Number of CSC timing measurements", 48, 0., 48.0);
 
-   hi_ecal_time = new TH1F("hi_ecal_time","ECAL Time at Vertex (inout)",theNBins,-40.*theScale,40.*theScale);
-   hi_ecal_time_err = new TH1F("hi_ecal_time_err","ECAL Time at Vertex Error",theNBins,0.,20.0);
-   hi_ecal_time_pull = new TH1F("hi_ecal_time_pull","ECAL Time at Vertex Pull",theNBins,-7.0,7.0);
-   hi_ecal_time_ecut = new TH1F("hi_ecal_time_ecut","ECAL Time at Vertex (inout) after energy cut",theNBins,-20.*theScale,20.*theScale);
-   hi_ecal_energy = new TH1F("hi_ecal_energy","ECAL max energy in 5x5 crystals",theNBins,.0,5.0);
+  hi_ecal_time = new TH1F("hi_ecal_time", "ECAL Time at Vertex (inout)", theNBins, -40. * theScale, 40. * theScale);
+  hi_ecal_time_err = new TH1F("hi_ecal_time_err", "ECAL Time at Vertex Error", theNBins, 0., 20.0);
+  hi_ecal_time_pull = new TH1F("hi_ecal_time_pull", "ECAL Time at Vertex Pull", theNBins, -7.0, 7.0);
+  hi_ecal_time_ecut = new TH1F(
+      "hi_ecal_time_ecut", "ECAL Time at Vertex (inout) after energy cut", theNBins, -20. * theScale, 20. * theScale);
+  hi_ecal_energy = new TH1F("hi_ecal_energy", "ECAL max energy in 5x5 crystals", theNBins, .0, 5.0);
 
-   hi_hcal_time = new TH1F("hi_hcal_time","HCAL Time at Vertex (inout)",theNBins,-40.*theScale,40.*theScale);
-   hi_hcal_time_err = new TH1F("hi_hcal_time_err","HCAL Time at Vertex Error",theNBins,0.,20.0);
-   hi_hcal_time_pull = new TH1F("hi_hcal_time_pull","HCAL Time at Vertex Pull",theNBins,-7.0,7.0);
-   hi_hcal_time_ecut = new TH1F("hi_hcal_time_ecut","HCAL Time at Vertex (inout) after energy cut",theNBins,-20.*theScale,20.*theScale);
-   hi_hcal_energy = new TH1F("hi_hcal_energy","HCAL max energy in 5x5 crystals",theNBins,.0,5.0);
+  hi_hcal_time = new TH1F("hi_hcal_time", "HCAL Time at Vertex (inout)", theNBins, -40. * theScale, 40. * theScale);
+  hi_hcal_time_err = new TH1F("hi_hcal_time_err", "HCAL Time at Vertex Error", theNBins, 0., 20.0);
+  hi_hcal_time_pull = new TH1F("hi_hcal_time_pull", "HCAL Time at Vertex Pull", theNBins, -7.0, 7.0);
+  hi_hcal_time_ecut = new TH1F(
+      "hi_hcal_time_ecut", "HCAL Time at Vertex (inout) after energy cut", theNBins, -20. * theScale, 20. * theScale);
+  hi_hcal_energy = new TH1F("hi_hcal_energy", "HCAL max energy in 5x5 crystals", theNBins, .0, 5.0);
 
-   hi_sta_eta = new TH1F("hi_sta_eta","#eta^{STA}",theNBins/2,theMinEta,theMaxEta);
-   hi_tk_eta  = new TH1F("hi_tk_eta","#eta^{TK}",theNBins/2,theMinEta,theMaxEta);
-   hi_glb_eta = new TH1F("hi_glb_eta","#eta^{GLB}",theNBins/2,theMinEta,theMaxEta);
-
+  hi_sta_eta = new TH1F("hi_sta_eta", "#eta^{STA}", theNBins / 2, theMinEta, theMaxEta);
+  hi_tk_eta = new TH1F("hi_tk_eta", "#eta^{TK}", theNBins / 2, theMinEta, theMaxEta);
+  hi_glb_eta = new TH1F("hi_glb_eta", "#eta^{GLB}", theNBins / 2, theMinEta, theMaxEta);
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
-MuonTimingValidator::endJob() {
-
+void MuonTimingValidator::endJob() {
   hFile->cd();
 
   gROOT->SetStyle("effStyle");
@@ -554,11 +560,10 @@ MuonTimingValidator::endJob() {
   hFile->Write();
 }
 
-float 
-MuonTimingValidator::calculateDistance(const math::XYZVector& vect1, const math::XYZVector& vect2) {
+float MuonTimingValidator::calculateDistance(const math::XYZVector& vect1, const math::XYZVector& vect2) {
   float dEta = vect1.eta() - vect2.eta();
   float dPhi = fabs(Geom::Phi<float>(vect1.phi()) - Geom::Phi<float>(vect2.phi()));
-  float distance = sqrt(pow(dEta,2) + pow(dPhi,2) );
+  float distance = sqrt(pow(dEta, 2) + pow(dPhi, 2));
 
   return distance;
 }
@@ -567,17 +572,18 @@ MuonTimingValidator::calculateDistance(const math::XYZVector& vect1, const math:
 // return h1/h2 with recalculated errors
 //
 TH1F* MuonTimingValidator::divideErr(TH1F* h1, TH1F* h2, TH1F* hout) {
-
   hout->Reset();
-  hout->Divide(h1,h2,1.,1.,"B");
+  hout->Divide(h1, h2, 1., 1., "B");
 
-  for (int i = 0; i <= hout->GetNbinsX()+1; i++ ) {
-    Float_t tot   = h2->GetBinContent(i) ;
+  for (int i = 0; i <= hout->GetNbinsX() + 1; i++) {
+    Float_t tot = h2->GetBinContent(i);
     Float_t tot_e = h2->GetBinError(i);
-    Float_t eff = hout->GetBinContent(i) ;
+    Float_t eff = hout->GetBinContent(i);
     Float_t Err = 0.;
-    if (tot > 0) Err = tot_e / tot * sqrt( eff* (1-eff) );
-    if (eff == 1. || edm::isNotFinite(Err)) Err=1.e-3;
+    if (tot > 0)
+      Err = tot_e / tot * sqrt(eff * (1 - eff));
+    if (eff == 1. || edm::isNotFinite(Err))
+      Err = 1.e-3;
     hout->SetBinError(i, Err);
   }
   return hout;

--- a/RecoMuon/MuonIdentification/test/MuonTimingValidator.h
+++ b/RecoMuon/MuonIdentification/test/MuonTimingValidator.h
@@ -35,7 +35,7 @@ namespace edm {
   //  class Event;
   class EventSetup;
   class InputTag;
-}
+}  // namespace edm
 
 class TFile;
 class TH1F;
@@ -49,36 +49,35 @@ class MuonTimingValidator : public edm::EDAnalyzer {
 public:
   explicit MuonTimingValidator(const edm::ParameterSet&);
   ~MuonTimingValidator();
-  
-  typedef std::pair< reco::TrackRef, SimTrackRef> CandToSim;
-  typedef std::pair< reco::TrackRef, SimTrackRef> CandStaSim;
-  typedef std::pair< reco::TrackRef, SimTrackRef> CandMuonSim;
-  
+
+  typedef std::pair<reco::TrackRef, SimTrackRef> CandToSim;
+  typedef std::pair<reco::TrackRef, SimTrackRef> CandStaSim;
+  typedef std::pair<reco::TrackRef, SimTrackRef> CandMuonSim;
+
 private:
-  virtual void beginJob() ;
+  virtual void beginJob();
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  virtual void endJob();
 
   virtual float calculateDistance(const math::XYZVector&, const math::XYZVector&);
   virtual TH1F* divideErr(TH1F*, TH1F*, TH1F*);
 
-
   // ----------member data ---------------------------
 
-  edm::InputTag TKtrackTags_; 
+  edm::InputTag TKtrackTags_;
   edm::EDGetTokenT<reco::TrackCollection> TKtrackTokens_;
-  edm::InputTag MuonTags_; 
+  edm::InputTag MuonTags_;
   edm::EDGetTokenT<reco::MuonCollection> MuonTokens_;
-  edm::InputTag CombinedTimeTags_; 
+  edm::InputTag CombinedTimeTags_;
   edm::EDGetTokenT<reco::MuonTimeExtraMap> CombinedTimeTokens_;
-  edm::InputTag DtTimeTags_; 
+  edm::InputTag DtTimeTags_;
   edm::EDGetTokenT<reco::MuonTimeExtraMap> DtTimeTokens_;
-  edm::InputTag CscTimeTags_; 
+  edm::InputTag CscTimeTags_;
   edm::EDGetTokenT<reco::MuonTimeExtraMap> CscTimeTokens_;
-  edm::InputTag SIMtrackTags_; 
+  edm::InputTag SIMtrackTags_;
 
   std::string out, open;
-  double  theMinEta, theMaxEta, theMinPt, thePtCut, theMinPtres, theMaxPtres, theScale;
+  double theMinEta, theMaxEta, theMinPt, thePtCut, theMinPtres, theMaxPtres, theScale;
   int theDtCut, theCscCut;
   int theNBins;
 
@@ -96,17 +95,17 @@ private:
   edm::Handle<reco::MuonTimeExtraMap> timeMap1;
   edm::Handle<reco::MuonTimeExtraMap> timeMap2;
   edm::Handle<reco::MuonTimeExtraMap> timeMap3;
-  
+
   //ROOT Pointers
   TFile* hFile;
   TStyle* effStyle;
 
-  TH1F* hi_sta_pt  ;
-  TH1F* hi_tk_pt   ;
-  TH1F* hi_glb_pt  ;
-  TH1F* hi_sta_phi ;
-  TH1F* hi_tk_phi  ;
-  TH1F* hi_glb_phi ;
+  TH1F* hi_sta_pt;
+  TH1F* hi_tk_pt;
+  TH1F* hi_glb_pt;
+  TH1F* hi_sta_phi;
+  TH1F* hi_tk_phi;
+  TH1F* hi_glb_phi;
 
   TH1F* hi_mutime_vtx;
   TH1F* hi_mutime_vtx_err;
@@ -176,9 +175,8 @@ private:
   TH1F* hi_hcal_time_ecut;
   TH1F* hi_hcal_energy;
 
-  TH1F* hi_tk_eta  ;
-  TH1F* hi_sta_eta  ;
-  TH1F* hi_glb_eta  ;
-
+  TH1F* hi_tk_eta;
+  TH1F* hi_sta_eta;
+  TH1F* hi_glb_eta;
 };
 #endif

--- a/RecoMuon/MuonIdentification/test/RPCMuonAnalyzer.cc
+++ b/RecoMuon/MuonIdentification/test/RPCMuonAnalyzer.cc
@@ -30,15 +30,14 @@ using namespace std;
 using namespace edm;
 using namespace reco;
 
-class RPCMuonAnalyzer : public edm::EDAnalyzer 
-{
+class RPCMuonAnalyzer : public edm::EDAnalyzer {
 public:
   RPCMuonAnalyzer(const edm::ParameterSet& pset);
-  ~RPCMuonAnalyzer() {};
+  ~RPCMuonAnalyzer(){};
 
   void analyze(const edm::Event& event, const edm::EventSetup& eventSetup);
-  void beginJob() {};
-  void endJob() {};
+  void beginJob(){};
+  void endJob(){};
 
 private:
   edm::InputTag muonLabel_;
@@ -69,42 +68,50 @@ private:
   TH2F* hIdCorrelationE_;
 };
 
-RPCMuonAnalyzer::RPCMuonAnalyzer(const edm::ParameterSet& pset)
-{
+RPCMuonAnalyzer::RPCMuonAnalyzer(const edm::ParameterSet& pset) {
   muonLabel_ = pset.getUntrackedParameter<edm::InputTag>("muon");
-  minPtTrk_  = pset.getUntrackedParameter<double>("minPtTrk");
+  minPtTrk_ = pset.getUntrackedParameter<double>("minPtTrk");
   maxEtaTrk_ = pset.getUntrackedParameter<double>("maxEtaTrk");
 
   edm::Service<TFileService> fs;
 
-  hNMuon_          = fs->make<TH1F>("hNMuon", "Number of muons;Number of muons", 10, 0, 10);
-  hNRPCMuon_       = fs->make<TH1F>("hNRPCMuon", "Number of RPC muons;Number of muons", 10, 0, 10);
-  hNRPCMuTight_    = fs->make<TH1F>("hNRPCMuTight", "Number of RPCMuTight;Number of muons", 10, 0, 10);
-  hNTrkMuTight_    = fs->make<TH1F>("hNTrkMuTight", "Number of TrkMuTight muons;Number of muons", 10, 0, 10);
-  hNTrkMuTight2_   = fs->make<TH1F>("hNTrkMuTight2", "Number of TrkMuTight muons;Number of muons", 10, 0, 10);
-  hNGlbMuTight_    = fs->make<TH1F>("hNGlbMuTight", "Number of GlobalMuPromptTight muons;Number of muons", 10, 0, 10);
-  hNGlbMuTight2_   = fs->make<TH1F>("hNGlbMuTight2", "Number of GlobalMuPromptTight muons;Number of muons", 10, 0, 10);
-  hNGlbMuTighter_  = fs->make<TH1F>("hNGlbMuTighter", "Number of GlobalMuPromptTight muons;Number of muons", 10, 0, 10);
-  hNGlbMuTighter2_ = fs->make<TH1F>("hNGlbMuTighter2", "Number of GlobalMuPromptTight muons;Number of muons", 10, 0, 10);
+  hNMuon_ = fs->make<TH1F>("hNMuon", "Number of muons;Number of muons", 10, 0, 10);
+  hNRPCMuon_ = fs->make<TH1F>("hNRPCMuon", "Number of RPC muons;Number of muons", 10, 0, 10);
+  hNRPCMuTight_ = fs->make<TH1F>("hNRPCMuTight", "Number of RPCMuTight;Number of muons", 10, 0, 10);
+  hNTrkMuTight_ = fs->make<TH1F>("hNTrkMuTight", "Number of TrkMuTight muons;Number of muons", 10, 0, 10);
+  hNTrkMuTight2_ = fs->make<TH1F>("hNTrkMuTight2", "Number of TrkMuTight muons;Number of muons", 10, 0, 10);
+  hNGlbMuTight_ = fs->make<TH1F>("hNGlbMuTight", "Number of GlobalMuPromptTight muons;Number of muons", 10, 0, 10);
+  hNGlbMuTight2_ = fs->make<TH1F>("hNGlbMuTight2", "Number of GlobalMuPromptTight muons;Number of muons", 10, 0, 10);
+  hNGlbMuTighter_ = fs->make<TH1F>("hNGlbMuTighter", "Number of GlobalMuPromptTight muons;Number of muons", 10, 0, 10);
+  hNGlbMuTighter2_ =
+      fs->make<TH1F>("hNGlbMuTighter2", "Number of GlobalMuPromptTight muons;Number of muons", 10, 0, 10);
 
-  const char* idNames[] = {
-    "All", "AllGlbMu", "AllStaMu", "AllTrkMu", "AllRPCMu", "RPCMuTight", "TMOneStationTight", "TMOneStationTight+", "GlbPromptTight", "GlbPromptTight+", "GlbPromptTighter", "GlbPromptTighter+"
-  };
-  const int nId = sizeof(idNames)/sizeof(const char*);
+  const char* idNames[] = {"All",
+                           "AllGlbMu",
+                           "AllStaMu",
+                           "AllTrkMu",
+                           "AllRPCMu",
+                           "RPCMuTight",
+                           "TMOneStationTight",
+                           "TMOneStationTight+",
+                           "GlbPromptTight",
+                           "GlbPromptTight+",
+                           "GlbPromptTighter",
+                           "GlbPromptTighter+"};
+  const int nId = sizeof(idNames) / sizeof(const char*);
   hIdCorrelation_ = fs->make<TH2F>("hIdCorrelation", "ID correlation", nId, 0, nId, nId, 0, nId);
   hIdCorrelationB_ = fs->make<TH2F>("hIdCorrelationBarrel", "ID correlation (Barrel)", nId, 0, nId, nId, 0, nId);
   hIdCorrelationO_ = fs->make<TH2F>("hIdCorrelationOverlap", "ID correlation (Overlap)", nId, 0, nId, nId, 0, nId);
   hIdCorrelationE_ = fs->make<TH2F>("hIdCorrelationEndcap", "ID correlation (Endcap)", nId, 0, nId, nId, 0, nId);
-  for ( int i=0; i<nId; ++i )
-  {
-    hIdCorrelation_->GetXaxis()->SetBinLabel(i+1, idNames[i]);
-    hIdCorrelation_->GetYaxis()->SetBinLabel(i+1, idNames[i]);
-    hIdCorrelationB_->GetXaxis()->SetBinLabel(i+1, idNames[i]);
-    hIdCorrelationB_->GetYaxis()->SetBinLabel(i+1, idNames[i]);
-    hIdCorrelationO_->GetXaxis()->SetBinLabel(i+1, idNames[i]);
-    hIdCorrelationO_->GetYaxis()->SetBinLabel(i+1, idNames[i]);
-    hIdCorrelationE_->GetXaxis()->SetBinLabel(i+1, idNames[i]);
-    hIdCorrelationE_->GetYaxis()->SetBinLabel(i+1, idNames[i]);
+  for (int i = 0; i < nId; ++i) {
+    hIdCorrelation_->GetXaxis()->SetBinLabel(i + 1, idNames[i]);
+    hIdCorrelation_->GetYaxis()->SetBinLabel(i + 1, idNames[i]);
+    hIdCorrelationB_->GetXaxis()->SetBinLabel(i + 1, idNames[i]);
+    hIdCorrelationB_->GetYaxis()->SetBinLabel(i + 1, idNames[i]);
+    hIdCorrelationO_->GetXaxis()->SetBinLabel(i + 1, idNames[i]);
+    hIdCorrelationO_->GetYaxis()->SetBinLabel(i + 1, idNames[i]);
+    hIdCorrelationE_->GetXaxis()->SetBinLabel(i + 1, idNames[i]);
+    hIdCorrelationE_->GetYaxis()->SetBinLabel(i + 1, idNames[i]);
   }
   hIdCorrelation_->SetOption("COLZ");
   hIdCorrelationB_->SetOption("COLZ");
@@ -112,69 +119,90 @@ RPCMuonAnalyzer::RPCMuonAnalyzer(const edm::ParameterSet& pset)
   hIdCorrelationE_->SetOption("COLZ");
 }
 
-void RPCMuonAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& eventSetup)
-{
-
+void RPCMuonAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& eventSetup) {
   // select the event
-  runNumber   = event.id().run();
+  runNumber = event.id().run();
   eventNumber = event.id().event();
 
   edm::Handle<edm::View<reco::Muon> > muonHandle;
   event.getByLabel(muonLabel_, muonHandle);
-  
+
   //nMuon = muonHandle->size();
   nMuon = 0;
   nGlbMuon = 0, nStaMuon = 0, nTrkMuon = 0;
   nRPCMuon = 0, nRPCMuTight = 0;
   nTrkMuTight = 0, nTrkMuTight2 = 0;
   nGlbMuTight = 0, nGlbMuTight2 = 0, nGlbMuTighter = 0, nGlbMuTighter2 = 0;
-  for ( edm::View<reco::Muon>::const_iterator muon = muonHandle->begin();
-        muon != muonHandle->end(); ++muon )
-  {
-
-    if ( muon->pt() < minPtTrk_ ) continue; 
+  for (edm::View<reco::Muon>::const_iterator muon = muonHandle->begin(); muon != muonHandle->end(); ++muon) {
+    if (muon->pt() < minPtTrk_)
+      continue;
     const double abseta = abs(muon->eta());
-    if ( abseta > maxEtaTrk_ ) continue;
+    if (abseta > maxEtaTrk_)
+      continue;
 
-    const bool idFlags[] = {
-      true,
-      muon->isGlobalMuon(), muon->isStandAloneMuon(), muon->isTrackerMuon(),
-      muon->isRPCMuon(),
-      muon::isGoodMuon(*muon, muon::RPCMuLoose) && muon->numberOfMatchedStations(reco::Muon::RPCHitAndTrackArbitration)>1 && muon->numberOfMatchedRPCLayers(reco::Muon::RPCHitAndTrackArbitration)>2,
-      muon::isGoodMuon(*muon, muon::TMOneStationTight),
-      muon::isGoodMuon(*muon, muon::TMOneStationTight) || (muon::isGoodMuon(*muon, muon::RPCMuLoose) && muon->numberOfMatchedStations(reco::Muon::RPCHitAndTrackArbitration)>1 && muon->numberOfMatchedRPCLayers(reco::Muon::RPCHitAndTrackArbitration)>2),
-      muon::isGoodMuon(*muon, muon::GlobalMuonPromptTight),
-      muon::isGoodMuon(*muon, muon::GlobalMuonPromptTight) || (muon::isGoodMuon(*muon, muon::RPCMuLoose) && muon->numberOfMatchedStations(reco::Muon::RPCHitAndTrackArbitration)>1 && muon->numberOfMatchedRPCLayers(reco::Muon::RPCHitAndTrackArbitration)>2),
-      muon::isGoodMuon(*muon, muon::GlobalMuonPromptTight) && muon->numberOfMatchedStations(reco::Muon::SegmentAndTrackArbitration)>1,
-      (muon::isGoodMuon(*muon, muon::GlobalMuonPromptTight) && muon->numberOfMatchedStations(reco::Muon::SegmentAndTrackArbitration)>1) || (muon::isGoodMuon(*muon, muon::RPCMuLoose) && muon->numberOfMatchedStations(reco::Muon::RPCHitAndTrackArbitration)>1 && muon->numberOfMatchedRPCLayers(reco::Muon::RPCHitAndTrackArbitration)>2)
-    };
+    const bool idFlags[] = {true,
+                            muon->isGlobalMuon(),
+                            muon->isStandAloneMuon(),
+                            muon->isTrackerMuon(),
+                            muon->isRPCMuon(),
+                            muon::isGoodMuon(*muon, muon::RPCMuLoose) &&
+                                muon->numberOfMatchedStations(reco::Muon::RPCHitAndTrackArbitration) > 1 &&
+                                muon->numberOfMatchedRPCLayers(reco::Muon::RPCHitAndTrackArbitration) > 2,
+                            muon::isGoodMuon(*muon, muon::TMOneStationTight),
+                            muon::isGoodMuon(*muon, muon::TMOneStationTight) ||
+                                (muon::isGoodMuon(*muon, muon::RPCMuLoose) &&
+                                 muon->numberOfMatchedStations(reco::Muon::RPCHitAndTrackArbitration) > 1 &&
+                                 muon->numberOfMatchedRPCLayers(reco::Muon::RPCHitAndTrackArbitration) > 2),
+                            muon::isGoodMuon(*muon, muon::GlobalMuonPromptTight),
+                            muon::isGoodMuon(*muon, muon::GlobalMuonPromptTight) ||
+                                (muon::isGoodMuon(*muon, muon::RPCMuLoose) &&
+                                 muon->numberOfMatchedStations(reco::Muon::RPCHitAndTrackArbitration) > 1 &&
+                                 muon->numberOfMatchedRPCLayers(reco::Muon::RPCHitAndTrackArbitration) > 2),
+                            muon::isGoodMuon(*muon, muon::GlobalMuonPromptTight) &&
+                                muon->numberOfMatchedStations(reco::Muon::SegmentAndTrackArbitration) > 1,
+                            (muon::isGoodMuon(*muon, muon::GlobalMuonPromptTight) &&
+                             muon->numberOfMatchedStations(reco::Muon::SegmentAndTrackArbitration) > 1) ||
+                                (muon::isGoodMuon(*muon, muon::RPCMuLoose) &&
+                                 muon->numberOfMatchedStations(reco::Muon::RPCHitAndTrackArbitration) > 1 &&
+                                 muon->numberOfMatchedRPCLayers(reco::Muon::RPCHitAndTrackArbitration) > 2)};
 
     ++nMuon;
-    if ( idFlags[1] ) ++nGlbMuon;
-    if ( idFlags[2] ) ++nStaMuon;
-    if ( idFlags[3] ) ++nTrkMuon;
+    if (idFlags[1])
+      ++nGlbMuon;
+    if (idFlags[2])
+      ++nStaMuon;
+    if (idFlags[3])
+      ++nTrkMuon;
 
-    if ( idFlags[4] ) ++nRPCMuon;
-    if ( idFlags[5] ) ++nRPCMuTight;
-    if ( idFlags[6] ) ++nTrkMuTight;
-    if ( idFlags[7] ) ++nTrkMuTight2;
+    if (idFlags[4])
+      ++nRPCMuon;
+    if (idFlags[5])
+      ++nRPCMuTight;
+    if (idFlags[6])
+      ++nTrkMuTight;
+    if (idFlags[7])
+      ++nTrkMuTight2;
 
-    if ( idFlags[8] ) ++nGlbMuTight;
-    if ( idFlags[9] ) ++nGlbMuTight2;
-    if ( idFlags[10] ) ++nGlbMuTighter;
-    if ( idFlags[11] ) ++nGlbMuTighter2;
+    if (idFlags[8])
+      ++nGlbMuTight;
+    if (idFlags[9])
+      ++nGlbMuTight2;
+    if (idFlags[10])
+      ++nGlbMuTighter;
+    if (idFlags[11])
+      ++nGlbMuTighter2;
 
     // Fill correlation matrix
-    for ( int i=0, n=sizeof(idFlags)/sizeof(const bool); i<n; ++i )
-    {
-      for ( int j=i; j<n; ++j )
-      {
-        if ( idFlags[i] and idFlags[j] )
-        {
-          hIdCorrelation_->Fill(i,j);
-          if ( abseta < 0.8 ) hIdCorrelationB_->Fill(i,j);
-          else if ( abseta < 1.2 ) hIdCorrelationO_->Fill(i,j);
-          else hIdCorrelationE_->Fill(i,j);
+    for (int i = 0, n = sizeof(idFlags) / sizeof(const bool); i < n; ++i) {
+      for (int j = i; j < n; ++j) {
+        if (idFlags[i] and idFlags[j]) {
+          hIdCorrelation_->Fill(i, j);
+          if (abseta < 0.8)
+            hIdCorrelationB_->Fill(i, j);
+          else if (abseta < 1.2)
+            hIdCorrelationO_->Fill(i, j);
+          else
+            hIdCorrelationE_->Fill(i, j);
         }
       }
     }
@@ -189,7 +217,6 @@ void RPCMuonAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& ev
   hNGlbMuTight2_->Fill(nGlbMuTight2);
   hNGlbMuTighter_->Fill(nGlbMuTighter);
   hNGlbMuTighter2_->Fill(nGlbMuTighter2);
-
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoMuon/MuonIdentification/test/TestMuons.cc
+++ b/RecoMuon/MuonIdentification/test/TestMuons.cc
@@ -9,7 +9,6 @@
  *  \author Dmytro Kovalskyi, R. Bellan - UCSB <riccardo.bellan@cern.ch> 
  */
 
-
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -27,133 +26,113 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 
 class TestMuons : public edm::EDAnalyzer {
- public:
-   explicit TestMuons(const edm::ParameterSet&);
-   virtual ~TestMuons(){}
-   
-  virtual void analyze (const edm::Event&, const edm::EventSetup&);
-  void printMuonCollections(const edm::Handle<edm::View<reco::Muon> > &muons);
-  void checkTimeMaps(const edm::Event& iEvent, const edm::Handle<reco::MuonCollection> &muons);
-  void checkPFMap(const edm::Event& iEvent, const edm::Handle<reco::MuonCollection> &muons);
- private:
-  edm::InputTag theInput;
+public:
+  explicit TestMuons(const edm::ParameterSet&);
+  virtual ~TestMuons() {}
 
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  void printMuonCollections(const edm::Handle<edm::View<reco::Muon> >& muons);
+  void checkTimeMaps(const edm::Event& iEvent, const edm::Handle<reco::MuonCollection>& muons);
+  void checkPFMap(const edm::Event& iEvent, const edm::Handle<reco::MuonCollection>& muons);
+
+private:
+  edm::InputTag theInput;
 };
 #endif
 
-TestMuons::TestMuons(const edm::ParameterSet& iConfig){
-
+TestMuons::TestMuons(const edm::ParameterSet& iConfig) {
   theInput = iConfig.getParameter<edm::InputTag>("InputCollection");
-
 }
 
-void TestMuons::analyze( const edm::Event& iEvent, const edm::EventSetup& iSetup){
-
+void TestMuons::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<edm::View<reco::Muon> > muonsV;
-  iEvent.getByLabel(theInput, muonsV);   
+  iEvent.getByLabel(theInput, muonsV);
   printMuonCollections(muonsV);
- 
+
   edm::Handle<reco::MuonCollection> muons;
   iEvent.getByLabel(theInput, muons);
-  
-  checkTimeMaps(iEvent,muons);
-  checkPFMap(iEvent,muons);
+
+  checkTimeMaps(iEvent, muons);
+  checkPFMap(iEvent, muons);
 }
 
-void TestMuons::checkTimeMaps(const edm::Event& iEvent, const edm::Handle<reco::MuonCollection> &muons){
-
-  std::cout << "checkTimeMaps"  <<std::endl;
+void TestMuons::checkTimeMaps(const edm::Event& iEvent, const edm::Handle<reco::MuonCollection>& muons) {
+  std::cout << "checkTimeMaps" << std::endl;
 
   edm::Handle<reco::MuonTimeExtraMap> timeMapCmb;
   edm::Handle<reco::MuonTimeExtraMap> timeMapDT;
   edm::Handle<reco::MuonTimeExtraMap> timeMapCSC;
 
-  iEvent.getByLabel(theInput.label(),"combined",timeMapCmb);
-  iEvent.getByLabel(theInput.label(),"dt",timeMapDT);
-  iEvent.getByLabel(theInput.label(),"csc",timeMapCSC);
-  
-  for(unsigned int imucount=0; imucount < muons->size(); ++imucount){
-    reco::MuonRef muonR(muons,imucount);
-    std::cout  << "Ref: " << muonR.id() << " " << muonR.key()
-	       << " Time CMB " <<  (*timeMapCmb)[muonR].timeAtIpInOut()
-	       << " time DT "  <<  (*timeMapDT)[muonR].timeAtIpInOut()
-	       << " time CSC " <<  (*timeMapCSC)[muonR].timeAtIpInOut() << std::endl;
+  iEvent.getByLabel(theInput.label(), "combined", timeMapCmb);
+  iEvent.getByLabel(theInput.label(), "dt", timeMapDT);
+  iEvent.getByLabel(theInput.label(), "csc", timeMapCSC);
+
+  for (unsigned int imucount = 0; imucount < muons->size(); ++imucount) {
+    reco::MuonRef muonR(muons, imucount);
+    std::cout << "Ref: " << muonR.id() << " " << muonR.key() << " Time CMB " << (*timeMapCmb)[muonR].timeAtIpInOut()
+              << " time DT " << (*timeMapDT)[muonR].timeAtIpInOut() << " time CSC "
+              << (*timeMapCSC)[muonR].timeAtIpInOut() << std::endl;
   }
 }
 
-
-
-
-
-void TestMuons::printMuonCollections(const edm::Handle<edm::View<reco::Muon> > &muons){
-  
-
-  for(edm::View<reco::Muon>::const_iterator muon = muons->begin(); muon != muons->end(); ++muon){
+void TestMuons::printMuonCollections(const edm::Handle<edm::View<reco::Muon> >& muons) {
+  for (edm::View<reco::Muon>::const_iterator muon = muons->begin(); muon != muons->end(); ++muon) {
     std::cout << "\n----------------------------------------------------" << std::endl;
     std::cout << "Muon (pt,eta,phi): " << muon->pt() << ", " << muon->eta() << ", " << muon->phi() << std::endl;
-    std::cout << "\t energy (ecal, hcal, ho): " << muon->calEnergy().em << ", " << 
-      muon->calEnergy().had << ", " << muon->calEnergy().ho << std::endl;
-    std::cout << "\t isolation dR=0.3 (sumPt, emEt, hadEt, hoEt, nTracks, nJets): " << 
-      muon->isolationR03().sumPt << ", " << muon->isolationR03().emEt << ", " << 
-      muon->isolationR03().hadEt << ", " << muon->isolationR03().hoEt << ", " <<
-      muon->isolationR03().nTracks << ", " << muon->isolationR03().nJets << std::endl;
-    std::cout << "\t isolation dR=0.5 (sumPt, emEt, hadEt, hoEt, nTracks, nJets): " << 
-      muon->isolationR05().sumPt << ", " << muon->isolationR05().emEt << ", " << 
-      muon->isolationR05().hadEt << ", " << muon->isolationR05().hoEt << ", " <<
-      muon->isolationR05().nTracks << ", " << muon->isolationR05().nJets << std::endl;
+    std::cout << "\t energy (ecal, hcal, ho): " << muon->calEnergy().em << ", " << muon->calEnergy().had << ", "
+              << muon->calEnergy().ho << std::endl;
+    std::cout << "\t isolation dR=0.3 (sumPt, emEt, hadEt, hoEt, nTracks, nJets): " << muon->isolationR03().sumPt
+              << ", " << muon->isolationR03().emEt << ", " << muon->isolationR03().hadEt << ", "
+              << muon->isolationR03().hoEt << ", " << muon->isolationR03().nTracks << ", " << muon->isolationR03().nJets
+              << std::endl;
+    std::cout << "\t isolation dR=0.5 (sumPt, emEt, hadEt, hoEt, nTracks, nJets): " << muon->isolationR05().sumPt
+              << ", " << muon->isolationR05().emEt << ", " << muon->isolationR05().hadEt << ", "
+              << muon->isolationR05().hoEt << ", " << muon->isolationR05().nTracks << ", " << muon->isolationR05().nJets
+              << std::endl;
     std::cout << "\t # matches: " << muon->numberOfMatches() << std::endl;
-    std::cout << "\t # caloCompatibility: " << muon->caloCompatibility() << std::endl;     
+    std::cout << "\t # caloCompatibility: " << muon->caloCompatibility() << std::endl;
 
-    
-    if(muon->isAValidMuonTrack(reco::Muon::TPFMS))
-      std::cout << "TPFMS pt: " << muon->tpfmsTrack()->pt() << std::endl;     
-    
-    if(muon->isAValidMuonTrack(reco::Muon::Picky))
-      std::cout << "Picky pt: " << muon->pickyTrack()->pt() << std::endl;     
-    
-    if(muon->isAValidMuonTrack(reco::Muon::DYT))
-      std::cout << "DYT pt: " << muon->dytTrack()->pt() << std::endl;     
-   
-    if(muon->isPFIsolationValid()){
-      std::cout << "PF Isolation is Valid." << std::endl 
-		<< "Iso 0.3, (sumChargedHadronPt, sumChargedParticlePt, sumNeutralHadronEt, sumPhotonEt, sumNeutralHadronEtHighThreshold, sumPhotonEtHighThreshold, sumPUPt): "
-		<< muon->pfIsolationR03().sumChargedHadronPt << ", " << muon->pfIsolationR03().sumChargedParticlePt << ", " 
-		<< muon->pfIsolationR03().sumNeutralHadronEt << ", " << muon->pfIsolationR03().sumPhotonEt << ", " 
-		<< muon->pfIsolationR03().sumNeutralHadronEtHighThreshold << ", " << muon->pfIsolationR03().sumPhotonEtHighThreshold << ", " 
-		<< muon->pfIsolationR03().sumPUPt <<std::endl;
-      std::cout << "Iso 0.4, (sumChargedHadronPt, sumChargedParticlePt, sumNeutralHadronEt, sumPhotonEt, sumNeutralHadronEtHighThreshold, sumPhotonEtHighThreshold, sumPUPt): "
-		<< muon->pfIsolationR04().sumChargedHadronPt << ", " << muon->pfIsolationR04().sumChargedParticlePt << ", " 
-		<< muon->pfIsolationR04().sumNeutralHadronEt << ", " << muon->pfIsolationR04().sumPhotonEt << ", " 
-		<< muon->pfIsolationR04().sumNeutralHadronEtHighThreshold << ", " << muon->pfIsolationR04().sumPhotonEtHighThreshold << ", " 
-		<< muon->pfIsolationR04().sumPUPt <<std::endl;
+    if (muon->isAValidMuonTrack(reco::Muon::TPFMS))
+      std::cout << "TPFMS pt: " << muon->tpfmsTrack()->pt() << std::endl;
 
+    if (muon->isAValidMuonTrack(reco::Muon::Picky))
+      std::cout << "Picky pt: " << muon->pickyTrack()->pt() << std::endl;
 
+    if (muon->isAValidMuonTrack(reco::Muon::DYT))
+      std::cout << "DYT pt: " << muon->dytTrack()->pt() << std::endl;
+
+    if (muon->isPFIsolationValid()) {
+      std::cout << "PF Isolation is Valid." << std::endl
+                << "Iso 0.3, (sumChargedHadronPt, sumChargedParticlePt, sumNeutralHadronEt, sumPhotonEt, "
+                   "sumNeutralHadronEtHighThreshold, sumPhotonEtHighThreshold, sumPUPt): "
+                << muon->pfIsolationR03().sumChargedHadronPt << ", " << muon->pfIsolationR03().sumChargedParticlePt
+                << ", " << muon->pfIsolationR03().sumNeutralHadronEt << ", " << muon->pfIsolationR03().sumPhotonEt
+                << ", " << muon->pfIsolationR03().sumNeutralHadronEtHighThreshold << ", "
+                << muon->pfIsolationR03().sumPhotonEtHighThreshold << ", " << muon->pfIsolationR03().sumPUPt
+                << std::endl;
+      std::cout << "Iso 0.4, (sumChargedHadronPt, sumChargedParticlePt, sumNeutralHadronEt, sumPhotonEt, "
+                   "sumNeutralHadronEtHighThreshold, sumPhotonEtHighThreshold, sumPUPt): "
+                << muon->pfIsolationR04().sumChargedHadronPt << ", " << muon->pfIsolationR04().sumChargedParticlePt
+                << ", " << muon->pfIsolationR04().sumNeutralHadronEt << ", " << muon->pfIsolationR04().sumPhotonEt
+                << ", " << muon->pfIsolationR04().sumNeutralHadronEtHighThreshold << ", "
+                << muon->pfIsolationR04().sumPhotonEtHighThreshold << ", " << muon->pfIsolationR04().sumPUPt
+                << std::endl;
     }
-
- 
   }
-  
 }
 
-
-void TestMuons::checkPFMap(const edm::Event& iEvent, const edm::Handle<reco::MuonCollection> &muons){
-
-  std::cout << "checkPFMaps"  <<std::endl;
+void TestMuons::checkPFMap(const edm::Event& iEvent, const edm::Handle<reco::MuonCollection>& muons) {
+  std::cout << "checkPFMaps" << std::endl;
 
   edm::Handle<edm::ValueMap<reco::PFCandidatePtr> > pfMap;
-  iEvent.getByLabel("particleFlow",theInput.label(),pfMap);
-  
-  
-  for(unsigned int imucount=0; imucount < muons->size(); ++imucount){
-    reco::MuonRef muonR(muons,imucount);
-    if ( (*pfMap)[muonR].isNonnull())
-      std::cout  << "PfCand muon pT: " << (*pfMap)[muonR]->muonRef()->pt()
-		 << " Muon pT: " << muonR->pt() << std::endl; 
+  iEvent.getByLabel("particleFlow", theInput.label(), pfMap);
+
+  for (unsigned int imucount = 0; imucount < muons->size(); ++imucount) {
+    reco::MuonRef muonR(muons, imucount);
+    if ((*pfMap)[muonR].isNonnull())
+      std::cout << "PfCand muon pT: " << (*pfMap)[muonR]->muonRef()->pt() << " Muon pT: " << muonR->pt() << std::endl;
   }
 }
-
-
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(TestMuons);

--- a/RecoMuon/MuonIsolation/interface/Cuts.h
+++ b/RecoMuon/MuonIsolation/interface/Cuts.h
@@ -5,42 +5,46 @@
 #include <vector>
 #include <string>
 
-namespace edm { class ParameterSet; }
+namespace edm {
+  class ParameterSet;
+}
 
 namespace muonisolation {
 
-class Cuts {
-public:
+  class Cuts {
+  public:
+    struct CutSpec {
+      muonisolation::Range<double> etaRange;
+      double conesize;
+      double threshold;
+    };
 
-  struct CutSpec { muonisolation::Range<double> etaRange; double conesize; double threshold; }; 
+    /// dummy constructor
+    Cuts() {}
 
-  /// dummy constructor
-  Cuts(){}
+    /// ctor by PSet
+    Cuts(const edm::ParameterSet& pset);
 
-  /// ctor by PSet
-  Cuts(const edm::ParameterSet & pset);
+    /// constructor from valid parameters
+    Cuts(const std::vector<double>& etaBounds,
+         const std::vector<double>& coneSizes,
+         const std::vector<double>& thresholds);
 
-  /// constructor from valid parameters 
-  Cuts( const std::vector<double> & etaBounds, 
-        const std::vector<double> & coneSizes, 
-        const std::vector<double> & thresholds);
+    const CutSpec& operator()(double eta) const;
 
-  const CutSpec & operator()(double eta) const;
+    const CutSpec& operator[](unsigned int i) const { return theCuts[i]; };
 
-  const CutSpec & operator[](unsigned int i) const {return theCuts[i];};
+    unsigned int size() { return theCuts.size(); };
 
-  unsigned int size() {return theCuts.size();};
+    std::string print() const;
 
-  std::string print() const;
+  private:
+    void init(const std::vector<double>& etaBounds,
+              const std::vector<double>& coneSizes,
+              const std::vector<double>& thresholds);
 
-private:
-  void init(
-      const std::vector<double> & etaBounds,
-      const std::vector<double> & coneSizes,
-      const std::vector<double> & thresholds);
+    std::vector<CutSpec> theCuts;
+  };
 
-  std::vector<CutSpec> theCuts;
-};
-
-}
+}  // namespace muonisolation
 #endif

--- a/RecoMuon/MuonIsolation/interface/CutsConeSizeFunction.h
+++ b/RecoMuon/MuonIsolation/interface/CutsConeSizeFunction.h
@@ -5,18 +5,19 @@
 #include "RecoMuon/MuonIsolation/interface/IsolatorByDeposit.h"
 
 namespace muonisolation {
-class CutsConeSizeFunction : public IsolatorByDeposit::ConeSizeFunction {
-public: 
-  CutsConeSizeFunction(const Cuts & cuts) : theLastCut(nullptr), theCuts(cuts) {} 
-  ~CutsConeSizeFunction() override = default;
-  float threshold() const { return theLastCut->threshold; }
-  float coneSize( float eta, float pt) const override {
-    theLastCut = & theCuts(eta); 
-    return theLastCut->conesize;
-  } 
-private:
-  mutable const Cuts::CutSpec * theLastCut;
-  const Cuts & theCuts;
-};
-}
+  class CutsConeSizeFunction : public IsolatorByDeposit::ConeSizeFunction {
+  public:
+    CutsConeSizeFunction(const Cuts& cuts) : theLastCut(nullptr), theCuts(cuts) {}
+    ~CutsConeSizeFunction() override = default;
+    float threshold() const { return theLastCut->threshold; }
+    float coneSize(float eta, float pt) const override {
+      theLastCut = &theCuts(eta);
+      return theLastCut->conesize;
+    }
+
+  private:
+    mutable const Cuts::CutSpec* theLastCut;
+    const Cuts& theCuts;
+  };
+}  // namespace muonisolation
 #endif

--- a/RecoMuon/MuonIsolation/interface/IsolatorByDeposit.h
+++ b/RecoMuon/MuonIsolation/interface/IsolatorByDeposit.h
@@ -12,63 +12,61 @@
 #include "RecoMuon/MuonIsolation/interface/MuIsoBaseIsolator.h"
 #include <vector>
 
-
 namespace muonisolation {
-class IsolatorByDeposit : public MuIsoBaseIsolator {
-public:
-  typedef MuIsoBaseIsolator::DepositContainer DepositContainer;
+  class IsolatorByDeposit : public MuIsoBaseIsolator {
+  public:
+    typedef MuIsoBaseIsolator::DepositContainer DepositContainer;
 
-  struct ConeSizeFunction {
-   virtual ~ConeSizeFunction() = default;
-   virtual float  coneSize( float eta, float pt) const = 0;
+    struct ConeSizeFunction {
+      virtual ~ConeSizeFunction() = default;
+      virtual float coneSize(float eta, float pt) const = 0;
+    };
+
+    //! construct with no addtnl thresholds on deposits
+    IsolatorByDeposit(float conesize, const std::vector<double>& weights);
+    IsolatorByDeposit(const ConeSizeFunction* conesize, const std::vector<double>& weights);
+
+    //! construct with non-default thresholds per deposit
+    IsolatorByDeposit(float conesize, const std::vector<double>& weights, const std::vector<double>& thresh);
+    IsolatorByDeposit(const ConeSizeFunction* conesize,
+                      const std::vector<double>& weights,
+                      const std::vector<double>& thresh);
+
+    ~IsolatorByDeposit() override {}
+
+    //! Set the weights for summing deposits of different types
+    virtual void setWeights(const std::vector<double>& weights) { theWeights = weights; }
+
+    //! Compute the deposit within the cone and return the isolation result
+    Result result(const DepositContainer& deposits, const edm::Event* = nullptr) const override;
+
+    //! Compute the count of deposit within the cone and return the isolation result
+    /*   virtual int resultInt(DepositContainer deposits) const; */
+
+    void setConeSize(float conesize) {
+      theConeSize = conesize;
+      theConeSizeFunction = nullptr;
+    }
+
+    void setConeSize(ConeSizeFunction* conesize) { theConeSizeFunction = conesize; }
+
+    //! Get the cone size
+    virtual float coneSize(float eta, float pT) const {
+      return theConeSizeFunction ? theConeSizeFunction->coneSize(eta, pT) : theConeSize;
+    }
+
+    ResultType resultType() const override { return ISOL_FLOAT_TYPE; }
+
+  private:
+    // Compute the weighted sum of deposits of different type within dRcone
+    double weightedSum(const DepositContainer& deposits, float dRcone) const;
+
+  private:
+    const ConeSizeFunction* theConeSizeFunction;
+    float theConeSize;
+    std::vector<double> theWeights;
+    std::vector<double> theDepThresholds;
   };
-
-  //! construct with no addtnl thresholds on deposits
-  IsolatorByDeposit(float conesize, const  std::vector<double> & weights);
-  IsolatorByDeposit(const ConeSizeFunction * conesize, const std::vector<double> & weights);
-
-  //! construct with non-default thresholds per deposit
-  IsolatorByDeposit(float conesize, 
-		    const std::vector<double> & weights, const std::vector<double>& thresh);
-  IsolatorByDeposit(const ConeSizeFunction * conesize, 
-		    const std::vector<double> & weights, const std::vector<double>& thresh);
-
-  ~IsolatorByDeposit() override {}
-
-  //! Set the weights for summing deposits of different types
-  virtual void setWeights(const std::vector<double>& weights) {theWeights=weights;}
-
-  //! Compute the deposit within the cone and return the isolation result
-  Result result(const DepositContainer& deposits, const edm::Event* = nullptr) const override;
-
-  //! Compute the count of deposit within the cone and return the isolation result
-/*   virtual int resultInt(DepositContainer deposits) const; */
-
-
-
-  void setConeSize(float conesize) { theConeSize = conesize; theConeSizeFunction = nullptr;} 
-
-  void setConeSize(ConeSizeFunction * conesize) { theConeSizeFunction = conesize; }
-
-
-  //! Get the cone size
-  virtual float coneSize(float eta, float pT) const {
-    return theConeSizeFunction ? theConeSizeFunction->coneSize(eta,pT) : theConeSize;
-  }
-
-  ResultType resultType() const override { return ISOL_FLOAT_TYPE;}
-
-
-private:
-  // Compute the weighted sum of deposits of different type within dRcone
-  double weightedSum(const DepositContainer& deposits, float dRcone) const;
-
-private:
-  const ConeSizeFunction * theConeSizeFunction;
-  float theConeSize;
-  std::vector<double> theWeights;
-  std::vector<double> theDepThresholds;
-};
-}
+}  // namespace muonisolation
 
 #endif

--- a/RecoMuon/MuonIsolation/interface/IsolatorByDepositCount.h
+++ b/RecoMuon/MuonIsolation/interface/IsolatorByDepositCount.h
@@ -12,45 +12,44 @@
 #include "RecoMuon/MuonIsolation/interface/MuIsoBaseIsolator.h"
 #include <vector>
 
-
 namespace muonisolation {
-class IsolatorByDepositCount : public MuIsoBaseIsolator {
-public:
-  typedef MuIsoBaseIsolator::DepositContainer DepositContainer;
+  class IsolatorByDepositCount : public MuIsoBaseIsolator {
+  public:
+    typedef MuIsoBaseIsolator::DepositContainer DepositContainer;
 
-  struct ConeSizeFunction {
-   virtual ~ConeSizeFunction() = default;
-   virtual float  coneSize( float eta, float pt) const = 0;
+    struct ConeSizeFunction {
+      virtual ~ConeSizeFunction() = default;
+      virtual float coneSize(float eta, float pt) const = 0;
+    };
+
+    //! construct with non-default thresholds per deposit
+    IsolatorByDepositCount(float conesize, const std::vector<double>& thresh);
+    IsolatorByDepositCount(const ConeSizeFunction* conesize, const std::vector<double>& thresh);
+
+    ~IsolatorByDepositCount() override = default;
+
+    //! Compute the deposit within the cone and return the isolation result
+    Result result(const DepositContainer& deposits, const edm::Event* = nullptr) const override;
+
+    void setConeSize(float conesize) {
+      theConeSize = conesize;
+      theConeSizeFunction = nullptr;
+    }
+
+    void setConeSize(ConeSizeFunction* conesize) { theConeSizeFunction = conesize; }
+
+    //! Get the cone size
+    virtual float coneSize(float eta, float pT) const {
+      return theConeSizeFunction ? theConeSizeFunction->coneSize(eta, pT) : theConeSize;
+    }
+
+    ResultType resultType() const override { return ISOL_INT_TYPE; }
+
+  private:
+    const ConeSizeFunction* theConeSizeFunction;
+    float theConeSize;
+    std::vector<double> theDepThresholds;
   };
-
-  //! construct with non-default thresholds per deposit
-  IsolatorByDepositCount(float conesize, const std::vector<double>& thresh);
-  IsolatorByDepositCount(const ConeSizeFunction * conesize, const std::vector<double>& thresh);
-
-  ~IsolatorByDepositCount() override = default;
-
-  //! Compute the deposit within the cone and return the isolation result
-  Result result(const DepositContainer& deposits, const edm::Event* = nullptr) const override;
-
-
-  void setConeSize(float conesize) { theConeSize = conesize; theConeSizeFunction = nullptr;} 
-
-  void setConeSize(ConeSizeFunction * conesize) { theConeSizeFunction = conesize; }
-
-
-  //! Get the cone size
-  virtual float coneSize(float eta, float pT) const {
-    return theConeSizeFunction ? theConeSizeFunction->coneSize(eta,pT) : theConeSize;
-  }
-
-  ResultType resultType() const override { return ISOL_INT_TYPE;}
-
-
-private:
-  const ConeSizeFunction * theConeSizeFunction;
-  float theConeSize;
-  std::vector<double> theDepThresholds;
-};
-}
+}  // namespace muonisolation
 
 #endif

--- a/RecoMuon/MuonIsolation/interface/IsolatorByNominalEfficiency.h
+++ b/RecoMuon/MuonIsolation/interface/IsolatorByNominalEfficiency.h
@@ -14,7 +14,9 @@
 #include <vector>
 #include <string>
 
-namespace muonisolation { class NominalEfficiencyThresholds; }
+namespace muonisolation {
+  class NominalEfficiencyThresholds;
+}
 
 namespace muonisolation {
   class IsolatorByNominalEfficiency : public MuIsoBaseIsolator {
@@ -22,14 +24,14 @@ namespace muonisolation {
     typedef MuIsoBaseIsolator::DepositContainer DepositContainer;
 
     //! Constructor
-    IsolatorByNominalEfficiency(const std::string & thrFile,
-				const std::vector<std::string> & ceff,
-				const std::vector<double> & weights);
+    IsolatorByNominalEfficiency(const std::string& thrFile,
+                                const std::vector<std::string>& ceff,
+                                const std::vector<double>& weights);
 
-    IsolatorByNominalEfficiency(const std::string & thrFile,
-				const std::vector<std::string> & ceff,
-				const std::vector<double> & weights, const std::vector<double> & thresh	);
-
+    IsolatorByNominalEfficiency(const std::string& thrFile,
+                                const std::vector<std::string>& ceff,
+                                const std::vector<double>& weights,
+                                const std::vector<double>& thresh);
 
     ~IsolatorByNominalEfficiency() override;
 
@@ -39,13 +41,13 @@ namespace muonisolation {
     Cuts cuts(float nominalEfficiency) const;
 
   private:
-
     class ConeSizes {
     private:
-      enum  IsoDim { DIM = 15};
+      enum IsoDim { DIM = 15 };
       static const float cone_dr[DIM];
+
     public:
-      int dim() const { return DIM;}
+      int dim() const { return DIM; }
       double size(int i) const;
       int index(float dr) const;
     };
@@ -56,20 +58,20 @@ namespace muonisolation {
     // Size of cone for a given nominal efficiency value.
     int bestConeForEfficiencyIndex(float eff_thr) const;
 
-    typedef std::multimap<float,int> mapNomEff_Cone;
+    typedef std::multimap<float, int> mapNomEff_Cone;
     mapNomEff_Cone cones(const std::vector<std::string>& names);
 
     std::string findPath(const std::string& fileName);
 
-    ResultType resultType() const override { return ISOL_FLOAT_TYPE;}
+    ResultType resultType() const override { return ISOL_FLOAT_TYPE; }
 
   private:
     mapNomEff_Cone coneForEfficiency;
-    NominalEfficiencyThresholds * thresholds;
+    NominalEfficiencyThresholds* thresholds;
     std::vector<double> theWeights;
     std::vector<double> theDepThresholds;
     ConeSizes theConesInfo;
   };
-}
+}  // namespace muonisolation
 
 #endif

--- a/RecoMuon/MuonIsolation/interface/MuIsoBaseAlgorithm.h
+++ b/RecoMuon/MuonIsolation/interface/MuIsoBaseAlgorithm.h
@@ -4,8 +4,12 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
-namespace edm { class Event; }
-namespace edm { class EventSetup; }
+namespace edm {
+  class Event;
+}
+namespace edm {
+  class EventSetup;
+}
 
 class MuIsoBaseAlgorithm {
 public:
@@ -13,9 +17,7 @@ public:
   virtual ~MuIsoBaseAlgorithm() {}
 
   /// The isolation result for one muon
-  virtual float isolation(const edm::Event&, 
-			  const edm::EventSetup&, 
-			  const reco::Track& muon) = 0;
+  virtual float isolation(const edm::Event&, const edm::EventSetup&, const reco::Track& muon) = 0;
   virtual float isolation(const edm::Event&, const edm::EventSetup&, const reco::TrackRef& muon) = 0;
 
   /// Return logical result of isolaton is all parameters and cuts are fixe
@@ -28,6 +30,5 @@ public:
 
   /// The component that computes the isolation value from the deposits
   //virtual MuIsoBaseIsolator  * isolator() = 0;
-
 };
 #endif

--- a/RecoMuon/MuonIsolation/interface/MuIsoBaseIsolator.h
+++ b/RecoMuon/MuonIsolation/interface/MuIsoBaseIsolator.h
@@ -10,65 +10,69 @@
 
 namespace muonisolation {
   class MuIsoBaseIsolator {
-
   public:
     typedef reco::IsoDeposit::Veto Veto;
     typedef reco::IsoDeposit::Vetos Vetos;
 
     struct DepositAndVetos {
-      DepositAndVetos(): dep(nullptr), vetos(nullptr) {}
-      DepositAndVetos(const reco::IsoDeposit* depA, const Vetos* vetosA = nullptr):
-	dep(depA), vetos(vetosA) {}
+      DepositAndVetos() : dep(nullptr), vetos(nullptr) {}
+      DepositAndVetos(const reco::IsoDeposit* depA, const Vetos* vetosA = nullptr) : dep(depA), vetos(vetosA) {}
       const reco::IsoDeposit* dep;
       const Vetos* vetos;
     };
     typedef std::vector<DepositAndVetos> DepositContainer;
-  
-    enum ResultType {
-      ISOL_INT_TYPE = 0,
-      ISOL_FLOAT_TYPE,
-      ISOL_BOOL_TYPE,
-      ISOL_INVALID_TYPE
-    };
+
+    enum ResultType { ISOL_INT_TYPE = 0, ISOL_FLOAT_TYPE, ISOL_BOOL_TYPE, ISOL_INVALID_TYPE };
 
     class Result {
     public:
       Result() : valInt(-999), valFloat(-999), valBool(false), typeF_(ISOL_INVALID_TYPE) {}
-	Result(ResultType typ) : valInt(-999), valFloat(-999.), valBool(false), typeF_(typ) {}
-	  
-	  template <typename T> T val() const;
-	  
-	  int valInt;
-	  float valFloat;
-	  bool valBool;
-	  ResultType typeF() const {return typeF_;}
+      Result(ResultType typ) : valInt(-999), valFloat(-999.), valBool(false), typeF_(typ) {}
+
+      template <typename T>
+      T val() const;
+
+      int valInt;
+      float valFloat;
+      bool valBool;
+      ResultType typeF() const { return typeF_; }
 
     protected:
-	  ResultType typeF_;
+      ResultType typeF_;
     };
-    
 
-    virtual ~MuIsoBaseIsolator(){}
+    virtual ~MuIsoBaseIsolator() {}
 
     //! Compute and return the isolation variable
     virtual Result result(const DepositContainer& deposits, const edm::Event* = nullptr) const = 0;
     //! Compute and return the isolation variable, with vetoes and the muon
-    virtual Result result(const DepositContainer& deposits, const reco::Candidate& muon, const edm::Event* = nullptr) const {
+    virtual Result result(const DepositContainer& deposits,
+                          const reco::Candidate& muon,
+                          const edm::Event* = nullptr) const {
       return result(deposits);
     }
     //! Compute and return the isolation variable, with vetoes and the muon
-    virtual Result result(const DepositContainer& deposits, const reco::Track& muon, const edm::Event* = nullptr) const {
+    virtual Result result(const DepositContainer& deposits,
+                          const reco::Track& muon,
+                          const edm::Event* = nullptr) const {
       return result(deposits);
     }
 
     virtual ResultType resultType() const = 0;
-
   };
 
-  template<> inline int MuIsoBaseIsolator::Result::val<int>() const { return valInt;}
-  template<> inline float MuIsoBaseIsolator::Result::val<float>() const { return valFloat;}
-  template<> inline bool MuIsoBaseIsolator::Result::val<bool>() const { return valBool;}
-  
-}
-#endif
+  template <>
+  inline int MuIsoBaseIsolator::Result::val<int>() const {
+    return valInt;
+  }
+  template <>
+  inline float MuIsoBaseIsolator::Result::val<float>() const {
+    return valFloat;
+  }
+  template <>
+  inline bool MuIsoBaseIsolator::Result::val<bool>() const {
+    return valBool;
+  }
 
+}  // namespace muonisolation
+#endif

--- a/RecoMuon/MuonIsolation/interface/MuIsoByTrackPt.h
+++ b/RecoMuon/MuonIsolation/interface/MuIsoByTrackPt.h
@@ -4,36 +4,49 @@
 #include "RecoMuon/MuonIsolation/interface/MuIsoBaseAlgorithm.h"
 #include "RecoMuon/MuonIsolation/interface/CutsConeSizeFunction.h"
 
-namespace reco { namespace isodeposit { class IsoDepositExtractor; }}
-namespace muonisolation { class IsolatorByDeposit; }
-namespace reco { class Track; }
-namespace edm { class Event; }
-namespace edm { class EventSetup; }
-namespace edm { class ConsumesCollector; }
-namespace edm { class ParameterSet; }
-
+namespace reco {
+  namespace isodeposit {
+    class IsoDepositExtractor;
+  }
+}  // namespace reco
+namespace muonisolation {
+  class IsolatorByDeposit;
+}
+namespace reco {
+  class Track;
+}
+namespace edm {
+  class Event;
+}
+namespace edm {
+  class EventSetup;
+}
+namespace edm {
+  class ConsumesCollector;
+}
+namespace edm {
+  class ParameterSet;
+}
 
 class MuIsoByTrackPt : public MuIsoBaseAlgorithm {
 public:
-  MuIsoByTrackPt(const edm::ParameterSet& conf, edm::ConsumesCollector && iC);
+  MuIsoByTrackPt(const edm::ParameterSet& conf, edm::ConsumesCollector&& iC);
   ~MuIsoByTrackPt() override;
 
   float isolation(const edm::Event&, const edm::EventSetup&, const reco::Track& muon) override;
-  float isolation(const edm::Event& ev, const edm::EventSetup& es, const reco::TrackRef& muon) override
-  {
+  float isolation(const edm::Event& ev, const edm::EventSetup& es, const reco::TrackRef& muon) override {
     return isolation(ev, es, *muon);
   }
   bool isIsolated(const edm::Event&, const edm::EventSetup&, const reco::Track& muon) override;
-  bool isIsolated(const edm::Event& ev, const edm::EventSetup& es, const reco::TrackRef& muon) override
-  {
+  bool isIsolated(const edm::Event& ev, const edm::EventSetup& es, const reco::TrackRef& muon) override {
     return isIsolated(ev, es, *muon);
   }
 
   void setConeSize(float dr);
   void setCut(float cut) { theCut = cut; }
 
-  virtual reco::isodeposit::IsoDepositExtractor * extractor() { return theExtractor.get(); }
-  virtual muonisolation::IsolatorByDeposit * isolator() { return theIsolator.get(); }
+  virtual reco::isodeposit::IsoDepositExtractor* extractor() { return theExtractor.get(); }
+  virtual muonisolation::IsolatorByDeposit* isolator() { return theIsolator.get(); }
 
 private:
   float theCut;

--- a/RecoMuon/MuonIsolation/interface/MuPFIsoHelper.h
+++ b/RecoMuon/MuonIsolation/interface/MuPFIsoHelper.h
@@ -1,13 +1,12 @@
 #ifndef RecoMuon_MuonIsolation_MuPFIsoHelper_H
 #define RecoMuon_MuonIsolation_MuPFIsoHelper_H
 
-//MuPFIsoHelper 
-//Class to embed PF2PAT style Isodeposits  
-//To reco::Muon 
+//MuPFIsoHelper
+//Class to embed PF2PAT style Isodeposits
+//To reco::Muon
 //
 //Author: Michalis Bachtis(U.Wisconsin)
 //bachtis@cern.ch
-
 
 // system include files
 #include <memory>
@@ -23,34 +22,28 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
-
-
-
 class MuPFIsoHelper {
-   public:
+public:
   typedef edm::ValueMap<double> CandDoubleMap;
-  
-  MuPFIsoHelper(const std::map<std::string,edm::ParameterSet>&,edm::ConsumesCollector&&);
+
+  MuPFIsoHelper(const std::map<std::string, edm::ParameterSet>&, edm::ConsumesCollector&&);
 
   void beginEvent(const edm::Event& iEvent);
 
-  int  embedPFIsolation(reco::Muon&,reco::MuonRef& );
-  reco::MuonPFIsolation makeIsoDeposit(reco::MuonRef&, 
-				       const edm::Handle<CandDoubleMap>&,
-				       const edm::Handle<CandDoubleMap>&,
-				       const edm::Handle<CandDoubleMap>&,
-				       const edm::Handle<CandDoubleMap>&,
-				       const edm::Handle<CandDoubleMap>&,
-				       const edm::Handle<CandDoubleMap>&,
-				       const edm::Handle<CandDoubleMap>&);
+  int embedPFIsolation(reco::Muon&, reco::MuonRef&);
+  reco::MuonPFIsolation makeIsoDeposit(reco::MuonRef&,
+                                       const edm::Handle<CandDoubleMap>&,
+                                       const edm::Handle<CandDoubleMap>&,
+                                       const edm::Handle<CandDoubleMap>&,
+                                       const edm::Handle<CandDoubleMap>&,
+                                       const edm::Handle<CandDoubleMap>&,
+                                       const edm::Handle<CandDoubleMap>&,
+                                       const edm::Handle<CandDoubleMap>&);
 
+  ~MuPFIsoHelper();
 
-  ~MuPFIsoHelper(); 
-
-
-   private:
-
-  std::map<std::string,edm::ParameterSet> labelMap_;
+private:
+  std::map<std::string, edm::ParameterSet> labelMap_;
 
   std::vector<edm::Handle<CandDoubleMap> > chargedParticle_;
   std::vector<edm::Handle<CandDoubleMap> > chargedHadron_;
@@ -67,6 +60,5 @@ class MuPFIsoHelper {
   std::vector<edm::EDGetTokenT<CandDoubleMap> > photonToken_;
   std::vector<edm::EDGetTokenT<CandDoubleMap> > photonHighThresholdToken_;
   std::vector<edm::EDGetTokenT<CandDoubleMap> > puToken_;
-
 };
 #endif

--- a/RecoMuon/MuonIsolation/interface/MuonIsolatorFactory.h
+++ b/RecoMuon/MuonIsolation/interface/MuonIsolatorFactory.h
@@ -6,6 +6,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
-typedef edmplugin::PluginFactory<muonisolation::MuIsoBaseIsolator* (const edm::ParameterSet&, edm::ConsumesCollector && iC) >  MuonIsolatorFactory;
+typedef edmplugin::PluginFactory<muonisolation::MuIsoBaseIsolator*(const edm::ParameterSet&,
+                                                                   edm::ConsumesCollector&& iC)>
+    MuonIsolatorFactory;
 
 #endif

--- a/RecoMuon/MuonIsolation/interface/Range.h
+++ b/RecoMuon/MuonIsolation/interface/Range.h
@@ -11,33 +11,41 @@
 
 namespace muonisolation {
 
-template<class T> class Range : public std::pair<T,T> {
-public:
+  template <class T>
+  class Range : public std::pair<T, T> {
+  public:
+    Range() {}
 
-  Range() { }
+    Range(const T& aMin, const T& aMax) : std::pair<T, T>(aMin, aMax) {}
 
-  Range(const T & aMin, const T & aMax) : std::pair<T,T> (aMin,aMax) { }
+    Range(const std::pair<T, T>& aPair) : std::pair<T, T>(aPair) {}
 
-  Range(const std::pair<T,T> & aPair ) : std::pair<T,T> (aPair) { }  
+    const T& min() const { return this->first; }
 
-  const T & min() const { return this->first; }
+    const T& max() const { return this->second; }
 
-  const T & max() const { return this->second; }
+    T mean() const { return (this->first + this->second) / 2.; }
 
-  T mean() const { return (this->first+this->second)/2.; }
+    bool empty() const { return (this->second < this->first); }
 
-  bool empty() const { return (this->second < this->first); }
+    bool inside(const T& value) const {
+      if (value < this->first || this->second < value)
+        return false;
+      else
+        return true;
+    }
 
-  bool inside(const T & value) const {
-    if (value < this->first || this->second < value)  return false; else  return true;
-  }
+    void sort() {
+      if (empty())
+        std::swap(this->first, this->second);
+    }
+  };
 
-  void sort() { if (empty() ) std::swap(this->first,this->second); }
-};
+}  // namespace muonisolation
 
+template <class T>
+std::ostream& operator<<(std::ostream& out, const muonisolation::Range<T>& r) {
+  return out << "(" << r.min() << "," << r.max() << ")";
 }
-
-template <class T> std::ostream & operator<<( std::ostream& out, const muonisolation::Range<T>& r) 
-{ return out << "("<<r.min()<<","<<r.max()<<")"; }
 
 #endif

--- a/RecoMuon/MuonIsolation/interface/SimpleCutsIsolator.h
+++ b/RecoMuon/MuonIsolation/interface/SimpleCutsIsolator.h
@@ -8,15 +8,13 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class SimpleCutsIsolator : public muonisolation::MuIsoBaseIsolator {
- public:
- SimpleCutsIsolator(const edm::ParameterSet & par, edm::ConsumesCollector && iC):
-    theCuts(par.getParameter<std::vector<double> > ("EtaBounds"),
-	    par.getParameter<std::vector<double> > ("ConeSizes"),
-	    par.getParameter<std::vector<double> > ("Thresholds"))
-    {
-    }
+public:
+  SimpleCutsIsolator(const edm::ParameterSet& par, edm::ConsumesCollector&& iC)
+      : theCuts(par.getParameter<std::vector<double> >("EtaBounds"),
+                par.getParameter<std::vector<double> >("ConeSizes"),
+                par.getParameter<std::vector<double> >("Thresholds")) {}
 
-  ResultType resultType() const override {return ISOL_BOOL_TYPE;}
+  ResultType resultType() const override { return ISOL_BOOL_TYPE; }
 
   Result result(const DepositContainer& deposits, const edm::Event* = nullptr) const override {
     Result answer(ISOL_BOOL_TYPE);
@@ -29,28 +27,25 @@ class SimpleCutsIsolator : public muonisolation::MuIsoBaseIsolator {
     Result answer(ISOL_BOOL_TYPE);
 
     muonisolation::Cuts::CutSpec cuts_here = theCuts(tk.eta());
-    
+
     double conesize = cuts_here.conesize;
     double dephlt = 0;
     unsigned int nDeps = deposits.size();
-    for(unsigned int iDep = 0; iDep < nDeps; ++iDep ){
+    for (unsigned int iDep = 0; iDep < nDeps; ++iDep) {
       dephlt += deposits[iDep].dep->depositWithin(conesize);
     }
     answer.valFloat = dephlt;
-    if (dephlt<cuts_here.threshold) {
+    if (dephlt < cuts_here.threshold) {
       answer.valBool = true;
     } else {
       answer.valBool = false;
     }
     return answer;
   }
-  
- private:
 
+private:
   // Isolation cuts
   muonisolation::Cuts theCuts;
-
-
 };
 
 #endif

--- a/RecoMuon/MuonIsolation/plugins/CaloExtractor.cc
+++ b/RecoMuon/MuonIsolation/plugins/CaloExtractor.cc
@@ -19,34 +19,34 @@ using namespace reco;
 using namespace muonisolation;
 using reco::isodeposit::Direction;
 
-CaloExtractor::CaloExtractor(const ParameterSet& par, edm::ConsumesCollector && iC) :
-  theCaloTowerCollectionToken(iC.consumes<CaloTowerCollection>(par.getParameter<edm::InputTag>("CaloTowerCollectionLabel"))),
-  theDepositLabel(par.getUntrackedParameter<string>("DepositLabel")),
-  theWeight_E(par.getParameter<double>("Weight_E")),
-  theWeight_H(par.getParameter<double>("Weight_H")),
-  theThreshold_E(par.getParameter<double>("Threshold_E")),
-  theThreshold_H(par.getParameter<double>("Threshold_H")),
-  theDR_Veto_E(par.getParameter<double>("DR_Veto_E")),
-  theDR_Veto_H(par.getParameter<double>("DR_Veto_H")),
-  theDR_Max(par.getParameter<double>("DR_Max")),
-  vertexConstraintFlag_XY(par.getParameter<bool>("Vertex_Constraint_XY")),
-  vertexConstraintFlag_Z(par.getParameter<bool>("Vertex_Constraint_Z"))
-{
-}
+CaloExtractor::CaloExtractor(const ParameterSet& par, edm::ConsumesCollector&& iC)
+    : theCaloTowerCollectionToken(
+          iC.consumes<CaloTowerCollection>(par.getParameter<edm::InputTag>("CaloTowerCollectionLabel"))),
+      theDepositLabel(par.getUntrackedParameter<string>("DepositLabel")),
+      theWeight_E(par.getParameter<double>("Weight_E")),
+      theWeight_H(par.getParameter<double>("Weight_H")),
+      theThreshold_E(par.getParameter<double>("Threshold_E")),
+      theThreshold_H(par.getParameter<double>("Threshold_H")),
+      theDR_Veto_E(par.getParameter<double>("DR_Veto_E")),
+      theDR_Veto_H(par.getParameter<double>("DR_Veto_H")),
+      theDR_Max(par.getParameter<double>("DR_Max")),
+      vertexConstraintFlag_XY(par.getParameter<bool>("Vertex_Constraint_XY")),
+      vertexConstraintFlag_Z(par.getParameter<bool>("Vertex_Constraint_Z")) {}
 
-void CaloExtractor::fillVetos(const edm::Event& event, const edm::EventSetup& eventSetup, const TrackCollection& muons)
-{
+void CaloExtractor::fillVetos(const edm::Event& event,
+                              const edm::EventSetup& eventSetup,
+                              const TrackCollection& muons) {
   theVetoCollection.clear();
 
   Handle<CaloTowerCollection> towers;
-  event.getByToken(theCaloTowerCollectionToken,towers);
+  event.getByToken(theCaloTowerCollectionToken, towers);
 
   edm::ESHandle<CaloGeometry> caloGeom;
   eventSetup.get<CaloGeometryRecord>().get(caloGeom);
 
   edm::ESHandle<MagneticField> bField;
   eventSetup.get<IdealMagneticFieldRecord>().get(bField);
-  double bz = bField->inInverseGeV(GlobalPoint(0.,0.,0.)).z();
+  double bz = bField->inInverseGeV(GlobalPoint(0., 0., 0.)).z();
 
   TrackCollection::const_iterator mu;
   TrackCollection::const_iterator muEnd(muons.end());
@@ -54,247 +54,230 @@ void CaloExtractor::fillVetos(const edm::Event& event, const edm::EventSetup& ev
   CaloTowerCollection::const_iterator cal;
   CaloTowerCollection::const_iterator calEnd(towers->end());
 
-  for ( mu = muons.begin(); mu != muEnd; ++mu ) {
-    for ( cal = towers->begin(); cal != calEnd; ++cal ) {
+  for (mu = muons.begin(); mu != muEnd; ++mu) {
+    for (cal = towers->begin(); cal != calEnd; ++cal) {
       //! make this abit faster
-      double dEta = fabs(mu->eta()-cal->eta());
-      if (fabs(dEta) > theDR_Max) continue;
+      double dEta = fabs(mu->eta() - cal->eta());
+      if (fabs(dEta) > theDR_Max)
+        continue;
 
-            double deltar0 = reco::deltaR(*mu,*cal);
-            if (deltar0>theDR_Max) continue;
+      double deltar0 = reco::deltaR(*mu, *cal);
+      if (deltar0 > theDR_Max)
+        continue;
 
-            double etecal = cal->emEt();
-            double eecal = cal->emEnergy();
-            bool doEcal = theWeight_E>0 && etecal>theThreshold_E && eecal>3*noiseEcal(*cal);
-            double ethcal = cal->hadEt();
-            double ehcal = cal->hadEnergy();
-            bool doHcal = theWeight_H>0 && ethcal>theThreshold_H && ehcal>3*noiseHcal(*cal);
-            if ((!doEcal) && (!doHcal)) continue;
+      double etecal = cal->emEt();
+      double eecal = cal->emEnergy();
+      bool doEcal = theWeight_E > 0 && etecal > theThreshold_E && eecal > 3 * noiseEcal(*cal);
+      double ethcal = cal->hadEt();
+      double ehcal = cal->hadEnergy();
+      bool doHcal = theWeight_H > 0 && ethcal > theThreshold_H && ehcal > 3 * noiseHcal(*cal);
+      if ((!doEcal) && (!doHcal))
+        continue;
 
-            DetId calId = cal->id();
-            GlobalPoint endpos = caloGeom->getPosition(calId);
-            GlobalPoint muatcal = MuonAtCaloPosition(*mu,bz,endpos, vertexConstraintFlag_XY, vertexConstraintFlag_Z);
-            double deltar = reco::deltaR(muatcal,endpos);
+      DetId calId = cal->id();
+      GlobalPoint endpos = caloGeom->getPosition(calId);
+      GlobalPoint muatcal = MuonAtCaloPosition(*mu, bz, endpos, vertexConstraintFlag_XY, vertexConstraintFlag_Z);
+      double deltar = reco::deltaR(muatcal, endpos);
 
-            if (doEcal) {
-                  if (deltar<theDR_Veto_E) theVetoCollection.push_back(calId);
-            } else {
-                  if (deltar<theDR_Veto_H) theVetoCollection.push_back(calId);
-            }
+      if (doEcal) {
+        if (deltar < theDR_Veto_E)
+          theVetoCollection.push_back(calId);
+      } else {
+        if (deltar < theDR_Veto_H)
+          theVetoCollection.push_back(calId);
       }
+    }
   }
-
 }
 
-IsoDeposit CaloExtractor::deposit( const Event & event, const EventSetup& eventSetup, const Track & muon) const
-{
-  IsoDeposit dep(muon.eta(), muon.phi() );
+IsoDeposit CaloExtractor::deposit(const Event& event, const EventSetup& eventSetup, const Track& muon) const {
+  IsoDeposit dep(muon.eta(), muon.phi());
   LogDebug("Muon|RecoMuon|L2MuonIsolationProducer")
-	  << " >>> Muon: pt " << muon.pt()
-	  << " eta " << muon.eta()
-	  << " phi " << muon.phi();
+      << " >>> Muon: pt " << muon.pt() << " eta " << muon.eta() << " phi " << muon.phi();
 
   Handle<CaloTowerCollection> towers;
-  event.getByToken(theCaloTowerCollectionToken,towers);
+  event.getByToken(theCaloTowerCollectionToken, towers);
 
   edm::ESHandle<CaloGeometry> caloGeom;
   eventSetup.get<CaloGeometryRecord>().get(caloGeom);
 
   edm::ESHandle<MagneticField> bField;
   eventSetup.get<IdealMagneticFieldRecord>().get(bField);
-  double bz = bField->inInverseGeV(GlobalPoint(0.,0.,0.)).z();
+  double bz = bField->inInverseGeV(GlobalPoint(0., 0., 0.)).z();
 
   CaloTowerCollection::const_iterator cal;
   CaloTowerCollection::const_iterator calEnd(towers->end());
-  for ( cal = towers->begin(); cal != calEnd; ++cal ) {
-      //! make this abit faster
-      double dEta = fabs(muon.eta()-cal->eta());
-      if (fabs(dEta) > theDR_Max) continue;
+  for (cal = towers->begin(); cal != calEnd; ++cal) {
+    //! make this abit faster
+    double dEta = fabs(muon.eta() - cal->eta());
+    if (fabs(dEta) > theDR_Max)
+      continue;
 
-      double deltar0 = reco::deltaR(muon,*cal);
-      if (deltar0>theDR_Max) continue;
+    double deltar0 = reco::deltaR(muon, *cal);
+    if (deltar0 > theDR_Max)
+      continue;
 
-      double etecal = cal->emEt();
-      double eecal = cal->emEnergy();
-      bool doEcal = theWeight_E>0 && etecal>theThreshold_E && eecal>3*noiseEcal(*cal);
-      double ethcal = cal->hadEt();
-      double ehcal = cal->hadEnergy();
-      bool doHcal = theWeight_H>0 && ethcal>theThreshold_H && ehcal>3*noiseHcal(*cal);
-      if ((!doEcal) && (!doHcal)) continue;
+    double etecal = cal->emEt();
+    double eecal = cal->emEnergy();
+    bool doEcal = theWeight_E > 0 && etecal > theThreshold_E && eecal > 3 * noiseEcal(*cal);
+    double ethcal = cal->hadEt();
+    double ehcal = cal->hadEnergy();
+    bool doHcal = theWeight_H > 0 && ethcal > theThreshold_H && ehcal > 3 * noiseHcal(*cal);
+    if ((!doEcal) && (!doHcal))
+      continue;
 
-      DetId calId = cal->id();
-      GlobalPoint endpos = caloGeom->getPosition(calId);
-      GlobalPoint muatcal = MuonAtCaloPosition(muon,bz,endpos,vertexConstraintFlag_XY, vertexConstraintFlag_Z);
-      double deltar = reco::deltaR(muatcal,endpos);
+    DetId calId = cal->id();
+    GlobalPoint endpos = caloGeom->getPosition(calId);
+    GlobalPoint muatcal = MuonAtCaloPosition(muon, bz, endpos, vertexConstraintFlag_XY, vertexConstraintFlag_Z);
+    double deltar = reco::deltaR(muatcal, endpos);
 
-      if (deltar<theDR_Veto_H) {
-	      dep.setVeto(IsoDeposit::Veto(reco::isodeposit::Direction(muatcal.eta(), muatcal.phi()), theDR_Veto_H));
+    if (deltar < theDR_Veto_H) {
+      dep.setVeto(IsoDeposit::Veto(reco::isodeposit::Direction(muatcal.eta(), muatcal.phi()), theDR_Veto_H));
+    }
+
+    if (doEcal) {
+      if (deltar < theDR_Veto_E) {
+        double calodep = theWeight_E * etecal;
+        if (doHcal)
+          calodep += theWeight_H * ethcal;
+        dep.addCandEnergy(calodep);
+        LogDebug("Muon|RecoMuon|L2MuonIsolationProducer")
+            << " >>> Calo deposit inside veto (with ECAL): deltar " << deltar << " calodep " << calodep << " ecaldep "
+            << etecal << " hcaldep " << ethcal << " eta " << cal->eta() << " phi " << cal->phi();
+        continue;
       }
-
-      if (doEcal) {
-            if (deltar<theDR_Veto_E) {
-                  double calodep = theWeight_E*etecal;
-                  if (doHcal) calodep += theWeight_H*ethcal;
-                  dep.addCandEnergy(calodep);
-	            LogDebug("Muon|RecoMuon|L2MuonIsolationProducer")
-	            << " >>> Calo deposit inside veto (with ECAL): deltar " << deltar
-	            << " calodep " << calodep
-	            << " ecaldep " << etecal
-	            << " hcaldep " << ethcal
-	            << " eta " << cal->eta()
-	            << " phi " << cal->phi();
-                  continue;
-            }
-      } else {
-            if (deltar<theDR_Veto_H) {
-                  dep.addCandEnergy(theWeight_H*ethcal);
-	            LogDebug("Muon|RecoMuon|L2MuonIsolationProducer")
-	            << " >>> Calo deposit inside veto (no ECAL): deltar " << deltar
-	            << " calodep " << theWeight_H*ethcal
-	            << " eta " << cal->eta()
-	            << " phi " << cal->phi();
-                  continue;
-            }
+    } else {
+      if (deltar < theDR_Veto_H) {
+        dep.addCandEnergy(theWeight_H * ethcal);
+        LogDebug("Muon|RecoMuon|L2MuonIsolationProducer")
+            << " >>> Calo deposit inside veto (no ECAL): deltar " << deltar << " calodep " << theWeight_H * ethcal
+            << " eta " << cal->eta() << " phi " << cal->phi();
+        continue;
       }
+    }
 
-      if (std::find(theVetoCollection.begin(), theVetoCollection.end()
-                  , calId)!=theVetoCollection.end()) {
-            LogDebug("Muon|RecoMuon|L2MuonIsolationProducer")
-            << " >>> Deposits belongs to other track: deltar, etecal, ethcal= "
-            << deltar << ", " << etecal << ", " << ethcal;
-            continue;
-      }
+    if (std::find(theVetoCollection.begin(), theVetoCollection.end(), calId) != theVetoCollection.end()) {
+      LogDebug("Muon|RecoMuon|L2MuonIsolationProducer")
+          << " >>> Deposits belongs to other track: deltar, etecal, ethcal= " << deltar << ", " << etecal << ", "
+          << ethcal;
+      continue;
+    }
 
-      if (doEcal) {
-            if (deltar>theDR_Veto_E) {
-                  double calodep = theWeight_E*etecal;
-                  if (doHcal) calodep += theWeight_H*ethcal;
-                  dep.addDeposit(reco::isodeposit::Direction(endpos.eta(), endpos.phi()),calodep);
-	            LogDebug("Muon|RecoMuon|L2MuonIsolationProducer")
-	            << " >>> Calo deposit (with ECAL): deltar " << deltar
-	            << " calodep " << calodep
-	            << " ecaldep " << etecal
-	            << " hcaldep " << ethcal
-	            << " eta " << cal->eta()
-	            << " phi " << cal->phi();
-            }
-      } else {
-            if (deltar>theDR_Veto_H) {
-	            dep.addDeposit(reco::isodeposit::Direction(endpos.eta(), endpos.phi()),theWeight_H*ethcal);
-	            LogDebug("Muon|RecoMuon|L2MuonIsolationProducer")
-	            << " >>> Calo deposit (no ECAL): deltar " << deltar
-	            << " calodep " << theWeight_H*ethcal
-	            << " eta " << cal->eta()
-	            << " phi " << cal->phi();
-            }
+    if (doEcal) {
+      if (deltar > theDR_Veto_E) {
+        double calodep = theWeight_E * etecal;
+        if (doHcal)
+          calodep += theWeight_H * ethcal;
+        dep.addDeposit(reco::isodeposit::Direction(endpos.eta(), endpos.phi()), calodep);
+        LogDebug("Muon|RecoMuon|L2MuonIsolationProducer")
+            << " >>> Calo deposit (with ECAL): deltar " << deltar << " calodep " << calodep << " ecaldep " << etecal
+            << " hcaldep " << ethcal << " eta " << cal->eta() << " phi " << cal->phi();
       }
+    } else {
+      if (deltar > theDR_Veto_H) {
+        dep.addDeposit(reco::isodeposit::Direction(endpos.eta(), endpos.phi()), theWeight_H * ethcal);
+        LogDebug("Muon|RecoMuon|L2MuonIsolationProducer")
+            << " >>> Calo deposit (no ECAL): deltar " << deltar << " calodep " << theWeight_H * ethcal << " eta "
+            << cal->eta() << " phi " << cal->phi();
+      }
+    }
   }
 
   return dep;
-
 }
 
-GlobalPoint CaloExtractor::MuonAtCaloPosition(const Track& muon, const double bz, const GlobalPoint& endpos, bool fixVxy, bool fixVz) {
-      double qoverp= muon.qoverp();
-      double cur = bz*muon.charge()/muon.pt();
-      double phi0 = muon.phi();
-      double dca = muon.dxy();
-      double theta = muon.theta();
-      double dz = muon.dz();
+GlobalPoint CaloExtractor::MuonAtCaloPosition(
+    const Track& muon, const double bz, const GlobalPoint& endpos, bool fixVxy, bool fixVz) {
+  double qoverp = muon.qoverp();
+  double cur = bz * muon.charge() / muon.pt();
+  double phi0 = muon.phi();
+  double dca = muon.dxy();
+  double theta = muon.theta();
+  double dz = muon.dz();
 
-      //LogDebug("Muon|RecoMuon|L2MuonIsolationProducer")
-          //<< " Pt(GeV): " <<  muon.pt()
-          //<< ", phi0 " <<  muon.phi0()
-             //<< ", eta " <<  muon.eta();
-      //LogDebug("Muon|RecoMuon|L2MuonIsolationProducer")
-          //<< " d0 " <<  muon.d0()
-          //<< ", dz " <<  muon.dz();
-      //LogDebug("Muon|RecoMuon|L2MuonIsolationProducer")
-          //<< " rhocal " <<  endpos.perp()
-          //<< ", zcal " <<  endpos.z();
+  //LogDebug("Muon|RecoMuon|L2MuonIsolationProducer")
+  //<< " Pt(GeV): " <<  muon.pt()
+  //<< ", phi0 " <<  muon.phi0()
+  //<< ", eta " <<  muon.eta();
+  //LogDebug("Muon|RecoMuon|L2MuonIsolationProducer")
+  //<< " d0 " <<  muon.d0()
+  //<< ", dz " <<  muon.dz();
+  //LogDebug("Muon|RecoMuon|L2MuonIsolationProducer")
+  //<< " rhocal " <<  endpos.perp()
+  //<< ", zcal " <<  endpos.z();
 
-      if (fixVxy && fixVz) {
-            // Note that here we assume no correlation between XY and Z projections
-            // This should be a reasonable approximation for our purposes
-            double errd02 = muon.covariance(muon.i_dxy,muon.i_dxy);
-            if (pow(muon.dxy(),2)<4*errd02) {
-                  phi0 -= muon.dxy()*muon.covariance(muon.i_dxy,muon.i_phi)
-                                     /errd02;
-                  cur -= muon.dxy()*muon.covariance(muon.i_dxy,muon.i_qoverp)
-                                     /errd02 * (cur/qoverp);
-                  dca = 0;
-            }
-            double errdsz2 = muon.covariance(muon.i_dsz,muon.i_dsz);
-            if (pow(muon.dsz(),2)<4*errdsz2) {
-                  theta += muon.dsz()*muon.covariance(muon.i_dsz,muon.i_lambda)
-                                     /errdsz2;
-                  dz = 0;
-            }
-      } else if (fixVxy) {
-            double errd02 = muon.covariance(muon.i_dxy,muon.i_dxy);
-            if (pow(muon.dxy(),2)<4*errd02) {
-                  phi0  -= muon.dxy()*muon.covariance(muon.i_dxy,muon.i_phi)
-                                     /errd02;
-                  cur -= muon.dxy()*muon.covariance(muon.i_dxy,muon.i_qoverp)
-                                     /errd02 * (cur/qoverp);
-                  theta += muon.dxy()*muon.covariance(muon.i_dxy,muon.i_lambda)
-                                     /errd02;
-                  dz    -= muon.dxy()*muon.covariance(muon.i_dxy,muon.i_dsz)
-                                     /errd02 * muon.p()/muon.pt();
-                  dca = 0;
-            }
-      } else if (fixVz) {
-            double errdsz2 = muon.covariance(muon.i_dsz,muon.i_dsz);
-            if (pow(muon.dsz(),2)<4*errdsz2) {
-                  theta += muon.dsz()*muon.covariance(muon.i_dsz,muon.i_lambda)
-                                     /errdsz2;
-                  phi0  -= muon.dsz()*muon.covariance(muon.i_dsz,muon.i_phi)
-                                     /errdsz2;
-                  cur -= muon.dsz()*muon.covariance(muon.i_dsz,muon.i_qoverp)
-                                     /errdsz2 * (cur/qoverp);
-                  dca   -= muon.dsz()*muon.covariance(muon.i_dsz,muon.i_dxy)
-                                     /errdsz2;
-                  dz = 0;
-            }
-      }
+  if (fixVxy && fixVz) {
+    // Note that here we assume no correlation between XY and Z projections
+    // This should be a reasonable approximation for our purposes
+    double errd02 = muon.covariance(muon.i_dxy, muon.i_dxy);
+    if (pow(muon.dxy(), 2) < 4 * errd02) {
+      phi0 -= muon.dxy() * muon.covariance(muon.i_dxy, muon.i_phi) / errd02;
+      cur -= muon.dxy() * muon.covariance(muon.i_dxy, muon.i_qoverp) / errd02 * (cur / qoverp);
+      dca = 0;
+    }
+    double errdsz2 = muon.covariance(muon.i_dsz, muon.i_dsz);
+    if (pow(muon.dsz(), 2) < 4 * errdsz2) {
+      theta += muon.dsz() * muon.covariance(muon.i_dsz, muon.i_lambda) / errdsz2;
+      dz = 0;
+    }
+  } else if (fixVxy) {
+    double errd02 = muon.covariance(muon.i_dxy, muon.i_dxy);
+    if (pow(muon.dxy(), 2) < 4 * errd02) {
+      phi0 -= muon.dxy() * muon.covariance(muon.i_dxy, muon.i_phi) / errd02;
+      cur -= muon.dxy() * muon.covariance(muon.i_dxy, muon.i_qoverp) / errd02 * (cur / qoverp);
+      theta += muon.dxy() * muon.covariance(muon.i_dxy, muon.i_lambda) / errd02;
+      dz -= muon.dxy() * muon.covariance(muon.i_dxy, muon.i_dsz) / errd02 * muon.p() / muon.pt();
+      dca = 0;
+    }
+  } else if (fixVz) {
+    double errdsz2 = muon.covariance(muon.i_dsz, muon.i_dsz);
+    if (pow(muon.dsz(), 2) < 4 * errdsz2) {
+      theta += muon.dsz() * muon.covariance(muon.i_dsz, muon.i_lambda) / errdsz2;
+      phi0 -= muon.dsz() * muon.covariance(muon.i_dsz, muon.i_phi) / errdsz2;
+      cur -= muon.dsz() * muon.covariance(muon.i_dsz, muon.i_qoverp) / errdsz2 * (cur / qoverp);
+      dca -= muon.dsz() * muon.covariance(muon.i_dsz, muon.i_dxy) / errdsz2;
+      dz = 0;
+    }
+  }
 
-      double sphi0 = sin(phi0);
-      double cphi0 = cos(phi0);
+  double sphi0 = sin(phi0);
+  double cphi0 = cos(phi0);
 
-      double xsin =  endpos.x()*sphi0 - endpos.y()*cphi0;
-      double xcos =  endpos.x()*cphi0 + endpos.y()*sphi0;
-      double fcdca = fabs(1-cur*dca);
-      double phif = atan2( fcdca*sphi0-cur*endpos.x()
-                         , fcdca*cphi0+cur*endpos.y());
-      double tphif2 = tan(0.5*(phif-phi0));
-      double dcaf = dca + xsin + xcos*tphif2;
+  double xsin = endpos.x() * sphi0 - endpos.y() * cphi0;
+  double xcos = endpos.x() * cphi0 + endpos.y() * sphi0;
+  double fcdca = fabs(1 - cur * dca);
+  double phif = atan2(fcdca * sphi0 - cur * endpos.x(), fcdca * cphi0 + cur * endpos.y());
+  double tphif2 = tan(0.5 * (phif - phi0));
+  double dcaf = dca + xsin + xcos * tphif2;
 
-      double x = endpos.x() - dcaf*sin(phif);
-      double y = endpos.y() + dcaf*cos(phif);
+  double x = endpos.x() - dcaf * sin(phif);
+  double y = endpos.y() + dcaf * cos(phif);
 
-      double deltas =  (x-muon.vx())*cphi0 + (y-muon.vy())*sphi0;
-      double deltaphi = normalizedPhi(phif-phi0);
-      if (deltaphi!=0) deltas = deltas*deltaphi/sin(deltaphi);
+  double deltas = (x - muon.vx()) * cphi0 + (y - muon.vy()) * sphi0;
+  double deltaphi = normalizedPhi(phif - phi0);
+  if (deltaphi != 0)
+    deltas = deltas * deltaphi / sin(deltaphi);
 
-      double z =dz;
-      double tantheta = tan(theta);
-      if (tantheta!=0) {
-            z += deltas/tan(theta);
-      } else {
-            z = endpos.z();
-      }
+  double z = dz;
+  double tantheta = tan(theta);
+  if (tantheta != 0) {
+    z += deltas / tan(theta);
+  } else {
+    z = endpos.z();
+  }
 
-      return GlobalPoint(x,y,z);
+  return GlobalPoint(x, y, z);
 }
 
 double CaloExtractor::noiseEcal(const CaloTower& tower) const {
-      double noise = 0.04;
-      double eta = tower.eta();
-      if (fabs(eta)>1.479) noise = 0.15;
-      return noise;
+  double noise = 0.04;
+  double eta = tower.eta();
+  if (fabs(eta) > 1.479)
+    noise = 0.15;
+  return noise;
 }
 
 double CaloExtractor::noiseHcal(const CaloTower& tower) const {
-      double noise = 0.2;
-      return noise;
+  double noise = 0.2;
+  return noise;
 }

--- a/RecoMuon/MuonIsolation/plugins/CaloExtractor.h
+++ b/RecoMuon/MuonIsolation/plugins/CaloExtractor.h
@@ -17,47 +17,48 @@
 
 namespace muonisolation {
 
-class CaloExtractor : public reco::isodeposit::IsoDepositExtractor {
+  class CaloExtractor : public reco::isodeposit::IsoDepositExtractor {
+  public:
+    CaloExtractor(){};
+    CaloExtractor(const edm::ParameterSet& par, edm::ConsumesCollector&& iC);
 
-public:
+    ~CaloExtractor() override {}
 
-  CaloExtractor(){};
-  CaloExtractor(const edm::ParameterSet& par, edm::ConsumesCollector && iC);
+    void fillVetos(const edm::Event& ev, const edm::EventSetup& evSetup, const reco::TrackCollection& tracks) override;
+    reco::IsoDeposit deposit(const edm::Event& ev,
+                             const edm::EventSetup& evSetup,
+                             const reco::Track& track) const override;
 
-  ~CaloExtractor() override{}
+    /// Extrapolate muons to calorimeter-object positions
+    static GlobalPoint MuonAtCaloPosition(
+        const reco::Track& muon, const double bz, const GlobalPoint& endpos, bool fixVxy = false, bool fixVz = false);
 
-  void fillVetos (const edm::Event & ev, const edm::EventSetup & evSetup, const reco::TrackCollection & tracks) override;
-  reco::IsoDeposit deposit (const edm::Event & ev, const edm::EventSetup & evSetup, const reco::Track & track) const override;
+  private:
+    // CaloTower Collection Label
+    edm::EDGetTokenT<CaloTowerCollection> theCaloTowerCollectionToken;
 
-  /// Extrapolate muons to calorimeter-object positions
-  static GlobalPoint MuonAtCaloPosition(const reco::Track& muon, const double bz, const GlobalPoint& endpos, bool fixVxy=false, bool fixVz=false);
+    // Label of deposit
+    std::string theDepositLabel;
 
-private:
-  // CaloTower Collection Label
-  edm::EDGetTokenT<CaloTowerCollection> theCaloTowerCollectionToken;
+    // Cone cuts and thresholds
+    double theWeight_E;
+    double theWeight_H;
+    double theThreshold_E;
+    double theThreshold_H;
+    double theDR_Veto_E;
+    double theDR_Veto_H;
+    double theDR_Max;
+    bool vertexConstraintFlag_XY;
+    bool vertexConstraintFlag_Z;
 
-  // Label of deposit
-  std::string theDepositLabel;
+    // Vector of calo Ids to veto
+    std::vector<DetId> theVetoCollection;
 
-  // Cone cuts and thresholds
-  double theWeight_E;
-  double theWeight_H;
-  double theThreshold_E;
-  double theThreshold_H;
-  double theDR_Veto_E;
-  double theDR_Veto_H;
-  double theDR_Max;
-  bool vertexConstraintFlag_XY;
-  bool vertexConstraintFlag_Z;
+    // Determine noise for HCAL and ECAL (take some defaults for the time being)
+    double noiseEcal(const CaloTower& tower) const;
+    double noiseHcal(const CaloTower& tower) const;
+  };
 
-  // Vector of calo Ids to veto
-  std::vector<DetId> theVetoCollection;
-
-  // Determine noise for HCAL and ECAL (take some defaults for the time being)
-  double noiseEcal(const CaloTower& tower) const;
-  double noiseHcal(const CaloTower& tower) const;
-};
-
-}
+}  // namespace muonisolation
 
 #endif

--- a/RecoMuon/MuonIsolation/plugins/CaloExtractorByAssociator.cc
+++ b/RecoMuon/MuonIsolation/plugins/CaloExtractorByAssociator.cc
@@ -30,33 +30,32 @@ using namespace muonisolation;
 using reco::isodeposit::Direction;
 
 namespace {
-  constexpr double dRMax_CandDep = 1.0;//pick up candidate own deposits up to this dR if theDR_Max is smaller
+  constexpr double dRMax_CandDep = 1.0;  //pick up candidate own deposits up to this dR if theDR_Max is smaller
 }
 
-CaloExtractorByAssociator::CaloExtractorByAssociator(const ParameterSet& par, edm::ConsumesCollector && iC) :
-  theUseRecHitsFlag(par.getParameter<bool>("UseRecHitsFlag")),
-  theDepositLabel(par.getUntrackedParameter<string>("DepositLabel")),
-  theDepositInstanceLabels(par.getParameter<std::vector<std::string> >("DepositInstanceLabels")),
-  thePropagatorName(par.getParameter<std::string>("PropagatorName")),
-  theThreshold_E(par.getParameter<double>("Threshold_E")),
-  theThreshold_H(par.getParameter<double>("Threshold_H")),
-  theThreshold_HO(par.getParameter<double>("Threshold_HO")),
-  theDR_Veto_E(par.getParameter<double>("DR_Veto_E")),
-  theDR_Veto_H(par.getParameter<double>("DR_Veto_H")),
-  theDR_Veto_HO(par.getParameter<double>("DR_Veto_HO")),
-  theCenterConeOnCalIntersection(par.getParameter<bool>("CenterConeOnCalIntersection")),
-  theDR_Max(par.getParameter<double>("DR_Max")),
-  theNoise_EB(par.getParameter<double>("Noise_EB")),
-  theNoise_EE(par.getParameter<double>("Noise_EE")),
-  theNoise_HB(par.getParameter<double>("Noise_HB")),
-  theNoise_HE(par.getParameter<double>("Noise_HE")),
-  theNoise_HO(par.getParameter<double>("Noise_HO")),
-  theNoiseTow_EB(par.getParameter<double>("NoiseTow_EB")),
-  theNoiseTow_EE(par.getParameter<double>("NoiseTow_EE")),
-  theService(nullptr),
-  theAssociator(nullptr),
-  thePrintTimeReport(par.getUntrackedParameter<bool>("PrintTimeReport"))
-{
+CaloExtractorByAssociator::CaloExtractorByAssociator(const ParameterSet& par, edm::ConsumesCollector&& iC)
+    : theUseRecHitsFlag(par.getParameter<bool>("UseRecHitsFlag")),
+      theDepositLabel(par.getUntrackedParameter<string>("DepositLabel")),
+      theDepositInstanceLabels(par.getParameter<std::vector<std::string> >("DepositInstanceLabels")),
+      thePropagatorName(par.getParameter<std::string>("PropagatorName")),
+      theThreshold_E(par.getParameter<double>("Threshold_E")),
+      theThreshold_H(par.getParameter<double>("Threshold_H")),
+      theThreshold_HO(par.getParameter<double>("Threshold_HO")),
+      theDR_Veto_E(par.getParameter<double>("DR_Veto_E")),
+      theDR_Veto_H(par.getParameter<double>("DR_Veto_H")),
+      theDR_Veto_HO(par.getParameter<double>("DR_Veto_HO")),
+      theCenterConeOnCalIntersection(par.getParameter<bool>("CenterConeOnCalIntersection")),
+      theDR_Max(par.getParameter<double>("DR_Max")),
+      theNoise_EB(par.getParameter<double>("Noise_EB")),
+      theNoise_EE(par.getParameter<double>("Noise_EE")),
+      theNoise_HB(par.getParameter<double>("Noise_HB")),
+      theNoise_HE(par.getParameter<double>("Noise_HE")),
+      theNoise_HO(par.getParameter<double>("Noise_HO")),
+      theNoiseTow_EB(par.getParameter<double>("NoiseTow_EB")),
+      theNoiseTow_EE(par.getParameter<double>("NoiseTow_EE")),
+      theService(nullptr),
+      theAssociator(nullptr),
+      thePrintTimeReport(par.getUntrackedParameter<bool>("PrintTimeReport")) {
   ParameterSet serviceParameters = par.getParameter<ParameterSet>("ServiceParameters");
   theService = new MuonServiceProxy(serviceParameters);
 
@@ -66,50 +65,54 @@ CaloExtractorByAssociator::CaloExtractorByAssociator(const ParameterSet& par, ed
   theAssociator = new TrackDetectorAssociator();
 }
 
-CaloExtractorByAssociator::~CaloExtractorByAssociator(){
-  if (theAssociatorParameters) delete theAssociatorParameters;
-  if (theService) delete theService;
-  if (theAssociator) delete theAssociator;
+CaloExtractorByAssociator::~CaloExtractorByAssociator() {
+  if (theAssociatorParameters)
+    delete theAssociatorParameters;
+  if (theService)
+    delete theService;
+  if (theAssociator)
+    delete theAssociator;
 }
 
-void CaloExtractorByAssociator::fillVetos(const edm::Event& event, const edm::EventSetup& eventSetup, const TrackCollection& muons)
-{
-//   LogWarning("CaloExtractorByAssociator")
-//     <<"fillVetos does nothing now: IsoDeposit provides enough functionality\n"
-//     <<"to remove a deposit at/around given (eta, phi)";
-
+void CaloExtractorByAssociator::fillVetos(const edm::Event& event,
+                                          const edm::EventSetup& eventSetup,
+                                          const TrackCollection& muons) {
+  //   LogWarning("CaloExtractorByAssociator")
+  //     <<"fillVetos does nothing now: IsoDeposit provides enough functionality\n"
+  //     <<"to remove a deposit at/around given (eta, phi)";
 }
 
-IsoDeposit CaloExtractorByAssociator::deposit( const Event & event, const EventSetup& eventSetup, const Track & muon) const
-{
+IsoDeposit CaloExtractorByAssociator::deposit(const Event& event,
+                                              const EventSetup& eventSetup,
+                                              const Track& muon) const {
   IsoDeposit::Direction muonDir(muon.eta(), muon.phi());
-  IsoDeposit dep(muonDir );
+  IsoDeposit dep(muonDir);
 
-//   LogWarning("CaloExtractorByAssociator")
-//     <<"single deposit is not an option here\n"
-//     <<"use ::deposits --> extract all and reweight as necessary";
+  //   LogWarning("CaloExtractorByAssociator")
+  //     <<"single deposit is not an option here\n"
+  //     <<"use ::deposits --> extract all and reweight as necessary";
 
   return dep;
-
 }
 
-
 //! Make separate deposits: for ECAL, HCAL, HO
-std::vector<IsoDeposit> CaloExtractorByAssociator::deposits( const Event & event, const EventSetup& eventSetup, const Track & muon) const
-{
+std::vector<IsoDeposit> CaloExtractorByAssociator::deposits(const Event& event,
+                                                            const EventSetup& eventSetup,
+                                                            const Track& muon) const {
   theService->update(eventSetup);
   theAssociator->setPropagator(&*(theService->propagator(thePropagatorName)));
 
   //! check configuration consistency
   //! could've been made at construction stage (fix later?)
-  if (theDepositInstanceLabels.size() != 3){
-    LogError("MuonIsolation")<<"Configuration is inconsistent: Need 3 deposit instance labels";
+  if (theDepositInstanceLabels.size() != 3) {
+    LogError("MuonIsolation") << "Configuration is inconsistent: Need 3 deposit instance labels";
   }
-  if (! (theDepositInstanceLabels[0].compare(0,1, std::string("e")) == 0)
-      || ! (theDepositInstanceLabels[1].compare(0,1, std::string("h")) == 0)
-      || ! (theDepositInstanceLabels[2].compare(0,2, std::string("ho")) == 0)){
-    LogWarning("MuonIsolation")<<"Deposit instance labels do not look like  (e*, h*, ho*):"
-			       <<"proceed at your own risk. The extractor interprets lab0=from ecal; lab1=from hcal; lab2=from ho";
+  if (!(theDepositInstanceLabels[0].compare(0, 1, std::string("e")) == 0) ||
+      !(theDepositInstanceLabels[1].compare(0, 1, std::string("h")) == 0) ||
+      !(theDepositInstanceLabels[2].compare(0, 2, std::string("ho")) == 0)) {
+    LogWarning("MuonIsolation")
+        << "Deposit instance labels do not look like  (e*, h*, ho*):"
+        << "proceed at your own risk. The extractor interprets lab0=from ecal; lab1=from hcal; lab2=from ho";
   }
 
   typedef IsoDeposit::Veto Veto;
@@ -124,34 +127,36 @@ std::vector<IsoDeposit> CaloExtractorByAssociator::deposits( const Event & event
   edm::ESHandle<MagneticField> bField;
   eventSetup.get<IdealMagneticFieldRecord>().get(bField);
 
-
   reco::TransientTrack tMuon(muon, &*bField);
   FreeTrajectoryState iFTS = tMuon.initialFreeState();
   TrackDetMatchInfo mInfo = theAssociator->associate(event, eventSetup, iFTS, *theAssociatorParameters);
 
   //! each deposit type veto is at the point of intersect with that detector
-  depEcal.setVeto(Veto(reco::isodeposit::Direction(mInfo.trkGlobPosAtEcal.eta(), mInfo.trkGlobPosAtEcal.phi()),
-		       theDR_Veto_E));
-  depHcal.setVeto(Veto(reco::isodeposit::Direction(mInfo.trkGlobPosAtHcal.eta(), mInfo.trkGlobPosAtHcal.phi()),
-		       theDR_Veto_H));
-  depHOcal.setVeto(Veto(reco::isodeposit::Direction(mInfo.trkGlobPosAtHO.eta(), mInfo.trkGlobPosAtHO.phi()),
-			theDR_Veto_HO));
+  depEcal.setVeto(
+      Veto(reco::isodeposit::Direction(mInfo.trkGlobPosAtEcal.eta(), mInfo.trkGlobPosAtEcal.phi()), theDR_Veto_E));
+  depHcal.setVeto(
+      Veto(reco::isodeposit::Direction(mInfo.trkGlobPosAtHcal.eta(), mInfo.trkGlobPosAtHcal.phi()), theDR_Veto_H));
+  depHOcal.setVeto(
+      Veto(reco::isodeposit::Direction(mInfo.trkGlobPosAtHO.eta(), mInfo.trkGlobPosAtHO.phi()), theDR_Veto_HO));
 
-  if (theCenterConeOnCalIntersection){
+  if (theCenterConeOnCalIntersection) {
     reco::isodeposit::Direction dirTmp = depEcal.veto().vetoDir;
     double dRtmp = depEcal.veto().dR;
-    depEcal = IsoDeposit(dirTmp); depEcal.setVeto(Veto(dirTmp, dRtmp));
+    depEcal = IsoDeposit(dirTmp);
+    depEcal.setVeto(Veto(dirTmp, dRtmp));
 
     dirTmp = depHcal.veto().vetoDir;
     dRtmp = depHcal.veto().dR;
-    depHcal = IsoDeposit(dirTmp); depHcal.setVeto(Veto(dirTmp, dRtmp));
+    depHcal = IsoDeposit(dirTmp);
+    depHcal.setVeto(Veto(dirTmp, dRtmp));
 
     dirTmp = depHOcal.veto().vetoDir;
     dRtmp = depHOcal.veto().dR;
-    depHOcal = IsoDeposit(dirTmp); depHOcal.setVeto(Veto(dirTmp, dRtmp));
+    depHOcal = IsoDeposit(dirTmp);
+    depHOcal.setVeto(Veto(dirTmp, dRtmp));
   }
 
-  if (theUseRecHitsFlag){
+  if (theUseRecHitsFlag) {
     //! do things based on rec-hits here
     //! too much copy-pasting now (refactor later?)
     edm::ESHandle<CaloGeometry> caloGeom;
@@ -159,200 +164,211 @@ std::vector<IsoDeposit> CaloExtractorByAssociator::deposits( const Event & event
 
     //Ecal
     std::vector<const EcalRecHit*>::const_iterator eHitCI = mInfo.ecalRecHits.begin();
-    for (; eHitCI != mInfo.ecalRecHits.end(); ++eHitCI){
+    for (; eHitCI != mInfo.ecalRecHits.end(); ++eHitCI) {
       const EcalRecHit* eHitCPtr = *eHitCI;
       GlobalPoint eHitPos = caloGeom->getPosition(eHitCPtr->detid());
       double deltar0 = reco::deltaR(muon, eHitPos);
-      double cosTheta = 1./cosh(eHitPos.eta());
+      double cosTheta = 1. / cosh(eHitPos.eta());
       double energy = eHitCPtr->energy();
-      double et = energy*cosTheta;
-      if (deltar0 > std::max(dRMax_CandDep, theDR_Max)
-	  || ! (et > theThreshold_E && energy > 3*noiseRecHit(eHitCPtr->detid()))) continue;
+      double et = energy * cosTheta;
+      if (deltar0 > std::max(dRMax_CandDep, theDR_Max) ||
+          !(et > theThreshold_E && energy > 3 * noiseRecHit(eHitCPtr->detid())))
+        continue;
 
       bool vetoHit = false;
       double deltar = reco::deltaR(mInfo.trkGlobPosAtEcal, eHitPos);
       //! first check if the hit is inside the veto cone by dR-alone
-      if (deltar < theDR_Veto_E ){
-	LogDebug("RecoMuon|CaloExtractorByAssociator")
-	  << " >>> Veto ECAL hit: Calo deltaR= " << deltar;
-	LogDebug("RecoMuon|CaloExtractorByAssociator")
-	  << " >>> Calo eta phi ethcal: " << eHitPos.eta() << " " << eHitPos.phi() << " " << et;
-	vetoHit = true;
+      if (deltar < theDR_Veto_E) {
+        LogDebug("RecoMuon|CaloExtractorByAssociator") << " >>> Veto ECAL hit: Calo deltaR= " << deltar;
+        LogDebug("RecoMuon|CaloExtractorByAssociator")
+            << " >>> Calo eta phi ethcal: " << eHitPos.eta() << " " << eHitPos.phi() << " " << et;
+        vetoHit = true;
       }
       //! and now pitch those in the crossed list
-      if (! vetoHit){
-	for (unsigned int iH = 0; iH< mInfo.crossedEcalIds.size() && ! vetoHit; ++iH){
-	  if (mInfo.crossedEcalIds[iH].rawId() == eHitCPtr->detid().rawId()) vetoHit = true;
-	}
+      if (!vetoHit) {
+        for (unsigned int iH = 0; iH < mInfo.crossedEcalIds.size() && !vetoHit; ++iH) {
+          if (mInfo.crossedEcalIds[iH].rawId() == eHitCPtr->detid().rawId())
+            vetoHit = true;
+        }
       }
 
       //check theDR_Max only here to keep vetoHits being added to the veto energy
-      if (deltar0 > theDR_Max && ! vetoHit) continue;
+      if (deltar0 > theDR_Max && !vetoHit)
+        continue;
 
-      if (vetoHit ){
-	depEcal.addCandEnergy(et);
+      if (vetoHit) {
+        depEcal.addCandEnergy(et);
       } else {
-	depEcal.addDeposit(reco::isodeposit::Direction(eHitPos.eta(), eHitPos.phi()), et);
+        depEcal.addDeposit(reco::isodeposit::Direction(eHitPos.eta(), eHitPos.phi()), et);
       }
     }
 
     //Hcal
     std::vector<const HBHERecHit*>::const_iterator hHitCI = mInfo.hcalRecHits.begin();
-    for (; hHitCI != mInfo.hcalRecHits.end(); ++hHitCI){
+    for (; hHitCI != mInfo.hcalRecHits.end(); ++hHitCI) {
       const HBHERecHit* hHitCPtr = *hHitCI;
       GlobalPoint hHitPos = caloGeom->getPosition(hHitCPtr->detid());
       double deltar0 = reco::deltaR(muon, hHitPos);
-      double cosTheta = 1./cosh(hHitPos.eta());
+      double cosTheta = 1. / cosh(hHitPos.eta());
       double energy = hHitCPtr->energy();
-      double et = energy*cosTheta;
-      if (deltar0 > std::max(dRMax_CandDep, theDR_Max)
-	  || ! (et > theThreshold_H && energy > 3*noiseRecHit(hHitCPtr->detid()))) continue;
+      double et = energy * cosTheta;
+      if (deltar0 > std::max(dRMax_CandDep, theDR_Max) ||
+          !(et > theThreshold_H && energy > 3 * noiseRecHit(hHitCPtr->detid())))
+        continue;
 
       bool vetoHit = false;
       double deltar = reco::deltaR(mInfo.trkGlobPosAtHcal, hHitPos);
       //! first check if the hit is inside the veto cone by dR-alone
-      if (deltar < theDR_Veto_H ){
-	LogDebug("RecoMuon|CaloExtractorByAssociator")
-	  << " >>> Veto HBHE hit: Calo deltaR= " << deltar;
-	LogDebug("RecoMuon|CaloExtractorByAssociator")
-	  << " >>> Calo eta phi ethcal: " << hHitPos.eta() << " " << hHitPos.phi() << " " << et;
-	vetoHit = true;
+      if (deltar < theDR_Veto_H) {
+        LogDebug("RecoMuon|CaloExtractorByAssociator") << " >>> Veto HBHE hit: Calo deltaR= " << deltar;
+        LogDebug("RecoMuon|CaloExtractorByAssociator")
+            << " >>> Calo eta phi ethcal: " << hHitPos.eta() << " " << hHitPos.phi() << " " << et;
+        vetoHit = true;
       }
       //! and now pitch those in the crossed list
-      if (! vetoHit){
-	for (unsigned int iH = 0; iH< mInfo.crossedHcalIds.size() && ! vetoHit; ++iH){
-	  if (mInfo.crossedHcalIds[iH].rawId() == hHitCPtr->detid().rawId()) vetoHit = true;
-	}
+      if (!vetoHit) {
+        for (unsigned int iH = 0; iH < mInfo.crossedHcalIds.size() && !vetoHit; ++iH) {
+          if (mInfo.crossedHcalIds[iH].rawId() == hHitCPtr->detid().rawId())
+            vetoHit = true;
+        }
       }
 
       //check theDR_Max only here to keep vetoHits being added to the veto energy
-      if (deltar0 > theDR_Max && ! vetoHit) continue;
+      if (deltar0 > theDR_Max && !vetoHit)
+        continue;
 
-      if (vetoHit ){
-	depHcal.addCandEnergy(et);
+      if (vetoHit) {
+        depHcal.addCandEnergy(et);
       } else {
-	depHcal.addDeposit(reco::isodeposit::Direction(hHitPos.eta(), hHitPos.phi()), et);
+        depHcal.addDeposit(reco::isodeposit::Direction(hHitPos.eta(), hHitPos.phi()), et);
       }
     }
 
     //HOcal
     std::vector<const HORecHit*>::const_iterator hoHitCI = mInfo.hoRecHits.begin();
-    for (; hoHitCI != mInfo.hoRecHits.end(); ++hoHitCI){
+    for (; hoHitCI != mInfo.hoRecHits.end(); ++hoHitCI) {
       const HORecHit* hoHitCPtr = *hoHitCI;
       GlobalPoint hoHitPos = caloGeom->getPosition(hoHitCPtr->detid());
       double deltar0 = reco::deltaR(muon, hoHitPos);
-      double cosTheta = 1./cosh(hoHitPos.eta());
+      double cosTheta = 1. / cosh(hoHitPos.eta());
       double energy = hoHitCPtr->energy();
-      double et = energy*cosTheta;
-      if (deltar0 > std::max(dRMax_CandDep, theDR_Max)
-	  || ! (et > theThreshold_HO && energy > 3*noiseRecHit(hoHitCPtr->detid()))) continue;
+      double et = energy * cosTheta;
+      if (deltar0 > std::max(dRMax_CandDep, theDR_Max) ||
+          !(et > theThreshold_HO && energy > 3 * noiseRecHit(hoHitCPtr->detid())))
+        continue;
 
       bool vetoHit = false;
       double deltar = reco::deltaR(mInfo.trkGlobPosAtHO, hoHitPos);
       //! first check if the hit is inside the veto cone by dR-alone
-      if (deltar < theDR_Veto_HO ){
-	LogDebug("RecoMuon|CaloExtractorByAssociator")
-	  << " >>> Veto HO hit: Calo deltaR= " << deltar;
-	LogDebug("RecoMuon|CaloExtractorByAssociator")
-	  << " >>> Calo eta phi ethcal: " << hoHitPos.eta() << " " << hoHitPos.phi() << " " << et;
-	vetoHit = true;
+      if (deltar < theDR_Veto_HO) {
+        LogDebug("RecoMuon|CaloExtractorByAssociator") << " >>> Veto HO hit: Calo deltaR= " << deltar;
+        LogDebug("RecoMuon|CaloExtractorByAssociator")
+            << " >>> Calo eta phi ethcal: " << hoHitPos.eta() << " " << hoHitPos.phi() << " " << et;
+        vetoHit = true;
       }
       //! and now pitch those in the crossed list
-      if (! vetoHit){
-	for (unsigned int iH = 0; iH< mInfo.crossedHOIds.size() && ! vetoHit; ++iH){
-	  if (mInfo.crossedHOIds[iH].rawId() == hoHitCPtr->detid().rawId()) vetoHit = true;
-	}
+      if (!vetoHit) {
+        for (unsigned int iH = 0; iH < mInfo.crossedHOIds.size() && !vetoHit; ++iH) {
+          if (mInfo.crossedHOIds[iH].rawId() == hoHitCPtr->detid().rawId())
+            vetoHit = true;
+        }
       }
 
       //check theDR_Max only here to keep vetoHits being added to the veto energy
-      if (deltar0 > theDR_Max && ! vetoHit) continue;
+      if (deltar0 > theDR_Max && !vetoHit)
+        continue;
 
-      if (vetoHit ){
-	depHOcal.addCandEnergy(et);
+      if (vetoHit) {
+        depHOcal.addCandEnergy(et);
       } else {
-	depHOcal.addDeposit(reco::isodeposit::Direction(hoHitPos.eta(), hoHitPos.phi()), et);
+        depHOcal.addDeposit(reco::isodeposit::Direction(hoHitPos.eta(), hoHitPos.phi()), et);
       }
     }
-
 
   } else {
     //! use calo towers
     std::vector<const CaloTower*>::const_iterator calCI = mInfo.towers.begin();
-    for (; calCI != mInfo.towers.end(); ++calCI){
+    for (; calCI != mInfo.towers.end(); ++calCI) {
       const CaloTower* calCPtr = *calCI;
-      double deltar0 = reco::deltaR(muon,*calCPtr);
-      if (deltar0> std::max(dRMax_CandDep, theDR_Max)) continue; 
+      double deltar0 = reco::deltaR(muon, *calCPtr);
+      if (deltar0 > std::max(dRMax_CandDep, theDR_Max))
+        continue;
 
       //even more copy-pasting .. need to refactor
       double etecal = calCPtr->emEt();
       double eecal = calCPtr->emEnergy();
-      bool doEcal = etecal>theThreshold_E && eecal>3*noiseEcal(*calCPtr);
+      bool doEcal = etecal > theThreshold_E && eecal > 3 * noiseEcal(*calCPtr);
       double ethcal = calCPtr->hadEt();
       double ehcal = calCPtr->hadEnergy();
-      bool doHcal = ethcal>theThreshold_H && ehcal>3*noiseHcal(*calCPtr);
+      bool doHcal = ethcal > theThreshold_H && ehcal > 3 * noiseHcal(*calCPtr);
       double ethocal = calCPtr->outerEt();
       double ehocal = calCPtr->outerEnergy();
-      bool doHOcal = ethocal>theThreshold_HO && ehocal>3*noiseHOcal(*calCPtr);
-      if ((!doEcal) && (!doHcal) && (!doHcal)) continue;
+      bool doHOcal = ethocal > theThreshold_HO && ehocal > 3 * noiseHOcal(*calCPtr);
+      if ((!doEcal) && (!doHcal) && (!doHcal))
+        continue;
 
       bool vetoTowerEcal = false;
       double deltarEcal = reco::deltaR(mInfo.trkGlobPosAtEcal, *calCPtr);
       //! first check if the tower is inside the veto cone by dR-alone
-      if (deltarEcal < theDR_Veto_E ){
-	LogDebug("RecoMuon|CaloExtractorByAssociator")
-	  << " >>> Veto ecal tower: Calo deltaR= " << deltarEcal;
-	LogDebug("RecoMuon|CaloExtractorByAssociator")
-	  << " >>> Calo eta phi ethcal: " << calCPtr->eta() << " " << calCPtr->phi() << " " << ethcal;
-	vetoTowerEcal = true;
+      if (deltarEcal < theDR_Veto_E) {
+        LogDebug("RecoMuon|CaloExtractorByAssociator") << " >>> Veto ecal tower: Calo deltaR= " << deltarEcal;
+        LogDebug("RecoMuon|CaloExtractorByAssociator")
+            << " >>> Calo eta phi ethcal: " << calCPtr->eta() << " " << calCPtr->phi() << " " << ethcal;
+        vetoTowerEcal = true;
       }
       bool vetoTowerHcal = false;
       double deltarHcal = reco::deltaR(mInfo.trkGlobPosAtHcal, *calCPtr);
       //! first check if the tower is inside the veto cone by dR-alone
-      if (deltarHcal < theDR_Veto_H ){
-	LogDebug("RecoMuon|CaloExtractorByAssociator")
-	  << " >>> Veto hcal tower: Calo deltaR= " << deltarHcal;
-	LogDebug("RecoMuon|CaloExtractorByAssociator")
-	  << " >>> Calo eta phi ethcal: " << calCPtr->eta() << " " << calCPtr->phi() << " " << ethcal;
-	vetoTowerHcal = true;
+      if (deltarHcal < theDR_Veto_H) {
+        LogDebug("RecoMuon|CaloExtractorByAssociator") << " >>> Veto hcal tower: Calo deltaR= " << deltarHcal;
+        LogDebug("RecoMuon|CaloExtractorByAssociator")
+            << " >>> Calo eta phi ethcal: " << calCPtr->eta() << " " << calCPtr->phi() << " " << ethcal;
+        vetoTowerHcal = true;
       }
       bool vetoTowerHOCal = false;
       double deltarHOcal = reco::deltaR(mInfo.trkGlobPosAtHO, *calCPtr);
       //! first check if the tower is inside the veto cone by dR-alone
-      if (deltarHOcal < theDR_Veto_HO ){
-	LogDebug("RecoMuon|CaloExtractorByAssociator")
-	  << " >>> Veto HO tower: Calo deltaR= " << deltarHOcal;
-	LogDebug("RecoMuon|CaloExtractorByAssociator")
-	  << " >>> Calo eta phi ethcal: " << calCPtr->eta() << " " << calCPtr->phi() << " " << ethcal;
-	vetoTowerHOCal = true;
+      if (deltarHOcal < theDR_Veto_HO) {
+        LogDebug("RecoMuon|CaloExtractorByAssociator") << " >>> Veto HO tower: Calo deltaR= " << deltarHOcal;
+        LogDebug("RecoMuon|CaloExtractorByAssociator")
+            << " >>> Calo eta phi ethcal: " << calCPtr->eta() << " " << calCPtr->phi() << " " << ethcal;
+        vetoTowerHOCal = true;
       }
 
       //! and now pitch those in the crossed list
-      if (! (vetoTowerHOCal && vetoTowerHcal &&  vetoTowerEcal )){
-	for (unsigned int iH = 0; iH< mInfo.crossedTowerIds.size(); ++iH){
-	  if (mInfo.crossedTowerIds[iH].rawId() == calCPtr->id().rawId()){
-	    vetoTowerEcal = true;
-	    vetoTowerHcal = true;
-	    vetoTowerHOCal = true;
-	    break;
-	  }
-	}
+      if (!(vetoTowerHOCal && vetoTowerHcal && vetoTowerEcal)) {
+        for (unsigned int iH = 0; iH < mInfo.crossedTowerIds.size(); ++iH) {
+          if (mInfo.crossedTowerIds[iH].rawId() == calCPtr->id().rawId()) {
+            vetoTowerEcal = true;
+            vetoTowerHcal = true;
+            vetoTowerHOCal = true;
+            break;
+          }
+        }
       }
 
-      if (deltar0>theDR_Max && !(vetoTowerEcal || vetoTowerHcal || vetoTowerHOCal)) continue;
+      if (deltar0 > theDR_Max && !(vetoTowerEcal || vetoTowerHcal || vetoTowerHOCal))
+        continue;
 
       reco::isodeposit::Direction towerDir(calCPtr->eta(), calCPtr->phi());
       //! add the Et of the tower to deposits if it's not a vetoed; put into muonEnergy otherwise
-      if (doEcal){
-	if (vetoTowerEcal) depEcal.addCandEnergy(etecal);
-	else if (deltar0<=theDR_Max) depEcal.addDeposit(towerDir, etecal);
+      if (doEcal) {
+        if (vetoTowerEcal)
+          depEcal.addCandEnergy(etecal);
+        else if (deltar0 <= theDR_Max)
+          depEcal.addDeposit(towerDir, etecal);
       }
-      if (doHcal){
-	if (vetoTowerHcal) depHcal.addCandEnergy(ethcal);
-	else if (deltar0<=theDR_Max) depHcal.addDeposit(towerDir, ethcal);
+      if (doHcal) {
+        if (vetoTowerHcal)
+          depHcal.addCandEnergy(ethcal);
+        else if (deltar0 <= theDR_Max)
+          depHcal.addDeposit(towerDir, ethcal);
       }
-      if (doHOcal){
-	if (vetoTowerHOCal) depHOcal.addCandEnergy(ethocal);
-	else if (deltar0<=theDR_Max) depHOcal.addDeposit(towerDir, ethocal);
+      if (doHOcal) {
+        if (vetoTowerHOCal)
+          depHOcal.addCandEnergy(ethocal);
+        else if (deltar0 <= theDR_Max)
+          depHOcal.addDeposit(towerDir, ethocal);
       }
     }
   }
@@ -363,47 +379,45 @@ std::vector<IsoDeposit> CaloExtractorByAssociator::deposits( const Event & event
   resultDeps.push_back(depHOcal);
 
   return resultDeps;
-
 }
 
 double CaloExtractorByAssociator::noiseEcal(const CaloTower& tower) const {
-      double noise = theNoiseTow_EB;
-      double eta = tower.eta();
-      if (fabs(eta)>1.479) noise = theNoiseTow_EE;
-      return noise;
+  double noise = theNoiseTow_EB;
+  double eta = tower.eta();
+  if (fabs(eta) > 1.479)
+    noise = theNoiseTow_EE;
+  return noise;
 }
 
 double CaloExtractorByAssociator::noiseHcal(const CaloTower& tower) const {
-  double noise = fabs(tower.eta())> 1.479 ? theNoise_HE : theNoise_HB;
+  double noise = fabs(tower.eta()) > 1.479 ? theNoise_HE : theNoise_HB;
   return noise;
 }
 
 double CaloExtractorByAssociator::noiseHOcal(const CaloTower& tower) const {
-      double noise = theNoise_HO;
-      return noise;
+  double noise = theNoise_HO;
+  return noise;
 }
 
-
 double CaloExtractorByAssociator::noiseRecHit(const DetId& detId) const {
-  double  noise = 100;
+  double noise = 100;
   DetId::Detector det = detId.det();
-  if (det == DetId::Ecal){
+  if (det == DetId::Ecal) {
     EcalSubdetector subDet = (EcalSubdetector)(detId.subdetId());
-    if (subDet == EcalBarrel){
+    if (subDet == EcalBarrel) {
       noise = theNoise_EB;
-    } else if (subDet == EcalEndcap){
+    } else if (subDet == EcalEndcap) {
       noise = theNoise_EE;
     }
-  } else if (det == DetId::Hcal){
+  } else if (det == DetId::Hcal) {
     HcalSubdetector subDet = (HcalSubdetector)(detId.subdetId());
-    if (subDet == HcalBarrel){
+    if (subDet == HcalBarrel) {
       noise = theNoise_HB;
-    } else if (subDet == HcalEndcap){
+    } else if (subDet == HcalEndcap) {
       noise = theNoise_HE;
-    } else if (subDet == HcalOuter){
+    } else if (subDet == HcalOuter) {
       noise = theNoise_HO;
     }
   }
   return noise;
 }
-

--- a/RecoMuon/MuonIsolation/plugins/CaloExtractorByAssociator.h
+++ b/RecoMuon/MuonIsolation/plugins/CaloExtractorByAssociator.h
@@ -32,27 +32,26 @@ class MuonServiceProxy;
 namespace muonisolation {
 
   class CaloExtractorByAssociator : public reco::isodeposit::IsoDepositExtractor {
-
   public:
-
     //! constructors
     CaloExtractorByAssociator(){};
-    CaloExtractorByAssociator(const edm::ParameterSet& par, edm::ConsumesCollector && iC);
+    CaloExtractorByAssociator(const edm::ParameterSet& par, edm::ConsumesCollector&& iC);
 
     //! destructor
     ~CaloExtractorByAssociator() override;
 
     //! allows to set extra vetoes (in addition to the muon) -- no-op at this point
-    void fillVetos (const edm::Event & ev, const edm::EventSetup & evSetup, const reco::TrackCollection & tracks) override;
+    void fillVetos(const edm::Event& ev, const edm::EventSetup& evSetup, const reco::TrackCollection& tracks) override;
     //! no-op: by design of this extractor the deposits are pulled out all at a time
-    reco::IsoDeposit
-      deposit(const edm::Event & ev, const edm::EventSetup & evSetup, const reco::Track & track) const override;
+    reco::IsoDeposit deposit(const edm::Event& ev,
+                             const edm::EventSetup& evSetup,
+                             const reco::Track& track) const override;
     //! return deposits for 3 calorimeter subdetectors (ecal, hcal, ho) -- in this order
-    std::vector<reco::IsoDeposit>
-      deposits(const edm::Event & ev, const edm::EventSetup & evSetup, const reco::Track & track) const override;
+    std::vector<reco::IsoDeposit> deposits(const edm::Event& ev,
+                                           const edm::EventSetup& evSetup,
+                                           const reco::Track& track) const override;
 
   private:
-
     //! use towers or rec hits
     bool theUseRecHitsFlag;
 
@@ -97,7 +96,6 @@ namespace muonisolation {
     //! the event setup proxy, it takes care the services update
     MuonServiceProxy* theService;
 
-
     //! associator, its' parameters and the propagator
     TrackAssociatorParameters* theAssociatorParameters;
     TrackDetectorAssociator* theAssociator;
@@ -110,9 +108,8 @@ namespace muonisolation {
     double noiseHcal(const CaloTower& tower) const;
     double noiseHOcal(const CaloTower& tower) const;
     double noiseRecHit(const DetId& detId) const;
-
   };
 
-}
+}  // namespace muonisolation
 
 #endif

--- a/RecoMuon/MuonIsolation/plugins/CutsIsolatorWithCorrection.cc
+++ b/RecoMuon/MuonIsolation/plugins/CutsIsolatorWithCorrection.cc
@@ -5,29 +5,28 @@
 
 using namespace muonisolation;
 
-CutsIsolatorWithCorrection::CutsIsolatorWithCorrection(const edm::ParameterSet & par,
-						       edm::ConsumesCollector && iC ):
-  theCuts(par.getParameter<std::vector<double> > ("EtaBounds"),
-	  par.getParameter<std::vector<double> > ("ConeSizes"),
-	  par.getParameter<std::vector<double> > ("Thresholds")),
-  theCutsRel(par.getParameter<std::vector<double> > ("EtaBoundsRel"),
-	  par.getParameter<std::vector<double> > ("ConeSizesRel"),
-	  par.getParameter<std::vector<double> > ("ThresholdsRel")),
-  theCutAbsIso(par.getParameter<bool>("CutAbsoluteIso")),
-  theCutRelativeIso(par.getParameter<bool>("CutRelativeIso")),
-  theUseRhoCorrection(par.getParameter<bool>("UseRhoCorrection")),
-  theRhoToken(iC.consumes<double>(par.getParameter<edm::InputTag>("RhoSrc"))),
-  theRhoMax(par.getParameter<double>("RhoMax")),
-  theRhoScaleBarrel(par.getParameter<double>("RhoScaleBarrel")),
-  theRhoScaleEndcap(par.getParameter<double>("RhoScaleEndcap")),
-  theEffAreaSFBarrel(par.getParameter<double>("EffAreaSFBarrel")),
-  theEffAreaSFEndcap(par.getParameter<double>("EffAreaSFEndcap")),
-  theReturnAbsoluteSum(par.getParameter<bool>("ReturnAbsoluteSum")),
-  theReturnRelativeSum(par.getParameter<bool>("ReturnRelativeSum")),
-  theAndOrCuts(par.getParameter<bool>("AndOrCuts"))
-{
-  if (! ( theCutAbsIso || theCutRelativeIso ) ) throw cms::Exception("BadConfiguration")
-    << "Something has to be cut: set either CutAbsoluteIso or CutRelativeIso to true";
+CutsIsolatorWithCorrection::CutsIsolatorWithCorrection(const edm::ParameterSet& par, edm::ConsumesCollector&& iC)
+    : theCuts(par.getParameter<std::vector<double> >("EtaBounds"),
+              par.getParameter<std::vector<double> >("ConeSizes"),
+              par.getParameter<std::vector<double> >("Thresholds")),
+      theCutsRel(par.getParameter<std::vector<double> >("EtaBoundsRel"),
+                 par.getParameter<std::vector<double> >("ConeSizesRel"),
+                 par.getParameter<std::vector<double> >("ThresholdsRel")),
+      theCutAbsIso(par.getParameter<bool>("CutAbsoluteIso")),
+      theCutRelativeIso(par.getParameter<bool>("CutRelativeIso")),
+      theUseRhoCorrection(par.getParameter<bool>("UseRhoCorrection")),
+      theRhoToken(iC.consumes<double>(par.getParameter<edm::InputTag>("RhoSrc"))),
+      theRhoMax(par.getParameter<double>("RhoMax")),
+      theRhoScaleBarrel(par.getParameter<double>("RhoScaleBarrel")),
+      theRhoScaleEndcap(par.getParameter<double>("RhoScaleEndcap")),
+      theEffAreaSFBarrel(par.getParameter<double>("EffAreaSFBarrel")),
+      theEffAreaSFEndcap(par.getParameter<double>("EffAreaSFEndcap")),
+      theReturnAbsoluteSum(par.getParameter<bool>("ReturnAbsoluteSum")),
+      theReturnRelativeSum(par.getParameter<bool>("ReturnRelativeSum")),
+      theAndOrCuts(par.getParameter<bool>("AndOrCuts")) {
+  if (!(theCutAbsIso || theCutRelativeIso))
+    throw cms::Exception("BadConfiguration")
+        << "Something has to be cut: set either CutAbsoluteIso or CutRelativeIso to true";
 }
 
 double CutsIsolatorWithCorrection::depSum(const DepositContainer& deposits, double dr, double corr) const {
@@ -35,7 +34,7 @@ double CutsIsolatorWithCorrection::depSum(const DepositContainer& deposits, doub
   unsigned int nDeps = deposits.size();
   //  edm::LogWarning("CutsIsolatorWithCorrection::depSumIn")
   //    << "add nDeposit "<< nDeps<< " \t dr "<<dr<<" \t corr "<<corr;
-  for(unsigned int iDep = 0; iDep < nDeps; ++iDep ){
+  for (unsigned int iDep = 0; iDep < nDeps; ++iDep) {
     double lDep = deposits[iDep].dep->depositWithin(dr);
     dephlt += lDep;
     //    edm::LogWarning("CutsIsolatorWithCorrection::depSumIDep")
@@ -45,9 +44,11 @@ double CutsIsolatorWithCorrection::depSum(const DepositContainer& deposits, doub
   return dephlt;
 }
 
-MuIsoBaseIsolator::Result CutsIsolatorWithCorrection::result(const DepositContainer& deposits, const reco::Track& tk, const edm::Event* ev ) const {
+MuIsoBaseIsolator::Result CutsIsolatorWithCorrection::result(const DepositContainer& deposits,
+                                                             const reco::Track& tk,
+                                                             const edm::Event* ev) const {
   Result answer(ISOL_BOOL_TYPE);
-  
+
   bool absDecision = false;
   bool relDecision = false;
 
@@ -59,54 +60,56 @@ MuIsoBaseIsolator::Result CutsIsolatorWithCorrection::result(const DepositContai
   //  edm::LogWarning("CutsIsolatorWithCorrection::resultIn")
   //    <<"Start tk.pt "<<tk.pt()<<" \t tk.eta "<<tk.eta()<<" \t tk.phi "<<tk.phi();
 
-
-
-  if (theUseRhoCorrection){
-    edm::Handle<double> rhoHandle; 
-    ev->getByToken(theRhoToken, rhoHandle); 
+  if (theUseRhoCorrection) {
+    edm::Handle<double> rhoHandle;
+    ev->getByToken(theRhoToken, rhoHandle);
     rho = *(rhoHandle.product());
-    if (rho < 0.0) rho = 0.0;
+    if (rho < 0.0)
+      rho = 0.0;
     double rhoScale = fabs(tk.eta()) > 1.442 ? theRhoScaleEndcap : theRhoScaleBarrel;
     effAreaSF = fabs(tk.eta()) > 1.442 ? theEffAreaSFEndcap : theEffAreaSFBarrel;
     //    edm::LogWarning("CutsIsolatorWithCorrection::resultInRho")
     //      << "got rho "<<rho<<" vs max "<<theRhoMax<<" will scale by "<<rhoScale;
-    if (rho > theRhoMax){
+    if (rho > theRhoMax) {
       rho = theRhoMax;
     }
-    rho = rho*rhoScale;
+    rho = rho * rhoScale;
     //    edm::LogWarning("CutsIsolatorWithCorrection::resultOutRho")<<" final rho "<<rho;
   }
 
-  if (theCutAbsIso){
+  if (theCutAbsIso) {
     muonisolation::Cuts::CutSpec cuts_here = theCuts(tk.eta());
     double conesize = cuts_here.conesize;
-    double dephlt = depSum(deposits, conesize, rho*conesize*conesize*pi*effAreaSF);
-    if (theReturnAbsoluteSum ) answer.valFloat = (float)dephlt;
-    if (dephlt<cuts_here.threshold) {
+    double dephlt = depSum(deposits, conesize, rho * conesize * conesize * pi * effAreaSF);
+    if (theReturnAbsoluteSum)
+      answer.valFloat = (float)dephlt;
+    if (dephlt < cuts_here.threshold) {
       absDecision = true;
     } else {
       absDecision = false;
     }
     //    edm::LogWarning("CutsIsolatorWithCorrection::resultOutAbsIso")
     //      <<"compared dephlt "<<dephlt<<" \t with "<<cuts_here.threshold;
-  } else absDecision = true;
-  
-  if (theCutRelativeIso){
+  } else
+    absDecision = true;
+
+  if (theCutRelativeIso) {
     muonisolation::Cuts::CutSpec cuts_here = theCutsRel(tk.eta());
     double conesize = cuts_here.conesize;
-    double dephlt = depSum(deposits, conesize, rho*conesize*conesize*pi*effAreaSF)/tk.pt();
-    if (theReturnRelativeSum ) answer.valFloat = (float)dephlt;
-    if (dephlt<cuts_here.threshold) {
+    double dephlt = depSum(deposits, conesize, rho * conesize * conesize * pi * effAreaSF) / tk.pt();
+    if (theReturnRelativeSum)
+      answer.valFloat = (float)dephlt;
+    if (dephlt < cuts_here.threshold) {
       relDecision = true;
     } else {
       relDecision = false;
     }
     //    edm::LogWarning("CutsIsolatorWithCorrection::resultOutRelIso")
     //      <<"compared dephlt "<<dephlt<<" \t with "<<cuts_here.threshold;
-  } else relDecision = true;
-  
+  } else
+    relDecision = true;
 
-  if (theAndOrCuts){
+  if (theAndOrCuts) {
     answer.valBool = absDecision && relDecision;
   } else {
     answer.valBool = absDecision || relDecision;
@@ -116,6 +119,6 @@ MuIsoBaseIsolator::Result CutsIsolatorWithCorrection::result(const DepositContai
   //    <<"isAbsIsolated "<<absDecision<<" \t isRelIsolated  "<<relDecision
   //    <<" \t combined with AND "<<theAndOrCuts
   //    <<" = "  << answer.valBool;
-  
+
   return answer;
 }

--- a/RecoMuon/MuonIsolation/plugins/CutsIsolatorWithCorrection.h
+++ b/RecoMuon/MuonIsolation/plugins/CutsIsolatorWithCorrection.h
@@ -7,11 +7,10 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 class CutsIsolatorWithCorrection : public muonisolation::MuIsoBaseIsolator {
- public:
-  CutsIsolatorWithCorrection(const edm::ParameterSet & par, 
-			     edm::ConsumesCollector && iC);
+public:
+  CutsIsolatorWithCorrection(const edm::ParameterSet& par, edm::ConsumesCollector&& iC);
 
-  ResultType resultType() const override {return ISOL_BOOL_TYPE;}
+  ResultType resultType() const override { return ISOL_BOOL_TYPE; }
 
   Result result(const DepositContainer& deposits, const edm::Event* = nullptr) const override {
     Result answer(ISOL_BOOL_TYPE);
@@ -21,8 +20,8 @@ class CutsIsolatorWithCorrection : public muonisolation::MuIsoBaseIsolator {
   }
 
   Result result(const DepositContainer& deposits, const reco::Track& tk, const edm::Event* = nullptr) const override;
-  
- private:
+
+private:
   double depSum(const DepositContainer& deposits, double dr, double corr) const;
 
   // Isolation cuts
@@ -41,7 +40,6 @@ class CutsIsolatorWithCorrection : public muonisolation::MuIsoBaseIsolator {
   bool theReturnAbsoluteSum;
   bool theReturnRelativeSum;
   bool theAndOrCuts;
-
 };
 
 #endif

--- a/RecoMuon/MuonIsolation/plugins/JetExtractor.h
+++ b/RecoMuon/MuonIsolation/plugins/JetExtractor.h
@@ -31,42 +31,40 @@ class MuonServiceProxy;
 
 namespace muonisolation {
 
-class JetExtractor : public reco::isodeposit::IsoDepositExtractor {
+  class JetExtractor : public reco::isodeposit::IsoDepositExtractor {
+  public:
+    JetExtractor(){};
+    JetExtractor(const edm::ParameterSet& par, edm::ConsumesCollector&& iC);
 
-public:
+    ~JetExtractor() override;
 
-  JetExtractor(){};
-  JetExtractor(const edm::ParameterSet& par, edm::ConsumesCollector && iC);
+    void fillVetos(const edm::Event& ev, const edm::EventSetup& evSetup, const reco::TrackCollection& tracks) override;
+    reco::IsoDeposit deposit(const edm::Event& ev,
+                             const edm::EventSetup& evSetup,
+                             const reco::Track& track) const override;
 
-  ~JetExtractor() override;
+  private:
+    edm::EDGetTokenT<reco::CaloJetCollection> theJetCollectionToken;
 
-  void fillVetos (const edm::Event & ev, const edm::EventSetup & evSetup, const reco::TrackCollection & tracks) override;
-  reco::IsoDeposit
-    deposit(const edm::Event & ev, const edm::EventSetup & evSetup, const reco::Track & track) const override;
+    std::string thePropagatorName;
 
-private:
-  edm::EDGetTokenT<reco::CaloJetCollection> theJetCollectionToken;
+    // Cone cuts and thresholds
+    double theThreshold;
+    double theDR_Veto;
+    double theDR_Max;
 
-  std::string thePropagatorName;
+    //excludes sumEt of towers that are inside muon veto cone
+    bool theExcludeMuonVeto;
 
-  // Cone cuts and thresholds
-  double theThreshold;
-  double theDR_Veto;
-  double theDR_Max;
+    //! the event setup proxy, it takes care the services update
+    MuonServiceProxy* theService;
 
-  //excludes sumEt of towers that are inside muon veto cone
-  bool theExcludeMuonVeto;
+    TrackAssociatorParameters* theAssociatorParameters;
+    TrackDetectorAssociator* theAssociator;
 
-  //! the event setup proxy, it takes care the services update
-  MuonServiceProxy* theService;
+    bool thePrintTimeReport;
+  };
 
-  TrackAssociatorParameters* theAssociatorParameters;
-  TrackDetectorAssociator* theAssociator;
-
-  bool thePrintTimeReport;
-
-};
-
-}
+}  // namespace muonisolation
 
 #endif

--- a/RecoMuon/MuonIsolation/plugins/MuonPFIsolationWithConeVeto.cc
+++ b/RecoMuon/MuonIsolation/plugins/MuonPFIsolationWithConeVeto.cc
@@ -12,23 +12,21 @@ namespace pat {
 
 class MuonPFIsolationWithConeVeto : public citk::IsolationConeDefinitionBase {
 public:
-  MuonPFIsolationWithConeVeto(const edm::ParameterSet& c) :
-    citk::IsolationConeDefinitionBase(c),
-    _vetoThreshold(c.getParameter<double>("VetoThreshold")),
-    _vetoConeSize2(std::pow(c.getParameter<double>("VetoConeSize"),2.0)),
-    _miniAODVertexCodes(c.getParameter<std::vector<unsigned> >("miniAODVertexCodes"))
-  {
+  MuonPFIsolationWithConeVeto(const edm::ParameterSet& c)
+      : citk::IsolationConeDefinitionBase(c),
+        _vetoThreshold(c.getParameter<double>("VetoThreshold")),
+        _vetoConeSize2(std::pow(c.getParameter<double>("VetoConeSize"), 2.0)),
+        _miniAODVertexCodes(c.getParameter<std::vector<unsigned> >("miniAODVertexCodes")) {
     char buf[50];
-    snprintf(buf,49,"ThresholdVeto%03.0f-ConeVeto%03.0f", 100*_vetoThreshold, 100*std::sqrt(_vetoConeSize2));
+    snprintf(buf, 49, "ThresholdVeto%03.0f-ConeVeto%03.0f", 100 * _vetoThreshold, 100 * std::sqrt(_vetoConeSize2));
     _additionalCode = std::string(buf);
   }
   MuonPFIsolationWithConeVeto(const MuonPFIsolationWithConeVeto&) = delete;
-  MuonPFIsolationWithConeVeto& operator=(const MuonPFIsolationWithConeVeto&) =delete;
+  MuonPFIsolationWithConeVeto& operator=(const MuonPFIsolationWithConeVeto&) = delete;
 
   void setConsumes(edm::ConsumesCollector) override {}
 
-  bool isInIsolationCone(const reco::CandidatePtr& physob,
-			 const reco::CandidatePtr& other) const final;
+  bool isInIsolationCone(const reco::CandidatePtr& physob, const reco::CandidatePtr& other) const final;
 
   //! Destructor
   ~MuonPFIsolationWithConeVeto() override{};
@@ -39,35 +37,32 @@ private:
   edm::EDGetTokenT<reco::VertexCollection> _vtxToken;
 };
 
-DEFINE_EDM_PLUGIN(CITKIsolationConeDefinitionFactory,
-		  MuonPFIsolationWithConeVeto,
-		  "MuonPFIsolationWithConeVeto");
+DEFINE_EDM_PLUGIN(CITKIsolationConeDefinitionFactory, MuonPFIsolationWithConeVeto, "MuonPFIsolationWithConeVeto");
 
 bool MuonPFIsolationWithConeVeto::isInIsolationCone(const reco::CandidatePtr& physob,
-                                                    const reco::CandidatePtr& iso_obj  ) const {
+                                                    const reco::CandidatePtr& iso_obj) const {
   const pat::PackedCandidatePtr aspacked(iso_obj);
   const reco::PFCandidatePtr aspf(iso_obj);
-  const double deltar2 = reco::deltaR2(*physob,*iso_obj);
+  const double deltar2 = reco::deltaR2(*physob, *iso_obj);
 
   bool result = true;
-  if( aspacked.isNonnull() && aspacked.get() ) {
-    if( aspacked->charge() != 0 ) {
+  if (aspacked.isNonnull() && aspacked.get()) {
+    if (aspacked->charge() != 0) {
       bool is_vertex_allowed = false;
-      for( const unsigned vtxtype : _miniAODVertexCodes ) {
-        if( vtxtype == aspacked->fromPV() ) {
+      for (const unsigned vtxtype : _miniAODVertexCodes) {
+        if (vtxtype == aspacked->fromPV()) {
           is_vertex_allowed = true;
           break;
         }
       }
-      result = result && ( is_vertex_allowed );
+      result = result && (is_vertex_allowed);
     }
-    result = result &&( aspacked->pt() > _vetoThreshold && deltar2 > _vetoConeSize2 && deltar2 < _coneSize2 );
-  } else if ( aspf.isNonnull() && aspf.get() ) {
-    result = result && ( aspf->pt() > _vetoThreshold && deltar2 > _vetoConeSize2 && deltar2 < _coneSize2 );
+    result = result && (aspacked->pt() > _vetoThreshold && deltar2 > _vetoConeSize2 && deltar2 < _coneSize2);
+  } else if (aspf.isNonnull() && aspf.get()) {
+    result = result && (aspf->pt() > _vetoThreshold && deltar2 > _vetoConeSize2 && deltar2 < _coneSize2);
   } else {
-    throw cms::Exception("InvalidIsolationInput")
-      << "The supplied candidate to be used as isolation "
-      << "was neither a reco::PFCandidate nor a pat::PackedCandidate!";
+    throw cms::Exception("InvalidIsolationInput") << "The supplied candidate to be used as isolation "
+                                                  << "was neither a reco::PFCandidate nor a pat::PackedCandidate!";
   }
   return result;
 }

--- a/RecoMuon/MuonIsolation/plugins/PixelTrackExtractor.cc
+++ b/RecoMuon/MuonIsolation/plugins/PixelTrackExtractor.cc
@@ -12,43 +12,40 @@
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
-
 using namespace edm;
 using namespace std;
 using namespace reco;
 using namespace muonisolation;
 using reco::isodeposit::Direction;
 
-PixelTrackExtractor::PixelTrackExtractor( const ParameterSet& par, edm::ConsumesCollector && iC ) :
-  theTrackCollectionToken(iC.consumes<TrackCollection >(par.getParameter<edm::InputTag>("inputTrackCollection"))),
-  theDepositLabel(par.getUntrackedParameter<string>("DepositLabel")),
-  theDiff_r(par.getParameter<double>("Diff_r")),
-  theDiff_z(par.getParameter<double>("Diff_z")),
-  theDR_Max(par.getParameter<double>("DR_Max")),
-  theDR_Veto(par.getParameter<double>("DR_Veto")),
-  theBeamlineOption(par.getParameter<string>("BeamlineOption")),
-  theBeamSpotToken(iC.mayConsume<BeamSpot>(par.getParameter<edm::InputTag>("BeamSpotLabel"))),
-  theNHits_Min(par.getParameter<unsigned int>("NHits_Min")),
-  theChi2Ndof_Max(par.getParameter<double>("Chi2Ndof_Max")),
-  theChi2Prob_Min(par.getParameter<double>("Chi2Prob_Min")),
-  thePt_Min(par.getParameter<double>("Pt_Min")),
-  thePropagateTracksToRadius(par.getParameter<bool>("PropagateTracksToRadius")),
-  theReferenceRadius(par.getParameter<double>("ReferenceRadius")),
-  theVetoLeadingTrack(par.getParameter<bool>("VetoLeadingTrack")), //! will veto leading track if
-  thePtVeto_Min(par.getParameter<double>("PtVeto_Min")),           //! .. it is above this threshold
-  theDR_VetoPt(par.getParameter<double>("DR_VetoPt"))              //!.. and is inside this cone
-{
+PixelTrackExtractor::PixelTrackExtractor(const ParameterSet& par, edm::ConsumesCollector&& iC)
+    : theTrackCollectionToken(iC.consumes<TrackCollection>(par.getParameter<edm::InputTag>("inputTrackCollection"))),
+      theDepositLabel(par.getUntrackedParameter<string>("DepositLabel")),
+      theDiff_r(par.getParameter<double>("Diff_r")),
+      theDiff_z(par.getParameter<double>("Diff_z")),
+      theDR_Max(par.getParameter<double>("DR_Max")),
+      theDR_Veto(par.getParameter<double>("DR_Veto")),
+      theBeamlineOption(par.getParameter<string>("BeamlineOption")),
+      theBeamSpotToken(iC.mayConsume<BeamSpot>(par.getParameter<edm::InputTag>("BeamSpotLabel"))),
+      theNHits_Min(par.getParameter<unsigned int>("NHits_Min")),
+      theChi2Ndof_Max(par.getParameter<double>("Chi2Ndof_Max")),
+      theChi2Prob_Min(par.getParameter<double>("Chi2Prob_Min")),
+      thePt_Min(par.getParameter<double>("Pt_Min")),
+      thePropagateTracksToRadius(par.getParameter<bool>("PropagateTracksToRadius")),
+      theReferenceRadius(par.getParameter<double>("ReferenceRadius")),
+      theVetoLeadingTrack(par.getParameter<bool>("VetoLeadingTrack")),  //! will veto leading track if
+      thePtVeto_Min(par.getParameter<double>("PtVeto_Min")),            //! .. it is above this threshold
+      theDR_VetoPt(par.getParameter<double>("DR_VetoPt"))               //!.. and is inside this cone
+{}
+
+reco::IsoDeposit::Vetos PixelTrackExtractor::vetos(const edm::Event& ev,
+                                                   const edm::EventSetup& evSetup,
+                                                   const reco::Track& track) const {
+  Direction dir(track.eta(), track.phi());
+  return reco::IsoDeposit::Vetos(1, veto(dir));
 }
 
-reco::IsoDeposit::Vetos PixelTrackExtractor::vetos(const edm::Event & ev,
-      const edm::EventSetup & evSetup, const reco::Track & track) const
-{
-  Direction dir(track.eta(),track.phi());
-  return reco::IsoDeposit::Vetos(1,veto(dir));
-}
-
-reco::IsoDeposit::Veto PixelTrackExtractor::veto(const Direction & dir) const
-{
+reco::IsoDeposit::Veto PixelTrackExtractor::veto(const Direction& dir) const {
   reco::IsoDeposit::Veto result;
   result.vetoDir = dir;
   result.dR = theDR_Veto;
@@ -56,62 +53,61 @@ reco::IsoDeposit::Veto PixelTrackExtractor::veto(const Direction & dir) const
 }
 
 Direction PixelTrackExtractor::directionAtPresetRadius(const Track& tk, double bz) const {
-  if (! thePropagateTracksToRadius ){
+  if (!thePropagateTracksToRadius) {
     return Direction(tk.eta(), tk.phi());
   }
 
   // this should represent a cylinder in global frame at R=refRadius cm, roughly where mid-layer of pixels is
   double psRadius = theReferenceRadius;
   double tkDxy = tk.dxy();
-  double s2D = fabs(tk.dxy()) < psRadius ? sqrt(psRadius*psRadius - tkDxy*tkDxy) : 0;
+  double s2D = fabs(tk.dxy()) < psRadius ? sqrt(psRadius * psRadius - tkDxy * tkDxy) : 0;
 
   // the field we get from the caller is already in units of GeV/cm
-  double dPhi = -s2D*tk.charge()*bz/tk.pt();
+  double dPhi = -s2D * tk.charge() * bz / tk.pt();
 
-  return Direction(tk.eta(), tk.phi()+dPhi);
+  return Direction(tk.eta(), tk.phi() + dPhi);
 }
 
-IsoDeposit PixelTrackExtractor::deposit(const Event & event, const EventSetup & eventSetup, const Track & muon) const
-{
+IsoDeposit PixelTrackExtractor::deposit(const Event& event, const EventSetup& eventSetup, const Track& muon) const {
   static const std::string metname = "MuonIsolation|PixelTrackExtractor";
 
   edm::ESHandle<MagneticField> bField;
   eventSetup.get<IdealMagneticFieldRecord>().get(bField);
-  double bz = bField->inInverseGeV(GlobalPoint(0.,0.,0.)).z();
+  double bz = bField->inInverseGeV(GlobalPoint(0., 0., 0.)).z();
 
   Direction muonDir(directionAtPresetRadius(muon, bz));
-  IsoDeposit deposit(muonDir );
+  IsoDeposit deposit(muonDir);
   //! Note, this can be reset below if theVetoLeadingTrack is set and conditions are met
-  deposit.setVeto( veto(muonDir) );
+  deposit.setVeto(veto(muonDir));
 
   deposit.addCandEnergy(muon.pt());
 
   Handle<TrackCollection> tracksH;
   event.getByToken(theTrackCollectionToken, tracksH);
   //  const TrackCollection tracks = *(tracksH.product());
-  LogTrace(metname)<<"***** TRACK COLLECTION SIZE: "<<tracksH->size();
+  LogTrace(metname) << "***** TRACK COLLECTION SIZE: " << tracksH->size();
 
   double vtx_z = muon.vz();
-  LogTrace(metname)<<"***** Muon vz: "<<vtx_z;
-  reco::TrackBase::Point beamPoint(0,0, 0);
+  LogTrace(metname) << "***** Muon vz: " << vtx_z;
+  reco::TrackBase::Point beamPoint(0, 0, 0);
 
-  if (theBeamlineOption == "BeamSpotFromEvent"){
+  if (theBeamlineOption == "BeamSpotFromEvent") {
     //pick beamSpot
     reco::BeamSpot beamSpot;
     edm::Handle<reco::BeamSpot> beamSpotH;
 
-    event.getByToken(theBeamSpotToken,beamSpotH);
+    event.getByToken(theBeamSpotToken, beamSpotH);
 
-    if (beamSpotH.isValid()){
+    if (beamSpotH.isValid()) {
       beamPoint = beamSpotH->position();
-      LogTrace(metname)<<"Extracted beam point at "<<beamPoint<<std::endl;
+      LogTrace(metname) << "Extracted beam point at " << beamPoint << std::endl;
     }
   }
 
-  LogTrace(metname)<<"Using beam point at "<<beamPoint<<std::endl;
+  LogTrace(metname) << "Using beam point at " << beamPoint << std::endl;
 
-  TrackSelector::Parameters pars(TrackSelector::Range(vtx_z-theDiff_z, vtx_z+theDiff_z),
-				 theDiff_r, muonDir, theDR_Max, beamPoint);
+  TrackSelector::Parameters pars(
+      TrackSelector::Range(vtx_z - theDiff_z, vtx_z + theDiff_z), theDiff_r, muonDir, theDR_Max, beamPoint);
 
   pars.nHitsMin = theNHits_Min;
   pars.chi2NdofMax = theChi2Ndof_Max;
@@ -120,32 +116,27 @@ IsoDeposit PixelTrackExtractor::deposit(const Event & event, const EventSetup & 
 
   TrackSelector selection(pars);
   TrackSelector::result_type sel_tracks = selection(*tracksH);
-  LogTrace(metname)<<"all tracks: "<<tracksH->size()<<" selected: "<<sel_tracks.size();
-
+  LogTrace(metname) << "all tracks: " << tracksH->size() << " selected: " << sel_tracks.size();
 
   double maxPt = -1;
   Direction maxPtDir;
   TrackSelector::result_type::const_iterator tkI = sel_tracks.begin();
   for (; tkI != sel_tracks.end(); ++tkI) {
     const reco::Track* tk = *tkI;
-    LogTrace(metname) << "This track has: pt= " << tk->pt() << ", eta= "
-        << tk->eta() <<", phi= "<<tk->phi();
+    LogTrace(metname) << "This track has: pt= " << tk->pt() << ", eta= " << tk->eta() << ", phi= " << tk->phi();
     Direction dirTrk(directionAtPresetRadius(*tk, bz));
     deposit.addDeposit(dirTrk, tk->pt());
-    double tkDr = (muonDir-dirTrk).deltaR;
+    double tkDr = (muonDir - dirTrk).deltaR;
     double tkPt = tk->pt();
-    if (theVetoLeadingTrack && tkPt > thePtVeto_Min
-	&& tkDr < theDR_VetoPt
-	&& maxPt < tkPt ){
+    if (theVetoLeadingTrack && tkPt > thePtVeto_Min && tkDr < theDR_VetoPt && maxPt < tkPt) {
       maxPt = tkPt;
       maxPtDir = dirTrk;
     }
   }
-  if (maxPt > 0){
+  if (maxPt > 0) {
     deposit.setVeto(veto(maxPtDir));
-    LogTrace(metname)<<" Set track veto the leading track with pt "
-		     <<maxPt<<" in direction  (eta,phi) "
-		     <<maxPtDir.eta()<<", "<<maxPtDir.phi();
+    LogTrace(metname) << " Set track veto the leading track with pt " << maxPt << " in direction  (eta,phi) "
+                      << maxPtDir.eta() << ", " << maxPtDir.phi();
   }
 
   return deposit;

--- a/RecoMuon/MuonIsolation/plugins/PixelTrackExtractor.h
+++ b/RecoMuon/MuonIsolation/plugins/PixelTrackExtractor.h
@@ -15,51 +15,51 @@
 
 namespace muonisolation {
 
-class PixelTrackExtractor : public reco::isodeposit::IsoDepositExtractor {
+  class PixelTrackExtractor : public reco::isodeposit::IsoDepositExtractor {
+  public:
+    PixelTrackExtractor(){};
+    PixelTrackExtractor(const edm::ParameterSet& par, edm::ConsumesCollector&& iC);
 
-public:
+    ~PixelTrackExtractor() override {}
 
-  PixelTrackExtractor(){};
-  PixelTrackExtractor(const edm::ParameterSet& par, edm::ConsumesCollector && iC);
+    void fillVetos(const edm::Event& ev, const edm::EventSetup& evSetup, const reco::TrackCollection& track) override {}
 
-  ~PixelTrackExtractor() override{}
+    virtual reco::IsoDeposit::Vetos vetos(const edm::Event& ev,
+                                          const edm::EventSetup& evSetup,
+                                          const reco::Track& track) const;
 
-  void fillVetos (const edm::Event & ev,
-      const edm::EventSetup & evSetup, const reco::TrackCollection & track) override {}
+    reco::IsoDeposit deposit(const edm::Event& ev,
+                             const edm::EventSetup& evSetup,
+                             const reco::Track& muon) const override;
 
-  virtual reco::IsoDeposit::Vetos vetos(const edm::Event & ev,
-      const edm::EventSetup & evSetup, const reco::Track & track)const;
+  private:
+    reco::IsoDeposit::Veto veto(const reco::IsoDeposit::Direction& dir) const;
 
-  reco::IsoDeposit deposit (const edm::Event & ev,
-      const edm::EventSetup & evSetup, const reco::Track & muon) const override;
+    reco::isodeposit::Direction directionAtPresetRadius(const reco::Track& tk, double bz) const;
 
-private:
-  reco::IsoDeposit::Veto veto( const reco::IsoDeposit::Direction & dir) const;
+  private:
+    // Parameter set
+    edm::EDGetTokenT<reco::TrackCollection> theTrackCollectionToken;  //! Track Collection Token
+    std::string theDepositLabel;                                      //! name for deposit
+    double theDiff_r;                                                 //! transverse distance to vertex
+    double theDiff_z;                                                 //! z distance to vertex
+    double theDR_Max;                                                 //! Maximum cone angle for deposits
+    double theDR_Veto;                                                //! Veto cone angle
+    std::string theBeamlineOption;                                    //! "NONE", "BeamSpotFromEvent"
+    edm::EDGetTokenT<reco::BeamSpot> theBeamSpotToken;                //! BeamSpot name
+    unsigned int theNHits_Min;                                        //! trk.numberOfValidHits >= theNHits_Min
+    double theChi2Ndof_Max;                                           //! trk.normalizedChi2 < theChi2Ndof_Max
+    double theChi2Prob_Min;  //! ChiSquaredProbability(trk.chi2,trk.ndof) > theChi2Prob_Min
+    double thePt_Min;        //! min track pt to include into iso deposit
 
-  reco::isodeposit::Direction directionAtPresetRadius(const reco::Track& tk, double bz) const;
-private:
-  // Parameter set
-  edm::EDGetTokenT<reco::TrackCollection> theTrackCollectionToken; //! Track Collection Token
-  std::string theDepositLabel;         //! name for deposit
-  double theDiff_r;                    //! transverse distance to vertex
-  double theDiff_z;                    //! z distance to vertex
-  double theDR_Max;                    //! Maximum cone angle for deposits
-  double theDR_Veto;                   //! Veto cone angle
-  std::string theBeamlineOption;       //! "NONE", "BeamSpotFromEvent"
-  edm::EDGetTokenT<reco::BeamSpot> theBeamSpotToken;      //! BeamSpot name
-  unsigned int theNHits_Min;                   //! trk.numberOfValidHits >= theNHits_Min
-  double theChi2Ndof_Max;              //! trk.normalizedChi2 < theChi2Ndof_Max
-  double theChi2Prob_Min;              //! ChiSquaredProbability(trk.chi2,trk.ndof) > theChi2Prob_Min
-  double thePt_Min;                    //! min track pt to include into iso deposit
+    bool thePropagateTracksToRadius;  //! If set to true will compare track eta-phi at ...
+    double theReferenceRadius;        //! ... this radius
 
-  bool thePropagateTracksToRadius;     //! If set to true will compare track eta-phi at ...
-  double theReferenceRadius;           //! ... this radius
+    bool theVetoLeadingTrack;  //! will veto leading track if
+    double thePtVeto_Min;      //! .. it is above this threshold
+    double theDR_VetoPt;       //!.. and is inside this cone
+  };
 
-  bool theVetoLeadingTrack;             //! will veto leading track if
-  double thePtVeto_Min;		        //! .. it is above this threshold
-  double theDR_VetoPt;		        //!.. and is inside this cone
-};
-
-}
+}  // namespace muonisolation
 
 #endif

--- a/RecoMuon/MuonIsolation/plugins/TrackExtractor.cc
+++ b/RecoMuon/MuonIsolation/plugins/TrackExtractor.cc
@@ -12,72 +12,68 @@ using namespace reco;
 using namespace muonisolation;
 using reco::isodeposit::Direction;
 
-TrackExtractor::TrackExtractor( const ParameterSet& par, edm::ConsumesCollector && iC ) :
-  theTrackCollectionToken(iC.consumes<TrackCollection>(par.getParameter<edm::InputTag>("inputTrackCollection"))),
-  theDepositLabel(par.getUntrackedParameter<string>("DepositLabel")),
-  theDiff_r(par.getParameter<double>("Diff_r")),
-  theDiff_z(par.getParameter<double>("Diff_z")),
-  theDR_Max(par.getParameter<double>("DR_Max")),
-  theDR_Veto(par.getParameter<double>("DR_Veto")),
-  theBeamlineOption(par.getParameter<string>("BeamlineOption")),
-  theBeamSpotToken(iC.consumes<reco::BeamSpot>(par.getParameter<edm::InputTag>("BeamSpotLabel"))),
-  theNHits_Min(par.getParameter<unsigned int>("NHits_Min")),
-  theChi2Ndof_Max(par.getParameter<double>("Chi2Ndof_Max")),
-  theChi2Prob_Min(par.getParameter<double>("Chi2Prob_Min")),
-  thePt_Min(par.getParameter<double>("Pt_Min"))
-{
+TrackExtractor::TrackExtractor(const ParameterSet& par, edm::ConsumesCollector&& iC)
+    : theTrackCollectionToken(iC.consumes<TrackCollection>(par.getParameter<edm::InputTag>("inputTrackCollection"))),
+      theDepositLabel(par.getUntrackedParameter<string>("DepositLabel")),
+      theDiff_r(par.getParameter<double>("Diff_r")),
+      theDiff_z(par.getParameter<double>("Diff_z")),
+      theDR_Max(par.getParameter<double>("DR_Max")),
+      theDR_Veto(par.getParameter<double>("DR_Veto")),
+      theBeamlineOption(par.getParameter<string>("BeamlineOption")),
+      theBeamSpotToken(iC.consumes<reco::BeamSpot>(par.getParameter<edm::InputTag>("BeamSpotLabel"))),
+      theNHits_Min(par.getParameter<unsigned int>("NHits_Min")),
+      theChi2Ndof_Max(par.getParameter<double>("Chi2Ndof_Max")),
+      theChi2Prob_Min(par.getParameter<double>("Chi2Prob_Min")),
+      thePt_Min(par.getParameter<double>("Pt_Min")) {}
+
+reco::IsoDeposit::Vetos TrackExtractor::vetos(const edm::Event& ev,
+                                              const edm::EventSetup& evSetup,
+                                              const reco::Track& track) const {
+  reco::isodeposit::Direction dir(track.eta(), track.phi());
+  return reco::IsoDeposit::Vetos(1, veto(dir));
 }
 
-reco::IsoDeposit::Vetos TrackExtractor::vetos(const edm::Event & ev,
-      const edm::EventSetup & evSetup, const reco::Track & track) const
-{
-  reco::isodeposit::Direction dir(track.eta(),track.phi());
-  return reco::IsoDeposit::Vetos(1,veto(dir));
-}
-
-reco::IsoDeposit::Veto TrackExtractor::veto(const reco::IsoDeposit::Direction & dir) const
-{
+reco::IsoDeposit::Veto TrackExtractor::veto(const reco::IsoDeposit::Direction& dir) const {
   reco::IsoDeposit::Veto result;
   result.vetoDir = dir;
   result.dR = theDR_Veto;
   return result;
 }
 
-IsoDeposit TrackExtractor::deposit(const Event & event, const EventSetup & eventSetup, const Track & muon) const
-{
+IsoDeposit TrackExtractor::deposit(const Event& event, const EventSetup& eventSetup, const Track& muon) const {
   static const std::string metname = "MuonIsolation|TrackExtractor";
 
   reco::isodeposit::Direction muonDir(muon.eta(), muon.phi());
-  IsoDeposit deposit(muonDir );
-  deposit.setVeto( veto(muonDir) );
+  IsoDeposit deposit(muonDir);
+  deposit.setVeto(veto(muonDir));
   deposit.addCandEnergy(muon.pt());
 
   Handle<TrackCollection> tracksH;
   event.getByToken(theTrackCollectionToken, tracksH);
   //  const TrackCollection tracks = *(tracksH.product());
-  LogTrace(metname)<<"***** TRACK COLLECTION SIZE: "<<tracksH->size();
+  LogTrace(metname) << "***** TRACK COLLECTION SIZE: " << tracksH->size();
 
   double vtx_z = muon.vz();
-  LogTrace(metname)<<"***** Muon vz: "<<vtx_z;
-  reco::TrackBase::Point beamPoint(0,0, 0);
+  LogTrace(metname) << "***** Muon vz: " << vtx_z;
+  reco::TrackBase::Point beamPoint(0, 0, 0);
 
-  if (theBeamlineOption == "BeamSpotFromEvent"){
+  if (theBeamlineOption == "BeamSpotFromEvent") {
     //pick beamSpot
     reco::BeamSpot beamSpot;
     edm::Handle<reco::BeamSpot> beamSpotH;
 
-    event.getByToken(theBeamSpotToken,beamSpotH);
+    event.getByToken(theBeamSpotToken, beamSpotH);
 
-    if (beamSpotH.isValid()){
+    if (beamSpotH.isValid()) {
       beamPoint = beamSpotH->position();
-      LogTrace(metname)<<"Extracted beam point at "<<beamPoint<<std::endl;
+      LogTrace(metname) << "Extracted beam point at " << beamPoint << std::endl;
     }
   }
 
-  LogTrace(metname)<<"Using beam point at "<<beamPoint<<std::endl;
+  LogTrace(metname) << "Using beam point at " << beamPoint << std::endl;
 
-  TrackSelector::Parameters pars(TrackSelector::Range(vtx_z-theDiff_z, vtx_z+theDiff_z),
-				 theDiff_r, muonDir, theDR_Max, beamPoint);
+  TrackSelector::Parameters pars(
+      TrackSelector::Range(vtx_z - theDiff_z, vtx_z + theDiff_z), theDiff_r, muonDir, theDR_Max, beamPoint);
 
   pars.nHitsMin = theNHits_Min;
   pars.chi2NdofMax = theChi2Ndof_Max;
@@ -86,14 +82,12 @@ IsoDeposit TrackExtractor::deposit(const Event & event, const EventSetup & event
 
   TrackSelector selection(pars);
   TrackSelector::result_type sel_tracks = selection(*tracksH);
-  LogTrace(metname)<<"all tracks: "<<tracksH->size()<<" selected: "<<sel_tracks.size();
-
+  LogTrace(metname) << "all tracks: " << tracksH->size() << " selected: " << sel_tracks.size();
 
   TrackSelector::result_type::const_iterator tkI = sel_tracks.begin();
   for (; tkI != sel_tracks.end(); ++tkI) {
     const reco::Track* tk = *tkI;
-    LogTrace(metname) << "This track has: pt= " << tk->pt() << ", eta= "
-        << tk->eta() <<", phi= "<<tk->phi();
+    LogTrace(metname) << "This track has: pt= " << tk->pt() << ", eta= " << tk->eta() << ", phi= " << tk->phi();
     reco::isodeposit::Direction dirTrk(tk->eta(), tk->phi());
     deposit.addDeposit(dirTrk, tk->pt());
   }

--- a/RecoMuon/MuonIsolation/plugins/TrackExtractor.h
+++ b/RecoMuon/MuonIsolation/plugins/TrackExtractor.h
@@ -15,42 +15,42 @@
 
 namespace muonisolation {
 
-class TrackExtractor : public reco::isodeposit::IsoDepositExtractor {
+  class TrackExtractor : public reco::isodeposit::IsoDepositExtractor {
+  public:
+    TrackExtractor(){};
+    TrackExtractor(const edm::ParameterSet& par, edm::ConsumesCollector&& iC);
 
-public:
+    ~TrackExtractor() override {}
 
-  TrackExtractor(){};
-  TrackExtractor(const edm::ParameterSet& par, edm::ConsumesCollector && iC);
+    void fillVetos(const edm::Event& ev, const edm::EventSetup& evSetup, const reco::TrackCollection& track) override {}
 
-  ~TrackExtractor() override{}
+    virtual reco::IsoDeposit::Vetos vetos(const edm::Event& ev,
+                                          const edm::EventSetup& evSetup,
+                                          const reco::Track& track) const;
 
-  void fillVetos (const edm::Event & ev,
-      const edm::EventSetup & evSetup, const reco::TrackCollection & track) override {}
+    reco::IsoDeposit deposit(const edm::Event& ev,
+                             const edm::EventSetup& evSetup,
+                             const reco::Track& muon) const override;
 
-  virtual reco::IsoDeposit::Vetos vetos(const edm::Event & ev,
-      const edm::EventSetup & evSetup, const reco::Track & track)const;
+  private:
+    reco::IsoDeposit::Veto veto(const reco::IsoDeposit::Direction& dir) const;
 
-  reco::IsoDeposit deposit (const edm::Event & ev,
-      const edm::EventSetup & evSetup, const reco::Track & muon) const override;
+  private:
+    // Parameter set
+    edm::EDGetTokenT<reco::TrackCollection> theTrackCollectionToken;  //! Track Collection Label
+    std::string theDepositLabel;                                      //! name for deposit
+    double theDiff_r;                                                 //! transverse distance to vertex
+    double theDiff_z;                                                 //! z distance to vertex
+    double theDR_Max;                                                 //! Maximum cone angle for deposits
+    double theDR_Veto;                                                //! Veto cone angle
+    std::string theBeamlineOption;                                    //! "NONE", "BeamSpotFromEvent"
+    edm::EDGetTokenT<reco::BeamSpot> theBeamSpotToken;                //! BeamSpot name
+    unsigned int theNHits_Min;                                        //! trk.numberOfValidHits >= theNHits_Min
+    double theChi2Ndof_Max;                                           //! trk.normalizedChi2 < theChi2Ndof_Max
+    double theChi2Prob_Min;  //! ChiSquaredProbability(trk.chi2,trk.ndof) > theChi2Prob_Min
+    double thePt_Min;        //! min track pt to include into iso deposit
+  };
 
-private:
-  reco::IsoDeposit::Veto veto( const reco::IsoDeposit::Direction & dir) const;
-private:
-  // Parameter set
-  edm::EDGetTokenT<reco::TrackCollection> theTrackCollectionToken; //! Track Collection Label
-  std::string theDepositLabel;         //! name for deposit
-  double theDiff_r;                    //! transverse distance to vertex
-  double theDiff_z;                    //! z distance to vertex
-  double theDR_Max;                    //! Maximum cone angle for deposits
-  double theDR_Veto;                   //! Veto cone angle
-  std::string theBeamlineOption;       //! "NONE", "BeamSpotFromEvent"
-  edm::EDGetTokenT<reco::BeamSpot> theBeamSpotToken;      //! BeamSpot name
-  unsigned int theNHits_Min;                   //! trk.numberOfValidHits >= theNHits_Min
-  double theChi2Ndof_Max;              //! trk.normalizedChi2 < theChi2Ndof_Max
-  double theChi2Prob_Min;              //! ChiSquaredProbability(trk.chi2,trk.ndof) > theChi2Prob_Min
-  double thePt_Min;                    //! min track pt to include into iso deposit
-};
-
-}
+}  // namespace muonisolation
 
 #endif

--- a/RecoMuon/MuonIsolation/plugins/TrackSelector.cc
+++ b/RecoMuon/MuonIsolation/plugins/TrackSelector.cc
@@ -5,74 +5,74 @@
 using namespace muonisolation;
 using namespace reco;
 
-TrackSelector::result_type TrackSelector::operator()(const TrackSelector::input_type & tracks) const
-{
+TrackSelector::result_type TrackSelector::operator()(const TrackSelector::input_type& tracks) const {
   static const std::string metname = "MuonIsolation|TrackSelector";
   result_type result;
-  for (auto const& tk: tracks) {
+  for (auto const& tk : tracks) {
+    //     float tZ = tk.vz();
+    //     float tD0 = fabs(tk.d0());
+    //     float tD0Cor = fabs(tk.dxy(thePars.beamPoint));
+    //     float tEta = tk.eta();
+    //     float tPhi = tk.phi();
+    //     unsigned int tHits = tk.numberOfValidHits();
+    //     float tChi2Ndof = tk.normalizedChi2();
+    //     float tChi2Prob = ChiSquaredProbability(tk.chi2(), tk.ndof());
+    //     float tPt = tk.pt();
 
-//     float tZ = tk.vz();
-//     float tD0 = fabs(tk.d0());
-//     float tD0Cor = fabs(tk.dxy(thePars.beamPoint));
-//     float tEta = tk.eta();
-//     float tPhi = tk.phi();
-//     unsigned int tHits = tk.numberOfValidHits();
-//     float tChi2Ndof = tk.normalizedChi2();
-//     float tChi2Prob = ChiSquaredProbability(tk.chi2(), tk.ndof());
-//     float tPt = tk.pt();
-
-//     LogTrace(metname)<<"Tk vz: "<<tZ
-// 		     <<",  d0: "<<tD0
-// 		     <<",  d0wrtBeam: "<<tD0Cor
-// 		     <<", eta: "<<tEta
-// 		     <<", phi: "<<tPhi
-// 		     <<", nHits: "<<tHits
-// 		     <<", chi2Norm: "<<tChi2Ndof
-// 		     <<", chi2Prob: "<<tChi2Prob
-// 		     <<std::endl;
+    //     LogTrace(metname)<<"Tk vz: "<<tZ
+    // 		     <<",  d0: "<<tD0
+    // 		     <<",  d0wrtBeam: "<<tD0Cor
+    // 		     <<", eta: "<<tEta
+    // 		     <<", phi: "<<tPhi
+    // 		     <<", nHits: "<<tHits
+    // 		     <<", chi2Norm: "<<tChi2Ndof
+    // 		     <<", chi2Prob: "<<tChi2Prob
+    // 		     <<std::endl;
 
     //! pick/read variables in order to cut down on unnecessary calls
     //! someone will have some fun reading the log if Debug is on
     //! the biggest reason is the numberOfValidHits call (the rest are not as costly)
 
-    float tZ = tk.vz(); 
+    float tZ = tk.vz();
     float tPt = tk.pt();
-    float tD0 = fabs(tk.d0());  
+    float tD0 = fabs(tk.d0());
     float tD0Cor = fabs(tk.dxy(thePars.beamPoint));
     float tEta = tk.eta();
     float tPhi = tk.phi();
     float tChi2Ndof = tk.normalizedChi2();
-    LogTrace(metname)<<"Tk vz: "<<tZ
-		     <<",  pt: "<<tPt
-		     <<",  d0: "<<tD0
- 		     <<",  d0wrtBeam: "<<tD0Cor
-		     <<", eta: "<<tEta
- 		     <<", phi: "<<tPhi
-		     <<", chi2Norm: "<<tChi2Ndof;
+    LogTrace(metname) << "Tk vz: " << tZ << ",  pt: " << tPt << ",  d0: " << tD0 << ",  d0wrtBeam: " << tD0Cor
+                      << ", eta: " << tEta << ", phi: " << tPhi << ", chi2Norm: " << tChi2Ndof;
     //! access to the remaining vars is slow
 
-    if ( !thePars.zRange.inside( tZ ) ) continue; 
-    if ( tPt < thePars.ptMin ) continue;
-    if ( !thePars.rRange.inside( tD0Cor) ) continue;
-    if ( thePars.dir.deltaR( reco::isodeposit::Direction(tEta, tPhi) ) > thePars.drMax ) continue;
-    if ( tChi2Ndof > thePars.chi2NdofMax ) continue;
+    if (!thePars.zRange.inside(tZ))
+      continue;
+    if (tPt < thePars.ptMin)
+      continue;
+    if (!thePars.rRange.inside(tD0Cor))
+      continue;
+    if (thePars.dir.deltaR(reco::isodeposit::Direction(tEta, tPhi)) > thePars.drMax)
+      continue;
+    if (tChi2Ndof > thePars.chi2NdofMax)
+      continue;
 
     //! skip if min Hits == 0; assumes any track has at least one valid hit
-    if (thePars.nHitsMin > 0 ){
+    if (thePars.nHitsMin > 0) {
       unsigned int tHits = tk.numberOfValidHits();
-      LogTrace(metname)<<", nHits: "<<tHits;
-      if ( tHits < thePars.nHitsMin ) continue;
+      LogTrace(metname) << ", nHits: " << tHits;
+      if (tHits < thePars.nHitsMin)
+        continue;
     }
 
     //! similarly here
-    if(thePars.chi2ProbMin > 0){
+    if (thePars.chi2ProbMin > 0) {
       float tChi2Prob = ChiSquaredProbability(tk.chi2(), tk.ndof());
-      LogTrace(metname)<<", chi2Prob: "<<tChi2Prob<<std::endl;
-      if ( tChi2Prob < thePars.chi2ProbMin ) continue;
+      LogTrace(metname) << ", chi2Prob: " << tChi2Prob << std::endl;
+      if (tChi2Prob < thePars.chi2ProbMin)
+        continue;
     }
 
-    LogTrace(metname)<<" ..... accepted"<<std::endl;
+    LogTrace(metname) << " ..... accepted" << std::endl;
     result.push_back(&tk);
-  } 
+  }
   return result;
 }

--- a/RecoMuon/MuonIsolation/plugins/TrackSelector.h
+++ b/RecoMuon/MuonIsolation/plugins/TrackSelector.h
@@ -12,42 +12,56 @@ namespace muonisolation {
 
   class TrackSelector {
   public:
-
     typedef muonisolation::Range<float> Range;
     typedef std::list<const reco::Track*> result_type;
     typedef reco::TrackCollection input_type;
     typedef reco::TrackBase::Point BeamPoint;
-  
+
     //!config parameters
     struct Parameters {
       Parameters()
-	:  zRange(-1e6,1e6), rRange(-1e6,1e6), dir(0,0), drMax(1e3), beamPoint(0,0,0),
-	   nHitsMin(0), chi2NdofMax(1e64), chi2ProbMin(-1.), ptMin(-1) {}
-      Parameters(const Range& dz, const double d0Max, const reco::isodeposit::Direction& dirC, double rMax, 
-		 const BeamPoint& point  = BeamPoint(0,0,0))
-	: zRange(dz), rRange(Range(0,d0Max)), dir(dirC), drMax(rMax), beamPoint(point),
-	  nHitsMin(0), chi2NdofMax(1e64), chi2ProbMin(-1.), ptMin(-1) {}
-      Range        zRange;  //! range in z
-      Range        rRange;  //! range in d0 or dxy (abs value)
-      reco::isodeposit::Direction       dir;  //! direction of the selection cone
-      double        drMax;  //! cone size
-      BeamPoint beamPoint;  //! beam spot position
-      unsigned int       nHitsMin;  //! nValidHits >= nHitsMin
-      double  chi2NdofMax;  //! max value of normalized chi2
-      double  chi2ProbMin;  //! ChiSquaredProbability( chi2, ndf ) > chi2ProbMin
-      double        ptMin;  //! tk.pt>ptMin
+          : zRange(-1e6, 1e6),
+            rRange(-1e6, 1e6),
+            dir(0, 0),
+            drMax(1e3),
+            beamPoint(0, 0, 0),
+            nHitsMin(0),
+            chi2NdofMax(1e64),
+            chi2ProbMin(-1.),
+            ptMin(-1) {}
+      Parameters(const Range& dz,
+                 const double d0Max,
+                 const reco::isodeposit::Direction& dirC,
+                 double rMax,
+                 const BeamPoint& point = BeamPoint(0, 0, 0))
+          : zRange(dz),
+            rRange(Range(0, d0Max)),
+            dir(dirC),
+            drMax(rMax),
+            beamPoint(point),
+            nHitsMin(0),
+            chi2NdofMax(1e64),
+            chi2ProbMin(-1.),
+            ptMin(-1) {}
+      Range zRange;                     //! range in z
+      Range rRange;                     //! range in d0 or dxy (abs value)
+      reco::isodeposit::Direction dir;  //! direction of the selection cone
+      double drMax;                     //! cone size
+      BeamPoint beamPoint;              //! beam spot position
+      unsigned int nHitsMin;            //! nValidHits >= nHitsMin
+      double chi2NdofMax;               //! max value of normalized chi2
+      double chi2ProbMin;               //! ChiSquaredProbability( chi2, ndf ) > chi2ProbMin
+      double ptMin;                     //! tk.pt>ptMin
     };
 
+    TrackSelector(const Parameters& pars) : thePars(pars) {}
 
-    TrackSelector(const Parameters& pars) : thePars(pars) { } 
-
-      result_type operator()(const input_type & tracks) const;
-
+    result_type operator()(const input_type& tracks) const;
 
   private:
-      Parameters thePars;
-  }; 
+    Parameters thePars;
+  };
 
-}
+}  // namespace muonisolation
 
-#endif 
+#endif

--- a/RecoMuon/MuonIsolation/plugins/module.cc
+++ b/RecoMuon/MuonIsolation/plugins/module.cc
@@ -1,7 +1,6 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-
 #include "PhysicsTools/IsolationAlgos/interface/IsoDepositExtractor.h"
 #include "PhysicsTools/IsolationAlgos/interface/IsoDepositExtractorFactory.h"
 #include "TrackExtractor.h"

--- a/RecoMuon/MuonIsolation/src/Cuts.cc
+++ b/RecoMuon/MuonIsolation/src/Cuts.cc
@@ -7,61 +7,56 @@
 using namespace std;
 using namespace muonisolation;
 
-Cuts::Cuts(const edm::ParameterSet & pset)
-{
-  vector<double> etaBounds  = pset.getParameter<std::vector<double> >("EtaBounds");
-  vector<double> coneSizes  = pset.getParameter<std::vector<double> >("ConeSizes");
+Cuts::Cuts(const edm::ParameterSet& pset) {
+  vector<double> etaBounds = pset.getParameter<std::vector<double> >("EtaBounds");
+  vector<double> coneSizes = pset.getParameter<std::vector<double> >("ConeSizes");
   vector<double> thresholds = pset.getParameter<std::vector<double> >("Thresholds");
-  init(etaBounds,coneSizes,thresholds);
+  init(etaBounds, coneSizes, thresholds);
 }
 
-Cuts::Cuts(const vector<double> & etaBounds, const vector<double> & coneSizes,
-      const vector<double> & thresholds) 
-{
-  init(etaBounds,coneSizes,thresholds);
+Cuts::Cuts(const vector<double>& etaBounds, const vector<double>& coneSizes, const vector<double>& thresholds) {
+  init(etaBounds, coneSizes, thresholds);
 }
 
-
-void Cuts::init(const vector<double> & etaBounds, const vector<double> & coneSizes,
-      const vector<double> & thresholds)
-{
+void Cuts::init(const vector<double>& etaBounds, const vector<double>& coneSizes, const vector<double>& thresholds) {
   double minEta = 0.;
   double coneSize = 0;
   double threshold = 0;
   unsigned int nEta = etaBounds.size();
-  for (unsigned int i=0; i< nEta; i++) {
-    if (i>0) minEta = etaBounds[i-1];
+  for (unsigned int i = 0; i < nEta; i++) {
+    if (i > 0)
+      minEta = etaBounds[i - 1];
     double maxEta = etaBounds[i];
-    if (i < coneSizes.size()) coneSize = coneSizes[i]; 
-    if (i < thresholds.size()) threshold = thresholds[i]; 
+    if (i < coneSizes.size())
+      coneSize = coneSizes[i];
+    if (i < thresholds.size())
+      threshold = thresholds[i];
 
-    CutSpec cut = {muonisolation::Range<double>(minEta,maxEta), coneSize, threshold };
-    
-    theCuts.push_back( cut ); 
-  } 
+    CutSpec cut = {muonisolation::Range<double>(minEta, maxEta), coneSize, threshold};
+
+    theCuts.push_back(cut);
+  }
 }
 
-const Cuts::CutSpec & Cuts::operator()(double eta) const
-{
+const Cuts::CutSpec& Cuts::operator()(double eta) const {
   double absEta = fabs(eta);
   unsigned int nCuts = theCuts.size();
-  unsigned int idx_eta = nCuts-1;
+  unsigned int idx_eta = nCuts - 1;
   for (unsigned int i = 0; i < nCuts; i++) {
-    if (absEta < theCuts[i].etaRange.max() ) { idx_eta = i; break; }
+    if (absEta < theCuts[i].etaRange.max()) {
+      idx_eta = i;
+      break;
+    }
   }
   return theCuts[idx_eta];
 }
 
-std::string Cuts::print() const
-{
+std::string Cuts::print() const {
   std::ostringstream result;
   typedef std::vector<CutSpec>::const_iterator IT;
   result << "Cuts : " << std::endl;
   for (IT it = theCuts.begin(), itEnd = theCuts.end(); it < itEnd; ++it) {
-    result << "eta: "<<(*it).etaRange
-           <<", cone: "<< (*it).conesize
-           <<", cut: "<<(*it).threshold
-           <<std::endl;
-  }  
+    result << "eta: " << (*it).etaRange << ", cone: " << (*it).conesize << ", cut: " << (*it).threshold << std::endl;
+  }
   return result.str();
 }

--- a/RecoMuon/MuonIsolation/src/IsolatorByDeposit.cc
+++ b/RecoMuon/MuonIsolation/src/IsolatorByDeposit.cc
@@ -1,34 +1,30 @@
 #include "RecoMuon/MuonIsolation/interface/IsolatorByDeposit.h"
 
-using std::vector;
 using reco::IsoDeposit;
+using std::vector;
 using namespace muonisolation;
 
-IsolatorByDeposit::IsolatorByDeposit(float conesize, const vector<double>& weights) 
-  : theConeSizeFunction(nullptr), theConeSize(conesize), theWeights(weights)
-{ 
+IsolatorByDeposit::IsolatorByDeposit(float conesize, const vector<double>& weights)
+    : theConeSizeFunction(nullptr), theConeSize(conesize), theWeights(weights) {
   theDepThresholds = std::vector<double>(weights.size(), -1e12);
 }
 
-IsolatorByDeposit::IsolatorByDeposit(const ConeSizeFunction * conesize, const vector<double>& weights) 
-  : theConeSizeFunction(conesize), theConeSize(0.), theWeights(weights)
-{ 
+IsolatorByDeposit::IsolatorByDeposit(const ConeSizeFunction* conesize, const vector<double>& weights)
+    : theConeSizeFunction(conesize), theConeSize(0.), theWeights(weights) {
   theDepThresholds = std::vector<double>(weights.size(), -1e12);
 }
 
-IsolatorByDeposit::IsolatorByDeposit(float conesize, const vector<double>& weights, const vector<double>& dThresh) 
-  : theConeSizeFunction(nullptr), theConeSize(conesize), theWeights(weights),
-    theDepThresholds(dThresh)
-{ }
+IsolatorByDeposit::IsolatorByDeposit(float conesize, const vector<double>& weights, const vector<double>& dThresh)
+    : theConeSizeFunction(nullptr), theConeSize(conesize), theWeights(weights), theDepThresholds(dThresh) {}
 
-IsolatorByDeposit::IsolatorByDeposit(const ConeSizeFunction * conesize, 
-				     const vector<double>& weights, const vector<double>& dThresh) 
-  : theConeSizeFunction(conesize), theConeSize(0.), theWeights(weights),
-    theDepThresholds(dThresh)
-{ }
+IsolatorByDeposit::IsolatorByDeposit(const ConeSizeFunction* conesize,
+                                     const vector<double>& weights,
+                                     const vector<double>& dThresh)
+    : theConeSizeFunction(conesize), theConeSize(0.), theWeights(weights), theDepThresholds(dThresh) {}
 
-MuIsoBaseIsolator::Result IsolatorByDeposit::result(const DepositContainer& deposits, const edm::Event*) const{
-  if (deposits.empty()) return Result(resultType());
+MuIsoBaseIsolator::Result IsolatorByDeposit::result(const DepositContainer& deposits, const edm::Event*) const {
+  if (deposits.empty())
+    return Result(resultType());
 
   // To determine the threshold, the direction of the cone of the first
   // set of deposits is used.
@@ -38,33 +34,30 @@ MuIsoBaseIsolator::Result IsolatorByDeposit::result(const DepositContainer& depo
   // value!
   float eta = deposits.front().dep->eta();
   float pt = deposits.front().dep->candEnergy();
-  float dr= coneSize(eta,pt);
-  float sumDep = weightedSum(deposits,dr);
+  float dr = coneSize(eta, pt);
+  float sumDep = weightedSum(deposits, dr);
 
-
-  Result res(resultType()); 
+  Result res(resultType());
   res.valFloat = sumDep;
   return res;
 }
 
-double
-IsolatorByDeposit::weightedSum(const DepositContainer& deposits,
-			       float dRcone) const {
-  double sumDep=0;
+double IsolatorByDeposit::weightedSum(const DepositContainer& deposits, float dRcone) const {
+  double sumDep = 0;
 
-  assert(deposits.size()==theWeights.size());
+  assert(deposits.size() == theWeights.size());
 
   vector<double>::const_iterator w = theWeights.begin();
   vector<double>::const_iterator dThresh = theDepThresholds.begin();
 
   typedef DepositContainer::const_iterator DI;
   for (DI dep = deposits.begin(), depEnd = deposits.end(); dep != depEnd; ++dep) {
-    if (dep->vetos != nullptr){
+    if (dep->vetos != nullptr) {
       sumDep += dep->dep->depositAndCountWithin(dRcone, *dep->vetos, (*dThresh)).first * (*w);
     } else {
       sumDep += dep->dep->depositAndCountWithin(dRcone, Vetos(), (*dThresh)).first * (*w);
     }
-//  cout << "IsolatorByDeposit: type = " << (*dep)->type() << " weight = " << (*w) << endl;
+    //  cout << "IsolatorByDeposit: type = " << (*dep)->type() << " weight = " << (*w) << endl;
     w++;
     dThresh++;
   }

--- a/RecoMuon/MuonIsolation/src/IsolatorByDepositCount.cc
+++ b/RecoMuon/MuonIsolation/src/IsolatorByDepositCount.cc
@@ -1,21 +1,20 @@
 #include "RecoMuon/MuonIsolation/interface/IsolatorByDepositCount.h"
 
-using std::vector;
 using reco::IsoDeposit;
+using std::vector;
 using namespace muonisolation;
 
-IsolatorByDepositCount::IsolatorByDepositCount(float conesize, const vector<double>& dThresh) 
-  : theConeSizeFunction(nullptr), theConeSize(conesize), theDepThresholds(dThresh)
-{ }
+IsolatorByDepositCount::IsolatorByDepositCount(float conesize, const vector<double>& dThresh)
+    : theConeSizeFunction(nullptr), theConeSize(conesize), theDepThresholds(dThresh) {}
 
-IsolatorByDepositCount::IsolatorByDepositCount(const ConeSizeFunction * conesize, 
-					       const vector<double>& dThresh) 
-  : theConeSizeFunction(conesize), theConeSize(0.), theDepThresholds(dThresh)
-{ }
+IsolatorByDepositCount::IsolatorByDepositCount(const ConeSizeFunction* conesize, const vector<double>& dThresh)
+    : theConeSizeFunction(conesize), theConeSize(0.), theDepThresholds(dThresh) {}
 
-MuIsoBaseIsolator::Result IsolatorByDepositCount::result(const DepositContainer& deposits, const edm::Event*) const{
-  if (deposits.empty()) return Result(resultType());
-  if (deposits.size()>1){    return Result(ISOL_INVALID_TYPE);
+MuIsoBaseIsolator::Result IsolatorByDepositCount::result(const DepositContainer& deposits, const edm::Event*) const {
+  if (deposits.empty())
+    return Result(resultType());
+  if (deposits.size() > 1) {
+    return Result(ISOL_INVALID_TYPE);
   }
 
   // To determine the threshold, the direction of the cone of the first
@@ -26,12 +25,11 @@ MuIsoBaseIsolator::Result IsolatorByDepositCount::result(const DepositContainer&
   // value!
   float eta = deposits.front().dep->eta();
   float pt = deposits.front().dep->candEnergy();
-  float dr= coneSize(eta,pt);
+  float dr = coneSize(eta, pt);
   DepositAndVetos depVet = deposits.front();
   std::pair<double, int> sumAndCount = depVet.dep->depositAndCountWithin(dr, *depVet.vetos, theDepThresholds.front());
 
-
-  Result res(resultType()); 
+  Result res(resultType());
   res.valInt = sumAndCount.second;
   return res;
 }

--- a/RecoMuon/MuonIsolation/src/IsolatorByNominalEfficiency.cc
+++ b/RecoMuon/MuonIsolation/src/IsolatorByNominalEfficiency.cc
@@ -6,64 +6,65 @@
 using namespace muonisolation;
 using namespace std;
 
-double IsolatorByNominalEfficiency::ConeSizes::size(int i) const
-{ if (i >= 0 && i< DIM) return cone_dr[i]; else return 0.; }
-
-int IsolatorByNominalEfficiency::ConeSizes::index(float dr) const
-{
- for(int i=DIM; i>=1; i--) if (cone_dr[i-1] < dr) return i;
- return 0;
+double IsolatorByNominalEfficiency::ConeSizes::size(int i) const {
+  if (i >= 0 && i < DIM)
+    return cone_dr[i];
+  else
+    return 0.;
 }
 
-const float IsolatorByNominalEfficiency::ConeSizes::cone_dr[]=
-{ 0.001, 0.02, 0.045, 0.09, 0.13, 0.17, 0.20, 0.24, 0.28, 0.32, 0.38, 0.45, 0.5, 0.6, 0.7};
+int IsolatorByNominalEfficiency::ConeSizes::index(float dr) const {
+  for (int i = DIM; i >= 1; i--)
+    if (cone_dr[i - 1] < dr)
+      return i;
+  return 0;
+}
 
-IsolatorByNominalEfficiency::IsolatorByNominalEfficiency(const string & thrFile, 
-    const vector<string> & ceff, const vector<double>& weights) : theWeights(weights){
-  thresholds        = new NominalEfficiencyThresholds(findPath(thrFile));
+const float IsolatorByNominalEfficiency::ConeSizes::cone_dr[] = {
+    0.001, 0.02, 0.045, 0.09, 0.13, 0.17, 0.20, 0.24, 0.28, 0.32, 0.38, 0.45, 0.5, 0.6, 0.7};
+
+IsolatorByNominalEfficiency::IsolatorByNominalEfficiency(const string& thrFile,
+                                                         const vector<string>& ceff,
+                                                         const vector<double>& weights)
+    : theWeights(weights) {
+  thresholds = new NominalEfficiencyThresholds(findPath(thrFile));
   coneForEfficiency = cones(ceff);
   theDepThresholds = std::vector<double>(weights.size(), -1e12);
 }
 
-IsolatorByNominalEfficiency::
-IsolatorByNominalEfficiency(const string & thrFile, const vector<string> & ceff, 
-			    const vector<double>& weights, const vector<double>& thresh
-			    ) : theWeights(weights), theDepThresholds(thresh){
-  thresholds        = new NominalEfficiencyThresholds(findPath(thrFile));
+IsolatorByNominalEfficiency::IsolatorByNominalEfficiency(const string& thrFile,
+                                                         const vector<string>& ceff,
+                                                         const vector<double>& weights,
+                                                         const vector<double>& thresh)
+    : theWeights(weights), theDepThresholds(thresh) {
+  thresholds = new NominalEfficiencyThresholds(findPath(thrFile));
   coneForEfficiency = cones(ceff);
 }
 
-IsolatorByNominalEfficiency::~IsolatorByNominalEfficiency()
-{
-  delete thresholds;
-}
+IsolatorByNominalEfficiency::~IsolatorByNominalEfficiency() { delete thresholds; }
 
-IsolatorByNominalEfficiency::mapNomEff_Cone
-    IsolatorByNominalEfficiency::cones(const vector<string>& usrVec) {
+IsolatorByNominalEfficiency::mapNomEff_Cone IsolatorByNominalEfficiency::cones(const vector<string>& usrVec) {
   mapNomEff_Cone result;
-  for (vector<string>::const_iterator is = usrVec.begin();
-         is != usrVec.end(); is++) {
-    char * evp = nullptr;
-    int  cone = strtol( (*is).c_str(), &evp, 10);
-    float effic = strtod(evp+1, &evp);
-    result.insert(make_pair(effic,cone));
+  for (vector<string>::const_iterator is = usrVec.begin(); is != usrVec.end(); is++) {
+    char* evp = nullptr;
+    int cone = strtol((*is).c_str(), &evp, 10);
+    float effic = strtod(evp + 1, &evp);
+    result.insert(make_pair(effic, cone));
   }
   return result;
 }
 
-string IsolatorByNominalEfficiency::findPath(const string&  fileName)
-{
+string IsolatorByNominalEfficiency::findPath(const string& fileName) {
   // FIXME
   edm::FileInPath f(fileName);
   return f.fullPath();
 }
 
-MuIsoBaseIsolator::Result
-IsolatorByNominalEfficiency::result(const DepositContainer& deposits, const edm::Event*) const{
-
+MuIsoBaseIsolator::Result IsolatorByNominalEfficiency::result(const DepositContainer& deposits,
+                                                              const edm::Event*) const {
   if (deposits.empty()) {
     cout << "IsolatorByNominalEfficiency: no deposit" << endl;
-    return Result(resultType()); //FIXME
+    return Result(resultType());  //FIXME
   }
 
   // To determine the threshold, the direction of the cone of the first
@@ -78,23 +79,24 @@ IsolatorByNominalEfficiency::result(const DepositContainer& deposits, const edm:
   // becomes non isolated
 
   float nominalEfficiency = 1.;
-  const float deltaeff=0.005;
-  const float mineff=deltaeff;
-  for (float eff=.995; eff>mineff; eff-=deltaeff) {
+  const float deltaeff = 0.005;
+  const float mineff = deltaeff;
+  for (float eff = .995; eff > mineff; eff -= deltaeff) {
     int cone = bestConeForEfficiencyIndex(eff);
     float coneSize = theConesInfo.size(cone);
-    NominalEfficiencyThresholds::ThresholdLocation location = {theEta,cone};
-    float thres  = thresholds->thresholdValueForEfficiency(location, eff);
-    float sumDep = weightedSum(deposits,coneSize);
-//      cout << "   Eff=" << eff
-//         << " eta=" << theEta
-//         << " cone=" << cone
-//         << " dR=" << coneSize
-//         << " thres=" << thres
-//         << " deposit=" << sumDep
-//         << " isolated=" << (sumDep < thres)
-//         << endl;
-    if (sumDep > thres) break;
+    NominalEfficiencyThresholds::ThresholdLocation location = {theEta, cone};
+    float thres = thresholds->thresholdValueForEfficiency(location, eff);
+    float sumDep = weightedSum(deposits, coneSize);
+    //      cout << "   Eff=" << eff
+    //         << " eta=" << theEta
+    //         << " cone=" << cone
+    //         << " dR=" << coneSize
+    //         << " thres=" << thres
+    //         << " deposit=" << sumDep
+    //         << " isolated=" << (sumDep < thres)
+    //         << endl;
+    if (sumDep > thres)
+      break;
     nominalEfficiency = eff;
   }
   Result res(resultType());
@@ -102,57 +104,53 @@ IsolatorByNominalEfficiency::result(const DepositContainer& deposits, const edm:
   return res;
 }
 
-int IsolatorByNominalEfficiency::bestConeForEfficiencyIndex(float eff_thr) const
-{
-
+int IsolatorByNominalEfficiency::bestConeForEfficiencyIndex(float eff_thr) const {
   //FIXME use upper_bound
   int best_cone;
   if (!coneForEfficiency.empty()) {
     best_cone = (--(coneForEfficiency.end()))->second;
-  } else return 0;
+  } else
+    return 0;
 
-   mapNomEff_Cone::const_reverse_iterator it;
-  for (it = coneForEfficiency.rbegin();
-       it != coneForEfficiency.rend(); it++) {
-    if (eff_thr <= (*it).first) best_cone = (*it).second;
+  mapNomEff_Cone::const_reverse_iterator it;
+  for (it = coneForEfficiency.rbegin(); it != coneForEfficiency.rend(); it++) {
+    if (eff_thr <= (*it).first)
+      best_cone = (*it).second;
   }
   return best_cone;
 }
 
+double IsolatorByNominalEfficiency::weightedSum(const DepositContainer& deposits, float dRcone) const {
+  double sumDep = 0;
 
-double IsolatorByNominalEfficiency::weightedSum(const DepositContainer& deposits,
-                                    float dRcone) const {
-  double sumDep=0;
-
-  assert(deposits.size()==theWeights.size());
+  assert(deposits.size() == theWeights.size());
 
   vector<double>::const_iterator w = theWeights.begin();
   vector<double>::const_iterator dThresh = theDepThresholds.begin();
-  for (DepositContainer::const_iterator dep = deposits.begin();
-       dep != deposits.end(); dep++) {
-    if (dep->vetos != nullptr){
+  for (DepositContainer::const_iterator dep = deposits.begin(); dep != deposits.end(); dep++) {
+    if (dep->vetos != nullptr) {
       sumDep += dep->dep->depositAndCountWithin(dRcone, *dep->vetos, *dThresh).first * (*w);
     } else {
       sumDep += dep->dep->depositAndCountWithin(dRcone, Vetos(), *dThresh).first * (*w);
     }
-    if (sumDep <0.) sumDep = 0.;
+    if (sumDep < 0.)
+      sumDep = 0.;
     w++;
     dThresh++;
   }
   return sumDep;
 }
 
-Cuts IsolatorByNominalEfficiency::cuts(float nominalEfficiency) const
-{
-  vector<double>  etaBounds = thresholds->bins();
-  vector<double>  coneSizes;
-  vector<double>  cutvalues;
-  for (vector<double>::const_iterator it=etaBounds.begin(),itEnd=etaBounds.end();it < itEnd;++it){
+Cuts IsolatorByNominalEfficiency::cuts(float nominalEfficiency) const {
+  vector<double> etaBounds = thresholds->bins();
+  vector<double> coneSizes;
+  vector<double> cutvalues;
+  for (vector<double>::const_iterator it = etaBounds.begin(), itEnd = etaBounds.end(); it < itEnd; ++it) {
     float eta = (*it);
     int icone = bestConeForEfficiencyIndex(nominalEfficiency);
-    coneSizes.push_back( theConesInfo.size(icone));
-    NominalEfficiencyThresholds::ThresholdLocation location = {eta-1.e-3f, icone};
-    cutvalues.push_back( thresholds->thresholdValueForEfficiency(location, nominalEfficiency));
+    coneSizes.push_back(theConesInfo.size(icone));
+    NominalEfficiencyThresholds::ThresholdLocation location = {eta - 1.e-3f, icone};
+    cutvalues.push_back(thresholds->thresholdValueForEfficiency(location, nominalEfficiency));
   }
-  return Cuts(etaBounds,coneSizes,cutvalues);
+  return Cuts(etaBounds, coneSizes, cutvalues);
 }

--- a/RecoMuon/MuonIsolation/src/MuIsoByTrackPt.cc
+++ b/RecoMuon/MuonIsolation/src/MuIsoByTrackPt.cc
@@ -13,44 +13,38 @@
 #include <vector>
 #include <iostream>
 
-using std::vector;
-using std::string;
 using reco::IsoDeposit;
+using std::string;
+using std::vector;
 using namespace muonisolation;
 
-
-MuIsoByTrackPt::MuIsoByTrackPt(const edm::ParameterSet& conf, edm::ConsumesCollector && iC)
-{
+MuIsoByTrackPt::MuIsoByTrackPt(const edm::ParameterSet& conf, edm::ConsumesCollector&& iC) {
   edm::ParameterSet extractorPSet = conf.getParameter<edm::ParameterSet>("ExtractorPSet");
   string extractorName = extractorPSet.getParameter<string>("ComponentName");
-  theExtractor = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>(IsoDepositExtractorFactoryFromHelper::get()->create(extractorName, extractorPSet, iC));
+  theExtractor = std::unique_ptr<reco::isodeposit::IsoDepositExtractor>(
+      IsoDepositExtractorFactoryFromHelper::get()->create(extractorName, extractorPSet, iC));
 
   theCut = conf.getUntrackedParameter<double>("Threshold", 0.);
-  float coneSize =  conf.getUntrackedParameter<double>("ConeSize", 0.);
-  vector<double> weights(1,1.);
+  float coneSize = conf.getUntrackedParameter<double>("ConeSize", 0.);
+  vector<double> weights(1, 1.);
   theIsolator = std::make_unique<IsolatorByDeposit>(coneSize, weights);
 }
 
 MuIsoByTrackPt::~MuIsoByTrackPt() = default;
 
-void MuIsoByTrackPt::setConeSize(float dr)
-{
-  theIsolator->setConeSize(dr);
-}
+void MuIsoByTrackPt::setConeSize(float dr) { theIsolator->setConeSize(dr); }
 
-float MuIsoByTrackPt::isolation(const edm::Event& ev, const edm::EventSetup& es, const reco::Track & muon)
-{
-  IsoDeposit dep = extractor()->deposit(ev,es,muon);
+float MuIsoByTrackPt::isolation(const edm::Event& ev, const edm::EventSetup& es, const reco::Track& muon) {
+  IsoDeposit dep = extractor()->deposit(ev, es, muon);
   MuIsoBaseIsolator::DepositContainer deposits;
   deposits.push_back(&dep);
-  if (isolator()->resultType() == MuIsoBaseIsolator::ISOL_FLOAT_TYPE){
+  if (isolator()->resultType() == MuIsoBaseIsolator::ISOL_FLOAT_TYPE) {
     return isolator()->result(deposits).valFloat;
   }
 
   return -999.;
 }
 
-bool MuIsoByTrackPt::isIsolated(const edm::Event& ev, const edm::EventSetup& es, const reco::Track& muon)
-{
-  return (isolation(ev,es,muon) > theCut);
+bool MuIsoByTrackPt::isIsolated(const edm::Event& ev, const edm::EventSetup& es, const reco::Track& muon) {
+  return (isolation(ev, es, muon) > theCut);
 }

--- a/RecoMuon/MuonIsolation/src/MuPFIsoHelper.cc
+++ b/RecoMuon/MuonIsolation/src/MuPFIsoHelper.cc
@@ -1,11 +1,9 @@
 #include "RecoMuon/MuonIsolation/interface/MuPFIsoHelper.h"
 
-
-MuPFIsoHelper::MuPFIsoHelper(const std::map<std::string,edm::ParameterSet>& labelMap, edm::ConsumesCollector&& iC):
-  labelMap_(labelMap)  
-{
+MuPFIsoHelper::MuPFIsoHelper(const std::map<std::string, edm::ParameterSet>& labelMap, edm::ConsumesCollector&& iC)
+    : labelMap_(labelMap) {
   edm::Handle<CandDoubleMap> nullHandle;
-  for(std::map<std::string,edm::ParameterSet>::const_iterator i = labelMap_.begin();i!=labelMap_.end();++i) {
+  for (std::map<std::string, edm::ParameterSet>::const_iterator i = labelMap_.begin(); i != labelMap_.end(); ++i) {
     chargedParticle_.push_back(nullHandle);
     chargedHadron_.push_back(nullHandle);
     neutralHadron_.push_back(nullHandle);
@@ -14,97 +12,83 @@ MuPFIsoHelper::MuPFIsoHelper(const std::map<std::string,edm::ParameterSet>& labe
     photonHighThreshold_.push_back(nullHandle);
     pu_.push_back(nullHandle);
 
-    chargedParticleToken_.push_back(iC.consumes<CandDoubleMap>(i->second.getParameter<edm::InputTag>("chargedParticle")));
+    chargedParticleToken_.push_back(
+        iC.consumes<CandDoubleMap>(i->second.getParameter<edm::InputTag>("chargedParticle")));
     chargedHadronToken_.push_back(iC.consumes<CandDoubleMap>(i->second.getParameter<edm::InputTag>("chargedHadron")));
     neutralHadronToken_.push_back(iC.consumes<CandDoubleMap>(i->second.getParameter<edm::InputTag>("neutralHadron")));
-    neutralHadronHighThresholdToken_.push_back(iC.consumes<CandDoubleMap>(i->second.getParameter<edm::InputTag>("neutralHadronHighThreshold")));
+    neutralHadronHighThresholdToken_.push_back(
+        iC.consumes<CandDoubleMap>(i->second.getParameter<edm::InputTag>("neutralHadronHighThreshold")));
     photonToken_.push_back(iC.consumes<CandDoubleMap>(i->second.getParameter<edm::InputTag>("photon")));
-    photonHighThresholdToken_.push_back(iC.consumes<CandDoubleMap>(i->second.getParameter<edm::InputTag>("photonHighThreshold")));
+    photonHighThresholdToken_.push_back(
+        iC.consumes<CandDoubleMap>(i->second.getParameter<edm::InputTag>("photonHighThreshold")));
     puToken_.push_back(iC.consumes<CandDoubleMap>(i->second.getParameter<edm::InputTag>("pu")));
   }
-    
-
-
-
 }
 
-
-
-MuPFIsoHelper::~MuPFIsoHelper() {
-
-}
-
+MuPFIsoHelper::~MuPFIsoHelper() {}
 
 reco::MuonPFIsolation MuPFIsoHelper::makeIsoDeposit(reco::MuonRef& muonRef,
-						    const edm::Handle<CandDoubleMap>& chargedParticle,
-						    const edm::Handle<CandDoubleMap>& chargedHadron,
-						    const edm::Handle<CandDoubleMap>& neutralHadron,
-						    const edm::Handle<CandDoubleMap>& neutralHadronHighThreshold,
-						    const edm::Handle<CandDoubleMap>& photon,
-						    const edm::Handle<CandDoubleMap>& photonHighThreshold,
-						    const edm::Handle<CandDoubleMap>& pu) {
-
+                                                    const edm::Handle<CandDoubleMap>& chargedParticle,
+                                                    const edm::Handle<CandDoubleMap>& chargedHadron,
+                                                    const edm::Handle<CandDoubleMap>& neutralHadron,
+                                                    const edm::Handle<CandDoubleMap>& neutralHadronHighThreshold,
+                                                    const edm::Handle<CandDoubleMap>& photon,
+                                                    const edm::Handle<CandDoubleMap>& photonHighThreshold,
+                                                    const edm::Handle<CandDoubleMap>& pu) {
   reco::MuonPFIsolation iso;
-  if(chargedParticle.isValid()) 
+  if (chargedParticle.isValid())
     iso.sumChargedParticlePt = (*chargedParticle)[muonRef];
 
-  if(chargedHadron.isValid()) 
-       iso.sumChargedHadronPt = (*chargedHadron)[muonRef];
+  if (chargedHadron.isValid())
+    iso.sumChargedHadronPt = (*chargedHadron)[muonRef];
 
-  if(neutralHadron.isValid()) 
-       iso.sumNeutralHadronEt = (*neutralHadron)[muonRef];
+  if (neutralHadron.isValid())
+    iso.sumNeutralHadronEt = (*neutralHadron)[muonRef];
 
-  if(neutralHadronHighThreshold.isValid()) 
-       iso.sumNeutralHadronEtHighThreshold = (*neutralHadronHighThreshold)[muonRef];
+  if (neutralHadronHighThreshold.isValid())
+    iso.sumNeutralHadronEtHighThreshold = (*neutralHadronHighThreshold)[muonRef];
 
-  if(photon.isValid()) 
-       iso.sumPhotonEt = (*photon)[muonRef];
+  if (photon.isValid())
+    iso.sumPhotonEt = (*photon)[muonRef];
 
-  if(photonHighThreshold.isValid()) 
-       iso.sumPhotonEtHighThreshold = (*photonHighThreshold)[muonRef];
+  if (photonHighThreshold.isValid())
+    iso.sumPhotonEtHighThreshold = (*photonHighThreshold)[muonRef];
 
-  if(pu.isValid()) 
-       iso.sumPUPt = (*pu)[muonRef];
+  if (pu.isValid())
+    iso.sumPUPt = (*pu)[muonRef];
 
   return iso;
 }
 
+int MuPFIsoHelper::embedPFIsolation(reco::Muon& muon, reco::MuonRef& muonRef) {
+  unsigned int count = 0;
+  for (std::map<std::string, edm::ParameterSet>::const_iterator i = labelMap_.begin(); i != labelMap_.end(); ++i) {
+    reco::MuonPFIsolation iso = makeIsoDeposit(muonRef,
+                                               chargedParticle_[count],
+                                               chargedHadron_[count],
+                                               neutralHadron_[count],
+                                               neutralHadronHighThreshold_[count],
+                                               photon_[count],
+                                               photonHighThreshold_[count],
+                                               pu_[count]);
 
-int MuPFIsoHelper::embedPFIsolation(reco::Muon& muon,reco::MuonRef& muonRef ) {
-
-  unsigned int count=0;
-  for(std::map<std::string,edm::ParameterSet>::const_iterator i = labelMap_.begin();i!=labelMap_.end();++i) {
-    reco::MuonPFIsolation iso =makeIsoDeposit(muonRef,
-					      chargedParticle_[count],
-					      chargedHadron_[count],
-					      neutralHadron_[count],
-					      neutralHadronHighThreshold_[count],
-                                              photon_[count],
-					      photonHighThreshold_[count],
-					      pu_[count]);
- 
-    muon.setPFIsolation(i->first,iso);
+    muon.setPFIsolation(i->first, iso);
     count++;
   }
-
 
   return 0;
 }
 
-
-
-void MuPFIsoHelper::beginEvent(const edm::Event& iEvent){
-
-  unsigned int count=0;
-  for(std::map<std::string,edm::ParameterSet>::const_iterator i = labelMap_.begin();i!=labelMap_.end();++i) {
-    iEvent.getByToken(chargedParticleToken_[count],chargedParticle_[count]);
-    iEvent.getByToken(chargedHadronToken_[count],chargedHadron_[count]);
-    iEvent.getByToken(neutralHadronToken_[count],neutralHadron_[count]);
-    iEvent.getByToken(neutralHadronHighThresholdToken_[count],neutralHadronHighThreshold_[count]);
-    iEvent.getByToken(photonToken_[count],photon_[count]);
-    iEvent.getByToken(photonHighThresholdToken_[count],photonHighThreshold_[count]);
-    iEvent.getByToken(puToken_[count],pu_[count]);
+void MuPFIsoHelper::beginEvent(const edm::Event& iEvent) {
+  unsigned int count = 0;
+  for (std::map<std::string, edm::ParameterSet>::const_iterator i = labelMap_.begin(); i != labelMap_.end(); ++i) {
+    iEvent.getByToken(chargedParticleToken_[count], chargedParticle_[count]);
+    iEvent.getByToken(chargedHadronToken_[count], chargedHadron_[count]);
+    iEvent.getByToken(neutralHadronToken_[count], neutralHadron_[count]);
+    iEvent.getByToken(neutralHadronHighThresholdToken_[count], neutralHadronHighThreshold_[count]);
+    iEvent.getByToken(photonToken_[count], photon_[count]);
+    iEvent.getByToken(photonHighThresholdToken_[count], photonHighThreshold_[count]);
+    iEvent.getByToken(puToken_[count], pu_[count]);
     count++;
   }
-
 }

--- a/RecoMuon/MuonIsolation/src/MuonIsolatorFactory.cc
+++ b/RecoMuon/MuonIsolation/src/MuonIsolatorFactory.cc
@@ -1,3 +1,3 @@
 #include "RecoMuon/MuonIsolation/interface/MuonIsolatorFactory.h"
 
-EDM_REGISTER_PLUGINFACTORY(MuonIsolatorFactory,"MuonIsolatorFactory");
+EDM_REGISTER_PLUGINFACTORY(MuonIsolatorFactory, "MuonIsolatorFactory");

--- a/RecoMuon/MuonIsolation/src/NominalEfficiencyThresholds.cc
+++ b/RecoMuon/MuonIsolation/src/NominalEfficiencyThresholds.cc
@@ -8,146 +8,134 @@
 using namespace muonisolation;
 using namespace std;
 
-NominalEfficiencyThresholds::EtaBounds::EtaBounds()
-{
+NominalEfficiencyThresholds::EtaBounds::EtaBounds() {
   float BaseEtaBin = 0.087;
-  theBounds[0]=0.0;
-  for (int it=1; it <= 20; it++) theBounds[it] = it*BaseEtaBin;
-  theBounds[21]=1.83;
-  theBounds[22]=1.93;
-  theBounds[23]=2.043;
-  theBounds[24]=2.172;
-  theBounds[25]=2.322;
-  theBounds[26]=2.5;
-  theBounds[27]=2.65;
-  theBounds[28]=3.0;
-  theBounds[29]=3.13;
-  theBounds[30]=3.305;
-  theBounds[31]=3.48;
-  theBounds[32]=3.655;
+  theBounds[0] = 0.0;
+  for (int it = 1; it <= 20; it++)
+    theBounds[it] = it * BaseEtaBin;
+  theBounds[21] = 1.83;
+  theBounds[22] = 1.93;
+  theBounds[23] = 2.043;
+  theBounds[24] = 2.172;
+  theBounds[25] = 2.322;
+  theBounds[26] = 2.5;
+  theBounds[27] = 2.65;
+  theBounds[28] = 3.0;
+  theBounds[29] = 3.13;
+  theBounds[30] = 3.305;
+  theBounds[31] = 3.48;
+  theBounds[32] = 3.655;
 }
 
-int NominalEfficiencyThresholds::EtaBounds::towerFromEta(double eta) const
-{
+int NominalEfficiencyThresholds::EtaBounds::towerFromEta(double eta) const {
   int number = 0;
   for (int num = 1; num <= NumberOfTowers; num++) {
-    if ( fabs(eta) > theBounds[num-1]) {
+    if (fabs(eta) > theBounds[num - 1]) {
       number = num;
-      if (eta < 0) number = -num;
+      if (eta < 0)
+        number = -num;
     }
   }
-  if (fabs(eta) >= theBounds[NumberOfTowers-1]) number = 0;
+  if (fabs(eta) >= theBounds[NumberOfTowers - 1])
+    number = 0;
   return number;
 }
 
-vector<double> NominalEfficiencyThresholds::bins() const
-{
+vector<double> NominalEfficiencyThresholds::bins() const {
   vector<double> result;
-  for (unsigned int i=1; i <=EtaBounds::NumberOfTowers; i++) result.push_back(etabounds(i));
-  return result;  
+  for (unsigned int i = 1; i <= EtaBounds::NumberOfTowers; i++)
+    result.push_back(etabounds(i));
+  return result;
 }
 
-bool NominalEfficiencyThresholds::EfficiencyBin::operator() (const EfficiencyBin & e1,
-                                     const EfficiencyBin & e2) const
-{
-  return e1.eff<= e2.eff_previous;
+bool NominalEfficiencyThresholds::EfficiencyBin::operator()(const EfficiencyBin &e1, const EfficiencyBin &e2) const {
+  return e1.eff <= e2.eff_previous;
 }
 
-bool NominalEfficiencyThresholds::locless::operator()(const ThresholdLocation & l1,
-                                const ThresholdLocation & l2) const
-{
+bool NominalEfficiencyThresholds::locless::operator()(const ThresholdLocation &l1, const ThresholdLocation &l2) const {
   int itow1 = abs(etabounds.towerFromEta(l1.eta));
   int itow2 = abs(etabounds.towerFromEta(l2.eta));
-  if (itow1 < itow2) return true;
-  if (itow1 == itow2 && l1.cone< l2.cone) return true;
+  if (itow1 < itow2)
+    return true;
+  if (itow1 == itow2 && l1.cone < l2.cone)
+    return true;
   return false;
 }
 
-NominalEfficiencyThresholds::NominalEfficiencyThresholds(const string & infile)
-{
+NominalEfficiencyThresholds::NominalEfficiencyThresholds(const string &infile) {
   FILE *INFILE;
   char buffer[81];
   char tag[5];
-  if ( (INFILE=fopen(infile.c_str(),"r")) == nullptr) {
-    cout << "Cannot open input file " << infile <<endl;
+  if ((INFILE = fopen(infile.c_str(), "r")) == nullptr) {
+    cout << "Cannot open input file " << infile << endl;
     return;
   }
   ThresholdLocation location;
   EfficiencyBin eb;
   eb.eff = 0;
   float thr_val;
-  while (fgets(buffer,80,INFILE)) {
-    sscanf(buffer,"%4s",tag);
-    if (strcmp(tag,"ver:") == 0){
-      cout <<" NominalEfficiencyThresholds: "<< infile <<" comment: "<<buffer<<endl;
+  while (fgets(buffer, 80, INFILE)) {
+    sscanf(buffer, "%4s", tag);
+    if (strcmp(tag, "ver:") == 0) {
+      cout << " NominalEfficiencyThresholds: " << infile << " comment: " << buffer << endl;
       thresholds.clear();
     }
-    if (strcmp(tag,"loc:") == 0) {
-      sscanf(buffer,"%*s %f %*s %d", &location.eta, &location.cone);
+    if (strcmp(tag, "loc:") == 0) {
+      sscanf(buffer, "%*s %f %*s %d", &location.eta, &location.cone);
       eb.eff = 0.;
     }
-    if (strcmp(tag,"thr:") == 0) {
+    if (strcmp(tag, "thr:") == 0) {
       eb.eff_previous = eb.eff;
-      sscanf(buffer,"%*s %f %f", &eb.eff, &thr_val);
-      add(location,ThresholdConstituent(eb,thr_val));
+      sscanf(buffer, "%*s %f %f", &eb.eff, &thr_val);
+      add(location, ThresholdConstituent(eb, thr_val));
     }
   }
   fclose(INFILE);
-  cout << "... done"<<endl;
+  cout << "... done" << endl;
   //dump();
 }
 
-
-void NominalEfficiencyThresholds::add(ThresholdLocation location,
-                           ThresholdConstituent threshold)
-{
+void NominalEfficiencyThresholds::add(ThresholdLocation location, ThresholdConstituent threshold) {
   MapType::iterator ploc = thresholds.find(location);
-  if ( ploc == thresholds.end() ) {
+  if (ploc == thresholds.end()) {
     ThresholdConstituents mt;
     mt.insert(threshold);
     thresholds[location] = mt;
   } else {
-//    cout << "insert element ("<<threshold.first.eff<<","
-//                            <<threshold.first.eff_previous<<") to map "<<endl;
+    //    cout << "insert element ("<<threshold.first.eff<<","
+    //                            <<threshold.first.eff_previous<<") to map "<<endl;
     (*ploc).second.insert(threshold);
-//    cout << "new size is:"<< (*ploc).second.size() <<endl;
+    //    cout << "new size is:"<< (*ploc).second.size() <<endl;
   }
 }
 
-void NominalEfficiencyThresholds::dump()
-{
+void NominalEfficiencyThresholds::dump() {
   MapType::iterator ploc;
   for (ploc = thresholds.begin(); ploc != thresholds.end(); ploc++) {
-    cout << "eta: "<< (*ploc).first.eta
-         << " icone: "<< (*ploc).first.cone<<endl;
+    cout << "eta: " << (*ploc).first.eta << " icone: " << (*ploc).first.cone << endl;
     ThresholdConstituents::iterator it;
     for (it = (*ploc).second.begin(); it != (*ploc).second.end(); it++) {
-      cout << " eff: "         << (*it).first.eff
-           << " eff_previous: "<< (*it).first.eff_previous
-           << " cut value: "   << (*it).second <<endl;
+      cout << " eff: " << (*it).first.eff << " eff_previous: " << (*it).first.eff_previous
+           << " cut value: " << (*it).second << endl;
     }
   }
 }
 
-float NominalEfficiencyThresholds::thresholdValueForEfficiency( 
-   ThresholdLocation location, float eff_thr) const 
-{
+float NominalEfficiencyThresholds::thresholdValueForEfficiency(ThresholdLocation location, float eff_thr) const {
   MapType::const_iterator ploc = thresholds.find(location);
-  if ( ploc == thresholds.end() ) {
-    cout << "NominalEfficiencyThresholds: Problem:can't find location in the map :( "
-       << location.eta << " " << location.cone << " " << eff_thr
-       <<endl;
+  if (ploc == thresholds.end()) {
+    cout << "NominalEfficiencyThresholds: Problem:can't find location in the map :( " << location.eta << " "
+         << location.cone << " " << eff_thr << endl;
     return -1;
   }
 
-  const float epsilon=1.e-6;
-  EfficiencyBin eb = {eff_thr,eff_thr-epsilon};
+  const float epsilon = 1.e-6;
+  EfficiencyBin eb = {eff_thr, eff_thr - epsilon};
   ThresholdConstituents::const_iterator it = (*ploc).second.find(eb);
   if (it == (*ploc).second.end()) {
-    cout << "NominalEfficiencyThresholds: Problem:can't find threshold in the map :("<<endl;
+    cout << "NominalEfficiencyThresholds: Problem:can't find threshold in the map :(" << endl;
     return -1;
   }
 
   return (*it).second;
 }
-

--- a/RecoMuon/MuonIsolation/src/NominalEfficiencyThresholds.h
+++ b/RecoMuon/MuonIsolation/src/NominalEfficiencyThresholds.h
@@ -7,61 +7,56 @@
 #include <vector>
 
 namespace muonisolation {
-class NominalEfficiencyThresholds {
-public:
-  NominalEfficiencyThresholds() { }
-  NominalEfficiencyThresholds(const std::string & infile);
-  ~NominalEfficiencyThresholds() { }
-
-  /// threshold location
-  struct ThresholdLocation { float eta; int cone; };
-
-  float thresholdValueForEfficiency(ThresholdLocation location, float eff_thr) const;
-
-  std::vector<double> bins() const;
-  void dump();
-
-private:
-
-
-  /// compare to efficiencies
-  struct EfficiencyBin {
-    float eff;
-    float eff_previous;
-    bool operator() (const EfficiencyBin & e1,
-                 const EfficiencyBin & e2) const;
-  };
-
-
-  class EtaBounds {
+  class NominalEfficiencyThresholds {
   public:
-    enum { NumberOfTowers = 32 };
-    EtaBounds();
-    int    towerFromEta(double eta) const;
-    float  operator()(unsigned int i) const { return theBounds[i]; }
+    NominalEfficiencyThresholds() {}
+    NominalEfficiencyThresholds(const std::string& infile);
+    ~NominalEfficiencyThresholds() {}
+
+    /// threshold location
+    struct ThresholdLocation {
+      float eta;
+      int cone;
+    };
+
+    float thresholdValueForEfficiency(ThresholdLocation location, float eff_thr) const;
+
+    std::vector<double> bins() const;
+    void dump();
+
   private:
-    float theBounds[NumberOfTowers+1]; //max eta of towers 1-32 (indx 1-32) and 0. for indx 0
-  };
+    /// compare to efficiencies
+    struct EfficiencyBin {
+      float eff;
+      float eff_previous;
+      bool operator()(const EfficiencyBin& e1, const EfficiencyBin& e2) const;
+    };
 
+    class EtaBounds {
+    public:
+      enum { NumberOfTowers = 32 };
+      EtaBounds();
+      int towerFromEta(double eta) const;
+      float operator()(unsigned int i) const { return theBounds[i]; }
 
-  /// compare two locations
-  struct locless {
-    bool operator()(const ThresholdLocation & l1,
-                const ThresholdLocation & l2) const;
+    private:
+      float theBounds[NumberOfTowers + 1];  //max eta of towers 1-32 (indx 1-32) and 0. for indx 0
+    };
+
+    /// compare two locations
+    struct locless {
+      bool operator()(const ThresholdLocation& l1, const ThresholdLocation& l2) const;
+      EtaBounds etabounds;
+    };
+
+    typedef std::pair<EfficiencyBin, float> ThresholdConstituent;
+    typedef std::map<EfficiencyBin, float, EfficiencyBin> ThresholdConstituents;
+    typedef std::map<ThresholdLocation, ThresholdConstituents, locless> MapType;
+
+    void add(ThresholdLocation location, ThresholdConstituent threshold);
+    MapType thresholds;
+
     EtaBounds etabounds;
   };
-
-
-
-  typedef std::pair<EfficiencyBin,float> ThresholdConstituent;
-  typedef std::map<EfficiencyBin,float,EfficiencyBin> ThresholdConstituents;
-  typedef std::map<ThresholdLocation,ThresholdConstituents,locless> MapType;
-
-  void add(ThresholdLocation location, ThresholdConstituent threshold);
-  MapType thresholds;
-
-  EtaBounds etabounds;
-};
-}
+}  // namespace muonisolation
 #endif
-

--- a/RecoVertex/LinearizationPointFinders/interface/CrossingPtBasedLinearizationPointFinder.h
+++ b/RecoVertex/LinearizationPointFinders/interface/CrossingPtBasedLinearizationPointFinder.h
@@ -6,7 +6,7 @@
 #include "RecoVertex/VertexTools/interface/ModeFinder3d.h"
 #include "RecoVertex/VertexTools/interface/RecTracksDistanceMatrix.h"
 
-  /** A linearization point finder. It works the following way:
+/** A linearization point finder. It works the following way:
    *  1. Calculate in an optimal way 'n_pairs' different crossing points.
    *     Optimal in this context means the following:
    *     a. Try to use as many different tracks as possible;
@@ -23,14 +23,12 @@
    *  2. Apply theAlgo on the n points.
    */
 
-class CrossingPtBasedLinearizationPointFinder : public LinearizationPointFinder
-{
+class CrossingPtBasedLinearizationPointFinder : public LinearizationPointFinder {
 public:
   /** \param n_pairs: how many track pairs will be considered (maximum)
    *                  a value of -1 means full combinatorics.
    */
-  CrossingPtBasedLinearizationPointFinder( const ModeFinder3d & algo,
-     const signed int n_pairs = 5 );
+  CrossingPtBasedLinearizationPointFinder(const ModeFinder3d &algo, const signed int n_pairs = 5);
 
   /** This constructor exploits the information stored in a 
    *  RecTracksDistanceMatrix object.
@@ -38,23 +36,23 @@ public:
    *                  a value of -1 means full combinatorics.
    */
 
-  CrossingPtBasedLinearizationPointFinder( 
-      const RecTracksDistanceMatrix * m, const ModeFinder3d & algo,
-      const signed int n_pairs = -1 );
+  CrossingPtBasedLinearizationPointFinder(const RecTracksDistanceMatrix *m,
+                                          const ModeFinder3d &algo,
+                                          const signed int n_pairs = -1);
 
-  CrossingPtBasedLinearizationPointFinder(
-      const CrossingPtBasedLinearizationPointFinder & );
+  CrossingPtBasedLinearizationPointFinder(const CrossingPtBasedLinearizationPointFinder &);
 
   ~CrossingPtBasedLinearizationPointFinder() override;
 
-/** Method giving back the Initial Linearization Point.
+  /** Method giving back the Initial Linearization Point.
  */
-  GlobalPoint getLinearizationPoint(const std::vector<reco::TransientTrack> & ) const override;
-  GlobalPoint getLinearizationPoint(const std::vector<FreeTrajectoryState> & ) const override;
+  GlobalPoint getLinearizationPoint(const std::vector<reco::TransientTrack> &) const override;
+  GlobalPoint getLinearizationPoint(const std::vector<FreeTrajectoryState> &) const override;
 
-  CrossingPtBasedLinearizationPointFinder * clone() const override {
-    return new CrossingPtBasedLinearizationPointFinder ( * this );
+  CrossingPtBasedLinearizationPointFinder *clone() const override {
+    return new CrossingPtBasedLinearizationPointFinder(*this);
   };
+
 protected:
   const bool useMatrix;
   signed int theNPairs;
@@ -63,22 +61,22 @@ protected:
 private:
   /// calls (*theAglo) (input)
   /// can optionally save input / output in .root file
-  GlobalPoint find ( const std::vector<std::pair <GlobalPoint , float> > & ) const;
+  GlobalPoint find(const std::vector<std::pair<GlobalPoint, float> > &) const;
+
 private:
-  ModeFinder3d * theAlgo;
+  ModeFinder3d *theAlgo;
 
   /** Private struct to order tracks by momentum
    */
   struct CompareTwoTracks {
-    int operator() ( const reco::TransientTrack & a, const reco::TransientTrack & b ) {
-            return a.initialFreeState().momentum().mag() >
-        	   b.initialFreeState().momentum().mag();
-//       return a.p() > b.p();
+    int operator()(const reco::TransientTrack &a, const reco::TransientTrack &b) {
+      return a.initialFreeState().momentum().mag() > b.initialFreeState().momentum().mag();
+      //       return a.p() > b.p();
     };
   };
-  std::vector <reco::TransientTrack> getBestTracks ( const std::vector<reco::TransientTrack> & ) const;
-  GlobalPoint useFullMatrix ( const std::vector<reco::TransientTrack> & ) const;
-  GlobalPoint useAllTracks  ( const std::vector<reco::TransientTrack> & ) const;
+  std::vector<reco::TransientTrack> getBestTracks(const std::vector<reco::TransientTrack> &) const;
+  GlobalPoint useFullMatrix(const std::vector<reco::TransientTrack> &) const;
+  GlobalPoint useAllTracks(const std::vector<reco::TransientTrack> &) const;
 };
 
 #endif

--- a/RecoVertex/LinearizationPointFinders/interface/DefaultLinearizationPointFinder.h
+++ b/RecoVertex/LinearizationPointFinders/interface/DefaultLinearizationPointFinder.h
@@ -3,21 +3,19 @@
 
 #include "RecoVertex/LinearizationPointFinders/interface/FsmwLinearizationPointFinder.h"
 
-  /** 
+/** 
    *  The default linearization point finder.
    *  This class is supposed to cover a very wide range of use uses;
    *  this is the class to use, unless you really know that you want 
    *  something else.
    */
 
-class DefaultLinearizationPointFinder : public FsmwLinearizationPointFinder
-{
+class DefaultLinearizationPointFinder : public FsmwLinearizationPointFinder {
 public:
-  DefaultLinearizationPointFinder() : 
-    FsmwLinearizationPointFinder ( 400, -.5, .4, 10, 5 ) {};
+  DefaultLinearizationPointFinder() : FsmwLinearizationPointFinder(400, -.5, .4, 10, 5){};
 
-  DefaultLinearizationPointFinder( const RecTracksDistanceMatrix * m ) :
-    FsmwLinearizationPointFinder ( m, 400, -.5, .4, 10, 5 ) {};
+  DefaultLinearizationPointFinder(const RecTracksDistanceMatrix* m)
+      : FsmwLinearizationPointFinder(m, 400, -.5, .4, 10, 5){};
 };
 
 #endif

--- a/RecoVertex/LinearizationPointFinders/interface/FallbackLinearizationPointFinder.h
+++ b/RecoVertex/LinearizationPointFinders/interface/FallbackLinearizationPointFinder.h
@@ -4,25 +4,22 @@
 #include "RecoVertex/VertexTools/interface/LinearizationPointFinder.h"
 #include "RecoVertex/VertexTools/interface/HsmModeFinder3d.h"
 
-  /** 
+/** 
    *  A fallback linearization point finder that is
    *  used if the 'actual' CrossingPtBasedLinPtFinder fails.
    *  Computes the mode based on innermost states.
    */
 
-class FallbackLinearizationPointFinder : public LinearizationPointFinder
-{
+class FallbackLinearizationPointFinder : public LinearizationPointFinder {
 public:
-  FallbackLinearizationPointFinder ( const ModeFinder3d & m = HsmModeFinder3d() );
-  GlobalPoint getLinearizationPoint(const std::vector<reco::TransientTrack> & ) const override;
-  GlobalPoint getLinearizationPoint(const std::vector<FreeTrajectoryState> & ) const override;
+  FallbackLinearizationPointFinder(const ModeFinder3d& m = HsmModeFinder3d());
+  GlobalPoint getLinearizationPoint(const std::vector<reco::TransientTrack>&) const override;
+  GlobalPoint getLinearizationPoint(const std::vector<FreeTrajectoryState>&) const override;
 
-  FallbackLinearizationPointFinder * clone() const override
-  {
-    return new FallbackLinearizationPointFinder ( * this );
-  };
+  FallbackLinearizationPointFinder* clone() const override { return new FallbackLinearizationPointFinder(*this); };
+
 private:
-  ModeFinder3d * theModeFinder;
+  ModeFinder3d* theModeFinder;
 };
 
 #endif

--- a/RecoVertex/LinearizationPointFinders/interface/FsmwLinearizationPointFinder.h
+++ b/RecoVertex/LinearizationPointFinders/interface/FsmwLinearizationPointFinder.h
@@ -3,7 +3,7 @@
 
 #include "RecoVertex/LinearizationPointFinders/interface/CrossingPtBasedLinearizationPointFinder.h"
 
-  /** A linearization point finder. It works the following way:
+/** A linearization point finder. It works the following way:
    *  1. Calculate in an optimal way 'n_pairs' different crossing points.
    *     Optimal in this context means the following:
    *     a. Try to use as many different tracks as possible;
@@ -20,8 +20,7 @@
    *  2. Do a Fsmw on the n points.
    */
 
-class FsmwLinearizationPointFinder : public CrossingPtBasedLinearizationPointFinder
-{
+class FsmwLinearizationPointFinder : public CrossingPtBasedLinearizationPointFinder {
 public:
   /**
    *  \param n_pairs how many track pairs are considered
@@ -31,15 +30,17 @@ public:
    *  \param cut cut parameter of the weight function
    *  \param fraction Fraction that is considered
    */
-  FsmwLinearizationPointFinder( signed int n_pairs = 250,
-                                float weight_exp = -2., float fraction = .5,
-                                float cut=10, int no_weight_above = 10 );
+  FsmwLinearizationPointFinder(
+      signed int n_pairs = 250, float weight_exp = -2., float fraction = .5, float cut = 10, int no_weight_above = 10);
 
-  FsmwLinearizationPointFinder( const RecTracksDistanceMatrix * m,
-      signed int n_pairs = 250, float weight_exp = -2., float fraction = .5,
-      float cut=10, int no_weight_above = 10 );
+  FsmwLinearizationPointFinder(const RecTracksDistanceMatrix* m,
+                               signed int n_pairs = 250,
+                               float weight_exp = -2.,
+                               float fraction = .5,
+                               float cut = 10,
+                               int no_weight_above = 10);
 
-  FsmwLinearizationPointFinder * clone() const override;
+  FsmwLinearizationPointFinder* clone() const override;
 };
 
 #endif

--- a/RecoVertex/LinearizationPointFinders/interface/HSMLinearizationPointFinder.h
+++ b/RecoVertex/LinearizationPointFinders/interface/HSMLinearizationPointFinder.h
@@ -3,7 +3,7 @@
 
 #include "RecoVertex/LinearizationPointFinders/interface/CrossingPtBasedLinearizationPointFinder.h"
 
-  /** A linearization point finder. It works the following way:
+/** A linearization point finder. It works the following way:
    *  1. Calculate in an optimal way 'n_pairs' different crossing points.
    *     Optimal in this context means the following:
    *     a. Try to use as many different tracks as possible;
@@ -20,14 +20,12 @@
    *  2. Do a HSM on the n points.
    */
 
-class HSMLinearizationPointFinder : public CrossingPtBasedLinearizationPointFinder
-{
+class HSMLinearizationPointFinder : public CrossingPtBasedLinearizationPointFinder {
 public:
-  HSMLinearizationPointFinder( const signed int n_pairs = 10 );
-  HSMLinearizationPointFinder( const RecTracksDistanceMatrix * m,
-      const signed int n_pairs = -1 );
+  HSMLinearizationPointFinder(const signed int n_pairs = 10);
+  HSMLinearizationPointFinder(const RecTracksDistanceMatrix* m, const signed int n_pairs = -1);
 
-  HSMLinearizationPointFinder * clone() const override;
+  HSMLinearizationPointFinder* clone() const override;
 };
 
 #endif

--- a/RecoVertex/LinearizationPointFinders/interface/LMSLinearizationPointFinder.h
+++ b/RecoVertex/LinearizationPointFinders/interface/LMSLinearizationPointFinder.h
@@ -3,7 +3,7 @@
 
 #include "RecoVertex/LinearizationPointFinders/interface/CrossingPtBasedLinearizationPointFinder.h"
 
-  /** A linearization point finder. It works the following way:
+/** A linearization point finder. It works the following way:
    *  1. Calculate in an optimal way 'n_pairs' different crossing points.
    *     Optimal in this context means the following:
    *     a. Try to use as many different tracks as possible;
@@ -20,14 +20,12 @@
    *  2. Do a LMS on the n points.
    */
 
-class LMSLinearizationPointFinder : public CrossingPtBasedLinearizationPointFinder
-{
+class LMSLinearizationPointFinder : public CrossingPtBasedLinearizationPointFinder {
 public:
-  LMSLinearizationPointFinder( const signed int n_pairs = 10 );
-  LMSLinearizationPointFinder( const RecTracksDistanceMatrix * m,
-      const signed int n_pairs = -1 );
+  LMSLinearizationPointFinder(const signed int n_pairs = 10);
+  LMSLinearizationPointFinder(const RecTracksDistanceMatrix* m, const signed int n_pairs = -1);
 
-  LMSLinearizationPointFinder * clone() const override;
+  LMSLinearizationPointFinder* clone() const override;
 };
 
 #endif

--- a/RecoVertex/LinearizationPointFinders/interface/LinPtException.h
+++ b/RecoVertex/LinearizationPointFinders/interface/LinPtException.h
@@ -3,14 +3,13 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 
-  /** 
+/** 
    *  A class that wraps cms::Exception by deriving from it.
    */
 
-class LinPtException : public cms::Exception
-{
+class LinPtException : public cms::Exception {
 public:
-  LinPtException( const char * reason ) : cms::Exception ( reason ) {};
+  LinPtException(const char* reason) : cms::Exception(reason){};
 };
 
 #endif

--- a/RecoVertex/LinearizationPointFinders/interface/SMSLinearizationPointFinder.h
+++ b/RecoVertex/LinearizationPointFinders/interface/SMSLinearizationPointFinder.h
@@ -4,7 +4,7 @@
 #include "RecoVertex/LinearizationPointFinders/interface/CrossingPtBasedLinearizationPointFinder.h"
 #include "RecoVertex/VertexTools/interface/SMS.h"
 
-  /** A linearization point finder. It works the following way:
+/** A linearization point finder. It works the following way:
    *  1. Calculate in an optimal way 'n_pairs' different crossing points.
    *     Optimal in this context means the following:
    *     a. Try to use as many different tracks as possible;
@@ -21,14 +21,12 @@
    *  2. Do a LMS on the n points.
    */
 
-class SMSLinearizationPointFinder : public CrossingPtBasedLinearizationPointFinder
-{
+class SMSLinearizationPointFinder : public CrossingPtBasedLinearizationPointFinder {
 public:
-  SMSLinearizationPointFinder( signed int n_pairs = 10,  const SMS & sms = SMS() );
-  SMSLinearizationPointFinder( const RecTracksDistanceMatrix * m,
-      signed int n_pairs = -1, const SMS & sms = SMS() );
+  SMSLinearizationPointFinder(signed int n_pairs = 10, const SMS& sms = SMS());
+  SMSLinearizationPointFinder(const RecTracksDistanceMatrix* m, signed int n_pairs = -1, const SMS& sms = SMS());
 
-  SMSLinearizationPointFinder * clone() const override;
+  SMSLinearizationPointFinder* clone() const override;
 };
 
 #endif

--- a/RecoVertex/LinearizationPointFinders/interface/SubsetHSMLinearizationPointFinder.h
+++ b/RecoVertex/LinearizationPointFinders/interface/SubsetHSMLinearizationPointFinder.h
@@ -3,7 +3,7 @@
 
 #include "RecoVertex/LinearizationPointFinders/interface/CrossingPtBasedLinearizationPointFinder.h"
 
-  /** A linearization point finder. It works the following way:
+/** A linearization point finder. It works the following way:
    *  1. Calculate in an optimal way 'n_pairs' different crossing points.
    *     Optimal in this context means the following:
    *     a. Try to use as many different tracks as possible;
@@ -20,14 +20,12 @@
    *  2. Do a SubsetHSM on the n points.
    */
 
-class SubsetHSMLinearizationPointFinder : public CrossingPtBasedLinearizationPointFinder
-{
+class SubsetHSMLinearizationPointFinder : public CrossingPtBasedLinearizationPointFinder {
 public:
-  SubsetHSMLinearizationPointFinder( const signed int n_pairs = 10 );
-  SubsetHSMLinearizationPointFinder( const RecTracksDistanceMatrix * m,
-      const signed int n_pairs = -1 );
+  SubsetHSMLinearizationPointFinder(const signed int n_pairs = 10);
+  SubsetHSMLinearizationPointFinder(const RecTracksDistanceMatrix* m, const signed int n_pairs = -1);
 
-  SubsetHSMLinearizationPointFinder * clone() const override;
+  SubsetHSMLinearizationPointFinder* clone() const override;
 };
 
 #endif

--- a/RecoVertex/LinearizationPointFinders/interface/ZeroLinearizationPointFinder.h
+++ b/RecoVertex/LinearizationPointFinders/interface/ZeroLinearizationPointFinder.h
@@ -3,20 +3,16 @@
 
 #include "RecoVertex/VertexTools/interface/LinearizationPointFinder.h"
 
-  /** 
+/** 
    *  A linearization point finder that always returns (0,0,0)
    */
 
-class ZeroLinearizationPointFinder : public LinearizationPointFinder
-{
+class ZeroLinearizationPointFinder : public LinearizationPointFinder {
 public:
-  GlobalPoint getLinearizationPoint(const std::vector<reco::TransientTrack> & ) const override;
-  GlobalPoint getLinearizationPoint(const std::vector<FreeTrajectoryState> & ) const override;
+  GlobalPoint getLinearizationPoint(const std::vector<reco::TransientTrack>&) const override;
+  GlobalPoint getLinearizationPoint(const std::vector<FreeTrajectoryState>&) const override;
 
-  ZeroLinearizationPointFinder * clone() const override
-  {
-    return new ZeroLinearizationPointFinder ( * this );
-  };
+  ZeroLinearizationPointFinder* clone() const override { return new ZeroLinearizationPointFinder(*this); };
 };
 
 #endif

--- a/RecoVertex/LinearizationPointFinders/src/CrossingPtBasedLinearizationPointFinder.cc
+++ b/RecoVertex/LinearizationPointFinders/src/CrossingPtBasedLinearizationPointFinder.cc
@@ -17,37 +17,30 @@
 #include "RecoVertex/VertexTools/interface/LmsModeFinder3d.h"
 #endif
 
-namespace
-{
-inline GlobalPoint operator - ( const GlobalPoint & a, const GlobalPoint & b )
-{
-    return GlobalPoint ( a.x() - b.x(), a.y() - b.y(), a.z() - b.z() );
-}
+namespace {
+  inline GlobalPoint operator-(const GlobalPoint& a, const GlobalPoint& b) {
+    return GlobalPoint(a.x() - b.x(), a.y() - b.y(), a.z() - b.z());
+  }
 
-inline GlobalPoint operator + ( const GlobalPoint & a, const GlobalPoint & b )
-{
-    return GlobalPoint ( a.x() + b.x(), a.y() + b.y(), a.z() + b.z() );
-}
+  inline GlobalPoint operator+(const GlobalPoint& a, const GlobalPoint& b) {
+    return GlobalPoint(a.x() + b.x(), a.y() + b.y(), a.z() + b.z());
+  }
 
-inline GlobalPoint operator / ( const GlobalPoint & a, const double b )
-{
-    return GlobalPoint ( a.x() / b, a.y() / b, a.z() / b );
-}
+  inline GlobalPoint operator/(const GlobalPoint& a, const double b) {
+    return GlobalPoint(a.x() / b, a.y() / b, a.z() / b);
+  }
 
 #ifndef __clang__
-inline GlobalPoint operator * ( const GlobalPoint & a, const double b )
-{
-    return GlobalPoint ( a.x() * b, a.y() * b, a.z() * b );
-}
+  inline GlobalPoint operator*(const GlobalPoint& a, const double b) {
+    return GlobalPoint(a.x() * b, a.y() * b, a.z() * b);
+  }
 
-inline GlobalPoint operator * ( const double b , const GlobalPoint & a )
-{
-    return GlobalPoint ( a.x() * b, a.y() * b, a.z() * b );
-}
+  inline GlobalPoint operator*(const double b, const GlobalPoint& a) {
+    return GlobalPoint(a.x() * b, a.y() * b, a.z() * b);
+  }
 #endif
 
-inline unsigned int sum ( unsigned int nr )
-{
+  inline unsigned int sum(unsigned int nr) {
     /*
     int ret=0;
     for ( int i=1; i<= nr ; i++ )
@@ -56,88 +49,72 @@ inline unsigned int sum ( unsigned int nr )
     }
     return ret;
     */
-    return ( nr * ( nr + 1 ) ) / 2;
-}
+    return (nr * (nr + 1)) / 2;
+  }
 
 #ifdef Use_GraphicsHarvester
 
-void graphicsDebug ( const std::vector < PointAndDistance > & input )
-{
-    bool sve = SimpleConfigurable<bool> (false,
-                                         "CrossingPointStudy:Harvest").value();
-    std::string fname = SimpleConfigurable<string>("crossingpoints.txt",
-                   "CrossingPointStudy:FileName").value();
-    if (sve)
-    {
-        for ( std::vector< PointAndDistance >::const_iterator i=input.begin();
-                i!=input.end() ; ++i )
-        {
-            std::map < std::string, MultiType > attrs;
-            attrs["name"]="GlobalPoint";
-            attrs["color"]="yellow";
-            attrs["mag"]=.7;
-            attrs["comment"]="Input for CrossingPtBasedLinearizationPointFinder";
-            PrimitivesHarvester( fname )
-            .save ( i->first, attrs );
-        }
-        std::map < std::string, MultiType > attrs;
-        attrs["name"]="The Mode(*theAlgo)";
-        attrs["color"]="green";
-        attrs["comment"]="Output from CrossingPtBasedLinearizationPointFinder";
-        PrimitivesHarvester( fname )
-        .save ( ret, attrs );
-        GlobalPoint subsethsm = SubsetHsmModeFinder3d()( input );
-        attrs["name"]="The Mode(SubsetHSM)";
-        attrs["color"]="red";
-        PrimitivesHarvester( fname ).save ( subsethsm, attrs );
-        GlobalPoint hsm = HsmModeFinder3d()( input );
-        attrs["name"]="The Mode(HSM)";
-        attrs["color"]="blue";
-        PrimitivesHarvester( fname ).save ( hsm, attrs );
-        GlobalPoint lms = LmsModeFinder3d()( input );
-        attrs["name"]="The Mode(LMS)";
-        attrs["color"]="gold";
-        PrimitivesHarvester( fname ).save ( lms, attrs );
+  void graphicsDebug(const std::vector<PointAndDistance>& input) {
+    bool sve = SimpleConfigurable<bool>(false, "CrossingPointStudy:Harvest").value();
+    std::string fname = SimpleConfigurable<string>("crossingpoints.txt", "CrossingPointStudy:FileName").value();
+    if (sve) {
+      for (std::vector<PointAndDistance>::const_iterator i = input.begin(); i != input.end(); ++i) {
+        std::map<std::string, MultiType> attrs;
+        attrs["name"] = "GlobalPoint";
+        attrs["color"] = "yellow";
+        attrs["mag"] = .7;
+        attrs["comment"] = "Input for CrossingPtBasedLinearizationPointFinder";
+        PrimitivesHarvester(fname).save(i->first, attrs);
+      }
+      std::map<std::string, MultiType> attrs;
+      attrs["name"] = "The Mode(*theAlgo)";
+      attrs["color"] = "green";
+      attrs["comment"] = "Output from CrossingPtBasedLinearizationPointFinder";
+      PrimitivesHarvester(fname).save(ret, attrs);
+      GlobalPoint subsethsm = SubsetHsmModeFinder3d()(input);
+      attrs["name"] = "The Mode(SubsetHSM)";
+      attrs["color"] = "red";
+      PrimitivesHarvester(fname).save(subsethsm, attrs);
+      GlobalPoint hsm = HsmModeFinder3d()(input);
+      attrs["name"] = "The Mode(HSM)";
+      attrs["color"] = "blue";
+      PrimitivesHarvester(fname).save(hsm, attrs);
+      GlobalPoint lms = LmsModeFinder3d()(input);
+      attrs["name"] = "The Mode(LMS)";
+      attrs["color"] = "gold";
+      PrimitivesHarvester(fname).save(lms, attrs);
     }
-}
+  }
 #endif
-}
+}  // namespace
+
+CrossingPtBasedLinearizationPointFinder::CrossingPtBasedLinearizationPointFinder(const ModeFinder3d& algo,
+                                                                                 const signed int n_pairs)
+    : useMatrix(false), theNPairs(n_pairs), theMatrix(nullptr), theAlgo(algo.clone()) {}
+
+CrossingPtBasedLinearizationPointFinder::CrossingPtBasedLinearizationPointFinder(const RecTracksDistanceMatrix* m,
+                                                                                 const ModeFinder3d& algo,
+                                                                                 const signed int n_pairs)
+    : useMatrix(m->hasCrossingPoints()), theNPairs(n_pairs), theMatrix(m), theAlgo(algo.clone()) {}
 
 CrossingPtBasedLinearizationPointFinder::CrossingPtBasedLinearizationPointFinder(
-    const ModeFinder3d & algo, const signed int n_pairs ) :
-        useMatrix ( false ) , theNPairs ( n_pairs ), theMatrix ( nullptr ),
-        theAlgo ( algo.clone() )
-{}
+    const CrossingPtBasedLinearizationPointFinder& o)
+    : useMatrix(o.useMatrix),
+      theNPairs(o.theNPairs),
+      theMatrix(o.theMatrix /* nope, we dont clone!! */),
+      theAlgo(o.theAlgo->clone()) {}
 
-CrossingPtBasedLinearizationPointFinder::CrossingPtBasedLinearizationPointFinder(
-    const RecTracksDistanceMatrix * m, const ModeFinder3d & algo,
-    const signed int n_pairs ) :
-        useMatrix ( m->hasCrossingPoints() ) ,
-        theNPairs ( n_pairs ), theMatrix ( m ), theAlgo ( algo.clone() )
-{}
+CrossingPtBasedLinearizationPointFinder::~CrossingPtBasedLinearizationPointFinder() { delete theAlgo; }
 
-CrossingPtBasedLinearizationPointFinder::CrossingPtBasedLinearizationPointFinder
-( const CrossingPtBasedLinearizationPointFinder & o ) :
-        useMatrix ( o.useMatrix ), theNPairs ( o.theNPairs ),
-        theMatrix ( o.theMatrix /* nope, we dont clone!! */ ),
-        theAlgo ( o.theAlgo->clone() )
-{}
+std::vector<reco::TransientTrack> CrossingPtBasedLinearizationPointFinder::getBestTracks(
+    const std::vector<reco::TransientTrack>& tracks) const {
+  unsigned int n_tracks = (2 * (unsigned int)(theNPairs)) < tracks.size() ? 2 * theNPairs : tracks.size();
 
-CrossingPtBasedLinearizationPointFinder::~CrossingPtBasedLinearizationPointFinder()
-{
-    delete theAlgo;
-}
+  std::vector<reco::TransientTrack> newtracks = tracks;
+  partial_sort(newtracks.begin(), newtracks.begin() + n_tracks, newtracks.end(), CompareTwoTracks());
+  newtracks.erase(newtracks.begin() + n_tracks, newtracks.end());
 
-std::vector <reco::TransientTrack> CrossingPtBasedLinearizationPointFinder::getBestTracks (
-    const std::vector<reco::TransientTrack> & tracks ) const
-{
-    unsigned int n_tracks = (2*(unsigned int) (theNPairs)) < tracks.size() ? 2*theNPairs : tracks.size();
-
-    std::vector <reco::TransientTrack> newtracks = tracks;
-    partial_sort ( newtracks.begin(), newtracks.begin()+n_tracks, newtracks.end(), CompareTwoTracks() );
-    newtracks.erase ( newtracks.begin()+n_tracks, newtracks.end() );
-
-    /*
+  /*
      * old version, when we have a default constructor
      *
     
@@ -146,197 +123,158 @@ std::vector <reco::TransientTrack> CrossingPtBasedLinearizationPointFinder::getB
                         newtracks.begin() + n_tracks  , CompareTwoTracks() );
                         */
 
-    return newtracks;
+  return newtracks;
 }
 
-typedef std::pair < GlobalPoint , float > PointAndDistance;
+typedef std::pair<GlobalPoint, float> PointAndDistance;
 
 GlobalPoint CrossingPtBasedLinearizationPointFinder::useAllTracks(
-    const std::vector<reco::TransientTrack> & tracks ) const
-{
-    std::vector< PointAndDistance > vgp;
-    // vgp.reserve ( ( tracks.size() * ( tracks.size()-1 ) ) / 2 - 1 );
-    TwoTrackMinimumDistance ttmd;
-    bool status;
-    std::vector<reco::TransientTrack>::const_iterator end=tracks.end();
-    std::vector<reco::TransientTrack>::const_iterator endm1=(end-1);
-    for ( std::vector<reco::TransientTrack>::const_iterator x=tracks.begin();
-            x!=endm1 ; ++x )
-    {
-        for ( std::vector<reco::TransientTrack>::const_iterator y=x+1;
-                y!=end; ++y )
-        {
-         status = ttmd.calculate( (*x).impactPointState(), (*y).impactPointState() );
-	 if (status) {
-	   std::pair < GlobalPoint, GlobalPoint > pts = ttmd.points();
-           std::pair < GlobalPoint , float > v ( ( pts.second + pts.first ) / 2. ,
-		 ( pts.second - pts.first ).mag() );
-           vgp.push_back( v );
-	 } // If sth goes wrong, we just dont add. Who cares?
-        }
+    const std::vector<reco::TransientTrack>& tracks) const {
+  std::vector<PointAndDistance> vgp;
+  // vgp.reserve ( ( tracks.size() * ( tracks.size()-1 ) ) / 2 - 1 );
+  TwoTrackMinimumDistance ttmd;
+  bool status;
+  std::vector<reco::TransientTrack>::const_iterator end = tracks.end();
+  std::vector<reco::TransientTrack>::const_iterator endm1 = (end - 1);
+  for (std::vector<reco::TransientTrack>::const_iterator x = tracks.begin(); x != endm1; ++x) {
+    for (std::vector<reco::TransientTrack>::const_iterator y = x + 1; y != end; ++y) {
+      status = ttmd.calculate((*x).impactPointState(), (*y).impactPointState());
+      if (status) {
+        std::pair<GlobalPoint, GlobalPoint> pts = ttmd.points();
+        std::pair<GlobalPoint, float> v((pts.second + pts.first) / 2., (pts.second - pts.first).mag());
+        vgp.push_back(v);
+      }  // If sth goes wrong, we just dont add. Who cares?
     }
-    if (vgp.empty() )
-    {
-        return FallbackLinearizationPointFinder().getLinearizationPoint ( tracks );
-    }
-    return find ( vgp );
+  }
+  if (vgp.empty()) {
+    return FallbackLinearizationPointFinder().getLinearizationPoint(tracks);
+  }
+  return find(vgp);
 }
 
 GlobalPoint CrossingPtBasedLinearizationPointFinder::useFullMatrix(
-    const std::vector<reco::TransientTrack> & tracks ) const
-{
-    std::vector< PointAndDistance > vgp;
-    vgp.reserve ( (int) ( tracks.size() * ( tracks.size() -1 ) / 2. - 1 ) );
-    std::vector<reco::TransientTrack>::const_iterator end=tracks.end();
-    std::vector<reco::TransientTrack>::const_iterator endm1=(end-1);
-    for ( std::vector<reco::TransientTrack>::const_iterator x=tracks.begin();
-            x!=endm1 ; ++x )
-    {
-        for ( std::vector<reco::TransientTrack>::const_iterator y=x+1;
-                y!=end; ++y )
-        {
-            PointAndDistance v ( theMatrix->crossingPoint ( *x , *y ),
-                                 theMatrix->distance ( *x, *y ) );
-            vgp.push_back ( v );
-        }
+    const std::vector<reco::TransientTrack>& tracks) const {
+  std::vector<PointAndDistance> vgp;
+  vgp.reserve((int)(tracks.size() * (tracks.size() - 1) / 2. - 1));
+  std::vector<reco::TransientTrack>::const_iterator end = tracks.end();
+  std::vector<reco::TransientTrack>::const_iterator endm1 = (end - 1);
+  for (std::vector<reco::TransientTrack>::const_iterator x = tracks.begin(); x != endm1; ++x) {
+    for (std::vector<reco::TransientTrack>::const_iterator y = x + 1; y != end; ++y) {
+      PointAndDistance v(theMatrix->crossingPoint(*x, *y), theMatrix->distance(*x, *y));
+      vgp.push_back(v);
     }
-    if (vgp.empty() )
-    {
-        return FallbackLinearizationPointFinder().getLinearizationPoint ( tracks );
-    }
-    return find ( vgp );
+  }
+  if (vgp.empty()) {
+    return FallbackLinearizationPointFinder().getLinearizationPoint(tracks);
+  }
+  return find(vgp);
 }
 
 GlobalPoint CrossingPtBasedLinearizationPointFinder::getLinearizationPoint(
-    const std::vector<FreeTrajectoryState> & tracks ) const
-{
-    return LinearizationPointFinder::getLinearizationPoint ( tracks );
+    const std::vector<FreeTrajectoryState>& tracks) const {
+  return LinearizationPointFinder::getLinearizationPoint(tracks);
 }
 
-GlobalPoint CrossingPtBasedLinearizationPointFinder::find (
-    const std::vector < PointAndDistance > & input ) const
-{
-    /*
+GlobalPoint CrossingPtBasedLinearizationPointFinder::find(const std::vector<PointAndDistance>& input) const {
+  /*
     std::cout << "[CrossingPtBasedLinearizationPointFinder] input size="
          << input.size() << std::endl;*/
-    GlobalPoint ret = (*theAlgo) (input);
+  GlobalPoint ret = (*theAlgo)(input);
 #ifdef Use_GraphicsHarvester
 
-    graphicsDebug ( input );
+  graphicsDebug(input);
 #endif
 
-    return ret;
+  return ret;
 }
 
 GlobalPoint CrossingPtBasedLinearizationPointFinder::getLinearizationPoint(
-    const std::vector<reco::TransientTrack> & tracks ) const
-{
-        if ( tracks.size() < 2 )
-          throw LinPtException
-          ("CrossingPtBasedLinPtFinder: too few tracks given.");
-        std::vector < PointAndDistance > vgp;
-        if ( theNPairs == -1 )
-        {
-            if ( useMatrix )
-            {
-                return useFullMatrix( tracks );
-            }
-            else
-            {
-                return useAllTracks ( tracks );
-            }
-        }
+    const std::vector<reco::TransientTrack>& tracks) const {
+  if (tracks.size() < 2)
+    throw LinPtException("CrossingPtBasedLinPtFinder: too few tracks given.");
+  std::vector<PointAndDistance> vgp;
+  if (theNPairs == -1) {
+    if (useMatrix) {
+      return useFullMatrix(tracks);
+    } else {
+      return useAllTracks(tracks);
+    }
+  }
 
-        if ( sum ( tracks.size() - 1 ) < ((unsigned int) (theNPairs)) )
-        {
-            /*
+  if (sum(tracks.size() - 1) < ((unsigned int)(theNPairs))) {
+    /*
             std::cout << "[CrossingPtBasedLinearizationPointFinder] we exploit all track pairs"
                  << std::endl;*/
-            // we have fewer track pair options than is foreseen
-            // in the quota.
-            // so we exploit all tracks pairs.
-            return useAllTracks ( tracks );
-        }
+    // we have fewer track pair options than is foreseen
+    // in the quota.
+    // so we exploit all tracks pairs.
+    return useAllTracks(tracks);
+  }
 
-        std::vector <reco::TransientTrack> goodtracks = getBestTracks ( tracks );
+  std::vector<reco::TransientTrack> goodtracks = getBestTracks(tracks);
 
-        // we sort according to momenta.
-        if ( goodtracks.size() < 2 )
-            throw LinPtException (
-                "CrossingPtBasedLinPtFinder: less than two tracks given");
-        // vgp.reserve ( theNPairs - 1 );
-        unsigned int t_first = 0;
-        unsigned int t_interval = goodtracks.size() / 2;
-        unsigned int lim = goodtracks.size() - 1;
+  // we sort according to momenta.
+  if (goodtracks.size() < 2)
+    throw LinPtException("CrossingPtBasedLinPtFinder: less than two tracks given");
+  // vgp.reserve ( theNPairs - 1 );
+  unsigned int t_first = 0;
+  unsigned int t_interval = goodtracks.size() / 2;
+  unsigned int lim = goodtracks.size() - 1;
 
-        /*
+  /*
         std::cout << "[CrossingPtBasedLinearizationPointFinder] we start: npairs=" << theNPairs
              << std::endl;
         std::cout << "[CrossingPtBasedLinearizationPointFinder] t_interval=" << t_interval << std::endl;
         std::cout << "[CrossingPtBasedLinearizationPointFinder goodtracks.size=" << goodtracks.size()
              << std::endl;*/
 
-        // the 'direction' false: intervals will expand
-        // true: intervals will shrink
-        bool dir = false;
+  // the 'direction' false: intervals will expand
+  // true: intervals will shrink
+  bool dir = false;
 
-        while ( vgp.size() < ((unsigned int) (theNPairs)) )
-        {
-            reco::TransientTrack rt1 = goodtracks [ t_first ];
-            reco::TransientTrack rt2 = goodtracks [ t_first + t_interval ];
-            // std::cout << "Considering now: " << t_first << ", " << t_first+t_interval << std::endl;
-            if ( useMatrix )
-            {
-                PointAndDistance v ( theMatrix->crossingPoint ( rt1, rt2 ),
-                                     theMatrix->distance ( rt1, rt2 ) );
-                vgp.push_back ( v );
-            }
-            else
-            { // No DistanceMatrix available
-                TwoTrackMinimumDistance ttmd;
-		bool status = ttmd.calculate( rt1.impactPointState(), rt2.impactPointState() );
-		if (status) {
-                  std::pair < GlobalPoint, GlobalPoint > pts = ttmd.points();
-                  PointAndDistance v ( ( pts.second + pts.first ) / 2. ,
-                                       ( pts.second - pts.first ).mag() );
-                  vgp.push_back( v );
-		}
-            }
-            if ( ( t_first + t_interval ) < lim )
-            {
-                t_first++;
-            }
-            else if ( dir )
-            {
-                t_first=0;
-                t_interval--;
-                if ( t_interval == 0 )
-                {
-                    /* std::cout << "[CrossingPtBasedLinearizationPointFinder] t_interval=0. break."
+  while (vgp.size() < ((unsigned int)(theNPairs))) {
+    reco::TransientTrack rt1 = goodtracks[t_first];
+    reco::TransientTrack rt2 = goodtracks[t_first + t_interval];
+    // std::cout << "Considering now: " << t_first << ", " << t_first+t_interval << std::endl;
+    if (useMatrix) {
+      PointAndDistance v(theMatrix->crossingPoint(rt1, rt2), theMatrix->distance(rt1, rt2));
+      vgp.push_back(v);
+    } else {  // No DistanceMatrix available
+      TwoTrackMinimumDistance ttmd;
+      bool status = ttmd.calculate(rt1.impactPointState(), rt2.impactPointState());
+      if (status) {
+        std::pair<GlobalPoint, GlobalPoint> pts = ttmd.points();
+        PointAndDistance v((pts.second + pts.first) / 2., (pts.second - pts.first).mag());
+        vgp.push_back(v);
+      }
+    }
+    if ((t_first + t_interval) < lim) {
+      t_first++;
+    } else if (dir) {
+      t_first = 0;
+      t_interval--;
+      if (t_interval == 0) {
+        /* std::cout << "[CrossingPtBasedLinearizationPointFinder] t_interval=0. break."
                          << std::endl;*/
-                    break;
-                }
-            }
-            else
-            {
-                t_first=0;
-                t_interval++;
-                if ( t_interval == goodtracks.size() )
-                {
-                    /* std::cout << "[CrossingPtBasedLinearizationPointFinder] t_interval="
+        break;
+      }
+    } else {
+      t_first = 0;
+      t_interval++;
+      if (t_interval == goodtracks.size()) {
+        /* std::cout << "[CrossingPtBasedLinearizationPointFinder] t_interval="
                          << goodtracks.size() << "(max). start to decrease intervals"
                          << std::endl; */
-                    dir=true;
-                    t_interval =  goodtracks.size() / 2 - 1;
-                }
-            }
-        }
-        if (vgp.empty() )
-        {
-            // no crossing points? Fallback to a crossingpoint-less lin pt finder!
-            return FallbackLinearizationPointFinder().getLinearizationPoint ( tracks );
-        }
-        return find ( vgp );
-    
-    return GlobalPoint(0.,0.,0.); // if nothing else, then return 0,0,0
+        dir = true;
+        t_interval = goodtracks.size() / 2 - 1;
+      }
+    }
+  }
+  if (vgp.empty()) {
+    // no crossing points? Fallback to a crossingpoint-less lin pt finder!
+    return FallbackLinearizationPointFinder().getLinearizationPoint(tracks);
+  }
+  return find(vgp);
+
+  return GlobalPoint(0., 0., 0.);  // if nothing else, then return 0,0,0
 }

--- a/RecoVertex/LinearizationPointFinders/src/FallbackLinearizationPointFinder.cc
+++ b/RecoVertex/LinearizationPointFinders/src/FallbackLinearizationPointFinder.cc
@@ -3,37 +3,29 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "RecoVertex/VertexTools/interface/FsmwModeFinder3d.h"
 
-FallbackLinearizationPointFinder::FallbackLinearizationPointFinder ( 
-    const ModeFinder3d & m ) : theModeFinder ( m.clone() ) {}
+FallbackLinearizationPointFinder::FallbackLinearizationPointFinder(const ModeFinder3d& m) : theModeFinder(m.clone()) {}
 
 GlobalPoint FallbackLinearizationPointFinder::getLinearizationPoint(
-    const std::vector<FreeTrajectoryState> & tracks ) const
-{
-  return GlobalPoint(0.,0.,0.);
+    const std::vector<FreeTrajectoryState>& tracks) const {
+  return GlobalPoint(0., 0., 0.);
 }
 
 GlobalPoint FallbackLinearizationPointFinder::getLinearizationPoint(
-    const std::vector<reco::TransientTrack> & tracks ) const
-{
-    switch ( tracks.size() )
-    {
-      case 0:
-        return GlobalPoint ( 0.,0.,0. );
-      case 1:
-        return tracks.begin()->impactPointState().globalPosition();
-      default:
-      {
-        std::vector < std::pair < GlobalPoint, float > > wtracks;
-        wtracks.reserve ( tracks.size() - 1 );
-        for ( std::vector< reco::TransientTrack >::const_iterator i=tracks.begin(); 
-              i!=tracks.end() ; ++i )
-        {
-            std::pair < GlobalPoint, float > tmp ( 
-                i->impactPointState().globalPosition(), 1. );
-            wtracks.push_back ( tmp );
-        }
-        return (*theModeFinder) ( wtracks );
+    const std::vector<reco::TransientTrack>& tracks) const {
+  switch (tracks.size()) {
+    case 0:
+      return GlobalPoint(0., 0., 0.);
+    case 1:
+      return tracks.begin()->impactPointState().globalPosition();
+    default: {
+      std::vector<std::pair<GlobalPoint, float> > wtracks;
+      wtracks.reserve(tracks.size() - 1);
+      for (std::vector<reco::TransientTrack>::const_iterator i = tracks.begin(); i != tracks.end(); ++i) {
+        std::pair<GlobalPoint, float> tmp(i->impactPointState().globalPosition(), 1.);
+        wtracks.push_back(tmp);
       }
+      return (*theModeFinder)(wtracks);
     }
-  return GlobalPoint ( 0.,0.,0. );
+  }
+  return GlobalPoint(0., 0., 0.);
 }

--- a/RecoVertex/LinearizationPointFinders/src/FsmwLinearizationPointFinder.cc
+++ b/RecoVertex/LinearizationPointFinders/src/FsmwLinearizationPointFinder.cc
@@ -1,20 +1,13 @@
 #include "RecoVertex/LinearizationPointFinders/interface/FsmwLinearizationPointFinder.h"
 #include "RecoVertex/VertexTools/interface/FsmwModeFinder3d.h"
 
-FsmwLinearizationPointFinder::FsmwLinearizationPointFinder(
-    signed int n_pairs, float we, float frac, float cut, int nwa ) :
-  CrossingPtBasedLinearizationPointFinder ( FsmwModeFinder3d(frac,we,cut,nwa), n_pairs )
-{ }
+FsmwLinearizationPointFinder::FsmwLinearizationPointFinder(signed int n_pairs, float we, float frac, float cut, int nwa)
+    : CrossingPtBasedLinearizationPointFinder(FsmwModeFinder3d(frac, we, cut, nwa), n_pairs) {}
 
 FsmwLinearizationPointFinder::FsmwLinearizationPointFinder(
-    const RecTracksDistanceMatrix * m, signed int n_pairs, float we, 
-       float frac, float cut, int nwa ) :
-  CrossingPtBasedLinearizationPointFinder ( m , 
-      FsmwModeFinder3d( frac,we,cut,nwa ), n_pairs )
-{ }
+    const RecTracksDistanceMatrix* m, signed int n_pairs, float we, float frac, float cut, int nwa)
+    : CrossingPtBasedLinearizationPointFinder(m, FsmwModeFinder3d(frac, we, cut, nwa), n_pairs) {}
 
-FsmwLinearizationPointFinder * FsmwLinearizationPointFinder::clone()
-  const
-{
-  return new FsmwLinearizationPointFinder ( * this );
+FsmwLinearizationPointFinder* FsmwLinearizationPointFinder::clone() const {
+  return new FsmwLinearizationPointFinder(*this);
 }

--- a/RecoVertex/LinearizationPointFinders/src/HSMLinearizationPointFinder.cc
+++ b/RecoVertex/LinearizationPointFinders/src/HSMLinearizationPointFinder.cc
@@ -1,18 +1,12 @@
 #include "RecoVertex/LinearizationPointFinders/interface/HSMLinearizationPointFinder.h"
 #include "RecoVertex/VertexTools/interface/HsmModeFinder3d.h"
 
-HSMLinearizationPointFinder::HSMLinearizationPointFinder(
-    const signed int n_pairs ) :
-  CrossingPtBasedLinearizationPointFinder ( HsmModeFinder3d(), n_pairs )
-{ }
+HSMLinearizationPointFinder::HSMLinearizationPointFinder(const signed int n_pairs)
+    : CrossingPtBasedLinearizationPointFinder(HsmModeFinder3d(), n_pairs) {}
 
-HSMLinearizationPointFinder::HSMLinearizationPointFinder(
-    const RecTracksDistanceMatrix * m, const signed int n_pairs ) :
-  CrossingPtBasedLinearizationPointFinder ( m , HsmModeFinder3d(), n_pairs )
-{ }
+HSMLinearizationPointFinder::HSMLinearizationPointFinder(const RecTracksDistanceMatrix* m, const signed int n_pairs)
+    : CrossingPtBasedLinearizationPointFinder(m, HsmModeFinder3d(), n_pairs) {}
 
-HSMLinearizationPointFinder * HSMLinearizationPointFinder::clone()
-  const
-{
-  return new HSMLinearizationPointFinder ( * this );
+HSMLinearizationPointFinder* HSMLinearizationPointFinder::clone() const {
+  return new HSMLinearizationPointFinder(*this);
 }

--- a/RecoVertex/LinearizationPointFinders/src/LMSLinearizationPointFinder.cc
+++ b/RecoVertex/LinearizationPointFinders/src/LMSLinearizationPointFinder.cc
@@ -1,18 +1,12 @@
 #include "RecoVertex/LinearizationPointFinders/interface/LMSLinearizationPointFinder.h"
 #include "RecoVertex/VertexTools/interface/LmsModeFinder3d.h"
 
-LMSLinearizationPointFinder::LMSLinearizationPointFinder(
-    const signed int n_pairs ) :
-  CrossingPtBasedLinearizationPointFinder ( LmsModeFinder3d(), n_pairs )
-{ }
+LMSLinearizationPointFinder::LMSLinearizationPointFinder(const signed int n_pairs)
+    : CrossingPtBasedLinearizationPointFinder(LmsModeFinder3d(), n_pairs) {}
 
-LMSLinearizationPointFinder::LMSLinearizationPointFinder(
-    const RecTracksDistanceMatrix * m, const signed int n_pairs ) :
-  CrossingPtBasedLinearizationPointFinder ( m , LmsModeFinder3d(), n_pairs )
-{ }
+LMSLinearizationPointFinder::LMSLinearizationPointFinder(const RecTracksDistanceMatrix* m, const signed int n_pairs)
+    : CrossingPtBasedLinearizationPointFinder(m, LmsModeFinder3d(), n_pairs) {}
 
-LMSLinearizationPointFinder * LMSLinearizationPointFinder::clone()
-  const
-{
-  return new LMSLinearizationPointFinder ( * this );
+LMSLinearizationPointFinder* LMSLinearizationPointFinder::clone() const {
+  return new LMSLinearizationPointFinder(*this);
 }

--- a/RecoVertex/LinearizationPointFinders/src/SMSLinearizationPointFinder.cc
+++ b/RecoVertex/LinearizationPointFinders/src/SMSLinearizationPointFinder.cc
@@ -1,20 +1,14 @@
 #include "RecoVertex/LinearizationPointFinders/interface/SMSLinearizationPointFinder.h"
 #include "RecoVertex/VertexTools/interface/SmsModeFinder3d.h"
 
-SMSLinearizationPointFinder::SMSLinearizationPointFinder(
-    const signed int n_pairs, const SMS & sms ) :
-  CrossingPtBasedLinearizationPointFinder ( 
-      SmsModeFinder3d( sms ), n_pairs )
-{ }
+SMSLinearizationPointFinder::SMSLinearizationPointFinder(const signed int n_pairs, const SMS& sms)
+    : CrossingPtBasedLinearizationPointFinder(SmsModeFinder3d(sms), n_pairs) {}
 
-SMSLinearizationPointFinder::SMSLinearizationPointFinder(
-    const RecTracksDistanceMatrix * m, const signed int n_pairs, const SMS & sms ) :
-  CrossingPtBasedLinearizationPointFinder ( m , 
-      SmsModeFinder3d( sms ), n_pairs )
-{ }
+SMSLinearizationPointFinder::SMSLinearizationPointFinder(const RecTracksDistanceMatrix* m,
+                                                         const signed int n_pairs,
+                                                         const SMS& sms)
+    : CrossingPtBasedLinearizationPointFinder(m, SmsModeFinder3d(sms), n_pairs) {}
 
-SMSLinearizationPointFinder * SMSLinearizationPointFinder::clone()
-  const
-{
-  return new SMSLinearizationPointFinder ( * this );
+SMSLinearizationPointFinder* SMSLinearizationPointFinder::clone() const {
+  return new SMSLinearizationPointFinder(*this);
 }

--- a/RecoVertex/LinearizationPointFinders/src/SubsetHSMLinearizationPointFinder.cc
+++ b/RecoVertex/LinearizationPointFinders/src/SubsetHSMLinearizationPointFinder.cc
@@ -1,18 +1,13 @@
 #include "RecoVertex/LinearizationPointFinders/interface/SubsetHSMLinearizationPointFinder.h"
 #include "RecoVertex/VertexTools/interface/SubsetHsmModeFinder3d.h"
 
-SubsetHSMLinearizationPointFinder::SubsetHSMLinearizationPointFinder(
-    const signed int n_pairs ) :
-  CrossingPtBasedLinearizationPointFinder ( SubsetHsmModeFinder3d(), n_pairs )
-{ }
+SubsetHSMLinearizationPointFinder::SubsetHSMLinearizationPointFinder(const signed int n_pairs)
+    : CrossingPtBasedLinearizationPointFinder(SubsetHsmModeFinder3d(), n_pairs) {}
 
-SubsetHSMLinearizationPointFinder::SubsetHSMLinearizationPointFinder(
-    const RecTracksDistanceMatrix * m, const signed int n_pairs ) :
-  CrossingPtBasedLinearizationPointFinder ( m , SubsetHsmModeFinder3d(), n_pairs )
-{ }
+SubsetHSMLinearizationPointFinder::SubsetHSMLinearizationPointFinder(const RecTracksDistanceMatrix* m,
+                                                                     const signed int n_pairs)
+    : CrossingPtBasedLinearizationPointFinder(m, SubsetHsmModeFinder3d(), n_pairs) {}
 
-SubsetHSMLinearizationPointFinder * SubsetHSMLinearizationPointFinder::clone()
-  const
-{
-  return new SubsetHSMLinearizationPointFinder ( * this );
+SubsetHSMLinearizationPointFinder* SubsetHSMLinearizationPointFinder::clone() const {
+  return new SubsetHSMLinearizationPointFinder(*this);
 }

--- a/RecoVertex/LinearizationPointFinders/src/ZeroLinearizationPointFinder.cc
+++ b/RecoVertex/LinearizationPointFinders/src/ZeroLinearizationPointFinder.cc
@@ -2,14 +2,10 @@
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 
-GlobalPoint ZeroLinearizationPointFinder::getLinearizationPoint(
-    const std::vector<FreeTrajectoryState> & tracks ) const
-{
-  return GlobalPoint(0.,0.,0.);
+GlobalPoint ZeroLinearizationPointFinder::getLinearizationPoint(const std::vector<FreeTrajectoryState>& tracks) const {
+  return GlobalPoint(0., 0., 0.);
 }
 
-GlobalPoint ZeroLinearizationPointFinder::getLinearizationPoint(
-    const std::vector<reco::TransientTrack> & tracks ) const
-{
-  return GlobalPoint(0.,0.,0.);
+GlobalPoint ZeroLinearizationPointFinder::getLinearizationPoint(const std::vector<reco::TransientTrack>& tracks) const {
+  return GlobalPoint(0., 0., 0.);
 }


### PR DESCRIPTION

Applying code-format for CMSSW category reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/344//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


