### PR TITLE
Running code-format for reconstruction

### DIFF
--- a/DataFormats/MuonReco/interface/CaloMuon.h
+++ b/DataFormats/MuonReco/interface/CaloMuon.h
@@ -17,35 +17,38 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 
 namespace reco {
- 
+
   class CaloMuon {
   public:
     CaloMuon();
-    virtual ~CaloMuon(){}     
-    
+    virtual ~CaloMuon() {}
+
     /// reference to Track reconstructed in the tracker only
     virtual TrackRef innerTrack() const { return innerTrack_; }
     virtual TrackRef track() const { return innerTrack(); }
     /// set reference to Track
-    virtual void setInnerTrack( const TrackRef & t ) { innerTrack_ = t; }
-    virtual void setTrack( const TrackRef & t ) { setInnerTrack(t); }
+    virtual void setInnerTrack(const TrackRef& t) { innerTrack_ = t; }
+    virtual void setTrack(const TrackRef& t) { setInnerTrack(t); }
     /// energy deposition
     bool isEnergyValid() const { return energyValid_; }
     /// get energy deposition information
     MuonEnergy calEnergy() const { return calEnergy_; }
     /// set energy deposition information
-    void setCalEnergy( const MuonEnergy& calEnergy ) { calEnergy_ = calEnergy; energyValid_ = true; }
-     
+    void setCalEnergy(const MuonEnergy& calEnergy) {
+      calEnergy_ = calEnergy;
+      energyValid_ = true;
+    }
+
     /// Muon hypothesis compatibility block
     /// Relative likelihood based on ECAL, HCAL, HO energy defined as
     /// L_muon/(L_muon+L_not_muon)
     float caloCompatibility() const { return caloCompatibility_; }
-    void  setCaloCompatibility(float input){ caloCompatibility_ = input; }
-    bool  isCaloCompatibilityValid() const { return caloCompatibility_>=0; } 
-     
+    void setCaloCompatibility(float input) { caloCompatibility_ = input; }
+    bool isCaloCompatibilityValid() const { return caloCompatibility_ >= 0; }
+
     /// a bunch of useful accessors
     int charge() const { return innerTrack_.get()->charge(); }
-    /// polar angle  
+    /// polar angle
     double theta() const { return innerTrack_.get()->theta(); }
     /// momentum vector magnitude
     double p() const { return innerTrack_.get()->p(); }
@@ -61,18 +64,17 @@ namespace reco {
     double phi() const { return innerTrack_.get()->phi(); }
     /// pseudorapidity of momentum vector
     double eta() const { return innerTrack_.get()->eta(); }
-     
+
   private:
     /// reference to Track reconstructed in the tracker only
     TrackRef innerTrack_;
-    /// energy deposition 
+    /// energy deposition
     MuonEnergy calEnergy_;
     bool energyValid_;
     /// muon hypothesis compatibility with observer calorimeter energy
     float caloCompatibility_;
   };
 
-}
-
+}  // namespace reco
 
 #endif

--- a/DataFormats/MuonReco/interface/DYTInfo.h
+++ b/DataFormats/MuonReco/interface/DYTInfo.h
@@ -7,7 +7,7 @@
 #include "DataFormats/DetId/interface/DetId.h"
 
 namespace reco {
- 
+
   class DYTInfo {
   public:
     /// Constructor - Destructor
@@ -15,57 +15,58 @@ namespace reco {
     ~DYTInfo();
 
     /// copy from another DYTInfo
-    void CopyFrom(const DYTInfo&);
-    
+    void CopyFrom(const DYTInfo &);
+
     /// number of stations used by DYT
-    const int  NStUsed() const { return NStUsed_; };
-    void setNStUsed( int NStUsed ) { NStUsed_=NStUsed; };
-       
+    const int NStUsed() const { return NStUsed_; };
+    void setNStUsed(int NStUsed) { NStUsed_ = NStUsed; };
+
     /// estimator values for all station
-    const std::vector<double>& DYTEstimators() const { return DYTEstimators_; };
-    void setDYTEstimators( const std::map<int, double> &dytEstMap ) {
+    const std::vector<double> &DYTEstimators() const { return DYTEstimators_; };
+    void setDYTEstimators(const std::map<int, double> &dytEstMap) {
       DYTEstimators_.clear();
       for (int st = 1; st <= 4; st++) {
-	if (dytEstMap.count(st) > 0) DYTEstimators_.push_back(dytEstMap.find(st)->second);
-        else DYTEstimators_.push_back(-1);
+        if (dytEstMap.count(st) > 0)
+          DYTEstimators_.push_back(dytEstMap.find(st)->second);
+        else
+          DYTEstimators_.push_back(-1);
       }
     };
-    void setDYTEstimators( const std::vector<double> &EstValues ) { DYTEstimators_ = EstValues; }
-    
+    void setDYTEstimators(const std::vector<double> &EstValues) { DYTEstimators_ = EstValues; }
+
     /// number of segments tested per muon station
-    const std::vector<bool>& UsedStations() const { return UsedStations_; };
-    void setUsedStations( const std::map<int, bool> &ustMap ) {
+    const std::vector<bool> &UsedStations() const { return UsedStations_; };
+    void setUsedStations(const std::map<int, bool> &ustMap) {
       UsedStations_.clear();
-      for (int st = 1; st <= 4; st++) 
+      for (int st = 1; st <= 4; st++)
         UsedStations_.push_back(ustMap.find(st)->second);
     };
-    void setUsedStations( const std::vector<bool> ustVal ) { UsedStations_ = ustVal; };
+    void setUsedStations(const std::vector<bool> ustVal) { UsedStations_ = ustVal; };
 
     /// DetId vector of chamber with valid estimator
-    const std::vector<DetId>& IdChambers() const { return IdChambers_; };
-    void setIdChambers( const std::map<int, DetId> &IdChambersMap ) {
+    const std::vector<DetId> &IdChambers() const { return IdChambers_; };
+    void setIdChambers(const std::map<int, DetId> &IdChambersMap) {
       IdChambers_.clear();
       for (int st = 1; st <= 4; st++)
         IdChambers_.push_back(IdChambersMap.find(st)->second);
     };
-    void setIdChambers( const std::vector<DetId> &IdChambersVal ) { IdChambers_ = IdChambersVal; };
-    
-    /// vector of thresholds  
-    const std::vector<double>& Thresholds() const { return Thresholds_; };
-    void setThresholds( const std::map<int, double> &ThresholdsMap ) {
+    void setIdChambers(const std::vector<DetId> &IdChambersVal) { IdChambers_ = IdChambersVal; };
+
+    /// vector of thresholds
+    const std::vector<double> &Thresholds() const { return Thresholds_; };
+    void setThresholds(const std::map<int, double> &ThresholdsMap) {
       Thresholds_.clear();
       for (int st = 1; st <= 4; st++)
-	Thresholds_.push_back(ThresholdsMap.find(st)->second);
+        Thresholds_.push_back(ThresholdsMap.find(st)->second);
     };
-    void setThresholds( const std::vector<double> &ThresholdsVal ) { Thresholds_ = ThresholdsVal; };
-    
+    void setThresholds(const std::vector<double> &ThresholdsVal) { Thresholds_ = ThresholdsVal; };
+
   private:
-    
-    int  NStUsed_;
+    int NStUsed_;
     std::vector<bool> UsedStations_;
     std::vector<double> DYTEstimators_;
     std::vector<DetId> IdChambers_;
     std::vector<double> Thresholds_;
   };
-}
+}  // namespace reco
 #endif

--- a/DataFormats/MuonReco/interface/EmulatedME0Segment.h
+++ b/DataFormats/MuonReco/interface/EmulatedME0Segment.h
@@ -15,62 +15,62 @@
 #include <iosfwd>
 
 class EmulatedME0Segment : public RecSegment {
-
 public:
+  /// Default constructor
+  EmulatedME0Segment() : theOrigin(0, 0, 0), theLocalDirection(0, 0, 0), theCovMatrix(4, 0), theChi2(0.) {}
 
-    /// Default constructor
- EmulatedME0Segment() : theOrigin(0,0,0), theLocalDirection(0,0,0), theCovMatrix(4,0),theChi2(0.) {}
-	
-    /// Constructor
-    EmulatedME0Segment(const LocalPoint& origin, const LocalVector& direction, const AlgebraicSymMatrix& errors, const double chi2);
-  
-    /// Destructor
-    ~EmulatedME0Segment() override;
+  /// Constructor
+  EmulatedME0Segment(const LocalPoint& origin,
+                     const LocalVector& direction,
+                     const AlgebraicSymMatrix& errors,
+                     const double chi2);
 
-    //--- Base class interface
-    EmulatedME0Segment* clone() const override { return new EmulatedME0Segment(*this); }
+  /// Destructor
+  ~EmulatedME0Segment() override;
 
-    LocalPoint localPosition() const override { return theOrigin; }
-    LocalError localPositionError() const override ;
-	
-    LocalVector localDirection() const override { return theLocalDirection; }
-    LocalError localDirectionError() const override ;
+  //--- Base class interface
+  EmulatedME0Segment* clone() const override { return new EmulatedME0Segment(*this); }
 
-    /// Parameters of the segment, for the track fit in the order (dx/dz, dy/dz, x, y )
-    AlgebraicVector parameters() const override;
+  LocalPoint localPosition() const override { return theOrigin; }
+  LocalError localPositionError() const override;
 
-    /// Covariance matrix of parameters()
-    AlgebraicSymMatrix parametersError() const override { return theCovMatrix; }
+  LocalVector localDirection() const override { return theLocalDirection; }
+  LocalError localDirectionError() const override;
 
-    /// The projection matrix relates the trajectory state parameters to the segment parameters(). 
-    AlgebraicMatrix projectionMatrix() const override;
+  /// Parameters of the segment, for the track fit in the order (dx/dz, dy/dz, x, y )
+  AlgebraicVector parameters() const override;
 
-    std::vector<const TrackingRecHit*> recHits() const override {return std::vector<const TrackingRecHit*> (); }
+  /// Covariance matrix of parameters()
+  AlgebraicSymMatrix parametersError() const override { return theCovMatrix; }
 
-    std::vector<TrackingRecHit*> recHits() override {return std::vector<TrackingRecHit*>();}
+  /// The projection matrix relates the trajectory state parameters to the segment parameters().
+  AlgebraicMatrix projectionMatrix() const override;
 
-    double chi2() const override { return theChi2; }
+  std::vector<const TrackingRecHit*> recHits() const override { return std::vector<const TrackingRecHit*>(); }
 
-    int dimension() const override { return 4; }
+  std::vector<TrackingRecHit*> recHits() override { return std::vector<TrackingRecHit*>(); }
 
-    int degreesOfFreedom() const override { return -1;}	 //Maybe  change later?
+  double chi2() const override { return theChi2; }
 
-    //--- Extension of the interface
-        
-    int nRecHits() const { return 0;}  //theME0RecHits.size(); }        
+  int dimension() const override { return 4; }
 
-    void print() const;		
-    
- private:
-    
-    //std::vector<ME0RecHit2D> theME0RecHits;
-    //  CAVEAT: these "Local" paramaters will in fact be filled by global coordinates
-    LocalPoint theOrigin;   // in chamber frame - the GeomDet local coordinate system
-    LocalVector theLocalDirection; // in chamber frame - the GeomDet local coordinate system
-    AlgebraicSymMatrix theCovMatrix; // the covariance matrix
-    double theChi2;
+  int degreesOfFreedom() const override { return -1; }  //Maybe  change later?
+
+  //--- Extension of the interface
+
+  int nRecHits() const { return 0; }  //theME0RecHits.size(); }
+
+  void print() const;
+
+private:
+  //std::vector<ME0RecHit2D> theME0RecHits;
+  //  CAVEAT: these "Local" paramaters will in fact be filled by global coordinates
+  LocalPoint theOrigin;             // in chamber frame - the GeomDet local coordinate system
+  LocalVector theLocalDirection;    // in chamber frame - the GeomDet local coordinate system
+  AlgebraicSymMatrix theCovMatrix;  // the covariance matrix
+  double theChi2;
 };
 
 std::ostream& operator<<(std::ostream& os, const EmulatedME0Segment& seg);
 
-#endif // ME0RecHit_EmulatedME0Segment_h
+#endif  // ME0RecHit_EmulatedME0Segment_h

--- a/DataFormats/MuonReco/interface/EmulatedME0SegmentCollection.h
+++ b/DataFormats/MuonReco/interface/EmulatedME0SegmentCollection.h
@@ -19,5 +19,3 @@ typedef std::vector<EmulatedME0Segment> EmulatedME0SegmentCollection;
 typedef edm::Ref<EmulatedME0SegmentCollection> EmulatedME0SegmentRef;
 
 #endif
-
-

--- a/DataFormats/MuonReco/interface/ME0Muon.h
+++ b/DataFormats/MuonReco/interface/ME0Muon.h
@@ -17,30 +17,34 @@
 #include "DataFormats/RecoCandidate/interface/RecoCandidate.h"
 
 namespace reco {
- 
-  class ME0Muon : public RecoCandidate{
+
+  class ME0Muon : public RecoCandidate {
   public:
     ME0Muon();
     //ME0Muon( const TrackRef & t, const ME0Segment & s) { innerTrack_ = t; me0Segment_ = s;}
-    ME0Muon( const TrackRef & t, const ME0Segment & s, const int v, const double c) { innerTrack_ = t; me0Segment_ = s; me0segid_=v; trackCharge_ = c;}
-    ~ME0Muon() override{}     
-    
+    ME0Muon(const TrackRef& t, const ME0Segment& s, const int v, const double c) {
+      innerTrack_ = t;
+      me0Segment_ = s;
+      me0segid_ = v;
+      trackCharge_ = c;
+    }
+    ~ME0Muon() override {}
+
     /// reference to Track reconstructed in the tracker only
     TrackRef innerTrack() const { return innerTrack_; }
     TrackRef track() const override { return innerTrack(); }
     /// set reference to Track
-    void setInnerTrack( const TrackRef & t ) { innerTrack_ = t; }
-    void setTrack( const TrackRef & t ) { setInnerTrack(t); }
+    void setInnerTrack(const TrackRef& t) { innerTrack_ = t; }
+    void setTrack(const TrackRef& t) { setInnerTrack(t); }
     /// set reference to our new ME0Segment type
-    void setME0Segment( const ME0Segment & s ) { me0Segment_ = s; }
+    void setME0Segment(const ME0Segment& s) { me0Segment_ = s; }
 
     const ME0Segment& me0segment() const { return me0Segment_; }
-    
-    //Added for testing
-    void setme0segid( const int v){me0segid_=v;}
-    int me0segid() const {return me0segid_;}
 
-    
+    //Added for testing
+    void setme0segid(const int v) { me0segid_ = v; }
+    int me0segid() const { return me0segid_; }
+
     const GlobalPoint& globalTrackPosAtSurface() const { return globalTrackPosAtSurface_; }
     const GlobalVector& globalTrackMomAtSurface() const { return globalTrackMomAtSurface_; }
     const LocalPoint& localTrackPosAtSurface() const { return localTrackPosAtSurface_; }
@@ -50,17 +54,25 @@ namespace reco {
     const AlgebraicSymMatrix66& globalTrackCov() const { return globalTrackCov_; }
     const AlgebraicSymMatrix55& localTrackCov() const { return localTrackCov_; }
 
-    void setGlobalTrackPosAtSurface(const GlobalPoint& globalTrackPosAtSurface) { globalTrackPosAtSurface_ = globalTrackPosAtSurface; }
-    void setGlobalTrackMomAtSurface(const GlobalVector& globalTrackMomAtSurface) { globalTrackMomAtSurface_ = globalTrackMomAtSurface; }
-    void setLocalTrackPosAtSurface(const LocalPoint& localTrackPosAtSurface) { localTrackPosAtSurface_ = localTrackPosAtSurface; }
-    void setLocalTrackMomAtSurface(const LocalVector& localTrackMomAtSurface) { localTrackMomAtSurface_ = localTrackMomAtSurface; }
+    void setGlobalTrackPosAtSurface(const GlobalPoint& globalTrackPosAtSurface) {
+      globalTrackPosAtSurface_ = globalTrackPosAtSurface;
+    }
+    void setGlobalTrackMomAtSurface(const GlobalVector& globalTrackMomAtSurface) {
+      globalTrackMomAtSurface_ = globalTrackMomAtSurface;
+    }
+    void setLocalTrackPosAtSurface(const LocalPoint& localTrackPosAtSurface) {
+      localTrackPosAtSurface_ = localTrackPosAtSurface;
+    }
+    void setLocalTrackMomAtSurface(const LocalVector& localTrackMomAtSurface) {
+      localTrackMomAtSurface_ = localTrackMomAtSurface;
+    }
     void setTrackCharge(const int& trackCharge) { trackCharge_ = trackCharge; }
     void setGlobalTrackCov(const AlgebraicSymMatrix66& trackCov) { globalTrackCov_ = trackCov; }
     void setLocalTrackCov(const AlgebraicSymMatrix55& trackCov) { localTrackCov_ = trackCov; }
-     
+
   private:
     /// check overlap with another candidate
-    bool overlap( const Candidate & ) const override;
+    bool overlap(const Candidate&) const override;
 
     /// reference to Track reconstructed in the tracker only
     TrackRef innerTrack_;
@@ -79,9 +91,6 @@ namespace reco {
     //double xpull_,ypull_,xdiff_,ydiff_,phidirdiff_;
   };
 
-}
-
+}  // namespace reco
 
 #endif
-
-

--- a/DataFormats/MuonReco/interface/ME0MuonCollection.h
+++ b/DataFormats/MuonReco/interface/ME0MuonCollection.h
@@ -18,5 +18,4 @@ typedef std::vector<reco::ME0Muon> ME0MuonCollection;
 /// persistent reference to a ME0Muon
 typedef edm::Ref<ME0MuonCollection> ME0MuonRef;
 
-	
 #endif

--- a/DataFormats/MuonReco/interface/Muon.h
+++ b/DataFormats/MuonReco/interface/Muon.h
@@ -23,22 +23,19 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 
 namespace reco {
- 
+
   class Muon : public RecoCandidate {
   public:
     Muon();
     /// constructor from values
-    Muon(  Charge, const LorentzVector &, const Point & = Point( 0, 0, 0 ) );
+    Muon(Charge, const LorentzVector&, const Point& = Point(0, 0, 0));
     /// create a clone
-    Muon * clone() const override;
+    Muon* clone() const override;
 
-    
-    
     /// map for Global Muon refitters
-    enum MuonTrackType {None, InnerTrack, OuterTrack, CombinedTrack, TPFMS, Picky, DYT};
+    enum MuonTrackType { None, InnerTrack, OuterTrack, CombinedTrack, TPFMS, Picky, DYT };
     typedef std::map<MuonTrackType, reco::TrackRef> MuonTrackRefMap;
     typedef std::pair<TrackRef, Muon::MuonTrackType> MuonTrackTypePair;
-
 
     ///
     /// ====================== TRACK BLOCK ===========================
@@ -54,43 +51,41 @@ namespace reco {
     virtual TrackRef globalTrack() const { return globalTrack_; }
     TrackRef combinedMuon() const override { return globalTrack(); }
 
-    virtual TrackRef tpfmsTrack() const { return muonTrackFromMap(TPFMS);}
-    virtual TrackRef pickyTrack() const { return muonTrackFromMap(Picky);}
-    virtual TrackRef dytTrack()   const { return muonTrackFromMap(DYT);}
-    
-    const Track * bestTrack() const override         {return muonTrack(bestTrackType_).get();}
-    TrackBaseRef  bestTrackRef() const override      {return reco::TrackBaseRef(muonTrack(bestTrackType_));}
-    virtual TrackRef      muonBestTrack() const     {return muonTrack(bestTrackType_);}
-    virtual MuonTrackType muonBestTrackType() const {return bestTrackType_;}
-    virtual TrackRef      tunePMuonBestTrack() const     {return muonTrack(bestTunePTrackType_);}
-    virtual MuonTrackType tunePMuonBestTrackType() const {return bestTunePTrackType_;}
+    virtual TrackRef tpfmsTrack() const { return muonTrackFromMap(TPFMS); }
+    virtual TrackRef pickyTrack() const { return muonTrackFromMap(Picky); }
+    virtual TrackRef dytTrack() const { return muonTrackFromMap(DYT); }
 
-
+    const Track* bestTrack() const override { return muonTrack(bestTrackType_).get(); }
+    TrackBaseRef bestTrackRef() const override { return reco::TrackBaseRef(muonTrack(bestTrackType_)); }
+    virtual TrackRef muonBestTrack() const { return muonTrack(bestTrackType_); }
+    virtual MuonTrackType muonBestTrackType() const { return bestTrackType_; }
+    virtual TrackRef tunePMuonBestTrack() const { return muonTrack(bestTunePTrackType_); }
+    virtual MuonTrackType tunePMuonBestTrackType() const { return bestTunePTrackType_; }
 
     bool isAValidMuonTrack(const MuonTrackType& type) const;
     TrackRef muonTrack(const MuonTrackType&) const;
 
     TrackRef muonTrackFromMap(const MuonTrackType& type) const {
       MuonTrackRefMap::const_iterator iter = refittedTrackMap_.find(type);
-      if (iter != refittedTrackMap_.end()) 
-	return iter->second;
-      else 
-	return TrackRef();
+      if (iter != refittedTrackMap_.end())
+        return iter->second;
+      else
+        return TrackRef();
     }
 
     /// set reference to Track
-    virtual void setInnerTrack( const TrackRef & t );
-    virtual void setTrack( const TrackRef & t );
+    virtual void setInnerTrack(const TrackRef& t);
+    virtual void setTrack(const TrackRef& t);
     /// set reference to Track
-    virtual void setOuterTrack( const TrackRef & t );
-    virtual void setStandAlone( const TrackRef & t );
+    virtual void setOuterTrack(const TrackRef& t);
+    virtual void setStandAlone(const TrackRef& t);
     /// set reference to Track
-    virtual void setGlobalTrack( const TrackRef & t );
-    virtual void setCombined( const TrackRef & t );
+    virtual void setGlobalTrack(const TrackRef& t);
+    virtual void setCombined(const TrackRef& t);
     // set reference to the Best Track
-    virtual void setBestTrack(MuonTrackType muonType) {bestTrackType_ = muonType;}
+    virtual void setBestTrack(MuonTrackType muonType) { bestTrackType_ = muonType; }
     // set reference to the Best Track by PF
-    virtual void setTunePBestTrack(MuonTrackType muonType) {bestTunePTrackType_ = muonType;}
+    virtual void setTunePBestTrack(MuonTrackType muonType) { bestTunePTrackType_ = muonType; }
 
     void setMuonTrack(const MuonTrackType&, const TrackRef&);
 
@@ -99,8 +94,8 @@ namespace reco {
     /// ====================== PF BLOCK ===========================
     ///
 
-    reco::Candidate::LorentzVector  pfP4() const  {return pfP4_;}
-    virtual void setPFP4( const reco::Candidate::LorentzVector& p4_ ); 
+    reco::Candidate::LorentzVector pfP4() const { return pfP4_; }
+    virtual void setPFP4(const reco::Candidate::LorentzVector& p4_);
 
     ///
     /// ====================== ENERGY BLOCK ===========================
@@ -110,8 +105,11 @@ namespace reco {
     /// get energy deposition information
     MuonEnergy calEnergy() const { return calEnergy_; }
     /// set energy deposition information
-    void setCalEnergy( const MuonEnergy& calEnergy ) { calEnergy_ = calEnergy; energyValid_ = true; }
-    
+    void setCalEnergy(const MuonEnergy& calEnergy) {
+      calEnergy_ = calEnergy;
+      energyValid_ = true;
+    }
+
     ///
     /// ====================== Quality BLOCK ===========================
     ///
@@ -120,45 +118,51 @@ namespace reco {
     /// get energy deposition information
     MuonQuality combinedQuality() const { return combinedQuality_; }
     /// set energy deposition information
-    void setCombinedQuality( const MuonQuality& combinedQuality ) { combinedQuality_ = combinedQuality; qualityValid_ = true; }
+    void setCombinedQuality(const MuonQuality& combinedQuality) {
+      combinedQuality_ = combinedQuality;
+      qualityValid_ = true;
+    }
 
     ///
     /// ====================== TIMING BLOCK ===========================
     ///
     /// timing information
-    bool isTimeValid() const { return (time_.nDof>0); }
+    bool isTimeValid() const { return (time_.nDof > 0); }
     /// get DT/CSC combined timing information
     MuonTime time() const { return time_; }
     /// set DT/CSC combined timing information
-    void setTime( const MuonTime& time ) { time_ = time; }
+    void setTime(const MuonTime& time) { time_ = time; }
     /// get RPC timing information
     MuonTime rpcTime() const { return rpcTime_; }
     /// set RPC timing information
-    void setRPCTime( const MuonTime& time ) { rpcTime_ = time; }
-     
+    void setRPCTime(const MuonTime& time) { rpcTime_ = time; }
+
     ///
     /// ====================== MUON MATCH BLOCK ===========================
     ///
     bool isMatchesValid() const { return matchesValid_; }
     /// get muon matching information
-    std::vector<MuonChamberMatch>& matches() { return muMatches_;}
-    const std::vector<MuonChamberMatch>& matches() const { return muMatches_;	}
+    std::vector<MuonChamberMatch>& matches() { return muMatches_; }
+    const std::vector<MuonChamberMatch>& matches() const { return muMatches_; }
     /// set muon matching information
-    void setMatches( const std::vector<MuonChamberMatch>& matches ) { muMatches_ = matches; matchesValid_ = true; }
-     
+    void setMatches(const std::vector<MuonChamberMatch>& matches) {
+      muMatches_ = matches;
+      matchesValid_ = true;
+    }
+
     ///
     /// ====================== MUON COMPATIBILITY BLOCK ===========================
     ///
     /// Relative likelihood based on ECAL, HCAL, HO energy defined as
     /// L_muon/(L_muon+L_not_muon)
     float caloCompatibility() const { return caloCompatibility_; }
-    void  setCaloCompatibility(float input){ caloCompatibility_ = input; }
-    bool  isCaloCompatibilityValid() const { return caloCompatibility_>=0; } 
-    
+    void setCaloCompatibility(float input) { caloCompatibility_ = input; }
+    bool isCaloCompatibilityValid() const { return caloCompatibility_ >= 0; }
+
     ///
     /// ====================== ISOLATION BLOCK ===========================
     ///
-    /// Summary of muon isolation information 
+    /// Summary of muon isolation information
     const MuonIsolation& isolationR03() const { return isolationR03_; }
     const MuonIsolation& isolationR05() const { return isolationR05_; }
 
@@ -169,72 +173,76 @@ namespace reco {
     const MuonPFIsolation& pfMeanDRIsoProfileR04() const { return pfIsoMeanDRR04_; }
     const MuonPFIsolation& pfSumDRIsoProfileR04() const { return pfIsoSumDRR04_; }
 
-
-    void setIsolation( const MuonIsolation& isoR03, const MuonIsolation& isoR05 );
+    void setIsolation(const MuonIsolation& isoR03, const MuonIsolation& isoR05);
     bool isIsolationValid() const { return isolationValid_; }
-    void setPFIsolation(const std::string& label,const reco::MuonPFIsolation& deposit);
-
+    void setPFIsolation(const std::string& label, const reco::MuonPFIsolation& deposit);
 
     bool isPFIsolationValid() const { return pfIsolationValid_; }
 
-
     /// define arbitration schemes
-    // WARNING: There can be not more than 7 arbritration types. If 
+    // WARNING: There can be not more than 7 arbritration types. If
     //          have more it will break the matching logic for types
     //          defined in MuonSegmentMatch
 
-    enum ArbitrationType { NoArbitration, SegmentArbitration, SegmentAndTrackArbitration, SegmentAndTrackArbitrationCleaned,
-			   RPCHitAndTrackArbitration, GEMSegmentAndTrackArbitration, ME0SegmentAndTrackArbitration };
+    enum ArbitrationType {
+      NoArbitration,
+      SegmentArbitration,
+      SegmentAndTrackArbitration,
+      SegmentAndTrackArbitrationCleaned,
+      RPCHitAndTrackArbitration,
+      GEMSegmentAndTrackArbitration,
+      ME0SegmentAndTrackArbitration
+    };
 
     ///
     /// ====================== STANDARD SELECTORS ===========================
     ///
     enum Selector {
-      CutBasedIdLoose        = 1UL<< 0,  
-      CutBasedIdMedium       = 1UL<< 1,  
-      CutBasedIdMediumPrompt = 1UL<< 2,  // medium with IP cuts
-      CutBasedIdTight        = 1UL<< 3,  
-      CutBasedIdGlobalHighPt = 1UL<< 4,  // high pt muon for Z',W' (better momentum resolution)
-      CutBasedIdTrkHighPt    = 1UL<< 5,  // high pt muon for boosted Z (better efficiency)
-      PFIsoVeryLoose         = 1UL<< 6,  // reliso<0.40
-      PFIsoLoose             = 1UL<< 7,  // reliso<0.25
-      PFIsoMedium            = 1UL<< 8,  // reliso<0.20
-      PFIsoTight             = 1UL<< 9,  // reliso<0.15
-      PFIsoVeryTight         = 1UL<<10,  // reliso<0.10
-      TkIsoLoose             = 1UL<<11,  // reliso<0.10
-      TkIsoTight             = 1UL<<12,  // reliso<0.05
-      SoftCutBasedId         = 1UL<<13,  
-      SoftMvaId              = 1UL<<14,  
-      MvaLoose               = 1UL<<15,  
-      MvaMedium              = 1UL<<16,  
-      MvaTight               = 1UL<<17,
-      MiniIsoLoose           = 1UL<<18,  // reliso<0.40
-      MiniIsoMedium          = 1UL<<19,  // reliso<0.20
-      MiniIsoTight           = 1UL<<20,  // reliso<0.10
-      MiniIsoVeryTight       = 1UL<<21,  // reliso<0.05
-      TriggerIdLoose         = 1UL<<22,  // robust selector for HLT
-      InTimeMuon             = 1UL<<23,   
-      PFIsoVeryVeryTight     = 1UL<<24,  // reliso<0.05
-      MultiIsoLoose          = 1UL<<25,  // miniIso with ptRatio and ptRel 
-      MultiIsoMedium         = 1UL<<26,   // miniIso with ptRatio and ptRel 
-      PuppiIsoLoose          = 1UL<<27,
-      PuppiIsoMedium         = 1UL<<28,
-      PuppiIsoTight          = 1UL<<29, 
-      MvaVTight              = 1UL<<30,
-      MvaVVTight             = 1UL<<31,
-      LowPtMvaLoose          = 1UL<<32,
-      LowPtMvaMedium         = 1UL<<33,
+      CutBasedIdLoose = 1UL << 0,
+      CutBasedIdMedium = 1UL << 1,
+      CutBasedIdMediumPrompt = 1UL << 2,  // medium with IP cuts
+      CutBasedIdTight = 1UL << 3,
+      CutBasedIdGlobalHighPt = 1UL << 4,  // high pt muon for Z',W' (better momentum resolution)
+      CutBasedIdTrkHighPt = 1UL << 5,     // high pt muon for boosted Z (better efficiency)
+      PFIsoVeryLoose = 1UL << 6,          // reliso<0.40
+      PFIsoLoose = 1UL << 7,              // reliso<0.25
+      PFIsoMedium = 1UL << 8,             // reliso<0.20
+      PFIsoTight = 1UL << 9,              // reliso<0.15
+      PFIsoVeryTight = 1UL << 10,         // reliso<0.10
+      TkIsoLoose = 1UL << 11,             // reliso<0.10
+      TkIsoTight = 1UL << 12,             // reliso<0.05
+      SoftCutBasedId = 1UL << 13,
+      SoftMvaId = 1UL << 14,
+      MvaLoose = 1UL << 15,
+      MvaMedium = 1UL << 16,
+      MvaTight = 1UL << 17,
+      MiniIsoLoose = 1UL << 18,      // reliso<0.40
+      MiniIsoMedium = 1UL << 19,     // reliso<0.20
+      MiniIsoTight = 1UL << 20,      // reliso<0.10
+      MiniIsoVeryTight = 1UL << 21,  // reliso<0.05
+      TriggerIdLoose = 1UL << 22,    // robust selector for HLT
+      InTimeMuon = 1UL << 23,
+      PFIsoVeryVeryTight = 1UL << 24,  // reliso<0.05
+      MultiIsoLoose = 1UL << 25,       // miniIso with ptRatio and ptRel
+      MultiIsoMedium = 1UL << 26,      // miniIso with ptRatio and ptRel
+      PuppiIsoLoose = 1UL << 27,
+      PuppiIsoMedium = 1UL << 28,
+      PuppiIsoTight = 1UL << 29,
+      MvaVTight = 1UL << 30,
+      MvaVVTight = 1UL << 31,
+      LowPtMvaLoose = 1UL << 32,
+      LowPtMvaMedium = 1UL << 33,
     };
-    
-    bool passed( uint64_t selection ) const { return (selectors_ & selection)==selection; }
-    bool passed( Selector selection ) const { return passed(static_cast<unsigned int>(selection)); }
+
+    bool passed(uint64_t selection) const { return (selectors_ & selection) == selection; }
+    bool passed(Selector selection) const { return passed(static_cast<unsigned int>(selection)); }
     uint64_t selectors() const { return selectors_; }
-    void setSelectors( uint64_t selectors ){ selectors_ = selectors; }
-    void setSelector(Selector selector, bool passed){ 
+    void setSelectors(uint64_t selectors) { selectors_ = selectors; }
+    void setSelector(Selector selector, bool passed) {
       if (passed)
-	selectors_ |= selector;
+        selectors_ |= selector;
       else
-	selectors_ &= ~selector;
+        selectors_ &= ~selector;
     }
 
     ///
@@ -245,61 +253,60 @@ namespace reco {
     /// number of chambers CSC or DT matches only (MuonChamberMatches include RPC rolls)
     int numberOfChambersCSCorDT() const;
     /// get number of chambers with matched segments
-    int numberOfMatches( ArbitrationType type = SegmentAndTrackArbitration ) const;
+    int numberOfMatches(ArbitrationType type = SegmentAndTrackArbitration) const;
     /// get number of stations with matched segments
     /// just adds the bits returned by stationMask
-    int numberOfMatchedStations( ArbitrationType type = SegmentAndTrackArbitration ) const;
-    /// expected number of stations with matching segments based on the absolute 
+    int numberOfMatchedStations(ArbitrationType type = SegmentAndTrackArbitration) const;
+    /// expected number of stations with matching segments based on the absolute
     /// distance from the edge of a chamber
-    unsigned int expectedNnumberOfMatchedStations( float minDistanceFromEdge = 10.0 ) const;
+    unsigned int expectedNnumberOfMatchedStations(float minDistanceFromEdge = 10.0) const;
     /// get bit map of stations with matched segments
     /// bits 0-1-2-3 = DT stations 1-2-3-4
     /// bits 4-5-6-7 = CSC stations 1-2-3-4
-    unsigned int stationMask( ArbitrationType type = SegmentAndTrackArbitration ) const;
+    unsigned int stationMask(ArbitrationType type = SegmentAndTrackArbitration) const;
     /// get bit map of stations with tracks within
-    /// given distance (in cm) of chamber edges 
+    /// given distance (in cm) of chamber edges
     /// bit assignments are same as above
-    int numberOfMatchedRPCLayers( ArbitrationType type = RPCHitAndTrackArbitration ) const;
-    unsigned int RPClayerMask( ArbitrationType type = RPCHitAndTrackArbitration ) const;
-    unsigned int stationGapMaskDistance( float distanceCut = 10. ) const;
+    int numberOfMatchedRPCLayers(ArbitrationType type = RPCHitAndTrackArbitration) const;
+    unsigned int RPClayerMask(ArbitrationType type = RPCHitAndTrackArbitration) const;
+    unsigned int stationGapMaskDistance(float distanceCut = 10.) const;
     /// same as above for given number of sigmas
-    unsigned int stationGapMaskPull( float sigmaCut = 3. ) const;
+    unsigned int stationGapMaskPull(float sigmaCut = 3.) const;
     /// # of digis in a given station layer
-    int nDigisInStation( int station, int muonSubdetId) const;
+    int nDigisInStation(int station, int muonSubdetId) const;
     /// tag a shower in a given station layer
-    bool hasShowerInStation( int station, int muonSubdetId, int nDtDigisCut = 20, int nCscDigisCut = 36 ) const;
+    bool hasShowerInStation(int station, int muonSubdetId, int nDtDigisCut = 20, int nCscDigisCut = 36) const;
     /// count the number of showers along a muon track
-    int numberOfShowers( int nDtDigisCut = 20, int nCscDigisCut = 36 ) const;
+    int numberOfShowers(int nDtDigisCut = 20, int nCscDigisCut = 36) const;
 
     /// muon type - type of the algorithm that reconstructed this muon
     /// multiple algorithms can reconstruct the same muon
-    static const unsigned int GlobalMuon     =  1<<1;
-    static const unsigned int TrackerMuon    =  1<<2;
-    static const unsigned int StandAloneMuon =  1<<3;
-    static const unsigned int CaloMuon =  1<<4;
-    static const unsigned int PFMuon =  1<<5;
-    static const unsigned int RPCMuon =  1<<6;
-    static const unsigned int GEMMuon =  1<<7;
-    static const unsigned int ME0Muon =  1<<8;
+    static const unsigned int GlobalMuon = 1 << 1;
+    static const unsigned int TrackerMuon = 1 << 2;
+    static const unsigned int StandAloneMuon = 1 << 3;
+    static const unsigned int CaloMuon = 1 << 4;
+    static const unsigned int PFMuon = 1 << 5;
+    static const unsigned int RPCMuon = 1 << 6;
+    static const unsigned int GEMMuon = 1 << 7;
+    static const unsigned int ME0Muon = 1 << 8;
 
-    void setType( unsigned int type ) { type_ = type; } 
-    unsigned int type() const { return type_; } 
+    void setType(unsigned int type) { type_ = type; }
+    unsigned int type() const { return type_; }
 
-   
     // override of method in base class reco::Candidate
     bool isMuon() const override { return true; }
-    bool isGlobalMuon()     const override { return type_ & GlobalMuon; }
-    bool isTrackerMuon()    const override { return type_ & TrackerMuon; }
+    bool isGlobalMuon() const override { return type_ & GlobalMuon; }
+    bool isTrackerMuon() const override { return type_ & TrackerMuon; }
     bool isStandAloneMuon() const override { return type_ & StandAloneMuon; }
     bool isCaloMuon() const override { return type_ & CaloMuon; }
-    bool isPFMuon() const {return type_ & PFMuon;} //fix me ! Has to go to type
-    bool isRPCMuon() const {return type_ & RPCMuon;}
-    bool isGEMMuon() const {return type_ & GEMMuon;}
-    bool isME0Muon() const {return type_ & ME0Muon;}
-    
+    bool isPFMuon() const { return type_ & PFMuon; }  //fix me ! Has to go to type
+    bool isRPCMuon() const { return type_ & RPCMuon; }
+    bool isGEMMuon() const { return type_ & GEMMuon; }
+    bool isME0Muon() const { return type_ & ME0Muon; }
+
   private:
     /// check overlap with another candidate
-    bool overlap( const Candidate & ) const override;
+    bool overlap(const Candidate&) const override;
     /// reference to Track reconstructed in the tracker only
     TrackRef innerTrack_;
     /// reference to Track reconstructed in the muon detector only
@@ -308,12 +315,12 @@ namespace reco {
     TrackRef globalTrack_;
     /// reference to the Global Track refitted with dedicated TeV reconstructors
     MuonTrackRefMap refittedTrackMap_;
-    /// reference to the Track chosen to assign the momentum value to the muon 
+    /// reference to the Track chosen to assign the momentum value to the muon
     MuonTrackType bestTrackType_;
-    /// reference to the Track chosen to assign the momentum value to the muon by PF 
+    /// reference to the Track chosen to assign the momentum value to the muon by PF
     MuonTrackType bestTunePTrackType_;
 
-    /// energy deposition 
+    /// energy deposition
     MuonEnergy calEnergy_;
     /// quality block
     MuonQuality combinedQuality_;
@@ -343,74 +350,87 @@ namespace reco {
 
     /// muon type mask
     unsigned int type_;
-    
+
     //PF muon p4
     reco::Candidate::LorentzVector pfP4_;
 
     // FixMe: Still missing trigger information
 
     /// get vector of muon chambers for given station and detector
-    const std::vector<const MuonChamberMatch*> chambers( int station, int muonSubdetId ) const;
+    const std::vector<const MuonChamberMatch*> chambers(int station, int muonSubdetId) const;
     /// get pointers to best segment and corresponding chamber in vector of chambers
-    std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> pair( const std::vector<const MuonChamberMatch*> &,
-								     ArbitrationType type = SegmentAndTrackArbitration ) const;
+    std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> pair(
+        const std::vector<const MuonChamberMatch*>&, ArbitrationType type = SegmentAndTrackArbitration) const;
     /// selector bitmap
     uint64_t selectors_;
-   public:
-     /// get number of segments
-    int numberOfSegments( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     /// get deltas between (best) segment and track
-     /// If no chamber or no segment returns 999999
-     float dX       ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float dY       ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float dDxDz    ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float dDyDz    ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float pullX    ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration, bool includeSegmentError = true ) const;
-     float pullY    ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration, bool includeSegmentError = true ) const;
-     float pullDxDz ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration, bool includeSegmentError = true ) const;
-     float pullDyDz ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration, bool includeSegmentError = true ) const;
-     /// get (best) segment information
-     /// If no segment returns 999999
-     float segmentX       ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float segmentY       ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float segmentDxDz    ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float segmentDyDz    ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float segmentXErr    ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float segmentYErr    ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float segmentDxDzErr ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float segmentDyDzErr ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     /// get track information in chamber that contains (best) segment
-     /// If no segment, get track information in chamber that has the most negative distance between the track
-     /// and the nearest chamber edge (the chamber with the deepest track)
-     /// If no chamber returns 999999
-     float trackEdgeX   ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float trackEdgeY   ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float trackX       ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float trackY       ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float trackDxDz    ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float trackDyDz    ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float trackXErr    ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float trackYErr    ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float trackDxDzErr ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float trackDyDzErr ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float trackDist    ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     float trackDistErr ( int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration ) const;
-     
-     float t0(int n=0) {
-	int i = 0;
-	for( std::vector<MuonChamberMatch>::const_iterator chamber = muMatches_.begin();
-	     chamber != muMatches_.end(); ++chamber )
-	  for ( std::vector<reco::MuonSegmentMatch>::const_iterator segment = chamber->segmentMatches.begin();
-		segment != chamber->segmentMatches.end(); ++segment )
-	    {
-	       if (i==n) return segment->t0;
-	       ++i;
-	    }
-	return 0;
-     }
+
+  public:
+    /// get number of segments
+    int numberOfSegments(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    /// get deltas between (best) segment and track
+    /// If no chamber or no segment returns 999999
+    float dX(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float dY(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float dDxDz(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float dDyDz(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float pullX(int station,
+                int muonSubdetId,
+                ArbitrationType type = SegmentAndTrackArbitration,
+                bool includeSegmentError = true) const;
+    float pullY(int station,
+                int muonSubdetId,
+                ArbitrationType type = SegmentAndTrackArbitration,
+                bool includeSegmentError = true) const;
+    float pullDxDz(int station,
+                   int muonSubdetId,
+                   ArbitrationType type = SegmentAndTrackArbitration,
+                   bool includeSegmentError = true) const;
+    float pullDyDz(int station,
+                   int muonSubdetId,
+                   ArbitrationType type = SegmentAndTrackArbitration,
+                   bool includeSegmentError = true) const;
+    /// get (best) segment information
+    /// If no segment returns 999999
+    float segmentX(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float segmentY(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float segmentDxDz(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float segmentDyDz(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float segmentXErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float segmentYErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float segmentDxDzErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float segmentDyDzErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    /// get track information in chamber that contains (best) segment
+    /// If no segment, get track information in chamber that has the most negative distance between the track
+    /// and the nearest chamber edge (the chamber with the deepest track)
+    /// If no chamber returns 999999
+    float trackEdgeX(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float trackEdgeY(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float trackX(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float trackY(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float trackDxDz(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float trackDyDz(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float trackXErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float trackYErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float trackDxDzErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float trackDyDzErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float trackDist(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+    float trackDistErr(int station, int muonSubdetId, ArbitrationType type = SegmentAndTrackArbitration) const;
+
+    float t0(int n = 0) {
+      int i = 0;
+      for (std::vector<MuonChamberMatch>::const_iterator chamber = muMatches_.begin(); chamber != muMatches_.end();
+           ++chamber)
+        for (std::vector<reco::MuonSegmentMatch>::const_iterator segment = chamber->segmentMatches.begin();
+             segment != chamber->segmentMatches.end();
+             ++segment) {
+          if (i == n)
+            return segment->t0;
+          ++i;
+        }
+      return 0;
+    }
   };
 
-}
-
+}  // namespace reco
 
 #endif

--- a/DataFormats/MuonReco/interface/MuonChamberMatch.h
+++ b/DataFormats/MuonReco/interface/MuonChamberMatch.h
@@ -7,34 +7,36 @@
 #include <vector>
 
 namespace reco {
-   class MuonChamberMatch {
-      public:
-         std::vector<reco::MuonSegmentMatch> segmentMatches;    // segments matching propagated track trajectory
-         std::vector<reco::MuonSegmentMatch> gemMatches;    // segments matching propagated track trajectory
-         std::vector<reco::MuonSegmentMatch> me0Matches;    // segments matching propagated track trajectory
-         std::vector<reco::MuonSegmentMatch> truthMatches;      // SimHit projection matching propagated track trajectory
-         std::vector<reco::MuonRPCHitMatch>  rpcMatches;        // rpc hits matching propagated track trajectory 
-         float edgeX;       // distance to closest edge in X (negative - inside, positive - outside)
-         float edgeY;       // distance to closest edge in Y (negative - inside, positive - outside)
-         float x;           // X position of the track
-         float y;           // Y position of the track
-         float xErr;        // propagation uncertainty in X
-         float yErr;        // propagation uncertainty in Y
-         float dXdZ;        // dX/dZ of the track
-         float dYdZ;        // dY/dZ of the track
-         float dXdZErr;     // propagation uncertainty in dX/dZ
-         float dYdZErr;     // propagation uncertainty in dY/dZ
-         DetId id;          // chamber ID
+  class MuonChamberMatch {
+  public:
+    std::vector<reco::MuonSegmentMatch> segmentMatches;  // segments matching propagated track trajectory
+    std::vector<reco::MuonSegmentMatch> gemMatches;      // segments matching propagated track trajectory
+    std::vector<reco::MuonSegmentMatch> me0Matches;      // segments matching propagated track trajectory
+    std::vector<reco::MuonSegmentMatch> truthMatches;    // SimHit projection matching propagated track trajectory
+    std::vector<reco::MuonRPCHitMatch> rpcMatches;       // rpc hits matching propagated track trajectory
+    float edgeX;    // distance to closest edge in X (negative - inside, positive - outside)
+    float edgeY;    // distance to closest edge in Y (negative - inside, positive - outside)
+    float x;        // X position of the track
+    float y;        // Y position of the track
+    float xErr;     // propagation uncertainty in X
+    float yErr;     // propagation uncertainty in Y
+    float dXdZ;     // dX/dZ of the track
+    float dYdZ;     // dY/dZ of the track
+    float dXdZErr;  // propagation uncertainty in dX/dZ
+    float dYdZErr;  // propagation uncertainty in dY/dZ
+    DetId id;       // chamber ID
 
-	 int nDigisInRange; // # of DT/CSC digis in the chamber close-by to the propagated track
+    int nDigisInRange;  // # of DT/CSC digis in the chamber close-by to the propagated track
 
-         int detector() const { return id.subdetId(); }
-         int station()  const;
+    int detector() const { return id.subdetId(); }
+    int station() const;
 
-         std::pair<float,float> getDistancePair(float edgeX, float edgeY, float xErr, float yErr) const;
-         float dist() const { return getDistancePair(edgeX, edgeY, xErr, yErr).first; }        // distance to absolute closest edge
-         float distErr() const { return getDistancePair(edgeX, edgeY, xErr, yErr).second; }    // propagation uncertainty in above distance
-   };
-}
+    std::pair<float, float> getDistancePair(float edgeX, float edgeY, float xErr, float yErr) const;
+    float dist() const { return getDistancePair(edgeX, edgeY, xErr, yErr).first; }  // distance to absolute closest edge
+    float distErr() const {
+      return getDistancePair(edgeX, edgeY, xErr, yErr).second;
+    }  // propagation uncertainty in above distance
+  };
+}  // namespace reco
 
 #endif

--- a/DataFormats/MuonReco/interface/MuonCocktails.h
+++ b/DataFormats/MuonReco/interface/MuonCocktails.h
@@ -15,62 +15,58 @@
 #include "DataFormats/TrackReco/interface/TrackToTrackMap.h"
 
 namespace muon {
-  
+
   reco::Muon::MuonTrackTypePair tevOptimized(const reco::TrackRef& combinedTrack,
-					     const reco::TrackRef& trackerTrack,
-					     const reco::TrackRef& tpfmsTrack,
-					     const reco::TrackRef& pickyTrack,
-					     const reco::TrackRef& dytTrack,
-					     const double ptThreshold = 200.,
-					     const double tune1 = 17.,
-					     const double tune2 = 40.,
-					     const double dptcut = 0.25);
+                                             const reco::TrackRef& trackerTrack,
+                                             const reco::TrackRef& tpfmsTrack,
+                                             const reco::TrackRef& pickyTrack,
+                                             const reco::TrackRef& dytTrack,
+                                             const double ptThreshold = 200.,
+                                             const double tune1 = 17.,
+                                             const double tune2 = 40.,
+                                             const double dptcut = 0.25);
 
   // Version for convenience. (NB: can be used with pat::Muon, even
   // with embedded tracks, equally conveniently!)
   inline reco::Muon::MuonTrackTypePair tevOptimized(const reco::Muon& muon,
-						    const double ptThreshold = 200.,
-						    const double tune1 = 17.,
-						    const double tune2 = 40.,
-						    const double dptcut = 0.25) {
+                                                    const double ptThreshold = 200.,
+                                                    const double tune1 = 17.,
+                                                    const double tune2 = 40.,
+                                                    const double dptcut = 0.25) {
     return tevOptimized(muon.globalTrack(),
-			muon.innerTrack(),
-			muon.tpfmsTrack(),
-			muon.pickyTrack(),
-			muon.dytTrack(),
-			ptThreshold,
-			tune1,
-			tune2,
-			dptcut);  
+                        muon.innerTrack(),
+                        muon.tpfmsTrack(),
+                        muon.pickyTrack(),
+                        muon.dytTrack(),
+                        ptThreshold,
+                        tune1,
+                        tune2,
+                        dptcut);
   }
 
-  reco::TrackRef getTevRefitTrack(const reco::TrackRef& combinedTrack,
-				  const reco::TrackToTrackMap& map);
-  
+  reco::TrackRef getTevRefitTrack(const reco::TrackRef& combinedTrack, const reco::TrackToTrackMap& map);
+
   // The cocktail used as the soon-to-be-old default momentum
   // assignment for the reco::Muon.
   reco::Muon::MuonTrackTypePair sigmaSwitch(const reco::TrackRef& combinedTrack,
-					    const reco::TrackRef& trackerTrack,
-					    const double nSigma = 2.,
-					    const double ptThreshold = 200.);
-  
+                                            const reco::TrackRef& trackerTrack,
+                                            const double nSigma = 2.,
+                                            const double ptThreshold = 200.);
+
   // Convenience version of the above.
   inline reco::Muon::MuonTrackTypePair sigmaSwitch(const reco::Muon& muon,
-						   const double nSigma = 2.,
-						   const double ptThreshold = 200.) {
-    return muon::sigmaSwitch(muon.globalTrack(),
-			     muon.innerTrack(),
-			     nSigma,
-			     ptThreshold);
+                                                   const double nSigma = 2.,
+                                                   const double ptThreshold = 200.) {
+    return muon::sigmaSwitch(muon.globalTrack(), muon.innerTrack(), nSigma, ptThreshold);
   }
 
   // "Truncated muon reconstructor": the first cocktail, between just
   // tracker-only and TPFMS. Similar to tevOptimized.
   reco::Muon::MuonTrackTypePair TMR(const reco::TrackRef& trackerTrack,
-				    const reco::TrackRef& fmsTrack,
-				    const double tune=4.);
-  
+                                    const reco::TrackRef& fmsTrack,
+                                    const double tune = 4.);
+
   double trackProbability(const reco::TrackRef track);
-}
+}  // namespace muon
 
 #endif

--- a/DataFormats/MuonReco/interface/MuonCosmicCompatibility.h
+++ b/DataFormats/MuonReco/interface/MuonCosmicCompatibility.h
@@ -2,26 +2,27 @@
 #define MuonReco_MuonCosmicCompatibility_h
 
 namespace reco {
-    struct MuonCosmicCompatibility {
+  struct MuonCosmicCompatibility {
+    /// combined cosmic-likeness: 0 == not cosmic-like
+    float cosmicCompatibility;
+    /// cosmic-likeness based on time: 0 == prompt-like
+    float timeCompatibility;
+    /// cosmic-likeness based on presence of a track in opp side: 0 == no matching opp tracks
+    float backToBackCompatibility;
+    /// cosmic-likeness based on overlap with traversing cosmic muon (only muon/STA hits are used)
+    float overlapCompatibility;
+    /// cosmic-likeness based on the 2D impact parameters (dxy, dz wrt to PV). 0 == cosmic-like
+    float ipCompatibility;
+    /// cosmic-likeness based on the event activity information: tracker track multiplicity and vertex quality. 0 == cosmic-like
+    float vertexCompatibility;
 
-      /// combined cosmic-likeness: 0 == not cosmic-like
-      float cosmicCompatibility;
-      /// cosmic-likeness based on time: 0 == prompt-like
-      float timeCompatibility;
-      /// cosmic-likeness based on presence of a track in opp side: 0 == no matching opp tracks
-      float backToBackCompatibility;
-      /// cosmic-likeness based on overlap with traversing cosmic muon (only muon/STA hits are used)
-      float overlapCompatibility;
-      /// cosmic-likeness based on the 2D impact parameters (dxy, dz wrt to PV). 0 == cosmic-like
-      float ipCompatibility;
-      /// cosmic-likeness based on the event activity information: tracker track multiplicity and vertex quality. 0 == cosmic-like
-      float vertexCompatibility;
-
-      MuonCosmicCompatibility():
-	cosmicCompatibility(0),timeCompatibility(0),
-	backToBackCompatibility(0),overlapCompatibility(0),
-        ipCompatibility(0), vertexCompatibility(0)
-      { }       
-    };
-}
+    MuonCosmicCompatibility()
+        : cosmicCompatibility(0),
+          timeCompatibility(0),
+          backToBackCompatibility(0),
+          overlapCompatibility(0),
+          ipCompatibility(0),
+          vertexCompatibility(0) {}
+  };
+}  // namespace reco
 #endif

--- a/DataFormats/MuonReco/interface/MuonEnergy.h
+++ b/DataFormats/MuonReco/interface/MuonEnergy.h
@@ -6,73 +6,81 @@
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include <vector>
 namespace reco {
-    struct HcalMuonRecHit{
-      float energy;
-      float chi2;
-      float time;
-      HcalDetId detId;
-      HcalMuonRecHit():
-      energy(0),chi2(0),time(0){}
-    };
+  struct HcalMuonRecHit {
+    float energy;
+    float chi2;
+    float time;
+    HcalDetId detId;
+    HcalMuonRecHit() : energy(0), chi2(0), time(0) {}
+  };
 
-    struct MuonEnergy {
-       /// CaloTower based energy
-       /// total energy
-       float tower; 
-       /// total energy in 3x3 tower shape
-       float towerS9; 
-       
-       /// ECAL crystal based energy (RecHits)
-       /// energy deposited in crossed ECAL crystals
-       float em; 
-       /// energy deposited in 3x3 ECAL crystal shape around central crystal
-       float emS9;
-       /// energy deposited in 5x5 ECAL crystal shape around central crystal
-       float emS25;
-       /// maximal energy of ECAL crystal in the 5x5 shape
-       float emMax;
-       
-       /// HCAL tower based energy (RecHits)
-       /// energy deposited in crossed HCAL towers
-       float had;
-       /// energy deposited in 3x3 HCAL tower shape around central tower
-       float hadS9;
-       /// maximal energy of HCAL tower in the 3x3 shape
-       float hadMax;
-       /// energy deposited in crossed HO towers
-       float ho;
-       /// energy deposited in 3x3 HO tower shape around central tower
-       float hoS9;
-       
-       /// Calorimeter timing
-       float ecal_time;
-       float ecal_timeError;
-       float hcal_time;
-       float hcal_timeError;
-       
-       /// Trajectory position at the calorimeter
-       math::XYZPointF ecal_position;
-       math::XYZPointF hcal_position;
-       
-       /// DetId of the central ECAL crystal
-       DetId ecal_id;
-       
-       /// DetId of the central HCAL tower with smallest depth
-       DetId hcal_id;
-       
-       ///
-       /// RecHits
-       ///
-       /// crossed HCAL rechits
-       std::vector<HcalMuonRecHit> crossedHadRecHits;
+  struct MuonEnergy {
+    /// CaloTower based energy
+    /// total energy
+    float tower;
+    /// total energy in 3x3 tower shape
+    float towerS9;
 
-       MuonEnergy():
-       tower(0), towerS9(0),
-       em(0), emS9(0), emS25(0), emMax(0),
-       had(0), hadS9(0), hadMax(0),
-	 ho(0), hoS9(0), ecal_time(0), ecal_timeError(0), hcal_time(0), hcal_timeError(0)
-	 { }
+    /// ECAL crystal based energy (RecHits)
+    /// energy deposited in crossed ECAL crystals
+    float em;
+    /// energy deposited in 3x3 ECAL crystal shape around central crystal
+    float emS9;
+    /// energy deposited in 5x5 ECAL crystal shape around central crystal
+    float emS25;
+    /// maximal energy of ECAL crystal in the 5x5 shape
+    float emMax;
 
-    };
-}
+    /// HCAL tower based energy (RecHits)
+    /// energy deposited in crossed HCAL towers
+    float had;
+    /// energy deposited in 3x3 HCAL tower shape around central tower
+    float hadS9;
+    /// maximal energy of HCAL tower in the 3x3 shape
+    float hadMax;
+    /// energy deposited in crossed HO towers
+    float ho;
+    /// energy deposited in 3x3 HO tower shape around central tower
+    float hoS9;
+
+    /// Calorimeter timing
+    float ecal_time;
+    float ecal_timeError;
+    float hcal_time;
+    float hcal_timeError;
+
+    /// Trajectory position at the calorimeter
+    math::XYZPointF ecal_position;
+    math::XYZPointF hcal_position;
+
+    /// DetId of the central ECAL crystal
+    DetId ecal_id;
+
+    /// DetId of the central HCAL tower with smallest depth
+    DetId hcal_id;
+
+    ///
+    /// RecHits
+    ///
+    /// crossed HCAL rechits
+    std::vector<HcalMuonRecHit> crossedHadRecHits;
+
+    MuonEnergy()
+        : tower(0),
+          towerS9(0),
+          em(0),
+          emS9(0),
+          emS25(0),
+          emMax(0),
+          had(0),
+          hadS9(0),
+          hadMax(0),
+          ho(0),
+          hoS9(0),
+          ecal_time(0),
+          ecal_timeError(0),
+          hcal_time(0),
+          hcal_timeError(0) {}
+  };
+}  // namespace reco
 #endif

--- a/DataFormats/MuonReco/interface/MuonFwd.h
+++ b/DataFormats/MuonReco/interface/MuonFwd.h
@@ -20,13 +20,13 @@ namespace reco {
 
   /// Links between the three tracks which can define a muon
   class MuonTrackLinks;
-  
+
   /// collection of MuonTrackLinks
   typedef std::vector<MuonTrackLinks> MuonTrackLinksCollection;
-  
+
   class CaloMuon;
   /// collection of Muon objects
   typedef std::vector<CaloMuon> CaloMuonCollection;
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/MuonReco/interface/MuonIsolation.h
+++ b/DataFormats/MuonReco/interface/MuonIsolation.h
@@ -1,22 +1,29 @@
 #ifndef MuonReco_MuonIsolation_h
 #define MuonReco_MuonIsolation_h
 
-
 namespace reco {
-   struct MuonIsolation {
-     float sumPt; //!< sum-pt of tracks
-     float emEt;  //!< ecal sum-Et
-     float hadEt; //!< hcal sum-Et
-     float hoEt;  //!< ho sum-Et
-     int nTracks; //!< number of tracks in the cone (excluding veto region)
-     int nJets;   //!< number of jets in the cone
-     float trackerVetoPt; //!< (sum-)pt inside the veto region in r-phi
-     float emVetoEt;  //!< ecal sum-et in the veto region in r-phi
-     float hadVetoEt;  //!< hcal sum-et in the veto region in r-phi
-     float hoVetoEt;    //!< ho sum-et in the veto region in r-phi
-     MuonIsolation():
-       sumPt(0),emEt(0),hadEt(0),hoEt(0),nTracks(0),nJets(0),
-	  trackerVetoPt(0), emVetoEt(0), hadVetoEt(0), hoVetoEt(0){};
-   };
-}
+  struct MuonIsolation {
+    float sumPt;          //!< sum-pt of tracks
+    float emEt;           //!< ecal sum-Et
+    float hadEt;          //!< hcal sum-Et
+    float hoEt;           //!< ho sum-Et
+    int nTracks;          //!< number of tracks in the cone (excluding veto region)
+    int nJets;            //!< number of jets in the cone
+    float trackerVetoPt;  //!< (sum-)pt inside the veto region in r-phi
+    float emVetoEt;       //!< ecal sum-et in the veto region in r-phi
+    float hadVetoEt;      //!< hcal sum-et in the veto region in r-phi
+    float hoVetoEt;       //!< ho sum-et in the veto region in r-phi
+    MuonIsolation()
+        : sumPt(0),
+          emEt(0),
+          hadEt(0),
+          hoEt(0),
+          nTracks(0),
+          nJets(0),
+          trackerVetoPt(0),
+          emVetoEt(0),
+          hadVetoEt(0),
+          hoVetoEt(0){};
+  };
+}  // namespace reco
 #endif

--- a/DataFormats/MuonReco/interface/MuonMETCorrectionData.h
+++ b/DataFormats/MuonReco/interface/MuonMETCorrectionData.h
@@ -6,30 +6,35 @@
 namespace reco {
   class MuonMETCorrectionData {
   public:
-    enum Type { NotUsed = 0,
-		CombinedTrackUsed = 1, GlobalTrackUsed = 1, 
-		InnerTrackUsed = 2, TrackUsed = 2, 
-		OuterTrackUsed = 3, StandAloneTrackUsed = 3,
-		TreatedAsPion = 4,
-		MuonP4V4QUsed = 5, MuonCandidateValuesUsed = 5
+    enum Type {
+      NotUsed = 0,
+      CombinedTrackUsed = 1,
+      GlobalTrackUsed = 1,
+      InnerTrackUsed = 2,
+      TrackUsed = 2,
+      OuterTrackUsed = 3,
+      StandAloneTrackUsed = 3,
+      TreatedAsPion = 4,
+      MuonP4V4QUsed = 5,
+      MuonCandidateValuesUsed = 5
     };
 
-    MuonMETCorrectionData(): type_(0), corrX_(0), corrY_(0) {}
-    MuonMETCorrectionData(Type type, float corrX, float corrY): type_(type), corrX_(corrX), corrY_(corrY) {}
+    MuonMETCorrectionData() : type_(0), corrX_(0), corrY_(0) {}
+    MuonMETCorrectionData(Type type, float corrX, float corrY) : type_(type), corrX_(corrX), corrY_(corrY) {}
 
-    Type type() { return Type(type_);}
-    float corrX() { return corrX_;}
-    float corrY() { return corrY_;}
-    float x() { return corrX_;}
-    float y() { return corrY_;}
-    float pt() { return sqrt(x()*x() + y()*y());}
+    Type type() { return Type(type_); }
+    float corrX() { return corrX_; }
+    float corrY() { return corrY_; }
+    float x() { return corrX_; }
+    float y() { return corrY_; }
+    float pt() { return sqrt(x() * x() + y() * y()); }
+
   protected:
     int type_;
     float corrX_;
     float corrY_;
   };
 
-}
+}  // namespace reco
 
-
-#endif //MuonReco_MuonMETCorrectionData_h
+#endif  //MuonReco_MuonMETCorrectionData_h

--- a/DataFormats/MuonReco/interface/MuonPFIsolation.h
+++ b/DataFormats/MuonReco/interface/MuonPFIsolation.h
@@ -1,23 +1,25 @@
 #ifndef MuonReco_MuonPFIsolation_h
 #define MuonReco_MuonPFIsolation_h
 
-
 namespace reco {
-   struct MuonPFIsolation {
-     float sumChargedHadronPt; //!< sum-pt of charged Hadron 
-     float sumChargedParticlePt; //!< sum-pt of charged Particles(inludes e/mu) 
-     float sumNeutralHadronEt;  //!< sum pt of neutral hadrons
-     float sumPhotonEt;  //!< sum pt of PF photons
-     float sumNeutralHadronEtHighThreshold;  //!< sum pt of neutral hadrons with a higher threshold
-     float sumPhotonEtHighThreshold;  //!< sum pt of PF photons with a higher threshold
-     float sumPUPt;  //!< sum pt of charged Particles not from PV  (for Pu corrections)
-     
-     MuonPFIsolation():
-       sumChargedHadronPt(0),sumChargedParticlePt(0),sumNeutralHadronEt(0),sumPhotonEt(0),
-       sumNeutralHadronEtHighThreshold(0), sumPhotonEtHighThreshold(0), sumPUPt(0) {}
+  struct MuonPFIsolation {
+    float sumChargedHadronPt;               //!< sum-pt of charged Hadron
+    float sumChargedParticlePt;             //!< sum-pt of charged Particles(inludes e/mu)
+    float sumNeutralHadronEt;               //!< sum pt of neutral hadrons
+    float sumPhotonEt;                      //!< sum pt of PF photons
+    float sumNeutralHadronEtHighThreshold;  //!< sum pt of neutral hadrons with a higher threshold
+    float sumPhotonEtHighThreshold;         //!< sum pt of PF photons with a higher threshold
+    float sumPUPt;                          //!< sum pt of charged Particles not from PV  (for Pu corrections)
 
-   };
+    MuonPFIsolation()
+        : sumChargedHadronPt(0),
+          sumChargedParticlePt(0),
+          sumNeutralHadronEt(0),
+          sumPhotonEt(0),
+          sumNeutralHadronEtHighThreshold(0),
+          sumPhotonEtHighThreshold(0),
+          sumPUPt(0) {}
+  };
 
-
-}
+}  // namespace reco
 #endif

--- a/DataFormats/MuonReco/interface/MuonQuality.h
+++ b/DataFormats/MuonReco/interface/MuonQuality.h
@@ -3,44 +3,47 @@
 
 #include "DataFormats/Math/interface/Point3D.h"
 namespace reco {
-    struct MuonQuality {
-      ///
-      /// bool returns true if standAloneMuon_updatedAtVtx was used in the fit
-      bool updatedSta;
-      /// value of the kink algorithm applied to the inner track stub
-      float trkKink;
-      /// value of the kink algorithm applied to the global track
-      float glbKink;
-      /// chi2 value for the inner track stub with respect to the global track
-      float trkRelChi2;
-      /// chi2 value for the outer track stub with respect to the global track
-      float staRelChi2;
-      /// chi2 value for the STA-TK matching of local position
-      float chi2LocalPosition;
-      /// chi2 value for the STA-TK matching of local momentum
-      float chi2LocalMomentum;
-      /// local distance seperation for STA-TK TSOS matching on same surface
-      float localDistance;
-      /// global delta-Eta-Phi of STA-TK matching
-      float globalDeltaEtaPhi;
-      /// if the STA-TK matching passed the tighter matching criteria
-      bool tightMatch;
-      /// the tail probability (-ln(P)) of the global fit
-      float glbTrackProbability;
+  struct MuonQuality {
+    ///
+    /// bool returns true if standAloneMuon_updatedAtVtx was used in the fit
+    bool updatedSta;
+    /// value of the kink algorithm applied to the inner track stub
+    float trkKink;
+    /// value of the kink algorithm applied to the global track
+    float glbKink;
+    /// chi2 value for the inner track stub with respect to the global track
+    float trkRelChi2;
+    /// chi2 value for the outer track stub with respect to the global track
+    float staRelChi2;
+    /// chi2 value for the STA-TK matching of local position
+    float chi2LocalPosition;
+    /// chi2 value for the STA-TK matching of local momentum
+    float chi2LocalMomentum;
+    /// local distance seperation for STA-TK TSOS matching on same surface
+    float localDistance;
+    /// global delta-Eta-Phi of STA-TK matching
+    float globalDeltaEtaPhi;
+    /// if the STA-TK matching passed the tighter matching criteria
+    bool tightMatch;
+    /// the tail probability (-ln(P)) of the global fit
+    float glbTrackProbability;
 
-      /// Kink position for the tracker stub and global track
-      math::XYZPoint tkKink_position;
-      math::XYZPoint glbKink_position;
-      
-      MuonQuality():
-	updatedSta(false),
-	trkKink(0), glbKink(0),
-	trkRelChi2(0), staRelChi2(0),
-	chi2LocalPosition(0),chi2LocalMomentum(0),
-	localDistance(0),globalDeltaEtaPhi(0),
-	tightMatch(false),glbTrackProbability(0)
-      { }
-       
-    };
-}
+    /// Kink position for the tracker stub and global track
+    math::XYZPoint tkKink_position;
+    math::XYZPoint glbKink_position;
+
+    MuonQuality()
+        : updatedSta(false),
+          trkKink(0),
+          glbKink(0),
+          trkRelChi2(0),
+          staRelChi2(0),
+          chi2LocalPosition(0),
+          chi2LocalMomentum(0),
+          localDistance(0),
+          globalDeltaEtaPhi(0),
+          tightMatch(false),
+          glbTrackProbability(0) {}
+  };
+}  // namespace reco
 #endif

--- a/DataFormats/MuonReco/interface/MuonRPCHitMatch.h
+++ b/DataFormats/MuonReco/interface/MuonRPCHitMatch.h
@@ -4,14 +4,14 @@
 #include <cmath>
 
 namespace reco {
-   class MuonRPCHitMatch {
-      public:
-         float x;              // X position of the matched segment
-         unsigned int mask;    // arbitration mask
-         int bx;               // bunch crossing
+  class MuonRPCHitMatch {
+  public:
+    float x;            // X position of the matched segment
+    unsigned int mask;  // arbitration mask
+    int bx;             // bunch crossing
 
-	 MuonRPCHitMatch():x(0),mask(0),bx(0){}
-   };
-}
+    MuonRPCHitMatch() : x(0), mask(0), bx(0) {}
+  };
+}  // namespace reco
 
 #endif

--- a/DataFormats/MuonReco/interface/MuonSegmentMatch.h
+++ b/DataFormats/MuonReco/interface/MuonSegmentMatch.h
@@ -9,53 +9,53 @@
 #include "DataFormats/GEMRecHit/interface/ME0SegmentCollection.h"
 
 namespace reco {
-   class MuonSegmentMatch {
-      public:
-         /// segment mask flags
-         static const unsigned int Arbitrated                = 1<<8;     // is arbitrated (multiple muons)
-         static const unsigned int BestInChamberByDX         = 1<<9;     // best delta x in single muon chamber
-         static const unsigned int BestInChamberByDR         = 1<<10;    // best delta r in single muon chamber
-         static const unsigned int BestInChamberByDXSlope    = 1<<11;    // best delta dx/dz in single muon chamber
-         static const unsigned int BestInChamberByDRSlope    = 1<<12;    // best delta dy/dz in single muon chamber
-         static const unsigned int BestInStationByDX         = 1<<13;    // best delta x in single muon station
-         static const unsigned int BestInStationByDR         = 1<<14;    // best delta r in single muon station
-         static const unsigned int BestInStationByDXSlope    = 1<<15;    // best delta dx/dz in single muon station
-         static const unsigned int BestInStationByDRSlope    = 1<<16;    // best delta dy/dz in single muon station
-         static const unsigned int BelongsToTrackByDX        = 1<<17;    // best delta x of multiple muons
-         static const unsigned int BelongsToTrackByDR        = 1<<18;    // best delta r of multiple muons
-         static const unsigned int BelongsToTrackByDXSlope   = 1<<19;    // best delta dx/dz of multiple muons
-         static const unsigned int BelongsToTrackByDRSlope   = 1<<20;    // best delta dy/dz of multiple muons
-         static const unsigned int BelongsToTrackByME1aClean = 1<<21;    // won ME1a segment sharing cleaning
-         static const unsigned int BelongsToTrackByOvlClean  = 1<<22;    // won chamber overlap segment sharing cleaning
-         static const unsigned int BelongsToTrackByClusClean = 1<<23;    // won cluster sharing cleaning
-         static const unsigned int BelongsToTrackByCleaning  = 1<<24;    // won any arbitration cleaning type, including defaults
+  class MuonSegmentMatch {
+  public:
+    /// segment mask flags
+    static const unsigned int Arbitrated = 1 << 8;                  // is arbitrated (multiple muons)
+    static const unsigned int BestInChamberByDX = 1 << 9;           // best delta x in single muon chamber
+    static const unsigned int BestInChamberByDR = 1 << 10;          // best delta r in single muon chamber
+    static const unsigned int BestInChamberByDXSlope = 1 << 11;     // best delta dx/dz in single muon chamber
+    static const unsigned int BestInChamberByDRSlope = 1 << 12;     // best delta dy/dz in single muon chamber
+    static const unsigned int BestInStationByDX = 1 << 13;          // best delta x in single muon station
+    static const unsigned int BestInStationByDR = 1 << 14;          // best delta r in single muon station
+    static const unsigned int BestInStationByDXSlope = 1 << 15;     // best delta dx/dz in single muon station
+    static const unsigned int BestInStationByDRSlope = 1 << 16;     // best delta dy/dz in single muon station
+    static const unsigned int BelongsToTrackByDX = 1 << 17;         // best delta x of multiple muons
+    static const unsigned int BelongsToTrackByDR = 1 << 18;         // best delta r of multiple muons
+    static const unsigned int BelongsToTrackByDXSlope = 1 << 19;    // best delta dx/dz of multiple muons
+    static const unsigned int BelongsToTrackByDRSlope = 1 << 20;    // best delta dy/dz of multiple muons
+    static const unsigned int BelongsToTrackByME1aClean = 1 << 21;  // won ME1a segment sharing cleaning
+    static const unsigned int BelongsToTrackByOvlClean = 1 << 22;   // won chamber overlap segment sharing cleaning
+    static const unsigned int BelongsToTrackByClusClean = 1 << 23;  // won cluster sharing cleaning
+    static const unsigned int BelongsToTrackByCleaning =
+        1 << 24;  // won any arbitration cleaning type, including defaults
 
-         float x;              // X position of the matched segment
-         float y;              // Y position of the matched segment
-         float xErr;           // uncertainty in X
-         float yErr;           // uncertainty in Y
-         float dXdZ;           // dX/dZ of the matched segment
-         float dYdZ;           // dY/dZ of the matched segment
-         float dXdZErr;        // uncertainty in dX/dZ
-         float dYdZErr;        // uncertainty in dY/dZ
-         unsigned int mask;    // arbitration mask
-         bool hasZed_;         // contains local y information (only relevant for segments in DT)
-         bool hasPhi_;         // contains local x information (only relevant for segments in DT)
+    float x;            // X position of the matched segment
+    float y;            // Y position of the matched segment
+    float xErr;         // uncertainty in X
+    float yErr;         // uncertainty in Y
+    float dXdZ;         // dX/dZ of the matched segment
+    float dYdZ;         // dY/dZ of the matched segment
+    float dXdZErr;      // uncertainty in dX/dZ
+    float dYdZErr;      // uncertainty in dY/dZ
+    unsigned int mask;  // arbitration mask
+    bool hasZed_;       // contains local y information (only relevant for segments in DT)
+    bool hasPhi_;       // contains local x information (only relevant for segments in DT)
 
-         bool isMask( unsigned int flag = Arbitrated ) const { return (mask & flag) == flag; }
-         void setMask( unsigned int flag ) { mask |= flag; }
-         float t0;
+    bool isMask(unsigned int flag = Arbitrated) const { return (mask & flag) == flag; }
+    void setMask(unsigned int flag) { mask |= flag; }
+    float t0;
 
-         DTRecSegment4DRef  dtSegmentRef;
-         CSCSegmentRef      cscSegmentRef;
-	 GEMSegmentRef      gemSegmentRef;
-	 ME0SegmentRef      me0SegmentRef;
-      MuonSegmentMatch():x(0),y(0),xErr(0),yErr(0),dXdZ(0),dYdZ(0),
-      dXdZErr(0),dYdZErr(0) {}
+    DTRecSegment4DRef dtSegmentRef;
+    CSCSegmentRef cscSegmentRef;
+    GEMSegmentRef gemSegmentRef;
+    ME0SegmentRef me0SegmentRef;
+    MuonSegmentMatch() : x(0), y(0), xErr(0), yErr(0), dXdZ(0), dYdZ(0), dXdZErr(0), dYdZErr(0) {}
 
-         bool hasZed() const { return hasZed_; }
-         bool hasPhi() const { return hasPhi_; }
-   };
-}
+    bool hasZed() const { return hasZed_; }
+    bool hasPhi() const { return hasPhi_; }
+  };
+}  // namespace reco
 
 #endif

--- a/DataFormats/MuonReco/interface/MuonSelectors.h
+++ b/DataFormats/MuonReco/interface/MuonSelectors.h
@@ -2,7 +2,7 @@
 #define MuonReco_MuonSelectors_h
 //
 // Package:    MuonReco
-// 
+//
 //
 // Original Author:  Jake Ribnik, Dmytro Kovalskyi
 
@@ -10,117 +10,130 @@
 #include "TMath.h"
 #include <string>
 
-namespace reco{class Vertex;}
+namespace reco {
+  class Vertex;
+}
 
 namespace muon {
-   /// Selector type
-   enum SelectionType {
-      All = 0,                      // dummy options - always true
-      AllGlobalMuons = 1,           // checks isGlobalMuon flag
-      AllStandAloneMuons = 2,       // checks isStandAloneMuon flag
-      AllTrackerMuons = 3,          // checks isTrackerMuon flag
-      TrackerMuonArbitrated = 4,    // resolve ambiguity of sharing segments
-      AllArbitrated = 5,            // all muons with the tracker muon arbitrated
-      GlobalMuonPromptTight = 6,    // global muons with tighter fit requirements
-      TMLastStationLoose = 7,       // penetration depth loose selector
-      TMLastStationTight = 8,       // penetration depth tight selector
-      TM2DCompatibilityLoose = 9,   // likelihood based loose selector
-      TM2DCompatibilityTight = 10,  // likelihood based tight selector
-      TMOneStationLoose = 11,       // require one well matched segment
-      TMOneStationTight = 12,       // require one well matched segment
-      TMLastStationOptimizedLowPtLoose = 13, // combination of TMLastStation and TMOneStation
-      TMLastStationOptimizedLowPtTight = 14, // combination of TMLastStation and TMOneStation
-      GMTkChiCompatibility = 15,    // require tk stub have good chi2 relative to glb track
-      GMStaChiCompatibility = 16,   // require sta stub have good chi2 compatibility relative to glb track
-      GMTkKinkTight = 17,           // require a small kink value in the tracker stub
-      TMLastStationAngLoose = 18,   // TMLastStationLoose with additional angular cuts
-      TMLastStationAngTight = 19,   // TMLastStationTight with additional angular cuts
-      TMOneStationAngLoose = 20,    // TMOneStationLoose with additional angular cuts
-      TMOneStationAngTight = 21,    // TMOneStationTight with additional angular cuts
-      // The two algorithms that follow are identical to what were known as
-      // TMLastStationOptimizedLowPt* (sans the Barrel) as late as revision
-      // 1.7 of this file. The names were changed because indeed the low pt
-      // optimization applies only to the barrel region, whereas the sel-
-      // ectors above are more efficient at low pt in the endcaps, which is
-      // what we feel is more suggestive of the algorithm name. This will be
-      // less confusing for future generations of CMS members, I hope...
-      TMLastStationOptimizedBarrelLowPtLoose = 22, // combination of TMLastStation and TMOneStation but with low pT optimization in barrel only
-      TMLastStationOptimizedBarrelLowPtTight = 23, // combination of TMLastStation and TMOneStation but with low pT optimization in barrel only
-      RPCMuLoose = 24,                             // checks isRPCMuon flag (require two well matched hits in different RPC layers)
-      AllME0Muons = 25,
-      ME0MuonArbitrated = 26,
-      AllGEMMuons = 27,
-      GEMMuonArbitrated = 28,
-      TriggerIdLoose = 29          
-   };
+  /// Selector type
+  enum SelectionType {
+    All = 0,                                // dummy options - always true
+    AllGlobalMuons = 1,                     // checks isGlobalMuon flag
+    AllStandAloneMuons = 2,                 // checks isStandAloneMuon flag
+    AllTrackerMuons = 3,                    // checks isTrackerMuon flag
+    TrackerMuonArbitrated = 4,              // resolve ambiguity of sharing segments
+    AllArbitrated = 5,                      // all muons with the tracker muon arbitrated
+    GlobalMuonPromptTight = 6,              // global muons with tighter fit requirements
+    TMLastStationLoose = 7,                 // penetration depth loose selector
+    TMLastStationTight = 8,                 // penetration depth tight selector
+    TM2DCompatibilityLoose = 9,             // likelihood based loose selector
+    TM2DCompatibilityTight = 10,            // likelihood based tight selector
+    TMOneStationLoose = 11,                 // require one well matched segment
+    TMOneStationTight = 12,                 // require one well matched segment
+    TMLastStationOptimizedLowPtLoose = 13,  // combination of TMLastStation and TMOneStation
+    TMLastStationOptimizedLowPtTight = 14,  // combination of TMLastStation and TMOneStation
+    GMTkChiCompatibility = 15,              // require tk stub have good chi2 relative to glb track
+    GMStaChiCompatibility = 16,             // require sta stub have good chi2 compatibility relative to glb track
+    GMTkKinkTight = 17,                     // require a small kink value in the tracker stub
+    TMLastStationAngLoose = 18,             // TMLastStationLoose with additional angular cuts
+    TMLastStationAngTight = 19,             // TMLastStationTight with additional angular cuts
+    TMOneStationAngLoose = 20,              // TMOneStationLoose with additional angular cuts
+    TMOneStationAngTight = 21,              // TMOneStationTight with additional angular cuts
+    // The two algorithms that follow are identical to what were known as
+    // TMLastStationOptimizedLowPt* (sans the Barrel) as late as revision
+    // 1.7 of this file. The names were changed because indeed the low pt
+    // optimization applies only to the barrel region, whereas the sel-
+    // ectors above are more efficient at low pt in the endcaps, which is
+    // what we feel is more suggestive of the algorithm name. This will be
+    // less confusing for future generations of CMS members, I hope...
+    TMLastStationOptimizedBarrelLowPtLoose =
+        22,  // combination of TMLastStation and TMOneStation but with low pT optimization in barrel only
+    TMLastStationOptimizedBarrelLowPtTight =
+        23,           // combination of TMLastStation and TMOneStation but with low pT optimization in barrel only
+    RPCMuLoose = 24,  // checks isRPCMuon flag (require two well matched hits in different RPC layers)
+    AllME0Muons = 25,
+    ME0MuonArbitrated = 26,
+    AllGEMMuons = 27,
+    GEMMuonArbitrated = 28,
+    TriggerIdLoose = 29
+  };
 
-   /// a lightweight "map" for selection type string label and enum value
-   struct SelectionTypeStringToEnum { const char *label; SelectionType value; };
-   SelectionType selectionTypeFromString( const std::string &label );
-     
-   /// main GoodMuon wrapper call
-   bool isGoodMuon( const reco::Muon& muon, SelectionType type, 
-		    reco::Muon::ArbitrationType arbitrationType = reco::Muon::SegmentAndTrackArbitration);
+  /// a lightweight "map" for selection type string label and enum value
+  struct SelectionTypeStringToEnum {
+    const char* label;
+    SelectionType value;
+  };
+  SelectionType selectionTypeFromString(const std::string& label);
 
-   // ===========================================================================
-   //                               Support functions
-   // 
-   enum AlgorithmType { TMLastStation, TM2DCompatibility, TMOneStation, RPCMu, ME0Mu, GEMMu };
-   
-   // specialized GoodMuon functions called from main wrapper
-   bool isGoodMuon( const reco::Muon& muon, 
-		    AlgorithmType type,
-		    double minCompatibility,
-		    reco::Muon::ArbitrationType arbitrationType );
-   
-   bool isGoodMuon( const reco::Muon& muon, 
-		    AlgorithmType type,
-		    int minNumberOfMatches,
-		    double maxAbsDx,
-		    double maxAbsPullX,
-		    double maxAbsDy,
-		    double maxAbsPullY,
-		    double maxChamberDist,
-		    double maxChamberDistPull,
-		    reco::Muon::ArbitrationType arbitrationType,
-		    bool   syncMinNMatchesNRequiredStationsInBarrelOnly = true,//this is what we had originally
-		    bool   applyAlsoAngularCuts = false);
+  /// main GoodMuon wrapper call
+  bool isGoodMuon(const reco::Muon& muon,
+                  SelectionType type,
+                  reco::Muon::ArbitrationType arbitrationType = reco::Muon::SegmentAndTrackArbitration);
 
-   bool isTightMuon(const reco::Muon&, const reco::Vertex&);
-   bool isLooseMuon(const reco::Muon&);
-   bool isMediumMuon(const reco::Muon&, bool run2016_hip_mitigation=false);
-   bool isSoftMuon(const reco::Muon&, const reco::Vertex&, bool run2016_hip_mitigation=false);
-   bool isHighPtMuon(const reco::Muon&, const reco::Vertex&);
-   bool isTrackerHighPtMuon(const reco::Muon&, const reco::Vertex&);
-   bool isLooseTriggerMuon(const reco::Muon&);
-   
-   // determine if station was crossed well withing active volume
-   unsigned int RequiredStationMask( const reco::Muon& muon,
-				     double maxChamberDist,
-				     double maxChamberDistPull,
-				     reco::Muon::ArbitrationType arbitrationType );
+  // ===========================================================================
+  //                               Support functions
+  //
+  enum AlgorithmType { TMLastStation, TM2DCompatibility, TMOneStation, RPCMu, ME0Mu, GEMMu };
 
-   // ------------ method to return the calo compatibility for a track with matched muon info  ------------
-   float caloCompatibility(const reco::Muon& muon);
+  // specialized GoodMuon functions called from main wrapper
+  bool isGoodMuon(const reco::Muon& muon,
+                  AlgorithmType type,
+                  double minCompatibility,
+                  reco::Muon::ArbitrationType arbitrationType);
 
-   // ------------ method to calculate the segment compatibility for a track with matched muon info  ------------
-   float segmentCompatibility(const reco::Muon& muon,reco::Muon::ArbitrationType arbitrationType = reco::Muon::SegmentAndTrackArbitration);
-   
-   // Check if two muon trajectory overlap
-   // The overlap is performed by comparing distance between two muon
-   // trajectories if they cross the same muon chamber. Trajectories 
-   // overlap if distance/uncertainty is smaller than allowed pullX 
-   // and pullY
-   bool overlap( const reco::Muon& muon1, const reco::Muon& muon2, 
-		 double pullX = 1.0, double pullY = 1.0, bool checkAdjacentChambers = false);
+  bool isGoodMuon(const reco::Muon& muon,
+                  AlgorithmType type,
+                  int minNumberOfMatches,
+                  double maxAbsDx,
+                  double maxAbsPullX,
+                  double maxAbsDy,
+                  double maxAbsPullY,
+                  double maxChamberDist,
+                  double maxChamberDistPull,
+                  reco::Muon::ArbitrationType arbitrationType,
+                  bool syncMinNMatchesNRequiredStationsInBarrelOnly = true,  //this is what we had originally
+                  bool applyAlsoAngularCuts = false);
 
-   /// Determine the number of shared segments between two muons.
-   /// Comparison is done using the segment references in the reco::Muon object.
-   int sharedSegments( const reco::Muon& muon1, const reco::Muon& muon2, 
-                       unsigned int segmentArbitrationMask = reco::MuonSegmentMatch::BestInChamberByDR ) ;
+  bool isTightMuon(const reco::Muon&, const reco::Vertex&);
+  bool isLooseMuon(const reco::Muon&);
+  bool isMediumMuon(const reco::Muon&, bool run2016_hip_mitigation = false);
+  bool isSoftMuon(const reco::Muon&, const reco::Vertex&, bool run2016_hip_mitigation = false);
+  bool isHighPtMuon(const reco::Muon&, const reco::Vertex&);
+  bool isTrackerHighPtMuon(const reco::Muon&, const reco::Vertex&);
+  bool isLooseTriggerMuon(const reco::Muon&);
 
-   reco::Muon::Selector makeSelectorBitset( reco::Muon const& muon,
-                                            reco::Vertex const* vertex=nullptr,
-                                            bool run2016_hip_mitigation=false );
-}
+  // determine if station was crossed well withing active volume
+  unsigned int RequiredStationMask(const reco::Muon& muon,
+                                   double maxChamberDist,
+                                   double maxChamberDistPull,
+                                   reco::Muon::ArbitrationType arbitrationType);
+
+  // ------------ method to return the calo compatibility for a track with matched muon info  ------------
+  float caloCompatibility(const reco::Muon& muon);
+
+  // ------------ method to calculate the segment compatibility for a track with matched muon info  ------------
+  float segmentCompatibility(const reco::Muon& muon,
+                             reco::Muon::ArbitrationType arbitrationType = reco::Muon::SegmentAndTrackArbitration);
+
+  // Check if two muon trajectory overlap
+  // The overlap is performed by comparing distance between two muon
+  // trajectories if they cross the same muon chamber. Trajectories
+  // overlap if distance/uncertainty is smaller than allowed pullX
+  // and pullY
+  bool overlap(const reco::Muon& muon1,
+               const reco::Muon& muon2,
+               double pullX = 1.0,
+               double pullY = 1.0,
+               bool checkAdjacentChambers = false);
+
+  /// Determine the number of shared segments between two muons.
+  /// Comparison is done using the segment references in the reco::Muon object.
+  int sharedSegments(const reco::Muon& muon1,
+                     const reco::Muon& muon2,
+                     unsigned int segmentArbitrationMask = reco::MuonSegmentMatch::BestInChamberByDR);
+
+  reco::Muon::Selector makeSelectorBitset(reco::Muon const& muon,
+                                          reco::Vertex const* vertex = nullptr,
+                                          bool run2016_hip_mitigation = false);
+}  // namespace muon
 #endif

--- a/DataFormats/MuonReco/interface/MuonShower.h
+++ b/DataFormats/MuonReco/interface/MuonShower.h
@@ -4,21 +4,17 @@
 #include <vector>
 
 namespace reco {
-    struct MuonShower {
+  struct MuonShower {
+    /// number of all the muon RecHits per chamber crossed by a track (1D hits)
+    std::vector<int> nStationHits;
+    /// number of the muon RecHits used by segments per chamber crossed by a track
+    std::vector<int> nStationCorrelatedHits;
+    /// the transverse size of the hit cluster
+    std::vector<float> stationShowerSizeT;
+    /// the radius of the cone containing the all the hits around the track
+    std::vector<float> stationShowerDeltaR;
 
-      /// number of all the muon RecHits per chamber crossed by a track (1D hits)
-      std::vector<int> nStationHits;
-      /// number of the muon RecHits used by segments per chamber crossed by a track
-      std::vector<int> nStationCorrelatedHits;
-      /// the transverse size of the hit cluster
-      std::vector<float> stationShowerSizeT;
-      /// the radius of the cone containing the all the hits around the track
-      std::vector<float> stationShowerDeltaR;
-
-      MuonShower():
-	nStationHits(0),nStationCorrelatedHits(0),
-	stationShowerSizeT(0),stationShowerDeltaR(0)
-      { }       
-    };
-}
+    MuonShower() : nStationHits(0), nStationCorrelatedHits(0), stationShowerSizeT(0), stationShowerDeltaR(0) {}
+  };
+}  // namespace reco
 #endif

--- a/DataFormats/MuonReco/interface/MuonSimInfo.h
+++ b/DataFormats/MuonReco/interface/MuonSimInfo.h
@@ -5,7 +5,7 @@
 #include "DataFormats/Math/interface/LorentzVector.h"
 
 namespace reco {
-/*
+  /*
 
 
  CLASSIFICATION: For each RECO Muon, match to SIM particle, and then:
@@ -28,76 +28,74 @@ namespace reco {
 
 */
 
-  enum MuonSimType { 
-    Unknown                     = 999, 
-    NotMatched                  = 0,
-    MatchedPunchthrough         = 1,
-    MatchedElectron             = 11,
-    MatchedPrimaryMuon          = 4,
+  enum MuonSimType {
+    Unknown = 999,
+    NotMatched = 0,
+    MatchedPunchthrough = 1,
+    MatchedElectron = 11,
+    MatchedPrimaryMuon = 4,
     MatchedMuonFromHeavyFlavour = 3,
     MatchedMuonFromLightFlavour = 2,
-    GhostPunchthrough           = -1,
-    GhostElectron               = -11,
-    GhostPrimaryMuon            = -4,
-    GhostMuonFromHeavyFlavour   = -3,
-    GhostMuonFromLightFlavour   = -2
+    GhostPunchthrough = -1,
+    GhostElectron = -11,
+    GhostPrimaryMuon = -4,
+    GhostMuonFromHeavyFlavour = -3,
+    GhostMuonFromLightFlavour = -2
   };
 
-  enum ExtendedMuonSimType { 
-    ExtUnknown                        = 999, 
-    ExtNotMatched                     = 0,
-    ExtMatchedPunchthrough            = 1,
-    ExtMatchedElectron                = 11,
-    MatchedMuonFromGaugeOrHiggsBoson  = 10,
-    MatchedMuonFromTau                = 9,
-    MatchedMuonFromB                  = 8,
-    MatchedMuonFromBtoC               = 7,
-    MatchedMuonFromC                  = 6,
-    MatchedMuonFromOtherLight         = 5,
-    MatchedMuonFromPiKppMuX           = 4,
-    MatchedMuonFromPiKNotppMuX        = 3,
+  enum ExtendedMuonSimType {
+    ExtUnknown = 999,
+    ExtNotMatched = 0,
+    ExtMatchedPunchthrough = 1,
+    ExtMatchedElectron = 11,
+    MatchedMuonFromGaugeOrHiggsBoson = 10,
+    MatchedMuonFromTau = 9,
+    MatchedMuonFromB = 8,
+    MatchedMuonFromBtoC = 7,
+    MatchedMuonFromC = 6,
+    MatchedMuonFromOtherLight = 5,
+    MatchedMuonFromPiKppMuX = 4,
+    MatchedMuonFromPiKNotppMuX = 3,
     MatchedMuonFromNonPrimaryParticle = 2,
-    ExtGhostPunchthrough              = -1,
-    ExtGhostElectron                  = -11,
-    GhostMuonFromGaugeOrHiggsBoson    = -10,
-    GhostMuonFromTau                  = -9,
-    GhostMuonFromB                    = -8,
-    GhostMuonFromBtoC                 = -7,
-    GhostMuonFromC                    = -6,
-    GhostMuonFromOtherLight           = -5,
-    GhostMuonFromPiKppMuX             = -4,
-    GhostMuonFromPiKNotppMuX          = -3,
-    GhostMuonFromNonPrimaryParticle   = -2
-    
-  };
+    ExtGhostPunchthrough = -1,
+    ExtGhostElectron = -11,
+    GhostMuonFromGaugeOrHiggsBoson = -10,
+    GhostMuonFromTau = -9,
+    GhostMuonFromB = -8,
+    GhostMuonFromBtoC = -7,
+    GhostMuonFromC = -6,
+    GhostMuonFromOtherLight = -5,
+    GhostMuonFromPiKppMuX = -4,
+    GhostMuonFromPiKNotppMuX = -3,
+    GhostMuonFromNonPrimaryParticle = -2
 
+  };
 
   class MuonSimInfo {
   public:
     MuonSimInfo();
-    typedef math::XYZPointD Point; ///< point in the space
-    typedef math::XYZTLorentzVectorD LorentzVector; ///< Lorentz vector
-    MuonSimType primaryClass; 
+    typedef math::XYZPointD Point;                   ///< point in the space
+    typedef math::XYZTLorentzVectorD LorentzVector;  ///< Lorentz vector
+    MuonSimType primaryClass;
     ExtendedMuonSimType extendedClass;
     int flavour;
-    int pdgId; // pdg ID of matching tracking particle
-    int g4processType; // Geant process producing the particle
+    int pdgId;          // pdg ID of matching tracking particle
+    int g4processType;  // Geant process producing the particle
     int motherPdgId;
     int motherFlavour;
-    int motherStatus;  // Status of the first gen particle 
+    int motherStatus;  // Status of the first gen particle
     int grandMotherPdgId;
     int grandMotherFlavour;
-    int heaviestMotherFlavour; 
+    int heaviestMotherFlavour;
     int tpId;
     int tpEvent;
-    int tpBX;    // bunch crossing
+    int tpBX;  // bunch crossing
     int charge;
     LorentzVector p4;
     Point vertex;
     Point motherVertex;
     float tpAssoQuality;
   };
-}
-
+}  // namespace reco
 
 #endif

--- a/DataFormats/MuonReco/interface/MuonTime.h
+++ b/DataFormats/MuonReco/interface/MuonTime.h
@@ -1,34 +1,31 @@
 #ifndef MuonReco_MuonTime_h
 #define MuonReco_MuonTime_h
 
-
 namespace reco {
-    struct MuonTime {
-       enum Direction { OutsideIn = -1, Undefined = 0, InsideOut = 1 };
-	    
-       /// number of muon stations used
-       int nDof;
-       
-       /// time of arrival at the IP for the Beta=1 hypothesis
-       ///  a) particle is moving from inside out
-       float timeAtIpInOut;
-       float timeAtIpInOutErr;
-       ///  b) particle is moving from outside in
-       float timeAtIpOutIn;
-       float timeAtIpOutInErr;
-       
-       /// direction estimation based on time dispersion
-       Direction direction() const
-	 {
-	    if (nDof<2) return Undefined;
-	    if ( timeAtIpInOutErr > timeAtIpOutInErr ) return OutsideIn;
-	    return InsideOut;
-	 }
-       
-       
-       MuonTime():
-       nDof(0), timeAtIpInOut(0), timeAtIpInOutErr(0), timeAtIpOutIn(0), timeAtIpOutInErr(0)
-	 {}
-    };
-}
+  struct MuonTime {
+    enum Direction { OutsideIn = -1, Undefined = 0, InsideOut = 1 };
+
+    /// number of muon stations used
+    int nDof;
+
+    /// time of arrival at the IP for the Beta=1 hypothesis
+    ///  a) particle is moving from inside out
+    float timeAtIpInOut;
+    float timeAtIpInOutErr;
+    ///  b) particle is moving from outside in
+    float timeAtIpOutIn;
+    float timeAtIpOutInErr;
+
+    /// direction estimation based on time dispersion
+    Direction direction() const {
+      if (nDof < 2)
+        return Undefined;
+      if (timeAtIpInOutErr > timeAtIpOutInErr)
+        return OutsideIn;
+      return InsideOut;
+    }
+
+    MuonTime() : nDof(0), timeAtIpInOut(0), timeAtIpInOutErr(0), timeAtIpOutIn(0), timeAtIpOutInErr(0) {}
+  };
+}  // namespace reco
 #endif

--- a/DataFormats/MuonReco/interface/MuonTimeExtra.h
+++ b/DataFormats/MuonReco/interface/MuonTimeExtra.h
@@ -11,74 +11,73 @@
  */
 
 namespace reco {
- 
+
   class MuonTimeExtra {
-    public:
-      MuonTimeExtra();
+  public:
+    MuonTimeExtra();
 
-      enum Direction { OutsideIn = -1, Undefined = 0, InsideOut = 1 };
+    enum Direction { OutsideIn = -1, Undefined = 0, InsideOut = 1 };
 
-      /// number of measurements used in timing calculation
-      int nDof() const { return nDof_; };
-      void setNDof( const int nDof ) { nDof_=nDof; };
-       
-      /// 1/beta for prompt particle hypothesis 
-      /// (time is constraint to the bunch crossing time)
-      float inverseBeta()    const { return inverseBeta_; };
-      float inverseBetaErr() const { return inverseBetaErr_; };
-      void setInverseBeta( const float iBeta ) { inverseBeta_=iBeta; };
-      void setInverseBetaErr( const float iBetaErr) { inverseBetaErr_=iBetaErr; };
-       
-      /// unconstrained 1/beta (time is free)
-      /// Sign convention:
-      ///   positive - outward moving particle
-      ///   negative - inward moving particle
-      float freeInverseBeta()    const { return freeInverseBeta_; };
-      float freeInverseBetaErr() const { return freeInverseBetaErr_; };
-      void setFreeInverseBeta( const float iBeta ) { freeInverseBeta_=iBeta; };
-      void setFreeInverseBetaErr( const float iBetaErr) { freeInverseBetaErr_=iBetaErr; };
+    /// number of measurements used in timing calculation
+    int nDof() const { return nDof_; };
+    void setNDof(const int nDof) { nDof_ = nDof; };
 
-      /// time of arrival at the IP for the Beta=1 hypothesis
-      ///  a) particle is moving from inside out
-      float timeAtIpInOut()    const { return timeAtIpInOut_; }; 
-      float timeAtIpInOutErr() const { return timeAtIpInOutErr_; };
-      void setTimeAtIpInOut( const float timeIp )     { timeAtIpInOut_=timeIp; }; 
-      void setTimeAtIpInOutErr( const float timeErr ) { timeAtIpInOutErr_=timeErr; };
-      ///  b) particle is moving from outside in
-      float timeAtIpOutIn()    const { return timeAtIpOutIn_; };
-      float timeAtIpOutInErr() const { return timeAtIpOutInErr_; };
-      void setTimeAtIpOutIn( const float timeIp )     { timeAtIpOutIn_=timeIp; }; 
-      void setTimeAtIpOutInErr( const float timeErr ) { timeAtIpOutInErr_=timeErr; };
-       
-      /// direction estimation based on time dispersion
-      Direction direction() const
-      {
-        if (nDof_<2) return Undefined;
-        if ( timeAtIpInOutErr_ > timeAtIpOutInErr_ ) return OutsideIn;
-        return InsideOut;
-      }
-     
-    private:
+    /// 1/beta for prompt particle hypothesis
+    /// (time is constraint to the bunch crossing time)
+    float inverseBeta() const { return inverseBeta_; };
+    float inverseBetaErr() const { return inverseBetaErr_; };
+    void setInverseBeta(const float iBeta) { inverseBeta_ = iBeta; };
+    void setInverseBetaErr(const float iBetaErr) { inverseBetaErr_ = iBetaErr; };
 
-      /// number of measurements used in timing calculation
-      int nDof_;
-       
-      /// 1/beta for prompt particle hypothesis 
-      float inverseBeta_;
-      float inverseBetaErr_;
-       
-      /// unconstrained 1/beta (time is free)
-      float freeInverseBeta_;
-      float freeInverseBetaErr_;
+    /// unconstrained 1/beta (time is free)
+    /// Sign convention:
+    ///   positive - outward moving particle
+    ///   negative - inward moving particle
+    float freeInverseBeta() const { return freeInverseBeta_; };
+    float freeInverseBetaErr() const { return freeInverseBetaErr_; };
+    void setFreeInverseBeta(const float iBeta) { freeInverseBeta_ = iBeta; };
+    void setFreeInverseBetaErr(const float iBetaErr) { freeInverseBetaErr_ = iBetaErr; };
 
-      /// time of arrival at the IP for the Beta=1 hypothesis
-      float timeAtIpInOut_;
-      float timeAtIpInOutErr_;
-      float timeAtIpOutIn_;
-      float timeAtIpOutInErr_;
-      
+    /// time of arrival at the IP for the Beta=1 hypothesis
+    ///  a) particle is moving from inside out
+    float timeAtIpInOut() const { return timeAtIpInOut_; };
+    float timeAtIpInOutErr() const { return timeAtIpInOutErr_; };
+    void setTimeAtIpInOut(const float timeIp) { timeAtIpInOut_ = timeIp; };
+    void setTimeAtIpInOutErr(const float timeErr) { timeAtIpInOutErr_ = timeErr; };
+    ///  b) particle is moving from outside in
+    float timeAtIpOutIn() const { return timeAtIpOutIn_; };
+    float timeAtIpOutInErr() const { return timeAtIpOutInErr_; };
+    void setTimeAtIpOutIn(const float timeIp) { timeAtIpOutIn_ = timeIp; };
+    void setTimeAtIpOutInErr(const float timeErr) { timeAtIpOutInErr_ = timeErr; };
+
+    /// direction estimation based on time dispersion
+    Direction direction() const {
+      if (nDof_ < 2)
+        return Undefined;
+      if (timeAtIpInOutErr_ > timeAtIpOutInErr_)
+        return OutsideIn;
+      return InsideOut;
+    }
+
+  private:
+    /// number of measurements used in timing calculation
+    int nDof_;
+
+    /// 1/beta for prompt particle hypothesis
+    float inverseBeta_;
+    float inverseBetaErr_;
+
+    /// unconstrained 1/beta (time is free)
+    float freeInverseBeta_;
+    float freeInverseBetaErr_;
+
+    /// time of arrival at the IP for the Beta=1 hypothesis
+    float timeAtIpInOut_;
+    float timeAtIpInOutErr_;
+    float timeAtIpOutIn_;
+    float timeAtIpOutInErr_;
   };
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/MuonReco/interface/MuonTimeExtraFwd.h
+++ b/DataFormats/MuonReco/interface/MuonTimeExtraFwd.h
@@ -10,7 +10,7 @@ namespace reco {
   class MuonTimeExtra;
   /// collection of MuonTimeExtra objects
 
-/*  typedef std::vector<MuonTimeExtra> MuonTimeExtraCollection;
+  /*  typedef std::vector<MuonTimeExtra> MuonTimeExtraCollection;
   /// presistent reference to a MuonTimeExtra object
   typedef edm::Ref<MuonTimeExtraCollection> MuonTimeExtraRef;
   /// references to a MuonTimeExtra collection
@@ -19,9 +19,9 @@ namespace reco {
   typedef edm::RefVector<MuonTimeExtraCollection> MuonTimeExtraRefVector;
   /// iterator over a vector of references to MuonTimeExtra objects all in the same collection
   typedef MuonTimeExtraRefVector::iterator muontimeextra_iterator; */
-  
+
   typedef edm::ValueMap<reco::MuonTimeExtra> MuonTimeExtraMap;
 
-}
+}  // namespace reco
 
 #endif

--- a/DataFormats/MuonReco/interface/MuonTimeExtraMap.h
+++ b/DataFormats/MuonReco/interface/MuonTimeExtraMap.h
@@ -9,7 +9,7 @@
 
 namespace reco {
 
-typedef edm::ValueMap<reco::MuonTimeExtra> MuonTimeExtraMap;
+  typedef edm::ValueMap<reco::MuonTimeExtra> MuonTimeExtraMap;
 
 }
 

--- a/DataFormats/MuonReco/interface/MuonToMuonMap.h
+++ b/DataFormats/MuonReco/interface/MuonToMuonMap.h
@@ -6,7 +6,7 @@
 
 namespace reco {
 
-typedef edm::ValueMap<reco::MuonRef> MuonToMuonMap;
+  typedef edm::ValueMap<reco::MuonRef> MuonToMuonMap;
 
 }
 

--- a/DataFormats/MuonReco/interface/MuonTrackLinks.h
+++ b/DataFormats/MuonReco/interface/MuonTrackLinks.h
@@ -14,43 +14,39 @@
 namespace reco {
 
   class MuonTrackLinks {
-
   public:
-
     /// Default Constructor
-    MuonTrackLinks(){}
-    
+    MuonTrackLinks() {}
+
     /// Constructor
-    MuonTrackLinks(reco::TrackRef tk, reco::TrackRef sta, reco::TrackRef glb):
-      theTkTrack(tk),theStaTrack(sta),theGlbTrack(glb){}
+    MuonTrackLinks(reco::TrackRef tk, reco::TrackRef sta, reco::TrackRef glb)
+        : theTkTrack(tk), theStaTrack(sta), theGlbTrack(glb) {}
 
     /// Destructor
     virtual ~MuonTrackLinks(){};
 
     // Operations
-  
+
     /// get the tracker's track which match with the stand alone muon tracks
-    inline reco::TrackRef trackerTrack() const {return theTkTrack;}
+    inline reco::TrackRef trackerTrack() const { return theTkTrack; }
 
     /// get the track built with the muon spectrometer alone
-    inline reco::TrackRef standAloneTrack() const {return theStaTrack;}
+    inline reco::TrackRef standAloneTrack() const { return theStaTrack; }
 
     /// get the combined track
-    inline reco::TrackRef globalTrack() const {return theGlbTrack;}
+    inline reco::TrackRef globalTrack() const { return theGlbTrack; }
 
     /// set the ref to tracker's track
-    inline void setTrackerTrack(reco::TrackRef tk) {theTkTrack = tk;}
+    inline void setTrackerTrack(reco::TrackRef tk) { theTkTrack = tk; }
 
     /// set the ref to stand alone track
-    inline void setStandAloneTrack(reco::TrackRef sta) {theStaTrack = sta;}
+    inline void setStandAloneTrack(reco::TrackRef sta) { theStaTrack = sta; }
 
     /// set the ref to combined track
-    inline void setGlobalTrack(reco::TrackRef glb) {theGlbTrack = glb;}
-  
-  protected:
+    inline void setGlobalTrack(reco::TrackRef glb) { theGlbTrack = glb; }
 
+  protected:
   private:
-    
     /// ref to tracker's track which match with the stand alone muon tracks
     reco::TrackRef theTkTrack;
 
@@ -60,6 +56,5 @@ namespace reco {
     /// ref to the combined track
     reco::TrackRef theGlbTrack;
   };
-}
+}  // namespace reco
 #endif
-

--- a/DataFormats/MuonReco/src/CaloMuon.cc
+++ b/DataFormats/MuonReco/src/CaloMuon.cc
@@ -2,7 +2,6 @@
 using namespace reco;
 
 CaloMuon::CaloMuon() {
-   energyValid_  = false;
-   caloCompatibility_ = -9999.;
+  energyValid_ = false;
+  caloCompatibility_ = -9999.;
 }
-

--- a/DataFormats/MuonReco/src/DYTInfo.cc
+++ b/DataFormats/MuonReco/src/DYTInfo.cc
@@ -1,19 +1,17 @@
 #include "DataFormats/MuonReco/interface/DYTInfo.h"
 using namespace reco;
 
-DYTInfo::DYTInfo() 
-{
+DYTInfo::DYTInfo() {
   NStUsed_ = 0;
-  DYTEstimators_.assign (4,-1);
-  UsedStations_.assign (4, false);
-  IdChambers_.assign (4,DetId());
-  Thresholds_.assign (4,-1);
+  DYTEstimators_.assign(4, -1);
+  UsedStations_.assign(4, false);
+  IdChambers_.assign(4, DetId());
+  Thresholds_.assign(4, -1);
 }
 
 DYTInfo::~DYTInfo() {}
 
-void DYTInfo::CopyFrom(const DYTInfo &dytInfo)
-{
+void DYTInfo::CopyFrom(const DYTInfo &dytInfo) {
   setNStUsed(dytInfo.NStUsed());
   setDYTEstimators(dytInfo.DYTEstimators());
   setUsedStations(dytInfo.UsedStations());

--- a/DataFormats/MuonReco/src/EmulatedME0Segment.cc
+++ b/DataFormats/MuonReco/src/EmulatedME0Segment.cc
@@ -7,10 +7,11 @@
 #include <DataFormats/MuonReco/interface/EmulatedME0Segment.h>
 #include <iostream>
 
-EmulatedME0Segment::EmulatedME0Segment(const LocalPoint& origin,  	const LocalVector& direction, const AlgebraicSymMatrix& errors, const double chi2) : 
-  theOrigin(origin), 
-  theLocalDirection(direction), theCovMatrix(errors), theChi2(chi2) {
-}
+EmulatedME0Segment::EmulatedME0Segment(const LocalPoint& origin,
+                                       const LocalVector& direction,
+                                       const AlgebraicSymMatrix& errors,
+                                       const double chi2)
+    : theOrigin(origin), theLocalDirection(direction), theCovMatrix(errors), theChi2(chi2) {}
 
 EmulatedME0Segment::~EmulatedME0Segment() {}
 
@@ -19,56 +20,47 @@ LocalError EmulatedME0Segment::localPositionError() const {
 }
 
 LocalError EmulatedME0Segment::localDirectionError() const {
-  return LocalError(theCovMatrix[0][0], theCovMatrix[0][1], theCovMatrix[1][1]); 
+  return LocalError(theCovMatrix[0][0], theCovMatrix[0][1], theCovMatrix[1][1]);
 }
-
 
 AlgebraicVector EmulatedME0Segment::parameters() const {
   // For consistency with DT and what we require for the TrackingRecHit interface,
   // the order of the parameters in the returned vector should be (dx/dz, dy/dz, x, z)
-  
+
   AlgebraicVector result(4);
 
-  result[0] = theLocalDirection.x()/theLocalDirection.z();
-  result[1] = theLocalDirection.y()/theLocalDirection.z();    
+  result[0] = theLocalDirection.x() / theLocalDirection.z();
+  result[1] = theLocalDirection.y() / theLocalDirection.z();
   result[2] = theOrigin.x();
   result[3] = theOrigin.y();
 
   return result;
 }
 
-namespace{
-  AlgebraicMatrix createStaticMatrix(){
-    AlgebraicMatrix m( 4, 5, 0);
+namespace {
+  AlgebraicMatrix createStaticMatrix() {
+    AlgebraicMatrix m(4, 5, 0);
     m[0][1] = 1;
     m[1][2] = 1;
     m[2][3] = 1;
     m[3][4] = 1;
     return m;
   }
-};
+};  // namespace
 
-namespace{
+namespace {
   const AlgebraicMatrix theProjectionMatrix = createStaticMatrix();
 };
 
-AlgebraicMatrix EmulatedME0Segment::projectionMatrix() const {
-  return theProjectionMatrix;
-}
-
-
+AlgebraicMatrix EmulatedME0Segment::projectionMatrix() const { return theProjectionMatrix; }
 
 //
-void EmulatedME0Segment::print() const {
-  std::cout << *this << std::endl;
-}
+void EmulatedME0Segment::print() const { std::cout << *this << std::endl; }
 
 std::ostream& operator<<(std::ostream& os, const EmulatedME0Segment& seg) {
-  os << "EmulatedME0Segment: local pos = " << seg.localPosition() << 
-    " posErr = (" << sqrt(seg.localPositionError().xx())<<","<<sqrt(seg.localPositionError().yy())<<
-    "0,)\n"<<
-    "            dir = " << seg.localDirection() <<
-    " dirErr = (" << sqrt(seg.localDirectionError().xx())<<","<<sqrt(seg.localDirectionError().yy())<<
-    "0,)\n";
-  return os;  
+  os << "EmulatedME0Segment: local pos = " << seg.localPosition() << " posErr = ("
+     << sqrt(seg.localPositionError().xx()) << "," << sqrt(seg.localPositionError().yy()) << "0,)\n"
+     << "            dir = " << seg.localDirection() << " dirErr = (" << sqrt(seg.localDirectionError().xx()) << ","
+     << sqrt(seg.localDirectionError().yy()) << "0,)\n";
+  return os;
 }

--- a/DataFormats/MuonReco/src/ME0Muon.cc
+++ b/DataFormats/MuonReco/src/ME0Muon.cc
@@ -6,12 +6,9 @@
 #include "DataFormats/MuonReco/interface/ME0Muon.h"
 using namespace reco;
 
-ME0Muon::ME0Muon() {
-}
+ME0Muon::ME0Muon() {}
 
-bool ME0Muon::overlap( const Candidate & c ) const {
-  const RecoCandidate * o = dynamic_cast<const RecoCandidate *>( & c );
-  return ( o != nullptr && 
-	   ( checkOverlap( track(), o->track() ))
-	   );
+bool ME0Muon::overlap(const Candidate &c) const {
+  const RecoCandidate *o = dynamic_cast<const RecoCandidate *>(&c);
+  return (o != nullptr && (checkOverlap(track(), o->track())));
 }

--- a/DataFormats/MuonReco/src/Muon.cc
+++ b/DataFormats/MuonReco/src/Muon.cc
@@ -6,53 +6,45 @@
 
 using namespace reco;
 
-Muon::Muon(  Charge q, const LorentzVector & p4, const Point & vtx ) :
-  RecoCandidate( q, p4, vtx, -13 * q ) {
-     energyValid_  = false;
-     matchesValid_ = false;
-     isolationValid_ = false;
-     pfIsolationValid_ = false;
-     qualityValid_ = false;
-     caloCompatibility_ = -9999.;
-     type_ = 0;
-     bestTunePTrackType_ = reco::Muon::None;
-     bestTrackType_ = reco::Muon::None;
-     selectors_ = 0;
+Muon::Muon(Charge q, const LorentzVector& p4, const Point& vtx) : RecoCandidate(q, p4, vtx, -13 * q) {
+  energyValid_ = false;
+  matchesValid_ = false;
+  isolationValid_ = false;
+  pfIsolationValid_ = false;
+  qualityValid_ = false;
+  caloCompatibility_ = -9999.;
+  type_ = 0;
+  bestTunePTrackType_ = reco::Muon::None;
+  bestTrackType_ = reco::Muon::None;
+  selectors_ = 0;
 }
 
 Muon::Muon() {
-   energyValid_  = false;
-   matchesValid_ = false;
-   isolationValid_ = false;
-   pfIsolationValid_ = false;
-   qualityValid_ = false;
-   caloCompatibility_ = -9999.;
-   type_ = 0;
-   bestTrackType_ = reco::Muon::None;
-   bestTunePTrackType_ = reco::Muon::None;
-   selectors_ = 0;
+  energyValid_ = false;
+  matchesValid_ = false;
+  isolationValid_ = false;
+  pfIsolationValid_ = false;
+  qualityValid_ = false;
+  caloCompatibility_ = -9999.;
+  type_ = 0;
+  bestTrackType_ = reco::Muon::None;
+  bestTunePTrackType_ = reco::Muon::None;
+  selectors_ = 0;
 }
 
-bool Muon::overlap( const Candidate & c ) const {
-  const RecoCandidate * o = dynamic_cast<const RecoCandidate *>( & c );
-  return ( o != nullptr && 
-	   ( checkOverlap( track(), o->track() ) ||
-	     checkOverlap( standAloneMuon(), o->standAloneMuon() ) ||
-	     checkOverlap( combinedMuon(), o->combinedMuon() ) ||
-	     checkOverlap( standAloneMuon(), o->track() ) ||
-	     checkOverlap( combinedMuon(), o->track() ) )
-	   );
+bool Muon::overlap(const Candidate& c) const {
+  const RecoCandidate* o = dynamic_cast<const RecoCandidate*>(&c);
+  return (o != nullptr && (checkOverlap(track(), o->track()) || checkOverlap(standAloneMuon(), o->standAloneMuon()) ||
+                           checkOverlap(combinedMuon(), o->combinedMuon()) ||
+                           checkOverlap(standAloneMuon(), o->track()) || checkOverlap(combinedMuon(), o->track())));
 }
 
-Muon * Muon::clone() const {
-  return new Muon( * this );
-}
+Muon* Muon::clone() const { return new Muon(*this); }
 
-int Muon::numberOfChambersCSCorDT() const
-{
+int Muon::numberOfChambersCSCorDT() const {
   int total = 0;
   int nAll = numberOfChambers();
-  for (int iC = 0; iC < nAll; ++iC){
+  for (int iC = 0; iC < nAll; ++iC) {
     if (matches()[iC].detector() == MuonSubdetId::CSC || matches()[iC].detector() == MuonSubdetId::DT)
       total++;
   }
@@ -60,902 +52,967 @@ int Muon::numberOfChambersCSCorDT() const
   return total;
 }
 
-int Muon::numberOfMatches( ArbitrationType type ) const
-{
-   int matches(0);
-   for( std::vector<MuonChamberMatch>::const_iterator chamberMatch = muMatches_.begin();
-         chamberMatch != muMatches_.end(); chamberMatch++ )
-   {
-      if(type == RPCHitAndTrackArbitration) {
-         if(chamberMatch->rpcMatches.empty()) continue;
-         matches += chamberMatch->rpcMatches.size();
-         continue;
-      }
-      if(type == ME0SegmentAndTrackArbitration) {
-         if(chamberMatch->me0Matches.empty()) continue;
-	  matches += chamberMatch->me0Matches.size();
-	continue;
-      }
-      if(type == GEMSegmentAndTrackArbitration) {
-         if(chamberMatch->gemMatches.empty()) continue;
-	  matches += chamberMatch->gemMatches.size();
-	continue;
-      }
-
-      if(chamberMatch->segmentMatches.empty()) continue;
-      if(type == NoArbitration) {
-         matches++;
-         continue;
-      }
-      
-      for( std::vector<MuonSegmentMatch>::const_iterator segmentMatch = chamberMatch->segmentMatches.begin();
-            segmentMatch != chamberMatch->segmentMatches.end(); segmentMatch++ )
-      {
-         if(type == SegmentArbitration)
-            if(segmentMatch->isMask(MuonSegmentMatch::BestInChamberByDR)) {
-               matches++;
-               break;
-            }
-         if(type == SegmentAndTrackArbitration)
-            if(segmentMatch->isMask(MuonSegmentMatch::BestInChamberByDR) &&
-                  segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByDR)) {
-               matches++;
-               break;
-            }
-	 if(type == SegmentAndTrackArbitrationCleaned)
-	   if(segmentMatch->isMask(MuonSegmentMatch::BestInChamberByDR) &&
-	         segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByDR) && 
-	         segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByCleaning)) {
-	     matches++;
-	     break;
-	   }
-      }
-   }
-
-   return matches;
-}
-
-int Muon::numberOfMatchedStations( ArbitrationType type ) const
-{
-   int stations(0);
-
-   unsigned int theStationMask = stationMask(type);
-   // eight stations, eight bits
-   for(int it = 0; it < 8; ++it)
-      if (theStationMask & 1<<it)
-         ++stations;
-
-   return stations;
-}
-
-unsigned int Muon::expectedNnumberOfMatchedStations( float minDistanceFromEdge ) const 
-{
-  unsigned int stationMask = 0;
-  for( auto& chamberMatch : muMatches_ )
-    {
-      if (chamberMatch.detector()!=MuonSubdetId::DT && chamberMatch.detector()!=MuonSubdetId::CSC) continue;
-      float edgeX = chamberMatch.edgeX;
-      float edgeY = chamberMatch.edgeY;
-      // check we if the trajectory is well within the acceptance
-      if(edgeX<0 && fabs(edgeX)>fabs(minDistanceFromEdge) &&
-	 edgeY<0 && fabs(edgeY)>fabs(minDistanceFromEdge))
-	stationMask |= 1<<( (chamberMatch.station()-1)+4*(chamberMatch.detector()-1) );
+int Muon::numberOfMatches(ArbitrationType type) const {
+  int matches(0);
+  for (std::vector<MuonChamberMatch>::const_iterator chamberMatch = muMatches_.begin();
+       chamberMatch != muMatches_.end();
+       chamberMatch++) {
+    if (type == RPCHitAndTrackArbitration) {
+      if (chamberMatch->rpcMatches.empty())
+        continue;
+      matches += chamberMatch->rpcMatches.size();
+      continue;
     }
+    if (type == ME0SegmentAndTrackArbitration) {
+      if (chamberMatch->me0Matches.empty())
+        continue;
+      matches += chamberMatch->me0Matches.size();
+      continue;
+    }
+    if (type == GEMSegmentAndTrackArbitration) {
+      if (chamberMatch->gemMatches.empty())
+        continue;
+      matches += chamberMatch->gemMatches.size();
+      continue;
+    }
+
+    if (chamberMatch->segmentMatches.empty())
+      continue;
+    if (type == NoArbitration) {
+      matches++;
+      continue;
+    }
+
+    for (std::vector<MuonSegmentMatch>::const_iterator segmentMatch = chamberMatch->segmentMatches.begin();
+         segmentMatch != chamberMatch->segmentMatches.end();
+         segmentMatch++) {
+      if (type == SegmentArbitration)
+        if (segmentMatch->isMask(MuonSegmentMatch::BestInChamberByDR)) {
+          matches++;
+          break;
+        }
+      if (type == SegmentAndTrackArbitration)
+        if (segmentMatch->isMask(MuonSegmentMatch::BestInChamberByDR) &&
+            segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByDR)) {
+          matches++;
+          break;
+        }
+      if (type == SegmentAndTrackArbitrationCleaned)
+        if (segmentMatch->isMask(MuonSegmentMatch::BestInChamberByDR) &&
+            segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByDR) &&
+            segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByCleaning)) {
+          matches++;
+          break;
+        }
+    }
+  }
+
+  return matches;
+}
+
+int Muon::numberOfMatchedStations(ArbitrationType type) const {
+  int stations(0);
+
+  unsigned int theStationMask = stationMask(type);
+  // eight stations, eight bits
+  for (int it = 0; it < 8; ++it)
+    if (theStationMask & 1 << it)
+      ++stations;
+
+  return stations;
+}
+
+unsigned int Muon::expectedNnumberOfMatchedStations(float minDistanceFromEdge) const {
+  unsigned int stationMask = 0;
+  for (auto& chamberMatch : muMatches_) {
+    if (chamberMatch.detector() != MuonSubdetId::DT && chamberMatch.detector() != MuonSubdetId::CSC)
+      continue;
+    float edgeX = chamberMatch.edgeX;
+    float edgeY = chamberMatch.edgeY;
+    // check we if the trajectory is well within the acceptance
+    if (edgeX < 0 && fabs(edgeX) > fabs(minDistanceFromEdge) && edgeY < 0 && fabs(edgeY) > fabs(minDistanceFromEdge))
+      stationMask |= 1 << ((chamberMatch.station() - 1) + 4 * (chamberMatch.detector() - 1));
+  }
   unsigned int n = 0;
-  for(unsigned int i=0; i<8; ++i)
-    if (stationMask&(1<<i)) n++;
+  for (unsigned int i = 0; i < 8; ++i)
+    if (stationMask & (1 << i))
+      n++;
   return n;
 }
 
-unsigned int Muon::stationMask( ArbitrationType type ) const
-{
-   unsigned int totMask(0);
-   unsigned int curMask(0);
+unsigned int Muon::stationMask(ArbitrationType type) const {
+  unsigned int totMask(0);
+  unsigned int curMask(0);
 
-   for( std::vector<MuonChamberMatch>::const_iterator chamberMatch = muMatches_.begin();
-         chamberMatch != muMatches_.end(); chamberMatch++ )
-   {
-      if(type == RPCHitAndTrackArbitration) {
-	 if(chamberMatch->rpcMatches.empty()) continue;
+  for (std::vector<MuonChamberMatch>::const_iterator chamberMatch = muMatches_.begin();
+       chamberMatch != muMatches_.end();
+       chamberMatch++) {
+    if (type == RPCHitAndTrackArbitration) {
+      if (chamberMatch->rpcMatches.empty())
+        continue;
 
-	 RPCDetId rollId = chamberMatch->id.rawId();
-	 const int region    = rollId.region();
-	 int rpcIndex = 1; if (region!=0) rpcIndex = 2;
-
-         for( std::vector<MuonRPCHitMatch>::const_iterator rpcMatch = chamberMatch->rpcMatches.begin();
-               rpcMatch != chamberMatch->rpcMatches.end(); rpcMatch++ )
-         {
-            curMask = 1<<( (chamberMatch->station()-1)+4*(rpcIndex-1) );
-
-            // do not double count
-            if(!(totMask & curMask))
-               totMask += curMask;
-         }
-         continue;
-      }
-
-      if(chamberMatch->segmentMatches.empty()) continue;
-      if(type == NoArbitration) {
-         curMask = 1<<( (chamberMatch->station()-1)+4*(chamberMatch->detector()-1) );
-         // do not double count
-         if(!(totMask & curMask))
-            totMask += curMask;
-         continue;
-      }
-
-      for( std::vector<MuonSegmentMatch>::const_iterator segmentMatch = chamberMatch->segmentMatches.begin();
-            segmentMatch != chamberMatch->segmentMatches.end(); segmentMatch++ )
-      {
-         if(type == SegmentArbitration)
-            if(segmentMatch->isMask(MuonSegmentMatch::BestInStationByDR)) {
-               curMask = 1<<( (chamberMatch->station()-1)+4*(chamberMatch->detector()-1) );
-               // do not double count
-               if(!(totMask & curMask))
-                  totMask += curMask;
-               break;
-            }
-         if(type == SegmentAndTrackArbitration)
-            if(segmentMatch->isMask(MuonSegmentMatch::BestInStationByDR) &&
-                  segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByDR)) {
-               curMask = 1<<( (chamberMatch->station()-1)+4*(chamberMatch->detector()-1) );
-               // do not double count
-               if(!(totMask & curMask))
-                  totMask += curMask;
-               break;
-            }
-	 if(type == SegmentAndTrackArbitrationCleaned)
-            if(segmentMatch->isMask(MuonSegmentMatch::BestInStationByDR) &&
-	          segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByDR) &&
-	          segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByCleaning)) {
-               curMask = 1<<( (chamberMatch->station()-1)+4*(chamberMatch->detector()-1) );
-               // do not double count
-               if(!(totMask & curMask))
-                  totMask += curMask;
-               break;
-            }
-      }
-   }
-
-   return totMask;
-}
-
-int Muon::numberOfMatchedRPCLayers( ArbitrationType type ) const
-{
-   int layers(0);
-
-   unsigned int theRPCLayerMask = RPClayerMask(type);
-   // maximum ten layers because of 6 layers in barrel and 3 (4) layers in each endcap before (after) upscope
-   for(int it = 0; it < 10; ++it)
-     if (theRPCLayerMask & 1<<it)
-       ++layers;
-
-   return layers;
-}
-
-unsigned int Muon::RPClayerMask( ArbitrationType type ) const
-{
-   unsigned int totMask(0);
-   unsigned int curMask(0);
-   for( std::vector<MuonChamberMatch>::const_iterator chamberMatch = muMatches_.begin();
-	 chamberMatch != muMatches_.end(); chamberMatch++ )
-   {
-      if(chamberMatch->rpcMatches.empty()) continue;
-	 
       RPCDetId rollId = chamberMatch->id.rawId();
       const int region = rollId.region();
+      int rpcIndex = 1;
+      if (region != 0)
+        rpcIndex = 2;
 
-      const int layer  = rollId.layer();
-      int rpcLayer = chamberMatch->station();
-      if (region==0) {
-	 rpcLayer = chamberMatch->station()-1 + chamberMatch->station()*layer;
-	 if ((chamberMatch->station()==2 && layer==2) || (chamberMatch->station()==4 && layer==1)) rpcLayer -= 1;
-      } else rpcLayer += 6;
-	 
-      for( std::vector<MuonRPCHitMatch>::const_iterator rpcMatch = chamberMatch->rpcMatches.begin();
-	    rpcMatch != chamberMatch->rpcMatches.end(); rpcMatch++ )
-      {
-	 curMask = 1<<(rpcLayer-1);
+      for (std::vector<MuonRPCHitMatch>::const_iterator rpcMatch = chamberMatch->rpcMatches.begin();
+           rpcMatch != chamberMatch->rpcMatches.end();
+           rpcMatch++) {
+        curMask = 1 << ((chamberMatch->station() - 1) + 4 * (rpcIndex - 1));
 
-	 // do not double count
-	 if(!(totMask & curMask))
-	    totMask += curMask;
+        // do not double count
+        if (!(totMask & curMask))
+          totMask += curMask;
       }
-   }
-   
-   return totMask;
+      continue;
+    }
 
+    if (chamberMatch->segmentMatches.empty())
+      continue;
+    if (type == NoArbitration) {
+      curMask = 1 << ((chamberMatch->station() - 1) + 4 * (chamberMatch->detector() - 1));
+      // do not double count
+      if (!(totMask & curMask))
+        totMask += curMask;
+      continue;
+    }
+
+    for (std::vector<MuonSegmentMatch>::const_iterator segmentMatch = chamberMatch->segmentMatches.begin();
+         segmentMatch != chamberMatch->segmentMatches.end();
+         segmentMatch++) {
+      if (type == SegmentArbitration)
+        if (segmentMatch->isMask(MuonSegmentMatch::BestInStationByDR)) {
+          curMask = 1 << ((chamberMatch->station() - 1) + 4 * (chamberMatch->detector() - 1));
+          // do not double count
+          if (!(totMask & curMask))
+            totMask += curMask;
+          break;
+        }
+      if (type == SegmentAndTrackArbitration)
+        if (segmentMatch->isMask(MuonSegmentMatch::BestInStationByDR) &&
+            segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByDR)) {
+          curMask = 1 << ((chamberMatch->station() - 1) + 4 * (chamberMatch->detector() - 1));
+          // do not double count
+          if (!(totMask & curMask))
+            totMask += curMask;
+          break;
+        }
+      if (type == SegmentAndTrackArbitrationCleaned)
+        if (segmentMatch->isMask(MuonSegmentMatch::BestInStationByDR) &&
+            segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByDR) &&
+            segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByCleaning)) {
+          curMask = 1 << ((chamberMatch->station() - 1) + 4 * (chamberMatch->detector() - 1));
+          // do not double count
+          if (!(totMask & curMask))
+            totMask += curMask;
+          break;
+        }
+    }
+  }
+
+  return totMask;
 }
 
-unsigned int Muon::stationGapMaskDistance( float distanceCut ) const
-{
-   unsigned int totMask(0);
-   for( int stationIndex = 1; stationIndex < 5; stationIndex++ )
-   {
-      for( int detectorIndex = 1; detectorIndex < 4; detectorIndex++ )
-      {
-         unsigned int curMask(0);
-         for( std::vector<MuonChamberMatch>::const_iterator chamberMatch = muMatches_.begin();
-               chamberMatch != muMatches_.end(); chamberMatch++ )
-         {
-            if(!(chamberMatch->station()==stationIndex && chamberMatch->detector()==detectorIndex)) continue;
+int Muon::numberOfMatchedRPCLayers(ArbitrationType type) const {
+  int layers(0);
 
-            float edgeX = chamberMatch->edgeX;
-            float edgeY = chamberMatch->edgeY;
-            if(edgeX<0 && fabs(edgeX)>fabs(distanceCut) &&
-                  edgeY<0 && fabs(edgeY)>fabs(distanceCut)) // inside the chamber so negates all gaps for this station
-            {
-               curMask = 0;
-               break;
-            }
-            if( ( fabs(edgeX) < fabs(distanceCut) && edgeY < fabs(distanceCut) ) ||
-		( fabs(edgeY) < fabs(distanceCut) && edgeX < fabs(distanceCut) ) ) // inside gap
-               curMask = 1<<( (stationIndex-1)+4*(detectorIndex-1) );
-         }
+  unsigned int theRPCLayerMask = RPClayerMask(type);
+  // maximum ten layers because of 6 layers in barrel and 3 (4) layers in each endcap before (after) upscope
+  for (int it = 0; it < 10; ++it)
+    if (theRPCLayerMask & 1 << it)
+      ++layers;
 
-         totMask += curMask; // add to total mask
-      }
-   }
-
-   return totMask;
+  return layers;
 }
 
-unsigned int Muon::stationGapMaskPull( float sigmaCut ) const
-{
-   unsigned int totMask(0);
-   for( int stationIndex = 1; stationIndex < 5; stationIndex++ )
-   {
-      for( int detectorIndex = 1; detectorIndex < 4; detectorIndex++ )
-      {
-         unsigned int curMask(0);
-         for( std::vector<MuonChamberMatch>::const_iterator chamberMatch = muMatches_.begin();
-               chamberMatch != muMatches_.end(); chamberMatch++ )
-         {
-            if(!(chamberMatch->station()==stationIndex && chamberMatch->detector()==detectorIndex)) continue;
+unsigned int Muon::RPClayerMask(ArbitrationType type) const {
+  unsigned int totMask(0);
+  unsigned int curMask(0);
+  for (std::vector<MuonChamberMatch>::const_iterator chamberMatch = muMatches_.begin();
+       chamberMatch != muMatches_.end();
+       chamberMatch++) {
+    if (chamberMatch->rpcMatches.empty())
+      continue;
 
-            float edgeX = chamberMatch->edgeX;
-            float edgeY = chamberMatch->edgeY;
-            float xErr  = chamberMatch->xErr+0.000001; // protect against division by zero later
-            float yErr  = chamberMatch->yErr+0.000001; // protect against division by zero later
-            if(edgeX<0 && fabs(edgeX/xErr)>fabs(sigmaCut) &&
-                  edgeY<0 && fabs(edgeY/yErr)>fabs(sigmaCut)) // inside the chamber so negates all gaps for this station
-            {
-               curMask = 0;
-               break;
-            }
-            if( ( fabs(edgeX/xErr) < fabs(sigmaCut) && edgeY/yErr < fabs(sigmaCut) ) ||
-		( fabs(edgeY/yErr) < fabs(sigmaCut) && edgeX/xErr < fabs(sigmaCut) ) ) // inside gap
-               curMask = 1<<((stationIndex-1)+4*(detectorIndex-1));
-         }
+    RPCDetId rollId = chamberMatch->id.rawId();
+    const int region = rollId.region();
 
-         totMask += curMask; // add to total mask
-      }
-   }
+    const int layer = rollId.layer();
+    int rpcLayer = chamberMatch->station();
+    if (region == 0) {
+      rpcLayer = chamberMatch->station() - 1 + chamberMatch->station() * layer;
+      if ((chamberMatch->station() == 2 && layer == 2) || (chamberMatch->station() == 4 && layer == 1))
+        rpcLayer -= 1;
+    } else
+      rpcLayer += 6;
 
-   return totMask;
+    for (std::vector<MuonRPCHitMatch>::const_iterator rpcMatch = chamberMatch->rpcMatches.begin();
+         rpcMatch != chamberMatch->rpcMatches.end();
+         rpcMatch++) {
+      curMask = 1 << (rpcLayer - 1);
+
+      // do not double count
+      if (!(totMask & curMask))
+        totMask += curMask;
+    }
+  }
+
+  return totMask;
 }
 
-int Muon::nDigisInStation( int station, int muonSubdetId ) const
-{
+unsigned int Muon::stationGapMaskDistance(float distanceCut) const {
+  unsigned int totMask(0);
+  for (int stationIndex = 1; stationIndex < 5; stationIndex++) {
+    for (int detectorIndex = 1; detectorIndex < 4; detectorIndex++) {
+      unsigned int curMask(0);
+      for (std::vector<MuonChamberMatch>::const_iterator chamberMatch = muMatches_.begin();
+           chamberMatch != muMatches_.end();
+           chamberMatch++) {
+        if (!(chamberMatch->station() == stationIndex && chamberMatch->detector() == detectorIndex))
+          continue;
+
+        float edgeX = chamberMatch->edgeX;
+        float edgeY = chamberMatch->edgeY;
+        if (edgeX < 0 && fabs(edgeX) > fabs(distanceCut) && edgeY < 0 &&
+            fabs(edgeY) > fabs(distanceCut))  // inside the chamber so negates all gaps for this station
+        {
+          curMask = 0;
+          break;
+        }
+        if ((fabs(edgeX) < fabs(distanceCut) && edgeY < fabs(distanceCut)) ||
+            (fabs(edgeY) < fabs(distanceCut) && edgeX < fabs(distanceCut)))  // inside gap
+          curMask = 1 << ((stationIndex - 1) + 4 * (detectorIndex - 1));
+      }
+
+      totMask += curMask;  // add to total mask
+    }
+  }
+
+  return totMask;
+}
+
+unsigned int Muon::stationGapMaskPull(float sigmaCut) const {
+  unsigned int totMask(0);
+  for (int stationIndex = 1; stationIndex < 5; stationIndex++) {
+    for (int detectorIndex = 1; detectorIndex < 4; detectorIndex++) {
+      unsigned int curMask(0);
+      for (std::vector<MuonChamberMatch>::const_iterator chamberMatch = muMatches_.begin();
+           chamberMatch != muMatches_.end();
+           chamberMatch++) {
+        if (!(chamberMatch->station() == stationIndex && chamberMatch->detector() == detectorIndex))
+          continue;
+
+        float edgeX = chamberMatch->edgeX;
+        float edgeY = chamberMatch->edgeY;
+        float xErr = chamberMatch->xErr + 0.000001;  // protect against division by zero later
+        float yErr = chamberMatch->yErr + 0.000001;  // protect against division by zero later
+        if (edgeX < 0 && fabs(edgeX / xErr) > fabs(sigmaCut) && edgeY < 0 &&
+            fabs(edgeY / yErr) > fabs(sigmaCut))  // inside the chamber so negates all gaps for this station
+        {
+          curMask = 0;
+          break;
+        }
+        if ((fabs(edgeX / xErr) < fabs(sigmaCut) && edgeY / yErr < fabs(sigmaCut)) ||
+            (fabs(edgeY / yErr) < fabs(sigmaCut) && edgeX / xErr < fabs(sigmaCut)))  // inside gap
+          curMask = 1 << ((stationIndex - 1) + 4 * (detectorIndex - 1));
+      }
+
+      totMask += curMask;  // add to total mask
+    }
+  }
+
+  return totMask;
+}
+
+int Muon::nDigisInStation(int station, int muonSubdetId) const {
   int nDigis(0);
   std::map<int, int> me11DigisPerCh;
 
-  if ( muonSubdetId != MuonSubdetId::CSC  &&
-       muonSubdetId != MuonSubdetId::DT )
+  if (muonSubdetId != MuonSubdetId::CSC && muonSubdetId != MuonSubdetId::DT)
     return 0;
-	   
-  for ( auto & match : muMatches_ )
-    {
-      if ( match.detector() != muonSubdetId ||
-	   match.station()  != station )
-	continue;
-	  
-      int nDigisInCh = match.nDigisInRange;
-      
-      if( muonSubdetId == MuonSubdetId::CSC && station == 1 )
-	{
-	  CSCDetId id(match.id.rawId());
-	  
-	  int chamber = id.chamber();
-          int ring    = id.ring();
-	  
-	  if ( ring == 1 || ring == 4 ) // merge ME1/1a and ME1/1b digis
-	    {
-	      if( me11DigisPerCh.find(chamber) == me11DigisPerCh.end() )
-		me11DigisPerCh[chamber] = 0;
-	      
-	      me11DigisPerCh[chamber] += nDigisInCh;
-	      
-	      continue;
-	    }
-	}
-      
-      if( nDigisInCh > nDigis )
-	nDigis = nDigisInCh;
+
+  for (auto& match : muMatches_) {
+    if (match.detector() != muonSubdetId || match.station() != station)
+      continue;
+
+    int nDigisInCh = match.nDigisInRange;
+
+    if (muonSubdetId == MuonSubdetId::CSC && station == 1) {
+      CSCDetId id(match.id.rawId());
+
+      int chamber = id.chamber();
+      int ring = id.ring();
+
+      if (ring == 1 || ring == 4)  // merge ME1/1a and ME1/1b digis
+      {
+        if (me11DigisPerCh.find(chamber) == me11DigisPerCh.end())
+          me11DigisPerCh[chamber] = 0;
+
+        me11DigisPerCh[chamber] += nDigisInCh;
+
+        continue;
+      }
     }
 
-  for ( const auto & me11DigisInCh : me11DigisPerCh )
-    {  
-      int nMe11DigisInCh = me11DigisInCh.second;
-      if ( nMe11DigisInCh > nDigis )
-	nDigis = nMe11DigisInCh;
-    }
-  
+    if (nDigisInCh > nDigis)
+      nDigis = nDigisInCh;
+  }
+
+  for (const auto& me11DigisInCh : me11DigisPerCh) {
+    int nMe11DigisInCh = me11DigisInCh.second;
+    if (nMe11DigisInCh > nDigis)
+      nDigis = nMe11DigisInCh;
+  }
+
   return nDigis;
 }
 
-bool Muon::hasShowerInStation( int station, int muonSubdetId, int nDtDigisCut, int nCscDigisCut ) const
-{
-  if (muonSubdetId != MuonSubdetId::DT && muonSubdetId != MuonSubdetId::CSC) return false;
+bool Muon::hasShowerInStation(int station, int muonSubdetId, int nDtDigisCut, int nCscDigisCut) const {
+  if (muonSubdetId != MuonSubdetId::DT && muonSubdetId != MuonSubdetId::CSC)
+    return false;
   auto nDigisCut = muonSubdetId == MuonSubdetId::DT ? nDtDigisCut : nCscDigisCut;
 
-  return nDigisInStation(station,muonSubdetId) >= nDigisCut ;   
+  return nDigisInStation(station, muonSubdetId) >= nDigisCut;
 }
 
-int Muon::numberOfShowers( int nDtDigisCut, int nCscDigisCut ) const
-{
+int Muon::numberOfShowers(int nDtDigisCut, int nCscDigisCut) const {
   int nShowers = 0;
-  for ( int station = 1; station < 5; ++station )
-    {
-      if ( hasShowerInStation(station,MuonSubdetId::DT,nDtDigisCut,nCscDigisCut) )
-	nShowers++;
-      if ( hasShowerInStation(station,MuonSubdetId::CSC,nDtDigisCut,nCscDigisCut) )
-	nShowers++;
-    }
+  for (int station = 1; station < 5; ++station) {
+    if (hasShowerInStation(station, MuonSubdetId::DT, nDtDigisCut, nCscDigisCut))
+      nShowers++;
+    if (hasShowerInStation(station, MuonSubdetId::CSC, nDtDigisCut, nCscDigisCut))
+      nShowers++;
+  }
 
   return nShowers;
 }
 
-int Muon::numberOfSegments( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   int segments(0);
-   for( std::vector<MuonChamberMatch>::const_iterator chamberMatch = muMatches_.begin();
-         chamberMatch != muMatches_.end(); chamberMatch++ )
-   {
-      if(chamberMatch->segmentMatches.empty()) continue;
-      if(!(chamberMatch->station()==station && chamberMatch->detector()==muonSubdetId)) continue;
+int Muon::numberOfSegments(int station, int muonSubdetId, ArbitrationType type) const {
+  int segments(0);
+  for (std::vector<MuonChamberMatch>::const_iterator chamberMatch = muMatches_.begin();
+       chamberMatch != muMatches_.end();
+       chamberMatch++) {
+    if (chamberMatch->segmentMatches.empty())
+      continue;
+    if (!(chamberMatch->station() == station && chamberMatch->detector() == muonSubdetId))
+      continue;
 
-      if(type == NoArbitration) {
-         segments += chamberMatch->segmentMatches.size();
-         continue;
+    if (type == NoArbitration) {
+      segments += chamberMatch->segmentMatches.size();
+      continue;
+    }
+
+    for (std::vector<MuonSegmentMatch>::const_iterator segmentMatch = chamberMatch->segmentMatches.begin();
+         segmentMatch != chamberMatch->segmentMatches.end();
+         segmentMatch++) {
+      if (type == SegmentArbitration)
+        if (segmentMatch->isMask(MuonSegmentMatch::BestInStationByDR)) {
+          segments++;
+          break;
+        }
+      if (type == SegmentAndTrackArbitration)
+        if (segmentMatch->isMask(MuonSegmentMatch::BestInStationByDR) &&
+            segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByDR)) {
+          segments++;
+          break;
+        }
+      if (type == SegmentAndTrackArbitrationCleaned)
+        if (segmentMatch->isMask(MuonSegmentMatch::BestInStationByDR) &&
+            segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByDR) &&
+            segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByCleaning)) {
+          segments++;
+          break;
+        }
+    }
+  }
+
+  return segments;
+}
+
+const std::vector<const MuonChamberMatch*> Muon::chambers(int station, int muonSubdetId) const {
+  std::vector<const MuonChamberMatch*> chambers;
+  for (std::vector<MuonChamberMatch>::const_iterator chamberMatch = muMatches_.begin();
+       chamberMatch != muMatches_.end();
+       chamberMatch++)
+    if (chamberMatch->station() == station && chamberMatch->detector() == muonSubdetId)
+      chambers.push_back(&(*chamberMatch));
+  return chambers;
+}
+
+std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> Muon::pair(
+    const std::vector<const MuonChamberMatch*>& chambers, ArbitrationType type) const {
+  MuonChamberMatch* m = nullptr;
+  MuonSegmentMatch* s = nullptr;
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair(m, s);
+
+  if (chambers.empty())
+    return chamberSegmentPair;
+  for (std::vector<const MuonChamberMatch*>::const_iterator chamberMatch = chambers.begin();
+       chamberMatch != chambers.end();
+       chamberMatch++) {
+    if ((*chamberMatch)->segmentMatches.empty())
+      continue;
+    if (type == NoArbitration)
+      return std::make_pair(*chamberMatch, &((*chamberMatch)->segmentMatches.front()));
+
+    for (std::vector<MuonSegmentMatch>::const_iterator segmentMatch = (*chamberMatch)->segmentMatches.begin();
+         segmentMatch != (*chamberMatch)->segmentMatches.end();
+         segmentMatch++) {
+      if (type == SegmentArbitration)
+        if (segmentMatch->isMask(MuonSegmentMatch::BestInStationByDR))
+          return std::make_pair(*chamberMatch, &(*segmentMatch));
+      if (type == SegmentAndTrackArbitration)
+        if (segmentMatch->isMask(MuonSegmentMatch::BestInStationByDR) &&
+            segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByDR))
+          return std::make_pair(*chamberMatch, &(*segmentMatch));
+      if (type == SegmentAndTrackArbitrationCleaned)
+        if (segmentMatch->isMask(MuonSegmentMatch::BestInStationByDR) &&
+            segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByDR) &&
+            segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByCleaning))
+          return std::make_pair(*chamberMatch, &(*segmentMatch));
+    }
+  }
+
+  return chamberSegmentPair;
+}
+
+float Muon::dX(int station, int muonSubdetId, ArbitrationType type) const {
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair =
+      pair(chambers(station, muonSubdetId), type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr)
+    return 999999;
+  if (!chamberSegmentPair.second->hasPhi())
+    return 999999;
+  return chamberSegmentPair.first->x - chamberSegmentPair.second->x;
+}
+
+float Muon::dY(int station, int muonSubdetId, ArbitrationType type) const {
+  if (station == 4 && muonSubdetId == MuonSubdetId::DT)
+    return 999999;  // no y information
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair =
+      pair(chambers(station, muonSubdetId), type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr)
+    return 999999;
+  if (!chamberSegmentPair.second->hasZed())
+    return 999999;
+  return chamberSegmentPair.first->y - chamberSegmentPair.second->y;
+}
+
+float Muon::dDxDz(int station, int muonSubdetId, ArbitrationType type) const {
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair =
+      pair(chambers(station, muonSubdetId), type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr)
+    return 999999;
+  if (!chamberSegmentPair.second->hasPhi())
+    return 999999;
+  return chamberSegmentPair.first->dXdZ - chamberSegmentPair.second->dXdZ;
+}
+
+float Muon::dDyDz(int station, int muonSubdetId, ArbitrationType type) const {
+  if (station == 4 && muonSubdetId == MuonSubdetId::DT)
+    return 999999;  // no y information
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair =
+      pair(chambers(station, muonSubdetId), type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr)
+    return 999999;
+  if (!chamberSegmentPair.second->hasZed())
+    return 999999;
+  return chamberSegmentPair.first->dYdZ - chamberSegmentPair.second->dYdZ;
+}
+
+float Muon::pullX(int station, int muonSubdetId, ArbitrationType type, bool includeSegmentError) const {
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair =
+      pair(chambers(station, muonSubdetId), type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr)
+    return 999999;
+  if (!chamberSegmentPair.second->hasPhi())
+    return 999999;
+  if (includeSegmentError)
+    return (chamberSegmentPair.first->x - chamberSegmentPair.second->x) /
+           sqrt(pow(chamberSegmentPair.first->xErr, 2) + pow(chamberSegmentPair.second->xErr, 2));
+  return (chamberSegmentPair.first->x - chamberSegmentPair.second->x) / chamberSegmentPair.first->xErr;
+}
+
+float Muon::pullY(int station, int muonSubdetId, ArbitrationType type, bool includeSegmentError) const {
+  if (station == 4 && muonSubdetId == MuonSubdetId::DT)
+    return 999999;  // no y information
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair =
+      pair(chambers(station, muonSubdetId), type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr)
+    return 999999;
+  if (!chamberSegmentPair.second->hasZed())
+    return 999999;
+  if (includeSegmentError)
+    return (chamberSegmentPair.first->y - chamberSegmentPair.second->y) /
+           sqrt(pow(chamberSegmentPair.first->yErr, 2) + pow(chamberSegmentPair.second->yErr, 2));
+  return (chamberSegmentPair.first->y - chamberSegmentPair.second->y) / chamberSegmentPair.first->yErr;
+}
+
+float Muon::pullDxDz(int station, int muonSubdetId, ArbitrationType type, bool includeSegmentError) const {
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair =
+      pair(chambers(station, muonSubdetId), type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr)
+    return 999999;
+  if (!chamberSegmentPair.second->hasPhi())
+    return 999999;
+  if (includeSegmentError)
+    return (chamberSegmentPair.first->dXdZ - chamberSegmentPair.second->dXdZ) /
+           sqrt(pow(chamberSegmentPair.first->dXdZErr, 2) + pow(chamberSegmentPair.second->dXdZErr, 2));
+  return (chamberSegmentPair.first->dXdZ - chamberSegmentPair.second->dXdZ) / chamberSegmentPair.first->dXdZErr;
+}
+
+float Muon::pullDyDz(int station, int muonSubdetId, ArbitrationType type, bool includeSegmentError) const {
+  if (station == 4 && muonSubdetId == MuonSubdetId::DT)
+    return 999999;  // no y information
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair =
+      pair(chambers(station, muonSubdetId), type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr)
+    return 999999;
+  if (!chamberSegmentPair.second->hasZed())
+    return 999999;
+  if (includeSegmentError)
+    return (chamberSegmentPair.first->dYdZ - chamberSegmentPair.second->dYdZ) /
+           sqrt(pow(chamberSegmentPair.first->dYdZErr, 2) + pow(chamberSegmentPair.second->dYdZErr, 2));
+  return (chamberSegmentPair.first->dYdZ - chamberSegmentPair.second->dYdZ) / chamberSegmentPair.first->dYdZErr;
+}
+
+float Muon::segmentX(int station, int muonSubdetId, ArbitrationType type) const {
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair =
+      pair(chambers(station, muonSubdetId), type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr)
+    return 999999;
+  if (!chamberSegmentPair.second->hasPhi())
+    return 999999;
+  return chamberSegmentPair.second->x;
+}
+
+float Muon::segmentY(int station, int muonSubdetId, ArbitrationType type) const {
+  if (station == 4 && muonSubdetId == MuonSubdetId::DT)
+    return 999999;  // no y information
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair =
+      pair(chambers(station, muonSubdetId), type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr)
+    return 999999;
+  if (!chamberSegmentPair.second->hasZed())
+    return 999999;
+  return chamberSegmentPair.second->y;
+}
+
+float Muon::segmentDxDz(int station, int muonSubdetId, ArbitrationType type) const {
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair =
+      pair(chambers(station, muonSubdetId), type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr)
+    return 999999;
+  if (!chamberSegmentPair.second->hasPhi())
+    return 999999;
+  return chamberSegmentPair.second->dXdZ;
+}
+
+float Muon::segmentDyDz(int station, int muonSubdetId, ArbitrationType type) const {
+  if (station == 4 && muonSubdetId == MuonSubdetId::DT)
+    return 999999;  // no y information
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair =
+      pair(chambers(station, muonSubdetId), type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr)
+    return 999999;
+  if (!chamberSegmentPair.second->hasZed())
+    return 999999;
+  return chamberSegmentPair.second->dYdZ;
+}
+
+float Muon::segmentXErr(int station, int muonSubdetId, ArbitrationType type) const {
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair =
+      pair(chambers(station, muonSubdetId), type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr)
+    return 999999;
+  if (!chamberSegmentPair.second->hasPhi())
+    return 999999;
+  return chamberSegmentPair.second->xErr;
+}
+
+float Muon::segmentYErr(int station, int muonSubdetId, ArbitrationType type) const {
+  if (station == 4 && muonSubdetId == MuonSubdetId::DT)
+    return 999999;  // no y information
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair =
+      pair(chambers(station, muonSubdetId), type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr)
+    return 999999;
+  if (!chamberSegmentPair.second->hasZed())
+    return 999999;
+  return chamberSegmentPair.second->yErr;
+}
+
+float Muon::segmentDxDzErr(int station, int muonSubdetId, ArbitrationType type) const {
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair =
+      pair(chambers(station, muonSubdetId), type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr)
+    return 999999;
+  if (!chamberSegmentPair.second->hasPhi())
+    return 999999;
+  return chamberSegmentPair.second->dXdZErr;
+}
+
+float Muon::segmentDyDzErr(int station, int muonSubdetId, ArbitrationType type) const {
+  if (station == 4 && muonSubdetId == MuonSubdetId::DT)
+    return 999999;  // no y information
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair =
+      pair(chambers(station, muonSubdetId), type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr)
+    return 999999;
+  if (!chamberSegmentPair.second->hasZed())
+    return 999999;
+  return chamberSegmentPair.second->dYdZErr;
+}
+
+float Muon::trackEdgeX(int station, int muonSubdetId, ArbitrationType type) const {
+  const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
+  if (muonChambers.empty())
+    return 999999;
+
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers, type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr) {
+    float dist = 999999;
+    float supVar = 999999;
+    for (std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
+         muonChamber != muonChambers.end();
+         ++muonChamber) {
+      float currDist = (*muonChamber)->dist();
+      if (currDist < dist) {
+        dist = currDist;
+        supVar = (*muonChamber)->edgeX;
       }
+    }
+    return supVar;
+  } else
+    return chamberSegmentPair.first->edgeX;
+}
 
-      for( std::vector<MuonSegmentMatch>::const_iterator segmentMatch = chamberMatch->segmentMatches.begin();
-            segmentMatch != chamberMatch->segmentMatches.end(); segmentMatch++ )
-      {
-         if(type == SegmentArbitration)
-            if(segmentMatch->isMask(MuonSegmentMatch::BestInStationByDR)) {
-               segments++;
-               break;
-            }
-         if(type == SegmentAndTrackArbitration)
-            if(segmentMatch->isMask(MuonSegmentMatch::BestInStationByDR) &&
-                  segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByDR)) {
-               segments++;
-               break;
-            }
-	 if(type == SegmentAndTrackArbitrationCleaned)
-            if(segmentMatch->isMask(MuonSegmentMatch::BestInStationByDR) &&
-                  segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByDR) &&
-	          segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByCleaning)) {
-               segments++;
-               break;
-            }
+float Muon::trackEdgeY(int station, int muonSubdetId, ArbitrationType type) const {
+  const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
+  if (muonChambers.empty())
+    return 999999;
+
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers, type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr) {
+    float dist = 999999;
+    float supVar = 999999;
+    for (std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
+         muonChamber != muonChambers.end();
+         ++muonChamber) {
+      float currDist = (*muonChamber)->dist();
+      if (currDist < dist) {
+        dist = currDist;
+        supVar = (*muonChamber)->edgeY;
       }
-   }
-
-   return segments;
+    }
+    return supVar;
+  } else
+    return chamberSegmentPair.first->edgeY;
 }
 
-const std::vector<const MuonChamberMatch*> Muon::chambers( int station, int muonSubdetId ) const
-{
-   std::vector<const MuonChamberMatch*> chambers;
-   for(std::vector<MuonChamberMatch>::const_iterator chamberMatch = muMatches_.begin();
-         chamberMatch != muMatches_.end(); chamberMatch++)
-      if(chamberMatch->station()==station && chamberMatch->detector()==muonSubdetId)
-         chambers.push_back(&(*chamberMatch));
-   return chambers;
-}
+float Muon::trackX(int station, int muonSubdetId, ArbitrationType type) const {
+  const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
+  if (muonChambers.empty())
+    return 999999;
 
-std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> Muon::pair( const std::vector<const MuonChamberMatch*> &chambers,
-     ArbitrationType type ) const
-{
-   MuonChamberMatch* m = nullptr;
-   MuonSegmentMatch* s = nullptr;
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair(m,s);
-
-   if(chambers.empty()) return chamberSegmentPair;
-   for( std::vector<const MuonChamberMatch*>::const_iterator chamberMatch = chambers.begin();
-         chamberMatch != chambers.end(); chamberMatch++ )
-   {
-      if((*chamberMatch)->segmentMatches.empty()) continue;
-      if(type == NoArbitration)
-         return std::make_pair(*chamberMatch, &((*chamberMatch)->segmentMatches.front()));
-
-      for( std::vector<MuonSegmentMatch>::const_iterator segmentMatch = (*chamberMatch)->segmentMatches.begin();
-            segmentMatch != (*chamberMatch)->segmentMatches.end(); segmentMatch++ )
-      {
-         if(type == SegmentArbitration)
-            if(segmentMatch->isMask(MuonSegmentMatch::BestInStationByDR)) 
-               return std::make_pair(*chamberMatch, &(*segmentMatch));
-         if(type == SegmentAndTrackArbitration)
-            if(segmentMatch->isMask(MuonSegmentMatch::BestInStationByDR) &&
-                  segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByDR))
-               return std::make_pair(*chamberMatch, &(*segmentMatch));
-	 if(type == SegmentAndTrackArbitrationCleaned)
-            if(segmentMatch->isMask(MuonSegmentMatch::BestInStationByDR) &&
-	          segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByDR) &&
-	          segmentMatch->isMask(MuonSegmentMatch::BelongsToTrackByCleaning))
-               return std::make_pair(*chamberMatch, &(*segmentMatch));
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers, type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr) {
+    float dist = 999999;
+    float supVar = 999999;
+    for (std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
+         muonChamber != muonChambers.end();
+         ++muonChamber) {
+      float currDist = (*muonChamber)->dist();
+      if (currDist < dist) {
+        dist = currDist;
+        supVar = (*muonChamber)->x;
       }
-   }
-
-   return chamberSegmentPair;
+    }
+    return supVar;
+  } else
+    return chamberSegmentPair.first->x;
 }
 
-float Muon::dX( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(chambers(station,muonSubdetId),type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) return 999999;
-   if(! chamberSegmentPair.second->hasPhi()) return 999999;
-   return chamberSegmentPair.first->x-chamberSegmentPair.second->x;
-}
+float Muon::trackY(int station, int muonSubdetId, ArbitrationType type) const {
+  const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
+  if (muonChambers.empty())
+    return 999999;
 
-float Muon::dY( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   if(station==4 && muonSubdetId==MuonSubdetId::DT) return 999999; // no y information
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(chambers(station,muonSubdetId),type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) return 999999;
-   if(! chamberSegmentPair.second->hasZed()) return 999999;
-   return chamberSegmentPair.first->y-chamberSegmentPair.second->y;
-}
-
-float Muon::dDxDz( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(chambers(station,muonSubdetId),type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) return 999999;
-   if(! chamberSegmentPair.second->hasPhi()) return 999999;
-   return chamberSegmentPair.first->dXdZ-chamberSegmentPair.second->dXdZ;
-}
-
-float Muon::dDyDz( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   if(station==4 && muonSubdetId==MuonSubdetId::DT) return 999999; // no y information
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(chambers(station,muonSubdetId),type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) return 999999;
-   if(! chamberSegmentPair.second->hasZed()) return 999999;
-   return chamberSegmentPair.first->dYdZ-chamberSegmentPair.second->dYdZ;
-}
-
-float Muon::pullX( int station, int muonSubdetId, ArbitrationType type, bool includeSegmentError ) const
-{
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(chambers(station,muonSubdetId),type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) return 999999;
-   if(! chamberSegmentPair.second->hasPhi()) return 999999;
-   if(includeSegmentError)
-      return (chamberSegmentPair.first->x-chamberSegmentPair.second->x)/sqrt(pow(chamberSegmentPair.first->xErr,2)+pow(chamberSegmentPair.second->xErr,2));
-   return (chamberSegmentPair.first->x-chamberSegmentPair.second->x)/chamberSegmentPair.first->xErr;
-}
-
-float Muon::pullY( int station, int muonSubdetId, ArbitrationType type, bool includeSegmentError) const
-{
-   if(station==4 && muonSubdetId==MuonSubdetId::DT) return 999999; // no y information
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(chambers(station,muonSubdetId),type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) return 999999;
-   if(! chamberSegmentPair.second->hasZed()) return 999999;
-   if(includeSegmentError)
-      return (chamberSegmentPair.first->y-chamberSegmentPair.second->y)/sqrt(pow(chamberSegmentPair.first->yErr,2)+pow(chamberSegmentPair.second->yErr,2));
-   return (chamberSegmentPair.first->y-chamberSegmentPair.second->y)/chamberSegmentPair.first->yErr;
-}
-
-float Muon::pullDxDz( int station, int muonSubdetId, ArbitrationType type, bool includeSegmentError ) const
-{
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(chambers(station,muonSubdetId),type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) return 999999;
-   if(! chamberSegmentPair.second->hasPhi()) return 999999;
-   if(includeSegmentError)
-      return (chamberSegmentPair.first->dXdZ-chamberSegmentPair.second->dXdZ)/sqrt(pow(chamberSegmentPair.first->dXdZErr,2)+pow(chamberSegmentPair.second->dXdZErr,2));
-   return (chamberSegmentPair.first->dXdZ-chamberSegmentPair.second->dXdZ)/chamberSegmentPair.first->dXdZErr;
-}
-
-float Muon::pullDyDz( int station, int muonSubdetId, ArbitrationType type, bool includeSegmentError ) const
-{
-   if(station==4 && muonSubdetId==MuonSubdetId::DT) return 999999; // no y information
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(chambers(station,muonSubdetId),type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) return 999999;
-   if(! chamberSegmentPair.second->hasZed()) return 999999;
-   if(includeSegmentError)
-      return (chamberSegmentPair.first->dYdZ-chamberSegmentPair.second->dYdZ)/sqrt(pow(chamberSegmentPair.first->dYdZErr,2)+pow(chamberSegmentPair.second->dYdZErr,2));
-   return (chamberSegmentPair.first->dYdZ-chamberSegmentPair.second->dYdZ)/chamberSegmentPair.first->dYdZErr;
-}
-
-float Muon::segmentX( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(chambers(station,muonSubdetId),type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) return 999999;
-   if(! chamberSegmentPair.second->hasPhi()) return 999999;
-   return chamberSegmentPair.second->x;
-}
-
-float Muon::segmentY( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   if(station==4 && muonSubdetId==MuonSubdetId::DT) return 999999; // no y information
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(chambers(station,muonSubdetId),type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) return 999999;
-   if(! chamberSegmentPair.second->hasZed()) return 999999;
-   return chamberSegmentPair.second->y;
-}
-
-float Muon::segmentDxDz( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(chambers(station,muonSubdetId),type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) return 999999;
-   if(! chamberSegmentPair.second->hasPhi()) return 999999;
-   return chamberSegmentPair.second->dXdZ;
-}
-
-float Muon::segmentDyDz( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   if(station==4 && muonSubdetId==MuonSubdetId::DT) return 999999; // no y information
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(chambers(station,muonSubdetId),type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) return 999999;
-   if(! chamberSegmentPair.second->hasZed()) return 999999;
-   return chamberSegmentPair.second->dYdZ;
-}
-
-float Muon::segmentXErr( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(chambers(station,muonSubdetId),type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) return 999999;
-   if(! chamberSegmentPair.second->hasPhi()) return 999999;
-   return chamberSegmentPair.second->xErr;
-}
-
-float Muon::segmentYErr( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   if(station==4 && muonSubdetId==MuonSubdetId::DT) return 999999; // no y information
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(chambers(station,muonSubdetId),type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) return 999999;
-   if(! chamberSegmentPair.second->hasZed()) return 999999;
-   return chamberSegmentPair.second->yErr;
-}
-
-float Muon::segmentDxDzErr( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(chambers(station,muonSubdetId),type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) return 999999;
-   if(! chamberSegmentPair.second->hasPhi()) return 999999;
-   return chamberSegmentPair.second->dXdZErr;
-}
-
-float Muon::segmentDyDzErr( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   if(station==4 && muonSubdetId==MuonSubdetId::DT) return 999999; // no y information
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(chambers(station,muonSubdetId),type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) return 999999;
-   if(! chamberSegmentPair.second->hasZed()) return 999999;
-   return chamberSegmentPair.second->dYdZErr;
-}
-
-float Muon::trackEdgeX( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
-   if(muonChambers.empty()) return 999999;
-
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers,type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) {
-      float dist  = 999999;
-      float supVar = 999999;
-      for(std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
-            muonChamber != muonChambers.end(); ++muonChamber) {
-         float currDist = (*muonChamber)->dist();
-         if(currDist<dist) {
-            dist  = currDist;
-            supVar = (*muonChamber)->edgeX;
-         }
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers, type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr) {
+    float dist = 999999;
+    float supVar = 999999;
+    for (std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
+         muonChamber != muonChambers.end();
+         ++muonChamber) {
+      float currDist = (*muonChamber)->dist();
+      if (currDist < dist) {
+        dist = currDist;
+        supVar = (*muonChamber)->y;
       }
-      return supVar;
-   } else return chamberSegmentPair.first->edgeX;
+    }
+    return supVar;
+  } else
+    return chamberSegmentPair.first->y;
 }
 
-float Muon::trackEdgeY( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
-   if(muonChambers.empty()) return 999999;
+float Muon::trackDxDz(int station, int muonSubdetId, ArbitrationType type) const {
+  const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
+  if (muonChambers.empty())
+    return 999999;
 
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers,type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) {
-      float dist  = 999999;
-      float supVar = 999999;
-      for(std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
-            muonChamber != muonChambers.end(); ++muonChamber) {
-         float currDist = (*muonChamber)->dist();
-         if(currDist<dist) {
-            dist  = currDist;
-            supVar = (*muonChamber)->edgeY;
-         }
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers, type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr) {
+    float dist = 999999;
+    float supVar = 999999;
+    for (std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
+         muonChamber != muonChambers.end();
+         ++muonChamber) {
+      float currDist = (*muonChamber)->dist();
+      if (currDist < dist) {
+        dist = currDist;
+        supVar = (*muonChamber)->dXdZ;
       }
-      return supVar;
-   } else return chamberSegmentPair.first->edgeY;
+    }
+    return supVar;
+  } else
+    return chamberSegmentPair.first->dXdZ;
 }
 
-float Muon::trackX( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
-   if(muonChambers.empty()) return 999999;
+float Muon::trackDyDz(int station, int muonSubdetId, ArbitrationType type) const {
+  const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
+  if (muonChambers.empty())
+    return 999999;
 
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers,type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) {
-      float dist  = 999999;
-      float supVar = 999999;
-      for(std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
-            muonChamber != muonChambers.end(); ++muonChamber) {
-         float currDist = (*muonChamber)->dist();
-         if(currDist<dist) {
-            dist  = currDist;
-            supVar = (*muonChamber)->x;
-         }
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers, type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr) {
+    float dist = 999999;
+    float supVar = 999999;
+    for (std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
+         muonChamber != muonChambers.end();
+         ++muonChamber) {
+      float currDist = (*muonChamber)->dist();
+      if (currDist < dist) {
+        dist = currDist;
+        supVar = (*muonChamber)->dYdZ;
       }
-      return supVar;
-   } else return chamberSegmentPair.first->x;
+    }
+    return supVar;
+  } else
+    return chamberSegmentPair.first->dYdZ;
 }
 
-float Muon::trackY( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
-   if(muonChambers.empty()) return 999999;
+float Muon::trackXErr(int station, int muonSubdetId, ArbitrationType type) const {
+  const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
+  if (muonChambers.empty())
+    return 999999;
 
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers,type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) {
-      float dist  = 999999;
-      float supVar = 999999;
-      for(std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
-            muonChamber != muonChambers.end(); ++muonChamber) {
-         float currDist = (*muonChamber)->dist();
-         if(currDist<dist) {
-            dist  = currDist;
-            supVar = (*muonChamber)->y;
-         }
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers, type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr) {
+    float dist = 999999;
+    float supVar = 999999;
+    for (std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
+         muonChamber != muonChambers.end();
+         ++muonChamber) {
+      float currDist = (*muonChamber)->dist();
+      if (currDist < dist) {
+        dist = currDist;
+        supVar = (*muonChamber)->xErr;
       }
-      return supVar;
-   } else return chamberSegmentPair.first->y;
+    }
+    return supVar;
+  } else
+    return chamberSegmentPair.first->xErr;
 }
 
-float Muon::trackDxDz( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
-   if(muonChambers.empty()) return 999999;
+float Muon::trackYErr(int station, int muonSubdetId, ArbitrationType type) const {
+  const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
+  if (muonChambers.empty())
+    return 999999;
 
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers,type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) {
-      float dist  = 999999;
-      float supVar = 999999;
-      for(std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
-            muonChamber != muonChambers.end(); ++muonChamber) {
-         float currDist = (*muonChamber)->dist();
-         if(currDist<dist) {
-            dist  = currDist;
-            supVar = (*muonChamber)->dXdZ;
-         }
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers, type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr) {
+    float dist = 999999;
+    float supVar = 999999;
+    for (std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
+         muonChamber != muonChambers.end();
+         ++muonChamber) {
+      float currDist = (*muonChamber)->dist();
+      if (currDist < dist) {
+        dist = currDist;
+        supVar = (*muonChamber)->yErr;
       }
-      return supVar;
-   } else return chamberSegmentPair.first->dXdZ;
+    }
+    return supVar;
+  } else
+    return chamberSegmentPair.first->yErr;
 }
 
-float Muon::trackDyDz( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
-   if(muonChambers.empty()) return 999999;
+float Muon::trackDxDzErr(int station, int muonSubdetId, ArbitrationType type) const {
+  const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
+  if (muonChambers.empty())
+    return 999999;
 
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers,type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) {
-      float dist  = 999999;
-      float supVar = 999999;
-      for(std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
-            muonChamber != muonChambers.end(); ++muonChamber) {
-         float currDist = (*muonChamber)->dist();
-         if(currDist<dist) {
-            dist  = currDist;
-            supVar = (*muonChamber)->dYdZ;
-         }
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers, type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr) {
+    float dist = 999999;
+    float supVar = 999999;
+    for (std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
+         muonChamber != muonChambers.end();
+         ++muonChamber) {
+      float currDist = (*muonChamber)->dist();
+      if (currDist < dist) {
+        dist = currDist;
+        supVar = (*muonChamber)->dXdZErr;
       }
-      return supVar;
-   } else return chamberSegmentPair.first->dYdZ;
+    }
+    return supVar;
+  } else
+    return chamberSegmentPair.first->dXdZErr;
 }
 
-float Muon::trackXErr( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
-   if(muonChambers.empty()) return 999999;
+float Muon::trackDyDzErr(int station, int muonSubdetId, ArbitrationType type) const {
+  const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
+  if (muonChambers.empty())
+    return 999999;
 
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers,type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) {
-      float dist  = 999999;
-      float supVar = 999999;
-      for(std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
-            muonChamber != muonChambers.end(); ++muonChamber) {
-         float currDist = (*muonChamber)->dist();
-         if(currDist<dist) {
-            dist  = currDist;
-            supVar = (*muonChamber)->xErr;
-         }
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers, type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr) {
+    float dist = 999999;
+    float supVar = 999999;
+    for (std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
+         muonChamber != muonChambers.end();
+         ++muonChamber) {
+      float currDist = (*muonChamber)->dist();
+      if (currDist < dist) {
+        dist = currDist;
+        supVar = (*muonChamber)->dYdZErr;
       }
-      return supVar;
-   } else return chamberSegmentPair.first->xErr;
+    }
+    return supVar;
+  } else
+    return chamberSegmentPair.first->dYdZErr;
 }
 
-float Muon::trackYErr( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
-   if(muonChambers.empty()) return 999999;
+float Muon::trackDist(int station, int muonSubdetId, ArbitrationType type) const {
+  const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
+  if (muonChambers.empty())
+    return 999999;
 
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers,type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) {
-      float dist  = 999999;
-      float supVar = 999999;
-      for(std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
-            muonChamber != muonChambers.end(); ++muonChamber) {
-         float currDist = (*muonChamber)->dist();
-         if(currDist<dist) {
-            dist  = currDist;
-            supVar = (*muonChamber)->yErr;
-         }
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers, type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr) {
+    float dist = 999999;
+    for (std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
+         muonChamber != muonChambers.end();
+         ++muonChamber) {
+      float currDist = (*muonChamber)->dist();
+      if (currDist < dist)
+        dist = currDist;
+    }
+    return dist;
+  } else
+    return chamberSegmentPair.first->dist();
+}
+
+float Muon::trackDistErr(int station, int muonSubdetId, ArbitrationType type) const {
+  const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
+  if (muonChambers.empty())
+    return 999999;
+
+  std::pair<const MuonChamberMatch*, const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers, type);
+  if (chamberSegmentPair.first == nullptr || chamberSegmentPair.second == nullptr) {
+    float dist = 999999;
+    float supVar = 999999;
+    for (std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
+         muonChamber != muonChambers.end();
+         ++muonChamber) {
+      float currDist = (*muonChamber)->dist();
+      if (currDist < dist) {
+        dist = currDist;
+        supVar = (*muonChamber)->distErr();
       }
-      return supVar;
-   } else return chamberSegmentPair.first->yErr;
+    }
+    return supVar;
+  } else
+    return chamberSegmentPair.first->distErr();
 }
 
-float Muon::trackDxDzErr( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
-   if(muonChambers.empty()) return 999999;
-
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers,type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) {
-      float dist  = 999999;
-      float supVar = 999999;
-      for(std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
-            muonChamber != muonChambers.end(); ++muonChamber) {
-         float currDist = (*muonChamber)->dist();
-         if(currDist<dist) {
-            dist  = currDist;
-            supVar = (*muonChamber)->dXdZErr;
-         }
-      }
-      return supVar;
-   } else return chamberSegmentPair.first->dXdZErr;
+void Muon::setIsolation(const MuonIsolation& isoR03, const MuonIsolation& isoR05) {
+  isolationR03_ = isoR03;
+  isolationR05_ = isoR05;
+  isolationValid_ = true;
 }
 
-float Muon::trackDyDzErr( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
-   if(muonChambers.empty()) return 999999;
-
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers,type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) {
-      float dist  = 999999;
-      float supVar = 999999;
-      for(std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
-            muonChamber != muonChambers.end(); ++muonChamber) {
-         float currDist = (*muonChamber)->dist();
-         if(currDist<dist) {
-            dist  = currDist;
-            supVar = (*muonChamber)->dYdZErr;
-         }
-      }
-      return supVar;
-   } else return chamberSegmentPair.first->dYdZErr;
-}
-
-float Muon::trackDist( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
-   if(muonChambers.empty()) return 999999;
-
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers,type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) {
-      float dist  = 999999;
-      for(std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
-            muonChamber != muonChambers.end(); ++muonChamber) {
-         float currDist = (*muonChamber)->dist();
-         if(currDist<dist) dist  = currDist;
-      }
-      return dist;
-   } else return chamberSegmentPair.first->dist();
-}
-
-float Muon::trackDistErr( int station, int muonSubdetId, ArbitrationType type ) const
-{
-   const std::vector<const MuonChamberMatch*> muonChambers = chambers(station, muonSubdetId);
-   if(muonChambers.empty()) return 999999;
-
-   std::pair<const MuonChamberMatch*,const MuonSegmentMatch*> chamberSegmentPair = pair(muonChambers,type);
-   if(chamberSegmentPair.first==nullptr || chamberSegmentPair.second==nullptr) {
-      float dist  = 999999;
-      float supVar = 999999;
-      for(std::vector<const MuonChamberMatch*>::const_iterator muonChamber = muonChambers.begin();
-            muonChamber != muonChambers.end(); ++muonChamber) {
-         float currDist = (*muonChamber)->dist();
-         if(currDist<dist) {
-            dist  = currDist;
-            supVar = (*muonChamber)->distErr();
-         }
-      }
-      return supVar;
-   } else return chamberSegmentPair.first->distErr();
-}
-
-void Muon::setIsolation( const MuonIsolation& isoR03, const MuonIsolation& isoR05 )
-{ 
-   isolationR03_ = isoR03;
-   isolationR05_ = isoR05;
-   isolationValid_ = true; 
-}
-
-
-void Muon::setPFIsolation(const std::string& label, const MuonPFIsolation& deposit) 
-{ 
-  if(label=="pfIsolationR03")
+void Muon::setPFIsolation(const std::string& label, const MuonPFIsolation& deposit) {
+  if (label == "pfIsolationR03")
     pfIsolationR03_ = deposit;
 
-  if(label=="pfIsolationR04")
+  if (label == "pfIsolationR04")
     pfIsolationR04_ = deposit;
 
-  if(label=="pfIsoMeanDRProfileR03")
+  if (label == "pfIsoMeanDRProfileR03")
     pfIsoMeanDRR03_ = deposit;
 
-  if(label=="pfIsoMeanDRProfileR04")
+  if (label == "pfIsoMeanDRProfileR04")
     pfIsoMeanDRR04_ = deposit;
 
-  if(label=="pfIsoSumDRProfileR03")
+  if (label == "pfIsoSumDRProfileR03")
     pfIsoSumDRR03_ = deposit;
 
-  if(label=="pfIsoSumDRProfileR04")
+  if (label == "pfIsoSumDRProfileR04")
     pfIsoSumDRR04_ = deposit;
 
-   pfIsolationValid_ = true; 
+  pfIsolationValid_ = true;
 }
 
-
-void Muon::setPFP4( const reco::Candidate::LorentzVector& p4 )
-{ 
-    pfP4_ = p4;
-    type_ = type_ | PFMuon;
+void Muon::setPFP4(const reco::Candidate::LorentzVector& p4) {
+  pfP4_ = p4;
+  type_ = type_ | PFMuon;
 }
 
+void Muon::setOuterTrack(const TrackRef& t) { outerTrack_ = t; }
+void Muon::setInnerTrack(const TrackRef& t) { innerTrack_ = t; }
+void Muon::setTrack(const TrackRef& t) { setInnerTrack(t); }
+void Muon::setStandAlone(const TrackRef& t) { setOuterTrack(t); }
+void Muon::setGlobalTrack(const TrackRef& t) { globalTrack_ = t; }
+void Muon::setCombined(const TrackRef& t) { setGlobalTrack(t); }
 
+bool Muon::isAValidMuonTrack(const MuonTrackType& type) const { return muonTrack(type).isNonnull(); }
 
-void Muon::setOuterTrack( const TrackRef & t ) { outerTrack_ = t; }
-void Muon::setInnerTrack( const TrackRef & t ) { innerTrack_ = t; }
-void Muon::setTrack( const TrackRef & t ) { setInnerTrack(t); }
-void Muon::setStandAlone( const TrackRef & t ) { setOuterTrack(t); }
-void Muon::setGlobalTrack( const TrackRef & t ) { globalTrack_ = t; }
-void Muon::setCombined( const TrackRef & t ) { setGlobalTrack(t); }
-
-
-bool Muon::isAValidMuonTrack(const MuonTrackType& type) const{
-  return muonTrack(type).isNonnull();
-}
-
-TrackRef Muon::muonTrack(const MuonTrackType& type) const{
+TrackRef Muon::muonTrack(const MuonTrackType& type) const {
   switch (type) {
-  case InnerTrack:     return innerTrack();
-  case OuterTrack:     return standAloneMuon(); 
-  case CombinedTrack:  return globalTrack();
-  case TPFMS:          return tpfmsTrack();
-  case Picky:          return pickyTrack();
-  case DYT:            return dytTrack();
-  default:             return muonTrackFromMap(type);
+    case InnerTrack:
+      return innerTrack();
+    case OuterTrack:
+      return standAloneMuon();
+    case CombinedTrack:
+      return globalTrack();
+    case TPFMS:
+      return tpfmsTrack();
+    case Picky:
+      return pickyTrack();
+    case DYT:
+      return dytTrack();
+    default:
+      return muonTrackFromMap(type);
   }
 }
 
 void Muon::setMuonTrack(const MuonTrackType& type, const TrackRef& t) {
-  
   switch (type) {
-  case InnerTrack:    setInnerTrack(t);             break;
-  case OuterTrack:    setStandAlone(t);             break;
-  case CombinedTrack: setGlobalTrack(t);            break;
-  default:            refittedTrackMap_[type] = t;  break;
+    case InnerTrack:
+      setInnerTrack(t);
+      break;
+    case OuterTrack:
+      setStandAlone(t);
+      break;
+    case CombinedTrack:
+      setGlobalTrack(t);
+      break;
+    default:
+      refittedTrackMap_[type] = t;
+      break;
   }
-
 }
-

--- a/DataFormats/MuonReco/src/MuonChamberMatch.cc
+++ b/DataFormats/MuonReco/src/MuonChamberMatch.cc
@@ -8,46 +8,58 @@
 #include <cmath>
 using namespace reco;
 
-int MuonChamberMatch::station()  const {
-   if( detector() ==  MuonSubdetId::DT ) {    // DT
-      DTChamberId segId(id.rawId());
-      return segId.station();
-   }
-   if( detector() == MuonSubdetId::CSC ) {    // CSC
-      CSCDetId segId(id.rawId());
-      return segId.station();
-   }
-   if( detector() == MuonSubdetId::RPC ) {    //RPC
-      RPCDetId segId(id.rawId());
-      return segId.station();
-   }
-   if( detector() == MuonSubdetId::GEM ) {    //GEM
-      GEMDetId segId(id.rawId());
-      return segId.station();
-   }
-   if( detector() == MuonSubdetId::ME0 ) {    //ME0
-      ME0DetId segId(id.rawId());
-      return segId.station();
-   }
-   return -1; // is this appropriate? fix this
+int MuonChamberMatch::station() const {
+  if (detector() == MuonSubdetId::DT) {  // DT
+    DTChamberId segId(id.rawId());
+    return segId.station();
+  }
+  if (detector() == MuonSubdetId::CSC) {  // CSC
+    CSCDetId segId(id.rawId());
+    return segId.station();
+  }
+  if (detector() == MuonSubdetId::RPC) {  //RPC
+    RPCDetId segId(id.rawId());
+    return segId.station();
+  }
+  if (detector() == MuonSubdetId::GEM) {  //GEM
+    GEMDetId segId(id.rawId());
+    return segId.station();
+  }
+  if (detector() == MuonSubdetId::ME0) {  //ME0
+    ME0DetId segId(id.rawId());
+    return segId.station();
+  }
+  return -1;  // is this appropriate? fix this
 }
 
-std::pair<float,float>
-MuonChamberMatch::getDistancePair(float edgeX, float edgeY, float xErr, float yErr) const
-{
-   if(edgeX>9E5&&edgeY>9E5&&xErr>9E5&&yErr>9E5) // there is no track
-      return std::make_pair(999999, 999999);
+std::pair<float, float> MuonChamberMatch::getDistancePair(float edgeX, float edgeY, float xErr, float yErr) const {
+  if (edgeX > 9E5 && edgeY > 9E5 && xErr > 9E5 && yErr > 9E5)  // there is no track
+    return std::make_pair(999999, 999999);
 
-   float distance = 999999;
-   float error    = 999999;
+  float distance = 999999;
+  float error = 999999;
 
-   if(edgeX<0 && edgeY<0) {
-      if(edgeX<edgeY) { distance = edgeY; error = yErr; }
-      else { distance = edgeX; error = xErr; }
-   }
-   if(edgeX<0 && edgeY>0) { distance = edgeY; error = yErr; }
-   if(edgeX>0 && edgeY<0) { distance = edgeX; error = xErr; }
-   if(edgeX>0 && edgeY>0) { distance = sqrt(edgeX*edgeX+edgeY*edgeY); error = distance ? sqrt(edgeX*edgeX*xErr*xErr+edgeY*edgeY*yErr*yErr)/fabs(distance) : 0; }
+  if (edgeX < 0 && edgeY < 0) {
+    if (edgeX < edgeY) {
+      distance = edgeY;
+      error = yErr;
+    } else {
+      distance = edgeX;
+      error = xErr;
+    }
+  }
+  if (edgeX < 0 && edgeY > 0) {
+    distance = edgeY;
+    error = yErr;
+  }
+  if (edgeX > 0 && edgeY < 0) {
+    distance = edgeX;
+    error = xErr;
+  }
+  if (edgeX > 0 && edgeY > 0) {
+    distance = sqrt(edgeX * edgeX + edgeY * edgeY);
+    error = distance ? sqrt(edgeX * edgeX * xErr * xErr + edgeY * edgeY * yErr * yErr) / fabs(distance) : 0;
+  }
 
-   return std::make_pair(distance, error);
+  return std::make_pair(distance, error);
 }

--- a/DataFormats/MuonReco/src/MuonCocktails.cc
+++ b/DataFormats/MuonReco/src/MuonCocktails.cc
@@ -6,82 +6,88 @@
 // Return the TeV-optimized refit track (aka the cocktail or Tune P) or
 // the tracker track if either the optimized pT or tracker pT is below the pT threshold
 //
-reco::Muon::MuonTrackTypePair  muon::tevOptimized(const reco::TrackRef& combinedTrack,
-						  const reco::TrackRef& trackerTrack,
-						  const reco::TrackRef& tpfmsTrack,
-						  const reco::TrackRef& pickyTrack,
-						  const reco::TrackRef& dytTrack,
-						  const double ptThreshold,
-						  const double tune1,
-						  const double tune2,
-						  double dptcut) {
-  const unsigned int nAlgo=5; 
+reco::Muon::MuonTrackTypePair muon::tevOptimized(const reco::TrackRef& combinedTrack,
+                                                 const reco::TrackRef& trackerTrack,
+                                                 const reco::TrackRef& tpfmsTrack,
+                                                 const reco::TrackRef& pickyTrack,
+                                                 const reco::TrackRef& dytTrack,
+                                                 const double ptThreshold,
+                                                 const double tune1,
+                                                 const double tune2,
+                                                 double dptcut) {
+  const unsigned int nAlgo = 5;
 
   // Array for convenience below.
-  const reco::Muon::MuonTrackTypePair refit[nAlgo] = { 
-    make_pair(trackerTrack, reco::Muon::InnerTrack), 
-    make_pair(combinedTrack,reco::Muon::CombinedTrack),
-    make_pair(tpfmsTrack,   reco::Muon::TPFMS),
-    make_pair(pickyTrack,   reco::Muon::Picky),
-    make_pair(dytTrack,     reco::Muon::DYT)
-  }; 
-  
+  const reco::Muon::MuonTrackTypePair refit[nAlgo] = {make_pair(trackerTrack, reco::Muon::InnerTrack),
+                                                      make_pair(combinedTrack, reco::Muon::CombinedTrack),
+                                                      make_pair(tpfmsTrack, reco::Muon::TPFMS),
+                                                      make_pair(pickyTrack, reco::Muon::Picky),
+                                                      make_pair(dytTrack, reco::Muon::DYT)};
+
   // Calculate the log(tail probabilities). If there's a problem,
   // signify this with prob == 0. The current problems recognized are:
   // the track being not available, whether the (re)fit failed or it's
   // just not in the event, or if the (re)fit ended up with no valid
   // hits.
-  double prob[nAlgo] = {0.,0.,0.,0.,0.};
-  bool valid[nAlgo] = {false,false,false,false,false};
+  double prob[nAlgo] = {0., 0., 0., 0., 0.};
+  bool valid[nAlgo] = {false, false, false, false, false};
 
   double dptmin = 1.;
 
-  if (dptcut>0) {  
+  if (dptcut > 0) {
     for (unsigned int i = 0; i < nAlgo; ++i)
       if (refit[i].first.isNonnull())
-        if (refit[i].first->ptError()/refit[i].first->pt()<dptmin) dptmin = refit[i].first->ptError()/refit[i].first->pt();
-  
-    if (dptmin>dptcut) dptcut = dptmin+0.15;
+        if (refit[i].first->ptError() / refit[i].first->pt() < dptmin)
+          dptmin = refit[i].first->ptError() / refit[i].first->pt();
+
+    if (dptmin > dptcut)
+      dptcut = dptmin + 0.15;
   }
 
-  for (unsigned int i = 0; i < nAlgo; ++i) 
-    if (refit[i].first.isNonnull()){ 
+  for (unsigned int i = 0; i < nAlgo; ++i)
+    if (refit[i].first.isNonnull()) {
       valid[i] = true;
-      if (refit[i].first->numberOfValidHits() && (refit[i].first->ptError()/refit[i].first->pt()<dptcut || dptcut<0)) 
-	prob[i] = muon::trackProbability(refit[i].first); 
+      if (refit[i].first->numberOfValidHits() &&
+          (refit[i].first->ptError() / refit[i].first->pt() < dptcut || dptcut < 0))
+        prob[i] = muon::trackProbability(refit[i].first);
     }
 
-  
   // Start with picky.
   int chosen = 3;
-  
+
   // If there's a problem with picky, make the default one of the
   // other tracks. Try TPFMS first, then global, then tracker-only.
-  if (prob[3] == 0.) { 
-
+  if (prob[3] == 0.) {
     // split so that passing dptcut<0 recreates EXACTLY the old tuneP behavior
-    if (dptcut>0) {
-      if      (prob[4] > 0.) chosen = 4;
-      else if (prob[0] > 0.) chosen = 0;
-      else if (prob[2] > 0.) chosen = 2;
-      else if (prob[1] > 0.) chosen = 1;
+    if (dptcut > 0) {
+      if (prob[4] > 0.)
+        chosen = 4;
+      else if (prob[0] > 0.)
+        chosen = 0;
+      else if (prob[2] > 0.)
+        chosen = 2;
+      else if (prob[1] > 0.)
+        chosen = 1;
     } else {
-      if      (prob[2] > 0.) chosen = 2;
-      else if (prob[1] > 0.) chosen = 1;
-      else if (prob[0] > 0.) chosen = 0;
+      if (prob[2] > 0.)
+        chosen = 2;
+      else if (prob[1] > 0.)
+        chosen = 1;
+      else if (prob[0] > 0.)
+        chosen = 0;
     }
-  } 
-  
-  // Now the algorithm: switch from picky to dyt if the difference is lower than a tuned value. Then 
+  }
+
+  // Now the algorithm: switch from picky to dyt if the difference is lower than a tuned value. Then
   //  switch from picky to tracker-only if the
   // difference, log(tail prob(picky)) - log(tail prob(tracker-only))
   // is greater than a tuned value. Then compare the
   // so-picked track to TPFMS in the same manner using another tuned
   // value.
-  if (prob[4]>0. && prob[3]>0.) {
-    if(refit[3].first->pt()>0 && refit[4].first->pt()>0 &&
-       (refit[4].first->ptError()/refit[4].first->pt()-refit[3].first->ptError()/refit[3].first->pt())<=0) 
-      chosen=4; // dyt
+  if (prob[4] > 0. && prob[3] > 0.) {
+    if (refit[3].first->pt() > 0 && refit[4].first->pt() > 0 &&
+        (refit[4].first->ptError() / refit[4].first->pt() - refit[3].first->ptError() / refit[3].first->pt()) <= 0)
+      chosen = 4;  // dyt
   }
 
   if (prob[0] > 0. && prob[chosen] > 0. && (prob[chosen] - prob[0]) > tune1)
@@ -89,16 +95,22 @@ reco::Muon::MuonTrackTypePair  muon::tevOptimized(const reco::TrackRef& combined
   if (prob[2] > 0. && (prob[chosen] - prob[2]) > tune2)
     chosen = 2;
 
-  // Sanity checks 
-  if (chosen == 4 && !valid[4] ) chosen = 3;
-  if (chosen == 3 && !valid[3] ) chosen = 2;
-  if (chosen == 2 && !valid[2] ) chosen = 1;
-  if (chosen == 1 && !valid[1] ) chosen = 0; 
+  // Sanity checks
+  if (chosen == 4 && !valid[4])
+    chosen = 3;
+  if (chosen == 3 && !valid[3])
+    chosen = 2;
+  if (chosen == 2 && !valid[2])
+    chosen = 1;
+  if (chosen == 1 && !valid[1])
+    chosen = 0;
 
   // Done. If pT of the chosen track (or pT of the tracker track) is below the threshold value, return the tracker track.
-  if (valid[chosen] && refit[chosen].first->pt() < ptThreshold && prob[0] > 0.) return make_pair(trackerTrack,reco::Muon::InnerTrack);    
-  if (trackerTrack->pt() < ptThreshold && prob[0] > 0.) return make_pair(trackerTrack,reco::Muon::InnerTrack);  
-  
+  if (valid[chosen] && refit[chosen].first->pt() < ptThreshold && prob[0] > 0.)
+    return make_pair(trackerTrack, reco::Muon::InnerTrack);
+  if (trackerTrack->pt() < ptThreshold && prob[0] > 0.)
+    return make_pair(trackerTrack, reco::Muon::InnerTrack);
+
   // Return the chosen track (which can be the global track in
   // very rare cases).
   return refit[chosen];
@@ -108,70 +120,66 @@ reco::Muon::MuonTrackTypePair  muon::tevOptimized(const reco::TrackRef& combined
 // calculate the tail probability (-ln(P)) of a fit
 //
 double muon::trackProbability(const reco::TrackRef track) {
-  
   int nDOF = (int)track->ndof();
-  if ( nDOF > 0 && track->chi2()> 0) { 
+  if (nDOF > 0 && track->chi2() > 0) {
     return -log(TMath::Prob(track->chi2(), nDOF));
-  } else { 
+  } else {
     return 0.0;
   }
-  
 }
 
-reco::TrackRef muon::getTevRefitTrack(const reco::TrackRef& combinedTrack,
-						     const reco::TrackToTrackMap& map) {
+reco::TrackRef muon::getTevRefitTrack(const reco::TrackRef& combinedTrack, const reco::TrackToTrackMap& map) {
   reco::TrackToTrackMap::const_iterator it = map.find(combinedTrack);
   return it == map.end() ? reco::TrackRef() : it->val;
 }
-
 
 //
 // Get the sigma-switch decision (tracker-only versus global).
 //
 reco::Muon::MuonTrackTypePair muon::sigmaSwitch(const reco::TrackRef& combinedTrack,
-						const reco::TrackRef& trackerTrack,
-						const double nSigma,
-						const double ptThreshold) {
+                                                const reco::TrackRef& trackerTrack,
+                                                const double nSigma,
+                                                const double ptThreshold) {
   // If either the global or tracker-only fits have pT below threshold
   // (default 200 GeV), return the tracker-only fit.
   if (combinedTrack->pt() < ptThreshold || trackerTrack->pt() < ptThreshold)
-    return make_pair(trackerTrack,reco::Muon::InnerTrack);
-  
+    return make_pair(trackerTrack, reco::Muon::InnerTrack);
+
   // If both are above the pT threshold, compare the difference in
   // q/p: if less than two sigma of the tracker-only track, switch to
   // global. Otherwise, use tracker-only.
   const double delta = fabs(trackerTrack->qoverp() - combinedTrack->qoverp());
   const double threshold = nSigma * trackerTrack->qoverpError();
-  return delta > threshold ? make_pair(trackerTrack,reco::Muon::InnerTrack) :  make_pair(combinedTrack,reco::Muon::CombinedTrack);
+  return delta > threshold ? make_pair(trackerTrack, reco::Muon::InnerTrack)
+                           : make_pair(combinedTrack, reco::Muon::CombinedTrack);
 }
 
 //
 // Get the TMR decision (tracker-only versus TPFMS).
 //
 reco::Muon::MuonTrackTypePair muon::TMR(const reco::TrackRef& trackerTrack,
-					const reco::TrackRef& fmsTrack,
-					const double tune) {
-  double probTK  = 0;
+                                        const reco::TrackRef& fmsTrack,
+                                        const double tune) {
+  double probTK = 0;
   double probFMS = 0;
-  
-  if (trackerTrack.isNonnull() && trackerTrack->numberOfValidHits())  
+
+  if (trackerTrack.isNonnull() && trackerTrack->numberOfValidHits())
     probTK = muon::trackProbability(trackerTrack);
   if (fmsTrack.isNonnull() && fmsTrack->numberOfValidHits())
     probFMS = muon::trackProbability(fmsTrack);
-  
-  bool TKok  = probTK > 0;
+
+  bool TKok = probTK > 0;
   bool FMSok = probFMS > 0;
-  
+
   if (TKok && FMSok) {
     if (probFMS - probTK > tune)
-      return make_pair(trackerTrack,reco::Muon::InnerTrack);
+      return make_pair(trackerTrack, reco::Muon::InnerTrack);
     else
-      return  make_pair(fmsTrack,reco::Muon::TPFMS);
-  }
-  else if (FMSok)
-    return  make_pair(fmsTrack,reco::Muon::TPFMS);
+      return make_pair(fmsTrack, reco::Muon::TPFMS);
+  } else if (FMSok)
+    return make_pair(fmsTrack, reco::Muon::TPFMS);
   else if (TKok)
-    return make_pair(trackerTrack,reco::Muon::InnerTrack);
+    return make_pair(trackerTrack, reco::Muon::InnerTrack);
   else
-    return make_pair(reco::TrackRef(),reco::Muon::None); 
+    return make_pair(reco::TrackRef(), reco::Muon::None);
 }

--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -6,79 +6,77 @@
 #include "DataFormats/MuonReco/interface/MuonRPCHitMatch.h"
 
 namespace muon {
-SelectionType selectionTypeFromString( const std::string &label )
-{
-   static const SelectionTypeStringToEnum selectionTypeStringToEnumMap[] = {
-      { "All", All },
-      { "AllGlobalMuons", AllGlobalMuons },
-      { "AllStandAloneMuons", AllStandAloneMuons },
-      { "AllTrackerMuons", AllTrackerMuons },
-      { "TrackerMuonArbitrated", TrackerMuonArbitrated },
-      { "AllArbitrated", AllArbitrated },
-      { "GlobalMuonPromptTight", GlobalMuonPromptTight },
-      { "TMLastStationLoose", TMLastStationLoose },
-      { "TMLastStationTight", TMLastStationTight },
-      { "TM2DCompatibilityLoose", TM2DCompatibilityLoose },
-      { "TM2DCompatibilityTight", TM2DCompatibilityTight },
-      { "TMOneStationLoose", TMOneStationLoose },
-      { "TMOneStationTight", TMOneStationTight },
-      { "TMLastStationOptimizedLowPtLoose", TMLastStationOptimizedLowPtLoose },
-      { "TMLastStationOptimizedLowPtTight", TMLastStationOptimizedLowPtTight },
-      { "GMTkChiCompatibility", GMTkChiCompatibility },
-      { "GMStaChiCompatibility", GMStaChiCompatibility},
-      { "GMTkKinkTight", GMTkKinkTight},
-      { "TMLastStationAngLoose", TMLastStationAngLoose },
-      { "TMLastStationAngTight", TMLastStationAngTight },
-      { "TMOneStationAngLoose", TMOneStationAngLoose },
-      { "TMOneStationAngTight", TMOneStationAngTight },
-      { "TMLastStationOptimizedBarrelLowPtLoose", TMLastStationOptimizedBarrelLowPtLoose },
-      { "TMLastStationOptimizedBarrelLowPtTight", TMLastStationOptimizedBarrelLowPtTight },
-      { "RPCMuLoose", RPCMuLoose },
-      { "AllME0Muons", AllME0Muons },
-      { "ME0MuonArbitrated", ME0MuonArbitrated },
-      { "AllGEMMuons", AllGEMMuons },
-      { "GEMMuonArbitrated", GEMMuonArbitrated },
-      { "TriggerIdLoose", TriggerIdLoose },
-      { nullptr, (SelectionType)-1 }
-   };
+  SelectionType selectionTypeFromString(const std::string& label) {
+    static const SelectionTypeStringToEnum selectionTypeStringToEnumMap[] = {
+        {"All", All},
+        {"AllGlobalMuons", AllGlobalMuons},
+        {"AllStandAloneMuons", AllStandAloneMuons},
+        {"AllTrackerMuons", AllTrackerMuons},
+        {"TrackerMuonArbitrated", TrackerMuonArbitrated},
+        {"AllArbitrated", AllArbitrated},
+        {"GlobalMuonPromptTight", GlobalMuonPromptTight},
+        {"TMLastStationLoose", TMLastStationLoose},
+        {"TMLastStationTight", TMLastStationTight},
+        {"TM2DCompatibilityLoose", TM2DCompatibilityLoose},
+        {"TM2DCompatibilityTight", TM2DCompatibilityTight},
+        {"TMOneStationLoose", TMOneStationLoose},
+        {"TMOneStationTight", TMOneStationTight},
+        {"TMLastStationOptimizedLowPtLoose", TMLastStationOptimizedLowPtLoose},
+        {"TMLastStationOptimizedLowPtTight", TMLastStationOptimizedLowPtTight},
+        {"GMTkChiCompatibility", GMTkChiCompatibility},
+        {"GMStaChiCompatibility", GMStaChiCompatibility},
+        {"GMTkKinkTight", GMTkKinkTight},
+        {"TMLastStationAngLoose", TMLastStationAngLoose},
+        {"TMLastStationAngTight", TMLastStationAngTight},
+        {"TMOneStationAngLoose", TMOneStationAngLoose},
+        {"TMOneStationAngTight", TMOneStationAngTight},
+        {"TMLastStationOptimizedBarrelLowPtLoose", TMLastStationOptimizedBarrelLowPtLoose},
+        {"TMLastStationOptimizedBarrelLowPtTight", TMLastStationOptimizedBarrelLowPtTight},
+        {"RPCMuLoose", RPCMuLoose},
+        {"AllME0Muons", AllME0Muons},
+        {"ME0MuonArbitrated", ME0MuonArbitrated},
+        {"AllGEMMuons", AllGEMMuons},
+        {"GEMMuonArbitrated", GEMMuonArbitrated},
+        {"TriggerIdLoose", TriggerIdLoose},
+        {nullptr, (SelectionType)-1}};
 
-   SelectionType value = (SelectionType)-1;
-   bool found = false;
-   for(int i = 0; selectionTypeStringToEnumMap[i].label && (! found); ++i)
-      if (! strcmp(label.c_str(), selectionTypeStringToEnumMap[i].label)) {
-         found = true;
-         value = selectionTypeStringToEnumMap[i].value;
+    SelectionType value = (SelectionType)-1;
+    bool found = false;
+    for (int i = 0; selectionTypeStringToEnumMap[i].label && (!found); ++i)
+      if (!strcmp(label.c_str(), selectionTypeStringToEnumMap[i].label)) {
+        found = true;
+        value = selectionTypeStringToEnumMap[i].value;
       }
 
-   // in case of unrecognized selection type
-   if (! found) throw cms::Exception("MuonSelectorError") << label << " is not a recognized SelectionType";
-   return value;
-}
-}
+    // in case of unrecognized selection type
+    if (!found)
+      throw cms::Exception("MuonSelectorError") << label << " is not a recognized SelectionType";
+    return value;
+  }
+}  // namespace muon
 
-unsigned int muon::RequiredStationMask( const reco::Muon& muon,
-					  double maxChamberDist,
-					  double maxChamberDistPull,
-					  reco::Muon::ArbitrationType arbitrationType )
-{
-   unsigned int theMask = 0;
+unsigned int muon::RequiredStationMask(const reco::Muon& muon,
+                                       double maxChamberDist,
+                                       double maxChamberDistPull,
+                                       reco::Muon::ArbitrationType arbitrationType) {
+  unsigned int theMask = 0;
 
-   for(int stationIdx = 1; stationIdx < 5; ++stationIdx)
-      for(int detectorIdx = 1; detectorIdx < 3; ++detectorIdx)
-         if(muon.trackDist(stationIdx,detectorIdx,arbitrationType) < maxChamberDist &&
-               muon.trackDist(stationIdx,detectorIdx,arbitrationType)/muon.trackDistErr(stationIdx,detectorIdx,arbitrationType) < maxChamberDistPull)
-            theMask += 1<<((stationIdx-1)+4*(detectorIdx-1));
+  for (int stationIdx = 1; stationIdx < 5; ++stationIdx)
+    for (int detectorIdx = 1; detectorIdx < 3; ++detectorIdx)
+      if (muon.trackDist(stationIdx, detectorIdx, arbitrationType) < maxChamberDist &&
+          muon.trackDist(stationIdx, detectorIdx, arbitrationType) /
+                  muon.trackDistErr(stationIdx, detectorIdx, arbitrationType) <
+              maxChamberDistPull)
+        theMask += 1 << ((stationIdx - 1) + 4 * (detectorIdx - 1));
 
-   return theMask;
+  return theMask;
 }
 
 // ------------ method to calculate the calo compatibility for a track with matched muon info  ------------
-float muon::caloCompatibility(const reco::Muon& muon) {
-  return muon.caloCompatibility();
-}
+float muon::caloCompatibility(const reco::Muon& muon) { return muon.caloCompatibility(); }
 
 // ------------ method to calculate the segment compatibility for a track with matched muon info  ------------
-float muon::segmentCompatibility(const reco::Muon& muon,reco::Muon::ArbitrationType arbitrationType) {
+float muon::segmentCompatibility(const reco::Muon& muon, reco::Muon::ArbitrationType arbitrationType) {
   bool use_weight_regain_at_chamber_boundary = true;
   bool use_match_dist_penalty = true;
 
@@ -92,32 +90,37 @@ float muon::segmentCompatibility(const reco::Muon& muon,reco::Muon::ArbitrationT
   int position_in_stations = 0;
   float full_weight = 0.;
 
-  for(int i = 1; i<=8; ++i) {
+  for (int i = 1; i <= 8; ++i) {
     // ********************************************************;
     // *** fill local info for this muon (do some counting) ***;
     // ************** begin ***********************************;
-    if(i<=4) { // this is the section for the DTs
-      if( muon.trackDist(i,1,arbitrationType) < 999999 ) { //current "raw" info that a track is close to a chamber
-	++nr_of_stations_crossed;
-	station_was_crossed[i-1] = 1;
-	if(muon.trackDist(i,1,arbitrationType) > -10. ) stations_w_track_at_boundary[i-1] = muon.trackDist(i,1,arbitrationType); 
-	else stations_w_track_at_boundary[i-1] = 0.;
+    if (i <= 4) {                                            // this is the section for the DTs
+      if (muon.trackDist(i, 1, arbitrationType) < 999999) {  //current "raw" info that a track is close to a chamber
+        ++nr_of_stations_crossed;
+        station_was_crossed[i - 1] = 1;
+        if (muon.trackDist(i, 1, arbitrationType) > -10.)
+          stations_w_track_at_boundary[i - 1] = muon.trackDist(i, 1, arbitrationType);
+        else
+          stations_w_track_at_boundary[i - 1] = 0.;
       }
-      if( muon.segmentX(i,1,arbitrationType) < 999999 ) { //current "raw" info that a segment is matched to the current track
-	++nr_of_stations_with_segment;
-	station_has_segmentmatch[i-1] = 1;
+      if (muon.segmentX(i, 1, arbitrationType) <
+          999999) {  //current "raw" info that a segment is matched to the current track
+        ++nr_of_stations_with_segment;
+        station_has_segmentmatch[i - 1] = 1;
       }
-    }
-    else     { // this is the section for the CSCs
-      if( muon.trackDist(i-4,2,arbitrationType) < 999999 ) { //current "raw" info that a track is close to a chamber
-	++nr_of_stations_crossed;
-	station_was_crossed[i-1] = 1;
-	if(muon.trackDist(i-4,2,arbitrationType) > -10. ) stations_w_track_at_boundary[i-1] = muon.trackDist(i-4,2,arbitrationType);
-	else stations_w_track_at_boundary[i-1] = 0.;
+    } else {                                                     // this is the section for the CSCs
+      if (muon.trackDist(i - 4, 2, arbitrationType) < 999999) {  //current "raw" info that a track is close to a chamber
+        ++nr_of_stations_crossed;
+        station_was_crossed[i - 1] = 1;
+        if (muon.trackDist(i - 4, 2, arbitrationType) > -10.)
+          stations_w_track_at_boundary[i - 1] = muon.trackDist(i - 4, 2, arbitrationType);
+        else
+          stations_w_track_at_boundary[i - 1] = 0.;
       }
-      if( muon.segmentX(i-4,2,arbitrationType) < 999999 ) { //current "raw" info that a segment is matched to the current track
-	++nr_of_stations_with_segment;
-	station_has_segmentmatch[i-1] = 1;
+      if (muon.segmentX(i - 4, 2, arbitrationType) <
+          999999) {  //current "raw" info that a segment is matched to the current track
+        ++nr_of_stations_with_segment;
+        station_has_segmentmatch[i - 1] = 1;
       }
     }
     // rough estimation of chamber border efficiency (should be parametrized better, this is just a quick guess):
@@ -136,149 +139,176 @@ float muon::segmentCompatibility(const reco::Muon& muon,reco::Muon::ArbitrationT
   //    const float slope = 0.5;
   //    const float attenuate_weight_regain = 1.;
   // if attenuate_weight_regain < 1., additional punishment if track is close to boundary and no segment
-  const float attenuate_weight_regain = 0.5; 
+  const float attenuate_weight_regain = 0.5;
 
-  for(int i = 1; i<=8; ++i) { // loop over all possible stations
+  for (int i = 1; i <= 8; ++i) {  // loop over all possible stations
 
     // first set all weights if a station has been crossed
     // later penalize if a station did not have a matching segment
 
     //old logic      if(station_has_segmentmatch[i-1] > 0 ) { // the track has an associated segment at the current station
-    if( station_was_crossed[i-1] > 0 ) { // the track crossed this chamber (or was nearby)
-      // - Apply a weight depending on the "depth" of the muon passage. 
-      // - The station_weight is later reduced for stations with badly matched segments. 
+    if (station_was_crossed[i - 1] > 0) {  // the track crossed this chamber (or was nearby)
+      // - Apply a weight depending on the "depth" of the muon passage.
+      // - The station_weight is later reduced for stations with badly matched segments.
       // - Even if there is no segment but the track passes close to a chamber boundary, the
       //   weight is set non zero and can go up to 0.5 of the full weight if the track is quite
       //   far from any station.
       ++position_in_stations;
 
-      switch ( nr_of_stations_crossed ) { // define different weights depending on how many stations were crossed
-      case 1 : 
-	station_weight[i-1] =  1.;
-	break;
-      case 2 :
-	if     ( position_in_stations == 1 ) station_weight[i-1] =  0.33;
-	else                                 station_weight[i-1] =  0.67;
-	break;
-      case 3 : 
-	if     ( position_in_stations == 1 ) station_weight[i-1] =  0.23;
-	else if( position_in_stations == 2 ) station_weight[i-1] =  0.33;
-	else                                 station_weight[i-1] =  0.44;
-	break;
-      case 4 : 
-	if     ( position_in_stations == 1 ) station_weight[i-1] =  0.10;
-	else if( position_in_stations == 2 ) station_weight[i-1] =  0.20;
-	else if( position_in_stations == 3 ) station_weight[i-1] =  0.30;
-	else                                 station_weight[i-1] =  0.40;
-	break;
-	  
-      default : 
-// 	LogTrace("MuonIdentification")<<"            // Message: A muon candidate track has more than 4 stations with matching segments.";
-// 	LogTrace("MuonIdentification")<<"            // Did not expect this - please let me know: ibloch@fnal.gov";
-	// for all other cases
-	station_weight[i-1] = 1./nr_of_stations_crossed;
+      switch (nr_of_stations_crossed) {  // define different weights depending on how many stations were crossed
+        case 1:
+          station_weight[i - 1] = 1.;
+          break;
+        case 2:
+          if (position_in_stations == 1)
+            station_weight[i - 1] = 0.33;
+          else
+            station_weight[i - 1] = 0.67;
+          break;
+        case 3:
+          if (position_in_stations == 1)
+            station_weight[i - 1] = 0.23;
+          else if (position_in_stations == 2)
+            station_weight[i - 1] = 0.33;
+          else
+            station_weight[i - 1] = 0.44;
+          break;
+        case 4:
+          if (position_in_stations == 1)
+            station_weight[i - 1] = 0.10;
+          else if (position_in_stations == 2)
+            station_weight[i - 1] = 0.20;
+          else if (position_in_stations == 3)
+            station_weight[i - 1] = 0.30;
+          else
+            station_weight[i - 1] = 0.40;
+          break;
+
+        default:
+          // 	LogTrace("MuonIdentification")<<"            // Message: A muon candidate track has more than 4 stations with matching segments.";
+          // 	LogTrace("MuonIdentification")<<"            // Did not expect this - please let me know: ibloch@fnal.gov";
+          // for all other cases
+          station_weight[i - 1] = 1. / nr_of_stations_crossed;
       }
 
-      if( use_weight_regain_at_chamber_boundary ) { // reconstitute some weight if there is no match but the segment is close to a boundary:
-	if(station_has_segmentmatch[i-1] <= 0 && stations_w_track_at_boundary[i-1] != 0. ) {
-	  // if segment is not present but track in inefficient region, do not count as "missing match" but add some reduced weight. 
-	  // original "match weight" is currently reduced by at least attenuate_weight_regain, variing with an error function down to 0 if the track is 
-	  // inside the chamber.
-	  station_weight[i-1] = station_weight[i-1]*attenuate_weight_regain*0.5*(TMath::Erf(stations_w_track_at_boundary[i-1]/6.)+1.); // remark: the additional scale of 0.5 normalizes Err to run from 0 to 1 in y
-	}
-	else if(station_has_segmentmatch[i-1] <= 0 && stations_w_track_at_boundary[i-1] == 0.) { // no segment match and track well inside chamber
-	  // full penalization
-	  station_weight[i-1] = 0.;
-	}
-      }
-      else { // always fully penalize tracks with no matching segment, whether the segment is close to the boundary or not.
-	if(station_has_segmentmatch[i-1] <= 0) station_weight[i-1] = 0.;
+      if (use_weight_regain_at_chamber_boundary) {  // reconstitute some weight if there is no match but the segment is close to a boundary:
+        if (station_has_segmentmatch[i - 1] <= 0 && stations_w_track_at_boundary[i - 1] != 0.) {
+          // if segment is not present but track in inefficient region, do not count as "missing match" but add some reduced weight.
+          // original "match weight" is currently reduced by at least attenuate_weight_regain, variing with an error function down to 0 if the track is
+          // inside the chamber.
+          station_weight[i - 1] = station_weight[i - 1] * attenuate_weight_regain * 0.5 *
+                                  (TMath::Erf(stations_w_track_at_boundary[i - 1] / 6.) +
+                                   1.);  // remark: the additional scale of 0.5 normalizes Err to run from 0 to 1 in y
+        } else if (station_has_segmentmatch[i - 1] <= 0 &&
+                   stations_w_track_at_boundary[i - 1] == 0.) {  // no segment match and track well inside chamber
+          // full penalization
+          station_weight[i - 1] = 0.;
+        }
+      } else {  // always fully penalize tracks with no matching segment, whether the segment is close to the boundary or not.
+        if (station_has_segmentmatch[i - 1] <= 0)
+          station_weight[i - 1] = 0.;
       }
 
-      if( station_has_segmentmatch[i-1] > 0 && 42 == 42 ) { // if track has matching segment, but the matching is not high quality, penalize
-	if(i<=4) { // we are in the DTs
-	  if( muon.dY(i,1,arbitrationType) < 999999 && muon.dX(i,1,arbitrationType) < 999999) { // have both X and Y match
-	    if(
-	       TMath::Sqrt(TMath::Power(muon.pullX(i,1,arbitrationType),2.)+TMath::Power(muon.pullY(i,1,arbitrationType),2.))> 1. ) {
-	      // reduce weight
-	      if(use_match_dist_penalty) {
-		// only use pull if 3 sigma is not smaller than 3 cm
-		if(TMath::Sqrt(TMath::Power(muon.dX(i,1,arbitrationType),2.)+TMath::Power(muon.dY(i,1,arbitrationType),2.)) < 3. && TMath::Sqrt(TMath::Power(muon.pullX(i,1,arbitrationType),2.)+TMath::Power(muon.pullY(i,1,arbitrationType),2.)) > 3. ) { 
-		  station_weight[i-1] *= 1./TMath::Power(
-							 TMath::Max((double)TMath::Sqrt(TMath::Power(muon.dX(i,1,arbitrationType),2.)+TMath::Power(muon.dY(i,1,arbitrationType),2.)),(double)1.),.25); 
-		}
-		else {
-		  station_weight[i-1] *= 1./TMath::Power(
-							 TMath::Sqrt(TMath::Power(muon.pullX(i,1,arbitrationType),2.)+TMath::Power(muon.pullY(i,1,arbitrationType),2.)),.25); 
-		}
-	      }
-	    }
-	  }
-	  else if (muon.dY(i,1,arbitrationType) >= 999999) { // has no match in Y
-	    if( muon.pullX(i,1,arbitrationType) > 1. ) { // has a match in X. Pull larger that 1 to avoid increasing the weight (just penalize, don't anti-penalize)
-	      // reduce weight
-	      if(use_match_dist_penalty) {
-		// only use pull if 3 sigma is not smaller than 3 cm
-		if( muon.dX(i,1,arbitrationType) < 3. && muon.pullX(i,1,arbitrationType) > 3. ) { 
-		  station_weight[i-1] *= 1./TMath::Power(TMath::Max((double)muon.dX(i,1,arbitrationType),(double)1.),.25);
-		}
-		else {
-		  station_weight[i-1] *= 1./TMath::Power(muon.pullX(i,1,arbitrationType),.25);
-		}
-	      }
-	    }
-	  }
-	  else { // has no match in X
-	    if( muon.pullY(i,1,arbitrationType) > 1. ) { // has a match in Y. Pull larger that 1 to avoid increasing the weight (just penalize, don't anti-penalize)
-	      // reduce weight
-	      if(use_match_dist_penalty) {
-		// only use pull if 3 sigma is not smaller than 3 cm
-		if( muon.dY(i,1,arbitrationType) < 3. && muon.pullY(i,1,arbitrationType) > 3. ) { 
-		  station_weight[i-1] *= 1./TMath::Power(TMath::Max((double)muon.dY(i,1,arbitrationType),(double)1.),.25);
-		}
-		else {
-		  station_weight[i-1] *= 1./TMath::Power(muon.pullY(i,1,arbitrationType),.25);
-		}
-	      }
-	    }
-	  }
-	}
-	else { // We are in the CSCs
-	  if(
-	     TMath::Sqrt(TMath::Power(muon.pullX(i-4,2,arbitrationType),2.)+TMath::Power(muon.pullY(i-4,2,arbitrationType),2.)) > 1. ) {
-	    // reduce weight
-	    if(use_match_dist_penalty) {
-	      // only use pull if 3 sigma is not smaller than 3 cm
-	      if(TMath::Sqrt(TMath::Power(muon.dX(i-4,2,arbitrationType),2.)+TMath::Power(muon.dY(i-4,2,arbitrationType),2.)) < 3. && TMath::Sqrt(TMath::Power(muon.pullX(i-4,2,arbitrationType),2.)+TMath::Power(muon.pullY(i-4,2,arbitrationType),2.)) > 3. ) { 
-		station_weight[i-1] *= 1./TMath::Power(
-						       TMath::Max((double)TMath::Sqrt(TMath::Power(muon.dX(i-4,2,arbitrationType),2.)+TMath::Power(muon.dY(i-4,2,arbitrationType),2.)),(double)1.),.25);
-	      }
-	      else {
-		station_weight[i-1] *= 1./TMath::Power(
-						       TMath::Sqrt(TMath::Power(muon.pullX(i-4,2,arbitrationType),2.)+TMath::Power(muon.pullY(i-4,2,arbitrationType),2.)),.25);
-	      }
-	    }
-	  }
-	}
+      if (station_has_segmentmatch[i - 1] > 0 &&
+          42 == 42) {  // if track has matching segment, but the matching is not high quality, penalize
+        if (i <= 4) {  // we are in the DTs
+          if (muon.dY(i, 1, arbitrationType) < 999999 &&
+              muon.dX(i, 1, arbitrationType) < 999999) {  // have both X and Y match
+            if (TMath::Sqrt(TMath::Power(muon.pullX(i, 1, arbitrationType), 2.) +
+                            TMath::Power(muon.pullY(i, 1, arbitrationType), 2.)) > 1.) {
+              // reduce weight
+              if (use_match_dist_penalty) {
+                // only use pull if 3 sigma is not smaller than 3 cm
+                if (TMath::Sqrt(TMath::Power(muon.dX(i, 1, arbitrationType), 2.) +
+                                TMath::Power(muon.dY(i, 1, arbitrationType), 2.)) < 3. &&
+                    TMath::Sqrt(TMath::Power(muon.pullX(i, 1, arbitrationType), 2.) +
+                                TMath::Power(muon.pullY(i, 1, arbitrationType), 2.)) > 3.) {
+                  station_weight[i - 1] *=
+                      1. /
+                      TMath::Power(TMath::Max((double)TMath::Sqrt(TMath::Power(muon.dX(i, 1, arbitrationType), 2.) +
+                                                                  TMath::Power(muon.dY(i, 1, arbitrationType), 2.)),
+                                              (double)1.),
+                                   .25);
+                } else {
+                  station_weight[i - 1] *=
+                      1. / TMath::Power(TMath::Sqrt(TMath::Power(muon.pullX(i, 1, arbitrationType), 2.) +
+                                                    TMath::Power(muon.pullY(i, 1, arbitrationType), 2.)),
+                                        .25);
+                }
+              }
+            }
+          } else if (muon.dY(i, 1, arbitrationType) >= 999999) {  // has no match in Y
+            if (muon.pullX(i, 1, arbitrationType) >
+                1.) {  // has a match in X. Pull larger that 1 to avoid increasing the weight (just penalize, don't anti-penalize)
+              // reduce weight
+              if (use_match_dist_penalty) {
+                // only use pull if 3 sigma is not smaller than 3 cm
+                if (muon.dX(i, 1, arbitrationType) < 3. && muon.pullX(i, 1, arbitrationType) > 3.) {
+                  station_weight[i - 1] *=
+                      1. / TMath::Power(TMath::Max((double)muon.dX(i, 1, arbitrationType), (double)1.), .25);
+                } else {
+                  station_weight[i - 1] *= 1. / TMath::Power(muon.pullX(i, 1, arbitrationType), .25);
+                }
+              }
+            }
+          } else {  // has no match in X
+            if (muon.pullY(i, 1, arbitrationType) >
+                1.) {  // has a match in Y. Pull larger that 1 to avoid increasing the weight (just penalize, don't anti-penalize)
+              // reduce weight
+              if (use_match_dist_penalty) {
+                // only use pull if 3 sigma is not smaller than 3 cm
+                if (muon.dY(i, 1, arbitrationType) < 3. && muon.pullY(i, 1, arbitrationType) > 3.) {
+                  station_weight[i - 1] *=
+                      1. / TMath::Power(TMath::Max((double)muon.dY(i, 1, arbitrationType), (double)1.), .25);
+                } else {
+                  station_weight[i - 1] *= 1. / TMath::Power(muon.pullY(i, 1, arbitrationType), .25);
+                }
+              }
+            }
+          }
+        } else {  // We are in the CSCs
+          if (TMath::Sqrt(TMath::Power(muon.pullX(i - 4, 2, arbitrationType), 2.) +
+                          TMath::Power(muon.pullY(i - 4, 2, arbitrationType), 2.)) > 1.) {
+            // reduce weight
+            if (use_match_dist_penalty) {
+              // only use pull if 3 sigma is not smaller than 3 cm
+              if (TMath::Sqrt(TMath::Power(muon.dX(i - 4, 2, arbitrationType), 2.) +
+                              TMath::Power(muon.dY(i - 4, 2, arbitrationType), 2.)) < 3. &&
+                  TMath::Sqrt(TMath::Power(muon.pullX(i - 4, 2, arbitrationType), 2.) +
+                              TMath::Power(muon.pullY(i - 4, 2, arbitrationType), 2.)) > 3.) {
+                station_weight[i - 1] *=
+                    1. /
+                    TMath::Power(TMath::Max((double)TMath::Sqrt(TMath::Power(muon.dX(i - 4, 2, arbitrationType), 2.) +
+                                                                TMath::Power(muon.dY(i - 4, 2, arbitrationType), 2.)),
+                                            (double)1.),
+                                 .25);
+              } else {
+                station_weight[i - 1] *=
+                    1. / TMath::Power(TMath::Sqrt(TMath::Power(muon.pullX(i - 4, 2, arbitrationType), 2.) +
+                                                  TMath::Power(muon.pullY(i - 4, 2, arbitrationType), 2.)),
+                                      .25);
+              }
+            }
+          }
+        }
       }
-	
+
       // Thoughts:
       // - should penalize if the segment has only x OR y info
       // - should also use the segment direction, as it now works!
-	
+
+    } else {  // track did not pass a chamber in this station - just reset weight
+      station_weight[i - 1] = 0.;
     }
-    else { // track did not pass a chamber in this station - just reset weight
-      station_weight[i-1] = 0.;
-    }
-      
+
     //increment final weight for muon:
-    full_weight += station_weight[i-1];
+    full_weight += station_weight[i - 1];
   }
 
   // if we don't expect any matches, we set the compatibility to
   // 0.5 as the track is as compatible with a muon as it is with
   // background - we should maybe rather set it to -0.5!
-  if( nr_of_stations_crossed == 0 ) {
+  if (nr_of_stations_crossed == 0) {
     //      full_weight = attenuate_weight_regain*0.5;
     full_weight = 0.5;
   }
@@ -288,368 +318,369 @@ float muon::segmentCompatibility(const reco::Muon& muon,reco::Muon::ArbitrationT
   // ************** end *************************************;
 
   return full_weight;
-
 }
 
-bool muon::isGoodMuon( const reco::Muon& muon, 
-			 AlgorithmType type,
-			 double minCompatibility,
-			 reco::Muon::ArbitrationType arbitrationType ) {
-  if (!muon.isMatchesValid()) return false;
+bool muon::isGoodMuon(const reco::Muon& muon,
+                      AlgorithmType type,
+                      double minCompatibility,
+                      reco::Muon::ArbitrationType arbitrationType) {
+  if (!muon.isMatchesValid())
+    return false;
   bool goodMuon = false;
-  
-  switch( type ) {
-  case TM2DCompatibility:
-    // Simplistic first cut in the 2D segment- vs calo-compatibility plane. Will have to be refined!
-    if( ( (0.8*caloCompatibility( muon ))+(1.2*segmentCompatibility( muon, arbitrationType )) ) > minCompatibility ) goodMuon = true;
-    else goodMuon = false;
-    return goodMuon;
-    break;
-  default : 
-    // 	LogTrace("MuonIdentification")<<"            // Invalid Algorithm Type called!";
-    goodMuon = false;
-    return goodMuon;
-    break;
+
+  switch (type) {
+    case TM2DCompatibility:
+      // Simplistic first cut in the 2D segment- vs calo-compatibility plane. Will have to be refined!
+      if (((0.8 * caloCompatibility(muon)) + (1.2 * segmentCompatibility(muon, arbitrationType))) > minCompatibility)
+        goodMuon = true;
+      else
+        goodMuon = false;
+      return goodMuon;
+      break;
+    default:
+      // 	LogTrace("MuonIdentification")<<"            // Invalid Algorithm Type called!";
+      goodMuon = false;
+      return goodMuon;
+      break;
   }
 }
 
-bool muon::isGoodMuon( const reco::Muon& muon,
-			 AlgorithmType type,
-			 int minNumberOfMatches,
-			 double maxAbsDx,
-			 double maxAbsPullX,
-			 double maxAbsDy,
-			 double maxAbsPullY,
-			 double maxChamberDist,
-			 double maxChamberDistPull,
-			 reco::Muon::ArbitrationType arbitrationType,
-             bool   syncMinNMatchesNRequiredStationsInBarrelOnly,
-             bool   applyAlsoAngularCuts)
-{
-   if (!muon.isMatchesValid()) return false;
-   bool goodMuon = false;
+bool muon::isGoodMuon(const reco::Muon& muon,
+                      AlgorithmType type,
+                      int minNumberOfMatches,
+                      double maxAbsDx,
+                      double maxAbsPullX,
+                      double maxAbsDy,
+                      double maxAbsPullY,
+                      double maxChamberDist,
+                      double maxChamberDistPull,
+                      reco::Muon::ArbitrationType arbitrationType,
+                      bool syncMinNMatchesNRequiredStationsInBarrelOnly,
+                      bool applyAlsoAngularCuts) {
+  if (!muon.isMatchesValid())
+    return false;
+  bool goodMuon = false;
 
-   if (type == TMLastStation) {
-      // To satisfy my own paranoia, if the user specifies that the
-      // minimum number of matches is zero, then return true.
-      if(minNumberOfMatches == 0) return true;
+  if (type == TMLastStation) {
+    // To satisfy my own paranoia, if the user specifies that the
+    // minimum number of matches is zero, then return true.
+    if (minNumberOfMatches == 0)
+      return true;
 
-      unsigned int theStationMask = muon.stationMask(arbitrationType);
-      unsigned int theRequiredStationMask = RequiredStationMask(muon, maxChamberDist, maxChamberDistPull, arbitrationType);
+    unsigned int theStationMask = muon.stationMask(arbitrationType);
+    unsigned int theRequiredStationMask =
+        RequiredStationMask(muon, maxChamberDist, maxChamberDistPull, arbitrationType);
 
-      // Require that there be at least a minimum number of segments
-      int numSegs = 0;
-      int numRequiredStations = 0;
-      for(int it = 0; it < 8; ++it) {
-         if(theStationMask & 1<<it) ++numSegs;
-         if(theRequiredStationMask & 1<<it) ++numRequiredStations;
+    // Require that there be at least a minimum number of segments
+    int numSegs = 0;
+    int numRequiredStations = 0;
+    for (int it = 0; it < 8; ++it) {
+      if (theStationMask & 1 << it)
+        ++numSegs;
+      if (theRequiredStationMask & 1 << it)
+        ++numRequiredStations;
+    }
+
+    // Make sure the minimum number of matches is not greater than
+    // the number of required stations but still greater than zero
+    if (syncMinNMatchesNRequiredStationsInBarrelOnly) {
+      // Note that we only do this in the barrel region!
+      if (fabs(muon.eta()) < 1.2) {
+        if (minNumberOfMatches > numRequiredStations)
+          minNumberOfMatches = numRequiredStations;
+        if (minNumberOfMatches < 1)  //SK: this only happens for negative values
+          minNumberOfMatches = 1;
       }
+    } else {
+      if (minNumberOfMatches > numRequiredStations)
+        minNumberOfMatches = numRequiredStations;
+      if (minNumberOfMatches < 1)  //SK: this only happens for negative values
+        minNumberOfMatches = 1;
+    }
 
-      // Make sure the minimum number of matches is not greater than
-      // the number of required stations but still greater than zero
-      if (syncMinNMatchesNRequiredStationsInBarrelOnly) {
-         // Note that we only do this in the barrel region!
-         if (fabs(muon.eta()) < 1.2) {
-            if(minNumberOfMatches > numRequiredStations)
-               minNumberOfMatches = numRequiredStations;
-            if(minNumberOfMatches < 1) //SK: this only happens for negative values
-               minNumberOfMatches = 1;
-         }
+    if (numSegs >= minNumberOfMatches)
+      goodMuon = true;
+
+    // Require that last required station have segment
+    // If there are zero required stations keep track
+    // of the last station with a segment so that we may
+    // apply the quality cuts below to it instead
+    int lastSegBit = 0;
+    if (theRequiredStationMask) {
+      for (int stationIdx = 7; stationIdx >= 0; --stationIdx)
+        if (theRequiredStationMask & 1 << stationIdx) {
+          if (theStationMask & 1 << stationIdx) {
+            lastSegBit = stationIdx;
+            goodMuon &= 1;
+            break;
+          } else {
+            goodMuon = false;
+            break;
+          }
+        }
+    } else {
+      for (int stationIdx = 7; stationIdx >= 0; --stationIdx)
+        if (theStationMask & 1 << stationIdx) {
+          lastSegBit = stationIdx;
+          break;
+        }
+    }
+
+    if (!goodMuon)
+      return false;
+
+    // Impose pull cuts on last segment
+    int station = 0, detector = 0;
+    station = lastSegBit < 4 ? lastSegBit + 1 : lastSegBit - 3;
+    detector = lastSegBit < 4 ? 1 : 2;
+
+    // Check x information
+    if (fabs(muon.pullX(station, detector, arbitrationType, true)) > maxAbsPullX &&
+        fabs(muon.dX(station, detector, arbitrationType)) > maxAbsDx)
+      return false;
+
+    if (applyAlsoAngularCuts && fabs(muon.pullDxDz(station, detector, arbitrationType, true)) > maxAbsPullX)
+      return false;
+
+    // Is this a tight algorithm, i.e. do we bother to check y information?
+    if (maxAbsDy < 999999) {  // really if maxAbsDy < 1E9 as currently defined
+
+      // Check y information
+      if (detector == 2) {  // CSC
+        if (fabs(muon.pullY(station, 2, arbitrationType, true)) > maxAbsPullY &&
+            fabs(muon.dY(station, 2, arbitrationType)) > maxAbsDy)
+          return false;
+
+        if (applyAlsoAngularCuts && fabs(muon.pullDyDz(station, 2, arbitrationType, true)) > maxAbsPullY)
+          return false;
       } else {
-         if(minNumberOfMatches > numRequiredStations)
-            minNumberOfMatches = numRequiredStations;
-         if(minNumberOfMatches < 1) //SK: this only happens for negative values
-            minNumberOfMatches = 1;
-      }
+        //
+        // In DT, if this is a "Tight" algorithm and the last segment is
+        // missing y information (always the case in station 4!!!), impose
+        // respective cuts on the next station in the stationMask that has
+        // a segment with y information.  If there are no segments with y
+        // information then there is nothing to penalize. Should we
+        // penalize in Tight for having zero segments with y information?
+        // That is the fundamental question.  Of course I am being uber
+        // paranoid; if this is a good muon then there will probably be at
+        // least one segment with y information but not always.  Suppose
+        // somehow a muon only creates segments in station 4, then we
+        // definitely do not want to require that there be at least one
+        // segment with y information because we will lose it completely.
+        //
 
-      if(numSegs >= minNumberOfMatches) goodMuon = true;
+        for (int stationIdx = station; stationIdx > 0; --stationIdx) {
+          if (!(theStationMask & 1 << (stationIdx - 1)))  // don't bother if the station is not in the stationMask
+            continue;
 
-      // Require that last required station have segment
-      // If there are zero required stations keep track
-      // of the last station with a segment so that we may
-      // apply the quality cuts below to it instead
-      int lastSegBit = 0;
-      if(theRequiredStationMask) {
-         for(int stationIdx = 7; stationIdx >= 0; --stationIdx)
-	   if(theRequiredStationMask & 1<<stationIdx){
-               if(theStationMask & 1<<stationIdx) {
-                  lastSegBit = stationIdx;
-                  goodMuon &= 1;
-                  break;
-               } else {
-                  goodMuon = false;
-                  break;
-               }
-	   }
-      } else {
-         for(int stationIdx = 7; stationIdx >= 0; --stationIdx)
-            if(theStationMask & 1<<stationIdx) {
-               lastSegBit = stationIdx;
-               break;
-            }
-      }
+          if (muon.dY(stationIdx, 1, arbitrationType) > 999998)  // no y-information
+            continue;
 
-      if(!goodMuon) return false;
-
-      // Impose pull cuts on last segment
-      int station = 0, detector = 0;
-      station  = lastSegBit < 4 ? lastSegBit+1 : lastSegBit-3;
-      detector = lastSegBit < 4 ? 1 : 2;
-
-      // Check x information
-      if(fabs(muon.pullX(station,detector,arbitrationType,true)) > maxAbsPullX &&
-            fabs(muon.dX(station,detector,arbitrationType)) > maxAbsDx)
-         return false;
-
-      if(applyAlsoAngularCuts && fabs(muon.pullDxDz(station,detector,arbitrationType,true)) > maxAbsPullX)
-         return false;
-
-      // Is this a tight algorithm, i.e. do we bother to check y information?
-      if (maxAbsDy < 999999) { // really if maxAbsDy < 1E9 as currently defined
-
-         // Check y information
-         if (detector == 2) { // CSC
-            if(fabs(muon.pullY(station,2,arbitrationType,true)) > maxAbsPullY &&
-                  fabs(muon.dY(station,2,arbitrationType)) > maxAbsDy)
-               return false;
-
-            if(applyAlsoAngularCuts && fabs(muon.pullDyDz(station,2,arbitrationType,true)) > maxAbsPullY)
-               return false;
-         } else {
-            //
-            // In DT, if this is a "Tight" algorithm and the last segment is
-            // missing y information (always the case in station 4!!!), impose
-            // respective cuts on the next station in the stationMask that has
-            // a segment with y information.  If there are no segments with y
-            // information then there is nothing to penalize. Should we
-            // penalize in Tight for having zero segments with y information?
-            // That is the fundamental question.  Of course I am being uber
-            // paranoid; if this is a good muon then there will probably be at
-            // least one segment with y information but not always.  Suppose
-            // somehow a muon only creates segments in station 4, then we
-            // definitely do not want to require that there be at least one
-            // segment with y information because we will lose it completely.
-            //
-
-            for (int stationIdx = station; stationIdx > 0; --stationIdx) {
-               if(! (theStationMask & 1<<(stationIdx-1)))  // don't bother if the station is not in the stationMask
-                  continue;
-
-               if(muon.dY(stationIdx,1,arbitrationType) > 999998) // no y-information
-                  continue;
-
-               if(fabs(muon.pullY(stationIdx,1,arbitrationType,true)) > maxAbsPullY &&
-                     fabs(muon.dY(stationIdx,1,arbitrationType)) > maxAbsDy) {
-                  return false;
-               }
-
-               if(applyAlsoAngularCuts && fabs(muon.pullDyDz(stationIdx,1,arbitrationType,true)) > maxAbsPullY)
-                  return false;
-
-               // If we get this far then great this is a good muon
-               return true;
-            }
-         }
-      }
-
-      return goodMuon;
-   } // TMLastStation
-
-   // TMOneStation requires only that there be one "good" segment, regardless
-   // of the required stations.  We do not penalize if there are absolutely zero
-   // segments with y information in the Tight algorithm.  Maybe I'm being
-   // paranoid but so be it.  If it's really a good muon then we will probably
-   // find at least one segment with both x and y information but you never
-   // know, and I don't want to deal with a potential inefficiency in the DT
-   // like we did with the original TMLastStation.  Incidentally, not penalizing
-   // for total lack of y information in the Tight algorithm is what is done in
-   // the new TMLastStation
-   //                   
-   if (type == TMOneStation) {
-      unsigned int theStationMask = muon.stationMask(arbitrationType);
-
-      // Of course there must be at least one segment
-      if (! theStationMask) return false;
-
-      int  station = 0, detector = 0;
-      // Keep track of whether or not there is a DT segment with y information.
-      // In the end, if it turns out there are absolutely zero DT segments with
-      // y information, require only that there was a segment with good x info.
-      // This of course only applies to the Tight algorithms.
-      bool existsGoodDTSegX = false;
-      bool existsDTSegY = false;
-
-      // Impose cuts on the segments in the station mask until we find a good one
-      // Might as well start with the lowest bit to speed things up.
-      for(int stationIdx = 0; stationIdx <= 7; ++stationIdx)
-         if(theStationMask & 1<<stationIdx) {
-            station  = stationIdx < 4 ? stationIdx+1 : stationIdx-3;
-            detector = stationIdx < 4 ? 1 : 2;
-
-            if((fabs(muon.pullX(station,detector,arbitrationType,true)) > maxAbsPullX &&
-                  fabs(muon.dX(station,detector,arbitrationType)) > maxAbsDx) ||
-                  (applyAlsoAngularCuts && fabs(muon.pullDxDz(station,detector,arbitrationType,true)) > maxAbsPullX))
-               continue;
-            else if (detector == 1)
-               existsGoodDTSegX = true;
-
-            // Is this a tight algorithm?  If yes, use y information
-            if (maxAbsDy < 999999) {
-               if (detector == 2) { // CSC
-                  if((fabs(muon.pullY(station,2,arbitrationType,true)) > maxAbsPullY &&
-                        fabs(muon.dY(station,2,arbitrationType)) > maxAbsDy) ||
-                        (applyAlsoAngularCuts && fabs(muon.pullDyDz(station,2,arbitrationType,true)) > maxAbsPullY))
-                     continue;
-               } else {
-
-                  if(muon.dY(station,1,arbitrationType) > 999998) // no y-information
-                     continue;
-                  else
-                     existsDTSegY = true;
-
-                  if((fabs(muon.pullY(station,1,arbitrationType,true)) > maxAbsPullY &&
-                        fabs(muon.dY(station,1,arbitrationType)) > maxAbsDy) ||
-                        (applyAlsoAngularCuts && fabs(muon.pullDyDz(station,1,arbitrationType,true)) > maxAbsPullY)) {
-                     continue;
-                  }
-               }
-            }
-
-            // If we get this far then great this is a good muon
-            return true;
-         }
-
-      // If we get this far then for sure there are no "good" CSC segments. For
-      // DT, check if there were any segments with y information.  If there
-      // were none, but there was a segment with good x, then we're happy. If 
-      // there WERE segments with y information, then they must have been shit
-      // since we are here so fail it.  Of course, if this is a Loose algorithm
-      // then fail immediately since if we had good x we would already have
-      // returned true
-      if (maxAbsDy < 999999) {
-         if (existsDTSegY)
+          if (fabs(muon.pullY(stationIdx, 1, arbitrationType, true)) > maxAbsPullY &&
+              fabs(muon.dY(stationIdx, 1, arbitrationType)) > maxAbsDy) {
             return false;
-         else if (existsGoodDTSegX)
-            return true;
-      } else
-         return false;
-   } // TMOneStation
+          }
 
-  if ( type == RPCMu )
-  {
-    if ( minNumberOfMatches == 0 ) return true;
-    
+          if (applyAlsoAngularCuts && fabs(muon.pullDyDz(stationIdx, 1, arbitrationType, true)) > maxAbsPullY)
+            return false;
+
+          // If we get this far then great this is a good muon
+          return true;
+        }
+      }
+    }
+
+    return goodMuon;
+  }  // TMLastStation
+
+  // TMOneStation requires only that there be one "good" segment, regardless
+  // of the required stations.  We do not penalize if there are absolutely zero
+  // segments with y information in the Tight algorithm.  Maybe I'm being
+  // paranoid but so be it.  If it's really a good muon then we will probably
+  // find at least one segment with both x and y information but you never
+  // know, and I don't want to deal with a potential inefficiency in the DT
+  // like we did with the original TMLastStation.  Incidentally, not penalizing
+  // for total lack of y information in the Tight algorithm is what is done in
+  // the new TMLastStation
+  //
+  if (type == TMOneStation) {
+    unsigned int theStationMask = muon.stationMask(arbitrationType);
+
+    // Of course there must be at least one segment
+    if (!theStationMask)
+      return false;
+
+    int station = 0, detector = 0;
+    // Keep track of whether or not there is a DT segment with y information.
+    // In the end, if it turns out there are absolutely zero DT segments with
+    // y information, require only that there was a segment with good x info.
+    // This of course only applies to the Tight algorithms.
+    bool existsGoodDTSegX = false;
+    bool existsDTSegY = false;
+
+    // Impose cuts on the segments in the station mask until we find a good one
+    // Might as well start with the lowest bit to speed things up.
+    for (int stationIdx = 0; stationIdx <= 7; ++stationIdx)
+      if (theStationMask & 1 << stationIdx) {
+        station = stationIdx < 4 ? stationIdx + 1 : stationIdx - 3;
+        detector = stationIdx < 4 ? 1 : 2;
+
+        if ((fabs(muon.pullX(station, detector, arbitrationType, true)) > maxAbsPullX &&
+             fabs(muon.dX(station, detector, arbitrationType)) > maxAbsDx) ||
+            (applyAlsoAngularCuts && fabs(muon.pullDxDz(station, detector, arbitrationType, true)) > maxAbsPullX))
+          continue;
+        else if (detector == 1)
+          existsGoodDTSegX = true;
+
+        // Is this a tight algorithm?  If yes, use y information
+        if (maxAbsDy < 999999) {
+          if (detector == 2) {  // CSC
+            if ((fabs(muon.pullY(station, 2, arbitrationType, true)) > maxAbsPullY &&
+                 fabs(muon.dY(station, 2, arbitrationType)) > maxAbsDy) ||
+                (applyAlsoAngularCuts && fabs(muon.pullDyDz(station, 2, arbitrationType, true)) > maxAbsPullY))
+              continue;
+          } else {
+            if (muon.dY(station, 1, arbitrationType) > 999998)  // no y-information
+              continue;
+            else
+              existsDTSegY = true;
+
+            if ((fabs(muon.pullY(station, 1, arbitrationType, true)) > maxAbsPullY &&
+                 fabs(muon.dY(station, 1, arbitrationType)) > maxAbsDy) ||
+                (applyAlsoAngularCuts && fabs(muon.pullDyDz(station, 1, arbitrationType, true)) > maxAbsPullY)) {
+              continue;
+            }
+          }
+        }
+
+        // If we get this far then great this is a good muon
+        return true;
+      }
+
+    // If we get this far then for sure there are no "good" CSC segments. For
+    // DT, check if there were any segments with y information.  If there
+    // were none, but there was a segment with good x, then we're happy. If
+    // there WERE segments with y information, then they must have been shit
+    // since we are here so fail it.  Of course, if this is a Loose algorithm
+    // then fail immediately since if we had good x we would already have
+    // returned true
+    if (maxAbsDy < 999999) {
+      if (existsDTSegY)
+        return false;
+      else if (existsGoodDTSegX)
+        return true;
+    } else
+      return false;
+  }  // TMOneStation
+
+  if (type == RPCMu) {
+    if (minNumberOfMatches == 0)
+      return true;
+
     int nMatch = 0;
-    for ( std::vector<reco::MuonChamberMatch>::const_iterator chamberMatch = muon.matches().begin();
-          chamberMatch != muon.matches().end(); ++chamberMatch )
-    {
-      if ( chamberMatch->detector() != 3 ) continue;
+    for (std::vector<reco::MuonChamberMatch>::const_iterator chamberMatch = muon.matches().begin();
+         chamberMatch != muon.matches().end();
+         ++chamberMatch) {
+      if (chamberMatch->detector() != 3)
+        continue;
 
       const double trkX = chamberMatch->x;
       const double errX = chamberMatch->xErr;
 
-      for ( std::vector<reco::MuonRPCHitMatch>::const_iterator rpcMatch = chamberMatch->rpcMatches.begin();
-            rpcMatch != chamberMatch->rpcMatches.end(); ++rpcMatch )
-      {
+      for (std::vector<reco::MuonRPCHitMatch>::const_iterator rpcMatch = chamberMatch->rpcMatches.begin();
+           rpcMatch != chamberMatch->rpcMatches.end();
+           ++rpcMatch) {
         const double rpcX = rpcMatch->x;
 
-        const double dX = fabs(rpcX-trkX);
-        if ( dX < maxAbsDx or dX/errX < maxAbsPullX )
-        {
+        const double dX = fabs(rpcX - trkX);
+        if (dX < maxAbsDx or dX / errX < maxAbsPullX) {
           ++nMatch;
           break;
         }
       }
     }
 
-    if ( nMatch >= minNumberOfMatches ) return true;
-    else return false;
-  } // RPCMu
-    
-  if ( type == ME0Mu )
-  {
-    if ( minNumberOfMatches == 0 ) return true;
-    
+    if (nMatch >= minNumberOfMatches)
+      return true;
+    else
+      return false;
+  }  // RPCMu
+
+  if (type == ME0Mu) {
+    if (minNumberOfMatches == 0)
+      return true;
+
     int nMatch = 0;
-    for ( const auto& chamberMatch : muon.matches() )
-    {
-      if ( chamberMatch.detector() != MuonSubdetId::ME0 ) continue;
+    for (const auto& chamberMatch : muon.matches()) {
+      if (chamberMatch.detector() != MuonSubdetId::ME0)
+        continue;
 
       const double trkX = chamberMatch.x;
       const double errX = chamberMatch.xErr;
       const double trkY = chamberMatch.y;
       const double errY = chamberMatch.yErr;
 
-      for ( const auto& segment : chamberMatch.me0Matches )
-      {
-          
+      for (const auto& segment : chamberMatch.me0Matches) {
         const double me0X = segment.x;
         const double me0ErrX = segment.xErr;
         const double me0Y = segment.y;
         const double me0ErrY = segment.yErr;
 
-        const double dX   = fabs(me0X - trkX);
-        const double dY   = fabs(me0Y - trkY);
-        const double pullX   = dX/std::sqrt(errX + me0ErrX);
-        const double pullY   = dY/std::sqrt(errY + me0ErrY);
-          
-        if ( (dX < maxAbsDx or pullX < maxAbsPullX) and (dY < maxAbsDy or pullY < maxAbsPullY) )
-        {
+        const double dX = fabs(me0X - trkX);
+        const double dY = fabs(me0Y - trkY);
+        const double pullX = dX / std::sqrt(errX + me0ErrX);
+        const double pullY = dY / std::sqrt(errY + me0ErrY);
+
+        if ((dX < maxAbsDx or pullX < maxAbsPullX) and (dY < maxAbsDy or pullY < maxAbsPullY)) {
           ++nMatch;
           break;
         }
       }
     }
 
-  return ( nMatch >= minNumberOfMatches );
-  } // ME0Mu
-    
-  if ( type == GEMMu )
-  {
-    if ( minNumberOfMatches == 0 ) return true;
-    
+    return (nMatch >= minNumberOfMatches);
+  }  // ME0Mu
+
+  if (type == GEMMu) {
+    if (minNumberOfMatches == 0)
+      return true;
+
     int nMatch = 0;
-    for ( const auto& chamberMatch : muon.matches() )
-    {
-      if ( chamberMatch.detector() != MuonSubdetId::GEM ) continue;
+    for (const auto& chamberMatch : muon.matches()) {
+      if (chamberMatch.detector() != MuonSubdetId::GEM)
+        continue;
 
       const double trkX = chamberMatch.x;
       const double errX = chamberMatch.xErr;
       const double trkY = chamberMatch.y;
       const double errY = chamberMatch.yErr;
 
-      for ( const auto& segment : chamberMatch.gemMatches )
-      {
-          
+      for (const auto& segment : chamberMatch.gemMatches) {
         const double gemX = segment.x;
         const double gemErrX = segment.xErr;
         const double gemY = segment.y;
         const double gemErrY = segment.yErr;
 
-        const double dX   = fabs(gemX - trkX);
-        const double dY   = fabs(gemY - trkY);
-        const double pullX   = dX/std::sqrt(errX + gemErrX);
-        const double pullY   = dY/std::sqrt(errY + gemErrY);
-          
-        if ( (dX < maxAbsDx or pullX < maxAbsPullX) and (dY < maxAbsDy or pullY < maxAbsPullY) )
-        {
+        const double dX = fabs(gemX - trkX);
+        const double dY = fabs(gemY - trkY);
+        const double pullX = dX / std::sqrt(errX + gemErrX);
+        const double pullY = dY / std::sqrt(errY + gemErrY);
+
+        if ((dX < maxAbsDx or pullX < maxAbsPullX) and (dY < maxAbsDy or pullY < maxAbsPullY)) {
           ++nMatch;
           break;
         }
       }
     }
 
-   return ( nMatch >= minNumberOfMatches );
-   } // GEMMu
+    return (nMatch >= minNumberOfMatches);
+  }  // GEMMu
 
-   return goodMuon;
+  return goodMuon;
 }
 
-bool muon::isGoodMuon( const reco::Muon& muon, SelectionType type,
-		       reco::Muon::ArbitrationType arbitrationType)
-{
-  switch (type)
-    {
+bool muon::isGoodMuon(const reco::Muon& muon, SelectionType type, reco::Muon::ArbitrationType arbitrationType) {
+  switch (type) {
     case muon::All:
       return true;
       break;
@@ -663,13 +694,14 @@ bool muon::isGoodMuon( const reco::Muon& muon, SelectionType type,
       return muon.isStandAloneMuon();
       break;
     case muon::TrackerMuonArbitrated:
-      return muon.isTrackerMuon() && muon.numberOfMatches(arbitrationType)>0;
+      return muon.isTrackerMuon() && muon.numberOfMatches(arbitrationType) > 0;
       break;
     case muon::AllArbitrated:
-      return ! muon.isTrackerMuon() || muon.numberOfMatches(arbitrationType)>0;
+      return !muon.isTrackerMuon() || muon.numberOfMatches(arbitrationType) > 0;
       break;
     case muon::GlobalMuonPromptTight:
-      return muon.isGlobalMuon() && muon.globalTrack()->normalizedChi2()<10. && muon.globalTrack()->hitPattern().numberOfValidMuonHits() >0;
+      return muon.isGlobalMuon() && muon.globalTrack()->normalizedChi2() < 10. &&
+             muon.globalTrack()->hitPattern().numberOfValidMuonHits() > 0;
       break;
       // For "Loose" algorithms we choose maximum y quantity cuts of 1E9 instead of
       // 9999 as before.  We do this because the muon methods return 999999 (note
@@ -682,244 +714,266 @@ bool muon::isGoodMuon( const reco::Muon& muon, SelectionType type,
       // TMLastStation and TMOneStation algorithms we actually use this huge number
       // to determine whether to consider y information at all.
     case muon::TMLastStationLoose:
-      return muon.isTrackerMuon() && isGoodMuon(muon,TMLastStation,2,3,3,1E9,1E9,-3,-3,arbitrationType,true,false);
+      return muon.isTrackerMuon() &&
+             isGoodMuon(muon, TMLastStation, 2, 3, 3, 1E9, 1E9, -3, -3, arbitrationType, true, false);
       break;
     case muon::TMLastStationTight:
-      return muon.isTrackerMuon() && isGoodMuon(muon,TMLastStation,2,3,3,3,3,-3,-3,arbitrationType,true,false);
+      return muon.isTrackerMuon() &&
+             isGoodMuon(muon, TMLastStation, 2, 3, 3, 3, 3, -3, -3, arbitrationType, true, false);
       break;
     case muon::TMOneStationLoose:
-      return muon.isTrackerMuon() && isGoodMuon(muon,TMOneStation,1,3,3,1E9,1E9,1E9,1E9,arbitrationType,false,false);
+      return muon.isTrackerMuon() &&
+             isGoodMuon(muon, TMOneStation, 1, 3, 3, 1E9, 1E9, 1E9, 1E9, arbitrationType, false, false);
       break;
     case muon::TMOneStationTight:
-      return muon.isTrackerMuon() && isGoodMuon(muon,TMOneStation,1,3,3,3,3,1E9,1E9,arbitrationType,false,false);
+      return muon.isTrackerMuon() &&
+             isGoodMuon(muon, TMOneStation, 1, 3, 3, 3, 3, 1E9, 1E9, arbitrationType, false, false);
       break;
     case muon::TMLastStationOptimizedLowPtLoose:
       if (muon.pt() < 8. && fabs(muon.eta()) < 1.2)
-	return muon.isTrackerMuon() && isGoodMuon(muon,TMOneStation,1,3,3,1E9,1E9,1E9,1E9,arbitrationType,false,false);
+        return muon.isTrackerMuon() &&
+               isGoodMuon(muon, TMOneStation, 1, 3, 3, 1E9, 1E9, 1E9, 1E9, arbitrationType, false, false);
       else
-	return muon.isTrackerMuon() && isGoodMuon(muon,TMLastStation,2,3,3,1E9,1E9,-3,-3,arbitrationType,false,false);
+        return muon.isTrackerMuon() &&
+               isGoodMuon(muon, TMLastStation, 2, 3, 3, 1E9, 1E9, -3, -3, arbitrationType, false, false);
       break;
     case muon::TMLastStationOptimizedLowPtTight:
       if (muon.pt() < 8. && fabs(muon.eta()) < 1.2)
-	return muon.isTrackerMuon() && isGoodMuon(muon,TMOneStation,1,3,3,3,3,1E9,1E9,arbitrationType,false,false);
+        return muon.isTrackerMuon() &&
+               isGoodMuon(muon, TMOneStation, 1, 3, 3, 3, 3, 1E9, 1E9, arbitrationType, false, false);
       else
-	return muon.isTrackerMuon() && isGoodMuon(muon,TMLastStation,2,3,3,3,3,-3,-3,arbitrationType,false,false);
+        return muon.isTrackerMuon() &&
+               isGoodMuon(muon, TMLastStation, 2, 3, 3, 3, 3, -3, -3, arbitrationType, false, false);
       break;
       //compatibility loose
     case muon::TM2DCompatibilityLoose:
-      return muon.isTrackerMuon() && isGoodMuon(muon,TM2DCompatibility,0.7,arbitrationType);
+      return muon.isTrackerMuon() && isGoodMuon(muon, TM2DCompatibility, 0.7, arbitrationType);
       break;
       //compatibility tight
     case muon::TM2DCompatibilityTight:
-      return muon.isTrackerMuon() && isGoodMuon(muon,TM2DCompatibility,1.0,arbitrationType);
+      return muon.isTrackerMuon() && isGoodMuon(muon, TM2DCompatibility, 1.0, arbitrationType);
       break;
     case muon::GMTkChiCompatibility:
-      return muon.isGlobalMuon() && muon.isQualityValid() && fabs(muon.combinedQuality().trkRelChi2 - muon.innerTrack()->normalizedChi2()) < 2.0;
+      return muon.isGlobalMuon() && muon.isQualityValid() &&
+             fabs(muon.combinedQuality().trkRelChi2 - muon.innerTrack()->normalizedChi2()) < 2.0;
       break;
     case muon::GMStaChiCompatibility:
-      return muon.isGlobalMuon() && muon.isQualityValid() && fabs(muon.combinedQuality().staRelChi2 - muon.outerTrack()->normalizedChi2()) < 2.0;
+      return muon.isGlobalMuon() && muon.isQualityValid() &&
+             fabs(muon.combinedQuality().staRelChi2 - muon.outerTrack()->normalizedChi2()) < 2.0;
       break;
     case muon::GMTkKinkTight:
       return muon.isGlobalMuon() && muon.isQualityValid() && muon.combinedQuality().trkKink < 100.0;
       break;
     case muon::TMLastStationAngLoose:
-      return muon.isTrackerMuon() && isGoodMuon(muon,TMLastStation,2,3,3,1E9,1E9,-3,-3,arbitrationType,false,true);
+      return muon.isTrackerMuon() &&
+             isGoodMuon(muon, TMLastStation, 2, 3, 3, 1E9, 1E9, -3, -3, arbitrationType, false, true);
       break;
     case muon::TMLastStationAngTight:
-      return muon.isTrackerMuon() && isGoodMuon(muon,TMLastStation,2,3,3,3,3,-3,-3,arbitrationType,false,true);
+      return muon.isTrackerMuon() &&
+             isGoodMuon(muon, TMLastStation, 2, 3, 3, 3, 3, -3, -3, arbitrationType, false, true);
       break;
     case muon::TMOneStationAngLoose:
-      return muon.isTrackerMuon() && isGoodMuon(muon,TMOneStation,1,3,3,1E9,1E9,1E9,1E9,arbitrationType,false,true);
+      return muon.isTrackerMuon() &&
+             isGoodMuon(muon, TMOneStation, 1, 3, 3, 1E9, 1E9, 1E9, 1E9, arbitrationType, false, true);
       break;
     case muon::TMOneStationAngTight:
-      return muon.isTrackerMuon() && isGoodMuon(muon,TMOneStation,1,3,3,3,3,1E9,1E9,arbitrationType,false,true);
+      return muon.isTrackerMuon() &&
+             isGoodMuon(muon, TMOneStation, 1, 3, 3, 3, 3, 1E9, 1E9, arbitrationType, false, true);
       break;
     case muon::TMLastStationOptimizedBarrelLowPtLoose:
       if (muon.pt() < 8. && fabs(muon.eta()) < 1.2)
-	return muon.isTrackerMuon() && isGoodMuon(muon,TMOneStation,1,3,3,1E9,1E9,1E9,1E9,arbitrationType,false,false);
+        return muon.isTrackerMuon() &&
+               isGoodMuon(muon, TMOneStation, 1, 3, 3, 1E9, 1E9, 1E9, 1E9, arbitrationType, false, false);
       else
-	return muon.isTrackerMuon() && isGoodMuon(muon,TMLastStation,2,3,3,1E9,1E9,-3,-3,arbitrationType,true,false);
+        return muon.isTrackerMuon() &&
+               isGoodMuon(muon, TMLastStation, 2, 3, 3, 1E9, 1E9, -3, -3, arbitrationType, true, false);
       break;
     case muon::TMLastStationOptimizedBarrelLowPtTight:
       if (muon.pt() < 8. && fabs(muon.eta()) < 1.2)
-	return muon.isTrackerMuon() && isGoodMuon(muon,TMOneStation,1,3,3,3,3,1E9,1E9,arbitrationType,false,false);
+        return muon.isTrackerMuon() &&
+               isGoodMuon(muon, TMOneStation, 1, 3, 3, 3, 3, 1E9, 1E9, arbitrationType, false, false);
       else
-	return muon.isTrackerMuon() && isGoodMuon(muon,TMLastStation,2,3,3,3,3,-3,-3,arbitrationType,true,false);
+        return muon.isTrackerMuon() &&
+               isGoodMuon(muon, TMLastStation, 2, 3, 3, 3, 3, -3, -3, arbitrationType, true, false);
       break;
     case muon::RPCMuLoose:
-	return muon.isRPCMuon() && isGoodMuon(muon, RPCMu, 2, 20, 4, 1e9, 1e9, 1e9, 1e9, arbitrationType, false, false);
+      return muon.isRPCMuon() && isGoodMuon(muon, RPCMu, 2, 20, 4, 1e9, 1e9, 1e9, 1e9, arbitrationType, false, false);
       break;
     case muon::AllME0Muons:
-	  return muon.isME0Muon();
+      return muon.isME0Muon();
       break;
     case muon::ME0MuonArbitrated:
-	  return muon.isME0Muon() && isGoodMuon(muon, ME0Mu, 1, 1e9, 1e9, 1e9, 1e9, 1e9, 1e9, arbitrationType, false, false);
+      return muon.isME0Muon() &&
+             isGoodMuon(muon, ME0Mu, 1, 1e9, 1e9, 1e9, 1e9, 1e9, 1e9, arbitrationType, false, false);
       break;
     case muon::AllGEMMuons:
-	  return muon.isGEMMuon();
+      return muon.isGEMMuon();
       break;
     case muon::GEMMuonArbitrated:
-	  return muon.isGEMMuon() && isGoodMuon(muon, GEMMu, 1, 1e9, 1e9, 1e9, 1e9, 1e9, 1e9, arbitrationType, false, false);
+      return muon.isGEMMuon() &&
+             isGoodMuon(muon, GEMMu, 1, 1e9, 1e9, 1e9, 1e9, 1e9, 1e9, arbitrationType, false, false);
       break;
     case muon::TriggerIdLoose:
       return isLooseTriggerMuon(muon);
       break;
     default:
       return false;
-    }
+  }
 }
 
-bool muon::overlap( const reco::Muon& muon1, const reco::Muon& muon2, 
-		    double pullX, double pullY, bool checkAdjacentChambers)
-{
+bool muon::overlap(
+    const reco::Muon& muon1, const reco::Muon& muon2, double pullX, double pullY, bool checkAdjacentChambers) {
   unsigned int nMatches1 = muon1.numberOfMatches(reco::Muon::SegmentAndTrackArbitration);
   unsigned int nMatches2 = muon2.numberOfMatches(reco::Muon::SegmentAndTrackArbitration);
-  unsigned int betterMuon = ( muon1.pt() > muon2.pt() ? 1 : 2 );
-  for ( std::vector<reco::MuonChamberMatch>::const_iterator chamber1 = muon1.matches().begin();
-	   chamber1 != muon1.matches().end(); ++chamber1 )
-    for ( std::vector<reco::MuonChamberMatch>::const_iterator chamber2 = muon2.matches().begin();
-	  chamber2 != muon2.matches().end(); ++chamber2 )
-      {
-	
-	// if ( (chamber1->segmentMatches.empty() || chamber2->segmentMatches.empty()) ) continue;
-	
-	// handle case where both muons have information about the same chamber
-	// here we know how close they are 
-	if ( chamber1->id == chamber2->id ){
-	  // found the same chamber
-	  if ( fabs(chamber1->x-chamber2->x) < 
-	       pullX * sqrt(chamber1->xErr*chamber1->xErr+chamber2->xErr*chamber2->xErr) )
-	    {
-	      if ( betterMuon == 1 )
-		nMatches2--;
-	      else
-		nMatches1--;
-	      if ( nMatches1==0 || nMatches2==0 ) return true;
-	      continue;
-	    }
-	  if ( fabs(chamber1->y-chamber2->y) < 
-	       pullY * sqrt(chamber1->yErr*chamber1->yErr+chamber2->yErr*chamber2->yErr) )
-	    {
-	      if ( betterMuon == 1 )
-		nMatches2--;
-	      else
-		nMatches1--;
-	      if ( nMatches1==0 || nMatches2==0 ) return true;
-	    }
-	} else {
-	  if ( ! checkAdjacentChambers ) continue;
-	  // check if tracks are pointing into overlaping region of the CSC detector
-	  if ( chamber1->id.subdetId() != MuonSubdetId::CSC || 
-	       chamber2->id.subdetId() != MuonSubdetId::CSC ) continue;
-	  CSCDetId id1(chamber1->id);
-	  CSCDetId id2(chamber2->id);
-	  if ( id1.endcap()  != id2.endcap() )  continue;
-	  if ( id1.station() != id2.station() ) continue;
-	  if ( id1.ring()    != id2.ring() )    continue;
-	  if ( abs(id1.chamber() - id2.chamber())>1 ) continue;
-	  // FIXME: we don't handle 18->1; 36->1 transitions since 
-	  // I don't know how to check for sure how many chambers
-	  // are there. Probably need to hard code some checks.
-	  
-	  // Now we have to make sure that both tracks are close to an edge
-	  // FIXME: ignored Y coordinate for now
-	  if ( fabs(chamber1->edgeX) > chamber1->xErr*pullX ) continue;
-	  if ( fabs(chamber2->edgeX) > chamber2->xErr*pullX ) continue;
-	  if ( chamber1->x * chamber2->x < 0 ) { // check if the same edge
-	    if ( betterMuon == 1 )
-	      nMatches2--;
-	    else
-	      nMatches1--;
-	    if ( nMatches1==0 || nMatches2==0 ) return true;
-	  }
-	}
+  unsigned int betterMuon = (muon1.pt() > muon2.pt() ? 1 : 2);
+  for (std::vector<reco::MuonChamberMatch>::const_iterator chamber1 = muon1.matches().begin();
+       chamber1 != muon1.matches().end();
+       ++chamber1)
+    for (std::vector<reco::MuonChamberMatch>::const_iterator chamber2 = muon2.matches().begin();
+         chamber2 != muon2.matches().end();
+         ++chamber2) {
+      // if ( (chamber1->segmentMatches.empty() || chamber2->segmentMatches.empty()) ) continue;
+
+      // handle case where both muons have information about the same chamber
+      // here we know how close they are
+      if (chamber1->id == chamber2->id) {
+        // found the same chamber
+        if (fabs(chamber1->x - chamber2->x) <
+            pullX * sqrt(chamber1->xErr * chamber1->xErr + chamber2->xErr * chamber2->xErr)) {
+          if (betterMuon == 1)
+            nMatches2--;
+          else
+            nMatches1--;
+          if (nMatches1 == 0 || nMatches2 == 0)
+            return true;
+          continue;
+        }
+        if (fabs(chamber1->y - chamber2->y) <
+            pullY * sqrt(chamber1->yErr * chamber1->yErr + chamber2->yErr * chamber2->yErr)) {
+          if (betterMuon == 1)
+            nMatches2--;
+          else
+            nMatches1--;
+          if (nMatches1 == 0 || nMatches2 == 0)
+            return true;
+        }
+      } else {
+        if (!checkAdjacentChambers)
+          continue;
+        // check if tracks are pointing into overlaping region of the CSC detector
+        if (chamber1->id.subdetId() != MuonSubdetId::CSC || chamber2->id.subdetId() != MuonSubdetId::CSC)
+          continue;
+        CSCDetId id1(chamber1->id);
+        CSCDetId id2(chamber2->id);
+        if (id1.endcap() != id2.endcap())
+          continue;
+        if (id1.station() != id2.station())
+          continue;
+        if (id1.ring() != id2.ring())
+          continue;
+        if (abs(id1.chamber() - id2.chamber()) > 1)
+          continue;
+        // FIXME: we don't handle 18->1; 36->1 transitions since
+        // I don't know how to check for sure how many chambers
+        // are there. Probably need to hard code some checks.
+
+        // Now we have to make sure that both tracks are close to an edge
+        // FIXME: ignored Y coordinate for now
+        if (fabs(chamber1->edgeX) > chamber1->xErr * pullX)
+          continue;
+        if (fabs(chamber2->edgeX) > chamber2->xErr * pullX)
+          continue;
+        if (chamber1->x * chamber2->x < 0) {  // check if the same edge
+          if (betterMuon == 1)
+            nMatches2--;
+          else
+            nMatches1--;
+          if (nMatches1 == 0 || nMatches2 == 0)
+            return true;
+        }
       }
+    }
   return false;
 }
 
-
-bool muon::isLooseTriggerMuon(const reco::Muon& muon){
+bool muon::isLooseTriggerMuon(const reco::Muon& muon) {
   // Requirements:
   // - no depencence on information not availabe in the muon object
   // - use only robust inputs
   bool tk_id = muon::isGoodMuon(muon, TMOneStationTight);
-  if ( not tk_id ) return false;
+  if (not tk_id)
+    return false;
   bool layer_requirements = muon.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5 &&
-    muon.innerTrack()->hitPattern().pixelLayersWithMeasurement() > 0;
-  bool match_requirements = (muon.expectedNnumberOfMatchedStations()<2) or (muon.numberOfMatchedStations()>1) or (muon.pt()<8);
+                            muon.innerTrack()->hitPattern().pixelLayersWithMeasurement() > 0;
+  bool match_requirements =
+      (muon.expectedNnumberOfMatchedStations() < 2) or (muon.numberOfMatchedStations() > 1) or (muon.pt() < 8);
   return layer_requirements and match_requirements;
 }
 
-bool muon::isTightMuon(const reco::Muon& muon, const reco::Vertex& vtx){
+bool muon::isTightMuon(const reco::Muon& muon, const reco::Vertex& vtx) {
+  if (!muon.isPFMuon() || !muon.isGlobalMuon())
+    return false;
 
-  if(!muon.isPFMuon() || !muon.isGlobalMuon() ) return false;
+  bool muID = isGoodMuon(muon, GlobalMuonPromptTight) && (muon.numberOfMatchedStations() > 1);
 
-  bool muID = isGoodMuon(muon,GlobalMuonPromptTight) && (muon.numberOfMatchedStations() > 1);
-    
-  
   bool hits = muon.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5 &&
-    muon.innerTrack()->hitPattern().numberOfValidPixelHits() > 0; 
+              muon.innerTrack()->hitPattern().numberOfValidPixelHits() > 0;
 
-  
-  bool ip = fabs(muon.muonBestTrack()->dxy(vtx.position())) < 0.2 && fabs(muon.muonBestTrack()->dz(vtx.position())) < 0.5;
-  
+  bool ip =
+      fabs(muon.muonBestTrack()->dxy(vtx.position())) < 0.2 && fabs(muon.muonBestTrack()->dz(vtx.position())) < 0.5;
+
   return muID && hits && ip;
 }
 
-
-bool muon::isLooseMuon(const reco::Muon& muon){
-  return muon.isPFMuon() && ( muon.isGlobalMuon() || muon.isTrackerMuon());
+bool muon::isLooseMuon(const reco::Muon& muon) {
+  return muon.isPFMuon() && (muon.isGlobalMuon() || muon.isTrackerMuon());
 }
 
-
-bool muon::isMediumMuon(const reco::Muon& muon, bool run2016_hip_mitigation){
-  if( not isLooseMuon(muon) ) return false;
-  if (run2016_hip_mitigation){
-    if (muon.innerTrack()->validFraction() < 0.49 ) return false; 
+bool muon::isMediumMuon(const reco::Muon& muon, bool run2016_hip_mitigation) {
+  if (not isLooseMuon(muon))
+    return false;
+  if (run2016_hip_mitigation) {
+    if (muon.innerTrack()->validFraction() < 0.49)
+      return false;
   } else {
-    if (muon.innerTrack()->validFraction() < 0.8 ) return false; 
+    if (muon.innerTrack()->validFraction() < 0.8)
+      return false;
   }
 
-  bool goodGlb = muon.isGlobalMuon() && 
-    muon.globalTrack()->normalizedChi2() < 3. && 
-    muon.combinedQuality().chi2LocalPosition < 12. && 
-    muon.combinedQuality().trkKink < 20.; 
+  bool goodGlb = muon.isGlobalMuon() && muon.globalTrack()->normalizedChi2() < 3. &&
+                 muon.combinedQuality().chi2LocalPosition < 12. && muon.combinedQuality().trkKink < 20.;
 
-  return (segmentCompatibility(muon) > (goodGlb ? 0.303 : 0.451)); 
+  return (segmentCompatibility(muon) > (goodGlb ? 0.303 : 0.451));
 }
 
-bool muon::isSoftMuon(const reco::Muon& muon, const reco::Vertex& vtx,
-		      bool run2016_hip_mitigation){
-
+bool muon::isSoftMuon(const reco::Muon& muon, const reco::Vertex& vtx, bool run2016_hip_mitigation) {
   bool muID = muon::isGoodMuon(muon, TMOneStationTight);
 
-  if(!muID) return false;
-  
-  bool layers = muon.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5 &&
-    muon.innerTrack()->hitPattern().pixelLayersWithMeasurement() > 0;
+  if (!muID)
+    return false;
 
-  bool ishighq = muon.innerTrack()->quality(reco::Track::highPurity); 
-  
+  bool layers = muon.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5 &&
+                muon.innerTrack()->hitPattern().pixelLayersWithMeasurement() > 0;
+
+  bool ishighq = muon.innerTrack()->quality(reco::Track::highPurity);
+
   bool ip = fabs(muon.innerTrack()->dxy(vtx.position())) < 0.3 && fabs(muon.innerTrack()->dz(vtx.position())) < 20.;
-  
-  return layers && ip && (ishighq|run2016_hip_mitigation);
+
+  return layers && ip && (ishighq | run2016_hip_mitigation);
 }
 
+bool muon::isHighPtMuon(const reco::Muon& muon, const reco::Vertex& vtx) {
+  if (!muon.isGlobalMuon())
+    return false;
 
+  bool muValHits = (muon.globalTrack()->hitPattern().numberOfValidMuonHits() > 0 ||
+                    muon.tunePMuonBestTrack()->hitPattern().numberOfValidMuonHits() > 0);
 
-bool muon::isHighPtMuon(const reco::Muon& muon, const reco::Vertex& vtx){
-  if(!muon.isGlobalMuon()) return false;
-
-  bool muValHits = ( muon.globalTrack()->hitPattern().numberOfValidMuonHits()>0 ||
-                     muon.tunePMuonBestTrack()->hitPattern().numberOfValidMuonHits()>0 );
-
-  bool muMatchedSt = muon.numberOfMatchedStations()>1;
-  if(!muMatchedSt) {
-    if( muon.isTrackerMuon() && muon.numberOfMatchedStations()==1 ) {
-      if( muon.expectedNnumberOfMatchedStations()<2 ||
-          !(muon.stationMask()==1 || muon.stationMask()==16) ||
-          muon.numberOfMatchedRPCLayers()>2
-        )
+  bool muMatchedSt = muon.numberOfMatchedStations() > 1;
+  if (!muMatchedSt) {
+    if (muon.isTrackerMuon() && muon.numberOfMatchedStations() == 1) {
+      if (muon.expectedNnumberOfMatchedStations() < 2 || !(muon.stationMask() == 1 || muon.stationMask() == 16) ||
+          muon.numberOfMatchedRPCLayers() > 2)
         muMatchedSt = true;
     }
   }
@@ -927,126 +981,146 @@ bool muon::isHighPtMuon(const reco::Muon& muon, const reco::Vertex& vtx){
   bool muID = muValHits && muMatchedSt;
 
   bool hits = muon.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5 &&
-    muon.innerTrack()->hitPattern().numberOfValidPixelHits() > 0; 
+              muon.innerTrack()->hitPattern().numberOfValidPixelHits() > 0;
 
-  bool momQuality = muon.tunePMuonBestTrack()->ptError()/muon.tunePMuonBestTrack()->pt() < 0.3;
+  bool momQuality = muon.tunePMuonBestTrack()->ptError() / muon.tunePMuonBestTrack()->pt() < 0.3;
 
   bool ip = fabs(muon.innerTrack()->dxy(vtx.position())) < 0.2 && fabs(muon.innerTrack()->dz(vtx.position())) < 0.5;
 
   return muID && hits && momQuality && ip;
-
 }
 
-bool muon::isTrackerHighPtMuon(const reco::Muon& muon, const reco::Vertex& vtx){
-  bool muID =   muon.isTrackerMuon() && muon.track().isNonnull() && (muon.numberOfMatchedStations() > 1);
-  if(!muID) return false;
+bool muon::isTrackerHighPtMuon(const reco::Muon& muon, const reco::Vertex& vtx) {
+  bool muID = muon.isTrackerMuon() && muon.track().isNonnull() && (muon.numberOfMatchedStations() > 1);
+  if (!muID)
+    return false;
 
   bool hits = muon.innerTrack()->hitPattern().trackerLayersWithMeasurement() > 5 &&
-    muon.innerTrack()->hitPattern().numberOfValidPixelHits() > 0; 
+              muon.innerTrack()->hitPattern().numberOfValidPixelHits() > 0;
 
-  bool momQuality = muon.tunePMuonBestTrack()->ptError()/muon.tunePMuonBestTrack()->pt() < 0.3;
+  bool momQuality = muon.tunePMuonBestTrack()->ptError() / muon.tunePMuonBestTrack()->pt() < 0.3;
 
   bool ip = fabs(muon.innerTrack()->dxy(vtx.position())) < 0.2 && fabs(muon.innerTrack()->dz(vtx.position())) < 0.5;
-  
+
   return muID && hits && momQuality && ip;
-
 }
 
-int muon::sharedSegments( const reco::Muon& mu, const reco::Muon& mu2, unsigned int segmentArbitrationMask ) {
-    int ret = 0;
-   
-    // Will do with a stupid double loop, since creating and filling a map is probably _more_ inefficient for a single lookup.
-    for(std::vector<reco::MuonChamberMatch>::const_iterator chamberMatch = mu.matches().begin();
-        chamberMatch != mu.matches().end(); ++chamberMatch) {
-        if (chamberMatch->segmentMatches.empty()) continue;
-        for(std::vector<reco::MuonChamberMatch>::const_iterator chamberMatch2 = mu2.matches().begin();
-            chamberMatch2 != mu2.matches().end(); ++chamberMatch2) {
-            if (chamberMatch2->segmentMatches.empty()) continue;
-            if (chamberMatch2->id() != chamberMatch->id()) continue;
-            for(std::vector<reco::MuonSegmentMatch>::const_iterator segmentMatch = chamberMatch->segmentMatches.begin(); 
-                segmentMatch != chamberMatch->segmentMatches.end(); ++segmentMatch) {
-                if (!segmentMatch->isMask(segmentArbitrationMask)) continue;
-                for(std::vector<reco::MuonSegmentMatch>::const_iterator segmentMatch2 = chamberMatch2->segmentMatches.begin(); 
-                    segmentMatch2 != chamberMatch2->segmentMatches.end(); ++segmentMatch2) {
-                    if (!segmentMatch2->isMask(segmentArbitrationMask)) continue;
-                    if ((segmentMatch->cscSegmentRef.isNonnull() && segmentMatch->cscSegmentRef == segmentMatch2->cscSegmentRef) ||
-                        (segmentMatch-> dtSegmentRef.isNonnull() && segmentMatch-> dtSegmentRef == segmentMatch2-> dtSegmentRef) ) {
-                        ++ret;
-                    } // is the same
-                } // segment of mu2 in chamber
-            } // segment of mu1 in chamber
-        } // chamber of mu2
-    } // chamber of mu1
-  
-    return ret; 
+int muon::sharedSegments(const reco::Muon& mu, const reco::Muon& mu2, unsigned int segmentArbitrationMask) {
+  int ret = 0;
+
+  // Will do with a stupid double loop, since creating and filling a map is probably _more_ inefficient for a single lookup.
+  for (std::vector<reco::MuonChamberMatch>::const_iterator chamberMatch = mu.matches().begin();
+       chamberMatch != mu.matches().end();
+       ++chamberMatch) {
+    if (chamberMatch->segmentMatches.empty())
+      continue;
+    for (std::vector<reco::MuonChamberMatch>::const_iterator chamberMatch2 = mu2.matches().begin();
+         chamberMatch2 != mu2.matches().end();
+         ++chamberMatch2) {
+      if (chamberMatch2->segmentMatches.empty())
+        continue;
+      if (chamberMatch2->id() != chamberMatch->id())
+        continue;
+      for (std::vector<reco::MuonSegmentMatch>::const_iterator segmentMatch = chamberMatch->segmentMatches.begin();
+           segmentMatch != chamberMatch->segmentMatches.end();
+           ++segmentMatch) {
+        if (!segmentMatch->isMask(segmentArbitrationMask))
+          continue;
+        for (std::vector<reco::MuonSegmentMatch>::const_iterator segmentMatch2 = chamberMatch2->segmentMatches.begin();
+             segmentMatch2 != chamberMatch2->segmentMatches.end();
+             ++segmentMatch2) {
+          if (!segmentMatch2->isMask(segmentArbitrationMask))
+            continue;
+          if ((segmentMatch->cscSegmentRef.isNonnull() &&
+               segmentMatch->cscSegmentRef == segmentMatch2->cscSegmentRef) ||
+              (segmentMatch->dtSegmentRef.isNonnull() && segmentMatch->dtSegmentRef == segmentMatch2->dtSegmentRef)) {
+            ++ret;
+          }  // is the same
+        }    // segment of mu2 in chamber
+      }      // segment of mu1 in chamber
+    }        // chamber of mu2
+  }          // chamber of mu1
+
+  return ret;
 }
 
-bool outOfTimeMuon(const reco::Muon& muon){
+bool outOfTimeMuon(const reco::Muon& muon) {
   const auto& combinedTime = muon.time();
-  const auto& rpcTime      = muon.rpcTime();
-  bool combinedTimeIsOk = (combinedTime.nDof>7);
-  bool rpcTimeIsOk = (rpcTime.nDof>1 && fabs(rpcTime.timeAtIpInOutErr)<0.001);
+  const auto& rpcTime = muon.rpcTime();
+  bool combinedTimeIsOk = (combinedTime.nDof > 7);
+  bool rpcTimeIsOk = (rpcTime.nDof > 1 && fabs(rpcTime.timeAtIpInOutErr) < 0.001);
   bool outOfTime = false;
-  if (rpcTimeIsOk){
-    if ( (fabs(rpcTime.timeAtIpInOut)>10 ) &&
-	 !(combinedTimeIsOk && fabs(combinedTime.timeAtIpInOut)<10) )
-      outOfTime = true; 
+  if (rpcTimeIsOk) {
+    if ((fabs(rpcTime.timeAtIpInOut) > 10) && !(combinedTimeIsOk && fabs(combinedTime.timeAtIpInOut) < 10))
+      outOfTime = true;
   } else {
-    if (combinedTimeIsOk && (combinedTime.timeAtIpInOut>20 || combinedTime.timeAtIpInOut<-45))
-      outOfTime = true; 
+    if (combinedTimeIsOk && (combinedTime.timeAtIpInOut > 20 || combinedTime.timeAtIpInOut < -45))
+      outOfTime = true;
   }
   return outOfTime;
 }
 
-
-reco::Muon::Selector muon::makeSelectorBitset( reco::Muon const& muon, 
-                                               reco::Vertex const* vertex,
-                                               bool run2016_hip_mitigation )
-{
+reco::Muon::Selector muon::makeSelectorBitset(reco::Muon const& muon,
+                                              reco::Vertex const* vertex,
+                                              bool run2016_hip_mitigation) {
   // https://twiki.cern.ch/twiki/bin/viewauth/CMS/SWGuideMuonIdRun2
   unsigned int selectors = muon.selectors();
   // Compute Id and Isolation variables
-  double chIso  = muon.pfIsolationR04().sumChargedHadronPt;
-  double nIso   = muon.pfIsolationR04().sumNeutralHadronEt;
+  double chIso = muon.pfIsolationR04().sumChargedHadronPt;
+  double nIso = muon.pfIsolationR04().sumNeutralHadronEt;
   double phoIso = muon.pfIsolationR04().sumPhotonEt;
-  double puIso  = muon.pfIsolationR04().sumPUPt;
-  double dbCorrectedIsolation = chIso + std::max( nIso + phoIso - .5*puIso, 0. ) ;
-  double dbCorrectedRelIso = dbCorrectedIsolation/muon.pt();
-  double tkRelIso = muon.isolationR03().sumPt/muon.pt();
+  double puIso = muon.pfIsolationR04().sumPUPt;
+  double dbCorrectedIsolation = chIso + std::max(nIso + phoIso - .5 * puIso, 0.);
+  double dbCorrectedRelIso = dbCorrectedIsolation / muon.pt();
+  double tkRelIso = muon.isolationR03().sumPt / muon.pt();
 
   // Base selectors
-  if (muon::isLooseMuon(muon))        selectors |= reco::Muon::CutBasedIdLoose;
-  if (vertex){
-    if (muon::isTightMuon(muon,*vertex))  selectors |= reco::Muon::CutBasedIdTight;
-    if (muon::isSoftMuon(muon,*vertex,run2016_hip_mitigation))   selectors |= reco::Muon::SoftCutBasedId;
-    if (muon::isHighPtMuon(muon,*vertex)) selectors |= reco::Muon::CutBasedIdGlobalHighPt;
-    if (muon::isTrackerHighPtMuon(muon,*vertex)) selectors |= reco::Muon::CutBasedIdTrkHighPt;
+  if (muon::isLooseMuon(muon))
+    selectors |= reco::Muon::CutBasedIdLoose;
+  if (vertex) {
+    if (muon::isTightMuon(muon, *vertex))
+      selectors |= reco::Muon::CutBasedIdTight;
+    if (muon::isSoftMuon(muon, *vertex, run2016_hip_mitigation))
+      selectors |= reco::Muon::SoftCutBasedId;
+    if (muon::isHighPtMuon(muon, *vertex))
+      selectors |= reco::Muon::CutBasedIdGlobalHighPt;
+    if (muon::isTrackerHighPtMuon(muon, *vertex))
+      selectors |= reco::Muon::CutBasedIdTrkHighPt;
   }
-  if (muon::isMediumMuon(muon,run2016_hip_mitigation)){
+  if (muon::isMediumMuon(muon, run2016_hip_mitigation)) {
     selectors |= reco::Muon::CutBasedIdMedium;
-    if ( vertex and 
-	 fabs(muon.muonBestTrack()->dz( vertex->position()))<0.1 and 
-	 fabs(muon.muonBestTrack()->dxy(vertex->position()))< 0.02 )
+    if (vertex and fabs(muon.muonBestTrack()->dz(vertex->position())) < 0.1 and
+        fabs(muon.muonBestTrack()->dxy(vertex->position())) < 0.02)
       selectors |= reco::Muon::CutBasedIdMediumPrompt;
   }
 
   // PF isolation
-  if (dbCorrectedRelIso<0.40)    selectors |= reco::Muon::PFIsoVeryLoose;
-  if (dbCorrectedRelIso<0.25)    selectors |= reco::Muon::PFIsoLoose;
-  if (dbCorrectedRelIso<0.20)    selectors |= reco::Muon::PFIsoMedium;
-  if (dbCorrectedRelIso<0.15)    selectors |= reco::Muon::PFIsoTight;
-  if (dbCorrectedRelIso<0.10)    selectors |= reco::Muon::PFIsoVeryTight;
-  if (dbCorrectedRelIso<0.05)    selectors |= reco::Muon::PFIsoVeryVeryTight;
-  
+  if (dbCorrectedRelIso < 0.40)
+    selectors |= reco::Muon::PFIsoVeryLoose;
+  if (dbCorrectedRelIso < 0.25)
+    selectors |= reco::Muon::PFIsoLoose;
+  if (dbCorrectedRelIso < 0.20)
+    selectors |= reco::Muon::PFIsoMedium;
+  if (dbCorrectedRelIso < 0.15)
+    selectors |= reco::Muon::PFIsoTight;
+  if (dbCorrectedRelIso < 0.10)
+    selectors |= reco::Muon::PFIsoVeryTight;
+  if (dbCorrectedRelIso < 0.05)
+    selectors |= reco::Muon::PFIsoVeryVeryTight;
+
   // Tracker isolation
-  if (tkRelIso<0.10)            selectors |= reco::Muon::TkIsoLoose;
-  if (tkRelIso<0.05)            selectors |= reco::Muon::TkIsoTight;
+  if (tkRelIso < 0.10)
+    selectors |= reco::Muon::TkIsoLoose;
+  if (tkRelIso < 0.05)
+    selectors |= reco::Muon::TkIsoTight;
 
   // Trigger selectors
-  if (isLooseTriggerMuon(muon)) selectors |= reco::Muon::TriggerIdLoose;
+  if (isLooseTriggerMuon(muon))
+    selectors |= reco::Muon::TriggerIdLoose;
 
   // Timing
-  if (!outOfTimeMuon(muon))     selectors |= reco::Muon::InTimeMuon;
+  if (!outOfTimeMuon(muon))
+    selectors |= reco::Muon::InTimeMuon;
 
   return static_cast<reco::Muon::Selector>(selectors);
 }

--- a/DataFormats/MuonReco/src/MuonSimInfo.cc
+++ b/DataFormats/MuonReco/src/MuonSimInfo.cc
@@ -2,22 +2,20 @@
 
 using namespace reco;
 
-MuonSimInfo::MuonSimInfo():
-  primaryClass(MuonSimType::Unknown),
-  extendedClass(ExtendedMuonSimType::ExtUnknown),
-  flavour(0),
-  pdgId(0),
-  g4processType(0),
-  motherPdgId(0),
-  motherFlavour(0),
-  motherStatus(0),
-  grandMotherPdgId(0),
-  grandMotherFlavour(0),
-  heaviestMotherFlavour(0),
-  tpId(-1),
-  tpEvent(999),
-  tpBX(999),
-  charge(0),
-  tpAssoQuality(-1)
-{
-}
+MuonSimInfo::MuonSimInfo()
+    : primaryClass(MuonSimType::Unknown),
+      extendedClass(ExtendedMuonSimType::ExtUnknown),
+      flavour(0),
+      pdgId(0),
+      g4processType(0),
+      motherPdgId(0),
+      motherFlavour(0),
+      motherStatus(0),
+      grandMotherPdgId(0),
+      grandMotherFlavour(0),
+      heaviestMotherFlavour(0),
+      tpId(-1),
+      tpEvent(999),
+      tpBX(999),
+      charge(0),
+      tpAssoQuality(-1) {}

--- a/DataFormats/MuonReco/src/MuonTimeExtra.cc
+++ b/DataFormats/MuonReco/src/MuonTimeExtra.cc
@@ -1,18 +1,17 @@
 #include "DataFormats/MuonReco/interface/MuonTimeExtra.h"
 using namespace reco;
 
-MuonTimeExtra::MuonTimeExtra() 
-{
-  nDof_=0;
-       
-  inverseBeta_=0.;
-  inverseBetaErr_=0.;
-   
-  freeInverseBeta_=0.;
-  freeInverseBetaErr_=0.;
+MuonTimeExtra::MuonTimeExtra() {
+  nDof_ = 0;
 
-  timeAtIpInOut_=0.;
-  timeAtIpInOutErr_=0.;
-  timeAtIpOutIn_=0.;
-  timeAtIpOutInErr_=0.;
+  inverseBeta_ = 0.;
+  inverseBetaErr_ = 0.;
+
+  freeInverseBeta_ = 0.;
+  freeInverseBetaErr_ = 0.;
+
+  timeAtIpInOut_ = 0.;
+  timeAtIpInOutErr_ = 0.;
+  timeAtIpOutIn_ = 0.;
+  timeAtIpOutInErr_ = 0.;
 }

--- a/DataFormats/MuonReco/src/classes.h
+++ b/DataFormats/MuonReco/src/classes.h
@@ -3,13 +3,13 @@
 #include "DataFormats/Common/interface/Association.h"
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/CaloMuon.h"
-#include "Rtypes.h" 
-#include "Math/Cartesian3D.h" 
-#include "Math/Polar3D.h" 
-#include "Math/CylindricalEta3D.h" 
-#include "Math/PxPyPzE4D.h" 
-#include <boost/cstdint.hpp> 
-#include "DataFormats/MuonReco/interface/MuonFwd.h" 
+#include "Rtypes.h"
+#include "Math/Cartesian3D.h"
+#include "Math/Polar3D.h"
+#include "Math/CylindricalEta3D.h"
+#include "Math/PxPyPzE4D.h"
+#include <boost/cstdint.hpp>
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/MuonReco/interface/MuonIsolation.h"
 #include "DataFormats/MuonReco/interface/MuonPFIsolation.h"
 #include "DataFormats/MuonReco/interface/MuonTrackLinks.h"
@@ -22,7 +22,7 @@
 #include "DataFormats/MuonReco/interface/MuonCosmicCompatibility.h"
 #include "DataFormats/MuonReco/interface/MuonShower.h"
 #include "DataFormats/MuonReco/interface/MuonToMuonMap.h"
-#include "DataFormats/TrackReco/interface/Track.h" 
+#include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/Common/interface/AssociationMap.h"
 #include "DataFormats/MuonReco/interface/DYTInfo.h"
 #include <DataFormats/MuonReco/interface/EmulatedME0Segment.h>
@@ -34,5 +34,3 @@
 
 #include <vector>
 #include <map>
-
-

--- a/RecoEcal/EgammaCoreTools/interface/BremRecoveryPhiRoadAlgo.h
+++ b/RecoEcal/EgammaCoreTools/interface/BremRecoveryPhiRoadAlgo.h
@@ -12,28 +12,25 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 class BremRecoveryPhiRoadAlgo {
+public:
+  BremRecoveryPhiRoadAlgo(const edm::ParameterSet& pset);
+  ~BremRecoveryPhiRoadAlgo() {}
 
-   public:
-      BremRecoveryPhiRoadAlgo(const edm::ParameterSet& pset);
-      ~BremRecoveryPhiRoadAlgo() {}
+  int barrelPhiRoad(double et);
+  double endcapPhiRoad(double energy);
 
-      int barrelPhiRoad(double et);
-      double endcapPhiRoad(double energy);
+private:
+  // parameters for EB
+  // if (et < etVec[i]) use cryVec_[i]
+  std::vector<double> etVec_;
+  std::vector<int> cryVec_;
+  int cryMin_;
 
-   private:
-      // parameters for EB
-      // if (et < etVec[i]) use cryVec_[i]
-      std::vector<double> etVec_;
-      std::vector<int> cryVec_;
-      int cryMin_;
-
-      // parameters for EE
-      // phi road = (a_ / (b_ + energy)) + c
-      double a_;
-      double b_;
-      double c_;
-
+  // parameters for EE
+  // phi road = (a_ / (b_ + energy)) + c
+  double a_;
+  double b_;
+  double c_;
 };
 
 #endif
-

--- a/RecoEcal/EgammaCoreTools/interface/ClusterEtLess.h
+++ b/RecoEcal/EgammaCoreTools/interface/ClusterEtLess.h
@@ -4,10 +4,8 @@
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 
 // Less than operator for sorting EcalRecHits according to energy.
-inline bool isClusterEtLess(const reco::CaloCluster& x, const reco::CaloCluster& y)
-{
-  return ( (x.energy() * sin(x.position().theta())) < (y.energy() * sin(y.position().theta())) ) ;
+inline bool isClusterEtLess(const reco::CaloCluster& x, const reco::CaloCluster& y) {
+  return ((x.energy() * sin(x.position().theta())) < (y.energy() * sin(y.position().theta())));
 }
 
 #endif
-

--- a/RecoEcal/EgammaCoreTools/interface/ClusterShapeAlgo.h
+++ b/RecoEcal/EgammaCoreTools/interface/ClusterShapeAlgo.h
@@ -26,28 +26,25 @@
 
 class CaloSubdetectorTopology;
 
-struct EcalClusterEnergyDeposition
-{ 
+struct EcalClusterEnergyDeposition {
   double deposited_energy;
   double r;
   double phi;
 };
 
-class ClusterShapeAlgo
-{
-
- public:
-  ClusterShapeAlgo(const edm::ParameterSet& par);
-  ClusterShapeAlgo() { };
+class ClusterShapeAlgo {
+public:
+  ClusterShapeAlgo(const edm::ParameterSet &par);
+  ClusterShapeAlgo(){};
   reco::ClusterShape Calculate(const reco::BasicCluster &passedCluster,
                                const EcalRecHitCollection *hits,
-                               const CaloSubdetectorGeometry * geometry,
-                               const CaloSubdetectorTopology* topology);
+                               const CaloSubdetectorGeometry *geometry,
+                               const CaloSubdetectorTopology *topology);
 
-  private:
-  void Calculate_TopEnergy(const reco::BasicCluster &passedCluster,const EcalRecHitCollection *hits);
-  void Calculate_2ndEnergy(const reco::BasicCluster &passedCluster,const EcalRecHitCollection *hits);
-  void Create_Map(const EcalRecHitCollection *hits, const CaloSubdetectorTopology* topology);
+private:
+  void Calculate_TopEnergy(const reco::BasicCluster &passedCluster, const EcalRecHitCollection *hits);
+  void Calculate_2ndEnergy(const reco::BasicCluster &passedCluster, const EcalRecHitCollection *hits);
+  void Create_Map(const EcalRecHitCollection *hits, const CaloSubdetectorTopology *topology);
   void Calculate_e2x2();
   void Calculate_e3x2();
   void Calculate_e3x3();
@@ -58,12 +55,17 @@ class ClusterShapeAlgo
   void Calculate_e2x5Top();
   void Calculate_e2x5Bottom();
   void Calculate_Covariances(const reco::BasicCluster &passedCluster,
-			     const EcalRecHitCollection* hits,
-			     const CaloSubdetectorGeometry* geometry);
-  void Calculate_BarrelBasketEnergyFraction(const reco::BasicCluster &passedCluster,const EcalRecHitCollection *hits,
-                                            const int EtaPhi,const CaloSubdetectorGeometry * geometry);
+                             const EcalRecHitCollection *hits,
+                             const CaloSubdetectorGeometry *geometry);
+  void Calculate_BarrelBasketEnergyFraction(const reco::BasicCluster &passedCluster,
+                                            const EcalRecHitCollection *hits,
+                                            const int EtaPhi,
+                                            const CaloSubdetectorGeometry *geometry);
   // defines a energy deposition topology in a reference system centered on the cluster
-  void Calculate_EnergyDepTopology(const reco::BasicCluster &passedCluster,const EcalRecHitCollection *hits, const CaloSubdetectorGeometry * geometry, bool logW=true);
+  void Calculate_EnergyDepTopology(const reco::BasicCluster &passedCluster,
+                                   const EcalRecHitCollection *hits,
+                                   const CaloSubdetectorGeometry *geometry,
+                                   bool logW = true);
   void Calculate_Polynomials(double rho);
   double factorial(int n) const;
   void Calculate_lat(const reco::BasicCluster &passedCluster);
@@ -82,7 +84,7 @@ class ClusterShapeAlgo
   double f51(double r);
   double f53(double r);
   double f55(double r);
-  double absZernikeMoment(const reco::BasicCluster &passedCluster, int n, int m, double R0=6.6);
+  double absZernikeMoment(const reco::BasicCluster &passedCluster, int n, int m, double R0 = 6.6);
   double fast_AbsZernikeMoment(const reco::BasicCluster &passedCluster, int n, int m, double R0);
   // Calculation of Zernike-Moments for general values of (n,m)
   double calc_AbsZernikeMoment(const reco::BasicCluster &passedCluster, int n, int m, double R0);
@@ -97,8 +99,8 @@ class ClusterShapeAlgo
   double e2x5Right_, e2x5Left_, e2x5Top_, e2x5Bottom_;
   double e3x2Ratio_;
   double lat_;
-  double etaLat_ ;
-  double phiLat_ ;
+  double etaLat_;
+  double phiLat_;
   double A20_, A42_;
   std::vector<double> energyBasketFractionEta_;
   std::vector<double> energyBasketFractionPhi_;
@@ -107,7 +109,6 @@ class ClusterShapeAlgo
   std::vector<double> fcn_;
 
   enum { Eta, Phi };
-
 };
 
 #endif

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h
@@ -18,21 +18,19 @@
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 
 namespace edm {
-        class Event;
-        class EventSetup;
-        class ParameterSet;
-}
-
+  class Event;
+  class EventSetup;
+  class ParameterSet;
+}  // namespace edm
 
 class EcalClusterFunctionBaseClass {
-        public:
-                virtual ~EcalClusterFunctionBaseClass() {};
-                virtual void  init( const edm::EventSetup& es ) = 0;
-                virtual float getValue( const reco::BasicCluster &, const EcalRecHitCollection & ) const = 0;
-                virtual float getValue( const reco::SuperCluster &, const int mode ) const = 0;
-	        //this one is needed for EcalClusterCrackCorrection:
-	        virtual float getValue( const reco::CaloCluster &) const {return 0;};
-
+public:
+  virtual ~EcalClusterFunctionBaseClass(){};
+  virtual void init(const edm::EventSetup &es) = 0;
+  virtual float getValue(const reco::BasicCluster &, const EcalRecHitCollection &) const = 0;
+  virtual float getValue(const reco::SuperCluster &, const int mode) const = 0;
+  //this one is needed for EcalClusterCrackCorrection:
+  virtual float getValue(const reco::CaloCluster &) const { return 0; };
 };
 
 #endif

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h
@@ -12,6 +12,6 @@
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionBaseClass.h"
-typedef edmplugin::PluginFactory< EcalClusterFunctionBaseClass*(const edm::ParameterSet&) > EcalClusterFunctionFactory;
+typedef edmplugin::PluginFactory<EcalClusterFunctionBaseClass*(const edm::ParameterSet&)> EcalClusterFunctionFactory;
 
 #endif

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
@@ -26,15 +26,21 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
 
-
 class CaloTopology;
 class CaloGeometry;
 class CaloSubdetectorTopology;
 
 class EcalClusterLazyToolsBase {
- public:
-  EcalClusterLazyToolsBase( const edm::Event &ev, const edm::EventSetup &es, edm::EDGetTokenT<EcalRecHitCollection> token1, edm::EDGetTokenT<EcalRecHitCollection> token2);
-  EcalClusterLazyToolsBase( const edm::Event &ev, const edm::EventSetup &es, edm::EDGetTokenT<EcalRecHitCollection> token1, edm::EDGetTokenT<EcalRecHitCollection> token2, edm::EDGetTokenT<EcalRecHitCollection> token3);
+public:
+  EcalClusterLazyToolsBase(const edm::Event &ev,
+                           const edm::EventSetup &es,
+                           edm::EDGetTokenT<EcalRecHitCollection> token1,
+                           edm::EDGetTokenT<EcalRecHitCollection> token2);
+  EcalClusterLazyToolsBase(const edm::Event &ev,
+                           const edm::EventSetup &es,
+                           edm::EDGetTokenT<EcalRecHitCollection> token1,
+                           edm::EDGetTokenT<EcalRecHitCollection> token2,
+                           edm::EDGetTokenT<EcalRecHitCollection> token3);
 
   // get time of basic cluster seed crystal
   float BasicClusterSeedTime(const reco::BasicCluster &cluster);
@@ -48,22 +54,29 @@ class EcalClusterLazyToolsBase {
   // mapping for preshower rechits
   std::map<DetId, EcalRecHit> rechits_map_;
   // get Preshower hit array
-  std::vector<float> getESHits(double X, double Y, double Z, const std::map<DetId, EcalRecHit>& rechits_map, const CaloGeometry* geometry, CaloSubdetectorTopology const *topology_p, int row=0, int plane=1);
+  std::vector<float> getESHits(double X,
+                               double Y,
+                               double Z,
+                               const std::map<DetId, EcalRecHit> &rechits_map,
+                               const CaloGeometry *geometry,
+                               CaloSubdetectorTopology const *topology_p,
+                               int row = 0,
+                               int plane = 1);
   // get Preshower hit shape
-  float getESShape(const std::vector<float>& ESHits0);
+  float getESShape(const std::vector<float> &ESHits0);
   // get Preshower effective sigmaRR
-  float eseffsirir( const reco::SuperCluster &cluster );
-  float eseffsixix( const reco::SuperCluster &cluster );
-  float eseffsiyiy( const reco::SuperCluster &cluster );
+  float eseffsirir(const reco::SuperCluster &cluster);
+  float eseffsixix(const reco::SuperCluster &cluster);
+  float eseffsiyiy(const reco::SuperCluster &cluster);
 
-  EcalRecHitCollection const* getEcalEBRecHitCollection() const { return ebRecHits_; }
-  EcalRecHitCollection const* getEcalEERecHitCollection() const { return eeRecHits_; }
-  EcalRecHitCollection const* getEcalESRecHitCollection() const { return esRecHits_; }
-  EcalIntercalibConstants const& getEcalIntercalibConstants() const { return *icalMap; }
-  edm::ESHandle<EcalLaserDbService> const& getLaserHandle() const { return laser; }
+  EcalRecHitCollection const *getEcalEBRecHitCollection() const { return ebRecHits_; }
+  EcalRecHitCollection const *getEcalEERecHitCollection() const { return eeRecHits_; }
+  EcalRecHitCollection const *getEcalESRecHitCollection() const { return esRecHits_; }
+  EcalIntercalibConstants const &getEcalIntercalibConstants() const { return *icalMap; }
+  edm::ESHandle<EcalLaserDbService> const &getLaserHandle() const { return laser; }
 
- protected:
-  EcalRecHitCollection const* getEcalRecHitCollection( const reco::BasicCluster &cluster ) const;
+protected:
+  EcalRecHitCollection const *getEcalRecHitCollection(const reco::BasicCluster &cluster) const;
 
   const CaloGeometry *geometry_;
   const CaloTopology *topology_;
@@ -76,156 +89,184 @@ class EcalClusterLazyToolsBase {
   std::shared_ptr<CaloSubdetectorTopology const> ecalPS_topology_;
 
   edm::ESHandle<EcalIntercalibConstants> ical;
-  const EcalIntercalibConstantMap*        icalMap;
-  edm::ESHandle<EcalADCToGeVConstant>    agc;
-  edm::ESHandle<EcalLaserDbService>      laser;
-  void getIntercalibConstants( const edm::EventSetup &es );
-  void getADCToGeV           ( const edm::EventSetup &es );
-  void getLaserDbService     ( const edm::EventSetup &es );
+  const EcalIntercalibConstantMap *icalMap;
+  edm::ESHandle<EcalADCToGeVConstant> agc;
+  edm::ESHandle<EcalLaserDbService> laser;
+  void getIntercalibConstants(const edm::EventSetup &es);
+  void getADCToGeV(const edm::EventSetup &es);
+  void getLaserDbService(const edm::EventSetup &es);
 
- private:
-  void getESRecHits( const edm::Event &ev );
+private:
+  void getESRecHits(const edm::Event &ev);
 
-}; // class EcalClusterLazyToolsBase
+};  // class EcalClusterLazyToolsBase
 
-template<class ClusterTools>
+template <class ClusterTools>
 class EcalClusterLazyToolsT : public EcalClusterLazyToolsBase {
-  public:
+public:
+  EcalClusterLazyToolsT(const edm::Event &ev,
+                        const edm::EventSetup &es,
+                        edm::EDGetTokenT<EcalRecHitCollection> token1,
+                        edm::EDGetTokenT<EcalRecHitCollection> token2)
+      : EcalClusterLazyToolsBase(ev, es, token1, token2) {}
 
-    EcalClusterLazyToolsT( const edm::Event &ev,
-                           const edm::EventSetup &es,
-                           edm::EDGetTokenT<EcalRecHitCollection> token1,
-                           edm::EDGetTokenT<EcalRecHitCollection> token2 )
-      : EcalClusterLazyToolsBase(ev,es,token1,token2) {}
+  EcalClusterLazyToolsT(const edm::Event &ev,
+                        const edm::EventSetup &es,
+                        edm::EDGetTokenT<EcalRecHitCollection> token1,
+                        edm::EDGetTokenT<EcalRecHitCollection> token2,
+                        edm::EDGetTokenT<EcalRecHitCollection> token3)
+      : EcalClusterLazyToolsBase(ev, es, token1, token2, token3) {}
 
-    EcalClusterLazyToolsT( const edm::Event &ev,
-                           const edm::EventSetup &es,
-                           edm::EDGetTokenT<EcalRecHitCollection> token1,
-                           edm::EDGetTokenT<EcalRecHitCollection> token2,
-                           edm::EDGetTokenT<EcalRecHitCollection> token3)
-      : EcalClusterLazyToolsBase(ev,es,token1,token2,token3) {}
+  // Get the rec hit energies in a rectangle matrix around the seed.
+  std::vector<float> energyMatrix(reco::BasicCluster const &cluster, int size) const {
+    auto recHits = getEcalRecHitCollection(cluster);
+    DetId maxId = ClusterTools::getMaximum(cluster, recHits).first;
 
-    // Get the rec hit energies in a rectangle matrix around the seed.
-    std::vector<float> energyMatrix(reco::BasicCluster const& cluster, int size) const {
-
-        auto recHits = getEcalRecHitCollection(cluster);
-        DetId maxId = ClusterTools::getMaximum(cluster, recHits).first;
-
-        std::vector<float> energies;
-        for (auto const& detId : CaloRectangleRange(size, maxId, *topology_)) {
-            energies.push_back(ClusterTools::recHitEnergy( detId, recHits));
-        }
-
-        return energies;
+    std::vector<float> energies;
+    for (auto const &detId : CaloRectangleRange(size, maxId, *topology_)) {
+      energies.push_back(ClusterTools::recHitEnergy(detId, recHits));
     }
 
-    // various energies in the matrix nxn surrounding the maximum energy crystal of the input cluster
-    //
-    // NOTE (29/10/08): we now use an eta/phi coordinate system rather than
-    //                  phi/eta to minmise possible screwups, for now e5x1 isnt
-    //                  defined all the majority of people who call it actually
-    //                  want e1x5 and it is thought it is better that their code
-    //                  doesnt compile rather than pick up the wrong function
-    //                  therefore in this version and later e1x5 = e5x1 in the old
-    //                  version so 1x5 is 1 crystal in eta and 5 crystals in phi
-    //                  note e3x2 does not have a definate eta/phi geometry, it
-    //                  takes the maximum 3x2 block containing the seed regardless
-    //                  of whether that 3 in eta or phi
-    float e1x3( const reco::BasicCluster &cluster )
-        { return ClusterTools::e1x3( cluster, getEcalRecHitCollection(cluster), topology_ ); }
-    float e3x1( const reco::BasicCluster &cluster )
-        { return ClusterTools::e3x1( cluster, getEcalRecHitCollection(cluster), topology_ ); }
-    float e1x5( const reco::BasicCluster &cluster )
-        { return ClusterTools::e1x5( cluster, getEcalRecHitCollection(cluster), topology_ ); }
-    float e5x1( const reco::BasicCluster &cluster )
-        { return ClusterTools::e5x1( cluster, getEcalRecHitCollection(cluster), topology_ ); }
-    float e2x2( const reco::BasicCluster &cluster )
-        { return ClusterTools::e2x2( cluster, getEcalRecHitCollection(cluster), topology_ ); }
-    float e3x2( const reco::BasicCluster &cluster )
-        { return ClusterTools::e3x2( cluster, getEcalRecHitCollection(cluster), topology_ ); }
-    float e3x3( const reco::BasicCluster &cluster )
-        { return ClusterTools::e3x3( cluster, getEcalRecHitCollection(cluster), topology_ ); }
-    float e4x4( const reco::BasicCluster &cluster )
-        { return ClusterTools::e4x4( cluster, getEcalRecHitCollection(cluster), topology_ ); }
-    float e5x5( const reco::BasicCluster &cluster )
-        { return ClusterTools::e5x5( cluster, getEcalRecHitCollection(cluster), topology_ ); }
-    int n5x5( const reco::BasicCluster &cluster )
-        { return ClusterTools::n5x5( cluster, getEcalRecHitCollection(cluster), topology_ ); }
-    // energy in the 2x5 strip right of the max crystal (does not contain max crystal)
-    // 2 crystals wide in eta, 5 wide in phi.
-    float e2x5Right( const reco::BasicCluster &cluster )
-        { return ClusterTools::e2x5Right( cluster, getEcalRecHitCollection(cluster), topology_ ); }
-    // energy in the 2x5 strip left of the max crystal (does not contain max crystal)
-    float e2x5Left( const reco::BasicCluster &cluster )
-        { return ClusterTools::e2x5Left( cluster, getEcalRecHitCollection(cluster), topology_ ); }
-    // energy in the 5x2 strip above the max crystal (does not contain max crystal)
-    // 5 crystals wide in eta, 2 wide in phi.
-    float e2x5Top( const reco::BasicCluster &cluster )
-        { return ClusterTools::e2x5Top( cluster, getEcalRecHitCollection(cluster), topology_ ); }
+    return energies;
+  }
 
-    // energy in the 5x2 strip below the max crystal (does not contain max crystal)
-    float e2x5Bottom( const reco::BasicCluster &cluster )
-        { return ClusterTools::e2x5Bottom( cluster, getEcalRecHitCollection(cluster), topology_ ); }
-    // energy in a 2x5 strip containing the seed (max) crystal.
-    // 2 crystals wide in eta, 5 wide in phi.
-    // it is the maximum of either (1x5left + 1x5center) or (1x5right + 1x5center)
-    float e2x5Max( const reco::BasicCluster &cluster )
-        { return ClusterTools::e2x5Max( cluster, getEcalRecHitCollection(cluster), topology_ ); }
-    // energies in the crystal left, right, top, bottom w.r.t. to the most energetic crystal
-    float eLeft( const reco::BasicCluster &cluster )
-        { return ClusterTools::eLeft( cluster, getEcalRecHitCollection(cluster), topology_ ); }
-    float eRight( const reco::BasicCluster &cluster )
-        { return ClusterTools::eRight( cluster, getEcalRecHitCollection(cluster), topology_ ); }
-    float eTop( const reco::BasicCluster &cluster )
-        { return ClusterTools::eTop( cluster, getEcalRecHitCollection(cluster), topology_ ); }
-    float eBottom( const reco::BasicCluster &cluster )
-        { return ClusterTools::eBottom( cluster, getEcalRecHitCollection(cluster), topology_ ); }
-    // the energy of the most energetic crystal in the cluster
-    float eMax( const reco::BasicCluster &cluster )
-        { return ClusterTools::eMax( cluster, getEcalRecHitCollection(cluster) ); }
-    // the energy of the second most energetic crystal in the cluster
-    float e2nd( const reco::BasicCluster &cluster )
-        { return ClusterTools::e2nd( cluster, getEcalRecHitCollection(cluster) ); }
+  // various energies in the matrix nxn surrounding the maximum energy crystal of the input cluster
+  //
+  // NOTE (29/10/08): we now use an eta/phi coordinate system rather than
+  //                  phi/eta to minmise possible screwups, for now e5x1 isnt
+  //                  defined all the majority of people who call it actually
+  //                  want e1x5 and it is thought it is better that their code
+  //                  doesnt compile rather than pick up the wrong function
+  //                  therefore in this version and later e1x5 = e5x1 in the old
+  //                  version so 1x5 is 1 crystal in eta and 5 crystals in phi
+  //                  note e3x2 does not have a definate eta/phi geometry, it
+  //                  takes the maximum 3x2 block containing the seed regardless
+  //                  of whether that 3 in eta or phi
+  float e1x3(const reco::BasicCluster &cluster) {
+    return ClusterTools::e1x3(cluster, getEcalRecHitCollection(cluster), topology_);
+  }
+  float e3x1(const reco::BasicCluster &cluster) {
+    return ClusterTools::e3x1(cluster, getEcalRecHitCollection(cluster), topology_);
+  }
+  float e1x5(const reco::BasicCluster &cluster) {
+    return ClusterTools::e1x5(cluster, getEcalRecHitCollection(cluster), topology_);
+  }
+  float e5x1(const reco::BasicCluster &cluster) {
+    return ClusterTools::e5x1(cluster, getEcalRecHitCollection(cluster), topology_);
+  }
+  float e2x2(const reco::BasicCluster &cluster) {
+    return ClusterTools::e2x2(cluster, getEcalRecHitCollection(cluster), topology_);
+  }
+  float e3x2(const reco::BasicCluster &cluster) {
+    return ClusterTools::e3x2(cluster, getEcalRecHitCollection(cluster), topology_);
+  }
+  float e3x3(const reco::BasicCluster &cluster) {
+    return ClusterTools::e3x3(cluster, getEcalRecHitCollection(cluster), topology_);
+  }
+  float e4x4(const reco::BasicCluster &cluster) {
+    return ClusterTools::e4x4(cluster, getEcalRecHitCollection(cluster), topology_);
+  }
+  float e5x5(const reco::BasicCluster &cluster) {
+    return ClusterTools::e5x5(cluster, getEcalRecHitCollection(cluster), topology_);
+  }
+  int n5x5(const reco::BasicCluster &cluster) {
+    return ClusterTools::n5x5(cluster, getEcalRecHitCollection(cluster), topology_);
+  }
+  // energy in the 2x5 strip right of the max crystal (does not contain max crystal)
+  // 2 crystals wide in eta, 5 wide in phi.
+  float e2x5Right(const reco::BasicCluster &cluster) {
+    return ClusterTools::e2x5Right(cluster, getEcalRecHitCollection(cluster), topology_);
+  }
+  // energy in the 2x5 strip left of the max crystal (does not contain max crystal)
+  float e2x5Left(const reco::BasicCluster &cluster) {
+    return ClusterTools::e2x5Left(cluster, getEcalRecHitCollection(cluster), topology_);
+  }
+  // energy in the 5x2 strip above the max crystal (does not contain max crystal)
+  // 5 crystals wide in eta, 2 wide in phi.
+  float e2x5Top(const reco::BasicCluster &cluster) {
+    return ClusterTools::e2x5Top(cluster, getEcalRecHitCollection(cluster), topology_);
+  }
 
-    // get the DetId and the energy of the maximum energy crystal of the input cluster
-    std::pair<DetId, float> getMaximum( const reco::BasicCluster &cluster )
-        { return ClusterTools::getMaximum( cluster, getEcalRecHitCollection(cluster) ); }
-    std::vector<float> energyBasketFractionEta( const reco::BasicCluster &cluster )
-        { return ClusterTools::energyBasketFractionEta( cluster, getEcalRecHitCollection(cluster) ); }
-    std::vector<float> energyBasketFractionPhi( const reco::BasicCluster &cluster )
-        { return ClusterTools::energyBasketFractionPhi( cluster, getEcalRecHitCollection(cluster) ); }
+  // energy in the 5x2 strip below the max crystal (does not contain max crystal)
+  float e2x5Bottom(const reco::BasicCluster &cluster) {
+    return ClusterTools::e2x5Bottom(cluster, getEcalRecHitCollection(cluster), topology_);
+  }
+  // energy in a 2x5 strip containing the seed (max) crystal.
+  // 2 crystals wide in eta, 5 wide in phi.
+  // it is the maximum of either (1x5left + 1x5center) or (1x5right + 1x5center)
+  float e2x5Max(const reco::BasicCluster &cluster) {
+    return ClusterTools::e2x5Max(cluster, getEcalRecHitCollection(cluster), topology_);
+  }
+  // energies in the crystal left, right, top, bottom w.r.t. to the most energetic crystal
+  float eLeft(const reco::BasicCluster &cluster) {
+    return ClusterTools::eLeft(cluster, getEcalRecHitCollection(cluster), topology_);
+  }
+  float eRight(const reco::BasicCluster &cluster) {
+    return ClusterTools::eRight(cluster, getEcalRecHitCollection(cluster), topology_);
+  }
+  float eTop(const reco::BasicCluster &cluster) {
+    return ClusterTools::eTop(cluster, getEcalRecHitCollection(cluster), topology_);
+  }
+  float eBottom(const reco::BasicCluster &cluster) {
+    return ClusterTools::eBottom(cluster, getEcalRecHitCollection(cluster), topology_);
+  }
+  // the energy of the most energetic crystal in the cluster
+  float eMax(const reco::BasicCluster &cluster) {
+    return ClusterTools::eMax(cluster, getEcalRecHitCollection(cluster));
+  }
+  // the energy of the second most energetic crystal in the cluster
+  float e2nd(const reco::BasicCluster &cluster) {
+    return ClusterTools::e2nd(cluster, getEcalRecHitCollection(cluster));
+  }
 
-    // return a vector v with v[0] = etaLat, v[1] = phiLat, v[2] = lat
-    std::vector<float> lat( const reco::BasicCluster &cluster, bool logW = true, float w0 = 4.7 )
-        { return ClusterTools::lat( cluster, getEcalRecHitCollection(cluster), geometry_, logW, w0 ); }
+  // get the DetId and the energy of the maximum energy crystal of the input cluster
+  std::pair<DetId, float> getMaximum(const reco::BasicCluster &cluster) {
+    return ClusterTools::getMaximum(cluster, getEcalRecHitCollection(cluster));
+  }
+  std::vector<float> energyBasketFractionEta(const reco::BasicCluster &cluster) {
+    return ClusterTools::energyBasketFractionEta(cluster, getEcalRecHitCollection(cluster));
+  }
+  std::vector<float> energyBasketFractionPhi(const reco::BasicCluster &cluster) {
+    return ClusterTools::energyBasketFractionPhi(cluster, getEcalRecHitCollection(cluster));
+  }
 
-    // return a vector v with v[0] = covEtaEta, v[1] = covEtaPhi, v[2] = covPhiPhi
-    std::vector<float> covariances(const reco::BasicCluster &cluster, float w0 = 4.7 )
-        { return ClusterTools::covariances( cluster, getEcalRecHitCollection(cluster), topology_, geometry_, w0 ); }
+  // return a vector v with v[0] = etaLat, v[1] = phiLat, v[2] = lat
+  std::vector<float> lat(const reco::BasicCluster &cluster, bool logW = true, float w0 = 4.7) {
+    return ClusterTools::lat(cluster, getEcalRecHitCollection(cluster), geometry_, logW, w0);
+  }
 
-    // return a vector v with v[0] = covIEtaIEta, v[1] = covIEtaIPhi, v[2] = covIPhiIPhi
-    // this function calculates differences in eta/phi in units of crystals not
-    // global eta/phi this is gives better performance in the crack regions of
-    // the calorimeter but gives otherwise identical results to covariances
-    // function this is only defined for the barrel, it returns covariances when
-    // the cluster is in the endcap Warning: covIEtaIEta has been studied by
-    // egamma, but so far covIPhiIPhi hasnt been studied extensively so there
-    // could be a bug in the covIPhiIEta or covIPhiIPhi calculations. I dont
-    // think there is but as it hasnt been heavily used, there might be one
-    std::vector<float> localCovariances(const reco::BasicCluster &cluster, float w0 = 4.7)
-        { return ClusterTools::localCovariances( cluster, getEcalRecHitCollection(cluster), topology_, w0 ); }
-    std::vector<float> scLocalCovariances(const reco::SuperCluster &cluster, float w0 = 4.7)
-        { return ClusterTools::scLocalCovariances( cluster, getEcalRecHitCollection(cluster), topology_, w0 ); }
-    double zernike20( const reco::BasicCluster &cluster, double R0 = 6.6, bool logW = true, float w0 = 4.7 )
-        { return ClusterTools::zernike20( cluster, getEcalRecHitCollection(cluster), geometry_, R0, logW, w0 ); }
-    double zernike42( const reco::BasicCluster &cluster, double R0 = 6.6, bool logW = true, float w0 = 4.7 )
-        { return ClusterTools::zernike42( cluster, getEcalRecHitCollection(cluster), geometry_, R0, logW, w0 ); }
+  // return a vector v with v[0] = covEtaEta, v[1] = covEtaPhi, v[2] = covPhiPhi
+  std::vector<float> covariances(const reco::BasicCluster &cluster, float w0 = 4.7) {
+    return ClusterTools::covariances(cluster, getEcalRecHitCollection(cluster), topology_, geometry_, w0);
+  }
 
-}; // class EcalClusterLazyToolsT
+  // return a vector v with v[0] = covIEtaIEta, v[1] = covIEtaIPhi, v[2] = covIPhiIPhi
+  // this function calculates differences in eta/phi in units of crystals not
+  // global eta/phi this is gives better performance in the crack regions of
+  // the calorimeter but gives otherwise identical results to covariances
+  // function this is only defined for the barrel, it returns covariances when
+  // the cluster is in the endcap Warning: covIEtaIEta has been studied by
+  // egamma, but so far covIPhiIPhi hasnt been studied extensively so there
+  // could be a bug in the covIPhiIEta or covIPhiIPhi calculations. I dont
+  // think there is but as it hasnt been heavily used, there might be one
+  std::vector<float> localCovariances(const reco::BasicCluster &cluster, float w0 = 4.7) {
+    return ClusterTools::localCovariances(cluster, getEcalRecHitCollection(cluster), topology_, w0);
+  }
+  std::vector<float> scLocalCovariances(const reco::SuperCluster &cluster, float w0 = 4.7) {
+    return ClusterTools::scLocalCovariances(cluster, getEcalRecHitCollection(cluster), topology_, w0);
+  }
+  double zernike20(const reco::BasicCluster &cluster, double R0 = 6.6, bool logW = true, float w0 = 4.7) {
+    return ClusterTools::zernike20(cluster, getEcalRecHitCollection(cluster), geometry_, R0, logW, w0);
+  }
+  double zernike42(const reco::BasicCluster &cluster, double R0 = 6.6, bool logW = true, float w0 = 4.7) {
+    return ClusterTools::zernike42(cluster, getEcalRecHitCollection(cluster), geometry_, R0, logW, w0);
+  }
 
+};  // class EcalClusterLazyToolsT
 
-namespace noZS { typedef EcalClusterLazyToolsT<noZS::EcalClusterTools> EcalClusterLazyTools; }
+namespace noZS {
+  typedef EcalClusterLazyToolsT<noZS::EcalClusterTools> EcalClusterLazyTools;
+}
 typedef EcalClusterLazyToolsT<::EcalClusterTools> EcalClusterLazyTools;
-
 
 #endif

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterPUCleaningTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterPUCleaningTools.h
@@ -20,20 +20,22 @@
 class CaloGeometry;
 
 class EcalClusterPUCleaningTools {
- public:
-  EcalClusterPUCleaningTools( const edm::Event &ev, const edm::EventSetup &es, const edm::InputTag& redEBRecHits, const edm::InputTag& redEERecHits );
+public:
+  EcalClusterPUCleaningTools(const edm::Event &ev,
+                             const edm::EventSetup &es,
+                             const edm::InputTag &redEBRecHits,
+                             const edm::InputTag &redEERecHits);
   ~EcalClusterPUCleaningTools();
   reco::SuperCluster CleanedSuperCluster(float xi, const reco::SuperCluster &cluster, const edm::Event &ev);
-  
- private:
-  void getGeometry( const edm::EventSetup &es );
-  void getEBRecHits( const edm::Event &ev, const edm::InputTag& redEBRecHits );
-  void getEERecHits( const edm::Event &ev, const edm::InputTag& redEERecHits );
-  
+
+private:
+  void getGeometry(const edm::EventSetup &es);
+  void getEBRecHits(const edm::Event &ev, const edm::InputTag &redEBRecHits);
+  void getEERecHits(const edm::Event &ev, const edm::InputTag &redEERecHits);
+
   const CaloGeometry *geometry_;
   const EcalRecHitCollection *ebRecHits_;
   const EcalRecHitCollection *eeRecHits_;
-		
 };
 
 #endif

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterSeverityLevelAlgo.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterSeverityLevelAlgo.h
@@ -8,25 +8,30 @@
 #include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
-
 class CaloTopology;
 class EBDetId;
 class EcalClusterSeverityLevelAlgo {
- public:
-
-  // the severity is the fraction of cluster energy 
-  // taken by good channels  
+public:
+  // the severity is the fraction of cluster energy
+  // taken by good channels
   // (e.g. not noisy, dead and recovered etc.)
-  static float goodFraction( const reco::CaloCluster & , const EcalRecHitCollection &,  const EcalSeverityLevelAlgo& );
+  static float goodFraction(const reco::CaloCluster&, const EcalRecHitCollection&, const EcalSeverityLevelAlgo&);
   // fraction of SC energy around closest problematic
-  static float fractionAroundClosestProblematic( const reco::CaloCluster & , const EcalRecHitCollection &, const CaloTopology* topology, const EcalSeverityLevelAlgo&  );
-  // retrieve closest problematic channel wrt seed crystal using as distance sqrt(ieta^2+ieta^2+iphi^2+iphi^2). Return a null detId in case not found within a search region of 11 (ieta) x 51 (iphi)  
-  static DetId closestProblematic( const reco::CaloCluster & , const EcalRecHitCollection &,  const CaloTopology* topology, const EcalSeverityLevelAlgo&   );
+  static float fractionAroundClosestProblematic(const reco::CaloCluster&,
+                                                const EcalRecHitCollection&,
+                                                const CaloTopology* topology,
+                                                const EcalSeverityLevelAlgo&);
+  // retrieve closest problematic channel wrt seed crystal using as distance sqrt(ieta^2+ieta^2+iphi^2+iphi^2). Return a null detId in case not found within a search region of 11 (ieta) x 51 (iphi)
+  static DetId closestProblematic(const reco::CaloCluster&,
+                                  const EcalRecHitCollection&,
+                                  const CaloTopology* topology,
+                                  const EcalSeverityLevelAlgo&);
   // retrieve the distance in ieta,iphi (number of crystals) of the closest problematic channel wrt seed crystal (defined as above)
   // return -1,-1 if no crystal is found within a search region of 11 (eta) x 51 (phi)
-  static std::pair<int,int> etaphiDistanceClosestProblematic( const reco::CaloCluster & , const EcalRecHitCollection &, const CaloTopology* topology, const EcalSeverityLevelAlgo&  );
-
-
+  static std::pair<int, int> etaphiDistanceClosestProblematic(const reco::CaloCluster&,
+                                                              const EcalRecHitCollection&,
+                                                              const CaloTopology* topology,
+                                                              const EcalSeverityLevelAlgo&);
 };
 
 #endif

--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h
@@ -49,7 +49,6 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-
 #include "CLHEP/Geometry/Transform3D.h"
 
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
@@ -57,253 +56,369 @@
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
 #include "Geometry/EcalAlgo/interface/EcalBarrelGeometry.h"
 
-
 class DetId;
 class CaloTopology;
 class CaloGeometry;
 
 struct Cluster2ndMoments {
-
   // major and minor cluster moments wrt principale axes:
   float sMaj;
   float sMin;
   // angle between sMaj and phi:
   float alpha;
-  Cluster2ndMoments():sMaj(0.),sMin(0.),alpha(0.){}
-
+  Cluster2ndMoments() : sMaj(0.), sMin(0.), alpha(0.) {}
 };
 
-template<bool noZS>
+template <bool noZS>
 class EcalClusterToolsT {
-        public:
-                // various energies in the matrix nxn surrounding the maximum energy crystal of the input cluster
-                //we use an eta/phi coordinate system rather than phi/eta
-                //note e3x2 does not have a definate eta/phi geometry, it takes the maximum 3x2 block containing the 
-                //seed regardless of whether that 3 in eta or phi
-                static float e1x3( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
+public:
+  // various energies in the matrix nxn surrounding the maximum energy crystal of the input cluster
+  //we use an eta/phi coordinate system rather than phi/eta
+  //note e3x2 does not have a definate eta/phi geometry, it takes the maximum 3x2 block containing the
+  //seed regardless of whether that 3 in eta or phi
+  static float e1x3(const reco::BasicCluster &cluster,
+                    const EcalRecHitCollection *recHits,
+                    const CaloTopology *topology);
 
+  static float e3x1(const reco::BasicCluster &cluster,
+                    const EcalRecHitCollection *recHits,
+                    const CaloTopology *topology);
 
-                static float e3x1( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
+  static float e1x5(const reco::BasicCluster &cluster,
+                    const EcalRecHitCollection *recHits,
+                    const CaloTopology *topology);
 
+  static float e5x1(const reco::BasicCluster &cluster,
+                    const EcalRecHitCollection *recHits,
+                    const CaloTopology *topology);
 
-                static float e1x5( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
+  static float e2x2(const reco::BasicCluster &cluster,
+                    const EcalRecHitCollection *recHits,
+                    const CaloTopology *topology);
 
-                static float e5x1( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
+  static float e3x2(const reco::BasicCluster &cluster,
+                    const EcalRecHitCollection *recHits,
+                    const CaloTopology *topology);
 
-                static float e2x2( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
+  static float e3x3(const reco::BasicCluster &cluster,
+                    const EcalRecHitCollection *recHits,
+                    const CaloTopology *topology);
 
-                static float e3x2( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
+  static float e4x4(const reco::BasicCluster &cluster,
+                    const EcalRecHitCollection *recHits,
+                    const CaloTopology *topology);
 
-                static float e3x3( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
+  static float e5x5(const reco::BasicCluster &cluster,
+                    const EcalRecHitCollection *recHits,
+                    const CaloTopology *topology);
+  static int n5x5(const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology *topology);
 
-                static float e4x4( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology);
+  // energy in the 2x5 strip right of the max crystal (does not contain max crystal)
+  // 2 crystals wide in eta, 5 wide in phi.
+  static float e2x5Right(const reco::BasicCluster &cluster,
+                         const EcalRecHitCollection *recHits,
+                         const CaloTopology *topology);
+  // energy in the 2x5 strip left of the max crystal (does not contain max crystal)
 
-                static float e5x5( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
-                static int   n5x5( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
+  static float e2x5Left(const reco::BasicCluster &cluster,
+                        const EcalRecHitCollection *recHits,
+                        const CaloTopology *topology);
+  // energy in the 5x2 strip above the max crystal (does not contain max crystal)
+  // 5 crystals wide in eta, 2 wide in phi.
 
-                // energy in the 2x5 strip right of the max crystal (does not contain max crystal)
-                // 2 crystals wide in eta, 5 wide in phi.
-                static float e2x5Right( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
-                // energy in the 2x5 strip left of the max crystal (does not contain max crystal)
+  static float e2x5Top(const reco::BasicCluster &cluster,
+                       const EcalRecHitCollection *recHits,
+                       const CaloTopology *topology);
+  // energy in the 5x2 strip below the max crystal (does not contain max crystal)
 
-                static float e2x5Left( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
-                // energy in the 5x2 strip above the max crystal (does not contain max crystal)
-                // 5 crystals wide in eta, 2 wide in phi.
+  static float e2x5Bottom(const reco::BasicCluster &cluster,
+                          const EcalRecHitCollection *recHits,
+                          const CaloTopology *topology);
+  // energy in a 2x5 strip containing the seed (max) crystal.
+  // 2 crystals wide in eta, 5 wide in phi.
+  // it is the maximum of either (1x5left + 1x5center) or (1x5right + 1x5center)
+  static float e2x5Max(const reco::BasicCluster &cluster,
+                       const EcalRecHitCollection *recHits,
+                       const CaloTopology *topology);
 
-                static float e2x5Top( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
-                // energy in the 5x2 strip below the max crystal (does not contain max crystal)                
+  // energies in the crystal left, right, top, bottom w.r.t. to the most energetic crystal
+  static float eLeft(const reco::BasicCluster &cluster,
+                     const EcalRecHitCollection *recHits,
+                     const CaloTopology *topology);
 
-                static float e2x5Bottom( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
-                // energy in a 2x5 strip containing the seed (max) crystal.
-                // 2 crystals wide in eta, 5 wide in phi.
-                // it is the maximum of either (1x5left + 1x5center) or (1x5right + 1x5center)
-                static float e2x5Max( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
+  static float eRight(const reco::BasicCluster &cluster,
+                      const EcalRecHitCollection *recHits,
+                      const CaloTopology *topology);
 
-                // energies in the crystal left, right, top, bottom w.r.t. to the most energetic crystal
-                static float eLeft( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
+  static float eTop(const reco::BasicCluster &cluster,
+                    const EcalRecHitCollection *recHits,
+                    const CaloTopology *topology);
 
-                static float eRight( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
+  static float eBottom(const reco::BasicCluster &cluster,
+                       const EcalRecHitCollection *recHits,
+                       const CaloTopology *topology);
+  // the energy of the most energetic crystal in the cluster
 
-                static float eTop( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
+  static float eMax(const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits);
 
-                static float eBottom( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology );
-                // the energy of the most energetic crystal in the cluster
+  // the energy of the second most energetic crystal in the cluster
+  static float e2nd(const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits);
 
-                static float eMax( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits );
+  // get the DetId and the energy of the maximum energy crystal of the input cluster
+  static std::pair<DetId, float> getMaximum(const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits);
 
-                // the energy of the second most energetic crystal in the cluster
-                static float e2nd( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits );
+  static std::vector<float> energyBasketFractionEta(const reco::BasicCluster &cluster,
+                                                    const EcalRecHitCollection *recHits);
 
-                // get the DetId and the energy of the maximum energy crystal of the input cluster
-                static std::pair<DetId, float> getMaximum( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits);
+  static std::vector<float> energyBasketFractionPhi(const reco::BasicCluster &cluster,
+                                                    const EcalRecHitCollection *recHits);
 
-                static std::vector<float> energyBasketFractionEta( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits );
+  // return a vector v with v[0] = etaLat, v[1] = phiLat, v[2] = lat
+  static std::vector<float> lat(const reco::BasicCluster &cluster,
+                                const EcalRecHitCollection *recHits,
+                                const CaloGeometry *geometry,
+                                bool logW = true,
+                                float w0 = 4.7);
 
-                static std::vector<float> energyBasketFractionPhi( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits);
+  // return a vector v with v[0] = covEtaEta, v[1] = covEtaPhi, v[2] = covPhiPhi
 
-                // return a vector v with v[0] = etaLat, v[1] = phiLat, v[2] = lat
-                static std::vector<float> lat( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloGeometry *geometry, bool logW = true, float w0 = 4.7 );
+  static std::vector<float> covariances(const reco::BasicCluster &cluster,
+                                        const EcalRecHitCollection *recHits,
+                                        const CaloTopology *topology,
+                                        const CaloGeometry *geometry,
+                                        float w0 = 4.7);
 
-                // return a vector v with v[0] = covEtaEta, v[1] = covEtaPhi, v[2] = covPhiPhi
+  // return a vector v with v[0] = covIEtaIEta, v[1] = covIEtaIPhi, v[2] = covIPhiIPhi
+  //this function calculates differences in eta/phi in units of crystals not global eta/phi
+  //this is gives better performance in the crack regions of the calorimeter but gives otherwise identical results to covariances function
+  //   except that it doesnt need an eta based correction funtion in the endcap
+  //it is multipled by an approprate crystal size to ensure it gives similar values to covariances(...)
+  //
+  //Warning: covIEtaIEta has been studied by egamma, but so far covIPhiIPhi hasnt been studied extensively so there could be a bug in
+  //         the covIPhiIEta or covIPhiIPhi calculations. I dont think there is but as it hasnt been heavily used, there might be one
+  static std::vector<float> localCovariances(const reco::BasicCluster &cluster,
+                                             const EcalRecHitCollection *recHits,
+                                             const CaloTopology *topology,
+                                             float w0 = 4.7);
 
-                static std::vector<float> covariances(const reco::BasicCluster &cluster, const EcalRecHitCollection* recHits, const CaloTopology *topology, const CaloGeometry* geometry, float w0 = 4.7);
+  static std::vector<float> scLocalCovariances(const reco::SuperCluster &cluster,
+                                               const EcalRecHitCollection *recHits,
+                                               const CaloTopology *topology,
+                                               float w0 = 4.7);
 
-                // return a vector v with v[0] = covIEtaIEta, v[1] = covIEtaIPhi, v[2] = covIPhiIPhi
-                //this function calculates differences in eta/phi in units of crystals not global eta/phi
-                //this is gives better performance in the crack regions of the calorimeter but gives otherwise identical results to covariances function
-                //   except that it doesnt need an eta based correction funtion in the endcap 
-                //it is multipled by an approprate crystal size to ensure it gives similar values to covariances(...)
-                //
-                //Warning: covIEtaIEta has been studied by egamma, but so far covIPhiIPhi hasnt been studied extensively so there could be a bug in 
-                //         the covIPhiIEta or covIPhiIPhi calculations. I dont think there is but as it hasnt been heavily used, there might be one
-                static std::vector<float> localCovariances(const reco::BasicCluster &cluster, const EcalRecHitCollection* recHits, const CaloTopology *topology, float w0 = 4.7);
-                
-                static std::vector<float> scLocalCovariances(const reco::SuperCluster &cluster, const EcalRecHitCollection* recHits,const CaloTopology *topology, float w0 = 4.7);
+  // cluster second moments with respect to principal axes:
+  static Cluster2ndMoments cluster2ndMoments(const reco::BasicCluster &basicCluster,
+                                             const EcalRecHitCollection &recHits,
+                                             double phiCorrectionFactor = 0.8,
+                                             double w0 = 4.7,
+                                             bool useLogWeights = true);
 
-                // cluster second moments with respect to principal axes:
-                static Cluster2ndMoments cluster2ndMoments( const reco::BasicCluster &basicCluster, const EcalRecHitCollection &recHits, double phiCorrectionFactor=0.8, double w0=4.7, bool useLogWeights=true);
+  static Cluster2ndMoments cluster2ndMoments(const reco::SuperCluster &superCluster,
+                                             const EcalRecHitCollection &recHits,
+                                             double phiCorrectionFactor = 0.8,
+                                             double w0 = 4.7,
+                                             bool useLogWeights = true);
+  static Cluster2ndMoments cluster2ndMoments(const std::vector<std::pair<const EcalRecHit *, float>> &RH_ptrs_fracs,
+                                             double phiCorrectionFactor = 0.8,
+                                             double w0 = 4.7,
+                                             bool useLogWeights = true);
 
-                static Cluster2ndMoments cluster2ndMoments( const reco::SuperCluster &superCluster, const EcalRecHitCollection &recHits, double phiCorrectionFactor=0.8, double w0=4.7, bool useLogWeights=true);
-                static Cluster2ndMoments cluster2ndMoments( const std::vector<std::pair<const EcalRecHit*, float> >& RH_ptrs_fracs, double  phiCorrectionFactor=0.8, double  w0=4.7, bool useLogWeights=true);
+  static double zernike20(const reco::BasicCluster &cluster,
+                          const EcalRecHitCollection *recHits,
+                          const CaloGeometry *geometry,
+                          double R0 = 6.6,
+                          bool logW = true,
+                          float w0 = 4.7);
+  static double zernike42(const reco::BasicCluster &cluster,
+                          const EcalRecHitCollection *recHits,
+                          const CaloGeometry *geometry,
+                          double R0 = 6.6,
+                          bool logW = true,
+                          float w0 = 4.7);
 
-                static double zernike20( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloGeometry *geometry, double R0 = 6.6, bool logW = true, float w0 = 4.7 );
-                static double zernike42( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloGeometry *geometry, double R0 = 6.6, bool logW = true, float w0 = 4.7 );
+  // get the detId's of a matrix centered in the maximum energy crystal = (0,0)
+  // the size is specified by ixMin, ixMax, iyMin, iyMax in unit of crystals
+  static std::vector<DetId> matrixDetId(const CaloTopology *topology, DetId id, CaloRectangle rectangle);
+  static std::vector<DetId> matrixDetId(const CaloTopology *topology, DetId id, int size) {
+    return matrixDetId(topology, id, CaloRectangle{-size, size, -size, size});
+  }
 
-                // get the detId's of a matrix centered in the maximum energy crystal = (0,0)
-                // the size is specified by ixMin, ixMax, iyMin, iyMax in unit of crystals
-                static std::vector<DetId> matrixDetId( const CaloTopology* topology, DetId id, CaloRectangle rectangle );
-                static std::vector<DetId> matrixDetId( const CaloTopology* topology, DetId id, int size )
-                    { return matrixDetId(topology, id, CaloRectangle{-size, size, -size, size}); }
+  // get the energy deposited in a matrix centered in the maximum energy crystal = (0,0)
+  // the size is specified by ixMin, ixMax, iyMin, iyMax in unit of crystals
+  static float matrixEnergy(const reco::BasicCluster &cluster,
+                            const EcalRecHitCollection *recHits,
+                            const CaloTopology *topology,
+                            DetId id,
+                            CaloRectangle rectangle);
+  static int matrixSize(const reco::BasicCluster &cluster,
+                        const EcalRecHitCollection *recHits,
+                        const CaloTopology *topology,
+                        DetId id,
+                        CaloRectangle rectangle);
 
-                // get the energy deposited in a matrix centered in the maximum energy crystal = (0,0)
-                // the size is specified by ixMin, ixMax, iyMin, iyMax in unit of crystals
-                static float matrixEnergy( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, DetId id, CaloRectangle rectangle );
-                static int matrixSize( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, DetId id, CaloRectangle rectangle );
+  static float getFraction(const std::vector<std::pair<DetId, float>> &v_id, DetId id);
+  // get the DetId and the energy of the maximum energy crystal in a vector of DetId
+  static std::pair<DetId, float> getMaximum(const std::vector<std::pair<DetId, float>> &v_id,
+                                            const EcalRecHitCollection *recHits);
 
-                static float getFraction( const std::vector< std::pair<DetId, float> > &v_id, DetId id);
-                // get the DetId and the energy of the maximum energy crystal in a vector of DetId
-                static std::pair<DetId, float> getMaximum( const std::vector< std::pair<DetId, float> > &v_id, const EcalRecHitCollection *recHits);
+  // get the energy of a DetId, return 0 if the DetId is not in the collection
+  static float recHitEnergy(DetId id, const EcalRecHitCollection *recHits);
 
-                // get the energy of a DetId, return 0 if the DetId is not in the collection
-                static float recHitEnergy(DetId id, const EcalRecHitCollection *recHits);
+  //Shower shape variables return vector <Roundness, Angle> of a photon
+  static std::vector<float> roundnessBarrelSuperClusters(const reco::SuperCluster &superCluster,
+                                                         const EcalRecHitCollection &recHits,
+                                                         int weightedPositionMethod = 0,
+                                                         float energyThreshold = 0.0);
+  static std::vector<float> roundnessBarrelSuperClustersUserExtended(const reco::SuperCluster &superCluster,
+                                                                     const EcalRecHitCollection &recHits,
+                                                                     int ieta_delta = 0,
+                                                                     int iphi_delta = 0,
+                                                                     float energyRHThresh = 0.00000,
+                                                                     int weightedPositionMethod = 0);
+  static std::vector<float> roundnessSelectedBarrelRecHits(
+      const std::vector<std::pair<const EcalRecHit *, float>> &rhVector, int weightedPositionMethod = 0);
 
-                //Shower shape variables return vector <Roundness, Angle> of a photon
-                static std::vector<float> roundnessBarrelSuperClusters( const reco::SuperCluster &superCluster ,const EcalRecHitCollection &recHits, int weightedPositionMethod = 0, float energyThreshold = 0.0);
-                static std::vector<float> roundnessBarrelSuperClustersUserExtended( const reco::SuperCluster &superCluster ,const EcalRecHitCollection &recHits, int ieta_delta=0, int iphi_delta=0, float energyRHThresh=0.00000, int weightedPositionMethod=0);
-                static std::vector<float> roundnessSelectedBarrelRecHits(const std::vector<std::pair<const EcalRecHit*,float> >&rhVector, int weightedPositionMethod = 0);
-  
-                //works out the number of staturated crystals in 5x5
-                static int nrSaturatedCrysIn5x5(const DetId& id,const EcalRecHitCollection* recHits,const CaloTopology *topology);
-        private:
-                struct EcalClusterEnergyDeposition
-                { 
-                        double deposited_energy;
-                        double r;
-                        double phi;
-                };
+  //works out the number of staturated crystals in 5x5
+  static int nrSaturatedCrysIn5x5(const DetId &id, const EcalRecHitCollection *recHits, const CaloTopology *topology);
 
-                static std::vector<EcalClusterEnergyDeposition> getEnergyDepTopology( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloGeometry *geometry, bool logW, float w0 );
+private:
+  struct EcalClusterEnergyDeposition {
+    double deposited_energy;
+    double r;
+    double phi;
+  };
 
-                static math::XYZVector meanClusterPosition( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology *topology, const CaloGeometry *geometry );
+  static std::vector<EcalClusterEnergyDeposition> getEnergyDepTopology(const reco::BasicCluster &cluster,
+                                                                       const EcalRecHitCollection *recHits,
+                                                                       const CaloGeometry *geometry,
+                                                                       bool logW,
+                                                                       float w0);
 
-                //return energy weighted mean distance from the seed crystal in number of crystals
-                //<iEta,iPhi>, iPhi is not defined for endcap and is returned as zero 
-                static std::pair<float,float>  mean5x5PositionInLocalCrysCoord(const reco::BasicCluster &cluster, const EcalRecHitCollection* recHits,const CaloTopology *topology);
+  static math::XYZVector meanClusterPosition(const reco::BasicCluster &cluster,
+                                             const EcalRecHitCollection *recHits,
+                                             const CaloTopology *topology,
+                                             const CaloGeometry *geometry);
 
-                static std::pair<float,float> mean5x5PositionInXY(const reco::BasicCluster &cluster, const EcalRecHitCollection* recHits,const CaloTopology *topology);
+  //return energy weighted mean distance from the seed crystal in number of crystals
+  //<iEta,iPhi>, iPhi is not defined for endcap and is returned as zero
+  static std::pair<float, float> mean5x5PositionInLocalCrysCoord(const reco::BasicCluster &cluster,
+                                                                 const EcalRecHitCollection *recHits,
+                                                                 const CaloTopology *topology);
 
-                static double f00(double r) { return 1; }
-                static double f11(double r) { return r; }
-                static double f20(double r) { return 2.0*r*r-1.0; }
-                static double f22(double r) { return r*r; }
-                static double f31(double r) { return 3.0*r*r*r - 2.0*r; }
-                static double f33(double r) { return r*r*r; }
-                static double f40(double r) { return 6.0*r*r*r*r-6.0*r*r+1.0; }
-                static double f42(double r) { return 4.0*r*r*r*r-3.0*r*r; }
-                static double f44(double r) { return r*r*r*r; }
-                static double f51(double r) { return 10.0*pow(r,5)-12.0*pow(r,3)+3.0*r; }
-                static double f53(double r) { return 5.0*pow(r,5) - 4.0*pow(r,3); }
-                static double f55(double r) { return pow(r,5); }
+  static std::pair<float, float> mean5x5PositionInXY(const reco::BasicCluster &cluster,
+                                                     const EcalRecHitCollection *recHits,
+                                                     const CaloTopology *topology);
 
-                static double absZernikeMoment( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloGeometry *geometry, int n, int m, double R0, bool logW, float w0 );
-                static double fast_AbsZernikeMoment(const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloGeometry *geometry, int n, int m, double R0, bool logW, float w0 );
-                static double calc_AbsZernikeMoment(const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloGeometry *geometry, int n, int m, double R0, bool logW, float w0 );
+  static double f00(double r) { return 1; }
+  static double f11(double r) { return r; }
+  static double f20(double r) { return 2.0 * r * r - 1.0; }
+  static double f22(double r) { return r * r; }
+  static double f31(double r) { return 3.0 * r * r * r - 2.0 * r; }
+  static double f33(double r) { return r * r * r; }
+  static double f40(double r) { return 6.0 * r * r * r * r - 6.0 * r * r + 1.0; }
+  static double f42(double r) { return 4.0 * r * r * r * r - 3.0 * r * r; }
+  static double f44(double r) { return r * r * r * r; }
+  static double f51(double r) { return 10.0 * pow(r, 5) - 12.0 * pow(r, 3) + 3.0 * r; }
+  static double f53(double r) { return 5.0 * pow(r, 5) - 4.0 * pow(r, 3); }
+  static double f55(double r) { return pow(r, 5); }
 
-                static double factorial(int n) {
-                        double res = 1.;
-                        for (int i = 2; i <= n; ++i) res *= i;
-                        return res;
-                }
+  static double absZernikeMoment(const reco::BasicCluster &cluster,
+                                 const EcalRecHitCollection *recHits,
+                                 const CaloGeometry *geometry,
+                                 int n,
+                                 int m,
+                                 double R0,
+                                 bool logW,
+                                 float w0);
+  static double fast_AbsZernikeMoment(const reco::BasicCluster &cluster,
+                                      const EcalRecHitCollection *recHits,
+                                      const CaloGeometry *geometry,
+                                      int n,
+                                      int m,
+                                      double R0,
+                                      bool logW,
+                                      float w0);
+  static double calc_AbsZernikeMoment(const reco::BasicCluster &cluster,
+                                      const EcalRecHitCollection *recHits,
+                                      const CaloGeometry *geometry,
+                                      int n,
+                                      int m,
+                                      double R0,
+                                      bool logW,
+                                      float w0);
 
-                //useful functions for the localCovariances function
-                static float getIEta(const DetId& id);
-                static float getIPhi(const DetId& id);
-                static float getNormedIX(const DetId& id);
-                static float getNormedIY(const DetId& id);
-                static float getDPhiEndcap(const DetId& crysId,float meanX,float meanY);
-                static float getNrCrysDiffInEta(const DetId& crysId,const DetId& orginId);
-                static float getNrCrysDiffInPhi(const DetId& crysId,const DetId& orginId);
+  static double factorial(int n) {
+    double res = 1.;
+    for (int i = 2; i <= n; ++i)
+      res *= i;
+    return res;
+  }
 
-                //useful functions for showerRoundnessBarrel function
-                static int deltaIEta(int seed_ieta, int rh_ieta);
-                static int deltaIPhi(int seed_iphi, int rh_iphi);
-                static std::vector<int> getSeedPosition(const std::vector<std::pair<const EcalRecHit*,float> >&RH_ptrs);
-                static float getSumEnergy(const std::vector<std::pair<const EcalRecHit*,float> >&RH_ptrs_fracs);
-                static float computeWeight(float eRH, float energyTotal, int weightedPositionMethod);
+  //useful functions for the localCovariances function
+  static float getIEta(const DetId &id);
+  static float getIPhi(const DetId &id);
+  static float getNormedIX(const DetId &id);
+  static float getNormedIY(const DetId &id);
+  static float getDPhiEndcap(const DetId &crysId, float meanX, float meanY);
+  static float getNrCrysDiffInEta(const DetId &crysId, const DetId &orginId);
+  static float getNrCrysDiffInPhi(const DetId &crysId, const DetId &orginId);
 
-                
+  //useful functions for showerRoundnessBarrel function
+  static int deltaIEta(int seed_ieta, int rh_ieta);
+  static int deltaIPhi(int seed_iphi, int rh_iphi);
+  static std::vector<int> getSeedPosition(const std::vector<std::pair<const EcalRecHit *, float>> &RH_ptrs);
+  static float getSumEnergy(const std::vector<std::pair<const EcalRecHit *, float>> &RH_ptrs_fracs);
+  static float computeWeight(float eRH, float energyTotal, int weightedPositionMethod);
 };
 
 // implementation
-template<bool noZS> 
-float EcalClusterToolsT<noZS>::getFraction( const std::vector< std::pair<DetId, float> > &v_id, DetId id)
-{
-  if(noZS) return 1.0;
+template <bool noZS>
+float EcalClusterToolsT<noZS>::getFraction(const std::vector<std::pair<DetId, float>> &v_id, DetId id) {
+  if (noZS)
+    return 1.0;
   float frac = 0.0;
-  for ( size_t i = 0; i < v_id.size(); ++i ) {
-    if(v_id[i].first.rawId()==id.rawId()){
-      frac= v_id[i].second;
+  for (size_t i = 0; i < v_id.size(); ++i) {
+    if (v_id[i].first.rawId() == id.rawId()) {
+      frac = v_id[i].second;
       break;
     }
   }
   return frac;
 }
 
-template<bool noZS>
-std::pair<DetId, float> EcalClusterToolsT<noZS>::getMaximum( const std::vector< std::pair<DetId, float> > &v_id, const EcalRecHitCollection *recHits)
-{
-    float max = 0;
-    DetId id(0);
-    for ( size_t i = 0; i < v_id.size(); ++i ) {
-      float energy = recHitEnergy( v_id[i].first, recHits ) * (noZS ? 1.0 : v_id[i].second);
-        if ( energy > max ) {
-            max = energy;
-            id = v_id[i].first;
-        }
+template <bool noZS>
+std::pair<DetId, float> EcalClusterToolsT<noZS>::getMaximum(const std::vector<std::pair<DetId, float>> &v_id,
+                                                            const EcalRecHitCollection *recHits) {
+  float max = 0;
+  DetId id(0);
+  for (size_t i = 0; i < v_id.size(); ++i) {
+    float energy = recHitEnergy(v_id[i].first, recHits) * (noZS ? 1.0 : v_id[i].second);
+    if (energy > max) {
+      max = energy;
+      id = v_id[i].first;
     }
-    return std::pair<DetId, float>(id, max);
+  }
+  return std::pair<DetId, float>(id, max);
 }
 
-template<bool noZS>
-std::pair<DetId, float> EcalClusterToolsT<noZS>::getMaximum( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits)
-{
-    return getMaximum( cluster.hitsAndFractions(), recHits );
+template <bool noZS>
+std::pair<DetId, float> EcalClusterToolsT<noZS>::getMaximum(const reco::BasicCluster &cluster,
+                                                            const EcalRecHitCollection *recHits) {
+  return getMaximum(cluster.hitsAndFractions(), recHits);
 }
 
-
-template<bool noZS>
-float EcalClusterToolsT<noZS>::recHitEnergy(DetId id, const EcalRecHitCollection *recHits)
-{
-  if ( id == DetId(0) ) {
+template <bool noZS>
+float EcalClusterToolsT<noZS>::recHitEnergy(DetId id, const EcalRecHitCollection *recHits) {
+  if (id == DetId(0)) {
     return 0;
   } else {
-    EcalRecHitCollection::const_iterator it = recHits->find( id );
-    if ( it != recHits->end() ) {
-      if( noZS && ( it->checkFlag(EcalRecHit::kTowerRecovered) ||
-                    it->checkFlag(EcalRecHit::kWeird) ||
-                   (it->detid().subdetId() == EcalBarrel && 
-                    it->checkFlag(EcalRecHit::kDiWeird) ))) return 0.0;
-      else return it->energy();
+    EcalRecHitCollection::const_iterator it = recHits->find(id);
+    if (it != recHits->end()) {
+      if (noZS && (it->checkFlag(EcalRecHit::kTowerRecovered) || it->checkFlag(EcalRecHit::kWeird) ||
+                   (it->detid().subdetId() == EcalBarrel && it->checkFlag(EcalRecHit::kDiWeird))))
+        return 0.0;
+      else
+        return it->energy();
     } else {
       //throw cms::Exception("EcalRecHitNotFound") << "The recHit corresponding to the DetId" << id.rawId() << " not found in the EcalRecHitCollection";
       // the recHit is not in the collection (hopefully zero suppressed)
@@ -312,7 +427,6 @@ float EcalClusterToolsT<noZS>::recHitEnergy(DetId id, const EcalRecHitCollection
   }
   return 0;
 }
-
 
 // Returns the energy in a rectangle of crystals
 // specified in eta by ixMin and ixMax
@@ -326,396 +440,441 @@ float EcalClusterToolsT<noZS>::recHitEnergy(DetId id, const EcalRecHitCollection
 //    -1 |_|_|_|_|_|
 //    -2 |_|_|_|_|_|
 //      -2 -1 0 1 2 ix
-template<bool noZS>
-float EcalClusterToolsT<noZS>::matrixEnergy( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, DetId id, CaloRectangle rectangle )
-{
-    float energy = 0;
-    auto const& vId = cluster.hitsAndFractions();
+template <bool noZS>
+float EcalClusterToolsT<noZS>::matrixEnergy(const reco::BasicCluster &cluster,
+                                            const EcalRecHitCollection *recHits,
+                                            const CaloTopology *topology,
+                                            DetId id,
+                                            CaloRectangle rectangle) {
+  float energy = 0;
+  auto const &vId = cluster.hitsAndFractions();
 
-    for (auto const& detId : rectangle(id, *topology)) {
-        energy += recHitEnergy( detId, recHits ) * getFraction(vId, detId);
-    }
+  for (auto const &detId : rectangle(id, *topology)) {
+    energy += recHitEnergy(detId, recHits) * getFraction(vId, detId);
+  }
 
-    return energy;
+  return energy;
 }
 
-template<bool noZS>
-int EcalClusterToolsT<noZS>::matrixSize( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, DetId id, CaloRectangle rectangle )
-{
-    int result = 0;
+template <bool noZS>
+int EcalClusterToolsT<noZS>::matrixSize(const reco::BasicCluster &cluster,
+                                        const EcalRecHitCollection *recHits,
+                                        const CaloTopology *topology,
+                                        DetId id,
+                                        CaloRectangle rectangle) {
+  int result = 0;
 
-    for (auto const& detId : rectangle(id, *topology)) {
-        const float energy = recHitEnergy(detId, recHits);
-        const float frac = getFraction(cluster.hitsAndFractions(), detId);
-        if(energy * frac > 0) result++;
-    }
-    return result;
+  for (auto const &detId : rectangle(id, *topology)) {
+    const float energy = recHitEnergy(detId, recHits);
+    const float frac = getFraction(cluster.hitsAndFractions(), detId);
+    if (energy * frac > 0)
+      result++;
+  }
+  return result;
 }
 
-
-template<bool noZS>
-std::vector<DetId> EcalClusterToolsT<noZS>::matrixDetId( const CaloTopology* topology, DetId id, CaloRectangle rectangle )
-{
-    std::vector<DetId> v;
-    for (auto const& detId : rectangle(id, *topology)) {
-        if ( detId != DetId(0) ) v.push_back(detId);
-    }
-    return v;
+template <bool noZS>
+std::vector<DetId> EcalClusterToolsT<noZS>::matrixDetId(const CaloTopology *topology,
+                                                        DetId id,
+                                                        CaloRectangle rectangle) {
+  std::vector<DetId> v;
+  for (auto const &detId : rectangle(id, *topology)) {
+    if (detId != DetId(0))
+      v.push_back(detId);
+  }
+  return v;
 }
 
-
-template<bool noZS>
-float EcalClusterToolsT<noZS>::e2x2( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
-{
-    DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
-    std::list<float> energies;
-    float max_E =  matrixEnergy( cluster, recHits, topology, id, {-1, 0, -1, 0} );
-    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id, {-1, 0,  0, 1} ) );
-    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id, { 0, 1,  0, 1} ) );
-    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id, { 0, 1, -1, 0} ) );
-    return max_E;
+template <bool noZS>
+float EcalClusterToolsT<noZS>::e2x2(const reco::BasicCluster &cluster,
+                                    const EcalRecHitCollection *recHits,
+                                    const CaloTopology *topology) {
+  DetId id = getMaximum(cluster.hitsAndFractions(), recHits).first;
+  std::list<float> energies;
+  float max_E = matrixEnergy(cluster, recHits, topology, id, {-1, 0, -1, 0});
+  max_E = std::max(max_E, matrixEnergy(cluster, recHits, topology, id, {-1, 0, 0, 1}));
+  max_E = std::max(max_E, matrixEnergy(cluster, recHits, topology, id, {0, 1, 0, 1}));
+  max_E = std::max(max_E, matrixEnergy(cluster, recHits, topology, id, {0, 1, -1, 0}));
+  return max_E;
 }
 
-template<bool noZS>
-float EcalClusterToolsT<noZS>::e3x2( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
-{
-    DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
-    float max_E = matrixEnergy( cluster, recHits, topology, id, {-1, 1, -1, 0} );
-    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id,  {0, 1, -1, 1} ) );
-    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id, {-1, 1,  0, 1} ) );
-    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id, {-1, 0, -1, 1} ) );
-    return max_E;
+template <bool noZS>
+float EcalClusterToolsT<noZS>::e3x2(const reco::BasicCluster &cluster,
+                                    const EcalRecHitCollection *recHits,
+                                    const CaloTopology *topology) {
+  DetId id = getMaximum(cluster.hitsAndFractions(), recHits).first;
+  float max_E = matrixEnergy(cluster, recHits, topology, id, {-1, 1, -1, 0});
+  max_E = std::max(max_E, matrixEnergy(cluster, recHits, topology, id, {0, 1, -1, 1}));
+  max_E = std::max(max_E, matrixEnergy(cluster, recHits, topology, id, {-1, 1, 0, 1}));
+  max_E = std::max(max_E, matrixEnergy(cluster, recHits, topology, id, {-1, 0, -1, 1}));
+  return max_E;
 }
 
-template<bool noZS>
-float EcalClusterToolsT<noZS>::e3x3( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
-{
-    DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
-    return matrixEnergy( cluster, recHits, topology, id, {-1, 1, -1, 1} );
+template <bool noZS>
+float EcalClusterToolsT<noZS>::e3x3(const reco::BasicCluster &cluster,
+                                    const EcalRecHitCollection *recHits,
+                                    const CaloTopology *topology) {
+  DetId id = getMaximum(cluster.hitsAndFractions(), recHits).first;
+  return matrixEnergy(cluster, recHits, topology, id, {-1, 1, -1, 1});
 }
 
-template<bool noZS>
-float EcalClusterToolsT<noZS>::e4x4( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
-{
-    DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;    
-    float max_E = matrixEnergy( cluster, recHits, topology, id, {-1, 2, -2, 1} );
-    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id, {-2, 1, -2, 1} ) );
-    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id, {-2, 1, -1, 2} ) );
-    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id, {-1, 2, -1, 2} ) );
-    return max_E;
+template <bool noZS>
+float EcalClusterToolsT<noZS>::e4x4(const reco::BasicCluster &cluster,
+                                    const EcalRecHitCollection *recHits,
+                                    const CaloTopology *topology) {
+  DetId id = getMaximum(cluster.hitsAndFractions(), recHits).first;
+  float max_E = matrixEnergy(cluster, recHits, topology, id, {-1, 2, -2, 1});
+  max_E = std::max(max_E, matrixEnergy(cluster, recHits, topology, id, {-2, 1, -2, 1}));
+  max_E = std::max(max_E, matrixEnergy(cluster, recHits, topology, id, {-2, 1, -1, 2}));
+  max_E = std::max(max_E, matrixEnergy(cluster, recHits, topology, id, {-1, 2, -1, 2}));
+  return max_E;
 }
 
-template<bool noZS>
-float EcalClusterToolsT<noZS>::e5x5( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
-{
-    DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
-    return matrixEnergy( cluster, recHits, topology, id, {-2, 2, -2, 2} );
+template <bool noZS>
+float EcalClusterToolsT<noZS>::e5x5(const reco::BasicCluster &cluster,
+                                    const EcalRecHitCollection *recHits,
+                                    const CaloTopology *topology) {
+  DetId id = getMaximum(cluster.hitsAndFractions(), recHits).first;
+  return matrixEnergy(cluster, recHits, topology, id, {-2, 2, -2, 2});
 }
 
-template<bool noZS>
-int EcalClusterToolsT<noZS>::n5x5( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
-{
-    DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
-    return matrixSize( cluster, recHits, topology, id, {-2, 2, -2, 2} );
+template <bool noZS>
+int EcalClusterToolsT<noZS>::n5x5(const reco::BasicCluster &cluster,
+                                  const EcalRecHitCollection *recHits,
+                                  const CaloTopology *topology) {
+  DetId id = getMaximum(cluster.hitsAndFractions(), recHits).first;
+  return matrixSize(cluster, recHits, topology, id, {-2, 2, -2, 2});
 }
 
-template<bool noZS>
-float EcalClusterToolsT<noZS>::eMax( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits )
-{
-    return getMaximum( cluster.hitsAndFractions(), recHits ).second;
+template <bool noZS>
+float EcalClusterToolsT<noZS>::eMax(const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits) {
+  return getMaximum(cluster.hitsAndFractions(), recHits).second;
 }
 
-template<bool noZS>
-float EcalClusterToolsT<noZS>::e2nd( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits )
-{
-    std::vector<float> energies;
-    const std::vector< std::pair<DetId, float> >& v_id = cluster.hitsAndFractions();
-    energies.reserve( v_id.size() );
-    if ( v_id.size() < 2 ) return 0;
-    for ( size_t i = 0; i < v_id.size(); ++i ) {
-      energies.push_back( recHitEnergy( v_id[i].first, recHits ) * (noZS ? 1.0 : v_id[i].second) );
-    }
-    std::partial_sort( energies.begin(), energies.begin()+2, energies.end(), std::greater<float>() );
-    return energies[1];
+template <bool noZS>
+float EcalClusterToolsT<noZS>::e2nd(const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits) {
+  std::vector<float> energies;
+  const std::vector<std::pair<DetId, float>> &v_id = cluster.hitsAndFractions();
+  energies.reserve(v_id.size());
+  if (v_id.size() < 2)
+    return 0;
+  for (size_t i = 0; i < v_id.size(); ++i) {
+    energies.push_back(recHitEnergy(v_id[i].first, recHits) * (noZS ? 1.0 : v_id[i].second));
+  }
+  std::partial_sort(energies.begin(), energies.begin() + 2, energies.end(), std::greater<float>());
+  return energies[1];
 }
 
-template<bool noZS>
-float EcalClusterToolsT<noZS>::e2x5Right( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
-{
-    DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
-    return matrixEnergy( cluster, recHits, topology, id, {1, 2, -2, 2} );
+template <bool noZS>
+float EcalClusterToolsT<noZS>::e2x5Right(const reco::BasicCluster &cluster,
+                                         const EcalRecHitCollection *recHits,
+                                         const CaloTopology *topology) {
+  DetId id = getMaximum(cluster.hitsAndFractions(), recHits).first;
+  return matrixEnergy(cluster, recHits, topology, id, {1, 2, -2, 2});
 }
 
-template<bool noZS>
-float EcalClusterToolsT<noZS>::e2x5Left( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
-{
-    DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
-    return matrixEnergy( cluster, recHits, topology, id, {-2, -1, -2, 2} );
+template <bool noZS>
+float EcalClusterToolsT<noZS>::e2x5Left(const reco::BasicCluster &cluster,
+                                        const EcalRecHitCollection *recHits,
+                                        const CaloTopology *topology) {
+  DetId id = getMaximum(cluster.hitsAndFractions(), recHits).first;
+  return matrixEnergy(cluster, recHits, topology, id, {-2, -1, -2, 2});
 }
 
-template<bool noZS>
-float EcalClusterToolsT<noZS>::e2x5Top( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
-{
-    DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
-    return matrixEnergy( cluster, recHits, topology, id, {-2, 2, 1, 2} );
+template <bool noZS>
+float EcalClusterToolsT<noZS>::e2x5Top(const reco::BasicCluster &cluster,
+                                       const EcalRecHitCollection *recHits,
+                                       const CaloTopology *topology) {
+  DetId id = getMaximum(cluster.hitsAndFractions(), recHits).first;
+  return matrixEnergy(cluster, recHits, topology, id, {-2, 2, 1, 2});
 }
 
-template<bool noZS>
-float EcalClusterToolsT<noZS>::e2x5Bottom( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
-{
-    DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
-    return matrixEnergy( cluster, recHits, topology, id, {-2, 2, -2, -1} );
+template <bool noZS>
+float EcalClusterToolsT<noZS>::e2x5Bottom(const reco::BasicCluster &cluster,
+                                          const EcalRecHitCollection *recHits,
+                                          const CaloTopology *topology) {
+  DetId id = getMaximum(cluster.hitsAndFractions(), recHits).first;
+  return matrixEnergy(cluster, recHits, topology, id, {-2, 2, -2, -1});
 }
 
 // Energy in 2x5 strip containing the max crystal.
 // Adapted from code by Sam Harper
-template<bool noZS>
-float EcalClusterToolsT<noZS>::e2x5Max( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
-{
-    DetId id =      getMaximum( cluster.hitsAndFractions(), recHits ).first;
+template <bool noZS>
+float EcalClusterToolsT<noZS>::e2x5Max(const reco::BasicCluster &cluster,
+                                       const EcalRecHitCollection *recHits,
+                                       const CaloTopology *topology) {
+  DetId id = getMaximum(cluster.hitsAndFractions(), recHits).first;
 
-    // 1x5 strip left of seed
-    float left   = matrixEnergy( cluster, recHits, topology, id, {-1, -1, -2, 2} );
-    // 1x5 strip right of seed
-    float right  = matrixEnergy( cluster, recHits, topology, id,  {1,  1, -2, 2} );
-    // 1x5 strip containing seed
-    float centre = matrixEnergy( cluster, recHits, topology, id,  {0,  0, -2, 2} );
+  // 1x5 strip left of seed
+  float left = matrixEnergy(cluster, recHits, topology, id, {-1, -1, -2, 2});
+  // 1x5 strip right of seed
+  float right = matrixEnergy(cluster, recHits, topology, id, {1, 1, -2, 2});
+  // 1x5 strip containing seed
+  float centre = matrixEnergy(cluster, recHits, topology, id, {0, 0, -2, 2});
 
-    // Return the maximum of (left+center) or (right+center) strip
-    return left > right ? left+centre : right+centre;
+  // Return the maximum of (left+center) or (right+center) strip
+  return left > right ? left + centre : right + centre;
 }
 
-template<bool noZS>
-float EcalClusterToolsT<noZS>::e1x5( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
-{
-    DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
-    return matrixEnergy( cluster, recHits, topology, id, {0, 0, -2, 2} );
+template <bool noZS>
+float EcalClusterToolsT<noZS>::e1x5(const reco::BasicCluster &cluster,
+                                    const EcalRecHitCollection *recHits,
+                                    const CaloTopology *topology) {
+  DetId id = getMaximum(cluster.hitsAndFractions(), recHits).first;
+  return matrixEnergy(cluster, recHits, topology, id, {0, 0, -2, 2});
 }
 
-template<bool noZS>
-float EcalClusterToolsT<noZS>::e5x1( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
-{
-    DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
-    return matrixEnergy( cluster, recHits, topology, id, {-2, 2, 0, 0} );
+template <bool noZS>
+float EcalClusterToolsT<noZS>::e5x1(const reco::BasicCluster &cluster,
+                                    const EcalRecHitCollection *recHits,
+                                    const CaloTopology *topology) {
+  DetId id = getMaximum(cluster.hitsAndFractions(), recHits).first;
+  return matrixEnergy(cluster, recHits, topology, id, {-2, 2, 0, 0});
 }
 
-template<bool noZS>
-float EcalClusterToolsT<noZS>::e1x3( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
-{
-    DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
-    return matrixEnergy( cluster, recHits, topology, id, {0, 0, -1, 1} );
+template <bool noZS>
+float EcalClusterToolsT<noZS>::e1x3(const reco::BasicCluster &cluster,
+                                    const EcalRecHitCollection *recHits,
+                                    const CaloTopology *topology) {
+  DetId id = getMaximum(cluster.hitsAndFractions(), recHits).first;
+  return matrixEnergy(cluster, recHits, topology, id, {0, 0, -1, 1});
 }
 
-template<bool noZS>
-float EcalClusterToolsT<noZS>::e3x1( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
-{
-    DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
-    return matrixEnergy( cluster, recHits, topology, id, {-1, 1, 0, 0} );
+template <bool noZS>
+float EcalClusterToolsT<noZS>::e3x1(const reco::BasicCluster &cluster,
+                                    const EcalRecHitCollection *recHits,
+                                    const CaloTopology *topology) {
+  DetId id = getMaximum(cluster.hitsAndFractions(), recHits).first;
+  return matrixEnergy(cluster, recHits, topology, id, {-1, 1, 0, 0});
 }
 
-template<bool noZS>
-float EcalClusterToolsT<noZS>::eLeft( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
-{
-    DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
-    return matrixEnergy( cluster, recHits, topology, id, {-1, -1, 0, 0} );
+template <bool noZS>
+float EcalClusterToolsT<noZS>::eLeft(const reco::BasicCluster &cluster,
+                                     const EcalRecHitCollection *recHits,
+                                     const CaloTopology *topology) {
+  DetId id = getMaximum(cluster.hitsAndFractions(), recHits).first;
+  return matrixEnergy(cluster, recHits, topology, id, {-1, -1, 0, 0});
 }
 
-template<bool noZS>
-float EcalClusterToolsT<noZS>::eRight( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
-{
-    DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
-    return matrixEnergy( cluster, recHits, topology, id, {1, 1, 0, 0} );
+template <bool noZS>
+float EcalClusterToolsT<noZS>::eRight(const reco::BasicCluster &cluster,
+                                      const EcalRecHitCollection *recHits,
+                                      const CaloTopology *topology) {
+  DetId id = getMaximum(cluster.hitsAndFractions(), recHits).first;
+  return matrixEnergy(cluster, recHits, topology, id, {1, 1, 0, 0});
 }
 
-template<bool noZS>
-float EcalClusterToolsT<noZS>::eTop( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
-{
-    DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
-    return matrixEnergy( cluster, recHits, topology, id, {0, 0, 1, 1} );
+template <bool noZS>
+float EcalClusterToolsT<noZS>::eTop(const reco::BasicCluster &cluster,
+                                    const EcalRecHitCollection *recHits,
+                                    const CaloTopology *topology) {
+  DetId id = getMaximum(cluster.hitsAndFractions(), recHits).first;
+  return matrixEnergy(cluster, recHits, topology, id, {0, 0, 1, 1});
 }
 
-template<bool noZS>
-float EcalClusterToolsT<noZS>::eBottom( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
-{
-    DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
-    return matrixEnergy( cluster, recHits, topology, id, {0, 0, -1, -1} );
+template <bool noZS>
+float EcalClusterToolsT<noZS>::eBottom(const reco::BasicCluster &cluster,
+                                       const EcalRecHitCollection *recHits,
+                                       const CaloTopology *topology) {
+  DetId id = getMaximum(cluster.hitsAndFractions(), recHits).first;
+  return matrixEnergy(cluster, recHits, topology, id, {0, 0, -1, -1});
 }
 
-template<bool noZS>
-std::vector<float> EcalClusterToolsT<noZS>::energyBasketFractionEta( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits )
-{
-    std::vector<float> basketFraction( 2 * EBDetId::kModulesPerSM );
-    float clusterEnergy = cluster.energy();
-    const std::vector< std::pair<DetId, float> >& v_id = cluster.hitsAndFractions();
-    if ( v_id[0].first.subdetId() != EcalBarrel ) {
-        edm::LogWarning("EcalClusterToolsT<noZS>::energyBasketFractionEta") << "Trying to get basket fraction for endcap basic-clusters. Basket fractions can be obtained ONLY for barrel basic-clusters. Returning empty vector.";
-        return basketFraction;
-    }
-    for ( size_t i = 0; i < v_id.size(); ++i ) {
-        basketFraction[ EBDetId(v_id[i].first).im()-1 + EBDetId(v_id[i].first).positiveZ()*EBDetId::kModulesPerSM ] += recHitEnergy( v_id[i].first, recHits ) * v_id[i].second / clusterEnergy;
-    }
-    std::sort( basketFraction.rbegin(), basketFraction.rend() );
+template <bool noZS>
+std::vector<float> EcalClusterToolsT<noZS>::energyBasketFractionEta(const reco::BasicCluster &cluster,
+                                                                    const EcalRecHitCollection *recHits) {
+  std::vector<float> basketFraction(2 * EBDetId::kModulesPerSM);
+  float clusterEnergy = cluster.energy();
+  const std::vector<std::pair<DetId, float>> &v_id = cluster.hitsAndFractions();
+  if (v_id[0].first.subdetId() != EcalBarrel) {
+    edm::LogWarning("EcalClusterToolsT<noZS>::energyBasketFractionEta")
+        << "Trying to get basket fraction for endcap basic-clusters. Basket fractions can be obtained ONLY for barrel "
+           "basic-clusters. Returning empty vector.";
     return basketFraction;
+  }
+  for (size_t i = 0; i < v_id.size(); ++i) {
+    basketFraction[EBDetId(v_id[i].first).im() - 1 + EBDetId(v_id[i].first).positiveZ() * EBDetId::kModulesPerSM] +=
+        recHitEnergy(v_id[i].first, recHits) * v_id[i].second / clusterEnergy;
+  }
+  std::sort(basketFraction.rbegin(), basketFraction.rend());
+  return basketFraction;
 }
 
-template<bool noZS>
-std::vector<float> EcalClusterToolsT<noZS>::energyBasketFractionPhi( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits )
-{
-    std::vector<float> basketFraction( 2 * (EBDetId::MAX_IPHI / EBDetId::kCrystalsInPhi) );
-    float clusterEnergy = cluster.energy();
-    const std::vector< std::pair<DetId, float> >& v_id = cluster.hitsAndFractions();
-    if ( v_id[0].first.subdetId() != EcalBarrel ) {
-        edm::LogWarning("EcalClusterToolsT<noZS>::energyBasketFractionPhi") << "Trying to get basket fraction for endcap basic-clusters. Basket fractions can be obtained ONLY for barrel basic-clusters. Returning empty vector.";
-        return basketFraction;
-    }
-    for ( size_t i = 0; i < v_id.size(); ++i ) {
-      basketFraction[ (EBDetId(v_id[i].first).iphi()-1)/EBDetId::kCrystalsInPhi + EBDetId(v_id[i].first).positiveZ()*EBDetId::kTowersInPhi] += recHitEnergy( v_id[i].first, recHits ) * (noZS ? 1.0 : v_id[i].second) / clusterEnergy;
-    }
-    std::sort( basketFraction.rbegin(), basketFraction.rend() );
+template <bool noZS>
+std::vector<float> EcalClusterToolsT<noZS>::energyBasketFractionPhi(const reco::BasicCluster &cluster,
+                                                                    const EcalRecHitCollection *recHits) {
+  std::vector<float> basketFraction(2 * (EBDetId::MAX_IPHI / EBDetId::kCrystalsInPhi));
+  float clusterEnergy = cluster.energy();
+  const std::vector<std::pair<DetId, float>> &v_id = cluster.hitsAndFractions();
+  if (v_id[0].first.subdetId() != EcalBarrel) {
+    edm::LogWarning("EcalClusterToolsT<noZS>::energyBasketFractionPhi")
+        << "Trying to get basket fraction for endcap basic-clusters. Basket fractions can be obtained ONLY for barrel "
+           "basic-clusters. Returning empty vector.";
     return basketFraction;
+  }
+  for (size_t i = 0; i < v_id.size(); ++i) {
+    basketFraction[(EBDetId(v_id[i].first).iphi() - 1) / EBDetId::kCrystalsInPhi +
+                   EBDetId(v_id[i].first).positiveZ() * EBDetId::kTowersInPhi] +=
+        recHitEnergy(v_id[i].first, recHits) * (noZS ? 1.0 : v_id[i].second) / clusterEnergy;
+  }
+  std::sort(basketFraction.rbegin(), basketFraction.rend());
+  return basketFraction;
 }
 
-template<bool noZS>
-std::vector<typename EcalClusterToolsT<noZS>::EcalClusterEnergyDeposition> EcalClusterToolsT<noZS>::getEnergyDepTopology( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloGeometry *geometry, bool logW, float w0 )
-{
-    std::vector<typename EcalClusterToolsT<noZS>::EcalClusterEnergyDeposition> energyDistribution;
-    // init a map of the energy deposition centered on the
-    // cluster centroid. This is for momenta calculation only.
-    CLHEP::Hep3Vector clVect(cluster.position().x(), cluster.position().y(), cluster.position().z());
-    CLHEP::Hep3Vector clDir(clVect);
-    clDir*=1.0/clDir.mag();
-    // in the transverse plane, axis perpendicular to clusterDir
-    CLHEP::Hep3Vector theta_axis(clDir.y(),-clDir.x(),0.0);
-    theta_axis *= 1.0/theta_axis.mag();
-    CLHEP::Hep3Vector phi_axis = theta_axis.cross(clDir);
+template <bool noZS>
+std::vector<typename EcalClusterToolsT<noZS>::EcalClusterEnergyDeposition>
+EcalClusterToolsT<noZS>::getEnergyDepTopology(const reco::BasicCluster &cluster,
+                                              const EcalRecHitCollection *recHits,
+                                              const CaloGeometry *geometry,
+                                              bool logW,
+                                              float w0) {
+  std::vector<typename EcalClusterToolsT<noZS>::EcalClusterEnergyDeposition> energyDistribution;
+  // init a map of the energy deposition centered on the
+  // cluster centroid. This is for momenta calculation only.
+  CLHEP::Hep3Vector clVect(cluster.position().x(), cluster.position().y(), cluster.position().z());
+  CLHEP::Hep3Vector clDir(clVect);
+  clDir *= 1.0 / clDir.mag();
+  // in the transverse plane, axis perpendicular to clusterDir
+  CLHEP::Hep3Vector theta_axis(clDir.y(), -clDir.x(), 0.0);
+  theta_axis *= 1.0 / theta_axis.mag();
+  CLHEP::Hep3Vector phi_axis = theta_axis.cross(clDir);
 
-    const std::vector< std::pair<DetId, float> >& clusterDetIds = cluster.hitsAndFractions();
+  const std::vector<std::pair<DetId, float>> &clusterDetIds = cluster.hitsAndFractions();
 
-    EcalClusterEnergyDeposition clEdep;
-    EcalRecHit testEcalRecHit;
-    std::vector< std::pair<DetId, float> >::const_iterator posCurrent;
-    // loop over crystals
-    for(posCurrent=clusterDetIds.begin(); posCurrent!=clusterDetIds.end(); ++posCurrent) {
-        EcalRecHitCollection::const_iterator itt = recHits->find( (*posCurrent).first );
-        testEcalRecHit=*itt;
+  EcalClusterEnergyDeposition clEdep;
+  EcalRecHit testEcalRecHit;
+  std::vector<std::pair<DetId, float>>::const_iterator posCurrent;
+  // loop over crystals
+  for (posCurrent = clusterDetIds.begin(); posCurrent != clusterDetIds.end(); ++posCurrent) {
+    EcalRecHitCollection::const_iterator itt = recHits->find((*posCurrent).first);
+    testEcalRecHit = *itt;
 
-        if(( (*posCurrent).first != DetId(0)) && (recHits->find( (*posCurrent).first ) != recHits->end())) {
-            clEdep.deposited_energy = testEcalRecHit.energy() * (noZS ? 1.0 : (*posCurrent).second);
-            // if logarithmic weight is requested, apply cut on minimum energy of the recHit
-            if(logW) {
-                //double w0 = parameterMap_.find("W0")->second;
+    if (((*posCurrent).first != DetId(0)) && (recHits->find((*posCurrent).first) != recHits->end())) {
+      clEdep.deposited_energy = testEcalRecHit.energy() * (noZS ? 1.0 : (*posCurrent).second);
+      // if logarithmic weight is requested, apply cut on minimum energy of the recHit
+      if (logW) {
+        //double w0 = parameterMap_.find("W0")->second;
 
-            double weight = std::max(0.0, w0 + log(std::abs(clEdep.deposited_energy)/cluster.energy()) );
-                if(weight==0) {
-                    LogDebug("ClusterShapeAlgo") << "Crystal has insufficient energy: E = " 
-                        << clEdep.deposited_energy << " GeV; skipping... ";
-                    continue;
-                }
-                else LogDebug("ClusterShapeAlgo") << "===> got crystal. Energy = " << clEdep.deposited_energy << " GeV. ";
-            }
-            DetId id_ = (*posCurrent).first;
-            const CaloSubdetectorGeometry* geo = geometry->getSubdetectorGeometry(id_);
-            auto this_cell = geo->getGeometry(id_);
-            const GlobalPoint& cellPos = this_cell->getPosition();
-            CLHEP::Hep3Vector gblPos (cellPos.x(),cellPos.y(),cellPos.z()); //surface position?
-            // Evaluate the distance from the cluster centroid
-            CLHEP::Hep3Vector diff = gblPos - clVect;
-            // Important: for the moment calculation, only the "lateral distance" is important
-            // "lateral distance" r_i = distance of the digi position from the axis Origin-Cluster Center
-            // ---> subtract the projection on clDir
-            CLHEP::Hep3Vector DigiVect = diff - diff.dot(clDir)*clDir;
-            clEdep.r = DigiVect.mag();
-            LogDebug("ClusterShapeAlgo") << "E = " << clEdep.deposited_energy
-                << "\tdiff = " << diff.mag()
-                << "\tr = " << clEdep.r;
-            clEdep.phi = DigiVect.angle(theta_axis);
-            if(DigiVect.dot(phi_axis)<0) clEdep.phi = 2 * M_PI - clEdep.phi;
-            energyDistribution.push_back(clEdep);
-        }
-    }
-    return energyDistribution;
-}
-
-template<bool noZS>
-std::vector<float> EcalClusterToolsT<noZS>::lat( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloGeometry *geometry, bool logW, float w0 )
-{
-    std::vector<EcalClusterToolsT::EcalClusterEnergyDeposition> energyDistribution = getEnergyDepTopology( cluster, recHits, geometry, logW, w0 );
-
-    std::vector<float> lat;
-    double r, redmoment=0;
-    double phiRedmoment = 0 ;
-    double etaRedmoment = 0 ;
-    int n,n1,n2,tmp;
-    int clusterSize=energyDistribution.size();
-    float etaLat_, phiLat_, lat_;
-    if (clusterSize<3) {
-        etaLat_ = 0.0 ;
-        lat_ = 0.0;
-        lat.push_back(0.);
-        lat.push_back(0.);
-        lat.push_back(0.);
-        return lat; 
-    }
-
-    n1=0; n2=1;
-    if (energyDistribution[1].deposited_energy > 
-            energyDistribution[0].deposited_energy) 
-    {
-        tmp=n2; n2=n1; n1=tmp;
-    }
-    for (int i=2; i<clusterSize; i++) {
-        n=i;
-        if (energyDistribution[i].deposited_energy > 
-                energyDistribution[n1].deposited_energy) 
-        {
-            tmp = n2;
-            n2 = n1; n1 = i; n=tmp;
-        } else {
-            if (energyDistribution[i].deposited_energy > 
-                    energyDistribution[n2].deposited_energy) 
-            {
-                tmp=n2; n2=i; n=tmp;
-            }
-        }
-
-        r = energyDistribution[n].r;
-        redmoment += r*r* energyDistribution[n].deposited_energy;
-        double rphi = r * cos (energyDistribution[n].phi) ;
-        phiRedmoment += rphi * rphi * energyDistribution[n].deposited_energy;
-        double reta = r * sin (energyDistribution[n].phi) ;
-        etaRedmoment += reta * reta * energyDistribution[n].deposited_energy;
-    } 
-    double e1 = energyDistribution[n1].deposited_energy;
-    double e2 = energyDistribution[n2].deposited_energy;
-
-    lat_ = redmoment/(redmoment+2.19*2.19*(e1+e2));
-    phiLat_ = phiRedmoment/(phiRedmoment+2.19*2.19*(e1+e2));
-    etaLat_ = etaRedmoment/(etaRedmoment+2.19*2.19*(e1+e2));
-
-    lat.push_back(etaLat_);
-    lat.push_back(phiLat_);
-    lat.push_back(lat_);
-    return lat;
-}
-
-template<bool noZS>
-math::XYZVector EcalClusterToolsT<noZS>::meanClusterPosition( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology *topology, const CaloGeometry *geometry )
-{
-    // find mean energy position of a 5x5 cluster around the maximum
-    math::XYZVector meanPosition(0.0, 0.0, 0.0);
-    const std::vector<std::pair<DetId,float> >& hsAndFs = cluster.hitsAndFractions();
-    std::vector<DetId> v_id = matrixDetId( topology, getMaximum( cluster, recHits ).first, 2 );
-    for( const std::pair<DetId,float>& hitAndFrac : hsAndFs ) {
-      for( std::vector<DetId>::const_iterator it = v_id.begin(); it != v_id.end(); ++it ) {
-        if( hitAndFrac.first != *it && !noZS) continue;
-        const CaloSubdetectorGeometry* geo = geometry->getSubdetectorGeometry(*it);
-        GlobalPoint positionGP = geo->getGeometry( *it )->getPosition();
-        math::XYZVector position(positionGP.x(),positionGP.y(),positionGP.z());
-        meanPosition = meanPosition + recHitEnergy( *it, recHits ) * position * hitAndFrac.second;
+        double weight = std::max(0.0, w0 + log(std::abs(clEdep.deposited_energy) / cluster.energy()));
+        if (weight == 0) {
+          LogDebug("ClusterShapeAlgo") << "Crystal has insufficient energy: E = " << clEdep.deposited_energy
+                                       << " GeV; skipping... ";
+          continue;
+        } else
+          LogDebug("ClusterShapeAlgo") << "===> got crystal. Energy = " << clEdep.deposited_energy << " GeV. ";
       }
-      if(noZS) break;
+      DetId id_ = (*posCurrent).first;
+      const CaloSubdetectorGeometry *geo = geometry->getSubdetectorGeometry(id_);
+      auto this_cell = geo->getGeometry(id_);
+      const GlobalPoint &cellPos = this_cell->getPosition();
+      CLHEP::Hep3Vector gblPos(cellPos.x(), cellPos.y(), cellPos.z());  //surface position?
+      // Evaluate the distance from the cluster centroid
+      CLHEP::Hep3Vector diff = gblPos - clVect;
+      // Important: for the moment calculation, only the "lateral distance" is important
+      // "lateral distance" r_i = distance of the digi position from the axis Origin-Cluster Center
+      // ---> subtract the projection on clDir
+      CLHEP::Hep3Vector DigiVect = diff - diff.dot(clDir) * clDir;
+      clEdep.r = DigiVect.mag();
+      LogDebug("ClusterShapeAlgo") << "E = " << clEdep.deposited_energy << "\tdiff = " << diff.mag()
+                                   << "\tr = " << clEdep.r;
+      clEdep.phi = DigiVect.angle(theta_axis);
+      if (DigiVect.dot(phi_axis) < 0)
+        clEdep.phi = 2 * M_PI - clEdep.phi;
+      energyDistribution.push_back(clEdep);
     }
-    return meanPosition / e5x5( cluster, recHits, topology );
+  }
+  return energyDistribution;
+}
+
+template <bool noZS>
+std::vector<float> EcalClusterToolsT<noZS>::lat(const reco::BasicCluster &cluster,
+                                                const EcalRecHitCollection *recHits,
+                                                const CaloGeometry *geometry,
+                                                bool logW,
+                                                float w0) {
+  std::vector<EcalClusterToolsT::EcalClusterEnergyDeposition> energyDistribution =
+      getEnergyDepTopology(cluster, recHits, geometry, logW, w0);
+
+  std::vector<float> lat;
+  double r, redmoment = 0;
+  double phiRedmoment = 0;
+  double etaRedmoment = 0;
+  int n, n1, n2, tmp;
+  int clusterSize = energyDistribution.size();
+  float etaLat_, phiLat_, lat_;
+  if (clusterSize < 3) {
+    etaLat_ = 0.0;
+    lat_ = 0.0;
+    lat.push_back(0.);
+    lat.push_back(0.);
+    lat.push_back(0.);
+    return lat;
+  }
+
+  n1 = 0;
+  n2 = 1;
+  if (energyDistribution[1].deposited_energy > energyDistribution[0].deposited_energy) {
+    tmp = n2;
+    n2 = n1;
+    n1 = tmp;
+  }
+  for (int i = 2; i < clusterSize; i++) {
+    n = i;
+    if (energyDistribution[i].deposited_energy > energyDistribution[n1].deposited_energy) {
+      tmp = n2;
+      n2 = n1;
+      n1 = i;
+      n = tmp;
+    } else {
+      if (energyDistribution[i].deposited_energy > energyDistribution[n2].deposited_energy) {
+        tmp = n2;
+        n2 = i;
+        n = tmp;
+      }
+    }
+
+    r = energyDistribution[n].r;
+    redmoment += r * r * energyDistribution[n].deposited_energy;
+    double rphi = r * cos(energyDistribution[n].phi);
+    phiRedmoment += rphi * rphi * energyDistribution[n].deposited_energy;
+    double reta = r * sin(energyDistribution[n].phi);
+    etaRedmoment += reta * reta * energyDistribution[n].deposited_energy;
+  }
+  double e1 = energyDistribution[n1].deposited_energy;
+  double e2 = energyDistribution[n2].deposited_energy;
+
+  lat_ = redmoment / (redmoment + 2.19 * 2.19 * (e1 + e2));
+  phiLat_ = phiRedmoment / (phiRedmoment + 2.19 * 2.19 * (e1 + e2));
+  etaLat_ = etaRedmoment / (etaRedmoment + 2.19 * 2.19 * (e1 + e2));
+
+  lat.push_back(etaLat_);
+  lat.push_back(phiLat_);
+  lat.push_back(lat_);
+  return lat;
+}
+
+template <bool noZS>
+math::XYZVector EcalClusterToolsT<noZS>::meanClusterPosition(const reco::BasicCluster &cluster,
+                                                             const EcalRecHitCollection *recHits,
+                                                             const CaloTopology *topology,
+                                                             const CaloGeometry *geometry) {
+  // find mean energy position of a 5x5 cluster around the maximum
+  math::XYZVector meanPosition(0.0, 0.0, 0.0);
+  const std::vector<std::pair<DetId, float>> &hsAndFs = cluster.hitsAndFractions();
+  std::vector<DetId> v_id = matrixDetId(topology, getMaximum(cluster, recHits).first, 2);
+  for (const std::pair<DetId, float> &hitAndFrac : hsAndFs) {
+    for (std::vector<DetId>::const_iterator it = v_id.begin(); it != v_id.end(); ++it) {
+      if (hitAndFrac.first != *it && !noZS)
+        continue;
+      const CaloSubdetectorGeometry *geo = geometry->getSubdetectorGeometry(*it);
+      GlobalPoint positionGP = geo->getGeometry(*it)->getPosition();
+      math::XYZVector position(positionGP.x(), positionGP.y(), positionGP.z());
+      meanPosition = meanPosition + recHitEnergy(*it, recHits) * position * hitAndFrac.second;
+    }
+    if (noZS)
+      break;
+  }
+  return meanPosition / e5x5(cluster, recHits, topology);
 }
 
 //returns mean energy weighted eta/phi in crystals from the seed
@@ -725,30 +884,34 @@ math::XYZVector EcalClusterToolsT<noZS>::meanClusterPosition( const reco::BasicC
 //I (Sam Harper) think it makes sense to ignore crystals with E<0 in the calculation as they are ignored
 //in the sigmaIEtaIEta calculation (well they arent fully ignored, they do still contribute to the e5x5 sum
 //in the sigmaIEtaIEta calculation but not here)
-template<bool noZS>
-std::pair<float,float>  EcalClusterToolsT<noZS>::mean5x5PositionInLocalCrysCoord(const reco::BasicCluster &cluster, const EcalRecHitCollection* recHits,const CaloTopology *topology)
-{
-    DetId seedId =  getMaximum( cluster, recHits ).first;
-    float meanDEta=0.;
-    float meanDPhi=0.;
-    float energySum=0.;
+template <bool noZS>
+std::pair<float, float> EcalClusterToolsT<noZS>::mean5x5PositionInLocalCrysCoord(const reco::BasicCluster &cluster,
+                                                                                 const EcalRecHitCollection *recHits,
+                                                                                 const CaloTopology *topology) {
+  DetId seedId = getMaximum(cluster, recHits).first;
+  float meanDEta = 0.;
+  float meanDPhi = 0.;
+  float energySum = 0.;
 
-    const std::vector<std::pair<DetId,float> >& hsAndFs = cluster.hitsAndFractions();
-    std::vector<DetId> v_id = matrixDetId( topology,seedId, 2 );
-    for( const std::pair<DetId,float>& hAndF : hsAndFs ) {
-      for ( std::vector<DetId>::const_iterator it = v_id.begin(); it != v_id.end(); ++it ) {
-        if( hAndF.first != *it && !noZS ) continue;
-        float energy = recHitEnergy(*it,recHits) * hAndF.second;
-        if(energy<0.) continue;//skipping negative energy crystals
-        meanDEta += energy * getNrCrysDiffInEta(*it,seedId);
-        meanDPhi += energy * getNrCrysDiffInPhi(*it,seedId);
-        energySum +=energy;
-      }
-      if(noZS) break;
+  const std::vector<std::pair<DetId, float>> &hsAndFs = cluster.hitsAndFractions();
+  std::vector<DetId> v_id = matrixDetId(topology, seedId, 2);
+  for (const std::pair<DetId, float> &hAndF : hsAndFs) {
+    for (std::vector<DetId>::const_iterator it = v_id.begin(); it != v_id.end(); ++it) {
+      if (hAndF.first != *it && !noZS)
+        continue;
+      float energy = recHitEnergy(*it, recHits) * hAndF.second;
+      if (energy < 0.)
+        continue;  //skipping negative energy crystals
+      meanDEta += energy * getNrCrysDiffInEta(*it, seedId);
+      meanDPhi += energy * getNrCrysDiffInPhi(*it, seedId);
+      energySum += energy;
     }
-    meanDEta /=energySum;
-    meanDPhi /=energySum;
-    return std::pair<float,float>(meanDEta,meanDPhi);
+    if (noZS)
+      break;
+  }
+  meanDEta /= energySum;
+  meanDPhi /= energySum;
+  return std::pair<float, float>(meanDEta, meanDPhi);
 }
 
 //returns mean energy weighted x/y in normalised crystal coordinates
@@ -757,629 +920,688 @@ std::pair<float,float>  EcalClusterToolsT<noZS>::mean5x5PositionInLocalCrysCoord
 //I (Sam Harper) think it makes sense to ignore crystals with E<0 in the calculation as they are ignored
 //in the sigmaIEtaIEta calculation (well they arent fully ignored, they do still contribute to the e5x5 sum
 //in the sigmaIEtaIEta calculation but not here)
-template<bool noZS>
-std::pair<float,float> EcalClusterToolsT<noZS>::mean5x5PositionInXY(const reco::BasicCluster &cluster, const EcalRecHitCollection* recHits,const CaloTopology *topology)
-{
-    DetId seedId =  getMaximum( cluster, recHits ).first;
+template <bool noZS>
+std::pair<float, float> EcalClusterToolsT<noZS>::mean5x5PositionInXY(const reco::BasicCluster &cluster,
+                                                                     const EcalRecHitCollection *recHits,
+                                                                     const CaloTopology *topology) {
+  DetId seedId = getMaximum(cluster, recHits).first;
 
-    std::pair<float,float> meanXY(0.,0.);
-    if(seedId.subdetId()==EcalBarrel) return meanXY;
-
-    float energySum=0.;
-
-    const std::vector<std::pair<DetId,float> >& hsAndFs = cluster.hitsAndFractions();
-    std::vector<DetId> v_id = matrixDetId( topology,seedId, 2);
-    for( const std::pair<DetId,float>& hAndF : hsAndFs ) {
-      for ( std::vector<DetId>::const_iterator it = v_id.begin(); it != v_id.end(); ++it ) {  
-        if( hAndF.first != *it && !noZS) continue;
-        float energy = recHitEnergy(*it,recHits) * hAndF.second;
-        if(energy<0.) continue;//skipping negative energy crystals
-        meanXY.first += energy * getNormedIX(*it);
-        meanXY.second += energy * getNormedIY(*it);
-        energySum +=energy;
-      }
-      if(noZS) break;
-    }
-    meanXY.first/=energySum;
-    meanXY.second/=energySum;
+  std::pair<float, float> meanXY(0., 0.);
+  if (seedId.subdetId() == EcalBarrel)
     return meanXY;
+
+  float energySum = 0.;
+
+  const std::vector<std::pair<DetId, float>> &hsAndFs = cluster.hitsAndFractions();
+  std::vector<DetId> v_id = matrixDetId(topology, seedId, 2);
+  for (const std::pair<DetId, float> &hAndF : hsAndFs) {
+    for (std::vector<DetId>::const_iterator it = v_id.begin(); it != v_id.end(); ++it) {
+      if (hAndF.first != *it && !noZS)
+        continue;
+      float energy = recHitEnergy(*it, recHits) * hAndF.second;
+      if (energy < 0.)
+        continue;  //skipping negative energy crystals
+      meanXY.first += energy * getNormedIX(*it);
+      meanXY.second += energy * getNormedIY(*it);
+      energySum += energy;
+    }
+    if (noZS)
+      break;
+  }
+  meanXY.first /= energySum;
+  meanXY.second /= energySum;
+  return meanXY;
 }
 
-template<bool noZS>
-std::vector<float> EcalClusterToolsT<noZS>::covariances(const reco::BasicCluster &cluster, const EcalRecHitCollection* recHits, const CaloTopology *topology, const CaloGeometry* geometry, float w0)
-{
-    float e_5x5 = e5x5( cluster, recHits, topology );
-    float covEtaEta, covEtaPhi, covPhiPhi;
-    if (e_5x5 >= 0.) {
-        //double w0_ = parameterMap_.find("W0")->second;
-        const std::vector< std::pair<DetId, float>>& v_id =cluster.hitsAndFractions();
-        math::XYZVector meanPosition = meanClusterPosition( cluster, recHits, topology, geometry );
+template <bool noZS>
+std::vector<float> EcalClusterToolsT<noZS>::covariances(const reco::BasicCluster &cluster,
+                                                        const EcalRecHitCollection *recHits,
+                                                        const CaloTopology *topology,
+                                                        const CaloGeometry *geometry,
+                                                        float w0) {
+  float e_5x5 = e5x5(cluster, recHits, topology);
+  float covEtaEta, covEtaPhi, covPhiPhi;
+  if (e_5x5 >= 0.) {
+    //double w0_ = parameterMap_.find("W0")->second;
+    const std::vector<std::pair<DetId, float>> &v_id = cluster.hitsAndFractions();
+    math::XYZVector meanPosition = meanClusterPosition(cluster, recHits, topology, geometry);
 
-        // now we can calculate the covariances
-        double numeratorEtaEta = 0;
-        double numeratorEtaPhi = 0;
-        double numeratorPhiPhi = 0;
-        double denominator     = 0;
+    // now we can calculate the covariances
+    double numeratorEtaEta = 0;
+    double numeratorEtaPhi = 0;
+    double numeratorPhiPhi = 0;
+    double denominator = 0;
 
-        DetId id = getMaximum( v_id, recHits ).first;
-        CaloRectangle rectangle{-2, 2, -2, 2};
-        for (auto const& detId : rectangle(id, *topology)) {
-            float frac=getFraction(v_id,detId);
-            float energy = recHitEnergy( detId, recHits )*frac;
+    DetId id = getMaximum(v_id, recHits).first;
+    CaloRectangle rectangle{-2, 2, -2, 2};
+    for (auto const &detId : rectangle(id, *topology)) {
+      float frac = getFraction(v_id, detId);
+      float energy = recHitEnergy(detId, recHits) * frac;
 
-            if ( energy <= 0 ) continue;
+      if (energy <= 0)
+        continue;
 
-            const CaloSubdetectorGeometry* geo = geometry->getSubdetectorGeometry(detId);
-            GlobalPoint position = geo->getGeometry(detId)->getPosition();
+      const CaloSubdetectorGeometry *geo = geometry->getSubdetectorGeometry(detId);
+      GlobalPoint position = geo->getGeometry(detId)->getPosition();
 
-            double dPhi = position.phi() - meanPosition.phi();
-            if (dPhi > + Geom::pi()) { dPhi = Geom::twoPi() - dPhi; }
-            if (dPhi < - Geom::pi()) { dPhi = Geom::twoPi() + dPhi; }
+      double dPhi = position.phi() - meanPosition.phi();
+      if (dPhi > +Geom::pi()) {
+        dPhi = Geom::twoPi() - dPhi;
+      }
+      if (dPhi < -Geom::pi()) {
+        dPhi = Geom::twoPi() + dPhi;
+      }
 
-            double dEta = position.eta() - meanPosition.eta();
-            double w = 0.;
-            w = std::max(0.0f, w0 + std::log( energy / e_5x5 ));
+      double dEta = position.eta() - meanPosition.eta();
+      double w = 0.;
+      w = std::max(0.0f, w0 + std::log(energy / e_5x5));
 
-            denominator += w;
-            numeratorEtaEta += w * dEta * dEta;
-            numeratorEtaPhi += w * dEta * dPhi;
-            numeratorPhiPhi += w * dPhi * dPhi;
-        }
-
-        if (denominator != 0.0) {
-            covEtaEta =  numeratorEtaEta / denominator;
-            covEtaPhi =  numeratorEtaPhi / denominator;
-            covPhiPhi =  numeratorPhiPhi / denominator;
-        } else {
-            covEtaEta = 999.9;
-            covEtaPhi = 999.9;
-            covPhiPhi = 999.9;
-        }
-
-    } else {
-        // Warn the user if there was no energy in the cells and return zeroes.
-        //       std::cout << "\ClusterShapeAlgo::Calculate_Covariances:  no energy in supplied cells.\n";
-        covEtaEta = 0;
-        covEtaPhi = 0;
-        covPhiPhi = 0;
+      denominator += w;
+      numeratorEtaEta += w * dEta * dEta;
+      numeratorEtaPhi += w * dEta * dPhi;
+      numeratorPhiPhi += w * dPhi * dPhi;
     }
-    std::vector<float> v;
-    v.push_back( covEtaEta );
-    v.push_back( covEtaPhi );
-    v.push_back( covPhiPhi );
-    return v;
+
+    if (denominator != 0.0) {
+      covEtaEta = numeratorEtaEta / denominator;
+      covEtaPhi = numeratorEtaPhi / denominator;
+      covPhiPhi = numeratorPhiPhi / denominator;
+    } else {
+      covEtaEta = 999.9;
+      covEtaPhi = 999.9;
+      covPhiPhi = 999.9;
+    }
+
+  } else {
+    // Warn the user if there was no energy in the cells and return zeroes.
+    //       std::cout << "\ClusterShapeAlgo::Calculate_Covariances:  no energy in supplied cells.\n";
+    covEtaEta = 0;
+    covEtaPhi = 0;
+    covPhiPhi = 0;
+  }
+  std::vector<float> v;
+  v.push_back(covEtaEta);
+  v.push_back(covEtaPhi);
+  v.push_back(covPhiPhi);
+  return v;
 }
 
 //for covIEtaIEta,covIEtaIPhi and covIPhiIPhi are defined but only covIEtaIEta has been actively studied
 //instead of using absolute eta/phi it counts crystals normalised so that it gives identical results to normal covariances except near the cracks where of course its better
 //it also does not require any eta correction function in the endcap
 //it is multipled by an approprate crystal size to ensure it gives similar values to covariances(...)
-template<bool noZS>
-std::vector<float> EcalClusterToolsT<noZS>::localCovariances(const reco::BasicCluster &cluster, const EcalRecHitCollection* recHits,const CaloTopology *topology,float w0)
-{
+template <bool noZS>
+std::vector<float> EcalClusterToolsT<noZS>::localCovariances(const reco::BasicCluster &cluster,
+                                                             const EcalRecHitCollection *recHits,
+                                                             const CaloTopology *topology,
+                                                             float w0) {
+  float e_5x5 = e5x5(cluster, recHits, topology);
+  float covEtaEta, covEtaPhi, covPhiPhi;
 
-    float e_5x5 = e5x5( cluster, recHits, topology );
-    float covEtaEta, covEtaPhi, covPhiPhi;
+  if (e_5x5 >= 0.) {
+    //double w0_ = parameterMap_.find("W0")->second;
+    const std::vector<std::pair<DetId, float>> &v_id = cluster.hitsAndFractions();
+    std::pair<float, float> mean5x5PosInNrCrysFromSeed = mean5x5PositionInLocalCrysCoord(cluster, recHits, topology);
+    std::pair<float, float> mean5x5XYPos = mean5x5PositionInXY(cluster, recHits, topology);
 
-    if (e_5x5 >= 0.) {
-        //double w0_ = parameterMap_.find("W0")->second;
-        const std::vector< std::pair<DetId, float> >& v_id = cluster.hitsAndFractions();
-        std::pair<float,float> mean5x5PosInNrCrysFromSeed =  mean5x5PositionInLocalCrysCoord( cluster, recHits, topology );
-        std::pair<float,float> mean5x5XYPos =  mean5x5PositionInXY(cluster,recHits,topology);
+    // now we can calculate the covariances
+    double numeratorEtaEta = 0;
+    double numeratorEtaPhi = 0;
+    double numeratorPhiPhi = 0;
+    double denominator = 0;
 
-        // now we can calculate the covariances
-        double numeratorEtaEta = 0;
-        double numeratorEtaPhi = 0;
-        double numeratorPhiPhi = 0;
-        double denominator     = 0;
+    //these allow us to scale the localCov by the crystal size
+    //so that the localCovs have the same average value as the normal covs
+    const double barrelCrysSize = 0.01745;  //approximate size of crystal in eta,phi in barrel
+    const double endcapCrysSize = 0.0447;   //the approximate crystal size sigmaEtaEta was corrected to in the endcap
 
-        //these allow us to scale the localCov by the crystal size 
-        //so that the localCovs have the same average value as the normal covs
-        const double barrelCrysSize = 0.01745; //approximate size of crystal in eta,phi in barrel
-        const double endcapCrysSize = 0.0447; //the approximate crystal size sigmaEtaEta was corrected to in the endcap
+    DetId seedId = getMaximum(v_id, recHits).first;
 
-        DetId seedId = getMaximum( v_id, recHits ).first;
+    bool isBarrel = seedId.subdetId() == EcalBarrel;
+    const double crysSize = isBarrel ? barrelCrysSize : endcapCrysSize;
 
-        bool isBarrel=seedId.subdetId()==EcalBarrel;
-        const double crysSize = isBarrel ? barrelCrysSize : endcapCrysSize;
+    CaloRectangle rectangle{-2, 2, -2, 2};
+    for (auto const &detId : rectangle(seedId, *topology)) {
+      float frac = getFraction(v_id, detId);
+      float energy = recHitEnergy(detId, recHits) * frac;
+      if (energy <= 0)
+        continue;
 
-        CaloRectangle rectangle{-2, 2, -2, 2};
-        for (auto const& detId : rectangle(seedId, *topology)) {
-            float frac = getFraction(v_id,detId);
-            float energy = recHitEnergy( detId, recHits )*frac;
-            if ( energy <= 0 ) continue;
+      float dEta = getNrCrysDiffInEta(detId, seedId) - mean5x5PosInNrCrysFromSeed.first;
+      float dPhi = 0;
 
-            float dEta = getNrCrysDiffInEta(detId,seedId) - mean5x5PosInNrCrysFromSeed.first;
-            float dPhi = 0;
+      if (isBarrel)
+        dPhi = getNrCrysDiffInPhi(detId, seedId) - mean5x5PosInNrCrysFromSeed.second;
+      else
+        dPhi = getDPhiEndcap(detId, mean5x5XYPos.first, mean5x5XYPos.second);
 
-            if(isBarrel)  dPhi = getNrCrysDiffInPhi(detId,seedId) - mean5x5PosInNrCrysFromSeed.second;
-            else dPhi = getDPhiEndcap(detId,mean5x5XYPos.first,mean5x5XYPos.second);
+      double w = std::max(0.0f, w0 + std::log(energy / e_5x5));
 
+      denominator += w;
+      numeratorEtaEta += w * dEta * dEta;
+      numeratorEtaPhi += w * dEta * dPhi;
+      numeratorPhiPhi += w * dPhi * dPhi;
+    }
 
-            double w = std::max(0.0f,w0 + std::log( energy / e_5x5 ));
-
-            denominator += w;
-            numeratorEtaEta += w * dEta * dEta;
-            numeratorEtaPhi += w * dEta * dPhi;
-            numeratorPhiPhi += w * dPhi * dPhi;
-        }
-
-
-        //multiplying by crysSize to make the values compariable to normal covariances
-        if (denominator != 0.0) {
-            covEtaEta =  crysSize*crysSize* numeratorEtaEta / denominator;
-            covEtaPhi =  crysSize*crysSize* numeratorEtaPhi / denominator;
-            covPhiPhi =  crysSize*crysSize* numeratorPhiPhi / denominator;
-        } else {
-            covEtaEta = 999.9;
-            covEtaPhi = 999.9;
-            covPhiPhi = 999.9;
-        }
-
-
+    //multiplying by crysSize to make the values compariable to normal covariances
+    if (denominator != 0.0) {
+      covEtaEta = crysSize * crysSize * numeratorEtaEta / denominator;
+      covEtaPhi = crysSize * crysSize * numeratorEtaPhi / denominator;
+      covPhiPhi = crysSize * crysSize * numeratorPhiPhi / denominator;
     } else {
-        // Warn the user if there was no energy in the cells and return zeroes.
-        //       std::cout << "\ClusterShapeAlgo::Calculate_Covariances:  no energy in supplied cells.\n";
-        covEtaEta = 0;
-        covEtaPhi = 0;
-        covPhiPhi = 0;
+      covEtaEta = 999.9;
+      covEtaPhi = 999.9;
+      covPhiPhi = 999.9;
     }
-    std::vector<float> v;
-    v.push_back( covEtaEta );
-    v.push_back( covEtaPhi );
-    v.push_back( covPhiPhi );
-    return v;
+
+  } else {
+    // Warn the user if there was no energy in the cells and return zeroes.
+    //       std::cout << "\ClusterShapeAlgo::Calculate_Covariances:  no energy in supplied cells.\n";
+    covEtaEta = 0;
+    covEtaPhi = 0;
+    covPhiPhi = 0;
+  }
+  std::vector<float> v;
+  v.push_back(covEtaEta);
+  v.push_back(covEtaPhi);
+  v.push_back(covPhiPhi);
+  return v;
 }
 
-template<bool noZS>
-double EcalClusterToolsT<noZS>::zernike20( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloGeometry *geometry, double R0, bool logW, float w0 )
-{
-    return absZernikeMoment( cluster, recHits, geometry, 2, 0, R0, logW, w0 );
+template <bool noZS>
+double EcalClusterToolsT<noZS>::zernike20(const reco::BasicCluster &cluster,
+                                          const EcalRecHitCollection *recHits,
+                                          const CaloGeometry *geometry,
+                                          double R0,
+                                          bool logW,
+                                          float w0) {
+  return absZernikeMoment(cluster, recHits, geometry, 2, 0, R0, logW, w0);
 }
 
-template<bool noZS>
-double EcalClusterToolsT<noZS>::zernike42( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloGeometry *geometry, double R0, bool logW, float w0 )
-{
-    return absZernikeMoment( cluster, recHits, geometry, 4, 2, R0, logW, w0 );
+template <bool noZS>
+double EcalClusterToolsT<noZS>::zernike42(const reco::BasicCluster &cluster,
+                                          const EcalRecHitCollection *recHits,
+                                          const CaloGeometry *geometry,
+                                          double R0,
+                                          bool logW,
+                                          float w0) {
+  return absZernikeMoment(cluster, recHits, geometry, 4, 2, R0, logW, w0);
 }
 
-template<bool noZS>
-double EcalClusterToolsT<noZS>::absZernikeMoment( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloGeometry *geometry, int n, int m, double R0, bool logW, float w0 )
-{
-    // 1. Check if n,m are correctly
-    if ((m>n) || ((n-m)%2 != 0) || (n<0) || (m<0)) return -1;
+template <bool noZS>
+double EcalClusterToolsT<noZS>::absZernikeMoment(const reco::BasicCluster &cluster,
+                                                 const EcalRecHitCollection *recHits,
+                                                 const CaloGeometry *geometry,
+                                                 int n,
+                                                 int m,
+                                                 double R0,
+                                                 bool logW,
+                                                 float w0) {
+  // 1. Check if n,m are correctly
+  if ((m > n) || ((n - m) % 2 != 0) || (n < 0) || (m < 0))
+    return -1;
 
-    // 2. Check if n,R0 are within validity Range :
-    // n>20 or R0<2.19cm  just makes no sense !
-    if ((n>20) || (R0<=2.19)) return -1;
-    if (n<=5) return fast_AbsZernikeMoment(cluster, recHits, geometry, n, m, R0, logW, w0 );
-    else return calc_AbsZernikeMoment(cluster, recHits, geometry, n, m, R0, logW, w0 );
+  // 2. Check if n,R0 are within validity Range :
+  // n>20 or R0<2.19cm  just makes no sense !
+  if ((n > 20) || (R0 <= 2.19))
+    return -1;
+  if (n <= 5)
+    return fast_AbsZernikeMoment(cluster, recHits, geometry, n, m, R0, logW, w0);
+  else
+    return calc_AbsZernikeMoment(cluster, recHits, geometry, n, m, R0, logW, w0);
 }
 
-template<bool noZS>
-double EcalClusterToolsT<noZS>::fast_AbsZernikeMoment(const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloGeometry *geometry, int n, int m, double R0, bool logW, float w0 )
-{
-    double r,ph,e,Re=0,Im=0;
-    double TotalEnergy = cluster.energy();
-    int index = (n/2)*(n/2)+(n/2)+m;
-    std::vector<EcalClusterEnergyDeposition> energyDistribution = getEnergyDepTopology( cluster, recHits, geometry, logW, w0 );
-    int clusterSize = energyDistribution.size();
-    if(clusterSize < 3) return 0.0;
+template <bool noZS>
+double EcalClusterToolsT<noZS>::fast_AbsZernikeMoment(const reco::BasicCluster &cluster,
+                                                      const EcalRecHitCollection *recHits,
+                                                      const CaloGeometry *geometry,
+                                                      int n,
+                                                      int m,
+                                                      double R0,
+                                                      bool logW,
+                                                      float w0) {
+  double r, ph, e, Re = 0, Im = 0;
+  double TotalEnergy = cluster.energy();
+  int index = (n / 2) * (n / 2) + (n / 2) + m;
+  std::vector<EcalClusterEnergyDeposition> energyDistribution =
+      getEnergyDepTopology(cluster, recHits, geometry, logW, w0);
+  int clusterSize = energyDistribution.size();
+  if (clusterSize < 3)
+    return 0.0;
 
-    for (int i=0; i<clusterSize; i++)
-    { 
-        r = energyDistribution[i].r / R0;
-        if (r<1) {
-            std::vector<double> pol;
-            pol.push_back( f00(r) );
-            pol.push_back( f11(r) );
-            pol.push_back( f20(r) );
-            pol.push_back( f22(r) );
-            pol.push_back( f31(r) );
-            pol.push_back( f33(r) );
-            pol.push_back( f40(r) );
-            pol.push_back( f42(r) );
-            pol.push_back( f44(r) );
-            pol.push_back( f51(r) );
-            pol.push_back( f53(r) );
-            pol.push_back( f55(r) );
-            ph = (energyDistribution[i]).phi;
-            e = energyDistribution[i].deposited_energy;
-            Re = Re + e/TotalEnergy * pol[index] * cos( (double) m * ph);
-            Im = Im - e/TotalEnergy * pol[index] * sin( (double) m * ph);
+  for (int i = 0; i < clusterSize; i++) {
+    r = energyDistribution[i].r / R0;
+    if (r < 1) {
+      std::vector<double> pol;
+      pol.push_back(f00(r));
+      pol.push_back(f11(r));
+      pol.push_back(f20(r));
+      pol.push_back(f22(r));
+      pol.push_back(f31(r));
+      pol.push_back(f33(r));
+      pol.push_back(f40(r));
+      pol.push_back(f42(r));
+      pol.push_back(f44(r));
+      pol.push_back(f51(r));
+      pol.push_back(f53(r));
+      pol.push_back(f55(r));
+      ph = (energyDistribution[i]).phi;
+      e = energyDistribution[i].deposited_energy;
+      Re = Re + e / TotalEnergy * pol[index] * cos((double)m * ph);
+      Im = Im - e / TotalEnergy * pol[index] * sin((double)m * ph);
+    }
+  }
+  return sqrt(Re * Re + Im * Im);
+}
+
+template <bool noZS>
+double EcalClusterToolsT<noZS>::calc_AbsZernikeMoment(const reco::BasicCluster &cluster,
+                                                      const EcalRecHitCollection *recHits,
+                                                      const CaloGeometry *geometry,
+                                                      int n,
+                                                      int m,
+                                                      double R0,
+                                                      bool logW,
+                                                      float w0) {
+  double r, ph, e, Re = 0, Im = 0, f_nm;
+  double TotalEnergy = cluster.energy();
+  std::vector<EcalClusterEnergyDeposition> energyDistribution =
+      getEnergyDepTopology(cluster, recHits, geometry, logW, w0);
+  int clusterSize = energyDistribution.size();
+  if (clusterSize < 3)
+    return 0.0;
+
+  for (int i = 0; i < clusterSize; ++i) {
+    r = energyDistribution[i].r / R0;
+    if (r < 1) {
+      ph = energyDistribution[i].phi;
+      e = energyDistribution[i].deposited_energy;
+      f_nm = 0;
+      for (int s = 0; s <= (n - m) / 2; s++) {
+        if (s % 2 == 0) {
+          f_nm = f_nm + factorial(n - s) * pow(r, (double)(n - 2 * s)) /
+                            (factorial(s) * factorial((n + m) / 2 - s) * factorial((n - m) / 2 - s));
+        } else {
+          f_nm = f_nm - factorial(n - s) * pow(r, (double)(n - 2 * s)) /
+                            (factorial(s) * factorial((n + m) / 2 - s) * factorial((n - m) / 2 - s));
         }
+      }
+      Re = Re + e / TotalEnergy * f_nm * cos((double)m * ph);
+      Im = Im - e / TotalEnergy * f_nm * sin((double)m * ph);
     }
-    return sqrt(Re*Re+Im*Im);
-}
-
-template<bool noZS>
-double EcalClusterToolsT<noZS>::calc_AbsZernikeMoment(const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloGeometry *geometry, int n, int m, double R0, bool logW, float w0 )
-{
-    double r, ph, e, Re=0, Im=0, f_nm;
-    double TotalEnergy = cluster.energy();
-    std::vector<EcalClusterEnergyDeposition> energyDistribution = getEnergyDepTopology( cluster, recHits, geometry, logW, w0 );
-    int clusterSize=energyDistribution.size();
-    if(clusterSize<3) return 0.0;
-
-    for (int i = 0; i < clusterSize; ++i)
-    { 
-        r = energyDistribution[i].r / R0;
-        if (r < 1) {
-            ph = energyDistribution[i].phi;
-            e = energyDistribution[i].deposited_energy;
-            f_nm = 0;
-            for (int s=0; s<=(n-m)/2; s++) {
-                if (s%2==0) { 
-                    f_nm = f_nm + factorial(n-s)*pow(r,(double) (n-2*s))/(factorial(s)*factorial((n+m)/2-s)*factorial((n-m)/2-s));
-                } else {
-                    f_nm = f_nm - factorial(n-s)*pow(r,(double) (n-2*s))/(factorial(s)*factorial((n+m)/2-s)*factorial((n-m)/2-s));
-                }
-            }
-            Re = Re + e/TotalEnergy * f_nm * cos( (double) m*ph);
-            Im = Im - e/TotalEnergy * f_nm * sin( (double) m*ph);
-        }
-    }
-    return sqrt(Re*Re+Im*Im);
+  }
+  return sqrt(Re * Re + Im * Im);
 }
 
 //returns the crystal 'eta' from the det id
 //it is defined as the number of crystals from the centre in the eta direction
 //for the barrel with its eta/phi geometry it is always integer
 //for the endcap it is fractional due to the x/y geometry
-template<bool noZS>
-float  EcalClusterToolsT<noZS>::getIEta(const DetId& id)
-{
-    if(id.det()==DetId::Ecal){
-        if(id.subdetId()==EcalBarrel){
-            EBDetId ebId(id);
-            return ebId.ieta();
-        }else if(id.subdetId()==EcalEndcap){
-            float iXNorm = getNormedIX(id);
-            float iYNorm = getNormedIY(id);
+template <bool noZS>
+float EcalClusterToolsT<noZS>::getIEta(const DetId &id) {
+  if (id.det() == DetId::Ecal) {
+    if (id.subdetId() == EcalBarrel) {
+      EBDetId ebId(id);
+      return ebId.ieta();
+    } else if (id.subdetId() == EcalEndcap) {
+      float iXNorm = getNormedIX(id);
+      float iYNorm = getNormedIY(id);
 
-            return std::sqrt(iXNorm*iXNorm+iYNorm*iYNorm);
-        }
+      return std::sqrt(iXNorm * iXNorm + iYNorm * iYNorm);
     }
-    return 0.;    
+  }
+  return 0.;
 }
-
 
 //returns the crystal 'phi' from the det id
 //it is defined as the number of crystals from the centre in the phi direction
 //for the barrel with its eta/phi geometry it is always integer
-//for the endcap it is not defined 
-template<bool noZS>
-float  EcalClusterToolsT<noZS>::getIPhi(const DetId& id)
-{
-    if(id.det()==DetId::Ecal){
-        if(id.subdetId()==EcalBarrel){
-            EBDetId ebId(id);
-            return ebId.iphi();
-        }
+//for the endcap it is not defined
+template <bool noZS>
+float EcalClusterToolsT<noZS>::getIPhi(const DetId &id) {
+  if (id.det() == DetId::Ecal) {
+    if (id.subdetId() == EcalBarrel) {
+      EBDetId ebId(id);
+      return ebId.iphi();
     }
-    return 0.;    
+  }
+  return 0.;
 }
 
 //want to map 1=-50,50=-1,51=1 and 100 to 50 so sub off one if zero or neg
-template<bool noZS>
-float EcalClusterToolsT<noZS>::getNormedIX(const DetId& id)
-{
-    if(id.det()==DetId::Ecal && id.subdetId()==EcalEndcap){
-        EEDetId eeId(id);      
-        int iXNorm  = eeId.ix()-50;
-        if(iXNorm<=0) iXNorm--;
-        return iXNorm;
-    }
-    return 0;
+template <bool noZS>
+float EcalClusterToolsT<noZS>::getNormedIX(const DetId &id) {
+  if (id.det() == DetId::Ecal && id.subdetId() == EcalEndcap) {
+    EEDetId eeId(id);
+    int iXNorm = eeId.ix() - 50;
+    if (iXNorm <= 0)
+      iXNorm--;
+    return iXNorm;
+  }
+  return 0;
 }
 
 //want to map 1=-50,50=-1,51=1 and 100 to 50 so sub off one if zero or neg
-template<bool noZS>
-float EcalClusterToolsT<noZS>::getNormedIY(const DetId& id)
-{
-    if(id.det()==DetId::Ecal && id.subdetId()==EcalEndcap){
-        EEDetId eeId(id);      
-        int iYNorm  = eeId.iy()-50;
-        if(iYNorm<=0) iYNorm--;
-        return iYNorm;
-    }
-    return 0;
+template <bool noZS>
+float EcalClusterToolsT<noZS>::getNormedIY(const DetId &id) {
+  if (id.det() == DetId::Ecal && id.subdetId() == EcalEndcap) {
+    EEDetId eeId(id);
+    int iYNorm = eeId.iy() - 50;
+    if (iYNorm <= 0)
+      iYNorm--;
+    return iYNorm;
+  }
+  return 0;
 }
 
 //nr crystals crysId is away from orgin id in eta
-template<bool noZS>
-float EcalClusterToolsT<noZS>::getNrCrysDiffInEta(const DetId& crysId,const DetId& orginId)
-{
-    float crysIEta = getIEta(crysId);
-    float orginIEta = getIEta(orginId);
-    bool isBarrel = orginId.subdetId()==EcalBarrel;
+template <bool noZS>
+float EcalClusterToolsT<noZS>::getNrCrysDiffInEta(const DetId &crysId, const DetId &orginId) {
+  float crysIEta = getIEta(crysId);
+  float orginIEta = getIEta(orginId);
+  bool isBarrel = orginId.subdetId() == EcalBarrel;
 
-    float nrCrysDiff = crysIEta-orginIEta;
+  float nrCrysDiff = crysIEta - orginIEta;
 
-    //no iEta=0 in barrel, so if go from positive to negative
-    //need to reduce abs(detEta) by 1
-    if(isBarrel){ 
-        if(crysIEta*orginIEta<0){ // -1 to 1 transition
-            if(crysIEta>0) nrCrysDiff--;
-            else nrCrysDiff++;
-        }
+  //no iEta=0 in barrel, so if go from positive to negative
+  //need to reduce abs(detEta) by 1
+  if (isBarrel) {
+    if (crysIEta * orginIEta < 0) {  // -1 to 1 transition
+      if (crysIEta > 0)
+        nrCrysDiff--;
+      else
+        nrCrysDiff++;
     }
-    return nrCrysDiff;
+  }
+  return nrCrysDiff;
 }
 
 //nr crystals crysId is away from orgin id in phi
-template<bool noZS>
-float EcalClusterToolsT<noZS>::getNrCrysDiffInPhi(const DetId& crysId,const DetId& orginId)
-{
-    float crysIPhi = getIPhi(crysId);
-    float orginIPhi = getIPhi(orginId);
-    bool isBarrel = orginId.subdetId()==EcalBarrel;
+template <bool noZS>
+float EcalClusterToolsT<noZS>::getNrCrysDiffInPhi(const DetId &crysId, const DetId &orginId) {
+  float crysIPhi = getIPhi(crysId);
+  float orginIPhi = getIPhi(orginId);
+  bool isBarrel = orginId.subdetId() == EcalBarrel;
 
-    float nrCrysDiff = crysIPhi-orginIPhi;
+  float nrCrysDiff = crysIPhi - orginIPhi;
 
-    if(isBarrel){ //if barrel, need to map into 0-180 
-        if (nrCrysDiff > + 180) { nrCrysDiff = nrCrysDiff - 360; }
-        if (nrCrysDiff < - 180) { nrCrysDiff = nrCrysDiff + 360; }
+  if (isBarrel) {  //if barrel, need to map into 0-180
+    if (nrCrysDiff > +180) {
+      nrCrysDiff = nrCrysDiff - 360;
     }
-    return nrCrysDiff;
+    if (nrCrysDiff < -180) {
+      nrCrysDiff = nrCrysDiff + 360;
+    }
+  }
+  return nrCrysDiff;
 }
 
 //nr crystals crysId is away from mean phi in 5x5 in phi
-template<bool noZS>
-float EcalClusterToolsT<noZS>::getDPhiEndcap(const DetId& crysId,float meanX,float meanY)
-{
-    float iXNorm  = getNormedIX(crysId);
-    float iYNorm  = getNormedIY(crysId);
+template <bool noZS>
+float EcalClusterToolsT<noZS>::getDPhiEndcap(const DetId &crysId, float meanX, float meanY) {
+  float iXNorm = getNormedIX(crysId);
+  float iYNorm = getNormedIY(crysId);
 
-    float hitLocalR2 = (iXNorm-meanX)*(iXNorm-meanX)+(iYNorm-meanY)*(iYNorm-meanY);
-    float hitR2 = iXNorm*iXNorm+iYNorm*iYNorm;
-    float meanR2 = meanX*meanX+meanY*meanY;
-    float hitR = sqrt(hitR2);
-    float meanR = sqrt(meanR2);
+  float hitLocalR2 = (iXNorm - meanX) * (iXNorm - meanX) + (iYNorm - meanY) * (iYNorm - meanY);
+  float hitR2 = iXNorm * iXNorm + iYNorm * iYNorm;
+  float meanR2 = meanX * meanX + meanY * meanY;
+  float hitR = sqrt(hitR2);
+  float meanR = sqrt(meanR2);
 
-    float tmp = (hitR2+meanR2-hitLocalR2)/(2*hitR*meanR);
-    if (tmp<-1) tmp =-1;
-    if (tmp>1)  tmp=1;
-    float phi = acos(tmp);
-    float dPhi = hitR*phi;
+  float tmp = (hitR2 + meanR2 - hitLocalR2) / (2 * hitR * meanR);
+  if (tmp < -1)
+    tmp = -1;
+  if (tmp > 1)
+    tmp = 1;
+  float phi = acos(tmp);
+  float dPhi = hitR * phi;
 
-    return dPhi;
+  return dPhi;
 }
 
-template<bool noZS>
-std::vector<float> EcalClusterToolsT<noZS>::scLocalCovariances(const reco::SuperCluster &cluster, const EcalRecHitCollection* recHits,const CaloTopology *topology, float w0)
-{
-    const reco::BasicCluster bcluster = *(cluster.seed());
+template <bool noZS>
+std::vector<float> EcalClusterToolsT<noZS>::scLocalCovariances(const reco::SuperCluster &cluster,
+                                                               const EcalRecHitCollection *recHits,
+                                                               const CaloTopology *topology,
+                                                               float w0) {
+  const reco::BasicCluster bcluster = *(cluster.seed());
 
-    float e_5x5 = e5x5(bcluster, recHits, topology);
-    float covEtaEta, covEtaPhi, covPhiPhi;
+  float e_5x5 = e5x5(bcluster, recHits, topology);
+  float covEtaEta, covEtaPhi, covPhiPhi;
 
-    if (e_5x5 >= 0.) {
-        const std::vector<std::pair<DetId, float> >& v_id = cluster.hitsAndFractions();
-        std::pair<float,float> mean5x5PosInNrCrysFromSeed =  mean5x5PositionInLocalCrysCoord(bcluster, recHits, topology);
-        std::pair<float,float> mean5x5XYPos =  mean5x5PositionInXY(cluster,recHits,topology);
-        // now we can calculate the covariances
-        double numeratorEtaEta = 0;
-        double numeratorEtaPhi = 0;
-        double numeratorPhiPhi = 0;
-        double denominator     = 0;
+  if (e_5x5 >= 0.) {
+    const std::vector<std::pair<DetId, float>> &v_id = cluster.hitsAndFractions();
+    std::pair<float, float> mean5x5PosInNrCrysFromSeed = mean5x5PositionInLocalCrysCoord(bcluster, recHits, topology);
+    std::pair<float, float> mean5x5XYPos = mean5x5PositionInXY(cluster, recHits, topology);
+    // now we can calculate the covariances
+    double numeratorEtaEta = 0;
+    double numeratorEtaPhi = 0;
+    double numeratorPhiPhi = 0;
+    double denominator = 0;
 
-        const double barrelCrysSize = 0.01745; //approximate size of crystal in eta,phi in barrel
-        const double endcapCrysSize = 0.0447; //the approximate crystal size sigmaEtaEta was corrected to in the endcap
+    const double barrelCrysSize = 0.01745;  //approximate size of crystal in eta,phi in barrel
+    const double endcapCrysSize = 0.0447;   //the approximate crystal size sigmaEtaEta was corrected to in the endcap
 
-        DetId seedId = getMaximum(v_id, recHits).first;  
-        bool isBarrel=seedId.subdetId()==EcalBarrel;
+    DetId seedId = getMaximum(v_id, recHits).first;
+    bool isBarrel = seedId.subdetId() == EcalBarrel;
 
-        const double crysSize = isBarrel ? barrelCrysSize : endcapCrysSize;
+    const double crysSize = isBarrel ? barrelCrysSize : endcapCrysSize;
 
-        for (size_t i = 0; i < v_id.size(); ++i) {
-            float frac = getFraction(v_id, v_id[i].first);
-            float energy = recHitEnergy(v_id[i].first, recHits)*frac;
+    for (size_t i = 0; i < v_id.size(); ++i) {
+      float frac = getFraction(v_id, v_id[i].first);
+      float energy = recHitEnergy(v_id[i].first, recHits) * frac;
 
-            if (energy <= 0) continue;
+      if (energy <= 0)
+        continue;
 
-            float dEta = getNrCrysDiffInEta(v_id[i].first,seedId) - mean5x5PosInNrCrysFromSeed.first;
-            float dPhi = 0;
-            if(isBarrel)  dPhi = getNrCrysDiffInPhi(v_id[i].first,seedId) - mean5x5PosInNrCrysFromSeed.second;
-            else dPhi = getDPhiEndcap(v_id[i].first,mean5x5XYPos.first,mean5x5XYPos.second);
+      float dEta = getNrCrysDiffInEta(v_id[i].first, seedId) - mean5x5PosInNrCrysFromSeed.first;
+      float dPhi = 0;
+      if (isBarrel)
+        dPhi = getNrCrysDiffInPhi(v_id[i].first, seedId) - mean5x5PosInNrCrysFromSeed.second;
+      else
+        dPhi = getDPhiEndcap(v_id[i].first, mean5x5XYPos.first, mean5x5XYPos.second);
 
+      double w = 0.;
+      w = std::max(0.0f, w0 + std::log(energy / e_5x5));
 
-
-            double w = 0.;
-            w = std::max(0.0f, w0 + std::log( energy / e_5x5 ));
-
-            denominator += w;
-            numeratorEtaEta += w * dEta * dEta;
-            numeratorEtaPhi += w * dEta * dPhi;
-            numeratorPhiPhi += w * dPhi * dPhi;
-        }
-
-        //multiplying by crysSize to make the values compariable to normal covariances
-        if (denominator != 0.0) {
-            covEtaEta =  crysSize*crysSize* numeratorEtaEta / denominator;
-            covEtaPhi =  crysSize*crysSize* numeratorEtaPhi / denominator;
-            covPhiPhi =  crysSize*crysSize* numeratorPhiPhi / denominator;
-        } else {
-            covEtaEta = 999.9;
-            covEtaPhi = 999.9;
-            covPhiPhi = 999.9;
-        }
-
-    } else {
-        // Warn the user if there was no energy in the cells and return zeroes.
-        // std::cout << "\ClusterShapeAlgo::Calculate_Covariances:  no energy in supplied cells.\n";
-        covEtaEta = 0;
-        covEtaPhi = 0;
-        covPhiPhi = 0;
+      denominator += w;
+      numeratorEtaEta += w * dEta * dEta;
+      numeratorEtaPhi += w * dEta * dPhi;
+      numeratorPhiPhi += w * dPhi * dPhi;
     }
 
-    std::vector<float> v;
-    v.push_back( covEtaEta );
-    v.push_back( covEtaPhi );
-    v.push_back( covPhiPhi );
+    //multiplying by crysSize to make the values compariable to normal covariances
+    if (denominator != 0.0) {
+      covEtaEta = crysSize * crysSize * numeratorEtaEta / denominator;
+      covEtaPhi = crysSize * crysSize * numeratorEtaPhi / denominator;
+      covPhiPhi = crysSize * crysSize * numeratorPhiPhi / denominator;
+    } else {
+      covEtaEta = 999.9;
+      covEtaPhi = 999.9;
+      covPhiPhi = 999.9;
+    }
 
-    return v;
+  } else {
+    // Warn the user if there was no energy in the cells and return zeroes.
+    // std::cout << "\ClusterShapeAlgo::Calculate_Covariances:  no energy in supplied cells.\n";
+    covEtaEta = 0;
+    covEtaPhi = 0;
+    covPhiPhi = 0;
+  }
+
+  std::vector<float> v;
+  v.push_back(covEtaEta);
+  v.push_back(covEtaPhi);
+  v.push_back(covPhiPhi);
+
+  return v;
 }
-
 
 // compute cluster second moments with respect to principal axes (eigenvectors of sEtaEta, sPhiPhi, sEtaPhi matrix)
 // store also angle alpha between major axis and phi.
-// takes into account shower elongation in phi direction due to magnetic field effect: 
-// default value of 0.8 ensures sMaj = sMin for unconverted photons 
+// takes into account shower elongation in phi direction due to magnetic field effect:
+// default value of 0.8 ensures sMaj = sMin for unconverted photons
 // (if phiCorrectionFactor=1 sMaj > sMin and alpha=0 also for unconverted photons)
-template<bool noZS>
-Cluster2ndMoments EcalClusterToolsT<noZS>::cluster2ndMoments( const reco::BasicCluster &basicCluster, const EcalRecHitCollection &recHits, double phiCorrectionFactor, double w0, bool useLogWeights) {
+template <bool noZS>
+Cluster2ndMoments EcalClusterToolsT<noZS>::cluster2ndMoments(const reco::BasicCluster &basicCluster,
+                                                             const EcalRecHitCollection &recHits,
+                                                             double phiCorrectionFactor,
+                                                             double w0,
+                                                             bool useLogWeights) {
+  if (recHits.empty())
+    return Cluster2ndMoments();
 
-  if(recHits.empty()) return Cluster2ndMoments();
+  std::vector<std::pair<const EcalRecHit *, float>> RH_ptrs_fracs;
 
-  std::vector<std::pair<const EcalRecHit*, float> > RH_ptrs_fracs;
-  
-  const std::vector< std::pair<DetId, float> >& myHitsPair = basicCluster.hitsAndFractions();
-  
-  for(unsigned int i=0; i<myHitsPair.size(); i++){
+  const std::vector<std::pair<DetId, float>> &myHitsPair = basicCluster.hitsAndFractions();
+
+  for (unsigned int i = 0; i < myHitsPair.size(); i++) {
     //get pointer to recHit object
     EcalRecHitCollection::const_iterator myRH = recHits.find(myHitsPair[i].first);
-    if(myRH != recHits.end()){
-      RH_ptrs_fracs.push_back(  std::make_pair(&(*myRH) , myHitsPair[i].second)  );
+    if (myRH != recHits.end()) {
+      RH_ptrs_fracs.push_back(std::make_pair(&(*myRH), myHitsPair[i].second));
     }
   }
-  
+
   return EcalClusterToolsT<noZS>::cluster2ndMoments(RH_ptrs_fracs, phiCorrectionFactor, w0, useLogWeights);
 }
 
-template<bool noZS>
-Cluster2ndMoments EcalClusterToolsT<noZS>::cluster2ndMoments( const reco::SuperCluster &superCluster, const EcalRecHitCollection &recHits, double phiCorrectionFactor, double w0, bool useLogWeights) {
-
-  return EcalClusterToolsT<noZS>::cluster2ndMoments( *(superCluster.seed()), recHits, phiCorrectionFactor, w0, useLogWeights);
-
+template <bool noZS>
+Cluster2ndMoments EcalClusterToolsT<noZS>::cluster2ndMoments(const reco::SuperCluster &superCluster,
+                                                             const EcalRecHitCollection &recHits,
+                                                             double phiCorrectionFactor,
+                                                             double w0,
+                                                             bool useLogWeights) {
+  return EcalClusterToolsT<noZS>::cluster2ndMoments(
+      *(superCluster.seed()), recHits, phiCorrectionFactor, w0, useLogWeights);
 }
 
-template<bool noZS>
-Cluster2ndMoments EcalClusterToolsT<noZS>::cluster2ndMoments( const std::vector<std::pair<const EcalRecHit*, float> >& RH_ptrs_fracs, double phiCorrectionFactor, double w0, bool useLogWeights) {
+template <bool noZS>
+Cluster2ndMoments EcalClusterToolsT<noZS>::cluster2ndMoments(
+    const std::vector<std::pair<const EcalRecHit *, float>> &RH_ptrs_fracs,
+    double phiCorrectionFactor,
+    double w0,
+    bool useLogWeights) {
+  if (RH_ptrs_fracs.empty())
+    return Cluster2ndMoments();
 
-  if(RH_ptrs_fracs.empty()) return Cluster2ndMoments();
+  double mid_eta(0), mid_phi(0), mid_x(0), mid_y(0);
 
-  double mid_eta(0),mid_phi(0),mid_x(0),mid_y(0);
-  
-  double Etot = EcalClusterToolsT<noZS>::getSumEnergy(  RH_ptrs_fracs  );
- 
-  double max_phi=-10.;
-  double min_phi=100.;
-  
-  
+  double Etot = EcalClusterToolsT<noZS>::getSumEnergy(RH_ptrs_fracs);
+
+  double max_phi = -10.;
+  double min_phi = 100.;
+
   std::vector<double> etaDetId;
   std::vector<double> phiDetId;
   std::vector<double> xDetId;
   std::vector<double> yDetId;
   std::vector<double> wiDetId;
- 
-  unsigned int nCry=0;
-  double denominator=0.;
+
+  unsigned int nCry = 0;
+  double denominator = 0.;
   bool isBarrel(true);
 
   // loop over rechits and compute weights:
-  for(std::vector<std::pair<const EcalRecHit*, float> >::const_iterator rhf_ptr = RH_ptrs_fracs.begin(); rhf_ptr != RH_ptrs_fracs.end(); rhf_ptr++){
-    const EcalRecHit* rh_ptr = rhf_ptr->first;
-
+  for (std::vector<std::pair<const EcalRecHit *, float>>::const_iterator rhf_ptr = RH_ptrs_fracs.begin();
+       rhf_ptr != RH_ptrs_fracs.end();
+       rhf_ptr++) {
+    const EcalRecHit *rh_ptr = rhf_ptr->first;
 
     //get iEta, iPhi
-    double temp_eta(0),temp_phi(0),temp_x(0),temp_y(0);
-    isBarrel = rh_ptr->detid().subdetId()==EcalBarrel;
-    
-    if(isBarrel) {
+    double temp_eta(0), temp_phi(0), temp_x(0), temp_y(0);
+    isBarrel = rh_ptr->detid().subdetId() == EcalBarrel;
+
+    if (isBarrel) {
       temp_eta = (getIEta(rh_ptr->detid()) > 0. ? getIEta(rh_ptr->detid()) + 84.5 : getIEta(rh_ptr->detid()) + 85.5);
-      temp_phi= getIPhi(rh_ptr->detid()) - 0.5;
+      temp_phi = getIPhi(rh_ptr->detid()) - 0.5;
+    } else {
+      temp_eta = getIEta(rh_ptr->detid());
+      temp_x = getNormedIX(rh_ptr->detid());
+      temp_y = getNormedIY(rh_ptr->detid());
     }
-    else {
-      temp_eta = getIEta(rh_ptr->detid());  
-      temp_x =  getNormedIX(rh_ptr->detid());
-      temp_y =  getNormedIY(rh_ptr->detid());
-    }	  
 
-    double temp_ene=rh_ptr->energy() * (noZS ? 1.0 : rhf_ptr->second);
-    
-    double temp_wi=((useLogWeights) ?
-                    std::max(0.0, w0 + std::log( std::abs(temp_ene)/Etot ))
-                    :  temp_ene);
+    double temp_ene = rh_ptr->energy() * (noZS ? 1.0 : rhf_ptr->second);
 
+    double temp_wi = ((useLogWeights) ? std::max(0.0, w0 + std::log(std::abs(temp_ene) / Etot)) : temp_ene);
 
-    if(temp_phi>max_phi) max_phi=temp_phi;
-    if(temp_phi<min_phi) min_phi=temp_phi;
+    if (temp_phi > max_phi)
+      max_phi = temp_phi;
+    if (temp_phi < min_phi)
+      min_phi = temp_phi;
     etaDetId.push_back(temp_eta);
     phiDetId.push_back(temp_phi);
     xDetId.push_back(temp_x);
     yDetId.push_back(temp_y);
     wiDetId.push_back(temp_wi);
-    denominator+=temp_wi;
+    denominator += temp_wi;
     nCry++;
   }
 
-  if(isBarrel){
+  if (isBarrel) {
     // correct phi wrap-around:
-    if(max_phi==359.5 && min_phi==0.5){ 
-      for(unsigned int i=0; i<nCry; i++){
-        if(phiDetId[i] - 179. > 0.) phiDetId[i]-=360.; 
-        mid_phi+=phiDetId[i]*wiDetId[i];
-        mid_eta+=etaDetId[i]*wiDetId[i];
+    if (max_phi == 359.5 && min_phi == 0.5) {
+      for (unsigned int i = 0; i < nCry; i++) {
+        if (phiDetId[i] - 179. > 0.)
+          phiDetId[i] -= 360.;
+        mid_phi += phiDetId[i] * wiDetId[i];
+        mid_eta += etaDetId[i] * wiDetId[i];
       }
-    } else{
-      for(unsigned int i=0; i<nCry; i++){
-        mid_phi+=phiDetId[i]*wiDetId[i];
-        mid_eta+=etaDetId[i]*wiDetId[i];
+    } else {
+      for (unsigned int i = 0; i < nCry; i++) {
+        mid_phi += phiDetId[i] * wiDetId[i];
+        mid_eta += etaDetId[i] * wiDetId[i];
       }
     }
-  }else{
-    for(unsigned int i=0; i<nCry; i++){
-      mid_eta+=etaDetId[i]*wiDetId[i];      
-      mid_x+=xDetId[i]*wiDetId[i];
-      mid_y+=yDetId[i]*wiDetId[i];
+  } else {
+    for (unsigned int i = 0; i < nCry; i++) {
+      mid_eta += etaDetId[i] * wiDetId[i];
+      mid_x += xDetId[i] * wiDetId[i];
+      mid_y += yDetId[i] * wiDetId[i];
     }
   }
-  
-  mid_eta/=denominator;
-  mid_phi/=denominator;
-  mid_x/=denominator;
-  mid_y/=denominator;
 
+  mid_eta /= denominator;
+  mid_phi /= denominator;
+  mid_x /= denominator;
+  mid_y /= denominator;
 
   // See = sigma eta eta
   // Spp = (B field corrected) sigma phi phi
   // See = (B field corrected) sigma eta phi
-  double See=0.;
-  double Spp=0.;
-  double Sep=0.;
-  double deta(0),dphi(0);
+  double See = 0.;
+  double Spp = 0.;
+  double Sep = 0.;
+  double deta(0), dphi(0);
   // compute (phi-corrected) covariance matrix:
-  for(unsigned int i=0; i<nCry; i++) {
-    if(isBarrel) {
-      deta = etaDetId[i]-mid_eta;
-      dphi = phiDetId[i]-mid_phi;
+  for (unsigned int i = 0; i < nCry; i++) {
+    if (isBarrel) {
+      deta = etaDetId[i] - mid_eta;
+      dphi = phiDetId[i] - mid_phi;
     } else {
-      deta = etaDetId[i]-mid_eta;
-      float hitLocalR2 = (xDetId[i]-mid_x)*(xDetId[i]-mid_x)+(yDetId[i]-mid_y)*(yDetId[i]-mid_y);
-      float hitR2 = xDetId[i]*xDetId[i]+yDetId[i]*yDetId[i];
-      float meanR2 = mid_x*mid_x+mid_y*mid_y;
+      deta = etaDetId[i] - mid_eta;
+      float hitLocalR2 = (xDetId[i] - mid_x) * (xDetId[i] - mid_x) + (yDetId[i] - mid_y) * (yDetId[i] - mid_y);
+      float hitR2 = xDetId[i] * xDetId[i] + yDetId[i] * yDetId[i];
+      float meanR2 = mid_x * mid_x + mid_y * mid_y;
       float hitR = sqrt(hitR2);
       float meanR = sqrt(meanR2);
-      float phi = acos((hitR2+meanR2-hitLocalR2)/(2*hitR*meanR));
-      dphi = hitR*phi;
-
+      float phi = acos((hitR2 + meanR2 - hitLocalR2) / (2 * hitR * meanR));
+      dphi = hitR * phi;
     }
-    See += (wiDetId[i]* deta * deta) / denominator;
-    Spp += phiCorrectionFactor*(wiDetId[i]* dphi * dphi) / denominator;
-    Sep += sqrt(phiCorrectionFactor)*(wiDetId[i]*deta*dphi) / denominator;
+    See += (wiDetId[i] * deta * deta) / denominator;
+    Spp += phiCorrectionFactor * (wiDetId[i] * dphi * dphi) / denominator;
+    Sep += sqrt(phiCorrectionFactor) * (wiDetId[i] * deta * dphi) / denominator;
   }
 
   Cluster2ndMoments returnMoments;
 
   // compute matrix eigenvalues:
-  returnMoments.sMaj = ((See + Spp) + sqrt((See - Spp)*(See - Spp) + 4.*Sep*Sep)) / 2.;
-  returnMoments.sMin = ((See + Spp) - sqrt((See - Spp)*(See - Spp) + 4.*Sep*Sep)) / 2.;
+  returnMoments.sMaj = ((See + Spp) + sqrt((See - Spp) * (See - Spp) + 4. * Sep * Sep)) / 2.;
+  returnMoments.sMin = ((See + Spp) - sqrt((See - Spp) * (See - Spp) + 4. * Sep * Sep)) / 2.;
 
-  returnMoments.alpha = atan( (See - Spp + sqrt( (Spp - See)*(Spp - See) + 4.*Sep*Sep )) / (2.*Sep));
+  returnMoments.alpha = atan((See - Spp + sqrt((Spp - See) * (Spp - See) + 4. * Sep * Sep)) / (2. * Sep));
 
   return returnMoments;
-
 }
 
 //compute shower shapes: roundness and angle in a vector. Roundness is 0th element, Angle is 1st element.
@@ -1389,284 +1611,303 @@ Cluster2ndMoments EcalClusterToolsT<noZS>::cluster2ndMoments( const std::vector<
 // this function uses only recHits belonging to a SC above energyThreshold (default 0)
 // you can select linear weighting = energy_recHit/total_energy         (weightedPositionMethod=0) default
 // or log weighting = max( 0.0, 4.2 + log(energy_recHit/total_energy) ) (weightedPositionMethod=1)
-template<bool noZS>
-std::vector<float> EcalClusterToolsT<noZS>::roundnessBarrelSuperClusters( const reco::SuperCluster &superCluster ,const EcalRecHitCollection &recHits, int weightedPositionMethod, float energyThreshold){//int positionWeightingMethod=0){
-  std::vector<std::pair<const EcalRecHit*, float> > RH_ptrs_fracs;
-    const std::vector< std::pair<DetId, float> >& myHitsPair = superCluster.hitsAndFractions();    
-    for(unsigned int i=0; i< myHitsPair.size(); ++i){
-        //get pointer to recHit object
-        EcalRecHitCollection::const_iterator myRH = recHits.find(myHitsPair[i].first);
-        if( myRH != recHits.end() && myRH->energy()*(noZS ? 1.0 : myHitsPair[i].second) > energyThreshold){ 
-            //require rec hit to have positive energy
-            RH_ptrs_fracs.push_back(  std::make_pair(&(*myRH) , myHitsPair[i].second)  );
-        }
+template <bool noZS>
+std::vector<float> EcalClusterToolsT<noZS>::roundnessBarrelSuperClusters(
+    const reco::SuperCluster &superCluster,
+    const EcalRecHitCollection &recHits,
+    int weightedPositionMethod,
+    float energyThreshold) {  //int positionWeightingMethod=0){
+  std::vector<std::pair<const EcalRecHit *, float>> RH_ptrs_fracs;
+  const std::vector<std::pair<DetId, float>> &myHitsPair = superCluster.hitsAndFractions();
+  for (unsigned int i = 0; i < myHitsPair.size(); ++i) {
+    //get pointer to recHit object
+    EcalRecHitCollection::const_iterator myRH = recHits.find(myHitsPair[i].first);
+    if (myRH != recHits.end() && myRH->energy() * (noZS ? 1.0 : myHitsPair[i].second) > energyThreshold) {
+      //require rec hit to have positive energy
+      RH_ptrs_fracs.push_back(std::make_pair(&(*myRH), myHitsPair[i].second));
     }
-    std::vector<float> temp = EcalClusterToolsT<noZS>::roundnessSelectedBarrelRecHits(RH_ptrs_fracs,weightedPositionMethod); 
-    return temp;
+  }
+  std::vector<float> temp =
+      EcalClusterToolsT<noZS>::roundnessSelectedBarrelRecHits(RH_ptrs_fracs, weightedPositionMethod);
+  return temp;
 }
 
 // this function uses all recHits within specified window ( with default values ieta_delta=2, iphi_delta=5) around SC's highest recHit.
 // recHits must pass an energy threshold "energyRHThresh" (default 0)
 // you can select linear weighting = energy_recHit/total_energy         (weightedPositionMethod=0)
 // or log weighting = max( 0.0, 4.2 + log(energy_recHit/total_energy) ) (weightedPositionMethod=1)
-template<bool noZS>
-std::vector<float> EcalClusterToolsT<noZS>::roundnessBarrelSuperClustersUserExtended( const reco::SuperCluster &superCluster ,const EcalRecHitCollection &recHits, int ieta_delta, int iphi_delta, float energyRHThresh, int weightedPositionMethod){
+template <bool noZS>
+std::vector<float> EcalClusterToolsT<noZS>::roundnessBarrelSuperClustersUserExtended(
+    const reco::SuperCluster &superCluster,
+    const EcalRecHitCollection &recHits,
+    int ieta_delta,
+    int iphi_delta,
+    float energyRHThresh,
+    int weightedPositionMethod) {
+  std::vector<std::pair<const EcalRecHit *, float>> RH_ptrs_fracs;
+  const std::vector<std::pair<DetId, float>> &myHitsPair = superCluster.hitsAndFractions();
+  for (unsigned int i = 0; i < myHitsPair.size(); ++i) {
+    //get pointer to recHit object
+    EcalRecHitCollection::const_iterator myRH = recHits.find(myHitsPair[i].first);
+    if (myRH != recHits.end() && myRH->energy() * (noZS ? 1.0 : myHitsPair[i].second) > energyRHThresh)
+      RH_ptrs_fracs.push_back(std::make_pair(&(*myRH), myHitsPair[i].second));
+  }
 
-  std::vector<std::pair<const EcalRecHit*, float> > RH_ptrs_fracs;
-    const std::vector< std::pair<DetId, float> >& myHitsPair = superCluster.hitsAndFractions();
-    for(unsigned int i=0; i<myHitsPair.size(); ++i){
-        //get pointer to recHit object
-        EcalRecHitCollection::const_iterator myRH = recHits.find(myHitsPair[i].first);
-        if(myRH != recHits.end() && myRH->energy()*(noZS ? 1.0 : myHitsPair[i].second) > energyRHThresh)
-            RH_ptrs_fracs.push_back(  std::make_pair(&(*myRH) , myHitsPair[i].second) );
+  std::vector<int> seedPosition = EcalClusterToolsT<noZS>::getSeedPosition(RH_ptrs_fracs);
+
+  for (EcalRecHitCollection::const_iterator rh = recHits.begin(); rh != recHits.end(); rh++) {
+    EBDetId EBdetIdi(rh->detid());
+    float the_fraction = 0;
+    //if(rh != recHits.end())
+    bool inEtaWindow = (abs(deltaIEta(seedPosition[0], EBdetIdi.ieta())) <= ieta_delta);
+    bool inPhiWindow = (abs(deltaIPhi(seedPosition[1], EBdetIdi.iphi())) <= iphi_delta);
+    bool passEThresh = (rh->energy() > energyRHThresh);
+    bool alreadyCounted = false;
+
+    // figure out if the rechit considered now is already inside the SC
+    bool is_SCrh_inside_recHits = false;
+    for (unsigned int i = 0; i < myHitsPair.size(); i++) {
+      EcalRecHitCollection::const_iterator SCrh = recHits.find(myHitsPair[i].first);
+      if (SCrh != recHits.end()) {
+        the_fraction = myHitsPair[i].second;
+        is_SCrh_inside_recHits = true;
+        if (rh->detid() == SCrh->detid())
+          alreadyCounted = true;
+      }
+    }  //for loop over SC's recHits
+
+    if (is_SCrh_inside_recHits && !alreadyCounted && passEThresh && inEtaWindow && inPhiWindow) {
+      RH_ptrs_fracs.push_back(std::make_pair(&(*rh), the_fraction));
     }
 
-
-    std::vector<int> seedPosition = EcalClusterToolsT<noZS>::getSeedPosition(  RH_ptrs_fracs  );
-
-    for(EcalRecHitCollection::const_iterator rh = recHits.begin(); rh != recHits.end(); rh++){
-        EBDetId EBdetIdi( rh->detid() );
-        float the_fraction = 0;
-        //if(rh != recHits.end())
-        bool inEtaWindow = (   abs(  deltaIEta(seedPosition[0],EBdetIdi.ieta())  ) <= ieta_delta   );
-        bool inPhiWindow = (   abs(  deltaIPhi(seedPosition[1],EBdetIdi.iphi())  ) <= iphi_delta   );
-        bool passEThresh = (  rh->energy() > energyRHThresh  );
-        bool alreadyCounted = false;
-
-        // figure out if the rechit considered now is already inside the SC
-        bool is_SCrh_inside_recHits = false;
-        for(unsigned int i=0; i<myHitsPair.size(); i++){
-            EcalRecHitCollection::const_iterator SCrh = recHits.find(myHitsPair[i].first);
-            if(SCrh != recHits.end()){
-                the_fraction = myHitsPair[i].second;
-                is_SCrh_inside_recHits = true;
-                if( rh->detid() == SCrh->detid()  ) alreadyCounted = true;
-            }
-        }//for loop over SC's recHits
-
-        if( is_SCrh_inside_recHits && !alreadyCounted && passEThresh && inEtaWindow && inPhiWindow){
-            RH_ptrs_fracs.push_back( std::make_pair(&(*rh),the_fraction) );
-        }
-
-    }//for loop over rh
-    return EcalClusterToolsT<noZS>::roundnessSelectedBarrelRecHits(RH_ptrs_fracs,weightedPositionMethod);
+  }  //for loop over rh
+  return EcalClusterToolsT<noZS>::roundnessSelectedBarrelRecHits(RH_ptrs_fracs, weightedPositionMethod);
 }
 
 // this function computes the roundness and angle variables for vector of pointers to recHits you pass it
 // you can select linear weighting = energy_recHit/total_energy         (weightedPositionMethod=0)
 // or log weighting = max( 0.0, 4.2 + log(energy_recHit/total_energy) ) (weightedPositionMethod=1)
-template<bool noZS>
-std::vector<float> EcalClusterToolsT<noZS>::roundnessSelectedBarrelRecHits( const std::vector<std::pair<const EcalRecHit*,float> >& RH_ptrs_fracs, int weightedPositionMethod){//int weightedPositionMethod = 0){
-    //positionWeightingMethod = 0 linear weighting, 1 log energy weighting
+template <bool noZS>
+std::vector<float> EcalClusterToolsT<noZS>::roundnessSelectedBarrelRecHits(
+    const std::vector<std::pair<const EcalRecHit *, float>> &RH_ptrs_fracs,
+    int weightedPositionMethod) {  //int weightedPositionMethod = 0){
+  //positionWeightingMethod = 0 linear weighting, 1 log energy weighting
 
-    std::vector<float> shapes; // this is the returning vector
+  std::vector<float> shapes;  // this is the returning vector
 
-    //make sure photon has more than one crystal; else roundness and angle suck
-    if(RH_ptrs_fracs.size()<2){
-        shapes.push_back( -3 );
-        shapes.push_back( -3 );
-        return shapes;
-    }
-
-    //Find highest E RH (Seed) and save info, compute sum total energy used
-    std::vector<int> seedPosition = EcalClusterToolsT<noZS>::getSeedPosition(  RH_ptrs_fracs  );// *recHits);
-    int tempInt = seedPosition[0];
-    if(tempInt <0) tempInt++;
-    float energyTotal = EcalClusterToolsT<noZS>::getSumEnergy(  RH_ptrs_fracs  );
-
-    //1st loop over rechits: compute new weighted center position in coordinates centered on seed
-    float centerIEta = 0.;
-    float centerIPhi = 0.;
-    float denominator = 0.;
-
-    for(std::vector<std::pair<const EcalRecHit*,float> >::const_iterator rhf_ptr = RH_ptrs_fracs.begin(); rhf_ptr != RH_ptrs_fracs.end(); rhf_ptr++){
-        const EcalRecHit* rh_ptr = rhf_ptr->first;
-        //get iEta, iPhi
-        EBDetId EBdetIdi( rh_ptr->detid() );
-        if(fabs(energyTotal) < 0.0001){
-            // don't /0, bad!
-            shapes.push_back( -2 );
-            shapes.push_back( -2 );
-            return shapes;
-        }
-        float rh_energy = rh_ptr->energy() * (noZS ? 1.0 : rhf_ptr->second);
-        float weight = 0;
-        if(std::abs(weightedPositionMethod)<0.0001){ //linear
-            weight = rh_energy/energyTotal;
-        }else{ //logrithmic
-            weight = std::max(0.0, 4.2 + log(rh_energy/energyTotal));
-        }
-        denominator += weight;
-        centerIEta += weight*deltaIEta(seedPosition[0],EBdetIdi.ieta());
-        centerIPhi += weight*deltaIPhi(seedPosition[1],EBdetIdi.iphi());
-    }
-    if(fabs(denominator) < 0.0001){
-        // don't /0, bad!
-        shapes.push_back( -2 );
-        shapes.push_back( -2 );
-        return shapes;
-    }
-    centerIEta = centerIEta / denominator;
-    centerIPhi = centerIPhi / denominator;
-
-
-    //2nd loop over rechits: compute inertia tensor
-    TMatrixDSym inertia(2); //initialize 2d inertia tensor
-    double inertia00 = 0.;
-    double inertia01 = 0.;// = inertia10 b/c matrix should be symmetric
-    double inertia11 = 0.;
-    int i = 0;
-    for(std::vector<std::pair<const EcalRecHit*,float> >::const_iterator rhf_ptr = RH_ptrs_fracs.begin(); rhf_ptr != RH_ptrs_fracs.end(); rhf_ptr++){
-      const EcalRecHit* rh_ptr = rhf_ptr->first;
-        //get iEta, iPhi
-        EBDetId EBdetIdi( rh_ptr->detid() );
-
-        if(fabs(energyTotal) < 0.0001){
-            // don't /0, bad!
-            shapes.push_back( -2 );
-            shapes.push_back( -2 );
-            return shapes;
-        }
-        float rh_energy = rh_ptr->energy() * (noZS ? 1.0 : rhf_ptr->second);
-        float weight = 0;
-        if(std::abs(weightedPositionMethod) < 0.0001){ //linear
-            weight = rh_energy/energyTotal;
-        }else{ //logrithmic
-            weight = std::max(0.0, 4.2 + log(rh_energy/energyTotal));
-        }
-
-        float ieta_rh_to_center = deltaIEta(seedPosition[0],EBdetIdi.ieta()) - centerIEta;
-        float iphi_rh_to_center = deltaIPhi(seedPosition[1],EBdetIdi.iphi()) - centerIPhi;
-
-        inertia00 += weight*iphi_rh_to_center*iphi_rh_to_center;
-        inertia01 -= weight*iphi_rh_to_center*ieta_rh_to_center;
-        inertia11 += weight*ieta_rh_to_center*ieta_rh_to_center;
-        i++;
-    }
-
-    inertia[0][0] = inertia00;
-    inertia[0][1] = inertia01; // use same number here
-    inertia[1][0] = inertia01; // and here to insure symmetry
-    inertia[1][1] = inertia11;
-
-
-    //step 1 find principal axes of inertia
-    TMatrixD eVectors(2,2);
-    TVectorD eValues(2);
-    //std::cout<<"EcalClusterToolsT<noZS>::showerRoundness- about to compute eVectors"<<std::endl;
-    eVectors=inertia.EigenVectors(eValues); //ordered highest eV to lowest eV (I checked!)
-    //and eVectors are in columns of matrix! I checked!
-    //and they are normalized to 1
-
-
-
-    //step 2 select eta component of smaller eVal's eVector
-    TVectorD smallerAxis(2);//easiest to spin SC on this axis (smallest eVal)
-    smallerAxis[0]=eVectors[0][1];//row,col  //eta component
-    smallerAxis[1]=eVectors[1][1];           //phi component
-
-    //step 3 compute interesting quatities
-    Double_t temp = fabs(smallerAxis[0]);// closer to 1 ->beamhalo, closer to 0 something else
-    if(fabs(eValues[0]) < 0.0001){
-        // don't /0, bad!
-        shapes.push_back( -2 );
-        shapes.push_back( -2 );
-        return shapes;
-    }
-
-    float Roundness = eValues[1]/eValues[0];
-    float Angle=acos(temp);
-
-    if( -0.00001 < Roundness && Roundness < 0) Roundness = 0.;
-    if( -0.00001 < Angle && Angle < 0 ) Angle = 0.;
-
-    shapes.push_back( Roundness );
-    shapes.push_back( Angle );
+  //make sure photon has more than one crystal; else roundness and angle suck
+  if (RH_ptrs_fracs.size() < 2) {
+    shapes.push_back(-3);
+    shapes.push_back(-3);
     return shapes;
+  }
 
-}
+  //Find highest E RH (Seed) and save info, compute sum total energy used
+  std::vector<int> seedPosition = EcalClusterToolsT<noZS>::getSeedPosition(RH_ptrs_fracs);  // *recHits);
+  int tempInt = seedPosition[0];
+  if (tempInt < 0)
+    tempInt++;
+  float energyTotal = EcalClusterToolsT<noZS>::getSumEnergy(RH_ptrs_fracs);
 
+  //1st loop over rechits: compute new weighted center position in coordinates centered on seed
+  float centerIEta = 0.;
+  float centerIPhi = 0.;
+  float denominator = 0.;
 
-template<bool noZS>
-int EcalClusterToolsT<noZS>::nrSaturatedCrysIn5x5(const DetId& id,const EcalRecHitCollection* recHits,const CaloTopology *topology)
-{
-    int nrSat=0;
-    CaloRectangle rectangle{-2, 2, -2, 2};
-    for (auto const& detId : rectangle(id, *topology)) {
-        auto recHitIt = recHits->find(detId);
-        if(recHitIt!=recHits->end() && recHitIt->checkFlag(EcalRecHit::kSaturated)) {
-            nrSat++;
-        }
+  for (std::vector<std::pair<const EcalRecHit *, float>>::const_iterator rhf_ptr = RH_ptrs_fracs.begin();
+       rhf_ptr != RH_ptrs_fracs.end();
+       rhf_ptr++) {
+    const EcalRecHit *rh_ptr = rhf_ptr->first;
+    //get iEta, iPhi
+    EBDetId EBdetIdi(rh_ptr->detid());
+    if (fabs(energyTotal) < 0.0001) {
+      // don't /0, bad!
+      shapes.push_back(-2);
+      shapes.push_back(-2);
+      return shapes;
     }
-    return nrSat;
+    float rh_energy = rh_ptr->energy() * (noZS ? 1.0 : rhf_ptr->second);
+    float weight = 0;
+    if (std::abs(weightedPositionMethod) < 0.0001) {  //linear
+      weight = rh_energy / energyTotal;
+    } else {  //logrithmic
+      weight = std::max(0.0, 4.2 + log(rh_energy / energyTotal));
+    }
+    denominator += weight;
+    centerIEta += weight * deltaIEta(seedPosition[0], EBdetIdi.ieta());
+    centerIPhi += weight * deltaIPhi(seedPosition[1], EBdetIdi.iphi());
+  }
+  if (fabs(denominator) < 0.0001) {
+    // don't /0, bad!
+    shapes.push_back(-2);
+    shapes.push_back(-2);
+    return shapes;
+  }
+  centerIEta = centerIEta / denominator;
+  centerIPhi = centerIPhi / denominator;
+
+  //2nd loop over rechits: compute inertia tensor
+  TMatrixDSym inertia(2);  //initialize 2d inertia tensor
+  double inertia00 = 0.;
+  double inertia01 = 0.;  // = inertia10 b/c matrix should be symmetric
+  double inertia11 = 0.;
+  int i = 0;
+  for (std::vector<std::pair<const EcalRecHit *, float>>::const_iterator rhf_ptr = RH_ptrs_fracs.begin();
+       rhf_ptr != RH_ptrs_fracs.end();
+       rhf_ptr++) {
+    const EcalRecHit *rh_ptr = rhf_ptr->first;
+    //get iEta, iPhi
+    EBDetId EBdetIdi(rh_ptr->detid());
+
+    if (fabs(energyTotal) < 0.0001) {
+      // don't /0, bad!
+      shapes.push_back(-2);
+      shapes.push_back(-2);
+      return shapes;
+    }
+    float rh_energy = rh_ptr->energy() * (noZS ? 1.0 : rhf_ptr->second);
+    float weight = 0;
+    if (std::abs(weightedPositionMethod) < 0.0001) {  //linear
+      weight = rh_energy / energyTotal;
+    } else {  //logrithmic
+      weight = std::max(0.0, 4.2 + log(rh_energy / energyTotal));
+    }
+
+    float ieta_rh_to_center = deltaIEta(seedPosition[0], EBdetIdi.ieta()) - centerIEta;
+    float iphi_rh_to_center = deltaIPhi(seedPosition[1], EBdetIdi.iphi()) - centerIPhi;
+
+    inertia00 += weight * iphi_rh_to_center * iphi_rh_to_center;
+    inertia01 -= weight * iphi_rh_to_center * ieta_rh_to_center;
+    inertia11 += weight * ieta_rh_to_center * ieta_rh_to_center;
+    i++;
+  }
+
+  inertia[0][0] = inertia00;
+  inertia[0][1] = inertia01;  // use same number here
+  inertia[1][0] = inertia01;  // and here to insure symmetry
+  inertia[1][1] = inertia11;
+
+  //step 1 find principal axes of inertia
+  TMatrixD eVectors(2, 2);
+  TVectorD eValues(2);
+  //std::cout<<"EcalClusterToolsT<noZS>::showerRoundness- about to compute eVectors"<<std::endl;
+  eVectors = inertia.EigenVectors(eValues);  //ordered highest eV to lowest eV (I checked!)
+  //and eVectors are in columns of matrix! I checked!
+  //and they are normalized to 1
+
+  //step 2 select eta component of smaller eVal's eVector
+  TVectorD smallerAxis(2);          //easiest to spin SC on this axis (smallest eVal)
+  smallerAxis[0] = eVectors[0][1];  //row,col  //eta component
+  smallerAxis[1] = eVectors[1][1];  //phi component
+
+  //step 3 compute interesting quatities
+  Double_t temp = fabs(smallerAxis[0]);  // closer to 1 ->beamhalo, closer to 0 something else
+  if (fabs(eValues[0]) < 0.0001) {
+    // don't /0, bad!
+    shapes.push_back(-2);
+    shapes.push_back(-2);
+    return shapes;
+  }
+
+  float Roundness = eValues[1] / eValues[0];
+  float Angle = acos(temp);
+
+  if (-0.00001 < Roundness && Roundness < 0)
+    Roundness = 0.;
+  if (-0.00001 < Angle && Angle < 0)
+    Angle = 0.;
+
+  shapes.push_back(Roundness);
+  shapes.push_back(Angle);
+  return shapes;
 }
 
+template <bool noZS>
+int EcalClusterToolsT<noZS>::nrSaturatedCrysIn5x5(const DetId &id,
+                                                  const EcalRecHitCollection *recHits,
+                                                  const CaloTopology *topology) {
+  int nrSat = 0;
+  CaloRectangle rectangle{-2, 2, -2, 2};
+  for (auto const &detId : rectangle(id, *topology)) {
+    auto recHitIt = recHits->find(detId);
+    if (recHitIt != recHits->end() && recHitIt->checkFlag(EcalRecHit::kSaturated)) {
+      nrSat++;
+    }
+  }
+  return nrSat;
+}
 
 //private functions useful for roundnessBarrelSuperClusters etc.
 //compute delta iphi between a seed and a particular recHit
 //iphi [1,360]
 //safe gaurds are put in to ensure the difference is between [-180,180]
-template<bool noZS>
-int EcalClusterToolsT<noZS>::deltaIPhi(int seed_iphi, int rh_iphi){
-    int rel_iphi = rh_iphi - seed_iphi;
-    // take care of cyclic variable iphi [1,360]
-    if(rel_iphi >  180) rel_iphi = rel_iphi - 360;
-    if(rel_iphi < -180) rel_iphi = rel_iphi + 360;
-    return rel_iphi;
+template <bool noZS>
+int EcalClusterToolsT<noZS>::deltaIPhi(int seed_iphi, int rh_iphi) {
+  int rel_iphi = rh_iphi - seed_iphi;
+  // take care of cyclic variable iphi [1,360]
+  if (rel_iphi > 180)
+    rel_iphi = rel_iphi - 360;
+  if (rel_iphi < -180)
+    rel_iphi = rel_iphi + 360;
+  return rel_iphi;
 }
 
 //compute delta ieta between a seed and a particular recHit
 //ieta [-85,-1] and [1,85]
 //safe gaurds are put in to shift the negative ieta +1 to make an ieta=0 so differences are computed correctly
-template<bool noZS>
-int EcalClusterToolsT<noZS>::deltaIEta(int seed_ieta, int rh_ieta){
-    // get rid of the fact that there is no ieta=0
-    if(seed_ieta < 0) seed_ieta++;
-    if(rh_ieta   < 0) rh_ieta++;
-    int rel_ieta = rh_ieta - seed_ieta;
-    return rel_ieta;
+template <bool noZS>
+int EcalClusterToolsT<noZS>::deltaIEta(int seed_ieta, int rh_ieta) {
+  // get rid of the fact that there is no ieta=0
+  if (seed_ieta < 0)
+    seed_ieta++;
+  if (rh_ieta < 0)
+    rh_ieta++;
+  int rel_ieta = rh_ieta - seed_ieta;
+  return rel_ieta;
 }
 
 //return (ieta,iphi) of highest energy recHit of the recHits passed to this function
-template<bool noZS>
-std::vector<int> EcalClusterToolsT<noZS>::getSeedPosition(const std::vector<std::pair<const EcalRecHit*, float> >& RH_ptrs_fracs){
-    std::vector<int> seedPosition;
-    float eSeedRH = 0;
-    int iEtaSeedRH = 0;
-    int iPhiSeedRH = 0;
+template <bool noZS>
+std::vector<int> EcalClusterToolsT<noZS>::getSeedPosition(
+    const std::vector<std::pair<const EcalRecHit *, float>> &RH_ptrs_fracs) {
+  std::vector<int> seedPosition;
+  float eSeedRH = 0;
+  int iEtaSeedRH = 0;
+  int iPhiSeedRH = 0;
 
-    for(auto const& rhf : RH_ptrs_fracs) {
-      const EcalRecHit* rh_ptr = rhf.first;
-        //get iEta, iPhi
-        EBDetId EBdetIdi( rh_ptr->detid() );
-        float rh_energy = rh_ptr->energy() * (noZS ? 1.0 : rhf.second);
+  for (auto const &rhf : RH_ptrs_fracs) {
+    const EcalRecHit *rh_ptr = rhf.first;
+    //get iEta, iPhi
+    EBDetId EBdetIdi(rh_ptr->detid());
+    float rh_energy = rh_ptr->energy() * (noZS ? 1.0 : rhf.second);
 
-        if(eSeedRH < rh_energy){
-            eSeedRH = rh_energy;
-            iEtaSeedRH = EBdetIdi.ieta();
-            iPhiSeedRH = EBdetIdi.iphi();
-        }
+    if (eSeedRH < rh_energy) {
+      eSeedRH = rh_energy;
+      iEtaSeedRH = EBdetIdi.ieta();
+      iPhiSeedRH = EBdetIdi.iphi();
+    }
 
-    }// for loop
+  }  // for loop
 
-    seedPosition.push_back(iEtaSeedRH);
-    seedPosition.push_back(iPhiSeedRH);
-    return seedPosition;
+  seedPosition.push_back(iEtaSeedRH);
+  seedPosition.push_back(iPhiSeedRH);
+  return seedPosition;
 }
 
 // return the total energy of the recHits passed to this function
-template<bool noZS>
-float EcalClusterToolsT<noZS>::getSumEnergy(const std::vector<std::pair<const EcalRecHit*, float> >& RH_ptrs_fracs){
-    float sumE = 0.;
-    for( const auto& hAndF : RH_ptrs_fracs ) {
-      sumE += hAndF.first->energy() * (noZS ? 1.0 : hAndF.second);
-    }
-    return sumE;
+template <bool noZS>
+float EcalClusterToolsT<noZS>::getSumEnergy(const std::vector<std::pair<const EcalRecHit *, float>> &RH_ptrs_fracs) {
+  float sumE = 0.;
+  for (const auto &hAndF : RH_ptrs_fracs) {
+    sumE += hAndF.first->energy() * (noZS ? 1.0 : hAndF.second);
+  }
+  return sumE;
 }
-
 
 typedef EcalClusterToolsT<false> EcalClusterTools;
 
-namespace noZS { typedef EcalClusterToolsT<true> EcalClusterTools; }
+namespace noZS {
+  typedef EcalClusterToolsT<true> EcalClusterTools;
+}
 
 #endif

--- a/RecoEcal/EgammaCoreTools/interface/EcalNextToDeadChannel.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalNextToDeadChannel.h
@@ -4,7 +4,7 @@
 /** Define an ecal container to tell wether the channel is close to a dead one.
     If the value is "true", the channel is next to a dead one
 **/
- 
+
 #include "CondFormats/EcalObjects/interface/EcalCondObjectContainer.h"
 
 typedef EcalCondObjectContainer<uint8_t> EcalNextToDeadChannel;

--- a/RecoEcal/EgammaCoreTools/interface/EcalNextToDeadChannelRcd.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalNextToDeadChannelRcd.h
@@ -1,7 +1,6 @@
 #ifndef EcalNextToDeadChannelRcd_h
 #define EcalNextToDeadChannelRcd_h
 
-
 #include "boost/mpl/vector.hpp"
 #include "FWCore/Framework/interface/DependentRecordImplementation.h"
 #include "CondFormats/DataRecord/interface/EcalChannelStatusRcd.h"
@@ -10,6 +9,8 @@
 // Registration of to the EventSetup mechanism
 //
 
-class EcalNextToDeadChannelRcd : public edm::eventsetup::DependentRecordImplementation<EcalNextToDeadChannelRcd, boost::mpl::vector<EcalChannelStatusRcd> > {};
+class EcalNextToDeadChannelRcd
+    : public edm::eventsetup::DependentRecordImplementation<EcalNextToDeadChannelRcd,
+                                                            boost::mpl::vector<EcalChannelStatusRcd> > {};
 
 #endif

--- a/RecoEcal/EgammaCoreTools/interface/EcalTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalTools.h
@@ -14,22 +14,20 @@
 #include "CondFormats/EcalObjects/interface/EcalChannelStatus.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
-class EcalTools{
-  
+class EcalTools {
 public:
-  
   /// the good old 1-e4/e1. Ignore hits below recHitThreshold
-  static float swissCross( const DetId& id, 
-			   const EcalRecHitCollection & recHits, 
-			   float recHitThreshold , 
-			   bool avoidIeta85=true);
+  static float swissCross(const DetId& id,
+                          const EcalRecHitCollection& recHits,
+                          float recHitThreshold,
+                          bool avoidIeta85 = true);
 
   /// true if the channel is near a dead one (in the 3x3)
   /** This function will use the ChannelStatus record to determine
       if the channel is next to a dead one, using bit 12 of the
       channel status word
    */
-  static bool isNextToDead( const DetId& id, const edm::EventSetup& es);
+  static bool isNextToDead(const DetId& id, const edm::EventSetup& es);
 
   /// same as isNextToDead, but will use information from the neighbour
   /** Looks at neighbours in 3x3 and returns true if one of them has
@@ -38,37 +36,27 @@ public:
         
    */
 
-  static bool isNextToDeadFromNeighbours( const DetId& id, 
-					  const EcalChannelStatus& chs,
-					  int chStatusThreshold) ; 
+  static bool isNextToDeadFromNeighbours(const DetId& id, const EcalChannelStatus& chs, int chStatusThreshold);
 
   /// true if near a crack or ecal border
-  static bool isNextToBoundary (const DetId& id);
+  static bool isNextToBoundary(const DetId& id);
 
-  /// return true if the channel at offsets dx,dy is dead 
-  static bool deadNeighbour(const DetId& id, const EcalChannelStatus& chs, 
-			    int chStatusThreshold, 
-			    int dx, int dy); 
+  /// return true if the channel at offsets dx,dy is dead
+  static bool deadNeighbour(const DetId& id, const EcalChannelStatus& chs, int chStatusThreshold, int dx, int dy);
 
   /// identify HGCal cells
-  static inline bool isHGCalDet(DetId::Detector thedet){
-    return (thedet == DetId::Forward || thedet == DetId::Hcal || thedet == DetId::HGCalEE || thedet == DetId::HGCalHSi || thedet == DetId::HGCalHSc);
+  static inline bool isHGCalDet(DetId::Detector thedet) {
+    return (thedet == DetId::Forward || thedet == DetId::Hcal || thedet == DetId::HGCalEE ||
+            thedet == DetId::HGCalHSi || thedet == DetId::HGCalHSc);
   }
 
 private:
-
-  static float recHitE( const DetId id, const EcalRecHitCollection &recHits );
-  static float recHitE( const DetId id, const EcalRecHitCollection & recHits, 
-			int dEta, int dPhi );
-  static float recHitApproxEt( const DetId id, 
-			       const EcalRecHitCollection &recHits );
-
-
-
+  static float recHitE(const DetId id, const EcalRecHitCollection& recHits);
+  static float recHitE(const DetId id, const EcalRecHitCollection& recHits, int dEta, int dPhi);
+  static float recHitApproxEt(const DetId id, const EcalRecHitCollection& recHits);
 };
 
-
-#endif // __EcalTools_h_
+#endif  // __EcalTools_h_
 
 // Configure (x)emacs for this file ...
 // Local Variables:

--- a/RecoEcal/EgammaCoreTools/interface/Mustache.h
+++ b/RecoEcal/EgammaCoreTools/interface/Mustache.h
@@ -6,51 +6,41 @@
 #include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
 
-
-
 namespace reco {
-  namespace MustacheKernel {    
-      bool inMustache(const float maxEta, const float maxPhi, 
-		      const float ClustE, const float ClusEta, 
-		      const float ClusPhi);
-      bool inDynamicDPhiWindow(const float seedEta, const float seedPhi,
-			       const float ClustE, const float ClusEta,
-			       const float clusPhi);
-     
-  }
+  namespace MustacheKernel {
+    bool inMustache(
+        const float maxEta, const float maxPhi, const float ClustE, const float ClusEta, const float ClusPhi);
+    bool inDynamicDPhiWindow(
+        const float seedEta, const float seedPhi, const float ClustE, const float ClusEta, const float clusPhi);
+
+  }  // namespace MustacheKernel
 
   class Mustache {
-    
   public:
-    void MustacheID(const CaloClusterPtrVector& clusters, 
-		    int & nclusters, float & EoutsideMustache);
-    void MustacheID(const std::vector<const CaloCluster*>&, 
-		    int & nclusers,
-		    float & EoutsideMustache); 
-    void MustacheID(const reco::SuperCluster& sc, 
-		    int & nclusters, 
-		    float & EoutsideMustache);
+    void MustacheID(const CaloClusterPtrVector& clusters, int& nclusters, float& EoutsideMustache);
+    void MustacheID(const std::vector<const CaloCluster*>&, int& nclusers, float& EoutsideMustache);
+    void MustacheID(const reco::SuperCluster& sc, int& nclusters, float& EoutsideMustache);
 
+    void MustacheClust(const std::vector<CaloCluster>& clusters,
+                       std::vector<unsigned int>& insideMust,
+                       std::vector<unsigned int>& outsideMust);
 
-    void MustacheClust(const std::vector<CaloCluster>& clusters, 
-		       std::vector<unsigned int>& insideMust, 
-		       std::vector<unsigned int>& outsideMust);
-    
     void FillMustacheVar(const std::vector<CaloCluster>& clusters);
     //return Functions for Mustache Variables:
-    float MustacheE(){return Energy_In_Mustache_;}
-    float MustacheEOut(){return Energy_Outside_Mustache_;}
-    float MustacheEtOut(){return Et_Outside_Mustache_;}
-    float LowestMustClust(){return LowestClusterEInMustache_;}
-    int InsideMust(){return included_;}
-    int OutsideMust(){return excluded_;}
+    float MustacheE() { return Energy_In_Mustache_; }
+    float MustacheEOut() { return Energy_Outside_Mustache_; }
+    float MustacheEtOut() { return Et_Outside_Mustache_; }
+    float LowestMustClust() { return LowestClusterEInMustache_; }
+    int InsideMust() { return included_; }
+    int OutsideMust() { return excluded_; }
+
   private:
-    template<class RandomAccessPtrIterator>
-      void MustacheID(const RandomAccessPtrIterator&,
-		      const RandomAccessPtrIterator&,
-		      int& nclusters,
-		      float& EoutsideMustache);
-    
+    template <class RandomAccessPtrIterator>
+    void MustacheID(const RandomAccessPtrIterator&,
+                    const RandomAccessPtrIterator&,
+                    int& nclusters,
+                    float& EoutsideMustache);
+
     float Energy_In_Mustache_;
     float Energy_Outside_Mustache_;
     float Et_Outside_Mustache_;
@@ -59,7 +49,6 @@ namespace reco {
     int included_;
   };
 
-  
-}
+}  // namespace reco
 
 #endif

--- a/RecoEcal/EgammaCoreTools/interface/PositionCalc.h
+++ b/RecoEcal/EgammaCoreTools/interface/PositionCalc.h
@@ -26,16 +26,15 @@
 #include "Geometry/EcalAlgo/interface/EcalPreshowerGeometry.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 
-class PositionCalc
-{
- public:
-  typedef std::vector< std::pair<DetId,float> > HitsAndFractions;
-  typedef std::vector< std::pair<DetId,double> > HitsAndEnergies;
-  // You must call Initialize before you can calculate positions or 
+class PositionCalc {
+public:
+  typedef std::vector<std::pair<DetId, float> > HitsAndFractions;
+  typedef std::vector<std::pair<DetId, double> > HitsAndEnergies;
+  // You must call Initialize before you can calculate positions or
   // covariances.
 
   PositionCalc(const edm::ParameterSet& par);
-  PositionCalc() { };
+  PositionCalc(){};
 
   const PositionCalc& operator=(const PositionCalc& rhs);
 
@@ -43,156 +42,143 @@ class PositionCalc
   // weighted average position of a vector of DetIds, which should be
   // a subset of the map used to Initialize.
 
-  template<typename HitType>
-  math::XYZPoint Calculate_Location( const HitsAndFractions&      iDetIds  ,
-				     const edm::SortedCollection<HitType>*    iRecHits ,
-				     const CaloSubdetectorGeometry* iSubGeom ,
-				     const CaloSubdetectorGeometry* iESGeom = nullptr ) ;
+  template <typename HitType>
+  math::XYZPoint Calculate_Location(const HitsAndFractions& iDetIds,
+                                    const edm::SortedCollection<HitType>* iRecHits,
+                                    const CaloSubdetectorGeometry* iSubGeom,
+                                    const CaloSubdetectorGeometry* iESGeom = nullptr);
 
- private:
-  bool    param_LogWeighted_;
-  double  param_T0_barl_;
-  double  param_T0_endc_;
-  double  param_T0_endcPresh_;
-  double  param_W0_;
-  double  param_X0_;
+private:
+  bool param_LogWeighted_;
+  double param_T0_barl_;
+  double param_T0_endc_;
+  double param_T0_endcPresh_;
+  double param_W0_;
+  double param_X0_;
 
-  const CaloSubdetectorGeometry* m_esGeom ;
-  bool m_esPlus ;
-  bool m_esMinus ;
-
+  const CaloSubdetectorGeometry* m_esGeom;
+  bool m_esPlus;
+  bool m_esMinus;
 };
 
-template<typename HitType>
-math::XYZPoint 
-PositionCalc::Calculate_Location( const PositionCalc::HitsAndFractions& iDetIds  ,
-				  const edm::SortedCollection<HitType>* iRecHits ,
-				  const CaloSubdetectorGeometry* iSubGeom ,
-				  const CaloSubdetectorGeometry* iESGeom   ) {
+template <typename HitType>
+math::XYZPoint PositionCalc::Calculate_Location(const PositionCalc::HitsAndFractions& iDetIds,
+                                                const edm::SortedCollection<HitType>* iRecHits,
+                                                const CaloSubdetectorGeometry* iSubGeom,
+                                                const CaloSubdetectorGeometry* iESGeom) {
   typedef edm::SortedCollection<HitType> HitTypeCollection;
-  math::XYZPoint returnValue ( 0, 0, 0 ) ;
-  
+  math::XYZPoint returnValue(0, 0, 0);
+
   // Throw an error if the cluster was not initialized properly
-  
-  if( nullptr == iRecHits || nullptr == iSubGeom ) {
-    throw cms::Exception("PositionCalc")
-      << "Calculate_Location() called uninitialized or wrong initialization.";
+
+  if (nullptr == iRecHits || nullptr == iSubGeom) {
+    throw cms::Exception("PositionCalc") << "Calculate_Location() called uninitialized or wrong initialization.";
   }
-  
-  if( !iDetIds.empty()   &&
-      !iRecHits->empty()     ) {
-    
-    HitsAndEnergies detIds; 
-    detIds.reserve( iDetIds.size() ) ;
-    
-    double eTot  ( 0 ) ;
-    double eMax  ( 0 ) ;
-    DetId  maxId ;
-    
+
+  if (!iDetIds.empty() && !iRecHits->empty()) {
+    HitsAndEnergies detIds;
+    detIds.reserve(iDetIds.size());
+
+    double eTot(0);
+    double eMax(0);
+    DetId maxId;
+
     // Check that DetIds are nonzero
-    typename HitTypeCollection::const_iterator endRecHits ( iRecHits->end() ) ;
-    HitsAndFractions::const_iterator n, endDiDs( iDetIds.end() );
-    for( n = iDetIds.begin(); n != endDiDs ; ++n ) {
-      const DetId dId ( (*n).first ) ;
-      const float frac( (*n).second) ; 
-      if( !dId.null() ) {
-	typename HitTypeCollection::const_iterator iHit ( iRecHits->find( dId ) ) ;
-	if( iHit != endRecHits ) {	       		   
-	  const double energy ( iHit->energy() *frac ) ;	   
-	  detIds.push_back( std::make_pair(dId,energy) );
-	  if( 0.0 < energy ) { // only save positive energies	    
-	    if( eMax < energy ) {
-	      eMax  = energy ;
-	      maxId = dId    ;	      
-	    }
-	    eTot += energy ;
-	  }
-	}
+    typename HitTypeCollection::const_iterator endRecHits(iRecHits->end());
+    HitsAndFractions::const_iterator n, endDiDs(iDetIds.end());
+    for (n = iDetIds.begin(); n != endDiDs; ++n) {
+      const DetId dId((*n).first);
+      const float frac((*n).second);
+      if (!dId.null()) {
+        typename HitTypeCollection::const_iterator iHit(iRecHits->find(dId));
+        if (iHit != endRecHits) {
+          const double energy(iHit->energy() * frac);
+          detIds.push_back(std::make_pair(dId, energy));
+          if (0.0 < energy) {  // only save positive energies
+            if (eMax < energy) {
+              eMax = energy;
+              maxId = dId;
+            }
+            eTot += energy;
+          }
+        }
       }
     }
-    
-    if( 0.0 >= eTot ) {
-      LogDebug("ZeroClusterEnergy") << "cluster with 0 energy: " 
-				    << eTot << " size: " << detIds.size() 
-				    << " , returning (0,0,0)";
+
+    if (0.0 >= eTot) {
+      LogDebug("ZeroClusterEnergy") << "cluster with 0 energy: " << eTot << " size: " << detIds.size()
+                                    << " , returning (0,0,0)";
     } else {
       // first time or when es geom changes set flags
-      if( nullptr != iESGeom && m_esGeom != iESGeom ) {
-	m_esGeom = iESGeom ;
-	for( uint32_t ic ( 0 ) ;
-	     ( ic != m_esGeom->getValidDetIds().size() ) &&
-	       ( (!m_esPlus) || (!m_esMinus) ) ; ++ic ) {
-	  const double z ( m_esGeom->getGeometry( m_esGeom->getValidDetIds()[ic] )->getPosition().z() ) ;
-	  m_esPlus  = m_esPlus  || ( 0 < z ) ;
-	  m_esMinus = m_esMinus || ( 0 > z ) ;
-	}
+      if (nullptr != iESGeom && m_esGeom != iESGeom) {
+        m_esGeom = iESGeom;
+        for (uint32_t ic(0); (ic != m_esGeom->getValidDetIds().size()) && ((!m_esPlus) || (!m_esMinus)); ++ic) {
+          const double z(m_esGeom->getGeometry(m_esGeom->getValidDetIds()[ic])->getPosition().z());
+          m_esPlus = m_esPlus || (0 < z);
+          m_esMinus = m_esMinus || (0 > z);
+        }
       }
-      
-      //Select the correct value of the T0 parameter depending on subdetector       
-      auto center_cell ( iSubGeom->getGeometry( maxId ) ) ;
-      const double ctreta (center_cell->getPosition().eta());
-      
-      // for barrel, use barrel T0; 
-      // for endcap: if preshower present && in preshower fiducial, 
+
+      //Select the correct value of the T0 parameter depending on subdetector
+      auto center_cell(iSubGeom->getGeometry(maxId));
+      const double ctreta(center_cell->getPosition().eta());
+
+      // for barrel, use barrel T0;
+      // for endcap: if preshower present && in preshower fiducial,
       //             use preshower T0
-      // else use endcap only T0       
-      const double preshowerStartEta =  1.653;
+      // else use endcap only T0
+      const double preshowerStartEta = 1.653;
       const int subdet = maxId.subdetId();
-      const double T0 ( subdet == EcalBarrel ? param_T0_barl_ :
-			( ( ( preshowerStartEta < fabs( ctreta ) ) &&
-			    ( ( ( 0 < ctreta ) && 
-				m_esPlus          ) ||
-			      ( ( 0 > ctreta ) &&
-				m_esMinus         )   )    ) ?
-			  param_T0_endcPresh_ : param_T0_endc_ ) ) ;
-      
+      const double T0(subdet == EcalBarrel ? param_T0_barl_
+                                           : (((preshowerStartEta < fabs(ctreta)) &&
+                                               (((0 < ctreta) && m_esPlus) || ((0 > ctreta) && m_esMinus)))
+                                                  ? param_T0_endcPresh_
+                                                  : param_T0_endc_));
+
       // Calculate shower depth
-      const float maxDepth ( param_X0_ * ( T0 + log( eTot ) ) ) ;
-      const float maxToFront ( center_cell->getPosition().mag() ) ; // to front face
-      
+      const float maxDepth(param_X0_ * (T0 + log(eTot)));
+      const float maxToFront(center_cell->getPosition().mag());  // to front face
+
       // Loop over hits and get weights
       double total_weight = 0;
-      const double eTot_inv = 1.0/eTot;
-      const double logETot_inv = ( param_LogWeighted_ ? log(eTot_inv) : 0 );
-      
-      double xw ( 0 ) ;
-      double yw ( 0 ) ;
-      double zw ( 0 ) ;
-      
-      
+      const double eTot_inv = 1.0 / eTot;
+      const double logETot_inv = (param_LogWeighted_ ? log(eTot_inv) : 0);
+
+      double xw(0);
+      double yw(0);
+      double zw(0);
+
       HitsAndEnergies::const_iterator j, hAndE_end = detIds.end();
-      for( j = detIds.begin() ; j != hAndE_end ; ++j ) {
-	const DetId dId ( (*j).first )  ;
-	const double e_j( (*j).second ) ;	     
-	
-	double weight = 0;
-	if ( param_LogWeighted_ ) {
-	  if ( e_j > 0.0 ) {
-	    weight = std::max( 0., param_W0_ + log(e_j) + logETot_inv );
-	  } else {
-	    weight = 0;
-	  }
-	} else {
-	  weight = e_j*eTot_inv;
-	}
-	
-	auto cell ( iSubGeom->getGeometry( dId ) ) ;
-	const float depth ( maxDepth + maxToFront - cell->getPosition().mag() ) ;
-	
-	const GlobalPoint pos (cell->getPosition( depth ) );
-	
-	xw += weight*pos.x() ;
-	yw += weight*pos.y() ;
-	zw += weight*pos.z() ;
-	
-	total_weight += weight ;
+      for (j = detIds.begin(); j != hAndE_end; ++j) {
+        const DetId dId((*j).first);
+        const double e_j((*j).second);
+
+        double weight = 0;
+        if (param_LogWeighted_) {
+          if (e_j > 0.0) {
+            weight = std::max(0., param_W0_ + log(e_j) + logETot_inv);
+          } else {
+            weight = 0;
+          }
+        } else {
+          weight = e_j * eTot_inv;
+        }
+
+        auto cell(iSubGeom->getGeometry(dId));
+        const float depth(maxDepth + maxToFront - cell->getPosition().mag());
+
+        const GlobalPoint pos(cell->getPosition(depth));
+
+        xw += weight * pos.x();
+        yw += weight * pos.y();
+        zw += weight * pos.z();
+
+        total_weight += weight;
       }
-      returnValue = math::XYZPoint( xw/total_weight, 
-				    yw/total_weight, 
-				    zw/total_weight ) ;
+      returnValue = math::XYZPoint(xw / total_weight, yw / total_weight, zw / total_weight);
     }
   }
-  return returnValue ;
+  return returnValue;
 }
 
 #endif

--- a/RecoEcal/EgammaCoreTools/interface/SuperClusterShapeAlgo.h
+++ b/RecoEcal/EgammaCoreTools/interface/SuperClusterShapeAlgo.h
@@ -24,25 +24,20 @@
 
 class CaloSubdetectorTopology;
 
-class SuperClusterShapeAlgo
-{
+class SuperClusterShapeAlgo {
+public:
+  SuperClusterShapeAlgo(const EcalRecHitCollection* hits, const CaloSubdetectorGeometry* geometry);
 
- public:
-  SuperClusterShapeAlgo(const EcalRecHitCollection* hits,
-			const CaloSubdetectorGeometry* geometry);
-
-  void Calculate_Covariances(const reco::SuperCluster &passedCluster);
+  void Calculate_Covariances(const reco::SuperCluster& passedCluster);
 
   double etaWidth() { return etaWidth_; }
   double phiWidth() { return phiWidth_; }
 
- private:
-
+private:
   const EcalRecHitCollection* recHits_;
   const CaloSubdetectorGeometry* geometry_;
 
   double etaWidth_, phiWidth_;
-  
 };
 
 #endif

--- a/RecoEcal/EgammaCoreTools/plugins/EcalBasicClusterLocalContCorrection.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalBasicClusterLocalContCorrection.cc
@@ -25,170 +25,159 @@
 using namespace std;
 using namespace edm;
 
-
-float EcalBasicClusterLocalContCorrection::getValue( const reco::SuperCluster & superCluster, const int mode ) const
-{
+float EcalBasicClusterLocalContCorrection::getValue(const reco::SuperCluster& superCluster, const int mode) const {
   //checkInit();
   return 1;
 }
 
-float EcalBasicClusterLocalContCorrection::getValue( const reco::BasicCluster & basicCluster, const EcalRecHitCollection & recHit ) const
-{
+float EcalBasicClusterLocalContCorrection::getValue(const reco::BasicCluster& basicCluster,
+                                                    const EcalRecHitCollection& recHit) const {
   checkInit();
 
   // number of parameters needed by this parametrization
   size_t nparams = 24;
 
   //correction factor to be returned, and to be calculated in this present function:
-  double correction_factor=1.;
-  double fetacor=1.; //eta dependent part of the correction factor
-  double fphicor=1.; //phi dependent part of the correction factor
-
+  double correction_factor = 1.;
+  double fetacor = 1.;  //eta dependent part of the correction factor
+  double fphicor = 1.;  //phi dependent part of the correction factor
 
   //--------------if barrel calculate local position wrt xtal center -------------------
   edm::ESHandle<CaloGeometry> caloGeometry;
-  es_->get<CaloGeometryRecord>().get(caloGeometry); 
-  const CaloSubdetectorGeometry* geom = caloGeometry->getSubdetectorGeometry(DetId::Ecal,EcalBarrel);//EcalBarrel = 1
-  
+  es_->get<CaloGeometryRecord>().get(caloGeometry);
+  const CaloSubdetectorGeometry* geom = caloGeometry->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);  //EcalBarrel = 1
 
-  const math::XYZPoint& position_ = basicCluster.position(); 
-  double Theta = -position_.theta()+0.5*TMath::Pi();
+  const math::XYZPoint& position_ = basicCluster.position();
+  double Theta = -position_.theta() + 0.5 * TMath::Pi();
   double Eta = position_.eta();
   double Phi = TVector2::Phi_mpi_pi(position_.phi());
-  
-  
-  
+
   //Calculate expected depth of the maximum shower from energy (like in PositionCalc::Calculate_Location()):
   // The parameters X0 and T0 are hardcoded here because these values were used to calculate the corrections:
-  const float X0 = 0.89; const float T0 = 7.4;
+  const float X0 = 0.89;
+  const float T0 = 7.4;
   double depth = X0 * (T0 + log(basicCluster.energy()));
-  
-  
+
   //search which crystal is closest to the cluster position and call it crystalseed:
   //std::vector<DetId> crystals_vector = *scRef.getHitsByDetId();   //deprecated
-  std::vector< std::pair<DetId, float> > crystals_vector = basicCluster.hitsAndFractions();
-  float dphimin=999.;
-  float detamin=999.;
+  std::vector<std::pair<DetId, float> > crystals_vector = basicCluster.hitsAndFractions();
+  float dphimin = 999.;
+  float detamin = 999.;
   int ietaclosest = 0;
   int iphiclosest = 0;
-  
-  
-  for (unsigned int icry=0; icry!=crystals_vector.size(); ++icry) 
-    {    
-      
-      EBDetId crystal(crystals_vector[icry].first);
-      auto cell=geom->getGeometry(crystal);// problema qui
-      GlobalPoint center_pos = cell->getPosition(depth);
-      double EtaCentr = center_pos.eta();
-      double PhiCentr = TVector2::Phi_mpi_pi(center_pos.phi());
-      if (TMath::Abs(EtaCentr-Eta) < detamin) {
-	detamin = TMath::Abs(EtaCentr-Eta); 
-	ietaclosest = crystal.ieta();
-      }
-      if (TMath::Abs(TVector2::Phi_mpi_pi(PhiCentr-Phi)) < dphimin) {
-	dphimin = TMath::Abs(TVector2::Phi_mpi_pi(PhiCentr-Phi)); 
-	iphiclosest = crystal.iphi();
-      }
-      
+
+  for (unsigned int icry = 0; icry != crystals_vector.size(); ++icry) {
+    EBDetId crystal(crystals_vector[icry].first);
+    auto cell = geom->getGeometry(crystal);  // problema qui
+    GlobalPoint center_pos = cell->getPosition(depth);
+    double EtaCentr = center_pos.eta();
+    double PhiCentr = TVector2::Phi_mpi_pi(center_pos.phi());
+    if (TMath::Abs(EtaCentr - Eta) < detamin) {
+      detamin = TMath::Abs(EtaCentr - Eta);
+      ietaclosest = crystal.ieta();
     }
- 
-  
+    if (TMath::Abs(TVector2::Phi_mpi_pi(PhiCentr - Phi)) < dphimin) {
+      dphimin = TMath::Abs(TVector2::Phi_mpi_pi(PhiCentr - Phi));
+      iphiclosest = crystal.iphi();
+    }
+  }
+
   EBDetId crystalseed(ietaclosest, iphiclosest);
 
-  
   // Get center cell position from shower depth
-  auto cell=geom->getGeometry(crystalseed);
+  auto cell = geom->getGeometry(crystalseed);
   GlobalPoint center_pos = cell->getPosition(depth);
 
   //PHI
   double PhiCentr = TVector2::Phi_mpi_pi(center_pos.phi());
-  double PhiWidth = (TMath::Pi()/180.);
-  double PhiCry = (TVector2::Phi_mpi_pi(Phi-PhiCentr))/PhiWidth;
-  if (PhiCry>0.5) PhiCry=0.5;
-  if (PhiCry<-0.5) PhiCry=-0.5;
+  double PhiWidth = (TMath::Pi() / 180.);
+  double PhiCry = (TVector2::Phi_mpi_pi(Phi - PhiCentr)) / PhiWidth;
+  if (PhiCry > 0.5)
+    PhiCry = 0.5;
+  if (PhiCry < -0.5)
+    PhiCry = -0.5;
   //flip to take into account ECAL barrel symmetries:
-  if (ietaclosest<0) PhiCry *= -1.;
-  
+  if (ietaclosest < 0)
+    PhiCry *= -1.;
 
   //ETA
-  double ThetaCentr = -center_pos.theta()+0.5*TMath::Pi();
-  double ThetaWidth = (TMath::Pi()/180.)*TMath::Cos(ThetaCentr);
-  double EtaCry = (Theta-ThetaCentr)/ThetaWidth;    
-  if (EtaCry>0.5) EtaCry=0.5;
-  if (EtaCry<-0.5) EtaCry=-0.5;
+  double ThetaCentr = -center_pos.theta() + 0.5 * TMath::Pi();
+  double ThetaWidth = (TMath::Pi() / 180.) * TMath::Cos(ThetaCentr);
+  double EtaCry = (Theta - ThetaCentr) / ThetaWidth;
+  if (EtaCry > 0.5)
+    EtaCry = 0.5;
+  if (EtaCry < -0.5)
+    EtaCry = -0.5;
   //flip to take into account ECAL barrel symmetries:
-  if (ietaclosest<0) EtaCry *= -1.;
-  
-
+  if (ietaclosest < 0)
+    EtaCry *= -1.;
 
   //-------------- end calculate local position -------------
-  
 
   size_t payloadsize = params_->params().size();
-  
-  if (payloadsize < nparams  )
-    edm::LogError("Invalid Payload") << "Parametrization requires " << nparams << " parameters but only " << payloadsize << " are found in DB. Perhaps incompatible Global Tag"  << std::endl;
-  
 
-  if (payloadsize > nparams  )
-    edm::LogWarning("Size mismatch ") << "Parametrization requires " << nparams << " parameters but " << payloadsize << " are found in DB. Perhaps incompatible Global Tag"  << std::endl;
-  
+  if (payloadsize < nparams)
+    edm::LogError("Invalid Payload") << "Parametrization requires " << nparams << " parameters but only " << payloadsize
+                                     << " are found in DB. Perhaps incompatible Global Tag" << std::endl;
 
+  if (payloadsize > nparams)
+    edm::LogWarning("Size mismatch ") << "Parametrization requires " << nparams << " parameters but " << payloadsize
+                                      << " are found in DB. Perhaps incompatible Global Tag" << std::endl;
 
-  std::pair<double,double> localPosition(EtaCry,PhiCry);
+  std::pair<double, double> localPosition(EtaCry, PhiCry);
 
-  //--- local cluster coordinates 
+  //--- local cluster coordinates
   float localEta = localPosition.first;
   float localPhi = localPosition.second;
-  
+
   //--- ecal module
-  int imod    = getEcalModule(basicCluster.seed());
-    
+  int imod = getEcalModule(basicCluster.seed());
+
   //-- corrections parameters
   float pe[3], pp[3];
-  pe[0]= (params_->params())[0+imod*3];
-  pe[1]= (params_->params())[1+imod*3];
-  pe[2]= (params_->params())[2+imod*3];
-  pp[0]= (params_->params())[12+imod*3];
-  pp[1]= (params_->params())[13+imod*3];
-  pp[2]= (params_->params())[14+imod*3];  
-
+  pe[0] = (params_->params())[0 + imod * 3];
+  pe[1] = (params_->params())[1 + imod * 3];
+  pe[2] = (params_->params())[2 + imod * 3];
+  pp[0] = (params_->params())[12 + imod * 3];
+  pp[1] = (params_->params())[13 + imod * 3];
+  pp[2] = (params_->params())[14 + imod * 3];
 
   //--- correction vs local eta
-  fetacor = pe[0]+pe[1]*localEta+pe[2]*localEta*localEta;
+  fetacor = pe[0] + pe[1] * localEta + pe[2] * localEta * localEta;
 
   //--- correction vs local phi
-  fphicor = pp[0]+pp[1]*localPhi+pp[2]*localPhi*localPhi;
-
+  fphicor = pp[0] + pp[1] * localPhi + pp[2] * localPhi * localPhi;
 
   //if the seed crystal is neighbourgh of a supermodule border, don't apply the phi dependent  containment corrections, but use the larger crack corrections instead.
-  int iphimod20 = TMath::Abs(iphiclosest%20);
-  if ( iphimod20 <=1 ) fphicor=1.;
+  int iphimod20 = TMath::Abs(iphiclosest % 20);
+  if (iphimod20 <= 1)
+    fphicor = 1.;
 
-  correction_factor  = (1./fetacor)*(1./fphicor);
-  
+  correction_factor = (1. / fetacor) * (1. / fphicor);
+
   //return the correction factor. Use it to multiply the cluster energy.
   return correction_factor;
 }
 
-
 //------------------------------------------------------------------------------------------------------
-int EcalBasicClusterLocalContCorrection::getEcalModule(DetId id) const
-{
+int EcalBasicClusterLocalContCorrection::getEcalModule(DetId id) const {
   int mod = 0;
   int ieta = (EBDetId(id)).ieta();
-  
-  if (fabs(ieta) <=25 ) mod = 0;
-  if (fabs(ieta) > 25 && fabs(ieta) <=45 ) mod = 1;
-  if (fabs(ieta) > 45 && fabs(ieta) <=65 ) mod = 2;
-  if (fabs(ieta) > 65 && fabs(ieta) <=85 ) mod = 3;
+
+  if (fabs(ieta) <= 25)
+    mod = 0;
+  if (fabs(ieta) > 25 && fabs(ieta) <= 45)
+    mod = 1;
+  if (fabs(ieta) > 45 && fabs(ieta) <= 65)
+    mod = 2;
+  if (fabs(ieta) > 65 && fabs(ieta) <= 85)
+    mod = 3;
 
   return (mod);
- 
 }
 //------------------------------------------------------------------------------------------------------
 
-
-
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
-DEFINE_EDM_PLUGIN( EcalClusterFunctionFactory, EcalBasicClusterLocalContCorrection, "EcalBasicClusterLocalContCorrection");
+DEFINE_EDM_PLUGIN(EcalClusterFunctionFactory,
+                  EcalBasicClusterLocalContCorrection,
+                  "EcalBasicClusterLocalContCorrection");

--- a/RecoEcal/EgammaCoreTools/plugins/EcalBasicClusterLocalContCorrection.h
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalBasicClusterLocalContCorrection.h
@@ -13,17 +13,16 @@
 #include "RecoEcal/EgammaCoreTools/plugins/EcalClusterLocalContCorrectionBaseClass.h"
 
 class EcalBasicClusterLocalContCorrection : public EcalClusterLocalContCorrectionBaseClass {
- public:
-  EcalBasicClusterLocalContCorrection( const edm::ParameterSet &) {};
+public:
+  EcalBasicClusterLocalContCorrection(const edm::ParameterSet &){};
   // compute the correction
   //virtual float getValue( const reco::BasicCluster &, const EcalRecHitCollection & ) const;
   //virtual float getValue( const reco::BasicCluster & basicCluster) const;
-  float getValue( const reco::BasicCluster &, const EcalRecHitCollection & ) const override;
-  float getValue( const reco::SuperCluster &, const int mode ) const override;
- private:	
-  int getEcalModule(DetId id) const;
-    
+  float getValue(const reco::BasicCluster &, const EcalRecHitCollection &) const override;
+  float getValue(const reco::SuperCluster &, const int mode) const override;
 
+private:
+  int getEcalModule(DetId id) const;
 };
 
 #endif

--- a/RecoEcal/EgammaCoreTools/plugins/EcalBasicClusterLocalContCorrectionsESProducer.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalBasicClusterLocalContCorrectionsESProducer.cc
@@ -9,45 +9,40 @@
 //#include "CalibCalorimetry/EcalCorrectionModules/interface/EcalBasicClusterLocalContCorrectionsESProducer.h"
 #include "RecoEcal/EgammaCoreTools/plugins/EcalBasicClusterLocalContCorrectionsESProducer.h"
 
-EcalBasicClusterLocalContCorrectionsESProducer::EcalBasicClusterLocalContCorrectionsESProducer(const edm::ParameterSet& iConfig)
-{   
-   setWhatProduced(this);
+EcalBasicClusterLocalContCorrectionsESProducer::EcalBasicClusterLocalContCorrectionsESProducer(
+    const edm::ParameterSet& iConfig) {
+  setWhatProduced(this);
 }
 
-
-EcalBasicClusterLocalContCorrectionsESProducer::~EcalBasicClusterLocalContCorrectionsESProducer(){ }
-
+EcalBasicClusterLocalContCorrectionsESProducer::~EcalBasicClusterLocalContCorrectionsESProducer() {}
 
 //
 // member functions
 //
 
-EcalBasicClusterLocalContCorrectionsESProducer::ReturnType
-EcalBasicClusterLocalContCorrectionsESProducer::produce(const EcalClusterLocalContCorrParametersRcd& iRecord)
-{
+EcalBasicClusterLocalContCorrectionsESProducer::ReturnType EcalBasicClusterLocalContCorrectionsESProducer::produce(
+    const EcalClusterLocalContCorrParametersRcd& iRecord) {
+  using namespace edm::es;
+  using namespace std;
 
-   using namespace edm::es;
-   using namespace std;
+  auto pEcalClusterLocalContCorrParameters = std::make_unique<EcalClusterLocalContCorrParameters>();
 
-   auto pEcalClusterLocalContCorrParameters = std::make_unique<EcalClusterLocalContCorrParameters>();
+  double values[] = {
+      1.00603, 0.00300789,   0.0667232,  // local eta, mod1
+      1.00655, 0.00386189,   0.073931,   // local eta, mod2
+      1.00634, 0.00631341,   0.0764134,  // local eta, mod3
+      1.00957, 0.0113306,    0.123808,   // local eta, mod4
+      1.00402, 0.00108324,   0.0428149,  // local phi, mod1
+      1.00393, 0.000937121,  0.041658,   // local phi, mod2
+      1.00299, 0.00126836,   0.0321188,  // local phi, mod3
+      1.00279, -0.000700709, 0.0293207   // local phi, mod4
+  };
 
-   double values[] = {  1.00603 , 0.00300789 , 0.0667232 , // local eta, mod1
-			1.00655 , 0.00386189 , 0.073931  , // local eta, mod2
-			1.00634 , 0.00631341 , 0.0764134 , // local eta, mod3
-			1.00957 , 0.0113306 , 0.123808   , // local eta, mod4
-			1.00402 , 0.00108324 , 0.0428149 , // local phi, mod1
-			1.00393 , 0.000937121 , 0.041658 , // local phi, mod2
-			1.00299 , 0.00126836 , 0.0321188 , // local phi, mod3
-			1.00279 , -0.000700709 , 0.0293207 // local phi, mod4
-   };
+  size_t size = 24;
+  pEcalClusterLocalContCorrParameters->params().resize(size);
+  std::copy(values, values + size, pEcalClusterLocalContCorrParameters->params().begin());
 
-   size_t size = 24;
-   pEcalClusterLocalContCorrParameters->params().resize(size);
-   std::copy(values,values+size,pEcalClusterLocalContCorrParameters->params().begin());
-   
-   return pEcalClusterLocalContCorrParameters ;
+  return pEcalClusterLocalContCorrParameters;
 }
-
-
 
 DEFINE_FWK_EVENTSETUP_MODULE(EcalBasicClusterLocalContCorrectionsESProducer);

--- a/RecoEcal/EgammaCoreTools/plugins/EcalBasicClusterLocalContCorrectionsESProducer.h
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalBasicClusterLocalContCorrectionsESProducer.h
@@ -2,7 +2,7 @@
 //
 // Package:    EcalBasicClusterLocalContCorrectionsESProducer
 // Class:      EcalBasicClusterLocalContCorrectionsESProducer
-// 
+//
 /**\class EcalBasicClusterLocalContCorrectionsESProducer EcalBasicClusterLocalContCorrectionsESProducer.h User/EcalBasicClusterLocalContCorrectionsESProducer/interface/EcalBasicClusterLocalContCorrectionsESProducer.h
 
  Description: Trivial ESProducer to provide EventSetup with (hard coded)
@@ -18,16 +18,13 @@
 #include "CondFormats/DataRecord/interface/EcalClusterLocalContCorrParametersRcd.h"
 
 class EcalBasicClusterLocalContCorrectionsESProducer : public edm::ESProducer {
-
-   public:
-      EcalBasicClusterLocalContCorrectionsESProducer(const edm::ParameterSet&);
-     ~EcalBasicClusterLocalContCorrectionsESProducer() override;
+public:
+  EcalBasicClusterLocalContCorrectionsESProducer(const edm::ParameterSet&);
+  ~EcalBasicClusterLocalContCorrectionsESProducer() override;
 
   typedef std::unique_ptr<EcalClusterLocalContCorrParameters> ReturnType;
-  
+
   ReturnType produce(const EcalClusterLocalContCorrParametersRcd&);
 
-   private:
-  
-
+private:
 };

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterCrackCorrection.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterCrackCorrection.cc
@@ -22,34 +22,29 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 #include <iostream>
 
-
-float EcalClusterCrackCorrection::getValue( const reco::BasicCluster & basicCluster, const EcalRecHitCollection & recHit) const
-{
+float EcalClusterCrackCorrection::getValue(const reco::BasicCluster& basicCluster,
+                                           const EcalRecHitCollection& recHit) const {
   //this is a dummy function, could be deleted in mother classes and here
-        checkInit();
+  checkInit();
 
-        // private member params_ = EcalClusterCrackCorrectionParameters
-        // (see in CondFormats/EcalObjects/interface)
-        EcalFunctionParameters::const_iterator it;
-        std::cout << "[[EcalClusterCrackCorrectionBaseClass::getValue]] " 
-                << params_->params().size() << " parameters:";
-        for ( it = params_->params().begin(); it != params_->params().end(); ++it ) {
-                std::cout << " " << *it;
-        }
-        std::cout << "\n";
-        return 1;
+  // private member params_ = EcalClusterCrackCorrectionParameters
+  // (see in CondFormats/EcalObjects/interface)
+  EcalFunctionParameters::const_iterator it;
+  std::cout << "[[EcalClusterCrackCorrectionBaseClass::getValue]] " << params_->params().size() << " parameters:";
+  for (it = params_->params().begin(); it != params_->params().end(); ++it) {
+    std::cout << " " << *it;
+  }
+  std::cout << "\n";
+  return 1;
 }
 
-
-float EcalClusterCrackCorrection::getValue( const reco::CaloCluster & seedbclus) const
-{
+float EcalClusterCrackCorrection::getValue(const reco::CaloCluster& seedbclus) const {
   checkInit();
 
   //correction factor to be returned, and to be calculated in this present function:
-  double correction_factor=1.;
-  double fetacor=1.; //eta dependent part of the correction factor
-  double fphicor=1.; //phi dependent part of the correction factor
-
+  double correction_factor = 1.;
+  double fetacor = 1.;  //eta dependent part of the correction factor
+  double fphicor = 1.;  //phi dependent part of the correction factor
 
   //********************************************************************************************************************//
   //These ECAL barrel module and supermodule border corrections correct a photon energy for leakage outside a 5x5 crystal cluster. They  depend on the local position in the hit crystal. The hit crystal needs to be at the border of a barrel module. The local position coordinates, called later EtaCry and PhiCry in the code, are comprised between -0.5 and 0.5 and correspond to the distance between the photon supercluster position and the center of the hit crystal, expressed in number of  crystal widthes. The correction parameters (that should be filled in CalibCalorimetry/EcalTrivialCondModules/python/EcalTrivialCondRetriever_cfi.py) were calculated using simulaion and thus take into account the effect of the magnetic field. They  only apply to unconverted photons in the barrel, but a use for non brem electrons could be considered (not tested yet). For more details, cf the CMS internal note 2009-013 by S. Tourneur and C. Seez
@@ -57,122 +52,124 @@ float EcalClusterCrackCorrection::getValue( const reco::CaloCluster & seedbclus)
   //Beware: The user should make sure it only uses this correction factor for unconverted photons (or not breming electrons)
 
   //const reco::CaloClusterPtr & seedbclus =  superCluster.seed();
-  
+
   //If not barrel, return 1:
-  if (TMath::Abs(seedbclus.eta()) >1.4442 ) return 1.;
+  if (TMath::Abs(seedbclus.eta()) > 1.4442)
+    return 1.;
 
   edm::ESHandle<CaloGeometry> pG;
-  es_->get<CaloGeometryRecord>().get(pG); 
-  
-  const CaloSubdetectorGeometry* geom=pG->getSubdetectorGeometry(DetId::Ecal,EcalBarrel);//EcalBarrel = 1
-  
-  const math::XYZPoint& position_ = seedbclus.position(); 
-  double Theta = -position_.theta()+0.5*TMath::Pi();
+  es_->get<CaloGeometryRecord>().get(pG);
+
+  const CaloSubdetectorGeometry* geom = pG->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);  //EcalBarrel = 1
+
+  const math::XYZPoint& position_ = seedbclus.position();
+  double Theta = -position_.theta() + 0.5 * TMath::Pi();
   double Eta = position_.eta();
   double Phi = TVector2::Phi_mpi_pi(position_.phi());
-  
+
   //Calculate expected depth of the maximum shower from energy (like in PositionCalc::Calculate_Location()):
   // The parameters X0 and T0 are hardcoded here because these values were used to calculate the corrections:
-  const float X0 = 0.89; const float T0 = 7.4;
+  const float X0 = 0.89;
+  const float T0 = 7.4;
   double depth = X0 * (T0 + log(seedbclus.energy()));
-  
-  
+
   //search which crystal is closest to the cluster position and call it crystalseed:
   //std::vector<DetId> crystals_vector = seedbclus.getHitsByDetId();   //deprecated
-  std::vector< std::pair<DetId, float> > crystals_vector = seedbclus.hitsAndFractions();
-  float dphimin=999.;
-  float detamin=999.;
+  std::vector<std::pair<DetId, float> > crystals_vector = seedbclus.hitsAndFractions();
+  float dphimin = 999.;
+  float detamin = 999.;
   int ietaclosest = 0;
   int iphiclosest = 0;
-  for (unsigned int icry=0; icry!=crystals_vector.size(); ++icry) {    
+  for (unsigned int icry = 0; icry != crystals_vector.size(); ++icry) {
     EBDetId crystal(crystals_vector[icry].first);
-    auto cell=geom->getGeometry(crystal);
+    auto cell = geom->getGeometry(crystal);
     GlobalPoint center_pos = cell->getPosition(depth);
     double EtaCentr = center_pos.eta();
     double PhiCentr = TVector2::Phi_mpi_pi(center_pos.phi());
-    if (TMath::Abs(EtaCentr-Eta) < detamin) {
-      detamin = TMath::Abs(EtaCentr-Eta); 
+    if (TMath::Abs(EtaCentr - Eta) < detamin) {
+      detamin = TMath::Abs(EtaCentr - Eta);
       ietaclosest = crystal.ieta();
     }
-    if (TMath::Abs(TVector2::Phi_mpi_pi(PhiCentr-Phi)) < dphimin) {
-      dphimin = TMath::Abs(TVector2::Phi_mpi_pi(PhiCentr-Phi)); 
+    if (TMath::Abs(TVector2::Phi_mpi_pi(PhiCentr - Phi)) < dphimin) {
+      dphimin = TMath::Abs(TVector2::Phi_mpi_pi(PhiCentr - Phi));
       iphiclosest = crystal.iphi();
     }
   }
   EBDetId crystalseed(ietaclosest, iphiclosest);
-  
+
   // Get center cell position from shower depth
-  auto cell=geom->getGeometry(crystalseed);
+  auto cell = geom->getGeometry(crystalseed);
   GlobalPoint center_pos = cell->getPosition(depth);
-  
+
   //if the seed crystal isn't neighbourgh of a supermodule border, don't apply the phi dependent crack corrections, but use the smaller phi dependent local containment correction instead.
-  if (ietaclosest<0) iphiclosest = 361 - iphiclosest; //inversion of phi 3 degree tilt 
-  int iphimod20 = iphiclosest%20;
-   if ( iphimod20 >1 ) fphicor=1.;
+  if (ietaclosest < 0)
+    iphiclosest = 361 - iphiclosest;  //inversion of phi 3 degree tilt
+  int iphimod20 = iphiclosest % 20;
+  if (iphimod20 > 1)
+    fphicor = 1.;
 
-   else{
-      double PhiCentr = TVector2::Phi_mpi_pi(center_pos.phi());
-      double PhiWidth = (TMath::Pi()/180.);
-      double PhiCry = (TVector2::Phi_mpi_pi(Phi-PhiCentr))/PhiWidth;
-      if (PhiCry>0.5) PhiCry=0.5;
-      if (PhiCry<-0.5) PhiCry=-0.5;
-       //flip to take into account ECAL barrel symmetries:
-      if (ietaclosest<0) PhiCry *= -1.;
+  else {
+    double PhiCentr = TVector2::Phi_mpi_pi(center_pos.phi());
+    double PhiWidth = (TMath::Pi() / 180.);
+    double PhiCry = (TVector2::Phi_mpi_pi(Phi - PhiCentr)) / PhiWidth;
+    if (PhiCry > 0.5)
+      PhiCry = 0.5;
+    if (PhiCry < -0.5)
+      PhiCry = -0.5;
+    //flip to take into account ECAL barrel symmetries:
+    if (ietaclosest < 0)
+      PhiCry *= -1.;
 
-      //Fetching parameters of the polynomial (see  CMS IN-2009/013)
-      double g[5];
-      int offset = iphimod20==0 ? 
-	10 //coefficients for one phi side of a SM
-	: 15; //coefficients for the other side
-      for (int k=0; k!=5; ++k) g[k] = (params_->params())[k+offset];
-      
-      fphicor=0.;
-      for (int k=0; k!=5; ++k) fphicor += g[k]*std::pow(PhiCry,k);
-   }
-   
-   //if the seed crystal isn't neighbourgh of a module border, don't apply the eta dependent crack corrections, but use the smaller eta dependent local containment correction instead.
-  int ietamod20 = ietaclosest%20;
-  if (TMath::Abs(ietaclosest) <25 || (TMath::Abs(ietamod20)!=5 && TMath::Abs(ietamod20)!=6) ) fetacor = 1.;
-  
-  else
-    {      
-      double ThetaCentr = -center_pos.theta()+0.5*TMath::Pi();
-      double ThetaWidth = (TMath::Pi()/180.)*TMath::Cos(ThetaCentr);
-      double EtaCry = (Theta-ThetaCentr)/ThetaWidth;    
-      if (EtaCry>0.5) EtaCry=0.5;
-      if (EtaCry<-0.5) EtaCry=-0.5;
-      //flip to take into account ECAL barrel symmetries:
-      if (ietaclosest<0) EtaCry *= -1.;
-      
-      //Fetching parameters of the polynomial (see  CMS IN-2009/013)
-      double f[5];
-      int offset = TMath::Abs(ietamod20)==5 ? 
-	0 //coefficients for eta side of an intermodule gap closer to the interaction point
-	: 5; //coefficients for the other eta side
-      for (int k=0; k!=5; ++k) f[k] = (params_->params())[k+offset];
-     
-      fetacor=0.;
-      for (int k=0; k!=5; ++k) fetacor += f[k]*std::pow(EtaCry,k); 
-    }
-  
-  correction_factor = 1./(fetacor*fphicor);
+    //Fetching parameters of the polynomial (see  CMS IN-2009/013)
+    double g[5];
+    int offset = iphimod20 == 0 ? 10   //coefficients for one phi side of a SM
+                                : 15;  //coefficients for the other side
+    for (int k = 0; k != 5; ++k)
+      g[k] = (params_->params())[k + offset];
+
+    fphicor = 0.;
+    for (int k = 0; k != 5; ++k)
+      fphicor += g[k] * std::pow(PhiCry, k);
+  }
+
+  //if the seed crystal isn't neighbourgh of a module border, don't apply the eta dependent crack corrections, but use the smaller eta dependent local containment correction instead.
+  int ietamod20 = ietaclosest % 20;
+  if (TMath::Abs(ietaclosest) < 25 || (TMath::Abs(ietamod20) != 5 && TMath::Abs(ietamod20) != 6))
+    fetacor = 1.;
+
+  else {
+    double ThetaCentr = -center_pos.theta() + 0.5 * TMath::Pi();
+    double ThetaWidth = (TMath::Pi() / 180.) * TMath::Cos(ThetaCentr);
+    double EtaCry = (Theta - ThetaCentr) / ThetaWidth;
+    if (EtaCry > 0.5)
+      EtaCry = 0.5;
+    if (EtaCry < -0.5)
+      EtaCry = -0.5;
+    //flip to take into account ECAL barrel symmetries:
+    if (ietaclosest < 0)
+      EtaCry *= -1.;
+
+    //Fetching parameters of the polynomial (see  CMS IN-2009/013)
+    double f[5];
+    int offset = TMath::Abs(ietamod20) == 5
+                     ? 0   //coefficients for eta side of an intermodule gap closer to the interaction point
+                     : 5;  //coefficients for the other eta side
+    for (int k = 0; k != 5; ++k)
+      f[k] = (params_->params())[k + offset];
+
+    fetacor = 0.;
+    for (int k = 0; k != 5; ++k)
+      fetacor += f[k] * std::pow(EtaCry, k);
+  }
+
+  correction_factor = 1. / (fetacor * fphicor);
   //*********************************************************************************************************************//
-  
+
   //return the correction factor. Use it to multiply the cluster energy.
   return correction_factor;
 }
 
-  
-
-
-
-
-
-
-
-       	  
-float EcalClusterCrackCorrection::getValue( const reco::SuperCluster & superCluster, const int mode ) const
-{
+float EcalClusterCrackCorrection::getValue(const reco::SuperCluster& superCluster, const int mode) const {
   checkInit();
 
   //********************************************************************************************************************//
@@ -181,11 +178,7 @@ float EcalClusterCrackCorrection::getValue( const reco::SuperCluster & superClus
   //Beware: The user should make sure it only uses this correction factor for unconverted photons (or not breming electrons)
 
   return getValue(*(superCluster.seed()));
-
- 
 }
 
-
-
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
-DEFINE_EDM_PLUGIN( EcalClusterFunctionFactory, EcalClusterCrackCorrection, "EcalClusterCrackCorrection");
+DEFINE_EDM_PLUGIN(EcalClusterFunctionFactory, EcalClusterCrackCorrection, "EcalClusterCrackCorrection");

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterCrackCorrection.h
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterCrackCorrection.h
@@ -13,14 +13,12 @@
 #include "RecoEcal/EgammaCoreTools/plugins/EcalClusterCrackCorrectionBaseClass.h"
 
 class EcalClusterCrackCorrection : public EcalClusterCrackCorrectionBaseClass {
-        public:
-                EcalClusterCrackCorrection( const edm::ParameterSet &) {};
-                // compute the correction
-                float getValue( const reco::BasicCluster &, const EcalRecHitCollection & ) const override;
-                float getValue( const reco::SuperCluster &, const int mode ) const override;
+public:
+  EcalClusterCrackCorrection(const edm::ParameterSet &){};
+  // compute the correction
+  float getValue(const reco::BasicCluster &, const EcalRecHitCollection &) const override;
+  float getValue(const reco::SuperCluster &, const int mode) const override;
 
-		float getValue( const reco::CaloCluster &) const override;
-
-		
+  float getValue(const reco::CaloCluster &) const override;
 };
 #endif

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterCrackCorrectionBaseClass.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterCrackCorrectionBaseClass.cc
@@ -5,37 +5,30 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-EcalClusterCrackCorrectionBaseClass::EcalClusterCrackCorrectionBaseClass() :
-        params_(nullptr)
-{}
+EcalClusterCrackCorrectionBaseClass::EcalClusterCrackCorrectionBaseClass() : params_(nullptr) {}
 
-EcalClusterCrackCorrectionBaseClass::~EcalClusterCrackCorrectionBaseClass()
-{}
+EcalClusterCrackCorrectionBaseClass::~EcalClusterCrackCorrectionBaseClass() {}
 
-void
-EcalClusterCrackCorrectionBaseClass::init( const edm::EventSetup& es )
-{
-        es.get<EcalClusterCrackCorrParametersRcd>().get( esParams_ );
-        params_ = esParams_.product();
-	es_ = &es; //needed to access the ECAL geometry
+void EcalClusterCrackCorrectionBaseClass::init(const edm::EventSetup& es) {
+  es.get<EcalClusterCrackCorrParametersRcd>().get(esParams_);
+  params_ = esParams_.product();
+  es_ = &es;  //needed to access the ECAL geometry
 
-        //// check if parameters are retrieved correctly
-        //EcalClusterCrackCorrParameters::const_iterator it;
-        //std::cout << "[[EcalClusterCrackCorrectionBaseClass::init]] " 
-        //        << params_->size() << " parameters:";
-        //for ( it = params_->begin(); it != params_->end(); ++it ) {
-        //        std::cout << " " << *it;
-        //}
-        //std::cout << "\n";
+  //// check if parameters are retrieved correctly
+  //EcalClusterCrackCorrParameters::const_iterator it;
+  //std::cout << "[[EcalClusterCrackCorrectionBaseClass::init]] "
+  //        << params_->size() << " parameters:";
+  //for ( it = params_->begin(); it != params_->end(); ++it ) {
+  //        std::cout << " " << *it;
+  //}
+  //std::cout << "\n";
 }
 
-void
-EcalClusterCrackCorrectionBaseClass::checkInit() const
-{
-        if ( ! params_ ) {
-                // non initialized function parameters: throw exception
-                throw cms::Exception("EcalClusterCrackCorrectionBaseClass::checkInit()") 
-                        << "Trying to access an uninitialized crack correction function.\n"
-                        "Please call `init( edm::EventSetup &)' before any use of the function.\n";
-        }
+void EcalClusterCrackCorrectionBaseClass::checkInit() const {
+  if (!params_) {
+    // non initialized function parameters: throw exception
+    throw cms::Exception("EcalClusterCrackCorrectionBaseClass::checkInit()")
+        << "Trying to access an uninitialized crack correction function.\n"
+           "Please call `init( edm::EventSetup &)' before any use of the function.\n";
+  }
 }

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterCrackCorrectionBaseClass.h
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterCrackCorrectionBaseClass.h
@@ -18,29 +18,28 @@
 #include "CondFormats/EcalObjects/interface/EcalClusterCrackCorrParameters.h"
 
 class EcalClusterCrackCorrectionBaseClass : public EcalClusterFunctionBaseClass {
-        public:
-                EcalClusterCrackCorrectionBaseClass();
-                EcalClusterCrackCorrectionBaseClass( const edm::ParameterSet & ) {};
-                ~EcalClusterCrackCorrectionBaseClass() override;
+public:
+  EcalClusterCrackCorrectionBaseClass();
+  EcalClusterCrackCorrectionBaseClass(const edm::ParameterSet &){};
+  ~EcalClusterCrackCorrectionBaseClass() override;
 
-                // get/set explicit methods for parameters
-                const EcalClusterCrackCorrParameters * getParameters() const { return params_; }
-                // check initialization
-                void checkInit() const;
-                
-                // compute the correction
-                float getValue( const reco::BasicCluster &, const EcalRecHitCollection & ) const override = 0;
-                float getValue( const reco::SuperCluster &, const int mode ) const override = 0;
-		
-		float getValue( const reco::CaloCluster &) const override{return 0;};
-                // set parameters
-                void init( const edm::EventSetup& es ) override;
+  // get/set explicit methods for parameters
+  const EcalClusterCrackCorrParameters *getParameters() const { return params_; }
+  // check initialization
+  void checkInit() const;
 
-        protected:
-                edm::ESHandle<EcalClusterCrackCorrParameters> esParams_;
-                const EcalClusterCrackCorrParameters * params_;
-		const edm::EventSetup * es_; //needed to access the ECAL geometry
+  // compute the correction
+  float getValue(const reco::BasicCluster &, const EcalRecHitCollection &) const override = 0;
+  float getValue(const reco::SuperCluster &, const int mode) const override = 0;
 
+  float getValue(const reco::CaloCluster &) const override { return 0; };
+  // set parameters
+  void init(const edm::EventSetup &es) override;
+
+protected:
+  edm::ESHandle<EcalClusterCrackCorrParameters> esParams_;
+  const EcalClusterCrackCorrParameters *params_;
+  const edm::EventSetup *es_;  //needed to access the ECAL geometry
 };
 
 #endif

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyCorrection.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyCorrection.cc
@@ -2,52 +2,57 @@
 
 // Shower leakage corrections developed by Jungzhie et al. using TB data
 // Developed for EB only!
-float EcalClusterEnergyCorrection::fEta(float energy, float eta, int algorithm) const
-{
-
+float EcalClusterEnergyCorrection::fEta(float energy, float eta, int algorithm) const {
   // this correction is setup only for EB
-  if ( algorithm != 0 ) return energy;
-  
-  float ieta = fabs(eta)*(5/0.087);
+  if (algorithm != 0)
+    return energy;
+
+  float ieta = fabs(eta) * (5 / 0.087);
   float p0 = (params_->params())[0];  // should be 40.2198
   float p1 = (params_->params())[1];  // should be -3.03103e-6
 
   float correctedEnergy = energy;
-  if ( ieta < p0 ) correctedEnergy = energy;
-  else             correctedEnergy = energy/(1.0 + p1*(ieta-p0)*(ieta-p0));
+  if (ieta < p0)
+    correctedEnergy = energy;
+  else
+    correctedEnergy = energy / (1.0 + p1 * (ieta - p0) * (ieta - p0));
   //std::cout << "ECEC fEta = " << correctedEnergy << std::endl;
   return correctedEnergy;
 }
 
-float EcalClusterEnergyCorrection::fBrem(float e, float brem, int algorithm) const 
-{
-  // brem == phiWidth/etaWidth of the SuperCluster 
-  // e  == energy of the SuperCluster 
-  // first parabola (for br > threshold) 
-  // p0 + p1*x + p2*x^2 
-  // second parabola (for br <= threshold) 
-  // ax^2 + bx + c, make y and y' the same in threshold 
-  // y = p0 + p1*threshold + p2*threshold^2  
-  // yprime = p1 + 2*p2*threshold 
-  // a = p3 
-  // b = yprime - 2*a*threshold 
-  // c = y - a*threshold^2 - b*threshold 
+float EcalClusterEnergyCorrection::fBrem(float e, float brem, int algorithm) const {
+  // brem == phiWidth/etaWidth of the SuperCluster
+  // e  == energy of the SuperCluster
+  // first parabola (for br > threshold)
+  // p0 + p1*x + p2*x^2
+  // second parabola (for br <= threshold)
+  // ax^2 + bx + c, make y and y' the same in threshold
+  // y = p0 + p1*threshold + p2*threshold^2
+  // yprime = p1 + 2*p2*threshold
+  // a = p3
+  // b = yprime - 2*a*threshold
+  // c = y - a*threshold^2 - b*threshold
 
   int offset;
-  if ( algorithm == 0 ) offset = 0;
-  else if ( algorithm == 1 ) offset = 20;
+  if (algorithm == 0)
+    offset = 0;
+  else if (algorithm == 1)
+    offset = 20;
   else {
     // not supported, produce no correction
     return e;
   }
 
-  //Make No Corrections if brem is invalid! 
-  if ( brem == 0 ) return e; 
+  //Make No Corrections if brem is invalid!
+  if (brem == 0)
+    return e;
 
-  float bremLowThr  = (params_->params())[2 + offset];
+  float bremLowThr = (params_->params())[2 + offset];
   float bremHighThr = (params_->params())[3 + offset];
-  if ( brem < bremLowThr  ) brem = bremLowThr;
-  if ( brem > bremHighThr ) brem = bremHighThr;
+  if (brem < bremLowThr)
+    brem = bremLowThr;
+  if (brem > bremHighThr)
+    brem = bremHighThr;
 
   // Parameters provided in cfg file
   float p0 = (params_->params())[4 + offset];
@@ -55,74 +60,81 @@ float EcalClusterEnergyCorrection::fBrem(float e, float brem, int algorithm) con
   float p2 = (params_->params())[6 + offset];
   float p3 = (params_->params())[7 + offset];
   float p4 = (params_->params())[8 + offset];
-  // 
-  float threshold = p4;  
+  //
+  float threshold = p4;
 
-  float y = p0*threshold*threshold + p1*threshold + p2; 
-  float yprime = 2*p0*threshold + p1; 
-  float a = p3; 
-  float b = yprime - 2*a*threshold; 
-  float c = y - a*threshold*threshold - b*threshold; 
-   
-  float fCorr = 1; 
-  if ( brem < threshold )  
-    fCorr = p0*brem*brem + p1*brem + p2; 
-  else  
-    fCorr = a*brem*brem + b*brem + c; 
- 
+  float y = p0 * threshold * threshold + p1 * threshold + p2;
+  float yprime = 2 * p0 * threshold + p1;
+  float a = p3;
+  float b = yprime - 2 * a * threshold;
+  float c = y - a * threshold * threshold - b * threshold;
+
+  float fCorr = 1;
+  if (brem < threshold)
+    fCorr = p0 * brem * brem + p1 * brem + p2;
+  else
+    fCorr = a * brem * brem + b * brem + c;
+
   //std::cout << "ECEC fBrem " << e/fCorr << std::endl;
-  return e/fCorr; 
-}   
+  return e / fCorr;
+}
 
-
-float EcalClusterEnergyCorrection::fEtEta(float et, float eta, int algorithm) const
-{ 
-  // et -- Et of the SuperCluster (with respect to (0,0,0)) 
-  // eta -- eta of the SuperCluster 
+float EcalClusterEnergyCorrection::fEtEta(float et, float eta, int algorithm) const {
+  // et -- Et of the SuperCluster (with respect to (0,0,0))
+  // eta -- eta of the SuperCluster
 
   //std::cout << "fEtEta, mode = " << algorithm << std::endl;
   //std::cout << "ECEC: p0    " << (params_->params())[9]  << " " << (params_->params())[10] << " " << (params_->params())[11] << " " << (params_->params())[12] << std::endl;
   //std::cout << "ECEC: p1    " << (params_->params())[13] << " " << (params_->params())[14] << " " << (params_->params())[15] << " " << (params_->params())[16] << std::endl;
   //std::cout << "ECEC: fcorr " << (params_->params())[17] << " " << (params_->params())[18] << " " << (params_->params())[19] << std::endl;
- 
-  float fCorr = 0.; 
+
+  float fCorr = 0.;
   int offset;
-  if ( algorithm == 0 ) offset = 0;
-  else if ( algorithm == 1 ) offset = 20;
-  else if ( algorithm == 10 ) offset = 28;
-  else if ( algorithm == 11 ) offset = 39;
+  if (algorithm == 0)
+    offset = 0;
+  else if (algorithm == 1)
+    offset = 20;
+  else if (algorithm == 10)
+    offset = 28;
+  else if (algorithm == 11)
+    offset = 39;
   else {
     // not supported, produce no correction
     return et;
   }
 
-  // Barrel 
-  if ( algorithm == 0 || algorithm == 10 ) { 
-    float p0 = (params_->params())[ 9 + offset]  + (params_->params())[10 + offset]/ (et + (params_->params())[11 + offset]) + (params_->params())[12 + offset]/(et*et);  
-    float p1 = (params_->params())[13 + offset]  + (params_->params())[14 + offset]/ (et + (params_->params())[15 + offset]) + (params_->params())[16 + offset]/(et*et);  
- 
-    fCorr = p0 +  p1 * atan((params_->params())[17 + offset]*((params_->params())[18 + offset]-fabs(eta))) + (params_->params())[19 + offset] * fabs(eta); 
- 
-  } else if ( algorithm == 1 || algorithm == 11 ) { // Endcap 
-    float p0 = (params_->params())[ 9 + offset] + (params_->params())[10 + offset]/sqrt(et); 
-    float p1 = (params_->params())[11 + offset] + (params_->params())[12 + offset]/sqrt(et); 
-    float p2 = (params_->params())[13 + offset] + (params_->params())[14 + offset]/sqrt(et); 
-    float p3 = (params_->params())[15 + offset] + (params_->params())[16 + offset]/sqrt(et); 
-  
-    fCorr = p0 + p1*fabs(eta) + p2*eta*eta + p3/fabs(eta); 
-  } 
- 
+  // Barrel
+  if (algorithm == 0 || algorithm == 10) {
+    float p0 = (params_->params())[9 + offset] +
+               (params_->params())[10 + offset] / (et + (params_->params())[11 + offset]) +
+               (params_->params())[12 + offset] / (et * et);
+    float p1 = (params_->params())[13 + offset] +
+               (params_->params())[14 + offset] / (et + (params_->params())[15 + offset]) +
+               (params_->params())[16 + offset] / (et * et);
+
+    fCorr = p0 + p1 * atan((params_->params())[17 + offset] * ((params_->params())[18 + offset] - fabs(eta))) +
+            (params_->params())[19 + offset] * fabs(eta);
+
+  } else if (algorithm == 1 || algorithm == 11) {  // Endcap
+    float p0 = (params_->params())[9 + offset] + (params_->params())[10 + offset] / sqrt(et);
+    float p1 = (params_->params())[11 + offset] + (params_->params())[12 + offset] / sqrt(et);
+    float p2 = (params_->params())[13 + offset] + (params_->params())[14 + offset] / sqrt(et);
+    float p3 = (params_->params())[15 + offset] + (params_->params())[16 + offset] / sqrt(et);
+
+    fCorr = p0 + p1 * fabs(eta) + p2 * eta * eta + p3 / fabs(eta);
+  }
+
   // cap the correction at 50%
-  if ( fCorr < 0.5 ) fCorr = 0.5;  
-  if ( fCorr > 1.5 ) fCorr = 1.5;   
- 
+  if (fCorr < 0.5)
+    fCorr = 0.5;
+  if (fCorr > 1.5)
+    fCorr = 1.5;
+
   //std::cout << "ECEC fEtEta " << et/fCorr << std::endl;
-  return et/fCorr; 
-} 
+  return et / fCorr;
+}
 
-
-float EcalClusterEnergyCorrection::getValue( const reco::SuperCluster & superCluster, const int mode ) const
-{
+float EcalClusterEnergyCorrection::getValue(const reco::SuperCluster& superCluster, const int mode) const {
   // mode flags:
   // hybrid modes: 1 - return f(eta) correction in GeV
   //               2 - return f(eta) + f(brem) correction
@@ -134,64 +146,61 @@ float EcalClusterEnergyCorrection::getValue( const reco::SuperCluster & superClu
   //                mode = 11 -- return f(et, eta) correction with respect to already corrected SC in endcap
 
   checkInit();
-  
-  float eta = fabs(superCluster.eta()); 
-  float brem = superCluster.phiWidth()/superCluster.etaWidth(); 
+
+  float eta = fabs(superCluster.eta());
+  float brem = superCluster.phiWidth() / superCluster.etaWidth();
   int algorithm = -1;
 
-  if ( mode <= 3  || mode == 10 ) {
+  if (mode <= 3 || mode == 10) {
     // algorithm: hybrid
     algorithm = 0;
 
     float energy = superCluster.rawEnergy();
-    if ( mode == 10 ) {
+    if (mode == 10) {
       algorithm = 10;
       energy = superCluster.energy();
     }
     float correctedEnergy = fEta(energy, eta, algorithm);
 
-    if ( mode == 1 ) {
+    if (mode == 1) {
       return correctedEnergy - energy;
 
     } else {
       // now apply F(brem)
       correctedEnergy = fBrem(correctedEnergy, brem, algorithm);
-      if ( mode == 2 ) {
-	return correctedEnergy - energy;
+      if (mode == 2) {
+        return correctedEnergy - energy;
       }
 
-      float correctedEt = correctedEnergy/cosh(eta);
+      float correctedEt = correctedEnergy / cosh(eta);
       correctedEt = fEtEta(correctedEt, eta, algorithm);
-      correctedEnergy = correctedEt*cosh(eta);
+      correctedEnergy = correctedEt * cosh(eta);
       return correctedEnergy - energy;
     }
-  } else if ( mode == 4 || mode == 5 || mode == 11 ) {
+  } else if (mode == 4 || mode == 5 || mode == 11) {
     algorithm = 1;
 
-    float energy = superCluster.rawEnergy() + superCluster.preshowerEnergy(); 
-    if ( mode == 11 ) {
-      algorithm = 11;    
+    float energy = superCluster.rawEnergy() + superCluster.preshowerEnergy();
+    if (mode == 11) {
+      algorithm = 11;
       energy = superCluster.energy();
     }
 
     float correctedEnergy = fBrem(energy, brem, algorithm);
-    if ( mode == 4 ) {
+    if (mode == 4) {
       return correctedEnergy - energy;
     }
 
-    float correctedEt = correctedEnergy/cosh(eta);
+    float correctedEt = correctedEnergy / cosh(eta);
     correctedEt = fEtEta(correctedEt, eta, algorithm);
-    correctedEnergy = correctedEt*cosh(eta);
+    correctedEnergy = correctedEt * cosh(eta);
     return correctedEnergy - energy;
 
   } else {
-    
     // perform no correction
     return 0;
   }
-  
 }
 
-
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
-DEFINE_EDM_PLUGIN( EcalClusterFunctionFactory, EcalClusterEnergyCorrection, "EcalClusterEnergyCorrection");
+DEFINE_EDM_PLUGIN(EcalClusterFunctionFactory, EcalClusterEnergyCorrection, "EcalClusterEnergyCorrection");

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyCorrection.h
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyCorrection.h
@@ -13,15 +13,15 @@
 #include "RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyCorrectionBaseClass.h"
 
 class EcalClusterEnergyCorrection : public EcalClusterEnergyCorrectionBaseClass {
-        public:
-                EcalClusterEnergyCorrection( const edm::ParameterSet &){};
-                // compute the correction
-                float getValue( const reco::SuperCluster &, const int mode ) const override;
-                float getValue( const reco::BasicCluster &, const EcalRecHitCollection & ) const override { return 0.;};
+public:
+  EcalClusterEnergyCorrection(const edm::ParameterSet &){};
+  // compute the correction
+  float getValue(const reco::SuperCluster &, const int mode) const override;
+  float getValue(const reco::BasicCluster &, const EcalRecHitCollection &) const override { return 0.; };
 
-	        float fEta  (float e,  float eta, int algorithm) const;
-		float fBrem (float e,  float eta, int algorithm) const;
-		float fEtEta(float et, float eta, int algorithm) const;
+  float fEta(float e, float eta, int algorithm) const;
+  float fBrem(float e, float eta, int algorithm) const;
+  float fEtEta(float et, float eta, int algorithm) const;
 };
 
 #endif

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyCorrectionBaseClass.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyCorrectionBaseClass.cc
@@ -5,26 +5,20 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-EcalClusterEnergyCorrectionBaseClass::EcalClusterEnergyCorrectionBaseClass()
-{}
+EcalClusterEnergyCorrectionBaseClass::EcalClusterEnergyCorrectionBaseClass() {}
 
-EcalClusterEnergyCorrectionBaseClass::~EcalClusterEnergyCorrectionBaseClass()
-{}
+EcalClusterEnergyCorrectionBaseClass::~EcalClusterEnergyCorrectionBaseClass() {}
 
-void
-EcalClusterEnergyCorrectionBaseClass::init( const edm::EventSetup& es )
-{
-        es.get<EcalClusterEnergyCorrectionParametersRcd>().get( esParams_ );
-        params_ = esParams_.product();
+void EcalClusterEnergyCorrectionBaseClass::init(const edm::EventSetup& es) {
+  es.get<EcalClusterEnergyCorrectionParametersRcd>().get(esParams_);
+  params_ = esParams_.product();
 }
 
-void
-EcalClusterEnergyCorrectionBaseClass::checkInit() const
-{
-        if ( ! params_ ) {
-                // non-initialized function parameters: throw exception
-                throw cms::Exception("EcalClusterEnergyCorrectionBaseClass::checkInit()") 
-                        << "Trying to access an uninitialized crack correction function.\n"
-                        "Please call `init( edm::EventSetup &)' before any use of the function.\n";
-        }
+void EcalClusterEnergyCorrectionBaseClass::checkInit() const {
+  if (!params_) {
+    // non-initialized function parameters: throw exception
+    throw cms::Exception("EcalClusterEnergyCorrectionBaseClass::checkInit()")
+        << "Trying to access an uninitialized crack correction function.\n"
+           "Please call `init( edm::EventSetup &)' before any use of the function.\n";
+  }
 }

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyCorrectionBaseClass.h
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyCorrectionBaseClass.h
@@ -20,32 +20,31 @@
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 
 namespace edm {
-        class EventSetup;
-        class ParameterSet;
-}
+  class EventSetup;
+  class ParameterSet;
+}  // namespace edm
 
 class EcalClusterEnergyCorrectionBaseClass : public EcalClusterFunctionBaseClass {
-        public:
-                EcalClusterEnergyCorrectionBaseClass();
-                EcalClusterEnergyCorrectionBaseClass( const edm::ParameterSet & ) {};
-                ~EcalClusterEnergyCorrectionBaseClass() override;
+public:
+  EcalClusterEnergyCorrectionBaseClass();
+  EcalClusterEnergyCorrectionBaseClass(const edm::ParameterSet &){};
+  ~EcalClusterEnergyCorrectionBaseClass() override;
 
-                // get/set explicit methods for parameters
-                const EcalClusterEnergyCorrectionParameters * getParameters() const { return params_; }
-                // check initialization
-                void checkInit() const;
-                
-                // compute the correction
-                float getValue( const reco::BasicCluster &, const EcalRecHitCollection & ) const override = 0;
-                float getValue( const reco::SuperCluster &, const int mode ) const override = 0;
+  // get/set explicit methods for parameters
+  const EcalClusterEnergyCorrectionParameters *getParameters() const { return params_; }
+  // check initialization
+  void checkInit() const;
 
+  // compute the correction
+  float getValue(const reco::BasicCluster &, const EcalRecHitCollection &) const override = 0;
+  float getValue(const reco::SuperCluster &, const int mode) const override = 0;
 
-                // set parameters
-                void init( const edm::EventSetup& es ) override;
+  // set parameters
+  void init(const edm::EventSetup &es) override;
 
-        protected:
-                edm::ESHandle<EcalClusterEnergyCorrectionParameters> esParams_;
-                const EcalClusterEnergyCorrectionParameters * params_;
+protected:
+  edm::ESHandle<EcalClusterEnergyCorrectionParameters> esParams_;
+  const EcalClusterEnergyCorrectionParameters *params_;
 };
 
 #endif

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyCorrectionObjectSpecific.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyCorrectionObjectSpecific.cc
@@ -5,40 +5,39 @@
 
 // Shower leakage corrections developed by Jungzhie et al. using TB data
 // Developed for EB only!
-float EcalClusterEnergyCorrectionObjectSpecific::fEta(float energy, float eta, int algorithm) const
-{
-
+float EcalClusterEnergyCorrectionObjectSpecific::fEta(float energy, float eta, int algorithm) const {
   //std::cout << "fEta function" << std::endl;
 
   // this correction is setup only for EB
-  if ( algorithm != 0 ) return energy;
-  
-  float ieta = fabs(eta)*(5/0.087);
+  if (algorithm != 0)
+    return energy;
+
+  float ieta = fabs(eta) * (5 / 0.087);
   float p0 = (params_->params())[0];  // should be 40.2198
   float p1 = (params_->params())[1];  // should be -3.03103e-6
 
   //std::cout << "ieta=" << ieta << std::endl;
 
   float correctedEnergy = energy;
-  if ( ieta < p0 ) correctedEnergy = energy;
-  else             correctedEnergy = energy/(1.0 + p1*(ieta-p0)*(ieta-p0));
+  if (ieta < p0)
+    correctedEnergy = energy;
+  else
+    correctedEnergy = energy / (1.0 + p1 * (ieta - p0) * (ieta - p0));
   //std::cout << "ECEC fEta = " << correctedEnergy << std::endl;
   return correctedEnergy;
 }
 
-float EcalClusterEnergyCorrectionObjectSpecific::fBremEta(float sigmaPhiSigmaEta, float eta, int algorithm) const
-{
+float EcalClusterEnergyCorrectionObjectSpecific::fBremEta(float sigmaPhiSigmaEta, float eta, int algorithm) const {
+  const float etaCrackMin = 1.44;
+  const float etaCrackMax = 1.56;
 
-  const float etaCrackMin = 1.44; 
-  const float etaCrackMax = 1.56; 
-   
-  //STD 
-  const int    nBinsEta              = 14; 
-  float       leftEta  [nBinsEta]   = { 0.02, 0.25, 0.46, 0.81, 0.91, 1.01, 1.16,           etaCrackMax,  1.653,  1.8, 2.0, 2.2, 2.3, 2.4 };  
-  float       rightEta [nBinsEta]   = { 0.25, 0.42, 0.77, 0.91, 1.01, 1.13, etaCrackMin,    1.653,        1.8  ,  2.0, 2.2, 2.3, 2.4, 2.5 };  
-		
+  //STD
+  const int nBinsEta = 14;
+  float leftEta[nBinsEta] = {0.02, 0.25, 0.46, 0.81, 0.91, 1.01, 1.16, etaCrackMax, 1.653, 1.8, 2.0, 2.2, 2.3, 2.4};
+  float rightEta[nBinsEta] = {0.25, 0.42, 0.77, 0.91, 1.01, 1.13, etaCrackMin, 1.653, 1.8, 2.0, 2.2, 2.3, 2.4, 2.5};
+
   float xcorr[nBinsEta];
-  
+
   float par0[nBinsEta];
   float par1[nBinsEta];
   float par2[nBinsEta];
@@ -50,47 +49,51 @@ float EcalClusterEnergyCorrectionObjectSpecific::fBremEta(float sigmaPhiSigmaEta
 
   float sigmaPhiSigmaEtaFit = -1;
 
-  // extra protections																					   
-  // fix sigmaPhiSigmaEta boundaries 
-  if (sigmaPhiSigmaEta < sigmaPhiSigmaEtaMin)  sigmaPhiSigmaEta = sigmaPhiSigmaEtaMin; 
-  if (sigmaPhiSigmaEta > sigmaPhiSigmaEtaMax  )  sigmaPhiSigmaEta = sigmaPhiSigmaEtaMax; 
+  // extra protections
+  // fix sigmaPhiSigmaEta boundaries
+  if (sigmaPhiSigmaEta < sigmaPhiSigmaEtaMin)
+    sigmaPhiSigmaEta = sigmaPhiSigmaEtaMin;
+  if (sigmaPhiSigmaEta > sigmaPhiSigmaEtaMax)
+    sigmaPhiSigmaEta = sigmaPhiSigmaEtaMax;
 
-  // eta = 0																						   
-  if (TMath::Abs(eta)  <  leftEta[0]            ) { eta = 0.02 ; }																   
-  // outside acceptance																					   
-  if (TMath::Abs(eta)  >=  rightEta[nBinsEta-1] ) { eta = 2.49; } //if (DBG) std::cout << " WARNING [applyScCorrections]: TMath::Abs(eta)  >=  rightEta[nBinsEta-1] " << std::endl;}  
-  
-  int tmpEta = -1;                                                                                                                                                                         
-  for (int iEta = 0; iEta < nBinsEta; ++iEta){								              								      	   
-    if ( leftEta[iEta] <= TMath::Abs(eta) && TMath::Abs(eta) <rightEta[iEta] ){				       									      	   
-      tmpEta = iEta;											       										   
-    }													       										   
-  }	
+  // eta = 0
+  if (TMath::Abs(eta) < leftEta[0]) {
+    eta = 0.02;
+  }
+  // outside acceptance
+  if (TMath::Abs(eta) >= rightEta[nBinsEta - 1]) {
+    eta = 2.49;
+  }  //if (DBG) std::cout << " WARNING [applyScCorrections]: TMath::Abs(eta)  >=  rightEta[nBinsEta-1] " << std::endl;}
 
+  int tmpEta = -1;
+  for (int iEta = 0; iEta < nBinsEta; ++iEta) {
+    if (leftEta[iEta] <= TMath::Abs(eta) && TMath::Abs(eta) < rightEta[iEta]) {
+      tmpEta = iEta;
+    }
+  }
 
-  if (algorithm==0){ //Electrons
+  if (algorithm == 0) {  //Electrons
 
-    
-    xcorr[0]=(params_->params())[2] ;
-    xcorr[1]=(params_->params())[3];
-    xcorr[2]=(params_->params())[4];
-    xcorr[3]=(params_->params())[5];
-    xcorr[4]=(params_->params())[6];
-    xcorr[5]=(params_->params())[7];
-    xcorr[6]=(params_->params())[8];
-    xcorr[7]=(params_->params())[9];
-    xcorr[8]=(params_->params())[10];
-    xcorr[9]=(params_->params())[11];
-    xcorr[10]=(params_->params())[12];
-    xcorr[11]=(params_->params())[13];
-    xcorr[12]=(params_->params())[14];
-    xcorr[13]=(params_->params())[15];
+    xcorr[0] = (params_->params())[2];
+    xcorr[1] = (params_->params())[3];
+    xcorr[2] = (params_->params())[4];
+    xcorr[3] = (params_->params())[5];
+    xcorr[4] = (params_->params())[6];
+    xcorr[5] = (params_->params())[7];
+    xcorr[6] = (params_->params())[8];
+    xcorr[7] = (params_->params())[9];
+    xcorr[8] = (params_->params())[10];
+    xcorr[9] = (params_->params())[11];
+    xcorr[10] = (params_->params())[12];
+    xcorr[11] = (params_->params())[13];
+    xcorr[12] = (params_->params())[14];
+    xcorr[13] = (params_->params())[15];
 
     par0[0] = (params_->params())[16];
     par1[0] = (params_->params())[17];
     par2[0] = (params_->params())[18];
-    par3[0] = (params_->params())[19]; //should be 0 (not used)
-    par4[0] = (params_->params())[20]; //should be 0 (not used)
+    par3[0] = (params_->params())[19];  //should be 0 (not used)
+    par4[0] = (params_->params())[20];  //should be 0 (not used)
 
     par0[1] = (params_->params())[21];
     par1[1] = (params_->params())[22];
@@ -101,97 +104,94 @@ float EcalClusterEnergyCorrectionObjectSpecific::fBremEta(float sigmaPhiSigmaEta
     par0[2] = (params_->params())[26];
     par1[2] = (params_->params())[27];
     par2[2] = (params_->params())[28];
-    par3[2] = (params_->params())[29]; //should be 0 (not used)
-    par4[2] = (params_->params())[30]; //should be 0 (not used)
-
+    par3[2] = (params_->params())[29];  //should be 0 (not used)
+    par4[2] = (params_->params())[30];  //should be 0 (not used)
 
     par0[3] = (params_->params())[31];
     par1[3] = (params_->params())[32];
     par2[3] = (params_->params())[33];
-    par2[4] = (params_->params())[34];//should be 0 (not used)
-    par2[5] = (params_->params())[35];//should be 0 (not used)
+    par2[4] = (params_->params())[34];  //should be 0 (not used)
+    par2[5] = (params_->params())[35];  //should be 0 (not used)
 
     par0[4] = (params_->params())[36];
     par1[4] = (params_->params())[37];
     par2[4] = (params_->params())[38];
-    par3[4] = (params_->params())[39];//should be 0 (not used)
-    par4[4] = (params_->params())[40];//should be 0 (not used)
+    par3[4] = (params_->params())[39];  //should be 0 (not used)
+    par4[4] = (params_->params())[40];  //should be 0 (not used)
 
     par0[5] = (params_->params())[41];
     par1[5] = (params_->params())[42];
     par2[5] = (params_->params())[43];
-    par3[5] = (params_->params())[44];//should be 0 (not used)
-    par4[5] = (params_->params())[45];//should be 0 (not used)
+    par3[5] = (params_->params())[44];  //should be 0 (not used)
+    par4[5] = (params_->params())[45];  //should be 0 (not used)
 
     par0[6] = (params_->params())[46];
     par1[6] = (params_->params())[47];
     par2[6] = (params_->params())[48];
-    par3[6] = (params_->params())[49];//should be 0 (not used)
-    par4[6] = (params_->params())[50];//should be 0 (not used)
+    par3[6] = (params_->params())[49];  //should be 0 (not used)
+    par4[6] = (params_->params())[50];  //should be 0 (not used)
 
     par0[7] = (params_->params())[51];
     par1[7] = (params_->params())[52];
     par2[7] = (params_->params())[53];
-    par3[7] = (params_->params())[54];//should be 0 (not used)
-    par4[7] = (params_->params())[55];//should be 0 (not used)
+    par3[7] = (params_->params())[54];  //should be 0 (not used)
+    par4[7] = (params_->params())[55];  //should be 0 (not used)
 
     par0[8] = (params_->params())[56];
     par1[8] = (params_->params())[57];
     par2[8] = (params_->params())[58];
-    par3[8] = (params_->params())[59];//should be 0 (not used)
-    par4[8] = (params_->params())[60];//should be 0 (not used)
+    par3[8] = (params_->params())[59];  //should be 0 (not used)
+    par4[8] = (params_->params())[60];  //should be 0 (not used)
 
     par0[9] = (params_->params())[61];
     par1[9] = (params_->params())[62];
     par2[9] = (params_->params())[63];
-    par3[9] = (params_->params())[64];//should be 0 (not used)
-    par4[9] = (params_->params())[65];//should be 0 (not used)
+    par3[9] = (params_->params())[64];  //should be 0 (not used)
+    par4[9] = (params_->params())[65];  //should be 0 (not used)
 
     par0[10] = (params_->params())[66];
     par1[10] = (params_->params())[67];
     par2[10] = (params_->params())[68];
-    par3[10] = (params_->params())[69];//should be 0 (not used)
-    par4[10] = (params_->params())[70];//should be 0 (not used)
+    par3[10] = (params_->params())[69];  //should be 0 (not used)
+    par4[10] = (params_->params())[70];  //should be 0 (not used)
 
     par0[11] = (params_->params())[71];
     par1[11] = (params_->params())[72];
     par2[11] = (params_->params())[73];
-    par3[11] = (params_->params())[74];//should be 0 (not used)
-    par4[11] = (params_->params())[75];//should be 0 (not used)
+    par3[11] = (params_->params())[74];  //should be 0 (not used)
+    par4[11] = (params_->params())[75];  //should be 0 (not used)
 
     par0[12] = (params_->params())[76];
     par1[12] = (params_->params())[77];
     par2[12] = (params_->params())[78];
-    par3[12] = (params_->params())[79];//should be 0 (not used)
-    par4[12] = (params_->params())[80];//should be 0 (not used)
+    par3[12] = (params_->params())[79];  //should be 0 (not used)
+    par4[12] = (params_->params())[80];  //should be 0 (not used)
 
     par0[13] = (params_->params())[81];
     par1[13] = (params_->params())[82];
     par2[13] = (params_->params())[83];
-    par3[13] = (params_->params())[84];//should be 0 (not used)
-    par4[13] = (params_->params())[85];//should be 0 (not used)
+    par3[13] = (params_->params())[84];  //should be 0 (not used)
+    par4[13] = (params_->params())[85];  //should be 0 (not used)
 
     sigmaPhiSigmaEtaFit = 1.2;
-
   }
 
-  if (algorithm==1){ //Photons
+  if (algorithm == 1) {  //Photons
 
-
-    xcorr[0]=(params_->params())[86];
-    xcorr[1]=(params_->params())[87];
-    xcorr[2]=(params_->params())[88];
-    xcorr[3]=(params_->params())[89];
-    xcorr[4]=(params_->params())[90];
-    xcorr[5]=(params_->params())[91];
-    xcorr[6]=(params_->params())[92];
-    xcorr[7]=(params_->params())[93];
-    xcorr[8]=(params_->params())[94];
-    xcorr[9]=(params_->params())[95];
-    xcorr[10]=(params_->params())[96];
-    xcorr[11]=(params_->params())[97];
-    xcorr[12]=(params_->params())[98];
-    xcorr[13]=(params_->params())[99];
+    xcorr[0] = (params_->params())[86];
+    xcorr[1] = (params_->params())[87];
+    xcorr[2] = (params_->params())[88];
+    xcorr[3] = (params_->params())[89];
+    xcorr[4] = (params_->params())[90];
+    xcorr[5] = (params_->params())[91];
+    xcorr[6] = (params_->params())[92];
+    xcorr[7] = (params_->params())[93];
+    xcorr[8] = (params_->params())[94];
+    xcorr[9] = (params_->params())[95];
+    xcorr[10] = (params_->params())[96];
+    xcorr[11] = (params_->params())[97];
+    xcorr[12] = (params_->params())[98];
+    xcorr[13] = (params_->params())[99];
 
     par0[0] = (params_->params())[100];
     par1[0] = (params_->params())[101];
@@ -216,7 +216,7 @@ float EcalClusterEnergyCorrectionObjectSpecific::fBremEta(float sigmaPhiSigmaEta
     par2[3] = (params_->params())[117];
     par3[3] = (params_->params())[118];
     par4[3] = (params_->params())[119];
-    
+
     par0[4] = (params_->params())[120];
     par1[4] = (params_->params())[121];
     par2[4] = (params_->params())[122];
@@ -228,7 +228,7 @@ float EcalClusterEnergyCorrectionObjectSpecific::fBremEta(float sigmaPhiSigmaEta
     par2[5] = (params_->params())[127];
     par3[5] = (params_->params())[128];
     par4[5] = (params_->params())[129];
-    
+
     par0[6] = (params_->params())[130];
     par1[6] = (params_->params())[131];
     par2[6] = (params_->params())[132];
@@ -246,7 +246,7 @@ float EcalClusterEnergyCorrectionObjectSpecific::fBremEta(float sigmaPhiSigmaEta
     par2[8] = (params_->params())[142];
     par3[8] = (params_->params())[143];
     par4[8] = (params_->params())[144];
-    
+
     par0[9] = (params_->params())[145];
     par1[9] = (params_->params())[146];
     par2[9] = (params_->params())[147];
@@ -276,59 +276,62 @@ float EcalClusterEnergyCorrectionObjectSpecific::fBremEta(float sigmaPhiSigmaEta
     par2[13] = (params_->params())[167];
     par3[13] = (params_->params())[168];
     par4[13] = (params_->params())[169];
-  
+
     sigmaPhiSigmaEtaFit = 1.;
-
   }
 
-  
-												       										           
-  
-  // Interpolation																					         
-  float tmpInter = 1;																				         
-  // In eta cracks/gaps 																				         
-  if (tmpEta == -1 ) { // need to interpolate    
-    for (int iEta = 0; iEta < nBinsEta-1; ++iEta){								       								         
-      if (rightEta[iEta] <= TMath::Abs(eta) && TMath::Abs(eta) <leftEta[iEta+1] ){													         
-	if (sigmaPhiSigmaEta >= sigmaPhiSigmaEtaFit)  {
-	  if (algorithm==0){ //electron
-	    tmpInter = ( par0[iEta] + sigmaPhiSigmaEta*par1[iEta] + sigmaPhiSigmaEta*sigmaPhiSigmaEta*par2[iEta] +  
-			 par0[iEta+1] + sigmaPhiSigmaEta*par1[iEta+1] + sigmaPhiSigmaEta*sigmaPhiSigmaEta*par2[iEta+1]) / 2. ; 
-	  }
-	  if (algorithm==1){ //photon
-	    tmpInter =   (par0[iEta  ]*(1.-exp(-(sigmaPhiSigmaEta-par4[iEta  ])/par1[iEta  ]))*par2[iEta  ]*sigmaPhiSigmaEta + par3[iEta  ]+
-			  par0[iEta+1]*(1.-exp(-(sigmaPhiSigmaEta-par4[iEta+1])/par1[iEta+1]))*par2[iEta+1]*sigmaPhiSigmaEta + par3[iEta+1] ) /2.;
-	  }
-	}
-	else tmpInter = (xcorr[iEta] + xcorr[iEta+1])/2.; 
-      }																						         
-    }																						         
-    return tmpInter;																					         
-  }  		
-																					         
+  // Interpolation
+  float tmpInter = 1;
+  // In eta cracks/gaps
+  if (tmpEta == -1) {  // need to interpolate
+    for (int iEta = 0; iEta < nBinsEta - 1; ++iEta) {
+      if (rightEta[iEta] <= TMath::Abs(eta) && TMath::Abs(eta) < leftEta[iEta + 1]) {
+        if (sigmaPhiSigmaEta >= sigmaPhiSigmaEtaFit) {
+          if (algorithm == 0) {  //electron
+            tmpInter = (par0[iEta] + sigmaPhiSigmaEta * par1[iEta] + sigmaPhiSigmaEta * sigmaPhiSigmaEta * par2[iEta] +
+                        par0[iEta + 1] + sigmaPhiSigmaEta * par1[iEta + 1] +
+                        sigmaPhiSigmaEta * sigmaPhiSigmaEta * par2[iEta + 1]) /
+                       2.;
+          }
+          if (algorithm == 1) {  //photon
+            tmpInter = (par0[iEta] * (1. - exp(-(sigmaPhiSigmaEta - par4[iEta]) / par1[iEta])) * par2[iEta] *
+                            sigmaPhiSigmaEta +
+                        par3[iEta] +
+                        par0[iEta + 1] * (1. - exp(-(sigmaPhiSigmaEta - par4[iEta + 1]) / par1[iEta + 1])) *
+                            par2[iEta + 1] * sigmaPhiSigmaEta +
+                        par3[iEta + 1]) /
+                       2.;
+          }
+        } else
+          tmpInter = (xcorr[iEta] + xcorr[iEta + 1]) / 2.;
+      }
+    }
+    return tmpInter;
+  }
+
   if (sigmaPhiSigmaEta >= sigmaPhiSigmaEtaFit) {
-    if (algorithm==0) return par0[tmpEta] + sigmaPhiSigmaEta*par1[tmpEta] + sigmaPhiSigmaEta*sigmaPhiSigmaEta*par2[tmpEta]; 
-    if (algorithm==1) return par0[tmpEta  ]*(1.-exp(-(sigmaPhiSigmaEta-par4[tmpEta  ])/par1[tmpEta  ]))*par2[tmpEta  ]*sigmaPhiSigmaEta + par3[tmpEta  ];
-  }
-  else return xcorr[tmpEta]; 
-
-
+    if (algorithm == 0)
+      return par0[tmpEta] + sigmaPhiSigmaEta * par1[tmpEta] + sigmaPhiSigmaEta * sigmaPhiSigmaEta * par2[tmpEta];
+    if (algorithm == 1)
+      return par0[tmpEta] * (1. - exp(-(sigmaPhiSigmaEta - par4[tmpEta]) / par1[tmpEta])) * par2[tmpEta] *
+                 sigmaPhiSigmaEta +
+             par3[tmpEta];
+  } else
+    return xcorr[tmpEta];
 
   return 1.;
 }
 
-float EcalClusterEnergyCorrectionObjectSpecific::fEt(float ET, int algorithm) const
-{
+float EcalClusterEnergyCorrectionObjectSpecific::fEt(float ET, int algorithm) const {
+  float par0 = -1;
+  float par1 = -1;
+  float par2 = -1;
+  float par3 = -1;
+  float par4 = -1;
+  float par5 = -1;
+  float par6 = -1;
 
-  float par0 =  -1; 
-  float par1 =  -1; 
-  float par2 =  -1;	   
-  float par3 =  -1;	   
-  float par4 =  -1;     
-  float par5 =  -1;     
-  float par6 =  -1;  
-
-  if (algorithm==0){ //Electrons EB
+  if (algorithm == 0) {  //Electrons EB
 
     par0 = (params_->params())[170];
     par1 = (params_->params())[171];
@@ -337,15 +340,17 @@ float EcalClusterEnergyCorrectionObjectSpecific::fEt(float ET, int algorithm) co
     par4 = (params_->params())[174];
     //assignments to 'par5'&'par6' have been deleted from here as they serve no purpose and cause dead assignment errors
 
-    if (ET > 200) ET =200;   		  
-    if (             ET <    5 ) return         1.;  
-    if (  5 <= ET && ET <   10 ) return         par0 ;  
-    if ( 10 <= ET && ET <= 200 ) return         (par1  + ET*par2)*(1- par3*exp(ET/ par4));
-
+    if (ET > 200)
+      ET = 200;
+    if (ET < 5)
+      return 1.;
+    if (5 <= ET && ET < 10)
+      return par0;
+    if (10 <= ET && ET <= 200)
+      return (par1 + ET * par2) * (1 - par3 * exp(ET / par4));
   }
 
-
-  if (algorithm==1){ //Electrons EE
+  if (algorithm == 1) {  //Electrons EE
 
     par0 = (params_->params())[177];
     par1 = (params_->params())[178];
@@ -354,112 +359,115 @@ float EcalClusterEnergyCorrectionObjectSpecific::fEt(float ET, int algorithm) co
     par4 = (params_->params())[181];
     //assignments to variables 'par5'&'par6' have been deleted from here as they serve no purpose and cause dead assignment errors
 
-    if (ET > 200) ET =200;   		  
-    if (             ET <    5 ) return         1.;  
-    if (  5 <= ET && ET <   10 ) return         par0;  
-    if ( 10 <= ET && ET <= 200 ) return         ( par1  + ET*par2)*(1-par3*exp(ET/par4));
-
+    if (ET > 200)
+      ET = 200;
+    if (ET < 5)
+      return 1.;
+    if (5 <= ET && ET < 10)
+      return par0;
+    if (10 <= ET && ET <= 200)
+      return (par1 + ET * par2) * (1 - par3 * exp(ET / par4));
   }
 
-  
+  if (algorithm == 2) {  //Photons EB
 
-  if (algorithm==2){ //Photons EB
-
-    par0 =  (params_->params())[184]; 
-    par1 =  (params_->params())[185]; 
-    par2 =  (params_->params())[186];	   
-    par3 =  (params_->params())[187];	   
-    par4 =  (params_->params())[188];  
+    par0 = (params_->params())[184];
+    par1 = (params_->params())[185];
+    par2 = (params_->params())[186];
+    par3 = (params_->params())[187];
+    par4 = (params_->params())[188];
     //assignments to 'par5'&'par6' have been deleted from here as they serve no purpose and cause dead assignment errors
 
-    if (             ET <   5 ) return         1.;  
-    if (  5 <= ET && ET <  10 ) return         par0 ;  
-    if ( 10 <= ET && ET <  20 ) return         par1 ;  
-    if ( 20 <= ET && ET < 140 ) return         par2 + par3*ET ;  
-    if (140 <= ET             ) return         par4;  
-
+    if (ET < 5)
+      return 1.;
+    if (5 <= ET && ET < 10)
+      return par0;
+    if (10 <= ET && ET < 20)
+      return par1;
+    if (20 <= ET && ET < 140)
+      return par2 + par3 * ET;
+    if (140 <= ET)
+      return par4;
   }
 
+  if (algorithm == 3) {  //Photons EE
 
-  if (algorithm==3){ //Photons EE
-		  
-    par0 =  (params_->params())[191];
-    par1 =  (params_->params())[192]; 
-    par2 =  (params_->params())[193]; 
-    par3 =  (params_->params())[194]; 
-    par4 =  (params_->params())[195]; 
-    par5 =  (params_->params())[196]; 
-    par6 =  (params_->params())[197];
+    par0 = (params_->params())[191];
+    par1 = (params_->params())[192];
+    par2 = (params_->params())[193];
+    par3 = (params_->params())[194];
+    par4 = (params_->params())[195];
+    par5 = (params_->params())[196];
+    par6 = (params_->params())[197];
 
-    if (             ET <   5 ) return         1.;  
-    if (  5 <= ET && ET <  10 ) return          par0 ;  
-    if ( 10 <= ET && ET <  20 ) return          par1 ;  
-    if ( 20 <= ET && ET <  30 ) return          par2 ;  
-    if ( 30 <= ET && ET < 200 ) return          par3 + par4 *ET + par5 *ET*ET ;  
-    if ( 200 <= ET            ) return          par6 ;   	
-
+    if (ET < 5)
+      return 1.;
+    if (5 <= ET && ET < 10)
+      return par0;
+    if (10 <= ET && ET < 20)
+      return par1;
+    if (20 <= ET && ET < 30)
+      return par2;
+    if (30 <= ET && ET < 200)
+      return par3 + par4 * ET + par5 * ET * ET;
+    if (200 <= ET)
+      return par6;
   }
-
 
   return 1.;
 }
 
+float EcalClusterEnergyCorrectionObjectSpecific::fEnergy(float E, int algorithm) const {
+  float par0 = -1;
+  float par1 = -1;
+  float par2 = -1;
+  float par3 = -1;
+  float par4 = -1;
 
-float EcalClusterEnergyCorrectionObjectSpecific::fEnergy(float E, int algorithm) const
-{
-
-  float par0 = -1;               
-  float par1 = -1; 
-  float par2 = -1; 
-  float par3 = -1; 
-  float par4 = -1; 
-
-  if (algorithm==0){ //Electrons EB
+  if (algorithm == 0) {  //Electrons EB
     return 1.;
   }
 
+  if (algorithm == 1) {  //Electrons EE
 
-  if (algorithm==1){ //Electrons EE
-			 	  
-    par0 = (params_->params())[198];            
+    par0 = (params_->params())[198];
     par1 = (params_->params())[199];
     par2 = (params_->params())[200];
     par3 = (params_->params())[201];
     par4 = (params_->params())[202];
-   				 	  
-    if (E > par0) E =par0;   		  
-    if (             E <   0 ) return         1.;  
-    if (  0 <= E && E <= par0 ) return         (par1 + E*par2 )*(1- par3*exp(E/par4 ));
- 		
+
+    if (E > par0)
+      E = par0;
+    if (E < 0)
+      return 1.;
+    if (0 <= E && E <= par0)
+      return (par1 + E * par2) * (1 - par3 * exp(E / par4));
   }
 
-
-  if (algorithm==2){ //Photons EB
+  if (algorithm == 2) {  //Photons EB
     return 1.;
   }
 
+  if (algorithm == 3) {  //Photons EE
 
-  if (algorithm==3){ //Photons EE
-			 	  
-    par0 = (params_->params())[203];             
+    par0 = (params_->params())[203];
     par1 = (params_->params())[204];
     par2 = (params_->params())[205];
     //assignments to 'par3'&'par4' have been deleted from here as they serve no purpose and cause dead assignment errors
 
-    if (E  > par0 ) E = par0 ;   		  
-    if (            E <   0     ) return      1.;  
-    if (  0 <= E && E <=  par0  ) return      par1 + E*par2; 
-
+    if (E > par0)
+      E = par0;
+    if (E < 0)
+      return 1.;
+    if (0 <= E && E <= par0)
+      return par1 + E * par2;
   }
 
   return 1.;
 }
 
-
-
-float EcalClusterEnergyCorrectionObjectSpecific::getValue( const reco::SuperCluster & superCluster, const int mode ) const
-{
-
+float EcalClusterEnergyCorrectionObjectSpecific::getValue(const reco::SuperCluster& superCluster,
+                                                          const int mode) const {
   float corr = 1.;
   float corr2 = 1.;
   float energy = 0;
@@ -468,47 +476,46 @@ float EcalClusterEnergyCorrectionObjectSpecific::getValue( const reco::SuperClus
   //std::cout << "subdet="<< subdet<< std::endl;
 
   //std::cout << "rawEnergy=" << superCluster.rawEnergy() << " SCeta=" << superCluster.eta() << std::endl;
-  
-  if (subdet==EcalBarrel){
-    float cetacorr = fEta(superCluster.rawEnergy(), superCluster.eta(), 0)/superCluster.rawEnergy();
+
+  if (subdet == EcalBarrel) {
+    float cetacorr = fEta(superCluster.rawEnergy(), superCluster.eta(), 0) / superCluster.rawEnergy();
     //std::cout << "cetacorr=" <<cetacorr<< std::endl;
 
-    energy = superCluster.rawEnergy()*cetacorr; //previously in CMSSW
+    energy = superCluster.rawEnergy() * cetacorr;  //previously in CMSSW
     //energy = superCluster.rawEnergy()*fEta(e5x5, superCluster.seed()->eta(), 0)/e5x5;
-  }
-  else if (subdet==EcalEndcap){
-    energy = superCluster.rawEnergy()+superCluster.preshowerEnergy();
+  } else if (subdet == EcalEndcap) {
+    energy = superCluster.rawEnergy() + superCluster.preshowerEnergy();
   }
 
   float newEnergy = energy;
 
-  if (mode==0){ //Electron
+  if (mode == 0) {  //Electron
 
-    corr = fBremEta(superCluster.phiWidth()/superCluster.etaWidth(), superCluster.eta(), 0);
+    corr = fBremEta(superCluster.phiWidth() / superCluster.etaWidth(), superCluster.eta(), 0);
 
-    float et = energy*TMath::Sin(2*TMath::ATan(TMath::Exp(-superCluster.eta())))/corr;
+    float et = energy * TMath::Sin(2 * TMath::ATan(TMath::Exp(-superCluster.eta()))) / corr;
 
-    if (subdet==EcalBarrel) corr2 = corr * fEt(et, 0);
-    if (subdet==EcalEndcap) corr2 = corr * fEnergy(energy/corr, 1);
+    if (subdet == EcalBarrel)
+      corr2 = corr * fEt(et, 0);
+    if (subdet == EcalEndcap)
+      corr2 = corr * fEnergy(energy / corr, 1);
 
-    newEnergy = energy/corr2; 
-
+    newEnergy = energy / corr2;
   }
 
-  if (mode==1){ //low R9 Photons
+  if (mode == 1) {  //low R9 Photons
 
-    corr = fBremEta(superCluster.phiWidth()/superCluster.etaWidth(), superCluster.eta(), 1);
+    corr = fBremEta(superCluster.phiWidth() / superCluster.etaWidth(), superCluster.eta(), 1);
 
-    float et = energy*TMath::Sin(2*TMath::ATan(TMath::Exp(-superCluster.eta())))/corr;
+    float et = energy * TMath::Sin(2 * TMath::ATan(TMath::Exp(-superCluster.eta()))) / corr;
 
-    if (subdet==EcalBarrel) corr2 = corr * fEt(et, 2);
-    if (subdet==EcalEndcap) corr2 = corr * fEnergy(energy/corr, 3);
+    if (subdet == EcalBarrel)
+      corr2 = corr * fEt(et, 2);
+    if (subdet == EcalEndcap)
+      corr2 = corr * fEnergy(energy / corr, 3);
 
-    newEnergy = energy/corr2; 
-
+    newEnergy = energy / corr2;
   }
-
-
 
   return newEnergy;
 }
@@ -520,7 +527,7 @@ float EcalClusterEnergyCorrectionObjectSpecific::getValue( const reco::GsfElectr
   return getValue(*(electron.superCluster()), 0);
 }
 */
- /*
+/*
 float EcalClusterEnergyCorrectionObjectSpecific::getValue( const reco::Photon & photon, const int mode) const
 {
 
@@ -581,6 +588,7 @@ float EcalClusterEnergyCorrectionObjectSpecific::getValue( const reco::Photon & 
 }
  */
 
-
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
-DEFINE_EDM_PLUGIN( EcalClusterFunctionFactory, EcalClusterEnergyCorrectionObjectSpecific, "EcalClusterEnergyCorrectionObjectSpecific");
+DEFINE_EDM_PLUGIN(EcalClusterFunctionFactory,
+                  EcalClusterEnergyCorrectionObjectSpecific,
+                  "EcalClusterEnergyCorrectionObjectSpecific");

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyCorrectionObjectSpecific.h
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyCorrectionObjectSpecific.h
@@ -2,7 +2,6 @@
 #ifndef RecoEcal_EgammaCoreTools_EcalClusterEnergyCorrection_ObjectSpecific_h
 #define RecoEcal_EgammaCoreTools_EcalClusterEnergyCorrection_ObjectSpecific_h
 
-
 /** \class EcalClusterEnergyCorrectionObjectSpecific
   *  Function that provides supercluster energy correction due to Bremsstrahlung loss
   *
@@ -18,28 +17,25 @@
 #include "RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyCorrectionObjectSpecificBaseClass.h"
 
 class EcalClusterEnergyCorrectionObjectSpecific : public EcalClusterEnergyCorrectionObjectSpecificBaseClass {
-        public:
-                EcalClusterEnergyCorrectionObjectSpecific( const edm::ParameterSet &){};
-                // compute the correction
+public:
+  EcalClusterEnergyCorrectionObjectSpecific(const edm::ParameterSet &){};
+  // compute the correction
 
-		//float getValue( const reco::Photon &, const int mode) const;
-		//virtual float getValue( const reco::GsfElectron &, const int mode) const;
+  //float getValue( const reco::Photon &, const int mode) const;
+  //virtual float getValue( const reco::GsfElectron &, const int mode) const;
 
-                float getValue( const reco::SuperCluster &, const int mode) const override;
-                float getValue( const reco::BasicCluster &, const EcalRecHitCollection & ) const override { return 0.;};
+  float getValue(const reco::SuperCluster &, const int mode) const override;
+  float getValue(const reco::BasicCluster &, const EcalRecHitCollection &) const override { return 0.; };
 
-	        float fEta  (float energy, float eta, int algorithm) const;
-		//float fBrem (float e,  float eta, int algorithm) const;
-		//float fEtEta(float et, float eta, int algorithm) const;
-		float fBremEta(float sigmaPhiSigmaEta, float eta, int algorithm) const;
-		float fEt(float et, int algorithm) const;
-		float fEnergy(float e, int algorithm) const;
+  float fEta(float energy, float eta, int algorithm) const;
+  //float fBrem (float e,  float eta, int algorithm) const;
+  //float fEtEta(float et, float eta, int algorithm) const;
+  float fBremEta(float sigmaPhiSigmaEta, float eta, int algorithm) const;
+  float fEt(float et, int algorithm) const;
+  float fEnergy(float e, int algorithm) const;
 
-
-		//float r9;
-		//float e5x5;
-
+  //float r9;
+  //float e5x5;
 };
-
 
 #endif

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyCorrectionObjectSpecificBaseClass.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyCorrectionObjectSpecificBaseClass.cc
@@ -5,28 +5,20 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-EcalClusterEnergyCorrectionObjectSpecificBaseClass::EcalClusterEnergyCorrectionObjectSpecificBaseClass()
-{}
+EcalClusterEnergyCorrectionObjectSpecificBaseClass::EcalClusterEnergyCorrectionObjectSpecificBaseClass() {}
 
-EcalClusterEnergyCorrectionObjectSpecificBaseClass::~EcalClusterEnergyCorrectionObjectSpecificBaseClass()
-{}
+EcalClusterEnergyCorrectionObjectSpecificBaseClass::~EcalClusterEnergyCorrectionObjectSpecificBaseClass() {}
 
-void
-EcalClusterEnergyCorrectionObjectSpecificBaseClass::init( const edm::EventSetup& es )
-{
-  es.get<EcalClusterEnergyCorrectionObjectSpecificParametersRcd>().get( esParams_ );
+void EcalClusterEnergyCorrectionObjectSpecificBaseClass::init(const edm::EventSetup& es) {
+  es.get<EcalClusterEnergyCorrectionObjectSpecificParametersRcd>().get(esParams_);
   params_ = esParams_.product();
 }
 
-void
-EcalClusterEnergyCorrectionObjectSpecificBaseClass::checkInit() const
-{
-  
-        if ( ! params_ ) {
-                // non-initialized function parameters: throw exception
-                throw cms::Exception("EcalClusterEnergyCorrectionObjectSpecificBaseClass::checkInit()") 
-                        << "Trying to access an uninitialized correction function.\n"
-                        "Please call `init( edm::EventSetup &)' before any use of the function.\n";
-        }
-   
+void EcalClusterEnergyCorrectionObjectSpecificBaseClass::checkInit() const {
+  if (!params_) {
+    // non-initialized function parameters: throw exception
+    throw cms::Exception("EcalClusterEnergyCorrectionObjectSpecificBaseClass::checkInit()")
+        << "Trying to access an uninitialized correction function.\n"
+           "Please call `init( edm::EventSetup &)' before any use of the function.\n";
+  }
 }

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyCorrectionObjectSpecificBaseClass.h
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyCorrectionObjectSpecificBaseClass.h
@@ -22,35 +22,34 @@
 //#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 
 namespace edm {
-        class EventSetup;
-        class ParameterSet;
-}
+  class EventSetup;
+  class ParameterSet;
+}  // namespace edm
 
 class EcalClusterEnergyCorrectionObjectSpecificBaseClass : public EcalClusterFunctionBaseClass {
-        public:
-                EcalClusterEnergyCorrectionObjectSpecificBaseClass();
-                EcalClusterEnergyCorrectionObjectSpecificBaseClass( const edm::ParameterSet & ) {};
-                ~EcalClusterEnergyCorrectionObjectSpecificBaseClass() override;
+public:
+  EcalClusterEnergyCorrectionObjectSpecificBaseClass();
+  EcalClusterEnergyCorrectionObjectSpecificBaseClass(const edm::ParameterSet &){};
+  ~EcalClusterEnergyCorrectionObjectSpecificBaseClass() override;
 
-                // get/set explicit methods for parameters
-                const EcalClusterEnergyCorrectionObjectSpecificParameters * getParameters() const { return params_; }
-                // check initialization
-                void checkInit() const;
-                
-                // compute the correction
-                float getValue( const reco::BasicCluster &, const EcalRecHitCollection & ) const override = 0;
-                float getValue( const reco::SuperCluster &, const int mode ) const override = 0;
-		
-		//virtual float getValue( const reco::Photon &, const int mode) const = 0;
-		//virtual float getValue( const reco::GsfElectron &, const int mode) const;
+  // get/set explicit methods for parameters
+  const EcalClusterEnergyCorrectionObjectSpecificParameters *getParameters() const { return params_; }
+  // check initialization
+  void checkInit() const;
 
+  // compute the correction
+  float getValue(const reco::BasicCluster &, const EcalRecHitCollection &) const override = 0;
+  float getValue(const reco::SuperCluster &, const int mode) const override = 0;
 
-                // set parameters
-                void init( const edm::EventSetup& es ) override;
+  //virtual float getValue( const reco::Photon &, const int mode) const = 0;
+  //virtual float getValue( const reco::GsfElectron &, const int mode) const;
 
-        protected:
-                edm::ESHandle<EcalClusterEnergyCorrectionObjectSpecificParameters> esParams_;
-                const EcalClusterEnergyCorrectionObjectSpecificParameters * params_;
+  // set parameters
+  void init(const edm::EventSetup &es) override;
+
+protected:
+  edm::ESHandle<EcalClusterEnergyCorrectionObjectSpecificParameters> esParams_;
+  const EcalClusterEnergyCorrectionObjectSpecificParameters *params_;
 };
 
 #endif

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyUncertainty.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyUncertainty.cc
@@ -1,71 +1,72 @@
 #include "RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyUncertainty.h"
 
+float EcalClusterEnergyUncertainty::getValue(const reco::SuperCluster& superCluster, const int mode) const {
+  checkInit();
+  // mode  = -1 returns negative energy uncertainty
+  //       = +1 returns positive energy uncertainty
+  //       =  0 (default) returns overall  energy uncertainty
+  float en = superCluster.energy();
+  float eta = fabs(superCluster.eta());
+  float et = en / cosh(eta);
+  //fixing divide by zero issue for brem varible, this is the case for single crystal superclusters
+  //as these "superclusters" are likely noise or spikes so setting value to 0 as the uncertainties
+  //will be incorrect regardless so doesnt matter what it is
+  float brem = superCluster.etaWidth() != 0 ? superCluster.phiWidth() / superCluster.etaWidth() : 0;
 
-float EcalClusterEnergyUncertainty::getValue( const reco::SuperCluster & superCluster, const int mode ) const
-{
-        checkInit();
-	// mode  = -1 returns negative energy uncertainty 
-	//       = +1 returns positive energy uncertainty 
-	//       =  0 (default) returns overall  energy uncertainty 
-	float en = superCluster.energy(); 
-	float eta = fabs(superCluster.eta()); 
-	float et = en/cosh(eta); 
-	//fixing divide by zero issue for brem varible, this is the case for single crystal superclusters
-	//as these "superclusters" are likely noise or spikes so setting value to 0 as the uncertainties 
-	//will be incorrect regardless so doesnt matter what it is
-	float brem = superCluster.etaWidth()!=0 ? superCluster.phiWidth()/superCluster.etaWidth() : 0;
-	
-	int offset = 0; 
-	
-	//if ( superCluster.algoID() == reco::CaloCluster::hybrid ) offset = 0; 
-	//else if ( superCluster.algoID() == reco::CaloCluster::multi5x5 ) offset = 36; 
-        // TEMPORARY FIX!!
-	if ( eta < 1.5 ) offset = 0; 
-	else if ( eta >= 1.5 ) offset = 36; 
-	else { 
-	  // not supported now 
-	  //std::cout << "Not supported value " << superCluster.algoID() << std::endl;
-	  //std::cout << "eta = " << superCluster.eta() << std::endl;
-	  //std::cout << "phi = " << superCluster.phi() << std::endl;
-	  //std::cout << "En  = " << superCluster.energy() << std::endl;
-	  return -1; 
-	}
-	if ( mode ==  0 ) offset += 0; // total effective uncertainty 
-	else if ( mode == -1 ) offset += 12;  // negative energy uncertainty 
-	else if ( mode ==  1 ) offset += 24;  // positive energy uncertainty 
-	else {
-	  // wrong input
-	  return 0;
-	}
+  int offset = 0;
 
-	float br0_0 = (params_->params())[offset + 0]; 
-	float br0_1 = (params_->params())[offset + 1]; 
-	float br0_2 = (params_->params())[offset + 2]; 
-	float br0_3 = (params_->params())[offset + 3]; 
-	
-	float br1_0 = (params_->params())[offset + 4];  
-	float br1_1 = (params_->params())[offset + 5];  
-	float br1_2 = (params_->params())[offset + 6];  
-	float br1_3 = (params_->params())[offset + 7];  
-	
-	float br2_0 = (params_->params())[offset + 8];  
-	float br2_1 = (params_->params())[offset + 9];  
-	float br2_2 = (params_->params())[offset + 10];  
-	float br2_3 = (params_->params())[offset + 11];  
-	
-	float p0 = (br0_0 + br0_1*brem) + (br0_2 + br0_3*brem)/et;  
-	float p1 = (br1_0 + br1_1*brem) + (br1_2 + br1_3*brem)/et;  
-	float p2 = (br2_0 + br2_1*brem) + (br2_2 + br2_3*brem)/et;  
-	//std::cout << "====================================================" << std::endl;
-	//std::cout << "et = " << et << "\t eta = " << eta << std::endl;
-	//std::cout << "p0 = " << p0 << "\t p1 = " << p1 << "\t p2 = " << p2 << std::endl;
-	float uncertainty = en*(p0 + p1*fabs(eta) + p2*eta*eta);  
-	//std::cout << uncertainty << std::endl;
-	//std::cout << std::endl;
-	return uncertainty;  
+  //if ( superCluster.algoID() == reco::CaloCluster::hybrid ) offset = 0;
+  //else if ( superCluster.algoID() == reco::CaloCluster::multi5x5 ) offset = 36;
+  // TEMPORARY FIX!!
+  if (eta < 1.5)
+    offset = 0;
+  else if (eta >= 1.5)
+    offset = 36;
+  else {
+    // not supported now
+    //std::cout << "Not supported value " << superCluster.algoID() << std::endl;
+    //std::cout << "eta = " << superCluster.eta() << std::endl;
+    //std::cout << "phi = " << superCluster.phi() << std::endl;
+    //std::cout << "En  = " << superCluster.energy() << std::endl;
+    return -1;
+  }
+  if (mode == 0)
+    offset += 0;  // total effective uncertainty
+  else if (mode == -1)
+    offset += 12;  // negative energy uncertainty
+  else if (mode == 1)
+    offset += 24;  // positive energy uncertainty
+  else {
+    // wrong input
+    return 0;
+  }
 
+  float br0_0 = (params_->params())[offset + 0];
+  float br0_1 = (params_->params())[offset + 1];
+  float br0_2 = (params_->params())[offset + 2];
+  float br0_3 = (params_->params())[offset + 3];
 
+  float br1_0 = (params_->params())[offset + 4];
+  float br1_1 = (params_->params())[offset + 5];
+  float br1_2 = (params_->params())[offset + 6];
+  float br1_3 = (params_->params())[offset + 7];
+
+  float br2_0 = (params_->params())[offset + 8];
+  float br2_1 = (params_->params())[offset + 9];
+  float br2_2 = (params_->params())[offset + 10];
+  float br2_3 = (params_->params())[offset + 11];
+
+  float p0 = (br0_0 + br0_1 * brem) + (br0_2 + br0_3 * brem) / et;
+  float p1 = (br1_0 + br1_1 * brem) + (br1_2 + br1_3 * brem) / et;
+  float p2 = (br2_0 + br2_1 * brem) + (br2_2 + br2_3 * brem) / et;
+  //std::cout << "====================================================" << std::endl;
+  //std::cout << "et = " << et << "\t eta = " << eta << std::endl;
+  //std::cout << "p0 = " << p0 << "\t p1 = " << p1 << "\t p2 = " << p2 << std::endl;
+  float uncertainty = en * (p0 + p1 * fabs(eta) + p2 * eta * eta);
+  //std::cout << uncertainty << std::endl;
+  //std::cout << std::endl;
+  return uncertainty;
 }
 
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
-DEFINE_EDM_PLUGIN( EcalClusterFunctionFactory, EcalClusterEnergyUncertainty, "EcalClusterEnergyUncertainty");
+DEFINE_EDM_PLUGIN(EcalClusterFunctionFactory, EcalClusterEnergyUncertainty, "EcalClusterEnergyUncertainty");

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyUncertainty.h
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyUncertainty.h
@@ -15,12 +15,11 @@
 #include "RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyUncertaintyBaseClass.h"
 
 class EcalClusterEnergyUncertainty : public EcalClusterEnergyUncertaintyBaseClass {
-        public:
-                EcalClusterEnergyUncertainty( const edm::ParameterSet &){};
-                // compute the correction
-                float getValue( const reco::SuperCluster &, const int mode ) const override;
-                float getValue( const reco::BasicCluster &, const EcalRecHitCollection & ) const override { return 0.;};
-	
+public:
+  EcalClusterEnergyUncertainty(const edm::ParameterSet &){};
+  // compute the correction
+  float getValue(const reco::SuperCluster &, const int mode) const override;
+  float getValue(const reco::BasicCluster &, const EcalRecHitCollection &) const override { return 0.; };
 };
 
 #endif

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyUncertaintyBaseClass.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyUncertaintyBaseClass.cc
@@ -5,26 +5,20 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-EcalClusterEnergyUncertaintyBaseClass::EcalClusterEnergyUncertaintyBaseClass()
-{}
+EcalClusterEnergyUncertaintyBaseClass::EcalClusterEnergyUncertaintyBaseClass() {}
 
-EcalClusterEnergyUncertaintyBaseClass::~EcalClusterEnergyUncertaintyBaseClass()
-{}
+EcalClusterEnergyUncertaintyBaseClass::~EcalClusterEnergyUncertaintyBaseClass() {}
 
-void
-EcalClusterEnergyUncertaintyBaseClass::init( const edm::EventSetup& es )
-{
-        es.get<EcalClusterEnergyUncertaintyParametersRcd>().get( esParams_ );
-        params_ = esParams_.product();
+void EcalClusterEnergyUncertaintyBaseClass::init(const edm::EventSetup& es) {
+  es.get<EcalClusterEnergyUncertaintyParametersRcd>().get(esParams_);
+  params_ = esParams_.product();
 }
 
-void
-EcalClusterEnergyUncertaintyBaseClass::checkInit() const
-{
-        if ( ! params_ ) {
-                // non-initialized function parameters: throw exception
-                throw cms::Exception("EcalClusterEnergyUncertaintyBaseClass::checkInit()") 
-                        << "Trying to access an uninitialized crack correction function.\n"
-                        "Please call `init( edm::EventSetup &)' before any use of the function.\n";
-        }
+void EcalClusterEnergyUncertaintyBaseClass::checkInit() const {
+  if (!params_) {
+    // non-initialized function parameters: throw exception
+    throw cms::Exception("EcalClusterEnergyUncertaintyBaseClass::checkInit()")
+        << "Trying to access an uninitialized crack correction function.\n"
+           "Please call `init( edm::EventSetup &)' before any use of the function.\n";
+  }
 }

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyUncertaintyBaseClass.h
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyUncertaintyBaseClass.h
@@ -20,32 +20,31 @@
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 
 namespace edm {
-        class EventSetup;
-        class ParameterSet;
-}
+  class EventSetup;
+  class ParameterSet;
+}  // namespace edm
 
 class EcalClusterEnergyUncertaintyBaseClass : public EcalClusterFunctionBaseClass {
-        public:
-                EcalClusterEnergyUncertaintyBaseClass();
-                EcalClusterEnergyUncertaintyBaseClass( const edm::ParameterSet & ) {};
-                ~EcalClusterEnergyUncertaintyBaseClass() override;
+public:
+  EcalClusterEnergyUncertaintyBaseClass();
+  EcalClusterEnergyUncertaintyBaseClass(const edm::ParameterSet &){};
+  ~EcalClusterEnergyUncertaintyBaseClass() override;
 
-                // get/set explicit methods for parameters
-                const EcalClusterEnergyUncertaintyParameters * getParameters() const { return params_; }
-                // check initialization
-                void checkInit() const;
-                
-                // compute the correction
-                float getValue( const reco::BasicCluster &, const EcalRecHitCollection & ) const override = 0;
-                float getValue( const reco::SuperCluster &, const int mode ) const override = 0;
+  // get/set explicit methods for parameters
+  const EcalClusterEnergyUncertaintyParameters *getParameters() const { return params_; }
+  // check initialization
+  void checkInit() const;
 
+  // compute the correction
+  float getValue(const reco::BasicCluster &, const EcalRecHitCollection &) const override = 0;
+  float getValue(const reco::SuperCluster &, const int mode) const override = 0;
 
-                // set parameters
-                void init( const edm::EventSetup& es ) override;
+  // set parameters
+  void init(const edm::EventSetup &es) override;
 
-        protected:
-                edm::ESHandle<EcalClusterEnergyUncertaintyParameters> esParams_;
-                const EcalClusterEnergyUncertaintyParameters * params_;
+protected:
+  edm::ESHandle<EcalClusterEnergyUncertaintyParameters> esParams_;
+  const EcalClusterEnergyUncertaintyParameters *params_;
 };
 
 #endif

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyUncertaintyObjectSpecific.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyUncertaintyObjectSpecific.cc
@@ -1,246 +1,253 @@
 #include "RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyUncertaintyObjectSpecific.h"
 #include "TMath.h"
 
-float EcalClusterEnergyUncertaintyObjectSpecific::getValue( const reco::SuperCluster & superCluster, const int mode ) const
-{
-        checkInit();
+float EcalClusterEnergyUncertaintyObjectSpecific::getValue(const reco::SuperCluster& superCluster,
+                                                           const int mode) const {
+  checkInit();
 
-	// mode  = 0 returns electron energy uncertainty 
+  // mode  = 0 returns electron energy uncertainty
 
-	float en = superCluster.energy();
-	float eta = fabs(superCluster.eta()); 
-	float et = en/cosh(eta); 
-	float brem = superCluster.etaWidth()!=0 ? superCluster.phiWidth()/superCluster.etaWidth() : 0;
-	
-	
-	const int nBinsEta=6;
-	const float EtaBins[nBinsEta+1] = {0.0, 0.7, 1.15, 1.44, 1.56, 2.0, 2.5};
+  float en = superCluster.energy();
+  float eta = fabs(superCluster.eta());
+  float et = en / cosh(eta);
+  float brem = superCluster.etaWidth() != 0 ? superCluster.phiWidth() / superCluster.etaWidth() : 0;
 
-	const int nBinsBrem=6;
-	const float BremBins  [nBinsBrem+1]= {0.8, 1.0, 2.0, 3.0, 4.0, 5.0, 10.0};
+  const int nBinsEta = 6;
+  const float EtaBins[nBinsEta + 1] = {0.0, 0.7, 1.15, 1.44, 1.56, 2.0, 2.5};
 
-	float par0[nBinsEta][nBinsBrem];
-	float par1[nBinsEta][nBinsBrem];
-	float par2[nBinsEta][nBinsBrem];
-	float par3[nBinsEta][nBinsBrem];
+  const int nBinsBrem = 6;
+  const float BremBins[nBinsBrem + 1] = {0.8, 1.0, 2.0, 3.0, 4.0, 5.0, 10.0};
 
-	par0[0][0]=0.00640519;
-	par1[0][0]=0.257578;
-	par2[0][0]=1.72437;
-	par3[0][0]=4.04686e-06;
+  float par0[nBinsEta][nBinsBrem];
+  float par1[nBinsEta][nBinsBrem];
+  float par2[nBinsEta][nBinsBrem];
+  float par3[nBinsEta][nBinsBrem];
 
-	par0[0][1]=0.00709569;
-	par1[0][1]=0.279844;
-	par2[0][1]=1.13789;
-	par3[0][1]=1.16239e-05;
+  par0[0][0] = 0.00640519;
+  par1[0][0] = 0.257578;
+  par2[0][0] = 1.72437;
+  par3[0][0] = 4.04686e-06;
 
-	par0[0][2]=0.0075544;
-	par1[0][2]=0.341346;
-	par2[0][2]=0.513396;
-	par3[0][2]=2.90054e-06;
+  par0[0][1] = 0.00709569;
+  par1[0][1] = 0.279844;
+  par2[0][1] = 1.13789;
+  par3[0][1] = 1.16239e-05;
 
-	par0[0][3]=0.00659365;
-	par1[0][3]=0.517649;
-	par2[0][3]=-3.1847;
-	par3[0][3]=7.37152e-07;
+  par0[0][2] = 0.0075544;
+  par1[0][2] = 0.341346;
+  par2[0][2] = 0.513396;
+  par3[0][2] = 2.90054e-06;
 
-	par0[0][4]=0.00771696;
-	par1[0][4]=0.492897;
-	par2[0][4]=-1.42222;
-	par3[0][4]=0.000358677;
+  par0[0][3] = 0.00659365;
+  par1[0][3] = 0.517649;
+  par2[0][3] = -3.1847;
+  par3[0][3] = 7.37152e-07;
 
-	par0[0][5]=0.00561532;
-	par1[0][5]=0.655138;
-	par2[0][5]=-3.29839;
-	par3[0][5]=6.25898e-07;
+  par0[0][4] = 0.00771696;
+  par1[0][4] = 0.492897;
+  par2[0][4] = -1.42222;
+  par3[0][4] = 0.000358677;
 
-	par0[1][0]=0.00273646;
-	par1[1][0]=0.714568;
-	par2[1][0]=-4.82956;
-	par3[1][0]=4.45878e-07;
+  par0[0][5] = 0.00561532;
+  par1[0][5] = 0.655138;
+  par2[0][5] = -3.29839;
+  par3[0][5] = 6.25898e-07;
 
-	par0[1][1]=0.00679797;
-	par1[1][1]=0.472856;
-	par2[1][1]=-0.281699;
-	par3[1][1]=5.46479e-05;
+  par0[1][0] = 0.00273646;
+  par1[1][0] = 0.714568;
+  par2[1][0] = -4.82956;
+  par3[1][0] = 4.45878e-07;
 
-	par0[1][2]=0.00845532;
-	par1[1][2]=0.611624;
-	par2[1][2]=-1.10104;
-	par3[1][2]=1.16803e-05;
+  par0[1][1] = 0.00679797;
+  par1[1][1] = 0.472856;
+  par2[1][1] = -0.281699;
+  par3[1][1] = 5.46479e-05;
 
-	par0[1][3]=0.00831068;
-	par1[1][3]=0.853653;
-	par2[1][3]=-4.23761;
-	par3[1][3]=2.61247e-05;
+  par0[1][2] = 0.00845532;
+  par1[1][2] = 0.611624;
+  par2[1][2] = -1.10104;
+  par3[1][2] = 1.16803e-05;
 
-	par0[1][4]=0.00845457;
-	par1[1][4]=0.984985;
-	par2[1][4]=-5.19548;
-	par3[1][4]=2.05044e-07;
+  par0[1][3] = 0.00831068;
+  par1[1][3] = 0.853653;
+  par2[1][3] = -4.23761;
+  par3[1][3] = 2.61247e-05;
 
-	par0[1][5]=0.0110227;
-	par1[1][5]=1.00356;
-	par2[1][5]=-4.31936;
-	par3[1][5]=0.14384;
-	
-	par0[2][0]=-0.00192618;
-	par1[2][0]=1.69986;
-	par2[2][0]=-16.4355;
-	par3[2][0]=1.94946e-06;
-	
-	par0[2][1]=0.0067622;
-	par1[2][1]=0.792209;
-	par2[2][1]=-1.18521;
-	par3[2][1]=0.066577;
+  par0[1][4] = 0.00845457;
+  par1[1][4] = 0.984985;
+  par2[1][4] = -5.19548;
+  par3[1][4] = 2.05044e-07;
 
-	par0[2][2]=0.00761595;
-	par1[2][2]=1.03058;
-	par2[2][2]=-4.17237;
-	par3[2][2]=0.168543;
+  par0[1][5] = 0.0110227;
+  par1[1][5] = 1.00356;
+  par2[1][5] = -4.31936;
+  par3[1][5] = 0.14384;
 
-	par0[2][3]=0.0119179;
-	par1[2][3]=0.910145;
-	par2[2][3]=-2.14122;
-	par3[2][3]=0.00342264;
-	
-	par0[2][4]=0.0139921;
-	par1[2][4]=1.01488;
-	par2[2][4]=-2.46637;
-	par3[2][4]=0.0458434;
+  par0[2][0] = -0.00192618;
+  par1[2][0] = 1.69986;
+  par2[2][0] = -16.4355;
+  par3[2][0] = 1.94946e-06;
 
-	par0[2][5]=0.013724;
-	par1[2][5]=1.49078;
-	par2[2][5]=-6.60661;
-	par3[2][5]=0.297821;
-	
-	par0[3][0]=-0.00197909;
-	par1[3][0]=4.40696;
-	par2[3][0]=-4.88737;
-	par3[3][0]=4.99999;
-	
-	par0[3][1]=0.0340196;
-	par1[3][1]=3.86278;
-	par2[3][1]=-10.899;
-	par3[3][1]=0.130098;
-	
-	par0[3][2]=0.0102397;
-	par1[3][2]=8.99643;
-	par2[3][2]=-31.5122;
-	par3[3][2]=0.00118335;
-	
-	par0[3][3]=0.0110891;
-	par1[3][3]=8.01794;
-	par2[3][3]=-21.9038;
-	par3[3][3]=0.000245975;
-	
-	par0[3][4]=0.0328931;
-	par1[3][4]=4.73441;
-	par2[3][4]=-12.1148;
-	par3[3][4]=3.01721e-05;
-	
-	par0[3][5]=0.0395614;
-	par1[3][5]=3.54327;
-	par2[3][5]=-12.6514;
-	par3[3][5]=0.119761;
-	
-	par0[4][0]=0.0121809;
-	par1[4][0]=0.965608;
-	par2[4][0]=-4.19667;
-	par3[4][0]=0.129896;
-	
-	par0[4][1]=0.0168951;
-	par1[4][1]=1.0218;
-	par2[4][1]=-4.03078;
-	par3[4][1]=0.374291;
-	
-	par0[4][2]=0.0213549;
-	par1[4][2]=1.29613;
-	par2[4][2]=-4.89024;
-	par3[4][2]=0.0297165;
-	
-	par0[4][3]=0.0262602;
-	par1[4][3]=1.41674;
-	par2[4][3]=-5.94928;
-	par3[4][3]=0.19298;
-	
-	par0[4][4]=0.0334892;
-	par1[4][4]=1.48572;
-	par2[4][4]=-5.3175;
-	par3[4][4]=0.0157013;
-	
-	par0[4][5]=0.0347093;
-	par1[4][5]=1.63127;
-	par2[4][5]=-7.27426;
-	par3[4][5]=0.201164;
+  par0[2][1] = 0.0067622;
+  par1[2][1] = 0.792209;
+  par2[2][1] = -1.18521;
+  par3[2][1] = 0.066577;
 
-	par0[5][0]=0.0185321;
-	par1[5][0]=0.255205;
-	par2[5][0]=1.56798;
-	par3[5][0]=5.07655e-11;
+  par0[2][2] = 0.00761595;
+  par1[2][2] = 1.03058;
+  par2[2][2] = -4.17237;
+  par3[2][2] = 0.168543;
 
-	par0[5][1]=0.0182718;
-	par1[5][1]=0.459086;
-	par2[5][1]=-0.48198;
-	par3[5][1]=0.00114946;
-	
-	par0[5][2]=0.0175505;
-	par1[5][2]=0.92848;
-	par2[5][2]=-4.52737;
-	par3[5][2]=0.154827;
+  par0[2][3] = 0.0119179;
+  par1[2][3] = 0.910145;
+  par2[2][3] = -2.14122;
+  par3[2][3] = 0.00342264;
 
-	par0[5][3]=0.0233833;
-	par1[5][3]=0.804105;
-	par2[5][3]=-3.75131;
-	par3[5][3]=2.84172;
+  par0[2][4] = 0.0139921;
+  par1[2][4] = 1.01488;
+  par2[2][4] = -2.46637;
+  par3[2][4] = 0.0458434;
 
-	par0[5][4]=0.0334892;
-	par1[5][4]=1.48572;
-	par2[5][4]=-5.3175;
-	par3[5][4]=0.0157013;
+  par0[2][5] = 0.013724;
+  par1[2][5] = 1.49078;
+  par2[2][5] = -6.60661;
+  par3[2][5] = 0.297821;
 
-	par0[5][5]=0.0347093;
-	par1[5][5]=1.63127;
-	par2[5][5]=-7.27426;
-	par3[5][5]=0.201164;
-	
-	int iEtaSl = -1;                                                                         
-	for (int iEta = 0; iEta < nBinsEta; ++iEta){								             
-	  if ( EtaBins[iEta] <= eta && eta <EtaBins[iEta+1] ){			 
-	    iEtaSl = iEta;											       		
-	  }
-	}
-	
-	int iBremSl = -1;                                                                        
-	for (int iBrem = 0; iBrem < nBinsBrem; ++iBrem){								         
-	  if ( BremBins[iBrem] <= brem && brem <BremBins[iBrem+1] ){			 
-	    iBremSl = iBrem;											       					 
-	  }													       					
-	}
-	
-	//this code is confusing as it has no concept of under and overflow bins
-	//we will use Et as an example but also applies to eta
-	//underflow is 1st bin (naively currently labeled as 0 to 0.7, its really <0.7)
-	//overflow is the final bin (naviely currently labeled as 5 to 10, its really >=5)
-	//logic: if brem is 0<=brem <0.7 it will be already set to the 1st bin, this checks if its <0
-	//logic: if brem is 5<=brem<10 it will be set to the last bin so this then checks if its >5 at which point 
-	//it also assigns it to the last bin. The value of 5 will have already been assigned in the for
-	//loop above to the last bin so its okay that its a >5 test 
-	if (eta>EtaBins[nBinsEta-1]) iEtaSl = nBinsEta-1;
-	if (brem<BremBins[0]) iBremSl = 0;
-	if (brem>BremBins[nBinsBrem-1]) iBremSl = nBinsBrem-1;
-	
-	float uncertainty = 0;
-	if (et<=5) uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl]/(5-par2[iEtaSl][iBremSl]) + par3[iEtaSl][iBremSl]/((5-par2[iEtaSl][iBremSl])*(5-par2[iEtaSl][iBremSl]));
-	if (et>=200) uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl]/(200-par2[iEtaSl][iBremSl]) + par3[iEtaSl][iBremSl]/((200-par2[iEtaSl][iBremSl])*(200-par2[iEtaSl][iBremSl]));
-	
-	if (et>5 && et<200) uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl]/(et-par2[iEtaSl][iBremSl]) + par3[iEtaSl][iBremSl]/((et-par2[iEtaSl][iBremSl])*(et-par2[iEtaSl][iBremSl]));
- 
-	
-	return (uncertainty*en);  
-	
+  par0[3][0] = -0.00197909;
+  par1[3][0] = 4.40696;
+  par2[3][0] = -4.88737;
+  par3[3][0] = 4.99999;
 
+  par0[3][1] = 0.0340196;
+  par1[3][1] = 3.86278;
+  par2[3][1] = -10.899;
+  par3[3][1] = 0.130098;
+
+  par0[3][2] = 0.0102397;
+  par1[3][2] = 8.99643;
+  par2[3][2] = -31.5122;
+  par3[3][2] = 0.00118335;
+
+  par0[3][3] = 0.0110891;
+  par1[3][3] = 8.01794;
+  par2[3][3] = -21.9038;
+  par3[3][3] = 0.000245975;
+
+  par0[3][4] = 0.0328931;
+  par1[3][4] = 4.73441;
+  par2[3][4] = -12.1148;
+  par3[3][4] = 3.01721e-05;
+
+  par0[3][5] = 0.0395614;
+  par1[3][5] = 3.54327;
+  par2[3][5] = -12.6514;
+  par3[3][5] = 0.119761;
+
+  par0[4][0] = 0.0121809;
+  par1[4][0] = 0.965608;
+  par2[4][0] = -4.19667;
+  par3[4][0] = 0.129896;
+
+  par0[4][1] = 0.0168951;
+  par1[4][1] = 1.0218;
+  par2[4][1] = -4.03078;
+  par3[4][1] = 0.374291;
+
+  par0[4][2] = 0.0213549;
+  par1[4][2] = 1.29613;
+  par2[4][2] = -4.89024;
+  par3[4][2] = 0.0297165;
+
+  par0[4][3] = 0.0262602;
+  par1[4][3] = 1.41674;
+  par2[4][3] = -5.94928;
+  par3[4][3] = 0.19298;
+
+  par0[4][4] = 0.0334892;
+  par1[4][4] = 1.48572;
+  par2[4][4] = -5.3175;
+  par3[4][4] = 0.0157013;
+
+  par0[4][5] = 0.0347093;
+  par1[4][5] = 1.63127;
+  par2[4][5] = -7.27426;
+  par3[4][5] = 0.201164;
+
+  par0[5][0] = 0.0185321;
+  par1[5][0] = 0.255205;
+  par2[5][0] = 1.56798;
+  par3[5][0] = 5.07655e-11;
+
+  par0[5][1] = 0.0182718;
+  par1[5][1] = 0.459086;
+  par2[5][1] = -0.48198;
+  par3[5][1] = 0.00114946;
+
+  par0[5][2] = 0.0175505;
+  par1[5][2] = 0.92848;
+  par2[5][2] = -4.52737;
+  par3[5][2] = 0.154827;
+
+  par0[5][3] = 0.0233833;
+  par1[5][3] = 0.804105;
+  par2[5][3] = -3.75131;
+  par3[5][3] = 2.84172;
+
+  par0[5][4] = 0.0334892;
+  par1[5][4] = 1.48572;
+  par2[5][4] = -5.3175;
+  par3[5][4] = 0.0157013;
+
+  par0[5][5] = 0.0347093;
+  par1[5][5] = 1.63127;
+  par2[5][5] = -7.27426;
+  par3[5][5] = 0.201164;
+
+  int iEtaSl = -1;
+  for (int iEta = 0; iEta < nBinsEta; ++iEta) {
+    if (EtaBins[iEta] <= eta && eta < EtaBins[iEta + 1]) {
+      iEtaSl = iEta;
+    }
+  }
+
+  int iBremSl = -1;
+  for (int iBrem = 0; iBrem < nBinsBrem; ++iBrem) {
+    if (BremBins[iBrem] <= brem && brem < BremBins[iBrem + 1]) {
+      iBremSl = iBrem;
+    }
+  }
+
+  //this code is confusing as it has no concept of under and overflow bins
+  //we will use Et as an example but also applies to eta
+  //underflow is 1st bin (naively currently labeled as 0 to 0.7, its really <0.7)
+  //overflow is the final bin (naviely currently labeled as 5 to 10, its really >=5)
+  //logic: if brem is 0<=brem <0.7 it will be already set to the 1st bin, this checks if its <0
+  //logic: if brem is 5<=brem<10 it will be set to the last bin so this then checks if its >5 at which point
+  //it also assigns it to the last bin. The value of 5 will have already been assigned in the for
+  //loop above to the last bin so its okay that its a >5 test
+  if (eta > EtaBins[nBinsEta - 1])
+    iEtaSl = nBinsEta - 1;
+  if (brem < BremBins[0])
+    iBremSl = 0;
+  if (brem > BremBins[nBinsBrem - 1])
+    iBremSl = nBinsBrem - 1;
+
+  float uncertainty = 0;
+  if (et <= 5)
+    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (5 - par2[iEtaSl][iBremSl]) +
+                  par3[iEtaSl][iBremSl] / ((5 - par2[iEtaSl][iBremSl]) * (5 - par2[iEtaSl][iBremSl]));
+  if (et >= 200)
+    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (200 - par2[iEtaSl][iBremSl]) +
+                  par3[iEtaSl][iBremSl] / ((200 - par2[iEtaSl][iBremSl]) * (200 - par2[iEtaSl][iBremSl]));
+
+  if (et > 5 && et < 200)
+    uncertainty = par0[iEtaSl][iBremSl] + par1[iEtaSl][iBremSl] / (et - par2[iEtaSl][iBremSl]) +
+                  par3[iEtaSl][iBremSl] / ((et - par2[iEtaSl][iBremSl]) * (et - par2[iEtaSl][iBremSl]));
+
+  return (uncertainty * en);
 }
 
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
-DEFINE_EDM_PLUGIN( EcalClusterFunctionFactory, EcalClusterEnergyUncertaintyObjectSpecific, "EcalClusterEnergyUncertaintyObjectSpecific");
+DEFINE_EDM_PLUGIN(EcalClusterFunctionFactory,
+                  EcalClusterEnergyUncertaintyObjectSpecific,
+                  "EcalClusterEnergyUncertaintyObjectSpecific");

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyUncertaintyObjectSpecific.h
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyUncertaintyObjectSpecific.h
@@ -15,12 +15,11 @@
 #include "RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyUncertaintyObjectSpecificBaseClass.h"
 
 class EcalClusterEnergyUncertaintyObjectSpecific : public EcalClusterEnergyUncertaintyObjectSpecificBaseClass {
-        public:
-                EcalClusterEnergyUncertaintyObjectSpecific( const edm::ParameterSet &){};
-                // compute the correction
-                float getValue( const reco::SuperCluster &, const int mode ) const override;
-                float getValue( const reco::BasicCluster &, const EcalRecHitCollection & ) const override { return 0.;};
-	
+public:
+  EcalClusterEnergyUncertaintyObjectSpecific(const edm::ParameterSet &){};
+  // compute the correction
+  float getValue(const reco::SuperCluster &, const int mode) const override;
+  float getValue(const reco::BasicCluster &, const EcalRecHitCollection &) const override { return 0.; };
 };
 
 #endif

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyUncertaintyObjectSpecificBaseClass.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyUncertaintyObjectSpecificBaseClass.cc
@@ -5,22 +5,16 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-EcalClusterEnergyUncertaintyObjectSpecificBaseClass::EcalClusterEnergyUncertaintyObjectSpecificBaseClass()
-{}
+EcalClusterEnergyUncertaintyObjectSpecificBaseClass::EcalClusterEnergyUncertaintyObjectSpecificBaseClass() {}
 
-EcalClusterEnergyUncertaintyObjectSpecificBaseClass::~EcalClusterEnergyUncertaintyObjectSpecificBaseClass()
-{}
+EcalClusterEnergyUncertaintyObjectSpecificBaseClass::~EcalClusterEnergyUncertaintyObjectSpecificBaseClass() {}
 
-void
-EcalClusterEnergyUncertaintyObjectSpecificBaseClass::init( const edm::EventSetup& es )
-{
+void EcalClusterEnergyUncertaintyObjectSpecificBaseClass::init(const edm::EventSetup& es) {
   //es.get<EcalClusterEnergyUncertaintyParametersRcd>().get( esParams_ );
   //params_ = esParams_.product();
 }
 
-void
-EcalClusterEnergyUncertaintyObjectSpecificBaseClass::checkInit() const
-{
+void EcalClusterEnergyUncertaintyObjectSpecificBaseClass::checkInit() const {
   /*
         if ( ! params_ ) {
                 // non-initialized function parameters: throw exception

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyUncertaintyObjectSpecificBaseClass.h
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterEnergyUncertaintyObjectSpecificBaseClass.h
@@ -20,32 +20,31 @@
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 
 namespace edm {
-        class EventSetup;
-        class ParameterSet;
-}
+  class EventSetup;
+  class ParameterSet;
+}  // namespace edm
 
 class EcalClusterEnergyUncertaintyObjectSpecificBaseClass : public EcalClusterFunctionBaseClass {
-        public:
-                EcalClusterEnergyUncertaintyObjectSpecificBaseClass();
-                EcalClusterEnergyUncertaintyObjectSpecificBaseClass( const edm::ParameterSet & ) {};
-                ~EcalClusterEnergyUncertaintyObjectSpecificBaseClass() override;
+public:
+  EcalClusterEnergyUncertaintyObjectSpecificBaseClass();
+  EcalClusterEnergyUncertaintyObjectSpecificBaseClass(const edm::ParameterSet &){};
+  ~EcalClusterEnergyUncertaintyObjectSpecificBaseClass() override;
 
-                // get/set explicit methods for parameters
-                //const EcalClusterEnergyUncertaintyParameters * getParameters() const { return params_; }
-                // check initialization
-                void checkInit() const;
-                
-                // compute the correction
-                float getValue( const reco::BasicCluster &, const EcalRecHitCollection & ) const override = 0;
-                float getValue( const reco::SuperCluster &, const int mode ) const override = 0;
+  // get/set explicit methods for parameters
+  //const EcalClusterEnergyUncertaintyParameters * getParameters() const { return params_; }
+  // check initialization
+  void checkInit() const;
 
+  // compute the correction
+  float getValue(const reco::BasicCluster &, const EcalRecHitCollection &) const override = 0;
+  float getValue(const reco::SuperCluster &, const int mode) const override = 0;
 
-                // set parameters
-                void init( const edm::EventSetup& es ) override;
+  // set parameters
+  void init(const edm::EventSetup &es) override;
 
-        protected:
-                //edm::ESHandle<EcalClusterEnergyUncertaintyObjectSpecificParameters> esParams_;
-                //const EcalClusterEnergyUncertaintyObjectSpecificParameters * params_;
+protected:
+  //edm::ESHandle<EcalClusterEnergyUncertaintyObjectSpecificParameters> esParams_;
+  //const EcalClusterEnergyUncertaintyObjectSpecificParameters * params_;
 };
 
 #endif

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterLocalContCorrection.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterLocalContCorrection.cc
@@ -24,141 +24,144 @@
 using namespace std;
 using namespace edm;
 
-float EcalClusterLocalContCorrection::getValue( const reco::BasicCluster & basicCluster, const EcalRecHitCollection & recHit) const
-{
-        checkInit();
-        // private member params_ = EcalClusterLocalContCorrectionParameters
-        // (see in CondFormats/EcalObjects/interface)
-        EcalFunctionParameters::const_iterator it;
-        std::cout << "[[EcalClusterLocalContCorrection::getValue]] " 
-                << params_->params().size() << " parameters:";
-        for ( it = params_->params().begin(); it != params_->params().end(); ++it ) {
-                std::cout << " " << *it;
-        }
-        std::cout << "\n";
-        return 1;
+float EcalClusterLocalContCorrection::getValue(const reco::BasicCluster& basicCluster,
+                                               const EcalRecHitCollection& recHit) const {
+  checkInit();
+  // private member params_ = EcalClusterLocalContCorrectionParameters
+  // (see in CondFormats/EcalObjects/interface)
+  EcalFunctionParameters::const_iterator it;
+  std::cout << "[[EcalClusterLocalContCorrection::getValue]] " << params_->params().size() << " parameters:";
+  for (it = params_->params().begin(); it != params_->params().end(); ++it) {
+    std::cout << " " << *it;
+  }
+  std::cout << "\n";
+  return 1;
 }
 
-
-float EcalClusterLocalContCorrection::getValue( const reco::SuperCluster & superCluster, const int mode ) const
-{
+float EcalClusterLocalContCorrection::getValue(const reco::SuperCluster& superCluster, const int mode) const {
   checkInit();
-  
+
   //correction factor to be returned, and to be calculated in this present function:
-  double correction_factor=1.;
-  double fetacor=1.; //eta dependent part of the correction factor
-  double fphicor=1.; //phi dependent part of the correction factor
+  double correction_factor = 1.;
+  double fetacor = 1.;  //eta dependent part of the correction factor
+  double fphicor = 1.;  //phi dependent part of the correction factor
 
   //********************************************************************************************************************//
   //These local containment corrections correct a photon energy for leakage outside a 5x5 crystal cluster. They  depend on the local position in the hit crystal. The local position coordinates, called later EtaCry and PhiCry in the code, are comprised between -0.5 and 0.5 and correspond to the distance between the photon supercluster position and the center of the hit crystal, expressed in number of  crystal widthes. The correction parameters (that should be filled in CalibCalorimetry/EcalTrivialCondModules/python/EcalTrivialCondRetriever_cfi.py) were calculated using simulaion and thus take into account the effect of the magnetic field. They  only apply to unconverted photons in the barrel, but a use for non brem electrons could be considered (not tested yet). For more details, cf the CMS internal note 2009-013 by S. Tourneur and C. Seez
 
   //Beware: The user should make sure it only uses this correction factor for unconverted photons (or not breming electrons)
 
+  const reco::CaloClusterPtr& seedbclus = superCluster.seed();
 
-  const reco::CaloClusterPtr & seedbclus =  superCluster.seed();
-  
   //If not barrel, return 1:
-  if (TMath::Abs(seedbclus->eta()) >1.4442 ) return 1.;
-  
+  if (TMath::Abs(seedbclus->eta()) > 1.4442)
+    return 1.;
+
   edm::ESHandle<CaloGeometry> pG;
-  es_->get<CaloGeometryRecord>().get(pG); 
-  
-  const CaloSubdetectorGeometry* geom=pG->getSubdetectorGeometry(DetId::Ecal,EcalBarrel);//EcalBarrel = 1
-  
-  const math::XYZPoint position_ = seedbclus->position(); 
-  double Theta = -position_.theta()+0.5*TMath::Pi();
+  es_->get<CaloGeometryRecord>().get(pG);
+
+  const CaloSubdetectorGeometry* geom = pG->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);  //EcalBarrel = 1
+
+  const math::XYZPoint position_ = seedbclus->position();
+  double Theta = -position_.theta() + 0.5 * TMath::Pi();
   double Eta = position_.eta();
   double Phi = TVector2::Phi_mpi_pi(position_.phi());
-  
+
   //Calculate expected depth of the maximum shower from energy (like in PositionCalc::Calculate_Location()):
   // The parameters X0 and T0 are hardcoded here because these values were used to calculate the corrections:
-  const float X0 = 0.89; const float T0 = 7.4;
+  const float X0 = 0.89;
+  const float T0 = 7.4;
   double depth = X0 * (T0 + log(seedbclus->energy()));
-  
-  
+
   //search which crystal is closest to the cluster position and call it crystalseed:
   //std::vector<DetId> crystals_vector = seedbclus->getHitsByDetId();   //deprecated
-  std::vector< std::pair<DetId, float> > crystals_vector = seedbclus->hitsAndFractions();
-  float dphimin=999.;
-  float detamin=999.;
+  std::vector<std::pair<DetId, float> > crystals_vector = seedbclus->hitsAndFractions();
+  float dphimin = 999.;
+  float detamin = 999.;
   int ietaclosest = 0;
   int iphiclosest = 0;
-  for (unsigned int icry=0; icry!=crystals_vector.size(); ++icry) {    
+  for (unsigned int icry = 0; icry != crystals_vector.size(); ++icry) {
     EBDetId crystal(crystals_vector[icry].first);
     auto cell = geom->getGeometry(crystal);
     GlobalPoint center_pos = cell->getPosition(depth);
     double EtaCentr = center_pos.eta();
     double PhiCentr = TVector2::Phi_mpi_pi(center_pos.phi());
-    if (TMath::Abs(EtaCentr-Eta) < detamin) {
-      detamin = TMath::Abs(EtaCentr-Eta); 
+    if (TMath::Abs(EtaCentr - Eta) < detamin) {
+      detamin = TMath::Abs(EtaCentr - Eta);
       ietaclosest = crystal.ieta();
     }
-    if (TMath::Abs(TVector2::Phi_mpi_pi(PhiCentr-Phi)) < dphimin) {
-      dphimin = TMath::Abs(TVector2::Phi_mpi_pi(PhiCentr-Phi)); 
+    if (TMath::Abs(TVector2::Phi_mpi_pi(PhiCentr - Phi)) < dphimin) {
+      dphimin = TMath::Abs(TVector2::Phi_mpi_pi(PhiCentr - Phi));
       iphiclosest = crystal.iphi();
     }
   }
   EBDetId crystalseed(ietaclosest, iphiclosest);
-  
+
   // Get center cell position from shower depth
   auto cell = geom->getGeometry(crystalseed);
   GlobalPoint center_pos = cell->getPosition(depth);
-  
+
   //if the seed crystal is neighbourgh of a supermodule border, don't apply the phi dependent  containment corrections, but use the larger crack corrections instead.
-  int iphimod20 = TMath::Abs(iphiclosest%20);
-   if ( iphimod20 <=1 ) fphicor=1.;
+  int iphimod20 = TMath::Abs(iphiclosest % 20);
+  if (iphimod20 <= 1)
+    fphicor = 1.;
 
-   else{
-      double PhiCentr = TVector2::Phi_mpi_pi(center_pos.phi());
-      double PhiWidth = (TMath::Pi()/180.);
-      double PhiCry = (TVector2::Phi_mpi_pi(Phi-PhiCentr))/PhiWidth;
-      if (PhiCry>0.5) PhiCry=0.5;
-      if (PhiCry<-0.5) PhiCry=-0.5;
-       //Some flips to take into account ECAL barrel symmetries:
-      if (ietaclosest<0) PhiCry *= -1.;
-      
-      //Fetching parameters of the polynomial (see  CMS IN-2009/013)
-      double g[5];
-      for (int k=0; k!=5; ++k) g[k] = (params_->params())[k+5];
-      
-      fphicor=0.;
-      for (int k=0; k!=5; ++k) fphicor += g[k]*std::pow(PhiCry,k);
-   }
-   
-   //if the seed crystal is neighbourgh of a module border, don't apply the eta dependent  containment corrections, but use the larger crack corrections instead.
-  int ietamod20 = TMath::Abs(ietaclosest%20);
-  if (TMath::Abs(ietaclosest) >24 && (ietamod20==5 || ietamod20==6) ) fetacor = 1.;
-  
-  else
-    {      
-      double ThetaCentr = -center_pos.theta()+0.5*TMath::Pi();
-      double ThetaWidth = (TMath::Pi()/180.)*TMath::Cos(ThetaCentr);
-      double EtaCry = (Theta-ThetaCentr)/ThetaWidth;    
-      if (EtaCry>0.5) EtaCry=0.5;
-      if (EtaCry<-0.5) EtaCry=-0.5;
-      //flip to take into account ECAL barrel symmetries:
-      if (ietaclosest<0) EtaCry *= -1.;
-      
-      //Fetching parameters of the polynomial (see  CMS IN-2009/013)
-      double f[5];
-      for (int k=0; k!=5; ++k) f[k] = (params_->params())[k];
-     
-      fetacor=0.;
-      for (int k=0; k!=5; ++k) fetacor += f[k]*std::pow(EtaCry,k);
-    }
-  
+  else {
+    double PhiCentr = TVector2::Phi_mpi_pi(center_pos.phi());
+    double PhiWidth = (TMath::Pi() / 180.);
+    double PhiCry = (TVector2::Phi_mpi_pi(Phi - PhiCentr)) / PhiWidth;
+    if (PhiCry > 0.5)
+      PhiCry = 0.5;
+    if (PhiCry < -0.5)
+      PhiCry = -0.5;
+    //Some flips to take into account ECAL barrel symmetries:
+    if (ietaclosest < 0)
+      PhiCry *= -1.;
 
-  correction_factor  = (params_->params())[10]/(fetacor*fphicor);
-  
+    //Fetching parameters of the polynomial (see  CMS IN-2009/013)
+    double g[5];
+    for (int k = 0; k != 5; ++k)
+      g[k] = (params_->params())[k + 5];
+
+    fphicor = 0.;
+    for (int k = 0; k != 5; ++k)
+      fphicor += g[k] * std::pow(PhiCry, k);
+  }
+
+  //if the seed crystal is neighbourgh of a module border, don't apply the eta dependent  containment corrections, but use the larger crack corrections instead.
+  int ietamod20 = TMath::Abs(ietaclosest % 20);
+  if (TMath::Abs(ietaclosest) > 24 && (ietamod20 == 5 || ietamod20 == 6))
+    fetacor = 1.;
+
+  else {
+    double ThetaCentr = -center_pos.theta() + 0.5 * TMath::Pi();
+    double ThetaWidth = (TMath::Pi() / 180.) * TMath::Cos(ThetaCentr);
+    double EtaCry = (Theta - ThetaCentr) / ThetaWidth;
+    if (EtaCry > 0.5)
+      EtaCry = 0.5;
+    if (EtaCry < -0.5)
+      EtaCry = -0.5;
+    //flip to take into account ECAL barrel symmetries:
+    if (ietaclosest < 0)
+      EtaCry *= -1.;
+
+    //Fetching parameters of the polynomial (see  CMS IN-2009/013)
+    double f[5];
+    for (int k = 0; k != 5; ++k)
+      f[k] = (params_->params())[k];
+
+    fetacor = 0.;
+    for (int k = 0; k != 5; ++k)
+      fetacor += f[k] * std::pow(EtaCry, k);
+  }
+
+  correction_factor = (params_->params())[10] / (fetacor * fphicor);
+
   //*********************************************************************************************************************//
-  
+
   //return the correction factor. Use it to multiply the cluster energy.
   return correction_factor;
 }
 
-
-
-
-
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
-DEFINE_EDM_PLUGIN( EcalClusterFunctionFactory, EcalClusterLocalContCorrection, "EcalClusterLocalContCorrection");
+DEFINE_EDM_PLUGIN(EcalClusterFunctionFactory, EcalClusterLocalContCorrection, "EcalClusterLocalContCorrection");

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterLocalContCorrection.h
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterLocalContCorrection.h
@@ -13,11 +13,11 @@
 #include "RecoEcal/EgammaCoreTools/plugins/EcalClusterLocalContCorrectionBaseClass.h"
 
 class EcalClusterLocalContCorrection : public EcalClusterLocalContCorrectionBaseClass {
-        public:
-                EcalClusterLocalContCorrection( const edm::ParameterSet &) {};
-                // compute the correction
-                float getValue( const reco::BasicCluster &, const EcalRecHitCollection & ) const override;
-                float getValue( const reco::SuperCluster &, const int mode ) const override;
+public:
+  EcalClusterLocalContCorrection(const edm::ParameterSet &){};
+  // compute the correction
+  float getValue(const reco::BasicCluster &, const EcalRecHitCollection &) const override;
+  float getValue(const reco::SuperCluster &, const int mode) const override;
 };
 
 #endif

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterLocalContCorrectionBaseClass.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterLocalContCorrectionBaseClass.cc
@@ -5,27 +5,21 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-EcalClusterLocalContCorrectionBaseClass::EcalClusterLocalContCorrectionBaseClass()
-{}
+EcalClusterLocalContCorrectionBaseClass::EcalClusterLocalContCorrectionBaseClass() {}
 
-EcalClusterLocalContCorrectionBaseClass::~EcalClusterLocalContCorrectionBaseClass()
-{}
+EcalClusterLocalContCorrectionBaseClass::~EcalClusterLocalContCorrectionBaseClass() {}
 
-void
-EcalClusterLocalContCorrectionBaseClass::init( const edm::EventSetup& es )
-{
-        es.get<EcalClusterLocalContCorrParametersRcd>().get( esParams_ );
-        params_ = esParams_.product();
-	es_ = &es; //needed to access the ECAL geometry
+void EcalClusterLocalContCorrectionBaseClass::init(const edm::EventSetup& es) {
+  es.get<EcalClusterLocalContCorrParametersRcd>().get(esParams_);
+  params_ = esParams_.product();
+  es_ = &es;  //needed to access the ECAL geometry
 }
 
-void
-EcalClusterLocalContCorrectionBaseClass::checkInit() const
-{
-        if ( ! params_ ) {
-                // non-initialized function parameters: throw exception
-                throw cms::Exception("EcalClusterLocalContCorrectionBaseClass::checkInit()") 
-                        << "Trying to access an uninitialized crack correction function.\n"
-                        "Please call `init( edm::EventSetup &)' before any use of the function.\n";
-        }
+void EcalClusterLocalContCorrectionBaseClass::checkInit() const {
+  if (!params_) {
+    // non-initialized function parameters: throw exception
+    throw cms::Exception("EcalClusterLocalContCorrectionBaseClass::checkInit()")
+        << "Trying to access an uninitialized crack correction function.\n"
+           "Please call `init( edm::EventSetup &)' before any use of the function.\n";
+  }
 }

--- a/RecoEcal/EgammaCoreTools/plugins/EcalClusterLocalContCorrectionBaseClass.h
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalClusterLocalContCorrectionBaseClass.h
@@ -21,33 +21,32 @@
 #include "DataFormats/EgammaReco/interface/BasicCluster.h"
 
 namespace edm {
-        class EventSetup;
-        class ParameterSet;
-}
+  class EventSetup;
+  class ParameterSet;
+}  // namespace edm
 
 class EcalClusterLocalContCorrectionBaseClass : public EcalClusterFunctionBaseClass {
-        public:
-                EcalClusterLocalContCorrectionBaseClass();
-                EcalClusterLocalContCorrectionBaseClass( const edm::ParameterSet & ) {};
-                ~EcalClusterLocalContCorrectionBaseClass() override;
+public:
+  EcalClusterLocalContCorrectionBaseClass();
+  EcalClusterLocalContCorrectionBaseClass(const edm::ParameterSet &){};
+  ~EcalClusterLocalContCorrectionBaseClass() override;
 
-                // get/set explicit methods for parameters
-                const EcalClusterLocalContCorrParameters * getParameters() const { return params_; }
-                // check initialization
-                void checkInit() const;
-                
-                // compute the correction
-                float getValue( const reco::BasicCluster &, const EcalRecHitCollection & ) const override = 0;
-                float getValue( const reco::SuperCluster &, const int mode ) const override = 0;
+  // get/set explicit methods for parameters
+  const EcalClusterLocalContCorrParameters *getParameters() const { return params_; }
+  // check initialization
+  void checkInit() const;
 
-                // set parameters
-                void init( const edm::EventSetup& es ) override;
+  // compute the correction
+  float getValue(const reco::BasicCluster &, const EcalRecHitCollection &) const override = 0;
+  float getValue(const reco::SuperCluster &, const int mode) const override = 0;
 
-        protected:
-                edm::ESHandle<EcalClusterLocalContCorrParameters> esParams_;
-                const EcalClusterLocalContCorrParameters * params_;
-		const edm::EventSetup * es_; //needed to access the ECAL geometry
-		 
+  // set parameters
+  void init(const edm::EventSetup &es) override;
+
+protected:
+  edm::ESHandle<EcalClusterLocalContCorrParameters> esParams_;
+  const EcalClusterLocalContCorrParameters *params_;
+  const edm::EventSetup *es_;  //needed to access the ECAL geometry
 };
 
 #endif

--- a/RecoEcal/EgammaCoreTools/plugins/EcalNextToDeadChannelESProducer.cc
+++ b/RecoEcal/EgammaCoreTools/plugins/EcalNextToDeadChannelESProducer.cc
@@ -22,25 +22,18 @@
    \date 18 May 2011
 */
 
-
 class EcalNextToDeadChannelESProducer : public edm::ESProducer {
-  
 public:
   EcalNextToDeadChannelESProducer(const edm::ParameterSet& iConfig);
-  
-  typedef std::shared_ptr<EcalNextToDeadChannel> ReturnType;
-  
-  ReturnType produce(const EcalNextToDeadChannelRcd& iRecord);
-  
 
+  typedef std::shared_ptr<EcalNextToDeadChannel> ReturnType;
+
+  ReturnType produce(const EcalNextToDeadChannelRcd& iRecord);
 
 private:
+  void setupNextToDeadChannels(const EcalChannelStatusRcd&, EcalNextToDeadChannel*);
 
-  void setupNextToDeadChannels(const EcalChannelStatusRcd&,
-                               EcalNextToDeadChannel*);
-
-  using HostType = edm::ESProductHost<EcalNextToDeadChannel,
-                                      EcalChannelStatusRcd>;
+  using HostType = edm::ESProductHost<EcalNextToDeadChannel, EcalChannelStatusRcd>;
 
   edm::ReusableObjectHolder<HostType> holder_;
 
@@ -48,90 +41,68 @@ private:
   int statusThreshold_;
 };
 
-EcalNextToDeadChannelESProducer::EcalNextToDeadChannelESProducer(const edm::ParameterSet& iConfig){
+EcalNextToDeadChannelESProducer::EcalNextToDeadChannelESProducer(const edm::ParameterSet& iConfig) {
   //the following line is needed to tell the framework what
   // data is being produced
   setWhatProduced(this);
 
-  statusThreshold_= iConfig.getParameter<int>("channelStatusThresholdForDead");
+  statusThreshold_ = iConfig.getParameter<int>("channelStatusThresholdForDead");
 }
 
+EcalNextToDeadChannelESProducer::ReturnType EcalNextToDeadChannelESProducer::produce(
+    const EcalNextToDeadChannelRcd& iRecord) {
+  auto host = holder_.makeOrGet([]() { return new HostType; });
 
-
-EcalNextToDeadChannelESProducer::ReturnType
-EcalNextToDeadChannelESProducer::produce(const EcalNextToDeadChannelRcd& iRecord){
-
-  auto host = holder_.makeOrGet([]() {
-    return new HostType;
-  });
-
-  host->ifRecordChanges<EcalChannelStatusRcd>(iRecord,
-                                              [this,h=host.get()](auto const& rec) {
-    setupNextToDeadChannels(rec, h);
-  });
+  host->ifRecordChanges<EcalChannelStatusRcd>(
+      iRecord, [this, h = host.get()](auto const& rec) { setupNextToDeadChannels(rec, h); });
 
   return host;
 }
 
-
-void 
-EcalNextToDeadChannelESProducer::
-setupNextToDeadChannels(const EcalChannelStatusRcd& chs,
-                        EcalNextToDeadChannel* rcd){
-
+void EcalNextToDeadChannelESProducer::setupNextToDeadChannels(const EcalChannelStatusRcd& chs,
+                                                              EcalNextToDeadChannel* rcd) {
   rcd->clear();
 
   // Find channels next to dead ones and fill corresponding record
 
-  edm::ESHandle <EcalChannelStatus> h;
-  chs.get (h);
-  
-  for(int ieta=-EBDetId::MAX_IETA; ieta<=EBDetId::MAX_IETA; ++ieta) {
-    if(ieta==0) continue;
-    for(int iphi=EBDetId::MIN_IPHI; iphi<=EBDetId::MAX_IPHI; ++iphi) {
-      if (EBDetId::validDetId(ieta,iphi)) {
-	
-	EBDetId detid(ieta,iphi);
-	
-	if (EcalTools::isNextToDeadFromNeighbours(detid,
-						  *h,
-						  statusThreshold_)){
-	  
-	  
-	  rcd->setValue(detid,1);
-	};
+  edm::ESHandle<EcalChannelStatus> h;
+  chs.get(h);
+
+  for (int ieta = -EBDetId::MAX_IETA; ieta <= EBDetId::MAX_IETA; ++ieta) {
+    if (ieta == 0)
+      continue;
+    for (int iphi = EBDetId::MIN_IPHI; iphi <= EBDetId::MAX_IPHI; ++iphi) {
+      if (EBDetId::validDetId(ieta, iphi)) {
+        EBDetId detid(ieta, iphi);
+
+        if (EcalTools::isNextToDeadFromNeighbours(detid, *h, statusThreshold_)) {
+          rcd->setValue(detid, 1);
+        };
       }
-    } // for phi
-  } // for eta
-  
+    }  // for phi
+  }    // for eta
+
   // endcap
 
-  for(int iX=EEDetId::IX_MIN; iX<=EEDetId::IX_MAX ;++iX) {
-    for(int iY=EEDetId::IY_MIN; iY<=EEDetId::IY_MAX; ++iY) {
-  
-      if (EEDetId::validDetId(iX,iY,1)) {
-	EEDetId detid(iX,iY,1);
+  for (int iX = EEDetId::IX_MIN; iX <= EEDetId::IX_MAX; ++iX) {
+    for (int iY = EEDetId::IY_MIN; iY <= EEDetId::IY_MAX; ++iY) {
+      if (EEDetId::validDetId(iX, iY, 1)) {
+        EEDetId detid(iX, iY, 1);
 
-	if (EcalTools::isNextToDeadFromNeighbours(detid,
-						  *h,
-						  statusThreshold_)){
-	  rcd->setValue(detid,1);
-	};
-	
+        if (EcalTools::isNextToDeadFromNeighbours(detid, *h, statusThreshold_)) {
+          rcd->setValue(detid, 1);
+        };
       }
 
-      if (EEDetId::validDetId(iX,iY,-1)) {
-	EEDetId detid(iX,iY,-1);
+      if (EEDetId::validDetId(iX, iY, -1)) {
+        EEDetId detid(iX, iY, -1);
 
-	if (EcalTools::isNextToDeadFromNeighbours(detid,
-						  *h,
-						  statusThreshold_)){
-     
-	  rcd->setValue(detid,1);
-	};
+        if (EcalTools::isNextToDeadFromNeighbours(detid, *h, statusThreshold_)) {
+          rcd->setValue(detid, 1);
+        };
       }
-    } // for iy
-  } // for ix
+    }  // for iy
+  }    // for ix
 }
 
 //define this as a plug-in

--- a/RecoEcal/EgammaCoreTools/src/BremRecoveryPhiRoadAlgo.cc
+++ b/RecoEcal/EgammaCoreTools/src/BremRecoveryPhiRoadAlgo.cc
@@ -4,50 +4,40 @@
 
 #include <iostream>
 
-BremRecoveryPhiRoadAlgo::BremRecoveryPhiRoadAlgo(const edm::ParameterSet& pset)
-{
+BremRecoveryPhiRoadAlgo::BremRecoveryPhiRoadAlgo(const edm::ParameterSet& pset) {
+  // get barrel and endcap parametersets
+  edm::ParameterSet barrelPset = pset.getParameter<edm::ParameterSet>("barrel");
+  edm::ParameterSet endcapPset = pset.getParameter<edm::ParameterSet>("endcap");
 
-   // get barrel and endcap parametersets
-   edm::ParameterSet barrelPset = pset.getParameter<edm::ParameterSet>("barrel");
-   edm::ParameterSet endcapPset = pset.getParameter<edm::ParameterSet>("endcap");
+  // set barrel parameters
+  etVec_ = barrelPset.getParameter<std::vector<double> >("etVec");
+  cryVec_ = barrelPset.getParameter<std::vector<int> >("cryVec");
+  cryMin_ = barrelPset.getParameter<int>("cryMin");
 
-   // set barrel parameters
-   etVec_ = barrelPset.getParameter<std::vector<double> >("etVec");
-   cryVec_ = barrelPset.getParameter<std::vector<int> >("cryVec");
-   cryMin_ = barrelPset.getParameter<int>("cryMin");
-
-   // set endcap parameters
-   a_ = endcapPset.getParameter<double>("a");
-   b_ = endcapPset.getParameter<double>("b");
-   c_ = endcapPset.getParameter<double>("c");
-
+  // set endcap parameters
+  a_ = endcapPset.getParameter<double>("a");
+  b_ = endcapPset.getParameter<double>("b");
+  c_ = endcapPset.getParameter<double>("c");
 }
 
-int BremRecoveryPhiRoadAlgo::barrelPhiRoad(double et)
-{
+int BremRecoveryPhiRoadAlgo::barrelPhiRoad(double et) {
+  //
+  // Take as input the ET in 5x5 crystals
+  // and compute the optimal phi road
+  // as a number of crystals
 
-   // 
-   // Take as input the ET in 5x5 crystals
-   // and compute the optimal phi road 
-   // as a number of crystals
-
-   for (unsigned int i = 0; i < cryVec_.size(); ++i)
-   {
-      if (et < etVec_[i]) return cryVec_[i];
-   }
-   return cryMin_;
-
+  for (unsigned int i = 0; i < cryVec_.size(); ++i) {
+    if (et < etVec_[i])
+      return cryVec_[i];
+  }
+  return cryMin_;
 }
 
-double BremRecoveryPhiRoadAlgo::endcapPhiRoad(double energy)
-{
+double BremRecoveryPhiRoadAlgo::endcapPhiRoad(double energy) {
+  //
+  // Take as input the energy in the seed BasicCluster
+  // and return the optimal phi road
+  // length in radians
 
-   //
-   // Take as input the energy in the seed BasicCluster
-   // and return the optimal phi road
-   // length in radians
-
-   return ((a_ / (energy + b_)) + c_);
-
+  return ((a_ / (energy + b_)) + c_);
 }
-

--- a/RecoEcal/EgammaCoreTools/src/ClusterShapeAlgo.cc
+++ b/RecoEcal/EgammaCoreTools/src/ClusterShapeAlgo.cc
@@ -16,17 +16,15 @@
 #include "CLHEP/Geometry/Transform3D.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
-ClusterShapeAlgo::ClusterShapeAlgo(const edm::ParameterSet& par) : 
-  parameterSet_(par) {}
+ClusterShapeAlgo::ClusterShapeAlgo(const edm::ParameterSet& par) : parameterSet_(par) {}
 
-reco::ClusterShape ClusterShapeAlgo::Calculate(const reco::BasicCluster &passedCluster,
-                                               const EcalRecHitCollection *hits,
-                                               const CaloSubdetectorGeometry * geometry,
-                                               const CaloSubdetectorTopology* topology)
-{
-  Calculate_TopEnergy(passedCluster,hits);
-  Calculate_2ndEnergy(passedCluster,hits);
-  Create_Map(hits,topology);
+reco::ClusterShape ClusterShapeAlgo::Calculate(const reco::BasicCluster& passedCluster,
+                                               const EcalRecHitCollection* hits,
+                                               const CaloSubdetectorGeometry* geometry,
+                                               const CaloSubdetectorTopology* topology) {
+  Calculate_TopEnergy(passedCluster, hits);
+  Calculate_2ndEnergy(passedCluster, hits);
+  Create_Map(hits, topology);
   Calculate_e2x2();
   Calculate_e3x2();
   Calculate_e3x3();
@@ -36,38 +34,53 @@ reco::ClusterShape ClusterShapeAlgo::Calculate(const reco::BasicCluster &passedC
   Calculate_e2x5Left();
   Calculate_e2x5Top();
   Calculate_e2x5Bottom();
-  Calculate_Covariances(passedCluster,hits,geometry);
-  Calculate_BarrelBasketEnergyFraction(passedCluster,hits, Eta, geometry);
-  Calculate_BarrelBasketEnergyFraction(passedCluster,hits, Phi, geometry);
-  Calculate_EnergyDepTopology (passedCluster,hits,geometry,true) ;
+  Calculate_Covariances(passedCluster, hits, geometry);
+  Calculate_BarrelBasketEnergyFraction(passedCluster, hits, Eta, geometry);
+  Calculate_BarrelBasketEnergyFraction(passedCluster, hits, Phi, geometry);
+  Calculate_EnergyDepTopology(passedCluster, hits, geometry, true);
   Calculate_lat(passedCluster);
   Calculate_ComplexZernikeMoments(passedCluster);
 
-  return reco::ClusterShape(covEtaEta_, covEtaPhi_, covPhiPhi_, eMax_, eMaxId_,
-			    e2nd_, e2ndId_, e2x2_, e3x2_, e3x3_,e4x4_, e5x5_,
-			    e2x5Right_, e2x5Left_, e2x5Top_, e2x5Bottom_,
-			    e3x2Ratio_, lat_, etaLat_, phiLat_, A20_, A42_,
-			    energyBasketFractionEta_, energyBasketFractionPhi_);
+  return reco::ClusterShape(covEtaEta_,
+                            covEtaPhi_,
+                            covPhiPhi_,
+                            eMax_,
+                            eMaxId_,
+                            e2nd_,
+                            e2ndId_,
+                            e2x2_,
+                            e3x2_,
+                            e3x3_,
+                            e4x4_,
+                            e5x5_,
+                            e2x5Right_,
+                            e2x5Left_,
+                            e2x5Top_,
+                            e2x5Bottom_,
+                            e3x2Ratio_,
+                            lat_,
+                            etaLat_,
+                            phiLat_,
+                            A20_,
+                            A42_,
+                            energyBasketFractionEta_,
+                            energyBasketFractionPhi_);
 }
 
-void ClusterShapeAlgo::Calculate_TopEnergy(const reco::BasicCluster &passedCluster,const EcalRecHitCollection *hits)
-{
-  double eMax=0;
+void ClusterShapeAlgo::Calculate_TopEnergy(const reco::BasicCluster& passedCluster, const EcalRecHitCollection* hits) {
+  double eMax = 0;
   DetId eMaxId(0);
 
-  const std::vector< std::pair<DetId, float> >& clusterDetIds = passedCluster.hitsAndFractions();
+  const std::vector<std::pair<DetId, float> >& clusterDetIds = passedCluster.hitsAndFractions();
 
   EcalRecHit testEcalRecHit;
 
-  for(auto const& posCurrent : clusterDetIds)
-  {
-    if ((posCurrent.first != DetId(0)) && (hits->find(posCurrent.first) != hits->end()))
-    {
+  for (auto const& posCurrent : clusterDetIds) {
+    if ((posCurrent.first != DetId(0)) && (hits->find(posCurrent.first) != hits->end())) {
       EcalRecHitCollection::const_iterator itt = hits->find(posCurrent.first);
       testEcalRecHit = *itt;
 
-      if(testEcalRecHit.energy() * posCurrent.second > eMax)
-      {
+      if (testEcalRecHit.energy() * posCurrent.second > eMax) {
         eMax = testEcalRecHit.energy() * posCurrent.second;
         eMaxId = testEcalRecHit.id();
       }
@@ -78,24 +91,20 @@ void ClusterShapeAlgo::Calculate_TopEnergy(const reco::BasicCluster &passedClust
   eMaxId_ = eMaxId;
 }
 
-void ClusterShapeAlgo::Calculate_2ndEnergy(const reco::BasicCluster &passedCluster,const EcalRecHitCollection *hits)
-{
-  double e2nd=0;
+void ClusterShapeAlgo::Calculate_2ndEnergy(const reco::BasicCluster& passedCluster, const EcalRecHitCollection* hits) {
+  double e2nd = 0;
   DetId e2ndId(0);
 
-  const std::vector< std::pair<DetId, float> >& clusterDetIds = passedCluster.hitsAndFractions();
+  const std::vector<std::pair<DetId, float> >& clusterDetIds = passedCluster.hitsAndFractions();
 
   EcalRecHit testEcalRecHit;
 
-  for(auto const& posCurrent : clusterDetIds)
-  { 
-    if (( posCurrent.first != DetId(0)) && (hits->find( posCurrent.first ) != hits->end()))
-    {
-      EcalRecHitCollection::const_iterator itt = hits->find( posCurrent.first );
+  for (auto const& posCurrent : clusterDetIds) {
+    if ((posCurrent.first != DetId(0)) && (hits->find(posCurrent.first) != hits->end())) {
+      EcalRecHitCollection::const_iterator itt = hits->find(posCurrent.first);
       testEcalRecHit = *itt;
 
-      if(testEcalRecHit.energy() * posCurrent.second > e2nd && testEcalRecHit.id() != eMaxId_)
-      {
+      if (testEcalRecHit.energy() * posCurrent.second > e2nd && testEcalRecHit.id() != eMaxId_) {
         e2nd = testEcalRecHit.energy() * posCurrent.second;
         e2ndId = testEcalRecHit.id();
       }
@@ -106,64 +115,66 @@ void ClusterShapeAlgo::Calculate_2ndEnergy(const reco::BasicCluster &passedClust
   e2ndId_ = e2ndId;
 }
 
-void ClusterShapeAlgo::Create_Map(const EcalRecHitCollection *hits,const CaloSubdetectorTopology* topology)
-{
+void ClusterShapeAlgo::Create_Map(const EcalRecHitCollection* hits, const CaloSubdetectorTopology* topology) {
   EcalRecHit tempEcalRecHit;
-  CaloNavigator<DetId> posCurrent = CaloNavigator<DetId>(eMaxId_,topology );
+  CaloNavigator<DetId> posCurrent = CaloNavigator<DetId>(eMaxId_, topology);
 
-  for(int x = 0; x < 5; x++)
-    for(int y = 0; y < 5; y++)
-    {
+  for (int x = 0; x < 5; x++)
+    for (int y = 0; y < 5; y++) {
       posCurrent.home();
-      posCurrent.offsetBy(-2+x,-2+y);
+      posCurrent.offsetBy(-2 + x, -2 + y);
 
-      if((*posCurrent != DetId(0)) && (hits->find(*posCurrent) != hits->end()))
-      {
-				EcalRecHitCollection::const_iterator itt = hits->find(*posCurrent);
-				tempEcalRecHit = *itt;
-				energyMap_[y][x] = std::make_pair(tempEcalRecHit.id(),tempEcalRecHit.energy()); 
-      }
-      else
-				energyMap_[y][x] = std::make_pair(DetId(0), 0);  
+      if ((*posCurrent != DetId(0)) && (hits->find(*posCurrent) != hits->end())) {
+        EcalRecHitCollection::const_iterator itt = hits->find(*posCurrent);
+        tempEcalRecHit = *itt;
+        energyMap_[y][x] = std::make_pair(tempEcalRecHit.id(), tempEcalRecHit.energy());
+      } else
+        energyMap_[y][x] = std::make_pair(DetId(0), 0);
     }
 }
 
-void ClusterShapeAlgo::Calculate_e2x2()
-{
+void ClusterShapeAlgo::Calculate_e2x2() {
   double e2x2Max = 0;
   double e2x2Test = 0;
 
-  int deltaX=0, deltaY=0;
+  int deltaX = 0, deltaY = 0;
 
-  for(int corner = 0; corner < 4; corner++)
-  {
-    switch(corner)
-    {
-      case 0: deltaX = -1; deltaY = -1; break;
-      case 1: deltaX = -1; deltaY =  1; break;
-      case 2: deltaX =  1; deltaY = -1; break;
-      case 3: deltaX =  1; deltaY =  1; break;
+  for (int corner = 0; corner < 4; corner++) {
+    switch (corner) {
+      case 0:
+        deltaX = -1;
+        deltaY = -1;
+        break;
+      case 1:
+        deltaX = -1;
+        deltaY = 1;
+        break;
+      case 2:
+        deltaX = 1;
+        deltaY = -1;
+        break;
+      case 3:
+        deltaX = 1;
+        deltaY = 1;
+        break;
     }
 
-    e2x2Test  = energyMap_[2][2].second;
-    e2x2Test += energyMap_[2+deltaY][2].second;
-    e2x2Test += energyMap_[2][2+deltaX].second;
-    e2x2Test += energyMap_[2+deltaY][2+deltaX].second;
+    e2x2Test = energyMap_[2][2].second;
+    e2x2Test += energyMap_[2 + deltaY][2].second;
+    e2x2Test += energyMap_[2][2 + deltaX].second;
+    e2x2Test += energyMap_[2 + deltaY][2 + deltaX].second;
 
-    if(e2x2Test > e2x2Max)
-    {
-			e2x2Max = e2x2Test;
-			e2x2_Diagonal_X_ = 2+deltaX;
-			e2x2_Diagonal_Y_ = 2+deltaY;
+    if (e2x2Test > e2x2Max) {
+      e2x2Max = e2x2Test;
+      e2x2_Diagonal_X_ = 2 + deltaX;
+      e2x2_Diagonal_Y_ = 2 + deltaY;
     }
   }
 
   e2x2_ = e2x2Max;
-
 }
 
-void ClusterShapeAlgo::Calculate_e3x2()
-{
+void ClusterShapeAlgo::Calculate_e3x2() {
   double e3x2 = 0.0;
   double e3x2Ratio = 0.0, e3x2RatioNumerator = 0.0, e3x2RatioDenominator = 0.0;
 
@@ -173,486 +184,502 @@ void ClusterShapeAlgo::Calculate_e3x2()
   double nextEnergy = -999;
   int nextEneryDirection = -1;
 
-  for(int cardinalDirection = 0; cardinalDirection < 4; cardinalDirection++)
-  {
-    switch(cardinalDirection)
-    {
-      case 0: deltaX = -1; deltaY =  0; break;
-      case 1: deltaX =  1; deltaY =  0; break;
-      case 2: deltaX =  0; deltaY = -1; break;
-      case 3: deltaX =  0; deltaY =  1; break;
+  for (int cardinalDirection = 0; cardinalDirection < 4; cardinalDirection++) {
+    switch (cardinalDirection) {
+      case 0:
+        deltaX = -1;
+        deltaY = 0;
+        break;
+      case 1:
+        deltaX = 1;
+        deltaY = 0;
+        break;
+      case 2:
+        deltaX = 0;
+        deltaY = -1;
+        break;
+      case 3:
+        deltaX = 0;
+        deltaY = 1;
+        break;
     }
-   
-    if(energyMap_[2+deltaY][2+deltaX].second >= nextEnergy)
-    {
-        nextEnergy = energyMap_[2+deltaY][2+deltaX].second;
-        nextEneryDirection = cardinalDirection;
-       
-        e2ndX = 2+deltaX;
-        e2ndY = 2+deltaY;
+
+    if (energyMap_[2 + deltaY][2 + deltaX].second >= nextEnergy) {
+      nextEnergy = energyMap_[2 + deltaY][2 + deltaX].second;
+      nextEneryDirection = cardinalDirection;
+
+      e2ndX = 2 + deltaX;
+      e2ndY = 2 + deltaY;
     }
-  }
- 
-  switch(nextEneryDirection)
-  {
-    case 0: ;
-    case 1: deltaX = 0; deltaY = 1; break;
-    case 2: ;
-    case 3: deltaX = 1; deltaY = 0; break;
   }
 
-  for(int sign = -1; sign <= 1; sign++)
-      e3x2 += (energyMap_[2+deltaY*sign][2+deltaX*sign].second + energyMap_[e2ndY+deltaY*sign][e2ndX+deltaX*sign].second);
- 
-  e3x2RatioNumerator   = energyMap_[e2ndY+deltaY][e2ndX+deltaX].second + energyMap_[e2ndY-deltaY][e2ndX-deltaX].second;
-  e3x2RatioDenominator = 0.5 + energyMap_[2+deltaY][2+deltaX].second + energyMap_[2-deltaY][2-deltaX].second;
+  switch (nextEneryDirection) {
+    case 0:;
+    case 1:
+      deltaX = 0;
+      deltaY = 1;
+      break;
+    case 2:;
+    case 3:
+      deltaX = 1;
+      deltaY = 0;
+      break;
+  }
+
+  for (int sign = -1; sign <= 1; sign++)
+    e3x2 += (energyMap_[2 + deltaY * sign][2 + deltaX * sign].second +
+             energyMap_[e2ndY + deltaY * sign][e2ndX + deltaX * sign].second);
+
+  e3x2RatioNumerator =
+      energyMap_[e2ndY + deltaY][e2ndX + deltaX].second + energyMap_[e2ndY - deltaY][e2ndX - deltaX].second;
+  e3x2RatioDenominator = 0.5 + energyMap_[2 + deltaY][2 + deltaX].second + energyMap_[2 - deltaY][2 - deltaX].second;
   e3x2Ratio = e3x2RatioNumerator / e3x2RatioDenominator;
 
   e3x2_ = e3x2;
   e3x2Ratio_ = e3x2Ratio;
-}  
+}
 
-void ClusterShapeAlgo::Calculate_e3x3()
-{
-  double e3x3=0;
+void ClusterShapeAlgo::Calculate_e3x3() {
+  double e3x3 = 0;
 
-  for(int i = 1; i <= 3; i++)
-    for(int j = 1; j <= 3; j++)
+  for (int i = 1; i <= 3; i++)
+    for (int j = 1; j <= 3; j++)
       e3x3 += energyMap_[j][i].second;
 
   e3x3_ = e3x3;
-
 }
 
-void ClusterShapeAlgo::Calculate_e4x4()
-{
-  double e4x4=0;
-	
-  int startX=-1, startY=-1;
+void ClusterShapeAlgo::Calculate_e4x4() {
+  double e4x4 = 0;
 
-	switch(e2x2_Diagonal_X_)
-	{
-		case 1: startX = 0; break;
-		case 3: startX = 1; break;
-	}
+  int startX = -1, startY = -1;
 
-	switch(e2x2_Diagonal_Y_)
-	{
-		case 1: startY = 0; break;
-		case 3: startY = 1; break;
-	}
+  switch (e2x2_Diagonal_X_) {
+    case 1:
+      startX = 0;
+      break;
+    case 3:
+      startX = 1;
+      break;
+  }
 
-  for(int i = startX; i <= startX+3; i++)
- 	  for(int j = startY; j <= startY+3; j++)
-   	  e4x4 += energyMap_[j][i].second;
+  switch (e2x2_Diagonal_Y_) {
+    case 1:
+      startY = 0;
+      break;
+    case 3:
+      startY = 1;
+      break;
+  }
+
+  for (int i = startX; i <= startX + 3; i++)
+    for (int j = startY; j <= startY + 3; j++)
+      e4x4 += energyMap_[j][i].second;
 
   e4x4_ = e4x4;
 }
 
-void ClusterShapeAlgo::Calculate_e5x5()
-{
-  double e5x5=0;
+void ClusterShapeAlgo::Calculate_e5x5() {
+  double e5x5 = 0;
 
-  for(int i = 0; i <= 4; i++)
-    for(int j = 0; j <= 4; j++)
+  for (int i = 0; i <= 4; i++)
+    for (int j = 0; j <= 4; j++)
       e5x5 += energyMap_[j][i].second;
 
   e5x5_ = e5x5;
-
 }
 
-void ClusterShapeAlgo::Calculate_e2x5Right()
-{
-double e2x5R=0.0;
-  for(int i = 0; i <= 4; i++){
-    for(int j = 0; j <= 4; j++){
-      if(j>2){e2x5R +=energyMap_[i][j].second;}
+void ClusterShapeAlgo::Calculate_e2x5Right() {
+  double e2x5R = 0.0;
+  for (int i = 0; i <= 4; i++) {
+    for (int j = 0; j <= 4; j++) {
+      if (j > 2) {
+        e2x5R += energyMap_[i][j].second;
+      }
     }
   }
-  e2x5Right_=e2x5R;
+  e2x5Right_ = e2x5R;
 }
 
-void ClusterShapeAlgo::Calculate_e2x5Left()
-{
-double e2x5L=0.0;
-  for(int i = 0; i <= 4; i++){
-    for(int j = 0; j <= 4; j++){
-      if(j<2){e2x5L +=energyMap_[i][j].second;}
+void ClusterShapeAlgo::Calculate_e2x5Left() {
+  double e2x5L = 0.0;
+  for (int i = 0; i <= 4; i++) {
+    for (int j = 0; j <= 4; j++) {
+      if (j < 2) {
+        e2x5L += energyMap_[i][j].second;
+      }
     }
   }
-  e2x5Left_=e2x5L;
+  e2x5Left_ = e2x5L;
 }
 
-void ClusterShapeAlgo::Calculate_e2x5Bottom()
-{
-double e2x5B=0.0;
-  for(int i = 0; i <= 4; i++){
-    for(int j = 0; j <= 4; j++){
-
-      if(i>2){e2x5B +=energyMap_[i][j].second;}
+void ClusterShapeAlgo::Calculate_e2x5Bottom() {
+  double e2x5B = 0.0;
+  for (int i = 0; i <= 4; i++) {
+    for (int j = 0; j <= 4; j++) {
+      if (i > 2) {
+        e2x5B += energyMap_[i][j].second;
+      }
     }
   }
-  e2x5Bottom_=e2x5B;
+  e2x5Bottom_ = e2x5B;
 }
 
-void ClusterShapeAlgo::Calculate_e2x5Top()
-{
-double e2x5T=0.0;
-  for(int i = 0; i <= 4; i++){
-    for(int j = 0; j <= 4; j++){
-
-      if(i<2){e2x5T +=energyMap_[i][j].second;}
+void ClusterShapeAlgo::Calculate_e2x5Top() {
+  double e2x5T = 0.0;
+  for (int i = 0; i <= 4; i++) {
+    for (int j = 0; j <= 4; j++) {
+      if (i < 2) {
+        e2x5T += energyMap_[i][j].second;
+      }
     }
   }
-  e2x5Top_=e2x5T;
+  e2x5Top_ = e2x5T;
 }
 
-void ClusterShapeAlgo::Calculate_Covariances(const reco::BasicCluster &passedCluster, const EcalRecHitCollection* hits, 
-					     const CaloSubdetectorGeometry* geometry)
-{
-  if (e5x5_ > 0.)
-    {
-      double w0_ = parameterSet_.getParameter<double>("W0");
-      
-      
-      // first find energy-weighted mean position - doing it when filling the energy map might save time
-      math::XYZVector meanPosition(0.0, 0.0, 0.0);
-      for (int i = 0; i < 5; ++i)
-	{
-	  for (int j = 0; j < 5; ++j)
-	    {
-	      DetId id = energyMap_[i][j].first;
-	      if (id != DetId(0))
-		{
-		  GlobalPoint positionGP = geometry->getGeometry(id)->getPosition();
-		  math::XYZVector position(positionGP.x(),positionGP.y(),positionGP.z());
-		  meanPosition = meanPosition + energyMap_[i][j].second * position;
-		}
-	    }
-	}
-      
-      meanPosition /= e5x5_;
-      
-      // now we can calculate the covariances
-      double numeratorEtaEta = 0;
-      double numeratorEtaPhi = 0;
-      double numeratorPhiPhi = 0;
-      double denominator     = 0;
-      
-      for (int i = 0; i < 5; ++i)
-	{
-	  for (int j = 0; j < 5; ++j)
-	    {
-	      DetId id = energyMap_[i][j].first;
-	      if (id != DetId(0))
-		{
-		  GlobalPoint position = geometry->getGeometry(id)->getPosition();
-		  
-		  double dPhi = position.phi() - meanPosition.phi();
-		  if (dPhi > + Geom::pi()) { dPhi = Geom::twoPi() - dPhi; }
-		  if (dPhi < - Geom::pi()) { dPhi = Geom::twoPi() + dPhi; }
-		  
-		  double dEta = position.eta() - meanPosition.eta();
-		  double w = 0.;
-		  if ( energyMap_[i][j].second > 0.)
-		    w = std::max(0.0, w0_ + log( energyMap_[i][j].second / e5x5_));
-		  
-		  denominator += w;
-		  numeratorEtaEta += w * dEta * dEta;
-		  numeratorEtaPhi += w * dEta * dPhi;
-		  numeratorPhiPhi += w * dPhi * dPhi;
-		}
-	    }
-	}
-      
-      covEtaEta_ = numeratorEtaEta / denominator;
-      covEtaPhi_ = numeratorEtaPhi / denominator;
-      covPhiPhi_ = numeratorPhiPhi / denominator;
+void ClusterShapeAlgo::Calculate_Covariances(const reco::BasicCluster& passedCluster,
+                                             const EcalRecHitCollection* hits,
+                                             const CaloSubdetectorGeometry* geometry) {
+  if (e5x5_ > 0.) {
+    double w0_ = parameterSet_.getParameter<double>("W0");
+
+    // first find energy-weighted mean position - doing it when filling the energy map might save time
+    math::XYZVector meanPosition(0.0, 0.0, 0.0);
+    for (int i = 0; i < 5; ++i) {
+      for (int j = 0; j < 5; ++j) {
+        DetId id = energyMap_[i][j].first;
+        if (id != DetId(0)) {
+          GlobalPoint positionGP = geometry->getGeometry(id)->getPosition();
+          math::XYZVector position(positionGP.x(), positionGP.y(), positionGP.z());
+          meanPosition = meanPosition + energyMap_[i][j].second * position;
+        }
+      }
     }
-  else 
-    {
-      // Warn the user if there was no energy in the cells and return zeroes.
-      //       std::cout << "\ClusterShapeAlgo::Calculate_Covariances:  no energy in supplied cells.\n";
-      covEtaEta_ = 0;
-      covEtaPhi_ = 0;
-      covPhiPhi_ = 0;
+
+    meanPosition /= e5x5_;
+
+    // now we can calculate the covariances
+    double numeratorEtaEta = 0;
+    double numeratorEtaPhi = 0;
+    double numeratorPhiPhi = 0;
+    double denominator = 0;
+
+    for (int i = 0; i < 5; ++i) {
+      for (int j = 0; j < 5; ++j) {
+        DetId id = energyMap_[i][j].first;
+        if (id != DetId(0)) {
+          GlobalPoint position = geometry->getGeometry(id)->getPosition();
+
+          double dPhi = position.phi() - meanPosition.phi();
+          if (dPhi > +Geom::pi()) {
+            dPhi = Geom::twoPi() - dPhi;
+          }
+          if (dPhi < -Geom::pi()) {
+            dPhi = Geom::twoPi() + dPhi;
+          }
+
+          double dEta = position.eta() - meanPosition.eta();
+          double w = 0.;
+          if (energyMap_[i][j].second > 0.)
+            w = std::max(0.0, w0_ + log(energyMap_[i][j].second / e5x5_));
+
+          denominator += w;
+          numeratorEtaEta += w * dEta * dEta;
+          numeratorEtaPhi += w * dEta * dPhi;
+          numeratorPhiPhi += w * dPhi * dPhi;
+        }
+      }
     }
+
+    covEtaEta_ = numeratorEtaEta / denominator;
+    covEtaPhi_ = numeratorEtaPhi / denominator;
+    covPhiPhi_ = numeratorPhiPhi / denominator;
+  } else {
+    // Warn the user if there was no energy in the cells and return zeroes.
+    //       std::cout << "\ClusterShapeAlgo::Calculate_Covariances:  no energy in supplied cells.\n";
+    covEtaEta_ = 0;
+    covEtaPhi_ = 0;
+    covPhiPhi_ = 0;
+  }
 }
 
-void ClusterShapeAlgo::Calculate_BarrelBasketEnergyFraction(const reco::BasicCluster &passedCluster,
-                                                            const EcalRecHitCollection *hits,
+void ClusterShapeAlgo::Calculate_BarrelBasketEnergyFraction(const reco::BasicCluster& passedCluster,
+                                                            const EcalRecHitCollection* hits,
                                                             const int EtaPhi,
-                                                            const CaloSubdetectorGeometry* geometry) 
-{
-  if(  (hits==nullptr) || ( ((*hits)[0]).id().subdetId() != EcalBarrel )  ) {
-     //std::cout << "No basket correction if no hits or for endacap!" << std::endl;
-     return;
+                                                            const CaloSubdetectorGeometry* geometry) {
+  if ((hits == nullptr) || (((*hits)[0]).id().subdetId() != EcalBarrel)) {
+    //std::cout << "No basket correction if no hits or for endacap!" << std::endl;
+    return;
   }
 
-  std::map<int,double> indexedBasketEnergy;
-  const std::vector< std::pair<DetId, float> >& clusterDetIds = passedCluster.hitsAndFractions();
+  std::map<int, double> indexedBasketEnergy;
+  const std::vector<std::pair<DetId, float> >& clusterDetIds = passedCluster.hitsAndFractions();
   const EcalBarrelGeometry* subDetGeometry = dynamic_cast<const EcalBarrelGeometry*>(geometry);
 
-  for(auto const& posCurrent : clusterDetIds)
-  {
+  for (auto const& posCurrent : clusterDetIds) {
     int basketIndex = 999;
 
-    if(EtaPhi == Eta) {
-      int unsignedIEta = abs(EBDetId( posCurrent.first ).ieta());
+    if (EtaPhi == Eta) {
+      int unsignedIEta = abs(EBDetId(posCurrent.first).ieta());
       std::vector<int> etaBasketSize = subDetGeometry->getEtaBaskets();
 
-      for(unsigned int i = 0; i < etaBasketSize.size(); i++) {
+      for (unsigned int i = 0; i < etaBasketSize.size(); i++) {
         unsignedIEta -= etaBasketSize[i];
-        if(unsignedIEta - 1 < 0)
-        {
+        if (unsignedIEta - 1 < 0) {
           basketIndex = i;
           break;
         }
       }
-      basketIndex = (basketIndex+1)*(EBDetId( posCurrent.first ).ieta() > 0 ? 1 : -1);
+      basketIndex = (basketIndex + 1) * (EBDetId(posCurrent.first).ieta() > 0 ? 1 : -1);
 
-    } else if(EtaPhi == Phi) {
-      int halfNumBasketInPhi = (EBDetId::MAX_IPHI - EBDetId::MIN_IPHI + 1)/subDetGeometry->getBasketSizeInPhi()/2;
+    } else if (EtaPhi == Phi) {
+      int halfNumBasketInPhi = (EBDetId::MAX_IPHI - EBDetId::MIN_IPHI + 1) / subDetGeometry->getBasketSizeInPhi() / 2;
 
-      basketIndex = (EBDetId( posCurrent.first ).iphi() - 1)/subDetGeometry->getBasketSizeInPhi()
-                  - (EBDetId( (clusterDetIds[0]).first ).iphi() - 1)/subDetGeometry->getBasketSizeInPhi();
+      basketIndex = (EBDetId(posCurrent.first).iphi() - 1) / subDetGeometry->getBasketSizeInPhi() -
+                    (EBDetId((clusterDetIds[0]).first).iphi() - 1) / subDetGeometry->getBasketSizeInPhi();
 
-      if(basketIndex >= halfNumBasketInPhi)             basketIndex -= 2*halfNumBasketInPhi;
-      else if(basketIndex <  -1*halfNumBasketInPhi)     basketIndex += 2*halfNumBasketInPhi;
+      if (basketIndex >= halfNumBasketInPhi)
+        basketIndex -= 2 * halfNumBasketInPhi;
+      else if (basketIndex < -1 * halfNumBasketInPhi)
+        basketIndex += 2 * halfNumBasketInPhi;
 
-    } else throw(std::runtime_error("\n\nOh No! Calculate_BarrelBasketEnergyFraction called on invalid index.\n\n"));
+    } else
+      throw(std::runtime_error("\n\nOh No! Calculate_BarrelBasketEnergyFraction called on invalid index.\n\n"));
 
-    indexedBasketEnergy[basketIndex] += (hits->find( posCurrent.first ))->energy();
+    indexedBasketEnergy[basketIndex] += (hits->find(posCurrent.first))->energy();
   }
 
   std::vector<double> energyFraction;
-  for(std::map<int,double>::iterator posCurrent = indexedBasketEnergy.begin(); posCurrent != indexedBasketEnergy.end(); posCurrent++)
-  {
-    energyFraction.push_back(indexedBasketEnergy[posCurrent->first]/passedCluster.energy());
+  for (std::map<int, double>::iterator posCurrent = indexedBasketEnergy.begin();
+       posCurrent != indexedBasketEnergy.end();
+       posCurrent++) {
+    energyFraction.push_back(indexedBasketEnergy[posCurrent->first] / passedCluster.energy());
   }
 
-  switch(EtaPhi)
-  {
-    case Eta: energyBasketFractionEta_ = energyFraction; break;
-    case Phi: energyBasketFractionPhi_ = energyFraction; break;
+  switch (EtaPhi) {
+    case Eta:
+      energyBasketFractionEta_ = energyFraction;
+      break;
+    case Phi:
+      energyBasketFractionPhi_ = energyFraction;
+      break;
   }
-
 }
 
-void ClusterShapeAlgo::Calculate_lat(const reco::BasicCluster &passedCluster) {
-
-  double r,redmoment=0;
-  double phiRedmoment = 0 ;
-  double etaRedmoment = 0 ;
-  int n,n1,n2,tmp;
-  int clusterSize=energyDistribution_.size();
-  if (clusterSize<3) {
-    etaLat_ = 0.0 ; 
+void ClusterShapeAlgo::Calculate_lat(const reco::BasicCluster& passedCluster) {
+  double r, redmoment = 0;
+  double phiRedmoment = 0;
+  double etaRedmoment = 0;
+  int n, n1, n2, tmp;
+  int clusterSize = energyDistribution_.size();
+  if (clusterSize < 3) {
+    etaLat_ = 0.0;
     lat_ = 0.0;
-    return; 
+    return;
   }
-  
-  n1=0; n2=1;
-  if (energyDistribution_[1].deposited_energy > 
-      energyDistribution_[0].deposited_energy) 
-    {
-      tmp=n2; n2=n1; n1=tmp;
-    }
-  for (int i=2; i<clusterSize; i++) {
-    n=i;
-    if (energyDistribution_[i].deposited_energy > 
-        energyDistribution_[n1].deposited_energy) 
-      {
+
+  n1 = 0;
+  n2 = 1;
+  if (energyDistribution_[1].deposited_energy > energyDistribution_[0].deposited_energy) {
+    tmp = n2;
+    n2 = n1;
+    n1 = tmp;
+  }
+  for (int i = 2; i < clusterSize; i++) {
+    n = i;
+    if (energyDistribution_[i].deposited_energy > energyDistribution_[n1].deposited_energy) {
+      tmp = n2;
+      n2 = n1;
+      n1 = i;
+      n = tmp;
+    } else {
+      if (energyDistribution_[i].deposited_energy > energyDistribution_[n2].deposited_energy) {
         tmp = n2;
-        n2 = n1; n1 = i; n=tmp;
-      } else {
-        if (energyDistribution_[i].deposited_energy > 
-            energyDistribution_[n2].deposited_energy) 
-          {
-            tmp=n2; n2=i; n=tmp;
-          }
+        n2 = i;
+        n = tmp;
       }
+    }
 
     r = energyDistribution_[n].r;
-    redmoment += r*r* energyDistribution_[n].deposited_energy;
-    double rphi = r * cos (energyDistribution_[n].phi) ;
+    redmoment += r * r * energyDistribution_[n].deposited_energy;
+    double rphi = r * cos(energyDistribution_[n].phi);
     phiRedmoment += rphi * rphi * energyDistribution_[n].deposited_energy;
-    double reta = r * sin (energyDistribution_[n].phi) ;
+    double reta = r * sin(energyDistribution_[n].phi);
     etaRedmoment += reta * reta * energyDistribution_[n].deposited_energy;
-  } 
+  }
   double e1 = energyDistribution_[n1].deposited_energy;
   double e2 = energyDistribution_[n2].deposited_energy;
-  
-  lat_ = redmoment/(redmoment+2.19*2.19*(e1+e2));
-  phiLat_ = phiRedmoment/(phiRedmoment+2.19*2.19*(e1+e2));
-  etaLat_ = etaRedmoment/(etaRedmoment+2.19*2.19*(e1+e2));
+
+  lat_ = redmoment / (redmoment + 2.19 * 2.19 * (e1 + e2));
+  phiLat_ = phiRedmoment / (phiRedmoment + 2.19 * 2.19 * (e1 + e2));
+  etaLat_ = etaRedmoment / (etaRedmoment + 2.19 * 2.19 * (e1 + e2));
 }
 
-void ClusterShapeAlgo::Calculate_ComplexZernikeMoments(const reco::BasicCluster &passedCluster) {
+void ClusterShapeAlgo::Calculate_ComplexZernikeMoments(const reco::BasicCluster& passedCluster) {
   // Calculate only the moments which go into the default cluster shape
   // (moments with m>=2 are the only sensitive to azimuthal shape)
-  A20_ = absZernikeMoment(passedCluster,2,0);
-  A42_ = absZernikeMoment(passedCluster,4,2);
+  A20_ = absZernikeMoment(passedCluster, 2, 0);
+  A42_ = absZernikeMoment(passedCluster, 4, 2);
 }
 
-double ClusterShapeAlgo::absZernikeMoment(const reco::BasicCluster &passedCluster,
-                                          int n, int m, double R0) {
+double ClusterShapeAlgo::absZernikeMoment(const reco::BasicCluster& passedCluster, int n, int m, double R0) {
   // 1. Check if n,m are correctly
-  if ((m>n) || ((n-m)%2 != 0) || (n<0) || (m<0)) return -1;
+  if ((m > n) || ((n - m) % 2 != 0) || (n < 0) || (m < 0))
+    return -1;
 
   // 2. Check if n,R0 are within validity Range :
   // n>20 or R0<2.19cm  just makes no sense !
-  if ((n>20) || (R0<=2.19)) return -1;
-  if (n<=5) return fast_AbsZernikeMoment(passedCluster,n,m,R0);
-  else return calc_AbsZernikeMoment(passedCluster,n,m,R0);
+  if ((n > 20) || (R0 <= 2.19))
+    return -1;
+  if (n <= 5)
+    return fast_AbsZernikeMoment(passedCluster, n, m, R0);
+  else
+    return calc_AbsZernikeMoment(passedCluster, n, m, R0);
 }
 
 double ClusterShapeAlgo::f00(double r) { return 1; }
 
 double ClusterShapeAlgo::f11(double r) { return r; }
 
-double ClusterShapeAlgo::f20(double r) { return 2.0*r*r-1.0; }
+double ClusterShapeAlgo::f20(double r) { return 2.0 * r * r - 1.0; }
 
-double ClusterShapeAlgo::f22(double r) { return r*r; }
+double ClusterShapeAlgo::f22(double r) { return r * r; }
 
-double ClusterShapeAlgo::f31(double r) { return 3.0*r*r*r - 2.0*r; }
+double ClusterShapeAlgo::f31(double r) { return 3.0 * r * r * r - 2.0 * r; }
 
-double ClusterShapeAlgo::f33(double r) { return r*r*r; }
+double ClusterShapeAlgo::f33(double r) { return r * r * r; }
 
-double ClusterShapeAlgo::f40(double r) { return 6.0*r*r*r*r-6.0*r*r+1.0; }
+double ClusterShapeAlgo::f40(double r) { return 6.0 * r * r * r * r - 6.0 * r * r + 1.0; }
 
-double ClusterShapeAlgo::f42(double r) { return 4.0*r*r*r*r-3.0*r*r; }
+double ClusterShapeAlgo::f42(double r) { return 4.0 * r * r * r * r - 3.0 * r * r; }
 
-double ClusterShapeAlgo::f44(double r) { return r*r*r*r; }
+double ClusterShapeAlgo::f44(double r) { return r * r * r * r; }
 
-double ClusterShapeAlgo::f51(double r) { return 10.0*pow(r,5)-12.0*pow(r,3)+3.0*r; }
+double ClusterShapeAlgo::f51(double r) { return 10.0 * pow(r, 5) - 12.0 * pow(r, 3) + 3.0 * r; }
 
-double ClusterShapeAlgo::f53(double r) { return 5.0*pow(r,5) - 4.0*pow(r,3); }
+double ClusterShapeAlgo::f53(double r) { return 5.0 * pow(r, 5) - 4.0 * pow(r, 3); }
 
-double ClusterShapeAlgo::f55(double r) { return pow(r,5); }
+double ClusterShapeAlgo::f55(double r) { return pow(r, 5); }
 
-double ClusterShapeAlgo::fast_AbsZernikeMoment(const reco::BasicCluster &passedCluster,
-                                               int n, int m, double R0) {
-  double r,ph,e,Re=0,Im=0,result;
+double ClusterShapeAlgo::fast_AbsZernikeMoment(const reco::BasicCluster& passedCluster, int n, int m, double R0) {
+  double r, ph, e, Re = 0, Im = 0, result;
   double TotalEnergy = passedCluster.energy();
-  int index = (n/2)*(n/2)+(n/2)+m;
-  int clusterSize=energyDistribution_.size();
-  if(clusterSize<3) return 0.0;
+  int index = (n / 2) * (n / 2) + (n / 2) + m;
+  int clusterSize = energyDistribution_.size();
+  if (clusterSize < 3)
+    return 0.0;
 
-  for (int i=0; i<clusterSize; i++)
-    { 
-      r = energyDistribution_[i].r / R0;
-      if (r<1) {
-        fcn_.clear();
-        Calculate_Polynomials(r);
-        ph = (energyDistribution_[i]).phi;
-        e = energyDistribution_[i].deposited_energy;
-        Re = Re + e/TotalEnergy * fcn_[index] * cos( (double) m * ph);
-        Im = Im - e/TotalEnergy * fcn_[index] * sin( (double) m * ph);
-      }
+  for (int i = 0; i < clusterSize; i++) {
+    r = energyDistribution_[i].r / R0;
+    if (r < 1) {
+      fcn_.clear();
+      Calculate_Polynomials(r);
+      ph = (energyDistribution_[i]).phi;
+      e = energyDistribution_[i].deposited_energy;
+      Re = Re + e / TotalEnergy * fcn_[index] * cos((double)m * ph);
+      Im = Im - e / TotalEnergy * fcn_[index] * sin((double)m * ph);
     }
-  result = sqrt(Re*Re+Im*Im);
+  }
+  result = sqrt(Re * Re + Im * Im);
 
   return result;
 }
 
-double ClusterShapeAlgo::calc_AbsZernikeMoment(const reco::BasicCluster &passedCluster,
-                                               int n, int m, double R0) {
-  double r,ph,e,Re=0,Im=0,f_nm,result;
+double ClusterShapeAlgo::calc_AbsZernikeMoment(const reco::BasicCluster& passedCluster, int n, int m, double R0) {
+  double r, ph, e, Re = 0, Im = 0, f_nm, result;
   double TotalEnergy = passedCluster.energy();
-  int clusterSize=energyDistribution_.size();
-  if(clusterSize<3) return 0.0;
+  int clusterSize = energyDistribution_.size();
+  if (clusterSize < 3)
+    return 0.0;
 
-  for (int i=0; i<clusterSize; i++)
-    { 
-      r = energyDistribution_[i].r / R0;
-      if (r<1) {
-        ph = (energyDistribution_[i]).phi;
-        e = energyDistribution_[i].deposited_energy;
-        f_nm=0;
-        for (int s=0; s<=(n-m)/2; s++) {
-          if (s%2==0)
-            { 
-              f_nm = f_nm + factorial(n-s)*pow(r,(double) (n-2*s))/(factorial(s)*factorial((n+m)/2-s)*factorial((n-m)/2-s));
-            }else {
-              f_nm = f_nm - factorial(n-s)*pow(r,(double) (n-2*s))/(factorial(s)*factorial((n+m)/2-s)*factorial((n-m)/2-s));
-            }
+  for (int i = 0; i < clusterSize; i++) {
+    r = energyDistribution_[i].r / R0;
+    if (r < 1) {
+      ph = (energyDistribution_[i]).phi;
+      e = energyDistribution_[i].deposited_energy;
+      f_nm = 0;
+      for (int s = 0; s <= (n - m) / 2; s++) {
+        if (s % 2 == 0) {
+          f_nm = f_nm + factorial(n - s) * pow(r, (double)(n - 2 * s)) /
+                            (factorial(s) * factorial((n + m) / 2 - s) * factorial((n - m) / 2 - s));
+        } else {
+          f_nm = f_nm - factorial(n - s) * pow(r, (double)(n - 2 * s)) /
+                            (factorial(s) * factorial((n + m) / 2 - s) * factorial((n - m) / 2 - s));
         }
-        Re = Re + e/TotalEnergy * f_nm * cos( (double) m*ph);
-        Im = Im - e/TotalEnergy * f_nm * sin( (double) m*ph);
       }
+      Re = Re + e / TotalEnergy * f_nm * cos((double)m * ph);
+      Im = Im - e / TotalEnergy * f_nm * sin((double)m * ph);
     }
-  result = sqrt(Re*Re+Im*Im);
+  }
+  result = sqrt(Re * Re + Im * Im);
 
   return result;
 }
 
-void ClusterShapeAlgo::Calculate_EnergyDepTopology (const reco::BasicCluster &passedCluster,
-						    const EcalRecHitCollection *hits,
-						    const CaloSubdetectorGeometry* geometry,
-						    bool logW) {
+void ClusterShapeAlgo::Calculate_EnergyDepTopology(const reco::BasicCluster& passedCluster,
+                                                   const EcalRecHitCollection* hits,
+                                                   const CaloSubdetectorGeometry* geometry,
+                                                   bool logW) {
   // resets the energy distribution
   energyDistribution_.clear();
 
   // init a map of the energy deposition centered on the
   // cluster centroid. This is for momenta calculation only.
-  CLHEP::Hep3Vector clVect(passedCluster.position().x(),
-                           passedCluster.position().y(),
-                           passedCluster.position().z());
+  CLHEP::Hep3Vector clVect(passedCluster.position().x(), passedCluster.position().y(), passedCluster.position().z());
   CLHEP::Hep3Vector clDir(clVect);
-  clDir*=1.0/clDir.mag();
+  clDir *= 1.0 / clDir.mag();
   // in the transverse plane, axis perpendicular to clusterDir
-  CLHEP::Hep3Vector theta_axis(clDir.y(),-clDir.x(),0.0);
-  theta_axis *= 1.0/theta_axis.mag();
+  CLHEP::Hep3Vector theta_axis(clDir.y(), -clDir.x(), 0.0);
+  theta_axis *= 1.0 / theta_axis.mag();
   CLHEP::Hep3Vector phi_axis = theta_axis.cross(clDir);
 
-  const std::vector< std::pair<DetId, float> >& clusterDetIds = passedCluster.hitsAndFractions();
+  const std::vector<std::pair<DetId, float> >& clusterDetIds = passedCluster.hitsAndFractions();
 
   EcalClusterEnergyDeposition clEdep;
   EcalRecHit testEcalRecHit;
   // loop over crystals
-  for(auto const& posCurrent : clusterDetIds) {
-    EcalRecHitCollection::const_iterator itt = hits->find( posCurrent.first );
-    testEcalRecHit=*itt;
+  for (auto const& posCurrent : clusterDetIds) {
+    EcalRecHitCollection::const_iterator itt = hits->find(posCurrent.first);
+    testEcalRecHit = *itt;
 
-    if(( posCurrent.first != DetId(0)) && (hits->find( posCurrent.first ) != hits->end())) {
+    if ((posCurrent.first != DetId(0)) && (hits->find(posCurrent.first) != hits->end())) {
       clEdep.deposited_energy = testEcalRecHit.energy();
 
       // if logarithmic weight is requested, apply cut on minimum energy of the recHit
-      if(logW) {
+      if (logW) {
         double w0_ = parameterSet_.getParameter<double>("W0");
 
-        if ( clEdep.deposited_energy == 0 ) {
+        if (clEdep.deposited_energy == 0) {
           LogDebug("ClusterShapeAlgo") << "Crystal has zero energy; skipping... ";
           continue;
         }
-        double weight = std::max(0.0, w0_ + log(fabs(clEdep.deposited_energy)/passedCluster.energy()) );
-        if(weight==0) {
-          LogDebug("ClusterShapeAlgo") << "Crystal has insufficient energy: E = " 
-                                       << clEdep.deposited_energy << " GeV; skipping... ";
+        double weight = std::max(0.0, w0_ + log(fabs(clEdep.deposited_energy) / passedCluster.energy()));
+        if (weight == 0) {
+          LogDebug("ClusterShapeAlgo") << "Crystal has insufficient energy: E = " << clEdep.deposited_energy
+                                       << " GeV; skipping... ";
           continue;
-        }
-        else LogDebug("ClusterShapeAlgo") << "===> got crystal. Energy = " << clEdep.deposited_energy << " GeV. ";
+        } else
+          LogDebug("ClusterShapeAlgo") << "===> got crystal. Energy = " << clEdep.deposited_energy << " GeV. ";
       }
       DetId id_ = posCurrent.first;
       auto this_cell = geometry->getGeometry(id_);
       const GlobalPoint& cellPos = this_cell->getPosition();
-      CLHEP::Hep3Vector gblPos (cellPos.x(),cellPos.y(),cellPos.z()); //surface position?
+      CLHEP::Hep3Vector gblPos(cellPos.x(), cellPos.y(), cellPos.z());  //surface position?
       // Evaluate the distance from the cluster centroid
       CLHEP::Hep3Vector diff = gblPos - clVect;
       // Important: for the moment calculation, only the "lateral distance" is important
       // "lateral distance" r_i = distance of the digi position from the axis Origin-Cluster Center
       // ---> subtract the projection on clDir
-      CLHEP::Hep3Vector DigiVect = diff - diff.dot(clDir)*clDir;
+      CLHEP::Hep3Vector DigiVect = diff - diff.dot(clDir) * clDir;
       clEdep.r = DigiVect.mag();
-      LogDebug("ClusterShapeAlgo") << "E = " << clEdep.deposited_energy
-                                   << "\tdiff = " << diff.mag()
+      LogDebug("ClusterShapeAlgo") << "E = " << clEdep.deposited_energy << "\tdiff = " << diff.mag()
                                    << "\tr = " << clEdep.r;
       clEdep.phi = DigiVect.angle(theta_axis);
-      if(DigiVect.dot(phi_axis)<0) clEdep.phi = 2*M_PI - clEdep.phi;
+      if (DigiVect.dot(phi_axis) < 0)
+        clEdep.phi = 2 * M_PI - clEdep.phi;
       energyDistribution_.push_back(clEdep);
     }
-  } 
+  }
 }
 
 void ClusterShapeAlgo::Calculate_Polynomials(double rho) {
@@ -671,7 +698,8 @@ void ClusterShapeAlgo::Calculate_Polynomials(double rho) {
 }
 
 double ClusterShapeAlgo::factorial(int n) const {
-  double res=1.0;
-  for(int i=2; i<=n; i++) res*=(double) i;
+  double res = 1.0;
+  for (int i = 2; i <= n; i++)
+    res *= (double)i;
   return res;
 }

--- a/RecoEcal/EgammaCoreTools/src/EcalClusterFunctionFactory.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClusterFunctionFactory.cc
@@ -2,6 +2,5 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ModuleFactory.h"
 
-
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterFunctionFactory.h"
 EDM_REGISTER_PLUGINFACTORY(EcalClusterFunctionFactory, "EcalClusterFunctionFactory");

--- a/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
@@ -22,23 +22,28 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 
-EcalClusterLazyToolsBase::EcalClusterLazyToolsBase( const edm::Event &ev, const edm::EventSetup &es, edm::EDGetTokenT<EcalRecHitCollection> token1, edm::EDGetTokenT<EcalRecHitCollection> token2)
-  : geometry_(&edm::get<CaloGeometry,CaloGeometryRecord>(es))
-  , topology_(&edm::get<CaloTopology,CaloTopologyRecord>(es))
-  , ebRecHits_(&edm::get(ev, token1))
-  , eeRecHits_(&edm::get(ev, token2))
-{
-  getIntercalibConstants( es );
-  getADCToGeV ( es );
-  getLaserDbService ( es );
+EcalClusterLazyToolsBase::EcalClusterLazyToolsBase(const edm::Event &ev,
+                                                   const edm::EventSetup &es,
+                                                   edm::EDGetTokenT<EcalRecHitCollection> token1,
+                                                   edm::EDGetTokenT<EcalRecHitCollection> token2)
+    : geometry_(&edm::get<CaloGeometry, CaloGeometryRecord>(es)),
+      topology_(&edm::get<CaloTopology, CaloTopologyRecord>(es)),
+      ebRecHits_(&edm::get(ev, token1)),
+      eeRecHits_(&edm::get(ev, token2)) {
+  getIntercalibConstants(es);
+  getADCToGeV(es);
+  getLaserDbService(es);
 }
 
-EcalClusterLazyToolsBase::EcalClusterLazyToolsBase( const edm::Event &ev, const edm::EventSetup &es, edm::EDGetTokenT<EcalRecHitCollection> token1, edm::EDGetTokenT<EcalRecHitCollection> token2, edm::EDGetTokenT<EcalRecHitCollection> token3)
-  : geometry_(&edm::get<CaloGeometry,CaloGeometryRecord>(es))
-  , topology_(&edm::get<CaloTopology,CaloTopologyRecord>(es))
-  , ebRecHits_(&edm::get(ev, token1))
-  , eeRecHits_(&edm::get(ev, token2))
-{
+EcalClusterLazyToolsBase::EcalClusterLazyToolsBase(const edm::Event &ev,
+                                                   const edm::EventSetup &es,
+                                                   edm::EDGetTokenT<EcalRecHitCollection> token1,
+                                                   edm::EDGetTokenT<EcalRecHitCollection> token2,
+                                                   edm::EDGetTokenT<EcalRecHitCollection> token3)
+    : geometry_(&edm::get<CaloGeometry, CaloGeometryRecord>(es)),
+      topology_(&edm::get<CaloTopology, CaloTopologyRecord>(es)),
+      ebRecHits_(&edm::get(ev, token1)),
+      eeRecHits_(&edm::get(ev, token2)) {
   const CaloSubdetectorGeometry *geometryES = geometry_->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
   if (geometryES) {
     ecalPS_topology_ = std::make_shared<EcalPreshowerTopology>();
@@ -47,16 +52,16 @@ EcalClusterLazyToolsBase::EcalClusterLazyToolsBase( const edm::Event &ev, const 
   }
 
   esRHToken_ = token3;
-  getESRecHits( ev );
+  getESRecHits(ev);
 
-  getIntercalibConstants( es );
-  getADCToGeV ( es );
-  getLaserDbService ( es );
+  getIntercalibConstants(es);
+  getADCToGeV(es);
+  getLaserDbService(es);
 }
 
-void EcalClusterLazyToolsBase::getESRecHits( const edm::Event &ev ) {
-  edm::Handle< EcalRecHitCollection > pESRecHits;
-  ev.getByToken( esRHToken_, pESRecHits );
+void EcalClusterLazyToolsBase::getESRecHits(const edm::Event &ev) {
+  edm::Handle<EcalRecHitCollection> pESRecHits;
+  ev.getByToken(esRHToken_, pESRecHits);
   esRecHits_ = pESRecHits.product();
   // make the map of rechits
   rechits_map_.clear();
@@ -64,19 +69,20 @@ void EcalClusterLazyToolsBase::getESRecHits( const edm::Event &ev ) {
     EcalRecHitCollection::const_iterator it;
     for (it = pESRecHits->begin(); it != pESRecHits->end(); ++it) {
       // remove bad ES rechits
-  	std::vector<int> badf = {
-  	  EcalRecHit::ESFlags::kESDead, // 1
-  	  EcalRecHit::ESFlags::kESTwoGoodRatios,
-  	  EcalRecHit::ESFlags::kESBadRatioFor12, // 5
-  	  EcalRecHit::ESFlags::kESBadRatioFor23Upper,
-  	  EcalRecHit::ESFlags::kESBadRatioFor23Lower,
-  	  EcalRecHit::ESFlags::kESTS1Largest,
-  	  EcalRecHit::ESFlags::kESTS3Largest,
-  	  EcalRecHit::ESFlags::kESTS3Negative, // 10
-  	  EcalRecHit::ESFlags::kESTS13Sigmas, // 14
-  	};
-  	
-  	if (it->checkFlags(badf)) continue;
+      std::vector<int> badf = {
+          EcalRecHit::ESFlags::kESDead,  // 1
+          EcalRecHit::ESFlags::kESTwoGoodRatios,
+          EcalRecHit::ESFlags::kESBadRatioFor12,  // 5
+          EcalRecHit::ESFlags::kESBadRatioFor23Upper,
+          EcalRecHit::ESFlags::kESBadRatioFor23Lower,
+          EcalRecHit::ESFlags::kESTS1Largest,
+          EcalRecHit::ESFlags::kESTS3Largest,
+          EcalRecHit::ESFlags::kESTS3Negative,  // 10
+          EcalRecHit::ESFlags::kESTS13Sigmas,   // 14
+      };
+
+      if (it->checkFlags(badf))
+        continue;
 
       //Make the map of DetID, EcalRecHit pairs
       rechits_map_.insert(std::make_pair(it->id(), *it));
@@ -84,200 +90,200 @@ void EcalClusterLazyToolsBase::getESRecHits( const edm::Event &ev ) {
   }
 }
 
-
-
-void EcalClusterLazyToolsBase::getIntercalibConstants( const edm::EventSetup &es )
-{
+void EcalClusterLazyToolsBase::getIntercalibConstants(const edm::EventSetup &es) {
   // get IC's
   es.get<EcalIntercalibConstantsRcd>().get(ical);
   icalMap = &ical->getMap();
 }
 
-
-
-void EcalClusterLazyToolsBase::getADCToGeV( const edm::EventSetup &es )
-{
+void EcalClusterLazyToolsBase::getADCToGeV(const edm::EventSetup &es) {
   // get ADCtoGeV
   es.get<EcalADCToGeVConstantRcd>().get(agc);
 }
 
-
-
-void EcalClusterLazyToolsBase::getLaserDbService     ( const edm::EventSetup &es ){
+void EcalClusterLazyToolsBase::getLaserDbService(const edm::EventSetup &es) {
   // transp corrections
   es.get<EcalLaserDbRecord>().get(laser);
 }
 
-
-const EcalRecHitCollection * EcalClusterLazyToolsBase::getEcalRecHitCollection( const reco::BasicCluster &cluster ) const
-{
-        if ( cluster.size() == 0 ) {
-                throw cms::Exception("InvalidCluster") << "The cluster has no crystals!";
-        }
-        DetId id = (cluster.hitsAndFractions()[0]).first; // size is by definition > 0 -- FIXME??
-        const EcalRecHitCollection *recHits = nullptr;
-        if ( id.subdetId() == EcalBarrel ) {
-                recHits = ebRecHits_;
-        } else if ( id.subdetId() == EcalEndcap ) {
-                recHits = eeRecHits_;
-        } else {
-                throw cms::Exception("InvalidSubdetector") << "The subdetId() " << id.subdetId() << " does not correspond to EcalBarrel neither EcalEndcap";
-        }
-        return recHits;
+const EcalRecHitCollection *EcalClusterLazyToolsBase::getEcalRecHitCollection(const reco::BasicCluster &cluster) const {
+  if (cluster.size() == 0) {
+    throw cms::Exception("InvalidCluster") << "The cluster has no crystals!";
+  }
+  DetId id = (cluster.hitsAndFractions()[0]).first;  // size is by definition > 0 -- FIXME??
+  const EcalRecHitCollection *recHits = nullptr;
+  if (id.subdetId() == EcalBarrel) {
+    recHits = ebRecHits_;
+  } else if (id.subdetId() == EcalEndcap) {
+    recHits = eeRecHits_;
+  } else {
+    throw cms::Exception("InvalidSubdetector")
+        << "The subdetId() " << id.subdetId() << " does not correspond to EcalBarrel neither EcalEndcap";
+  }
+  return recHits;
 }
 
+// get time of basic cluster seed crystal
+float EcalClusterLazyToolsBase::BasicClusterSeedTime(const reco::BasicCluster &cluster) {
+  const EcalRecHitCollection *recHits = getEcalRecHitCollection(cluster);
 
-// get time of basic cluster seed crystal 
-float EcalClusterLazyToolsBase::BasicClusterSeedTime(const reco::BasicCluster &cluster)
-{
-  
-  const EcalRecHitCollection *recHits = getEcalRecHitCollection( cluster );
-  
   DetId id = cluster.seed();
-  EcalRecHitCollection::const_iterator theSeedHit = recHits->find (id);
-  //  std::cout << "the seed of the BC has time: " 
-  //<< (*theSeedHit).time() 
-  //<< "and energy: " << (*theSeedHit).energy() << " collection size: " << recHits->size() 
+  EcalRecHitCollection::const_iterator theSeedHit = recHits->find(id);
+  //  std::cout << "the seed of the BC has time: "
+  //<< (*theSeedHit).time()
+  //<< "and energy: " << (*theSeedHit).energy() << " collection size: " << recHits->size()
   //<< "\n" <<std::endl; // GF debug
-  
+
   return (*theSeedHit).time();
 }
 
-
-// error-weighted average of time from constituents of basic cluster 
-float EcalClusterLazyToolsBase::BasicClusterTime(const reco::BasicCluster &cluster, const edm::Event &ev)
-{
-  
-  std::vector<std::pair<DetId, float> > clusterComponents = (cluster).hitsAndFractions() ;
+// error-weighted average of time from constituents of basic cluster
+float EcalClusterLazyToolsBase::BasicClusterTime(const reco::BasicCluster &cluster, const edm::Event &ev) {
+  std::vector<std::pair<DetId, float> > clusterComponents = (cluster).hitsAndFractions();
   //std::cout << "BC has this many components: " << clusterComponents.size() << std::endl; // GF debug
-  
-  const EcalRecHitCollection *recHits = getEcalRecHitCollection( cluster );
+
+  const EcalRecHitCollection *recHits = getEcalRecHitCollection(cluster);
   //std::cout << "BasicClusterClusterTime - rechits are this many: " << recHits->size() << std::endl; // GF debug
-  
-  
-  float weightedTsum   = 0;
-  float sumOfWeights   = 0;
-  
-  for (std::vector<std::pair<DetId, float> >::const_iterator detitr = clusterComponents.begin(); detitr != clusterComponents.end(); detitr++ )
-    {
-      //      EcalRecHitCollection::const_iterator theSeedHit = recHits->find (id); // trash this
-      EcalRecHitCollection::const_iterator oneHit = recHits->find( (detitr -> first) ) ;
-      
-      // in order to get back the ADC counts from the recHit energy, three ingredients are necessary:
-      // 1) get laser correction coefficient
-      float lasercalib = 1.;
-      lasercalib = laser->getLaserCorrection( detitr->first, ev.time());
-      // 2) get intercalibration
-      EcalIntercalibConstantMap::const_iterator icalit = icalMap->find(detitr->first);
-      EcalIntercalibConstant icalconst = 1.;
-      if( icalit!=icalMap->end() ) {
-	icalconst = (*icalit);
-	// std::cout << "icalconst set to: " << icalconst << std::endl;
-      } else {
-	edm::LogError("EcalClusterLazyTools") << "No intercalib const found for xtal "  << (detitr->first).rawId() << "bailing out";
-	assert(false);
-      }
-      // 3) get adc2GeV
-      float adcToGeV = 1.;
-      if       ( (detitr -> first).subdetId() == EcalBarrel )  adcToGeV = float(agc->getEBValue());
-      else if  ( (detitr -> first).subdetId() == EcalEndcap )  adcToGeV = float(agc->getEEValue());
-            float adc = 2.;
-      if (icalconst>0 && lasercalib>0 && adcToGeV>0)  adc= (*oneHit).energy()/(icalconst*lasercalib*adcToGeV);
 
-      // don't consider recHits with too little amplitude; take sigma_noise_total into account
-      if( (detitr -> first).subdetId() == EcalBarrel  &&  adc< (1.1*20) ) continue;
-      if( (detitr -> first).subdetId() == EcalEndcap  &&  adc< (2.2*20) ) continue;
+  float weightedTsum = 0;
+  float sumOfWeights = 0;
 
-      // count only on rechits whose error is trusted by the method (ratio)
-      if(! (*oneHit).isTimeErrorValid()) continue;
+  for (std::vector<std::pair<DetId, float> >::const_iterator detitr = clusterComponents.begin();
+       detitr != clusterComponents.end();
+       detitr++) {
+    //      EcalRecHitCollection::const_iterator theSeedHit = recHits->find (id); // trash this
+    EcalRecHitCollection::const_iterator oneHit = recHits->find((detitr->first));
 
-      float timeError    = (*oneHit).timeError();
-      // the constant used to build timeError is largely over-estimated ; remove in quadrature 0.6 and add 0.15 back.
-      // could be prettier if value of constant term was changed at recHit production level
-      if (timeError>0.6) timeError = sqrt( timeError*timeError - 0.6*0.6 + 0.15*0.15);
-      else               timeError = sqrt( timeError*timeError           + 0.15*0.15);
-
-      // do the error weighting
-      weightedTsum += (*oneHit).time() / (timeError*timeError);
-      sumOfWeights += 1. / (timeError*timeError);
-
+    // in order to get back the ADC counts from the recHit energy, three ingredients are necessary:
+    // 1) get laser correction coefficient
+    float lasercalib = 1.;
+    lasercalib = laser->getLaserCorrection(detitr->first, ev.time());
+    // 2) get intercalibration
+    EcalIntercalibConstantMap::const_iterator icalit = icalMap->find(detitr->first);
+    EcalIntercalibConstant icalconst = 1.;
+    if (icalit != icalMap->end()) {
+      icalconst = (*icalit);
+      // std::cout << "icalconst set to: " << icalconst << std::endl;
+    } else {
+      edm::LogError("EcalClusterLazyTools")
+          << "No intercalib const found for xtal " << (detitr->first).rawId() << "bailing out";
+      assert(false);
     }
-  
+    // 3) get adc2GeV
+    float adcToGeV = 1.;
+    if ((detitr->first).subdetId() == EcalBarrel)
+      adcToGeV = float(agc->getEBValue());
+    else if ((detitr->first).subdetId() == EcalEndcap)
+      adcToGeV = float(agc->getEEValue());
+    float adc = 2.;
+    if (icalconst > 0 && lasercalib > 0 && adcToGeV > 0)
+      adc = (*oneHit).energy() / (icalconst * lasercalib * adcToGeV);
+
+    // don't consider recHits with too little amplitude; take sigma_noise_total into account
+    if ((detitr->first).subdetId() == EcalBarrel && adc < (1.1 * 20))
+      continue;
+    if ((detitr->first).subdetId() == EcalEndcap && adc < (2.2 * 20))
+      continue;
+
+    // count only on rechits whose error is trusted by the method (ratio)
+    if (!(*oneHit).isTimeErrorValid())
+      continue;
+
+    float timeError = (*oneHit).timeError();
+    // the constant used to build timeError is largely over-estimated ; remove in quadrature 0.6 and add 0.15 back.
+    // could be prettier if value of constant term was changed at recHit production level
+    if (timeError > 0.6)
+      timeError = sqrt(timeError * timeError - 0.6 * 0.6 + 0.15 * 0.15);
+    else
+      timeError = sqrt(timeError * timeError + 0.15 * 0.15);
+
+    // do the error weighting
+    weightedTsum += (*oneHit).time() / (timeError * timeError);
+    sumOfWeights += 1. / (timeError * timeError);
+  }
+
   // what if no crytal is available for weighted average?
-  if     ( sumOfWeights ==0 )  return -999;
-  else   return ( weightedTsum / sumOfWeights);
-
+  if (sumOfWeights == 0)
+    return -999;
+  else
+    return (weightedTsum / sumOfWeights);
 }
-
 
 // get BasicClusterSeedTime of the seed basic cluser of the supercluster
-float EcalClusterLazyToolsBase::SuperClusterSeedTime(const reco::SuperCluster &cluster){
-
-  return BasicClusterSeedTime ( (*cluster.seed()) );
-
+float EcalClusterLazyToolsBase::SuperClusterSeedTime(const reco::SuperCluster &cluster) {
+  return BasicClusterSeedTime((*cluster.seed()));
 }
-
 
 // get BasicClusterTime of the seed basic cluser of the supercluster
-float EcalClusterLazyToolsBase::SuperClusterTime(const reco::SuperCluster &cluster, const edm::Event &ev){
-  
-  return BasicClusterTime ( (*cluster.seed()) , ev);
-
+float EcalClusterLazyToolsBase::SuperClusterTime(const reco::SuperCluster &cluster, const edm::Event &ev) {
+  return BasicClusterTime((*cluster.seed()), ev);
 }
 
-
 // get Preshower effective sigmaIRIR
-float EcalClusterLazyToolsBase::eseffsirir(const reco::SuperCluster &cluster)
-{
-  if (!(fabs(cluster.eta()) > 1.6 && fabs(cluster.eta()) < 3.)) return 0.;
+float EcalClusterLazyToolsBase::eseffsirir(const reco::SuperCluster &cluster) {
+  if (!(fabs(cluster.eta()) > 1.6 && fabs(cluster.eta()) < 3.))
+    return 0.;
 
-  if (!ecalPS_topology_) return 0.;
+  if (!ecalPS_topology_)
+    return 0.;
 
-  std::vector<float> phoESHitsIXIX = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, ecalPS_topology_.get(), 0, 1);
-  std::vector<float> phoESHitsIYIY = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, ecalPS_topology_.get(), 0, 2);
+  std::vector<float> phoESHitsIXIX =
+      getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, ecalPS_topology_.get(), 0, 1);
+  std::vector<float> phoESHitsIYIY =
+      getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, ecalPS_topology_.get(), 0, 2);
   float phoESShapeIXIX = getESShape(phoESHitsIXIX);
   float phoESShapeIYIY = getESShape(phoESHitsIYIY);
 
-  return sqrt(phoESShapeIXIX*phoESShapeIXIX + phoESShapeIYIY*phoESShapeIYIY);
+  return sqrt(phoESShapeIXIX * phoESShapeIXIX + phoESShapeIYIY * phoESShapeIYIY);
 }
 
 // get Preshower effective sigmaIXIX
-float EcalClusterLazyToolsBase::eseffsixix(const reco::SuperCluster &cluster)
-{
-  if (!(fabs(cluster.eta()) > 1.6 && fabs(cluster.eta()) < 3.)) return 0.;
+float EcalClusterLazyToolsBase::eseffsixix(const reco::SuperCluster &cluster) {
+  if (!(fabs(cluster.eta()) > 1.6 && fabs(cluster.eta()) < 3.))
+    return 0.;
 
-  if (!ecalPS_topology_) return 0.;
+  if (!ecalPS_topology_)
+    return 0.;
 
-  std::vector<float> phoESHitsIXIX = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, ecalPS_topology_.get(), 0, 1);
+  std::vector<float> phoESHitsIXIX =
+      getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, ecalPS_topology_.get(), 0, 1);
   float phoESShapeIXIX = getESShape(phoESHitsIXIX);
 
   return phoESShapeIXIX;
 }
 
 // get Preshower effective sigmaIYIY
-float EcalClusterLazyToolsBase::eseffsiyiy(const reco::SuperCluster &cluster)
-{
-  if (!(fabs(cluster.eta()) > 1.6 && fabs(cluster.eta()) < 3.)) return 0.;
+float EcalClusterLazyToolsBase::eseffsiyiy(const reco::SuperCluster &cluster) {
+  if (!(fabs(cluster.eta()) > 1.6 && fabs(cluster.eta()) < 3.))
+    return 0.;
 
-  if (!ecalPS_topology_) return 0.;
+  if (!ecalPS_topology_)
+    return 0.;
 
-  std::vector<float> phoESHitsIYIY = getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, ecalPS_topology_.get(), 0, 2);
+  std::vector<float> phoESHitsIYIY =
+      getESHits(cluster.x(), cluster.y(), cluster.z(), rechits_map_, geometry_, ecalPS_topology_.get(), 0, 2);
   float phoESShapeIYIY = getESShape(phoESHitsIYIY);
 
   return phoESShapeIYIY;
 }
 
 // get Preshower Rechits
-std::vector<float> EcalClusterLazyToolsBase::getESHits(double X, double Y, double Z, const std::map<DetId, EcalRecHit>& _rechits_map, const CaloGeometry* geometry, CaloSubdetectorTopology const *topology_p, int row, int plane) 
-{
+std::vector<float> EcalClusterLazyToolsBase::getESHits(double X,
+                                                       double Y,
+                                                       double Z,
+                                                       const std::map<DetId, EcalRecHit> &_rechits_map,
+                                                       const CaloGeometry *geometry,
+                                                       CaloSubdetectorTopology const *topology_p,
+                                                       int row,
+                                                       int plane) {
   std::map<DetId, EcalRecHit> rechits_map = _rechits_map;
   std::vector<float> esHits;
 
-  const GlobalPoint point(X,Y,Z);
+  const GlobalPoint point(X, Y, Z);
 
-  const CaloSubdetectorGeometry *geometry_p = geometry->getSubdetectorGeometry (DetId::Ecal,EcalPreshower);
+  const CaloSubdetectorGeometry *geometry_p = geometry->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
 
-  DetId esId = (dynamic_cast<const EcalPreshowerGeometry*>(geometry_p))->getClosestCellInPlane(point, plane);
+  DetId esId = (dynamic_cast<const EcalPreshowerGeometry *>(geometry_p))->getClosestCellInPlane(point, plane);
   ESDetId esDetId = (esId == DetId(0)) ? ESDetId(0) : ESDetId(esId);
 
   std::map<DetId, EcalRecHit>::iterator it;
@@ -289,34 +295,43 @@ std::vector<float> EcalClusterLazyToolsBase::getESHits(double X, double Y, doubl
   theESNav.setHome(strip);
 
   if (row == 1) {
-    if (plane==1 && strip != ESDetId(0)) strip = theESNav.north();
-    if (plane==2 && strip != ESDetId(0)) strip = theESNav.east();
+    if (plane == 1 && strip != ESDetId(0))
+      strip = theESNav.north();
+    if (plane == 2 && strip != ESDetId(0))
+      strip = theESNav.east();
   } else if (row == -1) {
-    if (plane==1 && strip != ESDetId(0)) strip = theESNav.south();
-    if (plane==2 && strip != ESDetId(0)) strip = theESNav.west();
+    if (plane == 1 && strip != ESDetId(0))
+      strip = theESNav.south();
+    if (plane == 2 && strip != ESDetId(0))
+      strip = theESNav.west();
   }
 
-
   if (strip == ESDetId(0)) {
-    for (int i=0; i<31; ++i) esHits.push_back(0);
+    for (int i = 0; i < 31; ++i)
+      esHits.push_back(0);
   } else {
     it = rechits_map.find(strip);
-    if (it != rechits_map.end() && it->second.energy() > 1.0e-10) esHits.push_back(it->second.energy());
-    else esHits.push_back(0);
+    if (it != rechits_map.end() && it->second.energy() > 1.0e-10)
+      esHits.push_back(it->second.energy());
+    else
+      esHits.push_back(0);
     //cout<<"center : "<<strip<<" "<<it->second.energy()<<endl;
 
     // Front Plane
-    if (plane==1) {
+    if (plane == 1) {
       // east road
-      for (int i=0; i<15; ++i) {
+      for (int i = 0; i < 15; ++i) {
         next = theESNav.east();
         if (next != ESDetId(0)) {
           it = rechits_map.find(next);
-          if (it != rechits_map.end() && it->second.energy() > 1.0e-10) esHits.push_back(it->second.energy());
-          else esHits.push_back(0);
+          if (it != rechits_map.end() && it->second.energy() > 1.0e-10)
+            esHits.push_back(it->second.energy());
+          else
+            esHits.push_back(0);
           //cout<<"east "<<i<<" : "<<next<<" "<<it->second.energy()<<endl;
         } else {
-          for (int j=i; j<15; j++) esHits.push_back(0);
+          for (int j = i; j < 15; j++)
+            esHits.push_back(0);
           break;
           //cout<<"east "<<i<<" : "<<next<<" "<<0<<endl;
         }
@@ -325,33 +340,39 @@ std::vector<float> EcalClusterLazyToolsBase::getESHits(double X, double Y, doubl
       // west road
       theESNav.setHome(strip);
       theESNav.home();
-      for (int i=0; i<15; ++i) {
+      for (int i = 0; i < 15; ++i) {
         next = theESNav.west();
         if (next != ESDetId(0)) {
           it = rechits_map.find(next);
-          if (it != rechits_map.end() && it->second.energy() > 1.0e-10) esHits.push_back(it->second.energy());
-          else esHits.push_back(0);
+          if (it != rechits_map.end() && it->second.energy() > 1.0e-10)
+            esHits.push_back(it->second.energy());
+          else
+            esHits.push_back(0);
           //cout<<"west "<<i<<" : "<<next<<" "<<it->second.energy()<<endl;
         } else {
-          for (int j=i; j<15; j++) esHits.push_back(0);
+          for (int j = i; j < 15; j++)
+            esHits.push_back(0);
           break;
           //cout<<"west "<<i<<" : "<<next<<" "<<0<<endl;
         }
       }
-    } // End of Front Plane
+    }  // End of Front Plane
 
     // Rear Plane
-    if (plane==2) {
+    if (plane == 2) {
       // north road
-      for (int i=0; i<15; ++i) {
+      for (int i = 0; i < 15; ++i) {
         next = theESNav.north();
         if (next != ESDetId(0)) {
           it = rechits_map.find(next);
-          if (it != rechits_map.end() && it->second.energy() > 1.0e-10) esHits.push_back(it->second.energy());
-          else esHits.push_back(0);
+          if (it != rechits_map.end() && it->second.energy() > 1.0e-10)
+            esHits.push_back(it->second.energy());
+          else
+            esHits.push_back(0);
           //cout<<"north "<<i<<" : "<<next<<" "<<it->second.energy()<<endl;
         } else {
-          for (int j=i; j<15; j++) esHits.push_back(0);
+          for (int j = i; j < 15; j++)
+            esHits.push_back(0);
           break;
           //cout<<"north "<<i<<" : "<<next<<" "<<0<<endl;
         }
@@ -360,53 +381,54 @@ std::vector<float> EcalClusterLazyToolsBase::getESHits(double X, double Y, doubl
       // south road
       theESNav.setHome(strip);
       theESNav.home();
-      for (int i=0; i<15; ++i) {
+      for (int i = 0; i < 15; ++i) {
         next = theESNav.south();
         if (next != ESDetId(0)) {
           it = rechits_map.find(next);
-          if (it != rechits_map.end() && it->second.energy() > 1.0e-10) esHits.push_back(it->second.energy());
-          else esHits.push_back(0);
+          if (it != rechits_map.end() && it->second.energy() > 1.0e-10)
+            esHits.push_back(it->second.energy());
+          else
+            esHits.push_back(0);
           //cout<<"south "<<i<<" : "<<next<<" "<<it->second.energy()<<endl;
         } else {
-          for (int j=i; j<15; j++) esHits.push_back(0);
+          for (int j = i; j < 15; j++)
+            esHits.push_back(0);
           break;
           //cout<<"south "<<i<<" : "<<next<<" "<<0<<endl;
         }
       }
-    } // End of Rear Plane
-  } // Fill ES RecHits
+    }  // End of Rear Plane
+  }    // Fill ES RecHits
 
   return esHits;
 }
 
-
 // get Preshower hit shape
-float EcalClusterLazyToolsBase::getESShape(const std::vector<float>& ESHits0)
-{
+float EcalClusterLazyToolsBase::getESShape(const std::vector<float> &ESHits0) {
   const int nBIN = 21;
   float esRH[nBIN];
-  for (int idx=0; idx<nBIN; idx++) {
+  for (int idx = 0; idx < nBIN; idx++) {
     esRH[idx] = 0.;
   }
 
-  for(int ibin=0; ibin<((nBIN+1)/2); ibin++) {
-    if (ibin==0) {
-      esRH[(nBIN-1)/2] = ESHits0[ibin];
+  for (int ibin = 0; ibin < ((nBIN + 1) / 2); ibin++) {
+    if (ibin == 0) {
+      esRH[(nBIN - 1) / 2] = ESHits0[ibin];
     } else {
-      esRH[(nBIN-1)/2+ibin] = ESHits0[ibin];
-      esRH[(nBIN-1)/2-ibin] = ESHits0[ibin+15];
+      esRH[(nBIN - 1) / 2 + ibin] = ESHits0[ibin];
+      esRH[(nBIN - 1) / 2 - ibin] = ESHits0[ibin + 15];
     }
   }
 
   // ---- Effective Energy Deposit Width ---- //
   double EffWidthSigmaISIS = 0.;
-  double totalEnergyISIS   = 0.;
-  double EffStatsISIS      = 0.;
-  for (int id_X=0; id_X<21; id_X++) {
-    totalEnergyISIS  += esRH[id_X];
-    EffStatsISIS     += esRH[id_X]*(id_X-10)*(id_X-10);
+  double totalEnergyISIS = 0.;
+  double EffStatsISIS = 0.;
+  for (int id_X = 0; id_X < 21; id_X++) {
+    totalEnergyISIS += esRH[id_X];
+    EffStatsISIS += esRH[id_X] * (id_X - 10) * (id_X - 10);
   }
-  EffWidthSigmaISIS  = (totalEnergyISIS>0.)  ? sqrt(fabs(EffStatsISIS  / totalEnergyISIS))   : 0.;
+  EffWidthSigmaISIS = (totalEnergyISIS > 0.) ? sqrt(fabs(EffStatsISIS / totalEnergyISIS)) : 0.;
 
   return EffWidthSigmaISIS;
 }

--- a/RecoEcal/EgammaCoreTools/src/EcalClusterPUCleaningTools.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClusterPUCleaningTools.cc
@@ -11,120 +11,109 @@
 
 #include "RecoEcal/EgammaCoreTools/interface/SuperClusterShapeAlgo.h"
 
-EcalClusterPUCleaningTools::EcalClusterPUCleaningTools( const edm::Event &ev, const edm::EventSetup &es, const edm::InputTag& redEBRecHits, const edm::InputTag& redEERecHits )
-{
-  getGeometry( es );
-  getEBRecHits( ev, redEBRecHits );
-  getEERecHits( ev, redEERecHits );
+EcalClusterPUCleaningTools::EcalClusterPUCleaningTools(const edm::Event &ev,
+                                                       const edm::EventSetup &es,
+                                                       const edm::InputTag &redEBRecHits,
+                                                       const edm::InputTag &redEERecHits) {
+  getGeometry(es);
+  getEBRecHits(ev, redEBRecHits);
+  getEERecHits(ev, redEERecHits);
 }
 
+EcalClusterPUCleaningTools::~EcalClusterPUCleaningTools() {}
 
-
-EcalClusterPUCleaningTools::~EcalClusterPUCleaningTools()
-{
-}
-
-
-void EcalClusterPUCleaningTools::getGeometry( const edm::EventSetup &es )
-{
+void EcalClusterPUCleaningTools::getGeometry(const edm::EventSetup &es) {
   edm::ESHandle<CaloGeometry> pGeometry;
   es.get<CaloGeometryRecord>().get(pGeometry);
   geometry_ = pGeometry.product();
 }
 
-void EcalClusterPUCleaningTools::getEBRecHits( const edm::Event &ev, const edm::InputTag& redEBRecHits )
-{
-  edm::Handle< EcalRecHitCollection > pEBRecHits;
-  ev.getByLabel( redEBRecHits, pEBRecHits );
+void EcalClusterPUCleaningTools::getEBRecHits(const edm::Event &ev, const edm::InputTag &redEBRecHits) {
+  edm::Handle<EcalRecHitCollection> pEBRecHits;
+  ev.getByLabel(redEBRecHits, pEBRecHits);
   ebRecHits_ = pEBRecHits.product();
 }
 
-
-
-void EcalClusterPUCleaningTools::getEERecHits( const edm::Event &ev, const edm::InputTag& redEERecHits )
-{
-  edm::Handle< EcalRecHitCollection > pEERecHits;
-  ev.getByLabel( redEERecHits, pEERecHits );
+void EcalClusterPUCleaningTools::getEERecHits(const edm::Event &ev, const edm::InputTag &redEERecHits) {
+  edm::Handle<EcalRecHitCollection> pEERecHits;
+  ev.getByLabel(redEERecHits, pEERecHits);
   eeRecHits_ = pEERecHits.product();
 }
 
-
-reco::SuperCluster EcalClusterPUCleaningTools::CleanedSuperCluster(float xi, const reco::SuperCluster &scluster, const edm::Event &ev ){
-  
+reco::SuperCluster EcalClusterPUCleaningTools::CleanedSuperCluster(float xi,
+                                                                   const reco::SuperCluster &scluster,
+                                                                   const edm::Event &ev) {
   //std::cout << "\nEcalClusterPUCleaningTools::CleanedSuperCluster called, this will give you back a cleaned supercluster" << std::endl;
 
   // seed basic cluster of initial SC: this will remain in the cleaned SC, by construction
-  const reco::CaloClusterPtr& seed = scluster.seed();
+  const reco::CaloClusterPtr &seed = scluster.seed();
 
-  float seedBCEnergy      = (scluster.seed())->energy(); // this should be replaced by the 5x5 around the seed; a good approx of how E_seed is defined 
-  float eSeed             = 0.35;                        // standard eSeed in EB ; see CMS IN-2010/008
-  int   numBcRemoved      = 0;  
+  float seedBCEnergy =
+      (scluster.seed())
+          ->energy();  // this should be replaced by the 5x5 around the seed; a good approx of how E_seed is defined
+  float eSeed = 0.35;  // standard eSeed in EB ; see CMS IN-2010/008
+  int numBcRemoved = 0;
 
-  double ClusterE = 0; //Sum of cluster energies for supercluster.
+  double ClusterE = 0;  //Sum of cluster energies for supercluster.
   //Holders for position of this supercluster.
-  double posX=0;
-  double posY=0;
-  double posZ=0;
+  double posX = 0;
+  double posY = 0;
+  double posZ = 0;
 
   reco::CaloClusterPtrVector thissc;
 
   // looping on basic clusters within the Supercluster
-  for(reco::CaloCluster_iterator bcIt = scluster.clustersBegin(); bcIt!=scluster.clustersEnd(); bcIt++)
-    {
-      // E_seed is an Et  selection on 5x1 dominoes (around which BC's are built), see CMS IN-2010/008
-      // here such selection is implemented on the full BC around it 
-      if( (*bcIt)->energy() > sqrt( eSeed*eSeed + xi*xi*seedBCEnergy*seedBCEnergy/cosh((*bcIt)->eta())/cosh((*bcIt)->eta())  ) ) 
-	{
-	  ;
-	}// the sum only of the BC's that pass the Esee selection
-      else{
-	numBcRemoved++;
-	continue;
-      }// count how many basic cluster get removed by the cleaning
-      
-      // if BC passes dynamic selection, include it in the 'cleaned' supercluster
-      thissc.push_back( (*bcIt) );
-      // cumulate energy and position of the cleaned supercluster
-      ClusterE += (*bcIt)->energy();
-      posX += (*bcIt)->energy() * (*bcIt)->position().X();
-      posY += (*bcIt)->energy() * (*bcIt)->position().Y();
-      posZ += (*bcIt)->energy() * (*bcIt)->position().Z();
-      
-    }// loop on basic clusters of the original SC
+  for (reco::CaloCluster_iterator bcIt = scluster.clustersBegin(); bcIt != scluster.clustersEnd(); bcIt++) {
+    // E_seed is an Et  selection on 5x1 dominoes (around which BC's are built), see CMS IN-2010/008
+    // here such selection is implemented on the full BC around it
+    if ((*bcIt)->energy() >
+        sqrt(eSeed * eSeed + xi * xi * seedBCEnergy * seedBCEnergy / cosh((*bcIt)->eta()) / cosh((*bcIt)->eta()))) {
+      ;
+    }  // the sum only of the BC's that pass the Esee selection
+    else {
+      numBcRemoved++;
+      continue;
+    }  // count how many basic cluster get removed by the cleaning
+
+    // if BC passes dynamic selection, include it in the 'cleaned' supercluster
+    thissc.push_back((*bcIt));
+    // cumulate energy and position of the cleaned supercluster
+    ClusterE += (*bcIt)->energy();
+    posX += (*bcIt)->energy() * (*bcIt)->position().X();
+    posY += (*bcIt)->energy() * (*bcIt)->position().Y();
+    posZ += (*bcIt)->energy() * (*bcIt)->position().Z();
+
+  }  // loop on basic clusters of the original SC
 
   posX /= ClusterE;
   posY /= ClusterE;
   posZ /= ClusterE;
 
-  // make temporary 'cleaned' supercluster in oder to compute the covariances 
-  double Epreshower=scluster.preshowerEnergy();
-  double phiWidth=0.; 
-  double etaWidth=0.; 
+  // make temporary 'cleaned' supercluster in oder to compute the covariances
+  double Epreshower = scluster.preshowerEnergy();
+  double phiWidth = 0.;
+  double etaWidth = 0.;
   reco::SuperCluster suCltmp(ClusterE, math::XYZPoint(posX, posY, posZ), seed, thissc, Epreshower, phiWidth, etaWidth);
-  
 
-  // construct cluster shape to compute ieta and iphi covariances of the SC 
-  const CaloSubdetectorGeometry *geometry_p=nullptr;
-  if (seed->seed().det() == DetId::Ecal && seed->seed().subdetId() == EcalBarrel){
+  // construct cluster shape to compute ieta and iphi covariances of the SC
+  const CaloSubdetectorGeometry *geometry_p = nullptr;
+  if (seed->seed().det() == DetId::Ecal && seed->seed().subdetId() == EcalBarrel) {
     geometry_p = geometry_->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-    SuperClusterShapeAlgo  SCShape(   ebRecHits_ , geometry_p); 
-    SCShape.Calculate_Covariances( suCltmp );
-    phiWidth= SCShape.phiWidth(); 
-    etaWidth= SCShape.etaWidth(); 
-  }
-  else if (seed->seed().det() == DetId::Ecal && seed->seed().subdetId() == EcalEndcap){
+    SuperClusterShapeAlgo SCShape(ebRecHits_, geometry_p);
+    SCShape.Calculate_Covariances(suCltmp);
+    phiWidth = SCShape.phiWidth();
+    etaWidth = SCShape.etaWidth();
+  } else if (seed->seed().det() == DetId::Ecal && seed->seed().subdetId() == EcalEndcap) {
     geometry_p = geometry_->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-    SuperClusterShapeAlgo  SCShape(   eeRecHits_ , geometry_p); 
-    SCShape.Calculate_Covariances( suCltmp );
-    phiWidth= SCShape.phiWidth(); 
-    etaWidth= SCShape.etaWidth(); 
-  }
-  else {
+    SuperClusterShapeAlgo SCShape(eeRecHits_, geometry_p);
+    SCShape.Calculate_Covariances(suCltmp);
+    phiWidth = SCShape.phiWidth();
+    etaWidth = SCShape.etaWidth();
+  } else {
     std::cout << "The seed crystal of this SC is neither in EB nor in EE. This is a problem. Bailing out " << std::endl;
     assert(-1);
   }
-  
-  // return the cleaned supercluster SCluster, with covariances updated 
-  return reco::SuperCluster(ClusterE, math::XYZPoint(posX, posY, posZ), seed, thissc, Epreshower, phiWidth, etaWidth);
 
+  // return the cleaned supercluster SCluster, with covariances updated
+  return reco::SuperCluster(ClusterE, math::XYZPoint(posX, posY, posZ), seed, thissc, Epreshower, phiWidth, etaWidth);
 }

--- a/RecoEcal/EgammaCoreTools/src/EcalClusterSeverityLevelAlgo.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClusterSeverityLevelAlgo.cc
@@ -7,135 +7,124 @@
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "Geometry/CaloTopology/interface/CaloTopology.h"
 
-float EcalClusterSeverityLevelAlgo::goodFraction( const reco::CaloCluster & cluster, 
-						  const EcalRecHitCollection & recHits, const EcalSeverityLevelAlgo& sevlv) 
-{
-        float fraction = 0.;
-        std::vector< std::pair<DetId, float> > hitsAndFracs = cluster.hitsAndFractions();
-        std::vector< std::pair<DetId, float> >::const_iterator it;
-        for ( it = hitsAndFracs.begin(); it != hitsAndFracs.end(); ++it ) {
-                DetId id = (*it).first;
-                EcalRecHitCollection::const_iterator jrh = recHits.find( id );
-                if ( jrh == recHits.end() ) {
-                        edm::LogError("EcalClusterSeverityLevelAlgo") << "The cluster DetId " << id.rawId() << " is not in the recHit collection!!";
-                        return -1;
-                }
-		      
-                uint32_t sev = sevlv.severityLevel( id, recHits);
-		//                if ( sev == EcalSeverityLevelAlgo::kBad ) ++recoveryFailed;
-                if ( sev == EcalSeverityLevel::kProblematic 
-                     || sev == EcalSeverityLevel::kRecovered || sev == EcalSeverityLevel::kBad ) 
-		  {
-// 		    std::cout << "[goodFraction] Found a problematic channel " << EBDetId(id) << " " << flag << " energy: " <<  (*jrh).energy() << std::endl;
-		    fraction += (*jrh).energy() * (*it).second / cluster.energy();
-		  }
-        }
-        return 1. - fraction;
+float EcalClusterSeverityLevelAlgo::goodFraction(const reco::CaloCluster& cluster,
+                                                 const EcalRecHitCollection& recHits,
+                                                 const EcalSeverityLevelAlgo& sevlv) {
+  float fraction = 0.;
+  std::vector<std::pair<DetId, float> > hitsAndFracs = cluster.hitsAndFractions();
+  std::vector<std::pair<DetId, float> >::const_iterator it;
+  for (it = hitsAndFracs.begin(); it != hitsAndFracs.end(); ++it) {
+    DetId id = (*it).first;
+    EcalRecHitCollection::const_iterator jrh = recHits.find(id);
+    if (jrh == recHits.end()) {
+      edm::LogError("EcalClusterSeverityLevelAlgo")
+          << "The cluster DetId " << id.rawId() << " is not in the recHit collection!!";
+      return -1;
+    }
+
+    uint32_t sev = sevlv.severityLevel(id, recHits);
+    //                if ( sev == EcalSeverityLevelAlgo::kBad ) ++recoveryFailed;
+    if (sev == EcalSeverityLevel::kProblematic || sev == EcalSeverityLevel::kRecovered ||
+        sev == EcalSeverityLevel::kBad) {
+      // 		    std::cout << "[goodFraction] Found a problematic channel " << EBDetId(id) << " " << flag << " energy: " <<  (*jrh).energy() << std::endl;
+      fraction += (*jrh).energy() * (*it).second / cluster.energy();
+    }
+  }
+  return 1. - fraction;
 }
 
-float EcalClusterSeverityLevelAlgo::fractionAroundClosestProblematic( const reco::CaloCluster & cluster, 
-								      const EcalRecHitCollection & recHits, const CaloTopology* topology, const EcalSeverityLevelAlgo& sevlv )
-{
-  DetId closestProb = closestProblematic(cluster , recHits, topology, sevlv);
+float EcalClusterSeverityLevelAlgo::fractionAroundClosestProblematic(const reco::CaloCluster& cluster,
+                                                                     const EcalRecHitCollection& recHits,
+                                                                     const CaloTopology* topology,
+                                                                     const EcalSeverityLevelAlgo& sevlv) {
+  DetId closestProb = closestProblematic(cluster, recHits, topology, sevlv);
   //  std::cout << "%%%%%%%%%%% Closest prob is " << EBDetId(closestProb) << std::endl;
   if (closestProb.null())
     return 0.;
-  
-  std::vector<DetId> neighbours = topology->getWindow(closestProb,3,3);
+
+  std::vector<DetId> neighbours = topology->getWindow(closestProb, 3, 3);
   std::vector<DetId>::const_iterator itn;
 
-  std::vector< std::pair<DetId, float> > hitsAndFracs = cluster.hitsAndFractions();
-  std::vector< std::pair<DetId, float> >::const_iterator it;
+  std::vector<std::pair<DetId, float> > hitsAndFracs = cluster.hitsAndFractions();
+  std::vector<std::pair<DetId, float> >::const_iterator it;
 
-  float fraction = 0.;  
+  float fraction = 0.;
 
-  for ( itn = neighbours.begin(); itn != neighbours.end(); ++itn )
-    {
-      //      std::cout << "Checking detId " << EBDetId((*itn)) << std::endl;
-      for ( it = hitsAndFracs.begin(); it != hitsAndFracs.end(); ++it ) 
-	{
-	  DetId id = (*it).first;
-	  if ( id != (*itn) )
-	    continue;
-	  //	  std::cout << "Is in cluster detId " << EBDetId(id) << std::endl;
-	  EcalRecHitCollection::const_iterator jrh = recHits.find( id );
-	  if ( jrh == recHits.end() ) 
-	    {
-	      edm::LogError("EcalClusterSeverityLevelAlgo") << "The cluster DetId " << id.rawId() << " is not in the recHit collection!!";
-	      return -1;
-	    }
+  for (itn = neighbours.begin(); itn != neighbours.end(); ++itn) {
+    //      std::cout << "Checking detId " << EBDetId((*itn)) << std::endl;
+    for (it = hitsAndFracs.begin(); it != hitsAndFracs.end(); ++it) {
+      DetId id = (*it).first;
+      if (id != (*itn))
+        continue;
+      //	  std::cout << "Is in cluster detId " << EBDetId(id) << std::endl;
+      EcalRecHitCollection::const_iterator jrh = recHits.find(id);
+      if (jrh == recHits.end()) {
+        edm::LogError("EcalClusterSeverityLevelAlgo")
+            << "The cluster DetId " << id.rawId() << " is not in the recHit collection!!";
+        return -1;
+      }
 
-	  fraction += (*jrh).energy() * (*it).second  / cluster.energy();
-	}
+      fraction += (*jrh).energy() * (*it).second / cluster.energy();
     }
+  }
   //  std::cout << "%%%%%%%%%%% Fraction is " << fraction << std::endl;
   return fraction;
 }
 
-DetId EcalClusterSeverityLevelAlgo::closestProblematic(const reco::CaloCluster & cluster, 
-						     const EcalRecHitCollection & recHits, 
-						       const CaloTopology* topology ,  const EcalSeverityLevelAlgo& sevlv)
-{
-  DetId seed=EcalClusterTools::getMaximum(cluster,&recHits).first;
-  if ( (seed.det() != DetId::Ecal) || 
-       (EcalSubdetector(seed.subdetId()) != EcalBarrel) )
-    {
-      //method not supported if not in Barrel
-      edm::LogError("EcalClusterSeverityLevelAlgo") << "The cluster seed is not in the BARREL";
-      return DetId(0);
-    }
+DetId EcalClusterSeverityLevelAlgo::closestProblematic(const reco::CaloCluster& cluster,
+                                                       const EcalRecHitCollection& recHits,
+                                                       const CaloTopology* topology,
+                                                       const EcalSeverityLevelAlgo& sevlv) {
+  DetId seed = EcalClusterTools::getMaximum(cluster, &recHits).first;
+  if ((seed.det() != DetId::Ecal) || (EcalSubdetector(seed.subdetId()) != EcalBarrel)) {
+    //method not supported if not in Barrel
+    edm::LogError("EcalClusterSeverityLevelAlgo") << "The cluster seed is not in the BARREL";
+    return DetId(0);
+  }
 
-  int minDist=9999; DetId closestProb(0);   
+  int minDist = 9999;
+  DetId closestProb(0);
   //Get a window of DetId around the seed crystal
-  std::vector<DetId> neighbours = topology->getWindow(seed,51,11);
+  std::vector<DetId> neighbours = topology->getWindow(seed, 51, 11);
 
-  for ( std::vector<DetId>::const_iterator it = neighbours.begin(); it != neighbours.end(); ++it ) 
-    {
-      EcalRecHitCollection::const_iterator jrh = recHits.find(*it);
-      if ( jrh == recHits.end() ) 
-	continue;
-      //Now checking rh flag   
-      uint32_t sev = sevlv.severityLevel( *it, recHits);
-      if (sev == EcalSeverityLevel::kGood)
-	continue;
-      //      std::cout << "[closestProblematic] Found a problematic channel " << EBDetId(*it) << " " << flag << std::endl;
-      //Find the closest DetId in eta,phi space (distance defined by deta^2 + dphi^2)
-      int deta=EBDetId::distanceEta(EBDetId(seed),EBDetId(*it));
-      int dphi=EBDetId::distancePhi(EBDetId(seed),EBDetId(*it));
-      double r = sqrt(deta*deta + dphi*dphi);
-      if (r < minDist){
-	closestProb = *it;
-	minDist = r;
-      }
+  for (std::vector<DetId>::const_iterator it = neighbours.begin(); it != neighbours.end(); ++it) {
+    EcalRecHitCollection::const_iterator jrh = recHits.find(*it);
+    if (jrh == recHits.end())
+      continue;
+    //Now checking rh flag
+    uint32_t sev = sevlv.severityLevel(*it, recHits);
+    if (sev == EcalSeverityLevel::kGood)
+      continue;
+    //      std::cout << "[closestProblematic] Found a problematic channel " << EBDetId(*it) << " " << flag << std::endl;
+    //Find the closest DetId in eta,phi space (distance defined by deta^2 + dphi^2)
+    int deta = EBDetId::distanceEta(EBDetId(seed), EBDetId(*it));
+    int dphi = EBDetId::distancePhi(EBDetId(seed), EBDetId(*it));
+    double r = sqrt(deta * deta + dphi * dphi);
+    if (r < minDist) {
+      closestProb = *it;
+      minDist = r;
     }
-      
+  }
+
   return closestProb;
 }
 
-std::pair<int,int> EcalClusterSeverityLevelAlgo::etaphiDistanceClosestProblematic( const reco::CaloCluster & cluster, 
-						     const EcalRecHitCollection & recHits, 
-										   const CaloTopology* topology,  const EcalSeverityLevelAlgo& sevlv )
-{
-  DetId seed=EcalClusterTools::getMaximum(cluster,&recHits).first;
-  if ( (seed.det() != DetId::Ecal) || 
-       (EcalSubdetector(seed.subdetId()) != EcalBarrel) )
-    {
-      edm::LogError("EcalClusterSeverityLevelAlgo") << "The cluster seed is not in the BARREL";
-      //method not supported if not in Barrel
-      return std::pair<int,int>(-1,-1);
-    }
+std::pair<int, int> EcalClusterSeverityLevelAlgo::etaphiDistanceClosestProblematic(const reco::CaloCluster& cluster,
+                                                                                   const EcalRecHitCollection& recHits,
+                                                                                   const CaloTopology* topology,
+                                                                                   const EcalSeverityLevelAlgo& sevlv) {
+  DetId seed = EcalClusterTools::getMaximum(cluster, &recHits).first;
+  if ((seed.det() != DetId::Ecal) || (EcalSubdetector(seed.subdetId()) != EcalBarrel)) {
+    edm::LogError("EcalClusterSeverityLevelAlgo") << "The cluster seed is not in the BARREL";
+    //method not supported if not in Barrel
+    return std::pair<int, int>(-1, -1);
+  }
 
-  DetId closestProb = closestProblematic(cluster , recHits, topology, sevlv);
+  DetId closestProb = closestProblematic(cluster, recHits, topology, sevlv);
 
-  if (! closestProb.null())
-    return std::pair<int,int>(EBDetId::distanceEta(EBDetId(seed),EBDetId(closestProb)),EBDetId::distancePhi(EBDetId(seed),EBDetId(closestProb)));
+  if (!closestProb.null())
+    return std::pair<int, int>(EBDetId::distanceEta(EBDetId(seed), EBDetId(closestProb)),
+                               EBDetId::distancePhi(EBDetId(seed), EBDetId(closestProb)));
   else
-    return std::pair<int,int>(-1,-1);
-} 
-
-
-
-
-
-
-
+    return std::pair<int, int>(-1, -1);
+}

--- a/RecoEcal/EgammaCoreTools/src/EcalNextToDeadChannelRcd.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalNextToDeadChannelRcd.cc
@@ -1,4 +1,4 @@
 #include "RecoEcal/EgammaCoreTools/interface/EcalNextToDeadChannelRcd.h"
 #include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
- 
+
 EVENTSETUP_RECORD_REG(EcalNextToDeadChannelRcd);

--- a/RecoEcal/EgammaCoreTools/src/EcalTools.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalTools.cc
@@ -8,151 +8,146 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-float EcalTools::swissCross( const DetId& id, 
-			     const EcalRecHitCollection & recHits, 
-			     float recHitThreshold , 
-			     bool avoidIeta85){
+float EcalTools::swissCross(const DetId& id,
+                            const EcalRecHitCollection& recHits,
+                            float recHitThreshold,
+                            bool avoidIeta85) {
   // compute swissCross
-  if ( id.subdetId() == EcalBarrel ) {
-    EBDetId ebId( id );
+  if (id.subdetId() == EcalBarrel) {
+    EBDetId ebId(id);
     // avoid recHits at |eta|=85 where one side of the neighbours is missing
     // (may improve considering also eta module borders, but no
     // evidence for the time being that there the performance is
     // different)
-    if ( abs(ebId.ieta())==85 && avoidIeta85) return 0;
+    if (abs(ebId.ieta()) == 85 && avoidIeta85)
+      return 0;
     // select recHits with Et above recHitThreshold
-    if ( recHitApproxEt( id, recHits ) < recHitThreshold ) return 0;
+    if (recHitApproxEt(id, recHits) < recHitThreshold)
+      return 0;
     float s4 = 0;
-    float e1 = recHitE( id, recHits );
+    float e1 = recHitE(id, recHits);
     // protect against nan (if 0 threshold is given above)
-    if ( e1 == 0 ) return 0;
-    s4 += recHitE( id, recHits,  1,  0 );
-    s4 += recHitE( id, recHits, -1,  0 );
-    s4 += recHitE( id, recHits,  0,  1 );
-    s4 += recHitE( id, recHits,  0, -1 );
+    if (e1 == 0)
+      return 0;
+    s4 += recHitE(id, recHits, 1, 0);
+    s4 += recHitE(id, recHits, -1, 0);
+    s4 += recHitE(id, recHits, 0, 1);
+    s4 += recHitE(id, recHits, 0, -1);
     return 1 - s4 / e1;
-  } else if ( id.subdetId() == EcalEndcap ) {
-    EEDetId eeId( id );
+  } else if (id.subdetId() == EcalEndcap) {
+    EEDetId eeId(id);
     // select recHits with E above recHitThreshold
-    float e1 = recHitE( id, recHits );
-    if ( e1 < recHitThreshold ) return 0;
+    float e1 = recHitE(id, recHits);
+    if (e1 < recHitThreshold)
+      return 0;
     float s4 = 0;
     // protect against nan (if 0 threshold is given above)
-    if ( e1 == 0 ) return 0;
-    s4 += recHitE( id, recHits,  1,  0 );
-    s4 += recHitE( id, recHits, -1,  0 );
-    s4 += recHitE( id, recHits,  0,  1 );
-    s4 += recHitE( id, recHits,  0, -1 );
+    if (e1 == 0)
+      return 0;
+    s4 += recHitE(id, recHits, 1, 0);
+    s4 += recHitE(id, recHits, -1, 0);
+    s4 += recHitE(id, recHits, 0, 1);
+    s4 += recHitE(id, recHits, 0, -1);
     return 1 - s4 / e1;
   }
   return 0;
 }
 
-
-bool EcalTools::isNextToDead( const DetId& id, const edm::EventSetup& es){
-  
+bool EcalTools::isNextToDead(const DetId& id, const edm::EventSetup& es) {
   edm::ESHandle<EcalNextToDeadChannel> dch;
   es.get<EcalNextToDeadChannelRcd>().get(dch);
-  
-  EcalNextToDeadChannel::const_iterator chIt = dch->find( id );
 
-  if ( chIt != dch->end() ) {
+  EcalNextToDeadChannel::const_iterator chIt = dch->find(id);
+
+  if (chIt != dch->end()) {
     return *chIt;
   } else {
-    edm::LogError("EcalDBError") 
-      << "No NextToDead  status found for xtal " 
-      << id.rawId() ;
+    edm::LogError("EcalDBError") << "No NextToDead  status found for xtal " << id.rawId();
   }
 
   return false;
-  
 }
 
-bool EcalTools::isNextToDeadFromNeighbours( const DetId& id, 
-					    const EcalChannelStatus& chs,
-					    int chStatusThreshold) {
-  
-  if (deadNeighbour(id,chs, chStatusThreshold, 1, 0)) return true;
-  if (deadNeighbour(id,chs, chStatusThreshold,-1, 0)) return true;
-  if (deadNeighbour(id,chs, chStatusThreshold, 0, 1)) return true;
-  if (deadNeighbour(id,chs, chStatusThreshold, 0,-1)) return true;
-  if (deadNeighbour(id,chs, chStatusThreshold, 1,-1)) return true;
-  if (deadNeighbour(id,chs, chStatusThreshold, 1, 1)) return true;
-  if (deadNeighbour(id,chs, chStatusThreshold,-1, 1)) return true;
-  if (deadNeighbour(id,chs, chStatusThreshold,-1,-1)) return true;
+bool EcalTools::isNextToDeadFromNeighbours(const DetId& id, const EcalChannelStatus& chs, int chStatusThreshold) {
+  if (deadNeighbour(id, chs, chStatusThreshold, 1, 0))
+    return true;
+  if (deadNeighbour(id, chs, chStatusThreshold, -1, 0))
+    return true;
+  if (deadNeighbour(id, chs, chStatusThreshold, 0, 1))
+    return true;
+  if (deadNeighbour(id, chs, chStatusThreshold, 0, -1))
+    return true;
+  if (deadNeighbour(id, chs, chStatusThreshold, 1, -1))
+    return true;
+  if (deadNeighbour(id, chs, chStatusThreshold, 1, 1))
+    return true;
+  if (deadNeighbour(id, chs, chStatusThreshold, -1, 1))
+    return true;
+  if (deadNeighbour(id, chs, chStatusThreshold, -1, -1))
+    return true;
 
   return false;
 }
 
-
-bool EcalTools::deadNeighbour(const DetId& id, 
-			      const EcalChannelStatus& chs,
-                              int chStatusThreshold, 
-			      int dx, int dy){
-
-  
+bool EcalTools::deadNeighbour(const DetId& id, const EcalChannelStatus& chs, int chStatusThreshold, int dx, int dy) {
   DetId nid;
-  if( id.subdetId() == EcalBarrel) nid = EBDetId::offsetBy( id, dx, dy );
-  else if( id.subdetId() == EcalEndcap) nid = EEDetId::offsetBy( id, dx, dy );
+  if (id.subdetId() == EcalBarrel)
+    nid = EBDetId::offsetBy(id, dx, dy);
+  else if (id.subdetId() == EcalEndcap)
+    nid = EEDetId::offsetBy(id, dx, dy);
 
-  if (!nid) return false;
+  if (!nid)
+    return false;
 
-  EcalChannelStatus::const_iterator chIt = chs.find( nid );
+  EcalChannelStatus::const_iterator chIt = chs.find(nid);
   uint16_t dbStatus = 0;
-  if ( chIt != chs.end() ) {
-    // note that 
-    dbStatus = chIt->getStatusCode() ;
+  if (chIt != chs.end()) {
+    // note that
+    dbStatus = chIt->getStatusCode();
   } else {
-    edm::LogError("EcalDBError") 
-      << "No channel status found for xtal " 
-      << id.rawId() 
-      << "! something wrong with EcalChannelStatus in your DB? ";
+    edm::LogError("EcalDBError") << "No channel status found for xtal " << id.rawId()
+                                 << "! something wrong with EcalChannelStatus in your DB? ";
   }
 
-  return (dbStatus>=chStatusThreshold );
-  
+  return (dbStatus >= chStatusThreshold);
 }
 
-
-
-float EcalTools::recHitE( const DetId id, 
-			  const EcalRecHitCollection & recHits,
-			  int di, int dj )
-{
+float EcalTools::recHitE(const DetId id, const EcalRecHitCollection& recHits, int di, int dj) {
   // in the barrel:   di = dEta   dj = dPhi
   // in the endcap:   di = dX     dj = dY
-  
+
   DetId nid;
-  if( id.subdetId() == EcalBarrel) nid = EBDetId::offsetBy( id, di, dj );
-  else if( id.subdetId() == EcalEndcap) nid = EEDetId::offsetBy( id, di, dj );
-  
-  return ( nid == DetId(0) ? 0 : recHitE( nid, recHits ) );
+  if (id.subdetId() == EcalBarrel)
+    nid = EBDetId::offsetBy(id, di, dj);
+  else if (id.subdetId() == EcalEndcap)
+    nid = EEDetId::offsetBy(id, di, dj);
+
+  return (nid == DetId(0) ? 0 : recHitE(nid, recHits));
 }
 
-float EcalTools::recHitE( const DetId id, const EcalRecHitCollection &recHits ){
-  if ( id == DetId(0) ) {
+float EcalTools::recHitE(const DetId id, const EcalRecHitCollection& recHits) {
+  if (id == DetId(0)) {
     return 0;
   } else {
-    EcalRecHitCollection::const_iterator it = recHits.find( id );
-    if ( it != recHits.end() ) return (*it).energy();
+    EcalRecHitCollection::const_iterator it = recHits.find(id);
+    if (it != recHits.end())
+      return (*it).energy();
   }
   return 0;
 }
 
-float EcalTools::recHitApproxEt( const DetId id, const EcalRecHitCollection &recHits ){
+float EcalTools::recHitApproxEt(const DetId id, const EcalRecHitCollection& recHits) {
   // for the time being works only for the barrel
-  if ( id.subdetId() == EcalBarrel ) {
-    return recHitE( id, recHits ) / cosh( EBDetId::approxEta( id ) );
+  if (id.subdetId() == EcalBarrel) {
+    return recHitE(id, recHits) / cosh(EBDetId::approxEta(id));
   }
   return 0;
 }
 
-
-bool isNextToBoundary(const DetId& id){
-
-  if ( id.subdetId() == EcalBarrel ) 
+bool isNextToBoundary(const DetId& id) {
+  if (id.subdetId() == EcalBarrel)
     return EBDetId::isNextToBoundary(EBDetId(id));
-  else  if ( id.subdetId() == EcalEndcap )
+  else if (id.subdetId() == EcalEndcap)
     return EEDetId::isNextToBoundary(EEDetId(id));
 
   return false;

--- a/RecoEcal/EgammaCoreTools/src/Mustache.cc
+++ b/RecoEcal/EgammaCoreTools/src/Mustache.cc
@@ -4,279 +4,255 @@
 #include <cmath>
 using namespace std;
 
-namespace reco {  
-  namespace MustacheKernel {    
-    bool inMustache(const float maxEta, const float maxPhi, 
-		    const float ClustE, const float ClusEta, 
-		    const float ClusPhi){
+namespace reco {
+  namespace MustacheKernel {
+    bool inMustache(
+        const float maxEta, const float maxPhi, const float ClustE, const float ClusEta, const float ClusPhi) {
       //bool inMust=false;
       //float eta0 = maxEta;
-      //float phi0 = maxPhi;      
-      
+      //float phi0 = maxPhi;
+
       constexpr float p00 = -0.107537;
       constexpr float p01 = 0.590969;
       constexpr float p02 = -0.076494;
       constexpr float p10 = -0.0268843;
       constexpr float p11 = 0.147742;
       constexpr float p12 = -0.0191235;
-      
+
       constexpr float w00 = -0.00571429;
       constexpr float w01 = -0.002;
       constexpr float w10 = 0.0135714;
       constexpr float w11 = 0.001;
-      
+
       const float sineta0 = std::sin(maxEta);
-      const float eta0xsineta0 = maxEta*sineta0;
-      
-      
-      //2 parabolas (upper and lower) 
+      const float eta0xsineta0 = maxEta * sineta0;
+
+      //2 parabolas (upper and lower)
       //of the form: y = a*x*x + b
-      
+
       //b comes from a fit to the width
-      //and has a slight dependence on E on the upper edge    
+      //and has a slight dependence on E on the upper edge
       // this only works because of fine tuning :-D
-      const float sqrt_log10_clustE = std::sqrt(std::log10(ClustE)+1.1);
+      const float sqrt_log10_clustE = std::sqrt(std::log10(ClustE) + 1.1);
       // we need to have this in two steps, so that we don't improperly shift
       // the lower bound!
-      float b_upper = w10*eta0xsineta0 + w11 / sqrt_log10_clustE;      
-      float b_lower = w00*eta0xsineta0 + w01 / sqrt_log10_clustE; 
-      const float midpoint =  0.5*( b_upper + b_lower );
+      float b_upper = w10 * eta0xsineta0 + w11 / sqrt_log10_clustE;
+      float b_lower = w00 * eta0xsineta0 + w01 / sqrt_log10_clustE;
+      const float midpoint = 0.5 * (b_upper + b_lower);
       b_upper -= midpoint;
       b_lower -= midpoint;
 
-      //the curvature comes from a parabolic 
-      //fit for many slices in eta given a 
+      //the curvature comes from a parabolic
+      //fit for many slices in eta given a
       //slice -0.1 < log10(Et) < 0.1
-      const float curv_up=eta0xsineta0*(p00*eta0xsineta0+p01)+p02;
-      const float curv_low=eta0xsineta0*(p10*eta0xsineta0+p11)+p12;
-      
+      const float curv_up = eta0xsineta0 * (p00 * eta0xsineta0 + p01) + p02;
+      const float curv_low = eta0xsineta0 * (p10 * eta0xsineta0 + p11) + p12;
+
       //solving for the curviness given the width of this particular point
-      const float a_upper=(1/(4*curv_up))-fabs(b_upper);
-      const float a_lower = (1/(4*curv_low))-fabs(b_lower);
-      
-      const double dphi=TVector2::Phi_mpi_pi(ClusPhi-maxPhi);
-      const double dphi2 = dphi*dphi;
+      const float a_upper = (1 / (4 * curv_up)) - fabs(b_upper);
+      const float a_lower = (1 / (4 * curv_low)) - fabs(b_lower);
+
+      const double dphi = TVector2::Phi_mpi_pi(ClusPhi - maxPhi);
+      const double dphi2 = dphi * dphi;
       // minimum offset is half a crystal width in either direction
       // because science.
-      const float upper_cut=( std::max((1./(4.*a_upper)),0.0)*dphi2 +
-			      std::max(b_upper,0.0087f) ) + 0.0087;
-      const float lower_cut=( std::max((1./(4.*a_lower)),0.0)*dphi2 + 
-			      std::min(b_lower,-0.0087f) );
-      
+      const float upper_cut = (std::max((1. / (4. * a_upper)), 0.0) * dphi2 + std::max(b_upper, 0.0087f)) + 0.0087;
+      const float lower_cut = (std::max((1. / (4. * a_lower)), 0.0) * dphi2 + std::min(b_lower, -0.0087f));
 
       //if(deta < upper_cut && deta > lower_cut) inMust=true;
-      
-      const float deta=(1-2*(maxEta<0))*(ClusEta-maxEta); // sign flip deta
+
+      const float deta = (1 - 2 * (maxEta < 0)) * (ClusEta - maxEta);  // sign flip deta
       return (deta < upper_cut && deta > lower_cut);
     }
 
-    bool inDynamicDPhiWindow(const float seedEta, const float seedPhi,
-			     const float ClustE, const float ClusEta,
-			     const float ClusPhi) {
+    bool inDynamicDPhiWindow(
+        const float seedEta, const float seedPhi, const float ClustE, const float ClusEta, const float ClusPhi) {
       // from Rishi's fits 06 June 2013 in log base 10
       constexpr double yoffsetEB = 7.151e-02;
-      constexpr double scaleEB   = 5.656e-01;
+      constexpr double scaleEB = 5.656e-01;
       constexpr double xoffsetEB = 2.931e-01;
-      constexpr double widthEB   = 2.976e-01;
+      constexpr double widthEB = 2.976e-01;
 
-      constexpr double yoffsetEE_0 =  5.058e-02;
-      constexpr double scaleEE_0   =  7.131e-01;
-      constexpr double xoffsetEE_0 =  1.668e-02;
-      constexpr double widthEE_0   =  4.114e-01;
+      constexpr double yoffsetEE_0 = 5.058e-02;
+      constexpr double scaleEE_0 = 7.131e-01;
+      constexpr double xoffsetEE_0 = 1.668e-02;
+      constexpr double widthEE_0 = 4.114e-01;
 
       constexpr double yoffsetEE_1 = -9.913e-02;
-      constexpr double scaleEE_1   =  4.404e+01;
+      constexpr double scaleEE_1 = 4.404e+01;
       constexpr double xoffsetEE_1 = -5.326e+00;
-      constexpr double widthEE_1   =  1.184e+00;
+      constexpr double widthEE_1 = 1.184e+00;
 
       constexpr double yoffsetEE_2 = -6.346e-01;
-      constexpr double scaleEE_2   =  1.317e+01;
+      constexpr double scaleEE_2 = 1.317e+01;
       constexpr double xoffsetEE_2 = -7.037e+00;
-      constexpr double widthEE_2   =  2.836e+00;
-      
-      
+      constexpr double widthEE_2 = 2.836e+00;
+
       const double absSeedEta = std::abs(seedEta);
-      const int etaBin = ( (int)(absSeedEta >= 1.479) + 
-			   (int)(absSeedEta >= 1.75)  +
-			   (int)(absSeedEta >= 2.0)     );
-      const double logClustEt = std::log10(ClustE/std::cosh(ClusEta));
-      const double clusDphi = std::abs(TVector2::Phi_mpi_pi(seedPhi - 
-							    ClusPhi));
+      const int etaBin = ((int)(absSeedEta >= 1.479) + (int)(absSeedEta >= 1.75) + (int)(absSeedEta >= 2.0));
+      const double logClustEt = std::log10(ClustE / std::cosh(ClusEta));
+      const double clusDphi = std::abs(TVector2::Phi_mpi_pi(seedPhi - ClusPhi));
 
       double yoffset, scale, xoffset, width, saturation, cutoff, maxdphi;
 
-      switch( etaBin ) {
-      case 0: // EB
-	yoffset = yoffsetEB;
-	scale   = scaleEB;
-	xoffset = xoffsetEB;
-	width   = 1.0/widthEB;
-	saturation = 0.14;
-	cutoff     = 0.60;
-	break;
-      case 1: // 1.479 -> 1.75
-	yoffset = yoffsetEE_0;
-	scale   = scaleEE_0;
-	xoffset = xoffsetEE_0;
-	width   = 1.0/widthEE_0;
-	saturation = 0.14;
-	cutoff     = 0.55;
-	break;
-      case 2: // 1.75 -> 2.0
-	yoffset = yoffsetEE_1;
-	scale   = scaleEE_1;
-	xoffset = xoffsetEE_1;
-	width   = 1.0/widthEE_1;
-	saturation = 0.12;
-	cutoff     = 0.45;
-	break;
-      case 3: // 2.0 and up
-	yoffset = yoffsetEE_2;
-	scale   = scaleEE_2;
-	xoffset = xoffsetEE_2;
-	width   = 1.0/widthEE_2;
-	saturation = 0.12;
-	cutoff     = 0.30;
-	break;
-      default:
-	throw cms::Exception("InValidEtaBin")
-	  << "Calculated invalid eta bin = " << etaBin 
-	  << " in \"inDynamicDPhiWindow\"" << std::endl;
+      switch (etaBin) {
+        case 0:  // EB
+          yoffset = yoffsetEB;
+          scale = scaleEB;
+          xoffset = xoffsetEB;
+          width = 1.0 / widthEB;
+          saturation = 0.14;
+          cutoff = 0.60;
+          break;
+        case 1:  // 1.479 -> 1.75
+          yoffset = yoffsetEE_0;
+          scale = scaleEE_0;
+          xoffset = xoffsetEE_0;
+          width = 1.0 / widthEE_0;
+          saturation = 0.14;
+          cutoff = 0.55;
+          break;
+        case 2:  // 1.75 -> 2.0
+          yoffset = yoffsetEE_1;
+          scale = scaleEE_1;
+          xoffset = xoffsetEE_1;
+          width = 1.0 / widthEE_1;
+          saturation = 0.12;
+          cutoff = 0.45;
+          break;
+        case 3:  // 2.0 and up
+          yoffset = yoffsetEE_2;
+          scale = scaleEE_2;
+          xoffset = xoffsetEE_2;
+          width = 1.0 / widthEE_2;
+          saturation = 0.12;
+          cutoff = 0.30;
+          break;
+        default:
+          throw cms::Exception("InValidEtaBin")
+              << "Calculated invalid eta bin = " << etaBin << " in \"inDynamicDPhiWindow\"" << std::endl;
       }
-      
-      maxdphi = yoffset+scale/(1+std::exp((logClustEt-xoffset)*width));
-      maxdphi = std::min(maxdphi,cutoff);
-      maxdphi = std::max(maxdphi,saturation);
-      
+
+      maxdphi = yoffset + scale / (1 + std::exp((logClustEt - xoffset) * width));
+      maxdphi = std::min(maxdphi, cutoff);
+      maxdphi = std::max(maxdphi, saturation);
+
       return clusDphi < maxdphi;
     }
-  }
-  
-  void Mustache::MustacheID(const reco::SuperCluster& sc, 
-			    int & nclusters, 
-			    float & EoutsideMustache) {
-    MustacheID(sc.clustersBegin(),sc.clustersEnd(), 
-	       nclusters, EoutsideMustache);
-  }
-  
-  void Mustache::MustacheID(const CaloClusterPtrVector& clusters, 
-			    int & nclusters, 
-			    float & EoutsideMustache) {    
-    MustacheID(clusters.begin(),clusters.end(),nclusters,EoutsideMustache);
-  }
-  
-  void Mustache::MustacheID(const std::vector<const CaloCluster*>& clusters, 
-			    int & nclusters, 
-			    float & EoutsideMustache) {
-    MustacheID(clusters.cbegin(),clusters.cend(),nclusters,EoutsideMustache);
+  }  // namespace MustacheKernel
+
+  void Mustache::MustacheID(const reco::SuperCluster& sc, int& nclusters, float& EoutsideMustache) {
+    MustacheID(sc.clustersBegin(), sc.clustersEnd(), nclusters, EoutsideMustache);
   }
 
-  template<class RandomAccessPtrIterator>
-  void Mustache::MustacheID(const RandomAccessPtrIterator& begin, 
-			    const RandomAccessPtrIterator& end,
-			    int & nclusters, 
-			    float & EoutsideMustache) {    
+  void Mustache::MustacheID(const CaloClusterPtrVector& clusters, int& nclusters, float& EoutsideMustache) {
+    MustacheID(clusters.begin(), clusters.end(), nclusters, EoutsideMustache);
+  }
+
+  void Mustache::MustacheID(const std::vector<const CaloCluster*>& clusters, int& nclusters, float& EoutsideMustache) {
+    MustacheID(clusters.cbegin(), clusters.cend(), nclusters, EoutsideMustache);
+  }
+
+  template <class RandomAccessPtrIterator>
+  void Mustache::MustacheID(const RandomAccessPtrIterator& begin,
+                            const RandomAccessPtrIterator& end,
+                            int& nclusters,
+                            float& EoutsideMustache) {
     nclusters = 0;
     EoutsideMustache = 0;
-    
-    unsigned int ncl = end-begin;
-    if(!ncl) return;
-    
+
+    unsigned int ncl = end - begin;
+    if (!ncl)
+      return;
+
     //loop over all clusters to find the one with highest energy
     RandomAccessPtrIterator icl = begin;
     RandomAccessPtrIterator clmax = end;
     float emax = 0;
-    for( ; icl != end; ++icl){
+    for (; icl != end; ++icl) {
       const float e = (*icl)->energy();
-      if(e > emax){
-	emax = e;
-	clmax = icl;
+      if (e > emax) {
+        emax = e;
+        clmax = icl;
       }
     }
-    
-    if(end == clmax) return;
-    
+
+    if (end == clmax)
+      return;
+
     float eta0 = (*clmax)->eta();
     float phi0 = (*clmax)->phi();
-    
 
     bool inMust = false;
     icl = begin;
-    for( ; icl != end; ++icl ){
-      inMust=MustacheKernel::inMustache(eta0, phi0, 
-					(*icl)->energy(), 
-					(*icl)->eta(), 
-					(*icl)->phi());
-      
+    for (; icl != end; ++icl) {
+      inMust = MustacheKernel::inMustache(eta0, phi0, (*icl)->energy(), (*icl)->eta(), (*icl)->phi());
+
       nclusters += (int)!inMust;
-      EoutsideMustache += (!inMust)*((*icl)->energy()); 
+      EoutsideMustache += (!inMust) * ((*icl)->energy());
     }
   }
-  
-  void Mustache::MustacheClust(const std::vector<CaloCluster>& clusters, 
-			       std::vector<unsigned int>& insideMust, 
-			       std::vector<unsigned int>& outsideMust){  
+
+  void Mustache::MustacheClust(const std::vector<CaloCluster>& clusters,
+                               std::vector<unsigned int>& insideMust,
+                               std::vector<unsigned int>& outsideMust) {
     unsigned int ncl = clusters.size();
-    if(!ncl) return;
-    
+    if (!ncl)
+      return;
+
     //loop over all clusters to find the one with highest energy
     float emax = 0;
     int imax = -1;
-    for(unsigned int i=0; i<ncl; ++i){
+    for (unsigned int i = 0; i < ncl; ++i) {
       float e = (clusters[i]).energy();
-      if(e > emax){
-	emax = e;
-	imax = i;
+      if (e > emax) {
+        emax = e;
+        imax = i;
       }
     }
-    
-    if(imax<0) return;
+
+    if (imax < 0)
+      return;
     float eta0 = (clusters[imax]).eta();
     float phi0 = (clusters[imax]).phi();
-    
-    
-    for(unsigned int k=0; k<ncl; k++){
-      
-      bool inMust=MustacheKernel::inMustache(eta0, phi0, 
-					     (clusters[k]).energy(), 
-					     (clusters[k]).eta(), 
-					     (clusters[k]).phi());
+
+    for (unsigned int k = 0; k < ncl; k++) {
+      bool inMust =
+          MustacheKernel::inMustache(eta0, phi0, (clusters[k]).energy(), (clusters[k]).eta(), (clusters[k]).phi());
       //return indices of Clusters outside the Mustache
-      if (!(inMust)){
-	outsideMust.push_back(k);
-      }
-      else{//return indices of Clusters inside the Mustache
-	insideMust.push_back(k);
+      if (!(inMust)) {
+        outsideMust.push_back(k);
+      } else {  //return indices of Clusters inside the Mustache
+        insideMust.push_back(k);
       }
     }
   }
-  
-  void Mustache::FillMustacheVar(const std::vector<CaloCluster>& clusters){
-    Energy_In_Mustache_=0;
-    Energy_Outside_Mustache_=0;
-    LowestClusterEInMustache_=0;
-    excluded_=0;
-    included_=0;
-    std::multimap<float, unsigned int>OrderedClust;
+
+  void Mustache::FillMustacheVar(const std::vector<CaloCluster>& clusters) {
+    Energy_In_Mustache_ = 0;
+    Energy_Outside_Mustache_ = 0;
+    LowestClusterEInMustache_ = 0;
+    excluded_ = 0;
+    included_ = 0;
+    std::multimap<float, unsigned int> OrderedClust;
     std::vector<unsigned int> insideMust;
     std::vector<unsigned int> outsideMust;
     MustacheClust(clusters, insideMust, outsideMust);
-    included_=insideMust.size(); excluded_=outsideMust.size();
-    for(unsigned int i=0; i<insideMust.size(); ++i){
-      unsigned int index=insideMust[i];
-      Energy_In_Mustache_=clusters[index].energy()+Energy_In_Mustache_;
+    included_ = insideMust.size();
+    excluded_ = outsideMust.size();
+    for (unsigned int i = 0; i < insideMust.size(); ++i) {
+      unsigned int index = insideMust[i];
+      Energy_In_Mustache_ = clusters[index].energy() + Energy_In_Mustache_;
       OrderedClust.insert(make_pair(clusters[index].energy(), index));
     }
-    for(unsigned int i=0; i<outsideMust.size(); ++i){
-      unsigned int index=outsideMust[i];
-      Energy_Outside_Mustache_=clusters[index].energy()+Energy_Outside_Mustache_;
-      Et_Outside_Mustache_=clusters[index].energy()*sin(clusters[index].position().theta())
-	+Et_Outside_Mustache_;
+    for (unsigned int i = 0; i < outsideMust.size(); ++i) {
+      unsigned int index = outsideMust[i];
+      Energy_Outside_Mustache_ = clusters[index].energy() + Energy_Outside_Mustache_;
+      Et_Outside_Mustache_ = clusters[index].energy() * sin(clusters[index].position().theta()) + Et_Outside_Mustache_;
     }
     std::multimap<float, unsigned int>::iterator it;
-    it=OrderedClust.begin();
-    unsigned int lowEindex=(*it).second; 
-    LowestClusterEInMustache_=clusters[lowEindex].energy();
-    
+    it = OrderedClust.begin();
+    unsigned int lowEindex = (*it).second;
+    LowestClusterEInMustache_ = clusters[lowEindex].energy();
   }
-}
+}  // namespace reco

--- a/RecoEcal/EgammaCoreTools/src/PositionCalc.cc
+++ b/RecoEcal/EgammaCoreTools/src/PositionCalc.cc
@@ -1,30 +1,27 @@
 #include "RecoEcal/EgammaCoreTools/interface/PositionCalc.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-PositionCalc::PositionCalc(const edm::ParameterSet& par) :
-  param_LogWeighted_   ( par.getParameter<bool>("LogWeighted")) ,
-  param_T0_barl_       ( par.getParameter<double>("T0_barl")) , 
-  param_T0_endc_       ( par.getParameter<double>("T0_endc")) , 
-  param_T0_endcPresh_  ( par.getParameter<double>("T0_endcPresh")) , 
-  param_W0_            ( par.getParameter<double>("W0")) ,
-  param_X0_            ( par.getParameter<double>("X0")) ,
-  m_esGeom             ( nullptr ) ,
-  m_esPlus             ( false ) ,
-  m_esMinus            ( false )
-{
-}
+PositionCalc::PositionCalc(const edm::ParameterSet& par)
+    : param_LogWeighted_(par.getParameter<bool>("LogWeighted")),
+      param_T0_barl_(par.getParameter<double>("T0_barl")),
+      param_T0_endc_(par.getParameter<double>("T0_endc")),
+      param_T0_endcPresh_(par.getParameter<double>("T0_endcPresh")),
+      param_W0_(par.getParameter<double>("W0")),
+      param_X0_(par.getParameter<double>("X0")),
+      m_esGeom(nullptr),
+      m_esPlus(false),
+      m_esMinus(false) {}
 
-const PositionCalc& PositionCalc::operator=( const PositionCalc& rhs ) 
-{
-   param_LogWeighted_ = rhs.param_LogWeighted_;
-   param_T0_barl_ = rhs.param_T0_barl_;
-   param_T0_endc_ = rhs.param_T0_endc_;
-   param_T0_endcPresh_ = rhs.param_T0_endcPresh_;
-   param_W0_ = rhs.param_W0_;
-   param_X0_ = rhs.param_X0_;
+const PositionCalc& PositionCalc::operator=(const PositionCalc& rhs) {
+  param_LogWeighted_ = rhs.param_LogWeighted_;
+  param_T0_barl_ = rhs.param_T0_barl_;
+  param_T0_endc_ = rhs.param_T0_endc_;
+  param_T0_endcPresh_ = rhs.param_T0_endcPresh_;
+  param_W0_ = rhs.param_W0_;
+  param_X0_ = rhs.param_X0_;
 
-   m_esGeom = rhs.m_esGeom ;
-   m_esPlus = rhs.m_esPlus ;
-   m_esMinus = rhs.m_esMinus ;
-   return *this;
+  m_esGeom = rhs.m_esGeom;
+  m_esPlus = rhs.m_esPlus;
+  m_esMinus = rhs.m_esMinus;
+  return *this;
 }

--- a/RecoEcal/EgammaCoreTools/src/SuperClusterShapeAlgo.cc
+++ b/RecoEcal/EgammaCoreTools/src/SuperClusterShapeAlgo.cc
@@ -11,51 +11,52 @@
 #include "DataFormats/Math/interface/Point3D.h"
 #include "DataFormats/Math/interface/Vector3D.h"
 
-SuperClusterShapeAlgo::SuperClusterShapeAlgo(const EcalRecHitCollection* hits,
-					     const CaloSubdetectorGeometry* geo) : 
-  recHits_(hits), geometry_(geo) { }
+SuperClusterShapeAlgo::SuperClusterShapeAlgo(const EcalRecHitCollection* hits, const CaloSubdetectorGeometry* geo)
+    : recHits_(hits), geometry_(geo) {}
 
-void SuperClusterShapeAlgo::Calculate_Covariances(const reco::SuperCluster &passedCluster)
-{
+void SuperClusterShapeAlgo::Calculate_Covariances(const reco::SuperCluster& passedCluster) {
   double numeratorEtaWidth = 0;
   double numeratorPhiWidth = 0;
 
   double scEnergy = passedCluster.energy();
   double denominator = scEnergy;
 
-  double scEta    = passedCluster.position().eta();
-  double scPhi    = passedCluster.position().phi();
+  double scEta = passedCluster.position().eta();
+  double scPhi = passedCluster.position().phi();
 
-  const std::vector<std::pair<DetId,float> > &detId = passedCluster.hitsAndFractions();
+  const std::vector<std::pair<DetId, float> >& detId = passedCluster.hitsAndFractions();
   // Loop over recHits associated with the given SuperCluster
-  for (std::vector<std::pair<DetId,float> >::const_iterator hit = detId.begin();
-       hit != detId.end(); ++hit) {
+  for (std::vector<std::pair<DetId, float> >::const_iterator hit = detId.begin(); hit != detId.end(); ++hit) {
     EcalRecHitCollection::const_iterator rHit = recHits_->find((*hit).first);
-    //FIXME: THIS IS JUST A WORKAROUND A FIX SHOULD BE APPLIED  
-    if(rHit == recHits_->end()) {
-      continue; 
+    //FIXME: THIS IS JUST A WORKAROUND A FIX SHOULD BE APPLIED
+    if (rHit == recHits_->end()) {
+      continue;
     }
     auto this_cell = geometry_->getGeometry(rHit->id());
-    if ( this_cell == nullptr ) {
+    if (this_cell == nullptr) {
       //edm::LogInfo("SuperClusterShapeAlgo") << "pointer to the cell in Calculate_Covariances is NULL!";
       continue;
     }
     GlobalPoint position = this_cell->getPosition();
     //take into account energy fractions
-    double energyHit = rHit->energy()*hit->second;
-    
+    double energyHit = rHit->energy() * hit->second;
+
     //form differences
     double dPhi = position.phi() - scPhi;
-    if (dPhi > + Geom::pi()) { dPhi = Geom::twoPi() - dPhi; }
-    if (dPhi < - Geom::pi()) { dPhi = Geom::twoPi() + dPhi; }
+    if (dPhi > +Geom::pi()) {
+      dPhi = Geom::twoPi() - dPhi;
+    }
+    if (dPhi < -Geom::pi()) {
+      dPhi = Geom::twoPi() + dPhi;
+    }
 
     double dEta = position.eta() - scEta;
 
-    if ( energyHit > 0 ) {
+    if (energyHit > 0) {
       numeratorEtaWidth += energyHit * dEta * dEta;
       numeratorPhiWidth += energyHit * dPhi * dPhi;
     }
-      
+
     etaWidth_ = sqrt(numeratorEtaWidth / denominator);
     phiWidth_ = sqrt(numeratorPhiWidth / denominator);
   }

--- a/RecoEcal/EgammaCoreTools/test/filterProbClusters.cc
+++ b/RecoEcal/EgammaCoreTools/test/filterProbClusters.cc
@@ -1,7 +1,5 @@
 // -*- C++ -*-
 
-
-
 #include <memory>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDFilter.h"
@@ -35,8 +33,10 @@ class ProbClustersFilter : public edm::EDFilter {
 public:
   explicit ProbClustersFilter(const edm::ParameterSet&);
   ~ProbClustersFilter();
+
 private:
   virtual bool filter(edm::Event&, const edm::EventSetup&);
+
 private:
   int maxDistance_;
   float maxGoodFraction_;
@@ -45,7 +45,6 @@ private:
   edm::InputTag endcapClusterCollection_;
   edm::InputTag reducedBarrelRecHitCollection_;
   edm::InputTag reducedEndcapRecHitCollection_;
- 
 };
 
 ProbClustersFilter::ProbClustersFilter(const edm::ParameterSet& iConfig) {
@@ -56,66 +55,61 @@ ProbClustersFilter::ProbClustersFilter(const edm::ParameterSet& iConfig) {
   reducedBarrelRecHitCollection_ = iConfig.getParameter<edm::InputTag>("reducedBarrelRecHitCollection");
   reducedEndcapRecHitCollection_ = iConfig.getParameter<edm::InputTag>("reducedEndcapRecHitCollection");
   conf_ = iConfig;
- 
 }
-
 
 ProbClustersFilter::~ProbClustersFilter() {}
 
-bool ProbClustersFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) 
-{
-  int problematicClusters=0;
+bool ProbClustersFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  int problematicClusters = 0;
 
-  edm::Handle< reco::SuperClusterCollection > pEBClusters;
-  iEvent.getByLabel( barrelClusterCollection_, pEBClusters );
-  const reco::SuperClusterCollection *ebClusters = pEBClusters.product();
-  
+  edm::Handle<reco::SuperClusterCollection> pEBClusters;
+  iEvent.getByLabel(barrelClusterCollection_, pEBClusters);
+  const reco::SuperClusterCollection* ebClusters = pEBClusters.product();
+
   //edm::Handle< reco::SuperClusterCollection > pEEClusters;
   //iEvent.getByLabel( endcapClusterCollection_, pEEClusters );
   //const reco::SuperClusterCollection *eeClusters = pEEClusters.product();
-  
-  edm::Handle< EcalRecHitCollection > pEBRecHits;
-  iEvent.getByLabel( reducedBarrelRecHitCollection_, pEBRecHits );
-  const EcalRecHitCollection *ebRecHits = pEBRecHits.product();
-  
+
+  edm::Handle<EcalRecHitCollection> pEBRecHits;
+  iEvent.getByLabel(reducedBarrelRecHitCollection_, pEBRecHits);
+  const EcalRecHitCollection* ebRecHits = pEBRecHits.product();
+
   //edm::Handle< EcalRecHitCollection > pEERecHits;
   //iEvent.getByLabel( reducedEndcapRecHitCollection_, pEERecHits );
   //const EcalRecHitCollection *eeRecHits = pEERecHits.product();
-  
+
   //edm::ESHandle<CaloGeometry> pGeometry;
   //iSetup.get<CaloGeometryRecord>().get(pGeometry);
   //const CaloGeometry *geometry = pGeometry.product();
-  
+
   edm::ESHandle<CaloTopology> pTopology;
   iSetup.get<CaloTopologyRecord>().get(pTopology);
-  const CaloTopology *topology = pTopology.product();
-  
-  
-  edm::ESHandle<EcalSeverityLevelAlgo> sevlvh;  
-  iSetup.get<EcalSeverityLevelAlgoRcd>().get(sevlvh);  
-  const EcalSeverityLevelAlgo * sevLv= sevlvh.product();
+  const CaloTopology* topology = pTopology.product();
+
+  edm::ESHandle<EcalSeverityLevelAlgo> sevlvh;
+  iSetup.get<EcalSeverityLevelAlgoRcd>().get(sevlvh);
+  const EcalSeverityLevelAlgo* sevLv = sevlvh.product();
 
   //        std::cout << "========== BARREL ==========" << std::endl;
-  for (reco::SuperClusterCollection::const_iterator it = ebClusters->begin(); it != ebClusters->end(); ++it ) 
-    {
-      float goodFraction=EcalClusterSeverityLevelAlgo::goodFraction( *it, *ebRecHits,*sevLv);
-      std::pair<int,int> distance=EcalClusterSeverityLevelAlgo::etaphiDistanceClosestProblematic( *it, *ebRecHits,topology,*sevLv);
-      if ( distance.first == -1 && distance.second==-1)
-	{
-	  distance.first=999;
-	  distance.second=999;
-	};
-      if ( goodFraction >= maxGoodFraction_ && sqrt(distance.first*distance.first +distance.second*distance.second) >= maxDistance_ )
-	continue;
-      ++problematicClusters;
-      //       std::cout << "seed" << EBDetId(EcalClusterTools::getMaximum(*it, ebRecHits).first) << std::endl;
-      //       std::cout << "goodFraction" << EcalClusterSeverityLevelAlgo::goodFraction( *it, *ebRecHits, *theEcalChStatus) << std::endl;
-      //       std::cout << "closestProblematicDetId" << EBDetId(EcalClusterSeverityLevelAlgo::closestProblematic( *it, *ebRecHits, *theEcalChStatus,topology)) << std::endl;
-      //       std::cout << "(deta,dphi)" << "(" << EcalClusterSeverityLevelAlgo::etaphiDistanceClosestProblematic( *it, *ebRecHits, *theEcalChStatus,topology).first << "," <<EcalClusterSeverityLevelAlgo::etaphiDistanceClosestProblematic( *it, *ebRecHits, *theEcalChStatus,topology).second << ")" << std::endl;
-    }
+  for (reco::SuperClusterCollection::const_iterator it = ebClusters->begin(); it != ebClusters->end(); ++it) {
+    float goodFraction = EcalClusterSeverityLevelAlgo::goodFraction(*it, *ebRecHits, *sevLv);
+    std::pair<int, int> distance =
+        EcalClusterSeverityLevelAlgo::etaphiDistanceClosestProblematic(*it, *ebRecHits, topology, *sevLv);
+    if (distance.first == -1 && distance.second == -1) {
+      distance.first = 999;
+      distance.second = 999;
+    };
+    if (goodFraction >= maxGoodFraction_ &&
+        sqrt(distance.first * distance.first + distance.second * distance.second) >= maxDistance_)
+      continue;
+    ++problematicClusters;
+    //       std::cout << "seed" << EBDetId(EcalClusterTools::getMaximum(*it, ebRecHits).first) << std::endl;
+    //       std::cout << "goodFraction" << EcalClusterSeverityLevelAlgo::goodFraction( *it, *ebRecHits, *theEcalChStatus) << std::endl;
+    //       std::cout << "closestProblematicDetId" << EBDetId(EcalClusterSeverityLevelAlgo::closestProblematic( *it, *ebRecHits, *theEcalChStatus,topology)) << std::endl;
+    //       std::cout << "(deta,dphi)" << "(" << EcalClusterSeverityLevelAlgo::etaphiDistanceClosestProblematic( *it, *ebRecHits, *theEcalChStatus,topology).first << "," <<EcalClusterSeverityLevelAlgo::etaphiDistanceClosestProblematic( *it, *ebRecHits, *theEcalChStatus,topology).second << ")" << std::endl;
+  }
 
   return problematicClusters;
 }
 
 DEFINE_FWK_MODULE(ProbClustersFilter);
-

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterFunctions.cc
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterFunctions.cc
@@ -2,7 +2,7 @@
 //
 // Package:    testEcalClusterFunctions
 // Class:      testEcalClusterFunctions
-// 
+//
 /**\class testEcalClusterFunctions testEcalClusterFunctions.cc
 
 Description: <one line class summary>
@@ -15,7 +15,6 @@ Implementation:
 //         Created:  Mon Apr  7 14:11:00 CEST 2008
 //
 //
-
 
 // system include files
 #include <memory>
@@ -37,36 +36,29 @@ Implementation:
 #include "CondFormats/EcalObjects/interface/EcalFunctionParameters.h"
 
 class testEcalClusterFunctions : public edm::EDAnalyzer {
-        public:
-                explicit testEcalClusterFunctions(const edm::ParameterSet&);
-                ~testEcalClusterFunctions() override = default;
+public:
+  explicit testEcalClusterFunctions(const edm::ParameterSet&);
+  ~testEcalClusterFunctions() override = default;
 
-        private:
-                void analyze(const edm::Event&, const edm::EventSetup&) override;
-                std::unique_ptr<EcalClusterFunctionBaseClass> ff_;
-
+private:
+  void analyze(const edm::Event&, const edm::EventSetup&) override;
+  std::unique_ptr<EcalClusterFunctionBaseClass> ff_;
 };
 
-
-
-testEcalClusterFunctions::testEcalClusterFunctions(const edm::ParameterSet& ps)
-{
-        std::string functionName = ps.getParameter<std::string>("functionName");
-        ff_ = std::unique_ptr<EcalClusterFunctionBaseClass>{EcalClusterFunctionFactory::get()->create( functionName, ps )};
-        std::cout << "got " << functionName << " function at: " << ff_.get() << "\n";
+testEcalClusterFunctions::testEcalClusterFunctions(const edm::ParameterSet& ps) {
+  std::string functionName = ps.getParameter<std::string>("functionName");
+  ff_ = std::unique_ptr<EcalClusterFunctionBaseClass>{EcalClusterFunctionFactory::get()->create(functionName, ps)};
+  std::cout << "got " << functionName << " function at: " << ff_.get() << "\n";
 }
 
-
-
-void testEcalClusterFunctions::analyze(const edm::Event& ev, const edm::EventSetup& es)
-{
-        // init function parameters
-        ff_->init( es );
-        // basic test with empty collections
-        reco::BasicCluster bc;
-        EcalRecHitCollection rhColl;
-        float corr = ff_->getValue( bc, rhColl );
-        std::cout << "correction: " << corr << "\n";
+void testEcalClusterFunctions::analyze(const edm::Event& ev, const edm::EventSetup& es) {
+  // init function parameters
+  ff_->init(es);
+  // basic test with empty collections
+  reco::BasicCluster bc;
+  EcalRecHitCollection rhColl;
+  float corr = ff_->getValue(bc, rhColl);
+  std::cout << "correction: " << corr << "\n";
 }
 
 //define this as a plug-in

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterLazyTools.cc
@@ -16,7 +16,6 @@ Implementation:
 //
 //
 
-
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -33,7 +32,6 @@ Implementation:
 
 #include <memory>
 
-
 class testEcalClusterLazyTools : public edm::one::EDAnalyzer<> {
 public:
   explicit testEcalClusterLazyTools(const edm::ParameterSet&);
@@ -41,108 +39,104 @@ public:
 private:
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  using LazyTools = noZS::EcalClusterLazyTools; // alternatively just EcalClusterLazyTools
+  using LazyTools = noZS::EcalClusterLazyTools;  // alternatively just EcalClusterLazyTools
 
   const edm::EDGetTokenT<reco::BasicClusterCollection> barrelClusterToken_;
   const edm::EDGetTokenT<reco::BasicClusterCollection> endcapClusterToken_;
   const edm::EDGetTokenT<EcalRecHitCollection> barrelRecHitToken_;
   const edm::EDGetTokenT<EcalRecHitCollection> endcapRecHitToken_;
-
 };
 
-
-
 testEcalClusterLazyTools::testEcalClusterLazyTools(const edm::ParameterSet& ps)
-  : barrelClusterToken_(consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("barrelClusterCollection")))
-  , endcapClusterToken_(consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("endcapClusterCollection")))
-  , barrelRecHitToken_(consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("barrelRecHitCollection")))
-  , endcapRecHitToken_(consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("endcapRecHitCollection")))
-{}
+    : barrelClusterToken_(
+          consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("barrelClusterCollection"))),
+      endcapClusterToken_(
+          consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("endcapClusterCollection"))),
+      barrelRecHitToken_(consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("barrelRecHitCollection"))),
+      endcapRecHitToken_(consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("endcapRecHitCollection"))) {}
 
+void testEcalClusterLazyTools::analyze(const edm::Event& ev, const edm::EventSetup& es) {
+  edm::Handle<reco::BasicClusterCollection> pEBClusters;
+  ev.getByToken(barrelClusterToken_, pEBClusters);
+  const reco::BasicClusterCollection* ebClusters = pEBClusters.product();
 
-void testEcalClusterLazyTools::analyze(const edm::Event& ev, const edm::EventSetup& es)
-{
-  edm::Handle< reco::BasicClusterCollection > pEBClusters;
-  ev.getByToken( barrelClusterToken_, pEBClusters );
-  const reco::BasicClusterCollection *ebClusters = pEBClusters.product();
+  edm::Handle<reco::BasicClusterCollection> pEEClusters;
+  ev.getByToken(endcapClusterToken_, pEEClusters);
+  const reco::BasicClusterCollection* eeClusters = pEEClusters.product();
 
-  edm::Handle< reco::BasicClusterCollection > pEEClusters;
-  ev.getByToken( endcapClusterToken_, pEEClusters );
-  const reco::BasicClusterCollection *eeClusters = pEEClusters.product();
-
-  LazyTools lazyTools( ev, es, barrelRecHitToken_, endcapRecHitToken_ );
+  LazyTools lazyTools(ev, es, barrelRecHitToken_, endcapRecHitToken_);
 
   std::cout << "========== BARREL ==========" << std::endl;
-  for(auto const& clus : *ebClusters) {
+  for (auto const& clus : *ebClusters) {
     std::cout << "----- new cluster -----" << std::endl;
     std::cout << "----------------- size: " << (clus).size() << " energy: " << (clus).energy() << std::endl;
 
-    std::cout << "e1x3..................... " << lazyTools.e1x3( clus ) << std::endl;
-    std::cout << "e3x1..................... " << lazyTools.e3x1( clus ) << std::endl;
-    std::cout << "e1x5..................... " << lazyTools.e1x5( clus ) << std::endl;
-    std::cout << "e5x1..................... " << lazyTools.e5x1( clus ) << std::endl;
-    std::cout << "e2x2..................... " << lazyTools.e2x2( clus ) << std::endl;
-    std::cout << "e3x3..................... " << lazyTools.e3x3( clus ) << std::endl;
-    std::cout << "e4x4..................... " << lazyTools.e4x4( clus ) << std::endl;
-    std::cout << "e5x5..................... " << lazyTools.e5x5( clus ) << std::endl;
-    std::cout << "n5x5..................... " << lazyTools.n5x5( clus ) << std::endl;
-    std::cout << "e2x5Right................ " << lazyTools.e2x5Right( clus ) << std::endl;
-    std::cout << "e2x5Left................. " << lazyTools.e2x5Left( clus ) << std::endl;
-    std::cout << "e2x5Top.................. " << lazyTools.e2x5Top( clus ) << std::endl;
-    std::cout << "e2x5Bottom............... " << lazyTools.e2x5Bottom( clus ) << std::endl;
-    std::cout << "e2x5Max.................. " << lazyTools.e2x5Max( clus ) << std::endl;
-    std::cout << "eMax..................... " << lazyTools.eMax( clus ) << std::endl;
-    std::cout << "e2nd..................... " << lazyTools.e2nd( clus ) << std::endl;
-    std::vector<float> vEta = lazyTools.energyBasketFractionEta( clus );
+    std::cout << "e1x3..................... " << lazyTools.e1x3(clus) << std::endl;
+    std::cout << "e3x1..................... " << lazyTools.e3x1(clus) << std::endl;
+    std::cout << "e1x5..................... " << lazyTools.e1x5(clus) << std::endl;
+    std::cout << "e5x1..................... " << lazyTools.e5x1(clus) << std::endl;
+    std::cout << "e2x2..................... " << lazyTools.e2x2(clus) << std::endl;
+    std::cout << "e3x3..................... " << lazyTools.e3x3(clus) << std::endl;
+    std::cout << "e4x4..................... " << lazyTools.e4x4(clus) << std::endl;
+    std::cout << "e5x5..................... " << lazyTools.e5x5(clus) << std::endl;
+    std::cout << "n5x5..................... " << lazyTools.n5x5(clus) << std::endl;
+    std::cout << "e2x5Right................ " << lazyTools.e2x5Right(clus) << std::endl;
+    std::cout << "e2x5Left................. " << lazyTools.e2x5Left(clus) << std::endl;
+    std::cout << "e2x5Top.................. " << lazyTools.e2x5Top(clus) << std::endl;
+    std::cout << "e2x5Bottom............... " << lazyTools.e2x5Bottom(clus) << std::endl;
+    std::cout << "e2x5Max.................. " << lazyTools.e2x5Max(clus) << std::endl;
+    std::cout << "eMax..................... " << lazyTools.eMax(clus) << std::endl;
+    std::cout << "e2nd..................... " << lazyTools.e2nd(clus) << std::endl;
+    std::vector<float> vEta = lazyTools.energyBasketFractionEta(clus);
     std::cout << "energyBasketFractionEta..";
-    for (size_t i = 0; i < vEta.size(); ++i ) {
+    for (size_t i = 0; i < vEta.size(); ++i) {
       std::cout << " " << vEta[i];
     }
     std::cout << std::endl;
-    std::vector<float> vPhi = lazyTools.energyBasketFractionPhi( clus );
+    std::vector<float> vPhi = lazyTools.energyBasketFractionPhi(clus);
     std::cout << "energyBasketFractionPhi..";
-    for (size_t i = 0; i < vPhi.size(); ++i ) {
+    for (size_t i = 0; i < vPhi.size(); ++i) {
       std::cout << " " << vPhi[i];
     }
     std::cout << std::endl;
-    std::vector<float> vLat = lazyTools.lat( clus );
+    std::vector<float> vLat = lazyTools.lat(clus);
     std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
-    std::vector<float> vCov = lazyTools.covariances( clus );
+    std::vector<float> vCov = lazyTools.covariances(clus);
     std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
-    std::vector<float> vLocCov = lazyTools.localCovariances( clus );
+    std::vector<float> vLocCov = lazyTools.localCovariances(clus);
     std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
-    std::cout << "zernike20................ " << lazyTools.zernike20( clus ) << std::endl;
-    std::cout << "zernike42................ " << lazyTools.zernike42( clus ) << std::endl;
+    std::cout << "zernike20................ " << lazyTools.zernike20(clus) << std::endl;
+    std::cout << "zernike42................ " << lazyTools.zernike42(clus) << std::endl;
   }
 
   std::cout << "========== ENDCAPS ==========" << std::endl;
-  for(auto const& clus : *eeClusters) {
+  for (auto const& clus : *eeClusters) {
     std::cout << "----- new cluster -----" << std::endl;
     std::cout << "----------------- size: " << (clus).size() << " energy: " << (clus).energy() << std::endl;
 
-    std::cout << "e1x3..................... " << lazyTools.e1x3( clus ) << std::endl;
-    std::cout << "e3x1..................... " << lazyTools.e3x1( clus ) << std::endl;
-    std::cout << "e1x5..................... " << lazyTools.e1x5( clus ) << std::endl;
-    std::cout << "e5x1..................... " << lazyTools.e5x1( clus ) << std::endl;
-    std::cout << "e2x2..................... " << lazyTools.e2x2( clus ) << std::endl;
-    std::cout << "e3x3..................... " << lazyTools.e3x3( clus ) << std::endl;
-    std::cout << "e4x4..................... " << lazyTools.e4x4( clus ) << std::endl;
-    std::cout << "e5x5..................... " << lazyTools.e5x5( clus ) << std::endl;
-    std::cout << "n5x5..................... " << lazyTools.n5x5( clus ) << std::endl;
-    std::cout << "e2x5Right................ " << lazyTools.e2x5Right( clus ) << std::endl;
-    std::cout << "e2x5Left................. " << lazyTools.e2x5Left( clus ) << std::endl;
-    std::cout << "e2x5Top.................. " << lazyTools.e2x5Top( clus ) << std::endl;
-    std::cout << "e2x5Bottom............... " << lazyTools.e2x5Bottom( clus ) << std::endl;
-    std::cout << "eMax..................... " << lazyTools.eMax( clus ) << std::endl;
-    std::cout << "e2nd..................... " << lazyTools.e2nd( clus ) << std::endl;
-    std::vector<float> vLat = lazyTools.lat( clus );
+    std::cout << "e1x3..................... " << lazyTools.e1x3(clus) << std::endl;
+    std::cout << "e3x1..................... " << lazyTools.e3x1(clus) << std::endl;
+    std::cout << "e1x5..................... " << lazyTools.e1x5(clus) << std::endl;
+    std::cout << "e5x1..................... " << lazyTools.e5x1(clus) << std::endl;
+    std::cout << "e2x2..................... " << lazyTools.e2x2(clus) << std::endl;
+    std::cout << "e3x3..................... " << lazyTools.e3x3(clus) << std::endl;
+    std::cout << "e4x4..................... " << lazyTools.e4x4(clus) << std::endl;
+    std::cout << "e5x5..................... " << lazyTools.e5x5(clus) << std::endl;
+    std::cout << "n5x5..................... " << lazyTools.n5x5(clus) << std::endl;
+    std::cout << "e2x5Right................ " << lazyTools.e2x5Right(clus) << std::endl;
+    std::cout << "e2x5Left................. " << lazyTools.e2x5Left(clus) << std::endl;
+    std::cout << "e2x5Top.................. " << lazyTools.e2x5Top(clus) << std::endl;
+    std::cout << "e2x5Bottom............... " << lazyTools.e2x5Bottom(clus) << std::endl;
+    std::cout << "eMax..................... " << lazyTools.eMax(clus) << std::endl;
+    std::cout << "e2nd..................... " << lazyTools.e2nd(clus) << std::endl;
+    std::vector<float> vLat = lazyTools.lat(clus);
     std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
-    std::vector<float> vCov = lazyTools.covariances( clus );
+    std::vector<float> vCov = lazyTools.covariances(clus);
     std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
-    std::vector<float> vLocCov = lazyTools.localCovariances( clus );
+    std::vector<float> vLocCov = lazyTools.localCovariances(clus);
     std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
-    std::cout << "zernike20................ " << lazyTools.zernike20( clus ) << std::endl;
-    std::cout << "zernike42................ " << lazyTools.zernike42( clus ) << std::endl;
+    std::cout << "zernike20................ " << lazyTools.zernike20(clus) << std::endl;
+    std::cout << "zernike42................ " << lazyTools.zernike42(clus) << std::endl;
   }
 }
 

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterSeverityAlgo.cc
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterSeverityAlgo.cc
@@ -2,7 +2,7 @@
 //
 // Package:    testEcalClusterSeverityAlgo
 // Class:      testEcalClusterSeverityAlgo
-// 
+//
 /**\class testEcalClusterSeverityAlgo testEcalClusterSeverityAlgo.cc
 
 Description: <one line class summary>
@@ -12,8 +12,6 @@ Implementation:
 */
 //
 // Original Author:  "Paolo Meridiani CERN CMG"
-
-
 
 // system include files
 #include <memory>
@@ -32,8 +30,6 @@ Implementation:
 #include "DataFormats/EgammaReco/interface/BasicClusterFwd.h"
 #include "DataFormats/EgammaReco/interface/SuperClusterFwd.h"
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
-
-
 
 // to use the cluster tools
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -58,24 +54,20 @@ Implementation:
 #include "TTree.h"
 #include "TFile.h"
 
-class testEcalClusterSeverityAlgo : public edm::EDAnalyzer 
-{
-  
+class testEcalClusterSeverityAlgo : public edm::EDAnalyzer {
 public:
-  
   explicit testEcalClusterSeverityAlgo(const edm::ParameterSet&);
   ~testEcalClusterSeverityAlgo();
-  
+
   edm::InputTag barrelClusterCollection_;
   edm::InputTag endcapClusterCollection_;
   edm::InputTag reducedBarrelRecHitCollection_;
   edm::InputTag reducedEndcapRecHitCollection_;
   edm::InputTag mcTruthCollection_;
-  
-  struct ClusterSeverityTreeContent
-  {
+
+  struct ClusterSeverityTreeContent {
 #define NMAXOBJ 50
-    //MC Variables     
+    //MC Variables
     int nSc;
     float scE[NMAXOBJ];
     float scEta[NMAXOBJ];
@@ -89,220 +81,188 @@ public:
     float mcPhi[NMAXOBJ];
   };
 
-  static void setBranchAddresses(TTree* chain, ClusterSeverityTreeContent& treeVars)    
-  {
-    chain -> SetBranchAddress("nSc",         &treeVars.nSc);
-    chain -> SetBranchAddress("scE", treeVars.scE);
-    chain -> SetBranchAddress("scEta", treeVars.scEta);
-    chain -> SetBranchAddress("scPhi", treeVars.scPhi);
-    chain -> SetBranchAddress("scGoodFraction", treeVars.scGoodFraction);
-    chain -> SetBranchAddress("scFracAroundClosProb", treeVars.scFracAroundClosProb);
-    chain -> SetBranchAddress("scClosProbEta", treeVars.scClosProbEta);
-    chain -> SetBranchAddress("scClosProbPhi", treeVars.scClosProbPhi);
-    chain -> SetBranchAddress("mcE", treeVars.mcE);
-    chain -> SetBranchAddress("mcEta", treeVars.mcEta);
-    chain -> SetBranchAddress("mcPhi", treeVars.mcPhi);
+  static void setBranchAddresses(TTree* chain, ClusterSeverityTreeContent& treeVars) {
+    chain->SetBranchAddress("nSc", &treeVars.nSc);
+    chain->SetBranchAddress("scE", treeVars.scE);
+    chain->SetBranchAddress("scEta", treeVars.scEta);
+    chain->SetBranchAddress("scPhi", treeVars.scPhi);
+    chain->SetBranchAddress("scGoodFraction", treeVars.scGoodFraction);
+    chain->SetBranchAddress("scFracAroundClosProb", treeVars.scFracAroundClosProb);
+    chain->SetBranchAddress("scClosProbEta", treeVars.scClosProbEta);
+    chain->SetBranchAddress("scClosProbPhi", treeVars.scClosProbPhi);
+    chain->SetBranchAddress("mcE", treeVars.mcE);
+    chain->SetBranchAddress("mcEta", treeVars.mcEta);
+    chain->SetBranchAddress("mcPhi", treeVars.mcPhi);
   }
 
-  static void setBranches(TTree* chain, ClusterSeverityTreeContent& treeVars)
-  {
-    chain -> Branch("nSc",         &treeVars.nSc , "nSc/I");
-    chain -> Branch("scE", treeVars.scE, "scE[nSc]/F");
-    chain -> Branch("scEta", treeVars.scEta, "scEta[nSc]/F");
-    chain -> Branch("scPhi", treeVars.scPhi, "scPhi[nSc]/F");
-    chain -> Branch("scGoodFraction", treeVars.scGoodFraction, "scGoodFraction[nSc]/F");
-    chain -> Branch("scFracAroundClosProb", treeVars.scFracAroundClosProb, "scFracAroundClosProb[nSc]/F");
-    chain -> Branch("scClosProbEta", treeVars.scClosProbEta, "scClosProbEta[nSc]/F");
-    chain -> Branch("scClosProbPhi", treeVars.scClosProbPhi, "scClosProbPhi[nSc]/F");
-    chain -> Branch("mcE", treeVars.mcE, "mcE[nSc]/F");
-    chain -> Branch("mcEta", treeVars.mcEta, "mcEta[nSc]/F");
-    chain -> Branch("mcPhi", treeVars.mcPhi, "mcPhi[nSc]/F");
+  static void setBranches(TTree* chain, ClusterSeverityTreeContent& treeVars) {
+    chain->Branch("nSc", &treeVars.nSc, "nSc/I");
+    chain->Branch("scE", treeVars.scE, "scE[nSc]/F");
+    chain->Branch("scEta", treeVars.scEta, "scEta[nSc]/F");
+    chain->Branch("scPhi", treeVars.scPhi, "scPhi[nSc]/F");
+    chain->Branch("scGoodFraction", treeVars.scGoodFraction, "scGoodFraction[nSc]/F");
+    chain->Branch("scFracAroundClosProb", treeVars.scFracAroundClosProb, "scFracAroundClosProb[nSc]/F");
+    chain->Branch("scClosProbEta", treeVars.scClosProbEta, "scClosProbEta[nSc]/F");
+    chain->Branch("scClosProbPhi", treeVars.scClosProbPhi, "scClosProbPhi[nSc]/F");
+    chain->Branch("mcE", treeVars.mcE, "mcE[nSc]/F");
+    chain->Branch("mcEta", treeVars.mcEta, "mcEta[nSc]/F");
+    chain->Branch("mcPhi", treeVars.mcPhi, "mcPhi[nSc]/F");
   }
 
-  void initializeBranches(TTree* chain, ClusterSeverityTreeContent& treeVars)
-  {
-    
+  void initializeBranches(TTree* chain, ClusterSeverityTreeContent& treeVars) {
     treeVars.nSc = 0;
-    for(int i = 0; i < NMAXOBJ; ++i)
-      {
-	treeVars.scE[i]=0;
-	treeVars.scEta[i]=0;
-	treeVars.scPhi[i]=0;
-	treeVars.scGoodFraction[i]=0;
-	treeVars.scFracAroundClosProb[i]=0;
-	treeVars.scClosProbEta[i]=0;
-	treeVars.scClosProbPhi[i]=0;
-	treeVars.mcE[i]=0;
-	treeVars.mcEta[i]=0;
-	treeVars.mcPhi[i]=0;
-      }
+    for (int i = 0; i < NMAXOBJ; ++i) {
+      treeVars.scE[i] = 0;
+      treeVars.scEta[i] = 0;
+      treeVars.scPhi[i] = 0;
+      treeVars.scGoodFraction[i] = 0;
+      treeVars.scFracAroundClosProb[i] = 0;
+      treeVars.scClosProbEta[i] = 0;
+      treeVars.scClosProbPhi[i] = 0;
+      treeVars.mcE[i] = 0;
+      treeVars.mcEta[i] = 0;
+      treeVars.mcPhi[i] = 0;
+    }
   }
 
 private:
-
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
-  
-  std::string outputFile_;
-  TFile *treeFile_;
-  TTree *tree_;
-  ClusterSeverityTreeContent myTreeVariables_;
+  virtual void endJob();
 
+  std::string outputFile_;
+  TFile* treeFile_;
+  TTree* tree_;
+  ClusterSeverityTreeContent myTreeVariables_;
 };
 
-
-
-testEcalClusterSeverityAlgo::testEcalClusterSeverityAlgo(const edm::ParameterSet& ps)
-{
-        barrelClusterCollection_ = ps.getParameter<edm::InputTag>("barrelClusterCollection");
-        endcapClusterCollection_ = ps.getParameter<edm::InputTag>("endcapClusterCollection");
-        reducedBarrelRecHitCollection_ = ps.getParameter<edm::InputTag>("reducedBarrelRecHitCollection");
-        reducedEndcapRecHitCollection_ = ps.getParameter<edm::InputTag>("reducedEndcapRecHitCollection");
-	mcTruthCollection_ = ps.getParameter<edm::InputTag>("mcTruthCollection");
-        outputFile_ = ps.getParameter<std::string>("outputFile");
-	treeFile_ = new TFile(outputFile_.c_str(),"RECREATE");
-	treeFile_->cd();
-	// Initialize Tree
-	tree_ = new TTree ( "ClusterSeverityAnalysis","ClusterSeverityAnalysis" ) ;
-	setBranches (tree_, myTreeVariables_) ;
-        
+testEcalClusterSeverityAlgo::testEcalClusterSeverityAlgo(const edm::ParameterSet& ps) {
+  barrelClusterCollection_ = ps.getParameter<edm::InputTag>("barrelClusterCollection");
+  endcapClusterCollection_ = ps.getParameter<edm::InputTag>("endcapClusterCollection");
+  reducedBarrelRecHitCollection_ = ps.getParameter<edm::InputTag>("reducedBarrelRecHitCollection");
+  reducedEndcapRecHitCollection_ = ps.getParameter<edm::InputTag>("reducedEndcapRecHitCollection");
+  mcTruthCollection_ = ps.getParameter<edm::InputTag>("mcTruthCollection");
+  outputFile_ = ps.getParameter<std::string>("outputFile");
+  treeFile_ = new TFile(outputFile_.c_str(), "RECREATE");
+  treeFile_->cd();
+  // Initialize Tree
+  tree_ = new TTree("ClusterSeverityAnalysis", "ClusterSeverityAnalysis");
+  setBranches(tree_, myTreeVariables_);
 }
 
+testEcalClusterSeverityAlgo::~testEcalClusterSeverityAlgo() {}
 
-
-testEcalClusterSeverityAlgo::~testEcalClusterSeverityAlgo()
-{
-}
-
-
-
-void testEcalClusterSeverityAlgo::analyze(const edm::Event& ev, const edm::EventSetup& es)
-{
+void testEcalClusterSeverityAlgo::analyze(const edm::Event& ev, const edm::EventSetup& es) {
   initializeBranches(tree_, myTreeVariables_);
 
   edm::Handle<edm::HepMCProduct> hepMC;
-  ev.getByLabel(mcTruthCollection_,hepMC);
-  const HepMC::GenEvent *myGenEvent = hepMC->GetEvent();
+  ev.getByLabel(mcTruthCollection_, hepMC);
+  const HepMC::GenEvent* myGenEvent = hepMC->GetEvent();
 
-  edm::ESHandle<EcalSeverityLevelAlgo> sevlvh;  
-  es.get<EcalSeverityLevelAlgoRcd>().get(sevlvh);  
-  const EcalSeverityLevelAlgo * sevLv= sevlvh.product();
+  edm::ESHandle<EcalSeverityLevelAlgo> sevlvh;
+  es.get<EcalSeverityLevelAlgoRcd>().get(sevlvh);
+  const EcalSeverityLevelAlgo* sevLv = sevlvh.product();
 
-  edm::Handle< reco::SuperClusterCollection > pEBClusters;
-        ev.getByLabel( barrelClusterCollection_, pEBClusters );
-        const reco::SuperClusterCollection *ebClusters = pEBClusters.product();
+  edm::Handle<reco::SuperClusterCollection> pEBClusters;
+  ev.getByLabel(barrelClusterCollection_, pEBClusters);
+  const reco::SuperClusterCollection* ebClusters = pEBClusters.product();
 
-        edm::Handle< reco::SuperClusterCollection > pEEClusters;
-        ev.getByLabel( endcapClusterCollection_, pEEClusters );
-        //const reco::SuperClusterCollection *eeClusters = pEEClusters.product();
+  edm::Handle<reco::SuperClusterCollection> pEEClusters;
+  ev.getByLabel(endcapClusterCollection_, pEEClusters);
+  //const reco::SuperClusterCollection *eeClusters = pEEClusters.product();
 
-        edm::Handle< EcalRecHitCollection > pEBRecHits;
-        ev.getByLabel( reducedBarrelRecHitCollection_, pEBRecHits );
-        const EcalRecHitCollection *ebRecHits = pEBRecHits.product();
+  edm::Handle<EcalRecHitCollection> pEBRecHits;
+  ev.getByLabel(reducedBarrelRecHitCollection_, pEBRecHits);
+  const EcalRecHitCollection* ebRecHits = pEBRecHits.product();
 
-        //edm::Handle< EcalRecHitCollection > pEERecHits;
-        //ev.getByLabel( reducedEndcapRecHitCollection_, pEERecHits );
-        //const EcalRecHitCollection *eeRecHits = pEERecHits.product();
+  //edm::Handle< EcalRecHitCollection > pEERecHits;
+  //ev.getByLabel( reducedEndcapRecHitCollection_, pEERecHits );
+  //const EcalRecHitCollection *eeRecHits = pEERecHits.product();
 
-        //edm::ESHandle<CaloGeometry> pGeometry;
-        //es.get<CaloGeometryRecord>().get(pGeometry);
-        //const CaloGeometry *geometry = pGeometry.product();
+  //edm::ESHandle<CaloGeometry> pGeometry;
+  //es.get<CaloGeometryRecord>().get(pGeometry);
+  //const CaloGeometry *geometry = pGeometry.product();
 
-        edm::ESHandle<CaloTopology> pTopology;
-        es.get<CaloTopologyRecord>().get(pTopology);
-        const CaloTopology *topology = pTopology.product();
+  edm::ESHandle<CaloTopology> pTopology;
+  es.get<CaloTopologyRecord>().get(pTopology);
+  const CaloTopology* topology = pTopology.product();
 
-	
-	//        std::cout << "========== BARREL ==========" << std::endl;
-	int problematicSC=0;
-        for (reco::SuperClusterCollection::const_iterator it = ebClusters->begin(); it != ebClusters->end(); ++it ) 
-	  {
-	    //apply an et Cut
-	    if ((*it).energy()/cosh((*it).eta())<15.)
-	      continue;
-	    //  	    if ( fabs(EcalClusterSeverityLevelAlgo::goodFraction( *it, *ebRecHits, *theEcalChStatus) - 1. ) < 1e-6 && EcalClusterSeverityLevelAlgo::closestProblematic( *it, *ebRecHits, *theEcalChStatus,topology).null() ) 
-	    //  	      continue;
-	    // 	    std::cout << "seed" << EBDetId(EcalClusterTools::getMaximum(*it, ebRecHits).first) << std::endl;
-	    // 	    std::cout << "goodFraction" << EcalClusterSeverityLevelAlgo::goodFraction( *it, *ebRecHits, *theEcalChStatus) << std::endl;
-	    // 	    std::cout << "closestProblematicDetId" << EBDetId(EcalClusterSeverityLevelAlgo::closestProblematic( *it, *ebRecHits, *theEcalChStatus,topology)) << std::endl;
-	    // 	    std::cout << "(deta,dphi)" << "(" << EcalClusterSeverityLevelAlgo::etaphiDistanceClosestProblematic( *it, *ebRecHits, *theEcalChStatus,topology).first << "," <<EcalClusterSeverityLevelAlgo::etaphiDistanceClosestProblematic( *it, *ebRecHits, *theEcalChStatus,topology).second << ")" << std::endl;
-	    
-	    HepMC::GenParticle* bestMcMatch=0;
-	    for ( HepMC::GenEvent::particle_const_iterator mcIter=myGenEvent->particles_begin(); mcIter != myGenEvent->particles_end(); mcIter++ ) {
-	      
-	      // select electrons
-	      if ( std::abs((*mcIter)->pdg_id()) == 11 )
-		{
-		
-		  // single primary electrons or electrons from Zs or Ws
-		  HepMC::GenParticle* mother = 0;
-		  if ( (*mcIter)->production_vertex() )  {
-		    if ( (*mcIter)->production_vertex()->particles_begin(HepMC::parents) !=
-			 (*mcIter)->production_vertex()->particles_end(HepMC::parents))
-		      mother = *((*mcIter)->production_vertex()->particles_begin(HepMC::parents));
-		  }
-		  if ( (
-			(mother == 0) || 
-			((mother != 0) && (std::abs(mother->pdg_id()) == 23)) ||
-			((mother != 0) && (std::abs(mother->pdg_id()) == 32)) ||
-			((mother != 0) && (std::abs(mother->pdg_id()) == 24))
-			)
-		       ) 
-		    {
-		    
-		    HepMC::GenParticle* genPc=(*mcIter);
-		    HepMC::FourVector pAssSim = genPc->momentum();
+  //        std::cout << "========== BARREL ==========" << std::endl;
+  int problematicSC = 0;
+  for (reco::SuperClusterCollection::const_iterator it = ebClusters->begin(); it != ebClusters->end(); ++it) {
+    //apply an et Cut
+    if ((*it).energy() / cosh((*it).eta()) < 15.)
+      continue;
+    //  	    if ( fabs(EcalClusterSeverityLevelAlgo::goodFraction( *it, *ebRecHits, *theEcalChStatus) - 1. ) < 1e-6 && EcalClusterSeverityLevelAlgo::closestProblematic( *it, *ebRecHits, *theEcalChStatus,topology).null() )
+    //  	      continue;
+    // 	    std::cout << "seed" << EBDetId(EcalClusterTools::getMaximum(*it, ebRecHits).first) << std::endl;
+    // 	    std::cout << "goodFraction" << EcalClusterSeverityLevelAlgo::goodFraction( *it, *ebRecHits, *theEcalChStatus) << std::endl;
+    // 	    std::cout << "closestProblematicDetId" << EBDetId(EcalClusterSeverityLevelAlgo::closestProblematic( *it, *ebRecHits, *theEcalChStatus,topology)) << std::endl;
+    // 	    std::cout << "(deta,dphi)" << "(" << EcalClusterSeverityLevelAlgo::etaphiDistanceClosestProblematic( *it, *ebRecHits, *theEcalChStatus,topology).first << "," <<EcalClusterSeverityLevelAlgo::etaphiDistanceClosestProblematic( *it, *ebRecHits, *theEcalChStatus,topology).second << ")" << std::endl;
 
+    HepMC::GenParticle* bestMcMatch = 0;
+    for (HepMC::GenEvent::particle_const_iterator mcIter = myGenEvent->particles_begin();
+         mcIter != myGenEvent->particles_end();
+         mcIter++) {
+      // select electrons
+      if (std::abs((*mcIter)->pdg_id()) == 11) {
+        // single primary electrons or electrons from Zs or Ws
+        HepMC::GenParticle* mother = 0;
+        if ((*mcIter)->production_vertex()) {
+          if ((*mcIter)->production_vertex()->particles_begin(HepMC::parents) !=
+              (*mcIter)->production_vertex()->particles_end(HepMC::parents))
+            mother = *((*mcIter)->production_vertex()->particles_begin(HepMC::parents));
+        }
+        if (((mother == 0) || ((mother != 0) && (std::abs(mother->pdg_id()) == 23)) ||
+             ((mother != 0) && (std::abs(mother->pdg_id()) == 32)) ||
+             ((mother != 0) && (std::abs(mother->pdg_id()) == 24)))) {
+          HepMC::GenParticle* genPc = (*mcIter);
+          HepMC::FourVector pAssSim = genPc->momentum();
 
-		    //bool okGsfFound = false;
-		    double ScOkRatio = 999999.;
-		    
-		    
-		    
-		    
-		    double dphi = (*it).phi()-pAssSim.phi();
-		    if (fabs(dphi)>CLHEP::pi)
-		      dphi = dphi < 0? (CLHEP::twopi) + dphi : dphi - CLHEP::twopi;
-		    double deltaR = sqrt(pow(((*it).eta()-pAssSim.eta()),2) + pow(dphi,2));
-		    if ( deltaR < 0.15 )
-		      {
-			
-			double tmpScRatio = (*it).energy()/pAssSim.t();
-			if ( fabs(tmpScRatio-1) < fabs(ScOkRatio-1) ) {
-			  ScOkRatio = tmpScRatio;
-			  bestMcMatch=genPc;
-			  //okGsfFound = true;
-			}
-		      }
-		    
-		  }
-		}
-	    }
-	  	  
-	    if (!bestMcMatch)
-	      continue;
-	    
-	    myTreeVariables_.scE[problematicSC]=(*it).energy();
-	    myTreeVariables_.scEta[problematicSC]=(*it).eta();
-	    myTreeVariables_.scPhi[problematicSC]=(*it).phi();
-	    myTreeVariables_.scGoodFraction[problematicSC]=EcalClusterSeverityLevelAlgo::goodFraction( *it, *ebRecHits, *sevLv);
-	    myTreeVariables_.scFracAroundClosProb[problematicSC]=EcalClusterSeverityLevelAlgo::fractionAroundClosestProblematic( *it, *ebRecHits,topology,*sevLv);
-	    std::pair<int,int> distanceClosestProblematic=EcalClusterSeverityLevelAlgo::etaphiDistanceClosestProblematic( *it, *ebRecHits,topology,*sevLv);
-	    myTreeVariables_.scClosProbEta[problematicSC]=distanceClosestProblematic.first;
-	    myTreeVariables_.scClosProbPhi[problematicSC]=distanceClosestProblematic.second;
-	    myTreeVariables_.mcE[problematicSC]=bestMcMatch->momentum().t();
-	    myTreeVariables_.mcEta[problematicSC]=bestMcMatch->momentum().eta();
-	    myTreeVariables_.mcPhi[problematicSC]=bestMcMatch->momentum().phi();
-	    ++problematicSC;
-	  }
-	myTreeVariables_.nSc=problematicSC;
-	tree_ -> Fill();
+          //bool okGsfFound = false;
+          double ScOkRatio = 999999.;
+
+          double dphi = (*it).phi() - pAssSim.phi();
+          if (fabs(dphi) > CLHEP::pi)
+            dphi = dphi < 0 ? (CLHEP::twopi) + dphi : dphi - CLHEP::twopi;
+          double deltaR = sqrt(pow(((*it).eta() - pAssSim.eta()), 2) + pow(dphi, 2));
+          if (deltaR < 0.15) {
+            double tmpScRatio = (*it).energy() / pAssSim.t();
+            if (fabs(tmpScRatio - 1) < fabs(ScOkRatio - 1)) {
+              ScOkRatio = tmpScRatio;
+              bestMcMatch = genPc;
+              //okGsfFound = true;
+            }
+          }
+        }
+      }
+    }
+
+    if (!bestMcMatch)
+      continue;
+
+    myTreeVariables_.scE[problematicSC] = (*it).energy();
+    myTreeVariables_.scEta[problematicSC] = (*it).eta();
+    myTreeVariables_.scPhi[problematicSC] = (*it).phi();
+    myTreeVariables_.scGoodFraction[problematicSC] =
+        EcalClusterSeverityLevelAlgo::goodFraction(*it, *ebRecHits, *sevLv);
+    myTreeVariables_.scFracAroundClosProb[problematicSC] =
+        EcalClusterSeverityLevelAlgo::fractionAroundClosestProblematic(*it, *ebRecHits, topology, *sevLv);
+    std::pair<int, int> distanceClosestProblematic =
+        EcalClusterSeverityLevelAlgo::etaphiDistanceClosestProblematic(*it, *ebRecHits, topology, *sevLv);
+    myTreeVariables_.scClosProbEta[problematicSC] = distanceClosestProblematic.first;
+    myTreeVariables_.scClosProbPhi[problematicSC] = distanceClosestProblematic.second;
+    myTreeVariables_.mcE[problematicSC] = bestMcMatch->momentum().t();
+    myTreeVariables_.mcEta[problematicSC] = bestMcMatch->momentum().eta();
+    myTreeVariables_.mcPhi[problematicSC] = bestMcMatch->momentum().phi();
+    ++problematicSC;
+  }
+  myTreeVariables_.nSc = problematicSC;
+  tree_->Fill();
 }
-
 
 void testEcalClusterSeverityAlgo::endJob() {
   treeFile_->cd();
-  tree_->Write () ;
+  tree_->Write();
   treeFile_->Close();
 }
 

--- a/RecoEcal/EgammaCoreTools/test/testEcalClusterTools.cc
+++ b/RecoEcal/EgammaCoreTools/test/testEcalClusterTools.cc
@@ -34,131 +34,131 @@ Implementation:
 #include <memory>
 
 class testEcalClusterTools : public edm::one::EDAnalyzer<> {
-  public:
-    explicit testEcalClusterTools(const edm::ParameterSet&);
+public:
+  explicit testEcalClusterTools(const edm::ParameterSet&);
 
-  private:
-    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+private:
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-    using ClusterTools = noZS::EcalClusterTools; // alternatively just EcalClusterTools
+  using ClusterTools = noZS::EcalClusterTools;  // alternatively just EcalClusterTools
 
-    const edm::EDGetToken barrelClusterToken_;
-    const edm::EDGetToken endcapClusterToken_;
-    const edm::EDGetToken barrelRecHitToken_;
-    const edm::EDGetToken endcapRecHitToken_;
+  const edm::EDGetToken barrelClusterToken_;
+  const edm::EDGetToken endcapClusterToken_;
+  const edm::EDGetToken barrelRecHitToken_;
+  const edm::EDGetToken endcapRecHitToken_;
 };
 
-
-
 testEcalClusterTools::testEcalClusterTools(const edm::ParameterSet& ps)
-    : barrelClusterToken_(consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("barrelClusterCollection")))
-    , endcapClusterToken_(consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("endcapClusterCollection")))
-    , barrelRecHitToken_(consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("barrelRecHitCollection")))
-    , endcapRecHitToken_(consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("endcapRecHitCollection")))
-{}
+    : barrelClusterToken_(
+          consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("barrelClusterCollection"))),
+      endcapClusterToken_(
+          consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("endcapClusterCollection"))),
+      barrelRecHitToken_(consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("barrelRecHitCollection"))),
+      endcapRecHitToken_(consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("endcapRecHitCollection"))) {}
 
+void testEcalClusterTools::analyze(const edm::Event& ev, const edm::EventSetup& es) {
+  edm::Handle<EcalRecHitCollection> pEBRecHits;
+  ev.getByToken(barrelRecHitToken_, pEBRecHits);
+  const EcalRecHitCollection* ebRecHits = pEBRecHits.product();
 
+  edm::Handle<EcalRecHitCollection> pEERecHits;
+  ev.getByToken(endcapRecHitToken_, pEERecHits);
+  const EcalRecHitCollection* eeRecHits = pEERecHits.product();
 
-void testEcalClusterTools::analyze(const edm::Event& ev, const edm::EventSetup& es)
-{
-    edm::Handle< EcalRecHitCollection > pEBRecHits;
-    ev.getByToken( barrelRecHitToken_, pEBRecHits );
-    const EcalRecHitCollection *ebRecHits = pEBRecHits.product();
+  edm::Handle<reco::BasicClusterCollection> pEBClusters;
+  ev.getByToken(barrelClusterToken_, pEBClusters);
+  const reco::BasicClusterCollection* ebClusters = pEBClusters.product();
 
-    edm::Handle< EcalRecHitCollection > pEERecHits;
-    ev.getByToken( endcapRecHitToken_, pEERecHits );
-    const EcalRecHitCollection *eeRecHits = pEERecHits.product();
+  edm::Handle<reco::BasicClusterCollection> pEEClusters;
+  ev.getByToken(endcapClusterToken_, pEEClusters);
+  const reco::BasicClusterCollection* eeClusters = pEEClusters.product();
 
-    edm::Handle< reco::BasicClusterCollection > pEBClusters;
-    ev.getByToken( barrelClusterToken_, pEBClusters );
-    const reco::BasicClusterCollection *ebClusters = pEBClusters.product();
+  edm::ESHandle<CaloGeometry> pGeometry;
+  es.get<CaloGeometryRecord>().get(pGeometry);
+  const CaloGeometry* geometry = pGeometry.product();
 
-    edm::Handle< reco::BasicClusterCollection > pEEClusters;
-    ev.getByToken( endcapClusterToken_, pEEClusters );
-    const reco::BasicClusterCollection *eeClusters = pEEClusters.product();
+  edm::ESHandle<CaloTopology> pTopology;
+  es.get<CaloTopologyRecord>().get(pTopology);
+  const CaloTopology* topology = pTopology.product();
 
-    edm::ESHandle<CaloGeometry> pGeometry;
-    es.get<CaloGeometryRecord>().get(pGeometry);
-    const CaloGeometry *geometry = pGeometry.product();
+  std::cout << "========== BARREL ==========" << std::endl;
+  for (auto const& clus : *ebClusters) {
+    DetId maxId = ClusterTools::getMaximum(clus, eeRecHits).first;
 
-    edm::ESHandle<CaloTopology> pTopology;
-    es.get<CaloTopologyRecord>().get(pTopology);
-    const CaloTopology *topology = pTopology.product();
+    std::cout << "----- new cluster -----" << std::endl;
+    std::cout << "----------------- size: " << clus.size() << " energy: " << clus.energy() << std::endl;
 
-    std::cout << "========== BARREL ==========" << std::endl;
-    for(auto const& clus : *ebClusters) {
-        DetId maxId = ClusterTools::getMaximum(clus, eeRecHits).first;
+    std::cout << "e1x3..................... " << ClusterTools::e1x3(clus, ebRecHits, topology) << std::endl;
+    std::cout << "e3x1..................... " << ClusterTools::e3x1(clus, ebRecHits, topology) << std::endl;
+    std::cout << "e1x5..................... " << ClusterTools::e1x5(clus, ebRecHits, topology) << std::endl;
+    std::cout << "e5x1..................... " << ClusterTools::e5x1(clus, ebRecHits, topology) << std::endl;
+    std::cout << "e2x2..................... " << ClusterTools::e2x2(clus, ebRecHits, topology) << std::endl;
+    std::cout << "e3x3..................... " << ClusterTools::e3x3(clus, ebRecHits, topology) << std::endl;
+    std::cout << "e4x4..................... " << ClusterTools::e4x4(clus, ebRecHits, topology) << std::endl;
+    std::cout << "e5x5..................... " << ClusterTools::e5x5(clus, ebRecHits, topology) << std::endl;
+    std::cout << "n5x5..................... " << ClusterTools::n5x5(clus, eeRecHits, topology) << std::endl;
+    std::cout << "e2x5Right................ " << ClusterTools::e2x5Right(clus, ebRecHits, topology) << std::endl;
+    std::cout << "e2x5Left................. " << ClusterTools::e2x5Left(clus, ebRecHits, topology) << std::endl;
+    std::cout << "e2x5Top.................. " << ClusterTools::e2x5Top(clus, ebRecHits, topology) << std::endl;
+    std::cout << "e2x5Bottom............... " << ClusterTools::e2x5Bottom(clus, ebRecHits, topology) << std::endl;
+    std::cout << "e2x5Max.................. " << ClusterTools::e2x5Max(clus, ebRecHits, topology) << std::endl;
+    std::cout << "eMax..................... " << ClusterTools::eMax(clus, ebRecHits) << std::endl;
+    std::cout << "e2nd..................... " << ClusterTools::e2nd(clus, ebRecHits) << std::endl;
+    std::vector<float> vEta = ClusterTools::energyBasketFractionEta(clus, ebRecHits);
+    std::cout << "energyBasketFractionEta..";
+    for (auto const& eta : vEta)
+      std::cout << " " << eta;
+    std::cout << std::endl;
+    std::vector<float> vPhi = ClusterTools::energyBasketFractionPhi(clus, ebRecHits);
+    std::cout << "energyBasketFractionPhi..";
+    for (auto const& phi : vPhi)
+      std::cout << " " << phi;
+    std::cout << std::endl;
+    std::vector<float> vLat = ClusterTools::lat(clus, ebRecHits, geometry);
+    std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
+    std::vector<float> vCov = ClusterTools::covariances(clus, ebRecHits, topology, geometry);
+    std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
+    std::vector<float> vLocCov = ClusterTools::localCovariances(clus, ebRecHits, topology);
+    std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
+    std::cout << "zernike20................ " << ClusterTools::zernike20(clus, ebRecHits, geometry) << std::endl;
+    std::cout << "zernike42................ " << ClusterTools::zernike42(clus, ebRecHits, geometry) << std::endl;
+    std::cout << "nrSaturatedCrysIn5x5..... " << ClusterTools::nrSaturatedCrysIn5x5(maxId, ebRecHits, topology)
+              << std::endl;
+  }
 
-        std::cout << "----- new cluster -----" << std::endl;
-        std::cout << "----------------- size: " << clus.size() << " energy: " << clus.energy() << std::endl;
+  std::cout << "========== ENDCAPS ==========" << std::endl;
+  for (auto const& clus : *eeClusters) {
+    DetId maxId = ClusterTools::getMaximum(clus, eeRecHits).first;
 
-        std::cout << "e1x3..................... " << ClusterTools::e1x3( clus, ebRecHits, topology ) << std::endl;
-        std::cout << "e3x1..................... " << ClusterTools::e3x1( clus, ebRecHits, topology ) << std::endl;
-        std::cout << "e1x5..................... " << ClusterTools::e1x5( clus, ebRecHits, topology ) << std::endl;
-        std::cout << "e5x1..................... " << ClusterTools::e5x1( clus, ebRecHits, topology ) << std::endl;
-        std::cout << "e2x2..................... " << ClusterTools::e2x2( clus, ebRecHits, topology ) << std::endl;
-        std::cout << "e3x3..................... " << ClusterTools::e3x3( clus, ebRecHits, topology ) << std::endl;
-        std::cout << "e4x4..................... " << ClusterTools::e4x4( clus, ebRecHits, topology ) << std::endl;
-        std::cout << "e5x5..................... " << ClusterTools::e5x5( clus, ebRecHits, topology ) << std::endl;
-        std::cout << "n5x5..................... " << ClusterTools::n5x5( clus, eeRecHits, topology ) << std::endl;
-        std::cout << "e2x5Right................ " << ClusterTools::e2x5Right( clus, ebRecHits, topology ) << std::endl;
-        std::cout << "e2x5Left................. " << ClusterTools::e2x5Left( clus, ebRecHits, topology ) << std::endl;
-        std::cout << "e2x5Top.................. " << ClusterTools::e2x5Top( clus, ebRecHits, topology ) << std::endl;
-        std::cout << "e2x5Bottom............... " << ClusterTools::e2x5Bottom( clus, ebRecHits, topology ) << std::endl;
-        std::cout << "e2x5Max.................. " << ClusterTools::e2x5Max( clus, ebRecHits, topology ) << std::endl;
-        std::cout << "eMax..................... " << ClusterTools::eMax( clus, ebRecHits ) << std::endl;
-        std::cout << "e2nd..................... " << ClusterTools::e2nd( clus, ebRecHits ) << std::endl;
-        std::vector<float> vEta = ClusterTools::energyBasketFractionEta( clus, ebRecHits );
-        std::cout << "energyBasketFractionEta..";
-        for (auto const& eta : vEta) std::cout << " " << eta;
-        std::cout << std::endl;
-        std::vector<float> vPhi = ClusterTools::energyBasketFractionPhi( clus, ebRecHits );
-        std::cout << "energyBasketFractionPhi..";
-        for (auto const& phi : vPhi) std::cout << " " << phi;
-        std::cout << std::endl;
-        std::vector<float> vLat = ClusterTools::lat( clus, ebRecHits, geometry );
-        std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
-        std::vector<float> vCov = ClusterTools::covariances( clus, ebRecHits, topology, geometry );
-        std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
-        std::vector<float> vLocCov = ClusterTools::localCovariances( clus, ebRecHits, topology );
-        std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
-        std::cout << "zernike20................ " << ClusterTools::zernike20( clus, ebRecHits, geometry ) << std::endl;
-        std::cout << "zernike42................ " << ClusterTools::zernike42( clus, ebRecHits, geometry ) << std::endl;
-        std::cout << "nrSaturatedCrysIn5x5..... " << ClusterTools::nrSaturatedCrysIn5x5( maxId, ebRecHits, topology) << std::endl;
-    }
+    std::cout << "----- new cluster -----" << std::endl;
+    std::cout << "----------------- size: " << clus.size() << " energy: " << clus.energy() << std::endl;
 
-    std::cout << "========== ENDCAPS ==========" << std::endl;
-    for(auto const& clus : *eeClusters) {
-        DetId maxId = ClusterTools::getMaximum(clus, eeRecHits).first;
-
-        std::cout << "----- new cluster -----" << std::endl;
-        std::cout << "----------------- size: " << clus.size() << " energy: " << clus.energy() << std::endl;
-
-        std::cout << "e1x3..................... " << ClusterTools::e1x3( clus, eeRecHits, topology ) << std::endl;
-        std::cout << "e3x1..................... " << ClusterTools::e3x1( clus, eeRecHits, topology ) << std::endl;
-        std::cout << "e1x5..................... " << ClusterTools::e1x5( clus, eeRecHits, topology ) << std::endl;
-        std::cout << "e5x1..................... " << ClusterTools::e5x1( clus, eeRecHits, topology ) << std::endl;
-        std::cout << "e2x2..................... " << ClusterTools::e2x2( clus, eeRecHits, topology ) << std::endl;
-        std::cout << "e3x3..................... " << ClusterTools::e3x3( clus, eeRecHits, topology ) << std::endl;
-        std::cout << "e4x4..................... " << ClusterTools::e4x4( clus, eeRecHits, topology ) << std::endl;
-        std::cout << "e5x5..................... " << ClusterTools::e5x5( clus, eeRecHits, topology ) << std::endl;
-        std::cout << "n5x5..................... " << ClusterTools::n5x5( clus, eeRecHits, topology ) << std::endl;
-        std::cout << "e2x5Right................ " << ClusterTools::e2x5Right( clus, eeRecHits, topology ) << std::endl;
-        std::cout << "e2x5Left................. " << ClusterTools::e2x5Left( clus, eeRecHits, topology ) << std::endl;
-        std::cout << "e2x5Top.................. " << ClusterTools::e2x5Top( clus, eeRecHits, topology ) << std::endl;
-        std::cout << "e2x5Bottom............... " << ClusterTools::e2x5Bottom( clus, eeRecHits, topology ) << std::endl;
-        std::cout << "eMax..................... " << ClusterTools::eMax( clus, eeRecHits ) << std::endl;
-        std::cout << "e2nd..................... " << ClusterTools::e2nd( clus, eeRecHits ) << std::endl;
-        std::vector<float> vLat = ClusterTools::lat( clus, eeRecHits, geometry );
-        std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
-        std::vector<float> vCov = ClusterTools::covariances( clus, eeRecHits, topology, geometry );
-        std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
-        std::vector<float> vLocCov = ClusterTools::localCovariances( clus, eeRecHits, topology );
-        std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
-        std::cout << "zernike20................ " << ClusterTools::zernike20( clus, eeRecHits, geometry ) << std::endl;
-        std::cout << "zernike42................ " << ClusterTools::zernike42( clus, eeRecHits, geometry ) << std::endl;
-        std::cout << "nrSaturatedCrysIn5x5..... " << ClusterTools::nrSaturatedCrysIn5x5( maxId, eeRecHits, topology) << std::endl;
-    }
+    std::cout << "e1x3..................... " << ClusterTools::e1x3(clus, eeRecHits, topology) << std::endl;
+    std::cout << "e3x1..................... " << ClusterTools::e3x1(clus, eeRecHits, topology) << std::endl;
+    std::cout << "e1x5..................... " << ClusterTools::e1x5(clus, eeRecHits, topology) << std::endl;
+    std::cout << "e5x1..................... " << ClusterTools::e5x1(clus, eeRecHits, topology) << std::endl;
+    std::cout << "e2x2..................... " << ClusterTools::e2x2(clus, eeRecHits, topology) << std::endl;
+    std::cout << "e3x3..................... " << ClusterTools::e3x3(clus, eeRecHits, topology) << std::endl;
+    std::cout << "e4x4..................... " << ClusterTools::e4x4(clus, eeRecHits, topology) << std::endl;
+    std::cout << "e5x5..................... " << ClusterTools::e5x5(clus, eeRecHits, topology) << std::endl;
+    std::cout << "n5x5..................... " << ClusterTools::n5x5(clus, eeRecHits, topology) << std::endl;
+    std::cout << "e2x5Right................ " << ClusterTools::e2x5Right(clus, eeRecHits, topology) << std::endl;
+    std::cout << "e2x5Left................. " << ClusterTools::e2x5Left(clus, eeRecHits, topology) << std::endl;
+    std::cout << "e2x5Top.................. " << ClusterTools::e2x5Top(clus, eeRecHits, topology) << std::endl;
+    std::cout << "e2x5Bottom............... " << ClusterTools::e2x5Bottom(clus, eeRecHits, topology) << std::endl;
+    std::cout << "eMax..................... " << ClusterTools::eMax(clus, eeRecHits) << std::endl;
+    std::cout << "e2nd..................... " << ClusterTools::e2nd(clus, eeRecHits) << std::endl;
+    std::vector<float> vLat = ClusterTools::lat(clus, eeRecHits, geometry);
+    std::cout << "lat...................... " << vLat[0] << " " << vLat[1] << " " << vLat[2] << std::endl;
+    std::vector<float> vCov = ClusterTools::covariances(clus, eeRecHits, topology, geometry);
+    std::cout << "covariances.............. " << vCov[0] << " " << vCov[1] << " " << vCov[2] << std::endl;
+    std::vector<float> vLocCov = ClusterTools::localCovariances(clus, eeRecHits, topology);
+    std::cout << "local covariances........ " << vLocCov[0] << " " << vLocCov[1] << " " << vLocCov[2] << std::endl;
+    std::cout << "zernike20................ " << ClusterTools::zernike20(clus, eeRecHits, geometry) << std::endl;
+    std::cout << "zernike42................ " << ClusterTools::zernike42(clus, eeRecHits, geometry) << std::endl;
+    std::cout << "nrSaturatedCrysIn5x5..... " << ClusterTools::nrSaturatedCrysIn5x5(maxId, eeRecHits, topology)
+              << std::endl;
+  }
 }
 
 //define this as a plug-in

--- a/RecoMET/METProducers/interface/BeamHaloSummaryProducer.h
+++ b/RecoMET/METProducers/interface/BeamHaloSummaryProducer.h
@@ -6,8 +6,7 @@
   [authors]: R. Remington, The University of Florida
   [description]: EDProducer which runs BeamHalo Id/Flagging algorithms and stores BeamHaloSummary object to the event. Inspiration for this implementation was taken from HcalNoisInfoProducer.cc by J.P Chou
   [date]: October 15, 2009
-*/  
-
+*/
 
 //Standard C++ classes
 #include <iostream>
@@ -53,18 +52,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 
-namespace reco
-{
+namespace reco {
   class BeamHaloSummaryProducer : public edm::stream::EDProducer<> {
-    
   public:
     explicit BeamHaloSummaryProducer(const edm::ParameterSet&);
     ~BeamHaloSummaryProducer() override;
-    
+
   private:
-    
     void produce(edm::Event&, const edm::EventSetup&) override;
-    
+
     edm::InputTag IT_CSCHaloData;
     edm::InputTag IT_EcalHaloData;
     edm::InputTag IT_HcalHaloData;
@@ -92,20 +88,19 @@ namespace reco
     float T_EcalShowerShapesAngle;
     int T_EcalSuperClusterSize;
     float T_EcalSuperClusterEnergy;
-    
+
     float L_HcalPhiWedgeEnergy;
     int L_HcalPhiWedgeConstituents;
     float L_HcalPhiWedgeToF;
     float L_HcalPhiWedgeConfidence;
-    
+
     float T_HcalPhiWedgeEnergy;
     int T_HcalPhiWedgeConstituents;
     float T_HcalPhiWedgeToF;
     float T_HcalPhiWedgeConfidence;
-    
+
     int problematicStripMinLength;
   };
-}
+}  // namespace reco
 
 #endif
-  

--- a/RecoMET/METProducers/interface/CSCHaloDataProducer.h
+++ b/RecoMET/METProducers/interface/CSCHaloDataProducer.h
@@ -8,7 +8,6 @@
   [date]: October 15, 2009
 */
 
-
 //Standard C++ classes
 #include <iostream>
 #include <string>
@@ -126,17 +125,14 @@
 
 class MuonServiceProxy;
 
-namespace reco
-{
-class CSCHaloDataProducer : public edm::stream::EDProducer<> {
-
+namespace reco {
+  class CSCHaloDataProducer : public edm::stream::EDProducer<> {
   public:
-    explicit CSCHaloDataProducer(const edm::ParameterSet&);
+    explicit CSCHaloDataProducer(const edm::ParameterSet &);
     ~CSCHaloDataProducer() override;
 
   private:
-
-    void produce(edm::Event&, const edm::EventSetup&) override;
+    void produce(edm::Event &, const edm::EventSetup &) override;
 
     //CSCHaloAlgo
     CSCHaloAlgo CSCAlgo;
@@ -147,7 +143,7 @@ class CSCHaloDataProducer : public edm::stream::EDProducer<> {
 
     //HLT
     edm::InputTag IT_HLTResult;
-    std::vector< edm::InputTag > vIT_HLTBit  ;
+    std::vector<edm::InputTag> vIT_HLTBit;
 
     //Muon-Segment Matching
     MuonSegmentMatcher *TheMatcher;
@@ -179,7 +175,6 @@ class CSCHaloDataProducer : public edm::stream::EDProducer<> {
     edm::EDGetTokenT<L1MuGMTReadoutCollection> l1mugmtro_token_;
     edm::EDGetTokenT<edm::TriggerResults> hltresult_token_;
   };
-}
+}  // namespace reco
 
 #endif
-

--- a/RecoMET/METProducers/interface/CaloMETProducer.h
+++ b/RecoMET/METProducers/interface/CaloMETProducer.h
@@ -31,34 +31,29 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 
 //____________________________________________________________________________||
-namespace metsig
-{
+namespace metsig {
   class SignAlgoResolutions;
 }
 
 //____________________________________________________________________________||
-namespace cms
-{
-  class CaloMETProducer: public edm::stream::EDProducer<>
-    {
-    public:
-      explicit CaloMETProducer(const edm::ParameterSet&);
-      ~CaloMETProducer() override;
-      void produce(edm::Event&, const edm::EventSetup&) override;
+namespace cms {
+  class CaloMETProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit CaloMETProducer(const edm::ParameterSet &);
+    ~CaloMETProducer() override;
+    void produce(edm::Event &, const edm::EventSetup &) override;
 
-    private:
+  private:
+    edm::EDGetTokenT<edm::View<reco::Candidate> > inputToken_;
 
-      edm::EDGetTokenT<edm::View<reco::Candidate> > inputToken_;
+    bool calculateSignificance_;
+    metsig::SignAlgoResolutions *resolutions_;
 
-      bool calculateSignificance_;
-      metsig::SignAlgoResolutions *resolutions_;
+    bool noHF_;
 
-      bool noHF_;
-
-      double globalThreshold_;
-
-    };
-}
+    double globalThreshold_;
+  };
+}  // namespace cms
 
 //____________________________________________________________________________||
-#endif // CaloMETProducer_h
+#endif  // CaloMETProducer_h

--- a/RecoMET/METProducers/interface/EcalHaloDataProducer.h
+++ b/RecoMET/METProducers/interface/EcalHaloDataProducer.h
@@ -6,8 +6,7 @@
   [authors]: R. Remington, The University of Florida
   [description]: EDProducer which runs EcalHaloAlgo and store the EcalHaloData object to the event.
   [date]: October 15, 2009
-*/  
-
+*/
 
 //Standard C++ classes
 #include <iostream>
@@ -55,7 +54,7 @@
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitDefs.h"
-#include "DataFormats/HepMCCandidate/interface/PdfInfo.h" 
+#include "DataFormats/HepMCCandidate/interface/PdfInfo.h"
 #include "DataFormats/GeometrySurface/interface/Cylinder.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 #include "DataFormats/GeometrySurface/interface/Cone.h"
@@ -90,18 +89,15 @@
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 
-namespace reco
-{
+namespace reco {
   class EcalHaloDataProducer : public edm::stream::EDProducer<> {
-    
   public:
     explicit EcalHaloDataProducer(const edm::ParameterSet&);
     ~EcalHaloDataProducer() override;
-    
+
   private:
-    
     void produce(edm::Event&, const edm::EventSetup&) override;
-    
+
     //RecHit Level
     edm::InputTag IT_EBRecHit;
     edm::InputTag IT_EERecHit;
@@ -118,17 +114,16 @@ namespace reco
     edm::EDGetTokenT<HBHERecHitCollection> hbherechit_token_;
     edm::EDGetTokenT<reco::SuperClusterCollection> supercluster_token_;
     edm::EDGetTokenT<reco::PhotonCollection> photon_token_;
-    
-    float  EBRecHitEnergyThreshold;
-    float  EERecHitEnergyThreshold;
-    float  ESRecHitEnergyThreshold;
-    float  SumEcalEnergyThreshold;
-    int  NHitsEcalThreshold;
+
+    float EBRecHitEnergyThreshold;
+    float EERecHitEnergyThreshold;
+    float ESRecHitEnergyThreshold;
+    float SumEcalEnergyThreshold;
+    int NHitsEcalThreshold;
 
     double RoundnessCut;
-    double AngleCut;  
+    double AngleCut;
   };
-}
+}  // namespace reco
 
 #endif
-  

--- a/RecoMET/METProducers/interface/ElseMETProducer.h
+++ b/RecoMET/METProducers/interface/ElseMETProducer.h
@@ -29,23 +29,19 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 
 //____________________________________________________________________________||
-namespace cms
-{
-  class ElseMETProducer: public edm::stream::EDProducer<>
-    {
-    public:
-      explicit ElseMETProducer(const edm::ParameterSet&);
-      ~ElseMETProducer() override { }
-      void produce(edm::Event&, const edm::EventSetup&) override;
+namespace cms {
+  class ElseMETProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit ElseMETProducer(const edm::ParameterSet&);
+    ~ElseMETProducer() override {}
+    void produce(edm::Event&, const edm::EventSetup&) override;
 
-    private:
+  private:
+    edm::EDGetTokenT<edm::View<reco::Candidate> > inputToken_;
 
-      edm::EDGetTokenT<edm::View<reco::Candidate> > inputToken_;
-
-      double globalThreshold_;
-
-    };
-}
+    double globalThreshold_;
+  };
+}  // namespace cms
 
 //____________________________________________________________________________||
-#endif // ElseMETProducer_h
+#endif  // ElseMETProducer_h

--- a/RecoMET/METProducers/interface/GenMETProducer.h
+++ b/RecoMET/METProducers/interface/GenMETProducer.h
@@ -31,29 +31,25 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 
 //____________________________________________________________________________||
-namespace cms
-{
-  class GenMETProducer: public edm::stream::EDProducer<>
-    {
-    public:
-      explicit GenMETProducer(const edm::ParameterSet&);
-      ~GenMETProducer() override { }
-      void produce(edm::Event&, const edm::EventSetup&) override;
+namespace cms {
+  class GenMETProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit GenMETProducer(const edm::ParameterSet&);
+    ~GenMETProducer() override {}
+    void produce(edm::Event&, const edm::EventSetup&) override;
 
-    private:
+  private:
+    edm::EDGetTokenT<edm::View<reco::Candidate> > inputToken_;
 
-      edm::EDGetTokenT<edm::View<reco::Candidate> > inputToken_;
+    double globalThreshold_;
 
-      double globalThreshold_;
+    bool onlyFiducial_;
 
-      bool onlyFiducial_;
+    bool applyFiducialThresholdForFractions_;
 
-      bool applyFiducialThresholdForFractions_;
-
-      bool usePt_;
-
-    };
-}
+    bool usePt_;
+  };
+}  // namespace cms
 
 //____________________________________________________________________________||
-#endif // GenMETProducer_h
+#endif  // GenMETProducer_h

--- a/RecoMET/METProducers/interface/GlobalHaloDataProducer.h
+++ b/RecoMET/METProducers/interface/GlobalHaloDataProducer.h
@@ -8,7 +8,6 @@
   [date]: October 15, 2009
 */
 
-
 //Standard C++ classes
 #include <iostream>
 #include <string>
@@ -176,16 +175,13 @@
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 
-namespace reco
-{
+namespace reco {
   class GlobalHaloDataProducer : public edm::stream::EDProducer<> {
-
   public:
     explicit GlobalHaloDataProducer(const edm::ParameterSet&);
     ~GlobalHaloDataProducer() override;
 
   private:
-
     void produce(edm::Event&, const edm::EventSetup&) override;
 
     GlobalHaloAlgo GlobalAlgo;
@@ -210,14 +206,13 @@ namespace reco
     edm::EDGetTokenT<HcalHaloData> hcalhalo_token_;
 
     float EcalMinMatchingRadius;
-    float  EcalMaxMatchingRadius;
+    float EcalMaxMatchingRadius;
     float HcalMinMatchingRadius;
     float HcalMaxMatchingRadius;
     float CaloTowerEtThreshold;
 
     bool ishlt;
   };
-}
+}  // namespace reco
 
 #endif
-

--- a/RecoMET/METProducers/interface/HcalHaloDataProducer.h
+++ b/RecoMET/METProducers/interface/HcalHaloDataProducer.h
@@ -6,8 +6,7 @@
   [authors]: R. Remington, The University of Florida
   [description]: EDProducer which runs HcalHaloAlgo and stores HcalHaloData object to the event. 
   [date]: October 15, 2009
-*/  
-
+*/
 
 //Standard C++ classes
 #include <iostream>
@@ -82,18 +81,15 @@
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 
-namespace reco
-{
+namespace reco {
   class HcalHaloDataProducer : public edm::stream::EDProducer<> {
-    
   public:
     explicit HcalHaloDataProducer(const edm::ParameterSet&);
     ~HcalHaloDataProducer() override;
-    
+
   private:
-    
     void produce(edm::Event&, const edm::EventSetup&) override;
-    
+
     //RecHit Level
     edm::InputTag IT_HBHERecHit;
     edm::InputTag IT_HORecHit;
@@ -113,7 +109,6 @@ namespace reco
     float SumHcalEnergyThreshold;
     int NHitsHcalThreshold;
   };
-}
+}  // namespace reco
 
 #endif
-  

--- a/RecoMET/METProducers/interface/HcalNoiseInfoProducer.h
+++ b/RecoMET/METProducers/interface/HcalNoiseInfoProducer.h
@@ -44,24 +44,23 @@ namespace reco {
   //
   // class declaration
   //
-  
+
   class HcalNoiseInfoProducer : public edm::stream::EDProducer<> {
   public:
     explicit HcalNoiseInfoProducer(const edm::ParameterSet&);
     ~HcalNoiseInfoProducer() override;
 
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-    
+
   private:
-    
     //
     // methods inherited from EDProducer
     // produce(...) fills an HcalNoiseRBXArray with information from various places, and then
     // picks which rbxs are interesting, storing them to the EDM.
     //
-    
+
     void produce(edm::Event&, const edm::EventSetup&) override;
-    
+
     //
     // more internal methods
     // fills an HcalNoiseRBXArray with various data
@@ -76,34 +75,33 @@ namespace reco {
     // other helper functions
     void fillOtherSummaryVariables(HcalNoiseSummary& summary, const CommonHcalNoiseRBXData& data) const;
 
-    
     //
     // parameters
     //
-    
-    bool fillDigis_;        // fill digi information into HcalNoiseRBXs
-    bool fillRecHits_;      // fill rechit information into HcalNoiseRBXs and HcalNoiseSummary
-    bool fillCaloTowers_;   // fill calotower information into HcalNoiseRBXs and HcalNoiseSummary
-    bool fillTracks_;       // fill track information into HcalNoiseSummary
-    bool fillLaserMonitor_; // fill laser monitor information into HcalNoiseSummary
+
+    bool fillDigis_;         // fill digi information into HcalNoiseRBXs
+    bool fillRecHits_;       // fill rechit information into HcalNoiseRBXs and HcalNoiseSummary
+    bool fillCaloTowers_;    // fill calotower information into HcalNoiseRBXs and HcalNoiseSummary
+    bool fillTracks_;        // fill track information into HcalNoiseSummary
+    bool fillLaserMonitor_;  // fill laser monitor information into HcalNoiseSummary
 
     // These provide the requirements for writing an RBX to the event
-    int maxProblemRBXs_;   // maximum number of problematic RBXs to be written to the event record
+    int maxProblemRBXs_;  // maximum number of problematic RBXs to be written to the event record
 
     // parameters for calculating summary variables
-    int maxCaloTowerIEta_;      // maximum caloTower ieta
-    double maxTrackEta_;        // maximum eta of the track
-    double minTrackPt_;         // minimum track Pt
+    int maxCaloTowerIEta_;  // maximum caloTower ieta
+    double maxTrackEta_;    // maximum eta of the track
+    double minTrackPt_;     // minimum track Pt
     double maxNHF_;
     int maxjetindex_;
 
-    const HcalTopology* theHcalTopology_;    
+    const HcalTopology* theHcalTopology_;
 
-    std::string digiCollName_;         // name of the digi collection
-    std::string recHitCollName_;       // name of the rechit collection
-    std::string caloTowerCollName_;    // name of the caloTower collection
-    std::string trackCollName_;        // name of the track collection
-    std::string jetCollName_;          // name of the jet collection
+    std::string digiCollName_;       // name of the digi collection
+    std::string recHitCollName_;     // name of the rechit collection
+    std::string caloTowerCollName_;  // name of the caloTower collection
+    std::string trackCollName_;      // name of the track collection
+    std::string jetCollName_;        // name of the jet collection
 
     edm::EDGetTokenT<HBHEDigiCollection> hbhedigi_token_;
     edm::EDGetTokenT<HcalCalibDigiCollection> hcalcalibdigi_token_;
@@ -113,21 +111,20 @@ namespace reco {
     edm::EDGetTokenT<reco::TrackCollection> track_token_;
     edm::EDGetTokenT<reco::PFJetCollection> jet_token_;
 
-    double totalCalibCharge;    // placeholder to calculate total charge in calibration channels
-    double totalLasmonCharge;    // placeholder to calculate total charge in laser monitor channels
+    double totalCalibCharge;   // placeholder to calculate total charge in calibration channels
+    double totalLasmonCharge;  // placeholder to calculate total charge in laser monitor channels
 
-    double minRecHitE_, minLowHitE_, minHighHitE_, minR45HitE_; // parameters used to determine noise status
-    HcalNoiseAlgo algo_; // algorithms to determine if an RBX is noisy
+    double minRecHitE_, minLowHitE_, minHighHitE_, minR45HitE_;  // parameters used to determine noise status
+    HcalNoiseAlgo algo_;                                         // algorithms to determine if an RBX is noisy
 
     bool useCalibDigi_;
 
     // Variables to store info regarding HBHE calibration digis
-    double calibdigiHBHEthreshold_;  // minimum charge calib digi in order to be counted by noise algorithm
-    std::vector<int> calibdigiHBHEtimeslices_; // time slices to use when computing calibration charge
+    double calibdigiHBHEthreshold_;             // minimum charge calib digi in order to be counted by noise algorithm
+    std::vector<int> calibdigiHBHEtimeslices_;  // time slices to use when computing calibration charge
     // Variables to store info regarding HF calibration digis
     double calibdigiHFthreshold_;
     std::vector<int> calibdigiHFtimeslices_;
-
 
     double TS4TS5EnergyThreshold_;
     std::vector<std::pair<double, double> > TS4TS5UpperCut_;
@@ -143,11 +140,11 @@ namespace reco {
     int laserMonitorTSStart_;
     int laserMonitorTSEnd_;
     unsigned laserMonitorSamples_;
-    
+
     std::vector<float> adc2fC;
     std::vector<float> adc2fCHF;
   };
-  
-} // end of namespace
+
+}  // namespace reco
 
 #endif

--- a/RecoMET/METProducers/interface/METSignificanceProducer.h
+++ b/RecoMET/METProducers/interface/METSignificanceProducer.h
@@ -40,34 +40,29 @@
 
 #include <string>
 
+//____________________________________________________________________________||
+namespace cms {
+  class METSignificanceProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit METSignificanceProducer(const edm::ParameterSet&);
+    ~METSignificanceProducer() override;
+    void produce(edm::Event&, const edm::EventSetup&) override;
+
+  private:
+    // ----------member data ---------------------------
+
+    edm::EDGetTokenT<edm::View<reco::Jet> > pfjetsToken_;
+    edm::EDGetTokenT<edm::View<reco::MET> > metToken_;
+    edm::EDGetTokenT<edm::View<reco::Candidate> > pfCandidatesToken_;
+    std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > > lepTokens_;
+    edm::EDGetTokenT<double> rhoToken_;
+    std::string jetSFType_;
+    std::string jetResPtType_;
+    std::string jetResPhiType_;
+
+    metsig::METSignificance* metSigAlgo_;
+  };
+}  // namespace cms
 
 //____________________________________________________________________________||
-namespace cms
-{
-  class METSignificanceProducer: public edm::stream::EDProducer<>
-    {
-    public:
-      explicit METSignificanceProducer(const edm::ParameterSet&);
-      ~METSignificanceProducer() override;
-      void produce(edm::Event&, const edm::EventSetup&) override;
-
-    private:
-
-      // ----------member data ---------------------------
-
-      edm::EDGetTokenT<edm::View<reco::Jet> > pfjetsToken_;
-      edm::EDGetTokenT<edm::View<reco::MET> > metToken_;
-      edm::EDGetTokenT<edm::View<reco::Candidate> > pfCandidatesToken_;
-      std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > > lepTokens_;
-      edm::EDGetTokenT<double> rhoToken_;
-      std::string jetSFType_;
-      std::string jetResPtType_;
-      std::string jetResPhiType_;
- 
-      metsig::METSignificance* metSigAlgo_;
-
-    };
-}
-
-//____________________________________________________________________________||
-#endif // METSignificanceProducer_h
+#endif  // METSignificanceProducer_h

--- a/RecoMET/METProducers/interface/MinMETProducerT.h
+++ b/RecoMET/METProducers/interface/MinMETProducerT.h
@@ -25,56 +25,50 @@
 #include <vector>
 
 template <typename T>
-class MinMETProducerT : public edm::stream::EDProducer<>
-{
+class MinMETProducerT : public edm::stream::EDProducer<> {
   typedef std::vector<T> METCollection;
 
- public:
-
-  explicit MinMETProducerT(const edm::ParameterSet& cfg)    : moduleLabel_(cfg.getParameter<std::string>("@module_label"))
-  {
+public:
+  explicit MinMETProducerT(const edm::ParameterSet& cfg)
+      : moduleLabel_(cfg.getParameter<std::string>("@module_label")) {
     src_ = cfg.getParameter<vInputTag>("src");
 
-    for ( vInputTag::const_iterator src_i = src_.begin();
-	  src_i != src_.end(); ++src_i ) {
-      src_token_.push_back( consumes<METCollection>(*src_i) );
+    for (vInputTag::const_iterator src_i = src_.begin(); src_i != src_.end(); ++src_i) {
+      src_token_.push_back(consumes<METCollection>(*src_i));
     }
     produces<METCollection>();
   }
   ~MinMETProducerT() override {}
 
- private:
-
-  void produce(edm::Event& evt, const edm::EventSetup& es) override
-  {
+private:
+  void produce(edm::Event& evt, const edm::EventSetup& es) override {
     auto outputMETs = std::make_unique<METCollection>();
 
     // check that all MET collections given as input have the same number of entries
     int numMEtObjects = -1;
     //    for ( vInputTag::const_iterator src_i = src_.begin();
     //  	  src_i != src_.end(); ++src_i ) {
-    for ( typename vInputToken::const_iterator src_i = src_token_.begin();
-	  src_i != src_token_.end(); ++src_i ) {
+    for (typename vInputToken::const_iterator src_i = src_token_.begin(); src_i != src_token_.end(); ++src_i) {
       edm::Handle<METCollection> inputMETs;
       //      evt.getByLabel(*src_i, inputMETs);
       evt.getByToken(*src_i, inputMETs);
-      if ( numMEtObjects == -1 ) numMEtObjects = inputMETs->size();
-      else if ( numMEtObjects != (int)inputMETs->size() )
-	throw cms::Exception("MinMETProducer::produce")
-	  << "Mismatch in number of input MET objects !!\n";
+      if (numMEtObjects == -1)
+        numMEtObjects = inputMETs->size();
+      else if (numMEtObjects != (int)inputMETs->size())
+        throw cms::Exception("MinMETProducer::produce") << "Mismatch in number of input MET objects !!\n";
     }
 
-    for ( int iMEtObject = 0; iMEtObject < numMEtObjects; ++iMEtObject ) {
+    for (int iMEtObject = 0; iMEtObject < numMEtObjects; ++iMEtObject) {
       const T* minMET = nullptr;
       //      for ( vInputTag::const_iterator src_i = src_.begin();
       //	    src_i != src_.end(); ++src_i ) {
-      for ( typename vInputToken::const_iterator src_i = src_token_.begin();
-	    src_i != src_token_.end(); ++src_i ) {
-	edm::Handle<METCollection> inputMETs;
-	//	evt.getByLabel(*src_i, inputMETs);
-	evt.getByToken(*src_i, inputMETs);
-	const T& inputMET = inputMETs->at(iMEtObject);
-	if ( minMET == nullptr || inputMET.pt() < minMET->pt() ) minMET = &inputMET;
+      for (typename vInputToken::const_iterator src_i = src_token_.begin(); src_i != src_token_.end(); ++src_i) {
+        edm::Handle<METCollection> inputMETs;
+        //	evt.getByLabel(*src_i, inputMETs);
+        evt.getByToken(*src_i, inputMETs);
+        const T& inputMET = inputMETs->at(iMEtObject);
+        if (minMET == nullptr || inputMET.pt() < minMET->pt())
+          minMET = &inputMET;
       }
       assert(minMET);
       outputMETs->push_back(T(*minMET));
@@ -94,14 +88,9 @@ class MinMETProducerT : public edm::stream::EDProducer<>
 #include "DataFormats/METReco/interface/CaloMET.h"
 #include "DataFormats/METReco/interface/PFMET.h"
 
-namespace reco
-{
+namespace reco {
   typedef MinMETProducerT<reco::CaloMET> MinCaloMETProducer;
   typedef MinMETProducerT<reco::PFMET> MinPFMETProducer;
-}
+}  // namespace reco
 
 #endif
-
-
-
-

--- a/RecoMET/METProducers/interface/MuonMET.h
+++ b/RecoMET/METProducers/interface/MuonMET.h
@@ -2,7 +2,7 @@
 //
 // Package:    METProducers
 // Class:      MuonMET
-// 
+//
 
 //____________________________________________________________________________||
 #ifndef RecoMET_MuonMET_h
@@ -20,17 +20,14 @@
 
 #include "RecoMET/METAlgorithms/interface/MuonMETAlgo.h"
 
-
 //____________________________________________________________________________||
-namespace cms 
-{
-  class MuonMET : public edm::stream::EDProducer<> 
-  {
+namespace cms {
+  class MuonMET : public edm::stream::EDProducer<> {
   public:
-    explicit MuonMET( const edm::ParameterSet& );
+    explicit MuonMET(const edm::ParameterSet&);
     explicit MuonMET();
-    ~MuonMET() override { }
-    void produce( edm::Event&, const edm::EventSetup& ) override;
+    ~MuonMET() override {}
+    void produce(edm::Event&, const edm::EventSetup&) override;
 
   private:
     MuonMETAlgo alg_;
@@ -40,9 +37,8 @@ namespace cms
     edm::EDGetTokenT<edm::ValueMap<reco::MuonMETCorrectionData> > inputValueMapMuonMetCorrToken_;
     edm::EDGetTokenT<edm::View<reco::CaloMET> > inputCaloMETToken_;
     edm::EDGetTokenT<edm::View<reco::MET> > inputMETToken_;
-    
   };
-}
+}  // namespace cms
 
 //____________________________________________________________________________||
-#endif // RecoMET_MuonMET_h
+#endif  // RecoMET_MuonMET_h

--- a/RecoMET/METProducers/interface/MuonMETValueMapProducer.h
+++ b/RecoMET/METProducers/interface/MuonMETValueMapProducer.h
@@ -31,47 +31,48 @@
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/MuonReco/interface/MuonMETCorrectionData.h"
 
-
 //____________________________________________________________________________||
-namespace cms
-{
+namespace cms {
 
-class MuonMETValueMapProducer : public edm::stream::EDProducer<>
-{
-public:
-  explicit MuonMETValueMapProducer(const edm::ParameterSet&);
-  ~MuonMETValueMapProducer() override { }
+  class MuonMETValueMapProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit MuonMETValueMapProducer(const edm::ParameterSet&);
+    ~MuonMETValueMapProducer() override {}
 
-private:
-  void produce(edm::Event&, const edm::EventSetup&) override;
+  private:
+    void produce(edm::Event&, const edm::EventSetup&) override;
 
-  void determine_deltax_deltay(double& deltax, double& deltay, const reco::Muon& muon, double bfield, edm::Event& iEvent, const edm::EventSetup& iSetup);
-  reco::MuonMETCorrectionData::Type decide_correction_type(const reco::Muon& muon, const math::XYZPoint &beamSpotPosition);
-  bool should_type_MuonCandidateValuesUsed(const reco::Muon& muon, const math::XYZPoint &beamSpotPosition);
-      
-  double minPt_;
-  double maxEta_;
-  bool isAlsoTkMu_;
-  double maxNormChi2_;
-  double maxd0_;
-  int minnHits_;
-  int minnValidStaHits_;
+    void determine_deltax_deltay(double& deltax,
+                                 double& deltay,
+                                 const reco::Muon& muon,
+                                 double bfield,
+                                 edm::Event& iEvent,
+                                 const edm::EventSetup& iSetup);
+    reco::MuonMETCorrectionData::Type decide_correction_type(const reco::Muon& muon,
+                                                             const math::XYZPoint& beamSpotPosition);
+    bool should_type_MuonCandidateValuesUsed(const reco::Muon& muon, const math::XYZPoint& beamSpotPosition);
 
-  bool useTrackAssociatorPositions_;
-  bool useHO_;
-  double towerEtThreshold_;
-  bool useRecHits_;
+    double minPt_;
+    double maxEta_;
+    bool isAlsoTkMu_;
+    double maxNormChi2_;
+    double maxd0_;
+    int minnHits_;
+    int minnValidStaHits_;
 
-  edm::EDGetTokenT<edm::View<reco::Muon> > muonToken_;
-  edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+    bool useTrackAssociatorPositions_;
+    bool useHO_;
+    double towerEtThreshold_;
+    bool useRecHits_;
 
-  TrackAssociatorParameters trackAssociatorParameters_;
-  TrackDetectorAssociator trackAssociator_;
-};
+    edm::EDGetTokenT<edm::View<reco::Muon> > muonToken_;
+    edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
 
-}
+    TrackAssociatorParameters trackAssociatorParameters_;
+    TrackDetectorAssociator trackAssociator_;
+  };
+
+}  // namespace cms
 
 //____________________________________________________________________________||
 #endif /* RecoMET_MuonMETValueMapProducer_h */
-
-

--- a/RecoMET/METProducers/interface/MuonTCMETValueMapProducer.h
+++ b/RecoMET/METProducers/interface/MuonTCMETValueMapProducer.h
@@ -35,86 +35,80 @@
 //____________________________________________________________________________||
 class TCMETAlgo;
 
-namespace cms
-{
+namespace cms {
 
-class MuonTCMETValueMapProducer : public edm::stream::EDProducer<>
-{
+  class MuonTCMETValueMapProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit MuonTCMETValueMapProducer(const edm::ParameterSet&);
+    ~MuonTCMETValueMapProducer() override;
 
-public:
-  explicit MuonTCMETValueMapProducer(const edm::ParameterSet&);
-  ~MuonTCMETValueMapProducer() override;
+  private:
+    void produce(edm::Event&, const edm::EventSetup&) override;
 
+    edm::Handle<reco::MuonCollection> muons_;
+    edm::Handle<reco::BeamSpot> beamSpot_;
+    edm::Handle<reco::VertexCollection> vertexHandle_;
 
-private:
-  void produce(edm::Event&, const edm::EventSetup&) override;
-      
-  edm::Handle<reco::MuonCollection>    muons_;
-  edm::Handle<reco::BeamSpot>          beamSpot_;
-  edm::Handle<reco::VertexCollection>  vertexHandle_;
+    edm::EDGetTokenT<reco::MuonCollection> muonToken_;
+    edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+    edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
 
-  edm::EDGetTokenT<reco::MuonCollection> muonToken_;
-  edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
-  edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
+    const class MagneticField* bField;
 
-  const class MagneticField* bField;
+    const reco::VertexCollection* vertices_;
 
-  const reco::VertexCollection *vertices_;
+    class TH2D* response_function;
 
-  class TH2D* response_function;
+    bool muonGlobal_;
+    bool muonTracker_;
+    bool useCaloMuons_;
+    bool hasValidVertex;
 
-  bool muonGlobal_;
-  bool muonTracker_;
-  bool useCaloMuons_;
-  bool hasValidVertex;
+    int rfType_;
+    int nLayers_;
+    int nLayersTight_;
+    int vertexNdof_;
+    double vertexZ_;
+    double vertexRho_;
+    double vertexMaxDZ_;
+    double maxpt_eta25_;
+    double maxpt_eta20_;
+    std::vector<reco::TrackBase::TrackAlgorithm> trackAlgos_;
+    double minpt_;
+    double maxpt_;
+    double maxeta_;
+    double maxchi2_;
+    double minhits_;
+    double maxPtErr_;
+    double maxd0cut_;
+    double maxchi2_tight_;
+    double minhits_tight_;
+    double maxPtErr_tight_;
+    double d0cuta_;
+    double d0cutb_;
+    bool usePvtxd0_;
+    std::vector<int> trkQuality_;
+    std::vector<reco::TrackBase::TrackAlgorithm> trkAlgos_;
 
-  int     rfType_;
-  int     nLayers_;
-  int     nLayersTight_;
-  int     vertexNdof_;
-  double  vertexZ_;
-  double  vertexRho_;
-  double  vertexMaxDZ_;
-  double  maxpt_eta25_;
-  double  maxpt_eta20_;
-  std::vector<reco::TrackBase::TrackAlgorithm> trackAlgos_;
-  double  minpt_;
-  double  maxpt_;
-  double  maxeta_;
-  double  maxchi2_;
-  double  minhits_;
-  double  maxPtErr_;
-  double  maxd0cut_;
-  double  maxchi2_tight_;
-  double  minhits_tight_;
-  double  maxPtErr_tight_;
-  double  d0cuta_;
-  double  d0cutb_;
-  bool    usePvtxd0_;
-  std::vector<int> trkQuality_;
-  std::vector<reco::TrackBase::TrackAlgorithm> trkAlgos_;
+    int muonMinValidStaHits_;
+    double muonpt_;
+    double muoneta_;
+    double muonchi2_;
+    double muonhits_;
+    double muond0_;
+    double muonDeltaR_;
+    double muon_dptrel_;
+    TCMETAlgo* tcmetAlgo_;
 
-  int     muonMinValidStaHits_;
-  double  muonpt_;
-  double  muoneta_;
-  double  muonchi2_;
-  double  muonhits_;
-  double  muond0_;
-  double  muonDeltaR_;
-  double  muon_dptrel_;
-  TCMETAlgo *tcmetAlgo_;
+    bool isGoodMuon(const reco::Muon*);
+    bool isGoodCaloMuon(const reco::Muon*, const unsigned int);
+    bool isGoodTrack(const reco::Muon*);
+    class TVector3 propagateTrack(const reco::Muon*);
+    int nLayers(const reco::TrackRef);
+    bool isValidVertex();
+  };
 
-  bool isGoodMuon( const reco::Muon* );
-  bool isGoodCaloMuon( const reco::Muon*, const unsigned int );
-  bool isGoodTrack( const reco::Muon* );
-  class TVector3 propagateTrack( const reco::Muon* );
-  int nLayers(const reco::TrackRef);
-  bool isValidVertex();
-};
-
-}
+}  // namespace cms
 
 //____________________________________________________________________________||
 #endif /* RecoMET_MuonTCMETValueMapProducer_h */
-
-

--- a/RecoMET/METProducers/interface/PFClusterMETProducer.h
+++ b/RecoMET/METProducers/interface/PFClusterMETProducer.h
@@ -28,25 +28,20 @@
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
+//____________________________________________________________________________||
+namespace cms {
+  class PFClusterMETProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit PFClusterMETProducer(const edm::ParameterSet&);
+    ~PFClusterMETProducer() override {}
+    void produce(edm::Event&, const edm::EventSetup&) override;
+
+  private:
+    edm::EDGetTokenT<edm::View<reco::Candidate> > inputToken_;
+
+    double globalThreshold_;
+  };
+}  // namespace cms
 
 //____________________________________________________________________________||
-namespace cms
-{
-  class PFClusterMETProducer: public edm::stream::EDProducer<>
-    {
-    public:
-      explicit PFClusterMETProducer(const edm::ParameterSet&);
-      ~PFClusterMETProducer() override { }
-      void produce(edm::Event&, const edm::EventSetup&) override;
-
-    private:
-
-      edm::EDGetTokenT<edm::View<reco::Candidate> > inputToken_;
-
-      double globalThreshold_;
-
-    };
-}
-
-//____________________________________________________________________________||
-#endif // PFClusterMETProducer_h
+#endif  // PFClusterMETProducer_h

--- a/RecoMET/METProducers/interface/PFMETProducer.h
+++ b/RecoMET/METProducers/interface/PFMETProducer.h
@@ -47,45 +47,40 @@
 
 #include <string>
 
-
 //____________________________________________________________________________||
-namespace metsig
-{
-    class SignAlgoResolutions;
+namespace metsig {
+  class SignAlgoResolutions;
 }
 
 //____________________________________________________________________________||
-namespace cms
-{
-  class PFMETProducer: public edm::stream::EDProducer<>
-    {
-    public:
-      explicit PFMETProducer(const edm::ParameterSet&);
-      ~PFMETProducer() override { }
-      void produce(edm::Event&, const edm::EventSetup&) override;
+namespace cms {
+  class PFMETProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit PFMETProducer(const edm::ParameterSet&);
+    ~PFMETProducer() override {}
+    void produce(edm::Event&, const edm::EventSetup&) override;
 
-    private:
+  private:
+    reco::METCovMatrix getMETCovMatrix(const edm::Event& event,
+                                       const edm::EventSetup&,
+                                       const edm::Handle<edm::View<reco::Candidate> >& input) const;
 
-      reco::METCovMatrix getMETCovMatrix(const edm::Event& event, const edm::EventSetup&, 
-					 const edm::Handle<edm::View<reco::Candidate> >& input) const;
+    edm::EDGetTokenT<edm::View<reco::Candidate> > inputToken_;
 
+    bool calculateSignificance_;
+    metsig::METSignificance* metSigAlgo_;
 
-      edm::EDGetTokenT<edm::View<reco::Candidate> > inputToken_;
+    double globalThreshold_;
+    double jetThreshold_;
 
-      bool calculateSignificance_;
-      metsig::METSignificance* metSigAlgo_;
-
-      double globalThreshold_;
-      double jetThreshold_;
-
-      edm::EDGetTokenT<edm::View<reco::Jet> > jetToken_;
-      std::vector< edm::EDGetTokenT<edm::View<reco::Candidate> > > lepTokens_;
-      std::string jetSFType_;
-      std::string jetResPtType_;
-      std::string jetResPhiType_;
-      edm::EDGetTokenT<double> rhoToken_;
+    edm::EDGetTokenT<edm::View<reco::Jet> > jetToken_;
+    std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > > lepTokens_;
+    std::string jetSFType_;
+    std::string jetResPtType_;
+    std::string jetResPhiType_;
+    edm::EDGetTokenT<double> rhoToken_;
   };
-}
+}  // namespace cms
 
 //____________________________________________________________________________||
-#endif // PFMETProducer_h
+#endif  // PFMETProducer_h

--- a/RecoMET/METProducers/interface/ParticleFlowForChargedMETProducer.h
+++ b/RecoMET/METProducers/interface/ParticleFlowForChargedMETProducer.h
@@ -4,7 +4,7 @@
 /*
   Producer of collection of charged PF candidates beloning to the main PV
   Author: Marco Zanetti, MIT
-*/  
+*/
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
@@ -15,18 +15,15 @@
 #include <DataFormats/VertexReco/interface/VertexFwd.h>
 #include <DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h>
 
-namespace reco
-{
+namespace reco {
   class ParticleFlowForChargedMETProducer : public edm::stream::EDProducer<> {
-    
   public:
     explicit ParticleFlowForChargedMETProducer(const edm::ParameterSet&);
     ~ParticleFlowForChargedMETProducer() override;
-    
+
   private:
-    
     void produce(edm::Event&, const edm::EventSetup&) override;
-    
+
     edm::InputTag pfCollectionLabel;
     edm::InputTag pvCollectionLabel;
 
@@ -36,7 +33,6 @@ namespace reco
     double dzCut;
     double neutralEtThreshold;
   };
-}
+}  // namespace reco
 
 #endif
-  

--- a/RecoMET/METProducers/interface/TCMETProducer.h
+++ b/RecoMET/METProducers/interface/TCMETProducer.h
@@ -30,21 +30,17 @@
 #include "RecoMET/METAlgorithms/interface/TCMETAlgo.h"
 
 //____________________________________________________________________________||
-namespace cms
-{
-  class TCMETProducer: public edm::stream::EDProducer<>
-    {
-    public:
-      explicit TCMETProducer(const edm::ParameterSet&);
-      ~TCMETProducer() override { }
-      void produce(edm::Event&, const edm::EventSetup&) override;
+namespace cms {
+  class TCMETProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit TCMETProducer(const edm::ParameterSet&);
+    ~TCMETProducer() override {}
+    void produce(edm::Event&, const edm::EventSetup&) override;
 
-    private:
-
-      TCMETAlgo tcMetAlgo_;
-
-    };
-}
+  private:
+    TCMETAlgo tcMetAlgo_;
+  };
+}  // namespace cms
 
 //____________________________________________________________________________||
-#endif // TCMETProducer_h
+#endif  // TCMETProducer_h

--- a/RecoMET/METProducers/src/BeamHaloSummaryProducer.cc
+++ b/RecoMET/METProducers/src/BeamHaloSummaryProducer.cc
@@ -12,21 +12,20 @@ using namespace edm;
 using namespace std;
 using namespace reco;
 
-BeamHaloSummaryProducer::BeamHaloSummaryProducer(const edm::ParameterSet& iConfig)
-{
+BeamHaloSummaryProducer::BeamHaloSummaryProducer(const edm::ParameterSet& iConfig) {
   IT_CSCHaloData = iConfig.getParameter<edm::InputTag>("CSCHaloDataLabel");
   IT_EcalHaloData = iConfig.getParameter<edm::InputTag>("EcalHaloDataLabel");
   IT_HcalHaloData = iConfig.getParameter<edm::InputTag>("HcalHaloDataLabel");
   IT_GlobalHaloData = iConfig.getParameter<edm::InputTag>("GlobalHaloDataLabel");
-  
-  L_EcalPhiWedgeEnergy = (float) iConfig.getParameter<double>("l_EcalPhiWedgeEnergy");
+
+  L_EcalPhiWedgeEnergy = (float)iConfig.getParameter<double>("l_EcalPhiWedgeEnergy");
   L_EcalPhiWedgeConstituents = iConfig.getParameter<int>("l_EcalPhiWedgeConstituents");
   L_EcalPhiWedgeToF = (float)iConfig.getParameter<double>("l_EcalPhiWedgeToF");
   L_EcalPhiWedgeConfidence = (float)iConfig.getParameter<double>("l_EcalPhiWedgeConfidence");
   L_EcalShowerShapesRoundness = (float)iConfig.getParameter<double>("l_EcalShowerShapesRoundness");
-  L_EcalShowerShapesAngle =(float) iConfig.getParameter<double>("l_EcalShowerShapesAngle");  
-  L_EcalSuperClusterSize = (int) iConfig.getParameter<int>("l_EcalSuperClusterSize");
-  L_EcalSuperClusterEnergy = (float) iConfig.getParameter<double>("l_EcalSuperClusterEnergy");
+  L_EcalShowerShapesAngle = (float)iConfig.getParameter<double>("l_EcalShowerShapesAngle");
+  L_EcalSuperClusterSize = (int)iConfig.getParameter<int>("l_EcalSuperClusterSize");
+  L_EcalSuperClusterEnergy = (float)iConfig.getParameter<double>("l_EcalSuperClusterEnergy");
 
   T_EcalPhiWedgeEnergy = (float)iConfig.getParameter<double>("t_EcalPhiWedgeEnergy");
   T_EcalPhiWedgeConstituents = iConfig.getParameter<int>("t_EcalPhiWedgeConstituents");
@@ -34,14 +33,14 @@ BeamHaloSummaryProducer::BeamHaloSummaryProducer(const edm::ParameterSet& iConfi
   T_EcalPhiWedgeConfidence = (float)iConfig.getParameter<double>("t_EcalPhiWedgeConfidence");
   T_EcalShowerShapesRoundness = (float)iConfig.getParameter<double>("t_EcalShowerShapesRoundness");
   T_EcalShowerShapesAngle = (float)iConfig.getParameter<double>("t_EcalShowerShapesAngle");
-  T_EcalSuperClusterSize = (int) iConfig.getParameter<int>("t_EcalSuperClusterSize");
-  T_EcalSuperClusterEnergy = (float) iConfig.getParameter<double>("t_EcalSuperClusterEnergy");
+  T_EcalSuperClusterSize = (int)iConfig.getParameter<int>("t_EcalSuperClusterSize");
+  T_EcalSuperClusterEnergy = (float)iConfig.getParameter<double>("t_EcalSuperClusterEnergy");
 
   L_HcalPhiWedgeEnergy = (float)iConfig.getParameter<double>("l_HcalPhiWedgeEnergy");
   L_HcalPhiWedgeConstituents = iConfig.getParameter<int>("l_HcalPhiWedgeConstituents");
   L_HcalPhiWedgeToF = (float)iConfig.getParameter<double>("l_HcalPhiWedgeToF");
   L_HcalPhiWedgeConfidence = (float)iConfig.getParameter<double>("l_HcalPhiWedgeConfidence");
-  
+
   T_HcalPhiWedgeEnergy = (float)iConfig.getParameter<double>("t_HcalPhiWedgeEnergy");
   T_HcalPhiWedgeConstituents = iConfig.getParameter<int>("t_HcalPhiWedgeConstituents");
   T_HcalPhiWedgeToF = (float)iConfig.getParameter<double>("t_HcalPhiWedgeToF");
@@ -57,9 +56,8 @@ BeamHaloSummaryProducer::BeamHaloSummaryProducer(const edm::ParameterSet& iConfi
   produces<BeamHaloSummary>();
 }
 
-void BeamHaloSummaryProducer::produce(Event& iEvent, const EventSetup& iSetup)
-{
-  // BeamHaloSummary object 
+void BeamHaloSummaryProducer::produce(Event& iEvent, const EventSetup& iSetup) {
+  // BeamHaloSummary object
   auto TheBeamHaloSummary = std::make_unique<BeamHaloSummary>();
 
   // CSC Specific Halo Data
@@ -67,60 +65,53 @@ void BeamHaloSummaryProducer::produce(Event& iEvent, const EventSetup& iSetup)
   //  iEvent.getByLabel(IT_CSCHaloData, TheCSCHaloData);
   iEvent.getByToken(cschalodata_token_, TheCSCHaloData);
 
-  const CSCHaloData CSCData = (*TheCSCHaloData.product() );
+  const CSCHaloData CSCData = (*TheCSCHaloData.product());
 
-  //CSCLoose Id for 2011 
-  if( CSCData.NumberOfHaloTriggers() ||
-      CSCData.NumberOfHaloTracks()   ||
-      (CSCData.NOutOfTimeHits() > 10 && CSCData.NFlatHaloSegments() > 2 ) ||
-      CSCData.GetSegmentsInBothEndcaps() ||
-      CSCData.NTracksSmalldT() )
+  //CSCLoose Id for 2011
+  if (CSCData.NumberOfHaloTriggers() || CSCData.NumberOfHaloTracks() ||
+      (CSCData.NOutOfTimeHits() > 10 && CSCData.NFlatHaloSegments() > 2) || CSCData.GetSegmentsInBothEndcaps() ||
+      CSCData.NTracksSmalldT())
     TheBeamHaloSummary->GetCSCHaloReport()[0] = 1;
 
   //CSCTight Id for 2011
-  if( (CSCData.NumberOfHaloTriggers() && CSCData.NumberOfHaloTracks()) ||
-      (CSCData.NOutOfTimeHits() > 10 && CSCData.NumberOfHaloTriggers() ) ||
-      (CSCData.NOutOfTimeHits() > 10 && CSCData.NumberOfHaloTracks() ) ||
-      CSCData.GetSegmentsInBothEndcaps() ||
-      (CSCData.NTracksSmalldT() && CSCData.NumberOfHaloTracks() ) ||
-      (CSCData.NFlatHaloSegments() > 3 && (CSCData.NumberOfHaloTriggers() || CSCData.NumberOfHaloTracks()) ))
+  if ((CSCData.NumberOfHaloTriggers() && CSCData.NumberOfHaloTracks()) ||
+      (CSCData.NOutOfTimeHits() > 10 && CSCData.NumberOfHaloTriggers()) ||
+      (CSCData.NOutOfTimeHits() > 10 && CSCData.NumberOfHaloTracks()) || CSCData.GetSegmentsInBothEndcaps() ||
+      (CSCData.NTracksSmalldT() && CSCData.NumberOfHaloTracks()) ||
+      (CSCData.NFlatHaloSegments() > 3 && (CSCData.NumberOfHaloTriggers() || CSCData.NumberOfHaloTracks())))
     TheBeamHaloSummary->GetCSCHaloReport()[1] = 1;
 
   //CSCLoose Id from 2010
-  if( CSCData.NumberOfHaloTriggers() || CSCData.NumberOfHaloTracks() || CSCData.NumberOfOutOfTimeTriggers() )
+  if (CSCData.NumberOfHaloTriggers() || CSCData.NumberOfHaloTracks() || CSCData.NumberOfOutOfTimeTriggers())
     TheBeamHaloSummary->GetCSCHaloReport()[2] = 1;
 
   //CSCTight Id from 2010
-  if( (CSCData.NumberOfHaloTriggers() && CSCData.NumberOfHaloTracks()) ||
+  if ((CSCData.NumberOfHaloTriggers() && CSCData.NumberOfHaloTracks()) ||
       (CSCData.NumberOfHaloTriggers() && CSCData.NumberOfOutOfTimeTriggers()) ||
-      (CSCData.NumberOfHaloTracks() && CSCData.NumberOfOutOfTimeTriggers() ) )
+      (CSCData.NumberOfHaloTracks() && CSCData.NumberOfOutOfTimeTriggers()))
     TheBeamHaloSummary->GetCSCHaloReport()[3] = 1;
 
   //CSCTight Id for 2015
-  if( (CSCData.NumberOfHaloTriggers_TrkMuUnVeto() && CSCData.NumberOfHaloTracks()) ||
-      (CSCData.NOutOfTimeHits() > 10 && CSCData.NumberOfHaloTriggers_TrkMuUnVeto() ) ||
-      (CSCData.NOutOfTimeHits() > 10 && CSCData.NumberOfHaloTracks() ) ||
+  if ((CSCData.NumberOfHaloTriggers_TrkMuUnVeto() && CSCData.NumberOfHaloTracks()) ||
+      (CSCData.NOutOfTimeHits() > 10 && CSCData.NumberOfHaloTriggers_TrkMuUnVeto()) ||
+      (CSCData.NOutOfTimeHits() > 10 && CSCData.NumberOfHaloTracks()) ||
       CSCData.GetSegmentsInBothEndcaps_Loose_TrkMuUnVeto() ||
-      (CSCData.NTracksSmalldT() && CSCData.NumberOfHaloTracks() ) ||
-      (CSCData.NFlatHaloSegments() > 3 && (CSCData.NumberOfHaloTriggers_TrkMuUnVeto() || CSCData.NumberOfHaloTracks()) ))
+      (CSCData.NTracksSmalldT() && CSCData.NumberOfHaloTracks()) ||
+      (CSCData.NFlatHaloSegments() > 3 && (CSCData.NumberOfHaloTriggers_TrkMuUnVeto() || CSCData.NumberOfHaloTracks())))
     TheBeamHaloSummary->GetCSCHaloReport()[4] = 1;
 
   //Update
-  if(  (CSCData.NumberOfHaloTriggers_TrkMuUnVeto() && CSCData.NFlatHaloSegments_TrkMuUnVeto() ) ||
-       CSCData.GetSegmentsInBothEndcaps_Loose_dTcut_TrkMuUnVeto() ||
-       CSCData.GetSegmentIsCaloMatched()
-       )
+  if ((CSCData.NumberOfHaloTriggers_TrkMuUnVeto() && CSCData.NFlatHaloSegments_TrkMuUnVeto()) ||
+      CSCData.GetSegmentsInBothEndcaps_Loose_dTcut_TrkMuUnVeto() || CSCData.GetSegmentIsCaloMatched())
     TheBeamHaloSummary->GetCSCHaloReport()[5] = 1;
-  
-
 
   //Ecal Specific Halo Data
   Handle<EcalHaloData> TheEcalHaloData;
   //  iEvent.getByLabel(IT_EcalHaloData, TheEcalHaloData);
   iEvent.getByToken(ecalhalodata_token_, TheEcalHaloData);
 
-  const EcalHaloData EcalData = (*TheEcalHaloData.product() );
-  
+  const EcalHaloData EcalData = (*TheEcalHaloData.product());
+
   bool EcalLooseId = false, EcalTightId = false;
   /*  COMMENTED OUT, NEEDS TO BE TUNED 
       const std::vector<PhiWedge> EcalWedges = EcalData.GetPhiWedges();
@@ -158,33 +149,32 @@ void BeamHaloSummaryProducer::produce(Event& iEvent, const EventSetup& iSetup)
 
   edm::ValueMap<float> vm_Angle = EcalData.GetShowerShapesAngle();
   edm::ValueMap<float> vm_Roundness = EcalData.GetShowerShapesRoundness();
-  
-  //Access selected SuperClusters
-  for(unsigned int n = 0 ; n < EcalData.GetSuperClusters().size() ; n++ )
-    {
-      edm::Ref<SuperClusterCollection> cluster(EcalData.GetSuperClusters()[n] );
-      
-      float angle = vm_Angle[cluster];
-      float roundness = vm_Roundness[cluster];
-      
-      //Loose Selection
-      if(  (angle > 0. && angle < L_EcalShowerShapesAngle ) && ( roundness > 0. && roundness < L_EcalShowerShapesRoundness ) )
-        {
-          if( cluster->energy() > L_EcalSuperClusterEnergy && cluster->size() > (unsigned int) L_EcalSuperClusterSize )
-            EcalLooseId = true;
-        }
 
-      //Tight Selection 
-      if(  (angle > 0. && angle < T_EcalShowerShapesAngle ) && ( roundness > 0. && roundness < T_EcalShowerShapesRoundness ) )
-        {
-          if( cluster->energy() > T_EcalSuperClusterEnergy && cluster->size() > (unsigned int)T_EcalSuperClusterSize )
-            EcalTightId = true;
-        }
+  //Access selected SuperClusters
+  for (unsigned int n = 0; n < EcalData.GetSuperClusters().size(); n++) {
+    edm::Ref<SuperClusterCollection> cluster(EcalData.GetSuperClusters()[n]);
+
+    float angle = vm_Angle[cluster];
+    float roundness = vm_Roundness[cluster];
+
+    //Loose Selection
+    if ((angle > 0. && angle < L_EcalShowerShapesAngle) &&
+        (roundness > 0. && roundness < L_EcalShowerShapesRoundness)) {
+      if (cluster->energy() > L_EcalSuperClusterEnergy && cluster->size() > (unsigned int)L_EcalSuperClusterSize)
+        EcalLooseId = true;
     }
-  
-  if( EcalLooseId ) 
+
+    //Tight Selection
+    if ((angle > 0. && angle < T_EcalShowerShapesAngle) &&
+        (roundness > 0. && roundness < T_EcalShowerShapesRoundness)) {
+      if (cluster->energy() > T_EcalSuperClusterEnergy && cluster->size() > (unsigned int)T_EcalSuperClusterSize)
+        EcalTightId = true;
+    }
+  }
+
+  if (EcalLooseId)
     TheBeamHaloSummary->GetEcalHaloReport()[0] = 1;
-  if( EcalTightId ) 
+  if (EcalTightId)
     TheBeamHaloSummary->GetEcalHaloReport()[1] = 1;
 
   // Hcal Specific Halo Data
@@ -192,51 +182,47 @@ void BeamHaloSummaryProducer::produce(Event& iEvent, const EventSetup& iSetup)
   //  iEvent.getByLabel(IT_HcalHaloData, TheHcalHaloData);
   iEvent.getByToken(hcalhalodata_token_, TheHcalHaloData);
 
-  const HcalHaloData HcalData = (*TheHcalHaloData.product() );
+  const HcalHaloData HcalData = (*TheHcalHaloData.product());
   const std::vector<PhiWedge>& HcalWedges = HcalData.GetPhiWedges();
   bool HcalLooseId = false, HcalTightId = false;
-  for( std::vector<PhiWedge>::const_iterator iWedge = HcalWedges.begin() ; iWedge != HcalWedges.end() ; iWedge++ )
-    {
-      bool HcaliPhi = false;
-      //Loose Id
-      if( iWedge-> Energy() > L_HcalPhiWedgeEnergy  && iWedge->NumberOfConstituents() > L_HcalPhiWedgeConstituents && std::abs(iWedge->ZDirectionConfidence()) > L_HcalPhiWedgeConfidence)
-        {
-          HcalLooseId = true;
-          HcaliPhi = true;
-        }
-
-      //Tight Id
-      if( iWedge-> Energy() > T_HcalPhiWedgeEnergy  && iWedge->NumberOfConstituents() > T_HcalPhiWedgeConstituents && std::abs(iWedge->ZDirectionConfidence()) > T_HcalPhiWedgeConfidence)
-        {
-          HcalTightId = true;
-          HcaliPhi = true;
-	}
-      
-      for( unsigned int i = 0 ; i < TheBeamHaloSummary->GetHcaliPhiSuspects().size() ; i++ )
-	{
-          if( iWedge->iPhi() == TheBeamHaloSummary->GetHcaliPhiSuspects()[i] )
-            {
-              HcaliPhi = false;  // already stored this iPhi 
-	      continue;
-            }
-	}
-      if( HcaliPhi ) 
-	TheBeamHaloSummary->GetHcaliPhiSuspects().push_back( iWedge->iPhi() ) ;
+  for (std::vector<PhiWedge>::const_iterator iWedge = HcalWedges.begin(); iWedge != HcalWedges.end(); iWedge++) {
+    bool HcaliPhi = false;
+    //Loose Id
+    if (iWedge->Energy() > L_HcalPhiWedgeEnergy && iWedge->NumberOfConstituents() > L_HcalPhiWedgeConstituents &&
+        std::abs(iWedge->ZDirectionConfidence()) > L_HcalPhiWedgeConfidence) {
+      HcalLooseId = true;
+      HcaliPhi = true;
     }
-  
-  if( HcalLooseId ) 
+
+    //Tight Id
+    if (iWedge->Energy() > T_HcalPhiWedgeEnergy && iWedge->NumberOfConstituents() > T_HcalPhiWedgeConstituents &&
+        std::abs(iWedge->ZDirectionConfidence()) > T_HcalPhiWedgeConfidence) {
+      HcalTightId = true;
+      HcaliPhi = true;
+    }
+
+    for (unsigned int i = 0; i < TheBeamHaloSummary->GetHcaliPhiSuspects().size(); i++) {
+      if (iWedge->iPhi() == TheBeamHaloSummary->GetHcaliPhiSuspects()[i]) {
+        HcaliPhi = false;  // already stored this iPhi
+        continue;
+      }
+    }
+    if (HcaliPhi)
+      TheBeamHaloSummary->GetHcaliPhiSuspects().push_back(iWedge->iPhi());
+  }
+
+  if (HcalLooseId)
     TheBeamHaloSummary->GetHcalHaloReport()[0] = 1;
-  if( HcalTightId ) 
+  if (HcalTightId)
     TheBeamHaloSummary->GetHcalHaloReport()[1] = 1;
 
-
-  for( unsigned int i = 0 ; i < HcalData.getProblematicStrips().size() ; i++ ) {
+  for (unsigned int i = 0; i < HcalData.getProblematicStrips().size(); i++) {
     auto const& problematicStrip = HcalData.getProblematicStrips()[i];
-    if(problematicStrip.cellTowerIds.size() < (unsigned int)problematicStripMinLength) continue;
+    if (problematicStrip.cellTowerIds.size() < (unsigned int)problematicStripMinLength)
+      continue;
 
     TheBeamHaloSummary->getProblematicStrips().push_back(problematicStrip);
   }
-
 
   // Global Halo Data
   Handle<GlobalHaloData> TheGlobalHaloData;
@@ -245,56 +231,52 @@ void BeamHaloSummaryProducer::produce(Event& iEvent, const EventSetup& iSetup)
 
   bool GlobalLooseId = false;
   bool GlobalTightId = false;
-  const GlobalHaloData GlobalData = (*TheGlobalHaloData.product() );
+  const GlobalHaloData GlobalData = (*TheGlobalHaloData.product());
   const std::vector<PhiWedge>& MatchedHcalWedges = GlobalData.GetMatchedHcalPhiWedges();
   const std::vector<PhiWedge>& MatchedEcalWedges = GlobalData.GetMatchedEcalPhiWedges();
 
   //Loose Id
-  if( !MatchedEcalWedges.empty() || !MatchedHcalWedges.empty() ) 
+  if (!MatchedEcalWedges.empty() || !MatchedHcalWedges.empty())
     GlobalLooseId = true;
 
   //Tight Id
-  for( std::vector<PhiWedge>::const_iterator iWedge = MatchedEcalWedges.begin() ; iWedge != MatchedEcalWedges.end(); iWedge ++ )
-    {
-      if( iWedge->NumberOfConstituents() > T_EcalPhiWedgeConstituents )
-        GlobalTightId = true;
-      if( std::abs(iWedge->ZDirectionConfidence()) > T_EcalPhiWedgeConfidence )
-	GlobalTightId = true;
-    }
+  for (std::vector<PhiWedge>::const_iterator iWedge = MatchedEcalWedges.begin(); iWedge != MatchedEcalWedges.end();
+       iWedge++) {
+    if (iWedge->NumberOfConstituents() > T_EcalPhiWedgeConstituents)
+      GlobalTightId = true;
+    if (std::abs(iWedge->ZDirectionConfidence()) > T_EcalPhiWedgeConfidence)
+      GlobalTightId = true;
+  }
 
-  for( std::vector<PhiWedge>::const_iterator iWedge = MatchedHcalWedges.begin() ; iWedge != MatchedHcalWedges.end(); iWedge ++ )
-    {
-      if( iWedge->NumberOfConstituents() > T_HcalPhiWedgeConstituents )
-        GlobalTightId = true;
-      if( std::abs(iWedge->ZDirectionConfidence()) > T_HcalPhiWedgeConfidence )
-	GlobalTightId = true;
-    }
+  for (std::vector<PhiWedge>::const_iterator iWedge = MatchedHcalWedges.begin(); iWedge != MatchedHcalWedges.end();
+       iWedge++) {
+    if (iWedge->NumberOfConstituents() > T_HcalPhiWedgeConstituents)
+      GlobalTightId = true;
+    if (std::abs(iWedge->ZDirectionConfidence()) > T_HcalPhiWedgeConfidence)
+      GlobalTightId = true;
+  }
 
-  if( GlobalLooseId ) 
+  if (GlobalLooseId)
     TheBeamHaloSummary->GetGlobalHaloReport()[0] = 1;
-  if( GlobalTightId )
+  if (GlobalTightId)
     TheBeamHaloSummary->GetGlobalHaloReport()[1] = 1;
-  
+
   //GlobalTight Id for 2016
-  if((GlobalData.GetSegmentIsEBCaloMatched() || GlobalData.GetHaloPatternFoundEB() ) ||
-     (GlobalData.GetSegmentIsEECaloMatched() || GlobalData.GetHaloPatternFoundEE() ) ||
-     (GlobalData.GetSegmentIsHBCaloMatched() || GlobalData.GetHaloPatternFoundHB() ) ||
-     (GlobalData.GetSegmentIsHECaloMatched() || GlobalData.GetHaloPatternFoundHE() ) 
-     )
+  if ((GlobalData.GetSegmentIsEBCaloMatched() || GlobalData.GetHaloPatternFoundEB()) ||
+      (GlobalData.GetSegmentIsEECaloMatched() || GlobalData.GetHaloPatternFoundEE()) ||
+      (GlobalData.GetSegmentIsHBCaloMatched() || GlobalData.GetHaloPatternFoundHB()) ||
+      (GlobalData.GetSegmentIsHECaloMatched() || GlobalData.GetHaloPatternFoundHE()))
     TheBeamHaloSummary->GetGlobalHaloReport()[2] = 1;
 
-  //Global SuperTight Id for 2016 
-  if((GlobalData.GetSegmentIsEBCaloMatched() && GlobalData.GetHaloPatternFoundEB() ) ||
-     (GlobalData.GetSegmentIsEECaloMatched() && GlobalData.GetHaloPatternFoundEE() ) ||
-     (GlobalData.GetSegmentIsHBCaloMatched() && GlobalData.GetHaloPatternFoundHB() ) ||
-     (GlobalData.GetSegmentIsHECaloMatched() && GlobalData.GetHaloPatternFoundHE() ) 
-     ) 
+  //Global SuperTight Id for 2016
+  if ((GlobalData.GetSegmentIsEBCaloMatched() && GlobalData.GetHaloPatternFoundEB()) ||
+      (GlobalData.GetSegmentIsEECaloMatched() && GlobalData.GetHaloPatternFoundEE()) ||
+      (GlobalData.GetSegmentIsHBCaloMatched() && GlobalData.GetHaloPatternFoundHB()) ||
+      (GlobalData.GetSegmentIsHECaloMatched() && GlobalData.GetHaloPatternFoundHE()))
     TheBeamHaloSummary->GetGlobalHaloReport()[3] = 1;
- 
-
 
   iEvent.put(std::move(TheBeamHaloSummary));
   return;
 }
 
-BeamHaloSummaryProducer::~BeamHaloSummaryProducer(){}
+BeamHaloSummaryProducer::~BeamHaloSummaryProducer() {}

--- a/RecoMET/METProducers/src/CSCHaloDataProducer.cc
+++ b/RecoMET/METProducers/src/CSCHaloDataProducer.cc
@@ -13,28 +13,27 @@ using namespace edm;
 using namespace std;
 using namespace reco;
 
-CSCHaloDataProducer::CSCHaloDataProducer(const edm::ParameterSet& iConfig)
-{
-  //Digi Level 
+CSCHaloDataProducer::CSCHaloDataProducer(const edm::ParameterSet& iConfig) {
+  //Digi Level
   IT_L1MuGMTReadout = iConfig.getParameter<edm::InputTag>("L1MuGMTReadoutLabel");
 
   //HLT Level
-  IT_HLTResult    = iConfig.getParameter<edm::InputTag>("HLTResultLabel");
-  CSCAlgo.vIT_HLTBit = iConfig.getParameter< std::vector< edm::InputTag> >("HLTBitLabel");
-  
+  IT_HLTResult = iConfig.getParameter<edm::InputTag>("HLTResultLabel");
+  CSCAlgo.vIT_HLTBit = iConfig.getParameter<std::vector<edm::InputTag> >("HLTBitLabel");
+
   //RecHit Level
-  IT_CSCRecHit   = iConfig.getParameter<edm::InputTag>("CSCRecHitLabel");
+  IT_CSCRecHit = iConfig.getParameter<edm::InputTag>("CSCRecHitLabel");
 
   //Calo RecHit
   IT_HBHErh = iConfig.getParameter<edm::InputTag>("HBHErhLabel");
-  IT_ECALBrh= iConfig.getParameter<edm::InputTag>("ECALBrhLabel");
-  IT_ECALErh= iConfig.getParameter<edm::InputTag>("ECALErhLabel");
-  //Higher Level Reco 
-  IT_CSCSegment = iConfig.getParameter<edm::InputTag>("CSCSegmentLabel");  
-  IT_CosmicMuon = iConfig.getParameter<edm::InputTag>("CosmicMuonLabel"); 
+  IT_ECALBrh = iConfig.getParameter<edm::InputTag>("ECALBrhLabel");
+  IT_ECALErh = iConfig.getParameter<edm::InputTag>("ECALErhLabel");
+  //Higher Level Reco
+  IT_CSCSegment = iConfig.getParameter<edm::InputTag>("CSCSegmentLabel");
+  IT_CosmicMuon = iConfig.getParameter<edm::InputTag>("CosmicMuonLabel");
   IT_Muon = iConfig.getParameter<edm::InputTag>("MuonLabel");
-  IT_SA   = iConfig.getParameter<edm::InputTag>("SALabel"); 
-  IT_ALCT = iConfig.getParameter<edm::InputTag>("ALCTDigiLabel"); 
+  IT_SA = iConfig.getParameter<edm::InputTag>("SALabel");
+  IT_ALCT = iConfig.getParameter<edm::InputTag>("ALCTDigiLabel");
 
   //Muon to Segment Matching
   edm::ParameterSet matchParameters = iConfig.getParameter<edm::ParameterSet>("MatchParameters");
@@ -42,51 +41,53 @@ CSCHaloDataProducer::CSCHaloDataProducer(const edm::ParameterSet& iConfig)
   TheMatcher = new MuonSegmentMatcher(matchParameters, iC);
 
   // Cosmic track selection parameters
-  CSCAlgo.SetDetaThreshold( (float) iConfig.getParameter<double>("DetaParam"));
-  CSCAlgo.SetDphiThreshold( (float) iConfig.getParameter<double>("DphiParam"));
-  CSCAlgo.SetMinMaxInnerRadius( (float) iConfig.getParameter<double>("InnerRMinParam") ,  (float) iConfig.getParameter<double>("InnerRMaxParam") );
-  CSCAlgo.SetMinMaxOuterRadius( (float) iConfig.getParameter<double>("OuterRMinParam"), (float) iConfig.getParameter<double>("OuterRMaxParam"));
-  CSCAlgo.SetNormChi2Threshold( (float) iConfig.getParameter<double>("NormChi2Param") );
- 
+  CSCAlgo.SetDetaThreshold((float)iConfig.getParameter<double>("DetaParam"));
+  CSCAlgo.SetDphiThreshold((float)iConfig.getParameter<double>("DphiParam"));
+  CSCAlgo.SetMinMaxInnerRadius((float)iConfig.getParameter<double>("InnerRMinParam"),
+                               (float)iConfig.getParameter<double>("InnerRMaxParam"));
+  CSCAlgo.SetMinMaxOuterRadius((float)iConfig.getParameter<double>("OuterRMinParam"),
+                               (float)iConfig.getParameter<double>("OuterRMaxParam"));
+  CSCAlgo.SetNormChi2Threshold((float)iConfig.getParameter<double>("NormChi2Param"));
+
   // MLR
-  CSCAlgo.SetMaxSegmentRDiff( (float) iConfig.getParameter<double>("MaxSegmentRDiff") );
-  CSCAlgo.SetMaxSegmentPhiDiff( (float) iConfig.getParameter<double>("MaxSegmentPhiDiff") );
-  CSCAlgo.SetMaxSegmentTheta( (float) iConfig.getParameter<double>("MaxSegmentTheta") );
+  CSCAlgo.SetMaxSegmentRDiff((float)iConfig.getParameter<double>("MaxSegmentRDiff"));
+  CSCAlgo.SetMaxSegmentPhiDiff((float)iConfig.getParameter<double>("MaxSegmentPhiDiff"));
+  CSCAlgo.SetMaxSegmentTheta((float)iConfig.getParameter<double>("MaxSegmentTheta"));
   // End MLR
 
-  CSCAlgo.SetMaxDtMuonSegment( (float) iConfig.getParameter<double>("MaxDtMuonSegment") );
-  CSCAlgo.SetMaxFreeInverseBeta( (float) iConfig.getParameter<double>("MaxFreeInverseBeta") );
-  CSCAlgo.SetExpectedBX( (short int) iConfig.getParameter<int>("ExpectedBX") );
-  CSCAlgo.SetRecHitTime0( (float) iConfig.getParameter<double>("RecHitTime0") );
-  CSCAlgo.SetRecHitTimeWindow( (float) iConfig.getParameter<double>("RecHitTimeWindow") );
-  CSCAlgo.SetMinMaxOuterMomentumTheta( (float)iConfig.getParameter<double>("MinOuterMomentumTheta"), (float)iConfig.getParameter<double>("MaxOuterMomentumTheta") );
-  CSCAlgo.SetMatchingDPhiThreshold( (float)iConfig.getParameter<double>("MatchingDPhiThreshold") );
-  CSCAlgo.SetMatchingDEtaThreshold( (float)iConfig.getParameter<double>("MatchingDEtaThreshold") );
-  CSCAlgo.SetMatchingDWireThreshold(iConfig.getParameter<int>("MatchingDWireThreshold") );
+  CSCAlgo.SetMaxDtMuonSegment((float)iConfig.getParameter<double>("MaxDtMuonSegment"));
+  CSCAlgo.SetMaxFreeInverseBeta((float)iConfig.getParameter<double>("MaxFreeInverseBeta"));
+  CSCAlgo.SetExpectedBX((short int)iConfig.getParameter<int>("ExpectedBX"));
+  CSCAlgo.SetRecHitTime0((float)iConfig.getParameter<double>("RecHitTime0"));
+  CSCAlgo.SetRecHitTimeWindow((float)iConfig.getParameter<double>("RecHitTimeWindow"));
+  CSCAlgo.SetMinMaxOuterMomentumTheta((float)iConfig.getParameter<double>("MinOuterMomentumTheta"),
+                                      (float)iConfig.getParameter<double>("MaxOuterMomentumTheta"));
+  CSCAlgo.SetMatchingDPhiThreshold((float)iConfig.getParameter<double>("MatchingDPhiThreshold"));
+  CSCAlgo.SetMatchingDEtaThreshold((float)iConfig.getParameter<double>("MatchingDEtaThreshold"));
+  CSCAlgo.SetMatchingDWireThreshold(iConfig.getParameter<int>("MatchingDWireThreshold"));
 
   cosmicmuon_token_ = consumes<reco::MuonCollection>(IT_CosmicMuon);
   csctimemap_token_ = consumes<reco::MuonTimeExtraMap>(edm::InputTag(IT_CosmicMuon.label(), "csc"));
-  muon_token_       = consumes<reco::MuonCollection>(IT_Muon);
+  muon_token_ = consumes<reco::MuonCollection>(IT_Muon);
   cscsegment_token_ = consumes<CSCSegmentCollection>(IT_CSCSegment);
-  cscrechit_token_  = consumes<CSCRecHit2DCollection>(IT_CSCRecHit);
-  cscalct_token_    = consumes<CSCALCTDigiCollection>(IT_ALCT);
-  l1mugmtro_token_  = consumes<L1MuGMTReadoutCollection>(IT_L1MuGMTReadout);
-  hbhereco_token_   = consumes<HBHERecHitCollection>(IT_HBHErh);
+  cscrechit_token_ = consumes<CSCRecHit2DCollection>(IT_CSCRecHit);
+  cscalct_token_ = consumes<CSCALCTDigiCollection>(IT_ALCT);
+  l1mugmtro_token_ = consumes<L1MuGMTReadoutCollection>(IT_L1MuGMTReadout);
+  hbhereco_token_ = consumes<HBHERecHitCollection>(IT_HBHErh);
   EcalRecHitsEB_token_ = consumes<EcalRecHitCollection>(IT_ECALBrh);
   EcalRecHitsEE_token_ = consumes<EcalRecHitCollection>(IT_ECALErh);
-  hltresult_token_  = consumes<edm::TriggerResults>(IT_HLTResult);
+  hltresult_token_ = consumes<edm::TriggerResults>(IT_HLTResult);
 
   produces<CSCHaloData>();
 }
 
-void CSCHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
-{
+void CSCHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   //Get CSC Geometry
   edm::ESHandle<CSCGeometry> TheCSCGeometry;
   iSetup.get<MuonGeometryRecord>().get(TheCSCGeometry);
 
-  //Get Muons Collection from Cosmic Reconstruction 
-  edm::Handle< reco::MuonCollection > TheCosmics;
+  //Get Muons Collection from Cosmic Reconstruction
+  edm::Handle<reco::MuonCollection> TheCosmics;
   //  iEvent.getByLabel(IT_CosmicMuon, TheCosmics);
   iEvent.getByToken(cosmicmuon_token_, TheCosmics);
 
@@ -95,8 +96,8 @@ void CSCHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
   //  iEvent.getByLabel(IT_CosmicMuon.label(),"csc",TheCSCTimeMap);
   iEvent.getByToken(csctimemap_token_, TheCSCTimeMap);
 
- //Collision Muon Collection
-  edm::Handle< reco::MuonCollection> TheMuons;
+  //Collision Muon Collection
+  edm::Handle<reco::MuonCollection> TheMuons;
   //  iEvent.getByLabel(IT_Muon, TheMuons);
   iEvent.getByToken(muon_token_, TheMuons);
 
@@ -110,8 +111,8 @@ void CSCHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
   //  iEvent.getByLabel(IT_CSCRecHit, TheCSCRecHits);
   iEvent.getByToken(cscrechit_token_, TheCSCRecHits);
 
-  //Get L1MuGMT 
-  edm::Handle < L1MuGMTReadoutCollection > TheL1GMTReadout ;
+  //Get L1MuGMT
+  edm::Handle<L1MuGMTReadoutCollection> TheL1GMTReadout;
   //  iEvent.getByLabel (IT_L1MuGMTReadout, TheL1GMTReadout);
   iEvent.getByToken(l1mugmtro_token_, TheL1GMTReadout);
 
@@ -122,26 +123,40 @@ void CSCHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
 
   //Calo rec hits
   Handle<HBHERecHitCollection> hbhehits;
-  iEvent.getByToken(hbhereco_token_,hbhehits);
+  iEvent.getByToken(hbhereco_token_, hbhehits);
   Handle<EcalRecHitCollection> ecalebhits;
   iEvent.getByToken(EcalRecHitsEB_token_, ecalebhits);
   Handle<EcalRecHitCollection> ecaleehits;
-  iEvent.getByToken(EcalRecHitsEE_token_,ecaleehits);
-  
-  //Get HLT Results                                                                                                                                                       
+  iEvent.getByToken(EcalRecHitsEE_token_, ecaleehits);
+
+  //Get HLT Results
   edm::Handle<edm::TriggerResults> TheHLTResults;
   //  iEvent.getByLabel( IT_HLTResult , TheHLTResults);
   iEvent.getByToken(hltresult_token_, TheHLTResults);
 
-  const edm::TriggerNames * triggerNames = nullptr;
+  const edm::TriggerNames* triggerNames = nullptr;
   if (TheHLTResults.isValid()) {
     triggerNames = &iEvent.triggerNames(*TheHLTResults);
   }
 
-
-  // Put it in the event                                                                                                                                                
-  iEvent.put(std::make_unique<CSCHaloData>(CSCAlgo.Calculate(*TheCSCGeometry, TheCosmics, TheCSCTimeMap, TheMuons, TheCSCSegments, TheCSCRecHits, TheL1GMTReadout, hbhehits,ecalebhits,ecaleehits,TheHLTResults, triggerNames, TheALCTs, TheMatcher, iEvent, iSetup)));
+  // Put it in the event
+  iEvent.put(std::make_unique<CSCHaloData>(CSCAlgo.Calculate(*TheCSCGeometry,
+                                                             TheCosmics,
+                                                             TheCSCTimeMap,
+                                                             TheMuons,
+                                                             TheCSCSegments,
+                                                             TheCSCRecHits,
+                                                             TheL1GMTReadout,
+                                                             hbhehits,
+                                                             ecalebhits,
+                                                             ecaleehits,
+                                                             TheHLTResults,
+                                                             triggerNames,
+                                                             TheALCTs,
+                                                             TheMatcher,
+                                                             iEvent,
+                                                             iSetup)));
   return;
 }
 
-CSCHaloDataProducer::~CSCHaloDataProducer(){}
+CSCHaloDataProducer::~CSCHaloDataProducer() {}

--- a/RecoMET/METProducers/src/CaloMETProducer.cc
+++ b/RecoMET/METProducers/src/CaloMETProducer.cc
@@ -27,34 +27,32 @@
 #include <cstring>
 
 //____________________________________________________________________________||
-namespace cms
-{
+namespace cms {
 
-//____________________________________________________________________________||
+  //____________________________________________________________________________||
   CaloMETProducer::CaloMETProducer(const edm::ParameterSet& iConfig)
-    : inputToken_(consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("src")))
-    , calculateSignificance_(iConfig.getParameter<bool>("calculateSignificance"))
-    , resolutions_(nullptr)
-    , globalThreshold_(iConfig.getParameter<double>("globalThreshold"))
-  {
+      : inputToken_(consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("src"))),
+        calculateSignificance_(iConfig.getParameter<bool>("calculateSignificance")),
+        resolutions_(nullptr),
+        globalThreshold_(iConfig.getParameter<double>("globalThreshold")) {
     noHF_ = iConfig.getParameter<bool>("noHF");
 
     std::string alias = iConfig.exists("alias") ? iConfig.getParameter<std::string>("alias") : "";
 
     produces<reco::CaloMETCollection>().setBranchAlias(alias);
 
-    if (calculateSignificance_) resolutions_ = new metsig::SignAlgoResolutions(iConfig);
+    if (calculateSignificance_)
+      resolutions_ = new metsig::SignAlgoResolutions(iConfig);
   }
 
-//____________________________________________________________________________||
-  CaloMETProducer::~CaloMETProducer()
-  {
-    if (resolutions_) delete resolutions_;
+  //____________________________________________________________________________||
+  CaloMETProducer::~CaloMETProducer() {
+    if (resolutions_)
+      delete resolutions_;
   }
 
-//____________________________________________________________________________||
-  void CaloMETProducer::produce(edm::Event& event, const edm::EventSetup& setup)
-  {
+  //____________________________________________________________________________||
+  void CaloMETProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
     edm::Handle<edm::View<reco::Candidate> > input;
     event.getByToken(inputToken_, input);
 
@@ -78,8 +76,8 @@ namespace cms
     event.put(std::move(calometcoll));
   }
 
-//____________________________________________________________________________||
+  //____________________________________________________________________________||
   DEFINE_FWK_MODULE(CaloMETProducer);
-}
+}  // namespace cms
 
 //____________________________________________________________________________||

--- a/RecoMET/METProducers/src/EcalHaloDataProducer.cc
+++ b/RecoMET/METProducers/src/EcalHaloDataProducer.cc
@@ -12,29 +12,28 @@ using namespace edm;
 using namespace std;
 using namespace reco;
 
-EcalHaloDataProducer::EcalHaloDataProducer(const edm::ParameterSet& iConfig)
-{
+EcalHaloDataProducer::EcalHaloDataProducer(const edm::ParameterSet& iConfig) {
   //RecHit Level
-  IT_EBRecHit    = iConfig.getParameter<edm::InputTag>("EBRecHitLabel");
-  IT_EERecHit    = iConfig.getParameter<edm::InputTag>("EERecHitLabel");
-  IT_ESRecHit    = iConfig.getParameter<edm::InputTag>("ESRecHitLabel");
-  IT_HBHERecHit    = iConfig.getParameter<edm::InputTag>("HBHERecHitLabel");
+  IT_EBRecHit = iConfig.getParameter<edm::InputTag>("EBRecHitLabel");
+  IT_EERecHit = iConfig.getParameter<edm::InputTag>("EERecHitLabel");
+  IT_ESRecHit = iConfig.getParameter<edm::InputTag>("ESRecHitLabel");
+  IT_HBHERecHit = iConfig.getParameter<edm::InputTag>("HBHERecHitLabel");
 
-  //Higher Level Reco 
+  //Higher Level Reco
   IT_SuperCluster = iConfig.getParameter<edm::InputTag>("SuperClusterLabel");
-  IT_Photon = iConfig.getParameter<edm::InputTag>("PhotonLabel") ;
+  IT_Photon = iConfig.getParameter<edm::InputTag>("PhotonLabel");
 
   // Shower Shape cuts for EcalAlgo
 
   RoundnessCut = iConfig.getParameter<double>("RoundnessCutParam");
   AngleCut = iConfig.getParameter<double>("AngleCutParam");
 
-  EBRecHitEnergyThreshold = (float) iConfig.getParameter<double> ("EBRecHitEnergyThresholdParam");
-  EERecHitEnergyThreshold = (float) iConfig.getParameter<double> ("EERecHitEnergyThresholdParam");
-  ESRecHitEnergyThreshold = (float) iConfig.getParameter<double> ("ESRecHitEnergyThresholdParam");
-  SumEcalEnergyThreshold = (float)iConfig.getParameter<double> ("SumEcalEnergyThresholdParam");
-  NHitsEcalThreshold = iConfig.getParameter<int> ("NHitsEcalThresholdParam");
-  
+  EBRecHitEnergyThreshold = (float)iConfig.getParameter<double>("EBRecHitEnergyThresholdParam");
+  EERecHitEnergyThreshold = (float)iConfig.getParameter<double>("EERecHitEnergyThresholdParam");
+  ESRecHitEnergyThreshold = (float)iConfig.getParameter<double>("ESRecHitEnergyThresholdParam");
+  SumEcalEnergyThreshold = (float)iConfig.getParameter<double>("SumEcalEnergyThresholdParam");
+  NHitsEcalThreshold = iConfig.getParameter<int>("NHitsEcalThresholdParam");
+
   RoundnessCut = iConfig.getParameter<double>("RoundnessCutParam");
   AngleCut = iConfig.getParameter<double>("AngleCutParam");
 
@@ -48,8 +47,7 @@ EcalHaloDataProducer::EcalHaloDataProducer(const edm::ParameterSet& iConfig)
   produces<EcalHaloData>();
 }
 
-void EcalHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
-{
+void EcalHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   //Get CaloGeometry
   edm::ESHandle<CaloGeometry> TheCaloGeometry;
   iSetup.get<CaloGeometryRecord>().get(TheCaloGeometry);
@@ -73,7 +71,7 @@ void EcalHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
   edm::Handle<HBHERecHitCollection> TheHBHERecHits;
   iEvent.getByToken(hbherechit_token_, TheHBHERecHits);
 
-  //Get ECAL Barrel SuperClusters                  
+  //Get ECAL Barrel SuperClusters
   edm::Handle<reco::SuperClusterCollection> TheSuperClusters;
   //  iEvent.getByLabel(IT_SuperCluster, TheSuperClusters);
   iEvent.getByToken(supercluster_token_, TheSuperClusters);
@@ -83,18 +81,17 @@ void EcalHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
   //  iEvent.getByLabel(IT_Photon, ThePhotons);
   iEvent.getByToken(photon_token_, ThePhotons);
 
-  //Run the EcalHaloAlgo to reconstruct the EcalHaloData object 
+  //Run the EcalHaloAlgo to reconstruct the EcalHaloData object
   EcalHaloAlgo EcalAlgo;
   EcalAlgo.SetRoundnessCut(RoundnessCut);
   EcalAlgo.SetAngleCut(AngleCut);
   EcalAlgo.SetRecHitEnergyThresholds(EBRecHitEnergyThreshold, EERecHitEnergyThreshold, ESRecHitEnergyThreshold);
   EcalAlgo.SetPhiWedgeThresholds(SumEcalEnergyThreshold, NHitsEcalThreshold);
-  
 
-  iEvent.put(std::make_unique<EcalHaloData>(EcalAlgo.Calculate(*TheCaloGeometry, ThePhotons, TheSuperClusters, TheEBRecHits, TheEERecHits, TheESRecHits, TheHBHERecHits,iSetup)));
+  iEvent.put(std::make_unique<EcalHaloData>(EcalAlgo.Calculate(
+      *TheCaloGeometry, ThePhotons, TheSuperClusters, TheEBRecHits, TheEERecHits, TheESRecHits, TheHBHERecHits, iSetup)));
 
   return;
 }
 
-EcalHaloDataProducer::~EcalHaloDataProducer(){}
-
+EcalHaloDataProducer::~EcalHaloDataProducer() {}

--- a/RecoMET/METProducers/src/ElseMETProducer.cc
+++ b/RecoMET/METProducers/src/ElseMETProducer.cc
@@ -27,23 +27,19 @@
 #include <cstring>
 
 //____________________________________________________________________________||
-namespace cms
-{
+namespace cms {
 
-//____________________________________________________________________________||
+  //____________________________________________________________________________||
   ElseMETProducer::ElseMETProducer(const edm::ParameterSet& iConfig)
-    : inputToken_(consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("src")))
-    , globalThreshold_(iConfig.getParameter<double>("globalThreshold"))
-  {
+      : inputToken_(consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("src"))),
+        globalThreshold_(iConfig.getParameter<double>("globalThreshold")) {
     std::string alias = iConfig.exists("alias") ? iConfig.getParameter<std::string>("alias") : "";
 
     produces<reco::METCollection>().setBranchAlias(alias);
   }
 
-
-//____________________________________________________________________________||
-  void ElseMETProducer::produce(edm::Event& event, const edm::EventSetup& setup)
-  {
+  //____________________________________________________________________________||
+  void ElseMETProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
     edm::Handle<edm::View<reco::Candidate> > input;
     event.getByToken(inputToken_, input);
 
@@ -51,15 +47,15 @@ namespace cms
     CommonMETData commonMETdata = algo.run(*input.product(), globalThreshold_);
 
     math::XYZTLorentzVector p4(commonMETdata.mex, commonMETdata.mey, 0.0, commonMETdata.met);
-    math::XYZPoint vtx(0,0,0);
+    math::XYZPoint vtx(0, 0, 0);
     reco::MET met(commonMETdata.sumet, p4, vtx);
     auto metcoll = std::make_unique<reco::METCollection>();
     metcoll->push_back(met);
     event.put(std::move(metcoll));
   }
 
-//____________________________________________________________________________||
+  //____________________________________________________________________________||
   DEFINE_FWK_MODULE(ElseMETProducer);
-}
+}  // namespace cms
 
 //____________________________________________________________________________||

--- a/RecoMET/METProducers/src/GenMETProducer.cc
+++ b/RecoMET/METProducers/src/GenMETProducer.cc
@@ -23,25 +23,21 @@
 #include <cstring>
 
 //____________________________________________________________________________||
-namespace cms
-{
+namespace cms {
 
-//____________________________________________________________________________||
+  //____________________________________________________________________________||
   GenMETProducer::GenMETProducer(const edm::ParameterSet& iConfig)
-    : inputToken_(consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("src")))
-    , globalThreshold_(iConfig.getParameter<double>("globalThreshold"))
-    , onlyFiducial_(iConfig.getParameter<bool>("onlyFiducialParticles"))
-    , applyFiducialThresholdForFractions_(iConfig.getParameter<bool>("applyFiducialThresholdForFractions"))
-    , usePt_(iConfig.getParameter<bool>("usePt"))
-  {
+      : inputToken_(consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("src"))),
+        globalThreshold_(iConfig.getParameter<double>("globalThreshold")),
+        onlyFiducial_(iConfig.getParameter<bool>("onlyFiducialParticles")),
+        applyFiducialThresholdForFractions_(iConfig.getParameter<bool>("applyFiducialThresholdForFractions")),
+        usePt_(iConfig.getParameter<bool>("usePt")) {
     std::string alias = iConfig.exists("alias") ? iConfig.getParameter<std::string>("alias") : "";
     produces<reco::GenMETCollection>().setBranchAlias(alias);
   }
 
-
-//____________________________________________________________________________||
-  void GenMETProducer::produce(edm::Event& event, const edm::EventSetup& setup)
-  {
+  //____________________________________________________________________________||
+  void GenMETProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
     edm::Handle<edm::View<reco::Candidate> > input;
     event.getByToken(inputToken_, input);
 
@@ -49,12 +45,13 @@ namespace cms
 
     GenSpecificAlgo gen;
     auto genmetcoll = std::make_unique<reco::GenMETCollection>();
-    genmetcoll->push_back(gen.addInfo(input, &commonMETdata, globalThreshold_, onlyFiducial_, applyFiducialThresholdForFractions_, usePt_));
+    genmetcoll->push_back(gen.addInfo(
+        input, &commonMETdata, globalThreshold_, onlyFiducial_, applyFiducialThresholdForFractions_, usePt_));
     event.put(std::move(genmetcoll));
   }
 
-//____________________________________________________________________________||
+  //____________________________________________________________________________||
   DEFINE_FWK_MODULE(GenMETProducer);
-}
+}  // namespace cms
 
 //____________________________________________________________________________||

--- a/RecoMET/METProducers/src/GlobalHaloDataProducer.cc
+++ b/RecoMET/METProducers/src/GlobalHaloDataProducer.cc
@@ -12,12 +12,10 @@ using namespace edm;
 using namespace std;
 using namespace reco;
 
-GlobalHaloDataProducer::GlobalHaloDataProducer(const edm::ParameterSet& iConfig)
-{
+GlobalHaloDataProducer::GlobalHaloDataProducer(const edm::ParameterSet& iConfig) {
+  ishlt = iConfig.getParameter<bool>("IsHLT");
 
-  ishlt = iConfig.getParameter< bool> ("IsHLT");
-
-  //Higher Level Reco 
+  //Higher Level Reco
   IT_met = iConfig.getParameter<edm::InputTag>("metLabel");
   IT_CaloTower = iConfig.getParameter<edm::InputTag>("calotowerLabel");
   IT_CSCSegment = iConfig.getParameter<edm::InputTag>("CSCSegmentLabel");
@@ -25,59 +23,68 @@ GlobalHaloDataProducer::GlobalHaloDataProducer(const edm::ParameterSet& iConfig)
   IT_Muon = iConfig.getParameter<edm::InputTag>("MuonLabel");
   //Halo Data from Sub-detectors
   IT_CSCHaloData = iConfig.getParameter<edm::InputTag>("CSCHaloDataLabel");
-  IT_EcalHaloData = iConfig.getParameter<edm::InputTag> ("EcalHaloDataLabel");
-  IT_HcalHaloData = iConfig.getParameter<edm::InputTag> ("HcalHaloDataLabel");
+  IT_EcalHaloData = iConfig.getParameter<edm::InputTag>("EcalHaloDataLabel");
+  IT_HcalHaloData = iConfig.getParameter<edm::InputTag>("HcalHaloDataLabel");
 
   EcalMinMatchingRadius = (float)iConfig.getParameter<double>("EcalMinMatchingRadiusParam");
   EcalMaxMatchingRadius = (float)iConfig.getParameter<double>("EcalMaxMatchingRadiusParam");
   HcalMinMatchingRadius = (float)iConfig.getParameter<double>("HcalMinMatchingRadiusParam");
   HcalMaxMatchingRadius = (float)iConfig.getParameter<double>("HcalMaxMatchingRadiusParam");
-  CaloTowerEtThreshold  = (float)iConfig.getParameter<double>("CaloTowerEtThresholdParam");
+  CaloTowerEtThreshold = (float)iConfig.getParameter<double>("CaloTowerEtThresholdParam");
 
-  //Parameters for CSC-calo matching  
-  //Flat segment theta condition: 
-  GlobalAlgo.SetMaxSegmentTheta( (float) iConfig.getParameter<double>("MaxSegmentTheta") );
-  //EB   
-  GlobalAlgo.setEtThresholdforCSCCaloMatchingEB((float) iConfig.getParameter<double>("rh_et_threshforcscmatching_eb") );
-  GlobalAlgo.setRcaloMinRsegmLowThresholdforCSCCaloMatchingEB((float) iConfig.getParameter<double>("rcalominrsegm_lowthresh_eb") );
-  GlobalAlgo.setRcaloMinRsegmHighThresholdforCSCCaloMatchingEB((float) iConfig.getParameter<double>("rcalominrsegm_highthresh_eb") );
-  GlobalAlgo.setDtcalosegmThresholdforCSCCaloMatchingEB((float) iConfig.getParameter<double>("dtcalosegm_thresh_eb") );
-  GlobalAlgo.setDPhicalosegmThresholdforCSCCaloMatchingEB((float) iConfig.getParameter<double>("dphicalosegm_thresh_eb") );
-  //EE 
-  GlobalAlgo.setEtThresholdforCSCCaloMatchingEE((float) iConfig.getParameter<double>("rh_et_threshforcscmatching_ee") );
-  GlobalAlgo.setRcaloMinRsegmLowThresholdforCSCCaloMatchingEE((float) iConfig.getParameter<double>("rcalominrsegm_lowthresh_ee") );
-  GlobalAlgo.setRcaloMinRsegmHighThresholdforCSCCaloMatchingEE((float) iConfig.getParameter<double>("rcalominrsegm_highthresh_ee") );
-  GlobalAlgo.setDtcalosegmThresholdforCSCCaloMatchingEE((float) iConfig.getParameter<double>("dtcalosegm_thresh_ee") );
-  GlobalAlgo.setDPhicalosegmThresholdforCSCCaloMatchingEE((float) iConfig.getParameter<double>("dphicalosegm_thresh_ee") );
+  //Parameters for CSC-calo matching
+  //Flat segment theta condition:
+  GlobalAlgo.SetMaxSegmentTheta((float)iConfig.getParameter<double>("MaxSegmentTheta"));
+  //EB
+  GlobalAlgo.setEtThresholdforCSCCaloMatchingEB((float)iConfig.getParameter<double>("rh_et_threshforcscmatching_eb"));
+  GlobalAlgo.setRcaloMinRsegmLowThresholdforCSCCaloMatchingEB(
+      (float)iConfig.getParameter<double>("rcalominrsegm_lowthresh_eb"));
+  GlobalAlgo.setRcaloMinRsegmHighThresholdforCSCCaloMatchingEB(
+      (float)iConfig.getParameter<double>("rcalominrsegm_highthresh_eb"));
+  GlobalAlgo.setDtcalosegmThresholdforCSCCaloMatchingEB((float)iConfig.getParameter<double>("dtcalosegm_thresh_eb"));
+  GlobalAlgo.setDPhicalosegmThresholdforCSCCaloMatchingEB(
+      (float)iConfig.getParameter<double>("dphicalosegm_thresh_eb"));
+  //EE
+  GlobalAlgo.setEtThresholdforCSCCaloMatchingEE((float)iConfig.getParameter<double>("rh_et_threshforcscmatching_ee"));
+  GlobalAlgo.setRcaloMinRsegmLowThresholdforCSCCaloMatchingEE(
+      (float)iConfig.getParameter<double>("rcalominrsegm_lowthresh_ee"));
+  GlobalAlgo.setRcaloMinRsegmHighThresholdforCSCCaloMatchingEE(
+      (float)iConfig.getParameter<double>("rcalominrsegm_highthresh_ee"));
+  GlobalAlgo.setDtcalosegmThresholdforCSCCaloMatchingEE((float)iConfig.getParameter<double>("dtcalosegm_thresh_ee"));
+  GlobalAlgo.setDPhicalosegmThresholdforCSCCaloMatchingEE(
+      (float)iConfig.getParameter<double>("dphicalosegm_thresh_ee"));
   //HB
-  GlobalAlgo.setEtThresholdforCSCCaloMatchingHB((float) iConfig.getParameter<double>("rh_et_threshforcscmatching_hb") );
-  GlobalAlgo.setRcaloMinRsegmLowThresholdforCSCCaloMatchingHB((float) iConfig.getParameter<double>("rcalominrsegm_lowthresh_hb") );
-  GlobalAlgo.setRcaloMinRsegmHighThresholdforCSCCaloMatchingHB((float) iConfig.getParameter<double>("rcalominrsegm_highthresh_hb") );
-  GlobalAlgo.setDtcalosegmThresholdforCSCCaloMatchingHB((float) iConfig.getParameter<double>("dtcalosegm_thresh_hb") );
-  GlobalAlgo.setDPhicalosegmThresholdforCSCCaloMatchingHB((float) iConfig.getParameter<double>("dphicalosegm_thresh_hb") );
-  //HE 
-  GlobalAlgo.setEtThresholdforCSCCaloMatchingHE((float) iConfig.getParameter<double>("rh_et_threshforcscmatching_he") );
-  GlobalAlgo.setRcaloMinRsegmLowThresholdforCSCCaloMatchingHE((float) iConfig.getParameter<double>("rcalominrsegm_lowthresh_he") );
-  GlobalAlgo.setRcaloMinRsegmHighThresholdforCSCCaloMatchingHE((float) iConfig.getParameter<double>("rcalominrsegm_highthresh_he") );
-  GlobalAlgo.setDtcalosegmThresholdforCSCCaloMatchingHE((float) iConfig.getParameter<double>("dtcalosegm_thresh_he") );
-  GlobalAlgo.setDPhicalosegmThresholdforCSCCaloMatchingHE((float) iConfig.getParameter<double>("dphicalosegm_thresh_he") );
+  GlobalAlgo.setEtThresholdforCSCCaloMatchingHB((float)iConfig.getParameter<double>("rh_et_threshforcscmatching_hb"));
+  GlobalAlgo.setRcaloMinRsegmLowThresholdforCSCCaloMatchingHB(
+      (float)iConfig.getParameter<double>("rcalominrsegm_lowthresh_hb"));
+  GlobalAlgo.setRcaloMinRsegmHighThresholdforCSCCaloMatchingHB(
+      (float)iConfig.getParameter<double>("rcalominrsegm_highthresh_hb"));
+  GlobalAlgo.setDtcalosegmThresholdforCSCCaloMatchingHB((float)iConfig.getParameter<double>("dtcalosegm_thresh_hb"));
+  GlobalAlgo.setDPhicalosegmThresholdforCSCCaloMatchingHB(
+      (float)iConfig.getParameter<double>("dphicalosegm_thresh_hb"));
+  //HE
+  GlobalAlgo.setEtThresholdforCSCCaloMatchingHE((float)iConfig.getParameter<double>("rh_et_threshforcscmatching_he"));
+  GlobalAlgo.setRcaloMinRsegmLowThresholdforCSCCaloMatchingHE(
+      (float)iConfig.getParameter<double>("rcalominrsegm_lowthresh_he"));
+  GlobalAlgo.setRcaloMinRsegmHighThresholdforCSCCaloMatchingHE(
+      (float)iConfig.getParameter<double>("rcalominrsegm_highthresh_he"));
+  GlobalAlgo.setDtcalosegmThresholdforCSCCaloMatchingHE((float)iConfig.getParameter<double>("dtcalosegm_thresh_he"));
+  GlobalAlgo.setDPhicalosegmThresholdforCSCCaloMatchingHE(
+      (float)iConfig.getParameter<double>("dphicalosegm_thresh_he"));
 
-
-
-  calotower_token_  = consumes<edm::View<Candidate> >(IT_CaloTower);
-  calomet_token_    = consumes<reco::CaloMETCollection>(IT_met);
+  calotower_token_ = consumes<edm::View<Candidate> >(IT_CaloTower);
+  calomet_token_ = consumes<reco::CaloMETCollection>(IT_met);
   cscsegment_token_ = consumes<CSCSegmentCollection>(IT_CSCSegment);
-  cscrechit_token_  = consumes<CSCRecHit2DCollection>(IT_CSCRecHit);
-  muon_token_       = consumes<reco::MuonCollection>(IT_Muon);
-  cschalo_token_    = consumes<CSCHaloData>(IT_CSCHaloData);
-  ecalhalo_token_   = consumes<EcalHaloData>(IT_EcalHaloData);
-  hcalhalo_token_   = consumes<HcalHaloData>(IT_HcalHaloData);
+  cscrechit_token_ = consumes<CSCRecHit2DCollection>(IT_CSCRecHit);
+  muon_token_ = consumes<reco::MuonCollection>(IT_Muon);
+  cschalo_token_ = consumes<CSCHaloData>(IT_CSCHaloData);
+  ecalhalo_token_ = consumes<EcalHaloData>(IT_EcalHaloData);
+  hcalhalo_token_ = consumes<HcalHaloData>(IT_HcalHaloData);
 
   produces<GlobalHaloData>();
 }
 
-void GlobalHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
-{
+void GlobalHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   //Get CSC Geometry
   edm::ESHandle<CSCGeometry> TheCSCGeometry;
   iSetup.get<MuonGeometryRecord>().get(TheCSCGeometry);
@@ -96,7 +103,7 @@ void GlobalHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
   iEvent.getByToken(calotower_token_, TheCaloTowers);
 
   //Get MET
-  edm::Handle< reco::CaloMETCollection > TheCaloMET;
+  edm::Handle<reco::CaloMETCollection> TheCaloMET;
   //  iEvent.getByLabel(IT_met, TheCaloMET);
   iEvent.getByToken(calomet_token_, TheCaloMET);
 
@@ -111,7 +118,7 @@ void GlobalHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
   iEvent.getByToken(cscrechit_token_, TheCSCRecHits);
 
   //Collision Muon Collection
-  edm::Handle< reco::MuonCollection> TheMuons;
+  edm::Handle<reco::MuonCollection> TheMuons;
   iEvent.getByToken(muon_token_, TheMuons);
 
   //Get CSCHaloData
@@ -129,23 +136,30 @@ void GlobalHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
   //  iEvent.getByLabel(IT_HcalHaloData, TheHcalHaloData );
   iEvent.getByToken(hcalhalo_token_, TheHcalHaloData);
 
-  // Run the GlobalHaloAlgo to reconstruct the GlobalHaloData object 
-  GlobalAlgo.SetEcalMatchingRadius(EcalMinMatchingRadius,EcalMaxMatchingRadius);
-  GlobalAlgo.SetHcalMatchingRadius(HcalMinMatchingRadius,HcalMaxMatchingRadius);
+  // Run the GlobalHaloAlgo to reconstruct the GlobalHaloData object
+  GlobalAlgo.SetEcalMatchingRadius(EcalMinMatchingRadius, EcalMaxMatchingRadius);
+  GlobalAlgo.SetHcalMatchingRadius(HcalMinMatchingRadius, HcalMaxMatchingRadius);
   GlobalAlgo.SetCaloTowerEtThreshold(CaloTowerEtThreshold);
   //  GlobalHaloData GlobalData;
 
-
-  if(TheCaloGeometry.isValid() && TheCaloMET.isValid() && TheCaloTowers.isValid() && TheCSCHaloData.isValid() && TheEcalHaloData.isValid() && TheHcalHaloData.isValid() )
-    {
-      iEvent.put(std::make_unique<GlobalHaloData>(GlobalHaloData(GlobalAlgo.Calculate(*TheCaloGeometry, *TheCSCGeometry,  *(&TheCaloMET.product()->front()), TheCaloTowers, TheCSCSegments, TheCSCRecHits, TheMuons, *TheCSCHaloData.product(), *TheEcalHaloData.product(), *TheHcalHaloData.product() ,ishlt))));
-    }
-  else 
-    {
-      iEvent.put(std::make_unique<GlobalHaloData>());
-    }
+  if (TheCaloGeometry.isValid() && TheCaloMET.isValid() && TheCaloTowers.isValid() && TheCSCHaloData.isValid() &&
+      TheEcalHaloData.isValid() && TheHcalHaloData.isValid()) {
+    iEvent.put(std::make_unique<GlobalHaloData>(GlobalHaloData(GlobalAlgo.Calculate(*TheCaloGeometry,
+                                                                                    *TheCSCGeometry,
+                                                                                    *(&TheCaloMET.product()->front()),
+                                                                                    TheCaloTowers,
+                                                                                    TheCSCSegments,
+                                                                                    TheCSCRecHits,
+                                                                                    TheMuons,
+                                                                                    *TheCSCHaloData.product(),
+                                                                                    *TheEcalHaloData.product(),
+                                                                                    *TheHcalHaloData.product(),
+                                                                                    ishlt))));
+  } else {
+    iEvent.put(std::make_unique<GlobalHaloData>());
+  }
 
   return;
 }
 
-GlobalHaloDataProducer::~GlobalHaloDataProducer(){}
+GlobalHaloDataProducer::~GlobalHaloDataProducer() {}

--- a/RecoMET/METProducers/src/HcalHaloDataProducer.cc
+++ b/RecoMET/METProducers/src/HcalHaloDataProducer.cc
@@ -12,32 +12,30 @@ using namespace edm;
 using namespace std;
 using namespace reco;
 
-HcalHaloDataProducer::HcalHaloDataProducer(const edm::ParameterSet& iConfig)
-{
+HcalHaloDataProducer::HcalHaloDataProducer(const edm::ParameterSet& iConfig) {
   //RecHit Level
-  IT_EBRecHit    = iConfig.getParameter<edm::InputTag>("EBRecHitLabel");
-  IT_EERecHit    = iConfig.getParameter<edm::InputTag>("EERecHitLabel");
-  IT_HBHERecHit  = iConfig.getParameter<edm::InputTag>("HBHERecHitLabel");
-  IT_HFRecHit    = iConfig.getParameter<edm::InputTag>("HFRecHitLabel");
-  IT_HORecHit    = iConfig.getParameter<edm::InputTag>("HORecHitLabel");
-  IT_CaloTowers =  iConfig.getParameter<edm::InputTag>("caloTowerCollName");
+  IT_EBRecHit = iConfig.getParameter<edm::InputTag>("EBRecHitLabel");
+  IT_EERecHit = iConfig.getParameter<edm::InputTag>("EERecHitLabel");
+  IT_HBHERecHit = iConfig.getParameter<edm::InputTag>("HBHERecHitLabel");
+  IT_HFRecHit = iConfig.getParameter<edm::InputTag>("HFRecHitLabel");
+  IT_HORecHit = iConfig.getParameter<edm::InputTag>("HORecHitLabel");
+  IT_CaloTowers = iConfig.getParameter<edm::InputTag>("caloTowerCollName");
 
   HBRecHitEnergyThreshold = (float)iConfig.getParameter<double>("HBRecHitEnergyThresholdParam");
   HERecHitEnergyThreshold = (float)iConfig.getParameter<double>("HERecHitEnergyThresholdParam");
-  SumHcalEnergyThreshold = (float) iConfig.getParameter<double>("SumHcalEnergyThresholdParam");
-  NHitsHcalThreshold =  iConfig.getParameter<int>("NHitsHcalThresholdParam");
+  SumHcalEnergyThreshold = (float)iConfig.getParameter<double>("SumHcalEnergyThresholdParam");
+  NHitsHcalThreshold = iConfig.getParameter<int>("NHitsHcalThresholdParam");
 
   ebrechit_token_ = consumes<EBRecHitCollection>(IT_EBRecHit);
   eerechit_token_ = consumes<EERecHitCollection>(IT_EERecHit);
   hbherechit_token_ = consumes<HBHERecHitCollection>(IT_HBHERecHit);
   hfrechit_token_ = consumes<HFRecHitCollection>(IT_HFRecHit);
-  calotower_token_     = consumes<CaloTowerCollection>(IT_CaloTowers);
+  calotower_token_ = consumes<CaloTowerCollection>(IT_CaloTowers);
 
   produces<HcalHaloData>();
 }
 
-void HcalHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
-{
+void HcalHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   //Get CaloGeometry
   edm::ESHandle<CaloGeometry> TheCaloGeometry;
   iSetup.get<CaloGeometryRecord>().get(TheCaloGeometry);
@@ -53,7 +51,7 @@ void HcalHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
   //Get EE RecHits
   edm::Handle<EERecHitCollection> TheEERecHits;
   iEvent.getByToken(eerechit_token_, TheEERecHits);
-  
+
   //Get HB/HE RecHits
   edm::Handle<HBHERecHitCollection> TheHBHERecHits;
   //  iEvent.getByLabel(IT_HBHERecHit, TheHBHERecHits);
@@ -66,13 +64,12 @@ void HcalHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
 
   // Run the HcalHaloAlgo to reconstruct the HcalHaloData object
   HcalHaloAlgo HcalAlgo;
-  HcalAlgo.SetRecHitEnergyThresholds( HBRecHitEnergyThreshold, HERecHitEnergyThreshold );
-  HcalAlgo.SetPhiWedgeThresholds( SumHcalEnergyThreshold, NHitsHcalThreshold );
+  HcalAlgo.SetRecHitEnergyThresholds(HBRecHitEnergyThreshold, HERecHitEnergyThreshold);
+  HcalAlgo.SetPhiWedgeThresholds(SumHcalEnergyThreshold, NHitsHcalThreshold);
 
-
-
-  iEvent.put(std::make_unique<HcalHaloData>(HcalAlgo.Calculate(*TheCaloGeometry, TheHBHERecHits, TheCaloTowers, TheEBRecHits, TheEERecHits,iSetup)));
+  iEvent.put(std::make_unique<HcalHaloData>(
+      HcalAlgo.Calculate(*TheCaloGeometry, TheHBHERecHits, TheCaloTowers, TheEBRecHits, TheEERecHits, iSetup)));
   return;
 }
 
-HcalHaloDataProducer::~HcalHaloDataProducer(){}
+HcalHaloDataProducer::~HcalHaloDataProducer() {}

--- a/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
+++ b/RecoMET/METProducers/src/HcalNoiseInfoProducer.cc
@@ -30,39 +30,38 @@ using namespace reco;
 // constructors and destructor
 //
 
-HcalNoiseInfoProducer::HcalNoiseInfoProducer(const edm::ParameterSet& iConfig) : algo_(iConfig)
-{
+HcalNoiseInfoProducer::HcalNoiseInfoProducer(const edm::ParameterSet& iConfig) : algo_(iConfig) {
   // set the parameters
-  fillDigis_         = iConfig.getParameter<bool>("fillDigis");
-  fillRecHits_       = iConfig.getParameter<bool>("fillRecHits");
-  fillCaloTowers_    = iConfig.getParameter<bool>("fillCaloTowers");
-  fillTracks_        = iConfig.getParameter<bool>("fillTracks");
-  fillLaserMonitor_  = iConfig.getParameter<bool>("fillLaserMonitor");
+  fillDigis_ = iConfig.getParameter<bool>("fillDigis");
+  fillRecHits_ = iConfig.getParameter<bool>("fillRecHits");
+  fillCaloTowers_ = iConfig.getParameter<bool>("fillCaloTowers");
+  fillTracks_ = iConfig.getParameter<bool>("fillTracks");
+  fillLaserMonitor_ = iConfig.getParameter<bool>("fillLaserMonitor");
 
-  maxProblemRBXs_    = iConfig.getParameter<int>("maxProblemRBXs");
+  maxProblemRBXs_ = iConfig.getParameter<int>("maxProblemRBXs");
 
-  maxCaloTowerIEta_  = iConfig.getParameter<int>("maxCaloTowerIEta");
-  maxTrackEta_       = iConfig.getParameter<double>("maxTrackEta");
-  minTrackPt_        = iConfig.getParameter<double>("minTrackPt");
+  maxCaloTowerIEta_ = iConfig.getParameter<int>("maxCaloTowerIEta");
+  maxTrackEta_ = iConfig.getParameter<double>("maxTrackEta");
+  minTrackPt_ = iConfig.getParameter<double>("minTrackPt");
 
-  digiCollName_      = iConfig.getParameter<std::string>("digiCollName");
-  recHitCollName_    = iConfig.getParameter<std::string>("recHitCollName");
+  digiCollName_ = iConfig.getParameter<std::string>("digiCollName");
+  recHitCollName_ = iConfig.getParameter<std::string>("recHitCollName");
   caloTowerCollName_ = iConfig.getParameter<std::string>("caloTowerCollName");
-  trackCollName_     = iConfig.getParameter<std::string>("trackCollName");
+  trackCollName_ = iConfig.getParameter<std::string>("trackCollName");
 
-  jetCollName_   = iConfig.getParameter<std::string>("jetCollName");
-  maxNHF_        = iConfig.getParameter<double>("maxNHF");
-  maxjetindex_   = iConfig.getParameter<int>("maxjetindex");
-  jet_token_     = consumes<reco::PFJetCollection>(edm::InputTag(jetCollName_));
+  jetCollName_ = iConfig.getParameter<std::string>("jetCollName");
+  maxNHF_ = iConfig.getParameter<double>("maxNHF");
+  maxjetindex_ = iConfig.getParameter<int>("maxjetindex");
+  jet_token_ = consumes<reco::PFJetCollection>(edm::InputTag(jetCollName_));
 
-  minRecHitE_        = iConfig.getParameter<double>("minRecHitE");
-  minLowHitE_        = iConfig.getParameter<double>("minLowHitE");
-  minHighHitE_       = iConfig.getParameter<double>("minHighHitE");
-  
-  minR45HitE_        = iConfig.getParameter<double>("minR45HitE");
+  minRecHitE_ = iConfig.getParameter<double>("minRecHitE");
+  minLowHitE_ = iConfig.getParameter<double>("minLowHitE");
+  minHighHitE_ = iConfig.getParameter<double>("minHighHitE");
+
+  minR45HitE_ = iConfig.getParameter<double>("minR45HitE");
 
   HcalAcceptSeverityLevel_ = iConfig.getParameter<uint32_t>("HcalAcceptSeverityLevel");
-  HcalRecHitFlagsToBeExcluded_ = iConfig.getParameter<std::vector<int> >("HcalRecHitFlagsToBeExcluded");
+  HcalRecHitFlagsToBeExcluded_ = iConfig.getParameter<std::vector<int>>("HcalRecHitFlagsToBeExcluded");
 
   // Digi threshold and time slices to use for HBHE and HF calibration digis
   calibdigiHBHEthreshold_ = 0;
@@ -70,128 +69,352 @@ HcalNoiseInfoProducer::HcalNoiseInfoProducer(const edm::ParameterSet& iConfig) :
   calibdigiHFthreshold_ = 0;
   calibdigiHFtimeslices_ = std::vector<int>();
 
-  calibdigiHBHEthreshold_   = iConfig.getParameter<double>("calibdigiHBHEthreshold");
-  calibdigiHBHEtimeslices_  = iConfig.getParameter<std::vector<int> >("calibdigiHBHEtimeslices");
-  calibdigiHFthreshold_   = iConfig.getParameter<double>("calibdigiHFthreshold");
-  calibdigiHFtimeslices_  = iConfig.getParameter<std::vector<int> >("calibdigiHFtimeslices");
+  calibdigiHBHEthreshold_ = iConfig.getParameter<double>("calibdigiHBHEthreshold");
+  calibdigiHBHEtimeslices_ = iConfig.getParameter<std::vector<int>>("calibdigiHBHEtimeslices");
+  calibdigiHFthreshold_ = iConfig.getParameter<double>("calibdigiHFthreshold");
+  calibdigiHFtimeslices_ = iConfig.getParameter<std::vector<int>>("calibdigiHFtimeslices");
 
   TS4TS5EnergyThreshold_ = iConfig.getParameter<double>("TS4TS5EnergyThreshold");
 
-  std::vector<double> TS4TS5UpperThresholdTemp = iConfig.getParameter<std::vector<double> >("TS4TS5UpperThreshold");
-  std::vector<double> TS4TS5UpperCutTemp = iConfig.getParameter<std::vector<double> >("TS4TS5UpperCut");
-  std::vector<double> TS4TS5LowerThresholdTemp = iConfig.getParameter<std::vector<double> >("TS4TS5LowerThreshold");
-  std::vector<double> TS4TS5LowerCutTemp = iConfig.getParameter<std::vector<double> >("TS4TS5LowerCut");
+  std::vector<double> TS4TS5UpperThresholdTemp = iConfig.getParameter<std::vector<double>>("TS4TS5UpperThreshold");
+  std::vector<double> TS4TS5UpperCutTemp = iConfig.getParameter<std::vector<double>>("TS4TS5UpperCut");
+  std::vector<double> TS4TS5LowerThresholdTemp = iConfig.getParameter<std::vector<double>>("TS4TS5LowerThreshold");
+  std::vector<double> TS4TS5LowerCutTemp = iConfig.getParameter<std::vector<double>>("TS4TS5LowerCut");
 
-  for(int i = 0; i < (int)TS4TS5UpperThresholdTemp.size() && i < (int)TS4TS5UpperCutTemp.size(); i++)
-     TS4TS5UpperCut_.push_back(std::pair<double, double>(TS4TS5UpperThresholdTemp[i], TS4TS5UpperCutTemp[i]));
+  for (int i = 0; i < (int)TS4TS5UpperThresholdTemp.size() && i < (int)TS4TS5UpperCutTemp.size(); i++)
+    TS4TS5UpperCut_.push_back(std::pair<double, double>(TS4TS5UpperThresholdTemp[i], TS4TS5UpperCutTemp[i]));
   sort(TS4TS5UpperCut_.begin(), TS4TS5UpperCut_.end());
 
-  for(int i = 0; i < (int)TS4TS5LowerThresholdTemp.size() && i < (int)TS4TS5LowerCutTemp.size(); i++)
-     TS4TS5LowerCut_.push_back(std::pair<double, double>(TS4TS5LowerThresholdTemp[i], TS4TS5LowerCutTemp[i]));
+  for (int i = 0; i < (int)TS4TS5LowerThresholdTemp.size() && i < (int)TS4TS5LowerCutTemp.size(); i++)
+    TS4TS5LowerCut_.push_back(std::pair<double, double>(TS4TS5LowerThresholdTemp[i], TS4TS5LowerCutTemp[i]));
   sort(TS4TS5LowerCut_.begin(), TS4TS5LowerCut_.end());
 
   // if digis are filled, then rechits must also be filled
-  if(fillDigis_ && !fillRecHits_) {
-    fillRecHits_=true;
+  if (fillDigis_ && !fillRecHits_) {
+    fillRecHits_ = true;
     edm::LogWarning("HCalNoiseInfoProducer") << " forcing fillRecHits to be true if fillDigis is true.\n";
   }
 
   // get the fiber configuration vectors
-  laserMonCBoxList_ = iConfig.getParameter<std::vector<int> >("laserMonCBoxList");
-  laserMonIPhiList_ = iConfig.getParameter<std::vector<int> >("laserMonIPhiList");
-  laserMonIEtaList_ = iConfig.getParameter<std::vector<int> >("laserMonIEtaList");
+  laserMonCBoxList_ = iConfig.getParameter<std::vector<int>>("laserMonCBoxList");
+  laserMonIPhiList_ = iConfig.getParameter<std::vector<int>>("laserMonIPhiList");
+  laserMonIEtaList_ = iConfig.getParameter<std::vector<int>>("laserMonIEtaList");
 
   // check that the vectors have the same size, if not
   // disable the laser monitor
-  if( !( (laserMonCBoxList_.size() == laserMonIEtaList_.size() ) && 
-         (laserMonCBoxList_.size() == laserMonIPhiList_.size() ) ) ) { 
-    edm::LogWarning("MisConfiguration")<<"Must provide equally sized lists for laserMonCBoxList, laserMonIEtaList, and laserMonIPhiList.  Will not fill LaserMon\n";
-    fillLaserMonitor_=false;
+  if (!((laserMonCBoxList_.size() == laserMonIEtaList_.size()) &&
+        (laserMonCBoxList_.size() == laserMonIPhiList_.size()))) {
+    edm::LogWarning("MisConfiguration") << "Must provide equally sized lists for laserMonCBoxList, laserMonIEtaList, "
+                                           "and laserMonIPhiList.  Will not fill LaserMon\n";
+    fillLaserMonitor_ = false;
   }
 
   // get the integration region with defaults
   laserMonitorTSStart_ = iConfig.getParameter<int>("laserMonTSStart");
-  laserMonitorTSEnd_   = iConfig.getParameter<int>("laserMonTSEnd");
+  laserMonitorTSEnd_ = iConfig.getParameter<int>("laserMonTSEnd");
   laserMonitorSamples_ = iConfig.getParameter<unsigned>("laserMonSamples");
 
-  adc2fC= std::vector<float> {-0.5,0.5,1.5,2.5,3.5,4.5,5.5,6.5,7.5,8.5,9.5,10.5,11.5,12.5,
-     13.5,15.,17.,19.,21.,23.,25.,27.,29.5,32.5,35.5,38.5,42.,46.,50.,54.5,59.5,
-     64.5,59.5,64.5,69.5,74.5,79.5,84.5,89.5,94.5,99.5,104.5,109.5,114.5,119.5,
-     124.5,129.5,137.,147.,157.,167.,177.,187.,197.,209.5,224.5,239.5,254.5,272.,
-     292.,312.,334.5,359.5,384.5,359.5,384.5,409.5,434.5,459.5,484.5,509.5,534.5,
-     559.5,584.5,609.5,634.5,659.5,684.5,709.5,747.,797.,847.,897.,947.,997.,
-     1047.,1109.5,1184.5,1259.5,1334.5,1422.,1522.,1622.,1734.5,1859.5,1984.5,
-     1859.5,1984.5,2109.5,2234.5,2359.5,2484.5,2609.5,2734.5,2859.5,2984.5,
-     3109.5,3234.5,3359.5,3484.5,3609.5,3797.,4047.,4297.,4547.,4797.,5047.,
-     5297.,5609.5,5984.5,6359.5,6734.5,7172.,7672.,8172.,8734.5,9359.5,9984.5};
+  adc2fC = std::vector<float>{
+      -0.5,   0.5,    1.5,    2.5,    3.5,    4.5,    5.5,    6.5,    7.5,    8.5,    9.5,    10.5,   11.5,
+      12.5,   13.5,   15.,    17.,    19.,    21.,    23.,    25.,    27.,    29.5,   32.5,   35.5,   38.5,
+      42.,    46.,    50.,    54.5,   59.5,   64.5,   59.5,   64.5,   69.5,   74.5,   79.5,   84.5,   89.5,
+      94.5,   99.5,   104.5,  109.5,  114.5,  119.5,  124.5,  129.5,  137.,   147.,   157.,   167.,   177.,
+      187.,   197.,   209.5,  224.5,  239.5,  254.5,  272.,   292.,   312.,   334.5,  359.5,  384.5,  359.5,
+      384.5,  409.5,  434.5,  459.5,  484.5,  509.5,  534.5,  559.5,  584.5,  609.5,  634.5,  659.5,  684.5,
+      709.5,  747.,   797.,   847.,   897.,   947.,   997.,   1047.,  1109.5, 1184.5, 1259.5, 1334.5, 1422.,
+      1522.,  1622.,  1734.5, 1859.5, 1984.5, 1859.5, 1984.5, 2109.5, 2234.5, 2359.5, 2484.5, 2609.5, 2734.5,
+      2859.5, 2984.5, 3109.5, 3234.5, 3359.5, 3484.5, 3609.5, 3797.,  4047.,  4297.,  4547.,  4797.,  5047.,
+      5297.,  5609.5, 5984.5, 6359.5, 6734.5, 7172.,  7672.,  8172.,  8734.5, 9359.5, 9984.5};
 
   // adc -> fC for qie10, for laser monitor
   // Taken from page 3 in
   // https://cms-docdb.cern.ch/cgi-bin/DocDB/RetrieveFile?docid=12570&filename=QIE10_final.pdf&version=5
-  adc2fCHF = std::vector<float> {
-    // - - - - - - - range 0 - - - - - - - -
-  //subrange0
-  1.58, 4.73, 7.88, 11.0, 14.2, 17.3, 20.5, 23.6,
-  26.8, 29.9, 33.1, 36.2, 39.4, 42.5, 45.7, 48.8,
-  //subrange1
-  53.6, 60.1, 66.6, 73.0, 79.5, 86.0, 92.5, 98.9,
-  105, 112, 118, 125, 131, 138, 144, 151,
-  //subrange2
-  157, 164, 170, 177, 186, 199, 212, 225,
-  238, 251, 264, 277, 289, 302, 315, 328,
-  //subrange3
-  341, 354, 367, 380, 393, 406, 418, 431,
-  444, 464, 490, 516, 542, 568, 594, 620,
+  adc2fCHF = std::vector<float>{// - - - - - - - range 0 - - - - - - - -
+                                //subrange0
+                                1.58,
+                                4.73,
+                                7.88,
+                                11.0,
+                                14.2,
+                                17.3,
+                                20.5,
+                                23.6,
+                                26.8,
+                                29.9,
+                                33.1,
+                                36.2,
+                                39.4,
+                                42.5,
+                                45.7,
+                                48.8,
+                                //subrange1
+                                53.6,
+                                60.1,
+                                66.6,
+                                73.0,
+                                79.5,
+                                86.0,
+                                92.5,
+                                98.9,
+                                105,
+                                112,
+                                118,
+                                125,
+                                131,
+                                138,
+                                144,
+                                151,
+                                //subrange2
+                                157,
+                                164,
+                                170,
+                                177,
+                                186,
+                                199,
+                                212,
+                                225,
+                                238,
+                                251,
+                                264,
+                                277,
+                                289,
+                                302,
+                                315,
+                                328,
+                                //subrange3
+                                341,
+                                354,
+                                367,
+                                380,
+                                393,
+                                406,
+                                418,
+                                431,
+                                444,
+                                464,
+                                490,
+                                516,
+                                542,
+                                568,
+                                594,
+                                620,
 
-  // - - - - - - - range 1 - - - - - - - -
-  //subrange0
-  569, 594, 619, 645, 670, 695, 720, 745,
-  771, 796, 821, 846, 871, 897, 922, 947,
-  //subrange1
-  960, 1010, 1060, 1120, 1170, 1220, 1270, 1320,
-  1370, 1430, 1480, 1530, 1580, 1630, 1690, 1740,
-  //subrange2
-  1790, 1840, 1890, 1940,  2020, 2120, 2230, 2330,
-  2430, 2540, 2640, 2740, 2850, 2950, 3050, 3150,
-  //subrange3
-  3260, 3360, 3460, 3570, 3670, 3770, 3880, 3980,
-  4080, 4240, 4450, 4650, 4860, 5070, 5280, 5490,
+                                // - - - - - - - range 1 - - - - - - - -
+                                //subrange0
+                                569,
+                                594,
+                                619,
+                                645,
+                                670,
+                                695,
+                                720,
+                                745,
+                                771,
+                                796,
+                                821,
+                                846,
+                                871,
+                                897,
+                                922,
+                                947,
+                                //subrange1
+                                960,
+                                1010,
+                                1060,
+                                1120,
+                                1170,
+                                1220,
+                                1270,
+                                1320,
+                                1370,
+                                1430,
+                                1480,
+                                1530,
+                                1580,
+                                1630,
+                                1690,
+                                1740,
+                                //subrange2
+                                1790,
+                                1840,
+                                1890,
+                                1940,
+                                2020,
+                                2120,
+                                2230,
+                                2330,
+                                2430,
+                                2540,
+                                2640,
+                                2740,
+                                2850,
+                                2950,
+                                3050,
+                                3150,
+                                //subrange3
+                                3260,
+                                3360,
+                                3460,
+                                3570,
+                                3670,
+                                3770,
+                                3880,
+                                3980,
+                                4080,
+                                4240,
+                                4450,
+                                4650,
+                                4860,
+                                5070,
+                                5280,
+                                5490,
 
-  // - - - - - - - range 2 - - - - - - - -
-  //subrange0
-  5080, 5280, 5480, 5680, 5880, 6080, 6280, 6480,
-  6680, 6890, 7090, 7290, 7490, 7690, 7890, 8090,
-  //subrange1
-  8400, 8810, 9220, 9630, 10000, 10400, 10900, 11300,
-  11700, 12100, 12500, 12900, 13300, 13700, 14100, 14500,
-  //subrange2
-  15000, 15400, 15800, 16200, 16800, 17600, 18400, 19300,
-  20100, 20900, 21700, 22500, 23400, 24200, 25000, 25800,
-  //subrange3
-  26600, 27500, 28300, 29100, 29900, 30700, 31600, 32400,
-  33200, 34400, 36100, 37700, 39400, 41000, 42700, 44300,
+                                // - - - - - - - range 2 - - - - - - - -
+                                //subrange0
+                                5080,
+                                5280,
+                                5480,
+                                5680,
+                                5880,
+                                6080,
+                                6280,
+                                6480,
+                                6680,
+                                6890,
+                                7090,
+                                7290,
+                                7490,
+                                7690,
+                                7890,
+                                8090,
+                                //subrange1
+                                8400,
+                                8810,
+                                9220,
+                                9630,
+                                10000,
+                                10400,
+                                10900,
+                                11300,
+                                11700,
+                                12100,
+                                12500,
+                                12900,
+                                13300,
+                                13700,
+                                14100,
+                                14500,
+                                //subrange2
+                                15000,
+                                15400,
+                                15800,
+                                16200,
+                                16800,
+                                17600,
+                                18400,
+                                19300,
+                                20100,
+                                20900,
+                                21700,
+                                22500,
+                                23400,
+                                24200,
+                                25000,
+                                25800,
+                                //subrange3
+                                26600,
+                                27500,
+                                28300,
+                                29100,
+                                29900,
+                                30700,
+                                31600,
+                                32400,
+                                33200,
+                                34400,
+                                36100,
+                                37700,
+                                39400,
+                                41000,
+                                42700,
+                                44300,
 
-  // - - - - - - - range 3 - - - - - - - - -
-  //subrange0
-  41100, 42700, 44300, 45900, 47600, 49200, 50800, 52500,
-  54100, 55700, 57400, 59000, 60600, 62200, 63900, 65500,
-  //subrange1
-  68000, 71300, 74700, 78000, 81400, 84700, 88000, 91400,
-  94700, 98100, 101000, 105000, 108000, 111000, 115000, 118000,
-  //subrange2
-  121000, 125000, 128000, 131000, 137000, 145000, 152000, 160000,
-  168000, 176000, 183000, 191000, 199000, 206000, 214000, 222000,
-  //subrange3
-  230000, 237000, 245000, 253000, 261000, 268000, 276000, 284000,
-  291000, 302000, 316000, 329000, 343000, 356000, 370000, 384000
-  };
+                                // - - - - - - - range 3 - - - - - - - - -
+                                //subrange0
+                                41100,
+                                42700,
+                                44300,
+                                45900,
+                                47600,
+                                49200,
+                                50800,
+                                52500,
+                                54100,
+                                55700,
+                                57400,
+                                59000,
+                                60600,
+                                62200,
+                                63900,
+                                65500,
+                                //subrange1
+                                68000,
+                                71300,
+                                74700,
+                                78000,
+                                81400,
+                                84700,
+                                88000,
+                                91400,
+                                94700,
+                                98100,
+                                101000,
+                                105000,
+                                108000,
+                                111000,
+                                115000,
+                                118000,
+                                //subrange2
+                                121000,
+                                125000,
+                                128000,
+                                131000,
+                                137000,
+                                145000,
+                                152000,
+                                160000,
+                                168000,
+                                176000,
+                                183000,
+                                191000,
+                                199000,
+                                206000,
+                                214000,
+                                222000,
+                                //subrange3
+                                230000,
+                                237000,
+                                245000,
+                                253000,
+                                261000,
+                                268000,
+                                276000,
+                                284000,
+                                291000,
+                                302000,
+                                316000,
+                                329000,
+                                343000,
+                                356000,
+                                370000,
+                                384000};
 
-  hbhedigi_token_      = consumes<HBHEDigiCollection>(edm::InputTag(digiCollName_));
+  hbhedigi_token_ = consumes<HBHEDigiCollection>(edm::InputTag(digiCollName_));
   hcalcalibdigi_token_ = consumes<HcalCalibDigiCollection>(edm::InputTag("hcalDigis"));
-  lasermondigi_token_  = consumes<QIE10DigiCollection>(iConfig.getParameter<edm::InputTag>("lasermonDigis"));
-  hbherechit_token_    = consumes<HBHERecHitCollection>(edm::InputTag(recHitCollName_));
-  calotower_token_     = consumes<CaloTowerCollection>(edm::InputTag(caloTowerCollName_));
-  track_token_         = consumes<reco::TrackCollection>(edm::InputTag(trackCollName_));
+  lasermondigi_token_ = consumes<QIE10DigiCollection>(iConfig.getParameter<edm::InputTag>("lasermonDigis"));
+  hbherechit_token_ = consumes<HBHERecHitCollection>(edm::InputTag(recHitCollName_));
+  calotower_token_ = consumes<CaloTowerCollection>(edm::InputTag(caloTowerCollName_));
+  track_token_ = consumes<reco::TrackCollection>(edm::InputTag(trackCollName_));
 
   // we produce a vector of HcalNoiseRBXs
   produces<HcalNoiseRBXCollection>();
@@ -199,10 +422,7 @@ HcalNoiseInfoProducer::HcalNoiseInfoProducer(const edm::ParameterSet& iConfig) :
   produces<HcalNoiseSummary>();
 }
 
-
-HcalNoiseInfoProducer::~HcalNoiseInfoProducer()
-{
-}
+HcalNoiseInfoProducer::~HcalNoiseInfoProducer() {}
 
 void HcalNoiseInfoProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -267,54 +487,130 @@ void HcalNoiseInfoProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   // define high level noise cuts
   desc.add<double>("hlMaxHPDEMF", -9999.0);
   desc.add<double>("hlMaxRBXEMF", 0.01);
-  
+
   // Calibration digi noise variables (used for finding laser noise events)
-  desc.add<double>("calibdigiHBHEthreshold", 15)->
-      setComment("minimum threshold in fC of any HBHE  \
+  desc.add<double>("calibdigiHBHEthreshold", 15)
+      ->setComment(
+          "minimum threshold in fC of any HBHE  \
               calib digi to be counted in summary");
-  desc.add<std::vector<int>>("calibdigiHBHEtimeslices", {3,4,5,6,})->
-      setComment("time slices to use when determining charge of HBHE calib digis");
-  desc.add<double>("calibdigiHFthreshold", -999)->
-      setComment("minimum threshold in fC of any HF calib digi to be counted in summary");
-  desc.add<std::vector<int>>("calibdigiHFtimeslices", {0,1,2,3,4,5,6,7,8,9,})->
-      setComment("time slices to use when determining charge of HF calib digis");
+  desc.add<std::vector<int>>("calibdigiHBHEtimeslices",
+                             {
+                                 3,
+                                 4,
+                                 5,
+                                 6,
+                             })
+      ->setComment("time slices to use when determining charge of HBHE calib digis");
+  desc.add<double>("calibdigiHFthreshold", -999)
+      ->setComment("minimum threshold in fC of any HF calib digi to be counted in summary");
+  desc.add<std::vector<int>>("calibdigiHFtimeslices",
+                             {
+                                 0,
+                                 1,
+                                 2,
+                                 3,
+                                 4,
+                                 5,
+                                 6,
+                                 7,
+                                 8,
+                                 9,
+                             })
+      ->setComment("time slices to use when determining charge of HF calib digis");
 
   // RBX-wide TS4TS5 variable
   desc.add<double>("TS4TS5EnergyThreshold", 50);
-  desc.add<std::vector<double>>("TS4TS5UpperThreshold", {70,90,100,400,4000,});
-  desc.add<std::vector<double>>("TS4TS5UpperCut", {1,0.8,0.75,0.72,0.72,});
-  desc.add<std::vector<double>>("TS4TS5LowerThreshold", {100,120,150,200,300,400,500,});
-  desc.add<std::vector<double>>("TS4TS5LowerCut", {-1,-0.7,-0.4,-0.2,-0.08,0,0.1,});
+  desc.add<std::vector<double>>("TS4TS5UpperThreshold",
+                                {
+                                    70,
+                                    90,
+                                    100,
+                                    400,
+                                    4000,
+                                });
+  desc.add<std::vector<double>>("TS4TS5UpperCut",
+                                {
+                                    1,
+                                    0.8,
+                                    0.75,
+                                    0.72,
+                                    0.72,
+                                });
+  desc.add<std::vector<double>>("TS4TS5LowerThreshold",
+                                {
+                                    100,
+                                    120,
+                                    150,
+                                    200,
+                                    300,
+                                    400,
+                                    500,
+                                });
+  desc.add<std::vector<double>>("TS4TS5LowerCut",
+                                {
+                                    -1,
+                                    -0.7,
+                                    -0.4,
+                                    -0.2,
+                                    -0.08,
+                                    0,
+                                    0.1,
+                                });
 
   // rechit R45 population filter variables
   // this comes in groups of four: (a_Count, a_Fraction, a_EnergyFraction, const)
   // flag as noise if (count * a_count + fraction * a_fraction + energyfraction * a_energyfraction + const) > 0
-  desc.add<std::vector<double>>("lRBXRecHitR45Cuts", 
-                                {0.0,1.0,0.0,-0.5,0.0,0.0,1.0,-0.5,})->
-      setComment("first 4 entries : equivalent to 'fraction > 0.5'  \
+  desc.add<std::vector<double>>("lRBXRecHitR45Cuts",
+                                {
+                                    0.0,
+                                    1.0,
+                                    0.0,
+                                    -0.5,
+                                    0.0,
+                                    0.0,
+                                    1.0,
+                                    -0.5,
+                                })
+      ->setComment(
+          "first 4 entries : equivalent to 'fraction > 0.5'  \
                   last 4 entries : equivalent to 'energy fraction > 0.5'");
-  desc.add<std::vector<double>>("tRBXRecHitR45Cuts", 
-                                {0.0,1.0,0.0,-0.2,0.0,0.0,1.0,-0.2,})->
-      setComment("first 4 entries : equivalent to 'fraction > 0.2' \
-                  last 4 entries : equivalent to 'energy fraction > 0.2'" );
+  desc.add<std::vector<double>>("tRBXRecHitR45Cuts",
+                                {
+                                    0.0,
+                                    1.0,
+                                    0.0,
+                                    -0.2,
+                                    0.0,
+                                    0.0,
+                                    1.0,
+                                    -0.2,
+                                })
+      ->setComment(
+          "first 4 entries : equivalent to 'fraction > 0.2' \
+                  last 4 entries : equivalent to 'energy fraction > 0.2'");
 
   // define the channels used for laser monitoring
   // note that the order here indicates the time order
   // of the channels
-  desc.add<std::vector<int>>("laserMonCBoxList", {5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,})->
-      setComment("time ordered list of the cBox values of laser monitor channels");
-  desc.add<std::vector<int>>("laserMonIPhiList", {23,22,21,20,19,18,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0})->
-      setComment("time ordered list of the iPhi values of laser monitor channels");
-  desc.add<std::vector<int>>("laserMonIEtaList", {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,})->
-      setComment("time ordered list of the iEta values of laser monitor channels");
+  desc.add<std::vector<int>>("laserMonCBoxList",
+                             {
+                                 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+                             })
+      ->setComment("time ordered list of the cBox values of laser monitor channels");
+  desc.add<std::vector<int>>("laserMonIPhiList",
+                             {23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0})
+      ->setComment("time ordered list of the iPhi values of laser monitor channels");
+  desc.add<std::vector<int>>("laserMonIEtaList",
+                             {
+                                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                             })
+      ->setComment("time ordered list of the iEta values of laser monitor channels");
 
   // boundaries for total charge integration
-  desc.add<int>("laserMonTSStart", 0)->
-      setComment("lower bound of laser monitor charge integration window");
-  desc.add<int>("laserMonTSEnd", -1)->
-      setComment("upper bound of laser monitor charge integration window (-1 = no bound)");
-  desc.add<unsigned>("laserMonSamples", 4)->
-      setComment("Number of laser monitor samples to take per channel");
+  desc.add<int>("laserMonTSStart", 0)->setComment("lower bound of laser monitor charge integration window");
+  desc.add<int>("laserMonTSEnd", -1)
+      ->setComment("upper bound of laser monitor charge integration window (-1 = no bound)");
+  desc.add<unsigned>("laserMonSamples", 4)->setComment("Number of laser monitor samples to take per channel");
 
   // what to fill
   desc.add<bool>("fillDigis", true);
@@ -326,11 +622,12 @@ void HcalNoiseInfoProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   // maximum number of RBXs to fill
   // if you want to record all RBXs above some energy threshold,
   // change maxProblemRBXs to 999 and pMinE (above) to the threshold you want
-  desc.add<int>("maxProblemRBXs", 72)->
-      setComment("maximum number of RBXs to fill.  if you want to record  \
+  desc.add<int>("maxProblemRBXs", 72)
+      ->setComment(
+          "maximum number of RBXs to fill.  if you want to record  \
               all RBXs above some energy threshold,change maxProblemRBXs to  \
               999 and pMinE (above) to the threshold you want");
-;
+  ;
 
   // parameters for calculating summary variables
   desc.add<int>("maxCaloTowerIEta", 20);
@@ -345,19 +642,28 @@ void HcalNoiseInfoProducer::fillDescriptions(edm::ConfigurationDescriptions& des
   desc.add<std::string>("caloTowerCollName", "towerMaker");
   desc.add<std::string>("trackCollName", "generalTracks");
   desc.add<std::string>("jetCollName", "ak4PFJets");
-  desc.add<edm::InputTag>("lasermonDigis", edm::InputTag( "hcalDigis", "LASERMON"));
+  desc.add<edm::InputTag>("lasermonDigis", edm::InputTag("hcalDigis", "LASERMON"));
 
   // severity level
   desc.add<unsigned int>("HcalAcceptSeverityLevel", 9);
 
-  // which hcal calo flags to mask 
-  // (HBHEIsolatedNoise=11, HBHEFlatNoise=12, HBHESpikeNoise=13, 
+  // which hcal calo flags to mask
+  // (HBHEIsolatedNoise=11, HBHEFlatNoise=12, HBHESpikeNoise=13,
   // HBHETriangleNoise=14, HBHETS4TS5Noise=15, HBHENegativeNoise=27)
-  desc.add<std::vector<int>>("HcalRecHitFlagsToBeExcluded", {11,12,13,14,15,27,})->
-      setComment("which hcal calo flags to mask (HBHEIsolatedNoise=11, \
+  desc.add<std::vector<int>>("HcalRecHitFlagsToBeExcluded",
+                             {
+                                 11,
+                                 12,
+                                 13,
+                                 14,
+                                 15,
+                                 27,
+                             })
+      ->setComment(
+          "which hcal calo flags to mask (HBHEIsolatedNoise=11, \
                   HBHEFlatNoise=12, HBHESpikeNoise=13, \
                   HBHETriangleNoise=14, HBHETS4TS5Noise=15, HBHENegativeNoise=27)");
-;
+  ;
 
   descriptions.add("hcalnoise", desc);
 }
@@ -367,197 +673,214 @@ void HcalNoiseInfoProducer::fillDescriptions(edm::ConfigurationDescriptions& des
 //
 
 // ------------ method called to produce the data  ------------
-void
-HcalNoiseInfoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void HcalNoiseInfoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   // this is what we're going to actually write to the EDM
   auto result1 = std::make_unique<HcalNoiseRBXCollection>();
   auto result2 = std::make_unique<HcalNoiseSummary>();
 
   // define an empty HcalNoiseRBXArray that we're going to fill
   HcalNoiseRBXArray rbxarray;
-  HcalNoiseSummary &summary=*result2;
+  HcalNoiseSummary& summary = *result2;
 
   // Get topology class to use later
   edm::ESHandle<HcalTopology> topo;
   iSetup.get<HcalRecNumberingRecord>().get(topo);
   theHcalTopology_ = topo.product();
-  
+
   // fill them with the various components
   // digi assumes that rechit information is available
-  if(fillRecHits_)    fillrechits(iEvent, iSetup, rbxarray, summary);
-  if(fillDigis_)      filldigis(iEvent, iSetup, rbxarray, summary);
-  if(fillCaloTowers_) fillcalotwrs(iEvent, iSetup, rbxarray, summary);
-  if(fillTracks_)     filltracks(iEvent, iSetup, summary);
+  if (fillRecHits_)
+    fillrechits(iEvent, iSetup, rbxarray, summary);
+  if (fillDigis_)
+    filldigis(iEvent, iSetup, rbxarray, summary);
+  if (fillCaloTowers_)
+    fillcalotwrs(iEvent, iSetup, rbxarray, summary);
+  if (fillTracks_)
+    filltracks(iEvent, iSetup, summary);
 
   filljetinfo(iEvent, iSetup, summary);
 
   // select those RBXs which are interesting
   // also look for the highest energy RBX
-  HcalNoiseRBXArray::iterator maxit=rbxarray.begin();
-  double maxenergy=-999;
-  bool maxwritten=false;
-  for(HcalNoiseRBXArray::iterator rit = rbxarray.begin(); rit!=rbxarray.end(); ++rit) {
-    HcalNoiseRBX &rbx=(*rit);
-    CommonHcalNoiseRBXData data(rbx, minRecHitE_, minLowHitE_, minHighHitE_, TS4TS5EnergyThreshold_,
-      TS4TS5UpperCut_, TS4TS5LowerCut_, minR45HitE_);
+  HcalNoiseRBXArray::iterator maxit = rbxarray.begin();
+  double maxenergy = -999;
+  bool maxwritten = false;
+  for (HcalNoiseRBXArray::iterator rit = rbxarray.begin(); rit != rbxarray.end(); ++rit) {
+    HcalNoiseRBX& rbx = (*rit);
+    CommonHcalNoiseRBXData data(rbx,
+                                minRecHitE_,
+                                minLowHitE_,
+                                minHighHitE_,
+                                TS4TS5EnergyThreshold_,
+                                TS4TS5UpperCut_,
+                                TS4TS5LowerCut_,
+                                minR45HitE_);
 
     // find the highest energy rbx
-    if(data.energy()>maxenergy) {
-      maxenergy=data.energy();
-      maxit=rit;
-      maxwritten=false;
+    if (data.energy() > maxenergy) {
+      maxenergy = data.energy();
+      maxit = rit;
+      maxwritten = false;
     }
 
     // find out if the rbx is problematic/noisy/etc.
     bool writerbx = algo_.isProblematic(data) || !algo_.passLooseNoiseFilter(data) ||
-      !algo_.passTightNoiseFilter(data) || !algo_.passHighLevelNoiseFilter(data);
+                    !algo_.passTightNoiseFilter(data) || !algo_.passHighLevelNoiseFilter(data);
 
     // fill variables in the summary object not filled elsewhere
     fillOtherSummaryVariables(summary, data);
 
-    if(writerbx) {
+    if (writerbx) {
       summary.nproblemRBXs_++;
-      if(summary.nproblemRBXs_<=maxProblemRBXs_) {
-	result1->push_back(rbx);
-	if(maxit==rit) maxwritten=true;
+      if (summary.nproblemRBXs_ <= maxProblemRBXs_) {
+        result1->push_back(rbx);
+        if (maxit == rit)
+          maxwritten = true;
       }
     }
-  } // end loop over rbxs
+  }  // end loop over rbxs
 
   // if we still haven't written the maximum energy rbx, write it now
-  if(!maxwritten) {
-    HcalNoiseRBX &rbx=(*maxit);
+  if (!maxwritten) {
+    HcalNoiseRBX& rbx = (*maxit);
 
     // add the RBX to the event
     result1->push_back(rbx);
   }
-  
+
   // put the rbxcollection and summary into the EDM
   iEvent.put(std::move(result1));
   iEvent.put(std::move(result2));
-  
+
   return;
 }
 
-
 // ------------ here we fill specific variables in the summary object not already accounted for earlier
-void
-HcalNoiseInfoProducer::fillOtherSummaryVariables(HcalNoiseSummary& summary, const CommonHcalNoiseRBXData& data) const
-{
+void HcalNoiseInfoProducer::fillOtherSummaryVariables(HcalNoiseSummary& summary,
+                                                      const CommonHcalNoiseRBXData& data) const {
   // charge ratio
-  if(algo_.passRatioThreshold(data) && data.validRatio()) {
-    if(data.ratio()<summary.minE2Over10TS()) {
+  if (algo_.passRatioThreshold(data) && data.validRatio()) {
+    if (data.ratio() < summary.minE2Over10TS()) {
       summary.mine2ts_ = data.e2ts();
-      summary.mine10ts_ = data.e10ts();    }
-    if(data.ratio()>summary.maxE2Over10TS()) {
+      summary.mine10ts_ = data.e10ts();
+    }
+    if (data.ratio() > summary.maxE2Over10TS()) {
       summary.maxe2ts_ = data.e2ts();
       summary.maxe10ts_ = data.e10ts();
     }
   }
 
   // ADC zeros
-  if(algo_.passZerosThreshold(data)) {
-    if(data.numZeros()>summary.maxZeros()) {
+  if (algo_.passZerosThreshold(data)) {
+    if (data.numZeros() > summary.maxZeros()) {
       summary.maxzeros_ = data.numZeros();
     }
   }
 
   // hits count
-  if(data.numHPDHits() > summary.maxHPDHits()) {
+  if (data.numHPDHits() > summary.maxHPDHits()) {
     summary.maxhpdhits_ = data.numHPDHits();
   }
-  if(data.numRBXHits() > summary.maxRBXHits()) {
+  if (data.numRBXHits() > summary.maxRBXHits()) {
     summary.maxrbxhits_ = data.numRBXHits();
   }
-  if(data.numHPDNoOtherHits() > summary.maxHPDNoOtherHits()) {
+  if (data.numHPDNoOtherHits() > summary.maxHPDNoOtherHits()) {
     summary.maxhpdhitsnoother_ = data.numHPDNoOtherHits();
   }
 
   // TS4TS5
-  if(data.PassTS4TS5() == false)
-     summary.hasBadRBXTS4TS5_ = true;
+  if (data.PassTS4TS5() == false)
+    summary.hasBadRBXTS4TS5_ = true;
 
-  if(algo_.passLooseRBXRechitR45(data) == false)
-     summary.hasBadRBXRechitR45Loose_ = true;
-  if(algo_.passTightRBXRechitR45(data) == false)
-     summary.hasBadRBXRechitR45Tight_ = true;
+  if (algo_.passLooseRBXRechitR45(data) == false)
+    summary.hasBadRBXRechitR45Loose_ = true;
+  if (algo_.passTightRBXRechitR45(data) == false)
+    summary.hasBadRBXRechitR45Tight_ = true;
 
   // hit timing
-  if(data.minLowEHitTime()<summary.min10GeVHitTime()) {
+  if (data.minLowEHitTime() < summary.min10GeVHitTime()) {
     summary.min10_ = data.minLowEHitTime();
   }
-  if(data.maxLowEHitTime()>summary.max10GeVHitTime()) {
+  if (data.maxLowEHitTime() > summary.max10GeVHitTime()) {
     summary.max10_ = data.maxLowEHitTime();
   }
   summary.rms10_ += data.lowEHitTimeSqrd();
   summary.cnthit10_ += data.numLowEHits();
-  if(data.minHighEHitTime()<summary.min25GeVHitTime()) {
+  if (data.minHighEHitTime() < summary.min25GeVHitTime()) {
     summary.min25_ = data.minHighEHitTime();
   }
-  if(data.maxHighEHitTime()>summary.max25GeVHitTime()) {
+  if (data.maxHighEHitTime() > summary.max25GeVHitTime()) {
     summary.max25_ = data.maxHighEHitTime();
   }
   summary.rms25_ += data.highEHitTimeSqrd();
   summary.cnthit25_ += data.numHighEHits();
 
   // EMF
-  if(algo_.passEMFThreshold(data)) {
-    if(summary.minHPDEMF() > data.HPDEMF()) {
+  if (algo_.passEMFThreshold(data)) {
+    if (summary.minHPDEMF() > data.HPDEMF()) {
       summary.minhpdemf_ = data.HPDEMF();
     }
-    if(summary.minRBXEMF() > data.RBXEMF()) {
+    if (summary.minRBXEMF() > data.RBXEMF()) {
       summary.minrbxemf_ = data.RBXEMF();
     }
   }
 
   // summary flag
-  if(!algo_.passLooseRatio(data))  summary.filterstatus_ |= 0x1;
-  if(!algo_.passLooseHits(data))   summary.filterstatus_ |= 0x2;
-  if(!algo_.passLooseZeros(data))  summary.filterstatus_ |= 0x4;
-  if(!algo_.passLooseTiming(data)) summary.filterstatus_ |= 0x8;
+  if (!algo_.passLooseRatio(data))
+    summary.filterstatus_ |= 0x1;
+  if (!algo_.passLooseHits(data))
+    summary.filterstatus_ |= 0x2;
+  if (!algo_.passLooseZeros(data))
+    summary.filterstatus_ |= 0x4;
+  if (!algo_.passLooseTiming(data))
+    summary.filterstatus_ |= 0x8;
 
-  if(!algo_.passTightRatio(data))  summary.filterstatus_ |= 0x100;
-  if(!algo_.passTightHits(data))   summary.filterstatus_ |= 0x200;
-  if(!algo_.passTightZeros(data))  summary.filterstatus_ |= 0x400;
-  if(!algo_.passTightTiming(data)) summary.filterstatus_ |= 0x800;
+  if (!algo_.passTightRatio(data))
+    summary.filterstatus_ |= 0x100;
+  if (!algo_.passTightHits(data))
+    summary.filterstatus_ |= 0x200;
+  if (!algo_.passTightZeros(data))
+    summary.filterstatus_ |= 0x400;
+  if (!algo_.passTightTiming(data))
+    summary.filterstatus_ |= 0x800;
 
-  if(!algo_.passHighLevelNoiseFilter(data)) summary.filterstatus_ |= 0x10000;
+  if (!algo_.passHighLevelNoiseFilter(data))
+    summary.filterstatus_ |= 0x10000;
 
   // summary refvectors
   JoinCaloTowerRefVectorsWithoutDuplicates join;
-  if(!algo_.passLooseNoiseFilter(data))
+  if (!algo_.passLooseNoiseFilter(data))
     join(summary.loosenoisetwrs_, data.rbxTowers());
-  if(!algo_.passTightNoiseFilter(data))
+  if (!algo_.passTightNoiseFilter(data))
     join(summary.tightnoisetwrs_, data.rbxTowers());
-  if(!algo_.passHighLevelNoiseFilter(data))
+  if (!algo_.passHighLevelNoiseFilter(data))
     join(summary.hlnoisetwrs_, data.rbxTowers());
 
   return;
 }
 
-
 // ------------ fill the array with digi information
-void
-HcalNoiseInfoProducer::filldigis(edm::Event& iEvent, const edm::EventSetup& iSetup, HcalNoiseRBXArray& array, HcalNoiseSummary& summary)
-{
+void HcalNoiseInfoProducer::filldigis(edm::Event& iEvent,
+                                      const edm::EventSetup& iSetup,
+                                      HcalNoiseRBXArray& array,
+                                      HcalNoiseSummary& summary) {
   // Some initialization
   totalCalibCharge = 0;
   totalLasmonCharge = 0;
 
   // Starting with this version (updated by Jeff Temple on Dec. 6, 2012), the "TS45" names in the variables are mis-nomers.  The actual time slices used are determined from the digiTimeSlices_ variable, which may not be limited to only time slices 4 and 5.  For now, "TS45" name kept, because that is what is used in HcalNoiseSummary object (in GetCalibCountTS45, etc.).  Likewise, the charge value in 'gt15' is now configurable, though the name remains the same.  For HBHE, we track both the number of calibration channels (NcalibTS45) and the number of calibration channels above threshold (NcalibTS45gt15).  For HF, we track only the number of channels above the given threshold in the given time window (NcalibHFgtX).  Default for HF in 2012 is to use the full time sample with effectively no threshold (threshold=-999)
-  int NcalibTS45=0;
-  int NcalibTS45gt15=0;
-  int NcalibHFgtX=0;
+  int NcalibTS45 = 0;
+  int NcalibTS45gt15 = 0;
+  int NcalibHFgtX = 0;
 
-  double chargecalibTS45=0;
-  double chargecalibgt15TS45=0;
+  double chargecalibTS45 = 0;
+  double chargecalibgt15TS45 = 0;
 
   // get the conditions and channel quality
   edm::ESHandle<HcalDbService> conditions;
   iSetup.get<HcalDbRecord>().get(conditions);
   edm::ESHandle<HcalChannelQuality> qualhandle;
-  iSetup.get<HcalChannelQualityRcd>().get("withTopo",qualhandle);
+  iSetup.get<HcalChannelQualityRcd>().get("withTopo", qualhandle);
   const HcalChannelQuality* myqual = qualhandle.product();
   edm::ESHandle<HcalSeverityLevelComputer> mycomputer;
   iSetup.get<HcalSeverityLevelComputerRcd>().get(mycomputer);
@@ -568,73 +891,81 @@ HcalNoiseInfoProducer::filldigis(edm::Event& iEvent, const edm::EventSetup& iSet
   //  iEvent.getByLabel(digiCollName_, handle);
   iEvent.getByToken(hbhedigi_token_, handle);
 
-  if(!handle.isValid()) {
-    throw edm::Exception(edm::errors::ProductNotFound) << " could not find HBHEDigiCollection named " << digiCollName_ << "\n.";
+  if (!handle.isValid()) {
+    throw edm::Exception(edm::errors::ProductNotFound)
+        << " could not find HBHEDigiCollection named " << digiCollName_ << "\n.";
     return;
   }
 
   // loop over all of the digi information
-  for(HBHEDigiCollection::const_iterator it=handle->begin(); it!=handle->end(); ++it) {
-    const HBHEDataFrame &digi=(*it);
+  for (HBHEDigiCollection::const_iterator it = handle->begin(); it != handle->end(); ++it) {
+    const HBHEDataFrame& digi = (*it);
     HcalDetId cell = digi.id();
-    DetId detcell=(DetId)cell;
+    DetId detcell = (DetId)cell;
 
     // check on cells to be ignored and dropped
-    const HcalChannelStatus* mydigistatus=myqual->getValues(detcell.rawId());
-    if(mySeverity->dropChannel(mydigistatus->getValue())) continue;
-    if(digi.zsMarkAndPass()) continue;
+    const HcalChannelStatus* mydigistatus = myqual->getValues(detcell.rawId());
+    if (mySeverity->dropChannel(mydigistatus->getValue()))
+      continue;
+    if (digi.zsMarkAndPass())
+      continue;
     // Drop if exclude bit set
-    if (mydigistatus->isBitSet(HcalChannelStatus::HcalCellExcludeFromHBHENoiseSummary)) continue;
-      
+    if (mydigistatus->isBitSet(HcalChannelStatus::HcalCellExcludeFromHBHENoiseSummary))
+      continue;
+
     // get the calibrations and coder
-    const HcalCalibrations& calibrations=conditions->getHcalCalibrations(cell);
-    const HcalQIECoder* channelCoder = conditions->getHcalCoder (cell);
+    const HcalCalibrations& calibrations = conditions->getHcalCalibrations(cell);
+    const HcalQIECoder* channelCoder = conditions->getHcalCoder(cell);
     const HcalQIEShape* shape = conditions->getHcalShape(channelCoder);
-    HcalCoderDb coder (*channelCoder, *shape);
+    HcalCoderDb coder(*channelCoder, *shape);
 
     // match the digi to an rbx and hpd
-    HcalNoiseRBX &rbx=(*array.findRBX(digi));
-    HcalNoiseHPD &hpd=(*array.findHPD(digi));
+    HcalNoiseRBX& rbx = (*array.findRBX(digi));
+    HcalNoiseHPD& hpd = (*array.findHPD(digi));
 
     // determine if the digi is one the highest energy hits in the HPD
     // this works because the rechits are sorted by energy (see fillrechits() below)
-    bool isBig=false, isBig5=false, isRBX=false;
-    int counter=0;
-    edm::RefVector<HBHERecHitCollection> &rechits=hpd.rechits_;
-    for(edm::RefVector<HBHERecHitCollection>::const_iterator rit=rechits.begin();
-	rit!=rechits.end(); ++rit, ++counter) {
-      const HcalDetId & detid = (*rit)->idFront();
-      if(DetId(detid) == digi.id()) {
-	if(counter==0) isBig=isBig5=true;  // digi is also the highest energy rechit
-	if(counter<5) isBig5=true;         // digi is one of 5 highest energy rechits
-	isRBX=true;
+    bool isBig = false, isBig5 = false, isRBX = false;
+    int counter = 0;
+    edm::RefVector<HBHERecHitCollection>& rechits = hpd.rechits_;
+    for (edm::RefVector<HBHERecHitCollection>::const_iterator rit = rechits.begin(); rit != rechits.end();
+         ++rit, ++counter) {
+      const HcalDetId& detid = (*rit)->idFront();
+      if (DetId(detid) == digi.id()) {
+        if (counter == 0)
+          isBig = isBig5 = true;  // digi is also the highest energy rechit
+        if (counter < 5)
+          isBig5 = true;  // digi is one of 5 highest energy rechits
+        isRBX = true;
       }
     }
 
     // loop over each of the digi's time slices
-    int totalzeros=0;
+    int totalzeros = 0;
     CaloSamples tool;
-    coder.adc2fC(digi,tool);
-    for(int ts=0; ts<tool.size(); ++ts) {
-
+    coder.adc2fC(digi, tool);
+    for (int ts = 0; ts < tool.size(); ++ts) {
       // count zero's
-      if(digi[ts].adc()==0) {
-	++hpd.totalZeros_;
-	++totalzeros;
+      if (digi[ts].adc() == 0) {
+        ++hpd.totalZeros_;
+        ++totalzeros;
       }
 
       // get the fC's
-      double corrfc = tool[ts]-calibrations.pedestal(digi[ts].capid());
+      double corrfc = tool[ts] - calibrations.pedestal(digi[ts].capid());
 
       // fill the relevant digi arrays
-      if(isBig)  hpd.bigCharge_[ts]+=corrfc;
-      if(isBig5) hpd.big5Charge_[ts]+=corrfc;
-      if(isRBX)  rbx.allCharge_[ts]+=corrfc;
+      if (isBig)
+        hpd.bigCharge_[ts] += corrfc;
+      if (isBig5)
+        hpd.big5Charge_[ts] += corrfc;
+      if (isRBX)
+        rbx.allCharge_[ts] += corrfc;
     }
 
     // record the maximum number of zero's found
-    if(totalzeros>hpd.maxZeros_)
-      hpd.maxZeros_=totalzeros;
+    if (totalzeros > hpd.maxZeros_)
+      hpd.maxZeros_ = totalzeros;
   }
 
   // get the calibration digis
@@ -642,125 +973,117 @@ HcalNoiseInfoProducer::filldigis(edm::Event& iEvent, const edm::EventSetup& iSet
   //  iEvent.getByLabel("hcalDigis", hCalib);
   iEvent.getByToken(hcalcalibdigi_token_, hCalib);
 
-
   // get the lasermon digis
   edm::Handle<QIE10DigiCollection> hLasermon;
   iEvent.getByToken(lasermondigi_token_, hLasermon);
 
   // get total charge in calibration channels
-  if(hCalib.isValid() == true)
-  {
+  if (hCalib.isValid() == true) {
+    for (HcalCalibDigiCollection::const_iterator digi = hCalib->begin(); digi != hCalib->end(); digi++) {
+      if (digi->id().hcalSubdet() == 0)
+        continue;
 
-     for(HcalCalibDigiCollection::const_iterator digi = hCalib->begin(); digi != hCalib->end(); digi++)
-     {
-        if(digi->id().hcalSubdet() == 0)
-           continue;
+      for (unsigned i = 0; i < (unsigned)digi->size(); i++)
+        totalCalibCharge = totalCalibCharge + adc2fC[digi->sample(i).adc() & 0xff];
 
+      HcalCalibDetId myid = (HcalCalibDetId)digi->id();
+      if (myid.calibFlavor() == HcalCalibDetId::HOCrosstalk)
+        continue;  // ignore HOCrosstalk channels
+      if (digi->zsMarkAndPass())
+        continue;  // skip "mark-and-pass" channels when computing charge in calib channels
 
-	for(unsigned i = 0; i < (unsigned)digi->size(); i++)
-	  totalCalibCharge = totalCalibCharge + adc2fC[digi->sample(i).adc()&0xff];
-	
+      if (digi->id().hcalSubdet() == HcalForward)  // check HF
+      {
+        double sumChargeHF = 0;
+        for (unsigned int i = 0; i < calibdigiHFtimeslices_.size(); ++i) {
+          // skip unphysical time slices
+          if (calibdigiHFtimeslices_[i] < 0 || calibdigiHFtimeslices_[i] > digi->size())
+            continue;
+          sumChargeHF += adc2fC[digi->sample(calibdigiHFtimeslices_[i]).adc() & 0xff];
+        }
+        if (sumChargeHF > calibdigiHFthreshold_)
+          ++NcalibHFgtX;
+      }                                                                                         // end of HF check
+      else if (digi->id().hcalSubdet() == HcalBarrel || digi->id().hcalSubdet() == HcalEndcap)  // now check HBHE
+      {
+        double sumChargeHBHE = 0;
+        for (unsigned int i = 0; i < calibdigiHBHEtimeslices_.size(); ++i) {
+          // skip unphysical time slices
+          if (calibdigiHBHEtimeslices_[i] < 0 || calibdigiHBHEtimeslices_[i] > digi->size())
+            continue;
+          sumChargeHBHE += adc2fC[digi->sample(calibdigiHBHEtimeslices_[i]).adc() & 0xff];
+        }
+        ++NcalibTS45;
+        chargecalibTS45 += sumChargeHBHE;
+        if (sumChargeHBHE > calibdigiHBHEthreshold_) {
+          ++NcalibTS45gt15;
+          chargecalibgt15TS45 += sumChargeHBHE;
+        }
+      }  // end of HBHE check
+    }    // loop on HcalCalibDigiCollection
 
-	HcalCalibDetId myid=(HcalCalibDetId)digi->id();
-	if ( myid.calibFlavor()==HcalCalibDetId::HOCrosstalk)
-	  continue; // ignore HOCrosstalk channels
-	if(digi->zsMarkAndPass()) continue;  // skip "mark-and-pass" channels when computing charge in calib channels
-
-
-	if (digi->id().hcalSubdet()==HcalForward) // check HF
-	  {
-	    double sumChargeHF=0;
-	    for (unsigned int i=0;i<calibdigiHFtimeslices_.size();++i)
-	      {
-		// skip unphysical time slices
-		if (calibdigiHFtimeslices_[i]<0 || calibdigiHFtimeslices_[i]>digi->size())
-		  continue;
-		sumChargeHF+=adc2fC[digi->sample(calibdigiHFtimeslices_[i]).adc()&0xff];
-	      }
-	    if (sumChargeHF>calibdigiHFthreshold_) ++NcalibHFgtX;
-	  } // end of HF check
-	else if (digi->id().hcalSubdet()==HcalBarrel || digi->id().hcalSubdet()==HcalEndcap) // now check HBHE
-	  {
-            double sumChargeHBHE=0;
-            for (unsigned int i=0;i<calibdigiHBHEtimeslices_.size();++i)
-              {
-                // skip unphysical time slices
-                if (calibdigiHBHEtimeslices_[i]<0 || calibdigiHBHEtimeslices_[i]>digi->size())
-                  continue;
-                sumChargeHBHE+=adc2fC[digi->sample(calibdigiHBHEtimeslices_[i]).adc()&0xff];
-              }
-	    ++NcalibTS45;
-	    chargecalibTS45+=sumChargeHBHE;
-            if (sumChargeHBHE>calibdigiHBHEthreshold_) 
-	      {
-		++NcalibTS45gt15;
-		chargecalibgt15TS45+=sumChargeHBHE;
-	      }
-          } // end of HBHE check
-     } // loop on HcalCalibDigiCollection
-
-  } // if (hCalib.isValid()==true)
-  if( fillLaserMonitor_  && (hLasermon.isValid() == true) ) {
-
+  }  // if (hCalib.isValid()==true)
+  if (fillLaserMonitor_ && (hLasermon.isValid() == true)) {
     int icombts = -1;
     float max_charge = 0;
     int max_ts = -1;
     std::vector<float> comb_charge;
-       
+
     unsigned nch = laserMonCBoxList_.size();
     // loop over channels in the order provided
-    for( unsigned ich = 0; ich < nch; ++ich ) {
+    for (unsigned ich = 0; ich < nch; ++ich) {
       int cboxch = laserMonCBoxList_[ich];
-      int iphi  = laserMonIPhiList_[ich];
-      int ieta  = laserMonIEtaList_[ich];
+      int iphi = laserMonIPhiList_[ich];
+      int ieta = laserMonIEtaList_[ich];
 
       // loop over digis, find the digi that matches this channel
-      for(const QIE10DataFrame & df : (*hLasermon)) {
-        HcalCalibDetId calibId( df.id() );
+      for (const QIE10DataFrame& df : (*hLasermon)) {
+        HcalCalibDetId calibId(df.id());
 
         int ch_cboxch = calibId.cboxChannel();
-        int ch_iphi   = calibId.iphi();
-        int ch_ieta   = calibId.ieta();
+        int ch_iphi = calibId.iphi();
+        int ch_ieta = calibId.ieta();
 
-        if( cboxch == ch_cboxch && iphi == ch_iphi && ieta == ch_ieta ) {
-
+        if (cboxch == ch_cboxch && iphi == ch_iphi && ieta == ch_ieta) {
           unsigned ts_size = df.samples();
 
           // loop over time slices
-          for( unsigned its = 0; its < ts_size; ++its ) {
+          for (unsigned its = 0; its < ts_size; ++its) {
             // if we are on the last channel, use all the data
-            // otherwise only take the unique samples 
-            if( ( (ich + 1) < nch )  && its >= laserMonitorSamples_ ) continue;
+            // otherwise only take the unique samples
+            if (((ich + 1) < nch) && its >= laserMonitorSamples_)
+              continue;
 
             bool ok = df[its].ok();
             int adc = df[its].adc();
 
             icombts++;
             // apply integration limits
-            if( icombts < laserMonitorTSStart_ ) continue;
-            if( laserMonitorTSEnd_ > 0 && icombts > laserMonitorTSEnd_ ) continue;
+            if (icombts < laserMonitorTSStart_)
+              continue;
+            if (laserMonitorTSEnd_ > 0 && icombts > laserMonitorTSEnd_)
+              continue;
 
-            if( ok && adc >= 0 ) { // protection against QIE reset or bad ADC values
+            if (ok && adc >= 0) {  // protection against QIE reset or bad ADC values
 
               float charge = adc2fCHF[adc];
-              if( charge > max_charge ) {
-                  max_charge = charge;
-                  max_ts = icombts;
+              if (charge > max_charge) {
+                max_charge = charge;
+                max_ts = icombts;
               }
 
-              comb_charge.push_back( charge );
-            } // if( ok && adc >= 0 ) 
-          } // loop over time slices
-        } // if( cboxch == ch_cboxch && iphi == ch_iphi && ieta == ch_ieta ) 
-      } // loop over digi collection
-    } // loop over channel list
+              comb_charge.push_back(charge);
+            }  // if( ok && adc >= 0 )
+          }    // loop over time slices
+        }      // if( cboxch == ch_cboxch && iphi == ch_iphi && ieta == ch_ieta )
+      }        // loop over digi collection
+    }          // loop over channel list
 
     // do not continue with the calculation
     // if the vector was not filled
-    if( comb_charge.empty() ) { 
+    if (comb_charge.empty()) {
       totalLasmonCharge = -1;
-    }
-    else {
+    } else {
       // integrate from +- 3 TS around the time sample
       // having the maximum charge
       int start_ts = max_ts - 3;
@@ -768,33 +1091,36 @@ HcalNoiseInfoProducer::filldigis(edm::Event& iEvent, const edm::EventSetup& iSet
 
       // Change the integration limits
       // if outside of the range
-      if( start_ts < 0 ) start_ts = 0;
-      if( end_ts >= int(comb_charge.size()) ) end_ts = comb_charge.size() - 1; 
+      if (start_ts < 0)
+        start_ts = 0;
+      if (end_ts >= int(comb_charge.size()))
+        end_ts = comb_charge.size() - 1;
 
-      for( int isum = start_ts; isum <= end_ts; ++isum ) {
-          totalLasmonCharge += comb_charge[isum];
+      for (int isum = start_ts; isum <= end_ts; ++isum) {
+        totalLasmonCharge += comb_charge[isum];
       }
     }
-  } // if( fillLaserMonitor_  && (hLasermon.isValid() == true) )
+  }  // if( fillLaserMonitor_  && (hLasermon.isValid() == true) )
 
   summary.calibCharge_ = totalCalibCharge;
   summary.lasmonCharge_ = totalLasmonCharge;
-  summary.calibCountTS45_=NcalibTS45;
-  summary.calibCountgt15TS45_=NcalibTS45gt15;
-  summary.calibChargeTS45_=chargecalibTS45;
-  summary.calibChargegt15TS45_=chargecalibgt15TS45;
-  summary.calibCountHF_=NcalibHFgtX;
+  summary.calibCountTS45_ = NcalibTS45;
+  summary.calibCountgt15TS45_ = NcalibTS45gt15;
+  summary.calibChargeTS45_ = chargecalibTS45;
+  summary.calibChargegt15TS45_ = chargecalibgt15TS45;
+  summary.calibCountHF_ = NcalibHFgtX;
 
   return;
 }
 
 // ------------ fill the array with rec hit information
-void
-HcalNoiseInfoProducer::fillrechits(edm::Event& iEvent, const edm::EventSetup& iSetup, HcalNoiseRBXArray& array, HcalNoiseSummary& summary) const
-{
+void HcalNoiseInfoProducer::fillrechits(edm::Event& iEvent,
+                                        const edm::EventSetup& iSetup,
+                                        HcalNoiseRBXArray& array,
+                                        HcalNoiseSummary& summary) const {
   // get the HCAL channel status map
   edm::ESHandle<HcalChannelQuality> hcalChStatus;
-  iSetup.get<HcalChannelQualityRcd>().get( "withTopo", hcalChStatus );
+  iSetup.get<HcalChannelQualityRcd>().get("withTopo", hcalChStatus);
   const HcalChannelQuality* dbHcalChStatus = hcalChStatus.product();
 
   // get the severity level computer
@@ -812,9 +1138,9 @@ HcalNoiseInfoProducer::fillrechits(edm::Event& iEvent, const edm::EventSetup& iS
   //  iEvent.getByLabel(recHitCollName_, handle);
   iEvent.getByToken(hbherechit_token_, handle);
 
-  if(!handle.isValid()) {
+  if (!handle.isValid()) {
     throw edm::Exception(edm::errors::ProductNotFound)
-      << " could not find HBHERecHitCollection named " << recHitCollName_ << "\n.";
+        << " could not find HBHERecHitCollection named " << recHitCollName_ << "\n.";
     return;
   }
 
@@ -823,16 +1149,14 @@ HcalNoiseInfoProducer::fillrechits(edm::Event& iEvent, const edm::EventSetup& iS
   summary.rechitEnergy_ = 0;
   summary.rechitEnergy15_ = 0;
 
-  summary.hitsInLaserRegion_=0;
-  summary.hitsInNonLaserRegion_=0;
-  summary.energyInLaserRegion_=0;
-  summary.energyInNonLaserRegion_=0;
-
-
+  summary.hitsInLaserRegion_ = 0;
+  summary.hitsInNonLaserRegion_ = 0;
+  summary.energyInLaserRegion_ = 0;
+  summary.energyInNonLaserRegion_ = 0;
 
   // loop over all of the rechit information
-  for(HBHERecHitCollection::const_iterator it=handle->begin(); it!=handle->end(); ++it) {
-    const HBHERecHit &rechit=(*it);
+  for (HBHERecHitCollection::const_iterator it = handle->begin(); it != handle->end(); ++it) {
+    const HBHERecHit& rechit = (*it);
 
     // skip bad rechits (other than those flagged by the isolated noise, triangle, flat, and spike algorithms)
     const DetId id = rechit.idFront();
@@ -844,114 +1168,120 @@ HcalNoiseInfoProducer::fillrechits(edm::Event& iEvent, const edm::EventSetup& iS
     uint32_t trianglebitset = (1 << HcalCaloFlagLabels::HBHETriangleNoise);
     uint32_t ts4ts5bitset = (1 << HcalCaloFlagLabels::HBHETS4TS5Noise);
     uint32_t negativebitset = (1 << HcalCaloFlagLabels::HBHENegativeNoise);
-    for(unsigned int i=0; i<HcalRecHitFlagsToBeExcluded_.size(); i++) {
+    for (unsigned int i = 0; i < HcalRecHitFlagsToBeExcluded_.size(); i++) {
       uint32_t bitset = (1 << HcalRecHitFlagsToBeExcluded_[i]);
-      recHitFlag = (recHitFlag & bitset) ? recHitFlag-bitset : recHitFlag;
+      recHitFlag = (recHitFlag & bitset) ? recHitFlag - bitset : recHitFlag;
     }
     const HcalChannelStatus* dbStatus = dbHcalChStatus->getValues(id);
 
     // Ignore rechit if exclude bit set, regardless of severity of other bits
-    if (dbStatus->isBitSet(HcalChannelStatus::HcalCellExcludeFromHBHENoiseSummary)) continue;
-      
+    if (dbStatus->isBitSet(HcalChannelStatus::HcalCellExcludeFromHBHENoiseSummary))
+      continue;
+
     int severityLevel = hcalSevLvlComputer->getSeverityLevel(id, recHitFlag, dbStatus->getValue());
-    bool isRecovered  = hcalSevLvlComputer->recoveredRecHit(id, recHitFlag);
-    if(severityLevel!=0 && !isRecovered && severityLevel>static_cast<int>(HcalAcceptSeverityLevel_)) continue;
+    bool isRecovered = hcalSevLvlComputer->recoveredRecHit(id, recHitFlag);
+    if (severityLevel != 0 && !isRecovered && severityLevel > static_cast<int>(HcalAcceptSeverityLevel_))
+      continue;
 
     // do some rechit counting and energies
     summary.rechitCount_ = summary.rechitCount_ + 1;
     summary.rechitEnergy_ = summary.rechitEnergy_ + rechit.eraw();
-    if (dbStatus->isBitSet(HcalChannelStatus::HcalBadLaserSignal)) // hit comes from a region where no laser calibration pulse is normally seen
-      {
-	++summary.hitsInNonLaserRegion_;
-	summary.energyInNonLaserRegion_+=rechit.eraw();
-      }
-    else // hit comes from region where laser calibration pulse is seen
-      {
-	++summary.hitsInLaserRegion_;
-	summary.energyInLaserRegion_+=rechit.eraw();
-      }
-
-    if(rechit.eraw() > 1.5)
+    if (dbStatus->isBitSet(
+            HcalChannelStatus::
+                HcalBadLaserSignal))  // hit comes from a region where no laser calibration pulse is normally seen
     {
+      ++summary.hitsInNonLaserRegion_;
+      summary.energyInNonLaserRegion_ += rechit.eraw();
+    } else  // hit comes from region where laser calibration pulse is seen
+    {
+      ++summary.hitsInLaserRegion_;
+      summary.energyInLaserRegion_ += rechit.eraw();
+    }
+
+    if (rechit.eraw() > 1.5) {
       summary.rechitCount15_ = summary.rechitCount15_ + 1;
       summary.rechitEnergy15_ = summary.rechitEnergy15_ + rechit.eraw();
     }
-    
+
     // Exclude uncollapsed QIE11 channels
-    if( CaloRecHitAuxSetter::getBit(rechit.auxPhase1(), HBHERecHitAuxSetter::OFF_TDC_TIME) &&
-       !CaloRecHitAuxSetter::getBit(rechit.auxPhase1(), HBHERecHitAuxSetter::OFF_COMBINED) ) continue;
-   
+    if (CaloRecHitAuxSetter::getBit(rechit.auxPhase1(), HBHERecHitAuxSetter::OFF_TDC_TIME) &&
+        !CaloRecHitAuxSetter::getBit(rechit.auxPhase1(), HBHERecHitAuxSetter::OFF_COMBINED))
+      continue;
+
     // if it was ID'd as isolated noise, update the summary object
-    if(rechit.flags() & isolbitset) {
+    if (rechit.flags() & isolbitset) {
       summary.nisolnoise_++;
       summary.isolnoisee_ += rechit.eraw();
       GlobalPoint gp = geo->getPosition(rechit.id());
-      double et = rechit.eraw()*gp.perp()/gp.mag();
+      double et = rechit.eraw() * gp.perp() / gp.mag();
       summary.isolnoiseet_ += et;
     }
 
-    if(rechit.flags() & flatbitset) {
+    if (rechit.flags() & flatbitset) {
       summary.nflatnoise_++;
       summary.flatnoisee_ += rechit.eraw();
       GlobalPoint gp = geo->getPosition(rechit.id());
-      double et = rechit.eraw()*gp.perp()/gp.mag();
+      double et = rechit.eraw() * gp.perp() / gp.mag();
       summary.flatnoiseet_ += et;
     }
 
-    if(rechit.flags() & spikebitset) {
+    if (rechit.flags() & spikebitset) {
       summary.nspikenoise_++;
       summary.spikenoisee_ += rechit.eraw();
       GlobalPoint gp = geo->getPosition(rechit.id());
-      double et = rechit.eraw()*gp.perp()/gp.mag();
+      double et = rechit.eraw() * gp.perp() / gp.mag();
       summary.spikenoiseet_ += et;
     }
 
-    if(rechit.flags() & trianglebitset) {
+    if (rechit.flags() & trianglebitset) {
       summary.ntrianglenoise_++;
       summary.trianglenoisee_ += rechit.eraw();
       GlobalPoint gp = geo->getPosition(rechit.id());
-      double et = rechit.eraw()*gp.perp()/gp.mag();
+      double et = rechit.eraw() * gp.perp() / gp.mag();
       summary.trianglenoiseet_ += et;
     }
 
-    if(rechit.flags() & ts4ts5bitset) {
-      if (not dbStatus->isBitSet(HcalChannelStatus::HcalCellExcludeFromHBHENoiseSummaryR45))  // only add to TS4TS5 if the bit is not marked as "HcalCellExcludeFromHBHENoiseSummaryR45"
-	{
-	  summary.nts4ts5noise_++;
-	  summary.ts4ts5noisee_ += rechit.eraw();
-	  GlobalPoint gp = geo->getPosition(rechit.id());
-	  double et = rechit.eraw()*gp.perp()/gp.mag();
-	  summary.ts4ts5noiseet_ += et;
-	}
+    if (rechit.flags() & ts4ts5bitset) {
+      if (not dbStatus->isBitSet(
+              HcalChannelStatus::
+                  HcalCellExcludeFromHBHENoiseSummaryR45))  // only add to TS4TS5 if the bit is not marked as "HcalCellExcludeFromHBHENoiseSummaryR45"
+      {
+        summary.nts4ts5noise_++;
+        summary.ts4ts5noisee_ += rechit.eraw();
+        GlobalPoint gp = geo->getPosition(rechit.id());
+        double et = rechit.eraw() * gp.perp() / gp.mag();
+        summary.ts4ts5noiseet_ += et;
+      }
     }
-    
-    if(rechit.flags() & negativebitset) {
-	  summary.nnegativenoise_++;
-	  summary.negativenoisee_ += rechit.eraw();
-	  GlobalPoint gp = geo->getPosition(rechit.id());
-	  double et = rechit.eraw()*gp.perp()/gp.mag();
-	  summary.negativenoiseet_ += et;
+
+    if (rechit.flags() & negativebitset) {
+      summary.nnegativenoise_++;
+      summary.negativenoisee_ += rechit.eraw();
+      GlobalPoint gp = geo->getPosition(rechit.id());
+      double et = rechit.eraw() * gp.perp() / gp.mag();
+      summary.negativenoiseet_ += et;
     }
 
     // find the hpd that the rechit is in
-    HcalNoiseHPD& hpd=(*array.findHPD(rechit));
+    HcalNoiseHPD& hpd = (*array.findHPD(rechit));
 
     // create a persistent reference to the rechit
-    edm::Ref<HBHERecHitCollection> myRef(handle, it-handle->begin());
+    edm::Ref<HBHERecHitCollection> myRef(handle, it - handle->begin());
 
     // store it in a place so that it remains sorted by energy
     hpd.refrechitset_.insert(myRef);
 
-  } // end loop over rechits
+  }  // end loop over rechits
 
   // loop over all HPDs and transfer the information from refrechitset_ to rechits_;
-  for(HcalNoiseRBXArray::iterator rbxit=array.begin(); rbxit!=array.end(); ++rbxit) {
-    for(std::vector<HcalNoiseHPD>::iterator hpdit=rbxit->hpds_.begin(); hpdit!=rbxit->hpds_.end(); ++hpdit) {
-
+  for (HcalNoiseRBXArray::iterator rbxit = array.begin(); rbxit != array.end(); ++rbxit) {
+    for (std::vector<HcalNoiseHPD>::iterator hpdit = rbxit->hpds_.begin(); hpdit != rbxit->hpds_.end(); ++hpdit) {
       // loop over all of the entries in the set and add them to rechits_
-      for(std::set<edm::Ref<HBHERecHitCollection>, RefHBHERecHitEnergyComparison>::const_iterator
-	    it=hpdit->refrechitset_.begin(); it!=hpdit->refrechitset_.end(); ++it) {
-	hpdit->rechits_.push_back(*it);
+      for (std::set<edm::Ref<HBHERecHitCollection>, RefHBHERecHitEnergyComparison>::const_iterator it =
+               hpdit->refrechitset_.begin();
+           it != hpdit->refrechitset_.end();
+           ++it) {
+        hpdit->rechits_.push_back(*it);
       }
     }
   }
@@ -961,40 +1291,41 @@ HcalNoiseInfoProducer::fillrechits(edm::Event& iEvent, const edm::EventSetup& iS
 }
 
 // ------------ fill the array with calo tower information
-void
-HcalNoiseInfoProducer::fillcalotwrs(edm::Event& iEvent, const edm::EventSetup& iSetup, HcalNoiseRBXArray& array, HcalNoiseSummary& summary) const
-{
+void HcalNoiseInfoProducer::fillcalotwrs(edm::Event& iEvent,
+                                         const edm::EventSetup& iSetup,
+                                         HcalNoiseRBXArray& array,
+                                         HcalNoiseSummary& summary) const {
   // get the calotowers
   edm::Handle<CaloTowerCollection> handle;
   //  iEvent.getByLabel(caloTowerCollName_, handle);
   iEvent.getByToken(calotower_token_, handle);
 
-  if(!handle.isValid()) {
+  if (!handle.isValid()) {
     throw edm::Exception(edm::errors::ProductNotFound)
-      << " could not find CaloTowerCollection named " << caloTowerCollName_ << "\n.";
+        << " could not find CaloTowerCollection named " << caloTowerCollName_ << "\n.";
     return;
   }
 
   summary.emenergy_ = summary.hadenergy_ = 0.0;
 
   // loop over all of the calotower information
-  for(CaloTowerCollection::const_iterator it = handle->begin(); it!=handle->end(); ++it) {
-    const CaloTower& twr=(*it);
+  for (CaloTowerCollection::const_iterator it = handle->begin(); it != handle->end(); ++it) {
+    const CaloTower& twr = (*it);
 
     // create a persistent reference to the tower
-    edm::Ref<CaloTowerCollection> myRef(handle, it-handle->begin());
+    edm::Ref<CaloTowerCollection> myRef(handle, it - handle->begin());
 
     // get all of the hpd's that are pointed to by the calotower
     std::vector<std::vector<HcalNoiseHPD>::iterator> hpditervec;
     array.findHPD(twr, hpditervec);
 
     // loop over the hpd's and add the reference to the RefVectors
-    for(std::vector<std::vector<HcalNoiseHPD>::iterator>::iterator it=hpditervec.begin();
-	it!=hpditervec.end(); ++it)
+    for (std::vector<std::vector<HcalNoiseHPD>::iterator>::iterator it = hpditervec.begin(); it != hpditervec.end();
+         ++it)
       (*it)->calotowers_.push_back(myRef);
 
     // skip over anything with |ieta|>maxCaloTowerIEta
-    if(twr.ietaAbs()>maxCaloTowerIEta_) {
+    if (twr.ietaAbs() > maxCaloTowerIEta_) {
       summary.emenergy_ += twr.emEnergy();
       summary.hadenergy_ += twr.hadEnergy();
     }
@@ -1004,65 +1335,60 @@ HcalNoiseInfoProducer::fillcalotwrs(edm::Event& iEvent, const edm::EventSetup& i
 }
 
 // ------------ fill the summary info from jets
-void
-HcalNoiseInfoProducer::filljetinfo(edm::Event& iEvent, const edm::EventSetup& iSetup, HcalNoiseSummary& summary) const
-{
-    bool goodJetFoundInLowBVRegion = false; // checks whether a jet is in
-                                            // a low BV region, where false
-                                            // noise flagging rate is higher.
-    if (!jetCollName_.empty())
-    {
-        edm::Handle<reco::PFJetCollection> pfjet_h;
-        iEvent.getByToken(jet_token_, pfjet_h);
+void HcalNoiseInfoProducer::filljetinfo(edm::Event& iEvent,
+                                        const edm::EventSetup& iSetup,
+                                        HcalNoiseSummary& summary) const {
+  bool goodJetFoundInLowBVRegion = false;  // checks whether a jet is in
+                                           // a low BV region, where false
+                                           // noise flagging rate is higher.
+  if (!jetCollName_.empty()) {
+    edm::Handle<reco::PFJetCollection> pfjet_h;
+    iEvent.getByToken(jet_token_, pfjet_h);
 
-        if (pfjet_h.isValid())
-        {
-            int jetindex=0;
-            for(reco::PFJetCollection::const_iterator jet = pfjet_h->begin();
-                jet != pfjet_h->end(); ++jet)
-            {
-                if (jetindex>maxjetindex_) break; // only look at jets with
-                                                  // indices up to maxjetindex_
+    if (pfjet_h.isValid()) {
+      int jetindex = 0;
+      for (reco::PFJetCollection::const_iterator jet = pfjet_h->begin(); jet != pfjet_h->end(); ++jet) {
+        if (jetindex > maxjetindex_)
+          break;  // only look at jets with
+                  // indices up to maxjetindex_
 
-                // Check whether jet is in low-BV region (0<eta<1.4, -1.8<phi<-1.4)
-                if (jet->eta()>0.0 && jet->eta()<1.4 &&
-                    jet->phi()>-1.8 && jet->phi()<-1.4)
-                {
-                    // Look for a good jet in low BV region;
-                    // if found, we will keep event
-                    if  (maxNHF_<0.0 || jet->neutralHadronEnergyFraction()<maxNHF_)
-                    {
-                        goodJetFoundInLowBVRegion=true;
-                        break;
-                    }
-                }
-                ++jetindex;
-            }
+        // Check whether jet is in low-BV region (0<eta<1.4, -1.8<phi<-1.4)
+        if (jet->eta() > 0.0 && jet->eta() < 1.4 && jet->phi() > -1.8 && jet->phi() < -1.4) {
+          // Look for a good jet in low BV region;
+          // if found, we will keep event
+          if (maxNHF_ < 0.0 || jet->neutralHadronEnergyFraction() < maxNHF_) {
+            goodJetFoundInLowBVRegion = true;
+            break;
+          }
         }
+        ++jetindex;
+      }
     }
+  }
 
-    summary.goodJetFoundInLowBVRegion_ = goodJetFoundInLowBVRegion;
+  summary.goodJetFoundInLowBVRegion_ = goodJetFoundInLowBVRegion;
 }
 
 // ------------ fill the summary with track information
-void
-HcalNoiseInfoProducer::filltracks(edm::Event& iEvent, const edm::EventSetup& iSetup, HcalNoiseSummary& summary) const
-{
+void HcalNoiseInfoProducer::filltracks(edm::Event& iEvent,
+                                       const edm::EventSetup& iSetup,
+                                       HcalNoiseSummary& summary) const {
   edm::Handle<reco::TrackCollection> handle;
   //  iEvent.getByLabel(trackCollName_, handle);
   iEvent.getByToken(track_token_, handle);
 
   // don't throw exception, just return quietly
-  if(!handle.isValid()) {
+  if (!handle.isValid()) {
     //    throw edm::Exception(edm::errors::ProductNotFound)
     //      << " could not find trackCollection named " << trackCollName_ << "\n.";
     return;
   }
 
-  summary.trackenergy_=0.0;
-  for(reco::TrackCollection::const_iterator iTrack = handle->begin(); iTrack!=handle->end(); ++iTrack) {
-    reco::Track trk=*iTrack;
-    if(trk.pt()<minTrackPt_ || fabs(trk.eta())>maxTrackEta_) continue;
+  summary.trackenergy_ = 0.0;
+  for (reco::TrackCollection::const_iterator iTrack = handle->begin(); iTrack != handle->end(); ++iTrack) {
+    reco::Track trk = *iTrack;
+    if (trk.pt() < minTrackPt_ || fabs(trk.eta()) > maxTrackEta_)
+      continue;
 
     summary.trackenergy_ += trk.p();
   }

--- a/RecoMET/METProducers/src/METSignificanceProducer.cc
+++ b/RecoMET/METProducers/src/METSignificanceProducer.cc
@@ -8,21 +8,17 @@
 //____________________________________________________________________________||
 #include "RecoMET/METProducers/interface/METSignificanceProducer.h"
 
-
 //____________________________________________________________________________||
-namespace cms
-{
+namespace cms {
 
-//____________________________________________________________________________||
-  METSignificanceProducer::METSignificanceProducer(const edm::ParameterSet& iConfig)
-  {
-    
-    std::vector<edm::InputTag> srcLeptonsTags = iConfig.getParameter< std::vector<edm::InputTag> >("srcLeptons");
-    for(std::vector<edm::InputTag>::const_iterator it=srcLeptonsTags.begin();it!=srcLeptonsTags.end();it++) {
-      lepTokens_.push_back( consumes<edm::View<reco::Candidate> >( *it ) );
+  //____________________________________________________________________________||
+  METSignificanceProducer::METSignificanceProducer(const edm::ParameterSet& iConfig) {
+    std::vector<edm::InputTag> srcLeptonsTags = iConfig.getParameter<std::vector<edm::InputTag> >("srcLeptons");
+    for (std::vector<edm::InputTag>::const_iterator it = srcLeptonsTags.begin(); it != srcLeptonsTags.end(); it++) {
+      lepTokens_.push_back(consumes<edm::View<reco::Candidate> >(*it));
     }
-    
-    pfjetsToken_    = consumes<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>("srcPfJets"));
+
+    pfjetsToken_ = consumes<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>("srcPfJets"));
 
     metToken_ = consumes<edm::View<reco::MET> >(iConfig.getParameter<edm::InputTag>("srcMet"));
     pfCandidatesToken_ = consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("srcPFCandidates"));
@@ -34,79 +30,73 @@ namespace cms
 
     metSigAlgo_ = new metsig::METSignificance(iConfig);
 
-   produces<double>("METSignificance");
-   produces<math::Error<2>::type>("METCovariance");
-   
+    produces<double>("METSignificance");
+    produces<math::Error<2>::type>("METCovariance");
   }
 
-  METSignificanceProducer::~METSignificanceProducer()
-  {
-     delete metSigAlgo_;
-  }
+  METSignificanceProducer::~METSignificanceProducer() { delete metSigAlgo_; }
 
-//____________________________________________________________________________||
-  void METSignificanceProducer::produce(edm::Event& event, const edm::EventSetup& setup)
-  {
-   //
-   // met
-   //
+  //____________________________________________________________________________||
+  void METSignificanceProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
+    //
+    // met
+    //
     edm::Handle<edm::View<reco::MET> > metHandle;
     event.getByToken(metToken_, metHandle);
     const reco::MET& met = (*metHandle)[0];
-    
+
     //
     // candidates
     //
     edm::Handle<reco::CandidateView> pfCandidates;
-    event.getByToken( pfCandidatesToken_, pfCandidates );
-    
+    event.getByToken(pfCandidatesToken_, pfCandidates);
+
     //
     // leptons
     //
-   std::vector< edm::Handle<reco::CandidateView> > leptons;
-   for ( std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator srcLeptons_i = lepTokens_.begin();
-         srcLeptons_i != lepTokens_.end(); ++srcLeptons_i ) {
-
+    std::vector<edm::Handle<reco::CandidateView> > leptons;
+    for (std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator srcLeptons_i = lepTokens_.begin();
+         srcLeptons_i != lepTokens_.end();
+         ++srcLeptons_i) {
       edm::Handle<reco::CandidateView> leptons_i;
       event.getByToken(*srcLeptons_i, leptons_i);
-      leptons.push_back( leptons_i );
+      leptons.push_back(leptons_i);
+    }
 
-   }
+    //
+    // jets
+    //
+    edm::Handle<edm::View<reco::Jet> > jets;
+    event.getByToken(pfjetsToken_, jets);
 
-   //
-   // jets
-   //
-   edm::Handle<edm::View<reco::Jet> > jets;
-   event.getByToken( pfjetsToken_, jets );
+    edm::Handle<double> rho;
+    event.getByToken(rhoToken_, rho);
 
-   edm::Handle<double> rho;
-   event.getByToken(rhoToken_, rho);
+    JME::JetResolution resPtObj = JME::JetResolution::get(setup, jetResPtType_);
+    JME::JetResolution resPhiObj = JME::JetResolution::get(setup, jetResPhiType_);
+    JME::JetResolutionScaleFactor resSFObj = JME::JetResolutionScaleFactor::get(setup, jetSFType_);
 
-   JME::JetResolution resPtObj = JME::JetResolution::get(setup, jetResPtType_);
-   JME::JetResolution resPhiObj = JME::JetResolution::get(setup, jetResPhiType_);
-   JME::JetResolutionScaleFactor resSFObj = JME::JetResolutionScaleFactor::get(setup, jetSFType_);
-   
-   //
-   // compute the significance
-   //
-   const reco::METCovMatrix cov = metSigAlgo_->getCovariance( *jets, leptons, pfCandidates, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData() );
-   double sig  = metSigAlgo_->getSignificance(cov, met);
+    //
+    // compute the significance
+    //
+    const reco::METCovMatrix cov = metSigAlgo_->getCovariance(
+        *jets, leptons, pfCandidates, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData());
+    double sig = metSigAlgo_->getSignificance(cov, met);
 
-   auto significance = std::make_unique<double>();
-   (*significance) = sig;
-   
-   auto covPtr = std::make_unique<math::Error<2>::type>();
-   (*covPtr)(0,0) = cov(0,0);
-   (*covPtr)(1,0) = cov(1,0);
-   (*covPtr)(1,1) = cov(1,1);
+    auto significance = std::make_unique<double>();
+    (*significance) = sig;
 
-   event.put(std::move(covPtr), "METCovariance" );
-   event.put(std::move(significance), "METSignificance" );
+    auto covPtr = std::make_unique<math::Error<2>::type>();
+    (*covPtr)(0, 0) = cov(0, 0);
+    (*covPtr)(1, 0) = cov(1, 0);
+    (*covPtr)(1, 1) = cov(1, 1);
 
+    event.put(std::move(covPtr), "METCovariance");
+    event.put(std::move(significance), "METSignificance");
   }
 
-//____________________________________________________________________________||
+  //____________________________________________________________________________||
   DEFINE_FWK_MODULE(METSignificanceProducer);
-}
+}  // namespace cms
 
 //____________________________________________________________________________||

--- a/RecoMET/METProducers/src/MinMETProducerT.cc
+++ b/RecoMET/METProducers/src/MinMETProducerT.cc
@@ -4,4 +4,3 @@
 
 DEFINE_FWK_MODULE(reco::MinCaloMETProducer);
 DEFINE_FWK_MODULE(reco::MinPFMETProducer);
-

--- a/RecoMET/METProducers/src/MuonMET.cc
+++ b/RecoMET/METProducers/src/MuonMET.cc
@@ -2,7 +2,7 @@
 //
 // Package:    METProducers
 // Class:      MuonMET
-// 
+//
 
 //____________________________________________________________________________||
 #include "RecoMET/METProducers/interface/MuonMET.h"
@@ -11,65 +11,54 @@
 #include "DataFormats/METReco/interface/CaloMETCollection.h"
 
 //____________________________________________________________________________||
-namespace cms 
-{
+namespace cms {
 
-//____________________________________________________________________________||
-  MuonMET::MuonMET( const edm::ParameterSet& iConfig )
-    : alg_()
-    , metTypeInputTag_(iConfig.getParameter<edm::InputTag>("metTypeInputTag"))
-  {
-
+  //____________________________________________________________________________||
+  MuonMET::MuonMET(const edm::ParameterSet& iConfig)
+      : alg_(), metTypeInputTag_(iConfig.getParameter<edm::InputTag>("metTypeInputTag")) {
     edm::InputTag muonsInputTag = iConfig.getParameter<edm::InputTag>("muonsInputTag");
     inputMuonToken_ = consumes<edm::View<reco::Muon> >(muonsInputTag);
 
-    edm::InputTag muonDepValueMap  = iConfig.getParameter<edm::InputTag>("muonMETDepositValueMapInputTag");
+    edm::InputTag muonDepValueMap = iConfig.getParameter<edm::InputTag>("muonMETDepositValueMapInputTag");
     inputValueMapMuonMetCorrToken_ = consumes<edm::ValueMap<reco::MuonMETCorrectionData> >(muonDepValueMap);
 
     edm::InputTag uncorMETInputTag = iConfig.getParameter<edm::InputTag>("uncorMETInputTag");
-    if( metTypeInputTag_.label() == "CaloMET" )
-      {
-	inputCaloMETToken_ = consumes<edm::View<reco::CaloMET> >(uncorMETInputTag);
-	produces<reco::CaloMETCollection>();
-      }
-    else
-      {
-	inputMETToken_ = consumes<edm::View<reco::MET> >(uncorMETInputTag);
-	produces<reco::METCollection>();
-      }
+    if (metTypeInputTag_.label() == "CaloMET") {
+      inputCaloMETToken_ = consumes<edm::View<reco::CaloMET> >(uncorMETInputTag);
+      produces<reco::CaloMETCollection>();
+    } else {
+      inputMETToken_ = consumes<edm::View<reco::MET> >(uncorMETInputTag);
+      produces<reco::METCollection>();
+    }
   }
 
   MuonMET::MuonMET() : alg_() {}
 
-  void MuonMET::produce( edm::Event& iEvent, const edm::EventSetup& iSetup )
-  {
+  void MuonMET::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     edm::Handle<edm::View<reco::Muon> > inputMuons;
     iEvent.getByToken(inputMuonToken_, inputMuons);
 
     edm::Handle<edm::ValueMap<reco::MuonMETCorrectionData> > vm_muCorrData_h;
-    
+
     iEvent.getByToken(inputValueMapMuonMetCorrToken_, vm_muCorrData_h);
-    
-    if( metTypeInputTag_.label() == "CaloMET")
-      {
-	edm::Handle<edm::View<reco::CaloMET> > inputUncorMet;
-	iEvent.getByToken(inputCaloMETToken_, inputUncorMet);
-	auto output = std::make_unique<reco::CaloMETCollection>();
-	alg_.run(*(inputMuons.product()), *(vm_muCorrData_h.product()), *(inputUncorMet.product()), &*output);
-	iEvent.put(std::move(output));
-      }
-    else
-      {
-	edm::Handle<edm::View<reco::MET> > inputUncorMet;
-	iEvent.getByToken(inputMETToken_, inputUncorMet);
-	auto output = std::make_unique<reco::METCollection>();
-	alg_.run(*(inputMuons.product()), *(vm_muCorrData_h.product()),*(inputUncorMet.product()), &*output);
-	iEvent.put(std::move(output));
-      }
+
+    if (metTypeInputTag_.label() == "CaloMET") {
+      edm::Handle<edm::View<reco::CaloMET> > inputUncorMet;
+      iEvent.getByToken(inputCaloMETToken_, inputUncorMet);
+      auto output = std::make_unique<reco::CaloMETCollection>();
+      alg_.run(*(inputMuons.product()), *(vm_muCorrData_h.product()), *(inputUncorMet.product()), &*output);
+      iEvent.put(std::move(output));
+    } else {
+      edm::Handle<edm::View<reco::MET> > inputUncorMet;
+      iEvent.getByToken(inputMETToken_, inputUncorMet);
+      auto output = std::make_unique<reco::METCollection>();
+      alg_.run(*(inputMuons.product()), *(vm_muCorrData_h.product()), *(inputUncorMet.product()), &*output);
+      iEvent.put(std::move(output));
+    }
   }
-//____________________________________________________________________________||
+  //____________________________________________________________________________||
   DEFINE_FWK_MODULE(MuonMET);
 
-}
+}  // namespace cms
 
 //____________________________________________________________________________||

--- a/RecoMET/METProducers/src/MuonMETValueMapProducer.cc
+++ b/RecoMET/METProducers/src/MuonMETValueMapProducer.cc
@@ -45,58 +45,54 @@
 #include "RecoMET/METAlgorithms/interface/MuonMETAlgo.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "DataFormats/Common/interface/ValueMap.h" 
+#include "DataFormats/Common/interface/ValueMap.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 //____________________________________________________________________________||
-namespace cms
-{
+namespace cms {
 
-MuonMETValueMapProducer::MuonMETValueMapProducer(const edm::ParameterSet& iConfig)
-  : minPt_(iConfig.getParameter<double>("minPt"))
-  , maxEta_(iConfig.getParameter<double>("maxEta"))
-  , isAlsoTkMu_(iConfig.getParameter<bool>("isAlsoTkMu"))
-  , maxNormChi2_(iConfig.getParameter<double>("maxNormChi2"))
-  , maxd0_(iConfig.getParameter<double>("maxd0"))
-  , minnHits_(iConfig.getParameter<int>("minnHits"))
-  , minnValidStaHits_(iConfig.getParameter<int>("minnValidStaHits"))
-  , useTrackAssociatorPositions_(iConfig.getParameter<bool>("useTrackAssociatorPositions"))
-  , useHO_(iConfig.getParameter<bool>("useHO"))
-  , towerEtThreshold_(iConfig.getParameter<double>("towerEtThreshold"))
-  , useRecHits_(iConfig.getParameter<bool>("useRecHits"))
-{
-  muonToken_ = consumes<edm::View<reco::Muon> >(iConfig.getParameter<edm::InputTag>("muonInputTag"));
-  beamSpotToken_ = consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpotInputTag"));
+  MuonMETValueMapProducer::MuonMETValueMapProducer(const edm::ParameterSet& iConfig)
+      : minPt_(iConfig.getParameter<double>("minPt")),
+        maxEta_(iConfig.getParameter<double>("maxEta")),
+        isAlsoTkMu_(iConfig.getParameter<bool>("isAlsoTkMu")),
+        maxNormChi2_(iConfig.getParameter<double>("maxNormChi2")),
+        maxd0_(iConfig.getParameter<double>("maxd0")),
+        minnHits_(iConfig.getParameter<int>("minnHits")),
+        minnValidStaHits_(iConfig.getParameter<int>("minnValidStaHits")),
+        useTrackAssociatorPositions_(iConfig.getParameter<bool>("useTrackAssociatorPositions")),
+        useHO_(iConfig.getParameter<bool>("useHO")),
+        towerEtThreshold_(iConfig.getParameter<double>("towerEtThreshold")),
+        useRecHits_(iConfig.getParameter<bool>("useRecHits")) {
+    muonToken_ = consumes<edm::View<reco::Muon>>(iConfig.getParameter<edm::InputTag>("muonInputTag"));
+    beamSpotToken_ = consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpotInputTag"));
 
-  edm::ParameterSet trackAssociatorParams = iConfig.getParameter<edm::ParameterSet>("TrackAssociatorParameters");
-  edm::ConsumesCollector iC = consumesCollector();
-  trackAssociatorParameters_.loadParameters(trackAssociatorParams, iC);
-  trackAssociator_.useDefaultPropagator();
-  
-  produces<edm::ValueMap<reco::MuonMETCorrectionData> >("muCorrData");
-}
+    edm::ParameterSet trackAssociatorParams = iConfig.getParameter<edm::ParameterSet>("TrackAssociatorParameters");
+    edm::ConsumesCollector iC = consumesCollector();
+    trackAssociatorParameters_.loadParameters(trackAssociatorParams, iC);
+    trackAssociator_.useDefaultPropagator();
 
-//____________________________________________________________________________||
-void MuonMETValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-  edm::Handle<edm::View<reco::Muon> > muons;
-  iEvent.getByToken(muonToken_, muons);
+    produces<edm::ValueMap<reco::MuonMETCorrectionData>>("muCorrData");
+  }
 
-  edm::Handle<reco::BeamSpot> beamSpot;
-  iEvent.getByToken(beamSpotToken_, beamSpot);
+  //____________________________________________________________________________||
+  void MuonMETValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+    edm::Handle<edm::View<reco::Muon>> muons;
+    iEvent.getByToken(muonToken_, muons);
 
-  edm::ESHandle<MagneticField> magneticField;
-  iSetup.get<IdealMagneticFieldRecord>().get(magneticField);
+    edm::Handle<reco::BeamSpot> beamSpot;
+    iEvent.getByToken(beamSpotToken_, beamSpot);
 
-  double bfield = magneticField->inTesla(GlobalPoint(0.,0.,0.)).z();
+    edm::ESHandle<MagneticField> magneticField;
+    iSetup.get<IdealMagneticFieldRecord>().get(magneticField);
 
-  std::vector<reco::MuonMETCorrectionData> muCorrDataList;
+    double bfield = magneticField->inTesla(GlobalPoint(0., 0., 0.)).z();
 
-  for(edm::View<reco::Muon>::const_iterator muon = muons->begin(); muon != muons->end(); ++muon)
-    {
+    std::vector<reco::MuonMETCorrectionData> muCorrDataList;
+
+    for (edm::View<reco::Muon>::const_iterator muon = muons->begin(); muon != muons->end(); ++muon) {
       double deltax = 0.0;
       double deltay = 0.0;
       determine_deltax_deltay(deltax, deltay, *muon, bfield, iEvent, iSetup);
@@ -105,67 +101,74 @@ void MuonMETValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup&
 
       reco::MuonMETCorrectionData muMETCorrData(muCorrType, deltax, deltay);
       muCorrDataList.push_back(muMETCorrData);
-
     }
-    
-  auto valueMapMuCorrData = std::make_unique<edm::ValueMap<reco::MuonMETCorrectionData>>();
 
-  edm::ValueMap<reco::MuonMETCorrectionData>::Filler dataFiller(*valueMapMuCorrData);
-     
-  dataFiller.insert(muons, muCorrDataList.begin(), muCorrDataList.end());
-  dataFiller.fill();
+    auto valueMapMuCorrData = std::make_unique<edm::ValueMap<reco::MuonMETCorrectionData>>();
 
-  iEvent.put(std::move(valueMapMuCorrData), "muCorrData");
-    
-}
+    edm::ValueMap<reco::MuonMETCorrectionData>::Filler dataFiller(*valueMapMuCorrData);
+
+    dataFiller.insert(muons, muCorrDataList.begin(), muCorrDataList.end());
+    dataFiller.fill();
+
+    iEvent.put(std::move(valueMapMuCorrData), "muCorrData");
+  }
+
+  //____________________________________________________________________________||
+  void MuonMETValueMapProducer::determine_deltax_deltay(double& deltax,
+                                                        double& deltay,
+                                                        const reco::Muon& muon,
+                                                        double bfield,
+                                                        edm::Event& iEvent,
+                                                        const edm::EventSetup& iSetup) {
+    reco::TrackRef mu_track;
+    if (muon.isGlobalMuon())
+      mu_track = muon.globalTrack();
+    else if (muon.isTrackerMuon() || muon.isRPCMuon() || muon.isGEMMuon() || muon.isME0Muon())
+      mu_track = muon.innerTrack();
+    else
+      mu_track = muon.outerTrack();
+
+    TrackDetMatchInfo info = trackAssociator_.associate(
+        iEvent, iSetup, trackAssociator_.getFreeTrajectoryState(iSetup, *mu_track), trackAssociatorParameters_);
+
+    MuonMETAlgo alg;
+    alg.GetMuDepDeltas(
+        &muon, info, useTrackAssociatorPositions_, useRecHits_, useHO_, towerEtThreshold_, deltax, deltay, bfield);
+  }
+
+  //____________________________________________________________________________||
+  reco::MuonMETCorrectionData::Type MuonMETValueMapProducer::decide_correction_type(
+      const reco::Muon& muon, const math::XYZPoint& beamSpotPosition) {
+    if (should_type_MuonCandidateValuesUsed(muon, beamSpotPosition))
+      return reco::MuonMETCorrectionData::Type::MuonCandidateValuesUsed;
+
+    return reco::MuonMETCorrectionData::Type::NotUsed;
+  }
+
+  //____________________________________________________________________________||
+  bool MuonMETValueMapProducer::should_type_MuonCandidateValuesUsed(const reco::Muon& muon,
+                                                                    const math::XYZPoint& beamSpotPosition) {
+    if (!muon.isGlobalMuon())
+      return false;
+    if (!muon.isTrackerMuon() && isAlsoTkMu_)
+      return false;
+    reco::TrackRef globTk = muon.globalTrack();
+    reco::TrackRef siTk = muon.innerTrack();
+
+    if (muon.pt() < minPt_ || fabs(muon.eta()) > maxEta_)
+      return false;
+    if (globTk->chi2() / globTk->ndof() > maxNormChi2_)
+      return false;
+    if (fabs(globTk->dxy(beamSpotPosition)) > fabs(maxd0_))
+      return false;
+    if (siTk->numberOfValidHits() < minnHits_)
+      return false;
+    if (globTk->hitPattern().numberOfValidMuonHits() < minnValidStaHits_)
+      return false;
+    return true;
+  }
+
+  //____________________________________________________________________________||
+}  // namespace cms
 
 //____________________________________________________________________________||
-void MuonMETValueMapProducer::determine_deltax_deltay(double& deltax, double& deltay, const reco::Muon& muon, double bfield, edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-  reco::TrackRef mu_track;
-  if(muon.isGlobalMuon()) mu_track = muon.globalTrack();
-  else if(muon.isTrackerMuon()||muon.isRPCMuon()||muon.isGEMMuon()||muon.isME0Muon()) mu_track = muon.innerTrack();
-  else mu_track = muon.outerTrack();
-
-  TrackDetMatchInfo info = trackAssociator_.associate(iEvent, iSetup,
-						      trackAssociator_.getFreeTrajectoryState(iSetup, *mu_track),
-						      trackAssociatorParameters_);
-
-  MuonMETAlgo alg;
-  alg.GetMuDepDeltas(&muon, info,
-		     useTrackAssociatorPositions_, useRecHits_,
-		     useHO_, towerEtThreshold_,
-		     deltax, deltay, bfield);
-
-}
-
-//____________________________________________________________________________||
-reco::MuonMETCorrectionData::Type MuonMETValueMapProducer::decide_correction_type(const reco::Muon& muon, const math::XYZPoint &beamSpotPosition)
-{
-  if(should_type_MuonCandidateValuesUsed(muon, beamSpotPosition))
-    return reco::MuonMETCorrectionData::Type::MuonCandidateValuesUsed;
-
-  return reco::MuonMETCorrectionData::Type::NotUsed;
-}
-
-//____________________________________________________________________________||
-bool MuonMETValueMapProducer::should_type_MuonCandidateValuesUsed(const reco::Muon& muon, const math::XYZPoint &beamSpotPosition)
-{
-  if(!muon.isGlobalMuon()) return false;
-  if(!muon.isTrackerMuon() && isAlsoTkMu_) return false;
-  reco::TrackRef globTk = muon.globalTrack();
-  reco::TrackRef siTk   = muon.innerTrack();
-
-  if(muon.pt() < minPt_ || fabs(muon.eta()) > maxEta_) return false;
-  if(globTk->chi2()/globTk->ndof() > maxNormChi2_) return false;
-  if(fabs(globTk->dxy(beamSpotPosition)) > fabs(maxd0_)) return false;
-  if(siTk->numberOfValidHits() < minnHits_) return false;
-  if(globTk->hitPattern().numberOfValidMuonHits() < minnValidStaHits_) return false;
-  return true;
-}
-  
-//____________________________________________________________________________||
-}
-
-//____________________________________________________________________________||
-

--- a/RecoMET/METProducers/src/MuonTCMETValueMapProducer.cc
+++ b/RecoMET/METProducers/src/MuonTCMETValueMapProducer.cc
@@ -2,7 +2,7 @@
 //
 // Package:    METProducers
 // Class:      MuonTCMETValueMapProducer
-// 
+//
 // Original Author:  Frank Golf
 //         Created:  Sun Mar 15 11:33:20 CDT 2009
 //
@@ -18,7 +18,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackBase.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "DataFormats/Common/interface/ValueMap.h" 
+#include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/MuonReco/interface/MuonMETCorrectionData.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 #include "DataFormats/GeometrySurface/interface/Cylinder.h"
@@ -44,404 +44,409 @@
 typedef math::XYZPoint Point;
 
 //____________________________________________________________________________||
-namespace cms
-{
+namespace cms {
 
-MuonTCMETValueMapProducer::MuonTCMETValueMapProducer(const edm::ParameterSet& iConfig)
-{
-  produces<edm::ValueMap<reco::MuonMETCorrectionData> > ("muCorrData");
+  MuonTCMETValueMapProducer::MuonTCMETValueMapProducer(const edm::ParameterSet& iConfig) {
+    produces<edm::ValueMap<reco::MuonMETCorrectionData>>("muCorrData");
 
-  rfType_     = iConfig.getParameter<int>("rf_type");
+    rfType_ = iConfig.getParameter<int>("rf_type");
 
-  nLayers_                = iConfig.getParameter<int>      ("nLayers");
-  nLayersTight_           = iConfig.getParameter<int>      ("nLayersTight");
-  vertexNdof_             = iConfig.getParameter<int>      ("vertexNdof");
-  vertexZ_                = iConfig.getParameter<double>   ("vertexZ");
-  vertexRho_              = iConfig.getParameter<double>   ("vertexRho");
-  vertexMaxDZ_            = iConfig.getParameter<double>   ("vertexMaxDZ");
-  maxpt_eta20_            = iConfig.getParameter<double>   ("maxpt_eta20");
-  maxpt_eta25_            = iConfig.getParameter<double>   ("maxpt_eta25");
+    nLayers_ = iConfig.getParameter<int>("nLayers");
+    nLayersTight_ = iConfig.getParameter<int>("nLayersTight");
+    vertexNdof_ = iConfig.getParameter<int>("vertexNdof");
+    vertexZ_ = iConfig.getParameter<double>("vertexZ");
+    vertexRho_ = iConfig.getParameter<double>("vertexRho");
+    vertexMaxDZ_ = iConfig.getParameter<double>("vertexMaxDZ");
+    maxpt_eta20_ = iConfig.getParameter<double>("maxpt_eta20");
+    maxpt_eta25_ = iConfig.getParameter<double>("maxpt_eta25");
 
-  // get configuration parameters
-  std::vector<std::string> algos = iConfig.getParameter<std::vector<std::string> >("trackAlgos");
-  std::transform(algos.begin(), algos.end(), std::back_inserter(trkAlgos_), [](const std::string& a) {
+    // get configuration parameters
+    std::vector<std::string> algos = iConfig.getParameter<std::vector<std::string>>("trackAlgos");
+    std::transform(algos.begin(), algos.end(), std::back_inserter(trkAlgos_), [](const std::string& a) {
       return reco::TrackBase::algoByName(a);
     });
-  maxd0cut_        = iConfig.getParameter<double>("d0_max"       );
-  minpt_           = iConfig.getParameter<double>("pt_min"       );
-  maxpt_           = iConfig.getParameter<double>("pt_max"       );
-  maxeta_          = iConfig.getParameter<double>("eta_max"      );
-  maxchi2_         = iConfig.getParameter<double>("chi2_max"     );
-  minhits_         = iConfig.getParameter<double>("nhits_min"    );
-  maxPtErr_        = iConfig.getParameter<double>("ptErr_max"    );
+    maxd0cut_ = iConfig.getParameter<double>("d0_max");
+    minpt_ = iConfig.getParameter<double>("pt_min");
+    maxpt_ = iConfig.getParameter<double>("pt_max");
+    maxeta_ = iConfig.getParameter<double>("eta_max");
+    maxchi2_ = iConfig.getParameter<double>("chi2_max");
+    minhits_ = iConfig.getParameter<double>("nhits_min");
+    maxPtErr_ = iConfig.getParameter<double>("ptErr_max");
 
-  trkQuality_      = iConfig.getParameter<std::vector<int> >("track_quality");
-  algos = iConfig.getParameter<std::vector<std::string> >("track_algos");
-  std::transform(algos.begin(), algos.end(), std::back_inserter(trkAlgos_), [](const std::string& a) {
+    trkQuality_ = iConfig.getParameter<std::vector<int>>("track_quality");
+    algos = iConfig.getParameter<std::vector<std::string>>("track_algos");
+    std::transform(algos.begin(), algos.end(), std::back_inserter(trkAlgos_), [](const std::string& a) {
       return reco::TrackBase::algoByName(a);
     });
-  maxchi2_tight_   = iConfig.getParameter<double>("chi2_max_tight");
-  minhits_tight_   = iConfig.getParameter<double>("nhits_min_tight");
-  maxPtErr_tight_  = iConfig.getParameter<double>("ptErr_max_tight");
-  usePvtxd0_       = iConfig.getParameter<bool>("usePvtxd0");
-  d0cuta_          = iConfig.getParameter<double>("d0cuta");
-  d0cutb_          = iConfig.getParameter<double>("d0cutb");
+    maxchi2_tight_ = iConfig.getParameter<double>("chi2_max_tight");
+    minhits_tight_ = iConfig.getParameter<double>("nhits_min_tight");
+    maxPtErr_tight_ = iConfig.getParameter<double>("ptErr_max_tight");
+    usePvtxd0_ = iConfig.getParameter<bool>("usePvtxd0");
+    d0cuta_ = iConfig.getParameter<double>("d0cuta");
+    d0cutb_ = iConfig.getParameter<double>("d0cutb");
 
-  muon_dptrel_  = iConfig.getParameter<double>("muon_dptrel");
-  muond0_     = iConfig.getParameter<double>("d0_muon"    );
-  muonpt_     = iConfig.getParameter<double>("pt_muon"    );
-  muoneta_    = iConfig.getParameter<double>("eta_muon"   );
-  muonchi2_   = iConfig.getParameter<double>("chi2_muon"  );
-  muonhits_   = iConfig.getParameter<double>("nhits_muon" );
-  muonGlobal_   = iConfig.getParameter<bool>("global_muon");
-  muonTracker_  = iConfig.getParameter<bool>("tracker_muon");
-  muonDeltaR_ = iConfig.getParameter<double>("deltaR_muon");
-  useCaloMuons_ = iConfig.getParameter<bool>("useCaloMuons");
-  muonMinValidStaHits_ = iConfig.getParameter<int>("muonMinValidStaHits");
+    muon_dptrel_ = iConfig.getParameter<double>("muon_dptrel");
+    muond0_ = iConfig.getParameter<double>("d0_muon");
+    muonpt_ = iConfig.getParameter<double>("pt_muon");
+    muoneta_ = iConfig.getParameter<double>("eta_muon");
+    muonchi2_ = iConfig.getParameter<double>("chi2_muon");
+    muonhits_ = iConfig.getParameter<double>("nhits_muon");
+    muonGlobal_ = iConfig.getParameter<bool>("global_muon");
+    muonTracker_ = iConfig.getParameter<bool>("tracker_muon");
+    muonDeltaR_ = iConfig.getParameter<double>("deltaR_muon");
+    useCaloMuons_ = iConfig.getParameter<bool>("useCaloMuons");
+    muonMinValidStaHits_ = iConfig.getParameter<int>("muonMinValidStaHits");
 
-  response_function = nullptr;
-  tcmetAlgo_=new TCMETAlgo();
+    response_function = nullptr;
+    tcmetAlgo_ = new TCMETAlgo();
 
-  if( rfType_ == 1 )
-    response_function = tcmetAlgo_->getResponseFunction_fit();
-  else if( rfType_ == 2 )
-    response_function = tcmetAlgo_->getResponseFunction_mode();
+    if (rfType_ == 1)
+      response_function = tcmetAlgo_->getResponseFunction_fit();
+    else if (rfType_ == 2)
+      response_function = tcmetAlgo_->getResponseFunction_mode();
 
-  muonToken_ = consumes<reco::MuonCollection>(iConfig.getParameter<edm::InputTag>("muonInputTag"));
-  beamSpotToken_ = consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpotInputTag"));
-  vertexToken_ = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexInputTag"));
-
-}
-
-//____________________________________________________________________________||
-MuonTCMETValueMapProducer::~MuonTCMETValueMapProducer()
-{
-    delete tcmetAlgo_;
-}
-
-//____________________________________________________________________________||
-void MuonTCMETValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-  iEvent.getByToken(muonToken_ , muons_);
-  iEvent.getByToken(beamSpotToken_, beamSpot_);
-
-  hasValidVertex = false;
-  if( usePvtxd0_ ){
-    iEvent.getByToken(vertexToken_  ,vertexHandle_);
-
-    if( vertexHandle_.isValid() ) {
-      vertices_ = vertexHandle_.product();
-      hasValidVertex = isValidVertex();
-    }
+    muonToken_ = consumes<reco::MuonCollection>(iConfig.getParameter<edm::InputTag>("muonInputTag"));
+    beamSpotToken_ = consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpotInputTag"));
+    vertexToken_ = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexInputTag"));
   }
 
-  edm::ESHandle<MagneticField> theMagField;
-  iSetup.get<IdealMagneticFieldRecord>().get(theMagField);
-  bField = theMagField.product();
+  //____________________________________________________________________________||
+  MuonTCMETValueMapProducer::~MuonTCMETValueMapProducer() { delete tcmetAlgo_; }
 
-  auto vm_muCorrData = std::make_unique<edm::ValueMap<reco::MuonMETCorrectionData>>();
+  //____________________________________________________________________________||
+  void MuonTCMETValueMapProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+    iEvent.getByToken(muonToken_, muons_);
+    iEvent.getByToken(beamSpotToken_, beamSpot_);
 
-  std::vector<reco::MuonMETCorrectionData> v_muCorrData;
+    hasValidVertex = false;
+    if (usePvtxd0_) {
+      iEvent.getByToken(vertexToken_, vertexHandle_);
 
-  unsigned int nMuons = muons_->size();
-
-  for (unsigned int iMu = 0; iMu < nMuons; iMu++) {
-
-    const reco::Muon* mu = &(*muons_)[iMu];
-    double deltax = 0.0;
-    double deltay = 0.0;
-
-    reco::MuonMETCorrectionData muMETCorrData(reco::MuonMETCorrectionData::NotUsed, deltax, deltay);
-    
-    reco::TrackRef mu_track;
-    if( mu->isGlobalMuon() || mu->isTrackerMuon() || mu->isCaloMuon() )
-      mu_track = mu->innerTrack();
-    else {
-      v_muCorrData.push_back( muMETCorrData );
-      continue;
-    }
-
-    // figure out depositions muons would make if they were treated as pions
-    if( isGoodTrack( mu ) ) {
-
-      if( mu_track->pt() < minpt_ )
-	muMETCorrData = reco::MuonMETCorrectionData(reco::MuonMETCorrectionData::TreatedAsPion, deltax, deltay);
-
-      else {
-	int bin_index   = response_function->FindBin( mu_track->eta(), mu_track->pt() );
-	double response = response_function->GetBinContent( bin_index );
-
-	TVector3 outerTrkPosition = propagateTrack( mu );
-
-	deltax = response * mu_track->p() * sin( outerTrkPosition.Theta() ) * cos( outerTrkPosition.Phi() );
-	deltay = response * mu_track->p() * sin( outerTrkPosition.Theta() ) * sin( outerTrkPosition.Phi() );
-
-	muMETCorrData = reco::MuonMETCorrectionData(reco::MuonMETCorrectionData::TreatedAsPion, deltax, deltay);
+      if (vertexHandle_.isValid()) {
+        vertices_ = vertexHandle_.product();
+        hasValidVertex = isValidVertex();
       }
     }
 
-    // figure out muon flag
-    if( isGoodMuon( mu ) )
-      v_muCorrData.push_back( reco::MuonMETCorrectionData(reco::MuonMETCorrectionData::MuonCandidateValuesUsed, deltax, deltay) );
+    edm::ESHandle<MagneticField> theMagField;
+    iSetup.get<IdealMagneticFieldRecord>().get(theMagField);
+    bField = theMagField.product();
 
-    else if( useCaloMuons_ && isGoodCaloMuon( mu, iMu ) )
-      v_muCorrData.push_back( reco::MuonMETCorrectionData(reco::MuonMETCorrectionData::MuonCandidateValuesUsed, deltax, deltay) );
+    auto vm_muCorrData = std::make_unique<edm::ValueMap<reco::MuonMETCorrectionData>>();
 
-    else v_muCorrData.push_back( muMETCorrData );
+    std::vector<reco::MuonMETCorrectionData> v_muCorrData;
+
+    unsigned int nMuons = muons_->size();
+
+    for (unsigned int iMu = 0; iMu < nMuons; iMu++) {
+      const reco::Muon* mu = &(*muons_)[iMu];
+      double deltax = 0.0;
+      double deltay = 0.0;
+
+      reco::MuonMETCorrectionData muMETCorrData(reco::MuonMETCorrectionData::NotUsed, deltax, deltay);
+
+      reco::TrackRef mu_track;
+      if (mu->isGlobalMuon() || mu->isTrackerMuon() || mu->isCaloMuon())
+        mu_track = mu->innerTrack();
+      else {
+        v_muCorrData.push_back(muMETCorrData);
+        continue;
+      }
+
+      // figure out depositions muons would make if they were treated as pions
+      if (isGoodTrack(mu)) {
+        if (mu_track->pt() < minpt_)
+          muMETCorrData = reco::MuonMETCorrectionData(reco::MuonMETCorrectionData::TreatedAsPion, deltax, deltay);
+
+        else {
+          int bin_index = response_function->FindBin(mu_track->eta(), mu_track->pt());
+          double response = response_function->GetBinContent(bin_index);
+
+          TVector3 outerTrkPosition = propagateTrack(mu);
+
+          deltax = response * mu_track->p() * sin(outerTrkPosition.Theta()) * cos(outerTrkPosition.Phi());
+          deltay = response * mu_track->p() * sin(outerTrkPosition.Theta()) * sin(outerTrkPosition.Phi());
+
+          muMETCorrData = reco::MuonMETCorrectionData(reco::MuonMETCorrectionData::TreatedAsPion, deltax, deltay);
+        }
+      }
+
+      // figure out muon flag
+      if (isGoodMuon(mu))
+        v_muCorrData.push_back(
+            reco::MuonMETCorrectionData(reco::MuonMETCorrectionData::MuonCandidateValuesUsed, deltax, deltay));
+
+      else if (useCaloMuons_ && isGoodCaloMuon(mu, iMu))
+        v_muCorrData.push_back(
+            reco::MuonMETCorrectionData(reco::MuonMETCorrectionData::MuonCandidateValuesUsed, deltax, deltay));
+
+      else
+        v_muCorrData.push_back(muMETCorrData);
+    }
+
+    edm::ValueMap<reco::MuonMETCorrectionData>::Filler dataFiller(*vm_muCorrData);
+
+    dataFiller.insert(muons_, v_muCorrData.begin(), v_muCorrData.end());
+    dataFiller.fill();
+
+    iEvent.put(std::move(vm_muCorrData), "muCorrData");
   }
-    
-  edm::ValueMap<reco::MuonMETCorrectionData>::Filler dataFiller(*vm_muCorrData);
 
-  dataFiller.insert( muons_, v_muCorrData.begin(), v_muCorrData.end());
-  dataFiller.fill();
-    
-  iEvent.put(std::move(vm_muCorrData), "muCorrData");
-}
-  
-//____________________________________________________________________________||
-bool MuonTCMETValueMapProducer::isGoodMuon( const reco::Muon* muon )
-{
-  double d0    = -999;
-  double nhits = 0;
-  double chi2  = 999;
+  //____________________________________________________________________________||
+  bool MuonTCMETValueMapProducer::isGoodMuon(const reco::Muon* muon) {
+    double d0 = -999;
+    double nhits = 0;
+    double chi2 = 999;
 
-  // get d0 corrected for beam spot
-  bool haveBeamSpot = true;
-  if( !beamSpot_.isValid() ) haveBeamSpot = false;
+    // get d0 corrected for beam spot
+    bool haveBeamSpot = true;
+    if (!beamSpot_.isValid())
+      haveBeamSpot = false;
 
-  if( muonGlobal_  && !muon->isGlobalMuon()  ) return false;
-  if( muonTracker_ && !muon->isTrackerMuon() ) return false;
+    if (muonGlobal_ && !muon->isGlobalMuon())
+      return false;
+    if (muonTracker_ && !muon->isTrackerMuon())
+      return false;
 
-  const reco::TrackRef siTrack     = muon->innerTrack();
-  const reco::TrackRef globalTrack = muon->globalTrack();
+    const reco::TrackRef siTrack = muon->innerTrack();
+    const reco::TrackRef globalTrack = muon->globalTrack();
 
-  Point bspot = haveBeamSpot ? beamSpot_->position() : Point(0,0,0);
-  if( siTrack.isNonnull() ) nhits = siTrack->numberOfValidHits();
-  if( globalTrack.isNonnull() ) 
-    {
-      d0   = -1 * globalTrack->dxy( bspot );
+    Point bspot = haveBeamSpot ? beamSpot_->position() : Point(0, 0, 0);
+    if (siTrack.isNonnull())
+      nhits = siTrack->numberOfValidHits();
+    if (globalTrack.isNonnull()) {
+      d0 = -1 * globalTrack->dxy(bspot);
       chi2 = globalTrack->normalizedChi2();
     }
 
-  if( fabs( d0 ) > muond0_ )                          return false;
-  if( muon->pt() < muonpt_ )                          return false;
-  if( fabs( muon->eta() ) > muoneta_ )                return false;
-  if( nhits < muonhits_ )                             return false;
-  if( chi2 > muonchi2_ )                              return false;
-  if( globalTrack->hitPattern().numberOfValidMuonHits() < muonMinValidStaHits_ ) return false;
+    if (fabs(d0) > muond0_)
+      return false;
+    if (muon->pt() < muonpt_)
+      return false;
+    if (fabs(muon->eta()) > muoneta_)
+      return false;
+    if (nhits < muonhits_)
+      return false;
+    if (chi2 > muonchi2_)
+      return false;
+    if (globalTrack->hitPattern().numberOfValidMuonHits() < muonMinValidStaHits_)
+      return false;
 
-  //reject muons with tracker dpt/pt > X
-  if( !siTrack.isNonnull() )                                return false;
-  if( siTrack->ptError() / siTrack->pt() > muon_dptrel_ )   return false;
+    //reject muons with tracker dpt/pt > X
+    if (!siTrack.isNonnull())
+      return false;
+    if (siTrack->ptError() / siTrack->pt() > muon_dptrel_)
+      return false;
 
-  else return true;
-}
+    else
+      return true;
+  }
 
-//____________________________________________________________________________||
-bool MuonTCMETValueMapProducer::isGoodCaloMuon( const reco::Muon* muon, const unsigned int index )
-{
+  //____________________________________________________________________________||
+  bool MuonTCMETValueMapProducer::isGoodCaloMuon(const reco::Muon* muon, const unsigned int index) {
+    if (muon->pt() < 10)
+      return false;
 
-  if( muon->pt() < 10 ) return false;
+    if (!isGoodTrack(muon))
+      return false;
 
-  if( !isGoodTrack( muon ) ) return false;
+    const reco::TrackRef inputSiliconTrack = muon->innerTrack();
+    if (!inputSiliconTrack.isNonnull())
+      return false;
 
-  const reco::TrackRef inputSiliconTrack = muon->innerTrack();
-  if( !inputSiliconTrack.isNonnull() ) return false;
-
-  //check if it is in the vicinity of a global or tracker muon
-  unsigned int nMuons = muons_->size();
-  for (unsigned int iMu = 0; iMu < nMuons; iMu++)
-    {
-
-      if( iMu == index ) continue;
+    //check if it is in the vicinity of a global or tracker muon
+    unsigned int nMuons = muons_->size();
+    for (unsigned int iMu = 0; iMu < nMuons; iMu++) {
+      if (iMu == index)
+        continue;
 
       const reco::Muon* mu = &(*muons_)[iMu];
 
       const reco::TrackRef testSiliconTrack = mu->innerTrack();
-      if( !testSiliconTrack.isNonnull() ) continue;
+      if (!testSiliconTrack.isNonnull())
+        continue;
 
       double deltaEta = inputSiliconTrack.get()->eta() - testSiliconTrack.get()->eta();
-      double deltaPhi = acos( cos( inputSiliconTrack.get()->phi() - testSiliconTrack.get()->phi() ) );
-      double deltaR   = TMath::Sqrt( deltaEta * deltaEta + deltaPhi * deltaPhi );
+      double deltaPhi = acos(cos(inputSiliconTrack.get()->phi() - testSiliconTrack.get()->phi()));
+      double deltaR = TMath::Sqrt(deltaEta * deltaEta + deltaPhi * deltaPhi);
 
-      if( deltaR < muonDeltaR_ ) return false;
+      if (deltaR < muonDeltaR_)
+        return false;
     }
 
-  return true;
-}
+    return true;
+  }
 
-//____________________________________________________________________________||
-bool MuonTCMETValueMapProducer::isGoodTrack( const reco::Muon* muon )
-{
-  double d0;
+  //____________________________________________________________________________||
+  bool MuonTCMETValueMapProducer::isGoodTrack(const reco::Muon* muon) {
+    double d0;
 
-  const reco::TrackRef siTrack = muon->innerTrack();
-  if (!siTrack.isNonnull())
-    return false;
+    const reco::TrackRef siTrack = muon->innerTrack();
+    if (!siTrack.isNonnull())
+      return false;
 
-  if( hasValidVertex )
-    {
+    if (hasValidVertex) {
       //get d0 corrected for primary vertex
-            
-      const Point pvtx = Point(vertices_->begin()->x(),
-			       vertices_->begin()->y(), 
-			       vertices_->begin()->z());
-            
-      double dz = siTrack->dz( pvtx );
-            
-      if( fabs( dz ) < vertexMaxDZ_ ){
-              
-	//get d0 corrected for pvtx
-	d0 = -1 * siTrack->dxy( pvtx );
-              
-      }else{
-              
-	// get d0 corrected for beam spot
-	bool haveBeamSpot = true;
-	if( !beamSpot_.isValid() ) haveBeamSpot = false;
-              
-	Point bspot = haveBeamSpot ? beamSpot_->position() : Point(0,0,0);
-	d0 = -1 * siTrack->dxy( bspot );
-              
+
+      const Point pvtx = Point(vertices_->begin()->x(), vertices_->begin()->y(), vertices_->begin()->z());
+
+      double dz = siTrack->dz(pvtx);
+
+      if (fabs(dz) < vertexMaxDZ_) {
+        //get d0 corrected for pvtx
+        d0 = -1 * siTrack->dxy(pvtx);
+
+      } else {
+        // get d0 corrected for beam spot
+        bool haveBeamSpot = true;
+        if (!beamSpot_.isValid())
+          haveBeamSpot = false;
+
+        Point bspot = haveBeamSpot ? beamSpot_->position() : Point(0, 0, 0);
+        d0 = -1 * siTrack->dxy(bspot);
       }
-    }
-  else
-    {
-       
+    } else {
       // get d0 corrected for beam spot
       bool haveBeamSpot = true;
-      if( !beamSpot_.isValid() ) haveBeamSpot = false;
-       
-      Point bspot = haveBeamSpot ? beamSpot_->position() : Point(0,0,0);
-      d0 = -1 * siTrack->dxy( bspot );
+      if (!beamSpot_.isValid())
+        haveBeamSpot = false;
+
+      Point bspot = haveBeamSpot ? beamSpot_->position() : Point(0, 0, 0);
+      d0 = -1 * siTrack->dxy(bspot);
     }
 
-  if(std::find(trackAlgos_.begin(), trackAlgos_.end(), siTrack->algo()) != trackAlgos_.end())
-    {
+    if (std::find(trackAlgos_.begin(), trackAlgos_.end(), siTrack->algo()) != trackAlgos_.end()) {
       //1st 4 tracking iterations (pT-dependent d0 cut)
-       
-      float d0cut = sqrt(std::pow(d0cuta_,2) + std::pow(d0cutb_/siTrack->pt(),2)); 
-      if(d0cut > maxd0cut_) d0cut = maxd0cut_;
-       
-      if( fabs( d0 ) > d0cut )            return false;
-      if( nLayers( siTrack ) < nLayers_ ) return false;
-    }
-  else
-    {
+
+      float d0cut = sqrt(std::pow(d0cuta_, 2) + std::pow(d0cutb_ / siTrack->pt(), 2));
+      if (d0cut > maxd0cut_)
+        d0cut = maxd0cut_;
+
+      if (fabs(d0) > d0cut)
+        return false;
+      if (nLayers(siTrack) < nLayers_)
+        return false;
+    } else {
       //last 2 tracking iterations (tighten chi2, nhits, pt error cuts)
-     
-      if( siTrack->normalizedChi2() > maxchi2_tight_ )               return false;
-      if( siTrack->numberOfValidHits() < minhits_tight_ )            return false;
-      if( (siTrack->ptError() / siTrack->pt()) > maxPtErr_tight_ )   return false;
-      if( nLayers( siTrack ) < nLayersTight_ )                       return false;
+
+      if (siTrack->normalizedChi2() > maxchi2_tight_)
+        return false;
+      if (siTrack->numberOfValidHits() < minhits_tight_)
+        return false;
+      if ((siTrack->ptError() / siTrack->pt()) > maxPtErr_tight_)
+        return false;
+      if (nLayers(siTrack) < nLayersTight_)
+        return false;
     }
 
-  if( siTrack->numberOfValidHits() < minhits_ )                         return false;
-  if( siTrack->normalizedChi2() > maxchi2_ )                            return false;
-  if( fabs( siTrack->eta() ) > maxeta_ )                                return false;
-  if( siTrack->pt() > maxpt_ )                                          return false;
-  if( (siTrack->ptError() / siTrack->pt()) > maxPtErr_ )                return false;
-  if( fabs( siTrack->eta() ) > 2.5 && siTrack->pt() > maxpt_eta25_ )    return false;
-  if( fabs( siTrack->eta() ) > 2.0 && siTrack->pt() > maxpt_eta20_ )    return false;
+    if (siTrack->numberOfValidHits() < minhits_)
+      return false;
+    if (siTrack->normalizedChi2() > maxchi2_)
+      return false;
+    if (fabs(siTrack->eta()) > maxeta_)
+      return false;
+    if (siTrack->pt() > maxpt_)
+      return false;
+    if ((siTrack->ptError() / siTrack->pt()) > maxPtErr_)
+      return false;
+    if (fabs(siTrack->eta()) > 2.5 && siTrack->pt() > maxpt_eta25_)
+      return false;
+    if (fabs(siTrack->eta()) > 2.0 && siTrack->pt() > maxpt_eta20_)
+      return false;
 
-  int cut = 0;
-  for( unsigned int i = 0; i < trkQuality_.size(); i++ )
-    {
+    int cut = 0;
+    for (unsigned int i = 0; i < trkQuality_.size(); i++) {
       cut |= (1 << trkQuality_.at(i));
     }
 
-  if( !( (siTrack->qualityMask() & cut) == cut ) ) return false;
-	  
-  bool isGoodAlgo = false;
-  if( trkAlgos_.empty() ) isGoodAlgo = true;
-  for( unsigned int i = 0; i < trkAlgos_.size(); i++ )
-    {
-      if( siTrack->algo() == trkAlgos_.at(i) ) isGoodAlgo = true;
+    if (!((siTrack->qualityMask() & cut) == cut))
+      return false;
+
+    bool isGoodAlgo = false;
+    if (trkAlgos_.empty())
+      isGoodAlgo = true;
+    for (unsigned int i = 0; i < trkAlgos_.size(); i++) {
+      if (siTrack->algo() == trkAlgos_.at(i))
+        isGoodAlgo = true;
     }
 
-  if( !isGoodAlgo ) return false;
-	  
-  return true;
-}
+    if (!isGoodAlgo)
+      return false;
 
-//____________________________________________________________________________||
-TVector3 MuonTCMETValueMapProducer::propagateTrack( const reco::Muon* muon)
-{
+    return true;
+  }
 
-  TVector3 outerTrkPosition;
+  //____________________________________________________________________________||
+  TVector3 MuonTCMETValueMapProducer::propagateTrack(const reco::Muon* muon) {
+    TVector3 outerTrkPosition;
 
-  outerTrkPosition.SetPtEtaPhi( 999., -10., 2 * TMath::Pi() );
+    outerTrkPosition.SetPtEtaPhi(999., -10., 2 * TMath::Pi());
 
-  const reco::TrackRef track = muon->innerTrack();
+    const reco::TrackRef track = muon->innerTrack();
 
-  if( !track.isNonnull() )
-    {
+    if (!track.isNonnull()) {
       return outerTrkPosition;
     }
 
-  GlobalPoint  tpVertex ( track->vx(), track->vy(), track->vz() );
-  GlobalVector tpMomentum ( track.get()->px(), track.get()->py(), track.get()->pz() );
-  int tpCharge ( track->charge() );
+    GlobalPoint tpVertex(track->vx(), track->vy(), track->vz());
+    GlobalVector tpMomentum(track.get()->px(), track.get()->py(), track.get()->pz());
+    int tpCharge(track->charge());
 
-  FreeTrajectoryState fts ( tpVertex, tpMomentum, tpCharge, bField);
+    FreeTrajectoryState fts(tpVertex, tpMomentum, tpCharge, bField);
 
-  const double zdist = 314.;
+    const double zdist = 314.;
 
-  const double radius = 130.;
+    const double radius = 130.;
 
-  const double corner = 1.479;
+    const double corner = 1.479;
 
-  Plane::PlanePointer lendcap = Plane::build( Plane::PositionType (0, 0, -zdist), Plane::RotationType () );
-  Plane::PlanePointer rendcap = Plane::build( Plane::PositionType (0, 0, zdist),  Plane::RotationType () );
+    Plane::PlanePointer lendcap = Plane::build(Plane::PositionType(0, 0, -zdist), Plane::RotationType());
+    Plane::PlanePointer rendcap = Plane::build(Plane::PositionType(0, 0, zdist), Plane::RotationType());
 
-  Cylinder::CylinderPointer barrel = Cylinder::build( Cylinder::PositionType (0, 0, 0), Cylinder::RotationType (), radius);
+    Cylinder::CylinderPointer barrel =
+        Cylinder::build(Cylinder::PositionType(0, 0, 0), Cylinder::RotationType(), radius);
 
-  AnalyticalPropagator myAP (bField, alongMomentum, 2*M_PI);
+    AnalyticalPropagator myAP(bField, alongMomentum, 2 * M_PI);
 
-  TrajectoryStateOnSurface tsos;
+    TrajectoryStateOnSurface tsos;
 
-  if( track.get()->eta() < -corner )
-    {
-      tsos = myAP.propagate( fts, *lendcap);
-    }
-  else if( fabs(track.get()->eta()) < corner )
-    {
-      tsos = myAP.propagate( fts, *barrel);
-    }
-  else if( track.get()->eta() > corner )
-    {
-      tsos = myAP.propagate( fts, *rendcap);
+    if (track.get()->eta() < -corner) {
+      tsos = myAP.propagate(fts, *lendcap);
+    } else if (fabs(track.get()->eta()) < corner) {
+      tsos = myAP.propagate(fts, *barrel);
+    } else if (track.get()->eta() > corner) {
+      tsos = myAP.propagate(fts, *rendcap);
     }
 
-  if( tsos.isValid() )
-    outerTrkPosition.SetXYZ( tsos.globalPosition().x(), tsos.globalPosition().y(), tsos.globalPosition().z() );
+    if (tsos.isValid())
+      outerTrkPosition.SetXYZ(tsos.globalPosition().x(), tsos.globalPosition().y(), tsos.globalPosition().z());
 
-  else
-    outerTrkPosition.SetPtEtaPhi( 999., -10., 2 * TMath::Pi() );
+    else
+      outerTrkPosition.SetPtEtaPhi(999., -10., 2 * TMath::Pi());
 
-  return outerTrkPosition;
-}
+    return outerTrkPosition;
+  }
 
+  //____________________________________________________________________________||
+  int MuonTCMETValueMapProducer::nLayers(const reco::TrackRef track) {
+    const reco::HitPattern& p = track->hitPattern();
+    return p.trackerLayersWithMeasurement();
+  }
 
-//____________________________________________________________________________||
-int MuonTCMETValueMapProducer::nLayers(const reco::TrackRef track)
-{
-  const reco::HitPattern& p = track->hitPattern();
-  return p.trackerLayersWithMeasurement();
-}
+  //____________________________________________________________________________||
+  bool MuonTCMETValueMapProducer::isValidVertex() {
+    if (vertices_->begin()->isFake())
+      return false;
+    if (vertices_->begin()->ndof() < vertexNdof_)
+      return false;
+    if (fabs(vertices_->begin()->z()) > vertexZ_)
+      return false;
+    if (sqrt(std::pow(vertices_->begin()->x(), 2) + std::pow(vertices_->begin()->y(), 2)) > vertexRho_)
+      return false;
 
-//____________________________________________________________________________||
-bool MuonTCMETValueMapProducer::isValidVertex()
-{
-  if( vertices_->begin()->isFake()                ) return false;
-  if( vertices_->begin()->ndof() < vertexNdof_    ) return false;
-  if( fabs( vertices_->begin()->z() ) > vertexZ_  ) return false;
-  if( sqrt( std::pow( vertices_->begin()->x() , 2 ) + std::pow( vertices_->begin()->y() , 2 ) ) > vertexRho_ ) return false;
-    
-  return true;
-    
-}
+    return true;
+  }
 
-}
+}  // namespace cms
 
 //____________________________________________________________________________||

--- a/RecoMET/METProducers/src/PFClusterMETProducer.cc
+++ b/RecoMET/METProducers/src/PFClusterMETProducer.cc
@@ -26,22 +26,18 @@
 #include <cstring>
 
 //____________________________________________________________________________||
-namespace cms
-{
+namespace cms {
 
-//____________________________________________________________________________||
+  //____________________________________________________________________________||
   PFClusterMETProducer::PFClusterMETProducer(const edm::ParameterSet& iConfig)
-    : inputToken_(consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("src")))
-    , globalThreshold_(iConfig.getParameter<double>("globalThreshold"))
-  {
+      : inputToken_(consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("src"))),
+        globalThreshold_(iConfig.getParameter<double>("globalThreshold")) {
     std::string alias = iConfig.exists("alias") ? iConfig.getParameter<std::string>("alias") : "";
     produces<reco::PFClusterMETCollection>().setBranchAlias(alias);
   }
 
-
-//____________________________________________________________________________||
-  void PFClusterMETProducer::produce(edm::Event& event, const edm::EventSetup& setup)
-  {
+  //____________________________________________________________________________||
+  void PFClusterMETProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
     edm::Handle<edm::View<reco::Candidate> > input;
     event.getByToken(inputToken_, input);
 
@@ -55,8 +51,8 @@ namespace cms
     event.put(std::move(pfclustermetcoll));
   }
 
-//____________________________________________________________________________||
+  //____________________________________________________________________________||
   DEFINE_FWK_MODULE(PFClusterMETProducer);
-}
+}  // namespace cms
 
 //____________________________________________________________________________||

--- a/RecoMET/METProducers/src/PFMETProducer.cc
+++ b/RecoMET/METProducers/src/PFMETProducer.cc
@@ -9,39 +9,35 @@
 #include "RecoMET/METProducers/interface/PFMETProducer.h"
 
 //____________________________________________________________________________||
-namespace cms
-{
+namespace cms {
 
-//____________________________________________________________________________||
+  //____________________________________________________________________________||
   PFMETProducer::PFMETProducer(const edm::ParameterSet& iConfig)
-    : inputToken_(consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("src")))
-    , calculateSignificance_(iConfig.getParameter<bool>("calculateSignificance"))
-    , globalThreshold_(iConfig.getParameter<double>("globalThreshold"))
-  {
-    if(calculateSignificance_)
-      {
-	metSigAlgo_ = new metsig::METSignificance(iConfig);
-	
-	jetToken_ = mayConsume<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>("srcJets"));
-	std::vector<edm::InputTag> srcLeptonsTags = iConfig.getParameter< std::vector<edm::InputTag> >("srcLeptons");
-	for(std::vector<edm::InputTag>::const_iterator it=srcLeptonsTags.begin();it!=srcLeptonsTags.end();it++) {
-	  lepTokens_.push_back( mayConsume<edm::View<reco::Candidate> >( *it ) );
-	}
-  
-	jetSFType_ = iConfig.getParameter<std::string>("srcJetSF");
-	jetResPtType_ = iConfig.getParameter<std::string>("srcJetResPt");
-	jetResPhiType_ = iConfig.getParameter<std::string>("srcJetResPhi");
-	rhoToken_ = consumes<double>(iConfig.getParameter<edm::InputTag>("srcRho"));
+      : inputToken_(consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>("src"))),
+        calculateSignificance_(iConfig.getParameter<bool>("calculateSignificance")),
+        globalThreshold_(iConfig.getParameter<double>("globalThreshold")) {
+    if (calculateSignificance_) {
+      metSigAlgo_ = new metsig::METSignificance(iConfig);
+
+      jetToken_ = mayConsume<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>("srcJets"));
+      std::vector<edm::InputTag> srcLeptonsTags = iConfig.getParameter<std::vector<edm::InputTag> >("srcLeptons");
+      for (std::vector<edm::InputTag>::const_iterator it = srcLeptonsTags.begin(); it != srcLeptonsTags.end(); it++) {
+        lepTokens_.push_back(mayConsume<edm::View<reco::Candidate> >(*it));
       }
+
+      jetSFType_ = iConfig.getParameter<std::string>("srcJetSF");
+      jetResPtType_ = iConfig.getParameter<std::string>("srcJetResPt");
+      jetResPhiType_ = iConfig.getParameter<std::string>("srcJetResPhi");
+      rhoToken_ = consumes<double>(iConfig.getParameter<edm::InputTag>("srcRho"));
+    }
 
     std::string alias = iConfig.exists("alias") ? iConfig.getParameter<std::string>("alias") : "";
 
     produces<reco::PFMETCollection>().setBranchAlias(alias);
   }
 
-//____________________________________________________________________________||
-  void PFMETProducer::produce(edm::Event& event, const edm::EventSetup& setup)
-  {
+  //____________________________________________________________________________||
+  void PFMETProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
     edm::Handle<edm::View<reco::Candidate> > input;
     event.getByToken(inputToken_, input);
 
@@ -56,11 +52,10 @@ namespace cms
 
     reco::PFMET pfmet(specific, commonMETdata.sumet, p4, vtx);
 
-    if(calculateSignificance_)
-      {
-	reco::METCovMatrix sigcov = getMETCovMatrix(event, setup, input);
-	pfmet.setSignificanceMatrix(sigcov);
-      }
+    if (calculateSignificance_) {
+      reco::METCovMatrix sigcov = getMETCovMatrix(event, setup, input);
+      pfmet.setSignificanceMatrix(sigcov);
+    }
 
     auto pfmetcoll = std::make_unique<reco::PFMETCollection>();
 
@@ -68,48 +63,45 @@ namespace cms
     event.put(std::move(pfmetcoll));
   }
 
-
-
-  reco::METCovMatrix PFMETProducer::getMETCovMatrix(const edm::Event& event, const edm::EventSetup& setup, const edm::Handle<edm::View<reco::Candidate> >& candInput) const {
-
-	// leptons
-	std::vector< edm::Handle<reco::CandidateView> > leptons;
-	for ( std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator srcLeptons_i = lepTokens_.begin();
-	      srcLeptons_i != lepTokens_.end(); ++srcLeptons_i ) {
-	  edm::Handle<reco::CandidateView> leptons_i;
-	  event.getByToken(*srcLeptons_i, leptons_i);
-     leptons.push_back( leptons_i );
-     /*
+  reco::METCovMatrix PFMETProducer::getMETCovMatrix(const edm::Event& event,
+                                                    const edm::EventSetup& setup,
+                                                    const edm::Handle<edm::View<reco::Candidate> >& candInput) const {
+    // leptons
+    std::vector<edm::Handle<reco::CandidateView> > leptons;
+    for (std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator srcLeptons_i = lepTokens_.begin();
+         srcLeptons_i != lepTokens_.end();
+         ++srcLeptons_i) {
+      edm::Handle<reco::CandidateView> leptons_i;
+      event.getByToken(*srcLeptons_i, leptons_i);
+      leptons.push_back(leptons_i);
+      /*
 	  for ( reco::CandidateView::const_iterator lepton = leptons_i->begin();
 		lepton != leptons_i->end(); ++lepton ) {
 	    leptons.push_back(*lepton);
 	  }
      */
-	}
+    }
 
-	// jets
-	edm::Handle<edm::View<reco::Jet> > inputJets;
-	event.getByToken( jetToken_, inputJets );
+    // jets
+    edm::Handle<edm::View<reco::Jet> > inputJets;
+    event.getByToken(jetToken_, inputJets);
 
-	JME::JetResolution resPtObj = JME::JetResolution::get(setup, jetResPtType_);
-	JME::JetResolution resPhiObj = JME::JetResolution::get(setup, jetResPhiType_);
-	JME::JetResolutionScaleFactor resSFObj = JME::JetResolutionScaleFactor::get(setup, jetSFType_);
+    JME::JetResolution resPtObj = JME::JetResolution::get(setup, jetResPtType_);
+    JME::JetResolution resPhiObj = JME::JetResolution::get(setup, jetResPhiType_);
+    JME::JetResolutionScaleFactor resSFObj = JME::JetResolutionScaleFactor::get(setup, jetSFType_);
 
-	edm::Handle<double> rho;
-	event.getByToken(rhoToken_, rho);
+    edm::Handle<double> rho;
+    event.getByToken(rhoToken_, rho);
 
-	//Compute the covariance matrix and fill it
-	reco::METCovMatrix cov = metSigAlgo_->getCovariance( *inputJets, leptons, candInput, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData() );
+    //Compute the covariance matrix and fill it
+    reco::METCovMatrix cov = metSigAlgo_->getCovariance(
+        *inputJets, leptons, candInput, *rho, resPtObj, resPhiObj, resSFObj, event.isRealData());
 
-	return cov;
+    return cov;
   }
 
-
-
-
-
-//____________________________________________________________________________||
+  //____________________________________________________________________________||
   DEFINE_FWK_MODULE(PFMETProducer);
-}
+}  // namespace cms
 
 //____________________________________________________________________________||

--- a/RecoMET/METProducers/src/ParticleFlowForChargedMETProducer.cc
+++ b/RecoMET/METProducers/src/ParticleFlowForChargedMETProducer.cc
@@ -7,23 +7,20 @@ using namespace edm;
 using namespace std;
 using namespace reco;
 
-ParticleFlowForChargedMETProducer::ParticleFlowForChargedMETProducer(const edm::ParameterSet& iConfig)
-{
-  pfCollectionLabel    = iConfig.getParameter<edm::InputTag>("PFCollectionLabel");
-  pvCollectionLabel    = iConfig.getParameter<edm::InputTag>("PVCollectionLabel");
+ParticleFlowForChargedMETProducer::ParticleFlowForChargedMETProducer(const edm::ParameterSet& iConfig) {
+  pfCollectionLabel = iConfig.getParameter<edm::InputTag>("PFCollectionLabel");
+  pvCollectionLabel = iConfig.getParameter<edm::InputTag>("PVCollectionLabel");
 
   pfCandidatesToken = consumes<PFCandidateCollection>(pfCollectionLabel);
   pvCollectionToken = consumes<VertexCollection>(pvCollectionLabel);
 
-  dzCut    = iConfig.getParameter<double>("dzCut");
-  neutralEtThreshold    = iConfig.getParameter<double>("neutralEtThreshold");
+  dzCut = iConfig.getParameter<double>("dzCut");
+  neutralEtThreshold = iConfig.getParameter<double>("neutralEtThreshold");
 
   produces<PFCandidateCollection>();
 }
 
-void ParticleFlowForChargedMETProducer::produce(Event& iEvent, const EventSetup& iSetup)
-{
-
+void ParticleFlowForChargedMETProducer::produce(Event& iEvent, const EventSetup& iSetup) {
   //Get the PV collection
   Handle<VertexCollection> pvCollection;
   iEvent.getByToken(pvCollectionToken, pvCollection);
@@ -36,31 +33,26 @@ void ParticleFlowForChargedMETProducer::produce(Event& iEvent, const EventSetup&
   // the output collection
   auto chargedPFCandidates = std::make_unique<PFCandidateCollection>();
   if (!pvCollection->empty()) {
-    for( unsigned i=0; i<pfCandidates->size(); i++ ) {
+    for (unsigned i = 0; i < pfCandidates->size(); i++) {
       const PFCandidate& pfCand = (*pfCandidates)[i];
       PFCandidatePtr pfCandPtr(pfCandidates, i);
-      
-      if (pfCandPtr->trackRef().isNonnull()) { 
-	if (pfCandPtr->trackRef()->dz((*vertex).position()) < dzCut) {
-	  chargedPFCandidates->push_back( pfCand );
-	  chargedPFCandidates->back().setSourceCandidatePtr( pfCandPtr );
-	}
-	
-      }
-      else if (neutralEtThreshold>0 and 
-	       pfCandPtr->pt()>neutralEtThreshold) {
-	chargedPFCandidates->push_back( pfCand );
-	chargedPFCandidates->back().setSourceCandidatePtr( pfCandPtr );
-      }  
-	
 
+      if (pfCandPtr->trackRef().isNonnull()) {
+        if (pfCandPtr->trackRef()->dz((*vertex).position()) < dzCut) {
+          chargedPFCandidates->push_back(pfCand);
+          chargedPFCandidates->back().setSourceCandidatePtr(pfCandPtr);
+        }
+
+      } else if (neutralEtThreshold > 0 and pfCandPtr->pt() > neutralEtThreshold) {
+        chargedPFCandidates->push_back(pfCand);
+        chargedPFCandidates->back().setSourceCandidatePtr(pfCandPtr);
+      }
     }
   }
-
 
   iEvent.put(std::move(chargedPFCandidates));
 
   return;
 }
 
-ParticleFlowForChargedMETProducer::~ParticleFlowForChargedMETProducer(){}
+ParticleFlowForChargedMETProducer::~ParticleFlowForChargedMETProducer() {}

--- a/RecoMET/METProducers/src/SealModule.cc
+++ b/RecoMET/METProducers/src/SealModule.cc
@@ -3,17 +3,17 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "RecoMET/METProducers/interface/BeamHaloSummaryProducer.h"
-#include "RecoMET/METProducers/interface/CSCHaloDataProducer.h" 
-#include "RecoMET/METProducers/interface/HcalHaloDataProducer.h" 
-#include "RecoMET/METProducers/interface/EcalHaloDataProducer.h" 
-#include "RecoMET/METProducers/interface/GlobalHaloDataProducer.h" 
-#include "RecoMET/METProducers/interface/ParticleFlowForChargedMETProducer.h" 
+#include "RecoMET/METProducers/interface/CSCHaloDataProducer.h"
+#include "RecoMET/METProducers/interface/HcalHaloDataProducer.h"
+#include "RecoMET/METProducers/interface/EcalHaloDataProducer.h"
+#include "RecoMET/METProducers/interface/GlobalHaloDataProducer.h"
+#include "RecoMET/METProducers/interface/ParticleFlowForChargedMETProducer.h"
 
 using reco::BeamHaloSummaryProducer;
 using reco::CSCHaloDataProducer;
-using reco::HcalHaloDataProducer;
 using reco::EcalHaloDataProducer;
 using reco::GlobalHaloDataProducer;
+using reco::HcalHaloDataProducer;
 using reco::ParticleFlowForChargedMETProducer;
 
 DEFINE_FWK_MODULE(BeamHaloSummaryProducer);

--- a/RecoMET/METProducers/src/TCMETProducer.cc
+++ b/RecoMET/METProducers/src/TCMETProducer.cc
@@ -16,12 +16,10 @@
 #include <cstring>
 
 //____________________________________________________________________________||
-namespace cms
-{
+namespace cms {
 
-//____________________________________________________________________________||
-  TCMETProducer::TCMETProducer(const edm::ParameterSet& iConfig)
-  {
+  //____________________________________________________________________________||
+  TCMETProducer::TCMETProducer(const edm::ParameterSet& iConfig) {
     std::string alias = iConfig.exists("alias") ? iConfig.getParameter<std::string>("alias") : "";
 
     produces<reco::METCollection>().setBranchAlias(alias);
@@ -29,16 +27,15 @@ namespace cms
     tcMetAlgo_.configure(iConfig, consumesCollector());
   }
 
-//____________________________________________________________________________||
-  void TCMETProducer::produce(edm::Event& event, const edm::EventSetup& setup)
-  {
-    auto tcmetcoll = std::make_unique<reco::METCollection>(); 
+  //____________________________________________________________________________||
+  void TCMETProducer::produce(edm::Event& event, const edm::EventSetup& setup) {
+    auto tcmetcoll = std::make_unique<reco::METCollection>();
     tcmetcoll->push_back(tcMetAlgo_.CalculateTCMET(event, setup));
     event.put(std::move(tcmetcoll));
   }
 
-//____________________________________________________________________________||
+  //____________________________________________________________________________||
   DEFINE_FWK_MODULE(TCMETProducer);
-}
+}  // namespace cms
 
 //____________________________________________________________________________||

--- a/RecoParticleFlow/PFClusterProducer/interface/CaloRecHitResolutionProvider.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/CaloRecHitResolutionProvider.h
@@ -5,65 +5,56 @@
 
 #include <cmath>
 
-class CaloRecHitResolutionProvider{
- public:
+class CaloRecHitResolutionProvider {
+public:
   CaloRecHitResolutionProvider(const edm::ParameterSet& iConfig) {
-    noiseTerm_ = iConfig.getParameter<double>("noiseTerm"); 
-    constantTerm2_ = std::pow(iConfig.getParameter<double>("constantTerm"), 2); 
-    noiseTermLowE_ = iConfig.getParameter<double>("noiseTermLowE"); 
-    corrTermLowE_ = iConfig.getParameter<double>("corrTermLowE"); 
-    constantTermLowE2_ = std::pow(iConfig.getParameter<double>("constantTermLowE"), 2); 
-    threshLowE_ = iConfig.getParameter<double>("threshLowE"); 
-    threshHighE_ = iConfig.getParameter<double>("threshHighE"); 
+    noiseTerm_ = iConfig.getParameter<double>("noiseTerm");
+    constantTerm2_ = std::pow(iConfig.getParameter<double>("constantTerm"), 2);
+    noiseTermLowE_ = iConfig.getParameter<double>("noiseTermLowE");
+    corrTermLowE_ = iConfig.getParameter<double>("corrTermLowE");
+    constantTermLowE2_ = std::pow(iConfig.getParameter<double>("constantTermLowE"), 2);
+    threshLowE_ = iConfig.getParameter<double>("threshLowE");
+    threshHighE_ = iConfig.getParameter<double>("threshHighE");
 
-    resHighE2_ = std::pow((noiseTerm_/threshHighE_), 2) + constantTerm2_;
+    resHighE2_ = std::pow((noiseTerm_ / threshHighE_), 2) + constantTerm2_;
   }
 
-  double timeResolution2(double energy)
-  {
+  double timeResolution2(double energy) {
     double res2 = 10000.;
 
     if (energy <= 0.)
       return res2;
-    else if (energy < threshLowE_)
-    {
-      if (corrTermLowE_ > 0.) {// different parametrisation
-        const double res = noiseTermLowE_/energy + corrTermLowE_/(energy*energy);
-        res2 = res*res;
+    else if (energy < threshLowE_) {
+      if (corrTermLowE_ > 0.) {  // different parametrisation
+        const double res = noiseTermLowE_ / energy + corrTermLowE_ / (energy * energy);
+        res2 = res * res;
+      } else {
+        const double noiseDivE = noiseTermLowE_ / energy;
+        res2 = noiseDivE * noiseDivE + constantTermLowE2_;
       }
-      else {
-        const double noiseDivE = noiseTermLowE_/energy;
-        res2 = noiseDivE*noiseDivE + constantTermLowE2_;
-      }
-    }
-    else if (energy < threshHighE_) {
-      const double noiseDivE = noiseTerm_/energy;
-      res2 = noiseDivE*noiseDivE + constantTerm2_;
-    }
-    else // if (energy >=threshHighE_)
+    } else if (energy < threshHighE_) {
+      const double noiseDivE = noiseTerm_ / energy;
+      res2 = noiseDivE * noiseDivE + constantTerm2_;
+    } else  // if (energy >=threshHighE_)
       res2 = resHighE2_;
 
     if (res2 > 10000.)
       return 10000.;
     return res2;
-    
   }
+
 private:
+  double noiseTerm_;      // Noise term
+  double constantTerm2_;  // Constant term
 
-  double noiseTerm_; // Noise term
-  double constantTerm2_; // Constant term
+  double noiseTermLowE_;      // Noise term for low E
+  double constantTermLowE2_;  // Constant term for low E
+  double corrTermLowE_;       // 2nd term for low E, different parametrisation
 
-  double noiseTermLowE_; // Noise term for low E
-  double constantTermLowE2_; // Constant term for low E
-  double corrTermLowE_; // 2nd term for low E, different parametrisation
+  double threshLowE_;   // different parametrisation below
+  double threshHighE_;  // resolution constant above
 
-  double threshLowE_; // different parametrisation below
-  double threshHighE_; // resolution constant above
-
-  double resHighE2_; // precompute res at high E
-
+  double resHighE2_;  // precompute res at high E
 };
 
 #endif
-
-

--- a/RecoParticleFlow/PFClusterProducer/interface/HGCRecHitNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/HGCRecHitNavigator.h
@@ -1,7 +1,6 @@
 #ifndef RecoParticleFlow_PFClusterProducer_HGCRecHitNavigator_h
 #define RecoParticleFlow_PFClusterProducer_HGCRecHitNavigator_h
 
-
 #include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h"
 #include "DataFormats/ParticleFlowReco/interface/PFLayer.h"
 #include "DataFormats/ForwardDetId/interface/ForwardSubdetector.h"
@@ -9,49 +8,51 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
-template <ForwardSubdetector D1, typename hgcee,
-          ForwardSubdetector D2, typename hgchef,
-          ForwardSubdetector D3, typename hgcheb>
+template <ForwardSubdetector D1,
+          typename hgcee,
+          ForwardSubdetector D2,
+          typename hgchef,
+          ForwardSubdetector D3,
+          typename hgcheb>
 class HGCRecHitNavigator : public PFRecHitNavigatorBase {
- public:
+public:
   HGCRecHitNavigator() = default;
 
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
     edm::ParameterSetDescription desc;
-    
-    desc.add<std::string>("name","PFRecHitHGCNavigator");
+
+    desc.add<std::string>("name", "PFRecHitHGCNavigator");
 
     edm::ParameterSetDescription descee;
-    descee.add<std::string>("name","PFRecHitHGCEENavigator");
-    descee.add<std::string>("topologySource","HGCalEESensitive");
+    descee.add<std::string>("name", "PFRecHitHGCEENavigator");
+    descee.add<std::string>("topologySource", "HGCalEESensitive");
     desc.add<edm::ParameterSetDescription>("hgcee", descee);
-    
+
     edm::ParameterSetDescription deschef;
-    deschef.add<std::string>("name","PFRecHitHGCHENavigator");
-    deschef.add<std::string>("topologySource","HGCalHESiliconSensitive");
+    deschef.add<std::string>("name", "PFRecHitHGCHENavigator");
+    deschef.add<std::string>("topologySource", "HGCalHESiliconSensitive");
     desc.add<edm::ParameterSetDescription>("hgchef", deschef);
-    
+
     edm::ParameterSetDescription descheb;
-    deschef.add<std::string>("name","PFRecHitHGCHENavigator");
-    deschef.add<std::string>("topologySource","HGCalHEScintillatorSensitive");
+    deschef.add<std::string>("name", "PFRecHitHGCHENavigator");
+    deschef.add<std::string>("topologySource", "HGCalHEScintillatorSensitive");
     desc.add<edm::ParameterSetDescription>("hgcheb", descheb);
-    
+
     descriptions.add("navigator", desc);
   }
-  
 
   HGCRecHitNavigator(const edm::ParameterSet& iConfig) {
-    if( iConfig.exists("hgcee") ) {
+    if (iConfig.exists("hgcee")) {
       eeNav_ = new hgcee(iConfig.getParameter<edm::ParameterSet>("hgcee"));
     } else {
       eeNav_ = nullptr;
     }
-    if( iConfig.exists("hgchef") ) {
+    if (iConfig.exists("hgchef")) {
       hefNav_ = new hgchef(iConfig.getParameter<edm::ParameterSet>("hgchef"));
     } else {
       hefNav_ = nullptr;
     }
-    if( iConfig.exists("hgcheb") ) {
+    if (iConfig.exists("hgcheb")) {
       hebNav_ = new hgcheb(iConfig.getParameter<edm::ParameterSet>("hgcheb"));
     } else {
       hebNav_ = nullptr;
@@ -59,31 +60,39 @@ class HGCRecHitNavigator : public PFRecHitNavigatorBase {
   }
 
   void beginEvent(const edm::EventSetup& iSetup) override {
-    if( nullptr != eeNav_ )  eeNav_->beginEvent(iSetup); 
-    if( nullptr != hefNav_ ) hefNav_->beginEvent(iSetup);
-    if( nullptr != hebNav_ ) hebNav_->beginEvent(iSetup);
+    if (nullptr != eeNav_)
+      eeNav_->beginEvent(iSetup);
+    if (nullptr != hefNav_)
+      hefNav_->beginEvent(iSetup);
+    if (nullptr != hebNav_)
+      hebNav_->beginEvent(iSetup);
   }
 
-  void associateNeighbours(reco::PFRecHit& hit,std::unique_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd) override {
-    switch( DetId(hit.detId()).subdetId() ) {
-    case D1:
-      if( nullptr != eeNav_ )  eeNav_->associateNeighbours(hit,hits,refProd);
-      break;
-    case D2:
-      if( nullptr != hefNav_ ) hefNav_->associateNeighbours(hit,hits,refProd);
-      break;
-    case D3:
-      if( nullptr != hebNav_ ) hebNav_->associateNeighbours(hit,hits,refProd);
-      break;
-    default:
-      break;
-    }     
+  void associateNeighbours(reco::PFRecHit& hit,
+                           std::unique_ptr<reco::PFRecHitCollection>& hits,
+                           edm::RefProd<reco::PFRecHitCollection>& refProd) override {
+    switch (DetId(hit.detId()).subdetId()) {
+      case D1:
+        if (nullptr != eeNav_)
+          eeNav_->associateNeighbours(hit, hits, refProd);
+        break;
+      case D2:
+        if (nullptr != hefNav_)
+          hefNav_->associateNeighbours(hit, hits, refProd);
+        break;
+      case D3:
+        if (nullptr != hebNav_)
+          hebNav_->associateNeighbours(hit, hits, refProd);
+        break;
+      default:
+        break;
+    }
   }
-  
- protected:
-      hgcee  *eeNav_;
-      hgchef *hefNav_;
-      hgcheb *hebNav_;
+
+protected:
+  hgcee* eeNav_;
+  hgchef* hefNav_;
+  hgcheb* hebNav_;
 };
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h
@@ -17,109 +17,106 @@
 namespace edm {
   class Event;
   class EventSetup;
-}
+}  // namespace edm
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 class InitialClusteringStepBase {
   typedef InitialClusteringStepBase ICSB;
- public:
-   InitialClusteringStepBase(const edm::ParameterSet& conf,
-			     edm::ConsumesCollector& sumes):    
-    _nSeeds(0), _nClustersFound(0),
-    _layerMap({ {"PS2",(int)PFLayer::PS2},
-	        {"PS1",(int)PFLayer::PS1},
-	        {"ECAL_ENDCAP",(int)PFLayer::ECAL_ENDCAP},
-	        {"ECAL_BARREL",(int)PFLayer::ECAL_BARREL},
-	        {"NONE",(int)PFLayer::NONE},
-	        {"HCAL_BARREL1",(int)PFLayer::HCAL_BARREL1},
-	        {"HCAL_BARREL2_RING0",(int)PFLayer::HCAL_BARREL2},
-		{"HCAL_BARREL2_RING1",100*(int)PFLayer::HCAL_BARREL2},
-	        {"HCAL_ENDCAP",(int)PFLayer::HCAL_ENDCAP},
-	        {"HF_EM",(int)PFLayer::HF_EM},
-		{"HF_HAD",(int)PFLayer::HF_HAD},
-		{"HGCAL",(int)PFLayer::HGCAL} }),
-    _algoName(conf.getParameter<std::string>("algoName")) { 
-    const std::vector<edm::ParameterSet>& thresholds =
-    conf.getParameterSetVector("thresholdsByDetector");
-    for( const auto& pset : thresholds ) {
+
+public:
+  InitialClusteringStepBase(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+      : _nSeeds(0),
+        _nClustersFound(0),
+        _layerMap({{"PS2", (int)PFLayer::PS2},
+                   {"PS1", (int)PFLayer::PS1},
+                   {"ECAL_ENDCAP", (int)PFLayer::ECAL_ENDCAP},
+                   {"ECAL_BARREL", (int)PFLayer::ECAL_BARREL},
+                   {"NONE", (int)PFLayer::NONE},
+                   {"HCAL_BARREL1", (int)PFLayer::HCAL_BARREL1},
+                   {"HCAL_BARREL2_RING0", (int)PFLayer::HCAL_BARREL2},
+                   {"HCAL_BARREL2_RING1", 100 * (int)PFLayer::HCAL_BARREL2},
+                   {"HCAL_ENDCAP", (int)PFLayer::HCAL_ENDCAP},
+                   {"HF_EM", (int)PFLayer::HF_EM},
+                   {"HF_HAD", (int)PFLayer::HF_HAD},
+                   {"HGCAL", (int)PFLayer::HGCAL}}),
+        _algoName(conf.getParameter<std::string>("algoName")) {
+    const std::vector<edm::ParameterSet>& thresholds = conf.getParameterSetVector("thresholdsByDetector");
+    for (const auto& pset : thresholds) {
       const std::string& det = pset.getParameter<std::string>("detector");
 
       std::vector<int> depths;
       std::vector<double> thresh_E;
-      std::vector<double> thresh_pT ;
+      std::vector<double> thresh_pT;
       std::vector<double> thresh_pT2;
 
-      if (det==std::string("HCAL_BARREL1") || det==std::string("HCAL_ENDCAP")) {
-	depths = pset.getParameter<std::vector<int> >("depths");
-	thresh_E = pset.getParameter<std::vector<double> >("gatheringThreshold");
-	thresh_pT = pset.getParameter<std::vector<double> >("gatheringThresholdPt");
-	if(thresh_E.size()!=depths.size() || thresh_pT.size()!=depths.size()) {
-	  throw cms::Exception("InvalidGatheringThreshold")
-	    << "gatheringThresholds mismatch with the numbers of depths";
-	}
+      if (det == std::string("HCAL_BARREL1") || det == std::string("HCAL_ENDCAP")) {
+        depths = pset.getParameter<std::vector<int> >("depths");
+        thresh_E = pset.getParameter<std::vector<double> >("gatheringThreshold");
+        thresh_pT = pset.getParameter<std::vector<double> >("gatheringThresholdPt");
+        if (thresh_E.size() != depths.size() || thresh_pT.size() != depths.size()) {
+          throw cms::Exception("InvalidGatheringThreshold")
+              << "gatheringThresholds mismatch with the numbers of depths";
+        }
       } else {
-	depths.push_back(0);
-	thresh_E.push_back(pset.getParameter<double>("gatheringThreshold"));
-	thresh_pT.push_back(pset.getParameter<double>("gatheringThresholdPt"));
+        depths.push_back(0);
+        thresh_E.push_back(pset.getParameter<double>("gatheringThreshold"));
+        thresh_pT.push_back(pset.getParameter<double>("gatheringThresholdPt"));
       }
 
-      for(unsigned int i=0;i < thresh_pT.size();++i){
-	thresh_pT2.push_back(thresh_pT[i]*thresh_pT[i]);
+      for (unsigned int i = 0; i < thresh_pT.size(); ++i) {
+        thresh_pT2.push_back(thresh_pT[i] * thresh_pT[i]);
       }
 
       auto entry = _layerMap.find(det);
-      if( entry == _layerMap.end() ) {
-	throw cms::Exception("InvalidDetectorLayer")
-	  << "Detector layer : " << det << " is not in the list of recognized"
-	  << " detector layers!";
+      if (entry == _layerMap.end()) {
+        throw cms::Exception("InvalidDetectorLayer")
+            << "Detector layer : " << det << " is not in the list of recognized"
+            << " detector layers!";
       }
-      _thresholds.emplace(_layerMap.find(det)->second, 
-			  std::make_tuple(depths,thresh_E,thresh_pT2));
-  }
+      _thresholds.emplace(_layerMap.find(det)->second, std::make_tuple(depths, thresh_E, thresh_pT2));
+    }
   }
   virtual ~InitialClusteringStepBase() = default;
   // get rid of things we should never use...
   InitialClusteringStepBase(const ICSB&) = delete;
   ICSB& operator=(const ICSB&) = delete;
 
-  virtual void update(const edm::EventSetup&) { }
+  virtual void update(const edm::EventSetup&) {}
 
-  virtual void updateEvent(const edm::Event&) { }
+  virtual void updateEvent(const edm::Event&) {}
 
   virtual void buildClusters(const edm::Handle<reco::PFRecHitCollection>&,
-			     const std::vector<bool>& mask,  // mask flags
-			     const std::vector<bool>& seeds, // seed flags
-			     reco::PFClusterCollection&) = 0; //output
+                             const std::vector<bool>& mask,    // mask flags
+                             const std::vector<bool>& seeds,   // seed flags
+                             reco::PFClusterCollection&) = 0;  //output
 
   std::ostream& operator<<(std::ostream& o) const {
-    o << "InitialClusteringStep with algo \"" << _algoName 
-      << "\" located " << _nSeeds << " seeds and built " 
+    o << "InitialClusteringStep with algo \"" << _algoName << "\" located " << _nSeeds << " seeds and built "
       << _nClustersFound << " clusters from those seeds. ";
     return o;
   }
 
   void reset() { _nSeeds = _nClustersFound = 0; }
 
- protected:
-  reco::PFRecHitRef makeRefhit( const edm::Handle<reco::PFRecHitCollection>& h,
-				const unsigned i ) const { 
-    return reco::PFRecHitRef(h,i);
+protected:
+  reco::PFRecHitRef makeRefhit(const edm::Handle<reco::PFRecHitCollection>& h, const unsigned i) const {
+    return reco::PFRecHitRef(h, i);
   }
-  unsigned _nSeeds, _nClustersFound; // basic performance information
-  const std::unordered_map<std::string,int> _layerMap;
+  unsigned _nSeeds, _nClustersFound;  // basic performance information
+  const std::unordered_map<std::string, int> _layerMap;
 
-  typedef std::tuple<std::vector<int> ,std::vector<double> , std::vector<double> > I3tuple;
-  std::unordered_map<int,I3tuple > _thresholds;
- 
- private:
+  typedef std::tuple<std::vector<int>, std::vector<double>, std::vector<double> > I3tuple;
+  std::unordered_map<int, I3tuple> _thresholds;
+
+private:
   const std::string _algoName;
-  
 };
 
 std::ostream& operator<<(std::ostream& o, const InitialClusteringStepBase& a);
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory< InitialClusteringStepBase* (const edm::ParameterSet&, edm::ConsumesCollector&) > InitialClusteringStepFactory;
+typedef edmplugin::PluginFactory<InitialClusteringStepBase*(const edm::ParameterSet&, edm::ConsumesCollector&)>
+    InitialClusteringStepFactory;
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h
@@ -13,16 +13,17 @@ namespace edm {
 
 class PFCPositionCalculatorBase {
   typedef PFCPositionCalculatorBase PosCalc;
- public:
-  PFCPositionCalculatorBase(const edm::ParameterSet& conf) :
-    _minFractionInCalc(conf.getParameter<double>("minFractionInCalc")),
-    _algoName(conf.getParameter<std::string>("algoName")) { }
+
+public:
+  PFCPositionCalculatorBase(const edm::ParameterSet& conf)
+      : _minFractionInCalc(conf.getParameter<double>("minFractionInCalc")),
+        _algoName(conf.getParameter<std::string>("algoName")) {}
   virtual ~PFCPositionCalculatorBase() = default;
   //get rid of things we should never use
   PFCPositionCalculatorBase(const PosCalc&) = delete;
   PosCalc& operator=(const PosCalc&) = delete;
 
-  virtual void update(const edm::EventSetup&) { }
+  virtual void update(const edm::EventSetup&) {}
 
   // here we transform one PFCluster to use the new position calculation
   virtual void calculateAndSetPosition(reco::PFCluster&) = 0;
@@ -30,17 +31,16 @@ class PFCPositionCalculatorBase {
   virtual void calculateAndSetPositions(reco::PFClusterCollection&) = 0;
 
   const std::string& name() const { return _algoName; }
-  
- protected:  
+
+protected:
   const float _minFractionInCalc;
 
- private:  
+private:
   const std::string _algoName;
-
 };
 
 // define the factory for this base class
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory< PFCPositionCalculatorBase* (const edm::ParameterSet&) > PFCPositionCalculatorFactory;
+typedef edmplugin::PluginFactory<PFCPositionCalculatorBase*(const edm::ParameterSet&)> PFCPositionCalculatorFactory;
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h
@@ -16,18 +16,19 @@ namespace edm {
 }
 
 class PFClusterBuilderBase {
-  typedef PFClusterBuilderBase PFCBB;  
- public:
+  typedef PFClusterBuilderBase PFCBB;
+
+public:
   typedef PFCPositionCalculatorBase PosCalc;
-  PFClusterBuilderBase(const edm::ParameterSet& conf):
-    _nSeeds(0), _nClustersFound(0),    
-    _minFractionToKeep(conf.getParameter<double>("minFractionToKeep")),
-    _algoName(conf.getParameter<std::string>("algoName")) {
-    if( conf.exists("positionCalc") ) {
+  PFClusterBuilderBase(const edm::ParameterSet& conf)
+      : _nSeeds(0),
+        _nClustersFound(0),
+        _minFractionToKeep(conf.getParameter<double>("minFractionToKeep")),
+        _algoName(conf.getParameter<std::string>("algoName")) {
+    if (conf.exists("positionCalc")) {
       const edm::ParameterSet& pcConf = conf.getParameterSet("positionCalc");
       const std::string& algo = pcConf.getParameter<std::string>("algoName");
-      _positionCalc = std::unique_ptr<PosCalc>{PFCPositionCalculatorFactory::get()->create(algo,
-                                                                                           pcConf)};
+      _positionCalc = std::unique_ptr<PosCalc>{PFCPositionCalculatorFactory::get()->create(algo, pcConf)};
     }
   }
   virtual ~PFClusterBuilderBase() = default;
@@ -35,36 +36,33 @@ class PFClusterBuilderBase {
   PFClusterBuilderBase(const PFCBB&) = delete;
   PFCBB& operator=(const PFCBB&) = delete;
 
-  virtual void update(const edm::EventSetup&) { }
+  virtual void update(const edm::EventSetup&) {}
 
   virtual void buildClusters(const reco::PFClusterCollection& topos,
-			     const std::vector<bool>& seedable,
-			     reco::PFClusterCollection& outclus) = 0;
+                             const std::vector<bool>& seedable,
+                             reco::PFClusterCollection& outclus) = 0;
 
   std::ostream& operator<<(std::ostream& o) const {
-    o << "PFClusterBuilder with algo \"" << _algoName 
-      << "\" located " << _nSeeds << " seeds and built " 
+    o << "PFClusterBuilder with algo \"" << _algoName << "\" located " << _nSeeds << " seeds and built "
       << _nClustersFound << " PFClusters from those seeds"
-      << " using position calculation: " << _positionCalc->name()
-      << "." << std::endl;
+      << " using position calculation: " << _positionCalc->name() << "." << std::endl;
     return o;
   }
 
   void reset() { _nSeeds = _nClustersFound = 0; }
 
- protected:
-  unsigned _nSeeds, _nClustersFound; // basic performance information
-  const float _minFractionToKeep; // min fraction value to keep in clusters
+protected:
+  unsigned _nSeeds, _nClustersFound;  // basic performance information
+  const float _minFractionToKeep;     // min fraction value to keep in clusters
   std::unique_ptr<PosCalc> _positionCalc;
 
- private:
+private:
   std::string _algoName;
-  
 };
 
 std::ostream& operator<<(std::ostream& o, const PFClusterBuilderBase& a);
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory< PFClusterBuilderBase* (const edm::ParameterSet&) > PFClusterBuilderFactory;
+typedef edmplugin::PluginFactory<PFClusterBuilderBase*(const edm::ParameterSet&)> PFClusterBuilderFactory;
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
@@ -24,52 +24,58 @@
 #include "CondFormats/EgammaObjects/interface/GBRForestD.h"
 
 class PFClusterEMEnergyCorrector {
- public:
-  PFClusterEMEnergyCorrector(const edm::ParameterSet& conf, edm::ConsumesCollector &&cc);
+public:
+  PFClusterEMEnergyCorrector(const edm::ParameterSet& conf, edm::ConsumesCollector&& cc);
   PFClusterEMEnergyCorrector(const PFClusterEMEnergyCorrector&) = delete;
   PFClusterEMEnergyCorrector& operator=(const PFClusterEMEnergyCorrector&) = delete;
 
-  void correctEnergies(const edm::Event &evt, const edm::EventSetup &es, const reco::PFCluster::EEtoPSAssociation &assoc, reco::PFClusterCollection& cs);
+  void correctEnergies(const edm::Event& evt,
+                       const edm::EventSetup& es,
+                       const reco::PFCluster::EEtoPSAssociation& assoc,
+                       reco::PFClusterCollection& cs);
 
- private:    
+private:
   double maxPtForMVAEvaluation_;
-       
-  edm::EDGetTokenT<EBSrFlagCollection> ebSrFlagToken_; 
-  edm::EDGetTokenT<EESrFlagCollection> eeSrFlagToken_; 
+
+  edm::EDGetTokenT<EBSrFlagCollection> ebSrFlagToken_;
+  edm::EDGetTokenT<EESrFlagCollection> eeSrFlagToken_;
 
   //required for reading SR flags
   edm::EDGetTokenT<EcalRecHitCollection> recHitsEB_;
-  edm::EDGetTokenT<EcalRecHitCollection> recHitsEE_;  
-  edm::EDGetTokenT<unsigned int> bunchSpacing_; 
-  
+  edm::EDGetTokenT<EcalRecHitCollection> recHitsEE_;
+  edm::EDGetTokenT<unsigned int> bunchSpacing_;
+
   std::vector<std::string> condnames_mean_;
-  std::vector<std::string> condnames_sigma_;  
+  std::vector<std::string> condnames_sigma_;
 
   std::vector<std::string> condnames_mean_25ns_;
-  std::vector<std::string> condnames_sigma_25ns_;  
+  std::vector<std::string> condnames_sigma_25ns_;
   std::vector<std::string> condnames_mean_50ns_;
-  std::vector<std::string> condnames_sigma_50ns_;  
-    
+  std::vector<std::string> condnames_sigma_50ns_;
+
   bool srfAwareCorrection_;
   bool applyCrackCorrections_;
   bool applyMVACorrections_;
 
   bool autoDetectBunchSpacing_;
   int bunchSpacingManual_;
-        
-  std::unique_ptr<PFEnergyCalibration> calibrator_;  
-  void getAssociatedPSEnergy(const size_t clusIdx, const reco::PFCluster::EEtoPSAssociation &assoc, float& e1, float& e2);
+
+  std::unique_ptr<PFEnergyCalibration> calibrator_;
+  void getAssociatedPSEnergy(const size_t clusIdx,
+                             const reco::PFCluster::EEtoPSAssociation& assoc,
+                             float& e1,
+                             float& e2);
 
   double meanlimlowEB_;
   double meanlimhighEB_;
   double meanoffsetEB_;
   double meanscaleEB_;
-  
+
   double meanlimlowEE_;
   double meanlimhighEE_;
   double meanoffsetEE_;
   double meanscaleEE_;
-  
+
   double sigmalimlowEB_;
   double sigmalimhighEB_;
   double sigmaoffsetEB_;
@@ -79,7 +85,6 @@ class PFClusterEMEnergyCorrector {
   double sigmalimhighEE_;
   double sigmaoffsetEE_;
   double sigmascaleEE_;
-
 };
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterEnergyCorrectorBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterEnergyCorrectorBase.h
@@ -10,19 +10,19 @@
 namespace edm {
   class Event;
   class EventSetup;
-}
+}  // namespace edm
 
 class PFClusterEnergyCorrectorBase {
   typedef PFClusterEnergyCorrectorBase Corrector;
- public:
-  PFClusterEnergyCorrectorBase(const edm::ParameterSet& conf) :
-    _algoName(conf.getParameter<std::string>("algoName")) { }
+
+public:
+  PFClusterEnergyCorrectorBase(const edm::ParameterSet& conf) : _algoName(conf.getParameter<std::string>("algoName")) {}
   virtual ~PFClusterEnergyCorrectorBase() = default;
   //get rid of things we should never use
   PFClusterEnergyCorrectorBase(const Corrector&) = delete;
   Corrector& operator=(const Corrector&) = delete;
 
-  virtual void update(const edm::EventSetup&) { }
+  virtual void update(const edm::EventSetup&) {}
 
   // here we transform one PFCluster to use the new position calculation
   virtual void correctEnergy(reco::PFCluster&) = 0;
@@ -30,13 +30,13 @@ class PFClusterEnergyCorrectorBase {
   virtual void correctEnergies(reco::PFClusterCollection&) = 0;
 
   const std::string& name() const { return _algoName; }
-   
- private:  
-  const std::string _algoName;
 
+private:
+  const std::string _algoName;
 };
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory< PFClusterEnergyCorrectorBase* (const edm::ParameterSet&) > PFClusterEnergyCorrectorFactory;
+typedef edmplugin::PluginFactory<PFClusterEnergyCorrectorBase*(const edm::ParameterSet&)>
+    PFClusterEnergyCorrectorFactory;
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFECALHashNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFECALHashNavigator.h
@@ -1,7 +1,6 @@
 #ifndef RecoParticleFlow_PFClusterProducer_PFECALHashNavigator_h
 #define RecoParticleFlow_PFClusterProducer_PFECALHashNavigator_h
 
-
 #include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
@@ -15,158 +14,108 @@
 #include "Geometry/EcalAlgo/interface/EcalEndcapGeometry.h"
 #include "Geometry/EcalAlgo/interface/EcalBarrelGeometry.h"
 
-  static const CaloDirection orderedDir[8]={SOUTHWEST,
-					    SOUTH,
-					    SOUTHEAST,
-					    WEST,
-					    EAST,
-					    NORTHWEST,
-					    NORTH,
-					    NORTHEAST};
-
+static const CaloDirection orderedDir[8] = {SOUTHWEST, SOUTH, SOUTHEAST, WEST, EAST, NORTHWEST, NORTH, NORTHEAST};
 
 class PFECALHashNavigator : public PFRecHitNavigatorBase {
- public:
+public:
+  PFECALHashNavigator() {}
 
+  PFECALHashNavigator(const edm::ParameterSet& iConfig) : PFRecHitNavigatorBase(iConfig) {
+    crossBarrelEndcapBorder_ = iConfig.getParameter<bool>("crossBarrelEndcapBorder");
 
-
-  PFECALHashNavigator() {
-
-  }
-
-
-
-  PFECALHashNavigator(const edm::ParameterSet& iConfig):
-    PFRecHitNavigatorBase(iConfig){
-
-  crossBarrelEndcapBorder_ =
-    iConfig.getParameter<bool>("crossBarrelEndcapBorder");
-
-  neighbourmapcalculated_ = false;
-
+    neighbourmapcalculated_ = false;
   }
 
   void beginEvent(const edm::EventSetup& iSetup) override {
-      edm::ESHandle<CaloGeometry> geoHandle;
-      iSetup.get<CaloGeometryRecord>().get(geoHandle);
-      
-      const CaloSubdetectorGeometry *ebTmp = 
-	geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-      const CaloSubdetectorGeometry *eeTmp = 
-	geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
+    edm::ESHandle<CaloGeometry> geoHandle;
+    iSetup.get<CaloGeometryRecord>().get(geoHandle);
 
-      barrelGeometry_  = dynamic_cast< const EcalBarrelGeometry* > (ebTmp);
-      endcapGeometry_  = dynamic_cast < const EcalEndcapGeometry* > (eeTmp);
+    const CaloSubdetectorGeometry* ebTmp = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
+    const CaloSubdetectorGeometry* eeTmp = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
 
-      // get the ecalBarrel topology
-      barrelTopology_ = std::make_unique<EcalBarrelTopology>(*geoHandle);
-      endcapTopology_ = std::make_unique<EcalEndcapTopology>(*geoHandle);
+    barrelGeometry_ = dynamic_cast<const EcalBarrelGeometry*>(ebTmp);
+    endcapGeometry_ = dynamic_cast<const EcalEndcapGeometry*>(eeTmp);
 
-      ecalNeighbArray(*barrelGeometry_,*barrelTopology_,*endcapGeometry_,*endcapTopology_);
+    // get the ecalBarrel topology
+    barrelTopology_ = std::make_unique<EcalBarrelTopology>(*geoHandle);
+    endcapTopology_ = std::make_unique<EcalEndcapTopology>(*geoHandle);
 
+    ecalNeighbArray(*barrelGeometry_, *barrelTopology_, *endcapGeometry_, *endcapTopology_);
   }
 
-  void associateNeighbours(reco::PFRecHit& rh,std::unique_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refprod) override {
+  void associateNeighbours(reco::PFRecHit& rh,
+                           std::unique_ptr<reco::PFRecHitCollection>& hits,
+                           edm::RefProd<reco::PFRecHitCollection>& refprod) override {
+    DetId center(rh.detId());
 
+    DetId north = move(center, NORTH);
+    DetId northeast = move(center, NORTHEAST);
+    DetId northwest = move(center, NORTHWEST);
+    DetId south = move(center, SOUTH);
+    DetId southeast = move(center, SOUTHEAST);
+    DetId southwest = move(center, SOUTHWEST);
+    DetId east = move(center, EAST);
+    DetId west = move(center, WEST);
 
-
-  DetId center( rh.detId() );
-
-
-  DetId north = move( center, NORTH );
-  DetId northeast = move( center, NORTHEAST );
-  DetId northwest = move( center, NORTHWEST ); 
-  DetId south = move( center, SOUTH );  
-  DetId southeast = move( center, SOUTHEAST );  
-  DetId southwest = move( center, SOUTHWEST );  
-  DetId east  = move( center, EAST );  
-  DetId west  = move( center, WEST );  
-
-
-  associateNeighbour(north,rh,hits,refprod,0,1,0);
-  associateNeighbour(northeast,rh,hits,refprod,1,1,0);
-  associateNeighbour(south,rh,hits,refprod,0,-1,0);
-  associateNeighbour(southwest,rh,hits,refprod,-1,-1,0);
-  associateNeighbour(east,rh,hits,refprod,1,0,0);
-  associateNeighbour(southeast,rh,hits,refprod,1,-1,0);
-  associateNeighbour(west,rh,hits,refprod,-1,0,0);
-  associateNeighbour(northwest,rh,hits,refprod,-1,1,0);
-
+    associateNeighbour(north, rh, hits, refprod, 0, 1, 0);
+    associateNeighbour(northeast, rh, hits, refprod, 1, 1, 0);
+    associateNeighbour(south, rh, hits, refprod, 0, -1, 0);
+    associateNeighbour(southwest, rh, hits, refprod, -1, -1, 0);
+    associateNeighbour(east, rh, hits, refprod, 1, 0, 0);
+    associateNeighbour(southeast, rh, hits, refprod, 1, -1, 0);
+    associateNeighbour(west, rh, hits, refprod, -1, 0, 0);
+    associateNeighbour(northwest, rh, hits, refprod, -1, 1, 0);
   }
 
-
-
-
-
-
-
-
- protected:
-
-
+protected:
   void ecalNeighbArray(const EcalBarrelGeometry& barrelGeom,
-		       const CaloSubdetectorTopology& barrelTopo,
-		       const EcalEndcapGeometry& endcapGeom,
-		       const CaloSubdetectorTopology& endcapTopo ){
-  
-
-
+                       const CaloSubdetectorTopology& barrelTopo,
+                       const EcalEndcapGeometry& endcapGeom,
+                       const CaloSubdetectorTopology& endcapTopo) {
     const unsigned nbarrel = 62000;
     // Barrel first. The hashed index runs from 0 to 61199
     neighboursEB_.resize(nbarrel);
-  
+
     //std::cout << " Building the array of neighbours (barrel) " ;
 
-    const std::vector<DetId>& vec(barrelGeom.getValidDetIds(DetId::Ecal,
-							  EcalBarrel));
-    unsigned size=vec.size();    
-    for(unsigned ic=0; ic<size; ++ic) 
-      {
-	// We get the 9 cells in a square. 
-	std::vector<DetId> neighbours(barrelTopo.getWindow(vec[ic],3,3));
-	//      std::cout << " Cell " << EBDetId(vec[ic]) << std::endl;
-	unsigned nneighbours=neighbours.size();
-	
-	unsigned hashedindex=EBDetId(vec[ic]).hashedIndex();
-	if(hashedindex>=nbarrel)
-	  {
-	    LogDebug("CaloGeometryTools")  << " Array overflow " << std::endl;
-	  }
+    const std::vector<DetId>& vec(barrelGeom.getValidDetIds(DetId::Ecal, EcalBarrel));
+    unsigned size = vec.size();
+    for (unsigned ic = 0; ic < size; ++ic) {
+      // We get the 9 cells in a square.
+      std::vector<DetId> neighbours(barrelTopo.getWindow(vec[ic], 3, 3));
+      //      std::cout << " Cell " << EBDetId(vec[ic]) << std::endl;
+      unsigned nneighbours = neighbours.size();
 
-
-	// If there are 9 cells, it is easy, and this order is know:
-	//      6  7  8
-	//      3  4  5 
-	//      0  1  2   (0 = SOUTHWEST)
-
-	if(nneighbours==9)
-	  {
-	    neighboursEB_[hashedindex].reserve(8);
-	    for(unsigned in=0;in<nneighbours;++in)
-	      {
-		// remove the centre
-		if(neighbours[in]!=vec[ic]) 
-		  {
-		    neighboursEB_[hashedindex].push_back(neighbours[in]);
-                  //          std::cout << " Neighbour " << in << " " << EBDetId(neighbours[in]) << std::endl;
-		  }
-	      }
-	  }
-	else
-	  {
-	    DetId central(vec[ic]);
-	    neighboursEB_[hashedindex].resize(8,DetId(0));
-	    for(unsigned idir=0;idir<8;++idir)
-	      {
-		DetId testid=central;
-		bool status=stdmove(testid,orderedDir[idir],
-				    barrelTopo, endcapTopo,
-				    barrelGeom, endcapGeom);
-		if(status) neighboursEB_[hashedindex][idir]=testid;
-	      }
-	    
-	  }
+      unsigned hashedindex = EBDetId(vec[ic]).hashedIndex();
+      if (hashedindex >= nbarrel) {
+        LogDebug("CaloGeometryTools") << " Array overflow " << std::endl;
       }
+
+      // If there are 9 cells, it is easy, and this order is know:
+      //      6  7  8
+      //      3  4  5
+      //      0  1  2   (0 = SOUTHWEST)
+
+      if (nneighbours == 9) {
+        neighboursEB_[hashedindex].reserve(8);
+        for (unsigned in = 0; in < nneighbours; ++in) {
+          // remove the centre
+          if (neighbours[in] != vec[ic]) {
+            neighboursEB_[hashedindex].push_back(neighbours[in]);
+            //          std::cout << " Neighbour " << in << " " << EBDetId(neighbours[in]) << std::endl;
+          }
+        }
+      } else {
+        DetId central(vec[ic]);
+        neighboursEB_[hashedindex].resize(8, DetId(0));
+        for (unsigned idir = 0; idir < 8; ++idir) {
+          DetId testid = central;
+          bool status = stdmove(testid, orderedDir[idir], barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+          if (status)
+            neighboursEB_[hashedindex][idir] = testid;
+        }
+      }
+    }
 
     // Moved to the endcap
 
@@ -174,275 +123,227 @@ class PFECALHashNavigator : public PFRecHitNavigatorBase {
     //  std::cout << " Building the array of neighbours (endcap) " ;
 
     //  vec.clear();
-    const std::vector<DetId>& vecee=endcapGeom.getValidDetIds(DetId::Ecal,EcalEndcap);
-    size=vecee.size();    
+    const std::vector<DetId>& vecee = endcapGeom.getValidDetIds(DetId::Ecal, EcalEndcap);
+    size = vecee.size();
     // There are some holes in the hashedIndex for the EE. Hence the array is bigger than the number
     // of crystals
-    const unsigned nendcap=19960;
+    const unsigned nendcap = 19960;
 
     neighboursEE_.resize(nendcap);
-    for(unsigned ic=0; ic<size; ++ic) 
-      {
-	// We get the 9 cells in a square. 
-	std::vector<DetId> neighbours(endcapTopo.getWindow(vecee[ic],3,3));
-	unsigned nneighbours=neighbours.size();
-	// remove the centre
-	unsigned hashedindex=EEDetId(vecee[ic]).hashedIndex();
-      
-	if(hashedindex>=nendcap)
-	  {
-	    LogDebug("CaloGeometryTools")  << " Array overflow " << std::endl;
-	  }
+    for (unsigned ic = 0; ic < size; ++ic) {
+      // We get the 9 cells in a square.
+      std::vector<DetId> neighbours(endcapTopo.getWindow(vecee[ic], 3, 3));
+      unsigned nneighbours = neighbours.size();
+      // remove the centre
+      unsigned hashedindex = EEDetId(vecee[ic]).hashedIndex();
 
-	if(nneighbours==9)
-	  {
-	    neighboursEE_[hashedindex].reserve(8);
-	    for(unsigned in=0;in<nneighbours;++in)
-	      {     
-		// remove the centre
-		if(neighbours[in]!=vecee[ic]) 
-		  {
-		    neighboursEE_[hashedindex].push_back(neighbours[in]);
-		  }
-	      }
-	  }
-	else
-	  {
-	    DetId central(vecee[ic]);
-	    neighboursEE_[hashedindex].resize(8,DetId(0));
-	    for(unsigned idir=0;idir<8;++idir)
-	      {
-		DetId testid=central;
-		bool status=stdmove(testid,orderedDir[idir],
-				    barrelTopo, endcapTopo,
-				    barrelGeom, endcapGeom);
-
-		if(status) neighboursEE_[hashedindex][idir]=testid;
-	      }
-
-	  }
+      if (hashedindex >= nendcap) {
+        LogDebug("CaloGeometryTools") << " Array overflow " << std::endl;
       }
+
+      if (nneighbours == 9) {
+        neighboursEE_[hashedindex].reserve(8);
+        for (unsigned in = 0; in < nneighbours; ++in) {
+          // remove the centre
+          if (neighbours[in] != vecee[ic]) {
+            neighboursEE_[hashedindex].push_back(neighbours[in]);
+          }
+        }
+      } else {
+        DetId central(vecee[ic]);
+        neighboursEE_[hashedindex].resize(8, DetId(0));
+        for (unsigned idir = 0; idir < 8; ++idir) {
+          DetId testid = central;
+          bool status = stdmove(testid, orderedDir[idir], barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+
+          if (status)
+            neighboursEE_[hashedindex][idir] = testid;
+        }
+      }
+    }
     //  std::cout << " done " << size <<std::endl;
     neighbourmapcalculated_ = true;
   }
 
+  bool stdsimplemove(DetId& cell,
+                     const CaloDirection& dir,
+                     const CaloSubdetectorTopology& barrelTopo,
+                     const CaloSubdetectorTopology& endcapTopo,
+                     const EcalBarrelGeometry& barrelGeom,
+                     const EcalEndcapGeometry& endcapGeom) const {
+    std::vector<DetId> neighbours;
 
+    // BARREL CASE
+    if (cell.subdetId() == EcalBarrel) {
+      EBDetId ebDetId = cell;
 
-bool stdsimplemove(DetId& cell, 
-		   const CaloDirection& dir,
-		   const CaloSubdetectorTopology& barrelTopo,
-		   const CaloSubdetectorTopology& endcapTopo,
-		   const EcalBarrelGeometry& barrelGeom,
-		   const EcalEndcapGeometry& endcapGeom ) 
-  const {
-  
-  std::vector<DetId> neighbours;
+      neighbours = barrelTopo.getNeighbours(ebDetId, dir);
 
-  // BARREL CASE 
-  if(cell.subdetId()==EcalBarrel) {
-    EBDetId ebDetId = cell;
+      // first try to move according to the standard navigation
+      if (!neighbours.empty() && !neighbours[0].null()) {
+        cell = neighbours[0];
+        return true;
+      }
 
-    neighbours = barrelTopo.getNeighbours(ebDetId,dir);
+      // failed.
 
-    // first try to move according to the standard navigation
-    if(!neighbours.empty() && !neighbours[0].null()) {
-      cell = neighbours[0];
-      return true;
+      if (crossBarrelEndcapBorder_) {
+        // are we on the outer ring ?
+        const int ietaAbs(ebDetId.ietaAbs());  // abs value of ieta
+        if (EBDetId::MAX_IETA == ietaAbs) {
+          // get ee nbrs for for end of barrel crystals
+
+          // yes we are
+          const EcalBarrelGeometry::OrderedListOfEEDetId& ol(*barrelGeom.getClosestEndcapCells(ebDetId));
+
+          // take closest neighbour on the other side, that is in the barrel.
+          cell = *(ol.begin());
+          return true;
+        }
+      }
     }
 
-    // failed.
+    // ENDCAP CASE
+    else if (cell.subdetId() == EcalEndcap) {
+      EEDetId eeDetId = cell;
 
-    if(crossBarrelEndcapBorder_) {
-      // are we on the outer ring ?
-      const int ietaAbs ( ebDetId.ietaAbs() ) ; // abs value of ieta
-      if( EBDetId::MAX_IETA == ietaAbs ) {
-	// get ee nbrs for for end of barrel crystals  
-	
-	// yes we are
-	const EcalBarrelGeometry::OrderedListOfEEDetId& 
-	  ol( * barrelGeom.getClosestEndcapCells( ebDetId ) ) ;
-	
-	// take closest neighbour on the other side, that is in the barrel.
-	cell = *(ol.begin() );
-	return true;
-      }   
+      neighbours = endcapTopo.getNeighbours(eeDetId, dir);
+
+      if (!neighbours.empty() && !neighbours[0].null()) {
+        cell = neighbours[0];
+        return true;
+      }
+
+      // failed.
+
+      if (crossBarrelEndcapBorder_) {
+        // are we on the outer ring ?
+        const int iphi(eeDetId.iPhiOuterRing());
+        if (iphi != 0) {
+          // yes we are
+          const EcalEndcapGeometry::OrderedListOfEBDetId& ol(*endcapGeom.getClosestBarrelCells(eeDetId));
+
+          // take closest neighbour on the other side, that is in the barrel.
+          cell = *(ol.begin());
+          return true;
+        }
+      }
     }
+
+    // everything failed
+    cell = DetId(0);
+    return false;
   }
 
-  // ENDCAP CASE 
-  else if(cell.subdetId()==EcalEndcap) {
+  bool stdmove(DetId& cell,
+               const CaloDirection& dir,
+               const CaloSubdetectorTopology& barrelTopo,
+               const CaloSubdetectorTopology& endcapTopo,
+               const EcalBarrelGeometry& barrelGeom,
+               const EcalEndcapGeometry& endcapGeom)
 
-    EEDetId eeDetId = cell;
+      const {
+    bool result;
 
-    neighbours= endcapTopo.getNeighbours(eeDetId,dir);
-
-    if(!neighbours.empty() && !neighbours[0].null()) {
-      cell = neighbours[0];
-      return true;
+    if (dir == NORTH) {
+      result = stdsimplemove(cell, NORTH, barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+      return result;
+    } else if (dir == SOUTH) {
+      result = stdsimplemove(cell, SOUTH, barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+      return result;
+    } else if (dir == EAST) {
+      result = stdsimplemove(cell, EAST, barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+      return result;
+    } else if (dir == WEST) {
+      result = stdsimplemove(cell, WEST, barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+      return result;
     }
 
-    // failed.
-
-    if(crossBarrelEndcapBorder_) {
-      // are we on the outer ring ?
-      const int iphi ( eeDetId.iPhiOuterRing() ) ;    
-      if( iphi!= 0) {
-	// yes we are
-	const EcalEndcapGeometry::OrderedListOfEBDetId& 
-	  ol( * endcapGeom.getClosestBarrelCells( eeDetId ) ) ;
-	
-	// take closest neighbour on the other side, that is in the barrel.
-	cell = *(ol.begin() );
-	return true;
-      }   
+    // One has to try both paths
+    else if (dir == NORTHEAST) {
+      result = stdsimplemove(cell, NORTH, barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+      if (result)
+        return stdsimplemove(cell, EAST, barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+      else {
+        result = stdsimplemove(cell, EAST, barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+        if (result)
+          return stdsimplemove(cell, NORTH, barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+        else
+          return false;
+      }
+    } else if (dir == NORTHWEST) {
+      result = stdsimplemove(cell, NORTH, barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+      if (result)
+        return stdsimplemove(cell, WEST, barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+      else {
+        result = stdsimplemove(cell, WEST, barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+        if (result)
+          return stdsimplemove(cell, NORTH, barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+        else
+          return false;
+      }
+    } else if (dir == SOUTHEAST) {
+      result = stdsimplemove(cell, SOUTH, barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+      if (result)
+        return stdsimplemove(cell, EAST, barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+      else {
+        result = stdsimplemove(cell, EAST, barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+        if (result)
+          return stdsimplemove(cell, SOUTH, barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+        else
+          return false;
+      }
+    } else if (dir == SOUTHWEST) {
+      result = stdsimplemove(cell, SOUTH, barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+      if (result)
+        return stdsimplemove(cell, WEST, barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+      else {
+        result = stdsimplemove(cell, SOUTH, barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+        if (result)
+          return stdsimplemove(cell, WEST, barrelTopo, endcapTopo, barrelGeom, endcapGeom);
+        else
+          return false;
+      }
     }
-  } 
+    cell = DetId(0);
+    return false;
+  }
 
-  // everything failed 
-  cell = DetId(0);
-  return false;
-}
+  DetId move(DetId cell, const CaloDirection& dir) const {
+    DetId originalcell = cell;
+    if (dir == NONE || cell == DetId(0))
+      return false;
 
+    // Conversion CaloDirection and index in the table
+    // CaloDirection :NONE,SOUTH,SOUTHEAST,SOUTHWEST,EAST,WEST, NORTHEAST,NORTHWEST,NORTH
+    // Table : SOUTHWEST,SOUTH,SOUTHEAST,WEST,EAST,NORTHWEST,NORTH, NORTHEAST
+    static const int calodirections[9] = {-1, 1, 2, 0, 4, 3, 7, 5, 6};
 
+    assert(neighbourmapcalculated_);
 
-bool stdmove(DetId& cell, 
-	     const CaloDirection& dir,
-	     const CaloSubdetectorTopology& barrelTopo,
-	     const CaloSubdetectorTopology& endcapTopo,
-	     const EcalBarrelGeometry& barrelGeom,
-	     const EcalEndcapGeometry& endcapGeom  ) 
-  
-  const {
-
-
-  bool result; 
-
-  if(dir==NORTH) {
-    result = stdsimplemove(cell,NORTH, barrelTopo, endcapTopo, barrelGeom, endcapGeom );
+    DetId result = (originalcell.subdetId() == EcalBarrel)
+                       ? neighboursEB_[EBDetId(originalcell).hashedIndex()][calodirections[dir]]
+                       : neighboursEE_[EEDetId(originalcell).hashedIndex()][calodirections[dir]];
     return result;
   }
-  else if(dir==SOUTH) {
-    result = stdsimplemove(cell,SOUTH, barrelTopo, endcapTopo, barrelGeom, endcapGeom );
-    return result;
-  }
-  else if(dir==EAST) {
-    result = stdsimplemove(cell,EAST, barrelTopo, endcapTopo, barrelGeom, endcapGeom );
-    return result;
-  }
-  else if(dir==WEST) {
-    result = stdsimplemove(cell,WEST, barrelTopo, endcapTopo, barrelGeom, endcapGeom );
-    return result;
-  }
-
-
-  // One has to try both paths
-  else if(dir==NORTHEAST)
-    {
-      result = stdsimplemove(cell,NORTH, barrelTopo, endcapTopo, barrelGeom, endcapGeom );
-      if(result)
-        return stdsimplemove(cell,EAST, barrelTopo, endcapTopo, barrelGeom, endcapGeom );
-      else
-        {
-          result = stdsimplemove(cell,EAST, barrelTopo, endcapTopo, barrelGeom, endcapGeom );
-          if(result)
-            return stdsimplemove(cell,NORTH, barrelTopo, endcapTopo, barrelGeom, endcapGeom );
-          else
-            return false; 
-        }
-    }
-  else if(dir==NORTHWEST)
-    {
-      result = stdsimplemove(cell,NORTH, barrelTopo, endcapTopo, barrelGeom, endcapGeom );
-      if(result)
-        return stdsimplemove(cell,WEST, barrelTopo, endcapTopo, barrelGeom, endcapGeom );
-      else
-        {
-          result = stdsimplemove(cell,WEST, barrelTopo, endcapTopo, barrelGeom, endcapGeom );
-          if(result)
-            return stdsimplemove(cell,NORTH, barrelTopo, endcapTopo, barrelGeom, endcapGeom );
-          else
-            return false; 
-        }
-    }
-  else if(dir == SOUTHEAST)
-    {
-      result = stdsimplemove(cell,SOUTH, barrelTopo, endcapTopo, barrelGeom, endcapGeom );
-      if(result)
-        return stdsimplemove(cell,EAST, barrelTopo, endcapTopo, barrelGeom, endcapGeom );
-      else
-        {
-          result = stdsimplemove(cell,EAST, barrelTopo, endcapTopo, barrelGeom, endcapGeom );
-          if(result)
-            return stdsimplemove(cell,SOUTH, barrelTopo, endcapTopo, barrelGeom, endcapGeom );
-          else
-            return false; 
-        }
-    }
-  else if(dir == SOUTHWEST)
-    {
-      result = stdsimplemove(cell,SOUTH, barrelTopo, endcapTopo, barrelGeom, endcapGeom );
-      if(result)
-        return stdsimplemove(cell,WEST, barrelTopo, endcapTopo, barrelGeom, endcapGeom );
-      else
-        {
-          result = stdsimplemove(cell,SOUTH, barrelTopo, endcapTopo, barrelGeom, endcapGeom );
-          if(result)
-            return stdsimplemove(cell,WEST, barrelTopo, endcapTopo, barrelGeom, endcapGeom );
-          else
-            return false; 
-        }
-    }
-  cell = DetId(0);
-  return false;
-}
-
-
-
-DetId move(DetId cell, 
-	   const CaloDirection&dir ) const
-{  
-  DetId originalcell = cell; 
-  if(dir==NONE || cell==DetId(0)) return false;
-  
-  // Conversion CaloDirection and index in the table
-  // CaloDirection :NONE,SOUTH,SOUTHEAST,SOUTHWEST,EAST,WEST, NORTHEAST,NORTHWEST,NORTH
-  // Table : SOUTHWEST,SOUTH,SOUTHEAST,WEST,EAST,NORTHWEST,NORTH, NORTHEAST
-  static const int calodirections[9]={-1,1,2,0,4,3,7,5,6};
-    
-  assert(neighbourmapcalculated_);
-
-  DetId result = (originalcell.subdetId()==EcalBarrel) ? 
-    neighboursEB_[EBDetId(originalcell).hashedIndex()][calodirections[dir]]:
-    neighboursEE_[EEDetId(originalcell).hashedIndex()][calodirections[dir]];
-  return result; 
-}
-
 
   std::unique_ptr<EcalEndcapTopology> endcapTopology_;
   std::unique_ptr<EcalBarrelTopology> barrelTopology_;
 
-  const EcalEndcapGeometry *endcapGeometry_;
-  const EcalBarrelGeometry *barrelGeometry_;
+  const EcalEndcapGeometry* endcapGeometry_;
+  const EcalBarrelGeometry* barrelGeometry_;
 
   /// for each ecal barrel rechit, keep track of the neighbours
-  std::vector<std::vector<DetId> >  neighboursEB_;
+  std::vector<std::vector<DetId> > neighboursEB_;
 
   /// for each ecal endcap rechit, keep track of the neighbours
-  std::vector<std::vector<DetId> >  neighboursEE_;
-  
+  std::vector<std::vector<DetId> > neighboursEE_;
+
   /// set to true in ecalNeighbArray
-  bool  neighbourmapcalculated_;
+  bool neighbourmapcalculated_;
 
   /// if true, navigation will cross the barrel-endcap border
-  bool  crossBarrelEndcapBorder_;
-
-
+  bool crossBarrelEndcapBorder_;
 };
 
-
-
-
-
 #endif
-
-

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalBarrelRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalBarrelRecHitCreator.h
@@ -25,112 +25,104 @@
 #include "Geometry/CaloTopology/interface/EcalTrigTowerConstituentsMap.h"
 #include "RecoCaloTools/Navigation/interface/CaloNavigator.h"
 
-class PFEcalBarrelRecHitCreator :  public  PFRecHitCreatorBase {
+class PFEcalBarrelRecHitCreator : public PFRecHitCreatorBase {
+public:
+  PFEcalBarrelRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC)
+      : PFRecHitCreatorBase(iConfig, iC) {
+    recHitToken_ = iC.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
+    auto srF = iConfig.getParameter<edm::InputTag>("srFlags");
+    if (not srF.label().empty())
+      srFlagToken_ = iC.consumes<EBSrFlagCollection>(srF);
+    triggerTowerMap_ = nullptr;
+  }
 
- public:  
- PFEcalBarrelRecHitCreator(const edm::ParameterSet& iConfig,edm::ConsumesCollector& iC):
-  PFRecHitCreatorBase(iConfig,iC)
-    {
-      recHitToken_ = iC.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
-      auto srF = iConfig.getParameter<edm::InputTag>("srFlags");
-      if (not srF.label().empty())
-	srFlagToken_ = iC.consumes<EBSrFlagCollection>(srF);
-      triggerTowerMap_ = nullptr;
-    }
-    
-  void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&out,std::unique_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) override {
+  void importRecHits(std::unique_ptr<reco::PFRecHitCollection>& out,
+                     std::unique_ptr<reco::PFRecHitCollection>& cleaned,
+                     const edm::Event& iEvent,
+                     const edm::EventSetup& iSetup) override {
+    beginEvent(iEvent, iSetup);
 
-    beginEvent(iEvent,iSetup);
-      
     edm::Handle<EcalRecHitCollection> recHitHandle;
 
     edm::ESHandle<CaloGeometry> geoHandle;
     iSetup.get<CaloGeometryRecord>().get(geoHandle);
-  
+
     bool useSrF = false;
-    if (not srFlagToken_.isUninitialized()){
-      iEvent.getByToken(srFlagToken_,srFlagHandle_);
+    if (not srFlagToken_.isUninitialized()) {
+      iEvent.getByToken(srFlagToken_, srFlagHandle_);
       useSrF = true;
     }
 
     // get the ecal geometry
-    const CaloSubdetectorGeometry *gTmp = 
-      geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
+    const CaloSubdetectorGeometry* gTmp = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
 
-    const EcalBarrelGeometry *ecalGeo = dynamic_cast<const EcalBarrelGeometry*>(gTmp);
+    const EcalBarrelGeometry* ecalGeo = dynamic_cast<const EcalBarrelGeometry*>(gTmp);
 
-    iEvent.getByToken(recHitToken_,recHitHandle);
-    for(const auto& erh : *recHitHandle ) {      
+    iEvent.getByToken(recHitToken_, recHitHandle);
+    for (const auto& erh : *recHitHandle) {
       const DetId& detid = erh.detid();
       auto energy = erh.energy();
       auto time = erh.time();
       bool hi = (useSrF ? isHighInterest(detid) : true);
 
-      const auto thisCell= ecalGeo->getGeometry(detid);
-  
+      const auto thisCell = ecalGeo->getGeometry(detid);
+
       // find rechit geometry
-      if(!thisCell) {
-        throw cms::Exception("PFEcalBarrelRecHitCreator") 
-          << "detid " << detid.rawId() << "not found in geometry";
+      if (!thisCell) {
+        throw cms::Exception("PFEcalBarrelRecHitCreator") << "detid " << detid.rawId() << "not found in geometry";
       }
 
-      out->emplace_back(thisCell, detid.rawId(), PFLayer::ECAL_BARREL, energy); 
+      out->emplace_back(thisCell, detid.rawId(), PFLayer::ECAL_BARREL, energy);
 
-      auto & rh = out->back();
-	
+      auto& rh = out->back();
+
       bool rcleaned = false;
-      bool keep=true;
+      bool keep = true;
 
       //Apply Q tests
-      for( const auto& qtest : qualityTests_ ) {
-        if (!qtest->test(rh,erh,rcleaned,hi)) {
-          keep = false;	    
+      for (const auto& qtest : qualityTests_) {
+        if (!qtest->test(rh, erh, rcleaned, hi)) {
+          keep = false;
         }
       }
-	  
-      if(keep) {
+
+      if (keep) {
         rh.setTime(time);
         rh.setDepth(1);
-      } 
-      else {
-        if (rcleaned) 
+      } else {
+        if (rcleaned)
           cleaned->push_back(std::move(out->back()));
         out->pop_back();
       }
     }
   }
 
-  void init(const edm::EventSetup &es) override {
-
+  void init(const edm::EventSetup& es) override {
     edm::ESHandle<EcalTrigTowerConstituentsMap> hTriggerTowerMap;
     es.get<IdealGeometryRecord>().get(hTriggerTowerMap);
     triggerTowerMap_ = hTriggerTowerMap.product();
-
   }
-      
 
- protected:
-
+protected:
   bool isHighInterest(const EBDetId& detid) {
-    bool result=false;
+    bool result = false;
     auto srf = srFlagHandle_->find(readOutUnitOf(detid));
-    if(srf==srFlagHandle_->end()) return false;
-    else result = ((srf->value() & ~EcalSrFlag::SRF_FORCED_MASK) == EcalSrFlag::SRF_FULL);
+    if (srf == srFlagHandle_->end())
+      return false;
+    else
+      result = ((srf->value() & ~EcalSrFlag::SRF_FORCED_MASK) == EcalSrFlag::SRF_FULL);
     return result;
   }
 
-  EcalTrigTowerDetId readOutUnitOf(const EBDetId& detid) const{
-    return triggerTowerMap_->towerOf(detid);
-  }
+  EcalTrigTowerDetId readOutUnitOf(const EBDetId& detid) const { return triggerTowerMap_->towerOf(detid); }
 
   edm::EDGetTokenT<EcalRecHitCollection> recHitToken_;
   edm::EDGetTokenT<EBSrFlagCollection> srFlagToken_;
 
   // ECAL trigger tower mapping
-  const EcalTrigTowerConstituentsMap * triggerTowerMap_;
+  const EcalTrigTowerConstituentsMap* triggerTowerMap_;
   // selective readout flags collection
   edm::Handle<EBSrFlagCollection> srFlagHandle_;
-
 };
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalEndcapRecHitCreator.h
@@ -27,121 +27,114 @@
 #include "Geometry/CaloTopology/interface/EcalPreshowerTopology.h"
 #include "RecoCaloTools/Navigation/interface/CaloNavigator.h"
 
-class PFEcalEndcapRecHitCreator :  public  PFRecHitCreatorBase {
+class PFEcalEndcapRecHitCreator : public PFRecHitCreatorBase {
+public:
+  PFEcalEndcapRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC)
+      : PFRecHitCreatorBase(iConfig, iC) {
+    recHitToken_ = iC.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
+    auto srF = iConfig.getParameter<edm::InputTag>("srFlags");
+    if (not srF.label().empty())
+      srFlagToken_ = iC.consumes<EESrFlagCollection>(srF);
+    elecMap_ = nullptr;
+  }
 
- public:  
- PFEcalEndcapRecHitCreator(const edm::ParameterSet& iConfig,edm::ConsumesCollector& iC):
-  PFRecHitCreatorBase(iConfig,iC)
-    {
-      recHitToken_ = iC.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
-      auto srF = iConfig.getParameter<edm::InputTag>("srFlags");
-      if (not srF.label().empty())
-	srFlagToken_ = iC.consumes<EESrFlagCollection>(srF);
-      elecMap_ = nullptr;
-    }
+  void importRecHits(std::unique_ptr<reco::PFRecHitCollection>& out,
+                     std::unique_ptr<reco::PFRecHitCollection>& cleaned,
+                     const edm::Event& iEvent,
+                     const edm::EventSetup& iSetup) override {
+    beginEvent(iEvent, iSetup);
 
-  void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&out,std::unique_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) override {
-
-    beginEvent(iEvent,iSetup);
- 
     edm::Handle<EcalRecHitCollection> recHitHandle;
 
     edm::ESHandle<CaloGeometry> geoHandle;
     iSetup.get<CaloGeometryRecord>().get(geoHandle);
-  
+
     bool useSrF = false;
-    if (not srFlagToken_.isUninitialized()){
-      iEvent.getByToken(srFlagToken_,srFlagHandle_);
+    if (not srFlagToken_.isUninitialized()) {
+      iEvent.getByToken(srFlagToken_, srFlagHandle_);
       useSrF = true;
     }
 
     // get the ecal geometry
-    const CaloSubdetectorGeometry *gTmp = 
-      geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
+    const CaloSubdetectorGeometry* gTmp = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
 
-    const EcalEndcapGeometry *ecalGeo = dynamic_cast<const EcalEndcapGeometry*>(gTmp);
+    const EcalEndcapGeometry* ecalGeo = dynamic_cast<const EcalEndcapGeometry*>(gTmp);
 
-    iEvent.getByToken(recHitToken_,recHitHandle);
-    for(const auto& erh : *recHitHandle ) {      
+    iEvent.getByToken(recHitToken_, recHitHandle);
+    for (const auto& erh : *recHitHandle) {
       const DetId& detid = erh.detid();
       auto energy = erh.energy();
       auto time = erh.time();
 
       bool hi = (useSrF ? isHighInterest(detid) : true);
-        
-      std::shared_ptr<const CaloCellGeometry> thisCell= ecalGeo->getGeometry(detid);
-  
+
+      std::shared_ptr<const CaloCellGeometry> thisCell = ecalGeo->getGeometry(detid);
+
       // find rechit geometry
-      if(!thisCell) {
-        throw cms::Exception("PFEcalEndcapRecHitCreator") 
-          << "detid "<< detid.rawId() << "not found in geometry";
+      if (!thisCell) {
+        throw cms::Exception("PFEcalEndcapRecHitCreator") << "detid " << detid.rawId() << "not found in geometry";
       }
 
-      out->emplace_back(thisCell, detid.rawId(), PFLayer::ECAL_ENDCAP, energy); 
+      out->emplace_back(thisCell, detid.rawId(), PFLayer::ECAL_ENDCAP, energy);
 
-      auto & rh = out->back();
-	
+      auto& rh = out->back();
+
       bool rcleaned = false;
-      bool keep=true;
+      bool keep = true;
 
       //Apply Q tests
-      for( const auto& qtest : qualityTests_ ) {
-        if (!qtest->test(rh,erh,rcleaned,hi)) {
-          keep = false;	    
+      for (const auto& qtest : qualityTests_) {
+        if (!qtest->test(rh, erh, rcleaned, hi)) {
+          keep = false;
         }
       }
-	  
-      if(keep) {
+
+      if (keep) {
         rh.setTime(time);
         rh.setDepth(1);
-      } 
-      else {
-        if (rcleaned) 
+      } else {
+        if (rcleaned)
           cleaned->push_back(std::move(out->back()));
         out->pop_back();
       }
     }
   }
 
-  void init(const edm::EventSetup &es) override {
-      
-    edm::ESHandle< EcalElectronicsMapping > ecalmapping;
-    es.get< EcalMappingRcd >().get(ecalmapping);
+  void init(const edm::EventSetup& es) override {
+    edm::ESHandle<EcalElectronicsMapping> ecalmapping;
+    es.get<EcalMappingRcd>().get(ecalmapping);
     elecMap_ = ecalmapping.product();
-
   }
 
- protected:
-
-
+protected:
   bool isHighInterest(const EEDetId& detid) {
-    bool result=false;
+    bool result = false;
     auto srf = srFlagHandle_->find(readOutUnitOf(detid));
-    if(srf==srFlagHandle_->end()) return false;
-    else result = ((srf->value() & ~EcalSrFlag::SRF_FORCED_MASK) == EcalSrFlag::SRF_FULL);
+    if (srf == srFlagHandle_->end())
+      return false;
+    else
+      result = ((srf->value() & ~EcalSrFlag::SRF_FORCED_MASK) == EcalSrFlag::SRF_FULL);
     return result;
   }
 
-  EcalScDetId readOutUnitOf(const EEDetId& detid) const{
+  EcalScDetId readOutUnitOf(const EEDetId& detid) const {
     const EcalElectronicsId& EcalElecId = elecMap_->getElectronicsId(detid);
-    int iDCC= EcalElecId.dccId();
+    int iDCC = EcalElecId.dccId();
     int iDccChan = EcalElecId.towerId();
     const bool ignoreSingle = true;
     const std::vector<EcalScDetId> id = elecMap_->getEcalScDetId(iDCC, iDccChan, ignoreSingle);
-    return !id.empty()?id[0]:EcalScDetId();
+    return !id.empty() ? id[0] : EcalScDetId();
   }
-
 
   edm::EDGetTokenT<EcalRecHitCollection> recHitToken_;
   edm::EDGetTokenT<EESrFlagCollection> srFlagToken_;
 
-  const EcalTrigTowerConstituentsMap* eTTmap_;  
+  const EcalTrigTowerConstituentsMap* eTTmap_;
 
   // Ecal electronics/geometrical mapping
   const EcalElectronicsMapping* elecMap_;
   // selective readout flags collection
   edm::Handle<EESrFlagCollection> srFlagHandle_;
-
 };
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFEcalRecHitCreatorMaxSample.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFEcalRecHitCreatorMaxSample.h
@@ -9,7 +9,6 @@
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 
-
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
@@ -23,83 +22,72 @@
 #include "Geometry/CaloTopology/interface/EcalPreshowerTopology.h"
 #include "RecoCaloTools/Navigation/interface/CaloNavigator.h"
 
-template <typename Geometry,PFLayer::Layer Layer,int Detector>
-  class PFEcalRecHitCreatorMaxSample final :  public  PFRecHitCreatorBase {
+template <typename Geometry, PFLayer::Layer Layer, int Detector>
+class PFEcalRecHitCreatorMaxSample final : public PFRecHitCreatorBase {
+public:
+  PFEcalRecHitCreatorMaxSample(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC)
+      : PFRecHitCreatorBase(iConfig, iC) {
+    recHitToken_ = iC.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
+  }
 
- public:  
-  PFEcalRecHitCreatorMaxSample(const edm::ParameterSet& iConfig,edm::ConsumesCollector& iC):
-    PFRecHitCreatorBase(iConfig,iC)
-    {
-      recHitToken_ = iC.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
-    }
+  void importRecHits(std::unique_ptr<reco::PFRecHitCollection>& out,
+                     std::unique_ptr<reco::PFRecHitCollection>& cleaned,
+                     const edm::Event& iEvent,
+                     const edm::EventSetup& iSetup) override {
+    beginEvent(iEvent, iSetup);
 
-    void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&out,std::unique_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) override {
+    edm::Handle<EcalRecHitCollection> recHitHandle;
 
-      beginEvent(iEvent,iSetup);
+    edm::ESHandle<CaloGeometry> geoHandle;
+    iSetup.get<CaloGeometryRecord>().get(geoHandle);
 
-      edm::Handle<EcalRecHitCollection> recHitHandle;
+    // get the ecal geometry
+    const CaloSubdetectorGeometry* gTmp = geoHandle->getSubdetectorGeometry(DetId::Ecal, Detector);
 
-      edm::ESHandle<CaloGeometry> geoHandle;
-      iSetup.get<CaloGeometryRecord>().get(geoHandle);
-  
-      // get the ecal geometry
-      const CaloSubdetectorGeometry *gTmp = 
-	geoHandle->getSubdetectorGeometry(DetId::Ecal, Detector);
+    const Geometry* ecalGeo = dynamic_cast<const Geometry*>(gTmp);
 
-      const Geometry *ecalGeo = dynamic_cast<const Geometry*>(gTmp);
+    iEvent.getByToken(recHitToken_, recHitHandle);
+    for (const auto& erh : *recHitHandle) {
+      const DetId& detid = erh.detid();
+      auto energy = erh.energy();
+      auto time = erh.time();
 
-      iEvent.getByToken(recHitToken_,recHitHandle);
-      for(const auto& erh : *recHitHandle ) {      
-	const DetId& detid = erh.detid();
-	auto energy = erh.energy();
-	auto time = erh.time();
+      std::shared_ptr<const CaloCellGeometry> thisCell = ecalGeo->getGeometry(detid);
 
-	std::shared_ptr<const CaloCellGeometry> thisCell= ecalGeo->getGeometry(detid);
-  
-	// find rechit geometry
-	if(!thisCell) {
-	  edm::LogError("PFEcalRecHitCreatorMaxSample")
-	    <<"warning detid "<<detid.rawId()
-	    <<" not found in geometry"<<std::endl;
-	  continue;
-	}
-
-
-	reco::PFRecHit rh(thisCell, detid.rawId(),Layer,
-			   energy); 
-
-
-	bool rcleaned = false;
-	bool keep=true;
-        bool hi = true; // this is std version for which the PF ZS is always applied
-
-	//Apply Q tests
-	for( const auto& qtest : qualityTests_ ) {
-	  if (!qtest->test(rh,erh,rcleaned,hi)) {
-	    keep = false;	    
-	  }
-	}
-	  
-	if(keep) {
-	  rh.setTime(time);
-	  rh.setDepth(1);
-	  out->push_back(rh);
-	}
-	else if (rcleaned) 
-	  cleaned->push_back(rh);
+      // find rechit geometry
+      if (!thisCell) {
+        edm::LogError("PFEcalRecHitCreatorMaxSample")
+            << "warning detid " << detid.rawId() << " not found in geometry" << std::endl;
+        continue;
       }
+
+      reco::PFRecHit rh(thisCell, detid.rawId(), Layer, energy);
+
+      bool rcleaned = false;
+      bool keep = true;
+      bool hi = true;  // this is std version for which the PF ZS is always applied
+
+      //Apply Q tests
+      for (const auto& qtest : qualityTests_) {
+        if (!qtest->test(rh, erh, rcleaned, hi)) {
+          keep = false;
+        }
+      }
+
+      if (keep) {
+        rh.setTime(time);
+        rh.setDepth(1);
+        out->push_back(rh);
+      } else if (rcleaned)
+        cleaned->push_back(rh);
     }
+  }
 
-
-
- protected:
+protected:
   edm::EDGetTokenT<EcalRecHitCollection> recHitToken_;
-
-
 };
 
-
-typedef PFEcalRecHitCreatorMaxSample<EcalBarrelGeometry,PFLayer::ECAL_BARREL,EcalBarrel> PFEBRecHitCreatorMaxSample;
-typedef PFEcalRecHitCreatorMaxSample<EcalEndcapGeometry,PFLayer::ECAL_ENDCAP,EcalEndcap> PFEERecHitCreatorMaxSample;
+typedef PFEcalRecHitCreatorMaxSample<EcalBarrelGeometry, PFLayer::ECAL_BARREL, EcalBarrel> PFEBRecHitCreatorMaxSample;
+typedef PFEcalRecHitCreatorMaxSample<EcalEndcapGeometry, PFLayer::ECAL_ENDCAP, EcalEndcap> PFEERecHitCreatorMaxSample;
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreatorMaxSample.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHBHERecHitCreatorMaxSample.h
@@ -22,221 +22,191 @@
 
 #include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"
 
-
 #include "CalibFormats/HcalObjects/interface/HcalDbService.h"
-
 
 #include "RecoCaloTools/Navigation/interface/CaloNavigator.h"
 
-
-class PFHBHERecHitCreatorMaxSample :  public  PFRecHitCreatorBase {
-
- public:  
-  PFHBHERecHitCreatorMaxSample(const edm::ParameterSet& iConfig,edm::ConsumesCollector& iC):
-    PFRecHitCreatorBase(iConfig,iC)
-    {
-      recHitToken_ = iC.consumes<edm::SortedCollection<HBHERecHit> >(iConfig.getParameter<edm::InputTag>("src"));
-    }
-
+class PFHBHERecHitCreatorMaxSample : public PFRecHitCreatorBase {
+public:
+  PFHBHERecHitCreatorMaxSample(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC)
+      : PFRecHitCreatorBase(iConfig, iC) {
+    recHitToken_ = iC.consumes<edm::SortedCollection<HBHERecHit> >(iConfig.getParameter<edm::InputTag>("src"));
+  }
 
   ~PFHBHERecHitCreatorMaxSample() override = default;
 
+  void importRecHits(std::unique_ptr<reco::PFRecHitCollection>& out,
+                     std::unique_ptr<reco::PFRecHitCollection>& cleaned,
+                     const edm::Event& iEvent,
+                     const edm::EventSetup& iSetup) override {
+    beginEvent(iEvent, iSetup);
 
-    void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&out,std::unique_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) override {
+    edm::Handle<edm::SortedCollection<HBHERecHit> > recHitHandle;
 
-      beginEvent(iEvent,iSetup);
+    edm::ESHandle<CaloGeometry> geoHandle;
+    iSetup.get<CaloGeometryRecord>().get(geoHandle);
 
-      edm::Handle<edm::SortedCollection<HBHERecHit> > recHitHandle;
+    edm::ESHandle<HcalDbService> conditions;
+    iSetup.get<HcalDbRecord>().get(conditions);
 
-      edm::ESHandle<CaloGeometry> geoHandle;
-      iSetup.get<CaloGeometryRecord>().get(geoHandle);
+    // get the ecal geometry
+    const CaloSubdetectorGeometry* hcalBarrelGeo = geoHandle->getSubdetectorGeometry(DetId::Hcal, HcalBarrel);
+    const CaloSubdetectorGeometry* hcalEndcapGeo = geoHandle->getSubdetectorGeometry(DetId::Hcal, HcalEndcap);
 
+    iEvent.getByToken(recHitToken_, recHitHandle);
+    for (const auto& erh : *recHitHandle) {
+      const HcalDetId detid = erh.idFront();
+      HcalSubdetector esd = (HcalSubdetector)detid.subdetId();
 
-      edm::ESHandle<HcalDbService> conditions;
-      iSetup.get<HcalDbRecord > ().get(conditions);
-  
-      // get the ecal geometry
-     const  CaloSubdetectorGeometry *hcalBarrelGeo = geoHandle->getSubdetectorGeometry(DetId::Hcal, HcalBarrel);
-      const CaloSubdetectorGeometry *hcalEndcapGeo = geoHandle->getSubdetectorGeometry(DetId::Hcal, HcalEndcap);
+      //CUSTOM ENERGY AND TIME RECO
 
-      iEvent.getByToken(recHitToken_,recHitHandle);
-      for( const auto& erh : *recHitHandle ) {      
-	const HcalDetId detid = erh.idFront();
-	HcalSubdetector esd=(HcalSubdetector)detid.subdetId();
-	
-	
-	//CUSTOM ENERGY AND TIME RECO
+      CaloSamples tool;
+      const HcalCalibrations& calibrations = conditions->getHcalCalibrations(detid);
+      const HcalQIECoder* channelCoder = conditions->getHcalCoder(detid);
+      const HcalQIEShape* shape = conditions->getHcalShape(channelCoder);
+      HcalCoderDb coder(*channelCoder, *shape);
+      int auxwd1 = erh.auxHBHE();  // TS = 0,1,2,3 info
+      int auxwd2 = erh.aux();      // TS = 4,5,6,7 info
 
-	CaloSamples tool;
-	const HcalCalibrations& calibrations = conditions->getHcalCalibrations(detid);
-	const HcalQIECoder* channelCoder = conditions->getHcalCoder(detid);
-	const HcalQIEShape* shape = conditions->getHcalShape(channelCoder);
-	HcalCoderDb coder(*channelCoder, *shape);
-	int auxwd1 = erh.auxHBHE();  // TS = 0,1,2,3 info
-	int auxwd2 = erh.aux();      // TS = 4,5,6,7 info 	
+      int adc[8];
+      int capid[8];
 
-	int adc[8];
-	int capid[8];
+      adc[0] = (auxwd1)&0x7F;
+      adc[1] = (auxwd1 >> 7) & 0x7F;
+      adc[2] = (auxwd1 >> 14) & 0x7F;
+      adc[3] = (auxwd1 >> 21) & 0x7F;
 
-	adc[0] = (auxwd1)       & 0x7F;
-	adc[1] = (auxwd1 >> 7)  & 0x7F;
-	adc[2] = (auxwd1 >> 14) & 0x7F;
-	adc[3] = (auxwd1 >> 21) & 0x7F;
-	
-	capid[0] = (auxwd1 >> 28) & 0x3;  // rotating through 4 values: 0,1,2,3
-	capid[1] = (capid[0] + 1 <= 3) ? capid[0] + 1 : 0;
-	capid[2] = (capid[1] + 1 <= 3) ? capid[1] + 1 : 0;
-	capid[3] = (capid[2] + 1 <= 3) ? capid[2] + 1 : 0;
+      capid[0] = (auxwd1 >> 28) & 0x3;  // rotating through 4 values: 0,1,2,3
+      capid[1] = (capid[0] + 1 <= 3) ? capid[0] + 1 : 0;
+      capid[2] = (capid[1] + 1 <= 3) ? capid[1] + 1 : 0;
+      capid[3] = (capid[2] + 1 <= 3) ? capid[2] + 1 : 0;
 
-	adc[4] = (auxwd2)       & 0x7F;
-	adc[5] = (auxwd2 >> 7)  & 0x7F;
-	adc[6] = (auxwd2 >> 14) & 0x7F;
-	adc[7] = (auxwd2 >> 21) & 0x7F;
+      adc[4] = (auxwd2)&0x7F;
+      adc[5] = (auxwd2 >> 7) & 0x7F;
+      adc[6] = (auxwd2 >> 14) & 0x7F;
+      adc[7] = (auxwd2 >> 21) & 0x7F;
 
-	capid[4] = (auxwd2 >> 28) & 0x3;
-	capid[5] = (capid[4] + 1 <= 3) ? capid[4] + 1 : 0;
-	capid[6] = (capid[5] + 1 <= 3) ? capid[5] + 1 : 0;
-	capid[7] = (capid[6] + 1 <= 3) ? capid[6] + 1 : 0; 
+      capid[4] = (auxwd2 >> 28) & 0x3;
+      capid[5] = (capid[4] + 1 <= 3) ? capid[4] + 1 : 0;
+      capid[6] = (capid[5] + 1 <= 3) ? capid[5] + 1 : 0;
+      capid[7] = (capid[6] + 1 <= 3) ? capid[6] + 1 : 0;
 
-	// Pack the above into HBHEDataFrame for subsequent linearization to fC 	
-	HBHEDataFrame digi(detid);
-	digi.setSize(10);
-	digi.setPresamples(4); 
-	for (int ii = 0; ii < 8; ii++) {
-	  HcalQIESample s (adc[ii], capid[ii], 0, 0);
-	  digi.setSample(ii,s);
-	} 
-	coder.adc2fC(digi, tool); 
-	HcalGenericDetId hcalGenDetId(erh.id());
-	std::array<double,8> samples;
-
-
-	//store the samples over thresholds
-	for (int ii = 0; ii < 8; ii++) {
-	  double sampleE = calibrations.respcorrgain(capid[ii]) *
-	    (tool[ii] - calibrations.pedestal(capid[ii]));
-	  if (sampleE>sampleCut_)
-	    samples[ii] = sampleE;
-	  else
-	    samples[ii] = 0.0;
-
-	}
-
-	
-	//run the algorithm
-	double energy=0.0;
-	double energy2=0.0;
-	double time=0.0;
-	double s2=0.0;
-	std::vector<double> hitEnergies;	  
-	std::vector<double> hitTimes;	  
-
-	for (int ii = 0; ii < 8; ii++) {
-	  energy=energy+samples[ii];
-	  s2=samples[ii]*samples[ii];
-	  time = time+(-100. + ii*25.0)*s2;
-	  energy2=energy2+s2;
-
-	  if (ii>0 && ii<7) {
-	    if (samples[ii]<=samples[ii-1] && samples[ii]<samples[ii+1] && energy>0) {
-	      hitEnergies.push_back(energy);
-	      hitTimes.push_back(time/energy2);
-	      energy=0.0;
-	      energy2=0.0;
-	      time=0.0;
-	    }
-	      
-	  }
-	  else if (ii==7 && energy>0) {
-	      hitEnergies.push_back(energy);
-	      hitTimes.push_back(time/energy2);
-	      energy=0.0;
-	      energy2=0.0;
-	      time=0.0;
-	  }
-
-	}	    
-
-	if (hitEnergies.empty())
-	  continue;
-
-	int depth = detid.depth();
-	
-	std::shared_ptr<const CaloCellGeometry> thisCell = nullptr;
-	PFLayer::Layer layer = PFLayer::HCAL_BARREL1;
-	switch(esd) {
-	case HcalBarrel:
-	  thisCell = hcalBarrelGeo->getGeometry(detid);
-	  layer    = PFLayer::HCAL_BARREL1;
-	  break;
-
-	case HcalEndcap:
-	  thisCell = hcalEndcapGeo->getGeometry(detid);
-	  layer    = PFLayer::HCAL_ENDCAP;
-	  break;
-	default:
-	  break;
-	}
-  
-	// find rechit geometry
-	if(!thisCell) {
-	  edm::LogError("PFHBHERecHitCreatorMaxSample")
-	    <<"warning detid "<<detid.rawId()
-	    <<" not found in geometry"<<std::endl;
-	  continue;
-	}
-
-
-
-	reco::PFRecHit rh(thisCell, detid.rawId(),layer,
-			   energy);
-
-	rh.setDepth(depth);
-
-
-	
-	//	for (unsigned int i=0;i<hitEnergies.size();++i)
-	//	  printf(" %f / %f ,",hitEnergies[i],hitTimes[i]);
-	
-	//now find the best hit	
-	auto best_hit = std::min_element(hitTimes.begin(),hitTimes.end(),
-				      [](const double& a, 
-					 const double& b){
-					   return fabs(a) < fabs(b);
-				      });
-
-
-	rh.setTime(*best_hit);
-	rh.setEnergy(hitEnergies[std::distance(hitTimes.begin(),best_hit)]);
-	//	printf("Best = %f %f\n",rh.energy(),rh.time());
-
-	//Apply Q tests
-	bool rcleaned = false;
-	bool keep=true;
-
-	for( const auto& qtest : qualityTests_ ) {
-	  if (!qtest->test(rh,erh,rcleaned)) {
-	    keep = false;
-	  }
-	}
-	  
-	if(keep) {
-	  out->push_back(rh);
-	}
-	else if (rcleaned) 
-	  cleaned->push_back(rh);
+      // Pack the above into HBHEDataFrame for subsequent linearization to fC
+      HBHEDataFrame digi(detid);
+      digi.setSize(10);
+      digi.setPresamples(4);
+      for (int ii = 0; ii < 8; ii++) {
+        HcalQIESample s(adc[ii], capid[ii], 0, 0);
+        digi.setSample(ii, s);
       }
+      coder.adc2fC(digi, tool);
+      HcalGenericDetId hcalGenDetId(erh.id());
+      std::array<double, 8> samples;
+
+      //store the samples over thresholds
+      for (int ii = 0; ii < 8; ii++) {
+        double sampleE = calibrations.respcorrgain(capid[ii]) * (tool[ii] - calibrations.pedestal(capid[ii]));
+        if (sampleE > sampleCut_)
+          samples[ii] = sampleE;
+        else
+          samples[ii] = 0.0;
+      }
+
+      //run the algorithm
+      double energy = 0.0;
+      double energy2 = 0.0;
+      double time = 0.0;
+      double s2 = 0.0;
+      std::vector<double> hitEnergies;
+      std::vector<double> hitTimes;
+
+      for (int ii = 0; ii < 8; ii++) {
+        energy = energy + samples[ii];
+        s2 = samples[ii] * samples[ii];
+        time = time + (-100. + ii * 25.0) * s2;
+        energy2 = energy2 + s2;
+
+        if (ii > 0 && ii < 7) {
+          if (samples[ii] <= samples[ii - 1] && samples[ii] < samples[ii + 1] && energy > 0) {
+            hitEnergies.push_back(energy);
+            hitTimes.push_back(time / energy2);
+            energy = 0.0;
+            energy2 = 0.0;
+            time = 0.0;
+          }
+
+        } else if (ii == 7 && energy > 0) {
+          hitEnergies.push_back(energy);
+          hitTimes.push_back(time / energy2);
+          energy = 0.0;
+          energy2 = 0.0;
+          time = 0.0;
+        }
+      }
+
+      if (hitEnergies.empty())
+        continue;
+
+      int depth = detid.depth();
+
+      std::shared_ptr<const CaloCellGeometry> thisCell = nullptr;
+      PFLayer::Layer layer = PFLayer::HCAL_BARREL1;
+      switch (esd) {
+        case HcalBarrel:
+          thisCell = hcalBarrelGeo->getGeometry(detid);
+          layer = PFLayer::HCAL_BARREL1;
+          break;
+
+        case HcalEndcap:
+          thisCell = hcalEndcapGeo->getGeometry(detid);
+          layer = PFLayer::HCAL_ENDCAP;
+          break;
+        default:
+          break;
+      }
+
+      // find rechit geometry
+      if (!thisCell) {
+        edm::LogError("PFHBHERecHitCreatorMaxSample")
+            << "warning detid " << detid.rawId() << " not found in geometry" << std::endl;
+        continue;
+      }
+
+      reco::PFRecHit rh(thisCell, detid.rawId(), layer, energy);
+
+      rh.setDepth(depth);
+
+      //	for (unsigned int i=0;i<hitEnergies.size();++i)
+      //	  printf(" %f / %f ,",hitEnergies[i],hitTimes[i]);
+
+      //now find the best hit
+      auto best_hit = std::min_element(
+          hitTimes.begin(), hitTimes.end(), [](const double& a, const double& b) { return fabs(a) < fabs(b); });
+
+      rh.setTime(*best_hit);
+      rh.setEnergy(hitEnergies[std::distance(hitTimes.begin(), best_hit)]);
+      //	printf("Best = %f %f\n",rh.energy(),rh.time());
+
+      //Apply Q tests
+      bool rcleaned = false;
+      bool keep = true;
+
+      for (const auto& qtest : qualityTests_) {
+        if (!qtest->test(rh, erh, rcleaned)) {
+          keep = false;
+        }
+      }
+
+      if (keep) {
+        out->push_back(rh);
+      } else if (rcleaned)
+        cleaned->push_back(rh);
     }
+  }
 
-
- protected:
-    edm::EDGetTokenT<edm::SortedCollection<HBHERecHit> > recHitToken_;
-    const double sampleCut_ = 0.6; // minimalistic threshold just to reduce the iterations 
-
+protected:
+  edm::EDGetTokenT<edm::SortedCollection<HBHERecHit> > recHitToken_;
+  const double sampleCut_ = 0.6;  // minimalistic threshold just to reduce the iterations
 };
-
-
-
-
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHFRecHitCreator.h
@@ -16,212 +16,184 @@
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "Geometry/CaloGeometry/interface/IdealZPrism.h"
 
-
 #include "RecoCaloTools/Navigation/interface/CaloNavigator.h"
 
-class PFHFRecHitCreator final :  public  PFRecHitCreatorBase {
+class PFHFRecHitCreator final : public PFRecHitCreatorBase {
+public:
+  PFHFRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC) : PFRecHitCreatorBase(iConfig, iC) {
+    recHitToken_ = iC.consumes<edm::SortedCollection<HFRecHit> >(iConfig.getParameter<edm::InputTag>("src"));
+    EM_Depth_ = iConfig.getParameter<double>("EMDepthCorrection");
+    HAD_Depth_ = iConfig.getParameter<double>("HADDepthCorrection");
+    shortFibre_Cut = iConfig.getParameter<double>("ShortFibre_Cut");
+    longFibre_Fraction = iConfig.getParameter<double>("LongFibre_Fraction");
+    longFibre_Cut = iConfig.getParameter<double>("LongFibre_Cut");
+    shortFibre_Fraction = iConfig.getParameter<double>("ShortFibre_Fraction");
+    thresh_HF_ = iConfig.getParameter<double>("thresh_HF");
+    HFCalib_ = iConfig.getParameter<double>("HFCalib29");
+  }
 
- public:  
-  PFHFRecHitCreator(const edm::ParameterSet& iConfig,edm::ConsumesCollector& iC):
-    PFRecHitCreatorBase(iConfig,iC)
-    {
-      recHitToken_ = iC.consumes<edm::SortedCollection<HFRecHit>  >(iConfig.getParameter<edm::InputTag>("src"));
-      EM_Depth_ = iConfig.getParameter<double>("EMDepthCorrection");
-      HAD_Depth_ = iConfig.getParameter<double>("HADDepthCorrection");
-      shortFibre_Cut = iConfig.getParameter<double>("ShortFibre_Cut");
-      longFibre_Fraction = iConfig.getParameter<double>("LongFibre_Fraction");
-      longFibre_Cut = iConfig.getParameter<double>("LongFibre_Cut");
-      shortFibre_Fraction = iConfig.getParameter<double>("ShortFibre_Fraction");
-      thresh_HF_ =    iConfig.getParameter<double>("thresh_HF");
-      HFCalib_ =    iConfig.getParameter<double>("HFCalib29");
+  void importRecHits(std::unique_ptr<reco::PFRecHitCollection>& out,
+                     std::unique_ptr<reco::PFRecHitCollection>& cleaned,
+                     const edm::Event& iEvent,
+                     const edm::EventSetup& iSetup) override {
+    reco::PFRecHitCollection tmpOut;
 
+    beginEvent(iEvent, iSetup);
+
+    edm::Handle<edm::SortedCollection<HFRecHit> > recHitHandle;
+
+    edm::ESHandle<CaloGeometry> geoHandle;
+    iSetup.get<CaloGeometryRecord>().get(geoHandle);
+
+    // get the ecal geometry
+    const CaloSubdetectorGeometry* hcalGeo = geoHandle->getSubdetectorGeometry(DetId::Hcal, HcalForward);
+
+    iEvent.getByToken(recHitToken_, recHitHandle);
+    for (const auto& erh : *recHitHandle) {
+      const HcalDetId& detid = (HcalDetId)erh.detid();
+      auto depth = detid.depth();
+
+      // ATTN: skip dual anode in HF for now (should be fixed in upstream changes)
+      if (depth > 2)
+        continue;
+
+      auto energy = erh.energy();
+      auto time = erh.time();
+
+      std::shared_ptr<const CaloCellGeometry> thisCell = hcalGeo->getGeometry(detid);
+      auto zp = dynamic_cast<IdealZPrism const*>(thisCell.get());
+      assert(zp);
+      thisCell = zp->forPF();
+
+      // find rechit geometry
+      if (!thisCell) {
+        edm::LogError("PFHFRecHitCreator")
+            << "warning detid " << detid.rawId() << " not found in geometry" << std::endl;
+        continue;
+      }
+
+      PFLayer::Layer layer = depth == 1 ? PFLayer::HF_EM : PFLayer::HF_HAD;
+
+      reco::PFRecHit rh(thisCell, detid.rawId(), layer, energy);
+      rh.setTime(time);
+      rh.setDepth(depth);
+
+      bool rcleaned = false;
+      bool keep = true;
+
+      //Apply Q tests
+      for (const auto& qtest : qualityTests_) {
+        if (!qtest->test(rh, erh, rcleaned)) {
+          keep = false;
+        }
+      }
+
+      if (keep) {
+        tmpOut.push_back(std::move(rh));
+      } else if (rcleaned)
+        cleaned->push_back(std::move(rh));
     }
+    //Sort by DetID the collection
+    DetIDSorter sorter;
+    if (!tmpOut.empty())
+      std::sort(tmpOut.begin(), tmpOut.end(), sorter);
 
+    /////////////////////HF DUAL READOUT/////////////////////////
 
+    for (auto& hit : tmpOut) {
+      reco::PFRecHit newHit = hit;
+      const HcalDetId& detid = (HcalDetId)hit.detId();
+      if (detid.depth() == 1) {
+        double lONG = hit.energy();
+        //find the short hit
+        HcalDetId shortID(HcalForward, detid.ieta(), detid.iphi(), 2);
+        auto found_hit =
+            std::lower_bound(tmpOut.begin(), tmpOut.end(), shortID, [](const reco::PFRecHit& a, HcalDetId b) {
+              return a.detId() < b.rawId();
+            });
+        if (found_hit != tmpOut.end() && found_hit->detId() == shortID.rawId()) {
+          double sHORT = found_hit->energy();
+          //Ask for fraction
+          double energy = lONG - sHORT;
 
-    void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&out,std::unique_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) override {
+          if (abs(detid.ieta()) <= 32)
+            energy *= HFCalib_;
+          newHit.setEnergy(energy);
+          if (!(lONG > longFibre_Cut && (sHORT / lONG < shortFibre_Fraction)))
+            if (energy > thresh_HF_)
+              out->push_back(newHit);
+        } else {
+          //make only long hit
+          double energy = lONG;
+          if (abs(detid.ieta()) <= 32)
+            energy *= HFCalib_;
+          newHit.setEnergy(energy);
 
+          if (energy > thresh_HF_)
+            out->push_back(newHit);
+        }
 
-      reco::PFRecHitCollection tmpOut;
+      } else {
+        double sHORT = hit.energy();
+        HcalDetId longID(HcalForward, detid.ieta(), detid.iphi(), 1);
+        auto found_hit =
+            std::lower_bound(tmpOut.begin(), tmpOut.end(), longID, [](const reco::PFRecHit& a, HcalDetId b) {
+              return a.detId() < b.rawId();
+            });
+        double energy = 2 * sHORT;
+        if (found_hit != tmpOut.end() && found_hit->detId() == longID.rawId()) {
+          double lONG = found_hit->energy();
+          //Ask for fraction
 
-      beginEvent(iEvent,iSetup);
+          //If in this case lONG-sHORT<0 add the energy to the sHORT
+          if ((lONG - sHORT) < thresh_HF_)
+            energy = lONG + sHORT;
 
-      edm::Handle<edm::SortedCollection<HFRecHit> > recHitHandle;
+          if (abs(detid.ieta()) <= 32)
+            energy *= HFCalib_;
 
-      edm::ESHandle<CaloGeometry> geoHandle;
-      iSetup.get<CaloGeometryRecord>().get(geoHandle);
-  
-      // get the ecal geometry
-      const CaloSubdetectorGeometry *hcalGeo = geoHandle->getSubdetectorGeometry(DetId::Hcal, HcalForward);
+          newHit.setEnergy(energy);
+          if (!(sHORT > shortFibre_Cut && (lONG / sHORT < longFibre_Fraction)))
+            if (energy > thresh_HF_)
+              out->push_back(newHit);
 
-      iEvent.getByToken(recHitToken_,recHitHandle);
-      for( const auto& erh : *recHitHandle ) {      
-	const HcalDetId& detid = (HcalDetId)erh.detid();
-	auto depth = detid.depth();
-
-	// ATTN: skip dual anode in HF for now (should be fixed in upstream changes)
-	if( depth > 2 ) continue; 
-
-	auto energy = erh.energy();
-	auto time = erh.time();
-
-	std::shared_ptr<const CaloCellGeometry> thisCell= hcalGeo->getGeometry(detid);
-	auto zp = dynamic_cast<IdealZPrism const*>(thisCell.get());
-	assert(zp);
-	thisCell = zp->forPF();
-	
-	// find rechit geometry
-	if(!thisCell) {
-	  edm::LogError("PFHFRecHitCreator")
-	    <<"warning detid "<<detid.rawId()
-	    <<" not found in geometry"<<std::endl;
-	  continue;
-	}
-
-	PFLayer::Layer layer  =  depth==1 ? PFLayer::HF_EM : PFLayer::HF_HAD;
-       
-
-	reco::PFRecHit rh(thisCell, detid.rawId(),layer,energy);
-	rh.setTime(time); 
-	rh.setDepth(depth);
-
-	bool rcleaned = false;
-	bool keep=true;
-
-	//Apply Q tests
-	for( const auto& qtest : qualityTests_ ) {
-	  if (!qtest->test(rh,erh,rcleaned)) {
-	    keep = false;
-	    
-	  }
-	}
-	  
-	if(keep) {
-	  tmpOut.push_back(std::move(rh));
-	}
-	else if (rcleaned) 
-	  cleaned->push_back(std::move(rh));
+        } else {
+          //only short hit!
+          if (abs(detid.ieta()) <= 32)
+            energy *= HFCalib_;
+          newHit.setEnergy(energy);
+          if (energy > thresh_HF_)
+            out->push_back(newHit);
+        }
       }
-      //Sort by DetID the collection
-      DetIDSorter sorter;
-      if (!tmpOut.empty())
-	std::sort(tmpOut.begin(),tmpOut.end(),sorter); 
-
-
-      /////////////////////HF DUAL READOUT/////////////////////////
-      
-      for (auto& hit : tmpOut) {
-	reco::PFRecHit newHit = hit;
-	const HcalDetId& detid = (HcalDetId)hit.detId();
-	if (detid.depth()==1) {
-	  double lONG=hit.energy();
-	  //find the short hit
-	  HcalDetId shortID (HcalForward, detid.ieta(), detid.iphi(), 2);
-	  auto found_hit = std::lower_bound(tmpOut.begin(),tmpOut.end(),
-					    shortID,
-					    [](const reco::PFRecHit& a, 
-					       HcalDetId b){
-					     return  a.detId() < b.rawId();
-					    });
-	if( found_hit != tmpOut.end() && found_hit->detId() == shortID.rawId() ) {
-	  double sHORT = found_hit->energy();
-	    //Ask for fraction
-	    double energy = lONG-sHORT;
-
-	    if (abs(detid.ieta())<=32)
-	      energy*=HFCalib_;
-	    newHit.setEnergy(energy);
-	    if (!( lONG > longFibre_Cut && 
-		   ( sHORT/lONG < shortFibre_Fraction)))
-	      if (energy>thresh_HF_)
-		out->push_back(newHit);
-	  }
-	  else
-	    {
-	      //make only long hit
-	      double energy = lONG;
-	      if (abs(detid.ieta())<=32)
-		energy*=HFCalib_;
-	      newHit.setEnergy(energy);
-
-	      if (energy>thresh_HF_)
-		out->push_back(newHit);
-
-	    }
-
-	}
-	else {
-	  double sHORT=hit.energy();
-	  HcalDetId longID (HcalForward, detid.ieta(), detid.iphi(), 1);
-	  auto found_hit = std::lower_bound(tmpOut.begin(),tmpOut.end(),
-					    longID,
-					    [](const reco::PFRecHit& a, 
-					       HcalDetId b){
-					      return a.detId() < b.rawId();
-					    });
-	  double energy = 2*sHORT;
-	  if( found_hit != tmpOut.end() && found_hit->detId() == longID.rawId() ) {
-	    double lONG = found_hit->energy();
-	    //Ask for fraction
-
-	    //If in this case lONG-sHORT<0 add the energy to the sHORT
-	    if ((lONG-sHORT)<thresh_HF_)
-	      energy = lONG+sHORT;
-
-	    if (abs(detid.ieta())<=32)
-	      energy*=HFCalib_;
-	    
-	    newHit.setEnergy(energy);
-	    if (!( sHORT > shortFibre_Cut && 
-		   ( lONG/sHORT < longFibre_Fraction)))
-	      if (energy>thresh_HF_)
-		out->push_back(newHit);
-
-	  }
-	  else {
-	    //only short hit!
-	    if (abs(detid.ieta())<=32)
-	      energy*=HFCalib_;
-	    newHit.setEnergy(energy);
-	      if (energy>thresh_HF_)
-		out->push_back(newHit);
-	  }
-	}
-
-
-      }
-
     }
+  }
 
+protected:
+  edm::EDGetTokenT<edm::SortedCollection<HFRecHit> > recHitToken_;
+  double EM_Depth_;
+  double HAD_Depth_;
+  // Don't allow large energy in short fibres if there is no energy in long fibres
+  double shortFibre_Cut;
+  double longFibre_Fraction;
 
+  // Don't allow large energy in long fibres if there is no energy in short fibres
+  double longFibre_Cut;
+  double shortFibre_Fraction;
+  double thresh_HF_;
+  double HFCalib_;
 
- protected:
-    edm::EDGetTokenT<edm::SortedCollection<HFRecHit> > recHitToken_;
-    double EM_Depth_;
-    double HAD_Depth_;
-    // Don't allow large energy in short fibres if there is no energy in long fibres
-    double shortFibre_Cut;  
-    double longFibre_Fraction;
+  class DetIDSorter {
+  public:
+    DetIDSorter() = default;
+    ~DetIDSorter() = default;
 
-    // Don't allow large energy in long fibres if there is no energy in short fibres
-    double longFibre_Cut;  
-    double shortFibre_Fraction;
-    double           thresh_HF_;
-    double HFCalib_;
-
-    class DetIDSorter {
-    public:
-      DetIDSorter() = default;
-      ~DetIDSorter() = default;
-
-      bool operator()(const reco::PFRecHit& a,
-		     const reco::PFRecHit& b) {
-	if (DetId(a.detId()).det() == DetId::Hcal || DetId(b.detId()).det() == DetId::Hcal) return (HcalDetId)(a.detId()) < (HcalDetId)(b.detId());
-	else return a.detId() < b.detId();
-      }
-
-    };
-
-
+    bool operator()(const reco::PFRecHit& a, const reco::PFRecHit& b) {
+      if (DetId(a.detId()).det() == DetId::Hcal || DetId(b.detId()).det() == DetId::Hcal)
+        return (HcalDetId)(a.detId()) < (HcalDetId)(b.detId());
+      else
+        return a.detId() < b.detId();
+    }
+  };
 };
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h
@@ -22,93 +22,84 @@
 
 #include "RecoLocalCalo/HGCalRecAlgos/interface/RecHitTools.h"
 
-template <typename DET,PFLayer::Layer Layer,DetId::Detector det,unsigned subdet>
-  class PFHGCalRecHitCreator :  public  PFRecHitCreatorBase {
+template <typename DET, PFLayer::Layer Layer, DetId::Detector det, unsigned subdet>
+class PFHGCalRecHitCreator : public PFRecHitCreatorBase {
+public:
+  PFHGCalRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC)
+      : PFRecHitCreatorBase(iConfig, iC) {
+    recHitToken_ = iC.consumes<HGCRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
+    geometryInstance_ = iConfig.getParameter<std::string>("geometryInstance");
+  }
 
- public:  
-  PFHGCalRecHitCreator(const edm::ParameterSet& iConfig,edm::ConsumesCollector& iC):
-    PFRecHitCreatorBase(iConfig,iC)
-    {
-      recHitToken_ = iC.consumes<HGCRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
-      geometryInstance_ = iConfig.getParameter<std::string>("geometryInstance");
+  void importRecHits(std::unique_ptr<reco::PFRecHitCollection>& out,
+                     std::unique_ptr<reco::PFRecHitCollection>& cleaned,
+                     const edm::Event& iEvent,
+                     const edm::EventSetup& iSetup) override {
+    // Setup RecHitTools to properly compute the position of the HGCAL Cells vie their DetIds
+    recHitTools_.getEventSetup(iSetup);
+
+    for (unsigned int i = 0; i < qualityTests_.size(); ++i) {
+      qualityTests_.at(i)->beginEvent(iEvent, iSetup);
     }
 
-    void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&out,std::unique_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) override {
+    edm::Handle<HGCRecHitCollection> recHitHandle;
+    iEvent.getByToken(recHitToken_, recHitHandle);
+    const HGCRecHitCollection& rechits = *recHitHandle;
 
-      // Setup RecHitTools to properly compute the position of the HGCAL Cells vie their DetIds
-      recHitTools_.getEventSetup(iSetup);
+    edm::ESHandle<CaloGeometry> geoHandle;
+    iSetup.get<CaloGeometryRecord>().get(geoHandle);
+    const CaloGeometry* geom = geoHandle.product();
 
-      for (unsigned int i=0;i<qualityTests_.size();++i) {
-	qualityTests_.at(i)->beginEvent(iEvent,iSetup);
+    unsigned skipped_rechits = 0;
+    for (const auto& hgrh : rechits) {
+      const DET detid(hgrh.detid());
+
+      if (det != detid.det() or (subdet != 0 and subdet != detid.subdetId())) {
+        throw cms::Exception("IncorrectHGCSubdetector")
+            << "det expected: " << det << " det gotten: " << detid.det() << " ; "
+            << "subdet expected: " << subdet << " subdet gotten: " << detid.subdetId() << std::endl;
       }
 
-      edm::Handle<HGCRecHitCollection> recHitHandle;
-      iEvent.getByToken(recHitToken_,recHitHandle);
-      const HGCRecHitCollection& rechits = *recHitHandle;
+      double energy = hgrh.energy();
+      double time = hgrh.time();
 
-      edm::ESHandle<CaloGeometry> geoHandle;
-      iSetup.get<CaloGeometryRecord>().get(geoHandle);
-      const CaloGeometry* geom = geoHandle.product();
+      auto thisCell = geom->getSubdetectorGeometry(det, subdet)->getGeometry(detid);
 
-      unsigned skipped_rechits = 0;
-      for (const auto & hgrh : rechits) {
-		const DET detid(hgrh.detid());
-	
-	if( det != detid.det() or (subdet != 0 and subdet != detid.subdetId() ) ) {
-	  throw cms::Exception("IncorrectHGCSubdetector")
-	    << "det expected: " << det 
-	    << " det gotten: " << detid.det() << " ; "
-	    << "subdet expected: " << subdet 
-	    << " subdet gotten: " << detid.subdetId() << std::endl;
-	}
-	
-	double energy = hgrh.energy();
-	double time = hgrh.time();	
-	
-	auto thisCell = geom->getSubdetectorGeometry(det,subdet)->getGeometry(detid);
-
-	// find rechit geometry
-	if(!thisCell) {
-	  LogDebug("PFHGCalRecHitCreator")
-	    <<"warning detid "<<detid.rawId()
-	    <<" not found in geometry"<<std::endl;
-	  ++skipped_rechits;
-	  continue;
-	}
-
-	reco::PFRecHit rh(thisCell, detid.rawId(),Layer,
-			   energy); 
-	
-	bool rcleaned = false;
-	bool keep=true;
-
-	//Apply Q tests
-	for (unsigned int i=0;i<qualityTests_.size();++i) {
-	  if (!qualityTests_.at(i)->test(rh,hgrh,rcleaned)) {
-	    keep = false;	    
-	  }
-	}
-	  
-	if(keep) {
-	  rh.setTime(time);
-	  out->push_back(rh);
-	}
-	else if (rcleaned) 
-	  cleaned->push_back(rh);
+      // find rechit geometry
+      if (!thisCell) {
+        LogDebug("PFHGCalRecHitCreator") << "warning detid " << detid.rawId() << " not found in geometry" << std::endl;
+        ++skipped_rechits;
+        continue;
       }
-      edm::LogInfo("HGCalRecHitCreator") 
-	<<  "Skipped " << skipped_rechits 
-	<< " out of " << rechits.size() << " rechits!" << std::endl;
-      edm::LogInfo("HGCalRecHitCreator")
-	<< "Created " << out->size() << " PFRecHits!" << std::endl;
+
+      reco::PFRecHit rh(thisCell, detid.rawId(), Layer, energy);
+
+      bool rcleaned = false;
+      bool keep = true;
+
+      //Apply Q tests
+      for (unsigned int i = 0; i < qualityTests_.size(); ++i) {
+        if (!qualityTests_.at(i)->test(rh, hgrh, rcleaned)) {
+          keep = false;
+        }
+      }
+
+      if (keep) {
+        rh.setTime(time);
+        out->push_back(rh);
+      } else if (rcleaned)
+        cleaned->push_back(rh);
     }
+    edm::LogInfo("HGCalRecHitCreator") << "Skipped " << skipped_rechits << " out of " << rechits.size() << " rechits!"
+                                       << std::endl;
+    edm::LogInfo("HGCalRecHitCreator") << "Created " << out->size() << " PFRecHits!" << std::endl;
+  }
 
-
-
- protected:
+protected:
   edm::EDGetTokenT<HGCRecHitCollection> recHitToken_;
   std::string geometryInstance_;
- private:
+
+private:
   hgcal::RecHitTools recHitTools_;
 };
 
@@ -117,13 +108,13 @@ template <typename DET,PFLayer::Layer Layer,DetId::Detector det,unsigned subdet>
 #include "DataFormats/ForwardDetId/interface/HGCSiliconDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCScintillatorDetId.h"
 
-typedef PFHGCalRecHitCreator<HGCalDetId,PFLayer::HGCAL,DetId::Forward,HGCEE> PFHGCEERecHitCreator;
-typedef PFHGCalRecHitCreator<HGCalDetId,PFLayer::HGCAL,DetId::Forward,HGCHEF> PFHGCHEFRecHitCreator;
-typedef PFHGCalRecHitCreator<HcalDetId ,PFLayer::HGCAL,DetId::Hcal,HcalEndcap> PFHGCHEBRecHitCreator;
+typedef PFHGCalRecHitCreator<HGCalDetId, PFLayer::HGCAL, DetId::Forward, HGCEE> PFHGCEERecHitCreator;
+typedef PFHGCalRecHitCreator<HGCalDetId, PFLayer::HGCAL, DetId::Forward, HGCHEF> PFHGCHEFRecHitCreator;
+typedef PFHGCalRecHitCreator<HcalDetId, PFLayer::HGCAL, DetId::Hcal, HcalEndcap> PFHGCHEBRecHitCreator;
 
-typedef PFHGCalRecHitCreator<HGCSiliconDetId     ,PFLayer::HGCAL,DetId::HGCalEE ,ForwardEmpty> PFHGCalEERecHitCreator;
-typedef PFHGCalRecHitCreator<HGCSiliconDetId     ,PFLayer::HGCAL,DetId::HGCalHSi,ForwardEmpty> PFHGCalHSiRecHitCreator;
-typedef PFHGCalRecHitCreator<HGCScintillatorDetId,PFLayer::HGCAL,DetId::HGCalHSc,ForwardEmpty> PFHGCalHScRecHitCreator;
-
+typedef PFHGCalRecHitCreator<HGCSiliconDetId, PFLayer::HGCAL, DetId::HGCalEE, ForwardEmpty> PFHGCalEERecHitCreator;
+typedef PFHGCalRecHitCreator<HGCSiliconDetId, PFLayer::HGCAL, DetId::HGCalHSi, ForwardEmpty> PFHGCalHSiRecHitCreator;
+typedef PFHGCalRecHitCreator<HGCScintillatorDetId, PFLayer::HGCAL, DetId::HGCalHSc, ForwardEmpty>
+    PFHGCalHScRecHitCreator;
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFHcalRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFHcalRecHitCreator.h
@@ -18,101 +18,87 @@
 
 #include "RecoCaloTools/Navigation/interface/CaloNavigator.h"
 
-template <typename Digi, typename Geometry,PFLayer::Layer Layer,int Detector>
-  class PFHcalRecHitCreator final :  public  PFRecHitCreatorBase {
+template <typename Digi, typename Geometry, PFLayer::Layer Layer, int Detector>
+class PFHcalRecHitCreator final : public PFRecHitCreatorBase {
+public:
+  PFHcalRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC) : PFRecHitCreatorBase(iConfig, iC) {
+    recHitToken_ = iC.consumes<edm::SortedCollection<Digi> >(iConfig.getParameter<edm::InputTag>("src"));
+  }
 
- public:  
-  PFHcalRecHitCreator(const edm::ParameterSet& iConfig,edm::ConsumesCollector& iC):
-    PFRecHitCreatorBase(iConfig,iC)
-    {
-      recHitToken_ = iC.consumes<edm::SortedCollection<Digi>  >(iConfig.getParameter<edm::InputTag>("src"));
-    }
+  void importRecHits(std::unique_ptr<reco::PFRecHitCollection>& out,
+                     std::unique_ptr<reco::PFRecHitCollection>& cleaned,
+                     const edm::Event& iEvent,
+                     const edm::EventSetup& iSetup) override {
+    beginEvent(iEvent, iSetup);
 
-    void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&out,std::unique_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) override {
+    edm::Handle<edm::SortedCollection<Digi> > recHitHandle;
 
+    edm::ESHandle<CaloGeometry> geoHandle;
+    iSetup.get<CaloGeometryRecord>().get(geoHandle);
+    edm::ESHandle<HcalTopology> hcalTopology;
+    iSetup.get<HcalRecNumberingRecord>().get(hcalTopology);
 
-      beginEvent(iEvent,iSetup);
+    // get the hcal geometry and topology
+    const CaloSubdetectorGeometry* gTmp = geoHandle->getSubdetectorGeometry(DetId::Hcal, Detector);
+    const Geometry* hcalGeo = dynamic_cast<const Geometry*>(gTmp);
+    const HcalTopology* theHcalTopology = hcalTopology.product();
 
-      edm::Handle<edm::SortedCollection<Digi> > recHitHandle;
+    iEvent.getByToken(recHitToken_, recHitHandle);
+    for (const auto& erh : *recHitHandle) {
+      HcalDetId detid = (HcalDetId)erh.detid();
+      HcalSubdetector esd = (HcalSubdetector)detid.subdetId();
 
-      edm::ESHandle<CaloGeometry> geoHandle;
-      iSetup.get<CaloGeometryRecord>().get(geoHandle);
-      edm::ESHandle<HcalTopology> hcalTopology;
-      iSetup.get<HcalRecNumberingRecord>().get( hcalTopology );
-  
-      // get the hcal geometry and topology
-      const CaloSubdetectorGeometry *gTmp = 
-	geoHandle->getSubdetectorGeometry(DetId::Hcal, Detector);
-      const Geometry *hcalGeo =dynamic_cast< const Geometry* > (gTmp);
-      const HcalTopology *theHcalTopology = hcalTopology.product();
+      //since hbhe are together kill other detector
+      if (esd != Detector && Detector != HcalOther)
+        continue;
 
-      iEvent.getByToken(recHitToken_,recHitHandle);
-      for( const auto& erh : *recHitHandle ) {      
-	HcalDetId detid = (HcalDetId)erh.detid();
-	HcalSubdetector esd=(HcalSubdetector)detid.subdetId();
-	
-	//since hbhe are together kill other detector
-	if (esd !=Detector && Detector != HcalOther  ) 
-	  continue;
-
-        if (theHcalTopology->getMergePositionFlag() && esd == HcalEndcap) {
-          detid = theHcalTopology->idFront(detid);
-	}
-
-	auto energy = erh.energy();
-	auto time = erh.time();
-	auto depth =detid.depth();
-	  
-	
-	auto thisCell= hcalGeo->getGeometry(detid);
-  
-	// find rechit geometry
-	if(!thisCell) {
-	  edm::LogError("PFHcalRecHitCreator")
-	    <<"warning detid "<<detid.rawId()
-	    <<" not found in geometry"<<std::endl;
-	  continue;
-	}
-
-
-	reco::PFRecHit rh(thisCell, detid.rawId(),Layer,
-			   energy);
-	rh.setTime(time); //Mike: This we will use later
-	rh.setDepth(depth);
-
- 
-	bool rcleaned = false;
-	bool keep=true;
-
-	//Apply Q tests
-	for( const auto& qtest : qualityTests_ ) {
-	  if (!qtest->test(rh,erh,rcleaned)) {
-	    keep = false;
-	    
-	  }
-	}
-	  
-	if(keep) {
-	  out->push_back(std::move(rh));
-	}
-	else if (rcleaned) 
-	  cleaned->push_back(std::move(rh));
+      if (theHcalTopology->getMergePositionFlag() && esd == HcalEndcap) {
+        detid = theHcalTopology->idFront(detid);
       }
+
+      auto energy = erh.energy();
+      auto time = erh.time();
+      auto depth = detid.depth();
+
+      auto thisCell = hcalGeo->getGeometry(detid);
+
+      // find rechit geometry
+      if (!thisCell) {
+        edm::LogError("PFHcalRecHitCreator")
+            << "warning detid " << detid.rawId() << " not found in geometry" << std::endl;
+        continue;
+      }
+
+      reco::PFRecHit rh(thisCell, detid.rawId(), Layer, energy);
+      rh.setTime(time);  //Mike: This we will use later
+      rh.setDepth(depth);
+
+      bool rcleaned = false;
+      bool keep = true;
+
+      //Apply Q tests
+      for (const auto& qtest : qualityTests_) {
+        if (!qtest->test(rh, erh, rcleaned)) {
+          keep = false;
+        }
+      }
+
+      if (keep) {
+        out->push_back(std::move(rh));
+      } else if (rcleaned)
+        cleaned->push_back(std::move(rh));
     }
+  }
 
-
-
- protected:
-    edm::EDGetTokenT<edm::SortedCollection<Digi> > recHitToken_;
-    int hoDepth_;
-
+protected:
+  edm::EDGetTokenT<edm::SortedCollection<Digi> > recHitToken_;
+  int hoDepth_;
 };
 
-typedef PFHcalRecHitCreator<HBHERecHit,CaloSubdetectorGeometry,PFLayer::HCAL_BARREL1,HcalBarrel> PFHBRecHitCreator;
-typedef PFHcalRecHitCreator<HORecHit,CaloSubdetectorGeometry,PFLayer::HCAL_BARREL2,HcalOuter> PFHORecHitCreator;
-typedef PFHcalRecHitCreator<HBHERecHit,CaloSubdetectorGeometry,PFLayer::HCAL_ENDCAP,HcalEndcap> PFHERecHitCreator;
-typedef PFHcalRecHitCreator<HFRecHit,CaloSubdetectorGeometry,PFLayer::HF_EM,HcalForward> PFHFEMRecHitCreator;
-typedef PFHcalRecHitCreator<HFRecHit,CaloSubdetectorGeometry,PFLayer::HF_HAD,HcalForward> PFHFHADRecHitCreator;
-
+typedef PFHcalRecHitCreator<HBHERecHit, CaloSubdetectorGeometry, PFLayer::HCAL_BARREL1, HcalBarrel> PFHBRecHitCreator;
+typedef PFHcalRecHitCreator<HORecHit, CaloSubdetectorGeometry, PFLayer::HCAL_BARREL2, HcalOuter> PFHORecHitCreator;
+typedef PFHcalRecHitCreator<HBHERecHit, CaloSubdetectorGeometry, PFLayer::HCAL_ENDCAP, HcalEndcap> PFHERecHitCreator;
+typedef PFHcalRecHitCreator<HFRecHit, CaloSubdetectorGeometry, PFLayer::HF_EM, HcalForward> PFHFEMRecHitCreator;
+typedef PFHcalRecHitCreator<HFRecHit, CaloSubdetectorGeometry, PFLayer::HF_HAD, HcalForward> PFHFHADRecHitCreator;
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h
@@ -10,7 +10,6 @@
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/ESDetId.h"
 
-
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
@@ -24,88 +23,78 @@
 #include "Geometry/CaloTopology/interface/EcalPreshowerTopology.h"
 #include "RecoCaloTools/Navigation/interface/CaloNavigator.h"
 
-class PFPSRecHitCreator final :  public  PFRecHitCreatorBase {
+class PFPSRecHitCreator final : public PFRecHitCreatorBase {
+public:
+  PFPSRecHitCreator(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC) : PFRecHitCreatorBase(iConfig, iC) {
+    recHitToken_ = iC.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
+  }
 
- public:  
-  PFPSRecHitCreator(const edm::ParameterSet& iConfig,edm::ConsumesCollector& iC):
-    PFRecHitCreatorBase(iConfig,iC)
-    {
-      recHitToken_ = iC.consumes<EcalRecHitCollection>(iConfig.getParameter<edm::InputTag>("src"));
-    }
+  void importRecHits(std::unique_ptr<reco::PFRecHitCollection>& out,
+                     std::unique_ptr<reco::PFRecHitCollection>& cleaned,
+                     const edm::Event& iEvent,
+                     const edm::EventSetup& iSetup) override {
+    beginEvent(iEvent, iSetup);
 
-    void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&out,std::unique_ptr<reco::PFRecHitCollection>& cleaned ,const edm::Event& iEvent,const edm::EventSetup& iSetup) override {
+    edm::Handle<EcalRecHitCollection> recHitHandle;
+    edm::ESHandle<CaloGeometry> geoHandle;
+    iSetup.get<CaloGeometryRecord>().get(geoHandle);
 
-      beginEvent(iEvent,iSetup);
+    // get the ecal geometry
+    const CaloSubdetectorGeometry* psGeometry = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
 
-      edm::Handle<EcalRecHitCollection> recHitHandle;
-      edm::ESHandle<CaloGeometry> geoHandle;
-      iSetup.get<CaloGeometryRecord>().get(geoHandle);
-  
-      // get the ecal geometry
-      const CaloSubdetectorGeometry *psGeometry = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
+    iEvent.getByToken(recHitToken_, recHitHandle);
+    for (const auto& erh : *recHitHandle) {
+      ESDetId detid(erh.detid());
+      auto energy = erh.energy();
 
-      iEvent.getByToken(recHitToken_,recHitHandle);
-      for( const auto& erh : *recHitHandle ) {      
-	ESDetId detid(erh.detid());
-	auto energy = erh.energy();
+      PFLayer::Layer layer = PFLayer::NONE;
 
-	PFLayer::Layer layer = PFLayer::NONE;
-	
-	switch( detid.plane() ) {
-	case 1:
-	  layer = PFLayer::PS1;
-	  break;
-	case 2:
-	  layer = PFLayer::PS2;
-	  break;
-	default:
-	  throw cms::Exception("PFRecHitBadInput")
-	    <<"incorrect preshower plane !! plane number "
-	    <<detid.plane()<<std::endl;
-	}
- 
-
-	
-	auto thisCell= psGeometry->getGeometry(detid);
-  
-	// find rechit geometry
-	if(!thisCell) {
-	  edm::LogError("PFPSRecHitCreator")
-	    <<"warning detid "<<detid.rawId()
-	    <<" not found in geometry"<<std::endl;
-	  continue;
-	}
-
-        out->emplace_back(thisCell, detid.rawId(),layer,energy);
-        auto & rh = out->back();
-	rh.setDepth(detid.plane());
-	rh.setTime(erh.time());
-	
-	bool rcleaned = false;
-	bool keep=true;
-        bool hi = true; // all ES rhs are produced, independently on the ECAL SRP decision
-
-	//Apply Q tests
-	for( const auto& qtest : qualityTests_ ) {
-	  if (!qtest->test(rh,erh,rcleaned,hi)) {
-	    keep = false;	    
-	  }
-	}
-	
-        if (rcleaned) 
-	  cleaned->push_back(std::move(out->back()));
-        if(!keep) 
-          out->pop_back();
+      switch (detid.plane()) {
+        case 1:
+          layer = PFLayer::PS1;
+          break;
+        case 2:
+          layer = PFLayer::PS2;
+          break;
+        default:
+          throw cms::Exception("PFRecHitBadInput")
+              << "incorrect preshower plane !! plane number " << detid.plane() << std::endl;
       }
+
+      auto thisCell = psGeometry->getGeometry(detid);
+
+      // find rechit geometry
+      if (!thisCell) {
+        edm::LogError("PFPSRecHitCreator")
+            << "warning detid " << detid.rawId() << " not found in geometry" << std::endl;
+        continue;
+      }
+
+      out->emplace_back(thisCell, detid.rawId(), layer, energy);
+      auto& rh = out->back();
+      rh.setDepth(detid.plane());
+      rh.setTime(erh.time());
+
+      bool rcleaned = false;
+      bool keep = true;
+      bool hi = true;  // all ES rhs are produced, independently on the ECAL SRP decision
+
+      //Apply Q tests
+      for (const auto& qtest : qualityTests_) {
+        if (!qtest->test(rh, erh, rcleaned, hi)) {
+          keep = false;
+        }
+      }
+
+      if (rcleaned)
+        cleaned->push_back(std::move(out->back()));
+      if (!keep)
+        out->pop_back();
     }
+  }
 
-
-
- protected:
+protected:
   edm::EDGetTokenT<EcalRecHitCollection> recHitToken_;
-
-
 };
-
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigator.h
@@ -1,7 +1,6 @@
 #ifndef RecoParticleFlow_PFClusterProducer_PFRecHitCaloNavigator_h
 #define RecoParticleFlow_PFClusterProducer_PFRecHitCaloNavigator_h
 
-
 #include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
@@ -20,92 +19,85 @@
 #include "Geometry/CaloTopology/interface/CaloTowerTopology.h"
 #include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
 
-
-template <typename DET,typename TOPO,bool ownsTopo=true>
+template <typename DET, typename TOPO, bool ownsTopo = true>
 class PFRecHitCaloNavigator : public PFRecHitNavigatorBase {
- public:
-
- ~PFRecHitCaloNavigator() override { if(!ownsTopo) { topology_.release(); } }
-
-  void associateNeighbours(reco::PFRecHit& hit,std::unique_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd) override {
-      DetId detid( hit.detId() );
-      
-      CaloNavigator<DET> navigator(detid, topology_.get());
-      
-      DetId N(0);
-      DetId E(0);
-      DetId S(0);
-      DetId W(0);
-      DetId NW(0);
-      DetId NE(0);
-      DetId SW(0);
-      DetId SE(0);
-
-
-      N=navigator.north();  
-      associateNeighbour(N,hit,hits,refProd,0,1,0);
-
-
-      if (N !=DetId(0)) {
-	NE=navigator.east();
-      }
-      else 
-	{
-	  navigator.home();
-	  E=navigator.east();
-	  NE=navigator.north();
-	}
-      associateNeighbour(NE,hit,hits,refProd,1,1,0);
-      navigator.home();
-
-      S = navigator.south();
-      associateNeighbour(S,hit,hits,refProd,0,-1,0);
-      
-      if (S !=DetId(0)) {
-	SW = navigator.west();
-      } else {
-	navigator.home();
-	W=navigator.west();
-	SW=navigator.south();
-      }
-      associateNeighbour(SW,hit,hits,refProd,-1,-1,0);
-      navigator.home();
-
-      E = navigator.east();
-      associateNeighbour(E,hit,hits,refProd,1,0,0);
-      
-      if (E !=DetId(0)) {
-	SE = navigator.south();
-      } else {
-	navigator.home();
-	S=navigator.south();
-	SE=navigator.east();
-      }
-      associateNeighbour(SE,hit,hits,refProd,1,-1,0);
-      navigator.home();
-
-
-      W = navigator.west();
-      associateNeighbour(W,hit,hits,refProd,-1,0,0);
-
-      if (W !=DetId(0)) {
-	NW = navigator.north();
-      } else {
-	navigator.home();
-	N=navigator.north();
-	NW=navigator.west();
-      }
-      associateNeighbour(NW,hit,hits,refProd,-1,1,0);
+public:
+  ~PFRecHitCaloNavigator() override {
+    if (!ownsTopo) {
+      topology_.release();
+    }
   }
 
+  void associateNeighbours(reco::PFRecHit& hit,
+                           std::unique_ptr<reco::PFRecHitCollection>& hits,
+                           edm::RefProd<reco::PFRecHitCollection>& refProd) override {
+    DetId detid(hit.detId());
 
+    CaloNavigator<DET> navigator(detid, topology_.get());
 
- protected:
+    DetId N(0);
+    DetId E(0);
+    DetId S(0);
+    DetId W(0);
+    DetId NW(0);
+    DetId NE(0);
+    DetId SW(0);
+    DetId SE(0);
+
+    N = navigator.north();
+    associateNeighbour(N, hit, hits, refProd, 0, 1, 0);
+
+    if (N != DetId(0)) {
+      NE = navigator.east();
+    } else {
+      navigator.home();
+      E = navigator.east();
+      NE = navigator.north();
+    }
+    associateNeighbour(NE, hit, hits, refProd, 1, 1, 0);
+    navigator.home();
+
+    S = navigator.south();
+    associateNeighbour(S, hit, hits, refProd, 0, -1, 0);
+
+    if (S != DetId(0)) {
+      SW = navigator.west();
+    } else {
+      navigator.home();
+      W = navigator.west();
+      SW = navigator.south();
+    }
+    associateNeighbour(SW, hit, hits, refProd, -1, -1, 0);
+    navigator.home();
+
+    E = navigator.east();
+    associateNeighbour(E, hit, hits, refProd, 1, 0, 0);
+
+    if (E != DetId(0)) {
+      SE = navigator.south();
+    } else {
+      navigator.home();
+      S = navigator.south();
+      SE = navigator.east();
+    }
+    associateNeighbour(SE, hit, hits, refProd, 1, -1, 0);
+    navigator.home();
+
+    W = navigator.west();
+    associateNeighbour(W, hit, hits, refProd, -1, 0, 0);
+
+    if (W != DetId(0)) {
+      NW = navigator.north();
+    } else {
+      navigator.home();
+      N = navigator.north();
+      NW = navigator.west();
+    }
+    associateNeighbour(NW, hit, hits, refProd, -1, 1, 0);
+  }
+
+protected:
   std::unique_ptr<const TOPO> topology_;
-
-
 };
 
 #endif
-
-

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h
@@ -2,7 +2,6 @@
 #ifndef RecoParticleFlow_PFClusterProducer_PFRecHitCaloNavigatorWithTime_h
 #define RecoParticleFlow_PFClusterProducer_PFRecHitCaloNavigatorWithTime_h
 
-
 #include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
@@ -23,129 +22,121 @@
 
 #include "RecoParticleFlow/PFClusterProducer/interface/CaloRecHitResolutionProvider.h"
 
-template <typename D,typename T,bool ownsTopo=true>
+template <typename D, typename T, bool ownsTopo = true>
 class PFRecHitCaloNavigatorWithTime : public PFRecHitNavigatorBase {
- public:
+public:
   PFRecHitCaloNavigatorWithTime(const edm::ParameterSet& iConfig) {
     sigmaCut2_ = pow(iConfig.getParameter<double>("sigmaCut"), 2);
     const edm::ParameterSet& timeResConf = iConfig.getParameterSet("timeResolutionCalc");
     _timeResolutionCalc.reset(new CaloRecHitResolutionProvider(timeResConf));
   }
 
-
- ~PFRecHitCaloNavigatorWithTime() override { if(!ownsTopo) { topology_.release(); } }
-
-
-  void associateNeighbours(reco::PFRecHit& hit,std::unique_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd) override {
-      DetId detid( hit.detId() );
-      
-      CaloNavigator<D> navigator(detid, topology_.get());
-      
-      DetId N(0);
-      DetId E(0);
-      DetId S(0);
-      DetId W(0);
-      DetId NW(0);
-      DetId NE(0);
-      DetId SW(0);
-      DetId SE(0);
-
-
-      N=navigator.north();  
-      associateNeighbour(N,hit,hits,refProd,0,1);
-
-
-      if (N !=DetId(0)) {
-	NE=navigator.east();
-      }
-      else 
-	{
-	  navigator.home();
-	  E=navigator.east();
-	  NE=navigator.north();
-	}
-      associateNeighbour(NE,hit,hits,refProd,1,1);
-      navigator.home();
-
-      S = navigator.south();
-      associateNeighbour(S,hit,hits,refProd,0,-1);
-      
-      if (S !=DetId(0)) {
-	SW = navigator.west();
-      } else {
-	navigator.home();
-	W=navigator.west();
-	SW=navigator.south();
-      }
-      associateNeighbour(SW,hit,hits,refProd,-1,-1);
-      navigator.home();
-
-      E = navigator.east();
-      associateNeighbour(E,hit,hits,refProd,1,0);
-      
-      if (E !=DetId(0)) {
-	SE = navigator.south();
-      } else {
-	navigator.home();
-	S=navigator.south();
-	SE=navigator.east();
-      }
-      associateNeighbour(SE,hit,hits,refProd,1,-1);
-      navigator.home();
-
-
-      W = navigator.west();
-      associateNeighbour(W,hit,hits,refProd,-1,0);
-
-      if (W !=DetId(0)) {
-	NW = navigator.north();
-      } else {
-	navigator.home();
-	N=navigator.north();
-	NW=navigator.west();
-      }
-      associateNeighbour(NW,hit,hits,refProd,-1,1);
+  ~PFRecHitCaloNavigatorWithTime() override {
+    if (!ownsTopo) {
+      topology_.release();
+    }
   }
 
+  void associateNeighbours(reco::PFRecHit& hit,
+                           std::unique_ptr<reco::PFRecHitCollection>& hits,
+                           edm::RefProd<reco::PFRecHitCollection>& refProd) override {
+    DetId detid(hit.detId());
 
+    CaloNavigator<D> navigator(detid, topology_.get());
 
- protected:
+    DetId N(0);
+    DetId E(0);
+    DetId S(0);
+    DetId W(0);
+    DetId NW(0);
+    DetId NE(0);
+    DetId SW(0);
+    DetId SE(0);
 
+    N = navigator.north();
+    associateNeighbour(N, hit, hits, refProd, 0, 1);
+
+    if (N != DetId(0)) {
+      NE = navigator.east();
+    } else {
+      navigator.home();
+      E = navigator.east();
+      NE = navigator.north();
+    }
+    associateNeighbour(NE, hit, hits, refProd, 1, 1);
+    navigator.home();
+
+    S = navigator.south();
+    associateNeighbour(S, hit, hits, refProd, 0, -1);
+
+    if (S != DetId(0)) {
+      SW = navigator.west();
+    } else {
+      navigator.home();
+      W = navigator.west();
+      SW = navigator.south();
+    }
+    associateNeighbour(SW, hit, hits, refProd, -1, -1);
+    navigator.home();
+
+    E = navigator.east();
+    associateNeighbour(E, hit, hits, refProd, 1, 0);
+
+    if (E != DetId(0)) {
+      SE = navigator.south();
+    } else {
+      navigator.home();
+      S = navigator.south();
+      SE = navigator.east();
+    }
+    associateNeighbour(SE, hit, hits, refProd, 1, -1);
+    navigator.home();
+
+    W = navigator.west();
+    associateNeighbour(W, hit, hits, refProd, -1, 0);
+
+    if (W != DetId(0)) {
+      NW = navigator.north();
+    } else {
+      navigator.home();
+      N = navigator.north();
+      NW = navigator.west();
+    }
+    associateNeighbour(NW, hit, hits, refProd, -1, 1);
+  }
+
+protected:
   double sigmaCut2_;
   std::unique_ptr<const T> topology_;
   std::unique_ptr<CaloRecHitResolutionProvider> _timeResolutionCalc;
 
+  void associateNeighbour(const DetId& id,
+                          reco::PFRecHit& hit,
+                          std::unique_ptr<reco::PFRecHitCollection>& hits,
+                          edm::RefProd<reco::PFRecHitCollection>& refProd,
+                          short eta,
+                          short phi) {
+    double sigma2 = 10000.0;
 
-  void associateNeighbour(const DetId& id, reco::PFRecHit& hit,std::unique_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd,short eta, short phi) {
-    double sigma2=10000.0;
-    
+    auto found_hit = std::lower_bound(hits->begin(), hits->end(), id, [](const reco::PFRecHit& a, DetId b) {
+      if (DetId(a.detId()).det() == DetId::Hcal || b.det() == DetId::Hcal)
+        return (HcalDetId)(a.detId()) < (HcalDetId)(b);
 
-    auto found_hit = std::lower_bound(hits->begin(),hits->end(),
-				      id,
-				      [](const reco::PFRecHit& a, 
-					  DetId b){
-					if (DetId(a.detId()).det() == DetId::Hcal || b.det() == DetId::Hcal) return (HcalDetId)(a.detId()) < (HcalDetId)(b);
+      else
+        return a.detId() < b.rawId();
+    });
 
-					else return a.detId() < b.rawId();
-				      });
-
-
-    if (found_hit != hits->end() && ((found_hit->detId() == id.rawId()) ||
-				     ((id.det()==DetId::Hcal) &&
-				      ((HcalDetId)(found_hit->detId()) == (HcalDetId)(id))))) {
-      sigma2 = _timeResolutionCalc->timeResolution2(hit.energy()) + _timeResolutionCalc->timeResolution2(found_hit->energy());
-      const double deltaTime = hit.time()-found_hit->time();
-      if(deltaTime*deltaTime<sigmaCut2_*sigma2) {
-	hit.addNeighbour(eta,phi,0,found_hit-hits->begin());
+    if (found_hit != hits->end() &&
+        ((found_hit->detId() == id.rawId()) ||
+         ((id.det() == DetId::Hcal) && ((HcalDetId)(found_hit->detId()) == (HcalDetId)(id))))) {
+      sigma2 = _timeResolutionCalc->timeResolution2(hit.energy()) +
+               _timeResolutionCalc->timeResolution2(found_hit->energy());
+      const double deltaTime = hit.time() - found_hit->time();
+      if (deltaTime * deltaTime < sigmaCut2_ * sigma2) {
+        hit.addNeighbour(eta, phi, 0, found_hit - hits->begin());
       }
     }
-
   }
-
-
-
 };
 
 #endif
-
-

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCreatorBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitCreatorBase.h
@@ -1,14 +1,11 @@
 #ifndef RecoParticleFlow_PFClusterProducer_PFRecHitCreatorBase_h
 #define RecoParticleFlow_PFClusterProducer_PFRecHitCreatorBase_h
 
-
-
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/ParticleFlowReco/interface/PFLayer.h"
@@ -23,36 +20,35 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTestBase.h"
 #include <memory>
 
-
 class PFRecHitCreatorBase {
- public:
+public:
   PFRecHitCreatorBase() {}
-  PFRecHitCreatorBase(const edm::ParameterSet& iConfig,edm::ConsumesCollector& iC) {
-    std::vector<edm::ParameterSet> qTests =   iConfig.getParameter<std::vector<edm::ParameterSet> >("qualityTests");
-    for (auto & qTest : qTests) {
+  PFRecHitCreatorBase(const edm::ParameterSet& iConfig, edm::ConsumesCollector& iC) {
+    std::vector<edm::ParameterSet> qTests = iConfig.getParameter<std::vector<edm::ParameterSet> >("qualityTests");
+    for (auto& qTest : qTests) {
       std::string name = qTest.getParameter<std::string>("name");
-      qualityTests_.emplace_back(PFRecHitQTestFactory::get()->create(name,qTest));
+      qualityTests_.emplace_back(PFRecHitQTestFactory::get()->create(name, qTest));
     }
   }
   virtual ~PFRecHitCreatorBase() = default;
 
-  virtual void init(const edm::EventSetup &es) { }
+  virtual void init(const edm::EventSetup& es) {}
 
-  virtual void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&,std::unique_ptr<reco::PFRecHitCollection>& ,const edm::Event&,const edm::EventSetup&)=0;
+  virtual void importRecHits(std::unique_ptr<reco::PFRecHitCollection>&,
+                             std::unique_ptr<reco::PFRecHitCollection>&,
+                             const edm::Event&,
+                             const edm::EventSetup&) = 0;
 
- protected:
-
-  void beginEvent(const edm::Event& event,const edm::EventSetup& setup) {
-    for (auto & qualityTest : qualityTests_)
-	qualityTest->beginEvent(event,setup);
+protected:
+  void beginEvent(const edm::Event& event, const edm::EventSetup& setup) {
+    for (auto& qualityTest : qualityTests_)
+      qualityTest->beginEvent(event, setup);
   }
 
-
   std::vector<std::unique_ptr<PFRecHitQTestBase> > qualityTests_;
-
 };
- 
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory<PFRecHitCreatorBase*(const edm::ParameterSet&,edm::ConsumesCollector&)> PFRecHitFactory;
+typedef edmplugin::PluginFactory<PFRecHitCreatorBase*(const edm::ParameterSet&, edm::ConsumesCollector&)>
+    PFRecHitFactory;
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitDualNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitDualNavigator.h
@@ -1,44 +1,36 @@
 #ifndef RecoParticleFlow_PFClusterProducer_PFRecHitDualNavigator_h
 #define RecoParticleFlow_PFClusterProducer_PFRecHitDualNavigator_h
 
-
 #include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h"
 #include "DataFormats/ParticleFlowReco/interface/PFLayer.h"
 
-
-
-template <PFLayer::Layer D1, typename barrel,PFLayer::Layer D2, typename endcap>
+template <PFLayer::Layer D1, typename barrel, PFLayer::Layer D2, typename endcap>
 class PFRecHitDualNavigator : public PFRecHitNavigatorBase {
- public:
+public:
   PFRecHitDualNavigator() = default;
 
-
-
-  PFRecHitDualNavigator(const edm::ParameterSet& iConfig){
+  PFRecHitDualNavigator(const edm::ParameterSet& iConfig) {
     barrelNav_ = new barrel(iConfig.getParameter<edm::ParameterSet>("barrel"));
     endcapNav_ = new endcap(iConfig.getParameter<edm::ParameterSet>("endcap"));
   }
 
   void beginEvent(const edm::EventSetup& iSetup) override {
-    barrelNav_->beginEvent(iSetup); 
+    barrelNav_->beginEvent(iSetup);
     endcapNav_->beginEvent(iSetup);
-
   }
 
-  void associateNeighbours(reco::PFRecHit& hit,std::unique_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd) override {
-      if (hit.layer() ==  D1)
-	barrelNav_->associateNeighbours(hit,hits,refProd);
-      else if (hit.layer() ==  D2)
-	endcapNav_->associateNeighbours(hit,hits,refProd);
+  void associateNeighbours(reco::PFRecHit& hit,
+                           std::unique_ptr<reco::PFRecHitCollection>& hits,
+                           edm::RefProd<reco::PFRecHitCollection>& refProd) override {
+    if (hit.layer() == D1)
+      barrelNav_->associateNeighbours(hit, hits, refProd);
+    else if (hit.layer() == D2)
+      endcapNav_->associateNeighbours(hit, hits, refProd);
   }
 
- protected:
-      barrel *barrelNav_;
-      endcap *endcapNav_;
-
-
+protected:
+  barrel* barrelNav_;
+  endcap* endcapNav_;
 };
 
 #endif
-
-

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitFakeNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitFakeNavigator.h
@@ -1,7 +1,6 @@
 #ifndef RecoParticleFlow_PFClusterProducer_PFRecHitFakeNavigator_h
 #define RecoParticleFlow_PFClusterProducer_PFRecHitFakeNavigator_h
 
-
 #include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
@@ -20,21 +19,16 @@
 #include "Geometry/CaloTopology/interface/CaloTowerTopology.h"
 #include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
 
-
 template <typename DET>
 class PFRecHitFakeNavigator : public PFRecHitNavigatorBase {
- public:
+public:
+  ~PFRecHitFakeNavigator() override = default;
 
- ~PFRecHitFakeNavigator() override = default;
+  void associateNeighbours(reco::PFRecHit& hit,
+                           std::unique_ptr<reco::PFRecHitCollection>& hits,
+                           edm::RefProd<reco::PFRecHitCollection>& refProd) override {}
 
-  void associateNeighbours(reco::PFRecHit& hit,std::unique_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd) override { }
-
-
-
- protected:
-
+protected:
 };
 
 #endif
-
-

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h
@@ -24,36 +24,34 @@
 #include <unordered_map>
 
 class PFRecHitNavigatorBase {
- public:
-  typedef std::unordered_map<unsigned,unsigned> DetIdToHitIdx;
+public:
+  typedef std::unordered_map<unsigned, unsigned> DetIdToHitIdx;
 
   PFRecHitNavigatorBase() = default;
   PFRecHitNavigatorBase(const edm::ParameterSet& iConfig) {}
 
   virtual ~PFRecHitNavigatorBase() = default;
 
-  virtual void beginEvent(const edm::EventSetup&)=0;
-  virtual void associateNeighbours(reco::PFRecHit&,std::unique_ptr<reco::PFRecHitCollection>&,edm::RefProd<reco::PFRecHitCollection>&)=0;
+  virtual void beginEvent(const edm::EventSetup&) = 0;
+  virtual void associateNeighbours(reco::PFRecHit&,
+                                   std::unique_ptr<reco::PFRecHitCollection>&,
+                                   edm::RefProd<reco::PFRecHitCollection>&) = 0;
 
-
- protected:
-
-  void associateNeighbour(const DetId& id, reco::PFRecHit& hit,std::unique_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd,short eta, short phi,short depth) {
-    auto found_hit = std::lower_bound(hits->begin(),hits->end(),
-				      id,
-				      [](const reco::PFRecHit& a, 
-					 const DetId& id){
-					return a.detId() < id;
-				      });
-    if( found_hit != hits->end() && found_hit->detId() == id.rawId() ) {
-      hit.addNeighbour(eta,phi,depth,found_hit-hits->begin());
-    }    
+protected:
+  void associateNeighbour(const DetId& id,
+                          reco::PFRecHit& hit,
+                          std::unique_ptr<reco::PFRecHitCollection>& hits,
+                          edm::RefProd<reco::PFRecHitCollection>& refProd,
+                          short eta,
+                          short phi,
+                          short depth) {
+    auto found_hit = std::lower_bound(
+        hits->begin(), hits->end(), id, [](const reco::PFRecHit& a, const DetId& id) { return a.detId() < id; });
+    if (found_hit != hits->end() && found_hit->detId() == id.rawId()) {
+      hit.addNeighbour(eta, phi, depth, found_hit - hits->begin());
+    }
   }
-
-
 };
-
-
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 typedef edmplugin::PluginFactory<PFRecHitNavigatorBase*(const edm::ParameterSet&)> PFRecHitNavigationFactory;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTestBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTestBase.h
@@ -1,7 +1,6 @@
 #ifndef RecoParticleFlow_PFClusterProducer_PFRecHitQTestBase_h
 #define RecoParticleFlow_PFClusterProducer_PFRecHitQTestBase_h
 
-
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -30,23 +29,20 @@
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputerRcd.h"
 
 class PFRecHitQTestBase {
- public:
+public:
   PFRecHitQTestBase() = default;
   PFRecHitQTestBase(const edm::ParameterSet& iConfig) {}
   virtual ~PFRecHitQTestBase() = default;
 
-  virtual void beginEvent(const edm::Event&,const edm::EventSetup&)=0;
+  virtual void beginEvent(const edm::Event&, const edm::EventSetup&) = 0;
 
-
-  virtual bool test( reco::PFRecHit& ,const EcalRecHit&,bool&,bool)=0;
-  virtual bool test( reco::PFRecHit& ,const HBHERecHit&,bool&)=0;
-  virtual bool test( reco::PFRecHit& ,const HFRecHit&,bool&)=0;
-  virtual bool test( reco::PFRecHit& ,const HORecHit&,bool&)=0;
-  virtual bool test( reco::PFRecHit& ,const CaloTower&,bool&)=0;
-  virtual bool test( reco::PFRecHit& ,const HGCRecHit&,bool&)=0;
-
+  virtual bool test(reco::PFRecHit&, const EcalRecHit&, bool&, bool) = 0;
+  virtual bool test(reco::PFRecHit&, const HBHERecHit&, bool&) = 0;
+  virtual bool test(reco::PFRecHit&, const HFRecHit&, bool&) = 0;
+  virtual bool test(reco::PFRecHit&, const HORecHit&, bool&) = 0;
+  virtual bool test(reco::PFRecHit&, const CaloTower&, bool&) = 0;
+  virtual bool test(reco::PFRecHit&, const HGCRecHit&, bool&) = 0;
 };
- 
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 typedef edmplugin::PluginFactory<PFRecHitQTestBase*(const edm::ParameterSet&)> PFRecHitQTestFactory;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -15,228 +15,178 @@
 //
 class PFRecHitQTestThreshold : public PFRecHitQTestBase {
 public:
-  PFRecHitQTestThreshold() {
+  PFRecHitQTestThreshold() {}
+
+  PFRecHitQTestThreshold(const edm::ParameterSet& iConfig)
+      : PFRecHitQTestBase(iConfig), threshold_(iConfig.getParameter<double>("threshold")) {}
+
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
+
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override {
+    return fullReadOut or pass(hit);
   }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override { return pass(hit); }
 
-  PFRecHitQTestThreshold(const edm::ParameterSet& iConfig):
-    PFRecHitQTestBase(iConfig),
-    threshold_(iConfig.getParameter<double>("threshold"))
-    {
-    }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override { return pass(hit); }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override { return pass(hit); }
 
-    void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-    }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override { return pass(hit); }
 
-    bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
-      return fullReadOut or pass(hit);
-    }
-    bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
-      return pass(hit);
-    }
-
-    bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
-      return pass(hit);
-    }
-    bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override{
-      return pass(hit);
-    }
-
-    bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
-      return pass(hit);
-    }
-
-    bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
-      return pass(hit);
-    }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override { return pass(hit); }
 
 protected:
   double threshold_;
 
-  bool pass(const reco::PFRecHit& hit){
-    if (hit.energy()>threshold_) return true;
+  bool pass(const reco::PFRecHit& hit) {
+    if (hit.energy() > threshold_)
+      return true;
 
     return false;
   }
 };
-
-
 
 //
 //  Quality test that checks threshold read from the DB
 //
 class PFRecHitQTestDBThreshold : public PFRecHitQTestBase {
 public:
-    PFRecHitQTestDBThreshold():eventSetup_(nullptr){
-    }
+  PFRecHitQTestDBThreshold() : eventSetup_(nullptr) {}
 
-    PFRecHitQTestDBThreshold(const edm::ParameterSet& iConfig):
-     PFRecHitQTestBase(iConfig),
-     applySelectionsToAllCrystals_(iConfig.getParameter<bool>("applySelectionsToAllCrystals")),    
-     eventSetup_(nullptr){
-    }
+  PFRecHitQTestDBThreshold(const edm::ParameterSet& iConfig)
+      : PFRecHitQTestBase(iConfig),
+        applySelectionsToAllCrystals_(iConfig.getParameter<bool>("applySelectionsToAllCrystals")),
+        eventSetup_(nullptr) {}
 
-    void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-        eventSetup_=&iSetup;
-    }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override { eventSetup_ = &iSetup; }
 
-    bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
-      if (applySelectionsToAllCrystals_) return pass(hit);  
-      return fullReadOut or pass(hit);
-    }
-    bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override {
+    if (applySelectionsToAllCrystals_)
       return pass(hit);
-    }
+    return fullReadOut or pass(hit);
+  }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override { return pass(hit); }
 
-    bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
-      return pass(hit);
-    }
-    bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override{
-      return pass(hit);
-    }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override { return pass(hit); }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override { return pass(hit); }
 
-    bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
-      return pass(hit);
-    }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override { return pass(hit); }
 
-    bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
-      return pass(hit);
-    }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override { return pass(hit); }
 
 protected:
-    
   bool applySelectionsToAllCrystals_;
-  const edm::EventSetup * eventSetup_;
+  const edm::EventSetup* eventSetup_;
 
-  
-  bool pass(const reco::PFRecHit& hit){
-
+  bool pass(const reco::PFRecHit& hit) {
     edm::ESHandle<EcalPFRecHitThresholds> ths;
     (*eventSetup_).get<EcalPFRecHitThresholdsRcd>().get(ths);
 
     float threshold = (*ths)[hit.detId()];
-    if (hit.energy()>threshold) return true;
+    if (hit.energy() > threshold)
+      return true;
 
     return false;
   }
 };
-
-
-
 
 //
 //  Quality test that checks kHCAL Severity
 //
 class PFRecHitQTestHCALChannel : public PFRecHitQTestBase {
 public:
-  PFRecHitQTestHCALChannel() {
-  }
+  PFRecHitQTestHCALChannel() {}
 
-  PFRecHitQTestHCALChannel(const edm::ParameterSet& iConfig):
-    PFRecHitQTestBase(iConfig)
-    {
-      thresholds_ = iConfig.getParameter<std::vector<int> >("maxSeverities");
-      cleanThresholds_ = iConfig.getParameter<std::vector<double> >("cleaningThresholds");
-      std::vector<std::string> flags = iConfig.getParameter<std::vector<std::string> >("flags");
-      for (auto & flag : flags) {
-        if (flag =="Standard") {
-          flags_.push_back(-1);
-          depths_.push_back(-1);
-        }
-        else if (flag =="HFInTime") {
-          flags_.push_back(1<<HcalCaloFlagLabels::HFInTimeWindow);
-          depths_.push_back(-1);
-        }
-        else if (flag =="HFDigi") {
-          flags_.push_back(1<<HcalCaloFlagLabels::HFDigiTime);
-          depths_.push_back(-1);
-        }
-        else if (flag =="HFLong") {
-          flags_.push_back(1<<HcalCaloFlagLabels::HFLongShort);
-          depths_.push_back(1);
-        }
-        else if (flag =="HFShort") {
-          flags_.push_back(1<<HcalCaloFlagLabels::HFLongShort);
-          depths_.push_back(2);
-        }
-        else {
-          flags_.push_back(-1);
-          depths_.push_back(-1);
-        }
+  PFRecHitQTestHCALChannel(const edm::ParameterSet& iConfig) : PFRecHitQTestBase(iConfig) {
+    thresholds_ = iConfig.getParameter<std::vector<int> >("maxSeverities");
+    cleanThresholds_ = iConfig.getParameter<std::vector<double> >("cleaningThresholds");
+    std::vector<std::string> flags = iConfig.getParameter<std::vector<std::string> >("flags");
+    for (auto& flag : flags) {
+      if (flag == "Standard") {
+        flags_.push_back(-1);
+        depths_.push_back(-1);
+      } else if (flag == "HFInTime") {
+        flags_.push_back(1 << HcalCaloFlagLabels::HFInTimeWindow);
+        depths_.push_back(-1);
+      } else if (flag == "HFDigi") {
+        flags_.push_back(1 << HcalCaloFlagLabels::HFDigiTime);
+        depths_.push_back(-1);
+      } else if (flag == "HFLong") {
+        flags_.push_back(1 << HcalCaloFlagLabels::HFLongShort);
+        depths_.push_back(1);
+      } else if (flag == "HFShort") {
+        flags_.push_back(1 << HcalCaloFlagLabels::HFLongShort);
+        depths_.push_back(2);
+      } else {
+        flags_.push_back(-1);
+        depths_.push_back(-1);
       }
     }
+  }
 
-    void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-      edm::ESHandle<HcalTopology> topo;
-      iSetup.get<HcalRecNumberingRecord>().get(topo);
-      theHcalTopology_ = topo.product();
-      edm::ESHandle<HcalChannelQuality> hcalChStatus;
-      iSetup.get<HcalChannelQualityRcd>().get( "withTopo", hcalChStatus );
-      theHcalChStatus_ = hcalChStatus.product();
-      edm::ESHandle<HcalSeverityLevelComputer> hcalSevLvlComputerHndl;
-      iSetup.get<HcalSeverityLevelComputerRcd>().get(hcalSevLvlComputerHndl);
-      hcalSevLvlComputer_  =  hcalSevLvlComputerHndl.product();
-    }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
+    edm::ESHandle<HcalTopology> topo;
+    iSetup.get<HcalRecNumberingRecord>().get(topo);
+    theHcalTopology_ = topo.product();
+    edm::ESHandle<HcalChannelQuality> hcalChStatus;
+    iSetup.get<HcalChannelQualityRcd>().get("withTopo", hcalChStatus);
+    theHcalChStatus_ = hcalChStatus.product();
+    edm::ESHandle<HcalSeverityLevelComputer> hcalSevLvlComputerHndl;
+    iSetup.get<HcalSeverityLevelComputerRcd>().get(hcalSevLvlComputerHndl);
+    hcalSevLvlComputer_ = hcalSevLvlComputerHndl.product();
+  }
 
-    bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
-      return true;
-    }
-    bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
-      return test(rh.detid(), rh.energy(), rh.flags(), clean);
-    }
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override { return true; }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override {
+    return test(rh.detid(), rh.energy(), rh.flags(), clean);
+  }
 
-    bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
-      return test(rh.detid(), rh.energy(), rh.flags(), clean);
-    }
-    bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override{
-      return test(rh.detid(), rh.energy(), rh.flags(), clean);
-    }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override {
+    return test(rh.detid(), rh.energy(), rh.flags(), clean);
+  }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override {
+    return test(rh.detid(), rh.energy(), rh.flags(), clean);
+  }
 
-    bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
-      return true;
-    }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override { return true; }
 
-    bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
-      return true;
-    }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override { return true; }
 
 protected:
-    std::vector<int> thresholds_;
-    std::vector<double> cleanThresholds_;
-    std::vector<int> flags_;
-    std::vector<int> depths_;
-    const HcalTopology* theHcalTopology_;
-    const HcalChannelQuality* theHcalChStatus_;
-    const HcalSeverityLevelComputer* hcalSevLvlComputer_;
+  std::vector<int> thresholds_;
+  std::vector<double> cleanThresholds_;
+  std::vector<int> flags_;
+  std::vector<int> depths_;
+  const HcalTopology* theHcalTopology_;
+  const HcalChannelQuality* theHcalChStatus_;
+  const HcalSeverityLevelComputer* hcalSevLvlComputer_;
 
-    bool test(unsigned aDETID, double energy, int flags, bool& clean){
+  bool test(unsigned aDETID, double energy, int flags, bool& clean) {
     HcalDetId detid = (HcalDetId)aDETID;
-    if (theHcalTopology_->getMergePositionFlag() and detid.subdet() == HcalEndcap){
+    if (theHcalTopology_->getMergePositionFlag() and detid.subdet() == HcalEndcap) {
       detid = theHcalTopology_->idFront(detid);
     }
 
     const HcalChannelStatus* theStatus = theHcalChStatus_->getValues(detid);
     unsigned theStatusValue = theStatus->getValue();
     // Now get severity of problems for the given detID, based on the rechit flag word and the channel quality status value
-    for (unsigned int i=0;i<thresholds_.size();++i) {
-      int hitSeverity =0;
+    for (unsigned int i = 0; i < thresholds_.size(); ++i) {
+      int hitSeverity = 0;
       if (energy < cleanThresholds_[i])
         continue;
 
-      if(flags_[i]<0) {
-        hitSeverity=hcalSevLvlComputer_->getSeverityLevel(detid, flags, theStatusValue);
-      }
-      else {
-        hitSeverity=hcalSevLvlComputer_->getSeverityLevel(detid, flags & flags_[i], theStatusValue);
+      if (flags_[i] < 0) {
+        hitSeverity = hcalSevLvlComputer_->getSeverityLevel(detid, flags, theStatusValue);
+      } else {
+        hitSeverity = hcalSevLvlComputer_->getSeverityLevel(detid, flags & flags_[i], theStatusValue);
       }
 
-      if (hitSeverity>thresholds_[i] and ((depths_[i]<0 or (depths_[i]==detid.depth())))) {
-        clean=true;
+      if (hitSeverity > thresholds_[i] and ((depths_[i] < 0 or (depths_[i] == detid.depth())))) {
+        clean = true;
         return false;
       }
     }
     return true;
   }
-
 };
 
 //
@@ -244,200 +194,152 @@ protected:
 //
 class PFRecHitQTestHCALTimeVsDepth : public PFRecHitQTestBase {
 public:
-  PFRecHitQTestHCALTimeVsDepth() {
+  PFRecHitQTestHCALTimeVsDepth() {}
+
+  PFRecHitQTestHCALTimeVsDepth(const edm::ParameterSet& iConfig) : PFRecHitQTestBase(iConfig) {
+    std::vector<edm::ParameterSet> psets = iConfig.getParameter<std::vector<edm::ParameterSet> >("cuts");
+    for (auto& pset : psets) {
+      depths_.push_back(pset.getParameter<int>("depth"));
+      minTimes_.push_back(pset.getParameter<double>("minTime"));
+      maxTimes_.push_back(pset.getParameter<double>("maxTime"));
+      thresholds_.push_back(pset.getParameter<double>("threshold"));
+    }
   }
 
-  PFRecHitQTestHCALTimeVsDepth(const edm::ParameterSet& iConfig):
-    PFRecHitQTestBase(iConfig)
-    {
-      std::vector<edm::ParameterSet> psets = iConfig.getParameter<std::vector<edm::ParameterSet> >("cuts");
-      for (auto & pset : psets) {
-        depths_.push_back(pset.getParameter<int>("depth"));
-        minTimes_.push_back(pset.getParameter<double>("minTime"));
-        maxTimes_.push_back(pset.getParameter<double>("maxTime"));
-        thresholds_.push_back(pset.getParameter<double>("threshold"));
-      }
-    }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
 
-    void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-    }
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override { return true; }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override {
+    return test(rh.detid(), rh.energy(), rh.time(), clean);
+  }
 
-    bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
-      return true;
-    }
-    bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
-      return test(rh.detid(), rh.energy(), rh.time(), clean);
-    }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override {
+    return test(rh.detid(), rh.energy(), rh.time(), clean);
+  }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override {
+    return test(rh.detid(), rh.energy(), rh.time(), clean);
+  }
 
-    bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
-      return test(rh.detid(), rh.energy(), rh.time(), clean);
-    }
-    bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override {
-      return test(rh.detid(), rh.energy(), rh.time(), clean);
-    }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override { return true; }
 
-    bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
-      return true;
-    }
-
-    bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
-      return true;
-    }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override { return true; }
 
 protected:
-    std::vector<int> depths_;
-    std::vector<double> minTimes_;
-    std::vector<double> maxTimes_;
-    std::vector<double> thresholds_;
+  std::vector<int> depths_;
+  std::vector<double> minTimes_;
+  std::vector<double> maxTimes_;
+  std::vector<double> thresholds_;
 
-    bool test(unsigned aDETID, double energy, double time, bool& clean){
-      HcalDetId detid(aDETID);
-      for (unsigned int i=0;i<depths_.size();++i) {
-        if (detid.depth() == depths_[i]) {
-          if ((time <minTimes_[i] or time >maxTimes_[i] ) and  energy>thresholds_[i])
-            {
-              clean=true;
-              return false;
-            }
-          break;
+  bool test(unsigned aDETID, double energy, double time, bool& clean) {
+    HcalDetId detid(aDETID);
+    for (unsigned int i = 0; i < depths_.size(); ++i) {
+      if (detid.depth() == depths_[i]) {
+        if ((time < minTimes_[i] or time > maxTimes_[i]) and energy > thresholds_[i]) {
+          clean = true;
+          return false;
         }
+        break;
       }
-      return true;
     }
+    return true;
+  }
 };
-
-
-
 
 //
 //  Quality test that applies threshold  as a function of depth
 //
 class PFRecHitQTestHCALThresholdVsDepth : public PFRecHitQTestBase {
 public:
-  PFRecHitQTestHCALThresholdVsDepth() {
+  PFRecHitQTestHCALThresholdVsDepth() {}
+
+  PFRecHitQTestHCALThresholdVsDepth(const edm::ParameterSet& iConfig) : PFRecHitQTestBase(iConfig) {
+    std::vector<edm::ParameterSet> psets = iConfig.getParameter<std::vector<edm::ParameterSet> >("cuts");
+    for (auto& pset : psets) {
+      depths_ = pset.getParameter<std::vector<int> >("depth");
+      thresholds_ = pset.getParameter<std::vector<double> >("threshold");
+      detector_ = pset.getParameter<int>("detectorEnum");
+      if (thresholds_.size() != depths_.size()) {
+        throw cms::Exception("InvalidPFRecHitThreshold") << "PFRecHitThreshold mismatch with the numbers of depths";
+      }
+    }
   }
 
-  PFRecHitQTestHCALThresholdVsDepth(const edm::ParameterSet& iConfig):
-    PFRecHitQTestBase(iConfig)
-    {
-      std::vector<edm::ParameterSet> psets = iConfig.getParameter<std::vector<edm::ParameterSet> >("cuts");
-      for (auto & pset : psets) {
-        depths_=pset.getParameter<std::vector<int> >("depth");
-        thresholds_=pset.getParameter<std::vector<double> >("threshold");
-	detector_=pset.getParameter<int>("detectorEnum");
-        if(thresholds_.size()!=depths_.size()) {
-          throw cms::Exception("InvalidPFRecHitThreshold")
-            << "PFRecHitThreshold mismatch with the numbers of depths";
-        }
-      }
-    }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
 
-    void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-    }
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override { return true; }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override {
+    return test(rh.detid(), rh.energy(), rh.time(), clean);
+  }
 
-    bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
-      return true;
-    }
-    bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
-      return test(rh.detid(), rh.energy(), rh.time(), clean);
-    }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override {
+    return test(rh.detid(), rh.energy(), rh.time(), clean);
+  }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override {
+    return test(rh.detid(), rh.energy(), rh.time(), clean);
+  }
 
-    bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
-      return test(rh.detid(), rh.energy(), rh.time(), clean);
-    }
-    bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override{
-      return test(rh.detid(), rh.energy(), rh.time(), clean);
-    }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override { return true; }
 
-    bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
-      return true;
-    }
-
-    bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
-      return true;
-    }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override { return true; }
 
 protected:
-    std::vector<int> depths_;
-    std::vector<double> thresholds_;
-    int detector_;
+  std::vector<int> depths_;
+  std::vector<double> thresholds_;
+  int detector_;
 
-    bool test(unsigned aDETID, double energy, double time, bool& clean){
-      HcalDetId detid(aDETID);
+  bool test(unsigned aDETID, double energy, double time, bool& clean) {
+    HcalDetId detid(aDETID);
 
-      for (unsigned int i=0;i<thresholds_.size();++i) {
-	if (detid.depth() == depths_[i] && detid.subdet() == detector_ ) {
-          if (  energy<thresholds_[i])
-            {
-              clean=false;
-              return false;
-            }
-          break;
+    for (unsigned int i = 0; i < thresholds_.size(); ++i) {
+      if (detid.depth() == depths_[i] && detid.subdet() == detector_) {
+        if (energy < thresholds_[i]) {
+          clean = false;
+          return false;
         }
+        break;
       }
-      return true;
     }
+    return true;
+  }
 };
-
-
-
-
 
 //
 //  Quality test that checks HO threshold applying different threshold in rings
 //
 class PFRecHitQTestHOThreshold : public PFRecHitQTestBase {
 public:
-  PFRecHitQTestHOThreshold():
-    threshold0_(0.),
-    threshold12_(0.)
-  {
-  }
+  PFRecHitQTestHOThreshold() : threshold0_(0.), threshold12_(0.) {}
 
-  PFRecHitQTestHOThreshold(const edm::ParameterSet& iConfig):
-    PFRecHitQTestBase(iConfig),
-    threshold0_(iConfig.getParameter<double>("threshold_ring0")),
-    threshold12_(iConfig.getParameter<double>("threshold_ring12"))
-  {
-  }
+  PFRecHitQTestHOThreshold(const edm::ParameterSet& iConfig)
+      : PFRecHitQTestBase(iConfig),
+        threshold0_(iConfig.getParameter<double>("threshold_ring0")),
+        threshold12_(iConfig.getParameter<double>("threshold_ring12")) {}
 
-  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-  }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
 
-  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override{
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override {
     HcalDetId detid(rh.detid());
-    if (abs(detid.ieta())<=4 and hit.energy()>threshold0_)
+    if (abs(detid.ieta()) <= 4 and hit.energy() > threshold0_)
       return true;
-    if (abs(detid.ieta())>4 and hit.energy()>threshold12_)
+    if (abs(detid.ieta()) > 4 and hit.energy() > threshold12_)
       return true;
 
     return false;
   }
 
-  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override { return true; }
 
 protected:
   const double threshold0_;
   const double threshold12_;
-
 };
 
 //
@@ -449,52 +351,43 @@ protected:
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 class PFRecHitQTestECALMultiThreshold : public PFRecHitQTestBase {
 public:
-  PFRecHitQTestECALMultiThreshold() {
-  }
+  PFRecHitQTestECALMultiThreshold() {}
 
-  PFRecHitQTestECALMultiThreshold(const edm::ParameterSet& iConfig):
-    PFRecHitQTestBase(iConfig),
-    thresholds_(iConfig.getParameter<std::vector<double> >("thresholds")),
-    applySelectionsToAllCrystals_(iConfig.getParameter<bool>("applySelectionsToAllCrystals"))
-    {
+  PFRecHitQTestECALMultiThreshold(const edm::ParameterSet& iConfig)
+      : PFRecHitQTestBase(iConfig),
+        thresholds_(iConfig.getParameter<std::vector<double> >("thresholds")),
+        applySelectionsToAllCrystals_(iConfig.getParameter<bool>("applySelectionsToAllCrystals")) {
     if (thresholds_.size() != EcalRingCalibrationTools::N_RING_TOTAL)
       throw edm::Exception(edm::errors::Configuration, "ValueError")
-        << "thresholds is expected to have " << EcalRingCalibrationTools::N_RING_TOTAL << " elements but has " << thresholds_.size();   
+          << "thresholds is expected to have " << EcalRingCalibrationTools::N_RING_TOTAL << " elements but has "
+          << thresholds_.size();
   }
 
   void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> pG;
     iSetup.get<CaloGeometryRecord>().get(pG);
     CaloSubdetectorGeometry const* endcapGeometry = pG->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-    endcapGeometrySet_=false;
+    endcapGeometrySet_ = false;
     if (endcapGeometry) {
       EcalRingCalibrationTools::setCaloGeometry(&(*pG));
-      endcapGeometrySet_=true;
+      endcapGeometrySet_ = true;
     }
   }
 
-  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
-    if (applySelectionsToAllCrystals_) return pass(hit);
-    else return fullReadOut or pass(hit);
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override {
+    if (applySelectionsToAllCrystals_)
+      return pass(hit);
+    else
+      return fullReadOut or pass(hit);
   }
-  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
-    return true;
-  }
-  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override { return true; }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override { return true; }
 
 protected:
   const std::vector<double> thresholds_;
@@ -502,18 +395,16 @@ protected:
 
   // apply selections to all crystals
   bool applySelectionsToAllCrystals_;
-  
-  
-  bool pass(const reco::PFRecHit& hit){
 
+  bool pass(const reco::PFRecHit& hit) {
     DetId detId(hit.detId());
 
     // this is to skip endcap ZS for Phase2 until there is a defined geometry
     // apply the loosest ZS threshold, for the first eta-ring in EB
     if (not endcapGeometrySet_) {
-
       // there is only ECAL EB in Phase 2
-      if(detId.subdetId() != EcalBarrel) return true;
+      if (detId.subdetId() != EcalBarrel)
+        return true;
 
       //   0-169: EB  eta-rings
       // 170-208: EE- eta rings
@@ -523,83 +414,62 @@ protected:
     }
 
     int iring = EcalRingCalibrationTools::getRingIndex(detId);
-    if (hit.energy() > thresholds_[iring]) return true;
+    if (hit.energy() > thresholds_[iring])
+      return true;
 
     return false;
   }
 };
 
-
 //
 //  Quality test that checks ecal quality cuts
 //
 class PFRecHitQTestECAL : public PFRecHitQTestBase {
-  public:
-    PFRecHitQTestECAL() {
-    }
+public:
+  PFRecHitQTestECAL() {}
 
-    PFRecHitQTestECAL(const edm::ParameterSet& iConfig):
-      PFRecHitQTestBase(iConfig),
-      thresholdCleaning_(iConfig.getParameter<double>("cleaningThreshold")),
-      timingCleaning_(iConfig.getParameter<bool>("timingCleaning")),
-      topologicalCleaning_(iConfig.getParameter<bool>("topologicalCleaning")),
-      skipTTRecoveredHits_(iConfig.getParameter<bool>("skipTTRecoveredHits"))
-  {
-  }
+  PFRecHitQTestECAL(const edm::ParameterSet& iConfig)
+      : PFRecHitQTestBase(iConfig),
+        thresholdCleaning_(iConfig.getParameter<double>("cleaningThreshold")),
+        timingCleaning_(iConfig.getParameter<bool>("timingCleaning")),
+        topologicalCleaning_(iConfig.getParameter<bool>("topologicalCleaning")),
+        skipTTRecoveredHits_(iConfig.getParameter<bool>("skipTTRecoveredHits")) {}
 
-    void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-    }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
 
-  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
-    if (skipTTRecoveredHits_ and rh.checkFlag(EcalRecHit::kTowerRecovered))
-    {
-      clean=true;
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override {
+    if (skipTTRecoveredHits_ and rh.checkFlag(EcalRecHit::kTowerRecovered)) {
+      clean = true;
       return false;
     }
-    if (timingCleaning_ and rh.energy() > thresholdCleaning_ and
-        rh.checkFlag(EcalRecHit::kOutOfTime))
-    {
-      clean=true;
+    if (timingCleaning_ and rh.energy() > thresholdCleaning_ and rh.checkFlag(EcalRecHit::kOutOfTime)) {
+      clean = true;
       return false;
     }
 
-    if (topologicalCleaning_ and (
-          rh.checkFlag(EcalRecHit::kWeird) or
-          rh.checkFlag(EcalRecHit::kDiWeird)))
-    {
-      clean=true;
+    if (topologicalCleaning_ and (rh.checkFlag(EcalRecHit::kWeird) or rh.checkFlag(EcalRecHit::kDiWeird))) {
+      clean = true;
       return false;
     }
 
     return true;
   }
 
-  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override { return true; }
 
 protected:
   double thresholdCleaning_;
   bool timingCleaning_;
   bool topologicalCleaning_;
   bool skipTTRecoveredHits_;
-
 };
 
 //
@@ -607,70 +477,46 @@ protected:
 //
 class PFRecHitQTestES : public PFRecHitQTestBase {
 public:
-  PFRecHitQTestES():
-    thresholdCleaning_(0.),
-    topologicalCleaning_(false)
-  {
-  }
+  PFRecHitQTestES() : thresholdCleaning_(0.), topologicalCleaning_(false) {}
 
-  PFRecHitQTestES(const edm::ParameterSet& iConfig):
-    PFRecHitQTestBase(iConfig),
-    thresholdCleaning_(iConfig.getParameter<double>("cleaningThreshold")),
-    topologicalCleaning_(iConfig.getParameter<bool>("topologicalCleaning"))
-  {
-  }
+  PFRecHitQTestES(const edm::ParameterSet& iConfig)
+      : PFRecHitQTestBase(iConfig),
+        thresholdCleaning_(iConfig.getParameter<double>("cleaningThreshold")),
+        topologicalCleaning_(iConfig.getParameter<bool>("topologicalCleaning")) {}
 
-  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-  }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
 
   bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override {
-
-    if ( rh.energy() < thresholdCleaning_ ) {
-      clean=false;
+    if (rh.energy() < thresholdCleaning_) {
+      clean = false;
       return false;
     }
 
-    if ( topologicalCleaning_ and
-         ( rh.checkFlag(EcalRecHit::kESDead) or
-           rh.checkFlag(EcalRecHit::kESTS13Sigmas) or
-           rh.checkFlag(EcalRecHit::kESBadRatioFor12) or
-           rh.checkFlag(EcalRecHit::kESBadRatioFor23Upper) or
-           rh.checkFlag(EcalRecHit::kESBadRatioFor23Lower) or
-           rh.checkFlag(EcalRecHit::kESTS1Largest) or
-           rh.checkFlag(EcalRecHit::kESTS3Largest) or
-           rh.checkFlag(EcalRecHit::kESTS3Negative)
-           )) {
-      clean=false;
+    if (topologicalCleaning_ and
+        (rh.checkFlag(EcalRecHit::kESDead) or rh.checkFlag(EcalRecHit::kESTS13Sigmas) or
+         rh.checkFlag(EcalRecHit::kESBadRatioFor12) or rh.checkFlag(EcalRecHit::kESBadRatioFor23Upper) or
+         rh.checkFlag(EcalRecHit::kESBadRatioFor23Lower) or rh.checkFlag(EcalRecHit::kESTS1Largest) or
+         rh.checkFlag(EcalRecHit::kESTS3Largest) or rh.checkFlag(EcalRecHit::kESTS3Negative))) {
+      clean = false;
       return false;
     }
 
     return true;
   }
 
-  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override { return true; }
 
 protected:
   const double thresholdCleaning_;
   const bool topologicalCleaning_;
-
 };
 
 //
@@ -678,47 +524,32 @@ protected:
 //
 class PFRecHitQTestHCALCalib29 : public PFRecHitQTestBase {
 public:
-  PFRecHitQTestHCALCalib29():
-    calibFactor_(0.)
-  {
-  }
+  PFRecHitQTestHCALCalib29() : calibFactor_(0.) {}
 
-  PFRecHitQTestHCALCalib29(const edm::ParameterSet& iConfig):
-    PFRecHitQTestBase(iConfig),
-    calibFactor_(iConfig.getParameter<double>("calibFactor"))
-  {
-  }
+  PFRecHitQTestHCALCalib29(const edm::ParameterSet& iConfig)
+      : PFRecHitQTestBase(iConfig), calibFactor_(iConfig.getParameter<double>("calibFactor")) {}
 
-  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-  }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
 
-  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override{
-    return true;
-  }
-  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override{
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override { return true; }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override {
     HcalDetId detId(hit.detId());
-    if (abs(detId.ieta())==29)
-      hit.setEnergy(hit.energy()*calibFactor_);
+    if (abs(detId.ieta()) == 29)
+      hit.setEnergy(hit.energy() * calibFactor_);
     return true;
   }
 
-  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override{
-    return true;
-  }
-  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override { return true; }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override { return true; }
 
-  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override{
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override {
     CaloTowerDetId detId(hit.detId());
-    if (detId.ietaAbs()==29)
-      hit.setEnergy(hit.energy()*calibFactor_);
+    if (detId.ietaAbs() == 29)
+      hit.setEnergy(hit.energy() * calibFactor_);
     return true;
   }
 
-  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override{
-    return true;
-  }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override { return true; }
 
 protected:
   const float calibFactor_;
@@ -726,58 +557,43 @@ protected:
 
 class PFRecHitQTestThresholdInMIPs : public PFRecHitQTestBase {
 public:
-  PFRecHitQTestThresholdInMIPs():
-    recHitEnergy_keV_(false),
-    threshold_(0.),
-    mip_(0.),
-    recHitEnergyMultiplier_(0.)
-  {
-  }
+  PFRecHitQTestThresholdInMIPs() : recHitEnergy_keV_(false), threshold_(0.), mip_(0.), recHitEnergyMultiplier_(0.) {}
 
-  PFRecHitQTestThresholdInMIPs(const edm::ParameterSet& iConfig):
-    PFRecHitQTestBase(iConfig),
-    recHitEnergy_keV_(iConfig.getParameter<bool>("recHitEnergyIs_keV")),
-    threshold_(iConfig.getParameter<double>("thresholdInMIPs")),
-    mip_(iConfig.getParameter<double>("mipValueInkeV")),
-    recHitEnergyMultiplier_(iConfig.getParameter<double>("recHitEnergyMultiplier"))
-  {
-  }
+  PFRecHitQTestThresholdInMIPs(const edm::ParameterSet& iConfig)
+      : PFRecHitQTestBase(iConfig),
+        recHitEnergy_keV_(iConfig.getParameter<bool>("recHitEnergyIs_keV")),
+        threshold_(iConfig.getParameter<double>("thresholdInMIPs")),
+        mip_(iConfig.getParameter<double>("mipValueInkeV")),
+        recHitEnergyMultiplier_(iConfig.getParameter<double>("recHitEnergyMultiplier")) {}
 
-  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-  }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
 
   bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override {
-    throw cms::Exception("WrongDetector")
-      << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
     return false;
   }
   bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override {
-    throw cms::Exception("WrongDetector")
-      << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
     return false;
   }
 
   bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override {
-    throw cms::Exception("WrongDetector")
-      << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
     return false;
   }
   bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override {
-    throw cms::Exception("WrongDetector")
-      << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
     return false;
   }
 
   bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override {
-    throw cms::Exception("WrongDetector")
-      << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
     return false;
   }
 
   bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override {
-    const double newE = ( recHitEnergy_keV_ ?
-        1.0e-6*rh.energy()*recHitEnergyMultiplier_ :
-        rh.energy()*recHitEnergyMultiplier_ );
+    const double newE =
+        (recHitEnergy_keV_ ? 1.0e-6 * rh.energy() * recHitEnergyMultiplier_ : rh.energy() * recHitEnergyMultiplier_);
     hit.setEnergy(newE);
     return pass(hit);
   }
@@ -787,145 +603,113 @@ protected:
   const double threshold_, mip_, recHitEnergyMultiplier_;
 
   bool pass(const reco::PFRecHit& hit) {
-    const double hitValueInMIPs = 1e6*hit.energy()/mip_;
+    const double hitValueInMIPs = 1e6 * hit.energy() / mip_;
     return hitValueInMIPs > threshold_;
   }
 };
 
 #include "Geometry/HGCalGeometry/interface/HGCalGeometry.h"
 class PFRecHitQTestThresholdInThicknessNormalizedMIPs : public PFRecHitQTestBase {
-  public:
-    PFRecHitQTestThresholdInThicknessNormalizedMIPs() :
-      geometryInstance_(""),
-      recHitEnergy_keV_(0.),
-      threshold_(0.),
-      mip_(0.),
-      recHitEnergyMultiplier_(0.) {
-      }
+public:
+  PFRecHitQTestThresholdInThicknessNormalizedMIPs()
+      : geometryInstance_(""), recHitEnergy_keV_(0.), threshold_(0.), mip_(0.), recHitEnergyMultiplier_(0.) {}
 
-    PFRecHitQTestThresholdInThicknessNormalizedMIPs(const edm::ParameterSet& iConfig) :
-      PFRecHitQTestBase(iConfig),
-      geometryInstance_(iConfig.getParameter<std::string>("geometryInstance")),
-      recHitEnergy_keV_(iConfig.getParameter<bool>("recHitEnergyIs_keV")),
-      threshold_(iConfig.getParameter<double>("thresholdInMIPs")),
-      mip_(iConfig.getParameter<double>("mipValueInkeV")),
-      recHitEnergyMultiplier_(iConfig.getParameter<double>("recHitEnergyMultiplier")) {
-      }
+  PFRecHitQTestThresholdInThicknessNormalizedMIPs(const edm::ParameterSet& iConfig)
+      : PFRecHitQTestBase(iConfig),
+        geometryInstance_(iConfig.getParameter<std::string>("geometryInstance")),
+        recHitEnergy_keV_(iConfig.getParameter<bool>("recHitEnergyIs_keV")),
+        threshold_(iConfig.getParameter<double>("thresholdInMIPs")),
+        mip_(iConfig.getParameter<double>("mipValueInkeV")),
+        recHitEnergyMultiplier_(iConfig.getParameter<double>("recHitEnergyMultiplier")) {}
 
-    void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
-      edm::ESHandle<HGCalGeometry> geoHandle;
-      iSetup.get<IdealGeometryRecord>().get(geometryInstance_, geoHandle);
-      ddd_ = &(geoHandle->topology().dddConstants());
-    }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {
+    edm::ESHandle<HGCalGeometry> geoHandle;
+    iSetup.get<IdealGeometryRecord>().get(geometryInstance_, geoHandle);
+    ddd_ = &(geoHandle->topology().dddConstants());
+  }
 
-    bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override {
-      throw cms::Exception("WrongDetector")
-        << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
-      return false;
-    }
-    bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override {
-      throw cms::Exception("WrongDetector")
-        << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
-      return false;
-    }
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override {
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
+    return false;
+  }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override {
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
+    return false;
+  }
 
-    bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override {
-      throw cms::Exception("WrongDetector")
-        << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
-      return false;
-    }
-    bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override {
-      throw cms::Exception("WrongDetector")
-        << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
-      return false;
-    }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override {
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
+    return false;
+  }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override {
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
+    return false;
+  }
 
-    bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override {
-      throw cms::Exception("WrongDetector")
-        << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
-      return false;
-    }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override {
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestThresholdInMIPs only works for HGCAL!";
+    return false;
+  }
 
-    bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override {
-      const double newE = ( recHitEnergy_keV_ ?
-          1.0e-6*rh.energy()*recHitEnergyMultiplier_ :
-          rh.energy()*recHitEnergyMultiplier_ );
-      const int wafer = HGCalDetId(rh.detid()).wafer();
-      const float mult  = (float) ddd_->waferTypeL(wafer); // 1 for 100um, 2 for 200um, 3 for 300um
-      hit.setEnergy(newE);
-      return pass(hit, mult);
-    }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override {
+    const double newE =
+        (recHitEnergy_keV_ ? 1.0e-6 * rh.energy() * recHitEnergyMultiplier_ : rh.energy() * recHitEnergyMultiplier_);
+    const int wafer = HGCalDetId(rh.detid()).wafer();
+    const float mult = (float)ddd_->waferTypeL(wafer);  // 1 for 100um, 2 for 200um, 3 for 300um
+    hit.setEnergy(newE);
+    return pass(hit, mult);
+  }
 
-  protected:
-    const std::string geometryInstance_;
-    const bool recHitEnergy_keV_;
-    const double threshold_, mip_, recHitEnergyMultiplier_;
-    const HGCalDDDConstants*  ddd_;
+protected:
+  const std::string geometryInstance_;
+  const bool recHitEnergy_keV_;
+  const double threshold_, mip_, recHitEnergyMultiplier_;
+  const HGCalDDDConstants* ddd_;
 
-    bool pass(const reco::PFRecHit& hit, const float mult) {
-      const double hitValueInMIPs = 1e6*hit.energy()/(mult*mip_);
-      return hitValueInMIPs > threshold_;
-    }
+  bool pass(const reco::PFRecHit& hit, const float mult) {
+    const double hitValueInMIPs = 1e6 * hit.energy() / (mult * mip_);
+    return hitValueInMIPs > threshold_;
+  }
 };
 
+class PFRecHitQTestHGCalThresholdSNR : public PFRecHitQTestBase {
+public:
+  PFRecHitQTestHGCalThresholdSNR() : thresholdSNR_(0.) {}
 
-class PFRecHitQTestHGCalThresholdSNR: public PFRecHitQTestBase
-{
-    public:
-        PFRecHitQTestHGCalThresholdSNR() :
-                thresholdSNR_(0.)
-        {
-        }
+  PFRecHitQTestHGCalThresholdSNR(const edm::ParameterSet& iConfig)
+      : PFRecHitQTestBase(iConfig), thresholdSNR_(iConfig.getParameter<double>("thresholdSNR")) {}
 
-        PFRecHitQTestHGCalThresholdSNR(const edm::ParameterSet& iConfig) :
-                PFRecHitQTestBase(iConfig), thresholdSNR_(iConfig.getParameter<double>("thresholdSNR"))
-        {
-        }
+  void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override {}
 
-        void beginEvent(const edm::Event& event, const edm::EventSetup& iSetup) override
-        {
-        }
+  bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override {
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
+    return false;
+  }
+  bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override {
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
+    return false;
+  }
 
-        bool test(reco::PFRecHit& hit, const EcalRecHit& rh, bool& clean, bool fullReadOut) override
-        {
-            throw cms::Exception("WrongDetector")
-                    << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
-            return false;
-        }
-        bool test(reco::PFRecHit& hit, const HBHERecHit& rh, bool& clean) override
-        {
-            throw cms::Exception("WrongDetector")
-                    << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
-            return false;
-        }
+  bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override {
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
+    return false;
+  }
+  bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override {
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
+    return false;
+  }
 
-        bool test(reco::PFRecHit& hit, const HFRecHit& rh, bool& clean) override
-        {
-            throw cms::Exception("WrongDetector")
-                    << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
-            return false;
-        }
-        bool test(reco::PFRecHit& hit, const HORecHit& rh, bool& clean) override
-        {
-            throw cms::Exception("WrongDetector")
-                    << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
-            return false;
-        }
+  bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override {
+    throw cms::Exception("WrongDetector") << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
+    return false;
+  }
 
-        bool test(reco::PFRecHit& hit, const CaloTower& rh, bool& clean) override
-        {
-            throw cms::Exception("WrongDetector")
-                    << "PFRecHitQTestHGCalThresholdSNR only works for HGCAL!";
-            return false;
-        }
+  bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override {
+    return rh.signalOverSigmaNoise() >= thresholdSNR_;
+  }
 
-        bool test(reco::PFRecHit& hit, const HGCRecHit& rh, bool& clean) override
-        {
-            return rh.signalOverSigmaNoise() >= thresholdSNR_;
-        }
-
-    protected:
-        const double thresholdSNR_;
+protected:
+  const double thresholdSNR_;
 };
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/RecHitTopologicalCleanerBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/RecHitTopologicalCleanerBase.h
@@ -9,22 +9,22 @@
 #include <string>
 
 class RecHitTopologicalCleanerBase {
- public:
-  RecHitTopologicalCleanerBase(const edm::ParameterSet& conf) { }
-  RecHitTopologicalCleanerBase(const RecHitTopologicalCleanerBase& ) = delete;
+public:
+  RecHitTopologicalCleanerBase(const edm::ParameterSet& conf) {}
+  RecHitTopologicalCleanerBase(const RecHitTopologicalCleanerBase&) = delete;
   virtual ~RecHitTopologicalCleanerBase() = default;
   RecHitTopologicalCleanerBase& operator=(const RecHitTopologicalCleanerBase&) = delete;
 
-  virtual void clean(const edm::Handle<reco::PFRecHitCollection>&, 
-		     std::vector<bool>&) = 0;
+  virtual void clean(const edm::Handle<reco::PFRecHitCollection>&, std::vector<bool>&) = 0;
 
   const std::string& name() const { return _algoName; }
 
- private:
+private:
   const std::string _algoName;
 };
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory< RecHitTopologicalCleanerBase* (const edm::ParameterSet&) > RecHitTopologicalCleanerFactory;
+typedef edmplugin::PluginFactory<RecHitTopologicalCleanerBase*(const edm::ParameterSet&)>
+    RecHitTopologicalCleanerFactory;
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/SeedFinderBase.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/SeedFinderBase.h
@@ -7,25 +7,23 @@
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
 
 class SeedFinderBase {
- public:
-  SeedFinderBase(const edm::ParameterSet& conf):
-    _algoName(conf.getParameter<std::string>("algoName")) { }
+public:
+  SeedFinderBase(const edm::ParameterSet& conf) : _algoName(conf.getParameter<std::string>("algoName")) {}
   SeedFinderBase(const SeedFinderBase&) = delete;
   virtual ~SeedFinderBase() = default;
   SeedFinderBase& operator=(const SeedFinderBase&) = delete;
 
-  virtual void findSeeds( const edm::Handle<reco::PFRecHitCollection>& input, 
-			  const std::vector<bool>& mask,
-			  std::vector<bool>& seedable ) = 0;
-  
+  virtual void findSeeds(const edm::Handle<reco::PFRecHitCollection>& input,
+                         const std::vector<bool>& mask,
+                         std::vector<bool>& seedable) = 0;
+
   const std::string& name() const { return _algoName; }
 
- private:
+private:
   const std::string _algoName;
-  
 };
 
 #include "FWCore/PluginManager/interface/PluginFactory.h"
-typedef edmplugin::PluginFactory< SeedFinderBase* (const edm::ParameterSet&) > SeedFinderFactory;
+typedef edmplugin::PluginFactory<SeedFinderBase*(const edm::ParameterSet&)> SeedFinderFactory;
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.cc
@@ -21,117 +21,107 @@
 #define LOGDRESSED(x) LogDebug(x)
 #endif
 
-Basic2DGenericPFlowClusterizer::
-Basic2DGenericPFlowClusterizer(const edm::ParameterSet& conf) :
-    PFClusterBuilderBase(conf),
-    _maxIterations(conf.getParameter<unsigned>("maxIterations")),
-    _stoppingTolerance(conf.getParameter<double>("stoppingTolerance")),
-    _showerSigma2(std::pow(conf.getParameter<double>("showerSigma"),2.0)),
-    _excludeOtherSeeds(conf.getParameter<bool>("excludeOtherSeeds")),
-    _minFracTot(conf.getParameter<double>("minFracTot")),
-    _layerMap({ {"PS2",(int)PFLayer::PS2},
-	        {"PS1",(int)PFLayer::PS1},
-	        {"ECAL_ENDCAP",(int)PFLayer::ECAL_ENDCAP},
-	        {"ECAL_BARREL",(int)PFLayer::ECAL_BARREL},
-	        {"NONE",(int)PFLayer::NONE},
-	        {"HCAL_BARREL1",(int)PFLayer::HCAL_BARREL1},
-	        {"HCAL_BARREL2_RING0",(int)PFLayer::HCAL_BARREL2},
-		{"HCAL_BARREL2_RING1",100*(int)PFLayer::HCAL_BARREL2},
-	        {"HCAL_ENDCAP",(int)PFLayer::HCAL_ENDCAP},
-	        {"HF_EM",(int)PFLayer::HF_EM},
-		{"HF_HAD",(int)PFLayer::HF_HAD} }) { 
-  const std::vector<edm::ParameterSet>& thresholds =
-    conf.getParameterSetVector("recHitEnergyNorms");
-  for( const auto& pset : thresholds ) {
+Basic2DGenericPFlowClusterizer::Basic2DGenericPFlowClusterizer(const edm::ParameterSet& conf)
+    : PFClusterBuilderBase(conf),
+      _maxIterations(conf.getParameter<unsigned>("maxIterations")),
+      _stoppingTolerance(conf.getParameter<double>("stoppingTolerance")),
+      _showerSigma2(std::pow(conf.getParameter<double>("showerSigma"), 2.0)),
+      _excludeOtherSeeds(conf.getParameter<bool>("excludeOtherSeeds")),
+      _minFracTot(conf.getParameter<double>("minFracTot")),
+      _layerMap({{"PS2", (int)PFLayer::PS2},
+                 {"PS1", (int)PFLayer::PS1},
+                 {"ECAL_ENDCAP", (int)PFLayer::ECAL_ENDCAP},
+                 {"ECAL_BARREL", (int)PFLayer::ECAL_BARREL},
+                 {"NONE", (int)PFLayer::NONE},
+                 {"HCAL_BARREL1", (int)PFLayer::HCAL_BARREL1},
+                 {"HCAL_BARREL2_RING0", (int)PFLayer::HCAL_BARREL2},
+                 {"HCAL_BARREL2_RING1", 100 * (int)PFLayer::HCAL_BARREL2},
+                 {"HCAL_ENDCAP", (int)PFLayer::HCAL_ENDCAP},
+                 {"HF_EM", (int)PFLayer::HF_EM},
+                 {"HF_HAD", (int)PFLayer::HF_HAD}}) {
+  const std::vector<edm::ParameterSet>& thresholds = conf.getParameterSetVector("recHitEnergyNorms");
+  for (const auto& pset : thresholds) {
     const std::string& det = pset.getParameter<std::string>("detector");
 
     std::vector<int> depths;
     std::vector<double> rhE_norm;
 
-    if (det==std::string("HCAL_BARREL1") || det==std::string("HCAL_ENDCAP")) {
-      depths= pset.getParameter<std::vector<int> >("depths");
+    if (det == std::string("HCAL_BARREL1") || det == std::string("HCAL_ENDCAP")) {
+      depths = pset.getParameter<std::vector<int> >("depths");
       rhE_norm = pset.getParameter<std::vector<double> >("recHitEnergyNorm");
     } else {
       depths.push_back(0);
       rhE_norm.push_back(pset.getParameter<double>("recHitEnergyNorm"));
     }
 
-    if( rhE_norm.size()!=depths.size() ) {
+    if (rhE_norm.size() != depths.size()) {
       throw cms::Exception("InvalidPFRecHitThreshold")
-	<< "PFlowClusterizerThreshold mismatch with the numbers of depths";
+          << "PFlowClusterizerThreshold mismatch with the numbers of depths";
     }
-
 
     auto entry = _layerMap.find(det);
-    if( entry == _layerMap.end() ) {
-      throw cms::Exception("InvalidDetectorLayer")
-	<< "Detector layer : " << det << " is not in the list of recognized"
-	<< " detector layers!";
+    if (entry == _layerMap.end()) {
+      throw cms::Exception("InvalidDetectorLayer") << "Detector layer : " << det << " is not in the list of recognized"
+                                                   << " detector layers!";
     }
-    _recHitEnergyNorms.emplace(_layerMap.find(det)->second,std::make_pair(depths,rhE_norm));
+    _recHitEnergyNorms.emplace(_layerMap.find(det)->second, std::make_pair(depths, rhE_norm));
   }
-  
-  if( conf.exists("allCellsPositionCalc") ) {
-    const edm::ParameterSet& acConf = 
-      conf.getParameterSet("allCellsPositionCalc");
-    const std::string& algoac = 
-      acConf.getParameter<std::string>("algoName");
+
+  if (conf.exists("allCellsPositionCalc")) {
+    const edm::ParameterSet& acConf = conf.getParameterSet("allCellsPositionCalc");
+    const std::string& algoac = acConf.getParameter<std::string>("algoName");
     _allCellsPosCalc = std::unique_ptr<PosCalc>{PFCPositionCalculatorFactory::get()->create(algoac, acConf)};
   }
   // if necessary a third pos calc for convergence testing
-  if( conf.exists("positionCalcForConvergence") ) {
-    const edm::ParameterSet& convConf = 
-      conf.getParameterSet("positionCalcForConvergence");
-    const std::string& algoconv = 
-      convConf.getParameter<std::string>("algoName");
+  if (conf.exists("positionCalcForConvergence")) {
+    const edm::ParameterSet& convConf = conf.getParameterSet("positionCalcForConvergence");
+    const std::string& algoconv = convConf.getParameter<std::string>("algoName");
     _convergencePosCalc = std::unique_ptr<PosCalc>{PFCPositionCalculatorFactory::get()->create(algoconv, convConf)};
   }
 }
 
-void Basic2DGenericPFlowClusterizer::
-buildClusters(const reco::PFClusterCollection& input,
-	      const std::vector<bool>& seedable,
-	      reco::PFClusterCollection& output) {
+void Basic2DGenericPFlowClusterizer::buildClusters(const reco::PFClusterCollection& input,
+                                                   const std::vector<bool>& seedable,
+                                                   reco::PFClusterCollection& output) {
   reco::PFClusterCollection clustersInTopo;
-  for( const auto& topocluster : input ) {
+  for (const auto& topocluster : input) {
     clustersInTopo.clear();
-    seedPFClustersFromTopo(topocluster,seedable,clustersInTopo);
-    const unsigned tolScal = 
-      std::pow(std::max(1.0,clustersInTopo.size()-1.0),2.0);
-    growPFClusters(topocluster,seedable,tolScal,0,tolScal,clustersInTopo);
+    seedPFClustersFromTopo(topocluster, seedable, clustersInTopo);
+    const unsigned tolScal = std::pow(std::max(1.0, clustersInTopo.size() - 1.0), 2.0);
+    growPFClusters(topocluster, seedable, tolScal, 0, tolScal, clustersInTopo);
     // step added by Josh Bendavid, removes low-fraction clusters
     // did not impact position resolution with fraction cut of 1e-7
     // decreases the size of each pf cluster considerably
     prunePFClusters(clustersInTopo);
     // recalculate the positions of the pruned clusters
-    if( _convergencePosCalc ) { 
+    if (_convergencePosCalc) {
       // if defined, use the special position calculation for convergence tests
       _convergencePosCalc->calculateAndSetPositions(clustersInTopo);
     } else {
-      if( clustersInTopo.size() == 1 && _allCellsPosCalc ) {
-	_allCellsPosCalc->calculateAndSetPosition(clustersInTopo.back());
+      if (clustersInTopo.size() == 1 && _allCellsPosCalc) {
+        _allCellsPosCalc->calculateAndSetPosition(clustersInTopo.back());
       } else {
-	_positionCalc->calculateAndSetPositions(clustersInTopo);
-      }   
+        _positionCalc->calculateAndSetPositions(clustersInTopo);
+      }
     }
-    for( auto& clusterout : clustersInTopo ) {
-      output.insert(output.end(),std::move(clusterout));
+    for (auto& clusterout : clustersInTopo) {
+      output.insert(output.end(), std::move(clusterout));
     }
   }
 }
 
-void Basic2DGenericPFlowClusterizer::
-seedPFClustersFromTopo(const reco::PFCluster& topo,
-		       const std::vector<bool>& seedable,
-		       reco::PFClusterCollection& initialPFClusters) const {
+void Basic2DGenericPFlowClusterizer::seedPFClustersFromTopo(const reco::PFCluster& topo,
+                                                            const std::vector<bool>& seedable,
+                                                            reco::PFClusterCollection& initialPFClusters) const {
   const auto& recHitFractions = topo.recHitFractions();
-  for( const auto& rhf : recHitFractions ) {
-    if( !seedable[rhf.recHitRef().key()] ) continue;
+  for (const auto& rhf : recHitFractions) {
+    if (!seedable[rhf.recHitRef().key()])
+      continue;
     initialPFClusters.push_back(reco::PFCluster());
     reco::PFCluster& current = initialPFClusters.back();
     current.addRecHitFraction(rhf);
-    current.setSeed(rhf.recHitRef()->detId());   
-    if( _convergencePosCalc ) {
+    current.setSeed(rhf.recHitRef()->detId());
+    if (_convergencePosCalc) {
       _convergencePosCalc->calculateAndSetPosition(current);
     } else {
       _positionCalc->calculateAndSetPosition(current);
@@ -139,135 +129,130 @@ seedPFClustersFromTopo(const reco::PFCluster& topo,
   }
 }
 
-void Basic2DGenericPFlowClusterizer::
-growPFClusters(const reco::PFCluster& topo,
-	       const std::vector<bool>& seedable,
-	       const unsigned toleranceScaling,
-	       const unsigned iter,
-	       double diff,
-	       reco::PFClusterCollection& clusters) const {
-  if( iter >= _maxIterations ) {
+void Basic2DGenericPFlowClusterizer::growPFClusters(const reco::PFCluster& topo,
+                                                    const std::vector<bool>& seedable,
+                                                    const unsigned toleranceScaling,
+                                                    const unsigned iter,
+                                                    double diff,
+                                                    reco::PFClusterCollection& clusters) const {
+  if (iter >= _maxIterations) {
     LOGDRESSED("Basic2DGenericPFlowClusterizer:growAndStabilizePFClusters")
-      <<"reached " << _maxIterations << " iterations, terminated position "
-      << "fit with diff = " << diff;
-  }      
-  if( iter >= _maxIterations || 
-      diff <= _stoppingTolerance*toleranceScaling) return;
-  // reset the rechits in this cluster, keeping the previous position    
-  std::vector<reco::PFCluster::REPPoint> clus_prev_pos;  
-  for( auto& cluster : clusters) {
+        << "reached " << _maxIterations << " iterations, terminated position "
+        << "fit with diff = " << diff;
+  }
+  if (iter >= _maxIterations || diff <= _stoppingTolerance * toleranceScaling)
+    return;
+  // reset the rechits in this cluster, keeping the previous position
+  std::vector<reco::PFCluster::REPPoint> clus_prev_pos;
+  for (auto& cluster : clusters) {
     const reco::PFCluster::REPPoint& repp = cluster.positionREP();
-    clus_prev_pos.emplace_back(repp.rho(),repp.eta(),repp.phi());
-    if( _convergencePosCalc ) {
-      if( clusters.size() == 1 && _allCellsPosCalc ) {
-	_allCellsPosCalc->calculateAndSetPosition(cluster);
+    clus_prev_pos.emplace_back(repp.rho(), repp.eta(), repp.phi());
+    if (_convergencePosCalc) {
+      if (clusters.size() == 1 && _allCellsPosCalc) {
+        _allCellsPosCalc->calculateAndSetPosition(cluster);
       } else {
-	_positionCalc->calculateAndSetPosition(cluster);
+        _positionCalc->calculateAndSetPosition(cluster);
       }
     }
     cluster.resetHitsAndFractions();
   }
-  // loop over topo cluster and grow current PFCluster hypothesis 
+  // loop over topo cluster and grow current PFCluster hypothesis
   std::vector<double> dist2, frac;
   double fractot = 0;
-  for( const reco::PFRecHitFraction& rhf : topo.recHitFractions() ) {
+  for (const reco::PFRecHitFraction& rhf : topo.recHitFractions()) {
     const reco::PFRecHitRef& refhit = rhf.recHitRef();
     int cell_layer = (int)refhit->layer();
-    if( cell_layer == PFLayer::HCAL_BARREL2 && 
-	std::abs(refhit->positionREP().eta()) > 0.34 ) {
+    if (cell_layer == PFLayer::HCAL_BARREL2 && std::abs(refhit->positionREP().eta()) > 0.34) {
       cell_layer *= 100;
-    }  
+    }
 
     math::XYZPoint topocellpos_xyz(refhit->position());
-    dist2.clear(); frac.clear(); fractot = 0;
+    dist2.clear();
+    frac.clear();
+    fractot = 0;
 
-    double recHitEnergyNorm=0.;
+    double recHitEnergyNorm = 0.;
     auto const& recHitEnergyNormDepthPair = _recHitEnergyNorms.find(cell_layer)->second;
 
-    for (unsigned int j=0; j<recHitEnergyNormDepthPair.second.size(); ++j) {
-      int depth=recHitEnergyNormDepthPair.first[j];
+    for (unsigned int j = 0; j < recHitEnergyNormDepthPair.second.size(); ++j) {
+      int depth = recHitEnergyNormDepthPair.first[j];
 
-      if( ( cell_layer == PFLayer::HCAL_BARREL1 && refhit->depth()== depth)
-	  || ( cell_layer == PFLayer::HCAL_ENDCAP && refhit->depth()== depth)
-	  || ( cell_layer != PFLayer::HCAL_ENDCAP && cell_layer != PFLayer::HCAL_BARREL1)
-	  ) recHitEnergyNorm = recHitEnergyNormDepthPair.second[j];
+      if ((cell_layer == PFLayer::HCAL_BARREL1 && refhit->depth() == depth) ||
+          (cell_layer == PFLayer::HCAL_ENDCAP && refhit->depth() == depth) ||
+          (cell_layer != PFLayer::HCAL_ENDCAP && cell_layer != PFLayer::HCAL_BARREL1))
+        recHitEnergyNorm = recHitEnergyNormDepthPair.second[j];
     }
 
     // add rechits to clusters, calculating fraction based on distance
-    for( auto& cluster : clusters ) {      
+    for (auto& cluster : clusters) {
       const math::XYZPoint& clusterpos_xyz = cluster.position();
       const math::XYZVector deltav = clusterpos_xyz - topocellpos_xyz;
-      const double d2 = deltav.Mag2()/_showerSigma2;
-      dist2.emplace_back( d2 );
-      if( d2 > 100 ) {
-	LOGDRESSED("Basic2DGenericPFlowClusterizer:growAndStabilizePFClusters")
-	  << "Warning! :: pfcluster-topocell distance is too large! d= "
-	  << d2;
+      const double d2 = deltav.Mag2() / _showerSigma2;
+      dist2.emplace_back(d2);
+      if (d2 > 100) {
+        LOGDRESSED("Basic2DGenericPFlowClusterizer:growAndStabilizePFClusters")
+            << "Warning! :: pfcluster-topocell distance is too large! d= " << d2;
       }
 
       // fraction assignment logic
       double fraction;
-      if( refhit->detId() == cluster.seed() && _excludeOtherSeeds ) {
-	fraction = 1.0;	
-      } else if ( seedable[refhit.key()] && _excludeOtherSeeds ) {
-	fraction = 0.0;
+      if (refhit->detId() == cluster.seed() && _excludeOtherSeeds) {
+        fraction = 1.0;
+      } else if (seedable[refhit.key()] && _excludeOtherSeeds) {
+        fraction = 0.0;
       } else {
-	fraction = cluster.energy()/recHitEnergyNorm * vdt::fast_expf( -0.5*d2 );
-      }      
+        fraction = cluster.energy() / recHitEnergyNorm * vdt::fast_expf(-0.5 * d2);
+      }
       fractot += fraction;
       frac.emplace_back(fraction);
     }
-    for( unsigned i = 0; i < clusters.size(); ++i ) {      
-      if( fractot > _minFracTot || 
-	  ( refhit->detId() == clusters[i].seed() && fractot > 0.0 ) ) {
-	frac[i]/=fractot;
+    for (unsigned i = 0; i < clusters.size(); ++i) {
+      if (fractot > _minFracTot || (refhit->detId() == clusters[i].seed() && fractot > 0.0)) {
+        frac[i] /= fractot;
       } else {
-	continue;
+        continue;
       }
-      // if the fraction has been set to 0, the cell 
+      // if the fraction has been set to 0, the cell
       // is now added to the cluster - careful ! (PJ, 19/07/08)
       // BUT KEEP ONLY CLOSE CELLS OTHERWISE MEMORY JUST EXPLOSES
-      // (PJ, 15/09/08 <- similar to what existed before the 
-      // previous bug fix, but keeps the close seeds inside, 
+      // (PJ, 15/09/08 <- similar to what existed before the
+      // previous bug fix, but keeps the close seeds inside,
       // even if their fraction was set to zero.)
-      // Also add a protection to keep the seed in the cluster 
+      // Also add a protection to keep the seed in the cluster
       // when the latter gets far from the former. These cases
-      // (about 1% of the clusters) need to be studied, as 
+      // (about 1% of the clusters) need to be studied, as
       // they create fake photons, in general.
-      // (PJ, 16/09/08) 
-      if( dist2[i] < 100.0 || frac[i] > 0.9999 ) {	
-	clusters[i].addRecHitFraction(reco::PFRecHitFraction(refhit,frac[i]));
+      // (PJ, 16/09/08)
+      if (dist2[i] < 100.0 || frac[i] > 0.9999) {
+        clusters[i].addRecHitFraction(reco::PFRecHitFraction(refhit, frac[i]));
       }
     }
   }
   // recalculate positions and calculate convergence parameter
-  double diff2 = 0.0;  
-  for( unsigned i = 0; i < clusters.size(); ++i ) {
-    if( _convergencePosCalc ) {
+  double diff2 = 0.0;
+  for (unsigned i = 0; i < clusters.size(); ++i) {
+    if (_convergencePosCalc) {
       _convergencePosCalc->calculateAndSetPosition(clusters[i]);
     } else {
-      if( clusters.size() == 1 && _allCellsPosCalc ) {
-	_allCellsPosCalc->calculateAndSetPosition(clusters[i]);
+      if (clusters.size() == 1 && _allCellsPosCalc) {
+        _allCellsPosCalc->calculateAndSetPosition(clusters[i]);
       } else {
-	_positionCalc->calculateAndSetPosition(clusters[i]);
+        _positionCalc->calculateAndSetPosition(clusters[i]);
       }
     }
-    const double delta2 = 
-      reco::deltaR2(clusters[i].positionREP(),clus_prev_pos[i]);    
-    if( delta2 > diff2 ) diff2 = delta2;
+    const double delta2 = reco::deltaR2(clusters[i].positionREP(), clus_prev_pos[i]);
+    if (delta2 > diff2)
+      diff2 = delta2;
   }
   diff = std::sqrt(diff2);
-  dist2.clear(); frac.clear(); clus_prev_pos.clear();// avoid badness
-  growPFClusters(topo,seedable,toleranceScaling,iter+1,diff,clusters);
+  dist2.clear();
+  frac.clear();
+  clus_prev_pos.clear();  // avoid badness
+  growPFClusters(topo, seedable, toleranceScaling, iter + 1, diff, clusters);
 }
 
-void Basic2DGenericPFlowClusterizer::
-prunePFClusters(reco::PFClusterCollection& clusters) const {
-  for( auto& cluster : clusters ) {
-    cluster.pruneUsing( [&](const reco::PFRecHitFraction& rhf)
-			{return rhf.fraction() > _minFractionToKeep;} 
-			);    
+void Basic2DGenericPFlowClusterizer::prunePFClusters(reco::PFClusterCollection& clusters) const {
+  for (auto& cluster : clusters) {
+    cluster.pruneUsing([&](const reco::PFRecHitFraction& rhf) { return rhf.fraction() > _minFractionToKeep; });
   }
 }
-
-

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowClusterizer.h
@@ -8,51 +8,50 @@
 
 class Basic2DGenericPFlowClusterizer : public PFClusterBuilderBase {
   typedef Basic2DGenericPFlowClusterizer B2DGPF;
- public:
+
+public:
   Basic2DGenericPFlowClusterizer(const edm::ParameterSet& conf);
-    
+
   ~Basic2DGenericPFlowClusterizer() override = default;
   Basic2DGenericPFlowClusterizer(const B2DGPF&) = delete;
   B2DGPF& operator=(const B2DGPF&) = delete;
 
-  void update(const edm::EventSetup& es) override { 
-    _positionCalc->update(es); 
-    if( _allCellsPosCalc ) _allCellsPosCalc->update(es);
-    if( _convergencePosCalc ) _convergencePosCalc->update(es);
+  void update(const edm::EventSetup& es) override {
+    _positionCalc->update(es);
+    if (_allCellsPosCalc)
+      _allCellsPosCalc->update(es);
+    if (_convergencePosCalc)
+      _convergencePosCalc->update(es);
   }
 
   void buildClusters(const reco::PFClusterCollection&,
-		     const std::vector<bool>&,
-		     reco::PFClusterCollection& outclus) override;
+                     const std::vector<bool>&,
+                     reco::PFClusterCollection& outclus) override;
 
- private:  
+private:
   const unsigned _maxIterations;
   const double _stoppingTolerance;
   const double _showerSigma2;
   const bool _excludeOtherSeeds;
   const double _minFracTot;
-  const std::unordered_map<std::string,int> _layerMap;
+  const std::unordered_map<std::string, int> _layerMap;
 
-  std::unordered_map<int,std::pair<std::vector<int>,std::vector<double> > > _recHitEnergyNorms;
+  std::unordered_map<int, std::pair<std::vector<int>, std::vector<double> > > _recHitEnergyNorms;
   std::unique_ptr<PFCPositionCalculatorBase> _allCellsPosCalc;
   std::unique_ptr<PFCPositionCalculatorBase> _convergencePosCalc;
-  
-  void seedPFClustersFromTopo(const reco::PFCluster&,
-			      const std::vector<bool>&,
-			      reco::PFClusterCollection&) const;
+
+  void seedPFClustersFromTopo(const reco::PFCluster&, const std::vector<bool>&, reco::PFClusterCollection&) const;
 
   void growPFClusters(const reco::PFCluster&,
-		      const std::vector<bool>&,
-		      const unsigned toleranceScaling,
-		      const unsigned iter,
-		      double dist,
-		      reco::PFClusterCollection&) const;
-  
+                      const std::vector<bool>&,
+                      const unsigned toleranceScaling,
+                      const unsigned iter,
+                      double dist,
+                      reco::PFClusterCollection&) const;
+
   void prunePFClusters(reco::PFClusterCollection&) const;
 };
 
-DEFINE_EDM_PLUGIN(PFClusterBuilderFactory,
-		  Basic2DGenericPFlowClusterizer,
-		  "Basic2DGenericPFlowClusterizer");
+DEFINE_EDM_PLUGIN(PFClusterBuilderFactory, Basic2DGenericPFlowClusterizer, "Basic2DGenericPFlowClusterizer");
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.cc
@@ -5,196 +5,185 @@
 
 #include <cmath>
 #include "CommonTools/Utils/interface/DynArray.h"
-#include<iterator>
+#include <iterator>
 #include <boost/function_output_iterator.hpp>
 
 #include "vdt/vdtMath.h"
 
-
 namespace {
-  inline
-  bool isBarrel(int cell_layer){
-    return (cell_layer == PFLayer::HCAL_BARREL1 ||
-	    cell_layer == PFLayer::HCAL_BARREL2 ||
-	    cell_layer == PFLayer::ECAL_BARREL);
-  }  
-}
+  inline bool isBarrel(int cell_layer) {
+    return (cell_layer == PFLayer::HCAL_BARREL1 || cell_layer == PFLayer::HCAL_BARREL2 ||
+            cell_layer == PFLayer::ECAL_BARREL);
+  }
+}  // namespace
 
-void Basic2DGenericPFlowPositionCalc::
-calculateAndSetPosition(reco::PFCluster& cluster) {
+void Basic2DGenericPFlowPositionCalc::calculateAndSetPosition(reco::PFCluster& cluster) {
   calculateAndSetPositionActual(cluster);
 }
 
-void Basic2DGenericPFlowPositionCalc::
-calculateAndSetPositions(reco::PFClusterCollection& clusters) {
-  for( reco::PFCluster& cluster : clusters ) {
+void Basic2DGenericPFlowPositionCalc::calculateAndSetPositions(reco::PFClusterCollection& clusters) {
+  for (reco::PFCluster& cluster : clusters) {
     calculateAndSetPositionActual(cluster);
   }
 }
 
-void Basic2DGenericPFlowPositionCalc::
-calculateAndSetPositionActual(reco::PFCluster& cluster) const {  
-  if( !cluster.seed() ) {
-    throw cms::Exception("ClusterWithNoSeed")
-      << " Found a cluster with no seed: " << cluster;
-  }  				
-  double cl_energy = 0;  
-  double cl_time = 0;  
-  double cl_timeweight=0.0;
-  double max_e = 0.0;  
+void Basic2DGenericPFlowPositionCalc::calculateAndSetPositionActual(reco::PFCluster& cluster) const {
+  if (!cluster.seed()) {
+    throw cms::Exception("ClusterWithNoSeed") << " Found a cluster with no seed: " << cluster;
+  }
+  double cl_energy = 0;
+  double cl_time = 0;
+  double cl_timeweight = 0.0;
+  double max_e = 0.0;
   PFLayer::Layer max_e_layer = PFLayer::NONE;
   // find the seed and max layer and also calculate time
   //Michalis : Even if we dont use timing in clustering here we should fill
   //the time information for the cluster. This should use the timing resolution(1/E)
   //so the weight should be fraction*E^2
   //calculate a simplistic depth now. The log weighted will be done
-  //in different stage  
+  //in different stage
 
-
-  auto const recHitCollection = &(*cluster.recHitFractions()[0].recHitRef()) - cluster.recHitFractions()[0].recHitRef().key();
+  auto const recHitCollection =
+      &(*cluster.recHitFractions()[0].recHitRef()) - cluster.recHitFractions()[0].recHitRef().key();
   auto nhits = cluster.recHitFractions().size();
-  struct LHit{ reco::PFRecHit const * hit; float energy; float fraction;};
-  declareDynArray(LHit,nhits,hits);
-  for(auto i=0U; i<nhits; ++i) {
-    auto const & hf = cluster.recHitFractions()[i];
+  struct LHit {
+    reco::PFRecHit const* hit;
+    float energy;
+    float fraction;
+  };
+  declareDynArray(LHit, nhits, hits);
+  for (auto i = 0U; i < nhits; ++i) {
+    auto const& hf = cluster.recHitFractions()[i];
     auto k = hf.recHitRef().key();
-    auto p = recHitCollection+k;
-    hits[i]= {p,(*p).energy(), float(hf.fraction())}; 
+    auto p = recHitCollection + k;
+    hits[i] = {p, (*p).energy(), float(hf.fraction())};
   }
 
-
   bool resGiven = bool(_timeResolutionCalcBarrel) & bool(_timeResolutionCalcEndcap);
-  LHit mySeed={nullptr};
-  for( auto const & rhf : hits ) {
-    const reco::PFRecHit & refhit = *rhf.hit;
-    if( refhit.detId() == cluster.seed() )  mySeed = rhf;
+  LHit mySeed = {nullptr};
+  for (auto const& rhf : hits) {
+    const reco::PFRecHit& refhit = *rhf.hit;
+    if (refhit.detId() == cluster.seed())
+      mySeed = rhf;
     const auto rh_fraction = rhf.fraction;
     const auto rh_rawenergy = rhf.energy;
-    const auto rh_energy = rh_rawenergy * rh_fraction;   
+    const auto rh_energy = rh_rawenergy * rh_fraction;
 #ifdef PF_DEBUG
-    if UNLIKELY( edm::isNotFinite(rh_energy) ) {
-      throw cms::Exception("PFClusterAlgo")
-	<<"rechit " << refhit.detId() << " has a NaN energy... " 
-	<< "The input of the particle flow clustering seems to be corrupted.";
-    }
+    if
+      UNLIKELY(edm::isNotFinite(rh_energy)) {
+        throw cms::Exception("PFClusterAlgo") << "rechit " << refhit.detId() << " has a NaN energy... "
+                                              << "The input of the particle flow clustering seems to be corrupted.";
+      }
 #endif
     cl_energy += rh_energy;
     // If time resolution is given, calculated weighted average
-    if ( resGiven ) {
+    if (resGiven) {
       double res2 = 1.e-4;
       int cell_layer = (int)refhit.layer();
-      res2 =  isBarrel(cell_layer) ? 1./_timeResolutionCalcBarrel->timeResolution2(rh_rawenergy) :
-                                     1./_timeResolutionCalcEndcap->timeResolution2(rh_rawenergy);
-      cl_time += rh_fraction*refhit.time()*res2;
-      cl_timeweight += rh_fraction*res2;
-    }
-    else { // assume resolution = 1/E**2
-      const double rh_rawenergy2 = rh_rawenergy*rh_rawenergy;
-      cl_timeweight+=rh_rawenergy2*rh_fraction;
-      cl_time += rh_rawenergy2*rh_fraction*refhit.time();
+      res2 = isBarrel(cell_layer) ? 1. / _timeResolutionCalcBarrel->timeResolution2(rh_rawenergy)
+                                  : 1. / _timeResolutionCalcEndcap->timeResolution2(rh_rawenergy);
+      cl_time += rh_fraction * refhit.time() * res2;
+      cl_timeweight += rh_fraction * res2;
+    } else {  // assume resolution = 1/E**2
+      const double rh_rawenergy2 = rh_rawenergy * rh_rawenergy;
+      cl_timeweight += rh_rawenergy2 * rh_fraction;
+      cl_time += rh_rawenergy2 * rh_fraction * refhit.time();
     }
 
-    if( rh_energy > max_e ) {
+    if (rh_energy > max_e) {
       max_e = rh_energy;
       max_e_layer = refhit.layer();
-    }    
+    }
   }
-  
+
   cluster.setEnergy(cl_energy);
-  cluster.setTime(cl_time/cl_timeweight);
+  cluster.setTime(cl_time / cl_timeweight);
   if (resGiven) {
-    cluster.setTimeError(std::sqrt(1.0f/float(cl_timeweight)));
+    cluster.setTimeError(std::sqrt(1.0f / float(cl_timeweight)));
   }
   cluster.setLayer(max_e_layer);
 
   // calculate the position
-  double depth = 0.0;  
+  double depth = 0.0;
   double position_norm = 0.0;
-  double x(0.0),y(0.0),z(0.0);
-  if( nullptr != mySeed.hit ) {
+  double x(0.0), y(0.0), z(0.0);
+  if (nullptr != mySeed.hit) {
     auto seedNeighbours = mySeed.hit->neighbours();
-    switch( _posCalcNCrystals ) {
-    case 5:
-      seedNeighbours = mySeed.hit->neighbours4();
-      break;
-    case 9:
-      seedNeighbours = mySeed.hit->neighbours8();
-      break;
-    default:
-      break;
+    switch (_posCalcNCrystals) {
+      case 5:
+        seedNeighbours = mySeed.hit->neighbours4();
+        break;
+      case 9:
+        seedNeighbours = mySeed.hit->neighbours8();
+        break;
+      default:
+        break;
     }
-    
+
     auto compute = [&](LHit const& rhf) {
-      const reco::PFRecHit & refhit = *rhf.hit;  
+      const reco::PFRecHit& refhit = *rhf.hit;
 
       int cell_layer = (int)refhit.layer();
-      float threshold=0;
+      float threshold = 0;
 
-      for (unsigned int j=0; j<(std::get<2>(_logWeightDenom)).size(); ++j) {
-	// barrel is detecor type1
-	int detectorEnum=std::get<0>(_logWeightDenom)[j];
-	int depth=std::get<1>(_logWeightDenom)[j];
+      for (unsigned int j = 0; j < (std::get<2>(_logWeightDenom)).size(); ++j) {
+        // barrel is detecor type1
+        int detectorEnum = std::get<0>(_logWeightDenom)[j];
+        int depth = std::get<1>(_logWeightDenom)[j];
 
-	if( ( cell_layer == PFLayer::HCAL_BARREL1 && detectorEnum==1 && refhit.depth()== depth)
-	    || ( cell_layer == PFLayer::HCAL_ENDCAP && detectorEnum==2 && refhit.depth()== depth)
-	    || detectorEnum==0
-	    ) threshold=std::get<2>(_logWeightDenom)[j];
-
+        if ((cell_layer == PFLayer::HCAL_BARREL1 && detectorEnum == 1 && refhit.depth() == depth) ||
+            (cell_layer == PFLayer::HCAL_ENDCAP && detectorEnum == 2 && refhit.depth() == depth) || detectorEnum == 0)
+          threshold = std::get<2>(_logWeightDenom)[j];
       }
 
       const auto rh_energy = rhf.energy * rhf.fraction;
-      const auto norm = ( rhf.fraction < _minFractionInCalc ?
-			  0.0f :
-			  std::max(0.0f,vdt::fast_logf(rh_energy*threshold)) );
-      const auto rhpos_xyz = refhit.position()*norm;
+      const auto norm =
+          (rhf.fraction < _minFractionInCalc ? 0.0f : std::max(0.0f, vdt::fast_logf(rh_energy * threshold)));
+      const auto rhpos_xyz = refhit.position() * norm;
       x += rhpos_xyz.x();
       y += rhpos_xyz.y();
       z += rhpos_xyz.z();
-      depth += refhit.depth()*norm;
+      depth += refhit.depth() * norm;
       position_norm += norm;
-
     };
-    
-    if(_posCalcNCrystals != -1) // sorted to make neighbour search faster (maybe)
-      std::sort(hits.begin(),hits.end(),[](LHit const& a, LHit const& b) { return a.hit<b.hit;});
-    
-    
-    if(_posCalcNCrystals == -1)
-      for( auto const & rhf : hits ) compute(rhf);
+
+    if (_posCalcNCrystals != -1)  // sorted to make neighbour search faster (maybe)
+      std::sort(hits.begin(), hits.end(), [](LHit const& a, LHit const& b) { return a.hit < b.hit; });
+
+    if (_posCalcNCrystals == -1)
+      for (auto const& rhf : hits)
+        compute(rhf);
     else {  // only seed and its neighbours
       compute(mySeed);
       // search seedNeighbours to find energy fraction in cluster (sic)
-      unInitDynArray(reco::PFRecHit const *,seedNeighbours.size(),nei);	  
-      for(auto k : seedNeighbours){ 
-	nei.push_back(recHitCollection+k);
+      unInitDynArray(reco::PFRecHit const*, seedNeighbours.size(), nei);
+      for (auto k : seedNeighbours) {
+        nei.push_back(recHitCollection + k);
       }
-      std::sort(nei.begin(),nei.end());
+      std::sort(nei.begin(), nei.end());
       struct LHitLess {
-	auto operator()(LHit const &a, reco::PFRecHit const * b) const {return a.hit<b;}
-	auto operator()(reco::PFRecHit const * b, LHit const &a) const {return b<a.hit;}
+        auto operator()(LHit const& a, reco::PFRecHit const* b) const { return a.hit < b; }
+        auto operator()(reco::PFRecHit const* b, LHit const& a) const { return b < a.hit; }
       };
-      std::set_intersection(hits.begin(),hits.end(),nei.begin(),nei.end(), 
-			    boost::make_function_output_iterator(compute),
-			    LHitLess()
-			    );
+      std::set_intersection(
+          hits.begin(), hits.end(), nei.begin(), nei.end(), boost::make_function_output_iterator(compute), LHitLess());
     }
   } else {
     throw cms::Exception("Basic2DGenerticPFlowPositionCalc")
-      << "Cluster seed hit is null, something is wrong with PFlow RecHit!";
+        << "Cluster seed hit is null, something is wrong with PFlow RecHit!";
   }
 
-  if( position_norm < _minAllowedNorm ) {
-    edm::LogError("WeirdClusterNormalization")
-      << "PFCluster too far from seeding cell: set position to (0,0,0).";
-    cluster.setPosition(math::XYZPoint(0,0,0));
+  if (position_norm < _minAllowedNorm) {
+    edm::LogError("WeirdClusterNormalization") << "PFCluster too far from seeding cell: set position to (0,0,0).";
+    cluster.setPosition(math::XYZPoint(0, 0, 0));
     cluster.calculatePositionREP();
   } else {
-    const double norm_inverse = 1.0/position_norm;
+    const double norm_inverse = 1.0 / position_norm;
     x *= norm_inverse;
     y *= norm_inverse;
     z *= norm_inverse;
     depth *= norm_inverse;
-    cluster.setPosition(math::XYZPoint(x,y,z));
+    cluster.setPosition(math::XYZPoint(x, y, z));
     cluster.setDepth(depth);
     cluster.calculatePositionREP();
   }

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericPFlowPositionCalc.h
@@ -11,44 +11,42 @@
 #include <tuple>
 
 class Basic2DGenericPFlowPositionCalc : public PFCPositionCalculatorBase {
- public:
-  Basic2DGenericPFlowPositionCalc(const edm::ParameterSet& conf) :
-    PFCPositionCalculatorBase(conf),    
-    _posCalcNCrystals(conf.getParameter<int>("posCalcNCrystals")),
-    _minAllowedNorm(conf.getParameter<double>("minAllowedNormalization"))
-  {  
-
+public:
+  Basic2DGenericPFlowPositionCalc(const edm::ParameterSet& conf)
+      : PFCPositionCalculatorBase(conf),
+        _posCalcNCrystals(conf.getParameter<int>("posCalcNCrystals")),
+        _minAllowedNorm(conf.getParameter<double>("minAllowedNormalization")) {
     std::vector<int> detectorEnum;
     std::vector<int> depths;
     std::vector<double> logWeightDenom;
     std::vector<float> logWeightDenomInv;
 
-    if(conf.exists("logWeightDenominatorByDetector")) {
+    if (conf.exists("logWeightDenominatorByDetector")) {
+      const std::vector<edm::ParameterSet>& logWeightDenominatorByDetectorPSet =
+          conf.getParameterSetVector("logWeightDenominatorByDetector");
 
-      const std::vector<edm::ParameterSet>& logWeightDenominatorByDetectorPSet = conf.getParameterSetVector("logWeightDenominatorByDetector");
+      for (const auto& pset : logWeightDenominatorByDetectorPSet) {
+        if (!pset.exists("detector")) {
+          throw cms::Exception("logWeightDenominatorByDetectorPSet") << "logWeightDenominator : detector not specified";
+        }
 
-      for( const auto& pset : logWeightDenominatorByDetectorPSet ) {
-	if(!pset.exists("detector")) {
-	  throw cms::Exception("logWeightDenominatorByDetectorPSet")
-	    << "logWeightDenominator : detector not specified";
-	}
+        const std::string& det = pset.getParameter<std::string>("detector");
 
-	const std::string& det = pset.getParameter<std::string>("detector");
-
-	if (det==std::string("HCAL_BARREL1") || det==std::string("HCAL_ENDCAP")) {
-	  std::vector<int> depthsT=pset.getParameter<std::vector<int> >("depths");
-	  std::vector<double> logWeightDenomT=pset.getParameter<std::vector<double> >("logWeightDenominator");
-	  if(logWeightDenomT.size()!=depthsT.size()) {
-	    throw cms::Exception("logWeightDenominator")
-	      << "logWeightDenominator mismatch with the numbers of depths";
-	  }
-	  for(unsigned int i=0;i < depthsT.size();++i){
-	    if(det==std::string("HCAL_BARREL1")) detectorEnum.push_back(1);
-	    if(det==std::string("HCAL_ENDCAP")) detectorEnum.push_back(2);
-	    depths.push_back(depthsT[i]);
-	    logWeightDenom.push_back(logWeightDenomT[i]);
-	  }
-	}
+        if (det == std::string("HCAL_BARREL1") || det == std::string("HCAL_ENDCAP")) {
+          std::vector<int> depthsT = pset.getParameter<std::vector<int> >("depths");
+          std::vector<double> logWeightDenomT = pset.getParameter<std::vector<double> >("logWeightDenominator");
+          if (logWeightDenomT.size() != depthsT.size()) {
+            throw cms::Exception("logWeightDenominator") << "logWeightDenominator mismatch with the numbers of depths";
+          }
+          for (unsigned int i = 0; i < depthsT.size(); ++i) {
+            if (det == std::string("HCAL_BARREL1"))
+              detectorEnum.push_back(1);
+            if (det == std::string("HCAL_ENDCAP"))
+              detectorEnum.push_back(2);
+            depths.push_back(depthsT[i]);
+            logWeightDenom.push_back(logWeightDenomT[i]);
+          }
+        }
       }
     } else {
       detectorEnum.push_back(0);
@@ -56,37 +54,33 @@ class Basic2DGenericPFlowPositionCalc : public PFCPositionCalculatorBase {
       logWeightDenom.push_back(conf.getParameter<double>("logWeightDenominator"));
     }
 
-    for(unsigned int i=0;i < depths.size();++i){
-      logWeightDenomInv.push_back(1./logWeightDenom[i]);
+    for (unsigned int i = 0; i < depths.size(); ++i) {
+      logWeightDenomInv.push_back(1. / logWeightDenom[i]);
     }
 
     //    _logWeightDenom = std::make_pair(depths,logWeightDenomInv);
-    _logWeightDenom = std::make_tuple(detectorEnum,depths,logWeightDenomInv);
+    _logWeightDenom = std::make_tuple(detectorEnum, depths, logWeightDenomInv);
 
     _timeResolutionCalcBarrel.reset(nullptr);
-    if( conf.exists("timeResolutionCalcBarrel") ) {
-      const edm::ParameterSet& timeResConf = 
-        conf.getParameterSet("timeResolutionCalcBarrel");
-        _timeResolutionCalcBarrel.reset(new CaloRecHitResolutionProvider(timeResConf));
+    if (conf.exists("timeResolutionCalcBarrel")) {
+      const edm::ParameterSet& timeResConf = conf.getParameterSet("timeResolutionCalcBarrel");
+      _timeResolutionCalcBarrel.reset(new CaloRecHitResolutionProvider(timeResConf));
     }
     _timeResolutionCalcEndcap.reset(nullptr);
-    if( conf.exists("timeResolutionCalcEndcap") ) {
-      const edm::ParameterSet& timeResConf = 
-        conf.getParameterSet("timeResolutionCalcEndcap");
-        _timeResolutionCalcEndcap.reset(new CaloRecHitResolutionProvider(timeResConf));
+    if (conf.exists("timeResolutionCalcEndcap")) {
+      const edm::ParameterSet& timeResConf = conf.getParameterSet("timeResolutionCalcEndcap");
+      _timeResolutionCalcEndcap.reset(new CaloRecHitResolutionProvider(timeResConf));
     }
 
-   switch( _posCalcNCrystals ) {
-    case 5:
-    case 9:
-    case -1:
-      break;
-    default:
-      edm::LogError("Basic2DGenericPFlowPositionCalc") << "posCalcNCrystals not valid";
-      assert(0); // bug
-   }
-
-
+    switch (_posCalcNCrystals) {
+      case 5:
+      case 9:
+      case -1:
+        break;
+      default:
+        edm::LogError("Basic2DGenericPFlowPositionCalc") << "posCalcNCrystals not valid";
+        assert(0);  // bug
+    }
   }
 
   Basic2DGenericPFlowPositionCalc(const Basic2DGenericPFlowPositionCalc&) = delete;
@@ -95,19 +89,17 @@ class Basic2DGenericPFlowPositionCalc : public PFCPositionCalculatorBase {
   void calculateAndSetPosition(reco::PFCluster&) override;
   void calculateAndSetPositions(reco::PFClusterCollection&) override;
 
- private:
+private:
   const int _posCalcNCrystals;
-  std::tuple<std::vector<int> ,std::vector<int> , std::vector<float> > _logWeightDenom;
+  std::tuple<std::vector<int>, std::vector<int>, std::vector<float> > _logWeightDenom;
   const float _minAllowedNorm;
-  
+
   std::unique_ptr<CaloRecHitResolutionProvider> _timeResolutionCalcBarrel;
   std::unique_ptr<CaloRecHitResolutionProvider> _timeResolutionCalcEndcap;
 
   void calculateAndSetPositionActual(reco::PFCluster&) const;
 };
 
-DEFINE_EDM_PLUGIN(PFCPositionCalculatorFactory,
-		  Basic2DGenericPFlowPositionCalc,
-		  "Basic2DGenericPFlowPositionCalc");
+DEFINE_EDM_PLUGIN(PFCPositionCalculatorFactory, Basic2DGenericPFlowPositionCalc, "Basic2DGenericPFlowPositionCalc");
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericTopoClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericTopoClusterizer.cc
@@ -13,89 +13,84 @@
 #define LOGDRESSED(x) LogDebug(x)
 #endif
 
-void Basic2DGenericTopoClusterizer::
-buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
-	      const std::vector<bool>& rechitMask,
-	      const std::vector<bool>& seedable,
-	      reco::PFClusterCollection& output) {
-  auto const & hits = *input;  
-  std::vector<bool> used(hits.size(),false);
+void Basic2DGenericTopoClusterizer::buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
+                                                  const std::vector<bool>& rechitMask,
+                                                  const std::vector<bool>& seedable,
+                                                  reco::PFClusterCollection& output) {
+  auto const& hits = *input;
+  std::vector<bool> used(hits.size(), false);
   std::vector<unsigned int> seeds;
-  
+
   // get the seeds and sort them descending in energy
-  seeds.reserve(hits.size());  
-  for( unsigned int i = 0; i < hits.size(); ++i ) {
-    if( !rechitMask[i] || !seedable[i] || used[i] ) continue;
+  seeds.reserve(hits.size());
+  for (unsigned int i = 0; i < hits.size(); ++i) {
+    if (!rechitMask[i] || !seedable[i] || used[i])
+      continue;
     seeds.emplace_back(i);
   }
   // maxHeap would be better
-  std::sort(seeds.begin(),seeds.end(),
-            [&](unsigned int i, unsigned int j) { return hits[i].energy()>hits[j].energy();});  
-  
+  std::sort(
+      seeds.begin(), seeds.end(), [&](unsigned int i, unsigned int j) { return hits[i].energy() > hits[j].energy(); });
+
   reco::PFCluster temp;
-  for( auto seed : seeds ) {    
-    if( !rechitMask[seed] || !seedable[seed] || used[seed] ) continue;    
+  for (auto seed : seeds) {
+    if (!rechitMask[seed] || !seedable[seed] || used[seed])
+      continue;
     temp.reset();
-    buildTopoCluster(input,rechitMask,seed,used,temp);
-    if( !temp.recHitFractions().empty() ) output.push_back(temp);
+    buildTopoCluster(input, rechitMask, seed, used, temp);
+    if (!temp.recHitFractions().empty())
+      output.push_back(temp);
   }
 }
 
-void Basic2DGenericTopoClusterizer::
-buildTopoCluster(const edm::Handle<reco::PFRecHitCollection>& input,
-		 const std::vector<bool>& rechitMask,
-		 unsigned int kcell,
-		 std::vector<bool>& used,		 
-		 reco::PFCluster& topocluster) {
-  auto const & cell = (*input)[kcell];
+void Basic2DGenericTopoClusterizer::buildTopoCluster(const edm::Handle<reco::PFRecHitCollection>& input,
+                                                     const std::vector<bool>& rechitMask,
+                                                     unsigned int kcell,
+                                                     std::vector<bool>& used,
+                                                     reco::PFCluster& topocluster) {
+  auto const& cell = (*input)[kcell];
   int cell_layer = (int)cell.layer();
-  if( cell_layer == PFLayer::HCAL_BARREL2 && 
-      std::abs(cell.positionREP().eta()) > 0.34 ) {
-      cell_layer *= 100;
-    }    
-
-  auto const& thresholds = _thresholds.find(cell_layer)->second;
-  double thresholdE=0.;
-  double thresholdPT2=0.;
-
-  for (unsigned int j=0; j<(std::get<1>(thresholds)).size(); ++j) {
-    int depth=std::get<0>(thresholds)[j];
-
-    if( ( cell_layer == PFLayer::HCAL_BARREL1 && cell.depth()== depth)
-	|| ( cell_layer == PFLayer::HCAL_ENDCAP && cell.depth()== depth)
-	|| ( cell_layer != PFLayer::HCAL_BARREL1 && cell_layer != PFLayer::HCAL_ENDCAP )
-	) { thresholdE=std::get<1>(thresholds)[j]; thresholdPT2=std::get<2>(thresholds)[j]; }
-
+  if (cell_layer == PFLayer::HCAL_BARREL2 && std::abs(cell.positionREP().eta()) > 0.34) {
+    cell_layer *= 100;
   }
 
-  if( cell.energy() < thresholdE ||
-      cell.pt2() < thresholdPT2  ) {
+  auto const& thresholds = _thresholds.find(cell_layer)->second;
+  double thresholdE = 0.;
+  double thresholdPT2 = 0.;
+
+  for (unsigned int j = 0; j < (std::get<1>(thresholds)).size(); ++j) {
+    int depth = std::get<0>(thresholds)[j];
+
+    if ((cell_layer == PFLayer::HCAL_BARREL1 && cell.depth() == depth) ||
+        (cell_layer == PFLayer::HCAL_ENDCAP && cell.depth() == depth) ||
+        (cell_layer != PFLayer::HCAL_BARREL1 && cell_layer != PFLayer::HCAL_ENDCAP)) {
+      thresholdE = std::get<1>(thresholds)[j];
+      thresholdPT2 = std::get<2>(thresholds)[j];
+    }
+  }
+
+  if (cell.energy() < thresholdE || cell.pt2() < thresholdPT2) {
     LOGDRESSED("GenericTopoCluster::buildTopoCluster()")
-      << "RecHit " << cell.detId() << " with enegy "
-      << cell.energy() << " GeV was rejected!." << std::endl;
+        << "RecHit " << cell.detId() << " with enegy " << cell.energy() << " GeV was rejected!." << std::endl;
     return;
   }
 
-
   auto k = kcell;
   used[k] = true;
-  auto ref = makeRefhit(input,k);
+  auto ref = makeRefhit(input, k);
   topocluster.addRecHitFraction(reco::PFRecHitFraction(ref, 1.0));
-  
-  auto const & neighbours = 
-    ( _useCornerCells ? cell.neighbours8() : cell.neighbours4() );
-  
-  for( auto nb : neighbours ) {
-    if( used[nb] || !rechitMask[nb] ) {
+
+  auto const& neighbours = (_useCornerCells ? cell.neighbours8() : cell.neighbours4());
+
+  for (auto nb : neighbours) {
+    if (used[nb] || !rechitMask[nb]) {
       LOGDRESSED("GenericTopoCluster::buildTopoCluster()")
-      	<< "  RecHit " << cell.detId() << "\'s" 
-	<< " neighbor RecHit " << input->at(nb).detId() 
-	<< " with enegy " 
-	<< input->at(nb).energy() << " GeV was rejected!" 
-	<< " Reasons : " << used[nb] << " (used) " 
-	<< !rechitMask[nb] << " (masked)." << std::endl;
+          << "  RecHit " << cell.detId() << "\'s"
+          << " neighbor RecHit " << input->at(nb).detId() << " with enegy " << input->at(nb).energy()
+          << " GeV was rejected!"
+          << " Reasons : " << used[nb] << " (used) " << !rechitMask[nb] << " (masked)." << std::endl;
       continue;
     }
-    buildTopoCluster(input,rechitMask,nb,used,topocluster);
+    buildTopoCluster(input, rechitMask, nb, used, topocluster);
   }
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericTopoClusterizer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Basic2DGenericTopoClusterizer.h
@@ -6,32 +6,28 @@
 
 class Basic2DGenericTopoClusterizer : public InitialClusteringStepBase {
   typedef Basic2DGenericTopoClusterizer B2DGT;
- public:
-  Basic2DGenericTopoClusterizer(const edm::ParameterSet& conf,
-				edm::ConsumesCollector& sumes) :
-    InitialClusteringStepBase(conf,sumes),
-    _useCornerCells(conf.getParameter<bool>("useCornerCells")) { }
+
+public:
+  Basic2DGenericTopoClusterizer(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+      : InitialClusteringStepBase(conf, sumes), _useCornerCells(conf.getParameter<bool>("useCornerCells")) {}
   ~Basic2DGenericTopoClusterizer() override = default;
   Basic2DGenericTopoClusterizer(const B2DGT&) = delete;
   B2DGT& operator=(const B2DGT&) = delete;
 
   void buildClusters(const edm::Handle<reco::PFRecHitCollection>&,
-		     const std::vector<bool>&,
-		     const std::vector<bool>&, 
-		     reco::PFClusterCollection&) override;
-  
- private:  
+                     const std::vector<bool>&,
+                     const std::vector<bool>&,
+                     reco::PFClusterCollection&) override;
+
+private:
   const bool _useCornerCells;
   void buildTopoCluster(const edm::Handle<reco::PFRecHitCollection>&,
-			const std::vector<bool>&, // masked rechits
-			unsigned int, //present rechit
-			std::vector<bool>&, // hit usage state
-			reco::PFCluster&); // the topocluster
-  
+                        const std::vector<bool>&,  // masked rechits
+                        unsigned int,              //present rechit
+                        std::vector<bool>&,        // hit usage state
+                        reco::PFCluster&);         // the topocluster
 };
 
-DEFINE_EDM_PLUGIN(InitialClusteringStepFactory,
-		  Basic2DGenericTopoClusterizer,
-		  "Basic2DGenericTopoClusterizer");
+DEFINE_EDM_PLUGIN(InitialClusteringStepFactory, Basic2DGenericTopoClusterizer, "Basic2DGenericTopoClusterizer");
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/Cluster3DPCACalculator.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Cluster3DPCACalculator.cc
@@ -15,51 +15,43 @@
 #include "TPrincipal.h"
 
 class Cluster3DPCACalculator : public PFCPositionCalculatorBase {
- public:
-  Cluster3DPCACalculator(const edm::ParameterSet& conf) :
-    PFCPositionCalculatorBase(conf),
-    updateTiming_(conf.getParameter<bool>("updateTiming")),
-    pca_(new TPrincipal(3,"D")){
-  }
+public:
+  Cluster3DPCACalculator(const edm::ParameterSet& conf)
+      : PFCPositionCalculatorBase(conf),
+        updateTiming_(conf.getParameter<bool>("updateTiming")),
+        pca_(new TPrincipal(3, "D")) {}
   Cluster3DPCACalculator(const Cluster3DPCACalculator&) = delete;
   Cluster3DPCACalculator& operator=(const Cluster3DPCACalculator&) = delete;
 
   void calculateAndSetPosition(reco::PFCluster&) override;
   void calculateAndSetPositions(reco::PFClusterCollection&) override;
 
- private:
+private:
   const bool updateTiming_;
   std::unique_ptr<TPrincipal> pca_;
 
-  void showerParameters(const reco::PFCluster&, math::XYZPoint&,
-			math::XYZVector& );
+  void showerParameters(const reco::PFCluster&, math::XYZPoint&, math::XYZVector&);
 
   void calculateAndSetPositionActual(reco::PFCluster&);
 };
 
-DEFINE_EDM_PLUGIN(PFCPositionCalculatorFactory,
-		  Cluster3DPCACalculator,
-		  "Cluster3DPCACalculator");
+DEFINE_EDM_PLUGIN(PFCPositionCalculatorFactory, Cluster3DPCACalculator, "Cluster3DPCACalculator");
 
-void Cluster3DPCACalculator::
-calculateAndSetPosition(reco::PFCluster& cluster) {
-  pca_.reset(new TPrincipal(3,"D"));
+void Cluster3DPCACalculator::calculateAndSetPosition(reco::PFCluster& cluster) {
+  pca_.reset(new TPrincipal(3, "D"));
   calculateAndSetPositionActual(cluster);
 }
 
-void Cluster3DPCACalculator::
-calculateAndSetPositions(reco::PFClusterCollection& clusters) {
-  for( reco::PFCluster& cluster : clusters ) {
-    pca_.reset(new TPrincipal(3,"D"));
+void Cluster3DPCACalculator::calculateAndSetPositions(reco::PFClusterCollection& clusters) {
+  for (reco::PFCluster& cluster : clusters) {
+    pca_.reset(new TPrincipal(3, "D"));
     calculateAndSetPositionActual(cluster);
   }
 }
 
-void Cluster3DPCACalculator::
-calculateAndSetPositionActual(reco::PFCluster& cluster) {
-  if( !cluster.seed() ) {
-    throw cms::Exception("ClusterWithNoSeed")
-      << " Found a cluster with no seed: " << cluster;
+void Cluster3DPCACalculator::calculateAndSetPositionActual(reco::PFCluster& cluster) {
+  if (!cluster.seed()) {
+    throw cms::Exception("ClusterWithNoSeed") << " Found a cluster with no seed: " << cluster;
   }
   double cl_energy = 0;
   double max_e = 0.0;
@@ -69,42 +61,41 @@ calculateAndSetPositionActual(reco::PFCluster& cluster) {
   reco::PFRecHitRef refseed;
   double pcavars[3];
 
-  for( const reco::PFRecHitFraction& rhf : cluster.recHitFractions() ) {
+  for (const reco::PFRecHitFraction& rhf : cluster.recHitFractions()) {
     const reco::PFRecHitRef& refhit = rhf.recHitRef();
     double rh_energy = refhit->energy();
     double rh_time = refhit->time();
     cl_energy += rh_energy * rhf.fraction();
-    if( rh_time > 0.0 ) { // time == -1 means no measurement
+    if (rh_time > 0.0) {  // time == -1 means no measurement
       // all times are offset by one nanosecond in digitizer
       // remove that here so all times of flight
       // are with respect to (0,0,0)
       avg_time += (rh_time - 1.0);
       time_norm += 1.0;
     }
-    if( rh_energy > max_e ) {
+    if (rh_energy > max_e) {
       max_e = rh_energy;
       max_e_layer = rhf.recHitRef()->layer();
     }
-    if( refhit->detId() == cluster.seed() ) refseed = refhit;
+    if (refhit->detId() == cluster.seed())
+      refseed = refhit;
     const double rh_fraction = rhf.fraction();
-    rh_energy = refhit->energy()*rh_fraction;
-    if( edm::isNotFinite(rh_energy) ) {
-//temporarily changed exception to warning
-//      throw cms::Exception("PFClusterAlgo")
-      edm::LogWarning("PFClusterAlgo")
-      <<"rechit " << refhit->detId() << " has a NaN energy... "
-      << "The input of the particle flow clustering seems to be corrupted.";
+    rh_energy = refhit->energy() * rh_fraction;
+    if (edm::isNotFinite(rh_energy)) {
+      //temporarily changed exception to warning
+      //      throw cms::Exception("PFClusterAlgo")
+      edm::LogWarning("PFClusterAlgo") << "rechit " << refhit->detId() << " has a NaN energy... "
+                                       << "The input of the particle flow clustering seems to be corrupted.";
       continue;
     }
     pcavars[0] = refhit->position().x();
     pcavars[1] = refhit->position().y();
     pcavars[2] = refhit->position().z();
-    int nhit = int( rh_energy*100 ); // put rec_hit energy in units of 10 MeV
+    int nhit = int(rh_energy * 100);  // put rec_hit energy in units of 10 MeV
 
-    for( int i = 0; i < nhit; ++i ) {
+    for (int i = 0; i < nhit; ++i) {
       pca_->AddRow(pcavars);
     }
-
   }
   cluster.setEnergy(cl_energy);
   cluster.setLayer(max_e_layer);
@@ -114,17 +105,17 @@ calculateAndSetPositionActual(reco::PFCluster& cluster) {
   const TVectorD& means = *(pca_->GetMeanValues());
   const TMatrixD& eigens = *(pca_->GetEigenVectors());
 
-  math::XYZPoint  barycenter(means[0],means[1],means[2]);
-  math::XYZVector axis(eigens(0,0),eigens(1,0),eigens(2,0));
+  math::XYZPoint barycenter(means[0], means[1], means[2]);
+  math::XYZVector axis(eigens(0, 0), eigens(1, 0), eigens(2, 0));
 
-  if( time_norm > 0.0 ) {
-    avg_time = avg_time/time_norm;
+  if (time_norm > 0.0) {
+    avg_time = avg_time / time_norm;
   } else {
     avg_time = std::numeric_limits<double>::min();
   }
 
-  if( axis.z()*barycenter.z() < 0.0 ) {
-    axis = math::XYZVector(-eigens(0,0),-eigens(1,0),-eigens(2,0));
+  if (axis.z() * barycenter.z() < 0.0) {
+    axis = math::XYZVector(-eigens(0, 0), -eigens(1, 0), -eigens(2, 0));
   }
 
   if (updateTiming_) {
@@ -132,5 +123,4 @@ calculateAndSetPositionActual(reco::PFCluster& cluster) {
   }
   cluster.setPosition(barycenter);
   cluster.calculatePositionREP();
-
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
@@ -20,39 +20,37 @@
 
 namespace {
   typedef reco::PFCluster::EEtoPSAssociation::value_type EEPSPair;
-  bool sortByKey(const EEPSPair& a, const EEPSPair& b) {
-    return a.first < b.first;
-  } 
+  bool sortByKey(const EEPSPair& a, const EEPSPair& b) { return a.first < b.first; }
 
   // why, why -1 and not <double>::max() ????
-  double testPreshowerDistance(reco::PFCluster const & eeclus,
-			       reco::PFCluster const & psclus) {
-    auto const & pspos = psclus.positionREP();
-    auto const & eepos = eeclus.positionREP();
+  double testPreshowerDistance(reco::PFCluster const& eeclus, reco::PFCluster const& psclus) {
+    auto const& pspos = psclus.positionREP();
+    auto const& eepos = eeclus.positionREP();
     // lazy continue based on geometry
-    if( eeclus.z()*psclus.z() < 0 ) return -1.0;
-    auto deta= std::abs(eepos.eta() - pspos.eta());
-    if( deta > 0.3 ) return -1.0;
-    auto dphi= std::abs(deltaPhi(eepos.phi(),  pspos.phi()));
-    if( dphi > 0.6 ) return -1.0;    
-    return LinkByRecHit::testECALAndPSByRecHit(eeclus,psclus,false);
+    if (eeclus.z() * psclus.z() < 0)
+      return -1.0;
+    auto deta = std::abs(eepos.eta() - pspos.eta());
+    if (deta > 0.3)
+      return -1.0;
+    auto dphi = std::abs(deltaPhi(eepos.phi(), pspos.phi()));
+    if (dphi > 0.6)
+      return -1.0;
+    return LinkByRecHit::testECALAndPSByRecHit(eeclus, psclus, false);
   }
-}
+}  // namespace
 
 class CorrectedECALPFClusterProducer : public edm::stream::EDProducer<> {
-public: 
-  CorrectedECALPFClusterProducer(const edm::ParameterSet& conf):
-    _minimumPSEnergy(conf.getParameter<double>("minimumPSEnergy")) {
-    const edm::InputTag&  inputECAL = 
-      conf.getParameter<edm::InputTag>("inputECAL");    
-    _inputECAL = consumes<reco::PFClusterCollection>( inputECAL );
+public:
+  CorrectedECALPFClusterProducer(const edm::ParameterSet& conf)
+      : _minimumPSEnergy(conf.getParameter<double>("minimumPSEnergy")) {
+    const edm::InputTag& inputECAL = conf.getParameter<edm::InputTag>("inputECAL");
+    _inputECAL = consumes<reco::PFClusterCollection>(inputECAL);
 
-    const edm::InputTag& inputPS = 
-      conf.getParameter<edm::InputTag>("inputPS");
-    _inputPS = consumes<reco::PFClusterCollection>( inputPS );
+    const edm::InputTag& inputPS = conf.getParameter<edm::InputTag>("inputPS");
+    _inputPS = consumes<reco::PFClusterCollection>(inputPS);
 
     const edm::ParameterSet& corConf = conf.getParameterSet("energyCorrector");
-    _corrector.reset(new PFClusterEMEnergyCorrector(corConf,consumesCollector()));
+    _corrector.reset(new PFClusterEMEnergyCorrector(corConf, consumesCollector()));
 
     produces<reco::PFCluster::EEtoPSAssociation>();
     produces<reco::PFClusterCollection>();
@@ -70,53 +68,54 @@ private:
 
 DEFINE_FWK_MODULE(CorrectedECALPFClusterProducer);
 
-void CorrectedECALPFClusterProducer::
-produce(edm::Event& e, const edm::EventSetup& es) {
+void CorrectedECALPFClusterProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   auto clusters_out = std::make_unique<reco::PFClusterCollection>();
   auto association_out = std::make_unique<reco::PFCluster::EEtoPSAssociation>();
-  
-  edm::Handle<reco::PFClusterCollection> handleECAL;
-  e.getByToken(_inputECAL,handleECAL);
-  edm::Handle<reco::PFClusterCollection> handlePS;
-  e.getByToken(_inputPS,handlePS);
 
-  auto const & ecals = *handleECAL;
-  auto const & pss = *handlePS;
+  edm::Handle<reco::PFClusterCollection> handleECAL;
+  e.getByToken(_inputECAL, handleECAL);
+  edm::Handle<reco::PFClusterCollection> handlePS;
+  e.getByToken(_inputPS, handlePS);
+
+  auto const& ecals = *handleECAL;
+  auto const& pss = *handlePS;
 
   clusters_out->reserve(ecals.size());
   association_out->reserve(ecals.size());
-  clusters_out->insert(clusters_out->end(),
-		       ecals.begin(),ecals.end());
+  clusters_out->insert(clusters_out->end(), ecals.begin(), ecals.end());
   //build the EE->PS association
-  for( unsigned i = 0; i < pss.size(); ++i ) {      
-    switch( pss[i].layer() ) { // just in case this isn't the ES...
-    case PFLayer::PS1:
-    case PFLayer::PS2:
-      break;
-    default:
+  for (unsigned i = 0; i < pss.size(); ++i) {
+    switch (pss[i].layer()) {  // just in case this isn't the ES...
+      case PFLayer::PS1:
+      case PFLayer::PS2:
+        break;
+      default:
+        continue;
+    }
+    if (pss[i].energy() < _minimumPSEnergy)
       continue;
-    }    
-    if(  pss[i].energy() < _minimumPSEnergy ) continue;
     int eematch = -1;
     auto min_dist = std::numeric_limits<double>::max();
-    for( size_t ic = 0; ic < ecals.size(); ++ic ) {
-      if( ecals[ic].layer() != PFLayer::ECAL_ENDCAP ) continue;
-      auto dist = testPreshowerDistance(ecals[ic],pss[i]);      
-      if (dist == -1.0) dist=std::numeric_limits<double>::max(); 
-      if( dist < min_dist ) {
-	eematch = ic;
-	min_dist = dist;
+    for (size_t ic = 0; ic < ecals.size(); ++ic) {
+      if (ecals[ic].layer() != PFLayer::ECAL_ENDCAP)
+        continue;
+      auto dist = testPreshowerDistance(ecals[ic], pss[i]);
+      if (dist == -1.0)
+        dist = std::numeric_limits<double>::max();
+      if (dist < min_dist) {
+        eematch = ic;
+        min_dist = dist;
       }
-    } // loop on EE clusters      
-    if( eematch>=0 ) {
-      edm::Ptr<reco::PFCluster> psclus(handlePS,i);
-      association_out->push_back(std::make_pair(eematch,psclus));
+    }  // loop on EE clusters
+    if (eematch >= 0) {
+      edm::Ptr<reco::PFCluster> psclus(handlePS, i);
+      association_out->push_back(std::make_pair(eematch, psclus));
     }
   }
-  std::sort(association_out->begin(),association_out->end(),sortByKey);
-  
-  _corrector->correctEnergies(e,es,*association_out,*clusters_out);
-  
+  std::sort(association_out->begin(), association_out->end(), sortByKey);
+
+  _corrector->correctEnergies(e, es, *association_out, *clusters_out);
+
   association_out->shrink_to_fit();
 
   e.put(std::move(association_out));
@@ -125,26 +124,26 @@ produce(edm::Event& e, const edm::EventSetup& es) {
 
 void CorrectedECALPFClusterProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  desc.add<double>("minimumPSEnergy",0.0);
-  desc.add<edm::InputTag>("inputPS",edm::InputTag("particleFlowClusterPS"));
+  desc.add<double>("minimumPSEnergy", 0.0);
+  desc.add<edm::InputTag>("inputPS", edm::InputTag("particleFlowClusterPS"));
   {
     edm::ParameterSetDescription psd0;
-    psd0.add<bool>("applyCrackCorrections",false);
-    psd0.add<bool>("applyMVACorrections",false);
-    psd0.add<bool>("srfAwareCorrection",false);    
-    psd0.add<bool>("autoDetectBunchSpacing",true);
-    psd0.add<int>("bunchSpacing",25);
-    psd0.add<double>("maxPtForMVAEvaluation",-99.);
-    psd0.add<std::string>("algoName","PFClusterEMEnergyCorrector");
-    psd0.add<edm::InputTag>("recHitsEBLabel",edm::InputTag("ecalRecHit","EcalRecHitsEB"));
-    psd0.add<edm::InputTag>("recHitsEELabel",edm::InputTag("ecalRecHit","EcalRecHitsEE"));
-    psd0.add<edm::InputTag>("verticesLabel",edm::InputTag("offlinePrimaryVertices"));
-    psd0.add<edm::InputTag>("ebSrFlagLabel",edm::InputTag("ecalDigis"));
-    psd0.add<edm::InputTag>("eeSrFlagLabel",edm::InputTag("ecalDigis"));
-    desc.add<edm::ParameterSetDescription>("energyCorrector",psd0);
+    psd0.add<bool>("applyCrackCorrections", false);
+    psd0.add<bool>("applyMVACorrections", false);
+    psd0.add<bool>("srfAwareCorrection", false);
+    psd0.add<bool>("autoDetectBunchSpacing", true);
+    psd0.add<int>("bunchSpacing", 25);
+    psd0.add<double>("maxPtForMVAEvaluation", -99.);
+    psd0.add<std::string>("algoName", "PFClusterEMEnergyCorrector");
+    psd0.add<edm::InputTag>("recHitsEBLabel", edm::InputTag("ecalRecHit", "EcalRecHitsEB"));
+    psd0.add<edm::InputTag>("recHitsEELabel", edm::InputTag("ecalRecHit", "EcalRecHitsEE"));
+    psd0.add<edm::InputTag>("verticesLabel", edm::InputTag("offlinePrimaryVertices"));
+    psd0.add<edm::InputTag>("ebSrFlagLabel", edm::InputTag("ecalDigis"));
+    psd0.add<edm::InputTag>("eeSrFlagLabel", edm::InputTag("ecalDigis"));
+    desc.add<edm::ParameterSetDescription>("energyCorrector", psd0);
   }
-  desc.add<edm::InputTag>("inputECAL",edm::InputTag("particleFlowClusterECALUncorrected"));
-  descriptions.add("particleFlowClusterECAL",desc);
+  desc.add<edm::InputTag>("inputECAL", edm::InputTag("particleFlowClusterECALUncorrected"));
+  descriptions.add("particleFlowClusterECAL", desc);
 }
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/ECAL2DPositionCalcWithDepthCorr.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/ECAL2DPositionCalcWithDepthCorr.cc
@@ -15,174 +15,162 @@
 // faithful reimplementation of RecoEcal/EgammaCoreTools PositionCalc
 // sorry Stefano
 
-void ECAL2DPositionCalcWithDepthCorr::
-update(const edm::EventSetup& es) {
-  
-    const CaloGeometryRecord& caloGeom = es.get<CaloGeometryRecord>();
-    edm::ESHandle<CaloGeometry> geohandle;
-    caloGeom.get(geohandle);
-    _ebGeom = geohandle->getSubdetectorGeometry(DetId::Ecal,EcalBarrel);
-    _eeGeom = geohandle->getSubdetectorGeometry(DetId::Ecal,EcalEndcap);
-    _esGeom = geohandle->getSubdetectorGeometry(DetId::Ecal,EcalPreshower);
-    if(_esGeom){
-      // ripped from RecoEcal/EgammaCoreTools 
-      for( uint32_t ic = 0; 
-	   ic < _esGeom->getValidDetIds().size() && 
-	     ( !_esPlus || !_esMinus ); ++ic ) {
-        const double z = _esGeom->getGeometry( _esGeom->getValidDetIds()[ic] )->getPosition().z();
-        _esPlus = _esPlus || ( 0 < z ) ;
-        _esMinus = _esMinus || ( 0 > z ) ;
-      }  
+void ECAL2DPositionCalcWithDepthCorr::update(const edm::EventSetup& es) {
+  const CaloGeometryRecord& caloGeom = es.get<CaloGeometryRecord>();
+  edm::ESHandle<CaloGeometry> geohandle;
+  caloGeom.get(geohandle);
+  _ebGeom = geohandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
+  _eeGeom = geohandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
+  _esGeom = geohandle->getSubdetectorGeometry(DetId::Ecal, EcalPreshower);
+  if (_esGeom) {
+    // ripped from RecoEcal/EgammaCoreTools
+    for (uint32_t ic = 0; ic < _esGeom->getValidDetIds().size() && (!_esPlus || !_esMinus); ++ic) {
+      const double z = _esGeom->getGeometry(_esGeom->getValidDetIds()[ic])->getPosition().z();
+      _esPlus = _esPlus || (0 < z);
+      _esMinus = _esMinus || (0 > z);
     }
+  }
 }
 
-void ECAL2DPositionCalcWithDepthCorr::
-calculateAndSetPosition(reco::PFCluster& cluster) {
+void ECAL2DPositionCalcWithDepthCorr::calculateAndSetPosition(reco::PFCluster& cluster) {
   calculateAndSetPositionActual(cluster);
 }
 
-void ECAL2DPositionCalcWithDepthCorr::
-calculateAndSetPositions(reco::PFClusterCollection& clusters) {
-  for( reco::PFCluster& cluster : clusters ) {
+void ECAL2DPositionCalcWithDepthCorr::calculateAndSetPositions(reco::PFClusterCollection& clusters) {
+  for (reco::PFCluster& cluster : clusters) {
     calculateAndSetPositionActual(cluster);
   }
 }
 
-void ECAL2DPositionCalcWithDepthCorr::
-calculateAndSetPositionActual(reco::PFCluster& cluster) const {  
-  constexpr double preshowerStartEta =  1.653;
+void ECAL2DPositionCalcWithDepthCorr::calculateAndSetPositionActual(reco::PFCluster& cluster) const {
+  constexpr double preshowerStartEta = 1.653;
   constexpr double preshowerEndEta = 2.6;
-  if( !cluster.seed() ) {
-    throw cms::Exception("ClusterWithNoSeed")
-      << " Found a cluster with no seed: " << cluster;
-  }  				
-  double cl_energy = 0;  
+  if (!cluster.seed()) {
+    throw cms::Exception("ClusterWithNoSeed") << " Found a cluster with no seed: " << cluster;
+  }
+  double cl_energy = 0;
   double cl_energy_float = 0;
-  double cl_time = 0;  
-  double cl_timeweight=0.0;
-  double max_e = 0.0;  
+  double cl_time = 0;
+  double cl_timeweight = 0.0;
+  double max_e = 0.0;
   double clusterT0 = 0.0;
   PFLayer::Layer max_e_layer = PFLayer::NONE;
-  reco::PFRecHitRef refmax;  
+  reco::PFRecHitRef refmax;
   // find the seed and max layer
-  for( const reco::PFRecHitFraction& rhf : cluster.recHitFractions() ) {
+  for (const reco::PFRecHitFraction& rhf : cluster.recHitFractions()) {
     const reco::PFRecHitRef& refhit = rhf.recHitRef();
     const double rh_fraction = rhf.fraction();
     const double rh_rawenergy = refhit->energy();
-    const double rh_energy = rh_rawenergy * rh_fraction;    
-    const double rh_energyf = ((float)rh_rawenergy) * ((float) rh_fraction);
-    if( !edm::isFinite(rh_energy) ) {
-      throw cms::Exception("PFClusterAlgo")
-	<<"rechit " << refhit->detId() << " has non-finite energy... " 
-	<< "The input of the particle flow clustering seems to be corrupted.";
+    const double rh_energy = rh_rawenergy * rh_fraction;
+    const double rh_energyf = ((float)rh_rawenergy) * ((float)rh_fraction);
+    if (!edm::isFinite(rh_energy)) {
+      throw cms::Exception("PFClusterAlgo") << "rechit " << refhit->detId() << " has non-finite energy... "
+                                            << "The input of the particle flow clustering seems to be corrupted.";
     }
     cl_energy += rh_energy;
     cl_energy_float += rh_energyf;
     // If time resolution is given, calculate weighted average
     if (_timeResolutionCalc) {
-      const double res2 = 1./_timeResolutionCalc->timeResolution2(rh_rawenergy);
-      cl_time += rh_fraction*refhit->time()*res2;
-      cl_timeweight += rh_fraction*res2;
+      const double res2 = 1. / _timeResolutionCalc->timeResolution2(rh_rawenergy);
+      cl_time += rh_fraction * refhit->time() * res2;
+      cl_timeweight += rh_fraction * res2;
+    } else {  // assume resolution ~ 1/E**2
+      const double rh_rawenergy2 = rh_rawenergy * rh_rawenergy;
+      cl_timeweight += rh_rawenergy2 * rh_fraction;
+      cl_time += rh_rawenergy2 * rh_fraction * refhit->time();
     }
-    else { // assume resolution ~ 1/E**2
-      const double rh_rawenergy2 = rh_rawenergy*rh_rawenergy;
-      cl_timeweight+=rh_rawenergy2*rh_fraction;
-      cl_time += rh_rawenergy2*rh_fraction*refhit->time();
-    }
-    if( rh_energy > max_e ) {
+    if (rh_energy > max_e) {
       max_e = rh_energy;
       max_e_layer = rhf.recHitRef()->layer();
       refmax = refhit;
-    }    
+    }
   }
   cluster.setEnergy(cl_energy);
-  cluster.setTime(cl_time/cl_timeweight);
+  cluster.setTime(cl_time / cl_timeweight);
   if (_timeResolutionCalc) {
-    cluster.setTimeError(std::sqrt(1.0f/float(cl_timeweight)));
+    cluster.setTimeError(std::sqrt(1.0f / float(cl_timeweight)));
   }
   cluster.setLayer(max_e_layer);
   const CaloSubdetectorGeometry* ecal_geom = nullptr;
-  // get seed geometry information  
-  switch(max_e_layer){
-  case PFLayer::ECAL_BARREL:
-    ecal_geom = _ebGeom;
-    clusterT0 = _param_T0_EB;
-    break;
-  case PFLayer::ECAL_ENDCAP:
-    ecal_geom = _eeGeom;
-    clusterT0 = _param_T0_EE;        
-    break;
-  default:
-    throw cms::Exception("InvalidLayer")
-      << "ECAL Position Calc only accepts ECAL_BARREL or ECAL_ENDCAP";
+  // get seed geometry information
+  switch (max_e_layer) {
+    case PFLayer::ECAL_BARREL:
+      ecal_geom = _ebGeom;
+      clusterT0 = _param_T0_EB;
+      break;
+    case PFLayer::ECAL_ENDCAP:
+      ecal_geom = _eeGeom;
+      clusterT0 = _param_T0_EE;
+      break;
+    default:
+      throw cms::Exception("InvalidLayer") << "ECAL Position Calc only accepts ECAL_BARREL or ECAL_ENDCAP";
   }
 
   auto center_cell = ecal_geom->getGeometry(refmax->detId());
   const double ctreta = center_cell->etaPos();
   const double actreta = std::abs(ctreta);
   // need to change T0 if in ES
-  if( actreta > preshowerStartEta && actreta < preshowerEndEta ) { 
-    if(ctreta > 0 && _esPlus ) clusterT0 = _param_T0_ES;
-    if(ctreta < 0 && _esMinus) clusterT0 = _param_T0_ES;
-  }  
+  if (actreta > preshowerStartEta && actreta < preshowerEndEta) {
+    if (ctreta > 0 && _esPlus)
+      clusterT0 = _param_T0_ES;
+    if (ctreta < 0 && _esMinus)
+      clusterT0 = _param_T0_ES;
+  }
   // floats to reproduce exactly the EGM code
-  const float maxDepth = _param_X0*(clusterT0 + vdt::fast_log(cl_energy_float));
-  const float maxToFront = center_cell->getPosition().mag();  
+  const float maxDepth = _param_X0 * (clusterT0 + vdt::fast_log(cl_energy_float));
+  const float maxToFront = center_cell->getPosition().mag();
   // calculate the position
   const double logETot_inv = -vdt::fast_log(cl_energy_float);
   double position_norm = 0.0;
-  double x(0.0),y(0.0),z(0.0);  
-  for( const reco::PFRecHitFraction& rhf : cluster.recHitFractions() ) {
+  double x(0.0), y(0.0), z(0.0);
+  for (const reco::PFRecHitFraction& rhf : cluster.recHitFractions()) {
     double weight = 0.0;
     const reco::PFRecHitRef& refhit = rhf.recHitRef();
     const double rh_energy = ((float)refhit->energy()) * ((float)rhf.fraction());
-    if( rh_energy > 0.0 ) weight = std::max(0.0,( _param_W0 + 
-						  vdt::fast_log(rh_energy) + 
-						  logETot_inv ));
+    if (rh_energy > 0.0)
+      weight = std::max(0.0, (_param_W0 + vdt::fast_log(rh_energy) + logETot_inv));
     auto cell = ecal_geom->getGeometry(refhit->detId());
-    const float depth = maxDepth + maxToFront - cell->getPosition().mag();    
-    const GlobalPoint pos =
-      static_cast<const TruncatedPyramid*>(cell.get())->getPosition(depth);
+    const float depth = maxDepth + maxToFront - cell->getPosition().mag();
+    const GlobalPoint pos = static_cast<const TruncatedPyramid*>(cell.get())->getPosition(depth);
 
-    x += weight*pos.x() ;
-    y += weight*pos.y() ;
-    z += weight*pos.z() ;
+    x += weight * pos.x();
+    y += weight * pos.y();
+    z += weight * pos.z();
 
-    position_norm += weight ;
+    position_norm += weight;
   }
-  
+
   // FALL BACK to LINEAR WEIGHTS
   if (position_norm == 0.) {
-    for( const reco::PFRecHitFraction& rhf : cluster.recHitFractions() ) {
+    for (const reco::PFRecHitFraction& rhf : cluster.recHitFractions()) {
       double weight = 0.0;
       const reco::PFRecHitRef& refhit = rhf.recHitRef();
       const double rh_energy = ((float)refhit->energy()) * ((float)rhf.fraction());
-      if( rh_energy > 0.0 ) 
-	weight = rh_energy/cluster.energy();
+      if (rh_energy > 0.0)
+        weight = rh_energy / cluster.energy();
 
       auto cell = ecal_geom->getGeometry(refhit->detId());
       const float depth = maxDepth + maxToFront - cell->getPosition().mag();
       const GlobalPoint pos = cell->getPosition(depth);
-      
-      x += weight*pos.x() ;
-      y += weight*pos.y() ;
-      z += weight*pos.z() ;
 
-      position_norm += weight ;
+      x += weight * pos.x();
+      y += weight * pos.y();
+      z += weight * pos.z();
+
+      position_norm += weight;
     }
   }
 
-  if( position_norm < _minAllowedNorm ) {
-    edm::LogError("WeirdClusterNormalization") 
-      << "PFCluster too far from seeding cell: set position to (0,0,0).";
-    cluster.setPosition(math::XYZPoint(0,0,0));
+  if (position_norm < _minAllowedNorm) {
+    edm::LogError("WeirdClusterNormalization") << "PFCluster too far from seeding cell: set position to (0,0,0).";
+    cluster.setPosition(math::XYZPoint(0, 0, 0));
   } else {
-    const double norm_inverse = 1.0/position_norm;
+    const double norm_inverse = 1.0 / position_norm;
     x *= norm_inverse;
     y *= norm_inverse;
     z *= norm_inverse;
 
-    cluster.setPosition(math::XYZPoint(x,y,z));
+    cluster.setPosition(math::XYZPoint(x, y, z));
     cluster.calculatePositionREP();
   }
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/ECAL2DPositionCalcWithDepthCorr.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/ECAL2DPositionCalcWithDepthCorr.h
@@ -15,27 +15,26 @@
 
 /// This is EGM version of the ECAL position + depth correction calculation
 class ECAL2DPositionCalcWithDepthCorr : public PFCPositionCalculatorBase {
- public:
-  ECAL2DPositionCalcWithDepthCorr(const edm::ParameterSet& conf) :
-    PFCPositionCalculatorBase(conf), 
-    _param_T0_EB(conf.getParameter<double>("T0_EB")),
-    _param_T0_EE(conf.getParameter<double>("T0_EE")),
-    _param_T0_ES(conf.getParameter<double>("T0_ES")),
-    _param_W0(conf.getParameter<double>("W0")),
-    _param_X0(conf.getParameter<double>("X0")),
-    _minAllowedNorm(conf.getParameter<double>("minAllowedNormalization")),
-    _ebGeom(nullptr),
-    _eeGeom(nullptr),
-    _esGeom(nullptr),
-    _esPlus(false),
-    _esMinus(false) {
-        _timeResolutionCalc.reset(nullptr);
-    if( conf.exists("timeResolutionCalc") ) {
-      const edm::ParameterSet& timeResConf = 
-        conf.getParameterSet("timeResolutionCalc");
-        _timeResolutionCalc.reset(new CaloRecHitResolutionProvider(timeResConf)); 
-      }
+public:
+  ECAL2DPositionCalcWithDepthCorr(const edm::ParameterSet& conf)
+      : PFCPositionCalculatorBase(conf),
+        _param_T0_EB(conf.getParameter<double>("T0_EB")),
+        _param_T0_EE(conf.getParameter<double>("T0_EE")),
+        _param_T0_ES(conf.getParameter<double>("T0_ES")),
+        _param_W0(conf.getParameter<double>("W0")),
+        _param_X0(conf.getParameter<double>("X0")),
+        _minAllowedNorm(conf.getParameter<double>("minAllowedNormalization")),
+        _ebGeom(nullptr),
+        _eeGeom(nullptr),
+        _esGeom(nullptr),
+        _esPlus(false),
+        _esMinus(false) {
+    _timeResolutionCalc.reset(nullptr);
+    if (conf.exists("timeResolutionCalc")) {
+      const edm::ParameterSet& timeResConf = conf.getParameterSet("timeResolutionCalc");
+      _timeResolutionCalc.reset(new CaloRecHitResolutionProvider(timeResConf));
     }
+  }
   ECAL2DPositionCalcWithDepthCorr(const ECAL2DPositionCalcWithDepthCorr&) = delete;
   ECAL2DPositionCalcWithDepthCorr& operator=(const ECAL2DPositionCalcWithDepthCorr&) = delete;
 
@@ -44,7 +43,7 @@ class ECAL2DPositionCalcWithDepthCorr : public PFCPositionCalculatorBase {
   void calculateAndSetPosition(reco::PFCluster&) override;
   void calculateAndSetPositions(reco::PFClusterCollection&) override;
 
- private:  
+private:
   const double _param_T0_EB;
   const double _param_T0_EE;
   const double _param_T0_ES;
@@ -52,7 +51,6 @@ class ECAL2DPositionCalcWithDepthCorr : public PFCPositionCalculatorBase {
   const double _param_X0;
   const double _minAllowedNorm;
 
-  
   //const CaloGeometryRecord  _caloGeom;
   const CaloSubdetectorGeometry* _ebGeom;
   const CaloSubdetectorGeometry* _eeGeom;
@@ -60,12 +58,10 @@ class ECAL2DPositionCalcWithDepthCorr : public PFCPositionCalculatorBase {
   bool _esPlus, _esMinus;
 
   std::unique_ptr<CaloRecHitResolutionProvider> _timeResolutionCalc;
-  
+
   void calculateAndSetPositionActual(reco::PFCluster&) const;
 };
 
-DEFINE_EDM_PLUGIN(PFCPositionCalculatorFactory,
-		  ECAL2DPositionCalcWithDepthCorr,
-		  "ECAL2DPositionCalcWithDepthCorr");
+DEFINE_EDM_PLUGIN(PFCPositionCalculatorFactory, ECAL2DPositionCalcWithDepthCorr, "ECAL2DPositionCalcWithDepthCorr");
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.cc
@@ -7,42 +7,39 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 namespace {
-  const reco::PFRecHit::Neighbours  _noNeighbours(nullptr,0);
+  const reco::PFRecHit::Neighbours _noNeighbours(nullptr, 0);
 }
 
-LocalMaximumSeedFinder::
-LocalMaximumSeedFinder(const edm::ParameterSet& conf) : 
-  SeedFinderBase(conf),   
-  _nNeighbours(conf.getParameter<int>("nNeighbours")),
-  _layerMap({ {"PS2",(int)PFLayer::PS2},
-	      {"PS1",(int)PFLayer::PS1},
-	      {"ECAL_ENDCAP",(int)PFLayer::ECAL_ENDCAP},
-	      {"ECAL_BARREL",(int)PFLayer::ECAL_BARREL},
-	      {"NONE",(int)PFLayer::NONE},
-	      {"HCAL_BARREL1",(int)PFLayer::HCAL_BARREL1},
-	      {"HCAL_BARREL2_RING0",(int)PFLayer::HCAL_BARREL2},
-              // hack to deal with ring1 in HO 
-	      {"HCAL_BARREL2_RING1", 19}, 
-	      {"HCAL_ENDCAP",(int)PFLayer::HCAL_ENDCAP},
-	      {"HF_EM",(int)PFLayer::HF_EM},
-	      {"HF_HAD",(int)PFLayer::HF_HAD} }) {
-  const std::vector<edm::ParameterSet>& thresholds =
-    conf.getParameterSetVector("thresholdsByDetector");
-  for( const auto& pset : thresholds ) {
+LocalMaximumSeedFinder::LocalMaximumSeedFinder(const edm::ParameterSet& conf)
+    : SeedFinderBase(conf),
+      _nNeighbours(conf.getParameter<int>("nNeighbours")),
+      _layerMap({{"PS2", (int)PFLayer::PS2},
+                 {"PS1", (int)PFLayer::PS1},
+                 {"ECAL_ENDCAP", (int)PFLayer::ECAL_ENDCAP},
+                 {"ECAL_BARREL", (int)PFLayer::ECAL_BARREL},
+                 {"NONE", (int)PFLayer::NONE},
+                 {"HCAL_BARREL1", (int)PFLayer::HCAL_BARREL1},
+                 {"HCAL_BARREL2_RING0", (int)PFLayer::HCAL_BARREL2},
+                 // hack to deal with ring1 in HO
+                 {"HCAL_BARREL2_RING1", 19},
+                 {"HCAL_ENDCAP", (int)PFLayer::HCAL_ENDCAP},
+                 {"HF_EM", (int)PFLayer::HF_EM},
+                 {"HF_HAD", (int)PFLayer::HF_HAD}}) {
+  const std::vector<edm::ParameterSet>& thresholds = conf.getParameterSetVector("thresholdsByDetector");
+  for (const auto& pset : thresholds) {
     const std::string& det = pset.getParameter<std::string>("detector");
 
     std::vector<int> depths;
     std::vector<double> thresh_E;
-    std::vector<double> thresh_pT ;
+    std::vector<double> thresh_pT;
     std::vector<double> thresh_pT2;
 
-    if (det==std::string("HCAL_BARREL1") || det==std::string("HCAL_ENDCAP")) {
+    if (det == std::string("HCAL_BARREL1") || det == std::string("HCAL_ENDCAP")) {
       depths = pset.getParameter<std::vector<int> >("depths");
       thresh_E = pset.getParameter<std::vector<double> >("seedingThreshold");
       thresh_pT = pset.getParameter<std::vector<double> >("seedingThresholdPt");
-      if(thresh_E.size()!=depths.size() || thresh_pT.size()!=depths.size()) {
-	throw cms::Exception("InvalidGatheringThreshold")
-	  << "gatheringThresholds mismatch with the numbers of depths";
+      if (thresh_E.size() != depths.size() || thresh_pT.size() != depths.size()) {
+        throw cms::Exception("InvalidGatheringThreshold") << "gatheringThresholds mismatch with the numbers of depths";
       }
     } else {
       depths.push_back(0);
@@ -50,109 +47,103 @@ LocalMaximumSeedFinder(const edm::ParameterSet& conf) :
       thresh_pT.push_back(pset.getParameter<double>("seedingThresholdPt"));
     }
 
-    for(unsigned int i=0;i < thresh_pT.size();++i){
-      thresh_pT2.push_back(thresh_pT[i]*thresh_pT[i]);
+    for (unsigned int i = 0; i < thresh_pT.size(); ++i) {
+      thresh_pT2.push_back(thresh_pT[i] * thresh_pT[i]);
     }
 
     auto entry = _layerMap.find(det);
-    if( entry == _layerMap.end() ) {
-      throw cms::Exception("InvalidDetectorLayer")
-	<< "Detector layer : " << det << " is not in the list of recognized"
-	<< " detector layers!";
+    if (entry == _layerMap.end()) {
+      throw cms::Exception("InvalidDetectorLayer") << "Detector layer : " << det << " is not in the list of recognized"
+                                                   << " detector layers!";
     }
 
-    _thresholds[entry->second+layerOffset]= 
-      std::make_tuple(depths,thresh_E,thresh_pT2);
+    _thresholds[entry->second + layerOffset] = std::make_tuple(depths, thresh_E, thresh_pT2);
   }
 }
 
 // the starting state of seedable is all false!
-void LocalMaximumSeedFinder::
-findSeeds( const edm::Handle<reco::PFRecHitCollection>& input,
-	   const std::vector<bool>& mask,
-	   std::vector<bool>& seedable ) {
-
+void LocalMaximumSeedFinder::findSeeds(const edm::Handle<reco::PFRecHitCollection>& input,
+                                       const std::vector<bool>& mask,
+                                       std::vector<bool>& seedable) {
   auto nhits = input->size();
-  initDynArray(bool,nhits,usable,true);
+  initDynArray(bool, nhits, usable, true);
   //need to run over energy sorted rechits
-  declareDynArray(float,nhits,energies);
-  unInitDynArray(int,nhits,qst); // queue storage
+  declareDynArray(float, nhits, energies);
+  unInitDynArray(int, nhits, qst);  // queue storage
   auto cmp = [&](int i, int j) { return energies[i] < energies[j]; };
-  std::priority_queue<int, DynArray<int>, decltype(cmp)> ordered_hits(cmp,std::move(qst));
+  std::priority_queue<int, DynArray<int>, decltype(cmp)> ordered_hits(cmp, std::move(qst));
 
-  for( unsigned i = 0; i < nhits; ++i ) {
-    if( !mask[i] ) continue; // cannot seed masked objects
-    auto const & maybeseed = (*input)[i];
-    energies[i]=maybeseed.energy();
+  for (unsigned i = 0; i < nhits; ++i) {
+    if (!mask[i])
+      continue;  // cannot seed masked objects
+    auto const& maybeseed = (*input)[i];
+    energies[i] = maybeseed.energy();
     int seedlayer = (int)maybeseed.layer();
-    if( seedlayer == PFLayer::HCAL_BARREL2 &&
-        std::abs(maybeseed.positionREP().eta()) > 0.34 ) {
+    if (seedlayer == PFLayer::HCAL_BARREL2 && std::abs(maybeseed.positionREP().eta()) > 0.34) {
       seedlayer = 19;
     }
-    auto const & thresholds = _thresholds[seedlayer+layerOffset];
+    auto const& thresholds = _thresholds[seedlayer + layerOffset];
 
+    double thresholdE = 0.;
+    double thresholdPT2 = 0.;
 
-    double thresholdE=0.;
-    double thresholdPT2=0.;
-
-    for (unsigned int j=0; j<(std::get<2>(thresholds)).size(); ++j) {
-
-      int depth=std::get<0>(thresholds)[j];
-      if( ( seedlayer == PFLayer::HCAL_BARREL1 && maybeseed.depth()== depth)
-	  || ( seedlayer == PFLayer::HCAL_ENDCAP && maybeseed.depth()== depth)
-	  || ( seedlayer != PFLayer::HCAL_BARREL1 && seedlayer != PFLayer::HCAL_ENDCAP)
-	  ) { thresholdE=std::get<1>(thresholds)[j]; thresholdPT2=std::get<2>(thresholds)[j]; }
-
+    for (unsigned int j = 0; j < (std::get<2>(thresholds)).size(); ++j) {
+      int depth = std::get<0>(thresholds)[j];
+      if ((seedlayer == PFLayer::HCAL_BARREL1 && maybeseed.depth() == depth) ||
+          (seedlayer == PFLayer::HCAL_ENDCAP && maybeseed.depth() == depth) ||
+          (seedlayer != PFLayer::HCAL_BARREL1 && seedlayer != PFLayer::HCAL_ENDCAP)) {
+        thresholdE = std::get<1>(thresholds)[j];
+        thresholdPT2 = std::get<2>(thresholds)[j];
+      }
     }
 
-    if( maybeseed.energy() < thresholdE ||
-	maybeseed.pt2() < thresholdPT2   ) usable[i] = false;
-    if( !usable[i] ) continue;
+    if (maybeseed.energy() < thresholdE || maybeseed.pt2() < thresholdPT2)
+      usable[i] = false;
+    if (!usable[i])
+      continue;
     ordered_hits.push(i);
-
   }
 
-
-  while(!ordered_hits.empty() ) {
+  while (!ordered_hits.empty()) {
     auto idx = ordered_hits.top();
-    ordered_hits.pop();  
-    if( !usable[idx] ) continue;
+    ordered_hits.pop();
+    if (!usable[idx])
+      continue;
     //get the neighbours of this seed
-    auto const & maybeseed = (*input)[idx];
-    reco::PFRecHit::Neighbours  myNeighbours;
-    switch( _nNeighbours ) {
-    case -1:
-      myNeighbours = maybeseed.neighbours();
-      break;
-    case 0: // for HF clustering
-      myNeighbours = _noNeighbours;
-      break;
-    case 4:
-      myNeighbours = maybeseed.neighbours4();
-      break;
-    case 8:
-      myNeighbours = maybeseed.neighbours8();
-      break;
-    default:
-      throw cms::Exception("InvalidConfiguration")
-	<< "LocalMaximumSeedFinder only accepts nNeighbors = {-1,0,4,8}";    
+    auto const& maybeseed = (*input)[idx];
+    reco::PFRecHit::Neighbours myNeighbours;
+    switch (_nNeighbours) {
+      case -1:
+        myNeighbours = maybeseed.neighbours();
+        break;
+      case 0:  // for HF clustering
+        myNeighbours = _noNeighbours;
+        break;
+      case 4:
+        myNeighbours = maybeseed.neighbours4();
+        break;
+      case 8:
+        myNeighbours = maybeseed.neighbours8();
+        break;
+      default:
+        throw cms::Exception("InvalidConfiguration") << "LocalMaximumSeedFinder only accepts nNeighbors = {-1,0,4,8}";
     }
     seedable[idx] = true;
-    for( auto neighbour : myNeighbours ) {
-      if( !mask[neighbour] ) continue;
-      if( energies[neighbour] > energies[idx] ) {
-//        std::cout << "how this can be?" << std::endl;
-	seedable[idx] = false;	
-	break;
+    for (auto neighbour : myNeighbours) {
+      if (!mask[neighbour])
+        continue;
+      if (energies[neighbour] > energies[idx]) {
+        //        std::cout << "how this can be?" << std::endl;
+        seedable[idx] = false;
+        break;
       }
     }
-    if( seedable[idx] ) {
-      for( auto neighbour : myNeighbours ) {
-	usable[neighbour] = false;
+    if (seedable[idx]) {
+      for (auto neighbour : myNeighbours) {
+        usable[neighbour] = false;
       }
     }
   }
 
-  LogDebug("LocalMaximumSeedFinder") << " found " << std::count(seedable.begin(),seedable.end(),true) << " seeds";
-
+  LogDebug("LocalMaximumSeedFinder") << " found " << std::count(seedable.begin(), seedable.end(), true) << " seeds";
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/LocalMaximumSeedFinder.h
@@ -7,27 +7,26 @@
 #include <tuple>
 
 class LocalMaximumSeedFinder final : public SeedFinderBase {
- public:
+public:
   LocalMaximumSeedFinder(const edm::ParameterSet& conf);
   LocalMaximumSeedFinder(const LocalMaximumSeedFinder&) = delete;
   LocalMaximumSeedFinder& operator=(const LocalMaximumSeedFinder&) = delete;
 
-  void findSeeds( const edm::Handle<reco::PFRecHitCollection>& input,
-		  const std::vector<bool>& mask,
-		  std::vector<bool>& seedable ) override;
+  void findSeeds(const edm::Handle<reco::PFRecHitCollection>& input,
+                 const std::vector<bool>& mask,
+                 std::vector<bool>& seedable) override;
 
- private:  
+private:
   const int _nNeighbours;
 
-  const std::unordered_map<std::string,int> _layerMap;
+  const std::unordered_map<std::string, int> _layerMap;
 
-  typedef std::tuple<std::vector<int>, std::vector<double> , std::vector<double> > I3tuple;
+  typedef std::tuple<std::vector<int>, std::vector<double>, std::vector<double> > I3tuple;
 
   std::array<I3tuple, 35> _thresholds;
   static constexpr int layerOffset = 15;
 };
 
-DEFINE_EDM_PLUGIN(SeedFinderFactory,
-		  LocalMaximumSeedFinder,"LocalMaximumSeedFinder");
+DEFINE_EDM_PLUGIN(SeedFinderFactory, LocalMaximumSeedFinder, "LocalMaximumSeedFinder");
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/Navigators.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/Navigators.cc
@@ -9,13 +9,9 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/PFECALHashNavigator.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/HGCRecHitNavigator.h"
 
-class PFRecHitEcalBarrelNavigatorWithTime : public PFRecHitCaloNavigatorWithTime<EBDetId,EcalBarrelTopology> {
- public:
-  PFRecHitEcalBarrelNavigatorWithTime(const edm::ParameterSet& iConfig):
-    PFRecHitCaloNavigatorWithTime(iConfig)
-    {
-
-    }
+class PFRecHitEcalBarrelNavigatorWithTime : public PFRecHitCaloNavigatorWithTime<EBDetId, EcalBarrelTopology> {
+public:
+  PFRecHitEcalBarrelNavigatorWithTime(const edm::ParameterSet& iConfig) : PFRecHitCaloNavigatorWithTime(iConfig) {}
 
   void beginEvent(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle;
@@ -24,13 +20,9 @@ class PFRecHitEcalBarrelNavigatorWithTime : public PFRecHitCaloNavigatorWithTime
   }
 };
 
-class PFRecHitEcalEndcapNavigatorWithTime : public PFRecHitCaloNavigatorWithTime<EEDetId,EcalEndcapTopology> {
- public:
-  PFRecHitEcalEndcapNavigatorWithTime(const edm::ParameterSet& iConfig):
-    PFRecHitCaloNavigatorWithTime(iConfig)
-    {
-
-    }
+class PFRecHitEcalEndcapNavigatorWithTime : public PFRecHitCaloNavigatorWithTime<EEDetId, EcalEndcapTopology> {
+public:
+  PFRecHitEcalEndcapNavigatorWithTime(const edm::ParameterSet& iConfig) : PFRecHitCaloNavigatorWithTime(iConfig) {}
 
   void beginEvent(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle;
@@ -39,11 +31,9 @@ class PFRecHitEcalEndcapNavigatorWithTime : public PFRecHitCaloNavigatorWithTime
   }
 };
 
-class PFRecHitEcalBarrelNavigator final : public PFRecHitCaloNavigator<EBDetId,EcalBarrelTopology> {
- public:
-  PFRecHitEcalBarrelNavigator(const edm::ParameterSet& iConfig) {
-
-  }
+class PFRecHitEcalBarrelNavigator final : public PFRecHitCaloNavigator<EBDetId, EcalBarrelTopology> {
+public:
+  PFRecHitEcalBarrelNavigator(const edm::ParameterSet& iConfig) {}
 
   void beginEvent(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle;
@@ -52,11 +42,9 @@ class PFRecHitEcalBarrelNavigator final : public PFRecHitCaloNavigator<EBDetId,E
   }
 };
 
-class PFRecHitEcalEndcapNavigator final : public PFRecHitCaloNavigator<EEDetId,EcalEndcapTopology> {
- public:
-  PFRecHitEcalEndcapNavigator(const edm::ParameterSet& iConfig) {
-
-  }
+class PFRecHitEcalEndcapNavigator final : public PFRecHitCaloNavigator<EEDetId, EcalEndcapTopology> {
+public:
+  PFRecHitEcalEndcapNavigator(const edm::ParameterSet& iConfig) {}
 
   void beginEvent(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloGeometry> geoHandle;
@@ -65,57 +53,39 @@ class PFRecHitEcalEndcapNavigator final : public PFRecHitCaloNavigator<EEDetId,E
   }
 };
 
-class PFRecHitPreshowerNavigator final : public PFRecHitCaloNavigator<ESDetId,EcalPreshowerTopology> {
- public:
-  PFRecHitPreshowerNavigator(const edm::ParameterSet& iConfig) {
+class PFRecHitPreshowerNavigator final : public PFRecHitCaloNavigator<ESDetId, EcalPreshowerTopology> {
+public:
+  PFRecHitPreshowerNavigator(const edm::ParameterSet& iConfig) {}
 
-  }
+  void beginEvent(const edm::EventSetup& iSetup) override { topology_ = std::make_unique<EcalPreshowerTopology>(); }
+};
 
+class PFRecHitHCALNavigator final : public PFRecHitCaloNavigator<HcalDetId, HcalTopology, false> {
+public:
+  PFRecHitHCALNavigator(const edm::ParameterSet& iConfig) {}
 
   void beginEvent(const edm::EventSetup& iSetup) override {
-    topology_ = std::make_unique<EcalPreshowerTopology>();
+    edm::ESHandle<HcalTopology> hcalTopology;
+    iSetup.get<HcalRecNumberingRecord>().get(hcalTopology);
+    topology_.release();
+    topology_.reset(hcalTopology.product());
+  }
+};
+class PFRecHitHCALNavigatorWithTime : public PFRecHitCaloNavigatorWithTime<HcalDetId, HcalTopology, false> {
+public:
+  PFRecHitHCALNavigatorWithTime(const edm::ParameterSet& iConfig) : PFRecHitCaloNavigatorWithTime(iConfig) {}
+
+  void beginEvent(const edm::EventSetup& iSetup) override {
+    edm::ESHandle<HcalTopology> hcalTopology;
+    iSetup.get<HcalRecNumberingRecord>().get(hcalTopology);
+    topology_.release();
+    topology_.reset(hcalTopology.product());
   }
 };
 
-
-class PFRecHitHCALNavigator final : public PFRecHitCaloNavigator<HcalDetId,HcalTopology,false> {
- public:
-  PFRecHitHCALNavigator(const edm::ParameterSet& iConfig) {
-
-  }
-
-
-  void beginEvent(const edm::EventSetup& iSetup) override {    
-      edm::ESHandle<HcalTopology> hcalTopology;
-      iSetup.get<HcalRecNumberingRecord>().get( hcalTopology );
-      topology_.release();
-      topology_.reset(hcalTopology.product());
-  }
-};
-class PFRecHitHCALNavigatorWithTime : public PFRecHitCaloNavigatorWithTime<HcalDetId,HcalTopology,false> {
- public:
-  PFRecHitHCALNavigatorWithTime(const edm::ParameterSet& iConfig):
-    PFRecHitCaloNavigatorWithTime(iConfig)
-  {
-    
-  }
-
-
-  void beginEvent(const edm::EventSetup& iSetup) override {    
-      edm::ESHandle<HcalTopology> hcalTopology;
-      iSetup.get<HcalRecNumberingRecord>().get( hcalTopology );
-      topology_.release();
-      topology_.reset(hcalTopology.product());
-  }
-};
-
-
-class PFRecHitCaloTowerNavigator : public PFRecHitCaloNavigator<CaloTowerDetId,CaloTowerTopology> {
- public:
-  PFRecHitCaloTowerNavigator(const edm::ParameterSet& iConfig) {
-
-  }
-
+class PFRecHitCaloTowerNavigator : public PFRecHitCaloNavigator<CaloTowerDetId, CaloTowerTopology> {
+public:
+  PFRecHitCaloTowerNavigator(const edm::ParameterSet& iConfig) {}
 
   void beginEvent(const edm::EventSetup& iSetup) override {
     edm::ESHandle<CaloTowerTopology> caloTowerTopology;
@@ -126,14 +96,16 @@ class PFRecHitCaloTowerNavigator : public PFRecHitCaloNavigator<CaloTowerDetId,C
 };
 
 typedef PFRecHitDualNavigator<PFLayer::ECAL_BARREL,
-			      PFRecHitEcalBarrelNavigator,
-			      PFLayer::ECAL_ENDCAP,
-			    PFRecHitEcalEndcapNavigator> PFRecHitECALNavigator;
+                              PFRecHitEcalBarrelNavigator,
+                              PFLayer::ECAL_ENDCAP,
+                              PFRecHitEcalEndcapNavigator>
+    PFRecHitECALNavigator;
 
-typedef  PFRecHitDualNavigator<PFLayer::ECAL_BARREL,
-			       PFRecHitEcalBarrelNavigatorWithTime,
-			       PFLayer::ECAL_ENDCAP,
-	   PFRecHitEcalEndcapNavigatorWithTime> PFRecHitECALNavigatorWithTime;
+typedef PFRecHitDualNavigator<PFLayer::ECAL_BARREL,
+                              PFRecHitEcalBarrelNavigatorWithTime,
+                              PFLayer::ECAL_ENDCAP,
+                              PFRecHitEcalEndcapNavigatorWithTime>
+    PFRecHitECALNavigatorWithTime;
 
 #include "DataFormats/ForwardDetId/interface/HGCEEDetId.h"
 #include "DataFormats/ForwardDetId/interface/HGCHEDetId.h"
@@ -141,44 +113,38 @@ typedef  PFRecHitDualNavigator<PFLayer::ECAL_BARREL,
 
 class PFRecHitHGCEENavigator : public PFRecHitFakeNavigator<HGCEEDetId> {
 public:
-  PFRecHitHGCEENavigator(const edm::ParameterSet& iConfig) {
-  }
+  PFRecHitHGCEENavigator(const edm::ParameterSet& iConfig) {}
 
-  void beginEvent(const edm::EventSetup& iSetup) override {      
-  }
+  void beginEvent(const edm::EventSetup& iSetup) override {}
 };
 
 class PFRecHitHGCHENavigator : public PFRecHitFakeNavigator<HGCHEDetId> {
 public:
-  PFRecHitHGCHENavigator(const edm::ParameterSet& iConfig) {
-  }
+  PFRecHitHGCHENavigator(const edm::ParameterSet& iConfig) {}
 
-  void beginEvent(const edm::EventSetup& iSetup) override {      
-  }
+  void beginEvent(const edm::EventSetup& iSetup) override {}
 };
 
 class PFRecHitHGCHexNavigator : public PFRecHitFakeNavigator<HGCalDetId> {
 public:
-  PFRecHitHGCHexNavigator(const edm::ParameterSet& iConfig) {
-  }
+  PFRecHitHGCHexNavigator(const edm::ParameterSet& iConfig) {}
 
-  void beginEvent(const edm::EventSetup& iSetup) override {      
-  }
+  void beginEvent(const edm::EventSetup& iSetup) override {}
 };
 
-typedef HGCRecHitNavigator<HGCEE,
-			   PFRecHitHGCHexNavigator,
-			   HGCHEF,
-			   PFRecHitHGCHexNavigator,
-			   HGCHEB,
-			   PFRecHitHGCHENavigator> PFRecHitHGCNavigator;
+typedef HGCRecHitNavigator<HGCEE, PFRecHitHGCHexNavigator, HGCHEF, PFRecHitHGCHexNavigator, HGCHEB, PFRecHitHGCHENavigator>
+    PFRecHitHGCNavigator;
 
 EDM_REGISTER_PLUGINFACTORY(PFRecHitNavigationFactory, "PFRecHitNavigationFactory");
 
 DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory, PFRecHitEcalBarrelNavigator, "PFRecHitEcalBarrelNavigator");
 DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory, PFRecHitEcalEndcapNavigator, "PFRecHitEcalEndcapNavigator");
-DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory, PFRecHitEcalBarrelNavigatorWithTime, "PFRecHitEcalBarrelNavigatorWithTime");
-DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory, PFRecHitEcalEndcapNavigatorWithTime, "PFRecHitEcalEndcapNavigatorWithTime");
+DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory,
+                  PFRecHitEcalBarrelNavigatorWithTime,
+                  "PFRecHitEcalBarrelNavigatorWithTime");
+DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory,
+                  PFRecHitEcalEndcapNavigatorWithTime,
+                  "PFRecHitEcalEndcapNavigatorWithTime");
 DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory, PFECALHashNavigator, "PFECALHashNavigator");
 DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory, PFRecHitECALNavigator, "PFRecHitECALNavigator");
 DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory, PFRecHitECALNavigatorWithTime, "PFRecHitECALNavigatorWithTime");
@@ -189,4 +155,3 @@ DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory, PFRecHitHCALNavigatorWithTime, "PFR
 DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory, PFRecHitHGCEENavigator, "PFRecHitHGCEENavigator");
 DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory, PFRecHitHGCHENavigator, "PFRecHitHGCHENavigator");
 DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory, PFRecHitHGCNavigator, "PFRecHitHGCNavigator");
-

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFBadHcalPseudoClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFBadHcalPseudoClusterProducer.cc
@@ -31,7 +31,6 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 
-
 using namespace std;
 using namespace edm;
 
@@ -40,134 +39,136 @@ using namespace edm;
 //
 
 class PFBadHcalPseudoClusterProducer : public edm::stream::EDProducer<> {
-    public:
-        explicit PFBadHcalPseudoClusterProducer(const edm::ParameterSet&);
-        ~PFBadHcalPseudoClusterProducer() override;
+public:
+  explicit PFBadHcalPseudoClusterProducer(const edm::ParameterSet&);
+  ~PFBadHcalPseudoClusterProducer() override;
 
-        static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-    private:
-        virtual void init(const EventSetup& c) ;
-        void produce(edm::Event&, const edm::EventSetup&) override;
+private:
+  virtual void init(const EventSetup& c);
+  void produce(edm::Event&, const edm::EventSetup&) override;
 
-        bool enabled_;
-        bool debug_;
+  bool enabled_;
+  bool debug_;
 
-        edm::ESHandle<HcalChannelQuality> hQuality_;
-        edm::ESHandle<CaloGeometry> hGeom_;
-        unsigned long long cacheId_quality_, cacheId_geom_;
-        std::vector<reco::PFCluster> badAreasC_;
-        std::vector<reco::PFRecHit> badAreasRH_;
+  edm::ESHandle<HcalChannelQuality> hQuality_;
+  edm::ESHandle<CaloGeometry> hGeom_;
+  unsigned long long cacheId_quality_, cacheId_geom_;
+  std::vector<reco::PFCluster> badAreasC_;
+  std::vector<reco::PFRecHit> badAreasRH_;
 };
 
-
-PFBadHcalPseudoClusterProducer::PFBadHcalPseudoClusterProducer(const edm::ParameterSet& ps) :
-   enabled_(ps.getParameter<bool>("enable")),
-   debug_(ps.getUntrackedParameter<bool>("debug",false)),
-   cacheId_quality_(0), cacheId_geom_(0)
-{
-    produces<std::vector<reco::PFCluster>>();
-    produces<std::vector<reco::PFRecHit>>("hits");
+PFBadHcalPseudoClusterProducer::PFBadHcalPseudoClusterProducer(const edm::ParameterSet& ps)
+    : enabled_(ps.getParameter<bool>("enable")),
+      debug_(ps.getUntrackedParameter<bool>("debug", false)),
+      cacheId_quality_(0),
+      cacheId_geom_(0) {
+  produces<std::vector<reco::PFCluster>>();
+  produces<std::vector<reco::PFRecHit>>("hits");
 }
 
+PFBadHcalPseudoClusterProducer::~PFBadHcalPseudoClusterProducer() {}
 
-PFBadHcalPseudoClusterProducer::~PFBadHcalPseudoClusterProducer()
-{
-}
+void PFBadHcalPseudoClusterProducer::init(const EventSetup& iSetup) {
+  badAreasC_.clear();
+  badAreasRH_.clear();
 
-void PFBadHcalPseudoClusterProducer::init(const EventSetup& iSetup)
-{
-    badAreasC_.clear();
-    badAreasRH_.clear();
+  edm::ESHandle<HcalChannelQuality> hQuality_;
+  iSetup.get<HcalChannelQualityRcd>().get("withTopo", hQuality_);
+  const HcalChannelQuality& chanquality = *hQuality_;
 
-    edm::ESHandle<HcalChannelQuality> hQuality_;
-    iSetup.get<HcalChannelQualityRcd>().get("withTopo",hQuality_);
-    const HcalChannelQuality & chanquality = *hQuality_;
+  edm::ESHandle<CaloGeometry> hGeom_;
+  iSetup.get<CaloGeometryRecord>().get(hGeom_);
+  const CaloGeometry& caloGeom = *hGeom_;
+  const CaloSubdetectorGeometry* hbGeom = caloGeom.getSubdetectorGeometry(DetId::Hcal, HcalBarrel);
+  const CaloSubdetectorGeometry* heGeom = caloGeom.getSubdetectorGeometry(DetId::Hcal, HcalEndcap);
 
-    edm::ESHandle<CaloGeometry> hGeom_;
-    iSetup.get<CaloGeometryRecord>().get(hGeom_);
-    const CaloGeometry& caloGeom = *hGeom_;
-    const CaloSubdetectorGeometry *hbGeom = caloGeom.getSubdetectorGeometry(DetId::Hcal, HcalBarrel);
-    const CaloSubdetectorGeometry *heGeom = caloGeom.getSubdetectorGeometry(DetId::Hcal, HcalEndcap);
-
-    int statusMask = ((1<<HcalChannelStatus::HcalCellOff) | (1<<HcalChannelStatus::HcalCellMask) | (1<<HcalChannelStatus::HcalCellDead));
-    // histogram the number of bad depths at each ieta, iphi
-    std::map<std::pair<int,int>, int> good, bads;
-    std::map<std::pair<int,int>, std::pair<int,HcalSubdetector>> minDepths;
-    for (const DetId & i : chanquality.getAllChannels()) {
-        if (i.det()!=DetId::Hcal) continue; // not an hcal cell
-        HcalDetId id = HcalDetId(i);
-        if (id.subdet() != HcalBarrel && id.subdet() != HcalEndcap) continue; // we don't deal with HO and HF here
-        int status = chanquality.getValues(id)->getValue();
-        auto tower = std::make_pair(id.ieta(), id.iphi());
-        if (status & statusMask) {
-            bads[tower]++;
-            if (debug_) std::cout << "Channel " << i() << " (subdet " << id.subdet() << ", zside " << id.zside() << ", ieta " << id.ieta() << ", iphi " << id.iphi() << " depth " << id.depth() << " has status " << status << "  masked " << (status & statusMask) << std::endl;
-        } else {
-            good[tower]++;
-        }
-        auto & minD = minDepths[tower];
-        if (minD.second == HcalEmpty || minD.first > id.depth()) {
-            minD.first  = id.depth();
-            minD.second = id.subdet();
-        }
+  int statusMask = ((1 << HcalChannelStatus::HcalCellOff) | (1 << HcalChannelStatus::HcalCellMask) |
+                    (1 << HcalChannelStatus::HcalCellDead));
+  // histogram the number of bad depths at each ieta, iphi
+  std::map<std::pair<int, int>, int> good, bads;
+  std::map<std::pair<int, int>, std::pair<int, HcalSubdetector>> minDepths;
+  for (const DetId& i : chanquality.getAllChannels()) {
+    if (i.det() != DetId::Hcal)
+      continue;  // not an hcal cell
+    HcalDetId id = HcalDetId(i);
+    if (id.subdet() != HcalBarrel && id.subdet() != HcalEndcap)
+      continue;  // we don't deal with HO and HF here
+    int status = chanquality.getValues(id)->getValue();
+    auto tower = std::make_pair(id.ieta(), id.iphi());
+    if (status & statusMask) {
+      bads[tower]++;
+      if (debug_)
+        std::cout << "Channel " << i() << " (subdet " << id.subdet() << ", zside " << id.zside() << ", ieta "
+                  << id.ieta() << ", iphi " << id.iphi() << " depth " << id.depth() << " has status " << status
+                  << "  masked " << (status & statusMask) << std::endl;
+    } else {
+      good[tower]++;
     }
-
-    const float dummyEnergy = 1e-5; // non-zero, but small (even if it shouldn't ever be used)
-    for (const auto & rec : bads) {
-        int ieta = rec.first.first, iphi = rec.first.second, nbad = rec.second, ngood = good[rec.first];
-        auto minDepth = minDepths[rec.first];   
-        bool barrel = minDepth.second == HcalBarrel;
-        HcalDetId id(minDepth.second, ieta, iphi, minDepth.first);
-        bool isBad = (nbad > 0 && nbad >= ngood);
-        if (debug_) std::cout << "At ieta " << id.ieta() << ", iphi " << id.iphi() << " I have " << nbad << " bad depths, " << ngood << " good depths. First depth is in " << (barrel ? "HB" : "HE") << " depth " << minDepth.first <<"; " << (isBad ? " MARK BAD": " ignore") << std::endl;
-        if (!isBad) continue;
-        PFLayer::Layer layer = (barrel ? PFLayer::HCAL_BARREL1 : PFLayer::HCAL_ENDCAP);
-        // make a PF RecHit
-        std::shared_ptr<const CaloCellGeometry> thisCell = (barrel ? hbGeom : heGeom)->getGeometry(id);
-        const GlobalPoint & pos = thisCell->getPosition();
-        badAreasRH_.emplace_back( thisCell, id(), layer, dummyEnergy );
-        // make a PF cluster (but can't add the rechit, as for that I need an edm::Ref)
-        badAreasC_.emplace_back( layer, dummyEnergy, pos.x(), pos.y(), pos.z() );
-        badAreasC_.back().setFlags(reco::CaloCluster::badHcalMarker);
+    auto& minD = minDepths[tower];
+    if (minD.second == HcalEmpty || minD.first > id.depth()) {
+      minD.first = id.depth();
+      minD.second = id.subdet();
     }
+  }
 
-    cacheId_quality_ = iSetup.get<HcalChannelQualityRcd>().cacheIdentifier();
-    cacheId_geom_ = iSetup.get<CaloGeometryRecord>().cacheIdentifier();
+  const float dummyEnergy = 1e-5;  // non-zero, but small (even if it shouldn't ever be used)
+  for (const auto& rec : bads) {
+    int ieta = rec.first.first, iphi = rec.first.second, nbad = rec.second, ngood = good[rec.first];
+    auto minDepth = minDepths[rec.first];
+    bool barrel = minDepth.second == HcalBarrel;
+    HcalDetId id(minDepth.second, ieta, iphi, minDepth.first);
+    bool isBad = (nbad > 0 && nbad >= ngood);
+    if (debug_)
+      std::cout << "At ieta " << id.ieta() << ", iphi " << id.iphi() << " I have " << nbad << " bad depths, " << ngood
+                << " good depths. First depth is in " << (barrel ? "HB" : "HE") << " depth " << minDepth.first << "; "
+                << (isBad ? " MARK BAD" : " ignore") << std::endl;
+    if (!isBad)
+      continue;
+    PFLayer::Layer layer = (barrel ? PFLayer::HCAL_BARREL1 : PFLayer::HCAL_ENDCAP);
+    // make a PF RecHit
+    std::shared_ptr<const CaloCellGeometry> thisCell = (barrel ? hbGeom : heGeom)->getGeometry(id);
+    const GlobalPoint& pos = thisCell->getPosition();
+    badAreasRH_.emplace_back(thisCell, id(), layer, dummyEnergy);
+    // make a PF cluster (but can't add the rechit, as for that I need an edm::Ref)
+    badAreasC_.emplace_back(layer, dummyEnergy, pos.x(), pos.y(), pos.z());
+    badAreasC_.back().setFlags(reco::CaloCluster::badHcalMarker);
+  }
+
+  cacheId_quality_ = iSetup.get<HcalChannelQualityRcd>().cacheIdentifier();
+  cacheId_geom_ = iSetup.get<CaloGeometryRecord>().cacheIdentifier();
 }
 
 // ------------ method called to produce the data  ------------
-    void
-PFBadHcalPseudoClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-    if (enabled_) {
-        if (cacheId_quality_ != iSetup.get<HcalChannelQualityRcd>().cacheIdentifier() ||
-               cacheId_geom_ != iSetup.get<CaloGeometryRecord>().cacheIdentifier()) {
-            init(iSetup);
-        }
+void PFBadHcalPseudoClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  if (enabled_) {
+    if (cacheId_quality_ != iSetup.get<HcalChannelQualityRcd>().cacheIdentifier() ||
+        cacheId_geom_ != iSetup.get<CaloGeometryRecord>().cacheIdentifier()) {
+      init(iSetup);
     }
+  }
 
+  auto outRH = std::make_unique<std::vector<reco::PFRecHit>>(badAreasRH_);
+  auto rhHandle = iEvent.put(std::move(outRH), "hits");
 
-    auto outRH = std::make_unique<std::vector<reco::PFRecHit>>(badAreasRH_);
-    auto rhHandle = iEvent.put(std::move(outRH), "hits");
+  auto outC = std::make_unique<std::vector<reco::PFCluster>>(badAreasC_);
 
-    auto outC = std::make_unique<std::vector<reco::PFCluster>>(badAreasC_);
+  // now we go set references
+  for (unsigned int i = 0, n = rhHandle->size(); i < n; ++i) {
+    (*outC)[i].addRecHitFraction(reco::PFRecHitFraction(reco::PFRecHitRef(rhHandle, i), 1.0));
+  }
 
-    // now we go set references
-    for (unsigned int i = 0, n = rhHandle->size(); i < n; ++i) {
-        (*outC)[i].addRecHitFraction( reco::PFRecHitFraction(reco::PFRecHitRef(rhHandle,i), 1.0) );
-    }
-
-    iEvent.put(std::move(outC));
+  iEvent.put(std::move(outC));
 }
 
-void PFBadHcalPseudoClusterProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
-    edm::ParameterSetDescription desc;
-    desc.add<bool>("enable", false)->setComment("activate the module (if false, it doesn't check the DB and produces an empty collection)");
-    desc.addUntracked<bool>("debug", false);
-    descriptions.add("particleFlowBadHcalPseudoCluster", desc);
+void PFBadHcalPseudoClusterProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<bool>("enable", false)
+      ->setComment("activate the module (if false, it doesn't check the DB and produces an empty collection)");
+  desc.addUntracked<bool>("debug", false);
+  descriptions.add("particleFlowBadHcalPseudoCluster", desc);
 }
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(PFBadHcalPseudoClusterProducer);
-

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.cc
@@ -30,7 +30,6 @@
 
 #include "RecoCaloTools/Navigation/interface/CaloNavigator.h"
 
-
 #include "Geometry/CaloTopology/interface/CaloTowerTopology.h"
 #include "RecoCaloTools/Navigation/interface/CaloTowerNavigator.h"
 
@@ -38,36 +37,22 @@
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputer.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalSeverityLevelComputerRcd.h"
 
-
 using namespace std;
 using namespace edm;
 
+PFCTRecHitProducer::PFCTRecHitProducer(const edm::ParameterSet& iConfig) {
+  thresh_Barrel_ = iConfig.getParameter<double>("thresh_Barrel");
+  thresh_Endcap_ = iConfig.getParameter<double>("thresh_Endcap");
 
-PFCTRecHitProducer::PFCTRecHitProducer(const edm::ParameterSet& iConfig)
-{
-  thresh_Barrel_ = 
-    iConfig.getParameter<double>("thresh_Barrel");
-  thresh_Endcap_ = 
-    iConfig.getParameter<double>("thresh_Endcap");
+  thresh_HF_ = iConfig.getParameter<double>("thresh_HF");
+  navigation_HF_ = iConfig.getParameter<bool>("navigation_HF");
+  weight_HFem_ = iConfig.getParameter<double>("weight_HFem");
+  weight_HFhad_ = iConfig.getParameter<double>("weight_HFhad");
 
-   
-  thresh_HF_ = 
-    iConfig.getParameter<double>("thresh_HF");
-  navigation_HF_ = 
-    iConfig.getParameter<bool>("navigation_HF");
-  weight_HFem_ =
-    iConfig.getParameter<double>("weight_HFem");
-  weight_HFhad_ =
-    iConfig.getParameter<double>("weight_HFhad");
-
-  HCAL_Calib_ =
-    iConfig.getParameter<bool>("HCAL_Calib");
-  HF_Calib_ =
-    iConfig.getParameter<bool>("HF_Calib");
-  HCAL_Calib_29 = 
-    iConfig.getParameter<double>("HCAL_Calib_29");
-  HF_Calib_29 = 
-    iConfig.getParameter<double>("HF_Calib_29");
+  HCAL_Calib_ = iConfig.getParameter<bool>("HCAL_Calib");
+  HF_Calib_ = iConfig.getParameter<bool>("HF_Calib");
+  HCAL_Calib_29 = iConfig.getParameter<double>("HCAL_Calib_29");
+  HF_Calib_29 = iConfig.getParameter<double>("HF_Calib_29");
 
   shortFibre_Cut = iConfig.getParameter<double>("ShortFibre_Cut");
   longFibre_Fraction = iConfig.getParameter<double>("LongFibre_Fraction");
@@ -99,43 +84,37 @@ PFCTRecHitProducer::PFCTRecHitProducer(const edm::ParameterSet& iConfig)
   HAD_Depth_ = iConfig.getParameter<double>("HAD_Depth");
 
   //Get integer values of individual HCAL HF flags
-  hcalHFLongShortFlagValue_=1<<HcalCaloFlagLabels::HFLongShort;
-  hcalHFDigiTimeFlagValue_=1<<HcalCaloFlagLabels::HFDigiTime;
-  hcalHFInTimeWindowFlagValue_=1<<HcalCaloFlagLabels::HFInTimeWindow;
- 
+  hcalHFLongShortFlagValue_ = 1 << HcalCaloFlagLabels::HFLongShort;
+  hcalHFDigiTimeFlagValue_ = 1 << HcalCaloFlagLabels::HFDigiTime;
+  hcalHFInTimeWindowFlagValue_ = 1 << HcalCaloFlagLabels::HFInTimeWindow;
+
   hcalToken_ = consumes<HBHERecHitCollection>(iConfig.getParameter<InputTag>("hcalRecHitsHBHE"));
   hfToken_ = consumes<HFRecHitCollection>(iConfig.getParameter<InputTag>("hcalRecHitsHF"));
   towersToken_ = consumes<CaloTowerCollection>(iConfig.getParameter<InputTag>("caloTowers"));
 
-					       
   edm::ParameterSet navSet = iConfig.getParameter<edm::ParameterSet>("navigator");
-  navigator_ = std::unique_ptr<PFRecHitNavigatorBase>{PFRecHitNavigationFactory::get()->create(navSet.getParameter<std::string>("name"),navSet)};
-					  
+  navigator_ = std::unique_ptr<PFRecHitNavigatorBase>{
+      PFRecHitNavigationFactory::get()->create(navSet.getParameter<std::string>("name"), navSet)};
+
   //--ab
   produces<reco::PFRecHitCollection>();
   produces<reco::PFRecHitCollection>("Cleaned");
   produces<reco::PFRecHitCollection>("HFHAD").setBranchAlias("HFHADRecHits");
   produces<reco::PFRecHitCollection>("HFEM").setBranchAlias("HFEMRecHits");
   //--ab
-  
 }
 
-
-void PFCTRecHitProducer::produce(edm::Event& iEvent, 
-			       const edm::EventSetup& iSetup) {
-
+void PFCTRecHitProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   navigator_->beginEvent(iSetup);
 
   edm::ESHandle<CaloGeometry> geoHandle;
   iSetup.get<CaloGeometryRecord>().get(geoHandle);
-  
+
   // get the hcalBarrel geometry
-  const CaloSubdetectorGeometry *hcalBarrelGeometry = 
-    geoHandle->getSubdetectorGeometry(DetId::Hcal, HcalBarrel);
+  const CaloSubdetectorGeometry* hcalBarrelGeometry = geoHandle->getSubdetectorGeometry(DetId::Hcal, HcalBarrel);
 
   // get the endcap geometry
-  const CaloSubdetectorGeometry *hcalEndcapGeometry = 
-    geoHandle->getSubdetectorGeometry(DetId::Hcal, HcalEndcap);
+  const CaloSubdetectorGeometry* hcalEndcapGeometry = geoHandle->getSubdetectorGeometry(DetId::Hcal, HcalEndcap);
 
   // Get Hcal Severity Level Computer, so that the severity of each rechit flag/status may be determined
   edm::ESHandle<HcalSeverityLevelComputer> hcalSevLvlComputerHndl;
@@ -144,37 +123,38 @@ void PFCTRecHitProducer::produce(edm::Event& iEvent,
 
   // Get Hcal Topology
   edm::ESHandle<HcalTopology> hcalTopology;
-  iSetup.get<HcalRecNumberingRecord>().get( hcalTopology );
+  iSetup.get<HcalRecNumberingRecord>().get(hcalTopology);
   theHcalTopology = hcalTopology.product();
 
-  auto rechits = std::make_unique<std::vector<reco::PFRecHit>>(); 
-  auto rechitsCleaned = std::make_unique<std::vector<reco::PFRecHit>>(); 
-  auto HFHADRecHits = std::make_unique<std::vector<reco::PFRecHit>>(); 
-  auto HFEMRecHits = std::make_unique<std::vector<reco::PFRecHit>>(); 
+  auto rechits = std::make_unique<std::vector<reco::PFRecHit>>();
+  auto rechitsCleaned = std::make_unique<std::vector<reco::PFRecHit>>();
+  auto HFHADRecHits = std::make_unique<std::vector<reco::PFRecHit>>();
+  auto HFEMRecHits = std::make_unique<std::vector<reco::PFRecHit>>();
 
-  edm::Handle<CaloTowerCollection> caloTowers; 
-  iEvent.getByToken(towersToken_,caloTowers);
-  edm::Handle<HFRecHitCollection>  hfHandle;  
-  iEvent.getByToken(hfToken_,hfHandle);
+  edm::Handle<CaloTowerCollection> caloTowers;
+  iEvent.getByToken(towersToken_, caloTowers);
+  edm::Handle<HFRecHitCollection> hfHandle;
+  iEvent.getByToken(hfToken_, hfHandle);
 
-  edm::Handle<HBHERecHitCollection>  hbheHandle;  
-  iEvent.getByToken(hcalToken_,hbheHandle);
+  edm::Handle<HBHERecHitCollection> hbheHandle;
+  iEvent.getByToken(hcalToken_, hbheHandle);
   // create rechits
   typedef CaloTowerCollection::const_iterator ICT;
-    
-  for(auto const & ct : *caloTowers) {
+
+  for (auto const& ct : *caloTowers) {
     // get the hadronic energy.
-    
+
     // Mike: Just ask for the Hadronic part only now!
-    // Patrick : ARGH ! While this is ok for the HCAL, this is 
-    // just wrong for the HF (in which em/had are artificially 
-    // separated. 
+    // Patrick : ARGH ! While this is ok for the HCAL, this is
+    // just wrong for the HF (in which em/had are artificially
+    // separated.
     double energy = ct.hadEnergy();
     //Auguste: Photons in HF have no hadEnergy in fastsim: -> all RecHit collections are empty with photons.
-    double energyEM = ct.emEnergy(); // For HF !
+    double energyEM = ct.emEnergy();  // For HF !
     //so test the total energy to deal with the photons in  HF:
-    if( (energy+energyEM) < 1e-9 ) continue;
-	  
+    if ((energy + energyEM) < 1e-9)
+      continue;
+
     //get the constituents of the tower
     const std::vector<DetId>& hits = ct.constituents();
     const std::vector<DetId>& allConstituents = theTowerConstituentsMap->constituentsOf(ct.id());
@@ -183,35 +163,36 @@ void PFCTRecHitProducer::produce(edm::Event& iEvent,
     //Loop on the calotower constituents and search for HCAL
     double dead = 0.;
     double alive = 0.;
-    for(auto hit : hits) {
-      if(hit.det()==DetId::Hcal) { 
-	foundHCALConstituent = true;
-	detid = hit;
-	if (theHcalTopology->getMergePositionFlag() && 
-	    detid.subdet() == HcalEndcap) {
-	  detid = theHcalTopology->idFront(detid);
-	}
-	// An HCAL tower was found: Look for dead ECAL channels in the same CaloTower.
-	if ( ECAL_Compensate_ && energy > ECAL_Threshold_ ) {
-	  for(auto allConstituent : allConstituents) { 
-	    if ( allConstituent.det()==DetId::Ecal ) { 
-	      alive += 1.;
-	      auto chIt = theEcalChStatus->find(allConstituent);
-	      unsigned int dbStatus = chIt != theEcalChStatus->end() ? chIt->getStatusCode() : 0;
-	      if ( dbStatus > ECAL_Dead_Code_ ) dead += 1.;
-	    }
-	  }
-	} 
-	// Protection: tower 29 in HF is merged with tower 30. 
-	// Just take the position of tower 30 in that case. 
-	if ( detid.subdet() == HcalForward && abs(detid.ieta()) == 29 ) continue; 
-	break;
+    for (auto hit : hits) {
+      if (hit.det() == DetId::Hcal) {
+        foundHCALConstituent = true;
+        detid = hit;
+        if (theHcalTopology->getMergePositionFlag() && detid.subdet() == HcalEndcap) {
+          detid = theHcalTopology->idFront(detid);
+        }
+        // An HCAL tower was found: Look for dead ECAL channels in the same CaloTower.
+        if (ECAL_Compensate_ && energy > ECAL_Threshold_) {
+          for (auto allConstituent : allConstituents) {
+            if (allConstituent.det() == DetId::Ecal) {
+              alive += 1.;
+              auto chIt = theEcalChStatus->find(allConstituent);
+              unsigned int dbStatus = chIt != theEcalChStatus->end() ? chIt->getStatusCode() : 0;
+              if (dbStatus > ECAL_Dead_Code_)
+                dead += 1.;
+            }
+          }
+        }
+        // Protection: tower 29 in HF is merged with tower 30.
+        // Just take the position of tower 30 in that case.
+        if (detid.subdet() == HcalForward && abs(detid.ieta()) == 29)
+          continue;
+        break;
       }
     }
 
     // In case of dead ECAL channel, rescale the HCAL energy...
-    double rescaleFactor = alive > 0. ? 1. + ECAL_Compensation_*dead/alive : 1.;
-	  
+    double rescaleFactor = alive > 0. ? 1. + ECAL_Compensation_ * dead / alive : 1.;
+
     reco::PFRecHit* pfrh = nullptr;
     reco::PFRecHit* pfrhCleaned = nullptr;
     //---ab: need 2 rechits for the HF:
@@ -221,123 +202,110 @@ void PFCTRecHitProducer::produce(edm::Event& iEvent,
     reco::PFRecHit* pfrhHFHADCleaned = nullptr;
     reco::PFRecHit* pfrhHFEMCleaned29 = nullptr;
     reco::PFRecHit* pfrhHFHADCleaned29 = nullptr;
-  
-    if(foundHCALConstituent)
-      {
-	// std::cout << ", new Energy = " << energy << std::endl;
-	switch( detid.subdet() ) {
-	case HcalBarrel: 
-	  {
-	    if(energy < thresh_Barrel_ ) continue;
-		if ( rescaleFactor > 1. ) { 
-		  pfrhCleaned = createHcalRecHit( detid, 
-						  energy, 
-						  PFLayer::HCAL_BARREL1, 
-						  hcalBarrelGeometry,
-						  ct.id() );
-		  pfrhCleaned->setTime(rescaleFactor);
-		  energy *= rescaleFactor;
-		}
-		pfrh = createHcalRecHit( detid, 
-					 energy, 
-					 PFLayer::HCAL_BARREL1, 
-					 hcalBarrelGeometry,
-					 ct.id() );
-		pfrh->setTime(rescaleFactor);
-	      }
-	      break;
-	    case HcalEndcap:
-	      {
-		if(energy < thresh_Endcap_ ) continue;
-		// Apply tower 29 calibration
-		if ( HCAL_Calib_ && abs(detid.ieta()) == 29 ) energy *= HCAL_Calib_29;
-		if ( rescaleFactor > 1. ) { 
-		  pfrhCleaned = createHcalRecHit( detid, 
-						  energy, 
-						  PFLayer::HCAL_ENDCAP, 
-						  hcalEndcapGeometry,
-						  ct.id() );
-		  pfrhCleaned->setTime(rescaleFactor);
-		  energy *= rescaleFactor;
-		}
-		pfrh = createHcalRecHit( detid, 
-					 energy, 
-					 PFLayer::HCAL_ENDCAP, 
-					 hcalEndcapGeometry,
-					 ct.id() );
-		pfrh->setTime(rescaleFactor);
-	      }
-	      break;
-	    case HcalOuter:
-	      {
-	      }
-	      break;
-	    case HcalForward:
-	      {
-		//---ab: 2 rechits for HF:
-		//double energyemHF = weight_HFem_*ct.emEnergy();
-		//double energyhadHF = weight_HFhad_*ct.hadEnergy();
-		double energyemHF = weight_HFem_ * energyEM;
-		double energyhadHF = weight_HFhad_ * energy;
-		// Some energy in the tower !
-		if((energyemHF+energyhadHF) < thresh_HF_ ) continue;
 
-		// Some cleaning in the HF 
-		double longFibre = energyemHF + energyhadHF/2.;
-		double shortFibre = energyhadHF/2.;
-		int ieta = detid.ieta();
-		int iphi = detid.iphi();
-		HcalDetId theLongDetId (HcalForward, ieta, iphi, 1);
-		HcalDetId theShortDetId (HcalForward, ieta, iphi, 2);
-		typedef HFRecHitCollection::const_iterator iHF;
-		auto theLongHit = hfHandle->find(theLongDetId); 
-		auto theShortHit = hfHandle->find(theShortDetId); 
-		// 
-		double theLongHitEnergy = 0.;
-		double theShortHitEnergy = 0.;
-		bool flagShortDPG =  false; 
-		bool flagLongDPG = false; 
-		bool flagShortTimeDPG = false; 
-		bool flagLongTimeDPG = false;
-		bool flagShortPulseDPG = false;
-		bool flagLongPulseDPG = false;
-		//
-		if ( theLongHit != hfHandle->end() ) { 
-		  int theLongFlag = theLongHit->flags();
-		  theLongHitEnergy = theLongHit->energy();
-		  flagLongDPG = applyLongShortDPG_ && ( hcalSevLvlComputer->getSeverityLevel(theLongDetId, theLongFlag & hcalHFLongShortFlagValue_, 0)> HcalMaxAllowedHFLongShortSev_);
-		  flagLongTimeDPG = applyTimeDPG_ && ( hcalSevLvlComputer->getSeverityLevel(theLongDetId, theLongFlag & hcalHFInTimeWindowFlagValue_, 0)> HcalMaxAllowedHFInTimeWindowSev_);
-		  flagLongPulseDPG = applyPulseDPG_ && ( hcalSevLvlComputer->getSeverityLevel(theLongDetId, theLongFlag & hcalHFDigiTimeFlagValue_, 0)> HcalMaxAllowedHFDigiTimeSev_);
+    if (foundHCALConstituent) {
+      // std::cout << ", new Energy = " << energy << std::endl;
+      switch (detid.subdet()) {
+        case HcalBarrel: {
+          if (energy < thresh_Barrel_)
+            continue;
+          if (rescaleFactor > 1.) {
+            pfrhCleaned = createHcalRecHit(detid, energy, PFLayer::HCAL_BARREL1, hcalBarrelGeometry, ct.id());
+            pfrhCleaned->setTime(rescaleFactor);
+            energy *= rescaleFactor;
+          }
+          pfrh = createHcalRecHit(detid, energy, PFLayer::HCAL_BARREL1, hcalBarrelGeometry, ct.id());
+          pfrh->setTime(rescaleFactor);
+        } break;
+        case HcalEndcap: {
+          if (energy < thresh_Endcap_)
+            continue;
+          // Apply tower 29 calibration
+          if (HCAL_Calib_ && abs(detid.ieta()) == 29)
+            energy *= HCAL_Calib_29;
+          if (rescaleFactor > 1.) {
+            pfrhCleaned = createHcalRecHit(detid, energy, PFLayer::HCAL_ENDCAP, hcalEndcapGeometry, ct.id());
+            pfrhCleaned->setTime(rescaleFactor);
+            energy *= rescaleFactor;
+          }
+          pfrh = createHcalRecHit(detid, energy, PFLayer::HCAL_ENDCAP, hcalEndcapGeometry, ct.id());
+          pfrh->setTime(rescaleFactor);
+        } break;
+        case HcalOuter: {
+        } break;
+        case HcalForward: {
+          //---ab: 2 rechits for HF:
+          //double energyemHF = weight_HFem_*ct.emEnergy();
+          //double energyhadHF = weight_HFhad_*ct.hadEnergy();
+          double energyemHF = weight_HFem_ * energyEM;
+          double energyhadHF = weight_HFhad_ * energy;
+          // Some energy in the tower !
+          if ((energyemHF + energyhadHF) < thresh_HF_)
+            continue;
 
-		  //flagLongDPG =  applyLongShortDPG_ && theLongHit->flagField(HcalCaloFlagLabels::HFLongShort)==1;
-		  //flagLongTimeDPG = applyTimeDPG_ && theLongHit->flagField(HcalCaloFlagLabels::HFInTimeWindow)==1;
-		  //flagLongPulseDPG = applyPulseDPG_ && theLongHit->flagField(HcalCaloFlagLabels::HFDigiTime)==1;
-		}
-		//
-		if ( theShortHit != hfHandle->end() ) { 
-		  int theShortFlag = theShortHit->flags();
-		  theShortHitEnergy = theShortHit->energy();
-		  flagShortDPG = applyLongShortDPG_ && ( hcalSevLvlComputer->getSeverityLevel(theShortDetId, theShortFlag & hcalHFLongShortFlagValue_, 0)> HcalMaxAllowedHFLongShortSev_);
-		  flagShortTimeDPG = applyTimeDPG_ && ( hcalSevLvlComputer->getSeverityLevel(theShortDetId, theShortFlag & hcalHFInTimeWindowFlagValue_, 0)> HcalMaxAllowedHFInTimeWindowSev_);
-		  flagShortPulseDPG = applyPulseDPG_ && ( hcalSevLvlComputer->getSeverityLevel(theShortDetId, theShortFlag & hcalHFDigiTimeFlagValue_, 0)> HcalMaxAllowedHFDigiTimeSev_);
-		  //flagShortDPG =  applyLongShortDPG_ && theShortHit->flagField(HcalCaloFlagLabels::HFLongShort)==1;
-		  //flagShortTimeDPG = applyTimeDPG_ && theShortHit->flagField(HcalCaloFlagLabels::HFInTimeWindow)==1;
-		  //flagShortPulseDPG = applyPulseDPG_ && theShortHit->flagField(HcalCaloFlagLabels::HFDigiTime)==1;
-		}
+          // Some cleaning in the HF
+          double longFibre = energyemHF + energyhadHF / 2.;
+          double shortFibre = energyhadHF / 2.;
+          int ieta = detid.ieta();
+          int iphi = detid.iphi();
+          HcalDetId theLongDetId(HcalForward, ieta, iphi, 1);
+          HcalDetId theShortDetId(HcalForward, ieta, iphi, 2);
+          typedef HFRecHitCollection::const_iterator iHF;
+          auto theLongHit = hfHandle->find(theLongDetId);
+          auto theShortHit = hfHandle->find(theShortDetId);
+          //
+          double theLongHitEnergy = 0.;
+          double theShortHitEnergy = 0.;
+          bool flagShortDPG = false;
+          bool flagLongDPG = false;
+          bool flagShortTimeDPG = false;
+          bool flagLongTimeDPG = false;
+          bool flagShortPulseDPG = false;
+          bool flagLongPulseDPG = false;
+          //
+          if (theLongHit != hfHandle->end()) {
+            int theLongFlag = theLongHit->flags();
+            theLongHitEnergy = theLongHit->energy();
+            flagLongDPG = applyLongShortDPG_ && (hcalSevLvlComputer->getSeverityLevel(
+                                                     theLongDetId, theLongFlag & hcalHFLongShortFlagValue_, 0) >
+                                                 HcalMaxAllowedHFLongShortSev_);
+            flagLongTimeDPG = applyTimeDPG_ && (hcalSevLvlComputer->getSeverityLevel(
+                                                    theLongDetId, theLongFlag & hcalHFInTimeWindowFlagValue_, 0) >
+                                                HcalMaxAllowedHFInTimeWindowSev_);
+            flagLongPulseDPG = applyPulseDPG_ && (hcalSevLvlComputer->getSeverityLevel(
+                                                      theLongDetId, theLongFlag & hcalHFDigiTimeFlagValue_, 0) >
+                                                  HcalMaxAllowedHFDigiTimeSev_);
 
-		// Then check the timing in short and long fibres in all other towers.
-		if ( theShortHitEnergy > longShortFibre_Cut && 
-		     ( theShortHit->time() < minShortTiming_Cut ||
-		       theShortHit->time() > maxShortTiming_Cut || 
-		       flagShortTimeDPG || flagShortPulseDPG ) ) { 
-		  // rescaleFactor = 0. ;
-		  pfrhHFHADCleaned = createHcalRecHit( detid, 
-						       theShortHitEnergy, 
-						       PFLayer::HF_HAD, 
-						       hcalEndcapGeometry,
-						       ct.id() );
-		  pfrhHFHADCleaned->setTime(theShortHit->time());
-		  /*
+            //flagLongDPG =  applyLongShortDPG_ && theLongHit->flagField(HcalCaloFlagLabels::HFLongShort)==1;
+            //flagLongTimeDPG = applyTimeDPG_ && theLongHit->flagField(HcalCaloFlagLabels::HFInTimeWindow)==1;
+            //flagLongPulseDPG = applyPulseDPG_ && theLongHit->flagField(HcalCaloFlagLabels::HFDigiTime)==1;
+          }
+          //
+          if (theShortHit != hfHandle->end()) {
+            int theShortFlag = theShortHit->flags();
+            theShortHitEnergy = theShortHit->energy();
+            flagShortDPG = applyLongShortDPG_ && (hcalSevLvlComputer->getSeverityLevel(
+                                                      theShortDetId, theShortFlag & hcalHFLongShortFlagValue_, 0) >
+                                                  HcalMaxAllowedHFLongShortSev_);
+            flagShortTimeDPG = applyTimeDPG_ && (hcalSevLvlComputer->getSeverityLevel(
+                                                     theShortDetId, theShortFlag & hcalHFInTimeWindowFlagValue_, 0) >
+                                                 HcalMaxAllowedHFInTimeWindowSev_);
+            flagShortPulseDPG = applyPulseDPG_ && (hcalSevLvlComputer->getSeverityLevel(
+                                                       theShortDetId, theShortFlag & hcalHFDigiTimeFlagValue_, 0) >
+                                                   HcalMaxAllowedHFDigiTimeSev_);
+            //flagShortDPG =  applyLongShortDPG_ && theShortHit->flagField(HcalCaloFlagLabels::HFLongShort)==1;
+            //flagShortTimeDPG = applyTimeDPG_ && theShortHit->flagField(HcalCaloFlagLabels::HFInTimeWindow)==1;
+            //flagShortPulseDPG = applyPulseDPG_ && theShortHit->flagField(HcalCaloFlagLabels::HFDigiTime)==1;
+          }
+
+          // Then check the timing in short and long fibres in all other towers.
+          if (theShortHitEnergy > longShortFibre_Cut &&
+              (theShortHit->time() < minShortTiming_Cut || theShortHit->time() > maxShortTiming_Cut ||
+               flagShortTimeDPG || flagShortPulseDPG)) {
+            // rescaleFactor = 0. ;
+            pfrhHFHADCleaned = createHcalRecHit(detid, theShortHitEnergy, PFLayer::HF_HAD, hcalEndcapGeometry, ct.id());
+            pfrhHFHADCleaned->setTime(theShortHit->time());
+            /*
 		  std::cout << "ieta/iphi = " << ieta << " " << iphi 
 			    << ", Energy em/had/long/short = " 
 			    << energyemHF << " " << energyhadHF << " "
@@ -349,23 +317,17 @@ void PFCTRecHitProducer::produce(edm::Event& iEvent,
 			    << flagShortPulseDPG << " " << flagLongPulseDPG << " "  
 			    << ". Short fibres were cleaned." << std::endl;
 		  */
-		  shortFibre -= theShortHitEnergy;
-		  theShortHitEnergy = 0.;
-		}
-		
-		
-		if ( theLongHitEnergy > longShortFibre_Cut && 
-		     ( theLongHit->time() < minLongTiming_Cut ||
-		       theLongHit->time() > maxLongTiming_Cut  || 
-		       flagLongTimeDPG || flagLongPulseDPG ) ) { 
-		  //rescaleFactor = 0. ;
-		  pfrhHFEMCleaned = createHcalRecHit( detid, 
-						      theLongHitEnergy, 
-						      PFLayer::HF_EM, 
-						      hcalEndcapGeometry,
-						      ct.id());
-		  pfrhHFEMCleaned->setTime(theLongHit->time());
-		  /*
+            shortFibre -= theShortHitEnergy;
+            theShortHitEnergy = 0.;
+          }
+
+          if (theLongHitEnergy > longShortFibre_Cut &&
+              (theLongHit->time() < minLongTiming_Cut || theLongHit->time() > maxLongTiming_Cut || flagLongTimeDPG ||
+               flagLongPulseDPG)) {
+            //rescaleFactor = 0. ;
+            pfrhHFEMCleaned = createHcalRecHit(detid, theLongHitEnergy, PFLayer::HF_EM, hcalEndcapGeometry, ct.id());
+            pfrhHFEMCleaned->setTime(theLongHit->time());
+            /*
 		  std::cout << "ieta/iphi = " << ieta << " " << iphi 
 			    << ", Energy em/had/long/short = " 
 			    << energyemHF << " " << energyhadHF << " "
@@ -377,30 +339,26 @@ void PFCTRecHitProducer::produce(edm::Event& iEvent,
 			    << flagShortPulseDPG << " " << flagLongPulseDPG << " "  
 			    << ". Long fibres were cleaned." << std::endl;
 		  */
-		  longFibre -= theLongHitEnergy;
-		  theLongHitEnergy = 0.;
-		}
+            longFibre -= theLongHitEnergy;
+            theLongHitEnergy = 0.;
+          }
 
-		// Some energy must be in the long fibres is there is some energy in the short fibres ! 
-		if ( theShortHitEnergy > shortFibre_Cut && 
-		     ( theLongHitEnergy/theShortHitEnergy < longFibre_Fraction || 
-		       flagShortDPG ) ) {
-		  // Check if the long-fibre hit was not cleaned already (because hot)
-		  // In this case don't apply the cleaning
-		  const HcalChannelStatus* theStatus = theHcalChStatus->getValues(theLongDetId);
-		  unsigned theStatusValue = theStatus->getValue();
-		  int theSeverityLevel = hcalSevLvlComputer->getSeverityLevel(detid, 0, theStatusValue);
-		  // The channel is killed
-		  /// if ( !theStatusValue ) 
-		  if (theSeverityLevel<=HcalMaxAllowedChannelStatusSev_) {
-		    // rescaleFactor = 0. ;
-		    pfrhHFHADCleaned = createHcalRecHit( detid, 
-							 theShortHitEnergy, 
-							 PFLayer::HF_HAD, 
-							 hcalEndcapGeometry,
-							 ct.id() );
-		    pfrhHFHADCleaned->setTime(theShortHit->time());
-		    /*
+          // Some energy must be in the long fibres is there is some energy in the short fibres !
+          if (theShortHitEnergy > shortFibre_Cut &&
+              (theLongHitEnergy / theShortHitEnergy < longFibre_Fraction || flagShortDPG)) {
+            // Check if the long-fibre hit was not cleaned already (because hot)
+            // In this case don't apply the cleaning
+            const HcalChannelStatus* theStatus = theHcalChStatus->getValues(theLongDetId);
+            unsigned theStatusValue = theStatus->getValue();
+            int theSeverityLevel = hcalSevLvlComputer->getSeverityLevel(detid, 0, theStatusValue);
+            // The channel is killed
+            /// if ( !theStatusValue )
+            if (theSeverityLevel <= HcalMaxAllowedChannelStatusSev_) {
+              // rescaleFactor = 0. ;
+              pfrhHFHADCleaned =
+                  createHcalRecHit(detid, theShortHitEnergy, PFLayer::HF_HAD, hcalEndcapGeometry, ct.id());
+              pfrhHFHADCleaned->setTime(theShortHit->time());
+              /*
 		    std::cout << "ieta/iphi = " << ieta << " " << iphi 
 			      << ", Energy em/had/long/short = " 
 			      << energyemHF << " " << energyhadHF << " "
@@ -413,32 +371,26 @@ void PFCTRecHitProducer::produce(edm::Event& iEvent,
 			      << flagShortPulseDPG << " " << flagLongPulseDPG << " "  
 			      << ". Short fibres were cleaned." << std::endl;
 		    */
-		    shortFibre -= theShortHitEnergy;
-		    theShortHitEnergy = 0.;
-		  }
-		}
+              shortFibre -= theShortHitEnergy;
+              theShortHitEnergy = 0.;
+            }
+          }
 
-		if ( theLongHitEnergy > longFibre_Cut && 
-		     ( theShortHitEnergy/theLongHitEnergy < shortFibre_Fraction || 
-		       flagLongDPG ) ) {
-		  // Check if the long-fibre hit was not cleaned already (because hot)
-		  // In this case don't apply the cleaning
-		  const HcalChannelStatus* theStatus = theHcalChStatus->getValues(theShortDetId);
-		  unsigned theStatusValue = theStatus->getValue();
+          if (theLongHitEnergy > longFibre_Cut &&
+              (theShortHitEnergy / theLongHitEnergy < shortFibre_Fraction || flagLongDPG)) {
+            // Check if the long-fibre hit was not cleaned already (because hot)
+            // In this case don't apply the cleaning
+            const HcalChannelStatus* theStatus = theHcalChStatus->getValues(theShortDetId);
+            unsigned theStatusValue = theStatus->getValue();
 
-		  int theSeverityLevel = hcalSevLvlComputer->getSeverityLevel(detid, 0, theStatusValue);
-		  // The channel is killed
-		  /// if ( !theStatusValue ) 
-		  if (theSeverityLevel<=HcalMaxAllowedChannelStatusSev_) {
-		    
-		    //rescaleFactor = 0. ;
-		    pfrhHFEMCleaned = createHcalRecHit( detid, 
-						      theLongHitEnergy, 
-						      PFLayer::HF_EM, 
-						      hcalEndcapGeometry,
-						      ct.id() );
-		    pfrhHFEMCleaned->setTime(theLongHit->time());
-		    /*
+            int theSeverityLevel = hcalSevLvlComputer->getSeverityLevel(detid, 0, theStatusValue);
+            // The channel is killed
+            /// if ( !theStatusValue )
+            if (theSeverityLevel <= HcalMaxAllowedChannelStatusSev_) {
+              //rescaleFactor = 0. ;
+              pfrhHFEMCleaned = createHcalRecHit(detid, theLongHitEnergy, PFLayer::HF_EM, hcalEndcapGeometry, ct.id());
+              pfrhHFEMCleaned->setTime(theLongHit->time());
+              /*
 		    std::cout << "ieta/iphi = " << ieta << " " << iphi 
 			      << ", Energy em/had/long/short = " 
 			      << energyemHF << " " << energyhadHF << " "
@@ -451,107 +403,113 @@ void PFCTRecHitProducer::produce(edm::Event& iEvent,
 			      << flagShortPulseDPG << " " << flagLongPulseDPG << " "  
 			      << ". Long fibres were cleaned." << std::endl;
 		    */
-		    longFibre -= theLongHitEnergy;
-		    theLongHitEnergy = 0.;
-		  }
-		}
+              longFibre -= theLongHitEnergy;
+              theLongHitEnergy = 0.;
+            }
+          }
 
-		// Special treatment for tower 29
-		// A tower with energy only at ieta = +/- 29 is not physical -> Clean
-		if ( abs(ieta) == 29 ) { 
-		  // rescaleFactor = 0. ;
-		  // Clean long fibres
-		  if ( theLongHitEnergy > shortFibre_Cut/2. ) { 
-		    pfrhHFEMCleaned29 = createHcalRecHit( detid, 
-							  theLongHitEnergy, 
-							  PFLayer::HF_EM, 
-							  hcalEndcapGeometry,
-							  ct.id() );
-		    pfrhHFEMCleaned29->setTime(theLongHit->time());
-		    /*
+          // Special treatment for tower 29
+          // A tower with energy only at ieta = +/- 29 is not physical -> Clean
+          if (abs(ieta) == 29) {
+            // rescaleFactor = 0. ;
+            // Clean long fibres
+            if (theLongHitEnergy > shortFibre_Cut / 2.) {
+              pfrhHFEMCleaned29 =
+                  createHcalRecHit(detid, theLongHitEnergy, PFLayer::HF_EM, hcalEndcapGeometry, ct.id());
+              pfrhHFEMCleaned29->setTime(theLongHit->time());
+              /*
 		    std::cout << "ieta/iphi = " << ieta << " " << iphi 
 			      << ", Energy em/had/long/short = " 
 			      << energyemHF << " " << energyhadHF << " "
 			      << theLongHitEnergy << " " << theShortHitEnergy << " " 
 			      << ". Long fibres were cleaned." << std::endl;
 		    */
-		    longFibre -= theLongHitEnergy;
-		    theLongHitEnergy = 0.;
-		  }
-		  // Clean short fibres
-		  if ( theShortHitEnergy > shortFibre_Cut/2. ) { 
-		    pfrhHFHADCleaned29 = createHcalRecHit( detid, 
-							   theShortHitEnergy, 
-							   PFLayer::HF_HAD, 
-							   hcalEndcapGeometry,
-							   ct.id());
-		    pfrhHFHADCleaned29->setTime(theShortHit->time());
-		    /*
+              longFibre -= theLongHitEnergy;
+              theLongHitEnergy = 0.;
+            }
+            // Clean short fibres
+            if (theShortHitEnergy > shortFibre_Cut / 2.) {
+              pfrhHFHADCleaned29 =
+                  createHcalRecHit(detid, theShortHitEnergy, PFLayer::HF_HAD, hcalEndcapGeometry, ct.id());
+              pfrhHFHADCleaned29->setTime(theShortHit->time());
+              /*
 		    std::cout << "ieta/iphi = " << ieta << " " << iphi 
 			      << ", Energy em/had/long/short = " 
 			      << energyemHF << " " << energyhadHF << " "
 			      << theLongHitEnergy << " " << theShortHitEnergy << " " 
 			      << ". Short fibres were cleaned." << std::endl;
 		    */
-		    shortFibre -= theShortHitEnergy;
-		    theShortHitEnergy = 0.;
-		  }
-		}
-		// Check the timing of the long and short fibre rechits
-		
-		// First, check the timing of long and short fibre in eta = 29 if tower 30.
-		else if ( abs(ieta) == 30 ) { 
-		  int ieta29 = ieta > 0 ? 29 : -29;
-		  HcalDetId theLongDetId29 (HcalForward, ieta29, iphi, 1);
-		  HcalDetId theShortDetId29 (HcalForward, ieta29, iphi, 2);
-		  auto theLongHit29 = hfHandle->find(theLongDetId29); 
-		  auto theShortHit29 = hfHandle->find(theShortDetId29); 
-		  // 
-		  double theLongHitEnergy29 = 0.;
-		  double theShortHitEnergy29 = 0.;
-		  bool flagShortDPG29 =  false; 
-		  bool flagLongDPG29 = false; 
-		  bool flagShortTimeDPG29 = false; 
-		  bool flagLongTimeDPG29 = false;
-		  bool flagShortPulseDPG29 = false;
-		  bool flagLongPulseDPG29 = false;
-		  //
-		  if ( theLongHit29 != hfHandle->end() ) { 
-		    int theLongFlag29 = theLongHit29->flags();
-		    theLongHitEnergy29 = theLongHit29->energy() ;
-		    flagLongDPG29 = applyLongShortDPG_ && ( hcalSevLvlComputer->getSeverityLevel(theLongDetId29, theLongFlag29 & hcalHFLongShortFlagValue_, 0)> HcalMaxAllowedHFLongShortSev_);
-		    flagLongTimeDPG29 = applyTimeDPG_ && ( hcalSevLvlComputer->getSeverityLevel(theLongDetId29, theLongFlag29 & hcalHFInTimeWindowFlagValue_, 0)> HcalMaxAllowedHFInTimeWindowSev_);
-		    flagLongPulseDPG29 = applyPulseDPG_ && ( hcalSevLvlComputer->getSeverityLevel(theLongDetId29, theLongFlag29 & hcalHFDigiTimeFlagValue_, 0)> HcalMaxAllowedHFDigiTimeSev_);
+              shortFibre -= theShortHitEnergy;
+              theShortHitEnergy = 0.;
+            }
+          }
+          // Check the timing of the long and short fibre rechits
 
-		    //flagLongDPG29 = applyLongShortDPG_ && theLongHit29->flagField(HcalCaloFlagLabels::HFLongShort)==1;
-		    //flagLongTimeDPG29 = applyTimeDPG_ && theLongHit29->flagField(HcalCaloFlagLabels::HFInTimeWindow)==1;
-		    //flagLongPulseDPG29 = applyPulseDPG_ && theLongHit29->flagField(HcalCaloFlagLabels::HFDigiTime)==1;
-		  }
-		  //
-		  if ( theShortHit29 != hfHandle->end() ) { 
-		    int theShortFlag29 = theShortHit29->flags();
-		    theShortHitEnergy29 = theShortHit29->energy();		  
-		    flagShortDPG29 = applyLongShortDPG_ && ( hcalSevLvlComputer->getSeverityLevel(theShortDetId29, theShortFlag29 & hcalHFLongShortFlagValue_, 0)> HcalMaxAllowedHFLongShortSev_);
-		    flagShortTimeDPG29 = applyTimeDPG_ && ( hcalSevLvlComputer->getSeverityLevel(theShortDetId29, theShortFlag29 & hcalHFInTimeWindowFlagValue_, 0)> HcalMaxAllowedHFInTimeWindowSev_);
-		    flagLongPulseDPG29 = applyPulseDPG_ && ( hcalSevLvlComputer->getSeverityLevel(theShortDetId29, theShortFlag29 & hcalHFDigiTimeFlagValue_, 0)> HcalMaxAllowedHFDigiTimeSev_);
+          // First, check the timing of long and short fibre in eta = 29 if tower 30.
+          else if (abs(ieta) == 30) {
+            int ieta29 = ieta > 0 ? 29 : -29;
+            HcalDetId theLongDetId29(HcalForward, ieta29, iphi, 1);
+            HcalDetId theShortDetId29(HcalForward, ieta29, iphi, 2);
+            auto theLongHit29 = hfHandle->find(theLongDetId29);
+            auto theShortHit29 = hfHandle->find(theShortDetId29);
+            //
+            double theLongHitEnergy29 = 0.;
+            double theShortHitEnergy29 = 0.;
+            bool flagShortDPG29 = false;
+            bool flagLongDPG29 = false;
+            bool flagShortTimeDPG29 = false;
+            bool flagLongTimeDPG29 = false;
+            bool flagShortPulseDPG29 = false;
+            bool flagLongPulseDPG29 = false;
+            //
+            if (theLongHit29 != hfHandle->end()) {
+              int theLongFlag29 = theLongHit29->flags();
+              theLongHitEnergy29 = theLongHit29->energy();
+              flagLongDPG29 = applyLongShortDPG_ && (hcalSevLvlComputer->getSeverityLevel(
+                                                         theLongDetId29, theLongFlag29 & hcalHFLongShortFlagValue_, 0) >
+                                                     HcalMaxAllowedHFLongShortSev_);
+              flagLongTimeDPG29 =
+                  applyTimeDPG_ && (hcalSevLvlComputer->getSeverityLevel(theLongDetId29,
+                                                                         theLongFlag29 & hcalHFInTimeWindowFlagValue_,
+                                                                         0) > HcalMaxAllowedHFInTimeWindowSev_);
+              flagLongPulseDPG29 = applyPulseDPG_ && (hcalSevLvlComputer->getSeverityLevel(
+                                                          theLongDetId29, theLongFlag29 & hcalHFDigiTimeFlagValue_, 0) >
+                                                      HcalMaxAllowedHFDigiTimeSev_);
 
-		    //flagShortDPG29 = applyLongShortDPG_ && theShortHit29->flagField(HcalCaloFlagLabels::HFLongShort)==1;
-		    //flagShortTimeDPG29 = applyTimeDPG_ && theShortHit29->flagField(HcalCaloFlagLabels::HFInTimeWindow)==1;
-		    //flagShortPulseDPG29 = applyPulseDPG_ && theShortHit29->flagField(HcalCaloFlagLabels::HFDigiTime)==1;
-		  }
+              //flagLongDPG29 = applyLongShortDPG_ && theLongHit29->flagField(HcalCaloFlagLabels::HFLongShort)==1;
+              //flagLongTimeDPG29 = applyTimeDPG_ && theLongHit29->flagField(HcalCaloFlagLabels::HFInTimeWindow)==1;
+              //flagLongPulseDPG29 = applyPulseDPG_ && theLongHit29->flagField(HcalCaloFlagLabels::HFDigiTime)==1;
+            }
+            //
+            if (theShortHit29 != hfHandle->end()) {
+              int theShortFlag29 = theShortHit29->flags();
+              theShortHitEnergy29 = theShortHit29->energy();
+              flagShortDPG29 =
+                  applyLongShortDPG_ &&
+                  (hcalSevLvlComputer->getSeverityLevel(
+                       theShortDetId29, theShortFlag29 & hcalHFLongShortFlagValue_, 0) > HcalMaxAllowedHFLongShortSev_);
+              flagShortTimeDPG29 =
+                  applyTimeDPG_ && (hcalSevLvlComputer->getSeverityLevel(theShortDetId29,
+                                                                         theShortFlag29 & hcalHFInTimeWindowFlagValue_,
+                                                                         0) > HcalMaxAllowedHFInTimeWindowSev_);
+              flagLongPulseDPG29 =
+                  applyPulseDPG_ &&
+                  (hcalSevLvlComputer->getSeverityLevel(theShortDetId29, theShortFlag29 & hcalHFDigiTimeFlagValue_, 0) >
+                   HcalMaxAllowedHFDigiTimeSev_);
 
-		  if ( theLongHitEnergy29 > longShortFibre_Cut && 
-		       ( theLongHit29->time() < minLongTiming_Cut ||
-		         theLongHit29->time() > maxLongTiming_Cut ||
-			 flagLongTimeDPG29 || flagLongPulseDPG29 ) ) { 
-		    //rescaleFactor = 0. ;
-		    pfrhHFEMCleaned29 = createHcalRecHit( detid, 
-							  theLongHitEnergy29, 
-							  PFLayer::HF_EM, 
-							  hcalEndcapGeometry,
-							  ct.id() );
-		    pfrhHFEMCleaned29->setTime(theLongHit29->time());
-		    /*
+              //flagShortDPG29 = applyLongShortDPG_ && theShortHit29->flagField(HcalCaloFlagLabels::HFLongShort)==1;
+              //flagShortTimeDPG29 = applyTimeDPG_ && theShortHit29->flagField(HcalCaloFlagLabels::HFInTimeWindow)==1;
+              //flagShortPulseDPG29 = applyPulseDPG_ && theShortHit29->flagField(HcalCaloFlagLabels::HFDigiTime)==1;
+            }
+
+            if (theLongHitEnergy29 > longShortFibre_Cut &&
+                (theLongHit29->time() < minLongTiming_Cut || theLongHit29->time() > maxLongTiming_Cut ||
+                 flagLongTimeDPG29 || flagLongPulseDPG29)) {
+              //rescaleFactor = 0. ;
+              pfrhHFEMCleaned29 =
+                  createHcalRecHit(detid, theLongHitEnergy29, PFLayer::HF_EM, hcalEndcapGeometry, ct.id());
+              pfrhHFEMCleaned29->setTime(theLongHit29->time());
+              /*
 		    std::cout << "ieta/iphi = " << ieta29 << " " << iphi 
 			      << ", Energy em/had/long/short = " 
 			      << energyemHF << " " << energyhadHF << " "
@@ -563,22 +521,18 @@ void PFCTRecHitProducer::produce(edm::Event& iEvent,
 			      << flagShortPulseDPG29 << " " << flagLongPulseDPG29 << " "  
 			      << ". Long fibres were cleaned." << std::endl;
 		    */
-		    longFibre -= theLongHitEnergy29;
-		    theLongHitEnergy29 = 0;
-		  }
+              longFibre -= theLongHitEnergy29;
+              theLongHitEnergy29 = 0;
+            }
 
-		  if ( theShortHitEnergy29 > longShortFibre_Cut && 
-		       ( theShortHit29->time() < minShortTiming_Cut ||
-		         theShortHit29->time() > maxShortTiming_Cut ||
-			 flagShortTimeDPG29 || flagShortPulseDPG29 ) ) { 
-		    //rescaleFactor = 0. ;
-		    pfrhHFHADCleaned29 = createHcalRecHit( detid, 
-							 theShortHitEnergy29, 
-							 PFLayer::HF_HAD, 
-							 hcalEndcapGeometry,
-							 ct.id() );
-		    pfrhHFHADCleaned29->setTime(theShortHit29->time());
-		    /*
+            if (theShortHitEnergy29 > longShortFibre_Cut &&
+                (theShortHit29->time() < minShortTiming_Cut || theShortHit29->time() > maxShortTiming_Cut ||
+                 flagShortTimeDPG29 || flagShortPulseDPG29)) {
+              //rescaleFactor = 0. ;
+              pfrhHFHADCleaned29 =
+                  createHcalRecHit(detid, theShortHitEnergy29, PFLayer::HF_HAD, hcalEndcapGeometry, ct.id());
+              pfrhHFHADCleaned29->setTime(theShortHit29->time());
+              /*
 		    std::cout << "ieta/iphi = " << ieta29 << " " << iphi 
 			      << ", Energy em/had/long/short = " 
 			      << energyemHF << " " << energyhadHF << " "
@@ -590,31 +544,27 @@ void PFCTRecHitProducer::produce(edm::Event& iEvent,
 			      << flagShortPulseDPG29 << " " << flagLongPulseDPG29 << " "  
 			      << ". Short fibres were cleaned." << std::endl;
 		    */
-		    shortFibre -= theShortHitEnergy29;
-		    theShortHitEnergy29 = 0;
-		  }
+              shortFibre -= theShortHitEnergy29;
+              theShortHitEnergy29 = 0;
+            }
 
-		  // Some energy must be in the long fibres is there is some energy in the short fibres ! 
-		  if ( theShortHitEnergy29 > shortFibre_Cut && 
-		       ( theLongHitEnergy29/theShortHitEnergy29 < 2.*longFibre_Fraction || 
-			 flagShortDPG29 ) ) {
-		    // Check if the long-fibre hit was not cleaned already (because hot)
-		    // In this case don't apply the cleaning
-		    const HcalChannelStatus* theStatus = theHcalChStatus->getValues(theLongDetId29);
-		    unsigned theStatusValue = theStatus->getValue();
+            // Some energy must be in the long fibres is there is some energy in the short fibres !
+            if (theShortHitEnergy29 > shortFibre_Cut &&
+                (theLongHitEnergy29 / theShortHitEnergy29 < 2. * longFibre_Fraction || flagShortDPG29)) {
+              // Check if the long-fibre hit was not cleaned already (because hot)
+              // In this case don't apply the cleaning
+              const HcalChannelStatus* theStatus = theHcalChStatus->getValues(theLongDetId29);
+              unsigned theStatusValue = theStatus->getValue();
 
-		    int theSeverityLevel = hcalSevLvlComputer->getSeverityLevel(detid, 0, theStatusValue);
-		    // The channel is killed
-		    /// if ( !theStatusValue ) 
-		    if (theSeverityLevel<=HcalMaxAllowedChannelStatusSev_) {
-		      //rescaleFactor = 0. ;
-		      pfrhHFHADCleaned29 = createHcalRecHit( detid, 
-							   theShortHitEnergy29, 
-							   PFLayer::HF_HAD, 
-							   hcalEndcapGeometry,
-							   ct.id() );
-		      pfrhHFHADCleaned29->setTime(theShortHit29->time());
-		      /*
+              int theSeverityLevel = hcalSevLvlComputer->getSeverityLevel(detid, 0, theStatusValue);
+              // The channel is killed
+              /// if ( !theStatusValue )
+              if (theSeverityLevel <= HcalMaxAllowedChannelStatusSev_) {
+                //rescaleFactor = 0. ;
+                pfrhHFHADCleaned29 =
+                    createHcalRecHit(detid, theShortHitEnergy29, PFLayer::HF_HAD, hcalEndcapGeometry, ct.id());
+                pfrhHFHADCleaned29->setTime(theShortHit29->time());
+                /*
 		      std::cout << "ieta/iphi = " << ieta29 << " " << iphi 
 				<< ", Energy em/had/long/short = " 
 				<< energyemHF << " " << energyhadHF << " "
@@ -627,32 +577,27 @@ void PFCTRecHitProducer::produce(edm::Event& iEvent,
 				<< flagShortPulseDPG29 << " " << flagLongPulseDPG29 << " "  
 				<< ". Short fibres were cleaned." << std::endl;
 		      */
-		      shortFibre -= theShortHitEnergy29;
-		      theShortHitEnergy29 = 0.;
-		    }	    
-		  }
-				  
-		  // Some energy must be in the short fibres is there is some energy in the long fibres ! 
-		  if ( theLongHitEnergy29 > longFibre_Cut && 
-		       ( theShortHitEnergy29/theLongHitEnergy29 < shortFibre_Fraction || 
-			 flagLongDPG29 ) ) {
-		    // Check if the long-fibre hit was not cleaned already (because hot)
-		    // In this case don't apply the cleaning
-		    const HcalChannelStatus* theStatus = theHcalChStatus->getValues(theShortDetId29);
-		    unsigned theStatusValue = theStatus->getValue();
-		    int theSeverityLevel = hcalSevLvlComputer->getSeverityLevel(detid, 0, theStatusValue);
-		    // The channel is killed
-		    /// if ( !theStatusValue ) 
-		    if (theSeverityLevel<=HcalMaxAllowedChannelStatusSev_) {
+                shortFibre -= theShortHitEnergy29;
+                theShortHitEnergy29 = 0.;
+              }
+            }
 
-		      //rescaleFactor = 0. ;
-		      pfrhHFEMCleaned29 = createHcalRecHit( detid, 
-							    theLongHitEnergy29, 
-							    PFLayer::HF_EM, 
-							    hcalEndcapGeometry,
-							    ct.id() );
-		      pfrhHFEMCleaned29->setTime(theLongHit29->time());
-		      /* 
+            // Some energy must be in the short fibres is there is some energy in the long fibres !
+            if (theLongHitEnergy29 > longFibre_Cut &&
+                (theShortHitEnergy29 / theLongHitEnergy29 < shortFibre_Fraction || flagLongDPG29)) {
+              // Check if the long-fibre hit was not cleaned already (because hot)
+              // In this case don't apply the cleaning
+              const HcalChannelStatus* theStatus = theHcalChStatus->getValues(theShortDetId29);
+              unsigned theStatusValue = theStatus->getValue();
+              int theSeverityLevel = hcalSevLvlComputer->getSeverityLevel(detid, 0, theStatusValue);
+              // The channel is killed
+              /// if ( !theStatusValue )
+              if (theSeverityLevel <= HcalMaxAllowedChannelStatusSev_) {
+                //rescaleFactor = 0. ;
+                pfrhHFEMCleaned29 =
+                    createHcalRecHit(detid, theLongHitEnergy29, PFLayer::HF_EM, hcalEndcapGeometry, ct.id());
+                pfrhHFEMCleaned29->setTime(theLongHit29->time());
+                /* 
 		      std::cout << "ieta/iphi = " << ieta29 << " " << iphi 
 				<< ", Energy em/had/long/short = " 
 				<< energyemHF << " " << energyhadHF << " "
@@ -665,177 +610,145 @@ void PFCTRecHitProducer::produce(edm::Event& iEvent,
 				<< flagShortPulseDPG29 << " " << flagLongPulseDPG29 << " "  
 				<< ". Long fibres were cleaned." << std::endl;
 		      */
-		      longFibre -= theLongHitEnergy29;
-		      theLongHitEnergy29 = 0.;
-		    }
-		  }
+                longFibre -= theLongHitEnergy29;
+                theLongHitEnergy29 = 0.;
+              }
+            }
 
-		
-		  // Check that the energy in tower 29 is smaller than in tower 30
-		  // First in long fibres
-		  if ( theLongHitEnergy29 > std::max(theLongHitEnergy,shortFibre_Cut/2) ) { 
-		    pfrhHFEMCleaned29 = createHcalRecHit( detid, 
-							  theLongHitEnergy29, 
-							  PFLayer::HF_EM, 
-							  hcalEndcapGeometry,
-							  ct.id() );
-		    pfrhHFEMCleaned29->setTime(theLongHit29->time());
-		    /*
+            // Check that the energy in tower 29 is smaller than in tower 30
+            // First in long fibres
+            if (theLongHitEnergy29 > std::max(theLongHitEnergy, shortFibre_Cut / 2)) {
+              pfrhHFEMCleaned29 =
+                  createHcalRecHit(detid, theLongHitEnergy29, PFLayer::HF_EM, hcalEndcapGeometry, ct.id());
+              pfrhHFEMCleaned29->setTime(theLongHit29->time());
+              /*
 		    std::cout << "ieta/iphi = " << ieta29 << " " << iphi 
 			      << ", Energy L29/S29/L30/S30 = " 
 			      << theLongHitEnergy29 << " " << theShortHitEnergy29 << " "
 			      << theLongHitEnergy << " " << theShortHitEnergy << " " 
 			      << ". Long fibres were cleaned." << std::endl;
 		    */
-		    longFibre -= theLongHitEnergy29;
-		    theLongHitEnergy29 = 0.;
-		  }
-		  // Second in short fibres
-		  if ( theShortHitEnergy29 > std::max(theShortHitEnergy,shortFibre_Cut/2.) ) { 
-		    pfrhHFHADCleaned29 = createHcalRecHit( detid, 
-							   theShortHitEnergy29, 
-							   PFLayer::HF_HAD, 
-							   hcalEndcapGeometry,
-							   ct.id() );
-		    pfrhHFHADCleaned29->setTime(theShortHit29->time());
-		    /*
+              longFibre -= theLongHitEnergy29;
+              theLongHitEnergy29 = 0.;
+            }
+            // Second in short fibres
+            if (theShortHitEnergy29 > std::max(theShortHitEnergy, shortFibre_Cut / 2.)) {
+              pfrhHFHADCleaned29 =
+                  createHcalRecHit(detid, theShortHitEnergy29, PFLayer::HF_HAD, hcalEndcapGeometry, ct.id());
+              pfrhHFHADCleaned29->setTime(theShortHit29->time());
+              /*
 		    std::cout << "ieta/iphi = " << ieta << " " << iphi 
 			      << ", Energy L29/S29/L30/S30 = " 
 			      << theLongHitEnergy29 << " " << theShortHitEnergy29 << " "
 			      << theLongHitEnergy << " " << theShortHitEnergy << " " 
 			      << ". Short fibres were cleaned." << std::endl;
 		    */
-		    shortFibre -= theShortHitEnergy29;
-		    theShortHitEnergy29 = 0.;
-		  }
-		}
-	      
+              shortFibre -= theShortHitEnergy29;
+              theShortHitEnergy29 = 0.;
+            }
+          }
 
-		// Determine EM and HAD after cleaning of short and long fibres
-		energyhadHF = 2.*shortFibre;
-		energyemHF = longFibre - shortFibre;
+          // Determine EM and HAD after cleaning of short and long fibres
+          energyhadHF = 2. * shortFibre;
+          energyemHF = longFibre - shortFibre;
 
-		// The EM energy might be negative, as it amounts to Long - Short
-		// In that case, put the EM "energy" in the HAD energy
-		// Just to avoid systematic positive bias due to "Short" high fluctuations
-		if ( energyemHF < thresh_HF_ ) { 
-		  energyhadHF += energyemHF;
-		  energyemHF = 0.;
-		}
+          // The EM energy might be negative, as it amounts to Long - Short
+          // In that case, put the EM "energy" in the HAD energy
+          // Just to avoid systematic positive bias due to "Short" high fluctuations
+          if (energyemHF < thresh_HF_) {
+            energyhadHF += energyemHF;
+            energyemHF = 0.;
+          }
 
-		// Apply HCAL calibration factors flor towers close to 29, if requested
-		if ( HF_Calib_ && abs(detid.ieta()) <= 32 ) { 
-		  energyhadHF *= HF_Calib_29;
-		  energyemHF *= HF_Calib_29;
-		}
-				
-		// Create an EM and a HAD rechit if above threshold.
-		if ( energyemHF > thresh_HF_ || energyhadHF > thresh_HF_ ) { 
-		  pfrhHFEM = createHcalRecHit( detid, 
-					       energyemHF, 
-					       PFLayer::HF_EM, 
-					       hcalEndcapGeometry,
-					       ct.id() );
-		  pfrhHFHAD = createHcalRecHit( detid, 
-						energyhadHF, 
-						PFLayer::HF_HAD, 
-						hcalEndcapGeometry,
-						ct.id() );
+          // Apply HCAL calibration factors flor towers close to 29, if requested
+          if (HF_Calib_ && abs(detid.ieta()) <= 32) {
+            energyhadHF *= HF_Calib_29;
+            energyemHF *= HF_Calib_29;
+          }
 
-		}
-		
-	      }
-	      break;
-	    default:
-	      LogError("PFCTRecHitProducerHCAL")
-		<<"CaloTower constituent: unknown layer : "
-		<<detid.subdet()<<endl;
-	    } 
+          // Create an EM and a HAD rechit if above threshold.
+          if (energyemHF > thresh_HF_ || energyhadHF > thresh_HF_) {
+            pfrhHFEM = createHcalRecHit(detid, energyemHF, PFLayer::HF_EM, hcalEndcapGeometry, ct.id());
+            pfrhHFHAD = createHcalRecHit(detid, energyhadHF, PFLayer::HF_HAD, hcalEndcapGeometry, ct.id());
+          }
 
-
-	    if(pfrh) { 
-	      rechits->push_back( *pfrh );
-	      delete pfrh;
-	    }
-	    if(pfrhCleaned) { 
-	      rechitsCleaned->push_back( *pfrhCleaned );
-	      delete pfrhCleaned;
-	    }
-	    if(pfrhHFEM) { 
-	      HFEMRecHits->push_back( *pfrhHFEM );
-	      delete pfrhHFEM;
-	    }
-	    if(pfrhHFHAD) { 
-	      HFHADRecHits->push_back( *pfrhHFHAD );
-	      delete pfrhHFHAD;
-	    }
-	    if(pfrhHFEMCleaned) { 
-	      rechitsCleaned->push_back( *pfrhHFEMCleaned );
-	      delete pfrhHFEMCleaned;
-	    }
-	    if(pfrhHFHADCleaned) { 
-	      rechitsCleaned->push_back( *pfrhHFHADCleaned );
-	      delete pfrhHFHADCleaned;
-	    }
-	    if(pfrhHFEMCleaned29) { 
-	      rechitsCleaned->push_back( *pfrhHFEMCleaned29 );
-	      delete pfrhHFEMCleaned29;
-	    }
-	    if(pfrhHFHADCleaned29) { 
-	      rechitsCleaned->push_back( *pfrhHFHADCleaned29 );
-	      delete pfrhHFHADCleaned29;
-	    }
-      }
-  }
-
-   //ok now do navigation
-   //create a refprod here
-
-   edm::RefProd<reco::PFRecHitCollection> refProd = 
-     iEvent.getRefBeforePut<reco::PFRecHitCollection>();
-
-
-   for( unsigned int i=0;i<rechits->size();++i) {
-     navigator_->associateNeighbours(rechits->at(i),rechits,refProd);
-   }
-
-    if   (navigation_HF_) {
-
-      edm::RefProd<reco::PFRecHitCollection> refProdEM = 
-	iEvent.getRefBeforePut<reco::PFRecHitCollection>("HFEM");
-
-
-      for( unsigned int i=0;i<HFEMRecHits->size();++i) {
-        navigator_->associateNeighbours(HFEMRecHits->at(i),HFEMRecHits,refProdEM);
+        } break;
+        default:
+          LogError("PFCTRecHitProducerHCAL") << "CaloTower constituent: unknown layer : " << detid.subdet() << endl;
       }
 
-      edm::RefProd<reco::PFRecHitCollection> refProdHAD = 
-	iEvent.getRefBeforePut<reco::PFRecHitCollection>("HFHAD");
-
-
-      for( unsigned int i=0;i<HFHADRecHits->size();++i) {
-        navigator_->associateNeighbours(HFHADRecHits->at(i),HFHADRecHits,refProdHAD);
+      if (pfrh) {
+        rechits->push_back(*pfrh);
+        delete pfrh;
+      }
+      if (pfrhCleaned) {
+        rechitsCleaned->push_back(*pfrhCleaned);
+        delete pfrhCleaned;
+      }
+      if (pfrhHFEM) {
+        HFEMRecHits->push_back(*pfrhHFEM);
+        delete pfrhHFEM;
+      }
+      if (pfrhHFHAD) {
+        HFHADRecHits->push_back(*pfrhHFHAD);
+        delete pfrhHFHAD;
+      }
+      if (pfrhHFEMCleaned) {
+        rechitsCleaned->push_back(*pfrhHFEMCleaned);
+        delete pfrhHFEMCleaned;
+      }
+      if (pfrhHFHADCleaned) {
+        rechitsCleaned->push_back(*pfrhHFHADCleaned);
+        delete pfrhHFHADCleaned;
+      }
+      if (pfrhHFEMCleaned29) {
+        rechitsCleaned->push_back(*pfrhHFEMCleaned29);
+        delete pfrhHFEMCleaned29;
+      }
+      if (pfrhHFHADCleaned29) {
+        rechitsCleaned->push_back(*pfrhHFHADCleaned29);
+        delete pfrhHFHADCleaned29;
       }
     }
+  }
 
-  iEvent.put(std::move(rechits),"");
-  iEvent.put(std::move(rechitsCleaned),"Cleaned");
-  iEvent.put(std::move(HFEMRecHits),"HFEM");
-  iEvent.put(std::move(HFHADRecHits),"HFHAD");
+  //ok now do navigation
+  //create a refprod here
 
+  edm::RefProd<reco::PFRecHitCollection> refProd = iEvent.getRefBeforePut<reco::PFRecHitCollection>();
+
+  for (unsigned int i = 0; i < rechits->size(); ++i) {
+    navigator_->associateNeighbours(rechits->at(i), rechits, refProd);
+  }
+
+  if (navigation_HF_) {
+    edm::RefProd<reco::PFRecHitCollection> refProdEM = iEvent.getRefBeforePut<reco::PFRecHitCollection>("HFEM");
+
+    for (unsigned int i = 0; i < HFEMRecHits->size(); ++i) {
+      navigator_->associateNeighbours(HFEMRecHits->at(i), HFEMRecHits, refProdEM);
+    }
+
+    edm::RefProd<reco::PFRecHitCollection> refProdHAD = iEvent.getRefBeforePut<reco::PFRecHitCollection>("HFHAD");
+
+    for (unsigned int i = 0; i < HFHADRecHits->size(); ++i) {
+      navigator_->associateNeighbours(HFHADRecHits->at(i), HFHADRecHits, refProdHAD);
+    }
+  }
+
+  iEvent.put(std::move(rechits), "");
+  iEvent.put(std::move(rechitsCleaned), "Cleaned");
+  iEvent.put(std::move(HFEMRecHits), "HFEM");
+  iEvent.put(std::move(HFHADRecHits), "HFHAD");
 }
 
 PFCTRecHitProducer::~PFCTRecHitProducer() = default;
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
-PFCTRecHitProducer::beginLuminosityBlock(const edm::LuminosityBlock& lumi,
-					 const EventSetup& es) {
-
-  // Get cleaned channels in the HCAL and HF 
+void PFCTRecHitProducer::beginLuminosityBlock(const edm::LuminosityBlock& lumi, const EventSetup& es) {
+  // Get cleaned channels in the HCAL and HF
   // HCAL channel status map ****************************************
-  edm::ESHandle<HcalChannelQuality> hcalChStatus;    
-  es.get<HcalChannelQualityRcd>().get( "withTopo", hcalChStatus );
+  edm::ESHandle<HcalChannelQuality> hcalChStatus;
+  es.get<HcalChannelQualityRcd>().get("withTopo", hcalChStatus);
   theHcalChStatus = hcalChStatus.product();
 
   // Retrieve the good/bad ECAL channels from the DB
@@ -848,37 +761,30 @@ PFCTRecHitProducer::beginLuminosityBlock(const edm::LuminosityBlock& lumi,
   theTowerConstituentsMap = cttopo.product();
 }
 
-
-reco::PFRecHit* 
-PFCTRecHitProducer::createHcalRecHit( const DetId& detid,
-					double energy,
-					PFLayer::Layer layer,
-					const CaloSubdetectorGeometry* geom,
-					const CaloTowerDetId& newDetId ) {
-  
+reco::PFRecHit* PFCTRecHitProducer::createHcalRecHit(const DetId& detid,
+                                                     double energy,
+                                                     PFLayer::Layer layer,
+                                                     const CaloSubdetectorGeometry* geom,
+                                                     const CaloTowerDetId& newDetId) {
   std::shared_ptr<const CaloCellGeometry> thisCell = geom->getGeometry(detid);
-  if(!thisCell) {
+  if (!thisCell) {
     edm::LogError("PFRecHitProducerHCAL")
-      <<"warning detid "<<detid.rawId()<<" not found in layer "
-      <<layer<<endl;
+        << "warning detid " << detid.rawId() << " not found in layer " << layer << endl;
     return nullptr;
   }
-    
-  switch ( layer ) { 
-  case PFLayer::HF_EM:
-  case PFLayer::HF_HAD:
-  {
-    auto zp = dynamic_cast<IdealZPrism const*>(thisCell.get());
-    assert(zp);
-    thisCell = zp->forPF();
-  }
-    break;
-  default:
-    break;
+
+  switch (layer) {
+    case PFLayer::HF_EM:
+    case PFLayer::HF_HAD: {
+      auto zp = dynamic_cast<IdealZPrism const*>(thisCell.get());
+      assert(zp);
+      thisCell = zp->forPF();
+    } break;
+    default:
+      break;
   }
 
-  auto rh = 
-    new reco::PFRecHit(thisCell, newDetId.rawId(),  layer, energy);
- 
+  auto rh = new reco::PFRecHit(thisCell, newDetId.rawId(), layer, energy);
+
   return rh;
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFCTRecHitProducer.h
@@ -28,33 +28,28 @@
 #include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 
-
 class CaloSubdetectorTopology;
 class CaloSubdetectorGeometry;
 class DetId;
 
 class dso_hidden PFCTRecHitProducer final : public edm::stream::EDProducer<> {
- public:
+public:
   explicit PFCTRecHitProducer(const edm::ParameterSet&);
   ~PFCTRecHitProducer() override;
 
-  void beginLuminosityBlock(const edm::LuminosityBlock& lumi, 
-				    const edm::EventSetup & es) override;
-  
-  void produce(edm::Event& iEvent, 
-	       const edm::EventSetup& iSetup) override;
+  void beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& es) override;
 
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
-  reco::PFRecHit*  createHcalRecHit( const DetId& detid, 
-				     double energy,
-				     PFLayer::Layer layer,
-				     const CaloSubdetectorGeometry* geom,
-				     const CaloTowerDetId& newDetId);
+  reco::PFRecHit* createHcalRecHit(const DetId& detid,
+                                   double energy,
+                                   PFLayer::Layer layer,
+                                   const CaloSubdetectorGeometry* geom,
+                                   const CaloTowerDetId& newDetId);
 
-
- protected:
-  double  thresh_Barrel_;
-  double  thresh_Endcap_;
+protected:
+  double thresh_Barrel_;
+  double thresh_Endcap_;
   const HcalChannelQuality* theHcalChStatus;
   const EcalChannelStatus* theEcalChStatus;
   const CaloTowerConstituentsMap* theTowerConstituentsMap;
@@ -64,12 +59,12 @@ class dso_hidden PFCTRecHitProducer final : public edm::stream::EDProducer<> {
   edm::EDGetTokenT<HBHERecHitCollection> hcalToken_;
   edm::EDGetTokenT<HFRecHitCollection> hfToken_;
   edm::EDGetTokenT<CaloTowerCollection> towersToken_;
-  
-  /// threshold for HF
-  double           thresh_HF_;
 
-  // Navigation in HF:  False = no real clustering in HF; True  = do clustering 
-  bool   navigation_HF_;
+  /// threshold for HF
+  double thresh_HF_;
+
+  // Navigation in HF:  False = no real clustering in HF; True  = do clustering
+  bool navigation_HF_;
   double weight_HFem_;
   double weight_HFhad_;
 
@@ -80,18 +75,18 @@ class dso_hidden PFCTRecHitProducer final : public edm::stream::EDProducer<> {
   float HF_Calib_29;
 
   // Don't allow large energy in short fibres if there is no energy in long fibres
-  double shortFibre_Cut;  
+  double shortFibre_Cut;
   double longFibre_Fraction;
 
   // Don't allow large energy in long fibres if there is no energy in short fibres
-  double longFibre_Cut;  
+  double longFibre_Cut;
   double shortFibre_Fraction;
 
   // Also apply HCAL DPG cleaning
   bool applyLongShortDPG_;
 
   // Don't allow too large timing excursion if energy in long/short fibres is large enough
-  double longShortFibre_Cut;  
+  double longShortFibre_Cut;
   double minShortTiming_Cut;
   double maxShortTiming_Cut;
   double minLongTiming_Cut;
@@ -99,10 +94,10 @@ class dso_hidden PFCTRecHitProducer final : public edm::stream::EDProducer<> {
 
   bool applyTimeDPG_;
   bool applyPulseDPG_;
-  int  HcalMaxAllowedHFLongShortSev_;
-  int  HcalMaxAllowedHFDigiTimeSev_;
-  int  HcalMaxAllowedHFInTimeWindowSev_;
-  int  HcalMaxAllowedChannelStatusSev_;
+  int HcalMaxAllowedHFLongShortSev_;
+  int HcalMaxAllowedHFDigiTimeSev_;
+  int HcalMaxAllowedHFInTimeWindowSev_;
+  int HcalMaxAllowedChannelStatusSev_;
 
   int hcalHFLongShortFlagValue_;
   int hcalHFDigiTimeFlagValue_;
@@ -118,13 +113,10 @@ class dso_hidden PFCTRecHitProducer final : public edm::stream::EDProducer<> {
   double EM_Depth_;
   double HAD_Depth_;
 
-
   int m_maxDepthHB;
   int m_maxDepthHE;
 
   std::unique_ptr<PFRecHitNavigatorBase> navigator_;
-
-
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterCollectionMerger.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterCollectionMerger.cc
@@ -14,25 +14,25 @@
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
 
 class PFClusterCollectionMerger : public edm::global::EDProducer<> {
-public: 
+public:
   PFClusterCollectionMerger(const edm::ParameterSet& conf) {
-    const std::vector<edm::InputTag>& inputs = 
-      conf.getParameter<std::vector<edm::InputTag> >("inputs");
-    for( const auto& input : inputs ) {
-      _inputs.push_back(consumes<reco::PFClusterCollection>( input ));
+    const std::vector<edm::InputTag>& inputs = conf.getParameter<std::vector<edm::InputTag> >("inputs");
+    for (const auto& input : inputs) {
+      _inputs.push_back(consumes<reco::PFClusterCollection>(input));
     }
     produces<reco::PFClusterCollection>();
   }
 
   void produce(edm::StreamID, edm::Event& e, const edm::EventSetup& es) const override {
     auto output = std::make_unique<reco::PFClusterCollection>();
-    for( const auto& input : _inputs ) {
+    for (const auto& input : _inputs) {
       edm::Handle<reco::PFClusterCollection> handle;
-      e.getByToken(input,handle);
-      output->insert(output->end(),handle->begin(),handle->end());
+      e.getByToken(input, handle);
+      output->insert(output->end(), handle->begin(), handle->end());
     }
     e.put(std::move(output));
   }
+
 private:
   std::vector<edm::EDGetTokenT<reco::PFClusterCollection> > _inputs;
 };

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalMultiCluster.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalMultiCluster.cc
@@ -5,15 +5,12 @@
 
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 
-void PFClusterFromHGCalMultiCluster::updateEvent(const edm::Event& ev) {
-  ev.getByToken(clusterToken_, clusterH_);
-}
+void PFClusterFromHGCalMultiCluster::updateEvent(const edm::Event& ev) { ev.getByToken(clusterToken_, clusterH_); }
 
-void PFClusterFromHGCalMultiCluster::buildClusters(
-    const edm::Handle<reco::PFRecHitCollection>& input,
-    const std::vector<bool>& rechitMask, const std::vector<bool>& seedable,
-    reco::PFClusterCollection& output) {
-
+void PFClusterFromHGCalMultiCluster::buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
+                                                   const std::vector<bool>& rechitMask,
+                                                   const std::vector<bool>& seedable,
+                                                   reco::PFClusterCollection& output) {
   const auto& hgcalMultiClusters = *clusterH_;
   auto const& hits = *input;
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalMultiCluster.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterFromHGCalMultiCluster.h
@@ -6,31 +6,28 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h"
 
 class PFClusterFromHGCalMultiCluster : public InitialClusteringStepBase {
- public:
-  PFClusterFromHGCalMultiCluster(const edm::ParameterSet& conf,
-                                 edm::ConsumesCollector& sumes)
+public:
+  PFClusterFromHGCalMultiCluster(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
       : InitialClusteringStepBase(conf, sumes) {
-    clusterToken_ = sumes.consumes<std::vector<reco::HGCalMultiCluster> >(
-        conf.getParameter<edm::InputTag>("clusterSrc"));
+    clusterToken_ =
+        sumes.consumes<std::vector<reco::HGCalMultiCluster> >(conf.getParameter<edm::InputTag>("clusterSrc"));
   }
   ~PFClusterFromHGCalMultiCluster() override {}
-  PFClusterFromHGCalMultiCluster(const PFClusterFromHGCalMultiCluster&) =
-      delete;
-  PFClusterFromHGCalMultiCluster& operator=(
-      const PFClusterFromHGCalMultiCluster&) = delete;
+  PFClusterFromHGCalMultiCluster(const PFClusterFromHGCalMultiCluster&) = delete;
+  PFClusterFromHGCalMultiCluster& operator=(const PFClusterFromHGCalMultiCluster&) = delete;
 
   void updateEvent(const edm::Event&) final;
 
   void buildClusters(const edm::Handle<reco::PFRecHitCollection>&,
-                     const std::vector<bool>&, const std::vector<bool>&,
+                     const std::vector<bool>&,
+                     const std::vector<bool>&,
                      reco::PFClusterCollection&) override;
 
- private:
+private:
   edm::EDGetTokenT<std::vector<reco::HGCalMultiCluster> > clusterToken_;
   edm::Handle<std::vector<reco::HGCalMultiCluster> > clusterH_;
 };
 
-DEFINE_EDM_PLUGIN(InitialClusteringStepFactory, PFClusterFromHGCalMultiCluster,
-                  "PFClusterFromHGCalMultiCluster");
+DEFINE_EDM_PLUGIN(InitialClusteringStepFactory, PFClusterFromHGCalMultiCluster, "PFClusterFromHGCalMultiCluster");
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
@@ -12,113 +12,99 @@
 #define LOGDRESSED(x) LogDebug(x)
 #endif
 
-PFClusterProducer::PFClusterProducer(const edm::ParameterSet& conf) :
-  _prodInitClusters(conf.getUntrackedParameter<bool>("prodInitialClusters",false))
-{
-  _rechitsLabel = consumes<reco::PFRecHitCollection>(conf.getParameter<edm::InputTag>("recHitsSource")); 
+PFClusterProducer::PFClusterProducer(const edm::ParameterSet& conf)
+    : _prodInitClusters(conf.getUntrackedParameter<bool>("prodInitialClusters", false)) {
+  _rechitsLabel = consumes<reco::PFRecHitCollection>(conf.getParameter<edm::InputTag>("recHitsSource"));
   //setup rechit cleaners
-  const edm::VParameterSet& cleanerConfs = 
-    conf.getParameterSetVector("recHitCleaners");
-  for( const auto& conf : cleanerConfs ) {
-    const std::string& cleanerName = 
-      conf.getParameter<std::string>("algoName");
-    _cleaners.emplace_back(RecHitTopologicalCleanerFactory::get()->create(cleanerName,conf));
+  const edm::VParameterSet& cleanerConfs = conf.getParameterSetVector("recHitCleaners");
+  for (const auto& conf : cleanerConfs) {
+    const std::string& cleanerName = conf.getParameter<std::string>("algoName");
+    _cleaners.emplace_back(RecHitTopologicalCleanerFactory::get()->create(cleanerName, conf));
   }
   edm::ConsumesCollector sumes = consumesCollector();
 
   // setup seed finding
-  const edm::ParameterSet& sfConf = 
-    conf.getParameterSet("seedFinder");
+  const edm::ParameterSet& sfConf = conf.getParameterSet("seedFinder");
   const std::string& sfName = sfConf.getParameter<std::string>("algoName");
-  _seedFinder = std::unique_ptr<SeedFinderBase>{SeedFinderFactory::get()->create(sfName,sfConf)};
+  _seedFinder = std::unique_ptr<SeedFinderBase>{SeedFinderFactory::get()->create(sfName, sfConf)};
   //setup topo cluster builder
-  const edm::ParameterSet& initConf = 
-    conf.getParameterSet("initialClusteringStep");
+  const edm::ParameterSet& initConf = conf.getParameterSet("initialClusteringStep");
   const std::string& initName = initConf.getParameter<std::string>("algoName");
-  _initialClustering = std::unique_ptr<ICSB>{InitialClusteringStepFactory::get()->create(initName,initConf,sumes)};
+  _initialClustering = std::unique_ptr<ICSB>{InitialClusteringStepFactory::get()->create(initName, initConf, sumes)};
   //setup pf cluster builder if requested
   const edm::ParameterSet& pfcConf = conf.getParameterSet("pfClusterBuilder");
-  if( !pfcConf.empty() ) {
+  if (!pfcConf.empty()) {
     const std::string& pfcName = pfcConf.getParameter<std::string>("algoName");
-    _pfClusterBuilder = std::unique_ptr<PFCBB>{PFClusterBuilderFactory::get()->create(pfcName,pfcConf)};
+    _pfClusterBuilder = std::unique_ptr<PFCBB>{PFClusterBuilderFactory::get()->create(pfcName, pfcConf)};
   }
   //setup (possible) recalcuation of positions
   const edm::ParameterSet& pConf = conf.getParameterSet("positionReCalc");
-  if( !pConf.empty() ) {
+  if (!pConf.empty()) {
     const std::string& pName = pConf.getParameter<std::string>("algoName");
-    _positionReCalc = std::unique_ptr<PosCalc>{PFCPositionCalculatorFactory::get()->create(pName,pConf)};
+    _positionReCalc = std::unique_ptr<PosCalc>{PFCPositionCalculatorFactory::get()->create(pName, pConf)};
   }
   // see if new need to apply corrections, setup if there.
-  const edm::ParameterSet& cConf =  conf.getParameterSet("energyCorrector");
-  if( !cConf.empty() ) {
+  const edm::ParameterSet& cConf = conf.getParameterSet("energyCorrector");
+  if (!cConf.empty()) {
     const std::string& cName = cConf.getParameter<std::string>("algoName");
-    _energyCorrector = std::unique_ptr<PFClusterEnergyCorrectorBase>{PFClusterEnergyCorrectorFactory::get()->create(cName,cConf)};
+    _energyCorrector =
+        std::unique_ptr<PFClusterEnergyCorrectorBase>{PFClusterEnergyCorrectorFactory::get()->create(cName, cConf)};
   }
-  
 
-  if( _prodInitClusters ) {
+  if (_prodInitClusters) {
     produces<reco::PFClusterCollection>("initialClusters");
   }
   produces<reco::PFClusterCollection>();
 }
 
-void PFClusterProducer::beginLuminosityBlock(const edm::LuminosityBlock& lumi, 
-					     const edm::EventSetup& es) {
+void PFClusterProducer::beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& es) {
   _initialClustering->update(es);
-  if( _pfClusterBuilder ) _pfClusterBuilder->update(es);
-  if( _positionReCalc ) _positionReCalc->update(es);
-  
+  if (_pfClusterBuilder)
+    _pfClusterBuilder->update(es);
+  if (_positionReCalc)
+    _positionReCalc->update(es);
 }
 
 void PFClusterProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   _initialClustering->reset();
-  if( _pfClusterBuilder ) _pfClusterBuilder->reset();
+  if (_pfClusterBuilder)
+    _pfClusterBuilder->reset();
 
   edm::Handle<reco::PFRecHitCollection> rechits;
-  e.getByToken(_rechitsLabel,rechits);  
-  
+  e.getByToken(_rechitsLabel, rechits);
+
   _initialClustering->updateEvent(e);
 
-  std::vector<bool> mask(rechits->size(),true);
-  for( const auto& cleaner : _cleaners ) {
+  std::vector<bool> mask(rechits->size(), true);
+  for (const auto& cleaner : _cleaners) {
     cleaner->clean(rechits, mask);
   }
 
-
-
-  std::vector<bool> seedable(rechits->size(),false);
-  _seedFinder->findSeeds(rechits,mask,seedable);
-
-
+  std::vector<bool> seedable(rechits->size(), false);
+  _seedFinder->findSeeds(rechits, mask, seedable);
 
   auto initialClusters = std::make_unique<reco::PFClusterCollection>();
   _initialClustering->buildClusters(rechits, mask, seedable, *initialClusters);
   LOGVERB("PFClusterProducer::produce()") << *_initialClustering;
 
-
-
-
   auto pfClusters = std::make_unique<reco::PFClusterCollection>();
   pfClusters.reset(new reco::PFClusterCollection);
-  if( _pfClusterBuilder ) { // if we've defined a re-clustering step execute it
+  if (_pfClusterBuilder) {  // if we've defined a re-clustering step execute it
     _pfClusterBuilder->buildClusters(*initialClusters, seedable, *pfClusters);
     LOGVERB("PFClusterProducer::produce()") << *_pfClusterBuilder;
   } else {
-    pfClusters->insert(pfClusters->end(),
-		       initialClusters->begin(),initialClusters->end());
+    pfClusters->insert(pfClusters->end(), initialClusters->begin(), initialClusters->end());
   }
 
-
-
-  
-  if( _positionReCalc ) {
+  if (_positionReCalc) {
     _positionReCalc->calculateAndSetPositions(*pfClusters);
   }
 
-  if( _energyCorrector ) {
+  if (_energyCorrector) {
     _energyCorrector->correctEnergies(*pfClusters);
   }
 
-  if( _prodInitClusters ) e.put(std::move(initialClusters),"initialClusters");
+  if (_prodInitClusters)
+    e.put(std::move(initialClusters), "initialClusters");
   e.put(std::move(pfClusters));
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.h
@@ -17,21 +17,20 @@
 
 #include <memory>
 
-
 class PFClusterProducer : public edm::stream::EDProducer<> {
   typedef RecHitTopologicalCleanerBase RHCB;
   typedef InitialClusteringStepBase ICSB;
   typedef PFClusterBuilderBase PFCBB;
   typedef PFCPositionCalculatorBase PosCalc;
- public:    
+
+public:
   PFClusterProducer(const edm::ParameterSet&);
   ~PFClusterProducer() override = default;
-  
-  void beginLuminosityBlock(const edm::LuminosityBlock&, 
-				    const edm::EventSetup&) override;
+
+  void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  
- private:
+
+private:
   // inputs
   edm::EDGetTokenT<reco::PFRecHitCollection> _rechitsLabel;
   // options

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterTimeAssigner.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterTimeAssigner.cc
@@ -16,29 +16,25 @@
 
 #include "DataFormats/Common/interface/ValueMap.h"
 
-
 class PFClusterTimeAssigner : public edm::stream::EDProducer<> {
-public: 
+public:
   PFClusterTimeAssigner(const edm::ParameterSet& conf) {
-    const edm::InputTag&  clusters = 
-      conf.getParameter<edm::InputTag>("src");    
-    clustersTok_ = consumes<reco::PFClusterCollection>( clusters );
+    const edm::InputTag& clusters = conf.getParameter<edm::InputTag>("src");
+    clustersTok_ = consumes<reco::PFClusterCollection>(clusters);
 
-    const edm::InputTag& times = 
-      conf.getParameter<edm::InputTag>("timeSrc");
-    timesTok_ = consumes<edm::ValueMap<float> >( times );
+    const edm::InputTag& times = conf.getParameter<edm::InputTag>("timeSrc");
+    timesTok_ = consumes<edm::ValueMap<float> >(times);
 
-    const edm::InputTag& timeResos = 
-      conf.getParameter<edm::InputTag>("timeResoSrc");
-    timeResosTok_ = consumes<edm::ValueMap<float> >( timeResos );
-    
+    const edm::InputTag& timeResos = conf.getParameter<edm::InputTag>("timeResoSrc");
+    timeResosTok_ = consumes<edm::ValueMap<float> >(timeResos);
+
     produces<reco::PFClusterCollection>();
   }
 
   void produce(edm::Event& e, const edm::EventSetup& es) override;
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-private:  
+private:
   edm::EDGetTokenT<reco::PFClusterCollection> clustersTok_;
   edm::EDGetTokenT<edm::ValueMap<float> > timesTok_;
   edm::EDGetTokenT<edm::ValueMap<float> > timeResosTok_;
@@ -46,44 +42,40 @@ private:
 
 DEFINE_FWK_MODULE(PFClusterTimeAssigner);
 
-void PFClusterTimeAssigner::
-produce(edm::Event& e, const edm::EventSetup& es) {
+void PFClusterTimeAssigner::produce(edm::Event& e, const edm::EventSetup& es) {
   auto clusters_out = std::make_unique<reco::PFClusterCollection>();
-  
-  edm::Handle<reco::PFClusterCollection> clustersH;
-  e.getByToken(clustersTok_,clustersH);
-  edm::Handle<edm::ValueMap<float> > timesH, timeResosH;
-  e.getByToken(timesTok_,timesH);
-  e.getByToken(timeResosTok_,timeResosH);
 
-  auto const & clusters = *clustersH;
-  auto const & times = *timesH;
-  auto const & timeResos = *timeResosH;
-  
+  edm::Handle<reco::PFClusterCollection> clustersH;
+  e.getByToken(clustersTok_, clustersH);
+  edm::Handle<edm::ValueMap<float> > timesH, timeResosH;
+  e.getByToken(timesTok_, timesH);
+  e.getByToken(timeResosTok_, timeResosH);
+
+  auto const& clusters = *clustersH;
+  auto const& times = *timesH;
+  auto const& timeResos = *timeResosH;
+
   clusters_out->reserve(clusters.size());
-  clusters_out->insert(clusters_out->end(),
-		       clusters.begin(),clusters.end());
+  clusters_out->insert(clusters_out->end(), clusters.begin(), clusters.end());
 
   //build the EE->PS association
   auto& out = *clusters_out;
-  for( unsigned i = 0; i < out.size(); ++i ) {      
-    
-    edm::Ref<reco::PFClusterCollection> clusterRef(clustersH,i);
+  for (unsigned i = 0; i < out.size(); ++i) {
+    edm::Ref<reco::PFClusterCollection> clusterRef(clustersH, i);
     const float time = times[clusterRef];
     const float timeReso = timeResos[clusterRef];
     out[i].setTime(time, timeReso);
-    
   }
 
   e.put(std::move(clusters_out));
 }
 
 void PFClusterTimeAssigner::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  edm::ParameterSetDescription desc;  
-  desc.add<edm::InputTag>("src",edm::InputTag("particleFlowClusterECALUncorrected"));
-  desc.add<edm::InputTag>("timeSrc",edm::InputTag("ecalBarrelClusterFastTimer"));
-  desc.add<edm::InputTag>("timeResoSrc",edm::InputTag("ecalBarrelClusterFastTimer"));
-  descriptions.add("particleFlowClusterTimeAssignerDefault",desc);
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src", edm::InputTag("particleFlowClusterECALUncorrected"));
+  desc.add<edm::InputTag>("timeSrc", edm::InputTag("ecalBarrelClusterFastTimer"));
+  desc.add<edm::InputTag>("timeResoSrc", edm::InputTag("ecalBarrelClusterFastTimer"));
+  descriptions.add("particleFlowClusterTimeAssignerDefault", desc);
 }
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterTimeSelector.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterTimeSelector.cc
@@ -5,81 +5,62 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
-
 using namespace std;
 using namespace edm;
 
-
-PFClusterTimeSelector::PFClusterTimeSelector(const edm::ParameterSet& iConfig):
-  clusters_(consumes<reco::PFClusterCollection>(iConfig.getParameter<edm::InputTag>("src")))
-{
-
+PFClusterTimeSelector::PFClusterTimeSelector(const edm::ParameterSet& iConfig)
+    : clusters_(consumes<reco::PFClusterCollection>(iConfig.getParameter<edm::InputTag>("src"))) {
   std::vector<edm::ParameterSet> cuts = iConfig.getParameter<std::vector<edm::ParameterSet> >("cuts");
-  for (const auto& cut :cuts ) {
+  for (const auto& cut : cuts) {
     CutInfo info;
-    info.depth   = cut.getParameter<double>("depth");
-    info.minE    = cut.getParameter<double>("minEnergy");
-    info.maxE    = cut.getParameter<double>("maxEnergy");
+    info.depth = cut.getParameter<double>("depth");
+    info.minE = cut.getParameter<double>("minEnergy");
+    info.maxE = cut.getParameter<double>("maxEnergy");
     info.minTime = cut.getParameter<double>("minTime");
     info.maxTime = cut.getParameter<double>("maxTime");
-    info.endcap  = cut.getParameter<bool>("endcap");
+    info.endcap = cut.getParameter<bool>("endcap");
     cutInfo_.push_back(info);
   }
-
 
   produces<reco::PFClusterCollection>();
   produces<reco::PFClusterCollection>("OOT");
 }
 
-
-void PFClusterTimeSelector::produce(edm::Event& iEvent, 
-			       const edm::EventSetup& iSetup) {
-
-  edm::Handle<reco::PFClusterCollection> clusters; 
-  iEvent.getByToken(clusters_,clusters);
+void PFClusterTimeSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  edm::Handle<reco::PFClusterCollection> clusters;
+  iEvent.getByToken(clusters_, clusters);
   auto out = std::make_unique<reco::PFClusterCollection>();
   auto outOOT = std::make_unique<reco::PFClusterCollection>();
 
-  for(const auto& cluster : *clusters ) {    
+  for (const auto& cluster : *clusters) {
     const double energy = cluster.energy();
-    const double time = cluster.time();    
-    const double depth = cluster.depth();    
-    const PFLayer::Layer  layer = cluster.layer();    
+    const double time = cluster.time();
+    const double depth = cluster.depth();
+    const PFLayer::Layer layer = cluster.layer();
     for (const auto& info : cutInfo_) {
-      if (energy<info.minE || energy>info.maxE)
-	continue;
-      if (depth<0.9*info.depth || depth>1.1*info.depth)
-	continue;
-      if ((info.endcap && (layer==PFLayer::ECAL_BARREL || layer==PFLayer::HCAL_BARREL1 || layer==PFLayer::HCAL_BARREL2))||
-	  (((!info.endcap) && (layer==PFLayer::ECAL_ENDCAP || layer==PFLayer::HCAL_ENDCAP))))
-	continue;
-      
-      if (time>info.minTime && time<info.maxTime)
-	out->push_back(cluster);
+      if (energy < info.minE || energy > info.maxE)
+        continue;
+      if (depth < 0.9 * info.depth || depth > 1.1 * info.depth)
+        continue;
+      if ((info.endcap &&
+           (layer == PFLayer::ECAL_BARREL || layer == PFLayer::HCAL_BARREL1 || layer == PFLayer::HCAL_BARREL2)) ||
+          (((!info.endcap) && (layer == PFLayer::ECAL_ENDCAP || layer == PFLayer::HCAL_ENDCAP))))
+        continue;
+
+      if (time > info.minTime && time < info.maxTime)
+        out->push_back(cluster);
       else
-	outOOT->push_back(cluster);
+        outOOT->push_back(cluster);
 
       break;
-
     }
-    
-  }    
-
-
+  }
 
   iEvent.put(std::move(out));
-  iEvent.put(std::move(outOOT),"OOT");
-
+  iEvent.put(std::move(outOOT), "OOT");
 }
 
 PFClusterTimeSelector::~PFClusterTimeSelector() = default;
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
-PFClusterTimeSelector::beginRun(const edm::Run& run,
-			   const EventSetup& es) {
-
- 
-}
-
-
+void PFClusterTimeSelector::beginRun(const edm::Run& run, const EventSetup& es) {}

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterTimeSelector.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterTimeSelector.h
@@ -16,18 +16,15 @@
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
 
 class PFClusterTimeSelector : public edm::stream::EDProducer<> {
- public:
+public:
   explicit PFClusterTimeSelector(const edm::ParameterSet&);
   ~PFClusterTimeSelector() override;
 
-  void beginRun(const edm::Run& run, const edm::EventSetup & es) override;
-  
-  void produce(edm::Event& iEvent, 
-	       const edm::EventSetup& iSetup) override;
+  void beginRun(const edm::Run& run, const edm::EventSetup& es) override;
 
+  void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
- protected:
-
+protected:
   struct CutInfo {
     double depth;
     double minE;
@@ -35,13 +32,11 @@ class PFClusterTimeSelector : public edm::stream::EDProducer<> {
     double minTime;
     double maxTime;
     bool endcap;
-
   };
 
   // ----------access to event data
   edm::EDGetTokenT<reco::PFClusterCollection> clusters_;
   std::vector<CutInfo> cutInfo_;
-
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.cc
@@ -12,45 +12,42 @@
 #define LOGDRESSED(x) LogDebug(x)
 #endif
 
-PFMultiDepthClusterProducer::PFMultiDepthClusterProducer(const edm::ParameterSet& conf)
-{
-  _clustersLabel = consumes<reco::PFClusterCollection>(conf.getParameter<edm::InputTag>("clustersSource")); 
+PFMultiDepthClusterProducer::PFMultiDepthClusterProducer(const edm::ParameterSet& conf) {
+  _clustersLabel = consumes<reco::PFClusterCollection>(conf.getParameter<edm::InputTag>("clustersSource"));
   const edm::ParameterSet& pfcConf = conf.getParameterSet("pfClusterBuilder");
-  if( !pfcConf.empty() ) {
+  if (!pfcConf.empty()) {
     const std::string& pfcName = pfcConf.getParameter<std::string>("algoName");
-    _pfClusterBuilder = std::unique_ptr<PFCBB>{PFClusterBuilderFactory::get()->create(pfcName,pfcConf)};
+    _pfClusterBuilder = std::unique_ptr<PFCBB>{PFClusterBuilderFactory::get()->create(pfcName, pfcConf)};
   }
   // see if new need to apply corrections, setup if there.
-  const edm::ParameterSet& cConf =  conf.getParameterSet("energyCorrector");
-  if( !cConf.empty() ) {
+  const edm::ParameterSet& cConf = conf.getParameterSet("energyCorrector");
+  if (!cConf.empty()) {
     const std::string& cName = cConf.getParameter<std::string>("algoName");
-    _energyCorrector = std::unique_ptr<PFClusterEnergyCorrectorBase>{PFClusterEnergyCorrectorFactory::get()->create(cName,cConf)};
+    _energyCorrector =
+        std::unique_ptr<PFClusterEnergyCorrectorBase>{PFClusterEnergyCorrectorFactory::get()->create(cName, cConf)};
   }
-  
+
   produces<reco::PFClusterCollection>();
 }
 
-void PFMultiDepthClusterProducer::beginLuminosityBlock(const edm::LuminosityBlock& lumi, 
-					     const edm::EventSetup& es) {
+void PFMultiDepthClusterProducer::beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& es) {
   _pfClusterBuilder->update(es);
-  
 }
 
 void PFMultiDepthClusterProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   _pfClusterBuilder->reset();
 
   edm::Handle<reco::PFClusterCollection> inputClusters;
-  e.getByToken(_clustersLabel,inputClusters);  
-  
+  e.getByToken(_clustersLabel, inputClusters);
+
   std::vector<bool> seedable;
 
   auto pfClusters = std::make_unique<reco::PFClusterCollection>();
   _pfClusterBuilder->buildClusters(*inputClusters, seedable, *pfClusters);
   LOGVERB("PFMultiDepthClusterProducer::produce()") << *_pfClusterBuilder;
 
-  if( _energyCorrector ) {
+  if (_energyCorrector) {
     _energyCorrector->correctEnergies(*pfClusters);
   }
   e.put(std::move(pfClusters));
-
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterProducer.h
@@ -17,20 +17,19 @@
 
 #include <memory>
 
-
 class PFMultiDepthClusterProducer : public edm::stream::EDProducer<> {
   typedef InitialClusteringStepBase ICSB;
   typedef PFClusterBuilderBase PFCBB;
   typedef PFCPositionCalculatorBase PosCalc;
- public:    
+
+public:
   PFMultiDepthClusterProducer(const edm::ParameterSet&);
   ~PFMultiDepthClusterProducer() override = default;
-  
-  void beginLuminosityBlock(const edm::LuminosityBlock&, 
-				    const edm::EventSetup&) override;
+
+  void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   void produce(edm::Event&, const edm::EventSetup&) override;
-  
- private:
+
+private:
   // inputs
   edm::EDGetTokenT<reco::PFClusterCollection> _clustersLabel;
   // options

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.cc
@@ -9,66 +9,49 @@
 
 #include <iterator>
 
-
-
-PFMultiDepthClusterizer::
-PFMultiDepthClusterizer(const edm::ParameterSet& conf) :
-  PFClusterBuilderBase(conf) 
-{
-  
-  if( conf.exists("allCellsPositionCalc") ) {
-    const edm::ParameterSet& acConf = 
-      conf.getParameterSet("allCellsPositionCalc");
-    const std::string& algoac = 
-      acConf.getParameter<std::string>("algoName");
+PFMultiDepthClusterizer::PFMultiDepthClusterizer(const edm::ParameterSet& conf) : PFClusterBuilderBase(conf) {
+  if (conf.exists("allCellsPositionCalc")) {
+    const edm::ParameterSet& acConf = conf.getParameterSet("allCellsPositionCalc");
+    const std::string& algoac = acConf.getParameter<std::string>("algoName");
     _allCellsPosCalc = std::unique_ptr<PosCalc>{PFCPositionCalculatorFactory::get()->create(algoac, acConf)};
   }
 
-  nSigmaEta_ = pow(conf.getParameter<double>("nSigmaEta"),2);
-  nSigmaPhi_ = pow(conf.getParameter<double>("nSigmaPhi"),2);
-
+  nSigmaEta_ = pow(conf.getParameter<double>("nSigmaEta"), 2);
+  nSigmaPhi_ = pow(conf.getParameter<double>("nSigmaPhi"), 2);
 }
 
-void PFMultiDepthClusterizer::
-buildClusters(const reco::PFClusterCollection& input,
-	      const std::vector<bool>& seedable,
-	      reco::PFClusterCollection& output) {
-
-  std::vector<double> etaRMS2(input.size(),0.0);
-  std::vector<double> phiRMS2(input.size(),0.0);
+void PFMultiDepthClusterizer::buildClusters(const reco::PFClusterCollection& input,
+                                            const std::vector<bool>& seedable,
+                                            reco::PFClusterCollection& output) {
+  std::vector<double> etaRMS2(input.size(), 0.0);
+  std::vector<double> phiRMS2(input.size(), 0.0);
 
   //We need to sort the clusters for smaller to larger depth
   //  for (unsigned int i=0;i<input.size();++i)
   //   printf(" cluster%f %f \n",input[i].depth(),input[i].energy());
 
-
-
   //calculate cluster shapes
-  calculateShowerShapes(input,etaRMS2,phiRMS2);
+  calculateShowerShapes(input, etaRMS2, phiRMS2);
 
   //link
-  auto && links = link(input,etaRMS2,phiRMS2); 
+  auto&& links = link(input, etaRMS2, phiRMS2);
   //  for (const auto& link: links)
   //    printf("link %d %d %f %f\n",link.from(),link.to(),link.dR(),link.dZ());
 
-
- 
-  std::vector<bool> mask(input.size(),false);
-  std::vector<bool> linked(input.size(),false);
+  std::vector<bool> mask(input.size(), false);
+  std::vector<bool> linked(input.size(), false);
 
   //prune
-  auto && prunedLinks =  prune(links,linked);
+  auto&& prunedLinks = prune(links, linked);
 
   //printf("Pruned links\n")
   //  for (const auto& link: prunedLinks)
   //  printf("link %d %d %f %f\n",link.from(),link.to(),link.dR(),link.dZ());
 
-
-
-  //now we need to build clusters 
-  for (unsigned int i=0;i<input.size();++i) {
+  //now we need to build clusters
+  for (unsigned int i = 0; i < input.size(); ++i) {
     //if not masked
-    if( mask[i])
+    if (mask[i])
       continue;
     //if not linked just spit it out
     if (!linked[i]) {
@@ -78,193 +61,177 @@ buildClusters(const reco::PFClusterCollection& input,
       continue;
     }
 
-
     //now business: if  linked and not  masked gather clusters
     reco::PFCluster cluster = input[i];
     mask[i] = true;
-    expandCluster(cluster,i, mask,input,prunedLinks);
+    expandCluster(cluster, i, mask, input, prunedLinks);
     _allCellsPosCalc->calculateAndSetPosition(cluster);
     output.push_back(cluster);
     //    printf("Added linked cluster with energy =%f\n",cluster.energy());
-    
   }
 }
 
+void PFMultiDepthClusterizer::calculateShowerShapes(const reco::PFClusterCollection& clusters,
+                                                    std::vector<double>& etaRMS2,
+                                                    std::vector<double>& phiRMS2) {
+  //shower shapes. here do not use the fractions
 
-void PFMultiDepthClusterizer::
-calculateShowerShapes(const reco::PFClusterCollection& clusters,std::vector<double>& etaRMS2,std::vector<double>& phiRMS2) {
-
-  //shower shapes. here do not use the fractions 
-
-  for( unsigned int i=0;i<clusters.size();++i ) {
-    const reco::PFCluster& cluster = clusters[i]; 
-    double etaSum=0.0; double phiSum=0.0;
-    auto const & crep = cluster.positionREP();
+  for (unsigned int i = 0; i < clusters.size(); ++i) {
+    const reco::PFCluster& cluster = clusters[i];
+    double etaSum = 0.0;
+    double phiSum = 0.0;
+    auto const& crep = cluster.positionREP();
     for (const auto& frac : cluster.recHitFractions()) {
-      auto const & h = *frac.recHitRef();
-      auto const & rep = h.positionREP();
-      etaSum += (frac.fraction()*h.energy())*std::abs(rep.eta()-crep.eta());
-      phiSum += (frac.fraction()*h.energy())*std::abs(deltaPhi(rep.phi(),crep.phi()));
+      auto const& h = *frac.recHitRef();
+      auto const& rep = h.positionREP();
+      etaSum += (frac.fraction() * h.energy()) * std::abs(rep.eta() - crep.eta());
+      phiSum += (frac.fraction() * h.energy()) * std::abs(deltaPhi(rep.phi(), crep.phi()));
     }
     //protection for single line : assign ~ tower
-    etaRMS2[i] = std::max(etaSum/cluster.energy(),0.1);
-    etaRMS2[i]*= etaRMS2[i];
-    phiRMS2[i] = std::max(phiSum/cluster.energy(),0.1);
-    phiRMS2[i]*=phiRMS2[i];
+    etaRMS2[i] = std::max(etaSum / cluster.energy(), 0.1);
+    etaRMS2[i] *= etaRMS2[i];
+    phiRMS2[i] = std::max(phiSum / cluster.energy(), 0.1);
+    phiRMS2[i] *= phiRMS2[i];
   }
-
 }
 
-
-std::vector<PFMultiDepthClusterizer::ClusterLink>   PFMultiDepthClusterizer::
-link(const reco::PFClusterCollection& clusters ,const std::vector<double>& etaRMS2,const std::vector<double>& phiRMS2) {
-
+std::vector<PFMultiDepthClusterizer::ClusterLink> PFMultiDepthClusterizer::link(
+    const reco::PFClusterCollection& clusters, const std::vector<double>& etaRMS2, const std::vector<double>& phiRMS2) {
   std::vector<ClusterLink> links;
   //loop on all pairs
-  for (unsigned int i=0;i<clusters.size();++i)
-    for (unsigned int j=0;j<clusters.size();++j) {
-      if (i==j )  continue;
+  for (unsigned int i = 0; i < clusters.size(); ++i)
+    for (unsigned int j = 0; j < clusters.size(); ++j) {
+      if (i == j)
+        continue;
 
-      const reco::PFCluster& cluster1 = clusters[i]; 
-      const reco::PFCluster& cluster2 = clusters[j]; 
+      const reco::PFCluster& cluster1 = clusters[i];
+      const reco::PFCluster& cluster2 = clusters[j];
 
       auto dz = (cluster2.depth() - cluster1.depth());
 
       //Do not link at the same layer and only link inside out!
-      if (dz<0.0f || std::abs(dz)<0.2f)  continue;
- 
-      auto const & crep1 = cluster1.positionREP();
-      auto const & crep2 = cluster2.positionREP();
- 
-      auto deta = crep1.eta()-crep2.eta();
-      deta = deta*deta/(etaRMS2[i]+etaRMS2[j]);
-      auto dphi = deltaPhi(crep1.phi(),crep2.phi());
-      dphi = dphi*dphi/(phiRMS2[i]+phiRMS2[j]);
+      if (dz < 0.0f || std::abs(dz) < 0.2f)
+        continue;
+
+      auto const& crep1 = cluster1.positionREP();
+      auto const& crep2 = cluster2.positionREP();
+
+      auto deta = crep1.eta() - crep2.eta();
+      deta = deta * deta / (etaRMS2[i] + etaRMS2[j]);
+      auto dphi = deltaPhi(crep1.phi(), crep2.phi());
+      dphi = dphi * dphi / (phiRMS2[i] + phiRMS2[j]);
 
       //      printf("Testing Link %d -> %d (%f %f %f %f ) \n",i,j,deta,dphi,cluster1.position().Eta()-cluster2.position().Eta(),deltaPhi(cluster1.position().Phi(),cluster2.position().Phi()));
 
-      if ( (deta<nSigmaEta_) & (dphi<nSigmaPhi_ ) )
-	links.push_back(ClusterLink(i,j,deta+dphi,std::abs(dz),cluster1.energy()+cluster2.energy()));
+      if ((deta < nSigmaEta_) & (dphi < nSigmaPhi_))
+        links.push_back(ClusterLink(i, j, deta + dphi, std::abs(dz), cluster1.energy() + cluster2.energy()));
     }
 
-      return links;
+  return links;
 }
 
-std::vector<PFMultiDepthClusterizer::ClusterLink> PFMultiDepthClusterizer::
-prune(std::vector<ClusterLink>& links,std::vector<bool>& linkedClusters) {
-      std::vector<ClusterLink> goodLinks ;
-      std::vector<bool> mask(links.size(),false);
-      if (links.empty()) return goodLinks;
+std::vector<PFMultiDepthClusterizer::ClusterLink> PFMultiDepthClusterizer::prune(std::vector<ClusterLink>& links,
+                                                                                 std::vector<bool>& linkedClusters) {
+  std::vector<ClusterLink> goodLinks;
+  std::vector<bool> mask(links.size(), false);
+  if (links.empty())
+    return goodLinks;
 
-      for (unsigned int i=0;i<links.size()-1;++i) {
-	if (mask[i])
-	  continue;
-	for (unsigned int j=i+1;j<links.size();++j) {
-	  if (mask[j])
-	    continue;
-	  
-	  const ClusterLink& link1  = links[i];
-	  const ClusterLink& link2  = links[j];
+  for (unsigned int i = 0; i < links.size() - 1; ++i) {
+    if (mask[i])
+      continue;
+    for (unsigned int j = i + 1; j < links.size(); ++j) {
+      if (mask[j])
+        continue;
 
-	  if (link1.to() == link2.to()) {//found two links going to the same spot,kill one  
-	    //first prefer nearby layers
-	    if (link1.dZ() < link2.dZ()) {
-	      mask[j]=true;
-	    }
-	    else if (link1.dZ() > link2.dZ()) {
-	      mask[i] = true;
-	    }
-	    else if (fabs(link1.dZ()-link2.dZ())<0.2) { //if same layer-pick based on transverse compatibility
-	      if (link1.dR()<link2.dR()) {
-		mask[j]=true;
-	      }
-	      else if (link1.dR()>link2.dR()) {
-		mask[i] = true;
-	      }
-	      else {
-		//same distance as well -> can happen !!!!! Pick the highest SUME 
-		if (link1.energy()<link2.energy())
-		  mask[i] = true;
-		else
-		  mask[j] = true;
-		  
-	      }
-	    }
-	  }
-	}
+      const ClusterLink& link1 = links[i];
+      const ClusterLink& link2 = links[j];
+
+      if (link1.to() == link2.to()) {  //found two links going to the same spot,kill one
+        //first prefer nearby layers
+        if (link1.dZ() < link2.dZ()) {
+          mask[j] = true;
+        } else if (link1.dZ() > link2.dZ()) {
+          mask[i] = true;
+        } else if (fabs(link1.dZ() - link2.dZ()) < 0.2) {  //if same layer-pick based on transverse compatibility
+          if (link1.dR() < link2.dR()) {
+            mask[j] = true;
+          } else if (link1.dR() > link2.dR()) {
+            mask[i] = true;
+          } else {
+            //same distance as well -> can happen !!!!! Pick the highest SUME
+            if (link1.energy() < link2.energy())
+              mask[i] = true;
+            else
+              mask[j] = true;
+          }
+        }
       }
-
-      for (unsigned int i=0;i<links.size();++i) {
-	if (mask[i])
-	  continue;
-	goodLinks.push_back(links[i]);
-	linkedClusters[links[i].from()]=true;
-	linkedClusters[links[i].to()]=true;
-      }
-
-
-      return goodLinks;       
-}	
-
-
-void 
-PFMultiDepthClusterizer::
-absorbCluster(reco::PFCluster& main, const reco::PFCluster& added) {
-  
-  double e1=0.0;
-  double e2=0.0;
-
-  //find seeds
-  for ( const auto& fraction : main.recHitFractions())
-    if (fraction.recHitRef()->detId() == main.seed()) {
-      e1=fraction.recHitRef()->energy();
-    }
-
-  for ( const auto& fraction : added.recHitFractions()) {
-    main.addRecHitFraction(fraction); 
-    if (fraction.recHitRef()->detId() == added.seed()) {
-      e2=fraction.recHitRef()->energy();
     }
   }
-  if (e2>e1)
-    main.setSeed(added.seed());
 
+  for (unsigned int i = 0; i < links.size(); ++i) {
+    if (mask[i])
+      continue;
+    goodLinks.push_back(links[i]);
+    linkedClusters[links[i].from()] = true;
+    linkedClusters[links[i].to()] = true;
+  }
+
+  return goodLinks;
 }
 
+void PFMultiDepthClusterizer::absorbCluster(reco::PFCluster& main, const reco::PFCluster& added) {
+  double e1 = 0.0;
+  double e2 = 0.0;
 
-void 
-PFMultiDepthClusterizer::
-expandCluster(reco::PFCluster& cluster,unsigned int point,std::vector<bool>& mask,const reco::PFClusterCollection& clusters,  const std::vector<ClusterLink>& links) {
+  //find seeds
+  for (const auto& fraction : main.recHitFractions())
+    if (fraction.recHitRef()->detId() == main.seed()) {
+      e1 = fraction.recHitRef()->energy();
+    }
+
+  for (const auto& fraction : added.recHitFractions()) {
+    main.addRecHitFraction(fraction);
+    if (fraction.recHitRef()->detId() == added.seed()) {
+      e2 = fraction.recHitRef()->energy();
+    }
+  }
+  if (e2 > e1)
+    main.setSeed(added.seed());
+}
+
+void PFMultiDepthClusterizer::expandCluster(reco::PFCluster& cluster,
+                                            unsigned int point,
+                                            std::vector<bool>& mask,
+                                            const reco::PFClusterCollection& clusters,
+                                            const std::vector<ClusterLink>& links) {
   for (const auto& link : links) {
     if (link.from() == point) {
       //found link that starts from this guy if not masked absorb
       if (!mask[link.from()]) {
-	absorbCluster(cluster,clusters[link.from()]);
-	mask[link.from()] = true;
+        absorbCluster(cluster, clusters[link.from()]);
+        mask[link.from()] = true;
       }
 
       if (!mask[link.to()]) {
-	absorbCluster(cluster,clusters[link.to()]);
-	mask[link.to()]=true;
-	expandCluster(cluster,link.to(),mask,clusters,links);
+        absorbCluster(cluster, clusters[link.to()]);
+        mask[link.to()] = true;
+        expandCluster(cluster, link.to(), mask, clusters, links);
       }
     }
     if (link.to() == point) {
       //found link that starts from this guy if not masked absorb
       if (!mask[link.to()]) {
-	absorbCluster(cluster,clusters[link.to()]);
-	mask[link.to()] = true;
+        absorbCluster(cluster, clusters[link.to()]);
+        mask[link.to()] = true;
       }
 
       if (!mask[link.from()]) {
-	absorbCluster(cluster,clusters[link.from()]);
-	mask[link.from()]=true;
-	expandCluster(cluster,link.from(),mask,clusters,links);
+        absorbCluster(cluster, clusters[link.from()]);
+        mask[link.from()] = true;
+        expandCluster(cluster, link.from(), mask, clusters, links);
       }
     }
-
-
-
   }
-
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFMultiDepthClusterizer.h
@@ -8,70 +8,66 @@
 
 class PFMultiDepthClusterizer final : public PFClusterBuilderBase {
   typedef PFMultiDepthClusterizer B2DGPF;
- public:
+
+public:
   PFMultiDepthClusterizer(const edm::ParameterSet& conf);
-    
+
   ~PFMultiDepthClusterizer() override = default;
   PFMultiDepthClusterizer(const B2DGPF&) = delete;
   B2DGPF& operator=(const B2DGPF&) = delete;
 
-  void update(const edm::EventSetup& es) override { 
-    _allCellsPosCalc->update(es);
-  }
+  void update(const edm::EventSetup& es) override { _allCellsPosCalc->update(es); }
 
   void buildClusters(const reco::PFClusterCollection&,
-		     const std::vector<bool>&,
-		     reco::PFClusterCollection& outclus) override;
+                     const std::vector<bool>&,
+                     reco::PFClusterCollection& outclus) override;
 
- private:  
+private:
   std::unique_ptr<PFCPositionCalculatorBase> _allCellsPosCalc;
-  double  nSigmaEta_;
-  double  nSigmaPhi_;
-  
+  double nSigmaEta_;
+  double nSigmaPhi_;
 
   class ClusterLink {
   public:
-    ClusterLink(unsigned int i,unsigned int j,double DR,double DZ,double energy) {
+    ClusterLink(unsigned int i, unsigned int j, double DR, double DZ, double energy) {
       from_ = i;
       to_ = j;
-      linkDR_ =DR; 
-      linkDZ_ =DZ; 
-      linkE_ =energy; 
+      linkDR_ = DR;
+      linkDZ_ = DZ;
+      linkE_ = energy;
     }
 
     ~ClusterLink() = default;
 
-    unsigned int from() const {return from_;}
-    unsigned int to() const {return to_;}
-    double dR() const {return linkDR_;}
-    double dZ() const {return linkDZ_;}
-    double energy() const {return linkE_;}
-    
+    unsigned int from() const { return from_; }
+    unsigned int to() const { return to_; }
+    double dR() const { return linkDR_; }
+    double dZ() const { return linkDZ_; }
+    double energy() const { return linkE_; }
+
   private:
     unsigned int from_;
     unsigned int to_;
     double linkDR_;
     double linkDZ_;
     double linkE_;
-
   };
 
+  void calculateShowerShapes(const reco::PFClusterCollection&, std::vector<double>&, std::vector<double>&);
+  std::vector<ClusterLink> link(const reco::PFClusterCollection&,
+                                const std::vector<double>&,
+                                const std::vector<double>&);
+  std::vector<ClusterLink> prune(std::vector<ClusterLink>&, std::vector<bool>& linkedClusters);
 
-  void calculateShowerShapes(const reco::PFClusterCollection&,std::vector<double>&,std::vector<double>&); 
-  std::vector<ClusterLink> link(const reco::PFClusterCollection&,const std::vector<double>&,const std::vector<double>&);
-  std::vector<ClusterLink>  prune(std::vector<ClusterLink>&,std::vector<bool>& linkedClusters);
+  void expandCluster(reco::PFCluster&,
+                     unsigned int point,
+                     std::vector<bool>& mask,
+                     const reco::PFClusterCollection&,
+                     const std::vector<ClusterLink>& links);
 
-
-  void expandCluster(reco::PFCluster&,unsigned int point, std::vector<bool>& mask,const reco::PFClusterCollection& , const std::vector<ClusterLink>& links);
-
-  void absorbCluster(reco::PFCluster&, const reco::PFCluster&) ;
-
-
-
+  void absorbCluster(reco::PFCluster&, const reco::PFCluster&);
 };
 
-DEFINE_EDM_PLUGIN(PFClusterBuilderFactory,
-		  PFMultiDepthClusterizer,
-		  "PFMultiDepthClusterizer");
+DEFINE_EDM_PLUGIN(PFClusterBuilderFactory, PFMultiDepthClusterizer, "PFMultiDepthClusterizer");
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
@@ -2,96 +2,82 @@
 #include "FWCore/Utilities/interface/RunningAverage.h"
 
 namespace {
-  bool sortByDetId(const reco::PFRecHit& a,
-		   const reco::PFRecHit& b) {
-    return a.detId() < b.detId();
-  }
+  bool sortByDetId(const reco::PFRecHit& a, const reco::PFRecHit& b) { return a.detId() < b.detId(); }
 
- edm::RunningAverage localRA1;
- edm::RunningAverage localRA2;
-}
+  edm::RunningAverage localRA1;
+  edm::RunningAverage localRA2;
+}  // namespace
 
- PFRecHitProducer:: PFRecHitProducer(const edm::ParameterSet& iConfig)
-{
-
+PFRecHitProducer::PFRecHitProducer(const edm::ParameterSet& iConfig) {
   produces<reco::PFRecHitCollection>();
   produces<reco::PFRecHitCollection>("Cleaned");
 
   edm::ConsumesCollector iC = consumesCollector();
 
   std::vector<edm::ParameterSet> creators = iConfig.getParameter<std::vector<edm::ParameterSet> >("producers");
-  for (auto & creator : creators) {
-      std::string name = creator.getParameter<std::string>("name");
-      creators_.emplace_back(PFRecHitFactory::get()->create(name,creator,iC));
+  for (auto& creator : creators) {
+    std::string name = creator.getParameter<std::string>("name");
+    creators_.emplace_back(PFRecHitFactory::get()->create(name, creator, iC));
   }
-
 
   edm::ParameterSet navSet = iConfig.getParameter<edm::ParameterSet>("navigator");
 
-  navigator_ = std::unique_ptr<PFRecHitNavigatorBase>{PFRecHitNavigationFactory::get()->create(navSet.getParameter<std::string>("name"),navSet)};
-    
+  navigator_ = std::unique_ptr<PFRecHitNavigatorBase>{
+      PFRecHitNavigationFactory::get()->create(navSet.getParameter<std::string>("name"), navSet)};
 }
 
-
- PFRecHitProducer::~ PFRecHitProducer() = default;
-
+PFRecHitProducer::~PFRecHitProducer() = default;
 
 //
 // member functions
 //
 
-void
- PFRecHitProducer::beginLuminosityBlock(edm::LuminosityBlock const& iLumi, const edm::EventSetup& iSetup) {
-  for( const auto& creator : creators_ ) {
+void PFRecHitProducer::beginLuminosityBlock(edm::LuminosityBlock const& iLumi, const edm::EventSetup& iSetup) {
+  for (const auto& creator : creators_) {
     creator->init(iSetup);
   }
 }
 
-void
- PFRecHitProducer::endLuminosityBlock(edm::LuminosityBlock const& iLumi, const edm::EventSetup&) { }
+void PFRecHitProducer::endLuminosityBlock(edm::LuminosityBlock const& iLumi, const edm::EventSetup&) {}
 
 // ------------ method called to produce the data  ------------
-void
- PFRecHitProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
-   auto out = std::make_unique<reco::PFRecHitCollection>();
-   auto cleaned = std::make_unique<reco::PFRecHitCollection>();
+void PFRecHitProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  using namespace edm;
+  auto out = std::make_unique<reco::PFRecHitCollection>();
+  auto cleaned = std::make_unique<reco::PFRecHitCollection>();
 
-   navigator_->beginEvent(iSetup);
+  navigator_->beginEvent(iSetup);
 
-   out->reserve(localRA1.upper());
-   cleaned->reserve(localRA2.upper());
+  out->reserve(localRA1.upper());
+  cleaned->reserve(localRA2.upper());
 
-   for( const auto& creator : creators_ ) {
-     creator->importRecHits(out,cleaned,iEvent,iSetup);
-   }
+  for (const auto& creator : creators_) {
+    creator->importRecHits(out, cleaned, iEvent, iSetup);
+  }
 
-   if (out->capacity()>2*out->size()) out->shrink_to_fit();
-   if (cleaned->capacity()>2*cleaned->size()) cleaned->shrink_to_fit();
-   localRA1.update(out->size());
-   localRA2.update(cleaned->size());
-   std::sort(out->begin(),out->end(),sortByDetId);
+  if (out->capacity() > 2 * out->size())
+    out->shrink_to_fit();
+  if (cleaned->capacity() > 2 * cleaned->size())
+    cleaned->shrink_to_fit();
+  localRA1.update(out->size());
+  localRA2.update(cleaned->size());
+  std::sort(out->begin(), out->end(), sortByDetId);
 
-   //create a refprod here
-   edm::RefProd<reco::PFRecHitCollection> refProd = 
-     iEvent.getRefBeforePut<reco::PFRecHitCollection>();
+  //create a refprod here
+  edm::RefProd<reco::PFRecHitCollection> refProd = iEvent.getRefBeforePut<reco::PFRecHitCollection>();
 
-   for( auto& pfrechit : *out ) {
-     navigator_->associateNeighbours(pfrechit,out,refProd);
-   }
+  for (auto& pfrechit : *out) {
+    navigator_->associateNeighbours(pfrechit, out, refProd);
+  }
 
-   iEvent.put(std::move(out),"");
-   iEvent.put(std::move(cleaned),"Cleaned");
-
+  iEvent.put(std::move(out), "");
+  iEvent.put(std::move(cleaned), "Cleaned");
 }
 
-void
- PFRecHitProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+void PFRecHitProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   //The following says we do not know what parameters are allowed so do no validation
   // Please change this to state exactly what you do use, even if it is no parameters
   edm::ParameterSetDescription desc;
   desc.setUnknown();
   descriptions.addDefault(desc);
 }
-

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.h
@@ -19,19 +19,19 @@
 //
 
 class PFRecHitProducer final : public edm::stream::EDProducer<> {
-   public:
-      explicit PFRecHitProducer(const edm::ParameterSet& iConfig);
-      ~PFRecHitProducer() override;
+public:
+  explicit PFRecHitProducer(const edm::ParameterSet& iConfig);
+  ~PFRecHitProducer() override;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-   private:
-      void produce(edm::Event&, const edm::EventSetup&) override;
-      void beginLuminosityBlock(edm::LuminosityBlock const&, const edm::EventSetup &) override;
-      void endLuminosityBlock(edm::LuminosityBlock const&, const edm::EventSetup &) override;
-      std::vector<std::unique_ptr<PFRecHitCreatorBase> > creators_;
-      std::unique_ptr<PFRecHitNavigatorBase> navigator_;
-      bool init_;
+private:
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  void beginLuminosityBlock(edm::LuminosityBlock const&, const edm::EventSetup&) override;
+  void endLuminosityBlock(edm::LuminosityBlock const&, const edm::EventSetup&) override;
+  std::vector<std::unique_ptr<PFRecHitCreatorBase> > creators_;
+  std::unique_ptr<PFRecHitNavigatorBase> navigator_;
+  bool init_;
 };
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFlow2DClusterizerWithTime.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFlow2DClusterizerWithTime.cc
@@ -23,120 +23,107 @@
 #define LOGDRESSED(x) LogDebug(x)
 #endif
 
-PFlow2DClusterizerWithTime::
-PFlow2DClusterizerWithTime(const edm::ParameterSet& conf) :
-    PFClusterBuilderBase(conf),
-    _maxIterations(conf.getParameter<unsigned>("maxIterations")),
-    _stoppingTolerance(conf.getParameter<double>("stoppingTolerance")),
-    _showerSigma2(std::pow(conf.getParameter<double>("showerSigma"),2.0)),
-    _timeSigma_eb(std::pow(conf.getParameter<double>("timeSigmaEB"),2.0)),
-    _timeSigma_ee(std::pow(conf.getParameter<double>("timeSigmaEE"),2.0)),
-    _excludeOtherSeeds(conf.getParameter<bool>("excludeOtherSeeds")),
-    _minFracTot(conf.getParameter<double>("minFracTot")),
-    _maxNSigmaTime(std::pow(conf.getParameter<double>("maxNSigmaTime"),2.0)),
-    _minChi2Prob(conf.getParameter<double>("minChi2Prob")),
-    _clusterTimeResFromSeed(conf.getParameter<bool>("clusterTimeResFromSeed")),
+PFlow2DClusterizerWithTime::PFlow2DClusterizerWithTime(const edm::ParameterSet& conf)
+    : PFClusterBuilderBase(conf),
+      _maxIterations(conf.getParameter<unsigned>("maxIterations")),
+      _stoppingTolerance(conf.getParameter<double>("stoppingTolerance")),
+      _showerSigma2(std::pow(conf.getParameter<double>("showerSigma"), 2.0)),
+      _timeSigma_eb(std::pow(conf.getParameter<double>("timeSigmaEB"), 2.0)),
+      _timeSigma_ee(std::pow(conf.getParameter<double>("timeSigmaEE"), 2.0)),
+      _excludeOtherSeeds(conf.getParameter<bool>("excludeOtherSeeds")),
+      _minFracTot(conf.getParameter<double>("minFracTot")),
+      _maxNSigmaTime(std::pow(conf.getParameter<double>("maxNSigmaTime"), 2.0)),
+      _minChi2Prob(conf.getParameter<double>("minChi2Prob")),
+      _clusterTimeResFromSeed(conf.getParameter<bool>("clusterTimeResFromSeed")),
 
-    _layerMap({ {"PS2",(int)PFLayer::PS2},
-	        {"PS1",(int)PFLayer::PS1},
-	        {"ECAL_ENDCAP",(int)PFLayer::ECAL_ENDCAP},
-	        {"ECAL_BARREL",(int)PFLayer::ECAL_BARREL},
-	        {"NONE",(int)PFLayer::NONE},
-	        {"HCAL_BARREL1",(int)PFLayer::HCAL_BARREL1},
-	        {"HCAL_BARREL2_RING0",(int)PFLayer::HCAL_BARREL2},
-		{"HCAL_BARREL2_RING1",100*(int)PFLayer::HCAL_BARREL2},
-	        {"HCAL_ENDCAP",(int)PFLayer::HCAL_ENDCAP},
-	        {"HF_EM",(int)PFLayer::HF_EM},
-		{"HF_HAD",(int)PFLayer::HF_HAD} }) { 
-
-
-  const std::vector<edm::ParameterSet>& thresholds =
-    conf.getParameterSetVector("recHitEnergyNorms");
-  for( const auto& pset : thresholds ) {
+      _layerMap({{"PS2", (int)PFLayer::PS2},
+                 {"PS1", (int)PFLayer::PS1},
+                 {"ECAL_ENDCAP", (int)PFLayer::ECAL_ENDCAP},
+                 {"ECAL_BARREL", (int)PFLayer::ECAL_BARREL},
+                 {"NONE", (int)PFLayer::NONE},
+                 {"HCAL_BARREL1", (int)PFLayer::HCAL_BARREL1},
+                 {"HCAL_BARREL2_RING0", (int)PFLayer::HCAL_BARREL2},
+                 {"HCAL_BARREL2_RING1", 100 * (int)PFLayer::HCAL_BARREL2},
+                 {"HCAL_ENDCAP", (int)PFLayer::HCAL_ENDCAP},
+                 {"HF_EM", (int)PFLayer::HF_EM},
+                 {"HF_HAD", (int)PFLayer::HF_HAD}}) {
+  const std::vector<edm::ParameterSet>& thresholds = conf.getParameterSetVector("recHitEnergyNorms");
+  for (const auto& pset : thresholds) {
     const std::string& det = pset.getParameter<std::string>("detector");
-    const double& rhE_norm = pset.getParameter<double>("recHitEnergyNorm");    
+    const double& rhE_norm = pset.getParameter<double>("recHitEnergyNorm");
     auto entry = _layerMap.find(det);
-    if( entry == _layerMap.end() ) {
-      throw cms::Exception("InvalidDetectorLayer")
-	<< "Detector layer : " << det << " is not in the list of recognized"
-	<< " detector layers!";
+    if (entry == _layerMap.end()) {
+      throw cms::Exception("InvalidDetectorLayer") << "Detector layer : " << det << " is not in the list of recognized"
+                                                   << " detector layers!";
     }
-    _recHitEnergyNorms.emplace(_layerMap.find(det)->second,rhE_norm);
+    _recHitEnergyNorms.emplace(_layerMap.find(det)->second, rhE_norm);
   }
-  
-  if( conf.exists("allCellsPositionCalc") ) {
-    const edm::ParameterSet& acConf = 
-      conf.getParameterSet("allCellsPositionCalc");
-    const std::string& algoac = 
-      acConf.getParameter<std::string>("algoName");
-    _allCellsPosCalc = std::unique_ptr<PFCPositionCalculatorBase>{PFCPositionCalculatorFactory::get()->create(algoac, acConf)};
+
+  if (conf.exists("allCellsPositionCalc")) {
+    const edm::ParameterSet& acConf = conf.getParameterSet("allCellsPositionCalc");
+    const std::string& algoac = acConf.getParameter<std::string>("algoName");
+    _allCellsPosCalc =
+        std::unique_ptr<PFCPositionCalculatorBase>{PFCPositionCalculatorFactory::get()->create(algoac, acConf)};
   }
   // if necessary a third pos calc for convergence testing
-  if( conf.exists("positionCalcForConvergence") ) {
-    const edm::ParameterSet& convConf = 
-      conf.getParameterSet("positionCalcForConvergence");
-    const std::string& algoconv = 
-      convConf.getParameter<std::string>("algoName");
-    _convergencePosCalc = std::unique_ptr<PFCPositionCalculatorBase>{PFCPositionCalculatorFactory::get()->create(algoconv, convConf)};
+  if (conf.exists("positionCalcForConvergence")) {
+    const edm::ParameterSet& convConf = conf.getParameterSet("positionCalcForConvergence");
+    const std::string& algoconv = convConf.getParameter<std::string>("algoName");
+    _convergencePosCalc =
+        std::unique_ptr<PFCPositionCalculatorBase>{PFCPositionCalculatorFactory::get()->create(algoconv, convConf)};
   }
-  if( conf.exists("timeResolutionCalcBarrel") ) {
-    const edm::ParameterSet& timeResConf = 
-      conf.getParameterSet("timeResolutionCalcBarrel");
-    _timeResolutionCalcBarrel = std::make_unique<CaloRecHitResolutionProvider>(
-        timeResConf);
+  if (conf.exists("timeResolutionCalcBarrel")) {
+    const edm::ParameterSet& timeResConf = conf.getParameterSet("timeResolutionCalcBarrel");
+    _timeResolutionCalcBarrel = std::make_unique<CaloRecHitResolutionProvider>(timeResConf);
   }
-  if( conf.exists("timeResolutionCalcEndcap") ) {
-    const edm::ParameterSet& timeResConf = 
-      conf.getParameterSet("timeResolutionCalcEndcap");
-    _timeResolutionCalcEndcap = std::make_unique<CaloRecHitResolutionProvider>(
-        timeResConf);
+  if (conf.exists("timeResolutionCalcEndcap")) {
+    const edm::ParameterSet& timeResConf = conf.getParameterSet("timeResolutionCalcEndcap");
+    _timeResolutionCalcEndcap = std::make_unique<CaloRecHitResolutionProvider>(timeResConf);
   }
 }
 
-void PFlow2DClusterizerWithTime::
-buildClusters(const reco::PFClusterCollection& input,
-	      const std::vector<bool>& seedable,
-	      reco::PFClusterCollection& output) {
+void PFlow2DClusterizerWithTime::buildClusters(const reco::PFClusterCollection& input,
+                                               const std::vector<bool>& seedable,
+                                               reco::PFClusterCollection& output) {
   reco::PFClusterCollection clustersInTopo;
-  for( const auto& topocluster : input ) {
+  for (const auto& topocluster : input) {
     clustersInTopo.clear();
-    seedPFClustersFromTopo(topocluster,seedable,clustersInTopo);
-    const unsigned tolScal = 
-      std::pow(std::max(1.0,clustersInTopo.size()-1.0),2.0);
-    growPFClusters(topocluster,seedable,tolScal,0,tolScal,clustersInTopo);
+    seedPFClustersFromTopo(topocluster, seedable, clustersInTopo);
+    const unsigned tolScal = std::pow(std::max(1.0, clustersInTopo.size() - 1.0), 2.0);
+    growPFClusters(topocluster, seedable, tolScal, 0, tolScal, clustersInTopo);
     // step added by Josh Bendavid, removes low-fraction clusters
     // did not impact position resolution with fraction cut of 1e-7
     // decreases the size of each pf cluster considerably
     prunePFClusters(clustersInTopo);
     // recalculate the positions of the pruned clusters
-    if( _convergencePosCalc ) { 
+    if (_convergencePosCalc) {
       // if defined, use the special position calculation for convergence tests
       _convergencePosCalc->calculateAndSetPositions(clustersInTopo);
     } else {
-      if( clustersInTopo.size() == 1 && _allCellsPosCalc ) {
-	_allCellsPosCalc->calculateAndSetPosition(clustersInTopo.back());
+      if (clustersInTopo.size() == 1 && _allCellsPosCalc) {
+        _allCellsPosCalc->calculateAndSetPosition(clustersInTopo.back());
       } else {
-	_positionCalc->calculateAndSetPositions(clustersInTopo);
-      }   
+        _positionCalc->calculateAndSetPositions(clustersInTopo);
+      }
     }
-    for( auto& clusterout : clustersInTopo ) {
-      output.insert(output.end(),std::move(clusterout));
+    for (auto& clusterout : clustersInTopo) {
+      output.insert(output.end(), std::move(clusterout));
     }
   }
 }
 
-void PFlow2DClusterizerWithTime::
-seedPFClustersFromTopo(const reco::PFCluster& topo,
-		       const std::vector<bool>& seedable,
-		       reco::PFClusterCollection& initialPFClusters) const {
+void PFlow2DClusterizerWithTime::seedPFClustersFromTopo(const reco::PFCluster& topo,
+                                                        const std::vector<bool>& seedable,
+                                                        reco::PFClusterCollection& initialPFClusters) const {
   const auto& recHitFractions = topo.recHitFractions();
-  for( const auto& rhf : recHitFractions ) {
-    if( !seedable[rhf.recHitRef().key()] ) continue;
+  for (const auto& rhf : recHitFractions) {
+    if (!seedable[rhf.recHitRef().key()])
+      continue;
     initialPFClusters.push_back(reco::PFCluster());
     reco::PFCluster& current = initialPFClusters.back();
     current.addRecHitFraction(rhf);
-    current.setSeed(rhf.recHitRef()->detId());   
-    if( _convergencePosCalc ) {
+    current.setSeed(rhf.recHitRef()->detId());
+    if (_convergencePosCalc) {
       _convergencePosCalc->calculateAndSetPosition(current);
     } else {
       _positionCalc->calculateAndSetPosition(current);
@@ -144,33 +131,32 @@ seedPFClustersFromTopo(const reco::PFCluster& topo,
   }
 }
 
-void PFlow2DClusterizerWithTime::
-growPFClusters(const reco::PFCluster& topo,
-	       const std::vector<bool>& seedable,
-	       const unsigned toleranceScaling,
-	       const unsigned iter,
-	       double diff,
-	       reco::PFClusterCollection& clusters) const {
-  if( iter >= _maxIterations ) {
+void PFlow2DClusterizerWithTime::growPFClusters(const reco::PFCluster& topo,
+                                                const std::vector<bool>& seedable,
+                                                const unsigned toleranceScaling,
+                                                const unsigned iter,
+                                                double diff,
+                                                reco::PFClusterCollection& clusters) const {
+  if (iter >= _maxIterations) {
     LOGDRESSED("PFlow2DClusterizerWithTime:growAndStabilizePFClusters")
-      <<"reached " << _maxIterations << " iterations, terminated position "
-      << "fit with diff = " << diff;
-  }      
-  if( iter >= _maxIterations || 
-      diff <= _stoppingTolerance*toleranceScaling) return;
-  // reset the rechits in this cluster, keeping the previous position    
-  std::vector<reco::PFCluster::REPPoint> clus_prev_pos;  
+        << "reached " << _maxIterations << " iterations, terminated position "
+        << "fit with diff = " << diff;
+  }
+  if (iter >= _maxIterations || diff <= _stoppingTolerance * toleranceScaling)
+    return;
+  // reset the rechits in this cluster, keeping the previous position
+  std::vector<reco::PFCluster::REPPoint> clus_prev_pos;
   // also calculate and keep the previous time resolution
   std::vector<double> clus_prev_timeres2;
-  
-  for( auto& cluster : clusters) {
+
+  for (auto& cluster : clusters) {
     const reco::PFCluster::REPPoint& repp = cluster.positionREP();
-    clus_prev_pos.emplace_back(repp.rho(),repp.eta(),repp.phi());
-    if( _convergencePosCalc ) {
-      if( clusters.size() == 1 && _allCellsPosCalc ) {
-	_allCellsPosCalc->calculateAndSetPosition(cluster);
+    clus_prev_pos.emplace_back(repp.rho(), repp.eta(), repp.phi());
+    if (_convergencePosCalc) {
+      if (clusters.size() == 1 && _allCellsPosCalc) {
+        _allCellsPosCalc->calculateAndSetPosition(cluster);
       } else {
-	_positionCalc->calculateAndSetPosition(cluster);
+        _positionCalc->calculateAndSetPosition(cluster);
       }
     }
     double resCluster2;
@@ -181,7 +167,7 @@ growPFClusters(const reco::PFCluster& topo,
     clus_prev_timeres2.push_back(resCluster2);
     cluster.resetHitsAndFractions();
   }
-  // loop over topo cluster and grow current PFCluster hypothesis 
+  // loop over topo cluster and grow current PFCluster hypothesis
   std::vector<double> dist2, frac;
 
   // Store chi2 values and nhits to calculate chi2 prob. inline
@@ -189,213 +175,194 @@ growPFClusters(const reco::PFCluster& topo,
   std::vector<size_t> clus_chi2_nhits;
 
   double fractot = 0;
-  for( const reco::PFRecHitFraction& rhf : topo.recHitFractions() ) {
+  for (const reco::PFRecHitFraction& rhf : topo.recHitFractions()) {
     const reco::PFRecHitRef& refhit = rhf.recHitRef();
     int cell_layer = (int)refhit->layer();
-    if( cell_layer == PFLayer::HCAL_BARREL2 && 
-	std::abs(refhit->positionREP().eta()) > 0.34 ) {
+    if (cell_layer == PFLayer::HCAL_BARREL2 && std::abs(refhit->positionREP().eta()) > 0.34) {
       cell_layer *= 100;
-    }  
-    const double recHitEnergyNorm = 
-      _recHitEnergyNorms.find(cell_layer)->second; 
+    }
+    const double recHitEnergyNorm = _recHitEnergyNorms.find(cell_layer)->second;
     math::XYZPoint topocellpos_xyz(refhit->position());
-    dist2.clear(); frac.clear(); fractot = 0;
+    dist2.clear();
+    frac.clear();
+    fractot = 0;
 
     // add rechits to clusters, calculating fraction based on distance
-    // need position in vector to get cluster time resolution   
+    // need position in vector to get cluster time resolution
     for (size_t iCluster = 0; iCluster < clusters.size(); ++iCluster) {
       reco::PFCluster& cluster = clusters[iCluster];
       const math::XYZPoint& clusterpos_xyz = cluster.position();
       const math::XYZVector deltav = clusterpos_xyz - topocellpos_xyz;
-      double d2 = deltav.Mag2()/_showerSigma2;
+      double d2 = deltav.Mag2() / _showerSigma2;
 
-      double d2time = dist2Time(cluster, refhit, cell_layer,
-        clus_prev_timeres2[iCluster]);
+      double d2time = dist2Time(cluster, refhit, cell_layer, clus_prev_timeres2[iCluster]);
       d2 += d2time;
 
-      if (_minChi2Prob > 0. && !passChi2Prob(iCluster, d2time, clus_chi2, 
-        clus_chi2_nhits))
+      if (_minChi2Prob > 0. && !passChi2Prob(iCluster, d2time, clus_chi2, clus_chi2_nhits))
         d2 = 999.;
 
-      dist2.emplace_back( d2);
+      dist2.emplace_back(d2);
 
-      if( d2 > 100 ) {
-	LOGDRESSED("PFlow2DClusterizerWithTime:growAndStabilizePFClusters")
-	  << "Warning! :: pfcluster-topocell distance is too large! d= "
-	  << d2;
+      if (d2 > 100) {
+        LOGDRESSED("PFlow2DClusterizerWithTime:growAndStabilizePFClusters")
+            << "Warning! :: pfcluster-topocell distance is too large! d= " << d2;
       }
       // fraction assignment logic
       double fraction;
-      if( refhit->detId() == cluster.seed() && _excludeOtherSeeds ) {
-	fraction = 1.0;	
-      } else if ( seedable[refhit.key()] && _excludeOtherSeeds ) {
-	fraction = 0.0;
+      if (refhit->detId() == cluster.seed() && _excludeOtherSeeds) {
+        fraction = 1.0;
+      } else if (seedable[refhit.key()] && _excludeOtherSeeds) {
+        fraction = 0.0;
       } else {
-	fraction = cluster.energy()/recHitEnergyNorm * vdt::fast_expf( -0.5*d2 );
-      }      
+        fraction = cluster.energy() / recHitEnergyNorm * vdt::fast_expf(-0.5 * d2);
+      }
       fractot += fraction;
       frac.emplace_back(fraction);
     }
-    for( unsigned i = 0; i < clusters.size(); ++i ) {      
-      if( fractot > _minFracTot || 
-	  ( refhit->detId() == clusters[i].seed() && fractot > 0.0 ) ) {
-	frac[i]/=fractot;
+    for (unsigned i = 0; i < clusters.size(); ++i) {
+      if (fractot > _minFracTot || (refhit->detId() == clusters[i].seed() && fractot > 0.0)) {
+        frac[i] /= fractot;
       } else {
-	continue;
+        continue;
       }
-      // if the fraction has been set to 0, the cell 
+      // if the fraction has been set to 0, the cell
       // is now added to the cluster - careful ! (PJ, 19/07/08)
       // BUT KEEP ONLY CLOSE CELLS OTHERWISE MEMORY JUST EXPLOSES
-      // (PJ, 15/09/08 <- similar to what existed before the 
-      // previous bug fix, but keeps the close seeds inside, 
+      // (PJ, 15/09/08 <- similar to what existed before the
+      // previous bug fix, but keeps the close seeds inside,
       // even if their fraction was set to zero.)
-      // Also add a protection to keep the seed in the cluster 
+      // Also add a protection to keep the seed in the cluster
       // when the latter gets far from the former. These cases
-      // (about 1% of the clusters) need to be studied, as 
+      // (about 1% of the clusters) need to be studied, as
       // they create fake photons, in general.
-      // (PJ, 16/09/08) 
-      if( dist2[i] < 100.0 || frac[i] > 0.9999 ) {	
-	clusters[i].addRecHitFraction(reco::PFRecHitFraction(refhit,frac[i]));
+      // (PJ, 16/09/08)
+      if (dist2[i] < 100.0 || frac[i] > 0.9999) {
+        clusters[i].addRecHitFraction(reco::PFRecHitFraction(refhit, frac[i]));
       }
     }
   }
   // recalculate positions and calculate convergence parameter
-  double diff2 = 0.0;  
-  for( unsigned i = 0; i < clusters.size(); ++i ) {
-    if( _convergencePosCalc ) {
+  double diff2 = 0.0;
+  for (unsigned i = 0; i < clusters.size(); ++i) {
+    if (_convergencePosCalc) {
       _convergencePosCalc->calculateAndSetPosition(clusters[i]);
     } else {
-      if( clusters.size() == 1 && _allCellsPosCalc ) {
-	_allCellsPosCalc->calculateAndSetPosition(clusters[i]);
+      if (clusters.size() == 1 && _allCellsPosCalc) {
+        _allCellsPosCalc->calculateAndSetPosition(clusters[i]);
       } else {
-	_positionCalc->calculateAndSetPosition(clusters[i]);
+        _positionCalc->calculateAndSetPosition(clusters[i]);
       }
     }
-    const double delta2 = 
-      reco::deltaR2(clusters[i].positionREP(),clus_prev_pos[i]);    
-    if( delta2 > diff2 ) diff2 = delta2;
+    const double delta2 = reco::deltaR2(clusters[i].positionREP(), clus_prev_pos[i]);
+    if (delta2 > diff2)
+      diff2 = delta2;
   }
   diff = std::sqrt(diff2);
-  dist2.clear(); frac.clear(); clus_prev_pos.clear();// avoid badness
-  clus_chi2.clear(); clus_chi2_nhits.clear(); clus_prev_timeres2.clear();
-  growPFClusters(topo,seedable,toleranceScaling,iter+1,diff,clusters);
+  dist2.clear();
+  frac.clear();
+  clus_prev_pos.clear();  // avoid badness
+  clus_chi2.clear();
+  clus_chi2_nhits.clear();
+  clus_prev_timeres2.clear();
+  growPFClusters(topo, seedable, toleranceScaling, iter + 1, diff, clusters);
 }
 
-void PFlow2DClusterizerWithTime::
-prunePFClusters(reco::PFClusterCollection& clusters) const {
-  for( auto& cluster : clusters ) {
-    cluster.pruneUsing( [&](const reco::PFRecHitFraction& rhf)
-			{return rhf.fraction() > _minFractionToKeep;} 
-			);    
+void PFlow2DClusterizerWithTime::prunePFClusters(reco::PFClusterCollection& clusters) const {
+  for (auto& cluster : clusters) {
+    cluster.pruneUsing([&](const reco::PFRecHitFraction& rhf) { return rhf.fraction() > _minFractionToKeep; });
   }
 }
 
-void PFlow2DClusterizerWithTime::clusterTimeResolutionFromSeed(reco::PFCluster& 
-  cluster, double& clusterRes2) const
-{
+void PFlow2DClusterizerWithTime::clusterTimeResolutionFromSeed(reco::PFCluster& cluster, double& clusterRes2) const {
   clusterRes2 = 10000.;
-  for (auto& rhf : cluster.recHitFractions())
-  {
+  for (auto& rhf : cluster.recHitFractions()) {
     const reco::PFRecHit& rh = *(rhf.recHitRef());
-    if (rh.detId() == cluster.seed())
-    {
+    if (rh.detId() == cluster.seed()) {
       cluster.setTime(rh.time());
-      bool isBarrel = (rh.layer() == PFLayer::HCAL_BARREL1 ||
-       rh.layer() == PFLayer::HCAL_BARREL2 ||
-       rh.layer() == PFLayer::ECAL_BARREL);
-     if (isBarrel)
-       clusterRes2 = _timeResolutionCalcBarrel->timeResolution2(rh.energy());
-     else
-       clusterRes2 = _timeResolutionCalcEndcap->timeResolution2(rh.energy());
-     cluster.setTimeError(std::sqrt(float(clusterRes2)));
+      bool isBarrel = (rh.layer() == PFLayer::HCAL_BARREL1 || rh.layer() == PFLayer::HCAL_BARREL2 ||
+                       rh.layer() == PFLayer::ECAL_BARREL);
+      if (isBarrel)
+        clusterRes2 = _timeResolutionCalcBarrel->timeResolution2(rh.energy());
+      else
+        clusterRes2 = _timeResolutionCalcEndcap->timeResolution2(rh.energy());
+      cluster.setTimeError(std::sqrt(float(clusterRes2)));
     }
   }
 }
 
-void PFlow2DClusterizerWithTime::clusterTimeResolution(reco::PFCluster& cluster, 
-    double& clusterRes2) const
-{
+void PFlow2DClusterizerWithTime::clusterTimeResolution(reco::PFCluster& cluster, double& clusterRes2) const {
   double sumTimeSigma2 = 0.;
   double sumSigma2 = 0.;
 
-  for (auto& rhf : cluster.recHitFractions())
-  {
+  for (auto& rhf : cluster.recHitFractions()) {
     const reco::PFRecHit& rh = *(rhf.recHitRef());
     const double rhf_f = rhf.fraction();
 
     if (rhf_f == 0.)
       continue;
 
-    bool isBarrel = (rh.layer() == PFLayer::HCAL_BARREL1 ||
-      rh.layer() == PFLayer::HCAL_BARREL2 ||
-      rh.layer() == PFLayer::ECAL_BARREL);
+    bool isBarrel = (rh.layer() == PFLayer::HCAL_BARREL1 || rh.layer() == PFLayer::HCAL_BARREL2 ||
+                     rh.layer() == PFLayer::ECAL_BARREL);
     double res2 = 10000.;
     if (isBarrel)
       res2 = _timeResolutionCalcBarrel->timeResolution2(rh.energy());
     else
       res2 = _timeResolutionCalcEndcap->timeResolution2(rh.energy());
 
-    sumTimeSigma2 += rhf_f * rh.time()/res2;
-    sumSigma2 += rhf_f/res2;
+    sumTimeSigma2 += rhf_f * rh.time() / res2;
+    sumSigma2 += rhf_f / res2;
   }
   if (sumSigma2 > 0.) {
-    clusterRes2 = 1./sumSigma2;
-    cluster.setTime(sumTimeSigma2/sumSigma2);
+    clusterRes2 = 1. / sumSigma2;
+    cluster.setTime(sumTimeSigma2 / sumSigma2);
     cluster.setTimeError(std::sqrt(float(clusterRes2)));
   } else {
     clusterRes2 = 999999.;
   }
 }
 
-double PFlow2DClusterizerWithTime::dist2Time(const reco::PFCluster& cluster, 
-  const reco::PFRecHitRef& refhit, int cell_layer, double prev_timeres2) const 
-{
-  const double deltaT = cluster.time()-refhit->time();
-  const double t2 = deltaT*deltaT;
+double PFlow2DClusterizerWithTime::dist2Time(const reco::PFCluster& cluster,
+                                             const reco::PFRecHitRef& refhit,
+                                             int cell_layer,
+                                             double prev_timeres2) const {
+  const double deltaT = cluster.time() - refhit->time();
+  const double t2 = deltaT * deltaT;
   double res2 = 100.;
 
-  if (cell_layer == PFLayer::HCAL_BARREL1 ||
-  cell_layer == PFLayer::HCAL_BARREL2 ||
-  cell_layer == PFLayer::ECAL_BARREL) {
+  if (cell_layer == PFLayer::HCAL_BARREL1 || cell_layer == PFLayer::HCAL_BARREL2 ||
+      cell_layer == PFLayer::ECAL_BARREL) {
     if (_timeResolutionCalcBarrel) {
       const double resCluster2 = prev_timeres2;
-      res2 = resCluster2 + _timeResolutionCalcBarrel->timeResolution2(
-        refhit->energy());
+      res2 = resCluster2 + _timeResolutionCalcBarrel->timeResolution2(refhit->energy());
+    } else {
+      return t2 / _timeSigma_eb;
     }
-    else {
-      return t2/_timeSigma_eb;
-    }
-  }
-  else if (cell_layer == PFLayer::HCAL_ENDCAP ||
-     cell_layer == PFLayer::HF_EM ||
-     cell_layer == PFLayer::HF_HAD ||
-     cell_layer == PFLayer::ECAL_ENDCAP) {
+  } else if (cell_layer == PFLayer::HCAL_ENDCAP || cell_layer == PFLayer::HF_EM || cell_layer == PFLayer::HF_HAD ||
+             cell_layer == PFLayer::ECAL_ENDCAP) {
     if (_timeResolutionCalcEndcap) {
       const double resCluster2 = prev_timeres2;
-      res2 = resCluster2 + _timeResolutionCalcEndcap->timeResolution2(
-        refhit->energy());
-    }
-     else {
-      return t2/_timeSigma_ee;
+      res2 = resCluster2 + _timeResolutionCalcEndcap->timeResolution2(refhit->energy());
+    } else {
+      return t2 / _timeSigma_ee;
     }
   }
 
-  double distTime2 = t2/res2;
+  double distTime2 = t2 / res2;
   if (distTime2 > _maxNSigmaTime)
-    return 999.; // reject hit
+    return 999.;  // reject hit
 
   return distTime2;
 }
 
-bool PFlow2DClusterizerWithTime::passChi2Prob(size_t iCluster, double dist2, 
-  std::vector<double>& clus_chi2, std::vector<size_t>& clus_chi2_nhits) const
-{
-  if (iCluster >= clus_chi2.size()) { // first hit
+bool PFlow2DClusterizerWithTime::passChi2Prob(size_t iCluster,
+                                              double dist2,
+                                              std::vector<double>& clus_chi2,
+                                              std::vector<size_t>& clus_chi2_nhits) const {
+  if (iCluster >= clus_chi2.size()) {  // first hit
     clus_chi2.push_back(dist2);
     clus_chi2_nhits.push_back(1);
     return true;
-  }
-  else {
+  } else {
     double chi2 = clus_chi2[iCluster];
     size_t nhitsCluster = clus_chi2_nhits[iCluster];
     chi2 += dist2;

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFlow2DClusterizerWithTime.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFlow2DClusterizerWithTime.h
@@ -10,24 +10,27 @@
 
 class PFlow2DClusterizerWithTime : public PFClusterBuilderBase {
   typedef PFlow2DClusterizerWithTime B2DGPF;
- public:
+
+public:
   PFlow2DClusterizerWithTime(const edm::ParameterSet& conf);
-    
+
   ~PFlow2DClusterizerWithTime() override = default;
   PFlow2DClusterizerWithTime(const B2DGPF&) = delete;
   B2DGPF& operator=(const B2DGPF&) = delete;
 
-  void update(const edm::EventSetup& es) override { 
-    _positionCalc->update(es); 
-    if( _allCellsPosCalc ) _allCellsPosCalc->update(es);
-    if( _convergencePosCalc ) _convergencePosCalc->update(es);
+  void update(const edm::EventSetup& es) override {
+    _positionCalc->update(es);
+    if (_allCellsPosCalc)
+      _allCellsPosCalc->update(es);
+    if (_convergencePosCalc)
+      _convergencePosCalc->update(es);
   }
 
   void buildClusters(const reco::PFClusterCollection&,
-		     const std::vector<bool>&,
-		     reco::PFClusterCollection& outclus) override;
+                     const std::vector<bool>&,
+                     reco::PFClusterCollection& outclus) override;
 
- private:  
+private:
   const unsigned _maxIterations;
   const double _stoppingTolerance;
   const double _showerSigma2;
@@ -38,37 +41,33 @@ class PFlow2DClusterizerWithTime : public PFClusterBuilderBase {
   const double _maxNSigmaTime;
   const double _minChi2Prob;
   const bool _clusterTimeResFromSeed;
-  
-  const std::unordered_map<std::string,int> _layerMap;
-  std::unordered_map<int,double> _recHitEnergyNorms;
+
+  const std::unordered_map<std::string, int> _layerMap;
+  std::unordered_map<int, double> _recHitEnergyNorms;
   std::unique_ptr<PFCPositionCalculatorBase> _allCellsPosCalc;
   std::unique_ptr<PFCPositionCalculatorBase> _convergencePosCalc;
 
   std::unique_ptr<CaloRecHitResolutionProvider> _timeResolutionCalcBarrel;
   std::unique_ptr<CaloRecHitResolutionProvider> _timeResolutionCalcEndcap;
-  
-  void seedPFClustersFromTopo(const reco::PFCluster&,
-			      const std::vector<bool>&,
-			      reco::PFClusterCollection&) const;
+
+  void seedPFClustersFromTopo(const reco::PFCluster&, const std::vector<bool>&, reco::PFClusterCollection&) const;
 
   void growPFClusters(const reco::PFCluster&,
-		      const std::vector<bool>&,
-		      const unsigned toleranceScaling,
-		      const unsigned iter,
-		      double dist,
-		      reco::PFClusterCollection&) const;
+                      const std::vector<bool>&,
+                      const unsigned toleranceScaling,
+                      const unsigned iter,
+                      double dist,
+                      reco::PFClusterCollection&) const;
   void clusterTimeResolution(reco::PFCluster& cluster, double& res) const;
-  void clusterTimeResolutionFromSeed(reco::PFCluster& cluster, double& res) 
-    const;
-  double dist2Time(const reco::PFCluster&, const reco::PFRecHitRef&, 
-    int cell_layer, double prev_timeres2) const;
-  bool passChi2Prob(size_t iCluster, double dist2, 
-    std::vector<double>& clus_chi2, std::vector<size_t>& clus_chi2_nhits) const;
+  void clusterTimeResolutionFromSeed(reco::PFCluster& cluster, double& res) const;
+  double dist2Time(const reco::PFCluster&, const reco::PFRecHitRef&, int cell_layer, double prev_timeres2) const;
+  bool passChi2Prob(size_t iCluster,
+                    double dist2,
+                    std::vector<double>& clus_chi2,
+                    std::vector<size_t>& clus_chi2_nhits) const;
   void prunePFClusters(reco::PFClusterCollection&) const;
 };
 
-DEFINE_EDM_PLUGIN(PFClusterBuilderFactory,
-		  PFlow2DClusterizerWithTime,
-		  "PFlow2DClusterizerWithTime");
+DEFINE_EDM_PLUGIN(PFClusterBuilderFactory, PFlow2DClusterizerWithTime, "PFlow2DClusterizerWithTime");
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/PassThruSeedFinder.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PassThruSeedFinder.cc
@@ -1,14 +1,10 @@
 #include "PassThruSeedFinder.h"
 
-PassThruSeedFinder::
-PassThruSeedFinder(const edm::ParameterSet& conf) : 
-  SeedFinderBase(conf){
-}
+PassThruSeedFinder::PassThruSeedFinder(const edm::ParameterSet& conf) : SeedFinderBase(conf) {}
 
 // the starting state of seedable is all false!
-void PassThruSeedFinder::
-findSeeds( const edm::Handle<reco::PFRecHitCollection>& input,
-	   const std::vector<bool>& mask,
-	   std::vector<bool>& seedable ) {  
-  seedable = std::vector<bool>(input->size(),true);  
+void PassThruSeedFinder::findSeeds(const edm::Handle<reco::PFRecHitCollection>& input,
+                                   const std::vector<bool>& mask,
+                                   std::vector<bool>& seedable) {
+  seedable = std::vector<bool>(input->size(), true);
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/PassThruSeedFinder.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PassThruSeedFinder.h
@@ -6,19 +6,18 @@
 #include <unordered_map>
 
 class PassThruSeedFinder : public SeedFinderBase {
- public:
+public:
   PassThruSeedFinder(const edm::ParameterSet& conf);
   PassThruSeedFinder(const PassThruSeedFinder&) = delete;
   PassThruSeedFinder& operator=(const PassThruSeedFinder&) = delete;
 
-  void findSeeds( const edm::Handle<reco::PFRecHitCollection>& input,
-		  const std::vector<bool>& mask,
-		  std::vector<bool>& seedable ) override;
+  void findSeeds(const edm::Handle<reco::PFRecHitCollection>& input,
+                 const std::vector<bool>& mask,
+                 std::vector<bool>& seedable) override;
 
- private:  
+private:
 };
 
-DEFINE_EDM_PLUGIN(SeedFinderFactory,
-		  PassThruSeedFinder,"PassThruSeedFinder");
+DEFINE_EDM_PLUGIN(SeedFinderFactory, PassThruSeedFinder, "PassThruSeedFinder");
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/RBXAndHPDCleaner.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/RBXAndHPDCleaner.cc
@@ -4,60 +4,57 @@
 #include <cmath>
 
 namespace {
-   bool greaterByEnergy(const std::pair<unsigned,double>& a,
-		       const std::pair<unsigned,double>& b) {
+  bool greaterByEnergy(const std::pair<unsigned, double>& a, const std::pair<unsigned, double>& b) {
     return a.second > b.second;
   }
-}
+}  // namespace
 
-
-void RBXAndHPDCleaner::
-clean(const edm::Handle<reco::PFRecHitCollection>& input,
-      std::vector<bool>& mask ) {
-  _hpds.clear(); _rbxs.clear();
+void RBXAndHPDCleaner::clean(const edm::Handle<reco::PFRecHitCollection>& input, std::vector<bool>& mask) {
+  _hpds.clear();
+  _rbxs.clear();
   //need to run over energy sorted rechits
-  std::vector<std::pair<unsigned,double> > ordered_hits;
+  std::vector<std::pair<unsigned, double> > ordered_hits;
   ordered_hits.reserve(input->size());
-  for( unsigned i = 0; i < input->size(); ++i ) {
-    std::pair<unsigned,double> val = std::make_pair(i,input->at(i).energy());
-    auto pos = std::upper_bound(ordered_hits.begin(),ordered_hits.end(),
-				val, greaterByEnergy);
-    ordered_hits.insert(pos,val);
-  }   
- 
-  for( const auto& idx_e : ordered_hits ) {
-    if( !mask[idx_e.first] ) continue;
+  for (unsigned i = 0; i < input->size(); ++i) {
+    std::pair<unsigned, double> val = std::make_pair(i, input->at(i).energy());
+    auto pos = std::upper_bound(ordered_hits.begin(), ordered_hits.end(), val, greaterByEnergy);
+    ordered_hits.insert(pos, val);
+  }
+
+  for (const auto& idx_e : ordered_hits) {
+    if (!mask[idx_e.first])
+      continue;
     const unsigned idx = idx_e.first;
     const reco::PFRecHit& rechit = input->at(idx);
     int layer = rechit.layer();
-    if ( layer != PFLayer::HCAL_BARREL1 && layer != PFLayer::HCAL_ENDCAP ) {
-      break; 
+    if (layer != PFLayer::HCAL_BARREL1 && layer != PFLayer::HCAL_ENDCAP) {
+      break;
     }
     HcalDetId theHcalDetId(rechit.detId());
     int ieta = theHcalDetId.ieta();
     int iphi = theHcalDetId.iphi();
     int ihpd = 0, irbx = 0;
-    switch( layer ) {
-    case PFLayer::HCAL_BARREL1:
-      ihpd = ( ieta < 0 ? -iphi : iphi );
-      irbx = ( ieta < 0 ? -(iphi+5)/4 : (iphi+5)/4 );
-      break;
-    case PFLayer::HCAL_ENDCAP:
-      ihpd = ( ieta < 0 ? -(iphi+1)/2-100 : (iphi+1)/2+100 );
-      irbx = ( ieta < 0 ? -(iphi+5)/4-20 : (iphi+5)/4+20 );
-      break;
-    default:
-      break;
+    switch (layer) {
+      case PFLayer::HCAL_BARREL1:
+        ihpd = (ieta < 0 ? -iphi : iphi);
+        irbx = (ieta < 0 ? -(iphi + 5) / 4 : (iphi + 5) / 4);
+        break;
+      case PFLayer::HCAL_ENDCAP:
+        ihpd = (ieta < 0 ? -(iphi + 1) / 2 - 100 : (iphi + 1) / 2 + 100);
+        irbx = (ieta < 0 ? -(iphi + 5) / 4 - 20 : (iphi + 5) / 4 + 20);
+        break;
+      default:
+        break;
     }
-    switch( std::abs(irbx) ) {
-    case 19:      
-      irbx = ( irbx < 0 ? -1 : 1 );
-      break;
-    case 39:
-      irbx = ( irbx < 0 ? -21 : 21 );
-      break;
-    default:
-      break;
+    switch (std::abs(irbx)) {
+      case 19:
+        irbx = (irbx < 0 ? -1 : 1);
+        break;
+      case 39:
+        irbx = (irbx < 0 ? -21 : 21);
+        break;
+      default:
+        break;
     }
     _hpds[ihpd].push_back(idx);
     _rbxs[irbx].push_back(idx);
@@ -66,167 +63,171 @@ clean(const edm::Handle<reco::PFRecHitCollection>& input,
   // and lots of energy
   std::unordered_map<int, std::vector<unsigned> > theHPDs;
   std::unordered_multimap<double, unsigned> theEnergies;
-  for( const auto& itrbx : _rbxs ) {
-    if( ( std::abs(itrbx.first)<20 && itrbx.second.size() > 30 ) || 
-	( std::abs(itrbx.first)>20 && itrbx.second.size() > 30 ) ) {
+  for (const auto& itrbx : _rbxs) {
+    if ((std::abs(itrbx.first) < 20 && itrbx.second.size() > 30) ||
+        (std::abs(itrbx.first) > 20 && itrbx.second.size() > 30)) {
       const std::vector<unsigned>& rechits = itrbx.second;
       theHPDs.clear();
       theEnergies.clear();
       int nSeeds0 = rechits.size();
-      for( unsigned jh = 0; jh < rechits.size(); ++jh ) {
-	const reco::PFRecHit&  rechit = (*input)[jh];
-	// check if rechit is a seed
-	unsigned nN = 0 ; // neighbours over threshold
-	bool isASeed = true;
-	auto const & neighbours4 = rechit.neighbours4();
-	for( auto k : neighbours4 ) {
-          auto const & neighbour = (*input)[k]; 
-	  if( neighbour.energy() > rechit.energy() ) {	    
-	    --nSeeds0;
-	    isASeed = false;
-	    break;
-	  } else {
-	    if( neighbour.energy() > 0.4 ) ++nN;
-	  }
-	}
-	if ( isASeed && !nN ) --nSeeds0;
+      for (unsigned jh = 0; jh < rechits.size(); ++jh) {
+        const reco::PFRecHit& rechit = (*input)[jh];
+        // check if rechit is a seed
+        unsigned nN = 0;  // neighbours over threshold
+        bool isASeed = true;
+        auto const& neighbours4 = rechit.neighbours4();
+        for (auto k : neighbours4) {
+          auto const& neighbour = (*input)[k];
+          if (neighbour.energy() > rechit.energy()) {
+            --nSeeds0;
+            isASeed = false;
+            break;
+          } else {
+            if (neighbour.energy() > 0.4)
+              ++nN;
+          }
+        }
+        if (isASeed && !nN)
+          --nSeeds0;
 
-	HcalDetId theHcalDetId(rechit.detId());
-	int iphi = theHcalDetId.iphi();
-	switch( rechit.layer() ) {
-	case PFLayer::HCAL_BARREL1:
-	  theHPDs[iphi].push_back(rechits[jh]);
-	  break;
-	case PFLayer::HCAL_ENDCAP:
-	  theHPDs[(iphi-1)/2].push_back(rechits[jh]);
-	  break;
-	default:
-	  break;
-	}
-	const double rhenergy = rechit.energy();
-	theEnergies.emplace(rhenergy,rechits[jh]);
+        HcalDetId theHcalDetId(rechit.detId());
+        int iphi = theHcalDetId.iphi();
+        switch (rechit.layer()) {
+          case PFLayer::HCAL_BARREL1:
+            theHPDs[iphi].push_back(rechits[jh]);
+            break;
+          case PFLayer::HCAL_ENDCAP:
+            theHPDs[(iphi - 1) / 2].push_back(rechits[jh]);
+            break;
+          default:
+            break;
+        }
+        const double rhenergy = rechit.energy();
+        theEnergies.emplace(rhenergy, rechits[jh]);
       }
-      if( nSeeds0 > 6 ) {
-	unsigned nHPD15 = 0;
-	for( const auto& itHPD : theHPDs ) {
-	  int hpdN = itHPD.first;
-	  const std::vector<unsigned>& hpdHits = itHPD.second;
-	  if( ( std::abs(hpdN) < 100 && hpdHits.size() > 14 ) || 
-	      ( std::abs(hpdN) > 100 && hpdHits.size() > 14 ) ) ++nHPD15;
-	}
-	if( nHPD15 > 1 ) {
-	  unsigned nn = 0;
-	  double threshold = 1.0;
-	  for( const auto& itEn : theEnergies ) {
-	    ++nn;
-	    if( nn< 5 ) {
-	      mask[itEn.second] = false;
-	    } else if ( nn == 5 ) {
-	      threshold = itEn.first*5;
-	      mask[itEn.second] = false;	      
-	    } else {
-	      if( itEn.first < threshold ) mask[itEn.second] = false;
-	    }
-	  }
-	}
+      if (nSeeds0 > 6) {
+        unsigned nHPD15 = 0;
+        for (const auto& itHPD : theHPDs) {
+          int hpdN = itHPD.first;
+          const std::vector<unsigned>& hpdHits = itHPD.second;
+          if ((std::abs(hpdN) < 100 && hpdHits.size() > 14) || (std::abs(hpdN) > 100 && hpdHits.size() > 14))
+            ++nHPD15;
+        }
+        if (nHPD15 > 1) {
+          unsigned nn = 0;
+          double threshold = 1.0;
+          for (const auto& itEn : theEnergies) {
+            ++nn;
+            if (nn < 5) {
+              mask[itEn.second] = false;
+            } else if (nn == 5) {
+              threshold = itEn.first * 5;
+              mask[itEn.second] = false;
+            } else {
+              if (itEn.first < threshold)
+                mask[itEn.second] = false;
+            }
+          }
+        }
       }
     }
   }
 
   // loop on the HPDs
-  std::unordered_map<int,std::vector<unsigned> >::iterator neighbour1;
-  std::unordered_map<int,std::vector<unsigned> >::iterator neighbour2;
-  std::unordered_map<int,std::vector<unsigned> >::iterator neighbour0;
-  std::unordered_map<int,std::vector<unsigned> >::iterator neighbour3;
-  unsigned size1 = 0, size2 = 0;  
-  for( const auto& ithpd : _hpds ) {
+  std::unordered_map<int, std::vector<unsigned> >::iterator neighbour1;
+  std::unordered_map<int, std::vector<unsigned> >::iterator neighbour2;
+  std::unordered_map<int, std::vector<unsigned> >::iterator neighbour0;
+  std::unordered_map<int, std::vector<unsigned> >::iterator neighbour3;
+  unsigned size1 = 0, size2 = 0;
+  for (const auto& ithpd : _hpds) {
     const std::vector<unsigned>& rechits = ithpd.second;
     theEnergies.clear();
-    for( const unsigned rhidx : rechits ) {
-      const reco::PFRecHit & rechit = input->at(rhidx);
-      theEnergies.emplace(rechit.energy(),rhidx); 
+    for (const unsigned rhidx : rechits) {
+      const reco::PFRecHit& rechit = input->at(rhidx);
+      theEnergies.emplace(rechit.energy(), rhidx);
     }
-   
+
     const int thehpd = ithpd.first;
-    switch( std::abs(thehpd) ) {
-    case 1:
-      neighbour1 = ( thehpd > 0 ? _hpds.find(72) : _hpds.find(-72) );
-      break;
-    case 72:
-      neighbour2 = ( thehpd > 0 ? _hpds.find(1) : _hpds.find(-1) );
-      break;
-    case 101:
-      neighbour1 = ( thehpd > 0 ? _hpds.find(136) : _hpds.find(-136) );
-      break;
-    case 136:
-      neighbour2 = ( thehpd > 0 ? _hpds.find(101) : _hpds.find(-101) );
-      break;
-    default:
-      neighbour1 = ( thehpd > 0 ? _hpds.find(thehpd-1) : _hpds.find(thehpd+1) );
-      neighbour2 = ( thehpd > 0 ? _hpds.find(thehpd+1) : _hpds.find(thehpd-1) );
-      break;
-    }
-    if( neighbour1 != _hpds.end() ) {
-      const int nb1 = neighbour1->first;
-      switch( std::abs(nb1) ) {
+    switch (std::abs(thehpd)) {
       case 1:
-	neighbour0 = ( nb1 > 0 ? _hpds.find(72) : _hpds.find(-72) );
-	break;
+        neighbour1 = (thehpd > 0 ? _hpds.find(72) : _hpds.find(-72));
+        break;
+      case 72:
+        neighbour2 = (thehpd > 0 ? _hpds.find(1) : _hpds.find(-1));
+        break;
       case 101:
-	neighbour0 = ( nb1 > 0 ? _hpds.find(136) : _hpds.find(-136) );
-	break;
+        neighbour1 = (thehpd > 0 ? _hpds.find(136) : _hpds.find(-136));
+        break;
+      case 136:
+        neighbour2 = (thehpd > 0 ? _hpds.find(101) : _hpds.find(-101));
+        break;
       default:
-	neighbour0 = ( nb1 > 0 ? _hpds.find(nb1-1) : _hpds.find(nb1+1) );
-	break;
+        neighbour1 = (thehpd > 0 ? _hpds.find(thehpd - 1) : _hpds.find(thehpd + 1));
+        neighbour2 = (thehpd > 0 ? _hpds.find(thehpd + 1) : _hpds.find(thehpd - 1));
+        break;
+    }
+    if (neighbour1 != _hpds.end()) {
+      const int nb1 = neighbour1->first;
+      switch (std::abs(nb1)) {
+        case 1:
+          neighbour0 = (nb1 > 0 ? _hpds.find(72) : _hpds.find(-72));
+          break;
+        case 101:
+          neighbour0 = (nb1 > 0 ? _hpds.find(136) : _hpds.find(-136));
+          break;
+        default:
+          neighbour0 = (nb1 > 0 ? _hpds.find(nb1 - 1) : _hpds.find(nb1 + 1));
+          break;
       }
     } else {
       neighbour0 = _hpds.end();
     }
-    
-    if( neighbour2 != _hpds.end() ) {
+
+    if (neighbour2 != _hpds.end()) {
       const int nb2 = neighbour2->first;
-      switch( std::abs(nb2) ) {
-      case 72:
-	neighbour3 = ( nb2 > 0 ? _hpds.find(1) : _hpds.find(-1) );
-	break;
-      case 136:
-	neighbour3 = ( nb2 > 0 ? _hpds.find(101) : _hpds.find(-101) );
-	break;
-      default:
-	neighbour3 = ( nb2 > 0 ? _hpds.find(nb2+1) : _hpds.find(nb2-1) );
-	break;
+      switch (std::abs(nb2)) {
+        case 72:
+          neighbour3 = (nb2 > 0 ? _hpds.find(1) : _hpds.find(-1));
+          break;
+        case 136:
+          neighbour3 = (nb2 > 0 ? _hpds.find(101) : _hpds.find(-101));
+          break;
+        default:
+          neighbour3 = (nb2 > 0 ? _hpds.find(nb2 + 1) : _hpds.find(nb2 - 1));
+          break;
       }
     } else {
       neighbour3 = _hpds.end();
     }
-    
+
     size1 = neighbour1 != _hpds.end() ? neighbour1->second.size() : 0;
     size2 = neighbour2 != _hpds.end() ? neighbour2->second.size() : 0;
-    if( size1 > 10 ) {
-      if ( ( abs(neighbour1->first) > 100 && neighbour1->second.size() > 15 ) || 
-	   ( abs(neighbour1->first) < 100 && neighbour1->second.size() > 12 ) ) 
-	size1 = neighbour0 != _hpds.end() ? neighbour0->second.size() : 0;
+    if (size1 > 10) {
+      if ((abs(neighbour1->first) > 100 && neighbour1->second.size() > 15) ||
+          (abs(neighbour1->first) < 100 && neighbour1->second.size() > 12))
+        size1 = neighbour0 != _hpds.end() ? neighbour0->second.size() : 0;
     }
-    if( size2 > 10 ) {
-      if ( ( abs(neighbour2->first) > 100 && neighbour2->second.size() > 15 ) || 
-	   ( abs(neighbour2->first) < 100 && neighbour2->second.size() > 12 ) ) 
-	size2 = neighbour3 != _hpds.end() ? neighbour3->second.size() : 0;
+    if (size2 > 10) {
+      if ((abs(neighbour2->first) > 100 && neighbour2->second.size() > 15) ||
+          (abs(neighbour2->first) < 100 && neighbour2->second.size() > 12))
+        size2 = neighbour3 != _hpds.end() ? neighbour3->second.size() : 0;
     }
-    if( ( std::abs(ithpd.first) > 100 && ithpd.second.size() > 15 ) ||
-	( std::abs(ithpd.first) < 100 && ithpd.second.size() > 12 ) ) {
-      if( (double)(size1+size2)/(float)ithpd.second.size() < 1.0 ) {
-	unsigned nn = 0;
-	double threshold = 1.0;
-	for( const auto& itEn : theEnergies ) {
-	  if( nn < 5 ) {
-	    mask[itEn.second] = false;
-	  } else if ( nn == 5 ) {
-	    threshold = itEn.first*2.5;
-	    mask[itEn.second] = false;
-	  } else {
-	    if( itEn.first < threshold ) mask[itEn.second] = false;
-	  }
-	}
+    if ((std::abs(ithpd.first) > 100 && ithpd.second.size() > 15) ||
+        (std::abs(ithpd.first) < 100 && ithpd.second.size() > 12)) {
+      if ((double)(size1 + size2) / (float)ithpd.second.size() < 1.0) {
+        unsigned nn = 0;
+        double threshold = 1.0;
+        for (const auto& itEn : theEnergies) {
+          if (nn < 5) {
+            mask[itEn.second] = false;
+          } else if (nn == 5) {
+            threshold = itEn.first * 2.5;
+            mask[itEn.second] = false;
+          } else {
+            if (itEn.first < threshold)
+              mask[itEn.second] = false;
+          }
+        }
       }
     }
   }

--- a/RecoParticleFlow/PFClusterProducer/plugins/RBXAndHPDCleaner.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/RBXAndHPDCleaner.h
@@ -6,20 +6,17 @@
 #include <unordered_map>
 
 class RBXAndHPDCleaner : public RecHitTopologicalCleanerBase {
- public:
-  RBXAndHPDCleaner(const edm::ParameterSet& conf) :
-    RecHitTopologicalCleanerBase(conf) { }
+public:
+  RBXAndHPDCleaner(const edm::ParameterSet& conf) : RecHitTopologicalCleanerBase(conf) {}
   RBXAndHPDCleaner(const RBXAndHPDCleaner&) = delete;
   RBXAndHPDCleaner& operator=(const RBXAndHPDCleaner&) = delete;
 
-  void clean( const edm::Handle<reco::PFRecHitCollection>& input,
-	      std::vector<bool>& mask ) override;
+  void clean(const edm::Handle<reco::PFRecHitCollection>& input, std::vector<bool>& mask) override;
 
- private:  
-  std::unordered_map<int,std::vector<unsigned> > _hpds, _rbxs;
+private:
+  std::unordered_map<int, std::vector<unsigned> > _hpds, _rbxs;
 };
 
-DEFINE_EDM_PLUGIN(RecHitTopologicalCleanerFactory,
-		  RBXAndHPDCleaner,"RBXAndHPDCleaner");
+DEFINE_EDM_PLUGIN(RecHitTopologicalCleanerFactory, RBXAndHPDCleaner, "RBXAndHPDCleaner");
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/RecHitCreators.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/RecHitCreators.cc
@@ -11,7 +11,6 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/PFPSRecHitCreator.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/PFHGCalRecHitCreator.h"
 
-
 EDM_REGISTER_PLUGINFACTORY(PFRecHitFactory, "PFRecHitFactory");
 DEFINE_EDM_PLUGIN(PFRecHitFactory, PFEcalEndcapRecHitCreator, "PFEERecHitCreator");
 DEFINE_EDM_PLUGIN(PFRecHitFactory, PFEcalBarrelRecHitCreator, "PFEBRecHitCreator");
@@ -30,4 +29,3 @@ DEFINE_EDM_PLUGIN(PFRecHitFactory, PFHGCHEBRecHitCreator, "PFHGCHEBRecHitCreator
 DEFINE_EDM_PLUGIN(PFRecHitFactory, PFHGCalEERecHitCreator, "PFHGCalEERecHitCreator");
 DEFINE_EDM_PLUGIN(PFRecHitFactory, PFHGCalHSiRecHitCreator, "PFHGCalHSiRecHitCreator");
 DEFINE_EDM_PLUGIN(PFRecHitFactory, PFHGCalHScRecHitCreator, "PFHGCalHScRecHitCreator");
-

--- a/RecoParticleFlow/PFClusterProducer/plugins/RecHitQualityTests.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/RecHitQualityTests.cc
@@ -17,6 +17,8 @@ DEFINE_EDM_PLUGIN(PFRecHitQTestFactory, PFRecHitQTestHCALTimeVsDepth, "PFRecHitQ
 DEFINE_EDM_PLUGIN(PFRecHitQTestFactory, PFRecHitQTestHCALThresholdVsDepth, "PFRecHitQTestHCALThresholdVsDepth");
 
 DEFINE_EDM_PLUGIN(PFRecHitQTestFactory, PFRecHitQTestThresholdInMIPs, "PFRecHitQTestThresholdInMIPs");
-DEFINE_EDM_PLUGIN(PFRecHitQTestFactory, PFRecHitQTestThresholdInThicknessNormalizedMIPs, "PFRecHitQTestThresholdInThicknessNormalizedMIPs");
+DEFINE_EDM_PLUGIN(PFRecHitQTestFactory,
+                  PFRecHitQTestThresholdInThicknessNormalizedMIPs,
+                  "PFRecHitQTestThresholdInThicknessNormalizedMIPs");
 
 DEFINE_EDM_PLUGIN(PFRecHitQTestFactory, PFRecHitQTestHGCalThresholdSNR, "PFRecHitQTestHGCalThresholdSNR");

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/ComputeClusterTime.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/ComputeClusterTime.h
@@ -6,23 +6,21 @@
 #include <cmath>
 #include <vector>
 
-
 // functions to select the hits to compute the time of a given cluster
 // start with the only hits with timing information
 // average among the hits contained in the chosen time interval
 
-// N.B. time is corrected wrt vtx-calorimeter distance 
+// N.B. time is corrected wrt vtx-calorimeter distance
 // with straight line and light speed hypothesis
-// for charged tracks or heavy particles (longer track length or beta < 1) 
+// for charged tracks or heavy particles (longer track length or beta < 1)
 // need to correct the offset at analysis level
-
-
 
 namespace hgcalsimclustertime {
 
   //time-interval based on that ~210ps wide and with the highest number of hits
-  float fixSizeHighestDensity(std::vector<float>& t, float deltaT=0.210 /*time window in ns*/, float timeWidthBy=0.5){
-
+  float fixSizeHighestDensity(std::vector<float>& t,
+                              float deltaT = 0.210 /*time window in ns*/,
+                              float timeWidthBy = 0.5) {
     float tolerance = 0.05f;
     std::sort(t.begin(), t.end());
 
@@ -31,23 +29,19 @@ namespace hgcalsimclustertime {
     int end_el = 0;
     float timeW = 0.f;
 
-    for(auto start = t.begin(); start != t.end(); ++start) {
+    for (auto start = t.begin(); start != t.end(); ++start) {
       const auto startRef = *start;
-      int c = count_if(start, t.end(), [&](float el) {
-	  return el - startRef <= deltaT + tolerance;
-	});
+      int c = count_if(start, t.end(), [&](float el) { return el - startRef <= deltaT + tolerance; });
       if (c > max_elements) {
-	max_elements = c;
-	auto last_el = find_if_not(start, t.end(), [&](float el) {
-	    return el - startRef <= deltaT + tolerance;
-	  });
-	auto val = *(--last_el);
-	if (std::abs(deltaT - (val - startRef)) < tolerance) {
-	  tolerance = std::abs(deltaT - (val - startRef));
-	}
-	start_el = distance(t.begin(), start);
-	end_el = distance(t.begin(), last_el);
-	timeW = val - startRef;
+        max_elements = c;
+        auto last_el = find_if_not(start, t.end(), [&](float el) { return el - startRef <= deltaT + tolerance; });
+        auto val = *(--last_el);
+        if (std::abs(deltaT - (val - startRef)) < tolerance) {
+          tolerance = std::abs(deltaT - (val - startRef));
+        }
+        start_el = distance(t.begin(), start);
+        end_el = distance(t.begin(), last_el);
+        timeW = val - startRef;
       }
     }
 
@@ -59,23 +53,23 @@ namespace hgcalsimclustertime {
     int num = 0;
     int totSize = t.size();
 
-    for(int ij=0; ij<=start_el; ++ij){
-      if(t[ij] > (t[start_el] - HalfTimeDiff) ){
-	for(int kl=ij; kl<totSize; ++kl){
-	  if(t[kl] < (t[end_el] + HalfTimeDiff) ){
-	    sum += t[kl];
-	    ++num;
-	  }
-	  else  break;
-	}
-	break;
+    for (int ij = 0; ij <= start_el; ++ij) {
+      if (t[ij] > (t[start_el] - HalfTimeDiff)) {
+        for (int kl = ij; kl < totSize; ++kl) {
+          if (t[kl] < (t[end_el] + HalfTimeDiff)) {
+            sum += t[kl];
+            ++num;
+          } else
+            break;
+        }
+        break;
       }
     }
 
-    if(num == 0) return -99.;
-    return sum/num;
+    if (num == 0)
+      return -99.;
+    return sum / num;
   }
-
 
   //useful for future developments - baseline for 0PU
   /*
@@ -125,6 +119,6 @@ namespace hgcalsimclustertime {
     return sum/num;
   }
   */
-}
+}  // namespace hgcalsimclustertime
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/GenericSimClusterMapper.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/GenericSimClusterMapper.h
@@ -8,12 +8,12 @@
 
 class GenericSimClusterMapper : public InitialClusteringStepBase {
   typedef GenericSimClusterMapper B2DGT;
- public:
- GenericSimClusterMapper(const edm::ParameterSet& conf,
-			 edm::ConsumesCollector& sumes) :
-    InitialClusteringStepBase(conf,sumes) { 
-      _simClusterToken = sumes.consumes<SimClusterCollection>(conf.getParameter<edm::InputTag>("simClusterSrc"));
-    }
+
+public:
+  GenericSimClusterMapper(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+      : InitialClusteringStepBase(conf, sumes) {
+    _simClusterToken = sumes.consumes<SimClusterCollection>(conf.getParameter<edm::InputTag>("simClusterSrc"));
+  }
   ~GenericSimClusterMapper() override = default;
   GenericSimClusterMapper(const B2DGT&) = delete;
   B2DGT& operator=(const B2DGT&) = delete;
@@ -21,18 +21,15 @@ class GenericSimClusterMapper : public InitialClusteringStepBase {
   void updateEvent(const edm::Event&) final;
 
   void buildClusters(const edm::Handle<reco::PFRecHitCollection>&,
-		     const std::vector<bool>&,
-		     const std::vector<bool>&, 
-		     reco::PFClusterCollection&) override;
-  
- private:  
+                     const std::vector<bool>&,
+                     const std::vector<bool>&,
+                     reco::PFClusterCollection&) override;
+
+private:
   edm::EDGetTokenT<SimClusterCollection> _simClusterToken;
   edm::Handle<SimClusterCollection> _simClusterH;
-  
 };
 
-DEFINE_EDM_PLUGIN(InitialClusteringStepFactory,
-		  GenericSimClusterMapper,
-		  "GenericSimClusterMapper");
+DEFINE_EDM_PLUGIN(InitialClusteringStepFactory, GenericSimClusterMapper, "GenericSimClusterMapper");
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticCluster.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticCluster.h
@@ -5,136 +5,83 @@
 #include <vector>
 #include <algorithm>
 
-class RealisticCluster
-{
-        using Hit3DPosition = std::array<float,3>;
+class RealisticCluster {
+  using Hit3DPosition = std::array<float, 3>;
 
-    public:
+public:
+  // for each SimCluster and for each layer, we store the position of the most energetic hit of the simcluster in the layer
 
-        // for each SimCluster and for each layer, we store the position of the most energetic hit of the simcluster in the layer
+  struct LayerInfo {
+    Hit3DPosition centerOfGravityAtLayer_;
+    Hit3DPosition maxHitPosAtLayer_;
+    float maxEnergyHitAtLayer_;
+  };
 
-        struct LayerInfo
-        {
-            Hit3DPosition centerOfGravityAtLayer_;
-            Hit3DPosition maxHitPosAtLayer_;
-            float maxEnergyHitAtLayer_;
-        };
+  RealisticCluster() : totalEnergy(0.f), exclusiveEnergy(0.f), visible(true) {}
 
-        RealisticCluster():
-            totalEnergy(0.f),
-            exclusiveEnergy(0.f),
-            visible(true)
-        {
+  void increaseEnergy(float value) { totalEnergy += value; }
+  void increaseExclusiveEnergy(float value) { exclusiveEnergy += value; }
 
-        }
+  float getExclusiveEnergyFraction() const {
+    float fraction = 0.f;
+    if (totalEnergy > 0.f) {
+      fraction = exclusiveEnergy / totalEnergy;
+    }
+    return fraction;
+  }
 
-        void increaseEnergy(float value)
-        {
-            totalEnergy+=value;
-        }
-        void increaseExclusiveEnergy(float value)
-        {
-            exclusiveEnergy+=value;
-        }
+  float getEnergy() const { return totalEnergy; }
 
-        float getExclusiveEnergyFraction() const
-        {
-            float fraction = 0.f;
-            if(totalEnergy>0.f){
-                fraction = exclusiveEnergy/totalEnergy;
-            }
-            return fraction;
-        }
+  float getExclusiveEnergy() const { return exclusiveEnergy; }
 
-        float getEnergy() const
-        {
-            return totalEnergy;
-        }
+  bool isVisible() const { return visible; }
 
-        float getExclusiveEnergy() const
-        {
-            return exclusiveEnergy;
-        }
+  void setVisible(bool vis) { visible = vis; }
 
-        bool isVisible() const
-        {
-            return visible;
-        }
+  void setCenterOfGravity(unsigned int layerId, const Hit3DPosition& position) {
+    layerInfo_[layerId].centerOfGravityAtLayer_ = position;
+  }
 
-        void setVisible(bool vis)
-        {
-            visible = vis;
-        }
+  Hit3DPosition getCenterOfGravity(unsigned int layerId) const { return layerInfo_[layerId].centerOfGravityAtLayer_; }
 
-        void setCenterOfGravity(unsigned int layerId, const Hit3DPosition& position)
-        {
-            layerInfo_[layerId].centerOfGravityAtLayer_ = position;
-        }
+  bool setMaxEnergyHit(unsigned int layerId, float newEnergy, const Hit3DPosition position) {
+    if (newEnergy > layerInfo_[layerId].maxEnergyHitAtLayer_) {
+      layerInfo_[layerId].maxEnergyHitAtLayer_ = newEnergy;
+      layerInfo_[layerId].maxHitPosAtLayer_ = position;
+      return true;
+    } else
+      return false;
+  }
 
-        Hit3DPosition getCenterOfGravity(unsigned int layerId) const
-        {
-            return layerInfo_[layerId].centerOfGravityAtLayer_ ;
-        }
+  Hit3DPosition getMaxEnergyPosition(unsigned int layerId) const { return layerInfo_[layerId].maxHitPosAtLayer_; }
 
-        bool setMaxEnergyHit(unsigned int layerId, float newEnergy, const Hit3DPosition position)
-        {
-            if (newEnergy > layerInfo_[layerId].maxEnergyHitAtLayer_)
-            {
-                layerInfo_[layerId].maxEnergyHitAtLayer_ = newEnergy;
-                layerInfo_[layerId].maxHitPosAtLayer_ = position;
-                return true;
-            }
-            else
-                return false;
-        }
+  float getMaxEnergy(unsigned int layerId) const { return layerInfo_[layerId].maxEnergyHitAtLayer_; }
 
-        Hit3DPosition getMaxEnergyPosition (unsigned int layerId) const
-        {
-            return layerInfo_[layerId].maxHitPosAtLayer_;
-        }
+  void setLayersNum(unsigned int numberOfLayers) { layerInfo_.resize(numberOfLayers); }
 
-        float getMaxEnergy(unsigned int layerId) const
-        {
-            return layerInfo_[layerId].maxEnergyHitAtLayer_;
-        }
+  unsigned int getLayersNum() const { return layerInfo_.size(); }
 
-        void setLayersNum(unsigned int numberOfLayers)
-        {
-            layerInfo_.resize(numberOfLayers);
-        }
+  void addHitAndFraction(unsigned int hit, float fraction) { hitIdsAndFractions_.emplace_back(hit, fraction); }
 
-        unsigned int getLayersNum() const
-        {
-            return layerInfo_.size();
-        }
+  void modifyFractionForHitId(float fraction, unsigned int hitId) {
+    auto it = std::find_if(hitIdsAndFractions_.begin(),
+                           hitIdsAndFractions_.end(),
+                           [&hitId](const std::pair<unsigned int, float>& element) { return element.first == hitId; });
 
-        void addHitAndFraction(unsigned int hit, float fraction)
-        {
-            hitIdsAndFractions_.emplace_back(hit,fraction);
-        }
+    it->second = fraction;
+  }
 
-        void modifyFractionForHitId(float fraction, unsigned int hitId)
-        {
-            auto it = std::find_if( hitIdsAndFractions_.begin(), hitIdsAndFractions_.end(),
-                [&hitId](const std::pair<unsigned int, float>& element){ return element.first == hitId;} );
+  void modifyFractionByIndex(float fraction, unsigned int index) { hitIdsAndFractions_[index].second = fraction; }
 
-            it->second = fraction;
-        }
+  const std::vector<std::pair<unsigned int, float> >& hitsIdsAndFractions() const { return hitIdsAndFractions_; }
 
-        void modifyFractionByIndex(float fraction, unsigned int index)
-        {
-            hitIdsAndFractions_[index].second = fraction;
-        }
+private:
+  std::vector<std::pair<unsigned int, float> > hitIdsAndFractions_;
+  std::vector<LayerInfo> layerInfo_;
 
-        const std::vector< std::pair<unsigned int, float> > & hitsIdsAndFractions() const { return hitIdsAndFractions_; }
-
-    private:
-        std::vector<std::pair<unsigned int, float> > hitIdsAndFractions_;
-        std::vector<LayerInfo> layerInfo_;
-
-        float totalEnergy;
-        float exclusiveEnergy;
-        bool visible;
+  float totalEnergy;
+  float exclusiveEnergy;
+  bool visible;
 };
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticHitToClusterAssociator.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticHitToClusterAssociator.h
@@ -10,330 +10,281 @@
 #include <unordered_map>
 #include "RealisticCluster.h"
 
-namespace
-{
+namespace {
 
-float getDecayLength(unsigned int layer, unsigned int fhOffset, unsigned int bhOffset)
-{
+  float getDecayLength(unsigned int layer, unsigned int fhOffset, unsigned int bhOffset) {
     constexpr float eeDecayLengthInLayer = 2.f;
     constexpr float fhDecayLengthInLayer = 1.5f;
     constexpr float bhDecayLengthInLayer = 1.f;
 
     if (layer <= fhOffset)
-        return eeDecayLengthInLayer;
+      return eeDecayLengthInLayer;
     else if (layer > fhOffset && layer <= bhOffset)
-        return fhDecayLengthInLayer;
+      return fhDecayLengthInLayer;
     else
-        return bhDecayLengthInLayer;
-}
-}
+      return bhDecayLengthInLayer;
+  }
+}  // namespace
 
+class RealisticHitToClusterAssociator {
+  using Hit3DPosition = std::array<float, 3>;
 
-class RealisticHitToClusterAssociator
-{
-        using Hit3DPosition = std::array<float,3>;
-
-    public:
-
-        struct RealisticHit
-        {
-                struct HitToCluster
-                {
-                        unsigned int simClusterId_;
-                        float mcEnergyFraction_;
-                        float distanceFromMaxHit_;
-                        float realisticEnergyFraction_;
-                };
-
-                Hit3DPosition hitPosition_;
-                float totalEnergy_;
-                unsigned int layerId_;
-                std::vector<HitToCluster> hitToCluster_;
-        };
-
-        void init(std::size_t numberOfHits, std::size_t numberOfSimClusters,
-                std::size_t numberOfLayers)
-        {
-            realisticHits_.resize(numberOfHits);
-            realisticSimClusters_.resize(numberOfSimClusters);
-            for(auto& sc: realisticSimClusters_)
-                sc.setLayersNum(numberOfLayers);
-        }
-
-        void insertHitPosition(float x, float y, float z, unsigned int hitIndex)
-        {
-            realisticHits_[hitIndex].hitPosition_ = {{x,y,z}};
-        }
-
-        void insertLayerId(unsigned int layerId, unsigned int hitIndex)
-        {
-            realisticHits_[hitIndex].layerId_ = layerId;
-        }
-
-        void insertHitEnergy(float energy, unsigned int hitIndex)
-        {
-            realisticHits_[hitIndex].totalEnergy_ = energy;
-        }
-
-        void insertSimClusterIdAndFraction(unsigned int scIdx, float fraction,
-                unsigned int hitIndex, float associatedEnergy)
-        {
-            realisticHits_[hitIndex].hitToCluster_.emplace_back(RealisticHit::HitToCluster{scIdx, fraction, 0.f, 0.f});
-            realisticSimClusters_[scIdx].setMaxEnergyHit(realisticHits_[hitIndex].layerId_, associatedEnergy, realisticHits_[hitIndex].hitPosition_);
-        }
-
-        float XYdistanceFromMaxHit(unsigned int hitId, unsigned int clusterId)
-        {
-            auto l = realisticHits_[hitId].layerId_;
-            const auto& maxHitPosition = realisticSimClusters_[clusterId].getMaxEnergyPosition(l);
-            float distanceSquared = std::pow((realisticHits_[hitId].hitPosition_[0] - maxHitPosition[0]),2) + std::pow((realisticHits_[hitId].hitPosition_[1] - maxHitPosition[1]),2);
-            return std::sqrt(distanceSquared);
-        }
-
-        float XYdistanceFromPointOnSameLayer(unsigned int hitId, const Hit3DPosition& point)
-        {
-            float distanceSquared = std::pow((realisticHits_[hitId].hitPosition_[0] - point[0]),2) + std::pow((realisticHits_[hitId].hitPosition_[1] - point[1]),2);
-            return std::sqrt(distanceSquared);
-        }
-
-        void computeAssociation( float exclusiveFraction, bool useMCFractionsForExclEnergy, unsigned int fhOffset, unsigned int bhOffset)
-        {
-            //if more than exclusiveFraction of a hit's energy belongs to a cluster, that rechit is not counted as shared
-            unsigned int numberOfHits = realisticHits_.size();
-            std::vector<float> partialEnergies;
-            for(unsigned int hitId = 0; hitId < numberOfHits; ++hitId)
-            {
-                partialEnergies.clear();
-                std::vector<unsigned int> removeAssociation;
-                auto& realisticHit = realisticHits_[hitId];
-                unsigned int numberOfClusters = realisticHit.hitToCluster_.size();
-                if(numberOfClusters == 1)
-                {
-                    unsigned int simClusterId = realisticHit.hitToCluster_[0].simClusterId_;
-                    float assignedFraction = 1.f;
-                    realisticHit.hitToCluster_[0].realisticEnergyFraction_ = assignedFraction;
-                    float assignedEnergy = realisticHit.totalEnergy_;
-                    realisticSimClusters_[simClusterId].increaseEnergy(assignedEnergy);
-                    realisticSimClusters_[simClusterId].addHitAndFraction(hitId, assignedFraction);
-                    realisticSimClusters_[simClusterId].increaseExclusiveEnergy(assignedEnergy);
-                }
-                else
-                {
-                    partialEnergies.resize(numberOfClusters,0.f);
-                    unsigned int layer = realisticHit.layerId_;
-                    float sumE = 0.f;
-                    float energyDecayLength = getDecayLength(layer, fhOffset, bhOffset);
-                    for(unsigned int clId = 0; clId < numberOfClusters; ++clId )
-                    {
-                        auto simClusterId = realisticHit.hitToCluster_[clId].simClusterId_;
-                        realisticHit.hitToCluster_[clId].distanceFromMaxHit_ = XYdistanceFromMaxHit(hitId,simClusterId);
-                        // partial energy is computed based on the distance from the maximum energy hit and its energy
-                        // partial energy is only needed to compute a fraction and it's not the energy assigned to the cluster
-                        auto maxEnergyOnLayer = realisticSimClusters_[simClusterId].getMaxEnergy(layer);
-                        if(maxEnergyOnLayer>0.f)
-                        {
-                            partialEnergies[clId] = maxEnergyOnLayer * std::exp(-realisticHit.hitToCluster_[clId].distanceFromMaxHit_/energyDecayLength);
-                        }
-                        sumE += partialEnergies[clId];
-                    }
-                    if(sumE > 0.f)
-                    {
-                        float invSumE = 1.f/sumE;
-                        for(unsigned int clId = 0; clId < numberOfClusters; ++clId )
-                        {
-                            unsigned int simClusterIndex = realisticHit.hitToCluster_[clId].simClusterId_;
-                            float assignedFraction = partialEnergies[clId]*invSumE;
-                            if(assignedFraction > 1e-3)
-                            {
-                                realisticHit.hitToCluster_[clId].realisticEnergyFraction_ = assignedFraction;
-                                float assignedEnergy = assignedFraction *realisticHit.totalEnergy_;
-                                realisticSimClusters_[simClusterIndex].increaseEnergy(assignedEnergy);
-                                realisticSimClusters_[simClusterIndex].addHitAndFraction(hitId, assignedFraction);
-                                // if the hits energy belongs for more than exclusiveFraction to a cluster, also the cluster's
-                                // exclusive energy is increased. The exclusive energy will be needed to evaluate if
-                                // a realistic cluster will be invisible, i.e. absorbed by other clusters
-                                if( (useMCFractionsForExclEnergy and realisticHit.hitToCluster_[clId].mcEnergyFraction_ > exclusiveFraction) or
-                                        (!useMCFractionsForExclEnergy and assignedFraction > exclusiveFraction) )
-                                {
-                                    realisticSimClusters_[simClusterIndex].increaseExclusiveEnergy(assignedEnergy);
-                                }
-                            }
-                            else
-                            {
-                                removeAssociation.push_back(simClusterIndex);
-                            }
-                        }
-                    }
-                }
-
-                while(!removeAssociation.empty())
-                {
-                    auto clusterToRemove = removeAssociation.back();
-                    removeAssociation.pop_back();
-
-                    realisticHit.hitToCluster_.erase(std::remove_if(realisticHit.hitToCluster_.begin(), realisticHit.hitToCluster_.end(), [clusterToRemove](const RealisticHit::HitToCluster& x)
-                    {
-                        return x.simClusterId_ == clusterToRemove;
-                    }), realisticHit.hitToCluster_.end());
-                }
-            }
-        }
-
-        void findAndMergeInvisibleClusters(float invisibleFraction, float exclusiveFraction)
-        {
-            unsigned int numberOfRealSimClusters = realisticSimClusters_.size();
-
-            for(unsigned int clId= 0; clId < numberOfRealSimClusters; ++clId)
-            {
-                if(realisticSimClusters_[clId].getExclusiveEnergyFraction() < invisibleFraction)
-                {
-                    realisticSimClusters_[clId].setVisible(false);
-                    auto& hAndF = realisticSimClusters_[clId].hitsIdsAndFractions();
-                    std::unordered_map < unsigned int, float> energyInNeighbors;
-                    float totalSharedEnergy=0.f;
-
-                    for(auto& elt : hAndF)
-                    {
-                        unsigned int hitId = elt.first;
-                        float fraction = elt.second;
-                        auto& realisticHit = realisticHits_[hitId];
-
-                        if(realisticHit.hitToCluster_.size() >1 && fraction < 1.f)
-                        {
-                            float correction = 1.f - fraction;
-                            unsigned int numberOfClusters = realisticHit.hitToCluster_.size();
-                            int clusterToRemove = -1;
-                            for(unsigned int i = 0; i< numberOfClusters; ++i)
-                            {
-                                auto simClusterIndex = realisticHit.hitToCluster_[i].simClusterId_;
-                                if(simClusterIndex == clId)
-                                {
-                                    clusterToRemove = i;
-                                }
-                                else
-                                if(realisticSimClusters_[simClusterIndex].isVisible())
-                                {
-                                    float oldFraction = realisticHit.hitToCluster_[i].realisticEnergyFraction_;
-                                    float newFraction = oldFraction/correction;
-                                    float oldEnergy = oldFraction*realisticHit.totalEnergy_;
-                                    float newEnergy= newFraction*realisticHit.totalEnergy_;
-                                    float sharedEnergy = newEnergy-oldEnergy;
-                                    energyInNeighbors[simClusterIndex] +=sharedEnergy;
-                                    totalSharedEnergy +=sharedEnergy;
-                                    realisticSimClusters_[simClusterIndex].increaseEnergy(sharedEnergy);
-                                    realisticSimClusters_[simClusterIndex].modifyFractionForHitId(newFraction, hitId);
-                                    realisticHit.hitToCluster_[i].realisticEnergyFraction_ = newFraction;
-                                    if(newFraction > exclusiveFraction)
-                                    {
-                                        realisticSimClusters_[simClusterIndex].increaseExclusiveEnergy(sharedEnergy);
-                                        if(oldFraction <=exclusiveFraction)
-                                        {
-                                            realisticSimClusters_[simClusterIndex].increaseExclusiveEnergy(oldEnergy);
-                                        }
-                                    }
-                                }
-                            }
-                            realisticSimClusters_[realisticHit.hitToCluster_[clusterToRemove].simClusterId_].modifyFractionForHitId(0.f, hitId);
-                            realisticHit.hitToCluster_.erase(realisticHit.hitToCluster_.begin()+clusterToRemove);
-                        }
-                    }
-
-                    for(auto& elt : hAndF)
-                    {
-                        unsigned int hitId = elt.first;
-                        auto& realisticHit = realisticHits_[hitId];
-                        if(realisticHit.hitToCluster_.size()==1 and realisticHit.hitToCluster_[0].simClusterId_ ==  clId and totalSharedEnergy > 0.f)
-                        {
-                            for (auto& pair: energyInNeighbors)
-                            {
-                                // hits that belonged completely to the absorbed cluster are redistributed
-                                // based on the fraction of energy shared in the shared hits
-                                float sharedFraction = pair.second/totalSharedEnergy;
-                                float assignedEnergy = realisticHit.totalEnergy_*sharedFraction;
-                                realisticSimClusters_[pair.first].increaseEnergy(assignedEnergy);
-                                realisticSimClusters_[pair.first].addHitAndFraction(hitId, sharedFraction);
-                                realisticHit.hitToCluster_.emplace_back(RealisticHit::HitToCluster{pair.first, 0.f, -1.f, sharedFraction});
-                                if(sharedFraction > exclusiveFraction)
-                                    realisticSimClusters_[pair.first].increaseExclusiveEnergy(assignedEnergy);
-                            }
-                        }
-                    }
-
-                }
-            }
-        }
-
-        void findCentersOfGravity()
-        {
-            for(auto& cluster : realisticSimClusters_)
-            {
-                if(cluster.isVisible())
-                {
-                    unsigned int layersNum = cluster.getLayersNum();
-                    std::vector<float> totalEnergyPerLayer(layersNum, 0.f);
-                    std::vector<float> xEnergyPerLayer(layersNum, 0.f);
-                    std::vector<float> yEnergyPerLayer(layersNum, 0.f);
-                    std::vector<float> zPositionPerLayer(layersNum, 0.f);
-                    const auto& hAndF = cluster.hitsIdsAndFractions();
-                    for(auto& elt : hAndF)
-                    {
-                        auto hitId = elt.first;
-                        auto fraction = elt.second;
-                        const auto & hit = realisticHits_[hitId];
-                        const auto & hitPos = hit.hitPosition_;
-                        auto layerId = hit.layerId_;
-                        auto hitEinCluster = hit.totalEnergy_*fraction;
-                        totalEnergyPerLayer[layerId]+= hitEinCluster;
-                        xEnergyPerLayer[layerId] += hitPos[0]*hitEinCluster;
-                        yEnergyPerLayer[layerId] += hitPos[1]*hitEinCluster;
-                        zPositionPerLayer[layerId] = hitPos[2];
-                    }
-                    Hit3DPosition centerOfGravity;
-                    for(unsigned int layerId=0; layerId<layersNum; layerId++)
-                    {
-                        auto energyOnLayer = totalEnergyPerLayer[layerId];
-                        if(energyOnLayer > 0.f)
-                        {
-                            centerOfGravity = {{xEnergyPerLayer[layerId]/energyOnLayer,yEnergyPerLayer[layerId]/energyOnLayer, zPositionPerLayer[layerId] }};
-                            cluster.setCenterOfGravity(layerId,centerOfGravity );
-                        }
-                    }
-                }
-            }
-        }
-
-        void filterHitsByDistance(float maxDistance)
-        {
-            for(auto& cluster : realisticSimClusters_)
-            {
-                if(cluster.isVisible())
-                {
-                    auto& hAndF = cluster.hitsIdsAndFractions();
-                    for(unsigned int i = 0; i<hAndF.size(); ++i)
-                    {
-                        auto hitId = hAndF[i].first;
-                        const auto & hit = realisticHits_[hitId];
-                        auto layerId = hit.layerId_;
-                        if(XYdistanceFromPointOnSameLayer(hitId, cluster.getCenterOfGravity(layerId)) > maxDistance)
-                        {
-                            cluster.increaseEnergy(-hit.totalEnergy_*hAndF[i].second);
-                            cluster.modifyFractionByIndex(0.f, i);
-                        }
-                    }
-                }
-            }
-        }
-
-        const std::vector< RealisticCluster > & realisticClusters() const
-        {   return realisticSimClusters_;}
-
-    private:
-        // the vector of the Realistic SimClusters
-        std::vector< RealisticCluster > realisticSimClusters_;
-        // the vector of the Realistic SimClusters
-        std::vector< RealisticHit > realisticHits_;
+public:
+  struct RealisticHit {
+    struct HitToCluster {
+      unsigned int simClusterId_;
+      float mcEnergyFraction_;
+      float distanceFromMaxHit_;
+      float realisticEnergyFraction_;
     };
 
+    Hit3DPosition hitPosition_;
+    float totalEnergy_;
+    unsigned int layerId_;
+    std::vector<HitToCluster> hitToCluster_;
+  };
 
+  void init(std::size_t numberOfHits, std::size_t numberOfSimClusters, std::size_t numberOfLayers) {
+    realisticHits_.resize(numberOfHits);
+    realisticSimClusters_.resize(numberOfSimClusters);
+    for (auto& sc : realisticSimClusters_)
+      sc.setLayersNum(numberOfLayers);
+  }
+
+  void insertHitPosition(float x, float y, float z, unsigned int hitIndex) {
+    realisticHits_[hitIndex].hitPosition_ = {{x, y, z}};
+  }
+
+  void insertLayerId(unsigned int layerId, unsigned int hitIndex) { realisticHits_[hitIndex].layerId_ = layerId; }
+
+  void insertHitEnergy(float energy, unsigned int hitIndex) { realisticHits_[hitIndex].totalEnergy_ = energy; }
+
+  void insertSimClusterIdAndFraction(unsigned int scIdx, float fraction, unsigned int hitIndex, float associatedEnergy) {
+    realisticHits_[hitIndex].hitToCluster_.emplace_back(RealisticHit::HitToCluster{scIdx, fraction, 0.f, 0.f});
+    realisticSimClusters_[scIdx].setMaxEnergyHit(
+        realisticHits_[hitIndex].layerId_, associatedEnergy, realisticHits_[hitIndex].hitPosition_);
+  }
+
+  float XYdistanceFromMaxHit(unsigned int hitId, unsigned int clusterId) {
+    auto l = realisticHits_[hitId].layerId_;
+    const auto& maxHitPosition = realisticSimClusters_[clusterId].getMaxEnergyPosition(l);
+    float distanceSquared = std::pow((realisticHits_[hitId].hitPosition_[0] - maxHitPosition[0]), 2) +
+                            std::pow((realisticHits_[hitId].hitPosition_[1] - maxHitPosition[1]), 2);
+    return std::sqrt(distanceSquared);
+  }
+
+  float XYdistanceFromPointOnSameLayer(unsigned int hitId, const Hit3DPosition& point) {
+    float distanceSquared = std::pow((realisticHits_[hitId].hitPosition_[0] - point[0]), 2) +
+                            std::pow((realisticHits_[hitId].hitPosition_[1] - point[1]), 2);
+    return std::sqrt(distanceSquared);
+  }
+
+  void computeAssociation(float exclusiveFraction,
+                          bool useMCFractionsForExclEnergy,
+                          unsigned int fhOffset,
+                          unsigned int bhOffset) {
+    //if more than exclusiveFraction of a hit's energy belongs to a cluster, that rechit is not counted as shared
+    unsigned int numberOfHits = realisticHits_.size();
+    std::vector<float> partialEnergies;
+    for (unsigned int hitId = 0; hitId < numberOfHits; ++hitId) {
+      partialEnergies.clear();
+      std::vector<unsigned int> removeAssociation;
+      auto& realisticHit = realisticHits_[hitId];
+      unsigned int numberOfClusters = realisticHit.hitToCluster_.size();
+      if (numberOfClusters == 1) {
+        unsigned int simClusterId = realisticHit.hitToCluster_[0].simClusterId_;
+        float assignedFraction = 1.f;
+        realisticHit.hitToCluster_[0].realisticEnergyFraction_ = assignedFraction;
+        float assignedEnergy = realisticHit.totalEnergy_;
+        realisticSimClusters_[simClusterId].increaseEnergy(assignedEnergy);
+        realisticSimClusters_[simClusterId].addHitAndFraction(hitId, assignedFraction);
+        realisticSimClusters_[simClusterId].increaseExclusiveEnergy(assignedEnergy);
+      } else {
+        partialEnergies.resize(numberOfClusters, 0.f);
+        unsigned int layer = realisticHit.layerId_;
+        float sumE = 0.f;
+        float energyDecayLength = getDecayLength(layer, fhOffset, bhOffset);
+        for (unsigned int clId = 0; clId < numberOfClusters; ++clId) {
+          auto simClusterId = realisticHit.hitToCluster_[clId].simClusterId_;
+          realisticHit.hitToCluster_[clId].distanceFromMaxHit_ = XYdistanceFromMaxHit(hitId, simClusterId);
+          // partial energy is computed based on the distance from the maximum energy hit and its energy
+          // partial energy is only needed to compute a fraction and it's not the energy assigned to the cluster
+          auto maxEnergyOnLayer = realisticSimClusters_[simClusterId].getMaxEnergy(layer);
+          if (maxEnergyOnLayer > 0.f) {
+            partialEnergies[clId] =
+                maxEnergyOnLayer * std::exp(-realisticHit.hitToCluster_[clId].distanceFromMaxHit_ / energyDecayLength);
+          }
+          sumE += partialEnergies[clId];
+        }
+        if (sumE > 0.f) {
+          float invSumE = 1.f / sumE;
+          for (unsigned int clId = 0; clId < numberOfClusters; ++clId) {
+            unsigned int simClusterIndex = realisticHit.hitToCluster_[clId].simClusterId_;
+            float assignedFraction = partialEnergies[clId] * invSumE;
+            if (assignedFraction > 1e-3) {
+              realisticHit.hitToCluster_[clId].realisticEnergyFraction_ = assignedFraction;
+              float assignedEnergy = assignedFraction * realisticHit.totalEnergy_;
+              realisticSimClusters_[simClusterIndex].increaseEnergy(assignedEnergy);
+              realisticSimClusters_[simClusterIndex].addHitAndFraction(hitId, assignedFraction);
+              // if the hits energy belongs for more than exclusiveFraction to a cluster, also the cluster's
+              // exclusive energy is increased. The exclusive energy will be needed to evaluate if
+              // a realistic cluster will be invisible, i.e. absorbed by other clusters
+              if ((useMCFractionsForExclEnergy and
+                   realisticHit.hitToCluster_[clId].mcEnergyFraction_ > exclusiveFraction) or
+                  (!useMCFractionsForExclEnergy and assignedFraction > exclusiveFraction)) {
+                realisticSimClusters_[simClusterIndex].increaseExclusiveEnergy(assignedEnergy);
+              }
+            } else {
+              removeAssociation.push_back(simClusterIndex);
+            }
+          }
+        }
+      }
+
+      while (!removeAssociation.empty()) {
+        auto clusterToRemove = removeAssociation.back();
+        removeAssociation.pop_back();
+
+        realisticHit.hitToCluster_.erase(std::remove_if(realisticHit.hitToCluster_.begin(),
+                                                        realisticHit.hitToCluster_.end(),
+                                                        [clusterToRemove](const RealisticHit::HitToCluster& x) {
+                                                          return x.simClusterId_ == clusterToRemove;
+                                                        }),
+                                         realisticHit.hitToCluster_.end());
+      }
+    }
+  }
+
+  void findAndMergeInvisibleClusters(float invisibleFraction, float exclusiveFraction) {
+    unsigned int numberOfRealSimClusters = realisticSimClusters_.size();
+
+    for (unsigned int clId = 0; clId < numberOfRealSimClusters; ++clId) {
+      if (realisticSimClusters_[clId].getExclusiveEnergyFraction() < invisibleFraction) {
+        realisticSimClusters_[clId].setVisible(false);
+        auto& hAndF = realisticSimClusters_[clId].hitsIdsAndFractions();
+        std::unordered_map<unsigned int, float> energyInNeighbors;
+        float totalSharedEnergy = 0.f;
+
+        for (auto& elt : hAndF) {
+          unsigned int hitId = elt.first;
+          float fraction = elt.second;
+          auto& realisticHit = realisticHits_[hitId];
+
+          if (realisticHit.hitToCluster_.size() > 1 && fraction < 1.f) {
+            float correction = 1.f - fraction;
+            unsigned int numberOfClusters = realisticHit.hitToCluster_.size();
+            int clusterToRemove = -1;
+            for (unsigned int i = 0; i < numberOfClusters; ++i) {
+              auto simClusterIndex = realisticHit.hitToCluster_[i].simClusterId_;
+              if (simClusterIndex == clId) {
+                clusterToRemove = i;
+              } else if (realisticSimClusters_[simClusterIndex].isVisible()) {
+                float oldFraction = realisticHit.hitToCluster_[i].realisticEnergyFraction_;
+                float newFraction = oldFraction / correction;
+                float oldEnergy = oldFraction * realisticHit.totalEnergy_;
+                float newEnergy = newFraction * realisticHit.totalEnergy_;
+                float sharedEnergy = newEnergy - oldEnergy;
+                energyInNeighbors[simClusterIndex] += sharedEnergy;
+                totalSharedEnergy += sharedEnergy;
+                realisticSimClusters_[simClusterIndex].increaseEnergy(sharedEnergy);
+                realisticSimClusters_[simClusterIndex].modifyFractionForHitId(newFraction, hitId);
+                realisticHit.hitToCluster_[i].realisticEnergyFraction_ = newFraction;
+                if (newFraction > exclusiveFraction) {
+                  realisticSimClusters_[simClusterIndex].increaseExclusiveEnergy(sharedEnergy);
+                  if (oldFraction <= exclusiveFraction) {
+                    realisticSimClusters_[simClusterIndex].increaseExclusiveEnergy(oldEnergy);
+                  }
+                }
+              }
+            }
+            realisticSimClusters_[realisticHit.hitToCluster_[clusterToRemove].simClusterId_].modifyFractionForHitId(
+                0.f, hitId);
+            realisticHit.hitToCluster_.erase(realisticHit.hitToCluster_.begin() + clusterToRemove);
+          }
+        }
+
+        for (auto& elt : hAndF) {
+          unsigned int hitId = elt.first;
+          auto& realisticHit = realisticHits_[hitId];
+          if (realisticHit.hitToCluster_.size() == 1 and realisticHit.hitToCluster_[0].simClusterId_ == clId and
+              totalSharedEnergy > 0.f) {
+            for (auto& pair : energyInNeighbors) {
+              // hits that belonged completely to the absorbed cluster are redistributed
+              // based on the fraction of energy shared in the shared hits
+              float sharedFraction = pair.second / totalSharedEnergy;
+              float assignedEnergy = realisticHit.totalEnergy_ * sharedFraction;
+              realisticSimClusters_[pair.first].increaseEnergy(assignedEnergy);
+              realisticSimClusters_[pair.first].addHitAndFraction(hitId, sharedFraction);
+              realisticHit.hitToCluster_.emplace_back(
+                  RealisticHit::HitToCluster{pair.first, 0.f, -1.f, sharedFraction});
+              if (sharedFraction > exclusiveFraction)
+                realisticSimClusters_[pair.first].increaseExclusiveEnergy(assignedEnergy);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  void findCentersOfGravity() {
+    for (auto& cluster : realisticSimClusters_) {
+      if (cluster.isVisible()) {
+        unsigned int layersNum = cluster.getLayersNum();
+        std::vector<float> totalEnergyPerLayer(layersNum, 0.f);
+        std::vector<float> xEnergyPerLayer(layersNum, 0.f);
+        std::vector<float> yEnergyPerLayer(layersNum, 0.f);
+        std::vector<float> zPositionPerLayer(layersNum, 0.f);
+        const auto& hAndF = cluster.hitsIdsAndFractions();
+        for (auto& elt : hAndF) {
+          auto hitId = elt.first;
+          auto fraction = elt.second;
+          const auto& hit = realisticHits_[hitId];
+          const auto& hitPos = hit.hitPosition_;
+          auto layerId = hit.layerId_;
+          auto hitEinCluster = hit.totalEnergy_ * fraction;
+          totalEnergyPerLayer[layerId] += hitEinCluster;
+          xEnergyPerLayer[layerId] += hitPos[0] * hitEinCluster;
+          yEnergyPerLayer[layerId] += hitPos[1] * hitEinCluster;
+          zPositionPerLayer[layerId] = hitPos[2];
+        }
+        Hit3DPosition centerOfGravity;
+        for (unsigned int layerId = 0; layerId < layersNum; layerId++) {
+          auto energyOnLayer = totalEnergyPerLayer[layerId];
+          if (energyOnLayer > 0.f) {
+            centerOfGravity = {{xEnergyPerLayer[layerId] / energyOnLayer,
+                                yEnergyPerLayer[layerId] / energyOnLayer,
+                                zPositionPerLayer[layerId]}};
+            cluster.setCenterOfGravity(layerId, centerOfGravity);
+          }
+        }
+      }
+    }
+  }
+
+  void filterHitsByDistance(float maxDistance) {
+    for (auto& cluster : realisticSimClusters_) {
+      if (cluster.isVisible()) {
+        auto& hAndF = cluster.hitsIdsAndFractions();
+        for (unsigned int i = 0; i < hAndF.size(); ++i) {
+          auto hitId = hAndF[i].first;
+          const auto& hit = realisticHits_[hitId];
+          auto layerId = hit.layerId_;
+          if (XYdistanceFromPointOnSameLayer(hitId, cluster.getCenterOfGravity(layerId)) > maxDistance) {
+            cluster.increaseEnergy(-hit.totalEnergy_ * hAndF[i].second);
+            cluster.modifyFractionByIndex(0.f, i);
+          }
+        }
+      }
+    }
+  }
+
+  const std::vector<RealisticCluster>& realisticClusters() const { return realisticSimClusters_; }
+
+private:
+  // the vector of the Realistic SimClusters
+  std::vector<RealisticCluster> realisticSimClusters_;
+  // the vector of the Realistic SimClusters
+  std::vector<RealisticHit> realisticHits_;
+};
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.cc
@@ -28,161 +28,131 @@
 
 namespace {
 
-inline
-bool isPi0(int pdgId)
-{
-    return pdgId == 111;
-}
+  inline bool isPi0(int pdgId) { return pdgId == 111; }
 
-inline
-bool isEGamma(int pdgId)
-{
+  inline bool isEGamma(int pdgId) {
     pdgId = std::abs(pdgId);
     return (pdgId == 11) or (pdgId == 22);
-}
+  }
 
-inline
-bool isHadron(int pdgId)
-{
+  inline bool isHadron(int pdgId) {
     pdgId = std::abs(pdgId) % 10000;
-    return ((pdgId > 100 and pdgId < 900) or
-           (pdgId > 1000 and pdgId < 9000));
-}
-}
+    return ((pdgId > 100 and pdgId < 900) or (pdgId > 1000 and pdgId < 9000));
+  }
+}  // namespace
 
-void RealisticSimClusterMapper::updateEvent(const edm::Event& ev)
-{
-    ev.getByToken(simClusterToken_, simClusterH_);
-}
+void RealisticSimClusterMapper::updateEvent(const edm::Event& ev) { ev.getByToken(simClusterToken_, simClusterH_); }
 
-void RealisticSimClusterMapper::update(const edm::EventSetup& es)
-{
-    rhtools_.getEventSetup(es);
-}
+void RealisticSimClusterMapper::update(const edm::EventSetup& es) { rhtools_.getEventSetup(es); }
 
 void RealisticSimClusterMapper::buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
-        const std::vector<bool>& rechitMask, const std::vector<bool>& seedable,
-        reco::PFClusterCollection& output)
-{
-    const SimClusterCollection& simClusters = *simClusterH_;
-    auto const& hits = *input;
-    RealisticHitToClusterAssociator realisticAssociator;
-    const int numberOfLayers = rhtools_.getGeometryType()==0 ? rhtools_.getLayer(ForwardSubdetector::ForwardEmpty) : rhtools_.getLayer(DetId::Forward);
-    realisticAssociator.init(hits.size(), simClusters.size(), numberOfLayers + 1);
-    // for quick indexing back to hit energy
-    std::unordered_map < uint32_t, size_t > detIdToIndex(hits.size());
-    for (uint32_t i = 0; i < hits.size(); ++i)
-    {
-        detIdToIndex[hits[i].detId()] = i;
-        auto ref = makeRefhit(input, i);
-        const auto& hitPos = rhtools_.getPosition(ref->detId());
+                                              const std::vector<bool>& rechitMask,
+                                              const std::vector<bool>& seedable,
+                                              reco::PFClusterCollection& output) {
+  const SimClusterCollection& simClusters = *simClusterH_;
+  auto const& hits = *input;
+  RealisticHitToClusterAssociator realisticAssociator;
+  const int numberOfLayers = rhtools_.getGeometryType() == 0 ? rhtools_.getLayer(ForwardSubdetector::ForwardEmpty)
+                                                             : rhtools_.getLayer(DetId::Forward);
+  realisticAssociator.init(hits.size(), simClusters.size(), numberOfLayers + 1);
+  // for quick indexing back to hit energy
+  std::unordered_map<uint32_t, size_t> detIdToIndex(hits.size());
+  for (uint32_t i = 0; i < hits.size(); ++i) {
+    detIdToIndex[hits[i].detId()] = i;
+    auto ref = makeRefhit(input, i);
+    const auto& hitPos = rhtools_.getPosition(ref->detId());
 
-        realisticAssociator.insertHitPosition(hitPos.x(), hitPos.y(), hitPos.z(), i);
-        realisticAssociator.insertHitEnergy(ref->energy(), i);
-        realisticAssociator.insertLayerId(rhtools_.getLayerWithOffset(ref->detId()), i);
+    realisticAssociator.insertHitPosition(hitPos.x(), hitPos.y(), hitPos.z(), i);
+    realisticAssociator.insertHitEnergy(ref->energy(), i);
+    realisticAssociator.insertLayerId(rhtools_.getLayerWithOffset(ref->detId()), i);
+  }
 
+  for (unsigned int ic = 0; ic < simClusters.size(); ++ic) {
+    const auto& sc = simClusters[ic];
+    const auto& hitsAndFractions = sc.hits_and_fractions();
+    for (const auto& hAndF : hitsAndFractions) {
+      auto itr = detIdToIndex.find(hAndF.first);
+      if (itr == detIdToIndex.end()) {
+        continue;  // hit wasn't saved in reco or did not pass the SNR threshold
+      }
+      auto hitId = itr->second;
+      auto ref = makeRefhit(input, hitId);
+      float fraction = hAndF.second;
+      float associatedEnergy = fraction * ref->energy();
+      realisticAssociator.insertSimClusterIdAndFraction(ic, fraction, hitId, associatedEnergy);
     }
+  }
+  realisticAssociator.computeAssociation(
+      exclusiveFraction_, useMCFractionsForExclEnergy_, rhtools_.lastLayerEE(), rhtools_.lastLayerFH());
+  realisticAssociator.findAndMergeInvisibleClusters(invisibleFraction_, exclusiveFraction_);
+  realisticAssociator.findCentersOfGravity();
+  if (maxDistanceFilter_)
+    realisticAssociator.filterHitsByDistance(maxDistance_);
 
-    for (unsigned int ic = 0; ic < simClusters.size(); ++ic)
-    {
-        const auto & sc = simClusters[ic];
-        const auto& hitsAndFractions = sc.hits_and_fractions();
-        for (const auto& hAndF : hitsAndFractions)
+  const auto& realisticClusters = realisticAssociator.realisticClusters();
+  unsigned int nClusters = realisticClusters.size();
+  float bin_norm = 1. / (calibMaxEta_ - calibMinEta_);
+  float egamma_bin_norm = egammaCalib_.size() * bin_norm;
+  float hadron_bin_norm = hadronCalib_.size() * bin_norm;
+  for (unsigned ic = 0; ic < nClusters; ++ic) {
+    float highest_energy = 0.0f;
+    output.emplace_back();
+    reco::PFCluster& back = output.back();
+    edm::Ref<std::vector<reco::PFRecHit> > seed;
+    float energyCorrection = 1.f;
+    float timeRealisticSC = -99.;
+    if (realisticClusters[ic].isVisible()) {
+      int pdgId = simClusters[ic].pdgId();
+      auto abseta = std::abs(simClusters[ic].eta());
+      if ((abseta >= calibMinEta_) and (abseta <= calibMaxEta_))  //protecting range
+      {
+        if ((isEGamma(pdgId) or isPi0(pdgId)) and !egammaCalib_.empty()) {
+          unsigned int etabin = std::floor(((abseta - calibMinEta_) * egamma_bin_norm));
+          energyCorrection = egammaCalib_[etabin];
+        } else if (isHadron(pdgId) and !(isPi0(pdgId)) and
+                   !hadronCalib_
+                        .empty())  // this function is expensive.. should we treat as hadron everything which is not egamma?
         {
-            auto itr = detIdToIndex.find(hAndF.first);
-            if (itr == detIdToIndex.end())
-            {
-                continue; // hit wasn't saved in reco or did not pass the SNR threshold
-            }
-            auto hitId = itr->second;
-            auto ref = makeRefhit(input, hitId);
-            float fraction = hAndF.second;
-            float associatedEnergy = fraction * ref->energy();
-            realisticAssociator.insertSimClusterIdAndFraction(ic, fraction, hitId,
-                    associatedEnergy);
+          unsigned int etabin = std::floor(((abseta - calibMinEta_) * hadron_bin_norm));
+          energyCorrection = hadronCalib_[etabin];
         }
+      }
+      std::vector<float> timeHits;
+      const auto& hitsIdsAndFractions = realisticClusters[ic].hitsIdsAndFractions();
+      for (const auto& idAndF : hitsIdsAndFractions) {
+        auto fraction = idAndF.second;
+        if (fraction > 0.f) {
+          auto ref = makeRefhit(input, idAndF.first);
+          back.addRecHitFraction(reco::PFRecHitFraction(ref, fraction));
+          const float hit_energy = fraction * ref->energy();
+          if (hit_energy > highest_energy || highest_energy == 0.0) {
+            highest_energy = hit_energy;
+            seed = ref;
+          }
+          //select hits good for timing
+          if (ref->time() > -1.) {
+            int rhLayer = rhtools_.getLayerWithOffset(ref->detId());
+            std::array<float, 3> scPosition = realisticClusters[ic].getCenterOfGravity(rhLayer);
+            float distanceSquared =
+                std::pow((ref->position().x() - scPosition[0]), 2) + std::pow((ref->position().y() - scPosition[1]), 2);
+            if (distanceSquared < maxDforTimingSquared_) {
+              timeHits.push_back(ref->time() - timeOffset_);
+            }
+          }
+        }
+      }
+      //assign time if minimum number of hits
+      if (timeHits.size() >= minNHitsforTiming_)
+        timeRealisticSC = hgcalsimclustertime::fixSizeHighestDensity(timeHits);
     }
-    realisticAssociator.computeAssociation(exclusiveFraction_, useMCFractionsForExclEnergy_,
-            rhtools_.lastLayerEE(), rhtools_.lastLayerFH());
-    realisticAssociator.findAndMergeInvisibleClusters(invisibleFraction_, exclusiveFraction_);
-    realisticAssociator.findCentersOfGravity();
-    if(maxDistanceFilter_)
-        realisticAssociator.filterHitsByDistance(maxDistance_);
-
-    const auto& realisticClusters = realisticAssociator.realisticClusters();
-    unsigned int nClusters = realisticClusters.size();
-    float bin_norm = 1. / (calibMaxEta_ - calibMinEta_);
-    float egamma_bin_norm = egammaCalib_.size() * bin_norm;
-    float hadron_bin_norm = hadronCalib_.size() * bin_norm;
-    for (unsigned ic = 0; ic < nClusters; ++ic)
-    {
-        float highest_energy = 0.0f;
-        output.emplace_back();
-        reco::PFCluster& back = output.back();
-        edm::Ref < std::vector<reco::PFRecHit> > seed;
-        float energyCorrection = 1.f;
-        float timeRealisticSC = -99.;
-        if (realisticClusters[ic].isVisible())
-        {
-            int pdgId = simClusters[ic].pdgId();
-            auto abseta = std::abs(simClusters[ic].eta());
-            if ((abseta >= calibMinEta_) and (abseta <= calibMaxEta_)) //protecting range
-            {
-                if ((isEGamma(pdgId) or isPi0(pdgId)) and !egammaCalib_.empty())
-                {
-                    unsigned int etabin = std::floor(
-                            ((abseta - calibMinEta_) * egamma_bin_norm));
-                    energyCorrection = egammaCalib_[etabin];
-                }
-                else if (isHadron(pdgId) and !(isPi0(pdgId)) and !hadronCalib_.empty()) // this function is expensive.. should we treat as hadron everything which is not egamma?
-                {
-                    unsigned int etabin = std::floor(
-                            ((abseta - calibMinEta_) * hadron_bin_norm));
-                    energyCorrection = hadronCalib_[etabin];
-                }
-
-            }
-	    std::vector<float> timeHits;
-            const auto& hitsIdsAndFractions = realisticClusters[ic].hitsIdsAndFractions();
-            for (const auto& idAndF : hitsIdsAndFractions)
-            {
-                auto fraction = idAndF.second;
-                if (fraction > 0.f)
-                {
-                    auto ref = makeRefhit(input, idAndF.first);
-                    back.addRecHitFraction(reco::PFRecHitFraction(ref, fraction));
-                    const float hit_energy = fraction * ref->energy();
-                    if (hit_energy > highest_energy || highest_energy == 0.0)
-                    {
-                        highest_energy = hit_energy;
-                        seed = ref;
-                    }
-                    //select hits good for timing
-                    if(ref->time() > -1. ){
-		      int rhLayer = rhtools_.getLayerWithOffset(ref->detId());
-		      std::array<float,3> scPosition = realisticClusters[ic].getCenterOfGravity(rhLayer);
-		      float distanceSquared = std::pow((ref->position().x() - scPosition[0]),2) + std::pow((ref->position().y() - scPosition[1]),2);
-		      if(distanceSquared < maxDforTimingSquared_){
-			timeHits.push_back(ref->time() - timeOffset_);
-		      }
-		    }
-                }
-            }
-	    //assign time if minimum number of hits
-	    if(timeHits.size() >= minNHitsforTiming_) timeRealisticSC = hgcalsimclustertime::fixSizeHighestDensity(timeHits);
-	}
-        if (!back.hitsAndFractions().empty())
-        {
-            back.setSeed(seed->detId());
-            back.setEnergy(realisticClusters[ic].getEnergy());
-            back.setCorrectedEnergy(energyCorrection*realisticClusters[ic].getEnergy()); //applying energy correction
-	    back.setTime(timeRealisticSC);
-        }
-        else
-        {
-            back.setSeed(-1);
-            back.setEnergy(0.f);
-        }
+    if (!back.hitsAndFractions().empty()) {
+      back.setSeed(seed->detId());
+      back.setEnergy(realisticClusters[ic].getEnergy());
+      back.setCorrectedEnergy(energyCorrection * realisticClusters[ic].getEnergy());  //applying energy correction
+      back.setTime(timeRealisticSC);
+    } else {
+      back.setSeed(-1);
+      back.setEnergy(0.f);
     }
+  }
 }
-

--- a/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SimMappers/RealisticSimClusterMapper.h
@@ -12,25 +12,23 @@
 #include "SimDataFormats/CaloAnalysis/interface/SimClusterFwd.h"
 
 class RealisticSimClusterMapper : public InitialClusteringStepBase {
- public:
- RealisticSimClusterMapper(const edm::ParameterSet& conf,
-			 edm::ConsumesCollector& sumes) :
-    InitialClusteringStepBase(conf,sumes),
-    invisibleFraction_(conf.getParameter<double>("invisibleFraction")),
-    exclusiveFraction_(conf.getParameter<double>("exclusiveFraction")),
-    maxDistanceFilter_(conf.getParameter<bool>("maxDistanceFilter")),
-    maxDistance_(conf.getParameter<double>("maxDistance")),
-    maxDforTimingSquared_(conf.getParameter<double>("maxDforTimingSquared")),
-    timeOffset_(conf.getParameter<double>("timeOffset")),
-    minNHitsforTiming_(conf.getParameter<unsigned int>("minNHitsforTiming")),
-    useMCFractionsForExclEnergy_(conf.getParameter<bool>("useMCFractionsForExclEnergy")),
-    calibMinEta_(conf.getParameter<double>("calibMinEta")),
-    calibMaxEta_(conf.getParameter<double>("calibMaxEta"))
-    {
-      simClusterToken_ = sumes.consumes<SimClusterCollection>(conf.getParameter<edm::InputTag>("simClusterSrc"));
-      hadronCalib_ = conf.getParameter < std::vector<double> > ("hadronCalib");
-      egammaCalib_ = conf.getParameter < std::vector<double> > ("egammaCalib");
-    }
+public:
+  RealisticSimClusterMapper(const edm::ParameterSet& conf, edm::ConsumesCollector& sumes)
+      : InitialClusteringStepBase(conf, sumes),
+        invisibleFraction_(conf.getParameter<double>("invisibleFraction")),
+        exclusiveFraction_(conf.getParameter<double>("exclusiveFraction")),
+        maxDistanceFilter_(conf.getParameter<bool>("maxDistanceFilter")),
+        maxDistance_(conf.getParameter<double>("maxDistance")),
+        maxDforTimingSquared_(conf.getParameter<double>("maxDforTimingSquared")),
+        timeOffset_(conf.getParameter<double>("timeOffset")),
+        minNHitsforTiming_(conf.getParameter<unsigned int>("minNHitsforTiming")),
+        useMCFractionsForExclEnergy_(conf.getParameter<bool>("useMCFractionsForExclEnergy")),
+        calibMinEta_(conf.getParameter<double>("calibMinEta")),
+        calibMaxEta_(conf.getParameter<double>("calibMaxEta")) {
+    simClusterToken_ = sumes.consumes<SimClusterCollection>(conf.getParameter<edm::InputTag>("simClusterSrc"));
+    hadronCalib_ = conf.getParameter<std::vector<double> >("hadronCalib");
+    egammaCalib_ = conf.getParameter<std::vector<double> >("egammaCalib");
+  }
 
   ~RealisticSimClusterMapper() override {}
   RealisticSimClusterMapper(const RealisticSimClusterMapper&) = delete;
@@ -40,11 +38,11 @@ class RealisticSimClusterMapper : public InitialClusteringStepBase {
   void update(const edm::EventSetup&) final;
 
   void buildClusters(const edm::Handle<reco::PFRecHitCollection>&,
-		     const std::vector<bool>&,
-		     const std::vector<bool>&, 
-		     reco::PFClusterCollection&) override;
-  
- private:  
+                     const std::vector<bool>&,
+                     const std::vector<bool>&,
+                     reco::PFClusterCollection&) override;
+
+private:
   hgcal::RecHitTools rhtools_;
   const float invisibleFraction_ = 0.3f;
   const float exclusiveFraction_ = 0.7f;
@@ -61,11 +59,8 @@ class RealisticSimClusterMapper : public InitialClusteringStepBase {
 
   edm::EDGetTokenT<SimClusterCollection> simClusterToken_;
   edm::Handle<SimClusterCollection> simClusterH_;
-  
 };
 
-DEFINE_EDM_PLUGIN(InitialClusteringStepFactory,
-		  RealisticSimClusterMapper,
-		  "RealisticSimClusterMapper");
+DEFINE_EDM_PLUGIN(InitialClusteringStepFactory, RealisticSimClusterMapper, "RealisticSimClusterMapper");
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/plugins/SpikeAndDoubleSpikeCleaner.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SpikeAndDoubleSpikeCleaner.cc
@@ -2,240 +2,243 @@
 #include <cmath>
 
 namespace {
-  std::pair<double,double> dCrack(double phi, double eta) {
-    constexpr double oneOverCrystalSize=1.0/0.0175;
-    constexpr double pi=M_PI;
-    constexpr double twopi=2*pi;
-    // the result below is from unrolling 
+  std::pair<double, double> dCrack(double phi, double eta) {
+    constexpr double oneOverCrystalSize = 1.0 / 0.0175;
+    constexpr double pi = M_PI;
+    constexpr double twopi = 2 * pi;
+    // the result below is from unrolling
     // the lazy-eval loop in PFClusterAlgo::dCrack
-    constexpr double cPhi[18] = {2.97025, 2.621184149601134, 2.272118299202268,
-				 1.9230524488034024, 1.5739865984045365, 
-				 1.2249207480056705, 0.8758548976068048, 
-				 0.5267890472079388, 0.1777231968090729, 
-				 -0.17134265358979306, -0.520408503988659, 
-				 -0.8694743543875245, -1.2185402047863905, 
-				 -1.5676060551852569, -1.9166719055841224, 
-				 -2.265737755982988, -2.6148036063818543, 
-				 -2.9638694567807207};
-    constexpr double cEta[9] = {0.0,
-				4.44747e-01, -4.44747e-01,
-				7.92824e-01, -7.92824e-01,
-				1.14090e+00, -1.14090e+00,
-				1.47464e+00, -1.47464e+00};
+    constexpr double cPhi[18] = {2.97025,
+                                 2.621184149601134,
+                                 2.272118299202268,
+                                 1.9230524488034024,
+                                 1.5739865984045365,
+                                 1.2249207480056705,
+                                 0.8758548976068048,
+                                 0.5267890472079388,
+                                 0.1777231968090729,
+                                 -0.17134265358979306,
+                                 -0.520408503988659,
+                                 -0.8694743543875245,
+                                 -1.2185402047863905,
+                                 -1.5676060551852569,
+                                 -1.9166719055841224,
+                                 -2.265737755982988,
+                                 -2.6148036063818543,
+                                 -2.9638694567807207};
+    constexpr double cEta[9] = {
+        0.0, 4.44747e-01, -4.44747e-01, 7.92824e-01, -7.92824e-01, 1.14090e+00, -1.14090e+00, 1.47464e+00, -1.47464e+00};
     // shift for eta < 0
     constexpr double delta_cPhi = 0.00638;
     // let's calculate dphi
     double defi = 0;
-    if( eta < 0 ) phi+=delta_cPhi;
-    if( phi >= -pi && phi <= pi ) {
+    if (eta < 0)
+      phi += delta_cPhi;
+    if (phi >= -pi && phi <= pi) {
       //the problem of the extrema
-      if( phi < cPhi[17] || phi >= cPhi[0] ) {
-	if( phi < 0 ) phi += 2*pi;
-	defi = std::min(std::abs(phi-cPhi[0]),std::abs(phi-cPhi[17]-twopi));
-      } else { // between these extrema
-	bool OK = false;
-	unsigned i = 16;
-	while(!OK) {
-	  if( phi < cPhi[i] ) {
-	    defi = std::min(std::abs(phi-cPhi[i+1]),std::abs(phi-cPhi[i]));
-	    OK=true;
-	  } else {
-	    i -= 1;
-	  }
-	}// end while
+      if (phi < cPhi[17] || phi >= cPhi[0]) {
+        if (phi < 0)
+          phi += 2 * pi;
+        defi = std::min(std::abs(phi - cPhi[0]), std::abs(phi - cPhi[17] - twopi));
+      } else {  // between these extrema
+        bool OK = false;
+        unsigned i = 16;
+        while (!OK) {
+          if (phi < cPhi[i]) {
+            defi = std::min(std::abs(phi - cPhi[i + 1]), std::abs(phi - cPhi[i]));
+            OK = true;
+          } else {
+            i -= 1;
+          }
+        }  // end while
       }
-    } else { // if there's a problem assume we're in a crack
-      defi = 0;      
+    } else {  // if there's a problem assume we're in a crack
+      defi = 0;
     }
     // let's calculate deta
     double deta = 999.0;
-    for( const double etaGap : cEta ) {
-      deta = std::min(deta,std::abs(eta-etaGap));
+    for (const double etaGap : cEta) {
+      deta = std::min(deta, std::abs(eta - etaGap));
     }
     defi *= oneOverCrystalSize;
     deta *= oneOverCrystalSize;
-    return std::make_pair(defi,deta);
+    return std::make_pair(defi, deta);
   }
-}
+}  // namespace
 
-SpikeAndDoubleSpikeCleaner::
-SpikeAndDoubleSpikeCleaner(const edm::ParameterSet& conf) :
-    RecHitTopologicalCleanerBase(conf),
-    _layerMap({ {"PS2",(int)PFLayer::PS2},
-	      {"PS1",(int)PFLayer::PS1},
-	      {"ECAL_ENDCAP",(int)PFLayer::ECAL_ENDCAP},
-	      {"ECAL_BARREL",(int)PFLayer::ECAL_BARREL},
-	      {"NONE",(int)PFLayer::NONE},
-	      {"HCAL_BARREL1",(int)PFLayer::HCAL_BARREL1},
-	      {"HCAL_BARREL2_RING0",(int)PFLayer::HCAL_BARREL2},
-              // hack to deal with ring1 in HO 
-	      {"HCAL_BARREL2_RING1",100*(int)PFLayer::HCAL_BARREL2}, 
-	      {"HCAL_ENDCAP",(int)PFLayer::HCAL_ENDCAP},
-	      {"HF_EM",(int)PFLayer::HF_EM},
-	      {"HF_HAD",(int)PFLayer::HF_HAD} }) {
-  const std::vector<edm::ParameterSet>& thresholds =
-    conf.getParameterSetVector("cleaningByDetector");
-  for( const auto& pset : thresholds ) {
+SpikeAndDoubleSpikeCleaner::SpikeAndDoubleSpikeCleaner(const edm::ParameterSet& conf)
+    : RecHitTopologicalCleanerBase(conf),
+      _layerMap({{"PS2", (int)PFLayer::PS2},
+                 {"PS1", (int)PFLayer::PS1},
+                 {"ECAL_ENDCAP", (int)PFLayer::ECAL_ENDCAP},
+                 {"ECAL_BARREL", (int)PFLayer::ECAL_BARREL},
+                 {"NONE", (int)PFLayer::NONE},
+                 {"HCAL_BARREL1", (int)PFLayer::HCAL_BARREL1},
+                 {"HCAL_BARREL2_RING0", (int)PFLayer::HCAL_BARREL2},
+                 // hack to deal with ring1 in HO
+                 {"HCAL_BARREL2_RING1", 100 * (int)PFLayer::HCAL_BARREL2},
+                 {"HCAL_ENDCAP", (int)PFLayer::HCAL_ENDCAP},
+                 {"HF_EM", (int)PFLayer::HF_EM},
+                 {"HF_HAD", (int)PFLayer::HF_HAD}}) {
+  const std::vector<edm::ParameterSet>& thresholds = conf.getParameterSetVector("cleaningByDetector");
+  for (const auto& pset : thresholds) {
     spike_cleaning info;
     const std::string& det = pset.getParameter<std::string>("detector");
-    info._minS4S1_a = pset.getParameter<double>("minS4S1_a");    
-    info._minS4S1_b = pset.getParameter<double>("minS4S1_b");    
+    info._minS4S1_a = pset.getParameter<double>("minS4S1_a");
+    info._minS4S1_b = pset.getParameter<double>("minS4S1_b");
     info._doubleSpikeS6S2 = pset.getParameter<double>("doubleSpikeS6S2");
     info._eneThreshMod = pset.getParameter<double>("energyThresholdModifier");
-    info._fracThreshMod = 
-      pset.getParameter<double>("fractionThresholdModifier");
+    info._fracThreshMod = pset.getParameter<double>("fractionThresholdModifier");
     info._doubleSpikeThresh = pset.getParameter<double>("doubleSpikeThresh");
     info._singleSpikeThresh = pset.getParameter<double>("singleSpikeThresh");
     auto entry = _layerMap.find(det);
-    if( entry == _layerMap.end() ) {
-      throw cms::Exception("InvalidDetectorLayer")
-	<< "Detector layer : " << det << " is not in the list of recognized"
-	<< " detector layers!";
+    if (entry == _layerMap.end()) {
+      throw cms::Exception("InvalidDetectorLayer") << "Detector layer : " << det << " is not in the list of recognized"
+                                                   << " detector layers!";
     }
-    _thresholds.emplace(_layerMap.find(det)->second,info);
-  }  
+    _thresholds.emplace(_layerMap.find(det)->second, info);
+  }
 }
 
-
-void SpikeAndDoubleSpikeCleaner::
-clean(const edm::Handle<reco::PFRecHitCollection>& input,
-      std::vector<bool>& mask ) {
+void SpikeAndDoubleSpikeCleaner::clean(const edm::Handle<reco::PFRecHitCollection>& input, std::vector<bool>& mask) {
   //need to run over energy sorted rechits
-  auto const & hits = *input;
-  std::vector<unsigned > ordered_hits(hits.size());
-  for( unsigned i = 0; i < hits.size(); ++i ) ordered_hits[i]=i;
-  std::sort(ordered_hits.begin(),ordered_hits.end(),[&](unsigned i, unsigned j) { return hits[i].energy()>hits[j].energy();});
-    
-  for( const auto& idx : ordered_hits ) {
+  auto const& hits = *input;
+  std::vector<unsigned> ordered_hits(hits.size());
+  for (unsigned i = 0; i < hits.size(); ++i)
+    ordered_hits[i] = i;
+  std::sort(ordered_hits.begin(), ordered_hits.end(), [&](unsigned i, unsigned j) {
+    return hits[i].energy() > hits[j].energy();
+  });
+
+  for (const auto& idx : ordered_hits) {
     const unsigned i = idx;
-    if( !mask[i] ) continue; // don't need to re-mask things :-)
+    if (!mask[i])
+      continue;  // don't need to re-mask things :-)
     const reco::PFRecHit& rechit = hits[i];
     int hitlayer = (int)rechit.layer();
-    if( hitlayer == PFLayer::HCAL_BARREL2 && 
-	std::abs(rechit.positionREP().eta()) > 0.34 ) {
+    if (hitlayer == PFLayer::HCAL_BARREL2 && std::abs(rechit.positionREP().eta()) > 0.34) {
       hitlayer *= 100;
-    }    
-    const spike_cleaning& clean = _thresholds.find(hitlayer)->second;    
-    if( rechit.energy() < clean._singleSpikeThresh ) continue;
+    }
+    const spike_cleaning& clean = _thresholds.find(hitlayer)->second;
+    if (rechit.energy() < clean._singleSpikeThresh)
+      continue;
 
-    //Fix needed for HF.  Here, we find the (up to) five companion rechits 
+    //Fix needed for HF.  Here, we find the (up to) five companion rechits
     //to work in conjunction with the neighbours4() implementation below for the full HF surrounding energy
     float compsumE = 0.0;
-    if ((hitlayer==PFLayer::HF_EM || hitlayer==PFLayer::HF_HAD)) {
+    if ((hitlayer == PFLayer::HF_EM || hitlayer == PFLayer::HF_HAD)) {
       int comp = 1;
-      if (hitlayer==PFLayer::HF_EM) comp = 2;
+      if (hitlayer == PFLayer::HF_EM)
+        comp = 2;
       const HcalDetId& detid = (HcalDetId)rechit.detId();
       int heta = detid.ieta();
       int hphi = detid.iphi();
-      
-      //At eta>39, phi segmentation changes 
-      int predphi =2;
-      if (std::abs(heta)>39) predphi=4;
 
-      int curphiL = hphi-predphi;
-      int curphiH = hphi+predphi;
+      //At eta>39, phi segmentation changes
+      int predphi = 2;
+      if (std::abs(heta) > 39)
+        predphi = 4;
+
+      int curphiL = hphi - predphi;
+      int curphiH = hphi + predphi;
 
       //HcalDetId valid phi range (0-72)
-      while (curphiL<0) curphiL+=72;
-      while (curphiH>72) curphiH-=72;
+      while (curphiL < 0)
+        curphiL += 72;
+      while (curphiH > 72)
+        curphiH -= 72;
 
-      std::pair<std::vector<int>, std::vector<int>>  phietas({heta,heta+1,heta-1,heta,heta},{hphi,hphi,hphi,curphiL,curphiH});
+      std::pair<std::vector<int>, std::vector<int>> phietas({heta, heta + 1, heta - 1, heta, heta},
+                                                            {hphi, hphi, hphi, curphiL, curphiH});
 
       std::vector<uint32_t> rawDetIds;
-      for(unsigned in=0;in<phietas.first.size();in++) {
-        HcalDetId tempID (HcalForward, phietas.first[in], phietas.second[in], comp);
+      for (unsigned in = 0; in < phietas.first.size(); in++) {
+        HcalDetId tempID(HcalForward, phietas.first[in], phietas.second[in], comp);
         rawDetIds.push_back(tempID.rawId());
       }
 
-      for( const auto& jdx : ordered_hits ) {
+      for (const auto& jdx : ordered_hits) {
         const unsigned j = jdx;
         const reco::PFRecHit& matchrechit = hits[j];
-        for( const auto& iID : rawDetIds ) if (iID==matchrechit.detId())compsumE+=matchrechit.energy();  
+        for (const auto& iID : rawDetIds)
+          if (iID == matchrechit.detId())
+            compsumE += matchrechit.energy();
       }
     }
     //End of fix needed for HF
 
     const double rhenergy = rechit.energy();
     // single spike cleaning
-    auto const & neighbours4 = rechit.neighbours4();
+    auto const& neighbours4 = rechit.neighbours4();
     double surroundingEnergy = compsumE;
-    for( auto k : neighbours4 ) {
-      if( !mask[k] ) continue;
-      auto const & neighbour = hits[k];
-      const double sum = neighbour.energy(); //energyUp is just rechit energy?
+    for (auto k : neighbours4) {
+      if (!mask[k])
+        continue;
+      auto const& neighbour = hits[k];
+      const double sum = neighbour.energy();  //energyUp is just rechit energy?
       surroundingEnergy += sum;
-    }    
+    }
     //   wannaBeSeed.energyUp()/wannaBeSeed.energy() : 1.;
-    // Fraction 1 is the balance between the hit and its neighbours 
+    // Fraction 1 is the balance between the hit and its neighbours
     // from both layers
-    const double fraction1 = surroundingEnergy/rhenergy;    
-    // removed spurious comments from old pfcluster algo... 
+    const double fraction1 = surroundingEnergy / rhenergy;
+    // removed spurious comments from old pfcluster algo...
     // look there if you want more history
-    const double f1Cut = ( clean._minS4S1_a*std::log10(rechit.energy()) + 
-			   clean._minS4S1_b );
-    if( fraction1 < f1Cut ) { 
+    const double f1Cut = (clean._minS4S1_a * std::log10(rechit.energy()) + clean._minS4S1_b);
+    if (fraction1 < f1Cut) {
       const double eta = rechit.positionREP().eta();
       const double aeta = std::abs(eta);
       const double phi = rechit.positionREP().phi();
-      std::pair<double,double> dcr = dCrack(phi,eta);
-      const double dcrmin = ( rechit.layer() ==  PFLayer::ECAL_BARREL ? 
-			      std::min(dcr.first,dcr.second):
-			      dcr.second );
-      if( aeta < 5.0 && 
-	  ( (aeta < 2.85 && dcrmin > 1.0) || 
-	    (rhenergy > clean._eneThreshMod*clean._singleSpikeThresh && 
-	     fraction1 < f1Cut/clean._fracThreshMod ) ) ) {	
-	mask[i] = false;
+      std::pair<double, double> dcr = dCrack(phi, eta);
+      const double dcrmin = (rechit.layer() == PFLayer::ECAL_BARREL ? std::min(dcr.first, dcr.second) : dcr.second);
+      if (aeta < 5.0 && ((aeta < 2.85 && dcrmin > 1.0) || (rhenergy > clean._eneThreshMod * clean._singleSpikeThresh &&
+                                                           fraction1 < f1Cut / clean._fracThreshMod))) {
+        mask[i] = false;
       }
-    }//if initial fraction cut (single spike)
+    }  //if initial fraction cut (single spike)
     // double spike removal
-    if( mask[i] && rhenergy > clean._doubleSpikeThresh ) {
+    if (mask[i] && rhenergy > clean._doubleSpikeThresh) {
       //Determine energy surrounding the seed and the most energetic neighbour
-      double surroundingEnergyi = 0.0;      
+      double surroundingEnergyi = 0.0;
       double enmax = -999.0;
-      unsigned int  mostEnergeticNeighbour=0;
-      auto const & neighbours4i = rechit.neighbours4();
-      for( auto k : neighbours4i ) {
-	if( !mask[k] ) continue;
-        auto const & neighbour = hits[k];
-	const double nenergy = neighbour.energy();
-	surroundingEnergyi += nenergy;
-	if( nenergy > enmax ) {
-	  enmax = nenergy;
-	  mostEnergeticNeighbour = k;
-	}
+      unsigned int mostEnergeticNeighbour = 0;
+      auto const& neighbours4i = rechit.neighbours4();
+      for (auto k : neighbours4i) {
+        if (!mask[k])
+          continue;
+        auto const& neighbour = hits[k];
+        const double nenergy = neighbour.energy();
+        surroundingEnergyi += nenergy;
+        if (nenergy > enmax) {
+          enmax = nenergy;
+          mostEnergeticNeighbour = k;
+        }
       }
       // is there an energetic neighbour
-      if( enmax > 0.0 ) {
-	double surroundingEnergyj = 0.0;
-	auto const & neighbours4j = 
-	  hits[mostEnergeticNeighbour].neighbours4();
-	for(auto k : neighbours4j ) {
-	  //if( !mask[k] &&  k != i) continue; // leave out?
-	  surroundingEnergyj += hits[k].energy();
-	}
-	// The energy surrounding the double spike candidate 
-	const double surroundingEnergyFraction = 
-	  (surroundingEnergyi+surroundingEnergyj) / 
-	  (rechit.energy()+hits[mostEnergeticNeighbour].energy()) - 1.;
-	if ( surroundingEnergyFraction < clean._doubleSpikeS6S2 ) { 
-	  const double eta = rechit.positionREP().eta();
-	  const double aeta = std::abs(eta);
-	  const double phi = rechit.positionREP().phi();
-	  std::pair<double,double> dcr = dCrack(phi,eta);
-	  const double dcrmin = ( rechit.layer() == PFLayer::ECAL_BARREL ? 
-				  std::min(dcr.first,dcr.second):
-				  dcr.second );
-	  if( aeta < 5.0 && 
-	      ( (aeta < 2.85 && dcrmin > 1.0) || 
-		(rhenergy > clean._eneThreshMod*clean._doubleSpikeThresh && 
-		 surroundingEnergyFraction < clean._doubleSpikeS6S2/clean._fracThreshMod ) 
-		) ) {	    
-	    mask[i] = false;
-	    mask[mostEnergeticNeighbour] = false;
-	  }
-	}
-      } // was there an energetic neighbour ? 
-    }// if double spike thresh
-  } // rechit loop
+      if (enmax > 0.0) {
+        double surroundingEnergyj = 0.0;
+        auto const& neighbours4j = hits[mostEnergeticNeighbour].neighbours4();
+        for (auto k : neighbours4j) {
+          //if( !mask[k] &&  k != i) continue; // leave out?
+          surroundingEnergyj += hits[k].energy();
+        }
+        // The energy surrounding the double spike candidate
+        const double surroundingEnergyFraction =
+            (surroundingEnergyi + surroundingEnergyj) / (rechit.energy() + hits[mostEnergeticNeighbour].energy()) - 1.;
+        if (surroundingEnergyFraction < clean._doubleSpikeS6S2) {
+          const double eta = rechit.positionREP().eta();
+          const double aeta = std::abs(eta);
+          const double phi = rechit.positionREP().phi();
+          std::pair<double, double> dcr = dCrack(phi, eta);
+          const double dcrmin = (rechit.layer() == PFLayer::ECAL_BARREL ? std::min(dcr.first, dcr.second) : dcr.second);
+          if (aeta < 5.0 && ((aeta < 2.85 && dcrmin > 1.0) ||
+                             (rhenergy > clean._eneThreshMod * clean._doubleSpikeThresh &&
+                              surroundingEnergyFraction < clean._doubleSpikeS6S2 / clean._fracThreshMod))) {
+            mask[i] = false;
+            mask[mostEnergeticNeighbour] = false;
+          }
+        }
+      }  // was there an energetic neighbour ?
+    }    // if double spike thresh
+  }      // rechit loop
 }

--- a/RecoParticleFlow/PFClusterProducer/plugins/SpikeAndDoubleSpikeCleaner.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/SpikeAndDoubleSpikeCleaner.h
@@ -7,8 +7,7 @@
 #include <unordered_map>
 
 class SpikeAndDoubleSpikeCleaner : public RecHitTopologicalCleanerBase {
- public:
-  
+public:
   struct spike_cleaning {
     double _singleSpikeThresh;
     double _minS4S1_a;
@@ -23,16 +22,13 @@ class SpikeAndDoubleSpikeCleaner : public RecHitTopologicalCleanerBase {
   SpikeAndDoubleSpikeCleaner(const SpikeAndDoubleSpikeCleaner&) = delete;
   SpikeAndDoubleSpikeCleaner& operator=(const SpikeAndDoubleSpikeCleaner&) = delete;
 
-  void clean( const edm::Handle<reco::PFRecHitCollection>& input,
-	      std::vector<bool>& mask ) override;
+  void clean(const edm::Handle<reco::PFRecHitCollection>& input, std::vector<bool>& mask) override;
 
- private:
-  const std::unordered_map<std::string,int> _layerMap;
-  std::unordered_map<int,spike_cleaning> _thresholds;
-  
+private:
+  const std::unordered_map<std::string, int> _layerMap;
+  std::unordered_map<int, spike_cleaning> _thresholds;
 };
 
-DEFINE_EDM_PLUGIN(RecHitTopologicalCleanerFactory,
-		  SpikeAndDoubleSpikeCleaner,"SpikeAndDoubleSpikeCleaner");
+DEFINE_EDM_PLUGIN(RecHitTopologicalCleanerFactory, SpikeAndDoubleSpikeCleaner, "SpikeAndDoubleSpikeCleaner");
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/src/InitialClusteringStepBase.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/InitialClusteringStepBase.cc
@@ -1,6 +1,5 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/InitialClusteringStepBase.h"
 
-std::ostream& operator<<(std::ostream& o, const InitialClusteringStepBase& a){return a<<o;}
+std::ostream& operator<<(std::ostream& o, const InitialClusteringStepBase& a) { return a << o; }
 
-EDM_REGISTER_PLUGINFACTORY(InitialClusteringStepFactory,
-			   "InitialClusteringStepFactory");
+EDM_REGISTER_PLUGINFACTORY(InitialClusteringStepFactory, "InitialClusteringStepFactory");

--- a/RecoParticleFlow/PFClusterProducer/src/PFCPositionCalculatorBase.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFCPositionCalculatorBase.cc
@@ -1,4 +1,3 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/PFCPositionCalculatorBase.h"
 
-EDM_REGISTER_PLUGINFACTORY(PFCPositionCalculatorFactory,
-			   "PFCPositionCalculatorFactory");
+EDM_REGISTER_PLUGINFACTORY(PFCPositionCalculatorFactory, "PFCPositionCalculatorFactory");

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterBuilderBase.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterBuilderBase.cc
@@ -1,6 +1,5 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/PFClusterBuilderBase.h"
 
-std::ostream& operator<<(std::ostream& o, const PFClusterBuilderBase& a){return a<<o;}
+std::ostream& operator<<(std::ostream& o, const PFClusterBuilderBase& a) { return a << o; }
 
-EDM_REGISTER_PLUGINFACTORY(PFClusterBuilderFactory,
-			   "PFClusterBuilderFactory");
+EDM_REGISTER_PLUGINFACTORY(PFClusterBuilderFactory, "PFClusterBuilderFactory");

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
@@ -5,151 +5,144 @@
 
 namespace {
   typedef reco::PFCluster::EEtoPSAssociation::value_type EEPSPair;
-  bool sortByKey(const EEPSPair& a, const EEPSPair& b) {
-    return a.first < b.first;
-  } 
+  bool sortByKey(const EEPSPair &a, const EEPSPair &b) { return a.first < b.first; }
 
-  double getOffset(const double lo, const double hi) { return lo + 0.5*(hi-lo); }
-  double getScale(const double lo, const double hi) { return 0.5*(hi-lo); }
+  double getOffset(const double lo, const double hi) { return lo + 0.5 * (hi - lo); }
+  double getScale(const double lo, const double hi) { return 0.5 * (hi - lo); }
+}  // namespace
+
+PFClusterEMEnergyCorrector::PFClusterEMEnergyCorrector(const edm::ParameterSet &conf, edm::ConsumesCollector &&cc)
+    : calibrator_(new PFEnergyCalibration) {
+  applyCrackCorrections_ = conf.getParameter<bool>("applyCrackCorrections");
+  applyMVACorrections_ = conf.getParameter<bool>("applyMVACorrections");
+  srfAwareCorrection_ = conf.getParameter<bool>("srfAwareCorrection");
+
+  maxPtForMVAEvaluation_ = conf.getParameter<double>("maxPtForMVAEvaluation");
+
+  if (applyMVACorrections_) {
+    meanlimlowEB_ = -0.336;
+    meanlimhighEB_ = 0.916;
+    meanoffsetEB_ = getOffset(meanlimlowEB_, meanlimhighEB_);
+    meanscaleEB_ = getScale(meanlimlowEB_, meanlimhighEB_);
+
+    meanlimlowEE_ = -0.336;
+    meanlimhighEE_ = 0.916;
+    meanoffsetEE_ = getOffset(meanlimlowEE_, meanlimhighEE_);
+    meanscaleEE_ = getScale(meanlimlowEE_, meanlimhighEE_);
+
+    sigmalimlowEB_ = 0.001;
+    sigmalimhighEB_ = 0.4;
+    sigmaoffsetEB_ = getOffset(sigmalimlowEB_, sigmalimhighEB_);
+    sigmascaleEB_ = getScale(sigmalimlowEB_, sigmalimhighEB_);
+
+    sigmalimlowEE_ = 0.001;
+    sigmalimhighEE_ = 0.4;
+    sigmaoffsetEE_ = getOffset(sigmalimlowEE_, sigmalimhighEE_);
+    sigmascaleEE_ = getScale(sigmalimlowEE_, sigmalimhighEE_);
+
+    recHitsEB_ = cc.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("recHitsEBLabel"));
+    recHitsEE_ = cc.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("recHitsEELabel"));
+    autoDetectBunchSpacing_ = conf.getParameter<bool>("autoDetectBunchSpacing");
+
+    if (autoDetectBunchSpacing_) {
+      bunchSpacing_ = cc.consumes<unsigned int>(edm::InputTag("bunchSpacingProducer"));
+      bunchSpacingManual_ = 0;
+    } else {
+      bunchSpacingManual_ = conf.getParameter<int>("bunchSpacing");
+    }
+
+    condnames_mean_25ns_.insert(condnames_mean_25ns_.end(),
+                                {"ecalPFClusterCorV2_EB_pfSize1_mean_25ns",
+                                 "ecalPFClusterCorV2_EB_pfSize2_mean_25ns",
+                                 "ecalPFClusterCorV2_EB_pfSize3_ptbin1_mean_25ns",
+                                 "ecalPFClusterCorV2_EB_pfSize3_ptbin2_mean_25ns",
+                                 "ecalPFClusterCorV2_EB_pfSize3_ptbin3_mean_25ns",
+                                 "ecalPFClusterCorV2_EE_pfSize1_mean_25ns",
+                                 "ecalPFClusterCorV2_EE_pfSize2_mean_25ns",
+                                 "ecalPFClusterCorV2_EE_pfSize3_ptbin1_mean_25ns",
+                                 "ecalPFClusterCorV2_EE_pfSize3_ptbin2_mean_25ns",
+                                 "ecalPFClusterCorV2_EE_pfSize3_ptbin3_mean_25ns"});
+    condnames_sigma_25ns_.insert(condnames_sigma_25ns_.end(),
+                                 {"ecalPFClusterCorV2_EB_pfSize1_sigma_25ns",
+                                  "ecalPFClusterCorV2_EB_pfSize2_sigma_25ns",
+                                  "ecalPFClusterCorV2_EB_pfSize3_ptbin1_sigma_25ns",
+                                  "ecalPFClusterCorV2_EB_pfSize3_ptbin2_sigma_25ns",
+                                  "ecalPFClusterCorV2_EB_pfSize3_ptbin3_sigma_25ns",
+                                  "ecalPFClusterCorV2_EE_pfSize1_sigma_25ns",
+                                  "ecalPFClusterCorV2_EE_pfSize2_sigma_25ns",
+                                  "ecalPFClusterCorV2_EE_pfSize3_ptbin1_sigma_25ns",
+                                  "ecalPFClusterCorV2_EE_pfSize3_ptbin2_sigma_25ns",
+                                  "ecalPFClusterCorV2_EE_pfSize3_ptbin3_sigma_25ns"});
+    condnames_mean_50ns_.insert(condnames_mean_50ns_.end(),
+                                {"ecalPFClusterCorV2_EB_pfSize1_mean_50ns",
+                                 "ecalPFClusterCorV2_EB_pfSize2_mean_50ns",
+                                 "ecalPFClusterCorV2_EB_pfSize3_ptbin1_mean_50ns",
+                                 "ecalPFClusterCorV2_EB_pfSize3_ptbin2_mean_50ns",
+                                 "ecalPFClusterCorV2_EB_pfSize3_ptbin3_mean_50ns",
+                                 "ecalPFClusterCorV2_EE_pfSize1_mean_50ns",
+                                 "ecalPFClusterCorV2_EE_pfSize2_mean_50ns",
+                                 "ecalPFClusterCorV2_EE_pfSize3_ptbin1_mean_50ns",
+                                 "ecalPFClusterCorV2_EE_pfSize3_ptbin2_mean_50ns",
+                                 "ecalPFClusterCorV2_EE_pfSize3_ptbin3_mean_50ns"});
+    condnames_sigma_50ns_.insert(condnames_sigma_50ns_.end(),
+                                 {"ecalPFClusterCorV2_EB_pfSize1_sigma_50ns",
+                                  "ecalPFClusterCorV2_EB_pfSize2_sigma_50ns",
+                                  "ecalPFClusterCorV2_EB_pfSize3_ptbin1_sigma_50ns",
+                                  "ecalPFClusterCorV2_EB_pfSize3_ptbin2_sigma_50ns",
+                                  "ecalPFClusterCorV2_EB_pfSize3_ptbin3_sigma_50ns",
+                                  "ecalPFClusterCorV2_EE_pfSize1_sigma_50ns",
+                                  "ecalPFClusterCorV2_EE_pfSize2_sigma_50ns",
+                                  "ecalPFClusterCorV2_EE_pfSize3_ptbin1_sigma_50ns",
+                                  "ecalPFClusterCorV2_EE_pfSize3_ptbin2_sigma_50ns",
+                                  "ecalPFClusterCorV2_EE_pfSize3_ptbin3_sigma_50ns"});
+
+    if (srfAwareCorrection_) {
+      sigmalimlowEE_ = 0.001;
+      sigmalimhighEE_ = 0.1;
+      sigmaoffsetEE_ = getOffset(sigmalimlowEE_, sigmalimhighEE_);
+      sigmascaleEE_ = getScale(sigmalimlowEE_, sigmalimhighEE_);
+
+      ebSrFlagToken_ = cc.consumes<EBSrFlagCollection>(conf.getParameter<edm::InputTag>("ebSrFlagLabel"));
+      eeSrFlagToken_ = cc.consumes<EESrFlagCollection>(conf.getParameter<edm::InputTag>("eeSrFlagLabel"));
+
+      condnames_mean_.insert(condnames_mean_.end(),
+                             {"ecalPFClusterCor2017V2_EB_ZS_mean_25ns",
+                              "ecalPFClusterCor2017V2_EB_Full_ptbin1_mean_25ns",
+                              "ecalPFClusterCor2017V2_EB_Full_ptbin2_mean_25ns",
+                              "ecalPFClusterCor2017V2_EB_Full_ptbin3_mean_25ns",
+                              "ecalPFClusterCor2017V2_EE_ZS_mean_25ns",
+                              "ecalPFClusterCor2017V2_EE_Full_ptbin1_mean_25ns",
+                              "ecalPFClusterCor2017V2_EE_Full_ptbin2_mean_25ns",
+                              "ecalPFClusterCor2017V2_EE_Full_ptbin3_mean_25ns"});
+
+      condnames_sigma_.insert(condnames_sigma_.end(),
+                              {"ecalPFClusterCor2017V2_EB_ZS_sigma_25ns",
+                               "ecalPFClusterCor2017V2_EB_Full_ptbin1_sigma_25ns",
+                               "ecalPFClusterCor2017V2_EB_Full_ptbin2_sigma_25ns",
+                               "ecalPFClusterCor2017V2_EB_Full_ptbin3_sigma_25ns",
+                               "ecalPFClusterCor2017V2_EE_ZS_sigma_25ns",
+                               "ecalPFClusterCor2017V2_EE_Full_ptbin1_sigma_25ns",
+                               "ecalPFClusterCor2017V2_EE_Full_ptbin2_sigma_25ns",
+                               "ecalPFClusterCor2017V2_EE_Full_ptbin3_sigma_25ns"});
+    }
+  }
 }
 
-PFClusterEMEnergyCorrector::PFClusterEMEnergyCorrector(const edm::ParameterSet& conf, edm::ConsumesCollector &&cc) :
-  calibrator_(new PFEnergyCalibration) {
-
-   applyCrackCorrections_ = conf.getParameter<bool>("applyCrackCorrections");
-   applyMVACorrections_ = conf.getParameter<bool>("applyMVACorrections");
-   srfAwareCorrection_ = conf.getParameter<bool>("srfAwareCorrection");
-
-   maxPtForMVAEvaluation_ = conf.getParameter<double>("maxPtForMVAEvaluation");
-     
-   if (applyMVACorrections_) {
-
-     meanlimlowEB_ = -0.336;
-     meanlimhighEB_ = 0.916;
-     meanoffsetEB_ = getOffset(meanlimlowEB_, meanlimhighEB_);
-     meanscaleEB_ = getScale(meanlimlowEB_, meanlimhighEB_);
-
-     meanlimlowEE_ = -0.336;
-     meanlimhighEE_ = 0.916;
-     meanoffsetEE_ = getOffset(meanlimlowEE_, meanlimhighEE_);
-     meanscaleEE_ = getScale(meanlimlowEE_, meanlimhighEE_);
-     
-     sigmalimlowEB_ = 0.001;
-     sigmalimhighEB_ = 0.4;
-     sigmaoffsetEB_ = getOffset(sigmalimlowEB_, sigmalimhighEB_);
-     sigmascaleEB_ = getScale(sigmalimlowEB_, sigmalimhighEB_);
-     
-     sigmalimlowEE_ = 0.001;
-     sigmalimhighEE_ = 0.4;
-     sigmaoffsetEE_ = getOffset(sigmalimlowEE_, sigmalimhighEE_);
-     sigmascaleEE_ = getScale(sigmalimlowEE_, sigmalimhighEE_);
-   
-     recHitsEB_ = cc.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("recHitsEBLabel"));
-     recHitsEE_ = cc.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("recHitsEELabel"));
-     autoDetectBunchSpacing_ = conf.getParameter<bool>("autoDetectBunchSpacing");
-     
-     if (autoDetectBunchSpacing_) {
-       bunchSpacing_ = cc.consumes<unsigned int>(edm::InputTag("bunchSpacingProducer"));
-       bunchSpacingManual_ = 0;
-     } else {
-       bunchSpacingManual_ = conf.getParameter<int>("bunchSpacing");
-     }
-     
-     condnames_mean_25ns_.insert(condnames_mean_25ns_.end(), {  
-   	 "ecalPFClusterCorV2_EB_pfSize1_mean_25ns",
-         "ecalPFClusterCorV2_EB_pfSize2_mean_25ns",
-	 "ecalPFClusterCorV2_EB_pfSize3_ptbin1_mean_25ns",
-	 "ecalPFClusterCorV2_EB_pfSize3_ptbin2_mean_25ns",
-	 "ecalPFClusterCorV2_EB_pfSize3_ptbin3_mean_25ns",
-	 "ecalPFClusterCorV2_EE_pfSize1_mean_25ns",
-	 "ecalPFClusterCorV2_EE_pfSize2_mean_25ns",
-	 "ecalPFClusterCorV2_EE_pfSize3_ptbin1_mean_25ns",
-	 "ecalPFClusterCorV2_EE_pfSize3_ptbin2_mean_25ns",
-	 "ecalPFClusterCorV2_EE_pfSize3_ptbin3_mean_25ns"});
-     condnames_sigma_25ns_.insert(condnames_sigma_25ns_.end(), {  
-	 "ecalPFClusterCorV2_EB_pfSize1_sigma_25ns",
-	 "ecalPFClusterCorV2_EB_pfSize2_sigma_25ns",
-	 "ecalPFClusterCorV2_EB_pfSize3_ptbin1_sigma_25ns",
-	 "ecalPFClusterCorV2_EB_pfSize3_ptbin2_sigma_25ns",
-	 "ecalPFClusterCorV2_EB_pfSize3_ptbin3_sigma_25ns",
-	 "ecalPFClusterCorV2_EE_pfSize1_sigma_25ns",
-	 "ecalPFClusterCorV2_EE_pfSize2_sigma_25ns",
-	 "ecalPFClusterCorV2_EE_pfSize3_ptbin1_sigma_25ns",
-	 "ecalPFClusterCorV2_EE_pfSize3_ptbin2_sigma_25ns",
-	 "ecalPFClusterCorV2_EE_pfSize3_ptbin3_sigma_25ns"});
-     condnames_mean_50ns_.insert(condnames_mean_50ns_.end(), { 
-	 "ecalPFClusterCorV2_EB_pfSize1_mean_50ns",
-	 "ecalPFClusterCorV2_EB_pfSize2_mean_50ns",
-	 "ecalPFClusterCorV2_EB_pfSize3_ptbin1_mean_50ns",
-	 "ecalPFClusterCorV2_EB_pfSize3_ptbin2_mean_50ns",
-	 "ecalPFClusterCorV2_EB_pfSize3_ptbin3_mean_50ns",
-	 "ecalPFClusterCorV2_EE_pfSize1_mean_50ns",
-	 "ecalPFClusterCorV2_EE_pfSize2_mean_50ns",
-	 "ecalPFClusterCorV2_EE_pfSize3_ptbin1_mean_50ns",
-	 "ecalPFClusterCorV2_EE_pfSize3_ptbin2_mean_50ns",
-	 "ecalPFClusterCorV2_EE_pfSize3_ptbin3_mean_50ns"});
-     condnames_sigma_50ns_.insert(condnames_sigma_50ns_.end(), {    
-	 "ecalPFClusterCorV2_EB_pfSize1_sigma_50ns",
-	 "ecalPFClusterCorV2_EB_pfSize2_sigma_50ns",
-	 "ecalPFClusterCorV2_EB_pfSize3_ptbin1_sigma_50ns",
-	 "ecalPFClusterCorV2_EB_pfSize3_ptbin2_sigma_50ns",
-	 "ecalPFClusterCorV2_EB_pfSize3_ptbin3_sigma_50ns",
-	 "ecalPFClusterCorV2_EE_pfSize1_sigma_50ns",
-	 "ecalPFClusterCorV2_EE_pfSize2_sigma_50ns",
-	 "ecalPFClusterCorV2_EE_pfSize3_ptbin1_sigma_50ns",
-	 "ecalPFClusterCorV2_EE_pfSize3_ptbin2_sigma_50ns",
-	 "ecalPFClusterCorV2_EE_pfSize3_ptbin3_sigma_50ns"});
-
-     if (srfAwareCorrection_) {
-
-       sigmalimlowEE_ = 0.001;
-       sigmalimhighEE_ = 0.1;
-       sigmaoffsetEE_ = getOffset(sigmalimlowEE_, sigmalimhighEE_);
-       sigmascaleEE_ = getScale(sigmalimlowEE_, sigmalimhighEE_);
-
-       ebSrFlagToken_ = cc.consumes<EBSrFlagCollection>(conf.getParameter<edm::InputTag>("ebSrFlagLabel"));
-       eeSrFlagToken_ = cc.consumes<EESrFlagCollection>(conf.getParameter<edm::InputTag>("eeSrFlagLabel"));
-
-       condnames_mean_.insert(condnames_mean_.end(), {    
-	   "ecalPFClusterCor2017V2_EB_ZS_mean_25ns",
-	   "ecalPFClusterCor2017V2_EB_Full_ptbin1_mean_25ns",
-	   "ecalPFClusterCor2017V2_EB_Full_ptbin2_mean_25ns",
-	   "ecalPFClusterCor2017V2_EB_Full_ptbin3_mean_25ns",
-	   "ecalPFClusterCor2017V2_EE_ZS_mean_25ns",
-	   "ecalPFClusterCor2017V2_EE_Full_ptbin1_mean_25ns",
-	   "ecalPFClusterCor2017V2_EE_Full_ptbin2_mean_25ns",
-	   "ecalPFClusterCor2017V2_EE_Full_ptbin3_mean_25ns"});
-       
-       condnames_sigma_.insert(condnames_sigma_.end(), {    
-	   "ecalPFClusterCor2017V2_EB_ZS_sigma_25ns",
-	   "ecalPFClusterCor2017V2_EB_Full_ptbin1_sigma_25ns",
-	   "ecalPFClusterCor2017V2_EB_Full_ptbin2_sigma_25ns",
-	   "ecalPFClusterCor2017V2_EB_Full_ptbin3_sigma_25ns",
-	   "ecalPFClusterCor2017V2_EE_ZS_sigma_25ns",
-	   "ecalPFClusterCor2017V2_EE_Full_ptbin1_sigma_25ns",
-	   "ecalPFClusterCor2017V2_EE_Full_ptbin2_sigma_25ns",
-	   "ecalPFClusterCor2017V2_EE_Full_ptbin3_sigma_25ns"});
-     }
-   }
-    
-}
-
-void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt, 
-						 const edm::EventSetup &es, 
-						 const reco::PFCluster::EEtoPSAssociation &assoc, 
-						 reco::PFClusterCollection& cs) {
-
+void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt,
+                                                 const edm::EventSetup &es,
+                                                 const reco::PFCluster::EEtoPSAssociation &assoc,
+                                                 reco::PFClusterCollection &cs) {
   // First deal with pre-MVA corrections
   // Kept for backward compatibility (and for HLT)
   if (!applyMVACorrections_) {
-    for (unsigned int idx = 0; idx<cs.size(); ++idx) {
+    for (unsigned int idx = 0; idx < cs.size(); ++idx) {
       reco::PFCluster &cluster = cs[idx];
       bool iseb = cluster.layer() == PFLayer::ECAL_BARREL;
-      float ePS1=0., ePS2=0.;
-      if(!iseb)
-	getAssociatedPSEnergy(idx, assoc, ePS1, ePS2);
-      double correctedEnergy = calibrator_->energyEm(cluster,ePS1,ePS2,applyCrackCorrections_);
-      cluster.setCorrectedEnergy(correctedEnergy);      
+      float ePS1 = 0., ePS2 = 0.;
+      if (!iseb)
+        getAssociatedPSEnergy(idx, assoc, ePS1, ePS2);
+      double correctedEnergy = calibrator_->energyEm(cluster, ePS1, ePS2, applyCrackCorrections_);
+      cluster.setCorrectedEnergy(correctedEnergy);
     }
     return;
   }
@@ -159,146 +152,146 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt,
   EcalReadoutTools readoutTool(evt, es);
 
   if (!srfAwareCorrection_) {
-
-    int bunchspacing = 450;  
+    int bunchspacing = 450;
     if (autoDetectBunchSpacing_) {
       edm::Handle<unsigned int> bunchSpacingH;
-      evt.getByToken(bunchSpacing_,bunchSpacingH);
+      evt.getByToken(bunchSpacing_, bunchSpacingH);
       bunchspacing = *bunchSpacingH;
-    }
-    else {
+    } else {
       bunchspacing = bunchSpacingManual_;
     }
-    
-    const std::vector<std::string>& condnames_mean = (bunchspacing == 25) ? condnames_mean_25ns_ : condnames_mean_50ns_;
-    const std::vector<std::string>& condnames_sigma = (bunchspacing == 25) ? condnames_sigma_25ns_ : condnames_sigma_50ns_;  
-    const unsigned int ncor = condnames_mean.size();    
+
+    const std::vector<std::string> &condnames_mean = (bunchspacing == 25) ? condnames_mean_25ns_ : condnames_mean_50ns_;
+    const std::vector<std::string> &condnames_sigma =
+        (bunchspacing == 25) ? condnames_sigma_25ns_ : condnames_sigma_50ns_;
+    const unsigned int ncor = condnames_mean.size();
     std::vector<edm::ESHandle<GBRForestD> > forestH_mean(ncor);
-    std::vector<edm::ESHandle<GBRForestD> > forestH_sigma(ncor);  
-    
-    for (unsigned int icor=0; icor<ncor; ++icor) {
-      es.get<GBRDWrapperRcd>().get(condnames_mean[icor],forestH_mean[icor]);
-      es.get<GBRDWrapperRcd>().get(condnames_sigma[icor],forestH_sigma[icor]);
+    std::vector<edm::ESHandle<GBRForestD> > forestH_sigma(ncor);
+
+    for (unsigned int icor = 0; icor < ncor; ++icor) {
+      es.get<GBRDWrapperRcd>().get(condnames_mean[icor], forestH_mean[icor]);
+      es.get<GBRDWrapperRcd>().get(condnames_sigma[icor], forestH_sigma[icor]);
     }
-    
-    std::array<float,5> eval;            
-    for (unsigned int idx = 0; idx<cs.size(); ++idx) {                        
+
+    std::array<float, 5> eval;
+    for (unsigned int idx = 0; idx < cs.size(); ++idx) {
       reco::PFCluster &cluster = cs[idx];
       bool iseb = cluster.layer() == PFLayer::ECAL_BARREL;
-      float ePS1=0., ePS2=0.;
-      if(!iseb)
-	getAssociatedPSEnergy(idx, assoc, ePS1, ePS2);
+      float ePS1 = 0., ePS2 = 0.;
+      if (!iseb)
+        getAssociatedPSEnergy(idx, assoc, ePS1, ePS2);
 
       double e = cluster.energy();
       double pt = cluster.pt();
       double evale = e;
-      if (maxPtForMVAEvaluation_>0. && pt>maxPtForMVAEvaluation_) {
-	evale *= maxPtForMVAEvaluation_/pt; 
+      if (maxPtForMVAEvaluation_ > 0. && pt > maxPtForMVAEvaluation_) {
+        evale *= maxPtForMVAEvaluation_ / pt;
       }
-      double invE = (e == 0.) ? 0. : 1./e; //guard against dividing by 0.      
-      int size = lazyTool.n5x5(cluster);      
-      
-      int ietaix=0;
-      int iphiiy=0;
+      double invE = (e == 0.) ? 0. : 1. / e;  //guard against dividing by 0.
+      int size = lazyTool.n5x5(cluster);
+
+      int ietaix = 0;
+      int iphiiy = 0;
       if (iseb) {
-	EBDetId ebseed(cluster.seed());
-	ietaix = ebseed.ieta();
-	iphiiy = ebseed.iphi();
+        EBDetId ebseed(cluster.seed());
+        ietaix = ebseed.ieta();
+        iphiiy = ebseed.iphi();
       } else {
-	EEDetId eeseed(cluster.seed());
-	ietaix = eeseed.ix();
-	iphiiy = eeseed.iy();      
+        EEDetId eeseed(cluster.seed());
+        ietaix = eeseed.ix();
+        iphiiy = eeseed.iy();
       }
 
       //find index of corrections (0-4 for EB, 5-9 for EE, depending on cluster size and raw pt)
-      int coridx = std::min(size,3)-1;
-      if (coridx==2) {
-	if (pt>4.5) {
-	  coridx += 1;
-	}
-	if (pt>18.) {
-	  coridx += 1;
-	}
+      int coridx = std::min(size, 3) - 1;
+      if (coridx == 2) {
+        if (pt > 4.5) {
+          coridx += 1;
+        }
+        if (pt > 18.) {
+          coridx += 1;
+        }
       }
       if (!iseb) {
-	coridx += 5;
+        coridx += 5;
       }
-      
+
       const GBRForestD &meanforest = *forestH_mean[coridx].product();
       const GBRForestD &sigmaforest = *forestH_sigma[coridx].product();
-      
+
       //fill array for forest evaluation
       eval[0] = evale;
       eval[1] = ietaix;
       eval[2] = iphiiy;
       if (!iseb) {
-	eval[3] = ePS1*invE;
-	eval[4] = ePS2*invE;
+        eval[3] = ePS1 * invE;
+        eval[4] = ePS2 * invE;
       }
-      
+
       //these are the actual BDT responses
       double rawmean = meanforest.GetResponse(eval.data());
       double rawsigma = sigmaforest.GetResponse(eval.data());
-      
+
       //apply transformation to limited output range (matching the training)
-      double mean = iseb ? meanoffsetEB_ + meanscaleEB_*vdt::fast_sin(rawmean) : meanoffsetEE_ + meanscaleEE_*vdt::fast_sin(rawmean);
-      double sigma = iseb ? sigmaoffsetEB_ + sigmascaleEB_*vdt::fast_sin(rawsigma) : sigmaoffsetEE_ + sigmascaleEE_*vdt::fast_sin(rawsigma);
-      
+      double mean = iseb ? meanoffsetEB_ + meanscaleEB_ * vdt::fast_sin(rawmean)
+                         : meanoffsetEE_ + meanscaleEE_ * vdt::fast_sin(rawmean);
+      double sigma = iseb ? sigmaoffsetEB_ + sigmascaleEB_ * vdt::fast_sin(rawsigma)
+                          : sigmaoffsetEE_ + sigmascaleEE_ * vdt::fast_sin(rawsigma);
+
       //regression target is ln(Etrue/Eraw)
       //so corrected energy is ecor=exp(mean)*e, uncertainty is exp(mean)*eraw*sigma=ecor*sigma
-      double ecor = vdt::fast_exp(mean)*e;
-      double sigmacor = sigma*ecor;
-      
+      double ecor = vdt::fast_exp(mean) * e;
+      double sigmacor = sigma * ecor;
+
       cluster.setCorrectedEnergy(ecor);
       cluster.setCorrectedEnergyUncertainty(sigmacor);
-      
     }
     return;
   }
 
   // Selective Readout Flags
-  edm::Handle<EBSrFlagCollection> ebSrFlags;   
-  edm::Handle<EESrFlagCollection> eeSrFlags;  
-  evt.getByToken(ebSrFlagToken_, ebSrFlags);  
+  edm::Handle<EBSrFlagCollection> ebSrFlags;
+  edm::Handle<EESrFlagCollection> eeSrFlags;
+  evt.getByToken(ebSrFlagToken_, ebSrFlags);
   evt.getByToken(eeSrFlagToken_, eeSrFlags);
   if (!ebSrFlags.isValid() || !eeSrFlags.isValid())
-    throw cms::Exception("PFClusterEMEnergyCorrector") << "This version of PFCluster corrections requires the SrFlagCollection information to proceed!\n";
-  
-  const unsigned int ncor = condnames_mean_.size();
-  
-  std::vector<edm::ESHandle<GBRForestD> > forestH_mean(ncor);
-  std::vector<edm::ESHandle<GBRForestD> > forestH_sigma(ncor);  
-  
-  for (unsigned int icor=0; icor<ncor; ++icor) {
-    es.get<GBRDWrapperRcd>().get(condnames_mean_[icor],forestH_mean[icor]);
-    es.get<GBRDWrapperRcd>().get(condnames_sigma_[icor],forestH_sigma[icor]);
-  }
-  
-  std::array<float,6> evalEB;
-  std::array<float,5> evalEE;    
-    
-  for (unsigned int idx = 0; idx<cs.size(); ++idx) {
+    throw cms::Exception("PFClusterEMEnergyCorrector")
+        << "This version of PFCluster corrections requires the SrFlagCollection information to proceed!\n";
 
+  const unsigned int ncor = condnames_mean_.size();
+
+  std::vector<edm::ESHandle<GBRForestD> > forestH_mean(ncor);
+  std::vector<edm::ESHandle<GBRForestD> > forestH_sigma(ncor);
+
+  for (unsigned int icor = 0; icor < ncor; ++icor) {
+    es.get<GBRDWrapperRcd>().get(condnames_mean_[icor], forestH_mean[icor]);
+    es.get<GBRDWrapperRcd>().get(condnames_sigma_[icor], forestH_sigma[icor]);
+  }
+
+  std::array<float, 6> evalEB;
+  std::array<float, 5> evalEE;
+
+  for (unsigned int idx = 0; idx < cs.size(); ++idx) {
     reco::PFCluster &cluster = cs[idx];
     bool iseb = cluster.layer() == PFLayer::ECAL_BARREL;
-    float ePS1=0., ePS2=0.;
-    if(!iseb)
+    float ePS1 = 0., ePS2 = 0.;
+    if (!iseb)
       getAssociatedPSEnergy(idx, assoc, ePS1, ePS2);
-    
+
     double e = cluster.energy();
     double pt = cluster.pt();
     double evale = e;
-    if (maxPtForMVAEvaluation_>0. && pt>maxPtForMVAEvaluation_) {
-      evale *= maxPtForMVAEvaluation_/pt; 
+    if (maxPtForMVAEvaluation_ > 0. && pt > maxPtForMVAEvaluation_) {
+      evale *= maxPtForMVAEvaluation_ / pt;
     }
-    double invE = (e == 0.) ? 0. : 1./e; //guard against dividing by 0.      
-    int size = lazyTool.n5x5(cluster);          
-    int reducedHits = size;    
-    if(size>=3)
+    double invE = (e == 0.) ? 0. : 1. / e;  //guard against dividing by 0.
+    int size = lazyTool.n5x5(cluster);
+    int reducedHits = size;
+    if (size >= 3)
       reducedHits = 3;
-    
-    int ietaix=0;
-    int iphiiy=0;
+
+    int ietaix = 0;
+    int iphiiy = 0;
     if (iseb) {
       EBDetId ebseed(cluster.seed());
       ietaix = ebseed.ieta();
@@ -306,36 +299,37 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt,
     } else {
       EEDetId eeseed(cluster.seed());
       ietaix = eeseed.ix();
-      iphiiy = eeseed.iy();      
+      iphiiy = eeseed.iy();
     }
 
     // Hardcoded number are positions of modules boundaries of ECAL
     int signeta = (ietaix > 0) ? 1 : -1;
-    int ietamod20 = (std::abs(ietaix) < 26) ? ietaix - signeta : (ietaix - 26*signeta) % 20;
-    int iphimod20 = (iphiiy-1) % 20;
-    
-    int clusFlag = 0;    
-    if (iseb){
+    int ietamod20 = (std::abs(ietaix) < 26) ? ietaix - signeta : (ietaix - 26 * signeta) % 20;
+    int iphimod20 = (iphiiy - 1) % 20;
+
+    int clusFlag = 0;
+    if (iseb) {
       auto ecalUnit = readoutTool.readOutUnitOf(static_cast<EBDetId>(cluster.seed()));
-      EBSrFlagCollection::const_iterator srf = ebSrFlags->find(ecalUnit);      
+      EBSrFlagCollection::const_iterator srf = ebSrFlags->find(ecalUnit);
       if (srf != ebSrFlags->end())
-	clusFlag = srf->value();
+        clusFlag = srf->value();
       else
-	clusFlag = 3;      
+        clusFlag = 3;
     } else {
       auto ecalUnit = readoutTool.readOutUnitOf(static_cast<EEDetId>(cluster.seed()));
-      EESrFlagCollection::const_iterator srf = eeSrFlags->find(ecalUnit);      
+      EESrFlagCollection::const_iterator srf = eeSrFlags->find(ecalUnit);
       if (srf != eeSrFlags->end())
-	clusFlag = srf->value();
+        clusFlag = srf->value();
       else
-	clusFlag = 3;      
+        clusFlag = 3;
     }
-  
+
     //find index of corrections (0-3 for EB, 4-7 for EE, depending on cluster size and raw pt)
     int coridx = 0;
     int regind = 0;
-    if (!iseb) regind = 4;
-    
+    if (!iseb)
+      regind = 4;
+
     ///////////////////////////////////////////////////////////////////////////////////
     ///a hit can be ZS or forced ZS. A hit can be in Full readout or Forced to be FULL readout
     ///if it is ZS, then clusFlag (in binary) = 0001
@@ -345,21 +339,25 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt,
     ///i.e 3rd bit is set.
     ///Even if it is forced, we should mark it is as ZS or FR. To take care of it, just check the LSB and second LSB(SLSB)
     ///////////////////////////////////////////////////////////////////////////////////
-    int ZS_bit = clusFlag>>0&1;
-    int FR_bit = clusFlag>>1&1;
-    
-    
+    int ZS_bit = clusFlag >> 0 & 1;
+    int FR_bit = clusFlag >> 1 & 1;
 
-    if (ZS_bit!=0 && FR_bit==0) ///it is clusFlag==1, 5
+    if (ZS_bit != 0 && FR_bit == 0)  ///it is clusFlag==1, 5
       coridx = 0 + regind;
-    else{
-      if (pt<2.5) coridx = 1 + regind;
-      else if (pt>=2.5 && pt<6.) coridx = 2 + regind;
-      else if (pt>=6.) coridx = 3 + regind;
+    else {
+      if (pt < 2.5)
+        coridx = 1 + regind;
+      else if (pt >= 2.5 && pt < 6.)
+        coridx = 2 + regind;
+      else if (pt >= 6.)
+        coridx = 3 + regind;
     }
-    if (ZS_bit==0 || clusFlag > 7) {
-      edm::LogWarning("PFClusterEMEnergyCorrector") << "We can only correct regions readout in ZS (flag 1,5) or FULL readout (flag 3,7). Flag " << clusFlag << " is not recognized."
-						    << "\n" << "Assuming FULL readout and continuing";
+    if (ZS_bit == 0 || clusFlag > 7) {
+      edm::LogWarning("PFClusterEMEnergyCorrector")
+          << "We can only correct regions readout in ZS (flag 1,5) or FULL readout (flag 3,7). Flag " << clusFlag
+          << " is not recognized."
+          << "\n"
+          << "Assuming FULL readout and continuing";
     }
 
     const GBRForestD &meanforest = *forestH_mean[coridx].product();
@@ -377,15 +375,15 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt,
       evalEE[0] = evale;
       evalEE[1] = ietaix;
       evalEE[2] = iphiiy;
-      evalEE[3] = (ePS1+ePS2)*invE;
+      evalEE[3] = (ePS1 + ePS2) * invE;
       evalEE[4] = reducedHits;
     }
-     
+
     //these are the actual BDT responses
     double rawmean = 1;
     double rawsigma = 0;
 
-    if(iseb){
+    if (iseb) {
       rawmean = meanforest.GetResponse(evalEB.data());
       rawsigma = sigmaforest.GetResponse(evalEB.data());
     } else {
@@ -396,51 +394,47 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt,
     //apply transformation to limited output range (matching the training)
     //the training was done with different transformations for EB and EE (width only)
     //makes a the code a bit more cumbersome, but it is not a problem per se
-    double mean = iseb ? meanoffsetEB_ + meanscaleEB_*vdt::fast_sin(rawmean) : meanoffsetEE_ + meanscaleEE_*vdt::fast_sin(rawmean);
-    double sigma = iseb ? sigmaoffsetEB_ + sigmascaleEB_*vdt::fast_sin(rawsigma) : sigmaoffsetEE_ + sigmascaleEE_*vdt::fast_sin(rawsigma);
-    
+    double mean = iseb ? meanoffsetEB_ + meanscaleEB_ * vdt::fast_sin(rawmean)
+                       : meanoffsetEE_ + meanscaleEE_ * vdt::fast_sin(rawmean);
+    double sigma = iseb ? sigmaoffsetEB_ + sigmascaleEB_ * vdt::fast_sin(rawsigma)
+                        : sigmaoffsetEE_ + sigmascaleEE_ * vdt::fast_sin(rawsigma);
+
     //regression target is ln(Etrue/Eraw)
     //so corrected energy is ecor=exp(mean)*e, uncertainty is exp(mean)*eraw*sigma=ecor*sigma
-    double ecor = iseb ? vdt::fast_exp(mean)*e : vdt::fast_exp(mean)*(e+ePS1+ePS2);
-    double sigmacor = sigma*ecor;
+    double ecor = iseb ? vdt::fast_exp(mean) * e : vdt::fast_exp(mean) * (e + ePS1 + ePS2);
+    double sigmacor = sigma * ecor;
 
-    LogDebug("PFClusterEMEnergyCorrector") << "ieta : iphi : ietamod20 : iphimod20 : size : reducedHits = "
-					   << ietaix << " " << iphiiy << " " 
-					   << ietamod20 << " " << iphimod20 << " " 
-					   << size << " " << reducedHits
-					   << "\n" << "isEB : eraw : ePS1 : ePS2 : (eps1+eps2)/raw : Flag = "
-					   << iseb << " " << evale << " " << ePS1 << " " << ePS2 << " " << (ePS1+ePS2)/evale << " " << clusFlag
-					   << "\n" << "response : correction = " 
-					   << exp(mean) << " " << ecor;
-    
+    LogDebug("PFClusterEMEnergyCorrector")
+        << "ieta : iphi : ietamod20 : iphimod20 : size : reducedHits = " << ietaix << " " << iphiiy << " " << ietamod20
+        << " " << iphimod20 << " " << size << " " << reducedHits << "\n"
+        << "isEB : eraw : ePS1 : ePS2 : (eps1+eps2)/raw : Flag = " << iseb << " " << evale << " " << ePS1 << " " << ePS2
+        << " " << (ePS1 + ePS2) / evale << " " << clusFlag << "\n"
+        << "response : correction = " << exp(mean) << " " << ecor;
+
     cluster.setCorrectedEnergy(ecor);
     cluster.setCorrectedEnergyUncertainty(sigmacor);
   }
-  
 }
 
-void PFClusterEMEnergyCorrector::getAssociatedPSEnergy(const size_t clusIdx, const reco::PFCluster::EEtoPSAssociation &assoc, float& e1, float& e2) {
-
+void PFClusterEMEnergyCorrector::getAssociatedPSEnergy(const size_t clusIdx,
+                                                       const reco::PFCluster::EEtoPSAssociation &assoc,
+                                                       float &e1,
+                                                       float &e2) {
   e1 = 0;
   e2 = 0;
-  auto ee_key_val = std::make_pair(clusIdx,edm::Ptr<reco::PFCluster>());
-  const auto clustops = std::equal_range(assoc.begin(),
-					 assoc.end(),
-					 ee_key_val,
-					 sortByKey);
-  for( auto i_ps = clustops.first; i_ps != clustops.second; ++i_ps) {
+  auto ee_key_val = std::make_pair(clusIdx, edm::Ptr<reco::PFCluster>());
+  const auto clustops = std::equal_range(assoc.begin(), assoc.end(), ee_key_val, sortByKey);
+  for (auto i_ps = clustops.first; i_ps != clustops.second; ++i_ps) {
     edm::Ptr<reco::PFCluster> psclus(i_ps->second);
-    switch( psclus->layer() ) {
-    case PFLayer::PS1:
-      e1 += psclus->energy();
-      break;
-    case PFLayer::PS2:
-      e2 += psclus->energy();
-      break;
-    default:
-      break;
+    switch (psclus->layer()) {
+      case PFLayer::PS1:
+        e1 += psclus->energy();
+        break;
+      case PFLayer::PS2:
+        e2 += psclus->energy();
+        break;
+      default:
+        break;
     }
   }
-
 }
-  

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterEnergyCorrectorBase.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterEnergyCorrectorBase.cc
@@ -1,4 +1,3 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/PFClusterEnergyCorrectorBase.h"
 
-EDM_REGISTER_PLUGINFACTORY(PFClusterEnergyCorrectorFactory,
-			   "PFClusterEnergyCorrectorFactory");
+EDM_REGISTER_PLUGINFACTORY(PFClusterEnergyCorrectorFactory, "PFClusterEnergyCorrectorFactory");

--- a/RecoParticleFlow/PFClusterProducer/src/RecHitTopologicalCleanerBase.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/RecHitTopologicalCleanerBase.cc
@@ -1,4 +1,3 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/RecHitTopologicalCleanerBase.h"
 
-EDM_REGISTER_PLUGINFACTORY(RecHitTopologicalCleanerFactory,
-			   "RecHitTopologicalCleanerFactory");
+EDM_REGISTER_PLUGINFACTORY(RecHitTopologicalCleanerFactory, "RecHitTopologicalCleanerFactory");

--- a/RecoParticleFlow/PFClusterProducer/src/SeedFinderBase.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/SeedFinderBase.cc
@@ -1,3 +1,3 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/SeedFinderBase.h"
 
-EDM_REGISTER_PLUGINFACTORY(SeedFinderFactory,"SeedFinderFactory");
+EDM_REGISTER_PLUGINFACTORY(SeedFinderFactory, "SeedFinderFactory");

--- a/RecoParticleFlow/PFClusterProducer/test/PFClusterAnalyzer.cc
+++ b/RecoParticleFlow/PFClusterProducer/test/PFClusterAnalyzer.cc
@@ -7,100 +7,63 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
-
 using namespace std;
 using namespace edm;
 using namespace reco;
 
 PFClusterAnalyzer::PFClusterAnalyzer(const edm::ParameterSet& iConfig) {
-  
+  inputTagPFClusters_ = iConfig.getParameter<InputTag>("PFClusters");
 
+  verbose_ = iConfig.getUntrackedParameter<bool>("verbose", false);
 
-  inputTagPFClusters_ 
-    = iConfig.getParameter<InputTag>("PFClusters");
+  printBlocks_ = iConfig.getUntrackedParameter<bool>("printBlocks", false);
 
-  verbose_ = 
-    iConfig.getUntrackedParameter<bool>("verbose",false);
-
-  printBlocks_ = 
-    iConfig.getUntrackedParameter<bool>("printBlocks",false);
-
-
-
-  LogDebug("PFClusterAnalyzer")
-    <<" input collection : "<<inputTagPFClusters_ ;
-   
+  LogDebug("PFClusterAnalyzer") << " input collection : " << inputTagPFClusters_;
 }
-
-
 
 PFClusterAnalyzer::~PFClusterAnalyzer() = default;
 
+void PFClusterAnalyzer::beginRun(const edm::Run& run, const edm::EventSetup& es) {}
 
+void PFClusterAnalyzer::analyze(const Event& iEvent, const EventSetup& iSetup) {
+  LogDebug("PFClusterAnalyzer") << "START event: " << iEvent.id().event() << " in run " << iEvent.id().run() << endl;
 
-void 
-PFClusterAnalyzer::beginRun(const edm::Run& run,
-			    const edm::EventSetup & es) { }
-
-
-void PFClusterAnalyzer::analyze(const Event& iEvent, 
-				  const EventSetup& iSetup) {
-  
-  LogDebug("PFClusterAnalyzer")<<"START event: "<<iEvent.id().event()
-			 <<" in run "<<iEvent.id().run()<<endl;
-  
-  
-  
   // get PFClusters
 
   Handle<PFClusterCollection> pfClusters;
-  fetchCandidateCollection(pfClusters, 
-			   inputTagPFClusters_, 
-			   iEvent );
+  fetchCandidateCollection(pfClusters, inputTagPFClusters_, iEvent);
 
   // get PFClusters for isolation
-  
-  
-  
-  for( unsigned i=0; i<pfClusters->size(); i++ ) {
-    
+
+  for (unsigned i = 0; i < pfClusters->size(); i++) {
     const reco::PFCluster& cluster = (*pfClusters)[i];
-    
-    if( verbose_ ) {
-      cout<<"PFCluster "<<endl;
-      cout<<cluster<<endl;
-      cout<<"CaloCluster "<<endl;
-      
-      const CaloCluster* caloc = dynamic_cast<const CaloCluster*> (&cluster);
+
+    if (verbose_) {
+      cout << "PFCluster " << endl;
+      cout << cluster << endl;
+      cout << "CaloCluster " << endl;
+
+      const CaloCluster* caloc = dynamic_cast<const CaloCluster*>(&cluster);
       assert(caloc);
-      cout<<*caloc<<endl;
-      cout<<endl;
-    }    
+      cout << *caloc << endl;
+      cout << endl;
+    }
   }
-    
-  LogDebug("PFClusterAnalyzer")<<"STOP event: "<<iEvent.id().event()
-			 <<" in run "<<iEvent.id().run()<<endl;
+
+  LogDebug("PFClusterAnalyzer") << "STOP event: " << iEvent.id().event() << " in run " << iEvent.id().run() << endl;
 }
 
-
-  
-void 
-PFClusterAnalyzer::fetchCandidateCollection(Handle<reco::PFClusterCollection>& c, 
-					    const InputTag& tag, 
-					    const Event& iEvent) const {
-  
+void PFClusterAnalyzer::fetchCandidateCollection(Handle<reco::PFClusterCollection>& c,
+                                                 const InputTag& tag,
+                                                 const Event& iEvent) const {
   bool found = iEvent.getByLabel(tag, c);
-  
-  if(!found ) {
-    ostringstream  err;
-    err<<" cannot get PFClusters: "
-       <<tag<<endl;
-    LogError("PFClusters")<<err.str();
-    throw cms::Exception( "MissingProduct", err.str());
+
+  if (!found) {
+    ostringstream err;
+    err << " cannot get PFClusters: " << tag << endl;
+    LogError("PFClusters") << err.str();
+    throw cms::Exception("MissingProduct", err.str());
   }
-  
 }
-
-
 
 DEFINE_FWK_MODULE(PFClusterAnalyzer);

--- a/RecoParticleFlow/PFClusterProducer/test/PFClusterAnalyzer.h
+++ b/RecoParticleFlow/PFClusterProducer/test/PFClusterAnalyzer.h
@@ -20,41 +20,32 @@
 \brief test analyzer for PFClusters
 */
 
-
-
-
 class PFClusterAnalyzer : public edm::EDAnalyzer {
- public:
-
+public:
   explicit PFClusterAnalyzer(const edm::ParameterSet&);
 
   ~PFClusterAnalyzer() override;
-  
+
   void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  void beginRun(const edm::Run & r, const edm::EventSetup & c) override;
+  void beginRun(const edm::Run& r, const edm::EventSetup& c) override;
 
- private:
-  
-  void 
-    fetchCandidateCollection(edm::Handle<reco::PFClusterCollection>& c, 
-			     const edm::InputTag& tag, 
-			     const edm::Event& iSetup) const;
+private:
+  void fetchCandidateCollection(edm::Handle<reco::PFClusterCollection>& c,
+                                const edm::InputTag& tag,
+                                const edm::Event& iSetup) const;
 
-/*   void printElementsInBlocks(const reco::PFCluster& cluster, */
-/* 			     std::ostream& out=std::cout) const; */
+  /*   void printElementsInBlocks(const reco::PFCluster& cluster, */
+  /* 			     std::ostream& out=std::cout) const; */
 
+  /// PFClusters in which we'll look for pile up particles
+  edm::InputTag inputTagPFClusters_;
 
-  
-  /// PFClusters in which we'll look for pile up particles 
-  edm::InputTag   inputTagPFClusters_;
-  
   /// verbose ?
-  bool   verbose_;
+  bool verbose_;
 
   /// print the blocks associated to a given candidate ?
-  bool   printBlocks_;
-
+  bool printBlocks_;
 };
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/test/PFClusterComparator.cc
+++ b/RecoParticleFlow/PFClusterProducer/test/PFClusterComparator.cc
@@ -14,202 +14,152 @@ using namespace edm;
 using namespace reco;
 
 PFClusterComparator::PFClusterComparator(const edm::ParameterSet& iConfig) {
-  
+  inputTagPFClusters_ = iConfig.getParameter<InputTag>("PFClusters");
 
+  inputTagPFClustersCompare_ = iConfig.getParameter<InputTag>("PFClustersCompare");
 
-  inputTagPFClusters_ 
-    = iConfig.getParameter<InputTag>("PFClusters");
+  verbose_ = iConfig.getUntrackedParameter<bool>("verbose", false);
 
-  inputTagPFClustersCompare_ 
-    = iConfig.getParameter<InputTag>("PFClustersCompare");
+  printBlocks_ = iConfig.getUntrackedParameter<bool>("printBlocks", false);
 
-  verbose_ = 
-    iConfig.getUntrackedParameter<bool>("verbose",false);
+  log10E_old = fs_->make<TH1F>("log10E_old", "log10(E cluster)", 500, -5, 5);
+  log10E_new = fs_->make<TH1F>("log10E_new", "log10(E cluster)", 500, -5, 5);
+  deltaEnergy = fs_->make<TH1F>("delta_energy", "E_{old} - E_{new}", 5000, -5, 5);
 
-  printBlocks_ = 
-    iConfig.getUntrackedParameter<bool>("printBlocks",false);
+  posX_old = fs_->make<TH1F>("posX_old", "log10(E cluster)", 50000, 0, 500);
+  posX_new = fs_->make<TH1F>("posX_new", "log10(E cluster)", 50000, 0, 500);
+  deltaX = fs_->make<TH1F>("delta_X", "X_{old} - X_{new}", 5000, -5, 5);
 
-  log10E_old = fs_->make<TH1F>("log10E_old","log10(E cluster)",500,-5,5);
-  log10E_new = fs_->make<TH1F>("log10E_new","log10(E cluster)",500,-5,5);
-  deltaEnergy = fs_->make<TH1F>("delta_energy","E_{old} - E_{new}",5000,-5,5);
+  posY_old = fs_->make<TH1F>("posY_old", "log10(E cluster)", 50000, 0, 500);
+  posY_new = fs_->make<TH1F>("posY_new", "log10(E cluster)", 50000, 0, 500);
+  deltaY = fs_->make<TH1F>("delta_Y", "Y_{old} - Y_{new}", 5000, -5, 5);
 
-  posX_old = fs_->make<TH1F>("posX_old","log10(E cluster)",50000,0,500);
-  posX_new = fs_->make<TH1F>("posX_new","log10(E cluster)",50000,0,500);
-  deltaX = fs_->make<TH1F>("delta_X","X_{old} - X_{new}",5000,-5,5);
+  posZ_old = fs_->make<TH1F>("posZ_old", "log10(E cluster)", 50000, 0, 500);
+  posZ_new = fs_->make<TH1F>("posZ_new", "log10(E cluster)", 50000, 0, 500);
+  deltaZ = fs_->make<TH1F>("delta_Z", "Z_{old} - Z_{new}", 5000, -5, 5);
 
-  posY_old = fs_->make<TH1F>("posY_old","log10(E cluster)",50000,0,500);
-  posY_new = fs_->make<TH1F>("posY_new","log10(E cluster)",50000,0,500);
-  deltaY = fs_->make<TH1F>("delta_Y","Y_{old} - Y_{new}",5000,-5,5);
-  
-  posZ_old = fs_->make<TH1F>("posZ_old","log10(E cluster)",50000,0,500);
-  posZ_new = fs_->make<TH1F>("posZ_new","log10(E cluster)",50000,0,500);
-  deltaZ = fs_->make<TH1F>("delta_Z","Z_{old} - Z_{new}",5000,-5,5);
-
-
-  LogDebug("PFClusterComparator")
-    <<" input collection : "<<inputTagPFClusters_ ;
-   
+  LogDebug("PFClusterComparator") << " input collection : " << inputTagPFClusters_;
 }
-
-
 
 PFClusterComparator::~PFClusterComparator() = default;
 
+void PFClusterComparator::beginRun(const edm::Run& run, const edm::EventSetup& es) {}
 
+void PFClusterComparator::analyze(const Event& iEvent, const EventSetup& iSetup) {
+  std::map<unsigned, unsigned> detId_count;
 
-void 
-PFClusterComparator::beginRun(const edm::Run& run,
-			    const edm::EventSetup & es) { }
-
-
-void PFClusterComparator::analyze(const Event& iEvent, 
-				  const EventSetup& iSetup) {
-  std::map<unsigned,unsigned> detId_count;
-    
   // get PFClusters
 
   Handle<PFClusterCollection> pfClusters;
-  fetchCandidateCollection(pfClusters, 
-			   inputTagPFClusters_, 
-			   iEvent );
+  fetchCandidateCollection(pfClusters, inputTagPFClusters_, iEvent);
 
   Handle<PFClusterCollection> pfClustersCompare;
-  fetchCandidateCollection(pfClustersCompare, 
-			   inputTagPFClustersCompare_, 
-			   iEvent );
+  fetchCandidateCollection(pfClustersCompare, inputTagPFClustersCompare_, iEvent);
 
   // get PFClusters for isolation
-  
+
   std::cout << "There are " << pfClusters->size() << " PFClusters in the original cluster collection." << std::endl;
   std::cout << "There are " << pfClustersCompare->size() << " PFClusters in the new cluster collection." << std::endl;
-  
-  std::cout << std::flush << "---- COMPARING OLD TO NEW ----"
-	    << std::endl  << std::flush;
 
-  for(auto const & cluster : *pfClusters) {  
+  std::cout << std::flush << "---- COMPARING OLD TO NEW ----" << std::endl << std::flush;
+
+  for (auto const& cluster : *pfClusters) {
     detId_count[cluster.seed().rawId()] += 1;
     log10E_old->Fill(std::log10(cluster.energy()));
     posX_old->Fill(std::abs(cluster.position().x()));
     posY_old->Fill(std::abs(cluster.position().y()));
     posZ_old->Fill(std::abs(cluster.position().z()));
     bool foundmatch = false;
-    for(auto const & clustercomp : *pfClustersCompare) {
-      if( cluster.seed().rawId() == clustercomp.seed().rawId() ) {
-	foundmatch = true;
-	const double denergy = std::abs(cluster.energy() - 
-					clustercomp.energy());
-	const double dcenergy = std::abs(cluster.correctedEnergy() - 
-					clustercomp.correctedEnergy());
-	const double dx = std::abs(cluster.position().x() - 
-				     clustercomp.position().x());
-	const double dy = std::abs(cluster.position().y() - 
-				     clustercomp.position().y());
-	const double dz = std::abs(cluster.position().z() - 
-				     clustercomp.position().z());
-	deltaEnergy->Fill((cluster.energy() - clustercomp.energy())/cluster.energy());
-	deltaX->Fill((cluster.position().x() - clustercomp.position().x())/cluster.position().x());
-	deltaY->Fill((cluster.position().y() - clustercomp.position().y())/cluster.position().y());
-	deltaZ->Fill((cluster.position().z() - clustercomp.position().z())/cluster.position().z());
-	
-	if( denergy/std::abs(cluster.energy()) >  1e-5 ) {
-	  std::cout << "   " << cluster.seed() 
-		    << " Energies different by larger than tolerance! "
-		    << "( "<< denergy << " )"
-		    << "[ " << detId_count[cluster.seed().rawId()] << " ]" 
-		    << " Old: " << std::setprecision(7) 
-		    << cluster.energy() << " GeV , New: "
-		    << clustercomp.energy() << " GeV" << std::endl;	  
-	}
-	if( dcenergy/std::abs(cluster.correctedEnergy()) >  1e-5 ) {
-	  std::cout << "   " << cluster.seed() 
-		    << " Corrected energies different by larger than tolerance! "
-		    << "( "<< dcenergy << " )"
-		    << "[ " << detId_count[cluster.seed().rawId()] << " ]" 
-		    << " Old: " << std::setprecision(7) 
-		    << cluster.correctedEnergy() << " GeV , New: "
-		    << clustercomp.correctedEnergy() << " GeV" << std::endl;	  
-	}
-	std::cout << std::flush;
-	if( dx/std::abs(cluster.position().x()) > 1e-5 ) {
-	  std::cout << "***" << cluster.seed() 
-		    << " X's different by larger than tolerance! "
-		    << "( "<< dx << " )"
-		    << "[ " << detId_count[cluster.seed().rawId()] << " ]" 
-		    << " Old: " << std::setprecision(7) 
-		    << cluster.position().x() << " , New: "
-		    << clustercomp.position().x() << std::endl;
-	}
-	std::cout << std::flush;
-	if( dy/std::abs(cluster.position().y()) > 1e-5 ) {
-	  std::cout << "---" << cluster.seed() 
-		    << " Y's different by larger than tolerance! "
-		    << "( "<< dy << " )"
-		    << "[ " << detId_count[cluster.seed().rawId()] << " ]" 
-		    << " Old: " << std::setprecision(7) 
-		    << cluster.position().y() << " , New: "
-		    << clustercomp.position().y() << std::endl;
-	}
-	std::cout << std::flush;
-	if( dz/std::abs(cluster.position().z()) > 1e-5 ) {
-	  std::cout << "+++" << cluster.seed() 
-		    << " Z's different by larger than tolerance! "
-		    << "( "<< dz << " )"
-		    << "[ " << detId_count[cluster.seed().rawId()] <<" ]" 
-		    << " Old: " << std::setprecision(7) 
-		    << cluster.position().z() << " , New: "
-		    << clustercomp.position().z() << std::endl;
-	}
-	std::cout << std::flush;
-      }      
+    for (auto const& clustercomp : *pfClustersCompare) {
+      if (cluster.seed().rawId() == clustercomp.seed().rawId()) {
+        foundmatch = true;
+        const double denergy = std::abs(cluster.energy() - clustercomp.energy());
+        const double dcenergy = std::abs(cluster.correctedEnergy() - clustercomp.correctedEnergy());
+        const double dx = std::abs(cluster.position().x() - clustercomp.position().x());
+        const double dy = std::abs(cluster.position().y() - clustercomp.position().y());
+        const double dz = std::abs(cluster.position().z() - clustercomp.position().z());
+        deltaEnergy->Fill((cluster.energy() - clustercomp.energy()) / cluster.energy());
+        deltaX->Fill((cluster.position().x() - clustercomp.position().x()) / cluster.position().x());
+        deltaY->Fill((cluster.position().y() - clustercomp.position().y()) / cluster.position().y());
+        deltaZ->Fill((cluster.position().z() - clustercomp.position().z()) / cluster.position().z());
+
+        if (denergy / std::abs(cluster.energy()) > 1e-5) {
+          std::cout << "   " << cluster.seed() << " Energies different by larger than tolerance! "
+                    << "( " << denergy << " )"
+                    << "[ " << detId_count[cluster.seed().rawId()] << " ]"
+                    << " Old: " << std::setprecision(7) << cluster.energy() << " GeV , New: " << clustercomp.energy()
+                    << " GeV" << std::endl;
+        }
+        if (dcenergy / std::abs(cluster.correctedEnergy()) > 1e-5) {
+          std::cout << "   " << cluster.seed() << " Corrected energies different by larger than tolerance! "
+                    << "( " << dcenergy << " )"
+                    << "[ " << detId_count[cluster.seed().rawId()] << " ]"
+                    << " Old: " << std::setprecision(7) << cluster.correctedEnergy()
+                    << " GeV , New: " << clustercomp.correctedEnergy() << " GeV" << std::endl;
+        }
+        std::cout << std::flush;
+        if (dx / std::abs(cluster.position().x()) > 1e-5) {
+          std::cout << "***" << cluster.seed() << " X's different by larger than tolerance! "
+                    << "( " << dx << " )"
+                    << "[ " << detId_count[cluster.seed().rawId()] << " ]"
+                    << " Old: " << std::setprecision(7) << cluster.position().x()
+                    << " , New: " << clustercomp.position().x() << std::endl;
+        }
+        std::cout << std::flush;
+        if (dy / std::abs(cluster.position().y()) > 1e-5) {
+          std::cout << "---" << cluster.seed() << " Y's different by larger than tolerance! "
+                    << "( " << dy << " )"
+                    << "[ " << detId_count[cluster.seed().rawId()] << " ]"
+                    << " Old: " << std::setprecision(7) << cluster.position().y()
+                    << " , New: " << clustercomp.position().y() << std::endl;
+        }
+        std::cout << std::flush;
+        if (dz / std::abs(cluster.position().z()) > 1e-5) {
+          std::cout << "+++" << cluster.seed() << " Z's different by larger than tolerance! "
+                    << "( " << dz << " )"
+                    << "[ " << detId_count[cluster.seed().rawId()] << " ]"
+                    << " Old: " << std::setprecision(7) << cluster.position().z()
+                    << " , New: " << clustercomp.position().z() << std::endl;
+        }
+        std::cout << std::flush;
+      }
     }
-    if( !foundmatch ) {      
-      std::cout << "Seed in old clusters and not new: " 
-		<< cluster << std::endl;
+    if (!foundmatch) {
+      std::cout << "Seed in old clusters and not new: " << cluster << std::endl;
     }
   }
-   
-  std::cout << std::flush << "---- COMPARING NEW TO OLD ----"
-	    << std::endl  << std::flush;
 
-  for(auto const & cluster : *pfClustersCompare) {     
+  std::cout << std::flush << "---- COMPARING NEW TO OLD ----" << std::endl << std::flush;
+
+  for (auto const& cluster : *pfClustersCompare) {
     log10E_new->Fill(std::log10(cluster.energy()));
     posX_new->Fill(std::abs(cluster.position().x()));
     posY_new->Fill(std::abs(cluster.position().y()));
     posZ_new->Fill(std::abs(cluster.position().z()));
     bool foundmatch = false;
-    for(auto const & clustercomp : *pfClusters) {
-      if( cluster.seed() == clustercomp.seed() ) {
-	foundmatch = true;
-
-      }      
+    for (auto const& clustercomp : *pfClusters) {
+      if (cluster.seed() == clustercomp.seed()) {
+        foundmatch = true;
+      }
     }
-    if( !foundmatch ) {      
-      std::cout << "Seed in new clusters and not old: " 
-		<< cluster << std::endl;
+    if (!foundmatch) {
+      std::cout << "Seed in new clusters and not old: " << cluster << std::endl;
     }
   }
   std::cout << std::flush;
 }
 
-
-  
-void 
-PFClusterComparator::fetchCandidateCollection(Handle<reco::PFClusterCollection>& c, 
-					    const InputTag& tag, 
-					    const Event& iEvent) const {
-  
+void PFClusterComparator::fetchCandidateCollection(Handle<reco::PFClusterCollection>& c,
+                                                   const InputTag& tag,
+                                                   const Event& iEvent) const {
   bool found = iEvent.getByLabel(tag, c);
-  
-  if(!found ) {
-    ostringstream  err;
-    err<<" cannot get PFClusters: "
-       <<tag<<endl;
-    LogError("PFClusters")<<err.str();
-    throw cms::Exception( "MissingProduct", err.str());
+
+  if (!found) {
+    ostringstream err;
+    err << " cannot get PFClusters: " << tag << endl;
+    LogError("PFClusters") << err.str();
+    throw cms::Exception("MissingProduct", err.str());
   }
-  
 }
-
-
 
 DEFINE_FWK_MODULE(PFClusterComparator);

--- a/RecoParticleFlow/PFClusterProducer/test/PFClusterComparator.h
+++ b/RecoParticleFlow/PFClusterProducer/test/PFClusterComparator.h
@@ -23,48 +23,39 @@
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 #include "TH1F.h"
 
-
-
 class PFClusterComparator : public edm::EDAnalyzer {
- public:
-
-  explicit PFClusterComparator(const edm::ParameterSet&);
+public:
+  explicit PFClusterComparator(const edm::ParameterSet &);
 
   ~PFClusterComparator() override;
-  
-  void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  void beginRun(const edm::Run & r, const edm::EventSetup & c) override;
+  void analyze(const edm::Event &, const edm::EventSetup &) override;
 
- private:
-  
-  void 
-    fetchCandidateCollection(edm::Handle<reco::PFClusterCollection>& c, 
-			     const edm::InputTag& tag, 
-			     const edm::Event& iSetup) const;
+  void beginRun(const edm::Run &r, const edm::EventSetup &c) override;
 
-/*   void printElementsInBlocks(const reco::PFCluster& cluster, */
-/* 			     std::ostream& out=std::cout) const; */
+private:
+  void fetchCandidateCollection(edm::Handle<reco::PFClusterCollection> &c,
+                                const edm::InputTag &tag,
+                                const edm::Event &iSetup) const;
 
+  /*   void printElementsInBlocks(const reco::PFCluster& cluster, */
+  /* 			     std::ostream& out=std::cout) const; */
 
-  
-  /// PFClusters in which we'll look for pile up particles 
-  edm::InputTag   inputTagPFClusters_;
-  edm::InputTag   inputTagPFClustersCompare_;
-  
+  /// PFClusters in which we'll look for pile up particles
+  edm::InputTag inputTagPFClusters_;
+  edm::InputTag inputTagPFClustersCompare_;
+
   edm::Service<TFileService> fs_;
   TH1F *log10E_old, *log10E_new, *deltaEnergy;
   TH1F *posX_old, *posX_new, *deltaX;
   TH1F *posY_old, *posY_new, *deltaY;
   TH1F *posZ_old, *posZ_new, *deltaZ;
-  
 
   /// verbose ?
-  bool   verbose_;
+  bool verbose_;
 
   /// print the blocks associated to a given candidate ?
-  bool   printBlocks_;
-
+  bool printBlocks_;
 };
 
 #endif


### PR DESCRIPTION

Applying code-format for CMSSW category reconstruction.
See the build logs here https://cmssdt.cern.ch/jenkins/job/GitHub-refactor-cmssw-module/351//console

cms-bot has successfully run the following:
- scram build code-checks-all
- scram build code-format-all
- scram build


